### PR TITLE
Second round of typo fixes

### DIFF
--- a/hw/dv/sv/dv_utils/dv_fcov_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_fcov_macros.svh
@@ -48,7 +48,7 @@
 `endif
 
 // Creates a coverpoint for an expression where only the expression true case is of interest for
-// coverage (e.g. where the expression indicates an event has occured).
+// coverage (e.g. where the expression indicates an event has occurred).
 `ifndef DV_FCOV_EXPR_SEEN
 `ifdef DV_FCOV_DISABLE_CP
   `define DV_FCOV_EXPR_SEEN(NAME_, EXPR_)

--- a/hw/ip/adc_ctrl/dv/cov/adc_ctrl_cov_bind.sv
+++ b/hw/ip/adc_ctrl/dv/cov/adc_ctrl_cov_bind.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Binds ADC_CTRL functional coverage interaface to the top level LC_CTRL module.
+// Binds ADC_CTRL functional coverage interface to the top level LC_CTRL module.
 module adc_ctrl_cov_bind;
   bind adc_ctrl_fsm adc_ctrl_fsm_cov_if u_adc_ctrl_fsm_cov_if (.*);
 endmodule

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cov.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_scoreboard.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_scoreboard.sv
@@ -223,7 +223,7 @@ class adc_ctrl_scoreboard extends cip_base_scoreboard #(
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (csr.get_name())
       // add individual case item for each csr
       "intr_state": begin

--- a/hw/ip/aes/dv/cov/aes_cov_bind.sv
+++ b/hw/ip/aes/dv/cov/aes_cov_bind.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Binds AES functional coverage interaface to the top level AES module.
+// Binds AES functional coverage interface to the top level AES module.
 module aes_cov_bind;
 
   bind aes aes_cov_if u_aes_cov_if (

--- a/hw/ip/aon_timer/dv/env/aon_timer_env_cov.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip/aon_timer/dv/env/aon_timer_scoreboard.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_scoreboard.sv
@@ -710,7 +710,7 @@ task aon_timer_scoreboard::process_tl_access(tl_seq_item item, tl_channels_e cha
 
   // process the csr req
   // for write, update local variable and fifo at address phase
-  // for read, update predication at address phase and compare at data phase
+  // for read, update prediction at address phase and compare at data phase
   case (csr.get_name())
     // add individual case item for each csr
     "intr_state": begin

--- a/hw/ip/csrng/dv/env/csrng_env_cov.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip/csrng/dv/env/csrng_scoreboard.sv
+++ b/hw/ip/csrng/dv/env/csrng_scoreboard.sv
@@ -153,7 +153,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (csr.get_name())
       // add individual case item for each csr
       "intr_state": begin

--- a/hw/ip/edn/dv/env/edn_env_cov.sv
+++ b/hw/ip/edn/dv/env/edn_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip/edn/dv/env/edn_scoreboard.sv
+++ b/hw/ip/edn/dv/env/edn_scoreboard.sv
@@ -155,7 +155,7 @@ class edn_scoreboard extends cip_base_scoreboard #(
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (csr.get_name())
       // add individual case item for each csr
       "intr_state": begin

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cov.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -1454,7 +1454,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (csr.get_name())
       // add individual case item for each csr
       "intr_state": begin

--- a/hw/ip/keymgr/dv/cov/keymgr_cov_bind.sv
+++ b/hw/ip/keymgr/dv/cov/keymgr_cov_bind.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Binds functional coverage interaface to the top level keymgr module.
+// Binds functional coverage interface to the top level keymgr module.
 module keymgr_cov_bind;
 
   bind keymgr cip_lc_tx_cov_if u_lc_escalate_en_cov_if (

--- a/hw/ip/keymgr/dv/env/keymgr_env_cov.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -465,7 +465,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (csr.get_name())
       // add individual case item for each csr
       "intr_state": begin

--- a/hw/ip/keymgr_dpe/dv/cov/keymgr_dpe_cov_bind.sv
+++ b/hw/ip/keymgr_dpe/dv/cov/keymgr_dpe_cov_bind.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Binds functional coverage interaface to the top level keymgr_dpe module.
+// Binds functional coverage interface to the top level keymgr_dpe module.
 module keymgr_dpe_cov_bind;
 
   bind keymgr_dpe cip_lc_tx_cov_if u_lc_escalate_en_cov_if (

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env_cov.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
@@ -506,7 +506,7 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (csr.get_name())
       // add individual case item for each csr
       "intr_state": begin

--- a/hw/ip/kmac/dv/env/kmac_env_cov.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -680,7 +680,7 @@ class kmac_scoreboard extends cip_base_scoreboard #(
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (csr_name)
       // add individual case item for each csr
       "intr_state": begin

--- a/hw/ip/lc_ctrl/dv/cov/lc_ctrl_cov_bind.sv
+++ b/hw/ip/lc_ctrl/dv/cov/lc_ctrl_cov_bind.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Binds LC_CTRL functional coverage interaface to the top level LC_CTRL module.
+// Binds LC_CTRL functional coverage interface to the top level LC_CTRL module.
 module lc_ctrl_cov_bind;
   // LC_CTRL FSM coverage
   bind lc_ctrl_fsm lc_ctrl_fsm_cov_if u_lc_ctrl_fsm_cov_if (.*);

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cov.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip/mbx/dv/env/mbx_env_cov.sv
+++ b/hw/ip/mbx/dv/env/mbx_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip/mbx/dv/env/mbx_scoreboard.sv
+++ b/hw/ip/mbx/dv/env/mbx_scoreboard.sv
@@ -193,7 +193,7 @@ return;
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (ral_name)
       RAL_T::type_name : begin
         process_tl_mbx_core_access(item, channel);

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip/pattgen/dv/cov/pattgen_cov_bind.sv
+++ b/hw/ip/pattgen/dv/cov/pattgen_cov_bind.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Binds PATTGEN functional coverage interaface to the top level PATTGEN module.
+// Binds PATTGEN functional coverage interface to the top level PATTGEN module.
 module pattgen_cov_bind;
 
   bind pattgen pattgen_cov_if u_pattgen_cov_if (.*);

--- a/hw/ip/pattgen/dv/env/pattgen_env_cov.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip/pattgen/dv/env/pattgen_scoreboard.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_scoreboard.sv
@@ -115,7 +115,7 @@ task pattgen_scoreboard::process_tl_access(tl_seq_item   item,
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (csr.get_name())
       "size": begin
         reg_value = ral.size.get_mirrored_value();

--- a/hw/ip/prim/fpv/vip/prim_alert_rxtx_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_alert_rxtx_assert_fpv.sv
@@ -113,7 +113,7 @@ module prim_alert_rxtx_assert_fpv
       prim_alert_rxtx_tb.i_prim_alert_sender.Idle) |=>
       alert_o,
       clk_i, !rst_ni || error_present || ping_req_i || init_pending)
-  // transmission of alerts in the general case which can include continuos ping collisions
+  // transmission of alerts in the general case which can include continuous ping collisions
   `ASSERT(AlertCheck1_A, alert_req_i || alert_test_i |=>
       strong(##[1:$] ((prim_alert_rxtx_tb.i_prim_alert_sender.state_q ==
       prim_alert_rxtx_tb.i_prim_alert_sender.Idle) && !ping_req_i) ##1 alert_o),

--- a/hw/ip/racl_ctrl/dv/env/racl_ctrl_env_cov.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_ctrl_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip/rom_ctrl/dv/cov/rom_ctrl_cov_bind.sv
+++ b/hw/ip/rom_ctrl/dv/cov/rom_ctrl_cov_bind.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Binds functional coverage interaface to the top level rom_ctrl module.
+// Binds functional coverage interface to the top level rom_ctrl module.
 module rom_ctrl_cov_bind;
 
   bind rom_ctrl rom_ctrl_cov_if u_rom_ctrl_cov_if (.*);

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cov.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
@@ -263,7 +263,7 @@ function void rom_ctrl_scoreboard::check_reg_access(tl_seq_item item, tl_channel
 
   // process the csr req
   // for write, update local variable and fifo at address phase
-  // for read, update predication at address phase and compare at data phase
+  // for read, update prediction at address phase and compare at data phase
   case (csr.get_name())
     // add individual case item for each csr
     "alert_test": begin

--- a/hw/ip/rv_dm/dv/env/rv_dm_env_cov.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
@@ -332,7 +332,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (ral_name)
       "rv_dm_regs_reg_block": begin
         case (csr.get_name())

--- a/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_env_cov.sv
+++ b/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_scoreboard.sv
+++ b/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_scoreboard.sv
@@ -112,7 +112,7 @@ task soc_dbg_ctrl_scoreboard::process_tl_core_access(
 
   // Process the CRS req:
   //  - for write, update local variable and fifo at address phase
-  //  - for read, update predication at address phase and compare at data phase
+  //  - for read, update prediction at address phase and compare at data phase
   case (csr.get_name())
     // Add individual case item for each csr
     "intr_state": begin

--- a/hw/ip/spi_host/dv/cov/spi_host_cov_bind.sv
+++ b/hw/ip/spi_host/dv/cov/spi_host_cov_bind.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Binds UART functional coverage interaface to the top level AES module.
+// Binds UART functional coverage interface to the top level AES module.
 module spi_host_cov_bind;
 
   bind spi_host spi_host_cov_if u_spi_cov_if (

--- a/hw/ip/spi_host/dv/env/spi_host_env_cov.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip/sram_ctrl/dv/cov/sram_ctrl_cov_bind.sv
+++ b/hw/ip/sram_ctrl/dv/cov/sram_ctrl_cov_bind.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Binds functional coverage interaface to the top level sram_ctrl module.
+// Binds functional coverage interface to the top level sram_ctrl module.
 module sram_ctrl_cov_bind;
 
   bind sram_ctrl cip_mubi_cov_if #(.Width(4)) u_hw_debug_en_mubi_cov_if (

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cov.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -549,7 +549,7 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (csr_name)
       // add individual case item for each csr
       "alert_test": begin

--- a/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_scoreboard.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_scoreboard.sv
@@ -86,7 +86,7 @@ class sysrst_ctrl_scoreboard extends cip_base_scoreboard #(
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (csr.get_name())
       // add individual case item for each csr
       "intr_state": begin

--- a/hw/ip/tlul/generic_dv/env/seq_lib/xbar_stress_all_vseq.sv
+++ b/hw/ip/tlul/generic_dv/env/seq_lib/xbar_stress_all_vseq.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// combine all xbar seqs in one seq to run in parallel for multiply times
+// combine all xbar seqs in one seq to run in parallel multiple times
 class xbar_stress_all_vseq extends xbar_base_vseq;
   `uvm_object_utils(xbar_stress_all_vseq)
 

--- a/hw/ip/tlul/generic_dv/env/xbar_scoreboard.sv
+++ b/hw/ip/tlul/generic_dv/env/xbar_scoreboard.sv
@@ -18,7 +18,7 @@ class xbar_scoreboard extends scoreboard_pkg::scoreboard #(.ITEM_T(tl_seq_item),
   // Customize the get_queue_name function
   // port_name is {"a/d_chan_", host/device name}
   // tl_channel is "a/d_chan_"
-  // tl_port is host/devcie name
+  // tl_port is host/device name
   virtual function string get_queue_name(tl_seq_item tr, string port_name);
     string queue_name;
     string tl_channel;

--- a/hw/ip/tlul/rtl/tlul_sram_byte.sv
+++ b/hw/ip/tlul/rtl/tlul_sram_byte.sv
@@ -216,7 +216,7 @@ module tlul_sram_byte import tlul_pkg::*; #(
 
     // If the readback feature is enabled, we assume that the write phase takes one extra cycle
     // due to the underlying scrambling mechanism. If this additional cycle is not needed anymore
-    // in the future (e.g. due to the removable of the scrambling mechanism), the readback does not
+    // in the future (e.g. due to the removal of the scrambling mechanism), the readback does not
     // need to be delayed by once cylce in the FSM below.
     `ASSERT(NoPendingWriteAfterWrite_A, wr_phase & mubi4_test_true_loose(rdback_en_q)
         |=> write_pending_i)

--- a/hw/ip/tlul/rtl/tlul_sram_byte.sv
+++ b/hw/ip/tlul/rtl/tlul_sram_byte.sv
@@ -217,7 +217,7 @@ module tlul_sram_byte import tlul_pkg::*; #(
     // If the readback feature is enabled, we assume that the write phase takes one extra cycle
     // due to the underlying scrambling mechanism. If this additional cycle is not needed anymore
     // in the future (e.g. due to the removal of the scrambling mechanism), the readback does not
-    // need to be delayed by once cylce in the FSM below.
+    // need to be delayed by one cycle in the FSM below.
     `ASSERT(NoPendingWriteAfterWrite_A, wr_phase & mubi4_test_true_loose(rdback_en_q)
         |=> write_pending_i)
 

--- a/hw/ip/uart/dv/env/uart_scoreboard.sv
+++ b/hw/ip/uart/dv/env/uart_scoreboard.sv
@@ -187,7 +187,7 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (csr.get_name())
       "ctrl": begin
         if (write && channel == AddrChannel) begin

--- a/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
@@ -993,7 +993,7 @@ class usbdev_scoreboard extends cip_base_scoreboard #(
 
   virtual function void reset(string kind = "HARD");
     super.reset(kind);
-    // Reset local fifos queues and variables
+    // reset local fifos queues and variables
     req_usb20_fifo.flush();
     rsp_usb20_fifo.flush();
     expected_rsp_q.delete();

--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env_cov.sv
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_scoreboard.sv
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_scoreboard.sv
@@ -265,7 +265,7 @@ task ac_range_check_scoreboard::process_tl_access(tl_seq_item item,
 
   // Process the CSR req:
   //  - for write, update local variable and FIFO at AChanWrite phase
-  //  - for read, update predication at AChanRead phase and compare at DChanRead phase
+  //  - for read, update prediction at AChanRead phase and compare at DChanRead phase
   case (csr_name)
     // Add individual case item for each csr
     "intr_state": begin

--- a/hw/ip_templates/alert_handler/dv/cov/alert_handler_cov_bind.sv.tpl
+++ b/hw/ip_templates/alert_handler/dv/cov/alert_handler_cov_bind.sv.tpl
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Binds ${(module_instance_name).upper()} functional coverage interafaces to the top level ${(module_instance_name).upper()} module.
+// Binds ${(module_instance_name).upper()} functional coverage interfaces to the top level ${(module_instance_name).upper()} module.
 
 module ${module_instance_name}_cov_bind;
   import ${module_instance_name}_pkg::*;

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_scoreboard.sv.tpl
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_scoreboard.sv.tpl
@@ -459,7 +459,7 @@ class ${module_instance_name}_scoreboard extends cip_base_scoreboard #(
     end
 
     // process the csr req
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
 
     if (!write) begin
       // On reads, if do_read_check, is set, then check mirrored_value against item.d_data

--- a/hw/ip_templates/clkmgr/dv/env/clkmgr_env_cov.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/clkmgr_env_cov.sv.tpl
@@ -7,7 +7,7 @@ from ipgen.clkmgr_gen import get_rg_srcs
 rg_srcs = get_rg_srcs(typed_clocks)
 %>\
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */
@@ -157,7 +157,7 @@ class clkmgr_env_cov extends cip_base_env_cov #(
 
   function new(string name, uvm_component parent);
     super.new(name, parent);
-    // The peripheral covergoups.
+    // The peripheral Covergroups.
     foreach (peri_cg_wrap[i]) begin
       clkmgr_env_pkg::peri_e peri = clkmgr_env_pkg::peri_e'(i);
       peri_cg_wrap[i] = new(peri.name);

--- a/hw/ip_templates/clkmgr/dv/env/clkmgr_scoreboard.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/clkmgr_scoreboard.sv.tpl
@@ -262,7 +262,7 @@ ${spc}cfg.clkmgr_vif.scanmode_i == MuBi4True);
 
     // Process the csr req:
     // - For write, update local variable and fifo at address phase.
-    // - For read, update predication at address phase and compare at data phase.
+    // - For read, update prediction at address phase and compare at data phase.
     case (csr.get_name())
       // add individual case item for each csr
       "alert_test": begin

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //
-// Covergoups that are dependent on run-time parameters that may be available
+// Covergroups that are dependent on run-time parameters that may be available
 // only in build_phase can be defined here
 // Covergroups may also be wrapped inside helper classes if needed.
 //

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -337,7 +337,7 @@ class flash_ctrl_scoreboard #(
           `DV_CHECK_NE_FATAL(csr, null)
           // process the csr req
           // for write, update local variable and fifo at address phase
-          // for read, update predication at address phase and compare at data phase
+          // for read, update prediction at address phase and compare at data phase
           if(!uvm_re_match("err_code*",csr.get_name())) begin
             if (cfg.en_cov) begin
               cov.sw_error_cg.sample(item.d_data);

--- a/hw/ip_templates/otp_ctrl/dv/cov/otp_ctrl_cov_bind.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/cov/otp_ctrl_cov_bind.sv.tpl
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Binds OTP_CTRL functional coverage interaface to the top level OTP_CTRL module.
+// Binds OTP_CTRL functional coverage interface to the top level OTP_CTRL module.
 //
 <%
 from topgen.lib import Name

--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env_cov.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env_cov.sv.tpl
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv.tpl
@@ -663,7 +663,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (csr_name)
       // add individual case item for each csr
       "intr_state": begin

--- a/hw/ip_templates/pwm/dv/env/pwm_env_cov.sv
+++ b/hw/ip_templates/pwm/dv/env/pwm_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip_templates/pwm/dv/env/pwm_scoreboard.sv
+++ b/hw/ip_templates/pwm/dv/env/pwm_scoreboard.sv
@@ -150,7 +150,7 @@ task pwm_scoreboard::process_tl_access(tl_seq_item   item,
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (csr.get_name())
       "regwen": begin
         regwen = regwen & item.a_data[0];

--- a/hw/ip_templates/pwrmgr/dv/env/pwrmgr_env_cov.sv.tpl
+++ b/hw/ip_templates/pwrmgr/dv/env/pwrmgr_env_cov.sv.tpl
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here.
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip_templates/pwrmgr/dv/env/pwrmgr_scoreboard.sv.tpl
+++ b/hw/ip_templates/pwrmgr/dv/env/pwrmgr_scoreboard.sv.tpl
@@ -246,7 +246,7 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (csr.get_name())
       // add individual case item for each csr
       "intr_state": begin

--- a/hw/ip_templates/rstmgr/dv/env/rstmgr_env_cov.sv
+++ b/hw/ip_templates/rstmgr/dv/env/rstmgr_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/ip_templates/rstmgr/dv/env/rstmgr_scoreboard.sv
+++ b/hw/ip_templates/rstmgr/dv/env/rstmgr_scoreboard.sv
@@ -158,7 +158,7 @@ class rstmgr_scoreboard extends cip_base_scoreboard #(
 
     // process the csr req:
     // for write, update local variable and fifo at address phase,
-    // for read, update predication at address phase and compare at data phase.
+    // for read, update prediction at address phase and compare at data phase.
     case (csr.get_name())
       // add individual case item for each csr
       "alert_test": begin

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env_cov.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_scoreboard.sv
@@ -265,7 +265,7 @@ task ac_range_check_scoreboard::process_tl_access(tl_seq_item item,
 
   // Process the CSR req:
   //  - for write, update local variable and FIFO at AChanWrite phase
-  //  - for read, update predication at AChanRead phase and compare at DChanRead phase
+  //  - for read, update prediction at AChanRead phase and compare at DChanRead phase
   case (csr_name)
     // Add individual case item for each csr
     "intr_state": begin

--- a/hw/top_darjeeling/ip_autogen/alert_handler/dv/cov/alert_handler_cov_bind.sv
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/dv/cov/alert_handler_cov_bind.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Binds ALERT_HANDLER functional coverage interafaces to the top level ALERT_HANDLER module.
+// Binds ALERT_HANDLER functional coverage interfaces to the top level ALERT_HANDLER module.
 
 module alert_handler_cov_bind;
   import alert_handler_pkg::*;

--- a/hw/top_darjeeling/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -459,7 +459,7 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
     end
 
     // process the csr req
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
 
     if (!write) begin
       // On reads, if do_read_check, is set, then check mirrored_value against item.d_data

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/clkmgr_env_cov.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/clkmgr_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */
@@ -149,7 +149,7 @@ class clkmgr_env_cov extends cip_base_env_cov #(
 
   function new(string name, uvm_component parent);
     super.new(name, parent);
-    // The peripheral covergoups.
+    // The peripheral Covergroups.
     foreach (peri_cg_wrap[i]) begin
       clkmgr_env_pkg::peri_e peri = clkmgr_env_pkg::peri_e'(i);
       peri_cg_wrap[i] = new(peri.name);

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -255,7 +255,7 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
 
     // Process the csr req:
     // - For write, update local variable and fifo at address phase.
-    // - For read, update predication at address phase and compare at data phase.
+    // - For read, update prediction at address phase and compare at data phase.
     case (csr.get_name())
       // add individual case item for each csr
       "alert_test": begin

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/cov/otp_ctrl_cov_bind.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/cov/otp_ctrl_cov_bind.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Binds OTP_CTRL functional coverage interaface to the top level OTP_CTRL module.
+// Binds OTP_CTRL functional coverage interface to the top level OTP_CTRL module.
 //
 `define PART_MUBI_COV(__part_name, __index)                                           \
   bind otp_ctrl cip_mubi_cov_if #(.Width(8)) ``__part_name``_read_lock_mubi_cov_if (  \

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_cov.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_cov.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -630,7 +630,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (csr_name)
       // add individual case item for each csr
       "intr_state": begin

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_env_cov.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here.
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -248,7 +248,7 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (csr.get_name())
       // add individual case item for each csr
       "intr_state": begin

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/rstmgr_env_cov.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/rstmgr_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/rstmgr_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/rstmgr_scoreboard.sv
@@ -158,7 +158,7 @@ class rstmgr_scoreboard extends cip_base_scoreboard #(
 
     // process the csr req:
     // for write, update local variable and fifo at address phase,
-    // for read, update predication at address phase and compare at data phase.
+    // for read, update prediction at address phase and compare at data phase.
     case (csr.get_name())
       // add individual case item for each csr
       "alert_test": begin

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/cov/alert_handler_cov_bind.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/cov/alert_handler_cov_bind.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Binds ALERT_HANDLER functional coverage interafaces to the top level ALERT_HANDLER module.
+// Binds ALERT_HANDLER functional coverage interfaces to the top level ALERT_HANDLER module.
 
 module alert_handler_cov_bind;
   import alert_handler_pkg::*;

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -459,7 +459,7 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
     end
 
     // process the csr req
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
 
     if (!write) begin
       // On reads, if do_read_check, is set, then check mirrored_value against item.d_data

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/clkmgr_env_cov.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/clkmgr_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */
@@ -161,7 +161,7 @@ class clkmgr_env_cov extends cip_base_env_cov #(
 
   function new(string name, uvm_component parent);
     super.new(name, parent);
-    // The peripheral covergoups.
+    // The peripheral Covergroups.
     foreach (peri_cg_wrap[i]) begin
       clkmgr_env_pkg::peri_e peri = clkmgr_env_pkg::peri_e'(i);
       peri_cg_wrap[i] = new(peri.name);

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -298,7 +298,7 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
 
     // Process the csr req:
     // - For write, update local variable and fifo at address phase.
-    // - For read, update predication at address phase and compare at data phase.
+    // - For read, update prediction at address phase and compare at data phase.
     case (csr.get_name())
       // add individual case item for each csr
       "alert_test": begin

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //
-// Covergoups that are dependent on run-time parameters that may be available
+// Covergroups that are dependent on run-time parameters that may be available
 // only in build_phase can be defined here
 // Covergroups may also be wrapped inside helper classes if needed.
 //

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -337,7 +337,7 @@ class flash_ctrl_scoreboard #(
           `DV_CHECK_NE_FATAL(csr, null)
           // process the csr req
           // for write, update local variable and fifo at address phase
-          // for read, update predication at address phase and compare at data phase
+          // for read, update prediction at address phase and compare at data phase
           if(!uvm_re_match("err_code*",csr.get_name())) begin
             if (cfg.en_cov) begin
               cov.sw_error_cg.sample(item.d_data);

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/cov/otp_ctrl_cov_bind.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/cov/otp_ctrl_cov_bind.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Binds OTP_CTRL functional coverage interaface to the top level OTP_CTRL module.
+// Binds OTP_CTRL functional coverage interface to the top level OTP_CTRL module.
 //
 `define PART_MUBI_COV(__part_name, __index)                                           \
   bind otp_ctrl cip_mubi_cov_if #(.Width(8)) ``__part_name``_read_lock_mubi_cov_if (  \

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_cov.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_cov.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -650,7 +650,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (csr_name)
       // add individual case item for each csr
       "intr_state": begin

--- a/hw/top_earlgrey/ip_autogen/pwm/dv/env/pwm_env_cov.sv
+++ b/hw/top_earlgrey/ip_autogen/pwm/dv/env/pwm_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/top_earlgrey/ip_autogen/pwm/dv/env/pwm_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/pwm/dv/env/pwm_scoreboard.sv
@@ -150,7 +150,7 @@ task pwm_scoreboard::process_tl_access(tl_seq_item   item,
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (csr.get_name())
       "regwen": begin
         regwen = regwen & item.a_data[0];

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_env_cov.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here.
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -242,7 +242,7 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (csr.get_name())
       // add individual case item for each csr
       "intr_state": begin

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/rstmgr_env_cov.sv
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/rstmgr_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/rstmgr_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/rstmgr_scoreboard.sv
@@ -158,7 +158,7 @@ class rstmgr_scoreboard extends cip_base_scoreboard #(
 
     // process the csr req:
     // for write, update local variable and fifo at address phase,
-    // for read, update predication at address phase and compare at data phase.
+    // for read, update prediction at address phase and compare at data phase.
     case (csr.get_name())
       // add individual case item for each csr
       "alert_test": begin

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/clkmgr_env_cov.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/clkmgr_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */
@@ -157,7 +157,7 @@ class clkmgr_env_cov extends cip_base_env_cov #(
 
   function new(string name, uvm_component parent);
     super.new(name, parent);
-    // The peripheral covergoups.
+    // The peripheral Covergroups.
     foreach (peri_cg_wrap[i]) begin
       clkmgr_env_pkg::peri_e peri = clkmgr_env_pkg::peri_e'(i);
       peri_cg_wrap[i] = new(peri.name);

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -289,7 +289,7 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
 
     // Process the csr req:
     // - For write, update local variable and fifo at address phase.
-    // - For read, update predication at address phase and compare at data phase.
+    // - For read, update prediction at address phase and compare at data phase.
     case (csr.get_name())
       // add individual case item for each csr
       "alert_test": begin

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //
-// Covergoups that are dependent on run-time parameters that may be available
+// Covergroups that are dependent on run-time parameters that may be available
 // only in build_phase can be defined here
 // Covergroups may also be wrapped inside helper classes if needed.
 //

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -337,7 +337,7 @@ class flash_ctrl_scoreboard #(
           `DV_CHECK_NE_FATAL(csr, null)
           // process the csr req
           // for write, update local variable and fifo at address phase
-          // for read, update predication at address phase and compare at data phase
+          // for read, update prediction at address phase and compare at data phase
           if(!uvm_re_match("err_code*",csr.get_name())) begin
             if (cfg.en_cov) begin
               cov.sw_error_cg.sample(item.d_data);

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/pwrmgr_env_cov.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/pwrmgr_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here.
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -242,7 +242,7 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (csr.get_name())
       // add individual case item for each csr
       "intr_state": begin

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_env_cov.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_env_cov.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_scoreboard.sv
@@ -158,7 +158,7 @@ class rstmgr_scoreboard extends cip_base_scoreboard #(
 
     // process the csr req:
     // for write, update local variable and fifo at address phase,
-    // for read, update predication at address phase and compare at data phase.
+    // for read, update prediction at address phase and compare at data phase.
     case (csr.get_name())
       // add individual case item for each csr
       "alert_test": begin

--- a/rules/opentitan/transform.bzl
+++ b/rules/opentitan/transform.bzl
@@ -163,7 +163,7 @@ def scramble_flash(ctx, **kwargs):
       kwargs: Overrides of values normally retrived from the context object.
         output: The name of the output file.  Constructed from `name` and `suffix`
                  if not specified.
-        suffix: The suffix to give the file if the ouput isn't specified.
+        suffix: The suffix to give the file if the output isn't specified.
         src: The src File object.
         otp: The OTP settings.
         otp_mmap: The OTP memory mapping file.

--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -77,7 +77,7 @@ static dif_uart_t uart;
 
 /**
  * Callbacks for processing USB reciept. The latter increments the
- * recieved character by one, to make them distinct.
+ * received character by one, to make them distinct.
  */
 static void usb_receipt_callback_0(uint8_t c) {
   c = make_printable(c, '?');

--- a/sw/device/lib/dif/dif_csrng.h
+++ b/sw/device/lib/dif/dif_csrng.h
@@ -141,11 +141,11 @@ typedef enum dif_csrng_error {
    */
   kDifCsrngErrorGenerateCmdCounter,
   /**
-   * Indicates a write to a full FIFO occured.
+   * Indicates a write to a full FIFO occurred.
    */
   kDifCsrngErrorFifoWrite,
   /**
-   * Indicates a read from an empty FIFO occured.
+   * Indicates a read from an empty FIFO occurred.
    */
   kDifCsrngErrorFifoRead,
   /**

--- a/sw/device/lib/dif/dif_edn.h
+++ b/sw/device/lib/dif/dif_edn.h
@@ -137,7 +137,7 @@ typedef enum dif_edn_status {
    */
   kDifEdnStatusCsrngStatus,
   /**
-   * Device has recieved an ACK from the CSRNG block.
+   * Device has received an ACK from the CSRNG block.
    */
   kDifEdnStatusCsrngAck,
 } dif_edn_status_t;
@@ -254,11 +254,11 @@ typedef enum dif_edn_error {
    */
   kDifEdnErrorCounterFault,
   /**
-   * Indicates a write to a full FIFO occured.
+   * Indicates a write to a full FIFO occurred.
    */
   kDifEdnErrorFifoWrite,
   /**
-   * Indicates a read from an empty FIFO occured.
+   * Indicates a read from an empty FIFO occurred.
    */
   kDifEdnErrorFifoRead,
   /**

--- a/sw/device/lib/dif/dif_i2c.h
+++ b/sw/device/lib/dif/dif_i2c.h
@@ -107,7 +107,7 @@ typedef struct dif_i2c_timing_config {
  */
 typedef struct dif_i2c_id {
   /**
-   * Mask the recieved I2C address before checking for a match. Received Address
+   * Mask the received I2C address before checking for a match. Received Address
    * & mask must equal the programmed address to activate I2C Device. If Address
    * & ~mask != 0, this will not match any addresses. A mask of 0x7f will cause
    * device to only respond to an exact match. The mask is 7 bits and LSB

--- a/sw/device/lib/dif/dif_kmac.h
+++ b/sw/device/lib/dif/dif_kmac.h
@@ -364,7 +364,7 @@ typedef struct dif_kmac_function_name {
  */
 typedef enum dif_kmac_error {
   /**
-   * No error has occured.
+   * No error has occurred.
    */
   kDifErrorNone = 0,
 

--- a/sw/device/lib/dif/dif_rom_ctrl.h
+++ b/sw/device/lib/dif/dif_rom_ctrl.h
@@ -27,7 +27,7 @@ extern "C" {
  */
 typedef enum dif_rom_ctrl_fatal_alert_cause {
   /**
-   * No error has occured.
+   * No error has occurred.
    */
   kDifRomCtrlFatalAlertCauseNoError = 0,
   /**

--- a/sw/device/lib/dif/dif_uart.h
+++ b/sw/device/lib/dif/dif_uart.h
@@ -140,7 +140,7 @@ typedef enum dif_uart_datapath {
  */
 typedef enum dif_uart_loopback {
   /**
-   * Indicates that outgoing TX bits should be recieved through RX.
+   * Indicates that outgoing TX bits should be received through RX.
    */
   kDifUartLoopbackSystem = 0,
   /**

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -239,7 +239,7 @@ void flash_ctrl_status_get(flash_ctrl_status_t *status);
  */
 typedef struct flash_ctrl_error_code {
   /**
-   * Flash macro error occured.
+   * Flash macro error occurred.
    */
   bool macro_err;
   /**

--- a/sw/device/silicon_creator/lib/xmodem.h
+++ b/sw/device/silicon_creator/lib/xmodem.h
@@ -35,7 +35,7 @@ void xmodem_cancel(void *iohandle);
  * @param iohandle An opaque user point associated with the io device.
  * @param frame The frame number expected (start at 1).
  * @param data Buffer to receive the data into.
- * @param rxlen The length of data recieved.
+ * @param rxlen The length of data received.
  * @param unknown_rx The byte received when the error is kErrorXmodemUnknown.
  * @return Error value.
  */

--- a/sw/device/tests/alert_handler_lpg_sleep_mode_pings.c
+++ b/sw/device/tests/alert_handler_lpg_sleep_mode_pings.c
@@ -234,7 +234,7 @@ static uint16_t alert_handler_num_fired_loc_alerts(void) {
   // Indicates if any of the alerts or local alerts is fired.
   uint16_t accumulator = 0;
   // Loop over all loc_alert_cause regs
-  // Keep the result for kDifAlertHandlerLocalAlertAlertPingFail in a seperate
+  // Keep the result for kDifAlertHandlerLocalAlertAlertPingFail in a separate
   // variable
   for (dif_alert_handler_local_alert_t i = 0; i < 7; i++) {
     CHECK_DIF_OK(

--- a/sw/device/tests/hmac_error_conditions_test.c
+++ b/sw/device/tests/hmac_error_conditions_test.c
@@ -22,7 +22,7 @@ OTTF_DEFINE_TEST_CONFIG();
 typedef enum hmac_err {
 
   /**
-   * No error has occured.
+   * No error has occurred.
    */
   kErrorNone = 0x0,
 

--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h
@@ -395,7 +395,7 @@ uint32_t pentest_linear_layer(uint32_t input);
  * masking, see `pentest_seed_lfsr()` and `pentest_next_lfsr()`. Internally, a
  * LUT-based AES S-Box is applied to the invididual bytes of the input word.
  *
- * In addition, the ouput bytes are XORed with the sbox[0]. This is useful to
+ * In addition, the output bytes are XORed with the sbox[0]. This is useful to
  * ensure an all-zero seed (used to switch off key masking) also results in an
  * all-zero output of the non-linear layer.
  *

--- a/sw/device/tests/rv_plic_smoketest.c
+++ b/sw/device/tests/rv_plic_smoketest.c
@@ -142,7 +142,7 @@ static void execute_test(dif_uart_t *uart) {
   // Force UART RX overflow interrupt.
   uart_rx_overflow_handled = false;
   CHECK_DIF_OK(dif_uart_irq_force(uart, kDifUartIrqRxOverflow, true));
-  // Check if the IRQ has occured and has been handled appropriately.
+  // Check if the IRQ has occurred and has been handled appropriately.
   if (!uart_rx_overflow_handled) {
     busy_spin_micros(10);
   }
@@ -151,7 +151,7 @@ static void execute_test(dif_uart_t *uart) {
   // Force UART TX done interrupt.
   uart_tx_done_handled = false;
   CHECK_DIF_OK(dif_uart_irq_force(uart, kDifUartIrqTxDone, true));
-  // Check if the IRQ has occured and has been handled appropriately.
+  // Check if the IRQ has occurred and has been handled appropriately.
   if (!uart_tx_done_handled) {
     busy_spin_micros(10);
   }

--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -1003,7 +1003,7 @@ impl TransportWrapper {
 
     /// As long as the returned `MaintainConnection` object is kept by the caller, this driver may
     /// assume that no other `opentitantool` processes attempt to access the same debugger device.
-    /// This allows for optimzations such as keeping USB handles open across function invocations.
+    /// This allows for optimizations such as keeping USB handles open across function invocations.
     pub fn maintain_connection(&self) -> Result<Rc<dyn MaintainConnection>> {
         self.transport.maintain_connection()
     }

--- a/sw/host/opentitanlib/src/debug/openocd.rs
+++ b/sw/host/opentitanlib/src/debug/openocd.rs
@@ -276,7 +276,7 @@ impl JtagChain for OpenOcdJtagChain {
         };
         self.openocd.execute(target)?;
 
-        // Capture outputs during initialization to see if error has occured during the process.
+        // Capture outputs during initialization to see if error has occurred during the process.
         let resp = self.openocd.execute("capture init")?;
         if resp.contains("JTAG scan chain interrogation failed") {
             bail!(OpenOcdError::InitializeFailure(resp));

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -159,7 +159,7 @@ pub trait Transport {
 
     /// As long as the returned `MaintainConnection` object is kept by the caller, this driver may
     /// assume that no other `opentitantool` processes attempt to access the same debugger device.
-    /// This allows for optimzations such as keeping USB handles open across function invocations.
+    /// This allows for optimizations such as keeping USB handles open across function invocations.
     fn maintain_connection(&self) -> Result<Rc<dyn MaintainConnection>> {
         // For implementations that have not implemented any optimizations, return a no-op object.
         Ok(Rc::new(()))
@@ -175,7 +175,7 @@ pub trait Transport {
 
 /// As long as this object is kept alive, the `Transport` driver may assume that no other
 /// `opentitantool` processes attempt to access the same debugger device.  This allows for
-/// optimzations such as keeping USB handles open across function invocations.
+/// optimizations such as keeping USB handles open across function invocations.
 pub trait MaintainConnection {}
 
 /// No-op implmentation of the trait, for use by `Transport` implementations that do not do

--- a/sw/host/tests/chip/spi_device/src/spi_passthru.rs
+++ b/sw/host/tests/chip/spi_device/src/spi_passthru.rs
@@ -183,7 +183,7 @@ fn test_read_sfdp(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     assert_eq!(buf, sfdp.data.as_slice());
 
     // Test a read that would go beyond the length of the SFDP data.
-    // The observed behavior should be that the buffer recieved from
+    // The observed behavior should be that the buffer received from
     // the device should wrap around.
     let buf = read_sfdp(&*spi, 0x30)?;
     let data = sfdp.data.as_slice();

--- a/util/reggen/README.md
+++ b/util/reggen/README.md
@@ -589,7 +589,7 @@ module name_reg_top (
   input clk_i,
   input rst_ni,
 
-  // Below Regster interface can be changed
+  // Below Register interface can be changed
   input  tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o,
 

--- a/util/uvmdvgen/env_cov.sv.tpl
+++ b/util/uvmdvgen/env_cov.sv.tpl
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Covergoups that are dependent on run-time parameters that may be available
+ * Covergroups that are dependent on run-time parameters that may be available
  * only in build_phase can be defined here
  * Covergroups may also be wrapped inside helper classes if needed.
  */

--- a/util/uvmdvgen/scoreboard.sv.tpl
+++ b/util/uvmdvgen/scoreboard.sv.tpl
@@ -91,7 +91,7 @@ class ${name}_scoreboard extends dv_base_scoreboard #(
 
     // process the csr req
     // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
+    // for read, update prediction at address phase and compare at data phase
     case (csr.get_name())
       // add individual case item for each csr
       "intr_state": begin


### PR DESCRIPTION
Round two.

Attempt at neutral correction of what I hope are universal seen as spelling and capitalisation errors in some documentation and code comments. 

Please flag any accidental changes to something that was already correctly spelt. My spell-checker is set to British, not American English, so there's a chance I accidentally "fixed" a spelling I didn't recognise as being the American variant.

Also includes some fixes to mistakes I made in the first round of fixes (https://github.com/lowRISC/opentitan/pull/27490).