### PR TITLE
[python] pin Python version in gen-python-requirements.sh

### DIFF
--- a/util/sh/scripts/gen-python-requirements.sh
+++ b/util/sh/scripts/gen-python-requirements.sh
@@ -16,6 +16,7 @@ uv pip compile \
   --generate-hashes \
   --no-annotate \
   --no-header \
+  --python 3.10 \
   "$PYTHON_REQS_IN_FILE" \
   -o "$PYTHON_REQS_OUT_FILE"
 echo -e "\n$(cat "$PYTHON_REQS_OUT_FILE")" > "$PYTHON_REQS_OUT_FILE"


### PR DESCRIPTION
It appears that UV can pick up locally installed Python versions when running `uv pip compile` and not honour current environment Python version and pyproject.toml. Pin to a specific version to avoid surprises when people need to repin on their environment.