### PR TITLE
[dv,manuf] Fixup bootstrapping of ate_manuf sims

### DIFF
--- a/hw/top_earlgrey/dv/chip_manuf_ate_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_manuf_ate_tests.hjson
@@ -56,6 +56,7 @@
         "+sw_test_timeout_ns=1000000000",
         "+use_otp_image=OtpTypeCustom",
         "+skip_flash_bkdr_load=1",
+        "+use_spi_load_bootstrap=1",
       ]
       run_timeout_mins: 800
     }
@@ -71,6 +72,7 @@
         "+sw_test_timeout_ns=1000000000",
         "+use_otp_image=OtpTypeCustom",
         "+skip_flash_bkdr_load=1",
+        "+use_spi_load_bootstrap=1",
       ]
       run_timeout_mins: 800
     }

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_ate_smoke_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_ate_smoke_vseq.sv
@@ -10,11 +10,9 @@ class chip_sw_rom_e2e_ate_smoke_vseq extends
   virtual task body();
     super.body();
 
-    // Drive SW straps for bootstrap.
-    `uvm_info(`gfn, "Driving SW straps high for bootstrap.", UVM_LOW)
-    cfg.chip_vif.sw_straps_if.drive(3'h7);
     `uvm_info(`gfn, "Initializing SPI flash bootstrap.", UVM_LOW)
     spi_device_load_bootstrap({cfg.sw_images[SwTypeTestSlotA], ".64.vmem"});
+    cfg.use_spi_load_bootstrap = 1'b0;
     `uvm_info(`gfn, "SPI flash bootstrap done.", UVM_LOW)
 
     // Wait for SRAM initialization to complete a second time (after bootstrap).

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_ft_perso_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_ft_perso_vseq.sv
@@ -10,11 +10,9 @@ class chip_sw_rom_e2e_ft_perso_vseq extends
   virtual task body();
     super.body();
 
-    // Drive SW straps for bootstrap.
-    `uvm_info(`gfn, "Driving SW straps high for bootstrap.", UVM_LOW)
-    cfg.chip_vif.sw_straps_if.drive(3'h7);
     `uvm_info(`gfn, "Initializing SPI flash bootstrap.", UVM_LOW)
     spi_device_load_bootstrap({cfg.sw_images[SwTypeTestSlotA], ".64.vmem"});
+    cfg.use_spi_load_bootstrap = 1'b0;
     `uvm_info(`gfn, "SPI flash bootstrap done.", UVM_LOW)
 
     // Wait for SRAM initialization to complete a second time (after bootstrap).


### PR DESCRIPTION
Without `"+use_spi_load_bootstrap=1"`, the logic in `chip_sw_base_vseq::set_and_release_sw_strap_nonblocking` clears the sw straps upon reaching SwTestStatusInBootRom. This prevents the bootstrap process from occurring.

With this change, e2e_ate_smoke now passes in sim, and e2e_ft_perso progresses to the point where it is waiting for SPI Console input.