### PR TITLE
[hw,entropy_src,rtl] Remove unused REV register

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -409,28 +409,6 @@
         }
       ]
     },
-    { name: "REV",
-      desc: "Revision register",
-      swaccess: "ro",
-      hwaccess: "none",
-      fields: [
-        { bits: "23:16",
-          name: "CHIP_TYPE",
-          desc: "Read of this register shows the type of chip using this block.",
-          resval: "0x1"
-        }
-        { bits: "15:8",
-          name: "HW_REVISION",
-          desc: "Read of this register shows the revision of this block.",
-          resval: "0x3"
-        }
-        { bits: "7:0",
-          name: "ABI_REVISION",
-          desc: "Read of this register shows the ABI of this block.",
-          resval: "0x3"
-        }
-      ]
-    },
     { name: "MODULE_ENABLE",
       desc: "Module enable register",
       swaccess: "rw",

--- a/hw/ip/entropy_src/doc/registers.md
+++ b/hw/ip/entropy_src/doc/registers.md
@@ -12,56 +12,55 @@
 | entropy_src.[`ME_REGWEN`](#me_regwen)                                 | 0x10     |        4 | Register write enable for module enable register             |
 | entropy_src.[`SW_REGUPD`](#sw_regupd)                                 | 0x14     |        4 | Register write enable for control and threshold registers    |
 | entropy_src.[`REGWEN`](#regwen)                                       | 0x18     |        4 | Register write enable for all control registers              |
-| entropy_src.[`REV`](#rev)                                             | 0x1c     |        4 | Revision register                                            |
-| entropy_src.[`MODULE_ENABLE`](#module_enable)                         | 0x20     |        4 | Module enable register                                       |
-| entropy_src.[`CONF`](#conf)                                           | 0x24     |        4 | Configuration register                                       |
-| entropy_src.[`ENTROPY_CONTROL`](#entropy_control)                     | 0x28     |        4 | Entropy control register                                     |
-| entropy_src.[`ENTROPY_DATA`](#entropy_data)                           | 0x2c     |        4 | Entropy data bits                                            |
-| entropy_src.[`HEALTH_TEST_WINDOWS`](#health_test_windows)             | 0x30     |        4 | Health test windows register                                 |
-| entropy_src.[`REPCNT_THRESHOLDS`](#repcnt_thresholds)                 | 0x34     |        4 | Repetition count test thresholds register                    |
-| entropy_src.[`REPCNTS_THRESHOLDS`](#repcnts_thresholds)               | 0x38     |        4 | Repetition count symbol test thresholds register             |
-| entropy_src.[`ADAPTP_HI_THRESHOLDS`](#adaptp_hi_thresholds)           | 0x3c     |        4 | Adaptive proportion test high thresholds register            |
-| entropy_src.[`ADAPTP_LO_THRESHOLDS`](#adaptp_lo_thresholds)           | 0x40     |        4 | Adaptive proportion test low thresholds register             |
-| entropy_src.[`BUCKET_THRESHOLDS`](#bucket_thresholds)                 | 0x44     |        4 | Bucket test thresholds register                              |
-| entropy_src.[`MARKOV_HI_THRESHOLDS`](#markov_hi_thresholds)           | 0x48     |        4 | Markov test high thresholds register                         |
-| entropy_src.[`MARKOV_LO_THRESHOLDS`](#markov_lo_thresholds)           | 0x4c     |        4 | Markov test low thresholds register                          |
-| entropy_src.[`EXTHT_HI_THRESHOLDS`](#extht_hi_thresholds)             | 0x50     |        4 | External health test high thresholds register                |
-| entropy_src.[`EXTHT_LO_THRESHOLDS`](#extht_lo_thresholds)             | 0x54     |        4 | External health test low thresholds register                 |
-| entropy_src.[`REPCNT_HI_WATERMARKS`](#repcnt_hi_watermarks)           | 0x58     |        4 | Repetition count test high watermarks register               |
-| entropy_src.[`REPCNTS_HI_WATERMARKS`](#repcnts_hi_watermarks)         | 0x5c     |        4 | Repetition count symbol test high watermarks register        |
-| entropy_src.[`ADAPTP_HI_WATERMARKS`](#adaptp_hi_watermarks)           | 0x60     |        4 | Adaptive proportion test high watermarks register            |
-| entropy_src.[`ADAPTP_LO_WATERMARKS`](#adaptp_lo_watermarks)           | 0x64     |        4 | Adaptive proportion test low watermarks register             |
-| entropy_src.[`EXTHT_HI_WATERMARKS`](#extht_hi_watermarks)             | 0x68     |        4 | External health test high watermarks register                |
-| entropy_src.[`EXTHT_LO_WATERMARKS`](#extht_lo_watermarks)             | 0x6c     |        4 | External health test low watermarks register                 |
-| entropy_src.[`BUCKET_HI_WATERMARKS`](#bucket_hi_watermarks)           | 0x70     |        4 | Bucket test high watermarks register                         |
-| entropy_src.[`MARKOV_HI_WATERMARKS`](#markov_hi_watermarks)           | 0x74     |        4 | Markov test high watermarks register                         |
-| entropy_src.[`MARKOV_LO_WATERMARKS`](#markov_lo_watermarks)           | 0x78     |        4 | Markov test low watermarks register                          |
-| entropy_src.[`REPCNT_TOTAL_FAILS`](#repcnt_total_fails)               | 0x7c     |        4 | Repetition count test failure counter register               |
-| entropy_src.[`REPCNTS_TOTAL_FAILS`](#repcnts_total_fails)             | 0x80     |        4 | Repetition count symbol test failure counter register        |
-| entropy_src.[`ADAPTP_HI_TOTAL_FAILS`](#adaptp_hi_total_fails)         | 0x84     |        4 | Adaptive proportion high test failure counter register       |
-| entropy_src.[`ADAPTP_LO_TOTAL_FAILS`](#adaptp_lo_total_fails)         | 0x88     |        4 | Adaptive proportion low test failure counter register        |
-| entropy_src.[`BUCKET_TOTAL_FAILS`](#bucket_total_fails)               | 0x8c     |        4 | Bucket test failure counter register                         |
-| entropy_src.[`MARKOV_HI_TOTAL_FAILS`](#markov_hi_total_fails)         | 0x90     |        4 | Markov high test failure counter register                    |
-| entropy_src.[`MARKOV_LO_TOTAL_FAILS`](#markov_lo_total_fails)         | 0x94     |        4 | Markov low test failure counter register                     |
-| entropy_src.[`EXTHT_HI_TOTAL_FAILS`](#extht_hi_total_fails)           | 0x98     |        4 | External health test high threshold failure counter register |
-| entropy_src.[`EXTHT_LO_TOTAL_FAILS`](#extht_lo_total_fails)           | 0x9c     |        4 | External health test low threshold failure counter register  |
-| entropy_src.[`ALERT_THRESHOLD`](#alert_threshold)                     | 0xa0     |        4 | Alert threshold register                                     |
-| entropy_src.[`ALERT_SUMMARY_FAIL_COUNTS`](#alert_summary_fail_counts) | 0xa4     |        4 | Alert summary failure counts register                        |
-| entropy_src.[`ALERT_FAIL_COUNTS`](#alert_fail_counts)                 | 0xa8     |        4 | Alert failure counts register                                |
-| entropy_src.[`EXTHT_FAIL_COUNTS`](#extht_fail_counts)                 | 0xac     |        4 | External health test alert failure counts register           |
-| entropy_src.[`FW_OV_CONTROL`](#fw_ov_control)                         | 0xb0     |        4 | Firmware override control register                           |
-| entropy_src.[`FW_OV_SHA3_START`](#fw_ov_sha3_start)                   | 0xb4     |        4 | Firmware override sha3 block start control register          |
-| entropy_src.[`FW_OV_WR_FIFO_FULL`](#fw_ov_wr_fifo_full)               | 0xb8     |        4 | Firmware override FIFO write full status register            |
-| entropy_src.[`FW_OV_RD_FIFO_OVERFLOW`](#fw_ov_rd_fifo_overflow)       | 0xbc     |        4 | Firmware override observe FIFO overflow status               |
-| entropy_src.[`FW_OV_RD_DATA`](#fw_ov_rd_data)                         | 0xc0     |        4 | Firmware override observe FIFO read register                 |
-| entropy_src.[`FW_OV_WR_DATA`](#fw_ov_wr_data)                         | 0xc4     |        4 | Firmware override FIFO write register                        |
-| entropy_src.[`OBSERVE_FIFO_THRESH`](#observe_fifo_thresh)             | 0xc8     |        4 | Observe FIFO threshold register                              |
-| entropy_src.[`OBSERVE_FIFO_DEPTH`](#observe_fifo_depth)               | 0xcc     |        4 | Observe FIFO depth register                                  |
-| entropy_src.[`DEBUG_STATUS`](#debug_status)                           | 0xd0     |        4 | Debug status register                                        |
-| entropy_src.[`RECOV_ALERT_STS`](#recov_alert_sts)                     | 0xd4     |        4 | Recoverable alert status register                            |
-| entropy_src.[`ERR_CODE`](#err_code)                                   | 0xd8     |        4 | Hardware detection of error conditions status register       |
-| entropy_src.[`ERR_CODE_TEST`](#err_code_test)                         | 0xdc     |        4 | Test error conditions register                               |
-| entropy_src.[`MAIN_SM_STATE`](#main_sm_state)                         | 0xe0     |        4 | Main state machine state debug register                      |
+| entropy_src.[`MODULE_ENABLE`](#module_enable)                         | 0x1c     |        4 | Module enable register                                       |
+| entropy_src.[`CONF`](#conf)                                           | 0x20     |        4 | Configuration register                                       |
+| entropy_src.[`ENTROPY_CONTROL`](#entropy_control)                     | 0x24     |        4 | Entropy control register                                     |
+| entropy_src.[`ENTROPY_DATA`](#entropy_data)                           | 0x28     |        4 | Entropy data bits                                            |
+| entropy_src.[`HEALTH_TEST_WINDOWS`](#health_test_windows)             | 0x2c     |        4 | Health test windows register                                 |
+| entropy_src.[`REPCNT_THRESHOLDS`](#repcnt_thresholds)                 | 0x30     |        4 | Repetition count test thresholds register                    |
+| entropy_src.[`REPCNTS_THRESHOLDS`](#repcnts_thresholds)               | 0x34     |        4 | Repetition count symbol test thresholds register             |
+| entropy_src.[`ADAPTP_HI_THRESHOLDS`](#adaptp_hi_thresholds)           | 0x38     |        4 | Adaptive proportion test high thresholds register            |
+| entropy_src.[`ADAPTP_LO_THRESHOLDS`](#adaptp_lo_thresholds)           | 0x3c     |        4 | Adaptive proportion test low thresholds register             |
+| entropy_src.[`BUCKET_THRESHOLDS`](#bucket_thresholds)                 | 0x40     |        4 | Bucket test thresholds register                              |
+| entropy_src.[`MARKOV_HI_THRESHOLDS`](#markov_hi_thresholds)           | 0x44     |        4 | Markov test high thresholds register                         |
+| entropy_src.[`MARKOV_LO_THRESHOLDS`](#markov_lo_thresholds)           | 0x48     |        4 | Markov test low thresholds register                          |
+| entropy_src.[`EXTHT_HI_THRESHOLDS`](#extht_hi_thresholds)             | 0x4c     |        4 | External health test high thresholds register                |
+| entropy_src.[`EXTHT_LO_THRESHOLDS`](#extht_lo_thresholds)             | 0x50     |        4 | External health test low thresholds register                 |
+| entropy_src.[`REPCNT_HI_WATERMARKS`](#repcnt_hi_watermarks)           | 0x54     |        4 | Repetition count test high watermarks register               |
+| entropy_src.[`REPCNTS_HI_WATERMARKS`](#repcnts_hi_watermarks)         | 0x58     |        4 | Repetition count symbol test high watermarks register        |
+| entropy_src.[`ADAPTP_HI_WATERMARKS`](#adaptp_hi_watermarks)           | 0x5c     |        4 | Adaptive proportion test high watermarks register            |
+| entropy_src.[`ADAPTP_LO_WATERMARKS`](#adaptp_lo_watermarks)           | 0x60     |        4 | Adaptive proportion test low watermarks register             |
+| entropy_src.[`EXTHT_HI_WATERMARKS`](#extht_hi_watermarks)             | 0x64     |        4 | External health test high watermarks register                |
+| entropy_src.[`EXTHT_LO_WATERMARKS`](#extht_lo_watermarks)             | 0x68     |        4 | External health test low watermarks register                 |
+| entropy_src.[`BUCKET_HI_WATERMARKS`](#bucket_hi_watermarks)           | 0x6c     |        4 | Bucket test high watermarks register                         |
+| entropy_src.[`MARKOV_HI_WATERMARKS`](#markov_hi_watermarks)           | 0x70     |        4 | Markov test high watermarks register                         |
+| entropy_src.[`MARKOV_LO_WATERMARKS`](#markov_lo_watermarks)           | 0x74     |        4 | Markov test low watermarks register                          |
+| entropy_src.[`REPCNT_TOTAL_FAILS`](#repcnt_total_fails)               | 0x78     |        4 | Repetition count test failure counter register               |
+| entropy_src.[`REPCNTS_TOTAL_FAILS`](#repcnts_total_fails)             | 0x7c     |        4 | Repetition count symbol test failure counter register        |
+| entropy_src.[`ADAPTP_HI_TOTAL_FAILS`](#adaptp_hi_total_fails)         | 0x80     |        4 | Adaptive proportion high test failure counter register       |
+| entropy_src.[`ADAPTP_LO_TOTAL_FAILS`](#adaptp_lo_total_fails)         | 0x84     |        4 | Adaptive proportion low test failure counter register        |
+| entropy_src.[`BUCKET_TOTAL_FAILS`](#bucket_total_fails)               | 0x88     |        4 | Bucket test failure counter register                         |
+| entropy_src.[`MARKOV_HI_TOTAL_FAILS`](#markov_hi_total_fails)         | 0x8c     |        4 | Markov high test failure counter register                    |
+| entropy_src.[`MARKOV_LO_TOTAL_FAILS`](#markov_lo_total_fails)         | 0x90     |        4 | Markov low test failure counter register                     |
+| entropy_src.[`EXTHT_HI_TOTAL_FAILS`](#extht_hi_total_fails)           | 0x94     |        4 | External health test high threshold failure counter register |
+| entropy_src.[`EXTHT_LO_TOTAL_FAILS`](#extht_lo_total_fails)           | 0x98     |        4 | External health test low threshold failure counter register  |
+| entropy_src.[`ALERT_THRESHOLD`](#alert_threshold)                     | 0x9c     |        4 | Alert threshold register                                     |
+| entropy_src.[`ALERT_SUMMARY_FAIL_COUNTS`](#alert_summary_fail_counts) | 0xa0     |        4 | Alert summary failure counts register                        |
+| entropy_src.[`ALERT_FAIL_COUNTS`](#alert_fail_counts)                 | 0xa4     |        4 | Alert failure counts register                                |
+| entropy_src.[`EXTHT_FAIL_COUNTS`](#extht_fail_counts)                 | 0xa8     |        4 | External health test alert failure counts register           |
+| entropy_src.[`FW_OV_CONTROL`](#fw_ov_control)                         | 0xac     |        4 | Firmware override control register                           |
+| entropy_src.[`FW_OV_SHA3_START`](#fw_ov_sha3_start)                   | 0xb0     |        4 | Firmware override sha3 block start control register          |
+| entropy_src.[`FW_OV_WR_FIFO_FULL`](#fw_ov_wr_fifo_full)               | 0xb4     |        4 | Firmware override FIFO write full status register            |
+| entropy_src.[`FW_OV_RD_FIFO_OVERFLOW`](#fw_ov_rd_fifo_overflow)       | 0xb8     |        4 | Firmware override observe FIFO overflow status               |
+| entropy_src.[`FW_OV_RD_DATA`](#fw_ov_rd_data)                         | 0xbc     |        4 | Firmware override observe FIFO read register                 |
+| entropy_src.[`FW_OV_WR_DATA`](#fw_ov_wr_data)                         | 0xc0     |        4 | Firmware override FIFO write register                        |
+| entropy_src.[`OBSERVE_FIFO_THRESH`](#observe_fifo_thresh)             | 0xc4     |        4 | Observe FIFO threshold register                              |
+| entropy_src.[`OBSERVE_FIFO_DEPTH`](#observe_fifo_depth)               | 0xc8     |        4 | Observe FIFO depth register                                  |
+| entropy_src.[`DEBUG_STATUS`](#debug_status)                           | 0xcc     |        4 | Debug status register                                        |
+| entropy_src.[`RECOV_ALERT_STS`](#recov_alert_sts)                     | 0xd0     |        4 | Recoverable alert status register                            |
+| entropy_src.[`ERR_CODE`](#err_code)                                   | 0xd4     |        4 | Hardware detection of error conditions status register       |
+| entropy_src.[`ERR_CODE_TEST`](#err_code_test)                         | 0xd8     |        4 | Test error conditions register                               |
+| entropy_src.[`MAIN_SM_STATE`](#main_sm_state)                         | 0xdc     |        4 | Main state machine state debug register                      |
 
 ## INTR_STATE
 Interrupt State Register
@@ -196,28 +195,9 @@ Register write enable for all control registers
 This read-only write enable bit will allow write access to control and threshold registers that are associated with this bit, but only when the [`MODULE_ENABLE`](#module_enable) register is set to `kMultiBitBool4False` and the [`SW_REGUPD`](#sw_regupd) write enable bit is set to true.
 When read as false, these registers become read-only.
 
-## REV
-Revision register
-- Offset: `0x1c`
-- Reset default: `0x10303`
-- Reset mask: `0xffffff`
-
-### Fields
-
-```wavejson
-{"reg": [{"name": "ABI_REVISION", "bits": 8, "attr": ["ro"], "rotate": 0}, {"name": "HW_REVISION", "bits": 8, "attr": ["ro"], "rotate": 0}, {"name": "CHIP_TYPE", "bits": 8, "attr": ["ro"], "rotate": 0}, {"bits": 8}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
-```
-
-|  Bits  |  Type  |  Reset  | Name         | Description                                                    |
-|:------:|:------:|:-------:|:-------------|:---------------------------------------------------------------|
-| 31:24  |        |         |              | Reserved                                                       |
-| 23:16  |   ro   |   0x1   | CHIP_TYPE    | Read of this register shows the type of chip using this block. |
-|  15:8  |   ro   |   0x3   | HW_REVISION  | Read of this register shows the revision of this block.        |
-|  7:0   |   ro   |   0x3   | ABI_REVISION | Read of this register shows the ABI of this block.             |
-
 ## MODULE_ENABLE
 Module enable register
-- Offset: `0x20`
+- Offset: `0x1c`
 - Reset default: `0x9`
 - Reset mask: `0xf`
 - Register enable: [`ME_REGWEN`](#me_regwen)
@@ -239,7 +219,7 @@ The modules of the entropy complex may only be enabled and disabled in a specifi
 
 ## CONF
 Configuration register
-- Offset: `0x24`
+- Offset: `0x20`
 - Reset default: `0x999999`
 - Reset mask: `0xffffffff`
 - Register enable: [`REGWEN`](#regwen)
@@ -297,7 +277,7 @@ Setting this field to `kMultiBitBool4False` selects the boot-time / bypass mode 
 
 ## ENTROPY_CONTROL
 Entropy control register
-- Offset: `0x28`
+- Offset: `0x24`
 - Reset default: `0x99`
 - Reset mask: `0xff`
 - Register enable: [`REGWEN`](#regwen)
@@ -329,7 +309,7 @@ In addition, the otp_en_entropy_src_fw_read input needs to be set to `kMultiBitB
 
 ## ENTROPY_DATA
 Entropy data bits
-- Offset: `0x2c`
+- Offset: `0x28`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -350,7 +330,7 @@ In addition, the otp_en_entropy_src_fw_read input needs to be set to `kMultiBitB
 
 ## HEALTH_TEST_WINDOWS
 Health test windows register
-- Offset: `0x30`
+- Offset: `0x2c`
 - Reset default: `0x600200`
 - Reset mask: `0xffffffff`
 - Register enable: [`REGWEN`](#regwen)
@@ -389,7 +369,7 @@ The use of window sizes below 512 samples is thus not recommended as this may no
 
 ## REPCNT_THRESHOLDS
 Repetition count test thresholds register
-- Offset: `0x34`
+- Offset: `0x30`
 - Reset default: `0xffffffff`
 - Reset mask: `0xffffffff`
 - Register enable: [`REGWEN`](#regwen)
@@ -424,7 +404,7 @@ This is the threshold size for the repetition count health test.
 
 ## REPCNTS_THRESHOLDS
 Repetition count symbol test thresholds register
-- Offset: `0x38`
+- Offset: `0x34`
 - Reset default: `0xffffffff`
 - Reset mask: `0xffffffff`
 - Register enable: [`REGWEN`](#regwen)
@@ -459,7 +439,7 @@ This is the threshold size for the repetition count symbol health test.
 
 ## ADAPTP_HI_THRESHOLDS
 Adaptive proportion test high thresholds register
-- Offset: `0x3c`
+- Offset: `0x38`
 - Reset default: `0xffffffff`
 - Reset mask: `0xffffffff`
 - Register enable: [`REGWEN`](#regwen)
@@ -494,7 +474,7 @@ This is the threshold size for the adaptive proportion health test.
 
 ## ADAPTP_LO_THRESHOLDS
 Adaptive proportion test low thresholds register
-- Offset: `0x40`
+- Offset: `0x3c`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 - Register enable: [`REGWEN`](#regwen)
@@ -529,7 +509,7 @@ This is the threshold size for the adaptive proportion health test.
 
 ## BUCKET_THRESHOLDS
 Bucket test thresholds register
-- Offset: `0x44`
+- Offset: `0x40`
 - Reset default: `0xffffffff`
 - Reset mask: `0xffffffff`
 - Register enable: [`REGWEN`](#regwen)
@@ -564,7 +544,7 @@ This is the threshold size for the bucket health test.
 
 ## MARKOV_HI_THRESHOLDS
 Markov test high thresholds register
-- Offset: `0x48`
+- Offset: `0x44`
 - Reset default: `0xffffffff`
 - Reset mask: `0xffffffff`
 - Register enable: [`REGWEN`](#regwen)
@@ -599,7 +579,7 @@ This is the threshold size for the Markov health test.
 
 ## MARKOV_LO_THRESHOLDS
 Markov test low thresholds register
-- Offset: `0x4c`
+- Offset: `0x48`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 - Register enable: [`REGWEN`](#regwen)
@@ -634,7 +614,7 @@ This is the threshold size for the Markov health test.
 
 ## EXTHT_HI_THRESHOLDS
 External health test high thresholds register
-- Offset: `0x50`
+- Offset: `0x4c`
 - Reset default: `0xffffffff`
 - Reset mask: `0xffffffff`
 - Register enable: [`REGWEN`](#regwen)
@@ -669,7 +649,7 @@ This is the threshold size for the external health test.
 
 ## EXTHT_LO_THRESHOLDS
 External health test low thresholds register
-- Offset: `0x54`
+- Offset: `0x50`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 - Register enable: [`REGWEN`](#regwen)
@@ -704,7 +684,7 @@ This is the threshold size for the external health test.
 
 ## REPCNT_HI_WATERMARKS
 Repetition count test high watermarks register
-- Offset: `0x58`
+- Offset: `0x54`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -721,7 +701,7 @@ Repetition count test high watermarks register
 
 ## REPCNTS_HI_WATERMARKS
 Repetition count symbol test high watermarks register
-- Offset: `0x5c`
+- Offset: `0x58`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -738,7 +718,7 @@ Repetition count symbol test high watermarks register
 
 ## ADAPTP_HI_WATERMARKS
 Adaptive proportion test high watermarks register
-- Offset: `0x60`
+- Offset: `0x5c`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -755,7 +735,7 @@ Adaptive proportion test high watermarks register
 
 ## ADAPTP_LO_WATERMARKS
 Adaptive proportion test low watermarks register
-- Offset: `0x64`
+- Offset: `0x60`
 - Reset default: `0xffffffff`
 - Reset mask: `0xffffffff`
 
@@ -772,7 +752,7 @@ Adaptive proportion test low watermarks register
 
 ## EXTHT_HI_WATERMARKS
 External health test high watermarks register
-- Offset: `0x68`
+- Offset: `0x64`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -789,7 +769,7 @@ External health test high watermarks register
 
 ## EXTHT_LO_WATERMARKS
 External health test low watermarks register
-- Offset: `0x6c`
+- Offset: `0x68`
 - Reset default: `0xffffffff`
 - Reset mask: `0xffffffff`
 
@@ -806,7 +786,7 @@ External health test low watermarks register
 
 ## BUCKET_HI_WATERMARKS
 Bucket test high watermarks register
-- Offset: `0x70`
+- Offset: `0x6c`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -823,7 +803,7 @@ Bucket test high watermarks register
 
 ## MARKOV_HI_WATERMARKS
 Markov test high watermarks register
-- Offset: `0x74`
+- Offset: `0x70`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -840,7 +820,7 @@ Markov test high watermarks register
 
 ## MARKOV_LO_WATERMARKS
 Markov test low watermarks register
-- Offset: `0x78`
+- Offset: `0x74`
 - Reset default: `0xffffffff`
 - Reset mask: `0xffffffff`
 
@@ -857,7 +837,7 @@ Markov test low watermarks register
 
 ## REPCNT_TOTAL_FAILS
 Repetition count test failure counter register
-- Offset: `0x7c`
+- Offset: `0x78`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -873,7 +853,7 @@ Repetition count test failure counter register
 
 ## REPCNTS_TOTAL_FAILS
 Repetition count symbol test failure counter register
-- Offset: `0x80`
+- Offset: `0x7c`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -889,7 +869,7 @@ Repetition count symbol test failure counter register
 
 ## ADAPTP_HI_TOTAL_FAILS
 Adaptive proportion high test failure counter register
-- Offset: `0x84`
+- Offset: `0x80`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -905,7 +885,7 @@ Adaptive proportion high test failure counter register
 
 ## ADAPTP_LO_TOTAL_FAILS
 Adaptive proportion low test failure counter register
-- Offset: `0x88`
+- Offset: `0x84`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -921,7 +901,7 @@ Adaptive proportion low test failure counter register
 
 ## BUCKET_TOTAL_FAILS
 Bucket test failure counter register
-- Offset: `0x8c`
+- Offset: `0x88`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -937,7 +917,7 @@ Bucket test failure counter register
 
 ## MARKOV_HI_TOTAL_FAILS
 Markov high test failure counter register
-- Offset: `0x90`
+- Offset: `0x8c`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -953,7 +933,7 @@ Markov high test failure counter register
 
 ## MARKOV_LO_TOTAL_FAILS
 Markov low test failure counter register
-- Offset: `0x94`
+- Offset: `0x90`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -969,7 +949,7 @@ Markov low test failure counter register
 
 ## EXTHT_HI_TOTAL_FAILS
 External health test high threshold failure counter register
-- Offset: `0x98`
+- Offset: `0x94`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -985,7 +965,7 @@ External health test high threshold failure counter register
 
 ## EXTHT_LO_TOTAL_FAILS
 External health test low threshold failure counter register
-- Offset: `0x9c`
+- Offset: `0x98`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -1008,7 +988,7 @@ In case the configured threshold is reached, firmware needs to disable/re-enable
 Note that when reaching the threshold while running in Firmware Override: Extract & Insert mode, the recoverable alert is not raised nor does the block stop operating.
 In other modes, the generation of the recoverable alert can be disabled by configuring a value of zero.
 The default value is set to two.
-- Offset: `0xa0`
+- Offset: `0x9c`
 - Reset default: `0xfffd0002`
 - Reset mask: `0xffffffff`
 - Register enable: [`REGWEN`](#regwen)
@@ -1035,7 +1015,7 @@ If an alert is signaled, the value persists until it is cleared by firmware.
 
 The register is automatically cleared after every passing health test window unless the ENTROPY_SRC is configured in Firmware Override: Extract & Insert mode.
 The register is also cleared after re-enabling the block.
-- Offset: `0xa4`
+- Offset: `0xa0`
 - Reset default: `0x0`
 - Reset mask: `0xffff`
 
@@ -1059,7 +1039,7 @@ Note that if multiple health tests fail for a certain window, the value in [`ALE
 
 All fields of this register are automatically cleared after every passing health test window unless the ENTROPY_SRC is configured in Firmware Override: Extract & Insert mode.
 The fields are also cleared after re-enabling the block.
-- Offset: `0xa8`
+- Offset: `0xa4`
 - Reset default: `0x0`
 - Reset mask: `0xfffffff0`
 
@@ -1089,7 +1069,7 @@ Note that if multiple health tests fail for a certain window, the value in [`ALE
 
 All fields of this register are automatically cleared after every passing health test window unless the ENTROPY_SRC is configured in Firmware Override: Extract & Insert mode.
 The fields are also cleared after re-enabling the block.
-- Offset: `0xac`
+- Offset: `0xa8`
 - Reset default: `0x0`
 - Reset mask: `0xff`
 
@@ -1107,7 +1087,7 @@ The fields are also cleared after re-enabling the block.
 
 ## FW_OV_CONTROL
 Firmware override control register
-- Offset: `0xb0`
+- Offset: `0xac`
 - Reset default: `0x99`
 - Reset mask: `0xff`
 - Register enable: [`REGWEN`](#regwen)
@@ -1152,7 +1132,7 @@ Note that the post-health test entropy bits collected in the observe FIFO contin
 
 ## FW_OV_SHA3_START
 Firmware override sha3 block start control register
-- Offset: `0xb4`
+- Offset: `0xb0`
 - Reset default: `0x9`
 - Reset mask: `0xf`
 
@@ -1178,7 +1158,7 @@ To avoid this, check that [`FW_OV_WR_FIFO_FULL`](#fw_ov_wr_fifo_full) is clear b
 
 ## FW_OV_WR_FIFO_FULL
 Firmware override FIFO write full status register
-- Offset: `0xb8`
+- Offset: `0xb4`
 - Reset default: `0x0`
 - Reset mask: `0x1`
 
@@ -1195,7 +1175,7 @@ Firmware override FIFO write full status register
 
 ## FW_OV_RD_FIFO_OVERFLOW
 Firmware override observe FIFO overflow status
-- Offset: `0xbc`
+- Offset: `0xb8`
 - Reset default: `0x0`
 - Reset mask: `0x1`
 
@@ -1219,7 +1199,7 @@ If an overflow event occurs, this bit is cleared by hardware as soon as the FIFO
 
 ## FW_OV_RD_DATA
 Firmware override observe FIFO read register
-- Offset: `0xc0`
+- Offset: `0xbc`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -1241,7 +1221,7 @@ Reading this register while the observe FIFO is empty results in a fatal error w
 
 ## FW_OV_WR_DATA
 Firmware override FIFO write register
-- Offset: `0xc4`
+- Offset: `0xc0`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -1262,7 +1242,7 @@ In addition, the otp_en_entropy_src_fw_over input needs to be set to `kMultiBitB
 
 ## OBSERVE_FIFO_THRESH
 Observe FIFO threshold register
-- Offset: `0xc8`
+- Offset: `0xc4`
 - Reset default: `0x10`
 - Reset mask: `0x3f`
 - Register enable: [`REGWEN`](#regwen)
@@ -1280,7 +1260,7 @@ Observe FIFO threshold register
 
 ## OBSERVE_FIFO_DEPTH
 Observe FIFO depth register
-- Offset: `0xcc`
+- Offset: `0xc8`
 - Reset default: `0x0`
 - Reset mask: `0x3f`
 
@@ -1297,7 +1277,7 @@ Observe FIFO depth register
 
 ## DEBUG_STATUS
 Debug status register
-- Offset: `0xd0`
+- Offset: `0xcc`
 - Reset default: `0x10000`
 - Reset mask: `0x303fb`
 
@@ -1323,7 +1303,7 @@ Debug status register
 
 ## RECOV_ALERT_STS
 Recoverable alert status register
-- Offset: `0xd4`
+- Offset: `0xd0`
 - Reset default: `0x0`
 - Reset mask: `0x8007ffaf`
 
@@ -1449,7 +1429,7 @@ Writing a zero resets this status bit.
 
 ## ERR_CODE
 Hardware detection of error conditions status register
-- Offset: `0xd8`
+- Offset: `0xd4`
 - Reset default: `0x0`
 - Reset mask: `0x71f0000f`
 
@@ -1543,7 +1523,7 @@ This bit will stay set until the next reset.
 
 ## ERR_CODE_TEST
 Test error conditions register
-- Offset: `0xdc`
+- Offset: `0xd8`
 - Reset default: `0x0`
 - Reset mask: `0x1f`
 
@@ -1568,7 +1548,7 @@ an interrupt or an alert.
 
 ## MAIN_SM_STATE
 Main state machine state debug register
-- Offset: `0xe0`
+- Offset: `0xdc`
 - Reset default: `0xf5`
 - Reset mask: `0x1ff`
 

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
@@ -14,7 +14,7 @@ package entropy_src_reg_pkg;
   parameter int BlockAw = 8;
 
   // Number of registers for every interface
-  parameter int NumRegs = 57;
+  parameter int NumRegs = 56;
 
   ////////////////////////////
   // Typedefs for registers //
@@ -796,56 +796,55 @@ package entropy_src_reg_pkg;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_ME_REGWEN_OFFSET = 8'h 10;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_SW_REGUPD_OFFSET = 8'h 14;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_REGWEN_OFFSET = 8'h 18;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REV_OFFSET = 8'h 1c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_MODULE_ENABLE_OFFSET = 8'h 20;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_CONF_OFFSET = 8'h 24;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ENTROPY_CONTROL_OFFSET = 8'h 28;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ENTROPY_DATA_OFFSET = 8'h 2c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_HEALTH_TEST_WINDOWS_OFFSET = 8'h 30;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNT_THRESHOLDS_OFFSET = 8'h 34;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNTS_THRESHOLDS_OFFSET = 8'h 38;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_HI_THRESHOLDS_OFFSET = 8'h 3c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_LO_THRESHOLDS_OFFSET = 8'h 40;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_BUCKET_THRESHOLDS_OFFSET = 8'h 44;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_HI_THRESHOLDS_OFFSET = 8'h 48;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_LO_THRESHOLDS_OFFSET = 8'h 4c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_HI_THRESHOLDS_OFFSET = 8'h 50;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_LO_THRESHOLDS_OFFSET = 8'h 54;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNT_HI_WATERMARKS_OFFSET = 8'h 58;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNTS_HI_WATERMARKS_OFFSET = 8'h 5c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_HI_WATERMARKS_OFFSET = 8'h 60;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_LO_WATERMARKS_OFFSET = 8'h 64;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_HI_WATERMARKS_OFFSET = 8'h 68;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_LO_WATERMARKS_OFFSET = 8'h 6c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_BUCKET_HI_WATERMARKS_OFFSET = 8'h 70;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_HI_WATERMARKS_OFFSET = 8'h 74;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_LO_WATERMARKS_OFFSET = 8'h 78;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNT_TOTAL_FAILS_OFFSET = 8'h 7c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNTS_TOTAL_FAILS_OFFSET = 8'h 80;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_HI_TOTAL_FAILS_OFFSET = 8'h 84;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_LO_TOTAL_FAILS_OFFSET = 8'h 88;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_BUCKET_TOTAL_FAILS_OFFSET = 8'h 8c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_HI_TOTAL_FAILS_OFFSET = 8'h 90;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_LO_TOTAL_FAILS_OFFSET = 8'h 94;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_HI_TOTAL_FAILS_OFFSET = 8'h 98;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_LO_TOTAL_FAILS_OFFSET = 8'h 9c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ALERT_THRESHOLD_OFFSET = 8'h a0;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ALERT_SUMMARY_FAIL_COUNTS_OFFSET = 8'h a4;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ALERT_FAIL_COUNTS_OFFSET = 8'h a8;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_FAIL_COUNTS_OFFSET = 8'h ac;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_CONTROL_OFFSET = 8'h b0;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_SHA3_START_OFFSET = 8'h b4;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_WR_FIFO_FULL_OFFSET = 8'h b8;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_RD_FIFO_OVERFLOW_OFFSET = 8'h bc;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_RD_DATA_OFFSET = 8'h c0;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_WR_DATA_OFFSET = 8'h c4;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_OBSERVE_FIFO_THRESH_OFFSET = 8'h c8;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_OBSERVE_FIFO_DEPTH_OFFSET = 8'h cc;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_DEBUG_STATUS_OFFSET = 8'h d0;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_RECOV_ALERT_STS_OFFSET = 8'h d4;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ERR_CODE_OFFSET = 8'h d8;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ERR_CODE_TEST_OFFSET = 8'h dc;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_MAIN_SM_STATE_OFFSET = 8'h e0;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MODULE_ENABLE_OFFSET = 8'h 1c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_CONF_OFFSET = 8'h 20;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ENTROPY_CONTROL_OFFSET = 8'h 24;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ENTROPY_DATA_OFFSET = 8'h 28;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_HEALTH_TEST_WINDOWS_OFFSET = 8'h 2c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNT_THRESHOLDS_OFFSET = 8'h 30;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNTS_THRESHOLDS_OFFSET = 8'h 34;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_HI_THRESHOLDS_OFFSET = 8'h 38;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_LO_THRESHOLDS_OFFSET = 8'h 3c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_BUCKET_THRESHOLDS_OFFSET = 8'h 40;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_HI_THRESHOLDS_OFFSET = 8'h 44;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_LO_THRESHOLDS_OFFSET = 8'h 48;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_HI_THRESHOLDS_OFFSET = 8'h 4c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_LO_THRESHOLDS_OFFSET = 8'h 50;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNT_HI_WATERMARKS_OFFSET = 8'h 54;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNTS_HI_WATERMARKS_OFFSET = 8'h 58;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_HI_WATERMARKS_OFFSET = 8'h 5c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_LO_WATERMARKS_OFFSET = 8'h 60;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_HI_WATERMARKS_OFFSET = 8'h 64;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_LO_WATERMARKS_OFFSET = 8'h 68;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_BUCKET_HI_WATERMARKS_OFFSET = 8'h 6c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_HI_WATERMARKS_OFFSET = 8'h 70;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_LO_WATERMARKS_OFFSET = 8'h 74;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNT_TOTAL_FAILS_OFFSET = 8'h 78;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNTS_TOTAL_FAILS_OFFSET = 8'h 7c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_HI_TOTAL_FAILS_OFFSET = 8'h 80;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_LO_TOTAL_FAILS_OFFSET = 8'h 84;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_BUCKET_TOTAL_FAILS_OFFSET = 8'h 88;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_HI_TOTAL_FAILS_OFFSET = 8'h 8c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_LO_TOTAL_FAILS_OFFSET = 8'h 90;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_HI_TOTAL_FAILS_OFFSET = 8'h 94;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_LO_TOTAL_FAILS_OFFSET = 8'h 98;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ALERT_THRESHOLD_OFFSET = 8'h 9c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ALERT_SUMMARY_FAIL_COUNTS_OFFSET = 8'h a0;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ALERT_FAIL_COUNTS_OFFSET = 8'h a4;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_FAIL_COUNTS_OFFSET = 8'h a8;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_CONTROL_OFFSET = 8'h ac;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_SHA3_START_OFFSET = 8'h b0;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_WR_FIFO_FULL_OFFSET = 8'h b4;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_RD_FIFO_OVERFLOW_OFFSET = 8'h b8;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_RD_DATA_OFFSET = 8'h bc;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_WR_DATA_OFFSET = 8'h c0;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_OBSERVE_FIFO_THRESH_OFFSET = 8'h c4;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_OBSERVE_FIFO_DEPTH_OFFSET = 8'h c8;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_DEBUG_STATUS_OFFSET = 8'h cc;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_RECOV_ALERT_STS_OFFSET = 8'h d0;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ERR_CODE_OFFSET = 8'h d4;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ERR_CODE_TEST_OFFSET = 8'h d8;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MAIN_SM_STATE_OFFSET = 8'h dc;
 
   // Reset values for hwext registers and their fields
   parameter logic [3:0] ENTROPY_SRC_INTR_TEST_RESVAL = 4'h 0;
@@ -927,7 +926,6 @@ package entropy_src_reg_pkg;
     ENTROPY_SRC_ME_REGWEN,
     ENTROPY_SRC_SW_REGUPD,
     ENTROPY_SRC_REGWEN,
-    ENTROPY_SRC_REV,
     ENTROPY_SRC_MODULE_ENABLE,
     ENTROPY_SRC_CONF,
     ENTROPY_SRC_ENTROPY_CONTROL,
@@ -980,7 +978,7 @@ package entropy_src_reg_pkg;
   } entropy_src_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] ENTROPY_SRC_PERMIT [57] = '{
+  parameter logic [3:0] ENTROPY_SRC_PERMIT [56] = '{
     4'b 0001, // index[ 0] ENTROPY_SRC_INTR_STATE
     4'b 0001, // index[ 1] ENTROPY_SRC_INTR_ENABLE
     4'b 0001, // index[ 2] ENTROPY_SRC_INTR_TEST
@@ -988,56 +986,55 @@ package entropy_src_reg_pkg;
     4'b 0001, // index[ 4] ENTROPY_SRC_ME_REGWEN
     4'b 0001, // index[ 5] ENTROPY_SRC_SW_REGUPD
     4'b 0001, // index[ 6] ENTROPY_SRC_REGWEN
-    4'b 0111, // index[ 7] ENTROPY_SRC_REV
-    4'b 0001, // index[ 8] ENTROPY_SRC_MODULE_ENABLE
-    4'b 1111, // index[ 9] ENTROPY_SRC_CONF
-    4'b 0001, // index[10] ENTROPY_SRC_ENTROPY_CONTROL
-    4'b 1111, // index[11] ENTROPY_SRC_ENTROPY_DATA
-    4'b 1111, // index[12] ENTROPY_SRC_HEALTH_TEST_WINDOWS
-    4'b 1111, // index[13] ENTROPY_SRC_REPCNT_THRESHOLDS
-    4'b 1111, // index[14] ENTROPY_SRC_REPCNTS_THRESHOLDS
-    4'b 1111, // index[15] ENTROPY_SRC_ADAPTP_HI_THRESHOLDS
-    4'b 1111, // index[16] ENTROPY_SRC_ADAPTP_LO_THRESHOLDS
-    4'b 1111, // index[17] ENTROPY_SRC_BUCKET_THRESHOLDS
-    4'b 1111, // index[18] ENTROPY_SRC_MARKOV_HI_THRESHOLDS
-    4'b 1111, // index[19] ENTROPY_SRC_MARKOV_LO_THRESHOLDS
-    4'b 1111, // index[20] ENTROPY_SRC_EXTHT_HI_THRESHOLDS
-    4'b 1111, // index[21] ENTROPY_SRC_EXTHT_LO_THRESHOLDS
-    4'b 1111, // index[22] ENTROPY_SRC_REPCNT_HI_WATERMARKS
-    4'b 1111, // index[23] ENTROPY_SRC_REPCNTS_HI_WATERMARKS
-    4'b 1111, // index[24] ENTROPY_SRC_ADAPTP_HI_WATERMARKS
-    4'b 1111, // index[25] ENTROPY_SRC_ADAPTP_LO_WATERMARKS
-    4'b 1111, // index[26] ENTROPY_SRC_EXTHT_HI_WATERMARKS
-    4'b 1111, // index[27] ENTROPY_SRC_EXTHT_LO_WATERMARKS
-    4'b 1111, // index[28] ENTROPY_SRC_BUCKET_HI_WATERMARKS
-    4'b 1111, // index[29] ENTROPY_SRC_MARKOV_HI_WATERMARKS
-    4'b 1111, // index[30] ENTROPY_SRC_MARKOV_LO_WATERMARKS
-    4'b 1111, // index[31] ENTROPY_SRC_REPCNT_TOTAL_FAILS
-    4'b 1111, // index[32] ENTROPY_SRC_REPCNTS_TOTAL_FAILS
-    4'b 1111, // index[33] ENTROPY_SRC_ADAPTP_HI_TOTAL_FAILS
-    4'b 1111, // index[34] ENTROPY_SRC_ADAPTP_LO_TOTAL_FAILS
-    4'b 1111, // index[35] ENTROPY_SRC_BUCKET_TOTAL_FAILS
-    4'b 1111, // index[36] ENTROPY_SRC_MARKOV_HI_TOTAL_FAILS
-    4'b 1111, // index[37] ENTROPY_SRC_MARKOV_LO_TOTAL_FAILS
-    4'b 1111, // index[38] ENTROPY_SRC_EXTHT_HI_TOTAL_FAILS
-    4'b 1111, // index[39] ENTROPY_SRC_EXTHT_LO_TOTAL_FAILS
-    4'b 1111, // index[40] ENTROPY_SRC_ALERT_THRESHOLD
-    4'b 0011, // index[41] ENTROPY_SRC_ALERT_SUMMARY_FAIL_COUNTS
-    4'b 1111, // index[42] ENTROPY_SRC_ALERT_FAIL_COUNTS
-    4'b 0001, // index[43] ENTROPY_SRC_EXTHT_FAIL_COUNTS
-    4'b 0001, // index[44] ENTROPY_SRC_FW_OV_CONTROL
-    4'b 0001, // index[45] ENTROPY_SRC_FW_OV_SHA3_START
-    4'b 0001, // index[46] ENTROPY_SRC_FW_OV_WR_FIFO_FULL
-    4'b 0001, // index[47] ENTROPY_SRC_FW_OV_RD_FIFO_OVERFLOW
-    4'b 1111, // index[48] ENTROPY_SRC_FW_OV_RD_DATA
-    4'b 1111, // index[49] ENTROPY_SRC_FW_OV_WR_DATA
-    4'b 0001, // index[50] ENTROPY_SRC_OBSERVE_FIFO_THRESH
-    4'b 0001, // index[51] ENTROPY_SRC_OBSERVE_FIFO_DEPTH
-    4'b 0111, // index[52] ENTROPY_SRC_DEBUG_STATUS
-    4'b 1111, // index[53] ENTROPY_SRC_RECOV_ALERT_STS
-    4'b 1111, // index[54] ENTROPY_SRC_ERR_CODE
-    4'b 0001, // index[55] ENTROPY_SRC_ERR_CODE_TEST
-    4'b 0011  // index[56] ENTROPY_SRC_MAIN_SM_STATE
+    4'b 0001, // index[ 7] ENTROPY_SRC_MODULE_ENABLE
+    4'b 1111, // index[ 8] ENTROPY_SRC_CONF
+    4'b 0001, // index[ 9] ENTROPY_SRC_ENTROPY_CONTROL
+    4'b 1111, // index[10] ENTROPY_SRC_ENTROPY_DATA
+    4'b 1111, // index[11] ENTROPY_SRC_HEALTH_TEST_WINDOWS
+    4'b 1111, // index[12] ENTROPY_SRC_REPCNT_THRESHOLDS
+    4'b 1111, // index[13] ENTROPY_SRC_REPCNTS_THRESHOLDS
+    4'b 1111, // index[14] ENTROPY_SRC_ADAPTP_HI_THRESHOLDS
+    4'b 1111, // index[15] ENTROPY_SRC_ADAPTP_LO_THRESHOLDS
+    4'b 1111, // index[16] ENTROPY_SRC_BUCKET_THRESHOLDS
+    4'b 1111, // index[17] ENTROPY_SRC_MARKOV_HI_THRESHOLDS
+    4'b 1111, // index[18] ENTROPY_SRC_MARKOV_LO_THRESHOLDS
+    4'b 1111, // index[19] ENTROPY_SRC_EXTHT_HI_THRESHOLDS
+    4'b 1111, // index[20] ENTROPY_SRC_EXTHT_LO_THRESHOLDS
+    4'b 1111, // index[21] ENTROPY_SRC_REPCNT_HI_WATERMARKS
+    4'b 1111, // index[22] ENTROPY_SRC_REPCNTS_HI_WATERMARKS
+    4'b 1111, // index[23] ENTROPY_SRC_ADAPTP_HI_WATERMARKS
+    4'b 1111, // index[24] ENTROPY_SRC_ADAPTP_LO_WATERMARKS
+    4'b 1111, // index[25] ENTROPY_SRC_EXTHT_HI_WATERMARKS
+    4'b 1111, // index[26] ENTROPY_SRC_EXTHT_LO_WATERMARKS
+    4'b 1111, // index[27] ENTROPY_SRC_BUCKET_HI_WATERMARKS
+    4'b 1111, // index[28] ENTROPY_SRC_MARKOV_HI_WATERMARKS
+    4'b 1111, // index[29] ENTROPY_SRC_MARKOV_LO_WATERMARKS
+    4'b 1111, // index[30] ENTROPY_SRC_REPCNT_TOTAL_FAILS
+    4'b 1111, // index[31] ENTROPY_SRC_REPCNTS_TOTAL_FAILS
+    4'b 1111, // index[32] ENTROPY_SRC_ADAPTP_HI_TOTAL_FAILS
+    4'b 1111, // index[33] ENTROPY_SRC_ADAPTP_LO_TOTAL_FAILS
+    4'b 1111, // index[34] ENTROPY_SRC_BUCKET_TOTAL_FAILS
+    4'b 1111, // index[35] ENTROPY_SRC_MARKOV_HI_TOTAL_FAILS
+    4'b 1111, // index[36] ENTROPY_SRC_MARKOV_LO_TOTAL_FAILS
+    4'b 1111, // index[37] ENTROPY_SRC_EXTHT_HI_TOTAL_FAILS
+    4'b 1111, // index[38] ENTROPY_SRC_EXTHT_LO_TOTAL_FAILS
+    4'b 1111, // index[39] ENTROPY_SRC_ALERT_THRESHOLD
+    4'b 0011, // index[40] ENTROPY_SRC_ALERT_SUMMARY_FAIL_COUNTS
+    4'b 1111, // index[41] ENTROPY_SRC_ALERT_FAIL_COUNTS
+    4'b 0001, // index[42] ENTROPY_SRC_EXTHT_FAIL_COUNTS
+    4'b 0001, // index[43] ENTROPY_SRC_FW_OV_CONTROL
+    4'b 0001, // index[44] ENTROPY_SRC_FW_OV_SHA3_START
+    4'b 0001, // index[45] ENTROPY_SRC_FW_OV_WR_FIFO_FULL
+    4'b 0001, // index[46] ENTROPY_SRC_FW_OV_RD_FIFO_OVERFLOW
+    4'b 1111, // index[47] ENTROPY_SRC_FW_OV_RD_DATA
+    4'b 1111, // index[48] ENTROPY_SRC_FW_OV_WR_DATA
+    4'b 0001, // index[49] ENTROPY_SRC_OBSERVE_FIFO_THRESH
+    4'b 0001, // index[50] ENTROPY_SRC_OBSERVE_FIFO_DEPTH
+    4'b 0111, // index[51] ENTROPY_SRC_DEBUG_STATUS
+    4'b 1111, // index[52] ENTROPY_SRC_RECOV_ALERT_STS
+    4'b 1111, // index[53] ENTROPY_SRC_ERR_CODE
+    4'b 0001, // index[54] ENTROPY_SRC_ERR_CODE_TEST
+    4'b 0011  // index[55] ENTROPY_SRC_MAIN_SM_STATE
   };
 
 endpackage

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -52,9 +52,9 @@ module entropy_src_reg_top (
 
   // also check for spurious write enables
   logic reg_we_err;
-  logic [56:0] reg_we_check;
+  logic [55:0] reg_we_check;
   prim_reg_we_check #(
-    .OneHotWidth(57)
+    .OneHotWidth(56)
   ) u_prim_reg_we_check (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
@@ -154,9 +154,6 @@ module entropy_src_reg_top (
   logic sw_regupd_qs;
   logic sw_regupd_wd;
   logic regwen_qs;
-  logic [7:0] rev_abi_revision_qs;
-  logic [7:0] rev_hw_revision_qs;
-  logic [7:0] rev_chip_type_qs;
   logic module_enable_we;
   logic [3:0] module_enable_qs;
   logic [3:0] module_enable_wd;
@@ -796,20 +793,6 @@ module entropy_src_reg_top (
     // to register interface (read)
     .qs     (regwen_qs)
   );
-
-
-  // R[rev]: V(False)
-  //   F[abi_revision]: 7:0
-  // constant-only read
-  assign rev_abi_revision_qs = 8'h3;
-
-  //   F[hw_revision]: 15:8
-  // constant-only read
-  assign rev_hw_revision_qs = 8'h3;
-
-  //   F[chip_type]: 23:16
-  // constant-only read
-  assign rev_chip_type_qs = 8'h1;
 
 
   // R[module_enable]: V(False)
@@ -3396,7 +3379,7 @@ module entropy_src_reg_top (
 
 
 
-  logic [56:0] addr_hit;
+  logic [55:0] addr_hit;
   always_comb begin
     addr_hit[ 0] = (reg_addr == ENTROPY_SRC_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == ENTROPY_SRC_INTR_ENABLE_OFFSET);
@@ -3405,56 +3388,55 @@ module entropy_src_reg_top (
     addr_hit[ 4] = (reg_addr == ENTROPY_SRC_ME_REGWEN_OFFSET);
     addr_hit[ 5] = (reg_addr == ENTROPY_SRC_SW_REGUPD_OFFSET);
     addr_hit[ 6] = (reg_addr == ENTROPY_SRC_REGWEN_OFFSET);
-    addr_hit[ 7] = (reg_addr == ENTROPY_SRC_REV_OFFSET);
-    addr_hit[ 8] = (reg_addr == ENTROPY_SRC_MODULE_ENABLE_OFFSET);
-    addr_hit[ 9] = (reg_addr == ENTROPY_SRC_CONF_OFFSET);
-    addr_hit[10] = (reg_addr == ENTROPY_SRC_ENTROPY_CONTROL_OFFSET);
-    addr_hit[11] = (reg_addr == ENTROPY_SRC_ENTROPY_DATA_OFFSET);
-    addr_hit[12] = (reg_addr == ENTROPY_SRC_HEALTH_TEST_WINDOWS_OFFSET);
-    addr_hit[13] = (reg_addr == ENTROPY_SRC_REPCNT_THRESHOLDS_OFFSET);
-    addr_hit[14] = (reg_addr == ENTROPY_SRC_REPCNTS_THRESHOLDS_OFFSET);
-    addr_hit[15] = (reg_addr == ENTROPY_SRC_ADAPTP_HI_THRESHOLDS_OFFSET);
-    addr_hit[16] = (reg_addr == ENTROPY_SRC_ADAPTP_LO_THRESHOLDS_OFFSET);
-    addr_hit[17] = (reg_addr == ENTROPY_SRC_BUCKET_THRESHOLDS_OFFSET);
-    addr_hit[18] = (reg_addr == ENTROPY_SRC_MARKOV_HI_THRESHOLDS_OFFSET);
-    addr_hit[19] = (reg_addr == ENTROPY_SRC_MARKOV_LO_THRESHOLDS_OFFSET);
-    addr_hit[20] = (reg_addr == ENTROPY_SRC_EXTHT_HI_THRESHOLDS_OFFSET);
-    addr_hit[21] = (reg_addr == ENTROPY_SRC_EXTHT_LO_THRESHOLDS_OFFSET);
-    addr_hit[22] = (reg_addr == ENTROPY_SRC_REPCNT_HI_WATERMARKS_OFFSET);
-    addr_hit[23] = (reg_addr == ENTROPY_SRC_REPCNTS_HI_WATERMARKS_OFFSET);
-    addr_hit[24] = (reg_addr == ENTROPY_SRC_ADAPTP_HI_WATERMARKS_OFFSET);
-    addr_hit[25] = (reg_addr == ENTROPY_SRC_ADAPTP_LO_WATERMARKS_OFFSET);
-    addr_hit[26] = (reg_addr == ENTROPY_SRC_EXTHT_HI_WATERMARKS_OFFSET);
-    addr_hit[27] = (reg_addr == ENTROPY_SRC_EXTHT_LO_WATERMARKS_OFFSET);
-    addr_hit[28] = (reg_addr == ENTROPY_SRC_BUCKET_HI_WATERMARKS_OFFSET);
-    addr_hit[29] = (reg_addr == ENTROPY_SRC_MARKOV_HI_WATERMARKS_OFFSET);
-    addr_hit[30] = (reg_addr == ENTROPY_SRC_MARKOV_LO_WATERMARKS_OFFSET);
-    addr_hit[31] = (reg_addr == ENTROPY_SRC_REPCNT_TOTAL_FAILS_OFFSET);
-    addr_hit[32] = (reg_addr == ENTROPY_SRC_REPCNTS_TOTAL_FAILS_OFFSET);
-    addr_hit[33] = (reg_addr == ENTROPY_SRC_ADAPTP_HI_TOTAL_FAILS_OFFSET);
-    addr_hit[34] = (reg_addr == ENTROPY_SRC_ADAPTP_LO_TOTAL_FAILS_OFFSET);
-    addr_hit[35] = (reg_addr == ENTROPY_SRC_BUCKET_TOTAL_FAILS_OFFSET);
-    addr_hit[36] = (reg_addr == ENTROPY_SRC_MARKOV_HI_TOTAL_FAILS_OFFSET);
-    addr_hit[37] = (reg_addr == ENTROPY_SRC_MARKOV_LO_TOTAL_FAILS_OFFSET);
-    addr_hit[38] = (reg_addr == ENTROPY_SRC_EXTHT_HI_TOTAL_FAILS_OFFSET);
-    addr_hit[39] = (reg_addr == ENTROPY_SRC_EXTHT_LO_TOTAL_FAILS_OFFSET);
-    addr_hit[40] = (reg_addr == ENTROPY_SRC_ALERT_THRESHOLD_OFFSET);
-    addr_hit[41] = (reg_addr == ENTROPY_SRC_ALERT_SUMMARY_FAIL_COUNTS_OFFSET);
-    addr_hit[42] = (reg_addr == ENTROPY_SRC_ALERT_FAIL_COUNTS_OFFSET);
-    addr_hit[43] = (reg_addr == ENTROPY_SRC_EXTHT_FAIL_COUNTS_OFFSET);
-    addr_hit[44] = (reg_addr == ENTROPY_SRC_FW_OV_CONTROL_OFFSET);
-    addr_hit[45] = (reg_addr == ENTROPY_SRC_FW_OV_SHA3_START_OFFSET);
-    addr_hit[46] = (reg_addr == ENTROPY_SRC_FW_OV_WR_FIFO_FULL_OFFSET);
-    addr_hit[47] = (reg_addr == ENTROPY_SRC_FW_OV_RD_FIFO_OVERFLOW_OFFSET);
-    addr_hit[48] = (reg_addr == ENTROPY_SRC_FW_OV_RD_DATA_OFFSET);
-    addr_hit[49] = (reg_addr == ENTROPY_SRC_FW_OV_WR_DATA_OFFSET);
-    addr_hit[50] = (reg_addr == ENTROPY_SRC_OBSERVE_FIFO_THRESH_OFFSET);
-    addr_hit[51] = (reg_addr == ENTROPY_SRC_OBSERVE_FIFO_DEPTH_OFFSET);
-    addr_hit[52] = (reg_addr == ENTROPY_SRC_DEBUG_STATUS_OFFSET);
-    addr_hit[53] = (reg_addr == ENTROPY_SRC_RECOV_ALERT_STS_OFFSET);
-    addr_hit[54] = (reg_addr == ENTROPY_SRC_ERR_CODE_OFFSET);
-    addr_hit[55] = (reg_addr == ENTROPY_SRC_ERR_CODE_TEST_OFFSET);
-    addr_hit[56] = (reg_addr == ENTROPY_SRC_MAIN_SM_STATE_OFFSET);
+    addr_hit[ 7] = (reg_addr == ENTROPY_SRC_MODULE_ENABLE_OFFSET);
+    addr_hit[ 8] = (reg_addr == ENTROPY_SRC_CONF_OFFSET);
+    addr_hit[ 9] = (reg_addr == ENTROPY_SRC_ENTROPY_CONTROL_OFFSET);
+    addr_hit[10] = (reg_addr == ENTROPY_SRC_ENTROPY_DATA_OFFSET);
+    addr_hit[11] = (reg_addr == ENTROPY_SRC_HEALTH_TEST_WINDOWS_OFFSET);
+    addr_hit[12] = (reg_addr == ENTROPY_SRC_REPCNT_THRESHOLDS_OFFSET);
+    addr_hit[13] = (reg_addr == ENTROPY_SRC_REPCNTS_THRESHOLDS_OFFSET);
+    addr_hit[14] = (reg_addr == ENTROPY_SRC_ADAPTP_HI_THRESHOLDS_OFFSET);
+    addr_hit[15] = (reg_addr == ENTROPY_SRC_ADAPTP_LO_THRESHOLDS_OFFSET);
+    addr_hit[16] = (reg_addr == ENTROPY_SRC_BUCKET_THRESHOLDS_OFFSET);
+    addr_hit[17] = (reg_addr == ENTROPY_SRC_MARKOV_HI_THRESHOLDS_OFFSET);
+    addr_hit[18] = (reg_addr == ENTROPY_SRC_MARKOV_LO_THRESHOLDS_OFFSET);
+    addr_hit[19] = (reg_addr == ENTROPY_SRC_EXTHT_HI_THRESHOLDS_OFFSET);
+    addr_hit[20] = (reg_addr == ENTROPY_SRC_EXTHT_LO_THRESHOLDS_OFFSET);
+    addr_hit[21] = (reg_addr == ENTROPY_SRC_REPCNT_HI_WATERMARKS_OFFSET);
+    addr_hit[22] = (reg_addr == ENTROPY_SRC_REPCNTS_HI_WATERMARKS_OFFSET);
+    addr_hit[23] = (reg_addr == ENTROPY_SRC_ADAPTP_HI_WATERMARKS_OFFSET);
+    addr_hit[24] = (reg_addr == ENTROPY_SRC_ADAPTP_LO_WATERMARKS_OFFSET);
+    addr_hit[25] = (reg_addr == ENTROPY_SRC_EXTHT_HI_WATERMARKS_OFFSET);
+    addr_hit[26] = (reg_addr == ENTROPY_SRC_EXTHT_LO_WATERMARKS_OFFSET);
+    addr_hit[27] = (reg_addr == ENTROPY_SRC_BUCKET_HI_WATERMARKS_OFFSET);
+    addr_hit[28] = (reg_addr == ENTROPY_SRC_MARKOV_HI_WATERMARKS_OFFSET);
+    addr_hit[29] = (reg_addr == ENTROPY_SRC_MARKOV_LO_WATERMARKS_OFFSET);
+    addr_hit[30] = (reg_addr == ENTROPY_SRC_REPCNT_TOTAL_FAILS_OFFSET);
+    addr_hit[31] = (reg_addr == ENTROPY_SRC_REPCNTS_TOTAL_FAILS_OFFSET);
+    addr_hit[32] = (reg_addr == ENTROPY_SRC_ADAPTP_HI_TOTAL_FAILS_OFFSET);
+    addr_hit[33] = (reg_addr == ENTROPY_SRC_ADAPTP_LO_TOTAL_FAILS_OFFSET);
+    addr_hit[34] = (reg_addr == ENTROPY_SRC_BUCKET_TOTAL_FAILS_OFFSET);
+    addr_hit[35] = (reg_addr == ENTROPY_SRC_MARKOV_HI_TOTAL_FAILS_OFFSET);
+    addr_hit[36] = (reg_addr == ENTROPY_SRC_MARKOV_LO_TOTAL_FAILS_OFFSET);
+    addr_hit[37] = (reg_addr == ENTROPY_SRC_EXTHT_HI_TOTAL_FAILS_OFFSET);
+    addr_hit[38] = (reg_addr == ENTROPY_SRC_EXTHT_LO_TOTAL_FAILS_OFFSET);
+    addr_hit[39] = (reg_addr == ENTROPY_SRC_ALERT_THRESHOLD_OFFSET);
+    addr_hit[40] = (reg_addr == ENTROPY_SRC_ALERT_SUMMARY_FAIL_COUNTS_OFFSET);
+    addr_hit[41] = (reg_addr == ENTROPY_SRC_ALERT_FAIL_COUNTS_OFFSET);
+    addr_hit[42] = (reg_addr == ENTROPY_SRC_EXTHT_FAIL_COUNTS_OFFSET);
+    addr_hit[43] = (reg_addr == ENTROPY_SRC_FW_OV_CONTROL_OFFSET);
+    addr_hit[44] = (reg_addr == ENTROPY_SRC_FW_OV_SHA3_START_OFFSET);
+    addr_hit[45] = (reg_addr == ENTROPY_SRC_FW_OV_WR_FIFO_FULL_OFFSET);
+    addr_hit[46] = (reg_addr == ENTROPY_SRC_FW_OV_RD_FIFO_OVERFLOW_OFFSET);
+    addr_hit[47] = (reg_addr == ENTROPY_SRC_FW_OV_RD_DATA_OFFSET);
+    addr_hit[48] = (reg_addr == ENTROPY_SRC_FW_OV_WR_DATA_OFFSET);
+    addr_hit[49] = (reg_addr == ENTROPY_SRC_OBSERVE_FIFO_THRESH_OFFSET);
+    addr_hit[50] = (reg_addr == ENTROPY_SRC_OBSERVE_FIFO_DEPTH_OFFSET);
+    addr_hit[51] = (reg_addr == ENTROPY_SRC_DEBUG_STATUS_OFFSET);
+    addr_hit[52] = (reg_addr == ENTROPY_SRC_RECOV_ALERT_STS_OFFSET);
+    addr_hit[53] = (reg_addr == ENTROPY_SRC_ERR_CODE_OFFSET);
+    addr_hit[54] = (reg_addr == ENTROPY_SRC_ERR_CODE_TEST_OFFSET);
+    addr_hit[55] = (reg_addr == ENTROPY_SRC_MAIN_SM_STATE_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -3517,8 +3499,7 @@ module entropy_src_reg_top (
                (addr_hit[52] & (|(ENTROPY_SRC_PERMIT[52] & ~reg_be))) |
                (addr_hit[53] & (|(ENTROPY_SRC_PERMIT[53] & ~reg_be))) |
                (addr_hit[54] & (|(ENTROPY_SRC_PERMIT[54] & ~reg_be))) |
-               (addr_hit[55] & (|(ENTROPY_SRC_PERMIT[55] & ~reg_be))) |
-               (addr_hit[56] & (|(ENTROPY_SRC_PERMIT[56] & ~reg_be)))));
+               (addr_hit[55] & (|(ENTROPY_SRC_PERMIT[55] & ~reg_be)))));
   end
 
   // Generate write-enables
@@ -3560,10 +3541,10 @@ module entropy_src_reg_top (
   assign sw_regupd_we = addr_hit[5] & reg_we & !reg_error;
 
   assign sw_regupd_wd = reg_wdata[0];
-  assign module_enable_we = addr_hit[8] & reg_we & !reg_error;
+  assign module_enable_we = addr_hit[7] & reg_we & !reg_error;
 
   assign module_enable_wd = reg_wdata[3:0];
-  assign conf_we = addr_hit[9] & reg_we & !reg_error;
+  assign conf_we = addr_hit[8] & reg_we & !reg_error;
 
   assign conf_fips_enable_wd = reg_wdata[3:0];
 
@@ -3578,116 +3559,116 @@ module entropy_src_reg_top (
   assign conf_entropy_data_reg_enable_wd = reg_wdata[23:20];
 
   assign conf_rng_bit_sel_wd = reg_wdata[31:24];
-  assign entropy_control_we = addr_hit[10] & reg_we & !reg_error;
+  assign entropy_control_we = addr_hit[9] & reg_we & !reg_error;
 
   assign entropy_control_es_route_wd = reg_wdata[3:0];
 
   assign entropy_control_es_type_wd = reg_wdata[7:4];
-  assign entropy_data_re = addr_hit[11] & reg_re & !reg_error;
-  assign health_test_windows_we = addr_hit[12] & reg_we & !reg_error;
+  assign entropy_data_re = addr_hit[10] & reg_re & !reg_error;
+  assign health_test_windows_we = addr_hit[11] & reg_we & !reg_error;
 
   assign health_test_windows_fips_window_wd = reg_wdata[15:0];
 
   assign health_test_windows_bypass_window_wd = reg_wdata[31:16];
-  assign repcnt_thresholds_re = addr_hit[13] & reg_re & !reg_error;
-  assign repcnt_thresholds_we = addr_hit[13] & reg_we & !reg_error;
+  assign repcnt_thresholds_re = addr_hit[12] & reg_re & !reg_error;
+  assign repcnt_thresholds_we = addr_hit[12] & reg_we & !reg_error;
 
   assign repcnt_thresholds_fips_thresh_wd = reg_wdata[15:0];
 
   assign repcnt_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign repcnts_thresholds_re = addr_hit[14] & reg_re & !reg_error;
-  assign repcnts_thresholds_we = addr_hit[14] & reg_we & !reg_error;
+  assign repcnts_thresholds_re = addr_hit[13] & reg_re & !reg_error;
+  assign repcnts_thresholds_we = addr_hit[13] & reg_we & !reg_error;
 
   assign repcnts_thresholds_fips_thresh_wd = reg_wdata[15:0];
 
   assign repcnts_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign adaptp_hi_thresholds_re = addr_hit[15] & reg_re & !reg_error;
-  assign adaptp_hi_thresholds_we = addr_hit[15] & reg_we & !reg_error;
+  assign adaptp_hi_thresholds_re = addr_hit[14] & reg_re & !reg_error;
+  assign adaptp_hi_thresholds_we = addr_hit[14] & reg_we & !reg_error;
 
   assign adaptp_hi_thresholds_fips_thresh_wd = reg_wdata[15:0];
 
   assign adaptp_hi_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign adaptp_lo_thresholds_re = addr_hit[16] & reg_re & !reg_error;
-  assign adaptp_lo_thresholds_we = addr_hit[16] & reg_we & !reg_error;
+  assign adaptp_lo_thresholds_re = addr_hit[15] & reg_re & !reg_error;
+  assign adaptp_lo_thresholds_we = addr_hit[15] & reg_we & !reg_error;
 
   assign adaptp_lo_thresholds_fips_thresh_wd = reg_wdata[15:0];
 
   assign adaptp_lo_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign bucket_thresholds_re = addr_hit[17] & reg_re & !reg_error;
-  assign bucket_thresholds_we = addr_hit[17] & reg_we & !reg_error;
+  assign bucket_thresholds_re = addr_hit[16] & reg_re & !reg_error;
+  assign bucket_thresholds_we = addr_hit[16] & reg_we & !reg_error;
 
   assign bucket_thresholds_fips_thresh_wd = reg_wdata[15:0];
 
   assign bucket_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign markov_hi_thresholds_re = addr_hit[18] & reg_re & !reg_error;
-  assign markov_hi_thresholds_we = addr_hit[18] & reg_we & !reg_error;
+  assign markov_hi_thresholds_re = addr_hit[17] & reg_re & !reg_error;
+  assign markov_hi_thresholds_we = addr_hit[17] & reg_we & !reg_error;
 
   assign markov_hi_thresholds_fips_thresh_wd = reg_wdata[15:0];
 
   assign markov_hi_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign markov_lo_thresholds_re = addr_hit[19] & reg_re & !reg_error;
-  assign markov_lo_thresholds_we = addr_hit[19] & reg_we & !reg_error;
+  assign markov_lo_thresholds_re = addr_hit[18] & reg_re & !reg_error;
+  assign markov_lo_thresholds_we = addr_hit[18] & reg_we & !reg_error;
 
   assign markov_lo_thresholds_fips_thresh_wd = reg_wdata[15:0];
 
   assign markov_lo_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign extht_hi_thresholds_re = addr_hit[20] & reg_re & !reg_error;
-  assign extht_hi_thresholds_we = addr_hit[20] & reg_we & !reg_error;
+  assign extht_hi_thresholds_re = addr_hit[19] & reg_re & !reg_error;
+  assign extht_hi_thresholds_we = addr_hit[19] & reg_we & !reg_error;
 
   assign extht_hi_thresholds_fips_thresh_wd = reg_wdata[15:0];
 
   assign extht_hi_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign extht_lo_thresholds_re = addr_hit[21] & reg_re & !reg_error;
-  assign extht_lo_thresholds_we = addr_hit[21] & reg_we & !reg_error;
+  assign extht_lo_thresholds_re = addr_hit[20] & reg_re & !reg_error;
+  assign extht_lo_thresholds_we = addr_hit[20] & reg_we & !reg_error;
 
   assign extht_lo_thresholds_fips_thresh_wd = reg_wdata[15:0];
 
   assign extht_lo_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign repcnt_hi_watermarks_re = addr_hit[22] & reg_re & !reg_error;
-  assign repcnts_hi_watermarks_re = addr_hit[23] & reg_re & !reg_error;
-  assign adaptp_hi_watermarks_re = addr_hit[24] & reg_re & !reg_error;
-  assign adaptp_lo_watermarks_re = addr_hit[25] & reg_re & !reg_error;
-  assign extht_hi_watermarks_re = addr_hit[26] & reg_re & !reg_error;
-  assign extht_lo_watermarks_re = addr_hit[27] & reg_re & !reg_error;
-  assign bucket_hi_watermarks_re = addr_hit[28] & reg_re & !reg_error;
-  assign markov_hi_watermarks_re = addr_hit[29] & reg_re & !reg_error;
-  assign markov_lo_watermarks_re = addr_hit[30] & reg_re & !reg_error;
-  assign repcnt_total_fails_re = addr_hit[31] & reg_re & !reg_error;
-  assign repcnts_total_fails_re = addr_hit[32] & reg_re & !reg_error;
-  assign adaptp_hi_total_fails_re = addr_hit[33] & reg_re & !reg_error;
-  assign adaptp_lo_total_fails_re = addr_hit[34] & reg_re & !reg_error;
-  assign bucket_total_fails_re = addr_hit[35] & reg_re & !reg_error;
-  assign markov_hi_total_fails_re = addr_hit[36] & reg_re & !reg_error;
-  assign markov_lo_total_fails_re = addr_hit[37] & reg_re & !reg_error;
-  assign extht_hi_total_fails_re = addr_hit[38] & reg_re & !reg_error;
-  assign extht_lo_total_fails_re = addr_hit[39] & reg_re & !reg_error;
-  assign alert_threshold_we = addr_hit[40] & reg_we & !reg_error;
+  assign repcnt_hi_watermarks_re = addr_hit[21] & reg_re & !reg_error;
+  assign repcnts_hi_watermarks_re = addr_hit[22] & reg_re & !reg_error;
+  assign adaptp_hi_watermarks_re = addr_hit[23] & reg_re & !reg_error;
+  assign adaptp_lo_watermarks_re = addr_hit[24] & reg_re & !reg_error;
+  assign extht_hi_watermarks_re = addr_hit[25] & reg_re & !reg_error;
+  assign extht_lo_watermarks_re = addr_hit[26] & reg_re & !reg_error;
+  assign bucket_hi_watermarks_re = addr_hit[27] & reg_re & !reg_error;
+  assign markov_hi_watermarks_re = addr_hit[28] & reg_re & !reg_error;
+  assign markov_lo_watermarks_re = addr_hit[29] & reg_re & !reg_error;
+  assign repcnt_total_fails_re = addr_hit[30] & reg_re & !reg_error;
+  assign repcnts_total_fails_re = addr_hit[31] & reg_re & !reg_error;
+  assign adaptp_hi_total_fails_re = addr_hit[32] & reg_re & !reg_error;
+  assign adaptp_lo_total_fails_re = addr_hit[33] & reg_re & !reg_error;
+  assign bucket_total_fails_re = addr_hit[34] & reg_re & !reg_error;
+  assign markov_hi_total_fails_re = addr_hit[35] & reg_re & !reg_error;
+  assign markov_lo_total_fails_re = addr_hit[36] & reg_re & !reg_error;
+  assign extht_hi_total_fails_re = addr_hit[37] & reg_re & !reg_error;
+  assign extht_lo_total_fails_re = addr_hit[38] & reg_re & !reg_error;
+  assign alert_threshold_we = addr_hit[39] & reg_we & !reg_error;
 
   assign alert_threshold_alert_threshold_wd = reg_wdata[15:0];
 
   assign alert_threshold_alert_threshold_inv_wd = reg_wdata[31:16];
-  assign alert_summary_fail_counts_re = addr_hit[41] & reg_re & !reg_error;
-  assign alert_fail_counts_re = addr_hit[42] & reg_re & !reg_error;
-  assign extht_fail_counts_re = addr_hit[43] & reg_re & !reg_error;
-  assign fw_ov_control_we = addr_hit[44] & reg_we & !reg_error;
+  assign alert_summary_fail_counts_re = addr_hit[40] & reg_re & !reg_error;
+  assign alert_fail_counts_re = addr_hit[41] & reg_re & !reg_error;
+  assign extht_fail_counts_re = addr_hit[42] & reg_re & !reg_error;
+  assign fw_ov_control_we = addr_hit[43] & reg_we & !reg_error;
 
   assign fw_ov_control_fw_ov_mode_wd = reg_wdata[3:0];
 
   assign fw_ov_control_fw_ov_entropy_insert_wd = reg_wdata[7:4];
-  assign fw_ov_sha3_start_we = addr_hit[45] & reg_we & !reg_error;
+  assign fw_ov_sha3_start_we = addr_hit[44] & reg_we & !reg_error;
 
   assign fw_ov_sha3_start_wd = reg_wdata[3:0];
-  assign fw_ov_wr_fifo_full_re = addr_hit[46] & reg_re & !reg_error;
-  assign fw_ov_rd_data_re = addr_hit[48] & reg_re & !reg_error;
-  assign fw_ov_wr_data_we = addr_hit[49] & reg_we & !reg_error;
+  assign fw_ov_wr_fifo_full_re = addr_hit[45] & reg_re & !reg_error;
+  assign fw_ov_rd_data_re = addr_hit[47] & reg_re & !reg_error;
+  assign fw_ov_wr_data_we = addr_hit[48] & reg_we & !reg_error;
 
   assign fw_ov_wr_data_wd = reg_wdata[31:0];
-  assign observe_fifo_thresh_we = addr_hit[50] & reg_we & !reg_error;
+  assign observe_fifo_thresh_we = addr_hit[49] & reg_we & !reg_error;
 
   assign observe_fifo_thresh_wd = reg_wdata[5:0];
-  assign observe_fifo_depth_re = addr_hit[51] & reg_re & !reg_error;
-  assign debug_status_re = addr_hit[52] & reg_re & !reg_error;
-  assign recov_alert_sts_we = addr_hit[53] & reg_we & !reg_error;
+  assign observe_fifo_depth_re = addr_hit[50] & reg_re & !reg_error;
+  assign debug_status_re = addr_hit[51] & reg_re & !reg_error;
+  assign recov_alert_sts_we = addr_hit[52] & reg_we & !reg_error;
 
   assign recov_alert_sts_fips_enable_field_alert_wd = reg_wdata[0];
 
@@ -3724,7 +3705,7 @@ module entropy_src_reg_top (
   assign recov_alert_sts_rng_fips_field_alert_wd = reg_wdata[18];
 
   assign recov_alert_sts_postht_entropy_drop_alert_wd = reg_wdata[31];
-  assign err_code_test_we = addr_hit[55] & reg_we & !reg_error;
+  assign err_code_test_we = addr_hit[54] & reg_we & !reg_error;
 
   assign err_code_test_wd = reg_wdata[4:0];
 
@@ -3737,21 +3718,21 @@ module entropy_src_reg_top (
     reg_we_check[4] = me_regwen_we;
     reg_we_check[5] = sw_regupd_we;
     reg_we_check[6] = 1'b0;
-    reg_we_check[7] = 1'b0;
-    reg_we_check[8] = module_enable_gated_we;
-    reg_we_check[9] = conf_gated_we;
-    reg_we_check[10] = entropy_control_gated_we;
-    reg_we_check[11] = 1'b0;
-    reg_we_check[12] = health_test_windows_gated_we;
-    reg_we_check[13] = repcnt_thresholds_gated_we;
-    reg_we_check[14] = repcnts_thresholds_gated_we;
-    reg_we_check[15] = adaptp_hi_thresholds_gated_we;
-    reg_we_check[16] = adaptp_lo_thresholds_gated_we;
-    reg_we_check[17] = bucket_thresholds_gated_we;
-    reg_we_check[18] = markov_hi_thresholds_gated_we;
-    reg_we_check[19] = markov_lo_thresholds_gated_we;
-    reg_we_check[20] = extht_hi_thresholds_gated_we;
-    reg_we_check[21] = extht_lo_thresholds_gated_we;
+    reg_we_check[7] = module_enable_gated_we;
+    reg_we_check[8] = conf_gated_we;
+    reg_we_check[9] = entropy_control_gated_we;
+    reg_we_check[10] = 1'b0;
+    reg_we_check[11] = health_test_windows_gated_we;
+    reg_we_check[12] = repcnt_thresholds_gated_we;
+    reg_we_check[13] = repcnts_thresholds_gated_we;
+    reg_we_check[14] = adaptp_hi_thresholds_gated_we;
+    reg_we_check[15] = adaptp_lo_thresholds_gated_we;
+    reg_we_check[16] = bucket_thresholds_gated_we;
+    reg_we_check[17] = markov_hi_thresholds_gated_we;
+    reg_we_check[18] = markov_lo_thresholds_gated_we;
+    reg_we_check[19] = extht_hi_thresholds_gated_we;
+    reg_we_check[20] = extht_lo_thresholds_gated_we;
+    reg_we_check[21] = 1'b0;
     reg_we_check[22] = 1'b0;
     reg_we_check[23] = 1'b0;
     reg_we_check[24] = 1'b0;
@@ -3769,24 +3750,23 @@ module entropy_src_reg_top (
     reg_we_check[36] = 1'b0;
     reg_we_check[37] = 1'b0;
     reg_we_check[38] = 1'b0;
-    reg_we_check[39] = 1'b0;
-    reg_we_check[40] = alert_threshold_gated_we;
+    reg_we_check[39] = alert_threshold_gated_we;
+    reg_we_check[40] = 1'b0;
     reg_we_check[41] = 1'b0;
     reg_we_check[42] = 1'b0;
-    reg_we_check[43] = 1'b0;
-    reg_we_check[44] = fw_ov_control_gated_we;
-    reg_we_check[45] = fw_ov_sha3_start_we;
+    reg_we_check[43] = fw_ov_control_gated_we;
+    reg_we_check[44] = fw_ov_sha3_start_we;
+    reg_we_check[45] = 1'b0;
     reg_we_check[46] = 1'b0;
     reg_we_check[47] = 1'b0;
-    reg_we_check[48] = 1'b0;
-    reg_we_check[49] = fw_ov_wr_data_we;
-    reg_we_check[50] = observe_fifo_thresh_gated_we;
+    reg_we_check[48] = fw_ov_wr_data_we;
+    reg_we_check[49] = observe_fifo_thresh_gated_we;
+    reg_we_check[50] = 1'b0;
     reg_we_check[51] = 1'b0;
-    reg_we_check[52] = 1'b0;
-    reg_we_check[53] = recov_alert_sts_we;
-    reg_we_check[54] = 1'b0;
-    reg_we_check[55] = err_code_test_we;
-    reg_we_check[56] = 1'b0;
+    reg_we_check[52] = recov_alert_sts_we;
+    reg_we_check[53] = 1'b0;
+    reg_we_check[54] = err_code_test_we;
+    reg_we_check[55] = 1'b0;
   end
 
   // Read data return
@@ -3832,16 +3812,10 @@ module entropy_src_reg_top (
       end
 
       addr_hit[7]: begin
-        reg_rdata_next[7:0] = rev_abi_revision_qs;
-        reg_rdata_next[15:8] = rev_hw_revision_qs;
-        reg_rdata_next[23:16] = rev_chip_type_qs;
-      end
-
-      addr_hit[8]: begin
         reg_rdata_next[3:0] = module_enable_qs;
       end
 
-      addr_hit[9]: begin
+      addr_hit[8]: begin
         reg_rdata_next[3:0] = conf_fips_enable_qs;
         reg_rdata_next[7:4] = conf_fips_flag_qs;
         reg_rdata_next[11:8] = conf_rng_fips_qs;
@@ -3851,156 +3825,156 @@ module entropy_src_reg_top (
         reg_rdata_next[31:24] = conf_rng_bit_sel_qs;
       end
 
-      addr_hit[10]: begin
+      addr_hit[9]: begin
         reg_rdata_next[3:0] = entropy_control_es_route_qs;
         reg_rdata_next[7:4] = entropy_control_es_type_qs;
       end
 
-      addr_hit[11]: begin
+      addr_hit[10]: begin
         reg_rdata_next[31:0] = entropy_data_qs;
       end
 
-      addr_hit[12]: begin
+      addr_hit[11]: begin
         reg_rdata_next[15:0] = health_test_windows_fips_window_qs;
         reg_rdata_next[31:16] = health_test_windows_bypass_window_qs;
       end
 
-      addr_hit[13]: begin
+      addr_hit[12]: begin
         reg_rdata_next[15:0] = repcnt_thresholds_fips_thresh_qs;
         reg_rdata_next[31:16] = repcnt_thresholds_bypass_thresh_qs;
       end
 
-      addr_hit[14]: begin
+      addr_hit[13]: begin
         reg_rdata_next[15:0] = repcnts_thresholds_fips_thresh_qs;
         reg_rdata_next[31:16] = repcnts_thresholds_bypass_thresh_qs;
       end
 
-      addr_hit[15]: begin
+      addr_hit[14]: begin
         reg_rdata_next[15:0] = adaptp_hi_thresholds_fips_thresh_qs;
         reg_rdata_next[31:16] = adaptp_hi_thresholds_bypass_thresh_qs;
       end
 
-      addr_hit[16]: begin
+      addr_hit[15]: begin
         reg_rdata_next[15:0] = adaptp_lo_thresholds_fips_thresh_qs;
         reg_rdata_next[31:16] = adaptp_lo_thresholds_bypass_thresh_qs;
       end
 
-      addr_hit[17]: begin
+      addr_hit[16]: begin
         reg_rdata_next[15:0] = bucket_thresholds_fips_thresh_qs;
         reg_rdata_next[31:16] = bucket_thresholds_bypass_thresh_qs;
       end
 
-      addr_hit[18]: begin
+      addr_hit[17]: begin
         reg_rdata_next[15:0] = markov_hi_thresholds_fips_thresh_qs;
         reg_rdata_next[31:16] = markov_hi_thresholds_bypass_thresh_qs;
       end
 
-      addr_hit[19]: begin
+      addr_hit[18]: begin
         reg_rdata_next[15:0] = markov_lo_thresholds_fips_thresh_qs;
         reg_rdata_next[31:16] = markov_lo_thresholds_bypass_thresh_qs;
       end
 
-      addr_hit[20]: begin
+      addr_hit[19]: begin
         reg_rdata_next[15:0] = extht_hi_thresholds_fips_thresh_qs;
         reg_rdata_next[31:16] = extht_hi_thresholds_bypass_thresh_qs;
       end
 
-      addr_hit[21]: begin
+      addr_hit[20]: begin
         reg_rdata_next[15:0] = extht_lo_thresholds_fips_thresh_qs;
         reg_rdata_next[31:16] = extht_lo_thresholds_bypass_thresh_qs;
       end
 
-      addr_hit[22]: begin
+      addr_hit[21]: begin
         reg_rdata_next[15:0] = repcnt_hi_watermarks_fips_watermark_qs;
         reg_rdata_next[31:16] = repcnt_hi_watermarks_bypass_watermark_qs;
       end
 
-      addr_hit[23]: begin
+      addr_hit[22]: begin
         reg_rdata_next[15:0] = repcnts_hi_watermarks_fips_watermark_qs;
         reg_rdata_next[31:16] = repcnts_hi_watermarks_bypass_watermark_qs;
       end
 
-      addr_hit[24]: begin
+      addr_hit[23]: begin
         reg_rdata_next[15:0] = adaptp_hi_watermarks_fips_watermark_qs;
         reg_rdata_next[31:16] = adaptp_hi_watermarks_bypass_watermark_qs;
       end
 
-      addr_hit[25]: begin
+      addr_hit[24]: begin
         reg_rdata_next[15:0] = adaptp_lo_watermarks_fips_watermark_qs;
         reg_rdata_next[31:16] = adaptp_lo_watermarks_bypass_watermark_qs;
       end
 
-      addr_hit[26]: begin
+      addr_hit[25]: begin
         reg_rdata_next[15:0] = extht_hi_watermarks_fips_watermark_qs;
         reg_rdata_next[31:16] = extht_hi_watermarks_bypass_watermark_qs;
       end
 
-      addr_hit[27]: begin
+      addr_hit[26]: begin
         reg_rdata_next[15:0] = extht_lo_watermarks_fips_watermark_qs;
         reg_rdata_next[31:16] = extht_lo_watermarks_bypass_watermark_qs;
       end
 
-      addr_hit[28]: begin
+      addr_hit[27]: begin
         reg_rdata_next[15:0] = bucket_hi_watermarks_fips_watermark_qs;
         reg_rdata_next[31:16] = bucket_hi_watermarks_bypass_watermark_qs;
       end
 
-      addr_hit[29]: begin
+      addr_hit[28]: begin
         reg_rdata_next[15:0] = markov_hi_watermarks_fips_watermark_qs;
         reg_rdata_next[31:16] = markov_hi_watermarks_bypass_watermark_qs;
       end
 
-      addr_hit[30]: begin
+      addr_hit[29]: begin
         reg_rdata_next[15:0] = markov_lo_watermarks_fips_watermark_qs;
         reg_rdata_next[31:16] = markov_lo_watermarks_bypass_watermark_qs;
       end
 
-      addr_hit[31]: begin
+      addr_hit[30]: begin
         reg_rdata_next[31:0] = repcnt_total_fails_qs;
       end
 
-      addr_hit[32]: begin
+      addr_hit[31]: begin
         reg_rdata_next[31:0] = repcnts_total_fails_qs;
       end
 
-      addr_hit[33]: begin
+      addr_hit[32]: begin
         reg_rdata_next[31:0] = adaptp_hi_total_fails_qs;
       end
 
-      addr_hit[34]: begin
+      addr_hit[33]: begin
         reg_rdata_next[31:0] = adaptp_lo_total_fails_qs;
       end
 
-      addr_hit[35]: begin
+      addr_hit[34]: begin
         reg_rdata_next[31:0] = bucket_total_fails_qs;
       end
 
-      addr_hit[36]: begin
+      addr_hit[35]: begin
         reg_rdata_next[31:0] = markov_hi_total_fails_qs;
       end
 
-      addr_hit[37]: begin
+      addr_hit[36]: begin
         reg_rdata_next[31:0] = markov_lo_total_fails_qs;
       end
 
-      addr_hit[38]: begin
+      addr_hit[37]: begin
         reg_rdata_next[31:0] = extht_hi_total_fails_qs;
       end
 
-      addr_hit[39]: begin
+      addr_hit[38]: begin
         reg_rdata_next[31:0] = extht_lo_total_fails_qs;
       end
 
-      addr_hit[40]: begin
+      addr_hit[39]: begin
         reg_rdata_next[15:0] = alert_threshold_alert_threshold_qs;
         reg_rdata_next[31:16] = alert_threshold_alert_threshold_inv_qs;
       end
 
-      addr_hit[41]: begin
+      addr_hit[40]: begin
         reg_rdata_next[15:0] = alert_summary_fail_counts_qs;
       end
 
-      addr_hit[42]: begin
+      addr_hit[41]: begin
         reg_rdata_next[7:4] = alert_fail_counts_repcnt_fail_count_qs;
         reg_rdata_next[11:8] = alert_fail_counts_adaptp_hi_fail_count_qs;
         reg_rdata_next[15:12] = alert_fail_counts_adaptp_lo_fail_count_qs;
@@ -4010,45 +3984,45 @@ module entropy_src_reg_top (
         reg_rdata_next[31:28] = alert_fail_counts_repcnts_fail_count_qs;
       end
 
-      addr_hit[43]: begin
+      addr_hit[42]: begin
         reg_rdata_next[3:0] = extht_fail_counts_extht_hi_fail_count_qs;
         reg_rdata_next[7:4] = extht_fail_counts_extht_lo_fail_count_qs;
       end
 
-      addr_hit[44]: begin
+      addr_hit[43]: begin
         reg_rdata_next[3:0] = fw_ov_control_fw_ov_mode_qs;
         reg_rdata_next[7:4] = fw_ov_control_fw_ov_entropy_insert_qs;
       end
 
-      addr_hit[45]: begin
+      addr_hit[44]: begin
         reg_rdata_next[3:0] = fw_ov_sha3_start_qs;
       end
 
-      addr_hit[46]: begin
+      addr_hit[45]: begin
         reg_rdata_next[0] = fw_ov_wr_fifo_full_qs;
       end
 
-      addr_hit[47]: begin
+      addr_hit[46]: begin
         reg_rdata_next[0] = fw_ov_rd_fifo_overflow_qs;
       end
 
-      addr_hit[48]: begin
+      addr_hit[47]: begin
         reg_rdata_next[31:0] = fw_ov_rd_data_qs;
       end
 
-      addr_hit[49]: begin
+      addr_hit[48]: begin
         reg_rdata_next[31:0] = '0;
       end
 
-      addr_hit[50]: begin
+      addr_hit[49]: begin
         reg_rdata_next[5:0] = observe_fifo_thresh_qs;
       end
 
-      addr_hit[51]: begin
+      addr_hit[50]: begin
         reg_rdata_next[5:0] = observe_fifo_depth_qs;
       end
 
-      addr_hit[52]: begin
+      addr_hit[51]: begin
         reg_rdata_next[1:0] = debug_status_entropy_fifo_depth_qs;
         reg_rdata_next[5:3] = debug_status_sha3_fsm_qs;
         reg_rdata_next[6] = debug_status_sha3_block_pr_qs;
@@ -4059,7 +4033,7 @@ module entropy_src_reg_top (
         reg_rdata_next[17] = debug_status_main_sm_boot_done_qs;
       end
 
-      addr_hit[53]: begin
+      addr_hit[52]: begin
         reg_rdata_next[0] = recov_alert_sts_fips_enable_field_alert_qs;
         reg_rdata_next[1] = recov_alert_sts_entropy_data_reg_en_field_alert_qs;
         reg_rdata_next[2] = recov_alert_sts_module_enable_field_alert_qs;
@@ -4080,7 +4054,7 @@ module entropy_src_reg_top (
         reg_rdata_next[31] = recov_alert_sts_postht_entropy_drop_alert_qs;
       end
 
-      addr_hit[54]: begin
+      addr_hit[53]: begin
         reg_rdata_next[0] = err_code_sfifo_esrng_err_qs;
         reg_rdata_next[1] = err_code_sfifo_distr_err_qs;
         reg_rdata_next[2] = err_code_sfifo_observe_err_qs;
@@ -4095,11 +4069,11 @@ module entropy_src_reg_top (
         reg_rdata_next[30] = err_code_fifo_state_err_qs;
       end
 
-      addr_hit[55]: begin
+      addr_hit[54]: begin
         reg_rdata_next[4:0] = err_code_test_qs;
       end
 
-      addr_hit[56]: begin
+      addr_hit[55]: begin
         reg_rdata_next[8:0] = main_sm_state_qs;
       end
 


### PR DESCRIPTION
This register implements an IP revision register which is unused in the current design. Remove that as part of the IP upgrade.