### PR TITLE
[BLOCKFILE] Add all Earlgrey-related RTL

### DIFF
--- a/BLOCKFILE
+++ b/BLOCKFILE
@@ -23,8 +23,7 @@ ci/scripts/check-pr-changes-allowed.py
 # Earlgrey related RTL
 hw/top_earlgrey/ip/*/rtl/*
 hw/top_earlgrey/ip_autogen/*/rtl/*
-hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
-hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+hw/top_earlgrey/rtl/*
 
 # Vendored IP
 hw/vendor/lowrisc_ibex/rtl/*


### PR DESCRIPTION
Previously, only `autogen/top_earlgrey.sv` and `autogen/chip_earlgrey_asic.sv` had changes blocked.  However, there are other RTL files, such as `autogen/top_earlgrey_pkg.sv` and `scan_role_pkg.sv`, that we don't want to get changed accidentally either.  This commit thus adds all Earlgrey-related RTL to BLOCKFILE.