### PR TITLE
[membkdr_util] Support for custom tile suffix

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_bkdr_util.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_bkdr_util.sv
@@ -13,9 +13,11 @@ class sram_ctrl_bkdr_util extends mem_bkdr_util;
                longint unsigned n_bits, err_detection_e err_detection_scheme,
                int num_prince_rounds_half = 3,
                int extra_bits_per_subword = 0, int unsigned system_base_addr = 0,
-               string tiling_path = "", uint32_t tile_depth = depth);
+               string tiling_path = "", string tiling_suffix_fmt_str = ".gen_ram_inst[%0d].%s",
+               uint32_t tile_depth = depth);
     super.new(name, path, depth, n_bits, err_detection_scheme, num_prince_rounds_half,
-              extra_bits_per_subword, system_base_addr, tiling_path, tile_depth);
+              extra_bits_per_subword, system_base_addr, tiling_path, tiling_suffix_fmt_str,
+              tile_depth);
   endfunction
 
   // Returns the address after scrambling it using the given nonce.


### PR DESCRIPTION
DFT might have a different path generation for the hierarchy. Provide a way to overwrite the tile suffix string.