### PR TITLE
[reggen] Add non-custom properties fields of the Systemrdl exporter

### DIFF
--- a/util/reggen/access.py
+++ b/util/reggen/access.py
@@ -9,6 +9,8 @@ from enum import Enum
 
 from reggen.lib import check_str
 
+from systemrdl.rdltypes import AccessType, OnReadType, OnWriteType  # type: ignore[attr-defined]
+
 
 class JsonEnum(Enum):
     def for_json(x) -> str:
@@ -45,6 +47,24 @@ class HwAccess(JsonEnum):
     NONE = 4  # No access allowed
 
 
+# Maps reggen software access property to SystemRDL properties. Each line in this table is
+# a set of RDL properties where:
+#   sw: Software read and write access.
+#   onread: Side effect when software reads.
+#   onwrite: Side effect when software writes.
+
+SWACCESS_RDL_MAP = {
+    SwAccess.RO: {"sw": AccessType.r},
+    SwAccess.RC: {"sw": AccessType.r, "onread": OnReadType.rclr},
+    SwAccess.R0W1C: {"sw": AccessType.w, "onwrite": OnWriteType.woclr},
+    SwAccess.RW: {"sw": AccessType.rw},
+    SwAccess.WO: {"sw": AccessType.w},
+    SwAccess.W1C: {"sw": AccessType.w, "onwrite": OnWriteType.woset},
+    SwAccess.W0C: {"sw": AccessType.w, "onwrite": OnWriteType.wzc},
+    SwAccess.W1S: {"sw": AccessType.w, "onwrite": OnWriteType.woset},
+    SwAccess.NONE: {"sw": AccessType.r},
+}
+
 # swaccess permitted values
 # text description, access enum, wr access enum, rd access enum, ok in window
 # yapf: disable
@@ -76,6 +96,16 @@ HWACCESS_PERMITTED = {
     "hrw": ("Read/Write", HwAccess.HRW),
     "hwo": ("Write Only", HwAccess.HWO),
     "none": ("No Access Needed", HwAccess.NONE),
+}
+
+# Maps reggen hardware access property to SystemRDL properties. Each line in this table is
+# a set of RDL properties where:
+#    hw: Hardware read and write access
+HWACCESS_RDL_MAP = {
+    HwAccess.HRO: {"hw": AccessType.r},
+    HwAccess.HRW: {"hw": AccessType.rw},
+    HwAccess.HWO: {"hw": AccessType.w},
+    HwAccess.NONE: {"hw": AccessType.rw},
 }
 
 
@@ -129,6 +159,9 @@ class SWAccess:
         """
         return self.value[1] != SwAccess.RC and self.allows_write()
 
+    def to_systemrdl(self) -> dict[str, object]:
+        return SWACCESS_RDL_MAP[self.value[1]]
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, SWAccess):
             return NotImplemented
@@ -151,6 +184,9 @@ class HWAccess:
 
     def allows_write(self) -> bool:
         return self.key in ["hrw", "hwo"]
+
+    def to_systemrdl(self) -> dict[str, object]:
+        return HWACCESS_RDL_MAP[self.value[1]]
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, HWAccess):

--- a/util/reggen/access.py
+++ b/util/reggen/access.py
@@ -11,7 +11,6 @@ from reggen.lib import check_str
 
 
 class JsonEnum(Enum):
-
     def for_json(x) -> str:
         return str(x)
 
@@ -73,45 +72,41 @@ SWACCESS_PERMITTED = {
 
 # hwaccess permitted values
 HWACCESS_PERMITTED = {
-    'hro': ("Read Only", HwAccess.HRO),
-    'hrw': ("Read/Write", HwAccess.HRW),
-    'hwo': ("Write Only", HwAccess.HWO),
-    'none': ("No Access Needed", HwAccess.NONE)
+    "hro": ("Read Only", HwAccess.HRO),
+    "hrw": ("Read/Write", HwAccess.HRW),
+    "hwo": ("Write Only", HwAccess.HWO),
+    "none": ("No Access Needed", HwAccess.NONE),
 }
 
 
 class SWAccess:
-
     def __init__(self, where: str, raw: object, is_mubi: bool = False):
-        self.key = check_str(raw, 'swaccess for {}'.format(where))
+        self.key = check_str(raw, "swaccess for {}".format(where))
         self.is_mubi = is_mubi
         try:
             self.value = SWACCESS_PERMITTED[self.key]
         except KeyError:
-            raise ValueError(
-                f'Unknown swaccess key, {self.key}, for {where}.') from None
+            raise ValueError(f"Unknown swaccess key, {self.key}, for {where}.") from None
 
     def dv_rights(self) -> str:
-        '''Return a UVM access string as used by uvm_field::set_access().'''
-        if self.key == 'r0w1c':
-            return 'W1C'
-        elif self.key in ['rw1s', 'rw1c', 'rw0c', 'r0w1c', 'rc'
-                          ] and self.is_mubi:
+        """Return a UVM access string as used by uvm_field::set_access()."""
+        if self.key == "r0w1c":
+            return "W1C"
+        elif self.key in ["rw1s", "rw1c", "rw0c", "r0w1c", "rc"] and self.is_mubi:
             # The native UVM implementations for these access modes are
             # incompatible with Mubi's. We hence have to use regular RW access
             # at the lowest level for the UVM RAL implementation, and model the
             # custom mubi behavior in the uvm_base_reg_field abstraction of
             # uvm_base_reg_field.
-            return 'RW'
+            return "RW"
         return str(self.value[1].name)
 
     def dv_mubi_rights(self) -> str:
-        '''Return a UVM access string as used by uvm_base_reg_field abstraction.
-        '''
+        """Return a UVM access string as used by uvm_base_reg_field abstraction."""
         if not self.is_mubi:
-            return 'NONE'
-        elif self.key == 'r0w1c':
-            return 'W1C'
+            return "NONE"
+        elif self.key == "r0w1c":
+            return "W1C"
 
         return str(self.value[1].name)
 
@@ -125,13 +120,13 @@ class SWAccess:
         return self.value[2] == SwWrAccess.WR
 
     def needs_we(self) -> bool:
-        '''Should the register for this field have a write-enable signal?
+        """Should the register for this field have a write-enable signal?
 
         This is almost the same as allows_write(), but doesn't return true for
         RC registers, which should use a read-enable signal (connected to their
         prim_subreg's we port).
 
-        '''
+        """
         return self.value[1] != SwAccess.RC and self.allows_write()
 
     def __eq__(self, other: object) -> bool:
@@ -140,24 +135,22 @@ class SWAccess:
         return (self.key == other.key) and (self.value == other.value)
 
     def __str__(self) -> str:
-        return '{}: {}'.format(self.key, self.value)
+        return "{}: {}".format(self.key, self.value)
 
 
 class HWAccess:
-
     def __init__(self, where: str, raw: object):
-        self.key = check_str(raw, 'hwaccess for {}'.format(where))
+        self.key = check_str(raw, "hwaccess for {}".format(where))
         try:
             self.value = HWACCESS_PERMITTED[self.key]
         except KeyError:
-            raise ValueError(
-                f'Unknown hwaccess key, {self.key}, for {where}.') from None
+            raise ValueError(f"Unknown hwaccess key, {self.key}, for {where}.") from None
 
     def allows_read(self) -> bool:
-        return self.key in ['hro', 'hrw']
+        return self.key in ["hro", "hrw"]
 
     def allows_write(self) -> bool:
-        return self.key in ['hrw', 'hwo']
+        return self.key in ["hrw", "hwo"]
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, HWAccess):
@@ -165,4 +158,4 @@ class HWAccess:
         return (self.key == other.key) and (self.value == other.value)
 
     def __str__(self) -> str:
-        return '{}: {}'.format(self.key, self.value)
+        return "{}: {}".format(self.key, self.value)

--- a/util/reggen/field.py
+++ b/util/reggen/field.py
@@ -488,4 +488,7 @@ class Field:
         hwaccess = self.hwaccess.to_systemrdl()
         importer.assign_property(field, "hw", hwaccess["hw"])
 
+        if self.desc:
+            importer.assign_property(field, "desc", self.desc)
+
         return field

--- a/util/reggen/field.py
+++ b/util/reggen/field.py
@@ -488,6 +488,9 @@ class Field:
         hwaccess = self.hwaccess.to_systemrdl()
         importer.assign_property(field, "hw", hwaccess["hw"])
 
+        if self.resval is not None:
+            importer.assign_property(field, "reset", self.resval)
+
         if self.desc:
             importer.assign_property(field, "desc", self.desc)
 

--- a/util/reggen/field.py
+++ b/util/reggen/field.py
@@ -491,6 +491,9 @@ class Field:
         if self.resval is not None:
             importer.assign_property(field, "reset", self.resval)
 
+        if self.hwqe:
+            importer.assign_property(field, "swmod", self.hwqe)
+
         if self.desc:
             importer.assign_property(field, "desc", self.desc)
 

--- a/util/reggen/field.py
+++ b/util/reggen/field.py
@@ -474,4 +474,18 @@ class Field:
 
     def to_systemrdl(self, importer: RDLImporter) -> systemrdl.component.Field:
         rdl_t = importer.create_field_definition(self.name)
-        return importer.instantiate_field(rdl_t, self.name, self.bits.lsb, self.bits.width())
+        field = importer.instantiate_field(
+            rdl_t, self.name.upper(), self.bits.lsb, self.bits.width()
+        )
+
+        swaccess = self.swaccess.to_systemrdl()
+        importer.assign_property(field, "sw", swaccess["sw"])
+        if "onread" in swaccess:
+            importer.assign_property(field, "onread", swaccess["onread"])
+        if "onwrite" in swaccess:
+            importer.assign_property(field, "onwrite", swaccess["onwrite"])
+
+        hwaccess = self.hwaccess.to_systemrdl()
+        importer.assign_property(field, "hw", hwaccess["hw"])
+
+        return field

--- a/util/reggen/gen_systemrdl.py
+++ b/util/reggen/gen_systemrdl.py
@@ -19,7 +19,6 @@ def gen(block: IpBlock, outfile: TextIO) -> int:
     comp = RDLCompiler()
     imp = RDLImporter(comp)
     imp.default_src_ref = FileSourceRef(outfile.name)
-    exp = exporter.SystemRDLExporter()
 
     rdl_addrmap = block.to_systemrdl(imp)
     if rdl_addrmap is None:
@@ -31,6 +30,6 @@ def gen(block: IpBlock, outfile: TextIO) -> int:
     # to exp.export (which expects a path rather than a stream).
     outfile.close()
 
-    exp.export(comp.elaborate(), outfile.name)
+    exporter.SystemRDLExporter().export(comp.elaborate(), outfile.name)
 
     return 0


### PR DESCRIPTION
Maps all the reggen properties that can be directly mapped to SystemRDL properties in register fields.

Custom properties and Register properties will in an follow-up PR. 