### PR TITLE
[sw] Add `nonstring` annotation to byte arrays

### DIFF
--- a/sw/device/lib/runtime/print.c
+++ b/sw/device/lib/runtime/print.c
@@ -47,12 +47,17 @@ enum {
 
 // NOTE: all of the lengths of the strings below are given so that the NUL
 // terminator is left off; that way, `sizeof(kConst)` does not include it.
-static const char kDigitsLow[16] = "0123456789abcdef";
-static const char kDigitsHigh[16] = "0123456789ABCDEF";
 
-static const char kErrorNul[17] = "%<unexpected nul>";
-static const char kUnknownSpec[15] = "%<unknown spec>";
-static const char kErrorTooWide[12] = "%<bad width>";
+__attribute__((nonstring)) static const char kDigitsLow[16] =
+    "0123456789abcdef";
+__attribute__((nonstring)) static const char kDigitsHigh[16] =
+    "0123456789ABCDEF";
+
+__attribute__((nonstring)) static const char kErrorNul[17] =
+    "%<unexpected nul>";
+__attribute__((nonstring)) static const char kUnknownSpec[15] =
+    "%<unknown spec>";
+__attribute__((nonstring)) static const char kErrorTooWide[12] = "%<bad width>";
 
 static size_t base_dev_null(void *data, const char *buf, size_t len) {
   return len;
@@ -766,7 +771,7 @@ size_t base_vfprintf(buffer_sink_t out, const char *format, va_list args) {
   return bytes_written;
 }
 
-const char kBaseHexdumpDefaultFmtAlphabet[256] =
+__attribute((nonstring)) const char kBaseHexdumpDefaultFmtAlphabet[256] =
     // clang-format off
   // First 32 characters are not printable.
   "................................"
@@ -829,7 +834,7 @@ size_t base_fhexdump_with(buffer_sink_t out, base_hexdump_fmt_t fmt,
     size_t line_bytes_written = 0;
     for (size_t word = 0; word < bytes_per_line; word += fmt.bytes_per_word) {
       if (len < line + word) {
-        char spaces[16] = "                ";
+        __attribute__((nonstring)) char spaces[16] = "                ";
         while (line_bytes_written < chars_per_line) {
           size_t to_print = chars_per_line - line_bytes_written;
           if (to_print > sizeof(spaces)) {


### PR DESCRIPTION
This attribute tells the compiler that the NUL terminator is intentionally missing. Later versions of Clang will complain that the NUL byte will be dropped due to the size of the array.

We might prefer an alias for this attribute. Perhaps:

```c
OT_NONSTRING
```

or

```c
OT_NO_NUL_TERMINATOR
```