### PR TITLE
[hw,otp_macro,rtl] Add RACL support

### DIFF
--- a/hw/ip/otp_macro/data/otp_macro.hjson
+++ b/hw/ip/otp_macro/data/otp_macro.hjson
@@ -37,7 +37,7 @@
     }
   ],
   bus_interfaces: [
-    { protocol: "tlul", direction: "device", name: "prim" }
+    { protocol: "tlul", direction: "device", name: "prim", racl_support: true }
   ],
   scan: "true", // Enable `scanmode_i` port
   scan_reset: "true", // Enable `scan_rst_ni` port
@@ -189,6 +189,27 @@
       act:     "req"
       default: "'0"
       package: "otp_macro_pkg"
+    },
+    // RACL interface
+    { struct:  "racl_policy_vec",
+      type:    "uni",
+      name:    "racl_policies",
+      act:     "rcv",
+      package: "top_racl_pkg",
+      desc:    '''
+        Incoming RACL policy vector from a racl_ctrl instance.
+        The policy selection vector (parameter) selects the policy for each register.
+      '''
+    },
+    { struct:  "racl_error_log",
+      type:    "uni",
+      name:    "racl_error",
+      act:     "req",
+      width:   "1"
+      package: "top_racl_pkg",
+      desc:    '''
+        RACL error log information of this module.
+      '''
     },
   ],
 

--- a/hw/ip/otp_macro/otp_macro.core
+++ b/hw/ip/otp_macro/otp_macro.core
@@ -14,6 +14,7 @@ filesets:
       - lowrisc:prim:secded
       - lowrisc:ip:otp_macro_pkg
       - lowrisc:virtual_ip:otp_ctrl_macro_pkg
+      - lowrisc:virtual_constants:top_racl_pkg
     files:
       - rtl/otp_macro_reg_pkg.sv
       - rtl/otp_macro_prim_reg_top.sv

--- a/hw/ip/otp_macro/rtl/otp_macro.sv
+++ b/hw/ip/otp_macro/rtl/otp_macro.sv
@@ -17,7 +17,12 @@ module otp_macro
   parameter         MemInitFile   = "",
   // Vendor test partition offset and size (both in bytes)
   parameter  int    VendorTestOffset = 0,
-  parameter  int    VendorTestSize   = 0
+  parameter  int    VendorTestSize   = 0,
+  // RACL definitions
+  parameter bit  EnableRacl       = 1'b0,
+  parameter bit  RaclErrorRsp     = 1'b1,
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[otp_macro_reg_pkg::NumRegsPrim] =
+    '{otp_macro_reg_pkg::NumRegsPrim{0}}
 ) (
   input                          clk_i,
   input                          rst_ni,
@@ -49,6 +54,10 @@ module otp_macro
   // Incoming request from OTP_CTRL
   input                          otp_ctrl_macro_req_t otp_i,
   output                         otp_ctrl_macro_rsp_t otp_o,
+
+  // RACL interface
+  input  top_racl_pkg::racl_policy_vec_t  racl_policies_i,
+  output top_racl_pkg::racl_error_log_t   racl_error_o,
 
   // DFT config and response port
   input                          otp_cfg_t cfg_i,
@@ -146,14 +155,20 @@ module otp_macro
 
   otp_macro_reg_pkg::otp_macro_prim_reg2hw_t reg2hw;
   otp_macro_reg_pkg::otp_macro_prim_hw2reg_t hw2reg;
-  otp_macro_prim_reg_top u_reg_top (
+  otp_macro_prim_reg_top #(
+    .EnableRacl       ( EnableRacl       ),
+    .RaclErrorRsp     ( RaclErrorRsp     ),
+    .RaclPolicySelVec ( RaclPolicySelVec )
+  ) u_reg_top (
     .clk_i,
     .rst_ni,
     .tl_i      (tl_h2d_gated ),
     .tl_o      (tl_d2h_gated ),
     .reg2hw    (reg2hw    ),
     .hw2reg    (hw2reg    ),
-    .intg_err_o(intg_err  )
+    .intg_err_o(intg_err  ),
+    .racl_policies_i,
+    .racl_error_o
   );
 
   logic unused_reg_sig;

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -1703,6 +1703,32 @@
           index: -1
         }
         {
+          name: racl_policies
+          desc:
+            '''
+            Incoming RACL policy vector from a racl_ctrl instance.
+            The policy selection vector (parameter) selects the policy for each register.
+            '''
+          struct: racl_policy_vec
+          package: top_racl_pkg
+          type: uni
+          act: rcv
+          width: 1
+          inst_name: otp_macro
+          index: -1
+        }
+        {
+          name: racl_error
+          desc: RACL error log information of this module.
+          struct: racl_error_log
+          package: top_racl_pkg
+          type: uni
+          act: req
+          width: 1
+          inst_name: otp_macro
+          index: -1
+        }
+        {
           name: prim_tl
           struct: tl
           package: tlul_pkg
@@ -21170,6 +21196,32 @@
         external: true
         top_signame: otp_cfg_rsp
         conn_type: false
+        index: -1
+      }
+      {
+        name: racl_policies
+        desc:
+          '''
+          Incoming RACL policy vector from a racl_ctrl instance.
+          The policy selection vector (parameter) selects the policy for each register.
+          '''
+        struct: racl_policy_vec
+        package: top_racl_pkg
+        type: uni
+        act: rcv
+        width: 1
+        inst_name: otp_macro
+        index: -1
+      }
+      {
+        name: racl_error
+        desc: RACL error log information of this module.
+        struct: racl_error_log
+        package: top_racl_pkg
+        type: uni
+        act: req
+        width: 1
+        inst_name: otp_macro
         index: -1
       }
       {

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -1252,6 +1252,8 @@ module top_darjeeling #(
       .otp_o(otp_ctrl_otp_macro_rsp),
       .cfg_i(otp_cfg_i),
       .cfg_rsp_o(otp_cfg_rsp_o),
+      .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
+      .racl_error_o(),
       .prim_tl_i(otp_macro_prim_tl_req),
       .prim_tl_o(otp_macro_prim_tl_rsp),
       .scanmode_i,

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2359,6 +2359,32 @@
           index: -1
         }
         {
+          name: racl_policies
+          desc:
+            '''
+            Incoming RACL policy vector from a racl_ctrl instance.
+            The policy selection vector (parameter) selects the policy for each register.
+            '''
+          struct: racl_policy_vec
+          package: top_racl_pkg
+          type: uni
+          act: rcv
+          width: 1
+          inst_name: otp_macro
+          index: -1
+        }
+        {
+          name: racl_error
+          desc: RACL error log information of this module.
+          struct: racl_error_log
+          package: top_racl_pkg
+          type: uni
+          act: req
+          width: 1
+          inst_name: otp_macro
+          index: -1
+        }
+        {
           name: prim_tl
           struct: tl
           package: tlul_pkg
@@ -19679,6 +19705,32 @@
         act: req
         width: 1
         default: "'0"
+        inst_name: otp_macro
+        index: -1
+      }
+      {
+        name: racl_policies
+        desc:
+          '''
+          Incoming RACL policy vector from a racl_ctrl instance.
+          The policy selection vector (parameter) selects the policy for each register.
+          '''
+        struct: racl_policy_vec
+        package: top_racl_pkg
+        type: uni
+        act: rcv
+        width: 1
+        inst_name: otp_macro
+        index: -1
+      }
+      {
+        name: racl_error
+        desc: RACL error log information of this module.
+        struct: racl_error_log
+        package: top_racl_pkg
+        type: uni
+        act: req
+        width: 1
         inst_name: otp_macro
         index: -1
       }

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1570,6 +1570,8 @@ module top_earlgrey #(
       .otp_o(otp_ctrl_otp_macro_rsp),
       .cfg_i('0),
       .cfg_rsp_o(),
+      .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
+      .racl_error_o(),
       .prim_tl_i(otp_macro_prim_tl_req),
       .prim_tl_o(otp_macro_prim_tl_rsp),
       .scanmode_i,


### PR DESCRIPTION
This PR adds RACL support to the underlying OTP macro instance. In the upstream, RACL is not used on this IP and tied-off.