### PR TITLE
[hw,prim_diff_decode,rtl] Add parametric skew cycle tolerance

### DIFF
--- a/hw/ip/adc_ctrl/rtl/adc_ctrl.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl.sv
@@ -9,7 +9,9 @@
 module adc_ctrl
   import adc_ctrl_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1
 ) (
   input clk_i,      // regular core clock for SW config interface
   input clk_aon_i,  // always-on slow clock for internal logic
@@ -51,6 +53,7 @@ module adc_ctrl
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -30,6 +30,8 @@ module aes
                                                     // need to skip reseeding requests.
                                                     // Useful for SCA only.
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned         AlertSkewCycles          = 1,
   parameter clearing_lfsr_seed_t RndCnstClearingLfsrSeed  = RndCnstClearingLfsrSeedDefault,
   parameter clearing_lfsr_perm_t RndCnstClearingLfsrPerm  = RndCnstClearingLfsrPermDefault,
   parameter clearing_lfsr_perm_t RndCnstClearingSharePerm = RndCnstClearingSharePermDefault,
@@ -227,6 +229,7 @@ module aes
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(i)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip/aon_timer/rtl/aon_timer.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer.sv
@@ -10,6 +10,8 @@
 module aon_timer import aon_timer_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned                    AlertSkewCycles           = 1,
   parameter bit                             EnableRacl                = 1'b0,
   parameter bit                             RaclErrorRsp              = EnableRacl,
   parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[NumRegs] = '{NumRegs{0}}
@@ -131,6 +133,7 @@ module aon_timer import aon_timer_reg_pkg::*;
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip/ascon/rtl/ascon.sv
+++ b/hw/ip/ascon/rtl/ascon.sv
@@ -8,7 +8,9 @@ module ascon
   import ascon_reg_pkg::*;
   import ascon_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn    = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned          AlertSkewCycles = 1
 ) (
   input clk_i,
   input rst_ni,
@@ -133,6 +135,7 @@ module ascon
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(i)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip/csrng/rtl/csrng.sv
+++ b/hw/ip/csrng/rtl/csrng.sv
@@ -12,6 +12,8 @@ module csrng
 #(
   parameter aes_pkg::sbox_impl_e SBoxImpl = aes_pkg::SBoxImplCanright,
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1,
   parameter int NHwApps = 2,
   parameter cs_keymgr_div_t RndCnstCsKeymgrDivNonProduction = CsKeymgrDivWidth'(0),
   parameter cs_keymgr_div_t RndCnstCsKeymgrDivProduction = CsKeymgrDivWidth'(0)
@@ -121,6 +123,7 @@ module csrng
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(i)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip/dma/rtl/dma.sv
+++ b/hw/ip/dma/rtl/dma.sv
@@ -10,6 +10,8 @@ module dma
   import dma_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned                    AlertSkewCycles           = 1,
   parameter bit                             EnableDataIntgGen         = 1'b1,
   parameter bit                             EnableRspDataIntgCheck    = 1'b1,
   parameter logic [RsvdWidth-1:0]           TlUserRsvd                = '0,
@@ -185,6 +187,7 @@ module dma
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip/edn/rtl/edn.sv
+++ b/hw/ip/edn/rtl/edn.sv
@@ -11,7 +11,9 @@ module edn
   import edn_reg_pkg::*;
 #(
   parameter int NumEndPoints = 8,
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1
 ) (
   input logic clk_i,
   input logic rst_ni,
@@ -94,6 +96,7 @@ module edn
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(i)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip/entropy_src/rtl/entropy_src.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src.sv
@@ -12,13 +12,15 @@ module entropy_src
   import entropy_src_reg_pkg::*;
   import prim_mubi_pkg::mubi8_t;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
-  parameter int RngBusWidth                    = 4,
-  parameter int RngBusBitSelWidth              = 2,
-  parameter int HealthTestWindowWidth          = 18,
-  parameter int EsFifoDepth                    = 3,
-  parameter int DistrFifoDepth                 = 2,
-  parameter bit Stub                           = 1'b0
+  parameter logic [NumAlerts-1:0] AlertAsyncOn    = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles          = 1,
+  parameter int RngBusWidth                       = 4,
+  parameter int RngBusBitSelWidth                 = 2,
+  parameter int HealthTestWindowWidth             = 18,
+  parameter int EsFifoDepth                       = 3,
+  parameter int DistrFifoDepth                    = 2,
+  parameter bit Stub                              = 1'b0
 ) (
   input logic clk_i,
   input logic rst_ni,
@@ -272,6 +274,7 @@ module entropy_src
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(i)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -10,7 +10,9 @@ module hmac
   import prim_sha2_pkg::*;
   import hmac_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1
 ) (
   input clk_i,
   input rst_ni,
@@ -775,6 +777,7 @@ module hmac
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip/i2c/rtl/i2c.sv
+++ b/hw/ip/i2c/rtl/i2c.sv
@@ -10,6 +10,8 @@ module i2c
   import i2c_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned                    AlertSkewCycles           = 1,
   parameter int unsigned                    InputDelayCycles          = 0,
   parameter bit                             EnableRacl                = 1'b0,
   parameter bit                             RaclErrorRsp              = EnableRacl,
@@ -90,6 +92,7 @@ module i2c
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip/keymgr/rtl/keymgr.sv
+++ b/hw/ip/keymgr/rtl/keymgr.sv
@@ -12,6 +12,8 @@ module keymgr
   import keymgr_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles       = 1,
   // In case this is set to true, the keymgr will ignore the creator / owner seeds
   // on the flash_i port and use the seeds provided in otp_key_i instead.
   parameter bit UseOtpSeedsInsteadOfFlash      = 1'b0,
@@ -737,6 +739,7 @@ module keymgr
                             reg2hw.alert_test.fatal_fault_err.qe;
   prim_alert_sender #(
     .AsyncOn(AlertAsyncOn[1]),
+    .SkewCycles(AlertSkewCycles),
     .IsFatal(1)
   ) u_fault_alert (
     .clk_i,
@@ -754,6 +757,7 @@ module keymgr
                              reg2hw.alert_test.recov_operation_err.qe;
   prim_alert_sender #(
     .AsyncOn(AlertAsyncOn[0]),
+    .SkewCycles(AlertSkewCycles),
     .IsFatal(0)
   ) u_op_err_alert (
     .clk_i,

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe.sv
@@ -13,6 +13,8 @@ module keymgr_dpe
   import keymgr_dpe_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles       = 1,
   parameter bit KmacEnMasking                  = 1'b1,
   parameter lfsr_seed_t RndCnstLfsrSeed        = RndCnstLfsrSeedDefault,
   parameter lfsr_perm_t RndCnstLfsrPerm        = RndCnstLfsrPermDefault,
@@ -752,6 +754,7 @@ module keymgr_dpe
                             reg2hw.alert_test.fatal_fault_err.qe;
   prim_alert_sender #(
     .AsyncOn(AlertAsyncOn[1]),
+    .SkewCycles(AlertSkewCycles),
     .IsFatal(1)
   ) u_fault_alert (
     .clk_i,
@@ -769,6 +772,7 @@ module keymgr_dpe
                              reg2hw.alert_test.recov_operation_err.qe;
   prim_alert_sender #(
     .AsyncOn(AlertAsyncOn[0]),
+    .SkewCycles(AlertSkewCycles),
     .IsFatal(0)
   ) u_op_err_alert (
     .clk_i,

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -37,7 +37,9 @@ module kmac
   parameter buffer_lfsr_seed_t RndCnstBufferLfsrSeed = RndCnstBufferLfsrSeedDefault,
   parameter msg_perm_t  RndCnstMsgPerm  = RndCnstMsgPermDefault,
 
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1
 ) (
   input clk_i,
   input rst_ni,
@@ -1466,6 +1468,7 @@ module kmac
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(i)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -14,6 +14,8 @@ module lc_ctrl
 #(
   // Enable asynchronous transitions on alerts.
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1,
   // Hardware revision numbers exposed in the CSRs.
   parameter logic [SiliconCreatorIdWidth-1:0] SiliconCreatorId = '0,
   parameter logic [ProductIdWidth-1:0]        ProductId        = '0,
@@ -640,6 +642,7 @@ module lc_ctrl
   for (genvar k = 0; k < NumAlerts; k++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[k]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -14,7 +14,7 @@ module lc_ctrl
 #(
   // Enable asynchronous transitions on alerts.
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
-  // Number of cycles a differential skew is tolerated on the alert signal
+  // Number of cycles a differential skew is tolerated on the alert and escalation signal
   parameter int unsigned AlertSkewCycles = 1,
   // Hardware revision numbers exposed in the CSRs.
   parameter logic [SiliconCreatorIdWidth-1:0] SiliconCreatorId = '0,
@@ -675,7 +675,8 @@ module lc_ctrl
   logic esc_scrap_state0;
   prim_esc_receiver #(
     .N_ESC_SEV   (EscNumSeverities),
-    .PING_CNT_DW (EscPingCountWidth)
+    .PING_CNT_DW (EscPingCountWidth),
+    .SkewCycles  (AlertSkewCycles)
   ) u_prim_esc_receiver0 (
     .clk_i,
     .rst_ni,
@@ -689,7 +690,8 @@ module lc_ctrl
   logic esc_scrap_state1;
   prim_esc_receiver #(
     .N_ESC_SEV   (EscNumSeverities),
-    .PING_CNT_DW (EscPingCountWidth)
+    .PING_CNT_DW (EscPingCountWidth),
+    .SkewCycles  (AlertSkewCycles)
   ) u_prim_esc_receiver1 (
     .clk_i,
     .rst_ni,

--- a/hw/ip/mbx/rtl/mbx.sv
+++ b/hw/ip/mbx/rtl/mbx.sv
@@ -9,6 +9,8 @@ module mbx
   import mbx_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]           AlertAsyncOn                    = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned                    AlertSkewCycles                 = 1,
   parameter int unsigned                    CfgSramAddrWidth                = 32,
   parameter int unsigned                    CfgSramDataWidth                = 32,
   parameter int unsigned                    CfgObjectSizeWidth              = 11,
@@ -121,6 +123,7 @@ module mbx
 
   mbx_hostif #(
     .AlertAsyncOn         ( AlertAsyncOn         ),
+    .AlertSkewCycles      ( AlertSkewCycles      ),
     .CfgSramAddrWidth     ( CfgSramAddrWidth     ),
     .CfgSramDataWidth     ( CfgSramDataWidth     ),
     .CfgObjectSizeWidth   ( CfgObjectSizeWidth   ),

--- a/hw/ip/mbx/rtl/mbx_hostif.sv
+++ b/hw/ip/mbx/rtl/mbx_hostif.sv
@@ -5,13 +5,15 @@
 module mbx_hostif
   import mbx_reg_pkg::*;
 #(
-    parameter logic [NumAlerts-1:0]           AlertAsyncOn                      = {NumAlerts{1'b1}},
-    parameter int unsigned                    CfgSramAddrWidth                  = 32,
-    parameter int unsigned                    CfgSramDataWidth                  = 32,
-    parameter int unsigned                    CfgObjectSizeWidth                = 11,
-    parameter bit                             EnableRacl                        = 1'b0,
-    parameter bit                             RaclErrorRsp                      = 1'b1,
-    parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVecCore[NumRegsCore] = '{NumRegsCore{0}}
+  parameter logic [NumAlerts-1:0]           AlertAsyncOn                      = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned                    AlertSkewCycles                   = 1,
+  parameter int unsigned                    CfgSramAddrWidth                  = 32,
+  parameter int unsigned                    CfgSramDataWidth                  = 32,
+  parameter int unsigned                    CfgObjectSizeWidth                = 11,
+  parameter bit                             EnableRacl                        = 1'b0,
+  parameter bit                             RaclErrorRsp                      = 1'b1,
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVecCore[NumRegsCore] = '{NumRegsCore{0}}
 ) (
   input  logic                          clk_i,
   input  logic                          rst_ni,
@@ -87,8 +89,9 @@ module mbx_hostif
   localparam logic [NumAlerts-1:0] IsFatal = {1'b0, 1'b1};
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
-      .AsyncOn ( AlertAsyncOn[i] ),
-      .IsFatal ( IsFatal[i]      )
+      .AsyncOn   ( AlertAsyncOn[i] ),
+      .SkewCycles( AlertSkewCycles ),
+      .IsFatal   ( IsFatal[i]      )
     ) u_prim_alert_sender (
     .clk_i          ( clk_i         ),
     .rst_ni         ( rst_ni        ),

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -13,9 +13,11 @@ module otbn
   import otbn_pkg::*;
   import otbn_reg_pkg::*;
 #(
-  parameter bit                   Stub         = 1'b0,
-  parameter regfile_e             RegFile      = RegFileFF,
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  parameter bit                   Stub            = 1'b0,
+  parameter regfile_e             RegFile         = RegFileFF,
+  parameter logic [NumAlerts-1:0] AlertAsyncOn    = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned          AlertSkewCycles = 1,
 
   // Default seed for URND PRNG
   parameter urnd_prng_seed_t RndCnstUrndPrngSeed = RndCnstUrndPrngSeedDefault,
@@ -1017,6 +1019,7 @@ module otbn
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(i == AlertFatal)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip/pattgen/rtl/pattgen.sv
+++ b/hw/ip/pattgen/rtl/pattgen.sv
@@ -7,7 +7,9 @@
 module pattgen
   import pattgen_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1
 ) (
   input clk_i,
   input rst_ni,
@@ -54,6 +56,7 @@ module pattgen
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip/prim/dv/prim_alert/tb/prim_alert_tb.sv
+++ b/hw/ip/prim/dv/prim_alert/tb/prim_alert_tb.sv
@@ -85,6 +85,7 @@ module prim_alert_tb;
   prim_mubi_pkg::mubi4_t     init_trig = prim_mubi_pkg::MuBi4False;
   prim_alert_sender #(
     .AsyncOn(IsAsync),
+    .SkewCycles(1),
     .IsFatal(IsFatal)
   ) i_alert_sender (
     .clk_i(clk),
@@ -98,7 +99,8 @@ module prim_alert_tb;
   );
 
   prim_alert_receiver #(
-    .AsyncOn(IsAsync)
+    .AsyncOn(IsAsync),
+    .SkewCycles(1)
   ) i_alert_receiver (
     .clk_i(clk),
     .rst_ni(rst_n),

--- a/hw/ip/prim/dv/prim_esc/tb/prim_esc_tb.sv
+++ b/hw/ip/prim/dv/prim_esc/tb/prim_esc_tb.sv
@@ -48,7 +48,9 @@ module prim_esc_tb;
   prim_esc_pkg::esc_tx_t esc_tx;
   prim_esc_pkg::esc_rx_t esc_rx;
 
-  prim_esc_sender i_esc_sender (
+  prim_esc_sender # (
+    .SkewCycles(1)
+  ) i_esc_sender (
     .clk_i(clk),
     .rst_ni(rst_n),
     .ping_req_i(ping_req),
@@ -62,7 +64,8 @@ module prim_esc_tb;
   prim_esc_receiver #(
     .N_ESC_SEV(4),
     // Set to 1 to avoid long wait period to check ping request reverse timeout.
-    .PING_CNT_DW(PING_CNT_DW)
+    .PING_CNT_DW(PING_CNT_DW),
+    .SkewCycles(1)
   ) i_esc_receiver (
     .clk_i(clk),
     .rst_ni(rst_n),

--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_fatal_tb.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_fatal_tb.sv
@@ -71,8 +71,9 @@ module prim_alert_rxtx_async_fatal_tb
   assign alert_tx_in.alert_n = alert_nq[alert_skew_i[1]] ^ alert_err_ni;
 
   prim_alert_sender #(
-    .AsyncOn ( AsyncOn ),
-    .IsFatal ( IsFatal )
+    .AsyncOn    ( AsyncOn ),
+    .SkewCycles ( 1       ),
+    .IsFatal    ( IsFatal )
   ) i_prim_alert_sender (
     .clk_i,
     .rst_ni,
@@ -85,7 +86,8 @@ module prim_alert_rxtx_async_fatal_tb
   );
 
   prim_alert_receiver #(
-    .AsyncOn ( AsyncOn )
+    .AsyncOn    ( AsyncOn    ),
+    .SkewCycles ( SkewCycles )
   ) i_prim_alert_receiver (
     .clk_i,
     .rst_ni,

--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_tb.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_tb.sv
@@ -71,8 +71,9 @@ module prim_alert_rxtx_async_tb
   assign alert_tx_in.alert_n = alert_nq[alert_skew_i[1]] ^ alert_err_ni;
 
   prim_alert_sender #(
-    .AsyncOn ( AsyncOn ),
-    .IsFatal ( IsFatal )
+    .AsyncOn    ( AsyncOn    ),
+    .SkewCycles ( SkewCycles ),
+    .IsFatal    ( IsFatal    )
   ) i_prim_alert_sender (
     .clk_i,
     .rst_ni,
@@ -85,7 +86,8 @@ module prim_alert_rxtx_async_tb
   );
 
   prim_alert_receiver #(
-    .AsyncOn ( AsyncOn )
+    .AsyncOn    ( AsyncOn    ),
+    .SkewCycles ( SkewCycles )
   ) i_prim_alert_receiver (
     .clk_i,
     .rst_ni,

--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_fatal_tb.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_fatal_tb.sv
@@ -46,8 +46,9 @@ module prim_alert_rxtx_fatal_tb
   assign alert_tx_in.alert_n = alert_tx_out.alert_n ^ alert_err_ni;
 
   prim_alert_sender #(
-    .AsyncOn ( AsyncOn ),
-    .IsFatal ( IsFatal )
+    .AsyncOn    ( AsyncOn    ),
+    .SkewCycles ( SkewCycles ),
+    .IsFatal    ( IsFatal    )
   ) i_prim_alert_sender (
     .clk_i,
     .rst_ni,
@@ -60,7 +61,8 @@ module prim_alert_rxtx_fatal_tb
   );
 
   prim_alert_receiver #(
-    .AsyncOn ( AsyncOn )
+    .AsyncOn    ( AsyncOn    ),
+    .SkewCycles ( SkewCycles )
   ) i_prim_alert_receiver (
     .clk_i,
     .rst_ni,

--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_tb.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_tb.sv
@@ -46,8 +46,9 @@ module prim_alert_rxtx_tb
   assign alert_tx_in.alert_n = alert_tx_out.alert_n ^ alert_err_ni;
 
   prim_alert_sender #(
-    .AsyncOn ( AsyncOn ),
-    .IsFatal ( IsFatal )
+    .AsyncOn    ( AsyncOn    ),
+    .SkewCycles ( SkewCycles ),
+    .IsFatal    ( IsFatal    )
   ) i_prim_alert_sender (
     .clk_i,
     .rst_ni,

--- a/hw/ip/prim/fpv/tb/prim_esc_rxtx_tb.sv
+++ b/hw/ip/prim/fpv/tb/prim_esc_rxtx_tb.sv
@@ -35,7 +35,9 @@ module prim_esc_rxtx_tb
   assign esc_tx_in.esc_p  = esc_tx_out.esc_p  ^ esc_err_pi;
   assign esc_tx_in.esc_n  = esc_tx_out.esc_n  ^ esc_err_ni;
 
-  prim_esc_sender u_prim_esc_sender (
+  prim_esc_sender #(
+    .SkewCycles(1)
+  ) u_prim_esc_sender (
     .clk_i        ,
     .rst_ni       ,
     .ping_req_i   ,
@@ -47,7 +49,8 @@ module prim_esc_rxtx_tb
   );
 
   prim_esc_receiver #(
-    .TimeoutCntDw(TimeoutCntDw)
+    .TimeoutCntDw(TimeoutCntDw),
+    .SkewCycles(1)
   ) u_prim_esc_receiver (
     .clk_i    ,
     .rst_ni   ,

--- a/hw/ip/prim/rtl/prim_alert_receiver.sv
+++ b/hw/ip/prim/rtl/prim_alert_receiver.sv
@@ -34,7 +34,9 @@ module prim_alert_receiver
   import prim_mubi_pkg::mubi4_t;
 #(
   // enables additional synchronization logic
-  parameter bit AsyncOn = 1'b0
+  parameter bit AsyncOn = 1'b0,
+  // Number of cycles a differential skew is tolerated on the differential alert signal.
+  parameter int unsigned SkewCycles = 1
 ) (
   input             clk_i,
   input             rst_ni,
@@ -74,7 +76,8 @@ module prim_alert_receiver
   );
 
   prim_diff_decode #(
-    .AsyncOn(AsyncOn)
+    .AsyncOn(AsyncOn),
+    .SkewCycles(SkewCycles)
   ) u_decode_alert (
     .clk_i,
     .rst_ni,
@@ -305,13 +308,13 @@ module prim_alert_receiver
         !(state_q inside {InitReq, InitAckWait}) &&
         mubi4_test_false_loose(init_trig_i)
         |->
-        ##[0:1] integ_fail_o)
+        ##[0:SkewCycles] integ_fail_o)
     `ASSERT(PingResponse1_A,
         ##1 $rose(alert_tx_i.alert_p) &&
         (alert_tx_i.alert_p ^ alert_tx_i.alert_n) ##2
         state_q == Idle && ping_pending_q
         |->
-        ##[0:1] ping_ok_o,
+        ##[0:SkewCycles] ping_ok_o,
         clk_i, !rst_ni || integ_fail_o || mubi4_test_true_strict(init_trig_i))
     // alert
     `ASSERT(Alert_A,
@@ -320,7 +323,7 @@ module prim_alert_receiver
         state_q == Idle &&
         !ping_pending_q
         |->
-        ##[0:1] alert_o,
+        ##[0:SkewCycles] alert_o,
         clk_i, !rst_ni || integ_fail_o || mubi4_test_true_strict(init_trig_i))
   end else begin : gen_sync_assert
     // signal integrity check propagation

--- a/hw/ip/prim/rtl/prim_alert_sender.sv
+++ b/hw/ip/prim/rtl/prim_alert_sender.sv
@@ -46,6 +46,8 @@ module prim_alert_sender
 #(
   // enables additional synchronization logic
   parameter bit AsyncOn = 1'b1,
+  // Number of cycles a differential skew is tolerated on the differential ack/ping signal.
+  parameter int unsigned SkewCycles = 1,
   // alert sender will latch the incoming alert event permanently and
   // keep on sending alert events until the next reset.
   parameter bit IsFatal = 1'b0
@@ -82,7 +84,8 @@ module prim_alert_sender
   );
 
   prim_diff_decode #(
-    .AsyncOn(AsyncOn)
+    .AsyncOn(AsyncOn),
+    .SkewCycles(SkewCycles)
   ) u_decode_ping (
     .clk_i,
     .rst_ni,
@@ -108,7 +111,8 @@ module prim_alert_sender
   );
 
   prim_diff_decode #(
-    .AsyncOn(AsyncOn)
+    .AsyncOn(AsyncOn),
+    .SkewCycles(SkewCycles)
   ) u_decode_ack (
     .clk_i,
     .rst_ni,
@@ -309,18 +313,20 @@ module prim_alert_sender
     // check propagation of sigint issues to output within three cycles, or four due to CDC
     // shift sequence to the right to avoid reset effects.
     `ASSERT(SigIntPing_A, ##1 PingSigInt_S |->
-        ##[3:4] alert_tx_o.alert_p == alert_tx_o.alert_n)
+        ##[SkewCycles+2:SkewCycles+3] alert_tx_o.alert_p == alert_tx_o.alert_n)
     `ASSERT(SigIntAck_A, ##1 AckSigInt_S |->
-        ##[3:4] alert_tx_o.alert_p == alert_tx_o.alert_n)
+        ##[SkewCycles+2:SkewCycles+3] alert_tx_o.alert_p == alert_tx_o.alert_n)
   `endif
 
     // Test in-band FSM reset request (via signal integrity error)
-    `ASSERT(InBandInitFsm_A, PingSigInt_S or AckSigInt_S |-> ##[3:4] state_q == Idle)
-    `ASSERT(InBandInitPing_A, PingSigInt_S or AckSigInt_S |-> ##[3:4] !ping_set_q)
+    `ASSERT(InBandInitFsm_A, PingSigInt_S or AckSigInt_S |->
+        ##[SkewCycles+2:SkewCycles+3] state_q == Idle)
+    `ASSERT(InBandInitPing_A, PingSigInt_S or AckSigInt_S |->
+        ##[SkewCycles+2:SkewCycles+3] !ping_set_q)
     // output must be driven diff unless sigint issue detected
     `ASSERT(DiffEncoding_A, (alert_rx_i.ack_p ^ alert_rx_i.ack_n) &&
         (alert_rx_i.ping_p ^ alert_rx_i.ping_n) |->
-        ##[3:5] alert_tx_o.alert_p ^ alert_tx_o.alert_n)
+        ##[SkewCycles+2:SkewCycles+4] alert_tx_o.alert_p ^ alert_tx_o.alert_n)
 
     // handshakes can take indefinite time if blocked due to sigint on outgoing
     // lines (which is not visible here). thus, we only check whether the

--- a/hw/ip/prim/rtl/prim_alert_to_diff.sv
+++ b/hw/ip/prim/rtl/prim_alert_to_diff.sv
@@ -14,7 +14,9 @@
 
 module prim_alert_to_diff #(
   // AsyncOn: Enables additional synchronization logic within the alert receiver.
-  parameter bit AsyncOn = 1'b0
+  parameter bit AsyncOn = 1'b0,
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned SkewCycles = 1
 ) (
   input logic                       clk_i,
   input logic                       rst_ni,
@@ -31,7 +33,8 @@ module prim_alert_to_diff #(
 
   // u_prim_alert_receiver: Instantiates the alert receiver module.
   prim_alert_receiver #(
-    .AsyncOn(AsyncOn)
+    .AsyncOn(AsyncOn),
+    .SkewCycles(SkewCycles)
   ) u_prim_alert_receiver (
     .clk_i,
     .rst_ni,

--- a/hw/ip/prim/rtl/prim_diff_decode.sv
+++ b/hw/ip/prim/rtl/prim_diff_decode.sv
@@ -19,7 +19,13 @@
 
 module prim_diff_decode #(
   // enables additional synchronization logic
-  parameter bit AsyncOn = 1'b0
+  parameter bit AsyncOn = 1'b0,
+  // Number of cycles a differential skew is tolerated before a signal integrity issue is flagged.
+  // Only has an effect if AsyncOn = 1
+  // 0 means no skew is tolerated (any mismatch is an immediate signal integrity error).
+  // 1 means a one-cycle skew is tolerated.
+  // Values larger than 1 are also supported.
+  parameter int unsigned SkewCycles = 1
 ) (
   input        clk_i,
   input        rst_ni,
@@ -44,12 +50,16 @@ module prim_diff_decode #(
   ///////////////////////////////////////////////////////////////
   if (AsyncOn) begin : gen_async
 
-    typedef enum logic [1:0] {IsStd, IsSkewed, SigInt} state_e;
+    typedef enum logic [1:0] {IsStd, IsSkewing, SigInt} state_e;
     state_e state_d, state_q;
     logic diff_p_edge, diff_n_edge, diff_check_ok, level;
 
     // 2 sync regs, one reg for edge detection
     logic diff_pq, diff_nq, diff_pd, diff_nd;
+
+    // Counter for skew cycles tolerated before flagging an issue
+    // The width needs to accommodate SkewCycles + 1 to count up to SkewCycles.
+    logic [prim_util_pkg::vbits(SkewCycles + 1)-1:0] skew_cnt_d, skew_cnt_q;
 
     prim_flop_2sync #(
       .Width(1),
@@ -87,7 +97,7 @@ module prim_diff_decode #(
 
     // sigint detection is a bit more involved in async case since
     // we might have skew on the diff pair, which can result in a
-    // one cycle sampling delay between the two wires
+    // N cycle sampling delay between the two wires
     // so we need a simple pattern matcher
     // the following waves are legal
     // clk    |   |   |   |   |   |   |   |
@@ -100,25 +110,24 @@ module prim_diff_decode #(
     //   _______                     ________
     // n        \_______ ... _______/
     //
-    // i.e., level changes may be off by one cycle - which is permissible
-    // as long as this condition is only one cycle long.
+    // i.e., level changes may be off by N cycle - which is permissible
+    // as long as this condition is only N cycle long.
 
 
     always_comb begin : p_diff_fsm
       // default
-      state_d  = state_q;
-      level_d  = level_q;
-      rise_o   = 1'b0;
-      fall_o   = 1'b0;
-      sigint_o = 1'b0;
+      state_d    = state_q;
+      level_d    = level_q;
+      skew_cnt_d = skew_cnt_q;
+      rise_o     = 1'b0;
+      fall_o     = 1'b0;
+      sigint_o   = 1'b0;
 
       unique case (state_q)
         // we remain here as long as
         // the diff pair is correctly encoded
         IsStd: begin
-          if (!diff_check_ok)
-            state_d = IsSkewed;
-          else begin
+          if (diff_check_ok) begin
             level_d = level;
             if (diff_p_edge && diff_n_edge) begin
               if (level) begin
@@ -127,27 +136,50 @@ module prim_diff_decode #(
                 fall_o = 1'b1;
               end
             end
+          end else begin
+            if (SkewCycles == 0) begin
+              // If no skew is tolerated, immediate signal integrity error
+              state_d  = SigInt;
+              sigint_o = 1'b1;
+            end else begin
+              // Mismatch with an edge: likely start of a tolerated skew
+              state_d    = IsSkewing;
+              skew_cnt_d = 1;
+            end
           end
         end
         // diff pair must be correctly encoded, otherwise we got a sigint
-        IsSkewed: begin
+        IsSkewing: begin
           if (diff_check_ok) begin
-            state_d = IsStd;
-            level_d = level;
+            state_d    = IsStd;
+            level_d    = level;
+            // Reset the skew counter
+            skew_cnt_d = '0;
+            // Assert event that was delayed due to skew resolution
             if (level) rise_o = 1'b1;
             else       fall_o = 1'b1;
           end else begin
-            state_d  = SigInt;
-            sigint_o = 1'b1;
+            if (skew_cnt_q < SkewCycles) begin
+              // Still within tolerated skew cycles
+              skew_cnt_d = skew_cnt_q + 1;
+            end else begin
+              // Maximum skew cycles exceeded, raise an integrity issue
+              state_d    = SigInt;
+              sigint_o   = 1'b1;
+              skew_cnt_d = '0;
+            end
           end
         end
-        // Signal integrity issue detected, remain here
-        // until resolved
+        // Signal integrity issue detected, remain here until resolved
         SigInt: begin
           sigint_o = 1'b1;
           if (diff_check_ok) begin
             state_d  = IsStd;
             sigint_o = 1'b0;
+            level_d  = level;
+            // Assert any event that was pending while in SigInt
+            if (level) rise_o = 1'b1;
+            else       fall_o = 1'b1;
           end
         end
         default : ;
@@ -156,15 +188,17 @@ module prim_diff_decode #(
 
     always_ff @(posedge clk_i or negedge rst_ni) begin : p_sync_reg
       if (!rst_ni) begin
-        state_q  <= IsStd;
-        diff_pq  <= 1'b0;
-        diff_nq  <= 1'b1;
-        level_q  <= 1'b0;
+        state_q    <= IsStd;
+        diff_pq    <= 1'b0;
+        diff_nq    <= 1'b1;
+        level_q    <= 1'b0;
+        skew_cnt_q <= '0;
       end else begin
-        state_q  <= state_d;
-        diff_pq  <= diff_pd;
-        diff_nq  <= diff_nd;
-        level_q  <= level_d;
+        state_q    <= state_d;
+        diff_pq    <= diff_pd;
+        diff_nq    <= diff_nd;
+        level_q    <= level_d;
+        skew_cnt_q <= skew_cnt_d;
       end
     end
 
@@ -224,48 +258,59 @@ module prim_diff_decode #(
     // assertions for asynchronous case
 `ifdef INC_ASSERT
   `ifndef FPV_ALERT_NO_SIGINT_ERR
-    // correctly detect sigint issue (only one transition cycle of permissible due to skew)
-    `ASSERT(SigintCheck0_A, gen_async.diff_pd == gen_async.diff_nd [*2] |-> sigint_o)
-    // the synchronizer adds 2 cycles of latency with respect to input signals.
-    `ASSERT(SigintCheck1_A,
-        ##1 (gen_async.diff_pd ^ gen_async.diff_nd) &&
-        $stable(gen_async.diff_pd) && $stable(gen_async.diff_nd) ##1
-        $rose(gen_async.diff_pd) && $stable(gen_async.diff_nd) ##1
-        $stable(gen_async.diff_pd) && $fell(gen_async.diff_nd)
-        |-> rise_o)
-    `ASSERT(SigintCheck2_A,
-        ##1 (gen_async.diff_pd ^ gen_async.diff_nd) &&
-        $stable(gen_async.diff_pd) && $stable(gen_async.diff_nd) ##1
-        $fell(gen_async.diff_pd) && $stable(gen_async.diff_nd) ##1
-        $stable(gen_async.diff_pd) && $rose(gen_async.diff_nd)
-        |-> fall_o)
-    `ASSERT(SigintCheck3_A,
-        ##1 (gen_async.diff_pd ^ gen_async.diff_nd) &&
-        $stable(gen_async.diff_pd) && $stable(gen_async.diff_nd) ##1
-        $rose(gen_async.diff_nd) && $stable(gen_async.diff_pd) ##1
-        $stable(gen_async.diff_nd) && $fell(gen_async.diff_pd)
-        |-> fall_o)
-    `ASSERT(SigintCheck4_A,
-        ##1 (gen_async.diff_pd ^ gen_async.diff_nd) &&
-        $stable(gen_async.diff_pd) && $stable(gen_async.diff_nd) ##1
-        $fell(gen_async.diff_nd) && $stable(gen_async.diff_pd) ##1
-        $stable(gen_async.diff_nd) && $rose(gen_async.diff_pd)
-        |-> rise_o)
-  `endif
+    // Correctly detect signal integrity issue:
+    // If diff_pd and diff_nd are equal for (SkewCycles + 1) consecutive cycles, sigint_o must be
+    // asserted.
+    `ASSERT(SigintCheck0_A,
+            gen_async.diff_pd == gen_async.diff_nd [* (SkewCycles + 1)] |-> sigint_o)
 
-    // correctly detect edges
+    // The following assertions (SigintCheck1_A to SigintCheck4_A) describe specific
+    // 1-cycle skew patterns that should lead to an edge. These are highly
+    // specific to SkewCycles = 1. Therefore, they are only included when SkewCycles is 1.
+    // the synchronizer adds 2 cycles of latency with respect to input signals.
+    if (SkewCycles == 1) begin : gen_specific_skew_asserts
+      `ASSERT(SigintCheck1_A,
+          ##1 (gen_async.diff_pd ^ gen_async.diff_nd) &&
+          $stable(gen_async.diff_pd) && $stable(gen_async.diff_nd) ##1
+          $rose(gen_async.diff_pd) && $stable(gen_async.diff_nd) ##1
+          $stable(gen_async.diff_pd) && $fell(gen_async.diff_nd)
+          |-> rise_o)
+      `ASSERT(SigintCheck2_A,
+          ##1 (gen_async.diff_pd ^ gen_async.diff_nd) &&
+          $stable(gen_async.diff_pd) && $stable(gen_async.diff_nd) ##1
+          $fell(gen_async.diff_pd) && $stable(gen_async.diff_nd) ##1
+          $stable(gen_async.diff_pd) && $rose(gen_async.diff_nd)
+          |-> fall_o)
+      `ASSERT(SigintCheck3_A,
+          ##1 (gen_async.diff_pd ^ gen_async.diff_nd) &&
+          $stable(gen_async.diff_pd) && $stable(gen_async.diff_nd) ##1
+          $rose(gen_async.diff_nd) && $stable(gen_async.diff_pd) ##1
+          $stable(gen_async.diff_nd) && $fell(gen_async.diff_pd)
+          |-> fall_o)
+      `ASSERT(SigintCheck4_A,
+          ##1 (gen_async.diff_pd ^ gen_async.diff_nd) &&
+          $stable(gen_async.diff_pd) && $stable(gen_async.diff_nd) ##1
+          $fell(gen_async.diff_nd) && $stable(gen_async.diff_pd) ##1
+          $stable(gen_async.diff_nd) && $rose(gen_async.diff_pd)
+          |-> rise_o)
+    end
+    `endif
+    // Correctly detect edges: an event should be asserted within SkewCycles cycles after a valid
+    // transition
     `ASSERT(RiseCheck_A,
         !sigint_o ##1 $rose(gen_async.diff_pd) && (gen_async.diff_pd ^ gen_async.diff_nd) |->
-        ##[0:1] rise_o,  clk_i, !rst_ni || sigint_o)
+        ##[0:SkewCycles] rise_o,  clk_i, !rst_ni || sigint_o)
     `ASSERT(FallCheck_A,
         !sigint_o ##1 $fell(gen_async.diff_pd) && (gen_async.diff_pd ^ gen_async.diff_nd) |->
-        ##[0:1] fall_o,  clk_i, !rst_ni || sigint_o)
+        ##[0:SkewCycles] fall_o,  clk_i, !rst_ni || sigint_o)
     `ASSERT(EventCheck_A,
         !sigint_o ##1 $changed(gen_async.diff_pd) && (gen_async.diff_pd ^ gen_async.diff_nd) |->
-        ##[0:1] event_o, clk_i, !rst_ni || sigint_o)
-    // correctly detect level
+        ##[0:SkewCycles] event_o, clk_i, !rst_ni || sigint_o)
+    // Correctly detect level: the output level should match diff_pd once the differential pair is
+    // stable
     `ASSERT(LevelCheck0_A,
-        !sigint_o && (gen_async.diff_pd ^ gen_async.diff_nd) [*2] |->
+        // Stable for SkewCycles + 1 cycles
+        !sigint_o && (gen_async.diff_pd ^ gen_async.diff_nd) [* (SkewCycles + 1)] |->
         gen_async.diff_pd == level_o,
         clk_i, !rst_ni || sigint_o)
 `endif

--- a/hw/ip/prim/rtl/prim_diff_to_alert.sv
+++ b/hw/ip/prim/rtl/prim_diff_to_alert.sv
@@ -8,6 +8,8 @@
 module prim_diff_to_alert #(
   // AsyncOn: Enables additional synchronization logic within the alert receiver.
   parameter bit AsyncOn = 1'b1,
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned SkewCycles = 1,
   // Alert sender will latch the incoming alert event permanently and
   // keep on sending alert events until the next reset.
   parameter bit IsFatal = 1'b1
@@ -53,6 +55,7 @@ module prim_diff_to_alert #(
 
   prim_alert_sender #(
     .AsyncOn(AsyncOn),
+    .SkewCycles(SkewCycles),
     .IsFatal(IsFatal)
   ) u_prim_alert_sender (
     .clk_i,

--- a/hw/ip/prim/rtl/prim_esc_receiver.sv
+++ b/hw/ip/prim/rtl/prim_esc_receiver.sv
@@ -29,6 +29,9 @@ module prim_esc_receiver
   // when this primitive is instantiated.
   parameter int PING_CNT_DW = 16,
 
+  // Number of cycles a differential skew is tolerated on the differential escalation signal.
+  parameter int unsigned SkewCycles = 1,
+
   // This counter monitors incoming ping requests and auto-escalates if the alert handler
   // ceases to send them regularly. The maximum number of cycles between subsequent ping requests
   // is N_ESC_SEV x (2 x 2 x 2**PING_CNT_DW), see also implementation of the ping timer
@@ -73,7 +76,8 @@ module prim_esc_receiver
   );
 
   prim_diff_decode #(
-    .AsyncOn(1'b0)
+    .AsyncOn(1'b0),
+    .SkewCycles(SkewCycles)
   ) u_decode_esc (
     .clk_i,
     .rst_ni,

--- a/hw/ip/prim/rtl/prim_esc_sender.sv
+++ b/hw/ip/prim/rtl/prim_esc_sender.sv
@@ -23,7 +23,10 @@
 
 module prim_esc_sender
   import prim_esc_pkg::*;
-(
+#(
+  // Number of cycles a differential skew is tolerated on the differential response signal.
+  parameter int unsigned SkewCycles = 1
+) (
   input           clk_i,
   input           rst_ni,
   // this triggers a ping test. keep asserted until ping_ok_o is pulsed high.
@@ -56,7 +59,8 @@ module prim_esc_sender
   );
 
   prim_diff_decode #(
-    .AsyncOn(1'b0)
+    .AsyncOn(1'b0),
+    .SkewCycles(SkewCycles)
   ) u_decode_resp (
     .clk_i,
     .rst_ni,

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -10,6 +10,8 @@ module rom_ctrl
 #(
   parameter                       BootRomInitFile = "",
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned          AlertSkewCycles = 1,
   parameter bit [63:0]            RndCnstScrNonce = '0,
   parameter bit [127:0]           RndCnstScrKey = '0,
   // ROM size in bytes
@@ -444,6 +446,7 @@ module rom_ctrl
   for (genvar i = 0; i < NumAlerts; i++) begin: gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(i == AlertFatal)
     ) u_alert_sender (
       .clk_i,

--- a/hw/ip/rv_dm/rtl/rv_dm.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm.sv
@@ -16,6 +16,8 @@ module rv_dm
   import rv_dm_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]           AlertAsyncOn                      = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned                    AlertSkewCycles                   = 1,
   parameter logic [31:0]                    IdcodeValue                       = 32'h 0000_0001,
   parameter bit                             UseDmiInterface                   = 1'b0,
   parameter bit                             SecVolatileRawUnlockEn            = 0,
@@ -162,6 +164,7 @@ module rv_dm
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip/rv_timer/rtl/rv_timer.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer.sv
@@ -9,6 +9,8 @@
 module rv_timer import rv_timer_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned                    AlertSkewCycles           = 1,
   parameter bit                             EnableRacl                = 1'b0,
   parameter bit                             RaclErrorRsp              = EnableRacl,
   parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[NumRegs] = '{NumRegs{0}}
@@ -151,6 +153,7 @@ module rv_timer import rv_timer_reg_pkg::*;
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl.sv
+++ b/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl.sv
@@ -10,7 +10,9 @@ module soc_dbg_ctrl
   import soc_dbg_ctrl_pkg::*;
   import soc_dbg_ctrl_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1
 ) (
   input logic                                       clk_i,
   input logic                                       rst_ni,
@@ -65,6 +67,7 @@ module soc_dbg_ctrl
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(IsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -11,6 +11,8 @@ module spi_device
   import spi_device_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn         = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned          AlertSkewCycles      = 1,
   parameter spi_device_pkg::sram_type_e SramType       = spi_device_pkg::DefaultSramType,
   parameter bit                             EnableRacl                    = 1'b0,
   parameter bit                             RaclErrorRsp                  = EnableRacl,
@@ -1940,6 +1942,7 @@ module spi_device
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -12,6 +12,8 @@ module spi_host
   import spi_host_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned                    AlertSkewCycles           = 1,
   parameter int unsigned                    NumCS                     = 1,
   parameter bit                             EnableRacl                = 1'b0,
   parameter bit                             RaclErrorRsp              = EnableRacl,
@@ -112,6 +114,7 @@ module spi_host
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -17,6 +17,8 @@ module sram_ctrl
   parameter int NumRamInst                                 = 1,
   // Enable asynchronous transitions on alerts.
   parameter logic [NumAlerts-1:0] AlertAsyncOn             = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned          AlertSkewCycles          = 1,
   // Enables the execute from SRAM feature.
   parameter bit InstrExec                                  = 1,
   // Number of PRINCE half rounds for the SRAM scrambling feature, can be [1..5].
@@ -204,6 +206,7 @@ module sram_ctrl
 
   prim_alert_sender #(
     .AsyncOn(AlertAsyncOn[0]),
+    .SkewCycles(AlertSkewCycles),
     .IsFatal(1)
   ) u_prim_alert_sender_parity (
     .clk_i,

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl.sv
@@ -10,7 +10,9 @@ module sysrst_ctrl
   import sysrst_ctrl_pkg::*;
   import sysrst_ctrl_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1
 ) (
   input  clk_i,  // Always-on 24MHz clock(config)
   input  clk_aon_i,  // Always-on 200KHz clock(logic)
@@ -70,6 +72,7 @@ module sysrst_ctrl
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip/uart/rtl/uart.sv
+++ b/hw/ip/uart/rtl/uart.sv
@@ -10,6 +10,8 @@ module uart
     import uart_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned                    AlertSkewCycles           = 1,
   parameter bit                             EnableRacl                = 1'b0,
   parameter bit                             RaclErrorRsp              = EnableRacl,
   parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[NumRegs] = '{NumRegs{0}}
@@ -100,6 +102,7 @@ module uart
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -15,6 +15,8 @@ module usbdev
 #(
   parameter bit Stub = 1'b0,
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1,
   // Max time (in microseconds) from rx_enable_o high to the
   // external differential receiver outputting valid data (when
   // configured to use one).
@@ -931,6 +933,7 @@ module usbdev
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
+++ b/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
@@ -7,6 +7,8 @@ module ${module_instance_name}
   import ${module_instance_name}_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned                    AlertSkewCycles           = 1,
   parameter bit                             RangeCheckErrorRsp        = 1'b1,
   parameter bit                             EnableRacl                = 1'b0,
   parameter bit                             RaclErrorRsp              = EnableRacl,
@@ -82,6 +84,7 @@ module ${module_instance_name}
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(IsFatal[i])
     ) u_prim_alert_sender (
       .clk_i         ( clk_i         ),

--- a/hw/ip_templates/alert_handler/rtl/alert_handler.sv.tpl
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler.sv.tpl
@@ -17,7 +17,7 @@ module ${module_instance_name}
   parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[${module_instance_name}_reg_pkg::NumRegs] = 
     '{${module_instance_name}_reg_pkg::NumRegs{0}},
 % endif
-  // Number of cycles a differential skew is tolerated on the alert signal
+  // Number of cycles a differential skew is tolerated on the alert and escalation signal
   parameter int unsigned AlertSkewCycles = 1,
   parameter int EscNumSeverities = ${n_esc_sev},
   parameter int EscPingCountWidth = ${ping_cnt_dw},
@@ -318,7 +318,9 @@ module ${module_instance_name}
     // put this RTL label inside that module due to the way our countermeasure annotation check
     // script discovers the RTL files. The label is thus put here. Please refer to
     // prim_esc_receiver.sv for the actual implementation of this mechanism.
-    prim_esc_sender u_esc_sender (
+    prim_esc_sender # (
+      .SkewCycles(AlertSkewCycles)
+    ) u_esc_sender (
       .clk_i,
       .rst_ni,
       .ping_req_i   ( esc_ping_req[k]  ),

--- a/hw/ip_templates/alert_handler/rtl/alert_handler.sv.tpl
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler.sv.tpl
@@ -17,6 +17,8 @@ module ${module_instance_name}
   parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[${module_instance_name}_reg_pkg::NumRegs] = 
     '{${module_instance_name}_reg_pkg::NumRegs{0}},
 % endif
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1,
   parameter int EscNumSeverities = ${n_esc_sev},
   parameter int EscPingCountWidth = ${ping_cnt_dw},
   // Compile time random constants, to be overriden by topgen.
@@ -210,7 +212,8 @@ module ${module_instance_name}
   // Target interrupt notification
   for (genvar k = 0 ; k < NAlerts ; k++) begin : gen_alerts
     prim_alert_receiver #(
-      .AsyncOn(AsyncOn[k])
+      .AsyncOn(AsyncOn[k]),
+      .SkewCycles(AlertSkewCycles)
     ) u_alert_receiver (
       .clk_i,
       .rst_ni,

--- a/hw/ip_templates/clkmgr/rtl/clkmgr.sv.tpl
+++ b/hw/ip_templates/clkmgr/rtl/clkmgr.sv.tpl
@@ -22,7 +22,9 @@ rg_srcs = get_rg_srcs(typed_clocks)
     import lc_ctrl_pkg::lc_tx_t;
     import prim_mubi_pkg::mubi4_t;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1
 ) (
   // Primary module control clocks and resets
   // This drives the register interface
@@ -246,6 +248,7 @@ rg_srcs = get_rg_srcs(typed_clocks)
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(AlertFatal[i])
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip_templates/flash_ctrl/rtl/flash_ctrl.sv.tpl
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_ctrl.sv.tpl
@@ -13,6 +13,8 @@ module flash_ctrl
   import flash_ctrl_top_specific_pkg::*;  import flash_ctrl_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn    = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned          AlertSkewCycles = 1,
   parameter flash_key_t           RndCnstAddrKey  = RndCnstAddrKeyDefault,
   parameter flash_key_t           RndCnstDataKey  = RndCnstDataKeyDefault,
   parameter all_seeds_t           RndCnstAllSeeds = RndCnstAllSeedsDefault,
@@ -982,6 +984,7 @@ module flash_ctrl
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(IsFatal[i])
     ) u_alert_sender (
       .clk_i,

--- a/hw/ip_templates/gpio/rtl/gpio.sv.tpl
+++ b/hw/ip_templates/gpio/rtl/gpio.sv.tpl
@@ -11,6 +11,8 @@ module ${module_instance_name}
   import ${module_instance_name}_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned                    AlertSkewCycles           = 1,
   parameter bit                             GpioAsHwStrapsEn          = 1,
   // This parameter instantiates 2-stage synchronizers on all GPIO inputs.
   parameter bit                             GpioAsyncOn               = 1,
@@ -376,6 +378,7 @@ module ${module_instance_name}
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip_templates/otp_ctrl/rtl/otp_ctrl.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/rtl/otp_ctrl.sv.tpl
@@ -22,6 +22,8 @@ module otp_ctrl
 #(
   // Enable asynchronous transitions on alerts.
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1,
   // Compile time random constants, to be overridden by topgen.
   parameter lfsr_seed_t RndCnstLfsrSeed = RndCnstLfsrSeedDefault,
   parameter lfsr_perm_t RndCnstLfsrPerm = RndCnstLfsrPermDefault,
@@ -599,6 +601,7 @@ end
   for (genvar k = 0; k < NumAlerts; k++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[k]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(AlertIsFatal[k])
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip_templates/pinmux/rtl/pinmux.sv.tpl
+++ b/hw/ip_templates/pinmux/rtl/pinmux.sv.tpl
@@ -15,10 +15,12 @@ module pinmux
   // Taget-specific pinmux configuration passed down from the
   // target-specific top-level.
   parameter target_cfg_t TargetCfg = DefaultTargetCfg,
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}${"," if enable_strap_sampling else ""}
 % if enable_strap_sampling:
-  parameter bit SecVolatileRawUnlockEn = 0
+  parameter bit SecVolatileRawUnlockEn = 0,
 % endif
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1
 ) (
   input                            clk_i,
   input                            rst_ni,
@@ -148,6 +150,7 @@ module pinmux
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip_templates/pwm/rtl/pwm.sv.tpl
+++ b/hw/ip_templates/pwm/rtl/pwm.sv.tpl
@@ -8,6 +8,8 @@ module ${module_instance_name}
   import ${module_instance_name}_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned                    AlertSkewCycles           = 1,
   parameter bit                             EnableRacl                = 1'b0,
   parameter bit                             RaclErrorRsp              = EnableRacl,
   parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[NumRegs] = '{NumRegs{0}},
@@ -63,6 +65,7 @@ module ${module_instance_name}
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip_templates/pwrmgr/rtl/pwrmgr.sv.tpl
+++ b/hw/ip_templates/pwrmgr/rtl/pwrmgr.sv.tpl
@@ -13,6 +13,8 @@ module pwrmgr
   import pwrmgr_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1,
   parameter int unsigned EscNumSeverities = 4,
   parameter int unsigned EscPingCountWidth = 16
 ) (
@@ -396,6 +398,7 @@ module pwrmgr
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i         ( clk_lc        ),

--- a/hw/ip_templates/pwrmgr/rtl/pwrmgr.sv.tpl
+++ b/hw/ip_templates/pwrmgr/rtl/pwrmgr.sv.tpl
@@ -13,7 +13,7 @@ module pwrmgr
   import pwrmgr_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
-  // Number of cycles a differential skew is tolerated on the alert signal
+  // Number of cycles a differential skew is tolerated on the alert and escalation signal
   parameter int unsigned AlertSkewCycles = 1,
   parameter int unsigned EscNumSeverities = 4,
   parameter int unsigned EscPingCountWidth = 16
@@ -142,7 +142,8 @@ module pwrmgr
   logic esc_rst_req_d, esc_rst_req_q;
   prim_esc_receiver #(
     .N_ESC_SEV   (EscNumSeverities),
-    .PING_CNT_DW (EscPingCountWidth)
+    .PING_CNT_DW (EscPingCountWidth),
+    .SkewCycles  (AlertSkewCycles)
   ) u_esc_rx (
     .clk_i(clk_esc),
     .rst_ni(rst_esc_n),

--- a/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
+++ b/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
@@ -4,6 +4,8 @@
 
 module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn              = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned          AlertSkewCycles           = 1,
   parameter int unsigned          NumSubscribingIps         = 1,
   parameter int unsigned          NumExternalSubscribingIps = 1,
   parameter bit                   RaclErrorRsp              = 1'b1
@@ -94,8 +96,9 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
 
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
-      .AsyncOn ( AlertAsyncOn[i] ),
-      .IsFatal ( IsFatal[i]      )
+      .AsyncOn    ( AlertAsyncOn[i] ),
+      .SkewCycles ( AlertSkewCycles ),
+      .IsFatal    ( IsFatal[i]      )
     ) u_prim_alert_sender (
       .clk_i         ( clk_i         ),
       .rst_ni        ( rst_ni        ),

--- a/hw/ip_templates/rstmgr/rtl/rstmgr.sv.tpl
+++ b/hw/ip_templates/rstmgr/rtl/rstmgr.sv.tpl
@@ -17,6 +17,8 @@ module rstmgr
   import prim_mubi_pkg::mubi4_t;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1,
   parameter bit SecCheck = 1,
   parameter int SecMaxSyncDelay = 2
 ) (
@@ -221,6 +223,7 @@ module rstmgr
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex.sv.tpl
+++ b/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex.sv.tpl
@@ -13,7 +13,7 @@ module ${module_instance_name}
   import ${module_instance_name}_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]   AlertAsyncOn     = {NumAlerts{1'b1}},
-  // Number of cycles a differential skew is tolerated on the alert signal
+  // Number of cycles a differential skew is tolerated on the alert and escalation signal
   parameter int unsigned            AlertSkewCycles  = 1,
   parameter bit                     PMPEnable        = 1'b1,
   parameter int unsigned            PMPGranularity   = 0,
@@ -258,7 +258,8 @@ module ${module_instance_name}
   logic esc_irq_nm;
   prim_esc_receiver #(
     .N_ESC_SEV   (NEscalationSeverities),
-    .PING_CNT_DW (WidthPingCounter)
+    .PING_CNT_DW (WidthPingCounter),
+    .SkewCycles  (AlertSkewCycles)
   ) u_prim_esc_receiver (
     .clk_i     ( clk_esc_i  ),
     .rst_ni    ( rst_esc_ni ),

--- a/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex.sv.tpl
+++ b/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex.sv.tpl
@@ -13,6 +13,8 @@ module ${module_instance_name}
   import ${module_instance_name}_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]   AlertAsyncOn     = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned            AlertSkewCycles  = 1,
   parameter bit                     PMPEnable        = 1'b1,
   parameter int unsigned            PMPGranularity   = 0,
   parameter int unsigned            PMPNumRegions    = 16,
@@ -827,6 +829,7 @@ module ${module_instance_name}
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[0]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(AlertFatal[i])
     ) u_alert_sender (
       .clk_i,

--- a/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex_peri.sv.tpl
+++ b/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex_peri.sv.tpl
@@ -11,7 +11,9 @@ module ${module_instance_name}_peri
   import ${module_instance_name}_peri_pkg::*;
   import ${module_instance_name}_peri_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1
 ) (
   input clk_i,
   input rst_ni,
@@ -109,6 +111,7 @@ module ${module_instance_name}_peri
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[0]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(AlertFatal[i])
     ) u_alert_sender (
       .clk_i,

--- a/hw/ip_templates/rv_plic/rtl/rv_plic.sv.tpl
+++ b/hw/ip_templates/rv_plic/rtl/rv_plic.sv.tpl
@@ -17,7 +17,9 @@
 `include "prim_assert.sv"
 
 module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn  = {NumAlerts{1'b1}},
+  parameter logic [NumAlerts-1:0] AlertAsyncOn    = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned          AlertSkewCycles = 1,
   // OpenTitan IP standardizes on level triggered interrupts,
   // hence LevelEdgeTrig is set to all-zeroes by default.
   // Note that in case of edge-triggered interrupts, CDC handling is not
@@ -222,6 +224,7 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/top_darjeeling/ip/soc_proxy/rtl/soc_proxy.sv
+++ b/hw/top_darjeeling/ip/soc_proxy/rtl/soc_proxy.sv
@@ -10,7 +10,9 @@ module soc_proxy
   import soc_proxy_reg_pkg::*;
   import soc_proxy_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1
 ) (
   input  logic clk_i,
   input  logic rst_ni,
@@ -343,6 +345,7 @@ module soc_proxy
   // Alert sender for integrity alerts
   prim_alert_sender #(
     .AsyncOn(AlertAsyncOn[FatalAlertIntg]),
+    .SkewCycles(AlertSkewCycles),
     .IsFatal(1)
   ) u_prim_fatal_alert_intg_sender (
     .clk_i,
@@ -359,6 +362,7 @@ module soc_proxy
   for (genvar i = 0; i < NumFatalExternalAlerts; i++) begin : gen_fatal_alert_sender
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[FatalAlertExternal0 + i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,
@@ -376,6 +380,7 @@ module soc_proxy
   for (genvar i = 0; i < NumRecovExternalAlerts; i++) begin : gen_recov_alert_sender
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[RecovAlertExternal0 + i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b0)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check.sv
@@ -7,6 +7,8 @@ module ac_range_check
   import ac_range_check_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned                    AlertSkewCycles           = 1,
   parameter bit                             RangeCheckErrorRsp        = 1'b1,
   parameter bit                             EnableRacl                = 1'b0,
   parameter bit                             RaclErrorRsp              = EnableRacl,
@@ -82,6 +84,7 @@ module ac_range_check
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(IsFatal[i])
     ) u_prim_alert_sender (
       .clk_i         ( clk_i         ),

--- a/hw/top_darjeeling/ip_autogen/alert_handler/rtl/alert_handler.sv
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/rtl/alert_handler.sv
@@ -11,7 +11,7 @@ module alert_handler
   import prim_alert_pkg::*;
   import prim_esc_pkg::*;
 #(
-  // Number of cycles a differential skew is tolerated on the alert signal
+  // Number of cycles a differential skew is tolerated on the alert and escalation signal
   parameter int unsigned AlertSkewCycles = 1,
   parameter int EscNumSeverities = 4,
   parameter int EscPingCountWidth = 16,
@@ -295,7 +295,9 @@ module alert_handler
     // put this RTL label inside that module due to the way our countermeasure annotation check
     // script discovers the RTL files. The label is thus put here. Please refer to
     // prim_esc_receiver.sv for the actual implementation of this mechanism.
-    prim_esc_sender u_esc_sender (
+    prim_esc_sender # (
+      .SkewCycles(AlertSkewCycles)
+    ) u_esc_sender (
       .clk_i,
       .rst_ni,
       .ping_req_i   ( esc_ping_req[k]  ),

--- a/hw/top_darjeeling/ip_autogen/alert_handler/rtl/alert_handler.sv
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/rtl/alert_handler.sv
@@ -11,6 +11,8 @@ module alert_handler
   import prim_alert_pkg::*;
   import prim_esc_pkg::*;
 #(
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1,
   parameter int EscNumSeverities = 4,
   parameter int EscPingCountWidth = 16,
   // Compile time random constants, to be overriden by topgen.
@@ -187,7 +189,8 @@ module alert_handler
   // Target interrupt notification
   for (genvar k = 0 ; k < NAlerts ; k++) begin : gen_alerts
     prim_alert_receiver #(
-      .AsyncOn(AsyncOn[k])
+      .AsyncOn(AsyncOn[k]),
+      .SkewCycles(AlertSkewCycles)
     ) u_alert_receiver (
       .clk_i,
       .rst_ni,

--- a/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr.sv
@@ -13,7 +13,9 @@
     import lc_ctrl_pkg::lc_tx_t;
     import prim_mubi_pkg::mubi4_t;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1
 ) (
   // Primary module control clocks and resets
   // This drives the register interface
@@ -264,6 +266,7 @@
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(AlertFatal[i])
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/top_darjeeling/ip_autogen/gpio/rtl/gpio.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/rtl/gpio.sv
@@ -11,6 +11,8 @@ module gpio
   import gpio_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned                    AlertSkewCycles           = 1,
   parameter bit                             GpioAsHwStrapsEn          = 1,
   // This parameter instantiates 2-stage synchronizers on all GPIO inputs.
   parameter bit                             GpioAsyncOn               = 1,
@@ -372,6 +374,7 @@ module gpio
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl.sv
@@ -22,6 +22,8 @@ module otp_ctrl
 #(
   // Enable asynchronous transitions on alerts.
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1,
   // Compile time random constants, to be overridden by topgen.
   parameter lfsr_seed_t RndCnstLfsrSeed = RndCnstLfsrSeedDefault,
   parameter lfsr_perm_t RndCnstLfsrPerm = RndCnstLfsrPermDefault,
@@ -595,6 +597,7 @@ end
   for (genvar k = 0; k < NumAlerts; k++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[k]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(AlertIsFatal[k])
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux.sv
+++ b/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux.sv
@@ -15,7 +15,9 @@ module pinmux
   // Taget-specific pinmux configuration passed down from the
   // target-specific top-level.
   parameter target_cfg_t TargetCfg = DefaultTargetCfg,
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1
 ) (
   input                            clk_i,
   input                            rst_ni,
@@ -90,6 +92,7 @@ module pinmux
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr.sv
@@ -12,6 +12,8 @@ module pwrmgr
   import pwrmgr_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1,
   parameter int unsigned EscNumSeverities = 4,
   parameter int unsigned EscPingCountWidth = 16
 ) (
@@ -381,6 +383,7 @@ module pwrmgr
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i         ( clk_lc        ),

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr.sv
@@ -12,7 +12,7 @@ module pwrmgr
   import pwrmgr_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
-  // Number of cycles a differential skew is tolerated on the alert signal
+  // Number of cycles a differential skew is tolerated on the alert and escalation signal
   parameter int unsigned AlertSkewCycles = 1,
   parameter int unsigned EscNumSeverities = 4,
   parameter int unsigned EscPingCountWidth = 16
@@ -139,7 +139,8 @@ module pwrmgr
   logic esc_rst_req_d, esc_rst_req_q;
   prim_esc_receiver #(
     .N_ESC_SEV   (EscNumSeverities),
-    .PING_CNT_DW (EscPingCountWidth)
+    .PING_CNT_DW (EscPingCountWidth),
+    .SkewCycles  (AlertSkewCycles)
   ) u_esc_rx (
     .clk_i(clk_esc),
     .rst_ni(rst_esc_n),

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv
@@ -4,6 +4,8 @@
 
 module racl_ctrl import racl_ctrl_reg_pkg::*; #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn              = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned          AlertSkewCycles           = 1,
   parameter int unsigned          NumSubscribingIps         = 1,
   parameter int unsigned          NumExternalSubscribingIps = 1,
   parameter bit                   RaclErrorRsp              = 1'b1
@@ -76,8 +78,9 @@ module racl_ctrl import racl_ctrl_reg_pkg::*; #(
 
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
-      .AsyncOn ( AlertAsyncOn[i] ),
-      .IsFatal ( IsFatal[i]      )
+      .AsyncOn    ( AlertAsyncOn[i] ),
+      .SkewCycles ( AlertSkewCycles ),
+      .IsFatal    ( IsFatal[i]      )
     ) u_prim_alert_sender (
       .clk_i         ( clk_i         ),
       .rst_ni        ( rst_ni        ),

--- a/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr.sv
@@ -14,6 +14,8 @@ module rstmgr
   import prim_mubi_pkg::mubi4_t;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1,
   parameter bit SecCheck = 1,
   parameter int SecMaxSyncDelay = 2
 ) (
@@ -217,6 +219,7 @@ module rstmgr
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -13,6 +13,8 @@ module rv_core_ibex
   import rv_core_ibex_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]   AlertAsyncOn     = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned            AlertSkewCycles  = 1,
   parameter bit                     PMPEnable        = 1'b1,
   parameter int unsigned            PMPGranularity   = 0,
   parameter int unsigned            PMPNumRegions    = 16,
@@ -802,6 +804,7 @@ module rv_core_ibex
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[0]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(AlertFatal[i])
     ) u_alert_sender (
       .clk_i,

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -13,7 +13,7 @@ module rv_core_ibex
   import rv_core_ibex_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]   AlertAsyncOn     = {NumAlerts{1'b1}},
-  // Number of cycles a differential skew is tolerated on the alert signal
+  // Number of cycles a differential skew is tolerated on the alert and escalation signal
   parameter int unsigned            AlertSkewCycles  = 1,
   parameter bit                     PMPEnable        = 1'b1,
   parameter int unsigned            PMPGranularity   = 0,
@@ -245,7 +245,8 @@ module rv_core_ibex
   logic esc_irq_nm;
   prim_esc_receiver #(
     .N_ESC_SEV   (NEscalationSeverities),
-    .PING_CNT_DW (WidthPingCounter)
+    .PING_CNT_DW (WidthPingCounter),
+    .SkewCycles  (AlertSkewCycles)
   ) u_prim_esc_receiver (
     .clk_i     ( clk_esc_i  ),
     .rst_ni    ( rst_esc_ni ),

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_peri.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_peri.sv
@@ -11,7 +11,9 @@ module rv_core_ibex_peri
   import rv_core_ibex_peri_pkg::*;
   import rv_core_ibex_peri_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1
 ) (
   input clk_i,
   input rst_ni,
@@ -109,6 +111,7 @@ module rv_core_ibex_peri
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[0]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(AlertFatal[i])
     ) u_alert_sender (
       .clk_i,

--- a/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic.sv
@@ -17,7 +17,9 @@
 `include "prim_assert.sv"
 
 module rv_plic import rv_plic_reg_pkg::*; #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn  = {NumAlerts{1'b1}},
+  parameter logic [NumAlerts-1:0] AlertAsyncOn    = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned          AlertSkewCycles = 1,
   // OpenTitan IP standardizes on level triggered interrupts,
   // hence LevelEdgeTrig is set to all-zeroes by default.
   // Note that in case of edge-triggered interrupts, CDC handling is not
@@ -364,6 +366,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -1018,7 +1018,8 @@ module top_darjeeling #(
 
 
   uart #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[0:0])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[0:0]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_uart0 (
 
       // Input
@@ -1055,6 +1056,7 @@ module top_darjeeling #(
   );
   gpio #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[1:1]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .GpioAsyncOn(GpioGpioAsyncOn),
     .GpioAsHwStrapsEn(GpioGpioAsHwStrapsEn)
   ) u_gpio (
@@ -1086,6 +1088,7 @@ module top_darjeeling #(
   );
   spi_device #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[2:2]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .SramType(SpiDeviceSramType)
   ) u_spi_device (
 
@@ -1135,6 +1138,7 @@ module top_darjeeling #(
   );
   i2c #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[3:3]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .InputDelayCycles(I2c0InputDelayCycles)
   ) u_i2c0 (
 
@@ -1182,7 +1186,8 @@ module top_darjeeling #(
       .rst_ni (rstmgr_aon_resets.rst_i2c0_n[rstmgr_pkg::Domain0Sel])
   );
   rv_timer #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[4:4])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[4:4]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_rv_timer (
 
       // Interrupt
@@ -1203,6 +1208,7 @@ module top_darjeeling #(
   );
   otp_ctrl #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[9:5]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .RndCnstLfsrSeed(RndCnstOtpCtrlLfsrSeed),
     .RndCnstLfsrPerm(RndCnstOtpCtrlLfsrPerm),
     .RndCnstScrmblKeyInit(RndCnstOtpCtrlScrmblKeyInit)
@@ -1289,6 +1295,7 @@ module top_darjeeling #(
   );
   lc_ctrl #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[12:10]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .SecVolatileRawUnlockEn(SecLcCtrlVolatileRawUnlockEn),
     .UseDmiInterface(LcCtrlUseDmiInterface),
     .RndCnstLcKeymgrDivInvalid(RndCnstLcCtrlLcKeymgrDivInvalid),
@@ -1402,6 +1409,7 @@ module top_darjeeling #(
   );
   spi_host #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[13:13]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .NumCS(SpiHost0NumCS)
   ) u_spi_host0 (
 
@@ -1438,6 +1446,7 @@ module top_darjeeling #(
   );
   pwrmgr #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[14:14]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .EscNumSeverities(AlertHandlerEscNumSeverities),
     .EscPingCountWidth(AlertHandlerEscPingCountWidth)
   ) u_pwrmgr_aon (
@@ -1490,6 +1499,7 @@ module top_darjeeling #(
   );
   rstmgr #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[16:15]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .SecCheck(SecRstmgrAonCheck),
     .SecMaxSyncDelay(SecRstmgrAonMaxSyncDelay)
   ) u_rstmgr_aon (
@@ -1524,7 +1534,8 @@ module top_darjeeling #(
       .rst_por_ni (rstmgr_aon_resets.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel])
   );
   clkmgr #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[18:17])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[18:17]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_clkmgr_aon (
       // [17]: recov_fault
       // [18]: fatal_fault
@@ -1572,6 +1583,7 @@ module top_darjeeling #(
   );
   pinmux #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[19:19]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .TargetCfg(PinmuxAonTargetCfg)
   ) u_pinmux_aon (
       // [19]: fatal_fault
@@ -1612,7 +1624,8 @@ module top_darjeeling #(
       .rst_sys_ni (rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel])
   );
   aon_timer #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[20:20])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[20:20]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_aon_timer_aon (
 
       // Interrupt
@@ -1640,7 +1653,8 @@ module top_darjeeling #(
       .rst_aon_ni (rstmgr_aon_resets.rst_lc_aon_n[rstmgr_pkg::DomainAonSel])
   );
   soc_proxy #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[49:21])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[49:21]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_soc_proxy (
 
       // Input
@@ -1722,6 +1736,7 @@ module top_darjeeling #(
   );
   sram_ctrl #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[50:50]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .RndCnstSramKey(RndCnstSramCtrlRetAonSramKey),
     .RndCnstSramNonce(RndCnstSramCtrlRetAonSramNonce),
     .RndCnstLfsrSeed(RndCnstSramCtrlRetAonLfsrSeed),
@@ -1763,6 +1778,7 @@ module top_darjeeling #(
   );
   rv_dm #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[51:51]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .IdcodeValue(RvDmIdcodeValue),
     .UseDmiInterface(RvDmUseDmiInterface),
     .SecVolatileRawUnlockEn(SecRvDmVolatileRawUnlockEn),
@@ -1809,7 +1825,8 @@ module top_darjeeling #(
       .rst_lc_ni (rstmgr_aon_resets.rst_lc_n[rstmgr_pkg::Domain0Sel])
   );
   rv_plic #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[52:52])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[52:52]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_rv_plic (
       // [52]: fatal_fault
       .alert_tx_o  ( alert_tx[52:52] ),
@@ -1829,6 +1846,7 @@ module top_darjeeling #(
   );
   aes #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[54:53]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .AES192Enable(1'b1),
     .SecMasking(SecAesMasking),
     .SecSBoxImpl(SecAesSBoxImpl),
@@ -1863,7 +1881,8 @@ module top_darjeeling #(
       .rst_edn_ni (rstmgr_aon_resets.rst_lc_n[rstmgr_pkg::Domain0Sel])
   );
   hmac #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[55:55])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[55:55]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_hmac (
 
       // Interrupt
@@ -1885,6 +1904,7 @@ module top_darjeeling #(
   );
   kmac #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[57:56]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .EnMasking(KmacEnMasking),
     .SwKeyMasked(KmacSwKeyMasked),
     .SecCmdDelay(SecKmacCmdDelay),
@@ -1927,6 +1947,7 @@ module top_darjeeling #(
   );
   otbn #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[59:58]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .Stub(OtbnStub),
     .RegFile(OtbnRegFile),
     .RndCnstUrndPrngSeed(RndCnstOtbnUrndPrngSeed),
@@ -1972,6 +1993,7 @@ module top_darjeeling #(
   );
   keymgr_dpe #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[61:60]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .KmacEnMasking(KeymgrDpeKmacEnMasking),
     .RndCnstLfsrSeed(RndCnstKeymgrDpeLfsrSeed),
     .RndCnstLfsrPerm(RndCnstKeymgrDpeLfsrPerm),
@@ -2018,6 +2040,7 @@ module top_darjeeling #(
   );
   csrng #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[63:62]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .RndCnstCsKeymgrDivNonProduction(RndCnstCsrngCsKeymgrDivNonProduction),
     .RndCnstCsKeymgrDivProduction(RndCnstCsrngCsKeymgrDivProduction),
     .SBoxImpl(CsrngSBoxImpl)
@@ -2051,6 +2074,7 @@ module top_darjeeling #(
   );
   entropy_src #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[65:64]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .RngBusWidth(EntropySrcRngBusWidth),
     .RngBusBitSelWidth(EntropySrcRngBusBitSelWidth),
     .HealthTestWindowWidth(EntropySrcHealthTestWindowWidth),
@@ -2094,7 +2118,8 @@ module top_darjeeling #(
       .rst_ni (rstmgr_aon_resets.rst_lc_n[rstmgr_pkg::Domain0Sel])
   );
   edn #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[67:66])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[67:66]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_edn0 (
 
       // Interrupt
@@ -2118,7 +2143,8 @@ module top_darjeeling #(
       .rst_ni (rstmgr_aon_resets.rst_lc_n[rstmgr_pkg::Domain0Sel])
   );
   edn #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[69:68])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[69:68]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_edn1 (
 
       // Interrupt
@@ -2143,6 +2169,7 @@ module top_darjeeling #(
   );
   sram_ctrl #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[70:70]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .RndCnstSramKey(RndCnstSramCtrlMainSramKey),
     .RndCnstSramNonce(RndCnstSramCtrlMainSramNonce),
     .RndCnstLfsrSeed(RndCnstSramCtrlMainLfsrSeed),
@@ -2184,6 +2211,7 @@ module top_darjeeling #(
   );
   sram_ctrl #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[71:71]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .RndCnstSramKey(RndCnstSramCtrlMboxSramKey),
     .RndCnstSramNonce(RndCnstSramCtrlMboxSramNonce),
     .RndCnstLfsrSeed(RndCnstSramCtrlMboxLfsrSeed),
@@ -2225,6 +2253,7 @@ module top_darjeeling #(
   );
   rom_ctrl #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[72:72]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .BootRomInitFile(RomCtrl0BootRomInitFile),
     .RndCnstScrNonce(RndCnstRomCtrl0ScrNonce),
     .RndCnstScrKey(RndCnstRomCtrl0ScrKey),
@@ -2252,6 +2281,7 @@ module top_darjeeling #(
   );
   rom_ctrl #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[73:73]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .BootRomInitFile(RomCtrl1BootRomInitFile),
     .RndCnstScrNonce(RndCnstRomCtrl1ScrNonce),
     .RndCnstScrKey(RndCnstRomCtrl1ScrKey),
@@ -2279,6 +2309,7 @@ module top_darjeeling #(
   );
   dma #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[74:74]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .EnableDataIntgGen(DmaEnableDataIntgGen),
     .EnableRspDataIntgCheck(DmaEnableRspDataIntgCheck),
     .TlUserRsvd(DmaTlUserRsvd),
@@ -2318,7 +2349,8 @@ module top_darjeeling #(
     .RaclPolicySelVecSoc(RACL_POLICY_SEL_VEC_MBX0_SOC),
     .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_WIN_MBX0_SOC_WDATA),
     .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_WIN_MBX0_SOC_RDATA),
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[76:75])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[76:75]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_mbx0 (
 
       // Interrupt
@@ -2354,7 +2386,8 @@ module top_darjeeling #(
     .RaclPolicySelVecSoc(RACL_POLICY_SEL_VEC_MBX1_SOC),
     .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_WIN_MBX1_SOC_WDATA),
     .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_WIN_MBX1_SOC_RDATA),
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[78:77])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[78:77]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_mbx1 (
 
       // Interrupt
@@ -2390,7 +2423,8 @@ module top_darjeeling #(
     .RaclPolicySelVecSoc(RACL_POLICY_SEL_VEC_MBX2_SOC),
     .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_WIN_MBX2_SOC_WDATA),
     .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_WIN_MBX2_SOC_RDATA),
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[80:79])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[80:79]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_mbx2 (
 
       // Interrupt
@@ -2426,7 +2460,8 @@ module top_darjeeling #(
     .RaclPolicySelVecSoc(RACL_POLICY_SEL_VEC_MBX3_SOC),
     .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_WIN_MBX3_SOC_WDATA),
     .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_WIN_MBX3_SOC_RDATA),
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[82:81])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[82:81]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_mbx3 (
 
       // Interrupt
@@ -2462,7 +2497,8 @@ module top_darjeeling #(
     .RaclPolicySelVecSoc(RACL_POLICY_SEL_VEC_MBX4_SOC),
     .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_WIN_MBX4_SOC_WDATA),
     .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_WIN_MBX4_SOC_RDATA),
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[84:83])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[84:83]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_mbx4 (
 
       // Interrupt
@@ -2498,7 +2534,8 @@ module top_darjeeling #(
     .RaclPolicySelVecSoc(RACL_POLICY_SEL_VEC_MBX5_SOC),
     .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_WIN_MBX5_SOC_WDATA),
     .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_WIN_MBX5_SOC_RDATA),
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[86:85])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[86:85]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_mbx5 (
 
       // Interrupt
@@ -2534,7 +2571,8 @@ module top_darjeeling #(
     .RaclPolicySelVecSoc(RACL_POLICY_SEL_VEC_MBX6_SOC),
     .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_WIN_MBX6_SOC_WDATA),
     .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_WIN_MBX6_SOC_RDATA),
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[88:87])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[88:87]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_mbx6 (
 
       // Interrupt
@@ -2570,7 +2608,8 @@ module top_darjeeling #(
     .RaclPolicySelVecSoc(RACL_POLICY_SEL_VEC_MBX_JTAG_SOC),
     .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_WIN_MBX_JTAG_SOC_WDATA),
     .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_WIN_MBX_JTAG_SOC_RDATA),
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[90:89])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[90:89]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_mbx_jtag (
 
       // Interrupt
@@ -2606,7 +2645,8 @@ module top_darjeeling #(
     .RaclPolicySelVecSoc(RACL_POLICY_SEL_VEC_MBX_PCIE0_SOC),
     .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_WIN_MBX_PCIE0_SOC_WDATA),
     .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_WIN_MBX_PCIE0_SOC_RDATA),
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[92:91])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[92:91]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_mbx_pcie0 (
 
       // Interrupt
@@ -2642,7 +2682,8 @@ module top_darjeeling #(
     .RaclPolicySelVecSoc(RACL_POLICY_SEL_VEC_MBX_PCIE1_SOC),
     .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_WIN_MBX_PCIE1_SOC_WDATA),
     .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_WIN_MBX_PCIE1_SOC_RDATA),
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[94:93])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[94:93]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_mbx_pcie1 (
 
       // Interrupt
@@ -2673,7 +2714,8 @@ module top_darjeeling #(
       .rst_ni (rstmgr_aon_resets.rst_lc_n[rstmgr_pkg::Domain0Sel])
   );
   soc_dbg_ctrl #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[96:95])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[96:95]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_soc_dbg_ctrl (
       // [95]: fatal_fault
       // [96]: recov_ctrl_update_err
@@ -2702,6 +2744,7 @@ module top_darjeeling #(
   racl_ctrl #(
     .RaclErrorRsp(1'b1),
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[98:97]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .NumSubscribingIps(RaclCtrlNumSubscribingIps),
     .NumExternalSubscribingIps(RaclCtrlNumExternalSubscribingIps)
   ) u_racl_ctrl (
@@ -2730,6 +2773,7 @@ module top_darjeeling #(
     .RaclErrorRsp(top_racl_pkg::ErrorRsp),
     .RaclPolicySelVec(RACL_POLICY_SEL_VEC_AC_RANGE_CHECK),
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[100:99]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .RangeCheckErrorRsp(AcRangeCheckRangeCheckErrorRsp)
   ) u_ac_range_check (
 
@@ -2758,6 +2802,7 @@ module top_darjeeling #(
   );
   rv_core_ibex #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[104:101]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .RndCnstLfsrSeed(RndCnstRvCoreIbexLfsrSeed),
     .RndCnstLfsrPerm(RndCnstRvCoreIbexLfsrPerm),
     .RndCnstIbexKeyDefault(RndCnstRvCoreIbexIbexKeyDefault),

--- a/hw/top_darjeeling/rtl/top_pkg.sv
+++ b/hw/top_darjeeling/rtl/top_pkg.sv
@@ -13,6 +13,9 @@ localparam int TL_DUW=14;   // d_user
 localparam int TL_DBW=(TL_DW>>3);
 localparam int TL_SZW=$clog2($clog2(TL_DBW)+1);
 
+// Number of cycles a differential skew is tolerated on the alert signal
+localparam int unsigned AlertSkewCycles = 1;
+
 // NOTE THAT THIS IS A FEATURE FOR TEST CHIPS ONLY TO MITIGATE
 // THE RISK OF A BROKEN OTP MACRO. THIS WILL BE DISABLED FOR
 // PRODUCTION DEVICES.

--- a/hw/top_darjeeling/rtl/top_pkg.sv
+++ b/hw/top_darjeeling/rtl/top_pkg.sv
@@ -14,7 +14,7 @@ localparam int TL_DBW=(TL_DW>>3);
 localparam int TL_SZW=$clog2($clog2(TL_DBW)+1);
 
 // Number of cycles a differential skew is tolerated on the alert signal
-localparam int unsigned AlertSkewCycles = 1;
+localparam int unsigned AlertSkewCycles = 3;
 
 // NOTE THAT THIS IS A FEATURE FOR TEST CHIPS ONLY TO MITIGATE
 // THE RISK OF A BROKEN OTP MACRO. THIS WILL BE DISABLED FOR

--- a/hw/top_darjeeling/templates/toplevel.sv.tpl
+++ b/hw/top_darjeeling/templates/toplevel.sv.tpl
@@ -523,10 +523,11 @@ else:
 slice = f"{lo+w-1}:{lo}"
 %>\
   % if 'outgoing_alert' in m:
-    .AlertAsyncOn(AsyncOnOutgoingAlert${alert_group.capitalize()}[${slice}])${"," if m["param_list"] else ""}
+    .AlertAsyncOn(AsyncOnOutgoingAlert${alert_group.capitalize()}[${slice}]),
   % else:
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[${slice}])${"," if m["param_list"] else ""}
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[${slice}]),
   % endif
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)${"," if m["param_list"] else ""}
   % endif
     % for i in m["param_list"]:
     .${i["name"]}(${i["name_top" if i.get("expose") == "true" or i.get("randtype", "none") != "none" else "default"]})${"," if not loop.last else ""}

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl.sv
@@ -10,7 +10,9 @@ module sensor_ctrl
   import sensor_ctrl_pkg::*;
   import sensor_ctrl_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1
 ) (
   // Primary module clocks
   input clk_i,
@@ -265,6 +267,7 @@ module sensor_ctrl
 
   prim_alert_sender #(
     .AsyncOn(AlertAsyncOn[RecovAlert]),
+    .SkewCycles(AlertSkewCycles),
     .IsFatal(0)
   ) u_prim_recov_alert_sender (
     .clk_i,

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler.sv
@@ -11,7 +11,7 @@ module alert_handler
   import prim_alert_pkg::*;
   import prim_esc_pkg::*;
 #(
-  // Number of cycles a differential skew is tolerated on the alert signal
+  // Number of cycles a differential skew is tolerated on the alert and escalation signal
   parameter int unsigned AlertSkewCycles = 1,
   parameter int EscNumSeverities = 4,
   parameter int EscPingCountWidth = 16,
@@ -295,7 +295,9 @@ module alert_handler
     // put this RTL label inside that module due to the way our countermeasure annotation check
     // script discovers the RTL files. The label is thus put here. Please refer to
     // prim_esc_receiver.sv for the actual implementation of this mechanism.
-    prim_esc_sender u_esc_sender (
+    prim_esc_sender # (
+      .SkewCycles(AlertSkewCycles)
+    ) u_esc_sender (
       .clk_i,
       .rst_ni,
       .ping_req_i   ( esc_ping_req[k]  ),

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler.sv
@@ -11,6 +11,8 @@ module alert_handler
   import prim_alert_pkg::*;
   import prim_esc_pkg::*;
 #(
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1,
   parameter int EscNumSeverities = 4,
   parameter int EscPingCountWidth = 16,
   // Compile time random constants, to be overriden by topgen.
@@ -187,7 +189,8 @@ module alert_handler
   // Target interrupt notification
   for (genvar k = 0 ; k < NAlerts ; k++) begin : gen_alerts
     prim_alert_receiver #(
-      .AsyncOn(AsyncOn[k])
+      .AsyncOn(AsyncOn[k]),
+      .SkewCycles(AlertSkewCycles)
     ) u_alert_receiver (
       .clk_i,
       .rst_ni,

--- a/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr.sv
@@ -13,7 +13,9 @@
     import lc_ctrl_pkg::lc_tx_t;
     import prim_mubi_pkg::mubi4_t;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1
 ) (
   // Primary module control clocks and resets
   // This drives the register interface
@@ -286,6 +288,7 @@
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(AlertFatal[i])
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl.sv
@@ -13,6 +13,8 @@ module flash_ctrl
   import flash_ctrl_top_specific_pkg::*;  import flash_ctrl_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn    = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned          AlertSkewCycles = 1,
   parameter flash_key_t           RndCnstAddrKey  = RndCnstAddrKeyDefault,
   parameter flash_key_t           RndCnstDataKey  = RndCnstDataKeyDefault,
   parameter all_seeds_t           RndCnstAllSeeds = RndCnstAllSeedsDefault,
@@ -983,6 +985,7 @@ module flash_ctrl
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(IsFatal[i])
     ) u_alert_sender (
       .clk_i,

--- a/hw/top_earlgrey/ip_autogen/gpio/rtl/gpio.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/rtl/gpio.sv
@@ -11,6 +11,8 @@ module gpio
   import gpio_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned                    AlertSkewCycles           = 1,
   parameter bit                             GpioAsHwStrapsEn          = 1,
   // This parameter instantiates 2-stage synchronizers on all GPIO inputs.
   parameter bit                             GpioAsyncOn               = 1,
@@ -200,6 +202,7 @@ module gpio
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl.sv
@@ -22,6 +22,8 @@ module otp_ctrl
 #(
   // Enable asynchronous transitions on alerts.
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1,
   // Compile time random constants, to be overridden by topgen.
   parameter lfsr_seed_t RndCnstLfsrSeed = RndCnstLfsrSeedDefault,
   parameter lfsr_perm_t RndCnstLfsrPerm = RndCnstLfsrPermDefault,
@@ -597,6 +599,7 @@ end
   for (genvar k = 0; k < NumAlerts; k++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[k]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(AlertIsFatal[k])
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux.sv
+++ b/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux.sv
@@ -15,8 +15,10 @@ module pinmux
   // Taget-specific pinmux configuration passed down from the
   // target-specific top-level.
   parameter target_cfg_t TargetCfg = DefaultTargetCfg,
+  parameter bit SecVolatileRawUnlockEn = 0,
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
-  parameter bit SecVolatileRawUnlockEn = 0
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1
 ) (
   input                            clk_i,
   input                            rst_ni,
@@ -140,6 +142,7 @@ module pinmux
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/top_earlgrey/ip_autogen/pwm/rtl/pwm.sv
+++ b/hw/top_earlgrey/ip_autogen/pwm/rtl/pwm.sv
@@ -8,6 +8,8 @@ module pwm
   import pwm_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned                    AlertSkewCycles           = 1,
   parameter bit                             EnableRacl                = 1'b0,
   parameter bit                             RaclErrorRsp              = EnableRacl,
   parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[NumRegs] = '{NumRegs{0}},
@@ -63,6 +65,7 @@ module pwm
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr.sv
@@ -12,6 +12,8 @@ module pwrmgr
   import pwrmgr_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1,
   parameter int unsigned EscNumSeverities = 4,
   parameter int unsigned EscPingCountWidth = 16
 ) (
@@ -386,6 +388,7 @@ module pwrmgr
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i         ( clk_lc        ),

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr.sv
@@ -12,7 +12,7 @@ module pwrmgr
   import pwrmgr_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
-  // Number of cycles a differential skew is tolerated on the alert signal
+  // Number of cycles a differential skew is tolerated on the alert and escalation signal
   parameter int unsigned AlertSkewCycles = 1,
   parameter int unsigned EscNumSeverities = 4,
   parameter int unsigned EscPingCountWidth = 16
@@ -138,7 +138,8 @@ module pwrmgr
   logic esc_rst_req_d, esc_rst_req_q;
   prim_esc_receiver #(
     .N_ESC_SEV   (EscNumSeverities),
-    .PING_CNT_DW (EscPingCountWidth)
+    .PING_CNT_DW (EscPingCountWidth),
+    .SkewCycles  (AlertSkewCycles)
   ) u_esc_rx (
     .clk_i(clk_esc),
     .rst_ni(rst_esc_n),

--- a/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr.sv
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr.sv
@@ -14,6 +14,8 @@ module rstmgr
   import prim_mubi_pkg::mubi4_t;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1,
   parameter bit SecCheck = 1,
   parameter int SecMaxSyncDelay = 2
 ) (
@@ -218,6 +220,7 @@ module rstmgr
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -13,6 +13,8 @@ module rv_core_ibex
   import rv_core_ibex_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]   AlertAsyncOn     = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned            AlertSkewCycles  = 1,
   parameter bit                     PMPEnable        = 1'b1,
   parameter int unsigned            PMPGranularity   = 0,
   parameter int unsigned            PMPNumRegions    = 16,
@@ -802,6 +804,7 @@ module rv_core_ibex
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[0]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(AlertFatal[i])
     ) u_alert_sender (
       .clk_i,

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -13,7 +13,7 @@ module rv_core_ibex
   import rv_core_ibex_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]   AlertAsyncOn     = {NumAlerts{1'b1}},
-  // Number of cycles a differential skew is tolerated on the alert signal
+  // Number of cycles a differential skew is tolerated on the alert and escalation signal
   parameter int unsigned            AlertSkewCycles  = 1,
   parameter bit                     PMPEnable        = 1'b1,
   parameter int unsigned            PMPGranularity   = 0,
@@ -245,7 +245,8 @@ module rv_core_ibex
   logic esc_irq_nm;
   prim_esc_receiver #(
     .N_ESC_SEV   (NEscalationSeverities),
-    .PING_CNT_DW (WidthPingCounter)
+    .PING_CNT_DW (WidthPingCounter),
+    .SkewCycles  (AlertSkewCycles)
   ) u_prim_esc_receiver (
     .clk_i     ( clk_esc_i  ),
     .rst_ni    ( rst_esc_ni ),

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_peri.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_peri.sv
@@ -11,7 +11,9 @@ module rv_core_ibex_peri
   import rv_core_ibex_peri_pkg::*;
   import rv_core_ibex_peri_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1
 ) (
   input clk_i,
   input rst_ni,
@@ -109,6 +111,7 @@ module rv_core_ibex_peri
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[0]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(AlertFatal[i])
     ) u_alert_sender (
       .clk_i,

--- a/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic.sv
@@ -17,7 +17,9 @@
 `include "prim_assert.sv"
 
 module rv_plic import rv_plic_reg_pkg::*; #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn  = {NumAlerts{1'b1}},
+  parameter logic [NumAlerts-1:0] AlertAsyncOn    = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned          AlertSkewCycles = 1,
   // OpenTitan IP standardizes on level triggered interrupts,
   // hence LevelEdgeTrig is set to all-zeroes by default.
   // Note that in case of edge-triggered interrupts, CDC handling is not
@@ -386,6 +388,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1078,7 +1078,8 @@ module top_earlgrey #(
 
 
   uart #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[0:0])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[0:0]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_uart0 (
 
       // Input
@@ -1114,7 +1115,8 @@ module top_earlgrey #(
       .rst_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel])
   );
   uart #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[1:1])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[1:1]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_uart1 (
 
       // Input
@@ -1150,7 +1152,8 @@ module top_earlgrey #(
       .rst_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel])
   );
   uart #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[2:2])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[2:2]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_uart2 (
 
       // Input
@@ -1186,7 +1189,8 @@ module top_earlgrey #(
       .rst_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel])
   );
   uart #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[3:3])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[3:3]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_uart3 (
 
       // Input
@@ -1223,6 +1227,7 @@ module top_earlgrey #(
   );
   gpio #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[4:4]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .GpioAsyncOn(GpioGpioAsyncOn),
     .GpioAsHwStrapsEn(GpioGpioAsHwStrapsEn)
   ) u_gpio (
@@ -1254,6 +1259,7 @@ module top_earlgrey #(
   );
   spi_device #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[5:5]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .SramType(SpiDeviceSramType)
   ) u_spi_device (
 
@@ -1303,6 +1309,7 @@ module top_earlgrey #(
   );
   i2c #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[6:6]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .InputDelayCycles(I2c0InputDelayCycles)
   ) u_i2c0 (
 
@@ -1351,6 +1358,7 @@ module top_earlgrey #(
   );
   i2c #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[7:7]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .InputDelayCycles(I2c1InputDelayCycles)
   ) u_i2c1 (
 
@@ -1399,6 +1407,7 @@ module top_earlgrey #(
   );
   i2c #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[8:8]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .InputDelayCycles(I2c2InputDelayCycles)
   ) u_i2c2 (
 
@@ -1446,7 +1455,8 @@ module top_earlgrey #(
       .rst_ni (rstmgr_aon_resets.rst_i2c2_n[rstmgr_pkg::Domain0Sel])
   );
   pattgen #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[9:9])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[9:9]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_pattgen (
 
       // Output
@@ -1475,7 +1485,8 @@ module top_earlgrey #(
       .rst_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel])
   );
   rv_timer #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[10:10])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[10:10]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_rv_timer (
 
       // Interrupt
@@ -1496,6 +1507,7 @@ module top_earlgrey #(
   );
   otp_ctrl #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[15:11]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .RndCnstLfsrSeed(RndCnstOtpCtrlLfsrSeed),
     .RndCnstLfsrPerm(RndCnstOtpCtrlLfsrPerm),
     .RndCnstScrmblKeyInit(RndCnstOtpCtrlScrmblKeyInit)
@@ -1584,6 +1596,7 @@ module top_earlgrey #(
   );
   lc_ctrl #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[18:16]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .SecVolatileRawUnlockEn(SecLcCtrlVolatileRawUnlockEn),
     .UseDmiInterface(LcCtrlUseDmiInterface),
     .RndCnstLcKeymgrDivInvalid(RndCnstLcCtrlLcKeymgrDivInvalid),
@@ -1697,6 +1710,7 @@ module top_earlgrey #(
   );
   spi_host #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[19:19]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .NumCS(SpiHost0NumCS)
   ) u_spi_host0 (
 
@@ -1733,6 +1747,7 @@ module top_earlgrey #(
   );
   spi_host #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[20:20]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .NumCS(SpiHost1NumCS)
   ) u_spi_host1 (
 
@@ -1769,6 +1784,7 @@ module top_earlgrey #(
   );
   usbdev #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[21:21]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .Stub(UsbdevStub),
     .RcvrWakeTimeUs(UsbdevRcvrWakeTimeUs)
   ) u_usbdev (
@@ -1836,6 +1852,7 @@ module top_earlgrey #(
   );
   pwrmgr #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[22:22]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .EscNumSeverities(AlertHandlerEscNumSeverities),
     .EscPingCountWidth(AlertHandlerEscPingCountWidth)
   ) u_pwrmgr_aon (
@@ -1887,6 +1904,7 @@ module top_earlgrey #(
   );
   rstmgr #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[24:23]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .SecCheck(SecRstmgrAonCheck),
     .SecMaxSyncDelay(SecRstmgrAonMaxSyncDelay)
   ) u_rstmgr_aon (
@@ -1922,7 +1940,8 @@ module top_earlgrey #(
       .rst_por_ni (rstmgr_aon_resets.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel])
   );
   clkmgr #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[26:25])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[26:25]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_clkmgr_aon (
       // [25]: recov_fault
       // [26]: fatal_fault
@@ -1972,7 +1991,8 @@ module top_earlgrey #(
       .rst_root_usb_ni (rstmgr_aon_resets.rst_por_usb_n[rstmgr_pkg::DomainAonSel])
   );
   sysrst_ctrl #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[27:27])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[27:27]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_sysrst_ctrl_aon (
 
       // Input
@@ -2022,7 +2042,8 @@ module top_earlgrey #(
       .rst_aon_ni (rstmgr_aon_resets.rst_lc_aon_n[rstmgr_pkg::DomainAonSel])
   );
   adc_ctrl #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[28:28])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[28:28]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_adc_ctrl_aon (
 
       // Interrupt
@@ -2045,7 +2066,8 @@ module top_earlgrey #(
       .rst_aon_ni (rstmgr_aon_resets.rst_lc_aon_n[rstmgr_pkg::DomainAonSel])
   );
   pwm #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[29:29])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[29:29]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_pwm_aon (
 
       // Output
@@ -2069,6 +2091,7 @@ module top_earlgrey #(
   );
   pinmux #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[30:30]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .SecVolatileRawUnlockEn(SecPinmuxAonVolatileRawUnlockEn),
     .TargetCfg(PinmuxAonTargetCfg)
   ) u_pinmux_aon (
@@ -2137,7 +2160,8 @@ module top_earlgrey #(
       .rst_sys_ni (rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel])
   );
   aon_timer #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[31:31])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[31:31]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_aon_timer_aon (
 
       // Interrupt
@@ -2165,7 +2189,8 @@ module top_earlgrey #(
       .rst_aon_ni (rstmgr_aon_resets.rst_lc_aon_n[rstmgr_pkg::DomainAonSel])
   );
   sensor_ctrl #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[33:32])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[33:32]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_sensor_ctrl_aon (
 
       // Output
@@ -2199,6 +2224,7 @@ module top_earlgrey #(
   );
   sram_ctrl #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[34:34]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .RndCnstSramKey(RndCnstSramCtrlRetAonSramKey),
     .RndCnstSramNonce(RndCnstSramCtrlRetAonSramNonce),
     .RndCnstLfsrSeed(RndCnstSramCtrlRetAonLfsrSeed),
@@ -2240,6 +2266,7 @@ module top_earlgrey #(
   );
   flash_ctrl #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[39:35]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .RndCnstAddrKey(RndCnstFlashCtrlAddrKey),
     .RndCnstDataKey(RndCnstFlashCtrlDataKey),
     .RndCnstAllSeeds(RndCnstFlashCtrlAllSeeds),
@@ -2315,6 +2342,7 @@ module top_earlgrey #(
   );
   rv_dm #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[40:40]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .IdcodeValue(RvDmIdcodeValue),
     .UseDmiInterface(RvDmUseDmiInterface),
     .SecVolatileRawUnlockEn(SecRvDmVolatileRawUnlockEn),
@@ -2361,7 +2389,8 @@ module top_earlgrey #(
       .rst_lc_ni (rstmgr_aon_resets.rst_lc_n[rstmgr_pkg::Domain0Sel])
   );
   rv_plic #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[41:41])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[41:41]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_rv_plic (
       // [41]: fatal_fault
       .alert_tx_o  ( alert_tx[41:41] ),
@@ -2381,6 +2410,7 @@ module top_earlgrey #(
   );
   aes #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[43:42]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .AES192Enable(1'b1),
     .SecMasking(SecAesMasking),
     .SecSBoxImpl(SecAesSBoxImpl),
@@ -2415,7 +2445,8 @@ module top_earlgrey #(
       .rst_edn_ni (rstmgr_aon_resets.rst_lc_n[rstmgr_pkg::Domain0Sel])
   );
   hmac #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[44:44])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[44:44]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_hmac (
 
       // Interrupt
@@ -2437,6 +2468,7 @@ module top_earlgrey #(
   );
   kmac #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[46:45]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .EnMasking(KmacEnMasking),
     .SwKeyMasked(KmacSwKeyMasked),
     .SecCmdDelay(SecKmacCmdDelay),
@@ -2479,6 +2511,7 @@ module top_earlgrey #(
   );
   otbn #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[48:47]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .Stub(OtbnStub),
     .RegFile(OtbnRegFile),
     .RndCnstUrndPrngSeed(RndCnstOtbnUrndPrngSeed),
@@ -2524,6 +2557,7 @@ module top_earlgrey #(
   );
   keymgr #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[50:49]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .UseOtpSeedsInsteadOfFlash(KeymgrUseOtpSeedsInsteadOfFlash),
     .KmacEnMasking(KeymgrKmacEnMasking),
     .RndCnstLfsrSeed(RndCnstKeymgrLfsrSeed),
@@ -2576,6 +2610,7 @@ module top_earlgrey #(
   );
   csrng #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[52:51]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .RndCnstCsKeymgrDivNonProduction(RndCnstCsrngCsKeymgrDivNonProduction),
     .RndCnstCsKeymgrDivProduction(RndCnstCsrngCsKeymgrDivProduction),
     .SBoxImpl(CsrngSBoxImpl)
@@ -2609,6 +2644,7 @@ module top_earlgrey #(
   );
   entropy_src #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[54:53]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .RngBusWidth(EntropySrcRngBusWidth),
     .RngBusBitSelWidth(EntropySrcRngBusBitSelWidth),
     .HealthTestWindowWidth(EntropySrcHealthTestWindowWidth),
@@ -2652,7 +2688,8 @@ module top_earlgrey #(
       .rst_ni (rstmgr_aon_resets.rst_lc_n[rstmgr_pkg::Domain0Sel])
   );
   edn #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[56:55])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[56:55]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_edn0 (
 
       // Interrupt
@@ -2676,7 +2713,8 @@ module top_earlgrey #(
       .rst_ni (rstmgr_aon_resets.rst_lc_n[rstmgr_pkg::Domain0Sel])
   );
   edn #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[58:57])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[58:57]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_edn1 (
 
       // Interrupt
@@ -2701,6 +2739,7 @@ module top_earlgrey #(
   );
   sram_ctrl #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[59:59]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .RndCnstSramKey(RndCnstSramCtrlMainSramKey),
     .RndCnstSramNonce(RndCnstSramCtrlMainSramNonce),
     .RndCnstLfsrSeed(RndCnstSramCtrlMainLfsrSeed),
@@ -2742,6 +2781,7 @@ module top_earlgrey #(
   );
   rom_ctrl #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[60:60]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .BootRomInitFile(RomCtrlBootRomInitFile),
     .RndCnstScrNonce(RndCnstRomCtrlScrNonce),
     .RndCnstScrKey(RndCnstRomCtrlScrKey),
@@ -2769,6 +2809,7 @@ module top_earlgrey #(
   );
   rv_core_ibex #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[64:61]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .RndCnstLfsrSeed(RndCnstRvCoreIbexLfsrSeed),
     .RndCnstLfsrPerm(RndCnstRvCoreIbexLfsrPerm),
     .RndCnstIbexKeyDefault(RndCnstRvCoreIbexIbexKeyDefault),

--- a/hw/top_earlgrey/rtl/top_pkg.sv
+++ b/hw/top_earlgrey/rtl/top_pkg.sv
@@ -14,6 +14,9 @@ localparam int TL_DUW=14;   // d_user
 localparam int TL_DBW=(TL_DW>>3);
 localparam int TL_SZW=$clog2($clog2(TL_DBW)+1);
 
+// Number of cycles a differential skew is tolerated on the alert signal
+localparam int unsigned AlertSkewCycles = 1;
+
 // NOTE THAT THIS IS A FEATURE FOR TEST CHIPS ONLY TO MITIGATE
 // THE RISK OF A BROKEN OTP MACRO. THIS WILL BE DISABLED FOR
 // PRODUCTION DEVICES.

--- a/hw/top_earlgrey/templates/toplevel.sv.tpl
+++ b/hw/top_earlgrey/templates/toplevel.sv.tpl
@@ -501,10 +501,11 @@ else:
 slice = f"{lo+w-1}:{lo}"
 %>\
   % if 'outgoing_alert' in m:
-    .AlertAsyncOn(AsyncOnOutgoingAlert${alert_group.capitalize()}[${slice}])${"," if m["param_list"] else ""}
+    .AlertAsyncOn(AsyncOnOutgoingAlert${alert_group.capitalize()}[${slice}]),
   % else:
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[${slice}])${"," if m["param_list"] else ""}
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[${slice}]),
   % endif
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)${"," if m["param_list"] else ""}
   % endif
     % for i in m["param_list"]:
     .${i["name"]}(${i["name_top" if i.get("expose") == "true" or i.get("randtype", "none") != "none" else "default"]})${"," if not loop.last else ""}

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr.sv
@@ -13,7 +13,9 @@
     import lc_ctrl_pkg::lc_tx_t;
     import prim_mubi_pkg::mubi4_t;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1
 ) (
   // Primary module control clocks and resets
   // This drives the register interface
@@ -282,6 +284,7 @@
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(AlertFatal[i])
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl.sv
@@ -13,6 +13,8 @@ module flash_ctrl
   import flash_ctrl_top_specific_pkg::*;  import flash_ctrl_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn    = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned          AlertSkewCycles = 1,
   parameter flash_key_t           RndCnstAddrKey  = RndCnstAddrKeyDefault,
   parameter flash_key_t           RndCnstDataKey  = RndCnstDataKeyDefault,
   parameter all_seeds_t           RndCnstAllSeeds = RndCnstAllSeedsDefault,
@@ -983,6 +985,7 @@ module flash_ctrl
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(IsFatal[i])
     ) u_alert_sender (
       .clk_i,

--- a/hw/top_englishbreakfast/ip_autogen/gpio/rtl/gpio.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/rtl/gpio.sv
@@ -11,6 +11,8 @@ module gpio
   import gpio_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned                    AlertSkewCycles           = 1,
   parameter bit                             GpioAsHwStrapsEn          = 1,
   // This parameter instantiates 2-stage synchronizers on all GPIO inputs.
   parameter bit                             GpioAsyncOn               = 1,
@@ -200,6 +202,7 @@ module gpio
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux.sv
@@ -15,8 +15,10 @@ module pinmux
   // Taget-specific pinmux configuration passed down from the
   // target-specific top-level.
   parameter target_cfg_t TargetCfg = DefaultTargetCfg,
+  parameter bit SecVolatileRawUnlockEn = 0,
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
-  parameter bit SecVolatileRawUnlockEn = 0
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1
 ) (
   input                            clk_i,
   input                            rst_ni,
@@ -140,6 +142,7 @@ module pinmux
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr.sv
@@ -12,6 +12,8 @@ module pwrmgr
   import pwrmgr_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1,
   parameter int unsigned EscNumSeverities = 4,
   parameter int unsigned EscPingCountWidth = 16
 ) (
@@ -386,6 +388,7 @@ module pwrmgr
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i         ( clk_lc        ),

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr.sv
@@ -12,7 +12,7 @@ module pwrmgr
   import pwrmgr_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
-  // Number of cycles a differential skew is tolerated on the alert signal
+  // Number of cycles a differential skew is tolerated on the alert and escalation signal
   parameter int unsigned AlertSkewCycles = 1,
   parameter int unsigned EscNumSeverities = 4,
   parameter int unsigned EscPingCountWidth = 16
@@ -138,7 +138,8 @@ module pwrmgr
   logic esc_rst_req_d, esc_rst_req_q;
   prim_esc_receiver #(
     .N_ESC_SEV   (EscNumSeverities),
-    .PING_CNT_DW (EscPingCountWidth)
+    .PING_CNT_DW (EscPingCountWidth),
+    .SkewCycles  (AlertSkewCycles)
   ) u_esc_rx (
     .clk_i(clk_esc),
     .rst_ni(rst_esc_n),

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr.sv
@@ -14,6 +14,8 @@ module rstmgr
   import prim_mubi_pkg::mubi4_t;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1,
   parameter bit SecCheck = 1,
   parameter int SecMaxSyncDelay = 2
 ) (
@@ -218,6 +220,7 @@ module rstmgr
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -13,6 +13,8 @@ module rv_core_ibex
   import rv_core_ibex_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]   AlertAsyncOn     = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned            AlertSkewCycles  = 1,
   parameter bit                     PMPEnable        = 1'b1,
   parameter int unsigned            PMPGranularity   = 0,
   parameter int unsigned            PMPNumRegions    = 16,
@@ -802,6 +804,7 @@ module rv_core_ibex
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[0]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(AlertFatal[i])
     ) u_alert_sender (
       .clk_i,

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -13,7 +13,7 @@ module rv_core_ibex
   import rv_core_ibex_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]   AlertAsyncOn     = {NumAlerts{1'b1}},
-  // Number of cycles a differential skew is tolerated on the alert signal
+  // Number of cycles a differential skew is tolerated on the alert and escalation signal
   parameter int unsigned            AlertSkewCycles  = 1,
   parameter bit                     PMPEnable        = 1'b1,
   parameter int unsigned            PMPGranularity   = 0,
@@ -245,7 +245,8 @@ module rv_core_ibex
   logic esc_irq_nm;
   prim_esc_receiver #(
     .N_ESC_SEV   (NEscalationSeverities),
-    .PING_CNT_DW (WidthPingCounter)
+    .PING_CNT_DW (WidthPingCounter),
+    .SkewCycles  (AlertSkewCycles)
   ) u_prim_esc_receiver (
     .clk_i     ( clk_esc_i  ),
     .rst_ni    ( rst_esc_ni ),

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_peri.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_peri.sv
@@ -11,7 +11,9 @@ module rv_core_ibex_peri
   import rv_core_ibex_peri_pkg::*;
   import rv_core_ibex_peri_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned AlertSkewCycles = 1
 ) (
   input clk_i,
   input rst_ni,
@@ -109,6 +111,7 @@ module rv_core_ibex_peri
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[0]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(AlertFatal[i])
     ) u_alert_sender (
       .clk_i,

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/rtl/rv_plic.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/rtl/rv_plic.sv
@@ -17,7 +17,9 @@
 `include "prim_assert.sv"
 
 module rv_plic import rv_plic_reg_pkg::*; #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn  = {NumAlerts{1'b1}},
+  parameter logic [NumAlerts-1:0] AlertAsyncOn    = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned          AlertSkewCycles = 1,
   // OpenTitan IP standardizes on level triggered interrupts,
   // hence LevelEdgeTrig is set to all-zeroes by default.
   // Note that in case of edge-triggered interrupts, CDC handling is not
@@ -288,6 +290,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
+      .SkewCycles(AlertSkewCycles),
       .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,

--- a/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
@@ -548,7 +548,8 @@ module top_englishbreakfast #(
 
 
   uart #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[0:0])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[0:0]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_uart0 (
 
       // Input
@@ -584,7 +585,8 @@ module top_englishbreakfast #(
       .rst_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel])
   );
   uart #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[1:1])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[1:1]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_uart1 (
 
       // Input
@@ -621,6 +623,7 @@ module top_englishbreakfast #(
   );
   gpio #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[2:2]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .GpioAsyncOn(GpioGpioAsyncOn),
     .GpioAsHwStrapsEn(GpioGpioAsHwStrapsEn)
   ) u_gpio (
@@ -652,6 +655,7 @@ module top_englishbreakfast #(
   );
   spi_device #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[3:3]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .SramType(SpiDeviceSramType)
   ) u_spi_device (
 
@@ -701,6 +705,7 @@ module top_englishbreakfast #(
   );
   spi_host #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[4:4]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .NumCS(SpiHost0NumCS)
   ) u_spi_host0 (
 
@@ -736,7 +741,8 @@ module top_englishbreakfast #(
       .rst_ni (rstmgr_aon_resets.rst_spi_host0_n[rstmgr_pkg::Domain0Sel])
   );
   rv_timer #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[5:5])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[5:5]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_rv_timer (
 
       // Interrupt
@@ -757,6 +763,7 @@ module top_englishbreakfast #(
   );
   usbdev #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[6:6]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .Stub(UsbdevStub),
     .RcvrWakeTimeUs(UsbdevRcvrWakeTimeUs)
   ) u_usbdev (
@@ -824,6 +831,7 @@ module top_englishbreakfast #(
   );
   pwrmgr #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[7:7]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .EscNumSeverities(4),
     .EscPingCountWidth(16)
   ) u_pwrmgr_aon (
@@ -875,6 +883,7 @@ module top_englishbreakfast #(
   );
   rstmgr #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[9:8]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .SecCheck(SecRstmgrAonCheck),
     .SecMaxSyncDelay(SecRstmgrAonMaxSyncDelay)
   ) u_rstmgr_aon (
@@ -910,7 +919,8 @@ module top_englishbreakfast #(
       .rst_por_ni (rstmgr_aon_resets.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel])
   );
   clkmgr #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[11:10])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[11:10]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_clkmgr_aon (
       // [10]: recov_fault
       // [11]: fatal_fault
@@ -961,6 +971,7 @@ module top_englishbreakfast #(
   );
   pinmux #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[12:12]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .SecVolatileRawUnlockEn(SecPinmuxAonVolatileRawUnlockEn),
     .TargetCfg(PinmuxAonTargetCfg)
   ) u_pinmux_aon (
@@ -1029,7 +1040,8 @@ module top_englishbreakfast #(
       .rst_sys_ni (rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel])
   );
   aon_timer #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[13:13])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[13:13]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_aon_timer_aon (
 
       // Interrupt
@@ -1058,6 +1070,7 @@ module top_englishbreakfast #(
   );
   flash_ctrl #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[18:14]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .RndCnstAddrKey(RndCnstFlashCtrlAddrKey),
     .RndCnstDataKey(RndCnstFlashCtrlDataKey),
     .RndCnstAllSeeds(RndCnstFlashCtrlAllSeeds),
@@ -1132,7 +1145,8 @@ module top_englishbreakfast #(
       .rst_otp_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel])
   );
   rv_plic #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[19:19])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[19:19]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles)
   ) u_rv_plic (
       // [19]: fatal_fault
       .alert_tx_o  ( alert_tx[19:19] ),
@@ -1152,6 +1166,7 @@ module top_englishbreakfast #(
   );
   aes #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[21:20]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .AES192Enable(1'b1),
     .SecMasking(SecAesMasking),
     .SecSBoxImpl(SecAesSBoxImpl),
@@ -1187,6 +1202,7 @@ module top_englishbreakfast #(
   );
   sram_ctrl #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[22:22]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .RndCnstSramKey(RndCnstSramCtrlMainSramKey),
     .RndCnstSramNonce(RndCnstSramCtrlMainSramNonce),
     .RndCnstLfsrSeed(RndCnstSramCtrlMainLfsrSeed),
@@ -1228,6 +1244,7 @@ module top_englishbreakfast #(
   );
   rom_ctrl #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[23:23]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .BootRomInitFile(RomCtrlBootRomInitFile),
     .RndCnstScrNonce(RndCnstRomCtrlScrNonce),
     .RndCnstScrKey(RndCnstRomCtrlScrKey),
@@ -1255,6 +1272,7 @@ module top_englishbreakfast #(
   );
   rv_core_ibex #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[27:24]),
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .RndCnstLfsrSeed(RndCnstRvCoreIbexLfsrSeed),
     .RndCnstLfsrPerm(RndCnstRvCoreIbexLfsrPerm),
     .RndCnstIbexKeyDefault(RndCnstRvCoreIbexIbexKeyDefault),


### PR DESCRIPTION
## Description

This PR introduces a new parameter `SkewCycles` to `prim_diff_decode`, allowing for configurable tolerance of differential signal skew across asynchronous boundaries. Previously, the module was hardcoded to tolerate only a single cycle of skew.

## Motivation

To enhance its flexibility and adaptability to various design requirements where different levels of signal skew might be expected or tolerated, it is now possible to specify the maximum number of consecutive cycles a differential mismatch can persist before a signal integrity (`SigInt`) issue is flagged.

## Usage

The `SkewCycles` parameter is added to all comportable IPs that use alerts and is routed down to their `prim_alert_(sender|receiver)` and `prim_esc_(sender|receiver)`. In the top design, a new parameter is added to the `top_pkg` called `AlertSkewCycles`. Topgen then connects this parameter during the module instntiation.
