### PR TITLE
[bazel] disable signing emulation perso images

### DIFF
--- a/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
@@ -90,6 +90,8 @@ EARLGREY_SKUS = {
 def disqualified_for_signing(name, data):
     if "staging" in name:
         return True
+    if "emulation" in name:
+        return True
     if "em00" in data["otp"]:
         return True
     return False


### PR DESCRIPTION
This disables signing of emulation perso images, which are signed on the fly by Bazel using fake keys.