### PR TITLE
[rv_core_ibex] Use a default lc_ctrl_pkg::On for lc_cpu_en

### DIFF
--- a/hw/ip_templates/rv_core_ibex/data/rv_core_ibex.hjson.tpl
+++ b/hw/ip_templates/rv_core_ibex/data/rv_core_ibex.hjson.tpl
@@ -171,6 +171,7 @@
       name:    "lc_cpu_en",
       act:     "rcv",
       package: "lc_ctrl_pkg",
+      default: "lc_ctrl_pkg::On",
     },
 
     { struct:  "lc_tx",

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -11469,8 +11469,8 @@
           type: uni
           act: rcv
           width: 1
+          default: lc_ctrl_pkg::On
           inst_name: rv_core_ibex
-          default: ""
           top_signame: lc_ctrl_lc_cpu_en
           index: -1
         }
@@ -27420,8 +27420,8 @@
         type: uni
         act: rcv
         width: 1
+        default: lc_ctrl_pkg::On
         inst_name: rv_core_ibex
-        default: ""
         top_signame: lc_ctrl_lc_cpu_en
         index: -1
       }

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
@@ -167,6 +167,7 @@
       name:    "lc_cpu_en",
       act:     "rcv",
       package: "lc_ctrl_pkg",
+      default: "lc_ctrl_pkg::On",
     },
 
     { struct:  "lc_tx",

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -10165,8 +10165,8 @@
           type: uni
           act: rcv
           width: 1
+          default: lc_ctrl_pkg::On
           inst_name: rv_core_ibex
-          default: ""
           top_signame: lc_ctrl_lc_cpu_en
           index: -1
         }
@@ -24463,8 +24463,8 @@
         type: uni
         act: rcv
         width: 1
+        default: lc_ctrl_pkg::On
         inst_name: rv_core_ibex
-        default: ""
         top_signame: lc_ctrl_lc_cpu_en
         index: -1
       }

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
@@ -167,6 +167,7 @@
       name:    "lc_cpu_en",
       act:     "rcv",
       package: "lc_ctrl_pkg",
+      default: "lc_ctrl_pkg::On",
     },
 
     { struct:  "lc_tx",

--- a/hw/top_earlgrey/templates/toplevel.sv.tpl
+++ b/hw/top_earlgrey/templates/toplevel.sv.tpl
@@ -364,11 +364,6 @@ module top_${top["name"]} #(
   assign rv_core_ibex_boot_addr = ADDR_SPACE_ROM;
 % endif
 
-  ## Not all top levels have a lifecycle controller.
-  ## For those that do not, always enable ibex.
-% if not lib.find_module(top["module"], 'lc_ctrl'):
-  assign rv_core_ibex_lc_cpu_en = lc_ctrl_pkg::On;
-% endif
 
   // Struct breakout module tool-inserted DFT TAP signals
   pinmux_jtag_breakout u_dft_tap_breakout (

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -4834,9 +4834,8 @@
           type: uni
           act: rcv
           width: 1
+          default: lc_ctrl_pkg::On
           inst_name: rv_core_ibex
-          default: ""
-          top_signame: rv_core_ibex_lc_cpu_en
           index: -1
         }
         {
@@ -5255,7 +5254,6 @@
       rv_core_ibex.irq_timer
       rv_core_ibex.hart_id
       rv_core_ibex.boot_addr
-      rv_core_ibex.lc_cpu_en
       pinmux_aon.dft_jtag
       sram_ctrl_main.otp_en_sram_ifetch
     ]
@@ -11655,9 +11653,8 @@
         type: uni
         act: rcv
         width: 1
+        default: lc_ctrl_pkg::On
         inst_name: rv_core_ibex
-        default: ""
-        top_signame: rv_core_ibex_lc_cpu_en
         index: -1
       }
       {
@@ -13479,15 +13476,6 @@
         struct: logic
         signame: rv_core_ibex_boot_addr
         width: 32
-        type: uni
-        end_idx: -1
-        default: ""
-      }
-      {
-        package: lc_ctrl_pkg
-        struct: lc_tx
-        signame: rv_core_ibex_lc_cpu_en
-        width: 1
         type: uni
         end_idx: -1
         default: ""

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -757,9 +757,6 @@
         // hardwired connections
         'rv_core_ibex.hart_id', 'rv_core_ibex.boot_addr',
 
-        // lc_ctrl.lc_cpu_en - always enabled for English Breakfast
-        'rv_core_ibex.lc_cpu_en'
-
         // Xbars
 
         // Pinmux JTAG signals for the tool-inserted DFT TAP

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
@@ -167,6 +167,7 @@
       name:    "lc_cpu_en",
       act:     "rcv",
       package: "lc_ctrl_pkg",
+      default: "lc_ctrl_pkg::On",
     },
 
     { struct:  "lc_tx",

--- a/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
@@ -376,7 +376,6 @@ module top_englishbreakfast #(
   logic       rv_core_ibex_irq_timer;
   logic [31:0] rv_core_ibex_hart_id;
   logic [31:0] rv_core_ibex_boot_addr;
-  lc_ctrl_pkg::lc_tx_t       rv_core_ibex_lc_cpu_en;
   jtag_pkg::jtag_req_t       pinmux_aon_dft_jtag_req;
   jtag_pkg::jtag_rsp_t       pinmux_aon_dft_jtag_rsp;
   prim_mubi_pkg::mubi8_t       sram_ctrl_main_otp_en_sram_ifetch;
@@ -403,7 +402,6 @@ module top_englishbreakfast #(
 
   assign rv_core_ibex_boot_addr = ADDR_SPACE_ROM_CTRL__ROM;
 
-  assign rv_core_ibex_lc_cpu_en = lc_ctrl_pkg::On;
 
   // Struct breakout module tool-inserted DFT TAP signals
   pinmux_jtag_breakout u_dft_tap_breakout (
@@ -1332,7 +1330,7 @@ module top_englishbreakfast #(
       .esc_rx_o(),
       .debug_req_i('0),
       .crash_dump_o(rv_core_ibex_crash_dump),
-      .lc_cpu_en_i(rv_core_ibex_lc_cpu_en),
+      .lc_cpu_en_i(lc_ctrl_pkg::On),
       .pwrmgr_cpu_en_i(pwrmgr_aon_fetch_en),
       .pwrmgr_o(rv_core_ibex_pwrmgr),
       .nmi_wdog_i('0),


### PR DESCRIPTION
AFAICT lc_ctrl's only connection to Ibex is lc_cpu_en, but there's assertions and a CM that need to be gated out, so it's not as simple as an SV parameter. To use this, set ipgen_param.LcCtrl to "false" to disable lc_ctrl's fetch enable signal (and also remove the `lc_cpu_en` inter-module signal).