### PR TITLE
[top_darjeeling] Use FuseSoC mapping for Darjeeling-specific pwrmgr dependency

### DIFF
--- a/hw/ip/soc_dbg_ctrl/soc_dbg_ctrl.core
+++ b/hw/ip/soc_dbg_ctrl/soc_dbg_ctrl.core
@@ -11,10 +11,7 @@ filesets:
       - lowrisc:ip:tlul
       - lowrisc:ip:rom_ctrl_pkg
       - lowrisc:ip:soc_dbg_ctrl_pkg
-      # TODO(PR #23555): This must depend upon the Darjeeling pwrmgr pkg directly
-      # for the pwr_boot_status_t structure presently.
-      # - lowrisc:ip_interfaces:pwrmgr_pkg
-      - lowrisc:darjeeling_ip:pwrmgr_pkg
+      - lowrisc:ip_interfaces:pwrmgr_pkg
       - lowrisc:ip:lc_ctrl_pkg
     files:
       - rtl/soc_dbg_ctrl_reg_pkg.sv

--- a/hw/ip_templates/pwrmgr/pwrmgr_pkg.core.tpl
+++ b/hw/ip_templates/pwrmgr/pwrmgr_pkg.core.tpl
@@ -4,6 +4,8 @@ CAPI=2:
 # SPDX-License-Identifier: Apache-2.0
 name: ${instance_vlnv("lowrisc:ip:pwrmgr_pkg:0.1")}
 description: "Power manager package"
+virtual:
+  - lowrisc:ip_interfaces:pwrmgr_pkg
 
 filesets:
   files_rtl:

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/pwrmgr_pkg.core
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/pwrmgr_pkg.core
@@ -4,6 +4,8 @@ CAPI=2:
 # SPDX-License-Identifier: Apache-2.0
 name: lowrisc:darjeeling_ip:pwrmgr_pkg:0.1
 description: "Power manager package"
+virtual:
+  - lowrisc:ip_interfaces:pwrmgr_pkg
 
 filesets:
   files_rtl:

--- a/hw/top_darjeeling/top_darjeeling.core
+++ b/hw/top_darjeeling/top_darjeeling.core
@@ -103,6 +103,7 @@ mapping:
   "lowrisc:virtual_constants:top_racl_pkg": "lowrisc:darjeeling_constants:top_racl_pkg"
   "lowrisc:systems:ast_pkg": "lowrisc:systems:top_darjeeling_ast_pkg"
   "lowrisc:dv:chip_env": "lowrisc:dv:top_darjeeling_chip_env"
+  "lowrisc:ip_interfaces:pwrmgr_pkg": "lowrisc:darjeeling_ip:pwrmgr_pkg"
   # TODO(#27347): prim_legacy_pkg is deprecated
   "lowrisc:prim:prim_pkg": "lowrisc:prim:prim_legacy_pkg"
 

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/pwrmgr_pkg.core
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/pwrmgr_pkg.core
@@ -4,6 +4,8 @@ CAPI=2:
 # SPDX-License-Identifier: Apache-2.0
 name: lowrisc:earlgrey_ip:pwrmgr_pkg:0.1
 description: "Power manager package"
+virtual:
+  - lowrisc:ip_interfaces:pwrmgr_pkg
 
 filesets:
   files_rtl:

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/pwrmgr_pkg.core
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/pwrmgr_pkg.core
@@ -4,6 +4,8 @@ CAPI=2:
 # SPDX-License-Identifier: Apache-2.0
 name: lowrisc:englishbreakfast_ip:pwrmgr_pkg:0.1
 description: "Power manager package"
+virtual:
+  - lowrisc:ip_interfaces:pwrmgr_pkg
 
 filesets:
   files_rtl:


### PR DESCRIPTION
Ridding the TODO, thanks to #23555!