### PR TITLE
Misc typo fixes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,7 +14,7 @@ PointerAlignment: Right
 #
 # This is slightly more confusing as some headers are auto-generated at build
 # time (*_regs.h), and some are auto-generated and checked in to the repo
-# (hw/top_earlgrey/sw/autogen/*.h). These rules cover both occurences.
+# (hw/top_earlgrey/sw/autogen/*.h). These rules cover both occurrences.
 #
 # The version of clang-format that we use does not regroup include statements,
 # but this is something we could do in future.

--- a/.flake8
+++ b/.flake8
@@ -7,6 +7,6 @@ ignore =
   # them when there's a long argument (help text, for example).
   E251,
   # Don't complain about line breaks before or after operators. The
-  # recomendations on this have changed in 2016, so leave out the explicit
+  # recommendations on this have changed in 2016, so leave out the explicit
   # checks: https://www.flake8rules.com/rules/W503.html
   W503, W504

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -663,7 +663,7 @@
   - [Directory Structure](./doc/contributing/directory_structure.md)
   - [Contributing to Documentation](./doc/contributing/doc/README.md)
     - [An Example IP Block's Documentation](./doc/contributing/doc/example_ip_block.md)
-  - [Continuous Intergration](./doc/contributing/ci/README.md)
+  - [Continuous Integration](./doc/contributing/ci/README.md)
   - [Top-Level Design and Targets](./doc/contributing/system_list.md)
   - [GitHub Notes](./doc/contributing/github_notes.md)
   - [Bazel Notes](./doc/contributing/bazel_notes.md)

--- a/hw/top_darjeeling/sw/autogen/tests/BUILD
+++ b/hw/top_darjeeling/sw/autogen/tests/BUILD
@@ -19,7 +19,7 @@ load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 package(default_visibility = ["//visibility:public"])
 
-# Number of periphals per test
+# Number of peripherals per test
 NR_IRQ_PERIPH_PER_TEST = 10
 
 # Total numbers of tests (the last will contain only remaining IRQs)

--- a/hw/top_earlgrey/sw/autogen/tests/BUILD
+++ b/hw/top_earlgrey/sw/autogen/tests/BUILD
@@ -21,7 +21,7 @@ load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 package(default_visibility = ["//visibility:public"])
 
-# Number of periphals per test
+# Number of peripherals per test
 NR_IRQ_PERIPH_PER_TEST = 10
 
 # Total numbers of tests (the last will contain only remaining IRQs)

--- a/hw/top_englishbreakfast/sw/autogen/tests/BUILD
+++ b/hw/top_englishbreakfast/sw/autogen/tests/BUILD
@@ -19,7 +19,7 @@ load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 package(default_visibility = ["//visibility:public"])
 
-# Number of periphals per test
+# Number of peripherals per test
 NR_IRQ_PERIPH_PER_TEST = 10
 
 # Total numbers of tests (the last will contain only remaining IRQs)

--- a/signing/softhsm/README.md
+++ b/signing/softhsm/README.md
@@ -1,6 +1,6 @@
 # SoftHSM2 Configuration
 
-This is a basic SoftHSM2 configurtion for testing signing flows with fake keys.
+This is a basic SoftHSM2 configuration for testing signing flows with fake keys.
 
 The configuration was created via:
 

--- a/site/book-theme/pagetoc.js
+++ b/site/book-theme/pagetoc.js
@@ -53,7 +53,7 @@ window.addEventListener("load", updateDynamicHighlight);
 window.addEventListener("scroll", updateDynamicHighlight);
 
 /* Style the heading that matches the URL fragment (i.e. when you click a hyperlink).
- * - Find the element with the ":target" psuedoclass applied
+ * - Find the element with the ":target" pseudo-class applied
  * - Measure it's rendered height, and set the '--target-height' variable to this value.
  * - The CSS selected by ":target" will style the horizontal highlighting bar to match this height. */
 var set_target_highlight = function(event) {
@@ -102,7 +102,7 @@ window.addEventListener("resize", set_pagetoc_height);
 
 /* create_pagetoc_structure()
  * Dynamically create a tree of <a> elements for each heading in
- * the content body, with wrapper divs for each level of heirarchy.
+ * the content body, with wrapper divs for each level of hierarchy.
  * This will allow formatting/styling which better illustrates the
  * structure of the page.
  * Add the created structure within the 'pagetoc' element.
@@ -212,7 +212,7 @@ var create_pagetoc_structure = function(el_pagetoc) {
     // startIdx to stopIdx, recursively adding more wrappers if
     // headings in the range are lower Hnum.
     // Strictly, 'startIdx <= stopIdx'
-    // This allows the heirarchy of the headings to be mirrored
+    // This allows the hierarchy of the headings to be mirrored
     // within the pagetoc structure, allowing for some context-aware
     // formatting options.
     function wrapAllDescendingElems(

--- a/util/design/README.md
+++ b/util/design/README.md
@@ -269,7 +269,7 @@ produces the following parameters for an 8-bit LFSR.
 ```
 ------------------------------------------------
 | COPY PASTE THE CODE TEMPLATE BELOW INTO YOUR |
-| RTL CODE, INLUDING THE COMMENT IN ORDER TO   |
+| RTL CODE, INCLUDING THE COMMENT IN ORDER TO  |
 | EASE AUDITABILITY AND REPRODUCIBILITY.       |
 ------------------------------------------------
 

--- a/util/design/gen-flash-img.py
+++ b/util/design/gen-flash-img.py
@@ -5,7 +5,7 @@
 r"""Takes a compiled VMEM image and processes it for loading into flash.
 
     Specifically, this takes a raw flash image and adds both layers of ECC
-    (integrity and reliablity), and optionally, scrambles the data using the
+    (integrity and reliability), and optionally, scrambles the data using the
     same XEX scrambling scheme used in the flash controller. This enables
     backdoor loading the flash on simulation platforms (e.g., DV and Verilator).
 """
@@ -325,7 +325,7 @@ def _reformat_flash_vmem(
                                          scrambling_configs.addr_key,
                                          scrambling_configs.data_key)
                     data_w_intg_ecc = intg_ecc | data
-                # `data_w_full_ecc` will be in format {reliablity ECC bits,
+                # `data_w_full_ecc` will be in format {reliability ECC bits,
                 # integrity ECC bits, data bits}.
                 data_w_full_ecc, _ = secded_gen.ecc_encode(
                     ecc_configs, "hamming",
@@ -395,7 +395,7 @@ def main(argv: List[str]):
     if scrambling_configs.scrambling_enabled:
         _compute_flash_scrambling_keys(scrambling_configs)
 
-    # Reformat flash VMEM file to add integrity/reliablity ECC and scrambling.
+    # Reformat flash VMEM file to add integrity/reliability ECC and scrambling.
     reformatted_vmem_lines = _reformat_flash_vmem(args.in_flash_vmem,
                                                   scrambling_configs)
 

--- a/util/design/gen-lfsr-seed.py
+++ b/util/design/gen-lfsr-seed.py
@@ -15,7 +15,7 @@ from lib import common as common
 SV_INSTRUCTIONS = """
 ------------------------------------------------
 | COPY PASTE THE CODE TEMPLATE BELOW INTO YOUR |
-| RTL CODE, INLUDING THE COMMENT IN ORDER TO   |
+| RTL CODE, INCLUDING THE COMMENT IN ORDER TO  |
 | EASE AUDITABILITY AND REPRODUCIBILITY.       |
 ------------------------------------------------
 """

--- a/util/design/gen-top-docs.py
+++ b/util/design/gen-top-docs.py
@@ -14,7 +14,7 @@ from tabulate import tabulate
 
 
 def to_markdown(text):
-    """Adds prefix and sufix newlines to 'text'."""
+    """Adds prefix and suffix newlines to 'text'."""
     doc_text = f"""
 {text}
 """

--- a/util/design/lib/LcStEnc.py
+++ b/util/design/lib/LcStEnc.py
@@ -47,7 +47,7 @@ def _get_incremental_codewords(config, base_ecc, existing_words):
 
     # We only need to spin through data bits that have not been set yet.
     # Hence, we first count how many bits are zero (and hence still
-    # modifyable). Then, we enumerate all possible combinations and scatter
+    # modifiable). Then, we enumerate all possible combinations and scatter
     # the bits of the enumerated values into the correct bit positions using
     # the scatter_bits() function.
     incr_cands = []

--- a/util/design/secded_gen.py
+++ b/util/design/secded_gen.py
@@ -735,7 +735,7 @@ def _hsiao_code(k, m):
     # Then message _k_ X matrix_code ==> original message with parity
     #
     # Make a row to have even number of 1 including the I matrix.
-    # This helps to calculate the syndrom at the decoding stage.
+    # This helps to calculate the syndrome at the decoding stage.
     # To reduce the max fan-in, Starting with smallest number 3.
     # the number means the number of one in a row.
     # Small number of ones means smaller fan-in overall.

--- a/util/design/sparse-fsm-encode.py
+++ b/util/design/sparse-fsm-encode.py
@@ -31,17 +31,17 @@ MAX_DRAWS = 10000
 MAX_RESTARTS = 10000
 
 SV_INSTRUCTIONS = """
-------------------------------------------------------
-| COPY PASTE THE CODE TEMPLATE BELOW INTO YOUR RTL   |
-| IMPLEMENTATION, INLUDING THE COMMENT AND PRIM_FLOP |
-| IN ORDER TO EASE AUDITABILITY AND REPRODUCIBILITY. |
-------------------------------------------------------
+-------------------------------------------------------
+| COPY PASTE THE CODE TEMPLATE BELOW INTO YOUR RTL    |
+| IMPLEMENTATION, INCLUDING THE COMMENT AND PRIM_FLOP |
+| IN ORDER TO EASE AUDITABILITY AND REPRODUCIBILITY.  |
+-------------------------------------------------------
 """
 
 C_INSTRUCTIONS = """
 ------------------------------------------------
 | COPY PASTE THE CODE TEMPLATE BELOW INTO YOUR |
-| C HEADER, INLUDING THE COMMENT IN ORDER TO   |
+| C HEADER, INCLUDING THE COMMENT IN ORDER TO  |
 | EASE AUDITABILITY AND REPRODUCIBILITY.       |
 ------------------------------------------------
 """
@@ -49,7 +49,7 @@ C_INSTRUCTIONS = """
 RUST_INSTRUCTIONS = """
 ------------------------------------------------
 | COPY PASTE THE CODE TEMPLATE BELOW INTO YOUR |
-| RUST FILE, INLUDING THE COMMENT IN ORDER TO  |
+| RUST FILE, INCLUDING THE COMMENT IN ORDER TO |
 | EASE AUDITABILITY AND REPRODUCIBILITY.       |
 ------------------------------------------------
 """

--- a/util/device_sw_utils/extract_sw_logs.py
+++ b/util/device_sw_utils/extract_sw_logs.py
@@ -22,7 +22,7 @@ from elftools.elf import elffile
 
 # A printf statement in C code is converted into a single write to a reserved
 # address in the RAM. The value written is the address of the log_fields_t
-# struct constucted from the log. It has the following fields:
+# struct constructed from the log. It has the following fields:
 # severity (int), 4 bytes:        0 (I), 1 (W), 2 (E), 3 (F)
 # file_name (int, ptr), 4 bytes:  Pointer to file_name string.
 # Line no (int), 4 bytes:         Line number of the log message.
@@ -68,7 +68,7 @@ def cleanup_format(_format):
     - Change %![N]?b        --> %[N]?d.
 
     Status values are printed as hexadecimal values which can be manually decoded
-    by users as necessary, to prevent errors occuring in tests due to lacking
+    by users as necessary, to prevent errors occurring in tests due to lacking
     support for this formatting specifier. JSON support for status printing is
     likewise just replaced by displaying the hex.
     - Change %!?[N]?r        --> %8h'''
@@ -130,7 +130,7 @@ def get_addr_strings(ro_contents):
     This function processes the read-only sections of the elf supplied as
     a list of ro_content tuples comprising of base addr, size and data in bytes
     and converts it into an {addr: (string, length} dict which is returned.
-    We preserve the original length of the string becuase the string may
+    We preserve the original length of the string because the string may
     go through cleanup methods which will alter it.'''
     result = {}
     for ro_content in ro_contents:

--- a/util/dtgen/dt_api.h.tpl
+++ b/util/dtgen/dt_api.h.tpl
@@ -87,7 +87,7 @@ dt_instance_id_t dt_plic_id_to_instance_id(dt_plic_irq_id_t irq);
  *
  * This type represents a raw alert ID from the Alert Handler.
  *
- * This is an alias to the top's `alert_id_t` type for backward compatability
+ * This is an alias to the top's `alert_id_t` type for backward compatibility
  * with existing code.
  */
 typedef ${top_name.as_snake_case()}_alert_id_t dt_alert_id_t;

--- a/util/dtgen/helper.py
+++ b/util/dtgen/helper.py
@@ -530,7 +530,7 @@ registers to connect a peripheral to this pad.""",  # noqa:E501
                 self.inst_from_irq_values[name] = module_name
 
     def has_alert_handler(self):
-        # FIXME find a better way then just harcoding this module name
+        # FIXME find a better way then just hardcoding this module name
         return any(module["name"] == "alert_handler" for module in self.top["module"])
 
     def _init_alert_map(self):
@@ -671,7 +671,7 @@ class IpHelper:
         return len(self.ip.alerts) > 0
 
     def has_alert_handler(self):
-        # FIXME find a better way then just harcoding this module name
+        # FIXME find a better way then just hardcoding this module name
         return any(module["name"] == "alert_handler" for module in self.top["module"])
 
     def _init_alerts(self):

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -188,7 +188,7 @@ class Deploy():
         """Recursively search and replace substitution variables.
 
         First pass: search within self dict. We ignore errors since some
-        substitions may be available in the second pass. Second pass: search
+        substitutions may be available in the second pass. Second pass: search
         the entire sim_cfg object."""
 
         self.__dict__ = find_and_substitute_wildcards(self.__dict__,

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -322,7 +322,7 @@ class FlowCfg():
             sys.exit(1)
 
     def _purge(self):
-        '''Purge the existing scratch areas in preperation for the new run.'''
+        '''Purge the existing scratch areas in preparation for the new run.'''
         return
 
     def purge(self):

--- a/util/dvsim/LsfLauncher.py
+++ b/util/dvsim/LsfLauncher.py
@@ -278,7 +278,7 @@ class LsfLauncher(Launcher):
         # so that we can report the status accurately.
         #
         # At this point, we could run bjobs or bhist to determine the status,
-        # but it has been found to be too slow, expecially when running 1000s
+        # but it has been found to be too slow, especially when running 1000s
         # of jobs. Plus, we have to read the job script output anyway to look
         # for those error messages.
         #

--- a/util/dvsim/NcLauncher.py
+++ b/util/dvsim/NcLauncher.py
@@ -72,7 +72,7 @@ class NcLauncher(Launcher):
                 ['--', f'{odir}/run.sh'])
 
     def _pre_launch(self):
-        # store the start_time (correspoinding to job wait time counter)
+        # store the start_time (corresponding to job wait time counter)
         super()._pre_launch()
         # set the nc_job_state to the initial state - waiting for resource
         self.nc_job_state = 'waiting'

--- a/util/dvsim/SynCfg.py
+++ b/util/dvsim/SynCfg.py
@@ -71,7 +71,7 @@ class SynCfg(OneShotCfg):
         #     },
         #
         #     "timing": {
-        #         # per timing group (ususally a clock domain)
+        #         # per timing group (usually a clock domain)
         #         # in nano seconds
         #         <group>  : {
         #             "tns"    : <value>,
@@ -92,7 +92,7 @@ class SynCfg(OneShotCfg):
         #         "macro"  : <value>,
         #         "total"  : <value>,
         #
-        #         # hierchical report of first submodule level
+        #         # hierarchical report of first submodule level
         #         "instances" : {
         #             <name> : {
         #               "comb"  : <value>,

--- a/util/dvsim/Testplan.py
+++ b/util/dvsim/Testplan.py
@@ -203,7 +203,7 @@ class Testpoint(Element):
         """Map test results to tests against this testpoint.
 
         Given a list of test results find the ones that match the tests listed
-        in this testpoint and buiild a structure. If no match is found, or if
+        in this testpoint and build a structure. If no match is found, or if
         self.tests is an empty list, indicate 0/1 passing so that it is
         factored into the final total.
         """
@@ -719,7 +719,7 @@ class Testplan:
         """Returns the final total as a summary."""
         assert self.test_results_mapped, "Have you invoked map_test_results()?"
 
-        # The last item in tespoints is the final sum total. We use that to
+        # The last item in testpoints is the final sum total. We use that to
         # return the results summary as a dict.
         total = self.testpoints[-1]
         assert total.name == "N.A."

--- a/util/dvsim/doc/design_doc.md
+++ b/util/dvsim/doc/design_doc.md
@@ -51,7 +51,7 @@ Some of the goals / usecases listed below are specific to an EDA tool flow (such
 - Readability
   - Describe testplans, tool configurations, build modes, run modes, test specifications, testplans and regressions in a human readable, but machine parsable format.
 
-- Scalablility
+- Scalability
   - Enable launching jobs into each new partner's unique compute infrastructure.
   - Provide a method to easily add support for more new EDA tool flows.
   - Support a wide variety of open / commercial EDA tools for each flow (i.e. run the same simulation with Synopsys VCS, Cadence Xcelium or Mentor Graphics Questa etc.).
@@ -84,11 +84,11 @@ Some of the goals / usecases listed below are specific to an EDA tool flow (such
     - Enable specification of common passing and failing patterns.
     - Enable specification of failing patterns that are specific to the EDA tool itself.
     - Assess pass / fail by parsing the EDA tool flow's log i.e., none of the failing patterns must be seen AND all passing patterns must be seen.
-  - Enable common failure signatures to be bucketized for the ease of readablility of the report.
+  - Enable common failure signatures to be bucketized for the ease of readability of the report.
   - Provide ability to publish the reports to a web server (as a command line option).
   - Report the wall-clock time and simulated time (the worst case, if the test is multiply seeded) for each test.
   - For simulations, enable mapping the results of the regression (i.e., the status of the set of tests run) to the testplan entries to indicate the testpoints that have been successfully completed.
-  - Enable common failure signatures to be bucketized for the ease of readablility of the report.
+  - Enable common failure signatures to be bucketized for the ease of readability of the report.
 
 - Debuggability
   - Provide logging at multiple levels (normal, verbose and debug) to help debug / triage tool / infrastructure issues.

--- a/util/dvsim/doc/glossary.md
+++ b/util/dvsim/doc/glossary.md
@@ -32,7 +32,7 @@ The [IBM LSF](https://www.ibm.com/docs/en/spectrum-lsf/10.1.0?topic=overview-lsf
 EDA tool flows are run at various levels of the design:
 - **Primitives**:
   The most basic building blocks used to create hardware designs
-  OpenTitan provides a library of reusble [primitives](../../../hw/ip/prim/).
+  OpenTitan provides a library of reusable [primitives](../../../hw/ip/prim/).
 
 - **Modules**:
   A discrete entity that implements a specific feature of a larger design
@@ -98,7 +98,7 @@ Please see [TBD]() for more details.
 DVSim provides these standard regression targets for all DUTs:
 - `smoke` (typically run in CI checks)
 - `nightly` (a full regression with coverage enabled, that is run every night)
-- `v1` / `v2` / `v3` (DVSim automatically extracts tests that are tagged V1 / V2 / V3 and creates a regression target.
+- `v1` / `v2` / `v3` (DVSim automatically extracts tests that are tagged V1 / V2 / V3 and creates a regression target).
 - `all` (runs all tests with the preset reseeds, without coverage)
 - `all_once` (run all tests with only a single randomly chosen seed)
 
@@ -145,7 +145,7 @@ The test specification label(s) that satisfy a testpoint are mapped to the testp
 
 ## Top level
 
-A top level entity is the highest design entity (i.e., a design entity which is itself, not instatiated as a sub-module in a different module) that is compiled and elaborated.
+A top level entity is the highest design entity (i.e., a design entity which is itself, not instantiated as a sub-module in a different module) that is compiled and elaborated.
 For simulations, this is typically the testbench, since it instantiates the DUT.
 In simulations, there are also standalone RTL modules (specifically, SVA bindfiles) that are not directly instantiated in the testbench or the DUT hierarchies.
 These are also considered "top levels" that are elaborated by the tool.

--- a/util/dvsim/qsubopts.py
+++ b/util/dvsim/qsubopts.py
@@ -6,7 +6,7 @@
 # ----------------------------------
 # qsubOptions Class
 # ----------------------------------
-"""A helper class designed to handle the managment of options and
+"""A helper class designed to handle the management of options and
 positional arguments to qsub and related Grid Engine executables.
 
 Contains functions to write the requested execution string either

--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -303,7 +303,7 @@ def find_and_substitute_wildcards(sub_dict,
     '''
     for key in sub_dict.keys():
         if type(sub_dict[key]) in [dict, OrderedDict]:
-            # Recursively call this funciton in sub-dicts
+            # Recursively call this function in sub-dicts
             sub_dict[key] = find_and_substitute_wildcards(
                 sub_dict[key], full_dict, ignored_wildcards, ignore_error)
 
@@ -313,7 +313,7 @@ def find_and_substitute_wildcards(sub_dict,
             # in case it contains a wildcard
             for i in range(len(sub_dict_key_values)):
                 if type(sub_dict_key_values[i]) in [dict, OrderedDict]:
-                    # Recursively call this funciton in sub-dicts
+                    # Recursively call this function in sub-dicts
                     sub_dict_key_values[i] = \
                         find_and_substitute_wildcards(sub_dict_key_values[i],
                                                       full_dict, ignored_wildcards, ignore_error)
@@ -361,7 +361,7 @@ def htmc_color_pc_cells(text):
     Depending on the identifier, it shades the cell in a specific way. A set of
     12 color palettes for setting those shades are encoded in ./style.css.
     These are 'cna' (grey), 'c0' (red), 'c1' ... 'c10' (green). The shade 'cna'
-    is used for items that are maked as 'not applicable'. The shades 'c1' to
+    is used for items that are marked as 'not applicable'. The shades 'c1' to
     'c9' form a gradient from red to lime-green to indicate 'levels of
     completeness'. 'cna' is used for greying out a box for 'not applicable'
     items, 'c0' is for items that are considered risky (or not yet started) and
@@ -391,7 +391,7 @@ def htmc_color_pc_cells(text):
         indicator is negative.
 
     N/A items can have any of the following indicators and need not be
-    preceeded with a numerical value:
+    preceded with a numerical value:
 
     '--', 'NA', 'N.A.', 'N.A', 'N/A', 'na', 'n.a.', 'n.a', 'n/a'
 
@@ -400,7 +400,7 @@ def htmc_color_pc_cells(text):
     # Replace <td> with <td class="color-class"> based on the fp
     # value. "color-classes" are listed in ./style.css as follows: "cna"
     # for NA value, "c0" to "c10" for fp value falling between 0.00-9.99,
-    # 10.00-19.99 ... 90.00-99.99, 100.0 respetively.
+    # 10.00-19.99 ... 90.00-99.99, 100.0 respectively.
     def color_cell(cell, cclass, indicator="%"):
         op = cell.replace("<td", "<td class=\"" + cclass + "\"")
         # Remove the indicator.
@@ -563,7 +563,7 @@ def mk_path(path):
 
     'path' is a Path-like object. If it does exist, the function simply
     returns. If it does not exist, the function creates the path and its
-    parent dictories if necessary.
+    parent directories if necessary.
     '''
     try:
         Path(path).mkdir(parents=True, exist_ok=True)

--- a/util/fix_trailing_whitespace.py
+++ b/util/fix_trailing_whitespace.py
@@ -55,7 +55,7 @@ def main():
         '--recursive', '-r',
         action='store_true',
         default=False,
-        help='traverse the entire tree modolo .gitignore'
+        help='traverse the entire tree modulo .gitignore'
     )
     parser.add_argument(
         '--verbose', '-v',

--- a/util/fpga/splice_rom.sh
+++ b/util/fpga/splice_rom.sh
@@ -127,7 +127,7 @@ hw/ip/rom_ctrl/util/gen_vivado_mem_image.py \
 
 # Splice the ROM.
 # The --debug flag is undocumented and causes updatemem to print out the INIT_XX
-# values of the four BRAM cells. These values are also oberservable when opening
+# values of the four BRAM cells. These values are also observable when opening
 # the implemented design in Vivado and then inspecting the cell properties of
 # the corresponding BRAM cells. This information is very useful when debugging
 # the splicing flow.

--- a/util/fpvgen.py
+++ b/util/fpvgen.py
@@ -34,7 +34,7 @@ def main():
         util/fpvgen.py hw/ip/prim/rtl/prim_fifo_sync.sv
 
         By default, the output directory is assumed to be '../fpv' with respect
-        to the toplevel module, but this can be overriden using the -eo switch.
+        to the toplevel module, but this can be overridden using the -eo switch.
 
         Further if the IP is comportable, this can be indicated using the -c
         switch, which causes the generator to add a bind statement for the CSR

--- a/util/fpvgen/README.md
+++ b/util/fpvgen/README.md
@@ -56,7 +56,7 @@ usage: fpvgen [-h] [-o OUTDIR] [-c] file
         util/fpvgen.py hw/ip/prim/rtl/prim_fifo_sync.sv
 
         By default, the output directory is assumed to be '../fpv' with respect
-        to the toplevel module, but this can be overriden using the -eo switch.
+        to the toplevel module, but this can be overridden using the -eo switch.
 
         Further if the IP is comportable, this can be indicated using the -c
         switch, which causes the generator to add a bind statement for the CSR

--- a/util/i2csvg/convert.py
+++ b/util/i2csvg/convert.py
@@ -202,7 +202,7 @@ def parse_file(infile, fifodata=False, prefix=None):
             continue
         schar = ','
         if fifodata and ',' not in line:
-            # fifodata could also be whitespace spearated
+            # fifodata could also be whitespace separated
             schar = None
 
         for sline in line.split(sep=schar):

--- a/util/make_new_dif/ip.py
+++ b/util/make_new_dif/ip.py
@@ -135,7 +135,7 @@ class Ip:
 
     def _load_parameters(self):
         assert (self._hjson_data and
-                "ERROR: must load IP HJSON before loarding Parameters")
+                "ERROR: must load IP HJSON before loading Parameters")
         parameters = {}
         if "param_list" in self._hjson_data:
             for parameter in self._hjson_data["param_list"]:

--- a/util/mdbook/difgen.py
+++ b/util/mdbook/difgen.py
@@ -138,7 +138,7 @@ def _get_html_or_empty(element: ET.Element, xpath: str) -> str:
     can be used to write CSS targeting specific Doxygen tags and recreate the
     intended formatting.
 
-    In addtion, the following semantic transformations are performed:
+    In addition, the following semantic transformations are performed:
     - `computeroutput` is transformed to `code`
 
     [1] https://github.com/doxygen/doxygen/blob/master/templates/xml/compound.xsd"""

--- a/util/mdbook_code_snippet.py
+++ b/util/mdbook_code_snippet.py
@@ -48,7 +48,7 @@ def is_declaration(line: str, defn: str) -> bool:
 
 
 def get_header_snippet(m: re.Match) -> str:
-    '''Given the filename and defintion name, create a Markdown snippet.
+    '''Given the filename and definition name, create a Markdown snippet.
 
     This function uses a very simplistic method to get the declaration from the
     header file plus the comment above it, if available:

--- a/util/otbn_build.py
+++ b/util/otbn_build.py
@@ -15,7 +15,7 @@ environment variables:
   sensible default values are provided (tools are generally expected to be in
   the $PATH).
 
-  OTBN_TOOLS         path to the OTBN linker and assemler tools
+  OTBN_TOOLS         path to the OTBN linker and assembler tools
   RV32_TOOL_LD       path to RV32 ld
   RV32_TOOL_AS       path to RV32 as
   RV32_TOOL_AR       path to RV32 ar

--- a/util/reggen/README.md
+++ b/util/reggen/README.md
@@ -127,7 +127,7 @@ reset_request_list | optional | list | list of signals requesting reset
 scan | optional | python Bool | Indicates the module have `scanmode_i`
 scan_reset | optional | python Bool | Indicates the module have `scan_rst_ni`
 scan_en | optional | python Bool | Indicates the module has `scan_en_i`
-SPDX-License-Identifier | optional | string | License ientifier (if using pure json) Only use this if unable to put this information in a comment at the top of the file.
+SPDX-License-Identifier | optional | string | License identifier (if using pure json) Only use this if unable to put this information in a comment at the top of the file.
 wakeup_list | optional | name list+ | list of peripheral wakeups
 countermeasures | optional | name list | list of countermeasures in this block
 features | optional | name list | list of functional features in this block
@@ -254,7 +254,7 @@ In all of these the swaccess parameter is inherited from the register
 level, and will be added so this key is always available to the
 backend. The RXS and ENRXS will default to zero reset value (unless
 something different is provided for the register) and will have the
-key added, but TXILVL expicitly sets its reset value as 2.
+key added, but TXILVL explicitly sets its reset value as 2.
 
 The missing bits 17 and 18 will be treated as reserved by the tool, as
 will any bits between 21 and the maximum in the register.

--- a/util/reggen/gen_dv.py
+++ b/util/reggen/gen_dv.py
@@ -78,7 +78,7 @@ def gen_core_file(outdir: str, lblock: str, dv_base_names: List[str],
     blocks_base_names = get_dv_base_names_objects(dv_base_names)
 
     if blocks_base_names is not None:
-        # Assume the core file naming convetion is the package name without `_pkg`
+        # Assume the core file naming convention is the package name without `_pkg`
         # suffix.
         for block in blocks_base_names:
             pkg_name = blocks_base_names[block].pkg

--- a/util/reggen/gen_selfdoc.py
+++ b/util/reggen/gen_selfdoc.py
@@ -128,7 +128,7 @@ In all of these the swaccess parameter is inherited from the register
 level, and will be added so this key is always available to the
 backend. The RXS and ENRXS will default to zero reset value (unless
 something different is provided for the register) and will have the
-key added, but TXILVL expicitly sets its reset value as 2.
+key added, but TXILVL explicitly sets its reset value as 2.
 
 The missing bits 17 and 18 will be treated as reserved by the tool, as
 will any bits between 21 and the maximum in the register.

--- a/util/reggen/gen_tock.py
+++ b/util/reggen/gen_tock.py
@@ -32,7 +32,7 @@ def indent(s: str, amount: int = 4) -> str:
     """Indents a multi-line string considering the depth of bracketing.
 
     This function assumes the input string is un-indented.  It will not
-    unindent an inapprorpiately indented string.
+    unindent an inappropriately indented string.
     """
     result = []
     indent = 0

--- a/util/reggen/ip_block.py
+++ b/util/reggen/ip_block.py
@@ -138,7 +138,7 @@ OPTIONAL_FIELDS = {
     'scan_reset': ['pb', 'Indicates the module have `scan_rst_ni`'],
     'scan_en': ['pb', 'Indicates the module has `scan_en_i`'],
     'SPDX-License-Identifier': [
-        's', "License ientifier (if using pure json) "
+        's', "License identifier (if using pure json) "
         "Only use this if unable to put this "
         "information in a comment at the top of the "
         "file."

--- a/util/reggen/multi_register.py
+++ b/util/reggen/multi_register.py
@@ -244,7 +244,7 @@ class MultiRegister(RegBase):
                              'but has regwen_multi set.')
 
         # The checks above should have checked that we cannot "turn on" being
-        # compact with the config file. Make sure of this explictly.
+        # compact with the config file. Make sure of this explicitly.
         assert default_compact or not compact
 
         # Generate the registers that this multireg expands into. Here, a

--- a/util/site/deploy.sh
+++ b/util/site/deploy.sh
@@ -147,7 +147,7 @@ _upload_br () {
 
     for f in $search_indexes; do
         # Get directory of file, relative to the build directory.
-        # - var=${var#*//} # removes stuff from the begining up to //
+        # - var=${var#*//} # removes stuff from the beginning up to //
         dir=$(dirname "${f#*"${build_dir}"/}")
         # When serving from gcloud buckets, file should be uploaded with an identical name as the
         # original, but compressed and with the matching 'content-encoding' and 'content-type' tags applied.

--- a/util/syn_yosys.sh
+++ b/util/syn_yosys.sh
@@ -91,7 +91,7 @@ declare -a modules=(
   "flash_phy"
 )
 
-# TODO: top_earlgrey appears to be too large for verification under the currrent
+# TODO: top_earlgrey appears to be too large for verification under the current
 # setup. Consider adding verification using `hier_compare`.
 
 for module in "${modules[@]}"; do

--- a/util/tlgen/item.py
+++ b/util/tlgen/item.py
@@ -48,12 +48,12 @@ class Node:
     # when False, no storage element
     # when True, FIFO present with default depth, the "fifo_pass"
     # variables control whether a particular direction in the fifo
-    # has the passthrough behvaior
+    # has the passthrough behavior
     pipeline = True
 
-    # FIFO passtru option. default True
+    # FIFO passthru option. default True
     # If pipeline is false, these fields have no meaning
-    # passthrough behavior refers to a FIFO passing the trasnaction
+    # passthrough behavior refers to a FIFO passing the transaction
     # through if the FIFO is currently empty
     req_fifo_pass = True
     rsp_fifo_pass = True

--- a/util/tlgen/lib.py
+++ b/util/tlgen/lib.py
@@ -198,7 +198,7 @@ def get_toggle_excl_bits(addr_ranges: List[List[int]],
     # Find all the bits that can be toggled to 1
     toggle_bits = 0
     for addr in addr_ranges:
-        # The size of the addres range should be power of 2
+        # The size of the address range should be power of 2
         assert is_pow2(addr[1] - addr[0] + 1)
 
         toggle_bits |= addr[0]

--- a/util/tlgen/validate.py
+++ b/util/tlgen/validate.py
@@ -261,7 +261,7 @@ def checkAddressSpacing(addr: Tuple[int, int],
     return len(result) != 0
 
 
-# this returns 1 if the size mask overlapps with the address base
+# this returns 1 if the size mask overlaps with the address base
 def checkBaseSizeOverlap(addr_base: int, size: int) -> int:
     return ((size - 1) & addr_base)
 

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -1436,7 +1436,7 @@ def main():
     parser.add_argument(
         "--no-plic",
         action="store_true",
-        help="If defined, topgen doesn't generate the interrup controller RTLs."
+        help="If defined, topgen doesn't generate the interrupt controller RTLs."
     )
     parser.add_argument("--no-rust",
                         action="store_true",
@@ -1591,7 +1591,7 @@ def main():
     # avoid performing multiple passes when creating the complete top
     # configuration. Please refer to the description in util/topgen/README.md.
     #
-    # This performs mutiple passes until the complete top configuration
+    # This performs multiple passes until the complete top configuration
     # doesn't change.
     #
     # This fix is related to #2083

--- a/util/topgen/README.md
+++ b/util/topgen/README.md
@@ -130,7 +130,7 @@ optional arguments:
   --verbose, -v         Verbose
   --no-top              If defined, topgen doesn't generate top_{name} RTLs.
   --no-xbar             If defined, topgen doesn't generate crossbar RTLs.
-  --no-plic             If defined, topgen doesn't generate the interrup controller RTLs.
+  --no-plic             If defined, topgen doesn't generate the interrupt controller RTLs.
   --no-gen-hjson        If defined, the tool assumes topcfg as a generated hjson. So it
                         bypasses the validation step and doesn't read ip and xbar
                         configurations

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -103,7 +103,7 @@ def elaborate_instance(instance, block: IpBlock):
             log.warning(f"{mod_name} has security-critical parameter "
                         f"{param.name} not exposed to top")
 
-        # Move special prefixes to the beginnining of the parameter name.
+        # Move special prefixes to the beginning of the parameter name.
         param_prefixes = ["Sec", "RndCnst", "MemSize"]
         name_top = cc_mod_name + param.name
         for prefix in param_prefixes:
@@ -182,7 +182,7 @@ def elaborate_instance(instance, block: IpBlock):
                     # signals of all IPs would reference to that single mangled
                     # parameter. Since parameters are instance dependent, that
                     # would fail. Therefore, copy the parameter first to have
-                    # a unique paramter for that particular signal and
+                    # a unique parameter for that particular signal and
                     # instance, which is safe to mangle.
                     s['width'] = deepcopy(s['width'])
                     s['width'].name_top = p['name_top']
@@ -646,7 +646,7 @@ def extract_clocks(top: ConfigT):
         # Ensure each module has a default case
         export_if = ep.get('clock_reset_export', [])
 
-        # The clock group attribute in an end point sets the defaut
+        # The clock group attribute in an end point sets the default
         # group for every clock in that end point.
         #
         # However, the end point can also override specific clocks to
@@ -678,7 +678,7 @@ def extract_clocks(top: ConfigT):
                     name = "{}_i".format(src_name)
 
                 elif group.unique:
-                    # new unqiue clock name
+                    # new unique clock name
                     name = "{}_{}".format(src_name, ep_name)
 
                 else:

--- a/util/topgen/secure_prng.py
+++ b/util/topgen/secure_prng.py
@@ -90,7 +90,7 @@ class secure_prng():
         error out.
         """
 
-        # Checks if the PRNG was instantitated before first use.
+        # Checks if the PRNG was Instantiated before first use.
         if not self.reseed_counter:
             log.error("Seed must be provided before requesting output. " +
                       "Use secure_prng.reseed()")

--- a/util/topgen/templates/BUILD.tpl
+++ b/util/topgen/templates/BUILD.tpl
@@ -76,7 +76,7 @@ load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 package(default_visibility = ["//visibility:public"])
 
-# Number of periphals per test
+# Number of peripherals per test
 NR_IRQ_PERIPH_PER_TEST = ${irq_per_test}
 
 # Total numbers of tests (the last will contain only remaining IRQs)

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -350,7 +350,7 @@ reset_requests_added = {}
 
 reset_request_required = {
     'name': ['s', 'the reset request name'],
-    'desc': ['s', 'the reset request descrption'],
+    'desc': ['s', 'the reset request description'],
     'module': ['s', 'the reset request source'],
 }
 reset_request_optional = {
@@ -478,7 +478,7 @@ class Target:
 class Flash:
     """Flash class contains information regarding parameter defaults.
        For now, only expose banks / pages_per_bank for user configuration.
-       For now, also enforce power of 2 requiremnt.
+       For now, also enforce power of 2 requirement.
     """
     max_banks = 4
     max_pages_per_bank = 1024

--- a/util/uvmdvgen/README.md
+++ b/util/uvmdvgen/README.md
@@ -59,7 +59,7 @@ optional arguments:
                         <name>_agent is created at this location. (default set
                         to './<name>')
   -eo [hw/ip/<ip>], --env-outdir [hw/ip/<ip>]
-                        Path to place the full tetsbench code. It creates 3
+                        Path to place the full testbench code. It creates 3
                         directories - dv, data and doc. The DV document and the
                         testplan Hjson files are placed in the doc and data
                         directories respectively. These are to be merged into
@@ -198,7 +198,7 @@ provided by `-hi` and `-ha` respectively. By default, these are set to 'False'
 
 * `env/i2c_host_scoreboard`
 
-    This is the scoreboard component that already creates the analysis fifos and
+    This is the scoreboard component that already creates the analysis FIFOs and
     queues for the agents passed via `-ea` switch. It adds starter tasks for
     processing each fifo in a forever loop and invokes them in the `run_phase`
     using `fork-join` statement. If the `-c` switch is passed, it also adds a

--- a/util/uvmdvgen/gen_env.py
+++ b/util/uvmdvgen/gen_env.py
@@ -1,7 +1,7 @@
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-"""Generate SystemVerilog UVM agent extended freom our DV lib
+"""Generate SystemVerilog UVM agent extended from our DV lib
 """
 
 import os


### PR DESCRIPTION
Standalone typo fix PR for non-HW and non-SW things.

Attempt at neutral correction of what I hope are universal seen as spelling and capitalisation errors in some documentation and code comments.

Please flag any accidental changes to something that was already correctly spelt. My spell-checker is set to British, not American English, so there's a chance I accidentally "fixed" a spelling I didn't recognise as being the American variant.
