### PR TITLE
[utils] Fixes utils.py for missed .name

### DIFF
--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -610,7 +610,7 @@ def clean_odirs(odir, max_odirs, ts_format=TS_FORMAT):
         return []
 
     dirs = sorted([old for old in pdir.iterdir() if (old.is_dir() and
-                                                     old != 'summary')],
+                                                     old.name != 'summary')],
                   key=os.path.getctime,
                   reverse=True)
 


### PR DESCRIPTION
Here old is a Path object. The old comparison old != 'summary' always evaluates to True because a Path object is never equal to the string 'summary'. Therefore the directory named summary would still be deleted. The updated check uses old.name != 'summary', which compares the directory’s name to the string, so a directory called summary is correctly skipped.