### PR TITLE
[sw] Add `nonstring` attribute

### DIFF
--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -625,6 +625,18 @@ extern "C++" {
 #define OT_USED __attribute__((used))
 
 /**
+ * An attribute used to indicate that a character array variable is not intended
+ * to be treated as a null-terminated string.
+ */
+#if defined(__clang__) && __clang_major__ >= 21
+#define OT_NONSTRING __attribute__((nonstring))
+#elif defined(__GNUC__) && !defined(__clang__)
+#define OT_NONSTRING __attribute__((nonstring))
+#else
+#define OT_NONSTRING
+#endif
+
+/**
  * OT_BUILD_FOR_STATIC_ANALYZER indicates whether we are compiling for the
  * purpose of static analysis. Currently, this macro only detects
  * Clang-Analyzer, which is used as a backend by Clang-Tidy.

--- a/sw/device/lib/runtime/print.c
+++ b/sw/device/lib/runtime/print.c
@@ -47,12 +47,12 @@ enum {
 
 // NOTE: all of the lengths of the strings below are given so that the NUL
 // terminator is left off; that way, `sizeof(kConst)` does not include it.
-static const char kDigitsLow[16] = "0123456789abcdef";
-static const char kDigitsHigh[16] = "0123456789ABCDEF";
+OT_NONSTRING static const char kDigitsLow[16] = "0123456789abcdef";
+OT_NONSTRING static const char kDigitsHigh[16] = "0123456789ABCDEF";
 
-static const char kErrorNul[17] = "%<unexpected nul>";
-static const char kUnknownSpec[15] = "%<unknown spec>";
-static const char kErrorTooWide[12] = "%<bad width>";
+OT_NONSTRING static const char kErrorNul[17] = "%<unexpected nul>";
+OT_NONSTRING static const char kUnknownSpec[15] = "%<unknown spec>";
+OT_NONSTRING static const char kErrorTooWide[12] = "%<bad width>";
 
 static size_t base_dev_null(void *data, const char *buf, size_t len) {
   return len;
@@ -766,7 +766,7 @@ size_t base_vfprintf(buffer_sink_t out, const char *format, va_list args) {
   return bytes_written;
 }
 
-const char kBaseHexdumpDefaultFmtAlphabet[256] =
+OT_NONSTRING const char kBaseHexdumpDefaultFmtAlphabet[256] =
     // clang-format off
   // First 32 characters are not printable.
   "................................"
@@ -829,7 +829,7 @@ size_t base_fhexdump_with(buffer_sink_t out, base_hexdump_fmt_t fmt,
     size_t line_bytes_written = 0;
     for (size_t word = 0; word < bytes_per_line; word += fmt.bytes_per_word) {
       if (len < line + word) {
-        char spaces[16] = "                ";
+        OT_NONSTRING char spaces[16] = "                ";
         while (line_bytes_written < chars_per_line) {
           size_t to_print = chars_per_line - line_bytes_written;
           if (to_print > sizeof(spaces)) {

--- a/sw/device/lib/testing/hmac_testutils.c
+++ b/sw/device/lib/testing/hmac_testutils.c
@@ -12,7 +12,7 @@
 
 #define MODULE_ID MAKE_MODULE_ID('h', 'm', 't')
 
-const char kHmacRefData[34] = "Sample message for keylen=blocklen";
+OT_NONSTRING const char kHmacRefData[34] = "Sample message for keylen=blocklen";
 
 const uint8_t kHmacRefLongKey[100] = {
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B,

--- a/sw/device/silicon_creator/lib/dbg_print.c
+++ b/sw/device/silicon_creator/lib/dbg_print.c
@@ -14,7 +14,7 @@
 #include "sw/device/silicon_creator/lib/drivers/uart.h"
 #include "sw/device/silicon_creator/lib/epmp_defs.h"
 
-static const char kHexTable[16] = "0123456789abcdef";
+OT_NONSTRING static const char kHexTable[16] = "0123456789abcdef";
 
 static void print_integer(unsigned value, bool is_signed) {
   char buf[12];

--- a/sw/device/silicon_creator/lib/drivers/uart.c
+++ b/sw/device/silicon_creator/lib/drivers/uart.c
@@ -109,7 +109,7 @@ void uart_write(const void *data, size_t len) {
 
 void uart_write_hex(uint32_t val, size_t len, uint32_t after) {
   HARDENED_CHECK_LE(len, sizeof(uint32_t));
-  static const uint8_t kHexTable[16] = "0123456789abcdef";
+  OT_NONSTRING static const uint8_t kHexTable[16] = "0123456789abcdef";
   size_t i = len * 8;
   do {
     i -= 4;

--- a/sw/device/silicon_creator/lib/shutdown.c
+++ b/sw/device/silicon_creator/lib/shutdown.c
@@ -370,7 +370,7 @@ static void shutdown_print(shutdown_log_prefix_t prefix, uint32_t val) {
   abs_mmio_write32(kUartBase + UART_WDATA_REG_OFFSET, prefix >> 24);
 
   // Print the hex representation of `val`.
-  const char kHexTable[16] = "0123456789abcdef";
+  OT_NONSTRING const char kHexTable[16] = "0123456789abcdef";
   // `kHexStrLen` is laundered so that it is loaded to a register at every
   // iteration.
   for (size_t i = 0; i < launder32(kHexStrLen); ++i) {

--- a/sw/device/tests/hmac_endianness_test.c
+++ b/sw/device/tests/hmac_endianness_test.c
@@ -39,14 +39,14 @@ static const dif_hmac_transaction_t kHmacconfig_bigd_bigm = {
     .message_endianness = kDifHmacEndiannessBig,
 };
 
-static const char kData[142] =
+OT_NONSTRING static const char kData[142] =
     "Every one suspects himself of at least one of "
     "the cardinal virtues, and this is mine: I am "
     "one of the few honest people that I have ever "
     "known";
 
-static const char kData2[8] = "Help Us ";
-static const char kData2_endian[8] = "pleH sU ";
+OT_NONSTRING static const char kData2[8] = "Help Us ";
+OT_NONSTRING static const char kData2_endian[8] = "pleH sU ";
 
 static const dif_hmac_digest_t kExpectedShaDigest = {
     .digest =

--- a/sw/device/tests/hmac_error_conditions_test.c
+++ b/sw/device/tests/hmac_error_conditions_test.c
@@ -60,7 +60,7 @@ static const dif_hmac_transaction_t kHmacTransactionConfig = {
     .message_endianness = kDifHmacEndiannessLittle,
 };
 
-static const char kData[142] =
+OT_NONSTRING static const char kData[142] =
     "Every one suspects himself of at least one of "
     "the cardinal virtues, and this is mine: I am "
     "one of the few honest people that I have ever "

--- a/sw/device/tests/hmac_secure_wipe_test.c
+++ b/sw/device/tests/hmac_secure_wipe_test.c
@@ -13,7 +13,7 @@
 
 OTTF_DEFINE_TEST_CONFIG();
 
-static const char kData[142] =
+OT_NONSTRING static const char kData[142] =
     "Every one suspects himself of at least one of "
     "the cardinal virtues, and this is mine: I am "
     "one of the few honest people that I have ever "

--- a/sw/device/tests/hmac_smoketest.c
+++ b/sw/device/tests/hmac_smoketest.c
@@ -23,7 +23,7 @@ static const dif_hmac_transaction_t kHmacTransactionConfig = {
     .message_endianness = kDifHmacEndiannessLittle,
 };
 
-static const char kData[142] =
+OT_NONSTRING static const char kData[142] =
     "Every one suspects himself of at least one of "
     "the cardinal virtues, and this is mine: I am "
     "one of the few honest people that I have ever "


### PR DESCRIPTION
Adds the `nonstring` attribute through a new `OT_NONSTRING` macro. This is used to prevent warnings when compiling with Clang 21+ and an array is initialized with a string literal but is sized not to include the terminating null.