### PR TITLE
[otbn,cov] Add bazel coverage support to OTBN simulator tests

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/dmem.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/dmem.py
@@ -52,7 +52,7 @@ class Dmem:
         # if the word has invalid integrity bits and we'll get an error if we
         # try to read it. Otherwise, we store the integer value.
         num_words = dmem_size // 4
-        self.data = [None] * num_words  # type: List[Optional[int]]
+        self.data: List[Optional[int]] = [None] * num_words
 
         # Because it's an actual memory, stores to DMEM take two cycles in the
         # RTL. We wouldn't need to model this except that a DMEM invalidation
@@ -63,8 +63,8 @@ class Dmem:
         # this cycle. However, the first commit() will then move it to the
         # self.pending list. Entries here will only make it to self.data on the
         # next commit().
-        self.trace = []  # type: List[TraceDmemStore]
-        self.pending = {}  # type: Dict[int, int]
+        self.trace: List[TraceDmemStore] = []
+        self.pending: Dict[int, int] = {}
 
     def _load_5byte_le_words(self, data: bytes) -> None:
         '''Replace the start of memory with data

--- a/hw/ip/otbn/dv/otbnsim/sim/dmem.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/dmem.py
@@ -66,7 +66,7 @@ class Dmem:
         self.trace: List[TraceDmemStore] = []
         self.pending: Dict[int, int] = {}
 
-    def _load_5byte_le_words(self, data: bytes) -> None:
+    def _load_5byte_le_words(self, data: bytes, offset: int = 0) -> None:
         '''Replace the start of memory with data
 
         The bytes loaded should represent each 32-bit word with 5 bytes,
@@ -97,9 +97,9 @@ class Dmem:
                 raise ValueError('The validity byte for 32-bit word {} '
                                  'in the input data is {}, not 0 or 1.'
                                  .format(idx32, vld))
-            self.data[idx32] = u32 if vld else None
+            self.data[idx32 + offset] = u32 if vld else None
 
-    def _load_4byte_le_words(self, data: bytes) -> None:
+    def _load_4byte_le_words(self, data: bytes, offset: int = 0) -> None:
         '''Replace the start of memory with data
 
         The bytes loaded should represent each 32-bit word with 4 bytes in
@@ -116,9 +116,9 @@ class Dmem:
             data = data + b'0' * (32 - (len(data) % 32))
 
         for idx32, u32 in enumerate(struct.iter_unpack('<I', data)):
-            self.data[idx32] = u32[0]
+            self.data[idx32 + offset] = u32[0]
 
-    def load_le_words(self, data: bytes, has_validity: bool) -> None:
+    def load_le_words(self, data: bytes, has_validity: bool, offset: int = 0) -> None:
         '''Replace the start of memory with data
 
         Uses the 5-byte format if has_validity is true and the 4-byte format
@@ -126,9 +126,9 @@ class Dmem:
 
         '''
         if has_validity:
-            self._load_5byte_le_words(data)
+            self._load_5byte_le_words(data, offset=offset)
         else:
-            self._load_4byte_le_words(data)
+            self._load_4byte_le_words(data, offset=offset)
 
     def dump_le_words(self) -> bytes:
         '''Return the contents of memory as bytes.

--- a/hw/ip/otbn/dv/otbnsim/sim/load_elf.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/load_elf.py
@@ -89,5 +89,6 @@ def load_elf(sim: OTBNSim, path: str) -> Optional[int]:
     sim.load_program(imem_insns)
     sim.loop_warps = loop_warps
     sim.load_data(dmem_bytes, has_validity=False)
+    sim.symbols = symbols
 
     return exp_end

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -25,11 +25,11 @@ StepRes = Tuple[Optional[OTBNInsn], List[Trace]]
 class OTBNSim:
     def __init__(self) -> None:
         self.state = OTBNState()
-        self.program = []  # type: List[OTBNInsn]
-        self.loop_warps = {}  # type: LoopWarps
-        self.stats = None  # type: Optional[ExecutionStats]
-        self._execute_generator = None  # type: Optional[Iterator[None]]
-        self._next_insn = None  # type: Optional[OTBNInsn]
+        self.program: List[OTBNInsn] = []
+        self.loop_warps: LoopWarps = {}
+        self.stats: Optional[ExecutionStats] = None
+        self._execute_generator: Optional[Iterator[None]] = None
+        self._next_insn: Optional[OTBNInsn] = None
 
     def load_program(self, program: List[OTBNInsn]) -> None:
         self.program = program.copy()

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -28,6 +28,7 @@ class OTBNSim:
         self.program: List[OTBNInsn] = []
         self.loop_warps: LoopWarps = {}
         self.stats: Optional[ExecutionStats] = None
+        self.symbols: Dict[str, int] = {}
         self._execute_generator: Optional[Iterator[None]] = None
         self._next_insn: Optional[OTBNInsn] = None
 

--- a/hw/ip/otbn/dv/otbnsim/sim/standalonesim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/standalonesim.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from itertools import cycle
-from typing import Optional, TextIO
+from typing import Dict, Optional, TextIO
 from .sim import OTBNSim
 from .state import FsmState
 
@@ -58,6 +58,23 @@ class StandaloneSim(OTBNSim):
                 break
 
         return insn_count
+
+    def load_dmem_vars(self, dmem_vars: Dict[str, bytes]) -> None:
+        for label, value in dmem_vars.items():
+            offset = self.symbols[label]
+            assert offset % 4 == 0, "Only word-aligned variables are supported."
+            self.state.dmem.load_le_words(value, has_validity=False, offset=offset // 4)
+
+    def load_regs_vars(self, regs: Dict[str, int]) -> None:
+        for label, value in regs.items():
+            if label.startswith('x'):
+                gpr_idx = int(label[1:])
+                self.state.gprs.get_reg(gpr_idx).write_unsigned(value)
+            elif label.startswith('w'):
+                wdr_idx = int(label[1:])
+                self.state.wdrs.get_reg(wdr_idx).write_unsigned(value)
+            else:
+                self.state.ext_regs.write(label, value, from_hw=False)
 
     def dump_regs(self, tgt: TextIO) -> None:
         for reg in ['ERR_BITS', 'INSN_CNT', 'STOP_PC']:

--- a/hw/ip/otbn/dv/otbnsim/sim/stats.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/stats.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import Counter
-import typing
 from typing import Dict, List, Optional, Tuple
 
 from elftools.dwarf.dwarfinfo import DWARFInfo  # type: ignore
@@ -22,13 +21,13 @@ class ExecutionStats:
         self.program = program
 
         self.stall_count = 0
-        self.insn_histo = Counter()  # type: typing.Counter[str]
-        self.func_calls = []  # type: List[Dict[str, int]]
-        self.loops = []  # type: List[Dict[str, int]]
+        self.insn_histo: Counter[str] = Counter()
+        self.func_calls: List[Dict[str, int]] = []
+        self.loops: List[Dict[str, int]] = []
 
         # Histogram indexed by the length of the (extended) basic block.
-        self.basic_block_histo = Counter()  # type: typing.Counter[int]
-        self.ext_basic_block_histo = Counter()  # type: typing.Counter[int]
+        self.basic_block_histo: Counter[int] = Counter()
+        self.ext_basic_block_histo: Counter[int] = Counter()
 
         self._current_basic_block_len = 0
         self._current_ext_basic_block_len = 0
@@ -275,9 +274,9 @@ class ExecutionStatAnalyzer:
         # The call graphs are on function granularity; the call sites
         # dictionary is indexed by the called function, but uses the call site
         # as value.
-        callgraph = {}  # type: Dict[int, typing.Counter[int]]
-        rev_callgraph = {}  # type: Dict[int, typing.Counter[int]]
-        rev_callsites = {}  # type: Dict[int, typing.Counter[int]]
+        callgraph: Dict[int, Counter[int]] = {}
+        rev_callgraph: Dict[int, Counter[int]] = {}
+        rev_callsites: Dict[int, Counter[int]] = {}
         for c in self._stats.func_calls:
             if c['caller_func'] not in callgraph:
                 callgraph[c['caller_func']] = Counter()

--- a/hw/ip/otbn/dv/otbnsim/standalone.py
+++ b/hw/ip/otbn/dv/otbnsim/standalone.py
@@ -10,12 +10,19 @@ import sys
 from sim.load_elf import load_elf
 from sim.standalonesim import StandaloneSim
 from sim.stats import ExecutionStatAnalyzer
+from shared.testcase import parse_testcase
 
 
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('elf')
     parser.add_argument('-v', '--verbose', action='store_true')
+    parser.add_argument(
+        '--testcase',
+        type=argparse.FileType('r'),
+        metavar="FILE",
+        help="Path to the testcase hjson file.",
+    )
     parser.add_argument(
         '--dump-dmem',
         metavar="FILE",
@@ -49,13 +56,26 @@ def main() -> int:
 
     sim = StandaloneSim()
     exp_end_addr = load_elf(sim, args.elf)
+
+    testcase = {}
+    if args.testcase:
+        testcase = parse_testcase(args.testcase.read(), sim.symbols)
+
     key0 = int((str("deadbeef") * 12), 16)
     key1 = int((str("baadf00d") * 12), 16)
     sim.state.wsrs.set_sideload_keys(key0, key1)
 
+    if testcase:
+        sim.load_dmem_vars(testcase['input']['dmem'])
+        sim.load_regs_vars(testcase['input']['regs'])
+
     sim.state.ext_regs.commit()
 
     sim.start(collect_stats)
+
+    if testcase.get('entrypoint'):
+        sim.state.pc = testcase['entrypoint']
+
     sim.run(verbose=args.verbose, dump_file=args.dump_regs)
 
     if exp_end_addr is not None:

--- a/hw/ip/otbn/util/otbn_sim_test.py
+++ b/hw/ip/otbn/util/otbn_sim_test.py
@@ -9,15 +9,14 @@ import argparse
 import subprocess
 import sys
 from enum import IntEnum
-from typing import Dict, List
+from typing import List
 import tempfile
 
-from elftools.elf.elffile import ELFFile  # type: ignore
-from elftools.elf.sections import SymbolTableSection  # type: ignore
-
 from shared.check import CheckResult
+from shared.elf import read_elf
 from shared.reg_dump import parse_reg_dump
 from shared.dmem_dump import parse_dmem_exp, parse_actual_dmem
+from shared.testcase import parse_testcase
 
 # Names of special registers
 ERR_BITS = 'ERR_BITS'
@@ -55,19 +54,6 @@ def get_err_names(err: int) -> List[str]:
     return out
 
 
-def _get_symbol_addr_map(elf_file: ELFFile) -> Dict[int, str]:
-    section = elf_file.get_section_by_name('.symtab')
-
-    if not isinstance(section, SymbolTableSection):
-        return {}
-
-    # Filter lables and offsets from data section
-    return {
-        sym.name: sym.entry.st_value
-        for sym in section.iter_symbols() if sym.entry['st_shndx'] == 2
-    }
-
-
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('simulator',
@@ -87,21 +73,39 @@ def main() -> int:
                         help=('File containing expected dmem values. '
                               'Addresses that are not listed are allowed to '
                               'have any value.'))
+    parser.add_argument('--testcase',
+                        metavar='FILE',
+                        type=argparse.FileType('r'),
+                        help='Path to the testcase hjson file.')
     parser.add_argument('elf',
                         help='Path to the .elf file for the OTBN program.')
     parser.add_argument('-v', '--verbose', action='store_true')
     args = parser.parse_args()
 
+    _, _, symbols = read_elf(args.elf)
+
     # Parse expected values.
     result = CheckResult()
+
+    cmd_flags = []
+
+    testcase = {}
+    if args.testcase:
+        testcase = parse_testcase(args.testcase.read(), symbols)
+        cmd_flags.extend([
+            "--testcase",
+            args.testcase.name,
+        ])
 
     with tempfile.NamedTemporaryFile() as regs_file, tempfile.NamedTemporaryFile() as dmem_file:
         cmd = [
             args.simulator,
+            *cmd_flags,
             "--dump-regs",
             regs_file.name,
             "--dump-dmem",
             dmem_file.name,
+            "--",
             args.elf,
         ]
         # Run the simulation and produce a register and dmem dump.
@@ -109,17 +113,28 @@ def main() -> int:
             cmd, check=True, universal_newlines=True
         )
 
-        if args.expected_dmem is not None:
-            dmem_file.seek(0)
-            actual_dmem = parse_actual_dmem(dmem_file.read())
-            expected_dmem = parse_dmem_exp(args.expected_dmem.read())
-
+        dmem_file.seek(0)
+        actual_dmem = parse_actual_dmem(dmem_file.read(), le_words=bool(testcase))
         actual_regs = parse_reg_dump(regs_file.read().decode('utf-8'))
 
     expected_err = 0
+    expected_regs = {}
     if args.expected_regs is not None:
         expected_regs = parse_reg_dump(args.expected_regs.read())
-        expected_err = expected_regs.get(ERR_BITS, 0)
+
+    expected_dmem = {}
+    if args.expected_dmem is not None:
+        expected_dmem = parse_dmem_exp(args.expected_dmem.read())
+
+    if testcase:
+        expected_dmem = testcase['output']['dmem']
+        expected_regs = testcase['output']['regs']
+
+    expected_err = expected_regs.get(ERR_BITS, 0)
+
+    if testcase.get('entrypoint') and not expected_err:
+        # expect call stack error since we overwrite the entrypoint.
+        expected_err = 0x00000004
 
     # Special handling for the ERR_BITS register.
     actual_err = actual_regs[ERR_BITS]
@@ -137,7 +152,7 @@ def main() -> int:
                        f"  {STOP_PC}\t= {stop_pc:#010x}")
 
     else:
-        if args.expected_regs is not None:
+        if expected_regs:
             for reg, expected_value in expected_regs.items():
                 actual_value = actual_regs.get(reg, None)
                 if actual_value != expected_value:
@@ -151,18 +166,18 @@ def main() -> int:
                                f"  Expected: {expected_str}\n"
                                f"  Actual:   {actual_str}")
 
-        if args.expected_dmem is not None:
-            elf_file = ELFFile(open(args.elf, 'rb'))
-            symbol_addr_map = _get_symbol_addr_map(elf_file)
-
+        if expected_dmem:
             for label, value in expected_dmem.items():
                 try:
-                    offset = symbol_addr_map[label]
-                    if actual_dmem[offset:offset + len(value)] != value:
+                    offset = symbols[label]
+                    actual = actual_dmem[offset:offset + len(value)]
+                    if actual != value:
                         result.err(
                             f"Mismatch for dmem {label}:\n"
-                            f"  Expected: {value.hex()}\n"
-                            f"  Actual:   {actual_dmem[offset:offset+len(value)].hex()}"
+                            f"  Expected:     {value.hex()}\n"
+                            f"  Actual:       {actual.hex()}\n"
+                            f"  Expected(BE): {value[::-1].hex()}\n"
+                            f"  Actual(BE):   {actual[::-1].hex()}"
                         )
                 except KeyError:
                     result.err(f'No label "{label}" found in elf-file.')

--- a/hw/ip/otbn/util/shared/dmem_dump.py
+++ b/hw/ip/otbn/util/shared/dmem_dump.py
@@ -41,7 +41,7 @@ def parse_dmem_exp(dump: str) -> Dict[str, int]:
     return out
 
 
-def parse_actual_dmem(dump: bytes) -> bytes:
+def parse_actual_dmem(dump: bytes, le_words=False) -> bytes:
     '''Parse the dmem dump.
 
     Returns the dmem bytes except integrity info.
@@ -53,7 +53,11 @@ def parse_actual_dmem(dump: bytes) -> bytes:
         tmp = []
         # discard byte indicating integrity status
         for v in struct.iter_unpack("<BI", w[0]):
-            tmp += [x for x in struct.unpack("4B", v[1].to_bytes(4, "big"))]
+            if le_words:
+                # align with dmem.load_le_words
+                tmp += v[1].to_bytes(4, 'little')
+            else:
+                tmp += v[1].to_bytes(4, "big")
         dmem_bytes += tmp
     assert len(dmem_bytes) == get_memory_layout().dmem_size_bytes
     return bytes(dmem_bytes)

--- a/hw/ip/otbn/util/shared/testcase.py
+++ b/hw/ip/otbn/util/shared/testcase.py
@@ -1,0 +1,84 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import hjson  # type: ignore
+import re
+from typing import Any, Dict
+
+
+def _is_numeric_str(value: str) -> bool:
+    return bool(re.match(r'(0x)?[0-9a-fA-F\s]+$', value))
+
+
+def parse_testcase(hjson_str: str, symbols: Dict[str, int] = {}) -> Dict[str, Any]:
+    '''Parse a testcase HJSON string.
+
+    Schema:
+    ```
+        {
+            entrypoint: str = "0" // Address or symbol of entrypoint
+            input: {
+                dmem: {
+                    <label>: <value>
+                },
+                regs: {
+                    <reg_name>: <value>
+                }
+            },
+            output: {
+                dmem: {
+                    <label>: <value>
+                },
+                regs: {
+                    <reg_name>: <value>
+                }
+            }
+        }
+    ```
+
+    Values may be integers, symbol strings, or numeric strings.
+
+    Args:
+        hjson_str: The HJSON string to parse.
+        symbols: A dict from symbol name (str) to value (int). This should contain
+                all symbols from the program being tested.
+
+    Returns:
+        A dict representing the parsed testcase.
+    '''
+    data: Dict[str, Any] = hjson.loads(hjson_str)
+
+    entrypoint = data.get('entrypoint', 0)
+    if isinstance(entrypoint, int):
+        pass
+    elif _is_numeric_str(entrypoint):
+        data['entrypoint'] = int(entrypoint, 0)
+    else:
+        data['entrypoint'] = symbols[entrypoint]
+
+    for key in ['input', 'output']:
+        data.setdefault(key, {})
+        data[key].setdefault('dmem', {})
+        data[key].setdefault('regs', {})
+
+        for label, value in data[key]['dmem'].items():
+            value = value.strip()
+            if not _is_numeric_str(value):
+                value = symbols[value]
+                data[key]['dmem'][label] = value.to_bytes(4, 'little')
+            else:
+                value = value.removeprefix("0x")
+                # big-endian int -> little-endian byte array
+                data[key]['dmem'][label] = bytes.fromhex(value)[::-1]
+
+        for label, value in data[key]['regs'].items():
+            if isinstance(value, int):
+                continue
+            value = value.strip()
+            if not _is_numeric_str(value):
+                data[key]['regs'][label] = symbols[value]
+            else:
+                data[key]['regs'][label] = int(value, 0)
+
+    return data

--- a/sw/otbn/crypto/boot.s
+++ b/sw/otbn/crypto/boot.s
@@ -80,6 +80,7 @@ start:
   beq   x2, x3, attestation_key_save
 
   /* Invalid mode; fail. */
+start_failed:
   unimp
   unimp
   unimp

--- a/sw/otbn/crypto/tests/BUILD
+++ b/sw/otbn/crypto/tests/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:otbn.bzl", "otbn_consttime_test", "otbn_library", "otbn_sim_test")
+load("//rules:otbn.bzl", "otbn_consttime_test", "otbn_library", "otbn_sim_test", "otbn_sim_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -383,6 +383,18 @@ otbn_sim_test(
     deps = [
         "//sw/otbn/crypto:p256_base",
         "//sw/otbn/crypto:p256_shared_key",
+    ],
+)
+
+otbn_sim_test_suite(
+    name = "p256_test",
+    binary = "//sw/otbn/crypto:run_p256",
+    tests = [
+        "p256_check_public_key_not_on_curve.hjson",
+        "p256_check_public_key_valid.hjson",
+        "p256_check_public_key_x_too_large.hjson",
+        "p256_check_public_key_y_too_large.hjson",
+        "p256_isoncurve_valid.hjson",
     ],
 )
 
@@ -1148,5 +1160,17 @@ otbn_consttime_test(
     subroutine = "X25519",
     deps = [
         ":x25519_test1",
+    ],
+)
+
+otbn_sim_test_suite(
+    name = "boot_test",
+    binary = "//sw/otbn/crypto:boot",
+    tests = [
+        "boot_key_endorse_valid.hjson",
+        "boot_key_save_valid.hjson",
+        "boot_keygen_valid.hjson",
+        "boot_mode_invalid.hjson",
+        "boot_sigverify_valid.hjson",
     ],
 )

--- a/sw/otbn/crypto/tests/boot_key_endorse_valid.hjson
+++ b/sw/otbn/crypto/tests/boot_key_endorse_valid.hjson
@@ -1,0 +1,48 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  /**
+   * @param[in]  dmem[msg]: Message digest (256 bits)
+   * @param[in]   dmem[d0]: First share of private key d (320 bits)
+   * @param[in]   dmem[d1]: Second share of private key d (320 bits)
+   * @param[out]   dmem[r]: Buffer for r component of signature (256 bits)
+   * @param[out]   dmem[s]: Buffer for s component of signature (256 bits)
+   */
+
+  "input": {
+    "dmem": {
+      "mode": "0x000005e8"  # MODE_ATTESTATION_ENDORSE
+
+      "msg": "0xbb5a52f42f9c9261ed4361f59422a1e30036e7c32b270c8807a419feca605023"
+      "d0":
+        '''
+          0x000000000000000000000000000000000000000000000000001cc542001cc542
+            001cc542001cc542001cc542001cc542001cc542001cc542001cc542001cc542
+        '''
+      "d1":
+        '''
+          0x000000000000000000000000000000000000000000000000baadf00dbaadf00d
+            baadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00d
+        '''
+    }
+  }
+  "output": {
+    "dmem": {
+      # Verified with:
+      # >>> import ecdsa
+      # >>> import hashlib
+      # >>> r = 0xfb9ccc2407d5f318d0dd995cbf4012e6796898fbc22829c94b691cb0df72e120
+      # >>> s = 0x3eaf474bba511934edb9aaaef0302cc337d6325fba907f26c1e76ba17a4e62a6
+      # >>> msg = b"123400"
+      # >>> x = "5868cc1d58a1ea20ee1cf22393d92a695e69ea89e85cbce80e94f900015ac2c4"
+      # >>> y = "17749c44e6401eda1e71722402d940dceeeee6b7277dac6cbc9a02a44f66aa6f"
+      # >>> p = ecdsa.VerifyingKey.from_string(bytes.fromhex(x + y), curve=ecdsa.NIST256p)
+      # >>> sig = r.to_bytes(32, 'big') + s.to_bytes(32, 'big')
+      # >>> p.verify(sig, msg, hashfunc=hashlib.sha256)
+
+      "r": "0xfb9ccc2407d5f318d0dd995cbf4012e6796898fbc22829c94b691cb0df72e120"
+      "s": "0x3eaf474bba511934edb9aaaef0302cc337d6325fba907f26c1e76ba17a4e62a6"
+    }
+  }
+}

--- a/sw/otbn/crypto/tests/boot_key_save_valid.hjson
+++ b/sw/otbn/crypto/tests/boot_key_save_valid.hjson
@@ -1,0 +1,44 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  /**
+   * @param[in]  dmem[attestation_additional_seed]: DRBG output.
+   * @param[out]  dmem[d0]: First share of private key (320 bits).
+   * @param[out]  dmem[d1]: Second share of private key (320 bits).
+   */
+
+  "input": {
+    "dmem": {
+      "mode": "0x0000064d"  # MODE_ATTESTATION_KEY_SAVE
+
+      "attestation_additional_seed":
+        '''
+        0xdecafbaddecafbaddecafbaddecafbaddecafbaddecafbaddecafbaddecafbad
+          decafbaddecafbaddecafbaddecafbaddecafbaddecafbaddecafbaddecafbad
+        '''
+    }
+  }
+  "output": {
+    "dmem": {
+      # Verified with:
+      # >>> d0 = 0x001cc542001cc542001cc542001cc542001cc542001cc542001cc542001cc542001cc542001cc542
+      # >>> d1 = 0xbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00d
+      # >>> consts = "deadbeef", "baadf00d", "decafbad"
+      # >>> key0, key1, seed = [int(e * 12, 16) for e in consts]
+      # >>> mask = 2^320 - 1
+      # >>> print((d0 + d1) % n == ((seed ^^ key0 ^^ key1) & mask) % n)
+
+      "d0":
+        '''
+          0x000000000000000000000000000000000000000000000000001cc542001cc542
+            001cc542001cc542001cc542001cc542001cc542001cc542001cc542001cc542
+        '''
+      "d1":
+        '''
+          0x000000000000000000000000000000000000000000000000baadf00dbaadf00d
+            baadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00d
+        '''
+    }
+  }
+}

--- a/sw/otbn/crypto/tests/boot_keygen_valid.hjson
+++ b/sw/otbn/crypto/tests/boot_keygen_valid.hjson
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  /**
+   * @param[in]  dmem[attestation_additional_seed]: DRBG output.
+   * @param[out]  dmem[x]: Public key x-coordinate.
+   * @param[out]  dmem[y]: Public key y-coordinate.
+   */
+
+  "input": {
+    "dmem": {
+      "mode": "0x000002bf"  # MODE_ATTESTATION_KEYGEN
+
+      "attestation_additional_seed":
+        '''
+        0xdecafbaddecafbaddecafbaddecafbaddecafbaddecafbaddecafbaddecafbad
+          decafbaddecafbaddecafbaddecafbaddecafbaddecafbaddecafbaddecafbad
+        '''
+    }
+  }
+  "output": {
+    "dmem": {
+      # Verified with:
+      # >>> consts = "deadbeef", "baadf00d", "decafbad"
+      # >>> key0, key1, seed = [int(e * 12, 16) for e in consts]
+      # >>> mask = 2^320 - 1
+      # >>> P = ((seed ^^ key0 ^^ key1) & mask) * G
+      # >>> print(hex(P.x()), hex(P.y()))
+
+      "x": "0x5868cc1d58a1ea20ee1cf22393d92a695e69ea89e85cbce80e94f900015ac2c4"
+      "y": "0x17749c44e6401eda1e71722402d940dceeeee6b7277dac6cbc9a02a44f66aa6f"
+    }
+  }
+}

--- a/sw/otbn/crypto/tests/boot_mode_invalid.hjson
+++ b/sw/otbn/crypto/tests/boot_mode_invalid.hjson
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  "input": {
+    "dmem": {
+      "mode": "0xdeadbeef"  # invalid mode enum
+    }
+  }
+  "output": {
+    "regs": {
+      "STOP_PC": "start_failed"
+      "ERR_BITS": "0x00000008"  # unimp trap
+    }
+  }
+}

--- a/sw/otbn/crypto/tests/boot_sigverify_valid.hjson
+++ b/sw/otbn/crypto/tests/boot_sigverify_valid.hjson
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  /**
+   * Test case 1 in wycheproof ecdsa_secp256r1_sha256_p1363_test.json
+   *
+   * @param[in]  dmem[msg]: message to be verified (256 bits)
+   * @param[in]  dmem[r]:   r component of signature (256 bits)
+   * @param[in]  dmem[s]:   s component of signature (256 bits)
+   * @param[in]  dmem[x]:   affine x-coordinate of public key (256 bits)
+   * @param[in]  dmem[y]:   affine y-coordinate of public key (256 bits)
+   * @param[out] dmem[ok]:  success/failure of basic checks (32 bits)
+   * @param[out] dmem[x_r]: dmem buffer for reduced affine x_r-coordinate (x_1)
+   */
+
+  "input": {
+    "dmem": {
+      "mode": "0x000007d3", # MODE_SIGVERIFY
+
+      "msg": "0xbb5a52f42f9c9261ed4361f59422a1e30036e7c32b270c8807a419feca605023"
+      "x": "0x2927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838"
+      "y": "0xc7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e"
+      "r": "0x2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18"
+      "s": "0x4cd60b855d442f5b3c7b11eb6c4e0ae7525fe710fab9aa7c77a67f79e6fadd76"
+    }
+  }
+  "output": {
+    "dmem": {
+      "ok": "0x00000739"  # HARDENED_TRUE
+      "x_r": "0x2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18"
+    }
+  }
+}

--- a/sw/otbn/crypto/tests/p256_check_public_key_not_on_curve.hjson
+++ b/sw/otbn/crypto/tests/p256_check_public_key_not_on_curve.hjson
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  "entrypoint": "p256_check_public_key",
+  "input": {
+    "dmem": {
+      # (x+1, y+1)
+      "x": "0x2927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732839"
+      "y": "0xc7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513f"
+      "ok": "0x00000739"  # HARDENED_TRUE
+    }
+  }
+  "output": {
+    "dmem": {
+      "ok": "0x000001d4"  # HARDENED_FALSE
+    }
+  }
+}

--- a/sw/otbn/crypto/tests/p256_check_public_key_valid.hjson
+++ b/sw/otbn/crypto/tests/p256_check_public_key_valid.hjson
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  "entrypoint": "p256_check_public_key",
+  "input": {
+    "dmem": {
+      # First public key of wycheproof ecdsa_secp256r1_sha256_p1363_test.json
+      "x": "0x2927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838"
+      "y": "0xc7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e"
+      "ok": "0x00000739"  # HARDENED_TRUE
+    }
+  }
+  "output": {
+    "dmem": {
+      "ok": "0x00000739"  # HARDENED_TRUE
+    }
+  }
+}

--- a/sw/otbn/crypto/tests/p256_check_public_key_x_too_large.hjson
+++ b/sw/otbn/crypto/tests/p256_check_public_key_x_too_large.hjson
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  "entrypoint": "p256_check_public_key",
+  "input": {
+    "dmem": {
+      # (p, y)
+      "x": "0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff"
+      "y": "0xc7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513f"
+      "ok": "0x00000739"  # HARDENED_TRUE
+    }
+  }
+  "output": {
+    "dmem": {
+      "ok": "0x000001d4"  # HARDENED_FALSE
+    }
+  }
+}

--- a/sw/otbn/crypto/tests/p256_check_public_key_y_too_large.hjson
+++ b/sw/otbn/crypto/tests/p256_check_public_key_y_too_large.hjson
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  "entrypoint": "p256_check_public_key",
+  "input": {
+    "dmem": {
+      # (x, p)
+      "x": "0x2927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838"
+      "y": "0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff"
+      "ok": "0x00000739"  # HARDENED_TRUE
+    }
+  }
+  "output": {
+    "dmem": {
+      "ok": "0x000001d4"  # HARDENED_FALSE
+    }
+  }
+}

--- a/sw/otbn/crypto/tests/p256_isoncurve_valid.hjson
+++ b/sw/otbn/crypto/tests/p256_isoncurve_valid.hjson
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  "entrypoint": "p256_isoncurve",
+  "input": {
+    "dmem": {
+      "x": "0xb5511a6afacdc5461628ce58db6c8bf36ec0c0b2f36b06899773b7b3bfa8c334"
+      "y": "0x42a1c6971f31c14343dd09eab53a17fa7f7a11d0ab9c6924a87070589e008c2e"
+    }
+    "regs": {
+      "w31": "0"
+    }
+  }
+  "output": {
+    "regs": {
+      "w18": "0xb103b614b389c6b8e1a08330a6ce0b9c4b3726ec0bf61f6bdd66af03a4af5660"
+      "w19": "0xb103b614b389c6b8e1a08330a6ce0b9c4b3726ec0bf61f6bdd66af03a4af5660"
+    }
+  }
+}

--- a/util/otbn_build.py
+++ b/util/otbn_build.py
@@ -83,7 +83,7 @@ def run_tool(tool, out_file: Path, args) -> None:
                                           dir=out_dir,
                                           delete=False)
     try:
-        if type(tool) == str:
+        if isinstance(tool, str):
             run_cmd([tool, '-o', tmpfile.name] + args,
                     cmd_to_str([tool, '-o', out_file] + args))
         else:
@@ -310,6 +310,7 @@ def main() -> int:
             '-O', 'elf32-littleriscv',
             '--set-section-flags=*=alloc,load,readonly',
             '--remove-section=.scratchpad', '--remove-section=.bss',
+            '--remove-section=.debug*',
             '--prefix-sections=.rodata.otbn', '--prefix-symbols', host_side_pfx
         ]
         for name, addr in get_otbn_syms(out_elf):


### PR DESCRIPTION
This pull request integrates the OTBN simulator with Bazel's code coverage tool.

To generate a coverage report, execute the following commands:

```shell
./bazelisk.sh coverage --combined_report=lcov //sw/otbn/crypto/tests/...
genhtml -o /tmp/$USER/coverage bazel-out/_coverage/_coverage_report.dat
```

Also, the simulator test rules have been improved with a simplified hjson test case interface, which is well-suited for writing parameterized tests and function unit tests.

---

P.S. flake8 raises unused import errors for those type comments, so we update those comments to type annotation syntax.