### PR TITLE
[cryptolib,sw] Add instruction count checks to ECC functions

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/p384.c
+++ b/sw/device/lib/crypto/impl/ecc/p384.c
@@ -88,6 +88,15 @@ enum {
   kCoordPaddingWords =
       (kOtbnWideWordNumWords - (kP384CoordWords % kOtbnWideWordNumWords)) %
       kOtbnWideWordNumWords,
+  /*
+   * The expected instruction counts for constant time functions.
+   */
+  kModeKeygenInsCnt = 1443816,
+  kModeKeygenSideloadInsCnt = 1443730,
+  kModeEcdhInsCnt = 1454932,
+  kModeEcdhSideloadInsCnt = 1455071,
+  kModeEcdsaSignInsCnt = 1505346,
+  kModeEcdsaSignSideloadInsCnt = 1505485,
 };
 
 static status_t p384_masked_scalar_write(const p384_masked_scalar_t *src,
@@ -165,6 +174,7 @@ status_t p384_keygen_finalize(p384_masked_scalar_t *private_key,
                               p384_point_t *public_key) {
   // Spin here waiting for OTBN to complete.
   HARDENED_TRY(otbn_busy_wait_for_done());
+  HARDENED_CHECK_EQ(otbn_instruction_count_get(), kModeKeygenInsCnt);
 
   // Read the masked private key from OTBN dmem.
   HARDENED_TRY(otbn_dmem_read(kP384MaskedScalarShareWords, kOtbnVarD0,
@@ -195,6 +205,7 @@ status_t p384_sideload_keygen_start(void) {
 status_t p384_sideload_keygen_finalize(p384_point_t *public_key) {
   // Spin here waiting for OTBN to complete.
   HARDENED_TRY(otbn_busy_wait_for_done());
+  HARDENED_CHECK_EQ(otbn_instruction_count_get(), kModeKeygenSideloadInsCnt);
 
   // Read the public key from OTBN dmem.
   HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarX, public_key->x));
@@ -240,8 +251,15 @@ status_t p384_ecdsa_sideload_sign_start(
 }
 
 status_t p384_ecdsa_sign_finalize(p384_ecdsa_signature_t *result) {
+  uint32_t ins_cnt;
   // Spin here waiting for OTBN to complete.
   HARDENED_TRY(otbn_busy_wait_for_done());
+  ins_cnt = otbn_instruction_count_get();
+  if (launder32(ins_cnt) == kModeEcdsaSignSideloadInsCnt) {
+    HARDENED_CHECK_EQ(ins_cnt, kModeEcdsaSignSideloadInsCnt);
+  } else {
+    HARDENED_CHECK_EQ(ins_cnt, kModeEcdsaSignInsCnt);
+  }
 
   // Read signature R out of OTBN dmem.
   HARDENED_TRY(otbn_dmem_read(kP384ScalarWords, kOtbnVarR, result->r));
@@ -323,8 +341,15 @@ status_t p384_ecdh_start(const p384_masked_scalar_t *private_key,
 }
 
 status_t p384_ecdh_finalize(p384_ecdh_shared_key_t *shared_key) {
+  uint32_t ins_cnt;
   // Spin here waiting for OTBN to complete.
   HARDENED_TRY(otbn_busy_wait_for_done());
+  ins_cnt = otbn_instruction_count_get();
+  if (launder32(ins_cnt) == kModeEcdhSideloadInsCnt) {
+    HARDENED_CHECK_EQ(ins_cnt, kModeEcdhSideloadInsCnt);
+  } else {
+    HARDENED_CHECK_EQ(ins_cnt, kModeEcdhInsCnt);
+  }
 
   // Read the status code out of DMEM (false if basic checks on the validity of
   // the signature and public key failed).


### PR DESCRIPTION
This commit adds instruction count checks to ECC functions that run in constant time. This helps protect against fault injection.