### PR TITLE
[otbn,cov] Add bazel coverage support to OTBN simulator tests

### DIFF
--- a/util/otbn_build.py
+++ b/util/otbn_build.py
@@ -310,6 +310,7 @@ def main() -> int:
             '-O', 'elf32-littleriscv',
             '--set-section-flags=*=alloc,load,readonly',
             '--remove-section=.scratchpad', '--remove-section=.bss',
+            '--remove-section=.debug*',
             '--prefix-sections=.rodata.otbn', '--prefix-symbols', host_side_pfx
         ]
         for name, addr in get_otbn_syms(out_elf):


### PR DESCRIPTION
This pull request integrates the OTBN simulator with Bazel's code coverage tool.

To generate a coverage report, execute the following commands:

```shell
./bazelisk.sh coverage --combined_report=lcov //sw/otbn/crypto/tests/...
genhtml -o /tmp/$USER/coverage bazel-out/_coverage/_coverage_report.dat
```