### PR TITLE
Cherrypick otbnsim lint fixes from master to earlgrey_1.0.0

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/dmem.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/dmem.py
@@ -52,7 +52,7 @@ class Dmem:
         # if the word has invalid integrity bits and we'll get an error if we
         # try to read it. Otherwise, we store the integer value.
         num_words = dmem_size // 4
-        self.data = [None] * num_words  # type: List[Optional[int]]
+        self.data: List[Optional[int]] = [None] * num_words
 
         # Because it's an actual memory, stores to DMEM take two cycles in the
         # RTL. We wouldn't need to model this except that a DMEM invalidation
@@ -63,8 +63,8 @@ class Dmem:
         # this cycle. However, the first commit() will then move it to the
         # self.pending list. Entries here will only make it to self.data on the
         # next commit().
-        self.trace = []  # type: List[TraceDmemStore]
-        self.pending = {}  # type: Dict[int, int]
+        self.trace: List[TraceDmemStore] = []
+        self.pending: Dict[int, int] = {}
 
     def _load_5byte_le_words(self, data: bytes) -> None:
         '''Replace the start of memory with data

--- a/hw/ip/otbn/dv/otbnsim/sim/edn_client.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/edn_client.py
@@ -18,12 +18,12 @@ class EdnClient:
         # non-None if we're in the middle of reading a value from the EDN. This
         # should always have length <= ACC_LEN (sending an extra beat of data
         # causes an error).
-        self._acc = None  # type: Optional[List[int]]
+        self._acc: Optional[List[int]] = None
 
         # A counter of the number of beats we've been waiting since self._acc
         # became full before being told that CDC was done. This is None unless
         # self._acc contains a list of ACC_LEN values.
-        self._cdc_counter = None  # type: Optional[int]
+        self._cdc_counter: Optional[int] = None
 
         # If true, the next transaction that completes will be discarded.
         self._poisoned = False
@@ -35,7 +35,7 @@ class EdnClient:
         self._fips_err = False
         self._rep_err = False
 
-        self._last_word = None  # type: Optional[int]
+        self._last_word: Optional[int] = None
 
     def request(self) -> None:
         '''Start a request if there isn't one pending'''

--- a/hw/ip/otbn/dv/otbnsim/sim/ext_regs.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/ext_regs.py
@@ -129,8 +129,8 @@ class RGReg:
     def __init__(self, fields: List[RGField], double_flopped: bool):
         self.fields = fields
         self.double_flopped = double_flopped
-        self._changes = []  # type: List[ExtRegChange]
-        self._next_changes = []  # type: List[ExtRegChange]
+        self._changes: List[ExtRegChange] = []
+        self._next_changes: List[ExtRegChange] = []
 
     @staticmethod
     def from_register(reg: Register, double_flopped: bool) -> 'RGReg':
@@ -254,7 +254,7 @@ class OTBNExtRegs:
     def __init__(self) -> None:
         _, reg_block = load_registers()
 
-        self.regs = {}  # type: Dict[str, RGReg]
+        self.regs: Dict[str, RGReg] = {}
         self._dirty = 0
 
         assert isinstance(reg_block, RegBlock)

--- a/hw/ip/otbn/dv/otbnsim/sim/flags.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/flags.py
@@ -38,7 +38,7 @@ class FlagReg:
         self.L = L
         self.Z = Z
 
-        self._new_val = None  # type: Optional['FlagReg']
+        self._new_val: Optional['FlagReg'] = None
 
     def set_flags(self, other: 'FlagReg') -> None:
         self._new_val = other

--- a/hw/ip/otbn/dv/otbnsim/sim/isa.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/isa.py
@@ -54,7 +54,7 @@ class OTBNInsn:
 
     # A class variable that holds the Insn subclass corresponding to this
     # instruction.
-    insn = DummyInsn()  # type: Insn
+    insn: Insn = DummyInsn()
 
     # A class variable that is set by Insn subclasses that represent
     # instructions that affect control flow (and are not allowed at the end of
@@ -76,7 +76,7 @@ class OTBNInsn:
         # Memoized disassembly for this instruction. We store the PC at which
         # we disassembled too (which should be the same next time around, but
         # it can't hurt to check).
-        self._disasm = None  # type: Optional[Tuple[int, str]]
+        self._disasm: Optional[Tuple[int, str]] = None
 
     def execute(self, state: OTBNState) -> Optional[Iterator[None]]:
         '''Execute the instruction

--- a/hw/ip/otbn/dv/otbnsim/sim/reg.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/reg.py
@@ -39,7 +39,7 @@ class Reg:
         self._width = width
 
         self._uval = uval
-        self._next_uval = None  # type: Optional[int]
+        self._next_uval: Optional[int] = None
 
     def read_unsigned(self, backdoor: bool = False) -> int:
         return self._uval
@@ -99,7 +99,7 @@ class RegFile:
         self._name_pfx = name_pfx
         self._width = width
         self._registers = [Reg(self, i, width, 0) for i in range(depth)]
-        self._pending_writes = set()  # type: Set[int]
+        self._pending_writes: Set[int] = set()
 
     def mark_written(self, idx: int) -> None:
         '''Mark a register as having been written'''

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -25,11 +25,11 @@ StepRes = Tuple[Optional[OTBNInsn], List[Trace]]
 class OTBNSim:
     def __init__(self) -> None:
         self.state = OTBNState()
-        self.program = []  # type: List[OTBNInsn]
-        self.loop_warps = {}  # type: LoopWarps
-        self.stats = None  # type: Optional[ExecutionStats]
-        self._execute_generator = None  # type: Optional[Iterator[None]]
-        self._next_insn = None  # type: Optional[OTBNInsn]
+        self.program: List[OTBNInsn] = []
+        self.loop_warps: LoopWarps = {}
+        self.stats: Optional[ExecutionStats] = None
+        self._execute_generator: Optional[Iterator[None]] = None
+        self._next_insn: Optional[OTBNInsn] = None
 
     def load_program(self, program: List[OTBNInsn]) -> None:
         self.program = program.copy()

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -138,7 +138,12 @@ class OTBNState:
         # cancelled).
         self.injected_err_bits = 0
         self.lock_immediately = False
-        self.zero_insn_cnt_next = False
+
+        # OTBN might zero its insn_cnt register during a secure wipe. The
+        # precise cycle that this happens depends slightly on how we decide to
+        # do so. If this is not None, it is a counter of the number of cycles
+        # before the zeroing should happen.
+        self.time_to_insn_cnt_zero = None  # type: Optional[int]
 
         # If this is set, all software errors should result in the model status
         # being locked.

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -85,7 +85,7 @@ class OTBNState:
         self.csrs = CSRFile()
 
         self.pc = 0
-        self._pc_next_override = None  # type: Optional[int]
+        self._pc_next_override: Optional[int] = None
 
         self.imem_size = get_memory_layout().imem_size_bytes
 
@@ -119,7 +119,7 @@ class OTBNState:
         # model except for matching its timing) has a copy of the next
         # instruction. Make this a counter, decremented once per cycle. When we
         # get to zero, we set the flag.
-        self._time_to_imem_invalidation = None  # type: Optional[int]
+        self._time_to_imem_invalidation: Optional[int] = None
         self.invalidated_imem = False
 
         # This is the number of cycles left for wiping. When we're in the
@@ -143,7 +143,7 @@ class OTBNState:
         # precise cycle that this happens depends slightly on how we decide to
         # do so. If this is not None, it is a counter of the number of cycles
         # before the zeroing should happen.
-        self.time_to_insn_cnt_zero = None  # type: Optional[int]
+        self.time_to_insn_cnt_zero: Optional[int] = None
 
         # If this is set, all software errors should result in the model status
         # being locked.
@@ -262,7 +262,7 @@ class OTBNState:
         return bool(self.loop_stack.stack)
 
     def changes(self) -> List[Trace]:
-        c = []  # type: List[Trace]
+        c: List[Trace] = []
         c += self.gprs.changes()
         if self._pc_next_override is not None:
             # Only append the next program counter to the trace if it has

--- a/hw/ip/otbn/dv/otbnsim/sim/stats.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/stats.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import Counter
-import typing
 from typing import Dict, List, Optional, Tuple
 
 from elftools.dwarf.dwarfinfo import DWARFInfo  # type: ignore

--- a/hw/ip/otbn/dv/otbnsim/sim/stats.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/stats.py
@@ -22,13 +22,13 @@ class ExecutionStats:
         self.program = program
 
         self.stall_count = 0
-        self.insn_histo = Counter()  # type: typing.Counter[str]
-        self.func_calls = []  # type: List[Dict[str, int]]
-        self.loops = []  # type: List[Dict[str, int]]
+        self.insn_histo: Counter[str] = Counter()
+        self.func_calls: List[Dict[str, int]] = []
+        self.loops: List[Dict[str, int]] = []
 
         # Histogram indexed by the length of the (extended) basic block.
-        self.basic_block_histo = Counter()  # type: typing.Counter[int]
-        self.ext_basic_block_histo = Counter()  # type: typing.Counter[int]
+        self.basic_block_histo: Counter[int] = Counter()
+        self.ext_basic_block_histo: Counter[int] = Counter()
 
         self._current_basic_block_len = 0
         self._current_ext_basic_block_len = 0
@@ -275,9 +275,9 @@ class ExecutionStatAnalyzer:
         # The call graphs are on function granularity; the call sites
         # dictionary is indexed by the called function, but uses the call site
         # as value.
-        callgraph = {}  # type: Dict[int, typing.Counter[int]]
-        rev_callgraph = {}  # type: Dict[int, typing.Counter[int]]
-        rev_callsites = {}  # type: Dict[int, typing.Counter[int]]
+        callgraph: Dict[int, Counter[int]] = {}  # type
+        rev_callgraph: Dict[int, Counter[int]] = {}
+        rev_callsites: Dict[int, Counter[int]] = {}
         for c in self._stats.func_calls:
             if c['caller_func'] not in callgraph:
                 callgraph[c['caller_func']] = Counter()

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -78,7 +78,7 @@ class DumbWSR(WSR):
     def __init__(self, name: str):
         super().__init__(name)
         self._value = 0
-        self._next_value = None  # type: Optional[int]
+        self._next_value: Optional[int] = None
 
     def on_start(self) -> None:
         self._value = 0
@@ -124,8 +124,8 @@ class RandWSR(WSR):
     def __init__(self, name: str, ext_regs: OTBNExtRegs):
         super().__init__(name)
 
-        self._random_value = None  # type: Optional[int]
-        self._next_random_value = None  # type: Optional[int]
+        self._random_value: Optional[int] = None
+        self._next_random_value: Optional[int] = None
         self._ext_regs = ext_regs
 
         # The pending_request flag says that we've started an instruction that
@@ -289,8 +289,8 @@ class SideloadKey:
     '''Represents a sideloaded key, with 384 bits of data and a valid signal'''
     def __init__(self, name: str):
         self.name = name
-        self._value = None  # type: Optional[int]
-        self._new_value = None  # type: Optional[Tuple[bool, int]]
+        self._value: Optional[int] = None
+        self._new_value: Optional[Tuple[bool, int]] = None
 
     def has_value(self) -> bool:
         return self._value is not None
@@ -424,7 +424,7 @@ class WSRFile:
         self.KeyS1.commit()
 
     def changes(self) -> List[Trace]:
-        ret = []  # type: List[Trace]
+        ret: List[Trace] = []
         ret += self.MOD.changes()
         ret += self.RND.changes()
         ret += self.ACC.changes()

--- a/hw/ip/otbn/dv/rig/rig/config.py
+++ b/hw/ip/otbn/dv/rig/rig/config.py
@@ -17,7 +17,7 @@ class Weights:
                              'but was actually a {}.'
                              .format(what, type(yml).__name__))
 
-        self.values = {}  # type: Dict[str, float]
+        self.values: Dict[str, float] = {}
         for key, value in yml.items():
             if not isinstance(key, str):
                 raise ValueError('{} had key {!r}, which is not a string.'
@@ -58,8 +58,8 @@ class MinMaxes:
                              'but was actually a {}.'
                              .format(what, type(yml).__name__))
 
-        self.min_values = {}  # type: Dict[str, int]
-        self.max_values = {}  # type: Dict[str, int]
+        self.min_values: Dict[str, int] = {}
+        self.max_values: Dict[str, int] = {}
 
         for key, value in yml.items():
             if not isinstance(key, str):

--- a/hw/ip/otbn/dv/rig/rig/gens/loop_dup_end.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/loop_dup_end.py
@@ -19,7 +19,7 @@ class LoopDupEndInner(Loop):
     '''The generator used by LoopDupEnd to make the inner loop'''
     def __init__(self, cfg: Config, insns_file: InsnsFile) -> None:
         super().__init__(cfg, insns_file)
-        self.loop_end_stack = []  # type: List[int]
+        self.loop_end_stack: List[int] = []
 
     def gen_with_end(self,
                      loop_end: int,

--- a/hw/ip/otbn/dv/rig/rig/snippet_gens.py
+++ b/hw/ip/otbn/dv/rig/rig/snippet_gens.py
@@ -66,8 +66,8 @@ class SnippetGens:
     ]
 
     def __init__(self, cfg: Config, insns_file: InsnsFile) -> None:
-        self._cont_generators = []  # type: List[Tuple[SnippetGen, float]]
-        self._end_generators = []   # type: List[Tuple[SnippetGen, float]]
+        self._cont_generators: List[Tuple[SnippetGen, float]] = []
+        self._end_generators: List[Tuple[SnippetGen, float]] = []
 
         # Grab an ECall generator. We'll use it in self.gens to append an ECALL
         # instruction if necessary.
@@ -193,7 +193,7 @@ class SnippetGens:
         model.pc at the place where the next instruction should be inserted).
 
         '''
-        children = []  # type: List[Snippet]
+        children: List[Snippet] = []
         while True:
             gen_ecall = False
             # If we've run out of space and end is False, we stop immediately.

--- a/hw/ip/otbn/util/docs/get_impl.py
+++ b/hw/ip/otbn/util/docs/get_impl.py
@@ -57,9 +57,9 @@ class NBAssign(cst.BaseSmallStatement):
 class ImplTransformer(cst.CSTTransformer):
     '''An AST visitor used to extract documentation from the ISS'''
     def __init__(self) -> None:
-        self.impls = {}  # type: Dict[str, Sequence[cst.BaseStatement]]
+        self.impls: Dict[str, Sequence[cst.BaseStatement]] = {}
 
-        self.cur_class = None  # type: Optional[str]
+        self.cur_class: Optional[str] = None
 
     def visit_ClassDef(self, node: cst.ClassDef) -> Optional[bool]:
         assert self.cur_class is None

--- a/hw/ip/otbn/util/shared/insn_yaml.py
+++ b/hw/ip/otbn/util/shared/insn_yaml.py
@@ -404,7 +404,7 @@ def load_file(path: str, isrs: Optional[IsrMaps]) -> InsnsFile:
 def make_isr_dict(path: str) -> IsrMap:
     '''Load a YAML file at path and return a map from name to Isr.'''
     try:
-        name_to_isr = {}  # type: Dict[str, Isr]
+        name_to_isr: Dict[str, Isr] = {}
         for isr in read_isrs(path):
             name = isr.name.lower()
             if name in name_to_isr:
@@ -417,7 +417,7 @@ def make_isr_dict(path: str) -> IsrMap:
                            .format(path, err)) from None
 
 
-_DEFAULT_INSNS_FILE = None  # type: Optional[InsnsFile]
+_DEFAULT_INSNS_FILE: Optional[InsnsFile] = None
 
 
 def load_insns_yaml() -> InsnsFile:

--- a/hw/ip/otbn/util/shared/mem_layout.py
+++ b/hw/ip/otbn/util/shared/mem_layout.py
@@ -67,7 +67,7 @@ class OtbnMemoryLayout:
         self.dmem_size_bytes = dmem_window[1] + _DmemScratchSizeBytes
 
 
-_LAYOUT = None  # type: Optional[OtbnMemoryLayout]
+_LAYOUT: Optional[OtbnMemoryLayout] = None
 
 
 def get_memory_layout() -> OtbnMemoryLayout:

--- a/hw/ip/otbn/util/shared/otbn_reggen.py
+++ b/hw/ip/otbn/util/shared/otbn_reggen.py
@@ -9,7 +9,7 @@ from typing import Optional, Tuple
 
 from reggen import ip_block, reg_block
 
-_LR_RETVAL = None  # type: Optional[Tuple[int, object]]
+_LR_RETVAL: Optional[Tuple[int, object]] = None
 
 
 def load_registers() -> Tuple[int, object]:

--- a/hw/ip/rom_ctrl/util/mem.py
+++ b/hw/ip/rom_ctrl/util/mem.py
@@ -109,7 +109,7 @@ class MemFile:
     def _load_preproc(width: int, infile: IO[str]) -> 'MemFile':
         '''Load a pre-processed file'''
         chunks = []
-        next_chunk = None  # type: Optional[MemChunk]
+        next_chunk: Optional[MemChunk] = None
         for line in infile:
             # If the line is empty or whitespace, skip it.
             if not line or line.isspace():
@@ -166,7 +166,7 @@ class MemFile:
     def load_elf32(infile: BinaryIO, base_addr: int) -> 'MemFile':
         '''Read a little-endian 32-bit ELF file'''
         elf_file = ELFFile(infile)
-        segments = []  # type: List[Tuple[int, int, bytes]]
+        segments: List[Tuple[int, int, bytes]] = []
         for segment in elf_file.iter_segments():
             seg_type = segment['p_type']
 
@@ -213,7 +213,7 @@ class MemFile:
         # Merge any adjacent segments, bridging any sub-word gaps. This doesn't
         # do any other right padding: we'll do that on the final pass that
         # converts to 32-bit words.
-        merged_segments = []  # type: List[Tuple[int, int, bytes]]
+        merged_segments: List[Tuple[int, int, bytes]] = []
         next_word = 0
         for lma, top, data in segments:
             # Round the LMA down to the previous word boundary. The non-overlap
@@ -248,7 +248,7 @@ class MemFile:
         # Assemble the bytes in each segment into little-endian 32-bit words.
         # Zero-extend any partial word at the end of a segment. Because of the
         # merging in the previous pass, we know this won't cause any overlaps.
-        chunks = []  # type: List[MemChunk]
+        chunks: List[MemChunk] = []
         for lma_word, _, data in merged_segments:
             words = []
             word = 0

--- a/util/design/lib/common.py
+++ b/util/design/lib/common.py
@@ -56,7 +56,7 @@ def check_bool(x):
     '''
     if isinstance(x, bool):
         return x
-    if not x.lower() in ["true", "false"]:
+    if x.lower() not in ["true", "false"]:
         raise RuntimeError("{} is not a boolean value.".format(x))
     else:
         return (x.lower() == "true")

--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -631,7 +631,7 @@ def check_bool(x):
     """
     if isinstance(x, bool):
         return x
-    if not x.lower() in ["true", "false"]:
+    if x.lower() not in ["true", "false"]:
         raise RuntimeError("{} is not a boolean value.".format(x))
     else:
         return (x.lower() == "true")

--- a/util/reggen/validate.py
+++ b/util/reggen/validate.py
@@ -51,7 +51,7 @@ def check_bool(x: Union[bool, str], err_prefix: str) -> Tuple[bool, bool]:
     if isinstance(x, bool):
         # if Bool returns as it is
         return x, False
-    if not x.lower() in ["true", "false"]:
+    if x.lower() not in ["true", "false"]:
         log.error(err_prefix + ": Bad field value " + x)
         return False, True
     else:

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -406,7 +406,7 @@ def amend_xbar(top: Dict[str, object],
     - size: from top["module"]
     """
     xbar_list = [x["name"] for x in top["xbar"]]
-    if not xbar["name"] in xbar_list:
+    if xbar["name"] not in xbar_list:
         log.info(
             "Xbar %s doesn't belong to the top %s. Check if the xbar doesn't need"
             % (xbar["name"], top["name"]))
@@ -496,7 +496,7 @@ def xbar_cross_node(node_name, device_xbar, xbars, visited=[]):
     devices = host_xbar["connections"][device_xbar["name"]]
 
     for node in host_xbar["nodes"]:
-        if not node["name"] in devices:
+        if node["name"] not in devices:
             continue
         if "xbar" in node and node["xbar"] is True:
             if "addr_range" not in node:


### PR DESCRIPTION
Manual cherrypick of:
* #24346
* #24569


Partially picked:
We only partially pick the commits related to otbnsim in this PR without the ruff config changes.
* #26374
  * [python] Convert type annotation comments to first-class syntax 
  * [python] Apply Ruff auto-fixes 
    * Ruff config changes are removed from this commit since it's not available on earlgrey_1.0.0
