### PR TITLE
[hw,prim_alert,dv] Add 3 cycles clock skew to the testbench config

### DIFF
--- a/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson
@@ -39,6 +39,10 @@
       build_opts: ["+define+IS_FATAL"]
     }
     {
+      name: fatal_alert_with_3_cycles_skew
+      build_opts: ["+define+IS_FATAL", "+defines+IS_3_CYCLE_SKEW"]
+    }
+    {
       name: sync_fatal_alert
       build_opts: ["+define+IS_FATAL", "+define+IS_SYNC"]
     }
@@ -54,6 +58,10 @@
       build_mode: fatal_alert
     }
     {
+      name: prim_async_fatal_alert_with_3_cycles_skew
+      build_mode: fatal_alert_with_3_cycles_skew
+    }
+    {
       name: prim_sync_alert
       build_mode: sync_alert
     }
@@ -66,7 +74,7 @@
   regressions: [
     {
       name: smoke
-      tests: ["prim_async_alert"]
+      tests: ["prim_async_alert", "prim_async_fatal_alert_with_3_cycles_skew"]
     }
   ]
   overrides: [

--- a/hw/ip/prim/dv/prim_alert/tb/prim_alert_tb.sv
+++ b/hw/ip/prim/dv/prim_alert/tb/prim_alert_tb.sv
@@ -33,6 +33,11 @@ module prim_alert_tb;
   `else
     localparam bit IsFatal = 0;
   `endif
+  `ifdef IS_3_CYCLE_SKEW
+    localparam int unsigned SkewCycles = 3;
+  `else
+    localparam int unsigned SkewCycles = 1;
+  `endif
 
   localparam time ClkPeriod  = 10_000;
   localparam int  WaitCycle = IsAsync ? 3 : 1;
@@ -85,7 +90,7 @@ module prim_alert_tb;
   prim_mubi_pkg::mubi4_t     init_trig = prim_mubi_pkg::MuBi4False;
   prim_alert_sender #(
     .AsyncOn(IsAsync),
-    .SkewCycles(1),
+    .SkewCycles(SkewCycles),
     .IsFatal(IsFatal)
   ) i_alert_sender (
     .clk_i(clk),
@@ -100,7 +105,7 @@ module prim_alert_tb;
 
   prim_alert_receiver #(
     .AsyncOn(IsAsync),
-    .SkewCycles(1)
+    .SkewCycles(SkewCycles)
   ) i_alert_receiver (
     .clk_i(clk),
     .rst_ni(rst_n),


### PR DESCRIPTION
This PR is a follow-up to https://github.com/lowRISC/opentitan/pull/27536 to add the variable skew cycle configuration to the prim alert testbench. The change adds the option to switch between 1 cycle skew (default) and 3, which is the config in Darjeeling at the moment. It is only enabled for the async fatal case.