### PR TITLE
[dtgen] Expose more ipgen params via dtgen

### DIFF
--- a/hw/ip_templates/ac_range_check/data/ac_range_check.tpldesc.hjson
+++ b/hw/ip_templates/ac_range_check/data/ac_range_check.tpldesc.hjson
@@ -26,6 +26,11 @@
       desc:    "Number of range registers",
       type:    "int",
       default: "32",
+      dtgen:
+      {
+        type: "uint8"
+        name: "num_ranges"
+      }
     }
     {
       name:    "nr_role_bits",

--- a/hw/ip_templates/rv_core_ibex/data/rv_core_ibex.tpldesc.hjson
+++ b/hw/ip_templates/rv_core_ibex/data/rv_core_ibex.tpldesc.hjson
@@ -14,6 +14,11 @@
       desc: "Number of translatable regions per ibex bus"
       type: "int"
       default: "2"
+      dtgen:
+      {
+        type: "uint8"
+        name: "num_regions"
+      }
     }
     {
       name: "uniquified_modules"

--- a/hw/ip_templates/rv_plic/data/rv_plic.tpldesc.hjson
+++ b/hw/ip_templates/rv_plic/data/rv_plic.tpldesc.hjson
@@ -20,6 +20,11 @@
       desc: "Number of interrupt sources"
       type: "int"
       default: "32"
+      dtgen:
+      {
+        type: "uint8"
+        name: "num_irq_sources"
+      }
     }
     {
       name: "target"

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/data/top_darjeeling_ac_range_check.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/data/top_darjeeling_ac_range_check.ipconfig.hjson
@@ -12,4 +12,13 @@
     topname: darjeeling
     uniquified_modules: {}
   }
+  dtgen:
+  {
+    num_ranges:
+    {
+      type: uint8
+      name: num_ranges
+      doc: Number of range registers
+    }
+  }
 }

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/data/top_darjeeling_rv_core_ibex.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/data/top_darjeeling_rv_core_ibex.ipconfig.hjson
@@ -11,4 +11,13 @@
     topname: darjeeling
     uniquified_modules: {}
   }
+  dtgen:
+  {
+    num_regions:
+    {
+      type: uint8
+      name: num_regions
+      doc: Number of translatable regions per ibex bus
+    }
+  }
 }

--- a/hw/top_darjeeling/ip_autogen/rv_plic/data/top_darjeeling_rv_plic.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/data/top_darjeeling_rv_plic.ipconfig.hjson
@@ -13,4 +13,13 @@
     uniquified_modules: {}
     racl_support: false
   }
+  dtgen:
+  {
+    src:
+    {
+      type: uint8
+      name: num_irq_sources
+      doc: Number of interrupt sources
+    }
+  }
 }

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/data/top_earlgrey_rv_core_ibex.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/data/top_earlgrey_rv_core_ibex.ipconfig.hjson
@@ -11,4 +11,13 @@
     topname: earlgrey
     uniquified_modules: {}
   }
+  dtgen:
+  {
+    num_regions:
+    {
+      type: uint8
+      name: num_regions
+      doc: Number of translatable regions per ibex bus
+    }
+  }
 }

--- a/hw/top_earlgrey/ip_autogen/rv_plic/data/top_earlgrey_rv_plic.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/data/top_earlgrey_rv_plic.ipconfig.hjson
@@ -13,4 +13,13 @@
     uniquified_modules: {}
     racl_support: false
   }
+  dtgen:
+  {
+    src:
+    {
+      type: uint8
+      name: num_irq_sources
+      doc: Number of interrupt sources
+    }
+  }
 }

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/data/top_englishbreakfast_rv_core_ibex.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/data/top_englishbreakfast_rv_core_ibex.ipconfig.hjson
@@ -11,4 +11,13 @@
     topname: englishbreakfast
     uniquified_modules: {}
   }
+  dtgen:
+  {
+    num_regions:
+    {
+      type: uint8
+      name: num_regions
+      doc: Number of translatable regions per ibex bus
+    }
+  }
 }

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/data/top_englishbreakfast_rv_plic.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/data/top_englishbreakfast_rv_plic.ipconfig.hjson
@@ -13,4 +13,13 @@
     uniquified_modules: {}
     racl_support: false
   }
+  dtgen:
+  {
+    src:
+    {
+      type: uint8
+      name: num_irq_sources
+      doc: Number of interrupt sources
+    }
+  }
 }


### PR DESCRIPTION
This PR exposes simpler parameters via the new ipgen dtgen interface. This allows multi-top compatible SW to query this parameter and generate a more generic driver or DIF.