### PR TITLE
[hw,racl_ctrl,rtl] Remove hwqe from ERROR_LOG_ADDRESS

### DIFF
--- a/hw/ip_templates/racl_ctrl/data/racl_ctrl.hjson.tpl
+++ b/hw/ip_templates/racl_ctrl/data/racl_ctrl.hjson.tpl
@@ -259,7 +259,6 @@
             '''
       swaccess: "ro"
       hwaccess: "hwo"
-      hwqe: "true"
       fields: [
         { bits: "31:0"
           name: "address"

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/data/racl_ctrl.hjson
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/data/racl_ctrl.hjson
@@ -305,7 +305,6 @@
             '''
       swaccess: "ro"
       hwaccess: "hwo"
-      hwqe: "true"
       fields: [
         { bits: "31:0"
           name: "address"

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_top.sv
@@ -667,10 +667,6 @@ module racl_ctrl_reg_top
 
 
   // R[error_log_address]: V(False)
-  logic error_log_address_qe;
-  logic [0:0] error_log_address_flds_we;
-  // In case all fields are read-only the aggregated register QE will be zero as well.
-  assign error_log_address_qe = &error_log_address_flds_we;
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -689,7 +685,7 @@ module racl_ctrl_reg_top
     .d      (hw2reg.error_log_address.d),
 
     // to internal hardware
-    .qe     (error_log_address_flds_we[0]),
+    .qe     (),
     .q      (),
     .ds     (),
 


### PR DESCRIPTION
The register is software read-only. hwqe on that register does not make sense, as software never asserts it. Remove that attribute.

This lint issue was not visible because down in the prim library, `prim_sha` has the following wildcard waiver:

```
waive -rules {NOT_READ} -location {*_reg_top.sv} -regexp {(address|param|user)} \
      -comment "Register module waiver"
```
I removed that one in https://github.com/lowRISC/opentitan/pull/27564