### PR TITLE
[dpi] Define _DEFAULT_SOURCE in two files to get BSD functions

### DIFF
--- a/hw/dv/dpi/uartdpi/uartdpi.c
+++ b/hw/dv/dpi/uartdpi/uartdpi.c
@@ -2,6 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// The code below uses cfmakeraw, which comes from unistd.h. With glibc, it is
+// only provided if the _DEFAULT_SOURCE feature test macro is defined (because
+// it came from BSD in the first place, so needs pulling in explicitly).
+#define _DEFAULT_SOURCE
+
 #include "uartdpi.h"
 
 #ifdef __linux__

--- a/hw/dv/dpi/usbdpi/usb_monitor.c
+++ b/hw/dv/dpi/usbdpi/usb_monitor.c
@@ -103,7 +103,7 @@ usb_monitor_ctx_t *usb_monitor_init(const char *filename,
   }
 
   // more useful for tail -f
-  setlinebuf(mon->file);
+  setvbuf(mon->file, NULL, _IOLBF, 0);
   printf(
       "\nUSBDPI: Monitor output file created at %s. Works well with tail:\n"
       "$ tail -f %s\n",


### PR DESCRIPTION
With the toolchain I was just trying to use for a compilation (GCC 14.2.1; glibc 2.40), these two files failed to build because we didn't have the relevant feature test macro defined. Define it...