### PR TITLE
[uart,dv] Do not error on missing UARTDPI_LOG_* plusarg

### DIFF
--- a/hw/dv/dpi/uartdpi/uartdpi.sv
+++ b/hw/dv/dpi/uartdpi/uartdpi.sv
@@ -42,7 +42,7 @@ module uartdpi #(
   function automatic void initialize();
     string plusarg_name = {"UARTDPI_LOG_", NAME};
     if (!$value$plusargs({plusarg_name, "=%s"}, log_file_path)) begin
-      $error($sformatf("No %s plusarg found.", plusarg_name));
+      $display($sformatf("No %s plusarg found.", plusarg_name));
     end
     ctx = uartdpi_create(NAME, log_file_path, EXIT_STRING);
   endfunction


### PR DESCRIPTION
Fix Verilator builds after #27208 was merged. This should hopefully solve current CI issues.

Our current Verilator test simulation setup does not provide a plusarg for the UARTDPI logs, and relies on the default log files being used (e.g. "uart0.log"). The introduction of an error on a missing plusarg causes Verilator simulation builds to fail - for now, we just `display` this error instead as a useful piece of info.

I'm not super familiar with SystemVerilog or the DV setup so please do mention if there's a more appropriate fix that could be applied here. Maybe in the future we should be explicitly passing in all these DPI log plusargs?