### PR TITLE
[sival] Add flash endurance testpoint

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson
@@ -353,5 +353,35 @@
       tests: ["chip_sw_flash_crash_alert"]
       bazel: ["//sw/device/tests:flash_ctrl_write_clear_test"]
     }
+    {
+      name: chip_sw_flash_endurance_prod
+      desc: '''Verify that the flash on PROD silicon can endure a minimum number of
+            program/erase cycles before it becomes unreliable.
+
+            Configure memory protected regions to override the default configuration as follows:
+            - ECC, scrambling & high endurance all disabled.
+            - ECC & scrambling disabled, high endurance enabled.
+
+            For each configuration, test the following sequence:
+            1. Find the last page that can be written to without errors.
+            2. Erase the target page, and verify the erase.
+            3. Write a pre-defined pattern to the entire page and read it back to verify.
+            4. Increment a counter if the erase & write succeeded.
+            5. Repeat 2->4 until any erased or written value does not match.
+            6. Check that the count exceeds a target program/erase cycle count.
+
+            To stress-test potential bit-flip issues on neighbouring cells, the pattern that is
+            written should alternate between 0xA5A5A5A5 and 0x5A5A5A5A. Alternating the pattern
+            will allow us to avoid missing failures when reusing the same pattern.
+
+            Note: This test will wear down flash, and so should only be run manually on devices /
+            pages where it is okay to wear the flash. This is not intended to be run frequently.
+            '''
+      stage: V3
+      si_stage: SV3
+      lc_states: ["PROD"]
+      tests: []
+      bazel: []
+    }
   ]
 }


### PR DESCRIPTION
For PROD silicon, we want a test that we can manually run to ensure that the on-chip flash can endure a certain number of Program/Erase cycles before it wears and starts to show faults. Add a testpoint for this test.

Running this test will wear down the flash and so should only be done manually, and carefully. We define the test as using the last working page so that the test can be run multiple times on the same chip without issues, wearing down pages that are less likely to be used by other tests or firmware.

I'm not as familiar with the high-endurance setting, but I've opted to add it to the test description since from my understanding it should allow flash to endure a greater number of program/erase operations.

*Aside*: I've tagged this test as `stage: V3` for now but since it's a manual SW only test, it should really be `stage: NA`. The current testplan linter's JSON schema doesn't allow this, and there are other tests in the testplan that provide stages for SW-only tests. This should probably be addressed in a separate PR.