### PR TITLE
[flash_ctrl, tests] Fix incorrect loop variable for test data

### DIFF
--- a/sw/device/tests/flash_ctrl_clock_freqs_test.c
+++ b/sw/device/tests/flash_ctrl_clock_freqs_test.c
@@ -137,7 +137,7 @@ static void do_data_partition_test(uint32_t bank_number) {
       uint32_t page_index =
           (i == 0) ? flash_bank_1_page_index : flash_bank_1_page_index_last;
       for (int j = 0; j < kDataSize; ++j) {
-        test_data[i] = rand_testutils_gen32();
+        test_data[j] = rand_testutils_gen32();
       }
       uint32_t address = 0;
       CHECK_STATUS_OK(flash_ctrl_testutils_data_region_setup(


### PR DESCRIPTION
Happened to notice this as I was looking through the test. Harmless, but also not doing what was intended.

Only a single word of the test data is actually being written to in each iteration, because the incorrect loop variable `i` is being used instead of the inner loop variable `j`. Fix this so that the full 16 words of test data is being randomized.