### PR TITLE
[c++,hw,sw] Enable project wide C++17 Support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,8 +7,8 @@ common --enable_bzlmod
 common --enable_workspace=no
 
 # https://opentitan.org/book/doc/contributing/style_guides/c_cpp_coding_style.html#c-version specifies
-build --action_env=BAZEL_CXXOPTS="-std=gnu++14"
-build --cxxopt='-std=gnu++14'
+build --action_env=BAZEL_CXXOPTS="-std=gnu++17"
+build --cxxopt='-std=gnu++17'
 build --conlyopt='-std=gnu11'
 
 # Never strip debugging information so that we can produce annotated

--- a/doc/contributing/style_guides/c_cpp_coding_style.md
+++ b/doc/contributing/style_guides/c_cpp_coding_style.md
@@ -266,13 +266,13 @@ This is not necessary in a `.c` or `.cc` file, where this cannot cause downstrea
 
 ### C++ Version
 
-C++ code should target C++14.
+C++ code should target C++17.
 
 ### Aggregate Initializers
 
 ***C++20-style designated initializers are permitted in C++ code, when used with POD types.***
 
-While we target C++14, both GCC and Clang allow C++20 designated initializers in C++14-mode, as an extension:
+While we target C++17, both GCC and Clang allow C++20 designated initializers in C++17-mode, as an extension:
 ```
 struct Foo { int a, b; };
 

--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -54,11 +54,10 @@
                // that gets passed to Make (stripping one level of quotes), and then needs to
                // result in an argument with an embedded space (the other one).
                "-CFLAGS --std=c99 -CFLAGS -fno-extended-identifiers",
-               // C++11 standard is enforced for all sources, including the DPI-C constructs.
-               // TODO, may need to update to c++14 to meet our requirements
+               // C++17 standard is enforced for all sources, including the DPI-C constructs.
                // Refer to
                // https://opentitan.org/book/doc/contributing/style_guides/c_cpp_coding_style.html#c-style-guide
-               "-CFLAGS --std=c++11",
+               "-CFLAGS --std=c++17",
                // Without this magic LDFLAGS argument below, we get compile time errors with
                // VCS on Google Linux machines that look like this:
                // .../libvcsnew.so: undefined reference to `snpsReallocFunc'

--- a/hw/ip/aes/pre_dv/aes_cipher_core_tb/aes_cipher_core_tb.core
+++ b/hw/ip/aes/pre_dv/aes_cipher_core_tb/aes_cipher_core_tb.core
@@ -43,7 +43,7 @@ targets:
 # -O
 #   Optimization levels have a large impact on the runtime performance of the
 #   simulation model. -O2 and -O3 are pretty similar, -Os is slower than -O2/-O3
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=aes_cipher_core_tb -g -O0"'
+          - '-CFLAGS "-std=c++17 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=aes_cipher_core_tb -g -O0"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
           # XXX: Cleanup all warnings and remove this option

--- a/hw/ip/aes/pre_dv/aes_sbox_tb/aes_sbox_tb.core
+++ b/hw/ip/aes/pre_dv/aes_sbox_tb/aes_sbox_tb.core
@@ -43,7 +43,7 @@ targets:
 # -O
 #   Optimization levels have a large impact on the runtime performance of the
 #   simulation model. -O2 and -O3 are pretty similar, -Os is slower than -O2/-O3
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=aes_sbox_tb -g -O0"'
+          - '-CFLAGS "-std=c++17 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=aes_sbox_tb -g -O0"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
           # XXX: Cleanup all warnings and remove this option

--- a/hw/ip/aes/pre_dv/aes_wrap_tb/aes_wrap_tb.core
+++ b/hw/ip/aes/pre_dv/aes_wrap_tb/aes_wrap_tb.core
@@ -43,7 +43,7 @@ targets:
 # -O
 #   Optimization levels have a large impact on the runtime performance of the
 #   simulation model. -O2 and -O3 are pretty similar, -Os is slower than -O2/-O3
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=aes_wrap_tb -g -O0"'
+          - '-CFLAGS "-std=c++17 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=aes_wrap_tb -g -O0"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
           # XXX: Cleanup all warnings and remove this option

--- a/hw/ip/ascon/pre_dv/ascon_tb/ascon_sim.core
+++ b/hw/ip/ascon/pre_dv/ascon_tb/ascon_sim.core
@@ -44,7 +44,7 @@ targets:
 # -O
 #   Optimization levels have a large impact on the runtime performance of the
 #   simulation model. -O2 and -O3 are pretty similar, -Os is slower than -O2/-O3
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ascon_sim -g -O0"'
+          - '-CFLAGS "-std=c++17 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ascon_sim -g -O0"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
           - "-Wno-PINCONNECTEMPTY"

--- a/hw/ip/kmac/pre_dv/kmac_reduced_tb/kmac_reduced_tb.core
+++ b/hw/ip/kmac/pre_dv/kmac_reduced_tb/kmac_reduced_tb.core
@@ -44,7 +44,7 @@ targets:
 # -O
 #   Optimization levels have a large impact on the runtime performance of the
 #   simulation model. -O2 and -O3 are pretty similar, -Os is slower than -O2/-O3
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=kmac_reduced_tb -g -O0"'
+          - '-CFLAGS "-std=c++17 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=kmac_reduced_tb -g -O0"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
           # This TB is mainly used for developing and prototyping security

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.core
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.core
@@ -64,7 +64,7 @@ targets:
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=otbn_top_sim"'
+          - '-CFLAGS "-std=c++17 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=otbn_top_sim"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
           # RAM primitives wider than 64bit (required for ECC) fail to build in

--- a/hw/ip/prim/pre_dv/prim_ascon/prim_ascon_duplex_tb/prim_ascon_dublex_tb.core
+++ b/hw/ip/prim/pre_dv/prim_ascon/prim_ascon_duplex_tb/prim_ascon_dublex_tb.core
@@ -46,7 +46,7 @@ targets:
 # -O
 #   Optimization levels have a large impact on the runtime performance of the
 #   simulation model. -O2 and -O3 are pretty similar, -Os is slower than -O2/-O3
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=prim_ascon_duplex_tb -g -O0"'
+          - '-CFLAGS "-std=c++17 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=prim_ascon_duplex_tb -g -O0"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
           # XXX: Cleanup all warnings and remove this option

--- a/hw/ip/prim/pre_dv/prim_ascon/prim_ascon_round_tb/prim_ascon_round_tb.core
+++ b/hw/ip/prim/pre_dv/prim_ascon/prim_ascon_round_tb/prim_ascon_round_tb.core
@@ -44,7 +44,7 @@ targets:
 # -O
 #   Optimization levels have a large impact on the runtime performance of the
 #   simulation model. -O2 and -O3 are pretty similar, -Os is slower than -O2/-O3
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=prim_ascon_round_tb -g -O0"'
+          - '-CFLAGS "-std=c++17 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=prim_ascon_round_tb -g -O0"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
           # XXX: Cleanup all warnings and remove this option

--- a/hw/ip/prim/pre_dv/prim_crc32/prim_crc32_sim.core
+++ b/hw/ip/prim/pre_dv/prim_crc32/prim_crc32_sim.core
@@ -53,7 +53,7 @@ targets:
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=prim_crc32_sim"'
+          - '-CFLAGS "-std=c++17 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=prim_crc32_sim"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
           # RAM primitives wider than 64bit (required for ECC) fail to build in

--- a/hw/ip/prim/pre_dv/prim_sync_reqack/prim_sync_reqack_tb.core
+++ b/hw/ip/prim/pre_dv/prim_sync_reqack/prim_sync_reqack_tb.core
@@ -43,7 +43,7 @@ targets:
 # -O
 #   Optimization levels have a large impact on the runtime performance of the
 #   simulation model. -O2 and -O3 are pretty similar, -Os is slower than -O2/-O3
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=prim_sync_reqack_tb -g -O0"'
+          - '-CFLAGS "-std=c++17 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=prim_sync_reqack_tb -g -O0"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
           # XXX: Cleanup all warnings and remove this option

--- a/hw/ip/prim/pre_dv/prim_trivium/prim_trivium_tb.core
+++ b/hw/ip/prim/pre_dv/prim_trivium/prim_trivium_tb.core
@@ -43,7 +43,7 @@ targets:
 # -O
 #   Optimization levels have a large impact on the runtime performance of the
 #   simulation model. -O2 and -O3 are pretty similar, -Os is slower than -O2/-O3
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=prim_trivium_tb -g -O0"'
+          - '-CFLAGS "-std=c++17 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=prim_trivium_tb -g -O0"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
           # XXX: Cleanup all warnings and remove this option

--- a/hw/top_darjeeling/ip/ast/ast.core
+++ b/hw/top_darjeeling/ip/ast/ast.core
@@ -123,5 +123,5 @@ targets:
       - files_rtl
     tools:
       vcs:
-        vcs_options: [-sverilog -ntb_opts uvm-1.2 -CFLAGS --std=c99 -CFLAGS -fno-extended-identifiers -CFLAGS --std=c++11 -timescale=1ns/1ps -l vcs.log]
+        vcs_options: [-sverilog -ntb_opts uvm-1.2 -CFLAGS --std=c99 -CFLAGS -fno-extended-identifiers -CFLAGS --std=c++17 -timescale=1ns/1ps -l vcs.log]
     toplevel: ast

--- a/hw/top_earlgrey/dv/verilator/chip_sim.core
+++ b/hw/top_earlgrey/dv/verilator/chip_sim.core
@@ -112,7 +112,7 @@ targets:
           - '--unroll-count 512'
           # TODO: Variable expansion depends on edalize internals. Find better solution.
           #       (Applies to LDFLAGS expansion below as well)
-          - '-CFLAGS "$(CFLAGS_FOR_BUILD) -std=c++11 -Wall -DVM_TRACE_FMT_FST -DVL_USER_STOP -DTOPLEVEL_NAME=chip_sim_tb"'
+          - '-CFLAGS "$(CFLAGS_FOR_BUILD) -std=c++17 -Wall -DVM_TRACE_FMT_FST -DVL_USER_STOP -DTOPLEVEL_NAME=chip_sim_tb"'
           - '-LDFLAGS "$(LDFLAGS_FOR_BUILD) -pthread -lutil -lelf"'
           - '-Wall'
           # Execute simulation with four threads by default, which works best

--- a/hw/top_earlgrey/ip/ast/ast.core
+++ b/hw/top_earlgrey/ip/ast/ast.core
@@ -128,5 +128,5 @@ targets:
       - files_rtl
     tools:
       vcs:
-        vcs_options: [-sverilog -ntb_opts uvm-1.2 -CFLAGS --std=c99 -CFLAGS -fno-extended-identifiers -CFLAGS --std=c++11 -timescale=1ns/1ps -l vcs.log]
+        vcs_options: [-sverilog -ntb_opts uvm-1.2 -CFLAGS --std=c99 -CFLAGS -fno-extended-identifiers -CFLAGS --std=c++17 -timescale=1ns/1ps -l vcs.log]
     toplevel: ast

--- a/hw/top_englishbreakfast/chip_englishbreakfast_verilator.core
+++ b/hw/top_englishbreakfast/chip_englishbreakfast_verilator.core
@@ -110,7 +110,7 @@ targets:
           - '--trace-params'
           - '--trace-max-array 1024'
           - '--unroll-count 512'
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DVL_USER_STOP -DTOPLEVEL_NAME=chip_englishbreakfast_verilator"'
+          - '-CFLAGS "-std=c++17 -Wall -DVM_TRACE_FMT_FST -DVL_USER_STOP -DTOPLEVEL_NAME=chip_englishbreakfast_verilator"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - '-Wall'
           # Execute simulation with four threads by default, which works best

--- a/hw/top_englishbreakfast/ip/ast/ast.core
+++ b/hw/top_englishbreakfast/ip/ast/ast.core
@@ -126,5 +126,5 @@ targets:
       - files_rtl
     tools:
       vcs:
-        vcs_options: [-sverilog -ntb_opts uvm-1.2 -CFLAGS --std=c99 -CFLAGS -fno-extended-identifiers -CFLAGS --std=c++11 -timescale=1ns/1ps -l vcs.log]
+        vcs_options: [-sverilog -ntb_opts uvm-1.2 -CFLAGS --std=c99 -CFLAGS -fno-extended-identifiers -CFLAGS --std=c++17 -timescale=1ns/1ps -l vcs.log]
     toplevel: ast

--- a/sw/host/tests/usbdev/usbdev_stream/build.sh
+++ b/sw/host/tests/usbdev/usbdev_stream/build.sh
@@ -3,12 +3,12 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-g++ -Wall -Werror -std=c++14 -c -o stream_test.o -DSTREAMTEST_LIBUSB=1 stream_test.cc
-g++ -Wall -Werror -std=c++14 -c -o usbdev_iso.o -DSTREAMTEST_LIBUSB=1 usbdev_iso.cc
-g++ -Wall -Werror -std=c++14 -c -o usbdev_int.o -DSTREAMTEST_LIBUSB=1 usbdev_int.cc
-g++ -Wall -Werror -std=c++14 -c -o usbdev_serial.o -DSTREAMTEST_LIBUSB=1 usbdev_serial.cc
-g++ -Wall -Werror -std=c++14 -c -o usbdev_stream.o -DSTREAMTEST_LIBUSB=1 usbdev_stream.cc
-g++ -Wall -Werror -std=c++14 -c -o usbdev_utils.o -DSTREAMTEST_LIBUSB=1 usbdev_utils.cc
-g++ -Wall -Werror -std=c++14 -c -o usb_device.o -DSTREAMTEST_LIBUSB=1 usb_device.cc
+g++ -Wall -Werror -std=c++17 -c -o stream_test.o -DSTREAMTEST_LIBUSB=1 stream_test.cc
+g++ -Wall -Werror -std=c++17 -c -o usbdev_iso.o -DSTREAMTEST_LIBUSB=1 usbdev_iso.cc
+g++ -Wall -Werror -std=c++17 -c -o usbdev_int.o -DSTREAMTEST_LIBUSB=1 usbdev_int.cc
+g++ -Wall -Werror -std=c++17 -c -o usbdev_serial.o -DSTREAMTEST_LIBUSB=1 usbdev_serial.cc
+g++ -Wall -Werror -std=c++17 -c -o usbdev_stream.o -DSTREAMTEST_LIBUSB=1 usbdev_stream.cc
+g++ -Wall -Werror -std=c++17 -c -o usbdev_utils.o -DSTREAMTEST_LIBUSB=1 usbdev_utils.cc
+g++ -Wall -Werror -std=c++17 -c -o usb_device.o -DSTREAMTEST_LIBUSB=1 usb_device.cc
 
 g++ -g -O2 -o stream_test stream_test.o usbdev_iso.o usbdev_int.o usbdev_serial.o usbdev_stream.o usbdev_utils.o usb_device.o -lusb-1.0

--- a/sw/host/tests/usbdev/usbdev_stream/build_standalone.sh
+++ b/sw/host/tests/usbdev/usbdev_stream/build_standalone.sh
@@ -3,4 +3,4 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-g++ -std=c++14 -Wall -Werror -g -O2 -o serial_test stream_test.cc usbdev_serial.cc usbdev_stream.cc usbdev_utils.cc usb_device.cc
+g++ -std=c++17 -Wall -Werror -g -O2 -o serial_test stream_test.cc usbdev_serial.cc usbdev_stream.cc usbdev_utils.cc usb_device.cc


### PR DESCRIPTION
The first three commits are cherry-picked from https://github.com/lowRISC/opentitan/pull/27530/.

The last commit updates master-branch only related C++11 references to C++17.