### PR TITLE
[sw] stop inlining hmac functions

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/hmac.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac.c
@@ -212,6 +212,16 @@ void hmac_sha256_restore(const hmac_context_t *ctx) {
   abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CMD_REG_OFFSET, cmd);
 }
 
-extern void hmac_hmac_sha256_init(hmac_key_t key, bool big_endian_digest);
-extern void hmac_sha256_init(void);
-extern void hmac_sha256_final(hmac_digest_t *digest);
+void hmac_sha256_init(void) {
+  hmac_sha256_configure(false);
+  hmac_sha256_start();
+}
+
+void hmac_hmac_sha256_init(hmac_key_t key, bool big_endian_digest) {
+  hmac_hmac_sha256_configure(big_endian_digest, key);
+  hmac_sha256_start();
+}
+
+void hmac_sha256_final(hmac_digest_t *digest) {
+  hmac_sha256_final_truncated(digest->digest, ARRAYSIZE(digest->digest));
+}

--- a/sw/device/silicon_creator/lib/drivers/hmac.h
+++ b/sw/device/silicon_creator/lib/drivers/hmac.h
@@ -107,18 +107,12 @@ void hmac_sha256_start(void);
 /**
  * Configures and starts HMAC in SHA256 mode with little-endian output.
  */
-inline void hmac_sha256_init(void) {
-  hmac_sha256_configure(false);
-  hmac_sha256_start();
-}
+void hmac_sha256_init(void);
 
 /**
  * Configures and starts HMAC in HMAC mode with little-endian output.
  */
-inline void hmac_hmac_sha256_init(hmac_key_t key, bool big_endian_digest) {
-  hmac_hmac_sha256_configure(big_endian_digest, key);
-  hmac_sha256_start();
-}
+void hmac_hmac_sha256_init(hmac_key_t key, bool big_endian_digest);
 
 /**
  * Sends `len` bytes from `data` to the SHA2-256 function.
@@ -169,9 +163,7 @@ void hmac_sha256_final_truncated(uint32_t *digest, size_t len);
  *
  * @param[out] digest Buffer to copy digest to.
  */
-inline void hmac_sha256_final(hmac_digest_t *digest) {
-  hmac_sha256_final_truncated(digest->digest, ARRAYSIZE(digest->digest));
-}
+void hmac_sha256_final(hmac_digest_t *digest);
 
 /**
  * Convenience single-shot function for computing the SHA-256 digest of a


### PR DESCRIPTION
The inlined HMAC initialization functions, which are redefined by mocks for unit tests, cause UB in GCC and are rejected by Clang.

This commit removes the `inline` attributes from these functions to resolve these issues.