### PR TITLE
[cov] Add more owner_block unit tests to improve the code coverage

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/owner_block_unittest.cc
+++ b/sw/device/silicon_creator/lib/ownership/owner_block_unittest.cc
@@ -87,6 +87,11 @@ struct owner_flash_config_8 {
   owner_flash_region_t config[8];
 };
 
+struct owner_flash_config_9 {
+  tlv_header_t header;
+  owner_flash_region_t config[9];
+};
+
 struct owner_flash_info_config_2 {
   tlv_header_t header;
   owner_info_page_t config[2];
@@ -224,6 +229,18 @@ const owner_flash_config_t &flash_config_contains_rom_ext =
     reinterpret_cast<const owner_flash_config_t &>(
         flash_config_contains_rom_ext_wrapped);
 
+const owner_flash_config_9 flash_config_too_many_entries_wrapped = {
+    .header =
+        {
+            .tag = kTlvTagFlashConfig,
+            .length = sizeof(owner_flash_config_9),
+        },
+};
+
+const owner_flash_config_t &flash_config_too_many_entries =
+    reinterpret_cast<const owner_flash_config_t &>(
+        flash_config_too_many_entries_wrapped);
+
 const owner_flash_info_config_2 info_config_wrapped = {
     .header =
         {
@@ -273,6 +290,14 @@ const owner_flash_info_config_2 info_config_wrapped = {
 
 const owner_flash_info_config_t &info_config =
     reinterpret_cast<const owner_flash_info_config_t &>(info_config_wrapped);
+
+TEST_F(OwnerBlockTest, FlashConfigTooManyEntries) {
+  uint32_t mp_index = 0;
+  rom_error_t error =
+      owner_block_flash_apply(&flash_config_too_many_entries, kBootSlotA,
+                              /*owner_lockdown=*/0, &mp_index);
+  EXPECT_EQ(error, kErrorOwnershipFlashConfigLength);
+}
 
 TEST_F(OwnerBlockTest, FlashConfigApplyBadRomExt) {
   // There are no expectations because `owner_block_flash_apply` will ignore
@@ -774,6 +799,48 @@ TEST_F(OwnerBlockTest, ParseBlockDupIsfb) {
   EXPECT_EQ(error, kErrorOwnershipDuplicateItem);
 }
 
+TEST_F(OwnerBlockTest, IsfbEraseEnableInvalidState) {
+  boot_data_t bootdata = {};
+  bootdata.ownership_state = kOwnershipStateUnlockedAny;
+  owner_config_t owner_config = {};
+  EXPECT_EQ(owner_block_info_isfb_erase_enable(&bootdata, &owner_config),
+            kErrorOk);
+}
+
+TEST_F(OwnerBlockTest, NonExistIsfbConfig) {
+  boot_data_t bootdata = {};
+  bootdata.ownership_state = kOwnershipStateLockedOwner;
+  owner_config_t owner_config = {};
+  owner_config.isfb = (const owner_isfb_config_t *)kHardenedBoolFalse;
+  EXPECT_EQ(owner_block_info_isfb_erase_enable(&bootdata, &owner_config),
+            kErrorOk);
+}
+
+TEST_F(OwnerBlockTest, NonExistInfoConfig) {
+  boot_data_t bootdata = {};
+  bootdata.ownership_state = kOwnershipStateLockedOwner;
+  owner_config_t owner_config = {};
+  owner_config.isfb = (const owner_isfb_config_t *)kHardenedBoolTrue;
+  owner_config.info = (const owner_flash_info_config_t *)kHardenedBoolFalse;
+  EXPECT_EQ(owner_block_info_isfb_erase_enable(&bootdata, &owner_config),
+            kErrorOk);
+}
+
+TEST(OwnerBlockTransferTest, ValidTransfer) {
+  owner_page_valid[1] = kOwnerPageStatusSealed;
+  boot_data_t bootdata = {};
+  bootdata.ownership_state = kOwnershipStateLockedOwner;
+  EXPECT_EQ(owner_block_page1_valid_for_transfer(&bootdata), kHardenedBoolTrue);
+}
+
+const owner_isfb_config_t isfb_config_bad_length = {
+    .header =
+        {
+            .tag = kTlvTagIntegrationSpecificFirmwareBinding,
+            .length = 0,
+        },
+};
+
 const owner_isfb_config_t isfb_config_bad_page = {
     .header =
         {
@@ -815,6 +882,8 @@ TEST_P(OwnerBlockBadIsfbTest, ParseBlockBadIsfb) {
 INSTANTIATE_TEST_SUITE_P(
     AllCases, OwnerBlockBadIsfbTest,
     testing::Values(IsfbError{isfb_config_bad_page, kErrorOwnershipISFBPage},
+                    IsfbError{isfb_config_bad_length,
+                              kErrorOwnershipInvalidTagLength},
                     IsfbError{isfb_config_bad_product_word_count,
                               kErrorOwnershipISFBSize}));
 
@@ -1220,6 +1289,30 @@ const owner_flash_config_4 invalid_flash_7_wrapped = {
 const owner_flash_config_t &invalid_flash_7 =
     reinterpret_cast<const owner_flash_config_t &>(invalid_flash_7_wrapped);
 
+// Flash configuration has a zero length.
+const owner_flash_config_4 invalid_flash_8_wrapped = {
+    .header =
+        {
+            .tag = kTlvTagFlashConfig,
+            .length = 0,
+        },
+};
+
+const owner_flash_config_t &invalid_flash_8 =
+    reinterpret_cast<const owner_flash_config_t &>(invalid_flash_8_wrapped);
+
+// Flash configuration has mis-aligned length.
+const owner_flash_config_4 invalid_flash_9_wrapped = {
+    .header =
+        {
+            .tag = kTlvTagFlashConfig,
+            .length = sizeof(owner_flash_config_4) + 1,
+        },
+};
+
+const owner_flash_config_t &invalid_flash_9 =
+    reinterpret_cast<const owner_flash_config_t &>(invalid_flash_9_wrapped);
+
 class RomExtFlashConfigTest
     : public OwnerBlockTest,
       public testing::WithParamInterface<
@@ -1246,7 +1339,9 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(&invalid_flash_4, kErrorOwnershipFlashConfigLength),
         std::make_tuple(&invalid_flash_5, kErrorOwnershipFlashConfigBounds),
         std::make_tuple(&invalid_flash_6, kErrorOwnershipFlashConfigSlots),
-        std::make_tuple(&invalid_flash_7, kErrorOwnershipFlashConfigSlots)));
+        std::make_tuple(&invalid_flash_7, kErrorOwnershipFlashConfigSlots),
+        std::make_tuple(&invalid_flash_8, kErrorOwnershipInvalidTagLength),
+        std::make_tuple(&invalid_flash_9, kErrorOwnershipInvalidTagLength)));
 
 struct FlashRegion {
   uint32_t start;
@@ -1335,6 +1430,8 @@ testing::Values(
     OwnerBlockLengths{kTlvTagApplicationKey, 512, kErrorOwnershipInvalidTagLength},
     OwnerBlockLengths{kTlvTagFlashConfig, 4, kErrorOwnershipInvalidTagLength},
     OwnerBlockLengths{kTlvTagInfoConfig, 4, kErrorOwnershipInvalidTagLength},
+    OwnerBlockLengths{kTlvTagFlashConfig, 12, kErrorOwnershipInvalidTagLength},
+    OwnerBlockLengths{kTlvTagInfoConfig, 12, kErrorOwnershipInvalidTagLength},
     OwnerBlockLengths{kTlvTagRescueConfig, 12, kErrorOwnershipInvalidTagLength}
 ));
 // clang-format on
@@ -1416,6 +1513,17 @@ testing::Values(
 class FlashInfoCheckTest : public OwnerBlockTest,
                            public testing::WithParamInterface<
                                std::tuple<uint8_t, uint8_t, rom_error_t>> {};
+
+TEST_F(FlashInfoCheckTest, FlashInfoCheckInvalidLength) {
+  const owner_flash_info_config_t info = {
+      .header =
+          {
+              .length = 0,
+          },
+  };
+  EXPECT_EQ(owner_block_flash_info_check(&info),
+            kErrorOwnershipInvalidTagLength);
+}
 
 TEST_P(FlashInfoCheckTest, ValidPage) {
   uint16_t bank, page;


### PR DESCRIPTION
This change adds test cases to cover error branches for invalid arguments, including unaligned size and out-of-bounds arguments.