### PR TITLE
[crypto] Harden RSA padding selection against FI

### DIFF
--- a/sw/device/lib/crypto/impl/rsa/rsa_signature.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_signature.c
@@ -74,11 +74,13 @@ static status_t message_encode(const otcrypto_hash_digest_t message_digest,
   // Check that the digest length is OK.
   HARDENED_TRY(digest_check(message_digest));
 
-  switch (padding_mode) {
+  switch (launder32(padding_mode)) {
     case kRsaSignaturePaddingPkcs1v15:
+      HARDENED_CHECK_EQ(padding_mode, kRsaSignaturePaddingPkcs1v15);
       return rsa_padding_pkcs1v15_encode(message_digest, encoded_message_len,
                                          encoded_message);
     case kRsaSignaturePaddingPss: {
+      HARDENED_CHECK_EQ(padding_mode, kRsaSignaturePaddingPss);
       // Generate a random salt value whose length matches the digest length.
       uint32_t salt[message_digest.len];
       HARDENED_TRY(entropy_complex_check());
@@ -126,11 +128,13 @@ static status_t encoded_message_verify(
   // Check that the digest length is OK.
   HARDENED_TRY(digest_check(message_digest));
 
-  switch (padding_mode) {
+  switch (launder32(padding_mode)) {
     case kRsaSignaturePaddingPkcs1v15:
+      HARDENED_CHECK_EQ(padding_mode, kRsaSignaturePaddingPkcs1v15);
       return rsa_padding_pkcs1v15_verify(message_digest, encoded_message,
                                          encoded_message_len, result);
     case kRsaSignaturePaddingPss:
+      HARDENED_CHECK_EQ(padding_mode, kRsaSignaturePaddingPss);
       return rsa_padding_pss_verify(message_digest, encoded_message,
                                     encoded_message_len, result);
     default:


### PR DESCRIPTION
This commit adds checks to the RSA codebase where, based on the selected padding scheme, the control-flow diverges. These checks make sure that a fault cannot allow an attacker to switch to a different padding scheme.