### PR TITLE
[ci] Update HyperDebug firmware for CW340s

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -53,7 +53,7 @@ jobs:
           job-patterns: ${{ inputs.bitstream }}
 
       - name: Update hyperdebug firmware
-        if: inputs.interface == 'hyper310'
+        if: inputs.interface == 'hyper310' || inputs.interface == 'cw340'
         run: |
           ./bazelisk.sh run \
               //sw/host/opentitantool:opentitantool -- \


### PR DESCRIPTION
We're currently not keeping the HyperDebugs up to date on the CW340s.