### PR TITLE
[crypto] Add Verify-after-Sign for ECDSA as a FI countermeasure

### DIFF
--- a/sw/device/lib/crypto/impl/ecc_p256.c
+++ b/sw/device/lib/crypto/impl/ecc_p256.c
@@ -41,6 +41,29 @@ otcrypto_status_t otcrypto_ecdsa_p256_verify(
                                                    verification_result);
 }
 
+otcrypto_status_t otcrypto_ecdsa_p256_sign_verify(
+    const otcrypto_blinded_key_t *private_key,
+    const otcrypto_unblinded_key_t *public_key,
+    const otcrypto_hash_digest_t message_digest,
+    otcrypto_word32_buf_t signature) {
+  // Signature generation.
+  HARDENED_TRY(
+      otcrypto_ecdsa_p256_sign(private_key, message_digest, signature));
+
+  // Verify signature before releasing it.
+  otcrypto_const_word32_buf_t signature_check = {
+      .data = signature.data,
+      .len = signature.len,
+  };
+  hardened_bool_t verification_result = kHardenedBoolFalse;
+  HARDENED_TRY(otcrypto_ecdsa_p256_verify(
+      public_key, message_digest, signature_check, &verification_result));
+
+  // Trap if signature verification failed.
+  HARDENED_CHECK_EQ(verification_result, kHardenedBoolTrue);
+  return OTCRYPTO_OK;
+}
+
 otcrypto_status_t otcrypto_ecdh_p256_keygen(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
   HARDENED_TRY(otcrypto_ecdh_p256_keygen_async_start(private_key));

--- a/sw/device/lib/crypto/impl/ecc_p384.c
+++ b/sw/device/lib/crypto/impl/ecc_p384.c
@@ -41,6 +41,29 @@ otcrypto_status_t otcrypto_ecdsa_p384_verify(
                                                    verification_result);
 }
 
+otcrypto_status_t otcrypto_ecdsa_p384_sign_verify(
+    const otcrypto_blinded_key_t *private_key,
+    const otcrypto_unblinded_key_t *public_key,
+    const otcrypto_hash_digest_t message_digest,
+    otcrypto_word32_buf_t signature) {
+  // Signature generation.
+  HARDENED_TRY(
+      otcrypto_ecdsa_p384_sign(private_key, message_digest, signature));
+
+  // Verify signature before releasing it.
+  otcrypto_const_word32_buf_t signature_check = {
+      .data = signature.data,
+      .len = signature.len,
+  };
+  hardened_bool_t verification_result = kHardenedBoolFalse;
+  HARDENED_TRY(otcrypto_ecdsa_p384_verify(
+      public_key, message_digest, signature_check, &verification_result));
+
+  // Trap if signature verification failed.
+  HARDENED_CHECK_EQ(verification_result, kHardenedBoolTrue);
+  return OTCRYPTO_OK;
+}
+
 otcrypto_status_t otcrypto_ecdh_p384_keygen(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
   HARDENED_TRY(otcrypto_ecdh_p384_keygen_async_start(private_key));

--- a/sw/device/lib/crypto/include/ecc_p256.h
+++ b/sw/device/lib/crypto/include/ecc_p256.h
@@ -57,6 +57,29 @@ otcrypto_status_t otcrypto_ecdsa_p256_sign(
     otcrypto_word32_buf_t signature);
 
 /**
+ * Generates an ECDSA signature with curve P-256 and verifies the signature
+ * before releasing it to mitigate fault injection attacks.
+ *
+ * The message digest must be exactly 256 bits (32 bytes) long, but may use any
+ * hash mode.  The caller is responsible for ensuring that the security
+ * strength of the hash function is at least equal to the security strength of
+ * the curve, but in some cases it may be truncated. See FIPS 186-5 for
+ * details.
+ *
+ * @param private_key Pointer to the blinded private key (d) struct.
+ * @param public_key Pointer to the unblinded public key (Q) struct.
+ * @param message_digest Message digest to be signed (pre-hashed).
+ * @param[out] signature Pointer to the signature struct with (r,s) values.
+ * @return Result of the ECDSA signature generation.
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_ecdsa_p256_sign_verify(
+    const otcrypto_blinded_key_t *private_key,
+    const otcrypto_unblinded_key_t *public_key,
+    const otcrypto_hash_digest_t message_digest,
+    otcrypto_word32_buf_t signature);
+
+/**
  * Verifies an ECDSA/P-256 signature.
  *
  * The message digest must be exactly 256 bits (32 bytes) long, but may use any

--- a/sw/device/lib/crypto/include/ecc_p384.h
+++ b/sw/device/lib/crypto/include/ecc_p384.h
@@ -57,6 +57,29 @@ otcrypto_status_t otcrypto_ecdsa_p384_sign(
     otcrypto_word32_buf_t signature);
 
 /**
+ * Generates an ECDSA signature with curve P-384 and verifies the signature
+ * before releasing it to mitigate fault injection attacks.
+
+ * The message digest must be exactly 384 bits (48 bytes) long, but may use any
+ * hash mode.  The caller is responsible for ensuring that the security
+ * strength of the hash function is at least equal to the security strength of
+ * the curve, but in some cases it may be truncated. See FIPS 186-5 for
+ * details.
+ *
+ * @param private_key Pointer to the blinded private key (d) struct.
+ * @param public_key Pointer to the unblinded public key (Q) struct.
+ * @param message_digest Message digest to be signed (pre-hashed).
+ * @param[out] signature Pointer to the signature struct with (r,s) values.
+ * @return Result of the ECDSA signature generation.
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_ecdsa_p384_sign_verify(
+    const otcrypto_blinded_key_t *private_key,
+    const otcrypto_unblinded_key_t *public_key,
+    const otcrypto_hash_digest_t message_digest,
+    otcrypto_word32_buf_t signature);
+
+/**
  * Verifies an ECDSA/P-384 signature.
  *
  * The message digest must be exactly 384 bits (48 bytes) long, but may use any


### PR DESCRIPTION
To mitigate fault injection attacks, this commit adds the new `otcrypto_ecdsa_p256_sign_verify()`
and `otcrypto_ecdsa_p384_sign_verify()` functions to the CryptoLib. Before releasing the generated signatures, these functions first verify them. If the verification failed, the functions trap.