### PR TITLE
[ci] Remove old dependencies from `apt-requirements.txt`

### DIFF
--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -10,18 +10,13 @@
 #
 # Keep it sorted.
 autoconf
-bison
 brotli
 build-essential
-clang-format
 cmake
 curl
-doxygen
 file
-flex
 g++
 git
-golang
 lcov
 libelf1
 libelf-dev
@@ -33,11 +28,9 @@ libpcsclite-dev
 libssl-dev
 libudev-dev
 libusb-1.0-0
-lld
 lrzsz
 lsb-release
 make
-ninja-build
 openssl
 perl
 pkgconf

--- a/ci/scripts/show-env.sh
+++ b/ci/scripts/show-env.sh
@@ -15,7 +15,6 @@ required_tools=(
     isort
     flake8
     ninja
-    doxygen
 )
 
 optional_tools=(

--- a/doc/getting_started/unofficial/fedora.md
+++ b/doc/getting_started/unofficial/fedora.md
@@ -9,12 +9,11 @@ Fedora uses a different package manager than the officially supported Ubuntu dev
 You can install equivalent packages to the `apt-requirements.txt` file with the following command:
 
 ```shell
-sudo dnf install autoconf bison make automake gcc gcc-c++ kernel-devel \
-         clang-tools-extra clang cmake curl \
-         doxygen flex g++ git golang lcov elfutils-libelf \
-         libftdi libftdi-devel ncurses-compat-libs openssl-devel \
-         systemd-devel libusb redhat-lsb-core \
-         make ninja-build perl pkgconf python3 python3-pip python3-setuptools \
-         python3-urllib3 python3-wheel srecord tree xsltproc zlib-devel xz clang-tools-extra \
-         clang11-libs clang-devel elfutils-libelf-devel
+sudo dnf install \
+         autoconf make automake gcc gcc-c++ kernel-devel clang cmake curl g++ \
+         git lcov elfutils-libelf libftdi libftdi-devel ncurses-compat-libs   \
+         openssl-devel systemd-devel libusb redhat-lsb-core make perl pkgconf \
+         python3 python3-pip python3-setuptools python3-urllib3 python3-wheel \
+         srecord tree xsltproc zlib-devel xz clang-tools-extra clang11-libs   \
+         clang-devel elfutils-libelf-devel
 ```

--- a/yum-requirements.txt
+++ b/yum-requirements.txt
@@ -6,30 +6,23 @@
 #
 # Keep it sorted.
 "Development Tools"
-autoconf
-bison
 brotli
 cmake
 curl
-doxygen
 epel-release
-flex
 gcc-c++
 git
-golang
 elfutils-libelf
 elfutils-libelf-devel
 libftdi
 libftdi-devel
 libudev-devel
 libusbx
-lld
 make
 openssl-devel
 redhat-lsb-core
 # A requirement of the prebuilt clang toolchain.
 ncurses
-ninja-build
 openssl11-libs
 openssl11-devel
 perl


### PR DESCRIPTION
I believe all of these are things that are now handled within Bazel so we don't need to download them on the system anymore.