### PR TITLE
[tlul,rtl] Use an enum for choice of arbiter

### DIFF
--- a/hw/ip/prim/rtl/prim_sram_arbiter.sv
+++ b/hw/ip/prim/rtl/prim_sram_arbiter.sv
@@ -8,14 +8,14 @@
 //  N:  Number of request ports
 //  DW: Data width (SECDED is not included)
 //  Aw: Address width
-//  ArbiterImpl: can be either PPC or BINTREE.
+//  ArbiterImpl: The arbiter to use (as defined in tlul_pkg)
 `include "prim_assert.sv"
 
 module prim_sram_arbiter #(
   parameter int unsigned N  = 4,
   parameter int unsigned SramDw = 32,
   parameter int unsigned SramAw = 12,
-  parameter ArbiterImpl = "PPC",
+  parameter tlul_pkg::arbiter_impl_e ArbiterImpl = tlul_pkg::PPCArbiter,
   parameter bit EnMask = 1'b 0 // Disable wmask if 0
 ) (
   input clk_i,
@@ -82,7 +82,7 @@ module prim_sram_arbiter #(
   end
 
 
-  if (ArbiterImpl == "PPC") begin : gen_arb_ppc
+  if (ArbiterImpl == tlul_pkg::PPCArbiter) begin : gen_arb_ppc
     prim_arbiter_ppc #(
       .N (N),
       .DW(ARB_DW)
@@ -98,7 +98,7 @@ module prim_sram_arbiter #(
       .data_o    ( sram_packed ),
       .ready_i   ( 1'b1        )
     );
-  end else if (ArbiterImpl == "BINTREE") begin : gen_tree_arb
+  end else if (ArbiterImpl == tlul_pkg::BintreeArbiter) begin : gen_tree_arb
     prim_arbiter_tree #(
       .N (N),
       .DW(ARB_DW)

--- a/hw/ip/tlul/rtl/tlul_pkg.sv
+++ b/hw/ip/tlul/rtl/tlul_pkg.sv
@@ -5,13 +5,22 @@
 
 package tlul_pkg;
 
-  // this can be either PPC or BINTREE
-  // there is no functional difference, but timing and area behavior is different
-  // between the two instances. PPC can result in smaller implementations when timing
-  // is not critical, whereas BINTREE is favorable when timing pressure is high (but this
-  // may also result in a larger implementation). on FPGA targets, BINTREE is favorable
-  // both in terms of area and timing.
-  parameter ArbiterImpl = "PPC";
+  // Different possible arbiters for TLUL arbitration.
+  typedef enum logic [0:0] {
+    // The PPC arbiter is defined in prim_arbiter_ppc and uses the parallel prefix computing
+    // optimization to optimize the request / arbiter tree. This can result in smaller
+    // implementations when timing is not critical.
+    PPCArbiter,
+
+    // The bintree arbiter is a binary tree implementation of a round robin arbiter, defined in
+    // prim_arbiter_tree. This might be more favorable than the PPC arbiter when timing pressure is
+    // high, but it may also result in a larger implementation.
+    //
+    // On FPGA targets, this arbiter is better than the PPC arbiter for both area and timing.
+    BintreeArbiter
+  } arbiter_impl_e;
+
+  parameter arbiter_impl_e ArbiterImpl = PPCArbiter;
 
   typedef enum logic [2:0] {
     PutFullData    = 3'h 0,

--- a/hw/ip/tlul/rtl/tlul_socket_m1.sv
+++ b/hw/ip/tlul/rtl/tlul_socket_m1.sv
@@ -165,7 +165,7 @@ module tlul_socket_m1 #(
 
   assign arb_ready = drsp_fifo_o.a_ready;
 
-  if (tlul_pkg::ArbiterImpl == "PPC") begin : gen_arb_ppc
+  if (tlul_pkg::ArbiterImpl == tlul_pkg::PPCArbiter) begin : gen_arb_ppc
     prim_arbiter_ppc #(
       .N          (M),
       .DW         ($bits(tlul_pkg::tl_h2d_t))
@@ -181,7 +181,7 @@ module tlul_socket_m1 #(
       .data_o    ( arb_data    ),
       .ready_i   ( arb_ready   )
     );
-  end else if (tlul_pkg::ArbiterImpl == "BINTREE") begin : gen_tree_arb
+  end else if (tlul_pkg::ArbiterImpl == tlul_pkg::BintreeArbiter) begin : gen_tree_arb
     prim_arbiter_tree #(
       .N          (M),
       .DW         ($bits(tlul_pkg::tl_h2d_t))


### PR DESCRIPTION
This should have no effect on the generated code, but avoids needing to pass strings around in the parameters.