### PR TITLE
[ipgen,bazel] Correct BUILD files for ipgen IPs

### DIFF
--- a/hw/ip_templates/ac_range_check/BUILD.tpl
+++ b/hw/ip_templates/ac_range_check/BUILD.tpl
@@ -21,5 +21,5 @@ filegroup(
     srcs = glob([
         "**/*.md",
         "**/*.svg",
-    ]) + ["//hw/top_${topname}/ip_autogen/ac_range_check/data:doc_files"],
+    ]) + ["//hw/top_${topname}/ip_autogen/${module_instance_name}/data:doc_files"],
 )

--- a/hw/ip_templates/ac_range_check/data/BUILD.tpl
+++ b/hw/ip_templates/ac_range_check/data/BUILD.tpl
@@ -4,10 +4,12 @@
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["top_${topname}_${module_instance_name}.ipconfig.hjson"])
+
 filegroup(
     name = "doc_files",
     srcs = glob([
-        "ac_range_check.hjson",
+        "${module_instance_name}.hjson",
         "*_testplan.hjson",
     ]),
 )

--- a/hw/ip_templates/alert_handler/BUILD.tpl
+++ b/hw/ip_templates/alert_handler/BUILD.tpl
@@ -21,5 +21,5 @@ filegroup(
     srcs = glob([
         "**/*.md",
         "**/*.svg",
-    ]) + ["//hw/top_${topname}/ip_autogen/alert_handler/data:doc_files"],
+    ]) + ["//hw/top_${topname}/ip_autogen/${module_instance_name}/data:doc_files"],
 )

--- a/hw/ip_templates/alert_handler/data/BUILD.tpl
+++ b/hw/ip_templates/alert_handler/data/BUILD.tpl
@@ -4,12 +4,12 @@
 
 package(default_visibility = ["//visibility:public"])
 
-exports_files(["top_${topname}_alert_handler.ipconfig.hjson"])
+exports_files(["top_${topname}_${module_instance_name}.ipconfig.hjson"])
 
 filegroup(
     name = "doc_files",
     srcs = glob([
-        "alert_handler.hjson",
+        "${module_instance_name}.hjson",
         "*_testplan.hjson",
     ]),
 )

--- a/hw/ip_templates/gpio/BUILD.tpl
+++ b/hw/ip_templates/gpio/BUILD.tpl
@@ -21,5 +21,5 @@ filegroup(
     srcs = glob([
         "**/*.md",
         "**/*.svg",
-    ]) + ["//hw/top_${topname}/ip_autogen/gpio/data:doc_files"],
+    ]) + ["//hw/top_${topname}/ip_autogen/${module_instance_name}/data:doc_files"],
 )

--- a/hw/ip_templates/gpio/data/BUILD.tpl
+++ b/hw/ip_templates/gpio/data/BUILD.tpl
@@ -4,12 +4,12 @@
 
 package(default_visibility = ["//visibility:public"])
 
-exports_files(["top_${topname}_gpio.ipconfig.hjson"])
+exports_files(["top_${topname}_${module_instance_name}.ipconfig.hjson"])
 
 filegroup(
     name = "doc_files",
     srcs = glob([
-        "gpio.hjson",
+        "${module_instance_name}.hjson",
         "*_testplan.hjson",
     ]),
 )

--- a/hw/ip_templates/pwm/BUILD.tpl
+++ b/hw/ip_templates/pwm/BUILD.tpl
@@ -21,5 +21,5 @@ filegroup(
     srcs = glob([
         "**/*.md",
         "**/*.svg",
-    ]) + ["//hw/top_${topname}/ip_autogen/pwm/data:doc_files"],
+    ]) + ["//hw/top_${topname}/ip_autogen/${module_instance_name}/data:doc_files"],
 )

--- a/hw/ip_templates/pwm/data/BUILD.tpl
+++ b/hw/ip_templates/pwm/data/BUILD.tpl
@@ -4,12 +4,12 @@
 
 package(default_visibility = ["//visibility:public"])
 
-exports_files(["top_${topname}_pwm.ipconfig.hjson"])
+exports_files(["top_${topname}_${module_instance_name}.ipconfig.hjson"])
 
 filegroup(
     name = "doc_files",
     srcs = glob([
-        "pwm.hjson",
+        "${module_instance_name}.hjson",
         "*_testplan.hjson",
     ]),
 )

--- a/hw/ip_templates/racl_ctrl/BUILD.tpl
+++ b/hw/ip_templates/racl_ctrl/BUILD.tpl
@@ -18,5 +18,5 @@ filegroup(
 
 filegroup(
     name = "doc_files",
-    srcs = glob(["**/*.md"]) + ["//hw/top_${topname}/ip_autogen/racl_ctrl/data:doc_files"],
+    srcs = glob(["**/*.md"]) + ["//hw/top_${topname}/ip_autogen/${module_instance_name}/data:doc_files"],
 )

--- a/hw/ip_templates/racl_ctrl/data/BUILD.tpl
+++ b/hw/ip_templates/racl_ctrl/data/BUILD.tpl
@@ -4,7 +4,9 @@
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["top_${topname}_${module_instance_name}.ipconfig.hjson"])
+
 filegroup(
     name = "doc_files",
-    srcs = ["racl_ctrl.hjson"],
+    srcs = ["${module_instance_name}.hjson"],
 )

--- a/hw/ip_templates/rv_core_ibex/BUILD.tpl
+++ b/hw/ip_templates/rv_core_ibex/BUILD.tpl
@@ -18,5 +18,5 @@ filegroup(
 
 filegroup(
     name = "doc_files",
-    srcs = glob(["**/*.md"]) + ["//hw/top_${topname}/ip_autogen/rv_core_ibex/data:doc_files"],
+    srcs = glob(["**/*.md"]) + ["//hw/top_${topname}/ip_autogen/${module_instance_name}/data:doc_files"],
 )

--- a/hw/ip_templates/rv_core_ibex/data/BUILD.tpl
+++ b/hw/ip_templates/rv_core_ibex/data/BUILD.tpl
@@ -4,12 +4,12 @@
 
 package(default_visibility = ["//visibility:public"])
 
-exports_files(["top_${topname}_rv_core_ibex.ipconfig.hjson"])
+exports_files(["top_${topname}_${module_instance_name}.ipconfig.hjson"])
 
 filegroup(
     name = "doc_files",
     srcs = glob([
-        "rv_core_ibex.hjson",
+        "${module_instance_name}.hjson",
         "*_testplan.hjson",
     ]),
 )

--- a/hw/ip_templates/rv_plic/BUILD.tpl
+++ b/hw/ip_templates/rv_plic/BUILD.tpl
@@ -21,5 +21,5 @@ filegroup(
     srcs = glob([
         "**/*.md",
         "**/*.svg",
-    ]) + ["//hw/top_${topname}/ip_autogen/rv_plic/data:doc_files"],
+    ]) + ["//hw/top_${topname}/ip_autogen/${module_instance_name}/data:doc_files"],
 )

--- a/hw/ip_templates/rv_plic/data/BUILD.tpl
+++ b/hw/ip_templates/rv_plic/data/BUILD.tpl
@@ -4,12 +4,12 @@
 
 package(default_visibility = ["//visibility:public"])
 
-exports_files(["top_${topname}_rv_plic.ipconfig.hjson"])
+exports_files(["top_${topname}_${module_instance_name}.ipconfig.hjson"])
 
 filegroup(
     name = "doc_files",
     srcs = glob([
-        "rv_plic.hjson",
+        "${module_instance_name}.hjson",
         "*_testplan.hjson",
     ]),
 )

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/data/BUILD
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/data/BUILD
@@ -4,6 +4,8 @@
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["top_darjeeling_ac_range_check.ipconfig.hjson"])
+
 filegroup(
     name = "doc_files",
     srcs = glob([

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/data/BUILD
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/data/BUILD
@@ -4,6 +4,8 @@
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["top_darjeeling_racl_ctrl.ipconfig.hjson"])
+
 filegroup(
     name = "doc_files",
     srcs = ["racl_ctrl.hjson"],


### PR DESCRIPTION
Some BUILD files of ipgen IPs didn't fully respect the module instance name, which can be different depending on the ipgen configuration. Properly factor the module instance name into the BUILD files. 