### PR TITLE
[hw,rv_core_ibex,rtl] Gate any pending requests on escalation

### DIFF
--- a/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex.sv.tpl
+++ b/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex.sv.tpl
@@ -190,6 +190,12 @@ module ${module_instance_name}
   tl_h2d_t tl_d_ibex2fifo;
   tl_d2h_t tl_d_fifo2ibex;
 
+  // TLUL LC Gate interfaces
+  tl_h2d_t tl_d_fifo2gate;
+  tl_d2h_t tl_d_gate2fifo;
+
+  logic tlul_lc_gate_core_d_error;
+
 `ifdef RVFI
   logic        rvfi_valid;
   logic [63:0] rvfi_order;
@@ -246,7 +252,7 @@ module ${module_instance_name}
   logic recov_core_event;
   // SEC_CM: BUS.INTEGRITY
   assign fatal_intg_event = ibus_intg_err | dbus_intg_err | alert_major_bus;
-  assign fatal_core_event = alert_major_internal | double_fault;
+  assign fatal_core_event = alert_major_internal | double_fault | tlul_lc_gate_core_d_error;
   assign recov_core_event = alert_minor;
 
   // configurations for address translation
@@ -300,8 +306,10 @@ module ${module_instance_name}
   logic irq_nm;
   assign irq_nm = |(reg2hw.nmi_state & reg2hw.nmi_enable);
 
-  lc_ctrl_pkg::lc_tx_t [0:0] lc_cpu_en;
-  prim_lc_sync u_lc_sync (
+  lc_ctrl_pkg::lc_tx_t [1:0] lc_cpu_en;
+  prim_lc_sync #(
+    .NumCopies(2)
+  ) u_lc_sync (
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_cpu_en_i),
@@ -715,12 +723,32 @@ module ${module_instance_name}
     .rst_ni,
     .tl_h_i      (tl_d_ibex2fifo),
     .tl_h_o      (tl_d_fifo2ibex),
-    .tl_d_o      (cored_tl_h_o),
-    .tl_d_i      (cored_tl_h_i),
+    .tl_d_o      (tl_d_fifo2gate),
+    .tl_d_i      (tl_d_gate2fifo),
     .spare_req_i (1'b0),
     .spare_req_o (),
     .spare_rsp_i (1'b0),
     .spare_rsp_o ());
+
+  // Gate any pending requests on escalation
+  tlul_lc_gate #(
+    .Outstanding(NumOutstandingReqs),
+    .NumGatesPerDirection(1),
+    // Don't return an error. Only interested in blocking a request at this stage
+    .ReturnBlankResp(1)
+  ) u_tlul_lc_gate_cored (
+    .clk_i,
+    .rst_ni,
+    .tl_h2d_i       (tl_d_fifo2gate),
+    .tl_d2h_o       (tl_d_gate2fifo),
+    .tl_h2d_o       (cored_tl_h_o),
+    .tl_d2h_i       (cored_tl_h_i),
+    .flush_req_i    (1'b0),
+    .flush_ack_o    (),
+    .resp_pending_o (),
+    .lc_en_i        (lc_cpu_en[1]),
+    .err_o          (tlul_lc_gate_core_d_error)
+  );
 
 `ifdef RVFI
   ibex_tracer ibex_tracer_i (
@@ -1093,6 +1121,8 @@ module ${module_instance_name}
       instr_intg_err)
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(IbexLockstepResetCountAlertCheck_A,
       u_core.gen_lockstep.u_ibex_lockstep.u_rst_shadow_cnt, alert_tx_o[2])
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CoredTlLcGateFsm_A,
+      u_tlul_lc_gate_cored.u_state_regs, alert_tx_o[2])
 
 `endif // ifdef INC_ASSERT
 endmodule

--- a/hw/top_darjeeling/dv/env/chip_if.sv
+++ b/hw/top_darjeeling/dv/env/chip_if.sv
@@ -756,28 +756,32 @@ interface chip_if;
     ext_clk_if.set_active(0, 0);
   endfunction
 
-  // Verifies an LC control signal broadcast by the LC controller.
-  function automatic void check_lc_ctrl_enable_signal(lc_ctrl_signal_e signal, bit expected_value);
-    lc_ctrl_pkg::lc_tx_t value;
+  // Get the requested LC control signal that was broadcast by the LC controller
+  function automatic lc_ctrl_pkg::lc_tx_t get_lc_ctrl_enable_signal(lc_ctrl_signal_e signal);
     case (signal)
-      LcCtrlSignalDftEn:        value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_dft_en_o);
-      LcCtrlSignalNvmDebugEn:   value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_nvm_debug_en_o);
-      LcCtrlSignalHwDebugEn:    value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_hw_debug_en_o);
-      LcCtrlSignalCpuEn:        value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_cpu_en_o);
+      LcCtrlSignalDftEn:        return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_dft_en_o);
+      LcCtrlSignalNvmDebugEn:   return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_nvm_debug_en_o);
+      LcCtrlSignalHwDebugEn:    return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_hw_debug_en_o);
+      LcCtrlSignalCpuEn:        return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_cpu_en_o);
       LcCtrlSignalCreatorSeedEn: begin
-        value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_creator_seed_sw_rw_en_o);
+        return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_creator_seed_sw_rw_en_o);
       end
       LcCtrlSignalOwnerSeedEn: begin
-        value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_owner_seed_sw_rw_en_o);
+        return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_owner_seed_sw_rw_en_o);
       end
-      LcCtrlSignalIsoRdEn:      value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_iso_part_sw_rd_en_o);
-      LcCtrlSignalIsoWrEn:      value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_iso_part_sw_wr_en_o);
-      LcCtrlSignalSeedRdEn:     value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_seed_hw_rd_en_o);
-      LcCtrlSignalKeyMgrEn:     value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_keymgr_en_o);
-      LcCtrlSignalEscEn:        value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_escalate_en_o);
-      LcCtrlSignalCheckBypEn:   value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_check_byp_en_o);
+      LcCtrlSignalIsoRdEn:      return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_iso_part_sw_rd_en_o);
+      LcCtrlSignalIsoWrEn:      return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_iso_part_sw_wr_en_o);
+      LcCtrlSignalSeedRdEn:     return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_seed_hw_rd_en_o);
+      LcCtrlSignalKeyMgrEn:     return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_keymgr_en_o);
+      LcCtrlSignalEscEn:        return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_escalate_en_o);
+      LcCtrlSignalCheckBypEn:   return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_check_byp_en_o);
       default:                  `uvm_fatal(MsgId, $sformatf("Bad choice: %0s", signal.name()))
     endcase
+  endfunction
+
+  // Verifies an LC control signal broadcast by the LC controller.
+  function automatic void check_lc_ctrl_enable_signal(lc_ctrl_signal_e signal, bit expected_value);
+    lc_ctrl_pkg::lc_tx_t value = get_lc_ctrl_enable_signal(signal);
     if (expected_value ~^ (value == lc_ctrl_pkg::On)) begin
       `uvm_info(MsgId, $sformatf("LC control signal %0s: value = %0s matched",
                                  signal.name(), value.name()), UVM_HIGH)

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_prim_tl_access_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_prim_tl_access_vseq.sv
@@ -13,6 +13,12 @@ class chip_prim_tl_access_vseq extends chip_stub_cpu_base_vseq;
 
   rand lc_state_e lc_state;
 
+  typedef enum bit [3:0] {
+    NormalResponse  = 0,
+    ZeroResponse    = 1,
+    ErrorResponse   = 2
+  } response_mode_e;
+
   constraint num_trans_c {
     num_trans inside {[2:10]};
   }
@@ -32,46 +38,79 @@ class chip_prim_tl_access_vseq extends chip_stub_cpu_base_vseq;
     super.initialize_otp_sig_verify();
   endfunction
 
-  virtual function bit allow_otp_prim_tl_access();
-    if (lc_state inside {LcStTestUnlocked0, LcStTestUnlocked1, LcStTestUnlocked2,
-        LcStTestUnlocked3, LcStTestUnlocked4, LcStTestUnlocked5, LcStTestUnlocked6,
-        LcStTestUnlocked7, LcStRma}) begin
-      return 1;
-    end else begin
-      return 0;
+  function response_mode_e get_response_mode(bit using_prims);
+    // If the CPU is disabled, the lc gate will respond with all zeros.
+    if (cfg.chip_vif.get_lc_ctrl_enable_signal(LcCtrlSignalCpuEn) != lc_ctrl_pkg::On) begin
+      return ZeroResponse;
     end
+
+    // If the CPU is enabled, but we have put lc_ctrl in a state that won't allow TL access to
+    // prims, we expect errors when we use prims.
+    if (using_prims &&
+        !(lc_state inside {LcStTestUnlocked0, LcStTestUnlocked1, LcStTestUnlocked2,
+                           LcStTestUnlocked3, LcStTestUnlocked4, LcStTestUnlocked5,
+                           LcStTestUnlocked6, LcStTestUnlocked7, LcStRma})) begin
+      return ErrorResponse;
+    end
+
+    // Otherwise, we expect a normal response (not an error and not all zero)
+    return NormalResponse;
   endfunction
 
-  virtual task rw_csr_addr_with_gating(uvm_reg csr, bit gated);
+  virtual task rw_csr_addr_with_gating(uvm_reg csr, response_mode_e rsp_mode);
     bit [TL_AW-1:0] addr = csr.get_address();
     bit [TL_DW-1:0] data = $urandom();
-    bit [TL_DW-1:0] exp_data;
+    bit [TL_DW-1:0] exp_data, fake_rdata;
+    bit             expect_errors, writes_work, use_fake_rdata;
 
     csr_excl_item csr_excl = get_excl_item(csr);
 
+    case (rsp_mode)
+      NormalResponse: begin
+        writes_work = 1;
+        expect_errors = 0;
+        use_fake_rdata = 0;
+      end
+      ZeroResponse: begin
+        writes_work = 0;
+        expect_errors = 0;
+        use_fake_rdata = 1;
+        fake_rdata = '0;
+      end
+      ErrorResponse: begin
+        writes_work = 0;
+        expect_errors = 1;
+        use_fake_rdata = 1;
+        fake_rdata = '1;
+      end
+      default: ;
+    endcase
+
     // Apply CsrExclWrite
     if (!csr_excl.is_excl(csr, CsrExclWrite, CsrAllTests)) begin
-      tl_access(.addr(addr), .write(1), .data(data), .exp_err_rsp(gated));
-      if (!gated) begin
+      tl_access(.addr(addr), .write(1), .data(data), .exp_err_rsp(expect_errors));
+      if (writes_work) begin
         void'(csr.predict(.value(data), .kind(UVM_PREDICT_WRITE)));
       end
     end
 
-    tl_access(.addr(addr), .write(1), .data(data), .exp_err_rsp(gated));
-    if (!gated) begin
+    tl_access(.addr(addr), .write(1), .data(data), .exp_err_rsp(expect_errors));
+    if (writes_work) begin
       void'(csr.predict(.value(data), .kind(UVM_PREDICT_WRITE)));
     end
-    exp_data = gated ? '1 : `gmv(csr);
-    `uvm_info(`gfn, $sformatf("Write addr %0h, write adata %0h, expect data %0h",
-              addr, data, exp_data), UVM_HIGH);
-    tl_access(.addr(addr), .write(0), .data(data), .exp_err_rsp(gated), .check_exp_data(1),
+
+    exp_data = use_fake_rdata ? fake_rdata : `gmv(csr);
+    `uvm_info(`gfn,
+              $sformatf("Write addr %0h, write adata %0h, expect data %0h", addr, data, exp_data),
+              UVM_HIGH);
+    tl_access(.addr(addr), .write(0), .data(data), .exp_err_rsp(expect_errors), .check_exp_data(1),
               .exp_data(exp_data));
   endtask
 
-  virtual task rand_rw_prim_regs(uvm_reg prim_regs[$], bit gated);
+  virtual task rand_rw_prim_regs(uvm_reg prim_regs[$], response_mode_e rsp_mode);
     `DV_CHECK_NE(prim_regs.size(), 0)
     prim_regs.shuffle();
-    foreach (prim_regs[i]) rw_csr_addr_with_gating(prim_regs[i], gated);
+    foreach (prim_regs[i]) rw_csr_addr_with_gating(prim_regs[i], rsp_mode);
   endtask
 
   virtual task body();
@@ -85,7 +124,7 @@ class chip_prim_tl_access_vseq extends chip_stub_cpu_base_vseq;
       if ($urandom_range(0, 1)) begin
         `uvm_info(`gfn, "Check OTP prim_tl access", UVM_HIGH)
         ral.otp_macro_prim.get_registers(otp_prim_regs);
-        rand_rw_prim_regs(otp_prim_regs, ~allow_otp_prim_tl_access());
+        rand_rw_prim_regs(otp_prim_regs, get_response_mode(1'b1));
       end
     end
   endtask : body

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -1029,28 +1029,32 @@ interface chip_if;
     ext_clk_if.set_active(0, 0);
   endfunction
 
-  // Verifies an LC control signal broadcast by the LC controller.
-  function automatic void check_lc_ctrl_enable_signal(lc_ctrl_signal_e signal, bit expected_value);
-    lc_ctrl_pkg::lc_tx_t value;
+  // Get the requested LC control signal that was broadcast by the LC controller
+  function automatic lc_ctrl_pkg::lc_tx_t get_lc_ctrl_enable_signal(lc_ctrl_signal_e signal);
     case (signal)
-      LcCtrlSignalDftEn:        value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_dft_en_o);
-      LcCtrlSignalNvmDebugEn:   value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_nvm_debug_en_o);
-      LcCtrlSignalHwDebugEn:    value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_hw_debug_en_o);
-      LcCtrlSignalCpuEn:        value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_cpu_en_o);
+      LcCtrlSignalDftEn:        return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_dft_en_o);
+      LcCtrlSignalNvmDebugEn:   return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_nvm_debug_en_o);
+      LcCtrlSignalHwDebugEn:    return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_hw_debug_en_o);
+      LcCtrlSignalCpuEn:        return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_cpu_en_o);
       LcCtrlSignalCreatorSeedEn: begin
-        value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_creator_seed_sw_rw_en_o);
+        return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_creator_seed_sw_rw_en_o);
       end
       LcCtrlSignalOwnerSeedEn: begin
-        value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_owner_seed_sw_rw_en_o);
+        return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_owner_seed_sw_rw_en_o);
       end
-      LcCtrlSignalIsoRdEn:      value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_iso_part_sw_rd_en_o);
-      LcCtrlSignalIsoWrEn:      value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_iso_part_sw_wr_en_o);
-      LcCtrlSignalSeedRdEn:     value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_seed_hw_rd_en_o);
-      LcCtrlSignalKeyMgrEn:     value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_keymgr_en_o);
-      LcCtrlSignalEscEn:        value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_escalate_en_o);
-      LcCtrlSignalCheckBypEn:   value = lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_check_byp_en_o);
+      LcCtrlSignalIsoRdEn:      return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_iso_part_sw_rd_en_o);
+      LcCtrlSignalIsoWrEn:      return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_iso_part_sw_wr_en_o);
+      LcCtrlSignalSeedRdEn:     return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_seed_hw_rd_en_o);
+      LcCtrlSignalKeyMgrEn:     return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_keymgr_en_o);
+      LcCtrlSignalEscEn:        return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_escalate_en_o);
+      LcCtrlSignalCheckBypEn:   return lc_ctrl_pkg::lc_tx_t'(`LC_CTRL_HIER.lc_check_byp_en_o);
       default:                  `uvm_fatal(MsgId, $sformatf("Bad choice: %0s", signal.name()))
     endcase
+  endfunction
+
+  // Verifies an LC control signal broadcast by the LC controller.
+  function automatic void check_lc_ctrl_enable_signal(lc_ctrl_signal_e signal, bit expected_value);
+    lc_ctrl_pkg::lc_tx_t value = get_lc_ctrl_enable_signal(signal);
     if (expected_value ~^ (value == lc_ctrl_pkg::On)) begin
       `uvm_info(MsgId, $sformatf("LC control signal %0s: value = %0s matched",
                                  signal.name(), value.name()), UVM_HIGH)

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_prim_tl_access_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_prim_tl_access_vseq.sv
@@ -13,6 +13,12 @@ class chip_prim_tl_access_vseq extends chip_stub_cpu_base_vseq;
 
   rand lc_state_e lc_state;
 
+  typedef enum bit [3:0] {
+    NormalResponse  = 0,
+    ZeroResponse    = 1,
+    ErrorResponse   = 2
+  } response_mode_e;
+
   constraint num_trans_c {
     num_trans inside {[2:10]};
   }
@@ -34,53 +40,82 @@ class chip_prim_tl_access_vseq extends chip_stub_cpu_base_vseq;
     super.initialize_otp_lc_state();
   endfunction
 
-  virtual function bit allow_otp_prim_tl_access();
-    if (lc_state inside {LcStTestUnlocked0, LcStTestUnlocked1, LcStTestUnlocked2,
-        LcStTestUnlocked3, LcStTestUnlocked4, LcStTestUnlocked5, LcStTestUnlocked6,
-        LcStTestUnlocked7, LcStRma}) begin
-      return 1;
-    end else begin
-      return 0;
+  function response_mode_e get_response_mode(bit using_prims);
+    // If the CPU is disabled, the lc gate will respond with all zeros.
+    if (cfg.chip_vif.get_lc_ctrl_enable_signal(LcCtrlSignalCpuEn) != lc_ctrl_pkg::On) begin
+      return ZeroResponse;
     end
+
+    // If the CPU is enabled, but we have put lc_ctrl in a state that won't allow TL access to
+    // prims, we expect errors when we use prims.
+    if (using_prims &&
+        !(lc_state inside {LcStTestUnlocked0, LcStTestUnlocked1, LcStTestUnlocked2,
+                           LcStTestUnlocked3, LcStTestUnlocked4, LcStTestUnlocked5,
+                           LcStTestUnlocked6, LcStTestUnlocked7, LcStRma})) begin
+      return ErrorResponse;
+    end
+
+    // Otherwise, we expect a normal response (not an error and not all zero)
+    return NormalResponse;
   endfunction
 
-  virtual task rw_csr_addr_with_gating(uvm_reg csr, bit gated);
+  task rw_csr_addr_with_gating(uvm_reg csr, response_mode_e rsp_mode);
     bit [TL_AW-1:0] addr = csr.get_address();
     bit [TL_DW-1:0] data = $urandom();
-    bit [TL_DW-1:0] exp_data;
+    bit [TL_DW-1:0] exp_data, fake_rdata;
+    bit             expect_errors, writes_work, use_fake_rdata;
 
     csr_excl_item csr_excl = get_excl_item(csr);
 
-    // If CsrExclAll, skip the test
-    if (csr_excl.is_excl(csr, CsrExclAll, CsrAllTests)) begin
-      return;
-    end
+    case (rsp_mode)
+      NormalResponse: begin
+        writes_work = 1;
+        expect_errors = 0;
+        use_fake_rdata = 0;
+      end
+      ZeroResponse: begin
+        writes_work = 0;
+        expect_errors = 0;
+        use_fake_rdata = 1;
+        fake_rdata = '0;
+      end
+      ErrorResponse: begin
+        writes_work = 0;
+        expect_errors = 1;
+        use_fake_rdata = 1;
+        fake_rdata = '1;
+      end
+      default: ;
+    endcase
+
     // Apply CsrExclWrite
     if (!csr_excl.is_excl(csr, CsrExclWrite, CsrAllTests)) begin
-      tl_access(.addr(addr), .write(1), .data(data), .exp_err_rsp(gated));
-      if (!gated) begin
+      tl_access(.addr(addr), .write(1), .data(data), .exp_err_rsp(expect_errors));
+      if (writes_work) begin
         void'(csr.predict(.value(data), .kind(UVM_PREDICT_WRITE)));
       end
     end
 
-    tl_access(.addr(addr), .write(1), .data(data), .exp_err_rsp(gated));
-    if (!gated) begin
+    tl_access(.addr(addr), .write(1), .data(data), .exp_err_rsp(expect_errors));
+    if (writes_work) begin
       void'(csr.predict(.value(data), .kind(UVM_PREDICT_WRITE)));
     end
-    exp_data = gated ? '1 : `gmv(csr);
-    `uvm_info(`gfn, $sformatf("%s: Write addr %0h, write adata %0h, expect data %0h gated:%0b",
-              csr.get_full_name(), addr, data, exp_data, gated), UVM_MEDIUM);
-    tl_access(.addr(addr), .write(0), .data(data), .exp_err_rsp(gated),
-              .check_exp_data(1), .exp_data(exp_data));
+
+    exp_data = use_fake_rdata ? fake_rdata : `gmv(csr);
+    `uvm_info(`gfn,
+              $sformatf("Write addr %0h, write adata %0h, expect data %0h", addr, data, exp_data),
+              UVM_HIGH);
+    tl_access(.addr(addr), .write(0), .data(data), .exp_err_rsp(expect_errors), .check_exp_data(1),
+              .exp_data(exp_data));
   endtask
 
-  virtual task rand_rw_prim_regs(uvm_reg prim_regs[$], bit gated);
+  task rand_rw_prim_regs(uvm_reg prim_regs[$], response_mode_e rsp_mode);
     `DV_CHECK_NE(prim_regs.size(), 0)
     prim_regs.shuffle();
-    foreach (prim_regs[i]) rw_csr_addr_with_gating(prim_regs[i], gated);
+    foreach (prim_regs[i]) rw_csr_addr_with_gating(prim_regs[i], rsp_mode);
   endtask
 
-  virtual task body();
+  task body();
     for (int trans_i = 1; trans_i <= num_trans; trans_i++) begin
       uvm_reg otp_prim_regs[$], flash_prim_regs[$];
 
@@ -91,13 +126,13 @@ class chip_prim_tl_access_vseq extends chip_stub_cpu_base_vseq;
       if ($urandom_range(0, 1)) begin
         `uvm_info(`gfn, "Check OTP prim_tl access", UVM_HIGH)
         ral.otp_macro_prim.get_registers(otp_prim_regs);
-        rand_rw_prim_regs(otp_prim_regs, ~allow_otp_prim_tl_access());
+        rand_rw_prim_regs(otp_prim_regs, get_response_mode(1'b1));
       end
 
       if ($urandom_range(0, 1)) begin
         `uvm_info(`gfn, "Check FLASH_CTRL prim_tl access", UVM_HIGH)
         ral.flash_ctrl_prim.get_registers(flash_prim_regs);
-        rand_rw_prim_regs(flash_prim_regs, 0);
+        rand_rw_prim_regs(flash_prim_regs, get_response_mode(1'b0));
       end
     end
   endtask : body


### PR DESCRIPTION
Previously it was possible to send out memory requests even though the RV Core is shutdown by the life cycle controller, i.e., lc_en = False and fetch_enable = False.

To better protect that and to ensure that no TLUL request is performed on the D-memory bus on an escalation event, a TLUL LC Gate is added to the D-mem interface. That gate blocks any pending requests upon an escalation.