### PR TITLE
[reggen] Render alert indices in enum

### DIFF
--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_pkg.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_pkg.sv
@@ -17,6 +17,11 @@ package adc_ctrl_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 32;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } adc_ctrl_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/aes/rtl/aes_reg_pkg.sv
+++ b/hw/ip/aes/rtl/aes_reg_pkg.sv
@@ -18,6 +18,12 @@ package aes_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 34;
 
+  // Alert indices
+  typedef enum int {
+    AlertRecovCtrlUpdateErrIdx = 0,
+    AlertFatalFaultIdx = 1
+  } aes_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_pkg.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_pkg.sv
@@ -15,6 +15,11 @@ package aon_timer_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 14;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } aon_timer_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -16,6 +16,12 @@ package csrng_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 24;
 
+  // Alert indices
+  typedef enum int {
+    AlertRecovAlertIdx = 0,
+    AlertFatalAlertIdx = 1
+  } csrng_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/dma/rtl/dma_reg_pkg.sv
+++ b/hw/ip/dma/rtl/dma_reg_pkg.sv
@@ -16,6 +16,11 @@ package dma_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 63;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } dma_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/edn/rtl/edn_reg_pkg.sv
+++ b/hw/ip/edn/rtl/edn_reg_pkg.sv
@@ -19,6 +19,12 @@ package edn_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 18;
 
+  // Alert indices
+  typedef enum int {
+    AlertRecovAlertIdx = 0,
+    AlertFatalAlertIdx = 1
+  } edn_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
@@ -16,6 +16,12 @@ package entropy_src_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 56;
 
+  // Alert indices
+  typedef enum int {
+    AlertRecovAlertIdx = 0,
+    AlertFatalAlertIdx = 1
+  } entropy_src_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/hmac/rtl/hmac_reg_pkg.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_pkg.sv
@@ -17,6 +17,11 @@ package hmac_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 59;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } hmac_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -17,6 +17,11 @@ package i2c_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 32;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } i2c_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/keymgr/rtl/keymgr_reg_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_pkg.sv
@@ -19,6 +19,12 @@ package keymgr_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 63;
 
+  // Alert indices
+  typedef enum int {
+    AlertRecovOperationErrIdx = 0,
+    AlertFatalFaultErrIdx = 1
+  } keymgr_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_pkg.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_pkg.sv
@@ -20,6 +20,12 @@ package keymgr_dpe_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 53;
 
+  // Alert indices
+  typedef enum int {
+    AlertRecovOperationErrIdx = 0,
+    AlertFatalFaultErrIdx = 1
+  } keymgr_dpe_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/kmac/rtl/kmac_reg_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_pkg.sv
@@ -21,6 +21,12 @@ package kmac_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 57;
 
+  // Alert indices
+  typedef enum int {
+    AlertRecovOperationErrIdx = 0,
+    AlertFatalFaultErrIdx = 1
+  } kmac_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
@@ -28,6 +28,13 @@ package lc_ctrl_reg_pkg;
   parameter int NumRegsRegs = 35;
   parameter int NumRegsDmi = 0;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalProgErrorIdx = 0,
+    AlertFatalStateErrorIdx = 1,
+    AlertFatalBusIntegErrorIdx = 2
+  } lc_ctrl_alert_idx_t;
+
   ///////////////////////////////////////////////
   // Typedefs for registers for regs interface //
   ///////////////////////////////////////////////

--- a/hw/ip/mbx/rtl/mbx_reg_pkg.sv
+++ b/hw/ip/mbx/rtl/mbx_reg_pkg.sv
@@ -17,6 +17,12 @@ package mbx_reg_pkg;
   parameter int NumRegsCore = 17;
   parameter int NumRegsSoc = 4;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0,
+    AlertRecovFaultIdx = 1
+  } mbx_alert_idx_t;
+
   ///////////////////////////////////////////////
   // Typedefs for registers for core interface //
   ///////////////////////////////////////////////

--- a/hw/ip/otbn/rtl/otbn_reg_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_pkg.sv
@@ -15,6 +15,12 @@ package otbn_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 11;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalIdx = 0,
+    AlertRecovIdx = 1
+  } otbn_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/pattgen/rtl/pattgen_reg_pkg.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_pkg.sv
@@ -16,6 +16,11 @@ package pattgen_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 12;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } pattgen_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -437,17 +437,17 @@ module rom_ctrl
   // Alert generation ==========================================================
 
   logic [NumAlerts-1:0] alert_test;
-  assign alert_test[AlertFatal] = reg2hw.alert_test.q &
-                                  reg2hw.alert_test.qe;
+  assign alert_test[AlertFatalIdx] = reg2hw.alert_test.q &
+                                     reg2hw.alert_test.qe;
 
   logic [NumAlerts-1:0] alerts;
-  assign alerts[AlertFatal] = bus_integrity_error | checker_alert | mux_alert;
+  assign alerts[AlertFatalIdx] = bus_integrity_error | checker_alert | mux_alert;
 
   for (genvar i = 0; i < NumAlerts; i++) begin: gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(i == AlertFatal)
+      .IsFatal(i == AlertFatalIdx)
     ) u_alert_sender (
       .clk_i,
       .rst_ni,
@@ -482,15 +482,15 @@ module rom_ctrl
     `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT_IN(CompareFsmAlert_A,
                                             gen_fsm_scramble_enabled.
                                             u_checker_fsm.u_compare.u_state_regs,
-                                            gen_alert_tx[AlertFatal].u_alert_sender.alert_req_i)
+                                            gen_alert_tx[AlertFatalIdx].u_alert_sender.alert_req_i)
     `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CheckerFsmAlert_A,
                                          gen_fsm_scramble_enabled.
                                          u_checker_fsm.u_state_regs,
-                                         alert_tx_o[AlertFatal])
+                                         alert_tx_o[AlertFatalIdx])
     `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT_IN(CompareAddrCtrCheck_A,
-                                              gen_fsm_scramble_enabled.
-                                              u_checker_fsm.u_compare.u_prim_count_addr,
-                                              gen_alert_tx[AlertFatal].u_alert_sender.alert_req_i)
+      gen_fsm_scramble_enabled.
+      u_checker_fsm.u_compare.u_prim_count_addr,
+      gen_alert_tx[AlertFatalIdx].u_alert_sender.alert_req_i)
   end
 
   // The pwrmgr_data_o output (the "done" and "good" signals) should have a known value when out of
@@ -551,32 +551,32 @@ module rom_ctrl
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT_IN(RegWeOnehotCheck_A,
                                                     u_reg_regs,
-                                                    (gen_alert_tx[AlertFatal].
+                                                    (gen_alert_tx[AlertFatalIdx].
                                                      u_alert_sender.alert_req_i))
 
   // Alert assertions for redundant counters.
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT_IN(RspFifoWptrCheck_A,
                                             u_tl_adapter_rom.u_rspfifo.gen_normal_fifo.
                                             u_fifo_cnt.gen_secure_ptrs.u_wptr,
-                                            gen_alert_tx[AlertFatal].u_alert_sender.alert_req_i)
+                                            gen_alert_tx[AlertFatalIdx].u_alert_sender.alert_req_i)
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT_IN(RspFifoRptrCheck_A,
                                             u_tl_adapter_rom.u_rspfifo.gen_normal_fifo.
                                             u_fifo_cnt.gen_secure_ptrs.u_rptr,
-                                            gen_alert_tx[AlertFatal].u_alert_sender.alert_req_i)
+                                            gen_alert_tx[AlertFatalIdx].u_alert_sender.alert_req_i)
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT_IN(SramReqFifoWptrCheck_A,
                                             u_tl_adapter_rom.u_sramreqfifo.gen_normal_fifo.
                                             u_fifo_cnt.gen_secure_ptrs.u_wptr,
-                                            gen_alert_tx[AlertFatal].u_alert_sender.alert_req_i)
+                                            gen_alert_tx[AlertFatalIdx].u_alert_sender.alert_req_i)
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT_IN(SramReqFifoRptrCheck_A,
                                             u_tl_adapter_rom.u_sramreqfifo.gen_normal_fifo.
                                             u_fifo_cnt.gen_secure_ptrs.u_rptr,
-                                            gen_alert_tx[AlertFatal].u_alert_sender.alert_req_i)
+                                            gen_alert_tx[AlertFatalIdx].u_alert_sender.alert_req_i)
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT_IN(ReqFifoWptrCheck_A,
                                             u_tl_adapter_rom.u_reqfifo.gen_normal_fifo.
                                             u_fifo_cnt.gen_secure_ptrs.u_wptr,
-                                            gen_alert_tx[AlertFatal].u_alert_sender.alert_req_i)
+                                            gen_alert_tx[AlertFatalIdx].u_alert_sender.alert_req_i)
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT_IN(ReqFifoRptrCheck_A,
                                             u_tl_adapter_rom.u_reqfifo.gen_normal_fifo.
                                             u_fifo_cnt.gen_secure_ptrs.u_rptr,
-                                            gen_alert_tx[AlertFatal].u_alert_sender.alert_req_i)
+                                            gen_alert_tx[AlertFatalIdx].u_alert_sender.alert_req_i)
 endmodule

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_pkg.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_pkg.sv
@@ -6,8 +6,6 @@
 
 package rom_ctrl_pkg;
 
-  parameter int AlertFatal = 0;
-
   typedef struct packed {
     prim_mubi_pkg::mubi4_t done;
     prim_mubi_pkg::mubi4_t good;

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_reg_pkg.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_reg_pkg.sv
@@ -17,6 +17,11 @@ package rom_ctrl_reg_pkg;
   parameter int NumRegsRegs = 18;
   parameter int NumRegsRom = 0;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalIdx = 0
+  } rom_ctrl_alert_idx_t;
+
   ///////////////////////////////////////////////
   // Typedefs for registers for regs interface //
   ///////////////////////////////////////////////

--- a/hw/ip/rv_dm/rtl/rv_dm_reg_pkg.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm_reg_pkg.sv
@@ -20,6 +20,11 @@ package rv_dm_reg_pkg;
   parameter int NumRegsMem = 281;
   parameter int NumRegsDbg = 0;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } rv_dm_alert_idx_t;
+
   ///////////////////////////////////////////////
   // Typedefs for registers for regs interface //
   ///////////////////////////////////////////////

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_pkg.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_pkg.sv
@@ -17,6 +17,11 @@ package rv_timer_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 10;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } rv_timer_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_reg_pkg.sv
+++ b/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_reg_pkg.sv
@@ -17,6 +17,12 @@ package soc_dbg_ctrl_reg_pkg;
   parameter int NumRegsCore = 7;
   parameter int NumRegsJtag = 6;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0,
+    AlertRecovCtrlUpdateErrIdx = 1
+  } soc_dbg_ctrl_alert_idx_t;
+
   ///////////////////////////////////////////////
   // Typedefs for registers for core interface //
   ///////////////////////////////////////////////

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -38,6 +38,11 @@ package spi_device_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 73;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } spi_device_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
@@ -19,6 +19,11 @@ package spi_host_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 12;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } spi_host_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_pkg.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_pkg.sv
@@ -17,6 +17,11 @@ package sram_ctrl_reg_pkg;
   parameter int NumRegsRegs = 9;
   parameter int NumRegsRam = 0;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalErrorIdx = 0
+  } sram_ctrl_alert_idx_t;
+
   ///////////////////////////////////////////////
   // Typedefs for registers for regs interface //
   ///////////////////////////////////////////////

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_pkg.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_pkg.sv
@@ -19,6 +19,11 @@ package sysrst_ctrl_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 43;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } sysrst_ctrl_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/uart/rtl/uart_reg_pkg.sv
+++ b/hw/ip/uart/rtl/uart_reg_pkg.sv
@@ -17,6 +17,11 @@ package uart_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 13;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } uart_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -16,6 +16,11 @@ package usbdev_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 43;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } usbdev_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
+++ b/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
@@ -73,22 +73,20 @@ module ${module_instance_name}
   logic [NumAlerts-1:0] alert_test, alert;
   logic deny_cnt_error;
 
-  assign alert[0]  = shadowed_update_err;
-  assign alert[1]  = reg_intg_error | shadowed_storage_err | deny_cnt_error;
+  assign alert[AlertRecovCtrlUpdateErrIdx]  = shadowed_update_err;
+  assign alert[AlertFatalFaultIdx]          = reg_intg_error | shadowed_storage_err |
+                                              deny_cnt_error;
 
-  assign alert_test = {
-    reg2hw.alert_test.fatal_fault.q &
-    reg2hw.alert_test.fatal_fault.qe,
-    reg2hw.alert_test.recov_ctrl_update_err.q &
-    reg2hw.alert_test.recov_ctrl_update_err.qe
-  };
+  assign alert_test[AlertFatalFaultIdx] = reg2hw.alert_test.fatal_fault.q &
+                                          reg2hw.alert_test.fatal_fault.qe;
+  assign alert_test[AlertRecovCtrlUpdateErrIdx] = reg2hw.alert_test.recov_ctrl_update_err.q &
+                                                  reg2hw.alert_test.recov_ctrl_update_err.qe;
 
-  localparam logic [NumAlerts-1:0] IsFatal = {1'b1, 1'b0};
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(IsFatal[i])
+      .IsFatal(i == AlertFatalFaultIdx)
     ) u_prim_alert_sender (
       .clk_i         ( clk_i         ),
       .rst_ni        ( rst_ni        ),

--- a/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
+++ b/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
@@ -75,30 +75,25 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
   logic [NumAlerts-1:0] alert_test, alert;
 
 % if enable_shadow_reg:
-  localparam logic [NumAlerts-1:0] IsFatal = {
-    1'b0, // [1] recov_ctrl_update_err
-    1'b1  // [0] fatal_fault
-  };
+  assign alert[AlertFatalFaultIdx]         = reg_intg_error | shadowed_storage_err;
+  assign alert[AlertRecovCtrlUpdateErrIdx] = shadowed_update_err;
 
-  assign alert[0]  = reg_intg_error | shadowed_storage_err; // fatal_fault
-  assign alert[1]  = shadowed_update_err;                   // recov_ctrl_update_err
-
-  assign alert_test[0] = reg2hw.alert_test.fatal_fault.q & reg2hw.alert_test.fatal_fault.qe;
-  assign alert_test[1] = reg2hw.alert_test.recov_ctrl_update_err.q &
-                         reg2hw.alert_test.recov_ctrl_update_err.qe;
+  assign alert_test[AlertFatalFaultIdx] = reg2hw.alert_test.fatal_fault.q &
+                                          reg2hw.alert_test.fatal_fault.qe;
+  assign alert_test[AlertRecovCtrlUpdateErrIdx] = reg2hw.alert_test.recov_ctrl_update_err.q &
+                                                  reg2hw.alert_test.recov_ctrl_update_err.qe;
 % else:
-  localparam logic [NumAlerts-1:0] IsFatal = {1'b1};
+  assign alert[AlertFatalFaultIdx] = reg_intg_error;
 
-  assign alert[0]  = reg_intg_error;
-  
-  assign alert_test[0] = reg2hw.alert_test.fatal_fault.q & reg2hw.alert_test.fatal_fault.qe;
+  assign alert_test[AlertFatalFaultIdx] = reg2hw.alert_test.fatal_fault.q &
+                                          reg2hw.alert_test.fatal_fault.qe;
 % endif
 
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
-      .AsyncOn    ( AlertAsyncOn[i] ),
-      .SkewCycles ( AlertSkewCycles ),
-      .IsFatal    ( IsFatal[i]      )
+      .AsyncOn    ( AlertAsyncOn[i]         ),
+      .SkewCycles ( AlertSkewCycles         ),
+      .IsFatal    ( i == AlertFatalFaultIdx )
     ) u_prim_alert_sender (
       .clk_i         ( clk_i         ),
       .rst_ni        ( rst_ni        ),

--- a/hw/top_darjeeling/ip/soc_proxy/rtl/soc_proxy_reg_pkg.sv
+++ b/hw/top_darjeeling/ip/soc_proxy/rtl/soc_proxy_reg_pkg.sv
@@ -18,6 +18,39 @@ package soc_proxy_reg_pkg;
   parameter int NumRegsCore = 4;
   parameter int NumRegsCtn = 0;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalAlertIntgIdx = 0,
+    AlertFatalAlertExternal0Idx = 1,
+    AlertFatalAlertExternal1Idx = 2,
+    AlertFatalAlertExternal2Idx = 3,
+    AlertFatalAlertExternal3Idx = 4,
+    AlertFatalAlertExternal4Idx = 5,
+    AlertFatalAlertExternal5Idx = 6,
+    AlertFatalAlertExternal6Idx = 7,
+    AlertFatalAlertExternal7Idx = 8,
+    AlertFatalAlertExternal8Idx = 9,
+    AlertFatalAlertExternal9Idx = 10,
+    AlertFatalAlertExternal10Idx = 11,
+    AlertFatalAlertExternal11Idx = 12,
+    AlertFatalAlertExternal12Idx = 13,
+    AlertFatalAlertExternal13Idx = 14,
+    AlertFatalAlertExternal14Idx = 15,
+    AlertFatalAlertExternal15Idx = 16,
+    AlertFatalAlertExternal16Idx = 17,
+    AlertFatalAlertExternal17Idx = 18,
+    AlertFatalAlertExternal18Idx = 19,
+    AlertFatalAlertExternal19Idx = 20,
+    AlertFatalAlertExternal20Idx = 21,
+    AlertFatalAlertExternal21Idx = 22,
+    AlertFatalAlertExternal22Idx = 23,
+    AlertFatalAlertExternal23Idx = 24,
+    AlertRecovAlertExternal0Idx = 25,
+    AlertRecovAlertExternal1Idx = 26,
+    AlertRecovAlertExternal2Idx = 27,
+    AlertRecovAlertExternal3Idx = 28
+  } soc_proxy_alert_idx_t;
+
   ///////////////////////////////////////////////
   // Typedefs for registers for core interface //
   ///////////////////////////////////////////////

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check.sv
@@ -73,22 +73,20 @@ module ac_range_check
   logic [NumAlerts-1:0] alert_test, alert;
   logic deny_cnt_error;
 
-  assign alert[0]  = shadowed_update_err;
-  assign alert[1]  = reg_intg_error | shadowed_storage_err | deny_cnt_error;
+  assign alert[AlertRecovCtrlUpdateErrIdx]  = shadowed_update_err;
+  assign alert[AlertFatalFaultIdx]          = reg_intg_error | shadowed_storage_err |
+                                              deny_cnt_error;
 
-  assign alert_test = {
-    reg2hw.alert_test.fatal_fault.q &
-    reg2hw.alert_test.fatal_fault.qe,
-    reg2hw.alert_test.recov_ctrl_update_err.q &
-    reg2hw.alert_test.recov_ctrl_update_err.qe
-  };
+  assign alert_test[AlertFatalFaultIdx] = reg2hw.alert_test.fatal_fault.q &
+                                          reg2hw.alert_test.fatal_fault.qe;
+  assign alert_test[AlertRecovCtrlUpdateErrIdx] = reg2hw.alert_test.recov_ctrl_update_err.q &
+                                                  reg2hw.alert_test.recov_ctrl_update_err.qe;
 
-  localparam logic [NumAlerts-1:0] IsFatal = {1'b1, 1'b0};
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(IsFatal[i])
+      .IsFatal(i == AlertFatalFaultIdx)
     ) u_prim_alert_sender (
       .clk_i         ( clk_i         ),
       .rst_ni        ( rst_ni        ),

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_pkg.sv
@@ -17,6 +17,12 @@ package ac_range_check_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 168;
 
+  // Alert indices
+  typedef enum int {
+    AlertRecovCtrlUpdateErrIdx = 0,
+    AlertFatalFaultIdx = 1
+  } ac_range_check_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
@@ -18,6 +18,12 @@ package clkmgr_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 16;
 
+  // Alert indices
+  typedef enum int {
+    AlertRecovFaultIdx = 0,
+    AlertFatalFaultIdx = 1
+  } clkmgr_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_darjeeling/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
@@ -17,6 +17,11 @@ package gpio_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 34;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } gpio_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -297,6 +297,15 @@ package otp_ctrl_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegsCore = 95;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalMacroErrorIdx = 0,
+    AlertFatalCheckErrorIdx = 1,
+    AlertFatalBusIntegErrorIdx = 2,
+    AlertFatalPrimOtpAlertIdx = 3,
+    AlertRecovPrimOtpAlertIdx = 4
+  } otp_ctrl_alert_idx_t;
+
   ///////////////////////////////////////////////
   // Typedefs for registers for core interface //
   ///////////////////////////////////////////////

--- a/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
@@ -21,6 +21,11 @@ package pinmux_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 503;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } pinmux_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
@@ -27,6 +27,11 @@ package pwrmgr_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 17;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } pwrmgr_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv
@@ -64,23 +64,19 @@ module racl_ctrl import racl_ctrl_reg_pkg::*; #(
   //////////////////////////////////////////////////////////////////////////////////////////////////
   logic [NumAlerts-1:0] alert_test, alert;
 
-  localparam logic [NumAlerts-1:0] IsFatal = {
-    1'b0, // [1] recov_ctrl_update_err
-    1'b1  // [0] fatal_fault
-  };
+  assign alert[AlertFatalFaultIdx]         = reg_intg_error | shadowed_storage_err;
+  assign alert[AlertRecovCtrlUpdateErrIdx] = shadowed_update_err;
 
-  assign alert[0]  = reg_intg_error | shadowed_storage_err; // fatal_fault
-  assign alert[1]  = shadowed_update_err;                   // recov_ctrl_update_err
-
-  assign alert_test[0] = reg2hw.alert_test.fatal_fault.q & reg2hw.alert_test.fatal_fault.qe;
-  assign alert_test[1] = reg2hw.alert_test.recov_ctrl_update_err.q &
-                         reg2hw.alert_test.recov_ctrl_update_err.qe;
+  assign alert_test[AlertFatalFaultIdx] = reg2hw.alert_test.fatal_fault.q &
+                                          reg2hw.alert_test.fatal_fault.qe;
+  assign alert_test[AlertRecovCtrlUpdateErrIdx] = reg2hw.alert_test.recov_ctrl_update_err.q &
+                                                  reg2hw.alert_test.recov_ctrl_update_err.qe;
 
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
-      .AsyncOn    ( AlertAsyncOn[i] ),
-      .SkewCycles ( AlertSkewCycles ),
-      .IsFatal    ( IsFatal[i]      )
+      .AsyncOn    ( AlertAsyncOn[i]         ),
+      .SkewCycles ( AlertSkewCycles         ),
+      .IsFatal    ( i == AlertFatalFaultIdx )
     ) u_prim_alert_sender (
       .clk_i         ( clk_i         ),
       .rst_ni        ( rst_ni        ),

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_pkg.sv
@@ -15,6 +15,12 @@ package racl_ctrl_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 9;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0,
+    AlertRecovCtrlUpdateErrIdx = 1
+  } racl_ctrl_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
@@ -20,6 +20,12 @@ package rstmgr_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 18;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0,
+    AlertFatalCnstyFaultIdx = 1
+  } rstmgr_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
@@ -18,6 +18,14 @@ package rv_core_ibex_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegsCfg = 265;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalSwErrIdx = 0,
+    AlertRecovSwErrIdx = 1,
+    AlertFatalHwErrIdx = 2,
+    AlertRecovHwErrIdx = 3
+  } rv_core_ibex_alert_idx_t;
+
   //////////////////////////////////////////////
   // Typedefs for registers for cfg interface //
   //////////////////////////////////////////////

--- a/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
@@ -18,6 +18,11 @@ package rv_plic_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 180;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } rv_plic_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_pkg.sv
@@ -19,6 +19,12 @@ package sensor_ctrl_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 29;
 
+  // Alert indices
+  typedef enum int {
+    AlertRecovAlertIdx = 0,
+    AlertFatalAlertIdx = 1
+  } sensor_ctrl_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
@@ -18,6 +18,12 @@ package clkmgr_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 22;
 
+  // Alert indices
+  typedef enum int {
+    AlertRecovFaultIdx = 0,
+    AlertFatalFaultIdx = 1
+  } clkmgr_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -36,6 +36,15 @@ package flash_ctrl_reg_pkg;
   parameter int NumRegsPrim = 21;
   parameter int NumRegsMem = 0;
 
+  // Alert indices
+  typedef enum int {
+    AlertRecovErrIdx = 0,
+    AlertFatalStdErrIdx = 1,
+    AlertFatalErrIdx = 2,
+    AlertFatalPrimFlashAlertIdx = 3,
+    AlertRecovPrimFlashAlertIdx = 4
+  } flash_ctrl_alert_idx_t;
+
   ///////////////////////////////////////////////
   // Typedefs for registers for core interface //
   ///////////////////////////////////////////////

--- a/hw/top_earlgrey/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
@@ -17,6 +17,11 @@ package gpio_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 18;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } gpio_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -279,6 +279,15 @@ package otp_ctrl_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegsCore = 56;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalMacroErrorIdx = 0,
+    AlertFatalCheckErrorIdx = 1,
+    AlertFatalBusIntegErrorIdx = 2,
+    AlertFatalPrimOtpAlertIdx = 3,
+    AlertRecovPrimOtpAlertIdx = 4
+  } otp_ctrl_alert_idx_t;
+
   ///////////////////////////////////////////////
   // Typedefs for registers for core interface //
   ///////////////////////////////////////////////

--- a/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
@@ -21,6 +21,11 @@ package pinmux_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 568;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } pinmux_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_earlgrey/ip_autogen/pwm/rtl/pwm_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/pwm/rtl/pwm_reg_pkg.sv
@@ -16,6 +16,11 @@ package pwm_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 23;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } pwm_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
@@ -29,6 +29,11 @@ package pwrmgr_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 17;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } pwrmgr_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
@@ -20,6 +20,12 @@ package rstmgr_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 28;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0,
+    AlertFatalCnstyFaultIdx = 1
+  } rstmgr_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
@@ -18,6 +18,14 @@ package rv_core_ibex_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegsCfg = 25;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalSwErrIdx = 0,
+    AlertRecovSwErrIdx = 1,
+    AlertFatalHwErrIdx = 2,
+    AlertRecovHwErrIdx = 3
+  } rv_core_ibex_alert_idx_t;
+
   //////////////////////////////////////////////
   // Typedefs for registers for cfg interface //
   //////////////////////////////////////////////

--- a/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
@@ -18,6 +18,11 @@ package rv_plic_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 202;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } rv_plic_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
@@ -18,6 +18,12 @@ package clkmgr_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 20;
 
+  // Alert indices
+  typedef enum int {
+    AlertRecovFaultIdx = 0,
+    AlertFatalFaultIdx = 1
+  } clkmgr_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -36,6 +36,15 @@ package flash_ctrl_reg_pkg;
   parameter int NumRegsPrim = 21;
   parameter int NumRegsMem = 0;
 
+  // Alert indices
+  typedef enum int {
+    AlertRecovErrIdx = 0,
+    AlertFatalStdErrIdx = 1,
+    AlertFatalErrIdx = 2,
+    AlertFatalPrimFlashAlertIdx = 3,
+    AlertRecovPrimFlashAlertIdx = 4
+  } flash_ctrl_alert_idx_t;
+
   ///////////////////////////////////////////////
   // Typedefs for registers for core interface //
   ///////////////////////////////////////////////

--- a/hw/top_englishbreakfast/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
@@ -17,6 +17,11 @@ package gpio_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 18;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } gpio_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
@@ -21,6 +21,11 @@ package pinmux_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 520;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } pinmux_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
@@ -26,6 +26,11 @@ package pwrmgr_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 17;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } pwrmgr_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
@@ -20,6 +20,12 @@ package rstmgr_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 18;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0,
+    AlertFatalCnstyFaultIdx = 1
+  } rstmgr_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
@@ -18,6 +18,14 @@ package rv_core_ibex_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegsCfg = 25;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalSwErrIdx = 0,
+    AlertRecovSwErrIdx = 1,
+    AlertFatalHwErrIdx = 2,
+    AlertRecovHwErrIdx = 3
+  } rv_core_ibex_alert_idx_t;
+
   //////////////////////////////////////////////
   // Typedefs for registers for cfg interface //
   //////////////////////////////////////////////

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
@@ -18,6 +18,11 @@ package rv_plic_reg_pkg;
   // Number of registers for every interface
   parameter int NumRegs = 98;
 
+  // Alert indices
+  typedef enum int {
+    AlertFatalFaultIdx = 0
+  } rv_plic_alert_idx_t;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/util/reggen/reg_pkg.sv.tpl
+++ b/util/reggen/reg_pkg.sv.tpl
@@ -385,6 +385,15 @@ package ${lblock}${"_" + block.alias_impl if block.alias_impl else ""}_reg_pkg;
 % for iface_name, rb in block.reg_blocks.items():
   parameter int NumRegs${iface_name.title() if iface_name else ""} = ${len(rb.flat_regs)};
 % endfor
+% if len(block.alerts):
+
+  // Alert indices
+  typedef enum int {
+% for idx, alert in enumerate(block.alerts):
+    Alert${lib.Name.to_camel_case(alert.name)}Idx = ${idx}${"" if idx == len(block.alerts) - 1 else ","}
+% endfor
+  } ${block.name.lower()}_alert_idx_t;
+% endif
 <%
   just_default = len(block.reg_blocks) == 1 and None in block.reg_blocks
 %>\


### PR DESCRIPTION
This PR adds an enum for the alert indices. This allows RTL to use that when accessing the alert array and to be more explicit rather than having hard-coded `[0]` and `[1]` statements.

Closes https://github.com/lowRISC/opentitan/issues/27398