### PR TITLE
[rules,bitstreams] Explicitely watch files

### DIFF
--- a/rules/bitstreams.bzl
+++ b/rules/bitstreams.bzl
@@ -55,6 +55,8 @@ def _bitstreams_repo_impl(rctx):
         "BAZEL_BITSTREAMS_CACHE",
         rctx.attr.cache,
     )
+    rctx.watch(rctx.attr.python_interpreter)
+    rctx.watch(rctx.attr._cache_manager)
     result = rctx.execute(
         [
             rctx.path(rctx.attr.python_interpreter),


### PR DESCRIPTION
Surprisingly, it seems that Bazel does not automatically watch the label attributes of the repository rule and it will not refetch it even when they change. Although this runs contrary to what we expect and this requires more investigation, this commit provides at least a workaround.

More precisely, I managed to reproduce the issue as follows:
- checkout master, and make sure that the bitstream is up-to-date by running
```bash
./bazelisk build @bitstreams//...
```
- edit `rules/scripts/bitstreams_workspace.py`, for example by making a change that prevents the file from even compiling
- run
```bash
./bazelisk build @bitstreams//...
./bazelisk fetch --configure
```
and observe that the bitstream rule is not evaluated, even though both commands should invalidate it.
- run
```bash
./bazelisk build @bitstreams//...
./bazelisk fetch --configure --force
```
and observe that bazel complains above the repository rule failing

TODO: investigate why this happens. My suggestion would be to move the repo rule to an extension and see if it fails the same way. This could be a bazel bug, or a bazel lack of documentation.