### PR TITLE
[ci] Rework nightly FPGA jobs

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -33,6 +33,10 @@ on:
       vivado_version:
         default: "2021.1"
         type: string
+      targets:
+        default: "//... @manufacturer_test_hooks//..."
+        type: string
+        description: Bazel target(s) to look for tests in
 
 jobs:
   fpga:
@@ -68,7 +72,7 @@ jobs:
           ci/scripts/run-bazel-test-query.sh \
             target_pattern_file.txt \
             "${{ inputs.tag_filters }}",-manual,-broken,-skip_in_ci \
-            //... @manufacturer_test_hooks//...
+            ${{ inputs.targets }}
 
           # Run FPGA tests
           if [[ -s target_pattern_file.txt ]]; then

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -41,6 +41,10 @@ on:
         default: true
         type: boolean
         description: Include additional test filters for "manual", "broken", and "skip_in_ci" tests.
+      cache_test_results:
+        default: true
+        type: boolean
+        description: Skip tests that previously passed and were cached by Bazel
 
 jobs:
   fpga:
@@ -83,9 +87,11 @@ jobs:
             "$tag_filters" \
             ${{ inputs.targets }}
 
+          cache_test_results="--cache_test_results=${{ inputs.cache_test_results }}"
+
           # Run FPGA tests
           if [[ -s target_pattern_file.txt ]]; then
-            ci/scripts/run-fpga-tests.sh "${{ inputs.interface }}" target_pattern_file.txt || {
+            ci/scripts/run-fpga-tests.sh "${{ inputs.interface }}" target_pattern_file.txt "$cache_test_results" || {
               res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}";
             }
           else

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -37,6 +37,10 @@ on:
         default: "//... @manufacturer_test_hooks//..."
         type: string
         description: Bazel target(s) to look for tests in
+      add_default_filters:
+        default: true
+        type: boolean
+        description: Include additional test filters for "manual", "broken", and "skip_in_ci" tests.
 
 jobs:
   fpga:
@@ -68,10 +72,15 @@ jobs:
           . util/build_consts.sh
           module load "xilinx/vivado/${{ inputs.vivado_version }}"
 
+          tag_filters="${{ inputs.tag_filters }}"
+          if ${{ inputs.add_default_filters }}; then
+            tag_filters+=",-manual,-broken,-skip_in_ci"
+          fi
+
           # Execute a query to find all targets that match the test tags and store them in a file.
           ci/scripts/run-bazel-test-query.sh \
             target_pattern_file.txt \
-            "${{ inputs.tag_filters }}",-manual,-broken,-skip_in_ci \
+            "$tag_filters" \
             ${{ inputs.targets }}
 
           # Run FPGA tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,221 +22,186 @@ env:
   VIVADO_VERSION: "2021.1"
 
 jobs:
-  fpga_cw310_sival_nightly:
-    name: FPGA CW310 SiVal tests
-    runs-on: [ubuntu-22.04-fpga, cw310]
+  chip_earlgrey_cw310:
+    name: Earl Grey for CW310
+    uses: ./.github/workflows/bitstream.yml
+    secrets: inherit
+    with:
+      top_name: earlgrey
+      design_suffix: cw310
 
-    env:
-      GS_PATH: opentitan-test-results
+  chip_earlgrey_cw310_hyperdebug:
+    name: Earl Grey for CW310 Hyperdebug
+    uses: ./.github/workflows/bitstream.yml
+    secrets: inherit
+    with:
+      top_name: earlgrey
+      design_suffix: cw310_hyperdebug
 
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Required for the bitstream cache to work.
-          ref: ${{ inputs.branch || 'earlgrey_1.0.0' }} # Schedule only work on the default branch, but we want to run on a different branch.
+  chip_earlgrey_cw340:
+    name: Earl Grey for CW340
+    uses: ./.github/workflows/bitstream.yml
+    secrets: inherit
+    with:
+      top_name: earlgrey
+      design_suffix: cw340
 
-      - name: Prepare environment
-        uses: ./.github/actions/prepare-env
-        with:
-          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
+  execute_fpga_cw310_test_rom_tests:
+    name: CW310 Test ROM Tests
+    needs: chip_earlgrey_cw310
+    uses: ./.github/workflows/fpga.yml
+    secrets: inherit
+    with:
+      job_name: execute_fpga_cw310_test_rom_tests
+      bitstream: chip_earlgrey_cw310
+      board: cw310
+      interface: cw310
+      tag_filters: cw310_test_rom,-broken,-manual
+      add_default_filters: false
+      cache_test_results: false
 
-      - name: Update hyperdebug
-        run: |
-          ./bazelisk.sh run //sw/host/opentitantool -- --interface=hyperdebug_dfu transport update-firmware
+  execute_fpga_cw310_rom_tests:
+    name: CW310 ROM Tests
+    needs: chip_earlgrey_cw310
+    uses: ./.github/workflows/fpga.yml
+    secrets: inherit
+    with:
+      job_name: execute_fpga_cw310_rom_tests
+      bitstream: chip_earlgrey_cw310
+      board: cw310
+      interface: cw310
+      tag_filters: cw310_rom_with_fake_keys,-broken,-manual
+      add_default_filters: false
+      cache_test_results: false
+      timeout: 240
 
-      - name: Run tests after ROM boot stage
-        if: success() || failure()
-        run: |
-          module load xilinx/vivado
-          bazel_tests="$(mktemp)"
-          ./bazelisk.sh query 'attr("tags", "[\[ ]cw310_sival[,\]]", tests(//sw/device/...))' \
-                                                    | grep -v examples \
-                                                    | grep -v penetrationtests \
-                                                    > "$bazel_tests"
-          ./bazelisk.sh test \
-            --build_tests_only \
-            --cache_test_results=no \
-            --test_tag_filters=-slow_test \
-            --target_pattern_file="$bazel_tests"
+  execute_fpga_cw310_rom_ext_tests:
+    name: CW310 ROM_EXT Tests
+    needs: chip_earlgrey_cw310
+    uses: ./.github/workflows/fpga.yml
+    secrets: inherit
+    with:
+      job_name: execute_fpga_cw310_rom_ext_tests
+      bitstream: chip_earlgrey_cw310
+      board: cw310
+      interface: cw310
+      tag_filters: cw310_rom_ext,-broken,-manual
+      add_default_filters: false
+      cache_test_results: false
 
-      - name: Run tests after ROM_EXT boot stage
-        if: success() || failure()
-        run: |
-          module load xilinx/vivado
-          bazel_tests="$(mktemp)"
-          ./bazelisk.sh query 'attr("tags", "[\[ ]cw310_sival_rom_ext[,\]]", tests(//sw/device/...))' \
-                                                    | grep -v examples \
-                                                    | grep -v penetrationtests \
-                                                    > "$bazel_tests"
-          ./bazelisk.sh test \
-            --build_tests_only \
-            --cache_test_results=no \
-            --test_tag_filters=-slow_test \
-            --target_pattern_file="$bazel_tests"
+  execute_fpga_cw310_sival_tests:
+    name: CW310 SiVal Tests
+    needs: chip_earlgrey_cw310_hyperdebug
+    uses: ./.github/workflows/fpga.yml
+    secrets: inherit
+    with:
+      job_name: execute_fpga_cw310_sival_tests
+      bitstream: chip_earlgrey_cw310_hyperdebug
+      board: cw310
+      interface: hyper310
+      tag_filters: cw310_sival,-broken,-manual
+      add_default_filters: false
+      cache_test_results: false
 
-      - name: Compute bucket destination
-        id: bucket_destination
-        if: ${{ !cancelled() }}
-        run: |
-          BUCKET_PATH=$GS_PATH/job/${{ github.job }}/branch/${{ inputs.branch || 'earlgrey_1.0.0'}}/$(date +%Y-%m-%d-%H%M%S)_test_results.xml
-          echo "BUCKET_PATH=$BUCKET_PATH" >> $GITHUB_OUTPUT
+  execute_fpga_cw310_sival_rom_ext_tests:
+    name: CW310 SiVal ROM_EXT Tests
+    needs: chip_earlgrey_cw310_hyperdebug
+    uses: ./.github/workflows/fpga.yml
+    secrets: inherit
+    with:
+      job_name: execute_fpga_cw310_sival_rom_ext_tests
+      bitstream: chip_earlgrey_cw310_hyperdebug
+      board: cw310
+      interface: hyper310
+      tag_filters: cw310_sival_rom_ext,-broken,-manual
+      add_default_filters: false
+      cache_test_results: false
 
-      - name: Publish Bazel test results
-        uses: ./.github/actions/publish-bazel-test-results
-        if: ${{ !cancelled() }}
-        with:
-          artifact-name: fpga_cw310_sival_nightly-test-results
-          bucket-destination: ${{ steps.bucket_destination.outputs.BUCKET_PATH }}
+  execute_fpga_cw310_bob_tests:
+    name: CW310 BoB (SPI and I2C) Tests
+    needs: chip_earlgrey_cw310
+    uses: ./.github/workflows/fpga.yml
+    secrets: inherit
+    with:
+      job_name: execute_bob_fpga_tests_cw310
+      bitstream: chip_earlgrey_cw310
+      board: cw310
+      interface: cw310
+      targets: "//sw/device/tests/pmod/..."
+      tag_filters: cw310_sival_rom_ext_no_hyper,-broken,-manual
+      add_default_filters: false
+      cache_test_results: false
 
-  fpga_cw340_sival_nightly:
-    name: FPGA CW340 SiVal tests
-    runs-on: [ubuntu-22.04-fpga, cw340]
+  execute_fpga_cw340_test_rom_tests:
+    name: CW340 SiVal Test ROM Tests
+    needs: chip_earlgrey_cw340
+    uses: ./.github/workflows/fpga.yml
+    secrets: inherit
+    with:
+      job_name: execute_fpga_cw340_test_rom_tests
+      bitstream: chip_earlgrey_cw340
+      board: cw340
+      interface: cw340
+      tag_filters: cw340_test_rom,-broken,-manual
+      add_default_filters: false
+      cache_test_results: false
 
-    env:
-      GS_PATH: opentitan-test-results
-      BAZEL_TEST_RESULTS: test_results.xml
+  execute_fpga_cw340_rom_tests:
+    name: CW340 SiVal ROM Tests
+    needs: chip_earlgrey_cw340
+    uses: ./.github/workflows/fpga.yml
+    secrets: inherit
+    with:
+      job_name: execute_fpga_cw340_rom_tests
+      bitstream: chip_earlgrey_cw340
+      board: cw340
+      interface: cw340
+      tag_filters: cw340_rom_with_fake_keys,-broken,-manual
+      add_default_filters: false
+      cache_test_results: false
 
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Required for the bitstream cache to work.
-          ref: ${{ inputs.branch || 'earlgrey_1.0.0' }} # Schedule only work on the default branch, but we want to run on a different branch.
+  execute_fpga_cw340_rom_ext_tests:
+    name: CW340 SiVal ROM_EXT Tests
+    needs: chip_earlgrey_cw340
+    uses: ./.github/workflows/fpga.yml
+    secrets: inherit
+    with:
+      job_name: execute_fpga_cw340_rom_ext_tests
+      bitstream: chip_earlgrey_cw340
+      board: cw340
+      interface: cw340
+      tag_filters: cw340_rom_ext,-broken,-manual
+      add_default_filters: false
+      cache_test_results: false
 
-      - name: Prepare environment
-        uses: ./.github/actions/prepare-env
-        with:
-          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
+  execute_fpga_cw340_sival_tests:
+    name: CW340 SiVal Tests
+    needs: chip_earlgrey_cw340
+    uses: ./.github/workflows/fpga.yml
+    secrets: inherit
+    with:
+      job_name: execute_fpga_cw340_sival_tests
+      bitstream: chip_earlgrey_cw340
+      board: cw340
+      interface: cw340
+      tag_filters: cw340_sival,-broken,-manual
+      add_default_filters: false
+      cache_test_results: false
 
-      - name: Update hyperdebug
-        run: |
-          ./bazelisk.sh run //sw/host/opentitantool -- --interface=hyperdebug_dfu transport update-firmware
-
-      - name: Run tests after ROM boot stage
-        if: success() || failure()
-        run: |
-          module load xilinx/vivado
-          bazel_tests="$(mktemp)"
-          ./bazelisk.sh query 'attr("tags", "[\[ ]cw340_sival[,\]]", tests(//sw/device/...))' \
-                                                    | grep -v examples \
-                                                    | grep -v penetrationtests \
-                                                    > "$bazel_tests"
-          ./bazelisk.sh test \
-            --build_tests_only \
-            --cache_test_results=no \
-            --test_tag_filters=-slow_test \
-            --target_pattern_file="$bazel_tests"
-
-      - name: Run tests after ROM_EXT boot stage
-        if: success() || failure()
-        run: |
-          module load xilinx/vivado
-          bazel_tests="$(mktemp)"
-          ./bazelisk.sh query 'attr("tags", "[\[ ]cw340_sival_rom_ext[,\]]", tests(//sw/device/...))' \
-                                                    | grep -v examples \
-                                                    | grep -v penetrationtests \
-                                                    > "$bazel_tests"
-          ./bazelisk.sh test \
-            --build_tests_only \
-            --cache_test_results=no \
-            --test_tag_filters=-slow_test \
-            --target_pattern_file="$bazel_tests"
-
-      - name: Compute bucket destination
-        id: bucket_destination
-        if: ${{ !cancelled() }}
-        run: |
-          BUCKET_PATH=$GS_PATH/job/${{ github.job }}/branch/${{ inputs.branch || 'earlgrey_1.0.0'}}/$(date +%Y-%m-%d-%H%M%S)_test_results.xml
-          echo "BUCKET_PATH=$BUCKET_PATH" >> $GITHUB_OUTPUT
-
-      - name: Publish Bazel test results
-        uses: ./.github/actions/publish-bazel-test-results
-        if: ${{ !cancelled() }}
-        with:
-          artifact-name: fpga_cw340_sival_nightly-test-results
-          bucket-destination: ${{ steps.bucket_destination.outputs.BUCKET_PATH }}
-
-  fpga_cw340_slow_sival_nightly:
-    name: FPGA CW340 slow SiVal tests
-    runs-on: [ubuntu-22.04-fpga, cw340]
-
-    env:
-      GS_PATH: opentitan-test-results
-      BAZEL_TEST_RESULTS: test_results.xml
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Required for the bitstream cache to work.
-          ref: ${{ inputs.branch || 'earlgrey_1.0.0' }} # Schedule only work on the default branch, but we want to run on a different branch.
-
-      - name: Prepare environment
-        uses: ./.github/actions/prepare-env
-        with:
-          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
-
-      - name: Update hyperdebug
-        run: |
-          ./bazelisk.sh run //sw/host/opentitantool -- --interface=hyperdebug_dfu transport update-firmware
-
-      - name: Run tests
-        if: success() || failure()
-        run: |
-          module load xilinx/vivado
-          bazel_tests="$(mktemp)"
-
-          ./bazelisk.sh query 'attr("tags", "[\[ ]cw340_sival_rom_ext[,\]]", tests(//sw/device/...))' \
-                      'intersect attr("tags", "slow_test", tests(//sw/device/...))' \
-                                                                  | grep -v examples \
-                                                                  | grep -v penetrationtests \
-                                                                  > "$bazel_tests"
-
-          ./bazelisk.sh test \
-            --build_tests_only \
-            --cache_test_results=no \
-            --target_pattern_file="$bazel_tests"
-
-      - name: Compute bucket destination
-        id: bucket_destination
-        if: ${{ !cancelled() }}
-        run: |
-          BUCKET_PATH=$GS_PATH/job/${{ github.job }}/branch/${{ inputs.branch || 'earlgrey_1.0.0'}}/$(date +%Y-%m-%d-%H%M%S)_test_results.xml
-          echo "BUCKET_PATH=$BUCKET_PATH" >> $GITHUB_OUTPUT
-
-      - name: Publish Bazel test results
-        uses: ./.github/actions/publish-bazel-test-results
-        if: ${{ !cancelled() }}
-        with:
-          artifact-name: fpga_cw340_slow_sival_nightly-test-results
-          bucket-destination: ${{ steps.bucket_destination.outputs.BUCKET_PATH }}
-
-  rom_e2e:
-    name: ROM E2E Tests
-    runs-on: [ubuntu-22.04-fpga, cw310]
-    timeout-minutes: 180
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Required for the bitstream cache to work.
-      - name: Prepare environment
-        uses: ./.github/actions/prepare-env
-        with:
-          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
-      - name: Run all ROM E2E tests
-        run: |
-          module load "xilinx/vivado/${VIVADO_VERSION}"
-          ./bazelisk.sh test \
-            --define DISABLE_VERILATOR_BUILD=true \
-            --define bitstream=gcp_splice \
-            --test_tag_filters=-verilator,-dv,-broken \
-            --build_tests_only \
-            --cache_test_results=no \
-            --test_output=errors \
-            //sw/device/silicon_creator/rom/e2e/...
-      - name: Publish Bazel test results
-        uses: ./.github/actions/publish-bazel-test-results
-        if: ${{ !cancelled() }}
-        with:
-          artifact-name: rom_e2e-test-results
+  execute_fpga_cw340_sival_rom_ext_tests:
+    name: CW340 SiVal ROM_EXT Tests
+    needs: chip_earlgrey_cw340
+    uses: ./.github/workflows/fpga.yml
+    secrets: inherit
+    with:
+      job_name: execute_fpga_cw340_sival_rom_ext_tests
+      bitstream: chip_earlgrey_cw340
+      board: cw340
+      interface: cw340
+      tag_filters: cw340_sival_rom_ext,-broken,-manual
+      add_default_filters: false
+      cache_test_results: false
+      timeout: 90
 
   slow_otbn_crypto_tests:
     name: Slow OTBN Crypto Tests
@@ -261,43 +226,3 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           artifact-name: slow_otbn_crypto_tests-test-results
-
-  bob_spi_i2c:
-    name: "BoB: SPI and I2C Tests"
-    runs-on: [ubuntu-22.04-fpga, cw310]
-    timeout-minutes: 180
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Required for the bitstream cache to work.
-      - name: Prepare environment
-        uses: ./.github/actions/prepare-env
-        with:
-          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
-      - name: Run the PMOD tests with Test ROM
-        run: |
-          module load "xilinx/vivado/${VIVADO_VERSION}"
-          ./bazelisk.sh test \
-            --define DISABLE_VERILATOR_BUILD=true \
-            --define bitstream=gcp_splice \
-            --build_tests_only \
-            --cache_test_results=no \
-            --test_output=errors \
-            --test_tag_filters="cw310_test_rom" \
-            $(./bazelisk.sh query 'attr("tags", "[\[ ]pmod[,\]]", tests(//...))')
-      - name: Run the PMOD tests for SiVal
-        run: |
-          module load "xilinx/vivado/${VIVADO_VERSION}"
-          ./bazelisk.sh test \
-            --define DISABLE_VERILATOR_BUILD=true \
-            --define bitstream=gcp_splice \
-            --build_tests_only \
-            --cache_test_results=no \
-            --test_output=errors \
-            --test_tag_filters=cw310_sival,-broken \
-            $(./bazelisk.sh query 'attr("tags", "[\[ ]pmod[,\]]", tests(//...))')
-      - name: Publish Bazel test results
-        uses: ./.github/actions/publish-bazel-test-results
-        if: ${{ !cancelled() }}
-        with:
-          artifact-name: bob_spi_i2c-test-results

--- a/ci/scripts/run-fpga-tests.sh
+++ b/ci/scripts/run-fpga-tests.sh
@@ -9,12 +9,13 @@ set -e
 . util/build_consts.sh
 
 if [ $# == 0 ]; then
-    echo >&2 "Usage: run-fpga-tests.sh <fpga> <target_pattern_file>"
-    echo >&2 "E.g. ./run-fpga-tests.sh cw310 list_of_test.txt"
+    echo >&2 "Usage: run-fpga-tests.sh <fpga> <target_pattern_file> [bazel options...]"
+    echo >&2 "E.g. ./run-fpga-tests.sh cw310 list_of_test.txt --cache_test_results=no"
     exit 1
 fi
 fpga="$1"
 target_pattern_file="$2"
+shift 2
 
 # Copy bitstreams and related files into the cache directory so Bazel will have
 # the corresponding targets in the @bitstreams workspace.
@@ -55,4 +56,4 @@ trap './bazelisk.sh run //sw/host/opentitantool -- --rcfile= --interface=${fpga}
     --build_tests_only \
     --define "$fpga"=lowrisc \
     --flaky_test_attempts=2 \
-    --target_pattern_file="${target_pattern_file}"
+    --target_pattern_file="${target_pattern_file}" "$@"

--- a/sw/device/tests/pmod/BUILD
+++ b/sw/device/tests/pmod/BUILD
@@ -32,6 +32,7 @@ fpga_cw310(
     base = "//hw/top_earlgrey:fpga_cw310_sival_rom_ext",
     # Override the hyperdebug bitstream, interface, and OTP & ROM MMIs.
     base_bitstream = "//hw/bitstream:bitstream",
+    exec_env = "fpga_cw310_sival_rom_ext_no_hyper",
     mmi = "//hw/bitstream:cw310_mmi",
     param = {
         "interface": "cw310",
@@ -46,19 +47,8 @@ opentitan_test(
     name = "spi_host_macronix1Gb_flash_test",
     srcs = ["spi_host_macronix1Gb_flash_test.c"],
     exec_env = dicts.add(
-        dicts.omit(
-            EARLGREY_TEST_ENVS,
-            # Requires special SiVal ROM EXT environment
-            ["//hw/top_earlgrey:fpga_cw310_sival_rom_ext"],
-        ),
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
-        {
-            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-            # Custom execution environment must be used for SiVal ROM EXT
-            # to ensure that all the PMOD pins are available.
-            ":top_earlgrey_fpga_cw310_sival_rom_ext_no_hyper": "sival_rom_ext_no_hyper",
-        },
+        {":top_earlgrey_fpga_cw310_sival_rom_ext_no_hyper": None},
     ),
     fpga = fpga_params(
         tags = [
@@ -67,16 +57,7 @@ opentitan_test(
         ],  # Requires the PMOD::BoB.
     ),
     silicon = silicon_params(
-        tags = [
-            "pmod",
-        ],  # Requires the PMOD::BoB.
-    ),
-    sival_rom_ext_no_hyper = fpga_params(
-        tags = [
-            "cw310_sival_rom_ext",
-            "manual",
-            "pmod",
-        ],  # Requires the PMOD::BoB.
+        tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
         "//hw/top:dt",
@@ -99,15 +80,18 @@ opentitan_test(
 opentitan_test(
     name = "spi_host_macronix128Mb_flash_test",
     srcs = ["spi_host_macronix128Mb_flash_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {":top_earlgrey_fpga_cw310_sival_rom_ext_no_hyper": None},
+    ),
     fpga = fpga_params(
         tags = [
             "manual",
             "pmod",
         ],  # Requires the PMOD::BoB.
+    ),
+    silicon = silicon_params(
+        tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
         "//hw/top:dt",
@@ -130,15 +114,18 @@ opentitan_test(
 opentitan_test(
     name = "spi_host_gigadevice256Mb_flash_test",
     srcs = ["spi_host_gigadevice256Mb_flash_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {":top_earlgrey_fpga_cw310_sival_rom_ext_no_hyper": None},
+    ),
     fpga = fpga_params(
         tags = [
             "manual",
             "pmod",
         ],  # Requires the PMOD::BoB.
+    ),
+    silicon = silicon_params(
+        tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
         "//hw/top:dt",
@@ -162,15 +149,18 @@ opentitan_test(
 opentitan_test(
     name = "spi_host_gigadevice1Gb_flash_test",
     srcs = ["spi_host_gigadevice1Gb_flash_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {":top_earlgrey_fpga_cw310_sival_rom_ext_no_hyper": None},
+    ),
     fpga = fpga_params(
         tags = [
             "manual",
             "pmod",
         ],  # Requires the PMOD::BoB.
+    ),
+    silicon = silicon_params(
+        tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
         "//hw/top:dt",
@@ -194,15 +184,18 @@ opentitan_test(
 opentitan_test(
     name = "spi_host_issi256Mb_flash_test",
     srcs = ["spi_host_issi256Mb_flash_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {":top_earlgrey_fpga_cw310_sival_rom_ext_no_hyper": None},
+    ),
     fpga = fpga_params(
         tags = [
             "manual",
             "pmod",
         ],  # Requires the PMOD::BoB.
+    ),
+    silicon = silicon_params(
+        tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
         "//hw/top:dt",
@@ -226,15 +219,18 @@ opentitan_test(
 opentitan_test(
     name = "spi_host_micron512Mb_flash_test",
     srcs = ["spi_host_micron512Mb_flash_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {":top_earlgrey_fpga_cw310_sival_rom_ext_no_hyper": None},
+    ),
     fpga = fpga_params(
         tags = [
             "manual",
             "pmod",
         ],  # Requires the PMOD::BoB.
+    ),
+    silicon = silicon_params(
+        tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
         "//hw/top:dt",
@@ -258,15 +254,18 @@ opentitan_test(
 opentitan_test(
     name = "spi_host_winbond1Gb_flash_test",
     srcs = ["spi_host_winbond1Gb_flash_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {":top_earlgrey_fpga_cw310_sival_rom_ext_no_hyper": None},
+    ),
     fpga = fpga_params(
         tags = [
             "manual",
             "pmod",
         ],  # Requires the PMOD::BoB.
+    ),
+    silicon = silicon_params(
+        tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
         "//hw/top:dt",
@@ -290,15 +289,18 @@ opentitan_test(
 opentitan_test(
     name = "i2c_host_accelerometer_test",
     srcs = ["i2c_host_accelerometer_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {":top_earlgrey_fpga_cw310_sival_rom_ext_no_hyper": None},
+    ),
     fpga = fpga_params(
         tags = [
             "manual",
             "pmod",
         ],  # Requires the PMOD::BoB.
+    ),
+    silicon = silicon_params(
+        tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -318,15 +320,18 @@ opentitan_test(
 opentitan_test(
     name = "i2c_host_ambient_light_detector_test",
     srcs = ["i2c_host_ambient_light_detector_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {":top_earlgrey_fpga_cw310_sival_rom_ext_no_hyper": None},
+    ),
     fpga = fpga_params(
         tags = [
             "manual",
             "pmod",
         ],  # Requires the PMOD::BoB.
+    ),
+    silicon = silicon_params(
+        tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -346,15 +351,18 @@ opentitan_test(
 opentitan_test(
     name = "i2c_host_hdc1080_humidity_temp_test",
     srcs = ["i2c_host_hdc1080_humidity_temp_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {":top_earlgrey_fpga_cw310_sival_rom_ext_no_hyper": None},
+    ),
     fpga = fpga_params(
         tags = [
             "manual",
             "pmod",
         ],  # Requires the PMOD::BoB.
+    ),
+    silicon = silicon_params(
+        tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -374,15 +382,18 @@ opentitan_test(
 opentitan_test(
     name = "i2c_host_clock_stretching_test",
     srcs = ["i2c_host_clock_stretching_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {":top_earlgrey_fpga_cw310_sival_rom_ext_no_hyper": None},
+    ),
     fpga = fpga_params(
         tags = [
             "manual",
             "pmod",
         ],  # Requires the PMOD::BoB.
+    ),
+    silicon = silicon_params(
+        tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -404,15 +415,18 @@ opentitan_test(
 opentitan_test(
     name = "i2c_host_compass_test",
     srcs = ["i2c_host_compass_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {":top_earlgrey_fpga_cw310_sival_rom_ext_no_hyper": None},
+    ),
     fpga = fpga_params(
         tags = [
             "manual",
             "pmod",
         ],  # Requires the PMOD::BoB.
+    ),
+    silicon = silicon_params(
+        tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -434,12 +448,8 @@ opentitan_test(
     name = "i2c_host_eeprom_test",
     srcs = ["i2c_host_eeprom_test.c"],
     exec_env = dicts.add(
-        EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
-        {
-            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        },
+        {":top_earlgrey_fpga_cw310_sival_rom_ext_no_hyper": None},
     ),
     fpga = fpga_params(
         tags = [
@@ -448,9 +458,7 @@ opentitan_test(
         ],  # Requires the PMOD::BoB.
     ),
     silicon = silicon_params(
-        tags = [
-            "pmod",
-        ],  # Requires the PMOD::BoB.
+        tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -471,11 +479,8 @@ opentitan_test(
     name = "i2c_host_fram_test",
     srcs = ["i2c_host_fram_test.c"],
     exec_env = dicts.add(
-        EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
-        {
-            "//hw/top_earlgrey:fpga_cw310_sival": None,
-        },
+        {":top_earlgrey_fpga_cw310_sival_rom_ext_no_hyper": None},
     ),
     fpga = fpga_params(
         tags = [
@@ -484,9 +489,7 @@ opentitan_test(
         ],  # Requires the PMOD::BoB.
     ),
     silicon = silicon_params(
-        tags = [
-            "pmod",
-        ],  # Requires the PMOD::BoB.
+        tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     # This test can take > 40 minutes, so mark it manual as it shouldn't run
     # in CI/nightlies.
@@ -509,15 +512,18 @@ opentitan_test(
 opentitan_test(
     name = "i2c_host_gas_sensor_test",
     srcs = ["i2c_host_gas_sensor_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {":top_earlgrey_fpga_cw310_sival_rom_ext_no_hyper": None},
+    ),
     fpga = fpga_params(
         tags = [
             "manual",
             "pmod",
         ],  # Requires the PMOD::BoB.
+    ),
+    silicon = silicon_params(
+        tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -537,15 +543,18 @@ opentitan_test(
 opentitan_test(
     name = "i2c_host_power_monitor_test",
     srcs = ["i2c_host_power_monitor_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {":top_earlgrey_fpga_cw310_sival_rom_ext_no_hyper": None},
+    ),
     fpga = fpga_params(
         tags = [
             "manual",
             "pmod",
         ],  # Requires the PMOD::BoB.
+    ),
+    silicon = silicon_params(
+        tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -565,15 +574,18 @@ opentitan_test(
 opentitan_test(
     name = "i2c_host_irq_test",
     srcs = ["i2c_host_irq_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {":top_earlgrey_fpga_cw310_sival_rom_ext_no_hyper": None},
+    ),
     fpga = fpga_params(
         tags = [
             "manual",
             "pmod",
         ],  # Requires the PMOD::BoB.
+    ),
+    silicon = silicon_params(
+        tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",


### PR DESCRIPTION
The FPGA jobs in nightly are reworked to use our reusable workflows.

* Every FPGA Bazel test is now executed.
* Bitstreams are built if needed.
* The Bazel cache is now available.

Normal CI only runs one version of each FPGA test. We run all execution environments of each test in nightlies to prevent regressions. Building bitstreams as-needed here lets (eventually) disable the non-HyperDebug bitstream build in regular CI, reducing load.

Example nightly run: https://github.com/lowRISC/opentitan/actions/runs/16312373557