### PR TITLE
[rom_ext] adding sig test rule with script

### DIFF
--- a/rules/tests/BUILD
+++ b/rules/tests/BUILD
@@ -4,7 +4,41 @@
 
 load("//rules/tests:const_unittest.bzl", "const_test_suite")
 load("//rules/tests:otp_unittest.bzl", "otp_test_suite")
+load("//rules:signing.bzl", "signature_test")
 
 const_test_suite()
 
 otp_test_suite()
+
+signature_test(
+    name = "corrupt_signature_test",
+    srcs = [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted_fpga_cw310_rom_with_fake_keys.fake_ecdsa_prod_key_0.signed.bin",
+    ],
+    negative_test = True,
+)
+
+signature_test(
+    name = "wrong_ecdsa_key_test",
+    srcs = ["//sw/device/silicon_creator/rom_ext:signed_spx_binaries"],
+    ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:dev_key_0_ecdsa_p256": "dev_key_0"},
+    negative_test = True,
+)
+
+signature_test(
+    name = "wrong_spx_key_test",
+    srcs = ["//sw/device/silicon_creator/rom_ext:signed_spx_binaries"],
+    negative_test = True,
+    spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:dev_key_0_spx": "dev_key_0"},
+)
+
+signature_test(
+    name = "wrong_domain_signature_test",
+    srcs = [
+        "//sw/device/silicon_creator/rom_ext:signed_spx_binaries",
+    ],
+    ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
+    negative_test = True,
+    spx_domain = "PrehashedSha256",  # "Pure", "PrehashedSha256"
+    spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx_key": "prod_spx_0"},
+)

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -17,8 +17,26 @@ load(
     "TEST_OWNER_CONFIGS",
 )
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("//rules:signing.bzl", "signature_test")
 
 package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "signed_spx_binaries",
+    testonly = True,
+    srcs = ["//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a"],
+    output_group = "fpga_cw310_signed_bin",
+)
+
+signature_test(
+    name = "rom_ext_signature_test",
+    srcs = [
+        ":signed_spx_binaries",
+    ],
+    ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
+    spx_domain = "Pure",  # "Pure", "PrehashedSha256"
+    spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx_key": "prod_spx_0"},
+)
 
 string_flag(
     name = "secver_write",

--- a/sw/device/silicon_creator/rom_ext/sival/binaries/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/binaries/BUILD
@@ -4,6 +4,7 @@
 
 load("//rules/opentitan:cc.bzl", "exec_env_filegroup")
 load("//rules:files.bzl", "copy_files")
+load("//rules:signing.bzl", "signature_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -45,4 +46,16 @@ exec_env_filegroup(
         "rom_ext_dice_cwt_prod_slot_virtual_fpga_cw340.signed.bin": "cw340",
         "rom_ext_dice_cwt_prod_slot_virtual_silicon_creator.signed.bin": "silicon",
     },
+)
+
+filegroup(
+    name = "signed_binaries",
+    srcs = glob(["*.signed.bin"]),
+)
+
+signature_test(
+    name = "sival_signature_test",
+    srcs = [
+        ":signed_binaries",
+    ],
 )


### PR DESCRIPTION
feat: Adding a signature verify test to check signed binaries

The intent is to have a way to verify a signed binary is good. One case is checking they are good before committing them into CI

test: run bazel test and verify no error found
