### PR TITLE
[fpv] Added synthesis_optimized script

### DIFF
--- a/hw/formal/tools/jaspergold/fpv.tcl
+++ b/hw/formal/tools/jaspergold/fpv.tcl
@@ -227,6 +227,10 @@ report
 
 if {$env(COV) == 1} {
   check_cov -measure -all -time_limit 2h
+  # Waive the synthesis_optimized cover items
+  set file $env(JG_TCL_DIR)/synthesis_optimized.tcl
+  puts "Waiving items optimized in synthesis from $file"
+  source $file
   check_cov -report -force -exclude { reset waived }
   check_cov -report -no_return -report_file cover.html \
       -html -force -exclude { reset waived }

--- a/hw/formal/tools/jaspergold/jaspergold.hjson
+++ b/hw/formal/tools/jaspergold/jaspergold.hjson
@@ -10,7 +10,10 @@
   // If this line is not seen in the log, then fail the test.
   build_pass_patterns: ["^INFO: Proof threads stopped\\.$"]
 
+  jg_tcl_dir: "{formal_root}/tools/{tool}"
+
   exports: [
-    {COMMON_MSG_TCL_PATH: "{formal_root}/tools/{tool}/jaspergold_common_message_process.tcl"}
+    {JG_TCL_DIR: "{jg_tcl_dir}"},
+    {COMMON_MSG_TCL_PATH: "{jg_tcl_dir}/jaspergold_common_message_process.tcl"}
   ]
 }

--- a/hw/formal/tools/jaspergold/synthesis_optimized.tcl
+++ b/hw/formal/tools/jaspergold/synthesis_optimized.tcl
@@ -1,0 +1,12 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+set all_cids [check_cov -list -cid]
+set non_optimized_cids [check_cov -list -exclude synthesis_optimized -cid]
+
+foreach cid $all_cids {
+  if {[lsearch -exact $non_optimized_cids $cid] == -1} {
+    check_cov -waiver -add -cover_item_id $cid -comment "Optimized in synthesis"
+  }
+}

--- a/hw/ip_templates/rv_plic/fpv/tb/coverage.tcl
+++ b/hw/ip_templates/rv_plic/fpv/tb/coverage.tcl
@@ -33,21 +33,6 @@ check_cov -waiver -add -source_file {src/lowrisc_prim_subreg_0/rtl/prim_subreg.s
  58 -end_line 58 -type {branch} -comment {wr_en is true and the branch doesn't contain the else\
  part}
 
-# The waivers below are waiving the branch and statement (inside those branches) in mubi(4-16)_and
-# function in prim_mubi_pkg used in rv_plic_csr_assert_fpv. Since, rv_plic registers doesn't have
-# any regwen types therefore all the mubi(4-16)_and functions are unused.
-check_cov -waiver -add -start_line 119 -end_line 139 -instance {prim_mubi_pkg} -comment {Unused\
- code block}
-
-check_cov -waiver -add -start_line 258 -end_line 278 -instance {prim_mubi_pkg} -comment {Unused\
- code block}
-
-check_cov -waiver -add -start_line 397 -end_line 417 -instance {prim_mubi_pkg} -comment {Unused\
- code block}
-
-check_cov -waiver -add -start_line 536 -end_line 556 -instance {prim_mubi_pkg} -comment {Unused\
- code block}
-
 # These two blocking assignment appear as undetectable and making an assertion for them looks
 # unreasonable as for this particular instance, they will always be generated as zero.
 check_cov -waiver -add -start_line 67 -end_line 68 -type {statement} -instance\

--- a/hw/top_darjeeling/ip_autogen/rv_plic/fpv/tb/coverage.tcl
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/fpv/tb/coverage.tcl
@@ -33,21 +33,6 @@ check_cov -waiver -add -source_file {src/lowrisc_prim_subreg_0/rtl/prim_subreg.s
  58 -end_line 58 -type {branch} -comment {wr_en is true and the branch doesn't contain the else\
  part}
 
-# The waivers below are waiving the branch and statement (inside those branches) in mubi(4-16)_and
-# function in prim_mubi_pkg used in rv_plic_csr_assert_fpv. Since, rv_plic registers doesn't have
-# any regwen types therefore all the mubi(4-16)_and functions are unused.
-check_cov -waiver -add -start_line 119 -end_line 139 -instance {prim_mubi_pkg} -comment {Unused\
- code block}
-
-check_cov -waiver -add -start_line 258 -end_line 278 -instance {prim_mubi_pkg} -comment {Unused\
- code block}
-
-check_cov -waiver -add -start_line 397 -end_line 417 -instance {prim_mubi_pkg} -comment {Unused\
- code block}
-
-check_cov -waiver -add -start_line 536 -end_line 556 -instance {prim_mubi_pkg} -comment {Unused\
- code block}
-
 # These two blocking assignment appear as undetectable and making an assertion for them looks
 # unreasonable as for this particular instance, they will always be generated as zero.
 check_cov -waiver -add -start_line 67 -end_line 68 -type {statement} -instance\

--- a/hw/top_earlgrey/ip_autogen/rv_plic/fpv/tb/coverage.tcl
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/fpv/tb/coverage.tcl
@@ -33,21 +33,6 @@ check_cov -waiver -add -source_file {src/lowrisc_prim_subreg_0/rtl/prim_subreg.s
  58 -end_line 58 -type {branch} -comment {wr_en is true and the branch doesn't contain the else\
  part}
 
-# The waivers below are waiving the branch and statement (inside those branches) in mubi(4-16)_and
-# function in prim_mubi_pkg used in rv_plic_csr_assert_fpv. Since, rv_plic registers doesn't have
-# any regwen types therefore all the mubi(4-16)_and functions are unused.
-check_cov -waiver -add -start_line 119 -end_line 139 -instance {prim_mubi_pkg} -comment {Unused\
- code block}
-
-check_cov -waiver -add -start_line 258 -end_line 278 -instance {prim_mubi_pkg} -comment {Unused\
- code block}
-
-check_cov -waiver -add -start_line 397 -end_line 417 -instance {prim_mubi_pkg} -comment {Unused\
- code block}
-
-check_cov -waiver -add -start_line 536 -end_line 556 -instance {prim_mubi_pkg} -comment {Unused\
- code block}
-
 # These two blocking assignment appear as undetectable and making an assertion for them looks
 # unreasonable as for this particular instance, they will always be generated as zero.
 check_cov -waiver -add -start_line 67 -end_line 68 -type {statement} -instance\

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/tb/coverage.tcl
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/tb/coverage.tcl
@@ -33,21 +33,6 @@ check_cov -waiver -add -source_file {src/lowrisc_prim_subreg_0/rtl/prim_subreg.s
  58 -end_line 58 -type {branch} -comment {wr_en is true and the branch doesn't contain the else\
  part}
 
-# The waivers below are waiving the branch and statement (inside those branches) in mubi(4-16)_and
-# function in prim_mubi_pkg used in rv_plic_csr_assert_fpv. Since, rv_plic registers doesn't have
-# any regwen types therefore all the mubi(4-16)_and functions are unused.
-check_cov -waiver -add -start_line 119 -end_line 139 -instance {prim_mubi_pkg} -comment {Unused\
- code block}
-
-check_cov -waiver -add -start_line 258 -end_line 278 -instance {prim_mubi_pkg} -comment {Unused\
- code block}
-
-check_cov -waiver -add -start_line 397 -end_line 417 -instance {prim_mubi_pkg} -comment {Unused\
- code block}
-
-check_cov -waiver -add -start_line 536 -end_line 556 -instance {prim_mubi_pkg} -comment {Unused\
- code block}
-
 # These two blocking assignment appear as undetectable and making an assertion for them looks
 # unreasonable as for this particular instance, they will always be generated as zero.
 check_cov -waiver -add -start_line 67 -end_line 68 -type {statement} -instance\


### PR DESCRIPTION
The cover items that are optimized in synthesis are
undetectable/deadcode in the stimuli coverage and
out of COI in the checker. They will remain
uncovered even if we try to cover them by writing
related assertions.