### PR TITLE
[test]: fix early return due to incorrect indent

### DIFF
--- a/sw/host/cryptotest/testvectors/parsers/wycheproof_ed25519_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/wycheproof_ed25519_parser.py
@@ -44,7 +44,7 @@ def parse_test_vectors(raw_data):
 
             test_vectors.append(test_vec)
 
-        return test_vectors
+    return test_vectors
 
 
 def main():


### PR DESCRIPTION
Fix indentation of the return statement (was in the outer for-loop, should be outside the for-loop).
The functions resturned after the first test group iteration. Tests from following test groups were not added to test_vectors.

Only 9 tests out of 150 were added to test_vectors.