### PR TITLE
[crypto] Wipe OTBN's DMEM in failure cases

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/p256.c
+++ b/sw/device/lib/crypto/impl/ecc/p256.c
@@ -132,18 +132,20 @@ status_t p256_sideload_keygen_start(void) {
 status_t p256_keygen_finalize(p256_masked_scalar_t *private_key,
                               p256_point_t *public_key) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY(otbn_busy_wait_for_done());
+  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
   HARDENED_CHECK_EQ(otbn_instruction_count_get(), kModeKeygenInsCnt);
 
   // Read the masked private key from OTBN dmem.
-  HARDENED_TRY(otbn_dmem_read(kP256MaskedScalarShareWords, kOtbnVarD0,
-                              private_key->share0));
-  HARDENED_TRY(otbn_dmem_read(kP256MaskedScalarShareWords, kOtbnVarD1,
-                              private_key->share1));
+  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(kP256MaskedScalarShareWords, kOtbnVarD0,
+                                        private_key->share0));
+  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(kP256MaskedScalarShareWords, kOtbnVarD1,
+                                        private_key->share1));
 
   // Read the public key from OTBN dmem.
-  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarX, public_key->x));
-  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarY, public_key->y));
+  HARDENED_TRY_WIPE_DMEM(
+      otbn_dmem_read(kP256CoordWords, kOtbnVarX, public_key->x));
+  HARDENED_TRY_WIPE_DMEM(
+      otbn_dmem_read(kP256CoordWords, kOtbnVarY, public_key->y));
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();
@@ -151,12 +153,14 @@ status_t p256_keygen_finalize(p256_masked_scalar_t *private_key,
 
 status_t p256_sideload_keygen_finalize(p256_point_t *public_key) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY(otbn_busy_wait_for_done());
+  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
   HARDENED_CHECK_EQ(otbn_instruction_count_get(), kModeKeygenSideloadInsCnt);
 
   // Read the public key from OTBN dmem.
-  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarX, public_key->x));
-  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarY, public_key->y));
+  HARDENED_TRY_WIPE_DMEM(
+      otbn_dmem_read(kP256CoordWords, kOtbnVarX, public_key->x));
+  HARDENED_TRY_WIPE_DMEM(
+      otbn_dmem_read(kP256CoordWords, kOtbnVarY, public_key->y));
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();
@@ -224,7 +228,7 @@ status_t p256_ecdsa_sideload_sign_start(
 status_t p256_ecdsa_sign_finalize(p256_ecdsa_signature_t *result) {
   uint32_t ins_cnt;
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY(otbn_busy_wait_for_done());
+  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
   ins_cnt = otbn_instruction_count_get();
   if (launder32(ins_cnt) == kModeEcdsaSignSideloadInsCnt) {
     HARDENED_CHECK_EQ(ins_cnt, kModeEcdsaSignSideloadInsCnt);
@@ -233,10 +237,12 @@ status_t p256_ecdsa_sign_finalize(p256_ecdsa_signature_t *result) {
   }
 
   // Read signature R out of OTBN dmem.
-  HARDENED_TRY(otbn_dmem_read(kP256ScalarWords, kOtbnVarR, result->r));
+  HARDENED_TRY_WIPE_DMEM(
+      otbn_dmem_read(kP256ScalarWords, kOtbnVarR, result->r));
 
   // Read signature S out of OTBN dmem.
-  HARDENED_TRY(otbn_dmem_read(kP256ScalarWords, kOtbnVarS, result->s));
+  HARDENED_TRY_WIPE_DMEM(
+      otbn_dmem_read(kP256ScalarWords, kOtbnVarS, result->s));
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();
@@ -274,20 +280,21 @@ status_t p256_ecdsa_verify_start(const p256_ecdsa_signature_t *signature,
 status_t p256_ecdsa_verify_finalize(const p256_ecdsa_signature_t *signature,
                                     hardened_bool_t *result) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY(otbn_busy_wait_for_done());
+  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
 
   // Read the status code out of DMEM (false if basic checks on the validity of
   // the signature and public key failed).
   uint32_t ok;
-  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarOk, &ok));
+  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(1, kOtbnVarOk, &ok));
   if (launder32(ok) != kHardenedBoolTrue) {
+    HARDENED_TRY(otbn_dmem_sec_wipe());
     return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_CHECK_EQ(ok, kHardenedBoolTrue);
 
   // Read x_r (recovered R) out of OTBN dmem.
   uint32_t x_r[kP256ScalarWords];
-  HARDENED_TRY(otbn_dmem_read(kP256ScalarWords, kOtbnVarXr, x_r));
+  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(kP256ScalarWords, kOtbnVarXr, x_r));
 
   *result = hardened_memeq(x_r, signature->r, kP256ScalarWords);
 
@@ -320,7 +327,7 @@ status_t p256_ecdh_start(const p256_masked_scalar_t *private_key,
 status_t p256_ecdh_finalize(p256_ecdh_shared_key_t *shared_key) {
   uint32_t ins_cnt;
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY(otbn_busy_wait_for_done());
+  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
   ins_cnt = otbn_instruction_count_get();
   if (launder32(ins_cnt) == kModeEcdhSideloadInsCnt) {
     HARDENED_CHECK_EQ(ins_cnt, kModeEcdhSideloadInsCnt);
@@ -330,15 +337,18 @@ status_t p256_ecdh_finalize(p256_ecdh_shared_key_t *shared_key) {
 
   // Read the code indicating if the public key is valid.
   uint32_t ok;
-  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarOk, &ok));
+  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(1, kOtbnVarOk, &ok));
   if (launder32(ok) != kHardenedBoolTrue) {
+    HARDENED_TRY(otbn_dmem_sec_wipe());
     return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_CHECK_EQ(ok, kHardenedBoolTrue);
 
   // Read the shares of the key from OTBN dmem (at vars x and y).
-  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarX, shared_key->share0));
-  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarY, shared_key->share1));
+  HARDENED_TRY_WIPE_DMEM(
+      otbn_dmem_read(kP256CoordWords, kOtbnVarX, shared_key->share0));
+  HARDENED_TRY_WIPE_DMEM(
+      otbn_dmem_read(kP256CoordWords, kOtbnVarY, shared_key->share1));
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();

--- a/sw/device/lib/crypto/impl/ecc/p384.c
+++ b/sw/device/lib/crypto/impl/ecc/p384.c
@@ -173,18 +173,20 @@ status_t p384_keygen_start(void) {
 status_t p384_keygen_finalize(p384_masked_scalar_t *private_key,
                               p384_point_t *public_key) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY(otbn_busy_wait_for_done());
+  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
   HARDENED_CHECK_EQ(otbn_instruction_count_get(), kModeKeygenInsCnt);
 
   // Read the masked private key from OTBN dmem.
-  HARDENED_TRY(otbn_dmem_read(kP384MaskedScalarShareWords, kOtbnVarD0,
-                              private_key->share0));
-  HARDENED_TRY(otbn_dmem_read(kP384MaskedScalarShareWords, kOtbnVarD1,
-                              private_key->share1));
+  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(kP384MaskedScalarShareWords, kOtbnVarD0,
+                                        private_key->share0));
+  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(kP384MaskedScalarShareWords, kOtbnVarD1,
+                                        private_key->share1));
 
   // Read the public key from OTBN dmem.
-  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarX, public_key->x));
-  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarY, public_key->y));
+  HARDENED_TRY_WIPE_DMEM(
+      otbn_dmem_read(kP384CoordWords, kOtbnVarX, public_key->x));
+  HARDENED_TRY_WIPE_DMEM(
+      otbn_dmem_read(kP384CoordWords, kOtbnVarY, public_key->y));
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();
@@ -204,12 +206,14 @@ status_t p384_sideload_keygen_start(void) {
 
 status_t p384_sideload_keygen_finalize(p384_point_t *public_key) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY(otbn_busy_wait_for_done());
+  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
   HARDENED_CHECK_EQ(otbn_instruction_count_get(), kModeKeygenSideloadInsCnt);
 
   // Read the public key from OTBN dmem.
-  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarX, public_key->x));
-  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarY, public_key->y));
+  HARDENED_TRY_WIPE_DMEM(
+      otbn_dmem_read(kP384CoordWords, kOtbnVarX, public_key->x));
+  HARDENED_TRY_WIPE_DMEM(
+      otbn_dmem_read(kP384CoordWords, kOtbnVarY, public_key->y));
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();
@@ -253,7 +257,7 @@ status_t p384_ecdsa_sideload_sign_start(
 status_t p384_ecdsa_sign_finalize(p384_ecdsa_signature_t *result) {
   uint32_t ins_cnt;
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY(otbn_busy_wait_for_done());
+  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
   ins_cnt = otbn_instruction_count_get();
   if (launder32(ins_cnt) == kModeEcdsaSignSideloadInsCnt) {
     HARDENED_CHECK_EQ(ins_cnt, kModeEcdsaSignSideloadInsCnt);
@@ -262,10 +266,12 @@ status_t p384_ecdsa_sign_finalize(p384_ecdsa_signature_t *result) {
   }
 
   // Read signature R out of OTBN dmem.
-  HARDENED_TRY(otbn_dmem_read(kP384ScalarWords, kOtbnVarR, result->r));
+  HARDENED_TRY_WIPE_DMEM(
+      otbn_dmem_read(kP384ScalarWords, kOtbnVarR, result->r));
 
   // Read signature S out of OTBN dmem.
-  HARDENED_TRY(otbn_dmem_read(kP384ScalarWords, kOtbnVarS, result->s));
+  HARDENED_TRY_WIPE_DMEM(
+      otbn_dmem_read(kP384ScalarWords, kOtbnVarS, result->s));
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();
@@ -300,20 +306,21 @@ status_t p384_ecdsa_verify_start(const p384_ecdsa_signature_t *signature,
 status_t p384_ecdsa_verify_finalize(const p384_ecdsa_signature_t *signature,
                                     hardened_bool_t *result) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY(otbn_busy_wait_for_done());
+  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
 
   // Read the status code out of DMEM (false if basic checks on the validity of
   // the signature and public key failed).
   uint32_t ok;
-  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarOk, &ok));
+  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(1, kOtbnVarOk, &ok));
   if (launder32(ok) != kHardenedBoolTrue) {
+    HARDENED_TRY(otbn_dmem_sec_wipe());
     return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_CHECK_EQ(ok, kHardenedBoolTrue);
 
   // Read x_r (recovered R) out of OTBN dmem.
   uint32_t x_r[kP384ScalarWords];
-  HARDENED_TRY(otbn_dmem_read(kP384ScalarWords, kOtbnVarXr, x_r));
+  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(kP384ScalarWords, kOtbnVarXr, x_r));
 
   *result = hardened_memeq(x_r, signature->r, kP384ScalarWords);
 
@@ -343,7 +350,7 @@ status_t p384_ecdh_start(const p384_masked_scalar_t *private_key,
 status_t p384_ecdh_finalize(p384_ecdh_shared_key_t *shared_key) {
   uint32_t ins_cnt;
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY(otbn_busy_wait_for_done());
+  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
   ins_cnt = otbn_instruction_count_get();
   if (launder32(ins_cnt) == kModeEcdhSideloadInsCnt) {
     HARDENED_CHECK_EQ(ins_cnt, kModeEcdhSideloadInsCnt);
@@ -354,15 +361,18 @@ status_t p384_ecdh_finalize(p384_ecdh_shared_key_t *shared_key) {
   // Read the status code out of DMEM (false if basic checks on the validity of
   // the signature and public key failed).
   uint32_t ok;
-  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarOk, &ok));
+  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(1, kOtbnVarOk, &ok));
   if (launder32(ok) != kHardenedBoolTrue) {
+    HARDENED_TRY(otbn_dmem_sec_wipe());
     return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_CHECK_EQ(ok, kHardenedBoolTrue);
 
   // Read the shares of the key from OTBN dmem (at vars x and y).
-  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarX, shared_key->share0));
-  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarY, shared_key->share1));
+  HARDENED_TRY_WIPE_DMEM(
+      otbn_dmem_read(kP384CoordWords, kOtbnVarX, shared_key->share0));
+  HARDENED_TRY_WIPE_DMEM(
+      otbn_dmem_read(kP384CoordWords, kOtbnVarY, shared_key->share1));
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();

--- a/sw/device/lib/crypto/impl/rsa/rsa_3072_verify.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_3072_verify.c
@@ -137,13 +137,14 @@ status_t rsa_3072_compute_constants(const rsa_3072_public_key_t *public_key,
   HARDENED_TRY(otbn_execute());
 
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY(otbn_busy_wait_for_done());
+  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
 
   // Read constant rr out of DMEM.
-  HARDENED_TRY(read_rsa_3072_int_from_otbn(kOtbnVarRsaRR, &result->rr));
+  HARDENED_TRY_WIPE_DMEM(
+      read_rsa_3072_int_from_otbn(kOtbnVarRsaRR, &result->rr));
 
   // Read constant m0_inv out of DMEM.
-  HARDENED_TRY(
+  HARDENED_TRY_WIPE_DMEM(
       otbn_dmem_read(kOtbnWideWordNumWords, kOtbnVarRsaM0Inv, result->m0_inv));
 
   // Wipe DMEM.
@@ -197,11 +198,11 @@ status_t rsa_3072_verify_finalize(const rsa_3072_int_t *message,
   *result = kHardenedBoolFalse;
 
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY(otbn_busy_wait_for_done());
+  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
 
   // Read recovered message out of OTBN dmem.
   rsa_3072_int_t recoveredMessage;
-  HARDENED_TRY(
+  HARDENED_TRY_WIPE_DMEM(
       read_rsa_3072_int_from_otbn(kOtbnVarRsaOutBuf, &recoveredMessage));
 
   // TODO: harden this memory comparison

--- a/sw/device/lib/crypto/impl/rsa/rsa_keygen.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_keygen.c
@@ -83,20 +83,21 @@ static status_t keygen_start(uint32_t mode) {
 static status_t keygen_finalize(uint32_t exp_mode, size_t num_words,
                                 uint32_t *n, uint32_t *d) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY(otbn_busy_wait_for_done());
+  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
 
   // Read the mode from OTBN dmem and panic if it's not as expected.
   uint32_t act_mode = 0;
-  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarRsaMode, &act_mode));
+  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(1, kOtbnVarRsaMode, &act_mode));
   if (act_mode != exp_mode) {
+    HARDENED_TRY(otbn_dmem_sec_wipe());
     return OTCRYPTO_FATAL_ERR;
   }
 
   // Read the public modulus (n) from OTBN dmem.
-  HARDENED_TRY(otbn_dmem_read(num_words, kOtbnVarRsaN, n));
+  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(num_words, kOtbnVarRsaN, n));
 
   // Read the private exponent (d) from OTBN dmem.
-  HARDENED_TRY(otbn_dmem_read(num_words, kOtbnVarRsaD, d));
+  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(num_words, kOtbnVarRsaD, d));
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();

--- a/sw/device/lib/crypto/impl/rsa/rsa_modexp.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_modexp.c
@@ -58,11 +58,11 @@ enum {
 
 status_t rsa_modexp_wait(size_t *num_words) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY(otbn_busy_wait_for_done());
+  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
 
   // Read the application mode.
   uint32_t mode;
-  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarRsaMode, &mode));
+  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(1, kOtbnVarRsaMode, &mode));
 
   *num_words = 0;
   if (mode == kMode2048Modexp || mode == kMode2048ModexpF4) {
@@ -94,7 +94,7 @@ status_t rsa_modexp_wait(size_t *num_words) {
 static status_t rsa_modexp_finalize(const size_t num_words, uint32_t *result) {
   // Wait for OTBN to complete and get the result size.
   size_t num_words_inferred;
-  HARDENED_TRY(rsa_modexp_wait(&num_words_inferred));
+  HARDENED_TRY_WIPE_DMEM(rsa_modexp_wait(&num_words_inferred));
 
   // Check that the inferred result size matches expectations.
   if (num_words != num_words_inferred) {
@@ -104,7 +104,7 @@ static status_t rsa_modexp_finalize(const size_t num_words, uint32_t *result) {
   }
 
   // Read the result.
-  HARDENED_TRY(otbn_dmem_read(num_words, kOtbnVarRsaInOut, result));
+  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(num_words, kOtbnVarRsaInOut, result));
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();

--- a/sw/device/lib/crypto/impl/sha2/sha256.c
+++ b/sw/device/lib/crypto/impl/sha2/sha256.c
@@ -87,7 +87,7 @@ static status_t process_message_buffer(sha256_otbn_ctx_t *ctx) {
 
   // Run the OTBN program.
   HARDENED_TRY(otbn_execute());
-  HARDENED_TRY(otbn_busy_wait_for_done());
+  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
 
   // Reset the message buffer counter.
   ctx->num_blocks = 0;
@@ -245,7 +245,7 @@ static status_t process_message(sha256_state_t *state, const uint8_t *msg,
   }
 
   // Read the final state from OTBN dmem.
-  HARDENED_TRY(
+  HARDENED_TRY_WIPE_DMEM(
       otbn_dmem_read(kSha256StateWords, kOtbnVarSha256State, new_state.H));
 
   // Clear OTBN's memory.

--- a/sw/device/lib/crypto/impl/sha2/sha512.c
+++ b/sw/device/lib/crypto/impl/sha2/sha512.c
@@ -135,7 +135,7 @@ static status_t process_message_buffer(sha512_otbn_ctx_t *ctx) {
 
   // Run the OTBN program.
   HARDENED_TRY(otbn_execute());
-  HARDENED_TRY(otbn_busy_wait_for_done());
+  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
 
   // Reset the message buffer counter.
   ctx->num_blocks = 0;
@@ -307,8 +307,9 @@ static status_t process_message(sha512_state_t *state, const uint8_t *msg,
   // boundaries.
   otbn_addr_t state_read_addr = kOtbnVarSha512State;
   for (size_t i = 0; i + 1 < kSha512StateWords; i += 2) {
-    HARDENED_TRY(otbn_dmem_read(1, state_read_addr, &new_state.H[i + 1]));
-    HARDENED_TRY(
+    HARDENED_TRY_WIPE_DMEM(
+        otbn_dmem_read(1, state_read_addr, &new_state.H[i + 1]));
+    HARDENED_TRY_WIPE_DMEM(
         otbn_dmem_read(1, state_read_addr + sizeof(uint32_t), &new_state.H[i]));
     state_read_addr += kOtbnWideWordNumBytes;
   }


### PR DESCRIPTION
This commit:

- Adds a couple of calls to `otbn_dmem_sec_wipe()`
- Adds a new `HARDENED_TRY_WIPE_DMEM()` macro that wipes the DMEM before returning

Closes #20050.