### PR TITLE
[rom_ctrl,rtl] Add a flop between rom_ctrl and kmac

### DIFF
--- a/hw/ip/rom_ctrl/data/rom_ctrl.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl.hjson
@@ -41,6 +41,18 @@
       expose:  "true"
     }
 
+    { name:      "FlopToKmac",
+      type:      "bit",
+      desc:      '''
+        Add a flop stage between the output of the ROM and the data that gets
+        sent to KMAC. This may break long paths in a target chip, at the cost of
+        adding chip area.
+      '''
+      local:     "true",
+      expose:    "true",
+      default:   "1'b0"
+    }
+
     { name:      "RndCnstScrNonce",
       type:      "bit [63:0]",
       desc:      "Fixed nonce used for address / data scrambling"

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -7786,6 +7786,20 @@
           name_top: RomCtrl0BootRomInitFile
         }
         {
+          name: FlopToKmac
+          desc:
+            '''
+            Add a flop stage between the output of the ROM and the data that gets
+            sent to KMAC. This may break long paths in a target chip, at the cost of
+            adding chip area.
+            '''
+          type: bit
+          default: 1'b0
+          local: "true"
+          expose: "true"
+          name_top: RomCtrl0FlopToKmac
+        }
+        {
           name: RndCnstScrNonce
           desc: Fixed nonce used for address / data scrambling
           type: bit [63:0]
@@ -7970,6 +7984,20 @@
           local: "false"
           expose: "true"
           name_top: RomCtrl1BootRomInitFile
+        }
+        {
+          name: FlopToKmac
+          desc:
+            '''
+            Add a flop stage between the output of the ROM and the data that gets
+            sent to KMAC. This may break long paths in a target chip, at the cost of
+            adding chip area.
+            '''
+          type: bit
+          default: 1'b0
+          local: "true"
+          expose: "true"
+          name_top: RomCtrl1FlopToKmac
         }
         {
           name: RndCnstScrNonce

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -7769,6 +7769,7 @@
       param_decl:
       {
         SecDisableScrambling: 1'b0
+        FlopToKmac: 1'b1
       }
       clock_connections:
       {
@@ -7794,7 +7795,7 @@
             adding chip area.
             '''
           type: bit
-          default: 1'b0
+          default: 1'b1
           local: "true"
           expose: "true"
           name_top: RomCtrl0FlopToKmac
@@ -7969,6 +7970,7 @@
       param_decl:
       {
         SecDisableScrambling: 1'b0
+        FlopToKmac: 1'b1
       }
       clock_connections:
       {
@@ -7994,7 +7996,7 @@
             adding chip area.
             '''
           type: bit
-          default: 1'b0
+          default: 1'b1
           local: "true"
           expose: "true"
           name_top: RomCtrl1FlopToKmac

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -887,7 +887,8 @@
         }
       },
       param_decl: {
-        SecDisableScrambling: "1'b0"
+        SecDisableScrambling: "1'b0",
+        FlopToKmac: "1'b1"
       }
     },
     { name: "rom_ctrl1",
@@ -913,7 +914,8 @@
         }
       },
       param_decl: {
-        SecDisableScrambling: "1'b0"
+        SecDisableScrambling: "1'b0",
+        FlopToKmac: "1'b1"
       }
     },
     { name: "dma",

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -338,6 +338,10 @@ module top_darjeeling #(
   localparam int SramCtrlMainOutstanding = 2;
   // local parameters for sram_ctrl_mbox
   localparam int SramCtrlMboxOutstanding = 2;
+  // local parameters for rom_ctrl0
+  localparam bit RomCtrl0FlopToKmac = 1'b0;
+  // local parameters for rom_ctrl1
+  localparam bit RomCtrl1FlopToKmac = 1'b0;
   // local parameters for racl_ctrl
   localparam int RaclCtrlNumSubscribingIps = 11;
 
@@ -2255,6 +2259,7 @@ module top_darjeeling #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[72:72]),
     .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .BootRomInitFile(RomCtrl0BootRomInitFile),
+    .FlopToKmac(RomCtrl0FlopToKmac),
     .RndCnstScrNonce(RndCnstRomCtrl0ScrNonce),
     .RndCnstScrKey(RndCnstRomCtrl0ScrKey),
     .SecDisableScrambling(SecRomCtrl0DisableScrambling),
@@ -2283,6 +2288,7 @@ module top_darjeeling #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[73:73]),
     .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .BootRomInitFile(RomCtrl1BootRomInitFile),
+    .FlopToKmac(RomCtrl1FlopToKmac),
     .RndCnstScrNonce(RndCnstRomCtrl1ScrNonce),
     .RndCnstScrKey(RndCnstRomCtrl1ScrKey),
     .SecDisableScrambling(SecRomCtrl1DisableScrambling),

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -339,9 +339,9 @@ module top_darjeeling #(
   // local parameters for sram_ctrl_mbox
   localparam int SramCtrlMboxOutstanding = 2;
   // local parameters for rom_ctrl0
-  localparam bit RomCtrl0FlopToKmac = 1'b0;
+  localparam bit RomCtrl0FlopToKmac = 1'b1;
   // local parameters for rom_ctrl1
-  localparam bit RomCtrl1FlopToKmac = 1'b0;
+  localparam bit RomCtrl1FlopToKmac = 1'b1;
   // local parameters for racl_ctrl
   localparam int RaclCtrlNumSubscribingIps = 11;
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -9414,6 +9414,20 @@
           name_top: RomCtrlBootRomInitFile
         }
         {
+          name: FlopToKmac
+          desc:
+            '''
+            Add a flop stage between the output of the ROM and the data that gets
+            sent to KMAC. This may break long paths in a target chip, at the cost of
+            adding chip area.
+            '''
+          type: bit
+          default: 1'b0
+          local: "true"
+          expose: "true"
+          name_top: RomCtrlFlopToKmac
+        }
+        {
           name: RndCnstScrNonce
           desc: Fixed nonce used for address / data scrambling
           type: bit [63:0]

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -264,6 +264,8 @@ module top_earlgrey #(
   localparam int unsigned EntropySrcDistrFifoDepth = 2;
   // local parameters for sram_ctrl_main
   localparam int SramCtrlMainOutstanding = 2;
+  // local parameters for rom_ctrl
+  localparam bit RomCtrlFlopToKmac = 1'b0;
 
   // Signals
   logic [56:0] mio_p2d;
@@ -2783,6 +2785,7 @@ module top_earlgrey #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[60:60]),
     .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .BootRomInitFile(RomCtrlBootRomInitFile),
+    .FlopToKmac(RomCtrlFlopToKmac),
     .RndCnstScrNonce(RndCnstRomCtrlScrNonce),
     .RndCnstScrKey(RndCnstRomCtrlScrKey),
     .SecDisableScrambling(SecRomCtrlDisableScrambling),

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -4123,6 +4123,20 @@
           name_top: RomCtrlBootRomInitFile
         }
         {
+          name: FlopToKmac
+          desc:
+            '''
+            Add a flop stage between the output of the ROM and the data that gets
+            sent to KMAC. This may break long paths in a target chip, at the cost of
+            adding chip area.
+            '''
+          type: bit
+          default: 1'b0
+          local: "true"
+          expose: "true"
+          name_top: RomCtrlFlopToKmac
+        }
+        {
           name: RndCnstScrNonce
           desc: Fixed nonce used for address / data scrambling
           type: bit [63:0]

--- a/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
@@ -168,6 +168,8 @@ module top_englishbreakfast #(
   localparam int SpiHost0NumCS = 1;
   // local parameters for sram_ctrl_main
   localparam int SramCtrlMainOutstanding = 2;
+  // local parameters for rom_ctrl
+  localparam bit RomCtrlFlopToKmac = 1'b0;
 
   // Signals
   logic [37:0] mio_p2d;
@@ -1244,6 +1246,7 @@ module top_englishbreakfast #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[23:23]),
     .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .BootRomInitFile(RomCtrlBootRomInitFile),
+    .FlopToKmac(RomCtrlFlopToKmac),
     .RndCnstScrNonce(RndCnstRomCtrlScrNonce),
     .RndCnstScrKey(RndCnstRomCtrlScrKey),
     .SecDisableScrambling(SecRomCtrlDisableScrambling),


### PR DESCRIPTION
This injects a clock edge between data coming out of the ROM and data going into KMAC to be hashed. Inserting the delay is pretty trivial: we just use a prim_fifo_sync.

There *is* an area vs. efficiency question. Because there is no pass-through, a prim_fifo_sync with depth 1 will have half throughput, because it has to alternate between taking an item and passing it on. Although, there's the bandwidth to do both on the same cycle, breaking the combinatorial path means that we can't pass the KMAC block's "ready" signal all the way back to the ROM.

This works perfectly well, but takes twice as long as you might hope.

A lazy workaround is to use Depth = 2. This is a little silly, because it uses twice as much area as necessary. But it's very easy from a coding perspective!