### PR TITLE
[keymgr_dpe,rtl] Allow a flop between keymgr_dpe and KMAC

### DIFF
--- a/hw/ip/keymgr_dpe/data/keymgr_dpe.hjson
+++ b/hw/ip/keymgr_dpe/data/keymgr_dpe.hjson
@@ -125,6 +125,16 @@
       local:     "false",
       expose:    "true",
     }
+    { name:      "FlopToKmac",
+      desc:      '''
+        If true, insert flops to break a potential long chain between
+        the active key slot and KMAC.
+      ''',
+      type:      "bit",
+      default:   "0",
+      local:     "true",
+      expose:    "true",
+    }
     // Random netlist constants
     { name:      "RndCnstLfsrSeed",
       desc:      "Compile-time random bits for initial LFSR seed",

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -6105,12 +6105,15 @@
           domain: "0"
         }
       }
+      param_decl:
+      {
+        FlopToKmac: 1'b1
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_secure
         clk_edn_i: clkmgr_aon_clocks.clk_main_secure
       }
-      param_decl: {}
       memory: {}
       param_list:
       [
@@ -6131,7 +6134,7 @@
             the active key slot and KMAC.
             '''
           type: bit
-          default: "0"
+          default: 1'b1
           local: "true"
           expose: "true"
           name_top: KeymgrDpeFlopToKmac

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -6124,6 +6124,19 @@
           name_top: KeymgrDpeKmacEnMasking
         }
         {
+          name: FlopToKmac
+          desc:
+            '''
+            If true, insert flops to break a potential long chain between
+            the active key slot and KMAC.
+            '''
+          type: bit
+          default: "0"
+          local: "true"
+          expose: "true"
+          name_top: KeymgrDpeFlopToKmac
+        }
+        {
           name: RndCnstLfsrSeed
           desc: Compile-time random bits for initial LFSR seed
           type: keymgr_pkg::lfsr_seed_t

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -767,6 +767,9 @@
       base_addr: {
         hart: "0x21140000",
       },
+      param_decl: {
+        FlopToKmac: "1'b1"
+      },
     },
     { name: "csrng",
       type: "csrng",

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -332,7 +332,7 @@ module top_darjeeling #(
   // local parameters for sram_ctrl_ret_aon
   localparam int SramCtrlRetAonOutstanding = 2;
   // local parameters for keymgr_dpe
-  localparam bit KeymgrDpeFlopToKmac = 0;
+  localparam bit KeymgrDpeFlopToKmac = 1'b1;
   // local parameters for entropy_src
   localparam int EntropySrcEsFifoDepth = 3;
   localparam int unsigned EntropySrcDistrFifoDepth = 26;

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -331,6 +331,8 @@ module top_darjeeling #(
   localparam int SpiHost0NumCS = 1;
   // local parameters for sram_ctrl_ret_aon
   localparam int SramCtrlRetAonOutstanding = 2;
+  // local parameters for keymgr_dpe
+  localparam bit KeymgrDpeFlopToKmac = 0;
   // local parameters for entropy_src
   localparam int EntropySrcEsFifoDepth = 3;
   localparam int unsigned EntropySrcDistrFifoDepth = 26;
@@ -2001,6 +2003,7 @@ module top_darjeeling #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[61:60]),
     .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .KmacEnMasking(KeymgrDpeKmacEnMasking),
+    .FlopToKmac(KeymgrDpeFlopToKmac),
     .RndCnstLfsrSeed(RndCnstKeymgrDpeLfsrSeed),
     .RndCnstLfsrPerm(RndCnstKeymgrDpeLfsrPerm),
     .RndCnstRandPerm(RndCnstKeymgrDpeRandPerm),


### PR DESCRIPTION
This should be useful in Darjeeling, where there's potentially a long path between the keymgr's active key slot and kmac's app input.