### PR TITLE
[devbundle] Create a devbundle for out-of-tree development

### DIFF
--- a/release/devbundle/BUILD
+++ b/release/devbundle/BUILD
@@ -1,0 +1,86 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules/opentitan:splice.bzl", "bitstream_splice")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
+
+package(default_visibility = ["//visibility:public"])
+
+bitstream_splice(
+    name = "bitstream_fpga_hyper310",
+    testonly = True,
+    # When the src bitstream and mmi fields are empty, the rule will use values
+    # from the exec_env.
+    exec_env = "//hw/top_earlgrey:fpga_hyper310_rom_ext",
+    otp = "//hw/bitstream/universal:none",
+    rom = "//hw/bitstream/universal:none",
+    tags = ["manual"],
+)
+
+bitstream_splice(
+    name = "bitstream_fpga_hyper340",
+    testonly = True,
+    # When the src bitstream and mmi fields are empty, the rule will use values
+    # from the exec_env.
+    exec_env = "//hw/top_earlgrey:fpga_cw340_rom_ext",
+    otp = "//hw/bitstream/universal:none",
+    rom = "//hw/bitstream/universal:none",
+    tags = ["manual"],
+)
+
+pkg_files(
+    name = "bitstreams",
+    testonly = True,
+    srcs = [
+        ":bitstream_fpga_hyper310",
+        ":bitstream_fpga_hyper340",
+    ],
+    tags = ["manual"],
+)
+
+pkg_filegroup(
+    name = "bitstreams_pkg",
+    testonly = True,
+    srcs = [
+        ":bitstreams",
+    ],
+    prefix = "bitstreams",
+    tags = ["manual"],
+)
+
+pkg_files(
+    name = "bazel",
+    srcs = [
+        "build_bazel",
+        "module_bazel",
+    ],
+    renames = {
+        "build_bazel": "BUILD.bazel",
+        "module_bazel": "MODULE.bazel",
+    },
+)
+
+# TODO(cfrantz): Implement release automation so we don't have to publish the artifact manually.
+# Upload this to the GCS bucket `artifacts.opentitan.org` and name the file
+# with a date tag (e.g. devbundle-YYYYMMDD.tar.xz).
+#
+# For example:
+# $ gcloud --acount=foo@opentitan.org \
+#       storage cp \
+#           bazel-bin/release/devbundle/devbundle.tar.xz \
+#           gs://artifacts.opentitan.org/dev_bundle/devbundle-20250718.tar.xz
+pkg_tar(
+    name = "devbundle",
+    testonly = True,
+    srcs = [
+        ":bazel",
+        ":bitstreams_pkg",
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:fpga_dev_pkg",
+        "//sw/device/silicon_creator/rom_ext:fpga_dev_pkg",
+        "//sw/host/opentitantool:package",
+    ],
+    extension = "tar.xz",
+    tags = ["manual"],
+)

--- a/release/devbundle/build_bazel
+++ b/release/devbundle/build_bazel
@@ -1,0 +1,7 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob(["**"]))

--- a/release/devbundle/module_bazel
+++ b/release/devbundle/module_bazel
@@ -1,0 +1,7 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+module(
+    name = "opentitan_devbundle",
+)

--- a/sw/device/silicon_creator/lib/ownership/keys/fake/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/keys/fake/BUILD
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 load("//rules/opentitan:keyutils.bzl", "key_ecdsa", "key_sphincs_plus")
 
 package(default_visibility = ["//visibility:public"])
@@ -161,4 +162,24 @@ key_ecdsa(
     private_key = "app_unauthorized_ecdsa_p256.der",
     pub_key = "app_unauthorized_ecdsa_p256.pub.der",
     type = "TestKey",
+)
+
+pkg_files(
+    name = "fpga_dev_files",
+    testonly = True,
+    srcs = [
+        ":app_dev",
+        ":app_dev_pub",
+        ":app_ecdsa_prod",
+        ":app_prod_ecdsa_pub",
+    ],
+)
+
+pkg_filegroup(
+    name = "fpga_dev_pkg",
+    testonly = True,
+    srcs = [
+        ":fpga_dev_files",
+    ],
+    prefix = "fake_keys",
 )

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
+load("//rules:files.bzl", "output_groups")
 load("//rules:const.bzl", "CONST", "hex")
 load("//rules:cross_platform.bzl", "dual_cc_device_library_of", "dual_cc_library", "dual_inputs")
 load("//rules:linker.bzl", "ld_library")
@@ -364,4 +366,33 @@ opentitan_binary(
         "//sw/device/silicon_creator/lib/rescue:rescue_xmodem",
         "//sw/device/silicon_creator/rom_ext/imm_section:main_section_dice_x509_slot_a",
     ],
+)
+
+output_groups(
+    name = "fpga_dev_binaries",
+    testonly = True,
+    srcs = [":rom_ext_dice_x509_slot_virtual"],
+    groups = [
+        "fpga_cw310_signed_bin",
+        "fpga_cw340_signed_bin",
+    ],
+)
+
+pkg_files(
+    name = "fpga_dev_files",
+    testonly = True,
+    srcs = [
+        ":fpga_dev_binaries",
+    ],
+    tags = ["manual"],
+)
+
+pkg_filegroup(
+    name = "fpga_dev_pkg",
+    testonly = True,
+    srcs = [
+        ":fpga_dev_files",
+    ],
+    prefix = "rom_ext",
+    tags = ["manual"],
 )

--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -77,6 +77,7 @@ rust_binary(
 pkg_files(
     name = "binary",
     srcs = [":opentitantool"],
+    attributes = pkg_attributes(mode = "0755"),
 )
 
 pkg_filegroup(


### PR DESCRIPTION
Create a devbundle to facilitate out-of-tree development of OS/applications.  Currently, includes:

- Opentitantool
- FPGA bitstreams for CW310 and CW340 FPGA boards.
- ROM_EXTs for CW310 and CW340 FPGA boards.
- Fake application keys for use with the ROM_EXTs.