### PR TITLE
[rom_ctrl] Make it possible to configure the rom to take 2 cycles

### DIFF
--- a/hw/ip/prim/rtl/prim_rom_adv.sv
+++ b/hw/ip/prim/rtl/prim_rom_adv.sv
@@ -3,16 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // ROM wrapper with rvalid register
+//
+// This is a very thin wrapper around prim_rom and adds an rvalid_o port, which it controls using a
+// shift register that is aware of the Latency parameter for the underlying ROM.
 
 `include "prim_assert.sv"
 
 module prim_rom_adv import prim_rom_pkg::*; #(
-  // Parameters passed on the ROM primitive.
-  parameter  int Width       = 32,
-  parameter  int Depth       = 2048, // 8kB default
-  parameter      MemInitFile = "", // VMEM file to initialize the memory with
+  parameter int unsigned Width       = 32,    // Bit width of each item
+  parameter int unsigned Depth       = 2048,  // Number of items
+  parameter int unsigned Latency     = 1,     // Number of cycles from request until response
+  parameter              MemInitFile = "",    // VMEM with the contents of the ROM
 
-  localparam int Aw          = $clog2(Depth)
+  localparam int Aw                  = $clog2(Depth)
 ) (
   input  logic             clk_i,
   input  logic             rst_ni,
@@ -20,13 +23,13 @@ module prim_rom_adv import prim_rom_pkg::*; #(
   input  logic [Aw-1:0]    addr_i,
   output logic             rvalid_o,
   output logic [Width-1:0] rdata_o,
-
-  input rom_cfg_t          cfg_i
+  input  rom_cfg_t         cfg_i
 );
 
   prim_rom #(
     .Width(Width),
     .Depth(Depth),
+    .Latency(Latency),
     .MemInitFile(MemInitFile)
   ) u_prim_rom (
     .clk_i,
@@ -37,12 +40,24 @@ module prim_rom_adv import prim_rom_pkg::*; #(
     .cfg_i
   );
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      rvalid_o <= 1'b0;
-    end else begin
-      rvalid_o <= req_i;
+  // We need the rvalid_o to be an Latency-cycle delayed version of req_i. If Latency is positive,
+  // we can represent this with a shift register. If Latency is zero (so the ROM responds
+  // combinatorially) rvalid_o is just equal to req_i.
+  if (Latency > 0) begin : gen_pos_latency
+    logic [Latency-1:0] rvalids_q, rvalids_d;
+    logic               unused_rvalid;
+
+    assign {unused_rvalid, rvalids_d} = {rvalids_q, req_i};
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        rvalids_q <= '0;
+      end else begin
+        rvalids_q <= rvalids_d;
+      end
     end
+    assign rvalid_o = rvalids_q[Latency-1];
+  end else begin : gen_zero_latency
+    assign rvalid_o = req_i;
   end
 
   ////////////////

--- a/hw/ip/prim_generic/rtl/prim_rom.sv
+++ b/hw/ip/prim_generic/rtl/prim_rom.sv
@@ -2,14 +2,30 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// A read-only memory
+//
+// There are Depth items of has Width bits each. Latency is the number of cycles that the ROM takes
+// to respond to a request (when req_i is high).
+//
+// The contents of the ROM can be initialised (in either simulation or synthesis) with a VMEM file.
+// The path to that file is given as the MemInitFile parameter.
+//
+// If the req_i signal is high then this cycle has a request for the data at address addr_i. Each
+// cycle that req_i is high, that data gets shifted into a shift register and the top item of that
+// register becomes visible after Latency cycles as rdata_o.
+//
+// cfg_i is a configuration signal that an implementation can pass straight through to to an
+// underlying ROM macro.
+
 `include "prim_assert.sv"
 
 module prim_rom import prim_rom_pkg::*; #(
-  parameter  int Width       = 32,
-  parameter  int Depth       = 2048, // 8kB default
-  parameter      MemInitFile = "", // VMEM file to initialize the memory with
+  parameter int unsigned Width       = 32,
+  parameter int unsigned Depth       = 2048,
+  parameter int unsigned Latency     = 1,
+  parameter              MemInitFile = "",   // VMEM file to initialize the memory with
 
-  localparam int Aw          = $clog2(Depth)
+  localparam int Aw = $clog2(Depth)
 ) (
   input  logic             clk_i,
   input  logic             rst_ni,
@@ -24,17 +40,17 @@ module prim_rom import prim_rom_pkg::*; #(
 
   logic [Width-1:0] mem [Depth];
 
-  always_ff @(posedge clk_i) begin
-    if (req_i) begin
-      rdata_o <= mem[addr_i];
+  if (Latency > 0) begin : gen_pos_latency
+    logic [Latency-1:0][Width-1:0] queue;
+    always_ff @(posedge clk_i) begin
+      queue <= (queue << Width) | (req_i ? mem[addr_i] : 0);
     end
+    assign rdata_o = queue[Latency-1];
+  end else begin : gen_zero_latency
+    assign rdata_o = mem[addr_i];
   end
 
   `include "prim_util_memload.svh"
-
-  ////////////////
-  // ASSERTIONS //
-  ////////////////
 
   // Control Signals should never be X
   `ASSERT(noXOnCsI, !$isunknown(req_i), clk_i, '0)

--- a/hw/ip/rom_ctrl/data/rom_ctrl.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl.hjson
@@ -53,6 +53,17 @@
       default:   "1'b0"
     }
 
+    { name:      "TwoCycleRom",
+      type:      "bit",
+      desc:      '''
+        The underlying ROM macro has a read latency of 1 clock cycle (0) or
+        2 clock cycles (1). This may help breaking long paths in a target chip.
+      '''
+      local:     "true",
+      expose:    "true",
+      default:   "1'b0"
+    }
+
     { name:      "RndCnstScrNonce",
       type:      "bit [63:0]",
       desc:      "Fixed nonce used for address / data scrambling"

--- a/hw/ip/rom_ctrl/dv/rom_ctrl_32kB_sim_cfg.hjson
+++ b/hw/ip/rom_ctrl/dv/rom_ctrl_32kB_sim_cfg.hjson
@@ -9,5 +9,7 @@
   // Import the base rom_ctrl sim_cfg file
   import_cfgs: ["{proj_root}/hw/ip/rom_ctrl/dv/rom_ctrl_base_sim_cfg.hjson"]
 
-  build_opts: ["+define+ROM_BYTE_ADDR_WIDTH=15"]
+  build_opts: ["+define+FLOP_TO_KMAC=0",
+               "+define+ROM_BYTE_ADDR_WIDTH=15",
+               "+define+TWO_CYCLE_ROM=0"]
 }

--- a/hw/ip/rom_ctrl/dv/rom_ctrl_64kB_sim_cfg.hjson
+++ b/hw/ip/rom_ctrl/dv/rom_ctrl_64kB_sim_cfg.hjson
@@ -9,5 +9,7 @@
   // Import the base rom_ctrl sim_cfg file
   import_cfgs: ["{proj_root}/hw/ip/rom_ctrl/dv/rom_ctrl_base_sim_cfg.hjson"]
 
-  build_opts: ["+define+ROM_BYTE_ADDR_WIDTH=16"]
+  build_opts: ["+define+FLOP_TO_KMAC=0",
+               "+define+ROM_BYTE_ADDR_WIDTH=16",
+               "+define+TWO_CYCLE_ROM=0"]
 }

--- a/hw/ip/rom_ctrl/dv/tb/tb.sv
+++ b/hw/ip/rom_ctrl/dv/tb/tb.sv
@@ -39,8 +39,9 @@ module tb;
   rom_ctrl #(
     .RndCnstScrNonce      (RND_CNST_SCR_NONCE),
     .RndCnstScrKey        (RND_CNST_SCR_KEY),
-    // ROM size in bytes
-    .MemSizeRom           (ROM_SIZE_BYTES)
+    .FlopToKmac           (`FLOP_TO_KMAC),
+    .MemSizeRom           (ROM_SIZE_BYTES),
+    .TwoCycleRom          (`TWO_CYCLE_ROM)
    ) dut (
     .clk_i                (clk),
     .rst_ni               (rst_n),

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -86,7 +86,6 @@ module rom_ctrl
   logic                     bus_rom_rvalid, bus_rom_rvalid_raw;
 
   logic [RomIndexWidth-1:0] checker_rom_index;
-  logic                     checker_rom_req;
   logic [DataWidth-1:0]     checker_rom_rdata, checker_rom_rdata_outer;
 
   logic                     internal_alert;
@@ -246,7 +245,9 @@ module rom_ctrl
     .bus_rdata_o       (bus_rom_rdata),
     .bus_rvalid_o      (bus_rom_rvalid_raw),
     .chk_addr_i        (checker_rom_index),
-    .chk_req_i         (checker_rom_req),
+    .chk_req_i         (1'b1), // Once the ROM has been checked after reset, the `rom_select_bus`
+                               // switches to the bus and the checker inputs including the request
+                               // signal get ignored.
     .chk_rdata_o       (checker_rom_rdata),
     .rom_rom_addr_o    (rom_rom_index),
     .rom_prince_addr_o (rom_prince_index),
@@ -375,7 +376,6 @@ module rom_ctrl
       .kmac_err_i           (kmac_err),
       .rom_select_bus_o     (rom_select_bus),
       .rom_addr_o           (checker_rom_index),
-      .rom_req_o            (checker_rom_req),
       .rom_data_i           (checker_rom_rdata[31:0]),
       .alert_o              (checker_alert)
     );
@@ -447,7 +447,6 @@ module rom_ctrl
     assign rom_select_bus = MuBi4True;
 
     assign checker_rom_index = '0;
-    assign checker_rom_req = 1'b0;
     assign checker_alert = 1'b0;
 
     logic unused_fsm_inputs;

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -559,6 +559,11 @@ module rom_ctrl
   `ASSERT_KNOWN(KmacDataOValidKnown_A, kmac_data_o.valid)
   `ASSERT_KNOWN_IF(KmacDataODataKnown_A, kmac_data_o, kmac_data_o.valid)
 
+  // Check that kmac_data_o.last is "telling the truth", so we definitely want kmac_data_o.valid to
+  // drop on the cycle after it is transferred.
+  `ASSERT(KmacLastTrue_A,
+          kmac_data_o.valid && kmac_data_i.ready && kmac_data_o.last |=> !kmac_data_o.valid)
+
   // Check that pwrmgr_data_o.good is stable when kmac_data_o.valid is asserted
   `ASSERT(StabilityChkKmac_A, kmac_data_o.valid && $past(kmac_data_o.valid)
           |-> $stable(pwrmgr_data_o.good))

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -234,7 +234,8 @@ module rom_ctrl
 
   rom_ctrl_mux #(
     .AW (RomIndexWidth),
-    .DW (DataWidth)
+    .DW (DataWidth),
+    .TwoCycleRom(TwoCycleRom)
   ) u_mux (
     .clk_i,
     .rst_ni,

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -25,7 +25,8 @@ module rom_ctrl
   parameter bit [127:0]           RndCnstScrKey = '0,
   // ROM size in bytes
   parameter int                   MemSizeRom = 32'h8000,
-
+  // If this parameter is set, the ROM responds in two cycles (instead of one).
+  parameter bit                   TwoCycleRom = 1'b0,
   // Disable all (de)scrambling operation. This disables both the scrambling block and the boot-time
   // checker. Don't use this in a real chip, but it's handy for small FPGA targets where we don't
   // want to spend area on unused scrambling.
@@ -281,7 +282,8 @@ module rom_ctrl
       .Width       (DataWidth),
       .Depth       (RomSizeWords),
       .ScrNonce    (RndCnstScrNonce),
-      .ScrKey      (RndCnstScrKey)
+      .ScrKey      (RndCnstScrKey),
+      .TwoCycleRom (TwoCycleRom)
     ) u_rom (
       .clk_i,
       .rst_ni,
@@ -303,7 +305,8 @@ module rom_ctrl
     prim_rom_adv #(
       .Width       (DataWidth),
       .Depth       (RomSizeWords),
-      .MemInitFile (BootRomInitFile)
+      .MemInitFile (BootRomInitFile),
+      .Latency     (TwoCycleRom ? 2 : 1)
     ) u_rom (
       .clk_i,
       .rst_ni,
@@ -356,9 +359,10 @@ module rom_ctrl
   if (!SecDisableScrambling) begin : gen_fsm_scramble_enabled
 
     rom_ctrl_fsm #(
-      .RomDepth  (RomSizeWords),
-      .TopCount  (8),
-      .DataWidth (DataWidth)
+      .RomDepth   (RomSizeWords),
+      .TopCount   (8),
+      .DataWidth  (DataWidth),
+      .TwoCycleRom(TwoCycleRom)
     ) u_checker_fsm (
       .clk_i,
       .rst_ni,

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_counter.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_counter.sv
@@ -15,105 +15,66 @@
 // be included in the hash computation).
 //
 // The counter works through the ROM, starting at address zero. For each address, it will supply
-// that address in read_addr_o and will set read_req_o. This combination makes a request to the ROM.
+// that address in read_addr_o, requesting a read from the ROM. If the read_last_data_o signal is
+// true, this word is the final word in the data that should be sent to KMAC.
 //
-// The data_addr_o signal holds the address of the last word that was requested from ROM. Since ROM
-// responds in a single cycle, this will be the address that corresponds to the data that is
-// currently being presented to KMAC (through the chk_rdata_o port of the mux).
-//
-// The data_last_nontop_o signal is true if the most recent word read from ROM was the final word in
-// the data that should be sent to KMAC.
-//
-// Finally, the data_rdy_i port is the ready response from KMAC. Knowing this means that the counter
-// can tell whether the last ROM word it read is being passed to KMAC, which means the counter can
-// step forwards to the next word.
+// The data_rdy_i port is the ready response from KMAC. Knowing this means that the counter can tell
+// whether the last ROM word it read is being passed to KMAC, which means it can step forwards to
+// the next word.
 
 `include "prim_assert.sv"
 
 module rom_ctrl_counter
   import prim_util_pkg::vbits;
 #(
-  parameter int RomDepth = 16,
-  parameter int RomTopCount = 2
+  parameter int unsigned RomDepth = 16,
+  parameter int unsigned RomTopCount = 2,
+
+  localparam int unsigned AW = vbits(RomDepth)
 ) (
-  input                        clk_i,
-  input                        rst_ni,
+  input           clk_i,
+  input           rst_ni,
 
-  output                       done_o,
+  output          done_o,
 
-  output [vbits(RomDepth)-1:0] read_addr_o,
-  output                       read_req_o,
+  output [AW-1:0] read_addr_o,
+  output logic    read_last_data_o,
 
-  output [vbits(RomDepth)-1:0] data_addr_o,
-
-  input                        data_rdy_i,
-  output                       data_last_nontop_o
+  input           data_rdy_i
 );
 
-  // The number of ROM entries that should be hashed. We assume there are at least 2, so that we can
-  // register the data_last_nontop_o signal.
-  localparam int RomNonTopCount = RomDepth - RomTopCount;
+  // The number of ROM entries in the image that should be hashed, using the convention that the
+  // "data" are the ROM entries other than their expected hash.
+  localparam int unsigned DataLen = RomDepth - RomTopCount;
 
   `ASSERT_INIT(TopCountValid_A, 1 <= RomTopCount && RomTopCount < RomDepth)
-  `ASSERT_INIT(NonTopCountValid_A, 2 <= RomNonTopCount)
+  `ASSERT_INIT(DataLenValid_A, 1 <= DataLen)
 
-  localparam int AW = vbits(RomDepth);
+  localparam int unsigned TopAddrInt     = RomDepth - 1;
+  localparam int unsigned TopDataAddrInt = DataLen - 1;
 
-  localparam int unsigned TopAddrInt = RomDepth - 1;
-  localparam int unsigned TNTAddrInt = RomNonTopCount - 2;
+  localparam bit [AW-1:0] TopAddr     = TopAddrInt[AW-1:0];
+  localparam bit [AW-1:0] TopDataAddr = TopDataAddrInt[AW-1:0];
 
-  localparam bit [AW-1:0] TopAddr = TopAddrInt[AW-1:0];
-  localparam bit [AW-1:0] TNTAddr = TNTAddrInt[AW-1:0];
+  logic [AW-1:0] addr_q;
+  logic          done_q;
 
-  logic          go;
-  logic          req_q, vld_q;
-  logic [AW-1:0] addr_q, addr_d;
-  logic          done_q, done_d;
-  logic          last_nontop_q, last_nontop_d;
-
-  assign done_d = addr_q == TopAddr;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       done_q <= 1'b0;
-    end else begin
-      done_q <= done_d;
+    end else if (addr_q == TopAddr) begin
+      done_q <= 1'b1;
     end
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      addr_q        <= '0;
-      last_nontop_q <= 1'b0;
-    end else if (go) begin
-      addr_q        <= addr_d;
-      last_nontop_q <= last_nontop_d;
+      addr_q <= '0;
+    end else if (data_rdy_i & ~done_q) begin
+      addr_q <= addr_q + AW'(1);
     end
   end
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      req_q <= 1'b0;
-      vld_q <= 1'b0;
-    end else begin
-      // The first ROM request goes out immediately after reset (once we reach the top of ROM, we
-      // signal done_o, after which the request signal is unused). We could clear it again when we
-      // are done, but there's no need: the mux will switch away from us anyway.
-      req_q <= 1'b1;
-
-      // ROM data is valid from one cycle after the request goes out.
-      vld_q <= req_q;
-    end
-  end
-
-  assign go = data_rdy_i & vld_q & ~done_d;
-
-  assign addr_d        = addr_q + {{AW-1{1'b0}}, 1'b1};
-  assign last_nontop_d = addr_q == TNTAddr;
-
   assign done_o             = done_q;
-  assign read_addr_o        = go ? addr_d : addr_q;
-  assign read_req_o         = req_q;
-  assign data_addr_o        = addr_q;
-  assign data_last_nontop_o = last_nontop_q;
-
+  assign read_addr_o        = addr_q;
+  assign read_last_data_o   = addr_q == TopDataAddr;
 endmodule

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
@@ -49,54 +49,54 @@ module rom_ctrl_fsm
   import rom_ctrl_pkg::*;
 #(
   parameter int RomDepth = 16,
-  parameter int TopCount = 8
+  parameter int TopCount = 8,
+
+  localparam int unsigned AW = vbits(RomDepth), // derived parameter
+  localparam int unsigned TAW = vbits(TopCount) // derived parameter
 ) (
-  input logic                        clk_i,
-  input logic                        rst_ni,
+  input logic                    clk_i,
+  input logic                    rst_ni,
 
   // CSR inputs for DIGEST and EXP_DIGEST. To make the indexing look nicer, these are ordered so
   // that DIGEST_0 is the bottom 32 bits (they get reversed while we're shuffling around the wires
   // in rom_ctrl).
-  input logic [TopCount*32-1:0]      digest_i,
-  input logic [TopCount*32-1:0]      exp_digest_i,
+  input logic [TopCount*32-1:0]  digest_i,
+  input logic [TopCount*32-1:0]  exp_digest_i,
 
   // CSR outputs for DIGEST and EXP_DIGEST. Ordered with word 0 as LSB.
-  output logic [TopCount*32-1:0]     digest_o,
-  output logic                       digest_vld_o,
-  output logic [31:0]                exp_digest_o,
-  output logic                       exp_digest_vld_o,
-  output logic [vbits(TopCount)-1:0] exp_digest_idx_o,
+  output logic [TopCount*32-1:0] digest_o,
+  output logic                   digest_vld_o,
+  output logic [31:0]            exp_digest_o,
+  output logic                   exp_digest_vld_o,
+  output logic [TAW-1:0]         exp_digest_idx_o,
 
   // To power manager and key manager
-  output pwrmgr_data_t               pwrmgr_data_o,
-  output keymgr_data_t               keymgr_data_o,
+  output pwrmgr_data_t           pwrmgr_data_o,
+  output keymgr_data_t           keymgr_data_o,
 
   // To KMAC (ROM data)
-  input logic                        kmac_rom_rdy_i,
-  output logic                       kmac_rom_vld_o,
-  output logic                       kmac_rom_last_o,
+  input logic                    kmac_rom_rdy_i,
+  output logic                   kmac_rom_vld_o,
+  output logic                   kmac_rom_last_o,
 
   // From KMAC (digest data)
-  input logic                        kmac_done_i,
-  input logic [TopCount*32-1:0]      kmac_digest_i,
-  input logic                        kmac_err_i,
+  input logic                    kmac_done_i,
+  input logic [TopCount*32-1:0]  kmac_digest_i,
+  input logic                    kmac_err_i,
 
   // To ROM mux
-  output mubi4_t                     rom_select_bus_o,
-  output logic [vbits(RomDepth)-1:0] rom_addr_o,
+  output mubi4_t                 rom_select_bus_o,
+  output logic [AW-1:0]          rom_addr_o,
 
   // Raw bits from ROM
-  input logic [31:0]                 rom_data_i,
+  input logic [31:0]             rom_data_i,
 
   // To alert system
-  output logic                       alert_o
+  output logic                   alert_o
 );
 
   import prim_mubi_pkg::mubi4_test_true_loose;
   import prim_mubi_pkg::MuBi4False, prim_mubi_pkg::MuBi4True;
-
-  localparam int AW = vbits(RomDepth);
-  localparam int TAW = vbits(TopCount);
 
   localparam int unsigned TopStartAddrInt = RomDepth - TopCount;
   localparam bit [AW-1:0] TopStartAddr    = TopStartAddrInt[AW-1:0];

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_mux.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_mux.sv
@@ -10,7 +10,8 @@ module rom_ctrl_mux
   import prim_mubi_pkg::mubi4_t;
 #(
   parameter int AW = 8,
-  parameter int DW = 39
+  parameter int DW = 39,
+  parameter bit TwoCycleRom = 1'b0  // If true, the ROM responds in two cycles (instead of one).
 ) (
   input logic           clk_i,
   input logic           rst_ni,
@@ -108,6 +109,11 @@ module rom_ctrl_mux
     end
   end
 
+  logic rsp_is_for_bus;
+  assign rsp_is_for_bus = TwoCycleRom ?
+                          mubi4_test_true_strict(sel_bus_qq) :
+                          mubi4_test_true_strict(sel_bus_q);
+
   assign alert_o = alert_q;
 
   // The bus can have access every cycle, from when the select signal switches to the bus.
@@ -115,7 +121,7 @@ module rom_ctrl_mux
   assign bus_rdata_o  = rom_clr_rdata_i;
   // A high rom_rvalid_i is a response to a bus request if the select signal pointed at the bus on
   // the previous cycle.
-  assign bus_rvalid_o = mubi4_test_true_strict(sel_bus_q) & rom_rvalid_i;
+  assign bus_rvalid_o = rsp_is_for_bus & rom_rvalid_i;
 
   assign chk_rdata_o = rom_scr_rdata_i;
 

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -7802,6 +7802,19 @@
           name_top: RomCtrl0FlopToKmac
         }
         {
+          name: TwoCycleRom
+          desc:
+            '''
+            The underlying ROM macro has a read latency of 1 clock cycle (0) or
+            2 clock cycles (1). This may help breaking long paths in a target chip.
+            '''
+          type: bit
+          default: 1'b0
+          local: "true"
+          expose: "true"
+          name_top: RomCtrl0TwoCycleRom
+        }
+        {
           name: RndCnstScrNonce
           desc: Fixed nonce used for address / data scrambling
           type: bit [63:0]
@@ -8001,6 +8014,19 @@
           local: "true"
           expose: "true"
           name_top: RomCtrl1FlopToKmac
+        }
+        {
+          name: TwoCycleRom
+          desc:
+            '''
+            The underlying ROM macro has a read latency of 1 clock cycle (0) or
+            2 clock cycles (1). This may help breaking long paths in a target chip.
+            '''
+          type: bit
+          default: 1'b0
+          local: "true"
+          expose: "true"
+          name_top: RomCtrl1TwoCycleRom
         }
         {
           name: RndCnstScrNonce

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -340,8 +340,10 @@ module top_darjeeling #(
   localparam int SramCtrlMboxOutstanding = 2;
   // local parameters for rom_ctrl0
   localparam bit RomCtrl0FlopToKmac = 1'b1;
+  localparam bit RomCtrl0TwoCycleRom = 1'b0;
   // local parameters for rom_ctrl1
   localparam bit RomCtrl1FlopToKmac = 1'b1;
+  localparam bit RomCtrl1TwoCycleRom = 1'b0;
   // local parameters for racl_ctrl
   localparam int RaclCtrlNumSubscribingIps = 11;
   // local parameters for rv_core_ibex
@@ -2262,6 +2264,7 @@ module top_darjeeling #(
     .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .BootRomInitFile(RomCtrl0BootRomInitFile),
     .FlopToKmac(RomCtrl0FlopToKmac),
+    .TwoCycleRom(RomCtrl0TwoCycleRom),
     .RndCnstScrNonce(RndCnstRomCtrl0ScrNonce),
     .RndCnstScrKey(RndCnstRomCtrl0ScrKey),
     .SecDisableScrambling(SecRomCtrl0DisableScrambling),
@@ -2291,6 +2294,7 @@ module top_darjeeling #(
     .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .BootRomInitFile(RomCtrl1BootRomInitFile),
     .FlopToKmac(RomCtrl1FlopToKmac),
+    .TwoCycleRom(RomCtrl1TwoCycleRom),
     .RndCnstScrNonce(RndCnstRomCtrl1ScrNonce),
     .RndCnstScrKey(RndCnstRomCtrl1ScrKey),
     .SecDisableScrambling(SecRomCtrl1DisableScrambling),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -9428,6 +9428,19 @@
           name_top: RomCtrlFlopToKmac
         }
         {
+          name: TwoCycleRom
+          desc:
+            '''
+            The underlying ROM macro has a read latency of 1 clock cycle (0) or
+            2 clock cycles (1). This may help breaking long paths in a target chip.
+            '''
+          type: bit
+          default: 1'b0
+          local: "true"
+          expose: "true"
+          name_top: RomCtrlTwoCycleRom
+        }
+        {
           name: RndCnstScrNonce
           desc: Fixed nonce used for address / data scrambling
           type: bit [63:0]

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -266,6 +266,7 @@ module top_earlgrey #(
   localparam int SramCtrlMainOutstanding = 2;
   // local parameters for rom_ctrl
   localparam bit RomCtrlFlopToKmac = 1'b0;
+  localparam bit RomCtrlTwoCycleRom = 1'b0;
   // local parameters for rv_core_ibex
   localparam bit RvCoreIbexInstructionPipeline = 1'b0;
 
@@ -2788,6 +2789,7 @@ module top_earlgrey #(
     .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .BootRomInitFile(RomCtrlBootRomInitFile),
     .FlopToKmac(RomCtrlFlopToKmac),
+    .TwoCycleRom(RomCtrlTwoCycleRom),
     .RndCnstScrNonce(RndCnstRomCtrlScrNonce),
     .RndCnstScrKey(RndCnstRomCtrlScrKey),
     .SecDisableScrambling(SecRomCtrlDisableScrambling),

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -4137,6 +4137,19 @@
           name_top: RomCtrlFlopToKmac
         }
         {
+          name: TwoCycleRom
+          desc:
+            '''
+            The underlying ROM macro has a read latency of 1 clock cycle (0) or
+            2 clock cycles (1). This may help breaking long paths in a target chip.
+            '''
+          type: bit
+          default: 1'b0
+          local: "true"
+          expose: "true"
+          name_top: RomCtrlTwoCycleRom
+        }
+        {
           name: RndCnstScrNonce
           desc: Fixed nonce used for address / data scrambling
           type: bit [63:0]

--- a/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
@@ -170,6 +170,7 @@ module top_englishbreakfast #(
   localparam int SramCtrlMainOutstanding = 2;
   // local parameters for rom_ctrl
   localparam bit RomCtrlFlopToKmac = 1'b0;
+  localparam bit RomCtrlTwoCycleRom = 1'b0;
   // local parameters for rv_core_ibex
   localparam bit RvCoreIbexInstructionPipeline = 1'b0;
 
@@ -1249,6 +1250,7 @@ module top_englishbreakfast #(
     .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .BootRomInitFile(RomCtrlBootRomInitFile),
     .FlopToKmac(RomCtrlFlopToKmac),
+    .TwoCycleRom(RomCtrlTwoCycleRom),
     .RndCnstScrNonce(RndCnstRomCtrlScrNonce),
     .RndCnstScrKey(RndCnstRomCtrlScrKey),
     .SecDisableScrambling(SecRomCtrlDisableScrambling),


### PR DESCRIPTION
The first commit in this PR adds a configurable extra flop to the ROM output, which means that anyone using `prim_rom` will see it take 2 cycles to respond. The rest of the commits (surprisingly fiddly!) are teaching `rom_ctrl` to allow this configuration. 

Amusingly, the 4th commit actually makes things a bit simpler: I suspect this shows that I wasn't quite as competent a few years ago!