### PR TITLE
[crypto] Disable the iCache when entering CL

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -217,6 +217,11 @@ dual_cc_library(
             "//hw/top_earlgrey/sw/autogen:top_earlgrey",
             "//hw/top:rv_core_ibex_c_regs",
             "//sw/device/lib/base:abs_mmio",
+            "//sw/device/lib/base:csr",
+        ],
+        shared = [
+            "//sw/device/lib/base:hardened",
+            "//sw/device/lib/crypto/impl:status",
         ],
     ),
 )

--- a/sw/device/lib/crypto/drivers/rv_core_ibex.c
+++ b/sw/device/lib/crypto/drivers/rv_core_ibex.c
@@ -6,12 +6,19 @@
 
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/csr.h"
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/crypto/impl/status.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "rv_core_ibex_regs.h"
 
 enum {
   kBaseAddr = TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR,
+  /**
+   * CSR_REG_CPUCTRL[0] is the iCache configuration field.
+   */
+  kCpuctrlICacheMask = 1,
 };
 
 /**
@@ -24,6 +31,33 @@ static void wait_rnd_valid(void) {
     if (bitfield_bit32_read(reg, RV_CORE_IBEX_RND_STATUS_RND_DATA_VALID_BIT)) {
       return;
     }
+  }
+}
+
+hardened_bool_t ibex_disable_icache(void) {
+  // Check if the instruction cache is already disabled.
+  uint32_t csr;
+  CSR_READ(CSR_REG_CPUCTRL, &csr);
+  hardened_bool_t icache_enabled = kHardenedBoolFalse;
+  if ((csr & kCpuctrlICacheMask) == 1) {
+    icache_enabled = kHardenedBoolTrue;
+  }
+
+  // If the instruction cache is enabled, disable it.
+  if (launder32(icache_enabled) == kHardenedBoolTrue) {
+    CSR_CLEAR_BITS(CSR_REG_CPUCTRL, kCpuctrlICacheMask);
+  } else {
+    HARDENED_CHECK_EQ(icache_enabled, kHardenedBoolFalse);
+  }
+
+  return icache_enabled;
+}
+
+void ibex_restore_icache(hardened_bool_t icache_enabled) {
+  // If the instruction cache was enabled before the CL disabled it, enable it
+  // again.
+  if (icache_enabled == kHardenedBoolTrue) {
+    CSR_SET_BITS(CSR_REG_CPUCTRL, kCpuctrlICacheMask);
   }
 }
 

--- a/sw/device/lib/crypto/drivers/rv_core_ibex.h
+++ b/sw/device/lib/crypto/drivers/rv_core_ibex.h
@@ -8,6 +8,26 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "sw/device/lib/base/hardened.h"
+
+/**
+ * Disable the Ibex Instruction Cache if it is enabled.
+ *
+ * Reads out the current state of the instruction cache. If it is enabled,
+ * disable it for the crypto lib.
+ *
+ * @return kHardenedBoolTrue if the iCache was enabled before we disabled it.
+ */
+hardened_bool_t ibex_disable_icache(void);
+
+/**
+ * Enables the Ibex Instruction Cache if icache_enabled is set.
+ *
+ * If icache_enabled == kHardenedBoolTrue, this function enables the iCache by
+ * writing to CPUCTRL.
+ */
+void ibex_restore_icache(hardened_bool_t icache_enabled);
+
 /**
  * Get random data from the EDN0 interface.
  *

--- a/sw/device/lib/crypto/impl/aes_gcm.c
+++ b/sw/device/lib/crypto/impl/aes_gcm.c
@@ -269,6 +269,9 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt(otcrypto_blinded_key_t *key,
   // Check the tag length.
   HARDENED_TRY(aes_gcm_check_tag_length(auth_tag.len, tag_len));
 
+  // Store the iCache state (on or off) and disable it when it is on.
+  hardened_bool_t icache_saved_state = ibex_disable_icache();
+
   // Construct the AES key.
   aes_key_t aes_key;
   HARDENED_TRY(aes_gcm_key_construct(key, &aes_key));
@@ -280,6 +283,10 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt(otcrypto_blinded_key_t *key,
                                auth_tag.data, ciphertext.data));
 
   HARDENED_TRY(clear_key_if_sideloaded(aes_key));
+
+  // Enable the iCache if it was previously enabled.
+  ibex_restore_icache(icache_saved_state);
+
   return OTCRYPTO_OK;
 }
 
@@ -305,6 +312,9 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt(
   // Ensure entropy complex is initialized.
   HARDENED_TRY(entropy_complex_check());
 
+  // Store the iCache state (on or off) and disable it when it is on.
+  hardened_bool_t icache_saved_state = ibex_disable_icache();
+
   // Construct the AES key.
   aes_key_t aes_key;
   HARDENED_TRY(aes_gcm_key_construct(key, &aes_key));
@@ -325,6 +335,10 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt(
                                auth_tag.data, plaintext.data, success));
 
   HARDENED_TRY(clear_key_if_sideloaded(aes_key));
+
+  // Enable the iCache if it was previously enabled.
+  ibex_restore_icache(icache_saved_state);
+
   return OTCRYPTO_OK;
 }
 
@@ -338,6 +352,9 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_init(
   // Ensure entropy complex is initialized.
   HARDENED_TRY(entropy_complex_check());
 
+  // Store the iCache state (on or off) and disable it when it is on.
+  hardened_bool_t icache_saved_state = ibex_disable_icache();
+
   // Construct the AES key.
   aes_key_t aes_key;
   HARDENED_TRY(aes_gcm_key_construct(key, &aes_key));
@@ -350,6 +367,10 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_init(
   // Save the context and clear the key if needed.
   gcm_context_save(&internal_ctx, ctx);
   HARDENED_TRY(clear_key_if_sideloaded(internal_ctx.key));
+
+  // Enable the iCache if it was previously enabled.
+  ibex_restore_icache(icache_saved_state);
+
   return OTCRYPTO_OK;
 }
 
@@ -363,6 +384,9 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt_init(
   // Ensure entropy complex is initialized.
   HARDENED_TRY(entropy_complex_check());
 
+  // Store the iCache state (on or off) and disable it when it is on.
+  hardened_bool_t icache_saved_state = ibex_disable_icache();
+
   // Construct the AES key.
   aes_key_t aes_key;
   HARDENED_TRY(aes_gcm_key_construct(key, &aes_key));
@@ -375,6 +399,10 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt_init(
   // Save the context and clear the key if needed.
   gcm_context_save(&internal_ctx, ctx);
   HARDENED_TRY(clear_key_if_sideloaded(internal_ctx.key));
+
+  // Enable the iCache if it was previously enabled.
+  ibex_restore_icache(icache_saved_state);
+
   return OTCRYPTO_OK;
 }
 
@@ -392,6 +420,9 @@ otcrypto_status_t otcrypto_aes_gcm_update_aad(otcrypto_aes_gcm_context_t *ctx,
     return OTCRYPTO_OK;
   }
 
+  // Store the iCache state (on or off) and disable it when it is on.
+  hardened_bool_t icache_saved_state = ibex_disable_icache();
+
   // Restore the AES-GCM context object and load the key if needed.
   aes_gcm_context_t internal_ctx;
   gcm_context_restore(ctx, &internal_ctx);
@@ -403,6 +434,10 @@ otcrypto_status_t otcrypto_aes_gcm_update_aad(otcrypto_aes_gcm_context_t *ctx,
   // Save the context and clear the key if needed.
   gcm_context_save(&internal_ctx, ctx);
   HARDENED_TRY(clear_key_if_sideloaded(internal_ctx.key));
+
+  // Enable the iCache if it was previously enabled.
+  ibex_restore_icache(icache_saved_state);
+
   return OTCRYPTO_OK;
 }
 
@@ -422,6 +457,9 @@ otcrypto_status_t otcrypto_aes_gcm_update_encrypted_data(
     // Nothing to do.
     return OTCRYPTO_OK;
   }
+
+  // Store the iCache state (on or off) and disable it when it is on.
+  hardened_bool_t icache_saved_state = ibex_disable_icache();
 
   // Restore the AES-GCM context object and load the key if needed.
   aes_gcm_context_t internal_ctx;
@@ -448,6 +486,10 @@ otcrypto_status_t otcrypto_aes_gcm_update_encrypted_data(
   // Save the context and clear the key if needed.
   gcm_context_save(&internal_ctx, ctx);
   HARDENED_TRY(clear_key_if_sideloaded(internal_ctx.key));
+
+  // Enable the iCache if it was previously enabled.
+  ibex_restore_icache(icache_saved_state);
+
   return OTCRYPTO_OK;
 }
 
@@ -466,6 +508,9 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_final(
 
   // Ensure entropy complex is initialized.
   HARDENED_TRY(entropy_complex_check());
+
+  // Store the iCache state (on or off) and disable it when it is on.
+  hardened_bool_t icache_saved_state = ibex_disable_icache();
 
   // Check the tag length.
   HARDENED_TRY(aes_gcm_check_tag_length(auth_tag.len, tag_len));
@@ -490,6 +535,10 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_final(
   // Clear the context and the key if needed.
   hardened_memshred(ctx->data, ARRAYSIZE(ctx->data));
   HARDENED_TRY(clear_key_if_sideloaded(internal_ctx.key));
+
+  // Enable the iCache if it was previously enabled.
+  ibex_restore_icache(icache_saved_state);
+
   return OTCRYPTO_OK;
 }
 
@@ -509,6 +558,9 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt_final(
 
   // Entropy complex needs to be initialized for `memshred`.
   HARDENED_TRY(entropy_complex_check());
+
+  // Store the iCache state (on or off) and disable it when it is on.
+  hardened_bool_t icache_saved_state = ibex_disable_icache();
 
   // Check the tag length.
   HARDENED_TRY(aes_gcm_check_tag_length(auth_tag.len, tag_len));
@@ -533,5 +585,9 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt_final(
   // Clear the context and the key if needed.
   hardened_memshred(ctx->data, ARRAYSIZE(ctx->data));
   HARDENED_TRY(clear_key_if_sideloaded(internal_ctx.key));
+
+  // Enable the iCache if it was previously enabled.
+  ibex_restore_icache(icache_saved_state);
+
   return OTCRYPTO_OK;
 }


### PR DESCRIPTION
This PR adds functionality to the CL that allows the library to disable and restore the instruction cache state.

To start discussions, this PR adds the iCache disable / restore to the AES-GCM CL implementation.