### PR TITLE
[pentest] Remove CW310 target from test framework

### DIFF
--- a/sw/device/tests/penetrationtests/pentest.bzl
+++ b/sw/device/tests/penetrationtests/pentest.bzl
@@ -19,8 +19,6 @@ load(
 # - cw340
 # - silicon
 PENTEST_EXEC_ENVS = {
-    "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
     "//hw/top_earlgrey:fpga_cw340_test_rom": "fpga_cw340",
     "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": "fpga_cw340",
 } | EARLGREY_SILICON_OWNER_ROM_EXT_ENVS


### PR DESCRIPTION
As certain features are disabled on CW310, remove the CW310 target from the automatic tests of the pentesting framework. This avoids that CI tries running the tests on CW310, which will fail.

CW310 bitstreams for ot-sca still can be build manually.