### PR TITLE
[crypto] Fix shift in p256_random_scalar share generation 

### DIFF
--- a/sw/otbn/crypto/p256_base.s
+++ b/sw/otbn/crypto/p256_base.s
@@ -1580,7 +1580,7 @@ p256_random_scalar:
      w16 <= w16[63:0] */
   bn.rshi   w18, w31, w16 >> 192
   bn.rshi   w20, w16, w31 >> 64
-  bn.rshi   w16, w20, w31 >> 192
+  bn.rshi   w16, w31, w20 >> 192
 
   /* Generate a random masking parameter.
      w14 <= URND(127) + 1 = x */

--- a/sw/otbn/crypto/p384_keygen.s
+++ b/sw/otbn/crypto/p384_keygen.s
@@ -77,8 +77,8 @@ p384_random_scalar:
 
   /* Shift bits to get 448-bit seeds.
      seed0 = [w7,w6], seed1 = [w9,w8]
-     w7 <= w7[192:0]
-     w9 <= w9[192:0] */
+     w7 <= w7[255:64]
+     w9 <= w9[255:64] */
   bn.rshi   w7, w31, w7 >> 64
   bn.rshi   w9, w31, w9 >> 64
 

--- a/sw/otbn/crypto/tests/boot_key_endorse_valid.hjson
+++ b/sw/otbn/crypto/tests/boot_key_endorse_valid.hjson
@@ -32,8 +32,8 @@
       # Verified with:
       # >>> import ecdsa
       # >>> import hashlib
-      # >>> r = 0xfb9ccc2407d5f318d0dd995cbf4012e6796898fbc22829c94b691cb0df72e120
-      # >>> s = 0x3eaf474bba511934edb9aaaef0302cc337d6325fba907f26c1e76ba17a4e62a6
+      # >>> r = 0x748aea2bcc338ac86f879e3cc6e438ea495b25d443c10682fb803a9d71b1394b
+      # >>> s = 0x02f72e11603b548fa5496da754d9cecdda277363f11e475492e8f62efcb766b9
       # >>> msg = b"123400"
       # >>> x = "5868cc1d58a1ea20ee1cf22393d92a695e69ea89e85cbce80e94f900015ac2c4"
       # >>> y = "17749c44e6401eda1e71722402d940dceeeee6b7277dac6cbc9a02a44f66aa6f"
@@ -41,8 +41,8 @@
       # >>> sig = r.to_bytes(32, 'big') + s.to_bytes(32, 'big')
       # >>> p.verify(sig, msg, hashfunc=hashlib.sha256)
 
-      "r": "0xfb9ccc2407d5f318d0dd995cbf4012e6796898fbc22829c94b691cb0df72e120"
-      "s": "0x3eaf474bba511934edb9aaaef0302cc337d6325fba907f26c1e76ba17a4e62a6"
+      "r": "0x748aea2bcc338ac86f879e3cc6e438ea495b25d443c10682fb803a9d71b1394b"
+      "s": "0x02f72e11603b548fa5496da754d9cecdda277363f11e475492e8f62efcb766b9"
     }
   }
 }


### PR DESCRIPTION
This commit fixes a bug where the most significant 64 bits were constantly set to 0 instead to the actual seed.

Thanks Yi-Hsuan Deng for spotting this!