### PR TITLE
[opentitanlib, testutils] Add utilities for dumping/parsing VCDs from GPIO samples

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -242,6 +242,7 @@ rust_library(
         "src/util/unknown.rs",
         "src/util/usb.rs",
         "src/util/usr_access.rs",
+        "src/util/vcd.rs",
         "src/util/vmem/mod.rs",
         "src/util/vmem/parser.rs",
         "src/util/voltage.rs",

--- a/sw/host/opentitanlib/src/io/gpio.rs
+++ b/sw/host/opentitanlib/src/io/gpio.rs
@@ -166,7 +166,7 @@ pub enum ClockNature {
 }
 
 /// Represents an edge detected on the GPIO pin.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MonitoringEvent {
     /// Identification of the signal that had an event, in the form of an index into the array
     /// originally passed to `monitoring_read()`.
@@ -178,7 +178,7 @@ pub struct MonitoringEvent {
     pub timestamp: u64,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MonitoringStartResponse {
     /// Transport timestamp at the time monitoring started.
     pub timestamp: u64,
@@ -186,7 +186,7 @@ pub struct MonitoringStartResponse {
     pub initial_levels: Vec<bool>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MonitoringReadResponse {
     /// List of events having occurred since the start or the last read.
     pub events: Vec<MonitoringEvent>,

--- a/sw/host/opentitanlib/src/test_utils/gpio_monitor.rs
+++ b/sw/host/opentitanlib/src/test_utils/gpio_monitor.rs
@@ -4,11 +4,11 @@
 
 use anyhow::{bail, ensure, Result};
 use std::borrow::Borrow;
-//use std::time::Duration;
 use std::rc::Rc;
 
 use crate::app::TransportWrapper;
-use crate::io::gpio::{ClockNature, Edge, GpioMonitoring, MonitoringEvent};
+use crate::io::gpio::{ClockNature, GpioMonitoring, MonitoringEvent};
+use crate::util::vcd::{dump_vcd, vcd_from_edges};
 
 // This structure makes it easier to monitor GPIOs and supports dumping a trace
 // in the VCD format for further examination. In addition, for easier debugging
@@ -122,7 +122,7 @@ impl<'a> GpioMon<'a> {
         self.dump_on_drop = dump_on_drop
     }
 
-    pub fn dump_vcd(&self) -> String {
+    pub fn dump_vcd(&self) -> Result<String> {
         self.waves.dump_vcd()
     }
 }
@@ -207,37 +207,20 @@ impl Waves {
     }
 
     // This function assumes that the events are sorted.
-    pub fn dump_vcd(&self) -> String {
-        const SYMBOLS: &[char] = &['!', '#', '$', '%', '&', '(', ')'];
-        assert!(self.pin_names.len() < SYMBOLS.len());
-        let mut vcd = String::new();
-        vcd.push_str("$timescale 1ns $end\n");
-        vcd.push_str("$scope module opentitanlib $end\n");
-        for (i, name) in self.pin_names.iter().enumerate() {
-            vcd.push_str(&format!("$var wire 1 {} {name} $end\n", SYMBOLS[i]));
-        }
-        vcd.push_str("$upscope $end\n");
-        vcd.push_str("$enddefinitions $end\n");
-
-        vcd.push_str("#0");
-        for (i, lvl) in self.initial_levels.iter().enumerate() {
-            vcd.push_str(&format!(" {}{}", if *lvl { 1 } else { 0 }, SYMBOLS[i]));
-        }
-        vcd.push('\n');
-
-        for event in &self.events {
-            let ns = self.timestamp_to_ns(event.timestamp);
-            let val = event.edge == Edge::Rising;
-            vcd.push_str(&format!(
-                "#{ns} {}{}\n",
-                val as u8, SYMBOLS[event.signal_index as usize]
-            ));
-        }
-        // Make sure that the final timestamp is after the last event.
-        let final_ts = std::cmp::max(self.events.last().unwrap().timestamp, self.final_timestamp);
-        vcd.push_str(&format!("#{}", self.timestamp_to_ns(final_ts),));
-
-        vcd
+    pub fn dump_vcd(&self) -> Result<String> {
+        let pin_names = self
+            .pin_names
+            .iter()
+            .map(|n| Some(n.to_string()))
+            .collect::<Vec<_>>();
+        dump_vcd(&vcd_from_edges(
+            pin_names,
+            self.resolution,
+            self.initial_timestamp,
+            &self.initial_levels,
+            &self.events,
+            self.final_timestamp,
+        )?)
     }
 }
 
@@ -255,7 +238,7 @@ impl Drop for GpioMon<'_> {
             }
             log::info!(
                 "====[ VCD dump ]====\n{}\n====[ end dump ]====",
-                self.dump_vcd()
+                self.dump_vcd().unwrap()
             );
         }
     }

--- a/sw/host/opentitanlib/src/util/mod.rs
+++ b/sw/host/opentitanlib/src/util/mod.rs
@@ -19,6 +19,7 @@ pub mod testing;
 pub mod unknown;
 pub mod usb;
 pub mod usr_access;
+pub mod vcd;
 pub mod vmem;
 pub mod voltage;
 

--- a/sw/host/opentitanlib/src/util/vcd.rs
+++ b/sw/host/opentitanlib/src/util/vcd.rs
@@ -1,0 +1,263 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use std::io;
+use thiserror::Error;
+
+/// A VCD file header, containing timescale info & additional metadata
+#[derive(Debug)]
+pub struct Header {
+    pub timescale_ps: Option<u128>,
+    pub date: Option<String>,
+    pub version: Option<String>,
+}
+
+/// A signal in a VCD file, of some known type & width along with a reference name
+/// e.g. "wire 1 ... rx_en"
+#[derive(Debug)]
+pub struct Signal {
+    pub signal_type: String,
+    pub width: u32,
+    pub reference: String,
+}
+
+/// A member item of some VCD scope, which is either another nested scope or
+/// a variable definition.
+#[derive(Debug)]
+pub enum ScopeItem {
+    Scope {
+        scope_type: String,
+        identifier: String,
+        items: Vec<Self>,
+    },
+    VarDef {
+        signal: Signal,
+        identifier: String,
+    },
+}
+
+impl ScopeItem {
+    /// Get the identifiers of all variables (recursively) defined in this scope.
+    pub fn var_names(&self) -> Vec<&str> {
+        match self {
+            ScopeItem::Scope { items, .. } => {
+                let mut identifiers = Vec::new();
+                for item in items {
+                    identifiers.extend(item.var_names())
+                }
+                identifiers
+            }
+            ScopeItem::VarDef { identifier, .. } => {
+                vec![identifier]
+            }
+        }
+    }
+}
+
+/// A variable definition section of a VCD file, which features a list of top-level
+/// scopes that encapsulate all signal variable definitions (vardefs).
+#[derive(Debug)]
+pub struct VarDefs {
+    scopes: Vec<ScopeItem>,
+}
+
+impl VarDefs {
+    /// Get the identifiers of all variables defined in the entire VarDefs section.
+    pub fn var_names(&self) -> Vec<&str> {
+        let mut identifiers = Vec::new();
+        for scope in &self.scopes {
+            identifiers.extend(scope.var_names());
+        }
+        identifiers
+    }
+}
+
+/// Four-valued scalar logic values
+#[derive(Debug)]
+pub enum ScalarValue {
+    Zero,
+    One,
+    /// Unknown / Don't Care
+    X,
+    /// High Impedance
+    Z,
+}
+
+/// An item in the value change section of a VCD file, which can be a timestamp
+/// entry, a change in the value of a signal (at the last seen timestamp), or
+/// some other command (not currently supported).
+#[derive(Debug)]
+pub enum ValueChangeItem {
+    Timestamp {
+        step: u128,
+    },
+    Scalar {
+        identifier: String,
+        value: ScalarValue,
+    },
+    // TODO: add other VCD signal types (vector, real vars, strings)
+}
+
+/// The value change section of a VCD file, which contains a sequence of
+/// value change item entries.
+#[derive(Debug)]
+pub struct ValueChangeSection {
+    pub changes: Vec<ValueChangeItem>,
+}
+
+/// A full VCD file definition, containing at least a header (with a timescale),
+/// some variable definition(s) and any recorded value change section.
+#[derive(Debug)]
+pub struct Vcd {
+    pub header: Header,
+    pub vardefs: VarDefs,
+    pub value_changes: ValueChangeSection,
+}
+
+impl Vcd {
+    /// Get the identifiers of all variables defined in the VCD file
+    pub fn var_names(&self) -> Vec<&str> {
+        self.vardefs.var_names()
+    }
+}
+
+/// Errors relating to VCD encoding/dumping
+#[derive(Debug, Error)]
+pub enum VcdDumpError {
+    #[error("Cannot represent VCD timescale {0}ps")]
+    InvalidTimescale(u128),
+    #[error("Timestamps out of order: {0} and {1}")]
+    TimestampsOutOfOrder(u128, u128),
+}
+
+/// Struct implementing methods for writing VCD data to some io::Write
+#[derive(Debug)]
+pub struct VcdWriter<W: io::Write> {
+    pub writer: W,
+}
+
+impl<W: io::Write> VcdWriter<W> {
+    pub fn new(writer: W) -> Self {
+        VcdWriter { writer }
+    }
+
+    pub fn flush(&mut self) -> Result<()> {
+        self.writer.flush()?;
+        Ok(())
+    }
+
+    pub fn write_vcd(&mut self, vcd: &Vcd) -> Result<()> {
+        self.write_header(&vcd.header)?;
+        self.write_vardefs(&vcd.vardefs)?;
+        self.write_value_change_section(&vcd.value_changes, 0u128)?;
+        writeln!(self.writer)?;
+        Ok(())
+    }
+
+    pub fn write_header(&mut self, header: &Header) -> Result<()> {
+        // TODO: perhaps avoid hardcoding for picos in the future,
+        // it might be sufficient to e.g. use ns/us/ms in some cases
+        if let Some(timescale_ps) = &header.timescale_ps {
+            if *timescale_ps < 1 {
+                bail!(VcdDumpError::InvalidTimescale(*timescale_ps));
+            }
+            writeln!(self.writer, "$timescale {}ps $end", timescale_ps)?;
+        }
+        if let Some(date) = &header.date {
+            writeln!(self.writer, "$date {} $end", date)?;
+        }
+        if let Some(version) = &header.version {
+            writeln!(self.writer, "$version {} $end", version)?;
+        }
+        Ok(())
+    }
+
+    pub fn write_vardefs(&mut self, vardefs: &VarDefs) -> Result<()> {
+        for scope in &vardefs.scopes {
+            self.write_scope_item(scope)?;
+        }
+        writeln!(self.writer, "$enddefinitions $end")?;
+        Ok(())
+    }
+
+    pub fn write_scope_item(&mut self, scope: &ScopeItem) -> Result<()> {
+        match scope {
+            ScopeItem::Scope {
+                scope_type,
+                identifier,
+                items,
+            } => {
+                writeln!(self.writer, "$scope {} {} $end", &scope_type, &identifier)?;
+                for item in items {
+                    self.write_scope_item(item)?;
+                }
+                writeln!(self.writer, "$upscope $end")?;
+            }
+            ScopeItem::VarDef { signal, identifier } => {
+                writeln!(
+                    self.writer,
+                    "$var {} {} {} {} $end",
+                    &signal.signal_type, signal.width, &identifier, &signal.reference
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn write_value_change_section(
+        &mut self,
+        vcs: &ValueChangeSection,
+        initial_timestamp: u128,
+    ) -> Result<()> {
+        let mut current_timestamp = initial_timestamp;
+        for (i, value_change_item) in vcs.changes.iter().enumerate() {
+            if let ValueChangeItem::Timestamp { step } = value_change_item {
+                if *step < current_timestamp {
+                    bail!(VcdDumpError::TimestampsOutOfOrder(current_timestamp, *step));
+                }
+                current_timestamp = *step;
+                if i != 0 {
+                    writeln!(self.writer)?;
+                }
+            }
+            self.write_value_change_item(value_change_item)?;
+            write!(self.writer, " ")?;
+        }
+        Ok(())
+    }
+
+    pub fn write_value_change_item(&mut self, item: &ValueChangeItem) -> Result<()> {
+        match item {
+            ValueChangeItem::Timestamp { step } => {
+                write!(self.writer, "#{}", step)?;
+            }
+            ValueChangeItem::Scalar { identifier, value } => {
+                self.write_scalar_change(identifier, value)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn write_scalar_change(&mut self, identifier: &str, value: &ScalarValue) -> Result<()> {
+        let value = match value {
+            ScalarValue::Zero => "0",
+            ScalarValue::One => "1",
+            ScalarValue::X => "X",
+            ScalarValue::Z => "Z",
+        };
+        write!(self.writer, "{}{}", value, identifier)?;
+        Ok(())
+    }
+}
+
+/// A helper function using a `VcdWriter` to directly dump a given Vcd to
+/// a string containing equivalent VCD file contents.
+pub fn dump_vcd(vcd: &Vcd) -> Result<String> {
+    let mut vcd_bytes = Vec::new();
+    let mut writer = VcdWriter::new(&mut vcd_bytes);
+    writer.write_vcd(vcd)?;
+    writer.flush()?;
+    Ok(String::from_utf8(vcd_bytes).expect("Generated VCD should be UTF-8 compatible"))
+}

--- a/sw/host/opentitantool/src/command/gpio.rs
+++ b/sw/host/opentitantool/src/command/gpio.rs
@@ -9,7 +9,7 @@ use std::any::Any;
 use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{Read, Write};
+use std::io::Read;
 use std::rc::Rc;
 use std::str::FromStr;
 use std::time::Duration;
@@ -22,6 +22,9 @@ use opentitanlib::io::gpio::{
 use opentitanlib::transport::Capability;
 use opentitanlib::util::file;
 use opentitanlib::util::raw_tty::RawTty;
+use opentitanlib::util::vcd::{
+    dump_vcd_wire_vardefs, Header, ScalarValue, ValueChangeItem, ValueChangeSection, VcdWriter,
+};
 use opentitanlib::util::voltage::Voltage;
 
 #[derive(Debug, Args)]
@@ -382,64 +385,80 @@ fn write_vcd_header(
     clock_nature: ClockNature,
     start_response: &MonitoringStartResponse,
 ) -> Result<()> {
-    let mut file = File::create(file)?;
-    writeln!(&mut file, "$version")?;
+    let file = File::create(file)?;
+    let mut writer = VcdWriter::new(file);
     let version = super::version::VersionResponse::default();
-    writeln!(
-        &mut file,
-        "   opentitantool {} {}",
+    let version_str = format!(
+        "opentitantool {} {}",
         version.version.as_ref().map_or("<unknown>", String::as_str),
         match version.clean {
             Some(true) => "clean",
             Some(false) => "modified",
             None => "<unknown>",
         }
-    )?;
-    writeln!(&mut file, "$end")?;
-    match clock_nature {
+    );
+    let timescale_ps = match clock_nature {
         ClockNature::Wallclock { resolution, .. } => {
-            writeln!(
-                &mut file,
-                "$timescale {}ps $end",
-                1000000000000u64 / resolution
-            )?;
+            Some(1_000_000_000_000u128 / resolution as u128)
         }
-        ClockNature::Unspecified => (),
-    }
-    writeln!(&mut file, "$scope module logic $end")?;
-    for (n, pin) in pins.iter().enumerate() {
-        writeln!(&mut file, "$var wire 1 '{} {} $end", n, pin)?;
-    }
-    writeln!(&mut file, "$upscope $end")?;
-    writeln!(&mut file, "$enddefinitions $end")?;
-    writeln!(&mut file, "#{}", start_response.timestamp)?;
+        ClockNature::Unspecified => None,
+    };
+    writer.write_header(&Header {
+        timescale_ps,
+        date: None,
+        version: Some(version_str),
+    })?;
+    let pin_info = pins
+        .iter()
+        .enumerate()
+        .map(|(n, name)| (format!("'{}", n), Some(name.to_string())))
+        .collect::<Vec<_>>();
+    writer.write_vardefs(&dump_vcd_wire_vardefs(String::from("logic"), pin_info))?;
+    let mut changes = vec![ValueChangeItem::Timestamp {
+        step: start_response.timestamp as u128,
+    }];
     for (n, v) in start_response.initial_levels.iter().enumerate() {
-        writeln!(&mut file, "{}'{}", if *v { 1 } else { 0 }, n)?;
+        let value = if *v {
+            ScalarValue::One
+        } else {
+            ScalarValue::Zero
+        };
+        changes.push(ValueChangeItem::Scalar {
+            identifier: format!("'{}", n),
+            value,
+        });
     }
+    writer.write_value_change_section(&ValueChangeSection { changes }, 0u128)?;
+    writer.flush()?;
     Ok(())
 }
 
 /// Appends the VCD data to the end of the file specified. Note the order of the gpios should
 /// be consistent between calls and match the order from the gpio start command.
 fn append_vcd_data(file: &str, read_response: &MonitoringReadResponse, last: bool) -> Result<()> {
-    let mut file = std::fs::OpenOptions::new().append(true).open(file)?;
+    let file = std::fs::OpenOptions::new().append(true).open(file)?;
+    let mut writer = VcdWriter::new(file);
+    let mut changes = Vec::new();
     for event in &read_response.events {
-        writeln!(&mut file, "#{}", event.timestamp)?;
-        writeln!(
-            &mut file,
-            "{}'{}",
-            match event.edge {
-                Edge::Rising => 1,
-                Edge::Falling => 0,
-            },
-            event.signal_index
-        )?;
+        changes.push(ValueChangeItem::Timestamp {
+            step: event.timestamp as u128,
+        });
+        let identifier = format!("'{}", event.signal_index);
+        let value = match event.edge {
+            Edge::Rising => ScalarValue::One,
+            Edge::Falling => ScalarValue::Zero,
+        };
+        changes.push(ValueChangeItem::Scalar { identifier, value });
     }
     // Output timestamp of final reading (all signals remained stable from the last edge until
     // this time.)
     if last {
-        writeln!(&mut file, "#{}", read_response.timestamp)?;
+        writer.write_value_change_item(&ValueChangeItem::Timestamp {
+            step: read_response.timestamp as u128,
+        })?;
     }
+    writer.write_value_change_section(&ValueChangeSection { changes }, 0u128)?;
+    writer.flush()?;
     Ok(())
 }
 

--- a/sw/host/tests/chip/pattgen/pattgen_ios.rs
+++ b/sw/host/tests/chip/pattgen/pattgen_ios.rs
@@ -416,7 +416,7 @@ fn pattgen_ios(
                 if res.is_err() || opts.dump_waves {
                     log::info!(
                         "====[ VCD dump ]====\n{}\n====[ end dump ]====",
-                        waves.dump_vcd()
+                        waves.dump_vcd()?
                     );
                 }
                 res.with_context(|| format!("channel {i} did not meet expectations"))?;


### PR DESCRIPTION
Context: This is the 4th of a series of PRs (see #27612, #27613, #27614) to better integrate bitbanging utilities with opentitanlib, with a goal of recording waves that can be replayed during provisioning.

This PR introduces new utilities to dump GPIO samples to a VCD file format, and to parse VCDs back into GPIO samples. Supported is added for both uniform (discrete) samples that are returned by the `gpio_bitbanging` transport interface, as well as edge-represented waveforms as returned by the `gpio_monitoring` interface. This extends the `GpioMonitor` utility introduced in #22329 (replacing it to use this interface).

Support for parsing VCD samples is only currently extended to support enough functionality so that we can load back the dumped VCDs, with the intent that more features can be supported in the future if we find a need for them. 

~~One open question: the functionality to dump VCDs from edges overlaps with #24784, but there are some key differences (that interface involves directly writing to a file, and allows data to be continually appended). I'm unsure whether this small duplication is fine or if I should aim to refactor so that this new utility can support usage for that functionality as well.~~ The most recent force push refactors the VCD utility to generalise it enough that it can support this use case, so I have added a new commit that replaces this logic to use the VCD library as well.