### PR TITLE
[dt] Add clkmgr measurable clock information

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -557,6 +557,7 @@
 - [Device Software](./sw/device/README.md)
   - [Build & Test Rules](./rules/opentitan/README.md)
     - [Top selection](./hw/top/README.md)
+      - [Top description](./hw/top/doc/top_desc.md)
       - [Creating a new top](./hw/top/doc/create_top.md)
     - [FPGA Bitstreams](./hw/bitstream/README.md)
   - [Device Libraries](./sw/device/lib/README.md)

--- a/hw/ip_templates/clkmgr/defs.bzl.tpl
+++ b/hw/ip_templates/clkmgr/defs.bzl.tpl
@@ -8,4 +8,6 @@ CLKMGR = opentitan_ip(
     hjson = "//hw/top_${topname}/ip_autogen/clkmgr/data:clkmgr.hjson",
     ipconfig = "//hw/top_${topname}/ip_autogen/clkmgr/data:top_${topname}_clkmgr.ipconfig.hjson",
     extension = "//hw/top_${topname}/ip_autogen/clkmgr/util:dt",
+    dt_hdr_deps = ["//sw/device/lib/base:bitfield"],
+    dt_src_deps = ["//hw/top:clkmgr_c_regs"],
 )

--- a/hw/ip_templates/clkmgr/util/BUILD.bazel.tpl
+++ b/hw/ip_templates/clkmgr/util/BUILD.bazel.tpl
@@ -7,6 +7,9 @@ package(default_visibility = ["//visibility:public"])
 py_library(
     name = "ipconfig",
     srcs = ["ipconfig.py"],
+    deps = [
+        "//util/ipgen",
+    ],
 )
 
 py_library(

--- a/hw/ip_templates/clkmgr/util/dt.py
+++ b/hw/ip_templates/clkmgr/util/dt.py
@@ -4,7 +4,7 @@
 """This contains a class which is used to help generate the device tables (DT)
 files.
 """
-from dtgen.helper import IpHelper, Extension, StructType, ScalarType, ArrayMapType
+from dtgen.helper import indent_text, IpHelper, Extension, StructType, ScalarType, ArrayMapType
 from topgen.lib import Name
 from typing import Dict, Optional
 import os
@@ -51,6 +51,30 @@ size_t dt_clkmgr_hintable_clock_count(dt_clkmgr_t dt);
  * @return Instance ID of the device whose clock is hintable.
  */
 dt_instance_id_t dt_clkmgr_hintable_clock(dt_clkmgr_t dt, size_t idx);
+
+/**
+ * Description of a measurable clock.
+ *
+ */
+%(measurable_clk_struct)s
+
+/**
+ * Get the number of measurable clocks.
+ *
+ * @param dt Instance of clkmgr.
+ * @return Number of measurable clocks.
+ */
+size_t dt_clkmgr_measurable_clock_count(dt_clkmgr_t dt);
+
+/**
+ * Get the description of a measurable clock.
+ *
+ * @param dt Instance of clkmgr.
+ * @param idx Index of the measurable clock, between 0 and
+ *            `dt_clkmgr_measurable_clock_count(dt)-1`.
+ * @return Description of the measurable clock.
+ */
+%(measurable_clk_struct_name)s dt_clkmgr_measurable_clock(dt_clkmgr_t dt, size_t idx);
 """
 
 SOURCE_EXT_TEMPLATE = """
@@ -69,18 +93,84 @@ size_t dt_clkmgr_hintable_clock_count(dt_clkmgr_t dt) {
 dt_instance_id_t dt_clkmgr_hintable_clock(dt_clkmgr_t dt, size_t idx) {
   return TRY_GET_DT(dt, kDtInstanceIdUnknown)->clkmgr_ext.hint_clks[idx];
 }
+
+size_t dt_clkmgr_measurable_clock_count(dt_clkmgr_t dt) {
+  return %(measurable_clk_count)d;
+}
+
+%(measurable_clk_struct_name)s dt_clkmgr_measurable_clock(dt_clkmgr_t dt, size_t idx) {
+  %(measurable_clk_struct_name)s invalid_clk = %(invalid_measure_clk)s;
+  return TRY_GET_DT(dt, invalid_clk)->clkmgr_ext.measurable_clks[idx];
+}
 """
 
 
 class ClkmgrExt(Extension):
     SW_CLOCKS_FIELD_NAME = Name(["sw", "clks"])
     HINT_CLOCKS_FIELD_NAME = Name(["hint", "clks"])
+    MEASURABLE_CLOCKS_FIELD_NAME = Name(["measurable", "clks"])
+
+    MEASURABLE_CLOCK_STRUCT_NAME = Name.from_snake_case("dt_clkmgr_measurable_clk")
+    MEASURABLE_CLOCK_STRUCT_CLK_FIELD_NAME = Name(["clock"])
+    MEASURABLE_CLOCK_STRUCT_CTRL_EN_OFF_FIELD_NAME = Name(["meas", "ctrl", "en", "off"])
+    MEASURABLE_CLOCK_STRUCT_CTRL_EN_EN_OFF_FIELD_NAME = \
+        Name(["meas", "ctrl", "en", "en", "field"])
+    MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_FIELD_NAME = Name(["meas", "ctrl", "shadowed", "off"])
+    MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_LO_FIELD_NAME = \
+        Name(["meas", "ctrl", "shadowed", "lo", "field"])
+    MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_HI_FIELD_NAME = \
+        Name(["meas", "ctrl", "shadowed", "hi", "field"])
 
     def __init__(self, ip_helper: IpHelper):
         self.ip_helper = ip_helper
         if self.ip_helper.ipconfig is None:
             raise RuntimeError("the clkmgr extension requires the ipconfig to be provided")
         self.ipconfig = ClkmgrIpConfig(self.ip_helper.ipconfig)
+
+        # Create a type to represent a measurable clock.
+        self.measurable_clk_struct = StructType(self.MEASURABLE_CLOCK_STRUCT_NAME)
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_STRUCT_CLK_FIELD_NAME,
+            field_type = ScalarType(self.ip_helper.top_helper.DT_CLOCK_ENUM_NAME),
+            docstring = "Clock",
+        )
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_OFF_FIELD_NAME,
+            field_type = ScalarType("uint32_t"),
+            docstring = "MEAS_CTRL_EN register offset",
+        )
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_EN_OFF_FIELD_NAME,
+            field_type = ScalarType("bitfield_field32_t"),
+            docstring = "MEAS_CTRL_EN_EN bitfield",
+        )
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_FIELD_NAME,
+            field_type = ScalarType("uint32_t"),
+            docstring = "CTRL_SHADOWED register offset",
+        )
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_LO_FIELD_NAME,
+            field_type = ScalarType("bitfield_field32_t"),
+            docstring = "CTRL_SHADOWED_LO bitfield",
+        )
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_HI_FIELD_NAME,
+            field_type = ScalarType("bitfield_field32_t"),
+            docstring = "CTRL_SHADOWED_HI bitfield",
+        )
+
+        # For an invalid clock, use an invalid clock ID, empty bitfields and
+        # invalid offsets.
+        empty_bitfield = "((bitfield_field32_t) { .mask = 0, .index = 0 })"
+        self.invalid_clk = {
+            self.MEASURABLE_CLOCK_STRUCT_CLK_FIELD_NAME: Name(["count"]),
+            self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_OFF_FIELD_NAME: "0xdead",
+            self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_EN_OFF_FIELD_NAME: empty_bitfield,
+            self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_FIELD_NAME: "0xdead",
+            self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_LO_FIELD_NAME: empty_bitfield,
+            self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_HI_FIELD_NAME: empty_bitfield,
+        }
 
     @staticmethod
     def create_ext(ip_helper: IpHelper) -> Optional["Extension"]:
@@ -90,6 +180,7 @@ class ClkmgrExt(Extension):
     def extend_dt_ip(self) -> tuple[Name, StructType]:
         sw_clk_count = len(self.ipconfig.sw_clks())
         hint_clk_count = len(self.ipconfig.hint_clks())
+        measurable_clk_count = len(self.ipconfig.measurable_clks())
         instance_id_enum = self.ip_helper.top_helper.instance_id_enum
 
         st = StructType()
@@ -113,6 +204,16 @@ class ClkmgrExt(Extension):
             ),
             docstring = "List of hintable clocks, in the order of the register fields",
         )
+        # Add field to list measurable clocks.
+        st.add_field(
+            name = self.MEASURABLE_CLOCKS_FIELD_NAME,
+            field_type = ArrayMapType(
+                elem_type = self.measurable_clk_struct,
+                index_type = ScalarType("size_t"),
+                length = str(measurable_clk_count),
+            ),
+            docstring = "List of measurables clocks",
+        )
         return Name(["clkmgr_ext"]), st
 
     def fill_dt_ip(self, m) -> Dict:
@@ -122,23 +223,53 @@ class ClkmgrExt(Extension):
         hint_clks = {}
         for (idx, clk) in enumerate(self.ipconfig.hint_clks()):
             hint_clks[str(idx)] = Name.from_snake_case(clk["module"])
+        measurable_clks = {}
+        for (idx, clk) in enumerate(self.ipconfig.measurable_clks()):
+            reg_prefix = "CLKMGR_{}_MEAS_CTRL_".format(clk.upper())
+            measurable_clks[str(idx)] = {
+                self.MEASURABLE_CLOCK_STRUCT_CLK_FIELD_NAME: Name.from_snake_case(clk),
+                self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_OFF_FIELD_NAME:
+                    reg_prefix + "EN_REG_OFFSET",
+                self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_EN_OFF_FIELD_NAME:
+                    reg_prefix + "EN_EN_FIELD",
+                self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_FIELD_NAME:
+                    reg_prefix + "SHADOWED_REG_OFFSET",
+                self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_LO_FIELD_NAME:
+                    reg_prefix + "SHADOWED_LO_FIELD",
+                self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_HI_FIELD_NAME:
+                    reg_prefix + "SHADOWED_HI_FIELD",
+            }
 
         return {
             self.SW_CLOCKS_FIELD_NAME: sw_clks,
             self.HINT_CLOCKS_FIELD_NAME: hint_clks,
+            self.MEASURABLE_CLOCKS_FIELD_NAME: measurable_clks,
         }
 
     def render_dt_ip(self, pos: Extension.DtIpPos) -> str:
         sw_clk_count = len(self.ipconfig.sw_clks())
         hint_clk_count = len(self.ipconfig.hint_clks())
+        measurable_clk_count = len(self.ipconfig.measurable_clks())
 
         if pos == Extension.DtIpPos.HeaderEnd:
-            return HEADER_EXT_TEMPLATE
+            subs = {
+                'measurable_clk_struct': self.measurable_clk_struct.render_type_def(),
+                'measurable_clk_struct_name': self.MEASURABLE_CLOCK_STRUCT_NAME.as_c_type(),
+            }
+            return HEADER_EXT_TEMPLATE % subs
         elif pos == Extension.DtIpPos.SourceEnd:
             subs = {
                 'sw_clk_count': sw_clk_count,
                 'hint_clk_count': hint_clk_count,
+                'measurable_clk_count': measurable_clk_count,
+                'invalid_measure_clk':
+                    indent_text(self.measurable_clk_struct.render_value(self.invalid_clk), "  "),
+                'measurable_clk_struct_name': self.MEASURABLE_CLOCK_STRUCT_NAME.as_c_type(),
             }
             return SOURCE_EXT_TEMPLATE % subs
+        elif pos == Extension.DtIpPos.SourceIncludes:
+            return '#include "clkmgr_regs.h"'
+        elif pos == Extension.DtIpPos.HeaderIncludes:
+            return '#include "sw/device/lib/base/bitfield.h"'
         else:
             return ""

--- a/hw/ip_templates/clkmgr/util/ipconfig.py
+++ b/hw/ip_templates/clkmgr/util/ipconfig.py
@@ -7,6 +7,8 @@ files.
 """
 from typing import List, Dict
 
+from ipgen.clkmgr_gen import get_rg_srcs
+
 
 class ClkmgrIpConfig:
     def __init__(self, ipconfig: object):
@@ -49,3 +51,12 @@ class ClkmgrIpConfig:
             }
             for clk in self.param_values["typed_clocks"]["hint_clks"].values()
         ]
+
+    def measurable_clks(self) -> List[str]:
+        """
+        Return the list of measurable clocks: each clock is described by its
+        name.
+        """
+        # Currently, the clkmgr measures every root-gated clock.
+        rg_srcs = get_rg_srcs(self.param_values["typed_clocks"])
+        return rg_srcs

--- a/hw/top/BUILD
+++ b/hw/top/BUILD
@@ -19,6 +19,7 @@ load(
     "opentitan_alias_top_attr",
     "opentitan_if_ip",
     "opentitan_require_ip",
+    "opentitan_select_ip_attr",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -102,14 +103,27 @@ cc_library(
     ]),
     # Make the header accessible as "dt_<ip>.h".
     includes = ["."],
-    deps = [":dt_api"],
+    deps = [":dt_api"] + flatten([
+        opentitan_select_ip_attr(
+            ip,
+            "dt_hdr_deps",
+            default = [],
+            required = False,
+        )
+        for ip in ALL_IP_NAMES
+    ]),
 )
 
 [
     cc_library(
         name = "dt_{}".format(ip),
         srcs = [":dt_{}_src".format(ip)],
-        deps = [":dt_headers"],
+        deps = [":dt_headers"] + opentitan_select_ip_attr(
+            ip,
+            "dt_src_deps",
+            default = [],
+            required = False,
+        ),
     )
     for ip in ALL_IP_NAMES
 ]

--- a/hw/top/BUILD
+++ b/hw/top/BUILD
@@ -7,7 +7,7 @@ load("//rules/opentitan:util.bzl", "flatten")
 load(
     "//rules:autogen.bzl",
     "opentitan_ip_c_header",
-    "opentitan_ip_dt_header",
+    "opentitan_ip_dt",
     "opentitan_ip_rust_header",
     "opentitan_top_dt_api",
 )
@@ -82,11 +82,10 @@ opentitan_top_dt_api(
 )
 
 [
-    opentitan_ip_dt_header(
+    opentitan_ip_dt(
         name = "dt_{}".format(ip),
         ip = ip,
         target_compatible_with = opentitan_require_ip(ip),
-        deps = [":dt_api"],
     )
     for ip in ALL_IP_NAMES
 ]

--- a/hw/top/README.md
+++ b/hw/top/README.md
@@ -69,7 +69,7 @@ It is generally recommended that device code either depends on `//hw/top:dt` if 
 
 ### Top description
 
-Each top has a description in Bazel created by `opentitan_top` which can be used to tweak the build graph. See [./top_desc.md] for more details.
+Each top has a description in Bazel created by `opentitan_top` which can be used to tweak the build graph. See [./doc/top_desc.md] for more details.
 
 ### Compatibility annotations
 
@@ -135,7 +135,7 @@ cc_library(
 )
 ```
 
-There more macro available to access the top's description, see [./top_desc.md] for more details.
+There more macro available to access the top's description, see [./doc/top_desc.md] for more details.
 
 ## Common operations
 

--- a/hw/top/doc/top_desc.md
+++ b/hw/top/doc/top_desc.md
@@ -34,7 +34,7 @@ MATCHA = opentitan_top(
 )
 ```
 
-Since this process can be quite tedious, parts of it are automated by topgen, see the documentation [top creation](./doc/create_top.md).
+Since this process can be quite tedious, parts of it are automated by topgen, see the documentation [top creation](./create_top.md).
 The list of attributes is explained in more details in the following sections.
 
 ## Attributes

--- a/hw/top/top_desc.md
+++ b/hw/top/top_desc.md
@@ -67,6 +67,8 @@ The following attributes have a well-defined meaning in the codebase:
 - `hjson`: label string of the Hjson description file of the IP.
 - `ipconfig`: for generated IPs, this is label string of the `<top>_<ip>.ipconfig.hjson` file created by `ipgen`.
 - `extension`: for IPs which want to provide an extension plugin to `dtgen`, this is the label-string of the `py_library` of the extension.
+- `dt_hdr_deps`: extra dependencies which will be added to the `cc_library` target containing the DT header for this IP.
+- `dt_src_deps`: extra dependencies which will be added to the `cc_library` target containing the DT source for this IP.
 
 Example for the `uart` IP:
 ```py

--- a/hw/top_darjeeling/ip_autogen/clkmgr/defs.bzl
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/defs.bzl
@@ -8,4 +8,6 @@ CLKMGR = opentitan_ip(
     hjson = "//hw/top_darjeeling/ip_autogen/clkmgr/data:clkmgr.hjson",
     ipconfig = "//hw/top_darjeeling/ip_autogen/clkmgr/data:top_darjeeling_clkmgr.ipconfig.hjson",
     extension = "//hw/top_darjeeling/ip_autogen/clkmgr/util:dt",
+    dt_hdr_deps = ["//sw/device/lib/base:bitfield"],
+    dt_src_deps = ["//hw/top:clkmgr_c_regs"],
 )

--- a/hw/top_darjeeling/ip_autogen/clkmgr/util/BUILD.bazel
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/util/BUILD.bazel
@@ -7,6 +7,9 @@ package(default_visibility = ["//visibility:public"])
 py_library(
     name = "ipconfig",
     srcs = ["ipconfig.py"],
+    deps = [
+        "//util/ipgen",
+    ],
 )
 
 py_library(

--- a/hw/top_darjeeling/ip_autogen/clkmgr/util/dt.py
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/util/dt.py
@@ -4,7 +4,7 @@
 """This contains a class which is used to help generate the device tables (DT)
 files.
 """
-from dtgen.helper import IpHelper, Extension, StructType, ScalarType, ArrayMapType
+from dtgen.helper import indent_text, IpHelper, Extension, StructType, ScalarType, ArrayMapType
 from topgen.lib import Name
 from typing import Dict, Optional
 import os
@@ -51,6 +51,30 @@ size_t dt_clkmgr_hintable_clock_count(dt_clkmgr_t dt);
  * @return Instance ID of the device whose clock is hintable.
  */
 dt_instance_id_t dt_clkmgr_hintable_clock(dt_clkmgr_t dt, size_t idx);
+
+/**
+ * Description of a measurable clock.
+ *
+ */
+%(measurable_clk_struct)s
+
+/**
+ * Get the number of measurable clocks.
+ *
+ * @param dt Instance of clkmgr.
+ * @return Number of measurable clocks.
+ */
+size_t dt_clkmgr_measurable_clock_count(dt_clkmgr_t dt);
+
+/**
+ * Get the description of a measurable clock.
+ *
+ * @param dt Instance of clkmgr.
+ * @param idx Index of the measurable clock, between 0 and
+ *            `dt_clkmgr_measurable_clock_count(dt)-1`.
+ * @return Description of the measurable clock.
+ */
+%(measurable_clk_struct_name)s dt_clkmgr_measurable_clock(dt_clkmgr_t dt, size_t idx);
 """
 
 SOURCE_EXT_TEMPLATE = """
@@ -69,18 +93,84 @@ size_t dt_clkmgr_hintable_clock_count(dt_clkmgr_t dt) {
 dt_instance_id_t dt_clkmgr_hintable_clock(dt_clkmgr_t dt, size_t idx) {
   return TRY_GET_DT(dt, kDtInstanceIdUnknown)->clkmgr_ext.hint_clks[idx];
 }
+
+size_t dt_clkmgr_measurable_clock_count(dt_clkmgr_t dt) {
+  return %(measurable_clk_count)d;
+}
+
+%(measurable_clk_struct_name)s dt_clkmgr_measurable_clock(dt_clkmgr_t dt, size_t idx) {
+  %(measurable_clk_struct_name)s invalid_clk = %(invalid_measure_clk)s;
+  return TRY_GET_DT(dt, invalid_clk)->clkmgr_ext.measurable_clks[idx];
+}
 """
 
 
 class ClkmgrExt(Extension):
     SW_CLOCKS_FIELD_NAME = Name(["sw", "clks"])
     HINT_CLOCKS_FIELD_NAME = Name(["hint", "clks"])
+    MEASURABLE_CLOCKS_FIELD_NAME = Name(["measurable", "clks"])
+
+    MEASURABLE_CLOCK_STRUCT_NAME = Name.from_snake_case("dt_clkmgr_measurable_clk")
+    MEASURABLE_CLOCK_STRUCT_CLK_FIELD_NAME = Name(["clock"])
+    MEASURABLE_CLOCK_STRUCT_CTRL_EN_OFF_FIELD_NAME = Name(["meas", "ctrl", "en", "off"])
+    MEASURABLE_CLOCK_STRUCT_CTRL_EN_EN_OFF_FIELD_NAME = \
+        Name(["meas", "ctrl", "en", "en", "field"])
+    MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_FIELD_NAME = Name(["meas", "ctrl", "shadowed", "off"])
+    MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_LO_FIELD_NAME = \
+        Name(["meas", "ctrl", "shadowed", "lo", "field"])
+    MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_HI_FIELD_NAME = \
+        Name(["meas", "ctrl", "shadowed", "hi", "field"])
 
     def __init__(self, ip_helper: IpHelper):
         self.ip_helper = ip_helper
         if self.ip_helper.ipconfig is None:
             raise RuntimeError("the clkmgr extension requires the ipconfig to be provided")
         self.ipconfig = ClkmgrIpConfig(self.ip_helper.ipconfig)
+
+        # Create a type to represent a measurable clock.
+        self.measurable_clk_struct = StructType(self.MEASURABLE_CLOCK_STRUCT_NAME)
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_STRUCT_CLK_FIELD_NAME,
+            field_type = ScalarType(self.ip_helper.top_helper.DT_CLOCK_ENUM_NAME),
+            docstring = "Clock",
+        )
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_OFF_FIELD_NAME,
+            field_type = ScalarType("uint32_t"),
+            docstring = "MEAS_CTRL_EN register offset",
+        )
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_EN_OFF_FIELD_NAME,
+            field_type = ScalarType("bitfield_field32_t"),
+            docstring = "MEAS_CTRL_EN_EN bitfield",
+        )
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_FIELD_NAME,
+            field_type = ScalarType("uint32_t"),
+            docstring = "CTRL_SHADOWED register offset",
+        )
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_LO_FIELD_NAME,
+            field_type = ScalarType("bitfield_field32_t"),
+            docstring = "CTRL_SHADOWED_LO bitfield",
+        )
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_HI_FIELD_NAME,
+            field_type = ScalarType("bitfield_field32_t"),
+            docstring = "CTRL_SHADOWED_HI bitfield",
+        )
+
+        # For an invalid clock, use an invalid clock ID, empty bitfields and
+        # invalid offsets.
+        empty_bitfield = "((bitfield_field32_t) { .mask = 0, .index = 0 })"
+        self.invalid_clk = {
+            self.MEASURABLE_CLOCK_STRUCT_CLK_FIELD_NAME: Name(["count"]),
+            self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_OFF_FIELD_NAME: "0xdead",
+            self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_EN_OFF_FIELD_NAME: empty_bitfield,
+            self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_FIELD_NAME: "0xdead",
+            self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_LO_FIELD_NAME: empty_bitfield,
+            self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_HI_FIELD_NAME: empty_bitfield,
+        }
 
     @staticmethod
     def create_ext(ip_helper: IpHelper) -> Optional["Extension"]:
@@ -90,6 +180,7 @@ class ClkmgrExt(Extension):
     def extend_dt_ip(self) -> tuple[Name, StructType]:
         sw_clk_count = len(self.ipconfig.sw_clks())
         hint_clk_count = len(self.ipconfig.hint_clks())
+        measurable_clk_count = len(self.ipconfig.measurable_clks())
         instance_id_enum = self.ip_helper.top_helper.instance_id_enum
 
         st = StructType()
@@ -113,6 +204,16 @@ class ClkmgrExt(Extension):
             ),
             docstring = "List of hintable clocks, in the order of the register fields",
         )
+        # Add field to list measurable clocks.
+        st.add_field(
+            name = self.MEASURABLE_CLOCKS_FIELD_NAME,
+            field_type = ArrayMapType(
+                elem_type = self.measurable_clk_struct,
+                index_type = ScalarType("size_t"),
+                length = str(measurable_clk_count),
+            ),
+            docstring = "List of measurables clocks",
+        )
         return Name(["clkmgr_ext"]), st
 
     def fill_dt_ip(self, m) -> Dict:
@@ -122,23 +223,53 @@ class ClkmgrExt(Extension):
         hint_clks = {}
         for (idx, clk) in enumerate(self.ipconfig.hint_clks()):
             hint_clks[str(idx)] = Name.from_snake_case(clk["module"])
+        measurable_clks = {}
+        for (idx, clk) in enumerate(self.ipconfig.measurable_clks()):
+            reg_prefix = "CLKMGR_{}_MEAS_CTRL_".format(clk.upper())
+            measurable_clks[str(idx)] = {
+                self.MEASURABLE_CLOCK_STRUCT_CLK_FIELD_NAME: Name.from_snake_case(clk),
+                self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_OFF_FIELD_NAME:
+                    reg_prefix + "EN_REG_OFFSET",
+                self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_EN_OFF_FIELD_NAME:
+                    reg_prefix + "EN_EN_FIELD",
+                self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_FIELD_NAME:
+                    reg_prefix + "SHADOWED_REG_OFFSET",
+                self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_LO_FIELD_NAME:
+                    reg_prefix + "SHADOWED_LO_FIELD",
+                self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_HI_FIELD_NAME:
+                    reg_prefix + "SHADOWED_HI_FIELD",
+            }
 
         return {
             self.SW_CLOCKS_FIELD_NAME: sw_clks,
             self.HINT_CLOCKS_FIELD_NAME: hint_clks,
+            self.MEASURABLE_CLOCKS_FIELD_NAME: measurable_clks,
         }
 
     def render_dt_ip(self, pos: Extension.DtIpPos) -> str:
         sw_clk_count = len(self.ipconfig.sw_clks())
         hint_clk_count = len(self.ipconfig.hint_clks())
+        measurable_clk_count = len(self.ipconfig.measurable_clks())
 
         if pos == Extension.DtIpPos.HeaderEnd:
-            return HEADER_EXT_TEMPLATE
+            subs = {
+                'measurable_clk_struct': self.measurable_clk_struct.render_type_def(),
+                'measurable_clk_struct_name': self.MEASURABLE_CLOCK_STRUCT_NAME.as_c_type(),
+            }
+            return HEADER_EXT_TEMPLATE % subs
         elif pos == Extension.DtIpPos.SourceEnd:
             subs = {
                 'sw_clk_count': sw_clk_count,
                 'hint_clk_count': hint_clk_count,
+                'measurable_clk_count': measurable_clk_count,
+                'invalid_measure_clk':
+                    indent_text(self.measurable_clk_struct.render_value(self.invalid_clk), "  "),
+                'measurable_clk_struct_name': self.MEASURABLE_CLOCK_STRUCT_NAME.as_c_type(),
             }
             return SOURCE_EXT_TEMPLATE % subs
+        elif pos == Extension.DtIpPos.SourceIncludes:
+            return '#include "clkmgr_regs.h"'
+        elif pos == Extension.DtIpPos.HeaderIncludes:
+            return '#include "sw/device/lib/base/bitfield.h"'
         else:
             return ""

--- a/hw/top_darjeeling/ip_autogen/clkmgr/util/ipconfig.py
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/util/ipconfig.py
@@ -7,6 +7,8 @@ files.
 """
 from typing import List, Dict
 
+from ipgen.clkmgr_gen import get_rg_srcs
+
 
 class ClkmgrIpConfig:
     def __init__(self, ipconfig: object):
@@ -49,3 +51,12 @@ class ClkmgrIpConfig:
             }
             for clk in self.param_values["typed_clocks"]["hint_clks"].values()
         ]
+
+    def measurable_clks(self) -> List[str]:
+        """
+        Return the list of measurable clocks: each clock is described by its
+        name.
+        """
+        # Currently, the clkmgr measures every root-gated clock.
+        rg_srcs = get_rg_srcs(self.param_values["typed_clocks"])
+        return rg_srcs

--- a/hw/top_earlgrey/ip_autogen/clkmgr/defs.bzl
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/defs.bzl
@@ -8,4 +8,6 @@ CLKMGR = opentitan_ip(
     hjson = "//hw/top_earlgrey/ip_autogen/clkmgr/data:clkmgr.hjson",
     ipconfig = "//hw/top_earlgrey/ip_autogen/clkmgr/data:top_earlgrey_clkmgr.ipconfig.hjson",
     extension = "//hw/top_earlgrey/ip_autogen/clkmgr/util:dt",
+    dt_hdr_deps = ["//sw/device/lib/base:bitfield"],
+    dt_src_deps = ["//hw/top:clkmgr_c_regs"],
 )

--- a/hw/top_earlgrey/ip_autogen/clkmgr/util/BUILD.bazel
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/util/BUILD.bazel
@@ -7,6 +7,9 @@ package(default_visibility = ["//visibility:public"])
 py_library(
     name = "ipconfig",
     srcs = ["ipconfig.py"],
+    deps = [
+        "//util/ipgen",
+    ],
 )
 
 py_library(

--- a/hw/top_earlgrey/ip_autogen/clkmgr/util/dt.py
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/util/dt.py
@@ -4,7 +4,7 @@
 """This contains a class which is used to help generate the device tables (DT)
 files.
 """
-from dtgen.helper import IpHelper, Extension, StructType, ScalarType, ArrayMapType
+from dtgen.helper import indent_text, IpHelper, Extension, StructType, ScalarType, ArrayMapType
 from topgen.lib import Name
 from typing import Dict, Optional
 import os
@@ -51,6 +51,30 @@ size_t dt_clkmgr_hintable_clock_count(dt_clkmgr_t dt);
  * @return Instance ID of the device whose clock is hintable.
  */
 dt_instance_id_t dt_clkmgr_hintable_clock(dt_clkmgr_t dt, size_t idx);
+
+/**
+ * Description of a measurable clock.
+ *
+ */
+%(measurable_clk_struct)s
+
+/**
+ * Get the number of measurable clocks.
+ *
+ * @param dt Instance of clkmgr.
+ * @return Number of measurable clocks.
+ */
+size_t dt_clkmgr_measurable_clock_count(dt_clkmgr_t dt);
+
+/**
+ * Get the description of a measurable clock.
+ *
+ * @param dt Instance of clkmgr.
+ * @param idx Index of the measurable clock, between 0 and
+ *            `dt_clkmgr_measurable_clock_count(dt)-1`.
+ * @return Description of the measurable clock.
+ */
+%(measurable_clk_struct_name)s dt_clkmgr_measurable_clock(dt_clkmgr_t dt, size_t idx);
 """
 
 SOURCE_EXT_TEMPLATE = """
@@ -69,18 +93,84 @@ size_t dt_clkmgr_hintable_clock_count(dt_clkmgr_t dt) {
 dt_instance_id_t dt_clkmgr_hintable_clock(dt_clkmgr_t dt, size_t idx) {
   return TRY_GET_DT(dt, kDtInstanceIdUnknown)->clkmgr_ext.hint_clks[idx];
 }
+
+size_t dt_clkmgr_measurable_clock_count(dt_clkmgr_t dt) {
+  return %(measurable_clk_count)d;
+}
+
+%(measurable_clk_struct_name)s dt_clkmgr_measurable_clock(dt_clkmgr_t dt, size_t idx) {
+  %(measurable_clk_struct_name)s invalid_clk = %(invalid_measure_clk)s;
+  return TRY_GET_DT(dt, invalid_clk)->clkmgr_ext.measurable_clks[idx];
+}
 """
 
 
 class ClkmgrExt(Extension):
     SW_CLOCKS_FIELD_NAME = Name(["sw", "clks"])
     HINT_CLOCKS_FIELD_NAME = Name(["hint", "clks"])
+    MEASURABLE_CLOCKS_FIELD_NAME = Name(["measurable", "clks"])
+
+    MEASURABLE_CLOCK_STRUCT_NAME = Name.from_snake_case("dt_clkmgr_measurable_clk")
+    MEASURABLE_CLOCK_STRUCT_CLK_FIELD_NAME = Name(["clock"])
+    MEASURABLE_CLOCK_STRUCT_CTRL_EN_OFF_FIELD_NAME = Name(["meas", "ctrl", "en", "off"])
+    MEASURABLE_CLOCK_STRUCT_CTRL_EN_EN_OFF_FIELD_NAME = \
+        Name(["meas", "ctrl", "en", "en", "field"])
+    MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_FIELD_NAME = Name(["meas", "ctrl", "shadowed", "off"])
+    MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_LO_FIELD_NAME = \
+        Name(["meas", "ctrl", "shadowed", "lo", "field"])
+    MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_HI_FIELD_NAME = \
+        Name(["meas", "ctrl", "shadowed", "hi", "field"])
 
     def __init__(self, ip_helper: IpHelper):
         self.ip_helper = ip_helper
         if self.ip_helper.ipconfig is None:
             raise RuntimeError("the clkmgr extension requires the ipconfig to be provided")
         self.ipconfig = ClkmgrIpConfig(self.ip_helper.ipconfig)
+
+        # Create a type to represent a measurable clock.
+        self.measurable_clk_struct = StructType(self.MEASURABLE_CLOCK_STRUCT_NAME)
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_STRUCT_CLK_FIELD_NAME,
+            field_type = ScalarType(self.ip_helper.top_helper.DT_CLOCK_ENUM_NAME),
+            docstring = "Clock",
+        )
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_OFF_FIELD_NAME,
+            field_type = ScalarType("uint32_t"),
+            docstring = "MEAS_CTRL_EN register offset",
+        )
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_EN_OFF_FIELD_NAME,
+            field_type = ScalarType("bitfield_field32_t"),
+            docstring = "MEAS_CTRL_EN_EN bitfield",
+        )
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_FIELD_NAME,
+            field_type = ScalarType("uint32_t"),
+            docstring = "CTRL_SHADOWED register offset",
+        )
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_LO_FIELD_NAME,
+            field_type = ScalarType("bitfield_field32_t"),
+            docstring = "CTRL_SHADOWED_LO bitfield",
+        )
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_HI_FIELD_NAME,
+            field_type = ScalarType("bitfield_field32_t"),
+            docstring = "CTRL_SHADOWED_HI bitfield",
+        )
+
+        # For an invalid clock, use an invalid clock ID, empty bitfields and
+        # invalid offsets.
+        empty_bitfield = "((bitfield_field32_t) { .mask = 0, .index = 0 })"
+        self.invalid_clk = {
+            self.MEASURABLE_CLOCK_STRUCT_CLK_FIELD_NAME: Name(["count"]),
+            self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_OFF_FIELD_NAME: "0xdead",
+            self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_EN_OFF_FIELD_NAME: empty_bitfield,
+            self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_FIELD_NAME: "0xdead",
+            self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_LO_FIELD_NAME: empty_bitfield,
+            self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_HI_FIELD_NAME: empty_bitfield,
+        }
 
     @staticmethod
     def create_ext(ip_helper: IpHelper) -> Optional["Extension"]:
@@ -90,6 +180,7 @@ class ClkmgrExt(Extension):
     def extend_dt_ip(self) -> tuple[Name, StructType]:
         sw_clk_count = len(self.ipconfig.sw_clks())
         hint_clk_count = len(self.ipconfig.hint_clks())
+        measurable_clk_count = len(self.ipconfig.measurable_clks())
         instance_id_enum = self.ip_helper.top_helper.instance_id_enum
 
         st = StructType()
@@ -113,6 +204,16 @@ class ClkmgrExt(Extension):
             ),
             docstring = "List of hintable clocks, in the order of the register fields",
         )
+        # Add field to list measurable clocks.
+        st.add_field(
+            name = self.MEASURABLE_CLOCKS_FIELD_NAME,
+            field_type = ArrayMapType(
+                elem_type = self.measurable_clk_struct,
+                index_type = ScalarType("size_t"),
+                length = str(measurable_clk_count),
+            ),
+            docstring = "List of measurables clocks",
+        )
         return Name(["clkmgr_ext"]), st
 
     def fill_dt_ip(self, m) -> Dict:
@@ -122,23 +223,53 @@ class ClkmgrExt(Extension):
         hint_clks = {}
         for (idx, clk) in enumerate(self.ipconfig.hint_clks()):
             hint_clks[str(idx)] = Name.from_snake_case(clk["module"])
+        measurable_clks = {}
+        for (idx, clk) in enumerate(self.ipconfig.measurable_clks()):
+            reg_prefix = "CLKMGR_{}_MEAS_CTRL_".format(clk.upper())
+            measurable_clks[str(idx)] = {
+                self.MEASURABLE_CLOCK_STRUCT_CLK_FIELD_NAME: Name.from_snake_case(clk),
+                self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_OFF_FIELD_NAME:
+                    reg_prefix + "EN_REG_OFFSET",
+                self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_EN_OFF_FIELD_NAME:
+                    reg_prefix + "EN_EN_FIELD",
+                self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_FIELD_NAME:
+                    reg_prefix + "SHADOWED_REG_OFFSET",
+                self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_LO_FIELD_NAME:
+                    reg_prefix + "SHADOWED_LO_FIELD",
+                self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_HI_FIELD_NAME:
+                    reg_prefix + "SHADOWED_HI_FIELD",
+            }
 
         return {
             self.SW_CLOCKS_FIELD_NAME: sw_clks,
             self.HINT_CLOCKS_FIELD_NAME: hint_clks,
+            self.MEASURABLE_CLOCKS_FIELD_NAME: measurable_clks,
         }
 
     def render_dt_ip(self, pos: Extension.DtIpPos) -> str:
         sw_clk_count = len(self.ipconfig.sw_clks())
         hint_clk_count = len(self.ipconfig.hint_clks())
+        measurable_clk_count = len(self.ipconfig.measurable_clks())
 
         if pos == Extension.DtIpPos.HeaderEnd:
-            return HEADER_EXT_TEMPLATE
+            subs = {
+                'measurable_clk_struct': self.measurable_clk_struct.render_type_def(),
+                'measurable_clk_struct_name': self.MEASURABLE_CLOCK_STRUCT_NAME.as_c_type(),
+            }
+            return HEADER_EXT_TEMPLATE % subs
         elif pos == Extension.DtIpPos.SourceEnd:
             subs = {
                 'sw_clk_count': sw_clk_count,
                 'hint_clk_count': hint_clk_count,
+                'measurable_clk_count': measurable_clk_count,
+                'invalid_measure_clk':
+                    indent_text(self.measurable_clk_struct.render_value(self.invalid_clk), "  "),
+                'measurable_clk_struct_name': self.MEASURABLE_CLOCK_STRUCT_NAME.as_c_type(),
             }
             return SOURCE_EXT_TEMPLATE % subs
+        elif pos == Extension.DtIpPos.SourceIncludes:
+            return '#include "clkmgr_regs.h"'
+        elif pos == Extension.DtIpPos.HeaderIncludes:
+            return '#include "sw/device/lib/base/bitfield.h"'
         else:
             return ""

--- a/hw/top_earlgrey/ip_autogen/clkmgr/util/ipconfig.py
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/util/ipconfig.py
@@ -7,6 +7,8 @@ files.
 """
 from typing import List, Dict
 
+from ipgen.clkmgr_gen import get_rg_srcs
+
 
 class ClkmgrIpConfig:
     def __init__(self, ipconfig: object):
@@ -49,3 +51,12 @@ class ClkmgrIpConfig:
             }
             for clk in self.param_values["typed_clocks"]["hint_clks"].values()
         ]
+
+    def measurable_clks(self) -> List[str]:
+        """
+        Return the list of measurable clocks: each clock is described by its
+        name.
+        """
+        # Currently, the clkmgr measures every root-gated clock.
+        rg_srcs = get_rg_srcs(self.param_values["typed_clocks"])
+        return rg_srcs

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/defs.bzl
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/defs.bzl
@@ -8,4 +8,6 @@ CLKMGR = opentitan_ip(
     hjson = "//hw/top_englishbreakfast/ip_autogen/clkmgr/data:clkmgr.hjson",
     ipconfig = "//hw/top_englishbreakfast/ip_autogen/clkmgr/data:top_englishbreakfast_clkmgr.ipconfig.hjson",
     extension = "//hw/top_englishbreakfast/ip_autogen/clkmgr/util:dt",
+    dt_hdr_deps = ["//sw/device/lib/base:bitfield"],
+    dt_src_deps = ["//hw/top:clkmgr_c_regs"],
 )

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/util/BUILD.bazel
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/util/BUILD.bazel
@@ -7,6 +7,9 @@ package(default_visibility = ["//visibility:public"])
 py_library(
     name = "ipconfig",
     srcs = ["ipconfig.py"],
+    deps = [
+        "//util/ipgen",
+    ],
 )
 
 py_library(

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/util/dt.py
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/util/dt.py
@@ -4,7 +4,7 @@
 """This contains a class which is used to help generate the device tables (DT)
 files.
 """
-from dtgen.helper import IpHelper, Extension, StructType, ScalarType, ArrayMapType
+from dtgen.helper import indent_text, IpHelper, Extension, StructType, ScalarType, ArrayMapType
 from topgen.lib import Name
 from typing import Dict, Optional
 import os
@@ -51,6 +51,30 @@ size_t dt_clkmgr_hintable_clock_count(dt_clkmgr_t dt);
  * @return Instance ID of the device whose clock is hintable.
  */
 dt_instance_id_t dt_clkmgr_hintable_clock(dt_clkmgr_t dt, size_t idx);
+
+/**
+ * Description of a measurable clock.
+ *
+ */
+%(measurable_clk_struct)s
+
+/**
+ * Get the number of measurable clocks.
+ *
+ * @param dt Instance of clkmgr.
+ * @return Number of measurable clocks.
+ */
+size_t dt_clkmgr_measurable_clock_count(dt_clkmgr_t dt);
+
+/**
+ * Get the description of a measurable clock.
+ *
+ * @param dt Instance of clkmgr.
+ * @param idx Index of the measurable clock, between 0 and
+ *            `dt_clkmgr_measurable_clock_count(dt)-1`.
+ * @return Description of the measurable clock.
+ */
+%(measurable_clk_struct_name)s dt_clkmgr_measurable_clock(dt_clkmgr_t dt, size_t idx);
 """
 
 SOURCE_EXT_TEMPLATE = """
@@ -69,18 +93,84 @@ size_t dt_clkmgr_hintable_clock_count(dt_clkmgr_t dt) {
 dt_instance_id_t dt_clkmgr_hintable_clock(dt_clkmgr_t dt, size_t idx) {
   return TRY_GET_DT(dt, kDtInstanceIdUnknown)->clkmgr_ext.hint_clks[idx];
 }
+
+size_t dt_clkmgr_measurable_clock_count(dt_clkmgr_t dt) {
+  return %(measurable_clk_count)d;
+}
+
+%(measurable_clk_struct_name)s dt_clkmgr_measurable_clock(dt_clkmgr_t dt, size_t idx) {
+  %(measurable_clk_struct_name)s invalid_clk = %(invalid_measure_clk)s;
+  return TRY_GET_DT(dt, invalid_clk)->clkmgr_ext.measurable_clks[idx];
+}
 """
 
 
 class ClkmgrExt(Extension):
     SW_CLOCKS_FIELD_NAME = Name(["sw", "clks"])
     HINT_CLOCKS_FIELD_NAME = Name(["hint", "clks"])
+    MEASURABLE_CLOCKS_FIELD_NAME = Name(["measurable", "clks"])
+
+    MEASURABLE_CLOCK_STRUCT_NAME = Name.from_snake_case("dt_clkmgr_measurable_clk")
+    MEASURABLE_CLOCK_STRUCT_CLK_FIELD_NAME = Name(["clock"])
+    MEASURABLE_CLOCK_STRUCT_CTRL_EN_OFF_FIELD_NAME = Name(["meas", "ctrl", "en", "off"])
+    MEASURABLE_CLOCK_STRUCT_CTRL_EN_EN_OFF_FIELD_NAME = \
+        Name(["meas", "ctrl", "en", "en", "field"])
+    MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_FIELD_NAME = Name(["meas", "ctrl", "shadowed", "off"])
+    MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_LO_FIELD_NAME = \
+        Name(["meas", "ctrl", "shadowed", "lo", "field"])
+    MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_HI_FIELD_NAME = \
+        Name(["meas", "ctrl", "shadowed", "hi", "field"])
 
     def __init__(self, ip_helper: IpHelper):
         self.ip_helper = ip_helper
         if self.ip_helper.ipconfig is None:
             raise RuntimeError("the clkmgr extension requires the ipconfig to be provided")
         self.ipconfig = ClkmgrIpConfig(self.ip_helper.ipconfig)
+
+        # Create a type to represent a measurable clock.
+        self.measurable_clk_struct = StructType(self.MEASURABLE_CLOCK_STRUCT_NAME)
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_STRUCT_CLK_FIELD_NAME,
+            field_type = ScalarType(self.ip_helper.top_helper.DT_CLOCK_ENUM_NAME),
+            docstring = "Clock",
+        )
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_OFF_FIELD_NAME,
+            field_type = ScalarType("uint32_t"),
+            docstring = "MEAS_CTRL_EN register offset",
+        )
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_EN_OFF_FIELD_NAME,
+            field_type = ScalarType("bitfield_field32_t"),
+            docstring = "MEAS_CTRL_EN_EN bitfield",
+        )
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_FIELD_NAME,
+            field_type = ScalarType("uint32_t"),
+            docstring = "CTRL_SHADOWED register offset",
+        )
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_LO_FIELD_NAME,
+            field_type = ScalarType("bitfield_field32_t"),
+            docstring = "CTRL_SHADOWED_LO bitfield",
+        )
+        self.measurable_clk_struct.add_field(
+            name = self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_HI_FIELD_NAME,
+            field_type = ScalarType("bitfield_field32_t"),
+            docstring = "CTRL_SHADOWED_HI bitfield",
+        )
+
+        # For an invalid clock, use an invalid clock ID, empty bitfields and
+        # invalid offsets.
+        empty_bitfield = "((bitfield_field32_t) { .mask = 0, .index = 0 })"
+        self.invalid_clk = {
+            self.MEASURABLE_CLOCK_STRUCT_CLK_FIELD_NAME: Name(["count"]),
+            self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_OFF_FIELD_NAME: "0xdead",
+            self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_EN_OFF_FIELD_NAME: empty_bitfield,
+            self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_FIELD_NAME: "0xdead",
+            self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_LO_FIELD_NAME: empty_bitfield,
+            self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_HI_FIELD_NAME: empty_bitfield,
+        }
 
     @staticmethod
     def create_ext(ip_helper: IpHelper) -> Optional["Extension"]:
@@ -90,6 +180,7 @@ class ClkmgrExt(Extension):
     def extend_dt_ip(self) -> tuple[Name, StructType]:
         sw_clk_count = len(self.ipconfig.sw_clks())
         hint_clk_count = len(self.ipconfig.hint_clks())
+        measurable_clk_count = len(self.ipconfig.measurable_clks())
         instance_id_enum = self.ip_helper.top_helper.instance_id_enum
 
         st = StructType()
@@ -113,6 +204,16 @@ class ClkmgrExt(Extension):
             ),
             docstring = "List of hintable clocks, in the order of the register fields",
         )
+        # Add field to list measurable clocks.
+        st.add_field(
+            name = self.MEASURABLE_CLOCKS_FIELD_NAME,
+            field_type = ArrayMapType(
+                elem_type = self.measurable_clk_struct,
+                index_type = ScalarType("size_t"),
+                length = str(measurable_clk_count),
+            ),
+            docstring = "List of measurables clocks",
+        )
         return Name(["clkmgr_ext"]), st
 
     def fill_dt_ip(self, m) -> Dict:
@@ -122,23 +223,53 @@ class ClkmgrExt(Extension):
         hint_clks = {}
         for (idx, clk) in enumerate(self.ipconfig.hint_clks()):
             hint_clks[str(idx)] = Name.from_snake_case(clk["module"])
+        measurable_clks = {}
+        for (idx, clk) in enumerate(self.ipconfig.measurable_clks()):
+            reg_prefix = "CLKMGR_{}_MEAS_CTRL_".format(clk.upper())
+            measurable_clks[str(idx)] = {
+                self.MEASURABLE_CLOCK_STRUCT_CLK_FIELD_NAME: Name.from_snake_case(clk),
+                self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_OFF_FIELD_NAME:
+                    reg_prefix + "EN_REG_OFFSET",
+                self.MEASURABLE_CLOCK_STRUCT_CTRL_EN_EN_OFF_FIELD_NAME:
+                    reg_prefix + "EN_EN_FIELD",
+                self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_FIELD_NAME:
+                    reg_prefix + "SHADOWED_REG_OFFSET",
+                self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_LO_FIELD_NAME:
+                    reg_prefix + "SHADOWED_LO_FIELD",
+                self.MEASURABLE_CLOCK_CTRL_SHADOWED_OFF_HI_FIELD_NAME:
+                    reg_prefix + "SHADOWED_HI_FIELD",
+            }
 
         return {
             self.SW_CLOCKS_FIELD_NAME: sw_clks,
             self.HINT_CLOCKS_FIELD_NAME: hint_clks,
+            self.MEASURABLE_CLOCKS_FIELD_NAME: measurable_clks,
         }
 
     def render_dt_ip(self, pos: Extension.DtIpPos) -> str:
         sw_clk_count = len(self.ipconfig.sw_clks())
         hint_clk_count = len(self.ipconfig.hint_clks())
+        measurable_clk_count = len(self.ipconfig.measurable_clks())
 
         if pos == Extension.DtIpPos.HeaderEnd:
-            return HEADER_EXT_TEMPLATE
+            subs = {
+                'measurable_clk_struct': self.measurable_clk_struct.render_type_def(),
+                'measurable_clk_struct_name': self.MEASURABLE_CLOCK_STRUCT_NAME.as_c_type(),
+            }
+            return HEADER_EXT_TEMPLATE % subs
         elif pos == Extension.DtIpPos.SourceEnd:
             subs = {
                 'sw_clk_count': sw_clk_count,
                 'hint_clk_count': hint_clk_count,
+                'measurable_clk_count': measurable_clk_count,
+                'invalid_measure_clk':
+                    indent_text(self.measurable_clk_struct.render_value(self.invalid_clk), "  "),
+                'measurable_clk_struct_name': self.MEASURABLE_CLOCK_STRUCT_NAME.as_c_type(),
             }
             return SOURCE_EXT_TEMPLATE % subs
+        elif pos == Extension.DtIpPos.SourceIncludes:
+            return '#include "clkmgr_regs.h"'
+        elif pos == Extension.DtIpPos.HeaderIncludes:
+            return '#include "sw/device/lib/base/bitfield.h"'
         else:
             return ""

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/util/ipconfig.py
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/util/ipconfig.py
@@ -7,6 +7,8 @@ files.
 """
 from typing import List, Dict
 
+from ipgen.clkmgr_gen import get_rg_srcs
+
 
 class ClkmgrIpConfig:
     def __init__(self, ipconfig: object):
@@ -49,3 +51,12 @@ class ClkmgrIpConfig:
             }
             for clk in self.param_values["typed_clocks"]["hint_clks"].values()
         ]
+
+    def measurable_clks(self) -> List[str]:
+        """
+        Return the list of measurable clocks: each clock is described by its
+        name.
+        """
+        # Currently, the clkmgr measures every root-gated clock.
+        rg_srcs = get_rg_srcs(self.param_values["typed_clocks"])
+        return rg_srcs

--- a/rules/autogen.bzl
+++ b/rules/autogen.bzl
@@ -350,15 +350,15 @@ def opentitan_top_dt_gen(name, gen_ips = [], gen_top = False, output_groups = {}
         ]),
     )
 
-def opentitan_ip_dt_header(name, ip, deps = None, target_compatible_with = []):
+def opentitan_ip_dt(name, ip, target_compatible_with = []):
     """
-    Generate the C header for an IP block as used in the current top.
+    Generate the C header/source for an IP block as used in the current top.
     The target will also be marked as compatible only with tops containing this IP.
-    Additionally, a `cc_library` will be created from this header with additional
-    dependencies on `deps`.
+    Specifically, three targets will be created:
+    - <name>_gen: rule generating all files
+    - <name>_src: filegroup containing only the source file of <name>_gen
+    - <name>_hdr: filegroup containing only the header file of <name>_gen
     """
-    if deps == None:
-        deps = []
     if target_compatible_with == None:
         target_compatible_with = []
 

--- a/util/dtgen/dt_ip.h.tpl
+++ b/util/dtgen/dt_ip.h.tpl
@@ -26,6 +26,9 @@
 #include "dt_api.h"
 #include <stdint.h>
 
+## Extension
+${helper.render_extension(Extension.DtIpPos.HeaderIncludes)}
+
 /**
  * List of instances.
  */

--- a/util/dtgen/helper.py
+++ b/util/dtgen/helper.py
@@ -260,6 +260,7 @@ class Extension(ABC):
         HeaderEnd = 0  # At the end of `dt_<ip>.h`
         SourceEnd = 1  # At the end of `dt_<ip>.c`
         SourceIncludes = 2  # At the include stage of `dt_<ip>.c`
+        HeaderIncludes = 3  # At the include stage of `dt_<ip>.h`
 
     def render_dt_ip(self, pos: DtIpPos) -> str:
         """


### PR DESCRIPTION
Currently the `clkmgr` DT does not expose any information about the measurable clocks which therefore need quite a bit of top-specific code. The PR exposes this information in a top-independent way.

The following information is necessary in order to operate a clock measurement:
- which clock is touches (e.g. IO, main, USB, ...)
- offset of the `ctrl_en` register (e.g. `CLKMGR_IO_MEAS_CTRL_EN_REG_OFFSET`) and
  - bitfield of the `EN` field (though it's the same for all, this is a bit cleaner)
- offset of the `ctrl_shadowed` register (e.g. `CLKMGR_IO_MEAS_CTRL_SHADOWED_REG_OFFSET `) and
   - bitfield of the `LO` field (different for each clock)
   - bitfield of the `HI` field (same)

Concretely, this is exposed as follows in the C API:
```c
/**
 * Description of a measurable clock.
 *
 */
typedef struct dt_clkmgr_measurable_clk {
  dt_clock_t clock; /**< Clock */
  uint32_t meas_ctrl_en_off; /**< MEAS_CTRL_EN register offset */
  bitfield_field32_t meas_ctrl_en_en_field; /**< MEAS_CTRL_EN_EN bitfield */
  uint32_t ctrl_shadowed_off; /**< CTRL_SHADOWED register offset */
  bitfield_field32_t ctrl_shadowed_lo_field; /**< CTRL_SHADOWED_LO bitfield */
  bitfield_field32_t ctrl_shadowed_hi_field; /**< CTRL_SHADOWED_HI bitfield */
} dt_clkmgr_measurable_clk_t;


/**
 * Get the number of measurable clocks.
 *
 * @param dt Instance of clkmgr.
 * @return Number of measurable clocks.
 */
size_t dt_clkmgr_measurable_clock_count(dt_clkmgr_t dt);

/**
 * Get the description of a measurable clock.
 *
 * @param dt Instance of clkmgr.
 * @param idx Index of the measurable clock, between 0 and
 *            `dt_clkmgr_measurable_clock_count(dt)-1`.
 * @return Description of the measurable clock.
 */
dt_clkmgr_measurable_clk_t dt_clkmgr_measurable_clock(dt_clkmgr_t dt, size_t idx);
```
Here is the correspond table, just to get a feeling:
```c
static const dt_desc_clkmgr_t clkmgr_desc[kDtClkmgrCount] = {
  [kDtClkmgrAon] = {
    .inst_id = kDtInstanceIdClkmgrAon,
    // ...
    .clkmgr_ext = {
      .sw_clks = {
        [0] = kDtInstanceIdUart0,
        [1] = kDtInstanceIdSpiDevice,
        [2] = kDtInstanceIdSpiHost0,
        [3] = kDtInstanceIdUsbdev,
      },
      .hint_clks = {
        [0] = kDtInstanceIdAes,
        [1] = kDtInstanceIdHmac,
        [2] = kDtInstanceIdKmac,
        [3] = kDtInstanceIdOtbn,
      },
      // NEW
      .measurable_clks = {
        [0] = {
          .clock = kDtClockIo,
          .meas_ctrl_en_off = CLKMGR_IO_MEAS_CTRL_EN_REG_OFFSET,
          .meas_ctrl_en_en_field = CLKMGR_IO_MEAS_CTRL_EN_EN_FIELD,
          .ctrl_shadowed_off = CLKMGR_IO_MEAS_CTRL_SHADOWED_REG_OFFSET,
          .ctrl_shadowed_lo_field = CLKMGR_IO_MEAS_CTRL_SHADOWED_LO_FIELD,
          .ctrl_shadowed_hi_field = CLKMGR_IO_MEAS_CTRL_SHADOWED_HI_FIELD,
        },
        [1] = {
          .clock = kDtClockIoDiv2,
          .meas_ctrl_en_off = CLKMGR_IO_DIV2_MEAS_CTRL_EN_REG_OFFSET,
          .meas_ctrl_en_en_field = CLKMGR_IO_DIV2_MEAS_CTRL_EN_EN_FIELD,
          .ctrl_shadowed_off = CLKMGR_IO_DIV2_MEAS_CTRL_SHADOWED_REG_OFFSET,
          .ctrl_shadowed_lo_field = CLKMGR_IO_DIV2_MEAS_CTRL_SHADOWED_LO_FIELD,
          .ctrl_shadowed_hi_field = CLKMGR_IO_DIV2_MEAS_CTRL_SHADOWED_HI_FIELD,
        },
        [2] = {
          .clock = kDtClockIoDiv4,
          .meas_ctrl_en_off = CLKMGR_IO_DIV4_MEAS_CTRL_EN_REG_OFFSET,
          .meas_ctrl_en_en_field = CLKMGR_IO_DIV4_MEAS_CTRL_EN_EN_FIELD,
          .ctrl_shadowed_off = CLKMGR_IO_DIV4_MEAS_CTRL_SHADOWED_REG_OFFSET,
          .ctrl_shadowed_lo_field = CLKMGR_IO_DIV4_MEAS_CTRL_SHADOWED_LO_FIELD,
          .ctrl_shadowed_hi_field = CLKMGR_IO_DIV4_MEAS_CTRL_SHADOWED_HI_FIELD,
        },
        [3] = {
          .clock = kDtClockMain,
          .meas_ctrl_en_off = CLKMGR_MAIN_MEAS_CTRL_EN_REG_OFFSET,
          .meas_ctrl_en_en_field = CLKMGR_MAIN_MEAS_CTRL_EN_EN_FIELD,
          .ctrl_shadowed_off = CLKMGR_MAIN_MEAS_CTRL_SHADOWED_REG_OFFSET,
          .ctrl_shadowed_lo_field = CLKMGR_MAIN_MEAS_CTRL_SHADOWED_LO_FIELD,
          .ctrl_shadowed_hi_field = CLKMGR_MAIN_MEAS_CTRL_SHADOWED_HI_FIELD,
        },
        [4] = {
          .clock = kDtClockUsb,
          .meas_ctrl_en_off = CLKMGR_USB_MEAS_CTRL_EN_REG_OFFSET,
          .meas_ctrl_en_en_field = CLKMGR_USB_MEAS_CTRL_EN_EN_FIELD,
          .ctrl_shadowed_off = CLKMGR_USB_MEAS_CTRL_SHADOWED_REG_OFFSET,
          .ctrl_shadowed_lo_field = CLKMGR_USB_MEAS_CTRL_SHADOWED_LO_FIELD,
          .ctrl_shadowed_hi_field = CLKMGR_USB_MEAS_CTRL_SHADOWED_HI_FIELD,
        },
      },
    },
  },
};
```

**Intended usage**

The idea would be that if someone wants to measure a clock, they already know the clock ID (`dt_clock_t`), either via a top-specific value, or by querying the DT from the source clock to a block. Then they list all measurable clocks in the DT to find the one that matches and now they have all the offsets/registers.

A PR will follow to convert the DIF and SW code.