### PR TITLE
[test] Handle alerts triggered by tests

### DIFF
--- a/ci/scripts/run-verilator-tests.sh
+++ b/ci/scripts/run-verilator-tests.sh
@@ -9,7 +9,7 @@ set -e
 
 ci/bazelisk.sh test \
     --build_tests_only=true \
-    --test_timeout=2400,2400,3600,-1 \
+    --test_timeout=2400,2400,4000,-1 \
     --local_test_jobs=8 \
     --local_cpu_resources=8 \
     --test_tag_filters=verilator,-broken \

--- a/sw/device/lib/dif/dif_alert_handler.h
+++ b/sw/device/lib/dif/dif_alert_handler.h
@@ -722,6 +722,32 @@ dif_result_t dif_alert_handler_get_class_state(
     dif_alert_handler_class_t alert_class,
     dif_alert_handler_class_state_t *state);
 
+/**
+ * Check whether an alert is currently enabled.
+ *
+ * @param alert_handler An alert handler handle.
+ * @param alert The alert to check enablement for.
+ * @param[out] is_enabled Out-param for the enabled state.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_alert_is_enabled(
+    const dif_alert_handler_t *alert_handler, dif_alert_handler_alert_t alert,
+    dif_toggle_t *is_enabled);
+
+/**
+ * Check whether an alert is currently enabled.
+ *
+ * @param alert_handler An alert handler handle.
+ * @param alert The alert to set enablement for.
+ * @param[out] enabled The enablement state to set.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_alert_set_enabled(
+    const dif_alert_handler_t *alert_handler, dif_alert_handler_alert_t alert,
+    dif_toggle_t enabled);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -50,6 +50,7 @@ cc_library(
         "//hw/ip/aes:model",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/dif:aes",
+        "//sw/device/lib/dif:alert_handler",
         "//sw/device/lib/dif:csrng_shared",
         "//sw/device/lib/dif:edn",
         "//sw/device/lib/runtime:ibex",

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -246,6 +246,7 @@ cc_library(
         "//sw/device/lib/dif:rstmgr",
         "//sw/device/lib/runtime:ibex",
         "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_alerts",
         "//sw/device/silicon_creator/lib/base:chip",
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
     ],

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -193,6 +193,7 @@ cc_library(
     ] + select({
         "//sw/device:is_english_breakfast": [],
         "//conditions:default": [
+            ":ottf_alerts",
             "//hw/top_earlgrey:alert_handler_c_regs",
             "//sw/device/lib/dif:alert_handler",
         ],

--- a/sw/device/lib/testing/test_framework/ottf_alerts.c
+++ b/sw/device/lib/testing/test_framework/ottf_alerts.c
@@ -11,15 +11,22 @@
 #include "sw/device/lib/runtime/irq.h"
 #include "sw/device/lib/testing/alert_handler_testutils.h"
 #include "sw/device/lib/testing/rv_plic_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
 
 #include "alert_handler_regs.h"
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+// Maximum number of alerts that can be expected at once.
+#define MAX_ALERTS_EXPECTED 16
+// Number of words required to store all alerts one per bit.
+#define ALERT_COUNT_WORDS (ALERT_HANDLER_PARAM_N_ALERTS + 31) / 32
+
+static dif_alert_handler_t ottf_alert_handler;
+
 status_t ottf_alerts_enable_all(void) {
-  dif_alert_handler_t alert_handler;
   TRY(dif_alert_handler_init(
       mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR),
-      &alert_handler));
+      &ottf_alert_handler));
 
   dif_alert_handler_alert_t alerts[ALERT_HANDLER_PARAM_N_ALERTS];
   dif_alert_handler_class_t alert_classes[ARRAYSIZE(alerts)];
@@ -59,11 +66,11 @@ status_t ottf_alerts_enable_all(void) {
       .classes_len = ARRAYSIZE(class_configs),
       .ping_timeout = UINT16_MAX,
   };
-  TRY(alert_handler_testutils_configure_all(&alert_handler, config,
+  TRY(alert_handler_testutils_configure_all(&ottf_alert_handler, config,
                                             kDifToggleDisabled));
 
   TRY(dif_alert_handler_irq_set_enabled(
-      &alert_handler, kDifAlertHandlerIrqClassd, kDifToggleEnabled));
+      &ottf_alert_handler, kDifAlertHandlerIrqClassd, kDifToggleEnabled));
 
   dif_rv_plic_t rv_plic;
   TRY(dif_rv_plic_init(mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR),
@@ -80,6 +87,133 @@ status_t ottf_alerts_enable_all(void) {
 
   irq_global_ctrl(true);
   irq_external_ctrl(true);
+
+  return OK_STATUS();
+}
+
+static_assert(ALERT_HANDLER_PARAM_N_ALERTS < 255,
+              "alert IDs stored as bytes with 0xff as sentinal");
+
+// List of expected alerts and the number of elements in the list.
+static volatile uint8_t alert_expected[MAX_ALERTS_EXPECTED] = {0};
+static volatile size_t alert_expected_cnt = 0;
+
+// Bitmap of whether each alert has been caught while expected.
+static volatile uint32_t alert_caught[ALERT_COUNT_WORDS] = {0};
+
+void ottf_alert_isr(uint32_t *exc_info) {
+  OT_DISCARD(exc_info);
+
+  bool expected_caught = false;
+
+  // Iterate over expected alerts and check if they are currently asserted.
+  //
+  // Note: we don't want to iterate over all 65 alerts and check if they were
+  // the cause because this is too slow for an ISR. Ibex has an instruction for
+  // counting leading zeroes in `alert_expected` words so this should be faster.
+  for (int i = 0; i < alert_expected_cnt; i++) {
+    dif_alert_handler_alert_t alert =
+        (dif_alert_handler_alert_t)alert_expected[i];
+
+    bool is_cause = false;
+    CHECK_DIF_OK(dif_alert_handler_alert_is_cause(&ottf_alert_handler, alert,
+                                                  &is_cause));
+
+    if (is_cause) {
+      CHECK_DIF_OK(
+          dif_alert_handler_alert_acknowledge(&ottf_alert_handler, alert));
+      alert_caught[alert / 32] |= (1 << (alert % 32));
+      expected_caught = true;
+    }
+  }
+
+  if (!expected_caught) {
+    // Log all asserted alerts.
+    // We can pay the cost of iterating all alerts in the failure case.
+    for (dif_alert_handler_alert_t alert = 0;
+         alert < ALERT_HANDLER_PARAM_N_ALERTS; alert++) {
+      bool is_cause = false;
+      CHECK_DIF_OK(dif_alert_handler_alert_is_cause(&ottf_alert_handler, alert,
+                                                    &is_cause));
+
+      // Don't print expected alerts that were triggered at the same time as
+      // unexpected alerts (unlikely but possible).
+      bool cause_expected = false;
+      for (int i = 0; i < alert_expected_cnt; i++) {
+        if (alert_expected[i] == alert) {
+          cause_expected = true;
+          break;
+        }
+      }
+
+      if (is_cause && !cause_expected) {
+        LOG_ERROR("ERROR: Alert %d is asserted but not expected", alert);
+      }
+    }
+
+    test_status_set(kTestStatusFailed);
+    abort();
+  }
+
+  // Clear the alert escalation counter.
+  CHECK_DIF_OK(dif_alert_handler_escalation_clear(&ottf_alert_handler,
+                                                  kDifAlertHandlerClassD));
+  // Complete the IRQ at the alert handler.
+  CHECK_DIF_OK(dif_alert_handler_irq_acknowledge(&ottf_alert_handler,
+                                                 kDifAlertHandlerIrqClassd));
+}
+
+status_t ottf_alerts_expect_alert_start(dif_alert_handler_alert_t alert) {
+  if (alert < 0 || alert > kTopEarlgreyAlertIdLast) {
+    return INVALID_ARGUMENT();
+  }
+
+  // Check for a full list.
+  if (alert_expected_cnt >= MAX_ALERTS_EXPECTED) {
+    return RESOURCE_EXHAUSTED();
+  }
+
+  alert_expected[alert_expected_cnt] = (uint8_t)alert;
+  alert_expected_cnt++;
+
+  return OK_STATUS();
+}
+
+status_t ottf_alerts_expect_alert_finish(dif_alert_handler_alert_t alert) {
+  if (alert < 0 || alert > kTopEarlgreyAlertIdLast) {
+    return INVALID_ARGUMENT();
+  }
+  // Find the index of this alert in the `alert_expected` list.
+  int expected_idx = 0;
+  for (; expected_idx < alert_expected_cnt; expected_idx++) {
+    if (alert_expected[expected_idx] == alert) {
+      break;
+    }
+  }
+
+  if (alert_expected_cnt == 0 || expected_idx >= alert_expected_cnt) {
+    // This alert was not expected with `ottf_alerts_expect_alert_start`.
+    return FAILED_PRECONDITION();
+  }
+
+  // Shift the list down one space to clear this expectation.
+  if (alert_expected_cnt < MAX_ALERTS_EXPECTED) {
+    for (int i = expected_idx + 1; i < alert_expected_cnt; i++) {
+      alert_expected[i - 1] = alert_expected[i];
+    }
+  }
+  alert_expected_cnt--;
+
+  uint32_t alert_word_idx = alert / 32;
+  uint32_t alert_bit_idx = alert % 32;
+
+  if (((alert_caught[alert_word_idx] >> alert_bit_idx) & 1) == 0) {
+    // Alert was not caught when expected.
+    return NOT_FOUND();
+  }
+
+  // Forget that the alert was caught.
+  alert_caught[alert_word_idx] &= ~(1 << alert_bit_idx);
 
   return OK_STATUS();
 }

--- a/sw/device/lib/testing/test_framework/ottf_alerts.c
+++ b/sw/device/lib/testing/test_framework/ottf_alerts.c
@@ -36,8 +36,8 @@ status_t ottf_alerts_enable_all(void) {
 
     // Temporarily skip alert 37 (`flash_ctrl_fatal_err`) on FPGAs and sims at
     // the owner stage since flash will not be provisioned with expected data.
-    // See #23038.
-    if (kDeviceType != kDeviceSilicon) {
+    if (i == kTopEarlgreyAlertIdFlashCtrlFatalErr &&
+        kDeviceType != kDeviceSilicon) {
       alerts[i] = 0;
     }
   }

--- a/sw/device/lib/testing/test_framework/ottf_alerts.c
+++ b/sw/device/lib/testing/test_framework/ottf_alerts.c
@@ -91,8 +91,16 @@ status_t ottf_alerts_enable_all(void) {
   return OK_STATUS();
 }
 
-static_assert(ALERT_HANDLER_PARAM_N_ALERTS < 255,
-              "alert IDs stored as bytes with 0xff as sentinal");
+status_t ottf_alerts_ignore_alert(dif_alert_handler_alert_t alert) {
+  TRY(dif_alert_handler_configure_alert(
+      &ottf_alert_handler, alert, kDifAlertHandlerClassD, kDifToggleDisabled,
+      kDifToggleDisabled));
+
+  return OK_STATUS();
+}
+
+static_assert(ALERT_HANDLER_PARAM_N_ALERTS < UINT8_MAX,
+              "alert IDs stored as bytes with 0xff as sentinel");
 
 // List of expected alerts and the number of elements in the list.
 static volatile uint8_t alert_expected[MAX_ALERTS_EXPECTED] = {0};

--- a/sw/device/lib/testing/test_framework/ottf_alerts.h
+++ b/sw/device/lib/testing/test_framework/ottf_alerts.h
@@ -23,6 +23,16 @@ OT_WARN_UNUSED_RESULT
 status_t ottf_alerts_enable_all(void);
 
 /**
+ * Disable an alert in OTTF's alert catching configuration.
+ *
+ * Useful when a particular alert cannot be dismissed when caught.
+ *
+ * @param alert The alert to be ignored.
+ */
+OT_WARN_UNUSED_RESULT
+status_t ottf_alerts_ignore_alert(dif_alert_handler_alert_t alert);
+
+/**
  * Record for the OTTF alert catcher that the given alert is expected.
  *
  * When this alert is caught, OTTF will not fault but will remember that

--- a/sw/device/lib/testing/test_framework/ottf_alerts.h
+++ b/sw/device/lib/testing/test_framework/ottf_alerts.h
@@ -6,6 +6,7 @@
 #define OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_ALERTS_H_
 
 #include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_alert_handler.h"
 
 /**
  * Configure and enable all alerts.
@@ -18,6 +19,40 @@
  *
  * Note that this function enables external IRQs for Ibex.
  */
+OT_WARN_UNUSED_RESULT
 status_t ottf_alerts_enable_all(void);
+
+/**
+ * Record for the OTTF alert catcher that the given alert is expected.
+ *
+ * When this alert is caught, OTTF will not fault but will remember that
+ * the alert fired. Pair this with `ottf_alerts_expect_alert_finish` to
+ * confirm that the expected alert was indeed caught.
+ *
+ * @param alert The alert that is expected.
+ */
+OT_WARN_UNUSED_RESULT
+status_t ottf_alerts_expect_alert_start(dif_alert_handler_alert_t alert);
+
+/**
+ * Finish expecting an alert and confirm that OTTF caught it firing.
+ *
+ * Must be called after `ottf_alerts_expect_alert_start`. If the alert
+ * was not caught while it was expected, an error result will be returned.
+
+ * The alert will no longer be expected after this call, and OTTF will
+ * forget that it was caught.
+ *
+ * @param alert The alert that was expected.
+ */
+OT_WARN_UNUSED_RESULT
+status_t ottf_alerts_expect_alert_finish(dif_alert_handler_alert_t alert);
+
+/**
+ * OTTF alert ISR handler.
+ *
+ * Called when an alert fires on class D when OTTF alert catching is enabled.
+ */
+void ottf_alert_isr(uint32_t *exc_info);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_ALERTS_H_

--- a/sw/device/lib/testing/test_framework/ottf_isrs.c
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.c
@@ -16,6 +16,7 @@
 
 #if !OT_IS_ENGLISH_BREAKFAST
 #include "sw/device/lib/dif/dif_alert_handler.h"
+#include "sw/device/lib/testing/test_framework/ottf_alerts.h"
 
 #include "alert_handler_regs.h"
 #endif  // !OT_IS_ENGLISH_BREAKFAST
@@ -200,32 +201,6 @@ OT_WEAK
 bool ottf_console_flow_control_isr(uint32_t *exc_info) { return false; }
 
 OT_WEAK
-void ottf_alert_isr(uint32_t *exc_info) {
-#if !OT_IS_ENGLISH_BREAKFAST
-  dif_alert_handler_t alert_handler;
-  CHECK_DIF_OK(dif_alert_handler_init(
-      mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR),
-      &alert_handler));
-
-  // Log all asserted alerts.
-  for (dif_alert_handler_alert_t alert = 0;
-       alert < ALERT_HANDLER_PARAM_N_ALERTS; alert++) {
-    bool is_cause = false;
-    CHECK_DIF_OK(
-        dif_alert_handler_alert_is_cause(&alert_handler, alert, &is_cause));
-    if (is_cause) {
-      LOG_ERROR("INFO: Alert %d is asserted", alert);
-    }
-  }
-
-  ottf_generic_fault_print(exc_info, "Alert IRQ", ibex_mcause_read());
-  abort();
-#else
-  return;
-#endif  // !OT_IS_ENGLISH_BREAKFAST
-}
-
-OT_WEAK
 void ottf_external_isr(uint32_t *exc_info) {
   const uint32_t kPlicTarget = kTopEarlgreyPlicTargetIbex0;
   dif_rv_plic_irq_id_t plic_irq_id;
@@ -249,7 +224,7 @@ void ottf_external_isr(uint32_t *exc_info) {
     CHECK_DIF_OK(
         dif_rv_plic_irq_complete(&ottf_plic, kPlicTarget, plic_irq_id));
     return;
-#endif  // OT_IS_ENGLISH_BREAKFAST
+#endif  //  !OT_IS_ENGLISH_BREAKFAST
   }
 
   LOG_ERROR("unhandled IRQ: plic_id=%d, peripheral ID=%d", plic_irq_id,
@@ -267,6 +242,9 @@ OT_WEAK
 bool ottf_handle_irq(uint32_t *exc_info,
                      top_earlgrey_plic_peripheral_t peripheral,
                      dif_rv_plic_irq_id_t plic_id) {
+  OT_DISCARD(exc_info);
+  OT_DISCARD(peripheral);
+  OT_DISCARD(plic_id);
   return false;
 }
 

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -183,6 +183,7 @@ void _ottf_main(void) {
 
 #if !OT_IS_ENGLISH_BREAKFAST
   if (!kOttfTestConfig.ignore_alerts) {
+    LOG_INFO("Enabling OTTF alert catcher");
     CHECK_STATUS_OK(ottf_alerts_enable_all());
   }
 #endif  // !OT_IS_ENGLISH_BREAKFAST

--- a/sw/device/lib/testing/test_framework/ottf_test_config.h
+++ b/sw/device/lib/testing/test_framework/ottf_test_config.h
@@ -132,8 +132,7 @@ typedef struct ottf_test_config {
    * escalate and abort the test.
    *
    * The alert handler configuration is not locked and can be modified further
-   * by the test. The ISR for class D can also be overridden by defining the
-   * symbol `ottf_alert_isr` in the test.
+   * by the test.
    */
   bool ignore_alerts;
 } ottf_test_config_t;

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -503,6 +503,7 @@ opentitan_test(
         EARLGREY_TEST_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
             # See #21706, expects keymgr state 0 so not working after ROM_EXT.
             "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
         },
@@ -516,6 +517,7 @@ opentitan_test(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/testing:keymgr_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_alerts",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/silicon_creator/manuf/lib:flash_info_fields",
     ],

--- a/sw/device/silicon_creator/lib/otbn_boot_services_functest.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services_functest.c
@@ -8,6 +8,7 @@
 #include "sw/device/lib/testing/flash_ctrl_testutils.h"
 #include "sw/device/lib/testing/keymgr_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_alerts.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/otbn_boot_services.h"
@@ -196,7 +197,8 @@ rom_error_t attestation_save_clear_key_test(void) {
   RETURN_IF_ERROR(otbn_boot_attestation_endorse(&digest, &sig));
 
   // Clear the key and check that endorsing now fails (it should even lock
-  // OTBN).
+  // OTBN). We cannot recover from the fatal alert so must ignore it.
+  CHECK_STATUS_OK(ottf_alerts_ignore_alert(kTopEarlgreyAlertIdOtbnFatal));
   RETURN_IF_ERROR(otbn_boot_attestation_key_clear());
   hmac_sha256(kTestMessage, kTestMessageLen, &digest);
   CHECK(otbn_boot_attestation_endorse(&digest, &sig) ==

--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -135,6 +135,7 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
     },
     fpga = fpga_params(
+        timeout = "long",
         binaries = {
             ":sram_cp_provision": "sram_cp_provision",
             ":sram_cp_provision_functest": "sram_cp_provision_functest",

--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
@@ -148,8 +148,10 @@ opentitan_binary(
     ],
     deps = [
         "//hw/top_earlgrey/ip_autogen/flash_ctrl:flash_ctrl_c_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:status",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf_alerts",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/lib/drivers:hmac",

--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/modify_digest.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/modify_digest.c
@@ -4,11 +4,13 @@
 
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ottf_alerts.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 
 #include "flash_ctrl_regs.h"
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -41,6 +43,10 @@ static status_t modify_digest_test(void) {
 }
 
 bool test_main(void) {
+  // This test intentionally creates an invalid digest triggering recoverable
+  // errors. Ignore the alert in OTTF.
+  ottf_alerts_ignore_alert(kTopEarlgreyAlertIdFlashCtrlRecovErr);
+
   status_t sts = modify_digest_test();
   if (status_err(sts)) {
     LOG_ERROR("modify_digest_test: %r", sts);

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2795,6 +2795,7 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
         },
     ),
     verilator = verilator_params(timeout = "long"),

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1592,6 +1592,7 @@ opentitan_test(
         "//sw/device/lib/testing:keymgr_testutils",
         "//sw/device/lib/testing:otp_ctrl_testutils",
         "//sw/device/lib/testing:pwrmgr_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_alerts",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1801,6 +1801,7 @@ opentitan_test(
         "//sw/device/lib/testing:isr_testutils",
         "//sw/device/lib/testing:lc_ctrl_testutils",
         "//sw/device/lib/testing:rv_plic_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_alerts",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
@@ -1936,6 +1937,7 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
         },
     ),
     # Run also as ROM_EXT stage as test coverage is reduced in silicon owner stage.
@@ -1952,6 +1954,7 @@ opentitan_test(
         "//sw/device/lib/dif:flash_ctrl",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:flash_ctrl_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_alerts",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
@@ -1987,6 +1990,7 @@ opentitan_test(
             "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
             # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
             "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
+            "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
         },
     ),
     verilator = verilator_params(timeout = "long"),
@@ -1999,6 +2003,7 @@ opentitan_test(
         "//sw/device/lib/dif:flash_ctrl",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:flash_ctrl_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_alerts",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1002,6 +1002,7 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
@@ -5549,6 +5550,7 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1527,6 +1527,7 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
         },
     ),
     verilator = verilator_params(timeout = "long"),
@@ -1552,6 +1553,7 @@ opentitan_test(
         "//sw/device/lib/testing:keymgr_testutils",
         "//sw/device/lib/testing:otp_ctrl_testutils",
         "//sw/device/lib/testing:pwrmgr_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_alerts",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -48,7 +48,12 @@ exports_files(glob([
 opentitan_test(
     name = "aes_masking_off_test",
     srcs = ["aes_masking_off_test.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
+        },
+    ),
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -60,6 +65,7 @@ opentitan_test(
         "//sw/device/lib/dif:aes",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:aes_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_alerts",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2279,6 +2279,7 @@ opentitan_test(
         "//sw/device/lib/testing:ret_sram_testutils",
         "//sw/device/lib/testing:rstmgr_testutils",
         "//sw/device/lib/testing:sram_ctrl_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_alerts",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
         "//sw/otbn/crypto:x25519_sideload",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2630,6 +2630,7 @@ opentitan_test(
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:keymgr_testutils",
         "//sw/device/lib/testing:kmac_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_alerts",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2267,6 +2267,8 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
+            "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1256,6 +1256,7 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
         },
     ),
     verilator = verilator_params(
@@ -1277,6 +1278,7 @@ opentitan_test(
         "//sw/device/lib/testing:rand_testutils",
         "//sw/device/lib/testing:rv_core_ibex_testutils",
         "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_alerts",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/tests:otbn_randomness_impl",
     ],
@@ -2458,6 +2460,7 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
         },
     ),
     verilator = verilator_params(timeout = "long"),
@@ -2473,6 +2476,7 @@ opentitan_test(
         "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing:keymgr_testutils",
         "//sw/device/lib/testing:otbn_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_alerts",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/otbn/crypto:x25519_sideload",
     ],
@@ -2814,6 +2818,7 @@ opentitan_test(
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing:otbn_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_alerts",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/otbn/code-snippets:err_test",
     ],
@@ -2919,6 +2924,8 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
+            "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
@@ -2930,6 +2937,7 @@ opentitan_test(
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing:otbn_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_alerts",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/otbn/code-snippets:barrett384",
         "//sw/otbn/code-snippets:err_test",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -7661,3 +7661,26 @@ opentitan_test(
         "//sw/device/silicon_creator/lib/sigverify",
     ],
 )
+
+opentitan_test(
+    name = "ottf_alert_catch_test",
+    srcs = ["ottf_alert_catch_test.c"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
+        },
+    ),
+    fpga = fpga_params(
+        exit_failure = "FAIL!",
+        exit_success = "Alert 3 is asserted",
+    ),
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/dif:alert_handler",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1324,6 +1324,7 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
         },
     ),
     verilator = verilator_params(
@@ -1344,6 +1345,7 @@ opentitan_test(
         "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing:rv_core_ibex_testutils",
         "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_alerts",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/tests/ast_clk_outs_test.c
+++ b/sw/device/tests/ast_clk_outs_test.c
@@ -10,6 +10,7 @@
 #include "sw/device/lib/testing/pwrmgr_testutils.h"
 #include "sw/device/lib/testing/sensor_ctrl_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_alerts.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -60,6 +61,12 @@ bool test_main(void) {
       mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
   CHECK_DIF_OK(dif_aon_timer_init(
       mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR), &aon_timer));
+
+  // The test will trigger many measurement errors which cause an alert that
+  // fires constantly with each new measurement and cannot really be
+  // acknowledged. Ignore this alert for the purpose of this test.
+  CHECK_STATUS_OK(
+      ottf_alerts_ignore_alert(kTopEarlgreyAlertIdClkmgrAonRecovFault));
 
   LOG_INFO("TEST: wait for ast init");
   IBEX_SPIN_FOR(sensor_ctrl_ast_init_done(&sensor_ctrl), 1000);

--- a/sw/device/tests/clkmgr_reset_frequency_test.c
+++ b/sw/device/tests/clkmgr_reset_frequency_test.c
@@ -10,6 +10,7 @@
 #include "sw/device/lib/testing/rstmgr_testutils.h"
 #include "sw/device/lib/testing/sensor_ctrl_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_alerts.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -51,6 +52,12 @@ bool test_main(void) {
       &sensor_ctrl));
   CHECK_DIF_OK(dif_rstmgr_init(
       mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+
+  // The test will trigger many measurement errors which cause an alert that
+  // fires constantly with each new measurement and cannot really be
+  // acknowledged. Ignore this alert for the purpose of this test.
+  CHECK_STATUS_OK(
+      ottf_alerts_ignore_alert(kTopEarlgreyAlertIdClkmgrAonRecovFault));
 
   LOG_INFO("TEST: wait for ast init");
   IBEX_SPIN_FOR(sensor_ctrl_ast_init_done(&sensor_ctrl), 1000);

--- a/sw/device/tests/entropy_src_bypass_mode_health_test.c
+++ b/sw/device/tests/entropy_src_bypass_mode_health_test.c
@@ -22,6 +22,7 @@
 #include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/otbn_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_alerts.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/tests/otbn_randomness_impl.h"
 
@@ -56,6 +57,10 @@ status_t init_test_environment(void) {
   TRY(dif_alert_handler_init(
       mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR),
       &alert_handler));
+
+  // Entropy testutils handle this recoverable alert separately, disable OTTF
+  // handling.
+  ottf_alerts_ignore_alert(kTopEarlgreyAlertIdEntropySrcRecovAlert);
   return OK_STATUS();
 }
 

--- a/sw/device/tests/entropy_src_edn_reqs_test.c
+++ b/sw/device/tests/entropy_src_edn_reqs_test.c
@@ -22,6 +22,7 @@
 #include "sw/device/lib/testing/otp_ctrl_testutils.h"
 #include "sw/device/lib/testing/pwrmgr_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_alerts.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/tests/otbn_randomness_impl.h"
 
@@ -224,6 +225,10 @@ void test_initialize(void) {
   CHECK_DIF_OK(dif_alert_handler_init(
       mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR),
       &alert_handler));
+
+  // We intentionally trigger this alert later, ignore it in OTTF.
+  CHECK_STATUS_OK(
+      ottf_alerts_ignore_alert(kTopEarlgreyAlertIdPwrmgrAonFatalFault));
 }
 
 status_t execute_test(void) {

--- a/sw/device/tests/flash_ctrl_info_access_lc.c
+++ b/sw/device/tests/flash_ctrl_info_access_lc.c
@@ -12,6 +12,7 @@
 #include "sw/device/lib/testing/lc_ctrl_testutils.h"
 #include "sw/device/lib/testing/rv_plic_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_alerts.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -80,8 +81,7 @@ bool ottf_handle_irq(uint32_t *exc_info,
   }
 
   dif_flash_ctrl_irq_t irq =
-    (dif_flash_ctrl_irq_t)(plic_id -
-                           flash_ctx.plic_flash_ctrl_start_irq_id);
+      (dif_flash_ctrl_irq_t)(plic_id - flash_ctx.plic_flash_ctrl_start_irq_id);
   fired_irqs[irq] = true;
 
   // Either acknowledge or mute IRQ.
@@ -133,7 +133,8 @@ static void flash_ctrl_init_with_event_irqs(mmio_region_t base_addr,
  */
 static void compare_and_clear_irq_variables(void) {
   for (int i = 0; i < kNumIRQs; ++i) {
-    CHECK(expected_irqs[i] == fired_irqs[i], "IRQ %d was %sexpected", i, expected_irqs[i] ? "" : "not ");
+    CHECK(expected_irqs[i] == fired_irqs[i], "IRQ %d was %sexpected", i,
+          expected_irqs[i] ? "" : "not ");
   }
   clear_irq_variables();
 }
@@ -179,9 +180,13 @@ static void test_info_part(uint32_t partition_number, const uint32_t *test_data,
     compare_and_clear_irq_variables();
     LOG_INFO("partition:%1d write done", partition_number);
   } else {
+    CHECK_STATUS_OK(
+        ottf_alerts_expect_alert_start(kTopEarlgreyAlertIdFlashCtrlRecovErr));
     CHECK_STATUS_NOT_OK(flash_ctrl_testutils_write(
         &flash_state, address, kPartitionId, test_data,
         kDifFlashCtrlPartitionTypeInfo, kInfoSize));
+    CHECK_STATUS_OK(
+        ottf_alerts_expect_alert_finish(kTopEarlgreyAlertIdFlashCtrlRecovErr));
     LOG_INFO("partition:%1d write not allowed", partition_number);
   }
 
@@ -206,9 +211,13 @@ static void test_info_part(uint32_t partition_number, const uint32_t *test_data,
     CHECK_ARRAYS_EQ(readback_data, test_data, kInfoSize);
     LOG_INFO("partition:%1d read done", partition_number);
   } else {
+    CHECK_STATUS_OK(
+        ottf_alerts_expect_alert_start(kTopEarlgreyAlertIdFlashCtrlRecovErr));
     CHECK_STATUS_NOT_OK(flash_ctrl_testutils_read(
         &flash_state, address, kPartitionId, readback_data,
         kDifFlashCtrlPartitionTypeInfo, kInfoSize, 1));
+    CHECK_STATUS_OK(
+        ottf_alerts_expect_alert_finish(kTopEarlgreyAlertIdFlashCtrlRecovErr));
     LOG_INFO("partition:%1d read not allowed", partition_number);
   }
 }

--- a/sw/device/tests/flash_ctrl_mem_protection_test.c
+++ b/sw/device/tests/flash_ctrl_mem_protection_test.c
@@ -10,6 +10,7 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/flash_ctrl_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_alerts.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 #include "flash_ctrl_regs.h"
@@ -161,10 +162,14 @@ static void test_mem_access(test_t region) {
       LOG_INFO("test_mem_access: page %d write complete",
                region.page_start + i);
     } else {
+      CHECK_STATUS_OK(
+          ottf_alerts_expect_alert_start(kTopEarlgreyAlertIdFlashCtrlRecovErr));
       CHECK_STATUS_NOT_OK(flash_ctrl_testutils_write(
           &flash, start_epage,
           /*partition_id=*/0, wdata, kDifFlashCtrlPartitionTypeData,
           ARRAYSIZE(wdata)));
+      CHECK_STATUS_OK(ottf_alerts_expect_alert_finish(
+          kTopEarlgreyAlertIdFlashCtrlRecovErr));
       LOG_INFO("test_mem_access: page %d write is not allowed",
                region.page_start + i);
     }
@@ -179,10 +184,14 @@ static void test_mem_access(test_t region) {
       LOG_INFO("test_mem_access: page %d read check complete",
                region.page_start + i);
     } else {
+      CHECK_STATUS_OK(
+          ottf_alerts_expect_alert_start(kTopEarlgreyAlertIdFlashCtrlRecovErr));
       CHECK_STATUS_NOT_OK(flash_ctrl_testutils_read(
           &flash, start_epage, /*partition_id=*/0, rdata,
           kDifFlashCtrlPartitionTypeData, ARRAYSIZE(rdata),
           /*delay=*/1));
+      CHECK_STATUS_OK(ottf_alerts_expect_alert_finish(
+          kTopEarlgreyAlertIdFlashCtrlRecovErr));
       LOG_INFO("test_mem_access: page %d read is not allowed",
                region.page_start + i);
     }

--- a/sw/device/tests/keymgr_derive_cdi_test.c
+++ b/sw/device/tests/keymgr_derive_cdi_test.c
@@ -11,6 +11,7 @@
 #include "sw/device/lib/testing/ret_sram_testutils.h"
 #include "sw/device/lib/testing/rstmgr_testutils.h"
 #include "sw/device/lib/testing/sram_ctrl_testutils.h"
+#include "sw/device/lib/testing/test_framework/ottf_alerts.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
 
@@ -190,7 +191,11 @@ static void derive_sw_key(const char *state_name, dif_keymgr_output_t *key) {
   // If the key version is larger than the permitted maximum version, then
   // the key generation must fail.
   params.version += 1;
+  CHECK_STATUS_OK(ottf_alerts_expect_alert_start(
+      kTopEarlgreyAlertIdKeymgrRecovOperationErr));
   CHECK_STATUS_NOT_OK(keymgr_testutils_generate_versioned_key(&keymgr, params));
+  CHECK_STATUS_OK(ottf_alerts_expect_alert_finish(
+      kTopEarlgreyAlertIdKeymgrRecovOperationErr));
 #endif
 }
 
@@ -236,7 +241,11 @@ static void derive_sideload_otbn_key(const char *state_name,
   // If the key version is larger than the permitted maximum version, then
   // the key generation must fail.
   params.version += 1;
+  CHECK_STATUS_OK(ottf_alerts_expect_alert_start(
+      kTopEarlgreyAlertIdKeymgrRecovOperationErr));
   CHECK_STATUS_NOT_OK(keymgr_testutils_generate_versioned_key(&keymgr, params));
+  CHECK_STATUS_OK(ottf_alerts_expect_alert_finish(
+      kTopEarlgreyAlertIdKeymgrRecovOperationErr));
 #endif
 }
 

--- a/sw/device/tests/keymgr_sideload_otbn_test.c
+++ b/sw/device/tests/keymgr_sideload_otbn_test.c
@@ -16,6 +16,7 @@
 #include "sw/device/lib/testing/keymgr_testutils.h"
 #include "sw/device/lib/testing/otbn_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_alerts.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -136,11 +137,14 @@ static void test_otbn_with_sideloaded_key(dif_keymgr_t *keymgr,
 
   // Clear the sideload key and check that OTBN errors with the correct error
   // code (`KEY_INVALID` bit 5 = 1).
+  CHECK_STATUS_OK(ottf_alerts_expect_alert_start(kTopEarlgreyAlertIdOtbnRecov));
   CHECK_DIF_OK(
       dif_keymgr_sideload_clear_set_enabled(keymgr, kDifToggleEnabled));
   LOG_INFO("Clearing the Keymgr generated sideload keys.");
   uint32_t at_clear_salt_result[8];
   run_x25519_app(otbn, at_clear_salt_result, kOtbnInvalidKeyErr);
+  CHECK_STATUS_OK(
+      ottf_alerts_expect_alert_finish(kTopEarlgreyAlertIdOtbnRecov));
 
   // Disable sideload key clearing.
   CHECK_DIF_OK(

--- a/sw/device/tests/kmac_error_conditions_test.c
+++ b/sw/device/tests/kmac_error_conditions_test.c
@@ -11,6 +11,7 @@
 #include "sw/device/lib/testing/keymgr_testutils.h"
 #include "sw/device/lib/testing/kmac_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_alerts.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -512,7 +513,11 @@ status_t test_err_shadow_reg_update(void) {
   mmio_region_write32(kmac.base_addr, KMAC_CFG_SHADOWED_REG_OFFSET, cfg_reg);
   // Change the value of one config bit and write again.
   cfg_reg = bitfield_bit32_write(cfg_reg, KMAC_CFG_SHADOWED_KMAC_EN_BIT, false);
+  CHECK_STATUS_OK(
+      ottf_alerts_expect_alert_start(kTopEarlgreyAlertIdKmacRecovOperationErr));
   mmio_region_write32(kmac.base_addr, KMAC_CFG_SHADOWED_REG_OFFSET, cfg_reg);
+  CHECK_STATUS_OK(ottf_alerts_expect_alert_finish(
+      kTopEarlgreyAlertIdKmacRecovOperationErr));
 
   // On a mismatch between first and second write, the recoverable alert should
   // trigger.

--- a/sw/device/tests/otbn_mem_scramble_test.c
+++ b/sw/device/tests/otbn_mem_scramble_test.c
@@ -8,6 +8,7 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/otbn_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_alerts.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -82,6 +83,7 @@ static volatile bool has_irq_fired;
  * This overrides the default OTTF load integrity handler.
  */
 void ottf_load_integrity_error_handler(uint32_t *exc_info) {
+  OT_DISCARD(exc_info);
   has_irq_fired = true;
 }
 
@@ -234,6 +236,11 @@ bool test_main(void) {
   CHECK_STATUS_OK(otbn_testutils_wait_for_done(&otbn, kDifOtbnErrBitsNoError));
   CHECK_DIF_OK(dif_otbn_write_cmd(&otbn, kDifOtbnCmdSecWipeDmem));
   CHECK_STATUS_OK(otbn_testutils_wait_for_done(&otbn, kDifOtbnErrBitsNoError));
+
+  // The following integrity errors in OTBN's memory causes a fatal alert in
+  // Ibex which cannot be acknowledge/dismissed, so we must ignore it instead.
+  CHECK_STATUS_OK(
+      ottf_alerts_ignore_alert(kTopEarlgreyAlertIdRvCoreIbexFatalHwErr));
 
   // Read back and check random address offsets. We don't care about the values.
   // "Most" reads should trigger integrity errors.

--- a/sw/device/tests/ottf_alert_catch_test.c
+++ b/sw/device/tests/ottf_alert_catch_test.c
@@ -1,0 +1,58 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_alert_handler.h"
+#include "sw/device/lib/dif/dif_uart.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_alerts.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// This test exercises OTTF's alert catching mechanism.
+//
+// We force two alerts: `Uart1FatalFault` and `Uart2FatalFault`. We expect the
+// first to be handled by our custom handler and the second to be handled by
+// OTTF leading to an error message and abort.
+//
+// The test is considered passing if we abort with `Alert 2 is asserted` and
+// failing if the test ends naturally.
+
+OTTF_DEFINE_TEST_CONFIG();
+
+enum {
+  kAlertTimeoutMicros = 1000,
+};
+
+bool test_main(void) {
+  dif_uart_t uart1, uart2, uart3;
+  CHECK_DIF_OK(dif_uart_init(
+      mmio_region_from_addr(TOP_EARLGREY_UART1_BASE_ADDR), &uart1));
+  CHECK_DIF_OK(dif_uart_init(
+      mmio_region_from_addr(TOP_EARLGREY_UART2_BASE_ADDR), &uart2));
+  CHECK_DIF_OK(dif_uart_init(
+      mmio_region_from_addr(TOP_EARLGREY_UART3_BASE_ADDR), &uart3));
+
+  LOG_INFO("Forcing alert on UART1 (expected)");
+  CHECK_STATUS_OK(
+      ottf_alerts_expect_alert_start(kTopEarlgreyAlertIdUart1FatalFault));
+  CHECK_DIF_OK(dif_uart_alert_force(&uart1, kDifUartAlertFatalFault));
+  busy_spin_micros(kAlertTimeoutMicros);
+  CHECK_STATUS_OK(
+      ottf_alerts_expect_alert_finish(kTopEarlgreyAlertIdUart1FatalFault));
+
+  LOG_INFO("Forcing alert on UART2 (ignored)");
+  CHECK_STATUS_OK(ottf_alerts_ignore_alert(kTopEarlgreyAlertIdUart2FatalFault));
+  CHECK_DIF_OK(dif_uart_alert_force(&uart2, kDifUartAlertFatalFault));
+  busy_spin_micros(kAlertTimeoutMicros);
+
+  LOG_INFO("Forcing alert on UART3 (unexpected)");
+  CHECK_DIF_OK(dif_uart_alert_force(&uart3, kDifUartAlertFatalFault));
+
+  LOG_INFO("Waiting for alert to be caught");
+  busy_spin_micros(kAlertTimeoutMicros);
+
+  LOG_INFO("Alert was not caught, we should not have gotten here");
+  return false;
+}

--- a/sw/device/tests/pwrmgr_deep_sleep_all_wake_ups.c
+++ b/sw/device/tests/pwrmgr_deep_sleep_all_wake_ups.c
@@ -35,7 +35,10 @@
   #5 is excluded because sensor_ctrl is not in the aon domain.
  */
 
-OTTF_DEFINE_TEST_CONFIG();
+// Test handles its own alerts.
+// `sensor_ctrl_aon_recov_alert` fires immediately on wake-up which doesn't
+// give us enough time to disable it specifically.
+OTTF_DEFINE_TEST_CONFIG(.ignore_alerts = true);
 
 /**
  * Clean up pwrmgr wakeup reason register for the next round.

--- a/sw/device/tests/pwrmgr_normal_sleep_all_wake_ups.c
+++ b/sw/device/tests/pwrmgr_normal_sleep_all_wake_ups.c
@@ -33,7 +33,10 @@
 
  */
 
-OTTF_DEFINE_TEST_CONFIG();
+// Test handles its own alerts.
+// `sensor_ctrl_aon_recov_alert` fires immediately on wake-up which doesn't
+// give us enough time to disable it specifically.
+OTTF_DEFINE_TEST_CONFIG(.ignore_alerts = true);
 
 bool test_main(void) {
   // Enable global and external IRQ at Ibex.

--- a/sw/device/tests/pwrmgr_sleep_wake_5_bug_test.c
+++ b/sw/device/tests/pwrmgr_sleep_wake_5_bug_test.c
@@ -33,7 +33,10 @@
   This is tracked by a retention sram counter, given there are resets involved.
  */
 
-OTTF_DEFINE_TEST_CONFIG();
+// Test handles its own alerts.
+// `sensor_ctrl_aon_recov_alert` fires immediately on wake-up which doesn't
+// give us enough time to disable it specifically.
+OTTF_DEFINE_TEST_CONFIG(.ignore_alerts = true);
 
 /**
  * Clean up pwrmgr wakeup reason register for the next round.

--- a/sw/device/tests/sensor_ctrl_wakeup_test.c
+++ b/sw/device/tests/sensor_ctrl_wakeup_test.c
@@ -18,7 +18,10 @@
 #include "sensor_ctrl_regs.h"  // Generated.
 #include "sw/device/lib/testing/autogen/isr_testutils.h"
 
-OTTF_DEFINE_TEST_CONFIG();
+// Test handles its own alerts.
+// `sensor_ctrl_aon_recov_alert` fires immediately on wake-up which doesn't
+// give us enough time to disable it specifically.
+OTTF_DEFINE_TEST_CONFIG(.ignore_alerts = true);
 
 static dif_pwrmgr_t pwrmgr;
 static dif_rv_plic_t plic;

--- a/sw/device/tests/sim_dv/pwrmgr_sleep_all_wake_ups_impl.c
+++ b/sw/device/tests/sim_dv/pwrmgr_sleep_all_wake_ups_impl.c
@@ -355,14 +355,16 @@ static pwrmgr_isr_ctx_t pwrmgr_isr_ctx = {
 /**
  * External interrupt handler.
  */
-void ottf_external_isr(uint32_t *exc_info) {
-  dif_pwrmgr_irq_t irq_id;
-  top_earlgrey_plic_peripheral_t peripheral;
+bool ottf_handle_irq(uint32_t *exc_info,
+                     top_earlgrey_plic_peripheral_t peripheral,
+                     dif_pwrmgr_irq_t irq_id) {
+  OT_DISCARD(exc_info);
 
-  isr_testutils_pwrmgr_isr(plic_ctx, pwrmgr_isr_ctx, &peripheral, &irq_id);
+  if (peripheral == kTopEarlgreyPlicPeripheralPwrmgrAon &&
+      irq_id == kTopEarlgreyPlicIrqIdPwrmgrAonWakeup) {
+    CHECK_DIF_OK(dif_pwrmgr_irq_acknowledge(&pwrmgr, kDifPwrmgrIrqWakeup));
+    return true;
+  }
 
-  // Check that both the peripheral and the irq id is correct
-  CHECK(peripheral == kTopEarlgreyPlicPeripheralPwrmgrAon,
-        "IRQ peripheral: %d is incorrect", peripheral);
-  CHECK(irq_id == kDifPwrmgrIrqWakeup, "IRQ ID: %d is incorrect", irq_id);
+  return false;
 }


### PR DESCRIPTION
This PR adds alert handling to tests which intentionally trigger alerts. In some cases it fixes alerts that were not supposed to trigger.

Two new APIs were added for dealing with alerts:

* `ottf_alerts_expect_alert_{start,finish}`
* `ottf_alerts_ignore_alert`

OTTF can now acknowledge expected alerts and then check that they were triggered between the `_start` and `_finish` calls. Multiple alerts can be expected at once. Alerts that were not expected cause the test to fail.

Alerts can also be ignored (disabled) if they cannot be acknowledged properly, for example with fatal alerts.

Also adds new DIFs for enabling alerts without reconfiguring the class.

Also changes the keymgs init testutil to not try to rewrite the creator secret when it’s already locked. This caused a recoverable alert that was being ignored.

Also fixes a bug where only alert 0 was configured outside silicon.

Also adds a log line when the catcher is enabled.

Also increases some test timeouts that were close but sometimes too short.