### PR TITLE
[i2c, sival] Tighten `i2c_host_fram_test` test thresholds

### DIFF
--- a/sw/device/examples/teacup_demos/teacup_leds_and_screen_demo.c
+++ b/sw/device/examples/teacup_demos/teacup_leds_and_screen_demo.c
@@ -148,7 +148,8 @@ static status_t peripheral_init(void) {
 
 static status_t configure_led_i2c_controller(void) {
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
-  TRY(i2c_testutils_set_speed(&i2c, kDifI2cSpeedFastPlus));
+  TRY(i2c_testutils_set_speed(&i2c, kDifI2cSpeedFastPlus,
+                              /*sda_rise_nanos=*/400, /*sda_fall_nanos=*/110));
   TRY(leds_i2c_controller_configure(&i2c));
   return OK_STATUS();
 }

--- a/sw/device/examples/teacup_demos/teacup_leds_demo.c
+++ b/sw/device/examples/teacup_demos/teacup_leds_demo.c
@@ -77,7 +77,8 @@ static status_t peripheral_init(void) {
 
 static status_t configure_led_i2c_controller(void) {
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
-  TRY(i2c_testutils_set_speed(&i2c, kDifI2cSpeedFastPlus));
+  TRY(i2c_testutils_set_speed(&i2c, kDifI2cSpeedFastPlus,
+                              /*sda_rise_nanos=*/400, /*sda_fall_nanos=*/110));
   TRY(leds_i2c_controller_configure(&i2c));
   return OK_STATUS();
 }

--- a/sw/device/lib/testing/i2c_testutils.c
+++ b/sw/device/lib/testing/i2c_testutils.c
@@ -375,7 +375,9 @@ status_t i2c_testutils_detach_pinmux(const dif_pinmux_t *pinmux,
   return OK_STATUS();
 }
 
-status_t i2c_testutils_set_speed(const dif_i2c_t *i2c, dif_i2c_speed_t speed) {
+status_t i2c_testutils_set_speed(const dif_i2c_t *i2c, dif_i2c_speed_t speed,
+                                 uint32_t sda_rise_nanos,
+                                 uint32_t sda_fall_nanos) {
   uint32_t speed_khz = 0;
   switch (speed) {
     case kDifI2cSpeedStandard:
@@ -396,8 +398,8 @@ status_t i2c_testutils_set_speed(const dif_i2c_t *i2c, dif_i2c_speed_t speed) {
       .lowest_target_device_speed = speed,
       .clock_period_nanos =
           (uint32_t)udiv64_slow(1000000000, kClockFreqPeripheralHz, NULL),
-      .sda_rise_nanos = 400,
-      .sda_fall_nanos = 110,
+      .sda_rise_nanos = sda_rise_nanos,
+      .sda_fall_nanos = sda_fall_nanos,
       .scl_period_nanos = 1000000 / speed_khz};
 
   dif_i2c_status_t status;

--- a/sw/device/lib/testing/i2c_testutils.h
+++ b/sw/device/lib/testing/i2c_testutils.h
@@ -226,13 +226,21 @@ status_t i2c_testutils_read(const dif_i2c_t *i2c, uint8_t addr,
 
 /**
  * Set the i2c timing parameters based on the desired speed mode.
+ * Also see
+ * https://opentitan.org/book/hw/ip/i2c/doc/programmers_guide.html#initialization
  *
  * @param i2c An I2C DIF handle.
  * @param speed The speed mode.
+ * @param sda_rise_nanos The expected time it takes for the I2C bus signal to
+ * rise. This depends on hardware interconnect properties.
+ * @param sda_fall_nanos The expected time it takes for the I2C bus signal to
+ * fall. This depends on hardware interconnect properties.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-status_t i2c_testutils_set_speed(const dif_i2c_t *i2c, dif_i2c_speed_t speed);
+status_t i2c_testutils_set_speed(const dif_i2c_t *i2c, dif_i2c_speed_t speed,
+                                 uint32_t sda_rise_nanos,
+                                 uint32_t sda_fall_nanos);
 
 /**
  * Busy spin until the i2c host get idle.

--- a/sw/device/tests/i2c_target_smbus_arp_test.c
+++ b/sw/device/tests/i2c_target_smbus_arp_test.c
@@ -297,7 +297,8 @@ static status_t test_init(void) {
   TRY(dif_i2c_init(base_addr, &i2c));
 
   TRY(i2c_testutils_select_pinmux(&pinmux, 0, I2cPinmuxPlatformIdHyper310));
-  TRY(i2c_testutils_set_speed(&i2c, kDifI2cSpeedStandard));
+  TRY(i2c_testutils_set_speed(&i2c, kDifI2cSpeedStandard,
+                              /*sda_rise_nanos=*/400, /*sda_fall_nanos=*/110));
 
   // 25 ms bus timeout. The upper limit of support is ~1 GHz for the IP, so OK
   // to make the frequency a uint32_t.

--- a/sw/device/tests/i2c_target_test.c
+++ b/sw/device/tests/i2c_target_test.c
@@ -91,7 +91,8 @@ static status_t i2c_configure_instance(dif_i2c_t *i2c, dif_pinmux_t *pinmux,
 
   TRY(i2c_testutils_select_pinmux(pinmux, i2c_instance,
                                   I2cPinmuxPlatformIdHyper310));
-  TRY(i2c_testutils_set_speed(i2c, kDifI2cSpeedStandard));
+  TRY(i2c_testutils_set_speed(i2c, kDifI2cSpeedStandard, /*sda_rise_nanos=*/400,
+                              /*sda_fall_nanos=*/110));
   TRY(dif_i2c_host_set_enabled(i2c, kDifToggleEnabled));
   return OK_STATUS();
 }

--- a/sw/device/tests/pmod/i2c_host_accelerometer_test.c
+++ b/sw/device/tests/pmod/i2c_host_accelerometer_test.c
@@ -145,7 +145,8 @@ bool test_main(void) {
 
   test_result = OK_STATUS();
   for (size_t i = 0; i < ARRAYSIZE(speeds); ++i) {
-    CHECK_STATUS_OK(i2c_testutils_set_speed(&i2c, speeds[i]));
+    CHECK_STATUS_OK(i2c_testutils_set_speed(
+        &i2c, speeds[i], /*sda_rise_nanos=*/400, /*sda_fall_nanos=*/110));
     EXECUTE_TEST(test_result, read_device_id);
     EXECUTE_TEST(test_result, read_write_thresh_tap);
     EXECUTE_TEST(test_result, take_measurement);

--- a/sw/device/tests/pmod/i2c_host_ambient_light_detector_test.c
+++ b/sw/device/tests/pmod/i2c_host_ambient_light_detector_test.c
@@ -154,7 +154,8 @@ bool test_main(void) {
 
   test_result = OK_STATUS();
   for (size_t i = 0; i < ARRAYSIZE(speeds); ++i) {
-    CHECK_STATUS_OK(i2c_testutils_set_speed(&i2c, speeds[i]));
+    CHECK_STATUS_OK(i2c_testutils_set_speed(
+        &i2c, speeds[i], /*sda_rise_nanos=*/400, /*sda_fall_nanos=*/110));
     EXECUTE_TEST(test_result, read_part_id);
     EXECUTE_TEST(test_result, read_manufacturer_id);
     EXECUTE_TEST(test_result, write_read_measure_rate);

--- a/sw/device/tests/pmod/i2c_host_clock_stretching_test.c
+++ b/sw/device/tests/pmod/i2c_host_clock_stretching_test.c
@@ -236,7 +236,8 @@ bool test_main(void) {
 
   status_t test_result = OK_STATUS();
   for (size_t i = 0; i < ARRAYSIZE(speeds); ++i) {
-    CHECK_STATUS_OK(i2c_testutils_set_speed(&i2c, speeds[i]));
+    CHECK_STATUS_OK(i2c_testutils_set_speed(
+        &i2c, speeds[i], /*sda_rise_nanos=*/400, /*sda_fall_nanos=*/110));
     EXECUTE_TEST(test_result, read_manufacture_id);
     EXECUTE_TEST(test_result, read_product_id);
     EXECUTE_TEST(test_result, rx_stretch_timeout);

--- a/sw/device/tests/pmod/i2c_host_compass_test.c
+++ b/sw/device/tests/pmod/i2c_host_compass_test.c
@@ -138,7 +138,8 @@ bool test_main(void) {
 
   test_result = OK_STATUS();
   for (size_t i = 0; i < ARRAYSIZE(speeds); ++i) {
-    CHECK_STATUS_OK(i2c_testutils_set_speed(&i2c, speeds[i]));
+    CHECK_STATUS_OK(i2c_testutils_set_speed(
+        &i2c, speeds[i], /*sda_rise_nanos=*/400, /*sda_fall_nanos=*/110));
     EXECUTE_TEST(test_result, read_product_id);
     EXECUTE_TEST(test_result, take_measurement);
   }
@@ -146,7 +147,8 @@ bool test_main(void) {
   // Reset the i2c peripheral and re-run a test
   // to check the peripheral works after reset.
   CHECK_STATUS_OK(reset_i2c_and_check());
-  CHECK_STATUS_OK(i2c_testutils_set_speed(&i2c, kDifI2cSpeedFast));
+  CHECK_STATUS_OK(i2c_testutils_set_speed(
+      &i2c, kDifI2cSpeedFast, /*sda_rise_nanos=*/400, /*sda_fall_nanos=*/110));
   EXECUTE_TEST(test_result, read_product_id);
 
   return status_ok(test_result);

--- a/sw/device/tests/pmod/i2c_host_eeprom_test.c
+++ b/sw/device/tests/pmod/i2c_host_eeprom_test.c
@@ -201,7 +201,8 @@ bool test_main(void) {
                                  kDifI2cSpeedFastPlus};
 
     for (size_t i = 0; i < ARRAYSIZE(kSpeeds); ++i) {
-      CHECK_STATUS_OK(i2c_testutils_set_speed(&i2c, kSpeeds[i]));
+      CHECK_STATUS_OK(i2c_testutils_set_speed(
+          &i2c, kSpeeds[i], /*sda_rise_nanos=*/400, /*sda_fall_nanos=*/110));
       EXECUTE_TEST(test_result, write_read_random, &i2c);
       EXECUTE_TEST(test_result, write_read_page, &i2c, false);
       EXECUTE_TEST(test_result, write_read_page_with_irq, &i2c);

--- a/sw/device/tests/pmod/i2c_host_fram_test.c
+++ b/sw/device/tests/pmod/i2c_host_fram_test.c
@@ -212,7 +212,7 @@ const test_setup_t kSetup[] = {
     // approaches the peripheral clock.
     {.speed = kDifI2cSpeedStandard, .kbps = (uint32_t)(100 * 0.984 * 0.85)},
     {.speed = kDifI2cSpeedFast, .kbps = (uint32_t)(400 * 0.92 * 0.85)},
-    {.speed = kDifI2cSpeedFastPlus, .kbps = (uint32_t)(1000 * 0.55 * 0.75)}};
+    {.speed = kDifI2cSpeedFastPlus, .kbps = (uint32_t)(1000 * 0.48 * 0.85)}};
 
 bool test_main(void) {
   dif_pinmux_t pinmux;

--- a/sw/device/tests/pmod/i2c_host_fram_test.c
+++ b/sw/device/tests/pmod/i2c_host_fram_test.c
@@ -228,7 +228,9 @@ bool test_main(void) {
     CHECK_STATUS_OK(i2c_configure(&i2c, &pinmux, i2c_instance, platform));
 
     for (size_t i = 0; i < ARRAYSIZE(kSetup); ++i) {
-      CHECK_STATUS_OK(i2c_testutils_set_speed(&i2c, kSetup[i].speed));
+      CHECK_STATUS_OK(i2c_testutils_set_speed(&i2c, kSetup[i].speed,
+                                              /*sda_rise_nanos=*/400,
+                                              /*sda_fall_nanos=*/110));
       EXECUTE_TEST(test_result, read_device_id, &i2c);
       EXECUTE_TEST(test_result, write_read_byte, &i2c);
       EXECUTE_TEST(test_result, write_read_page, &i2c);

--- a/sw/device/tests/pmod/i2c_host_fram_test.c
+++ b/sw/device/tests/pmod/i2c_host_fram_test.c
@@ -201,18 +201,20 @@ static status_t test_shutdown(dif_i2c_t *i2c, dif_pinmux_t *pinmux,
 }
 
 typedef struct test_setup {
+  // The speed to configure the I2C with
   dif_i2c_speed_t speed;
+  // The minimum threshold estimated data rate we expect to see over the test
   uint32_t kbps;
 } test_setup_t;
 
-const test_setup_t kSetup[] = {
-    // kbps: We discount 85% for the start and stop bits.
-    // We also have to discount a factor to account for rounding errors.
-    // The rounding error becomes higher with higher speeds, as the i2c clock
-    // approaches the peripheral clock.
-    {.speed = kDifI2cSpeedStandard, .kbps = (uint32_t)(100 * 0.984 * 0.85)},
-    {.speed = kDifI2cSpeedFast, .kbps = (uint32_t)(400 * 0.92 * 0.85)},
-    {.speed = kDifI2cSpeedFastPlus, .kbps = (uint32_t)(1000 * 0.48 * 0.85)}};
+test_setup_t setup[] = {
+    // kbps: Discount 15% (* 0.85) to account for ~15% of transactions being
+    // start/stop bits, ACKs, etc. We then discount an additional factor to
+    // account for clock rounding errors. The rounding error becomes higher
+    // with higher speeds, as the i2c clock approaches the peripheral clock.
+    {.speed = kDifI2cSpeedStandard, .kbps = (uint32_t)(100 * 0.85 * 0.99)},
+    {.speed = kDifI2cSpeedFast, .kbps = (uint32_t)(400 * 0.85 * 0.92)},
+    {.speed = kDifI2cSpeedFastPlus, .kbps = (uint32_t)(1000 * 0.85 * 0.5)}};
 
 bool test_main(void) {
   dif_pinmux_t pinmux;
@@ -221,20 +223,28 @@ bool test_main(void) {
   CHECK_DIF_OK(dif_pinmux_init(
       mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
 
+  if (kDeviceType == kDeviceSilicon) {
+    // On silicon, set tighter thresholds as we expect to be much closer
+    // to our target speed.
+    setup[0].kbps = (uint32_t)(100 * 0.85 * 0.99);
+    setup[1].kbps = (uint32_t)(400 * 0.85 * 0.98);
+    setup[2].kbps = (uint32_t)(1000 * 0.85 * 0.95);
+  }
+
   i2c_pinmux_platform_id_t platform = I2cPinmuxPlatformIdCw310Pmod;
   status_t test_result = OK_STATUS();
   for (uint8_t i2c_instance = 0; i2c_instance < kI2cInstances; ++i2c_instance) {
     LOG_INFO("Testing i2c%d", i2c_instance);
     CHECK_STATUS_OK(i2c_configure(&i2c, &pinmux, i2c_instance, platform));
 
-    for (size_t i = 0; i < ARRAYSIZE(kSetup); ++i) {
-      CHECK_STATUS_OK(i2c_testutils_set_speed(&i2c, kSetup[i].speed,
-                                              /*sda_rise_nanos=*/400,
-                                              /*sda_fall_nanos=*/110));
+    for (size_t i = 0; i < ARRAYSIZE(setup); ++i) {
+      CHECK_STATUS_OK(i2c_testutils_set_speed(&i2c, setup[i].speed,
+                                              /*sda_rise_nanos=*/100,
+                                              /*sda_fall_nanos=*/25));
       EXECUTE_TEST(test_result, read_device_id, &i2c);
       EXECUTE_TEST(test_result, write_read_byte, &i2c);
       EXECUTE_TEST(test_result, write_read_page, &i2c);
-      EXECUTE_TEST(test_result, throughput, &i2c, kSetup[i].kbps);
+      EXECUTE_TEST(test_result, throughput, &i2c, setup[i].kbps);
       CHECK_STATUS_OK(test_result);
     }
     CHECK_STATUS_OK(test_shutdown(&i2c, &pinmux, i2c_instance));

--- a/sw/device/tests/pmod/i2c_host_gas_sensor_test.c
+++ b/sw/device/tests/pmod/i2c_host_gas_sensor_test.c
@@ -147,7 +147,8 @@ bool test_main(void) {
 
   test_result = OK_STATUS();
   for (size_t i = 0; i < ARRAYSIZE(speeds); ++i) {
-    CHECK_STATUS_OK(i2c_testutils_set_speed(&i2c, speeds[i]));
+    CHECK_STATUS_OK(i2c_testutils_set_speed(
+        &i2c, speeds[i], /*sda_rise_nanos=*/400, /*sda_fall_nanos=*/110));
     EXECUTE_TEST(test_result, read_serial_number);
     EXECUTE_TEST(test_result, measure_raw);
     EXECUTE_TEST(test_result, self_test);

--- a/sw/device/tests/pmod/i2c_host_hdc1080_humidity_temp_test.c
+++ b/sw/device/tests/pmod/i2c_host_hdc1080_humidity_temp_test.c
@@ -128,7 +128,8 @@ bool test_main(void) {
 
   test_result = OK_STATUS();
   for (size_t i = 0; i < ARRAYSIZE(speeds); ++i) {
-    CHECK_STATUS_OK(i2c_testutils_set_speed(&i2c, speeds[i]));
+    CHECK_STATUS_OK(i2c_testutils_set_speed(
+        &i2c, speeds[i], /*sda_rise_nanos=*/400, /*sda_fall_nanos=*/110));
     EXECUTE_TEST(test_result, read_manufacture_id);
     EXECUTE_TEST(test_result, read_product_id);
     EXECUTE_TEST(test_result, read_temperature);

--- a/sw/device/tests/pmod/i2c_host_irq_test.c
+++ b/sw/device/tests/pmod/i2c_host_irq_test.c
@@ -326,7 +326,9 @@ bool test_main(void) {
   CHECK_STATUS_OK(test_init());
 
   test_result = OK_STATUS();
-  CHECK_STATUS_OK(i2c_testutils_set_speed(&i2c, kDifI2cSpeedStandard));
+  CHECK_STATUS_OK(i2c_testutils_set_speed(&i2c, kDifI2cSpeedStandard,
+                                          /*sda_rise_nanos=*/400,
+                                          /*sda_fall_nanos=*/110));
   EXECUTE_TEST(test_result, nak_irq);
   EXECUTE_TEST(test_result, nak_irq_disabled);
   EXECUTE_TEST(test_result, cmd_complete_irq);

--- a/sw/device/tests/pmod/i2c_host_power_monitor_test.c
+++ b/sw/device/tests/pmod/i2c_host_power_monitor_test.c
@@ -171,7 +171,8 @@ bool test_main(void) {
 
   test_result = OK_STATUS();
   for (size_t i = 0; i < ARRAYSIZE(speeds); ++i) {
-    CHECK_STATUS_OK(i2c_testutils_set_speed(&i2c, speeds[i]));
+    CHECK_STATUS_OK(i2c_testutils_set_speed(
+        &i2c, speeds[i], /*sda_rise_nanos=*/400, /*sda_fall_nanos=*/110));
     EXECUTE_TEST(test_result, read_manufacture_id);
     EXECUTE_TEST(test_result, read_product_id);
     EXECUTE_TEST(test_result, read_write_1byte);


### PR DESCRIPTION
See the commit messages for more details.

In silicon environments, set much tighter thresholds on the expected speeds in the `i2c_host_fram_test`. To enable this to work despite the test utilities to compute I2C timing configurations, lower SDA rise and fall times (based on physical characteristics) must be provided, and so the existing test utilities are modified to allow for this.