### PR TITLE
[doc] Align copyright message in doc with actual header

### DIFF
--- a/doc/contributing/hw/comportability/README.md
+++ b/doc/contributing/hw/comportability/README.md
@@ -36,7 +36,7 @@ All comportable IP must adhere to a few requirements, briefly discussed here.
 ### License and copyright
 
 All files should include a comment with a copyright message.
-This is normally "lowRISC contributors".
+This is normally "lowRISC contributors (OpenTitan project)".
 The style is to not include a year in the notice.
 Files adapted from other sources should retain any copyright messages and include details of the upstream location.
 


### PR DESCRIPTION
It seems we forgot to update the occurrence in the text when updating the guidance and the actual example header also displayed further down in the same doc.