### PR TITLE
[sw] Ensure string in .text section doesn't misalign code

### DIFF
--- a/sw/device/tests/rv_core_ibex_address_translation_test.S
+++ b/sw/device/tests/rv_core_ibex_address_translation_test.S
@@ -78,7 +78,13 @@ get_name_end:
   ret
 
 name:
-  .string "My name is Titan, Open Titan"
+  // ensure the following string has an even length (including the null), while
+  // the bug https://github.com/llvm/llvm-project/issues/147771 remains unfixed
+  // or the fix has not been included in the OpenTitan toolchain. LLD uses `nop`
+  // and `c.nop` instructions to realign code sections, so it's unable to
+  // realign back to two bytes. If the code is not aligned to a half word, debug
+  // builds of LLD will trip on an assertion.
+  .string "My name is Titan, Open Titan!"
 
 /**
  * Reserve some area to map functions to.

--- a/sw/device/tests/rv_core_ibex_address_translation_test.c
+++ b/sw/device/tests/rv_core_ibex_address_translation_test.c
@@ -17,7 +17,7 @@
 
 #define TEST_STR "Hello there, WHaT 1S Y0Ur N@ME?"
 #define EXPECTED_RESULT_MAKE_LOWER_CASE "hello there, what 1s y0ur n@me?"
-#define EXPECTED_RESULT_GET_NAME "My name is Titan, Open Titan"
+#define EXPECTED_RESULT_GET_NAME "My name is Titan, Open Titan!"
 
 OTTF_DEFINE_TEST_CONFIG();
 


### PR DESCRIPTION
Add one more character to a `.string` in a `.text` section to ensure it has an even number of characters (counting the null) and thus keep the code aligned to 2 bytes (RVC).

This works around a [linker bug](https://github.com/llvm/llvm-project/issues/147771). If the code is misaligned, debug builds of LLD will trip on an assertion.