### PR TITLE
[sw] Fix cast of `ujson_putbuf` to `sink_func_ptr`

### DIFF
--- a/sw/device/lib/ujson/ujson.c
+++ b/sw/device/lib/ujson/ujson.c
@@ -31,6 +31,14 @@ status_t ujson_putbuf(ujson_t *uj, const char *buf, size_t len) {
   return uj->putbuf(uj->io_context, buf, len);
 }
 
+static size_t ujson_putbuf_sink(ujson_t *uj, const char *buf, size_t len) {
+  status_t result = ujson_putbuf(uj, buf, len);
+  if (!status_ok(result)) {
+    return 0;
+  }
+  return (size_t)result.value;
+}
+
 status_t ujson_getc(ujson_t *uj) {
   int16_t buffer = uj->buffer;
   if (buffer >= 0) {
@@ -413,7 +421,7 @@ status_t ujson_deserialize_status_t(ujson_t *uj, status_t *value) {
 status_t ujson_serialize_status_t(ujson_t *uj, const status_t *value) {
   buffer_sink_t out = {
       .data = uj,
-      .sink = (size_t(*)(void *, const char *, size_t))ujson_putbuf,
+      .sink = (sink_func_ptr)ujson_putbuf_sink,
   };
   base_fprintf(out, "%!r", *value);
   return OK_STATUS();


### PR DESCRIPTION
The function `ujson_putbuf` has the type `sink_func_ptr` except that it returns a `status_t` instead of a `size_t`. Although those are the same at an ABI level, at the C level they are different types. More recent versions of Clang warn about casting betwen such incompatible types. This commit fixes such a casting warning by introducing a wrapper function `ujson_putbuf_sink` with the appropriate `sink_func_ptr` type.