### PR TITLE
[crypto/sw] Enable cryptolib map file analysis

### DIFF
--- a/sw/device/silicon_owner/bare_metal/BUILD
+++ b/sw/device/silicon_owner/bare_metal/BUILD
@@ -9,6 +9,11 @@ load("//rules/opentitan:defs.bzl", "fpga_params", "opentitan_binary", "opentitan
 
 package(default_visibility = ["//visibility:public"])
 
+filegroup(
+    name = "bare_metal_start",
+    srcs = ["bare_metal_start.S"],
+)
+
 ld_library(
     name = "ld_common",
     includes = ["bare_metal_common.ld"],

--- a/sw/device/silicon_owner/bare_metal/bare_metal_common.ld
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_common.ld
@@ -104,12 +104,6 @@ SECTIONS {
   } > owner_flash
 
   /**
-   * Critical static data that is accessible by both the ROM and the ROM
-   * extension.
-   */
-  INCLUDE sw/device/silicon_creator/lib/base/static_critical.ld
-
-  /**
    * Mutable data section, at the bottom of ram_main. This will be initialized
    * from flash at runtime by the CRT.
    *

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -40,14 +40,24 @@ cc_library(
     ],
 )
 
-cc_binary(
+opentitan_binary(
     name = "otcrypto_export_size",
-    srcs = ["otcrypto_export_size.c"],
+    testonly = True,
+    srcs = [
+        "otcrypto_export_size.c",
+        "//sw/device/silicon_owner/bare_metal:bare_metal_start",
+    ],
     # Disable link-time optimization to preserve unused cryptolib functions.
     copts = ["-fno-lto"],
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310_rom_ext",
+    ],
+    linker_script = "//sw/device/silicon_owner/bare_metal:ld_slot_a",
+    manifest = "//sw/device/silicon_owner/bare_metal:manifest",
     deps = [
         ":otcrypto_interface",
-        "//sw/device/lib/arch:silicon",
+        "//sw/device/lib/crt",
+        "//sw/device/silicon_creator/lib:manifest_def",
     ],
 )
 

--- a/sw/device/tests/crypto/otcrypto_export_size.c
+++ b/sw/device/tests/crypto/otcrypto_export_size.c
@@ -5,12 +5,4 @@
 #include "sw/device/tests/crypto/otcrypto_interface.h"
 
 // Simple main function so the linker doesn't discard the inerface struct.
-int main(void) {
-  uint32_t digest_data[8];
-  otcrypto_hash_digest_t digest = {.data = digest_data, .len = 8};
-  otcrypto.sha2_256((otcrypto_const_byte_buf_t){.data = NULL, .len = 0},
-                    &digest);
-
-  // SHA256('') is a constant value; this will always be 0.
-  return digest_data[0] & 1;
-}
+void bare_metal_main(void) { (void)otcrypto; }

--- a/sw/device/tests/crypto/otcrypto_interface.c
+++ b/sw/device/tests/crypto/otcrypto_interface.c
@@ -4,7 +4,7 @@
 
 #include "sw/device/tests/crypto/otcrypto_interface.h"
 
-const otcrypto_interface_t otcrypto = {
+volatile otcrypto_interface_t otcrypto = {
     // Symmetric key generation.
     .symmetric_keygen = &otcrypto_symmetric_keygen,
     .hw_backed_key = &otcrypto_hw_backed_key,

--- a/sw/device/tests/crypto/otcrypto_interface.h
+++ b/sw/device/tests/crypto/otcrypto_interface.h
@@ -339,7 +339,7 @@ typedef struct otcrypto_interface_t {
 
 } otcrypto_interface_t;
 
-extern const otcrypto_interface_t otcrypto;
+extern volatile otcrypto_interface_t otcrypto;
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/util/py/scripts/mapfile_to_json.py
+++ b/util/py/scripts/mapfile_to_json.py
@@ -24,7 +24,10 @@ parser.add_argument('--html',
 parser.add_argument('--regions',
                     default='rom,ram_main,eflash',
                     help='Which memory regions to analyze')
-parser.add_argument('mapfile',
+parser.add_argument('--target',
+                    default='',
+                    help='Bazel target to generate map file')
+parser.add_argument('--mapfile',
                     metavar='MAPFILE',
                     type=str,
                     help='Mapfile to process')
@@ -425,9 +428,35 @@ class Mapfile(object):
         return csz
 
 
+def generate_map(target):
+    # Define the Bazel command as a list of arguments
+    # bazel_cmd = ["bazel", "build", "//sw/device/tests/crypto:otcrypto_export_size"]
+    map_file = None
+    bazel_cmd = ["bazel", "build", target]
+    try:
+        result = subprocess.run(bazel_cmd, check=True, capture_output=True, text=True)
+        print(result)
+        # Search output for the .map file line
+        for line in result.stderr.splitlines():
+            print(line)
+            if line.strip().endswith('.map'):
+                # The file path is the whole line or first token
+                map_file = line.strip().split()[0]
+        print("Generate map file from target succeeded:\n", result.stdout)
+    except subprocess.CalledProcessError as e:
+        print("Generate map file from target failed:\n", e.stderr)
+
+    return map_file
+
+
 def main(args):
     m = Mapfile(regions=args.regions.split(','),
                 ignore_debug=args.ignore_debug)
+
+    if args.mapfile is None:
+        # If no mapfile is provided generate the map file from a bazel target.
+        args.mapfile = generate_map(args.target)
+
     m.parse(args.mapfile)
     if args.arrangement == 'region':
         regions = m.by_memory_region()


### PR DESCRIPTION
Thanks to @cfrantz for this fix!

This PR contains necessary updates to allow for building the map file of the whole crypto lib and then use the map file to hjson python script to create a visual representation of the map file for easier analysis of the memory usage.

To generate the map file and the HTML use the following commands:
`bazel build  //sw/device/tests/crypto:otcrypto_export_size`
`./util/py/scripts/mapfile_to_json.py -v -a file --regions eflash bazel-bin/sw/device/tests/crypto/otcrypto_export_size_fpga_cw310_rom_ext.map`

The second command will open the html straight away. You can also create an HTML file and open it later by removing the `-v` option and adding `-html <path to file>`