### PR TITLE
[ci] use GitHub app token to create pull request

### DIFF
--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -22,10 +22,10 @@ jobs:
     # default token. We should in the future move to a PAT owned by lowrisc-bot and create pull request
     # on its behalf.
     permissions:
+      # Needed for authentication.
+      id-token: write
       # Needed for the action to create branch.
       contents: write
-      # Needed for the action to create a pull request.
-      pull-requests: write
 
     name: Cherry-pick Pull Request
     if: github.event.pull_request.merged == true && (github.event_name != 'labeled' || startsWith('CherryPick:', github.event.label.name))
@@ -35,23 +35,30 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Obtain token to create PR
+        id: pr_token
+        run: |
+          # Obtain OIDC token from GitHub
+          ID_TOKEN=$(curl -sSf -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://ca.lowrisc.org" | jq -r .value)
+          echo "::add-mask::$ID_TOKEN"
+          # Exchange for a token to create PR
+          PR_TOKEN=$(curl -sSf -X POST -H "Authorization: Bearer $ID_TOKEN" "https://ca.lowrisc.org/api/github/repos/${{ github.repository }}/token")
+          echo "::add-mask::$PR_TOKEN"
+          echo "pr_token=$PR_TOKEN" >> "$GITHUB_OUTPUT"
+
       - name: Create backport PRs
         id: backport
         uses: korthout/backport-action@e8161d6a0dbfa2651b7daa76cbb75bc7c925bbf3 # v2.4.1
         with:
           label_pattern: "^CherryPick:([^ ]+)$"
           pull_title: "Cherry-pick to ${target_branch}: ${pull_title}"
+          github_token: ${{ steps.pr_token.outputs.pr_token }}
           pull_description: |
             This is an automatic cherry-pick of #${pull_number} to branch `${target_branch}`.
-
-            > [!IMPORTANT]
-            > This automated pull request cannot trigger CI tests itself.
-            >
-            > Please close and re-open the pull request manually to start CI.
 
       - name: Apply label for manually cherry picking
         if: ${{ steps.backport.outputs.was_successful == 'false' }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.pr_token.outputs.pr_token }}
         run: |
           gh pr edit ${{ github.event.pull_request.number }} --add-label 'Manually CherryPick'


### PR DESCRIPTION
This modifies the cherry-pick workflow to use a lowRISC-managed GitHub token minter to generate an access token with ability to create pull_requests as the "lowrisc-ci" app.

This allows GitHub action to trigger and bypass the restriction that actions performed by GitHub actions cannot itself trigger another GitHub actions (as a recursion prevention measure), and therefore allows CI to run on cherry-picked pull requests.

A test PR created by this action can be seen here: https://github.com/lowRISC/opentitan/pull/27724, with checks triggered at https://github.com/lowRISC/opentitan/pull/27724/checks.