### PR TITLE
OTTF console backports

### DIFF
--- a/sw/device/lib/runtime/print.c
+++ b/sw/device/lib/runtime/print.c
@@ -17,8 +17,6 @@
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/runtime/hart.h"
 
-#include "spi_device_regs.h"  // Generated.
-
 // This is declared as an enum to force the values to be
 // compile-time constants, but the type is otherwise not
 // used for anything.
@@ -77,15 +75,6 @@ void base_set_stdout(buffer_sink_t out) {
   base_stdout = out;
 }
 
-static const size_t kSpiDeviceReadBufferSizeBytes =
-    SPI_DEVICE_PARAM_SRAM_READ_BUFFER_DEPTH * sizeof(uint32_t);
-static const size_t kSpiDeviceFrameHeaderSizeBytes = 12;
-static const size_t kSpiDeviceBufferPreservedSizeBytes =
-    kSpiDeviceFrameHeaderSizeBytes;
-static const size_t kSpiDeviceMaxFramePayloadSizeBytes =
-    kSpiDeviceReadBufferSizeBytes - kSpiDeviceFrameHeaderSizeBytes -
-    kSpiDeviceBufferPreservedSizeBytes - 4;
-static const uint32_t kSpiDeviceFrameMagicNumber = 0xa5a5beef;
 static uint32_t spi_device_frame_num = 0;
 
 static status_t spi_device_send_data(dif_spi_device_handle_t *spi_device,

--- a/sw/device/lib/runtime/print.h
+++ b/sw/device/lib/runtime/print.h
@@ -12,6 +12,8 @@
 #include "sw/device/lib/dif/dif_spi_device.h"
 #include "sw/device/lib/dif/dif_uart.h"
 
+#include "spi_device_regs.h"  // Generated.
+
 /**
  * @file
  * @brief Libc-like printing facilities.
@@ -48,6 +50,20 @@ typedef struct buffer_sink {
   void *data;
   sink_func_ptr sink;
 } buffer_sink_t;
+
+/**
+ * SPI console buffer management constants.
+ */
+enum {
+  kSpiDeviceReadBufferSizeBytes =
+      SPI_DEVICE_PARAM_SRAM_READ_BUFFER_DEPTH * sizeof(uint32_t),
+  kSpiDeviceFrameHeaderSizeBytes = 12,
+  kSpiDeviceBufferPreservedSizeBytes = kSpiDeviceFrameHeaderSizeBytes,
+  kSpiDeviceMaxFramePayloadSizeBytes = kSpiDeviceReadBufferSizeBytes -
+                                       kSpiDeviceFrameHeaderSizeBytes -
+                                       kSpiDeviceBufferPreservedSizeBytes - 4,
+  kSpiDeviceFrameMagicNumber = 0xa5a5beef,
+};
 
 /**
  * Returns a function pointer to the spi device sink function.

--- a/sw/device/lib/testing/test_framework/ottf_console.h
+++ b/sw/device/lib/testing/test_framework/ottf_console.h
@@ -120,6 +120,14 @@ size_t ottf_console_spi_device_read(size_t buf_size, uint8_t *const buf);
 status_t ottf_console_putbuf(void *io, const char *buf, size_t len);
 
 /**
+ * Flush remaining buffered data to the OTTF console.
+ *
+ * @param context An IO context
+ * @return OK or an error.
+ */
+status_t ottf_console_flushbuf(void *io);
+
+/**
  * Get a single character from the OTTF console.
  *
  * @return The next character or an error.

--- a/sw/device/lib/testing/test_framework/ottf_test_config.h
+++ b/sw/device/lib/testing/test_framework/ottf_test_config.h
@@ -31,6 +31,15 @@ typedef struct ottf_console {
    * reconfigure it before printing the test status.
    */
   bool test_may_clobber;
+  /**
+   * Indicates if SW buffering should be turned on for `ottf_console_putbuf()`
+   * to increase the transmit performance when using a peripheral backend like
+   * SPI that has a frame overhead associated with each packet transmission.
+   *
+   * Set this option to true if you are using the SPI console device with UJSON
+   * transmissions.
+   */
+  bool putbuf_buffered;
 } ottf_console_t;
 
 typedef struct ottf_console_tx_indicator {

--- a/sw/device/lib/testing/test_framework/ujson_ottf.c
+++ b/sw/device/lib/testing/test_framework/ujson_ottf.c
@@ -10,5 +10,6 @@
 #include "sw/device/lib/ujson/ujson.h"
 
 ujson_t ujson_ottf_console(void) {
-  return ujson_init(ottf_console_get(), ottf_console_getc, ottf_console_putbuf);
+  return ujson_init(ottf_console_get(), ottf_console_getc, ottf_console_putbuf,
+                    ottf_console_flushbuf);
 }

--- a/sw/device/lib/testing/test_framework/ujson_ottf.h
+++ b/sw/device/lib/testing/test_framework/ujson_ottf.h
@@ -73,6 +73,7 @@ ujson_t ujson_ottf_console(void);
     TRY(ujson_putbuf(uj_ctx_, " CRC:", 5));       \
     TRY(ujson_serialize_uint32_t(uj_ctx_, &crc)); \
     TRY(ujson_putbuf(uj_ctx_, "\n", 1));          \
+    TRY(ujson_flushbuf(uj));                      \
     OK_STATUS();                                  \
   })
 

--- a/sw/device/lib/ujson/example_roundtrip.c
+++ b/sw/device/lib/ujson/example_roundtrip.c
@@ -34,7 +34,7 @@ status_t check_crc32(ujson_t *uj) {
 }
 
 status_t roundtrip(const char *name) {
-  ujson_t uj = ujson_init(NULL, stdio_getc, stdio_putbuf);
+  ujson_t uj = ujson_init(NULL, stdio_getc, stdio_putbuf, NULL);
   if (!strcmp(name, "foo")) {
     foo x = {0};
     TRY(ujson_deserialize_foo(&uj, &x));

--- a/sw/device/lib/ujson/test_helpers.h
+++ b/sw/device/lib/ujson/test_helpers.h
@@ -19,7 +19,8 @@ class SourceSink {
   const std::string &Sink() { return sink_; }
 
   ujson_t UJson() {
-    return ujson_init((void *)this, &SourceSink::getc, &SourceSink::putbuf);
+    return ujson_init((void *)this, &SourceSink::getc, &SourceSink::putbuf,
+                      nullptr);
   }
 
   void Reset() {

--- a/sw/device/lib/ujson/ujson.c
+++ b/sw/device/lib/ujson/ujson.c
@@ -17,8 +17,9 @@
 static bool is_space(int c) { return c == ' ' || (c >= '\t' && c < '\t' + 5); }
 
 ujson_t ujson_init(void *context, status_t (*getc)(void *),
-                   status_t (*putbuf)(void *, const char *, size_t)) {
-  ujson_t u = UJSON_INIT(context, getc, putbuf);
+                   status_t (*putbuf)(void *, const char *, size_t),
+                   status_t (*flushbuf)(void *)) {
+  ujson_t u = UJSON_INIT(context, getc, putbuf, flushbuf);
   return u;
 }
 
@@ -38,6 +39,8 @@ static size_t ujson_putbuf_sink(ujson_t *uj, const char *buf, size_t len) {
   }
   return (size_t)result.value;
 }
+
+status_t ujson_flushbuf(ujson_t *uj) { return uj->flushbuf(uj->io_context); }
 
 status_t ujson_getc(ujson_t *uj) {
   int16_t buffer = uj->buffer;

--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -245,7 +245,7 @@ cc_library(
         ":personalize_ext",
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/dif:flash_ctrl",
-        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
         "//sw/device/lib/testing/test_framework:status",
         "//sw/device/lib/testing/test_framework:ujson_ottf",
         "//sw/device/silicon_creator/lib:attestation",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4420,7 +4420,9 @@ opentitan_test(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing/json:provisioning_data",
         "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
     ],
 )
 

--- a/sw/device/tests/ottf_console_with_gpio_tx_indicator_test.c
+++ b/sw/device/tests/ottf_console_with_gpio_tx_indicator_test.c
@@ -4,9 +4,11 @@
 
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/json/provisioning_data.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_console.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
@@ -79,7 +81,9 @@ static const char kTest4KbDataStr[] =
     "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     "bbbbbbbbbbbbbbbbbbbbbbbbbb";
 
-bool test_main(void) {
+static perso_blob_t perso_blob_to_host;
+
+static status_t test_base_printf(void) {
   // Send a string using the TX-ready GPIO indicator pin. Note, we use
   // `base_printf()`directly, instead of LOG_INFO(), as we only want to print
   // the exact string as is, with no additional metadata.
@@ -94,7 +98,26 @@ bool test_main(void) {
   base_printf("ABC");
   base_printf("%s", kTest4KbDataStr);
 
-  abort();
+  return OK_STATUS();
+}
 
+static status_t test_large_ujson_tx(ujson_t *uj) {
+  // Note: this should match the size of the "body" field in
+  // `sw/device/lib/testing/json/provisioning_data.h`.
+  const size_t kPayloadSize = ARRAYSIZE(perso_blob_to_host.body);
+  for (size_t i = 0; i < kPayloadSize; ++i) {
+    perso_blob_to_host.body[i] = (uint8_t)(i % 256);
+  }
+  perso_blob_to_host.num_objs = 1;
+  perso_blob_to_host.next_free = kPayloadSize;
+  RESP_OK(ujson_serialize_perso_blob_t, uj, &perso_blob_to_host);
+  return OK_STATUS();
+}
+
+bool test_main(void) {
+  ujson_t uj = ujson_ottf_console();
+  CHECK_STATUS_OK(test_base_printf());
+  CHECK_STATUS_OK(test_large_ujson_tx(&uj));
+  abort();
   return true;
 }

--- a/sw/device/tests/ottf_console_with_gpio_tx_indicator_test.c
+++ b/sw/device/tests/ottf_console_with_gpio_tx_indicator_test.c
@@ -17,8 +17,8 @@ static const dif_gpio_pin_t kGpioPinSpiConsoleTxReady = 0;
 OTTF_DEFINE_TEST_CONFIG(
         .console.type = kOttfConsoleSpiDevice,
         .console.base_addr = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR,
-        .console.test_may_clobber = false, .silence_console_prints = true,
-        .console_tx_indicator.enable = true,
+        .console.test_may_clobber = false, .console.putbuf_buffered = true,
+        .silence_console_prints = true, .console_tx_indicator.enable = true,
         .console_tx_indicator.spi_console_tx_ready_mio = kDtPadIoa5,
         .console_tx_indicator.spi_console_tx_ready_gpio =
             kGpioPinSpiConsoleTxReady);

--- a/sw/host/opentitanlib/src/uart/console.rs
+++ b/sw/host/opentitanlib/src/uart/console.rs
@@ -43,7 +43,7 @@ impl<T: Read + AsFd> ReadAsFd for T {}
 impl UartConsole {
     const CTRL_B: u8 = 2;
     const CTRL_C: u8 = 3;
-    const BUFFER_LEN: usize = 16384;
+    const BUFFER_LEN: usize = 32768;
 
     // Runs an interactive console until CTRL_C is received.
     pub fn interact<T>(

--- a/sw/host/tests/chip/ottf_console_with_gpio_tx_indicator/BUILD
+++ b/sw/host/tests/chip/ottf_console_with_gpio_tx_indicator/BUILD
@@ -13,6 +13,7 @@ rust_binary(
     ],
     deps = [
         "//sw/host/opentitanlib",
+        "//sw/host/provisioning/ujson_lib",
         "@crate_index//:anyhow",
         "@crate_index//:clap",
         "@crate_index//:humantime",


### PR DESCRIPTION
Backport  #27063 and one commit of #26983

Follow up to #27623



NOTE: after hours of debugging, I figured out that `kPayloadSize` was hardcoded to the wrong value due to master/earlgrey_1.0.0 differences which was causing some silent corruption. I changed the code to use `ARRAYSIZE` of the struct field.