### PR TITLE
[util,sw] Add argument for consttime test to ignore subroutines

### DIFF
--- a/hw/ip/otbn/util/check_const_time.py
+++ b/hw/ip/otbn/util/check_const_time.py
@@ -27,6 +27,13 @@ def main() -> int:
         help=('The specific subroutine to check. If not provided, the start '
               'point is _imem_start (whole program).'))
     parser.add_argument(
+        '--ignore',
+        nargs='+',
+        type=str,
+        required=False,
+        help=('The specific subroutines to ignore. Use this argument '
+              'if violations should be ignored for a subroutine.'))
+    parser.add_argument(
         '--constants',
         nargs='+',
         type=str,
@@ -68,6 +75,14 @@ def main() -> int:
         _, _, control_deps = get_subroutine_iflow(program, graph,
                                                   args.subroutine, constants)
 
+    control_deps_ignore = {}
+    if args.ignore is not None:
+        for subroutine in args.ignore:
+            graph = subroutine_control_graph(program, subroutine)
+            _, _, control_deps_ignore_temp = get_subroutine_iflow(program, graph,
+                                                                  subroutine, {})
+            control_deps_ignore.update(control_deps_ignore_temp)
+
     if args.secrets is None:
         if args.verbose:
             print(
@@ -85,12 +100,15 @@ def main() -> int:
             for node, pcs in control_deps.items() if node in args.secrets
         }
 
+    secret_control_deps_filt = {k: v for k, v in secret_control_deps.items()
+                                if v not in control_deps_ignore.values()}
+
     out = CheckResult()
 
-    if len(secret_control_deps) != 0:
+    if len(secret_control_deps_filt) != 0:
         msg = 'The following secrets may influence control flow:\n  '
         msg += '\n  '.join(stringify_control_deps(program,
-                                                  secret_control_deps))
+                                                  secret_control_deps_filt))
         out.err(msg)
 
     if args.verbose or out.has_errors() or out.has_warnings():

--- a/rules/otbn.bzl
+++ b/rules/otbn.bzl
@@ -267,6 +267,8 @@ def _otbn_consttime_test_impl(ctx):
     script_content = "{} {} --verbose".format(ctx.executable._checker.short_path, elf.short_path)
     if ctx.attr.subroutine:
         script_content += " --subroutine {}".format(ctx.attr.subroutine)
+    if ctx.attr.ignore:
+        script_content += " --ignore {}".format(" ".join(ctx.attr.ignore))
     if ctx.attr.secrets:
         script_content += " --secrets {}".format(" ".join(ctx.attr.secrets))
     if ctx.attr.initial_constants:
@@ -513,6 +515,7 @@ otbn_consttime_test = rule(
         "srcs": attr.label_list(allow_files = True),
         "deps": attr.label_list(providers = [OutputGroupInfo]),
         "subroutine": attr.string(),
+        "ignore": attr.string_list(),
         "secrets": attr.string_list(),
         "initial_constants": attr.string_list(),
         "_checker": attr.label(


### PR DESCRIPTION
If we want to add FI checks to consttime routines, the consttime tests will fail. This PR allows us to ignore certain subroutines during consttime tests.