### PR TITLE
[dv, csr] Fix prediction of non-hro REGWEN registers for hro registers

### DIFF
--- a/util/reggen/fpv_csr.sv.tpl
+++ b/util/reggen/fpv_csr.sv.tpl
@@ -149,7 +149,7 @@ module ${mod_base}_csr_assert_fpv import tlul_pkg::*;
      mubi_regwen = False
      mubi_width = 4
      # Locate the REGWEN register and determine its type.
-     for reg in hro_regs_list:
+     for reg in rb.flat_regs:
        if reg.name == regwen:
          hidden_regwen = False
          if reg.fields[0].mubi:


### PR DESCRIPTION
When locating the REGWEN register of hardware read-only (hro) registers, the auto-generated DV implementation erroneously searched the list of hro registers, instead of the list of all registers.

This bug caused DV to fail for hardware IP blocks featuring hro CSRs controlled by non-hro registers. One example is ENTROPY_SRC for which write accesses to several configuration CSRs is blocked through a hwo / software read-only REGWEN CSR. As a result of this bug, the crucial entropy_src_rng vseq had a failure rate of 100% and the functional coverage for the ENTROPY_SRC was as low as 20%.

This is a follow-up of commit 06b911723fd485323e34749bbb7e7a741b8dbd1e .