### PR TITLE
[Testplantool] Add option to group bazel test suite by lc_state

### DIFF
--- a/util/testplantool/README.md
+++ b/util/testplantool/README.md
@@ -40,8 +40,16 @@ Available testpoint filters:
 fields filters:
     --fields: Comma separated list of fields that should be in the output.
 
-## Exporting the SiVal bazel testsuites:
+## Exporting bazel testsuites:
+Based on SiVal stage
 ```sh
 bazel run util/testplantool -- export-testsuite \
 $(pwd)/hw/top_earlgrey/data/chip_testplan.hjson $(pwd)/sw/device/tests/sival/BUILD
+```
+
+Based on `lc_state`
+```sh
+mkdir -p sw/device/tests/lc_state
+bazel run util/testplantool -- export-testsuite -g "lc_state" \
+$(pwd)/hw/top_earlgrey/data/chip_testplan.hjson $(pwd)/sw/device/tests/lc_state/BUILD
 ```

--- a/util/testplantool/cli.py
+++ b/util/testplantool/cli.py
@@ -153,6 +153,10 @@ def export_testsuite(input_file: str, out_file: str, group_by: str):
         all_suite = Template(ALL_SUITE_TEMPLATE)
         file.write(all_suite.render(suites=[s.lower() + "_tests" for s in items]))
 
+    elif group_by == "lc_state":
+        for item in tp.get_lc_states():
+            filtered = tp.filter_testpoints(lc_state=item).filter_fields(["bazel"])
+            tests = filtered.get_bazel()
+            file.write(template.render(suite_name=item.lower(), test_list=tests))
+
     print(f"Generated {out_file}.")
-
-

--- a/util/testplantool/testplanlib/lib.py
+++ b/util/testplantool/testplanlib/lib.py
@@ -81,22 +81,22 @@ class Testplan:
 
     @staticmethod
     def from_dict(testplan: dict) -> "Testplan":
-        OPTIONAL_FIELDS = [
-            "bazel",
-            "lc_states",
-            "features",
-            "boot_stages",
-            "tags",
-            "otp_mutate",
-            "host_support",
-            "si_stage",
-        ]
+        OPTIONAL_FIELDS = {
+            "bazel": lambda: [],
+            "lc_states": lambda: [],
+            "features": lambda: [],
+            "boot_stages": lambda: [],
+            "tags": lambda: [],
+            "otp_mutate": lambda: False,
+            "host_support": lambda: False,
+            "si_stage": lambda: "None",
+        }
         testpoints = testplan["testpoints"]
         for test in testpoints:
             test["ip"] = testplan.get("name", "unknown")
-            for f in OPTIONAL_FIELDS:
+            for f, default in OPTIONAL_FIELDS.items():
                 if f not in test:
-                    test[f] = "None"
+                    test[f] = default()
 
         return Testplan(testpoints)
 

--- a/util/testplantool/testplanlib/lib.py
+++ b/util/testplantool/testplanlib/lib.py
@@ -18,7 +18,7 @@ class Testplan:
         """
         Return a unique list of bazel targets
         """
-        res = [item for tp in self.testpoints for item in tp["bazel"]]
+        res = [item for tp in self.testpoints for item in tp.get("bazel", [])]
         return list(sorted(set(res)))
 
     def get_si_stage(self) -> list[str]:

--- a/util/testplantool/testplanlib/lib.py
+++ b/util/testplantool/testplanlib/lib.py
@@ -29,6 +29,13 @@ class Testplan:
         res = filter(lambda item: item.lower() not in ["na", "none"], res)
         return list(sorted(set(res)))
 
+    def get_lc_states(self) -> list[str]:
+        """
+        Return a unique list of life-cycle stages
+        """
+        res = [state for tp in self.testpoints for state in tp.get("lc_states", [])]
+        return list(sorted(set(res)))
+
     def join(self, other: "Testplan") -> None:
         self.testpoints.extend(other.testpoints)
 


### PR DESCRIPTION
## Exporting bazel testsuites:
Based on SiVal stage
```sh
bazel run util/testplantool -- export-testsuite \
$(pwd)/hw/top_earlgrey/data/chip_testplan.hjson $(pwd)/sw/device/tests/sival/BUILD
```

Based on `lc_state`
```sh
mkdir -p sw/device/tests/lc_state
bazel run util/testplantool -- export-testsuite -g "lc_state" \
$(pwd)/hw/top_earlgrey/data/chip_testplan.hjson $(pwd)/sw/device/tests/lc_state/BUILD
```
