### PR TITLE
[alert_handler] Allow async_on and lpg_map params to be strings.

### DIFF
--- a/hw/ip_templates/alert_handler/data/alert_handler.hjson.tpl
+++ b/hw/ip_templates/alert_handler/data/alert_handler.hjson.tpl
@@ -78,12 +78,14 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
             '''
       type: "logic [NAlerts-1:0][NLpgWidth-1:0]",
       default: '''
-% if lpg_map:
+% if lpg_map and isinstance(lpg_map, list):
                {
   % for l in list(reversed(lpg_map)):
                  ${l}${"" if loop.last else ","}
   % endfor
                }
+% elif lpg_map:
+               ${lpg_map}
 % else:
                '0
 % endif
@@ -109,12 +111,14 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
             '''
       type: "logic [NAlerts-1:0]",
       default: '''
-% if async_on:
+% if async_on and isinstance(async_on, list):
                {
   % for a in list(reversed(async_on)):
                  ${a}${"" if loop.last else ","}
   % endfor
                }
+% elif async_on:
+               ${async_on}
 % else:
                '0
 % endif


### PR DESCRIPTION
This allows e.g., to use `async_on: "{NAlerts{1'b1}}"` instead of `[1'b1, 1'b1, ...]` to avoid potential issues when the number of elements in the provided list does not match the `n_alerts` param. This is useful when the alert_handler IP is used outside of an OT top.