### PR TITLE
[crypto] Fix .data to .bss for P384 code

### DIFF
--- a/sw/otbn/crypto/p384_base_mult.s
+++ b/sw/otbn/crypto/p384_base_mult.s
@@ -95,7 +95,7 @@ p384_base_mult:
   ret
 
 /* variables and scratchpad memory */
-.section .data
+.section .bss
 
 .balign 32
 

--- a/sw/otbn/crypto/p384_curve_point_valid.s
+++ b/sw/otbn/crypto/p384_curve_point_valid.s
@@ -31,7 +31,7 @@ validate_point:
 
   ecall
 
-.data
+.bss
 
 /* Public key x-coordinate. */
 .globl x

--- a/sw/otbn/crypto/p384_ecdsa_sca.s
+++ b/sw/otbn/crypto/p384_ecdsa_sca.s
@@ -33,7 +33,7 @@ p384_ecdsa_verify:
   /*jal      x1, p384_verify*/
   ecall
 
-.data
+.bss
 
 /* Freely available DMEM space. */
 

--- a/sw/otbn/crypto/p384_isoncurve.s
+++ b/sw/otbn/crypto/p384_isoncurve.s
@@ -283,7 +283,7 @@ p384_invalid_input:
   /* End the program. */
   ecall
 
-.data
+.bss
 
 /* Success code for basic validity checks on the public key and signature.
    Should be HARDENED_BOOL_TRUE or HARDENED_BOOL_FALSE. */

--- a/sw/otbn/crypto/p384_keygen.s
+++ b/sw/otbn/crypto/p384_keygen.s
@@ -226,7 +226,7 @@ p384_generate_k:
 
   ret
 
-.section .data
+.section .bss
 
 .balign 32
 

--- a/sw/otbn/crypto/p384_keygen_from_seed.s
+++ b/sw/otbn/crypto/p384_keygen_from_seed.s
@@ -183,7 +183,7 @@ p384_key_from_seed:
 
   ret
 
-.section .data
+.section .bss
 
 .balign 32
 

--- a/sw/otbn/crypto/p384_scalar_mult.s
+++ b/sw/otbn/crypto/p384_scalar_mult.s
@@ -174,7 +174,7 @@ p384_scalar_mult:
   ret
 
 /* scratchpad memory */
-.section .data
+.section .bss
 
 .balign 32
 

--- a/sw/otbn/crypto/p384_sign.s
+++ b/sw/otbn/crypto/p384_sign.s
@@ -270,7 +270,7 @@ p384_sign:
 
 
 /* scratchpad memory */
-.section .data
+.section .bss
 
 .balign 32
 

--- a/sw/otbn/crypto/p384_verify.s
+++ b/sw/otbn/crypto/p384_verify.s
@@ -435,7 +435,7 @@ p384_verify:
 
 
 /* scratchpad memory */
-.section .data
+.section .bss
 
 .balign 32
 


### PR DESCRIPTION
It seems like our compiler does not auto convert .data to .bss if all zero vars are defined. This fixes respective .data sections for P384 code which should have been .bss. This saves ca. 2kB of OTBN binary.