### PR TITLE
[ci] skip verible installation if not needed

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -25,6 +25,9 @@ inputs:
     description: Path at which to install Verible
     required: true
     default: /tools/verible
+  install-verible:
+    description: Install verbile
+    default: false
   configure-bazel:
     description: Configure Bazel to use remote cache
     required: true
@@ -73,6 +76,7 @@ runs:
       shell: bash
 
     - name: Install Verible
+      if: inputs.install-verible == 'true'
       run: |
         VERIBLE_TAR="verible-${{ inputs.verible-version }}-linux-static-x86_64.tar.gz"
         VERIBLE_URL="https://github.com/chipsalliance/verible/releases/download/${{ inputs.verible-version }}/${VERIBLE_TAR}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
         uses: ./.github/actions/prepare-env
         with:
           service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
+          install-verible: true
       - name: Countermeasures implemented (earlgrey)
         run: ./ci/scripts/check-countermeasures.sh earlgrey
       - name: Countermeasures implemented (englishbreakfast)


### PR DESCRIPTION
It appears none of the actions except slow-lint need verible, so let's make it by default not installed.