### PR TITLE
[darjeeling] Connect LC DFT enable in RVDM

### DIFF
--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -4857,6 +4857,7 @@
           width: 1
           default: lc_ctrl_pkg::Off
           inst_name: rv_dm
+          top_signame: lc_ctrl_lc_dft_en
           index: -1
         }
         {
@@ -11857,6 +11858,7 @@
         ast.lc_dft_en
         pwrmgr_aon.lc_dft_en
         soc_dbg_ctrl.lc_dft_en
+        rv_dm.lc_dft_en
       ]
       lc_ctrl.lc_hw_debug_clr:
       [
@@ -23841,6 +23843,7 @@
         width: 1
         default: lc_ctrl_pkg::Off
         inst_name: rv_dm
+        top_signame: lc_ctrl_lc_dft_en
         index: -1
       }
       {

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -1288,7 +1288,8 @@
       'lc_ctrl.lc_dft_en'          : ['otp_macro.lc_dft_en',
                                       'ast.lc_dft_en',
                                       'pwrmgr_aon.lc_dft_en',
-                                      'soc_dbg_ctrl.lc_dft_en'
+                                      'soc_dbg_ctrl.lc_dft_en',
+                                      'rv_dm.lc_dft_en'
                                      ],
       'lc_ctrl.lc_hw_debug_clr'    : ['rv_dm.lc_hw_debug_clr'],
       'lc_ctrl.lc_hw_debug_en'     : ['sram_ctrl_main.lc_hw_debug_en',

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -1794,7 +1794,7 @@ module top_darjeeling #(
       .jtag_o(),
       .lc_hw_debug_clr_i(lc_ctrl_lc_hw_debug_clr),
       .lc_hw_debug_en_i(lc_ctrl_lc_hw_debug_en),
-      .lc_dft_en_i(lc_ctrl_pkg::Off),
+      .lc_dft_en_i(lc_ctrl_lc_dft_en),
       .pinmux_hw_debug_en_i(lc_ctrl_pkg::Off),
       .otp_dis_rv_dm_late_debug_i(rv_dm_otp_dis_rv_dm_late_debug),
       .unavailable_i(1'b0),


### PR DESCRIPTION
This signal is a missing connection. Tests need to be updated to cover for that.