### PR TITLE
[otp_ctrl, dv] Unrecognized hierarchical name  in $asseroff task

### DIFF
--- a/hw/dv/tools/dvsim/xcelium.hjson
+++ b/hw/dv/tools/dvsim/xcelium.hjson
@@ -50,7 +50,8 @@
                // This warning is thrown when a scalar enum variable is assigned to an enum array.
                // Other tools (e.g., FPV) treat such assignments as an error, hence we bump it to
                // an error in simulation so that this can be caught early in CI.
-               "-xmerror ENUMERR"
+               "-xmerror ENUMERR",
+               "-enable_abv_asrtctrl_enh"
                ]
 
   // We want to allow the possibility of passing no test or no test sequence. Unfortunately,


### PR DESCRIPTION
Xcelium complains about the $assertoff assertion control task having OtpErrorState_A. The $assertoff task have a hierarchy that contains a path to a generate loop as well. But assertion control on generate blocks is not supported by default and the switch added in this PR enables the support for them.