### PR TITLE
[dv,dma] Initial improvements to DMA coverage collection

### DIFF
--- a/hw/ip/dma/dv/dma_sim_cfg.hjson
+++ b/hw/ip/dma/dv/dma_sim_cfg.hjson
@@ -26,10 +26,13 @@
   // Import additional common sim cfg files.
   import_cfgs: [// Project wide common sim cfg file
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
+                // Common CIP test lists
+                "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"]
-
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 1


### PR DESCRIPTION
This PR improves the group coverage by collecting interrupt-related coverage for the CIP interrupt tests, and adding CIP test descriptions that are appropriate to verification of the DMA block.
