### PR TITLE
Use freestanding environment

### DIFF
--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -18,7 +18,7 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "doc_files",
-    srcs = glob(["**/*.md"]),
+    srcs = glob(["**/*.md"]) + ["//sw/device/lib/base/freestanding:doc_files"],
 )
 
 dual_cc_library(

--- a/sw/device/lib/base/freestanding/BUILD
+++ b/sw/device/lib/base/freestanding/BUILD
@@ -1,0 +1,17 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_skylib//rules/directory:directory.bzl", "directory")
+
+package(default_visibility = ["//visibility:public"])
+
+directory(
+    name = "freestanding",
+    srcs = glob(["**"]),
+)
+
+filegroup(
+    name = "doc_files",
+    srcs = glob(["**/*.md"]),
+)

--- a/sw/device/lib/base/freestanding/string.h
+++ b/sw/device/lib/base/freestanding/string.h
@@ -1,0 +1,26 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_FREESTANDING_STRING_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_FREESTANDING_STRING_H_
+
+#include <stddef.h>
+
+/**
+ * @file
+ * @brief C library string handling (Freestanding)
+ *
+ * This header implements the string.h standard header, as required by C24 S4p7,
+ * and to the extent implemented by `sw/device/lib/base/memory.h`.
+ *
+ */
+
+void *memcpy(void *dest, const void *src, size_t len);
+void *memset(void *dest, int value, size_t len);
+int memcmp(const void *lhs, const void *rhs, size_t len);
+int memrcmp(const void *lhs, const void *rhs, size_t len);
+void *memchr(const void *ptr, int value, size_t len);
+void *memrchr(const void *ptr, int value, size_t len);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_FREESTANDING_STRING_H_

--- a/third_party/lowrisc/BUILD.lowrisc_rv32imcb_toolchain.bazel
+++ b/third_party/lowrisc/BUILD.lowrisc_rv32imcb_toolchain.bazel
@@ -41,27 +41,3 @@ subdirectory(
     parent = ":root",
     path = "lib/clang/16/include",
 )
-
-subdirectory(
-    name = "riscv32-unknown-elf-include",
-    parent = ":root",
-    path = "riscv32-unknown-elf/include",
-)
-
-subdirectory(
-    name = "cxx-include",
-    parent = ":root",
-    path = "riscv32-unknown-elf/include/c++/10.2.0",
-)
-
-subdirectory(
-    name = "cxx-backward",
-    parent = ":root",
-    path = "riscv32-unknown-elf/include/c++/10.2.0/backward",
-)
-
-subdirectory(
-    name = "cxx-riscv32-unknown-elf",
-    parent = ":root",
-    path = "riscv32-unknown-elf/include/c++/10.2.0/riscv32-unknown-elf",
-)

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -41,7 +41,6 @@ cc_toolchain(
         ":arch_rv32imc",
         ":arch_rv32imcb",
         ":abi",
-        ":sys_spec",
         ":warnings",
         ":reproducible",
         ":symbol_garbage_collection",
@@ -220,27 +219,15 @@ cc_args(
         "-isystem",
         "{clang-include}",
         "-isystem",
-        "{riscv32-include}",
-        "-isystem",
-        "{cxx-include}",
-        "-isystem",
-        "{cxx-backward}",
-        "-isystem",
-        "{cxx-riscv32}",
+        "{freestanding}",
     ],
     data = [
-        "@lowrisc_rv32imcb_toolchain//:cxx-backward",
-        "@lowrisc_rv32imcb_toolchain//:cxx-include",
-        "@lowrisc_rv32imcb_toolchain//:cxx-riscv32-unknown-elf",
+        "//sw/device/lib/base/freestanding",
         "@lowrisc_rv32imcb_toolchain//:lib-clang-include",
-        "@lowrisc_rv32imcb_toolchain//:riscv32-unknown-elf-include",
     ],
     format = {
         "clang-include": "@lowrisc_rv32imcb_toolchain//:lib-clang-include",
-        "riscv32-include": "@lowrisc_rv32imcb_toolchain//:riscv32-unknown-elf-include",
-        "cxx-include": "@lowrisc_rv32imcb_toolchain//:cxx-include",
-        "cxx-backward": "@lowrisc_rv32imcb_toolchain//:cxx-backward",
-        "cxx-riscv32": "@lowrisc_rv32imcb_toolchain//:cxx-riscv32-unknown-elf",
+        "freestanding": "//sw/device/lib/base/freestanding",
     },
 )
 
@@ -400,16 +387,10 @@ cc_args_list(
 )
 
 cc_args(
-    name = "sys_spec",
-    actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
-    args = ["-lnosys"],
-)
-
-cc_args(
     name = "constructor_destructor",
     actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
     args = [
-        # Indicate that this program may not neccesarily be able to use standard system calls.
+        # Indicate that this program may not necessarily be able to use standard system calls.
         "-ffreestanding",
         # Instantiate global variables only once.
         "-fno-common",


### PR DESCRIPTION
Remove the use of headers provided by Newlib and GCC. Instead, use a freestanding environment provided by a combination of Clang + OpenTitan.

Also, don't link again nosys, as we aren't linking agaist Newlib, nor do we want to.