### PR TITLE
[sw][aes] Remove unneeded includes from `aes.c`

### DIFF
--- a/sw/device/sca/lib/aes.c
+++ b/sw/device/sca/lib/aes.c
@@ -22,10 +22,6 @@
  */
 #include "aes.h"
 
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
-
 #include "sw/device/lib/base/memory.h"
 
 enum {


### PR DESCRIPTION
As part of an effort to remove unneeded toolchain dependencies, I noticed that `sw/device/sca/lib/aes.c` was including C headers even though they aren't used nor do we link against a C library. Remove those includes, as that will make it easier to work with a  pure freestanding environment.