### PR TITLE
Backport [earlgrey,sival] Convert a few more target to emulation images

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -486,10 +486,10 @@ silicon(
     },
     # The //conditions:default ROM_EXT needs to be updated to use the following
     # target once available:
-    # //sw/device/silicon_creator/rom_ext/sival/binaries:rom_ext_real_prod_signed_slot_a
+    # //sw/device/silicon_creator/rom_ext/sival/binaries:rom_ext_prod_slot_a
     rom_ext = select({
-        "//signing:test_keys": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_a",
-        "//conditions:default": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_a",
+        "//signing:test_keys": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_slot_a",
+        "//conditions:default": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_slot_a",
     }),
     test_cmd = """
         --exec="transport init"

--- a/hw/top_earlgrey/data/otp/sival_skus/BUILD
+++ b/hw/top_earlgrey/data/otp/sival_skus/BUILD
@@ -12,6 +12,7 @@ load(
     "CONST",
     "EARLGREY_ALERTS",
     "EARLGREY_LOC_ALERTS",
+    "get_lc_items",
 )
 load(
     "//rules:otp.bzl",
@@ -19,6 +20,7 @@ load(
     "otp_alert_classification",
     "otp_alert_digest",
     "otp_hex",
+    "otp_image",
     "otp_image_consts",
     "otp_json",
     "otp_partition",
@@ -229,3 +231,32 @@ cc_library(
         "//sw/device/silicon_creator/manuf/lib:otp_img_types",
     ],
 )
+
+# The `LC_MISSION_STATES` object contains the set of mission mode life cycle
+# states.
+LC_MISSION_STATES = get_lc_items(
+    CONST.LCV.DEV,
+    CONST.LCV.PROD,
+    CONST.LCV.PROD_END,
+)
+
+# Personalized configuration for FPGA testing. Available on `LC_MISSION_STATES`
+# life cycle states.
+# See sw/device/tests/doc/sival/devguide.md for more details.
+[
+    otp_image(
+        name = "otp_img_{}_manuf_personalized".format(lc_state),
+        src = "//hw/top_earlgrey/data/otp:otp_json_{}".format(lc_state),
+        overlays = [
+            "//hw/top_earlgrey/data/otp:otp_json_fixed_secret0",
+            ":alert_digest_cfg",
+            ":otp_json_creator_sw_cfg",
+            ":otp_json_owner_sw_cfg",
+            "//hw/top_earlgrey/data/otp:otp_json_hw_cfg0",
+            "//hw/top_earlgrey/data/otp:otp_json_hw_cfg1",
+            "//hw/top_earlgrey/data/otp:otp_json_secret1",
+            "//hw/top_earlgrey/data/otp:otp_json_fixed_secret2",
+        ] + OTP_SIGVERIFY_FAKE_KEYS,
+    )
+    for lc_state, _ in LC_MISSION_STATES
+]

--- a/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
@@ -20,33 +20,33 @@ EARLGREY_OTP_CFGS = {
 # personalization binaries that configure OTP and flash info pages as defined
 # in these bazel targets.
 EARLGREY_SKUS = {
-    # OTP Config: SIVAL; DICE Certs: X.509; Additional Certs: None
-    "sival": {
-        "otp": "sival",
+    # OTP Config: Emulation; DICE Certs: X.509; Additional Certs: None
+    "emulation": {
+        "otp": "emulation",
         "ca_config": "//sw/device/silicon_creator/manuf/keys/fake:ca_config.json",
         "ca_data": ["//sw/device/silicon_creator/manuf/keys/fake:ca_data"],
         "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice"],
         "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
         "device_ext_libs": ["@provisioning_exts//:default_perso_fw_ext"],
         "ownership_libs": ["//sw/device/silicon_creator/lib/ownership:test_owner"],
-        "rom_ext": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_b",
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_b",
         "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_b",
     },
-    # OTP Config: SIVAL; DICE Certs: CWT; Additional Certs: None
+    # OTP Config: Emulation; DICE Certs: CWT; Additional Certs: None
     # TODO(#24281): uncomment when DICE CWT cert flows are fully supported
-    # "sival_dice_cwt": {
-    #     "otp": "sival",
+    # "emulation_dice_cwt": {
+    #     "otp": "emulation",
     #     "ca_config": "//sw/device/silicon_creator/manuf/keys/fake:ca_config.json",
     #     "ca_data": ["//sw/device/silicon_creator/manuf/keys/fake:ca_data"],
     #     "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice_cwt"],
     #     "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
     #     "device_ext_libs": ["@provisioning_exts//:default_perso_fw_ext"],
-    #     "rom_ext": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_b",
+    #     "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_b",
     #     "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_b",
     # },
     # OTP Config: SIVAL; DICE Certs: X.509; Additional Certs: TPM EK
-    "sival_tpm": {
-        "otp": "sival",
+    "emulation_tpm": {
+        "otp": "emulation",
         "ca_config": "//sw/device/silicon_creator/manuf/keys/fake:ca_config.json",
         "ca_data": ["//sw/device/silicon_creator/manuf/keys/fake:ca_data"],
         "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice"],
@@ -56,7 +56,7 @@ EARLGREY_SKUS = {
             "//sw/device/silicon_creator/manuf/base:tpm_perso_fw_ext",
         ],
         "ownership_libs": ["//sw/device/silicon_creator/lib/ownership:test_owner"],
-        "rom_ext": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_b",
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_b",
         "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_b",
     },
 } | EXT_EARLGREY_SKUS

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -222,7 +222,7 @@ opentitan_test(
     deps = [
         ":flash_info_fields",
         # Testing sival SKU only should be sufficient.
-        ":individualize_sw_cfg_sival",
+        ":individualize_sw_cfg_emulation",
         "//hw/top:otp_ctrl_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:status",

--- a/sw/device/silicon_creator/rom_ext/sival/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/BUILD
@@ -43,17 +43,17 @@ ROM_EXT_FEATURES = [
 # with the sival keys pre-programmed into OTP.
 # You can manually create such a bitstream with:
 #
-# bazel build //hw/bitstream/universal:splice --//hw/bitstream/universal:env=//hw/top_earlgrey:fpga_cw310_sival
+# bazel build //hw/bitstream/universal:splice \
+#   --//hw/bitstream/universal:env=//hw/top_earlgrey:fpga_hyper310_rom_ext \
+#   --//hw/bitstream/universal:otp=//hw/top_earlgrey/data/otp/sival_skus:otp_img_prod_manuf_personalized
 [
     opentitan_binary(
-        name = "rom_ext_fake_prod_signed_slot_{}".format(slot),
+        name = "rom_ext_fake_slot_{}".format(slot),
         ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
         exec_env = [
             "//hw/top_earlgrey:silicon_creator",
             "//hw/top_earlgrey:fpga_cw310",
             "//hw/top_earlgrey:fpga_cw340",
-            "//hw/top_earlgrey:sim_dv_base",
-            "//hw/top_earlgrey:sim_verilator_base",
         ],
         linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_{}".format(slot),
         linkopts = LINK_ORDER,
@@ -62,6 +62,9 @@ ROM_EXT_FEATURES = [
         # TODO(#26060): Temporarily disable SPX signing of ROM_EXT.
         #spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
         deps = [
+            # The sival_owner C library is included only in the "fake" ROM_EXT,
+            # as it is typically used to test FPGA flows and the FPGA doesn't
+            # retain ownership information across bitstream reloads.
             ":sival_owner",
             "//sw/device/lib/crt",
             "//sw/device/silicon_creator/lib:manifest_def",
@@ -74,7 +77,7 @@ ROM_EXT_FEATURES = [
 
 [
     opentitan_binary(
-        name = "rom_ext_real_prod_signed_slot_{}".format(slot),
+        name = "rom_ext_prod_slot_{}".format(slot),
         exec_env = [
             "//hw/top_earlgrey:silicon_creator",
             "//hw/top_earlgrey:fpga_cw310",


### PR DESCRIPTION
This is a partial backport of #25195. Indeed #25195 does two things:
- update the key material of ealgrey_1.0.0 from the ES to A1
- change a few FPGA targets from sival to emulation images

This PR only backports the second type of changes.