### PR TITLE
[sw][ottf] Fix warning about unused `ottf_backdoor_flush_read_buffers`

### DIFF
--- a/sw/device/lib/testing/test_framework/ottf_utils.h
+++ b/sw/device/lib/testing/test_framework/ottf_utils.h
@@ -75,7 +75,7 @@
 
 #if defined(OPENTITAN_IS_EARLGREY)
 
-static void ottf_backdoor_flush_read_buffers(void) {
+static inline void ottf_backdoor_flush_read_buffers(void) {
   // On earlgrey, some backdoor variables may live on flash, which
   // has a read buffer that needs to be flushed to get up-to-date value.
   //
@@ -90,7 +90,7 @@ static void ottf_backdoor_flush_read_buffers(void) {
 
 #elif defined(OPENTITAN_IS_DARJEELING)
 
-static void ottf_backdoor_flush_read_buffers(void) {}
+static inline void ottf_backdoor_flush_read_buffers(void) {}
 
 #else
 #error Unsupported top


### PR DESCRIPTION
The function `ottf_backdoor_flush_read_buffers` is only used by the macro `OTTF_BACKDOOR_READ`, but that macro isn't always used. That causes warnings about the function being unused in some translation units. Marking the function as `inline` fixes that issue.