### PR TITLE
[rules] Make the nonhermetic repo rule explicitely depend on PATH

### DIFF
--- a/rules/nonhermetic.bzl
+++ b/rules/nonhermetic.bzl
@@ -45,5 +45,5 @@ def _nonhermetic_repo_impl(rctx):
 nonhermetic_repo = repository_rule(
     implementation = _nonhermetic_repo_impl,
     attrs = {},
-    environ = NONHERMETIC_ENV_VARS,
+    environ = NONHERMETIC_ENV_VARS + ["PATH"],
 )


### PR DESCRIPTION
The PATH is indirectly used to resolve binaries (in rctx.which) but Bazel does not track this as a dependency on PATH, which may cause the repository to not be invalidated when PATH changes.