### PR TITLE
[host,usbdev] Fix variable `num_bytes` unused in release builds

### DIFF
--- a/sw/host/tests/usbdev/usbdev_stream/usbdev_iso.cc
+++ b/sw/host/tests/usbdev/usbdev_stream/usbdev_iso.cc
@@ -147,6 +147,7 @@ bool USBDevIso::ServiceOUT() {
     uint8_t *data;
     size_t num_bytes = DataAvailable(&data);
     assert(num_bytes >= len);
+    (void)num_bytes;
 
     // Supply details of the single OUT packet.
     if (!xfrOut_) {


### PR DESCRIPTION
In the code

```c
size_t num_bytes = DataAvailable(&data);
assert(num_bytes >= len);
```

the variable `num_bytes` is only used when assertions are enabled. That causes an unused variable warning in release builds. This patch fixes that warning.