### PR TITLE
[bazel] use `rctx.getenv` instead of repository `environ`

### DIFF
--- a/rules/bitstreams.bzl
+++ b/rules/bitstreams.bzl
@@ -51,10 +51,13 @@ design (i.e. mix-and-match).
 def _bitstreams_repo_impl(rctx):
     # First, check if an existing pre-built bitstream cache repo exists, and if
     # so, use it instead of building one.
-    cache_path = rctx.os.environ.get(
+    cache_path = rctx.getenv(
         "BAZEL_BITSTREAMS_CACHE",
         rctx.attr.cache,
     )
+
+    # Used by the cache manager
+    rctx.getenv("BITSTREAM")
     rctx.watch(rctx.attr.python_interpreter)
     rctx.watch(rctx.attr._cache_manager)
     result = rctx.execute(
@@ -121,7 +124,6 @@ bitstreams_repo = repository_rule(
             allow_files = True,
         ),
     },
-    environ = ["BAZEL_BITSTREAMS_CACHE", "BITSTREAM"],
     # This rule depends on the Git repository, but there's no ergonomic way to
     # encode the dependency in Bazel. Instead, indicate that the rule depends on
     # something outside of Bazel's dependency graph and rely on the user calling

--- a/rules/nonhermetic.bzl
+++ b/rules/nonhermetic.bzl
@@ -33,9 +33,11 @@ to Bazel rules as possible, thus improves reproducibility and cacheability.
 """
 
 def _nonhermetic_repo_impl(rctx):
-    env = "\n".join(["    \"{}\": \"{}\",".format(v, rctx.os.environ.get(v, "")) for v in NONHERMETIC_ENV_VARS])
-    home = rctx.os.environ.get("HOME", "")
+    env = "\n".join(["    \"{}\": \"{}\",".format(v, rctx.getenv(v, "")) for v in NONHERMETIC_ENV_VARS])
+    home = rctx.getenv("HOME", "")
 
+    # Declare sensitivity on PATH, this is not implied by `rctx.which`
+    path = rctx.getenv("PATH")
     bins = {name: rctx.which(name) for name in NONHERMETIC_BINS}
     bin_paths = "\n".join(["    \"{}\": \"{}\",".format(name, rctx.path(path).dirname if path != None else "/no-such-path") for name, path in bins.items()])
 
@@ -45,5 +47,4 @@ def _nonhermetic_repo_impl(rctx):
 nonhermetic_repo = repository_rule(
     implementation = _nonhermetic_repo_impl,
     attrs = {},
-    environ = NONHERMETIC_ENV_VARS,
 )


### PR DESCRIPTION
Bazel documentation says that `environ` is deprecated. This change removes the usage of it and replace `rctx.os.environ` with `rctx.getenv` which is the recommended way that automatically registered a dependency.

This change also fixes the missing dependency on `HOME` and `PATH`.