### PR TITLE
[dv] Downgrade more errors when building vcs simv with newer compilers

### DIFF
--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -38,12 +38,15 @@
                // and final value of the selection input at the end of a simulation timestep.
                // See https://github.com/lowRISC/ibex/issues/845.
                "-xlrm uniq_prior_final",
-               // Newer compiler versions have escalated this warning into an error by default, and
-               // VCS generates code to build the simulation executable which fails this check.
+               // Newer compiler versions have escalated these warnings into an error by default, and
+               // VCS generates code to build the simulation executable which fails these checks.
                // De-escalate the error (only when building the simv itself.)
                // > rmapats.c:20:9: error: implicit declaration of function 'vcs_simpSetEBlkEvtID'
                // >  [-Wimplicit-function-declaration]
-               "-Xcflags='-Wno-error=implicit-function-declaration'",
+               // > rmapats.c:466:36: error: passing argument 1 of 'setChildClockWriteFuncAndPcode' makes
+               // > integer from pointer without a cast
+               // >  [-Wint-conversion]
+               "-Xcflags='-Wno-error=implicit-function-declaration -Wno-error=int-conversion'",
                // Force DPI-C compilation in C99 mode. The -fno-extended-identifiers flag tells g++
                // not to worry about unicode. For some bizarre reason, the VCS DPI code contains
                // preprocessor macros with smart quotes, which causes GCC 10.2 and later to choke


### PR DESCRIPTION
6d9e632e previously downgraded 'implicit-function-declaration' errors into warnings when building the vcs simv executable, which is an issue on newer compiler releases which have changed the default severity for several checks.

int-conversion errors have also been observed for the same reason. An example is given below.

Downgrade this error as well. (again, only while building the simv)

// rmapats.c:466:36: error: passing argument 1 of
// 'setChildClockWriteFuncAndPcode' makes integer from pointer without a cast //  [-Wint-conversion]