### PR TITLE
[lc_ctrl, doc] Fix typo in the STATE register description

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -1295,7 +1295,7 @@
             desc: '''
                   This field exposes the id state in redundant enum format.
                   The 2bit id state enum is repeated 16x so that it fills the entire 32bit register.
-                  The encoding is straightforward replication: [val, val, ... val]."
+                  The encoding is straightforward replication: `[val, val, ... val]`.
                   '''
             enum: [
               { value: "0x0",

--- a/hw/ip/lc_ctrl/doc/registers.md
+++ b/hw/ip/lc_ctrl/doc/registers.md
@@ -492,7 +492,7 @@ This register exposes the id state of the device.
 ### LC_ID_STATE . STATE
 This field exposes the id state in redundant enum format.
 The 2bit id state enum is repeated 16x so that it fills the entire 32bit register.
-The encoding is straightforward replication: [val, val, ... val]."
+The encoding is straightforward replication: `[val, val, ... val]`.
 
 | Value      | Name         | Description                               |
 |:-----------|:-------------|:------------------------------------------|


### PR DESCRIPTION
Fix typo in the STATE register description