### PR TITLE
[base] Make random_order more random

### DIFF
--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -259,6 +259,15 @@ cc_library(
     deps = [":bitfield"],
 )
 
+cc_test(
+    name = "random_order_unittest",
+    srcs = ["random_order_unittest.cc"],
+    deps = [
+        ":random_order",
+        "@googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "hardened_memory",
     srcs = ["hardened_memory.c"],

--- a/sw/device/lib/base/hardened_memory_unittest.cc
+++ b/sw/device/lib/base/hardened_memory_unittest.cc
@@ -34,6 +34,7 @@ constexpr uint32_t kRandomWord = 0xdeadbeef;
 // Override whatever the default randomness source is so we can verify it
 // actually gets used.
 extern "C" size_t hardened_memshred_random_word() { return kRandomWord; }
+extern "C" uint32_t random_order_random_word(void) { return kRandomWord; }
 
 TEST(HardenedMemory, MemShred) {
   std::vector<uint32_t> xs = {1, 2, 3, 4, 5, 6, 7, 8};

--- a/sw/device/lib/base/random_order.c
+++ b/sw/device/lib/base/random_order.c
@@ -10,10 +10,13 @@
 // traverses from 0 to `min_len * 2`.
 
 void random_order_init(random_order_t *ctx, size_t min_len) {
-  ctx->state = 0;
+  ctx->state = random_order_random_word();
   ctx->max = min_len * 2;
 }
 
 size_t random_order_len(const random_order_t *ctx) { return ctx->max; }
 
-size_t random_order_advance(random_order_t *ctx) { return ctx->state++; }
+size_t random_order_advance(random_order_t *ctx) {
+  size_t val = ctx->state++;
+  return val % ctx->max;
+}

--- a/sw/device/lib/base/random_order.h
+++ b/sw/device/lib/base/random_order.h
@@ -6,6 +6,7 @@
 #define OPENTITAN_SW_DEVICE_LIB_BASE_RANDOM_ORDER_H_
 
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -15,6 +16,13 @@ extern "C" {
  * @file
  * @brief Functions for generating random traversal orders.
  */
+
+/**
+ * Expects some external implementation of randomness to be linked.
+ *
+ * @return A fresh random word.
+ */
+extern uint32_t random_order_random_word(void);
 
 /**
  * Context for a random traversal order.
@@ -46,6 +54,7 @@ typedef struct random_order {
  *
  * @param ctx The context to initialize.
  * @param min_len The minimum length this traversal order must visit.
+ *                This value should be in the range [1..SSIZE_MAX].
  */
 void random_order_init(random_order_t *ctx, size_t min_len);
 

--- a/sw/device/lib/base/random_order_unittest.cc
+++ b/sw/device/lib/base/random_order_unittest.cc
@@ -1,0 +1,88 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/random_order.h"
+
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace random_order_unittest {
+namespace {
+
+using ::testing::Each;
+using ::testing::ElementsAre;
+
+uint32_t current_random_word = 0xdeadbeef;
+
+extern "C" uint32_t random_order_random_word(void) {
+  return current_random_word;
+}
+
+/**
+ * Basic invariant checks on a random order context.
+ *
+ * @param ctx Context to check.
+ * @param len Length of the target iteration sequence.
+ */
+static void ctx_check(random_order_t *ctx, size_t len) {
+  // `max` should be greater than the length, strictly if possible.
+  EXPECT_LE(len, ctx->max);
+  if (len < SIZE_MAX) {
+    EXPECT_LT(len, ctx->max);
+  }
+}
+
+TEST(RandomOrder, InitSmallTest) {
+  // Check that values are OK for several small `min_len` values.
+  random_order_t ctx;
+  for (size_t i = 1; i < 100; i++) {
+    random_order_init(&ctx, i);
+    ctx_check(&ctx, i);
+  }
+}
+
+TEST(RandomOrder, InitLargeTest) {
+  // Check that values are OK for several large `min_len` values.
+  random_order_t ctx;
+  for (size_t i = 0; i < 100; i++) {
+    size_t len = SSIZE_MAX - i;
+    random_order_init(&ctx, len);
+    ctx_check(&ctx, len);
+  }
+}
+
+TEST(RandomOrder, InitRndZeroTest) {
+  // Check that zeroes are handled appropriately.
+  size_t len = 10;
+  uint32_t tmp = current_random_word;
+  current_random_word = 0;
+  random_order_t ctx;
+  random_order_init(&ctx, len);
+  ctx_check(&ctx, len);
+  current_random_word = tmp;
+}
+
+TEST(RandomOrder, SpecTest) {
+  // Ensure that advancing through the random order struct hits all numbers in
+  // the target sequence.
+  size_t len = 100;
+  random_order_t ctx;
+  random_order_init(&ctx, len);
+
+  std::vector<bool> hit(len);
+  for (size_t i = 0; i < len; i++) {
+    hit[i] = false;
+  }
+
+  for (size_t i = 0; i < random_order_len(&ctx); i++) {
+    uint32_t j = random_order_advance(&ctx);
+    hit[j] = true;
+  }
+  EXPECT_THAT(hit, Each(true));
+}
+
+}  // namespace
+}  // namespace random_order_unittest

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -106,6 +106,9 @@ hmac_digest_t owner_history_hash;
 // Verifying key index
 size_t verify_key;
 
+// Supply a source of randomness for the random order functions.
+uint32_t random_order_random_word(void) { return rnd_uint32(); }
+
 OT_WARN_UNUSED_RESULT
 static uint32_t rom_ext_current_slot(void) {
   uint32_t pc = ibex_addr_remap_get(0);


### PR DESCRIPTION
The implementation of `random_order` in the earlgrey_1.0.0 branch is completely deterministic.  Rather than backporting the implementation from `master`, this change simply randomizes the starting position.

Do not cherrypick to master.