### PR TITLE
[reggen, kmac] Fix conflicting configuration in register

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -805,7 +805,6 @@
       '''
       swaccess: "ro"
       hwaccess: "hwo"
-      regwen: "CFG_REGWEN"
       fields: [
         { bits: "HashCntW-1:0"
           name: "hash_cnt"

--- a/hw/ip/kmac/doc/registers.md
+++ b/hw/ip/kmac/doc/registers.md
@@ -507,7 +507,6 @@ counter is only reset by the CMD.hash_cnt_clr CSR bit.
 - Offset: `0x24`
 - Reset default: `0x0`
 - Reset mask: `0x3ff`
-- Register enable: [`CFG_REGWEN`](#cfg_regwen)
 
 ### Fields
 


### PR DESCRIPTION
In the register ENTROPY_REFRESH_HASH_CNT the property `swaccess=ro` conflicts with `regwen` as confirmed by reggen which generated the same RTL after this change.