### PR TITLE
[sw] Fix missing `switch` `default` label problems

### DIFF
--- a/sw/device/lib/testing/i2c_testutils.c
+++ b/sw/device/lib/testing/i2c_testutils.c
@@ -390,6 +390,8 @@ status_t i2c_testutils_set_speed(const dif_i2c_t *i2c, dif_i2c_speed_t speed) {
       LOG_INFO("Setting i2c to %s mode.", "FastPlus (1000kHz)");
       speed_khz = 1000;
       break;
+    default:
+      break;
   }
   // I2C speed parameters.
   dif_i2c_timing_config_t timing_config = {

--- a/sw/device/lib/testing/spi_flash_testutils.c
+++ b/sw/device/lib/testing/spi_flash_testutils.c
@@ -389,6 +389,8 @@ status_t spi_flash_testutils_quad_enable(dif_spi_host_t *spih, uint8_t method,
       // Reserved.
       return INVALID_ARGUMENT();
       break;
+    default:
+      break;
   }
   return OK_STATUS();
 }

--- a/sw/device/lib/testing/usb_testutils_controlep.c
+++ b/sw/device/lib/testing/usb_testutils_controlep.c
@@ -282,6 +282,8 @@ static usb_testutils_ctstate_t setup_req(usb_testutils_controlep_ctx_t *ctctx,
           case kVendorSetupReqTestStatus: {
             // TODO - pass the received test status to the OTTF directly?
           } break;
+          default:
+            break;
         }
       }
       return kUsbTestutilsCtError;

--- a/sw/device/silicon_creator/lib/drivers/keymgr.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.c
@@ -196,11 +196,11 @@ static rom_error_t keymgr_wait_until_done(void) {
       abs_mmio_write32(kBase + KEYMGR_ERR_CODE_REG_OFFSET, err_code);
       return kErrorKeymgrInternal;
     }
+    default:
+      // Should be unreachable.
+      HARDENED_TRAP();
+      return kErrorKeymgrInternal;
   }
-
-  // Should be unreachable.
-  HARDENED_TRAP();
-  return kErrorKeymgrInternal;
 }
 
 rom_error_t sc_keymgr_generate_key(

--- a/sw/device/tests/aes_interrupt_encryption_test.c
+++ b/sw/device/tests/aes_interrupt_encryption_test.c
@@ -71,6 +71,8 @@ status_t execute_test(void) {
         aes_mode = kDifAesModeCtr;
         memcpy(iv_mode.iv, kAesModesIvCtr, sizeof(kAesModesIvCtr));
         break;
+      default:
+        break;
     }
     // Initialise AES.
     dif_aes_t aes;

--- a/sw/device/tests/power_virus_systemtest.c
+++ b/sw/device/tests/power_virus_systemtest.c
@@ -321,6 +321,8 @@ static void log_entropy_src_alert_failures(void) {
         LOG_INFO("High Fails (Mailbox): %d", counts.high_fails[i]);
         LOG_INFO("Low Fails (Mailbox): %d", counts.low_fails[i]);
         break;
+      default:
+        break;
     }
   }
 }


### PR DESCRIPTION
Starting with version 18, Clang now actually respects `-Wswitch-default` instead of silently ignoring it. This patch fixes several cases of `switch` statements with a missing `default` label, to avoid warnings when compiling with recent versions of Clang.