### PR TITLE
[topgen,rv_plic] Enforce limit of 1024 interrupts and fix docs

### DIFF
--- a/hw/ip_templates/rv_plic/README.md
+++ b/hw/ip_templates/rv_plic/README.md
@@ -11,7 +11,7 @@ See that document for integration overview within the broader top level system.
 ## Features
 
 - RISC-V Platform-Level Interrupt Controller (PLIC) compliant interrupt controller
-- Support arbitrary number of interrupt vectors (up to 255) and targets
+- Support arbitrary number of interrupt vectors (up to 1023) and targets
 - Support interrupt enable, interrupt status registers
 - Memory-mapped MSIP register per HART for software interrupt control.
 

--- a/hw/top_darjeeling/ip_autogen/rv_plic/README.md
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/README.md
@@ -11,7 +11,7 @@ See that document for integration overview within the broader top level system.
 ## Features
 
 - RISC-V Platform-Level Interrupt Controller (PLIC) compliant interrupt controller
-- Support arbitrary number of interrupt vectors (up to 255) and targets
+- Support arbitrary number of interrupt vectors (up to 1023) and targets
 - Support interrupt enable, interrupt status registers
 - Memory-mapped MSIP register per HART for software interrupt control.
 

--- a/hw/top_earlgrey/ip_autogen/rv_plic/README.md
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/README.md
@@ -11,7 +11,7 @@ See that document for integration overview within the broader top level system.
 ## Features
 
 - RISC-V Platform-Level Interrupt Controller (PLIC) compliant interrupt controller
-- Support arbitrary number of interrupt vectors (up to 255) and targets
+- Support arbitrary number of interrupt vectors (up to 1023) and targets
 - Support interrupt enable, interrupt status registers
 - Memory-mapped MSIP register per HART for software interrupt control.
 

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/README.md
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/README.md
@@ -11,7 +11,7 @@ See that document for integration overview within the broader top level system.
 ## Features
 
 - RISC-V Platform-Level Interrupt Controller (PLIC) compliant interrupt controller
-- Support arbitrary number of interrupt vectors (up to 255) and targets
+- Support arbitrary number of interrupt vectors (up to 1023) and targets
 - Support interrupt enable, interrupt status registers
 - Memory-mapped MSIP register per HART for software interrupt control.
 

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -412,6 +412,11 @@ def _get_rv_plic_params(top: ConfigT, name: str) -> ParamsT:
     if num_srcs <= 1:
         log.warning(f"no interrupts are connected to {name}, is it needed?")
 
+    if num_srcs > 1024:
+        log.error(f"RISC-V PLIC Error: Configured interrupt sources ({num_srcs}) "
+                  "exceed the maximum of 1024.")
+        return
+
     if num_targets < 1:
         log.warning(f"{name} specifies no targets, is it needed?")
 


### PR DESCRIPTION
The RV PLIC implementation already conforms to the RVI spec and supports up to 1023 interrupts, although the docs say otherwise. This PR fixes the docs and adds the limit to topgen if the number of interrupts is too large.