### PR TITLE
[hw,rv_core_ibex,rtl] Add optional pipe in instruction request path

### DIFF
--- a/hw/ip_templates/rv_core_ibex/data/rv_core_ibex.hjson.tpl
+++ b/hw/ip_templates/rv_core_ibex/data/rv_core_ibex.hjson.tpl
@@ -542,6 +542,13 @@
       local:   "false"
       expose:  "true"
     }
+    { name:    "InstructionPipeline"
+      type:    "bit"
+      default: "1'b0"
+      desc:    "Add a pipeline stage in the instruction interface between Ibex and the address translation"
+      local:   "true"
+      expose:  "true"
+    },
   ],
   features: [
     {

--- a/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex.sv.tpl
+++ b/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex.sv.tpl
@@ -12,38 +12,39 @@ module ${module_instance_name}
   import rv_core_ibex_pkg::*;
   import ${module_instance_name}_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0]   AlertAsyncOn     = {NumAlerts{1'b1}},
+  parameter logic [NumAlerts-1:0]   AlertAsyncOn        = {NumAlerts{1'b1}},
   // Number of cycles a differential skew is tolerated on the alert and escalation signal
-  parameter int unsigned            AlertSkewCycles  = 1,
-  parameter bit                     PMPEnable        = 1'b1,
-  parameter int unsigned            PMPGranularity   = 0,
-  parameter int unsigned            PMPNumRegions    = 16,
-  parameter int unsigned            MHPMCounterNum   = 10,
-  parameter int unsigned            MHPMCounterWidth = 32,
-  parameter ibex_pkg::pmp_cfg_t     PMPRstCfg[16]    = ibex_pkg::PmpCfgRst,
-  parameter logic [33:0]            PMPRstAddr[16]   = ibex_pkg::PmpAddrRst,
-  parameter ibex_pkg::pmp_mseccfg_t PMPRstMsecCfg    = ibex_pkg::PmpMseccfgRst,
-  parameter bit                     RV32E            = 0,
-  parameter ibex_pkg::rv32m_e       RV32M            = ibex_pkg::RV32MSingleCycle,
-  parameter ibex_pkg::rv32b_e       RV32B            = ibex_pkg::RV32BOTEarlGrey,
-  parameter ibex_pkg::regfile_e     RegFile          = ibex_pkg::RegFileFF,
-  parameter bit                     BranchTargetALU  = 1'b1,
-  parameter bit                     WritebackStage   = 1'b1,
-  parameter bit                     ICache           = 1'b1,
-  parameter bit                     ICacheECC        = 1'b1,
-  parameter bit                     ICacheScramble   = 1'b1,
-  parameter int unsigned            ICacheNWays      = 2,
-  parameter bit                     BranchPredictor  = 1'b0,
-  parameter bit                     DbgTriggerEn     = 1'b1,
-  parameter int unsigned            DbgHwBreakNum    = 4,
-  parameter bit                     SecureIbex       = 1'b1,
-  parameter ibex_pkg::lfsr_seed_t   RndCnstLfsrSeed  = ibex_pkg::RndCnstLfsrSeedDefault,
-  parameter ibex_pkg::lfsr_perm_t   RndCnstLfsrPerm  = ibex_pkg::RndCnstLfsrPermDefault,
-  parameter int unsigned            DmBaseAddr       = 32'h1A110000,
-  parameter int unsigned            DmAddrMask       = 32'h00000FFF,
-  parameter int unsigned            DmHaltAddr       = 32'h1A110800,
-  parameter int unsigned            DmExceptionAddr  = 32'h1A110808,
-  parameter bit                     PipeLine         = 1'b0,
+  parameter int unsigned            AlertSkewCycles     = 1,
+  parameter bit                     PMPEnable           = 1'b1,
+  parameter int unsigned            PMPGranularity      = 0,
+  parameter int unsigned            PMPNumRegions       = 16,
+  parameter int unsigned            MHPMCounterNum      = 10,
+  parameter int unsigned            MHPMCounterWidth    = 32,
+  parameter ibex_pkg::pmp_cfg_t     PMPRstCfg[16]       = ibex_pkg::PmpCfgRst,
+  parameter logic [33:0]            PMPRstAddr[16]      = ibex_pkg::PmpAddrRst,
+  parameter ibex_pkg::pmp_mseccfg_t PMPRstMsecCfg       = ibex_pkg::PmpMseccfgRst,
+  parameter bit                     RV32E               = 0,
+  parameter ibex_pkg::rv32m_e       RV32M               = ibex_pkg::RV32MSingleCycle,
+  parameter ibex_pkg::rv32b_e       RV32B               = ibex_pkg::RV32BOTEarlGrey,
+  parameter ibex_pkg::regfile_e     RegFile             = ibex_pkg::RegFileFF,
+  parameter bit                     BranchTargetALU     = 1'b1,
+  parameter bit                     WritebackStage      = 1'b1,
+  parameter bit                     ICache              = 1'b1,
+  parameter bit                     ICacheECC           = 1'b1,
+  parameter bit                     ICacheScramble      = 1'b1,
+  parameter int unsigned            ICacheNWays         = 2,
+  parameter bit                     BranchPredictor     = 1'b0,
+  parameter bit                     DbgTriggerEn        = 1'b1,
+  parameter int unsigned            DbgHwBreakNum       = 4,
+  parameter bit                     SecureIbex          = 1'b1,
+  parameter ibex_pkg::lfsr_seed_t   RndCnstLfsrSeed     = ibex_pkg::RndCnstLfsrSeedDefault,
+  parameter ibex_pkg::lfsr_perm_t   RndCnstLfsrPerm     = ibex_pkg::RndCnstLfsrPermDefault,
+  parameter int unsigned            DmBaseAddr          = 32'h1A110000,
+  parameter int unsigned            DmAddrMask          = 32'h00000FFF,
+  parameter int unsigned            DmHaltAddr          = 32'h1A110800,
+  parameter int unsigned            DmExceptionAddr     = 32'h1A110808,
+  parameter bit                     PipeLine            = 1'b0,
+  parameter bit                     InstructionPipeline = 1'b0,
   parameter logic [ibex_pkg::SCRAMBLE_KEY_W-1:0] RndCnstIbexKeyDefault =
       ibex_pkg::RndCnstIbexKeyDefault,
   parameter logic [ibex_pkg::SCRAMBLE_NONCE_W-1:0] RndCnstIbexNonceDefault =
@@ -160,10 +161,10 @@ module ${module_instance_name}
   localparam int NumOutstandingReqs = ICache ? 8 : 2;
 
   // Instruction interface (internal)
-  logic        instr_req;
-  logic        instr_gnt;
+  logic        instr_req, instr_req_q;
+  logic        instr_gnt, instr_gnt_ibex;
   logic        instr_rvalid;
-  logic [31:0] instr_addr;
+  logic [31:0] instr_addr, instr_addr_q;
   logic [31:0] instr_rdata;
   logic [6:0]  instr_rdata_intg;
   logic        instr_err;
@@ -457,7 +458,7 @@ module ${module_instance_name}
     .boot_addr_i,
 
     .instr_req_o        ( instr_req        ),
-    .instr_gnt_i        ( instr_gnt        ),
+    .instr_gnt_i        ( instr_gnt_ibex   ),
     .instr_rvalid_i     ( instr_rvalid     ),
     .instr_addr_o       ( instr_addr       ),
     .instr_rdata_i      ( instr_rdata      ),
@@ -579,6 +580,28 @@ module ${module_instance_name}
     end
   end
 
+  // Add an optional pipeline stage between Ibex and the address translation
+  if (InstructionPipeline) begin : gen_instr_req_pipe
+    // Request is granted for Ibex if the pipeline's request is granted or if the pipeline is empty
+    assign instr_gnt_ibex = instr_gnt || !instr_req_q;
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        instr_req_q  <= 1'b0;
+        instr_addr_q <= 32'h0;
+      end else if (instr_gnt_ibex) begin
+        // The request is captured if the pipeline's request is granted or if the pipeline is empty
+        instr_req_q  <= instr_req;
+        // Only capture the address if the request is valid
+        if (instr_req) begin
+          instr_addr_q <= instr_addr;
+        end
+      end
+    end
+  end else begin : gen_no_instr_req_pipe
+    assign instr_req_q = instr_req;
+    assign instr_addr_q = instr_addr;
+    assign instr_gnt_ibex = instr_gnt;
+  end
 
   //
   // Convert ibex data/instruction bus to TL-UL
@@ -591,7 +614,7 @@ module ${module_instance_name}
     .clk_i,
     .rst_ni(addr_trans_rst_ni),
     .region_cfg_i(ibus_region_cfg),
-    .addr_i(instr_addr),
+    .addr_i(instr_addr_q),
     .addr_o(instr_addr_trans)
   );
 
@@ -608,7 +631,7 @@ module ${module_instance_name}
   ) tl_adapter_host_i_ibex (
     .clk_i,
     .rst_ni,
-    .req_i        (instr_req),
+    .req_i        (instr_req_q),
     .instr_type_i (prim_mubi_pkg::MuBi4True),
     .gnt_o        (instr_gnt),
     .addr_i       (instr_addr_trans),

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -10903,6 +10903,7 @@
         DmHaltAddr: tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::HaltAddress[31:0]
         DmExceptionAddr: tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::ExceptionAddress[31:0]
         PipeLine: "1"
+        InstructionPipeline: "1"
         NEscalationSeverities: AlertHandlerEscNumSeverities
         WidthPingCounter: AlertHandlerEscPingCountWidth
       }
@@ -11294,6 +11295,15 @@
           local: "false"
           expose: "true"
           name_top: RvCoreIbexCsrMimpId
+        }
+        {
+          name: InstructionPipeline
+          desc: Add a pipeline stage in the instruction interface between Ibex and the address translation
+          type: bit
+          default: "1"
+          local: "true"
+          expose: "true"
+          name_top: RvCoreIbexInstructionPipeline
         }
       ]
       inter_signal_list:

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -1124,6 +1124,7 @@
                    DmHaltAddr: "tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::HaltAddress[31:0]",
                    DmExceptionAddr: "tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::ExceptionAddress[31:0]",
                    PipeLine: "1",
+                   InstructionPipeline: "1",
                    NEscalationSeverities: "AlertHandlerEscNumSeverities",
                    WidthPingCounter: "AlertHandlerEscPingCountWidth",
                   },

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
@@ -516,6 +516,13 @@
       local:   "false"
       expose:  "true"
     }
+    { name:    "InstructionPipeline"
+      type:    "bit"
+      default: "1'b0"
+      desc:    "Add a pipeline stage in the instruction interface between Ibex and the address translation"
+      local:   "true"
+      expose:  "true"
+    },
   ],
   features: [
     {

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -344,6 +344,8 @@ module top_darjeeling #(
   localparam bit RomCtrl1FlopToKmac = 1'b1;
   // local parameters for racl_ctrl
   localparam int RaclCtrlNumSubscribingIps = 11;
+  // local parameters for rv_core_ibex
+  localparam bit RvCoreIbexInstructionPipeline = 1;
 
   // Signals
   logic [3:0] mio_p2d;
@@ -2844,7 +2846,8 @@ module top_darjeeling #(
     .PipeLine(RvCoreIbexPipeLine),
     .TlulHostUserRsvdBits(RvCoreIbexTlulHostUserRsvdBits),
     .CsrMvendorId(RvCoreIbexCsrMvendorId),
-    .CsrMimpId(RvCoreIbexCsrMimpId)
+    .CsrMimpId(RvCoreIbexCsrMimpId),
+    .InstructionPipeline(RvCoreIbexInstructionPipeline)
   ) u_rv_core_ibex (
       // [101]: fatal_sw_err
       // [102]: recov_sw_err

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -9986,6 +9986,15 @@
           expose: "true"
           name_top: RvCoreIbexCsrMimpId
         }
+        {
+          name: InstructionPipeline
+          desc: Add a pipeline stage in the instruction interface between Ibex and the address translation
+          type: bit
+          default: 1'b0
+          local: "true"
+          expose: "true"
+          name_top: RvCoreIbexInstructionPipeline
+        }
       ]
       inter_signal_list:
       [

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
@@ -516,6 +516,13 @@
       local:   "false"
       expose:  "true"
     }
+    { name:    "InstructionPipeline"
+      type:    "bit"
+      default: "1'b0"
+      desc:    "Add a pipeline stage in the instruction interface between Ibex and the address translation"
+      local:   "true"
+      expose:  "true"
+    },
   ],
   features: [
     {

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -266,6 +266,8 @@ module top_earlgrey #(
   localparam int SramCtrlMainOutstanding = 2;
   // local parameters for rom_ctrl
   localparam bit RomCtrlFlopToKmac = 1'b0;
+  // local parameters for rv_core_ibex
+  localparam bit RvCoreIbexInstructionPipeline = 1'b0;
 
   // Signals
   logic [56:0] mio_p2d;
@@ -2848,7 +2850,8 @@ module top_earlgrey #(
     .PipeLine(RvCoreIbexPipeLine),
     .TlulHostUserRsvdBits(RvCoreIbexTlulHostUserRsvdBits),
     .CsrMvendorId(RvCoreIbexCsrMvendorId),
-    .CsrMimpId(RvCoreIbexCsrMimpId)
+    .CsrMimpId(RvCoreIbexCsrMimpId),
+    .InstructionPipeline(RvCoreIbexInstructionPipeline)
   ) u_rv_core_ibex (
       // [61]: fatal_sw_err
       // [62]: recov_sw_err

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -4666,6 +4666,15 @@
           expose: "true"
           name_top: RvCoreIbexCsrMimpId
         }
+        {
+          name: InstructionPipeline
+          desc: Add a pipeline stage in the instruction interface between Ibex and the address translation
+          type: bit
+          default: 1'b0
+          local: "true"
+          expose: "true"
+          name_top: RvCoreIbexInstructionPipeline
+        }
       ]
       inter_signal_list:
       [

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
@@ -516,6 +516,13 @@
       local:   "false"
       expose:  "true"
     }
+    { name:    "InstructionPipeline"
+      type:    "bit"
+      default: "1'b0"
+      desc:    "Add a pipeline stage in the instruction interface between Ibex and the address translation"
+      local:   "true"
+      expose:  "true"
+    },
   ],
   features: [
     {

--- a/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
@@ -170,6 +170,8 @@ module top_englishbreakfast #(
   localparam int SramCtrlMainOutstanding = 2;
   // local parameters for rom_ctrl
   localparam bit RomCtrlFlopToKmac = 1'b0;
+  // local parameters for rv_core_ibex
+  localparam bit RvCoreIbexInstructionPipeline = 1'b0;
 
   // Signals
   logic [37:0] mio_p2d;
@@ -1309,7 +1311,8 @@ module top_englishbreakfast #(
     .PipeLine(RvCoreIbexPipeLine),
     .TlulHostUserRsvdBits(RvCoreIbexTlulHostUserRsvdBits),
     .CsrMvendorId(RvCoreIbexCsrMvendorId),
-    .CsrMimpId(RvCoreIbexCsrMimpId)
+    .CsrMimpId(RvCoreIbexCsrMimpId),
+    .InstructionPipeline(RvCoreIbexInstructionPipeline)
   ) u_rv_core_ibex (
       // [24]: fatal_sw_err
       // [25]: recov_sw_err


### PR DESCRIPTION
Add an optional pipeline stage in the address request path between the Ibex core and the address translation to break a long path between the instruction fetch FSM and the TLUL request. Given that the number of address translation regions is parametrizable and the Darjeeling uses 32 vs 2 in Earlgrey, this is a considerable long path.

To cut that, this PR adds a pipeline stage in between. If Ibex' instruction cache works properly, there should not be much impact on the real performance. The stage is only enabled for Darjeeling.