### PR TITLE
[doc,dma] Extensions to DMA documentation

### DIFF
--- a/hw/ip/dma/doc/programmers_guide.md
+++ b/hw/ip/dma/doc/programmers_guide.md
@@ -33,7 +33,7 @@ The following three types of interrupts are supported:
 
 1.  **Transfer Completion:** An interrupt is raised when the entire data transfer (as defined by `TOTAL_DATA_SIZE`) is complete.
 2.  **Chunk Completion:** An interrupt is raised after the transfer of a single chunk of data (as defined by `CHUNK_DATA_SIZE`) is finished. This interrupt is only available when not using the [Hardware Handshaking Mode](#Hardware_Handshaking_Mode).
-3.  **Error Condition:** An interrupt is raised if an error occurs during the transfer process.
+3.  **Error Condition:** An interrupt is raised if an [error](#Error Condition) occurs during the transfer process.
 
 The current status of the DMA, including pending interrupts, can be read from the [`STATUS`](registers.md#status) register.
 Since interrupts are implemented as status bits, they are cleared by writing a '1' to the corresponding bit in the `STATUS` register.
@@ -92,9 +92,18 @@ When initiating a transfer with inline hashing, the `initial_transfer` bit in th
 This signals the DMA to initialize its internal hash state.
 When using chunked transfers with inline hashing, subsequent chunk transfers should have the `initial_transfer` bit cleared to prevent re-initialization of the hash state between chunks.
 
-The endianness of the resulting hash digest can be configured using the `digest_swap` bit in the [`CONTROL`](registers.md#control) register.
-
 Once the transfer is complete, the computed hash digest value can be read from the [`SHA2_DIGEST_0-15`](registers.md#sha2_digest) registers.
+
+The endianness of the resulting hash digest can be configured using the `digest_swap` bit in the [`CONTROL`](registers.md#control) register.
+Changing this bit affects the digests of subsequent DMA transfers; it does not alter the current contents of the [`SHA2_DIGEST_0-15`](registers.md#sha2_digest) registers.
+
+## Error Condition
+
+For security reasons, the DMA controller performs extensive checking of the configuration registers before starting a transfer.
+If any part of the configuration is invalid, the controller reports all detected errors in the [`ERROR_CODE`](registers.md#error_code) register.
+An error may also be reported during a transfer if either the source device or the destination device detects an error condition.
+
+After an error has occurred, firmware must write a 1 to the `error` bit of the [`STATUS`](registers.md#status) register to clear the error condition before another DMA transfer can be performed.
 
 ## Device Interface Functions (DIFs)
 

--- a/hw/ip/dma/dv/README.md
+++ b/hw/ip/dma/dv/README.md
@@ -1,5 +1,18 @@
 # DMA DV document
 
+## Goals
+* **DV**
+  * Verify all DMA IP features by running dynamic simulations with a SV/UVM based testbench.
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules.
+  * Achieve the required level of code and functional coverage.
+* **FPV**
+  * Verify TileLink device protocol compliance with an SVA based testbench.
+
+## Current status
+* [Design & verification stage](../../../README.md)
+  * [HW development stages](../../../../doc/project_governance/development_stages.md)
+* [Simulation results]()
+
 ## Testbench architecture
 
 The DMA testbench has been constructed based on the [CIP testbench architecture](../../../dv/sv/cip_lib/README.md).
@@ -8,6 +21,69 @@ The DMA testbench has been constructed based on the [CIP testbench architecture]
 
 ![Block diagram](./doc/tb.svg)
 
-## Testplan
+### Top level testbench
 
+The top level testbench for the DMA IP is located at `hw/ip/dma/dv/tb/tb.sv`. It instantiates the DMA DUT module `hw/ip/dma/rtl/dma.sv`.
+Additionally, the following interfaces are instantiated to connect to the DUT:
+* [Clock and reset interface](../../../dv/sv/common_ifs/README.md)
+* [TileLink host interface](../../../dv/sv/tl_agent/README.md)
+* DMA System Bus to TL-UL adapter ([`dma_sys_tl_if`](../dv/env/dma_sys_tl_if.sv))
+* Interrupts ([`pins_if`](../../../dv/sv/common_ifs/README.md))
+
+There are four TileLink interfaces:
+* The configuration register interface (device).
+* OpenTitan Internal bus (host).
+* SoC Control Network bus (host).
+* SoC System Bus (host).
+
+An adapter is used to connect the SoC System Bus port of the DMA controller to a TL-UL agent to support verification of this non-TileLink port.
+Since the OpenTitan TL-UL components support only a 32-bit address space presently but the SoC System Bus carries a 64-bit address, the base address of this adapter is randomized and it presents a 4GiB window within the 64-bit address space.
+The adapter will respond with an error if the DMA IP attempts to access an address outside of this window.
+
+### Common DV utility components
+The following utilities provide generic helper tasks and functions to perform activities that are common across the project:
+* [common_ifs](../../../dv/sv/common_ifs/README.md)
+* [dv_utils_pkg](../../../dv/sv/dv_utils/README.md)
+* [csr_utils_pkg](../../../dv/sv/csr_utils/README.md)
+
+### UVM RAL Model
+The DMA RAL model is created with the [`ralgen`](../../../dv/tools/ralgen/README.md) FuseSoC generator script automatically when the simulation is at the build stage.
+
+It can be created manually by invoking [`regtool`](../../../../util/reggen/doc/setup_and_use.md).
+```console
+$ $REPO_TOP/util/regtool.py $REPO_TOP/hw/ip/dma/data/dma.hjson -s --outdir <path_to_directory>
+```
+
+### Stimulus Strategy
+#### Test sequences
+The test sequences for the DMA IP may be found in `hw/ip/dma/dv/env/seq_lib`.
+All sequences derive from `dma_base_vseq` which provides basic access to the DMA configuration registers, as well as functionality that is common to many of the derived sequences.
+Deriving from `dma_base_vseq` is a sequence called `dma_generic_vseq` which is capable of performing any transfer that the DMA IP supports, and this sequence is further specialized in derived sequences by the use of constraints.
+There are two main categories of derived sequences called `dma_handshake_<>` and `dma_memory_<>` which, respectively, perform DMA transfers with and without the use of hardware-handshaking to/from a Low Speed I/O peripheral.
+
+#### Functional coverage
+TBD
+
+### Self-checking strategy
+#### Scoreboard
+Within the DV environment the `dma_scoreboard` checks every transaction within a transfer occurs as expected, checking the read data, the write data and the write strobes.
+Additionally any expected interrupts from the DMA IP are modeled using a variable-timing model to accommodate variations in the timing of randomized bus activity, as well as future changes to the IP.
+
+For most configurations of the DMA controller, the scoreboard will also check the contents of the destination memory/FIFO once a transfer has completed.
+This just provides additional confidence and the output from the DMA IP is as expected.
+The scoreboard performs complete prediction and checking of both the read and the write traffic, i.e. everything is checked during transfer itself.
+
+Finally the scoreboard incorporates independent behavioral code for calculating the SHA2 digest on the data being transferred, and thus checks the digest against that produced by the RTL for inline hashing operations.
+
+#### Assertions
+* TLUL assertions: The `sva/dma_bind.sv` binds the `tlul_assert` [assertions](../../tlul/doc/TlulProtocolChecker.md) to the IP to ensure TileLink interface protocol compliance.
+* Unknown checks on DUT outputs: The RTL has assertions to ensure all outputs are initialized to known values after coming out of reset.
+
+### Building and running tests
+The DMA IP has been verified using the in-house regression tool [`dvsim`](../../../../util/dvsim/README.md) for building and running tests/regressions.
+```console
+$ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/dma/dv/dma_sim_cfg.hjson -i dma_generic_smoke
+```
+
+## Testplan
 [Testplan](../data/dma_testplan.hjson)

--- a/hw/ip/dma/dv/sva/dma_bind.sv
+++ b/hw/ip/dma/dv/sva/dma_bind.sv
@@ -42,5 +42,4 @@ module dma_bind;
     .d2h  (host_tl_h_i)
   );
 
-  // TODO: bins tlul_assert to SYS interface
 endmodule

--- a/hw/ip/dma/dv/tb/tb.sv
+++ b/hw/ip/dma/dv/tb/tb.sv
@@ -40,6 +40,16 @@ module tb;
   assign tl_sys_if.h2d = sys_tl_adapter_if.tl_h2d;
   assign sys_tl_adapter_if.tl_d2h = tl_sys_if.d2h;
 
+  // Connect assertion module to SYS interface
+  tlul_assert #(
+    .EndpointType("Device")
+  ) tlul_assert_sys (
+    .clk_i  (clk),
+    .rst_ni (rst_n),
+    .h2d    (tl_sys_if.h2d),
+    .d2h    (tl_sys_if.d2h)
+  );
+
   `DV_ALERT_IF_CONNECT()
 
   // Instantiate DUT


### PR DESCRIPTION
This PR extends the documentation in the programmer's guide as well as making the DV README.md much more complete. Additionally it connects a `tlul_assert` to the remaining bus (SoC System) because this appears to have been overlooked following the introduction of the SoC SYS <-> TL-UL adapter interface.