### PR TITLE
[ottf] Backport improved IRQ handling

### DIFF
--- a/sw/device/lib/testing/test_framework/ottf_console.c
+++ b/sw/device/lib/testing/test_framework/ottf_console.c
@@ -39,8 +39,6 @@ static char main_spi_buf[kSpiDeviceMaxFramePayloadSizeBytes];
 ottf_console_t *ottf_console_get(void) { return &main_console; }
 
 void ottf_console_init(void) {
-  CHECK_DIF_OK(dif_rv_plic_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &ottf_plic));
   // Initialize/Configure the console device.
   uintptr_t base_addr = kOttfTestConfig.console.base_addr;
   main_console.type = kOttfTestConfig.console.type;

--- a/sw/device/lib/testing/test_framework/ottf_isrs.c
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.c
@@ -233,9 +233,10 @@ void ottf_external_isr(uint32_t *exc_info) {
 
   top_earlgrey_plic_peripheral_t peripheral = (top_earlgrey_plic_peripheral_t)
       top_earlgrey_plic_interrupt_for_peripheral[plic_irq_id];
-
-  if (peripheral == kTopEarlgreyPlicPeripheralUart0 &&
-      ottf_console_flow_control_isr(exc_info)) {
+  // See if the test code wants to handle it.
+  bool handled = ottf_handle_irq(exc_info, peripheral, plic_irq_id);
+  // If not, see if that interrupt corresponds to an OTTF console IRQ.
+  if (handled || ottf_console_flow_control_isr(exc_info)) {
     // Complete the IRQ at PLIC.
     CHECK_DIF_OK(
         dif_rv_plic_irq_complete(&ottf_plic, kPlicTarget, plic_irq_id));
@@ -251,6 +252,8 @@ void ottf_external_isr(uint32_t *exc_info) {
 #endif  // OT_IS_ENGLISH_BREAKFAST
   }
 
+  LOG_ERROR("unhandled IRQ: plic_id=%d, peripheral ID=%d", plic_irq_id,
+            peripheral);
   ottf_generic_fault_print(exc_info, "External IRQ", ibex_mcause_read());
   abort();
 }
@@ -258,6 +261,13 @@ void ottf_external_isr(uint32_t *exc_info) {
 static void generic_internal_irq_handler(uint32_t *exc_info) {
   ottf_generic_fault_print(exc_info, "Internal IRQ", ibex_mcause_read());
   abort();
+}
+
+OT_WEAK
+bool ottf_handle_irq(uint32_t *exc_info,
+                     top_earlgrey_plic_peripheral_t peripheral,
+                     dif_rv_plic_irq_id_t plic_id) {
+  return false;
 }
 
 OT_WEAK

--- a/sw/device/lib/testing/test_framework/ottf_isrs.h
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.h
@@ -8,6 +8,8 @@
 
 #include "sw/device/lib/dif/dif_rv_plic.h"
 
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
 /**
  * OTTF global PLIC interface.
  */
@@ -136,6 +138,34 @@ void ottf_timer_isr(uint32_t *exc_info);
  * overridden at link-time by providing an additional non-weak definition.
  */
 void ottf_external_isr(uint32_t *exc_info);
+
+/**
+ * Test external IRQ handler.
+ *
+ * `ottf_isrs.c` provides a weak definition of this symbol, which can be
+ * overridden at link-time by providing an additional non-weak definition.
+ *
+ * Overriding this function is the preferred way for device tests to handle
+ * IRQs, unless they really need to bypass the OTTF entirely.
+ *
+ * Before calling this function, `ottf_external_isr` will claim the interrupt
+ * at the PLIC and obtain the corresponding instance ID using the DT.
+ * If this function returns true, `ottf_external_isr` will complete the
+ * interrupt at the PLIC. If this function returns false, the OTTF will try
+ * to handle this IRQ for its internal functions (e.g. ottf_console). If that's
+ * not possible, a fatal error will occur.
+ *
+ * NOTE When overriding `ottf_handle_irq`, the code does not need to call
+ * `ottf_console_flow_control_isr`, this will be done automatically if the
+ * function returns false.
+ *
+ * @param inst_id The device instance that produced the interrupt.
+ * @param plid_id The PLIC IRQ ID to handle.
+ * @returns Whether the IRQ was handled.
+ */
+bool ottf_handle_irq(uint32_t *exc_info,
+                     top_earlgrey_plic_peripheral_t peripheral,
+                     dif_rv_plic_irq_id_t plic_id);
 
 /**
  * OTTF external NMI internal IRQ handler.

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -16,6 +16,7 @@
 #include "sw/device/lib/dif/dif_base.h"
 #include "sw/device/lib/dif/dif_rstmgr.h"
 #include "sw/device/lib/dif/dif_rv_core_ibex.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/log.h"
@@ -24,6 +25,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/coverage.h"
 #include "sw/device/lib/testing/test_framework/ottf_console.h"
+#include "sw/device/lib/testing/test_framework/ottf_isrs.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
 #include "sw/device/lib/testing/test_framework/status.h"
 #include "sw/device/silicon_creator/lib/manifest_def.h"
@@ -165,6 +167,11 @@ void _ottf_main(void) {
   if (kOttfTestConfig.clear_reset_reason) {
     CHECK_DIF_OK(dif_rstmgr_reset_info_clear(&rstmgr));
   }
+
+  // Initialize the global rv_plic DIF context for interrupts.
+  // This needs to happen before ottf_console_init.
+  CHECK_DIF_OK(dif_rv_plic_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &ottf_plic));
 
   // Initialize the console to enable logging for non-DV simulation platforms.
   if (kDeviceType != kDeviceSimDV) {


### PR DESCRIPTION
Partial backport of https://github.com/lowRISC/opentitan/pull/26279 without multitop changes.

I'd like to use this improved IRQ handling mechanism which doesn't interfere with flow control for alert handling. I have tweaked the commits slightly to pass a `peripheral` to the ISR instead of a multitop `devid`.