### PR TITLE
[chip, dv] Removed the entry for prim_otp

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_all_escalation_resets_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_all_escalation_resets_vseq.sv
@@ -38,7 +38,6 @@ class chip_sw_all_escalation_resets_vseq extends chip_sw_base_vseq;
     '{"*lc_ctrl*prim_reg_we_check*", TopEarlgreyAlertIdLcCtrlFatalBusIntegError},
     '{"*otbn*prim_reg_we_check*", TopEarlgreyAlertIdOtbnFatal},
     // TopEarlgreyAlertIdOtpCtrlFatalMacroError: done in chip_sw_otp_ctrl_escalation_vseq
-    '{"*otp_ctrl.u_otp.*u_state_regs", TopEarlgreyAlertIdOtpCtrlFatalPrimOtpAlert},
     '{"*otp_ctrl*u_otp_ctrl_dai*", TopEarlgreyAlertIdOtpCtrlFatalCheckError},
     '{"*otp_ctrl*prim_reg_we_check*", TopEarlgreyAlertIdOtpCtrlFatalBusIntegError},
     '{"*pattgen*prim_reg_we_check*", TopEarlgreyAlertIdPattgenFatalFault},


### PR DESCRIPTION
PR [#27001](https://github.com/lowRISC/opentitan/pull/27001) moved prim_otp out of otp_ctrl

This PR resolves the failure with tests like
** chip_sw_all_escalation_resets
** chip_sw_alert_handler_lpg_sleep_mode_alerts
and many more that fails on finding the path to
*otp_ctrl.u_otp.*u_state_regs