### PR TITLE
[dma] Improvements to handling of TL-UL errors

### DIFF
--- a/hw/ip/dma/data/dma_testplan.hjson
+++ b/hw/ip/dma/data/dma_testplan.hjson
@@ -128,12 +128,12 @@
               - Wait for PLIC interrupt assertion if INTR_ENABLE.int_enable is set else poll for DMAC.ABORTED bit
 
               Checking:
-              - Check if STATUS.aborted bit is set (This indicates DMA operation is aborted)
+              - Check if STATUS.error bit is set (This indicates DMA operation is aborted)
               - Check that there are no TLUL transactions on source and destination interfaces after error response
               - Check if DMA generates an alert
               '''
         stage: V2
-        tests: ["dma_memory_tl_error"]
+        tests: ["dma_memory_stress"]
       }
       {
         name: dma_handshake_tl_error
@@ -143,16 +143,16 @@
               Stimulus:
               - Configure DMA to perform a copy operation with different source and destination parameters in hardware_handshake mode
               - Start DMA operation by setting DMAC.GO bit
-              - Respond with error on destination TLUL interface
+              - Respond with an error on either source or destination TLUL interface request
               - Wait for PLIC interrupt assertion if INTR_ENABLE.int_enable is set else poll for DMAC.DONE bit
 
               Checking:
-              - Check that there are no TLUL transactions on destination interface after error in the input TLUL interface
-              - Check if STATUS.aborted bit is set (This indicates DMA operation is aborted)
+              - Check if STATUS.error bit is set (This indicates DMA operation is aborted)
+              - Check that there are no TLUL transactions on source and destination interfaces after error response
               - Check if DMA generates an alert
               '''
         stage: V2
-        tests: ["dma_handshake_tl_error"]
+        tests: ["dma_handshake_stress"]
       }
       {
         name: dma_handshake_stress

--- a/hw/ip/dma/dv/env/dma_sys_tl_if.sv
+++ b/hw/ip/dma/dv/env/dma_sys_tl_if.sv
@@ -106,9 +106,7 @@ interface dma_sys_tl_if
     sys_d2h.read_data_vld          = (tl_d2h.d_valid & (tl_d2h.d_opcode == AccessAckData))
                                    | read_mismatch;
     sys_d2h.read_data              = tl_d2h.d_data;
-    sys_d2h.error_vld              = (tl_d2h.d_valid & (tl_d2h.d_opcode == AccessAckData) &
-                                      tl_d2h.d_error)
-                                   | read_mismatch;
+    sys_d2h.error_vld              = (tl_d2h.d_valid & tl_d2h.d_error) | read_mismatch;
   end
 
 `ifdef INC_ASSERT

--- a/hw/ip/dma/rtl/dma.sv
+++ b/hw/ip/dma/rtl/dma.sv
@@ -889,8 +889,9 @@ module dma
             next_error[DmaSrcAddrErr] = 1'b1;
           end
 
-          // If the destination ASID is the SOC control por or the OT internal port we are accessing
-          // a 32-bit address space. Thus the upper bits of the destination address must be zero
+          // If the destination ASID is the SOC control port or the OT internal port we are
+          // accessing a 32-bit address space. Thus the upper bits of the destination address must
+          // be zero
           if ((dst_asid inside {SocControlAddr, OtInternalAddr}) &&
               (|reg2hw.dst_addr_hi.q)) begin
             next_error[DmaDstAddrErr] = 1'b1;


### PR DESCRIPTION
This PR improves the handling of TL-UL errors:
- map the dma_memory|handshake_tl_error testpoints.
- catch any TL-UL transaction that occurs after a bus error has occurred.
- propagate TL-UL errors back to SoC System bus now that they do occur and RTL handles them.
