### PR TITLE
[prim] remove $clog2 workaroud for Xcelium < 19.10

### DIFF
--- a/hw/ip/prim/rtl/prim_util_pkg.sv
+++ b/hw/ip/prim/rtl/prim_util_pkg.sv
@@ -8,37 +8,6 @@
  */
 package prim_util_pkg;
   /**
-   * Math function: $clog2 as specified in Verilog-2005
-   *
-   * Do not use this function if $clog2() is available.
-   *
-   * clog2 =          0        for value == 0
-   *         ceil(log2(value)) for value >= 1
-   *
-   * This implementation is a synthesizable variant of the $clog2 function as
-   * specified in the Verilog-2005 standard (IEEE 1364-2005).
-   *
-   * To quote the standard:
-   *   The system function $clog2 shall return the ceiling of the log
-   *   base 2 of the argument (the log rounded up to an integer
-   *   value). The argument can be an integer or an arbitrary sized
-   *   vector value. The argument shall be treated as an unsigned
-   *   value, and an argument value of 0 shall produce a result of 0.
-   */
-  function automatic integer _clog2(integer value);
-    integer result;
-    // Use an intermediate value to avoid assigning to an input port, which produces a warning in
-    // Synopsys DC.
-    integer v = value;
-    v = v - 1;
-    for (result = 0; v > 0; result++) begin
-      v = v >> 1;
-    end
-    return result;
-  endfunction
-
-
-  /**
    * Math function: Number of bits needed to address |value| items.
    *
    *                  0        for value == 0
@@ -72,18 +41,7 @@ package prim_util_pkg;
    *   logic [vbits(64 + 1)-1:0] store_number_64;       // width is [6:0]
    */
   function automatic integer vbits(integer value);
-`ifdef XCELIUM
-    // The use of system functions was not allowed here in Verilog-2001, but is
-    // valid since (System)Verilog-2005, which is also when $clog2() first
-    // appeared.
-    // Xcelium < 19.10 does not yet support the use of $clog2() here, fall back
-    // to an implementation without a system function. Remove this workaround
-    // if we require a newer Xcelium version.
-    // See #2579 and #2597.
-    return (value == 1) ? 1 : _clog2(value);
-`else
     return (value == 1) ? 1 : $clog2(value);
-`endif
   endfunction
 
   /**


### PR DESCRIPTION
The minimum supported version is now 21.09, so this workaround can be safely removed.