### PR TITLE
[ci] fix duplicated work on merge queues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches-ignore:
       - "backport-*"
-      - "gh-readonly-queue/*"
+      - "gh-readonly-queue/**"
     tags:
       - "*"
   merge_group:

--- a/.github/workflows/private-ci.yml
+++ b/.github/workflows/private-ci.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches-ignore:
       - "backport-*"
+      - "gh-readonly-queue/**"
     tags:
       - "*"
   pull_request_target:


### PR DESCRIPTION
The merge groups are pushed to `gh-readonly-queue/<branch>/<hash>` which is not matched by `gh-readonly-queue/*`, two stars are needed here as it's a glob.