### PR TITLE
[sw] Fix shift with undefined behavior

### DIFF
--- a/sw/device/tests/sram_ctrl_execution_test.c
+++ b/sw/device/tests/sram_ctrl_execution_test.c
@@ -83,7 +83,8 @@ bool test_main(void) {
         "expected PMPCFG1 to be unconfigured before changing it");
 
   CSR_SET_BITS(CSR_REG_PMPCFG1,
-               (kEpmpModeNapot | kEpmpPermLockedReadWriteExecute) << 24);
+               ((uint32_t)(kEpmpModeNapot | kEpmpPermLockedReadWriteExecute))
+                   << 24);
 
   // Note: We can test the negative case only using the retention SRAM since
   // execution is unconditionally enabled for the main SRAM in the RMA life


### PR DESCRIPTION
To avoid shifting a 1 into the sign bit, which is UB, cast the PMP mode flags to `uint32_t` before doing the shift.