### PR TITLE
[ipgen] Fix loading of ipconfig from a file

### DIFF
--- a/util/ipgen/lib.py
+++ b/util/ipgen/lib.py
@@ -303,7 +303,7 @@ class IpConfig:
         """ Load an IpConfig from a raw object """
 
         rd = check_keys(raw, 'configuration file ' + where, ['instance_name'],
-                        ['param_values'])
+                        ['param_values', 'dtgen'])
         instance_name = check_name(rd.get('instance_name'),
                                    "the key 'instance_name' of " + where)
 
@@ -314,6 +314,9 @@ class IpConfig:
 
         param_values = IpConfig._check_param_values(template_params,
                                                     rd['param_values'])
+        # The dtgen part of the configuration only depends on the template
+        # and not on the values, so it is re-derived in the constructor anyway.
+        # Therefore we just ignore it.
 
         return cls(template_params, instance_name, param_values)
 


### PR DESCRIPTION
When `dtgen` support was added to the ipconfig, only the constructor was updated but not the code loading from a file. Since topgen directly calls the constructor, this was not caught in CI but it throws an error if running ipgen directly, e.g.
```
  util/ipgen.py generate -C hw/ip_templates/ac_range_check -o hw/top_darjeeling/ip_autogen/ac_range_check -c hw/top_darjeeling/ip_autogen/ac_range_check/data/top_darjeeling_ac_range_check.ipconfig.hjson -f
```