### PR TITLE
[dv,dma] Improve SoC System bus testing

### DIFF
--- a/hw/ip/dma/dv/dma_sim_cfg.hjson
+++ b/hw/ip/dma/dv/dma_sim_cfg.hjson
@@ -50,73 +50,66 @@
     {
       name: dma_generic_smoke
       uvm_test_seq: dma_generic_smoke_vseq
-      run_opts: ["+dma_dv_waive_system_bus=1"]
       reseed: 50
     }
     {
       name: dma_memory_smoke
       uvm_test_seq: dma_memory_smoke_vseq
-      run_opts: ["+dma_dv_waive_system_bus=1"]
       reseed: 25
     }
     {
       name: dma_handshake_smoke
       uvm_test_seq: dma_handshake_smoke_vseq
-      run_opts: ["+dma_dv_waive_system_bus=1"]
       reseed: 25
     }
     {
       name: dma_memory_region_lock
       uvm_test_seq: dma_memory_region_lock_vseq
-      run_opts: ["+dma_dv_waive_system_bus=1"]
       reseed: 5
     }
     {
       name: dma_abort
       uvm_test_seq: dma_abort_vseq
-      run_opts: ["+dma_dv_waive_system_bus=1"]
       reseed: 5
     }
     {
       name: dma_short_transfer
       uvm_test_seq: dma_short_transfer_vseq
-      run_opts: ["+dma_dv_waive_system_bus=1"]
       reseed: 25
     }
     {
       name: dma_longer_transfer
       uvm_test_seq: dma_longer_transfer_vseq
-      run_opts: ["+dma_dv_waive_system_bus=1", "+test_timeout_ns=300_000_000_000"]
+      run_opts: ["+test_timeout_ns=300_000_000_000"]
       reseed: 5
     }
     {
       name: dma_mem_enabled
       uvm_test_seq: dma_mem_enabled_vseq
-      run_opts: ["+dma_dv_waive_system_bus=1"]
       reseed: 5
     }
     {
       name: dma_generic_stress
       uvm_test_seq: dma_generic_stress_vseq
-      run_opts: ["+dma_dv_waive_system_bus=1", "+test_timeout_ns=300_000_000_000"]
+      run_opts: ["+test_timeout_ns=300_000_000_000"]
       reseed: 5
     }
     {
       name: dma_memory_stress
       uvm_test_seq: dma_memory_stress_vseq
-      run_opts: ["+dma_dv_waive_system_bus=1", "+test_timeout_ns=300_000_000_000"]
+      run_opts: ["+test_timeout_ns=300_000_000_000"]
       reseed: 3
     }
     {
       name: dma_handshake_stress
       uvm_test_seq: dma_handshake_stress_vseq
-      run_opts: ["+dma_dv_waive_system_bus=1", "+test_timeout_ns=300_000_000_000"]
+      run_opts: ["+test_timeout_ns=300_000_000_000"]
       reseed: 3
     }
     {
       name: dma_stress_all
       uvm_test_seq: dma_stress_all_vseq
-      run_opts: ["+dma_dv_waive_system_bus=1", "+test_timeout_ns=300_000_000_000"]
+      run_opts: ["+test_timeout_ns=300_000_000_000"]
       reseed: 3
     }
   ]

--- a/hw/ip/dma/dv/env/dma_env_cfg.sv
+++ b/hw/ip/dma/dv/env/dma_env_cfg.sv
@@ -16,11 +16,10 @@ class dma_env_cfg extends cip_base_env_cfg #(.RAL_T(dma_reg_block));
   // Scoreboard
   dma_scoreboard        scoreboard_h;
 
-  // Waive full testing of the SoC System bus within block level DV?
-  bit dma_dv_waive_system_bus;
   // Note: Currently we have only a 32-bit TL-UL model of the SoC System bus when full testing of
   // the System bus has been explicitly waived.
-  logic [31:0] soc_system_hi_addr;
+  logic [SYS_ADDR_WIDTH-1:0] soc_system_src_base_addr;
+  logic [SYS_ADDR_WIDTH-1:0] soc_system_dst_base_addr;
 
   // Names of interfaces used in DMA block
   // These variables are used to store names of FIFO that are used

--- a/hw/ip/dma/dv/env/dma_scoreboard.sv
+++ b/hw/ip/dma/dv/env/dma_scoreboard.sv
@@ -566,8 +566,9 @@ class dma_scoreboard extends cip_base_scoreboard #(
             `DV_CHECK_FATAL(a_chan_fifo.try_get(item),
                             "dir_fifo pointed at A channel, but a_chan_fifo empty")
             a_addr = item.a_addr;
-            if (cfg.dma_dv_waive_system_bus && if_name == "sys") begin
-              a_addr[63:32] = cfg.soc_system_hi_addr;
+            if (if_name == "sys") begin
+              a_addr += (item.a_opcode == Get) ? cfg.soc_system_src_base_addr
+                                               : cfg.soc_system_dst_base_addr;
             end
 
             `uvm_info(`gfn, $sformatf("received %s a_chan %s item with addr: %0x and data: %0x",
@@ -589,8 +590,9 @@ class dma_scoreboard extends cip_base_scoreboard #(
             `DV_CHECK_FATAL(d_chan_fifo.try_get(item),
                             "dir_fifo pointed at D channel, but d_chan_fifo empty")
             a_addr = item.a_addr;
-            if (cfg.dma_dv_waive_system_bus && if_name == "sys") begin
-              a_addr[63:32] = cfg.soc_system_hi_addr;
+            if (if_name == "sys") begin
+              a_addr += (item.a_opcode == Get) ? cfg.soc_system_src_base_addr
+                                               : cfg.soc_system_dst_base_addr;
             end
             `uvm_info(`gfn, $sformatf("received %s d_chan item with addr: %0x and data: %0x",
                                       if_name, a_addr, item.d_data), UVM_HIGH)
@@ -1092,9 +1094,8 @@ class dma_scoreboard extends cip_base_scoreboard #(
           `uvm_info(`gfn, $sformatf("dma_config\n %s",
                                     dma_config.sprint()), UVM_HIGH)
           // Check if configuration is valid;
-          // Note: this may depend upon whether full SoC System bus testing has been waived.
-          dma_config.dma_dv_waive_system_bus = cfg.dma_dv_waive_system_bus;
-          dma_config.soc_system_hi_addr = cfg.soc_system_hi_addr;
+          dma_config.soc_system_src_base_addr = cfg.soc_system_src_base_addr;
+          dma_config.soc_system_dst_base_addr = cfg.soc_system_dst_base_addr;
           operation_in_progress = 1'b1;
           exp_src_addr = dma_config.src_addr;
           exp_dst_addr = dma_config.dst_addr;

--- a/hw/ip/dma/dv/env/dma_seq_item.sv
+++ b/hw/ip/dma/dv/env/dma_seq_item.sv
@@ -75,11 +75,11 @@ class dma_seq_item extends uvm_sequence_item;
   // Variable used to constrain destination address range to lie within the DMA-enabled address
   // range (consulted iff `valid_dma_config`).
   bit dst_addr_in_range;
-  // Waive testing of the system bus within this DV environment?
-  bit dma_dv_waive_system_bus;
-  // Note: Currently we have only a 32-bit TL-UL model of the SoC System bus when full testing of
-  // the System bus has been explicitly waived.
-  rand bit [31:0] soc_system_hi_addr;
+  // Note: Currently we have only a 32-bit TL-UL model of the SoC System bus, but the DMA controller
+  // is restricted to transfers of less than 4GiB so we randomize the start address of the TL-UL
+  // memory model and use an adapter to adjust the addresses within the bus traffic.
+  rand bit [SYS_ADDR_WIDTH-1:0] soc_system_src_base_addr;
+  rand bit [SYS_ADDR_WIDTH-1:0] soc_system_dst_base_addr;
 
   // Bit used to indicate if the configuration is valid
   bit is_valid_config;
@@ -112,6 +112,9 @@ class dma_seq_item extends uvm_sequence_item;
     `uvm_field_array_int(intr_src_addr, UVM_DEFAULT)
     `uvm_field_array_int(intr_src_wr_val, UVM_DEFAULT)
     `uvm_field_array_int(sha2_digest, UVM_DEFAULT)
+    `uvm_field_int(soc_system_src_base_addr, UVM_DEFAULT)
+    `uvm_field_int(soc_system_dst_base_addr, UVM_DEFAULT)
+    `uvm_field_int(lsio_trigger_i, UVM_DEFAULT)
   `uvm_object_utils_end
 
   constraint lsio_trigger_i_c {
@@ -141,6 +144,13 @@ class dma_seq_item extends uvm_sequence_item;
   // Constrain array size to number of handshake interrupt signals
   constraint intr_src_wr_val_c {
     intr_src_wr_val.size() == dma_reg_pkg::NumIntClearSources;
+  }
+
+  // Constrain the Soc System source base address so that we have a full 4GiB window and ensure
+  // that it's word-aligned.
+  constraint soc_sys_src_base_c {
+    soc_system_src_base_addr <= {SYS_ADDR_WIDTH{1'b1}} - 32'hFFFF_FFFF;
+    soc_system_src_base_addr[1:0] == 2'b00;
   }
 
   constraint src_addr_c {
@@ -184,13 +194,18 @@ class dma_seq_item extends uvm_sequence_item;
         }
       }
     }
-    // When full testing of the SoC System bus has been waived, testing is restricted to a 4GiB
-    // address window but we can vary the address window for each transfer.
-    if (dma_dv_waive_system_bus && src_asid == SocSystemAddr) {
+    if (src_asid == SocSystemAddr) {
       // Source address range must lie within the selected 4GiB window and not spill over.
-      src_addr[63:32] == soc_system_hi_addr;
-      src_addr[31:0] <= ~total_data_size;  // == 32'hFFFF_FFFF - total_data_size.
+      src_addr >= soc_system_src_base_addr &&
+      src_addr - soc_system_src_base_addr <= 32'hFFFF_FFFF - total_data_size;
     }
+  }
+
+  // Constrain the Soc System destination base address so that we have a full 4GiB window and ensure
+  // that it's word-aligned.
+  constraint soc_sys_dst_base_c {
+    soc_system_dst_base_addr <= {SYS_ADDR_WIDTH{1'b1}} - 32'hFFFF_FFFF;
+    soc_system_dst_base_addr[1:0] == 2'b00;
   }
 
   constraint dst_addr_c {
@@ -218,15 +233,6 @@ class dma_seq_item extends uvm_sequence_item;
           if (!dst_chunk_wrap) {
             mem_range_limit - dst_addr >= total_data_size;
           }
-          if (src_asid == OtInternalAddr) {
-            // Avoid overlap between source and destination buffers, also leaving a slight gap so
-            // that any out-of-bounds access does not hit a contiguous buffer
-            //
-            // `total_data_size` here is often larger than the valid addressable range in
-            // handshake mode, but keeps things simpler
-            (dst_addr > src_addr + total_data_size + 'h10) ||
-            (src_addr > dst_addr + total_data_size + 'h10);
-          }
         } else {
           // Choose a destination address range that lies partially outside the DMA-enabled memory
           // range.
@@ -244,12 +250,32 @@ class dma_seq_item extends uvm_sequence_item;
         }
       }
     }
-    // When full testing of the SoC System bus has been waived, testing is restricted to a 4GiB
-    // address window but we can vary the address window for each transfer.
-    if (dma_dv_waive_system_bus && dst_asid == SocSystemAddr) {
-      // Destination address range must lie within the selected 4GiB window and not spill over.
-      dst_addr[63:32] == soc_system_hi_addr;
-      dst_addr[31:0] <= ~total_data_size;  // == 32'hFFFF_FFFF - total_data_size.
+    if (dst_asid == SocSystemAddr) {
+      // Source address range must lie within the selected 4GiB window and not spill over.
+      dst_addr >= soc_system_dst_base_addr &&
+      dst_addr - soc_system_dst_base_addr <= 32'hFFFF_FFFF - total_data_size;
+    }
+
+    if (src_asid == dst_asid) {
+      // Avoid overlap between source and destination buffers, also leaving a slight gap so
+      // that any out-of-bounds access does not hit a contiguous buffer
+      //
+      // `total_data_size` here is often larger than the valid addressable range in
+      // handshake mode, but keeps things simpler
+      if (src_asid == SocSystemAddr) {
+        // We must consider the two SoC System base addresses that have been chosen; the key
+        // point to understand here it is that it is permissible for the two buffers to overlap
+        // in the 64-bit address space in this case, but they _must not_ overlap within the
+        // single TL-UL 32-bit address space after the source and destination addresses have
+        // been translated.
+        (dst_addr - soc_system_dst_base_addr >
+         src_addr - soc_system_src_base_addr + total_data_size + 'h10) ||
+        (src_addr - soc_system_src_base_addr >
+         dst_addr - soc_system_dst_base_addr + total_data_size + 'h10);
+      } else {
+        (dst_addr > src_addr + total_data_size + 'h10) ||
+        (src_addr > dst_addr + total_data_size + 'h10);
+      }
     }
   }
 
@@ -336,8 +362,12 @@ class dma_seq_item extends uvm_sequence_item;
 
   constraint mem_range_limit_c {
     // Set solver order to make sure mem range limit is randomized correctly in case
-    // valid_dma_config is set
-    solve mem_range_base before mem_range_limit;
+    // valid_dma_config is set.
+    //
+    // We also choose the SoC System base addresses up front, because these are simple and cannot
+    // later be invalidated. We do this even if not waiving full testing because in that case they
+    // shall simply be ignored.
+    solve soc_system_src_base_addr, soc_system_dst_base_addr, mem_range_base before mem_range_limit;
     // For valid DMA config, [mem_range_base, mem_range_limit) describes the addressable memory
     // window, but it need not always be enabled, and only applies to transfers crossing the divide
     // (importing to/exporting from OT)
@@ -509,29 +539,27 @@ class dma_seq_item extends uvm_sequence_item;
       end
     end
 
-    // Testing of the System bus may be waived in this DV environment
-    if (dma_dv_waive_system_bus) begin
-      // Use of the System bus is not invalid per se, but there are additional constraints that
-      // have had to be introduced to permit testing in block level DV (see `soc_system_hi_addr`
-      // above); if the upper bits do not match then reads or writes will be faulted, and 32-bit
-      // address wraparound is not permitted.
-      if (src_asid == SocSystemAddr) begin
-        if (src_addr[63:32] != soc_system_hi_addr || src_addr[31:0] >= ~src_memory_range) begin
-          `uvm_info(`gfn, " - Limitations of 32-bit TL-UL for testing System bus Reads not met",
-                    UVM_MEDIUM)
-          valid_config = 0;
-        end
+    // Use of the System bus imposes additional constraints that have had to be introduced to
+    // permit testing in block level DV (see `soc_system_src|dst_base_addr` above); if the transfer
+    // lies outside of the specified 4GiB window then reads or writes will be faulted by the adapter
+    // interface.
+    if (src_asid == SocSystemAddr) begin
+      logic [SYS_ADDR_WIDTH-1:0] end_addr = soc_system_src_base_addr + 32'hFFFF_FFFC;
+      if (src_addr < soc_system_src_base_addr || src_addr > end_addr ||
+          end_addr - src_addr < src_memory_range) begin
+        `uvm_info(`gfn, " - Limitations of 32-bit TL-UL for testing System bus Reads not met",
+                  UVM_MEDIUM)
+        valid_config = 0;
       end
-      if (dst_asid == SocSystemAddr) begin
-        if (dst_addr[63:32] != soc_system_hi_addr || dst_addr[31:0] >= ~dst_memory_range) begin
-          `uvm_info(`gfn, " - Limitations of 32-bit TL-UL for testing System bus Writes not met",
-                    UVM_MEDIUM)
-          valid_config = 0;
-        end
+    end
+    if (dst_asid == SocSystemAddr) begin
+      logic [SYS_ADDR_WIDTH-1:0] end_addr = soc_system_dst_base_addr + 32'hFFFF_FFFC;
+      if (dst_addr < soc_system_dst_base_addr || dst_addr > end_addr ||
+          end_addr - dst_addr < dst_memory_range) begin
+        `uvm_info(`gfn, " - Limitations of 32-bit TL-UL for testing System bus Writes not met",
+                  UVM_MEDIUM)
+        valid_config = 0;
       end
-    end else if (src_asid == SocSystemAddr || dst_asid == SocSystemAddr) begin
-      // This is not necessarily invalid; just issue a notification in case the test fails.
-      `uvm_info(`gfn, " - SoCSystemAddr is NOT fully implemented", UVM_LOW)
     end
 
     // Check that the ASIDs are valid

--- a/hw/ip/dma/dv/env/dma_sys_tl_if.sv
+++ b/hw/ip/dma/dv/env/dma_sys_tl_if.sv
@@ -5,6 +5,18 @@
 `include "dv_macros.svh"
 `include "prim_assert.sv"
 
+// Since there is no proper model of the SoC System Bus and attached devices presently, this
+// interface permits them to be connected to the existing TL-UL components within the OpenTitan
+// project.
+//
+// A further complication is that they are presently restricted to 32-bit addressing, but the
+// SoC System Bus has a 64-bit address space. We resolve this by presenting a 4GiB addressing
+// window on the SoC System Bus and programming a base address from the DV environment.
+// Since the DUT itself only supports transfers of less than 4GiB this provides completes testing.
+//
+// For additional verification we permit the TL-UL memory model to be mapped at different
+// base addresses for the Read and Write sides of the DUT.
+
 interface dma_sys_tl_if
   import dma_pkg::*;
   import tlul_pkg::*;
@@ -16,8 +28,11 @@ interface dma_sys_tl_if
   input   clk_i,
   input   rst_ni
 );
-  // Base address of TL-UL agent (4GiB aligned for TLAddrWidth == 32; bottom 32 bits are unused.)
-  logic [SYS_ADDR_WIDTH-1:0] base_addr;
+  // Base address of TL-UL agent (4B aligned for TLAddrWidth == 32; bottom 2 bits are unused),
+  // for each of the command types in turn.
+  logic [SYS_ADDR_WIDTH-1:0] base_addr[SYS_NUM_REQ_CH];
+  // Last valid word-aligned address within the window; derived from the base address.
+  logic [SYS_ADDR_WIDTH-1:0] end_addr[SYS_NUM_REQ_CH];
 
   // Compute 'a_size' value for single word read/write on TL-UL.
   localparam int unsigned WordSize = $clog2(SYS_DATA_BYTEWIDTH);
@@ -25,12 +40,17 @@ interface dma_sys_tl_if
   // Set the base address of the window mapping the TL-UL agent into the 64-bit address space.
   // Presently the agent is restricted to 32-bit addressing, so we map it to a 4GiB-aligned base
   // address, and check the upper 32 bits on each read/write access.
-  function static void set_base_addr(logic [SYS_ADDR_WIDTH-1:0] base);
+  function static void set_base_addr(sys_cmd_type_e cmd, logic [SYS_ADDR_WIDTH-1:0] base);
     // Note that when the adapter is not expected to be encountering traffic, the base address is
     // invalidated using all Xs.
-    `DV_CHECK_FATAL(base === {SYS_ADDR_WIDTH{1'bX}} || base[31:0] === 0,
+    `DV_CHECK_FATAL(base === {SYS_ADDR_WIDTH{1'bX}} || base[1:0] === 0,
                     "Valid TL Agent base address must be 32-bit aligned", "dma_sys_tl_if");
-    base_addr = base;
+    // Check that we have space for a full 4GiB address window.
+    `DV_CHECK_FATAL(base === {SYS_ADDR_WIDTH{1'bX}} ||
+                    {SYS_ADDR_WIDTH{1'b1}} - 32'hFFFF_FFFF >= base,
+                    "Base address is too high", "dma_sys_tl_if");
+    base_addr[cmd] = base;
+    end_addr[cmd] = base + SYS_ADDR_WIDTH'(32'hFFFF_FFFC);  // inclusive, word-aligned.
   endfunction
 
   // SoC System Bus host connection
@@ -45,10 +65,13 @@ interface dma_sys_tl_if
   tl_a_op_e                   h2d_opcode;
   logic [63:0]                h2d_address;
   logic [top_pkg::TL_DBW-1:0] h2d_mask;
+  sys_cmd_type_e              h2d_cmd;
   always_comb begin
     h2d_opcode  = Get;
     h2d_address = 'b0;
     h2d_mask    = 'b0;
+    // Default to selecting the read addresses; they will not be used unless `vld_vec` asserted.
+    h2d_cmd     = SysCmdRead;
 
     // Writes take precedence over reads.
     //
@@ -59,6 +82,7 @@ interface dma_sys_tl_if
       h2d_opcode  = &sys_h2d.write_be ? PutFullData : PutPartialData;
       h2d_address = sys_h2d.iova_vec[SysCmdWrite];
       h2d_mask    = sys_h2d.write_be;
+      h2d_cmd     = SysCmdWrite;
     end else if (sys_h2d.vld_vec[SysCmdRead]) begin
       // Read request
       h2d_address = sys_h2d.iova_vec[SysCmdRead];
@@ -70,12 +94,16 @@ interface dma_sys_tl_if
   // values by the host.
   // Address mismatches are reported immediately to the host and the request is not forwarded to
   // the TL-UL agent.
-  wire addr_matches = (h2d_address >> TLAddrWidth) === (base_addr >> TLAddrWidth);
+  wire addr_matches = (h2d_address >= base_addr[h2d_cmd] && h2d_address <= end_addr[h2d_cmd]);
   wire h2d_a_valid  = addr_matches & |sys_h2d.vld_vec;
   // Writes take precedence over reads.
   wire write_mismatch =  sys_h2d.vld_vec[SysCmdWrite] & !addr_matches;
   wire read_mismatch  = !sys_h2d.vld_vec[SysCmdWrite] & sys_h2d.vld_vec[SysCmdRead] &
                         !addr_matches;
+
+  // Calculate the TL-UL address by performing an arbitrary subtraction; this just makes the
+  // verification a bit more thorough than a bitfield-base approach like BAT.
+  wire [TLAddrWidth-1:0] tlul_address = (h2d_address - base_addr[h2d_cmd]);
 
   assign tl_h2d = '{
     // Host->device address channel
@@ -85,7 +113,7 @@ interface dma_sys_tl_if
     a_size:    top_pkg::TL_SZW'(WordSize),
     a_mask:    h2d_mask,
     a_source:  'b0,
-    a_address: h2d_address[TLAddrWidth-1:0],
+    a_address: tlul_address,
     // Host->device write data
     a_data:    sys_h2d.write_data,
     a_user:    'b0,


### PR DESCRIPTION
Support finer granularity in the choice of the 4GiB address window into which the TL-UL memory is mapped. Instead of being 4GiB-aligned it is now 4B-aligned. This just provides more robust checking of the addressing arithmetic within the DUT.

Introduce separate 4GiB windows with different base addresses for the source and destination traffic.

Since the DMA controller itself can only perform transfers of less than 4GiB, now that the adapter supports separated read and writes transfers we can lose the 'waiving' of full verification.