### PR TITLE
[dv,otp_ctrl] Fix a few unit test failures

### DIFF
--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv.tpl
@@ -1,4 +1,5 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 <%
@@ -55,6 +56,10 @@ package otp_ctrl_env_pkg;
   parameter uint OTP_ARRAY_SIZE = LcTransitionCntOffset / TL_SIZE;
 
   parameter int OTP_ADDR_WIDTH = OtpByteAddrWidth-2;
+
+  // The full word size of the OTP macro, including ECC.
+  parameter int OTP_MACRO_FULL_WIDTH = OtpWidth + prim_secded_pkg::get_synd_width(
+              prim_secded_pkg::SecdedHamming, OtpWidth);
 
   parameter uint NUM_PRIM_REG = 8;
 

--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_if.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_if.sv.tpl
@@ -1,4 +1,5 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 <%
@@ -267,9 +268,12 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
 
 //  `ASSERT(CioTestOWithDftOn_A, lc_dft_en_i == lc_ctrl_pkg::On |->
 //                               ${"##"}[2:3] cio_test_o == `PRIM_GENERIC_OTP_PATH.test_vect_o)
-  `ASSERT(CioTestOWithDftOff_A, lc_dft_en_i != lc_ctrl_pkg::On |-> ##[2:3] cio_test_o == 0)
-  `ASSERT(CioTestEnOWithDftOn_A, lc_dft_en_i == lc_ctrl_pkg::On |-> ##[2:3] cio_test_en_o == '1)
-  `ASSERT(CioTestEnOWithDftOff_A, lc_dft_en_i != lc_ctrl_pkg::On |-> ##[2:3] cio_test_en_o == 0)
+  `ASSERT(CioTestOWithDftOff_A, lc_dft_en_i != lc_ctrl_pkg::On |->
+                                ${"##"}[2:3] lc_dft_en_i == lc_ctrl_pkg::On || cio_test_o == 0)
+  `ASSERT(CioTestEnOWithDftOn_A, lc_dft_en_i == lc_ctrl_pkg::On |->
+                                 ${"##"}[2:3] lc_dft_en_i != lc_ctrl_pkg::On || cio_test_en_o == '1)
+  `ASSERT(CioTestEnOWithDftOff_A, lc_dft_en_i != lc_ctrl_pkg::On |->
+                                  ${"##"}[2:3] lc_dft_en_i == lc_ctrl_pkg::On || cio_test_en_o == 0)
 
 
   `define OTP_ASSERT_WO_LC_ESC(NAME, SEQ) ${"\\"}

--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_if.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_if.sv.tpl
@@ -197,7 +197,7 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
 % endfor
   endtask
 
-  // Force prim_generic_otp input cmd_i to a invalid value.
+  // Force prim_generic_otp input cmd_i to an invalid value.
   task automatic force_invalid_otp_cmd_i();
     @(posedge clk_i);
     force `PRIM_GENERIC_OTP_CMD_I_PATH = otp_ctrl_macro_pkg::cmd_e'(2'b10);

--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv.tpl
@@ -1,4 +1,5 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 <%
@@ -279,41 +280,51 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
   // 1. Externally lc_escalation_en is set to lc_ctrl_pkg::On.
   // 2. Internal fatal alert triggered and all partitions are driven to error states.
   virtual task process_lc_esc();
-    forever begin
-      wait(cfg.otp_ctrl_vif.alert_reqs == 1 && cfg.en_scb);
-
-      if (cfg.otp_ctrl_vif.lc_esc_on == 0) `DV_CHECK_NE(exp_alert, OtpNoAlert)
-
-      if (exp_alert != OtpCheckAlert) set_exp_alert("fatal_check_error", 1, 5);
-
-      // If the lc_escalation is triggered by internal fatal alert, wait 2 negedge until status is
-      // updated internally
-      if (cfg.otp_ctrl_vif.lc_esc_on == 0) begin
-        cfg.clk_rst_vif.wait_n_clks(2);
-        exp_status[OtpCheckPendingIdx] = 0;
-        exp_status[OtpDaiIdleIdx] = 0;
-      end else begin
-        exp_status = '0;
-        // Only lc_esc_on will set these bits to 1.
-        exp_status[OtpDerivKeyFsmErrIdx:OtpLfsrFsmErrIdx] = '1;
+    fork
+      // Handle external escalation requests.
+      forever begin
+        wait(cfg.otp_ctrl_vif.lc_escalate_en_i != lc_ctrl_pkg::Off && cfg.en_scb);
+        `uvm_info(`gfn, "Got lc_escalate_en_i", UVM_MEDIUM)
+        set_exp_alert("fatal_check_error", 1, 5);
+        wait(cfg.otp_ctrl_vif.lc_escalate_en_i == lc_ctrl_pkg::Off);
       end
+      // Handle internal alerts.
+      forever begin
+        wait(cfg.otp_ctrl_vif.alert_reqs == 1 && cfg.en_scb);
 
-      // Update status bits.
-      foreach (FATAL_EXP_STATUS[i]) begin
-        if (FATAL_EXP_STATUS[i]) begin
-          predict_err(.status_err_idx(otp_status_e'(i)), .err_code(OtpFsmStateError),
-                      .update_esc_err(1));
+        if (cfg.otp_ctrl_vif.lc_esc_on == 0) `DV_CHECK_NE(exp_alert, OtpNoAlert)
+
+        if (exp_alert != OtpCheckAlert) set_exp_alert("fatal_check_error", 1, 5);
+
+        // If the lc_escalation is triggered by internal fatal alert, wait 2 negedge until status is
+        // updated internally
+        if (cfg.otp_ctrl_vif.lc_esc_on == 0) begin
+          cfg.clk_rst_vif.wait_n_clks(2);
+          exp_status[OtpCheckPendingIdx] = 0;
+          exp_status[OtpDaiIdleIdx] = 0;
+        end else begin
+          exp_status = '0;
+          // Only lc_esc_on will set these bits to 1.
+          exp_status[OtpDerivKeyFsmErrIdx:OtpLfsrFsmErrIdx] = '1;
         end
+
+        // Update status bits.
+        foreach (FATAL_EXP_STATUS[i]) begin
+          if (FATAL_EXP_STATUS[i]) begin
+            predict_err(.status_err_idx(otp_status_e'(i)), .err_code(OtpFsmStateError),
+                        .update_esc_err(1));
+          end
+        end
+
+        // Update digest values and direct_access_regwen.
+        predict_rdata(1, 0, 0);
+        void'(ral.direct_access_regwen.predict(.value(0), .kind(UVM_PREDICT_READ)));
+
+        // DAI access is locked until reset, so no need to backdoor read otp write value until reset.
+
+        wait(cfg.otp_ctrl_vif.alert_reqs == 0);
       end
-
-      // Update digest values and direct_access_regwen.
-      predict_rdata(1, 0, 0);
-      void'(ral.direct_access_regwen.predict(.value(0), .kind(UVM_PREDICT_READ)));
-
-      // DAI access is locked until reset, so no need to backdoor read otp write value until reset.
-
-      wait(cfg.otp_ctrl_vif.alert_reqs == 0);
-    end
+    join
   endtask
 
   // This task monitors if lc_program req is interrupted by reset.
@@ -752,30 +763,21 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
                 // Check if it is sw partition read lock
                 check_dai_rd_data = 1;
 
+                // Hardware digests are always readable.
                 // SW partitions write read_lock_csr can lock read access.
-                if (sw_read_lock ||
-                    // Secret partitions cal digest can also lock read access.
-                    // However, digest is always readable except SW partitions (Issue #5752).
-                    (is_secret(dai_addr) && get_digest_reg_val(part_idx) != 0 &&
-                     !is_digest(dai_addr)) ||
-                    // If the partition has creator key material and lc_creator_seed_sw_rw is
-                    // disable, then return access error.
-                    (PartInfo[part_idx].iskeymgr_creator && !is_digest(dai_addr) &&
-                     cfg.otp_ctrl_vif.lc_creator_seed_sw_rw_en_i != lc_ctrl_pkg::On)) begin
+                if (!(is_digest(dai_addr) && PartInfo[part_idx].hw_digest) &&
+                    (sw_read_lock ||
+                     // Secret partitions cal digest can also lock read access.
+                     (is_secret(dai_addr) && get_digest_reg_val(part_idx) != 0) ||
+                     // If the partition has creator key material and lc_creator_seed_sw_rw is
+                     // disabled, or the partition has owner key material and lc_owner_seed_sw_rw
+                     // is disabled, then return access error.
+                     (PartInfo[part_idx].iskeymgr_creator &&
+                      cfg.otp_ctrl_vif.lc_creator_seed_sw_rw_en_i != lc_ctrl_pkg::On) ||
+                     (PartInfo[part_idx].iskeymgr_owner &&
+                      cfg.otp_ctrl_vif.lc_owner_seed_sw_rw_en_i != lc_ctrl_pkg::On))) begin
                   predict_err(OtpDaiErrIdx, OtpAccessError);
                   predict_rdata(is_secret(dai_addr) || is_digest(dai_addr), 0, 0);
-                end else if (sw_read_lock ||
-                    // Secret partitions cal digest can also lock read access.
-                    // However, digest is always readable except SW partitions (Issue #5752).
-                    (is_secret(dai_addr) && get_digest_reg_val(part_idx) != 0 &&
-                     !is_digest(dai_addr)) ||
-                    // If the partition has owner key material and lc_owner_seed_sw_rw is disable,
-                    // then return access error.
-                    (PartInfo[part_idx].iskeymgr_owner && !is_digest(dai_addr) &&
-                     cfg.otp_ctrl_vif.lc_owner_seed_sw_rw_en_i != lc_ctrl_pkg::On)) begin
-                  predict_err(OtpDaiErrIdx, OtpAccessError);
-                  predict_rdata(is_secret(dai_addr) || is_digest(dai_addr), 0, 0);
-
                 end else begin
                   bit [TL_DW-1:0] read_out0, read_out1;
                   bit [TL_AW-1:0] otp_addr = get_scb_otp_addr();

--- a/hw/ip_templates/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv.tpl
@@ -1,4 +1,5 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 <%
@@ -162,12 +163,13 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     bit [TL_DW-1:0] val;
     dai_wr_inprogress = 1;
     if (write_unused_addr) begin
-      if (used_dai_addrs.exists(addr[OTP_ADDR_WIDTH - 1 : 0])) begin
+      bit [OTP_ADDR_WIDTH - 1 : 0] granule_addr = normalize_dai_addr(addr);
+      if (used_dai_addrs.exists(granule_addr)) begin
         `uvm_info(`gfn, $sformatf("addr %0h is already written!", addr), UVM_MEDIUM)
         dai_wr_inprogress = 0;
         return;
       end else begin
-        used_dai_addrs[addr] = 1;
+        used_dai_addrs[granule_addr] = 1;
       end
     end
     addr = randomize_dai_addr(addr);

--- a/hw/ip_templates/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv.tpl
@@ -350,19 +350,17 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   // This function backdoor inject error according to ecc_err:
   // - for OtpEccUncorrErr it injects a 2 bit error
   // - for OtpEccCorrErr it injects a 1 bit error
-  // This function will output original backdoor read data for the given address
+  // Return the original backdoor read data for the given address
   // so the error can be cleared.
   virtual function bit [TL_DW-1:0] backdoor_inject_ecc_err(bit [TL_DW-1:0] addr,
                                                            otp_ecc_err_e   ecc_err);
-    bit [TL_DW-1:0] val;
-    addr = {addr[TL_DW-1:2], 2'b00};
-    val = cfg.mem_bkdr_util_h.read32(addr);
+    uvm_hdl_data_t val = cfg.mem_bkdr_util_h.read(addr);
     if (ecc_err == OtpNoEccErr || addr >= (LifeCycleOffset + LifeCycleSize)) return val;
 
     // Backdoor read and write back with error bits
     cfg.mem_bkdr_util_h.inject_errors(addr, (ecc_err == OtpEccUncorrErr) ? 2 : 1);
     `uvm_info(`gfn, $sformatf("original val %0h, addr %0h, err_type %0s",
-                              val, addr, ecc_err.name), UVM_HIGH)
+                              OTP_MACRO_FULL_WIDTH'(val), addr, ecc_err.name), UVM_HIGH)
     return val;
   endfunction
 
@@ -400,7 +398,10 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     if (wait_done && val) csr_spinwait(ral.status.check_pending, 0);
 
     if (ecc_err != OtpNoEccErr) begin
-      cfg.mem_bkdr_util_h.write32(addr, backdoor_rd_val);
+      `uvm_info(`gfn, $sformatf("Repairing ecc error %0d at 0x%x with data 0x%x",
+                    ecc_err, addr, OTP_MACRO_FULL_WIDTH'(backdoor_rd_val)),
+                    UVM_HIGH)
+      cfg.mem_bkdr_util_h.write(addr, backdoor_rd_val);
       cfg.ecc_chk_err = '{default: OtpNoEccErr};
     end
   endtask

--- a/hw/ip_templates/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv.tpl
@@ -172,7 +172,8 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
 
         // Inject ECC error.
         if (ecc_otp_err != OtpNoEccErr && dai_addr < LifeCycleOffset) begin
-          `uvm_info(`gfn, $sformatf("Injecting ecc error %0d at 0x%x", ecc_otp_err, dai_addr),
+          `uvm_info(`gfn, $sformatf("Injecting ecc error %0d at 0x%x, old data 0x%x",
+                    ecc_otp_err, dai_addr, OTP_MACRO_FULL_WIDTH'(backdoor_rd_val)),
                     UVM_HIGH)
           backdoor_rd_val = backdoor_inject_ecc_err(dai_addr, ecc_otp_err);
         end

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -1,4 +1,5 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 package otp_ctrl_env_pkg;
@@ -48,6 +49,10 @@ package otp_ctrl_env_pkg;
   parameter uint OTP_ARRAY_SIZE = LcTransitionCntOffset / TL_SIZE;
 
   parameter int OTP_ADDR_WIDTH = OtpByteAddrWidth-2;
+
+  // The full word size of the OTP macro, including ECC.
+  parameter int OTP_MACRO_FULL_WIDTH = OtpWidth + prim_secded_pkg::get_synd_width(
+              prim_secded_pkg::SecdedHamming, OtpWidth);
 
   parameter uint NUM_PRIM_REG = 8;
 

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -294,7 +294,7 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
     end
   endtask
 
-  // Force prim_generic_otp input cmd_i to a invalid value.
+  // Force prim_generic_otp input cmd_i to an invalid value.
   task automatic force_invalid_otp_cmd_i();
     @(posedge clk_i);
     force `PRIM_GENERIC_OTP_CMD_I_PATH = otp_ctrl_macro_pkg::cmd_e'(2'b10);

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -1,4 +1,5 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 // This interface collect the broadcast output data from OTP,
@@ -379,9 +380,12 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
 
 //  `ASSERT(CioTestOWithDftOn_A, lc_dft_en_i == lc_ctrl_pkg::On |->
 //                               ##[2:3] cio_test_o == `PRIM_GENERIC_OTP_PATH.test_vect_o)
-  `ASSERT(CioTestOWithDftOff_A, lc_dft_en_i != lc_ctrl_pkg::On |-> ##[2:3] cio_test_o == 0)
-  `ASSERT(CioTestEnOWithDftOn_A, lc_dft_en_i == lc_ctrl_pkg::On |-> ##[2:3] cio_test_en_o == '1)
-  `ASSERT(CioTestEnOWithDftOff_A, lc_dft_en_i != lc_ctrl_pkg::On |-> ##[2:3] cio_test_en_o == 0)
+  `ASSERT(CioTestOWithDftOff_A, lc_dft_en_i != lc_ctrl_pkg::On |->
+                                ##[2:3] lc_dft_en_i == lc_ctrl_pkg::On || cio_test_o == 0)
+  `ASSERT(CioTestEnOWithDftOn_A, lc_dft_en_i == lc_ctrl_pkg::On |->
+                                 ##[2:3] lc_dft_en_i != lc_ctrl_pkg::On || cio_test_en_o == '1)
+  `ASSERT(CioTestEnOWithDftOff_A, lc_dft_en_i != lc_ctrl_pkg::On |->
+                                  ##[2:3] lc_dft_en_i == lc_ctrl_pkg::On || cio_test_en_o == 0)
 
 
   `define OTP_ASSERT_WO_LC_ESC(NAME, SEQ) \

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -1,4 +1,5 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 class otp_ctrl_base_vseq extends cip_base_vseq #(
@@ -148,12 +149,13 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     bit [TL_DW-1:0] val;
     dai_wr_inprogress = 1;
     if (write_unused_addr) begin
-      if (used_dai_addrs.exists(addr[OTP_ADDR_WIDTH - 1 : 0])) begin
+      bit [OTP_ADDR_WIDTH - 1 : 0] granule_addr = normalize_dai_addr(addr);
+      if (used_dai_addrs.exists(granule_addr)) begin
         `uvm_info(`gfn, $sformatf("addr %0h is already written!", addr), UVM_MEDIUM)
         dai_wr_inprogress = 0;
         return;
       end else begin
-        used_dai_addrs[addr] = 1;
+        used_dai_addrs[granule_addr] = 1;
       end
     end
     addr = randomize_dai_addr(addr);

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -554,19 +554,17 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   // This function backdoor inject error according to ecc_err:
   // - for OtpEccUncorrErr it injects a 2 bit error
   // - for OtpEccCorrErr it injects a 1 bit error
-  // This function will output original backdoor read data for the given address
+  // Return the original backdoor read data for the given address
   // so the error can be cleared.
   virtual function bit [TL_DW-1:0] backdoor_inject_ecc_err(bit [TL_DW-1:0] addr,
                                                            otp_ecc_err_e   ecc_err);
-    bit [TL_DW-1:0] val;
-    addr = {addr[TL_DW-1:2], 2'b00};
-    val = cfg.mem_bkdr_util_h.read32(addr);
+    uvm_hdl_data_t val = cfg.mem_bkdr_util_h.read(addr);
     if (ecc_err == OtpNoEccErr || addr >= (LifeCycleOffset + LifeCycleSize)) return val;
 
     // Backdoor read and write back with error bits
     cfg.mem_bkdr_util_h.inject_errors(addr, (ecc_err == OtpEccUncorrErr) ? 2 : 1);
     `uvm_info(`gfn, $sformatf("original val %0h, addr %0h, err_type %0s",
-                              val, addr, ecc_err.name), UVM_HIGH)
+                              OTP_MACRO_FULL_WIDTH'(val), addr, ecc_err.name), UVM_HIGH)
     return val;
   endfunction
 
@@ -604,7 +602,10 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     if (wait_done && val) csr_spinwait(ral.status.check_pending, 0);
 
     if (ecc_err != OtpNoEccErr) begin
-      cfg.mem_bkdr_util_h.write32(addr, backdoor_rd_val);
+      `uvm_info(`gfn, $sformatf("Repairing ecc error %0d at 0x%x with data 0x%x",
+                    ecc_err, addr, OTP_MACRO_FULL_WIDTH'(backdoor_rd_val)),
+                    UVM_HIGH)
+      cfg.mem_bkdr_util_h.write(addr, backdoor_rd_val);
       cfg.ecc_chk_err = '{default: OtpNoEccErr};
     end
   endtask

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -1,4 +1,5 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 // smoke test vseq to walk through DAI states and request keys
@@ -178,7 +179,8 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
       end
 
       for (int i = 0; i < num_dai_op; i++) begin
-        bit [TL_DW-1:0] rdata0, rdata1, backdoor_rd_val;
+        bit [TL_DW-1:0] rdata0, rdata1;
+        uvm_hdl_data_t backdoor_rd_val;
         if (cfg.stop_transaction_generators()) break;
 
         `DV_CHECK_RANDOMIZE_FATAL(this)
@@ -219,9 +221,10 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
 
         // Backdoor restore injected ECC error, but should not affect fatal alerts.
         if (ecc_otp_err != OtpNoEccErr && dai_addr < LifeCycleOffset) begin
-          `uvm_info(`gfn, $sformatf("Injecting ecc error %0d at 0x%x", ecc_otp_err, dai_addr),
+          `uvm_info(`gfn, $sformatf("Repairing ecc error %0d at 0x%x with 0x%x",
+                    ecc_otp_err, dai_addr, OTP_MACRO_FULL_WIDTH'(backdoor_rd_val)),
                     UVM_HIGH)
-          cfg.mem_bkdr_util_h.write32({dai_addr[TL_DW-3:2], 2'b00}, backdoor_rd_val);
+          cfg.mem_bkdr_util_h.write(dai_addr, backdoor_rd_val);
           // Wait for two lock cycles to make sure the local escalation error propagates to other
           // partitions and err_code reg.
           cfg.clk_rst_vif.wait_clks(2);

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -201,7 +201,8 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
 
         // Inject ECC error.
         if (ecc_otp_err != OtpNoEccErr && dai_addr < LifeCycleOffset) begin
-          `uvm_info(`gfn, $sformatf("Injecting ecc error %0d at 0x%x", ecc_otp_err, dai_addr),
+          `uvm_info(`gfn, $sformatf("Injecting ecc error %0d at 0x%x, old data 0x%x",
+                    ecc_otp_err, dai_addr, OTP_MACRO_FULL_WIDTH'(backdoor_rd_val)),
                     UVM_HIGH)
           backdoor_rd_val = backdoor_inject_ecc_err(dai_addr, ecc_otp_err);
         end

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -1,4 +1,5 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 package otp_ctrl_env_pkg;
@@ -48,6 +49,10 @@ package otp_ctrl_env_pkg;
   parameter uint OTP_ARRAY_SIZE = LcTransitionCntOffset / TL_SIZE;
 
   parameter int OTP_ADDR_WIDTH = OtpByteAddrWidth-2;
+
+  // The full word size of the OTP macro, including ECC.
+  parameter int OTP_MACRO_FULL_WIDTH = OtpWidth + prim_secded_pkg::get_synd_width(
+              prim_secded_pkg::SecdedHamming, OtpWidth);
 
   parameter uint NUM_PRIM_REG = 8;
 

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -215,7 +215,7 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
     end
   endtask
 
-  // Force prim_generic_otp input cmd_i to a invalid value.
+  // Force prim_generic_otp input cmd_i to an invalid value.
   task automatic force_invalid_otp_cmd_i();
     @(posedge clk_i);
     force `PRIM_GENERIC_OTP_CMD_I_PATH = otp_ctrl_macro_pkg::cmd_e'(2'b10);

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -1,4 +1,5 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 // This interface collect the broadcast output data from OTP,
@@ -287,9 +288,12 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
 
 //  `ASSERT(CioTestOWithDftOn_A, lc_dft_en_i == lc_ctrl_pkg::On |->
 //                               ##[2:3] cio_test_o == `PRIM_GENERIC_OTP_PATH.test_vect_o)
-  `ASSERT(CioTestOWithDftOff_A, lc_dft_en_i != lc_ctrl_pkg::On |-> ##[2:3] cio_test_o == 0)
-  `ASSERT(CioTestEnOWithDftOn_A, lc_dft_en_i == lc_ctrl_pkg::On |-> ##[2:3] cio_test_en_o == '1)
-  `ASSERT(CioTestEnOWithDftOff_A, lc_dft_en_i != lc_ctrl_pkg::On |-> ##[2:3] cio_test_en_o == 0)
+  `ASSERT(CioTestOWithDftOff_A, lc_dft_en_i != lc_ctrl_pkg::On |->
+                                ##[2:3] lc_dft_en_i == lc_ctrl_pkg::On || cio_test_o == 0)
+  `ASSERT(CioTestEnOWithDftOn_A, lc_dft_en_i == lc_ctrl_pkg::On |->
+                                 ##[2:3] lc_dft_en_i != lc_ctrl_pkg::On || cio_test_en_o == '1)
+  `ASSERT(CioTestEnOWithDftOff_A, lc_dft_en_i != lc_ctrl_pkg::On |->
+                                  ##[2:3] lc_dft_en_i == lc_ctrl_pkg::On || cio_test_en_o == 0)
 
 
   `define OTP_ASSERT_WO_LC_ESC(NAME, SEQ) \

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -1,4 +1,5 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
@@ -268,41 +269,51 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
   // 1. Externally lc_escalation_en is set to lc_ctrl_pkg::On.
   // 2. Internal fatal alert triggered and all partitions are driven to error states.
   virtual task process_lc_esc();
-    forever begin
-      wait(cfg.otp_ctrl_vif.alert_reqs == 1 && cfg.en_scb);
-
-      if (cfg.otp_ctrl_vif.lc_esc_on == 0) `DV_CHECK_NE(exp_alert, OtpNoAlert)
-
-      if (exp_alert != OtpCheckAlert) set_exp_alert("fatal_check_error", 1, 5);
-
-      // If the lc_escalation is triggered by internal fatal alert, wait 2 negedge until status is
-      // updated internally
-      if (cfg.otp_ctrl_vif.lc_esc_on == 0) begin
-        cfg.clk_rst_vif.wait_n_clks(2);
-        exp_status[OtpCheckPendingIdx] = 0;
-        exp_status[OtpDaiIdleIdx] = 0;
-      end else begin
-        exp_status = '0;
-        // Only lc_esc_on will set these bits to 1.
-        exp_status[OtpDerivKeyFsmErrIdx:OtpLfsrFsmErrIdx] = '1;
+    fork
+      // Handle external escalation requests.
+      forever begin
+        wait(cfg.otp_ctrl_vif.lc_escalate_en_i != lc_ctrl_pkg::Off && cfg.en_scb);
+        `uvm_info(`gfn, "Got lc_escalate_en_i", UVM_MEDIUM)
+        set_exp_alert("fatal_check_error", 1, 5);
+        wait(cfg.otp_ctrl_vif.lc_escalate_en_i == lc_ctrl_pkg::Off);
       end
+      // Handle internal alerts.
+      forever begin
+        wait(cfg.otp_ctrl_vif.alert_reqs == 1 && cfg.en_scb);
 
-      // Update status bits.
-      foreach (FATAL_EXP_STATUS[i]) begin
-        if (FATAL_EXP_STATUS[i]) begin
-          predict_err(.status_err_idx(otp_status_e'(i)), .err_code(OtpFsmStateError),
-                      .update_esc_err(1));
+        if (cfg.otp_ctrl_vif.lc_esc_on == 0) `DV_CHECK_NE(exp_alert, OtpNoAlert)
+
+        if (exp_alert != OtpCheckAlert) set_exp_alert("fatal_check_error", 1, 5);
+
+        // If the lc_escalation is triggered by internal fatal alert, wait 2 negedge until status is
+        // updated internally
+        if (cfg.otp_ctrl_vif.lc_esc_on == 0) begin
+          cfg.clk_rst_vif.wait_n_clks(2);
+          exp_status[OtpCheckPendingIdx] = 0;
+          exp_status[OtpDaiIdleIdx] = 0;
+        end else begin
+          exp_status = '0;
+          // Only lc_esc_on will set these bits to 1.
+          exp_status[OtpDerivKeyFsmErrIdx:OtpLfsrFsmErrIdx] = '1;
         end
+
+        // Update status bits.
+        foreach (FATAL_EXP_STATUS[i]) begin
+          if (FATAL_EXP_STATUS[i]) begin
+            predict_err(.status_err_idx(otp_status_e'(i)), .err_code(OtpFsmStateError),
+                        .update_esc_err(1));
+          end
+        end
+
+        // Update digest values and direct_access_regwen.
+        predict_rdata(1, 0, 0);
+        void'(ral.direct_access_regwen.predict(.value(0), .kind(UVM_PREDICT_READ)));
+
+        // DAI access is locked until reset, so no need to backdoor read otp write value until reset.
+
+        wait(cfg.otp_ctrl_vif.alert_reqs == 0);
       end
-
-      // Update digest values and direct_access_regwen.
-      predict_rdata(1, 0, 0);
-      void'(ral.direct_access_regwen.predict(.value(0), .kind(UVM_PREDICT_READ)));
-
-      // DAI access is locked until reset, so no need to backdoor read otp write value until reset.
-
-      wait(cfg.otp_ctrl_vif.alert_reqs == 0);
-    end
+    join
   endtask
 
   // This task monitors if lc_program req is interrupted by reset.
@@ -738,30 +749,21 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
                 // Check if it is sw partition read lock
                 check_dai_rd_data = 1;
 
+                // Hardware digests are always readable.
                 // SW partitions write read_lock_csr can lock read access.
-                if (sw_read_lock ||
-                    // Secret partitions cal digest can also lock read access.
-                    // However, digest is always readable except SW partitions (Issue #5752).
-                    (is_secret(dai_addr) && get_digest_reg_val(part_idx) != 0 &&
-                     !is_digest(dai_addr)) ||
-                    // If the partition has creator key material and lc_creator_seed_sw_rw is
-                    // disable, then return access error.
-                    (PartInfo[part_idx].iskeymgr_creator && !is_digest(dai_addr) &&
-                     cfg.otp_ctrl_vif.lc_creator_seed_sw_rw_en_i != lc_ctrl_pkg::On)) begin
+                if (!(is_digest(dai_addr) && PartInfo[part_idx].hw_digest) &&
+                    (sw_read_lock ||
+                     // Secret partitions cal digest can also lock read access.
+                     (is_secret(dai_addr) && get_digest_reg_val(part_idx) != 0) ||
+                     // If the partition has creator key material and lc_creator_seed_sw_rw is
+                     // disabled, or the partition has owner key material and lc_owner_seed_sw_rw
+                     // is disabled, then return access error.
+                     (PartInfo[part_idx].iskeymgr_creator &&
+                      cfg.otp_ctrl_vif.lc_creator_seed_sw_rw_en_i != lc_ctrl_pkg::On) ||
+                     (PartInfo[part_idx].iskeymgr_owner &&
+                      cfg.otp_ctrl_vif.lc_owner_seed_sw_rw_en_i != lc_ctrl_pkg::On))) begin
                   predict_err(OtpDaiErrIdx, OtpAccessError);
                   predict_rdata(is_secret(dai_addr) || is_digest(dai_addr), 0, 0);
-                end else if (sw_read_lock ||
-                    // Secret partitions cal digest can also lock read access.
-                    // However, digest is always readable except SW partitions (Issue #5752).
-                    (is_secret(dai_addr) && get_digest_reg_val(part_idx) != 0 &&
-                     !is_digest(dai_addr)) ||
-                    // If the partition has owner key material and lc_owner_seed_sw_rw is disable,
-                    // then return access error.
-                    (PartInfo[part_idx].iskeymgr_owner && !is_digest(dai_addr) &&
-                     cfg.otp_ctrl_vif.lc_owner_seed_sw_rw_en_i != lc_ctrl_pkg::On)) begin
-                  predict_err(OtpDaiErrIdx, OtpAccessError);
-                  predict_rdata(is_secret(dai_addr) || is_digest(dai_addr), 0, 0);
-
                 end else begin
                   bit [TL_DW-1:0] read_out0, read_out1;
                   bit [TL_AW-1:0] otp_addr = get_scb_otp_addr();

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -1,4 +1,5 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 class otp_ctrl_base_vseq extends cip_base_vseq #(
@@ -148,12 +149,13 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     bit [TL_DW-1:0] val;
     dai_wr_inprogress = 1;
     if (write_unused_addr) begin
-      if (used_dai_addrs.exists(addr[OTP_ADDR_WIDTH - 1 : 0])) begin
+      bit [OTP_ADDR_WIDTH - 1 : 0] granule_addr = normalize_dai_addr(addr);
+      if (used_dai_addrs.exists(granule_addr)) begin
         `uvm_info(`gfn, $sformatf("addr %0h is already written!", addr), UVM_MEDIUM)
         dai_wr_inprogress = 0;
         return;
       end else begin
-        used_dai_addrs[addr] = 1;
+        used_dai_addrs[granule_addr] = 1;
       end
     end
     addr = randomize_dai_addr(addr);

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -181,7 +181,8 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
 
         // Inject ECC error.
         if (ecc_otp_err != OtpNoEccErr && dai_addr < LifeCycleOffset) begin
-          `uvm_info(`gfn, $sformatf("Injecting ecc error %0d at 0x%x", ecc_otp_err, dai_addr),
+          `uvm_info(`gfn, $sformatf("Injecting ecc error %0d at 0x%x, old data 0x%x",
+                    ecc_otp_err, dai_addr, OTP_MACRO_FULL_WIDTH'(backdoor_rd_val)),
                     UVM_HIGH)
           backdoor_rd_val = backdoor_inject_ecc_err(dai_addr, ecc_otp_err);
         end

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -1,4 +1,5 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 // smoke test vseq to walk through DAI states and request keys
@@ -158,7 +159,8 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
       end
 
       for (int i = 0; i < num_dai_op; i++) begin
-        bit [TL_DW-1:0] rdata0, rdata1, backdoor_rd_val;
+        bit [TL_DW-1:0] rdata0, rdata1;
+        uvm_hdl_data_t backdoor_rd_val;
         if (cfg.stop_transaction_generators()) break;
 
         `DV_CHECK_RANDOMIZE_FATAL(this)
@@ -199,9 +201,10 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
 
         // Backdoor restore injected ECC error, but should not affect fatal alerts.
         if (ecc_otp_err != OtpNoEccErr && dai_addr < LifeCycleOffset) begin
-          `uvm_info(`gfn, $sformatf("Injecting ecc error %0d at 0x%x", ecc_otp_err, dai_addr),
+          `uvm_info(`gfn, $sformatf("Repairing ecc error %0d at 0x%x with 0x%x",
+                    ecc_otp_err, dai_addr, OTP_MACRO_FULL_WIDTH'(backdoor_rd_val)),
                     UVM_HIGH)
-          cfg.mem_bkdr_util_h.write32({dai_addr[TL_DW-3:2], 2'b00}, backdoor_rd_val);
+          cfg.mem_bkdr_util_h.write(dai_addr, backdoor_rd_val);
           // Wait for two lock cycles to make sure the local escalation error propagates to other
           // partitions and err_code reg.
           cfg.clk_rst_vif.wait_clks(2);


### PR DESCRIPTION
This has 6 commits:
1) Fix tracking of addresses already written
2) Simplify error injection
3) Fix otp_ctrl_init_fail test to be independent of OTP size
4) Fix otp_ctrl_background_chks setting the timeout before last check
5) Tighten up cio_test assertions
6) Handle external lc escalation, fix handling hardware digests and handling
    lc blockages in dai reads 