### PR TITLE
[bazel, rust] fix Rust edition version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -66,7 +66,7 @@ single_version_override(
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.repository_set(
     name = "rust_host",
-    edition = "2021",
+    edition = "2024",
     exec_triple = "x86_64-unknown-linux-gnu",
     sha256s = {
         "2025-01-03/rustc-nightly-x86_64-unknown-linux-gnu.tar.xz": "a7e713b2c38d2c16a2025d228480909a2281c91ad8fd225b1dacc3eda933724c",


### PR DESCRIPTION
This was possibily unintentionally changed in #25979. Revert it back to the intended edition.