### PR TITLE
[topgen] Add PrngFactory for PRNGs with different seeds

### DIFF
--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -1209,7 +1209,7 @@
           randcount: 40
           randtype: data
           name_top: RndCnstOtpCtrlLfsrSeed
-          default: 0x58fa9063ce
+          default: 0x272efaa51f
           randwidth: 40
         }
         {
@@ -1219,7 +1219,7 @@
           randcount: 40
           randtype: perm
           name_top: RndCnstOtpCtrlLfsrPerm
-          default: 0x2dd6809079e67935a195848e7ca5065c47018d980335588c44f1494026c8
+          default: 0x34f8105ca31378705d70b6420112544a28d56256a659b9c63a11487e4103
           randwidth: 240
         }
         {
@@ -1229,7 +1229,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstOtpCtrlScrmblKeyInit
-          default: 0xe34f64ce978305bfc3481a2162ea2792b7508f1eab067af954dda5491439a9dd
+          default: 0x55176264e55c329c8ae4725aeaf6728150127ac755d70063277642b5309a1639
           randwidth: 256
         }
       ]
@@ -1840,7 +1840,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivInvalid
-          default: 0xe6320801fdcf25a4fba528399117069e
+          default: 0x90b966cd494444c3bcdf8087b7facd65
           randwidth: 128
         }
         {
@@ -1850,7 +1850,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivTestUnlocked
-          default: 0x77c887f53dda6fb4ef8758b99027b6aa
+          default: 0xe9654cd85bc66d10208c4fb51b97bbf4
           randwidth: 128
         }
         {
@@ -1860,7 +1860,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivDev
-          default: 0x7468bc0bd8d70368e7cfb11a99675b14
+          default: 0xd12c378ccfd6a5a5bf3032db51fa1eb9
           randwidth: 128
         }
         {
@@ -1870,7 +1870,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivProduction
-          default: 0x6240619335a9e2d123834d18744778be
+          default: 0x2f6ce10e90f9c5c06f733dc911a321dd
           randwidth: 128
         }
         {
@@ -1880,7 +1880,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivRma
-          default: 0x5e63c087e36838b56b1a45f6fd312f53
+          default: 0x4c0ac2406d467215dab3f2b54a52e672
           randwidth: 128
         }
         {
@@ -1890,7 +1890,7 @@
           randcount: 1024
           randtype: data
           name_top: RndCnstLcCtrlInvalidTokens
-          default: 0x53fa7b2ce9fc83ddaf1dd8c5a42e2ad24fa02221b6ff5aad7a9c09d5d9fdd1cfcf512835c0cfae2ed0c69fa488685cea9bc1c89bfb7399aef5c6eb5d6e4e23416a0aa6d7ac7ec9c3304470fbe505f9649400ca9864fd4ce49d2cfc6ecc102540ead8734700a5207132689471aa822bc51cdd4d37ac2d246c4264f37ec1982017
+          default: 0x8678af0718068e344d2eae4d73c8fa54de8aa4a4f258f3b2a145fd1950ae55d693e57968117e66dc634155e0f8150242862eb20eea9a1f7544716551512a112ded678ce824a08e29c772795a358ec30f1bedd1af0ec9d9a9cf36a2b130d32afe121af734f628363aaa0e93d45c423690ed05bd1e710f22d1095889fbd8a7b57f
           randwidth: 1024
         }
         {
@@ -2492,7 +2492,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstAlertHandlerLfsrSeed
-          default: 0x94adda1b
+          default: 0xb1e11df3
           randwidth: 32
         }
         {
@@ -2502,7 +2502,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstAlertHandlerLfsrPerm
-          default: 0x2c7c7806d8fe46f651c95dc1b36ba44554de4e42
+          default: 0x47c16293507a44a96f3499cc30dfb57362be7b0c
           randwidth: 160
         }
         {
@@ -4425,7 +4425,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlRetAonSramKey
-          default: 0x21d8cb69d4f3a15faf834cad515d76bd
+          default: 0xa1dcd0488805541166f1ec8ceb42692b
           randwidth: 128
         }
         {
@@ -4435,7 +4435,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlRetAonSramNonce
-          default: 0x37c7bec5f33fdca11a72dc05a2313b71
+          default: 0x89a6f99b1a7ac084224ade4612980d4
           randwidth: 128
         }
         {
@@ -4445,7 +4445,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstSramCtrlRetAonLfsrSeed
-          default: 0x8e6d6dbb8ec647d1
+          default: 0x8e6c6493a50eedba
           randwidth: 64
         }
         {
@@ -4455,7 +4455,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstSramCtrlRetAonLfsrPerm
-          default: 0xb7742874b52317695c3cdd614d1c1702a7ef13bf561e078a9826ccac36bc9e9b9988623193efc9e7254ed330584bab38
+          default: 0x2566eb213c537de7ba1307f72bc145aad3533ad9f0fe2482b8c847586c256d5c7be0406df33a34529e4f0b9a279aa71
           randwidth: 384
         }
         {
@@ -5309,7 +5309,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstAesClearingLfsrSeed
-          default: 0x2482cc34468c37bf
+          default: 0x14a8f2b75c265c9c
           randwidth: 64
         }
         {
@@ -5319,7 +5319,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstAesClearingLfsrPerm
-          default: 0x57677e4b32baaafaf9e2c13099a62759b8bcfde7f5d219714ce9012293d9a10b8d0095f28d42d18031771fd32d08673b
+          default: 0x47641a7feca51196fa8832697778edac7e2f63520d2a7594ccc9803ce5ee574782170efde6890b806053aa1712c7cfec
           randwidth: 384
         }
         {
@@ -5329,7 +5329,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstAesClearingSharePerm
-          default: 0x1c841ed1bb4e7f8222eab3a08f24aadb3adc36f31d67c977e44d069ebc3105365638747a68f8c1949968d9cd5dfd212
+          default: 0x5bb39d122eb5483188e73ffcab0c770b27d584d617daca596d07242a668132e9742c5fb83c952f4d11e0b63a2b9de03d
           randwidth: 384
         }
         {
@@ -5339,7 +5339,7 @@
           randcount: 288
           randtype: data
           name_top: RndCnstAesMaskingLfsrSeed
-          default: 0x36270315f91066fb63a6e6eb54493c0631cd3062adf6d00b7e756f81353c10ac316a9c7a
+          default: 0xa0d95ce4ee55b032c07a29b920b7953e485f23ad102c6a0efce9f0ec4c712146a4ab60da
           randwidth: 288
         }
         {
@@ -5349,7 +5349,7 @@
           randcount: 160
           randtype: perm
           name_top: RndCnstAesMaskingLfsrPerm
-          default: 0x9107678e8f0118524a1a5a0e9f544d2a5e69054f5380264171333a0d5f0f7e1b57616a3911970b42566402308c832d6d9d84776c121c3b864b8b731f2e595c48452f3d51407b829b7c080c94278735755b28786595898d8a049368321606179c50253f24317a4e19235d7f72921096902c3e1e6636135815740a1d37476f216260467d44767970853899039a1420986b495522436e004c9e3c81098863292b34
+          default: 0x646b7344050d0c6101416f8a7568107e583e351a0f85628e495c3806999c76292757959188225470601d69481e71312c13439f6a4e84041c460a3498232567878c5f967286092d554a4d4b63325e53028f1b3a90214218802033503f79082f7a7b8139780b2815364c036d7d0716949366374f24405b1f302a0e92476c7f749a2b3d5d14567745008d2697522e1151125a3c1789833b9e59827c199b9d6e658b
           randwidth: 1280
         }
       ]
@@ -5624,7 +5624,7 @@
           randcount: 288
           randtype: data
           name_top: RndCnstKmacLfsrSeed
-          default: 0xfd7f6334613aa93b656444d70350a89ebc0cfbd0a03925fc80535f277451d2be0c46fdd2
+          default: 0x382af33b479718558e6759764645aad1fb21c18124635e3d50a88f6808045627ac18f377
           randwidth: 288
         }
         {
@@ -5634,7 +5634,7 @@
           randcount: 800
           randtype: perm
           name_top: RndCnstKmacLfsrPerm
-          default: 0x62a473f8e39c84bb85a51ae7857664535593e4516657f9ec35bd632631ef05d97c75c393841a787913690b8ac6bed552a47265714badc7b1ed1892fc96d1c0e13443ed20680d63a345d83317a5ec171f8d63da2ede924db3a11fc6c674293c8345955c2b96a797a6893b2cab542781a141921326dce02f0649af9700b98a5e6692fe4ccbf6e414086e9aea195e2f61d857c00759882f61173aa1de7444018291708a407a0cbb836aa8256da7a2416527d27252463420b51e817f0ee2b6700fd166ea85bfe081c587901e2841204e6712962256c49c405b328233f1350627db9463b162d879e1899d28fa3abca6a6e06dbaa2348b0f9205c5f2b343172c2c6e76d3833a3fc4e28615a06a954b73031c0dac649399dfd3e1d59fc24064f4150222d47b57ac22ca056c8b7762d6142f0590471e9a34ac84a5462529ada7c8e649cd2767e1fd9d79d58156b50c552ab5ae53089948d37fef8333179a1457adca42d1d399665589e0098d1b2cdb3eb9a6c865424236066998982aeda1bc61054070decb3eaddb7d2d60da23b43c1dda92085a04820b38fd17e36aed06422f4a6243a4ea403e99c25745ee386713692e806044c8961ab9aa79acae7523144ee4975ea3c8f10eb1573182af1249f30cb42b79840539046a8e1f5f5098443d1a9cf5c5c8c20299a4524b1fa906a171903bc47c5a5bf8a97722826abeb63cd5a710a1580a26256f4fd9489e03509af6a0b4336ae2a14e2c23c461236d4d44540a4f48c518af5f869b5095111e552d861144313f0786e8801a0940283a11dc35cc61f81f4ddcbac1677ee753aaef9b0aa9cd684960e17497266b26ef0d0ec32a34efafb019291297ded7e5f6b6065c392e53d5122011759b11d1a1a80036799322e0f38941139620c0538119a4c42a4a8c278d5c9bf115ae00765909731232df51f5df621285aac3411217ce879424c3ece09dca63551974c1c8840c316bf7a316646abaa4e19350d9b5bdbce9a004f6ac45670487259d7010a04a41ba5c1dba08357ee0af686202b4b3008a8a02a512f9ba8254c34a98096f91a4c1482f91434ac1862e7780d9a72305ba5439cf77ba16a491e994dc394ff5b65662c8da2944c78a7128cf21458791f1848c385df0b003e4425391091525bc0028c855796ae1dbf5d095e4f3c1b40e4d13ae45982d7954f558cc441cc08adec2ea1c26adbbb22c1e0b16b0104140e35ae366263439c9966a50b2013a6d9bdd3b4ea0a7d016945b731eed8ccb6305fe69ddd7e2fa600c92f62037d179d0acb4f025d70a4048fa3a395e9115b22e8ee7667df24c9b3120132ec42270812f02eab0737691b4f9f7375a66c207658923223737b041a0a3ae140b11c52e18f2cd430b71840b1cb259ba5b1a585709628fa762f0a2c8
+          default: 0x6c6518ba9e6496c2467b490691117ea9c32b50ec6ea3d2863650d4b2dadd0a95ec16c7c4d09306476a86481c677d1e2b2c5f6788dc5c40260b338459ac581882f64a1000515563264ade7f9eaf1341994b1b66407c2e666832907d97805aab2c6a570a4b1c9195e8ad8c89c221f9746e80b5e550025884e7265a1a552f8b6263b99593027034944547f72a413c60a840f0b3c0b918d1b910da91fc4af0b5f26fc0a298517128a8eb9b1202570821d349dedbb53aa3ee990123280d722cff0e4663cc752fd4d0aeef0e1c330cc60546c5be7d781bb41a3c3b5975f5cfc11c5061df4944e4c7075aa3a46af23e6a197c9e5d2c3c2256232e314a170480625588584d21e4f7210c532da0be04b849a74140aa29d814679460baa08200785779e4974a8c2ed6868dc6658e926caa04602370505ae43731b47403fb6c680fa6d6ac330b8c9404c853a27b70dd6c0817c6b562cbe2d59b8a86a871a6b6a34bde70268da1eae0674f6974341d8856706da4564601fd560db4828b4dce4894ef3ca00039e8180002be8129e2338b100c15644061972a6845bcb22684d2e5359d646d635ed9a3015dac11dc1a387c31bae5754fe426e6e2412de471cd860089acb73a04818a1b2b1d90be8459c65589770dc6b4d824626d29df03c61c899512298861c4fb64d4779a3e3f0e3a2628136f3106a3ae0faa0e99824b098ca423e96b004f889d5430d55a5ecc06ce229ee72c28b84139f80f7adaca615721cc45da01c00a36b69c3fabe965d48b319b9e6c6962f6c8925427332855438474894abc2bdbeaf9875118c52d80d60af09fab0d86bd5cb18e0c70d33092a6fed59f0581f9c74e480ae8ae00582b36af7864412aa82f0cc0c6ca1f6744ce1e0744976c5e6a1457270d63a0e07df70a5fab32c9294e6619796ce5ebfcdeab5e41ee7594090c7e353f6f542239b6293c46f475e5808496c76bb982855bb0937dfb7d61a5083552129aa69a82c034f04631d44815be4299424c1942d4c351ae4ecb2a00022a20fbbafd226619e1265989d5fcf8c39b56346e041f20f507afd0fb4e87892d7569510d8d99505c4f82660df8c2afb9170f645a4152d0938058fe4d87eea8aeb3525de7a53057db799ddd1d1ce8edf3c5007b7c5ac54cf0895ba803b06db868a865ce5716f0c2e29498b1e10a5a0f082616c1b11c476a4aad914564637bceb8102c85ab27a98f6f4cda766e4b9fe95692485547feb44f5c1948f478c788cc8e866a2b169f62903b0953818174c823a2146339983aaaa836155497245ce59207353cf5132691581a9d80c594a99a87725f16702304d6ae4e16d9c64fbf2130e941a36eb772d147e7220cb4a5ed9010bdc6a3745aec6101c14d1e4099fbf98744c4510da91c05d2aed696e53a6c6f
           randwidth: 8000
         }
         {
@@ -5644,7 +5644,7 @@
           randcount: 800
           randtype: data
           name_top: RndCnstKmacBufferLfsrSeed
-          default: 0x82c54e1481730f66854723d00560945b6c126ffec03bf1a985028fae5eca762b77b0aaa69486cff6100543fa654b771979a70dde33ff89cf0ed4d484bcbd6b2ae72e35145b5f97c0e9b65e98cea48c3df219340a563da5b6396fce53002a2961ac84bdda
+          default: 0x8eced8859f464d1d910540eec6ba0486f07cffaf7b8b9213bd8dc7b927797c09dfeaf1272b92abc409056cfa513aed0de2186c2b2a4874e4adaca4c6809e571b351756bf8d18e24be7e1c96737b726a4c6f04993b3e6aae70f22aaf748b57c320264e157
           randwidth: 800
         }
         {
@@ -5654,7 +5654,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstKmacMsgPerm
-          default: 0xc955307f8181637fe30d17bc5fd019b8bd6076649bd903930a1256207cccfaf2aae4da6d6ac9e47223f1ebb968d2b144
+          default: 0x52dd59f560e06b6fa776c08970b3a9fcd8b996f7faafb8744c58c7deef28991ca47b01b33d022a5570446d8300292c78
           randwidth: 384
         }
       ]
@@ -5848,7 +5848,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstOtbnUrndPrngSeed
-          default: 0xa575b899b4caae056cf2b85353e1a33975e7b1209b868a4acd919ed9795d5f51
+          default: 0x600d2a41bc465efe57aa3b59bd6b0a40216363420f041ed29a965b68faea3e59
           randwidth: 256
         }
         {
@@ -5886,7 +5886,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstOtbnOtbnKey
-          default: 0x9aa8cd47ac68b65650a1bb5a4a6dbf0b
+          default: 0xd4f2e2a0b42eb9a8c3ab227b50766d2e
           randwidth: 128
         }
         {
@@ -5896,7 +5896,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstOtbnOtbnNonce
-          default: 0xc7c1c7af8402bacd
+          default: 0xaec89eb13b07e9bf
           randwidth: 64
         }
       ]
@@ -6130,7 +6130,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstKeymgrDpeLfsrSeed
-          default: 0x250ed8960c88b4b1
+          default: 0x4ee42784136d42c8
           randwidth: 64
         }
         {
@@ -6140,7 +6140,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstKeymgrDpeLfsrPerm
-          default: 0xa3fb9af729349f5d820605b362d23a1ac4993dcdd3e0e35de4510af171c08cc5150e2271c0bee942f6fe966ad17a1a9f
+          default: 0x73a93266a6b6e1fb1dce0b54c02f3e0063eb8bd5858f5418a040791c3c694cd48c9ca20bde5eef7a6ba157fd0939b457
           randwidth: 384
         }
         {
@@ -6150,7 +6150,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstKeymgrDpeRandPerm
-          default: 0x6f92165b3355778fdd0678f9470ba75c8b08809a
+          default: 0x474d410ed8502fbd47e50a56c6e64724e0fe3bd5
           randwidth: 160
         }
         {
@@ -6160,7 +6160,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrDpeRevisionSeed
-          default: 0xb6ee6e7ad485ff3ca72c2242223ce6d70f17b4f4b32818aa49d125b4defb1f3c
+          default: 0xf90ef5e2b74beee27cfa19ea576ca8a8225c8e17053e44b68dd7822a6859f2cf
           randwidth: 256
         }
         {
@@ -6170,7 +6170,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrDpeSoftOutputSeed
-          default: 0xbe8a29be065c26d23550bbc139ff6461763d7e966a8a7219eb2e8ef9f11a152
+          default: 0x52a55fd181b082d03c583756f11aa5b37f9544c4aa90eb97e1c0f8086f627a28
           randwidth: 256
         }
         {
@@ -6180,7 +6180,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrDpeHardOutputSeed
-          default: 0xe6c71aa23b8864416e750c01a3339c6c7aa11244ecd28a62cb1b851078c2a5f1
+          default: 0x1c5681d6566641eecccc88876ad113c50ad1be4d94dce8fca54128a3860ae1d3
           randwidth: 256
         }
         {
@@ -6190,7 +6190,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrDpeAesSeed
-          default: 0x8eee28d0b562043b7312efad871f92e7527da865d661281fe98dfcd72e3c6d15
+          default: 0x493fbef6b9ba5dfe4463a4615ef46762a794a8c2597e69fb259b961914cd75bb
           randwidth: 256
         }
         {
@@ -6200,7 +6200,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrDpeKmacSeed
-          default: 0xa85d63009596f7966c5c68caedde4ab7c65fb8d59618284064d7194e4707ada
+          default: 0xfd36ba48e780d27cd582540c7a68ff254edfd852829fecccabd4af9c9032da20
           randwidth: 256
         }
         {
@@ -6210,7 +6210,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrDpeOtbnSeed
-          default: 0x81f8a6db14ca845beee60798289ad4fb0df1768296390152700e078ec5a951b6
+          default: 0xbdaf59fe2ae209b8325d2c8c35fc960679b106a87e59e6aeb1b5302d33401070
           randwidth: 256
         }
         {
@@ -6220,7 +6220,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrDpeNoneSeed
-          default: 0x27cf2ccd155d84fdaced736e93362c8da83c5f4dd2093e4d2a70dd99dcf4ccac
+          default: 0x251696fbb4ba169a6cd82fad46a0a5c04009bb934c7ef7b83b6e40610b4309fc
           randwidth: 256
         }
       ]
@@ -6424,7 +6424,7 @@
           randcount: 384
           randtype: data
           name_top: RndCnstCsrngCsKeymgrDivNonProduction
-          default: 0x341a2f1a2704f5e21287fa168af251b370d034cda605152662f4d11b3245d5943ea5fd2e4bea016b7911deaf01df7425
+          default: 0xb9dc54d4276137f9901d09a76aeaa19de5c579fd38bdf38f0c21d6a52226b6a4a7bdb05fe921615bf2ff984540f7d43e
           randwidth: 384
         }
         {
@@ -6434,7 +6434,7 @@
           randcount: 384
           randtype: data
           name_top: RndCnstCsrngCsKeymgrDivProduction
-          default: 0x47371445d6e3955145e3074d9ca9e8a4ef06a6f14a5c8fcac0d6396e606a620a9ffb23756bda420a9e7bd1a7c41e3a37
+          default: 0xce76b4eb13363774ed2ed45545e927f6d9e4abac398d42c745eef646c1464dca86dafd7c7c71e6058ddfd871c51cacba
           randwidth: 384
         }
         {
@@ -7140,7 +7140,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramKey
-          default: 0xb747d3d7b758b37d1d1ca19a079c48d7
+          default: 0xf4410f06dcc036fcd16fcde97d171891
           randwidth: 128
         }
         {
@@ -7150,7 +7150,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramNonce
-          default: 0xd4e67100a6aaebe45b6f09aefb72895e
+          default: 0x105dd895e3a1d0a19a16d6dbd8b20fc9
           randwidth: 128
         }
         {
@@ -7160,7 +7160,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstSramCtrlMainLfsrSeed
-          default: 0xc90d876315db9ad8
+          default: 0xe662e1e1b4982b3e
           randwidth: 64
         }
         {
@@ -7170,7 +7170,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstSramCtrlMainLfsrPerm
-          default: 0xd58134893911fa70a6380e0b53a19676dfdf5db42966a81a0c857c16572c376052c077afecadf1f61ae88c9333c8fe6e
+          default: 0x5700cef8725c61b0b488d107bc24e8073feab3dad64de462bd12e53f9f75450a6cb0a1d47a4d67e96b56e4aef0e2623
           randwidth: 384
         }
         {
@@ -7467,7 +7467,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMboxSramKey
-          default: 0xc9adde7bfb79fb9cc4c0b2d1aed6700a
+          default: 0xaa516c144b34c96dfabb6f6e79208a74
           randwidth: 128
         }
         {
@@ -7477,7 +7477,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMboxSramNonce
-          default: 0x44ea3e7e0610a663d52b082b9aef0e42
+          default: 0xf35c79f397c4e4c7e22b7581848a90a1
           randwidth: 128
         }
         {
@@ -7487,7 +7487,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstSramCtrlMboxLfsrSeed
-          default: 0x6df4866fe88a8baa
+          default: 0x254b2276bec9fc1a
           randwidth: 64
         }
         {
@@ -7497,7 +7497,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstSramCtrlMboxLfsrPerm
-          default: 0x313255020282c197b789fb87992c785a8ea335a9c81b3474bdc76b921daa054cbd103f186e542cecfb75e6917e5cbfce
+          default: 0x638051f4a7e18333acd09fc7ea96b70eb6d4c35002be3e65a2740b77e91c17bd8fb578843591969b1312b93cbca8855e
           randwidth: 384
         }
         {
@@ -7808,7 +7808,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstRomCtrl0ScrNonce
-          default: 0x37bebb1d8879e257
+          default: 0xdc260a79998eff5c
           randwidth: 64
         }
         {
@@ -7818,7 +7818,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstRomCtrl0ScrKey
-          default: 0x23b9d533238865874ef2d375583c209c
+          default: 0x710b67838adfb99a5eca671672cf19bc
           randwidth: 128
         }
         {
@@ -8009,7 +8009,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstRomCtrl1ScrNonce
-          default: 0x27d35c5794f680b
+          default: 0xa6adc1ebfab611f1
           randwidth: 64
         }
         {
@@ -8019,7 +8019,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstRomCtrl1ScrKey
-          default: 0x124893c22e6a22f5ad2e7591ecad6cca
+          default: 0x9e7262e0a491970e51b28e7026d0e5dc
           randwidth: 128
         }
         {
@@ -10963,7 +10963,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstRvCoreIbexLfsrSeed
-          default: 0x220de3c0
+          default: 0xe9e265a4
           randwidth: 32
         }
         {
@@ -10973,7 +10973,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstRvCoreIbexLfsrPerm
-          default: 0x3d1a8b4f92ee1c92c5f55ab77f30c2fe74124060
+          default: 0x32b4fa623c5a2f6914e90832d6767bf41c327ea2
           randwidth: 160
         }
         {
@@ -10983,7 +10983,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstRvCoreIbexIbexKeyDefault
-          default: 0xf2546ea845a7ade1002b84b739380023
+          default: 0xffaff9760f5e838bd8e2413ab956b10
           randwidth: 128
         }
         {
@@ -10993,7 +10993,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstRvCoreIbexIbexNonceDefault
-          default: 0xc25c3deaf38d871a
+          default: 0x6ca7139a07effee4
           randwidth: 64
         }
         {

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling_rnd_cnst_pkg.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling_rnd_cnst_pkg.sv
@@ -18,17 +18,17 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter otp_ctrl_top_specific_pkg::lfsr_seed_t RndCnstOtpCtrlLfsrSeed = {
-    40'h58_FA9063CE
+    40'h27_2EFAA51F
   };
 
   // Compile-time random permutation for LFSR output
   parameter otp_ctrl_top_specific_pkg::lfsr_perm_t RndCnstOtpCtrlLfsrPerm = {
-    240'h2DD6_809079E6_7935A195_848E7CA5_065C4701_8D980335_588C44F1_494026C8
+    240'h34F8_105CA313_78705D70_B6420112_544A28D5_6256A659_B9C63A11_487E4103
   };
 
   // Compile-time random permutation for scrambling key/nonce register reset value
   parameter otp_ctrl_top_specific_pkg::scrmbl_key_init_t RndCnstOtpCtrlScrmblKeyInit = {
-    256'hE34F64CE_978305BF_C3481A21_62EA2792_B7508F1E_AB067AF9_54DDA549_1439A9DD
+    256'h55176264_E55C329C_8AE4725A_EAF67281_50127AC7_55D70063_277642B5_309A1639
   };
 
   ////////////////////////////////////////////
@@ -36,35 +36,35 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Diversification value used for all invalid life cycle states.
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivInvalid = {
-    128'hE6320801_FDCF25A4_FBA52839_9117069E
+    128'h90B966CD_494444C3_BCDF8087_B7FACD65
   };
 
   // Diversification value used for the TEST_UNLOCKED* life cycle states.
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivTestUnlocked = {
-    128'h77C887F5_3DDA6FB4_EF8758B9_9027B6AA
+    128'hE9654CD8_5BC66D10_208C4FB5_1B97BBF4
   };
 
   // Diversification value used for the DEV life cycle state.
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivDev = {
-    128'h7468BC0B_D8D70368_E7CFB11A_99675B14
+    128'hD12C378C_CFD6A5A5_BF3032DB_51FA1EB9
   };
 
   // Diversification value used for the PROD/PROD_END life cycle states.
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivProduction = {
-    128'h62406193_35A9E2D1_23834D18_744778BE
+    128'h2F6CE10E_90F9C5C0_6F733DC9_11A321DD
   };
 
   // Diversification value used for the RMA life cycle state.
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivRma = {
-    128'h5E63C087_E36838B5_6B1A45F6_FD312F53
+    128'h4C0AC240_6D467215_DAB3F2B5_4A52E672
   };
 
   // Compile-time random bits used for invalid tokens in the token mux
   parameter lc_ctrl_pkg::lc_token_mux_t RndCnstLcCtrlInvalidTokens = {
-    256'h53FA7B2C_E9FC83DD_AF1DD8C5_A42E2AD2_4FA02221_B6FF5AAD_7A9C09D5_D9FDD1CF,
-    256'hCF512835_C0CFAE2E_D0C69FA4_88685CEA_9BC1C89B_FB7399AE_F5C6EB5D_6E4E2341,
-    256'h6A0AA6D7_AC7EC9C3_304470FB_E505F964_9400CA98_64FD4CE4_9D2CFC6E_CC102540,
-    256'hEAD87347_00A52071_32689471_AA822BC5_1CDD4D37_AC2D246C_4264F37E_C1982017
+    256'h8678AF07_18068E34_4D2EAE4D_73C8FA54_DE8AA4A4_F258F3B2_A145FD19_50AE55D6,
+    256'h93E57968_117E66DC_634155E0_F8150242_862EB20E_EA9A1F75_44716551_512A112D,
+    256'hED678CE8_24A08E29_C772795A_358EC30F_1BEDD1AF_0EC9D9A9_CF36A2B1_30D32AFE,
+    256'h121AF734_F628363A_AA0E93D4_5C423690_ED05BD1E_710F22D1_095889FB_D8A7B57F
   };
 
   ////////////////////////////////////////////
@@ -72,12 +72,12 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter alert_handler_pkg::lfsr_seed_t RndCnstAlertHandlerLfsrSeed = {
-    32'h94ADDA1B
+    32'hB1E11DF3
   };
 
   // Compile-time random permutation for LFSR output
   parameter alert_handler_pkg::lfsr_perm_t RndCnstAlertHandlerLfsrPerm = {
-    160'h2C7C7806_D8FE46F6_51C95DC1_B36BA445_54DE4E42
+    160'h47C16293_507A44A9_6F3499CC_30DFB573_62BE7B0C
   };
 
   ////////////////////////////////////////////
@@ -85,23 +85,23 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlRetAonSramKey = {
-    128'h21D8CB69_D4F3A15F_AF834CAD_515D76BD
+    128'hA1DCD048_88055411_66F1EC8C_EB42692B
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlRetAonSramNonce = {
-    128'h37C7BEC5_F33FDCA1_1A72DC05_A2313B71
+    128'h089A6F99_B1A7AC08_4224ADE4_612980D4
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter sram_ctrl_pkg::lfsr_seed_t RndCnstSramCtrlRetAonLfsrSeed = {
-    64'h8E6D6DBB_8EC647D1
+    64'h8E6C6493_A50EEDBA
   };
 
   // Compile-time random permutation for LFSR output
   parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlRetAonLfsrPerm = {
-    128'hB7742874_B5231769_5C3CDD61_4D1C1702,
-    256'hA7EF13BF_561E078A_9826CCAC_36BC9E9B_99886231_93EFC9E7_254ED330_584BAB38
+    128'h02566EB2_13C537DE_7BA1307F_72BC145A,
+    256'hAD3533AD_9F0FE248_2B8C8475_86C256D5_C7BE0406_DF33A345_29E4F0B9_A279AA71
   };
 
   ////////////////////////////////////////////
@@ -109,34 +109,34 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for register clearing.
   parameter aes_pkg::clearing_lfsr_seed_t RndCnstAesClearingLfsrSeed = {
-    64'h2482CC34_468C37BF
+    64'h14A8F2B7_5C265C9C
   };
 
   // Permutation applied to the LFSR of the PRNG used for clearing.
   parameter aes_pkg::clearing_lfsr_perm_t RndCnstAesClearingLfsrPerm = {
-    128'h57677E4B_32BAAAFA_F9E2C130_99A62759,
-    256'hB8BCFDE7_F5D21971_4CE90122_93D9A10B_8D0095F2_8D42D180_31771FD3_2D08673B
+    128'h47641A7F_ECA51196_FA883269_7778EDAC,
+    256'h7E2F6352_0D2A7594_CCC9803C_E5EE5747_82170EFD_E6890B80_6053AA17_12C7CFEC
   };
 
   // Permutation applied to the clearing PRNG output for clearing the second share of registers.
   parameter aes_pkg::clearing_lfsr_perm_t RndCnstAesClearingSharePerm = {
-    128'h01C841ED_1BB4E7F8_222EAB3A_08F24AAD,
-    256'hB3ADC36F_31D67C97_7E44D069_EBC31053_65638747_A68F8C19_49968D9C_D5DFD212
+    128'h5BB39D12_2EB54831_88E73FFC_AB0C770B,
+    256'h27D584D6_17DACA59_6D07242A_668132E9_742C5FB8_3C952F4D_11E0B63A_2B9DE03D
   };
 
   // Default seed of the PRNG used for masking.
   parameter aes_pkg::masking_lfsr_seed_t RndCnstAesMaskingLfsrSeed = {
-    32'h36270315,
-    256'hF91066FB_63A6E6EB_54493C06_31CD3062_ADF6D00B_7E756F81_353C10AC_316A9C7A
+    32'hA0D95CE4,
+    256'hEE55B032_C07A29B9_20B7953E_485F23AD_102C6A0E_FCE9F0EC_4C712146_A4AB60DA
   };
 
   // Permutation applied to the output of the PRNG used for masking.
   parameter aes_pkg::masking_lfsr_perm_t RndCnstAesMaskingLfsrPerm = {
-    256'h9107678E_8F011852_4A1A5A0E_9F544D2A_5E69054F_53802641_71333A0D_5F0F7E1B,
-    256'h57616A39_11970B42_56640230_8C832D6D_9D84776C_121C3B86_4B8B731F_2E595C48,
-    256'h452F3D51_407B829B_7C080C94_27873575_5B287865_95898D8A_04936832_1606179C,
-    256'h50253F24_317A4E19_235D7F72_92109690_2C3E1E66_36135815_740A1D37_476F2162,
-    256'h60467D44_76797085_3899039A_1420986B_49552243_6E004C9E_3C810988_63292B34
+    256'h646B7344_050D0C61_01416F8A_7568107E_583E351A_0F85628E_495C3806_999C7629,
+    256'h27579591_88225470_601D6948_1E71312C_13439F6A_4E84041C_460A3498_23256787,
+    256'h8C5F9672_86092D55_4A4D4B63_325E5302_8F1B3A90_21421880_2033503F_79082F7A,
+    256'h7B813978_0B281536_4C036D7D_07169493_66374F24_405B1F30_2A0E9247_6C7F749A,
+    256'h2B3D5D14_56774500_8D269752_2E115112_5A3C1789_833B9E59_827C199B_9D6E658B
   };
 
   ////////////////////////////////////////////
@@ -144,58 +144,58 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random data for PRNG default seed
   parameter kmac_pkg::lfsr_seed_t RndCnstKmacLfsrSeed = {
-    32'hFD7F6334,
-    256'h613AA93B_656444D7_0350A89E_BC0CFBD0_A03925FC_80535F27_7451D2BE_0C46FDD2
+    32'h382AF33B,
+    256'h47971855_8E675976_4645AAD1_FB21C181_24635E3D_50A88F68_08045627_AC18F377
   };
 
   // Compile-time random permutation for PRNG output
   parameter kmac_pkg::lfsr_perm_t RndCnstKmacLfsrPerm = {
-    64'h62A473F8_E39C84BB,
-    256'h85A51AE7_85766453_5593E451_6657F9EC_35BD6326_31EF05D9_7C75C393_841A7879,
-    256'h13690B8A_C6BED552_A4726571_4BADC7B1_ED1892FC_96D1C0E1_3443ED20_680D63A3,
-    256'h45D83317_A5EC171F_8D63DA2E_DE924DB3_A11FC6C6_74293C83_45955C2B_96A797A6,
-    256'h893B2CAB_542781A1_41921326_DCE02F06_49AF9700_B98A5E66_92FE4CCB_F6E41408,
-    256'h6E9AEA19_5E2F61D8_57C00759_882F6117_3AA1DE74_44018291_708A407A_0CBB836A,
-    256'hA8256DA7_A2416527_D2725246_3420B51E_817F0EE2_B6700FD1_66EA85BF_E081C587,
-    256'h901E2841_204E6712_962256C4_9C405B32_8233F135_0627DB94_63B162D8_79E1899D,
-    256'h28FA3ABC_A6A6E06D_BAA2348B_0F9205C5_F2B34317_2C2C6E76_D3833A3F_C4E28615,
-    256'hA06A954B_73031C0D_AC649399_DFD3E1D5_9FC24064_F4150222_D47B57AC_22CA056C,
-    256'h8B7762D6_142F0590_471E9A34_AC84A546_2529ADA7_C8E649CD_2767E1FD_9D79D581,
-    256'h56B50C55_2AB5AE53_089948D3_7FEF8333_179A1457_ADCA42D1_D3996655_89E0098D,
-    256'h1B2CDB3E_B9A6C865_42423606_6998982A_EDA1BC61_054070DE_CB3EADDB_7D2D60DA,
-    256'h23B43C1D_DA92085A_04820B38_FD17E36A_ED06422F_4A6243A4_EA403E99_C25745EE,
-    256'h38671369_2E806044_C8961AB9_AA79ACAE_7523144E_E4975EA3_C8F10EB1_573182AF,
-    256'h1249F30C_B42B7984_0539046A_8E1F5F50_98443D1A_9CF5C5C8_C20299A4_524B1FA9,
-    256'h06A17190_3BC47C5A_5BF8A977_22826ABE_B63CD5A7_10A1580A_26256F4F_D9489E03,
-    256'h509AF6A0_B4336AE2_A14E2C23_C461236D_4D44540A_4F48C518_AF5F869B_5095111E,
-    256'h552D8611_44313F07_86E8801A_0940283A_11DC35CC_61F81F4D_DCBAC167_7EE753AA,
-    256'hEF9B0AA9_CD684960_E1749726_6B26EF0D_0EC32A34_EFAFB019_291297DE_D7E5F6B6,
-    256'h065C392E_53D51220_11759B11_D1A1A800_36799322_E0F38941_139620C0_538119A4,
-    256'hC42A4A8C_278D5C9B_F115AE00_76590973_1232DF51_F5DF6212_85AAC341_1217CE87,
-    256'h9424C3EC_E09DCA63_551974C1_C8840C31_6BF7A316_646ABAA4_E19350D9_B5BDBCE9,
-    256'hA004F6AC_45670487_259D7010_A04A41BA_5C1DBA08_357EE0AF_686202B4_B3008A8A,
-    256'h02A512F9_BA8254C3_4A98096F_91A4C148_2F91434A_C1862E77_80D9A723_05BA5439,
-    256'hCF77BA16_A491E994_DC394FF5_B65662C8_DA2944C7_8A7128CF_21458791_F1848C38,
-    256'h5DF0B003_E4425391_091525BC_0028C855_796AE1DB_F5D095E4_F3C1B40E_4D13AE45,
-    256'h982D7954_F558CC44_1CC08ADE_C2EA1C26_ADBBB22C_1E0B16B0_104140E3_5AE36626,
-    256'h3439C996_6A50B201_3A6D9BDD_3B4EA0A7_D016945B_731EED8C_CB6305FE_69DDD7E2,
-    256'hFA600C92_F62037D1_79D0ACB4_F025D70A_4048FA3A_395E9115_B22E8EE7_667DF24C,
-    256'h9B312013_2EC42270_812F02EA_B0737691_B4F9F737_5A66C207_65892322_3737B041,
-    256'hA0A3AE14_0B11C52E_18F2CD43_0B71840B_1CB259BA_5B1A5857_09628FA7_62F0A2C8
+    64'h6C6518BA_9E6496C2,
+    256'h467B4906_91117EA9_C32B50EC_6EA3D286_3650D4B2_DADD0A95_EC16C7C4_D0930647,
+    256'h6A86481C_677D1E2B_2C5F6788_DC5C4026_0B338459_AC581882_F64A1000_51556326,
+    256'h4ADE7F9E_AF134199_4B1B6640_7C2E6668_32907D97_805AAB2C_6A570A4B_1C9195E8,
+    256'hAD8C89C2_21F9746E_80B5E550_025884E7_265A1A55_2F8B6263_B9959302_70349445,
+    256'h47F72A41_3C60A840_F0B3C0B9_18D1B910_DA91FC4A_F0B5F26F_C0A29851_7128A8EB,
+    256'h9B120257_0821D349_DEDBB53A_A3EE9901_23280D72_2CFF0E46_63CC752F_D4D0AEEF,
+    256'h0E1C330C_C60546C5_BE7D781B_B41A3C3B_5975F5CF_C11C5061_DF4944E4_C7075AA3,
+    256'hA46AF23E_6A197C9E_5D2C3C22_56232E31_4A170480_62558858_4D21E4F7_210C532D,
+    256'hA0BE04B8_49A74140_AA29D814_679460BA_A0820078_5779E497_4A8C2ED6_868DC665,
+    256'h8E926CAA_04602370_505AE437_31B47403_FB6C680F_A6D6AC33_0B8C9404_C853A27B,
+    256'h70DD6C08_17C6B562_CBE2D59B_8A86A871_A6B6A34B_DE70268D_A1EAE067_4F697434,
+    256'h1D885670_6DA45646_01FD560D_B4828B4D_CE4894EF_3CA00039_E8180002_BE8129E2,
+    256'h338B100C_15644061_972A6845_BCB22684_D2E5359D_646D635E_D9A3015D_AC11DC1A,
+    256'h387C31BA_E5754FE4_26E6E241_2DE471CD_860089AC_B73A0481_8A1B2B1D_90BE8459,
+    256'hC6558977_0DC6B4D8_24626D29_DF03C61C_89951229_8861C4FB_64D4779A_3E3F0E3A,
+    256'h2628136F_3106A3AE_0FAA0E99_824B098C_A423E96B_004F889D_5430D55A_5ECC06CE,
+    256'h229EE72C_28B84139_F80F7ADA_CA615721_CC45DA01_C00A36B6_9C3FABE9_65D48B31,
+    256'h9B9E6C69_62F6C892_54273328_55438474_894ABC2B_DBEAF987_5118C52D_80D60AF0,
+    256'h9FAB0D86_BD5CB18E_0C70D330_92A6FED5_9F0581F9_C74E480A_E8AE0058_2B36AF78,
+    256'h64412AA8_2F0CC0C6_CA1F6744_CE1E0744_976C5E6A_1457270D_63A0E07D_F70A5FAB,
+    256'h32C9294E_6619796C_E5EBFCDE_AB5E41EE_7594090C_7E353F6F_542239B6_293C46F4,
+    256'h75E58084_96C76BB9_82855BB0_937DFB7D_61A50835_52129AA6_9A82C034_F04631D4,
+    256'h4815BE42_99424C19_42D4C351_AE4ECB2A_00022A20_FBBAFD22_6619E126_5989D5FC,
+    256'hF8C39B56_346E041F_20F507AF_D0FB4E87_892D7569_510D8D99_505C4F82_660DF8C2,
+    256'hAFB9170F_645A4152_D0938058_FE4D87EE_A8AEB352_5DE7A530_57DB799D_DD1D1CE8,
+    256'hEDF3C500_7B7C5AC5_4CF0895B_A803B06D_B868A865_CE5716F0_C2E29498_B1E10A5A,
+    256'h0F082616_C1B11C47_6A4AAD91_4564637B_CEB8102C_85AB27A9_8F6F4CDA_766E4B9F,
+    256'hE9569248_5547FEB4_4F5C1948_F478C788_CC8E866A_2B169F62_903B0953_818174C8,
+    256'h23A21463_39983AAA_A8361554_97245CE5_9207353C_F5132691_581A9D80_C594A99A,
+    256'h87725F16_702304D6_AE4E16D9_C64FBF21_30E941A3_6EB772D1_47E7220C_B4A5ED90,
+    256'h10BDC6A3_745AEC61_01C14D1E_4099FBF9_8744C451_0DA91C05_D2AED696_E53A6C6F
   };
 
   // Compile-time random data for PRNG buffer default seed
   parameter kmac_pkg::buffer_lfsr_seed_t RndCnstKmacBufferLfsrSeed = {
-    32'h82C54E14,
-    256'h81730F66_854723D0_0560945B_6C126FFE_C03BF1A9_85028FAE_5ECA762B_77B0AAA6,
-    256'h9486CFF6_100543FA_654B7719_79A70DDE_33FF89CF_0ED4D484_BCBD6B2A_E72E3514,
-    256'h5B5F97C0_E9B65E98_CEA48C3D_F219340A_563DA5B6_396FCE53_002A2961_AC84BDDA
+    32'h8ECED885,
+    256'h9F464D1D_910540EE_C6BA0486_F07CFFAF_7B8B9213_BD8DC7B9_27797C09_DFEAF127,
+    256'h2B92ABC4_09056CFA_513AED0D_E2186C2B_2A4874E4_ADACA4C6_809E571B_351756BF,
+    256'h8D18E24B_E7E1C967_37B726A4_C6F04993_B3E6AAE7_0F22AAF7_48B57C32_0264E157
   };
 
   // Compile-time random permutation for LFSR Message output
   parameter kmac_pkg::msg_perm_t RndCnstKmacMsgPerm = {
-    128'hC955307F_8181637F_E30D17BC_5FD019B8,
-    256'hBD607664_9BD90393_0A125620_7CCCFAF2_AAE4DA6D_6AC9E472_23F1EBB9_68D2B144
+    128'h52DD59F5_60E06B6F_A776C089_70B3A9FC,
+    256'hD8B996F7_FAAFB874_4C58C7DE_EF28991C_A47B01B3_3D022A55_70446D83_00292C78
   };
 
   ////////////////////////////////////////////
@@ -203,17 +203,17 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for URND.
   parameter otbn_pkg::urnd_prng_seed_t RndCnstOtbnUrndPrngSeed = {
-    256'hA575B899_B4CAAE05_6CF2B853_53E1A339_75E7B120_9B868A4A_CD919ED9_795D5F51
+    256'h600D2A41_BC465EFE_57AA3B59_BD6B0A40_21636342_0F041ED2_9A965B68_FAEA3E59
   };
 
   // Compile-time random reset value for IMem/DMem scrambling key.
   parameter otp_ctrl_pkg::otbn_key_t RndCnstOtbnOtbnKey = {
-    128'h9AA8CD47_AC68B656_50A1BB5A_4A6DBF0B
+    128'hD4F2E2A0_B42EB9A8_C3AB227B_50766D2E
   };
 
   // Compile-time random reset value for IMem/DMem scrambling nonce.
   parameter otp_ctrl_pkg::otbn_nonce_t RndCnstOtbnOtbnNonce = {
-    64'hC7C1C7AF_8402BACD
+    64'hAEC89EB1_3B07E9BF
   };
 
   ////////////////////////////////////////////
@@ -221,53 +221,53 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter keymgr_pkg::lfsr_seed_t RndCnstKeymgrDpeLfsrSeed = {
-    64'h250ED896_0C88B4B1
+    64'h4EE42784_136D42C8
   };
 
   // Compile-time random permutation for LFSR output
   parameter keymgr_pkg::lfsr_perm_t RndCnstKeymgrDpeLfsrPerm = {
-    128'hA3FB9AF7_29349F5D_820605B3_62D23A1A,
-    256'hC4993DCD_D3E0E35D_E4510AF1_71C08CC5_150E2271_C0BEE942_F6FE966A_D17A1A9F
+    128'h73A93266_A6B6E1FB_1DCE0B54_C02F3E00,
+    256'h63EB8BD5_858F5418_A040791C_3C694CD4_8C9CA20B_DE5EEF7A_6BA157FD_0939B457
   };
 
   // Compile-time random permutation for entropy used in share overriding
   parameter keymgr_pkg::rand_perm_t RndCnstKeymgrDpeRandPerm = {
-    160'h6F92165B_3355778F_DD0678F9_470BA75C_8B08809A
+    160'h474D410E_D8502FBD_47E50A56_C6E64724_E0FE3BD5
   };
 
   // Compile-time random bits for revision seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrDpeRevisionSeed = {
-    256'hB6EE6E7A_D485FF3C_A72C2242_223CE6D7_0F17B4F4_B32818AA_49D125B4_DEFB1F3C
+    256'hF90EF5E2_B74BEEE2_7CFA19EA_576CA8A8_225C8E17_053E44B6_8DD7822A_6859F2CF
   };
 
   // Compile-time random bits for software generation seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrDpeSoftOutputSeed = {
-    256'h0BE8A29B_E065C26D_23550BBC_139FF646_1763D7E9_66A8A721_9EB2E8EF_9F11A152
+    256'h52A55FD1_81B082D0_3C583756_F11AA5B3_7F9544C4_AA90EB97_E1C0F808_6F627A28
   };
 
   // Compile-time random bits for hardware generation seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrDpeHardOutputSeed = {
-    256'hE6C71AA2_3B886441_6E750C01_A3339C6C_7AA11244_ECD28A62_CB1B8510_78C2A5F1
+    256'h1C5681D6_566641EE_CCCC8887_6AD113C5_0AD1BE4D_94DCE8FC_A54128A3_860AE1D3
   };
 
   // Compile-time random bits for generation seed when aes destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrDpeAesSeed = {
-    256'h8EEE28D0_B562043B_7312EFAD_871F92E7_527DA865_D661281F_E98DFCD7_2E3C6D15
+    256'h493FBEF6_B9BA5DFE_4463A461_5EF46762_A794A8C2_597E69FB_259B9619_14CD75BB
   };
 
   // Compile-time random bits for generation seed when kmac destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrDpeKmacSeed = {
-    256'h0A85D630_09596F79_66C5C68C_AEDDE4AB_7C65FB8D_59618284_064D7194_E4707ADA
+    256'hFD36BA48_E780D27C_D582540C_7A68FF25_4EDFD852_829FECCC_ABD4AF9C_9032DA20
   };
 
   // Compile-time random bits for generation seed when otbn destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrDpeOtbnSeed = {
-    256'h81F8A6DB_14CA845B_EEE60798_289AD4FB_0DF17682_96390152_700E078E_C5A951B6
+    256'hBDAF59FE_2AE209B8_325D2C8C_35FC9606_79B106A8_7E59E6AE_B1B5302D_33401070
   };
 
   // Compile-time random bits for generation seed when no destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrDpeNoneSeed = {
-    256'h27CF2CCD_155D84FD_ACED736E_93362C8D_A83C5F4D_D2093E4D_2A70DD99_DCF4CCAC
+    256'h251696FB_B4BA169A_6CD82FAD_46A0A5C0_4009BB93_4C7EF7B8_3B6E4061_0B4309FC
   };
 
   ////////////////////////////////////////////
@@ -275,14 +275,14 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for csrng state group diversification value
   parameter csrng_pkg::cs_keymgr_div_t RndCnstCsrngCsKeymgrDivNonProduction = {
-    128'h341A2F1A_2704F5E2_1287FA16_8AF251B3,
-    256'h70D034CD_A6051526_62F4D11B_3245D594_3EA5FD2E_4BEA016B_7911DEAF_01DF7425
+    128'hB9DC54D4_276137F9_901D09A7_6AEAA19D,
+    256'hE5C579FD_38BDF38F_0C21D6A5_2226B6A4_A7BDB05F_E921615B_F2FF9845_40F7D43E
   };
 
   // Compile-time random bits for csrng state group diversification value
   parameter csrng_pkg::cs_keymgr_div_t RndCnstCsrngCsKeymgrDivProduction = {
-    128'h47371445_D6E39551_45E3074D_9CA9E8A4,
-    256'hEF06A6F1_4A5C8FCA_C0D6396E_606A620A_9FFB2375_6BDA420A_9E7BD1A7_C41E3A37
+    128'hCE76B4EB_13363774_ED2ED455_45E927F6,
+    256'hD9E4ABAC_398D42C7_45EEF646_C1464DCA_86DAFD7C_7C71E605_8DDFD871_C51CACBA
   };
 
   ////////////////////////////////////////////
@@ -290,23 +290,23 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlMainSramKey = {
-    128'hB747D3D7_B758B37D_1D1CA19A_079C48D7
+    128'hF4410F06_DCC036FC_D16FCDE9_7D171891
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlMainSramNonce = {
-    128'hD4E67100_A6AAEBE4_5B6F09AE_FB72895E
+    128'h105DD895_E3A1D0A1_9A16D6DB_D8B20FC9
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter sram_ctrl_pkg::lfsr_seed_t RndCnstSramCtrlMainLfsrSeed = {
-    64'hC90D8763_15DB9AD8
+    64'hE662E1E1_B4982B3E
   };
 
   // Compile-time random permutation for LFSR output
   parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlMainLfsrPerm = {
-    128'hD5813489_3911FA70_A6380E0B_53A19676,
-    256'hDFDF5DB4_2966A81A_0C857C16_572C3760_52C077AF_ECADF1F6_1AE88C93_33C8FE6E
+    128'h05700CEF_8725C61B_0B488D10_7BC24E80,
+    256'h73FEAB3D_AD64DE46_2BD12E53_F9F75450_A6CB0A1D_47A4D67E_96B56E4A_EF0E2623
   };
 
   ////////////////////////////////////////////
@@ -314,23 +314,23 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlMboxSramKey = {
-    128'hC9ADDE7B_FB79FB9C_C4C0B2D1_AED6700A
+    128'hAA516C14_4B34C96D_FABB6F6E_79208A74
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlMboxSramNonce = {
-    128'h44EA3E7E_0610A663_D52B082B_9AEF0E42
+    128'hF35C79F3_97C4E4C7_E22B7581_848A90A1
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter sram_ctrl_pkg::lfsr_seed_t RndCnstSramCtrlMboxLfsrSeed = {
-    64'h6DF4866F_E88A8BAA
+    64'h254B2276_BEC9FC1A
   };
 
   // Compile-time random permutation for LFSR output
   parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlMboxLfsrPerm = {
-    128'h31325502_0282C197_B789FB87_992C785A,
-    256'h8EA335A9_C81B3474_BDC76B92_1DAA054C_BD103F18_6E542CEC_FB75E691_7E5CBFCE
+    128'h638051F4_A7E18333_ACD09FC7_EA96B70E,
+    256'hB6D4C350_02BE3E65_A2740B77_E91C17BD_8FB57884_3591969B_1312B93C_BCA8855E
   };
 
   ////////////////////////////////////////////
@@ -338,12 +338,12 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Fixed nonce used for address / data scrambling
   parameter bit [63:0] RndCnstRomCtrl0ScrNonce = {
-    64'h37BEBB1D_8879E257
+    64'hDC260A79_998EFF5C
   };
 
   // Randomised constant used as a scrambling key for ROM data
   parameter bit [127:0] RndCnstRomCtrl0ScrKey = {
-    128'h23B9D533_23886587_4EF2D375_583C209C
+    128'h710B6783_8ADFB99A_5ECA6716_72CF19BC
   };
 
   ////////////////////////////////////////////
@@ -351,12 +351,12 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Fixed nonce used for address / data scrambling
   parameter bit [63:0] RndCnstRomCtrl1ScrNonce = {
-    64'h027D35C5_794F680B
+    64'hA6ADC1EB_FAB611F1
   };
 
   // Randomised constant used as a scrambling key for ROM data
   parameter bit [127:0] RndCnstRomCtrl1ScrKey = {
-    128'h124893C2_2E6A22F5_AD2E7591_ECAD6CCA
+    128'h9E7262E0_A491970E_51B28E70_26D0E5DC
   };
 
   ////////////////////////////////////////////
@@ -364,22 +364,22 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for random instructions.
   parameter ibex_pkg::lfsr_seed_t RndCnstRvCoreIbexLfsrSeed = {
-    32'h220DE3C0
+    32'hE9E265A4
   };
 
   // Permutation applied to the LFSR of the PRNG used for random instructions.
   parameter ibex_pkg::lfsr_perm_t RndCnstRvCoreIbexLfsrPerm = {
-    160'h3D1A8B4F_92EE1C92_C5F55AB7_7F30C2FE_74124060
+    160'h32B4FA62_3C5A2F69_14E90832_D6767BF4_1C327EA2
   };
 
   // Default icache scrambling key
   parameter logic [ibex_pkg::SCRAMBLE_KEY_W-1:0] RndCnstRvCoreIbexIbexKeyDefault = {
-    128'hF2546EA8_45A7ADE1_002B84B7_39380023
+    128'h0FFAFF97_60F5E838_BD8E2413_AB956B10
   };
 
   // Default icache scrambling nonce
   parameter logic [ibex_pkg::SCRAMBLE_NONCE_W-1:0] RndCnstRvCoreIbexIbexNonceDefault = {
-    64'hC25C3DEA_F38D871A
+    64'h6CA7139A_07EFFEE4
   };
 
 endpackage : top_darjeeling_rnd_cnst_pkg

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1858,7 +1858,7 @@
           randcount: 40
           randtype: data
           name_top: RndCnstOtpCtrlLfsrSeed
-          default: 0x4f64ce9783
+          default: 0x309a163990
           randwidth: 40
         }
         {
@@ -1868,7 +1868,7 @@
           randcount: 40
           randtype: perm
           name_top: RndCnstOtpCtrlLfsrPerm
-          default: 0x30e2cd7239915839107536995c511e9e57e00a285b28f0151d4258206481
+          default: 0x28c1c838f5e301069d05379551c18598359f90408d60b6c98a7860951499
           randwidth: 240
         }
         {
@@ -1878,7 +1878,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstOtpCtrlScrmblKeyInit
-          default: 0x7468bc0bd8d70368e7cfb11a99675b146240619335a9e2d123834d18744778be
+          default: 0x21dd4c0ac2406d467215dab3f2b54a52e6728678af0718068e344d2eae4d73c8
           randwidth: 256
         }
       ]
@@ -2494,7 +2494,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivInvalid
-          default: 0x5e63c087e36838b56b1a45f6fd312f53
+          default: 0xfa54de8aa4a4f258f3b2a145fd1950ae
           randwidth: 128
         }
         {
@@ -2504,7 +2504,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivTestUnlocked
-          default: 0x53fa7b2ce9fc83ddaf1dd8c5a42e2ad2
+          default: 0x55d693e57968117e66dc634155e0f815
           randwidth: 128
         }
         {
@@ -2514,7 +2514,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivDev
-          default: 0x4fa02221b6ff5aad7a9c09d5d9fdd1cf
+          default: 0x242862eb20eea9a1f7544716551512a
           randwidth: 128
         }
         {
@@ -2524,7 +2524,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivProduction
-          default: 0xcf512835c0cfae2ed0c69fa488685cea
+          default: 0x112ded678ce824a08e29c772795a358e
           randwidth: 128
         }
         {
@@ -2534,7 +2534,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivRma
-          default: 0x9bc1c89bfb7399aef5c6eb5d6e4e2341
+          default: 0xc30f1bedd1af0ec9d9a9cf36a2b130d3
           randwidth: 128
         }
         {
@@ -2544,7 +2544,7 @@
           randcount: 1024
           randtype: data
           name_top: RndCnstLcCtrlInvalidTokens
-          default: 0x6a0aa6d7ac7ec9c3304470fbe505f9649400ca9864fd4ce49d2cfc6ecc102540ead8734700a5207132689471aa822bc51cdd4d37ac2d246c4264f37ec198201794adda1b16929df5e06a56aaded443259ffb5736dd6801215b98e162dcc09e31e8382e46e4fecfda2375a6147421d8cb69d4f3a15faf834cad515d76bd37c7be
+          default: 0x2afe121af734f628363aaa0e93d45c423690ed05bd1e710f22d1095889fbd8a7b57fb1e11df367c1c1ede3f35cfc8f6e72abdd73a9eefbf8b7081eb9f636e13ca9d21f1edebe60a22db6d398d4a21b73699e80820434a1dcd0488805541166f1ec8ceb42692b089a6f99b1a7ac084224ade4612980d48e6c6493a50eedbac6a4
           randwidth: 1024
         }
         {
@@ -3154,7 +3154,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstAlertHandlerLfsrSeed
-          default: 0xc5f33fdc
+          default: 0x6b7a8a9b
           randwidth: 32
         }
         {
@@ -3164,7 +3164,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstAlertHandlerLfsrPerm
-          default: 0xc65720dc8f9a845f6a1c62516ab63d39be0db874
+          default: 0x1119aa856ebb4c0f2b7fb52191f3078a133975e5
           randwidth: 160
         }
         {
@@ -5906,7 +5906,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlRetAonSramKey
-          default: 0x4b6a0cd066336e9b0bdf6a55f0d23bb7
+          default: 0x521d4711e64066908adfd5918f8c563c
           randwidth: 128
         }
         {
@@ -5916,7 +5916,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlRetAonSramNonce
-          default: 0xdc0dc524d3b0554603562188552794dd
+          default: 0x92184f1c76a61e112578bf9f469fc482
           randwidth: 128
         }
         {
@@ -5926,7 +5926,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstSramCtrlRetAonLfsrSeed
-          default: 0x2bebf67f318b5a49
+          default: 0xfa14a8f2b75c265c
           randwidth: 64
         }
         {
@@ -5936,7 +5936,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstSramCtrlRetAonLfsrPerm
-          default: 0xe4e6d896c3e8066ed32909f049e11da6bc488997f75a101af179382f2d7f147b7a08672fd2344dce026a53e32edbd543
+          default: 0xe758c46bddbbfd061f0c9c91762bb71f420d2a6a54ad959b32500f397b55cde085bfac38a242e01814ea85c4b1f3eb27
           randwidth: 384
         }
         {
@@ -6239,7 +6239,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstFlashCtrlAddrKey
-          default: 0xf0ef478248447b11420873650cbc6aee
+          default: 0xf6037b9daca18eb5801c444ebc53ec27
           randwidth: 128
         }
         {
@@ -6249,7 +6249,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstFlashCtrlDataKey
-          default: 0xa2c8ee2de417e3d05d145c3a684922f7
+          default: 0xf13eb602172c4d950331bebad605bb69
           randwidth: 128
         }
         {
@@ -6259,7 +6259,7 @@
           randcount: 512
           randtype: data
           name_top: RndCnstFlashCtrlAllSeeds
-          default: 0xdc57cc668c58f099531a3221a2eddca41f778dde61de9734b7ecdec517110ed2ceb31d789f996bcd43ba4fb06b9ea47dbf441aa625f5ddf2dcb03c2b867024d5
+          default: 0x6be7a52b9a29e3c871ee416dc904583df8bae9c46dee80a869a1ce14c113994cf87eda86140651ac88eb62e834aa3425c620c68ce20120a0d95ce4ee55b032c0
           randwidth: 512
         }
         {
@@ -6269,7 +6269,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstFlashCtrlLfsrSeed
-          default: 0x4654c6e6
+          default: 0x7a29b920
           randwidth: 32
         }
         {
@@ -6279,7 +6279,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstFlashCtrlLfsrPerm
-          default: 0x50fc8f9fb826e306841c34eda63a45a5d79155e9
+          default: 0x76f3c6fc3cd20a79a3f6234ee05a51548b49e56
           randwidth: 160
         }
         {
@@ -7232,7 +7232,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstAesClearingLfsrSeed
-          default: 0xd00b7e756f81353c
+          default: 0x3beafe8389e9f8ac
           randwidth: 64
         }
         {
@@ -7242,7 +7242,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstAesClearingLfsrPerm
-          default: 0x530a34a8127f92f0c6d8bb5c8c7e515bded975795fea686c3b5bb317ec7c4a954841b013dcf8028b263828d7a768cac4
+          default: 0x73039aa6e7c86e04990aba3ea860739d8353c50c87863783d2230af17dbf55d991d40dc9938ef92ec97af541163efb45
           randwidth: 384
         }
         {
@@ -7252,7 +7252,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstAesClearingSharePerm
-          default: 0x8ac7aa1a9fc8115f247475a6fb7c4f2a0acd73596fb7ac97b9315a27051bf408d00428516730cbe68e1f4b660e9fbd0c
+          default: 0x3dbb3322bb83fe5e2253dc8678e62045268b14a0294dc0a3116d2692a9f9ef15ed04935dfb0dfa87532fd95419a1ff07
           randwidth: 384
         }
         {
@@ -7262,7 +7262,7 @@
           randcount: 288
           randtype: data
           name_top: RndCnstAesMaskingLfsrSeed
-          default: 0x51a50ac312c182822cf6ad12452480a61092e8a80cdf267889e06a8a1ab5f6db8158aa7c
+          default: 0x8a468d23eecbd09de6b8f9faeaf1a70e57e8eda03a353b76a2f833509acc7b3aa3fa7dac
           randwidth: 288
         }
         {
@@ -7272,7 +7272,7 @@
           randcount: 160
           randtype: perm
           name_top: RndCnstAesMaskingLfsrPerm
-          default: 0x377a4a727e8f357024262156918e494c104f305d366b186a1583878a758b882d5e0a972f082b0b8429400792763e22901f0412474e46854371963c414d09116802935b1b58949f0d146d01551e57277b541c1766787d8660732a67482079623877336f99196c312c3d162e0f4b513f8142450e059a741d597c23069c699e8c135f53809b390c50034464653b3a619d637f5a8d89321a5c6e9552002582342898
+          default: 0x111e1d25773743872e29390f513a910112627b524e484f7a706e8d5b69736f6857072d09827c2c713c801b7f4c96909879323f1c2766846d9e8586409c31444928422697617d4d108b955c9a928a176b58835d145f05740a889b412065728c9922896460083335190e2f0b75157e5a1a4b93530d036c8f0c56139d0204348e54503d946324812145467659675518473b2a38004a5e16361f6a30069f782b3e23
           randwidth: 1280
         }
       ]
@@ -7533,7 +7533,7 @@
           randcount: 288
           randtype: data
           name_top: RndCnstKmacLfsrSeed
-          default: 0xd58dc810dd8eb1225d79f3ec320bb4d2d4692b1f9d1645f037d9dc83e4b7b7d0e5638801
+          default: 0xe6aef30d8577834ccc6caaa63a8e6604338151b9a23c08f9eed04ca1ebb0bdd305ffb6c4
           randwidth: 288
         }
         {
@@ -7543,7 +7543,7 @@
           randcount: 800
           randtype: perm
           name_top: RndCnstKmacLfsrPerm
-          default: 0xc75c2a171038e805291da85db7ed8e8aaaf49e5d2515b5eda1a9a3cbc41852d1146c5e481bb54af80463e0cd78b8b1f84c97222d9533022aaf44494db94418feb56c610b1d15831aac2d0c3beb7189341e475ac45cb7cce2cad3c72cf378500ac8c5c2bd60642b406e90d5590575068921c435aa973748193b86d5fa111c2b890143b590a19c434e30d682273a1f2264950be4a7aca887e8f826835197f9729f45a958dcbfba5a3a60fe36cdd8163860db8a64542b5a505dca164651a1657116c26c762a6c3c46ef3aa0f04da95595e0b8639d40bb35c04881fae71b27250341843b0f91af1e7f0d4aa28da29ce7723196d860b67871c2264b09180245459b4f226bf8b3afcdf3f2d29609fab84864ee37515815ea49bd9ca6976609de6be64086761cb1a6657a3e0a5888b7c39efa4825506f5b98f40e11f0d8a49a87b8b6a92108e6cb0f035f72404b10006a3a3d82c6967a9da40491363a1149316c476b64992e299fdb5144dac05352e47aacc272d67a079260c9c8112bb7a9fd9c26c23d4579d1ca8e36af9181fd397a64769055be831bdef259997c31da92296746b043e0361c5d3319fa9d3d63c741f90b57652399b67da0e009e21b31438a3570d6487a0db1a7d360660ec982aeb41bc61056ed0dcaf3e8c855ed44b5ff7e8ed0f17488d599dc821681281c20c566eb82d16285f7867131906420bc5cb059f9cbc480fa2d40719cd5f273b1536a1ec186c4c97e8163272656ec676252baab86ae744dcca70033ca190ea794ddd69a6978a196af0b853a74a800539046ba14fb61097943d1aa2f6e971c5cd77b429798524b1d8b7168c0c4f40c421f16928e5a5dc8a9ae66bfcf35690028560289895bd3f65206a11f96894202b042c0b4336146c27c542e4c66086a014a0a8634d2b2252522c862794798ab261667bcdae634fd0fcf1c59d5099cf551b92ed2e4cc7719123c62c249224932348c9bf32967ae823b297d01ea2275c5139620c0538119a4c42a4a8c278d5c939615ae0076590a6d0232df51f5df6224d4a16ac2904485f3b266da20fb38294918a63551974c1c8840c317067a2da646f0bb8e1a2700436ac6f481b78013dafc159c121c9675c042812906edb9841d8ec8357d01baac8202f9c4e7b022c080ad79a12fab6c454c3497aeb025be46930520be450d2c22188b9e0366e18c16e950e73ddee85ad547a91994dc394ff5b65662c8db31440a0a7128cfa4c851629e791f1848c385df0c1c3e442cb94e44245496f000a32155e5ab876ce699d095e4f3c1b4ad839344eb91660882553d563311073022b7b0ba8709a2b1328b0782c5ac04105038d6bda39662fb98d0e72659a942c804e945c734ed3a829f405a516dcc76ce332d8c17f9a7b76fd775f84f980324bd
+          default: 0x8b5f6c52e176ecc9267e5e0b16556f958b3580876599d178e1bb8d00e2fd8db1c756adacf0a2671a1a247312d321189b52e29d477782d15d6295a4a04d428c068711da643416b6e8ab69c55f555baa79be17c0c66f3d57e80a25a3d8bb807d4652d1331d229686e41e23140886d9ae88852e0771ec0a452352814718722ac326328274a00c20bf53a4215459125df3b45273d4dac433371271cc25822f57a30e349b0c5efe15f0f759d03e5f134db6b203a994cb28a0c8defc3fc09278fe09c8d6fd0e5592f402c7318c17ae9ebe9f99aa7d5d92c78a9041a8b771d98e67f94f061a6e56f0c3ae1229ce8e93dd313e9c139ac03decbd26db611f97ac38d6845c47fb199e4c4d89822606820054ca61c2d5e8801904ab9d63415933de782ea0e5186c5aef957840a24e92f60d871d13091a604ad609c31442a12cc5246961e4981f2e497ea40fd090acae852a1aa012c671e2489c5dd4594603b5c0d17e3235e2c11011c27123b81826de5844675605620f11721e6c36ecc5a2ab58ec455ad3c699c2f150180c4aee93cd525c9bb28eb92e6dca0c8b0f8a1bae011f8d119a1732630321af681b496cddad57450c8133304aca882f8b5462f33566b1aa5d7c2bf6c97b82557268da4a1251e9ba82a503da130d076215d41b6cf9a1ee5719a66cdb4813ab556c648e44dd33998ef8c4f24a80e00460000afab0a7990e2985020c1ca4406188aa04e413a5effab9c94d197840d69011b735e76ad90430c06a1c2b8d1d011fc9ee3d33b0c7862759285175a553d0445e4c47111964086029ab296a074b73a1cb1221b970ac3802fb356719562bc437879366a42491132a98b41c150aad1229886761a31c4fb292180723c8bef038ed29a5ed6844d90c41ad99c923077d1cc58671adc9f10e286aa2ea32742540a140e7abe418d2152db186202e51dfd8fa382ee701ad24ba0aa8748f1d40b88d3f6c5707028d69e462c0fc4055d962bb1609492d99188f03eadda04bc0e58ebc81f7dc297eb1bbbca5880e6619796cea305cde84afb7907baf6952406f9dcfd5b5089f0eab7d9f4e1d7bd82125a98b7aa5b396e9e8df7edf5869420d5488e929bdee682c034f272118c7512056f90a650930650b530d46ba764ecb2b24022a20f25ca9226a7b0526a01662757f3e0536d58d1b8107c83d41f0343c23b422498d98569510d8d99505c4f82660e939b1f8459419151e645a41531f938058fe4daaa1f5962bc0949779e94c15f6de677747473a3b7cd1301ce5b2c5aaf845aa4cf0895bbb43b06db868a865ce5716d842e2b0a5262a6c429683c20985c4313af1c476a4ac1514564637bceb8102c85b007aac463dbd3369d9b92e7fa55a4921551ffad13d706523d1e31e23323a19a8ac5a7d8a40ec254e06
           randwidth: 8000
         }
         {
@@ -7553,7 +7553,7 @@
           randcount: 800
           randtype: data
           name_top: RndCnstKmacBufferLfsrSeed
-          default: 0x75e7b1209b868a4acd919ed9795d5f519aa8cd47ac68b65650a1bb5a4a6dbf0bc7c1c7af8402bacd250ed8960c88b4b17ea9867b47ae9a95aaf96dbe43a4472dc0c72f2488d40ccad7575333e5e48f00bbc1f91e5eea7ad029c213141ee86e77b99bf0a1
+          default: 0x3b07e9bf4ee42784136d42c85e456f3b26d15f5584bb9879bd2497852c23d0fa289c3348ce364ed534970e1fd45ec606be134fc08318bd29b22b08df647bdc30068e7513200fa828bfee3eccf02417fa68d004534267f60b34a8f072e77ee4859b243f92
           randwidth: 800
         }
         {
@@ -7563,7 +7563,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstKmacMsgPerm
-          default: 0xf24f6a4181572048be494e1dfe16a8b0f4d50f76eb9b20315b4a73076b7b6609ce3422b92fa723c1e25118c1e5b9fd6f
+          default: 0x4ddacc9daffeca104f3baf62617a4a90d1507b1807a3644b23b546b77f0901472a8f40ee7f5125e780925b065bbe6b33
           randwidth: 384
         }
       ]
@@ -7757,7 +7757,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstOtbnUrndPrngSeed
-          default: 0x3ca72c2242223ce6d70f17b4f4b32818aa49d125b4defb1f3c0be8a29be065c2
+          default: 0x627a281c5681d6566641eecccc88876ad113c50ad1be4d94dce8fca54128a386
           randwidth: 256
         }
         {
@@ -7795,7 +7795,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstOtbnOtbnKey
-          default: 0x6d23550bbc139ff6461763d7e966a8a7
+          default: 0xae1d3493fbef6b9ba5dfe4463a4615e
           randwidth: 128
         }
         {
@@ -7805,7 +7805,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstOtbnOtbnNonce
-          default: 0x219eb2e8ef9f11a1
+          default: 0xf46762a794a8c259
           randwidth: 64
         }
       ]
@@ -8040,7 +8040,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstKeymgrLfsrSeed
-          default: 0x52e6c71aa23b8864
+          default: 0x7e69fb259b961914
           randwidth: 64
         }
         {
@@ -8050,7 +8050,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstKeymgrLfsrPerm
-          default: 0x4bbde0996949e0fa88cad4ec5cb570ff508dafd933f05e5a65f507bee70e0712a3a76d2119889113a7be9cca000dd6d0
+          default: 0x661c843bba36fa2f30bc14078e6b45c58b1bfdc94f03a1912d7a4229620c92baa7dd44c969e0d5e357f48394bd36e773
           randwidth: 384
         }
         {
@@ -8060,7 +8060,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstKeymgrRandPerm
-          default: 0x6c74abd4c4b30fdc0fe8d84b302f22a41fee49c9
+          default: 0x165cb816b3c6a20e6c6622a96f33ed3f5e995c28
           randwidth: 160
         }
         {
@@ -8070,7 +8070,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrRevisionSeed
-          default: 0x2ccd155d84fdaced736e93362c8da83c5f4dd2093e4d2a70dd99dcf4ccac341a
+          default: 0xa52226b6a4a7bdb05fe921615bf2ff984540f7d43ece76b4eb13363774ed2ed4
           randwidth: 256
         }
         {
@@ -8080,7 +8080,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrCreatorIdentitySeed
-          default: 0x2f1a2704f5e21287fa168af251b370d034cda605152662f4d11b3245d5943ea5
+          default: 0x5545e927f6d9e4abac398d42c745eef646c1464dca86dafd7c7c71e6058ddfd8
           randwidth: 256
         }
         {
@@ -8090,7 +8090,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrOwnerIntIdentitySeed
-          default: 0xfd2e4bea016b7911deaf01df742547371445d6e3955145e3074d9ca9e8a4ef06
+          default: 0x71c51cacbaf4410f06dcc036fcd16fcde97d171891105dd895e3a1d0a19a16d6
           randwidth: 256
         }
         {
@@ -8100,7 +8100,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrOwnerIdentitySeed
-          default: 0xa6f14a5c8fcac0d6396e606a620a9ffb23756bda420a9e7bd1a7c41e3a37b747
+          default: 0xdbd8b20fc9e662e1e1b4982b3e8eff63890dbeae926fd468a77efde3de5b4caf
           randwidth: 256
         }
         {
@@ -8110,7 +8110,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrSoftOutputSeed
-          default: 0xd3d7b758b37d1d1ca19a079c48d7d4e67100a6aaebe45b6f09aefb72895ec90d
+          default: 0x4776a247baba4c9908ed16bc5415ec16d28c53551312fcedcf2832a66ceacf8e
           randwidth: 256
         }
         {
@@ -8120,7 +8120,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrHardOutputSeed
-          default: 0x876315db9ad8bbe63ecace31278da3acfc873ec5a22829bd781efe2b4b06f4b3
+          default: 0xd4d5b616177dd43b56fa754e1f53ad658193b563d9bdc6d2aee84852f0cc7371
           randwidth: 256
         }
         {
@@ -8130,7 +8130,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrAesSeed
-          default: 0x49e0372b7394d415d937f3578cc1200dd1fb1d0ecf948594bc831c3e0e1f33c9
+          default: 0xed3a6faa516c144b34c96dfabb6f6e79208a74f35c79f397c4e4c7e22b758184
           randwidth: 256
         }
         {
@@ -8140,7 +8140,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrKmacSeed
-          default: 0x98cabd61dac609b5dd0e0c602aef2e932b1fb8fb631dd82de6c9adde7bfb79fb
+          default: 0x8a90a1254b2276bec9fc1a7a5722a9aaca4db84a32e5c6985a1a6435118b5f5f
           randwidth: 256
         }
         {
@@ -8150,7 +8150,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrOtbnSeed
-          default: 0x9cc4c0b2d1aed6700a44ea3e7e0610a663d52b082b9aef0e426df4866fe88a8b
+          default: 0x3fd3b9313116b67192d856dd742d40e072e417ad9a5f261204cbcc69a2147819
           randwidth: 256
         }
         {
@@ -8160,7 +8160,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrCdi
-          default: 0xaa3b3b2f5e3917a7a7d4b5e53c38b3cedc40946cf3635f0c112f435205ef40d4
+          default: 0xb290a4bb0264347c0f91b0cec93c0129d85b95801dbe03f17e69dc260a79998e
           randwidth: 256
         }
         {
@@ -8170,7 +8170,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrNoneSeed
-          default: 0xb50cbd86b4932d75cebe7060738efa2035418082cfe96e5cc1280fbe2f2e3236
+          default: 0xff5c710b67838adfb99a5eca671672cf19bca6adc1ebfab611f19e7262e0a491
           randwidth: 256
         }
       ]
@@ -8384,7 +8384,7 @@
           randcount: 384
           randtype: data
           name_top: RndCnstCsrngCsKeymgrDivNonProduction
-          default: 0x88bcc7ecbb1a7db7be4ccaf27d6eb83fd28156d9cb50075d6af437bebb1d8879e25723b9d533238865874ef2d375583c
+          default: 0x970e51b28e7026d0e5dce9e265a416a812231cfa76e3d982f8fdcec9ae1af0b8cd9e17606ec981060e94795a1d573089
           randwidth: 384
         }
         {
@@ -8394,7 +8394,7 @@
           randcount: 384
           randtype: data
           name_top: RndCnstCsrngCsKeymgrDivProduction
-          default: 0x209c027d35c5794f680b124893c22e6a22f5ad2e7591ecad6cca220de3c0051a862508d4ce0015f9376719bd15980c9e
+          default: 0x578c104a36a647e90ffaff9760f5e838bd8e2413ab956b106ca7139a07effee457dee82b6e06663c291739ff0e7d6447
           randwidth: 384
         }
         {
@@ -9095,7 +9095,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramKey
-          default: 0x525dcbc7a2e75c94580bc5da0a20865a
+          default: 0x58fee1c58564cf346d9622e537109136
           randwidth: 128
         }
         {
@@ -9105,7 +9105,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramNonce
-          default: 0x9b36b012f2546ea845a7ade1002b84b7
+          default: 0x6efbd61b0cb470b944ef806e573b44b6
           randwidth: 128
         }
         {
@@ -9115,7 +9115,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstSramCtrlMainLfsrSeed
-          default: 0x39380023c25c3dea
+          default: 0x43ebf0c5de019fc0
           randwidth: 64
         }
         {
@@ -9125,7 +9125,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstSramCtrlMainLfsrPerm
-          default: 0x5c16b58efd74310e6cb4648037d4969e379ce946fa13f676ca49d1eaba2b24fb07c256582de3adbb30b60450f1a18fc
+          default: 0xb99612d278f8a9759da4322bf1f55305b821cef680db5dc7170b2d94610b7b2a0f38a08c24defde7afd04648949bec5c
           randwidth: 384
         }
         {
@@ -9434,7 +9434,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstRomCtrlScrNonce
-          default: 0x86282b72c315dc48
+          default: 0x356888ae5343dd78
           randwidth: 64
         }
         {
@@ -9444,7 +9444,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstRomCtrlScrKey
-          default: 0x76f6acfa65e2f3fff25369dff7245670
+          default: 0x4cba5bebbe2a6ead062d9516fdd8b110
           randwidth: 128
         }
         {
@@ -9653,7 +9653,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstRvCoreIbexLfsrSeed
-          default: 0x4342d7cd
+          default: 0x861a797c
           randwidth: 32
         }
         {
@@ -9663,7 +9663,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstRvCoreIbexLfsrPerm
-          default: 0x8a44441e74cc34a083fb359f5e5fb8933c56adc3
+          default: 0xae8d23a0970e7624b55c64ddd5bfdf1c70505216
           randwidth: 160
         }
         {
@@ -9673,7 +9673,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstRvCoreIbexIbexKeyDefault
-          default: 0xa6bfbfb2eb0038e80868a59e9dd11bbf
+          default: 0x1c67f59cba5482c1e35e6e3335c20cc7
           randwidth: 128
         }
         {
@@ -9683,7 +9683,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstRvCoreIbexIbexNonceDefault
-          default: 0x7449121cdefc0bd7
+          default: 0x78fc309917b9c870
           randwidth: 64
         }
         {

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
@@ -18,17 +18,17 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter otp_ctrl_top_specific_pkg::lfsr_seed_t RndCnstOtpCtrlLfsrSeed = {
-    40'h4F_64CE9783
+    40'h30_9A163990
   };
 
   // Compile-time random permutation for LFSR output
   parameter otp_ctrl_top_specific_pkg::lfsr_perm_t RndCnstOtpCtrlLfsrPerm = {
-    240'h30E2_CD723991_58391075_36995C51_1E9E57E0_0A285B28_F0151D42_58206481
+    240'h28C1_C838F5E3_01069D05_379551C1_8598359F_90408D60_B6C98A78_60951499
   };
 
   // Compile-time random permutation for scrambling key/nonce register reset value
   parameter otp_ctrl_top_specific_pkg::scrmbl_key_init_t RndCnstOtpCtrlScrmblKeyInit = {
-    256'h7468BC0B_D8D70368_E7CFB11A_99675B14_62406193_35A9E2D1_23834D18_744778BE
+    256'h21DD4C0A_C2406D46_7215DAB3_F2B54A52_E6728678_AF071806_8E344D2E_AE4D73C8
   };
 
   ////////////////////////////////////////////
@@ -36,35 +36,35 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Diversification value used for all invalid life cycle states.
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivInvalid = {
-    128'h5E63C087_E36838B5_6B1A45F6_FD312F53
+    128'hFA54DE8A_A4A4F258_F3B2A145_FD1950AE
   };
 
   // Diversification value used for the TEST_UNLOCKED* life cycle states.
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivTestUnlocked = {
-    128'h53FA7B2C_E9FC83DD_AF1DD8C5_A42E2AD2
+    128'h55D693E5_7968117E_66DC6341_55E0F815
   };
 
   // Diversification value used for the DEV life cycle state.
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivDev = {
-    128'h4FA02221_B6FF5AAD_7A9C09D5_D9FDD1CF
+    128'h0242862E_B20EEA9A_1F754471_6551512A
   };
 
   // Diversification value used for the PROD/PROD_END life cycle states.
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivProduction = {
-    128'hCF512835_C0CFAE2E_D0C69FA4_88685CEA
+    128'h112DED67_8CE824A0_8E29C772_795A358E
   };
 
   // Diversification value used for the RMA life cycle state.
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivRma = {
-    128'h9BC1C89B_FB7399AE_F5C6EB5D_6E4E2341
+    128'hC30F1BED_D1AF0EC9_D9A9CF36_A2B130D3
   };
 
   // Compile-time random bits used for invalid tokens in the token mux
   parameter lc_ctrl_pkg::lc_token_mux_t RndCnstLcCtrlInvalidTokens = {
-    256'h6A0AA6D7_AC7EC9C3_304470FB_E505F964_9400CA98_64FD4CE4_9D2CFC6E_CC102540,
-    256'hEAD87347_00A52071_32689471_AA822BC5_1CDD4D37_AC2D246C_4264F37E_C1982017,
-    256'h94ADDA1B_16929DF5_E06A56AA_DED44325_9FFB5736_DD680121_5B98E162_DCC09E31,
-    256'hE8382E46_E4FECFDA_2375A614_7421D8CB_69D4F3A1_5FAF834C_AD515D76_BD37C7BE
+    256'h2AFE121A_F734F628_363AAA0E_93D45C42_3690ED05_BD1E710F_22D10958_89FBD8A7,
+    256'hB57FB1E1_1DF367C1_C1EDE3F3_5CFC8F6E_72ABDD73_A9EEFBF8_B7081EB9_F636E13C,
+    256'hA9D21F1E_DEBE60A2_2DB6D398_D4A21B73_699E8082_0434A1DC_D0488805_541166F1,
+    256'hEC8CEB42_692B089A_6F99B1A7_AC084224_ADE46129_80D48E6C_6493A50E_EDBAC6A4
   };
 
   ////////////////////////////////////////////
@@ -72,12 +72,12 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter alert_handler_pkg::lfsr_seed_t RndCnstAlertHandlerLfsrSeed = {
-    32'hC5F33FDC
+    32'h6B7A8A9B
   };
 
   // Compile-time random permutation for LFSR output
   parameter alert_handler_pkg::lfsr_perm_t RndCnstAlertHandlerLfsrPerm = {
-    160'hC65720DC_8F9A845F_6A1C6251_6AB63D39_BE0DB874
+    160'h1119AA85_6EBB4C0F_2B7FB521_91F3078A_133975E5
   };
 
   ////////////////////////////////////////////
@@ -85,23 +85,23 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlRetAonSramKey = {
-    128'h4B6A0CD0_66336E9B_0BDF6A55_F0D23BB7
+    128'h521D4711_E6406690_8ADFD591_8F8C563C
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlRetAonSramNonce = {
-    128'hDC0DC524_D3B05546_03562188_552794DD
+    128'h92184F1C_76A61E11_2578BF9F_469FC482
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter sram_ctrl_pkg::lfsr_seed_t RndCnstSramCtrlRetAonLfsrSeed = {
-    64'h2BEBF67F_318B5A49
+    64'hFA14A8F2_B75C265C
   };
 
   // Compile-time random permutation for LFSR output
   parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlRetAonLfsrPerm = {
-    128'hE4E6D896_C3E8066E_D32909F0_49E11DA6,
-    256'hBC488997_F75A101A_F179382F_2D7F147B_7A08672F_D2344DCE_026A53E3_2EDBD543
+    128'hE758C46B_DDBBFD06_1F0C9C91_762BB71F,
+    256'h420D2A6A_54AD959B_32500F39_7B55CDE0_85BFAC38_A242E018_14EA85C4_B1F3EB27
   };
 
   ////////////////////////////////////////////
@@ -109,28 +109,28 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for default address key
   parameter flash_ctrl_pkg::flash_key_t RndCnstFlashCtrlAddrKey = {
-    128'hF0EF4782_48447B11_42087365_0CBC6AEE
+    128'hF6037B9D_ACA18EB5_801C444E_BC53EC27
   };
 
   // Compile-time random bits for default data key
   parameter flash_ctrl_pkg::flash_key_t RndCnstFlashCtrlDataKey = {
-    128'hA2C8EE2D_E417E3D0_5D145C3A_684922F7
+    128'hF13EB602_172C4D95_0331BEBA_D605BB69
   };
 
   // Compile-time random bits for default seeds
   parameter flash_ctrl_top_specific_pkg::all_seeds_t RndCnstFlashCtrlAllSeeds = {
-    256'hDC57CC66_8C58F099_531A3221_A2EDDCA4_1F778DDE_61DE9734_B7ECDEC5_17110ED2,
-    256'hCEB31D78_9F996BCD_43BA4FB0_6B9EA47D_BF441AA6_25F5DDF2_DCB03C2B_867024D5
+    256'h6BE7A52B_9A29E3C8_71EE416D_C904583D_F8BAE9C4_6DEE80A8_69A1CE14_C113994C,
+    256'hF87EDA86_140651AC_88EB62E8_34AA3425_C620C68C_E20120A0_D95CE4EE_55B032C0
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter flash_ctrl_top_specific_pkg::lfsr_seed_t RndCnstFlashCtrlLfsrSeed = {
-    32'h4654C6E6
+    32'h7A29B920
   };
 
   // Compile-time random permutation for LFSR output
   parameter flash_ctrl_top_specific_pkg::lfsr_perm_t RndCnstFlashCtrlLfsrPerm = {
-    160'h50FC8F9F_B826E306_841C34ED_A63A45A5_D79155E9
+    160'h076F3C6F_C3CD20A7_9A3F6234_EE05A515_48B49E56
   };
 
   ////////////////////////////////////////////
@@ -138,34 +138,34 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for register clearing.
   parameter aes_pkg::clearing_lfsr_seed_t RndCnstAesClearingLfsrSeed = {
-    64'hD00B7E75_6F81353C
+    64'h3BEAFE83_89E9F8AC
   };
 
   // Permutation applied to the LFSR of the PRNG used for clearing.
   parameter aes_pkg::clearing_lfsr_perm_t RndCnstAesClearingLfsrPerm = {
-    128'h530A34A8_127F92F0_C6D8BB5C_8C7E515B,
-    256'hDED97579_5FEA686C_3B5BB317_EC7C4A95_4841B013_DCF8028B_263828D7_A768CAC4
+    128'h73039AA6_E7C86E04_990ABA3E_A860739D,
+    256'h8353C50C_87863783_D2230AF1_7DBF55D9_91D40DC9_938EF92E_C97AF541_163EFB45
   };
 
   // Permutation applied to the clearing PRNG output for clearing the second share of registers.
   parameter aes_pkg::clearing_lfsr_perm_t RndCnstAesClearingSharePerm = {
-    128'h8AC7AA1A_9FC8115F_247475A6_FB7C4F2A,
-    256'h0ACD7359_6FB7AC97_B9315A27_051BF408_D0042851_6730CBE6_8E1F4B66_0E9FBD0C
+    128'h3DBB3322_BB83FE5E_2253DC86_78E62045,
+    256'h268B14A0_294DC0A3_116D2692_A9F9EF15_ED04935D_FB0DFA87_532FD954_19A1FF07
   };
 
   // Default seed of the PRNG used for masking.
   parameter aes_pkg::masking_lfsr_seed_t RndCnstAesMaskingLfsrSeed = {
-    32'h51A50AC3,
-    256'h12C18282_2CF6AD12_452480A6_1092E8A8_0CDF2678_89E06A8A_1AB5F6DB_8158AA7C
+    32'h8A468D23,
+    256'hEECBD09D_E6B8F9FA_EAF1A70E_57E8EDA0_3A353B76_A2F83350_9ACC7B3A_A3FA7DAC
   };
 
   // Permutation applied to the output of the PRNG used for masking.
   parameter aes_pkg::masking_lfsr_perm_t RndCnstAesMaskingLfsrPerm = {
-    256'h377A4A72_7E8F3570_24262156_918E494C_104F305D_366B186A_1583878A_758B882D,
-    256'h5E0A972F_082B0B84_29400792_763E2290_1F041247_4E468543_71963C41_4D091168,
-    256'h02935B1B_58949F0D_146D0155_1E57277B_541C1766_787D8660_732A6748_20796238,
-    256'h77336F99_196C312C_3D162E0F_4B513F81_42450E05_9A741D59_7C23069C_699E8C13,
-    256'h5F53809B_390C5003_4464653B_3A619D63_7F5A8D89_321A5C6E_95520025_82342898
+    256'h111E1D25_77374387_2E29390F_513A9101_12627B52_4E484F7A_706E8D5B_69736F68,
+    256'h57072D09_827C2C71_3C801B7F_4C969098_79323F1C_2766846D_9E858640_9C314449,
+    256'h28422697_617D4D10_8B955C9A_928A176B_58835D14_5F05740A_889B4120_65728C99,
+    256'h22896460_08333519_0E2F0B75_157E5A1A_4B93530D_036C8F0C_56139D02_04348E54,
+    256'h503D9463_24812145_46765967_5518473B_2A38004A_5E16361F_6A30069F_782B3E23
   };
 
   ////////////////////////////////////////////
@@ -173,58 +173,58 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random data for PRNG default seed
   parameter kmac_pkg::lfsr_seed_t RndCnstKmacLfsrSeed = {
-    32'hD58DC810,
-    256'hDD8EB122_5D79F3EC_320BB4D2_D4692B1F_9D1645F0_37D9DC83_E4B7B7D0_E5638801
+    32'hE6AEF30D,
+    256'h8577834C_CC6CAAA6_3A8E6604_338151B9_A23C08F9_EED04CA1_EBB0BDD3_05FFB6C4
   };
 
   // Compile-time random permutation for PRNG output
   parameter kmac_pkg::lfsr_perm_t RndCnstKmacLfsrPerm = {
-    64'hC75C2A17_1038E805,
-    256'h291DA85D_B7ED8E8A_AAF49E5D_2515B5ED_A1A9A3CB_C41852D1_146C5E48_1BB54AF8,
-    256'h0463E0CD_78B8B1F8_4C97222D_9533022A_AF44494D_B94418FE_B56C610B_1D15831A,
-    256'hAC2D0C3B_EB718934_1E475AC4_5CB7CCE2_CAD3C72C_F378500A_C8C5C2BD_60642B40,
-    256'h6E90D559_05750689_21C435AA_97374819_3B86D5FA_111C2B89_0143B590_A19C434E,
-    256'h30D68227_3A1F2264_950BE4A7_ACA887E8_F8268351_97F9729F_45A958DC_BFBA5A3A,
-    256'h60FE36CD_D8163860_DB8A6454_2B5A505D_CA164651_A1657116_C26C762A_6C3C46EF,
-    256'h3AA0F04D_A95595E0_B8639D40_BB35C048_81FAE71B_27250341_843B0F91_AF1E7F0D,
-    256'h4AA28DA2_9CE77231_96D860B6_7871C226_4B091802_45459B4F_226BF8B3_AFCDF3F2,
-    256'hD29609FA_B84864EE_37515815_EA49BD9C_A6976609_DE6BE640_86761CB1_A6657A3E,
-    256'h0A5888B7_C39EFA48_25506F5B_98F40E11_F0D8A49A_87B8B6A9_2108E6CB_0F035F72,
-    256'h404B1000_6A3A3D82_C6967A9D_A4049136_3A114931_6C476B64_992E299F_DB5144DA,
-    256'hC05352E4_7AACC272_D67A0792_60C9C811_2BB7A9FD_9C26C23D_4579D1CA_8E36AF91,
-    256'h81FD397A_64769055_BE831BDE_F259997C_31DA9229_6746B043_E0361C5D_3319FA9D,
-    256'h3D63C741_F90B5765_2399B67D_A0E009E2_1B31438A_3570D648_7A0DB1A7_D360660E,
-    256'hC982AEB4_1BC61056_ED0DCAF3_E8C855ED_44B5FF7E_8ED0F174_88D599DC_82168128,
-    256'h1C20C566_EB82D162_85F78671_31906420_BC5CB059_F9CBC480_FA2D4071_9CD5F273,
-    256'hB1536A1E_C186C4C9_7E816327_2656EC67_6252BAAB_86AE744D_CCA70033_CA190EA7,
-    256'h94DDD69A_6978A196_AF0B853A_74A80053_9046BA14_FB610979_43D1AA2F_6E971C5C,
-    256'hD77B4297_98524B1D_8B7168C0_C4F40C42_1F16928E_5A5DC8A9_AE66BFCF_35690028,
-    256'h56028989_5BD3F652_06A11F96_894202B0_42C0B433_6146C27C_542E4C66_086A014A,
-    256'h0A8634D2_B2252522_C8627947_98AB2616_67BCDAE6_34FD0FCF_1C59D509_9CF551B9,
-    256'h2ED2E4CC_7719123C_62C24922_4932348C_9BF32967_AE823B29_7D01EA22_75C51396,
-    256'h20C05381_19A4C42A_4A8C278D_5C939615_AE007659_0A6D0232_DF51F5DF_6224D4A1,
-    256'h6AC29044_85F3B266_DA20FB38_294918A6_3551974C_1C8840C3_17067A2D_A646F0BB,
-    256'h8E1A2700_436AC6F4_81B78013_DAFC159C_121C9675_C0428129_06EDB984_1D8EC835,
-    256'h7D01BAAC_8202F9C4_E7B022C0_80AD79A1_2FAB6C45_4C3497AE_B025BE46_930520BE,
-    256'h450D2C22_188B9E03_66E18C16_E950E73D_DEE85AD5_47A91994_DC394FF5_B65662C8,
-    256'hDB31440A_0A7128CF_A4C85162_9E791F18_48C385DF_0C1C3E44_2CB94E44_245496F0,
-    256'h00A32155_E5AB876C_E699D095_E4F3C1B4_AD839344_EB916608_82553D56_33110730,
-    256'h22B7B0BA_8709A2B1_328B0782_C5AC0410_5038D6BD_A39662FB_98D0E726_59A942C8,
-    256'h04E945C7_34ED3A82_9F405A51_6DCC76CE_332D8C17_F9A7B76F_D775F84F_980324BD
+    64'h8B5F6C52_E176ECC9,
+    256'h267E5E0B_16556F95_8B358087_6599D178_E1BB8D00_E2FD8DB1_C756ADAC_F0A2671A,
+    256'h1A247312_D321189B_52E29D47_7782D15D_6295A4A0_4D428C06_8711DA64_3416B6E8,
+    256'hAB69C55F_555BAA79_BE17C0C6_6F3D57E8_0A25A3D8_BB807D46_52D1331D_229686E4,
+    256'h1E231408_86D9AE88_852E0771_EC0A4523_52814718_722AC326_328274A0_0C20BF53,
+    256'hA4215459_125DF3B4_5273D4DA_C4333712_71CC2582_2F57A30E_349B0C5E_FE15F0F7,
+    256'h59D03E5F_134DB6B2_03A994CB_28A0C8DE_FC3FC092_78FE09C8_D6FD0E55_92F402C7,
+    256'h318C17AE_9EBE9F99_AA7D5D92_C78A9041_A8B771D9_8E67F94F_061A6E56_F0C3AE12,
+    256'h29CE8E93_DD313E9C_139AC03D_ECBD26DB_611F97AC_38D6845C_47FB199E_4C4D8982,
+    256'h26068200_54CA61C2_D5E88019_04AB9D63_415933DE_782EA0E5_186C5AEF_957840A2,
+    256'h4E92F60D_871D1309_1A604AD6_09C31442_A12CC524_6961E498_1F2E497E_A40FD090,
+    256'hACAE852A_1AA012C6_71E2489C_5DD45946_03B5C0D1_7E3235E2_C11011C2_7123B818,
+    256'h26DE5844_67560562_0F11721E_6C36ECC5_A2AB58EC_455AD3C6_99C2F150_180C4AEE,
+    256'h93CD525C_9BB28EB9_2E6DCA0C_8B0F8A1B_AE011F8D_119A1732_630321AF_681B496C,
+    256'hDDAD5745_0C813330_4ACA882F_8B5462F3_3566B1AA_5D7C2BF6_C97B8255_7268DA4A,
+    256'h1251E9BA_82A503DA_130D0762_15D41B6C_F9A1EE57_19A66CDB_4813AB55_6C648E44,
+    256'hDD33998E_F8C4F24A_80E00460_000AFAB0_A7990E29_85020C1C_A4406188_AA04E413,
+    256'hA5EFFAB9_C94D1978_40D69011_B735E76A_D90430C0_6A1C2B8D_1D011FC9_EE3D33B0,
+    256'hC7862759_285175A5_53D0445E_4C471119_64086029_AB296A07_4B73A1CB_1221B970,
+    256'hAC3802FB_35671956_2BC43787_9366A424_91132A98_B41C150A_AD122988_6761A31C,
+    256'h4FB29218_0723C8BE_F038ED29_A5ED6844_D90C41AD_99C92307_7D1CC586_71ADC9F1,
+    256'h0E286AA2_EA327425_40A140E7_ABE418D2_152DB186_202E51DF_D8FA382E_E701AD24,
+    256'hBA0AA874_8F1D40B8_8D3F6C57_07028D69_E462C0FC_4055D962_BB160949_2D99188F,
+    256'h03EADDA0_4BC0E58E_BC81F7DC_297EB1BB_BCA5880E_6619796C_EA305CDE_84AFB790,
+    256'h7BAF6952_406F9DCF_D5B5089F_0EAB7D9F_4E1D7BD8_2125A98B_7AA5B396_E9E8DF7E,
+    256'hDF586942_0D5488E9_29BDEE68_2C034F27_2118C751_2056F90A_65093065_0B530D46,
+    256'hBA764ECB_2B24022A_20F25CA9_226A7B05_26A01662_757F3E05_36D58D1B_8107C83D,
+    256'h41F0343C_23B42249_8D985695_10D8D995_05C4F826_60E939B1_F8459419_151E645A,
+    256'h41531F93_8058FE4D_AAA1F596_2BC09497_79E94C15_F6DE6777_47473A3B_7CD1301C,
+    256'hE5B2C5AA_F845AA4C_F0895BBB_43B06DB8_68A865CE_5716D842_E2B0A526_2A6C4296,
+    256'h83C20985_C4313AF1_C476A4AC_15145646_37BCEB81_02C85B00_7AAC463D_BD3369D9,
+    256'hB92E7FA5_5A492155_1FFAD13D_706523D1_E31E2332_3A19A8AC_5A7D8A40_EC254E06
   };
 
   // Compile-time random data for PRNG buffer default seed
   parameter kmac_pkg::buffer_lfsr_seed_t RndCnstKmacBufferLfsrSeed = {
-    32'h75E7B120,
-    256'h9B868A4A_CD919ED9_795D5F51_9AA8CD47_AC68B656_50A1BB5A_4A6DBF0B_C7C1C7AF,
-    256'h8402BACD_250ED896_0C88B4B1_7EA9867B_47AE9A95_AAF96DBE_43A4472D_C0C72F24,
-    256'h88D40CCA_D7575333_E5E48F00_BBC1F91E_5EEA7AD0_29C21314_1EE86E77_B99BF0A1
+    32'h3B07E9BF,
+    256'h4EE42784_136D42C8_5E456F3B_26D15F55_84BB9879_BD249785_2C23D0FA_289C3348,
+    256'hCE364ED5_34970E1F_D45EC606_BE134FC0_8318BD29_B22B08DF_647BDC30_068E7513,
+    256'h200FA828_BFEE3ECC_F02417FA_68D00453_4267F60B_34A8F072_E77EE485_9B243F92
   };
 
   // Compile-time random permutation for LFSR Message output
   parameter kmac_pkg::msg_perm_t RndCnstKmacMsgPerm = {
-    128'hF24F6A41_81572048_BE494E1D_FE16A8B0,
-    256'hF4D50F76_EB9B2031_5B4A7307_6B7B6609_CE3422B9_2FA723C1_E25118C1_E5B9FD6F
+    128'h4DDACC9D_AFFECA10_4F3BAF62_617A4A90,
+    256'hD1507B18_07A3644B_23B546B7_7F090147_2A8F40EE_7F5125E7_80925B06_5BBE6B33
   };
 
   ////////////////////////////////////////////
@@ -232,17 +232,17 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for URND.
   parameter otbn_pkg::urnd_prng_seed_t RndCnstOtbnUrndPrngSeed = {
-    256'h3CA72C22_42223CE6_D70F17B4_F4B32818_AA49D125_B4DEFB1F_3C0BE8A2_9BE065C2
+    256'h627A281C_5681D656_6641EECC_CC88876A_D113C50A_D1BE4D94_DCE8FCA5_4128A386
   };
 
   // Compile-time random reset value for IMem/DMem scrambling key.
   parameter otp_ctrl_pkg::otbn_key_t RndCnstOtbnOtbnKey = {
-    128'h6D23550B_BC139FF6_461763D7_E966A8A7
+    128'h0AE1D349_3FBEF6B9_BA5DFE44_63A4615E
   };
 
   // Compile-time random reset value for IMem/DMem scrambling nonce.
   parameter otp_ctrl_pkg::otbn_nonce_t RndCnstOtbnOtbnNonce = {
-    64'h219EB2E8_EF9F11A1
+    64'hF46762A7_94A8C259
   };
 
   ////////////////////////////////////////////
@@ -250,73 +250,73 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter keymgr_pkg::lfsr_seed_t RndCnstKeymgrLfsrSeed = {
-    64'h52E6C71A_A23B8864
+    64'h7E69FB25_9B961914
   };
 
   // Compile-time random permutation for LFSR output
   parameter keymgr_pkg::lfsr_perm_t RndCnstKeymgrLfsrPerm = {
-    128'h4BBDE099_6949E0FA_88CAD4EC_5CB570FF,
-    256'h508DAFD9_33F05E5A_65F507BE_E70E0712_A3A76D21_19889113_A7BE9CCA_000DD6D0
+    128'h661C843B_BA36FA2F_30BC1407_8E6B45C5,
+    256'h8B1BFDC9_4F03A191_2D7A4229_620C92BA_A7DD44C9_69E0D5E3_57F48394_BD36E773
   };
 
   // Compile-time random permutation for entropy used in share overriding
   parameter keymgr_pkg::rand_perm_t RndCnstKeymgrRandPerm = {
-    160'h6C74ABD4_C4B30FDC_0FE8D84B_302F22A4_1FEE49C9
+    160'h165CB816_B3C6A20E_6C6622A9_6F33ED3F_5E995C28
   };
 
   // Compile-time random bits for revision seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrRevisionSeed = {
-    256'h2CCD155D_84FDACED_736E9336_2C8DA83C_5F4DD209_3E4D2A70_DD99DCF4_CCAC341A
+    256'hA52226B6_A4A7BDB0_5FE92161_5BF2FF98_4540F7D4_3ECE76B4_EB133637_74ED2ED4
   };
 
   // Compile-time random bits for creator identity seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrCreatorIdentitySeed = {
-    256'h2F1A2704_F5E21287_FA168AF2_51B370D0_34CDA605_152662F4_D11B3245_D5943EA5
+    256'h5545E927_F6D9E4AB_AC398D42_C745EEF6_46C1464D_CA86DAFD_7C7C71E6_058DDFD8
   };
 
   // Compile-time random bits for owner intermediate identity seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrOwnerIntIdentitySeed = {
-    256'hFD2E4BEA_016B7911_DEAF01DF_74254737_1445D6E3_955145E3_074D9CA9_E8A4EF06
+    256'h71C51CAC_BAF4410F_06DCC036_FCD16FCD_E97D1718_91105DD8_95E3A1D0_A19A16D6
   };
 
   // Compile-time random bits for owner identity seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrOwnerIdentitySeed = {
-    256'hA6F14A5C_8FCAC0D6_396E606A_620A9FFB_23756BDA_420A9E7B_D1A7C41E_3A37B747
+    256'hDBD8B20F_C9E662E1_E1B4982B_3E8EFF63_890DBEAE_926FD468_A77EFDE3_DE5B4CAF
   };
 
   // Compile-time random bits for software generation seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrSoftOutputSeed = {
-    256'hD3D7B758_B37D1D1C_A19A079C_48D7D4E6_7100A6AA_EBE45B6F_09AEFB72_895EC90D
+    256'h4776A247_BABA4C99_08ED16BC_5415EC16_D28C5355_1312FCED_CF2832A6_6CEACF8E
   };
 
   // Compile-time random bits for hardware generation seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrHardOutputSeed = {
-    256'h876315DB_9AD8BBE6_3ECACE31_278DA3AC_FC873EC5_A22829BD_781EFE2B_4B06F4B3
+    256'hD4D5B616_177DD43B_56FA754E_1F53AD65_8193B563_D9BDC6D2_AEE84852_F0CC7371
   };
 
   // Compile-time random bits for generation seed when aes destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrAesSeed = {
-    256'h49E0372B_7394D415_D937F357_8CC1200D_D1FB1D0E_CF948594_BC831C3E_0E1F33C9
+    256'hED3A6FAA_516C144B_34C96DFA_BB6F6E79_208A74F3_5C79F397_C4E4C7E2_2B758184
   };
 
   // Compile-time random bits for generation seed when kmac destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrKmacSeed = {
-    256'h98CABD61_DAC609B5_DD0E0C60_2AEF2E93_2B1FB8FB_631DD82D_E6C9ADDE_7BFB79FB
+    256'h8A90A125_4B2276BE_C9FC1A7A_5722A9AA_CA4DB84A_32E5C698_5A1A6435_118B5F5F
   };
 
   // Compile-time random bits for generation seed when otbn destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrOtbnSeed = {
-    256'h9CC4C0B2_D1AED670_0A44EA3E_7E0610A6_63D52B08_2B9AEF0E_426DF486_6FE88A8B
+    256'h3FD3B931_3116B671_92D856DD_742D40E0_72E417AD_9A5F2612_04CBCC69_A2147819
   };
 
   // Compile-time random bits for generation seed when no CDI is selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrCdi = {
-    256'hAA3B3B2F_5E3917A7_A7D4B5E5_3C38B3CE_DC40946C_F3635F0C_112F4352_05EF40D4
+    256'hB290A4BB_0264347C_0F91B0CE_C93C0129_D85B9580_1DBE03F1_7E69DC26_0A79998E
   };
 
   // Compile-time random bits for generation seed when no destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrNoneSeed = {
-    256'hB50CBD86_B4932D75_CEBE7060_738EFA20_35418082_CFE96E5C_C1280FBE_2F2E3236
+    256'hFF5C710B_67838ADF_B99A5ECA_671672CF_19BCA6AD_C1EBFAB6_11F19E72_62E0A491
   };
 
   ////////////////////////////////////////////
@@ -324,14 +324,14 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for csrng state group diversification value
   parameter csrng_pkg::cs_keymgr_div_t RndCnstCsrngCsKeymgrDivNonProduction = {
-    128'h88BCC7EC_BB1A7DB7_BE4CCAF2_7D6EB83F,
-    256'hD28156D9_CB50075D_6AF437BE_BB1D8879_E25723B9_D5332388_65874EF2_D375583C
+    128'h970E51B2_8E7026D0_E5DCE9E2_65A416A8,
+    256'h12231CFA_76E3D982_F8FDCEC9_AE1AF0B8_CD9E1760_6EC98106_0E94795A_1D573089
   };
 
   // Compile-time random bits for csrng state group diversification value
   parameter csrng_pkg::cs_keymgr_div_t RndCnstCsrngCsKeymgrDivProduction = {
-    128'h209C027D_35C5794F_680B1248_93C22E6A,
-    256'h22F5AD2E_7591ECAD_6CCA220D_E3C0051A_862508D4_CE0015F9_376719BD_15980C9E
+    128'h578C104A_36A647E9_0FFAFF97_60F5E838,
+    256'hBD8E2413_AB956B10_6CA7139A_07EFFEE4_57DEE82B_6E06663C_291739FF_0E7D6447
   };
 
   ////////////////////////////////////////////
@@ -339,23 +339,23 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlMainSramKey = {
-    128'h525DCBC7_A2E75C94_580BC5DA_0A20865A
+    128'h58FEE1C5_8564CF34_6D9622E5_37109136
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlMainSramNonce = {
-    128'h9B36B012_F2546EA8_45A7ADE1_002B84B7
+    128'h6EFBD61B_0CB470B9_44EF806E_573B44B6
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter sram_ctrl_pkg::lfsr_seed_t RndCnstSramCtrlMainLfsrSeed = {
-    64'h39380023_C25C3DEA
+    64'h43EBF0C5_DE019FC0
   };
 
   // Compile-time random permutation for LFSR output
   parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlMainLfsrPerm = {
-    128'h05C16B58_EFD74310_E6CB4648_037D4969,
-    256'hE379CE94_6FA13F67_6CA49D1E_ABA2B24F_B07C2565_82DE3ADB_B30B6045_0F1A18FC
+    128'hB99612D2_78F8A975_9DA4322B_F1F55305,
+    256'hB821CEF6_80DB5DC7_170B2D94_610B7B2A_0F38A08C_24DEFDE7_AFD04648_949BEC5C
   };
 
   ////////////////////////////////////////////
@@ -363,12 +363,12 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Fixed nonce used for address / data scrambling
   parameter bit [63:0] RndCnstRomCtrlScrNonce = {
-    64'h86282B72_C315DC48
+    64'h356888AE_5343DD78
   };
 
   // Randomised constant used as a scrambling key for ROM data
   parameter bit [127:0] RndCnstRomCtrlScrKey = {
-    128'h76F6ACFA_65E2F3FF_F25369DF_F7245670
+    128'h4CBA5BEB_BE2A6EAD_062D9516_FDD8B110
   };
 
   ////////////////////////////////////////////
@@ -376,22 +376,22 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for random instructions.
   parameter ibex_pkg::lfsr_seed_t RndCnstRvCoreIbexLfsrSeed = {
-    32'h4342D7CD
+    32'h861A797C
   };
 
   // Permutation applied to the LFSR of the PRNG used for random instructions.
   parameter ibex_pkg::lfsr_perm_t RndCnstRvCoreIbexLfsrPerm = {
-    160'h8A44441E_74CC34A0_83FB359F_5E5FB893_3C56ADC3
+    160'hAE8D23A0_970E7624_B55C64DD_D5BFDF1C_70505216
   };
 
   // Default icache scrambling key
   parameter logic [ibex_pkg::SCRAMBLE_KEY_W-1:0] RndCnstRvCoreIbexIbexKeyDefault = {
-    128'hA6BFBFB2_EB0038E8_0868A59E_9DD11BBF
+    128'h1C67F59C_BA5482C1_E35E6E33_35C20CC7
   };
 
   // Default icache scrambling nonce
   parameter logic [ibex_pkg::SCRAMBLE_NONCE_W-1:0] RndCnstRvCoreIbexIbexNonceDefault = {
-    64'h7449121C_DEFC0BD7
+    64'h78FC3099_17B9C870
   };
 
 endpackage : top_earlgrey_rnd_cnst_pkg

--- a/util/design/lib/OtpMemImg.py
+++ b/util/design/lib/OtpMemImg.py
@@ -13,7 +13,7 @@ from typing import List, Tuple
 
 from mako.template import Template
 from mubi.prim_mubi import mubi_value_as_int
-from topgen import secure_prng as sp
+from topgen.secure_prng import SecurePrngFactory
 
 from lib import common
 from lib.LcStEnc import LcStEnc
@@ -227,7 +227,7 @@ class OtpMemImg(OtpMemMap):
         log.info('')
 
         # Re-initialize with seed to make results reproducible.
-        sp.reseed(OTP_IMG_SEED_DIVERSIFIER + int(img_config['seed']))
+        SecurePrngFactory.create("otpmemimg", OTP_IMG_SEED_DIVERSIFIER + int(img_config['seed']))
 
         if 'partitions' not in img_config:
             raise RuntimeError('Missing partitions key in configuration.')
@@ -341,7 +341,8 @@ class OtpMemImg(OtpMemMap):
             mubi_str = ""
             mubi_val_str = ""
             item.setdefault('value', '0x0')
-            common.random_or_hexvalue(item, 'value', item_width)
+            prng = SecurePrngFactory.get("otpmemimg")
+            common.random_or_hexvalue(prng, item, 'value', item_width)
 
         mmap_item['value'] = item['value']
 

--- a/util/design/lib/common.py
+++ b/util/design/lib/common.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../'))
 
-from topgen import secure_prng as sp  # noqa : E402
+from topgen.secure_prng import secure_prng  # noqa : E402
 
 
 def wrapped_docstring():
@@ -294,7 +294,7 @@ def _parse_hex(value):
         return int(value, 16)
 
 
-def random_or_hexvalue(dict_obj, key, num_bits):
+def random_or_hexvalue(prng: secure_prng, dict_obj: dict, key: str, num_bits: int) -> None:
     '''Convert hex value at "key" to an integer or draw a random number.'''
 
     # Initialize to default if this key does not exist.
@@ -302,7 +302,7 @@ def random_or_hexvalue(dict_obj, key, num_bits):
 
     # Generate a random number of requested size in this case.
     if dict_obj[key] == '<random>':
-        dict_obj[key] = sp.getrandbits(num_bits)
+        dict_obj[key] = prng.getrandbits(num_bits)
     # Otherwise attempt to convert this number to an int.
     # Check that the range is correct.
     else:

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -32,7 +32,8 @@ from reggen.ip_block import IpBlock
 from topgen import get_hjsonobj_xbars
 from topgen import intermodule as im
 from topgen import lib as lib
-from topgen import merge_top, secure_prng, validate_top
+from topgen import merge_top, validate_top
+from topgen.secure_prng import SecurePrngFactory
 from topgen.c_test import TopGenCTest
 from topgen.clocks import Clocks
 from topgen.gen_dv import gen_dv
@@ -1530,7 +1531,7 @@ def main():
     for pass_idx in range(maximum_passes):
         log.info("Generation pass {}".format(pass_idx + 1))
         # Use the same seed for each pass to have stable random constants.
-        secure_prng.reseed(topcfg["rnd_cnst_seed"])
+        SecurePrngFactory.create("topgen", topcfg["rnd_cnst_seed"])
         # Insert the config file path of the HJSON to allow parsing files
         # relative the config directory
         cfg_copy["cfg_path"] = Path(args.topcfg).parent

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -16,7 +16,8 @@ from reggen.ip_block import IpBlock
 from reggen.params import (LocalParam, MemSizeParameter, Parameter,
                            RandParameter)
 from reggen.validate import check_bool
-from topgen import lib, secure_prng
+from topgen import lib
+from topgen.secure_prng import SecurePrngFactory
 from topgen.typing import IpBlocksT
 
 from .clocks import Clocks, UnmanagedClocks
@@ -26,7 +27,8 @@ from .resets import Resets, UnmanagedResets
 def _get_random_data_hex_literal(width):
     """ Fetch 'width' random bits and return them as hex literal"""
     width = int(width)
-    literal_str = hex(secure_prng.getrandbits(width))
+    prng = SecurePrngFactory.get("topgen")
+    literal_str = hex(prng.getrandbits(width))
     return literal_str
 
 
@@ -36,7 +38,8 @@ def _get_random_perm_hex_literal(numel):
     num_elements = int(numel)
     width = int(ceil(log2(num_elements)))
     idx = [x for x in range(num_elements)]
-    secure_prng.shuffle(idx)
+    prng = SecurePrngFactory.get("topgen")
+    prng.shuffle(idx)
     literal_str = ""
     for k in idx:
         literal_str += format(k, '0' + str(width) + 'b')

--- a/util/topgen/secure_prng.py
+++ b/util/topgen/secure_prng.py
@@ -17,6 +17,7 @@ import logging as log
 import sys
 from math import ceil as _ceil
 from math import log as _log
+from typing import Any
 
 from Crypto.Cipher import AES
 
@@ -304,15 +305,33 @@ class secure_prng():
         return test_point
 
 
-# ----------------------------------------------------------------------
-# Create one instance, and export its methods as module-level functions.
-# The functions share state across all uses.
+class SecurePrngFactory:
+    """
+    A factory class for creating and managing named pseudo-random number generators (PRNGs).
 
-_inst = secure_prng()
-reseed = _inst.reseed
-fetchbyte = _inst.fetchbyte
-getrandbits = _inst.getrandbits
-randbelow = _inst.randbelow
-shuffle = _inst.shuffle
-choice = _inst.choice
-test_point_gen = _inst.test_point_gen
+    This factory allows you to instantiate multiple PRNGs with different seeds
+    and retrieve them later by name.
+    """
+    _rngs: dict[str, secure_prng] = {}
+
+    @classmethod
+    def create(cls, name: str, seed: Any) -> None:
+        """
+        Creates and registers a new pseudo-random number generator.
+
+        If a generator with the same name already exists, it will be
+        overwritten with the new one.
+        """
+        rng_instance = secure_prng()
+        rng_instance.reseed(seed)
+        cls._rngs[name] = rng_instance
+
+    @classmethod
+    def get(cls, name: str) -> secure_prng:
+        """
+        Retrieves a previously created pseudo-random number generator by its name.
+        """
+        if name not in cls._rngs:
+            raise KeyError(f"Error: PRNG with name '{name}' not found. "
+                           "Please create it first using SecurePrngFactory.create().")
+        return cls._rngs[name]


### PR DESCRIPTION
Previously, there was a rather single singleton implementation where only a single PRNG lived in the design at once. Re-seeding the PRNG caused all subsequent PRNG invocations to use that seed. That meant, once the otp map reseeded the PRNG, all topgen calls to the PRNG used the otp map seed.

This PR fixes that by introducing a factory that allows creating multiple PRNGs with different namespaces. Now, the otp map and also otp image generation can create their own PRNG instance without interfering with the topgen PRNG.

cc @matutem 