### PR TITLE
[sw,crypto] Fix instruction count FI check

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/p256.c
+++ b/sw/device/lib/crypto/impl/ecc/p256.c
@@ -81,12 +81,12 @@ enum {
   /*
    * The expected instruction counts for constant time functions.
    */
-  kModeKeygenInsCnt = 564222,
-  kModeKeygenSideloadInsCnt = 564107,
-  kModeEcdhInsCnt = 571605,
-  kModeEcdhSideloadInsCnt = 571665,
-  kModeEcdsaSignInsCnt = 597419,
-  kModeEcdsaSignSideloadInsCnt = 597479,
+  kModeKeygenInsCnt = 565388,
+  kModeKeygenSideloadInsCnt = 565273,
+  kModeEcdhInsCnt = 572565,
+  kModeEcdhSideloadInsCnt = 572625,
+  kModeEcdsaSignInsCnt = 598592,
+  kModeEcdsaSignSideloadInsCnt = 598652,
 };
 
 static status_t p256_masked_scalar_write(const p256_masked_scalar_t *src,

--- a/sw/device/lib/crypto/impl/ecc/p384.c
+++ b/sw/device/lib/crypto/impl/ecc/p384.c
@@ -91,10 +91,10 @@ enum {
   /*
    * The expected instruction counts for constant time functions.
    */
-  kModeKeygenInsCnt = 1443816,
-  kModeKeygenSideloadInsCnt = 1443730,
-  kModeEcdhInsCnt = 1454932,
-  kModeEcdhSideloadInsCnt = 1455071,
+  kModeKeygenInsCnt = 1444128,
+  kModeKeygenSideloadInsCnt = 1444042,
+  kModeEcdhInsCnt = 1454936,
+  kModeEcdhSideloadInsCnt = 1455075,
   kModeEcdsaSignInsCnt = 1505346,
   kModeEcdsaSignSideloadInsCnt = 1505485,
 };


### PR DESCRIPTION
After two PRs were merged at the same time the instruction time check didn't check for the correct value any more. This commit fixes that issue.