### PR TITLE
Backport 25406 ([provisioning]: allow the owner to specify perso success condition)

### DIFF
--- a/sw/host/provisioning/ft/src/main.rs
+++ b/sw/host/provisioning/ft/src/main.rs
@@ -16,7 +16,7 @@ use p256::NistP256;
 use cert_lib::{CaConfig, CaKey, CaKeyType};
 use ft_lib::response::PersonalizeResponse;
 use ft_lib::{
-    check_rom_ext_boot_up, run_ft_personalize, run_sram_ft_individualize, test_exit, test_unlock,
+    check_slot_b_boot_up, run_ft_personalize, run_sram_ft_individualize, test_exit, test_unlock,
 };
 use opentitanlib::backend;
 use opentitanlib::console::spi::SpiConsoleDevice;
@@ -110,6 +110,10 @@ struct Opts {
     /// Name of the SPI interface to connect to the OTTF console.
     #[arg(long, default_value = "BOOTSTRAP")]
     console_spi: String,
+
+    /// Owner's firmware string indicating successful start up.
+    #[arg(long)]
+    owner_success_text: Option<String>,
 }
 
 fn main() -> Result<()> {
@@ -291,7 +295,13 @@ fn main() -> Result<()> {
         &mut response,
     )?;
 
-    check_rom_ext_boot_up(&transport, &opts.init, opts.timeout, &mut response)?;
+    check_slot_b_boot_up(
+        &transport,
+        &opts.init,
+        opts.timeout,
+        &mut response,
+        opts.owner_success_text,
+    )?;
     log::info!("Provisioning Done");
     let doc = if opts.provisioning_data.pretty {
         serde_json::to_string_pretty(&response)?


### PR DESCRIPTION
Backport #25406 ([provisioning]: allow the owner to specify perso success condition). Depends on #27836