### PR TITLE
Backport 25407 ([manuf] Build stand-alone orchestrator package)

### DIFF
--- a/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
@@ -32,6 +32,7 @@ EARLGREY_SKUS = {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_b",
         "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_b",
         "ecdsa_key": {},
+        "orchestrator_cfg": "//sw/host/provisioning/orchestrator/configs/skus:emulation.hjson",
     },
     # OTP Config: Emulation; DICE Certs: CWT; Additional Certs: None
     "emulation_dice_cwt": {
@@ -45,6 +46,7 @@ EARLGREY_SKUS = {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_cwt_slot_b",
         "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_b",
         "ecdsa_key": {},
+        "orchestrator_cfg": "//sw/host/provisioning/orchestrator/configs/skus:emulation.hjson",
     },
     # OTP Config: Emulation; DICE Certs: X.509; Additional Certs: TPM EK
     "emulation_tpm": {
@@ -61,22 +63,26 @@ EARLGREY_SKUS = {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_b",
         "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_b",
         "ecdsa_key": {},
+        "orchestrator_cfg": "//sw/host/provisioning/orchestrator/configs/skus:emulation.hjson",
     },
-    # TODO(cfrantz, ttrippel): Add SIVAL configs when we sign perso and
-    # ROM_EXT binaries.
-    #"sival": {
-    #    "otp": "sival",
-    #    "ca_config": "//sw/device/silicon_creator/manuf/keys/fake:ca_config.json",
-    #    "ca_data": ["//sw/device/silicon_creator/manuf/keys/fake:ca_data"],
-    #    "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice"],
-    #    "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
-    #    "device_ext_libs": ["@provisioning_exts//:default_perso_fw_ext"],
-    #    "ownership_libs": ["//sw/device/silicon_creator/rom_ext/sival:sival_owner"],
-    #    "rom_ext": "//sw/device/silicon_creator/rom_ext/sival/binaries:rom_ext_dice_x509_prod",
-    #    "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_b",
-    #    "ecdsa_key": {"//hw/ip/otp_ctrl/data/earlgrey_skus/sival/keys:keyset": "sv00-earlgrey-a1-root-ecdsa-prod-0"},
-    #    "perso_bin": "//sw/device/silicon_creator/manuf/base/binaries:ft_personalize_sival",
-    #},
+    # This configuration is not really usable in master but left here as an example until
+    # a more appropriate solution is found.
+    # "sival": {
+    #     "otp": "sival",
+    #     "ca_config": "//sw/device/silicon_creator/manuf/keys/fake:ca_config.json",
+    #     "ca_data": ["//sw/device/silicon_creator/manuf/keys/fake:ca_data"],
+    #     "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice"],
+    #     "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
+    #     "device_ext_libs": ["@provisioning_exts//:default_perso_fw_ext"],
+    #     "ownership_libs": ["//sw/device/silicon_creator/rom_ext/sival:sival_owner"],
+    #     "rom_ext": "//sw/device/silicon_creator/rom_ext/sival/binaries:rom_ext_dice_x509_prod",
+    #     # TODO(cfrantz, ttrippel): This owner_fw isn't signed with the sival owner keys,
+    #     # so we expect the ROM_EXT to BFV with `kErrorOwnershipKeyNotFound`,
+    #     "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_b",
+    #     "ecdsa_key": {"//hw/top_earlgrey/data/otp/skus/sival/keys:keyset": "sv00-earlgrey-a1-root-ecdsa-prod-0"},
+    #     "perso_bin": "//sw/device/silicon_creator/manuf/base/binaries:ft_personalize_sival",
+    #     "orchestrator_cfg": "//sw/host/provisioning/orchestrator/configs/skus:emulation.hjson",
+    # },
 } | EXT_EARLGREY_SKUS
 
 _TEST_TOKENS = """

--- a/sw/host/provisioning/orchestrator/README.md
+++ b/sw/host/provisioning/orchestrator/README.md
@@ -8,21 +8,24 @@ ways:
 
 ## Running with Bazel
 
-To run on an CW310 FPGA for testing, run:
+To run on an FPGA for testing, run:
+
 ```
+# Select either cw340 or cw310
+export FPGA_TARGET=hyper310
 bazel run \
-  --//hw/bitstream/universal:env=//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys \
+  --//hw/bitstream/universal:env=//hw/top_earlgrey:fpga_${FPGA_TARGET}_rom_with_fake_keys \
   --//hw/bitstream/universal:otp=//hw/top_earlgrey/data/otp/emulation:otp_img_test_unlocked0_manuf_empty \
   //sw/host/provisioning/orchestrator/src:orchestrator -- \
     --sku-config=$(pwd)/sw/host/provisioning/orchestrator/configs/skus/sival.hjson \
     --test-unlock-token="0x11111111_11111111_11111111_11111111" \
     --test-exit-token="0x22222222_22222222_22222222_22222222" \
-    --rma-unlock-token="0x33333333_33333333_33333333_33333333" \
-    --fpga=hyper310 \
+    --fpga=${FPGA_TARGET} \
     --non-interactive
 ```
 
 To run on silicon, run:
+
 ```
 bazel run \
   //sw/host/provisioning/orchestrator/src:orchestrator -- \
@@ -35,4 +38,55 @@ bazel run \
 
 ## Running Directly
 
-WIP
+Build the orchestrator package. This will build a package with all SKU
+dependencies.
+
+```
+export FPGA_TARGET=hyper310
+bazel build \
+  --//hw/bitstream/universal:env=//hw/top_earlgrey:fpga_${FPGA_TARGET}_rom_with_fake_keys \
+  --//hw/bitstream/universal:otp=//hw/ip/otp_ctrl/data/earlgrey_skus/emulation:otp_img_test_unlocked0_manuf_empty \
+  //sw/host/provisioning/orchestrator/src:orchestrator.zip
+```
+
+To run the packaged orchestrator script:
+
+```
+export ORCHESTRATOR_RUN_DIR=/tmp/orchestrator
+mkdir -p ${ORCHESTRATOR_RUN_DIR}
+cd ${ORCHESTRATOR_RUN_DIR}
+cp ${REPO_TOP}/bazel-bin/sw/host/provisioning/orchestrator/src/orchestrator.zip .
+
+
+export ORCHESTRATOR_ZIP="${ORCHESTRATOR_RUN_DIR}/orchestrator.zip"
+
+# Extract runfile folders from orchestrator package.
+unzip ${ORCHESTRATOR_ZIP} \
+  "runfiles/lowrisc_opentitan/*" \
+  "runfiles/openocd/*" \
+  "runfiles/provisioning_exts/*"
+
+# All external dependencies are mapped under
+# runfiles/lowrisc_opentitan/external.
+mkdir -p  runfiles/lowrisc_opentitan/external
+
+ln -fs $(pwd)/runfiles/openocd runfiles/lowrisc_opentitan/external
+
+# The following is needed if you are using the provisioning extensions
+# infrastructure.
+PROVISIONING_EXT_RUNFILES=$(pwd)/runfiles/provisioning_exts
+[ -d "${PROVISION_EXT_RUNFILES}" ] &&   \
+  ln -fs "${PROVISIONING_EXT_RUNFILES}" \
+    runfiles/lowrisc_opentitan/external/provisioning_exts
+
+# Run tool. The path to the --sku-config parameter is relative to the
+# runfiles-dir.
+export FPGA_TARGET=hyper310
+python3 ${ORCHESTRATOR_ZIP} \
+  --sku-config=sw/host/provisioning/orchestrator/configs/skus/emulation.hjson \
+  --test-unlock-token="0x11111111_11111111_11111111_11111111" \
+  --test-exit-token="0x22222222_22222222_22222222_22222222" \
+  --fpga=${FPGA_TARGET} \
+  --non-interactive \
+  --runfiles-dir=$(pwd)/runfiles/lowrisc_opentitan
+```

--- a/sw/host/provisioning/orchestrator/configs/skus/BUILD
+++ b/sw/host/provisioning/orchestrator/configs/skus/BUILD
@@ -2,6 +2,19 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load(
+    "//sw/device/silicon_creator/manuf/base:provisioning_inputs.bzl",
+    "EARLGREY_SKUS",
+)
+
 package(default_visibility = ["//visibility:public"])
 
 exports_files(glob(["**"]))
+
+filegroup(
+    name = "sku_all",
+    srcs = depset([
+        config["orchestrator_cfg"]
+        for _, config in EARLGREY_SKUS.items()
+    ]).to_list(),
+)

--- a/sw/host/provisioning/orchestrator/configs/skus/emulation.hjson
+++ b/sw/host/provisioning/orchestrator/configs/skus/emulation.hjson
@@ -1,0 +1,26 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# OpenTitan SIVAL SKU configuration.
+
+{
+  name: "emulation",
+  product: "earlgrey_a1",
+  si_creator: "nuvoton",
+  package: "npcr10",
+  target_lc_state: "prod",
+  dice_ca: {
+    certificate: "sw/device/silicon_creator/manuf/keys/fake/dice_ca.pem",
+    key: "sw/device/silicon_creator/manuf/keys/fake/sk.pkcs8.der",
+    key_type: "Raw",
+    key_id: "0xfe584ae7_53790cfd_8601a312_fb32d3c1_b822d112"
+  }
+  ext_ca: {
+    certificate: "sw/device/silicon_creator/manuf/keys/fake/ext_ca.pem",
+    key: "sw/device/silicon_creator/manuf/keys/fake/sk.pkcs8.der",
+    key_type: "Raw",
+    key_id: "0xfe584ae7_53790cfd_8601a312_fb32d3c1_b822d112"
+  }
+  token_encrypt_key: "sw/device/silicon_creator/manuf/keys/fake/rma_unlock_enc_rsa3072.pub.der"
+}

--- a/sw/host/provisioning/orchestrator/src/BUILD
+++ b/sw/host/provisioning/orchestrator/src/BUILD
@@ -65,11 +65,10 @@ py_library(
     ],
 )
 
-py_binary(
-    name = "orchestrator",
+filegroup(
+    name = "data_dependencies",
     testonly = True,
-    srcs = ["orchestrator.py"],
-    data = [
+    srcs = [
         "//hw/bitstream/universal:splice",
         "//sw/device/silicon_creator/manuf/base:ft_personalize_all",
         "//sw/device/silicon_creator/manuf/base:sram_cp_provision",
@@ -80,10 +79,18 @@ py_binary(
         "//sw/device/silicon_creator/manuf/keys/fake:sk.pkcs8.der",
         "//sw/host/provisioning/cp",
         "//sw/host/provisioning/ft:ft_all",
+        "//sw/host/provisioning/orchestrator/configs/skus:sku_all",
         "//third_party/openocd:jtag_cmsis_dap_adapter_cfg",
         "//third_party/openocd:jtag_olimex_cfg",
         "//third_party/openocd:openocd_bin",
     ],
+)
+
+py_binary(
+    name = "orchestrator",
+    testonly = True,
+    srcs = ["orchestrator.py"],
+    data = [":data_dependencies"],
     imports = ["."],
     deps = [
         ":device_id",
@@ -92,4 +99,11 @@ py_binary(
         ":util",
         requirement("hjson"),
     ],
+)
+
+filegroup(
+    name = "orchestrator.zip",
+    testonly = True,
+    srcs = [":orchestrator"],
+    output_group = "python_zip_file",
 )

--- a/sw/host/provisioning/orchestrator/src/orchestrator.py
+++ b/sw/host/provisioning/orchestrator/src/orchestrator.py
@@ -5,6 +5,7 @@
 
 import argparse
 import logging
+import os
 import shlex
 import subprocess
 import sys
@@ -107,11 +108,20 @@ def main(args_in):
         help="Skip all non-required user confirmations.",
     )
     parser.add_argument(
+        "--runfiles-dir",
+        type=str,
+        help="Runfiles directory to use for provisioning.",
+    )
+    parser.add_argument(
         "--log-dir",
         default="logs",
         help="Root directory to store log files under.",
     )
     args = parser.parse_args(args_in)
+
+    # All relative paths are relative to the runfiles directory.
+    if args.runfiles_dir:
+        os.chdir(args.runfiles_dir)
 
     # Load and validate a SKU configuration file.
     sku_config_args = {}

--- a/sw/host/provisioning/orchestrator/src/ot_dut.py
+++ b/sw/host/provisioning/orchestrator/src/ot_dut.py
@@ -16,23 +16,25 @@ from util import confirm, format_hex, run
 _FPGA_UNIVERSAL_SPLICE_BITSTREAM = "hw/bitstream/universal/splice.bit"
 
 # CP and FT shared flags.
+_OPENOCD_BIN = "third_party/openocd/build_openocd/bin/openocd"
+_OPENOCD_ADAPTER_CONFIG = "external/openocd/tcl/interface/cmsis-dap.cfg"
 _BASE_PROVISIONING_FLAGS = """
-    --interface={} \
-    --openocd=third_party/openocd/build_openocd/bin/openocd \
-    --openocd-adapter-config=external/openocd/tcl/interface/cmsis-dap.cfg \
+    --interface={target} \
+    --openocd={openocd_bin} \
+    --openocd-adapter-config={openocd_cfg} \
 """
 _ZERO_256BIT_HEXSTR = "0x" + "_".join(["00000000"] * 8)
 
 # yapf: disable
 # CP & FT Device Firmware
 _BASE_DEV_DIR          = "sw/device/silicon_creator/manuf/base"  # noqa: E221
-_CP_DEVICE_ELF         = _BASE_DEV_DIR + "/sram_cp_provision_{}.elf"  # noqa: E221
-_FT_INDIVID_DEVICE_ELF = _BASE_DEV_DIR + "/sram_ft_individualize_{}_{}.elf"  # noqa: E221
-_FT_PERSO_DEVICE_BIN   = _BASE_DEV_DIR + "/ft_personalize_{}_{}.prod_key_0.prod_key_0.signed.bin"  # noqa: E221, E501
-_FT_FW_BUNDLE_BIN      = _BASE_DEV_DIR + "/ft_fw_bundle_{}_{}.img"  # noqa: E221
+_CP_DEVICE_ELF         = "{base_dir}/sram_cp_provision_{target}.elf"  # noqa: E221
+_FT_INDIVID_DEVICE_ELF = "{base_dir}/sram_ft_individualize_{sku}_{target}.elf"  # noqa: E221
+_FT_PERSO_DEVICE_BIN   = "{base_dir}/ft_personalize_{sku}_{target}.prod_key_0.prod_key_0.signed.bin"  # noqa: E221, E501
+_FT_FW_BUNDLE_BIN      = "{base_dir}/ft_fw_bundle_{sku}_{target}.img"  # noqa: E221
 # CP & FT Host Binaries
 _CP_HOST_BIN = "sw/host/provisioning/cp/cp"
-_FT_HOST_BIN = "sw/host/provisioning/ft/ft_{}"
+_FT_HOST_BIN = "sw/host/provisioning/ft/ft_{sku}"
 # yapf: enable
 
 
@@ -60,6 +62,9 @@ class OtDut():
             confirm()
         os.makedirs(self.log_dir, exist_ok=True)
 
+    def _base_dev_dir(self) -> str:
+        return _BASE_DEV_DIR
+
     def run_cp(self) -> None:
         """Runs the CP provisioning flow on the target DUT."""
         logging.info("Running CP provisioning ...")
@@ -67,18 +72,25 @@ class OtDut():
         # Set cmd args and device ELF.
         host_flags = _BASE_PROVISIONING_FLAGS
         device_elf = _CP_DEVICE_ELF
+        print(f"device_elf: {device_elf}")
         if self.fpga:
             # Set host flags and device binary for FPGA DUT.
-            host_flags = host_flags.format(self.fpga)
+            host_flags = host_flags.format(target=self.fpga,
+                                           openocd_bin=_OPENOCD_BIN,
+                                           openocd_cfg=_OPENOCD_ADAPTER_CONFIG)
             host_flags += " --clear-bitstream"
             host_flags += f" --bitstream={_FPGA_UNIVERSAL_SPLICE_BITSTREAM}"
             device_elf = device_elf.format(
-                f"fpga_{self.fpga}_rom_with_fake_keys")
+                base_dir=self._base_dev_dir(),
+                target=f"fpga_{self.fpga}_rom_with_fake_keys")
         else:
             # Set host flags and device binary for Silicon DUT.
-            host_flags = host_flags.format("teacup")
+            host_flags = host_flags.format(target="teacup",
+                                           openocd_bin=_OPENOCD_BIN,
+                                           openocd_cfg=_OPENOCD_ADAPTER_CONFIG)
             host_flags += " --disable-dft-on-reset"
-            device_elf = device_elf.format("silicon_creator")
+            device_elf = device_elf.format(base_dir=self._base_dev_dir(),
+                                           target="silicon_creator")
 
         # Assemble CP command.
         cmd = f"""{_CP_HOST_BIN} \
@@ -114,7 +126,7 @@ class OtDut():
         logging.info("Running FT provisioning ...")
 
         # Set cmd args and device ELF.
-        host_bin = _FT_HOST_BIN.format(self.sku_config.name)
+        host_bin = _FT_HOST_BIN.format(sku=self.sku_config.name)
         host_flags = _BASE_PROVISIONING_FLAGS
         individ_elf = _FT_INDIVID_DEVICE_ELF
         perso_bin = _FT_PERSO_DEVICE_BIN
@@ -123,29 +135,43 @@ class OtDut():
             # Set host flags and device binaries for FPGA DUT.
             # No need to load another bitstream, we will take over where CP
             # stage above left off.
-            host_flags = host_flags.format(self.fpga)
+            host_flags = host_flags.format(target=self.fpga,
+                                           openocd_bin=_OPENOCD_BIN,
+                                           openocd_cfg=_OPENOCD_ADAPTER_CONFIG)
             individ_elf = individ_elf.format(
-                self.sku_config.name, f"fpga_{self.fpga}_rom_with_fake_keys")
+                base_dir=self._base_dev_dir(),
+                sku=self.sku_config.name,
+                target=f"fpga_{self.fpga}_rom_with_fake_keys")
             perso_bin = perso_bin.format(
-                self.sku_config.name, f"fpga_{self.fpga}_rom_with_fake_keys")
+                base_dir=self._base_dev_dir(),
+                sku=self.sku_config.name,
+                target=f"fpga_{self.fpga}_rom_with_fake_keys")
             fw_bundle_bin = fw_bundle_bin.format(
-                self.sku_config.name, f"fpga_{self.fpga}_rom_with_fake_keys")
+                base_dir=self._base_dev_dir(),
+                sku=self.sku_config.name,
+                target=f"fpga_{self.fpga}_rom_with_fake_keys")
         else:
             # Set host flags and device binaries for Silicon DUT.
-            host_flags = host_flags.format("teacup")
+            host_flags = host_flags.format(target="teacup",
+                                           openocd_bin=_OPENOCD_BIN,
+                                           openocd_cfg=_OPENOCD_ADAPTER_CONFIG)
             host_flags += " --disable-dft-on-reset"
-            individ_elf = individ_elf.format(self.sku_config.name,
-                                             "silicon_creator")
-            perso_bin = perso_bin.format(self.sku_config.name,
-                                         "silicon_creator")
-            fw_bundle_bin = fw_bundle_bin.format(self.sku_config.name,
-                                                 "silicon_creator")
+            individ_elf = individ_elf.format(base_dir=self._base_dev_dir(),
+                                             sku=self.sku_config.name,
+                                             target="silicon_creator")
+            perso_bin = perso_bin.format(base_dir=self._base_dev_dir(),
+                                         sku=self.sku_config.name,
+                                         target="silicon_creator")
+            fw_bundle_bin = fw_bundle_bin.format(base_dir=self._base_dev_dir(),
+                                                 sku=self.sku_config.name,
+                                                 target="silicon_creator")
 
         # Write CA configs to a JSON tmpfile.
         ca_config_dict = {
             "dice": self.sku_config.dice_ca.to_dict_entry(),
             "ext": self.sku_config.ext_ca.to_dict_entry(),
         }
+
         with tempfile.NamedTemporaryFile(mode="w+") as ca_config_file:
             json.dump(ca_config_dict, ca_config_file)
             ca_config_file.flush()
@@ -163,7 +189,6 @@ class OtDut():
             --device-id="{self.device_id}" \
             --test-unlock-token="{format_hex(self.test_unlock_token, width=32)}" \
             --test-exit-token="{format_hex(self.test_exit_token, width=32)}" \
-            --rma-unlock-token="{format_hex(self.rma_unlock_token, width=32)}" \
             --target-mission-mode-lc-state="{self.sku_config.target_lc_state}" \
             --rom-ext-measurement="{_ZERO_256BIT_HEXSTR}" \
             --owner-manifest-measurement="{_ZERO_256BIT_HEXSTR}" \


### PR DESCRIPTION
Backport #25407 ([manuf] Build stand-alone orchestrator package).
Depends on #27878.

I haven't actually tested the instructions but I suspect that with bzlmod being enabled on the master branch (and not in earlgrey_1.0.0 at the time), it's quite likely that it would break down due to runfiles.

Conflict note: to avoid further conflict, I left the `sival` configuration in the provisioning inputs more or less unchanged. But since we don't check in earlgrey_1.0.0 material in master, I had to leave it commented. This configuration is not usable in master anyway and this will have to be rethough after we are doing backporting.