### PR TITLE
[topgen] Various small fixes

### DIFF
--- a/hw/ip_templates/rv_plic/data/rv_plic.hjson.tpl
+++ b/hw/ip_templates/rv_plic/data/rv_plic.hjson.tpl
@@ -2,7 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-<% import math %>\
+<%
+  import math
+
+# Interrupt 0 is reserved to indicate "no interrupt" so the number of real
+# sources is src-1. This template assumes that there is at least one real interrupt,
+# otherwise it generates invalid bitfields.
+  assert src > 1, "the rv_plic template assumes that there is at least one interrupt"
+%>\
 # ${(module_instance_name).upper()} register template
 #
 # Parameter (given by Python tool)

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -1201,7 +1201,7 @@ def generate_full_ipgens(args: argparse.Namespace, topcfg: ConfigT,
         if len(modules) > 1 and single_instance:
             raise SystemExit(f"Cannot have more than one {template_type} per top")
         for module in modules:
-            log.info(f"Generating {template_type} with ipgen")
+            log.info(f'Generating {module["type"]} with ipgen from template {template_type}')
             if get_params:
                 args = (topcfg,) if single_instance else (topcfg, module["name"])
                 params = get_params(*args)

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -398,7 +398,7 @@ def generate_outgoing_interrupts(top: ConfigT, out_path: Path) -> None:
 def _get_rv_plic_params(top: ConfigT, name: str) -> ParamsT:
     """Gets parameters for plic ipgen from top config."""
     # Get this PLIC instance
-    module = lib.find_module(top["module"], name, use_base_template_type=False)
+    module = lib.find_module_by_name(top["module"], name)
 
     # Count number of interrupts
     # Interrupt source 0 is tied to 0 to conform RISC-V PLIC spec.
@@ -1117,7 +1117,7 @@ def create_ipgen_blocks(topcfg: ConfigT, alias_cfgs: Dict[str, ConfigT],
     # Add rv_plic
     amend_interrupt(topcfg, name_to_block, allow_missing_blocks=True)
     for inst in ipgen_instances.get("rv_plic", []):
-        insert_ip_attrs(inst, _get_rv_plic_params(topcfg, inst["type"]))
+        insert_ip_attrs(inst, _get_rv_plic_params(topcfg, inst["name"]))
 
     return ip_attrs
 

--- a/util/topgen/lib.py
+++ b/util/topgen/lib.py
@@ -869,7 +869,7 @@ def find_modules(modules: List[Dict[str, object]],
 def find_module(
         modules: List[Dict[str, object]],
         type: str,
-        use_base_template_type=True) -> Optional[List[Dict[str, object]]]:
+        use_base_template_type=True) -> Optional[Dict[str, object]]:
     '''Returns the first module of a given type
 
     If use_base_template_type is set to True, ipgen-based modules are

--- a/util/topgen/lib.py
+++ b/util/topgen/lib.py
@@ -880,6 +880,15 @@ def find_module(
     return mods[0] if mods else None
 
 
+def find_module_by_name(modules: List[Dict[str, object]],
+                        name: str) -> Optional[Dict[str, object]]:
+    """Return the (first) module with a given name, or None."""
+    for m in modules:
+        if m["name"] == name:
+            return m
+    return None
+
+
 def get_addr_space(top: ConfigT, addr_space_name: str) -> ConfigT:
     """Returns the address dict for a given address space name"""
     for addr_space in top['addr_spaces']:

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -381,7 +381,7 @@ def xbar_adddevice(top: ConfigT, name_to_block: IpBlocksT, xbar: ConfigT,
         log.error(
             "Another crossbar %s needs to be specified in the 'nodes' list" %
             device)
-        return
+        raise RuntimeError(f"Cannot add device {device} to crossbar")
 
     # If there is no module or memory with the right name, this might still be
     # ok: we might be connecting to another crossbar or to a predefined module.
@@ -402,13 +402,13 @@ def xbar_adddevice(top: ConfigT, name_to_block: IpBlocksT, xbar: ConfigT,
         if device in predefined_modules:
             log.error("device %s shouldn't be host type" % device)
 
-            return
+            raise RuntimeError(f"Cannot add device {device} to crossbar")
 
         # case 3: not defined
         # Crossbar check
         log.error("Device %s doesn't exist in 'module', 'memory', predefined, "
                   "or as a node object" % device)
-        return
+        raise RuntimeError(f"Cannot add device {device} to crossbar")
 
     # If we get here, inst points an instance of some block or memory. It
     # shouldn't point at a crossbar (because that would imply a naming clash)


### PR DESCRIPTION
This PR addresses some small issues issues found when playing with topgen. The context is trying to remove assumptions about names in topgen. For this experiment, I tried renaming the rv_plic to another name, and also give it a nonstandard "type name". This fails because for ipgen IP, topgen currently enforces that name==type (which can be different from the template_type however). This still caught some errors however. To reproducing things, here is the diff I was playing with:

```diff
iff --git i/hw/top_darjeeling/data/top_darjeeling.hjson w/hw/top_darjeeling/data/top_darjeeling.hjson
index 95093ee276..c49187efdd 100644
--- i/hw/top_darjeeling/data/top_darjeeling.hjson
+++ w/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -200,7 +200,7 @@
   interrupts: {
     // Any module with interrupts that doesn't specify plic
     // will have its interrupts sent here
-    default_plic: "rv_plic"
+    default_plic: "rv_plic_nuclear"
   }
 
   // `addr_spaces` names the distinct address spaces present in the device.
@@ -236,7 +236,7 @@
             "soc_proxy.core",
             "soc_dbg_ctrl.core",
             "sram_ctrl_ret_aon",
-            "rv_plic",
+            "rv_plic_nuclear",
             "aes",
             "hmac",
             "otbn",
@@ -689,8 +689,8 @@
       },
       generate_dif: "False"
     },
-    { name: "rv_plic",
-      type: "rv_plic",
+    { name: "rv_plic_nuclear",
+      type: "rv_plic_planck",
       template_type: "rv_plic",
       clock_srcs: {clk_i: "main"},
       clock_group: "secure",
@@ -1328,8 +1328,8 @@
       'otp_ctrl.otp_macro'         : ['otp_macro.otp'],
 
       // rv_plic connections
-      'rv_plic.msip' : ['rv_core_ibex.irq_software'],
-      'rv_plic.irq'  : ['rv_core_ibex.irq_external'],
+      'rv_plic_nuclear.msip' : ['rv_core_ibex.irq_software'],
+      'rv_plic_nuclear.irq'  : ['rv_core_ibex.irq_external'],
 
       // rv_dm connections
       'rv_dm.debug_req': ['rv_core_ibex.debug_req'],
diff --git i/hw/top_darjeeling/data/xbar_main.hjson w/hw/top_darjeeling/data/xbar_main.hjson
index ba00a1c0c1..e368dcd53d 100644
--- i/hw/top_darjeeling/data/xbar_main.hjson
+++ w/hw/top_darjeeling/data/xbar_main.hjson
@@ -157,11 +157,11 @@
       req_fifo_pass: false,
       rsp_fifo_pass: false,
     },
-    { name:      "rv_plic",
+    { name:      "rv_plic_nuclear",
       type:      "device",
       clock:     "clk_main_i",
       reset:     "rst_main_ni",
-      inst_type: "rv_plic",
+      inst_type: "rv_plic_planck",
       req_fifo_pass: false,
       rsp_fifo_pass: false,
     },
@@ -375,7 +375,7 @@
       "rom_ctrl0.rom", "rom_ctrl0.regs", "rom_ctrl1.rom", "rom_ctrl1.regs",
       "rv_dm.mem", "rv_dm.regs", "sram_ctrl_main.ram", "peri",
       "aes", "entropy_src", "csrng", "edn0", "edn1", "hmac",
-      "rv_plic", "otbn", "keymgr_dpe", "kmac", "sram_ctrl_main.regs",
+      "rv_plic_nuclear", "otbn", "keymgr_dpe", "kmac", "sram_ctrl_main.regs",
       "rv_core_ibex.cfg", "sram_ctrl_mbox.ram", "sram_ctrl_mbox.regs",
       "soc_proxy.ctn", "soc_proxy.core", "dma", "mbx0.core", "mbx1.core",
       "mbx2.core", "mbx3.core", "mbx4.core", "mbx5.core", "mbx6.core",
@@ -385,7 +385,7 @@
       "rom_ctrl0.rom", "rom_ctrl0.regs", "rom_ctrl1.rom", "rom_ctrl1.regs",
       "rv_dm.mem", "rv_dm.regs", "sram_ctrl_main.ram", "peri",
       "aes", "entropy_src", "csrng", "edn0", "edn1", "hmac",
-      "rv_plic", "otbn", "keymgr_dpe", "kmac", "sram_ctrl_main.regs",
+      "rv_plic_nuclear", "otbn", "keymgr_dpe", "kmac", "sram_ctrl_main.regs",
       "rv_core_ibex.cfg", "sram_ctrl_mbox.ram", "sram_ctrl_mbox.regs",
       "soc_proxy.ctn", "soc_proxy.core", "dma", "mbx0.core", "mbx1.core",
       "mbx2.core", "mbx3.core", "mbx4.core", "mbx5.core", "mbx6.core",
(python-venv) [16:18:17][pamaury@jamesBOND:/home/pamaury/project/opentitan]topgen_some_fixe$ git diff -- hw/top_darjeeling/data/*.hjson
diff --git i/hw/top_darjeeling/data/top_darjeeling.hjson w/hw/top_darjeeling/data/top_darjeeling.hjson
index 95093ee276..c49187efdd 100644
--- i/hw/top_darjeeling/data/top_darjeeling.hjson
+++ w/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -200,7 +200,7 @@
   interrupts: {
     // Any module with interrupts that doesn't specify plic
     // will have its interrupts sent here
-    default_plic: "rv_plic"
+    default_plic: "rv_plic_nuclear"
   }
 
   // `addr_spaces` names the distinct address spaces present in the device.
@@ -236,7 +236,7 @@
             "soc_proxy.core",
             "soc_dbg_ctrl.core",
             "sram_ctrl_ret_aon",
-            "rv_plic",
+            "rv_plic_nuclear",
             "aes",
             "hmac",
             "otbn",
@@ -689,8 +689,8 @@
       },
       generate_dif: "False"
     },
-    { name: "rv_plic",
-      type: "rv_plic",
+    { name: "rv_plic_nuclear",
+      type: "rv_plic_planck",
       template_type: "rv_plic",
       clock_srcs: {clk_i: "main"},
       clock_group: "secure",
@@ -1328,8 +1328,8 @@
       'otp_ctrl.otp_macro'         : ['otp_macro.otp'],
 
       // rv_plic connections
-      'rv_plic.msip' : ['rv_core_ibex.irq_software'],
-      'rv_plic.irq'  : ['rv_core_ibex.irq_external'],
+      'rv_plic_nuclear.msip' : ['rv_core_ibex.irq_software'],
+      'rv_plic_nuclear.irq'  : ['rv_core_ibex.irq_external'],
 
       // rv_dm connections
       'rv_dm.debug_req': ['rv_core_ibex.debug_req'],
diff --git i/hw/top_darjeeling/data/xbar_main.hjson w/hw/top_darjeeling/data/xbar_main.hjson
index ba00a1c0c1..e368dcd53d 100644
--- i/hw/top_darjeeling/data/xbar_main.hjson
+++ w/hw/top_darjeeling/data/xbar_main.hjson
@@ -157,11 +157,11 @@
       req_fifo_pass: false,
       rsp_fifo_pass: false,
     },
-    { name:      "rv_plic",
+    { name:      "rv_plic_nuclear",
       type:      "device",
       clock:     "clk_main_i",
       reset:     "rst_main_ni",
-      inst_type: "rv_plic",
+      inst_type: "rv_plic_planck",
       req_fifo_pass: false,
       rsp_fifo_pass: false,
     },
@@ -375,7 +375,7 @@
       "rom_ctrl0.rom", "rom_ctrl0.regs", "rom_ctrl1.rom", "rom_ctrl1.regs",
       "rv_dm.mem", "rv_dm.regs", "sram_ctrl_main.ram", "peri",
       "aes", "entropy_src", "csrng", "edn0", "edn1", "hmac",
-      "rv_plic", "otbn", "keymgr_dpe", "kmac", "sram_ctrl_main.regs",
+      "rv_plic_nuclear", "otbn", "keymgr_dpe", "kmac", "sram_ctrl_main.regs",
       "rv_core_ibex.cfg", "sram_ctrl_mbox.ram", "sram_ctrl_mbox.regs",
       "soc_proxy.ctn", "soc_proxy.core", "dma", "mbx0.core", "mbx1.core",
       "mbx2.core", "mbx3.core", "mbx4.core", "mbx5.core", "mbx6.core",
@@ -385,7 +385,7 @@
       "rom_ctrl0.rom", "rom_ctrl0.regs", "rom_ctrl1.rom", "rom_ctrl1.regs",
       "rv_dm.mem", "rv_dm.regs", "sram_ctrl_main.ram", "peri",
       "aes", "entropy_src", "csrng", "edn0", "edn1", "hmac",
-      "rv_plic", "otbn", "keymgr_dpe", "kmac", "sram_ctrl_main.regs",
+      "rv_plic_nuclear", "otbn", "keymgr_dpe", "kmac", "sram_ctrl_main.regs",
       "rv_core_ibex.cfg", "sram_ctrl_mbox.ram", "sram_ctrl_mbox.regs",
       "soc_proxy.ctn", "soc_proxy.core", "dma", "mbx0.core", "mbx1.core",
       "mbx2.core", "mbx3.core", "mbx4.core", "mbx5.core", "mbx6.core",

```