### PR TITLE
[chip, dv] Added a switch to get different randomization per instance

### DIFF
--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -124,6 +124,12 @@
   run_opts:   ["-licqueue",
                "-ucli -do {run_script}",
                "+ntb_random_seed={svseed}",
+               // In VCS, all random generation starts with an initial seed and that remains same
+               // for each instance of the module. Hence, for each instance of the same module
+               // $urandom() generates same random value.
+               // Below switch generates different randomization values per instance of a module.
+               // Refer to https://github.com/lowRISC/opentitan/issues/27659 for more details.
+               "-xlrm hier_inst_seed",
                // Disable the display of the SystemVerilog assert and cover statement summary
                // at the end of simulation. This summary is list of assertions that started but
                // did not finish because the simulation terminated, or assertions that did not


### PR DESCRIPTION
Issue [27659](https://github.com/lowRISC/opentitan/issues/27659) can give better context.

There is a discussion about tweaking DV environment to get different randomization per instance for every tool. But until then, adding the switch makes sense to get consistency in failures b/w Xcelium and VCS.