### PR TITLE
[perso] add host hook for SKU cert customization

### DIFF
--- a/sw/device/silicon_creator/manuf/extensions/default_ft_ext_lib.rs
+++ b/sw/device/silicon_creator/manuf/extensions/default_ft_ext_lib.rs
@@ -3,8 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use arrayvec::ArrayVec;
 use util_lib::response::PersonalizeResponse;
 
-pub fn ft_ext(_response: &PersonalizeResponse) -> Result<Option<String>> {
+pub fn ft_inject_certs_ext(endorsed_cert_concat: ArrayVec<u8, 5120>) -> Result<ArrayVec<u8, 5120>> {
+    Ok(endorsed_cert_concat)
+}
+
+pub fn ft_post_boot_ext(_response: &PersonalizeResponse) -> Result<Option<String>> {
     Ok(None)
 }

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -18,7 +18,7 @@ use cert_lib::{
     parse_and_endorse_x509_cert, validate_cert_chain, validate_cwt_dice_chain, CaConfig, CaKey,
     EndorsedCert,
 };
-use ft_ext_lib::ft_ext;
+use ft_ext_lib::{ft_inject_certs_ext, ft_post_boot_ext};
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::console::spi::SpiConsoleDevice;
 use opentitanlib::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg};
@@ -524,6 +524,7 @@ fn provision_certificates(
 
     // Execute extension hook.
     let t0 = Instant::now();
+    endorsed_cert_concat = ft_inject_certs_ext(endorsed_cert_concat)?;
     response.stats.log_elapsed_time("perso-ft-ext", t0);
 
     // Authenticate WAS HMAC.
@@ -718,7 +719,7 @@ pub fn check_slot_b_boot_up(
     let error_code_msg = r"BFV:.*\r\n";
 
     // Optional text requried by certain SKUs.
-    let owner_ext_string = ft_ext(response)?;
+    let owner_ext_string = ft_post_boot_ext(response)?;
 
     // Compile the full regex anchor including possible error messages and
     // expected owner FW messages.


### PR DESCRIPTION
Some SKUs may require additional certificates be injected into the perso blob that is sent from the host to the device. This adds a host-side test harness hook to enable such customization.