### PR TITLE
[hw,dma,rtl] Use top_racl_pkg to derive RACL role size

### DIFF
--- a/hw/ip/dma/data/dma.hjson
+++ b/hw/ip/dma/data/dma.hjson
@@ -52,9 +52,9 @@
       local: "false",
       expose: "true",
     },
-    { name: "SysRacl",
-      desc: "Value of `racl_vec` field in `sys` output",
-      type: "logic [dma_pkg::SYS_RACL_WIDTH-1:0]"
+    { name: "SysRaclRole",
+      desc: "RACL propagated on the Sys interface via `racl_vec`",
+      type: "top_racl_pkg::racl_role_t"
       default: "'0",
       local: "false",
       expose: "true",

--- a/hw/ip/dma/dma_pkg.core
+++ b/hw/ip/dma/dma_pkg.core
@@ -7,6 +7,8 @@ description: "DMA Engine Package"
 
 filesets:
   files_rtl:
+    depend:
+      - lowrisc:virtual_constants:top_racl_pkg
     files:
       - rtl/dma_reg_pkg.sv
       - rtl/dma_pkg.sv

--- a/hw/ip/dma/rtl/dma_pkg.sv
+++ b/hw/ip/dma/rtl/dma_pkg.sv
@@ -109,7 +109,6 @@ package dma_pkg;
   parameter int unsigned SYS_NUM_REQ_CH      = 2;
   parameter int unsigned SYS_ADDR_WIDTH      = 64;
   parameter int unsigned SYS_METADATA_WIDTH  = 3;
-  parameter int unsigned SYS_RACL_WIDTH      = 4;
   parameter int unsigned SYS_DATA_BYTEWIDTH  = 4;
   parameter int unsigned SYS_DATA_WIDTH      = SYS_DATA_BYTEWIDTH * 8;
   parameter int unsigned SYS_NUM_ERROR_TYPES = 1;
@@ -134,14 +133,14 @@ package dma_pkg;
 
   // System port request interface
   typedef struct packed {
-    logic     [SYS_NUM_REQ_CH-1:0]                         vld_vec;
-    logic     [SYS_NUM_REQ_CH-1:0][SYS_METADATA_WIDTH-1:0] metadata_vec;
-    sys_opc_e [SYS_NUM_REQ_CH-1:0]                         opcode_vec;
-    logic     [SYS_NUM_REQ_CH-1:0][SYS_ADDR_WIDTH-1:0]     iova_vec;
-    logic     [SYS_NUM_REQ_CH-1:0][SYS_RACL_WIDTH-1:0]     racl_vec;
-    logic     [SYS_DATA_WIDTH-1:0]                         write_data;
-    logic     [SYS_DATA_BYTEWIDTH-1:0]                     write_be;
-    logic     [SYS_DATA_BYTEWIDTH-1:0]                     read_be;
+    logic                     [SYS_NUM_REQ_CH-1:0]                         vld_vec;
+    logic                     [SYS_NUM_REQ_CH-1:0][SYS_METADATA_WIDTH-1:0] metadata_vec;
+    sys_opc_e                 [SYS_NUM_REQ_CH-1:0]                         opcode_vec;
+    logic                     [SYS_NUM_REQ_CH-1:0][SYS_ADDR_WIDTH-1:0]     iova_vec;
+    top_racl_pkg::racl_role_t [SYS_NUM_REQ_CH-1:0]                         racl_vec;
+    logic                     [SYS_DATA_WIDTH-1:0]                         write_data;
+    logic                     [SYS_DATA_BYTEWIDTH-1:0]                     write_be;
+    logic                     [SYS_DATA_BYTEWIDTH-1:0]                     read_be;
   } sys_req_t;
 
   // System port response interface

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -8182,13 +8182,13 @@
           name_top: DmaTlUserRsvd
         }
         {
-          name: SysRacl
-          desc: Value of `racl_vec` field in `sys` output
-          type: logic [dma_pkg::SYS_RACL_WIDTH-1:0]
+          name: SysRaclRole
+          desc: RACL propagated on the Sys interface via `racl_vec`
+          type: top_racl_pkg::racl_role_t
           default: "'0"
           local: "false"
           expose: "true"
-          name_top: DmaSysRacl
+          name_top: DmaSysRaclRole
         }
         {
           name: OtAgentId

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -116,7 +116,7 @@ module top_darjeeling #(
   parameter bit DmaEnableDataIntgGen = 1'b1,
   parameter bit DmaEnableRspDataIntgCheck = 1'b1,
   parameter logic [tlul_pkg::RsvdWidth-1:0] DmaTlUserRsvd = '0,
-  parameter logic [dma_pkg::SYS_RACL_WIDTH-1:0] DmaSysRacl = '0,
+  parameter top_racl_pkg::racl_role_t DmaSysRaclRole = '0,
   parameter int unsigned DmaOtAgentId = 0,
   // parameters for mbx0
   // parameters for mbx1
@@ -2321,7 +2321,7 @@ module top_darjeeling #(
     .EnableDataIntgGen(DmaEnableDataIntgGen),
     .EnableRspDataIntgCheck(DmaEnableRspDataIntgCheck),
     .TlUserRsvd(DmaTlUserRsvd),
-    .SysRacl(DmaSysRacl),
+    .SysRaclRole(DmaSysRaclRole),
     .OtAgentId(DmaOtAgentId)
   ) u_dma (
 


### PR DESCRIPTION
Since RACL is now within OpenTitan, derive the RACL role sizes from there instead of having a second, hard-coded parameter for the size of a RACL role.