### PR TITLE
[ci] fail merge blockers quickly when jobs failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -807,16 +807,16 @@ jobs:
     name: Merge blocker${{ github.event_name != 'pull_request' && ' (skipped)' || '' }}
     runs-on: ubuntu-latest
     needs: quick_lint
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ !cancelled() && github.event_name == 'pull_request' }}
     steps:
       - name: Complete
-        run: 'true'
+        run: ${{ needs.quick_lint.result == 'success' }}
 
   merge_blocker_merge:
     name: Merge blocker${{ github.event_name != 'merge_group' && ' (skipped)' || '' }}
     runs-on: ubuntu-latest
     needs: cache_bitstreams
-    if: ${{ github.event_name == 'merge_group' }}
+    if: ${{ !cancelled() && github.event_name == 'merge_group' }}
     steps:
       - name: Complete
-        run: 'true'
+        run: ${{ needs.cache_bitstreams.result == 'success' }}


### PR DESCRIPTION
Currently when the required job failed, the merge blockers are skipped and the merge will fail after a timeout. Change to let the merge blocker still evaluate and fail fast when this happens.