### PR TITLE
Enable perso_tlv obj_type check

### DIFF
--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
@@ -29,10 +29,11 @@ rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
   // Extract LTV object type.
   PERSO_TLV_GET_FIELD(Objh, Type, objh, &obj_type);
   obj->obj_type = obj_type;
-  /*if (obj_type != kPersoObjectTypeX509Cert &&*/
-  /*obj_type != kPersoObjectTypeCwtCert) {*/
-  /*return kErrorPersoTlvCertObjNotFound;*/
-  /*}*/
+  if (obj_type != kPersoObjectTypeX509Cert &&
+      obj_type != kPersoObjectTypeCwtCert &&
+      obj_type != kPersoObjectTypeX509Tbs) {
+    return kErrorPersoTlvCertObjNotFound;
+  }
   buf += sizeof(perso_tlv_object_header_t);
   ltv_buf_size -= sizeof(perso_tlv_object_header_t);
 


### PR DESCRIPTION
This PR re-enables previously disabled `obj_type` checks, to prevent `perso_tlv_get_cert_obj` from returning `kErrorOk` with an invalid `obj_type`.