### PR TITLE
Backport 25433 [provisioning] remove RMA token from orchestrator inputs

### DIFF
--- a/sw/host/provisioning/orchestrator/README.md
+++ b/sw/host/provisioning/orchestrator/README.md
@@ -29,7 +29,6 @@ bazel run \
     --sku-config=$(pwd)/sw/host/provisioning/orchestrator/configs/skus/emulation.hjson \
     --test-unlock-token=<token as a hexstring> \
     --test-exit-token=<token as a hexstring> \
-    --rma-unlock-token=<token as a hexstring> \
     --non-interactive
 ```
 

--- a/sw/host/provisioning/orchestrator/configs/skus/sival.hjson
+++ b/sw/host/provisioning/orchestrator/configs/skus/sival.hjson
@@ -5,11 +5,12 @@
 # OpenTitan SIVAL SKU configuration.
 
 {
-  name: "emulation",
+  name: "sival",
   product: "earlgrey_a1",
   si_creator: "nuvoton",
   package: "npcr10",
   target_lc_state: "prod",
+  # TODO: update with real CA and RMA token keys.
   dice_ca: {
     certificate: "sw/device/silicon_creator/manuf/keys/fake/dice_ca.pem",
     key: "sw/device/silicon_creator/manuf/keys/fake/sk.pkcs8.der",

--- a/sw/host/provisioning/orchestrator/src/orchestrator.py
+++ b/sw/host/provisioning/orchestrator/src/orchestrator.py
@@ -91,11 +91,6 @@ def main(args_in):
         help="Raw test exit token to inject into OTP SECRET0 partition.",
     )
     parser.add_argument(
-        "--rma-unlock-token",
-        type=parse_hexstring_to_int,
-        help="Raw RMA token to inject into OTP SECRET2 partition.",
-    )
-    parser.add_argument(
         "--fpga",
         choices=["hyper310", "cw340"],
         help="Run flow on FPGA (instead of silicon).",
@@ -146,7 +141,6 @@ def main(args_in):
                 device_id=device_id,
                 test_unlock_token=args.test_unlock_token,
                 test_exit_token=args.test_exit_token,
-                rma_unlock_token=args.rma_unlock_token,
                 fpga=args.fpga,
                 require_confirmation=not args.non_interactive)
     dut.run_cp()

--- a/sw/host/provisioning/orchestrator/src/ot_dut.py
+++ b/sw/host/provisioning/orchestrator/src/ot_dut.py
@@ -44,7 +44,6 @@ class OtDut():
     device_id: DeviceId
     test_unlock_token: str
     test_exit_token: str
-    rma_unlock_token: str
     fpga: str
     require_confirmation: bool = True
 
@@ -86,10 +85,8 @@ class OtDut():
         --logging=info \
         {host_flags} \
         --elf={device_elf} \
-        --device-id="{self.device_id}" \
         --test-unlock-token="{format_hex(self.test_unlock_token, width=32)}" \
         --test-exit-token="{format_hex(self.test_exit_token, width=32)}" \
-        --manuf-state="{_ZERO_256BIT_HEXSTR}" \
         --wafer-auth-secret="{_ZERO_256BIT_HEXSTR}" \
         """
 
@@ -173,8 +170,6 @@ class OtDut():
             --ca-config={ca_config_file.name} \
             --token-encrypt-key-der-file={self.sku_config.token_encrypt_key} \
             """
-            if self.rma_unlock_token is not None:
-                cmd += f'--rma-unlock-token="{format_hex(self.rma_unlock_token, width=32)}" \\\n'
 
             # Get user confirmation before running command.
             logging.info(f"Running command: {cmd}")

--- a/sw/host/provisioning/orchestrator/tests/device_id_test.py
+++ b/sw/host/provisioning/orchestrator/tests/device_id_test.py
@@ -129,7 +129,7 @@ class TestDeviceId(unittest.TestCase):
                 format_hex(expected_field, width=4)))
 
     def test_sku_id_field(self):
-        expected_field = bytes_to_int("LUME".encode("utf-8"))
+        expected_field = bytes_to_int("AVIS".encode("utf-8"))
         actual_field = (self.device_id.to_int() >> 160) & 0xffffffff
         self.assertEqual(
             actual_field, expected_field, "actual: {}, expected: {}.".format(


### PR DESCRIPTION
**DO NOT MERGE before https://github.com/lowRISC/opentitan/pull/27881,**

Backport [provisioning] remove RMA token from orchestrator inputs #25433
 ([provisioning] remove RMA token from orchestrator inputs) 