### PR TITLE
[rstmgr] Avoid consistency check failures due to CDC instrumentation

### DIFF
--- a/hw/ip_templates/rstmgr/rtl/rstmgr_cnsty_chk.sv
+++ b/hw/ip_templates/rstmgr/rtl/rstmgr_cnsty_chk.sv
@@ -57,7 +57,20 @@ module rstmgr_cnsty_chk
   logic sync_parent_rst;
   prim_flop_2sync #(
     .Width(1),
-    .ResetValue(1)
+    .ResetValue(1),
+    // We disable CDC randomization for this instance to prevent the CDC instrumentation from
+    // delaying the parent reset de-assertion until after the child reset de-assertion which would
+    // trigger a consistency check failure.
+    //
+    // This is fine as this scenario cannot occur in reality:
+    // Both parent_rst_asserted and child_rst_asserted are synchronous to the same clock, and the
+    // child_rst_ni reset of the latter is derived from the parent_rst_ni of the former using a
+    // 2-flop synchronizer (see u_rst_sync in rstmgr_leaf_rst) which is clocked using the same
+    // clock (clk_io_div4_i). This means child_rst_asserted always de-asserts after
+    // parent_rst_asserted unless we are under attack.
+    //
+    // For details, refer to https://github.com/lowRISC/opentitan/issues/27659 .
+    .EnablePrimCdcRand(0)
   ) u_parent_sync (
     .clk_i,
     .rst_ni,

--- a/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_cnsty_chk.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_cnsty_chk.sv
@@ -57,7 +57,20 @@ module rstmgr_cnsty_chk
   logic sync_parent_rst;
   prim_flop_2sync #(
     .Width(1),
-    .ResetValue(1)
+    .ResetValue(1),
+    // We disable CDC randomization for this instance to prevent the CDC instrumentation from
+    // delaying the parent reset de-assertion until after the child reset de-assertion which would
+    // trigger a consistency check failure.
+    //
+    // This is fine as this scenario cannot occur in reality:
+    // Both parent_rst_asserted and child_rst_asserted are synchronous to the same clock, and the
+    // child_rst_ni reset of the latter is derived from the parent_rst_ni of the former using a
+    // 2-flop synchronizer (see u_rst_sync in rstmgr_leaf_rst) which is clocked using the same
+    // clock (clk_io_div4_i). This means child_rst_asserted always de-asserts after
+    // parent_rst_asserted unless we are under attack.
+    //
+    // For details, refer to https://github.com/lowRISC/opentitan/issues/27659 .
+    .EnablePrimCdcRand(0)
   ) u_parent_sync (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr_cnsty_chk.sv
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr_cnsty_chk.sv
@@ -57,7 +57,20 @@ module rstmgr_cnsty_chk
   logic sync_parent_rst;
   prim_flop_2sync #(
     .Width(1),
-    .ResetValue(1)
+    .ResetValue(1),
+    // We disable CDC randomization for this instance to prevent the CDC instrumentation from
+    // delaying the parent reset de-assertion until after the child reset de-assertion which would
+    // trigger a consistency check failure.
+    //
+    // This is fine as this scenario cannot occur in reality:
+    // Both parent_rst_asserted and child_rst_asserted are synchronous to the same clock, and the
+    // child_rst_ni reset of the latter is derived from the parent_rst_ni of the former using a
+    // 2-flop synchronizer (see u_rst_sync in rstmgr_leaf_rst) which is clocked using the same
+    // clock (clk_io_div4_i). This means child_rst_asserted always de-asserts after
+    // parent_rst_asserted unless we are under attack.
+    //
+    // For details, refer to https://github.com/lowRISC/opentitan/issues/27659 .
+    .EnablePrimCdcRand(0)
   ) u_parent_sync (
     .clk_i,
     .rst_ni,

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr_cnsty_chk.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr_cnsty_chk.sv
@@ -57,7 +57,20 @@ module rstmgr_cnsty_chk
   logic sync_parent_rst;
   prim_flop_2sync #(
     .Width(1),
-    .ResetValue(1)
+    .ResetValue(1),
+    // We disable CDC randomization for this instance to prevent the CDC instrumentation from
+    // delaying the parent reset de-assertion until after the child reset de-assertion which would
+    // trigger a consistency check failure.
+    //
+    // This is fine as this scenario cannot occur in reality:
+    // Both parent_rst_asserted and child_rst_asserted are synchronous to the same clock, and the
+    // child_rst_ni reset of the latter is derived from the parent_rst_ni of the former using a
+    // 2-flop synchronizer (see u_rst_sync in rstmgr_leaf_rst) which is clocked using the same
+    // clock (clk_io_div4_i). This means child_rst_asserted always de-asserts after
+    // parent_rst_asserted unless we are under attack.
+    //
+    // For details, refer to https://github.com/lowRISC/opentitan/issues/27659 .
+    .EnablePrimCdcRand(0)
   ) u_parent_sync (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
The module is built such that the parent reset can never de-assert after the child reset. However, depending on the simulation tool and its settings, the CDC instrumentation may delay the synchronization of the parent reset de-assertion until after the child reset de-assertion which then triggers an unexpected consistency check failure. To avoid this, we disable the CDC randomization for the parent reset assertion synchronization.

This is related to lowRISC/OpenTitan#27659.