### PR TITLE
[dtgen] Correctly handle the case where the plic is not named rv_plic

### DIFF
--- a/util/dtgen/dt_api.c.tpl
+++ b/util/dtgen/dt_api.c.tpl
@@ -26,9 +26,8 @@ else:
 #include <stdint.h>
 
 <%
-  top_plic_irq_id_name = Name.from_snake_case("top_" + helper.top["name"] + "_plic_irq_id")
-  top_plic_irq_id_last = top_plic_irq_id_name + Name(["last"])
-  top_plic_irq_id_count = top_plic_irq_id_name + Name(["count"])
+  top_plic_irq_id_last = helper.the_plic_irq_id_type_name + Name(["last"])
+  top_plic_irq_id_count = helper.the_plic_irq_id_type_name + Name(["count"])
 %>
 enum {
   ${top_plic_irq_id_count.as_c_enum()} = ${top_plic_irq_id_last.as_c_enum()} + 1,

--- a/util/dtgen/dt_api.h.tpl
+++ b/util/dtgen/dt_api.h.tpl
@@ -70,10 +70,10 @@ dt_device_type_t dt_device_type(dt_instance_id_t id);
  * This is an alias to the top's `plic_irq_id_t` type for backward compatibility
  * with existing code.
  */
-typedef ${top_name.as_snake_case()}_plic_irq_id_t dt_plic_irq_id_t;
+typedef ${helper.the_plic_irq_id_type_name.as_c_type()} dt_plic_irq_id_t;
 
 /** PLIC IRQ ID for no interrupt. */
-static const dt_plic_irq_id_t kDtPlicIrqIdNone=${top_name.as_c_enum()}PlicIrqIdNone;
+static const dt_plic_irq_id_t kDtPlicIrqIdNone = ${helper.the_plic_irq_id_type_name.as_c_enum()}None;
 
 /**
  * Get the instance ID for a given PLIC IRQ ID.


### PR DESCRIPTION
The code was assuming in quite a few places that the PLIC is named `rv_plic`. This PR fixes the code by having the helper find the name of the PLIC and use that everywhere. Note that `dtgen` still currently assumes that there is a single PLIC.

This was tested by using the following diff and compiling the DT headers:
```diff
diff --git i/hw/top_darjeeling/data/top_darjeeling.hjson w/hw/top_darjeeling/data/top_darjeeling.hjson
index 408a0a28a4..038950d9b5 100644
--- i/hw/top_darjeeling/data/top_darjeeling.hjson
+++ w/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -198,7 +198,7 @@
 
   // Any module with interrupts that doesn't specify plic
   // will have its interrupts sent here
-  default_plic: "rv_plic"
+  default_plic: "my_plic"
 
   // Any module with alerts that doesn't specify alert_handler
   // will have its alerts sent here
@@ -237,7 +237,7 @@
             "soc_proxy.core",
             "soc_dbg_ctrl.core",
             "sram_ctrl_ret_aon",
-            "rv_plic",
+            "my_plic",
             "aes",
             "hmac",
             "otbn",
@@ -690,8 +690,8 @@
       },
       generate_dif: "False"
     },
-    { name: "rv_plic",
-      type: "rv_plic",
+    { name: "my_plic",
+      type: "my_plic",
       template_type: "rv_plic",
       clock_srcs: {clk_i: "main"},
       clock_group: "secure",
@@ -1329,8 +1329,8 @@
       'otp_ctrl.otp_macro'         : ['otp_macro.otp'],
 
       // rv_plic connections
-      'rv_plic.msip' : ['rv_core_ibex.irq_software'],
-      'rv_plic.irq'  : ['rv_core_ibex.irq_external'],
+      'my_plic.msip' : ['rv_core_ibex.irq_software'],
+      'my_plic.irq'  : ['rv_core_ibex.irq_external'],
 
       // rv_dm connections
       'rv_dm.debug_req': ['rv_core_ibex.debug_req'],
diff --git i/hw/top_darjeeling/data/xbar_main.hjson w/hw/top_darjeeling/data/xbar_main.hjson
index ba00a1c0c1..ba3e0a895c 100644
--- i/hw/top_darjeeling/data/xbar_main.hjson
+++ w/hw/top_darjeeling/data/xbar_main.hjson
@@ -157,11 +157,11 @@
       req_fifo_pass: false,
       rsp_fifo_pass: false,
     },
-    { name:      "rv_plic",
+    { name:      "my_plic",
       type:      "device",
       clock:     "clk_main_i",
       reset:     "rst_main_ni",
-      inst_type: "rv_plic",
+      inst_type: "rv_plic_planck",
       req_fifo_pass: false,
       rsp_fifo_pass: false,
     },
@@ -375,7 +375,7 @@
       "rom_ctrl0.rom", "rom_ctrl0.regs", "rom_ctrl1.rom", "rom_ctrl1.regs",
       "rv_dm.mem", "rv_dm.regs", "sram_ctrl_main.ram", "peri",
       "aes", "entropy_src", "csrng", "edn0", "edn1", "hmac",
-      "rv_plic", "otbn", "keymgr_dpe", "kmac", "sram_ctrl_main.regs",
+      "my_plic", "otbn", "keymgr_dpe", "kmac", "sram_ctrl_main.regs",
       "rv_core_ibex.cfg", "sram_ctrl_mbox.ram", "sram_ctrl_mbox.regs",
       "soc_proxy.ctn", "soc_proxy.core", "dma", "mbx0.core", "mbx1.core",
       "mbx2.core", "mbx3.core", "mbx4.core", "mbx5.core", "mbx6.core",
@@ -385,7 +385,7 @@
       "rom_ctrl0.rom", "rom_ctrl0.regs", "rom_ctrl1.rom", "rom_ctrl1.regs",
       "rv_dm.mem", "rv_dm.regs", "sram_ctrl_main.ram", "peri",
       "aes", "entropy_src", "csrng", "edn0", "edn1", "hmac",
-      "rv_plic", "otbn", "keymgr_dpe", "kmac", "sram_ctrl_main.regs",
+      "my_plic", "otbn", "keymgr_dpe", "kmac", "sram_ctrl_main.regs",
       "rv_core_ibex.cfg", "sram_ctrl_mbox.ram", "sram_ctrl_mbox.regs",
       "soc_proxy.ctn", "soc_proxy.core", "dma", "mbx0.core", "mbx1.core",
       "mbx2.core", "mbx3.core", "mbx4.core", "mbx5.core", "mbx6.core",
```