### PR TITLE
[sw,sram_program] Add stack region overlapping check

### DIFF
--- a/sw/device/examples/sram_program/sram_program.ld
+++ b/sw/device/examples/sram_program/sram_program.ld
@@ -59,23 +59,23 @@ SECTIONS {
      * hopefully only take one instruction. Other data will likely need
      * multiple instructions to load, so we're less concerned about address
      * materialisation taking more than one instruction. */
-    KEEP(*(.srodata))
-    KEEP(*(.srodata.*))
-    KEEP(*(.rodata))
-    KEEP(*(.rodata.*))
+    *(.srodata)
+    *(.srodata.*)
+    *(.rodata)
+    *(.rodata.*)
     . = ALIGN(4);
-    KEEP(*(.sdata))
-    KEEP(*(.sdata.*))
-    KEEP(*(.data))
-    KEEP(*(.data.*))
+    *(.sdata)
+    *(.sdata.*)
+    *(.data)
+    *(.data.*)
     . = ALIGN(4);
-    KEEP(*(.text))
-    KEEP(*(.text.*))
+    *(.text)
+    *(.text.*)
     . = ALIGN(4);
-    KEEP(*(.sbss))
-    KEEP(*(.sbss.*))
-    KEEP(*(.bss))
-    KEEP(*(.bss.*))
+    *(.sbss)
+    *(.sbss.*)
+    *(.bss)
+    *(.bss.*)
     . = ALIGN(4);
   } > ram_main
 

--- a/sw/device/silicon_creator/manuf/lib/sram_program.ld
+++ b/sw/device/silicon_creator/manuf/lib/sram_program.ld
@@ -113,6 +113,11 @@ SECTIONS {
     /* Ensure section end is word-aligned. */
     . = ALIGN(4);
     _bss_end = .;
+
+    ASSERT(
+      ABSOLUTE(_stack_start) >= ABSOLUTE(_bss_end),
+      "bss section overflowed to stack region");
+
   } > ram_main : sram_segment
 
   INCLUDE sw/device/info_sections.ld

--- a/sw/device/silicon_creator/manuf/lib/sram_program.ld
+++ b/sw/device/silicon_creator/manuf/lib/sram_program.ld
@@ -58,16 +58,16 @@ SECTIONS {
   } > ram_main : sram_segment
 
   .text : ALIGN(4) {
-    KEEP(*(.crt))
-    KEEP(*(.text))
-    KEEP(*(.text.*))
+    *(.crt)
+    *(.text)
+    *(.text.*)
     . = ALIGN(4);
     _text_end = .;
   } > ram_main : sram_segment
 
   .rodata : ALIGN(4) {
-    KEEP(*(.rodata))
-    KEEP(*(.rodata.*))
+    *(.rodata)
+    *(.rodata.*)
     . = ALIGN(4);
     __rodata_end = .;
   } > ram_main : sram_segment
@@ -83,14 +83,14 @@ SECTIONS {
      * difference to distinguish data from small data. */
     __global_pointer$ = . + 2048;
 
-    KEEP(*(.data))
-    KEEP(*(.data.*))
+    *(.data)
+    *(.data.*)
 
     /* Place all small data sections together. */
-    KEEP(*(.srodata))
-    KEEP(*(.srodata.*))
-    KEEP(*(.sdata))
-    KEEP(*(.sdata.*))
+    *(.srodata)
+    *(.srodata.*)
+    *(.sdata)
+    *(.sdata.*)
     . = ALIGN(4);
     _crc_end = .;
   } > ram_main : sram_segment


### PR DESCRIPTION
The bss section of the SRAM provisioning program silently overflowed into the allocated stack region. This PR partially cherrypicked the KEEP fixes from #26354 to fix it:
* `[sw,sram_program] Don't KEEP() all sections`  commit from:
  * #26354

This PR also adds a check to detect when the bss section overlaps with the stack.

---

Result of `//sw/device/silicon_creator/manuf/base/sram_ft_individualize_sival_fpga_hyper310_rom_with_fake_keys.elf`:

Before: (bss ends at 0x1001e294, while stack starts at 0x1001c000)
```
  [ 6] .bss              NOBITS          1001b998 019a98 002900 00  WA  0   0  4
```

After:
```
  [ 6] .bss              NOBITS          1000d21c 00b31c 0009b0 00  WA  0   0  4
```