### PR TITLE
[sw,base] Reduce the size of macro expansion of TRY/INTO_STATUS

### DIFF
--- a/sw/device/lib/crypto/impl/status.h
+++ b/sw/device/lib/crypto/impl/status.h
@@ -28,22 +28,27 @@ extern "C" {
 #define OTCRYPTO_OK ((status_t){.value = kHardenedBoolTrue})
 #ifdef OTCRYPTO_STATUS_DEBUG
 
-#define OTCRYPTO_RECOV_ERR                                \
-  ((status_t){.value = (int32_t)(0x80000000 | MODULE_ID | \
+#define OTCRYPTO_RECOV_ERR                                                  \
+  ((status_t){.value = (int32_t)(0x80000000 |                               \
+                                 status_encode_module_id(MODULE_ID) << 16 | \
                                  ((__LINE__ & 0x7ff) << 5) | kAborted)})
-#define OTCRYPTO_FATAL_ERR                           \
-  ((status_t){.value =                               \
-                  (int32_t)(0x80000000 | MODULE_ID | \
+#define OTCRYPTO_FATAL_ERR                                             \
+  ((status_t){.value =                                                 \
+                  (int32_t)(0x80000000 |                               \
+                            status_encode_module_id(MODULE_ID) << 16 | \
                             ((__LINE__ & 0x7ff) << 5) | kFailedPrecondition)})
-#define OTCRYPTO_BAD_ARGS                            \
-  ((status_t){.value =                               \
-                  (int32_t)(0x80000000 | MODULE_ID | \
+#define OTCRYPTO_BAD_ARGS                                              \
+  ((status_t){.value =                                                 \
+                  (int32_t)(0x80000000 |                               \
+                            status_encode_module_id(MODULE_ID) << 16 | \
                             ((__LINE__ & 0x7ff) << 5) | kInvalidArgument)})
-#define OTCRYPTO_ASYNC_INCOMPLETE                         \
-  ((status_t){.value = (int32_t)(0x80000000 | MODULE_ID | \
+#define OTCRYPTO_ASYNC_INCOMPLETE                                           \
+  ((status_t){.value = (int32_t)(0x80000000 |                               \
+                                 status_encode_module_id(MODULE_ID) << 16 | \
                                  ((__LINE__ & 0x7ff) << 5) | kUnavailable)})
-#define OTCRYPTO_NOT_IMPLEMENTED                          \
-  ((status_t){.value = (int32_t)(0x80000000 | MODULE_ID | \
+#define OTCRYPTO_NOT_IMPLEMENTED                                            \
+  ((status_t){.value = (int32_t)(0x80000000 |                               \
+                                 status_encode_module_id(MODULE_ID) << 16 | \
                                  ((__LINE__ & 0x7ff) << 5) | kUnimplemented)})
 #else
 

--- a/sw/device/tests/penetrationtests/json/cryptolib_fi_asym_commands.h
+++ b/sw/device/tests/penetrationtests/json/cryptolib_fi_asym_commands.h
@@ -21,6 +21,8 @@ extern "C" {
 #define ED25519_CMD_MAX_MSG_BYTES 128
 #define ED25519_CMD_SIG_BYTES 64
 
+#define MODULE_ID MAKE_MODULE_ID('j', 's', 'a')
+
 // clang-format off
 
 #define CRYPTOLIBFIASYM_SUBCOMMAND(_, value) \
@@ -544,6 +546,8 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymED25519VerifyIn, cryptolib_fi_asym_ed25519_ver
     field(ast_alerts, uint32_t, 2) \
     field(cfg, size_t)
 UJSON_SERDE_STRUCT(CryptoLibFiAsymED25519VerifyOut, cryptolib_fi_asym_ed25519_verify_out_t, CRYPTOLIBFIASYM_ED25519_VERIFY_OUT);
+
+#undef MODULE_ID
 
 // clang-format on
 

--- a/sw/host/opentitanlib/src/util/status.rs
+++ b/sw/host/opentitanlib/src/util/status.rs
@@ -124,12 +124,10 @@ mod test {
         const ARG: i32 = 42;
         let mod_id_bytes = MOD_ID.as_bytes();
         assert_eq!(mod_id_bytes.len(), 3);
-        // Unfortunately the input to status_create assumes that the module ID value
-        // is already shifted and we cannot extract the MAKE_MODULE_ID macro from the
-        // headers using bindgen.
+        // The following reimplement the MAKE_MODULE_ID macro in rust.
         let mod_id_val = ((mod_id_bytes[0].to_ascii_uppercase() as u32) << 16)
-            | ((mod_id_bytes[1].to_ascii_uppercase() as u32) << 21)
-            | ((mod_id_bytes[2].to_ascii_uppercase() as u32) << 26);
+            | ((mod_id_bytes[1].to_ascii_uppercase() as u32) << 8)
+            | (mod_id_bytes[2].to_ascii_uppercase() as u32);
         let raw_status = status_create_safe(CODE, mod_id_val, "".to_string(), ARG);
 
         // Now decode status.

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -331,6 +331,7 @@ cc_args(
         "-Wstrict-prototypes",
         "-Wswitch-default",
         "-Wtype-limits",
+        "-Wno-gnu-auto-type",
     ],
 )
 


### PR DESCRIPTION
Those macros expand to a large number of lines. When used in the usjon parser with complex structure, it can easily produced 100000+ lines of code which take a very long time to compile.

The main aim of this rewrite that to guarantee that `TRY(x)` only expands `x` **once**. Currently the code `x` multiple times and if the `x` itself contains another `TRY`, things can quickly escalate. Unfortunately, in order to only expand `x` once **AND** know it type, I think the only option is to use an auto type which is not standard. In the PR, I am using `__auto_type` which is a GCC extension but which is well supported by Clang.

On top of that, the PR goes a step further and moves the status conversion to a dedicated `static inline __into_status` routine. This has the advantage of making the code more readable but also avoid producing large amount of code that the compiler will then have to discard. Finally, we also avoid making `MAKE_MODULE_ID` complicated because it is used hundred of times, and instead move the "to 5-bit ASCII" conversion to `status_create`.

**Benchmark**
In order to run a comparison, I did the following first:
```console
time ./bazelisk.sh build //sw/device/tests/penetrationtests/json:cryptolib_sca_asym_commands
```
Before PR: 17s
After PR: 2s

Another metric is the number/size of the line after the preprocessor. This can be done as follows:
```console
./bazelisk.sh build //sw/device/tests/penetrationtests/json:cryptolib_sca_asym_commands --save_temps
# look for *.i file in output and run
ls -lh path_to_file.i
```
Before PR: 11M
After PR: 1.5M

I also looked at the code size of some cryptolib firmware and did not observe any change.

**Remark:** this is the result of many iterations and tests. This is surprisingly subtle, small changes can lead to vast compile time or code size differences. If there are other important binaries whose size should be tested, let me know.