### PR TITLE
[mbx] Declare WDATA as a rw register

### DIFF
--- a/hw/ip/mbx/data/mbx.hjson
+++ b/hw/ip/mbx/data/mbx.hjson
@@ -461,7 +461,7 @@
       { window: {
           name: "WDATA"
           items: "1"
-          swaccess: "wo"
+          swaccess: "rw"
           desc: '''DOE mailbox write data register.
                 The DOE instance receives data objects via writes to this register.
                 A successful write adds one DWORD to the data object being assembled in the DOE instance.

--- a/hw/ip/mbx/doc/registers.md
+++ b/hw/ip/mbx/doc/registers.md
@@ -425,7 +425,7 @@ A write of 1 to the DOE Go bit in the DOE Control Register marks the completion 
 
 - Word Aligned Offset Range: `0x10`to`0x10`
 - Size (words): `1`
-- Access: `wo`
+- Access: `rw`
 - Byte writes are *not* supported.
 
 ## RDATA


### PR DESCRIPTION
Since reading WDATA is defined to return a value or zero rather than raise a TL-UL error in response, define it as a `rw` window; otherwise the csr/mem testing will fail on this memory window.

~~@Razer6 - is this appropriate for the SoC side? There is CIP code that tries to read from windows that are declared 'write only' and it expects a TL-UL error in response, so an alternative to marking it as 'rw' would be to loop back the '_re' signal to the 'error_i' on the tlul_adapter_reg, but the RTL annotates the return of zero as read data.~~ Thanks.