### PR TITLE
[pinmux,rtl] Fix minor mistake in assertion

### DIFF
--- a/hw/ip_templates/pinmux/rtl/pinmux_strap_sampling.sv.tpl
+++ b/hw/ip_templates/pinmux/rtl/pinmux_strap_sampling.sv.tpl
@@ -220,7 +220,7 @@ module pinmux_strap_sampling
       lc_tx_test_false_loose(pinmux_hw_debug_en_q) ##1
       lc_tx_test_true_strict(pinmux_hw_debug_en_q)
       |->
-      $past(lc_tx_test_true_strict(lc_hw_debug_en[0])))
+      lc_tx_test_true_strict($past(lc_hw_debug_en[0])))
   // Check that latching ON can only occur if strap_en_i is set.
   `ASSERT(LcHwDebugEnSetRev1_A,
       lc_tx_test_false_loose(pinmux_hw_debug_en_q) ##1

--- a/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_strap_sampling.sv
+++ b/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_strap_sampling.sv
@@ -217,7 +217,7 @@ module pinmux_strap_sampling
       lc_tx_test_false_loose(pinmux_hw_debug_en_q) ##1
       lc_tx_test_true_strict(pinmux_hw_debug_en_q)
       |->
-      $past(lc_tx_test_true_strict(lc_hw_debug_en[0])))
+      lc_tx_test_true_strict($past(lc_hw_debug_en[0])))
   // Check that latching ON can only occur if strap_en_i is set.
   `ASSERT(LcHwDebugEnSetRev1_A,
       lc_tx_test_false_loose(pinmux_hw_debug_en_q) ##1

--- a/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_strap_sampling.sv
+++ b/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_strap_sampling.sv
@@ -218,7 +218,7 @@ module pinmux_strap_sampling
       lc_tx_test_false_loose(pinmux_hw_debug_en_q) ##1
       lc_tx_test_true_strict(pinmux_hw_debug_en_q)
       |->
-      $past(lc_tx_test_true_strict(lc_hw_debug_en[0])))
+      lc_tx_test_true_strict($past(lc_hw_debug_en[0])))
   // Check that latching ON can only occur if strap_en_i is set.
   `ASSERT(LcHwDebugEnSetRev1_A,
       lc_tx_test_false_loose(pinmux_hw_debug_en_q) ##1

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_strap_sampling.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_strap_sampling.sv
@@ -218,7 +218,7 @@ module pinmux_strap_sampling
       lc_tx_test_false_loose(pinmux_hw_debug_en_q) ##1
       lc_tx_test_true_strict(pinmux_hw_debug_en_q)
       |->
-      $past(lc_tx_test_true_strict(lc_hw_debug_en[0])))
+      lc_tx_test_true_strict($past(lc_hw_debug_en[0])))
   // Check that latching ON can only occur if strap_en_i is set.
   `ASSERT(LcHwDebugEnSetRev1_A,
       lc_tx_test_false_loose(pinmux_hw_debug_en_q) ##1


### PR DESCRIPTION
The existing version of the assertion applied $past to an arbitrary expression, rather than a signal. This causes warnings in FPV like this:

    [WARN (VERI-2560)] src/lowrisc_earlgrey_ip_pinmux_0.1/rtl/pinmux_strap_sampling.sv(221): use of automatic variable 'lc_tx_test_true_strict' in sampled value function is illegal in SystemVerilog 1800-2009 dialect

Fortunately, the fix is trivial.