### PR TITLE
[prim,fpv] Avoid prim_clock_mux2 using $isunknown in FPV

### DIFF
--- a/hw/ip/prim_generic/rtl/prim_clock_mux2.sv
+++ b/hw/ip/prim_generic/rtl/prim_clock_mux2.sv
@@ -16,10 +16,16 @@ module prim_clock_mux2 #(
   // We model the mux with logic operations for GTECH runs.
   assign clk_o = (sel_i & clk1_i) | (~sel_i & clk0_i);
 
-  // make sure sel is never X (including during reset)
-  // need to use ##1 as this could break with inverted clocks that
-  // start with a rising edge at the beginning of the simulation.
+  // Make sure sel is never X.
+  //
+  // So that this can be a clocked assertion, we check it on the posedge of each input clock.
+  //
+  // This is disabled for FPV runs (because some formal tools don't have a concept of "X"). The
+  // assertion comes after a ##1 to allow inverted clocks that start with a rising edge at the
+  // beginning of the simulation.
+`ifndef FPV_ON
   `ASSERT(selKnown0, ##1 !$isunknown(sel_i), clk0_i, 0)
   `ASSERT(selKnown1, ##1 !$isunknown(sel_i), clk1_i, 0)
+`endif
 
 endmodule : prim_clock_mux2


### PR DESCRIPTION
Jasper's behaviour is to make $isunknown(...) = 0, so this won't change anything in the results of formal runs. But it gets rid of a couple of warnings.

Since I was reasoning about this carefully, I've also tidied up the comment a bit. In particular, the "including during reset" note is bogus: there is no reset signal!