### PR TITLE
[pinmux,rtl] Tweak the FpvSecCmBusIntegrity_A assertion

### DIFF
--- a/hw/ip_templates/pinmux/rtl/pinmux.sv.tpl
+++ b/hw/ip_templates/pinmux/rtl/pinmux.sv.tpl
@@ -712,11 +712,10 @@ module pinmux
   //   `ASSERT_KNOWN_IF(DioOutKnownO_A, dio_out_o[k], dio_oe_o[k])
   // end
 
-  // Pinmux does not have a block-level DV environment, hence we add an FPV assertion to test this.
-  `ASSERT(FpvSecCmBusIntegrity_A,
-          $rose(u_reg.intg_err)
-          |->
-          ${"##"}[0:`_SEC_CM_ALERT_MAX_CYC] (alert_tx_o[0].alert_p))
+  // Check that an integrity error in the register block will cause the alert sender to be told to
+  // send an alert. This is equivalent to ASSERT_ERROR_TRIGGER_ALERT_IN (but doesn't set
+  // unused_assert_connected, because that signal doesn't exist).
+  `ASSERT(FpvSecCmBusIntegrity_A, $rose(u_reg.intg_err) |-> ##[0:1] alerts[0])
 
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[0])

--- a/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux.sv
+++ b/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux.sv
@@ -511,11 +511,10 @@ module pinmux
   //   `ASSERT_KNOWN_IF(DioOutKnownO_A, dio_out_o[k], dio_oe_o[k])
   // end
 
-  // Pinmux does not have a block-level DV environment, hence we add an FPV assertion to test this.
-  `ASSERT(FpvSecCmBusIntegrity_A,
-          $rose(u_reg.intg_err)
-          |->
-          ##[0:`_SEC_CM_ALERT_MAX_CYC] (alert_tx_o[0].alert_p))
+  // Check that an integrity error in the register block will cause the alert sender to be told to
+  // send an alert. This is equivalent to ASSERT_ERROR_TRIGGER_ALERT_IN (but doesn't set
+  // unused_assert_connected, because that signal doesn't exist).
+  `ASSERT(FpvSecCmBusIntegrity_A, $rose(u_reg.intg_err) |-> ##[0:1] alerts[0])
 
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[0])

--- a/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux.sv
+++ b/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux.sv
@@ -682,11 +682,10 @@ module pinmux
   //   `ASSERT_KNOWN_IF(DioOutKnownO_A, dio_out_o[k], dio_oe_o[k])
   // end
 
-  // Pinmux does not have a block-level DV environment, hence we add an FPV assertion to test this.
-  `ASSERT(FpvSecCmBusIntegrity_A,
-          $rose(u_reg.intg_err)
-          |->
-          ##[0:`_SEC_CM_ALERT_MAX_CYC] (alert_tx_o[0].alert_p))
+  // Check that an integrity error in the register block will cause the alert sender to be told to
+  // send an alert. This is equivalent to ASSERT_ERROR_TRIGGER_ALERT_IN (but doesn't set
+  // unused_assert_connected, because that signal doesn't exist).
+  `ASSERT(FpvSecCmBusIntegrity_A, $rose(u_reg.intg_err) |-> ##[0:1] alerts[0])
 
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[0])

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux.sv
@@ -682,11 +682,10 @@ module pinmux
   //   `ASSERT_KNOWN_IF(DioOutKnownO_A, dio_out_o[k], dio_oe_o[k])
   // end
 
-  // Pinmux does not have a block-level DV environment, hence we add an FPV assertion to test this.
-  `ASSERT(FpvSecCmBusIntegrity_A,
-          $rose(u_reg.intg_err)
-          |->
-          ##[0:`_SEC_CM_ALERT_MAX_CYC] (alert_tx_o[0].alert_p))
+  // Check that an integrity error in the register block will cause the alert sender to be told to
+  // send an alert. This is equivalent to ASSERT_ERROR_TRIGGER_ALERT_IN (but doesn't set
+  // unused_assert_connected, because that signal doesn't exist).
+  `ASSERT(FpvSecCmBusIntegrity_A, $rose(u_reg.intg_err) |-> ##[0:1] alerts[0])
 
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[0])


### PR DESCRIPTION
This is analogous to the change we made in e.g. rom_ctrl (commit 0f7e1226574), where we change the assertion to actually be true.

In both cases, the original version of the assertion wasn't strictly true because the alert receiver could stall the communication from the alert sender, meaning that the alert_p signal would never go high.

Since we verify the alert system separately, this commit simplifies things by just checking that we *ask* the alert system to do something.