### PR TITLE
[pinmux,fpv] Correct the MioJtagAttrO_A assertion

### DIFF
--- a/hw/ip_templates/pinmux/data/pinmux_fpv_testplan.hjson
+++ b/hw/ip_templates/pinmux/data/pinmux_fpv_testplan.hjson
@@ -520,7 +520,8 @@
     }
     {
       name: MioJtagAttrO_A
-      desc: "If jtag is enabled, the jtag `mio_attr_o` index should be equal to 0."
+      desc: '''If JTAG is enabled, each padring attribute should be clamped to zero, except that
+               Schmitt triggering should be enabled for the tck and trst pads.'''
       stage: V1
       tests: ["pinmux_assert"]
     }

--- a/hw/ip_templates/pinmux/fpv/vip/pinmux_assert_fpv.sv.tpl
+++ b/hw/ip_templates/pinmux/fpv/vip/pinmux_assert_fpv.sv.tpl
@@ -308,12 +308,15 @@ module pinmux_assert_fpv
 
   `ASSERT(MioAttrO_A, mio_attr_o[mio_sel_i] == (mio_pad_attr & mio_pad_attr_mask))
 
-  `ASSERT(MioJtagAttrO_A, pinmux.u_pinmux_strap_sampling.jtag_en |->
-                          mio_attr_o[TargetCfg.tck_idx] == 0 &&
-                          mio_attr_o[TargetCfg.tms_idx] == 0 &&
-                          mio_attr_o[TargetCfg.trst_idx] == 0 &&
-                          mio_attr_o[TargetCfg.tdi_idx] == 0 &&
-                          mio_attr_o[TargetCfg.tdo_idx] == 0)
+  // When JTAG is enabled, the mio pad addributes should mostly be tied to zero. The only exception
+  // is for the tck and trst signals, which should be configured to enable Schmitt triggering.
+  `ASSERT(MioJtagAttrO_A,
+          pinmux.u_pinmux_strap_sampling.jtag_en |->
+          mio_attr_o[TargetCfg.tck_idx]  == '{schmitt_en: 1'b1, default: '0} &&
+          mio_attr_o[TargetCfg.tms_idx]  == '0 &&
+          mio_attr_o[TargetCfg.trst_idx] == '{schmitt_en: 1'b1, default: '0} &&
+          mio_attr_o[TargetCfg.tdi_idx]  == '0 &&
+          mio_attr_o[TargetCfg.tdo_idx]  == '0)
 
   // ------ Dio_attr_o ------
   pinmux_reg_pkg::pinmux_reg2hw_dio_pad_attr_mreg_t dio_pad_attr;

--- a/hw/top_darjeeling/ip_autogen/pinmux/data/pinmux_fpv_testplan.hjson
+++ b/hw/top_darjeeling/ip_autogen/pinmux/data/pinmux_fpv_testplan.hjson
@@ -520,7 +520,8 @@
     }
     {
       name: MioJtagAttrO_A
-      desc: "If jtag is enabled, the jtag `mio_attr_o` index should be equal to 0."
+      desc: '''If JTAG is enabled, each padring attribute should be clamped to zero, except that
+               Schmitt triggering should be enabled for the tck and trst pads.'''
       stage: V1
       tests: ["pinmux_assert"]
     }

--- a/hw/top_darjeeling/ip_autogen/pinmux/fpv/vip/pinmux_assert_fpv.sv
+++ b/hw/top_darjeeling/ip_autogen/pinmux/fpv/vip/pinmux_assert_fpv.sv
@@ -276,12 +276,15 @@ module pinmux_assert_fpv
 
   `ASSERT(MioAttrO_A, mio_attr_o[mio_sel_i] == (mio_pad_attr & mio_pad_attr_mask))
 
-  `ASSERT(MioJtagAttrO_A, pinmux.u_pinmux_strap_sampling.jtag_en |->
-                          mio_attr_o[TargetCfg.tck_idx] == 0 &&
-                          mio_attr_o[TargetCfg.tms_idx] == 0 &&
-                          mio_attr_o[TargetCfg.trst_idx] == 0 &&
-                          mio_attr_o[TargetCfg.tdi_idx] == 0 &&
-                          mio_attr_o[TargetCfg.tdo_idx] == 0)
+  // When JTAG is enabled, the mio pad addributes should mostly be tied to zero. The only exception
+  // is for the tck and trst signals, which should be configured to enable Schmitt triggering.
+  `ASSERT(MioJtagAttrO_A,
+          pinmux.u_pinmux_strap_sampling.jtag_en |->
+          mio_attr_o[TargetCfg.tck_idx]  == '{schmitt_en: 1'b1, default: '0} &&
+          mio_attr_o[TargetCfg.tms_idx]  == '0 &&
+          mio_attr_o[TargetCfg.trst_idx] == '{schmitt_en: 1'b1, default: '0} &&
+          mio_attr_o[TargetCfg.tdi_idx]  == '0 &&
+          mio_attr_o[TargetCfg.tdo_idx]  == '0)
 
   // ------ Dio_attr_o ------
   pinmux_reg_pkg::pinmux_reg2hw_dio_pad_attr_mreg_t dio_pad_attr;

--- a/hw/top_earlgrey/ip_autogen/pinmux/data/pinmux_fpv_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/pinmux/data/pinmux_fpv_testplan.hjson
@@ -520,7 +520,8 @@
     }
     {
       name: MioJtagAttrO_A
-      desc: "If jtag is enabled, the jtag `mio_attr_o` index should be equal to 0."
+      desc: '''If JTAG is enabled, each padring attribute should be clamped to zero, except that
+               Schmitt triggering should be enabled for the tck and trst pads.'''
       stage: V1
       tests: ["pinmux_assert"]
     }

--- a/hw/top_earlgrey/ip_autogen/pinmux/fpv/vip/pinmux_assert_fpv.sv
+++ b/hw/top_earlgrey/ip_autogen/pinmux/fpv/vip/pinmux_assert_fpv.sv
@@ -302,12 +302,15 @@ module pinmux_assert_fpv
 
   `ASSERT(MioAttrO_A, mio_attr_o[mio_sel_i] == (mio_pad_attr & mio_pad_attr_mask))
 
-  `ASSERT(MioJtagAttrO_A, pinmux.u_pinmux_strap_sampling.jtag_en |->
-                          mio_attr_o[TargetCfg.tck_idx] == 0 &&
-                          mio_attr_o[TargetCfg.tms_idx] == 0 &&
-                          mio_attr_o[TargetCfg.trst_idx] == 0 &&
-                          mio_attr_o[TargetCfg.tdi_idx] == 0 &&
-                          mio_attr_o[TargetCfg.tdo_idx] == 0)
+  // When JTAG is enabled, the mio pad addributes should mostly be tied to zero. The only exception
+  // is for the tck and trst signals, which should be configured to enable Schmitt triggering.
+  `ASSERT(MioJtagAttrO_A,
+          pinmux.u_pinmux_strap_sampling.jtag_en |->
+          mio_attr_o[TargetCfg.tck_idx]  == '{schmitt_en: 1'b1, default: '0} &&
+          mio_attr_o[TargetCfg.tms_idx]  == '0 &&
+          mio_attr_o[TargetCfg.trst_idx] == '{schmitt_en: 1'b1, default: '0} &&
+          mio_attr_o[TargetCfg.tdi_idx]  == '0 &&
+          mio_attr_o[TargetCfg.tdo_idx]  == '0)
 
   // ------ Dio_attr_o ------
   pinmux_reg_pkg::pinmux_reg2hw_dio_pad_attr_mreg_t dio_pad_attr;

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/data/pinmux_fpv_testplan.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/data/pinmux_fpv_testplan.hjson
@@ -520,7 +520,8 @@
     }
     {
       name: MioJtagAttrO_A
-      desc: "If jtag is enabled, the jtag `mio_attr_o` index should be equal to 0."
+      desc: '''If JTAG is enabled, each padring attribute should be clamped to zero, except that
+               Schmitt triggering should be enabled for the tck and trst pads.'''
       stage: V1
       tests: ["pinmux_assert"]
     }

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/fpv/vip/pinmux_assert_fpv.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/fpv/vip/pinmux_assert_fpv.sv
@@ -302,12 +302,15 @@ module pinmux_assert_fpv
 
   `ASSERT(MioAttrO_A, mio_attr_o[mio_sel_i] == (mio_pad_attr & mio_pad_attr_mask))
 
-  `ASSERT(MioJtagAttrO_A, pinmux.u_pinmux_strap_sampling.jtag_en |->
-                          mio_attr_o[TargetCfg.tck_idx] == 0 &&
-                          mio_attr_o[TargetCfg.tms_idx] == 0 &&
-                          mio_attr_o[TargetCfg.trst_idx] == 0 &&
-                          mio_attr_o[TargetCfg.tdi_idx] == 0 &&
-                          mio_attr_o[TargetCfg.tdo_idx] == 0)
+  // When JTAG is enabled, the mio pad addributes should mostly be tied to zero. The only exception
+  // is for the tck and trst signals, which should be configured to enable Schmitt triggering.
+  `ASSERT(MioJtagAttrO_A,
+          pinmux.u_pinmux_strap_sampling.jtag_en |->
+          mio_attr_o[TargetCfg.tck_idx]  == '{schmitt_en: 1'b1, default: '0} &&
+          mio_attr_o[TargetCfg.tms_idx]  == '0 &&
+          mio_attr_o[TargetCfg.trst_idx] == '{schmitt_en: 1'b1, default: '0} &&
+          mio_attr_o[TargetCfg.tdi_idx]  == '0 &&
+          mio_attr_o[TargetCfg.tdo_idx]  == '0)
 
   // ------ Dio_attr_o ------
   pinmux_reg_pkg::pinmux_reg2hw_dio_pad_attr_mreg_t dio_pad_attr;


### PR DESCRIPTION
The expected pad attributes changed with commit b3869fb and we didn't update the assertion to match.

This commit updates it, and also expands the testplan entry (which was out of date and didn't really make much sense as a sentence anyway).

Fixes #27947.