### PR TITLE
[entropy_src/dv] Correct computation of window_size/rng_frames in SCB

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
@@ -190,15 +190,16 @@ package entropy_src_env_pkg;
   endfunction
 
   //
-  // Helper function to determines the proper window_size for the current round of health checks
+  // Helper function to determine the proper window_size for the current round of health checks
   // as a function of the seed index.
   //
-  // Like like the phase helper function above, this function is required for both scoreboarding and
+  // Like the phase helper function above, this function is required for both scoreboarding and
   // sequence generation.
   //
   // The window size also dictates the amount of data needed to create a single seed.
   //
-  function automatic int rng_window_size(int seed_idx, bit fips_enable, bit fw_ov_insert,
+  function automatic int rng_window_size(int seed_idx, bit fips_enable, bit rng_bit_en,
+                                         bit fw_ov_insert, int bypass_window_size,
                                          int fips_window_size);
     entropy_phase_e phase;
 
@@ -207,8 +208,13 @@ package entropy_src_env_pkg;
 
     phase = convert_seed_idx_to_phase(seed_idx, fips_enable, fw_ov_insert);
 
-    return (phase == BOOT || phase == HALTED) ? entropy_src_pkg::CSRNG_BUS_WIDTH : fips_window_size;
-
+    // The bypass window is specified in bits, whereas the FIPS window is specified in symbols.
+    // `rng_bit_en` manipulates the symbol size.
+    if (phase == BOOT || phase == HALTED) begin
+      return rng_bit_en ? bypass_window_size : bypass_window_size / `RNG_BUS_WIDTH;
+    end else begin
+      return fips_window_size;
+    end
   endfunction
 
   // Determine a random failure time according to an exponential distribution with

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -2610,9 +2610,8 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
   endfunction
 
   task health_test_scoring_thread();
-    bit [15:0]                window_size;
+    int                       window_size;
     entropy_phase_e           dut_fsm_phase;
-    int                       window_rng_frames;
     int                       pass_requirement, pass_count, startup_fail_count;
     bit                       fw_ov_insert;
     bit                       is_fips_mode;
@@ -2682,20 +2681,14 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
 
         `uvm_info(`gfn, $sformatf("phase: %s\n", dut_fsm_phase.name), UVM_HIGH)
 
-        window_size = rng_window_size(seed_idx, is_fips_mode, fw_ov_insert,
+        // `window` is a queue of items of `RNG_BUS_WIDTH size. Depending on the configuration of
+        // the DUT, the rate of the entropy input and whether we're performing the startup health
+        // checks, we expect a different number of elements to get accumulated.
+        window_size = rng_window_size(seed_idx, is_fips_mode, rng_bit_en, fw_ov_insert,
+                                      `gmv(ral.health_test_windows.bypass_window),
                                       `gmv(ral.health_test_windows.fips_window));
 
         `uvm_info(`gfn, $sformatf("window_size: %08d\n", window_size), UVM_HIGH)
-
-        // Note on RNG bit enable and window frame count:
-        // When rng_bit_enable is selected, the function below repacks the data so that
-        // the selected bit fills a whole frame.
-        // This mirrors the DUT's behavior of repacking the data before the health checks
-        //
-        // Thus the number of window frames RNG_BUS_WIDTH times as large when the bit select is
-        // enabled.
-
-        window_rng_frames = rng_bit_en ? window_size : (window_size / `RNG_BUS_WIDTH);
 
         forever begin : window_loop
           string fmt;
@@ -2725,13 +2718,13 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
           if (disable_detected) break; // No sample events. DUT has shutdown
 
           // In case of entropy drops, there is more entropy to be health tested than the usual
-          // window_rng_frames.
+          // window_size.
           if (xht_item.req.window_wrap_pulse) begin
-            `DV_CHECK(window.size() == (window_rng_frames + post_ht_drops))
+            `DV_CHECK(window.size() == (window_size + post_ht_drops))
             post_ht_drops = 0;
             break;
           end else begin
-            `DV_CHECK(window.size() < (window_rng_frames + post_ht_drops))
+            `DV_CHECK(window.size() < (window_size + post_ht_drops))
           end
           // Check whether the rng_bit_en and the rng_bit_sel match the values in the CONF register.
           `DV_CHECK(xht_item.req.rng_bit_en == rng_bit_en)


### PR DESCRIPTION
To check the size of the noise samples queue, we need to know the expected window size, which depends on whether we're running in FIPS or bypass mode, and whether the single-bit mode is enabled. The reason is that as of commit a0f1e73ac7093fbb5a972bd973e62d78a1d43a60, the window size in bypass mode is specified in bits. In contrast, the window size in FIPS mode is always specified in symbols and switching to single-bit mode effectively alters the symbol size.

This commit helps resolving around 85% of the failures currently observed in ENTROPY_SRC block-level DV.