### PR TITLE
Backport 25488 and 25493  ([manuf] orchestrator.py tweaks, [provisioning] the DIN fields should be parsed as BCD values)

### DIFF
--- a/sw/host/provisioning/orchestrator/src/db.py
+++ b/sw/host/provisioning/orchestrator/src/db.py
@@ -10,8 +10,6 @@ from dataclasses import dataclass
 
 import ot_dut
 
-DEFAULT_DB_FILENAME = "provisioning.sqlite"
-
 
 @dataclass
 class DBConfig(object):

--- a/sw/host/provisioning/orchestrator/src/device_id.py
+++ b/sw/host/provisioning/orchestrator/src/device_id.py
@@ -53,22 +53,22 @@ class DeviceIdentificationNumber:
 
     def to_int(self) -> int:
         din = 0
-        din |= self.wafer_y_coord << 44
-        din |= self.wafer_x_coord << 32
-        din |= self.wafer << 24
-        din |= self.lot << 12
-        din |= self.week << 4
+        din |= util.bcd_encode(self.wafer_y_coord) << 44
+        din |= util.bcd_encode(self.wafer_x_coord) << 32
+        din |= util.bcd_encode(self.wafer) << 24
+        din |= util.bcd_encode(self.lot) << 12
+        din |= util.bcd_encode(self.week) << 4
         din |= self.year
         return din
 
     @staticmethod
     def from_int(din: int) -> "DeviceIdentificationNumber":
-        year = util.read_int_as_decimal_str(din & 0xF)
-        week = util.read_int_as_decimal_str((din >> 4) & 0xFF)
-        lot = util.read_int_as_decimal_str((din >> 12) & 0xFFF)
-        wafer = util.read_int_as_decimal_str((din >> 24) & 0xFF)
-        wafer_x_coord = util.read_int_as_decimal_str((din >> 32) & 0xFFF)
-        wafer_y_coord = util.read_int_as_decimal_str((din >> 44) & 0xFFF)
+        year = util.bcd_decode(din & 0xF)
+        week = util.bcd_decode((din >> 4) & 0xFF)
+        lot = util.bcd_decode((din >> 12) & 0xFFF)
+        wafer = util.bcd_decode((din >> 24) & 0xFF)
+        wafer_x_coord = util.bcd_decode((din >> 32) & 0xFFF)
+        wafer_y_coord = util.bcd_decode((din >> 44) & 0xFFF)
         return DeviceIdentificationNumber(year=year,
                                           week=week,
                                           lot=lot,

--- a/sw/host/provisioning/orchestrator/src/device_id.py
+++ b/sw/host/provisioning/orchestrator/src/device_id.py
@@ -6,8 +6,8 @@
 import struct
 from dataclasses import dataclass
 
-from sku_config import SkuConfig
 import util
+from sku_config import SkuConfig
 
 _RESERVED_WORD = 0
 
@@ -63,12 +63,12 @@ class DeviceIdentificationNumber:
 
     @staticmethod
     def from_int(din: int) -> "DeviceIdentificationNumber":
-        year = din & 0xF
-        week = (din >> 4) & 0xFF
-        lot = (din >> 12) & 0xFFF
-        wafer = (din >> 24) & 0xFF
-        wafer_x_coord = (din >> 32) & 0xFFF
-        wafer_y_coord = (din >> 44) & 0xFFF
+        year = util.read_int_as_decimal_str(din & 0xF)
+        week = util.read_int_as_decimal_str((din >> 4) & 0xFF)
+        lot = util.read_int_as_decimal_str((din >> 12) & 0xFFF)
+        wafer = util.read_int_as_decimal_str((din >> 24) & 0xFF)
+        wafer_x_coord = util.read_int_as_decimal_str((din >> 32) & 0xFFF)
+        wafer_y_coord = util.read_int_as_decimal_str((din >> 44) & 0xFFF)
         return DeviceIdentificationNumber(year=year,
                                           week=week,
                                           lot=lot,

--- a/sw/host/provisioning/orchestrator/src/orchestrator.py
+++ b/sw/host/provisioning/orchestrator/src/orchestrator.py
@@ -114,6 +114,11 @@ def main(args_in):
         default="logs",
         help="Root directory to store log files under.",
     )
+    parser.add_argument(
+        "--cp-only",
+        action="store_true",
+        help="If set, only run CP stage (skips FT and database write).",
+    )
     args = parser.parse_args(args_in)
 
     # All relative paths are relative to the runfiles directory.
@@ -160,11 +165,14 @@ def main(args_in):
                 fpga=args.fpga,
                 require_confirmation=not args.non_interactive)
     dut.run_cp()
-    dut.run_ft()
+    if not args.cp_only:
+        dut.run_ft()
 
-    device_record = db.DeviceRecord.from_dut(dut)
-    device_record.upsert(db_handle)
-    logging.info(f"Added DeviceRecord to database: {device_record}")
+        device_record = db.DeviceRecord.from_dut(dut)
+        device_record.upsert(db_handle)
+        logging.info(f"Added DeviceRecord to database: {device_record}")
+    else:
+        logging.info("FT skipped since --cp-only was provided")
 
 
 if __name__ == "__main__":

--- a/sw/host/provisioning/orchestrator/src/ot_dut.py
+++ b/sw/host/provisioning/orchestrator/src/ot_dut.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import tempfile
 from dataclasses import dataclass
 
@@ -156,8 +157,8 @@ class OtDut():
             self.device_id.update_base_id(cp_device_id)
 
             self._make_log_dir()
-            os.rename(stdout_logfile, f"{self.log_dir}/cp_out.log.txt")
-            os.rename(stderr_logfile, f"{self.log_dir}/cp_err.log.txt")
+            shutil.move(stdout_logfile, f"{self.log_dir}/cp_out.log.txt")
+            shutil.move(stderr_logfile, f"{self.log_dir}/cp_err.log.txt")
 
         self.cp_data = chip_probe_data
         logging.info(f"CP logs saved to {self.log_dir}.")

--- a/sw/host/provisioning/orchestrator/src/util.py
+++ b/sw/host/provisioning/orchestrator/src/util.py
@@ -25,6 +25,15 @@ def format_hex(n, width=8):
     return format(n, f"#0{width + 2}x")  # + 2 to account for 0x chars
 
 
+def read_int_as_decimal_str(x: int) -> int:
+    """Interpret a number by reading its hexadecimal representation as a decimal number.
+
+    For example, `70` in hex is `0x46` and should be read as the decimal value 46.
+    This encoding is a manufacturing equipment constraint.
+    """
+    return int(hex(x)[2:])
+
+
 def confirm():
     """Get user confirmation to continue."""
     confirm = input("Type confirm to continue: ")

--- a/sw/host/provisioning/orchestrator/src/util.py
+++ b/sw/host/provisioning/orchestrator/src/util.py
@@ -25,13 +25,21 @@ def format_hex(n, width=8):
     return format(n, f"#0{width + 2}x")  # + 2 to account for 0x chars
 
 
-def read_int_as_decimal_str(x: int) -> int:
-    """Interpret a number by reading its hexadecimal representation as a decimal number.
+def bcd_decode(x: int) -> int:
+    """Convert a BCD int to an int.
 
-    For example, `70` in hex is `0x46` and should be read as the decimal value 46.
+    For example, `0x46` hex represents `46` decimal.
     This encoding is a manufacturing equipment constraint.
     """
     return int(hex(x)[2:])
+
+
+def bcd_encode(x: int) -> int:
+    """Converts an int to a BCD int.
+
+    For example, `46` decimal is encoded as `0x46`.
+    """
+    return int(str(x), 16)
 
 
 def confirm():

--- a/sw/host/provisioning/orchestrator/tests/BUILD
+++ b/sw/host/provisioning/orchestrator/tests/BUILD
@@ -22,7 +22,7 @@ py_test(
         "//sw/device/silicon_creator/manuf/keys/fake:dice_ca.pem",
         "//sw/device/silicon_creator/manuf/keys/fake:ext_ca.pem",
         "//sw/device/silicon_creator/manuf/keys/fake:sk.pkcs8.der",
-        "//sw/host/provisioning/orchestrator/configs/skus:sival.hjson",
+        "//sw/host/provisioning/orchestrator/configs/skus:emulation.hjson",
     ],
     deps = [
         requirement("hjson"),

--- a/sw/host/provisioning/orchestrator/tests/device_id_test.py
+++ b/sw/host/provisioning/orchestrator/tests/device_id_test.py
@@ -8,9 +8,9 @@ import unittest
 import hjson
 from device_id import DeviceId, DeviceIdentificationNumber
 from sku_config import SkuConfig
-from util import bytes_to_int, format_hex
+from util import bcd_encode, bytes_to_int, format_hex
 
-_SIVAL_SKU_CONFIG = "sw/host/provisioning/orchestrator/configs/skus/sival.hjson"
+_SIVAL_SKU_CONFIG = "sw/host/provisioning/orchestrator/configs/skus/emulation.hjson"
 
 
 class TestDeviceId(unittest.TestCase):
@@ -57,7 +57,7 @@ class TestDeviceId(unittest.TestCase):
                 format_hex(expected_field, width=1)))
 
     def test_din_week_field(self):
-        expected_field = 49
+        expected_field = bcd_encode(49)
         actual_field = (self.device_id.to_int() >> 36) & 0xff
         self.assertEqual(
             actual_field, expected_field, "actual: {}, expected: {}.".format(
@@ -65,7 +65,7 @@ class TestDeviceId(unittest.TestCase):
                 format_hex(expected_field, width=2)))
 
     def test_din_lot_field(self):
-        expected_field = 343
+        expected_field = bcd_encode(343)
         actual_field = (self.device_id.to_int() >> 44) & 0xfff
         self.assertEqual(
             actual_field, expected_field, "actual: {}, expected: {}.".format(
@@ -73,7 +73,7 @@ class TestDeviceId(unittest.TestCase):
                 format_hex(expected_field, width=3)))
 
     def test_din_wafer_field(self):
-        expected_field = 72
+        expected_field = bcd_encode(72)
         actual_field = (self.device_id.to_int() >> 56) & 0xff
         self.assertEqual(
             actual_field, expected_field, "actual: {}, expected: {}.".format(
@@ -81,7 +81,7 @@ class TestDeviceId(unittest.TestCase):
                 format_hex(expected_field, width=2)))
 
     def test_din_wafer_x_coord_field(self):
-        expected_field = 635
+        expected_field = bcd_encode(635)
         actual_field = (self.device_id.to_int() >> 64) & 0xfff
         self.assertEqual(
             actual_field, expected_field, "actual: {}, expected: {}.".format(
@@ -89,7 +89,7 @@ class TestDeviceId(unittest.TestCase):
                 format_hex(expected_field, width=3)))
 
     def test_din_wafer_y_coord_field(self):
-        expected_field = 242
+        expected_field = bcd_encode(242)
         actual_field = (self.device_id.to_int() >> 76) & 0xfff
         self.assertEqual(
             actual_field, expected_field, "actual: {}, expected: {}.".format(
@@ -129,7 +129,7 @@ class TestDeviceId(unittest.TestCase):
                 format_hex(expected_field, width=4)))
 
     def test_sku_id_field(self):
-        expected_field = bytes_to_int("AVIS".encode("utf-8"))
+        expected_field = bytes_to_int("LUME".encode("utf-8"))
         actual_field = (self.device_id.to_int() >> 160) & 0xffffffff
         self.assertEqual(
             actual_field, expected_field, "actual: {}, expected: {}.".format(


### PR DESCRIPTION
Backport #25488 and #25493. Depends on #27953.
Also contains commit [bed096d](https://github.com/lowRISC/opentitan/commit/bed096d3b9cdf9e6d78a93116e22480a5c92666b) from #25502 to fix the device ID test