### PR TITLE
[prim,fpv] Make HungHandShake_A and ReqTimeout_A bounded assertions

### DIFF
--- a/hw/ip/prim/rtl/prim_reg_cdc_arb.sv
+++ b/hw/ip/prim/rtl/prim_reg_cdc_arb.sv
@@ -236,10 +236,22 @@ module prim_reg_cdc_arb #(
     assign src_ack_o = src_req & (id_q == SelSwReq);
     assign src_update_o = src_req & (id_q == SelHwReq);
 
-    // once hardware makes an update request, we must eventually see an update pulse
+    // Once hardware makes an update request, we must eventually see an update pulse
+    //
+    // This is fundamentally a liveness property and only really useful in a formal setting (since a
+    // simulation can never give a counterexample). Unfortunately, proving liveness properties can
+    // be intractable for formal tools. This assertion bounds the time, making it a safety property
+    // that the tool can handle more easily.
+    //
+    // The required bound depends on the ratio between the two clocks. If there are N edges of
+    // clk_dst_i for each edge of clk_src_i, we can expect a bound of 2*N to suffice (this is
+    // waiting for u_dst_update_sync to synchronise dst_update_req to src_req).
+    //
+    // The possible clock ratios rely on tool configuration, but we set N=10 (which matches the
+    // configuration for the main clock and the slow aon clock in our FPV tool setup).
     `ifdef FPV_ON
-      `ASSERT(ReqTimeout_A, $rose(id_q == SelHwReq) |-> s_eventually(src_update_o),
-              clk_src_i, !rst_src_ni)
+    `ASSERT(ReqTimeout_A, $rose(id_q == SelHwReq) |-> ##[0:20] src_update_o,
+            clk_src_i, !rst_src_ni)
       // TODO: #14913 check if we can add additional sim assertions.
     `endif
 


### PR DESCRIPTION
The liveness version (either expressed as HungHandShake_A was, or using s_eventually) doesn't seem to get to completion in my local tests. But we *can* put an upper bound on the properties by using a worst case of clock ratios and this *does* get to a proof. Phew.