### PR TITLE
[dv,dma] Exercise combinational responses

### DIFF
--- a/hw/ip/dma/dv/env/dma_env_cfg.sv
+++ b/hw/ip/dma/dv/env/dma_env_cfg.sv
@@ -103,6 +103,12 @@ class dma_env_cfg extends cip_base_env_cfg #(.RAL_T(dma_reg_block));
     // TL Agent Configuration - RAL based
     m_tl_agent_cfg.max_outstanding_req = 1;
 
+    // The DMA controller must be able to handle combinational devices too, i.e. those
+    // with a combinational path from `a_valid` to `d_valid` on the TL-UL bus.
+    tl_agent_dma_host_cfg.device_can_rsp_on_same_cycle = 1'b1;
+    tl_agent_dma_ctn_cfg.device_can_rsp_on_same_cycle = 1'b1;
+    tl_agent_dma_sys_cfg.device_can_rsp_on_same_cycle = 1'b1;
+
   endfunction: initialize
 
 endclass


### PR DESCRIPTION
The DUT supports read/write traffic from/to combinational devices (e.g. ROM/RAM connected directly to the TL-UL), which assert `d_valid` in the same cycle that a transaction is accepted ('a_valid & a_ready').

Modify the DV environment to enable combinational responses. This requires us to synchronize the notifications of A channel and D channel activity within the scoreboard, which we now do with minimal change to the current structure of the scoreboard; collect both the A channel and the D channel items before dispatching them into the existing checking logic.

(Requires #27973 for tests to pass.)