### PR TITLE
[corefiles] Properly select prim_legacy_pkg and remove a virtual core/mapping

### DIFF
--- a/hw/ip/prim/README.md
+++ b/hw/ip/prim/README.md
@@ -185,7 +185,6 @@ mapping:
   "lowrisc:virtual_constants:top_racl_pkg": "lowrisc:earlgrey_constants:top_racl_pkg"
   "lowrisc:systems:ast_pkg": "lowrisc:systems:top_earlgrey_ast_pkg"
   "lowrisc:virtual_ip:flash_ctrl_prim_reg_top": "lowrisc:earlgrey_ip:flash_ctrl_prim_reg_top"
-  "lowrisc:dv:chip_env": "lowrisc:dv:top_earlgrey_chip_env"
   "lowrisc:prim:prim_pkg": "lowrisc:prim:prim_legacy_pkg"
 ```
 

--- a/hw/top_darjeeling/top_darjeeling.core
+++ b/hw/top_darjeeling/top_darjeeling.core
@@ -63,6 +63,8 @@ filesets:
       - lowrisc:prim:all
       - lowrisc:prim:mubi
       - lowrisc:systems:top_darjeeling_pkg
+      # TODO(#27347): prim_pkg is deprecated
+      - lowrisc:prim:prim_legacy_pkg
       - "fileset_partner  ? (partner:systems:top_darjeeling_ast_pkg)"
       - "!fileset_partner ? (lowrisc:systems:top_darjeeling_ast_pkg)"
     files:
@@ -102,7 +104,6 @@ mapping:
   "lowrisc:virtual_constants:top_pkg": "lowrisc:darjeeling_constants:top_pkg"
   "lowrisc:virtual_constants:top_racl_pkg": "lowrisc:darjeeling_constants:top_racl_pkg"
   "lowrisc:systems:ast_pkg": "lowrisc:systems:top_darjeeling_ast_pkg"
-  "lowrisc:dv:chip_env": "lowrisc:dv:top_darjeeling_chip_env"
   # TODO(#27347): prim_legacy_pkg is deprecated
   "lowrisc:prim:prim_pkg": "lowrisc:prim:prim_legacy_pkg"
 

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -4,8 +4,6 @@ CAPI=2:
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:dv:top_earlgrey_chip_env:0.1"
 description: "CHIP DV UVM environmnt"
-virtual:
-  - lowrisc:dv:chip_env
 
 filesets:
   files_dv:

--- a/hw/top_earlgrey/dv/tests/chip_test.core
+++ b/hw/top_earlgrey/dv/tests/chip_test.core
@@ -10,7 +10,7 @@ virtual:
 filesets:
   files_dv:
     depend:
-      - lowrisc:dv:chip_env
+      - lowrisc:dv:top_earlgrey_chip_env
     files:
       - chip_test_pkg.sv
       - chip_base_test.sv: {is_include_file: true}

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -60,6 +60,8 @@ filesets:
       - lowrisc:prim:usb_diff_rx
       - lowrisc:prim:mubi
       - lowrisc:systems:top_earlgrey_pkg
+      # TODO(#27347): prim_pkg is deprecated
+      - lowrisc:prim:prim_legacy_pkg
       - "fileset_partner  ? (partner:systems:top_earlgrey_ast_pkg)"
       - "!fileset_partner ? (lowrisc:systems:top_earlgrey_ast_pkg)"
       - "fileset_partner  ? (partner:ip:otp_macro)"
@@ -101,7 +103,6 @@ mapping:
   "lowrisc:virtual_constants:top_racl_pkg": "lowrisc:earlgrey_constants:top_racl_pkg"
   "lowrisc:systems:ast_pkg": "lowrisc:systems:top_earlgrey_ast_pkg"
   "lowrisc:virtual_ip:flash_ctrl_prim_reg_top": "lowrisc:earlgrey_ip:flash_ctrl_prim_reg_top"
-  "lowrisc:dv:chip_env": "lowrisc:dv:top_earlgrey_chip_env"
   # TODO(#27347): prim_legacy_pkg is deprecated
   "lowrisc:prim:prim_pkg": "lowrisc:prim:prim_legacy_pkg"
 


### PR DESCRIPTION
This PR properly selects the `prim_legacy_pkg` for the top core file. As a second change, it removes one virtual core where there is no necessity to be one.  It also removes their mapping from the top mappings