### PR TITLE
[rom_ext,manuf] Write boot status to the transition token registers

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -415,6 +415,7 @@ dual_cc_library(
             "//sw/device/lib/base:bitfield",
             "//sw/device/lib/base:hardened",
             "//sw/device/lib/base:macros",
+            "//sw/device/lib/base:abs_mmio",
             "//sw/device/silicon_creator/lib/base:sec_mmio",
         ],
     ),

--- a/sw/device/silicon_creator/lib/drivers/lifecycle.c
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle.c
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <stdint.h>
 
+#include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/macros.h"
@@ -123,4 +124,15 @@ hardened_bool_t lifecycle_din_eq(lifecycle_device_id_t *id, uint32_t *din) {
   if (id->device_id[1] == din[0] && id->device_id[2] == din[1])
     return kHardenedBoolTrue;
   return kHardenedBoolFalse;
+}
+
+bool lifecycle_claim(uint32_t claim) {
+  abs_mmio_write32(kBase + LC_CTRL_CLAIM_TRANSITION_IF_REG_OFFSET, claim);
+  return (bool)abs_mmio_read32(kBase + LC_CTRL_TRANSITION_REGWEN_REG_OFFSET);
+}
+
+void lifecycle_set_status(lifecycle_status_word_t word, uint32_t value) {
+  abs_mmio_write32(
+      kBase + LC_CTRL_TRANSITION_TOKEN_0_REG_OFFSET + word * sizeof(uint32_t),
+      value);
 }

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -6,6 +6,7 @@
 
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/multibits.h"
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
 #include "sw/device/lib/dif/dif_gpio.h"
@@ -41,6 +42,7 @@
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/drivers/keymgr.h"
 #include "sw/device/silicon_creator/lib/drivers/kmac.h"
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
 #include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
 #include "sw/device/silicon_creator/lib/drivers/watchdog.h"
@@ -220,6 +222,13 @@ static status_t log_self_hash(perso_blob_t *perso_blob_to_host) {
                                    perso_blob_to_host));
   perso_blob_to_host->num_objs++;
   return OK_STATUS();
+}
+
+/*
+ * Return a pointer to the ROM_EXT manifest located in the slot a.
+ */
+static const manifest_t *rom_ext_manifest_a_get(void) {
+  return (const manifest_t *)TOP_EARLGREY_EFLASH_BASE_ADDR;
 }
 
 /*
@@ -1167,6 +1176,17 @@ static status_t provision(ujson_t *uj) {
 }
 
 bool test_main(void) {
+  // Log our boot status in the lifecycle token registers.
+  const manifest_t *self = rom_ext_manifest_a_get();
+  lifecycle_claim(kMultiBitBool8True);
+  lifecycle_set_status(kLifecycleStatusWordRomExtVersion, self->version_minor);
+  lifecycle_set_status(kLifecycleStatusWordRomExtSecVersion,
+                       self->security_version);
+  lifecycle_set_status(kLifecycleStatusWordOwnerVersion, 0);
+  lifecycle_set_status(kLifecycleStatusWordDeviceStatus,
+                       kLifecycleDeviceStatusPersoStart);
+  lifecycle_claim(kMultiBitBool8False);
+
   // Unconditionally disable the watchdog timer.
   // This is needed to avoid a watchdog reset if enabled in the ROM.
   watchdog_disable();

--- a/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
@@ -6,6 +6,10 @@ load("//rules:const.bzl", "CONST", "hex")
 load("//rules:linker.bzl", "ld_library")
 load("//rules:manifest.bzl", "manifest")
 load("//rules/opentitan:defs.bzl", "cw310_params", "fpga_params", "opentitan_test")
+load(
+    "//sw/device/silicon_creator/rom_ext:defs.bzl",
+    "ROM_EXT_VERSION",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -128,5 +132,36 @@ opentitan_test(
     deps = [
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/silicon_creator/lib:dbg_print",
+    ],
+)
+
+opentitan_test(
+    name = "rom_ext_device_status_test",
+    srcs = ["//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+    },
+    fpga = fpga_params(
+        device_status = "0x1",
+        needs_jtag = True,
+        owner_fw_version = "0",
+        rom_ext_sec_version = ROM_EXT_VERSION.SECURITY,
+        rom_ext_version = ROM_EXT_VERSION.MINOR,
+        test_cmd = """
+            --bootstrap={firmware}
+            --wait-for="PASS!"
+            --rom-ext-version="{rom_ext_version}"
+            --rom-ext-sec-version="{rom_ext_sec_version}"
+            --owner-fw-version="{owner_fw_version}"
+            --device-status="{device_status}"
+        """,
+        test_harness = "//sw/host/tests/rom_ext/device_status",
+    ),
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
     ],
 )

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -8,6 +8,7 @@
 #include "sw/device/lib/base/csr.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/multibits.h"
 #include "sw/device/lib/base/stdasm.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/silicon_creator/lib/base/boot_measurements.h"
@@ -482,6 +483,16 @@ static rom_error_t rom_ext_advance_secver(boot_data_t *boot_data,
 static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   HARDENED_RETURN_IF_ERROR(rom_ext_init(boot_data));
   const manifest_t *self = rom_ext_manifest();
+
+  lifecycle_claim(kMultiBitBool8True);
+  lifecycle_set_status(kLifecycleStatusWordRomExtVersion, self->version_minor);
+  lifecycle_set_status(kLifecycleStatusWordRomExtSecVersion,
+                       self->security_version);
+  lifecycle_set_status(kLifecycleStatusWordOwnerVersion, 0);
+  lifecycle_set_status(kLifecycleStatusWordDeviceStatus,
+                       kLifecycleDeviceStatusRomExtStart);
+  lifecycle_claim(kMultiBitBool8False);
+
   dbg_printf("ROM_EXT:%u.%u\r\n", self->version_major, self->version_minor);
 
   // Print the version of immutable section if exists.

--- a/sw/host/tests/rom_ext/device_status/BUILD
+++ b/sw/host/tests/rom_ext/device_status/BUILD
@@ -1,0 +1,21 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "device_status",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+    ],
+)

--- a/sw/host/tests/rom_ext/device_status/src/main.rs
+++ b/sw/host/tests/rom_ext/device_status/src/main.rs
@@ -1,0 +1,99 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use std::time::Duration;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg};
+use opentitanlib::execute_test;
+use opentitanlib::io::jtag::JtagTap;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::lc_transition;
+use opentitanlib::uart::console::UartConsole;
+use opentitanlib::util::parse_int::ParseInt;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Duration of the reset pulse.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "60s")]
+    pub timeout: Duration,
+
+    /// Wait for regex from the console before reading status from JTAG.
+    #[arg(long)]
+    wait_for: String,
+
+    #[arg(long, value_parser = u32::from_str)]
+    rom_ext_version: u32,
+    #[arg(long, value_parser = u32::from_str)]
+    rom_ext_sec_version: u32,
+    #[arg(long, value_parser = u32::from_str)]
+    owner_fw_version: u32,
+    #[arg(long, value_parser = u32::from_str)]
+    device_status: u32,
+}
+
+fn check_device_status(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    // Reset the chip, select the LC TAP, and connect to it.
+    transport.pin_strapping("PINMUX_TAP_LC")?.apply()?;
+    transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
+    let mut jtag = opts
+        .init
+        .jtag_params
+        .create(transport)?
+        .connect(JtagTap::LcTap)?;
+
+    let uart = transport.uart("console").context("failed to get UART")?;
+    let _ = UartConsole::wait_for(&*uart, &opts.wait_for, opts.timeout)?;
+
+    let lc_state = jtag.read_lc_ctrl_reg(&LcCtrlReg::LcState)?;
+    let hw0 = jtag.read_lc_ctrl_reg(&LcCtrlReg::HwRevision0)?;
+    let hw1 = jtag.read_lc_ctrl_reg(&LcCtrlReg::HwRevision1)?;
+    log::info!(
+        "Hardware device {hw0:08x}:{hw1:02x} in lc_state {}({lc_state:08x})",
+        DifLcCtrlState::from_redundant_encoding(lc_state)?.lc_state_to_str()
+    );
+
+    lc_transition::claim_lc_mutex(&mut *jtag, true)?;
+    let rom_ext_version = jtag.read_lc_ctrl_reg(&LcCtrlReg::TransitionToken0)?;
+    let rom_ext_sec_version = jtag.read_lc_ctrl_reg(&LcCtrlReg::TransitionToken1)?;
+    let owner_fw_version = jtag.read_lc_ctrl_reg(&LcCtrlReg::TransitionToken2)?;
+    let device_status = jtag.read_lc_ctrl_reg(&LcCtrlReg::TransitionToken3)?;
+    lc_transition::claim_lc_mutex(&mut *jtag, false)?;
+
+    log::info!("rom_ext_version:     {rom_ext_version}");
+    log::info!("rom_ext_sec_version: {rom_ext_sec_version}");
+    log::info!("owner_fw_version:    {owner_fw_version}");
+    log::info!("device_status:       {device_status}");
+
+    assert_eq!(
+        opts.rom_ext_version, rom_ext_version,
+        "testing rom_ext_version"
+    );
+    assert_eq!(
+        opts.rom_ext_sec_version, rom_ext_sec_version,
+        "testing rom_ext_sec_version"
+    );
+    assert_eq!(
+        opts.owner_fw_version, owner_fw_version,
+        "testing owner_fw_version"
+    );
+    assert_eq!(opts.device_status, device_status, "testing device_status");
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    execute_test!(check_device_status, &opts, &transport);
+
+    Ok(())
+}


### PR DESCRIPTION
In order to more easily track boot stages during manufacturing, write status and version information into the `TRANSITION_TOKEN` registers in the lifecycle controller.  These registers may be accessed both from firmware and via JTAG, allowing an easy status readout during the manufacturing process.

1. Add helpers and definitions to the lifecycle controller driver.
2. Write status and version information when the ROM_EXT starts.
3. Write status and version information when ft_personalize starts.
4. Add a test that verifies the ROM_EXT values can be read via JTAG.