### PR TITLE
[util] fix bug in OTP image generation script

### DIFF
--- a/util/design/gen-otp-img.py
+++ b/util/design/gen-otp-img.py
@@ -79,7 +79,7 @@ def main():
                         '-q',
                         action='store_true',
                         help='''Don't print out progress messages.''')
-    parser.add_argument('-stamp',
+    parser.add_argument('--stamp',
                         action='store_true',
                         help='''
                         Add a comment 'Generated on [Date] with [Command]' to


### PR DESCRIPTION
The Bazel rule propagates a `--stamp` flag, not a `-stamp` flag.