### PR TITLE
Cherry-pick to earlgrey_1.0.0:  [opentitanlib] misc. UART improvements #27614 

### DIFF
--- a/sw/host/opentitanlib/src/app/config/structs.rs
+++ b/sw/host/opentitanlib/src/app/config/structs.rs
@@ -75,7 +75,7 @@ pub struct StrappingConfiguration {
 }
 
 /// Parity configuration for UART communication.
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone, Copy, Debug, PartialEq)]
 pub enum UartParity {
     None,
     Even,
@@ -85,7 +85,7 @@ pub enum UartParity {
 }
 
 /// Stop bits configuration for UART communication.
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone, Copy, Debug, PartialEq)]
 pub enum UartStopBits {
     Stop1,
     Stop1_5,
@@ -93,7 +93,7 @@ pub enum UartStopBits {
 }
 
 /// Configuration of a particular UART port.
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Default, Deserialize, Clone, Debug)]
 pub struct UartConfiguration {
     /// The user-visible name of the UART.
     pub name: String,

--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -27,6 +27,7 @@ use crate::transport::{
 use anyhow::{bail, ensure, Result};
 use indicatif::{ProgressBar, ProgressStyle};
 
+use serialport::Parity;
 use std::any::Any;
 use std::cell::{Cell, RefCell};
 use std::collections::hash_map::Entry;
@@ -173,6 +174,15 @@ impl PinConfiguration {
 }
 
 #[derive(Default, Debug)]
+pub struct UartConfiguration {
+    pub underlying_instance: String,
+    pub baud_rate: Option<u32>,
+    pub parity: Option<config::UartParity>,
+    pub stop_bits: Option<config::UartStopBits>,
+    pub alias_of: Option<String>,
+}
+
+#[derive(Default, Debug)]
 pub struct SpiConfiguration {
     pub underlying_instance: String,
     pub mode: Option<TransferMode>,
@@ -199,8 +209,8 @@ pub struct TransportWrapperBuilder {
     requires_list: Vec<(String, String)>,
     pin_alias_map: HashMap<String, String>,
     pin_on_io_expander_map: HashMap<String, config::IoExpanderPin>,
-    uart_map: HashMap<String, String>,
     pin_conf_list: Vec<(String, PinConfiguration)>,
+    uart_conf_map: HashMap<String, config::UartConfiguration>,
     spi_conf_map: HashMap<String, config::SpiConfiguration>,
     i2c_conf_map: HashMap<String, config::I2cConfiguration>,
     strapping_conf_map: HashMap<String, Vec<(String, PinConfiguration)>>,
@@ -217,8 +227,8 @@ pub struct TransportWrapper {
     provides_map: HashMap<String, String>,
     pin_map: HashMap<String, String>,
     artificial_pin_map: HashMap<String, Rc<dyn GpioPin>>,
-    uart_map: HashMap<String, String>,
     pin_conf_map: HashMap<String, PinConfiguration>,
+    uart_conf_map: HashMap<String, UartConfiguration>,
     spi_conf_map: HashMap<String, SpiConfiguration>,
     i2c_conf_map: HashMap<String, I2cConfiguration>,
     strapping_conf_map: HashMap<String, HashMap<String, PinConfiguration>>,
@@ -247,8 +257,8 @@ impl TransportWrapperBuilder {
             requires_list: Vec::new(),
             pin_alias_map: HashMap::new(),
             pin_on_io_expander_map: HashMap::new(),
-            uart_map: HashMap::new(),
             pin_conf_list: Vec::new(),
+            uart_conf_map: HashMap::new(),
             spi_conf_map: HashMap::new(),
             i2c_conf_map: HashMap::new(),
             strapping_conf_map: HashMap::new(),
@@ -288,6 +298,23 @@ impl TransportWrapperBuilder {
             conf_entry.invert = Some(invert);
         }
         pin_conf_list.push((pin_conf.name.to_string(), conf_entry))
+    }
+
+    fn record_uart_conf(
+        uart_conf_map: &mut HashMap<String, config::UartConfiguration>,
+        uart_conf: &config::UartConfiguration,
+    ) -> Result<(), ()> {
+        let entry = uart_conf_map
+            .entry(uart_conf.name.to_uppercase().to_string())
+            .or_insert_with(|| config::UartConfiguration {
+                name: uart_conf.name.clone(),
+                ..Default::default()
+            });
+        merge_field(&mut entry.baudrate, &uart_conf.baudrate)?;
+        merge_field(&mut entry.parity, &uart_conf.parity)?;
+        merge_field(&mut entry.stopbits, &uart_conf.stopbits)?;
+        merge_field(&mut entry.alias_of, &uart_conf.alias_of)?;
+        Ok(())
     }
 
     fn record_spi_conf(
@@ -414,12 +441,12 @@ impl TransportWrapperBuilder {
             })?;
         }
         for uart_conf in file.uarts {
-            if let Some(alias_of) = &uart_conf.alias_of {
-                self.uart_map
-                    .insert(uart_conf.name.to_uppercase(), alias_of.clone());
-            }
-            // TODO(#8769): Record baud / parity configration for later
-            // use when opening uart.
+            Self::record_uart_conf(&mut self.uart_conf_map, &uart_conf).map_err(|_| {
+                TransportError::InconsistentConf(
+                    TransportInterfaceType::Uart,
+                    uart_conf.name.to_string(),
+                )
+            })?;
         }
         for io_expander_conf in file.io_expanders {
             match self
@@ -496,6 +523,49 @@ impl TransportWrapperBuilder {
                 })?;
         }
         Ok(result_pin_conf_map)
+    }
+
+    fn resolve_uart_conf(
+        name: &str,
+        uart_conf_map: &HashMap<String, config::UartConfiguration>,
+    ) -> Result<UartConfiguration> {
+        if let Some(entry) = uart_conf_map.get(name.to_uppercase().as_str()) {
+            let mut conf = if let Some(ref alias_of) = entry.alias_of {
+                Self::resolve_uart_conf(alias_of.as_str(), uart_conf_map)?
+            } else {
+                UartConfiguration {
+                    underlying_instance: name.to_uppercase().to_string(),
+                    ..Default::default()
+                }
+            };
+            // Apply configuration from this level
+            if let Some(baud_rate) = entry.baudrate {
+                conf.baud_rate = Some(baud_rate);
+            }
+            if let Some(parity) = entry.parity {
+                conf.parity = Some(parity);
+            }
+            if let Some(stop_bits) = entry.stopbits {
+                conf.stop_bits = Some(stop_bits);
+            }
+            Ok(conf)
+        } else {
+            Ok(UartConfiguration {
+                underlying_instance: name.to_string(),
+                ..Default::default()
+            })
+        }
+    }
+
+    fn consolidate_uart_conf_map(
+        uart_conf_map: &HashMap<String, config::UartConfiguration>,
+    ) -> Result<HashMap<String, UartConfiguration>> {
+        let mut resolved_uart_conf_map = HashMap::new();
+        for name in uart_conf_map.keys() {
+            resolved_uart_conf_map
+                .insert(name.clone(), Self::resolve_uart_conf(name, uart_conf_map)?);
+        }
+        Ok(resolved_uart_conf_map)
     }
 
     fn resolve_spi_conf(
@@ -631,6 +701,7 @@ impl TransportWrapperBuilder {
                 Self::consolidate_pin_conf_map(&self.pin_alias_map, &pin_conf_map)?,
             );
         }
+        let uart_conf_map = Self::consolidate_uart_conf_map(&self.uart_conf_map)?;
         let spi_conf_map = Self::consolidate_spi_conf_map(&self.spi_conf_map, &self.pin_alias_map)?;
         let i2c_conf_map = Self::consolidate_i2c_conf_map(&self.i2c_conf_map)?;
         let mut transport_wrapper = TransportWrapper {
@@ -640,7 +711,7 @@ impl TransportWrapperBuilder {
             provides_map,
             pin_map: self.pin_alias_map,
             artificial_pin_map: HashMap::new(),
-            uart_map: self.uart_map,
+            uart_conf_map,
             pin_conf_map,
             spi_conf_map,
             i2c_conf_map,
@@ -804,7 +875,45 @@ impl TransportWrapper {
 
     /// Returns a [`Uart`] implementation.
     pub fn uart(&self, name: &str) -> Result<Rc<dyn Uart>> {
-        self.transport.uart(map_name(&self.uart_map, name).as_str())
+        let uart_conf = self.uart_conf_map.get(name.to_uppercase().as_str());
+        let uart_name = uart_conf
+            .map(|uart_conf| uart_conf.underlying_instance.as_str())
+            .unwrap_or(name);
+        let uart = self.transport.uart(uart_name)?;
+        if let Some(conf) = uart_conf {
+            // Since current OT tests harnesses quite freely re-create the Uart
+            // when they expect it to continue receiving in the background, we
+            // try and read the values first and only set if there is a mismatch.
+            if let Some(baud_rate) = conf.baud_rate {
+                if let Ok(current_baud_rate) = uart.get_baudrate() {
+                    if current_baud_rate != baud_rate {
+                        uart.set_baudrate(baud_rate)?;
+                    }
+                } else {
+                    log::warn!("Could not read UART baud rate to check it is {}", baud_rate);
+                }
+            }
+            if let Some(parity) = conf.parity {
+                let new_parity = match parity {
+                    config::UartParity::None => Parity::None,
+                    config::UartParity::Even => Parity::Even,
+                    config::UartParity::Odd => Parity::Odd,
+                    config::UartParity::Mark | config::UartParity::Space => {
+                        log::warn!("Mark & Space parities not yet supported");
+                        Parity::None
+                    }
+                };
+                if let Ok(current_parity) = uart.get_parity() {
+                    if current_parity != new_parity {
+                        uart.set_parity(new_parity)?;
+                    }
+                } else {
+                    log::warn!("Could not read UART parity to check it is {}", new_parity);
+                }
+            }
+            // TODO: stop bits are not yet supported in the UART interface
+        }
+        Ok(uart)
     }
 
     /// Returns a [`GpioPin`] implementation.

--- a/sw/host/opentitanlib/src/io/uart.rs
+++ b/sw/host/opentitanlib/src/io/uart.rs
@@ -46,7 +46,7 @@ impl UartParams {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[repr(u8)]
 pub enum FlowControl {
     // No flow control.

--- a/sw/host/opentitanlib/src/io/uart.rs
+++ b/sw/host/opentitanlib/src/io/uart.rs
@@ -65,6 +65,11 @@ pub trait Uart {
     /// Sets the UART baudrate.  May do nothing for virtual UARTs.
     fn set_baudrate(&self, baudrate: u32) -> Result<()>;
 
+    // Returns whether software flow control is enabled for the UART `write`s.
+    fn get_flow_control(&self) -> Result<FlowControl> {
+        unimplemented!();
+    }
+
     /// Enables software flow control for `write`s.
     fn set_flow_control(&self, flow_control: bool) -> Result<()> {
         if flow_control {

--- a/sw/host/opentitanlib/src/io/uart.rs
+++ b/sw/host/opentitanlib/src/io/uart.rs
@@ -109,6 +109,10 @@ pub trait Uart {
         Err(TransportError::UnsupportedOperation.into())
     }
 
+    fn get_parity(&self) -> Result<Parity> {
+        Err(TransportError::UnsupportedOperation.into())
+    }
+
     /// Query if nonblocking mio mode is supported.
     fn supports_nonblocking_read(&self) -> Result<bool> {
         Ok(false)

--- a/sw/host/opentitanlib/src/proxy/handler.rs
+++ b/sw/host/opentitanlib/src/proxy/handler.rs
@@ -269,6 +269,16 @@ impl<'a> TransportCommandHandler<'a> {
                         instance.set_parity(*parity)?;
                         Ok(Response::Uart(UartResponse::SetParity))
                     }
+                    UartRequest::GetFlowControl => {
+                        let flow_control = instance.get_flow_control()?;
+                        Ok(Response::Uart(UartResponse::GetFlowControl {
+                            flow_control,
+                        }))
+                    }
+                    UartRequest::SetFlowControl(flow_control) => {
+                        instance.set_flow_control(*flow_control)?;
+                        Ok(Response::Uart(UartResponse::SetFlowControl))
+                    }
                     UartRequest::GetDevicePath => {
                         let path = instance.get_device_path()?;
                         Ok(Response::Uart(UartResponse::GetDevicePath { path }))

--- a/sw/host/opentitanlib/src/proxy/handler.rs
+++ b/sw/host/opentitanlib/src/proxy/handler.rs
@@ -261,6 +261,10 @@ impl<'a> TransportCommandHandler<'a> {
                         instance.set_break(*enable)?;
                         Ok(Response::Uart(UartResponse::SetBreak))
                     }
+                    UartRequest::GetParity => {
+                        let parity = instance.get_parity()?;
+                        Ok(Response::Uart(UartResponse::GetParity { parity }))
+                    }
                     UartRequest::SetParity(parity) => {
                         instance.set_parity(*parity)?;
                         Ok(Response::Uart(UartResponse::SetParity))

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -12,7 +12,7 @@ use crate::io::gpio::{
 };
 use crate::io::i2c::DeviceStatus;
 use crate::io::spi::{MaxSizes, TransferMode};
-use crate::io::uart::Parity;
+use crate::io::uart::{FlowControl, Parity};
 use crate::proxy::errors::SerializedError;
 use crate::transport::Capabilities;
 use crate::util::voltage::Voltage;
@@ -179,6 +179,8 @@ pub enum UartRequest {
     SetBreak(bool),
     GetParity,
     SetParity(Parity),
+    GetFlowControl,
+    SetFlowControl(bool),
     GetDevicePath,
     Read {
         timeout_millis: Option<u32>,
@@ -198,6 +200,8 @@ pub enum UartResponse {
     SetBreak,
     GetParity { parity: Parity },
     SetParity,
+    GetFlowControl { flow_control: FlowControl },
+    SetFlowControl,
     GetDevicePath { path: String },
     Read { data: Vec<u8> },
     Write,

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -177,6 +177,7 @@ pub enum UartRequest {
         rate: u32,
     },
     SetBreak(bool),
+    GetParity,
     SetParity(Parity),
     GetDevicePath,
     Read {
@@ -195,6 +196,7 @@ pub enum UartResponse {
     GetBaudrate { rate: u32 },
     SetBaudrate,
     SetBreak,
+    GetParity { parity: Parity },
     SetParity,
     GetDevicePath { path: String },
     Read { data: Vec<u8> },

--- a/sw/host/opentitanlib/src/transport/common/uart.rs
+++ b/sw/host/opentitanlib/src/transport/common/uart.rs
@@ -129,10 +129,14 @@ impl Uart for SerialPortUart {
         Ok(())
     }
 
+    fn get_flow_control(&self) -> Result<FlowControl> {
+        Ok(self.flow_control.get())
+    }
+
     fn set_flow_control(&self, flow_control: bool) -> Result<()> {
         self.flow_control.set(match flow_control {
             false => FlowControl::None,
-            // When flow-control is enabled, assume we're haven't
+            // When flow-control is enabled, assume we haven't
             // already been put into a pause state.
             true => FlowControl::Resume,
         });

--- a/sw/host/opentitanlib/src/transport/hyperdebug/uart.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/uart.rs
@@ -12,7 +12,7 @@ use serialport::Parity;
 
 use super::UartInterface;
 use crate::io::nonblocking_help::NonblockingHelp;
-use crate::io::uart::{Uart, UartError};
+use crate::io::uart::{FlowControl, Uart, UartError};
 use crate::transport::common::uart::SerialPortUart;
 use crate::transport::hyperdebug::Inner;
 use crate::transport::TransportError;
@@ -88,6 +88,10 @@ impl Uart for HyperdebugUart {
             &[],
         )?;
         Ok(())
+    }
+
+    fn get_flow_control(&self) -> Result<FlowControl> {
+        self.serial_port.get_flow_control()
     }
 
     fn set_flow_control(&self, flow_control: bool) -> Result<()> {

--- a/sw/host/opentitanlib/src/transport/hyperdebug/uart.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/uart.rs
@@ -80,10 +80,19 @@ impl Uart for HyperdebugUart {
 
     fn set_baudrate(&self, baudrate: u32) -> Result<()> {
         let usb_handle = self.inner.usb_device.borrow();
+        let compressed_baudrate: u16 = ((baudrate + 50) / 100).try_into()?;
+        let decompressed_baudrate = compressed_baudrate as u32 * 100;
+        if decompressed_baudrate != baudrate {
+            log::warn!(
+                "Warning: accuracy loss when setting baud rate. UART will use {} Bd instead of {}",
+                decompressed_baudrate,
+                baudrate
+            );
+        }
         usb_handle.write_control(
             rusb::request_type(Direction::Out, RequestType::Vendor, Recipient::Interface),
             ControlRequest::SetBaud as u8,
-            ((baudrate + 50) / 100).try_into()?,
+            compressed_baudrate,
             self.usb_interface as u16,
             &[],
         )?;

--- a/sw/host/opentitanlib/src/transport/proxy/uart.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/uart.rs
@@ -87,6 +87,13 @@ impl Uart for ProxyUart {
         }
     }
 
+    fn get_parity(&self) -> Result<Parity> {
+        match self.execute_command(UartRequest::GetParity)? {
+            UartResponse::GetParity { parity } => Ok(parity),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+
     fn set_parity(&self, parity: Parity) -> Result<()> {
         match self.execute_command(UartRequest::SetParity(parity))? {
             UartResponse::SetParity => Ok(()),

--- a/sw/host/opentitanlib/src/transport/proxy/uart.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/uart.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use super::ProxyError;
 use crate::io::nonblocking_help::NonblockingHelp;
-use crate::io::uart::{Parity, Uart};
+use crate::io::uart::{FlowControl, Parity, Uart};
 use crate::proxy::protocol::{Request, Response, UartRequest, UartResponse};
 use crate::transport::proxy::{Inner, Proxy};
 
@@ -97,6 +97,20 @@ impl Uart for ProxyUart {
     fn set_parity(&self, parity: Parity) -> Result<()> {
         match self.execute_command(UartRequest::SetParity(parity))? {
             UartResponse::SetParity => Ok(()),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+
+    fn get_flow_control(&self) -> Result<FlowControl> {
+        match self.execute_command(UartRequest::GetFlowControl)? {
+            UartResponse::GetFlowControl { flow_control } => Ok(flow_control),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+
+    fn set_flow_control(&self, flow_control: bool) -> Result<()> {
+        match self.execute_command(UartRequest::SetFlowControl(flow_control))? {
+            UartResponse::SetFlowControl => Ok(()),
             _ => bail!(ProxyError::UnexpectedReply()),
         }
     }


### PR DESCRIPTION
A manual backport of https://github.com/lowRISC/opentitan/pull/27614 to resolve conflicts when cherry-picking due to code original to `earlgrey_1.0.0`.