### PR TITLE
[crypto] AES-GCM SCA hardening

### DIFF
--- a/sw/device/lib/crypto/impl/aes_gcm/BUILD
+++ b/sw/device/lib/crypto/impl/aes_gcm/BUILD
@@ -24,8 +24,10 @@ cc_library(
     srcs = ["ghash.c"],
     hdrs = ["ghash.h"],
     deps = [
+        "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",
+        "//sw/device/lib/crypto/drivers:rv_core_ibex",
     ],
 )
 

--- a/sw/device/lib/crypto/impl/aes_gcm/aes_gcm.c
+++ b/sw/device/lib/crypto/impl/aes_gcm/aes_gcm.c
@@ -220,8 +220,22 @@ static status_t aes_gcm_hash_subkey(
   HARDENED_TRY(
       aes_encrypt_block(key, &zero, &zero, &hash_subkey, security_level));
 
+  // Create two shares of the hash subkey.
+  aes_block_t hash_subkey_share0;
+  aes_block_t hash_subkey_share1;
+
+  // Share 0: random data.
+  hardened_memshred(hash_subkey_share0.data, kAesBlockNumWords);
+
+  // Share 1: hash_subkey ^ hash_subkey_share0
+  hardened_memcpy(hash_subkey_share1.data, hash_subkey_share0.data,
+                  kAesBlockNumWords);
+  // TODO(#28008): make sure that we do not override shares.
+  hardened_xor(hash_subkey_share1.data, hash_subkey.data, kAesBlockNumWords);
+
   // Set the key for the GHASH context.
-  ghash_init_subkey(hash_subkey.data, ctx);
+  ghash_init_subkey(hash_subkey_share0.data, ctx->tbl0);
+  ghash_init_subkey(hash_subkey_share1.data, ctx->tbl1);
 
   return OTCRYPTO_OK;
 }
@@ -249,6 +263,29 @@ static status_t aes_gcm_counter(const size_t iv_len, const uint32_t *iv,
   } else if (iv_len == 4) {
     // If the IV is 128 bits, then J0 = GHASH(H, IV || {0}^120 || 0x80), where
     // {0}^120 means 120 zero bits (15 0x00 bytes).
+
+    // As the encrypted initial counter block S only can be computed AFTER
+    // aes_gcm_counter(), set S0 and S1 to random.
+    aes_block_t enc_initial_counter_block;
+    hardened_memshred(enc_initial_counter_block.data, kAesBlockNumWords);
+
+    // Split the initial counter block S into two shares S0 and S1.
+    // S0: random data.
+    aes_block_t enc_initial_counter_block0;
+    hardened_memshred(enc_initial_counter_block0.data, kAesBlockNumWords);
+
+    // S1: S ^ S0
+    aes_block_t enc_initial_counter_block1;
+    hardened_memcpy(enc_initial_counter_block1.data,
+                    enc_initial_counter_block0.data, kAesBlockNumWords);
+    hardened_xor(enc_initial_counter_block1.data,
+                 enc_initial_counter_block.data, kAesBlockNumWords);
+
+    // Calculate the masking correction terms and store the encrypted initial
+    // counter blocks S0 and S1.
+    ghash_handle_enc_initial_counter_block(
+        enc_initial_counter_block0.data, enc_initial_counter_block1.data, ctx);
+
     ghash_init(ctx);
     ghash_update(ctx, iv_len * sizeof(uint32_t), (unsigned char *)iv);
     uint8_t buffer[kAesBlockNumBytes];
@@ -256,6 +293,10 @@ static status_t aes_gcm_counter(const size_t iv_len, const uint32_t *iv,
     buffer[kAesBlockNumBytes - 1] = 0x80;
     ghash_update(ctx, kAesBlockNumBytes, buffer);
     ghash_final(ctx, j0->data);
+    // In the masking scheme, the GHASH function now actually XORs the initial
+    // counter block S to the output. As we do not want to have this for J0,
+    // correct the output.
+    hardened_xor(j0->data, enc_initial_counter_block.data, kAesBlockNumWords);
   } else {
     // Should not happen; invalid IV length.
     return OTCRYPTO_BAD_ARGS;
@@ -285,29 +326,16 @@ static status_t aes_gcm_get_tag(aes_gcm_context_t *ctx, size_t tag_len,
       __builtin_bswap64(((uint64_t)ctx->input_len) * 8),
   };
 
-  // Finish computing S by appending (len64(A) || len64(C)).
+  // Append (len64(A) || len64(C)) and XOR the result with S1 to get the final
+  // tag.
   ghash_update(&ctx->ghash_ctx, kAesBlockNumBytes, (unsigned char *)last_block);
-  aes_block_t s;
-  ghash_final(&ctx->ghash_ctx, s.data);
-
-  // Compute the tag T = GCTR(K, J0, S).
-  uint32_t full_tag[kAesBlockNumWords];
-  size_t full_tag_len;
-  aes_block_t empty = {.data = {0}};
-  HARDENED_TRY(aes_gcm_gctr(ctx->key, &ctx->initial_counter_block,
-                            /*partial_len=*/0, &empty, kAesBlockNumBytes,
-                            (unsigned char *)s.data, ctx->security_level,
-                            &full_tag_len, (unsigned char *)full_tag));
-
-  // Sanity check.
-  if (full_tag_len != kAesBlockNumBytes) {
-    return OTCRYPTO_FATAL_ERR;
-  }
+  aes_block_t full_tag;
+  ghash_final(&ctx->ghash_ctx, full_tag.data);
 
   // Truncate the tag if needed. NIST requires we take the most significant
   // bits in big-endian representation, which corresponds to the least
   // significant bits in Ibex's little-endian representation.
-  HARDENED_TRY(hardened_memcpy(tag, full_tag, tag_len));
+  HARDENED_TRY(hardened_memcpy(tag, full_tag.data, tag_len));
   return OTCRYPTO_OK;
 }
 
@@ -352,6 +380,33 @@ static status_t aes_gcm_init(const aes_key_t key, const size_t iv_len,
   // Compute the counter block (called J0 in the NIST specification).
   HARDENED_TRY(aes_gcm_counter(iv_len, iv, &ctx->ghash_ctx,
                                &ctx->initial_counter_block));
+
+  // Create the encrypted initial counter block S.
+  aes_block_t zero;
+  memset(zero.data, 0, kAesBlockNumBytes);
+  aes_block_t enc_initial_counter_block;
+  HARDENED_TRY(aes_encrypt_block(key, &ctx->initial_counter_block, &zero,
+                                 &enc_initial_counter_block,
+                                 ctx->security_level));
+
+  // Split the initial counter block S into two shares S0 and S1.
+  // S0: random data.
+  aes_block_t enc_initial_counter_block0;
+  hardened_memshred(enc_initial_counter_block0.data, kAesBlockNumWords);
+
+  // S1: S ^ S0
+  aes_block_t enc_initial_counter_block1;
+  hardened_memcpy(enc_initial_counter_block1.data,
+                  enc_initial_counter_block0.data, kAesBlockNumWords);
+  // TODO(#28008): make sure that we do not override shares.
+  hardened_xor(enc_initial_counter_block1.data, enc_initial_counter_block.data,
+               kAesBlockNumWords);
+
+  // Calculate the masking correction terms and store the encrypted initial
+  // counter blocks.
+  ghash_handle_enc_initial_counter_block(enc_initial_counter_block0.data,
+                                         enc_initial_counter_block1.data,
+                                         &ctx->ghash_ctx);
 
   // Set the initial IV for GCTR to inc32(J0).
   // The eventual ciphertext is C = GCTR(K, inc32(J0), plaintext).

--- a/sw/device/lib/crypto/impl/aes_gcm/ghash.c
+++ b/sw/device/lib/crypto/impl/aes_gcm/ghash.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/crypto/impl/aes_gcm/ghash.h"
 
+#include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 
@@ -143,11 +144,11 @@ static uint8_t reverse_bits(uint8_t byte) {
   return out;
 }
 
-void ghash_init_subkey(const uint32_t *hash_subkey, ghash_context_t *ctx) {
+void ghash_init_subkey(const uint32_t *hash_subkey, ghash_block_t *tbl) {
   // Initialize 0 * H = 0.
-  memset(ctx->tbl[0].data, 0, kGhashBlockNumBytes);
+  memset(tbl[0].data, 0, kGhashBlockNumBytes);
   // Initialize 1 * H = H.
-  memcpy(ctx->tbl[0x8].data, hash_subkey, kGhashBlockNumBytes);
+  memcpy(tbl[0x8].data, hash_subkey, kGhashBlockNumBytes);
 
   // To get remaining entries, we use a variant of "shift and add"; in
   // polynomial terms, a shift is a multiplication by x. Note that, because the
@@ -157,16 +158,19 @@ void ghash_init_subkey(const uint32_t *hash_subkey, ghash_context_t *ctx) {
   for (uint8_t i = 2; i < 16; i += 2) {
     // Find the product corresponding to (i >> 1) * H and multiply by x to
     // shift 1; this will be i * H.
-    galois_mulx(&ctx->tbl[reverse_bits(i >> 1)], &ctx->tbl[reverse_bits(i)]);
+    galois_mulx(&tbl[reverse_bits(i >> 1)], &tbl[reverse_bits(i)]);
 
     // Add H to i * H to get (i + 1) * H.
-    block_xor(&ctx->tbl[reverse_bits(i)], &ctx->tbl[0x8],
-              &ctx->tbl[reverse_bits(i + 1)]);
+    block_xor(&tbl[reverse_bits(i)], &tbl[0x8], &tbl[reverse_bits(i + 1)]);
   }
 }
 
 void ghash_init(ghash_context_t *ctx) {
-  memset(ctx->state.data, 0, kGhashBlockNumBytes);
+  // Randomize the initial state.
+  hardened_memshred(ctx->state0.data, kGhashBlockNumWords);
+  hardened_memshred(ctx->state1.data, kGhashBlockNumWords);
+  // Initialize the ghash block counter.
+  ctx->ghash_block_cnt = 0;
 }
 
 /**
@@ -182,9 +186,12 @@ void ghash_init(ghash_context_t *ctx) {
  * This operation corresponds to multiplication in the Galois field with order
  * 2^128, modulo the polynomial x^128 +  x^8 + x^2 + x + 1
  *
- * @param ctx GHASH context, updated in place.
+ * @param state GHASH state.
+ * @param tbl Product table for the masked hash subkey.
+ * @return Multiplication of the state and the hash subkey.
  */
-static void galois_mul_state_key(ghash_context_t *ctx) {
+static ghash_block_t galois_mul_state_key(ghash_block_t state,
+                                          ghash_block_t tbl[16]) {
   // Initialize the multiplication result to 0.
   ghash_block_t result;
   memset(result.data, 0, kGhashBlockNumBytes);
@@ -217,7 +224,7 @@ static void galois_mul_state_key(ghash_context_t *ctx) {
     // Add the product of the next window and H to `result`. We process the
     // windows starting with the most significant polynomial terms, which means
     // starting from the last byte and proceeding to the first.
-    uint8_t tbl_index = block_byte_get(&ctx->state, (kNumWindows - 1 - i) >> 1);
+    uint8_t tbl_index = block_byte_get(&state, (kNumWindows - 1 - i) >> 1);
 
     // Select the less significant 4 bits if i is even, or the more significant
     // 4 bits if i is odd. This does not need to be constant time, since the
@@ -227,10 +234,9 @@ static void galois_mul_state_key(ghash_context_t *ctx) {
     } else {
       tbl_index &= 0x0f;
     }
-    block_xor(&result, &ctx->tbl[tbl_index], &result);
+    block_xor(&result, &tbl[tbl_index], &result);
   }
-
-  memcpy(ctx->state.data, result.data, kGhashBlockNumBytes);
+  return result;
 }
 
 /**
@@ -240,10 +246,67 @@ static void galois_mul_state_key(ghash_context_t *ctx) {
  * @param block Block to incorporate.
  */
 static void ghash_process_block(ghash_context_t *ctx, ghash_block_t *block) {
-  // XOR `state` with the next input block.
-  block_xor(&ctx->state, block, &ctx->state);
-  // Multiply state by H in-place.
-  galois_mul_state_key(ctx);
+  ghash_block_t s0_tmp;
+  ghash_block_t s1_tmp;
+  if (ctx->ghash_block_cnt == 0) {
+    // Process share 0.
+    // share0_tmp = (S0 + T0) * H0
+    hardened_memcpy(s0_tmp.data, block->data, kGhashBlockNumWords);
+    hardened_xor(s0_tmp.data, ctx->enc_initial_counter_block0.data,
+                 kGhashBlockNumWords);
+    s0_tmp = galois_mul_state_key(s0_tmp, ctx->tbl0);
+
+    // Apply the correction terms for state share 0.
+    // share0 = share0_tmp + (S0*(H0+1))
+    hardened_memcpy(ctx->state0.data, s0_tmp.data, kGhashBlockNumWords);
+    hardened_xor(ctx->state0.data, ctx->correction_term0.data,
+                 kGhashBlockNumWords);
+
+    // TODO(#28013): randomize register file content before processing the
+    // second share.
+
+    // Process share 1.
+    // share1_tmp = (S1 + T0) * H1
+    hardened_memcpy(s1_tmp.data, block->data, kGhashBlockNumWords);
+    hardened_xor(s1_tmp.data, ctx->enc_initial_counter_block1.data,
+                 kGhashBlockNumWords);
+    s1_tmp = galois_mul_state_key(s1_tmp, ctx->tbl1);
+
+    // Apply the correction terms for state share 1.
+    // share1 = share1_tmp + correction_term1
+    hardened_memcpy(ctx->state1.data, s1_tmp.data, kGhashBlockNumWords);
+    hardened_xor(ctx->state1.data, ctx->correction_term1_init.data,
+                 kGhashBlockNumWords);
+  } else {
+    // Process share 0.
+    // tmp = (share0+TN-1)+share1
+    ghash_block_t tmp;
+    hardened_memcpy(tmp.data, block->data, kGhashBlockNumWords);
+    hardened_xor(tmp.data, ctx->state0.data, kGhashBlockNumWords);
+    hardened_xor(tmp.data, ctx->state1.data, kGhashBlockNumWords);
+
+    // s0_tmp = tmp * H0
+    s0_tmp = galois_mul_state_key(tmp, ctx->tbl0);
+
+    // Apply the correction terms for state share 0.
+    // share0 = share0_tmp + (S0*(H0+1))
+    hardened_memcpy(ctx->state0.data, s0_tmp.data, kGhashBlockNumWords);
+    hardened_xor(ctx->state0.data, ctx->correction_term0.data,
+                 kGhashBlockNumWords);
+
+    // Process share 1.
+    // share1_tmp = tmp * H1
+    s1_tmp = galois_mul_state_key(tmp, ctx->tbl1);
+
+    // Apply the correction terms for state share 1.
+    // share1 = share1_tmp + (S0*H0)
+    hardened_memcpy(ctx->state1.data, s1_tmp.data, kGhashBlockNumWords);
+    hardened_xor(ctx->state1.data, ctx->correction_term1.data,
+                 kGhashBlockNumWords);
+  }
+
+  // Increment the number of processed ghash block counter.
+  ctx->ghash_block_cnt++;
 }
 
 void ghash_process_full_blocks(ghash_context_t *ctx, size_t partial_len,
@@ -293,6 +356,35 @@ void ghash_update(ghash_context_t *ctx, size_t input_len,
   }
 }
 
+void ghash_handle_enc_initial_counter_block(
+    const uint32_t *enc_initial_counter_block0,
+    const uint32_t *enc_initial_counter_block1, ghash_context_t *ctx) {
+  // correction_term0 = S0 * (H0 + 1).
+  ghash_block_t s0;
+  hardened_memcpy(s0.data, enc_initial_counter_block0, kGhashBlockNumWords);
+  ghash_block_t mul_tmp = galois_mul_state_key(s0, ctx->tbl0);
+  block_xor(&mul_tmp, &s0, &ctx->correction_term0);
+
+  // correction_term1 = S0 * H1.
+  ctx->correction_term1 = galois_mul_state_key(s0, ctx->tbl1);
+
+  // correction_term1_init = S1 * H1.
+  ghash_block_t s1;
+  hardened_memcpy(s1.data, enc_initial_counter_block1, kGhashBlockNumWords);
+  ctx->correction_term1_init = galois_mul_state_key(s1, ctx->tbl1);
+
+  // Save the encrypted initial counter blocks into the ghash context as we
+  // need them throughout the ghash computations.
+  hardened_memcpy(ctx->enc_initial_counter_block0.data,
+                  enc_initial_counter_block0, kGhashBlockNumWords);
+  hardened_memcpy(ctx->enc_initial_counter_block1.data,
+                  enc_initial_counter_block1, kGhashBlockNumWords);
+}
+
 void ghash_final(ghash_context_t *ctx, uint32_t *result) {
-  memcpy(result, ctx->state.data, kGhashBlockNumBytes);
+  // Tag = (state0 + state1) + S1
+  ghash_block_t final_block;
+  block_xor(&ctx->state0, &ctx->state1, &final_block);
+  block_xor(&final_block, &ctx->enc_initial_counter_block1, &final_block);
+  memcpy(result, final_block.data, kGhashBlockNumBytes);
 }

--- a/sw/device/lib/crypto/impl/aes_gcm/ghash_unittest.cc
+++ b/sw/device/lib/crypto/impl/aes_gcm/ghash_unittest.cc
@@ -13,6 +13,14 @@ namespace ghash_unittest {
 namespace {
 using ::testing::ElementsAreArray;
 
+// Zero block.
+std::array<uint32_t, 4> Zero = {
+    0x0,
+    0x0,
+    0x0,
+    0x0,
+};
+
 TEST(Ghash, McGrawViegaTestCase1) {
   // GHASH computation from test case 1 of:
   // https://csrc.nist.rip/groups/ST/toolkit/BCM/documents/proposedmodes/gcm/gcm-spec.pdf
@@ -31,7 +39,9 @@ TEST(Ghash, McGrawViegaTestCase1) {
 
   // Compute GHASH(H, A, C).
   ghash_context_t ctx;
-  ghash_init_subkey(H.data(), &ctx);
+  ghash_init_subkey(H.data(), ctx.tbl0);
+  ghash_init_subkey(Zero.data(), ctx.tbl1);
+  ghash_handle_enc_initial_counter_block(Zero.data(), Zero.data(), &ctx);
   ghash_init(&ctx);
   uint32_t result[kGhashBlockNumWords];
   ghash_final(&ctx, result);
@@ -59,11 +69,11 @@ TEST(Ghash, ProcessFullBlocksOneByte) {
 
   // Initialize context.
   ghash_context_t ctx;
-  ghash_init_subkey(H.data(), &ctx);
+  ghash_init_subkey(H.data(), ctx.tbl0);
+  ghash_init_subkey(Zero.data(), ctx.tbl1);
+  ghash_handle_enc_initial_counter_block(Zero.data(), Zero.data(), &ctx);
   ghash_init(&ctx);
-  EXPECT_THAT(ctx.state.data, testing::ElementsAreArray(zero_block));
   ghash_process_full_blocks(&ctx, partial_len, &partial, input_len, input);
-  EXPECT_THAT(ctx.state.data, testing::ElementsAreArray(zero_block));
   EXPECT_EQ(partial.data[0], input_word);
   EXPECT_EQ(partial.data[1], 0);
   EXPECT_EQ(partial.data[2], 0);
@@ -85,9 +95,10 @@ TEST(Ghash, Mul1) {
   uint8_t one = 0x80;
 
   ghash_context_t ctx;
-  ghash_init_subkey(H.data(), &ctx);
+  ghash_init_subkey(H.data(), ctx.tbl0);
+  ghash_init_subkey(Zero.data(), ctx.tbl1);
+  ghash_handle_enc_initial_counter_block(Zero.data(), Zero.data(), &ctx);
   ghash_init(&ctx);
-  EXPECT_THAT(ctx.state.data, testing::ElementsAreArray(zero));
 
   ghash_block_t partial = {.data = {0}};
   size_t partial_len = 0;
@@ -96,10 +107,9 @@ TEST(Ghash, Mul1) {
   ghash_process_full_blocks(&ctx, partial_len, &partial, input_len, input);
   EXPECT_LT(input_len, kGhashBlockNumBytes - partial_len);
   EXPECT_EQ(partial.data[0], one);
-  EXPECT_THAT(ctx.state.data, testing::ElementsAreArray(zero));
 
   ghash_update(&ctx, 1, &one);
-  EXPECT_THAT(ctx.state.data, testing::ElementsAreArray(H));
+  EXPECT_THAT(ctx.state0.data, testing::ElementsAreArray(H));
   uint32_t result[kGhashBlockNumWords];
   ghash_final(&ctx, result);
 
@@ -144,7 +154,9 @@ TEST(Ghash, McGrawViegaTestCase2) {
 
   // Compute GHASH(H, A, C).
   ghash_context_t ctx;
-  ghash_init_subkey(H.data(), &ctx);
+  ghash_init_subkey(H.data(), ctx.tbl0);
+  ghash_init_subkey(Zero.data(), ctx.tbl1);
+  ghash_handle_enc_initial_counter_block(Zero.data(), Zero.data(), &ctx);
   ghash_init(&ctx);
   ghash_update(&ctx, A.size() * sizeof(uint32_t), (unsigned char *)A.data());
   ghash_update(&ctx, C.size() * sizeof(uint32_t), (unsigned char *)C.data());
@@ -190,7 +202,9 @@ TEST(Ghash, ContextReset) {
 
   // Initialize the hash subkey (should only need to do this once).
   ghash_context_t ctx;
-  ghash_init_subkey(H.data(), &ctx);
+  ghash_init_subkey(H.data(), ctx.tbl0);
+  ghash_init_subkey(Zero.data(), ctx.tbl1);
+  ghash_handle_enc_initial_counter_block(Zero.data(), Zero.data(), &ctx);
 
   // Compute GHASH(H, A, C).
   ghash_init(&ctx);
@@ -254,7 +268,9 @@ TEST(Ghash, McGrawViegaTestCase18) {
 
   // Compute GHASH(H, A, C).
   ghash_context_t ctx;
-  ghash_init_subkey(H.data(), &ctx);
+  ghash_init_subkey(H.data(), ctx.tbl0);
+  ghash_init_subkey(Zero.data(), ctx.tbl1);
+  ghash_handle_enc_initial_counter_block(Zero.data(), Zero.data(), &ctx);
   ghash_init(&ctx);
   ghash_update(&ctx, A.size() * sizeof(uint32_t), (unsigned char *)A.data());
   ghash_update(&ctx, C.size() * sizeof(uint32_t), (unsigned char *)C.data());

--- a/sw/device/lib/crypto/include/aes_gcm.h
+++ b/sw/device/lib/crypto/include/aes_gcm.h
@@ -39,7 +39,7 @@ typedef enum otcrypto_aes_gcm_tag_len {
  * change.
  */
 typedef struct otcrypto_aes_gcm_context {
-  uint32_t data[102];
+  uint32_t data[192];
 } otcrypto_aes_gcm_context_t;
 
 /**


### PR DESCRIPTION
This commit hardens the GHASH function against SCA. The masking scheme follows the approach highlighted in lowRISC/opentitan#27258.

In summary, this masking schemes processes the shares of the hash subkey H = H0 + H1 and the encrypted intial counter block S = S0 + S1 independently.

**Code Size and Performance Analysis**
Runtime: 142933 to 178564 cycles (25+%) for the first AES-GCM testvector.
Code size: from 83,051B to 83,885B (+1%)

**SCA Measurements**
Unfortunately the executing time of AES-GCM is too long to record power traces using the CW setup. Hence, instead, I focused on measuring the multiplication inside the [ghash_process_block(](https://github.com/lowRISC/opentitan/blob/3479cd5ee544e82e6eb8f7b042db42c3472de8e6/sw/device/lib/crypto/impl/aes_gcm/ghash.c#L242)) function:
state = H * (state + block)

For the SCA analysis, the following input was used:
- The block is set to a constant input.
- H is fixed or random. This is done by setting the AES-GCM key k to a fixed or a random value as H=Ek(0^128)
- The AES-GCM IV is always random to make sure that the encrypted initial counter block is always different as it is used in the masking scheme.

Masking disabled (before this PR):
<img width="640" height="480" alt="aes_gcm_no_masking" src="https://github.com/user-attachments/assets/761ab3e1-ecce-4d53-af6f-eecadf0b4328" />

Masking enabled (this PR):
<img width="640" height="480" alt="aes_gcm_masking" src="https://github.com/user-attachments/assets/1ec449a6-dc7b-4129-b06c-a15bb0c03056" />
