### PR TITLE
[topgen,template] Various topgen.py fixes

### DIFF
--- a/util/topgen.py
+++ b/util/topgen.py
@@ -1745,26 +1745,27 @@ def main():
                                 helper=c_helper,
                                 gencmd=gencmd_c)
 
-                # "toplevel_BUILD.h.tpl" -> "sw/autogen/BUILD"
-                memory_cheader_path = cformat_dir / "BUILD"
-                render_template(TOPGEN_TEMPLATE_PATH / "toplevel_BUILD.tpl",
-                                memory_cheader_path,
-                                helper=c_helper,
-                                gencmd=gencmd_bzl)
-
-                # "data_BUILD.h.tpl" -> "data/autogen/BUILD"
-                render_template(TOPGEN_TEMPLATE_PATH / "data_BUILD.tpl",
-                                path / "data" / "autogen" / "BUILD",
-                                gencmd=gencmd_bzl)
-                # "data_defs.bzl.tpl" -> "data/autogen/defs.bzl"
-                render_template(TOPGEN_TEMPLATE_PATH / "data_defs.bzl.tpl",
-                                path / "data" / "autogen" / "defs.bzl",
-                                gencmd=gencmd_bzl)
-
         for idx, path in enumerate(out_paths):
             cformat_dir = path / "sw" / "autogen"
             c_helper.header_macro_prefix = (
                 "OPENTITAN_" + str(rel_header_dir).replace("/", "_").upper())
+
+            # "toplevel_BUILD.h.tpl" -> "sw/autogen/BUILD"
+            memory_cheader_path = cformat_dir / "BUILD"
+            render_template(TOPGEN_TEMPLATE_PATH / "toplevel_BUILD.tpl",
+                            memory_cheader_path,
+                            helper=c_helper,
+                            gencmd=gencmd_bzl)
+
+            # "data_BUILD.h.tpl" -> "data/autogen/BUILD"
+            render_template(TOPGEN_TEMPLATE_PATH / "data_BUILD.tpl",
+                            path / "data" / "autogen" / "BUILD",
+                            gencmd=gencmd_bzl)
+
+            # "data_defs.bzl.tpl" -> "data/autogen/defs.bzl"
+            render_template(TOPGEN_TEMPLATE_PATH / "data_defs.bzl.tpl",
+                            path / "data" / "autogen" / "defs.bzl",
+                            gencmd=gencmd_bzl)
 
             # "toplevel_memory.ld.tpl" ->
             #   "sw/autogen/{top_name}{addr_space_suffix}_memory.ld"

--- a/util/topgen/templates/toplevel_pkg.sv.tpl
+++ b/util/topgen/templates/toplevel_pkg.sv.tpl
@@ -263,7 +263,10 @@ package top_${top["name"]}${addr_space_suffix}_pkg;
 % endfor
     ${lib.Name.from_snake_case("dio_pad_count").as_camel_case()}
   } dio_pad_e;
+% endif # has_pinmux
+% if addr_space_suffix == "":
 
+## TODO this is a hack such that peripheral_e and AST macros are only generated once
 <%
     instances = sorted(set(inst for (inst, _), __ in helper.devices(addr_space_name)))
 %>\
@@ -285,6 +288,6 @@ package top_${top["name"]}${addr_space_suffix}_pkg;
   `define INOUT_AI inout
   `define INOUT_AO inout
 `endif
-% endif
+% endif # addr_space_suffix
 
 endpackage


### PR DESCRIPTION
This makes it such that some of the non-addr-space-specific templates are not rendered for each address space.
And second, previously in toplevel_pkg.sv.tpl the `peripheral_e` enum and the AST macros were gated by `if has_pinmux`. I have replaced this with a `if addr_space_suffix == ""`. While this is not ideal, at least it's more correct than before.

There's no change in any of the generated files.

This change comes from a larger future PR where I'm trying to figure out the best way to decouple address-space-specific headers from toplevel headers and where I'm trying to remove special handling of the "hart" address space. I'll raise an issue to discuss this once I know more about this.