### PR TITLE
[racl_ctrl] Don't store lowest 2 bits in error_log_address register

### DIFF
--- a/hw/ip_templates/racl_ctrl/data/racl_ctrl.hjson.tpl
+++ b/hw/ip_templates/racl_ctrl/data/racl_ctrl.hjson.tpl
@@ -252,7 +252,8 @@
       ]
     }
     { name: "ERROR_LOG_ADDRESS"
-      desc: '''Contains the address on which a RACL violation occurred.
+      desc: '''Contains the bits [top_pkg::TL_AW-1:2] of the address on which a RACL violation occurred.
+               The address is shifted by 2 bits since TLUL access are always 4 byte aligned.
                This register is valid if and only if the `valid` field of !!ERROR_LOG is true.
                Once valid, the address doesn't change (even if there are subsequent RACL violations) until the register gets cleared.
                This register gets cleared when SW writes `1` to the `valid` field of the !!ERROR_LOG register.
@@ -260,11 +261,11 @@
       swaccess: "ro"
       hwaccess: "hwo"
       fields: [
-        { bits: "31:0"
+        { bits: "29:0"
           name: "address"
           resval: 0x0
           desc: '''
-                Address on which a RACL violation occurred.
+                Address on which a RACL violation occurred, shifted by 2 bits to the right.
                 '''
         }
       ]

--- a/hw/ip_templates/racl_ctrl/doc/programmers_guide.md
+++ b/hw/ip_templates/racl_ctrl/doc/programmers_guide.md
@@ -17,7 +17,7 @@ Interrupts are disabled by default but can be enabled via the [`INTR_ENABLE`](./
 
 When a RACL error occurs, the following information about the error is logged in the [`ERROR_LOG`](./registers.md#error_log) and [`ERROR_LOG_ADDRESS`](./registers.md#error_log_address) registers.
 
-- `ERROR_LOG_ADDRESS` contains the address on which a RACL violation occurred.
+- `ERROR_LOG_ADDRESS` contains the address, shifted by 2 bits to the right, on which a RACL violation occurred.
 - `ERROR_LOG.valid` indicates that the log registers contain valid data.
 - `ERROR_LOG.overflow` indicates that a RACL error occurred while the `valid` bit was set or that more than one error was reported in the same clock cycle.
 - `ERROR_LOG.read_access` states whether the RACL error occurred due to a read (`1`) or write (`0`) operation.

--- a/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
+++ b/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
@@ -199,8 +199,14 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
   assign hw2reg.error_log.ctn_uid.d  = clear_log ? '0 : racl_error_arb.ctn_uid;
   assign hw2reg.error_log.ctn_uid.de = first_error | clear_log;
 
-  assign hw2reg.error_log_address.d  = clear_log ? '0 : racl_error_arb.request_address;
+  assign hw2reg.error_log_address.d  = clear_log
+                                       ? '0
+                                       : racl_error_arb.request_address[top_pkg::TL_AW-1:2];
   assign hw2reg.error_log_address.de = first_error | clear_log;
+
+  // unused request_address bits
+  logic unused_request_address;
+  assign unused_request_address = ^racl_error_arb.request_address[1:0];
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Interrupt handling

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/data/racl_ctrl.hjson
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/data/racl_ctrl.hjson
@@ -298,7 +298,8 @@
       ]
     }
     { name: "ERROR_LOG_ADDRESS"
-      desc: '''Contains the address on which a RACL violation occurred.
+      desc: '''Contains the bits [top_pkg::TL_AW-1:2] of the address on which a RACL violation occurred.
+               The address is shifted by 2 bits since TLUL access are always 4 byte aligned.
                This register is valid if and only if the `valid` field of !!ERROR_LOG is true.
                Once valid, the address doesn't change (even if there are subsequent RACL violations) until the register gets cleared.
                This register gets cleared when SW writes `1` to the `valid` field of the !!ERROR_LOG register.
@@ -306,11 +307,11 @@
       swaccess: "ro"
       hwaccess: "hwo"
       fields: [
-        { bits: "31:0"
+        { bits: "29:0"
           name: "address"
           resval: 0x0
           desc: '''
-                Address on which a RACL violation occurred.
+                Address on which a RACL violation occurred, shifted by 2 bits to the right.
                 '''
         }
       ]

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/doc/programmers_guide.md
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/doc/programmers_guide.md
@@ -17,7 +17,7 @@ Interrupts are disabled by default but can be enabled via the [`INTR_ENABLE`](./
 
 When a RACL error occurs, the following information about the error is logged in the [`ERROR_LOG`](./registers.md#error_log) and [`ERROR_LOG_ADDRESS`](./registers.md#error_log_address) registers.
 
-- `ERROR_LOG_ADDRESS` contains the address on which a RACL violation occurred.
+- `ERROR_LOG_ADDRESS` contains the address, shifted by 2 bits to the right, on which a RACL violation occurred.
 - `ERROR_LOG.valid` indicates that the log registers contain valid data.
 - `ERROR_LOG.overflow` indicates that a RACL error occurred while the `valid` bit was set or that more than one error was reported in the same clock cycle.
 - `ERROR_LOG.read_access` states whether the RACL error occurred due to a read (`1`) or write (`0`) operation.

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/doc/registers.md
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/doc/registers.md
@@ -3,17 +3,17 @@
 <!-- BEGIN CMDGEN util/regtool.py -d ./hw/top_darjeeling/ip_autogen/racl_ctrl/data/racl_ctrl.hjson -->
 ## Summary
 
-| Name                                                                    | Offset   |   Length | Description                                              |
-|:------------------------------------------------------------------------|:---------|---------:|:---------------------------------------------------------|
-| racl_ctrl.[`POLICY_ALL_RD_WR_SHADOWED`](#policy_all_rd_wr_shadowed)     | 0x0      |        4 | Read and write policy for ALL_RD_WR                      |
-| racl_ctrl.[`POLICY_ROT_PRIVATE_SHADOWED`](#policy_rot_private_shadowed) | 0x8      |        4 | Read and write policy for ROT_PRIVATE                    |
-| racl_ctrl.[`POLICY_SOC_ROT_SHADOWED`](#policy_soc_rot_shadowed)         | 0x10     |        4 | Read and write policy for SOC_ROT                        |
-| racl_ctrl.[`INTR_STATE`](#intr_state)                                   | 0xe8     |        4 | Interrupt State Register                                 |
-| racl_ctrl.[`INTR_ENABLE`](#intr_enable)                                 | 0xec     |        4 | Interrupt Enable Register                                |
-| racl_ctrl.[`INTR_TEST`](#intr_test)                                     | 0xf0     |        4 | Interrupt Test Register                                  |
-| racl_ctrl.[`ALERT_TEST`](#alert_test)                                   | 0xf4     |        4 | Alert Test Register.                                     |
-| racl_ctrl.[`ERROR_LOG`](#error_log)                                     | 0xf8     |        4 | Error logging registers                                  |
-| racl_ctrl.[`ERROR_LOG_ADDRESS`](#error_log_address)                     | 0xfc     |        4 | Contains the address on which a RACL violation occurred. |
+| Name                                                                    | Offset   |   Length | Description                                                                               |
+|:------------------------------------------------------------------------|:---------|---------:|:------------------------------------------------------------------------------------------|
+| racl_ctrl.[`POLICY_ALL_RD_WR_SHADOWED`](#policy_all_rd_wr_shadowed)     | 0x0      |        4 | Read and write policy for ALL_RD_WR                                                       |
+| racl_ctrl.[`POLICY_ROT_PRIVATE_SHADOWED`](#policy_rot_private_shadowed) | 0x8      |        4 | Read and write policy for ROT_PRIVATE                                                     |
+| racl_ctrl.[`POLICY_SOC_ROT_SHADOWED`](#policy_soc_rot_shadowed)         | 0x10     |        4 | Read and write policy for SOC_ROT                                                         |
+| racl_ctrl.[`INTR_STATE`](#intr_state)                                   | 0xe8     |        4 | Interrupt State Register                                                                  |
+| racl_ctrl.[`INTR_ENABLE`](#intr_enable)                                 | 0xec     |        4 | Interrupt Enable Register                                                                 |
+| racl_ctrl.[`INTR_TEST`](#intr_test)                                     | 0xf0     |        4 | Interrupt Test Register                                                                   |
+| racl_ctrl.[`ALERT_TEST`](#alert_test)                                   | 0xf4     |        4 | Alert Test Register.                                                                      |
+| racl_ctrl.[`ERROR_LOG`](#error_log)                                     | 0xf8     |        4 | Error logging registers                                                                   |
+| racl_ctrl.[`ERROR_LOG_ADDRESS`](#error_log_address)                     | 0xfc     |        4 | Contains the bits [top_pkg::TL_AW-1:2] of the address on which a RACL violation occurred. |
 
 ## POLICY_ALL_RD_WR_SHADOWED
 Read and write policy for ALL_RD_WR
@@ -157,23 +157,25 @@ Error logging registers
 |   0    |  rw1c  |   0x0   | valid       | Indicates a RACL error and the log register contains valid data. Writing a one clears this register and the [`ERROR_LOG_ADDRESS`](#error_log_address) register. |
 
 ## ERROR_LOG_ADDRESS
-Contains the address on which a RACL violation occurred.
+Contains the bits [top_pkg::TL_AW-1:2] of the address on which a RACL violation occurred.
+   The address is shifted by 2 bits since TLUL access are always 4 byte aligned.
    This register is valid if and only if the `valid` field of [`ERROR_LOG`](#error_log) is true.
    Once valid, the address doesn't change (even if there are subsequent RACL violations) until the register gets cleared.
    This register gets cleared when SW writes `1` to the `valid` field of the [`ERROR_LOG`](#error_log) register.
 - Offset: `0xfc`
 - Reset default: `0x0`
-- Reset mask: `0xffffffff`
+- Reset mask: `0x3fffffff`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "address", "bits": 32, "attr": ["ro"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "address", "bits": 30, "attr": ["ro"], "rotate": 0}, {"bits": 2}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name    | Description                                 |
-|:------:|:------:|:-------:|:--------|:--------------------------------------------|
-|  31:0  |   ro   |   0x0   | address | Address on which a RACL violation occurred. |
+|  Bits  |  Type  |  Reset  | Name    | Description                                                                 |
+|:------:|:------:|:-------:|:--------|:----------------------------------------------------------------------------|
+| 31:30  |        |         |         | Reserved                                                                    |
+|  29:0  |   ro   |   0x0   | address | Address on which a RACL violation occurred, shifted by 2 bits to the right. |
 
 
 <!-- END CMDGEN -->

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv
@@ -178,8 +178,14 @@ module racl_ctrl import racl_ctrl_reg_pkg::*; #(
   assign hw2reg.error_log.ctn_uid.d  = clear_log ? '0 : racl_error_arb.ctn_uid;
   assign hw2reg.error_log.ctn_uid.de = first_error | clear_log;
 
-  assign hw2reg.error_log_address.d  = clear_log ? '0 : racl_error_arb.request_address;
+  assign hw2reg.error_log_address.d  = clear_log
+                                       ? '0
+                                       : racl_error_arb.request_address[top_pkg::TL_AW-1:2];
   assign hw2reg.error_log_address.de = first_error | clear_log;
+
+  // unused request_address bits
+  logic unused_request_address;
+  assign unused_request_address = ^racl_error_arb.request_address[1:0];
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Interrupt handling

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_pkg.sv
@@ -112,7 +112,7 @@ package racl_ctrl_reg_pkg;
   } racl_ctrl_hw2reg_error_log_reg_t;
 
   typedef struct packed {
-    logic [31:0] d;
+    logic [29:0] d;
     logic        de;
   } racl_ctrl_hw2reg_error_log_address_reg_t;
 
@@ -130,9 +130,9 @@ package racl_ctrl_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    racl_ctrl_hw2reg_intr_state_reg_t intr_state; // [51:50]
-    racl_ctrl_hw2reg_error_log_reg_t error_log; // [49:33]
-    racl_ctrl_hw2reg_error_log_address_reg_t error_log_address; // [32:0]
+    racl_ctrl_hw2reg_intr_state_reg_t intr_state; // [49:48]
+    racl_ctrl_hw2reg_error_log_reg_t error_log; // [47:31]
+    racl_ctrl_hw2reg_error_log_address_reg_t error_log_address; // [30:0]
   } racl_ctrl_hw2reg_t;
 
   // Register offsets

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_top.sv
@@ -179,7 +179,7 @@ module racl_ctrl_reg_top
   logic error_log_read_access_qs;
   logic [3:0] error_log_role_qs;
   logic [4:0] error_log_ctn_uid_qs;
-  logic [31:0] error_log_address_qs;
+  logic [29:0] error_log_address_qs;
 
   // Register instances
   // R[policy_all_rd_wr_shadowed]: V(False)
@@ -668,9 +668,9 @@ module racl_ctrl_reg_top
 
   // R[error_log_address]: V(False)
   prim_subreg #(
-    .DW      (32),
+    .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0),
+    .RESVAL  (30'h0),
     .Mubi    (1'b0)
   ) u_error_log_address (
     .clk_i   (clk_i),
@@ -871,7 +871,7 @@ module racl_ctrl_reg_top
       end
 
       racl_addr_hit_read[8]: begin
-        reg_rdata_next[31:0] = error_log_address_qs;
+        reg_rdata_next[29:0] = error_log_address_qs;
       end
 
       default: begin


### PR DESCRIPTION
This PR changes the error_log_address register to not store the lowest 2 bits of the address. These 2 bits are always zero since TLUL requests are always 4-byte-aligned.