### PR TITLE
[racl_ctrl,dv] Connect up an interrupt interface for racl_ctrl DV

### DIFF
--- a/hw/ip/racl_ctrl/dv/env/racl_ctrl_env_cfg.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_ctrl_env_cfg.sv
@@ -29,8 +29,11 @@ endfunction
 
 function void racl_ctrl_env_cfg::initialize(bit [31:0] csr_base_addr = '1);
   list_of_alerts = racl_ctrl_env_pkg::LIST_OF_ALERTS;
+
+  // Tell the CIP base code how many interrupts we have (defaults to zero)
+  num_interrupts = 1;
+
   super.initialize(csr_base_addr);
-  num_interrupts = 0;
 
   // Tell regs about ral, which contains the actual register model.
   regs.set_reg_block(ral);

--- a/hw/ip/racl_ctrl/dv/racl_ctrl_tests.hjson
+++ b/hw/ip/racl_ctrl/dv/racl_ctrl_tests.hjson
@@ -20,6 +20,7 @@
                 // Common CIP test lists
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 


### PR DESCRIPTION
This depends on #27218 and #27393. Once those two PRs are merged, only the final commit remains. Its commit message is:

```
[racl_ctrl,dv] Connect up an interrupt interface in tb
This gets registered as "intr_vif" in uvm_config_db. That gets picked
up by cip_base_env and then stored as cip_base_env_cfg.intr_vif in the
environment's config object.

Setting the num_interrupts field to 1 in that config object means that
the CIP base code will know about the existence of the interrupt (and
will automatically generate sequences to poke the associated intr_test
register).

Finally, we add intr_test.hjson to the configurations imported by
racl_ctrl_tests. This contains racl_ctrl_intr_test, which implements
the intr_test testpoint in intr_test_testplan (imported by
racl_ctrl_testplan).
```