### PR TITLE
[bazel,qemu] Stream QEMU stdout logs during test execution

### DIFF
--- a/rules/scripts/qemu_pass.py
+++ b/rules/scripts/qemu_pass.py
@@ -17,23 +17,25 @@ def main() -> int:
     r = Runfiles.Create()
     qemu_bin = r.Rlocation("qemu_opentitan/build/qemu-system-riscv32")
 
-    # Run the process capturing (then echoing) `stdout` and `stderr`.
-    proc = subprocess.run(
-        [qemu_bin] + sys.argv[1:],
+    # Run the process streaming (echoing) `stdout` and `stderr`.
+    proc = subprocess.Popen(
+        " ".join([qemu_bin] + sys.argv[1:]),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+        bufsize=1,
+        shell=True,
         text=True,
     )
-    sys.stdout.write(proc.stdout or "")
-    sys.stderr.write(proc.stderr or "")
-
-    if proc.stdout.find("PASS!") != -1:
-        return proc.returncode
-    elif proc.returncode == 0:
+    for line in proc.stdout:
+        sys.stdout.write(line)
+        sys.stdout.flush()
+        if "PASS!" in line:
+            return proc.wait()
+    returncode = proc.wait()
+    if returncode == 0:
         # QEMU exited successfully but we didn't see `PASS!`, fail instead.
         return 1
-    else:
-        return proc.returncode
+    return returncode
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replace the `subprocess.run` in the `qemu_pass.py` script with an equivalent manual Popen implementation to allow streaming the received test output line by line, as we can do in other test environments.

I tested this with
```
# A test that fails in QEMU
./bazelisk.sh test --test_output=streamed //sw/device/lib/base:memory_perftest_sim_qemu_rom_with_fake_keys
# A test that passses in QEMU, and takes a while so we can see stdout streaming
./bazelisk.sh test //sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_kat1_sim_qemu_rom_with_fake_keys -t- --test_output=streamed
```
