### PR TITLE
[racl_ctrl,dv] Add a missing dependency to racl_ctrl_ral.core

### DIFF
--- a/hw/ip_templates/racl_ctrl/dv/racl_ctrl_ral.core.tpl
+++ b/hw/ip_templates/racl_ctrl/dv/racl_ctrl_ral.core.tpl
@@ -10,6 +10,7 @@ filesets:
   ral_dep:
     depend:
       - lowrisc:dv:ralgen
+      - lowrisc:dv:dv_base_reg
 
 generate:
   ral:

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/dv/racl_ctrl_ral.core
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/dv/racl_ctrl_ral.core
@@ -10,6 +10,7 @@ filesets:
   ral_dep:
     depend:
       - lowrisc:dv:ralgen
+      - lowrisc:dv:dv_base_reg
 
 generate:
   ral:


### PR DESCRIPTION
The missing dependency meant that the "cover reg top" flavour of the testbench didn't build. Adding it here ensures that the generated ral module comes *after* dv_base_reg_pkg.sv.