### PR TITLE
[opentitantool] Add support for DER/PEM signatures in `ecdsa verify`

### DIFF
--- a/sw/host/opentitantool/src/command/ecdsa.rs
+++ b/sw/host/opentitantool/src/command/ecdsa.rs
@@ -280,8 +280,7 @@ impl CommandDispatch for EcdsaVerifyCommand {
             unreachable!();
         };
         let signature = if let Some(signature_file) = &self.signature_file {
-            let bytes = std::fs::read(signature_file)?;
-            EcdsaRawSignature::try_from(bytes.as_slice())?
+            EcdsaRawSignature::read_from_file(signature_file)?
         } else if let Some(signature) = &self.signature {
             EcdsaRawSignature::try_from(hex::decode(signature)?.as_slice())?
         } else {


### PR DESCRIPTION
The `opentitantool ecdsa verify` command previously only supported raw 64-byte binary signature files.

This change updates the command to use the
`EcdsaRawSignature::read_from_file` helper function. This function can automatically detect and parse raw binary, ASN.1 DER, and PEM encoded signature files.