### PR TITLE
[dv] Improve the logic in cip_base_scoreboard.predict_tl_err

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -583,8 +583,26 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
             write_w_instr_type_err | instr_type_err | cfg.tl_mem_access_gated | csr_read_err);
   endfunction
 
-  virtual function void check_tl_read_value_after_error(tl_seq_item item, dv_base_reg_block block);
-    `DV_CHECK_EQ(item.d_data, 32'hFFFF_FFFF, "d_data mismatch when d_error = 1")
+  protected function void check_tl_read_value_after_error(tl_seq_item item,
+                                                          dv_base_reg_block block);
+    bit [DataWidth-1:0] exp_data;
+    tlul_pkg::tl_a_user_t a_user = tlul_pkg::tl_a_user_t'(item.a_user);
+
+    // Determine expected data.
+    // When the access target was a CSR, tlul_adapter_reg always returns a '1.
+    // When the access target was the memory, tlul_adapter_sram either returns
+    // DataWhenInstrError ('1) or DataWhenError ('0) depending whether it was a
+    // instruction type access or not.
+    uvm_reg_addr_t csr_addr = block.get_word_aligned_addr(item.a_addr);
+    if (csr_addr inside {block.csr_addrs}) begin
+      exp_data = '1;
+    end else begin
+      // if error occurs when it's an instruction, return all 0 since it's an illegal instruction
+      if (a_user.instr_type == prim_mubi_pkg::MuBi4True) exp_data = 0;
+      else                                               exp_data = '1;
+    end
+
+    `DV_CHECK_EQ(item.d_data, exp_data, "d_data mismatch when d_error = 1")
   endfunction
 
   // Return true if the given address is mapped in the register block

--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -479,7 +479,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
 
     bit unmapped_err   = !is_tl_access_mapped_addr(item.a_addr, block);
     bit bus_intg_err   = !item.is_a_chan_intg_ok(.throw_error(0));
-    bit byte_wr_err    = is_tl_access_unsupported_byte_wr(item, ral_name);
+    bit byte_wr_err    = is_tl_access_unsupported_byte_wr(item, block);
     bit csr_size_err   = !is_tl_csr_write_size_gte_csr_width(item, ral_name);
     bit tl_item_err    = item.get_exp_d_error();
     bit csr_read_err   = is_csr_fetch(item, ral_name);
@@ -651,14 +651,14 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   // file specifically for DV purposes, using an externally sourced specification as reference
   // (third party 'vendored-in' code). The end result is - the TL adapter prevents non-word writes
   // to the entire region. See issue #10765 for more details.
-  virtual function bit is_tl_access_unsupported_byte_wr(tl_seq_item item, string ral_name);
+  local function bit is_tl_access_unsupported_byte_wr(tl_seq_item item, dv_base_reg_block block);
     // TODO: We should infer byte enable support from the adapter attached to the interface (i.e.
     // the map) instead. To do that, more extensive changes may be needed, because we do not know
-    // which map to pick - we only know the ral_name of the interface. For now,
+    // which map to pick - we only know the register block. For now,
     // dv_base_reg_block::supports_byte_enable serves this need.
-    return !cfg.ral_models[ral_name].get_supports_byte_enable() &&
-        item.a_opcode inside {tlul_pkg::PutFullData, tlul_pkg::PutPartialData} &&
-        (item.a_size != 2 || item.a_mask != '1);
+    return (!block.get_supports_byte_enable() &&
+            item.a_opcode inside {tlul_pkg::PutFullData, tlul_pkg::PutPartialData} &&
+            (item.a_size != 2 || item.a_mask != '1));
   endfunction
 
   virtual function bit is_data_intg_passthru_mem(tl_seq_item item, string ral_name);

--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -529,7 +529,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
       // integrity at d_user is from DUT, which should be always correct, except data integrity for
       // passthru memory
       void'(item.is_d_chan_intg_ok(
-            .en_data_intg_chk(!is_data_intg_passthru_mem(item, ral_name) ||
+            .en_data_intg_chk(!is_data_intg_passthru_mem(item, block) ||
                               !cfg.disable_d_user_data_intg_check_for_passthru_mem),
             .throw_error(cfg.m_tl_agent_cfgs[ral_name].check_tl_errs)));
 
@@ -662,9 +662,9 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
             (item.a_size != 2 || item.a_mask != '1));
   endfunction
 
-  virtual function bit is_data_intg_passthru_mem(tl_seq_item item, string ral_name);
-    uvm_reg_addr_t addr = cfg.ral_models[ral_name].get_normalized_addr(item.a_addr);
-    uvm_mem mem = cfg.ral_models[ral_name].default_map.get_mem_by_offset(addr);
+  local function bit is_data_intg_passthru_mem(tl_seq_item item, dv_base_reg_block block);
+    uvm_reg_addr_t addr = block.get_normalized_addr(item.a_addr);
+    uvm_mem mem = block.default_map.get_mem_by_offset(addr);
 
     if (mem == null) begin
       return 0;

--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -437,14 +437,14 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
     return 0;
   endfunction
 
-  // Check if the tl_mapped address is a csr
-  virtual function bit is_csr_fetch(tl_seq_item item, string ral_name);
+  // Return true if item is a fetch from a mapped address in the given register block
+  protected function bit is_csr_fetch(tl_seq_item item, dv_base_reg_block block);
     cip_tl_seq_item cip_item;
     `downcast(cip_item, item)
     return (item.a_opcode == tlul_pkg::Get &&
             cip_item.get_instr_type() == MuBi4True &&
-            is_tl_access_mapped_addr(item.a_addr, cfg.ral_models[ral_name]) &&
-            !is_mem_addr(item.a_addr, cfg.ral_models[ral_name]));
+            is_tl_access_mapped_addr(item.a_addr, block) &&
+            !is_mem_addr(item.a_addr, block));
   endfunction
 
   // Return whether an A-channel access was invalid and check any D-channel response.
@@ -482,7 +482,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
     bit byte_wr_err    = is_tl_access_unsupported_byte_wr(item, block);
     bit csr_size_err   = !is_tl_csr_write_size_gte_csr_width(item, block);
     bit tl_item_err    = item.get_exp_d_error();
-    bit csr_read_err   = is_csr_fetch(item, ral_name);
+    bit csr_read_err   = is_csr_fetch(item, block);
 
     bit mem_access_err, mem_byte_access_err, mem_wo_err, mem_ro_err, custom_err;
 

--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -491,7 +491,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
     logic           cmd_intg_err, data_intg_err;
     bit             write_w_instr_type_err, instr_type_err;
 
-    mem_access_err = !is_tl_mem_access_allowed(item, ral_name, mem_byte_access_err, mem_wo_err,
+    mem_access_err = !is_tl_mem_access_allowed(item, block, mem_byte_access_err, mem_wo_err,
                                                mem_ro_err, custom_err);
 
     `downcast(cip_item, item)
@@ -597,18 +597,19 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   // check if tl mem access will trigger error or not
   // `custom_err` is not set by this base class method. It can be set by the extended class
   // scoreboard to indicate additional, implementation specific errors.
-  virtual function bit is_tl_mem_access_allowed(input tl_seq_item item, input string ral_name,
-                                                output bit mem_byte_access_err,
-                                                output bit mem_wo_err,
-                                                output bit mem_ro_err,
-                                                output bit custom_err);
-    if (is_mem_addr(item.a_addr, cfg.ral_models[ral_name])) begin
+  protected virtual function bit is_tl_mem_access_allowed(tl_seq_item       item,
+                                                          dv_base_reg_block block,
+                                                          output bit        mem_byte_access_err,
+                                                          output bit        mem_wo_err,
+                                                          output bit        mem_ro_err,
+                                                          output bit        custom_err);
+    if (is_mem_addr(item.a_addr, block)) begin
       dv_base_mem mem;
       bit invalid_access;
-      uvm_reg_addr_t addr = cfg.ral_models[ral_name].get_normalized_addr(item.a_addr);
-      string mem_access = get_mem_access_by_addr(cfg.ral_models[ral_name], addr);
+      uvm_reg_addr_t addr = block.get_normalized_addr(item.a_addr);
+      string mem_access = get_mem_access_by_addr(block, addr);
 
-      `downcast(mem, get_mem_by_addr(cfg.ral_models[ral_name], addr))
+      `downcast(mem, get_mem_by_addr(block, addr))
 
       // Check if write isn't full word for mem that doesn't allow byte access.
       if (!mem.get_mem_partial_write_support() &&

--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -557,7 +557,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
 
       // In data read phase, check d_data when d_error = 1.
       if (item.d_error && (item.d_opcode == tlul_pkg::AccessAckData)) begin
-        check_tl_read_value_after_error(item, ral_name);
+        check_tl_read_value_after_error(item, block);
       end
 
       // we don't have cross coverage for simultaneous errors because 1) they're not important,
@@ -583,7 +583,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
             write_w_instr_type_err | instr_type_err | cfg.tl_mem_access_gated | csr_read_err);
   endfunction
 
-  virtual function void check_tl_read_value_after_error(tl_seq_item item, string ral_name);
+  virtual function void check_tl_read_value_after_error(tl_seq_item item, dv_base_reg_block block);
     `DV_CHECK_EQ(item.d_data, 32'hFFFF_FFFF, "d_data mismatch when d_error = 1")
   endfunction
 

--- a/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
@@ -315,7 +315,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
     bit data_phase_write  = (write && channel == DataChannel);
 
     // Scoreboard only takes csr address, so filter out memory address.
-    if (is_mem_addr(item, ral_name)) return;
+    if (is_mem_addr(item.a_addr, cfg.ral_models[ral_name])) return;
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -172,27 +172,6 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
     return super.predict_tl_err(item, channel, ral_name);
   endfunction
 
-  virtual function void check_tl_read_value_after_error(tl_seq_item item, dv_base_reg_block block);
-    bit [TL_DW-1:0] exp_data;
-    tlul_pkg::tl_a_user_t a_user = tlul_pkg::tl_a_user_t'(item.a_user);
-
-    // Determine expected data.
-    // When the access target was a CSR, tlul_adapter_reg always returns a '1.
-    // When the access target was the memory, tlul_adapter_sram either returns
-    // DataWhenInstrError ('1) or DataWhenError ('0) depending whether it was a
-    // instruction type access or not.
-    uvm_reg_addr_t csr_addr = block.get_word_aligned_addr(item.a_addr);
-    if (csr_addr inside {block.csr_addrs}) begin
-      exp_data = '1;
-    end else begin
-      // if error occurs when it's an instruction, return all 0 since it's an illegal instruction
-      if (a_user.instr_type == prim_mubi_pkg::MuBi4True) exp_data = 0;
-      else                                               exp_data = '1;
-    end
-
-    `DV_CHECK_EQ(item.d_data, exp_data, "d_data mismatch when d_error = 1")
-  endfunction
-
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     kdi_fifo = new("kdi_fifo", this);

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -172,7 +172,7 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
     return super.predict_tl_err(item, channel, ral_name);
   endfunction
 
-  virtual function void check_tl_read_value_after_error(tl_seq_item item, string ral_name);
+  virtual function void check_tl_read_value_after_error(tl_seq_item item, dv_base_reg_block block);
     bit [TL_DW-1:0] exp_data;
     tlul_pkg::tl_a_user_t a_user = tlul_pkg::tl_a_user_t'(item.a_user);
 
@@ -181,8 +181,8 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
     // When the access target was the memory, tlul_adapter_sram either returns
     // DataWhenInstrError ('1) or DataWhenError ('0) depending whether it was a
     // instruction type access or not.
-    uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
+    uvm_reg_addr_t csr_addr = block.get_word_aligned_addr(item.a_addr);
+    if (csr_addr inside {block.csr_addrs}) begin
       exp_data = '1;
     end else begin
       // if error occurs when it's an instruction, return all 0 since it's an illegal instruction

--- a/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
@@ -641,7 +641,7 @@ class usbdev_scoreboard extends cip_base_scoreboard #(
       csr_name = csr.get_name();
       index = get_index_from_reg_name(csr_name);
       return csr_name;
-    end else if (is_mem_addr(item, ral_name)) begin
+    end else if (is_mem_addr(item.a_addr, cfg.ral_models[ral_name])) begin
       // There is only a single memory window; it provides access to the packet buffer memory.
       uvm_mem mem = ral.default_map.get_mem_by_offset(item.a_addr);
       uvm_reg_addr_t masked_addr = item.a_addr & ral.get_addr_mask();

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -217,13 +217,13 @@ class flash_ctrl_scoreboard #(
     if (skip_read_check) do_read_check = 0;
     // if access was to a valid csr, get the csr handle
     if ((is_mem_addr(
-            item, ral_name
+            item.a_addr, cfg.ral_models[ral_name]
         ) || (csr_addr inside {cfg.ral_models[ral_name].csr_addrs})) &&
             !cfg.dir_rd_in_progress) begin
 
       // if incoming access is a write to a valid csr, then make updates right away.
       if (addr_phase_write) begin
-        if (is_mem_addr(item, ral_name) && cfg.scb_check) begin  // prog fifo
+        if (is_mem_addr(item.a_addr, cfg.ral_models[ral_name]) && cfg.scb_check) begin  // prog fifo
           if (idx_wr == 0) begin
             csr_rd(.ptr(ral.addr), .value(data), .backdoor(1'b1));
             wr_addr = word_align_addr(get_field_val(ral.addr.start, data));
@@ -382,7 +382,8 @@ class flash_ctrl_scoreboard #(
                          "reg name: %0s", csr.get_full_name()))
           end
           void'(csr.predict(.value(item.d_data), .kind(UVM_PREDICT_READ)));
-        end else if (is_mem_addr(item, ral_name) && cfg.scb_check) begin  // rd fifo
+        end else if (is_mem_addr(item.a_addr, cfg.ral_models[ral_name]) && cfg.scb_check) begin
+          // rd fifo
           if (idx_rd == 0) begin
             csr_rd(.ptr(ral.addr), .value(data), .backdoor(1'b1));
             rd_addr = word_align_addr(get_field_val(ral.addr.start, data));

--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv.tpl
@@ -1468,7 +1468,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
 
         // In data read phase, check d_data when d_error = 1.
         if (item.d_error && (item.d_opcode == tlul_pkg::AccessAckData)) begin
-          check_tl_read_value_after_error(item, ral_name);
+          check_tl_read_value_after_error(item, cfg.ral_models[ral_name]);
         end
       end
       return 1;

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -2037,7 +2037,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
 
         // In data read phase, check d_data when d_error = 1.
         if (item.d_error && (item.d_opcode == tlul_pkg::AccessAckData)) begin
-          check_tl_read_value_after_error(item, ral_name);
+          check_tl_read_value_after_error(item, cfg.ral_models[ral_name]);
         end
       end
       return 1;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -217,13 +217,13 @@ class flash_ctrl_scoreboard #(
     if (skip_read_check) do_read_check = 0;
     // if access was to a valid csr, get the csr handle
     if ((is_mem_addr(
-            item, ral_name
+            item.a_addr, cfg.ral_models[ral_name]
         ) || (csr_addr inside {cfg.ral_models[ral_name].csr_addrs})) &&
             !cfg.dir_rd_in_progress) begin
 
       // if incoming access is a write to a valid csr, then make updates right away.
       if (addr_phase_write) begin
-        if (is_mem_addr(item, ral_name) && cfg.scb_check) begin  // prog fifo
+        if (is_mem_addr(item.a_addr, cfg.ral_models[ral_name]) && cfg.scb_check) begin  // prog fifo
           if (idx_wr == 0) begin
             csr_rd(.ptr(ral.addr), .value(data), .backdoor(1'b1));
             wr_addr = word_align_addr(get_field_val(ral.addr.start, data));
@@ -382,7 +382,8 @@ class flash_ctrl_scoreboard #(
                          "reg name: %0s", csr.get_full_name()))
           end
           void'(csr.predict(.value(item.d_data), .kind(UVM_PREDICT_READ)));
-        end else if (is_mem_addr(item, ral_name) && cfg.scb_check) begin  // rd fifo
+        end else if (is_mem_addr(item.a_addr, cfg.ral_models[ral_name]) && cfg.scb_check) begin
+          // rd fifo
           if (idx_rd == 0) begin
             csr_rd(.ptr(ral.addr), .value(data), .backdoor(1'b1));
             rd_addr = word_align_addr(get_field_val(ral.addr.start, data));

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -1680,7 +1680,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
 
         // In data read phase, check d_data when d_error = 1.
         if (item.d_error && (item.d_opcode == tlul_pkg::AccessAckData)) begin
-          check_tl_read_value_after_error(item, ral_name);
+          check_tl_read_value_after_error(item, cfg.ral_models[ral_name]);
         end
       end
       return 1;

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -217,13 +217,13 @@ class flash_ctrl_scoreboard #(
     if (skip_read_check) do_read_check = 0;
     // if access was to a valid csr, get the csr handle
     if ((is_mem_addr(
-            item, ral_name
+            item.a_addr, cfg.ral_models[ral_name]
         ) || (csr_addr inside {cfg.ral_models[ral_name].csr_addrs})) &&
             !cfg.dir_rd_in_progress) begin
 
       // if incoming access is a write to a valid csr, then make updates right away.
       if (addr_phase_write) begin
-        if (is_mem_addr(item, ral_name) && cfg.scb_check) begin  // prog fifo
+        if (is_mem_addr(item.a_addr, cfg.ral_models[ral_name]) && cfg.scb_check) begin  // prog fifo
           if (idx_wr == 0) begin
             csr_rd(.ptr(ral.addr), .value(data), .backdoor(1'b1));
             wr_addr = word_align_addr(get_field_val(ral.addr.start, data));
@@ -382,7 +382,8 @@ class flash_ctrl_scoreboard #(
                          "reg name: %0s", csr.get_full_name()))
           end
           void'(csr.predict(.value(item.d_data), .kind(UVM_PREDICT_READ)));
-        end else if (is_mem_addr(item, ral_name) && cfg.scb_check) begin  // rd fifo
+        end else if (is_mem_addr(item.a_addr, cfg.ral_models[ral_name]) && cfg.scb_check) begin
+          // rd fifo
           if (idx_rd == 0) begin
             csr_rd(.ptr(ral.addr), .value(data), .backdoor(1'b1));
             rd_addr = word_align_addr(get_field_val(ral.addr.start, data));


### PR DESCRIPTION
This was inspired by a (rather incorrect) PR I pushed about otp_ctrl DV: #27934. After @matutem pointed out my mistake, I spent a bit of time tidying up and adding more careful documentation in the relevant bits of `cip_base_scoreboard`.

The problem that I was trying to fix in the wrong PR linked above is fixed properly in the final commit of the PR ("Use special behaviour...").