### PR TITLE
[fpv,mbx] Bind FPV assertions to both CSR interfaces

### DIFF
--- a/hw/ip/mbx/data/mbx.hjson
+++ b/hw/ip/mbx/data/mbx.hjson
@@ -19,9 +19,9 @@
 
   clocking: [{clock: "clk_i", reset: "rst_ni", primary: true}]
   bus_interfaces: [
-    { protocol: "tlul", direction: "device", name: "core", racl_support: true }
+    { protocol: "tlul", direction: "device", name: "core", hier_path: "u_hostif.u_regs", racl_support: true }
     { protocol: "tlul", direction: "host",   name: "sram" }
-    { protocol: "tlul", direction: "device", name: "soc", racl_support: true }
+    { protocol: "tlul", direction: "device", name: "soc", hier_path: "u_sysif.u_regs", racl_support: true }
   ]
   inter_signal_list: [
     { struct:  "logic",

--- a/hw/ip/mbx/dv/sva/mbx_bind.sv
+++ b/hw/ip/mbx/dv/sva/mbx_bind.sv
@@ -34,12 +34,20 @@ module mbx_bind;
     .d2h  (soc_tl_d_o)
   );
 
-  // TODO: Revisit this
-  //bind mbx mbx_csr_assert_fpv mbx_csr_assert (
-  //   .clk_i,
-  //   .rst_ni,
-  //   .h2d (core_tl_d_i),
-  //   .d2h (core_tl_d_o)
-  //);
+  // FPV CSR read and write assertions on ROT-side config interface
+  bind mbx mbx_core_csr_assert_fpv mbx_core_csr_assert (
+     .clk_i,
+     .rst_ni,
+     .h2d (core_tl_d_i),
+     .d2h (core_tl_d_o)
+  );
+
+  // FPV CSR read and write assertions on SoC-side config interface
+  bind mbx mbx_soc_csr_assert_fpv mbx_soc_csr_assert (
+     .clk_i,
+     .rst_ni,
+     .h2d (soc_tl_d_i),
+     .d2h (soc_tl_d_o)
+  );
 
 endmodule

--- a/hw/ip/mbx/dv/sva/mbx_sva.core
+++ b/hw/ip/mbx/dv/sva/mbx_sva.core
@@ -29,6 +29,7 @@ targets:
       - files_dv
     generate:
       - csr_assert_gen
+
   formal:
     <<: *default_target
     filesets:

--- a/hw/ip/mbx/rtl/mbx.sv
+++ b/hw/ip/mbx/rtl/mbx.sv
@@ -386,7 +386,7 @@ module mbx
 
   // Assertions
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A,
-                                                 u_sysif.u_soc_regs,
+                                                 u_sysif.u_regs_soc,
                                                  alert_tx_o[0])
   // All outputs should be known at all times after reset.
   `ASSERT_KNOWN(AlertsKnown_A, alert_tx_o)

--- a/hw/ip/mbx/rtl/mbx_hostif.sv
+++ b/hw/ip/mbx/rtl/mbx_hostif.sv
@@ -110,7 +110,7 @@ module mbx_hostif
     .EnableRacl(EnableRacl),
     .RaclErrorRsp(RaclErrorRsp),
     .RaclPolicySelVec(RaclPolicySelVecCore)
-  ) u_regs(
+  ) u_regs_core(
     .clk_i           ( clk_i           ),
     .rst_ni          ( rst_ni          ),
     .tl_i            ( tl_host_i       ),
@@ -249,6 +249,6 @@ module mbx_hostif
 
   // Assertions
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A,
-                                                 u_regs,
+                                                 u_regs_core,
                                                  alert_tx_o[0])
 endmodule

--- a/hw/ip/mbx/rtl/mbx_sysif.sv
+++ b/hw/ip/mbx/rtl/mbx_sysif.sv
@@ -95,7 +95,7 @@ module mbx_sysif
     .EnableRacl(EnableRacl),
     .RaclErrorRsp(RaclErrorRsp),
     .RaclPolicySelVec(RaclPolicySelVecSoc)
-  ) u_soc_regs (
+  ) u_regs_soc (
     .clk_i            ( clk_i               ),
     .rst_ni           ( rst_ni              ),
     .tl_i             ( tl_sys_i            ),


### PR DESCRIPTION
Bind FPV CSR assertions into the MBX block level DV. Please note that in order to achieve this with our present tooling, it is necessary to rename the '_reg_top' module instances since it adds the interface name to the hierarchical path (see util/reggen/fpv_csr.sv.tpl).