### PR TITLE
[dv,mbx] Rework scoreboard and add coverage

### DIFF
--- a/hw/ip/mbx/dv/env/mbx_env.sv
+++ b/hw/ip/mbx/dv/env/mbx_env.sv
@@ -28,13 +28,22 @@ class mbx_env extends cip_base_env #(
     m_tl_agent_sram = tl_agent::type_id::create("m_tl_agent_sram", this);
     uvm_config_db#(tl_agent_cfg)::set(this, "m_tl_agent_sram", "cfg", cfg.m_tl_agent_sram_cfg);
 
+    cfg.m_tl_agent_sram_cfg.synchronise_ports = 1'b1;
+
   endfunction: build_phase
 
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
 
     virtual_sequencer.tl_sequencer_sram_h = m_tl_agent_sram.sequencer;
-    // TODO: Connect analysis ports.
+
+    // Connect tl_agent monitor ports to scoreboard analysis FIFOs.
+    m_tl_agent_sram.monitor.a_chan_port.connect(
+        scoreboard.tl_a_chan_fifos["tl_sram_a_chan"].analysis_export);
+    m_tl_agent_sram.monitor.d_chan_port.connect(
+        scoreboard.tl_d_chan_fifos["tl_sram_d_chan"].analysis_export);
+    m_tl_agent_sram.monitor.channel_dir_port.connect(
+        scoreboard.tl_dir_fifos["tl_sram_dir"].analysis_export);
   endfunction: connect_phase
 
 endclass: mbx_env

--- a/hw/ip/mbx/dv/env/mbx_env_cfg.sv
+++ b/hw/ip/mbx/dv/env/mbx_env_cfg.sv
@@ -44,7 +44,9 @@ class mbx_env_cfg extends cip_base_env_cfg #(
     // RoT-side SRAM interface. This has no RAL because it is a Device-mode TL agent
     // and thus we manage the agent and its configuration ourselves.
     `uvm_create_obj(tl_agent_cfg, m_tl_agent_sram_cfg)
-    m_tl_agent_sram_cfg.max_outstanding_req = 16;
+    // The DUT logic will send up to 4 overlapped read/write requests, which it counts
+    // internally.
+    m_tl_agent_sram_cfg.max_outstanding_req = 4;
     m_tl_agent_sram_cfg.if_mode = dv_utils_pkg::Device;
 
     // The mailbox must be able to handle combinational devices too, i.e. those

--- a/hw/ip/mbx/dv/env/mbx_env_cov.sv
+++ b/hw/ip/mbx/dv/env/mbx_env_cov.sv
@@ -2,24 +2,177 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-/**
- * Covergroups that are dependent on run-time parameters that may be available
- * only in build_phase can be defined here
- * Covergroups may also be wrapped inside helper classes if needed.
- */
+`ifdef MBX_ENV_COV_32B_ADDR_BINS
+  `dv_fatal("Did not expected MBX_ENV_COV_32B_ADDR_BINS to be defined already.");
+`else
+  `define MBX_ENV_COV_32B_ADDR_BINS \
+    bins less_than_1MiB = {[0:'hf_ffff]}; \
+    bins between_1MiB_and_2_GiB = {['h10_0000:'h7fff_ffff]}; \
+    bins between_2_and_4_GiB = {['h8000_0000:'hffff_ffff]};
+`endif
+
+// Check that we have seen all significant Inbound and Outbound mailbox addresses within
+// the RoT address space so that there are no restrictions upon the physical memory map,
+// e.g. MSB clear as well as MSB set.
+covergroup mbx_mem_range_cg with function sample(bit [top_pkg::TL_AW-1:0] imbx_base,
+                                                 bit [top_pkg::TL_AW-1:0] ombx_base);
+  option.per_instance = 1;
+  option.name = "mem_range_cg";
+
+  cp_imbx_base: coverpoint imbx_base {
+    `MBX_ENV_COV_32B_ADDR_BINS
+  }
+
+  cp_ombx_base: coverpoint ombx_base {
+    `MBX_ENV_COV_32B_ADDR_BINS
+  }
+
+  cr_imbx_base_X_ombx_base: cross
+    cp_imbx_base,
+    cp_ombx_base;
+
+endgroup
+
+// Check that all RoT-side CONTROL bits have been stimulated/unstimulated.
+covergroup mbx_rot_control_cg with function sample(bit abort,
+                                                   bit error,
+                                                   bit sys_async_msg);
+  option.per_instance = 1;
+  option.name = "rot_control_cg";
+
+  cp_abort: coverpoint abort;
+  cp_error: coverpoint error;
+  cp_sys_async_msg: coverpoint sys_async_msg;
+
+endgroup
+
+// Check that all RoT-side STATUS indicators have been observed both asserted and deasserted.
+covergroup mbx_rot_status_cg with function sample(bit busy,
+                                                  bit sys_intr_state,
+                                                  bit sys_intr_enable,
+                                                  bit sys_async_enable);
+  option.per_instance = 1;
+  option.name = "rot_status_cg";
+
+  cp_busy: coverpoint busy;
+  cp_sys_intr_state: coverpoint sys_intr_state;
+  cp_sys_intr_enable: coverpoint sys_intr_enable;
+  cp_sys_async_enable: coverpoint sys_async_enable;
+
+endgroup
+
+// Check that all SoC-side CONTROL bits have been stimulated.
+covergroup mbx_soc_control_cg with function sample(bit abort,
+                                                   bit doe_intr_en,
+                                                   bit doe_async_msg_en,
+                                                   bit go);
+  option.per_instance = 1;
+  option.name = "soc_control_cg";
+
+  cp_abort: coverpoint abort;
+  cp_doe_intr_en: coverpoint doe_intr_en;
+  cp_doe_async_msg_en: coverpoint doe_async_msg_en;
+  cp_go: coverpoint go;
+
+endgroup
+
+// Ensure that we have observed all SoC-side STATUS indicators both asserted and deasserted.
+covergroup mbx_soc_status_cg with function sample(bit busy,
+                                                  bit doe_intr_status,
+                                                  bit error,
+                                                  bit doe_async_msg_status,
+                                                  bit ready);
+  option.per_instance = 1;
+  option.name = "soc_status_cg";
+
+  cp_busy: coverpoint busy;
+  cp_doe_intr_status: coverpoint doe_intr_status;
+  cp_error: coverpoint error;
+  cp_doe_async_msg_status: coverpoint doe_async_msg_status;
+  cp_ready: coverpoint ready;
+
+endgroup
+
+// Check that we have observed corner-case response lengths.
+covergroup mbx_object_size_cg with function sample(bit [10:0] object_size);
+  option.per_instance = 1;
+  option.name = "object_size_cg";
+
+  cp_object_size: coverpoint object_size {
+    bins one_word = {1};
+    bins below_256 = {[2:255]};
+    bins above_256 = {[256:1023]};
+    bins max_size = {1024};
+  }
+
+endgroup
+
+// Collect coverage of the interrupt pin(s) on the SoC side.
+// RoT-side interrupt pins are sampled in the CIP layer.
+covergroup mbx_soc_intr_pins_cg (uint num_interrupts) with function sample(uint intr_pin,
+                                                                           bit  intr_pin_value);
+  cp_intr_pin: coverpoint intr_pin {
+    bins all_pins[] = {[0:num_interrupts-1]};
+  }
+  cp_intr_pin_value: coverpoint intr_pin_value {
+    bins values[] = {0, 1};
+    bins transitions[] = (0 => 1), (1 => 0);
+  }
+  cp_intr_pins_all_values: cross cp_intr_pin, cp_intr_pin_value;
+endgroup
+
+// Check that different DOE interrupt message address/data values have been observed,
+// on both register interfaces (RoT- and SoC-side).
+//
+// The DOE_INTR_MSG_ADDR and DOE_INTR_MSG_DATA registers are simply 32-bit channels
+// presented from the SoC interface to the RoT interface; just ensure that each
+// bit has independently been seen in both possible states.
+covergroup mbx_doe_intr_msg_addr_cg(uint addr_width) with function sample(uint addr_bit,
+                                                                          uint addr_bit_value);
+  cp_addr_bit: coverpoint addr_bit {
+    bins all_bits[] = {[0:addr_width-1]};
+  }
+  cp_addr_bit_value: coverpoint addr_bit_value {
+    bins values[] = {0, 1};
+    bins transitions[] = (0 => 1), (1 => 0);
+  }
+  cr_addr_bit_X_addr_bit_value: cross cp_addr_bit, cp_addr_bit_value;
+endgroup
+
+covergroup mbx_doe_intr_msg_data_cg(uint data_width) with function sample(uint data_bit,
+                                                                          uint data_bit_value);
+  cp_data_bit: coverpoint data_bit {
+    bins all_bits[] = {[0:data_width-1]};
+  }
+  cp_data_bit_value: coverpoint data_bit_value {
+    bins values[] = {0, 1};
+    bins transitions[] = (0 => 1), (1 => 0);
+  }
+  cr_data_bit_X_data_bit_value: cross cp_data_bit, cp_data_bit_value;
+endgroup
 
 class mbx_env_cov extends cip_base_env_cov #(.CFG_T(mbx_env_cfg));
   `uvm_component_utils(mbx_env_cov)
 
-  // the base class provides the following handles for use:
-  // mbx_env_cfg: cfg
-
-  // covergroups
-  // [add covergroups here]
+  mbx_mem_range_cg mem_range_cg;
+  mbx_rot_control_cg rot_control_cg;
+  mbx_rot_status_cg rot_status_cg;
+  mbx_soc_control_cg soc_control_cg;
+  mbx_soc_status_cg soc_status_cg;
+  mbx_object_size_cg object_size_cg;
+  mbx_doe_intr_msg_addr_cg doe_intr_msg_addr_cg;
+  mbx_doe_intr_msg_data_cg doe_intr_msg_data_cg;
 
   function new(string name, uvm_component parent);
     super.new(name, parent);
-    // [instantiate covergroups here]
+    mem_range_cg = new();
+    rot_control_cg = new();
+    rot_status_cg = new();
+    soc_control_cg = new();
+    soc_status_cg = new();
+    object_size_cg = new();
+    doe_intr_msg_addr_cg = new(top_pkg::TL_AW);
+    doe_intr_msg_data_cg = new(top_pkg::TL_DW);
   endfunction : new
 
   virtual function void build_phase(uvm_phase phase);

--- a/hw/ip/mbx/dv/env/mbx_scoreboard.sv
+++ b/hw/ip/mbx/dv/env/mbx_scoreboard.sv
@@ -61,14 +61,14 @@ class mbx_scoreboard extends cip_base_scoreboard #(
      forever begin
        bit exp_irq;
 
-       wait(exp_mbx_core_irq_q.size() != 0);
+       wait (exp_mbx_core_irq_q.size() != 0);
        exp_irq = exp_mbx_core_irq_q.pop_front();
-       if(exp_irq == 1) begin
+       if (exp_irq == 1) begin
          cfg.clk_rst_vif.wait_n_clks(2);
          `DV_CHECK_EQ(exp_irq, cfg.intr_vif.pins[MbxCoreReady],
                       "Expecting interrupt pin to go high")
        end
-       if(exp_irq == 0) begin
+       if (exp_irq == 0) begin
          // TODO: Earlier it was set to '1', updating it to larger value for the RTL change
          // to go, reduce it once the RTL is fixed.
          cfg.clk_rst_vif.wait_n_clks(5);
@@ -90,357 +90,269 @@ class mbx_scoreboard extends cip_base_scoreboard #(
     //join_none
   endtask
 
+  // Model TL-UL register accesses. There are two TL-UL register interfaces:
+  // - Root of Trust side (a.k.a. `core`)
+  // - System On Chip side
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
-    uvm_reg csr;
-    bit     do_read_check   = 1'b1;
-    bit     write           = item.is_write();
-    uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
-    bit [31:0] mask = 'hffff_ffff;
-
-    bit addr_phase_read   = (!write && channel == AddrChannel);
-    bit addr_phase_write  = (write && channel == AddrChannel);
-    bit data_phase_read   = (!write && channel == DataChannel);
-    bit data_phase_write  = (write && channel == DataChannel);
-
-    // if access was to a valid csr, get the csr handle
-    if (ral_name != cfg.mbx_mem_ral_name) begin
-      if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-        csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-        `DV_CHECK_NE_FATAL(csr, null)
-      end
-      else begin
-        // TODO: this does not yet cope with the fact that WDATA and RDATA accesses do not produce
-        // a hit in the above test, since they are not CSRs
-        // `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
-        return;
-      end
-
-      // if incoming access is a write to a valid csr, then make updates right away
-      if(addr_phase_write) begin
-        void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
-      end
-    end
-
-    if((ral_name == RAL_T::type_name)
-        && (csr.get_name() == "status")
-        && addr_phase_write) begin
-      mbxsts_core_wr_in_progress = 1'b1;
-    end
-    if((ral_name == RAL_T::type_name)
-        && (csr.get_name() == "status")
-        && data_phase_write) begin
-      mbxsts_core_wr_in_progress = 1'b0;
-    end
-
-    if((ral_name == RAL_T::type_name)
-        && (csr.get_name() == "status")
-        && addr_phase_read) begin
-      mbxsts_core_rd_in_progress = 1'b1;
-    end
-    if((ral_name == RAL_T::type_name)
-        && (csr.get_name() == "status")
-        && data_phase_read) begin
-      mbxsts_core_rd_in_progress = 1'b0;
-    end
-
-    if((ral_name == cfg.mbx_soc_ral_name)
-        && (csr.get_name() == "soc_status")
-        && addr_phase_read) begin
-      mbxsts_system_rd_in_progress = 1'b1;
-    end
-    if((ral_name == cfg.mbx_soc_ral_name)
-        && (csr.get_name() == "soc_status")
-        && data_phase_read) begin
-      mbxsts_system_rd_in_progress = 1'b0;
-    end
-
-    if((ral_name == cfg.mbx_soc_ral_name)
-        && (csr.get_name() == "control")
-        && addr_phase_write) begin
-      mbxsts_system_wr_in_progress = 1'b1;
-    end
-    if((ral_name == cfg.mbx_soc_ral_name)
-        && (csr.get_name() == "control")
-        && data_phase_write) begin
-      mbxsts_system_wr_in_progress = 1'b0;
-    end
-
-
-    if((mbxsts_core_wr_in_progress
-           && ((ral_name == cfg.mbx_soc_ral_name)
-           && (csr.get_name() == "soc_status")
-           && data_phase_read))
-        || ((ral_name == RAL_T::type_name)
-           && (csr.get_name() == "status")
-           && data_phase_read)
-           && (mbxsts_system_wr_in_progress)) begin
-      skip_read_check = 1'b1;
-    end
-
-    if(((ral_name == cfg.mbx_soc_ral_name)
-         ||(ral_name == RAL_T::type_name))
-         && ((csr.get_name() == "soc_status")
-         || (csr.get_name() == "status"))) begin
-      do_read_check = ~skip_read_check;
-      if(do_read_check == 1'b0) begin
-        `uvm_info(`gfn,
-         "Skipping read for status from system/core as core/system is updating it",
-         UVM_LOW)
-      end
-    end
-
-// TODO: The scoreboard needs updating and completing.
-return;
-
-    // process the csr req
-    // for write, update local variable and fifo at address phase
-    // for read, update prediction at address phase and compare at data phase
     case (ral_name)
-      RAL_T::type_name : begin
-        process_tl_mbx_core_access(item, channel);
-      end
-      cfg.mbx_soc_ral_name : begin
-        process_tl_mbx_soc_access(item, channel);
-      end
-      cfg.mbx_mem_ral_name : begin
-        process_tl_mbx_mem_access(item, channel);
-        return;
-      end
-      default: begin
-        `uvm_fatal(`gfn, $sformatf("invalid ral: %0s", ral_name))
-      end
+      RAL_T::type_name:     process_tl_mbx_core_access(item, channel);
+      cfg.mbx_soc_ral_name: process_tl_mbx_soc_access(item, channel);
+      default: `uvm_fatal(`gfn, $sformatf("Invalid RAL: %0s", ral_name))
     endcase
-
-    // On reads, if do_read_check, is set, then check mirrored_value against item.d_data
-    if (data_phase_read) begin
-      if(csr.get_name() == "status") begin
-        // TODO: Remove this, once mbx doe ready bit issue is resolved
-        mask = 'h7fff_ffff;
-      end
-      if (do_read_check) begin
-    void'(csr.predict(.value(item.d_data), .kind(UVM_PREDICT_READ)));
-      end
-
-    end
-    if(((ral_name == cfg.mbx_soc_ral_name)
-         || (ral_name == RAL_T::type_name))
-         && (csr.get_name() == "status")
-         && data_phase_read) begin
-      skip_read_check = 1'b0;
-    end
   endtask
 
+  // Model register accesses on the RoT ('core') TL-UL bus.
   virtual function void process_tl_mbx_core_access(tl_seq_item item, tl_channels_e channel);
     uvm_reg csr;
-    bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[RAL_T::type_name].get_word_aligned_addr(
                               item.a_addr);
-
-    bit addr_phase_read   = (!write && channel == AddrChannel);
     bit addr_phase_write  = (write && channel == AddrChannel);
     bit data_phase_read   = (!write && channel == DataChannel);
-    bit data_phase_write  = (write && channel == DataChannel);
 
     `uvm_info(`gfn, "process_tl_mbx_core_access -- Start", UVM_DEBUG)
     csr = cfg.ral_models[RAL_T::type_name].default_map.get_reg_by_offset(csr_addr);
 
-    case(csr.get_name())
-      default:; // Do nothing
-      "inbound_write_ptr" : begin
-        if(addr_phase_write) begin
-          m_ibmbx_ptr = item.a_data;
+    if (csr && addr_phase_write) begin
+      // If incoming access is a write to a valid CSR, then make updates right away.
+      void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
+
+      case (csr.get_name())
+        default:; // Do nothing
+        "inbound_write_ptr": m_ibmbx_ptr = item.a_data;
+        "outbound_read_ptr": begin
+          m_obmbx_ptr_q[0] = item.a_data;
+          m_obmbx_ptr = item.a_data;
         end
-        if(addr_phase_read) begin
+        "inbound_base_address": begin
+          // Do nothing
+        end
+        "inbound_limit_address": begin
+          // Do nothing
+        end
+        "outbound_base_address": begin
+          // Do nothing
+        end
+        "outbound_limit_address": begin
+          // Do nothing
+        end
+        "outbound_object_size": begin
+          m_obdwcnt = item.a_data;
+          `uvm_info(`gfn, $sformatf("Updating m_obdwcnt to %0d", m_obdwcnt), UVM_LOW)
+        end
+        "control": begin
+          /* TODO: This looks suspect; confusion over w1c?
+          if (ral.control.abort.get_mirrored_value() == 0) begin
+            exp_mbx_core_irq = 0;
+            exp_mbx_core_irq_q.push_back(0);
+          end
+          if (ral.control.error.get_mirrored_value() == 1) begin
+            // TODO: Check if busy bit is expected to be cleared - RVSCS-491
+            void'(ral.status.busy.predict(.value(0), .kind(UVM_PREDICT_READ)));
+          end
+          */
+        end
+        "status": begin
+          /* TODO: Add the support for async message sts
+          if (ral.status.busy.get_mirrored_value() == 0) begin
+            exp_mbx_core_irq = 0;
+            exp_mbx_core_irq_q.push_back(0);
+          end
+          */
+        end
+      endcase
+    end else if (csr && data_phase_read) begin
+      bit [31:0] mask = 'hffff_ffff;
+      bit do_read_check = 1'b1;
+
+      case (csr.get_name())
+        default:; // Do nothing
+        "inbound_write_ptr": begin
           void'(ral.inbound_write_ptr.predict(
             .value(ral.inbound_base_address.get() + m_ibmbx_ptr),
             .kind(UVM_PREDICT_READ)));
         end
-      end
-      "outbound_read_ptr" : begin
-        if(addr_phase_write) begin
-          m_obmbx_ptr_q[0] = item.a_data;
-          m_obmbx_ptr = item.a_data;
-        end
-        if(addr_phase_read) begin
+        "outbound_read_ptr": begin
           void'(ral.outbound_read_ptr.predict(
             .value(ral.outbound_base_address.get() + (m_obmbx_ptr_q[0])),
             .kind(UVM_PREDICT_READ)));
         end
-      end
-      "inbound_base_address" : begin
-        // Do nothing
-      end
-      "inbound_limit_address" : begin
-        // Do nothing
-      end
-      "outbound_base_address" : begin
-        // Do nothing
-      end
-      "outbound_limit_address" : begin
-        // Do nothing
-      end
-      "outbound_object_size" : begin
-        if(addr_phase_write) begin
-          m_obdwcnt = item.a_data;
-          `uvm_info(`gfn, $sformatf("Updating m_obdwcnt to %0d", m_obdwcnt), UVM_LOW)
+        "inbound_base_address": begin
+          // Do nothing
         end
-        if(addr_phase_read) begin
+        "inbound_limit_address": begin
+          // Do nothing
+        end
+        "outbound_base_address": begin
+          // Do nothing
+        end
+        "outbound_limit_address": begin
+          // Do nothing
+        end
+        "outbound_object_size": begin
           void'(ral.outbound_object_size.predict(.value(m_obdwcnt), .kind(UVM_PREDICT_READ)));
         end
-      end
-      "control" : begin
-        if(addr_phase_write) begin
-          if(ral.control.abort.get_mirrored_value() == 0) begin
-            exp_mbx_core_irq = 0;
-            exp_mbx_core_irq_q.push_back(0);
-          end
-          if(ral.control.error.get_mirrored_value() == 1) begin
-            // TODO: Check if busy bit is expected to be cleared - RVSCS-491
-            void'(ral.status.busy.predict(.value(0), .kind(UVM_PREDICT_READ)));
-          end
+        "control": begin
+          // Do nothing
         end
-      end
-      "status" : begin
-        if(addr_phase_read) begin
+        "status": begin
           //TODO: Review ready field
-          //void'(ral.status.ready.predict(.value(m_obdwcnt != 0), .kind(UVM_PREDICT_READ)));
+          mask = 'h7fff_ffff;
         end
-        // TODO: Add the support for async message sts
-        if(addr_phase_write) begin
-          if(ral.status.busy.get_mirrored_value() == 0) begin
-            exp_mbx_core_irq = 0;
-            exp_mbx_core_irq_q.push_back(0);
-          end
-        end
-      end
-      // TODO: Add interrupt registers
-    endcase
-    `uvm_info(`gfn, "process_tl_mbx_core_access -- End", UVM_DEBUG)
-  endfunction: process_tl_mbx_core_access
+      endcase
 
+      if (do_read_check) begin
+        // Check mirrored_value against item.d_data
+        void'(csr.predict(.value(item.d_data), .kind(UVM_PREDICT_READ)));
+      end
+    end
+
+    `uvm_info(`gfn, "process_tl_mbx_core_access -- End", UVM_DEBUG)
+  endfunction : process_tl_mbx_core_access
+
+  // Model register accesses on the SoC TL-UL bus.
   virtual function void process_tl_mbx_soc_access(tl_seq_item item, tl_channels_e channel);
     uvm_reg csr;
-    bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();
     uvm_reg_addr_t csr_addr =
       cfg.ral_models[cfg.mbx_soc_ral_name].get_word_aligned_addr(item.a_addr);
-
-    bit addr_phase_read   = (!write && channel == AddrChannel);
     bit addr_phase_write  = (write && channel == AddrChannel);
     bit data_phase_read   = (!write && channel == DataChannel);
-    bit data_phase_write  = (write && channel == DataChannel);
 
     `uvm_info(`gfn, "process_tl_mbx_soc_access -- Start", UVM_DEBUG)
     csr = cfg.ral_models[cfg.mbx_soc_ral_name].default_map.get_reg_by_offset(csr_addr);
-    case(csr.get_name())
-      default:; // Do nothing
-      "soc_control" : begin
-        mbx_soc_reg_soc_control ctl_reg_h;
 
-        `DV_CHECK_FATAL($cast(ctl_reg_h, csr), "Unable to cast csr handle to MBX control type")
-        if(data_phase_write) begin
-          if(ctl_reg_h.abort.get() == 1) begin
-            exp_mbx_core_irq = 1;
-            exp_mbx_core_irq_q.push_back(1);
-            // TODO: Check if busy bit also needs to be set
-            void'(ral.control.abort.predict(.value(1), .kind(UVM_PREDICT_WRITE)));
-            void'(ral.status.busy.predict(.value(1), .kind(UVM_PREDICT_WRITE)));
-            if((ral.status.busy.get() == 1) || (ral.control.error.get() == 1) ||
-              (m_obdwcnt != 0)) begin
-              void'(ral.status.busy.predict(.value(1), .kind(UVM_PREDICT_WRITE)));
-            end
-          end else if((item.a_data[31] & item.a_mask[3]) == 1) begin
-            // if (ctl_reg_h.abort.get() == 1)
-            if((ral.status.busy.get() == 0) && (ral.control.error.get() == 0) &&
-              (ral.control.abort.get() == 0)) begin
-              void'(ral.status.busy.predict(.value(1), .kind(UVM_PREDICT_WRITE)));
-              void'(m_mbx_soc_ral.soc_status.busy.predict(.value(1), .kind(UVM_PREDICT_READ)));
+    // Note: WDATA and RDATA memory windows exist on the SoC TL-UL interface, and these are not
+    //       regular CSRs, so `csr` will be null.
 
+    if (addr_phase_write) begin
+      if (csr) begin
+        // If incoming access is a write to a valid CSR, then make updates right away.
+        void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
+
+        case (csr.get_name())
+          default:; // Do nothing
+          "soc_control": begin
+            mbx_soc_reg_soc_control ctl_reg_h;
+
+            `DV_CHECK_FATAL($cast(ctl_reg_h, csr), "Unable to cast csr handle to MBX control type")
+
+            /* TODO: Fix this.
+            if(ctl_reg_h.abort.get() == 1) begin
               exp_mbx_core_irq = 1;
               exp_mbx_core_irq_q.push_back(1);
+              // TODO: Check if busy bit also needs to be set
+              void'(ral.control.abort.predict(.value(1), .kind(UVM_PREDICT_WRITE)));
+              void'(ral.status.busy.predict(.value(1), .kind(UVM_PREDICT_WRITE)));
+              if((ral.status.busy.get() == 1) || (ral.control.error.get() == 1) ||
+                (m_obdwcnt != 0)) begin
+                void'(ral.status.busy.predict(.value(1), .kind(UVM_PREDICT_WRITE)));
+              end
+            end else if((item.a_data[31] & item.a_mask[3]) == 1) begin
+              // if (ctl_reg_h.abort.get() == 1)
+              if((ral.status.busy.get() == 0) && (ral.control.error.get() == 0) &&
+                (ral.control.abort.get() == 0)) begin
+                void'(ral.status.busy.predict(.value(1), .kind(UVM_PREDICT_WRITE)));
+                void'(m_mbx_soc_ral.soc_status.busy.predict(.value(1), .kind(UVM_PREDICT_READ)));
+
+                exp_mbx_core_irq = 1;
+                exp_mbx_core_irq_q.push_back(1);
+              end
+            end
+            */
+            void'(ral.status.sys_intr_enable.predict(
+                     .value(ctl_reg_h.doe_intr_en.get()),
+                     .kind(UVM_PREDICT_WRITE)));
+            // TODO: Add async logic
+          end
+          "soc_status": begin
+            mbx_soc_reg_soc_status soc_sts_reg_h;
+            mbx_core_reg_status hst_sts_reg_h;
+            mbx_core_reg_control hst_ctl_reg_h;
+
+            `DV_CHECK_FATAL($cast(soc_sts_reg_h, csr),
+              "Unable to cast csr handle to soc_status type")
+            hst_sts_reg_h = ral.status;
+            hst_ctl_reg_h = ral.control;
+            if((item.a_data[1] & item.a_mask[0]) == 1) begin
+              void'(hst_sts_reg_h.sys_intr_state.predict(.value(0)));
             end
           end
-          void'(ral.status.sys_intr_enable.predict(
-                   .value(ctl_reg_h.doe_intr_en.get()),
-                   .kind(UVM_PREDICT_WRITE)));
-          // TODO: Add async logic
-        end
-        if(addr_phase_read) begin
-          void'(ctl_reg_h.abort.predict(
-                          .value(0),
-                          .kind(UVM_PREDICT_READ)));
-          void'(ctl_reg_h.doe_intr_en.predict(
-                          .value(ral.status.sys_intr_enable.get()),
-                          .kind(UVM_PREDICT_READ)));
-          void'(ctl_reg_h.go.predict(
-                          .value(0),
-                          .kind(UVM_PREDICT_READ)));
-          // TODO Add async logic
-        end
+        endcase
+      end else begin
+        // TODO: else model WDATA / RDATA.
+        // WDATA: m_ib_q.push_back(item.a_data);
+        // RDATA:
+        //  int tmp_ptr=0;
+        //  if(m_obmbx_ptr_q.size() == 0)
+        //    tmp_ptr = m_obmbx_ptr+4;
+        //  else
+        //    tmp_ptr = m_obmbx_ptr_q[$]+4;
+        //    m_obmbx_ptr_q.push_back(tmp_ptr);
+        //    m_obmbx_ptr = tmp_ptr;
+        //    m_obdwcnt--;
+        //    void'(m_ob_q.pop_front());
       end
-      "soc_status" : begin
-        mbx_soc_reg_soc_status soc_sts_reg_h;
-        mbx_core_reg_status hst_sts_reg_h;
-        mbx_core_reg_control hst_ctl_reg_h;
+    end else if (data_phase_read) begin
+      bit do_read_check = 1'b1;
 
-        `DV_CHECK_FATAL($cast(soc_sts_reg_h, csr),
-          "Unable to cast csr handle to soc_status type")
-        hst_sts_reg_h = ral.status;
-        hst_ctl_reg_h = ral.control;
-        if(addr_phase_read) begin
-          void'(soc_sts_reg_h.busy.predict(
-                             .value(hst_sts_reg_h.busy.get()),
-                             .kind(UVM_PREDICT_READ)));
-          void'(soc_sts_reg_h.doe_intr_status.predict(
-                             .value(hst_sts_reg_h.sys_intr_state.get()),
-                             .kind(UVM_PREDICT_READ)));
-          void'(soc_sts_reg_h.error.predict(
-                             .value(hst_ctl_reg_h.error.get()),
-                             .kind(UVM_PREDICT_READ)));
-          //TODO: Review new ready field
-          void'(soc_sts_reg_h.ready.predict(
-                             .value(m_obdwcnt != 0),
-                             .kind(UVM_PREDICT_READ)));
-        end
-        if(addr_phase_write) begin
-          if((item.a_data[1] & item.a_mask[0]) == 1) begin
-            void'(hst_sts_reg_h.sys_intr_state.predict(.value(0)));
+      if (csr) begin
+        case (csr.get_name())
+          default:; // Do nothing
+          "soc_control": begin
+            mbx_soc_reg_soc_control ctl_reg_h;
+            void'(ctl_reg_h.abort.predict(
+                            .value(0),
+                            .kind(UVM_PREDICT_READ)));
+            void'(ctl_reg_h.doe_intr_en.predict(
+                            .value(ral.status.sys_intr_enable.get()),
+                            .kind(UVM_PREDICT_READ)));
+            void'(ctl_reg_h.go.predict(
+                            .value(0),
+                            .kind(UVM_PREDICT_READ)));
+            // TODO Add async logic
           end
-        end
-      end
-      "wdata" : begin
-        if(addr_phase_write) begin
-          m_ib_q.push_back(item.a_data);
-        end
-        if(addr_phase_read) begin
-          void'(csr.predict(.value(0), .kind(UVM_PREDICT_READ)));
-        end
-      end
-      "rdata" : begin
-        if(addr_phase_read) begin
-          if(m_obdwcnt == 0) begin
-             void'(csr.predict(.value(0), .kind(UVM_PREDICT_READ)));
-          end else begin
-             void'(csr.predict(.value(m_ob_q[0]), .kind(UVM_PREDICT_READ)));
+          "soc_status": begin
+            mbx_soc_reg_soc_status soc_sts_reg_h;
+            mbx_core_reg_status hst_sts_reg_h;
+            mbx_core_reg_control hst_ctl_reg_h;
+
+            `DV_CHECK_FATAL($cast(soc_sts_reg_h, csr),
+              "Unable to cast csr handle to soc_status type")
+            hst_sts_reg_h = ral.status;
+            hst_ctl_reg_h = ral.control;
+
+            void'(soc_sts_reg_h.busy.predict(
+                               .value(hst_sts_reg_h.busy.get()),
+                               .kind(UVM_PREDICT_READ)));
+            void'(soc_sts_reg_h.doe_intr_status.predict(
+                               .value(hst_sts_reg_h.sys_intr_state.get()),
+                               .kind(UVM_PREDICT_READ)));
+            void'(soc_sts_reg_h.error.predict(
+                               .value(hst_ctl_reg_h.error.get()),
+                               .kind(UVM_PREDICT_READ)));
+            //TODO: Review new ready field
+            void'(soc_sts_reg_h.ready.predict(
+                               .value(m_obdwcnt != 0),
+                               .kind(UVM_PREDICT_READ)));
           end
-        end
-        if(addr_phase_write) begin
-          int tmp_ptr=0;
-          if(m_obmbx_ptr_q.size() == 0)
-            tmp_ptr = m_obmbx_ptr+4;
-          else
-            tmp_ptr = m_obmbx_ptr_q[$]+4;
-            m_obmbx_ptr_q.push_back(tmp_ptr);
-            m_obmbx_ptr = tmp_ptr;
-            m_obdwcnt--;
-            void'(m_ob_q.pop_front());
-        end
+        endcase
+      end else begin
+        // TODO: else model WDATA / RDATA.
+        // WDATA: void'(csr.predict(.value(0), .kind(UVM_PREDICT_READ)));
+        // RDATA:
+        //  if(m_obdwcnt == 0) begin
+        //      void'(csr.predict(.value(0), .kind(UVM_PREDICT_READ)));
+        //  end else begin
+        //       void'(csr.predict(.value(m_ob_q[0]), .kind(UVM_PREDICT_READ)));
+        //  end
       end
-    endcase
+    end
     `uvm_info(`gfn, "process_tl_mbx_soc_access -- End", UVM_DEBUG)
-  endfunction: process_tl_mbx_soc_access
+  endfunction : process_tl_mbx_soc_access
 
+  // TODO: This is presently unused, but we shall want to check all of the TL-UL traffic to/from
+  // the mailbox SRAM as it happens.
   virtual function void process_tl_mbx_mem_access(tl_seq_item item, tl_channels_e channel);
     bit write             = item.is_write();
     bit addr_phase_read   = (!write && channel == AddrChannel);
@@ -449,7 +361,7 @@ return;
     bit data_phase_write  = (write && channel == DataChannel);
 
     `uvm_info(`gfn, "process_tl_mbx_mem_access -- Start", UVM_DEBUG)
-    if(addr_phase_read || addr_phase_write) begin
+    if (addr_phase_read || addr_phase_write) begin
       // Check for integrity error on Address
       void'(item.is_a_chan_intg_ok(.throw_error(1)));
 
@@ -484,7 +396,7 @@ return;
         void'(m_ib_q.pop_front());
       end
     end
-    if(data_phase_read) begin
+    if (data_phase_read) begin
       bit is_addr_match;
 
       // Check if address is within OB Mailbox SRAM range
@@ -508,7 +420,7 @@ return;
 
     end
     `uvm_info(`gfn, "process_tl_mbx_mem_access -- End", UVM_DEBUG)
-  endfunction: process_tl_mbx_mem_access
+  endfunction : process_tl_mbx_mem_access
 
   virtual function void reset(string kind = "HARD");
     super.reset(kind);

--- a/hw/ip/mbx/dv/env/mbx_scoreboard.sv
+++ b/hw/ip/mbx/dv/env/mbx_scoreboard.sv
@@ -250,8 +250,9 @@ class mbx_scoreboard extends cip_base_scoreboard #(
           // Our expectation of the `busy` indicator.
           void'(ral.status.busy.predict(.value(m_mbx_busy), .kind(UVM_PREDICT_READ)));
           // These fields are aliases of the SoC-side status indicators.
-          void'(ral.status.sys_intr_state.predict(
-                  .value(`gmv(m_mbx_soc_ral.soc_status.doe_intr_status)), .kind(UVM_PREDICT_READ)));
+          // TODO: We still need to model interrupts properly.
+          //void'(ral.status.sys_intr_state.predict(
+          //        .value(`gmv(m_mbx_soc_ral.soc_status.doe_intr_status)), .kind(UVM_PREDICT_READ)));
           void'(ral.status.sys_intr_enable.predict(
                   .value(`gmv(m_mbx_soc_ral.soc_control.doe_intr_en)), .kind(UVM_PREDICT_READ)));
           void'(ral.status.sys_async_enable.predict(
@@ -265,6 +266,8 @@ class mbx_scoreboard extends cip_base_scoreboard #(
               .sys_intr_enable(get_field_val(ral.status.sys_intr_enable, item.d_data)),
               .sys_async_enable(get_field_val(ral.status.busy, item.d_data)));
           end
+          // TODO: the scoreboard cannot really check this yet; requires interrupt prediction.
+          do_read_check = 1'b0;
         end
 
         "intr_state": begin

--- a/hw/ip/mbx/dv/env/mbx_scoreboard.sv
+++ b/hw/ip/mbx/dv/env/mbx_scoreboard.sv
@@ -9,34 +9,42 @@ class mbx_scoreboard extends cip_base_scoreboard #(
   );
   `uvm_component_utils(mbx_scoreboard)
 
-  // local variables
+  // Expected Inbound write and Outbound read addresses.
   bit [top_pkg::TL_AW-1:0] m_ibmbx_ptr;
-  bit [top_pkg::TL_AW-1:0] m_obmbx_ptr_q[$];
   bit [top_pkg::TL_AW-1:0] m_obmbx_ptr;
-  bit [9:0] m_obdwcnt;
+  // Expected destination address for WDATA write.
+  bit [top_pkg::TL_AW-1:0] m_ib_wdata_ptr;
+  // Count of Outbound response words.
+  bit [10:0] m_obdwcnt;
 
   bit exp_mbx_core_irq;
   bit exp_mbx_core_irq_q[$];
 
-  // TLM agent fifos
+  // Expected status; these indications are visible on both register interfaces.
+  bit m_mbx_busy = 1'b0;
+  bit m_mbx_ready = 1'b0;
+  bit m_mbx_error = 1'b0;
+  bit m_mbx_abort = 1'b0;
+  bit m_mbx_async_msg = 1'b0;
 
   // local queues to hold incoming packets pending comparison
-  bit [top_pkg::TL_DW-1:0] m_ib_q[$]; // Inbound data (request to RoT).
-  bit [top_pkg::TL_DW-1:0] m_ob_q[$]; // Outbound data (response from RoT).
+  bit m_ibmbx_start = 1'b1;
+  bit [top_pkg::TL_DW-1:0] m_ib_data_q[$]; // Inbound data (request to RoT).
+  bit [top_pkg::TL_DW-1:0] m_ob_data_q[$]; // Outbound data (response from RoT).
 
   // System RAL model; keep a local handle for cleaner/easier access.
   mbx_soc_reg_block m_mbx_soc_ral;
 
   `uvm_component_new
 
-  // TODO: Presently no additional work to be done.
-  // function void build_phase(uvm_phase phase);
-  //   super.build_phase(phase);
-  // endfunction
-  //
-  // function void connect_phase(uvm_phase phase);
-  //   super.connect_phase(phase);
-  // endfunction
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+
+    // Create analysis FIFOs to receive items from the SRAM tl_agent monitor.
+    tl_a_chan_fifos["tl_sram_a_chan"] = new("tl_sram_a_chan", this);
+    tl_d_chan_fifos["tl_sram_d_chan"] = new("tl_sram_d_chan", this);
+    tl_dir_fifos["tl_sram_dir"] = new("tl_sram_dir", this);
+  endfunction
 
   virtual task monitor_core_interrupt();
     `uvm_info(`gfn, "monitor_core_interrupt -- Start", UVM_DEBUG)
@@ -78,12 +86,53 @@ class mbx_scoreboard extends cip_base_scoreboard #(
   task run_phase(uvm_phase phase);
     super.run_phase(phase);
     `downcast(m_mbx_soc_ral, cfg.ral_models[cfg.mbx_soc_ral_name])
+    // We need a process to monitor the TL-UL traffic on the SRAM port.
+    fork
+      begin
+        uvm_tlm_analysis_fifo#(tl_seq_item) a_chan_fifo = tl_a_chan_fifos["tl_sram_a_chan"];
+        uvm_tlm_analysis_fifo#(tl_seq_item) d_chan_fifo = tl_d_chan_fifos["tl_sram_d_chan"];
+        uvm_tlm_analysis_fifo#(tl_channels_e) dir_fifo  = tl_dir_fifos["tl_sram_dir"];
+
+        forever begin
+          tl_seq_item   item;
+          tl_channels_e dir;
+
+          dir_fifo.get(dir);
+          case (dir)
+            AddrChannel: begin
+              `DV_CHECK_FATAL(a_chan_fifo.try_get(item),
+                              "dir_fifo pointed at A channel, but a_chan_fifo empty")
+            end
+            DataChannel: begin
+              `DV_CHECK_FATAL(d_chan_fifo.try_get(item),
+                              "dir_fifo pointed at D channel, but d_chan_fifo empty")
+            end
+            default: `dv_fatal($sformatf("Invalid direction %p from tl_agent monitor", dir))
+          endcase
+          process_tl_mbx_mem_access(item, dir);
+        end
+      end
+    join_none
     // TODO: Re-enable interrupt checking once scoreboard is fully functional
     //fork
     //  monitor_core_interrupt();
     //  monitor_exp_core_interrupts();
     //join_none
   endtask
+
+  // Mailbox becoming Idle. This can occur for a number of reasons:
+  // - clearing an abort request.
+  // - raising an error condition.
+  // - transfer of response completed.
+  function void mbx_deactivate();
+    m_mbx_busy    = 1'b0;
+    m_mbx_ready   = 1'b0;
+    m_mbx_error   = 1'b0;
+    m_mbx_abort   = 1'b0;
+    m_ibmbx_start = 1'b1;
+    m_ib_data_q.delete();
+    m_ob_data_q.delete();
+  endfunction
 
   // Model TL-UL register accesses. There are two TL-UL register interfaces:
   // - Root of Trust side (a.k.a. `core`)
@@ -109,6 +158,10 @@ class mbx_scoreboard extends cip_base_scoreboard #(
     csr = cfg.ral_models[RAL_T::type_name].default_map.get_reg_by_offset(csr_addr);
 
     if (csr && addr_phase_write) begin
+      `uvm_info(`gfn, $sformatf("Core register '%s' write 0x%x", csr.get_name(), item.a_data),
+                UVM_MEDIUM)
+
+      // `ADDRESS_RANGE_REGWEN` controls writing to the address-related registers on the RoT side.
       if (prim_mubi_pkg::MuBi4True == `gmv(ral.address_range_regwen) ||
           !ral.address_range_regwen.locks_reg_or_fld(csr)) begin
         // If incoming access is a write to a valid CSR, then make updates right away.
@@ -129,36 +182,40 @@ class mbx_scoreboard extends cip_base_scoreboard #(
           end
         end
 
-        "outbound_object_size": begin
-          m_obdwcnt = item.a_data;
-          `uvm_info(`gfn, $sformatf("Updating m_obdwcnt to %0d", m_obdwcnt), UVM_LOW)
-        end
         "control": begin
-          /* TODO: This looks suspect; confusion over w1c?
-          if (ral.control.abort.get_mirrored_value() == 0) begin
-            exp_mbx_core_irq = 0;
-            exp_mbx_core_irq_q.push_back(0);
+          if (get_field_val(ral.control.abort, item.a_data)) begin
+            // Clearing Abort condition; this also serves as a RoT firmware 'panic' akin to a sw
+            // reset of the DUT.
+            mbx_deactivate();
           end
-          if (ral.control.error.get_mirrored_value() == 1) begin
-            // TODO: Check if busy bit is expected to be cleared - RVSCS-491
-            void'(ral.status.busy.predict(.value(0), .kind(UVM_PREDICT_READ)));
+          // Setting of error condition.
+          if (get_field_val(ral.control.error, item.a_data)) begin
+            mbx_deactivate();
+            m_mbx_error = 1'b1;
+            m_ibmbx_start = 1'b1;
           end
-          */
+          // Raise asynchronous message notification.
+          if (get_field_val(ral.control.sys_async_msg, item.a_data)) m_mbx_async_msg = 1'b1;
+          if (cfg.en_cov) begin
+            // Collect coverage on stimulation of CONTROL bits.
+            cov.rot_control_cg.sample(.abort(get_field_val(ral.control.abort, item.a_data)),
+                                      .error(get_field_val(ral.control.error, item.a_data)),
+                                      .sys_async_msg(get_field_val(ral.control.sys_async_msg,
+                                                                   item.a_data)));
+          end
         end
-        "status": begin
-          /* TODO: Add the support for async message sts
-          if (ral.status.busy.get_mirrored_value() == 0) begin
-            exp_mbx_core_irq = 0;
-            exp_mbx_core_irq_q.push_back(0);
-          end
-          */
-          //
+
+        "outbound_object_size": begin
+          m_obdwcnt = get_field_val(ral.outbound_object_size.cnt, item.a_data);
+          `uvm_info(`gfn, $sformatf("Updating m_obdwcnt to %0d", m_obdwcnt), UVM_LOW)
+          if (cfg.en_cov) cov.object_size_cg.sample(m_obdwcnt);
         end
 
         // These registers do not require any further modeling.
         "alert_test",
         "intr_state",
         "intr_enable",
+        "status",
         "address_range_regwen",
         "address_range_valid",
         "inbound_base_address",
@@ -166,38 +223,48 @@ class mbx_scoreboard extends cip_base_scoreboard #(
         "inbound_write_ptr",
         "outbound_read_ptr",
         "outbound_base_address",
-        "outbound_limit_address":; // Do nothing
+        "outbound_limit_address",
+        "doe_intr_msg_addr",
+        "doe_intr_msg_data":; // Do nothing
 
         default: `dv_fatal($sformatf("Core register '%s' write not modeled", csr.get_name()))
       endcase
     end else if (csr && data_phase_read) begin
-      bit [31:0] mask = 'hffff_ffff;
       bit do_read_check = 1'b1;
 
       case (csr.get_name())
         "inbound_write_ptr": begin
           // Update prediction based upon observed traffic to SRAM.
-          void'(ral.inbound_write_ptr.predict(
-            .value(ral.inbound_base_address.get() + m_ibmbx_ptr),
-            .kind(UVM_PREDICT_READ)));
+          void'(ral.inbound_write_ptr.predict(.value(m_ibmbx_ptr), .kind(UVM_PREDICT_READ)));
         end
         "outbound_read_ptr": begin
           // Update prediction based upon observed traffic from SRAM.
-          void'(ral.outbound_read_ptr.predict(
-            .value(ral.outbound_base_address.get() + (m_obmbx_ptr_q[0])),
-            .kind(UVM_PREDICT_READ)));
+          void'(ral.outbound_read_ptr.predict(.value(m_obmbx_ptr), .kind(UVM_PREDICT_READ)));
         end
         "outbound_object_size": begin
           // Update prediction based upon observed traffic from SRAM.
           void'(ral.outbound_object_size.predict(.value(m_obdwcnt), .kind(UVM_PREDICT_READ)));
         end
 
-        "control": begin
-          // TODO: Do nothing presently
-        end
         "status": begin
-          //TODO: Review ready field
-          mask = 'h7fff_ffff;
+          // Our expectation of the `busy` indicator.
+          void'(ral.status.busy.predict(.value(m_mbx_busy), .kind(UVM_PREDICT_READ)));
+          // These fields are aliases of the SoC-side status indicators.
+          void'(ral.status.sys_intr_state.predict(
+                  .value(`gmv(m_mbx_soc_ral.soc_status.doe_intr_status)), .kind(UVM_PREDICT_READ)));
+          void'(ral.status.sys_intr_enable.predict(
+                  .value(`gmv(m_mbx_soc_ral.soc_control.doe_intr_en)), .kind(UVM_PREDICT_READ)));
+          void'(ral.status.sys_async_enable.predict(
+                  .value(`gmv(m_mbx_soc_ral.soc_control.doe_async_msg_en)),
+                  .kind(UVM_PREDICT_READ)));
+          if (cfg.en_cov) begin
+            // Collect coverage for the observed DUT status indicators.
+            cov.rot_status_cg.sample(
+              .busy(get_field_val(ral.status.busy, item.d_data)),
+              .sys_intr_state(get_field_val(ral.status.sys_intr_state, item.d_data)),
+              .sys_intr_enable(get_field_val(ral.status.sys_intr_enable, item.d_data)),
+              .sys_async_enable(get_field_val(ral.status.busy, item.d_data)));
+          end
         end
 
         "intr_state": begin
@@ -218,6 +285,7 @@ class mbx_scoreboard extends cip_base_scoreboard #(
         "alert_test",
         "intr_enable",
         "intr_test",
+        "control",
         "address_range_regwen",
         "address_range_valid",
         "inbound_base_address",
@@ -225,6 +293,27 @@ class mbx_scoreboard extends cip_base_scoreboard #(
         "outbound_base_address",
         "outbound_limit_address":; // Do nothing
 
+        // These registers are aliases of the SoC-side registers; they form a Read Only channel
+        // from the SoC side. They have no direct input on the DUT internals or its ports, but are
+        // instead intended to be used by firmware via another channel.
+        "doe_intr_msg_addr": begin
+          uvm_reg_data_t addr = item.d_data;
+          // We cannot readily predict this value with accurate timing.
+          do_read_check = 1'b0;
+          if (cfg.en_cov) begin
+            // Collect coverage to be sure that we have seen each of the bits in each of its two
+            // possible states.
+            foreach (addr[i]) cov.doe_intr_msg_addr_cg.sample(i, addr[i]);
+          end
+        end
+        "doe_intr_msg_data": begin
+          uvm_reg_data_t data = item.d_data;
+          // We cannot readily predict this value with accurate timing.
+          do_read_check = 1'b0;
+          if (cfg.en_cov) begin
+            foreach (data[i]) cov.doe_intr_msg_data_cg.sample(i, data[i]);
+          end
+        end
         default: `dv_fatal($sformatf("Core register '%s' read not modeled", csr.get_name()))
       endcase
 
@@ -255,63 +344,48 @@ class mbx_scoreboard extends cip_base_scoreboard #(
 
     if (addr_phase_write) begin
       if (csr) begin
+        `uvm_info(`gfn, $sformatf("SoC register '%s' write 0x%x", csr.get_name(), item.a_data),
+                  UVM_MEDIUM)
+
         // If incoming access is a write to a valid CSR, then make updates right away.
         void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
 
         case (csr.get_name())
           "soc_control": begin
-            mbx_soc_reg_soc_control ctl_reg_h;
-
-            `DV_CHECK_FATAL($cast(ctl_reg_h, csr), "Unable to cast csr handle to MBX control type")
-
-            /* TODO: Fix this.
-            if(ctl_reg_h.abort.get() == 1) begin
-              exp_mbx_core_irq = 1;
-              exp_mbx_core_irq_q.push_back(1);
-              // TODO: Check if busy bit also needs to be set
-              void'(ral.control.abort.predict(.value(1), .kind(UVM_PREDICT_WRITE)));
-              void'(ral.status.busy.predict(.value(1), .kind(UVM_PREDICT_WRITE)));
-              if((ral.status.busy.get() == 1) || (ral.control.error.get() == 1) ||
-                (m_obdwcnt != 0)) begin
-                void'(ral.status.busy.predict(.value(1), .kind(UVM_PREDICT_WRITE)));
-              end
-            end */
+            // Abort requests.
+            if (get_field_val(m_mbx_soc_ral.soc_control.abort, item.a_data)) begin
+              mbx_deactivate();
+              m_mbx_abort = 1'b1;
+            end
             // Go bit notifies the RoT side that there is a message available.
             if (get_field_val(m_mbx_soc_ral.soc_control.go, item.a_data)) begin
-              /* TODO: Fix this.
-              // if (ctl_reg_h.abort.get() == 1)
-              if((ral.status.busy.get() == 0) && (ral.control.error.get() == 0) &&
-                (ral.control.abort.get() == 0)) begin
-                void'(ral.status.busy.predict(.value(1), .kind(UVM_PREDICT_WRITE)));
-                void'(m_mbx_soc_ral.soc_status.busy.predict(.value(1), .kind(UVM_PREDICT_READ)));
+              // Note that the Inbound mailbox (SoC -> RoT) is already active at this point and
+              // will have written (most of) the request into the mailbox SRAM.
+              m_mbx_busy = 1'b1;
+              // Set the initial expectation of the Outbox read pointer.
+              m_obmbx_ptr = `gmv(ral.outbound_base_address);
 
-                exp_mbx_core_irq = 1;
-                exp_mbx_core_irq_q.push_back(1);
-              end
-              */
               if (cfg.en_cov) begin
                 cov.mem_range_cg.sample(`gmv(ral.inbound_base_address),
                                         `gmv(ral.outbound_base_address));
               end
             end
-            void'(ral.status.sys_intr_enable.predict(
-                     .value(ctl_reg_h.doe_intr_en.get()),
-                     .kind(UVM_PREDICT_WRITE)));
-            // TODO: Add async logic
-          end
-          "soc_status": begin
-            mbx_soc_reg_soc_status soc_sts_reg_h;
-            mbx_core_reg_status hst_sts_reg_h;
-            mbx_core_reg_control hst_ctl_reg_h;
-
-            `DV_CHECK_FATAL($cast(soc_sts_reg_h, csr),
-              "Unable to cast csr handle to soc_status type")
-            hst_sts_reg_h = ral.status;
-            hst_ctl_reg_h = ral.control;
-            if((item.a_data[1] & item.a_mask[0]) == 1) begin
-              void'(hst_sts_reg_h.sys_intr_state.predict(.value(0)));
+            if (cfg.en_cov) begin
+              // Collect coverage on stimulation of SOC_CONTROL bits.
+              cov.soc_control_cg.sample(
+                .abort(get_field_val(m_mbx_soc_ral.soc_control.abort, item.a_data)),
+                .doe_intr_en(get_field_val(m_mbx_soc_ral.soc_control.doe_intr_en, item.a_data)),
+                .doe_async_msg_en(get_field_val(m_mbx_soc_ral.soc_control.doe_async_msg_en,
+                                                item.a_data)),
+                .go(get_field_val(m_mbx_soc_ral.soc_control.go, item.a_data)));
             end
           end
+
+          // These registers do not require any further modeling.
+          "soc_status",
+          "soc_doe_intr_msg_addr",
+          "soc_doe_intr_msg_data":; // Do nothing
+
           default: `dv_fatal($sformatf("SoC register '%s' write not modeled", csr.get_name()))
         endcase
       end else begin
@@ -321,73 +395,81 @@ class mbx_scoreboard extends cip_base_scoreboard #(
         uvm_mem mem = m_mbx_soc_ral.default_map.get_mem_by_offset(csr_addr);
         case (mem.get_name())
           "wdata": begin
-            `uvm_info(`gfn, $sformatf("WDATA write of 0x%0x", item.a_data), UVM_MEDIUM)
-            m_ib_q.push_back(item.a_data);
+            `uvm_info(`gfn, $sformatf("WDATA write of 0x%0x (Inbox [0x%0x,0x%0x] wdata_ptr 0x%0x",
+                                      item.a_data, `gmv(ral.inbound_base_address),
+                                      `gmv(ral.inbound_limit_address), m_ib_wdata_ptr),
+                      UVM_MEDIUM)
+            // Set the initial expectation of the Inbox write pointer.
+            if (m_ibmbx_start) begin
+              m_ibmbx_start = 1'b0;
+              // Expected address for memory traffic.
+              m_ibmbx_ptr = `gmv(ral.inbound_base_address);
+              // Expected address at which WDATA would be written, if deemed valid.
+              m_ib_wdata_ptr = m_ibmbx_ptr;
+            end
+            if (m_ib_wdata_ptr <= `gmv(ral.inbound_limit_address)) begin
+              // Append this data word to the request.
+              m_ib_data_q.push_back(item.a_data);
+              m_ib_wdata_ptr += 4;
+            end else begin
+              // Raise an Inbound mailbox overflow error.
+              m_mbx_error = 1'b1;
+            end
           end
           "rdata": begin
             // Writing to RDATA pops the most recent data word from the Outbox.
-            if (m_ob_q.size() > 0) begin
+            if (m_ob_data_q.size() > 0) begin
               `uvm_info(`gfn, "RDATA write, popping DWORD", UVM_MEDIUM)
-              m_ob_q.pop_front();
+              m_ob_data_q.pop_front();
+            end
+            // Update our expectation of whether the mailbox is busy.
+            if (!m_ob_data_q.size()) begin
+              m_mbx_busy = 1'b0;
+              m_mbx_ready = 1'b0;
+              // Starting a new request on the Inbound side.
+              m_ibmbx_start = 1'b1;
             end
           end
           default: `dv_fatal($sformatf("SoC memory '%s' write not handled", mem.get_name()))
         endcase
-        // RDATA:
-        //  int tmp_ptr=0;
-        //  if(m_obmbx_ptr_q.size() == 0)
-        //    tmp_ptr = m_obmbx_ptr+4;
-        //  else
-        //    tmp_ptr = m_obmbx_ptr_q[$]+4;
-        //    m_obmbx_ptr_q.push_back(tmp_ptr);
-        //    m_obmbx_ptr = tmp_ptr;
-        //    m_obdwcnt--;
-        //    void'(m_ob_q.pop_front());
       end
     end else if (data_phase_read) begin
       if (csr) begin
         bit do_read_check = 1'b1;
 
         case (csr.get_name())
-          "soc_control": begin
-            mbx_soc_reg_soc_control ctl_reg_h;
-            void'(ctl_reg_h.abort.predict(
-                            .value(0),
-                            .kind(UVM_PREDICT_READ)));
-            void'(ctl_reg_h.doe_intr_en.predict(
-                            .value(ral.status.sys_intr_enable.get()),
-                            .kind(UVM_PREDICT_READ)));
-            void'(ctl_reg_h.go.predict(
-                            .value(0),
-                            .kind(UVM_PREDICT_READ)));
-            // TODO Add async logic
-          end
           "soc_status": begin
-            mbx_soc_reg_soc_status soc_sts_reg_h;
-            mbx_core_reg_status hst_sts_reg_h;
-            mbx_core_reg_control hst_ctl_reg_h;
-
-            `DV_CHECK_FATAL($cast(soc_sts_reg_h, csr),
-              "Unable to cast csr handle to soc_status type")
-            hst_sts_reg_h = ral.status;
-            hst_ctl_reg_h = ral.control;
-
-            void'(soc_sts_reg_h.busy.predict(
-                               .value(hst_sts_reg_h.busy.get()),
-                               .kind(UVM_PREDICT_READ)));
-            void'(soc_sts_reg_h.doe_intr_status.predict(
-                               .value(hst_sts_reg_h.sys_intr_state.get()),
-                               .kind(UVM_PREDICT_READ)));
-            void'(soc_sts_reg_h.error.predict(
-                               .value(hst_ctl_reg_h.error.get()),
-                               .kind(UVM_PREDICT_READ)));
-            //TODO: Review new ready field
-            void'(soc_sts_reg_h.ready.predict(
-                               .value(m_obdwcnt != 0),
-                               .kind(UVM_PREDICT_READ)));
-            // TODO: The scoreboard is not yet up to checking this.
+            void'(m_mbx_soc_ral.soc_status.busy.predict(.value(m_mbx_busy),
+                                                        .kind(UVM_PREDICT_READ)));
+            void'(m_mbx_soc_ral.soc_status.doe_intr_status.predict(
+                    .value(|{m_mbx_ready, m_mbx_abort, m_mbx_error, m_mbx_async_msg}),
+                    .kind(UVM_PREDICT_READ)));
+            void'(m_mbx_soc_ral.soc_status.error.predict(.value(m_mbx_error),
+                                                         .kind(UVM_PREDICT_READ)));
+            void'(m_mbx_soc_ral.soc_status.doe_async_msg_status.predict(.value(m_mbx_async_msg),
+                                                                        .kind(UVM_PREDICT_READ)));
+            void'(m_mbx_soc_ral.soc_status.ready.predict(.value(m_mbx_ready),
+                                                         .kind(UVM_PREDICT_READ)));
+            if (cfg.en_cov) begin
+              // Collect coverage for the observed DUT status indicators.
+              cov.soc_status_cg.sample(
+                .busy(get_field_val(m_mbx_soc_ral.soc_status.ready, item.d_data)),
+                .doe_intr_status(get_field_val(m_mbx_soc_ral.soc_status.doe_intr_status,
+                                               item.d_data)),
+                .error(get_field_val(m_mbx_soc_ral.soc_status.error, item.d_data)),
+                .doe_async_msg_status(get_field_val(m_mbx_soc_ral.soc_status.doe_async_msg_status,
+                                                    item.d_data)),
+                .ready(get_field_val(m_mbx_soc_ral.soc_status.ready, item.d_data)));
+            end
+            // TODO: Modeling is presently not up to the task.
             do_read_check = 1'b0;
           end
+
+          // These registers do not require any further modeling.
+          "soc_control",
+          "soc_doe_intr_msg_addr",
+          "soc_doe_intr_msg_data":; // Do nothing
+
           default: `dv_fatal($sformatf("SoC register '%s' read not modeled", csr.get_name()))
         endcase
 
@@ -409,7 +491,7 @@ class mbx_scoreboard extends cip_base_scoreboard #(
           end
           "rdata": begin
             uvm_reg_data_t exp_data = 0;
-            if (m_ob_q.size() > 0) exp_data = m_ob_q[0];
+            if (m_ob_data_q.size() > 0) exp_data = m_ob_data_q[0];
             `DV_CHECK_EQ(item.d_data, exp_data, "RDATA read data mismatched")
           end
           default: `dv_fatal($sformatf("SoC memory '%s' read not handled", mem.get_name()))
@@ -419,8 +501,6 @@ class mbx_scoreboard extends cip_base_scoreboard #(
     `uvm_info(`gfn, "process_tl_mbx_soc_access -- End", UVM_DEBUG)
   endfunction : process_tl_mbx_soc_access
 
-  // TODO: This is presently unused, but we shall want to check all of the TL-UL traffic to/from
-  // the mailbox SRAM as it happens.
   virtual function void process_tl_mbx_mem_access(tl_seq_item item, tl_channels_e channel);
     bit write             = item.is_write();
     bit addr_phase_read   = (!write && channel == AddrChannel);
@@ -438,54 +518,49 @@ class mbx_scoreboard extends cip_base_scoreboard #(
          $sformatf("Incorrect a_size(%0d) or a_mask('b%0b)", item.a_size, item.a_mask))
 
       // Check the addresses are generated between the configured limits only
-      if(addr_phase_write) begin
+      if (addr_phase_write) begin
         bit is_addr_match;
 
         // Check if address is within IB Mailbox SRAM range
-        if((item.a_addr >= ral.inbound_base_address.get()) &&
-          (item.a_addr < ral.inbound_limit_address.get())) begin
-          is_addr_match = 1'b1;
-        end
+        is_addr_match = (item.a_addr >= ral.inbound_base_address.get()) &&
+                        (item.a_addr <= ral.inbound_limit_address.get());
         `DV_CHECK_EQ(is_addr_match, 1,
           $sformatf("Address('h%0h) doesn't match any of inbound mailbox address ranges",
           item.a_addr))
 
         // Check if the SRAM write is expected or not
-        `DV_CHECK_NE(m_ib_q.size(), 0, "No write data in mbxwrdat register")
+        `DV_CHECK_NE(m_ib_data_q.size(), 0, "No write data in WDATA register")
 
         // Check if the SRAM write address is correct.
-        `DV_CHECK_EQ(item.a_addr, (ral.inbound_base_address.get() + m_ibmbx_ptr),
-          "Incorrect address seen on the write to SRAM")
+        `DV_CHECK_EQ(item.a_addr, m_ibmbx_ptr, "Incorrect address seen on the write to SRAM")
         m_ibmbx_ptr += 4;
 
-        // Check if the data written matches with the data written to wrdat register
-        `DV_CHECK_EQ(item.a_data, m_ib_q[0],
-          "Bus data doesn't match with data written to wdat")
-        void'(m_ib_q.pop_front());
+        // Check if the data written matches with the data written to WDATA.
+        `DV_CHECK_EQ(item.a_data, m_ib_data_q[0],
+          "Bus data doesn't match with data written to WDATA")
+        void'(m_ib_data_q.pop_front());
       end
-    end
-    if (data_phase_read) begin
+    end else if (data_phase_read) begin
       bit is_addr_match;
 
       // Check if address is within OB Mailbox SRAM range
-      if((item.a_addr >= ral.outbound_base_address.get()) &&
-        (item.a_addr < ral.outbound_limit_address.get())) begin
-        is_addr_match = 1'b1;
-      end
+      is_addr_match = (item.a_addr >= ral.outbound_base_address.get()) &&
+                      (item.a_addr <= ral.outbound_limit_address.get());
       `DV_CHECK_EQ(is_addr_match, 1,
         $sformatf("Address('h%0h) out of outbound mailbox address ranges",  item.a_addr))
 
       // No read should occur when obdwcnt is '0'
       `DV_CHECK_NE(m_obdwcnt, 0, "Illegal read from memory when obdwcnt is 0")
 
-       m_obmbx_ptr = m_obmbx_ptr_q[0];
       // Check if the SRAM read address is correct.
-      `DV_CHECK_EQ(item.a_addr, (ral.outbound_base_address.get() + m_obmbx_ptr_q[0]),
-        "Incorrect address seen on the read to SRAM")
-      `uvm_info(`gfn, $sformatf("Added data 'h%0h to m_ob_q", item.d_data), UVM_LOW)
-       m_ob_q.push_back(item.d_data);
-       void'(m_obmbx_ptr_q.pop_front());
+      `DV_CHECK_EQ(item.a_addr, m_obmbx_ptr, "Incorrect address seen on the read to SRAM")
+      `uvm_info(`gfn, $sformatf("Added data 'h%0h to m_ob_data_q", item.d_data), UVM_LOW)
+      m_ob_data_q.push_back(item.d_data);
 
+      // Update Outbound reader state.
+      m_mbx_ready = 1'b1;
+      m_obmbx_ptr += 4;
+      m_obdwcnt--;
     end
     `uvm_info(`gfn, "process_tl_mbx_mem_access -- End", UVM_DEBUG)
   endfunction : process_tl_mbx_mem_access
@@ -493,22 +568,26 @@ class mbx_scoreboard extends cip_base_scoreboard #(
   virtual function void reset(string kind = "HARD");
     super.reset(kind);
     // reset local fifos queues and variables
-    m_ib_q.delete();
-    m_ob_q.delete();
+    m_ib_data_q.delete();
+    m_ob_data_q.delete();
     m_ibmbx_ptr = 0;
     m_obmbx_ptr = 0;
     m_obdwcnt = 0;
+    m_mbx_busy = 1'b0;
+    m_mbx_error = 1'b0;
+    m_mbx_async_msg = 1'b0;
+    m_ibmbx_start = 1'b1;
     exp_mbx_core_irq = 0;
   endfunction
 
   function void check_phase(uvm_phase phase);
     super.check_phase(phase);
     // post test checks - ensure that all local fifos and queues are empty
-    if(m_ib_q.size() > 0) begin
-      `uvm_error(`gfn, $sformatf("m_ib_q is not empty(%0d)", m_ib_q.size()))
+    if(m_ib_data_q.size() > 0) begin
+      `uvm_error(`gfn, $sformatf("m_ib_data_q is not empty(%0d)", m_ib_data_q.size()))
     end
-    if(m_ob_q.size() > 0) begin
-      `uvm_error(`gfn, $sformatf("m_ob_q is not empty(%0d)", m_ob_q.size()))
+    if(m_ob_data_q.size() > 0) begin
+      `uvm_error(`gfn, $sformatf("m_ob_data_q is not empty(%0d)", m_ob_data_q.size()))
     end
     if(exp_mbx_core_irq_q.size() > 0) begin
       `uvm_error(`gfn, $sformatf("exp_mbx_core_irq_q is not empty(%0d)", exp_mbx_core_irq_q.size()))


### PR DESCRIPTION
This PR extensively changes the MBX scoreboard, most of which was previously deactivated.
- Introduce register modeling on both RoT and SoC sides with predictions and checking where possible.
- Complete and bring up checking of the traffic from/to the MBX DUT.
- Add functional coverage.
- Collect functional coverage within the modified scoreboard.
- Ensure that coverage is collected on the RoT side for STATUS register reads; previously this register was not read because it carries only aliases of the SoC-side CONTROL and STATUS bits.
