### PR TITLE
[lint] Make the verible lint step top aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,11 +122,11 @@ jobs:
       - name: Vendored files
         run: ./ci/scripts/check-vendoring.sh
       - name: Verible RTL
-        run: ./ci/scripts/verible-lint.sh rtl
+        run: ./ci/scripts/verible-lint.sh rtl earlgrey
       - name: Verible DV
-        run: ./ci/scripts/verible-lint.sh dv
+        run: ./ci/scripts/verible-lint.sh dv earlgrey
       - name: Verible FPV
-        run: ./ci/scripts/verible-lint.sh fpv
+        run: ./ci/scripts/verible-lint.sh fpv earlgrey
 
   build_docs:
     name: Build documentation

--- a/ci/jobs/slow-lint.sh
+++ b/ci/jobs/slow-lint.sh
@@ -30,10 +30,10 @@ echo "### Check vendored directories are up-to-date"
 ci/scripts/check-vendoring.sh
 
 echo -e "\n### Style-Lint RTL Verilog source files with Verible"
-ci/scripts/verible-lint.sh rtl
+ci/scripts/verible-lint.sh rtl earlgrey
 
 echo -e "\n### Style-Lint DV Verilog source files with Verible"
-ci/scripts/verible-lint.sh dv
+ci/scripts/verible-lint.sh dv earlgrey
 
 echo -e "\n### Style-Lint FPV Verilog source files with Verible"
-ci/scripts/verible-lint.sh fpv
+ci/scripts/verible-lint.sh fpv earlgrey

--- a/ci/scripts/verible-lint.sh
+++ b/ci/scripts/verible-lint.sh
@@ -5,36 +5,48 @@
 
 # A wrapper around Verible lint, used for CI.
 #
-# Expects a single argument, which is the pull request's target branch
-# (usually "master").
+# Expects two arguments:
+# 1. The lint flavour (rtl, dv, fpv)
+# 2. The top name (earlgrey, darjeeling, englishbreakfast)
 
 set -e
 
-if [ $# != 1 ]; then
-    echo >&2 "Usage: verible-lint.sh <flavour>"
+if [ $# != 2 ]; then
+    echo >&2 "Usage: verible-lint.sh <flavour> <top>"
+    echo >&2 "  flavour: rtl, dv, or fpv"
+    echo >&2 "  top: earlgrey, darjeeling, or englishbreakfast"
     exit 1
 fi
 flavour="$1"
+top="$2"
 
 case "$flavour" in
     rtl)
         human_desc=design
-        dvsim_cfg=hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
+        dvsim_cfg="hw/top_${top}/lint/top_${top}_lint_cfgs.hjson"
         ;;
 
     dv)
         human_desc=DV
-        dvsim_cfg=hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson
+        dvsim_cfg="hw/top_${top}/lint/top_${top}_dv_lint_cfgs.hjson"
         ;;
     fpv)
         human_desc=FPV
-        dvsim_cfg=hw/top_earlgrey/lint/top_earlgrey_fpv_lint_cfgs.hjson
+        dvsim_cfg="hw/top_${top}/lint/top_${top}_fpv_lint_cfgs.hjson"
         ;;
 
     *)
         echo >&2 "Unknown lint flavour: $flavour"
+        echo >&2 "Supported flavours: rtl, dv, fpv"
         exit 1
 esac
+
+# Check if the lint configuration file exists
+if [ ! -f "$dvsim_cfg" ]; then
+    echo >&2 "Lint configuration file not found: $dvsim_cfg"
+    echo >&2 "Make sure the top '$top' supports '$flavour' linting"
+    exit 1
+fi
 
 # DVSIM_MAX_PARALLEL constrains how many tasks dvsim.py will try to
 # run in parallel. If it hasn't already been set, set it to be the
@@ -48,7 +60,7 @@ fi
 env DVSIM_MAX_PARALLEL="$mp" \
   util/dvsim/dvsim.py --tool=veriblelint "$dvsim_cfg" || {
     echo "::error::"\
-        "Verilog style lint of ${human_desc} sources with Verible failed." \
+        "Verilog style lint of ${human_desc} sources with Verible failed for top '${top}'." \
         "Run 'util/dvsim/dvsim.py -t veriblelint ${dvsim_cfg}' and fix all errors."
     exit 1
 }


### PR DESCRIPTION
This PR refactors the `verible-lint.sh` script to be top-aware, allowing it to work with other tops instead of being hardcoded to `earlgrey`. 

### Problem

The `verible-lint.sh` script (as many others) was hardcoded to use `top_earlgrey` for all lint configurations, making it impossible to use with other tops like Darjeeling or Englishbreakast. This created a maintenance burden and limited the script's usefulness in multi-top scenarios.

### Solution

The script interface was modified to accept a second parameter for the top name, replacing hardcoded `earlgrey` paths with dynamic construction using `${top}` substitution. There is no explicit top validation to allow the script to work also with downstream tops. An implicit top validation is performed by checking if the lint config file exists. All existing CI jobs and GitHub Actions workflows were updated to maintain backward compatibility by explicitly passing earlgrey as the top parameter.
