### PR TITLE
 Manual cherry-pick to `master`: [bazel,qemu] Stream QEMU stdout logs during test execution

### DIFF
--- a/rules/scripts/qemu_pass.py
+++ b/rules/scripts/qemu_pass.py
@@ -19,25 +19,25 @@ def _main() -> int:
     r = Runfiles.Create()
     qemu_bin = r.Rlocation("qemu_opentitan/build/qemu-system-riscv32")
 
-    # Run the process capturing (then echoing) `stdout` and `stderr`.
-    proc = subprocess.run(  # noqa: S603 (trust that the command is valid).
-        [qemu_bin] + sys.argv[1:],
+    # Run the process streaming (echoing) `stdout` and `stderr`.
+    proc = subprocess.Popen(  # noqa: S603 (trust that the command is valid).
+        " ".join([qemu_bin] + sys.argv[1:]),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+        bufsize=1,
+        shell=True,
         text=True,
-        check=False,
     )
-    sys.stdout.write(proc.stdout or "")
-    sys.stderr.write(proc.stderr or "")
-
-    if proc.stdout.find("PASS!") != -1:
-        return proc.returncode
-
-    if proc.returncode == 0:
+    for line in proc.stdout:
+        sys.stdout.write(line)
+        sys.stdout.flush()
+        if "PASS!" in line:
+            return proc.wait()
+    returncode = proc.wait()
+    if returncode == 0:
         # QEMU exited successfully but we didn't see `PASS!`, fail instead.
         return 1
-
-    return proc.returncode
+    return returncode
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A manual cherry pick of https://github.com/lowRISC/opentitan/pull/27998 due to conflicts in the QEMU script in `master` due to Python linting changes.