### PR TITLE
[csrng/dv] Fix DV paths to FSM-related asserts

### DIFF
--- a/hw/ip/csrng/dv/sva/csrng_assert_if.sv
+++ b/hw/ip/csrng/dv/sva/csrng_assert_if.sv
@@ -5,8 +5,11 @@
 // An interface that is bound into the csrng module and enables/disables assertions embedded in its
 // code.
 
-// These hierarchical paths are all up-references and go up one step (to leave the bound-in
-// interface), then select a block that is a child of the csrng module.
+// These hierarchical paths were meant to all be up-references, going up one step (to leave the
+// bound-in interface), then select a block that is a child of the csrng module.
+// However, due to the missing support for up-references in $assertoff() (and probably other
+// assertion-control functions), they have to be absolute references for now.
+`define DUT_PATH tb.dut
 `define PATH1 \
     u_csrng_core.gen_cmd_stage[2].u_csrng_cmd_stage
 `define PATH2 \
@@ -36,31 +39,31 @@ interface csrng_assert_if
 );
 
   task automatic assert_off ();
-    $assertoff(0, `PATH1.u_state_regs_A);
-    $assertoff(0, `PATH2.`PATH2_1.AesCipherControlStateValid);
-    $assertoff(0, `PATH2.`PATH2_2.AesCipherControlStateValid);
-    $assertoff(0, `PATH2.`PATH2_3.AesCipherControlStateValid);
-    $assertoff(0, `PATH2.`PATH2_1.u_state_regs_A);
-    $assertoff(0, `PATH2.`PATH2_2.u_state_regs_A);
-    $assertoff(0, `PATH2.`PATH2_3.u_state_regs_A);
-    $assertoff(0, `PATH6.u_outblk_state_regs_A);
-    $assertoff(0, `PATH6.u_blk_enc_state_regs_A);
-    $assertoff(0, `PATH7.u_state_regs_A);
-    $assertoff(0, `PATH8.u_state_regs_A);
+    $assertoff(0, `DUT_PATH.`PATH1.u_state_regs_A);
+    $assertoff(0, `DUT_PATH.`PATH2.`PATH2_1.AesCipherControlStateValid);
+    $assertoff(0, `DUT_PATH.`PATH2.`PATH2_2.AesCipherControlStateValid);
+    $assertoff(0, `DUT_PATH.`PATH2.`PATH2_3.AesCipherControlStateValid);
+    $assertoff(0, `DUT_PATH.`PATH2.`PATH2_1.u_state_regs_A);
+    $assertoff(0, `DUT_PATH.`PATH2.`PATH2_2.u_state_regs_A);
+    $assertoff(0, `DUT_PATH.`PATH2.`PATH2_3.u_state_regs_A);
+    $assertoff(0, `DUT_PATH.`PATH6.u_outblk_state_regs_A);
+    $assertoff(0, `DUT_PATH.`PATH6.u_blk_enc_state_regs_A);
+    $assertoff(0, `DUT_PATH.`PATH7.u_state_regs_A);
+    $assertoff(0, `DUT_PATH.`PATH8.u_state_regs_A);
   endtask // assert_off
 
   task automatic assert_on ();
-    $asserton(0, `PATH1.u_state_regs_A);
-    $asserton(0, `PATH2.`PATH2_1.AesCipherControlStateValid);
-    $asserton(0, `PATH2.`PATH2_2.AesCipherControlStateValid);
-    $asserton(0, `PATH2.`PATH2_3.AesCipherControlStateValid);
-    $asserton(0, `PATH2.`PATH2_1.u_state_regs_A);
-    $asserton(0, `PATH2.`PATH2_2.u_state_regs_A);
-    $asserton(0, `PATH2.`PATH2_3.u_state_regs_A);
-    $asserton(0, `PATH6.u_outblk_state_regs_A);
-    $asserton(0, `PATH6.u_blk_enc_state_regs_A);
-    $asserton(0, `PATH7.u_state_regs_A);
-    $asserton(0, `PATH8.u_state_regs_A);
+    $asserton(0, `DUT_PATH.`PATH1.u_state_regs_A);
+    $asserton(0, `DUT_PATH.`PATH2.`PATH2_1.AesCipherControlStateValid);
+    $asserton(0, `DUT_PATH.`PATH2.`PATH2_2.AesCipherControlStateValid);
+    $asserton(0, `DUT_PATH.`PATH2.`PATH2_3.AesCipherControlStateValid);
+    $asserton(0, `DUT_PATH.`PATH2.`PATH2_1.u_state_regs_A);
+    $asserton(0, `DUT_PATH.`PATH2.`PATH2_2.u_state_regs_A);
+    $asserton(0, `DUT_PATH.`PATH2.`PATH2_3.u_state_regs_A);
+    $asserton(0, `DUT_PATH.`PATH6.u_outblk_state_regs_A);
+    $asserton(0, `DUT_PATH.`PATH6.u_blk_enc_state_regs_A);
+    $asserton(0, `DUT_PATH.`PATH7.u_state_regs_A);
+    $asserton(0, `DUT_PATH.`PATH8.u_state_regs_A);
   endtask // assert_on
 
   task automatic assert_off_alert ();


### PR DESCRIPTION
`dv/sva/csrng_assert_if.sv` contains a list of FSM-related SVAs that need to be turned off before running tests in which FSMs are forced to invalid encodings/states. These paths were relative to the DUT, not to the test environment, which resulted in these asserts not being found when requested to be disabled (and re-enabled after the test).

This caused a sizable number of tests to fail (`csrng_intr` and `csrng_err`); with this fix, the [pass rate](https://nightly.reports.lowrisc.org/opentitan_weekly_earlgrey/2025_06_22/hw/ip/csrng/dv/report.html) increases from ~95% to ~99%.