### PR TITLE
[prim/rtl] Synthesizable `countones` function

### DIFF
--- a/hw/ip_templates/otp_ctrl/otp_ctrl.core.tpl
+++ b/hw/ip_templates/otp_ctrl/otp_ctrl.core.tpl
@@ -25,6 +25,7 @@ filesets:
       - lowrisc:prim:secded
       - lowrisc:prim:edn_req
       - lowrisc:prim:sec_anchor
+      - lowrisc:prim:sum_tree
       # TODO(#27347): prim_pkg is deprecated
       - lowrisc:prim:prim_pkg
       - ${instance_vlnv("lowrisc:ip:pwrmgr_pkg")}

--- a/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_dai.sv
+++ b/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_dai.sv
@@ -922,6 +922,30 @@ module otp_ctrl_dai
   assign addr_calc = {cnt, {$clog2(ScrmblBlockWidth/8){1'b0}}} + addr_base;
   assign otp_addr_o = OtpAddrWidth'(addr_calc >> OtpAddrShift);
 
+  ///////////////////////
+  // Zeroization Logic //
+  ///////////////////////
+
+  // Count the number of set bits in the read-out word and release it when the `ZEROIZE` command is
+  // invoked.
+
+  logic [$clog2(ScrmblBlockWidth+1)-1:0] otp_rdata_cnt;
+
+  // Use the `prim_sum_tree` primitive to emulate the SystemVerilog function $countones which is
+  // not supported by all tools.
+  prim_sum_tree #(
+    .NumSrc(ScrmblBlockWidth),
+    .Saturate(1'b0),
+    .InWidth(1)
+  ) u_countones (
+    .clk_i       (clk_i),
+    .rst_ni      (rst_ni),
+    .values_i    (otp_rdata_i),
+    .valid_i     ({ScrmblBlockWidth{1'b1}}),
+    .sum_value_o (otp_rdata_cnt),
+    .sum_valid_o ()
+  );
+
   ///////////////
   // Registers //
   ///////////////
@@ -946,7 +970,7 @@ module otp_ctrl_dai
         end else if (data_sel == DaiData) begin
           data_q <= dai_wdata_i;
         end else if (data_sel == ZerData) begin
-           data_q <= countones(otp_rdata_i);
+           data_q <= ScrmblBlockWidth'(otp_rdata_cnt);
         end else begin
           data_q <= otp_rdata_i;
         end
@@ -964,7 +988,6 @@ module otp_ctrl_dai
     .d_i(zer_trigs_d),
     .q_o({zer_trigs_o})
   );
-
 
   ////////////////
   // Assertions //

--- a/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_top_specific_pkg.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_top_specific_pkg.sv.tpl
@@ -86,19 +86,9 @@ package otp_ctrl_top_specific_pkg;
   // stuck-at-0 bits.
   parameter int unsigned ZeroizationValidBound = ScrmblBlockWidth - 6; // 90.625%
 
-  // Count the number of set bits in a word. Effectively implements `$countones` which is not
-  // supported by all tools.
-  function automatic logic [ScrmblBlockWidth-1:0] countones(logic [ScrmblBlockWidth-1:0] word);
-    logic [ScrmblBlockWidth-1:0] count = '0;
-    for (int i = 0; i < ScrmblBlockWidth; i++) begin
-      count = count + word[i];
-    end
-    return count;
-  endfunction : countones
-
   // Check if the zeroization marker fulfills the zeroization criterion.
-  function automatic logic check_zeroized_valid(logic [ScrmblBlockWidth-1:0] word);
-    return countones(word) >= ZeroizationValidBound;
+  function automatic logic check_zeroized_valid(logic [$clog2(ScrmblBlockWidth+1)-1:0] count);
+    return count >= ZeroizationValidBound;
   endfunction : check_zeroized_valid
 
   ////////////////////////////////

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/otp_ctrl.core
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/otp_ctrl.core
@@ -25,6 +25,7 @@ filesets:
       - lowrisc:prim:secded
       - lowrisc:prim:edn_req
       - lowrisc:prim:sec_anchor
+      - lowrisc:prim:sum_tree
       # TODO(#27347): prim_pkg is deprecated
       - lowrisc:prim:prim_pkg
       - lowrisc:darjeeling_ip:pwrmgr_pkg

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_dai.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_dai.sv
@@ -922,6 +922,30 @@ module otp_ctrl_dai
   assign addr_calc = {cnt, {$clog2(ScrmblBlockWidth/8){1'b0}}} + addr_base;
   assign otp_addr_o = OtpAddrWidth'(addr_calc >> OtpAddrShift);
 
+  ///////////////////////
+  // Zeroization Logic //
+  ///////////////////////
+
+  // Count the number of set bits in the read-out word and release it when the `ZEROIZE` command is
+  // invoked.
+
+  logic [$clog2(ScrmblBlockWidth+1)-1:0] otp_rdata_cnt;
+
+  // Use the `prim_sum_tree` primitive to emulate the SystemVerilog function $countones which is
+  // not supported by all tools.
+  prim_sum_tree #(
+    .NumSrc(ScrmblBlockWidth),
+    .Saturate(1'b0),
+    .InWidth(1)
+  ) u_countones (
+    .clk_i       (clk_i),
+    .rst_ni      (rst_ni),
+    .values_i    (otp_rdata_i),
+    .valid_i     ({ScrmblBlockWidth{1'b1}}),
+    .sum_value_o (otp_rdata_cnt),
+    .sum_valid_o ()
+  );
+
   ///////////////
   // Registers //
   ///////////////
@@ -946,7 +970,7 @@ module otp_ctrl_dai
         end else if (data_sel == DaiData) begin
           data_q <= dai_wdata_i;
         end else if (data_sel == ZerData) begin
-           data_q <= countones(otp_rdata_i);
+           data_q <= ScrmblBlockWidth'(otp_rdata_cnt);
         end else begin
           data_q <= otp_rdata_i;
         end
@@ -964,7 +988,6 @@ module otp_ctrl_dai
     .d_i(zer_trigs_d),
     .q_o({zer_trigs_o})
   );
-
 
   ////////////////
   // Assertions //

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_top_specific_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_top_specific_pkg.sv
@@ -86,19 +86,9 @@ package otp_ctrl_top_specific_pkg;
   // stuck-at-0 bits.
   parameter int unsigned ZeroizationValidBound = ScrmblBlockWidth - 6; // 90.625%
 
-  // Count the number of set bits in a word. Effectively implements `$countones` which is not
-  // supported by all tools.
-  function automatic logic [ScrmblBlockWidth-1:0] countones(logic [ScrmblBlockWidth-1:0] word);
-    logic [ScrmblBlockWidth-1:0] count = '0;
-    for (int i = 0; i < ScrmblBlockWidth; i++) begin
-      count = count + word[i];
-    end
-    return count;
-  endfunction : countones
-
   // Check if the zeroization marker fulfills the zeroization criterion.
-  function automatic logic check_zeroized_valid(logic [ScrmblBlockWidth-1:0] word);
-    return countones(word) >= ZeroizationValidBound;
+  function automatic logic check_zeroized_valid(logic [$clog2(ScrmblBlockWidth+1)-1:0] count);
+    return count >= ZeroizationValidBound;
   endfunction : check_zeroized_valid
 
   ////////////////////////////////

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/otp_ctrl.core
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/otp_ctrl.core
@@ -25,6 +25,7 @@ filesets:
       - lowrisc:prim:secded
       - lowrisc:prim:edn_req
       - lowrisc:prim:sec_anchor
+      - lowrisc:prim:sum_tree
       # TODO(#27347): prim_pkg is deprecated
       - lowrisc:prim:prim_pkg
       - lowrisc:earlgrey_ip:pwrmgr_pkg

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_dai.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_dai.sv
@@ -922,6 +922,30 @@ module otp_ctrl_dai
   assign addr_calc = {cnt, {$clog2(ScrmblBlockWidth/8){1'b0}}} + addr_base;
   assign otp_addr_o = OtpAddrWidth'(addr_calc >> OtpAddrShift);
 
+  ///////////////////////
+  // Zeroization Logic //
+  ///////////////////////
+
+  // Count the number of set bits in the read-out word and release it when the `ZEROIZE` command is
+  // invoked.
+
+  logic [$clog2(ScrmblBlockWidth+1)-1:0] otp_rdata_cnt;
+
+  // Use the `prim_sum_tree` primitive to emulate the SystemVerilog function $countones which is
+  // not supported by all tools.
+  prim_sum_tree #(
+    .NumSrc(ScrmblBlockWidth),
+    .Saturate(1'b0),
+    .InWidth(1)
+  ) u_countones (
+    .clk_i       (clk_i),
+    .rst_ni      (rst_ni),
+    .values_i    (otp_rdata_i),
+    .valid_i     ({ScrmblBlockWidth{1'b1}}),
+    .sum_value_o (otp_rdata_cnt),
+    .sum_valid_o ()
+  );
+
   ///////////////
   // Registers //
   ///////////////
@@ -946,7 +970,7 @@ module otp_ctrl_dai
         end else if (data_sel == DaiData) begin
           data_q <= dai_wdata_i;
         end else if (data_sel == ZerData) begin
-           data_q <= countones(otp_rdata_i);
+           data_q <= ScrmblBlockWidth'(otp_rdata_cnt);
         end else begin
           data_q <= otp_rdata_i;
         end
@@ -964,7 +988,6 @@ module otp_ctrl_dai
     .d_i(zer_trigs_d),
     .q_o({zer_trigs_o})
   );
-
 
   ////////////////
   // Assertions //

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_top_specific_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_top_specific_pkg.sv
@@ -86,19 +86,9 @@ package otp_ctrl_top_specific_pkg;
   // stuck-at-0 bits.
   parameter int unsigned ZeroizationValidBound = ScrmblBlockWidth - 6; // 90.625%
 
-  // Count the number of set bits in a word. Effectively implements `$countones` which is not
-  // supported by all tools.
-  function automatic logic [ScrmblBlockWidth-1:0] countones(logic [ScrmblBlockWidth-1:0] word);
-    logic [ScrmblBlockWidth-1:0] count = '0;
-    for (int i = 0; i < ScrmblBlockWidth; i++) begin
-      count = count + word[i];
-    end
-    return count;
-  endfunction : countones
-
   // Check if the zeroization marker fulfills the zeroization criterion.
-  function automatic logic check_zeroized_valid(logic [ScrmblBlockWidth-1:0] word);
-    return countones(word) >= ZeroizationValidBound;
+  function automatic logic check_zeroized_valid(logic [$clog2(ScrmblBlockWidth+1)-1:0] count);
+    return count >= ZeroizationValidBound;
   endfunction : check_zeroized_valid
 
   ////////////////////////////////


### PR DESCRIPTION
Two commits:

1. Remove `countones` logic from DAI. The count value is released unconditionally.
2. Use `prim_sum_tree` for the calculation of `countones`.

Addresses #28017.