### PR TITLE
[crypto] HMAC SCA and FI hardening

### DIFF
--- a/sw/device/lib/crypto/drivers/hmac.c
+++ b/sw/device/lib/crypto/drivers/hmac.c
@@ -394,6 +394,10 @@ static status_t oneshot(const uint32_t cfg, const uint32_t *key,
   // Write the key (no-op if the key length is 0, e.g. for hashing).
   key_write(key, key_wordlen);
 
+  // Read back the HMAC configuration and compare to the expected configuration.
+  HARDENED_CHECK_EQ(abs_mmio_read32(kHmacBaseAddr + HMAC_CFG_REG_OFFSET),
+                    launder32(cfg));
+
   // Send the START command.
   uint32_t cmd =
       bitfield_bit32_write(HMAC_CMD_REG_RESVAL, HMAC_CMD_HASH_START_BIT, 1);

--- a/sw/device/lib/crypto/drivers/hmac.c
+++ b/sw/device/lib/crypto/drivers/hmac.c
@@ -179,10 +179,8 @@ static void clear(void) {
  * @param key_wordlen The length of the key in words.
  */
 static void key_write(const uint32_t *key, size_t key_wordlen) {
-  for (size_t i = 0; i < key_wordlen; i++) {
-    abs_mmio_write32(
-        kHmacBaseAddr + HMAC_KEY_0_REG_OFFSET + sizeof(uint32_t) * i, key[i]);
-  }
+  uint32_t key_reg = kHmacBaseAddr + HMAC_KEY_0_REG_OFFSET;
+  hardened_memcpy((uint32_t *)key_reg, key, key_wordlen);
 }
 
 /**


### PR DESCRIPTION
- Randomize the key write order
- Read back the HMAC config and compare to the expected config