### PR TITLE
[entropy_src] Fix bucket test failure aggregation and prediction for Darjeeling variant

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -295,7 +295,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic [FullRegWidth-1:0] bucket_total_fails;
   logic [EighthRegWidth-1:0]  bucket_fail_count;
   logic [NumBucketHtInst-1:0] bucket_fail_pulse;
-  logic [prim_util_pkg::vbits(NumBucketHtInst)-1:0] bucket_fail_pulse_step;
+  logic [prim_util_pkg::vbits(NumBucketHtInst+1)-1:0] bucket_fail_pulse_step;
   logic                      bucket_fails_cntr_err;
   logic                      bucket_alert_cntr_err;
 


### PR DESCRIPTION
This PR 1) fixes an RTL bug in Darjeeling which could lead to bucket test failures getting ignored and 2) fixes the prediction of the bucket test related registers for Darjeeling. The prediction of the `BUCKET_HI_WATERMARKS` and the `BUCKET_TOTAL_FAILS` registers as well as the `ALERT_FAIL_COUNTS.BUCKET_FAIL_COUNT` were all wrong before.

This is related to #27471.