### PR TITLE
[entropy_src] Fix bucket test result aggregation for Darjeeling, correct threshold computation

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -202,7 +202,7 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
       fifo_cntr_err     :/ 4};}
 
   constraint which_cntr_replicate_c {which_cntr_replicate inside {[0:`RNG_BUS_WIDTH-1]};}
-  int        num_bins = 2**`RNG_BUS_WIDTH;
+  int        num_bins = 2**entropy_src_pkg::bucket_ht_data_width(`RNG_BUS_WIDTH);
   constraint which_bin_c {which_bin inside {[0:num_bins-1]};}
   constraint which_ht_inst_c {which_ht_inst inside {
     [0:entropy_src_pkg::num_bucket_ht_inst(`RNG_BUS_WIDTH)-1]};

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
@@ -251,6 +251,62 @@ package entropy_src_env_pkg;
     return random_fail_time;
   endfunction // randomize_failure_time
 
+  // Helper function to compute the approximated parameters of the distribution of test results
+  // based on the window size, the selected test, threshold_scope, and single- or multi-channel
+  // operation.
+  function automatic void approximate_distribution(int window_size, health_test_e test,
+                                                   bit per_line, bit rng_bit_enable,
+                                                   output int n, output real p,
+                                                   output real mean, output real stddev);
+
+    // The bucket health test is performed group wise to every 4 adjacent channels.
+    // If RNG_BUS_WIDTH is  larger than 4, the bucket health test gets instantiated multiple
+    // times, once per 4 channels.
+    int BucketHtDataWidth = entropy_src_pkg::bucket_ht_data_width(`RNG_BUS_WIDTH);
+    int NumBuckets = 2**BucketHtDataWidth;
+    int unsigned NumBucketHtInst = entropy_src_pkg::num_bucket_ht_inst(`RNG_BUS_WIDTH);
+
+    case(test)
+      adaptp_ht: begin
+        // When running in single-channel mode, a single line / counter observes all the trials.
+        // When accumulating all channels into a single score, the number of trials adds up as well.
+        // In contrast, we effectively reduce the number of trials when performing the test on a
+        // per-line basis.
+        n = rng_bit_enable || !per_line ? window_size : window_size / `RNG_BUS_WIDTH;
+        p = 0.5;
+      end
+      bucket_ht: begin
+        // The bucket health test is performed group wise. But the scoring is done at the group
+        // level, i.e., every group does n trials and we don't average across groups.
+        n = window_size / BucketHtDataWidth / NumBucketHtInst;
+        p = 1.0/real'(NumBuckets);
+      end
+      markov_ht: begin
+        // When running in single-channel mode, a single channel observes all the sample pairs.
+        // When accumulating all channels into a single score, the number of pairs adds up.
+        // In contrast, we effectively reduce teh number of pairs when performing the test on a
+        // per-line basis.
+        n = rng_bit_enable || !per_line ? window_size / 2 : window_size / 2 / `RNG_BUS_WIDTH;
+        p = 0.5;
+      end
+      default: begin
+        `dv_fatal("Invalid test!", "entropy_src_env_pkg::ideal_threshold_recommendation")
+      end
+    endcase
+
+    // The RNG sequence is assumed to be uniformly distributed at random. According to the central
+    // limit theorem (CLT), the distributions of the inidividual health tests converge to normal or
+    // rather binomial distributions (as we're dealing with discrete variables) under appropriate
+    // conditions (such as the health test window being sufficiently large).
+    //
+    // For binomial distributions, the mean and standard deviation can be approximated as follows
+    // (see https://en.wikipedia.org/wiki/Binomial_distribution#Normal_approximation):
+    mean   = p * n;
+    stddev = $sqrt(p * (1 - p) * n);
+
+    return;
+  endfunction
+
   //
   // Helper function: ideal_threshold_recommendation
   //
@@ -267,6 +323,8 @@ package entropy_src_env_pkg;
   // health_test_e test: the test to consider (adaptp_ht, bucket_ht, or markov_ht)
   // bit       per_line: set to 1 if the test is being evaluated on a per_line basis
   //                     (if 0, the range applies if the results are summed over all RNG lines)
+  // bit rng_bit_enable: set to 1 if single-channel mode is enabled
+  //                     (if 0, all channels of the RNG noise source are used)
   // which_ht_e  hi_low: which threshold to calculate, upper or lower.
   // real desired_sigma: the number of standard deviations to provide within the range.  Assuming
   //                     the window size is large enough to treat the test as normally distributed,
@@ -313,33 +371,14 @@ package entropy_src_env_pkg;
   // from the tabled values particularly for smaller window sizes and at higher sigma values.
 
   function automatic int ideal_threshold_recommendation(int window_size, health_test_e test,
-                                                        bit per_line, which_ht_e hi_low,
-                                                        real desired_sigma);
+                                                        bit per_line, bit rng_bit_enable,
+                                                        which_ht_e hi_low, real desired_sigma);
     int n;
     real p, mean, stddev;
     int result, upper_threshold, lower_threshold;
     string msg;
 
-    case(test)
-      adaptp_ht: begin
-        // number of trials is equal to number of bits, either in the whole window or per line
-        n = per_line ? (window_size / `RNG_BUS_WIDTH) : window_size;
-        p = 0.5;
-      end
-      bucket_ht: begin
-        n = (window_size / `RNG_BUS_WIDTH);
-        p = 1.0/real'(1 << `RNG_BUS_WIDTH);
-      end
-      markov_ht: begin
-        n = per_line ? (window_size / `RNG_BUS_WIDTH / 2) : window_size / 2;
-        p = 0.5;
-      end
-      default: begin
-        `dv_fatal("Invalid test!", "entropy_src_env_pkg::ideal_threshold_recommendation")
-      end
-    endcase
-    mean   = p * n;
-    stddev = $sqrt(p * (1 - p) * n);
+    approximate_distribution(window_size, test, per_line, rng_bit_enable, n, p, mean, stddev);
 
     lower_threshold = (test == bucket_ht) ? 0 : $floor(mean - desired_sigma * stddev);
     upper_threshold = $ceil(mean + desired_sigma * stddev);
@@ -356,6 +395,7 @@ package entropy_src_env_pkg;
         $sformatf("window_size: %d\n", window_size),
         $sformatf("test: %s\n", test.name()),
         $sformatf("per_line: %d\n", per_line),
+        $sformatf("rng_bit_enable: %d\n", rng_bit_enable),
         $sformatf("high or low: %s\n", hi_low.name()),
         $sformatf("desired sigma: %f\n", desired_sigma),
         $sformatf("n: %d, p: %f\n", n, p),
@@ -376,32 +416,13 @@ package entropy_src_env_pkg;
   // coverpoints. This function is effectively the inverse of ideal_threshold_recommendation.
   //
   function automatic real ideal_threshold_to_sigma(int window_size, health_test_e test,
-                                                  bit per_line, which_ht_e hi_low,
-                                                  int actual_threshold);
+                                                  bit per_line, bit rng_bit_enable,
+                                                  which_ht_e hi_low, int actual_threshold);
     int n;
     real p, mean, stddev;
     real result, offset;
 
-    case(test)
-      adaptp_ht: begin
-        // number of trials is equal to number of bits, either in the whole window or per line
-        n = per_line ? (window_size / `RNG_BUS_WIDTH) : window_size;
-        p = 0.5;
-      end
-      bucket_ht: begin
-        n = (window_size / `RNG_BUS_WIDTH);
-        p = 1.0/real'(1 << `RNG_BUS_WIDTH);
-      end
-      markov_ht: begin
-        n = per_line ? (window_size / `RNG_BUS_WIDTH / 2) : window_size / 2;
-        p = 0.5;
-      end
-      default: begin
-        `dv_fatal("Invalid test!", "entropy_src_env_pkg::ideal_threshold_recommendation")
-      end
-    endcase
-    mean   = p * n;
-    stddev = $sqrt(p * (1 - p) * n);
+    approximate_distribution(window_size, test, per_line, rng_bit_enable, n, p, mean, stddev);
 
     offset = actual_threshold - mean;
 

--- a/hw/ip/entropy_src/dv/env/entropy_src_path_if.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_path_if.sv
@@ -8,8 +8,6 @@
     tb.dut.u_entropy_src_core
 `define REPCNT \
     u_entropy_src_repcnt_ht.u_prim_max_tree_rep_cntr_max
-`define BUCKET \
-    u_entropy_src_bucket_ht.u_prim_max_tree_bin_cntr_max
 
 interface entropy_src_path_if ();
   import uvm_pkg::*;
@@ -116,4 +114,3 @@ endinterface // entropy_src_path_if
 
 `undef CORE
 `undef REPCNT
-`undef BUCKET

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -361,7 +361,6 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
     parameter int unsigned NumBucketHtInst = entropy_src_pkg::num_bucket_ht_inst(`RNG_BUS_WIDTH);
 
     bucket_test_result result;
-    int sum = 0;
     int buckets [][];
 
     // Init 2D array
@@ -705,8 +704,8 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
 
   function bit evaluate_bucket_test(queue_of_rng_val_t window, bit fips_mode);
     bucket_test_result test_result;
+    int max_value;
     int value;
-    int sum = 0;
     bit fail;
     bit any_fail = 0;
     int threshold;
@@ -727,11 +726,8 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
     sigma = ideal_threshold_to_sigma(window_size_scaled, bucket_ht, 0, high_test, threshold);
 
     test_result = calc_bucket_test(window);
-
-    for (int i = 0; i < test_result.size(); i++) begin
-      sum = sum + test_result[i];
-    end
-    update_watermark("bucket", fips_mode, sum);
+    max_value = test_result.max()[0];
+    update_watermark("bucket", fips_mode, max_value);
 
     for (int i = 0; i < test_result.size(); i++) begin
       value = test_result[i];

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_rng_seq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_rng_seq.sv
@@ -150,6 +150,8 @@ class entropy_src_base_rng_seq extends push_pull_indefinite_host_seq#(
   // test_e        test: the test to consider (AdaptP, Bucket, or Markov)
   // bit       per_line: set to 1 if the test is being evaluated on a per_line basis
   //                     (if 0, the range applies if the results are summed over all RNG lines)
+  // bit rng_bit_enable: set to 1 if single-channel mode is enabled
+  //                     (if 0, all channels of the RNG noise source are used)
   // real desired_sigma: the number of standard deviations to provide within the range.  Assuming
   //                     the window size is large enough to treat the test as normally distributed,
   //                     the probability of the test within the range increases with the number of
@@ -170,12 +172,12 @@ class entropy_src_base_rng_seq extends push_pull_indefinite_host_seq#(
 
 
   virtual function void threshold_rec(int window_size, health_test_e test, bit per_line,
-                                      real desired_sigma, output int lower_threshold,
-                                      output int upper_threshold);
-    lower_threshold = ideal_threshold_recommendation(window_size, test, per_line, low_test,
-                                                     desired_sigma);
-    upper_threshold = ideal_threshold_recommendation(window_size, test, per_line, high_test,
-                                                     desired_sigma);
+                                      bit rng_bit_enable, real desired_sigma,
+                                      output int lower_threshold, output int upper_threshold);
+    lower_threshold = ideal_threshold_recommendation(window_size, test, per_line, rng_bit_enable,
+                                                     low_test, desired_sigma);
+    upper_threshold = ideal_threshold_recommendation(window_size, test, per_line, rng_bit_enable,
+                                                     high_test, desired_sigma);
   endfunction
 
 endclass

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_err_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_err_vseq.sv
@@ -30,8 +30,6 @@
     u_sha3.u_keccak.u_round_count
 `define REPCNT \
     u_entropy_src_repcnt_ht.u_prim_max_tree_rep_cntr_max
-`define BUCKET \
-    u_entropy_src_bucket_ht.u_prim_max_tree_bin_cntr_max
 
 class entropy_src_err_vseq extends entropy_src_base_vseq;
   `uvm_object_utils(entropy_src_err_vseq)
@@ -167,7 +165,7 @@ class entropy_src_err_vseq extends entropy_src_base_vseq;
         fld = csr.get_field_by_name(fld_name);
 
         foreach (path_exts[i]) begin
-          fifo_forced_paths[i] = cfg.entropy_src_path_vif.fifo_err_path("sfifo_esrng",
+          fifo_forced_paths[i] = cfg.entropy_src_path_vif.fifo_err_path(fifo_name,
                                                                         path_exts[i]);
         end
         force_fifo_err(path1, path2, value1, value2, fld, 1'b1);

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_err_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_err_vseq.sv
@@ -180,10 +180,9 @@ class entropy_src_err_vseq extends entropy_src_base_vseq;
 
         fld = csr.get_field_by_name({cfg.which_fifo.name(), "_err"});
         force_path_err(path, value, fld, 1'b1);
-        // TODO(#23988): uncomment the following lines.
-        // // Additionally check if FIFO_STATE_ERR is set.
-        // fld = csr.get_field_by_name("fifo_state_err");
-        // csr_rd_check(.ptr(fld), .compare_value(1'b1));
+        // Additionally check if FIFO_STATE_ERR is set.
+        fld = csr.get_field_by_name("fifo_state_err");
+        csr_rd_check(.ptr(fld), .compare_value(1'b1));
         cov_vif.cg_fifo_err_sample(cfg.which_fifo_err, cfg.which_fifo);
       end
       sfifo_esrng_err_test, sfifo_distr_err_test, sfifo_observe_err_test, sfifo_esfinal_err_test,

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -289,7 +289,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic                    bucket_bypass_threshold_wr;
   logic [HalfRegWidth-1:0] bucket_threshold;
   logic [NumBucketHtInst-1:0][HalfRegWidth-1:0] bucket_event_cnt;
-  logic [HalfRegWidth-1:0] bucket_event_cnt_combined;
+  logic [HalfRegWidth-1:0] bucket_event_cnt_max;
   logic [HalfRegWidth-1:0] bucket_event_hwm_fips;
   logic [HalfRegWidth-1:0] bucket_event_hwm_bypass;
   logic [FullRegWidth-1:0] bucket_total_fails;
@@ -1895,13 +1895,30 @@ module entropy_src_core import entropy_src_pkg::*; #(
     );
   end
 
-  // Add all partial errors to be consumed by the watermark registers
+  // Extract the maximum bin counter value from all NumBucketHtInst groups of BucketHtDataWidth
+  // channels.
+  if (NumBucketHtInst > 1) begin : gen_bucket_max_tree
+    prim_max_tree #(
+      .NumSrc(NumBucketHtInst),
+      .Width(HalfRegWidth)
+    ) u_prim_max_tree_bin_cntr_max (
+      .clk_i,
+      .rst_ni,
+      .values_i   (bucket_event_cnt),
+      .valid_i    ({NumBucketHtInst{1'b1}}),
+      .max_value_o(bucket_event_cnt_max),
+      .max_idx_o  (),
+      .max_valid_o()
+    );
+  end else begin : gen_no_bucket_max_tree
+    assign bucket_event_cnt_max = bucket_event_cnt[0];
+  end
+
+  // Add the failure pulses from all NumBucketHtInst groups.
   always_comb begin
-    bucket_event_cnt_combined = 0;
-    bucket_fail_pulse_step    = 0;
+    bucket_fail_pulse_step = 0;
     for (int i = 0; i < NumBucketHtInst; i++) begin
-      bucket_event_cnt_combined += bucket_event_cnt[i];
-      bucket_fail_pulse_step    += bucket_fail_pulse[i];
+      bucket_fail_pulse_step += bucket_fail_pulse[i];
     end
   end
 
@@ -1926,7 +1943,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .rst_ni              (rst_ni),
     .clear_i             (health_test_clr),
     .event_i             (health_test_done_pulse && !es_bypass_mode),
-    .value_i             (bucket_event_cnt_combined),
+    .value_i             (bucket_event_cnt_max),
     .value_o             (bucket_event_hwm_fips)
   );
 
@@ -1938,7 +1955,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .rst_ni              (rst_ni),
     .clear_i             (health_test_clr),
     .event_i             (health_test_done_pulse && es_bypass_mode),
-    .value_i             (bucket_event_cnt_combined),
+    .value_i             (bucket_event_cnt_max),
     .value_o             (bucket_event_hwm_bypass)
   );
 

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -950,16 +950,19 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign fifo_write_err_sum =
          sfifo_esrng_err[2] ||
          sfifo_observe_err[2] ||
+         sfifo_distr_err[2] ||
          sfifo_esfinal_err[2] ||
          err_code_test_bit[28];
   assign fifo_read_err_sum =
          sfifo_esrng_err[1] ||
          sfifo_observe_err[1] ||
+         sfifo_distr_err[1] ||
          sfifo_esfinal_err[1] ||
          err_code_test_bit[29];
   assign fifo_status_err_sum =
          sfifo_esrng_err[0] ||
          sfifo_observe_err[0] ||
+         sfifo_distr_err[0] ||
          sfifo_esfinal_err[0] ||
          err_code_test_bit[30];
 


### PR DESCRIPTION
This PR contains two main changes:

1) an RTL change to take the max bin count value of all Bucket test instances (rather than summing the max bin counts of the individual instances up as before), 

2) a DV and tooling change to correct the threshold computation. Previously, most health tests continuously failed in the rng and the rng_max_rate tests which is bad for coverage.