### PR TITLE
[sw,e2e] Add SRAM execution owner config testcases

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/test_owner.c
+++ b/sw/device/silicon_creator/lib/ownership/test_owner.c
@@ -71,6 +71,10 @@
   (owner_keydata_t) { .ecdsa = UNLOCK_ECDSA_P256 }
 #endif
 
+#ifndef TEST_OWNER_SRAM_EXEC_MODE
+#define TEST_OWNER_SRAM_EXEC_MODE kOwnerSramExecModeDisabledLocked
+#endif
+
 // The following preprocessor symbols are only relevant when
 // WITH_RESCUE_PROTOCOL is defined.
 #ifndef WITH_RESCUE_GPIO_PARAM
@@ -121,7 +125,7 @@ rom_error_t sku_creator_owner_init(boot_data_t *bootdata) {
   owner_page[0].header.length = 2048;
   owner_page[0].header.version = (struct_version_t){0, 0};
   owner_page[0].config_version = TEST_OWNER_CONFIG_VERSION;
-  owner_page[0].sram_exec_mode = kOwnerSramExecModeDisabledLocked;
+  owner_page[0].sram_exec_mode = TEST_OWNER_SRAM_EXEC_MODE;
   owner_page[0].ownership_key_alg = TEST_OWNER_KEY_ALG;
   owner_page[0].update_mode = TEST_OWNER_UPDATE_MODE;
   owner_page[0].min_security_version_bl0 = UINT32_MAX;

--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -52,6 +52,18 @@ TEST_OWNER_CONFIGS = {
         "owner_defines": ["TEST_OWNER_UPDATE_MODE=kOwnershipUpdateModeNewVersion"],
         "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_xmodem"],
     },
+    "owner_sram_exec_enabled": {
+        "owner_defines": [
+            "TEST_OWNER_SRAM_EXEC_MODE=kOwnerSramExecModeEnabled",
+        ],
+        "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_xmodem"],
+    },
+    "owner_sram_exec_disabled": {
+        "owner_defines": [
+            "TEST_OWNER_SRAM_EXEC_MODE=kOwnerSramExecModeDisabled",
+        ],
+        "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_xmodem"],
+    },
     "usbdfu": {
         # Enable USB-DFU triggered by SW_STRAPS value 3.
         "owner_defines": [

--- a/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
@@ -135,6 +135,57 @@ opentitan_test(
     ],
 )
 
+SRAM_EXEC_TESTCASES = [
+    {
+        "name": "enabled",
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_sram_exec_enabled",
+        "exit_success": "value = 00000006, 00000006, 00000001[\\s\\S]*PASS!",
+    },
+    {
+        "name": "disabled",
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_sram_exec_disabled",
+        "exit_success": "value = 00000009, 00000006, 00000001[\\s\\S]*PASS!",
+    },
+    {
+        "name": "disabled_locked",
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_virtual",
+        "exit_success": "value = 00000009, 00000009, 00000000[\\s\\S]*MCAUSE=00000001",
+    },
+]
+
+[
+    opentitan_test(
+        name = "sram_exec_{}_test".format(test["name"]),
+        srcs = ["sram_exec_test.c"],
+        exec_env = {
+            "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+            "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+        },
+        fpga = fpga_params(
+            changes_otp = True,
+            exit_success = test["exit_success"],
+            rom_ext = test["rom_ext"],
+            test_cmd = """
+                --exec="transport init"
+                --exec="fpga clear-bitstream"
+                --exec="fpga load-bitstream {bitstream}"
+                --exec="bootstrap --clear-uart=true {firmware}"
+                --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+                no-op
+            """,
+        ),
+        linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
+        deps = [
+            "//hw/ip/sram_ctrl/data:sram_ctrl_c_regs",
+            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//sw/device/lib/base:abs_mmio",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib:dbg_print",
+        ],
+    )
+    for test in SRAM_EXEC_TESTCASES
+]
+
 opentitan_test(
     name = "rom_ext_device_status_test",
     srcs = ["//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test"],

--- a/sw/device/silicon_creator/rom_ext/e2e/handoff/sram_exec_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/handoff/sram_exec_test.c
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/dbg_print.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+#include "sram_ctrl_regs.h"                           // Generated.
+
+OTTF_DEFINE_TEST_CONFIG();
+
+enum {
+  kBase = TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR,
+};
+
+int test_stub(void) { return 0x42; }
+
+// SRAM copy of `test_stub` bytecodes.
+uint32_t test_stub_sram[32];
+
+bool test_main(void) {
+  // Try to enable SRAM_EXEC
+  uint32_t reg_before = abs_mmio_read32(kBase + SRAM_CTRL_EXEC_REG_OFFSET);
+  uint32_t reg_wen = abs_mmio_read32(kBase + SRAM_CTRL_EXEC_REGWEN_REG_OFFSET);
+  abs_mmio_write32(kBase + SRAM_CTRL_EXEC_REG_OFFSET, kMultiBitBool4True);
+  uint32_t reg_after = abs_mmio_read32(kBase + SRAM_CTRL_EXEC_REG_OFFSET);
+  dbg_printf("value = %x, %x, %x\r\n", reg_before, reg_after, reg_wen);
+
+  // Try to execute code on SRAM.
+  memcpy(test_stub_sram, test_stub, sizeof(test_stub_sram));
+  int result = ((int (*)(void))test_stub_sram)();
+
+  return result == 0x42;
+}


### PR DESCRIPTION
This change adds an end-to-end test for SRAM execution mode owner config switches.

The test verifies that the SRAM execution mode can be enabled, disabled, and disabled+locked.