### PR TITLE
[OtpMemImg] Don't hard-code partitions for alignment and SW header skip

### DIFF
--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -1496,6 +1496,7 @@
             integrity: false
             bkout_type: false
             zeroizable: false
+            skip_sw_header: true
             items:
             [
               {
@@ -3093,6 +3094,7 @@
             integrity: true
             bkout_type: true
             zeroizable: false
+            skip_sw_header: true
             items:
             [
               {
@@ -3154,6 +3156,7 @@
             integrity: true
             bkout_type: true
             zeroizable: false
+            skip_sw_header: true
             items:
             [
               {
@@ -3255,6 +3258,7 @@
             integrity: true
             bkout_type: false
             zeroizable: true
+            skip_sw_header: true
             items:
             [
               {
@@ -3325,6 +3329,7 @@
             integrity: true
             bkout_type: false
             zeroizable: true
+            skip_sw_header: true
             items:
             [
               {
@@ -3384,6 +3389,7 @@
             integrity: true
             bkout_type: false
             zeroizable: true
+            skip_sw_header: true
             items:
             [
               {
@@ -3476,6 +3482,7 @@
             integrity: true
             bkout_type: false
             zeroizable: true
+            skip_sw_header: true
             items:
             [
               {
@@ -3534,6 +3541,7 @@
             key_sel: NoKey
             integrity: true
             bkout_type: false
+            skip_sw_header: true
             items:
             [
               {

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.secrets.testing.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.secrets.testing.gen.hjson
@@ -849,6 +849,7 @@
             integrity: false
             bkout_type: false
             zeroizable: false
+            skip_sw_header: true
             items:
             [
               {
@@ -2446,6 +2447,7 @@
             integrity: true
             bkout_type: true
             zeroizable: false
+            skip_sw_header: true
             items:
             [
               {
@@ -2507,6 +2509,7 @@
             integrity: true
             bkout_type: true
             zeroizable: false
+            skip_sw_header: true
             items:
             [
               {
@@ -2608,6 +2611,7 @@
             integrity: true
             bkout_type: false
             zeroizable: true
+            skip_sw_header: true
             items:
             [
               {
@@ -2678,6 +2682,7 @@
             integrity: true
             bkout_type: false
             zeroizable: true
+            skip_sw_header: true
             items:
             [
               {
@@ -2737,6 +2742,7 @@
             integrity: true
             bkout_type: false
             zeroizable: true
+            skip_sw_header: true
             items:
             [
               {
@@ -2829,6 +2835,7 @@
             integrity: true
             bkout_type: false
             zeroizable: true
+            skip_sw_header: true
             items:
             [
               {
@@ -2887,6 +2894,7 @@
             key_sel: NoKey
             integrity: true
             bkout_type: false
+            skip_sw_header: true
             items:
             [
               {

--- a/hw/top_darjeeling/data/otp/otp_ctrl_mmap.hjson
+++ b/hw/top_darjeeling/data/otp/otp_ctrl_mmap.hjson
@@ -65,18 +65,19 @@
     // Note that the digest items are added automatically to the address map.
     partitions: [
         {
-            name:       "VENDOR_TEST",
-            variant:    "Unbuffered",
-            absorb:     false,
-            secret:     false,
-            sw_digest:  true,
-            hw_digest:  false,
-            write_lock: "Digest",
-            read_lock:  "CSR",
-            key_sel:    "NoKey",
-            integrity:  false, // Do not use integrity (ECC) on this partition.
-            bkout_type: false, // Do not generate a breakout type for this partition.
-            zeroizable: false
+            name:           "VENDOR_TEST",
+            variant:        "Unbuffered",
+            absorb:         false,
+            secret:         false,
+            sw_digest:      true,
+            hw_digest:      false,
+            write_lock:     "Digest",
+            read_lock:      "CSR",
+            key_sel:        "NoKey",
+            integrity:      false, // Do not use integrity (ECC) on this partition.
+            bkout_type:     false, // Do not generate a breakout type for this partition.
+            zeroizable:     false,
+            skip_sw_header: true,
             items: [
                 {
                     name: "SCRATCH",
@@ -846,17 +847,18 @@
             '''
         }
         {
-            name:       "HW_CFG0",
-            variant:    "Buffered",
-            secret:     false,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "None",
-            key_sel:    "NoKey",
-            integrity:  true,
-            bkout_type: true,
-            zeroizable: false,
+            name:           "HW_CFG0",
+            variant:        "Buffered",
+            secret:         false,
+            sw_digest:      false,
+            hw_digest:      true,
+            write_lock:     "Digest",
+            read_lock:      "None",
+            key_sel:        "NoKey",
+            integrity:      true,
+            bkout_type:     true,
+            zeroizable:     false,
+            skip_sw_header: true,
             items: [
                 {
                     name:        "DEVICE_ID",
@@ -879,17 +881,18 @@
             '''
         }
         {
-            name:       "HW_CFG1",
-            variant:    "Buffered",
-            secret:     false,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "None",
-            key_sel:    "NoKey",
-            integrity:  true,
-            bkout_type: true,
-            zeroizable: false,
+            name:           "HW_CFG1",
+            variant:        "Buffered",
+            secret:         false,
+            sw_digest:      false,
+            hw_digest:      true,
+            write_lock:     "Digest",
+            read_lock:      "None",
+            key_sel:        "NoKey",
+            integrity:      true,
+            bkout_type:     true,
+            zeroizable:     false,
+            skip_sw_header: true,
             items: [
                 {
                     name:        "SOC_DBG_STATE",
@@ -942,17 +945,18 @@
             '''
         }
         {
-            name:       "SECRET0",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "Secret0Key",
-            integrity:  true,
-            bkout_type: false,
-            zeroizable: true,
+            name:           "SECRET0",
+            variant:        "Buffered",
+            secret:         true,
+            sw_digest:      false,
+            hw_digest:      true,
+            write_lock:     "Digest",
+            read_lock:      "Digest",
+            key_sel:        "Secret0Key",
+            integrity:      true,
+            bkout_type:     false,
+            zeroizable:     true,
+            skip_sw_header: true,
             items: [
                 {
                     name: "TEST_UNLOCK_TOKEN",
@@ -973,17 +977,18 @@
             '''
         }
         {
-            name:       "SECRET1",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "Secret1Key",
-            integrity:  true,
-            bkout_type: false,
-            zeroizable: true,
+            name:           "SECRET1",
+            variant:        "Buffered",
+            secret:         true,
+            sw_digest:      false,
+            hw_digest:      true,
+            write_lock:     "Digest",
+            read_lock:      "Digest",
+            key_sel:        "Secret1Key",
+            integrity:      true,
+            bkout_type:     false,
+            zeroizable:     true,
+            skip_sw_header: true,
             items: [
                    {
                     name: "SRAM_DATA_KEY_SEED",
@@ -996,17 +1001,18 @@
             '''
         }
         {
-            name:       "SECRET2",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "Secret2Key",
-            integrity:  true,
-            bkout_type: false,
-            zeroizable: true,
+            name:           "SECRET2",
+            variant:        "Buffered",
+            secret:         true,
+            sw_digest:      false,
+            hw_digest:      true,
+            write_lock:     "Digest",
+            read_lock:      "Digest",
+            key_sel:        "Secret2Key",
+            integrity:      true,
+            bkout_type:     false,
+            zeroizable:     true,
+            skip_sw_header: true,
             items: [
                 {
                     name: "RMA_TOKEN",
@@ -1037,17 +1043,18 @@
             '''
         }
         {
-            name:       "SECRET3",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "Secret3Key",
-            integrity:  true,
-            bkout_type: false,
-            zeroizable: true,
+            name:           "SECRET3",
+            variant:        "Buffered",
+            secret:         true,
+            sw_digest:      false,
+            hw_digest:      true,
+            write_lock:     "Digest",
+            read_lock:      "Digest",
+            key_sel:        "Secret3Key",
+            integrity:      true,
+            bkout_type:     false,
+            zeroizable:     true,
+            skip_sw_header: true,
             items: [
                 {
                     name: "OWNER_SEED",
@@ -1061,16 +1068,17 @@
             '''
         }
         {
-            name:       "LIFE_CYCLE",
-            variant:    "LifeCycle",
-            secret:     false,
-            sw_digest:  false,
-            hw_digest:  false,
-            write_lock: "None",
-            read_lock:  "None",
-            key_sel:    "NoKey",
-            integrity:  true,
-            bkout_type: false,
+            name:           "LIFE_CYCLE",
+            variant:        "LifeCycle",
+            secret:         false,
+            sw_digest:      false,
+            hw_digest:      false,
+            write_lock:     "None",
+            read_lock:      "None",
+            key_sel:        "NoKey",
+            integrity:      true,
+            bkout_type:     false,
+            skip_sw_header: true,
             items: [
                 // The life cycle transition count is specified
                 // first such that any programming attempt of the life cycle

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/data/top_darjeeling_otp_ctrl.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/data/top_darjeeling_otp_ctrl.ipconfig.hjson
@@ -70,6 +70,7 @@
           integrity: false
           bkout_type: false
           zeroizable: false
+          skip_sw_header: true
           items:
           [
             {
@@ -1667,6 +1668,7 @@
           integrity: true
           bkout_type: true
           zeroizable: false
+          skip_sw_header: true
           items:
           [
             {
@@ -1728,6 +1730,7 @@
           integrity: true
           bkout_type: true
           zeroizable: false
+          skip_sw_header: true
           items:
           [
             {
@@ -1829,6 +1832,7 @@
           integrity: true
           bkout_type: false
           zeroizable: true
+          skip_sw_header: true
           items:
           [
             {
@@ -1899,6 +1903,7 @@
           integrity: true
           bkout_type: false
           zeroizable: true
+          skip_sw_header: true
           items:
           [
             {
@@ -1958,6 +1963,7 @@
           integrity: true
           bkout_type: false
           zeroizable: true
+          skip_sw_header: true
           items:
           [
             {
@@ -2050,6 +2056,7 @@
           integrity: true
           bkout_type: false
           zeroizable: true
+          skip_sw_header: true
           items:
           [
             {
@@ -2108,6 +2115,7 @@
           key_sel: NoKey
           integrity: true
           bkout_type: false
+          skip_sw_header: true
           items:
           [
             {

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2161,6 +2161,7 @@
             key_sel: NoKey
             integrity: false
             bkout_type: false
+            skip_sw_header: true
             items:
             [
               {
@@ -3793,6 +3794,7 @@
             key_sel: NoKey
             integrity: true
             bkout_type: true
+            skip_sw_header: true
             items:
             [
               {
@@ -3863,6 +3865,7 @@
             key_sel: NoKey
             integrity: true
             bkout_type: true
+            skip_sw_header: true
             items:
             [
               {
@@ -3954,6 +3957,7 @@
             key_sel: Secret0Key
             integrity: true
             bkout_type: false
+            skip_sw_header: true
             items:
             [
               {
@@ -4013,6 +4017,7 @@
             key_sel: Secret1Key
             integrity: true
             bkout_type: false
+            skip_sw_header: true
             items:
             [
               {
@@ -4083,6 +4088,7 @@
             key_sel: Secret2Key
             integrity: true
             bkout_type: false
+            skip_sw_header: true
             items:
             [
               {
@@ -4153,6 +4159,7 @@
             key_sel: NoKey
             integrity: true
             bkout_type: false
+            skip_sw_header: true
             items:
             [
               {

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.secrets.testing.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.secrets.testing.gen.hjson
@@ -804,6 +804,7 @@
             key_sel: NoKey
             integrity: false
             bkout_type: false
+            skip_sw_header: true
             items:
             [
               {
@@ -2436,6 +2437,7 @@
             key_sel: NoKey
             integrity: true
             bkout_type: true
+            skip_sw_header: true
             items:
             [
               {
@@ -2506,6 +2508,7 @@
             key_sel: NoKey
             integrity: true
             bkout_type: true
+            skip_sw_header: true
             items:
             [
               {
@@ -2597,6 +2600,7 @@
             key_sel: Secret0Key
             integrity: true
             bkout_type: false
+            skip_sw_header: true
             items:
             [
               {
@@ -2656,6 +2660,7 @@
             key_sel: Secret1Key
             integrity: true
             bkout_type: false
+            skip_sw_header: true
             items:
             [
               {
@@ -2726,6 +2731,7 @@
             key_sel: Secret2Key
             integrity: true
             bkout_type: false
+            skip_sw_header: true
             items:
             [
               {
@@ -2796,6 +2802,7 @@
             key_sel: NoKey
             integrity: true
             bkout_type: false
+            skip_sw_header: true
             items:
             [
               {

--- a/hw/top_earlgrey/data/otp/otp_ctrl_mmap.hjson
+++ b/hw/top_earlgrey/data/otp/otp_ctrl_mmap.hjson
@@ -70,16 +70,17 @@
     // Note that the digest items are added automatically to the address map.
     partitions: [
         {
-            name:       "VENDOR_TEST",
-            variant:    "Unbuffered",
-            secret:     false,
-            sw_digest:  true,
-            hw_digest:  false,
-            write_lock: "Digest",
-            read_lock:  "CSR",
-            key_sel:    "NoKey",
-            integrity:  false, // Do not use integrity (ECC) on this partition.
-            bkout_type: false, // Do not generate a breakout type for this partition.
+            name:           "VENDOR_TEST",
+            variant:        "Unbuffered",
+            secret:         false,
+            sw_digest:      true,
+            hw_digest:      false,
+            write_lock:     "Digest",
+            read_lock:      "CSR",
+            key_sel:        "NoKey",
+            integrity:      false, // Do not use integrity (ECC) on this partition.
+            bkout_type:     false, // Do not generate a breakout type for this partition.
+            skip_sw_header: true,
             items: [
                 {
                     name: "SCRATCH",
@@ -949,16 +950,17 @@
                          '''
         }
         {
-            name:       "HW_CFG0",
-            variant:    "Buffered",
-            secret:     false,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "None",
-            key_sel:    "NoKey",
-            integrity:  true,
-            bkout_type: true,
+            name:           "HW_CFG0",
+            variant:        "Buffered",
+            secret:         false,
+            sw_digest:      false,
+            hw_digest:      true,
+            write_lock:     "Digest",
+            read_lock:      "None",
+            key_sel:        "NoKey",
+            integrity:      true,
+            bkout_type:     true,
+            skip_sw_header: true,
             items: [
                 {
                     name:        "DEVICE_ID",
@@ -988,16 +990,17 @@
             '''
         }
         {
-            name:       "HW_CFG1",
-            variant:    "Buffered",
-            secret:     false,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "None",
-            key_sel:    "NoKey",
-            integrity:  true,
-            bkout_type: true,
+            name:           "HW_CFG1",
+            variant:        "Buffered",
+            secret:         false,
+            sw_digest:      false,
+            hw_digest:      true,
+            write_lock:     "Digest",
+            read_lock:      "None",
+            key_sel:        "NoKey",
+            integrity:      true,
+            bkout_type:     true,
+            skip_sw_header: true,
             items: [
                 {
                     name:        "EN_SRAM_IFETCH",
@@ -1041,16 +1044,17 @@
             '''
         }
         {
-            name:       "SECRET0",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "Secret0Key",
-            integrity:  true,
-            bkout_type: false,
+            name:           "SECRET0",
+            variant:        "Buffered",
+            secret:         true,
+            sw_digest:      false,
+            hw_digest:      true,
+            write_lock:     "Digest",
+            read_lock:      "Digest",
+            key_sel:        "Secret0Key",
+            integrity:      true,
+            bkout_type:     false,
+            skip_sw_header: true,
             items: [
                 {
                     name: "TEST_UNLOCK_TOKEN",
@@ -1071,16 +1075,17 @@
             '''
         }
         {
-            name:       "SECRET1",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "Secret1Key",
-            integrity:  true,
-            bkout_type: false,
+            name:           "SECRET1",
+            variant:        "Buffered",
+            secret:         true,
+            sw_digest:      false,
+            hw_digest:      true,
+            write_lock:     "Digest",
+            read_lock:      "Digest",
+            key_sel:        "Secret1Key",
+            integrity:      true,
+            bkout_type:     false,
+            skip_sw_header: true,
             items: [
                 {
                     name: "FLASH_ADDR_KEY_SEED",
@@ -1103,16 +1108,17 @@
             '''
         }
         {
-            name:       "SECRET2",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "Secret2Key",
-            integrity:  true,
-            bkout_type: false,
+            name:           "SECRET2",
+            variant:        "Buffered",
+            secret:         true,
+            sw_digest:      false,
+            hw_digest:      true,
+            write_lock:     "Digest",
+            read_lock:      "Digest",
+            key_sel:        "Secret2Key",
+            integrity:      true,
+            bkout_type:     false,
+            skip_sw_header: true,
             items: [
                 {
                     name: "RMA_TOKEN",
@@ -1137,16 +1143,17 @@
             '''
         }
         {
-            name:       "LIFE_CYCLE",
-            variant:    "LifeCycle",
-            secret:     false,
-            sw_digest:  false,
-            hw_digest:  false,
-            write_lock: "None",
-            read_lock:  "None",
-            key_sel:    "NoKey",
-            integrity:  true,
-            bkout_type: false,
+            name:           "LIFE_CYCLE",
+            variant:        "LifeCycle",
+            secret:         false,
+            sw_digest:      false,
+            hw_digest:      false,
+            write_lock:     "None",
+            read_lock:      "None",
+            key_sel:        "NoKey",
+            integrity:      true,
+            bkout_type:     false,
+            skip_sw_header: true,
             items: [
                 // The life cycle transition count is specified
                 // first such that any programming attempt of the life cycle

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/data/top_earlgrey_otp_ctrl.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/data/top_earlgrey_otp_ctrl.ipconfig.hjson
@@ -74,6 +74,7 @@
           key_sel: NoKey
           integrity: false
           bkout_type: false
+          skip_sw_header: true
           items:
           [
             {
@@ -1706,6 +1707,7 @@
           key_sel: NoKey
           integrity: true
           bkout_type: true
+          skip_sw_header: true
           items:
           [
             {
@@ -1776,6 +1778,7 @@
           key_sel: NoKey
           integrity: true
           bkout_type: true
+          skip_sw_header: true
           items:
           [
             {
@@ -1867,6 +1870,7 @@
           key_sel: Secret0Key
           integrity: true
           bkout_type: false
+          skip_sw_header: true
           items:
           [
             {
@@ -1926,6 +1930,7 @@
           key_sel: Secret1Key
           integrity: true
           bkout_type: false
+          skip_sw_header: true
           items:
           [
             {
@@ -1996,6 +2001,7 @@
           key_sel: Secret2Key
           integrity: true
           bkout_type: false
+          skip_sw_header: true
           items:
           [
             {
@@ -2066,6 +2072,7 @@
           key_sel: NoKey
           integrity: true
           bkout_type: false
+          skip_sw_header: true
           items:
           [
             {

--- a/util/design/lib/OtpMemImg.py
+++ b/util/design/lib/OtpMemImg.py
@@ -20,9 +20,6 @@ from lib.LcStEnc import LcStEnc
 from lib.OtpMemMap import OtpMemMap
 from lib.Present import Present
 
-_OTP_SW_SKIP_FROM_HEADER = ('VENDOR_TEST', 'HW_CFG0', 'HW_CFG1', 'SECRET0',
-                            'SECRET1', 'SECRET2', 'LIFE_CYCLE')
-
 
 def _present_64bit_encrypt(plain, key):
     '''Scramble a 64bit block with PRESENT cipher'''
@@ -540,7 +537,7 @@ class OtpMemImg(OtpMemMap):
         '''
         data = {}
         for part in self.config['partitions']:
-            if part['name'] in _OTP_SW_SKIP_FROM_HEADER:
+            if part.get('skip_sw_header'):
                 continue
             items = []
             for item in part["items"]:

--- a/util/design/lib/OtpMemImg.py
+++ b/util/design/lib/OtpMemImg.py
@@ -22,17 +22,6 @@ from lib.Present import Present
 
 _OTP_SW_SKIP_FROM_HEADER = ('VENDOR_TEST', 'HW_CFG0', 'HW_CFG1', 'SECRET0',
                             'SECRET1', 'SECRET2', 'LIFE_CYCLE')
-_OTP_SW_WRITE_BYTE_ALIGNMENT = {
-    'CREATOR_SW_CFG': 4,
-    'OWNER_SW_CFG': 4,
-    'HW_CFG0': 4,
-    'HW_CFG1': 4,
-    'ROT_CREATOR_AUTH_CODESIGN': 4,
-    'ROT_CREATOR_AUTH_STATE': 4,
-    'SECRET0': 8,
-    'SECRET1': 8,
-    'SECRET2': 8,
-}
 
 
 def _present_64bit_encrypt(plain, key):
@@ -558,7 +547,9 @@ class OtpMemImg(OtpMemMap):
                 if 'value' not in item.keys():
                     continue
 
-                alignment = _OTP_SW_WRITE_BYTE_ALIGNMENT[part['name']]
+                # Secret partitions connected to the keymgr haven 8-byte alignment, other partitions
+                # have a 4-byte alignment
+                alignment = 8 if common.check_bool(part["secret"]) else 4
 
                 # TODO: Handle aggregation of fields to match write boundary.
                 if item['size'] < alignment:


### PR DESCRIPTION
Add the Darjeeling partitions to the SW skips for generating the C header and make it more generic to support more HWCFG/SECRET partitions.