### PR TITLE
[hw,otp_macro,rtl] otp_macro has a dependency on ast_pkg

### DIFF
--- a/hw/ip/otp_macro/otp_macro.core
+++ b/hw/ip/otp_macro/otp_macro.core
@@ -15,6 +15,7 @@ filesets:
       - lowrisc:ip:otp_macro_pkg
       - lowrisc:virtual_ip:otp_ctrl_macro_pkg
       - lowrisc:virtual_constants:top_racl_pkg
+      - lowrisc:systems:ast_pkg
     files:
       - rtl/otp_macro_reg_pkg.sv
       - rtl/otp_macro_prim_reg_top.sv


### PR DESCRIPTION
Let's add the dependency to the core file.