### PR TITLE
[perso_tlv] Enable obj_type checks

### DIFF
--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
@@ -30,7 +30,8 @@ rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
   PERSO_TLV_GET_FIELD(Objh, Type, objh, &obj_type);
   obj->obj_type = obj_type;
   if (obj_type != kPersoObjectTypeX509Cert &&
-      obj_type != kPersoObjectTypeCwtCert) {
+      obj_type != kPersoObjectTypeCwtCert &&
+      obj_type != kPersoObjectTypeX509Tbs) {
     return kErrorPersoTlvCertObjNotFound;
   }
   buf += sizeof(perso_tlv_object_header_t);


### PR DESCRIPTION
This change expands the valid type checks to include kPersoObjectTypeX509Tbs, matching the recent change in the `earlgrey_1.0.0` branch.

(cherry picked from commit bdd735fd4c4172228b3a8fa939a8315035b80f08)