### PR TITLE
[bazel] Properly select secrets file depending on top and seed config

### DIFF
--- a/hw/top/BUILD
+++ b/hw/top/BUILD
@@ -11,12 +11,13 @@ load(
     "opentitan_ip_rust_header",
     "opentitan_top_dt_api",
 )
+load("//rules/opentitan:hw.bzl", "get_top_attr")
 load(
     "//hw/top:defs.bzl",
     "ALL_IP_NAMES",
+    "ALL_SEED_NAMES",
     "ALL_TOPS",
     "ALL_TOP_NAMES",
-    "ALL_SEED_NAMES",
     "opentitan_alias_top_attr",
     "opentitan_if_ip",
     "opentitan_require_ip",
@@ -81,6 +82,33 @@ opentitan_alias_top_attr(
 opentitan_alias_top_attr(
     name = "top_otp_map",
     attr_name = "otp_map",
+)
+
+# For each top, create a selecting alias for the seed.
+[
+    alias(
+        name = "top_{}_seed_secrets".format(top.name),
+        actual = select({
+            ":is_seed_{}".format(seed): secrets
+            for (seed, secrets) in get_top_attr(top, "secret_cfgs", False, {}).items()
+        }),
+        target_compatible_with = select({
+            ":is_seed_{}".format(seed): []
+            for seed in get_top_attr(top, "secret_cfgs", False, {}).keys()
+        } | {
+            "//conditions:default": ["@platforms//:incompatible"],
+        }),
+    )
+    for top in ALL_TOPS
+]
+
+# Then create an alias overall
+alias(
+    name = "secrets",
+    actual = select({
+        "@lowrisc_opentitan//hw/top:is_{}".format(top): ":top_{}_seed_secrets".format(top)
+        for top in ALL_TOP_NAMES
+    }),
 )
 
 # C register headers for all IPs.

--- a/hw/top/BUILD
+++ b/hw/top/BUILD
@@ -16,6 +16,7 @@ load(
     "ALL_IP_NAMES",
     "ALL_TOPS",
     "ALL_TOP_NAMES",
+    "ALL_SEED_NAMES",
     "opentitan_alias_top_attr",
     "opentitan_if_ip",
     "opentitan_require_ip",
@@ -36,6 +37,13 @@ string_flag(
     values = ALL_TOP_NAMES,
 )
 
+# Use this flag to select the seed.
+string_flag(
+    name = "seed",
+    build_setting_default = "testing",
+    values = ALL_SEED_NAMES,
+)
+
 # Config settings to test against tops.
 [
     config_setting(
@@ -45,6 +53,17 @@ string_flag(
         },
     )
     for top in ALL_TOP_NAMES
+]
+
+# Config settings to test against seeds.
+[
+    config_setting(
+        name = "is_seed_{}".format(seed),
+        flag_values = {
+            ":seed": seed,
+        },
+    )
+    for seed in ALL_SEED_NAMES
 ]
 
 # Point to the right top library.

--- a/hw/top/defs.bzl
+++ b/hw/top/defs.bzl
@@ -23,6 +23,14 @@ def _all_ip_names():
 
 ALL_IP_NAMES = _all_ip_names()
 
+def _all_seed_names():
+    names = {}
+    for top in ALL_TOPS:
+        names.update(top.attrs.get("secret_cfgs", {}))
+    return sorted(names.keys())
+
+ALL_SEED_NAMES = _all_seed_names()
+
 def opentitan_if_ip(ip, obj, default):
     """
     Return a select expression that evaluate to `obj` if the ip is

--- a/hw/top_darjeeling/BUILD
+++ b/hw/top_darjeeling/BUILD
@@ -32,7 +32,6 @@ sim_dv(
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     otp_mmap = "//hw/top_darjeeling/data/otp:otp_ctrl_mmap.hjson",
-    rom_scramble_config = "//hw/top_darjeeling/data/autogen:top_darjeeling.secrets.testing.gen.hjson",
     top_secret_cfg = "//hw/top_darjeeling/data/autogen:top_darjeeling.secrets.testing.gen.hjson",
 )
 

--- a/hw/top_darjeeling/BUILD
+++ b/hw/top_darjeeling/BUILD
@@ -32,7 +32,6 @@ sim_dv(
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     otp_mmap = "//hw/top_darjeeling/data/otp:otp_ctrl_mmap.hjson",
-    top_secret_cfg = "//hw/top_darjeeling/data/autogen:top_darjeeling.secrets.testing.gen.hjson",
 )
 
 sim_dv(

--- a/hw/top_darjeeling/defs.bzl
+++ b/hw/top_darjeeling/defs.bzl
@@ -16,4 +16,7 @@ DARJEELING = opentitan_top(
     std_otp_overlay = DARJEELING_STD_OTP_OVERLAYS,
     otp_sigverify_fake_keys = DARJEELING_OTP_SIGVERIFY_FAKE_KEYS,
     ips = DARJEELING_IPS,
+    secret_cfgs = {
+        "testing": "//hw/top_darjeeling/data/autogen:top_darjeeling.secrets.testing.gen.hjson",
+    },
 )

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -78,7 +78,6 @@ fpga_cw310(
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     test_cmd = "testing-not-supported",
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 fpga_cw310(
@@ -133,7 +132,6 @@ sim_qemu(
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     otp = "//hw/top_earlgrey/data/otp:img_rma",
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 sim_qemu(
@@ -227,7 +225,6 @@ fpga_cw305(
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     test_cmd = "testing-not-supported",
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 ###########################################################################
@@ -261,7 +258,6 @@ fpga_cw340(
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
     test_cmd = "testing-not-supported",
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 fpga_cw340(
@@ -400,7 +396,6 @@ silicon(
         --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
         no-op
     """,
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 silicon(
@@ -443,7 +438,6 @@ silicon(
         --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
         no-op
     """,
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 ###########################################################################
@@ -464,7 +458,6 @@ sim_verilator(
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     otp = "//hw/top_earlgrey/data/otp:img_rma",
     test_cmd = "testing-not-supported",
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 sim_verilator(
@@ -526,7 +519,6 @@ sim_dv(
     otp = "//hw/top_earlgrey/data/otp:img_rma",
     otp_data_perm = "//util/design/data:data_perm",
     otp_mmap = "//hw/top_earlgrey/data/otp:otp_ctrl_mmap.hjson",
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 sim_dv(

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -77,7 +77,6 @@ fpga_cw310(
         "//hw/top_earlgrey/sw/dt:fpga_cw310",
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
-    rom_scramble_config = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     test_cmd = "testing-not-supported",
     top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
@@ -134,7 +133,6 @@ sim_qemu(
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     otp = "//hw/top_earlgrey/data/otp:img_rma",
-    rom_scramble_config = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
@@ -228,7 +226,6 @@ fpga_cw305(
         "//sw/device/lib/arch:fpga_cw305",
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
-    rom_scramble_config = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     test_cmd = "testing-not-supported",
     top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
@@ -263,7 +260,6 @@ fpga_cw340(
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
-    rom_scramble_config = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     test_cmd = "testing-not-supported",
     top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
@@ -398,7 +394,6 @@ silicon(
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
-    rom_scramble_config = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     test_cmd = """
         --exec="transport init"
         --exec="bootstrap --clear-uart=true {firmware}"
@@ -468,7 +463,6 @@ sim_verilator(
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     otp = "//hw/top_earlgrey/data/otp:img_rma",
-    rom_scramble_config = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     test_cmd = "testing-not-supported",
     top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
@@ -532,7 +526,6 @@ sim_dv(
     otp = "//hw/top_earlgrey/data/otp:img_rma",
     otp_data_perm = "//util/design/data:data_perm",
     otp_mmap = "//hw/top_earlgrey/data/otp:otp_ctrl_mmap.hjson",
-    rom_scramble_config = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 

--- a/hw/top_earlgrey/data/otp/BUILD
+++ b/hw/top_earlgrey/data/otp/BUILD
@@ -438,7 +438,6 @@ otp_alert_digest(
 otp_image(
     name = "img_raw",
     src = ":otp_json_raw",
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 [
@@ -453,7 +452,6 @@ otp_image(
             ":otp_json_secret0",
             ":otp_json_creator_sw_cfg_test_unlocked",
         ] + OTP_SIGVERIFY_FAKE_KEYS,
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     )
     for i in range(0, 8)
 ]
@@ -466,7 +464,6 @@ otp_image(
             ":otp_json_secret0",
             ":otp_json_creator_sw_cfg_test_unlocked",
         ],
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     )
     for i in range(0, 7)
 ]
@@ -487,35 +484,30 @@ otp_image(
         ":otp_json_owner_sw_cfg",
         ":otp_json_alert_digest_cfg",
     ] + OTP_SIGVERIFY_FAKE_KEYS,
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 otp_image(
     name = "img_dev",
     src = ":otp_json_dev",
     overlays = STD_OTP_OVERLAYS,
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 otp_image(
     name = "img_prod",
     src = ":otp_json_prod",
     overlays = STD_OTP_OVERLAYS,
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 otp_image(
     name = "img_prod_end",
     src = ":otp_json_prod_end",
     overlays = STD_OTP_OVERLAYS,
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 otp_image(
     name = "img_rma",
     src = ":otp_json_rma",
     overlays = STD_OTP_OVERLAYS,
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 # Create an execution-disabling overlay
@@ -534,7 +526,6 @@ otp_image(
     name = "img_exec_disabled",
     src = ":otp_json_rma",
     overlays = STD_OTP_OVERLAYS + [":otp_json_exec_disabled"],
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 # Create a bootstrap-disabling overlay
@@ -553,7 +544,6 @@ otp_image(
     name = "img_bootstrap_disabled",
     src = ":otp_json_rma",
     overlays = STD_OTP_OVERLAYS + [":otp_json_bootstrap_disabled"],
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 filegroup(

--- a/hw/top_earlgrey/data/otp/emulation/BUILD
+++ b/hw/top_earlgrey/data/otp/emulation/BUILD
@@ -276,7 +276,6 @@ otp_image_consts(
     # Do not add additional overlays here. Update the `MANUF_SW_INITIALIZED`
     # OTP profile instead.
     overlays = MANUF_SW_INITIALIZED + OTP_SIGVERIFY_FAKE_KEYS,
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 # Library containing {CREATOR,OWNER}_SW_CFG and
@@ -298,7 +297,6 @@ cc_library(
 otp_image(
     name = "otp_img_test_unlocked0_manuf_empty",
     src = "//hw/top_earlgrey/data/otp:otp_json_test_unlocked0",
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 # `MANUF_INITIALIZED` configuration. This configuration will be generally used
@@ -308,7 +306,6 @@ otp_image(
     name = "otp_img_test_locked0_manuf_initialized",
     src = "//hw/top_earlgrey/data/otp:otp_json_test_locked0",
     overlays = MANUF_INITIALIZED,
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 # `MANUF_INITIALIZED` OTP configuration. Available on TEST_UNLOCK states 1-7.
@@ -318,7 +315,6 @@ otp_image(
         name = "otp_img_test_unlocked{}_manuf_initialized".format(i),
         src = "//hw/top_earlgrey/data/otp:otp_json_test_unlocked{}".format(i),
         overlays = MANUF_INITIALIZED,
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     )
     for i in range(1, 8)
 ]
@@ -333,7 +329,6 @@ otp_image(
         name = "otp_img_{}_manuf_individualized".format(lc_state),
         src = "//hw/top_earlgrey/data/otp:otp_json_{}".format(lc_state),
         overlays = MANUF_INDIVIDUALIZED,
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     )
     for lc_state, _ in get_lc_items(
         CONST.LCV.TEST_UNLOCKED1,
@@ -357,7 +352,6 @@ otp_image(
         name = "otp_img_{}_manuf_personalized".format(lc_state),
         src = "//hw/top_earlgrey/data/otp:otp_json_{}".format(lc_state),
         overlays = MANUF_PERSONALIZED,
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     )
     for lc_state, _ in LC_MISSION_STATES
 ]
@@ -366,7 +360,6 @@ otp_image(
     name = "otp_img_dev_manuf_personalized_enable_rv_dm_late_debug_enable",
     src = "//hw/top_earlgrey/data/otp:otp_json_dev",
     overlays = MANUF_PERSONALIZED + [":otp_json_hw_cfg1_enable_rv_dm_late_debug"],
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 # `MANUF_PERSONALIZED` configuration for RMA. Only available in secure environments.
@@ -374,5 +367,4 @@ otp_image(
     name = "otp_img_rma_manuf_personalized",
     src = "//hw/top_earlgrey/data/otp:otp_json_rma",
     overlays = MANUF_PERSONALIZED,
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )

--- a/hw/top_earlgrey/data/otp/sival_skus/BUILD
+++ b/hw/top_earlgrey/data/otp/sival_skus/BUILD
@@ -219,7 +219,6 @@ otp_image_consts(
         ":otp_json_creator_sw_cfg",
         ":otp_json_owner_sw_cfg",
     ] + OTP_SIGVERIFY_FAKE_KEYS,
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 # Library containing {CREATOR,OWNER}_SW_CFG and
@@ -258,7 +257,6 @@ LC_MISSION_STATES = get_lc_items(
             "//hw/top_earlgrey/data/otp:otp_json_secret1",
             "//hw/top_earlgrey/data/otp:otp_json_fixed_secret2",
         ] + OTP_SIGVERIFY_FAKE_KEYS,
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     )
     for lc_state, _ in LC_MISSION_STATES
 ]

--- a/hw/top_earlgrey/defs.bzl
+++ b/hw/top_earlgrey/defs.bzl
@@ -16,4 +16,7 @@ EARLGREY = opentitan_top(
     std_otp_overlay = EARLGREY_STD_OTP_OVERLAYS,
     otp_sigverify_fake_keys = EARLGREY_OTP_SIGVERIFY_FAKE_KEYS,
     ips = EARLGREY_IPS,
+    secret_cfgs = {
+        "testing": "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
+    },
 )

--- a/hw/top_englishbreakfast/defs.bzl
+++ b/hw/top_englishbreakfast/defs.bzl
@@ -12,4 +12,7 @@ ENGLISHBREAKFAST = opentitan_top(
     top_lib = "//hw/top_englishbreakfast/sw/autogen:top_englishbreakfast",
     top_ld = "//hw/top_englishbreakfast/sw/autogen:top_englishbreakfast_memory",
     ips = ENGLISHBREAKFAST_IPS,
+    secret_cfgs = {
+        "testing": "//hw/top_englishbreakfast/data/autogen:top_englishbreakfast.secrets.testing.gen.hjson",
+    },
 )

--- a/rules/lc.bzl
+++ b/rules/lc.bzl
@@ -57,6 +57,7 @@ lc_raw_unlock_token = rule(
         ),
         "top_secret_cfg": attr.label(
             allow_single_file = True,
+            default = "//hw/top:secrets",
             doc = "Generated top configuration file including secrets.",
         ),
         "_tool": attr.label(

--- a/rules/opentitan/exec_env.bzl
+++ b/rules/opentitan/exec_env.bzl
@@ -31,7 +31,6 @@ _FIELDS = {
     "top_secret_cfg": ("file.top_secret_cfg", True),
     "otp_data_perm": ("attr.otp_data_perm", False),
     "flash_scramble_tool": ("attr.flash_scramble_tool", False),
-    "rom_scramble_config": ("file.rom_scramble_config", False),
     "openocd": ("attr.openocd", False),
     "openocd_adapter_config": ("attr.openocd_adapter_config", False),
 }
@@ -211,11 +210,6 @@ def exec_env_common_attrs(**kwargs):
             default = "//hw/ip/rom_ctrl/util:scramble_image",
             executable = True,
             cfg = "exec",
-        ),
-        "rom_scramble_config": attr.label(
-            default = kwargs.get("rom_scramble_config", None),
-            doc = "ROM scrambling config for this environment",
-            allow_single_file = True,
         ),
         "openocd": attr.label(
             doc = "OpenOCD binary for this environment",

--- a/rules/opentitan/exec_env.bzl
+++ b/rules/opentitan/exec_env.bzl
@@ -28,7 +28,7 @@ _FIELDS = {
     "data": ("attr.data", False),
     "extract_sw_logs": ("attr.extract_sw_logs", False),
     "otp_mmap": ("file.otp_mmap", False),
-    "top_secret_cfg": ("file.top_secret_cfg", True),
+    "top_secret_cfg": ("file.top_secret_cfg", False),
     "otp_data_perm": ("attr.otp_data_perm", False),
     "flash_scramble_tool": ("attr.flash_scramble_tool", False),
     "openocd": ("attr.openocd", False),
@@ -194,6 +194,7 @@ def exec_env_common_attrs(**kwargs):
         ),
         "top_secret_cfg": attr.label(
             allow_single_file = True,
+            default = "//hw/top:secrets",
             doc = "Generated top configuration file including secrets.",
         ),
         "otp_data_perm": attr.label(

--- a/rules/opentitan/fpga.bzl
+++ b/rules/opentitan/fpga.bzl
@@ -68,8 +68,8 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
             name = name,
             src = elf,
             suffix = "39.scr.vmem",
-            rom_scramble_config = exec_env.rom_scramble_config,
             rom_scramble_tool = ctx.executable.rom_scramble_tool,
+            top_secret_cfg = exec_env.top_secret_cfg,
         )
 
         # The englishbreakfast verilator model does not understand ROM

--- a/rules/opentitan/legacy.bzl
+++ b/rules/opentitan/legacy.bzl
@@ -120,8 +120,8 @@ scramble_flash_vmem = rv_rule(
         "otp": attr.label(allow_single_file = True),
         "top_secret_cfg": attr.label(
             allow_single_file = True,
+            default = "//hw/top:secrets",
             doc = "Generated top configuration file including secrets.",
-            mandatory = True,
         ),
         "otp_data_perm": attr.label(
             default = "//util/design/data:data_perm",

--- a/rules/opentitan/silicon.bzl
+++ b/rules/opentitan/silicon.bzl
@@ -57,8 +57,8 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
             name = name,
             src = elf,
             suffix = "39.scr.vmem",
-            rom_scramble_config = exec_env.rom_scramble_config,
             rom_scramble_tool = ctx.executable.rom_scramble_tool,
+            top_secret_cfg = exec_env.top_secret_cfg,
         )
         default = rom
         vmem = rom

--- a/rules/opentitan/sim_dv.bzl
+++ b/rules/opentitan/sim_dv.bzl
@@ -51,8 +51,8 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
             name = name,
             src = elf,
             suffix = "39.scr.vmem",
-            rom_scramble_config = exec_env.rom_scramble_config,
             rom_scramble_tool = ctx.executable.rom_scramble_tool,
+            top_secret_cfg = exec_env.top_secret_cfg,
         )
 
         # We may want to run non-scrambled ROM in DV environment, for faster

--- a/rules/opentitan/sim_verilator.bzl
+++ b/rules/opentitan/sim_verilator.bzl
@@ -48,8 +48,8 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
             name = name,
             src = elf,
             suffix = "39.scr.vmem",
-            rom_scramble_config = exec_env.rom_scramble_config,
             rom_scramble_tool = ctx.executable.rom_scramble_tool,
+            top_secret_cfg = exec_env.top_secret_cfg,
         )
 
         # The englishbreakfast verilator model does not understand ROM

--- a/rules/opentitan/transform.bzl
+++ b/rules/opentitan/transform.bzl
@@ -262,9 +262,9 @@ def convert_to_scrambled_rom_vmem(ctx, **kwargs):
         output: The name of the output file.  Constructed from `name` and `suffix`
                  if not specified.
         src: The src File object.
-        rom_scramble_config: The scrambling config.
         rom_scramble_tool: The scrambling tool.
         rom_scramble_mode: The scrambling mode.
+        top_secret_cfg: The secrets configuration of the top.
     Returns:
       (The transformed File, The hashfile)
     """
@@ -280,7 +280,7 @@ def convert_to_scrambled_rom_vmem(ctx, **kwargs):
 
     src = get_override(ctx, "attr.src", kwargs)
 
-    config = get_override(ctx, "file.rom_scramble_config", kwargs)
+    config = get_override(ctx, "file.top_secret_cfg", kwargs)
     tool = get_override(ctx, "executable.rom_scramble_tool", kwargs)
     mode = get_override(ctx, "attr.rom_scramble_mode", kwargs)
 

--- a/rules/otp.bzl
+++ b/rules/otp.bzl
@@ -274,8 +274,8 @@ otp_image = rule(
         ),
         "top_secret_cfg": attr.label(
             allow_single_file = True,
+            default = "//hw/top:secrets",
             doc = "Generated top configuration file including secrets.",
-            mandatory = True,
         ),
         "data_perm": attr.label(
             default = "//util/design/data:data_perm",
@@ -341,13 +341,13 @@ otp_image_consts = rule(
         ),
         "mmap_def": attr.label(
             allow_single_file = True,
-            default = "//hw/top_earlgrey/data/otp:otp_ctrl_mmap.hjson",
+            default = "//hw/top:top_otp_map",
             doc = "OTP Controller memory map file in Hjson format.",
         ),
         "top_secret_cfg": attr.label(
             allow_single_file = True,
+            default = "//hw/top:secrets",
             doc = "Generated top configuration file including secrets.",
-            mandatory = True,
         ),
         "c_template": attr.label(
             allow_single_file = True,

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -165,7 +165,6 @@ opentitan_test(
             "//hw/top_earlgrey/data/otp:otp_json_fixed_secret0",
             "//hw/top_earlgrey/data/otp:otp_json_exec_disabled",
         ] + OTP_SIGVERIFY_FAKE_KEYS,
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
         visibility = ["//visibility:public"],
     )
     for i in range(0, 8)
@@ -462,7 +461,6 @@ opentitan_test(
 otp_image(
     name = "otp_img_otp_ctrl_functest",
     src = "//hw/top_earlgrey/data/otp:otp_json_test_unlocked0",
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     visibility = ["//visibility:private"],
 )
 

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -108,7 +108,6 @@ test_suite(
 
 lc_raw_unlock_token(
     name = "lc_raw_unlock_token",
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 opentitan_test(

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -62,7 +62,6 @@ otp_image(
     name = "otp_img_default",
     src = ":otp_json_default",
     overlays = OTP_SIGVERIFY_FAKE_KEYS,
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     visibility = ["//visibility:private"],
 )
 

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -240,7 +240,6 @@ opentitan_test(
         name = "empty_test_slot_{}_{}_corrupted_sim_dv_scr_vmem64_signed".format(slot, key),
         testonly = True,
         src = ":empty_test_slot_{}_{}_corrupted_sim_dv_vmem64_signed".format(slot, key),
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     )
     for slot in SLOTS
     for key in SIGVERIFY_LC_KEYS

--- a/sw/device/silicon_creator/rom/e2e/boot_data_recovery/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_data_recovery/BUILD
@@ -115,7 +115,6 @@ BOOT_DATA_RECOVERY_CASES = [
             case["lc_state"],
             case["default_boot_data"],
         )],
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     )
     for case in BOOT_DATA_RECOVERY_CASES
 ]

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_bad_manifest/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_bad_manifest/BUILD
@@ -208,7 +208,6 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
         ),
         src = "//hw/top_earlgrey/data/otp:otp_json_{}".format(lc_state),
         overlays = STD_OTP_OVERLAYS + [":otp_json_sec_ver_{}".format(sec_ver)],
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
         visibility = ["//visibility:private"],
     )
     for lc_state, _ in get_lc_items()

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_flash_ecc_error/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_flash_ecc_error/BUILD
@@ -142,7 +142,6 @@ otp_image(
     name = "otp_img_boot_policy_flash_ecc_error",
     src = "//hw/top_earlgrey/data/otp:otp_json_prod",
     overlays = STD_OTP_OVERLAYS + [":otp_json_flash_data_cfg_default_scr_and_ecc_enabled"],
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     visibility = ["//visibility:private"],
 )
 
@@ -153,7 +152,6 @@ otp_image(
         ":otp_json_flash_data_cfg_default_scr_and_ecc_enabled",
         ":otp_json_flash_exc_handler_disabled",
     ],
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     visibility = ["//visibility:private"],
 )
 

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_newer/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_newer/BUILD
@@ -108,7 +108,6 @@ BOOT_POLICY_NEWER_CASES = [
         name = "otp_img_boot_policy_newer_{}".format(lc_state),
         src = "//hw/top_earlgrey/data/otp:otp_json_{}".format(lc_state),
         overlays = STD_OTP_OVERLAYS,
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     )
     for lc_state, _ in get_lc_items()
 ]

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_rollback/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_rollback/BUILD
@@ -81,7 +81,6 @@ otp_json(
         name = "otp_img_boot_policy_rollback_{}".format(lc_state),
         src = "//hw/top_earlgrey/data/otp:otp_json_{}".format(lc_state),
         overlays = STD_OTP_OVERLAYS + [":otp_json_boot_policy_rollback"],
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
         visibility = ["//visibility:private"],
     )
     for lc_state, _ in get_lc_items()

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_valid/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_valid/BUILD
@@ -49,7 +49,6 @@ BOOT_POLICY_VALID_CASES = [
         name = "otp_img_boot_policy_valid_{}".format(lc_state),
         src = "//hw/top_earlgrey/data/otp:otp_json_{}".format(lc_state),
         overlays = STD_OTP_OVERLAYS,
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     )
     for lc_state, _ in get_lc_items()
 ]

--- a/sw/device/silicon_creator/rom/e2e/bootstrap/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/bootstrap/BUILD
@@ -62,7 +62,6 @@ otp_image(
     overlays = STD_OTP_OVERLAYS + [
         ":otp_json_bootstrap_rma",
     ],
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     visibility = ["//visibility:private"],
 )
 

--- a/sw/device/silicon_creator/rom/e2e/immutable_rom_ext_section/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/immutable_rom_ext_section/BUILD
@@ -181,7 +181,6 @@ IMMUTABLE_PARTITION_TEST_CASES = [
                 s["name"],
             ),
         ],
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
         visibility = ["//visibility:private"],
     )
     for s in ROM_EXT_SLOTS

--- a/sw/device/silicon_creator/rom/e2e/jtag_inject/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/jtag_inject/BUILD
@@ -27,7 +27,6 @@ package(default_visibility = ["//visibility:public"])
         name = "img_{}_exec_disabled".format(lc_state),
         src = "//hw/top_earlgrey/data/otp:otp_json_" + lc_state,
         overlays = STD_OTP_OVERLAYS + ["//hw/top_earlgrey/data/otp:otp_json_exec_disabled"],
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
         visibility = ["//visibility:private"],
     )
     for lc_state, _ in get_lc_items()

--- a/sw/device/silicon_creator/rom/e2e/keymgr/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/keymgr/BUILD
@@ -60,7 +60,6 @@ rom_e2e_keymgr_init_configs = [
         name = "otp_img_keymgr_{}".format(config["name"]),
         src = "//hw/top_earlgrey/data/otp:otp_json_rma",
         overlays = STD_OTP_OVERLAYS + [":otp_json_keymgr_{}".format(config["name"])],
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
         visibility = ["//visibility:private"],
     )
     for config in rom_e2e_keymgr_init_configs

--- a/sw/device/silicon_creator/rom/e2e/presigned_images/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/presigned_images/BUILD
@@ -24,7 +24,6 @@ scramble_flash_vmem(
     name = "rom_e2e_self_hash_sim_dv_scr_vmem64",
     src = ":rom_e2e_self_hash_sim_dv_vmem64",
     otp = "//hw/top_earlgrey/data/otp:img_test_unlocked0",
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 [

--- a/sw/device/silicon_creator/rom/e2e/release/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/release/BUILD
@@ -22,7 +22,6 @@ otp_image(
     overlays = STD_OTP_OVERLAYS + [
         "//sw/device/silicon_creator/rom/e2e/sigverify_spx:otp_json_sigverify_spx_enabled_true",
     ],
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     visibility = ["//visibility:private"],
 )
 

--- a/sw/device/silicon_creator/rom/e2e/reset_reason/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/reset_reason/BUILD
@@ -41,7 +41,6 @@ otp_image(
     name = "otp_img_reset_reason",
     src = "//hw/top_earlgrey/data/otp:otp_json_rma",
     overlays = STD_OTP_OVERLAYS + [":otp_json_reset_reason"],
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 opentitan_test(
@@ -136,7 +135,6 @@ RESET_CORRUPTION_SCENARIOS = [
         overlays = STD_OTP_OVERLAYS + [
             ":otp_json_reset_reason_{}".format(t["name"]),
         ],
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     )
     for t in RESET_CORRUPTION_SCENARIOS
 ]

--- a/sw/device/silicon_creator/rom/e2e/retention_ram/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/retention_ram/BUILD
@@ -43,7 +43,6 @@ otp_image(
     name = "otp_img_reset_ret_ram",
     src = "//hw/top_earlgrey/data/otp:otp_json_rma",
     overlays = STD_OTP_OVERLAYS + [":otp_json_reset_ret_ram_overlay"],
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     visibility = ["//visibility:private"],
 )
 

--- a/sw/device/silicon_creator/rom/e2e/rom_e2e_bootstrap_entry/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/rom_e2e_bootstrap_entry/BUILD
@@ -29,7 +29,6 @@ package(default_visibility = ["//visibility:public"])
         name = "otp_img_e2e_bootstrap_entry_{}".format(lc_state),
         src = "//hw/top_earlgrey/data/otp:otp_json_{}".format(lc_state),
         overlays = STD_OTP_OVERLAYS,
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     )
     for lc_state, _ in get_lc_items()
 ]

--- a/sw/device/silicon_creator/rom/e2e/rom_ext_upgrade_interrupt/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/rom_ext_upgrade_interrupt/BUILD
@@ -53,7 +53,6 @@ otp_json(
         name = "otp_img_rom_ext_upgrade_interrupt_{}".format(lc_state),
         src = "//hw/top_earlgrey/data/otp:otp_json_{}".format(lc_state),
         overlays = STD_OTP_OVERLAYS + [":otp_json_rom_ext_upgrade_interrupt"],
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
         visibility = ["//visibility:private"],
     )
     for lc_state, _ in get_lc_items()

--- a/sw/device/silicon_creator/rom/e2e/shutdown_alert/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/shutdown_alert/BUILD
@@ -161,7 +161,6 @@ otp_alert_digest(
             ":shutdown_alert_owner_sw_cfg",
             ":shutdown_alert_digest_cfg",
         ],
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     )
     for lc_state, _ in ALERT_LC_STATES
 ]

--- a/sw/device/silicon_creator/rom/e2e/shutdown_output/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/shutdown_output/BUILD
@@ -44,7 +44,6 @@ package(default_visibility = ["//visibility:public"])
         name = "otp_img_shutdown_output_{}".format(lc_state),
         src = "//hw/top_earlgrey/data/otp:otp_json_{}".format(lc_state),
         overlays = STD_OTP_OVERLAYS,
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     )
     for lc_state, _ in get_lc_items()
 ]

--- a/sw/device/silicon_creator/rom/e2e/shutdown_redact/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/shutdown_redact/BUILD
@@ -69,7 +69,6 @@ REDACT.update({"INVALID": 0x0})
         ),
         src = "//hw/top_earlgrey/data/otp:otp_json_{}".format(lc_state),
         overlays = STD_OTP_OVERLAYS + [":otp_json_{}_overlay".format(redact.lower())],
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
         visibility = ["//visibility:private"],
     )
     for lc_state, _ in get_lc_items()

--- a/sw/device/silicon_creator/rom/e2e/shutdown_watchdog/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/shutdown_watchdog/BUILD
@@ -89,7 +89,6 @@ SHUTDOWN_WATCHDOG_CASES = [
                 t["bite_threshold"],
             ),
         ],
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     )
     for t in SHUTDOWN_WATCHDOG_CASES
 ]

--- a/sw/device/silicon_creator/rom/e2e/sigverify_always/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_always/BUILD
@@ -41,7 +41,6 @@ package(default_visibility = ["//visibility:public"])
     name = "otp_img_sigverify_always_{}".format(lc_state),
     src = "//hw/top_earlgrey/data/otp:otp_json_{}".format(lc_state),
     overlays = STD_OTP_OVERLAYS,
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 ) for lc_state, _ in get_lc_items()]
 
 SIGVERIFY_BAD_CASES = [

--- a/sw/device/silicon_creator/rom/e2e/sigverify_key_type/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_key_type/BUILD
@@ -129,7 +129,6 @@ otp_json(
         overlays = STD_OTP_OVERLAYS + [
             ":otp_json_enable_spx",
         ],
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     )
     for lc_state, _ in get_lc_items()
 ]

--- a/sw/device/silicon_creator/rom/e2e/sigverify_key_validity/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_key_validity/BUILD
@@ -201,7 +201,6 @@ KEY_VALIDITY_TESTS = [
         overlays = STD_OTP_OVERLAYS + [
             ":otp_json_sigverify_key_validity_{}".format(test["name"]),
         ],
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     )
     for test in KEY_VALIDITY_TESTS
     for lc_state, _ in get_lc_items()

--- a/sw/device/silicon_creator/rom/e2e/sigverify_spx/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_spx/BUILD
@@ -139,7 +139,6 @@ opentitan_binary(
         overlays = STD_OTP_OVERLAYS + [
             ":otp_json_sigverify_spx_{}".format(t["name"]),
         ],
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
         visibility = ["//visibility:private"],
     )
     for lc_state, _ in get_lc_items()

--- a/sw/device/silicon_creator/rom/e2e/sigverify_usage_constraints/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_usage_constraints/BUILD
@@ -81,7 +81,6 @@ otp_json(
         name = "otp_img_sigverify_usage_constraints_{}".format(lc_state),
         src = "//hw/top_earlgrey/data/otp:otp_json_{}".format(lc_state),
         overlays = STD_OTP_OVERLAYS + [":otp_json_set_usage_constraint_params_overlay"],
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
         visibility = ["//visibility:private"],
     )
     for lc_state, _ in get_lc_items()

--- a/sw/device/silicon_creator/rom/e2e/sram/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sram/BUILD
@@ -40,7 +40,6 @@ otp_image(
     name = "otp_img_readback_enable",
     src = "//hw/top_earlgrey/data/otp:otp_json_rma",
     overlays = STD_OTP_OVERLAYS + [":otp_json_readback_enable"],
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 _TESTS = {

--- a/sw/device/silicon_creator/rom/e2e/watchdog/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/watchdog/BUILD
@@ -52,7 +52,6 @@ otp_json(
         name = "otp_img_watchdog_enable_{}".format(lc_state),
         src = "//hw/top_earlgrey/data/otp:otp_json_{}".format(lc_state),
         overlays = STD_OTP_OVERLAYS + [":otp_json_watchdog_enable"],
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     )
     for lc_state, _ in get_lc_items()
 ]

--- a/sw/device/silicon_creator/rom_ext/e2e/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/BUILD
@@ -42,5 +42,4 @@ otp_image(
     overlays = STD_OTP_OVERLAYS + [
         ":otp_json_secret2_locked",
     ],
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
@@ -61,7 +61,6 @@ filegroup(
             "//sw/device/silicon_creator/rom_ext/e2e:otp_json_secret2_locked",
             ":otp_json_with_{}_imm_romext_enabled".format(name),
         ],
-        top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
         visibility = ["//visibility:private"],
     )
     for name in IMM_SECTION_VARIATIONS

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2396,7 +2396,6 @@ otp_image(
     name = "otp_ctrl_descrambling_otp_image",
     src = "//hw/top_earlgrey/data/otp:otp_json_rma",
     overlays = STD_OTP_OVERLAYS + [":otp_ctrl_descrambling_otp_json"],
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     visibility = ["//visibility:private"],
 )
 
@@ -5637,7 +5636,6 @@ otp_image(
     name = "power_virus_systemtest_otp_img_rma",
     src = "//hw/top_earlgrey/data/otp:otp_json_rma",
     overlays = STD_OTP_OVERLAYS + [":power_virus_systemtest_otp_overlay"],
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     visibility = ["//visibility:private"],
 )
 
@@ -5779,7 +5777,6 @@ otp_image(
     name = "flash_scrambling_smoketest_otp_img_rma",
     src = "//hw/top_earlgrey/data/otp:otp_json_rma",
     overlays = STD_OTP_OVERLAYS + [":flash_scrambling_smoketest_otp_overlay"],
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
     visibility = ["//visibility:private"],
 )
 

--- a/sw/host/provisioning/cp_lib/BUILD
+++ b/sw/host/provisioning/cp_lib/BUILD
@@ -9,7 +9,6 @@ package(default_visibility = ["//visibility:public"])
 
 lc_raw_unlock_token(
     name = "lc_raw_unlock_token",
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 rust_library(

--- a/sw/host/tests/manuf/manuf_cp_unlock_raw/BUILD
+++ b/sw/host/tests/manuf/manuf_cp_unlock_raw/BUILD
@@ -9,7 +9,6 @@ package(default_visibility = ["//visibility:public"])
 
 lc_raw_unlock_token(
     name = "lc_raw_unlock_token",
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 rust_binary(

--- a/sw/host/tests/manuf/manuf_cp_volatile_unlock_raw/BUILD
+++ b/sw/host/tests/manuf/manuf_cp_volatile_unlock_raw/BUILD
@@ -9,7 +9,6 @@ package(default_visibility = ["//visibility:public"])
 
 lc_raw_unlock_token(
     name = "lc_raw_unlock_token",
-    top_secret_cfg = "//hw/top_earlgrey/data/autogen:top_earlgrey.secrets.testing.gen.hjson",
 )
 
 rust_binary(

--- a/util/design/data/BUILD
+++ b/util/design/data/BUILD
@@ -15,11 +15,6 @@ exports_files(glob(["**"]))
 # multiple seeds needed to achieve DV coverage.
 
 string_flag(
-    name = "seed_cfg",
-    build_setting_default = "hw/top_earlgrey/data/top_earlgrey_seed.testing.hjson",
-)
-
-string_flag(
     name = "data_perm",
     build_setting_default = "",
 )


### PR DESCRIPTION
This PR extends the build system to allow providing a seed via a string label. Based on the seed and the selected top, bazel dynamically selects the `secrets.seed.gen.hjson`, which is used by the underlying tools.