### PR TITLE
[rescue,test] Add more tests for xmodem rescue

### DIFF
--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -688,3 +688,23 @@ opentitan_test(
         test_harness = "//sw/host/tests/rescue:rescue_test",
     ),
 )
+
+opentitan_test(
+    name = "xmodem_rescue_error_handling_test",
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+    },
+    fpga = fpga_params(
+        assemble = "{romext}@{rom_ext_slot_a} {firmware}@{owner_slot_a}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a": "romext",
+            ":boot_test_slot_a": "firmware",
+        },
+        test_cmd = """
+        --clear-bitstream
+        --bootstrap={firmware}
+        """,
+        test_harness = "//sw/host/tests/rescue:xmodem_rescue_error_handling",
+    ),
+)

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -280,32 +280,77 @@ genrule(
     for protocol, config in _CONFIGS.items()
 ]
 
-opentitan_test(
-    name = "rescue_rate_test",
-    exec_env = {
-        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
-        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
-    },
-    fpga = fpga_params(
-        assemble = "",
-        binaries = {
-            ":boot_test_slot_a": "payload",
+[
+    opentitan_test(
+        name = "rescue_rate_{}_test".format(rate),
+        exec_env = {
+            "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+            "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
         },
-        changes_otp = True,
-        test_cmd = """
-            --exec="transport init"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {rom_ext}"
-            # First make sure the ROM_EXT is faulting because there is no firmware
-            --exec="console --non-interactive --exit-success='BFV:' --exit-failure='PASS|FAIL'"
-            # Load firmware via rescue
-            --exec="rescue firmware --rate=115200 {payload:signed_bin}"
-            # Check for firmware execution
-            --exec="console --baudrate=115200 --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-            no-op
-        """,
-    ),
-)
+        fpga = fpga_params(
+            assemble = "",
+            binaries = {
+                ":boot_test_slot_a": "payload",
+            },
+            changes_otp = True,
+            rate = rate,
+            test_cmd = """
+                --exec="transport init"
+                --exec="fpga load-bitstream {bitstream}"
+                --exec="bootstrap --clear-uart=true {rom_ext}"
+                # First make sure the ROM_EXT is faulting because there is no firmware
+                --exec="console --non-interactive --exit-success='BFV:' --exit-failure='PASS|FAIL'"
+                # Load firmware via rescue
+                --exec="rescue firmware --rate={rate} {payload:signed_bin}"
+                # Check for firmware execution
+                --exec="console --baudrate=115200 --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+                no-op
+            """,
+        ),
+    )
+    # FPGA CW310 and CW340 only support the baudrate up to 230K.
+    for rate in [
+        "115200",
+        "230400",
+    ]
+]
+
+[
+    opentitan_test(
+        name = "rescue_unsupported_rate_{}_test".format(rate),
+        exec_env = {
+            "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+            "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+        },
+        fpga = fpga_params(
+            assemble = "",
+            binaries = {
+                ":boot_test_slot_a": "payload",
+            },
+            changes_otp = True,
+            rate = rate,
+            test_cmd = """
+                --exec="transport init"
+                --exec="fpga load-bitstream {bitstream}"
+                --exec="bootstrap --clear-uart=true {rom_ext}"
+                # Trigger rescue.
+                --exec="rescue no-op"
+                --exec="console --non-interactive --send='BAUD\r{rate}\r' --exit-success='unsupported baudrate' --exit-failure='BFV:.*\r\n'"
+                # Try the `REBO` mode and make sure we reboot without crash.
+                --exec="console --non-interactive --send='REBO\r' --exit-success='ROM:' --exit-failure='BFV:.*\r\n'"
+                no-op
+            """,
+        ),
+    )
+    # FPGA CW310 and CW340 only support the baudrate up to 230K.
+    for rate in [
+        "460K",
+        "921K",
+        "1M33",
+        "1M50",
+        "INVALID",
+    ]
+]
 
 # TODO(lowRISC#26481): Eliminate this test when we no longer care about
 # supporting version 0 of the rescue protocol.

--- a/sw/host/tests/rescue/BUILD
+++ b/sw/host/tests/rescue/BUILD
@@ -47,3 +47,19 @@ rust_binary(
         "@lowrisc_serde_annotate//serde_annotate",
     ],
 )
+
+rust_binary(
+    name = "xmodem_rescue_error_handling",
+    srcs = ["xmodem_rescue_error_handling.rs"],
+    deps = [
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:base64ct",
+        "@crate_index//:clap",
+        "@crate_index//:hex",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:regex",
+        "@lowrisc_serde_annotate//serde_annotate",
+    ],
+)

--- a/sw/host/tests/rescue/xmodem_rescue_error_handling.rs
+++ b/sw/host/tests/rescue/xmodem_rescue_error_handling.rs
@@ -1,0 +1,365 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::bool_assert_comparison)]
+use anyhow::Result;
+use clap::Parser;
+
+use std::rc::Rc;
+use std::time::Duration;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::io::uart::Uart;
+use opentitanlib::rescue::xmodem::XmodemError;
+use opentitanlib::rescue::{EntryMode, Rescue, RescueMode, RescueSerial};
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+}
+
+const POLYNOMIAL: u16 = 0x1021;
+const CRC: u8 = 0x43;
+const SOH: u8 = 0x01;
+const STX: u8 = 0x02;
+const EOF: u8 = 0x04;
+const ACK: u8 = 0x06;
+const NAK: u8 = 0x15;
+const CAN: u8 = 0x18;
+
+const BLOCK128_LEN: usize = 128;
+const CRC_LEN: usize = 2;
+const HEADER_LEN: usize = 3;
+
+fn send_packet_timeout(
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    rescue: &RescueSerial,
+) -> Result<()> {
+    rescue.enter(transport, EntryMode::Reset)?;
+    rescue.set_mode(RescueMode::Rescue)?;
+    let mut ch = 0u8;
+    uart.read(std::slice::from_mut(&mut ch))?;
+    assert_eq!(ch, CRC);
+
+    uart.write(&[STX])?;
+
+    // Ensure we can still boot into Owner SW.
+    UartConsole::wait_for(uart, r"Finished", Duration::from_secs(5))?;
+    Ok(())
+}
+
+fn send_data_timeout(
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    rescue: &RescueSerial,
+) -> Result<()> {
+    rescue.enter(transport, EntryMode::Reset)?;
+    rescue.set_mode(RescueMode::Rescue)?;
+    let mut ch = 0u8;
+    uart.read(std::slice::from_mut(&mut ch))?;
+    assert_eq!(ch, CRC);
+
+    uart.write(&[STX, 1, 254])?;
+
+    // Ensure we can still boot into Owner SW.
+    UartConsole::wait_for(uart, r"Finished", Duration::from_secs(5))?;
+    Ok(())
+}
+
+fn send_crc_timeout(
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    rescue: &RescueSerial,
+) -> Result<()> {
+    rescue.enter(transport, EntryMode::Reset)?;
+    rescue.set_mode(RescueMode::Rescue)?;
+    let mut ch = 0u8;
+    uart.read(std::slice::from_mut(&mut ch))?;
+    assert_eq!(ch, CRC);
+
+    let mut buf = vec![0xff; HEADER_LEN + BLOCK128_LEN];
+    buf[0] = SOH;
+    buf[1] = 1;
+    buf[2] = 255 - buf[1];
+    uart.write(&buf)?;
+
+    // Ensure we can still boot into Owner SW.
+    UartConsole::wait_for(uart, r"Finished", Duration::from_secs(5))?;
+    Ok(())
+}
+
+fn send_data_crc_error_cancel(
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    rescue: &RescueSerial,
+) -> Result<()> {
+    rescue.enter(transport, EntryMode::Reset)?;
+    rescue.set_mode(RescueMode::Rescue)?;
+    let mut ch = 0u8;
+    uart.read(std::slice::from_mut(&mut ch))?;
+    assert_eq!(ch, CRC);
+    let mut buf = vec![0xff; HEADER_LEN + BLOCK128_LEN + CRC_LEN];
+    buf[0] = SOH;
+    buf[1] = 1;
+    buf[2] = 255 - buf[1];
+    uart.write(&buf)?;
+    let mut ch = 0u8;
+    uart.read(std::slice::from_mut(&mut ch))?;
+    assert_eq!(ch, NAK);
+    buf[1] = buf[2];
+    uart.write(&buf)?;
+    uart.read(std::slice::from_mut(&mut ch))?;
+    assert_eq!(ch, CAN);
+
+    // Ensure we can still boot into Owner SW.
+    UartConsole::wait_for(uart, r"Finished", Duration::from_secs(5))?;
+    Ok(())
+}
+
+fn send_packet_bad_len(
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    rescue: &RescueSerial,
+) -> Result<()> {
+    rescue.enter(transport, EntryMode::Reset)?;
+    rescue.set_mode(RescueMode::Rescue)?;
+    let mut ch = 0u8;
+    uart.read(std::slice::from_mut(&mut ch))?;
+    assert_eq!(ch, CRC);
+
+    let buf_1k = vec![0xff; 1024];
+    let buf_128 = vec![0xff; 128];
+
+    uart.write(&[STX, 1, 254])?;
+    uart.write(&buf_1k)?;
+    let crc = crc16(&buf_1k[..]);
+    uart.write(&[(crc >> 8) as u8, (crc & 0xFF) as u8])?;
+    let mut ch = 0u8;
+    uart.read(std::slice::from_mut(&mut ch))?;
+
+    uart.write(&[SOH, 2, 253])?;
+    uart.write(&buf_128)?;
+    let crc = crc16(&buf_128[..]);
+    uart.write(&[(crc >> 8) as u8, (crc & 0xFF) as u8])?;
+    uart.read(std::slice::from_mut(&mut ch))?;
+
+    uart.write(&[STX, 3, 252])?;
+    uart.write(&buf_1k)?;
+
+    // Ensure we can still boot into Owner SW.
+    UartConsole::wait_for(uart, r"Finished", Duration::from_secs(5))?;
+    Ok(())
+}
+
+fn recv_start_timeout(
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    rescue: &RescueSerial,
+) -> Result<()> {
+    rescue.enter(transport, EntryMode::Reset)?;
+    rescue.set_mode(RescueMode::BootLog)?;
+    let buf = vec![0xff; 29];
+    uart.write(&buf)?;
+
+    // Ensure we can still boot into Owner SW.
+    UartConsole::wait_for(uart, r"Finished", Duration::from_secs(5))?;
+    Ok(())
+}
+
+fn recv_start_cancel(
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    rescue: &RescueSerial,
+) -> Result<()> {
+    rescue.enter(transport, EntryMode::Reset)?;
+    rescue.set_mode(RescueMode::BootLog)?;
+    uart.write(&[CAN, CAN])?;
+
+    // Ensure we can still boot into Owner SW.
+    UartConsole::wait_for(uart, r"Finished", Duration::from_secs(5))?;
+    Ok(())
+}
+
+fn recv_start_nak(
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    rescue: &RescueSerial,
+) -> Result<()> {
+    rescue.enter(transport, EntryMode::Reset)?;
+    rescue.set_mode(RescueMode::BootLog)?;
+    uart.write(&[NAK, NAK])?;
+
+    // Ensure we can still boot into Owner SW.
+    UartConsole::wait_for(uart, r"Finished", Duration::from_secs(5))?;
+    Ok(())
+}
+
+fn recv_data_timeout(
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    rescue: &RescueSerial,
+) -> Result<()> {
+    rescue.enter(transport, EntryMode::Reset)?;
+    rescue.set_mode(RescueMode::BootLog)?;
+    uart.write(&[CRC])?;
+    uart.write(&[NAK])?;
+
+    // Ensure we can still boot into Owner SW.
+    UartConsole::wait_for(uart, r"Finished", Duration::from_secs(5))?;
+    Ok(())
+}
+
+fn recv_data_cancel(
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    rescue: &RescueSerial,
+) -> Result<()> {
+    rescue.enter(transport, EntryMode::Reset)?;
+    rescue.set_mode(RescueMode::BootLog)?;
+    uart.write(&[CRC])?;
+    uart.write(&[CAN, CAN])?;
+
+    // Ensure we can still boot into Owner SW.
+    UartConsole::wait_for(uart, r"Finished", Duration::from_secs(5))?;
+    Ok(())
+}
+
+fn recv_data_nak(
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    rescue: &RescueSerial,
+) -> Result<()> {
+    rescue.enter(transport, EntryMode::Reset)?;
+    rescue.set_mode(RescueMode::BootLog)?;
+    uart.write(&[CRC])?;
+    uart.write(&[NAK, NAK])?;
+
+    // Ensure we can still boot into Owner SW.
+    UartConsole::wait_for(uart, r"Finished", Duration::from_secs(5))?;
+    Ok(())
+}
+
+fn crc16(buf: &[u8]) -> u16 {
+    let mut crc = 0u16;
+    for byte in buf {
+        crc ^= (*byte as u16) << 8;
+        for _bit in 0..8 {
+            let msb = crc & 0x8000 != 0;
+            crc <<= 1;
+            if msb {
+                crc ^= POLYNOMIAL;
+            }
+        }
+    }
+    crc
+}
+
+fn recv_finish_nak(
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    rescue: &RescueSerial,
+) -> Result<()> {
+    rescue.enter(transport, EntryMode::Reset)?;
+    rescue.set_mode(RescueMode::BootLog)?;
+
+    // Send the byte indicating the protocol we want (Xmodem-CRC).
+    uart.write(&[CRC])?;
+
+    let mut block = 1u8;
+    let mut errors = 0usize;
+    loop {
+        // The first byte of the packet is the packet type which indicates the block size.
+        let mut byte = 0u8;
+        uart.read(std::slice::from_mut(&mut byte))?;
+        let block_len = match byte {
+            SOH => 128,
+            STX => 1024,
+            EOF => {
+                // End of file. Intentionally send a NAK rather than ACK.
+                uart.write(&[NAK])?;
+                break;
+            }
+            _ => {
+                return Err(XmodemError::UnsupportedMode(format!(
+                    "bad start of packet: {byte:02x} ({})",
+                    byte as char
+                ))
+                .into());
+            }
+        };
+
+        // The next two bytes are the block number and its complement.
+        let mut bnum = 0u8;
+        let mut bcom = 0u8;
+        uart.read(std::slice::from_mut(&mut bnum))?;
+        uart.read(std::slice::from_mut(&mut bcom))?;
+        let cancel = block != bnum || bnum != 255 - bcom;
+
+        // The next `block_len` bytes are the packet itself.
+        let mut buffer = vec![0; block_len];
+        let mut total = 0;
+        while total < block_len {
+            let n = uart.read(&mut buffer[total..])?;
+            total += n;
+        }
+
+        // The final two bytes are the CRC16.
+        let mut crc1 = 0u8;
+        let mut crc2 = 0u8;
+        uart.read(std::slice::from_mut(&mut crc1))?;
+        uart.read(std::slice::from_mut(&mut crc2))?;
+        let crc = u16::from_be_bytes([crc1, crc2]);
+
+        // If we should cancel, do it now.
+        if cancel {
+            uart.write(&[CAN, CAN])?;
+            return Err(XmodemError::Cancelled.into());
+        }
+        if crc16(&buffer) == crc {
+            // CRC was good; send an ACK
+            uart.write(&[ACK])?;
+            block = block.wrapping_add(1);
+        } else {
+            uart.write(&[NAK])?;
+            errors += 1;
+        }
+        if errors >= 2 {
+            return Err(XmodemError::ExhaustedRetries(errors).into());
+        }
+    }
+    rescue.reboot()?;
+
+    // Ensure we can still boot into Owner SW.
+    UartConsole::wait_for(uart, r"Finished", Duration::from_secs(5))?;
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+    let uart = transport.uart("console")?;
+    let rescue = RescueSerial::new(Rc::clone(&uart));
+    send_packet_timeout(&transport, &*uart, &rescue)?;
+    send_data_timeout(&transport, &*uart, &rescue)?;
+    send_crc_timeout(&transport, &*uart, &rescue)?;
+    send_data_crc_error_cancel(&transport, &*uart, &rescue)?;
+    send_packet_bad_len(&transport, &*uart, &rescue)?;
+    recv_start_timeout(&transport, &*uart, &rescue)?;
+    recv_start_cancel(&transport, &*uart, &rescue)?;
+    recv_start_nak(&transport, &*uart, &rescue)?;
+    recv_data_timeout(&transport, &*uart, &rescue)?;
+    recv_data_cancel(&transport, &*uart, &rescue)?;
+    recv_data_nak(&transport, &*uart, &rescue)?;
+    recv_finish_nak(&transport, &*uart, &rescue)?;
+    Ok(())
+}


### PR DESCRIPTION
This includes two commits that
- Add comprehensive baud rate tests for xmodem rescue
- Add xmodem error handling test 
    - Timeouts during packet, data, and CRC transmission.
    - CRC errors leading to NAK and eventual cancellation.
    - Handling of packets with incorrect lengths.