### PR TITLE
[sw,e2e] Add testcase for OwnerSw DICE debug mode measurements

### DIFF
--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
@@ -193,3 +193,45 @@ opentitan_test(
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
     ],
 )
+
+DEBUG_MODE_TESTCASES = [
+    {
+        "name": "off",
+        "key": {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "prod_key_0"},
+        "defines": ["TEST_EXPECT_DEBUG_OFF=1"],
+    },
+    {
+        "name": "on",
+        "key": {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_test_ecdsa": "test_key_0"},
+        "defines": ["TEST_EXPECT_DEBUG_ON=1"],
+    },
+]
+
+[
+    opentitan_test(
+        name = "debug_mode_{}_{}_test".format(
+            testcase["name"],
+            variation,
+        ),
+        srcs = ["debug_mode_test.c"],
+        defines = testcase["defines"],
+        ecdsa_key = testcase["key"],
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+            "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+        },
+        fpga = fpga_params(
+            rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_{}_slot_a".format(variation),
+        ),
+        deps = [
+            "//sw/device/lib/base:status",
+            "//sw/device/lib/runtime:log",
+            "//sw/device/lib/testing/test_framework:check",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+            "//sw/device/silicon_creator/manuf/base:perso_tlv_data",
+        ],
+    )
+    for testcase in DEBUG_MODE_TESTCASES
+    for variation in ROM_EXT_VARIATIONS.keys()
+]

--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/debug_mode_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/debug_mode_test.c
@@ -1,0 +1,143 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
+#include "sw/device/silicon_creator/manuf/base/perso_tlv_data.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+enum {
+  kX509Cdi1DebugOffset = 585,
+  kCwtCdi1DebugOffset = 266,
+};
+
+const char kX509Cdi1DebugOff[] = {
+    // kAsn1TagClassContext | DiceTcbInfoFlags (7)
+    0x87,
+    // 4-bit BitString
+    0x02,
+    0x04,
+    // Debug mode = 0
+    0x00,
+};
+
+const char kX509Cdi1DebugOn[] = {
+    // kAsn1TagClassContext | DiceTcbInfoFlags (7)
+    0x87,
+    // 4-bit BitString
+    0x02,
+    0x04,
+    // Debug mode = 1
+    0x10,
+};
+
+const char kCwtCdi1DebugOff[] = {
+    // map label: mode (-4670551)
+    0x3a,
+    0x00,
+    0x47,
+    0x44,
+    0x56,
+    // 1-byte bytestring
+    0x41,
+    // Debug mode = normal (1)
+    0x01,
+};
+
+const char kCwtCdi1DebugOn[] = {
+    // map label: mode (-4670551)
+    0x3a,
+    0x00,
+    0x47,
+    0x44,
+    0x56,
+    // 1-byte bytestring
+    0x41,
+    // Debug mode = debug (2)
+    0x02,
+};
+
+static status_t test_debug_mode(void) {
+  uint8_t data[2048];
+  TRY(flash_ctrl_info_read(&kFlashCtrlInfoPageDiceCerts, 0,
+                           sizeof(data) / sizeof(uint32_t), data));
+
+  uint32_t offset = 0;
+  size_t len = sizeof(data);
+  while (true) {
+    perso_tlv_cert_obj_t obj = {0};
+    rom_error_t err = perso_tlv_get_cert_obj(data + offset, len, &obj);
+    if (err != kErrorOk) {
+      break;
+    }
+    offset += (obj.obj_size + 7) & ~7u;
+    len -= obj.obj_size;
+
+    LOG_INFO("%s type=%d sz=%d", obj.name, obj.obj_type, obj.obj_size);
+
+    // Test for CDI_1
+    if (memcmp(obj.name, "CDI_1", 5) != 0) {
+      continue;
+    }
+
+    // Extract debug mode from the attestation
+    uint8_t debug_mode = 0x42;
+    if (obj.obj_type == kPersoObjectTypeX509Cert) {
+      uint8_t *mode_ptr = obj.cert_body_p + kX509Cdi1DebugOffset;
+      if (memcmp(mode_ptr, kX509Cdi1DebugOn, sizeof(kX509Cdi1DebugOn)) == 0) {
+        debug_mode = true;
+      } else if (memcmp(mode_ptr, kX509Cdi1DebugOff,
+                        sizeof(kX509Cdi1DebugOff)) == 0) {
+        debug_mode = false;
+      } else {
+        LOG_INFO("Unknown x509 debug mode");
+        return INVALID_ARGUMENT();
+      }
+    } else if (obj.obj_type == kPersoObjectTypeCwtCert) {
+      uint8_t *mode_ptr = obj.cert_body_p + kCwtCdi1DebugOffset;
+      if (memcmp(mode_ptr, kCwtCdi1DebugOn, sizeof(kCwtCdi1DebugOn)) == 0) {
+        debug_mode = true;
+      } else if (memcmp(mode_ptr, kCwtCdi1DebugOff, sizeof(kCwtCdi1DebugOff)) ==
+                 0) {
+        debug_mode = false;
+      } else {
+        LOG_INFO("Unknown CWT debug mode");
+        return INVALID_ARGUMENT();
+      }
+    } else {
+      LOG_INFO("Unknown CDI_1 format");
+      return INVALID_ARGUMENT();
+    }
+
+    // Assert the debug mode expectation
+    if (debug_mode == true) {
+      LOG_INFO("debug = true");
+#ifdef TEST_EXPECT_DEBUG_ON
+      return OK_STATUS();
+#endif
+    } else if (debug_mode == false) {
+      LOG_INFO("debug = false");
+#ifdef TEST_EXPECT_DEBUG_OFF
+      return OK_STATUS();
+#endif
+    } else {
+      LOG_INFO("Unknown debug mode");
+      return INVALID_ARGUMENT();
+    }
+  }
+
+  return UNKNOWN();
+}
+
+bool test_main(void) {
+  status_t sts = test_debug_mode();
+  if (status_err(sts)) {
+    LOG_ERROR("test_debug_mode: %r", sts);
+  }
+  return status_ok(sts);
+}


### PR DESCRIPTION
This change introduces a new end-to-end test for the DICE chain to verify the correct measurement of the debug mode.

The test reads the DICE attestation data from flash, parses the CDI_1 certificate, and extracts the debug mode information. It then compares this extracted debug mode with an expected value.

This ensures that the debug mode state is accurately reflected in the DICE measurements, which is critical for secure boot and attestation.