### PR TITLE
Eighth round of HW typo fixes

### DIFF
--- a/hw/ip_templates/gpio/data/gpio.hjson.tpl
+++ b/hw/ip_templates/gpio/data/gpio.hjson.tpl
@@ -116,7 +116,7 @@
     {
       name: "GPIO.IN.FILTER"
       desc: '''GPIO module provides noise filter control.
-      It can be enabled with programing GPIO.CTRL_EN_INPUT_FILTER.
+      It can be enabled with programming GPIO.CTRL_EN_INPUT_FILTER.
       Once it enables, input value must be stable for 16cycles before transitioning
       '''
     }

--- a/hw/ip_templates/gpio/data/gpio_testplan.hjson.tpl
+++ b/hw/ip_templates/gpio/data/gpio_testplan.hjson.tpl
@@ -84,7 +84,7 @@
     }
     {
       name: interrupt_and_noise_filter
-      desc: '''GPIO test that exercise GPIO noise filter functionaliy along with random interrupt
+      desc: '''GPIO test that exercise GPIO noise filter functionality along with random interrupt
             programming and randomly toggling each GPIO pin value, independently of other GPIO pins.
             Each random iteration performs following operations:
             1. programs random values in one or more interrupt registers
@@ -147,7 +147,7 @@
     }
     {
       name: straps_data
-      desc: '''Verify the straps data/valid ouput expected values based on the strap_en and gpio_i inputs:
+      desc: '''Verify the straps data/valid output expected values based on the strap_en and gpio_i inputs:
       - Drive gpio_i input with random values.
       - Set strap_en high for at least one clock cycle.
       - Read the registers hw_straps_data_in and hw_straps_data_in_valid.

--- a/hw/ip_templates/gpio/dv/README.md.tpl
+++ b/hw/ip_templates/gpio/dv/README.md.tpl
@@ -83,9 +83,9 @@ To ensure high quality constrained random stimulus, it is necessary to develop a
 ${"###"} Self-checking strategy
 ${"####"} Scoreboard
 The `${module_instance_name}_scoreboard` is primarily used for end to end checking.
-It creates the following tlm analysis fifos to retrieve the data monitored by tlul interface agent monitors:
-* tl_a_chan_fifo: tl address channel
-* tl_d_chan_fifo: tl data channel
+It creates the following tlm analysis FIFOs to retrieve the data monitored by TLUL interface agent monitors:
+* tl_a_chan_fifo: TL address channel
+* tl_d_chan_fifo: TL data channel
 
 GPIO scoreboard monitors all valid GPIO CSR register accesses, activity on GPIO IOs, and interrupt pins. For any monitored write transaction, CSR values are updated in RAL. Based on monitored activity, GPIO scoreboard predicts updated values of required CSRs.
 

--- a/hw/ip_templates/gpio/dv/env/gpio_env.core.tpl
+++ b/hw/ip_templates/gpio/dv/env/gpio_env.core.tpl
@@ -3,7 +3,7 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: ${instance_vlnv(f"lowrisc:dv:{module_instance_name}_env:0.1")}
-description: "GPIO DV UVM environmnt"
+description: "GPIO DV UVM environment"
 filesets:
   files_dv:
     depend:

--- a/hw/ip_templates/gpio/dv/env/gpio_env_cov.sv.tpl
+++ b/hw/ip_templates/gpio/dv/env/gpio_env_cov.sv.tpl
@@ -33,7 +33,7 @@ class gpio_out_oe_cov_obj extends uvm_object;
   `uvm_object_utils(gpio_out_oe_cov_obj)
 
   // Covergroup: var1_var2_cg
-  // Covergroup invovling two variables of bit type and are meant to
+  // Covergroup involving two variables of bit type and are meant to
   // be used for cross coverage related to *out* and *oe* registers
   covergroup var1_var2_cg(string name) with function sample(bit var1, bit var2);
     option.per_instance = 1;
@@ -117,7 +117,7 @@ class ${module_instance_name}_env_cov extends cip_base_env_cov #(.CFG_T(${module
         intr_state_cov_obj[each_pin] = new($sformatf("intr_state_cov_obj_pin%0d", each_pin));
         // Create per pin coverage interrupts
         foreach(intr_types[each_type]) begin
-          // Per pin coverage for "Intrrupt Control Enable" values
+          // Per pin coverage for "Interrupt Control Enable" values
           // and transitions for each type of interrupt
           intr_ctrl_en_cov_objs[each_pin][{"intr_ctrl_en_", intr_types[each_type]}] =
               new({"intr_ctrl_en_", intr_types[each_type], $sformatf("_pin%0d_cov", each_pin)});

--- a/hw/ip_templates/gpio/dv/env/gpio_scoreboard.sv.tpl
+++ b/hw/ip_templates/gpio/dv/env/gpio_scoreboard.sv.tpl
@@ -29,7 +29,7 @@ class ${module_instance_name}_scoreboard extends cip_base_scoreboard #(.CFG_T ($
   bit [TL_DW-1:0] last_intr_test_event;
   // Flag to:
   //  (i) indicate that write to INTR_STATE register just happened, and
-  // (ii) store information of which all interupt bits were cleared
+  // (ii) store information of which all interrupt bits were cleared
   bit [TL_DW-1:0] cleared_intr_bits;
   // Flag to indicate that the strap was triggered
   bit first_strap_triggered;
@@ -688,7 +688,7 @@ class ${module_instance_name}_scoreboard extends cip_base_scoreboard #(.CFG_T ($
           end
         end
       end
-      // Coverage Sampling: Cross coverage of (edge tiggered intr type)x(enable)x(state)
+      // Coverage Sampling: Cross coverage of (edge triggered intr type)x(enable)x(state)
       // when type is enabled
       if (cfg.en_cov) begin
         foreach (rising_edge_intr_events[each_bit]) begin
@@ -703,7 +703,7 @@ class ${module_instance_name}_scoreboard extends cip_base_scoreboard #(.CFG_T ($
         end
       end
     end
-    // 2. Look for level triggerred interrupts
+    // 2. Look for level triggered interrupts
     begin
       bit [TL_DW-1:0] lvlhigh_intr_events, lvllow_intr_events;
       for (uint each_bit = 0; each_bit < TL_DW; each_bit++) begin
@@ -721,7 +721,7 @@ class ${module_instance_name}_scoreboard extends cip_base_scoreboard #(.CFG_T ($
           end
         end
       end
-      // Coverage Sampling: Cross coverage of (edge tiggered intr type)x(enable)x(state)
+      // Coverage Sampling: Cross coverage of (edge triggered intr type)x(enable)x(state)
       // when type is enabled
       if (cfg.en_cov) begin
         foreach (lvlhigh_intr_events[each_bit]) begin

--- a/hw/ip_templates/gpio/dv/env/seq_lib/gpio_filter_stress_vseq.sv.tpl
+++ b/hw/ip_templates/gpio/dv/env/seq_lib/gpio_filter_stress_vseq.sv.tpl
@@ -8,13 +8,13 @@
 // (  i) programs random set of interrupt registers with random values
 // ( ii) programs CTRL_EN_INPUT_FILTER register to random value
 // (iii) DATA_IN and INTR_STATE are read back and their read data are checked
-//       aginst predicted values.
+//       against predicted values.
 // ( iv) random noise data (data with many frequent asynchronous toggling) is
 //       driven on gpio pins. After few cycles (less than FILTER_CYCLES), the
 //       are toggled to original values before noise was driven. This would make
 //       sure than noise filter does not see stable data on any pin long enough.
 // (  v) DATA_IN and INTR_STATE are read back and their read data are checked
-//       aginst predicted values.
+//       against predicted values.
 // ( vi) Non-noise data is driven multiple times (That is, gpio pins are kept
 //       stable for FILTER_CYCLES or longer). Every time after driving
 //       non-noise data, registers DATA_IN and INTR_STATE are read back and
@@ -50,7 +50,7 @@ class ${module_instance_name}_filter_stress_vseq extends ${module_instance_name}
 
       // program random set of interrupt registers
       pgm_intr_regs();
-      // Calclulate update on interrupt state with new interrupt registers'
+      // Calculate update on interrupt state with new interrupt registers'
       // programming
       update_intr_state(crnt_intr_status, stable_value, stable_value);
       // Read and check DATA_IN and INTR_STATE registers
@@ -179,7 +179,7 @@ class ${module_instance_name}_filter_stress_vseq extends ${module_instance_name}
         new_intr_state_updates = 1'b1;
       end
     end
-    // Look for level triggerred interrupts
+    // Look for level triggered interrupts
     if (new_intr_state_updates == 1'b0) begin
       if ((pin_crnt_exp_filtered_value == 1'b1 && intr_ctrl_en_lvlhigh[pin_idx]) ||
           (pin_crnt_exp_filtered_value == 1'b0 && intr_ctrl_en_lvllow[pin_idx])) begin
@@ -192,7 +192,7 @@ class ${module_instance_name}_filter_stress_vseq extends ${module_instance_name}
 
   task read_and_check(bit [NUM_GPIOS-1:0] predicted_data_in,
                       bit [NUM_GPIOS-1:0] predicted_intr_state);
-    // Read DATA_IN and check if predictaed and actual values match
+    // Read DATA_IN and check if predicted and actual values match
     csr_rd_check(.ptr(ral.data_in), .compare_value(predicted_data_in));
     // Read interrupt value after noise driving is finished
     csr_rd_check(.ptr(ral.intr_state), .compare_value(predicted_intr_state));

--- a/hw/ip_templates/gpio/dv/env/seq_lib/gpio_full_random_vseq.sv.tpl
+++ b/hw/ip_templates/gpio/dv/env/seq_lib/gpio_full_random_vseq.sv.tpl
@@ -102,7 +102,7 @@ class ${module_instance_name}_full_random_vseq extends ${module_instance_name}_r
   // As some of the GPIO pins are already configured and driven as inputs, we need
   // to make sure that DATA_OUT and DATA_OE combination is programmed such that:
   // - Output driven on pin is same as GPIO input value, or
-  // - Outpurt enable on pin is 0
+  // - Output enable on pin is 0
   // By doing either of above two options, we make sure that none of the GPIO pins
   // become unknowns due to multiple drivers with conflicting values.
   task pgm_out_oe_regs(bit [NUM_GPIOS-1:0] gpio_if_pins_o_val,

--- a/hw/ip_templates/gpio/dv/env/seq_lib/gpio_intr_with_filter_rand_intr_event_vseq.sv.tpl
+++ b/hw/ip_templates/gpio/dv/env/seq_lib/gpio_intr_with_filter_rand_intr_event_vseq.sv.tpl
@@ -290,7 +290,7 @@ class ${module_instance_name}_intr_with_filter_rand_intr_event_vseq extends ${mo
           new_intr_state_updates[pin] = 1'b1;
         end
       end
-      // Look for level triggerred interrupts
+      // Look for level triggered interrupts
       if (new_intr_state_updates[pin] == 1'b0) begin
         if ((crnt_exp_filtered_value[pin] == 1'b1 && intr_ctrl_en_lvlhigh[pin]) ||
             (crnt_exp_filtered_value[pin] == 1'b0 && intr_ctrl_en_lvllow[pin])) begin

--- a/hw/ip_templates/gpio/dv/env/seq_lib/gpio_rand_straps_vseq.sv.tpl
+++ b/hw/ip_templates/gpio/dv/env/seq_lib/gpio_rand_straps_vseq.sv.tpl
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Verify the straps data/valid ouput expected values based on the strap_en and gpio_in inputs:
+// Verify the straps data/valid output expected values based on the strap_en and gpio_in inputs:
 //    - Drive gpio_in input with random values.
 //    - Set the strap_en high for at least one clock cycle.
 //    - Read the registers hw_straps_data_in and hw_straps_data_in_valid.
@@ -99,7 +99,7 @@ class ${module_instance_name}_rand_straps_vseq extends ${module_instance_name}_b
   // This task start the strap en test. First it will test the strap enable
   // with the driven gpio_i. On a second step drive the gpio_out and check the strap
   // registers based on that. And finally applies a second reset and check if the strap registers
-  // are reseted.
+  // are reset.
   task start_test();
 
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(gpio_in)

--- a/hw/ip_templates/gpio/rtl/gpio.sv.tpl
+++ b/hw/ip_templates/gpio/rtl/gpio.sv.tpl
@@ -150,7 +150,7 @@ module ${module_instance_name}
       // Hold by default
       inp_prd_cnt_d[i] = inp_prd_cnt_q[i];
 
-      // Clearing takes precendence
+      // Clearing takes precedence
       if (inp_prd_cnt_clr[i]) begin
         inp_prd_cnt_d[i] = '0;
       end else if (inp_prd_cnt_inc[i] && inp_prd_cnt_q[i] != '1) begin

--- a/hw/ip_templates/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip_templates/pinmux/data/pinmux.hjson.tpl
@@ -1023,7 +1023,7 @@
                       The behavior is as specified in !!WKUP_DETECTOR,
                       !!WKUP_DETECTOR_CNT_TH and !!WKUP_DETECTOR_PADSEL.
                       '''
-                      // In CSR tests, we do not touch the chip IOs. Thet are either pulled low or
+                      // In CSR tests, we do not touch the chip IOs. They are either pulled low or
                       // or undriven.
                       //
                       // Random writes to the wkup detect CSRs may result in the case where the

--- a/hw/ip_templates/pinmux/data/pinmux.tpldesc.hjson
+++ b/hw/ip_templates/pinmux/data/pinmux.tpldesc.hjson
@@ -35,13 +35,13 @@
     }
     {
       name: "n_mio_periph_in"
-      desc: "Number of MIO periperal ins"
+      desc: "Number of MIO peripheral ins"
       type: "int"
       default: "8"
     }
     {
       name: "n_mio_periph_out"
-      desc: "Number of MIO periperal outs"
+      desc: "Number of MIO peripheral outs"
       type: "int"
       default: "8"
     }
@@ -53,13 +53,13 @@
     }
     {
       name: "n_dio_periph_in"
-      desc: "Number of DIO periperal ins"
+      desc: "Number of DIO peripheral ins"
       type: "int"
       default: "8"
     }
     {
       name: "n_dio_periph_out"
-      desc: "Number of DIO periperal outs"
+      desc: "Number of DIO peripheral outs"
       type: "int"
       default: "8"
     }

--- a/hw/ip_templates/pinmux/data/pinmux_fpv_testplan.hjson
+++ b/hw/ip_templates/pinmux/data/pinmux_fpv_testplan.hjson
@@ -567,7 +567,7 @@
     {
       name: WkupTimedHigh_A
       desc: '''When register `wkup_detector_en` is set to 1 and `wkup_detector.mode` is set to 3,
-            which means postive pulse cycles are used to detect wakeup. If variable `final_pin_val`
+            which means positive pulse cycles are used to detect wakeup. If variable `final_pin_val`
             stays high longer than the threshold, then `wkup_cause` register's `de` attribute
             should be set to 1.'''
       stage: V1

--- a/hw/ip_templates/pinmux/rtl/pinmux.sv.tpl
+++ b/hw/ip_templates/pinmux/rtl/pinmux.sv.tpl
@@ -12,7 +12,7 @@ module pinmux
   import pinmux_reg_pkg::*;
   import prim_pad_wrapper_pkg::*;
 #(
-  // Taget-specific pinmux configuration passed down from the
+  // Target-specific pinmux configuration passed down from the
   // target-specific top-level.
   parameter target_cfg_t TargetCfg = DefaultTargetCfg,
 % if enable_strap_sampling:
@@ -644,7 +644,7 @@ module pinmux
       .wkup_mode_i        ( wkup_mode_e'(reg2hw.wkup_detector[k].mode.q) ),
       .wkup_cnt_th_i      ( reg2hw.wkup_detector_cnt_th[k].q             ),
       .pin_value_i        ( pin_value                                    ),
-      // wakeup request pulse on clk_aon, will be synced back to the bus domain insie the CSR node.
+      // wakeup request pulse on clk_aon, will be synced back to the bus domain inside the CSR node.
       .aon_wkup_pulse_o   ( hw2reg.wkup_cause[k].de                      )
     );
 

--- a/hw/ip_templates/pinmux/rtl/pinmux_strap_sampling.sv.tpl
+++ b/hw/ip_templates/pinmux/rtl/pinmux_strap_sampling.sv.tpl
@@ -8,7 +8,7 @@ module pinmux_strap_sampling
   import prim_pad_wrapper_pkg::*;
   import lc_ctrl_pkg::*;
 #(
-  // Taget-specific pinmux configuration passed down from the
+  // Target-specific pinmux configuration passed down from the
   // target-specific top-level.
   parameter target_cfg_t TargetCfg = DefaultTargetCfg
 ) (
@@ -265,7 +265,7 @@ module pinmux_strap_sampling
   assign dft_strap_test_o.straps = dft_strap_q;
 
 
-  // During dft enabled states, we continously sample all straps unless
+  // During dft enabled states, we continuously sample all straps unless
   // told not to do so by external dft logic
   logic tap_sampling_en;
   logic dft_hold_tap_sel;
@@ -291,7 +291,7 @@ module pinmux_strap_sampling
     if (strap_en_q && tap_sampling_en) begin
       dft_strap_sample_en = 1'b1;
     end
-    // In DFT-enabled life cycle states we continously
+    // In DFT-enabled life cycle states we continuously
     // sample the TAP straps to be able to switch back and
     // forth between different TAPs.
     if (strap_en_q || tap_sampling_en) begin

--- a/hw/ip_templates/pwm/data/pwm_testplan.hjson
+++ b/hw/ip_templates/pwm/data/pwm_testplan.hjson
@@ -15,7 +15,7 @@
             pwm_smoke tests pulse and blink mode for a single channel
 
             Stimulus:
-              - configure the envionment for one PWM channel
+              - configure the environment for one PWM channel
               - program the duty cycle a and b values
               - configure  the ClkDiv and Resn
 

--- a/hw/ip_templates/pwm/dv/env/pwm_env_cov.sv
+++ b/hw/ip_templates/pwm/dv/env/pwm_env_cov.sv
@@ -183,7 +183,7 @@ class pwm_env_cov extends cip_base_env_cov #(.CFG_T(pwm_env_cfg));
     tl_core_eq_cross_cp: cross core_clk_cp, tl_clk_cp;
   endgroup : clock_cg
 
-// Since DUT doesnt have a status register or a output signal to monitor underflow / overflow.
+// Since DUT doesn't have a status register or a output signal to monitor underflow / overflow.
 // passing the coverage from TB calculated values
   covergroup dc_uf_ovf_tb_cg with function sample(bit [PWM_NUM_CHANNELS-1:0] channel, bit uf_ovf);
      // sampled channel

--- a/hw/ip_templates/pwrmgr/data/pwrmgr.hjson.tpl
+++ b/hw/ip_templates/pwrmgr/data/pwrmgr.hjson.tpl
@@ -307,21 +307,21 @@
     % endfor
 
     { name: "NumRstReqs",
-      desc: "Number of peripheral reset requets",
+      desc: "Number of peripheral reset requests",
       type: "int",
       default: "${NumRstReqs}",
       local: "true"
     },
 
     { name: "NumIntRstReqs",
-      desc: "Number of pwrmgr internal reset requets",
+      desc: "Number of pwrmgr internal reset requests",
       type: "int",
       default: "${len(int_reset_reqs)}",
       local: "true"
     },
 
     { name: "NumDebugRstReqs",
-      desc: "Number of debug reset requets",
+      desc: "Number of debug reset requests",
       type: "int",
       default: "${len(debug_reset_reqs)}",
       local: "true"

--- a/hw/ip_templates/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
+++ b/hw/ip_templates/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
@@ -98,7 +98,7 @@
             - Expecting fatal alert event and rstreqs[ResetEscIdx].
             - Add assertion to see if u_esc_timeout happens, then
               rstreqs[ResetEscIdx] should be asserted.
-            - After the alert agent processese the alert
+            - After the alert agent processes the alert
               by asserting escalation reset,
               see if dut is back to normal operation state.
             '''

--- a/hw/ip_templates/pwrmgr/doc/theory_of_operation.md
+++ b/hw/ip_templates/pwrmgr/doc/theory_of_operation.md
@@ -77,7 +77,7 @@ The fast FSM notifies the reset manager to release the life cycle reset stage, w
 Once OTP sensing completes, the life cycle controller is initialized.
 The initialization of the life cycle controller puts the device into its allowed operating state.
 
-Once life cycle initialization is done, the fast FSM acknowledges the slow FSM rquest and initiates strap sampling.
+Once life cycle initialization is done, the fast FSM acknowledges the slow FSM request and initiates strap sampling.
 Once strap sampling is complete, the sequence continues once the rom controller finishes its checks.
 Note that `flash_ctrl` initialization is explicitly not done here, please see [sections below](#flash-handling) for more details.
 The processor is allowed to start executing, the fast FSM transitions to `Active` state and waits for a software low power entry request.

--- a/hw/ip_templates/pwrmgr/dv/env/pwrmgr_if.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/pwrmgr_if.sv
@@ -124,7 +124,7 @@ interface pwrmgr_if (
   always_comb intr_status = `PATH_TO_DUT.reg2hw.intr_state.q;
 
   // This is only used to determine if an interrupt will be set in case of a reset while in
-  // low power.  tryIt is very hard to perdict if the reset or a wakeup happen first, so this
+  // low power.  tryIt is very hard to predict if the reset or a wakeup happen first, so this
   // signal is used to help instead.
   pwrmgr_pkg::pwrup_cause_e pwrup_cause;
   always_comb pwrup_cause = `PATH_TO_DUT.slow_pwrup_cause;

--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_esc_clk_rst_malfunc_vseq.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_esc_clk_rst_malfunc_vseq.sv
@@ -23,7 +23,7 @@ class pwrmgr_esc_clk_rst_malfunc_vseq extends pwrmgr_base_vseq;
     wait_for_rom_and_active();
   endtask : body
 
-  // Trigers an escalation timeout fault, either stopping clk_esc_i or driving rst_esc_ni.
+  // Triggers an escalation timeout fault, either stopping clk_esc_i or driving rst_esc_ni.
   //
   // Randomly set a bit to 0 or 1: if 0 stop clk_esc_i, if 1 make rst_esc_ni active.
   task trigger_escalation_timeout();

--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_invalid_vseq.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_invalid_vseq.sv
@@ -42,7 +42,7 @@ class pwrmgr_lowpower_invalid_vseq extends pwrmgr_base_vseq;
 
     // Spurious interrupt check can be executed by
     // residue of lowpower task. Since we cannot kill csr op
-    // by disable fork, we have to disable spurious interrup check.
+    // by disable fork, we have to disable spurious interrupt check.
     cfg.invalid_st_test = 1;
 
     wait_for_rom_and_active();

--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_wakeup_race_vseq.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_wakeup_race_vseq.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // The lowpower_wakeup race test randomly enables wakeups, info capture, and interrupts,
-// and sends wakeups in the temporal vecinity of low power entry. It also sends wakeups
+// and sends wakeups in the temporal vicinity of low power entry. It also sends wakeups
 // after wakeup processing starts.
 class pwrmgr_lowpower_wakeup_race_vseq extends pwrmgr_base_vseq;
   `uvm_object_utils(pwrmgr_lowpower_wakeup_race_vseq)

--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_sec_cm_ctrl_config_regwen_vseq.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_sec_cm_ctrl_config_regwen_vseq.sv
@@ -1,7 +1,7 @@
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-// Decription:
+// Description:
 // Create low power transition and wakeup a few times.
 // When PWRMGR.CONTROL.LOW_POWER_HINT is set and core_sleep is high,
 // issue random write to PWRMGR.CONTROL and check

--- a/hw/ip_templates/pwrmgr/rtl/pwrmgr.sv.tpl
+++ b/hw/ip_templates/pwrmgr/rtl/pwrmgr.sv.tpl
@@ -368,7 +368,7 @@ module pwrmgr
   assign hw2reg.fault_status.esc_timeout.de     = esc_timeout_lc_q;
   assign hw2reg.fault_status.esc_timeout.d      = 1'b1;
 
-  // The main power domain glitch automatically causes a reset, so regsitering
+  // The main power domain glitch automatically causes a reset, so registering
   // an alert is functionally pointless.  However, if an attacker somehow manages/
   // to silence the reset, this gives us one potential back-up path through alert_handler.
   // Allow capture of main_pd fault status whenever the system is live.
@@ -524,7 +524,7 @@ module pwrmgr
   assign hw2reg.cfg_cdc_sync.d = 1'b0;
 
   ////////////////////////////
-  ///  Wakup and reset capture
+  ///  Wakeup and reset capture
   ////////////////////////////
 
   // reset and wakeup requests are captured into the slow clock domain and then

--- a/hw/ip_templates/pwrmgr/util/dt.py
+++ b/hw/ip_templates/pwrmgr/util/dt.py
@@ -22,7 +22,7 @@ HEADER_EXT_TEMPLATE = """
  * Some instances can have several wakeup signals, e.g. the pinmux has two (`pin` and `usb`).
  * For such IPs, it is not sufficient to know the instance, we also need to know which
  * signal triggered the wakeup. The `wakeup` index can be used to distinguish between those.
- * This value should be casted to the `dt_<ip>_wakeup_t` type of the corresponding IP.
+ * This value should be cast to the `dt_<ip>_wakeup_t` type of the corresponding IP.
  * For example, if the `pwrmgr` has two `pinmux` wakeup sources as described above, it's
  * two wakeup sources will be described as follows:
  * ```c

--- a/hw/ip_templates/rstmgr/data/rstmgr_sec_cm_testplan.hjson
+++ b/hw/ip_templates/rstmgr/data/rstmgr_sec_cm_testplan.hjson
@@ -68,7 +68,7 @@
       name: sec_cm_leaf_rst_shadow
       desc: '''Verify the countermeasure(s) LEAF.RST.SHADOW.
             After power up, create glitch to a shadow leaf reset module.
-            Check if normal leaf reset module is not triggerred.
+            Check if normal leaf reset module is not triggered.
             Do over all {shadow, normal} leaf reset module pairs
             '''
       stage: V2S

--- a/hw/ip_templates/rstmgr/dv/env/seq_lib/rstmgr_leaf_rst_shadow_attack_vseq.sv
+++ b/hw/ip_templates/rstmgr/dv/env/seq_lib/rstmgr_leaf_rst_shadow_attack_vseq.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Description:
 // Test assert glitch to shadow leaf reset module and
-// check if nomal reset module got affected or vice versa
+// check if normal reset module got affected or vice versa
 class rstmgr_leaf_rst_shadow_attack_vseq extends rstmgr_base_vseq;
   `uvm_object_utils(rstmgr_leaf_rst_shadow_attack_vseq)
 

--- a/hw/ip_templates/rv_core_ibex/data/rv_core_ibex.hjson.tpl
+++ b/hw/ip_templates/rv_core_ibex/data/rv_core_ibex.hjson.tpl
@@ -410,7 +410,7 @@
     { name:    "ICacheScramble"
       type:    "bit"
       default: "0"
-      desc:    "Scramble instruction cach"
+      desc:    "Scramble instruction cache"
       local:   "false"
       expose:  "true"
     },
@@ -434,7 +434,7 @@
     { name:    "DbgTriggerEn"
       type:    "bit"
       default: "1"
-      desc:    "Enable degug trigger"
+      desc:    "Enable debug trigger"
       local:   "false"
       expose:  "true"
     },
@@ -466,7 +466,7 @@
     { name:    "DmAddrMask"
       type:    "int unsigned"
       default: "4095" //"32'h00000FFF"
-      desc:    "Adress mask of Debug Module"
+      desc:    "Address mask of Debug Module"
       local:   "false"
       expose:  "true"
     }

--- a/hw/ip_templates/rv_core_ibex/data/rv_core_ibex_testplan.hjson.tpl
+++ b/hw/ip_templates/rv_core_ibex/data/rv_core_ibex_testplan.hjson.tpl
@@ -12,7 +12,7 @@
               - Generate instruction binary and load to memory model
               - Only arithmetic instructions are generated
               - Assert fetch enable to start the core execution
-              - Terminate the test after ecall instructinon in detected
+              - Terminate the test after ecall instruction in detected
               - All instruction results are compared against spike simulation'''
       stage: V1
       tests: ["riscv_arithmetic_basic_test"]
@@ -102,7 +102,7 @@
               - Reserved instructions as specified in RISC-V user mode spec
               - CSR instruction to not implemented CSR
               - Execute S/U mode instructions in machine mode
-            Verify the illlegal instruction exception is raised and the context is captured correctly in privieged mode CSRs
+            Verify the illegal instruction exception is raised and the context is captured correctly in privileged mode CSRs
               - mstatus, mcause, mepc
             Verify the core can resume execution after returning from trap handling'''
       stage: V1
@@ -204,7 +204,7 @@
     {
       name: riscv_debug_ebreakmu_test
       desc: '''
-            - set dcsr.ebreakm/u at begining of test
+            - set dcsr.ebreakm/u at beginning of test
             - randomly insert ebreak instructions in generated code
             - boot randomly into either M/U modes
             - verify that ebreak instructions (in either mode) now enter debug mode'''
@@ -285,7 +285,7 @@
       desc: '''
             Perform all CSR instructions to implemented privileged CSR
             Verify the reset value of the privileged CSR
-            Verify WARL field can be upated properly'''
+            Verify WARL field can be updated properly'''
       stage: V1
       tests: ["riscv_csr_test"]
     }

--- a/hw/ip_templates/rv_plic/data/rv_plic_fpv_testplan.hjson.tpl
+++ b/hw/ip_templates/rv_plic/data/rv_plic_fpv_testplan.hjson.tpl
@@ -8,7 +8,7 @@
     {
       name: LevelTriggeredIp_A
       desc: '''If interrupt pending (`ip`) is triggered, and the level indicator is set to
-            level triggered (`le=0`), then in the prvious clock cycle, the interrupt source
+            level triggered (`le=0`), then in the previous clock cycle, the interrupt source
             (`intr_src_i) should be set to 1.'''
       stage: V2
       tests: ["${module_instance_name}_assert"]
@@ -43,7 +43,7 @@
       name: TriggerIrqForwardCheck_A
       desc: '''If interrupt is enabled (`ie=1`), interrupt pending is set (`ip=1`), interrupt
             input has the highest priority among the rest of the inputs, and its priority is
-            above the threshold. Then in the next clock clcye, the `irq_o` should be triggered,
+            above the threshold. Then in the next clock cycle, the `irq_o` should be triggered,
             and the `irq_id_o` will reflect the input ID.'''
       stage: V2
       tests: ["${module_instance_name}_assert"]

--- a/hw/ip_templates/rv_plic/rtl/rv_plic.sv.tpl
+++ b/hw/ip_templates/rv_plic/rtl/rv_plic.sv.tpl
@@ -298,7 +298,7 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
   //    precondition about the initial state of the prim_alert_sender FSM, guaranteeing that we're
   //    not waiting for an ack.
   //
-  //  - The prim_alert_sender musn't detect a signal integrity issue on the alert signal coming in
+  //  - The prim_alert_sender mustn't detect a signal integrity issue on the alert signal coming in
   //    (alert_rx_i). Normally FpvSecCm tests get analysed with an FPV_ALERT_NO_SIGINT_ERR define,
   //    but we don't have that defined here. To avoid this happening, we want an assertion of the
   //    form "If no integrity error is detected for _SEC_CM_ALERT_MAX_CYC cycles, the alert_p signal

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -10606,7 +10606,7 @@
         }
         {
           name: ICacheScramble
-          desc: Scramble instruction cach
+          desc: Scramble instruction cache
           type: bit
           default: "1"
           local: "false"
@@ -10633,7 +10633,7 @@
         }
         {
           name: DbgTriggerEn
-          desc: Enable degug trigger
+          desc: Enable debug trigger
           type: bit
           default: "1"
           local: "false"
@@ -10669,7 +10669,7 @@
         }
         {
           name: DmAddrMask
-          desc: Adress mask of Debug Module
+          desc: Address mask of Debug Module
           type: int unsigned
           default: tl_main_pkg::ADDR_MASK_RV_DM__MEM
           local: "false"

--- a/hw/top_darjeeling/ip_autogen/gpio/data/gpio.hjson
+++ b/hw/top_darjeeling/ip_autogen/gpio/data/gpio.hjson
@@ -110,7 +110,7 @@
     {
       name: "GPIO.IN.FILTER"
       desc: '''GPIO module provides noise filter control.
-      It can be enabled with programing GPIO.CTRL_EN_INPUT_FILTER.
+      It can be enabled with programming GPIO.CTRL_EN_INPUT_FILTER.
       Once it enables, input value must be stable for 16cycles before transitioning
       '''
     }

--- a/hw/top_darjeeling/ip_autogen/gpio/data/gpio_testplan.hjson
+++ b/hw/top_darjeeling/ip_autogen/gpio/data/gpio_testplan.hjson
@@ -84,7 +84,7 @@
     }
     {
       name: interrupt_and_noise_filter
-      desc: '''GPIO test that exercise GPIO noise filter functionaliy along with random interrupt
+      desc: '''GPIO test that exercise GPIO noise filter functionality along with random interrupt
             programming and randomly toggling each GPIO pin value, independently of other GPIO pins.
             Each random iteration performs following operations:
             1. programs random values in one or more interrupt registers
@@ -147,7 +147,7 @@
     }
     {
       name: straps_data
-      desc: '''Verify the straps data/valid ouput expected values based on the strap_en and gpio_i inputs:
+      desc: '''Verify the straps data/valid output expected values based on the strap_en and gpio_i inputs:
       - Drive gpio_i input with random values.
       - Set strap_en high for at least one clock cycle.
       - Read the registers hw_straps_data_in and hw_straps_data_in_valid.

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/README.md
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/README.md
@@ -83,9 +83,9 @@ To ensure high quality constrained random stimulus, it is necessary to develop a
 ### Self-checking strategy
 #### Scoreboard
 The `gpio_scoreboard` is primarily used for end to end checking.
-It creates the following tlm analysis fifos to retrieve the data monitored by tlul interface agent monitors:
-* tl_a_chan_fifo: tl address channel
-* tl_d_chan_fifo: tl data channel
+It creates the following tlm analysis FIFOs to retrieve the data monitored by TLUL interface agent monitors:
+* tl_a_chan_fifo: TL address channel
+* tl_d_chan_fifo: TL data channel
 
 GPIO scoreboard monitors all valid GPIO CSR register accesses, activity on GPIO IOs, and interrupt pins. For any monitored write transaction, CSR values are updated in RAL. Based on monitored activity, GPIO scoreboard predicts updated values of required CSRs.
 

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_env.core
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_env.core
@@ -3,7 +3,7 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: lowrisc:darjeeling_dv:gpio_env:0.1
-description: "GPIO DV UVM environmnt"
+description: "GPIO DV UVM environment"
 filesets:
   files_dv:
     depend:

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_env_cov.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_env_cov.sv
@@ -33,7 +33,7 @@ class gpio_out_oe_cov_obj extends uvm_object;
   `uvm_object_utils(gpio_out_oe_cov_obj)
 
   // Covergroup: var1_var2_cg
-  // Covergroup invovling two variables of bit type and are meant to
+  // Covergroup involving two variables of bit type and are meant to
   // be used for cross coverage related to *out* and *oe* registers
   covergroup var1_var2_cg(string name) with function sample(bit var1, bit var2);
     option.per_instance = 1;
@@ -117,7 +117,7 @@ class gpio_env_cov extends cip_base_env_cov #(.CFG_T(gpio_env_cfg));
         intr_state_cov_obj[each_pin] = new($sformatf("intr_state_cov_obj_pin%0d", each_pin));
         // Create per pin coverage interrupts
         foreach(intr_types[each_type]) begin
-          // Per pin coverage for "Intrrupt Control Enable" values
+          // Per pin coverage for "Interrupt Control Enable" values
           // and transitions for each type of interrupt
           intr_ctrl_en_cov_objs[each_pin][{"intr_ctrl_en_", intr_types[each_type]}] =
               new({"intr_ctrl_en_", intr_types[each_type], $sformatf("_pin%0d_cov", each_pin)});

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
@@ -29,7 +29,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
   bit [TL_DW-1:0] last_intr_test_event;
   // Flag to:
   //  (i) indicate that write to INTR_STATE register just happened, and
-  // (ii) store information of which all interupt bits were cleared
+  // (ii) store information of which all interrupt bits were cleared
   bit [TL_DW-1:0] cleared_intr_bits;
   // Flag to indicate that the strap was triggered
   bit first_strap_triggered;
@@ -733,7 +733,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
           end
         end
       end
-      // Coverage Sampling: Cross coverage of (edge tiggered intr type)x(enable)x(state)
+      // Coverage Sampling: Cross coverage of (edge triggered intr type)x(enable)x(state)
       // when type is enabled
       if (cfg.en_cov) begin
         foreach (rising_edge_intr_events[each_bit]) begin
@@ -748,7 +748,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
         end
       end
     end
-    // 2. Look for level triggerred interrupts
+    // 2. Look for level triggered interrupts
     begin
       bit [TL_DW-1:0] lvlhigh_intr_events, lvllow_intr_events;
       for (uint each_bit = 0; each_bit < TL_DW; each_bit++) begin
@@ -766,7 +766,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
           end
         end
       end
-      // Coverage Sampling: Cross coverage of (edge tiggered intr type)x(enable)x(state)
+      // Coverage Sampling: Cross coverage of (edge triggered intr type)x(enable)x(state)
       // when type is enabled
       if (cfg.en_cov) begin
         foreach (lvlhigh_intr_events[each_bit]) begin

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/env/seq_lib/gpio_filter_stress_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/env/seq_lib/gpio_filter_stress_vseq.sv
@@ -8,13 +8,13 @@
 // (  i) programs random set of interrupt registers with random values
 // ( ii) programs CTRL_EN_INPUT_FILTER register to random value
 // (iii) DATA_IN and INTR_STATE are read back and their read data are checked
-//       aginst predicted values.
+//       against predicted values.
 // ( iv) random noise data (data with many frequent asynchronous toggling) is
 //       driven on gpio pins. After few cycles (less than FILTER_CYCLES), the
 //       are toggled to original values before noise was driven. This would make
 //       sure than noise filter does not see stable data on any pin long enough.
 // (  v) DATA_IN and INTR_STATE are read back and their read data are checked
-//       aginst predicted values.
+//       against predicted values.
 // ( vi) Non-noise data is driven multiple times (That is, gpio pins are kept
 //       stable for FILTER_CYCLES or longer). Every time after driving
 //       non-noise data, registers DATA_IN and INTR_STATE are read back and
@@ -50,7 +50,7 @@ class gpio_filter_stress_vseq extends gpio_intr_with_filter_rand_intr_event_vseq
 
       // program random set of interrupt registers
       pgm_intr_regs();
-      // Calclulate update on interrupt state with new interrupt registers'
+      // Calculate update on interrupt state with new interrupt registers'
       // programming
       update_intr_state(crnt_intr_status, stable_value, stable_value);
       // Read and check DATA_IN and INTR_STATE registers
@@ -179,7 +179,7 @@ class gpio_filter_stress_vseq extends gpio_intr_with_filter_rand_intr_event_vseq
         new_intr_state_updates = 1'b1;
       end
     end
-    // Look for level triggerred interrupts
+    // Look for level triggered interrupts
     if (new_intr_state_updates == 1'b0) begin
       if ((pin_crnt_exp_filtered_value == 1'b1 && intr_ctrl_en_lvlhigh[pin_idx]) ||
           (pin_crnt_exp_filtered_value == 1'b0 && intr_ctrl_en_lvllow[pin_idx])) begin
@@ -192,7 +192,7 @@ class gpio_filter_stress_vseq extends gpio_intr_with_filter_rand_intr_event_vseq
 
   task read_and_check(bit [NUM_GPIOS-1:0] predicted_data_in,
                       bit [NUM_GPIOS-1:0] predicted_intr_state);
-    // Read DATA_IN and check if predictaed and actual values match
+    // Read DATA_IN and check if predicted and actual values match
     csr_rd_check(.ptr(ral.data_in), .compare_value(predicted_data_in));
     // Read interrupt value after noise driving is finished
     csr_rd_check(.ptr(ral.intr_state), .compare_value(predicted_intr_state));

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/env/seq_lib/gpio_full_random_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/env/seq_lib/gpio_full_random_vseq.sv
@@ -102,7 +102,7 @@ class gpio_full_random_vseq extends gpio_random_long_reg_writes_reg_reads_vseq;
   // As some of the GPIO pins are already configured and driven as inputs, we need
   // to make sure that DATA_OUT and DATA_OE combination is programmed such that:
   // - Output driven on pin is same as GPIO input value, or
-  // - Outpurt enable on pin is 0
+  // - Output enable on pin is 0
   // By doing either of above two options, we make sure that none of the GPIO pins
   // become unknowns due to multiple drivers with conflicting values.
   task pgm_out_oe_regs(bit [NUM_GPIOS-1:0] gpio_if_pins_o_val,

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/env/seq_lib/gpio_intr_with_filter_rand_intr_event_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/env/seq_lib/gpio_intr_with_filter_rand_intr_event_vseq.sv
@@ -290,7 +290,7 @@ class gpio_intr_with_filter_rand_intr_event_vseq extends gpio_base_vseq;
           new_intr_state_updates[pin] = 1'b1;
         end
       end
-      // Look for level triggerred interrupts
+      // Look for level triggered interrupts
       if (new_intr_state_updates[pin] == 1'b0) begin
         if ((crnt_exp_filtered_value[pin] == 1'b1 && intr_ctrl_en_lvlhigh[pin]) ||
             (crnt_exp_filtered_value[pin] == 1'b0 && intr_ctrl_en_lvllow[pin])) begin

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/env/seq_lib/gpio_rand_straps_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/env/seq_lib/gpio_rand_straps_vseq.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Verify the straps data/valid ouput expected values based on the strap_en and gpio_in inputs:
+// Verify the straps data/valid output expected values based on the strap_en and gpio_in inputs:
 //    - Drive gpio_in input with random values.
 //    - Set the strap_en high for at least one clock cycle.
 //    - Read the registers hw_straps_data_in and hw_straps_data_in_valid.
@@ -99,7 +99,7 @@ class gpio_rand_straps_vseq extends gpio_base_vseq;
   // This task start the strap en test. First it will test the strap enable
   // with the driven gpio_i. On a second step drive the gpio_out and check the strap
   // registers based on that. And finally applies a second reset and check if the strap registers
-  // are reseted.
+  // are reset.
   task start_test();
 
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(gpio_in)

--- a/hw/top_darjeeling/ip_autogen/gpio/rtl/gpio.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/rtl/gpio.sv
@@ -147,7 +147,7 @@ module gpio
       // Hold by default
       inp_prd_cnt_d[i] = inp_prd_cnt_q[i];
 
-      // Clearing takes precendence
+      // Clearing takes precedence
       if (inp_prd_cnt_clr[i]) begin
         inp_prd_cnt_d[i] = '0;
       end else if (inp_prd_cnt_inc[i] && inp_prd_cnt_q[i] != '1) begin

--- a/hw/top_darjeeling/ip_autogen/pinmux/data/pinmux.hjson
+++ b/hw/top_darjeeling/ip_autogen/pinmux/data/pinmux.hjson
@@ -698,7 +698,7 @@
                       The behavior is as specified in !!WKUP_DETECTOR,
                       !!WKUP_DETECTOR_CNT_TH and !!WKUP_DETECTOR_PADSEL.
                       '''
-                      // In CSR tests, we do not touch the chip IOs. Thet are either pulled low or
+                      // In CSR tests, we do not touch the chip IOs. They are either pulled low or
                       // or undriven.
                       //
                       // Random writes to the wkup detect CSRs may result in the case where the

--- a/hw/top_darjeeling/ip_autogen/pinmux/data/pinmux_fpv_testplan.hjson
+++ b/hw/top_darjeeling/ip_autogen/pinmux/data/pinmux_fpv_testplan.hjson
@@ -567,7 +567,7 @@
     {
       name: WkupTimedHigh_A
       desc: '''When register `wkup_detector_en` is set to 1 and `wkup_detector.mode` is set to 3,
-            which means postive pulse cycles are used to detect wakeup. If variable `final_pin_val`
+            which means positive pulse cycles are used to detect wakeup. If variable `final_pin_val`
             stays high longer than the threshold, then `wkup_cause` register's `de` attribute
             should be set to 1.'''
       stage: V1

--- a/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux.sv
+++ b/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux.sv
@@ -12,7 +12,7 @@ module pinmux
   import pinmux_reg_pkg::*;
   import prim_pad_wrapper_pkg::*;
 #(
-  // Taget-specific pinmux configuration passed down from the
+  // Target-specific pinmux configuration passed down from the
   // target-specific top-level.
   parameter target_cfg_t TargetCfg = DefaultTargetCfg,
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
@@ -463,7 +463,7 @@ module pinmux
       .wkup_mode_i        ( wkup_mode_e'(reg2hw.wkup_detector[k].mode.q) ),
       .wkup_cnt_th_i      ( reg2hw.wkup_detector_cnt_th[k].q             ),
       .pin_value_i        ( pin_value                                    ),
-      // wakeup request pulse on clk_aon, will be synced back to the bus domain insie the CSR node.
+      // wakeup request pulse on clk_aon, will be synced back to the bus domain inside the CSR node.
       .aon_wkup_pulse_o   ( hw2reg.wkup_cause[k].de                      )
     );
 

--- a/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_strap_sampling.sv
+++ b/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_strap_sampling.sv
@@ -8,7 +8,7 @@ module pinmux_strap_sampling
   import prim_pad_wrapper_pkg::*;
   import lc_ctrl_pkg::*;
 #(
-  // Taget-specific pinmux configuration passed down from the
+  // Target-specific pinmux configuration passed down from the
   // target-specific top-level.
   parameter target_cfg_t TargetCfg = DefaultTargetCfg
 ) (
@@ -259,7 +259,7 @@ module pinmux_strap_sampling
   assign dft_strap_test_o.straps = dft_strap_q;
 
 
-  // During dft enabled states, we continously sample all straps unless
+  // During dft enabled states, we continuously sample all straps unless
   // told not to do so by external dft logic
   logic tap_sampling_en;
   logic dft_hold_tap_sel;
@@ -285,7 +285,7 @@ module pinmux_strap_sampling
     if (strap_en_q && tap_sampling_en) begin
       dft_strap_sample_en = 1'b1;
     end
-    // In DFT-enabled life cycle states we continously
+    // In DFT-enabled life cycle states we continuously
     // sample the TAP straps to be able to switch back and
     // forth between different TAPs.
     if (strap_en_q || tap_sampling_en) begin

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/data/pwrmgr.hjson
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/data/pwrmgr.hjson
@@ -330,21 +330,21 @@
 
 
     { name: "NumRstReqs",
-      desc: "Number of peripheral reset requets",
+      desc: "Number of peripheral reset requests",
       type: "int",
       default: "2",
       local: "true"
     },
 
     { name: "NumIntRstReqs",
-      desc: "Number of pwrmgr internal reset requets",
+      desc: "Number of pwrmgr internal reset requests",
       type: "int",
       default: "2",
       local: "true"
     },
 
     { name: "NumDebugRstReqs",
-      desc: "Number of debug reset requets",
+      desc: "Number of debug reset requests",
       type: "int",
       default: "1",
       local: "true"

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
@@ -98,7 +98,7 @@
             - Expecting fatal alert event and rstreqs[ResetEscIdx].
             - Add assertion to see if u_esc_timeout happens, then
               rstreqs[ResetEscIdx] should be asserted.
-            - After the alert agent processese the alert
+            - After the alert agent processes the alert
               by asserting escalation reset,
               see if dut is back to normal operation state.
             '''

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/doc/theory_of_operation.md
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/doc/theory_of_operation.md
@@ -77,7 +77,7 @@ The fast FSM notifies the reset manager to release the life cycle reset stage, w
 Once OTP sensing completes, the life cycle controller is initialized.
 The initialization of the life cycle controller puts the device into its allowed operating state.
 
-Once life cycle initialization is done, the fast FSM acknowledges the slow FSM rquest and initiates strap sampling.
+Once life cycle initialization is done, the fast FSM acknowledges the slow FSM request and initiates strap sampling.
 Once strap sampling is complete, the sequence continues once the rom controller finishes its checks.
 Note that `flash_ctrl` initialization is explicitly not done here, please see [sections below](#flash-handling) for more details.
 The processor is allowed to start executing, the fast FSM transitions to `Active` state and waits for a software low power entry request.

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv
@@ -124,7 +124,7 @@ interface pwrmgr_if (
   always_comb intr_status = `PATH_TO_DUT.reg2hw.intr_state.q;
 
   // This is only used to determine if an interrupt will be set in case of a reset while in
-  // low power.  tryIt is very hard to perdict if the reset or a wakeup happen first, so this
+  // low power.  tryIt is very hard to predict if the reset or a wakeup happen first, so this
   // signal is used to help instead.
   pwrmgr_pkg::pwrup_cause_e pwrup_cause;
   always_comb pwrup_cause = `PATH_TO_DUT.slow_pwrup_cause;

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_esc_clk_rst_malfunc_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_esc_clk_rst_malfunc_vseq.sv
@@ -23,7 +23,7 @@ class pwrmgr_esc_clk_rst_malfunc_vseq extends pwrmgr_base_vseq;
     wait_for_rom_and_active();
   endtask : body
 
-  // Trigers an escalation timeout fault, either stopping clk_esc_i or driving rst_esc_ni.
+  // Triggers an escalation timeout fault, either stopping clk_esc_i or driving rst_esc_ni.
   //
   // Randomly set a bit to 0 or 1: if 0 stop clk_esc_i, if 1 make rst_esc_ni active.
   task trigger_escalation_timeout();

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_invalid_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_invalid_vseq.sv
@@ -42,7 +42,7 @@ class pwrmgr_lowpower_invalid_vseq extends pwrmgr_base_vseq;
 
     // Spurious interrupt check can be executed by
     // residue of lowpower task. Since we cannot kill csr op
-    // by disable fork, we have to disable spurious interrup check.
+    // by disable fork, we have to disable spurious interrupt check.
     cfg.invalid_st_test = 1;
 
     wait_for_rom_and_active();

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_wakeup_race_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_wakeup_race_vseq.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // The lowpower_wakeup race test randomly enables wakeups, info capture, and interrupts,
-// and sends wakeups in the temporal vecinity of low power entry. It also sends wakeups
+// and sends wakeups in the temporal vicinity of low power entry. It also sends wakeups
 // after wakeup processing starts.
 class pwrmgr_lowpower_wakeup_race_vseq extends pwrmgr_base_vseq;
   `uvm_object_utils(pwrmgr_lowpower_wakeup_race_vseq)

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_sec_cm_ctrl_config_regwen_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_sec_cm_ctrl_config_regwen_vseq.sv
@@ -1,7 +1,7 @@
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-// Decription:
+// Description:
 // Create low power transition and wakeup a few times.
 // When PWRMGR.CONTROL.LOW_POWER_HINT is set and core_sleep is high,
 // issue random write to PWRMGR.CONTROL and check

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr.sv
@@ -353,7 +353,7 @@ module pwrmgr
   assign hw2reg.fault_status.esc_timeout.de     = esc_timeout_lc_q;
   assign hw2reg.fault_status.esc_timeout.d      = 1'b1;
 
-  // The main power domain glitch automatically causes a reset, so regsitering
+  // The main power domain glitch automatically causes a reset, so registering
   // an alert is functionally pointless.  However, if an attacker somehow manages/
   // to silence the reset, this gives us one potential back-up path through alert_handler.
   // Allow capture of main_pd fault status whenever the system is live.
@@ -488,7 +488,7 @@ module pwrmgr
   assign hw2reg.cfg_cdc_sync.d = 1'b0;
 
   ////////////////////////////
-  ///  Wakup and reset capture
+  ///  Wakeup and reset capture
   ////////////////////////////
 
   // reset and wakeup requests are captured into the slow clock domain and then

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/util/dt.py
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/util/dt.py
@@ -22,7 +22,7 @@ HEADER_EXT_TEMPLATE = """
  * Some instances can have several wakeup signals, e.g. the pinmux has two (`pin` and `usb`).
  * For such IPs, it is not sufficient to know the instance, we also need to know which
  * signal triggered the wakeup. The `wakeup` index can be used to distinguish between those.
- * This value should be casted to the `dt_<ip>_wakeup_t` type of the corresponding IP.
+ * This value should be cast to the `dt_<ip>_wakeup_t` type of the corresponding IP.
  * For example, if the `pwrmgr` has two `pinmux` wakeup sources as described above, it's
  * two wakeup sources will be described as follows:
  * ```c

--- a/hw/top_darjeeling/ip_autogen/rstmgr/data/rstmgr_sec_cm_testplan.hjson
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/data/rstmgr_sec_cm_testplan.hjson
@@ -68,7 +68,7 @@
       name: sec_cm_leaf_rst_shadow
       desc: '''Verify the countermeasure(s) LEAF.RST.SHADOW.
             After power up, create glitch to a shadow leaf reset module.
-            Check if normal leaf reset module is not triggerred.
+            Check if normal leaf reset module is not triggered.
             Do over all {shadow, normal} leaf reset module pairs
             '''
       stage: V2S

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/seq_lib/rstmgr_leaf_rst_shadow_attack_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/seq_lib/rstmgr_leaf_rst_shadow_attack_vseq.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Description:
 // Test assert glitch to shadow leaf reset module and
-// check if nomal reset module got affected or vice versa
+// check if normal reset module got affected or vice versa
 class rstmgr_leaf_rst_shadow_attack_vseq extends rstmgr_base_vseq;
   `uvm_object_utils(rstmgr_leaf_rst_shadow_attack_vseq)
 

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
@@ -384,7 +384,7 @@
     { name:    "ICacheScramble"
       type:    "bit"
       default: "0"
-      desc:    "Scramble instruction cach"
+      desc:    "Scramble instruction cache"
       local:   "false"
       expose:  "true"
     },
@@ -408,7 +408,7 @@
     { name:    "DbgTriggerEn"
       type:    "bit"
       default: "1"
-      desc:    "Enable degug trigger"
+      desc:    "Enable debug trigger"
       local:   "false"
       expose:  "true"
     },
@@ -440,7 +440,7 @@
     { name:    "DmAddrMask"
       type:    "int unsigned"
       default: "4095" //"32'h00000FFF"
-      desc:    "Adress mask of Debug Module"
+      desc:    "Address mask of Debug Module"
       local:   "false"
       expose:  "true"
     }

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/data/rv_core_ibex_testplan.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/data/rv_core_ibex_testplan.hjson
@@ -12,7 +12,7 @@
               - Generate instruction binary and load to memory model
               - Only arithmetic instructions are generated
               - Assert fetch enable to start the core execution
-              - Terminate the test after ecall instructinon in detected
+              - Terminate the test after ecall instruction in detected
               - All instruction results are compared against spike simulation'''
       stage: V1
       tests: ["riscv_arithmetic_basic_test"]
@@ -102,7 +102,7 @@
               - Reserved instructions as specified in RISC-V user mode spec
               - CSR instruction to not implemented CSR
               - Execute S/U mode instructions in machine mode
-            Verify the illlegal instruction exception is raised and the context is captured correctly in privieged mode CSRs
+            Verify the illegal instruction exception is raised and the context is captured correctly in privileged mode CSRs
               - mstatus, mcause, mepc
             Verify the core can resume execution after returning from trap handling'''
       stage: V1
@@ -204,7 +204,7 @@
     {
       name: riscv_debug_ebreakmu_test
       desc: '''
-            - set dcsr.ebreakm/u at begining of test
+            - set dcsr.ebreakm/u at beginning of test
             - randomly insert ebreak instructions in generated code
             - boot randomly into either M/U modes
             - verify that ebreak instructions (in either mode) now enter debug mode'''
@@ -285,7 +285,7 @@
       desc: '''
             Perform all CSR instructions to implemented privileged CSR
             Verify the reset value of the privileged CSR
-            Verify WARL field can be upated properly'''
+            Verify WARL field can be updated properly'''
       stage: V1
       tests: ["riscv_csr_test"]
     }

--- a/hw/top_darjeeling/ip_autogen/rv_plic/data/rv_plic_fpv_testplan.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/data/rv_plic_fpv_testplan.hjson
@@ -8,7 +8,7 @@
     {
       name: LevelTriggeredIp_A
       desc: '''If interrupt pending (`ip`) is triggered, and the level indicator is set to
-            level triggered (`le=0`), then in the prvious clock cycle, the interrupt source
+            level triggered (`le=0`), then in the previous clock cycle, the interrupt source
             (`intr_src_i) should be set to 1.'''
       stage: V2
       tests: ["rv_plic_assert"]
@@ -43,7 +43,7 @@
       name: TriggerIrqForwardCheck_A
       desc: '''If interrupt is enabled (`ie=1`), interrupt pending is set (`ip=1`), interrupt
             input has the highest priority among the rest of the inputs, and its priority is
-            above the threshold. Then in the next clock clcye, the `irq_o` should be triggered,
+            above the threshold. Then in the next clock cycle, the `irq_o` should be triggered,
             and the `irq_id_o` will reflect the input ID.'''
       stage: V2
       tests: ["rv_plic_assert"]

--- a/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic.sv
@@ -423,7 +423,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   //    precondition about the initial state of the prim_alert_sender FSM, guaranteeing that we're
   //    not waiting for an ack.
   //
-  //  - The prim_alert_sender musn't detect a signal integrity issue on the alert signal coming in
+  //  - The prim_alert_sender mustn't detect a signal integrity issue on the alert signal coming in
   //    (alert_rx_i). Normally FpvSecCm tests get analysed with an FPV_ALERT_NO_SIGINT_ERR define,
   //    but we don't have that defined here. To avoid this happening, we want an assertion of the
   //    form "If no integrity error is detected for _SEC_CM_ALERT_MAX_CYC cycles, the alert_p signal

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -9265,7 +9265,7 @@
         }
         {
           name: ICacheScramble
-          desc: Scramble instruction cach
+          desc: Scramble instruction cache
           type: bit
           default: "1"
           local: "false"
@@ -9292,7 +9292,7 @@
         }
         {
           name: DbgTriggerEn
-          desc: Enable degug trigger
+          desc: Enable debug trigger
           type: bit
           default: "1"
           local: "false"
@@ -9328,7 +9328,7 @@
         }
         {
           name: DmAddrMask
-          desc: Adress mask of Debug Module
+          desc: Address mask of Debug Module
           type: int unsigned
           default: tl_main_pkg::ADDR_MASK_RV_DM__MEM
           local: "false"

--- a/hw/top_earlgrey/ip_autogen/gpio/data/gpio.hjson
+++ b/hw/top_earlgrey/ip_autogen/gpio/data/gpio.hjson
@@ -110,7 +110,7 @@
     {
       name: "GPIO.IN.FILTER"
       desc: '''GPIO module provides noise filter control.
-      It can be enabled with programing GPIO.CTRL_EN_INPUT_FILTER.
+      It can be enabled with programming GPIO.CTRL_EN_INPUT_FILTER.
       Once it enables, input value must be stable for 16cycles before transitioning
       '''
     }

--- a/hw/top_earlgrey/ip_autogen/gpio/data/gpio_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/gpio/data/gpio_testplan.hjson
@@ -84,7 +84,7 @@
     }
     {
       name: interrupt_and_noise_filter
-      desc: '''GPIO test that exercise GPIO noise filter functionaliy along with random interrupt
+      desc: '''GPIO test that exercise GPIO noise filter functionality along with random interrupt
             programming and randomly toggling each GPIO pin value, independently of other GPIO pins.
             Each random iteration performs following operations:
             1. programs random values in one or more interrupt registers
@@ -147,7 +147,7 @@
     }
     {
       name: straps_data
-      desc: '''Verify the straps data/valid ouput expected values based on the strap_en and gpio_i inputs:
+      desc: '''Verify the straps data/valid output expected values based on the strap_en and gpio_i inputs:
       - Drive gpio_i input with random values.
       - Set strap_en high for at least one clock cycle.
       - Read the registers hw_straps_data_in and hw_straps_data_in_valid.

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/README.md
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/README.md
@@ -83,9 +83,9 @@ To ensure high quality constrained random stimulus, it is necessary to develop a
 ### Self-checking strategy
 #### Scoreboard
 The `gpio_scoreboard` is primarily used for end to end checking.
-It creates the following tlm analysis fifos to retrieve the data monitored by tlul interface agent monitors:
-* tl_a_chan_fifo: tl address channel
-* tl_d_chan_fifo: tl data channel
+It creates the following tlm analysis FIFOs to retrieve the data monitored by TLUL interface agent monitors:
+* tl_a_chan_fifo: TL address channel
+* tl_d_chan_fifo: TL data channel
 
 GPIO scoreboard monitors all valid GPIO CSR register accesses, activity on GPIO IOs, and interrupt pins. For any monitored write transaction, CSR values are updated in RAL. Based on monitored activity, GPIO scoreboard predicts updated values of required CSRs.
 

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_env.core
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_env.core
@@ -3,7 +3,7 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: lowrisc:earlgrey_dv:gpio_env:0.1
-description: "GPIO DV UVM environmnt"
+description: "GPIO DV UVM environment"
 filesets:
   files_dv:
     depend:

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_env_cov.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_env_cov.sv
@@ -33,7 +33,7 @@ class gpio_out_oe_cov_obj extends uvm_object;
   `uvm_object_utils(gpio_out_oe_cov_obj)
 
   // Covergroup: var1_var2_cg
-  // Covergroup invovling two variables of bit type and are meant to
+  // Covergroup involving two variables of bit type and are meant to
   // be used for cross coverage related to *out* and *oe* registers
   covergroup var1_var2_cg(string name) with function sample(bit var1, bit var2);
     option.per_instance = 1;
@@ -117,7 +117,7 @@ class gpio_env_cov extends cip_base_env_cov #(.CFG_T(gpio_env_cfg));
         intr_state_cov_obj[each_pin] = new($sformatf("intr_state_cov_obj_pin%0d", each_pin));
         // Create per pin coverage interrupts
         foreach(intr_types[each_type]) begin
-          // Per pin coverage for "Intrrupt Control Enable" values
+          // Per pin coverage for "Interrupt Control Enable" values
           // and transitions for each type of interrupt
           intr_ctrl_en_cov_objs[each_pin][{"intr_ctrl_en_", intr_types[each_type]}] =
               new({"intr_ctrl_en_", intr_types[each_type], $sformatf("_pin%0d_cov", each_pin)});

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
@@ -29,7 +29,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
   bit [TL_DW-1:0] last_intr_test_event;
   // Flag to:
   //  (i) indicate that write to INTR_STATE register just happened, and
-  // (ii) store information of which all interupt bits were cleared
+  // (ii) store information of which all interrupt bits were cleared
   bit [TL_DW-1:0] cleared_intr_bits;
   // Flag to indicate that the strap was triggered
   bit first_strap_triggered;
@@ -677,7 +677,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
           end
         end
       end
-      // Coverage Sampling: Cross coverage of (edge tiggered intr type)x(enable)x(state)
+      // Coverage Sampling: Cross coverage of (edge triggered intr type)x(enable)x(state)
       // when type is enabled
       if (cfg.en_cov) begin
         foreach (rising_edge_intr_events[each_bit]) begin
@@ -692,7 +692,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
         end
       end
     end
-    // 2. Look for level triggerred interrupts
+    // 2. Look for level triggered interrupts
     begin
       bit [TL_DW-1:0] lvlhigh_intr_events, lvllow_intr_events;
       for (uint each_bit = 0; each_bit < TL_DW; each_bit++) begin
@@ -710,7 +710,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
           end
         end
       end
-      // Coverage Sampling: Cross coverage of (edge tiggered intr type)x(enable)x(state)
+      // Coverage Sampling: Cross coverage of (edge triggered intr type)x(enable)x(state)
       // when type is enabled
       if (cfg.en_cov) begin
         foreach (lvlhigh_intr_events[each_bit]) begin

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/env/seq_lib/gpio_filter_stress_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/env/seq_lib/gpio_filter_stress_vseq.sv
@@ -8,13 +8,13 @@
 // (  i) programs random set of interrupt registers with random values
 // ( ii) programs CTRL_EN_INPUT_FILTER register to random value
 // (iii) DATA_IN and INTR_STATE are read back and their read data are checked
-//       aginst predicted values.
+//       against predicted values.
 // ( iv) random noise data (data with many frequent asynchronous toggling) is
 //       driven on gpio pins. After few cycles (less than FILTER_CYCLES), the
 //       are toggled to original values before noise was driven. This would make
 //       sure than noise filter does not see stable data on any pin long enough.
 // (  v) DATA_IN and INTR_STATE are read back and their read data are checked
-//       aginst predicted values.
+//       against predicted values.
 // ( vi) Non-noise data is driven multiple times (That is, gpio pins are kept
 //       stable for FILTER_CYCLES or longer). Every time after driving
 //       non-noise data, registers DATA_IN and INTR_STATE are read back and
@@ -50,7 +50,7 @@ class gpio_filter_stress_vseq extends gpio_intr_with_filter_rand_intr_event_vseq
 
       // program random set of interrupt registers
       pgm_intr_regs();
-      // Calclulate update on interrupt state with new interrupt registers'
+      // Calculate update on interrupt state with new interrupt registers'
       // programming
       update_intr_state(crnt_intr_status, stable_value, stable_value);
       // Read and check DATA_IN and INTR_STATE registers
@@ -179,7 +179,7 @@ class gpio_filter_stress_vseq extends gpio_intr_with_filter_rand_intr_event_vseq
         new_intr_state_updates = 1'b1;
       end
     end
-    // Look for level triggerred interrupts
+    // Look for level triggered interrupts
     if (new_intr_state_updates == 1'b0) begin
       if ((pin_crnt_exp_filtered_value == 1'b1 && intr_ctrl_en_lvlhigh[pin_idx]) ||
           (pin_crnt_exp_filtered_value == 1'b0 && intr_ctrl_en_lvllow[pin_idx])) begin
@@ -192,7 +192,7 @@ class gpio_filter_stress_vseq extends gpio_intr_with_filter_rand_intr_event_vseq
 
   task read_and_check(bit [NUM_GPIOS-1:0] predicted_data_in,
                       bit [NUM_GPIOS-1:0] predicted_intr_state);
-    // Read DATA_IN and check if predictaed and actual values match
+    // Read DATA_IN and check if predicted and actual values match
     csr_rd_check(.ptr(ral.data_in), .compare_value(predicted_data_in));
     // Read interrupt value after noise driving is finished
     csr_rd_check(.ptr(ral.intr_state), .compare_value(predicted_intr_state));

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/env/seq_lib/gpio_full_random_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/env/seq_lib/gpio_full_random_vseq.sv
@@ -102,7 +102,7 @@ class gpio_full_random_vseq extends gpio_random_long_reg_writes_reg_reads_vseq;
   // As some of the GPIO pins are already configured and driven as inputs, we need
   // to make sure that DATA_OUT and DATA_OE combination is programmed such that:
   // - Output driven on pin is same as GPIO input value, or
-  // - Outpurt enable on pin is 0
+  // - Output enable on pin is 0
   // By doing either of above two options, we make sure that none of the GPIO pins
   // become unknowns due to multiple drivers with conflicting values.
   task pgm_out_oe_regs(bit [NUM_GPIOS-1:0] gpio_if_pins_o_val,

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/env/seq_lib/gpio_intr_with_filter_rand_intr_event_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/env/seq_lib/gpio_intr_with_filter_rand_intr_event_vseq.sv
@@ -290,7 +290,7 @@ class gpio_intr_with_filter_rand_intr_event_vseq extends gpio_base_vseq;
           new_intr_state_updates[pin] = 1'b1;
         end
       end
-      // Look for level triggerred interrupts
+      // Look for level triggered interrupts
       if (new_intr_state_updates[pin] == 1'b0) begin
         if ((crnt_exp_filtered_value[pin] == 1'b1 && intr_ctrl_en_lvlhigh[pin]) ||
             (crnt_exp_filtered_value[pin] == 1'b0 && intr_ctrl_en_lvllow[pin])) begin

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/env/seq_lib/gpio_rand_straps_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/env/seq_lib/gpio_rand_straps_vseq.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Verify the straps data/valid ouput expected values based on the strap_en and gpio_in inputs:
+// Verify the straps data/valid output expected values based on the strap_en and gpio_in inputs:
 //    - Drive gpio_in input with random values.
 //    - Set the strap_en high for at least one clock cycle.
 //    - Read the registers hw_straps_data_in and hw_straps_data_in_valid.
@@ -99,7 +99,7 @@ class gpio_rand_straps_vseq extends gpio_base_vseq;
   // This task start the strap en test. First it will test the strap enable
   // with the driven gpio_i. On a second step drive the gpio_out and check the strap
   // registers based on that. And finally applies a second reset and check if the strap registers
-  // are reseted.
+  // are reset.
   task start_test();
 
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(gpio_in)

--- a/hw/top_earlgrey/ip_autogen/pinmux/data/pinmux.hjson
+++ b/hw/top_earlgrey/ip_autogen/pinmux/data/pinmux.hjson
@@ -1000,7 +1000,7 @@
                       The behavior is as specified in !!WKUP_DETECTOR,
                       !!WKUP_DETECTOR_CNT_TH and !!WKUP_DETECTOR_PADSEL.
                       '''
-                      // In CSR tests, we do not touch the chip IOs. Thet are either pulled low or
+                      // In CSR tests, we do not touch the chip IOs. They are either pulled low or
                       // or undriven.
                       //
                       // Random writes to the wkup detect CSRs may result in the case where the

--- a/hw/top_earlgrey/ip_autogen/pinmux/data/pinmux_fpv_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/pinmux/data/pinmux_fpv_testplan.hjson
@@ -567,7 +567,7 @@
     {
       name: WkupTimedHigh_A
       desc: '''When register `wkup_detector_en` is set to 1 and `wkup_detector.mode` is set to 3,
-            which means postive pulse cycles are used to detect wakeup. If variable `final_pin_val`
+            which means positive pulse cycles are used to detect wakeup. If variable `final_pin_val`
             stays high longer than the threshold, then `wkup_cause` register's `de` attribute
             should be set to 1.'''
       stage: V1

--- a/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux.sv
+++ b/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux.sv
@@ -12,7 +12,7 @@ module pinmux
   import pinmux_reg_pkg::*;
   import prim_pad_wrapper_pkg::*;
 #(
-  // Taget-specific pinmux configuration passed down from the
+  // Target-specific pinmux configuration passed down from the
   // target-specific top-level.
   parameter target_cfg_t TargetCfg = DefaultTargetCfg,
   parameter bit SecVolatileRawUnlockEn = 0,
@@ -618,7 +618,7 @@ module pinmux
       .wkup_mode_i        ( wkup_mode_e'(reg2hw.wkup_detector[k].mode.q) ),
       .wkup_cnt_th_i      ( reg2hw.wkup_detector_cnt_th[k].q             ),
       .pin_value_i        ( pin_value                                    ),
-      // wakeup request pulse on clk_aon, will be synced back to the bus domain insie the CSR node.
+      // wakeup request pulse on clk_aon, will be synced back to the bus domain inside the CSR node.
       .aon_wkup_pulse_o   ( hw2reg.wkup_cause[k].de                      )
     );
 

--- a/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_strap_sampling.sv
+++ b/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_strap_sampling.sv
@@ -8,7 +8,7 @@ module pinmux_strap_sampling
   import prim_pad_wrapper_pkg::*;
   import lc_ctrl_pkg::*;
 #(
-  // Taget-specific pinmux configuration passed down from the
+  // Target-specific pinmux configuration passed down from the
   // target-specific top-level.
   parameter target_cfg_t TargetCfg = DefaultTargetCfg
 ) (
@@ -261,7 +261,7 @@ module pinmux_strap_sampling
   assign dft_strap_test_o.straps = dft_strap_q;
 
 
-  // During dft enabled states, we continously sample all straps unless
+  // During dft enabled states, we continuously sample all straps unless
   // told not to do so by external dft logic
   logic tap_sampling_en;
   logic dft_hold_tap_sel;
@@ -287,7 +287,7 @@ module pinmux_strap_sampling
     if (strap_en_q && tap_sampling_en) begin
       dft_strap_sample_en = 1'b1;
     end
-    // In DFT-enabled life cycle states we continously
+    // In DFT-enabled life cycle states we continuously
     // sample the TAP straps to be able to switch back and
     // forth between different TAPs.
     if (strap_en_q || tap_sampling_en) begin

--- a/hw/top_earlgrey/ip_autogen/pwm/data/pwm_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwm/data/pwm_testplan.hjson
@@ -15,7 +15,7 @@
             pwm_smoke tests pulse and blink mode for a single channel
 
             Stimulus:
-              - configure the envionment for one PWM channel
+              - configure the environment for one PWM channel
               - program the duty cycle a and b values
               - configure  the ClkDiv and Resn
 

--- a/hw/top_earlgrey/ip_autogen/pwm/dv/env/pwm_env_cov.sv
+++ b/hw/top_earlgrey/ip_autogen/pwm/dv/env/pwm_env_cov.sv
@@ -183,7 +183,7 @@ class pwm_env_cov extends cip_base_env_cov #(.CFG_T(pwm_env_cfg));
     tl_core_eq_cross_cp: cross core_clk_cp, tl_clk_cp;
   endgroup : clock_cg
 
-// Since DUT doesnt have a status register or a output signal to monitor underflow / overflow.
+// Since DUT doesn't have a status register or a output signal to monitor underflow / overflow.
 // passing the coverage from TB calculated values
   covergroup dc_uf_ovf_tb_cg with function sample(bit [PWM_NUM_CHANNELS-1:0] channel, bit uf_ovf);
      // sampled channel

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/data/pwrmgr.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/data/pwrmgr.hjson
@@ -350,21 +350,21 @@
 
 
     { name: "NumRstReqs",
-      desc: "Number of peripheral reset requets",
+      desc: "Number of peripheral reset requests",
       type: "int",
       default: "2",
       local: "true"
     },
 
     { name: "NumIntRstReqs",
-      desc: "Number of pwrmgr internal reset requets",
+      desc: "Number of pwrmgr internal reset requests",
       type: "int",
       default: "2",
       local: "true"
     },
 
     { name: "NumDebugRstReqs",
-      desc: "Number of debug reset requets",
+      desc: "Number of debug reset requests",
       type: "int",
       default: "1",
       local: "true"

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
@@ -98,7 +98,7 @@
             - Expecting fatal alert event and rstreqs[ResetEscIdx].
             - Add assertion to see if u_esc_timeout happens, then
               rstreqs[ResetEscIdx] should be asserted.
-            - After the alert agent processese the alert
+            - After the alert agent processes the alert
               by asserting escalation reset,
               see if dut is back to normal operation state.
             '''

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/doc/theory_of_operation.md
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/doc/theory_of_operation.md
@@ -77,7 +77,7 @@ The fast FSM notifies the reset manager to release the life cycle reset stage, w
 Once OTP sensing completes, the life cycle controller is initialized.
 The initialization of the life cycle controller puts the device into its allowed operating state.
 
-Once life cycle initialization is done, the fast FSM acknowledges the slow FSM rquest and initiates strap sampling.
+Once life cycle initialization is done, the fast FSM acknowledges the slow FSM request and initiates strap sampling.
 Once strap sampling is complete, the sequence continues once the rom controller finishes its checks.
 Note that `flash_ctrl` initialization is explicitly not done here, please see [sections below](#flash-handling) for more details.
 The processor is allowed to start executing, the fast FSM transitions to `Active` state and waits for a software low power entry request.

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv
@@ -124,7 +124,7 @@ interface pwrmgr_if (
   always_comb intr_status = `PATH_TO_DUT.reg2hw.intr_state.q;
 
   // This is only used to determine if an interrupt will be set in case of a reset while in
-  // low power.  tryIt is very hard to perdict if the reset or a wakeup happen first, so this
+  // low power.  tryIt is very hard to predict if the reset or a wakeup happen first, so this
   // signal is used to help instead.
   pwrmgr_pkg::pwrup_cause_e pwrup_cause;
   always_comb pwrup_cause = `PATH_TO_DUT.slow_pwrup_cause;

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_esc_clk_rst_malfunc_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_esc_clk_rst_malfunc_vseq.sv
@@ -23,7 +23,7 @@ class pwrmgr_esc_clk_rst_malfunc_vseq extends pwrmgr_base_vseq;
     wait_for_rom_and_active();
   endtask : body
 
-  // Trigers an escalation timeout fault, either stopping clk_esc_i or driving rst_esc_ni.
+  // Triggers an escalation timeout fault, either stopping clk_esc_i or driving rst_esc_ni.
   //
   // Randomly set a bit to 0 or 1: if 0 stop clk_esc_i, if 1 make rst_esc_ni active.
   task trigger_escalation_timeout();

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_invalid_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_invalid_vseq.sv
@@ -42,7 +42,7 @@ class pwrmgr_lowpower_invalid_vseq extends pwrmgr_base_vseq;
 
     // Spurious interrupt check can be executed by
     // residue of lowpower task. Since we cannot kill csr op
-    // by disable fork, we have to disable spurious interrup check.
+    // by disable fork, we have to disable spurious interrupt check.
     cfg.invalid_st_test = 1;
 
     wait_for_rom_and_active();

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_wakeup_race_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_wakeup_race_vseq.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // The lowpower_wakeup race test randomly enables wakeups, info capture, and interrupts,
-// and sends wakeups in the temporal vecinity of low power entry. It also sends wakeups
+// and sends wakeups in the temporal vicinity of low power entry. It also sends wakeups
 // after wakeup processing starts.
 class pwrmgr_lowpower_wakeup_race_vseq extends pwrmgr_base_vseq;
   `uvm_object_utils(pwrmgr_lowpower_wakeup_race_vseq)

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_sec_cm_ctrl_config_regwen_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_sec_cm_ctrl_config_regwen_vseq.sv
@@ -1,7 +1,7 @@
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-// Decription:
+// Description:
 // Create low power transition and wakeup a few times.
 // When PWRMGR.CONTROL.LOW_POWER_HINT is set and core_sleep is high,
 // issue random write to PWRMGR.CONTROL and check

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr.sv
@@ -358,7 +358,7 @@ module pwrmgr
   assign hw2reg.fault_status.esc_timeout.de     = esc_timeout_lc_q;
   assign hw2reg.fault_status.esc_timeout.d      = 1'b1;
 
-  // The main power domain glitch automatically causes a reset, so regsitering
+  // The main power domain glitch automatically causes a reset, so registering
   // an alert is functionally pointless.  However, if an attacker somehow manages/
   // to silence the reset, this gives us one potential back-up path through alert_handler.
   // Allow capture of main_pd fault status whenever the system is live.
@@ -501,7 +501,7 @@ module pwrmgr
   assign hw2reg.cfg_cdc_sync.d = 1'b0;
 
   ////////////////////////////
-  ///  Wakup and reset capture
+  ///  Wakeup and reset capture
   ////////////////////////////
 
   // reset and wakeup requests are captured into the slow clock domain and then

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/util/dt.py
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/util/dt.py
@@ -22,7 +22,7 @@ HEADER_EXT_TEMPLATE = """
  * Some instances can have several wakeup signals, e.g. the pinmux has two (`pin` and `usb`).
  * For such IPs, it is not sufficient to know the instance, we also need to know which
  * signal triggered the wakeup. The `wakeup` index can be used to distinguish between those.
- * This value should be casted to the `dt_<ip>_wakeup_t` type of the corresponding IP.
+ * This value should be cast to the `dt_<ip>_wakeup_t` type of the corresponding IP.
  * For example, if the `pwrmgr` has two `pinmux` wakeup sources as described above, it's
  * two wakeup sources will be described as follows:
  * ```c

--- a/hw/top_earlgrey/ip_autogen/rstmgr/data/rstmgr_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/data/rstmgr_sec_cm_testplan.hjson
@@ -68,7 +68,7 @@
       name: sec_cm_leaf_rst_shadow
       desc: '''Verify the countermeasure(s) LEAF.RST.SHADOW.
             After power up, create glitch to a shadow leaf reset module.
-            Check if normal leaf reset module is not triggerred.
+            Check if normal leaf reset module is not triggered.
             Do over all {shadow, normal} leaf reset module pairs
             '''
       stage: V2S

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/seq_lib/rstmgr_leaf_rst_shadow_attack_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/seq_lib/rstmgr_leaf_rst_shadow_attack_vseq.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Description:
 // Test assert glitch to shadow leaf reset module and
-// check if nomal reset module got affected or vice versa
+// check if normal reset module got affected or vice versa
 class rstmgr_leaf_rst_shadow_attack_vseq extends rstmgr_base_vseq;
   `uvm_object_utils(rstmgr_leaf_rst_shadow_attack_vseq)
 

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
@@ -384,7 +384,7 @@
     { name:    "ICacheScramble"
       type:    "bit"
       default: "0"
-      desc:    "Scramble instruction cach"
+      desc:    "Scramble instruction cache"
       local:   "false"
       expose:  "true"
     },
@@ -408,7 +408,7 @@
     { name:    "DbgTriggerEn"
       type:    "bit"
       default: "1"
-      desc:    "Enable degug trigger"
+      desc:    "Enable debug trigger"
       local:   "false"
       expose:  "true"
     },
@@ -440,7 +440,7 @@
     { name:    "DmAddrMask"
       type:    "int unsigned"
       default: "4095" //"32'h00000FFF"
-      desc:    "Adress mask of Debug Module"
+      desc:    "Address mask of Debug Module"
       local:   "false"
       expose:  "true"
     }

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/data/rv_core_ibex_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/data/rv_core_ibex_testplan.hjson
@@ -12,7 +12,7 @@
               - Generate instruction binary and load to memory model
               - Only arithmetic instructions are generated
               - Assert fetch enable to start the core execution
-              - Terminate the test after ecall instructinon in detected
+              - Terminate the test after ecall instruction in detected
               - All instruction results are compared against spike simulation'''
       stage: V1
       tests: ["riscv_arithmetic_basic_test"]
@@ -102,7 +102,7 @@
               - Reserved instructions as specified in RISC-V user mode spec
               - CSR instruction to not implemented CSR
               - Execute S/U mode instructions in machine mode
-            Verify the illlegal instruction exception is raised and the context is captured correctly in privieged mode CSRs
+            Verify the illegal instruction exception is raised and the context is captured correctly in privileged mode CSRs
               - mstatus, mcause, mepc
             Verify the core can resume execution after returning from trap handling'''
       stage: V1
@@ -204,7 +204,7 @@
     {
       name: riscv_debug_ebreakmu_test
       desc: '''
-            - set dcsr.ebreakm/u at begining of test
+            - set dcsr.ebreakm/u at beginning of test
             - randomly insert ebreak instructions in generated code
             - boot randomly into either M/U modes
             - verify that ebreak instructions (in either mode) now enter debug mode'''
@@ -285,7 +285,7 @@
       desc: '''
             Perform all CSR instructions to implemented privileged CSR
             Verify the reset value of the privileged CSR
-            Verify WARL field can be upated properly'''
+            Verify WARL field can be updated properly'''
       stage: V1
       tests: ["riscv_csr_test"]
     }

--- a/hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic_fpv_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic_fpv_testplan.hjson
@@ -8,7 +8,7 @@
     {
       name: LevelTriggeredIp_A
       desc: '''If interrupt pending (`ip`) is triggered, and the level indicator is set to
-            level triggered (`le=0`), then in the prvious clock cycle, the interrupt source
+            level triggered (`le=0`), then in the previous clock cycle, the interrupt source
             (`intr_src_i) should be set to 1.'''
       stage: V2
       tests: ["rv_plic_assert"]
@@ -43,7 +43,7 @@
       name: TriggerIrqForwardCheck_A
       desc: '''If interrupt is enabled (`ie=1`), interrupt pending is set (`ip=1`), interrupt
             input has the highest priority among the rest of the inputs, and its priority is
-            above the threshold. Then in the next clock clcye, the `irq_o` should be triggered,
+            above the threshold. Then in the next clock cycle, the `irq_o` should be triggered,
             and the `irq_id_o` will reflect the input ID.'''
       stage: V2
       tests: ["rv_plic_assert"]

--- a/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic.sv
@@ -445,7 +445,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   //    precondition about the initial state of the prim_alert_sender FSM, guaranteeing that we're
   //    not waiting for an ack.
   //
-  //  - The prim_alert_sender musn't detect a signal integrity issue on the alert signal coming in
+  //  - The prim_alert_sender mustn't detect a signal integrity issue on the alert signal coming in
   //    (alert_rx_i). Normally FpvSecCm tests get analysed with an FPV_ALERT_NO_SIGINT_ERR define,
   //    but we don't have that defined here. To avoid this happening, we want an assertion of the
   //    form "If no integrity error is detected for _SEC_CM_ALERT_MAX_CYC cycles, the alert_p signal

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -4345,7 +4345,7 @@
         }
         {
           name: ICacheScramble
-          desc: Scramble instruction cach
+          desc: Scramble instruction cache
           type: bit
           default: "0"
           local: "false"
@@ -4372,7 +4372,7 @@
         }
         {
           name: DbgTriggerEn
-          desc: Enable degug trigger
+          desc: Enable debug trigger
           type: bit
           default: "1"
           local: "false"
@@ -4408,7 +4408,7 @@
         }
         {
           name: DmAddrMask
-          desc: Adress mask of Debug Module
+          desc: Address mask of Debug Module
           type: int unsigned
           default: "4095"
           local: "false"

--- a/hw/top_englishbreakfast/ip_autogen/gpio/data/gpio.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/data/gpio.hjson
@@ -110,7 +110,7 @@
     {
       name: "GPIO.IN.FILTER"
       desc: '''GPIO module provides noise filter control.
-      It can be enabled with programing GPIO.CTRL_EN_INPUT_FILTER.
+      It can be enabled with programming GPIO.CTRL_EN_INPUT_FILTER.
       Once it enables, input value must be stable for 16cycles before transitioning
       '''
     }

--- a/hw/top_englishbreakfast/ip_autogen/gpio/data/gpio_testplan.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/data/gpio_testplan.hjson
@@ -84,7 +84,7 @@
     }
     {
       name: interrupt_and_noise_filter
-      desc: '''GPIO test that exercise GPIO noise filter functionaliy along with random interrupt
+      desc: '''GPIO test that exercise GPIO noise filter functionality along with random interrupt
             programming and randomly toggling each GPIO pin value, independently of other GPIO pins.
             Each random iteration performs following operations:
             1. programs random values in one or more interrupt registers
@@ -147,7 +147,7 @@
     }
     {
       name: straps_data
-      desc: '''Verify the straps data/valid ouput expected values based on the strap_en and gpio_i inputs:
+      desc: '''Verify the straps data/valid output expected values based on the strap_en and gpio_i inputs:
       - Drive gpio_i input with random values.
       - Set strap_en high for at least one clock cycle.
       - Read the registers hw_straps_data_in and hw_straps_data_in_valid.

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/README.md
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/README.md
@@ -83,9 +83,9 @@ To ensure high quality constrained random stimulus, it is necessary to develop a
 ### Self-checking strategy
 #### Scoreboard
 The `gpio_scoreboard` is primarily used for end to end checking.
-It creates the following tlm analysis fifos to retrieve the data monitored by tlul interface agent monitors:
-* tl_a_chan_fifo: tl address channel
-* tl_d_chan_fifo: tl data channel
+It creates the following tlm analysis FIFOs to retrieve the data monitored by TLUL interface agent monitors:
+* tl_a_chan_fifo: TL address channel
+* tl_d_chan_fifo: TL data channel
 
 GPIO scoreboard monitors all valid GPIO CSR register accesses, activity on GPIO IOs, and interrupt pins. For any monitored write transaction, CSR values are updated in RAL. Based on monitored activity, GPIO scoreboard predicts updated values of required CSRs.
 

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_env.core
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_env.core
@@ -3,7 +3,7 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: lowrisc:englishbreakfast_dv:gpio_env:0.1
-description: "GPIO DV UVM environmnt"
+description: "GPIO DV UVM environment"
 filesets:
   files_dv:
     depend:

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_env_cov.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_env_cov.sv
@@ -33,7 +33,7 @@ class gpio_out_oe_cov_obj extends uvm_object;
   `uvm_object_utils(gpio_out_oe_cov_obj)
 
   // Covergroup: var1_var2_cg
-  // Covergroup invovling two variables of bit type and are meant to
+  // Covergroup involving two variables of bit type and are meant to
   // be used for cross coverage related to *out* and *oe* registers
   covergroup var1_var2_cg(string name) with function sample(bit var1, bit var2);
     option.per_instance = 1;
@@ -117,7 +117,7 @@ class gpio_env_cov extends cip_base_env_cov #(.CFG_T(gpio_env_cfg));
         intr_state_cov_obj[each_pin] = new($sformatf("intr_state_cov_obj_pin%0d", each_pin));
         // Create per pin coverage interrupts
         foreach(intr_types[each_type]) begin
-          // Per pin coverage for "Intrrupt Control Enable" values
+          // Per pin coverage for "Interrupt Control Enable" values
           // and transitions for each type of interrupt
           intr_ctrl_en_cov_objs[each_pin][{"intr_ctrl_en_", intr_types[each_type]}] =
               new({"intr_ctrl_en_", intr_types[each_type], $sformatf("_pin%0d_cov", each_pin)});

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
@@ -29,7 +29,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
   bit [TL_DW-1:0] last_intr_test_event;
   // Flag to:
   //  (i) indicate that write to INTR_STATE register just happened, and
-  // (ii) store information of which all interupt bits were cleared
+  // (ii) store information of which all interrupt bits were cleared
   bit [TL_DW-1:0] cleared_intr_bits;
   // Flag to indicate that the strap was triggered
   bit first_strap_triggered;
@@ -677,7 +677,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
           end
         end
       end
-      // Coverage Sampling: Cross coverage of (edge tiggered intr type)x(enable)x(state)
+      // Coverage Sampling: Cross coverage of (edge triggered intr type)x(enable)x(state)
       // when type is enabled
       if (cfg.en_cov) begin
         foreach (rising_edge_intr_events[each_bit]) begin
@@ -692,7 +692,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
         end
       end
     end
-    // 2. Look for level triggerred interrupts
+    // 2. Look for level triggered interrupts
     begin
       bit [TL_DW-1:0] lvlhigh_intr_events, lvllow_intr_events;
       for (uint each_bit = 0; each_bit < TL_DW; each_bit++) begin
@@ -710,7 +710,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
           end
         end
       end
-      // Coverage Sampling: Cross coverage of (edge tiggered intr type)x(enable)x(state)
+      // Coverage Sampling: Cross coverage of (edge triggered intr type)x(enable)x(state)
       // when type is enabled
       if (cfg.en_cov) begin
         foreach (lvlhigh_intr_events[each_bit]) begin

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/seq_lib/gpio_filter_stress_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/seq_lib/gpio_filter_stress_vseq.sv
@@ -8,13 +8,13 @@
 // (  i) programs random set of interrupt registers with random values
 // ( ii) programs CTRL_EN_INPUT_FILTER register to random value
 // (iii) DATA_IN and INTR_STATE are read back and their read data are checked
-//       aginst predicted values.
+//       against predicted values.
 // ( iv) random noise data (data with many frequent asynchronous toggling) is
 //       driven on gpio pins. After few cycles (less than FILTER_CYCLES), the
 //       are toggled to original values before noise was driven. This would make
 //       sure than noise filter does not see stable data on any pin long enough.
 // (  v) DATA_IN and INTR_STATE are read back and their read data are checked
-//       aginst predicted values.
+//       against predicted values.
 // ( vi) Non-noise data is driven multiple times (That is, gpio pins are kept
 //       stable for FILTER_CYCLES or longer). Every time after driving
 //       non-noise data, registers DATA_IN and INTR_STATE are read back and
@@ -50,7 +50,7 @@ class gpio_filter_stress_vseq extends gpio_intr_with_filter_rand_intr_event_vseq
 
       // program random set of interrupt registers
       pgm_intr_regs();
-      // Calclulate update on interrupt state with new interrupt registers'
+      // Calculate update on interrupt state with new interrupt registers'
       // programming
       update_intr_state(crnt_intr_status, stable_value, stable_value);
       // Read and check DATA_IN and INTR_STATE registers
@@ -179,7 +179,7 @@ class gpio_filter_stress_vseq extends gpio_intr_with_filter_rand_intr_event_vseq
         new_intr_state_updates = 1'b1;
       end
     end
-    // Look for level triggerred interrupts
+    // Look for level triggered interrupts
     if (new_intr_state_updates == 1'b0) begin
       if ((pin_crnt_exp_filtered_value == 1'b1 && intr_ctrl_en_lvlhigh[pin_idx]) ||
           (pin_crnt_exp_filtered_value == 1'b0 && intr_ctrl_en_lvllow[pin_idx])) begin
@@ -192,7 +192,7 @@ class gpio_filter_stress_vseq extends gpio_intr_with_filter_rand_intr_event_vseq
 
   task read_and_check(bit [NUM_GPIOS-1:0] predicted_data_in,
                       bit [NUM_GPIOS-1:0] predicted_intr_state);
-    // Read DATA_IN and check if predictaed and actual values match
+    // Read DATA_IN and check if predicted and actual values match
     csr_rd_check(.ptr(ral.data_in), .compare_value(predicted_data_in));
     // Read interrupt value after noise driving is finished
     csr_rd_check(.ptr(ral.intr_state), .compare_value(predicted_intr_state));

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/seq_lib/gpio_full_random_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/seq_lib/gpio_full_random_vseq.sv
@@ -102,7 +102,7 @@ class gpio_full_random_vseq extends gpio_random_long_reg_writes_reg_reads_vseq;
   // As some of the GPIO pins are already configured and driven as inputs, we need
   // to make sure that DATA_OUT and DATA_OE combination is programmed such that:
   // - Output driven on pin is same as GPIO input value, or
-  // - Outpurt enable on pin is 0
+  // - Output enable on pin is 0
   // By doing either of above two options, we make sure that none of the GPIO pins
   // become unknowns due to multiple drivers with conflicting values.
   task pgm_out_oe_regs(bit [NUM_GPIOS-1:0] gpio_if_pins_o_val,

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/seq_lib/gpio_intr_with_filter_rand_intr_event_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/seq_lib/gpio_intr_with_filter_rand_intr_event_vseq.sv
@@ -290,7 +290,7 @@ class gpio_intr_with_filter_rand_intr_event_vseq extends gpio_base_vseq;
           new_intr_state_updates[pin] = 1'b1;
         end
       end
-      // Look for level triggerred interrupts
+      // Look for level triggered interrupts
       if (new_intr_state_updates[pin] == 1'b0) begin
         if ((crnt_exp_filtered_value[pin] == 1'b1 && intr_ctrl_en_lvlhigh[pin]) ||
             (crnt_exp_filtered_value[pin] == 1'b0 && intr_ctrl_en_lvllow[pin])) begin

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/seq_lib/gpio_rand_straps_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/seq_lib/gpio_rand_straps_vseq.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Verify the straps data/valid ouput expected values based on the strap_en and gpio_in inputs:
+// Verify the straps data/valid output expected values based on the strap_en and gpio_in inputs:
 //    - Drive gpio_in input with random values.
 //    - Set the strap_en high for at least one clock cycle.
 //    - Read the registers hw_straps_data_in and hw_straps_data_in_valid.
@@ -99,7 +99,7 @@ class gpio_rand_straps_vseq extends gpio_base_vseq;
   // This task start the strap en test. First it will test the strap enable
   // with the driven gpio_i. On a second step drive the gpio_out and check the strap
   // registers based on that. And finally applies a second reset and check if the strap registers
-  // are reseted.
+  // are reset.
   task start_test();
 
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(gpio_in)

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/data/pinmux.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/data/pinmux.hjson
@@ -1000,7 +1000,7 @@
                       The behavior is as specified in !!WKUP_DETECTOR,
                       !!WKUP_DETECTOR_CNT_TH and !!WKUP_DETECTOR_PADSEL.
                       '''
-                      // In CSR tests, we do not touch the chip IOs. Thet are either pulled low or
+                      // In CSR tests, we do not touch the chip IOs. They are either pulled low or
                       // or undriven.
                       //
                       // Random writes to the wkup detect CSRs may result in the case where the

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/data/pinmux_fpv_testplan.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/data/pinmux_fpv_testplan.hjson
@@ -567,7 +567,7 @@
     {
       name: WkupTimedHigh_A
       desc: '''When register `wkup_detector_en` is set to 1 and `wkup_detector.mode` is set to 3,
-            which means postive pulse cycles are used to detect wakeup. If variable `final_pin_val`
+            which means positive pulse cycles are used to detect wakeup. If variable `final_pin_val`
             stays high longer than the threshold, then `wkup_cause` register's `de` attribute
             should be set to 1.'''
       stage: V1

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux.sv
@@ -12,7 +12,7 @@ module pinmux
   import pinmux_reg_pkg::*;
   import prim_pad_wrapper_pkg::*;
 #(
-  // Taget-specific pinmux configuration passed down from the
+  // Target-specific pinmux configuration passed down from the
   // target-specific top-level.
   parameter target_cfg_t TargetCfg = DefaultTargetCfg,
   parameter bit SecVolatileRawUnlockEn = 0,
@@ -618,7 +618,7 @@ module pinmux
       .wkup_mode_i        ( wkup_mode_e'(reg2hw.wkup_detector[k].mode.q) ),
       .wkup_cnt_th_i      ( reg2hw.wkup_detector_cnt_th[k].q             ),
       .pin_value_i        ( pin_value                                    ),
-      // wakeup request pulse on clk_aon, will be synced back to the bus domain insie the CSR node.
+      // wakeup request pulse on clk_aon, will be synced back to the bus domain inside the CSR node.
       .aon_wkup_pulse_o   ( hw2reg.wkup_cause[k].de                      )
     );
 

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_strap_sampling.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_strap_sampling.sv
@@ -8,7 +8,7 @@ module pinmux_strap_sampling
   import prim_pad_wrapper_pkg::*;
   import lc_ctrl_pkg::*;
 #(
-  // Taget-specific pinmux configuration passed down from the
+  // Target-specific pinmux configuration passed down from the
   // target-specific top-level.
   parameter target_cfg_t TargetCfg = DefaultTargetCfg
 ) (
@@ -261,7 +261,7 @@ module pinmux_strap_sampling
   assign dft_strap_test_o.straps = dft_strap_q;
 
 
-  // During dft enabled states, we continously sample all straps unless
+  // During dft enabled states, we continuously sample all straps unless
   // told not to do so by external dft logic
   logic tap_sampling_en;
   logic dft_hold_tap_sel;
@@ -287,7 +287,7 @@ module pinmux_strap_sampling
     if (strap_en_q && tap_sampling_en) begin
       dft_strap_sample_en = 1'b1;
     end
-    // In DFT-enabled life cycle states we continously
+    // In DFT-enabled life cycle states we continuously
     // sample the TAP straps to be able to switch back and
     // forth between different TAPs.
     if (strap_en_q || tap_sampling_en) begin

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/data/pwrmgr.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/data/pwrmgr.hjson
@@ -305,21 +305,21 @@
 
 
     { name: "NumRstReqs",
-      desc: "Number of peripheral reset requets",
+      desc: "Number of peripheral reset requests",
       type: "int",
       default: "1",
       local: "true"
     },
 
     { name: "NumIntRstReqs",
-      desc: "Number of pwrmgr internal reset requets",
+      desc: "Number of pwrmgr internal reset requests",
       type: "int",
       default: "2",
       local: "true"
     },
 
     { name: "NumDebugRstReqs",
-      desc: "Number of debug reset requets",
+      desc: "Number of debug reset requests",
       type: "int",
       default: "1",
       local: "true"

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
@@ -98,7 +98,7 @@
             - Expecting fatal alert event and rstreqs[ResetEscIdx].
             - Add assertion to see if u_esc_timeout happens, then
               rstreqs[ResetEscIdx] should be asserted.
-            - After the alert agent processese the alert
+            - After the alert agent processes the alert
               by asserting escalation reset,
               see if dut is back to normal operation state.
             '''

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/doc/theory_of_operation.md
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/doc/theory_of_operation.md
@@ -77,7 +77,7 @@ The fast FSM notifies the reset manager to release the life cycle reset stage, w
 Once OTP sensing completes, the life cycle controller is initialized.
 The initialization of the life cycle controller puts the device into its allowed operating state.
 
-Once life cycle initialization is done, the fast FSM acknowledges the slow FSM rquest and initiates strap sampling.
+Once life cycle initialization is done, the fast FSM acknowledges the slow FSM request and initiates strap sampling.
 Once strap sampling is complete, the sequence continues once the rom controller finishes its checks.
 Note that `flash_ctrl` initialization is explicitly not done here, please see [sections below](#flash-handling) for more details.
 The processor is allowed to start executing, the fast FSM transitions to `Active` state and waits for a software low power entry request.

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv
@@ -124,7 +124,7 @@ interface pwrmgr_if (
   always_comb intr_status = `PATH_TO_DUT.reg2hw.intr_state.q;
 
   // This is only used to determine if an interrupt will be set in case of a reset while in
-  // low power.  tryIt is very hard to perdict if the reset or a wakeup happen first, so this
+  // low power.  tryIt is very hard to predict if the reset or a wakeup happen first, so this
   // signal is used to help instead.
   pwrmgr_pkg::pwrup_cause_e pwrup_cause;
   always_comb pwrup_cause = `PATH_TO_DUT.slow_pwrup_cause;

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_esc_clk_rst_malfunc_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_esc_clk_rst_malfunc_vseq.sv
@@ -23,7 +23,7 @@ class pwrmgr_esc_clk_rst_malfunc_vseq extends pwrmgr_base_vseq;
     wait_for_rom_and_active();
   endtask : body
 
-  // Trigers an escalation timeout fault, either stopping clk_esc_i or driving rst_esc_ni.
+  // Triggers an escalation timeout fault, either stopping clk_esc_i or driving rst_esc_ni.
   //
   // Randomly set a bit to 0 or 1: if 0 stop clk_esc_i, if 1 make rst_esc_ni active.
   task trigger_escalation_timeout();

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_invalid_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_invalid_vseq.sv
@@ -42,7 +42,7 @@ class pwrmgr_lowpower_invalid_vseq extends pwrmgr_base_vseq;
 
     // Spurious interrupt check can be executed by
     // residue of lowpower task. Since we cannot kill csr op
-    // by disable fork, we have to disable spurious interrup check.
+    // by disable fork, we have to disable spurious interrupt check.
     cfg.invalid_st_test = 1;
 
     wait_for_rom_and_active();

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_wakeup_race_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_wakeup_race_vseq.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // The lowpower_wakeup race test randomly enables wakeups, info capture, and interrupts,
-// and sends wakeups in the temporal vecinity of low power entry. It also sends wakeups
+// and sends wakeups in the temporal vicinity of low power entry. It also sends wakeups
 // after wakeup processing starts.
 class pwrmgr_lowpower_wakeup_race_vseq extends pwrmgr_base_vseq;
   `uvm_object_utils(pwrmgr_lowpower_wakeup_race_vseq)

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_sec_cm_ctrl_config_regwen_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_sec_cm_ctrl_config_regwen_vseq.sv
@@ -1,7 +1,7 @@
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-// Decription:
+// Description:
 // Create low power transition and wakeup a few times.
 // When PWRMGR.CONTROL.LOW_POWER_HINT is set and core_sleep is high,
 // issue random write to PWRMGR.CONTROL and check

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr.sv
@@ -358,7 +358,7 @@ module pwrmgr
   assign hw2reg.fault_status.esc_timeout.de     = esc_timeout_lc_q;
   assign hw2reg.fault_status.esc_timeout.d      = 1'b1;
 
-  // The main power domain glitch automatically causes a reset, so regsitering
+  // The main power domain glitch automatically causes a reset, so registering
   // an alert is functionally pointless.  However, if an attacker somehow manages/
   // to silence the reset, this gives us one potential back-up path through alert_handler.
   // Allow capture of main_pd fault status whenever the system is live.
@@ -501,7 +501,7 @@ module pwrmgr
   assign hw2reg.cfg_cdc_sync.d = 1'b0;
 
   ////////////////////////////
-  ///  Wakup and reset capture
+  ///  Wakeup and reset capture
   ////////////////////////////
 
   // reset and wakeup requests are captured into the slow clock domain and then

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/util/dt.py
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/util/dt.py
@@ -22,7 +22,7 @@ HEADER_EXT_TEMPLATE = """
  * Some instances can have several wakeup signals, e.g. the pinmux has two (`pin` and `usb`).
  * For such IPs, it is not sufficient to know the instance, we also need to know which
  * signal triggered the wakeup. The `wakeup` index can be used to distinguish between those.
- * This value should be casted to the `dt_<ip>_wakeup_t` type of the corresponding IP.
+ * This value should be cast to the `dt_<ip>_wakeup_t` type of the corresponding IP.
  * For example, if the `pwrmgr` has two `pinmux` wakeup sources as described above, it's
  * two wakeup sources will be described as follows:
  * ```c

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/data/rstmgr_sec_cm_testplan.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/data/rstmgr_sec_cm_testplan.hjson
@@ -68,7 +68,7 @@
       name: sec_cm_leaf_rst_shadow
       desc: '''Verify the countermeasure(s) LEAF.RST.SHADOW.
             After power up, create glitch to a shadow leaf reset module.
-            Check if normal leaf reset module is not triggerred.
+            Check if normal leaf reset module is not triggered.
             Do over all {shadow, normal} leaf reset module pairs
             '''
       stage: V2S

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/seq_lib/rstmgr_leaf_rst_shadow_attack_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/seq_lib/rstmgr_leaf_rst_shadow_attack_vseq.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Description:
 // Test assert glitch to shadow leaf reset module and
-// check if nomal reset module got affected or vice versa
+// check if normal reset module got affected or vice versa
 class rstmgr_leaf_rst_shadow_attack_vseq extends rstmgr_base_vseq;
   `uvm_object_utils(rstmgr_leaf_rst_shadow_attack_vseq)
 

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
@@ -384,7 +384,7 @@
     { name:    "ICacheScramble"
       type:    "bit"
       default: "0"
-      desc:    "Scramble instruction cach"
+      desc:    "Scramble instruction cache"
       local:   "false"
       expose:  "true"
     },
@@ -408,7 +408,7 @@
     { name:    "DbgTriggerEn"
       type:    "bit"
       default: "1"
-      desc:    "Enable degug trigger"
+      desc:    "Enable debug trigger"
       local:   "false"
       expose:  "true"
     },
@@ -440,7 +440,7 @@
     { name:    "DmAddrMask"
       type:    "int unsigned"
       default: "4095" //"32'h00000FFF"
-      desc:    "Adress mask of Debug Module"
+      desc:    "Address mask of Debug Module"
       local:   "false"
       expose:  "true"
     }

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/data/rv_core_ibex_testplan.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/data/rv_core_ibex_testplan.hjson
@@ -12,7 +12,7 @@
               - Generate instruction binary and load to memory model
               - Only arithmetic instructions are generated
               - Assert fetch enable to start the core execution
-              - Terminate the test after ecall instructinon in detected
+              - Terminate the test after ecall instruction in detected
               - All instruction results are compared against spike simulation'''
       stage: V1
       tests: ["riscv_arithmetic_basic_test"]
@@ -102,7 +102,7 @@
               - Reserved instructions as specified in RISC-V user mode spec
               - CSR instruction to not implemented CSR
               - Execute S/U mode instructions in machine mode
-            Verify the illlegal instruction exception is raised and the context is captured correctly in privieged mode CSRs
+            Verify the illegal instruction exception is raised and the context is captured correctly in privileged mode CSRs
               - mstatus, mcause, mepc
             Verify the core can resume execution after returning from trap handling'''
       stage: V1
@@ -204,7 +204,7 @@
     {
       name: riscv_debug_ebreakmu_test
       desc: '''
-            - set dcsr.ebreakm/u at begining of test
+            - set dcsr.ebreakm/u at beginning of test
             - randomly insert ebreak instructions in generated code
             - boot randomly into either M/U modes
             - verify that ebreak instructions (in either mode) now enter debug mode'''
@@ -285,7 +285,7 @@
       desc: '''
             Perform all CSR instructions to implemented privileged CSR
             Verify the reset value of the privileged CSR
-            Verify WARL field can be upated properly'''
+            Verify WARL field can be updated properly'''
       stage: V1
       tests: ["riscv_csr_test"]
     }

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/data/rv_plic_fpv_testplan.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/data/rv_plic_fpv_testplan.hjson
@@ -8,7 +8,7 @@
     {
       name: LevelTriggeredIp_A
       desc: '''If interrupt pending (`ip`) is triggered, and the level indicator is set to
-            level triggered (`le=0`), then in the prvious clock cycle, the interrupt source
+            level triggered (`le=0`), then in the previous clock cycle, the interrupt source
             (`intr_src_i) should be set to 1.'''
       stage: V2
       tests: ["rv_plic_assert"]
@@ -43,7 +43,7 @@
       name: TriggerIrqForwardCheck_A
       desc: '''If interrupt is enabled (`ie=1`), interrupt pending is set (`ip=1`), interrupt
             input has the highest priority among the rest of the inputs, and its priority is
-            above the threshold. Then in the next clock clcye, the `irq_o` should be triggered,
+            above the threshold. Then in the next clock cycle, the `irq_o` should be triggered,
             and the `irq_id_o` will reflect the input ID.'''
       stage: V2
       tests: ["rv_plic_assert"]

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/rtl/rv_plic.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/rtl/rv_plic.sv
@@ -347,7 +347,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   //    precondition about the initial state of the prim_alert_sender FSM, guaranteeing that we're
   //    not waiting for an ack.
   //
-  //  - The prim_alert_sender musn't detect a signal integrity issue on the alert signal coming in
+  //  - The prim_alert_sender mustn't detect a signal integrity issue on the alert signal coming in
   //    (alert_rx_i). Normally FpvSecCm tests get analysed with an FPV_ALERT_NO_SIGINT_ERR define,
   //    but we don't have that defined here. To avoid this happening, we want an assertion of the
   //    form "If no integrity error is detected for _SEC_CM_ALERT_MAX_CYC cycles, the alert_p signal


### PR DESCRIPTION
Really this is the second half of round six, which had to be split up to make CI happy.

> Attempt at neutral correction of what I hope are universal seen as spelling and capitalisation errors in some documentation and code comments.
> 
> Please flag any accidental changes to something that was already correctly spelt. My spell-checker is set to British, not American English, so there's a chance I accidentally "fixed" a spelling I didn't recognise as being the American variant.