### PR TITLE
[entropy_src] Add parameter to disable the CS AES halt request interface, disable it for Darjeeling

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -199,6 +199,13 @@
       local:   "true",
       expose:  "true"
     },
+    { name:    "EnCsAesHaltReqIf",
+      type:    "bit",
+      default: "1",
+      desc:    "Enable (1) or disable (0) the CS AES halt request interface",
+      local:   "true",
+      expose:  "true"
+    },
     { name:    "DistrFifoDepth",
       type:    "int unsigned",
       default: "2",

--- a/hw/ip/entropy_src/dv/entropy_src_rng16bits_sim_cfg.hjson
+++ b/hw/ip/entropy_src/dv/entropy_src_rng16bits_sim_cfg.hjson
@@ -11,6 +11,6 @@
 
   build_opts: ["+define+RNG_BUS_WIDTH=16",
                "+define+RNG_BUS_BIT_SEL_WIDTH=4",
-               "+define+EN_CS_AES_HALT_REQ_IF=1"
-               "+define+DISTR_FIFO_DEPTH=26"]
+               "+define+EN_CS_AES_HALT_REQ_IF=0",
+               "+define+DISTR_FIFO_DEPTH=11"]
 }

--- a/hw/ip/entropy_src/dv/entropy_src_rng16bits_sim_cfg.hjson
+++ b/hw/ip/entropy_src/dv/entropy_src_rng16bits_sim_cfg.hjson
@@ -11,5 +11,6 @@
 
   build_opts: ["+define+RNG_BUS_WIDTH=16",
                "+define+RNG_BUS_BIT_SEL_WIDTH=4",
+               "+define+EN_CS_AES_HALT_REQ_IF=1"
                "+define+DISTR_FIFO_DEPTH=26"]
 }

--- a/hw/ip/entropy_src/dv/entropy_src_rng4bits_sim_cfg.hjson
+++ b/hw/ip/entropy_src/dv/entropy_src_rng4bits_sim_cfg.hjson
@@ -11,5 +11,6 @@
 
   build_opts: ["+define+RNG_BUS_WIDTH=4",
                "+define+RNG_BUS_BIT_SEL_WIDTH=2",
+               "+define+EN_CS_AES_HALT_REQ_IF=1",
                "+define+DISTR_FIFO_DEPTH=2"]
 }

--- a/hw/ip/entropy_src/dv/tb/tb.sv
+++ b/hw/ip/entropy_src/dv/tb/tb.sv
@@ -49,6 +49,7 @@ module tb;
     .RngBusWidth(`RNG_BUS_WIDTH),
     .RngBusBitSelWidth(`RNG_BUS_BIT_SEL_WIDTH),
     .HealthTestWindowWidth(16 + `RNG_BUS_BIT_SEL_WIDTH),
+    .EnCsAesHaltReqIf(`EN_CS_AES_HALT_REQ_IF),
     .DistrFifoDepth(`DISTR_FIFO_DEPTH)
   ) dut (
     .clk_i                        (clk        ),

--- a/hw/ip/entropy_src/rtl/entropy_src.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src.sv
@@ -19,6 +19,7 @@ module entropy_src
   parameter int RngBusBitSelWidth                 = 2,
   parameter int HealthTestWindowWidth             = 18,
   parameter int EsFifoDepth                       = 3,
+  parameter bit EnCsAesHaltReqIf                  = 1'b1,
   parameter int DistrFifoDepth                    = 2,
   parameter bit Stub                              = 1'b0
 ) (
@@ -173,6 +174,7 @@ module entropy_src
     .RngBusBitSelWidth(RngBusBitSelWidth),
     .HealthTestWindowWidth(HealthTestWindowWidth),
     .EsFifoDepth(EsFifoDepth),
+    .EnCsAesHaltReqIf(EnCsAesHaltReqIf),
     .DistrFifoDepth(DistrFifoDepth),
     .BucketHtDataWidth(BucketHtDataWidth),
     .NumBucketHtInst(NumBucketHtInst)

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -6220,6 +6220,15 @@
           name_top: EntropySrcEsFifoDepth
         }
         {
+          name: EnCsAesHaltReqIf
+          desc: Enable (1) or disable (0) the CS AES halt request interface
+          type: bit
+          default: "1"
+          local: "true"
+          expose: "true"
+          name_top: EntropySrcEnCsAesHaltReqIf
+        }
+        {
           name: DistrFifoDepth
           desc: Number of 32-bit entries in the distr FIFO
           type: int unsigned

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -6169,7 +6169,8 @@
         RngBusWidth: "16"
         RngBusBitSelWidth: "4"
         HealthTestWindowWidth: "20"
-        DistrFifoDepth: "26"
+        EnCsAesHaltReqIf: "0"
+        DistrFifoDepth: "11"
       }
       clock_connections:
       {
@@ -6223,7 +6224,7 @@
           name: EnCsAesHaltReqIf
           desc: Enable (1) or disable (0) the CS AES halt request interface
           type: bit
-          default: "1"
+          default: "0"
           local: "true"
           expose: "true"
           name_top: EntropySrcEnCsAesHaltReqIf
@@ -6232,7 +6233,7 @@
           name: DistrFifoDepth
           desc: Number of 32-bit entries in the distr FIFO
           type: int unsigned
-          default: "26"
+          default: "11"
           local: "true"
           expose: "true"
           name_top: EntropySrcDistrFifoDepth

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -783,10 +783,13 @@
       param_decl: {
         RngBusWidth: "16",
         RngBusBitSelWidth: "4",
-        HealthTestWindowWidth: "20"
+        HealthTestWindowWidth: "20",
+        // Disable the CS AES halt request interface as it's not required for Darjeeling to reduce
+        // the amount of backpressure in the hardware pipeline.
+        EnCsAesHaltReqIf: "0",
         // On Darjeeling, in worst case, there is a new 16-bit entropy word from the RNG every 3
-        // cycles. Based on the back pressure formula in the entropy_src, this yields a depth of 26.
-        DistrFifoDepth: "26",
+        // cycles. Based on the back pressure formula in the entropy_src, this yields a depth of 11.
+        DistrFifoDepth: "11",
       },
     },
     { name: "edn0",

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -331,8 +331,8 @@ module top_darjeeling #(
   localparam int SramCtrlRetAonOutstanding = 2;
   // local parameters for entropy_src
   localparam int EntropySrcEsFifoDepth = 3;
-  localparam bit EntropySrcEnCsAesHaltReqIf = 1;
-  localparam int unsigned EntropySrcDistrFifoDepth = 26;
+  localparam bit EntropySrcEnCsAesHaltReqIf = 0;
+  localparam int unsigned EntropySrcDistrFifoDepth = 11;
   // local parameters for sram_ctrl_main
   localparam int SramCtrlMainOutstanding = 2;
   // local parameters for sram_ctrl_mbox

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -331,6 +331,7 @@ module top_darjeeling #(
   localparam int SramCtrlRetAonOutstanding = 2;
   // local parameters for entropy_src
   localparam int EntropySrcEsFifoDepth = 3;
+  localparam bit EntropySrcEnCsAesHaltReqIf = 1;
   localparam int unsigned EntropySrcDistrFifoDepth = 26;
   // local parameters for sram_ctrl_main
   localparam int SramCtrlMainOutstanding = 2;
@@ -2083,6 +2084,7 @@ module top_darjeeling #(
     .RngBusBitSelWidth(EntropySrcRngBusBitSelWidth),
     .HealthTestWindowWidth(EntropySrcHealthTestWindowWidth),
     .EsFifoDepth(EntropySrcEsFifoDepth),
+    .EnCsAesHaltReqIf(EntropySrcEnCsAesHaltReqIf),
     .DistrFifoDepth(EntropySrcDistrFifoDepth),
     .Stub(EntropySrcStub)
   ) u_entropy_src (

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -8084,6 +8084,15 @@
           name_top: EntropySrcEsFifoDepth
         }
         {
+          name: EnCsAesHaltReqIf
+          desc: Enable (1) or disable (0) the CS AES halt request interface
+          type: bit
+          default: "1"
+          local: "true"
+          expose: "true"
+          name_top: EntropySrcEnCsAesHaltReqIf
+        }
+        {
           name: DistrFifoDepth
           desc: Number of 32-bit entries in the distr FIFO
           type: int unsigned

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -259,6 +259,7 @@ module top_earlgrey #(
   localparam int SramCtrlRetAonOutstanding = 2;
   // local parameters for entropy_src
   localparam int EntropySrcEsFifoDepth = 3;
+  localparam bit EntropySrcEnCsAesHaltReqIf = 1;
   localparam int unsigned EntropySrcDistrFifoDepth = 2;
   // local parameters for sram_ctrl_main
   localparam int SramCtrlMainOutstanding = 2;
@@ -2651,6 +2652,7 @@ module top_earlgrey #(
     .RngBusBitSelWidth(EntropySrcRngBusBitSelWidth),
     .HealthTestWindowWidth(EntropySrcHealthTestWindowWidth),
     .EsFifoDepth(EntropySrcEsFifoDepth),
+    .EnCsAesHaltReqIf(EntropySrcEnCsAesHaltReqIf),
     .DistrFifoDepth(EntropySrcDistrFifoDepth),
     .Stub(EntropySrcStub)
   ) u_entropy_src (


### PR DESCRIPTION
As discussed today @Razer6 . This also reduces the depth of the distribution FIFO.