### PR TITLE
[ownership] Add keysets in ownership { dummy, fake} app keys

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -162,7 +162,7 @@ fpga_cw310(
     testonly = True,
     base = ":fpga_cw310_test_rom",
     ecdsa_key = select({
-        "//signing:test_keys": {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "prod_key_0"},
+        "//signing:test_keys": {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0"},
         # We choose key zero in the appkey's keyset, which should be app-key-prod-0.
         "//conditions:default": {"//signing:appkey": "0"},
     }),
@@ -221,7 +221,7 @@ fpga_cw310(
     name = "fpga_hyper310_rom_ext",
     testonly = True,
     base = ":fpga_hyper310_rom_with_fake_keys",
-    ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "prod_key_0"},
+    ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0"},
     exec_env = "fpga_hyper310_rom_ext",
     libs = [
         "//sw/device/lib/arch:boot_stage_owner",
@@ -267,7 +267,7 @@ fpga_cw310(
     name = "fpga_cw310_sival_rom_ext",
     testonly = True,
     base = ":fpga_hyper310_rom_ext",
-    ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "prod_key_0"},
+    ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0"},
     exec_env = "fpga_cw310_sival_rom_ext",
     libs = [
         "//sw/device/lib/arch:boot_stage_owner",
@@ -376,7 +376,7 @@ fpga_cw340(
     testonly = True,
     base = ":fpga_cw340_rom_with_fake_keys",
     ecdsa_key = select({
-        "//signing:test_keys": {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "prod_key_0"},
+        "//signing:test_keys": {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0"},
         # We choose key zero in the appkey's keyset, which should be app-key-prod-0.
         "//conditions:default": {"//signing:appkey": "0"},
     }),
@@ -428,7 +428,7 @@ fpga_cw340(
     name = "fpga_cw340_sival_rom_ext",
     testonly = True,
     base = ":fpga_cw340_rom_ext",
-    ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "prod_key_0"},
+    ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0"},
     exec_env = "fpga_cw340_sival_rom_ext",
     libs = [
         "//sw/device/lib/arch:boot_stage_owner",
@@ -490,7 +490,7 @@ silicon(
     ],
     design = "earlgrey",
     ecdsa_key = select({
-        "//signing:test_keys": {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "prod_key_0"},
+        "//signing:test_keys": {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0"},
         # We choose key zero in the appkey's keyset, which should be app-key-prod-0.
         "//conditions:default": {"//signing:appkey": "0"},
     }),

--- a/sw/device/silicon_creator/lib/ownership/keys/dummy/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/keys/dummy/BUILD
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 load("//rules/opentitan:keyutils.bzl", "key_ecdsa")
+load("//rules:signing.bzl", "keyset")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -56,4 +57,14 @@ key_ecdsa(
     private_key = "app_prod_ecdsa_p256.der",
     pub_key = "app_prod_ecdsa_p256.pub.der",
     type = "ProdKey",
+)
+
+keyset(
+    name = "ecdsa_keyset",
+    build_setting_default = "",
+    keys = {
+        "app_prod_ecdsa_p256.der": "app_prod_0",
+    },
+    profile = "local",
+    tool = "//signing/tokens:local",
 )

--- a/sw/device/silicon_creator/lib/ownership/keys/fake/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/keys/fake/BUILD
@@ -4,6 +4,7 @@
 
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 load("//rules/opentitan:keyutils.bzl", "key_ecdsa", "key_sphincs_plus")
+load("//rules:signing.bzl", "keyset")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -182,4 +183,28 @@ pkg_filegroup(
         ":fpga_dev_files",
     ],
     prefix = "fake_keys",
+)
+
+keyset(
+    name = "ecdsa_keyset",
+    build_setting_default = "",
+    keys = {
+        "app_prod_ecdsa_p256.der": "app_prod_0",
+        "app_dev_ecdsa_p256.der": "app_dev_0",
+        "app_test_ecdsa_p256.der": "app_test_0",
+        "app_unauthorized_ecdsa_p256.der": "app_unauthorized_0",
+    },
+    profile = "local",
+    tool = "//signing/tokens:local",
+)
+
+keyset(
+    name = "spx_keyset",
+    build_setting_default = "",
+    keys = {
+        "app_prod_spx.pem": "app_prod_0",
+        "app_dev_spx.pem": "app_dev_0:domain=PreHashedSha256",
+    },
+    profile = "local",
+    tool = "//signing/tokens:local",
 )

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -27,7 +27,7 @@ opentitan_binary(
     srcs = ["//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test"],
     defines = ["WITH_OWNERSHIP_INFO=1"],
     ecdsa_key = {
-        "//sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa": "app_prod",
+        "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
     },
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
@@ -48,7 +48,7 @@ opentitan_binary(
     testonly = True,
     srcs = ["flash_regions.c"],
     ecdsa_key = {
-        "//sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa": "app_prod",
+        "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
     },
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
@@ -83,7 +83,7 @@ manifest({
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_transfer_any_test
 ownership_transfer_test(
     name = "transfer_any_test",
-    ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa": "app_prod"},
+    ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0"},
     fpga = fpga_params(
         changes_otp = True,
         test_cmd = """
@@ -303,7 +303,7 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "bad_locked_update_test",
     ecdsa_key = {
-        "//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "app_prod",
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
     fpga = fpga_params(
         changes_otp = True,
@@ -497,7 +497,7 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "fpga_owner_upgrade_test",
     ecdsa_key = {
-        "//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "app_prod",
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
     fpga = fpga_params(
         changes_otp = True,
@@ -523,7 +523,7 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "newversion_update_test",
     ecdsa_key = {
-        "//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "app_prod",
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
     fpga = fpga_params(
         changes_otp = True,
@@ -547,7 +547,7 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "newversion_noupdate_test",
     ecdsa_key = {
-        "//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "app_prod",
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
     fpga = fpga_params(
         changes_otp = True,
@@ -571,7 +571,7 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "newversion_nodelock_test",
     ecdsa_key = {
-        "//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "app_prod",
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
     fpga = fpga_params(
         changes_otp = True,
@@ -596,7 +596,7 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "newversion_badlock_test",
     ecdsa_key = {
-        "//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "app_prod",
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
     fpga = fpga_params(
         changes_otp = True,
@@ -627,7 +627,7 @@ opentitan_binary(
         "WITH_KEYMGR=1",
     ],
     ecdsa_key = {
-        "//sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa": "app_prod",
+        "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
     },
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
@@ -654,7 +654,7 @@ ownership_transfer_test(
         "WITH_KEYMGR=1",
     ],
     ecdsa_key = {
-        "//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "app_prod",
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
     fpga = fpga_params(
         binaries = {
@@ -690,7 +690,7 @@ ownership_transfer_test(
 
 ownership_transfer_test(
     name = "transfer_ecdsa_to_pq_test",
-    ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "app_prod"},
+    ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0"},
     fpga = fpga_params(
         binaries = {
             ":boot_test": "boot_test",
@@ -724,7 +724,7 @@ ownership_transfer_test(
 
 ownership_transfer_test(
     name = "transfer_pq_to_pq_test",
-    ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "app_prod"},
+    ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0"},
     fpga = fpga_params(
         binaries = {
             ":boot_test": "boot_test",
@@ -759,7 +759,7 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "newversion_pq_to_pq_update_test",
     ecdsa_key = {
-        "//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "app_prod",
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
     fpga = fpga_params(
         changes_otp = True,
@@ -787,7 +787,7 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "newversion_pq_downgrade_test",
     ecdsa_key = {
-        "//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "app_prod",
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
     fpga = fpga_params(
         changes_otp = True,

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/defs.bzl
@@ -15,7 +15,7 @@ def ownership_transfer_test(
             "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
         },
         ecdsa_key = {
-            "//sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa": "app_prod",
+            "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
         },
         manifest = None,
         data = [

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
@@ -264,37 +264,37 @@ opentitan_test(
 
 _KEYS = {
     "dev": {
-        "ecdsa": {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_dev_ecdsa": "dev_key_0"},
+        "ecdsa": {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_dev_0"},
         "spx": {},
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
     "dev_hybrid_spx_prehashed": {
-        "ecdsa": {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_dev_ecdsa": "dev_key_0"},
-        "spx": {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_dev_spx": "dev_key_0"},
+        "ecdsa": {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_dev_0"},
+        "spx": {"//sw/device/silicon_creator/lib/ownership/keys/fake:spx_keyset": "app_dev_0"},
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
     "prod": {
-        "ecdsa": {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "prod_key_0"},
+        "ecdsa": {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0"},
         "spx": {},
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
     "prod_hybrid_spx_pure": {
-        "ecdsa": {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "prod_key_0"},
-        "spx": {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_spx": "prod_key_0"},
+        "ecdsa": {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0"},
+        "spx": {"//sw/device/silicon_creator/lib/ownership/keys/fake:spx_keyset": "app_prod_0"},
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
     "test": {
-        "ecdsa": {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_test_ecdsa": "test_key_0"},
+        "ecdsa": {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_test_0"},
         "spx": {},
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
     "unauthorized": {
-        "ecdsa": {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_unauthorized_ecdsa": "unauthorized_key_0"},
+        "ecdsa": {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_unauthorized_0"},
         "spx": {},
         "exit_success": DEFAULT_TEST_FAILURE_MSG,
         "exit_failure": DEFAULT_TEST_SUCCESS_MSG,
@@ -351,14 +351,14 @@ manifest(d = {
 opentitan_test(
     name = "isfb_boot_test",
     srcs = [":boot_test"],
-    ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "prod_key_0"},
+    ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0"},
     exec_env = {
         "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(),
     manifest = ":isfb_manifest",
-    spx_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_spx": "prod_key_0"},
+    spx_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:spx_keyset": "app_prod_0"},
     deps = [
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:ottf_main",


### PR DESCRIPTION
Add keysets from lib/ownership to prepare for removal of the key_{ecdsa,
spx} keys.