### PR TITLE
[prim]  Add parameter to control saturation behavior of prim_sum_tree and model that behavior in ENTROPY_SRC

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
@@ -30,6 +30,7 @@ package entropy_src_env_pkg;
   parameter string            LIST_OF_ALERTS[NUM_ALERTS] = {"recov_alert","fatal_alert"};
   parameter uint              OBSERVE_FIFO_DEPTH         = 32;
   parameter uint              POST_HT_WIDTH              = 32;
+  parameter uint              HALF_REG_WIDTH             = 16;
   parameter uint              PRECON_FIFO_DEPTH          = 2;
   parameter uint              BYPASS_FIFO_DEPTH          = 12;
 

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -351,7 +351,12 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
       maxval = maxq[0];
       minq = test_cnt.min();
       minval = minq[0];
-      return test_cnt.sum();
+      result = test_cnt.sum();
+      // Saturation
+      if (result > {HALF_REG_WIDTH{1'b1}}) begin
+        result = {HALF_REG_WIDTH{1'b1}};
+      end
+      return result;
     end
   endfunction
 
@@ -398,6 +403,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
   function int calc_markov_test(queue_of_rng_val_t window, output int maxval, output int minval);
     int pair_cnt[`RNG_BUS_WIDTH];
     int minq[$], maxq[$];
+    int result = '0;
     bit rng_bit_en = (`gmv(ral.conf.rng_bit_enable) == MuBi4True);
     int rng_bit_sel = `gmv(ral.conf.rng_bit_sel);
     // Round down to the highest even number.
@@ -421,7 +427,12 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
       maxval = maxq[0];
       minq = pair_cnt.min();
       minval = minq[0];
-      return pair_cnt.sum();
+      result = pair_cnt.sum();
+      // Saturation
+      if (result > {HALF_REG_WIDTH{1'b1}}) begin
+        result = {HALF_REG_WIDTH{1'b1}};
+      end
+      return result;
     end
   endfunction
 

--- a/hw/ip/entropy_src/rtl/entropy_src_adaptp_ht.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_adaptp_ht.sv
@@ -103,7 +103,7 @@ module entropy_src_adaptp_ht #(
 
   prim_sum_tree #(
     .NumSrc(RngBusWidth),
-    .Width(RegWidth)
+    .InWidth(RegWidth)
   ) u_sum (
     .clk_i       (clk_i),
     .rst_ni      (rst_ni),

--- a/hw/ip/entropy_src/rtl/entropy_src_markov_ht.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_markov_ht.sv
@@ -133,7 +133,7 @@ module entropy_src_markov_ht #(
 
   prim_sum_tree #(
     .NumSrc(RngBusWidth),
-    .Width(RegWidth)
+    .InWidth(RegWidth)
   ) u_sum (
     .clk_i       (clk_i),
     .rst_ni      (rst_ni),

--- a/hw/ip/prim/rtl/prim_sum_tree.sv
+++ b/hw/ip/prim/rtl/prim_sum_tree.sv
@@ -3,26 +3,34 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Based on prim_max_tree, this module implements an explicit binary tree to find the
-// sum of this inputs. The solution has O(N) area and O(log(N)) delay complexity, and
+// sum of its inputs. The solution has O(N) area and O(log(N)) delay complexity, and
 // thus scales well with many input sources.
 //
-// Note that only input values marked as "valid" are respected in the maximum computation.
+// Note that only input values marked as "valid" are respected in the sum computation.
 // Invalid values are treated as 0.
 //
+// By default, the width of the output is equal to the width of the inputs and the internal adders
+// saturate. By setting the `Saturate` parameter to 0, this behavior can be disabled. The
+// intermediate results as well as the output are then properly sized such that no overflows
+// can happen.
 
 `include "prim_assert.sv"
 
 module prim_sum_tree #(
-  parameter int NumSrc = 32,
-  parameter int Width = 8
+  parameter  int NumSrc    = 32,
+  parameter  bit Saturate  = 1'b1,
+  parameter  int InWidth   = 8,
+
+  localparam int NumLevels = $clog2(NumSrc), // derived parameter
+  localparam int OutWidth  = Saturate ? InWidth : InWidth + NumLevels// derived parameter
 ) (
   // The module is combinational - the clock and reset are only used for assertions.
-  input                         clk_i,
-  input                         rst_ni,
-  input [NumSrc-1:0][Width-1:0] values_i,    // Input values
-  input [NumSrc-1:0]            valid_i,     // Input valid bits
-  output logic [Width-1:0]      sum_value_o, // Summation result
-  output logic                  sum_valid_o  // Whether any of the inputs is valid
+  input                           clk_i,
+  input                           rst_ni,
+  input [NumSrc-1:0][InWidth-1:0] values_i,    // Input values
+  input [NumSrc-1:0]              valid_i,     // Input valid bits
+  output logic     [OutWidth-1:0] sum_value_o, // Summation result
+  output logic                    sum_valid_o  // Whether any of the inputs is valid
 );
 
   ///////////////////////
@@ -34,9 +42,8 @@ module prim_sum_tree #(
 
   // Align to powers of 2 for simplicity.
   // A full binary tree with N levels has 2**N + 2**N-1 nodes.
-  localparam int NumLevels = $clog2(NumSrc);
   logic [2**(NumLevels+1)-2:0]               vld_tree;
-  logic [2**(NumLevels+1)-2:0][Width-1:0]    sum_tree;
+  logic [2**(NumLevels+1)-2:0][OutWidth-1:0] sum_tree;
 
   for (genvar level = 0; level < NumLevels+1; level++) begin : gen_tree
     //
@@ -62,20 +69,35 @@ module prim_sum_tree #(
       if (level == NumLevels) begin : gen_leafs
         if (offset < NumSrc) begin : gen_assign
           assign vld_tree[Pa] = valid_i[offset];
-          assign sum_tree[Pa] = values_i[offset];
+          assign sum_tree[Pa] = OutWidth'(values_i[offset]);
         end else begin : gen_tie_off
           assign vld_tree[Pa] = '0;
           assign sum_tree[Pa] = '0;
         end
       // This creates the node assignments.
       end else begin : gen_nodes
-        logic [Width-1:0] node_sum; // Local helper variable
-        // In case only one of the parents is valid, forward that one
-        // In case both parents are valid, forward the one with higher value
-        assign node_sum = (vld_tree[C0] & vld_tree[C1]) ? sum_tree[C1] + sum_tree[C0] :
+        logic [OutWidth-1:0] node_sum;
+        logic [OutWidth-1:0] sum;
+        if (Saturate) begin : gen_sat
+          // `sum` is not sized to hold the carry bit.
+          localparam int LocWidth = OutWidth + 1;
+          logic [LocWidth-1:0] loc_sum;
+          assign loc_sum = LocWidth'(sum_tree[C1]) + LocWidth'(sum_tree[C0]);
+
+          // Saturation
+          assign sum = loc_sum[LocWidth-1] ? {OutWidth{1'b1}} : loc_sum[LocWidth-2:0];
+
+        end else begin : gen_no_sat
+          // Simply add the node inputs - `sum` is properly sized to hold also the carry bit.
+          assign sum = sum_tree[C1] + sum_tree[C0];
+        end
+
+        // In case only one of the parents is valid, forward that one.
+        // In case both parents are valid, forward the sum.
+        assign node_sum = (vld_tree[C0] & vld_tree[C1]) ? sum          :
                           (vld_tree[C0])                ? sum_tree[C0] :
                           (vld_tree[C1])                ? sum_tree[C1] :
-                          {Width'(0)};
+                          {OutWidth'(0)};
 
         // Forwarding muxes
         // Note: these ternaries have triggered a synthesis bug in Vivado versions older
@@ -100,18 +122,27 @@ module prim_sum_tree #(
   // pragma coverage off
 
   // Helper functions for assertions below.
-  function automatic logic [Width-1:0] sum_value (input logic [NumSrc-1:0][Width-1:0] values_i,
-                                                  input logic [NumSrc-1:0]            valid_i);
-    logic [Width-1:0] sum = '0;
+  function automatic logic [OutWidth-1:0] sum_value (
+      input logic [NumSrc-1:0][InWidth-1:0] values_i,
+      input logic [NumSrc-1:0]              valid_i
+  );
+    localparam int LocWidth = Saturate ? OutWidth + 1 : OutWidth;
+    logic [OutWidth-1:0] sum = '0;
+    logic [LocWidth-1:0] loc_sum;
     for (int k = 0; k < NumSrc; k++) begin
       if (valid_i[k]) begin
-        sum += values_i[k];
+        loc_sum = LocWidth'(sum) + LocWidth'(values_i[k]);
+        if (Saturate) begin
+          sum = loc_sum[LocWidth-1] ? {OutWidth{1'b1}} : loc_sum[LocWidth-2:0];
+        end else begin
+          sum = loc_sum;
+        end
       end
     end
     return sum;
   endfunction : sum_value
 
-  logic [Width-1:0] sum_value_exp;
+  logic [OutWidth-1:0] sum_value_exp;
   assign sum_value_exp = sum_value(values_i, valid_i);
   //VCS coverage on
   // pragma coverage on


### PR DESCRIPTION
See commit messages for details. This is especially relevant for the Darjeeling configuration of the ENTROPY_SRC where these counters can overflow otherwise.