### PR TITLE
[sw,cryptolib] p384 remasking

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/p384.c
+++ b/sw/device/lib/crypto/impl/ecc/p384.c
@@ -95,8 +95,8 @@ enum {
   kModeKeygenSideloadInsCnt = 1858743,
   kModeEcdhInsCnt = 1870436,
   kModeEcdhSideloadInsCnt = 1870572,
-  kModeEcdsaSignInsCnt = 1509708,
-  kModeEcdsaSignSideloadInsCnt = 1509844,
+  kModeEcdsaSignInsCnt = 1509753,
+  kModeEcdsaSignSideloadInsCnt = 1509889,
 };
 
 static status_t p384_masked_scalar_write(const p384_masked_scalar_t *src,

--- a/sw/otbn/crypto/p384_sign.s
+++ b/sw/otbn/crypto/p384_sign.s
@@ -161,6 +161,32 @@ p384_sign:
   bn.mov    w27, w16
   bn.mov    w28, w17
 
+  /* [w3,w2] <= n << 64 */
+  bn.rshi w2, w12, w31 >> 192
+  bn.rshi w3, w13, w12 >> 192
+
+  /* Load 448 bits of randomness into [w30,w29] */
+  bn.wsrr  w29, URND
+  bn.wsrr  w30, URND
+  bn.rshi  w30, w31, w30 >> 64
+
+  /* [w9,w8] <= [w30,w29] - [w3,w2] = rand(448) - (n << 64) */
+  bn.sub    w8, w29, w2
+  bn.subb   w9, w30, w3
+
+  /* [w1,w0] <= m mod (n << 64) */
+  bn.sel    w0, w29, w8, FG0.C
+  bn.sel    w1, w30, w9, FG0.C
+
+  /* Clear flags and randomize registers. */
+  bn.sub    w31, w31, w31
+  bn.wsrr    w8, URND
+  bn.wsrr    w9, URND
+  bn.wsrr   w10, URND
+  bn.wsrr   w11, URND
+  bn.wsrr   w29, URND
+  bn.wsrr   w30, URND
+
   /* load 1st share d0 from dmem
      [w11,w10] <= d0 = dmem[dptr_d0] */
   bn.mov    w16, w4      /* prepare for next p384_mulmod488x128_n call below */
@@ -168,22 +194,67 @@ p384_sign:
   bn.lid    x2++, 0(x4)
   bn.lid    x2++, 32(x4)
 
+  /* [w9,w8] <= d0 + m */
+  bn.add    w8, w10, w0
+  bn.addc   w9, w11, w1
+
+  /* [w30,w29] <= d0 + m - (n << 64) */
+  bn.sub    w29, w8, w2
+  bn.subb   w30, w9, w3
+
+  /* [w11,w10] <= d0 + m mod (n << 64) */
+  bn.sel    w10, w8, w29, FG0.C
+  bn.sel    w11, w9, w30, FG0.C
+
   /* [w7,w6] <= ([w11,w10] * w4) mod n = (d0 * alpha) mod n */
   jal       x1, p384_mulmod448x128_n
   bn.mov    w6, w16
   bn.mov    w7, w17
 
+  /* Clear flags and randomize registers. */
+  bn.sub    w31, w31, w31
+  bn.wsrr    w8, URND
+  bn.wsrr    w9, URND
+  bn.wsrr   w10, URND
+  bn.wsrr   w11, URND
+  bn.wsrr   w16, URND
+  bn.wsrr   w17, URND
+  bn.wsrr   w29, URND
+  bn.wsrr   w30, URND
+
   /* load 2nd share d1 from dmem
-     [w11,w10] <= d1 = dmem[dptr_d1] */
+     [w30,w29] <= d1 = dmem[dptr_d1] */
   bn.mov    w16, w4      /* prepare for next p384_mulmod488x128_n call below */
-  li        x2, 10
+  li        x2, 29
   bn.lid    x2++, 0(x5)
   bn.lid    x2++, 32(x5)
+
+  /* [w30,w29] <= d1 - m */
+  bn.sub    w29, w29, w0, FG1
+  bn.subb   w30, w30, w1, FG1
+
+  /* [w9,w8] <= d1 - m + (n << 64) */
+  bn.add    w8, w29, w2
+  bn.addc   w9, w30, w3
+
+  /* [w11,w10] <= d1 - m mod (n << 64) */
+  bn.sel    w10, w8, w29, FG1.C
+  bn.sel    w11, w9, w30, FG1.C
 
   /* [w9,w8] <= ([w11,w10] * w4) mod n = (d1 * alpha) mod n */
   jal       x1, p384_mulmod448x128_n
   bn.mov    w8, w16
   bn.mov    w9, w17
+
+  /* Clear flags and randomize registers. */
+  bn.sub    w31, w31, w31
+  bn.sub    w31, w31, w31, FG1
+  bn.wsrr   w10, URND
+  bn.wsrr   w11, URND
+  bn.wsrr   w16, URND
+  bn.wsrr   w17, URND
+  bn.wsrr   w29, URND
+  bn.wsrr   w30, URND
 
   /* Multiplicative masking of message msg */
 


### PR DESCRIPTION
This PR adds remasking of the secret key scalar each time
the sign routine is executed. This is added as a countermeasure
against SCA.

Based on #28043 