### PR TITLE
[racl_ctrl,dv] Set a sensible number of subscribers in the testbench

### DIFF
--- a/hw/ip_templates/racl_ctrl/data/racl_ctrl.tpldesc.hjson
+++ b/hw/ip_templates/racl_ctrl/data/racl_ctrl.tpldesc.hjson
@@ -52,6 +52,12 @@
       default: "2"
     }
     {
+      name: "nr_external_subscribing_ips"
+      desc: "Number of external RACL subscribing IPs"
+      type: "int"
+      default: "1"
+    }
+    {
       name: "policies"
       desc: "The RACL policies"
       type: "object"

--- a/hw/ip_templates/racl_ctrl/dv/tb.sv.tpl
+++ b/hw/ip_templates/racl_ctrl/dv/tb.sv.tpl
@@ -16,12 +16,8 @@ module tb;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
-  // NOTE: These values come from the top-level instantiation. For now, we're fixing them to
-  // something reasonable, but we don't intend the testing to have an opinion about their values
-  //
-  // *These* values get passed through to the environment through the config db.
-  localparam int unsigned NumSubscribingIps = 5;
-  localparam int unsigned NumExternalSubscribingIps = 5;
+  localparam int unsigned NumSubscribingIps = ${nr_subscribing_ips};
+  localparam int unsigned NumExternalSubscribingIps = ${nr_external_subscribing_ips};
 
   wire clk, rst_n, rst_shadowed_n;
   wire intr_racl_error;

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/data/top_darjeeling_racl_ctrl.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/data/top_darjeeling_racl_ctrl.ipconfig.hjson
@@ -66,5 +66,6 @@
     topname: darjeeling
     uniquified_modules: {}
     enable_shadow_reg: true
+    nr_external_subscribing_ips: 1
   }
 }

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/dv/tb.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/dv/tb.sv
@@ -16,12 +16,8 @@ module tb;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
-  // NOTE: These values come from the top-level instantiation. For now, we're fixing them to
-  // something reasonable, but we don't intend the testing to have an opinion about their values
-  //
-  // *These* values get passed through to the environment through the config db.
-  localparam int unsigned NumSubscribingIps = 5;
-  localparam int unsigned NumExternalSubscribingIps = 5;
+  localparam int unsigned NumSubscribingIps = 11;
+  localparam int unsigned NumExternalSubscribingIps = 1;
 
   wire clk, rst_n, rst_shadowed_n;
   wire intr_racl_error;


### PR DESCRIPTION
This gets rid of a "todo when you get round to it" note that I left myself and forgot about!