### PR TITLE
[sw,e2e] Add fault test for OWNER_SW returning to ROM_EXT

### DIFF
--- a/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
@@ -52,6 +52,10 @@ _FAULT_TEST_CASES = {
         "defines": ["HARDWARE_INTERRUPT=1"],
         "exit_success": "BFV:8b524902",
     },
+    "return_boot_failed": {
+        "defines": ["RETURN_TO_ROM_EXT=1"],
+        "exit_success": "BFV:01524509",  # kErrorRomExtBootFailed
+    },
 }
 
 [

--- a/sw/device/silicon_creator/rom_ext/e2e/handoff/fault_start.S
+++ b/sw/device/silicon_creator/rom_ext/e2e/handoff/fault_start.S
@@ -21,6 +21,11 @@
   .global _start_boot
   .type _start_boot, @function
 _start_boot:
+
+#ifdef RETURN_TO_ROM_EXT
+  ret
+#endif
+
   /**
    * Set up the global pointer `gp`.
    *


### PR DESCRIPTION
The `OWNER_SW` is not intended to return control to the `ROM_EXT`; if it does, the `ROM_EXT` should report an error.

This commit introduces a new fault test, `return_boot_failed`, which simulates the `OWNER_SW` returning to `ROM_EXT` (e.g., via a `ret` instruction) to verify that `ROM_EXT` correctly handles this unexpected scenario.

This test can make sure the `ROM_EXT` handles this error situation correctly.