### PR TITLE
[sw,keymgr] trap if keymgr is idle after starting op

### DIFF
--- a/sw/device/lib/crypto/drivers/keymgr.c
+++ b/sw/device/lib/crypto/drivers/keymgr.c
@@ -72,9 +72,12 @@ static void keymgr_start(keymgr_diversification_t diversification) {
  * Wait for the key manager to finish an operation.
  *
  * Polls the key manager until it is no longer busy. If the operation completed
- * successfully or the key manager was already idle, returns OTCRYPTO_OK. If
- * there was an error during the operation, reads and clears the error code
- * and returns OTCRYPTO_RECOV_ERR; the operation can be retried afterwards.
+ * successfully, returns OTCRYPTO_OK. If there was an error during the
+ * operation, reads and clears the error code and returns OTCRYPTO_RECOV_ERR;
+ * the operation can be retried afterwards.
+ *
+ * This function assumes an operation has already been started by the caller.
+ * The function traps if the keymgr is already idle.
  *
  * @return OK or error.
  */
@@ -91,12 +94,12 @@ static status_t keymgr_wait_until_done(void) {
   // Clear OP_STATUS by writing back the value we read.
   abs_mmio_write32(kBaseAddr + KEYMGR_OP_STATUS_REG_OFFSET, reg);
 
-  // Check if the key manager reported errors. If it is already idle or
-  // completed an operation successfully, return an OK status. No other
-  // statuses (e.g. WIP) should be possible.
+  // Check if the key manager reported errors. If it completed an operation
+  // successfully, return an OK status. No other statuses (e.g. WIP) should
+  // be possible.
+  // The `IDLE` status is left unhandled because the keymgr should never be
+  // idle after an operation has been started by the caller.
   switch (status) {
-    case KEYMGR_OP_STATUS_STATUS_VALUE_IDLE:
-      return OTCRYPTO_OK;
     case KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS:
       return OTCRYPTO_OK;
     case KEYMGR_OP_STATUS_STATUS_VALUE_DONE_ERROR: {

--- a/sw/device/silicon_creator/lib/drivers/keymgr.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.c
@@ -162,9 +162,11 @@ static rom_error_t keymgr_is_idle(void) {
  * Wait for the key manager to finish an operation.
  *
  * Polls the key manager until it is no longer busy. If the operation completed
- * successfully or the key manager was already idle, returns kErrorOk. If
- * there was an error during the operation, reads and clears the error code
- * and returns kErrorKeymgrInternal.
+ * successfully, returns kErrorOk. If there was an error during the operation,
+ * reads and clears the error code and returns kErrorKeymgrInternal.
+ *
+ * This function assumes an operation has already been started by the caller,
+ * and traps if the keymgr is already idle.
  *
  * @return OK or error.
  */
@@ -180,13 +182,12 @@ static rom_error_t keymgr_wait_until_done(void) {
     status = bitfield_field32_read(reg, KEYMGR_OP_STATUS_STATUS_FIELD);
   } while (status == KEYMGR_OP_STATUS_STATUS_VALUE_WIP);
 
-  // Check if the key manager reported errors. If it is already idle or
-  // completed an operation successfully, return an OK status. A `WIP` status
-  // should not be possible because of the check above.
+  // Check if the key manager reported errors. If it completed an operation
+  // successfully, return an OK status. A `WIP` status should not be possible
+  // because of the check above.
+  // The `IDLE` status is left unhandled because the keymgr should never be
+  // idle after an operation has been started by the caller.
   switch (launder32(status)) {
-    case KEYMGR_OP_STATUS_STATUS_VALUE_IDLE:
-      HARDENED_CHECK_EQ(status, KEYMGR_OP_STATUS_STATUS_VALUE_IDLE);
-      return kErrorOk;
     case KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS:
       HARDENED_CHECK_EQ(status, KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
       return kErrorOk;


### PR DESCRIPTION
Fixes:
* #27683

---

The `keymgr_wait_until_done()` function should be only called after an operation has been started by the caller.

This commit removes the `IDLE` status check from the switch-case in `keymgr_wait_until_done()` to enforce this invariant. If the keymgr is found to be `IDLE` the execution will now proceed to the default error-handling case and trigger a trap.