### PR TITLE
WIP: [earlgrey / FPGA] Remove dependencies on software targets

### DIFF
--- a/.github/workflows/bitstream.yml
+++ b/.github/workflows/bitstream.yml
@@ -83,20 +83,22 @@ jobs:
         run: |
           . util/build_consts.sh
 
-          vlnv_path=lowrisc_systems_chip_${{ inputs.top_name }}_${{ inputs.design_suffix }}_0.1
+          bazel_package=//hw/bitstream/vivado
+          bitstream_target=${bazel_package}:fpga_${{ inputs.design_suffix }}
           design_name=chip_${{ inputs.top_name }}_${{ inputs.design_suffix }}
+          logs_base=$(./bazelisk.sh cquery --output=files --output_groups=logs ${bitstream_target})
 
           echo "Synthesis log"
-          cat $OBJ_DIR/hw/top_${{ inputs.top_name }}/${design_name}/build.fpga_${{ inputs.design_suffix }}/${vlnv_path}/synth-vivado/${vlnv_path}.runs/synth_1/runme.log || true
+          cat ${logs_base}/synth_1/runme.log || true
 
           echo "Implementation log"
-          cat $OBJ_DIR/hw/top_${{ inputs.top_name }}/${design_name}/build.fpga_${{ inputs.design_suffix }}/${vlnv_path}/synth-vivado/${vlnv_path}.runs/impl_1/runme.log || true
+          cat ${logs_base}/impl_1/runme.log || true
 
           echo "Utilization report"
-          cat $OBJ_DIR/hw/top_${{ inputs.top_name }}/${design_name}/build.fpga_${{ inputs.design_suffix }}/${vlnv_path}/synth-vivado/${vlnv_path}.runs/impl_1/${design_name}_utilization_placed.rpt || true
+          cat ${logs_base}/impl_1/${design_name}_utilization_placed.rpt || true
 
           echo "Timing summary report"
-          cat $OBJ_DIR/hw/top_${{ inputs.top_name }}/${design_name}/build.fpga_${{ inputs.design_suffix }}/${vlnv_path}/synth-vivado/${vlnv_path}.runs/impl_1/${design_name}_timing_summary_routed.rpt || true
+          cat ${logs_base}/impl_1/${design_name}_timing_summary_routed.rpt || true
 
       - name: Upload step outputs
         uses: actions/upload-artifact@v4

--- a/hw/bitstream/vivado/BUILD
+++ b/hw/bitstream/vivado/BUILD
@@ -11,26 +11,6 @@ load("//rules:bitstreams.bzl", "bitstream_manifest_fragment")
 
 package(default_visibility = ["//visibility:public"])
 
-# The readmem directives in the fusesoc-ized build tree will be in the subdir
-# ${build_root}/${core}/${target}-${tool}/src/lowrisc_prim_util_memload_0/rtl/prim_util_memload.svh,
-# and ${build_root} will be a subdirectory called `build.fpga_cw310` inside of
-# bazel-out/k8-{configname}/bin/hw/bitstream/vivado.
-# Therefore, the relative path between prim_util_memload.svh and the project-root
-# relative $(location ...) resolved labels is up 10 subdirectories.
-_PREFIX = "../../../../../../../../../../.."
-
-_CW310_TESTROM = "//sw/device/lib/testing/test_rom:test_rom_fpga_cw310_scr_vmem"
-
-_CW340_TESTROM = _CW310_TESTROM
-
-_OTP_RMA = "//hw/top_earlgrey/data/otp:img_rma"
-
-_CW310_TESTROM_PATH = "{}/$(location {})".format(_PREFIX, _CW310_TESTROM)
-
-_CW340_TESTROM_PATH = _CW310_TESTROM_PATH
-
-_OTP_RMA_PATH = "{}/$(location {})".format(_PREFIX, _OTP_RMA)
-
 _FPGA_PATH_TMPL = "lowrisc_systems_{}_0.1/synth-vivado/{}"
 
 # Note: all of the targets are tagged with "manual" to prevent them from being
@@ -42,15 +22,9 @@ fusesoc_build(
     testonly = True,
     srcs = [
         "//hw:rtl_files",
-        _CW310_TESTROM,
-        _OTP_RMA,
     ],
     cores = ["//hw:cores"],
     data = ["//hw/ip/otbn:rtl_files"],
-    flags = [
-        "--BootRomInitFile=" + _CW310_TESTROM_PATH,
-        "--OtpMacroMemInitFile=" + _OTP_RMA_PATH,
-    ],
     output_groups = {
         "bitstream": [_FPGA_PATH_TMPL.format("chip_earlgrey_cw310", "lowrisc_systems_chip_earlgrey_cw310_0.1.bit")],
         "mmi": [_FPGA_PATH_TMPL.format("chip_earlgrey_cw310", "memories.mmi")],
@@ -83,15 +57,9 @@ fusesoc_build(
     testonly = True,
     srcs = [
         "//hw:rtl_files",
-        _CW310_TESTROM,
-        _OTP_RMA,
     ],
     cores = ["//hw:cores"],
     data = ["//hw/ip/otbn:rtl_files"],
-    flags = [
-        "--BootRomInitFile=" + _CW310_TESTROM_PATH,
-        "--OtpMacroMemInitFile=" + _OTP_RMA_PATH,
-    ],
     output_groups = {
         "bitstream": [_FPGA_PATH_TMPL.format("chip_earlgrey_cw310_hyperdebug", "lowrisc_systems_chip_earlgrey_cw310_hyperdebug_0.1.bit")],
         "mmi": [_FPGA_PATH_TMPL.format("chip_earlgrey_cw310_hyperdebug", "memories.mmi")],
@@ -124,15 +92,9 @@ fusesoc_build(
     testonly = True,
     srcs = [
         "//hw:rtl_files",
-        _CW340_TESTROM,
-        _OTP_RMA,
     ],
     cores = ["//hw:cores"],
     data = ["//hw/ip/otbn:rtl_files"],
-    flags = [
-        "--BootRomInitFile=" + _CW340_TESTROM_PATH,
-        "--OtpMacroMemInitFile=" + _OTP_RMA_PATH,
-    ],
     output_groups = {
         "bitstream": [_FPGA_PATH_TMPL.format("chip_earlgrey_cw340", "lowrisc_systems_chip_earlgrey_cw340_0.1.bit")],
         "mmi": [_FPGA_PATH_TMPL.format("chip_earlgrey_cw340", "memories.mmi")],

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_pkg.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_pkg.sv
@@ -13,4 +13,11 @@ package prim_xilinx_pkg;
     return 0;
   endfunction
 
+  // Preserves a RAM for updatemem compatibility. For architectures that
+  // support UltraRAM, for example, forces the memory primitive to be block
+  // RAMs.
+  function automatic bit force_ram_updatemem_compat(int width, int depth);
+    return 0;
+  endfunction
+
 endpackage : prim_xilinx_pkg

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_rom.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_rom.sv
@@ -7,7 +7,7 @@
 module prim_rom import prim_rom_pkg::*; #(
   parameter  int Width       = 32,
   parameter  int Depth       = 2048, // 8kB default
-  parameter  string MemInitFile = "", // VMEM file to initialize the memory with
+  parameter      MemInitFile = "", // VMEM file to initialize the memory with
 
   localparam int Aw          = $clog2(Depth)
 ) (

--- a/hw/ip/prim_xilinx_ultrascale/prim_xilinx_ultrascale.core
+++ b/hw/ip/prim_xilinx_ultrascale/prim_xilinx_ultrascale.core
@@ -24,7 +24,7 @@ filesets:
       - lowrisc:prim_xilinx:ram_1p
       - lowrisc:prim_generic:ram_1r1w
       - lowrisc:prim_generic:ram_2p
-      - lowrisc:prim_generic:rom
+      - lowrisc:prim_xilinx:rom
       - lowrisc:prim_generic:usb_diff_rx
       - lowrisc:prim_xilinx:xnor2
       - lowrisc:prim_xilinx:xor2
@@ -48,7 +48,7 @@ mapping:
   "lowrisc:prim:ram_1p"       : lowrisc:prim_xilinx:ram_1p
   "lowrisc:prim:ram_1r1w"     : lowrisc:prim_generic:ram_1r1w
   "lowrisc:prim:ram_2p"       : lowrisc:prim_generic:ram_2p
-  "lowrisc:prim:rom"          : lowrisc:prim_generic:rom
+  "lowrisc:prim:rom"          : lowrisc:prim_xilinx:rom
   "lowrisc:prim:usb_diff_rx"  : lowrisc:prim_generic:usb_diff_rx
   "lowrisc:prim:xnor2"        : lowrisc:prim_xilinx:xnor2
   "lowrisc:prim:xor2"         : lowrisc:prim_xilinx:xor2

--- a/hw/top_earlgrey/chip_earlgrey_cw310.core
+++ b/hw/top_earlgrey/chip_earlgrey_cw310.core
@@ -60,12 +60,12 @@ parameters:
   BootRomInitFile:
     datatype: str
     description: Scrambled boot ROM initialization file in 40 bit vmem hex format
-    default: "../../../../../build-bin/sw/device/lib/testing/test_rom/test_rom_fpga_cw310.scr.39.vmem"
+    default: ""
     paramtype: vlogparam
   OtpMacroMemInitFile:
     datatype: str
     description: OTP initialization file in vmem hex format
-    default: "../../../../../build-bin/sw/device/otp_img/otp_img_fpga_cw310.vmem"
+    default: ""
     paramtype: vlogparam
   # For value definition, please see ip/prim/rtl/prim_pkg.sv
   PRIM_DEFAULT_IMPL:

--- a/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug.core
+++ b/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug.core
@@ -62,12 +62,12 @@ parameters:
   BootRomInitFile:
     datatype: str
     description: Scrambled boot ROM initialization file in 40 bit vmem hex format
-    default: "../../../../../build-bin/sw/device/lib/testing/test_rom/test_rom_fpga_cw310.scr.39.vmem"
+    default: ""
     paramtype: vlogparam
   OtpMacroMemInitFile:
     datatype: str
     description: OTP initialization file in vmem hex format
-    default: "../../../../../build-bin/sw/device/otp_img/otp_img_fpga_cw310.vmem"
+    default: ""
     paramtype: vlogparam
   # For value definition, please see ip/prim/rtl/prim_pkg.sv
   PRIM_DEFAULT_IMPL:

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -12,10 +12,10 @@
 module chip_earlgrey_cw310 #(
   // Path to a VMEM file containing the contents of the boot ROM, which will be
   // baked into the FPGA bitstream.
-  parameter BootRomInitFile = "test_rom_fpga_cw310.32.vmem",
+  parameter BootRomInitFile = "",
   // Path to a VMEM file containing the contents of the emulated OTP, which will be
   // baked into the FPGA bitstream.
-  parameter OtpMacroMemInitFile = "otp_img_fpga_cw310.vmem"
+  parameter OtpMacroMemInitFile = ""
 ) (
   // Dedicated Pads
   inout POR_N, // Manual Pad

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw340.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw340.sv
@@ -12,10 +12,10 @@
 module chip_earlgrey_cw340 #(
   // Path to a VMEM file containing the contents of the boot ROM, which will be
   // baked into the FPGA bitstream.
-  parameter BootRomInitFile = "test_rom_fpga_cw340.32.vmem",
+  parameter BootRomInitFile = "",
   // Path to a VMEM file containing the contents of the emulated OTP, which will be
   // baked into the FPGA bitstream.
-  parameter OtpMacroMemInitFile = "otp_img_fpga_cw340.vmem"
+  parameter OtpMacroMemInitFile = ""
 ) (
   // Dedicated Pads
   inout POR_N, // Manual Pad

--- a/hw/top_earlgrey/rtl/prim_xilinx_pkg.sv
+++ b/hw/top_earlgrey/rtl/prim_xilinx_pkg.sv
@@ -17,4 +17,12 @@ package prim_xilinx_pkg;
     return 0;
   endfunction
 
+  function automatic bit force_ram_updatemem_compat(int width, int depth);
+    // Force the OTP macro to be updatemem compatible
+    if (width == 22 && depth >= 1024) begin
+      return 1;
+    end
+    return 0;
+  endfunction
+
 endpackage : prim_xilinx_pkg

--- a/hw/top_earlgrey/templates/chiplevel.sv.tpl
+++ b/hw/top_earlgrey/templates/chiplevel.sv.tpl
@@ -67,10 +67,10 @@ module chip_${top["name"]}_${target["name"]} #(
 %   else:
   // Path to a VMEM file containing the contents of the boot ROM, which will be
   // baked into the FPGA bitstream.
-  parameter BootRomInitFile = "test_rom_fpga_${target["name"]}.32.vmem",
+  parameter BootRomInitFile = "",
   // Path to a VMEM file containing the contents of the emulated OTP, which will be
   // baked into the FPGA bitstream.
-  parameter OtpMacroMemInitFile = "otp_img_fpga_${target["name"]}.vmem"
+  parameter OtpMacroMemInitFile = ""
 %   endif
 ) (
 % else:

--- a/hw/top_earlgrey/util/vivado_hook_opt_design_post.tcl
+++ b/hw/top_earlgrey/util/vivado_hook_opt_design_post.tcl
@@ -19,16 +19,7 @@ switch ${fpga_family} {
   }
 }
 
-if {[catch [get_cells -hierarchical -filter " NAME =~  *u_rom_ctrl*u_rom*rdata_o_reg_0 && PRIMITIVE_TYPE =~ ${bram_regex} "]]\
- && [catch [get_cells -hierarchical -filter " NAME =~  *u_rom_ctrl*u_rom*rdata_o_reg_1 && PRIMITIVE_TYPE =~ ${bram_regex} "]]\
- && [catch [get_cells -hierarchical -filter " NAME =~  *u_rom_ctrl*u_rom*rdata_o_reg_2 && PRIMITIVE_TYPE =~ ${bram_regex} "]]\
- && [catch [get_cells -hierarchical -filter " NAME =~  *u_rom_ctrl*u_rom*rdata_o_reg_3 && PRIMITIVE_TYPE =~ ${bram_regex} "]]\
- && [catch [get_cells -hierarchical -filter " NAME =~  *u_rom_ctrl*u_rom*rdata_o_reg_4 && PRIMITIVE_TYPE =~ ${bram_regex} "]]\
- && [catch [get_cells -hierarchical -filter " NAME =~  *u_rom_ctrl*u_rom*rdata_o_reg_5 && PRIMITIVE_TYPE =~ ${bram_regex} "]]\
- && [catch [get_cells -hierarchical -filter " NAME =~  *u_rom_ctrl*u_rom*rdata_o_reg_6 && PRIMITIVE_TYPE =~ ${bram_regex} "]]\
- && [catch [get_cells -hierarchical -filter " NAME =~  *u_rom_ctrl*u_rom*rdata_o_reg_7 && PRIMITIVE_TYPE =~ ${bram_regex} "]]\
- && [catch [get_cells -hierarchical -filter " NAME =~  *u_rom_ctrl*u_rom*rdata_o_reg_8 && PRIMITIVE_TYPE =~ ${bram_regex} "]]\
- && [catch [get_cells -hierarchical -filter " NAME =~  *u_rom_ctrl*u_rom*rdata_o_reg_9 && PRIMITIVE_TYPE =~ ${bram_regex} "]] } {
+if {[catch [get_cells -hierarchical -filter "NAME =~  *u_rom_ctrl*u_rom*u_prim_rom* && PRIMITIVE_TYPE =~ ${bram_regex}" ]]} {
   send_msg "Designcheck 2-2" INFO "BRAM implementation found for Boot ROM."
 } else {
   send_msg "Designcheck 2-3" ERROR "BRAM implementation not found for Boot ROM."

--- a/hw/top_earlgrey/util/vivado_hook_write_bitstream_pre.tcl
+++ b/hw/top_earlgrey/util/vivado_hook_write_bitstream_pre.tcl
@@ -232,7 +232,7 @@ dict set memInfo rom [apply $gen_mem_info $rom_brams $mem_type_regex 40 1 "Proce
 # that its data input overruns the address space. The workaround is to pretend
 # the address space is 16 times larger than we would normally compute.
 set otp_brams [split [get_cells -hierarchical -filter " PRIMITIVE_TYPE =~ ${bram_regex} && NAME =~ *u_otp_macro*"] " "]
-dict set memInfo otp [apply $gen_mem_info $otp_brams $mem_type_regex 0 16 "Processor"]
+dict set memInfo otp [apply $gen_mem_info $otp_brams $mem_type_regex 0 16 "MemoryArray"]
 
 # The flash banks have 76-bit wide words. 64 bits are data, and 12 bits are metadata / integrity.
 for {set bank 0} {$bank < 2} {incr bank} {


### PR DESCRIPTION
Add a function to prim_xilinx_pkg to specify whether to force memories to be updatemem-compatible, and implement this in prim_ram_1p.

Add the property to OTP's backing memory.

Remove the software targets as dependencies for the FPGA builds.

(WIP)