### PR TITLE
[sw,rom] Fix CPU debug info OTP configuration in ROM

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/clkmgr/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/clkmgr/BUILD
@@ -1,0 +1,78 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//rules/opentitan:defs.bzl",
+    "opentitan_test",
+)
+load(
+    "//rules:const.bzl",
+    "CONST",
+)
+load(
+    "//rules:otp.bzl",
+    "STD_OTP_OVERLAYS",
+    "otp_hex",
+    "otp_image",
+    "otp_json",
+    "otp_partition",
+)
+load(
+    "//rules/opentitan:defs.bzl",
+    "fpga_params",
+    "opentitan_test",
+)
+
+otp_json(
+    name = "otp_json_jitter_enabled",
+    partitions = [
+        otp_partition(
+            name = "CREATOR_SW_CFG",
+            items = {
+                "CREATOR_SW_CFG_JITTER_EN": otp_hex(CONST.MUBI4_TRUE),
+            },
+        ),
+    ],
+)
+
+otp_image(
+    name = "otp_img_jitter_enabled",
+    src = "//hw/top_earlgrey/data/otp:otp_json_rma",
+    overlays = STD_OTP_OVERLAYS + [":otp_json_jitter_enabled"],
+)
+
+JITTER_TESTCASES = [
+    {
+        "name": "disabled",
+        "fpga": fpga_params(),
+        "defines": ["TEST_JITTER_DISABLED"],
+    },
+    {
+        "name": "enabled",
+        "fpga": fpga_params(
+            otp = ":otp_img_jitter_enabled",
+        ),
+        "defines": ["TEST_JITTER_ENABLED"],
+    },
+]
+
+[
+    opentitan_test(
+        name = "jitter_{}_test".format(testcase["name"]),
+        srcs = ["jitter_test.c"],
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
+        },
+        fpga = testcase["fpga"],
+        local_defines = testcase["defines"],
+        deps = [
+            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//sw/device/lib/dif:base",
+            "//sw/device/lib/dif:clkmgr",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+        ],
+    )
+    for testcase in JITTER_TESTCASES
+]

--- a/sw/device/silicon_creator/rom/e2e/clkmgr/jitter_test.c
+++ b/sw/device/silicon_creator/rom/e2e/clkmgr/jitter_test.c
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/lib/dif/dif_clkmgr.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  dif_clkmgr_t clkmgr;
+  CHECK_DIF_OK(dif_clkmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR), &clkmgr));
+
+  // Get the initial jitter state: this is right after reset so it should be
+  // disabled.
+  dif_toggle_t state;
+  CHECK_DIF_OK(dif_clkmgr_jitter_get_enabled(&clkmgr, &state));
+#if defined(TEST_JITTER_DISABLED)
+  CHECK(state == kDifToggleDisabled);
+#elif defined(TEST_JITTER_ENABLED)
+  CHECK(state == kDifToggleEnabled);
+#else
+#error "no jitter test variant is defined"
+#endif
+  return true;
+}

--- a/sw/device/silicon_creator/rom/e2e/rstmgr/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/rstmgr/BUILD
@@ -1,0 +1,150 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules/opentitan:defs.bzl", "fpga_params", "opentitan_test")
+load(
+    "//rules:const.bzl",
+    "CONST",
+)
+load(
+    "//rules:otp.bzl",
+    "STD_OTP_OVERLAYS",
+    "otp_hex",
+    "otp_image",
+    "otp_json",
+    "otp_partition",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+otp_json(
+    name = "otp_json_cpu_info_enabled",
+    partitions = [
+        otp_partition(
+            name = "OWNER_SW_CFG",
+            items = {
+                "OWNER_SW_CFG_ROM_RSTMGR_INFO_EN": otp_hex(CONST.HARDENED_BYTE_TRUE << 8),
+            },
+        ),
+    ],
+)
+
+otp_image(
+    name = "otp_img_cpu_info_enabled",
+    src = "//hw/top_earlgrey/data/otp:otp_json_rma",
+    overlays = STD_OTP_OVERLAYS + [":otp_json_cpu_info_enabled"],
+)
+
+CPU_INFO_TESTCASES = [
+    {
+        "name": "disabled",
+        "fpga": fpga_params(),
+        "defines": ["TEST_CPU_INFO_DISABLED"],
+    },
+    {
+        "name": "enabled",
+        "fpga": fpga_params(
+            exit_failure = "PASS!",
+
+            # These expectations only applies to earlgrey. See #27498.
+            # After the ROM is fixed, the test should report PASS.
+            exit_success = "BFV:0152530d",
+            otp = ":otp_img_cpu_info_enabled",
+        ),
+        "defines": ["TEST_CPU_INFO_ENABLED"],
+    },
+]
+
+[
+    opentitan_test(
+        name = "cpu_info_{}_test".format(testcase["name"]),
+        srcs = ["cpu_info_test.c"],
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
+        },
+        fpga = testcase["fpga"],
+        local_defines = testcase["defines"],
+        deps = [
+            "//hw/top:rstmgr_c_regs",
+            "//sw/device/lib/base:macros",
+            "//sw/device/lib/base:mmio",
+            "//sw/device/lib/dif:rv_core_ibex",
+            "//sw/device/lib/runtime:log",
+            "//sw/device/lib/testing:rv_core_ibex_testutils",
+            "//sw/device/lib/testing/test_framework:check",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib:error",
+            "//sw/device/silicon_creator/lib/drivers:retention_sram",
+            "//sw/device/silicon_creator/lib/drivers:rstmgr",
+        ],
+    )
+    for testcase in CPU_INFO_TESTCASES
+]
+
+otp_json(
+    name = "otp_json_alert_info_enabled",
+    partitions = [
+        otp_partition(
+            name = "OWNER_SW_CFG",
+            items = {
+                "OWNER_SW_CFG_ROM_RSTMGR_INFO_EN": otp_hex(CONST.HARDENED_BYTE_TRUE << 0),
+            },
+        ),
+    ],
+)
+
+otp_image(
+    name = "otp_img_alert_info_enabled",
+    src = "//hw/top_earlgrey/data/otp:otp_json_rma",
+    overlays = STD_OTP_OVERLAYS + [
+        ":otp_json_alert_info_enabled",
+        "//sw/device/silicon_creator/rom/e2e/shutdown_alert:shutdown_alert_owner_sw_cfg",
+        "//sw/device/silicon_creator/rom/e2e/shutdown_alert:shutdown_alert_digest_cfg",
+    ],
+)
+
+ALERT_INFO_TESTCASES = [
+    {
+        "name": "disabled",
+        "fpga": fpga_params(
+            otp = "//sw/device/silicon_creator/rom/e2e/shutdown_alert:otp_img_shutdown_alert_rma",
+        ),
+        "defines": ["TEST_ALERT_INFO_DISABLED"],
+    },
+    {
+        "name": "enabled",
+        "fpga": fpga_params(
+            otp = ":otp_img_alert_info_enabled",
+        ),
+        "defines": ["TEST_ALERT_INFO_ENABLED"],
+    },
+]
+
+[
+    opentitan_test(
+        name = "alert_info_{}_test".format(testcase["name"]),
+        srcs = ["alert_info_test.c"],
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
+        },
+        fpga = testcase["fpga"],
+        local_defines = testcase["defines"],
+        deps = [
+            "//hw/top:dt",
+            "//hw/top:uart_c_regs",
+            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//sw/device/lib/base:abs_mmio",
+            "//sw/device/lib/base:macros",
+            "//sw/device/lib/runtime:log",
+            "//sw/device/lib/testing/test_framework:check",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib:error",
+            "//sw/device/silicon_creator/lib/drivers:retention_sram",
+            "//sw/device/silicon_creator/lib/drivers:rstmgr",
+        ],
+    )
+    for testcase in ALERT_INFO_TESTCASES
+]

--- a/sw/device/silicon_creator/rom/e2e/rstmgr/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/rstmgr/BUILD
@@ -45,11 +45,6 @@ CPU_INFO_TESTCASES = [
     {
         "name": "enabled",
         "fpga": fpga_params(
-            exit_failure = "PASS!",
-
-            # These expectations only applies to earlgrey. See #27498.
-            # After the ROM is fixed, the test should report PASS.
-            exit_success = "BFV:0152530d",
             otp = ":otp_img_cpu_info_enabled",
         ),
         "defines": ["TEST_CPU_INFO_ENABLED"],

--- a/sw/device/silicon_creator/rom/e2e/rstmgr/alert_info_test.c
+++ b/sw/device/silicon_creator/rom/e2e/rstmgr/alert_info_test.c
@@ -1,0 +1,69 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "hw/top/dt/dt_uart.h"
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#include "hw/top/uart_regs.h"
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static const dt_uart_t kUartDt = kDtUart0;
+
+/**
+ * Base address of the uart registers.
+ */
+static inline uint32_t uart_reg_base(void) {
+  return dt_uart_reg_block(kUartDt, kDtUartRegBlockCore);
+}
+
+static void uart_alert_trigger(void) {
+  abs_mmio_write32(
+      uart_reg_base() + UART_ALERT_TEST_REG_OFFSET,
+      bitfield_bit32_write(0, UART_ALERT_TEST_FATAL_FAULT_BIT, true));
+}
+
+static void check_alert_info_dump(void) {
+  rstmgr_info_t info;
+
+  rstmgr_alert_info_collect(&info);
+  uint32_t all_values = 0;
+  for (int i = 0; i < info.length; i++) {
+    LOG_INFO("DUMP[%d]: 0x%x", i, info.info[i]);
+    all_values |= info.info[i];
+  }
+
+#if defined(TEST_ALERT_INFO_ENABLED)
+  CHECK(all_values != 0, "All crashdump values are zero.");
+#elif defined(TEST_ALERT_INFO_DISABLED)
+  CHECK(all_values == 0, "All crashdump values should be zero.");
+#else
+#error "no alert info test variant is defined"
+#endif
+}
+
+bool test_main(void) {
+  uint32_t reset_reasons = retention_sram_get()->creator.reset_reasons;
+  if (bitfield_bit32_read(reset_reasons, kRstmgrReasonPowerOn)) {
+    LOG_INFO("No alert escalation, going to trigger alert...");
+    uart_alert_trigger();
+    LOG_INFO("UART alert routine returned!");
+    return false;
+  } else if (rstmgr_is_hw_reset_reason(kDtRstmgrAon, reset_reasons,
+                                       kDtInstanceIdAlertHandler, 0)) {
+    LOG_INFO("Escalation detected!");
+    check_alert_info_dump();
+    return true;
+  } else {
+    LOG_INFO("Unhandled reset reason: %d", reset_reasons);
+    return false;
+  }
+}

--- a/sw/device/silicon_creator/rom/e2e/rstmgr/cpu_info_test.c
+++ b/sw/device/silicon_creator/rom/e2e/rstmgr/cpu_info_test.c
@@ -1,0 +1,96 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_rv_core_ibex.h"
+#include "sw/device/lib/testing/rv_core_ibex_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#include "hw/top/rstmgr_regs.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+enum {
+  kCpuDumpSize = 8,
+  kIllegalAddr0 = 0xF0000000,
+};
+
+// The labels to points in the code of which the memory address is needed.
+extern const char kFaultAddrStart[];
+extern const char kFaultAddrEnd[];
+
+// This variable is used to ensure loads from an address aren't optimised out.
+volatile static uint32_t addr_val;
+
+/**
+ * Overrides the default OTTF exception handler.
+ */
+void ottf_exception_handler(uint32_t *exc_info) {
+  OT_DISCARD(exc_info);
+  rstmgr_reset();
+}
+
+static void check_cpu_info_dump(void) {
+  LOG_INFO("Checking CPU info dump after fault.");
+
+  rstmgr_info_t info;
+
+  rstmgr_cpu_info_collect(&info);
+  CHECK(info.length == kCpuDumpSize,
+        "The observed cpu info dump's size was %d, "
+        "but it was expected to be %d",
+        info.length, kCpuDumpSize);
+
+  dif_rv_core_ibex_crash_dump_state_t dump =
+      ((dif_rv_core_ibex_crash_dump_info_t *)info.info)->fault_state;
+
+  RV_CORE_IBEX_TESTUTILS_PRINT_CRASH_DUMP(dump);
+
+#if defined(TEST_CPU_INFO_ENABLED)
+  uint32_t start = (uint32_t)kFaultAddrStart;
+  uint32_t end = (uint32_t)kFaultAddrEnd;
+
+  CHECK(kIllegalAddr0 == dump.mtval,
+        "Last Exception Access Addr: Expected 0x%x != Observed 0x%x",
+        kIllegalAddr0, dump.mtval);
+  CHECK(start <= dump.mpec && dump.mpec <= end,
+        "The Observed MPEC, 0x%x, was not in the expected range [0x%x, 0x%x]",
+        dump.mpec, start, end);
+#elif defined(TEST_CPU_INFO_DISABLED)
+  CHECK(dump.mtval == 0, "mtval should be zero, got 0x%x", dump.mtval);
+  CHECK(dump.mpec == 0, "mpec should be zero, got 0x%x", dump.mpec);
+  CHECK(dump.mdaa == 0, "mdaa should be zero, got 0x%x", dump.mdaa);
+  CHECK(dump.mnpc == 0, "mnpc should be zero, got 0x%x", dump.mnpc);
+  CHECK(dump.mcpc == 0, "mcpc should be zero, got 0x%x", dump.mcpc);
+#else
+#error "no cpu info test variant is defined"
+#endif
+}
+
+bool test_main(void) {
+  uint32_t reset_reasons = retention_sram_get()->creator.reset_reasons;
+  switch (reset_reasons) {
+    case 1 << kRstmgrReasonPowerOn:
+      LOG_INFO("Triggering fault.");
+
+      OT_ADDRESSABLE_LABEL(kFaultAddrStart);
+      addr_val = mmio_region_read32(mmio_region_from_addr(kIllegalAddr0), 0);
+      OT_ADDRESSABLE_LABEL(kFaultAddrEnd);
+      return false;
+    case 1 << kRstmgrReasonSoftwareRequest:
+      LOG_INFO("Escalation detected!");
+      check_cpu_info_dump();
+      return true;
+    default:
+      LOG_INFO("Unhandled reset reason: %d", reset_reasons);
+      return false;
+  }
+
+  return false;
+}

--- a/sw/device/silicon_creator/rom/rom_start.S
+++ b/sw/device/silicon_creator/rom/rom_start.S
@@ -212,7 +212,7 @@ LABEL_FOR_TEST(kRomStartStoreT1ToBiteThold)
   andi t2, t0, 0xff
   bne  t2, t1, .L_skip_rstmgr_cpu_info_en
   li   t2, (1 << RSTMGR_CPU_INFO_CTRL_EN_BIT)
-  sw   t2,  RSTMGR_ALERT_INFO_CTRL_REG_OFFSET(a0)
+  sw   t2,  RSTMGR_CPU_INFO_CTRL_REG_OFFSET(a0)
 .L_skip_rstmgr_cpu_info_en:
 
 LABEL_FOR_TEST(kRomStartWatchdogEnabled)


### PR DESCRIPTION
This PR resolves #27498 on the `master` branch:
* #27498

The first two commits are cherry-picked from #28058, with extra multi-top fixes.
The final commit resolves the bug and activates the previously cherry-picked test.