### PR TITLE
[bazel] Move EARLGREY_SLOTS to a separate defs.bzl file

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//hw/top_earlgrey:defs.bzl", "EARLGREY_SLOTS")
 load(
     "//rules:autogen.bzl",
     "autogen_hjson_c_header",
@@ -72,14 +73,6 @@ filegroup(
 CLEAR_MANIFEST = manifest(d = {
     "name": "none_manifest",
 })
-
-EARLGREY_SLOTS = {
-    "rom_ext_slot_a": "0x0",
-    "rom_ext_slot_b": "0x80000",
-    "owner_slot_a": "0x10000",
-    "owner_slot_b": "0x90000",
-    "rom_ext_size": "0x10000",
-}
 
 ###########################################################################
 # FPGA CW310 Environments

--- a/hw/top_earlgrey/defs.bzl
+++ b/hw/top_earlgrey/defs.bzl
@@ -1,0 +1,11 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+EARLGREY_SLOTS = {
+    "rom_ext_slot_a": "0x0",
+    "rom_ext_slot_b": "0x80000",
+    "owner_slot_a": "0x10000",
+    "owner_slot_b": "0x90000",
+    "rom_ext_size": "0x10000",
+}


### PR DESCRIPTION
This change moves the `EARLGREY_SLOTS` definition from `hw/top_earlgrey/BUILD` to a new shared Bazel definition file `hw/top_earlgrey/defs.bzl`.

This change makes it possible to reference the slots when defining new exec environments in the private repository.