### PR TITLE
[hw,keymgr_dpe,rtl] Support 8 key slots

### DIFF
--- a/hw/ip/keymgr_dpe/data/keymgr_dpe.hjson
+++ b/hw/ip/keymgr_dpe/data/keymgr_dpe.hjson
@@ -515,7 +515,7 @@ countermeasures: [
           ]
         },
 
-        { bits: "15:14",
+        { bits: "16:14",
           name: "SLOT_SRC_SEL",
           resval: "0x0"
           desc: '''
@@ -523,7 +523,7 @@ countermeasures: [
           '''
         },
 
-        { bits: "19:18",
+        { bits: "20:18",
           name: "SLOT_DST_SEL",
           resval: "0x0"
           desc: '''

--- a/hw/ip/keymgr_dpe/doc/registers.md
+++ b/hw/ip/keymgr_dpe/doc/registers.md
@@ -176,21 +176,21 @@ Other values are reserved.
 Key manager operation controls
 - Offset: `0x18`
 - Reset default: `0x10`
-- Reset mask: `0xcf070`
+- Reset mask: `0x1df070`
 - Register enable: [`CFG_REGWEN`](#cfg_regwen)
 
 ### Fields
 
 ```wavejson
-{"reg": [{"bits": 4}, {"name": "OPERATION", "bits": 3, "attr": ["rw"], "rotate": -90}, {"bits": 5}, {"name": "DEST_SEL", "bits": 2, "attr": ["rw"], "rotate": -90}, {"name": "SLOT_SRC_SEL", "bits": 2, "attr": ["rw"], "rotate": -90}, {"bits": 2}, {"name": "SLOT_DST_SEL", "bits": 2, "attr": ["rw"], "rotate": -90}, {"bits": 12}], "config": {"lanes": 1, "fontsize": 10, "vspace": 140}}
+{"reg": [{"bits": 4}, {"name": "OPERATION", "bits": 3, "attr": ["rw"], "rotate": -90}, {"bits": 5}, {"name": "DEST_SEL", "bits": 2, "attr": ["rw"], "rotate": -90}, {"name": "SLOT_SRC_SEL", "bits": 3, "attr": ["rw"], "rotate": -90}, {"bits": 1}, {"name": "SLOT_DST_SEL", "bits": 3, "attr": ["rw"], "rotate": -90}, {"bits": 11}], "config": {"lanes": 1, "fontsize": 10, "vspace": 140}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name                                            |
 |:------:|:------:|:-------:|:------------------------------------------------|
-| 31:20  |        |         | Reserved                                        |
-| 19:18  |   rw   |   0x0   | [SLOT_DST_SEL](#control_shadowed--slot_dst_sel) |
-| 17:16  |        |         | Reserved                                        |
-| 15:14  |   rw   |   0x0   | [SLOT_SRC_SEL](#control_shadowed--slot_src_sel) |
+| 31:21  |        |         | Reserved                                        |
+| 20:18  |   rw   |   0x0   | [SLOT_DST_SEL](#control_shadowed--slot_dst_sel) |
+|   17   |        |         | Reserved                                        |
+| 16:14  |   rw   |   0x0   | [SLOT_SRC_SEL](#control_shadowed--slot_src_sel) |
 | 13:12  |   rw   |   0x0   | [DEST_SEL](#control_shadowed--dest_sel)         |
 |  11:7  |        |         | Reserved                                        |
 |  6:4   |   rw   |   0x1   | [OPERATION](#control_shadowed--operation)       |

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_pkg.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_pkg.sv
@@ -7,7 +7,7 @@ package keymgr_dpe_pkg;
   // Most of the parameters are directly reused from keymgr_pkg
   import keymgr_pkg::*;
 
-  parameter int DpeNumSlots = 4;
+  parameter int DpeNumSlots = 8;
   parameter int DpeNumSlotsWidth = prim_util_pkg::vbits(DpeNumSlots);
 
   // keymgr and keymgr_dpe have different maximum KMAC input widths. The below widths correspond to

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_pkg.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_pkg.sv
@@ -60,10 +60,10 @@ package keymgr_dpe_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [1:0]  q;
+      logic [2:0]  q;
     } slot_dst_sel;
     struct packed {
-      logic [1:0]  q;
+      logic [2:0]  q;
     } slot_src_sel;
     struct packed {
       logic [1:0]  q;
@@ -330,12 +330,12 @@ package keymgr_dpe_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    keymgr_dpe_reg2hw_intr_state_reg_t intr_state; // [635:635]
-    keymgr_dpe_reg2hw_intr_enable_reg_t intr_enable; // [634:634]
-    keymgr_dpe_reg2hw_intr_test_reg_t intr_test; // [633:632]
-    keymgr_dpe_reg2hw_alert_test_reg_t alert_test; // [631:628]
-    keymgr_dpe_reg2hw_start_reg_t start; // [627:627]
-    keymgr_dpe_reg2hw_control_shadowed_reg_t control_shadowed; // [626:618]
+    keymgr_dpe_reg2hw_intr_state_reg_t intr_state; // [637:637]
+    keymgr_dpe_reg2hw_intr_enable_reg_t intr_enable; // [636:636]
+    keymgr_dpe_reg2hw_intr_test_reg_t intr_test; // [635:634]
+    keymgr_dpe_reg2hw_alert_test_reg_t alert_test; // [633:630]
+    keymgr_dpe_reg2hw_start_reg_t start; // [629:629]
+    keymgr_dpe_reg2hw_control_shadowed_reg_t control_shadowed; // [628:618]
     keymgr_dpe_reg2hw_sideload_clear_reg_t sideload_clear; // [617:615]
     keymgr_dpe_reg2hw_reseed_interval_shadowed_reg_t reseed_interval_shadowed; // [614:599]
     keymgr_dpe_reg2hw_slot_policy_regwen_reg_t slot_policy_regwen; // [598:597]

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_top.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_top.sv
@@ -151,12 +151,12 @@ module keymgr_dpe_reg_top (
   logic [1:0] control_shadowed_dest_sel_wd;
   logic control_shadowed_dest_sel_storage_err;
   logic control_shadowed_dest_sel_update_err;
-  logic [1:0] control_shadowed_slot_src_sel_qs;
-  logic [1:0] control_shadowed_slot_src_sel_wd;
+  logic [2:0] control_shadowed_slot_src_sel_qs;
+  logic [2:0] control_shadowed_slot_src_sel_wd;
   logic control_shadowed_slot_src_sel_storage_err;
   logic control_shadowed_slot_src_sel_update_err;
-  logic [1:0] control_shadowed_slot_dst_sel_qs;
-  logic [1:0] control_shadowed_slot_dst_sel_wd;
+  logic [2:0] control_shadowed_slot_dst_sel_qs;
+  logic [2:0] control_shadowed_slot_dst_sel_wd;
   logic control_shadowed_slot_dst_sel_storage_err;
   logic control_shadowed_slot_dst_sel_update_err;
   logic sideload_clear_we;
@@ -577,11 +577,11 @@ module keymgr_dpe_reg_top (
     .err_storage (control_shadowed_dest_sel_storage_err)
   );
 
-  //   F[slot_src_sel]: 15:14
+  //   F[slot_src_sel]: 16:14
   prim_subreg_shadow #(
-    .DW      (2),
+    .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0),
+    .RESVAL  (3'h0),
     .Mubi    (1'b0)
   ) u_control_shadowed_slot_src_sel (
     .clk_i   (clk_i),
@@ -613,11 +613,11 @@ module keymgr_dpe_reg_top (
     .err_storage (control_shadowed_slot_src_sel_storage_err)
   );
 
-  //   F[slot_dst_sel]: 19:18
+  //   F[slot_dst_sel]: 20:18
   prim_subreg_shadow #(
-    .DW      (2),
+    .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0),
+    .RESVAL  (3'h0),
     .Mubi    (1'b0)
   ) u_control_shadowed_slot_dst_sel (
     .clk_i   (clk_i),
@@ -2852,9 +2852,9 @@ module keymgr_dpe_reg_top (
 
   assign control_shadowed_dest_sel_wd = reg_wdata[13:12];
 
-  assign control_shadowed_slot_src_sel_wd = reg_wdata[15:14];
+  assign control_shadowed_slot_src_sel_wd = reg_wdata[16:14];
 
-  assign control_shadowed_slot_dst_sel_wd = reg_wdata[19:18];
+  assign control_shadowed_slot_dst_sel_wd = reg_wdata[20:18];
   assign sideload_clear_we = addr_hit[7] & reg_we & !reg_error;
 
   assign sideload_clear_wd = reg_wdata[2:0];
@@ -3106,8 +3106,8 @@ module keymgr_dpe_reg_top (
       addr_hit[6]: begin
         reg_rdata_next[6:4] = control_shadowed_operation_qs;
         reg_rdata_next[13:12] = control_shadowed_dest_sel_qs;
-        reg_rdata_next[15:14] = control_shadowed_slot_src_sel_qs;
-        reg_rdata_next[19:18] = control_shadowed_slot_dst_sel_qs;
+        reg_rdata_next[16:14] = control_shadowed_slot_src_sel_qs;
+        reg_rdata_next[20:18] = control_shadowed_slot_dst_sel_qs;
       end
 
       addr_hit[7]: begin


### PR DESCRIPTION
This is to allow more key slots to be active at the same time. Possibly in the future to hold more than one tree.