### PR TITLE
[bazel] Add 'lib' prefix to OTBN binary outputs

### DIFF
--- a/rules/otbn.bzl
+++ b/rules/otbn.bzl
@@ -84,7 +84,7 @@ def _otbn_binary(ctx, additional_srcs = []):
     # Declare output files.
     elf = ctx.actions.declare_file(ctx.attr.name + ".elf")
     rv32embed = ctx.actions.declare_file(ctx.attr.name + ".rv32embed.o")
-    archive = ctx.actions.declare_file(ctx.attr.name + ".rv32embed.a")
+    archive = ctx.actions.declare_file("lib" + ctx.attr.name + ".rv32embed.a")
 
     deps = [f for dep in ctx.attr.deps for f in dep.files.to_list()]
 

--- a/util/otbn_build.py
+++ b/util/otbn_build.py
@@ -335,7 +335,7 @@ def main() -> int:
             emb_file.write(b'\1\0')
 
         if archive:
-            out_embedded_a = out_dir / (app_name + '.rv32embed.a')
+            out_embedded_a = out_dir / ('lib' + app_name + '.rv32embed.a')
             call_rv32_ar(['rcs', out_embedded_a, out_embedded_obj])
 
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
This change addresses a linker error when attempting to use the generated OTBN archive library as a dependency due to missing the `lib` prefix. Update the name in both the Bazel rule and the associated Python script.