### PR TITLE
[hw,keymgr_dpe,rtl] Ability to load a root key into a slot

### DIFF
--- a/hw/ip/keymgr_dpe/data/keymgr_dpe.hjson
+++ b/hw/ip/keymgr_dpe/data/keymgr_dpe.hjson
@@ -464,6 +464,13 @@ countermeasures: [
                 Moves key manager DPE to disabled state.
                 '''
             },
+            {
+              value: "5",
+              name: "Load root key",
+              desc: '''
+                Loads the root key into the key manager.
+                '''
+            }
           ],
         },
 

--- a/hw/ip/keymgr_dpe/doc/registers.md
+++ b/hw/ip/keymgr_dpe/doc/registers.md
@@ -226,6 +226,7 @@ Key manager DPE operation selection
 | 0x2     | Generate SW Output | Generates a key manager output that is visible to software from the current state. |
 | 0x3     | Generate HW Output | Generates a cryptographic key that is visible only to hardware crypto blocks.      |
 | 0x4     | Disable            | Moves key manager DPE to disabled state.                                           |
+| 0x5     | Load root key      | Loads the root key into the key manager.                                           |
 
 Other values are reserved.
 

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_ctrl.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_ctrl.sv
@@ -146,11 +146,12 @@ module keymgr_dpe_ctrl
   logic fsm_at_disabled;
   logic fsm_at_invalid;
 
-  logic adv_req, gen_req, erase_req, dis_req;
+  logic adv_req, gen_req, erase_req, dis_req, load_req;
   assign adv_req   = op_req & (op_i == OpDpeAdvance);
   assign gen_req   = op_req & gen_key_op;
   assign erase_req = op_req & (op_i == OpDpeErase);
   assign dis_req   = op_req & (op_i == OpDpeDisable);
+  assign load_req  = op_req & (op_i == OpDpeLoadRootKey);
 
   ///////////////////////////
   //  interaction between operation fsm and software
@@ -204,6 +205,7 @@ module keymgr_dpe_ctrl
                          op_update & dis_req                    ? SlotWipeInternalOnly :
                          op_update & (op_err | fsm_at_disabled) ? SlotUpdateIdle       :
                          op_update & adv_req                    ? SlotLoadFromKmac     :
+                         op_update & load_req                   ? SlotLoadRoot         :
                          op_update & erase_req                  ? SlotErase            :
                          SlotUpdateIdle;
 
@@ -396,6 +398,7 @@ module keymgr_dpe_ctrl
   logic invalid_advance;
   logic invalid_erase;
   logic invalid_gen;
+  logic invalid_load;
   // TODO(#384): Make sure that:
   // 1) inv_state is correctly computed
   // 2) inv_state is correctly consumed by FSM
@@ -515,7 +518,11 @@ module keymgr_dpe_ctrl
         op_req = op_start_i;
 
         // This is the operational state, most operations are valid (modulo policy violations).
-        invalid_op = invalid_advance | invalid_erase | invalid_gen | (~en_i & op_start_i);
+        invalid_op = invalid_advance |
+                     invalid_erase   |
+                     invalid_gen     |
+                     invalid_load    |
+                     (~en_i & op_start_i);
 
         // Given that the root key was latched by an earlier FSM state, we need to take care of
         // clearing the sensitive root key.
@@ -608,6 +615,7 @@ module keymgr_dpe_ctrl
     .gen_req_i(gen_req),
     .erase_req_i(erase_req),
     .dis_req_i(dis_req),
+    .load_req_i(load_req),
     .op_ack_o(op_ack),
     .op_busy_o(op_busy),
     .op_update_o(op_update),
@@ -671,6 +679,8 @@ module keymgr_dpe_ctrl
   assign invalid_erase = erase_req & ~destination_slot_valid;
 
   assign invalid_gen = gen_req & (~active_key_slot_o.valid | ~key_version_vld_o);
+
+  assign invalid_load = load_req & (~root_key_i.valid | destination_slot_valid);
 
   // This is similar to `invalid_advance` except that it does not depend on a incoming request.
   // The outer module uses `invalid_advance_o` to invalidate KMAC msg payload, when the advance

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_pkg.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_pkg.sv
@@ -31,7 +31,8 @@ package keymgr_dpe_pkg;
     OpDpeErase = 1,
     OpDpeGenSwOut = 2,
     OpDpeGenHwOut = 3,
-    OpDpeDisable = 4
+    OpDpeDisable = 4,
+    OpDpeLoadRootKey = 5
   } keymgr_dpe_ops_e;
 
   // Encoding generated with:


### PR DESCRIPTION
The `keymgr_dpe` currently only supports a single DICE tree, as the root key is loaded exclusively at initialization. This prevents the creation of new, independent security domains at runtime.

This PR adds a new load command to the `keymgr_dpe`. This command makes it possible to load a new root key into a specified key slot at any point after initialization. This effectively enables the creation of a second (or subsequent) DICE tree, allowing for dynamic key management and derivation in separate contexts.

