### PR TITLE
[pentest] Add CW310 builds

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/BUILD
@@ -20,6 +20,7 @@ package(default_visibility = ["//visibility:public"])
 
 PENTEST_EXEC_ENVS = dicts.add(
     {
+        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
         "//hw/top_earlgrey:fpga_cw340_test_rom": None,
         "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
     },


### PR DESCRIPTION
Add `fpga_cw310_test_rom` to the pentest BAZEL build targets such that we can build binaries for ot-sca.