### PR TITLE
Partial backport of 25540 ([signing] Setup owner signing for FPGA environments)

### DIFF
--- a/sw/device/silicon_owner/bare_metal/BUILD
+++ b/sw/device/silicon_owner/bare_metal/BUILD
@@ -107,6 +107,8 @@ opentitan_binary(
     srcs = ["bare_metal_start.S"],
     exec_env = [
         "//hw/top_earlgrey:fpga_cw310_rom_ext",
+        "//hw/top_earlgrey:fpga_cw340_rom_ext",
+        "//hw/top_earlgrey:silicon_owner_sival_rom_ext",
     ],
     linker_script = ":ld_slot_virtual",
     manifest = ":manifest",


### PR DESCRIPTION
Partial backport of #25540. I did not include the changes to support the appkey since it is not relevant to master.