### PR TITLE
[prim,alert] Fix SkewCycles assertions in alert sender & receiver

### DIFF
--- a/hw/ip/prim/rtl/prim_alert_receiver.sv
+++ b/hw/ip/prim/rtl/prim_alert_receiver.sv
@@ -60,6 +60,9 @@ module prim_alert_receiver
 
   import prim_mubi_pkg::mubi4_test_true_strict;
 
+  default clocking @(posedge clk_i); endclocking
+  default disable iff !rst_ni;
+
   /////////////////////////////////
   // decode differential signals //
   /////////////////////////////////
@@ -303,28 +306,29 @@ module prim_alert_receiver
 
   if (AsyncOn) begin : gen_async_assert
     // signal integrity check propagation
-    `ASSERT(SigInt_A,
-        alert_tx_i.alert_p == alert_tx_i.alert_n [*2] ##2
-        !(state_q inside {InitReq, InitAckWait}) &&
-        mubi4_test_false_loose(init_trig_i)
-        |->
-        ##[0:SkewCycles] integ_fail_o)
-    `ASSERT(PingResponse1_A,
-        ##1 $rose(alert_tx_i.alert_p) &&
-        (alert_tx_i.alert_p ^ alert_tx_i.alert_n) ##2
-        state_q == Idle && ping_pending_q
-        |->
-        ##[0:SkewCycles] ping_ok_o,
-        clk_i, !rst_ni || integ_fail_o || mubi4_test_true_strict(init_trig_i))
+    SigInt_A: assert property (alert_tx_i.alert_p == alert_tx_i.alert_n [*(SkewCycles + 1)]
+                               |-> ##[1:3]
+                               ((state_q inside {InitReq, InitAckWait}) ||
+                                mubi4_test_true_strict(init_trig_i) ||
+                                integ_fail_o))
+      else `ASSERT_ERROR(SigInt_A)
+    PingResponse1_A: assert property (disable iff (!rst_ni || integ_fail_o ||
+                                                   mubi4_test_true_strict(init_trig_i))
+                                      ##1 $rose(alert_tx_i.alert_p) &&
+                                      (alert_tx_i.alert_p ^ alert_tx_i.alert_n) ##2
+                                      state_q == Idle && ping_pending_q
+                                      |->
+                                      ##[0:1] ping_ok_o)
+      else `ASSERT_ERROR(PingResponse1_A)
     // alert
-    `ASSERT(Alert_A,
-        ##1 $rose(alert_tx_i.alert_p) &&
-        (alert_tx_i.alert_p ^ alert_tx_i.alert_n) ##2
-        state_q == Idle &&
-        !ping_pending_q
-        |->
-        ##[0:SkewCycles] alert_o,
-        clk_i, !rst_ni || integ_fail_o || mubi4_test_true_strict(init_trig_i))
+    Alert_A: assert property (disable iff (!rst_ni || integ_fail_o ||
+                                           mubi4_test_true_strict(init_trig_i))
+                              ##1 $rose(alert_tx_i.alert_p) &&
+                              (alert_tx_i.alert_p ^ alert_tx_i.alert_n) ##2
+                              state_q == Idle && !ping_pending_q
+                              |->
+                              ##[0:1] alert_o)
+      else `ASSERT_ERROR(Alert_A)
   end else begin : gen_sync_assert
     // signal integrity check propagation
     `ASSERT(SigInt_A,

--- a/hw/ip/prim/rtl/prim_alert_sender.sv
+++ b/hw/ip/prim/rtl/prim_alert_sender.sv
@@ -67,6 +67,8 @@ module prim_alert_sender
   output alert_tx_t alert_tx_o
 );
 
+  default clocking @(posedge clk_i); endclocking
+  default disable iff !rst_ni;
 
   /////////////////////////////////
   // decode differential signals //
@@ -303,38 +305,53 @@ module prim_alert_sender
 
   if (AsyncOn) begin : gen_async_assert
     sequence PingSigInt_S;
-      alert_rx_i.ping_p == alert_rx_i.ping_n [*2];
+      alert_rx_i.ping_p == alert_rx_i.ping_n [*(SkewCycles + 1)];
     endsequence
     sequence AckSigInt_S;
-      alert_rx_i.ping_p == alert_rx_i.ping_n [*2];
+      alert_rx_i.ping_p == alert_rx_i.ping_n [*(SkewCycles + 1)];
     endsequence
 
-  `ifndef FPV_ALERT_NO_SIGINT_ERR
-    // check propagation of sigint issues to output within three cycles, or four due to CDC
-    // shift sequence to the right to avoid reset effects.
-    `ASSERT(SigIntPing_A, ##1 PingSigInt_S |->
-        ##[SkewCycles+2:SkewCycles+3] alert_tx_o.alert_p == alert_tx_o.alert_n)
-    `ASSERT(SigIntAck_A, ##1 AckSigInt_S |->
-        ##[SkewCycles+2:SkewCycles+3] alert_tx_o.alert_p == alert_tx_o.alert_n)
-  `endif
+`ifndef FPV_ALERT_NO_SIGINT_ERR
+    // Check that any sigint issue is propagated to the output within at most four cycles (this
+    // allows three cycles for the logic plus one for CDC uncertainty).
+    SigIntPing_A:
+      assert property (##1 PingSigInt_S |-> ##[3:4] alert_tx_o.alert_p == alert_tx_o.alert_n)
+        else `ASSERT_ERROR(SigIntPing_A)
+
+    SigIntAck_A:
+      assert property (##1 AckSigInt_S |-> ##[3:4] alert_tx_o.alert_p == alert_tx_o.alert_n)
+        else `ASSERT_ERROR(SigIntAck_A)
+`endif
 
     // Test in-band FSM reset request (via signal integrity error)
-    `ASSERT(InBandInitFsm_A, PingSigInt_S or AckSigInt_S |->
-        ##[SkewCycles+2:SkewCycles+3] state_q == Idle)
-    `ASSERT(InBandInitPing_A, PingSigInt_S or AckSigInt_S |->
-        ##[SkewCycles+2:SkewCycles+3] !ping_set_q)
-    // output must be driven diff unless sigint issue detected
-    `ASSERT(DiffEncoding_A, (alert_rx_i.ack_p ^ alert_rx_i.ack_n) &&
-        (alert_rx_i.ping_p ^ alert_rx_i.ping_n) |->
-        ##[SkewCycles+2:SkewCycles+4] alert_tx_o.alert_p ^ alert_tx_o.alert_n)
+    InBandInitFsm_A:
+      assert property (PingSigInt_S or AckSigInt_S |-> ##[3:4] state_q == Idle)
+        else `ASSERT_ERROR(InBandInitFsm_A)
+
+    InBandInitPing_A:
+      assert property (PingSigInt_S or AckSigInt_S |-> ##[3:4] !ping_set_q)
+        else `ASSERT_ERROR(InBandInitPing_A)
+
+    // Output must be driven diff unless sigint issue detected
+    DiffEncoding_A:
+      assert property ((alert_rx_i.ack_p ^ alert_rx_i.ack_n) &&
+                       (alert_rx_i.ping_p ^ alert_rx_i.ping_n) |->
+                       ##[3:5] alert_tx_o.alert_p ^ alert_tx_o.alert_n)
+        else `ASSERT_ERROR(DiffEncoding_A)
 
     // handshakes can take indefinite time if blocked due to sigint on outgoing
     // lines (which is not visible here). thus, we only check whether the
     // handshake is correctly initiated and defer the full handshake checking to the testbench.
-    `ASSERT(PingHs_A, ##1 $changed(alert_rx_i.ping_p) &&
-        (alert_rx_i.ping_p ^ alert_rx_i.ping_n) ##2 state_q == Idle |=>
-        ##[0:1] $rose(alert_tx_o.alert_p), clk_i,
-        !rst_ni || (alert_tx_o.alert_p == alert_tx_o.alert_n))
+    PingHs_A:
+      assert property (disable iff (!rst_ni || (alert_tx_o.alert_p == alert_tx_o.alert_n))
+                       ##1
+                       ($changed(alert_rx_i.ping_p) &&
+                        (alert_rx_i.ping_p ^ alert_rx_i.ping_n))
+                       ##2
+                       state_q == Idle |=>
+                       ##[0:1] $rose(alert_tx_o.alert_p))
+        else `ASSERT_ERROR(PingHs_A)
+
   end else begin : gen_sync_assert
     sequence PingSigInt_S;
       alert_rx_i.ping_p == alert_rx_i.ping_n;


### PR DESCRIPTION
The assertions weren't quite right after the change in f5cdd1ce and the SkewCycles parameter ended up being used to measure the time until the signal integrity problem was reported, rather than the time the signals had to be equal.

This fixes things again. Since I'm touching the code in question, it also switches the assertions to use a more conventional style (using default clocking and default disable iff to avoid the reasonably inpenetrable `ASSERT macro) and slightly reformats a couple of the multi-cycle properties to make them a bit easier to read.