### PR TITLE
[rom] Removal of key_{ecdsa, spx} within the rom fake key

### DIFF
--- a/rules/opentitan/keyutils.bzl
+++ b/rules/opentitan/keyutils.bzl
@@ -234,24 +234,24 @@ SILICON_CREATOR_KEYS = struct(
     FAKE = struct(
         ECDSA = struct(
             TEST = [
-                create_test_key("fake_ecdsa_test_key_0", "@//sw/device/silicon_creator/rom/keys/fake/ecdsa:test_key_0_ecdsa_p256"),
+                create_test_key("test_key_0", "@//sw/device/silicon_creator/rom/keys/fake/ecdsa:ecdsa_keyset"),
             ],
             DEV = [
-                create_dev_key("fake_ecdsa_dev_key_0", "@//sw/device/silicon_creator/rom/keys/fake/ecdsa:dev_key_0_ecdsa_p256"),
+                create_dev_key("dev_key_0", "@//sw/device/silicon_creator/rom/keys/fake/ecdsa:ecdsa_keyset"),
             ],
             PROD = [
-                create_prod_key("fake_ecdsa_prod_key_0", "@//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256"),
+                create_prod_key("prod_key_0", "@//sw/device/silicon_creator/rom/keys/fake/ecdsa:ecdsa_keyset"),
             ],
         ),
         SPX = struct(
             TEST = [
-                create_test_key("fake_spx_test_key_0", "@//sw/device/silicon_creator/rom/keys/fake/spx:test_key_0_spx"),
+                create_test_key("test_key_0", "@//sw/device/silicon_creator/rom/keys/fake/spx:spx_keyset"),
             ],
             DEV = [
-                create_dev_key("fake_spx_dev_key_0", "@//sw/device/silicon_creator/rom/keys/fake/spx:dev_key_0_spx"),
+                create_dev_key("dev_key_0", "@//sw/device/silicon_creator/rom/keys/fake/spx:spx_keyset"),
             ],
             PROD = [
-                create_prod_key("fake_spx_prod_key_0", "@//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx"),
+                create_prod_key("prod_key_0", "@//sw/device/silicon_creator/rom/keys/fake/spx:spx_keyset"),
             ],
         ),
     ),

--- a/rules/tests/BUILD
+++ b/rules/tests/BUILD
@@ -13,7 +13,7 @@ otp_test_suite()
 signature_test(
     name = "corrupt_signature_test",
     srcs = [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted_fpga_cw310_rom_with_fake_keys.fake_ecdsa_prod_key_0.signed.bin",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted_fpga_cw310_rom_with_fake_keys.prod_key_0.signed.bin",
     ],
     negative_test = True,
 )

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -540,9 +540,9 @@ opentitan_test(
     name = "stack_utilization_test",
     cw310 = fpga_params(
         binaries = {
-            "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_prod_key_0_fpga_cw310_rom_with_fake_keys_signed_bin": "good_a",
-            "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_fake_ecdsa_prod_key_0_fpga_cw310_rom_with_fake_keys_signed_bin": "good_b",
-            "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_prod_key_0_corrupted_fpga_cw310_rom_with_fake_keys_signed_bin": "bad_a",
+            "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_prod_key_0_fpga_cw310_rom_with_fake_keys_signed_bin": "good_a",
+            "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_prod_key_0_fpga_cw310_rom_with_fake_keys_signed_bin": "good_b",
+            "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_prod_key_0_corrupted_fpga_cw310_rom_with_fake_keys_signed_bin": "bad_a",
             ":empty_flash": "empty",
         },
         stack_usage = "STK:[0-9A-Fa-f/]+\r\n",

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -183,7 +183,7 @@ opentitan_test(
 # The following filegroup is required to allow dvsim to build the
 # empty_test_slot_* targets as the `sim_dv` execution environment is expected
 # as a suffix in the target label. For example:
-#  `//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_prod_key_0_sim_dv`
+#  `//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_prod_key_0_sim_dv`
 [
     filegroup(
         name = "empty_test_slot_{}_{}_sim_dv".format(slot, key),

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_valid/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_valid/BUILD
@@ -87,8 +87,8 @@ BOOT_POLICY_VALID_CASES = [
             ),
             binaries = {
                 # PROD keys can sign binaries able to run across all life cycle states.
-                "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_prod_key_0{}".format(a["suffix"]): "slot_a",
-                "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_fake_ecdsa_prod_key_0{}".format(b["suffix"]): "slot_b",
+                "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_prod_key_0{}".format(a["suffix"]): "slot_a",
+                "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_prod_key_0{}".format(b["suffix"]): "slot_b",
             },
             bitstream = "bitstream_boot_policy_valid_{}".format(lc_state),
             exit_failure = MSG_PASS if a["desc"] == b["desc"] and a["desc"] == "bad" else DEFAULT_TEST_FAILURE_MSG,

--- a/sw/device/silicon_creator/rom/e2e/release/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/release/BUILD
@@ -33,7 +33,7 @@ otp_image(
 #     dv = dv_params(
 #         rom = "//sw/device/silicon_creator/rom:mask_rom",
 #     ),
-#     ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
+#     ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:ecdsa_keyset": "prod_key_0"},
 #     exec_env = {
 #         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
 #         "//hw/top_earlgrey:sim_dv": None,
@@ -43,7 +43,7 @@ otp_image(
 #         otp = ":otp_img_sigverify_spx_prod",
 #     ),
 #     manifest = "//sw/device/silicon_creator/rom_ext:manifest",
-#     spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
+#     spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:spx_keyset": "prod_key_0"},
 #     deps = [
 #         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
 #         "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",

--- a/sw/device/silicon_creator/rom/e2e/sigverify_key_type/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_key_type/BUILD
@@ -86,7 +86,7 @@ SPX_ALLOWED_IN_LC_STATES = {
 # LC states.
 KEY_TYPE_ECDSA_TESTS = [
     {
-        "name": key.ecdsa.name,
+        "name": "ecdsa_{}".format(key.ecdsa.name),
         "exit_failure": ECDSA_ALLOWED_IN_LC_STATES["exit_failure"][key.ecdsa.name],
         "exit_success": ECDSA_ALLOWED_IN_LC_STATES["exit_success"][key.ecdsa.name],
         "ecdsa_key": {key.ecdsa.label: key.ecdsa.name},
@@ -99,7 +99,7 @@ KEY_TYPE_ECDSA_TESTS = [
 # LC states.
 KEY_TYPE_SPX_TESTS = [
     {
-        "name": key.spx.name,
+        "name": "spx_{}".format(key.spx.name),
         "exit_failure": SPX_ALLOWED_IN_LC_STATES["exit_failure"][key.spx.name],
         "exit_success": SPX_ALLOWED_IN_LC_STATES["exit_success"][key.spx.name],
         "ecdsa_key": {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:ecdsa_keyset": "prod_key_0"},

--- a/sw/device/silicon_creator/rom/keys/README.md
+++ b/sw/device/silicon_creator/rom/keys/README.md
@@ -15,7 +15,7 @@ bazel build //sw/host/opentitantool
 ```
 Generate new key:
 ```
-bazel-bin/sw/host/opentitantool/opentitantool spx key generate sw/device/silicon_creator/rom/keys/fake/spx/ test_key_0_spx
+bazel-bin/sw/host/opentitantool/opentitantool spx key generate sw/device/silicon_creator/rom/keys/fake/spx/ spx_keyset "test_key_0"
 ```
 Manually fix data in the header file (in this case `sw/device/silicon_creator/rom/keys/fake/spx/test_key_0_spx.h`). Skip this step for unauthorized keys. This command prints the data in the right format:
 ```

--- a/sw/device/silicon_creator/rom/keys/fake/ecdsa/BUILD
+++ b/sw/device/silicon_creator/rom/keys/fake/ecdsa/BUILD
@@ -2,42 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules/opentitan:keyutils.bzl", "key_ecdsa")
 load("//rules:signing.bzl", "keyset")
 
 package(default_visibility = ["//visibility:public"])
-
-key_ecdsa(
-    name = "test_key_0_ecdsa_p256",
-    method = "local",
-    private_key = "test_key_0_ecdsa_p256.der",
-    pub_key = "test_key_0_ecdsa_p256.pub.der",
-    type = "TestKey",
-)
-
-key_ecdsa(
-    name = "dev_key_0_ecdsa_p256",
-    method = "local",
-    private_key = "dev_key_0_ecdsa_p256.der",
-    pub_key = "dev_key_0_ecdsa_p256.pub.der",
-    type = "DevKey",
-)
-
-key_ecdsa(
-    name = "prod_key_0_ecdsa_p256",
-    method = "local",
-    private_key = "prod_key_0_ecdsa_p256.der",
-    pub_key = "prod_key_0_ecdsa_p256.pub.der",
-    type = "ProdKey",
-)
-
-key_ecdsa(
-    name = "prod_key_1_ecdsa_p256",
-    method = "local",
-    private_key = "prod_key_1_ecdsa_p256.der",
-    pub_key = "prod_key_1_ecdsa_p256.pub.der",
-    type = "ProdKey",
-)
 
 keyset(
     name = "ecdsa_keyset",

--- a/sw/device/silicon_creator/rom/keys/fake/otp/BUILD
+++ b/sw/device/silicon_creator/rom/keys/fake/otp/BUILD
@@ -18,38 +18,38 @@ otp_json_rot_keys(
         otp_partition(
             name = "ROT_CREATOR_AUTH_CODESIGN",
             items = {
-                # //sw/device/silicon_creator/rom/keys/fake/ecdsa:test_key_0_ecdsa_p256
+                # //sw/device/silicon_creator/rom/keys/fake/ecdsa:ecdsa_keyset "test_key_0"
                 "ROT_CREATOR_AUTH_CODESIGN_ECDSA_KEY_TYPE0": otp_hex(CONST.SIGVERIFY.KEY_TYPE.TEST),
                 "ROT_CREATOR_AUTH_CODESIGN_ECDSA_KEY0": "0xdeb1e092bb56aeb4a5d7eb1df773fc51012abb223c413ac2444da9ded8e17e502e66e6cb6937e2375bcb453d845024cfe9e0f4807bfccca80bba6de3ee07109a",
 
-                # //sw/device/silicon_creator/rom/keys/fake/ecdsa:dev_key_0_ecdsa_p256
+                # //sw/device/silicon_creator/rom/keys/fake/ecdsa:ecdsa_keyset "dev_key_0"
                 "ROT_CREATOR_AUTH_CODESIGN_ECDSA_KEY_TYPE1": otp_hex(CONST.SIGVERIFY.KEY_TYPE.DEV),
                 "ROT_CREATOR_AUTH_CODESIGN_ECDSA_KEY1": "0xce8c4b5b70df4ad0c9dbc64bf7a103fdb1dfa2cc40529329ba9eb9172fbccaafd0b7ee1365a85787b9e7bf8aa742ec258ce157388a01ceb04f7ed1a3c11c931c",
 
-                # //sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256
+                # //sw/device/silicon_creator/rom/keys/fake/ecdsa:ecdsa_keyset "prod_key_0"
                 "ROT_CREATOR_AUTH_CODESIGN_ECDSA_KEY_TYPE2": otp_hex(CONST.SIGVERIFY.KEY_TYPE.PROD),
                 "ROT_CREATOR_AUTH_CODESIGN_ECDSA_KEY2": "0x7e571d04866f12e00a5b3c2e734ebd05611a0325ef6d90140e3cd2091ddda9bd8277988ce6557b33923499d90eeeff0028a525c10fa3a5a438daf96b9bf2dafd",
 
-                # //sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_1_ecdsa_p256
+                # //sw/device/silicon_creator/rom/keys/fake/ecdsa:ecdsa_keyset "prod_key_1"
                 "ROT_CREATOR_AUTH_CODESIGN_ECDSA_KEY_TYPE3": otp_hex(CONST.SIGVERIFY.KEY_TYPE.PROD),
                 "ROT_CREATOR_AUTH_CODESIGN_ECDSA_KEY3": "0xb70fd07db1c79bbb87f974e6d3ea06e1f120582d2e8abaf1ddd1167aac4d7547fbf0b76ae2838f6cec711f34204d24202fccd456ad9f2278d80fe551423e545e",
 
-                # //sw/device/silicon_creator/rom/keys/fake/spx:test_key_0_spx
+                # //sw/device/silicon_creator/rom/keys/fake/spx:spx_keyset "test_key_0"
                 "ROT_CREATOR_AUTH_CODESIGN_SPX_KEY_TYPE0": otp_hex(CONST.SIGVERIFY.KEY_TYPE.TEST),
                 "ROT_CREATOR_AUTH_CODESIGN_SPX_KEY0": "0xa7fd92541005bf04f172710eaafa228220ce5b2a73e009c74fdc04eefa2a1ba6",
                 "ROT_CREATOR_AUTH_CODESIGN_SPX_KEY_CONFIG0": otp_hex(CONST.SPX_CONFIG_ID.SHA2_128S),
 
-                # //sw/device/silicon_creator/rom/keys/fake/spx:dev_key_0_spx
+                # //sw/device/silicon_creator/rom/keys/fake/spx:spx_keyset "dev_key_0"
                 "ROT_CREATOR_AUTH_CODESIGN_SPX_KEY_TYPE1": otp_hex(CONST.SIGVERIFY.KEY_TYPE.DEV),
                 "ROT_CREATOR_AUTH_CODESIGN_SPX_KEY1": "0x594087c53775908295afa7000d11eec6fc430f8e7858e774e595f1d161f34ce4",
                 "ROT_CREATOR_AUTH_CODESIGN_SPX_KEY_CONFIG1": otp_hex(CONST.SPX_CONFIG_ID.SHA2_128S),
 
-                # //sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx
+                # //sw/device/silicon_creator/rom/keys/fake/spx:spx_keyset "prod_key_0"
                 "ROT_CREATOR_AUTH_CODESIGN_SPX_KEY_TYPE2": otp_hex(CONST.SIGVERIFY.KEY_TYPE.PROD),
                 "ROT_CREATOR_AUTH_CODESIGN_SPX_KEY2": "0x789b490a8c50f4dadee29c091dfe267bfedece98519c46bdb2ade5d32d3e6e02",
                 "ROT_CREATOR_AUTH_CODESIGN_SPX_KEY_CONFIG2": otp_hex(CONST.SPX_CONFIG_ID.SHA2_128S),
 
-                # //sw/device/silicon_creator/rom/keys/fake/spx:prod_key_1_spx
+                # //sw/device/silicon_creator/rom/keys/fake/spx:spx_keyset "prod_key_1"
                 "ROT_CREATOR_AUTH_CODESIGN_SPX_KEY_TYPE3": otp_hex(CONST.SIGVERIFY.KEY_TYPE.PROD),
                 "ROT_CREATOR_AUTH_CODESIGN_SPX_KEY3": "0x4d83c8d10356fbb033ae5f9a3ee242a21f5a1a8b8c9a5579496271faad63458a",
                 "ROT_CREATOR_AUTH_CODESIGN_SPX_KEY_CONFIG3": otp_hex(CONST.SPX_CONFIG_ID.SHA2_128S_PREHASH),

--- a/sw/device/silicon_creator/rom/keys/fake/spx/BUILD
+++ b/sw/device/silicon_creator/rom/keys/fake/spx/BUILD
@@ -2,68 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules/opentitan:keyutils.bzl", "key_sphincs_plus")
 load("//rules:signing.bzl", "keyset")
 
 package(default_visibility = ["//visibility:public"])
-
-filegroup(
-    name = "test_key_0_spx",
-    srcs = ["test_key_0_spx.pem"],
-)
-
-key_sphincs_plus(
-    name = "test_key_0_spx_key",
-    config = {"domain": "Pure"},
-    method = "local",
-    private_key = "test_key_0_spx.pem",
-    pub_key = "test_key_0_spx.pub.pem",
-    type = "TestKey",
-)
-
-filegroup(
-    name = "dev_key_0_spx",
-    srcs = ["dev_key_0_spx.pem"],
-)
-
-key_sphincs_plus(
-    name = "dev_key_0_spx_key",
-    config = {"domain": "Pure"},
-    method = "local",
-    private_key = "dev_key_0_spx.pem",
-    pub_key = "dev_key_0_spx.pub.pem",
-    type = "TestKey",
-)
-
-filegroup(
-    name = "prod_key_0_spx",
-    srcs = ["prod_key_0_spx.pem"],
-)
-
-key_sphincs_plus(
-    name = "prod_key_0_spx_key",
-    config = {"domain": "Pure"},
-    method = "local",
-    private_key = "prod_key_0_spx.pem",
-    pub_key = "prod_key_0_spx.pub.pem",
-    type = "TestKey",
-)
-
-filegroup(
-    name = "prod_key_1_spx",
-    srcs = ["prod_key_1_spx.pem"],
-)
-
-key_sphincs_plus(
-    name = "prod_key_1_spx_key",
-    config = {
-        "domain": "PreHashedSha256",
-    },
-    method = "local",
-    private_key = "prod_key_1_spx.pem",
-    pub_key = "prod_key_1_spx.pub.pem",
-    type = "TestKey",
-)
 
 keyset(
     name = "spx_keyset",


### PR DESCRIPTION
Since the keyset are now placed within the ROM fake keys, we should be able to remove any reference to the key_{ecdsa, spx}.