### PR TITLE
[HARDENED_TRY] Harden HARDENED_TRY

### DIFF
--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -5,6 +5,14 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
+load(
+    "//rules/opentitan:defs.bzl",
+    "EARLGREY_TEST_ENVS",
+    "cw310_params",
+    "fpga_params",
+    "opentitan_test",
+    "verilator_params",
+)
 
 config_setting(
     name = "crypto_status_debug",
@@ -268,6 +276,20 @@ cc_library(
     deps = [
         "//sw/device/lib/base:status",
         "//sw/device/lib/crypto/include:datatypes",
+    ],
+)
+
+opentitan_test(
+    name = "status_functest",
+    srcs = ["status_functest.c"],
+    exec_env = EARLGREY_TEST_ENVS,
+    verilator = verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        ":status",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
 

--- a/sw/device/lib/crypto/impl/status.h
+++ b/sw/device/lib/crypto/impl/status.h
@@ -58,29 +58,48 @@ extern "C" {
 
 #endif
 
-#ifndef OT_DISABLE_HARDENING
+#if !defined(OT_DISABLE_HARDENING) && defined(OT_PLATFORM_RV32)
 /**
  * Hardened version of the `TRY` macro from `status.h`.
  *
  * Returns an error if either expr_ represents an error, or if the OK code does
  * not match the expected hardened value.
  *
+ * To optimize code size this macro uses 16b branch on zero instructions with
+ * respective arithmetic for comparisons. In both the case where the status is
+ * OK or not, an additional check is performed to stop potential fault attacks
+ * by doubling the branch. More specifically, in both the case where the status
+ * is OK or not an additional check is performed to stop potential fault
+ * attacks.
+ *
+ * This macro specifically uses the fact that error statuses are negative
+ * values.
+ *
  * @param expr_ An expression that evaluates to a `status_t`.
  * @return The enclosed OK value.
  */
-#define HARDENED_TRY(expr_)                                             \
-  do {                                                                  \
-    status_t status_ = expr_;                                           \
-    if (launder32(OT_UNSIGNED(status_.value)) != kHardenedBoolTrue) {   \
-      return (status_t){                                                \
-          .value = (int32_t)(OT_UNSIGNED(status_.value) | 0x80000000)}; \
-    }                                                                   \
-    HARDENED_CHECK_EQ(status_.value, kHardenedBoolTrue);                \
-    status_.value;                                                      \
+#define HARDENED_TRY(expr_)                                            \
+  do {                                                                 \
+    uint32_t status_ = OT_UNSIGNED(expr_.value);                       \
+    asm volatile("addi %[status_], %[status_], -%[kHardenedBoolTrue]"  \
+                 : [status_] "+r"(status_)                             \
+                 : [kHardenedBoolTrue] "i"(kHardenedBoolTrue)          \
+                 :);                                                   \
+    if (status_) {                                                     \
+      asm volatile("addi %[status_], %[status_], %[kHardenedBoolTrue]" \
+                   : [status_] "+r"(status_)                           \
+                   : [kHardenedBoolTrue] "i"(kHardenedBoolTrue)        \
+                   :);                                                 \
+      if ((int32_t)(status_) < 0) {                                    \
+        return (status_t){.value = (int32_t)(status_ | 0x80000000)};   \
+      }                                                                \
+      asm volatile("unimp");                                           \
+    }                                                                  \
+    if (launder32(status_)) {                                          \
+      asm volatile("unimp");                                           \
+    }                                                                  \
   } while (false)
-
-#else  // OT_DISABLE_HARDENING
-
+#else  // !OT_PLATFORM_RV32 || OT_DISABLE_HARDENING
 /**
  * Alternate version of HARDENED_TRY that is logically equivalent.
  *

--- a/sw/device/lib/crypto/impl/status_functest.c
+++ b/sw/device/lib/crypto/impl/status_functest.c
@@ -1,0 +1,74 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ottf_isrs.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+otcrypto_status_t reverse_status(otcrypto_status_t status) {
+  otcrypto_status_t result;
+  if (status_ok(status) == false) {
+    result = OTCRYPTO_OK;
+  } else {
+    // We take an arbitrary bad status here.
+    result = OTCRYPTO_BAD_ARGS;
+  }
+  return result;
+}
+
+otcrypto_status_t return_status(otcrypto_status_t status) { return status; }
+otcrypto_status_t good_test(void) {
+  HARDENED_TRY(return_status(OTCRYPTO_OK));
+  return OTCRYPTO_OK;
+}
+otcrypto_status_t bad_test(otcrypto_status_t status) {
+  HARDENED_TRY(return_status(status));
+  return OTCRYPTO_OK;
+}
+
+// Reverse the status so we execute tests returning an ok status.
+otcrypto_status_t bad_args_test(void) {
+  otcrypto_status_t result = bad_test(OTCRYPTO_BAD_ARGS);
+  return reverse_status(result);
+}
+otcrypto_status_t recov_err_test(void) {
+  otcrypto_status_t result = bad_test(OTCRYPTO_RECOV_ERR);
+  return reverse_status(result);
+}
+otcrypto_status_t fatal_err_test(void) {
+  otcrypto_status_t result = bad_test(OTCRYPTO_FATAL_ERR);
+  return reverse_status(result);
+}
+otcrypto_status_t async_incomplete_test(void) {
+  otcrypto_status_t result = bad_test(OTCRYPTO_ASYNC_INCOMPLETE);
+  return reverse_status(result);
+}
+otcrypto_status_t not_implemented_test(void) {
+  otcrypto_status_t result = bad_test(OTCRYPTO_NOT_IMPLEMENTED);
+  return reverse_status(result);
+}
+
+bool test_main(void) {
+  status_t result = OTCRYPTO_OK;
+  // Test hardened_try when the check is valid.
+  EXECUTE_TEST(result, good_test);
+
+  // Test hardened_try when the check is invalid.
+  EXECUTE_TEST(result, bad_args_test);
+  EXECUTE_TEST(result, recov_err_test);
+  EXECUTE_TEST(result, fatal_err_test);
+  EXECUTE_TEST(result, async_incomplete_test);
+  EXECUTE_TEST(result, not_implemented_test);
+
+  return status_ok(result);
+}


### PR DESCRIPTION
The HARDENED_TRY macro currently only does a redundant branch in case the status is ok, but misses a redundant branch for the error limb.

Adapt the macro such that it performs a redundant branch on each case. In order to save code size, a new configuration is used.

The assembly has the following pattern:

j function
addi a0, a0, -1849 // This is done to branch on zero to save code size, and to force the compiler to work with a0 (not to compile away some of the checks)
beqz a0, continue_branch
addi a0, a0, 1849
bltz a0, return_branch
unimp
...
continue_branch:
beqz a0, rest_of_the_code
unimp

Finally, running //sw/device/tests/crypto:otcrypto_export_size, code size goes from ~84k to ~83k.