### PR TITLE
[hw,lc_ctrl,sec] Move SEC_CM label from state package to lc_ctrl

### DIFF
--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -757,6 +757,8 @@ module lc_ctrl
   // LC FSM //
   ////////////
 
+  // SEC_CM: MANUF.STATE.SPARSE
+  // SEC_CM: TRANSITION.CTR.SPARSE
   lc_ctrl_fsm #(
     .NumRmaAckSigs                 ( NumRmaAckSigs                  ),
     .RndCnstLcKeymgrDivInvalid     ( RndCnstLcKeymgrDivInvalid      ),

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_state_pkg.sv.tpl
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_state_pkg.sv.tpl
@@ -128,7 +128,6 @@ package lc_ctrl_state_pkg;
   // Note that the ECC bits are not defined in this package as they will be calculated by
   // the OTP ECC logic at runtime.
 
-  // SEC_CM: MANUF.STATE.SPARSE
   // The A/B values are used for the encoded LC state.
 % for word in lc_st_enc.config['genwords']['lc_state']:
   parameter logic [${data_width-1}:0] A${loop.index} = ${data_width}'b${word[0][ecc_width:]}; // ECC: ${ecc_width}'b${word[0][0:ecc_width]}
@@ -136,7 +135,6 @@ package lc_ctrl_state_pkg;
 
 % endfor
 
-  // SEC_CM: TRANSITION.CTR.SPARSE
   // The C/D values are used for the encoded LC transition counter.
 % for word in lc_st_enc.config['genwords']['lc_cnt']:
   parameter logic [${data_width-1}:0] C${loop.index} = ${data_width}'b${word[0][ecc_width:]}; // ECC: ${ecc_width}'b${word[0][0:ecc_width]}
@@ -158,7 +156,7 @@ package lc_ctrl_state_pkg;
 
 % endfor
 
-  // The I/Jvalues are used for the encoded AUTH state.
+  // The I/J values are used for the encoded AUTH state.
 % for word in lc_st_enc.config['genwords']['auth_state']:
   parameter logic [${data_width-1}:0] I${loop.index} = ${data_width}'b${word[0][ecc_width:]}; // ECC: ${ecc_width}'b${word[0][0:ecc_width]}
   parameter logic [${data_width-1}:0] J${loop.index} = ${data_width}'b${word[1][ecc_width:]}; // ECC: ${ecc_width}'b${word[1][0:ecc_width]}

--- a/hw/top_darjeeling/rtl/autogen/testing/lc_ctrl_state_pkg.sv
+++ b/hw/top_darjeeling/rtl/autogen/testing/lc_ctrl_state_pkg.sv
@@ -92,7 +92,6 @@ package lc_ctrl_state_pkg;
   // Note that the ECC bits are not defined in this package as they will be calculated by
   // the OTP ECC logic at runtime.
 
-  // SEC_CM: MANUF.STATE.SPARSE
   // The A/B values are used for the encoded LC state.
   parameter logic [15:0] A0 = 16'b1000110001100000; // ECC: 6'b101010
   parameter logic [15:0] B0 = 16'b1011110111101110; // ECC: 6'b101110
@@ -155,7 +154,6 @@ package lc_ctrl_state_pkg;
   parameter logic [15:0] B19 = 16'b1001101101111010; // ECC: 6'b111111
 
 
-  // SEC_CM: TRANSITION.CTR.SPARSE
   // The C/D values are used for the encoded LC transition counter.
   parameter logic [15:0] C0 = 16'b0000000011101001; // ECC: 6'b101001
   parameter logic [15:0] D0 = 16'b0101100111111111; // ECC: 6'b111001
@@ -264,7 +262,7 @@ package lc_ctrl_state_pkg;
   parameter logic [15:0] H7 = 16'b1101111101101010; // ECC: 6'b001101
 
 
-  // The I/Jvalues are used for the encoded AUTH state.
+  // The I/J values are used for the encoded AUTH state.
   parameter logic [15:0] I0 = 16'b0101110110010000; // ECC: 6'b010000
   parameter logic [15:0] J0 = 16'b1111110111010010; // ECC: 6'b111000
 

--- a/hw/top_earlgrey/rtl/autogen/testing/lc_ctrl_state_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/testing/lc_ctrl_state_pkg.sv
@@ -92,7 +92,6 @@ package lc_ctrl_state_pkg;
   // Note that the ECC bits are not defined in this package as they will be calculated by
   // the OTP ECC logic at runtime.
 
-  // SEC_CM: MANUF.STATE.SPARSE
   // The A/B values are used for the encoded LC state.
   parameter logic [15:0] A0 = 16'b1000110001100000; // ECC: 6'b101010
   parameter logic [15:0] B0 = 16'b1011110111101110; // ECC: 6'b101110
@@ -155,7 +154,6 @@ package lc_ctrl_state_pkg;
   parameter logic [15:0] B19 = 16'b1001101101111010; // ECC: 6'b111111
 
 
-  // SEC_CM: TRANSITION.CTR.SPARSE
   // The C/D values are used for the encoded LC transition counter.
   parameter logic [15:0] C0 = 16'b0000000011101001; // ECC: 6'b101001
   parameter logic [15:0] D0 = 16'b0101100111111111; // ECC: 6'b111001
@@ -264,7 +262,7 @@ package lc_ctrl_state_pkg;
   parameter logic [15:0] H7 = 16'b1101111101101010; // ECC: 6'b001101
 
 
-  // The I/Jvalues are used for the encoded AUTH state.
+  // The I/J values are used for the encoded AUTH state.
   parameter logic [15:0] I0 = 16'b0101110110010000; // ECC: 6'b010000
   parameter logic [15:0] J0 = 16'b1111110111010010; // ECC: 6'b111000
 

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -1342,9 +1342,6 @@ def _check_countermeasures(completecfg: ConfigT, name_to_block: IpBlocksT,
                            name_to_hjson: Dict[str, Path]) -> bool:
     success = True
     for name, hjson_path in name_to_hjson.items():
-        # TODO(#26362): Enable LC Ctrl back once check countermeasures can deal with dependencies
-        if name == "lc_ctrl":
-            continue
         log.debug("name %s, hjson %s", name, hjson_path)
         sv_files = (hjson_path.parents[1] / 'rtl').glob('*.sv')
         rtl_names = CounterMeasure.search_rtl_files(sv_files)


### PR DESCRIPTION
That way we can re-enable the check-countermeasures CI check for lc_ctrl since all labels are within the lc_ctrl folder.