### PR TITLE
[hw,keymgr_dpe,rtl] Remove constraint of maximum number of derivation stages

### DIFF
--- a/hw/ip/keymgr_dpe/doc/theory_of_operation.md
+++ b/hw/ip/keymgr_dpe/doc/theory_of_operation.md
@@ -28,7 +28,7 @@ In order to address the relationships among keymgr_dpe slots and their stored DP
 
 ## Key Manager Slots
 
-Keymgr_dpe consists of `DpeNumBootStages` slots, which is a generic parameter.
+Keymgr_dpe consists of `DpeNumSlots` slots, which is a generic parameter.
 Each of these key manager slots can store a DPE context, i.e. all DICE-related information for a particular boot stage. That includes a secret key along with additional context information described below.
 The secret key size is fixed to 256-bit.
 

--- a/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_base_vseq.sv
+++ b/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_base_vseq.sv
@@ -244,8 +244,6 @@ class keymgr_dpe_base_vseq extends cip_base_vseq #(
         });
         if (current_state == keymgr_dpe_pkg::StWorkDpeAvailable) begin
           is_good_op &= cfg.keymgr_dpe_vif.internal_key_slots[src_slot].valid == 1;
-          is_good_op &= cfg.keymgr_dpe_vif.internal_key_slots[src_slot].boot_stage <
-            (keymgr_dpe_pkg::DpeNumBootStages-1);
           is_good_op &= cfg.keymgr_dpe_vif.internal_key_slots[src_slot].key_policy.allow_child == 1;
           if (cfg.keymgr_dpe_vif.internal_key_slots[src_slot].key_policy.retain_parent == 0) begin
             is_good_op &= (src_slot == dst_slot);

--- a/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_smoke_vseq.sv
+++ b/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_smoke_vseq.sv
@@ -64,8 +64,8 @@ class keymgr_dpe_smoke_vseq extends keymgr_dpe_base_vseq;
         dst_slot ++;
       end
       // Boot stages 0-3 are used for previous key slots. In the final key slot
-      // src_slot must differ from last iteration's dst slot. As all 4 boot stages
-      // as defined by DpeNumBootStages are exhausted.
+      // src_slot must differ from last iteration's dst slot.
+      // FIXME: Remove this constraint since DpeNumBootStages is removed.
       else if (iter == keymgr_dpe_pkg::DpeNumSlots) begin
         src_slot = $urandom_range(0,(keymgr_dpe_pkg::DpeNumSlots-1)-2);
         dst_slot ++;

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_ctrl.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_ctrl.sv
@@ -269,10 +269,8 @@ module keymgr_dpe_ctrl
     end
   end
 
-  logic [DpeNumBootStagesWidth-1:0] active_slot_boot_stage;
   keymgr_dpe_policy_t active_slot_policy;
   assign active_key_slot_o      = key_slots_q[slot_src_sel_i];
-  assign active_slot_boot_stage = active_key_slot_o.boot_stage;
   assign active_slot_policy     = active_key_slot_o.key_policy;
 
   assign data_valid_o = op_ack & gen_key_op & ~invalid_op;
@@ -306,7 +304,7 @@ module keymgr_dpe_ctrl
       // secret (UDS) that comes from peripheral OTP port.
       SlotLoadRoot: begin
         key_slots_d[slot_dst_sel_i].valid = 1;
-        key_slots_d[slot_dst_sel_i].boot_stage = 0;
+        key_slots_d[slot_dst_sel_i].boot_stage = BootStageCreator;
         key_slots_d[slot_dst_sel_i].key[0] ^= root_key_i.key[0];
         key_slots_d[slot_dst_sel_i].key[1] ^= root_key_i.key[1];
         key_slots_d[slot_dst_sel_i].max_key_version = max_key_version_i;
@@ -320,7 +318,8 @@ module keymgr_dpe_ctrl
         key_slots_d[slot_dst_sel_i].valid = 1;
         key_slots_d[slot_dst_sel_i].key = kmac_data_i;
         key_slots_d[slot_dst_sel_i].max_key_version = max_key_version_i;
-        key_slots_d[slot_dst_sel_i].boot_stage = active_slot_boot_stage + 1;
+        key_slots_d[slot_dst_sel_i].boot_stage =
+          (active_key_slot_o.boot_stage == BootStageCreator) ? BootStageOwner : BootStageRuntime;
         key_slots_d[slot_dst_sel_i].key_policy = slot_policy_i;
       end
 
@@ -649,9 +648,6 @@ module keymgr_dpe_ctrl
   logic invalid_allow_child;
   assign invalid_allow_child = ~active_slot_policy.allow_child;
 
-  logic invalid_max_boot_stage;
-  assign invalid_max_boot_stage = active_slot_boot_stage >= DpeNumBootStages - 1;
-
   // Check source validity
   logic invalid_src_slot;
   assign invalid_src_slot = ~active_key_slot_o.valid;
@@ -665,8 +661,9 @@ module keymgr_dpe_ctrl
                            (slot_src_sel_i == slot_dst_sel_i | destination_slot_valid) :
                            (slot_src_sel_i != slot_dst_sel_i);
 
-  assign invalid_advance = adv_req & (invalid_allow_child | invalid_max_boot_stage |
-                                      invalid_src_slot | invalid_retain_parent);
+  assign invalid_advance = adv_req & (invalid_allow_child |
+                                      invalid_src_slot    |
+                                      invalid_retain_parent);
 
   assign invalid_erase = erase_req & ~destination_slot_valid;
 
@@ -676,8 +673,7 @@ module keymgr_dpe_ctrl
   // The outer module uses `invalid_advance_o` to invalidate KMAC msg payload, when the advance
   // operation is not valid. It is better be loose here and ask to invalidate even when there is no
   // advance request.
-  assign invalid_advance_o = invalid_allow_child | invalid_max_boot_stage |
-                                      invalid_src_slot | invalid_retain_parent;
+  assign invalid_advance_o = invalid_allow_child | invalid_src_slot | invalid_retain_parent;
 
   // Exportable DPE is not yet implemented, so mark it unused for lint.
   logic unused_exportable_bit;

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_pkg.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_pkg.sv
@@ -7,10 +7,8 @@ package keymgr_dpe_pkg;
   // Most of the parameters are directly reused from keymgr_pkg
   import keymgr_pkg::*;
 
-  parameter int DpeNumBootStages = 4;  // Number of key manager stages
   parameter int DpeNumSlots = 4;
   parameter int DpeNumSlotsWidth = prim_util_pkg::vbits(DpeNumSlots);
-  parameter int DpeNumBootStagesWidth = $clog2(DpeNumBootStages);
 
   // keymgr and keymgr_dpe have different maximum KMAC input widths. The below widths correspond to
   // the following inputs to advance to the creator root key state:
@@ -85,10 +83,19 @@ package keymgr_dpe_pkg;
     logic allow_child;
   } keymgr_dpe_policy_t;
 
+  // Enumeration for boot stage. In the BootStageRuntime stage, there is no limit on the number of
+  // advance calls.
+  parameter int DpeBootStagesWidth = 2;
+  typedef enum logic [DpeBootStagesWidth-1:0] {
+    BootStageCreator = 0,
+    BootStageOwner   = 1,
+    BootStageRuntime = 2
+  } keymgr_dpe_boot_stage_e;
+
   // An internal secret key slot
   typedef struct packed {
     logic valid;
-    logic [DpeNumBootStagesWidth-1:0] boot_stage;
+    keymgr_dpe_boot_stage_e boot_stage;
     logic [Shares-1:0][KeyWidth-1:0] key;
     logic [KeyVersionWidth-1:0] max_key_version;
     keymgr_dpe_policy_t key_policy;

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_keymgr_dpe_key_derivation_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_keymgr_dpe_key_derivation_vseq.sv
@@ -142,7 +142,7 @@ class chip_sw_keymgr_dpe_key_derivation_vseq extends chip_sw_base_vseq;
       bit key_found = 1'b0;
       for (int i = 0; i < keymgr_dpe_pkg::DpeNumSlots; i++) begin
         keymgr_dpe_pkg::keymgr_dpe_slot_t slot = get_key_slot(i);
-        if (slot.valid && slot.boot_stage == 'd1) begin
+        if (slot.valid && slot.boot_stage == keymgr_dpe_pkg::BootStageOwner) begin
           `DV_CHECK_EQ(key_found, 1'b0, "Expecting only one boot stage 1 key")
           key_found = 1'b1;
           stage_1_key = slot.key;
@@ -191,7 +191,7 @@ class chip_sw_keymgr_dpe_key_derivation_vseq extends chip_sw_base_vseq;
       bit key_found = 1'b0;
       for (int i = 0; i < keymgr_dpe_pkg::DpeNumSlots; i++) begin
         keymgr_dpe_pkg::keymgr_dpe_slot_t slot = get_key_slot(i);
-        if (slot.valid && slot.boot_stage == 'd2) begin
+        if (slot.valid && slot.boot_stage == keymgr_dpe_pkg::BootStageRuntime) begin
           `DV_CHECK_EQ(key_found, 1'b0, "Expecting only one boot stage 2 key")
           key_found = 1'b1;
           stage_2_key = slot.key;
@@ -239,7 +239,7 @@ class chip_sw_keymgr_dpe_key_derivation_vseq extends chip_sw_base_vseq;
      bit key_found = 1'b0;
      for (int i = 0; i < keymgr_dpe_pkg::DpeNumSlots; i++) begin
        keymgr_dpe_pkg::keymgr_dpe_slot_t slot = get_key_slot(i);
-       if (slot.valid && slot.boot_stage == 'd3) begin
+       if (slot.valid && slot.boot_stage == keymgr_dpe_pkg::BootStageRuntime) begin
          `DV_CHECK_EQ(key_found, 1'b0, "Expecting only one boot stage 3 key")
          key_found = 1'b1;
          stage_3_key = slot.key;


### PR DESCRIPTION
When considering attestation, there are more than 4 boot stages needed. To add more flexibility, remove the maximum at all.