### PR TITLE
[otp_ctrl/rtl] Unconditionally reject DAI writes to zeroization marker

### DIFF
--- a/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_dai.sv
+++ b/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_dai.sv
@@ -495,10 +495,11 @@ module otp_ctrl_dai
               base_sel_q == DaiOffset &&
               otp_addr_o[OtpAddrWidth-1:2] < digest_addr_lut[part_idx][OtpAddrWidth-1:2]) ||
              // If this is a write to an unbuffered partition
-             (PartInfo[part_idx].variant != Buffered && base_sel_q == DaiOffset &&
-              !(PartInfo[part_idx].zeroizable &&
-                (otp_addr_o[OtpAddrWidth-1:2] ==
-                 zeroize_addr_lut[part_idx][OtpAddrWidth-1:2]))))) begin
+             (PartInfo[part_idx].variant != Buffered && base_sel_q == DaiOffset)) &&
+            // Don't allow DAI writes to the zeroization marker.
+            !(PartInfo[part_idx].zeroizable &&
+                (otp_addr_o[OtpAddrWidth-1:2] == zeroize_addr_lut[part_idx][OtpAddrWidth-1:2]))
+        ) begin
           otp_req_o = 1'b1;
           // Depending on the partition configuration,
           // the wrapper is instructed to ignore integrity errors.

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_dai.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_dai.sv
@@ -495,10 +495,11 @@ module otp_ctrl_dai
               base_sel_q == DaiOffset &&
               otp_addr_o[OtpAddrWidth-1:2] < digest_addr_lut[part_idx][OtpAddrWidth-1:2]) ||
              // If this is a write to an unbuffered partition
-             (PartInfo[part_idx].variant != Buffered && base_sel_q == DaiOffset &&
-              !(PartInfo[part_idx].zeroizable &&
-                (otp_addr_o[OtpAddrWidth-1:2] ==
-                 zeroize_addr_lut[part_idx][OtpAddrWidth-1:2]))))) begin
+             (PartInfo[part_idx].variant != Buffered && base_sel_q == DaiOffset)) &&
+            // Don't allow DAI writes to the zeroization marker.
+            !(PartInfo[part_idx].zeroizable &&
+                (otp_addr_o[OtpAddrWidth-1:2] == zeroize_addr_lut[part_idx][OtpAddrWidth-1:2]))
+        ) begin
           otp_req_o = 1'b1;
           // Depending on the partition configuration,
           // the wrapper is instructed to ignore integrity errors.

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_dai.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_dai.sv
@@ -495,10 +495,11 @@ module otp_ctrl_dai
               base_sel_q == DaiOffset &&
               otp_addr_o[OtpAddrWidth-1:2] < digest_addr_lut[part_idx][OtpAddrWidth-1:2]) ||
              // If this is a write to an unbuffered partition
-             (PartInfo[part_idx].variant != Buffered && base_sel_q == DaiOffset &&
-              !(PartInfo[part_idx].zeroizable &&
-                (otp_addr_o[OtpAddrWidth-1:2] ==
-                 zeroize_addr_lut[part_idx][OtpAddrWidth-1:2]))))) begin
+             (PartInfo[part_idx].variant != Buffered && base_sel_q == DaiOffset)) &&
+            // Don't allow DAI writes to the zeroization marker.
+            !(PartInfo[part_idx].zeroizable &&
+                (otp_addr_o[OtpAddrWidth-1:2] == zeroize_addr_lut[part_idx][OtpAddrWidth-1:2]))
+        ) begin
           otp_req_o = 1'b1;
           // Depending on the partition configuration,
           // the wrapper is instructed to ignore integrity errors.


### PR DESCRIPTION
Before this commit, DAI writes to the zeroization marker field were rejected for buffered partitions with a HW digest and for unbuffered partitions.  While this effectively applies to all OTP partitions configured upstream (for both Darjeeling and Earlgrey) already, it is cleaner to just *always* reject DAI writes to the zeroization marker field.