### PR TITLE
[crypto] launder HARDENED_CHECK inputs

### DIFF
--- a/sw/device/lib/crypto/drivers/aes.c
+++ b/sw/device/lib/crypto/drivers/aes.c
@@ -220,8 +220,8 @@ static status_t aes_begin(aes_key_t key, const aes_block_t *iv,
   HARDENED_TRY(aes_write_key(key));
 
   // All modes except ECB need to set an IV.
-  if (key.mode != launder32(kAesCipherModeEcb)) {
-    HARDENED_CHECK_NE(key.mode, kAesCipherModeEcb);
+  if (key.mode != kAesCipherModeEcb) {
+    HARDENED_CHECK_NE(launder32(key.mode), kAesCipherModeEcb);
     uint32_t iv_offset = kBase + AES_IV_0_REG_OFFSET;
     for (size_t i = 0; i < ARRAYSIZE(iv->data); ++i) {
       abs_mmio_write32(iv_offset + i * sizeof(uint32_t), iv->data[i]);
@@ -234,13 +234,13 @@ static status_t aes_begin(aes_key_t key, const aes_block_t *iv,
 
   // Check that AES is ready to receive input data.
   uint32_t status = abs_mmio_read32(kBase + AES_STATUS_REG_OFFSET);
-  if (!bitfield_bit32_read(launder32(status), AES_STATUS_INPUT_READY_BIT)) {
+  if (!bitfield_bit32_read(status, AES_STATUS_INPUT_READY_BIT)) {
     return OTCRYPTO_RECOV_ERR;
   }
-  HARDENED_CHECK_EQ(
-      bitfield_bit32_read(abs_mmio_read32(kBase + AES_STATUS_REG_OFFSET),
-                          AES_STATUS_INPUT_READY_BIT),
-      true);
+  HARDENED_CHECK_EQ(launder32(bitfield_bit32_read(
+                        abs_mmio_read32(kBase + AES_STATUS_REG_OFFSET),
+                        AES_STATUS_INPUT_READY_BIT)),
+                    true);
 
   return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -46,11 +46,10 @@ static status_t aes_key_construct(otcrypto_blinded_key_t *blinded_key,
                                   const otcrypto_aes_mode_t aes_mode,
                                   aes_key_t *aes_key) {
   // Key integrity check.
-  if (launder32(integrity_blinded_key_check(blinded_key)) !=
-      kHardenedBoolTrue) {
+  if (integrity_blinded_key_check(blinded_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(blinded_key),
+  HARDENED_CHECK_EQ(launder32(integrity_blinded_key_check(blinded_key)),
                     kHardenedBoolTrue);
 
   if (blinded_key->config.hw_backed == kHardenedBoolTrue) {
@@ -165,7 +164,7 @@ static status_t aes_padding_apply(otcrypto_aes_padding_t padding_mode,
       // Unrecognized padding mode.
       return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(padding_written, kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(launder32(padding_written), kHardenedBoolTrue);
 
   return OTCRYPTO_OK;
 }
@@ -225,7 +224,7 @@ static status_t get_block(otcrypto_const_byte_buf_t input,
   // Randomize the destination buffer.
   HARDENED_TRY(hardened_memshred(block->data, ARRAYSIZE(block->data)));
 
-  if (launder32(index) < num_full_blocks) {
+  if (index < num_full_blocks) {
     HARDENED_CHECK_LT(index, num_full_blocks);
     // No need to worry about padding, just copy the data into the output
     // block.
@@ -234,7 +233,7 @@ static status_t get_block(otcrypto_const_byte_buf_t input,
            kAesBlockNumBytes);
     return OTCRYPTO_OK;
   }
-  HARDENED_CHECK_GE(index, num_full_blocks);
+  HARDENED_CHECK_GE(launder32(index), num_full_blocks);
 
   // If we get here, this block is the one with padding. It may be a partial
   // block or an empty block that will be entirely filled with padded bytes.
@@ -308,16 +307,16 @@ static otcrypto_status_t otcrypto_aes_impl(
   // Construct the IV and check its length. ECB mode will ignore the IV, so in
   // this case it is left uninitialized.
   aes_block_t aes_iv;
-  if (aes_mode == launder32(kAesCipherModeEcb)) {
-    HARDENED_CHECK_EQ(aes_mode, kAesCipherModeEcb);
+  if (aes_mode == kAesCipherModeEcb) {
+    HARDENED_CHECK_EQ(launder32(aes_mode), kAesCipherModeEcb);
   } else {
-    HARDENED_CHECK_NE(aes_mode, kAesCipherModeEcb);
+    HARDENED_CHECK_NE(launder32(aes_mode), kAesCipherModeEcb);
 
     // The IV must be exactly one block long.
-    if (launder32(iv.len) != kAesBlockNumWords) {
+    if (iv.len != kAesBlockNumWords) {
       return OTCRYPTO_BAD_ARGS;
     }
-    HARDENED_CHECK_EQ(iv.len, kAesBlockNumWords);
+    HARDENED_CHECK_EQ(launder32(iv.len), kAesBlockNumWords);
     HARDENED_TRY(hardened_memcpy(aes_iv.data, iv.data, kAesBlockNumWords));
   }
 
@@ -391,17 +390,17 @@ static otcrypto_status_t otcrypto_aes_impl(
 
   // Retrieve the output from the final `block_offset` blocks (providing no
   // input).
-  for (i = block_offset; launder32(i) > 0; --i) {
+  for (i = block_offset; i > 0; --i) {
     HARDENED_TRY(aes_update(&block_out, /*src=*/NULL));
     // TODO(#17711) Change to `hardened_memcpy`.
     memcpy(&cipher_output.data[(input_nblocks - i) * kAesBlockNumBytes],
            block_out.data, kAesBlockNumBytes);
   }
   // Check that the loop ran for the correct number of iterations.
-  HARDENED_CHECK_EQ(i, 0);
+  HARDENED_CHECK_EQ(launder32(i), 0);
 
   // Deinitialize the AES block and update the IV (in ECB mode, skip the IV).
-  if (aes_mode == launder32(kAesCipherModeEcb)) {
+  if (aes_mode == kAesCipherModeEcb) {
     HARDENED_TRY(aes_end(NULL));
   } else {
     HARDENED_TRY(aes_end(&aes_iv));

--- a/sw/device/lib/crypto/impl/ecc_p256.c
+++ b/sw/device/lib/crypto/impl/ecc_p256.c
@@ -69,12 +69,14 @@ static status_t internal_p256_keygen_start(
   // Ensure the entropy complex is initialized.
   HARDENED_TRY(entropy_complex_check());
 
-  if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
-    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
+  if (private_key->config.hw_backed == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
+                      kHardenedBoolTrue);
     HARDENED_TRY(keyblob_sideload_key_otbn(private_key));
     return p256_sideload_keygen_start();
-  } else if (launder32(private_key->config.hw_backed) == kHardenedBoolFalse) {
-    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
+  } else if (private_key->config.hw_backed == kHardenedBoolFalse) {
+    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
+                      kHardenedBoolFalse);
     return p256_keygen_start();
   } else {
     return OTCRYPTO_BAD_ARGS;
@@ -89,10 +91,11 @@ otcrypto_status_t otcrypto_ecdsa_p256_keygen_async_start(
   }
 
   // Check the key mode.
-  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdsaP256) {
+  if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP256) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdsaP256);
+  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
+                    kOtcryptoKeyModeEcdsaP256);
 
   return internal_p256_keygen_start(private_key);
 }
@@ -117,32 +120,35 @@ static status_t p256_private_key_length_check(
     return OTCRYPTO_BAD_ARGS;
   }
 
-  if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
+  if (private_key->config.hw_backed == kHardenedBoolTrue) {
     // Skip the length check in this case; if the salt is the wrong length, the
     // keyblob library will catch it before we sideload the key.
     return OTCRYPTO_OK;
   }
-  HARDENED_CHECK_NE(private_key->config.hw_backed, kHardenedBoolTrue);
+  HARDENED_CHECK_NE(launder32(private_key->config.hw_backed),
+                    kHardenedBoolTrue);
 
   // Check the unmasked length.
-  if (launder32(private_key->config.key_length) != kP256ScalarBytes) {
+  if (private_key->config.key_length != kP256ScalarBytes) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(private_key->config.key_length, kP256ScalarBytes);
+  HARDENED_CHECK_EQ(launder32(private_key->config.key_length),
+                    kP256ScalarBytes);
 
   // Check the single-share length.
-  if (launder32(keyblob_share_num_words(private_key->config)) !=
+  if (keyblob_share_num_words(private_key->config) !=
       kP256MaskedScalarShareWords) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(keyblob_share_num_words(private_key->config),
+  HARDENED_CHECK_EQ(launder32(keyblob_share_num_words(private_key->config)),
                     kP256MaskedScalarShareWords);
 
   // Check the keyblob length.
-  if (launder32(private_key->keyblob_length) != sizeof(p256_masked_scalar_t)) {
+  if (private_key->keyblob_length != sizeof(p256_masked_scalar_t)) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(private_key->keyblob_length, sizeof(p256_masked_scalar_t));
+  HARDENED_CHECK_EQ(launder32(private_key->keyblob_length),
+                    sizeof(p256_masked_scalar_t));
 
   return OTCRYPTO_OK;
 }
@@ -163,10 +169,10 @@ static status_t p256_private_key_length_check(
 OT_WARN_UNUSED_RESULT
 static status_t p256_public_key_length_check(
     const otcrypto_unblinded_key_t *public_key) {
-  if (launder32(public_key->key_length) != sizeof(p256_point_t)) {
+  if (public_key->key_length != sizeof(p256_point_t)) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(public_key->key_length, sizeof(p256_point_t));
+  HARDENED_CHECK_EQ(launder32(public_key->key_length), sizeof(p256_point_t));
   return OTCRYPTO_OK;
 }
 
@@ -198,11 +204,13 @@ static status_t internal_p256_keygen_finalize(
   // The `finalize` call should be the last potentially error-causing line
   // before returning to the caller.
 
-  if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
-    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
+  if (private_key->config.hw_backed == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
+                      kHardenedBoolTrue);
     HARDENED_TRY(p256_sideload_keygen_finalize(pk));
-  } else if (launder32(private_key->config.hw_backed) == kHardenedBoolFalse) {
-    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
+  } else if (private_key->config.hw_backed == kHardenedBoolFalse) {
+    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
+                      kHardenedBoolFalse);
 
     // Randomize the keyblob before writing secret data.
     HARDENED_TRY(hardened_memshred(private_key->keyblob,
@@ -231,12 +239,13 @@ otcrypto_status_t otcrypto_ecdsa_p256_keygen_async_finalize(
   }
 
   // Check the key modes.
-  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdsaP256 ||
-      launder32(public_key->key_mode) != kOtcryptoKeyModeEcdsaP256) {
+  if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP256 ||
+      public_key->key_mode != kOtcryptoKeyModeEcdsaP256) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdsaP256);
-  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdsaP256);
+  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
+                    kOtcryptoKeyModeEcdsaP256);
+  HARDENED_CHECK_EQ(launder32(public_key->key_mode), kOtcryptoKeyModeEcdsaP256);
 
   return internal_p256_keygen_finalize(private_key, public_key);
 }
@@ -253,35 +262,37 @@ otcrypto_status_t otcrypto_ecdsa_p256_sign_async_start(
   HARDENED_TRY(entropy_complex_check());
 
   // Check the integrity of the private key.
-  if (launder32(integrity_blinded_key_check(private_key)) !=
-      kHardenedBoolTrue) {
+  if (integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(private_key),
+  HARDENED_CHECK_EQ(launder32(integrity_blinded_key_check(private_key)),
                     kHardenedBoolTrue);
 
-  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdsaP256) {
+  if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP256) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdsaP256);
+  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
+                    kOtcryptoKeyModeEcdsaP256);
 
   // Check the digest length.
-  if (launder32(message_digest.len) != kP256ScalarWords) {
+  if (message_digest.len != kP256ScalarWords) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(message_digest.len, kP256ScalarWords);
+  HARDENED_CHECK_EQ(launder32(message_digest.len), kP256ScalarWords);
 
   // Check the key length.
   HARDENED_TRY(p256_private_key_length_check(private_key));
 
-  if (launder32(private_key->config.hw_backed) == kHardenedBoolFalse) {
+  if (private_key->config.hw_backed == kHardenedBoolFalse) {
     // Start the asynchronous signature-generation routine.
-    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
+    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
+                      kHardenedBoolFalse);
     HARDENED_TRY(p256_ecdsa_sign_start(
         message_digest.data, (p256_masked_scalar_t *)private_key->keyblob));
-  } else if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
+  } else if (private_key->config.hw_backed == kHardenedBoolTrue) {
     // Load the key and start in sideloaded-key mode.
-    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
+    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
+                      kHardenedBoolTrue);
     HARDENED_TRY(keyblob_sideload_key_otbn(private_key));
     HARDENED_TRY(p256_ecdsa_sideload_sign_start(message_digest.data));
   } else {
@@ -310,11 +321,12 @@ otcrypto_status_t otcrypto_ecdsa_p256_sign_async_start(
  */
 OT_WARN_UNUSED_RESULT
 static status_t p256_signature_length_check(size_t len) {
-  if (launder32(len) > UINT32_MAX / sizeof(uint32_t) ||
-      launder32(len) * sizeof(uint32_t) != sizeof(p256_ecdsa_signature_t)) {
+  if (len > UINT32_MAX / sizeof(uint32_t) ||
+      len * sizeof(uint32_t) != sizeof(p256_ecdsa_signature_t)) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(len * sizeof(uint32_t), sizeof(p256_ecdsa_signature_t));
+  HARDENED_CHECK_EQ(launder32(len) * sizeof(uint32_t),
+                    sizeof(p256_ecdsa_signature_t));
 
   return OTCRYPTO_OK;
 }
@@ -352,28 +364,27 @@ otcrypto_status_t otcrypto_ecdsa_p256_verify_async_start(
   HARDENED_TRY(entropy_complex_check());
 
   // Check the integrity of the public key.
-  if (launder32(integrity_unblinded_key_check(public_key)) !=
-      kHardenedBoolTrue) {
+  if (integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(integrity_unblinded_key_check(public_key),
+  HARDENED_CHECK_EQ(launder32(integrity_unblinded_key_check(public_key)),
                     kHardenedBoolTrue);
 
   // Check the public key mode.
-  if (launder32(public_key->key_mode) != kOtcryptoKeyModeEcdsaP256) {
+  if (public_key->key_mode != kOtcryptoKeyModeEcdsaP256) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdsaP256);
+  HARDENED_CHECK_EQ(launder32(public_key->key_mode), kOtcryptoKeyModeEcdsaP256);
 
   // Check the public key size.
   HARDENED_TRY(p256_public_key_length_check(public_key));
   p256_point_t *pk = (p256_point_t *)public_key->key;
 
   // Check the digest length.
-  if (launder32(message_digest.len) != kP256ScalarWords) {
+  if (message_digest.len != kP256ScalarWords) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(message_digest.len, kP256ScalarWords);
+  HARDENED_CHECK_EQ(launder32(message_digest.len), kP256ScalarWords);
 
   // Check the signature lengths.
   HARDENED_TRY(p256_signature_length_check(signature.len));
@@ -412,10 +423,11 @@ otcrypto_status_t otcrypto_ecdh_p256_keygen_async_start(
     return OTCRYPTO_BAD_ARGS;
   }
 
-  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdhP256) {
+  if (private_key->config.key_mode != kOtcryptoKeyModeEcdhP256) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdhP256);
+  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
+                    kOtcryptoKeyModeEcdhP256);
   return internal_p256_keygen_start(private_key);
 }
 
@@ -427,12 +439,13 @@ otcrypto_status_t otcrypto_ecdh_p256_keygen_async_finalize(
     return OTCRYPTO_BAD_ARGS;
   }
 
-  if (launder32(public_key->key_mode) != kOtcryptoKeyModeEcdhP256 ||
-      launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdhP256) {
+  if (public_key->key_mode != kOtcryptoKeyModeEcdhP256 ||
+      private_key->config.key_mode != kOtcryptoKeyModeEcdhP256) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdhP256);
-  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdhP256);
+  HARDENED_CHECK_EQ(launder32(public_key->key_mode), kOtcryptoKeyModeEcdhP256);
+  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
+                    kOtcryptoKeyModeEcdhP256);
   return internal_p256_keygen_finalize(private_key, public_key);
 }
 
@@ -448,36 +461,37 @@ otcrypto_status_t otcrypto_ecdh_p256_async_start(
   HARDENED_TRY(entropy_complex_check());
 
   // Check the integrity of the keys.
-  if (launder32(integrity_blinded_key_check(private_key)) !=
-          kHardenedBoolTrue ||
-      launder32(integrity_unblinded_key_check(public_key)) !=
-          kHardenedBoolTrue) {
+  if (integrity_blinded_key_check(private_key) != kHardenedBoolTrue ||
+      integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(private_key),
+  HARDENED_CHECK_EQ(launder32(integrity_blinded_key_check(private_key)),
                     kHardenedBoolTrue);
-  HARDENED_CHECK_EQ(integrity_unblinded_key_check(public_key),
+  HARDENED_CHECK_EQ(launder32(integrity_unblinded_key_check(public_key)),
                     kHardenedBoolTrue);
 
   // Check the key modes.
-  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdhP256 ||
-      launder32(public_key->key_mode) != kOtcryptoKeyModeEcdhP256) {
+  if (private_key->config.key_mode != kOtcryptoKeyModeEcdhP256 ||
+      public_key->key_mode != kOtcryptoKeyModeEcdhP256) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdhP256);
-  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdhP256);
+  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
+                    kOtcryptoKeyModeEcdhP256);
+  HARDENED_CHECK_EQ(launder32(public_key->key_mode), kOtcryptoKeyModeEcdhP256);
 
   // Check the key lengths.
   HARDENED_TRY(p256_private_key_length_check(private_key));
   HARDENED_TRY(p256_public_key_length_check(public_key));
   p256_point_t *pk = (p256_point_t *)public_key->key;
 
-  if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
-    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
+  if (private_key->config.hw_backed == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
+                      kHardenedBoolTrue);
     HARDENED_TRY(keyblob_sideload_key_otbn(private_key));
     HARDENED_TRY(p256_sideload_ecdh_start(pk));
-  } else if (launder32(private_key->config.hw_backed) == kHardenedBoolFalse) {
-    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
+  } else if (private_key->config.hw_backed == kHardenedBoolFalse) {
+    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
+                      kHardenedBoolFalse);
     HARDENED_TRY(
         p256_ecdh_start((p256_masked_scalar_t *)private_key->keyblob, pk));
   } else {
@@ -510,19 +524,21 @@ otcrypto_status_t otcrypto_ecdh_p256_async_finalize(
   if (launder32(shared_secret->config.hw_backed) != kHardenedBoolFalse) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(shared_secret->config.hw_backed, kHardenedBoolFalse);
+  HARDENED_CHECK_EQ(launder32(shared_secret->config.hw_backed),
+                    kHardenedBoolFalse);
 
   // Check shared secret length.
-  if (launder32(shared_secret->config.key_length) != kP256CoordBytes) {
+  if (shared_secret->config.key_length != kP256CoordBytes) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(shared_secret->config.key_length, kP256CoordBytes);
-  if (launder32(shared_secret->keyblob_length) !=
+  HARDENED_CHECK_EQ(launder32(shared_secret->config.key_length),
+                    kP256CoordBytes);
+  if (shared_secret->keyblob_length !=
       keyblob_num_words(shared_secret->config) * sizeof(uint32_t)) {
     return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_CHECK_EQ(
-      shared_secret->keyblob_length,
+      launder32(shared_secret->keyblob_length),
       keyblob_num_words(shared_secret->config) * sizeof(uint32_t));
 
   // Note: This operation wipes DMEM after retrieving the keys, so if an error

--- a/sw/device/lib/crypto/impl/ecc_p384.c
+++ b/sw/device/lib/crypto/impl/ecc_p384.c
@@ -69,12 +69,14 @@ static status_t internal_p384_keygen_start(
   // Check that the entropy complex is initialized.
   HARDENED_TRY(entropy_complex_check());
 
-  if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
-    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
+  if (private_key->config.hw_backed == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
+                      kHardenedBoolTrue);
     HARDENED_TRY(keyblob_sideload_key_otbn(private_key));
     return p384_sideload_keygen_start();
-  } else if (launder32(private_key->config.hw_backed) == kHardenedBoolFalse) {
-    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
+  } else if (private_key->config.hw_backed == kHardenedBoolFalse) {
+    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
+                      kHardenedBoolFalse);
     return p384_keygen_start();
   } else {
     return OTCRYPTO_BAD_ARGS;
@@ -89,10 +91,11 @@ otcrypto_status_t otcrypto_ecdsa_p384_keygen_async_start(
   }
 
   // Check the key mode.
-  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdsaP384) {
+  if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP384) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdsaP384);
+  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
+                    kOtcryptoKeyModeEcdsaP384);
 
   return internal_p384_keygen_start(private_key);
 }
@@ -117,32 +120,35 @@ static status_t p384_private_key_length_check(
     return OTCRYPTO_BAD_ARGS;
   }
 
-  if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
+  if (private_key->config.hw_backed == kHardenedBoolTrue) {
     // Skip the length check in this case; if the salt is the wrong length, the
     // keyblob library will catch it before we sideload the key.
     return OTCRYPTO_OK;
   }
-  HARDENED_CHECK_NE(private_key->config.hw_backed, kHardenedBoolTrue);
+  HARDENED_CHECK_NE(launder32(private_key->config.hw_backed),
+                    kHardenedBoolTrue);
 
   // Check the unmasked length.
-  if (launder32(private_key->config.key_length) != kP384ScalarBytes) {
+  if (private_key->config.key_length != kP384ScalarBytes) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(private_key->config.key_length, kP384ScalarBytes);
+  HARDENED_CHECK_EQ(launder32(private_key->config.key_length),
+                    kP384ScalarBytes);
 
   // Check the single-share length.
-  if (launder32(keyblob_share_num_words(private_key->config)) !=
+  if (keyblob_share_num_words(private_key->config) !=
       kP384MaskedScalarShareWords) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(keyblob_share_num_words(private_key->config),
+  HARDENED_CHECK_EQ(launder32(keyblob_share_num_words(private_key->config)),
                     kP384MaskedScalarShareWords);
 
   // Check the keyblob length.
-  if (launder32(private_key->keyblob_length) != sizeof(p384_masked_scalar_t)) {
+  if (private_key->keyblob_length != sizeof(p384_masked_scalar_t)) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(private_key->keyblob_length, sizeof(p384_masked_scalar_t));
+  HARDENED_CHECK_EQ(launder32(private_key->keyblob_length),
+                    sizeof(p384_masked_scalar_t));
 
   return OTCRYPTO_OK;
 }
@@ -163,10 +169,10 @@ static status_t p384_private_key_length_check(
 OT_WARN_UNUSED_RESULT
 static status_t p384_public_key_length_check(
     const otcrypto_unblinded_key_t *public_key) {
-  if (launder32(public_key->key_length) != sizeof(p384_point_t)) {
+  if (public_key->key_length != sizeof(p384_point_t)) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(public_key->key_length, sizeof(p384_point_t));
+  HARDENED_CHECK_EQ(launder32(public_key->key_length), sizeof(p384_point_t));
   return OTCRYPTO_OK;
 }
 /**
@@ -194,15 +200,17 @@ static status_t internal_p384_keygen_finalize(
   // Interpret the key buffer as a P-384 point.
   p384_point_t *pk = (p384_point_t *)public_key->key;
 
-  if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
+  if (private_key->config.hw_backed == kHardenedBoolTrue) {
     // Note: This operation wipes DMEM after retrieving the keys, so if an error
     // occurs after this point then the keys would be unrecoverable. This should
     // be the last potentially error-causing line before returning to the
     // caller.
-    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
+    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
+                      kHardenedBoolTrue);
     HARDENED_TRY(p384_sideload_keygen_finalize(pk));
-  } else if (launder32(private_key->config.hw_backed) == kHardenedBoolFalse) {
-    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
+  } else if (private_key->config.hw_backed == kHardenedBoolFalse) {
+    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
+                      kHardenedBoolFalse);
 
     // Randomize the keyblob before writing secret data.
     HARDENED_TRY(hardened_memshred(private_key->keyblob,
@@ -232,12 +240,13 @@ otcrypto_status_t otcrypto_ecdsa_p384_keygen_async_finalize(
   }
 
   // Check the key modes.
-  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdsaP384 ||
-      launder32(public_key->key_mode) != kOtcryptoKeyModeEcdsaP384) {
+  if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP384 ||
+      public_key->key_mode != kOtcryptoKeyModeEcdsaP384) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdsaP384);
-  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdsaP384);
+  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
+                    kOtcryptoKeyModeEcdsaP384);
+  HARDENED_CHECK_EQ(launder32(public_key->key_mode), kOtcryptoKeyModeEcdsaP384);
 
   HARDENED_TRY(internal_p384_keygen_finalize(private_key, public_key));
 
@@ -257,35 +266,37 @@ otcrypto_status_t otcrypto_ecdsa_p384_sign_async_start(
   HARDENED_TRY(entropy_complex_check());
 
   // Check the integrity of the private key.
-  if (launder32(integrity_blinded_key_check(private_key)) !=
-      kHardenedBoolTrue) {
+  if (integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(private_key),
+  HARDENED_CHECK_EQ(launder32(integrity_blinded_key_check(private_key)),
                     kHardenedBoolTrue);
 
-  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdsaP384) {
+  if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP384) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdsaP384);
+  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
+                    kOtcryptoKeyModeEcdsaP384);
 
   // Check the digest length.
-  if (launder32(message_digest.len) != kP384ScalarWords) {
+  if (message_digest.len != kP384ScalarWords) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(message_digest.len, kP384ScalarWords);
+  HARDENED_CHECK_EQ(launder32(message_digest.len), kP384ScalarWords);
 
   // Check the key length.
   HARDENED_TRY(p384_private_key_length_check(private_key));
 
-  if (launder32(private_key->config.hw_backed) == kHardenedBoolFalse) {
+  if (private_key->config.hw_backed == kHardenedBoolFalse) {
     // Start the asynchronous signature-generation routine.
-    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
+    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
+                      kHardenedBoolFalse);
     HARDENED_TRY(p384_ecdsa_sign_start(
         message_digest.data, (p384_masked_scalar_t *)private_key->keyblob));
-  } else if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
+  } else if (private_key->config.hw_backed == kHardenedBoolTrue) {
     // Load the key and start in sideloaded-key mode.
-    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
+    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
+                      kHardenedBoolTrue);
     HARDENED_TRY(keyblob_sideload_key_otbn(private_key));
     HARDENED_TRY(p384_ecdsa_sideload_sign_start(message_digest.data));
   } else {
@@ -314,11 +325,12 @@ otcrypto_status_t otcrypto_ecdsa_p384_sign_async_start(
  */
 OT_WARN_UNUSED_RESULT
 static status_t p384_signature_length_check(size_t len) {
-  if (launder32(len) > UINT32_MAX / sizeof(uint32_t) ||
-      launder32(len) * sizeof(uint32_t) != sizeof(p384_ecdsa_signature_t)) {
+  if (len > UINT32_MAX / sizeof(uint32_t) ||
+      len * sizeof(uint32_t) != sizeof(p384_ecdsa_signature_t)) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(len * sizeof(uint32_t), sizeof(p384_ecdsa_signature_t));
+  HARDENED_CHECK_EQ(launder32(len) * sizeof(uint32_t),
+                    sizeof(p384_ecdsa_signature_t));
 
   return OTCRYPTO_OK;
 }
@@ -355,28 +367,27 @@ otcrypto_status_t otcrypto_ecdsa_p384_verify_async_start(
   HARDENED_TRY(entropy_complex_check());
 
   // Check the integrity of the public key.
-  if (launder32(integrity_unblinded_key_check(public_key)) !=
-      kHardenedBoolTrue) {
+  if (integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(integrity_unblinded_key_check(public_key),
+  HARDENED_CHECK_EQ(launder32(integrity_unblinded_key_check(public_key)),
                     kHardenedBoolTrue);
 
   // Check the public key mode.
-  if (launder32(public_key->key_mode) != kOtcryptoKeyModeEcdsaP384) {
+  if (public_key->key_mode != kOtcryptoKeyModeEcdsaP384) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdsaP384);
+  HARDENED_CHECK_EQ(launder32(public_key->key_mode), kOtcryptoKeyModeEcdsaP384);
 
   // Check the public key size.
   HARDENED_TRY(p384_public_key_length_check(public_key));
   p384_point_t *pk = (p384_point_t *)public_key->key;
 
   // Check the digest length.
-  if (launder32(message_digest.len) != kP384ScalarWords) {
+  if (message_digest.len != kP384ScalarWords) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(message_digest.len, kP384ScalarWords);
+  HARDENED_CHECK_EQ(launder32(message_digest.len), kP384ScalarWords);
 
   // Check the signature lengths.
   HARDENED_TRY(p384_signature_length_check(signature.len));
@@ -415,10 +426,11 @@ otcrypto_status_t otcrypto_ecdh_p384_keygen_async_start(
     return OTCRYPTO_BAD_ARGS;
   }
 
-  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdhP384) {
+  if (private_key->config.key_mode != kOtcryptoKeyModeEcdhP384) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdhP384);
+  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
+                    kOtcryptoKeyModeEcdhP384);
   return internal_p384_keygen_start(private_key);
 }
 
@@ -430,12 +442,13 @@ otcrypto_status_t otcrypto_ecdh_p384_keygen_async_finalize(
     return OTCRYPTO_BAD_ARGS;
   }
 
-  if (launder32(public_key->key_mode) != kOtcryptoKeyModeEcdhP384 ||
-      launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdhP384) {
+  if (public_key->key_mode != kOtcryptoKeyModeEcdhP384 ||
+      private_key->config.key_mode != kOtcryptoKeyModeEcdhP384) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdhP384);
-  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdhP384);
+  HARDENED_CHECK_EQ(launder32(public_key->key_mode), kOtcryptoKeyModeEcdhP384);
+  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
+                    kOtcryptoKeyModeEcdhP384);
   return internal_p384_keygen_finalize(private_key, public_key);
 }
 
@@ -451,36 +464,37 @@ otcrypto_status_t otcrypto_ecdh_p384_async_start(
   HARDENED_TRY(entropy_complex_check());
 
   // Check the integrity of the keys.
-  if (launder32(integrity_blinded_key_check(private_key)) !=
-          kHardenedBoolTrue ||
-      launder32(integrity_unblinded_key_check(public_key)) !=
-          kHardenedBoolTrue) {
+  if (integrity_blinded_key_check(private_key) != kHardenedBoolTrue ||
+      integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(private_key),
+  HARDENED_CHECK_EQ(launder32(integrity_blinded_key_check(private_key)),
                     kHardenedBoolTrue);
-  HARDENED_CHECK_EQ(integrity_unblinded_key_check(public_key),
+  HARDENED_CHECK_EQ(launder32(integrity_unblinded_key_check(public_key)),
                     kHardenedBoolTrue);
 
   // Check the key modes.
-  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdhP384 ||
-      launder32(public_key->key_mode) != kOtcryptoKeyModeEcdhP384) {
+  if (private_key->config.key_mode != kOtcryptoKeyModeEcdhP384 ||
+      public_key->key_mode != kOtcryptoKeyModeEcdhP384) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdhP384);
-  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdhP384);
+  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
+                    kOtcryptoKeyModeEcdhP384);
+  HARDENED_CHECK_EQ(launder32(public_key->key_mode), kOtcryptoKeyModeEcdhP384);
 
   // Check the key lengths.
   HARDENED_TRY(p384_private_key_length_check(private_key));
   HARDENED_TRY(p384_public_key_length_check(public_key));
   p384_point_t *pk = (p384_point_t *)public_key->key;
 
-  if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
-    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
+  if (private_key->config.hw_backed == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
+                      kHardenedBoolTrue);
     HARDENED_TRY(keyblob_sideload_key_otbn(private_key));
     HARDENED_TRY(p384_sideload_ecdh_start(pk));
-  } else if (launder32(private_key->config.hw_backed) == kHardenedBoolFalse) {
-    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
+  } else if (private_key->config.hw_backed == kHardenedBoolFalse) {
+    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
+                      kHardenedBoolFalse);
     HARDENED_TRY(
         p384_ecdh_start((p384_masked_scalar_t *)private_key->keyblob, pk));
   } else {
@@ -510,17 +524,19 @@ otcrypto_status_t otcrypto_ecdh_p384_async_finalize(
   HARDENED_TRY(entropy_complex_check());
 
   // Shared keys cannot be sideloaded because they are software-generated.
-  if (launder32(shared_secret->config.hw_backed) != kHardenedBoolFalse) {
+  if (shared_secret->config.hw_backed != kHardenedBoolFalse) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(shared_secret->config.hw_backed, kHardenedBoolFalse);
+  HARDENED_CHECK_EQ(launder32(shared_secret->config.hw_backed),
+                    kHardenedBoolFalse);
 
   // Check shared secret length.
-  if (launder32(shared_secret->config.key_length) != kP384CoordBytes) {
+  if (shared_secret->config.key_length != kP384CoordBytes) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(shared_secret->config.key_length, kP384CoordBytes);
-  if (launder32(shared_secret->keyblob_length) !=
+  HARDENED_CHECK_EQ(launder32(shared_secret->config.key_length),
+                    kP384CoordBytes);
+  if (shared_secret->keyblob_length !=
       keyblob_num_words(shared_secret->config) * sizeof(uint32_t)) {
     return OTCRYPTO_BAD_ARGS;
   }


### PR DESCRIPTION
The assembly of the crypto shows several redundant operations such as bne a0, a0 or beq a1, a1. These originate from uses of HARDENED_CHECK_ operations. Add launder functions to inputs to force these checks to be meaningful.

The pattern that seems to work is:

if (condition) { ... }

HARDENED_CHECK(launder(condition))