### PR TITLE
WIP: [fpga/splice] Correct MMI order for updatemem

### DIFF
--- a/hw/ip/rom_ctrl/util/gen_vivado_mem_image.py
+++ b/hw/ip/rom_ctrl/util/gen_vivado_mem_image.py
@@ -221,12 +221,12 @@ def main() -> int:
     assert len(vmem.chunks) == 1
     words = vmem.chunks[0].words
 
-    if width == 24:
-        logger.info("Generating updatemem-compatible MEM file for OTP image.")
-        updatemem_pieces = otp_words_to_updatemem_pieces(words)
-        updatemem_line = ' '.join(updatemem_pieces)
-        args.outfile.write(updatemem_line + '\n')
-        return 0
+    # if width == 24:
+    #     logger.info("Generating updatemem-compatible MEM file for OTP image.")
+    #     updatemem_pieces = otp_words_to_updatemem_pieces(words)
+    #     updatemem_line = ' '.join(updatemem_pieces)
+    #     args.outfile.write(updatemem_line + '\n')
+    #     return 0
 
     logger.info("Generating updatemem-compatible MEM file for ROM.")
     # Loop over all words, and:
@@ -241,7 +241,8 @@ def main() -> int:
         # Generate the address.
         addr = idx * math.ceil(width / 8)
         # Convert endianness.
-        data = swap_bytes(width, word, args.swap_nibbles)
+        # data = swap_bytes(width, word, args.swap_nibbles)
+        data = word
         # Check for contiguous addresses. If any are found, omit this word's
         # address to speed up `updatemem` operation.
         toks = []

--- a/hw/top_englishbreakfast/util/vivado_hook_write_bitstream_pre.tcl
+++ b/hw/top_englishbreakfast/util/vivado_hook_write_bitstream_pre.tcl
@@ -88,7 +88,9 @@ proc generate_mmi {filename mem_infos designtask_count} {
                 puts $fileout "    <MemoryLayout Name=\"$id\" CoreMemory_Width=\"$width\" MemoryType=\"RAM_SP\">"
             }
 
-            foreach inst [lsort -dictionary $brams] {
+	    # updatemem fills memory in the order of the bit slices, instead of
+	    # respecting indices. List the MSB slices first.
+            foreach inst [lsort -decreasing -dictionary $brams] {
                 set loc [get_property LOC [get_cells $inst]]
                 set loc_matches [regexp $mem_type_regex $loc loc_match loc_prefix loc_suffix]
                 if {$loc_matches == 0} {
@@ -163,7 +165,7 @@ proc dump_init_strings {filename brams designtask_count} {
     set filepath "${workroot}/${filename}"
     set fileout [open $filepath "w"]
 
-    foreach inst [lsort -dictionary $brams] {
+    foreach inst [lsort -decreasing -dictionary $brams] {
         set bram [get_cells $inst]
 
         set loc [get_property LOC $bram]


### PR DESCRIPTION
...and undo the sequence of a transformation followed by its inverse.

Updatemem fills the memories based on the order of the bit lanes as they appear in the MMI file. In a VMEM file, the MSBs appear first, but in the MMI file, the LSBs appear first. gen_vivado_mem_image corrects for an ostensibly broken MMI generation script. Correct the MMI script and remove the transformations in gen_vivado_mem_image.