### PR TITLE
[bazel,qemu] Fix missing OTP override on some QEMU tests

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/keymgr/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/keymgr/BUILD
@@ -89,6 +89,7 @@ rom_e2e_keymgr_init_configs = [
                 # Test uses rstmgr, keep running on fatal resets:
                 "ot-rstmgr.fatal_reset": 0,
             },
+            otp = ":otp_img_keymgr_{}".format(config["name"]),
         ),
         verilator = verilator_params(
             timeout = "eternal",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1847,6 +1847,9 @@ _FLASH_CTRL_INFO_ACCESS_LC_STATES = get_lc_items(
         fpga = fpga_params(
             otp = "//hw/ip/otp_ctrl/data:img_{}".format(lc_state),
         ),
+        qemu = qemu_params(
+            otp = "//hw/ip/otp_ctrl/data:img_{}".format(lc_state),
+        ),
         deps = [
             "//hw/top_earlgrey/sw/autogen:top_earlgrey",
             "//sw/device/lib/base:mmio",


### PR DESCRIPTION
When I added the QEMU environment to the tests in https://github.com/lowRISC/opentitan/pull/28138 I missed the OTP overrides that were required in the test parameters (only present on FPGA currently) - add these so that we actually exercise the test functionality, rather than testing in the RMA state.