### PR TITLE
[bazel] Allow QEMU OTP to be overridden by params

### DIFF
--- a/rules/opentitan/qemu.bzl
+++ b/rules/opentitan/qemu.bzl
@@ -291,7 +291,7 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
     otp = gen_otp(
         ctx,
         otptool = exec_env.otptool,
-        vmem = exec_env.otp,
+        vmem = get_fallback(ctx, "file.otp", exec_env),
     )
 
     qemu_cfg = gen_cfg(


### PR DESCRIPTION
Previously we were always taking the execution environment's default instead of checking for overrides in parameters.