### PR TITLE
[sw/build] Switch failing AES tests to cw340

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -120,6 +120,8 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         DARJEELING_TEST_ENVS,
         {
+            "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
+            "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
@@ -1329,6 +1331,8 @@ opentitan_test(
         ),
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
+            "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
+            "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),


### PR DESCRIPTION
This commit switches tests that are failing due to AES being used in the unmasked configuration to cw340 where masking still is enabled.
edn_sw_mode doesn't make sense to run with an unused mask configuration since this test stalls AES by not providing entropy. However if AES is not in the masked configuration, entropy is not needed and AES cannot be stalled in this way.