### PR TITLE
[top_darjeeling/formal] Fix config

### DIFF
--- a/hw/top_darjeeling/formal/chip_conn_cfg.hjson
+++ b/hw/top_darjeeling/formal/chip_conn_cfg.hjson
@@ -10,7 +10,7 @@
   fusesoc_core: lowrisc:systems:chip_darjeeling_asic:0.1
 
   bbox_cmd: "[list aon_osc io_osc sys_osc]"
-  conn_csvs_dir: "{proj_root}/hw/{top_chip}/formal/conn_csvs"
+  conn_csvs_dir: "{proj_root}/hw/top_darjeeling/formal/conn_csvs"
   conn_csvs: ["{conn_csvs_dir}/analog_sigs.csv",
               "{conn_csvs_dir}/aon_timer_rst.csv",
               "{conn_csvs_dir}/ast_infra.csv",
@@ -41,7 +41,7 @@
   // TODO: reduce run time and turn on coverage
   cov: false
 
-  rel_path: "hw/{top_chip}/{sub_flow}/{tool}"
+  rel_path: "hw/top_darjeeling/{sub_flow}/{tool}"
 
   publish_report: true
 }


### PR DESCRIPTION
The `top_chip` variable was introduced in [this commit](https://github.com/lowRISC/opentitan/tree/dc06a181e1686f44847b9a8040398bef69b56b9e), but it is not set. This leads dvsim to fail on the specific config.

To align this file with Earl Grey, we hardcode the path here instead of setting a variable that must be constant.