### PR TITLE
[cryptotest] Remove duplicate ECDSA schema field

### DIFF
--- a/sw/host/cryptotest/testvectors/data/schemas/ecdsa_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/ecdsa_schema.json
@@ -59,10 +59,6 @@
         "description": "Qy",
         "type": "string"
       },
-      "d": {
-        "description": "Private value d",
-        "type": "string"
-      },
       "r": {
         "description": "r parameter",
         "type": "string"


### PR DESCRIPTION
This duplicate field was introduced at commit 73fc849dae1a82547d90476603077e2ef6521d57.