### PR TITLE
[rom] Remove key_{ecdsa,spx} and filegroup rules

### DIFF
--- a/rules/opentitan/keyutils.bzl
+++ b/rules/opentitan/keyutils.bzl
@@ -259,7 +259,7 @@ SILICON_CREATOR_KEYS = struct(
     REAL = None,
     UNAUTHORIZED = struct(
         SPX = [
-            create_key_("spx_unauthorized_0", "@//sw/device/silicon_creator/rom/keys/unauthorized/spx:unauthorized_0_spx", []),
+            create_key_("unauthorized_key_0", "@//sw/device/silicon_creator/rom/keys/unauthorized/spx:spx_keyset", []),
         ],
     ),
 )

--- a/sw/device/silicon_creator/rom/keys/unauthorized/ecdsa/BUILD
+++ b/sw/device/silicon_creator/rom/keys/unauthorized/ecdsa/BUILD
@@ -2,18 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules/opentitan:keyutils.bzl", "key_ecdsa")
 load("//rules:signing.bzl", "keyset")
 
 package(default_visibility = ["//visibility:public"])
-
-key_ecdsa(
-    name = "unauthorized_key_0_ecdsa_p256",
-    method = "local",
-    private_key = "unauthorized_key_0_ecdsa_p256.der",
-    pub_key = "unauthorized_key_0_ecdsa_p256.pub.der",
-    type = "TestKey",
-)
 
 keyset(
     name = "ecdsa_keyset",

--- a/sw/device/silicon_creator/rom/keys/unauthorized/spx/BUILD
+++ b/sw/device/silicon_creator/rom/keys/unauthorized/spx/BUILD
@@ -6,11 +6,6 @@ package(default_visibility = ["//visibility:public"])
 
 load("//rules:signing.bzl", "keyset")
 
-filegroup(
-    name = "unauthorized_0_spx",
-    srcs = ["unauthorized_0_spx.pem"],
-)
-
 keyset(
     name = "spx_keyset",
     build_setting_default = "",


### PR DESCRIPTION
- Remove `key_{ecdsa,spx} and filegroup rules for the "unauthorized" keys.
- Remove any references to the now-deleted rules.  Reference the "unauthorized" keyset instead.