### PR TITLE
[hw,keymgr_dpe,rtl] Restrict loads of new keys with a dedicated LOCK

### DIFF
--- a/hw/ip/keymgr_dpe/data/keymgr_dpe.hjson
+++ b/hw/ip/keymgr_dpe/data/keymgr_dpe.hjson
@@ -1131,5 +1131,26 @@ countermeasures: [
       ]
     },
 
+    { name: "LOAD_KEY_LOCK",
+      desc: "Register write lock for the LOAD_KEY command",
+      swaccess: "rw1s",
+      hwaccess: "hro",
+      fields: [
+        { bits: "0",
+          name: "LOCK",
+          resval: "0"
+          desc: '''
+            Load key register write lock.
+
+            Load key lock to 0, and its value cannot be altered by software until the next reset or locked.
+            Once locked, the LOAD_KEY command is disabled.
+          '''
+        },
+      ]
+      // Don't let automated CSR tests write random values to this register, as it could lock
+      // writing to other registers, which the automated tests are not aware of.
+      tags: ["excl:CsrAllTests:CsrExclWrite"]
+    },
+
   ],
 }

--- a/hw/ip/keymgr_dpe/doc/registers.md
+++ b/hw/ip/keymgr_dpe/doc/registers.md
@@ -58,6 +58,7 @@
 | keymgr_dpe.[`ERR_CODE`](#err_code)                                 | 0xc8     |        4 | Key manager error code.                                                    |
 | keymgr_dpe.[`FAULT_STATUS`](#fault_status)                         | 0xcc     |        4 | This register represents both synchronous and asynchronous fatal faults.   |
 | keymgr_dpe.[`DEBUG`](#debug)                                       | 0xd0     |        4 | The register holds some debug information that may be convenient if keymgr |
+| keymgr_dpe.[`LOAD_KEY_LOCK`](#load_key_lock)                       | 0xd4     |        4 | Register write lock for the LOAD_KEY command                               |
 
 ## INTR_STATE
 Interrupt State Register
@@ -689,6 +690,23 @@ misbehaves.
 |   2    |  rw0c  |   0x0   | INVALID_DEV_ID       | Device ID failed input checks during operation       |
 |   1    |  rw0c  |   0x0   | INVALID_OWNER_SEED   | Owner seed failed input checks during operation      |
 |   0    |  rw0c  |   0x0   | INVALID_CREATOR_SEED | Creator seed failed input checks during operation    |
+
+## LOAD_KEY_LOCK
+Register write lock for the LOAD_KEY command
+- Offset: `0xd4`
+- Reset default: `0x0`
+- Reset mask: `0x1`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "LOCK", "bits": 1, "attr": ["rw1s"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name   | Description                                                                                                                                                                  |
+|:------:|:------:|:-------:|:-------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|  31:1  |        |         |        | Reserved                                                                                                                                                                     |
+|   0    |  rw1s  |   0x0   | LOCK   | Load key register write lock. Load key lock to 0, and its value cannot be altered by software until the next reset or locked. Once locked, the LOAD_KEY command is disabled. |
 
 
 <!-- END CMDGEN -->

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe.sv
@@ -294,6 +294,7 @@ module keymgr_dpe
     .prng_en_o(ctrl_lfsr_en),
     .entropy_i(ctrl_rand),
     .op_i(keymgr_dpe_ops_e'(reg2hw.control_shadowed.operation.q)),
+    .load_key_lock_i(reg2hw.load_key_lock.q),
     // TODO(#384): Add assertions to check that we are not losing some bits by casting
     // slot_src/dst_sel bits to enum type
     .slot_src_sel_i(keymgr_dpe_slot_idx_e'(reg2hw.control_shadowed.slot_src_sel.q)),

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_ctrl.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_ctrl.sv
@@ -31,6 +31,7 @@ module keymgr_dpe_ctrl
   // Software interface
   input op_start_i,
   input keymgr_dpe_ops_e op_i,
+  input load_key_lock_i,
   input [DpeNumSlotsWidth-1:0] slot_src_sel_i,
   input [DpeNumSlotsWidth-1:0] slot_dst_sel_i,
   input keymgr_dpe_policy_t slot_policy_i,
@@ -676,7 +677,9 @@ module keymgr_dpe_ctrl
 
   assign invalid_gen = gen_req & (~active_key_slot_o.valid | ~key_version_vld_o);
 
-  assign invalid_load = load_req & (~root_key_i.valid | destination_slot_valid);
+  assign invalid_load = load_req & (~root_key_i.valid      |
+                                    destination_slot_valid |
+                                    load_key_lock_i);
 
   // This is similar to `invalid_advance` except that it does not depend on a incoming request.
   // The outer module uses `invalid_advance_o` to invalidate KMAC msg payload, when the advance

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_pkg.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_pkg.sv
@@ -18,7 +18,7 @@ package keymgr_dpe_reg_pkg;
   parameter int BlockAw = 8;
 
   // Number of registers for every interface
-  parameter int NumRegs = 53;
+  parameter int NumRegs = 54;
 
   // Alert indices
   typedef enum int {
@@ -171,6 +171,10 @@ package keymgr_dpe_reg_pkg;
       logic        q;
     } cmd;
   } keymgr_dpe_reg2hw_fault_status_reg_t;
+
+  typedef struct packed {
+    logic        q;
+  } keymgr_dpe_reg2hw_load_key_lock_reg_t;
 
   typedef struct packed {
     logic        d;
@@ -333,23 +337,24 @@ package keymgr_dpe_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    keymgr_dpe_reg2hw_intr_state_reg_t intr_state; // [638:638]
-    keymgr_dpe_reg2hw_intr_enable_reg_t intr_enable; // [637:637]
-    keymgr_dpe_reg2hw_intr_test_reg_t intr_test; // [636:635]
-    keymgr_dpe_reg2hw_alert_test_reg_t alert_test; // [634:631]
-    keymgr_dpe_reg2hw_start_reg_t start; // [630:630]
-    keymgr_dpe_reg2hw_control_shadowed_reg_t control_shadowed; // [629:618]
-    keymgr_dpe_reg2hw_sideload_clear_reg_t sideload_clear; // [617:615]
-    keymgr_dpe_reg2hw_reseed_interval_shadowed_reg_t reseed_interval_shadowed; // [614:599]
-    keymgr_dpe_reg2hw_slot_policy_regwen_reg_t slot_policy_regwen; // [598:597]
-    keymgr_dpe_reg2hw_slot_policy_reg_t slot_policy; // [596:594]
-    keymgr_dpe_reg2hw_sw_binding_regwen_reg_t sw_binding_regwen; // [593:592]
-    keymgr_dpe_reg2hw_sw_binding_mreg_t [7:0] sw_binding; // [591:336]
-    keymgr_dpe_reg2hw_salt_mreg_t [7:0] salt; // [335:80]
-    keymgr_dpe_reg2hw_key_version_mreg_t [0:0] key_version; // [79:48]
-    keymgr_dpe_reg2hw_max_key_ver_regwen_reg_t max_key_ver_regwen; // [47:46]
-    keymgr_dpe_reg2hw_max_key_ver_shadowed_reg_t max_key_ver_shadowed; // [45:14]
-    keymgr_dpe_reg2hw_fault_status_reg_t fault_status; // [13:0]
+    keymgr_dpe_reg2hw_intr_state_reg_t intr_state; // [639:639]
+    keymgr_dpe_reg2hw_intr_enable_reg_t intr_enable; // [638:638]
+    keymgr_dpe_reg2hw_intr_test_reg_t intr_test; // [637:636]
+    keymgr_dpe_reg2hw_alert_test_reg_t alert_test; // [635:632]
+    keymgr_dpe_reg2hw_start_reg_t start; // [631:631]
+    keymgr_dpe_reg2hw_control_shadowed_reg_t control_shadowed; // [630:619]
+    keymgr_dpe_reg2hw_sideload_clear_reg_t sideload_clear; // [618:616]
+    keymgr_dpe_reg2hw_reseed_interval_shadowed_reg_t reseed_interval_shadowed; // [615:600]
+    keymgr_dpe_reg2hw_slot_policy_regwen_reg_t slot_policy_regwen; // [599:598]
+    keymgr_dpe_reg2hw_slot_policy_reg_t slot_policy; // [597:595]
+    keymgr_dpe_reg2hw_sw_binding_regwen_reg_t sw_binding_regwen; // [594:593]
+    keymgr_dpe_reg2hw_sw_binding_mreg_t [7:0] sw_binding; // [592:337]
+    keymgr_dpe_reg2hw_salt_mreg_t [7:0] salt; // [336:81]
+    keymgr_dpe_reg2hw_key_version_mreg_t [0:0] key_version; // [80:49]
+    keymgr_dpe_reg2hw_max_key_ver_regwen_reg_t max_key_ver_regwen; // [48:47]
+    keymgr_dpe_reg2hw_max_key_ver_shadowed_reg_t max_key_ver_shadowed; // [46:15]
+    keymgr_dpe_reg2hw_fault_status_reg_t fault_status; // [14:1]
+    keymgr_dpe_reg2hw_load_key_lock_reg_t load_key_lock; // [0:0]
   } keymgr_dpe_reg2hw_t;
 
   // HW -> register type
@@ -423,6 +428,7 @@ package keymgr_dpe_reg_pkg;
   parameter logic [BlockAw-1:0] KEYMGR_DPE_ERR_CODE_OFFSET = 8'h c8;
   parameter logic [BlockAw-1:0] KEYMGR_DPE_FAULT_STATUS_OFFSET = 8'h cc;
   parameter logic [BlockAw-1:0] KEYMGR_DPE_DEBUG_OFFSET = 8'h d0;
+  parameter logic [BlockAw-1:0] KEYMGR_DPE_LOAD_KEY_LOCK_OFFSET = 8'h d4;
 
   // Reset values for hwext registers and their fields
   parameter logic [0:0] KEYMGR_DPE_INTR_TEST_RESVAL = 1'h 0;
@@ -493,11 +499,12 @@ package keymgr_dpe_reg_pkg;
     KEYMGR_DPE_OP_STATUS,
     KEYMGR_DPE_ERR_CODE,
     KEYMGR_DPE_FAULT_STATUS,
-    KEYMGR_DPE_DEBUG
+    KEYMGR_DPE_DEBUG,
+    KEYMGR_DPE_LOAD_KEY_LOCK
   } keymgr_dpe_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] KEYMGR_DPE_PERMIT [53] = '{
+  parameter logic [3:0] KEYMGR_DPE_PERMIT [54] = '{
     4'b 0001, // index[ 0] KEYMGR_DPE_INTR_STATE
     4'b 0001, // index[ 1] KEYMGR_DPE_INTR_ENABLE
     4'b 0001, // index[ 2] KEYMGR_DPE_INTR_TEST
@@ -550,7 +557,8 @@ package keymgr_dpe_reg_pkg;
     4'b 0001, // index[49] KEYMGR_DPE_OP_STATUS
     4'b 0001, // index[50] KEYMGR_DPE_ERR_CODE
     4'b 0011, // index[51] KEYMGR_DPE_FAULT_STATUS
-    4'b 0011  // index[52] KEYMGR_DPE_DEBUG
+    4'b 0011, // index[52] KEYMGR_DPE_DEBUG
+    4'b 0001  // index[53] KEYMGR_DPE_LOAD_KEY_LOCK
   };
 
 endpackage


### PR DESCRIPTION
To limit the point where new keys can be added, add a new LOCK register that gates the LOAD command.