### PR TITLE
[sw,signing] Enforce hash length for pre-hashed SHA256

### DIFF
--- a/sw/host/sphincsplus/key.rs
+++ b/sw/host/sphincsplus/key.rs
@@ -56,7 +56,10 @@ impl SpxDomain {
         match self {
             Self::None => message.into(),
             Self::Pure => [&[0u8, 0u8], message].concat().into(),
-            Self::PreHashedSha256 => [&Self::SHA256_DOMAIN, message].concat().into(),
+            Self::PreHashedSha256 => {
+                assert_eq!(message.len(), 32);
+                [&Self::SHA256_DOMAIN, message].concat().into()
+            }
         }
     }
 }


### PR DESCRIPTION
The SPHINCS+ key generation and signing functions expect a 32-byte message when the `PreHashedSha256` domain parameter is used. Enforce this length constraint with an assertion.