### PR TITLE
[sw,opentitantool] Add overlap check during image assembly

### DIFF
--- a/sw/host/opentitanlib/src/image/image.rs
+++ b/sw/host/opentitanlib/src/image/image.rs
@@ -662,6 +662,10 @@ impl ImageAssembler {
     fn read(path: &Path, buf: &mut [u8]) -> Result<usize> {
         let mut file = File::open(path)?;
         let len = file.metadata()?.len() as usize;
+        ensure!(len <= buf.len(), ImageError::IncompleteRead(len, buf.len()));
+        if buf[..len].iter().any(|&c| c != 0xff) {
+            bail!("{path:?} Overlapped during image assembly");
+        }
         let n = file.read(buf)?;
         ensure!(len == n, ImageError::IncompleteRead(len, n));
         Ok(n)


### PR DESCRIPTION
This change adds a new check to ensure that the image assembly process does not result in overlapping firmware being written into the same region to catch oversized firmware.