### PR TITLE
[crypto] Improve FI hardening of switch case statements

### DIFF
--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -338,28 +338,40 @@ static status_t csrng_send_app_cmd(uint32_t base_address,
   uint32_t reg;
   bool ready;
 
-  switch (cmd_type) {
+  entropy_csrng_send_app_cmd_type_t cmd_type_used = launder32(0);
+  switch (launder32(cmd_type)) {
     case kEntropyCsrngSendAppCmdTypeCsrng:
       cmd_reg_addr = base_address + CSRNG_CMD_REQ_REG_OFFSET;
       sts_reg_addr = base_address + CSRNG_SW_CMD_STS_REG_OFFSET;
       rdy_bit_offset = CSRNG_SW_CMD_STS_CMD_RDY_BIT;
       reg_rdy_bit_offset = CSRNG_SW_CMD_STS_CMD_RDY_BIT;
+      cmd_type_used =
+          launder32(cmd_type_used) | kEntropyCsrngSendAppCmdTypeCsrng;
       break;
     case kEntropyCsrngSendAppCmdTypeEdnSw:
       cmd_reg_addr = base_address + EDN_SW_CMD_REQ_REG_OFFSET;
       sts_reg_addr = base_address + EDN_SW_CMD_STS_REG_OFFSET;
       rdy_bit_offset = EDN_SW_CMD_STS_CMD_RDY_BIT;
       reg_rdy_bit_offset = EDN_SW_CMD_STS_CMD_REG_RDY_BIT;
+      cmd_type_used =
+          launder32(cmd_type_used) | kEntropyCsrngSendAppCmdTypeEdnSw;
       break;
     case kEntropyCsrngSendAppCmdTypeEdnGen:
       cmd_reg_addr = base_address + EDN_GENERATE_CMD_REG_OFFSET;
+      cmd_type_used =
+          launder32(cmd_type_used) | kEntropyCsrngSendAppCmdTypeEdnGen;
       break;
     case kEntropyCsrngSendAppCmdTypeEdnRes:
       cmd_reg_addr = base_address + EDN_RESEED_CMD_REG_OFFSET;
+      cmd_type_used =
+          launder32(cmd_type_used) | kEntropyCsrngSendAppCmdTypeEdnRes;
       break;
     default:
       return OTCRYPTO_BAD_ARGS;
   }
+  // Check if we landed in the correct case statement. Use ORs for this to
+  // avoid that multiple cases were executed.
+  HARDENED_CHECK_EQ(launder32(cmd_type_used), cmd_type);
 
   if ((cmd_type == kEntropyCsrngSendAppCmdTypeCsrng) ||
       (cmd_type == kEntropyCsrngSendAppCmdTypeEdnSw)) {

--- a/sw/device/lib/crypto/drivers/keymgr.c
+++ b/sw/device/lib/crypto/drivers/keymgr.c
@@ -101,14 +101,19 @@ static status_t keymgr_wait_until_done(void) {
   // statuses (e.g. WIP) should be possible.
   switch (status) {
     case KEYMGR_OP_STATUS_STATUS_VALUE_IDLE:
+      HARDENED_CHECK_EQ(launder32(status), KEYMGR_OP_STATUS_STATUS_VALUE_IDLE);
       return OTCRYPTO_OK;
     case KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS:
+      HARDENED_CHECK_EQ(launder32(status),
+                        KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
       return OTCRYPTO_OK;
     case KEYMGR_OP_STATUS_STATUS_VALUE_DONE_ERROR: {
       // Clear the ERR_CODE register before returning.
       uint32_t err_code =
           abs_mmio_read32(keymgr_base() + KEYMGR_ERR_CODE_REG_OFFSET);
       abs_mmio_write32(keymgr_base() + KEYMGR_ERR_CODE_REG_OFFSET, err_code);
+      HARDENED_CHECK_EQ(launder32(status),
+                        KEYMGR_OP_STATUS_STATUS_VALUE_DONE_ERROR);
       return OTCRYPTO_RECOV_ERR;
     }
   }

--- a/sw/device/lib/crypto/drivers/kmac.c
+++ b/sw/device/lib/crypto/drivers/kmac.c
@@ -167,25 +167,34 @@ static status_t kmac_get_keccak_rate_words(kmac_security_str_t security_str,
   // Since Keccak state is 1600 bits, rate is calculated with
   // rate = (1600 - 2*x) where x is the security strength (i.e. half the
   // capacity).
-  switch (security_str) {
+  kmac_security_str_t security_str_set = launder32(0);
+  switch (launder32(security_str)) {
     case kKmacSecurityStrength128:
       *keccak_rate = (1600 - 2 * 128) / 32;
+      security_str_set = launder32(security_str_set) | kKmacSecurityStrength128;
       break;
     case kKmacSecurityStrength224:
       *keccak_rate = (1600 - 2 * 224) / 32;
+      security_str_set = launder32(security_str_set) | kKmacSecurityStrength224;
       break;
     case kKmacSecurityStrength256:
       *keccak_rate = (1600 - 2 * 256) / 32;
+      security_str_set = launder32(security_str_set) | kKmacSecurityStrength256;
       break;
     case kKmacSecurityStrength384:
       *keccak_rate = (1600 - 2 * 384) / 32;
+      security_str_set = launder32(security_str_set) | kKmacSecurityStrength384;
       break;
     case kKmacSecurityStrength512:
       *keccak_rate = (1600 - 2 * 512) / 32;
+      security_str_set = launder32(security_str_set) | kKmacSecurityStrength512;
       break;
     default:
       return OTCRYPTO_BAD_ARGS;
   }
+  // Check if we landed in the correct case statement. Use ORs for this to
+  // avoid that multiple cases were executed.
+  HARDENED_CHECK_EQ(launder32(security_str_set), security_str);
   return OTCRYPTO_OK;
 }
 
@@ -201,25 +210,34 @@ static status_t kmac_get_keccak_rate_words(kmac_security_str_t security_str,
 OT_WARN_UNUSED_RESULT
 static status_t kmac_get_key_len_bytes(size_t key_len,
                                        kmac_key_len_t *key_len_enum) {
-  switch (key_len) {
+  size_t key_len_set = launder32(0);
+  switch (launder32(key_len)) {
     case 128 / 8:
       *key_len_enum = kKmacKeyLength128;
+      key_len_set = launder32(key_len_set) | (128 / 8);
       break;
     case 192 / 8:
       *key_len_enum = kKmacKeyLength192;
+      key_len_set = launder32(key_len_set) | (192 / 8);
       break;
     case 256 / 8:
       *key_len_enum = kKmacKeyLength256;
+      key_len_set = launder32(key_len_set) | (256 / 8);
       break;
     case 384 / 8:
       *key_len_enum = kKmacKeyLength384;
+      key_len_set = launder32(key_len_set) | (384 / 8);
       break;
     case 512 / 8:
       *key_len_enum = kKmacKeyLength512;
+      key_len_set = launder32(key_len_set) | (512 / 8);
       break;
     default:
       return OTCRYPTO_BAD_ARGS;
   }
+  // Check if we landed in the correct case statement. Use ORs for this to
+  // avoid that multiple cases were executed.
+  HARDENED_CHECK_EQ(launder32(key_len_set), key_len);
   return OTCRYPTO_OK;
 }
 

--- a/sw/device/lib/crypto/impl/hkdf.c
+++ b/sw/device/lib/crypto/impl/hkdf.c
@@ -25,22 +25,29 @@
 static status_t digest_num_words_from_key_mode(otcrypto_key_mode_t key_mode,
                                                size_t *digest_words) {
   *digest_words = 0;
+  size_t digest_words_set = launder32(0);
   switch (launder32(key_mode)) {
     case kOtcryptoKeyModeHmacSha256:
-      HARDENED_CHECK_EQ(key_mode, kOtcryptoKeyModeHmacSha256);
       *digest_words = 256 / 32;
+      digest_words_set =
+          launder32(digest_words_set) | kOtcryptoKeyModeHmacSha256;
       break;
     case kOtcryptoKeyModeHmacSha384:
-      HARDENED_CHECK_EQ(key_mode, kOtcryptoKeyModeHmacSha384);
       *digest_words = 384 / 32;
+      digest_words_set =
+          launder32(digest_words_set) | kOtcryptoKeyModeHmacSha384;
       break;
     case kOtcryptoKeyModeHmacSha512:
-      HARDENED_CHECK_EQ(key_mode, kOtcryptoKeyModeHmacSha512);
       *digest_words = 512 / 32;
+      digest_words_set =
+          launder32(digest_words_set) | kOtcryptoKeyModeHmacSha512;
       break;
     default:
       return OTCRYPTO_BAD_ARGS;
   }
+  // Check if we landed in the correct case statement. Use ORs for this to
+  // avoid that multiple cases were executed.
+  HARDENED_CHECK_EQ(launder32(digest_words_set), key_mode);
   HARDENED_CHECK_NE(*digest_words, 0);
   return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/impl/kdf_ctr.c
+++ b/sw/device/lib/crypto/impl/kdf_ctr.c
@@ -39,22 +39,27 @@ static status_t check_zero_byte(const otcrypto_const_byte_buf_t buffer) {
 static status_t digest_num_words_from_key_mode(otcrypto_key_mode_t key_mode,
                                                size_t *digest_words) {
   *digest_words = 0;
+  otcrypto_key_mode_t key_mode_used = launder32(0);
   switch (launder32(key_mode)) {
     case kOtcryptoKeyModeHmacSha256:
-      HARDENED_CHECK_EQ(key_mode, kOtcryptoKeyModeHmacSha256);
       *digest_words = 256 / 32;
+      key_mode_used = launder32(key_mode_used) | kOtcryptoKeyModeHmacSha256;
       break;
     case kOtcryptoKeyModeHmacSha384:
-      HARDENED_CHECK_EQ(key_mode, kOtcryptoKeyModeHmacSha384);
       *digest_words = 384 / 32;
+      key_mode_used = launder32(key_mode_used) | kOtcryptoKeyModeHmacSha384;
       break;
     case kOtcryptoKeyModeHmacSha512:
-      HARDENED_CHECK_EQ(key_mode, kOtcryptoKeyModeHmacSha512);
       *digest_words = 512 / 32;
+      key_mode_used = launder32(key_mode_used) | kOtcryptoKeyModeHmacSha512;
       break;
     default:
       return OTCRYPTO_BAD_ARGS;
   }
+  // Check if we landed in the correct case statement. Use ORs for this to
+  // avoid that multiple cases were executed.
+  HARDENED_CHECK_EQ(launder32(key_mode_used), key_mode);
+
   HARDENED_CHECK_NE(*digest_words, 0);
   return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/impl/keyblob.c
+++ b/sw/device/lib/crypto/impl/keyblob.c
@@ -159,21 +159,22 @@ status_t keyblob_ensure_xor_masked(const otcrypto_key_config_t config) {
   otcrypto_key_type_t key_type =
       (otcrypto_key_type_t)(launder32((uint32_t)config.key_mode) >> 16);
   int32_t result = (int32_t)launder32((uint32_t)(OTCRYPTO_OK.value ^ key_type));
+  otcrypto_key_type_t key_type_used = launder32(0);
   switch (launder32(key_type)) {
     case kOtcryptoKeyTypeAes:
-      HARDENED_CHECK_EQ(config.key_mode >> 16, kOtcryptoKeyTypeAes);
+      key_type_used = launder32(key_type_used) | kOtcryptoKeyTypeAes;
       result ^= launder32(kOtcryptoKeyTypeAes);
       break;
     case kOtcryptoKeyTypeHmac:
-      HARDENED_CHECK_EQ(config.key_mode >> 16, kOtcryptoKeyTypeHmac);
+      key_type_used = launder32(key_type_used) | kOtcryptoKeyTypeHmac;
       result ^= launder32(kOtcryptoKeyTypeHmac);
       break;
     case kOtcryptoKeyTypeKmac:
-      HARDENED_CHECK_EQ(config.key_mode >> 16, kOtcryptoKeyTypeKmac);
+      key_type_used = launder32(key_type_used) | kOtcryptoKeyTypeKmac;
       result ^= launder32(kOtcryptoKeyTypeKmac);
       break;
     case kOtcryptoKeyTypeKdf:
-      HARDENED_CHECK_EQ(config.key_mode >> 16, kOtcryptoKeyTypeKdf);
+      key_type_used = launder32(key_type_used) | kOtcryptoKeyTypeKdf;
       result ^= launder32(kOtcryptoKeyTypeKdf);
       break;
     case kOtcryptoKeyTypeEcc:
@@ -186,6 +187,10 @@ status_t keyblob_ensure_xor_masked(const otcrypto_key_config_t config) {
       // Unrecognized key type.
       return OTCRYPTO_BAD_ARGS;
   }
+  // Check if we landed in the correct case statement. Use ORs for this to
+  // avoid that multiple cases were executed.
+  HARDENED_CHECK_EQ(launder32(key_type_used), key_type);
+
   HARDENED_CHECK_NE(config.key_mode >> 16, kOtcryptoKeyTypeEcc);
   HARDENED_CHECK_NE(config.key_mode >> 16, kOtcryptoKeyTypeRsa);
 


### PR DESCRIPTION
This PR improves the FI hardening of switch case statements. In each case, the case condition is ORed into a common variable. After the switch case statement, check if this common variable is equal to the expected condition value. By using ORs, we can make sure that only a single case statement was executed.

More details, including the assembly instructions of the improved switch case statements,  can be found in lowRISC/opentitan#28203.