### PR TITLE
[tlul_assert,dv] Include uvm_macros.svh to use uvm_fatal

### DIFF
--- a/hw/ip/tlul/rtl/tlul_assert.sv
+++ b/hw/ip/tlul/rtl/tlul_assert.sv
@@ -23,6 +23,7 @@ module tlul_assert #(
 
 `ifdef UVM
   import uvm_pkg::*;
+  `include "uvm_macros.svh"
 `endif
   import tlul_pkg::*;
   import top_pkg::*;


### PR DESCRIPTION
tlul_assert uses `uvm_fatal` later on but misses to include  `uvm_macros.svh` 