### PR TITLE
[p256] Harden bn.sel and rshi

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/p256.c
+++ b/sw/device/lib/crypto/impl/ecc/p256.c
@@ -81,12 +81,12 @@ enum {
   /*
    * The expected instruction counts for constant time functions.
    */
-  kModeKeygenInsCnt = 567175,
-  kModeKeygenSideloadInsCnt = 567060,
-  kModeEcdhInsCnt = 574858,
-  kModeEcdhSideloadInsCnt = 574918,
-  kModeEcdsaSignInsCnt = 600349,
-  kModeEcdsaSignSideloadInsCnt = 600409,
+  kModeKeygenInsCnt = 574237,
+  kModeKeygenSideloadInsCnt = 574122,
+  kModeEcdhInsCnt = 581920,
+  kModeEcdhSideloadInsCnt = 581980,
+  kModeEcdsaSignInsCnt = 607411,
+  kModeEcdsaSignSideloadInsCnt = 607471,
 };
 
 static status_t p256_masked_scalar_write(const p256_masked_scalar_t *src,


### PR DESCRIPTION
Harden the OTBN code for p256 against side-channel analysis.
- Remove the second load of shifting w7 (was not needed)
- Shift the second share of the scalar with randomness instead of with zeros
- Perform bn.sel without unmasking the scalar

Note that in p256.c you can view the instruction count difference.