### PR TITLE
[sw,cov] Enable hmac HW workaround under coverage mode

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -205,6 +205,7 @@ dual_cc_library(
             "@googletest//:gtest",
         ],
         shared = [
+            ":ibex",
             "//sw/device/lib/base:abs_mmio",
             "//sw/device/lib/base:bitfield",
             "//sw/device/lib/base:hardened",


### PR DESCRIPTION
The HMAC hardware on Earl Grey 1.0.0 has a known issue that requires a software workaround in coverage mode due to increased latency.

This change ports the necessary workaround from sw/device/lib/crypto/drivers/hmac.c into the silicon_creator driver library.