### PR TITLE
[scrambling] Allow the scrambling script to handle SecDisableScrambling

### DIFF
--- a/hw/ip/rom_ctrl/util/scramble_image.py
+++ b/hw/ip/rom_ctrl/util/scramble_image.py
@@ -438,14 +438,15 @@ class Scrambler:
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument('hjson')
+    parser.add_argument('top_hjson')
+    parser.add_argument('secrets_hjson')
     parser.add_argument('mode')
     parser.add_argument('infile', type=argparse.FileType('rb'))
     parser.add_argument('outfile', type=argparse.FileType('w'))
     parser.add_argument('hashfile', type=argparse.FileType('w'))
 
     args = parser.parse_args()
-    scrambler = Scrambler.from_hjson_path(args.hjson, args.mode, args.hashfile)
+    scrambler = Scrambler.from_hjson_path(args.secrets_hjson, args.mode, args.hashfile)
 
     # Load the input ELF file
     clr_mem = MemFile.load_elf32(args.infile, scrambler.rom_base)

--- a/hw/ip/rom_ctrl/util/scramble_image.py
+++ b/hw/ip/rom_ctrl/util/scramble_image.py
@@ -31,9 +31,11 @@ class MemoryController:
     PARAM_VALUE = "__value"
 
     def __init__(
-            self, mem_ctrl: _UDict, ctrl_name: str, memory_type: str, mode: str):
+            self, top_mem_ctrl: _UDict, secrets_mem_ctrl: _UDict, ctrl_name: str,
+            memory_type: str, mode: str):
         '''A memory controller constructor
-        @mem_ctrl The memory controller hjson dictionary.
+        @mem_ctrl The memory controller hjson dictionary (in the top configuration)
+        @mem_ctrl The memory controller hjson dictionary (in the secrets file)
         @ctrl_name is the memory controller IP block name (e.g. 'rom_ctrl0' for the base ROM)
         @memory_type is the memory type this memory controller run ('rom' or 'ram')
         @mode is the memory scrambling mode
@@ -49,11 +51,14 @@ class MemoryController:
         assert key_name is not None
         assert nonce_name is not None
 
-        size_words = MemoryController._get_size_words(mem_ctrl, memory_type)
-        base = MemoryController._get_base(mem_ctrl, memory_type)
-        params = MemoryController._get_params(mem_ctrl)
+        size_words = MemoryController._get_size_words(secrets_mem_ctrl, memory_type)
+        base = MemoryController._get_base(secrets_mem_ctrl, memory_type)
+        # Merge parameters of the top configuration and secrets. The secrets take precedence
+        params = MemoryController._get_params(top_mem_ctrl) | \
+            MemoryController._get_params(secrets_mem_ctrl)
         nonce, nonce_width = MemoryController._get_param_cnst(params, nonce_name)
         scr_key, scr_key_width = MemoryController._get_param_cnst(params, key_name)
+        scrambling_disabled = MemoryController._get_param_bit(params, "SecDisableScrambling")
 
         self.ctrl_name = ctrl_name
         self.memory_type = memory_type
@@ -63,6 +68,7 @@ class MemoryController:
         self.scr_key_width = scr_key_width
         self.nonce = nonce
         self.nonce_width = nonce_width
+        self.scrambling_disabled = scrambling_disabled
 
     @staticmethod
     def _get_params(module: _UDict) -> Dict[str, _UDict]:
@@ -109,6 +115,23 @@ class MemoryController:
         return val, width
 
     @staticmethod
+    def _get_param_bit(params: Dict[str, _UDict], name: str) -> bool:
+        param = params.get(name)
+        assert isinstance(param, dict)
+
+        assert param.get('type') == 'bit'
+        val = param.get(MemoryController.PARAM_VALUE)
+        assert isinstance(val, str)
+        assert 'b' in val, f"invalid bit value for parameter {name}"
+        val_width, val = val.split("'b")
+        assert int(val_width) == 1, f"parameter {name} has value unexpected width {val_width}"
+
+        val = int(val, 0)
+        assert 0 <= val <= 1, f"invalid bit value for parameter {name}"
+
+        return bool(val)
+
+    @staticmethod
     def _get_size_words(module: _UDict, memory_type: str) -> int:
         memory = module.get("memory")
         assert isinstance(memory, dict)
@@ -131,33 +154,53 @@ class MemoryController:
         return int(base_addr, 16)
 
     @staticmethod
-    def from_hjson_path(path: str, mode: str) -> Optional["MemoryController"]:
-        with open(path, "r", encoding='utf-8') as handle:
+    def from_hjson_path(top_cfg_path: str, secrets_path: str, mode: str) \
+            -> Optional["MemoryController"]:
+        with open(secrets_path, "r", encoding='utf-8') as handle:
+            secrets = hjson.load(handle, use_decimal=True)
+        with open(top_cfg_path, "r", encoding='utf-8') as handle:
             top = hjson.load(handle, use_decimal=True)
 
+        assert isinstance(secrets, dict)
         assert isinstance(top, dict)
-        modules = top.get('module')
-        assert isinstance(modules, list)
+        top_modules = top.get('module')
+        secrets_modules = secrets.get('module')
+        assert isinstance(top_modules, list)
+        assert isinstance(secrets_modules, list)
 
-        for entry in modules:
+        for entry in secrets_modules:
             assert isinstance(entry, dict)
             entry_type = entry.get('type')
             assert isinstance(entry_type, str)
             entry_name = entry.get('name')
             assert isinstance(entry_name, str)
 
+            # Find the corresponding entry in the top cfg.
+            found = False
+            for top_entry in top_modules:
+                assert isinstance(top_entry, dict)
+                top_entry_type = top_entry.get('type')
+                assert isinstance(top_entry_type, str)
+                top_entry_name = top_entry.get('name')
+                assert isinstance(top_entry_name, str)
+                if top_entry_type == entry_type and top_entry_name == entry_name:
+                    found = True
+                    break
+            assert found, "secrets file contain entry for module '{entry_name}'," + \
+                " but it does not exist in the top configuration"
+
             if mode == ScramblingMode.ROM0.value:
                 # Earlgrey has only one ROM, named `rom_ctrl`, while Darjeeling's
                 # first ROM is named `rom_ctrl0`
                 if entry_name in ("rom_ctrl", "rom_ctrl0"):
                     if entry_type == "rom_ctrl":
-                        return MemoryController(entry, entry_name, entry_type, mode)
+                        return MemoryController(top_entry, entry, entry_name, entry_type, mode)
             elif mode == ScramblingMode.ROM1.value:
                 if entry_name == "rom_ctrl1" and entry_type == "rom_ctrl":
-                    return MemoryController(entry, entry_name, entry_type, mode)
+                    return MemoryController(top_entry, entry, entry_name, entry_type, mode)
             elif mode == ScramblingMode.SRAM.value:
                 if entry_name == "sram_ctrl_main" and entry_type == "sram_ctrl":
-                    return MemoryController(entry, entry_name, entry_type, mode)
+                    return MemoryController(top_entry, entry, entry_name, entry_type, mode)
 
         return None
 
@@ -251,7 +294,7 @@ class Scrambler:
     subst_perm_rounds = 2
     num_rounds_half = 3
 
-    def __init__(self, nonce: int, nonce_width: int,
+    def __init__(self, disable: bool, nonce: int, nonce_width: int,
                  key: int, key_width: int,
                  rom_base: int, rom_size_words: int,
                  hash_file: IO[str]):
@@ -261,6 +304,7 @@ class Scrambler:
         assert 0 <= key < (1 << key_width)
         assert 0 < rom_size_words < (1 << 64)
 
+        self.disable = disable
         self.nonce = nonce
         self.nonce_width = nonce_width
         self.key = key
@@ -273,12 +317,16 @@ class Scrambler:
 
         self._addr_width = (rom_size_words - 1).bit_length()
 
+    def is_disabled(self) -> bool:
+        return self.disable
+
     @staticmethod
-    def from_hjson_path(path: str, mode: str, hash_file: IO[str]) -> 'Scrambler':
-        mem_ctrl = MemoryController.from_hjson_path(path, mode)
+    def from_hjson_path(top_cfg_path: str, secrets_path: str, mode: str, hash_file: IO[str]) \
+            -> 'Scrambler':
+        mem_ctrl = MemoryController.from_hjson_path(top_cfg_path, secrets_path, mode)
         assert mem_ctrl is not None
 
-        return Scrambler(mem_ctrl.nonce, mem_ctrl.nonce_width,
+        return Scrambler(mem_ctrl.scrambling_disabled, mem_ctrl.nonce, mem_ctrl.nonce_width,
                          mem_ctrl.scr_key, mem_ctrl.scr_key_width,
                          mem_ctrl.base, mem_ctrl.size_words, hash_file)
 
@@ -462,7 +510,8 @@ def main() -> int:
     parser.add_argument('hashfile', type=argparse.FileType('w'))
 
     args = parser.parse_args()
-    scrambler = Scrambler.from_hjson_path(args.secrets_hjson, args.mode, args.hashfile)
+    scrambler = Scrambler.from_hjson_path(args.top_hjson, args.secrets_hjson,
+                                          args.mode, args.hashfile)
 
     # Load the input ELF file
     clr_mem = MemFile.load_elf32(args.infile, scrambler.rom_base)
@@ -470,6 +519,13 @@ def main() -> int:
     # Flatten the file, padding with pseudo-random data and ensuring it's
     # exactly scrambler.rom_size_words words long.
     clr_flat = scrambler.flatten(clr_mem)
+
+    # If scrambling is disabled then the memory width is 32 bits, ie no ECC
+    # and the data is not scrambled. There is also no hash added.
+    if scrambler.is_disabled():
+        print("scrambling disabled")
+        clr_flat.write_vmem(args.outfile)
+        return 0
 
     # Extend from 32 bits to 39 by adding Hsiao (39,32) ECC bits.
     clr_flat.add_ecc32()

--- a/hw/top/BUILD
+++ b/hw/top/BUILD
@@ -67,6 +67,11 @@ string_flag(
     for seed in ALL_SEED_NAMES
 ]
 
+opentitan_alias_top_attr(
+    name = "top_gen_hjson",
+    attr_name = "hjson",
+)
+
 # Point to the right top library.
 opentitan_alias_top_attr(
     name = "top_lib",

--- a/rules/autogen.bzl
+++ b/rules/autogen.bzl
@@ -10,7 +10,6 @@ load(
     "opentitan_require_ip_attr",
     "opentitan_require_top_attr",
     "opentitan_select_ip_attr",
-    "opentitan_select_top_attr",
 )
 
 """Autogeneration rules for OpenTitan.
@@ -343,7 +342,7 @@ def opentitan_top_dt_gen(name, gen_ips = [], gen_top = False, output_groups = {}
             for ip in gen_ips
         ]),
         output_groups = output_groups,
-        top_hjson = opentitan_select_top_attr("hjson"),
+        top_hjson = "//hw/top:top_gen_hjson",
         target_compatible_with = target_compatible_with + opentitan_require_top_attr("hjson") + flatten([
             opentitan_require_ip_attr(ip, "hjson")
             for ip in gen_ips
@@ -495,7 +494,7 @@ def opentitan_autogen_isr_testutils(name, ips = [], deps = [], target_compatible
             opentitan_select_ip_attr(ip, "hjson", required = False, default = [], fn = lambda x: [x])
             for ip in ips
         ]),
-        top_hjson = opentitan_select_top_attr("hjson"),
+        top_hjson = "//hw/top:top_gen_hjson",
         output_groups = {
             "hdr": ["isr_testutils.h"],
             "src": ["isr_testutils.c"],

--- a/rules/opentitan/exec_env.bzl
+++ b/rules/opentitan/exec_env.bzl
@@ -28,6 +28,7 @@ _FIELDS = {
     "data": ("attr.data", False),
     "extract_sw_logs": ("attr.extract_sw_logs", False),
     "otp_mmap": ("file.otp_mmap", False),
+    "top_gen_hjson": ("file.top_gen_hjson", False),
     "top_secret_cfg": ("file.top_secret_cfg", False),
     "otp_data_perm": ("attr.otp_data_perm", False),
     "flash_scramble_tool": ("attr.flash_scramble_tool", False),
@@ -191,6 +192,11 @@ def exec_env_common_attrs(**kwargs):
             allow_single_file = True,
             default = kwargs.get("otp_mmap"),
             doc = "OTP memory map configuration HJSON file.",
+        ),
+        "top_gen_hjson": attr.label(
+            allow_single_file = True,
+            default = "//hw/top:top_gen_hjson",
+            doc = "Generated top configuration file of the top.",
         ),
         "top_secret_cfg": attr.label(
             allow_single_file = True,

--- a/rules/opentitan/fpga.bzl
+++ b/rules/opentitan/fpga.bzl
@@ -69,6 +69,7 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
             src = elf,
             suffix = "39.scr.vmem",
             rom_scramble_tool = ctx.executable.rom_scramble_tool,
+            top_gen_hjson = exec_env.top_gen_hjson,
             top_secret_cfg = exec_env.top_secret_cfg,
         )
 

--- a/rules/opentitan/silicon.bzl
+++ b/rules/opentitan/silicon.bzl
@@ -58,6 +58,7 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
             src = elf,
             suffix = "39.scr.vmem",
             rom_scramble_tool = ctx.executable.rom_scramble_tool,
+            top_gen_hjson = exec_env.top_gen_hjson,
             top_secret_cfg = exec_env.top_secret_cfg,
         )
         default = rom

--- a/rules/opentitan/sim_dv.bzl
+++ b/rules/opentitan/sim_dv.bzl
@@ -52,6 +52,7 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
             src = elf,
             suffix = "39.scr.vmem",
             rom_scramble_tool = ctx.executable.rom_scramble_tool,
+            top_gen_hjson = exec_env.top_gen_hjson,
             top_secret_cfg = exec_env.top_secret_cfg,
         )
 

--- a/rules/opentitan/sim_verilator.bzl
+++ b/rules/opentitan/sim_verilator.bzl
@@ -49,6 +49,7 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
             src = elf,
             suffix = "39.scr.vmem",
             rom_scramble_tool = ctx.executable.rom_scramble_tool,
+            top_gen_hjson = exec_env.top_gen_hjson,
             top_secret_cfg = exec_env.top_secret_cfg,
         )
 

--- a/rules/opentitan/transform.bzl
+++ b/rules/opentitan/transform.bzl
@@ -280,15 +280,17 @@ def convert_to_scrambled_rom_vmem(ctx, **kwargs):
 
     src = get_override(ctx, "attr.src", kwargs)
 
-    config = get_override(ctx, "file.top_secret_cfg", kwargs)
+    top_config = get_override(ctx, "file.top_gen_hjson", kwargs)
+    secrets = get_override(ctx, "file.top_secret_cfg", kwargs)
     tool = get_override(ctx, "executable.rom_scramble_tool", kwargs)
     mode = get_override(ctx, "attr.rom_scramble_mode", kwargs)
 
     ctx.actions.run(
         outputs = [output, hashfile],
-        inputs = [src, tool, config],
+        inputs = [src, tool, top_config, secrets],
         arguments = [
-            config.path,
+            top_config.path,
+            secrets.path,
             mode,
             src.path,
             output.path,


### PR DESCRIPTION
This PR replaces #28231 and does a few things:
- it adds the top hjson to the exec_env
- it then uses that to pass the hjson to the ROM scrambling script
- it fixes the scrambling script to correctly read parameters from the files
- finally it lets the scrambling script handle the case where scrambling is disabled (only english breakfast uses that at the moment).