### PR TITLE
[dv] Tidy-ups in dv_base_env_cfg

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -15,6 +15,14 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
   // True if the scoreboard should check that pings on the alert interface get timely responses.
   bit en_scb_ping_chk = 1;
 
+  // A flag that the cip_base_vseq sets before it triggers a reset in the stress_all_with_rand_reset
+  // test. Once this is set, it causes the stop_transaction_generators() function to return true,
+  // which causes some environments to pause their sequences to leave a "quiet gap".
+  //
+  // The flag is set by calling the set_intention_to_reset() function and can be seen by calling
+  // stop_transaction_generators.
+  local bit will_reset  = 0;
+
   // If this flag is set then we allow the stress_all_with_rand_reset task to apply a reset without
   // waiting for CSR accesses to complete. This will only work if the IP block's vseqs
   //
@@ -266,4 +274,27 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
 
   endfunction
 
- endclass
+  // This can be used to stop transaction generators either upon reset or in preparation to issue a
+  // random reset.
+  function bit stop_transaction_generators();
+    return this.will_reset || this.under_reset;
+  endfunction
+
+  // This can be used to announce the intention to generate a random reset soon, to allow
+  // transaction generators to stop, and fire a reset with no outstanding transactions.
+  virtual function void set_intention_to_reset();
+    `uvm_info(`gfn, "Setting intention to reset", UVM_MEDIUM)
+    this.will_reset = 1'b1;
+  endfunction
+
+  // This dv_base_env_cfg function is called by dv_base_scoreboard::monitor_reset when it sees a
+  // reset on the main clk_rst_if.
+  //
+  // The override here clears the will_reset flag (since we have now seen the reset we were waiting
+  // for).
+  function void reset_asserted();
+    super.reset_asserted();
+    this.will_reset = 0;
+  endfunction
+
+endclass

--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -8,6 +8,10 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
   bit en_tl_err_cov      = 1;
   bit en_tl_intg_err_cov = 1;
 
+  // True if the scoreboard should check TL transactions for integrity. A transaction that fails its
+  // integrity check is expected to be ignored (although it may cause an alert).
+  bit en_scb_tl_err_chk = 1;
+
   // If this flag is set then we allow the stress_all_with_rand_reset task to apply a reset without
   // waiting for CSR accesses to complete. This will only work if the IP block's vseqs
   //

--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -12,6 +12,9 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
   // integrity check is expected to be ignored (although it may cause an alert).
   bit en_scb_tl_err_chk = 1;
 
+  // True if the scoreboard should check that pings on the alert interface get timely responses.
+  bit en_scb_ping_chk = 1;
+
   // If this flag is set then we allow the stress_all_with_rand_reset task to apply a reset without
   // waiting for CSR accesses to complete. This will only work if the IP block's vseqs
   //

--- a/hw/dv/sv/cip_lib/cip_base_test.sv
+++ b/hw/dv/sv/cip_lib/cip_base_test.sv
@@ -22,6 +22,11 @@ class cip_base_test #(type CFG_T = cip_base_env_cfg,
     end
   endfunction
 
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    void'($value$plusargs("en_scb_tl_err_chk=%0b", cfg.en_scb_tl_err_chk));
+  endfunction
+
   virtual task run_phase(uvm_phase phase);
     // Disable random delays in specific `prim_cdc_rand_delay`s even if CDC instrumentation is
     // enabled.  (See `cip_base_env_cfg` for details.)

--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -14,11 +14,6 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
   bit under_reset       = 0;
   bit is_initialized;        // Indicates that the initialize() method has been called.
 
-  // JTAG DMI knob
-  // this has to be set test.build
-  // before cfg.initialize
-  bit use_jtag_dmi = 0;
-
   // The scope and runtime of a existing test can be reduced by setting this variable. This is
   // useful to keep the runtime down especially in time-sensitive runs such as CI, which is meant
   // to check the code health and not find design bugs. It is set via plusarg and retrieved in

--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -2,17 +2,37 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// A base environment configuration that is used for all OpenTitan environments.
+
 class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
 
-  bit is_active         = 1;
-  bit en_scb            = 1; // can be changed at run-time
-  bit en_scb_mem_chk    = 1;
+  // True if the environment is active (and thus drives sequences items to the dut). This is the
+  // default.
+  bit is_active = 1;
 
-  bit en_cov            = 0; // Enable via plusarg, only if coverage collection is turned on.
-  bit en_dv_cdc         = 0; // Enable via plusarg.
+  // True if the scoreboard should be enabled. If it is false, the scoreboard still runs, but should
+  // ignore its checks.
+  bit en_scb = 1;
 
-  bit under_reset       = 0;
-  bit is_initialized;        // Indicates that the initialize() method has been called.
+  // True if the scoreboard should check memory read transactions and predict memory updates from
+  // write transactions.
+  bit en_scb_mem_chk = 1;
+
+  // Enable functional coverage collection. This causes monitors and scoreboards to collect coverage
+  // (through a dv_base_env_cov object).
+  bit en_cov = 0;
+
+  // Enable CDC instrumentation
+  bit en_dv_cdc = 0;
+
+  // A bit that is true if the environment is currently under reset. This should controlled by
+  // calling the reset_asserted and reset_deasserted functions. By default,
+  // dv_base_scoreboard::monitor_reset maintains this value.
+  bit under_reset = 0;
+
+  // A flag to show that the initialize method has been called. This is protected (rather than
+  // local) to allow specialised environments set it to avoid the initialize method being called.
+  protected bit is_initialized = 0;
 
   // The scope and runtime of a existing test can be reduced by setting this variable. This is
   // useful to keep the runtime down especially in time-sensitive runs such as CI, which is meant
@@ -20,162 +40,221 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
   // `dv_base_test`.
   bit smoke_test = 0;
 
-  // bit to configure all uvcs with zero delays to create high bw test
+  // If this is true, all UVCs should run with zero delays, which creates a high bandwidth test.
   rand bit zero_delays;
 
-  // set zero_delays 40% of the time
-  constraint zero_delays_c {
-    zero_delays dist {1'b0 := 6, 1'b1 := 4};
-  }
-
-  // reg model & q of valid csr addresses
-  RAL_T             ral;
-  dv_base_reg_block ral_models[string];
-
-  // A queue of the names of RAL models that should be created in the `initialize` function
-  // Related agents, adapters will be created in env as well as connecting them with scb
-  // For example, if the IP has an additional RAL model named `ral1`, add it into the list as below
-  //   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
-  //     ral_model_names.push_back("ral1");
-  //     super.initialize(csr_base_addr);
+  // A queue of the names of RAL models that should be created in the `initialize` function. Related
+  // agents and adapters will be created in the environment as well as connecting them with the
+  // scoreboard.
+  //
+  // To add another RAL model, a subclass of dv_base_env_cfg should implement initialize and add its
+  // name before calling super.initialize.
+  //
+  // The collection of RAL model names is used as an index in ral_models, clk_rst_vifs and
+  // clk_freqs_mhz.
   string ral_model_names[$] = {RAL_T::type_name};
 
-  // clk_rst_if & freq
-  // clk_rst_vif and clk_freq_mhz are used for default clk/rst. If more than one RAL, the other
-  // clk_rst_vif and clk_freq_mhz can be found from the associative arrays
-  virtual clk_rst_if  clk_rst_vif;
-  virtual clk_rst_if  clk_rst_vifs[string];
-  rand uint clk_freq_mhz;
+  // A RAL model for each name in ral_model_names.
+  dv_base_reg_block ral_models[string];
+
+  // A clock and reset interface for each name in ral_model_names. An item is the clock and reset
+  // that should be used for the associated TL interface.
+  virtual clk_rst_if clk_rst_vifs[string];
+
+  // Clock frequencies for the TL interfaces indexed by ral_model_names.
   rand uint clk_freqs_mhz[string];
 
-  constraint clk_freq_mhz_c {
-    `DV_COMMON_CLK_CONSTRAINT(clk_freq_mhz)
-    foreach (clk_freqs_mhz[i]) {
-      `DV_COMMON_CLK_CONSTRAINT(clk_freqs_mhz[i])
-    }
-  }
+  // The "default" RAL's register model. This corresponds to RAL_T::type_name as a model name, and
+  // the variable is of type RAL_T (a more specialised class) to simplify access.
+  RAL_T ral;
+
+  // The interface for the clock and reset assoicated with the default RAL.
+  virtual clk_rst_if clk_rst_vif;
+
+  // The frequency of the clock and reset assoicated with the default RAL.
+  rand uint clk_freq_mhz;
+
+  // Set zero_delays 40% of the time
+  extern constraint zero_delays_c;
+
+  // Constrain frequencies of the various clocks.
+  extern constraint clk_freq_mhz_c;
 
   `uvm_object_param_utils_begin(dv_base_env_cfg #(RAL_T))
-    `uvm_field_int   (is_active,   UVM_DEFAULT)
-    `uvm_field_int   (en_scb,      UVM_DEFAULT)
-    `uvm_field_int   (en_cov,      UVM_DEFAULT)
-    `uvm_field_int   (zero_delays, UVM_DEFAULT)
+    `uvm_field_int              (is_active,       UVM_DEFAULT)
+    `uvm_field_int              (en_scb,          UVM_DEFAULT)
+    `uvm_field_int              (en_scb_mem_chk,  UVM_DEFAULT)
+    `uvm_field_int              (en_cov,          UVM_DEFAULT)
+    `uvm_field_int              (en_dv_cdc,       UVM_DEFAULT)
+    `uvm_field_int              (smoke_test,      UVM_DEFAULT)
+    `uvm_field_int              (zero_delays,     UVM_DEFAULT)
+    `uvm_field_queue_string     (ral_model_names, UVM_DEFAULT)
+    `uvm_field_aa_object_string (ral_models,      UVM_DEFAULT)
+    `uvm_field_aa_int_string    (clk_freqs_mhz,   UVM_DEFAULT)
   `uvm_object_utils_end
 
-  `uvm_object_new
+  extern function new (string name="");
 
-  function void pre_randomize();
-    `DV_CHECK_FATAL(is_initialized, "Please invoke initialize() before randomizing this object.")
-  endfunction
+  extern function void pre_randomize();
+  extern function void post_randomize();
 
-  function void post_randomize();
-    if (clk_freqs_mhz.size > 0) begin
-      `DV_CHECK_FATAL(clk_freqs_mhz.exists(RAL_T::type_name))
-      clk_freqs_mhz[RAL_T::type_name] = clk_freq_mhz;
-    end
-  endfunction
-
-  virtual function void initialize(bit [bus_params_pkg::BUS_AW-1:0] csr_base_addr = '1);
-    is_initialized = 1'b1;
-
-    // build the ral model
-    create_ral_models(csr_base_addr);
-
-    // add items to clk_freqs_mhz before randomizing it
-    foreach (ral_model_names[i]) begin
-      clk_freqs_mhz[ral_model_names[i]] = 0;
-    end
-  endfunction
+  // Initialise the object with RAL models and set it up for randomisation
+  //
+  // This is virtual, allowing subclasses to set up list_of_alerts and num_interrupts.
+  extern virtual function void initialize(bit [BUS_AW-1:0] csr_base_addr = '1);
 
   // Set pre-build RAL knobs.
   //
   // This method enables setting pre-build config knobs that can be used to control how the RAL
   // sub-structures are created.
-  protected virtual function void pre_build_ral_settings(dv_base_reg_block ral);
-  endfunction
+  extern protected virtual function void pre_build_ral_settings(dv_base_reg_block ral);
 
   // Perform post-build, pre-lock modifications to the RAL.
   //
   // For some registers / fields, the correct access policies or reset values may not be set. Fixes
   // like those can be made with this method.
-  protected virtual function void post_build_ral_settings(dv_base_reg_block ral);
-  endfunction
+  extern protected virtual function void post_build_ral_settings(dv_base_reg_block ral);
 
-  virtual function void reset_asserted();
-    this.under_reset = 1;
-    csr_utils_pkg::reset_asserted();
-  endfunction
+  // Update the under_reset flag to match the fact that reset has been asserted. This is currently
+  // driven by dv_base_scoreboard::monitor_reset.
+  extern virtual function void reset_asserted();
 
-  virtual function void reset_deasserted();
-    this.under_reset = 0;
-    csr_utils_pkg::reset_deasserted();
-  endfunction
+  // Update the under_reset flag to match the fact that reset is no longer asserted. This is
+  // currently driven by dv_base_scoreboard::monitor_reset.
+  extern virtual function void reset_deasserted();
 
   // Create missing RAL models and set their base addresses based on the supplied arg.
   //
   // csr_base_addr is the base address to set to the RAL models. If it is all 1s, then we treat that
   // as an indication to randomize the base address internally instead.
-  local function void create_ral_models(bit [bus_params_pkg::BUS_AW-1:0] csr_base_addr = '1);
+  extern local function void make_ral_models(bit [BUS_AW-1:0] csr_base_addr);
 
-    foreach (ral_model_names[i]) begin
-      dv_base_reg_block reg_blk;
-      string ral_name = ral_model_names[i];
-      bit randomize_base_addr = &csr_base_addr;
+  // Create the named RAL model and set its base address based on csr_base_addr. This randomises as
+  // described in make_ral_models.
+  extern local function void make_ral_model(string           ral_model_name,
+                                            bit [BUS_AW-1:0] csr_base_addr);
 
-      if (ral_models.exists(ral_name)) begin
-        // If a model for this name already exists, set reg_blk to point at it.
-        reg_blk = ral_models[ral_name];
-      end else begin
-        // If a model for this name doesn't already exist, we should make one.
-        reg_blk = create_ral_by_name(ral_name);
-
-        // Build the register block with an arbitrary base address (we choose 0). We'll change it
-        // later.
-        pre_build_ral_settings(reg_blk);
-        reg_blk.build(.base_addr(0), .csr_excl(null));
-        reg_blk.addr_width = bus_params_pkg::BUS_AW;
-        reg_blk.data_width = bus_params_pkg::BUS_DW;
-        reg_blk.be_width = bus_params_pkg::BUS_DBW;
-        post_build_ral_settings(reg_blk);
-        reg_blk.lock_model();
-
-        ral_models[ral_name] = reg_blk;
-        if (reg_blk.get_name() == RAL_T::type_name) `downcast(ral, reg_blk)
-      end
-
-      // At this point, either the model existed already or we've just created and locked it. In
-      // either case, it should now be locked.
-      if (!reg_blk.is_locked())
-        `uvm_fatal(`gfn, $sformatf("ral_models[%s] is not locked.", ral_name))
-
-      // Since the model is locked, we know its layout. Set the base address for the register block.
-      reg_blk.set_base_addr(.base_addr(`UVM_REG_ADDR_WIDTH'(csr_base_addr)),
-                            .randomize_base_addr(randomize_base_addr));
-    end
-
-    if (ral_model_names.size > 0) begin
-      `DV_CHECK_FATAL(ral_models.exists(RAL_T::type_name))
-    end
-  endfunction
-
-  virtual function dv_base_reg_block create_ral_by_name(string name);
-    uvm_object        obj;
-    uvm_factory       factory;
-    dv_base_reg_block ral;
-
-    factory = uvm_factory::get();
-    obj = factory.create_object_by_name(.requested_type_name(name), .name(name));
-    if (obj == null) begin
-      // print factory overrides to help debug
-      factory.print();
-      `uvm_fatal(`gfn,
-                 $sformatf({"Could not create %0s as a RAL model. ",
-                            "See above for a list of type/instance overrides"},
-                           name))
-    end
-    if (!$cast(ral, obj)) begin
-      `uvm_fatal(`gfn, $sformatf("Cast failed - %0s is not a dv_base_reg_block", name))
-    end
-    return ral;
-  endfunction
+  // Create the named register block. This protected function is virtual to allow subclasses to
+  // customise how the register block is created.
+  extern protected virtual function dv_base_reg_block create_ral_by_name(string name);
 endclass
+
+constraint dv_base_env_cfg::zero_delays_c {
+  zero_delays dist {1'b0 := 6, 1'b1 := 4};
+}
+
+constraint dv_base_env_cfg::clk_freq_mhz_c {
+  `DV_COMMON_CLK_CONSTRAINT(clk_freq_mhz)
+  foreach (clk_freqs_mhz[i]) {
+    `DV_COMMON_CLK_CONSTRAINT(clk_freqs_mhz[i])
+  }
+}
+
+function dv_base_env_cfg::new (string name="");
+  super.new(name);
+endfunction
+
+function void dv_base_env_cfg::pre_randomize();
+  if (!is_initialized) `uvm_fatal(`gfn, "Run initialize() before randomizing this object.")
+endfunction
+
+function void dv_base_env_cfg::post_randomize();
+  if (clk_freqs_mhz.size > 0) begin
+    `DV_CHECK_FATAL(clk_freqs_mhz.exists(RAL_T::type_name))
+    clk_freqs_mhz[RAL_T::type_name] = clk_freq_mhz;
+  end
+endfunction
+
+function void dv_base_env_cfg::initialize(bit [BUS_AW-1:0] csr_base_addr = '1);
+  is_initialized = 1'b1;
+
+  // build the ral model
+  make_ral_models(csr_base_addr);
+
+  // add items to clk_freqs_mhz before randomizing it
+  foreach (ral_model_names[i]) begin
+    clk_freqs_mhz[ral_model_names[i]] = 0;
+  end
+endfunction
+
+function void dv_base_env_cfg::pre_build_ral_settings(dv_base_reg_block ral);
+  // This is an empty function that a subclass can override
+endfunction
+
+function void dv_base_env_cfg::post_build_ral_settings(dv_base_reg_block ral);
+  // This is an empty function that a subclass can override
+endfunction
+
+function void dv_base_env_cfg::reset_asserted();
+  this.under_reset = 1;
+  csr_utils_pkg::reset_asserted();
+endfunction
+
+function void dv_base_env_cfg::reset_deasserted();
+  this.under_reset = 0;
+  csr_utils_pkg::reset_deasserted();
+endfunction
+
+function void dv_base_env_cfg::make_ral_models(bit [BUS_AW-1:0] csr_base_addr);
+  foreach (ral_model_names[i]) make_ral_model(ral_model_names[i], csr_base_addr);
+  `DV_CHECK_FATAL(ral_models.exists(RAL_T::type_name))
+endfunction
+
+function void dv_base_env_cfg::make_ral_model(string           ral_model_name,
+                                              bit [BUS_AW-1:0] csr_base_addr);
+  dv_base_reg_block reg_blk;
+  bit randomize_base_addr = &csr_base_addr;
+
+  if (ral_models.exists(ral_model_name)) begin
+    // If a model for this name already exists, set reg_blk to point at it.
+    reg_blk = ral_models[ral_model_name];
+  end else begin
+    // If a model for this name doesn't already exist, we should make one.
+    reg_blk = create_ral_by_name(ral_model_name);
+
+    // Build the register block with an arbitrary base address (we choose 0). We'll change it
+    // later.
+    pre_build_ral_settings(reg_blk);
+    reg_blk.build(.base_addr(0), .csr_excl(null));
+    reg_blk.addr_width = BUS_AW;
+    reg_blk.data_width = bus_params_pkg::BUS_DW;
+    reg_blk.be_width = bus_params_pkg::BUS_DBW;
+    post_build_ral_settings(reg_blk);
+    reg_blk.lock_model();
+
+    ral_models[ral_model_name] = reg_blk;
+    if (reg_blk.get_name() == RAL_T::type_name) `downcast(ral, reg_blk)
+  end
+
+  // At this point, either the model existed already or we've just created and locked it. In
+  // either case, it should now be locked.
+  if (!reg_blk.is_locked()) begin
+    `uvm_fatal(`gfn, $sformatf("ral_models[%s] is not locked.", ral_model_name))
+  end
+
+  // Since the model is locked, we know its layout. Set the base address for the register block.
+  reg_blk.set_base_addr(.base_addr(`UVM_REG_ADDR_WIDTH'(csr_base_addr)),
+                        .randomize_base_addr(randomize_base_addr));
+  ral_models[ral_model_name] = reg_blk;
+endfunction
+
+function dv_base_reg_block dv_base_env_cfg::create_ral_by_name(string name);
+  uvm_object        obj;
+  uvm_factory       factory;
+  dv_base_reg_block ral;
+
+  factory = uvm_factory::get();
+  obj = factory.create_object_by_name(.requested_type_name(name), .name(name));
+  if (obj == null) begin
+    // print factory overrides to help debug
+    factory.print();
+    `uvm_fatal(`gfn,
+               $sformatf({"Could not create %0s as a RAL model. ",
+                          "See above for a list of type/instance overrides"},
+                         name))
+  end
+  if (!$cast(ral, obj)) begin
+    `uvm_fatal(`gfn, $sformatf("Cast failed - %0s is not a dv_base_reg_block", name))
+  end
+  return ral;
+endfunction

--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -11,7 +11,6 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
   bit en_cov            = 0; // Enable via plusarg, only if coverage collection is turned on.
   bit en_dv_cdc         = 0; // Enable via plusarg.
 
-  local bit will_reset  = 0;
   bit under_reset       = 0;
   bit is_initialized;        // Indicates that the initialize() method has been called.
 
@@ -107,22 +106,8 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
   protected virtual function void post_build_ral_settings(dv_base_reg_block ral);
   endfunction
 
-  // This can be used to stop transaction generators either upon reset or in preparation to
-  // issue a random reset.
-  virtual function bit stop_transaction_generators();
-    return this.will_reset || this.under_reset;
-  endfunction
-
-  // This can be used to announce the intention to generate a random reset soon, to allow
-  // transaction generators to stop, and fire a reset with no outstanding transactions.
-  virtual function void set_intention_to_reset();
-    `uvm_info(`gfn, "Setting intention to reset", UVM_MEDIUM)
-    this.will_reset = 1'b1;
-  endfunction
-
   virtual function void reset_asserted();
     this.under_reset = 1;
-    this.will_reset = 0;
     csr_utils_pkg::reset_asserted();
   endfunction
 

--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -7,7 +7,7 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
   bit is_active         = 1;
   bit en_scb            = 1; // can be changed at run-time
   bit en_scb_mem_chk    = 1;
-  bit en_scb_ping_chk   = 1;
+
   bit en_cov            = 0; // Enable via plusarg, only if coverage collection is turned on.
   bit en_dv_cdc         = 0; // Enable via plusarg.
 

--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -6,7 +6,6 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
 
   bit is_active         = 1;
   bit en_scb            = 1; // can be changed at run-time
-  bit en_scb_tl_err_chk = 1;
   bit en_scb_mem_chk    = 1;
   bit en_scb_ping_chk   = 1;
   bit en_cov            = 0; // Enable via plusarg, only if coverage collection is turned on.

--- a/hw/dv/sv/dv_lib/dv_base_test.sv
+++ b/hw/dv/sv/dv_lib/dv_base_test.sv
@@ -43,7 +43,6 @@ class dv_base_test #(type CFG_T = dv_base_env_cfg,
 
     // Enable scoreboard (and sub-scoreboard checks) via plusarg.
     void'($value$plusargs("en_scb=%0b", cfg.en_scb));
-    void'($value$plusargs("en_scb_tl_err_chk=%0b", cfg.en_scb_tl_err_chk));
     void'($value$plusargs("en_scb_mem_chk=%0b", cfg.en_scb_mem_chk));
     // Enable fastest design performance by configuring zero delays in all agents.
     void'($value$plusargs("zero_delays=%0b", cfg.zero_delays));

--- a/hw/dv/sv/dv_lib/dv_base_test.sv
+++ b/hw/dv/sv/dv_lib/dv_base_test.sv
@@ -36,7 +36,6 @@ class dv_base_test #(type CFG_T = dv_base_env_cfg,
 
     env = ENV_T::type_id::create("env", this);
     cfg = CFG_T::type_id::create("cfg", this);
-    void'($value$plusargs("use_jtag_dmi=%0b", cfg.use_jtag_dmi));
     cfg.initialize();
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
     uvm_config_db#(CFG_T)::set(this, "env", "cfg", cfg);

--- a/hw/ip/mbx/dv/env/mbx_env_cfg.sv
+++ b/hw/ip/mbx/dv/env/mbx_env_cfg.sv
@@ -55,7 +55,7 @@ class mbx_env_cfg extends cip_base_env_cfg #(
 
   endfunction: initialize
 
-  virtual function dv_base_reg_block create_ral_by_name(string name);
+  virtual protected function dv_base_reg_block create_ral_by_name(string name);
     if (name == RAL_T::type_name) begin
       return super.create_ral_by_name(name);
     end else if (name == mbx_soc_ral_name) begin

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
@@ -27,7 +27,7 @@ class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block
   extern constraint kmac_accept_delay_max_c;
   extern function new (string name="");
   extern virtual function void initialize(bit [31:0] csr_base_addr = '1);
-  extern virtual function dv_base_reg_block create_ral_by_name(string name);
+  extern virtual protected function dv_base_reg_block create_ral_by_name(string name);
 
   `uvm_object_utils_begin(rom_ctrl_env_cfg)
   `uvm_object_utils_end

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
@@ -94,7 +94,7 @@ class sram_ctrl_env_cfg #(parameter int AddrWidth = 10)
   //
   // Note that the SRAM only has 2 RAL models, one is the "default" CSR model,
   // and the other is the custom model to represent the memory primitive.
-  virtual function dv_base_reg_block create_ral_by_name(string name);
+  virtual protected function dv_base_reg_block create_ral_by_name(string name);
     if (name == RAL_T::type_name) begin
       return super.create_ral_by_name(name);
     end else if (name == sram_ral_name) begin

--- a/hw/top_darjeeling/dv/env/chip_env_cfg.sv
+++ b/hw/top_darjeeling/dv/env/chip_env_cfg.sv
@@ -26,6 +26,10 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // Memory backdoor util instances for all memory instances in the chip.
   mem_bkdr_util mem_bkdr_util_h[chip_mem_e];
 
+  // If this is true, the environment will connect DMI over JTAG. If this is enabled through a
+  // plusarg, the test calls set_use_jtag_dmi() to set this bit as part of the build phase.
+  bit use_jtag_dmi = 0;
+
   // Creator SW config region in OTP that holds the AST config data. Randomized for open source.
   //
   // These are written via backdoor to the OTP region that starts at
@@ -190,20 +194,6 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
 
     // create jtag agent config obj
     m_jtag_riscv_agent_cfg = jtag_riscv_agent_cfg::type_id::create("m_jtag_riscv_agent_cfg");
-    m_jtag_riscv_agent_cfg.use_jtag_dmi = use_jtag_dmi;
-    if (use_jtag_dmi == 1) begin
-      // Both, the regs only supports 1 outstanding.
-      m_tl_agent_cfgs[RAL_T::type_name].max_outstanding_req = 1;
-
-      m_jtag_agent_cfg = jtag_agent_cfg::type_id::create("m_jtag_agent_cfg");
-      m_jtag_agent_cfg.if_mode = dv_utils_pkg::Host;
-      m_jtag_agent_cfg.is_active = 1'b1;
-      m_jtag_agent_cfg.ir_len = JTAG_IR_LEN;
-
-      // Set the 'correct' IDCODE register value to the JTAG DTM RAL.
-      m_jtag_agent_cfg.jtag_dtm_ral.idcode.set_reset(RV_DM_JTAG_IDCODE);
-      m_jtag_riscv_agent_cfg.m_jtag_agent_cfg = m_jtag_agent_cfg;
-    end
 
     // create spi agent config obj
     m_spi_host_agent_cfg = spi_agent_cfg::type_id::create("m_spi_host_agent_cfg");
@@ -227,28 +217,9 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     `DV_CHECK_LE_FATAL(num_ram_ctn_tiles, 16)
     `DV_CHECK_LE_FATAL(num_otbn_dmem_tiles, 16)
 
-    if (use_jtag_dmi == 1) begin
-      jtag_dmi_ral = create_jtag_dmi_reg_block(m_jtag_riscv_agent_cfg.m_jtag_agent_cfg);
-      // Fix the reset values of these fields based on our design.
-      `uvm_info(`gfn, "Fixing reset values in jtag_dmi_ral", UVM_LOW)
-      jtag_dmi_ral.hartinfo.dataaddr.set_reset(dm::DataAddr);
-      jtag_dmi_ral.hartinfo.datasize.set_reset(dm::DataCount);
-      jtag_dmi_ral.hartinfo.dataaccess.set_reset(1);  // TODO: verify this!
-      jtag_dmi_ral.hartinfo.nscratch.set_reset(2);  // TODO: verify this!
-      jtag_dmi_ral.abstractcs.datacount.set_reset(dm::DataCount);
-      jtag_dmi_ral.abstractcs.progbufsize.set_reset(dm::ProgBufSize);
-      jtag_dmi_ral.dmstatus.authenticated.set_reset(1);  // No authentication performed.
-      jtag_dmi_ral.sbcs.sbaccess32.set_reset(1);
-      jtag_dmi_ral.sbcs.sbaccess16.set_reset(1);
-      jtag_dmi_ral.sbcs.sbaccess8.set_reset(1);
-      jtag_dmi_ral.sbcs.sbasize.set_reset(32);
-      apply_jtag_dmi_ral_csr_excl();
-    end
-
     // Create the JTAG RV debugger instance.
     debugger = jtag_rv_debugger::type_id::create("debugger");
     debugger.set_cfg(m_jtag_agent_cfg);
-    debugger.set_ral(jtag_dmi_ral);
     debugger.num_harts = rv_dm_reg_pkg::NrHarts;
     debugger.num_triggers = 4;  // TODO: wire this from `top_darjeeling_pkg`.
 
@@ -264,6 +235,55 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     num_ram_mbox_tiles = 1;
     num_ram_ctn_tiles = 1;
     num_otbn_dmem_tiles = 1;
+  endfunction
+
+  // Set the use_jtag_dmi field to be true, which will cause the chip environment to run a DMI agent
+  // over a JTAG connection.
+  //
+  // This should be called as part of build_phase in the test, before build_phase for the
+  // environment runs.
+  function void set_use_jtag_dmi();
+    if (this.use_jtag_dmi) return;
+
+    this.use_jtag_dmi = 1;
+    m_jtag_riscv_agent_cfg.use_jtag_dmi = 1;
+
+    // Both, the regs only supports 1 outstanding.
+    m_tl_agent_cfgs[RAL_T::type_name].max_outstanding_req = 1;
+
+    m_jtag_agent_cfg = jtag_agent_cfg::type_id::create("m_jtag_agent_cfg");
+    m_jtag_agent_cfg.if_mode = dv_utils_pkg::Host;
+    m_jtag_agent_cfg.is_active = 1'b1;
+    m_jtag_agent_cfg.ir_len = JTAG_IR_LEN;
+
+    // Set the 'correct' IDCODE register value to the JTAG DTM RAL.
+    m_jtag_agent_cfg.jtag_dtm_ral.idcode.set_reset(RV_DM_JTAG_IDCODE);
+    m_jtag_riscv_agent_cfg.m_jtag_agent_cfg = m_jtag_agent_cfg;
+
+    // Create the DMI register block. Because use_jtag_dmi was false at the start of the function,
+    // we know it is currently null.
+    if (jtag_dmi_ral != null) `uvm_fatal(`gfn, "jtag_dmi_ral unexpectedly set")
+
+    jtag_dmi_ral = create_jtag_dmi_reg_block(m_jtag_riscv_agent_cfg.m_jtag_agent_cfg);
+
+    // Fix the reset values of these fields based on our design.
+    `uvm_info(`gfn, "Fixing reset values in jtag_dmi_ral", UVM_LOW)
+    jtag_dmi_ral.hartinfo.dataaddr.set_reset(dm::DataAddr);
+    jtag_dmi_ral.hartinfo.datasize.set_reset(dm::DataCount);
+    jtag_dmi_ral.hartinfo.dataaccess.set_reset(1);  // TODO: verify this!
+    jtag_dmi_ral.hartinfo.nscratch.set_reset(2);  // TODO: verify this!
+    jtag_dmi_ral.abstractcs.datacount.set_reset(dm::DataCount);
+    jtag_dmi_ral.abstractcs.progbufsize.set_reset(dm::ProgBufSize);
+    jtag_dmi_ral.dmstatus.authenticated.set_reset(1);  // No authentication performed.
+    jtag_dmi_ral.sbcs.sbaccess32.set_reset(1);
+    jtag_dmi_ral.sbcs.sbaccess16.set_reset(1);
+    jtag_dmi_ral.sbcs.sbaccess8.set_reset(1);
+    jtag_dmi_ral.sbcs.sbasize.set_reset(32);
+    apply_jtag_dmi_ral_csr_excl();
+
+    // Finally, tell the debugger (which should already exist) about the register block we just
+    // created.
+    debugger.set_ral(jtag_dmi_ral);
   endfunction
 
   // Disable functional coverage of comportable IP-specific specialized registers.

--- a/hw/top_darjeeling/dv/tests/chip_base_test.sv
+++ b/hw/top_darjeeling/dv/tests/chip_base_test.sv
@@ -19,6 +19,7 @@ class chip_base_test extends cip_base_test #(
   virtual function void build_phase(uvm_phase phase);
     string sw_images_plusarg;
     string use_otp_image_plusarg;
+    bit    use_jtag_dmi;
 
     super.build_phase(phase);
 
@@ -79,6 +80,11 @@ class chip_base_test extends cip_base_test #(
     test_timeout_ns = 50_000_000;
     test_timeout_ns = `DV_MAX2(test_timeout_ns, 5 * cfg.sw_test_timeout_ns);
     `uvm_info(`gfn, $sformatf("test_timeout_ns = %0d", test_timeout_ns), UVM_LOW)
+
+    void'($value$plusargs("use_jtag_dmi=%0b", use_jtag_dmi));
+    if (use_jtag_dmi) begin
+      cfg.set_use_jtag_dmi();
+    end
   endfunction : build_phase
 
 endclass : chip_base_test

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -32,6 +32,10 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // Memory backdoor util instances for all memory instances in the chip.
   mem_bkdr_util mem_bkdr_util_h[chip_mem_e];
 
+  // If this is true, the environment will connect DMI over JTAG. If this is enabled through a
+  // plusarg, the test calls set_use_jtag_dmi() to set this bit as part of the build phase.
+  bit use_jtag_dmi = 0;
+
   // Creator SW config region in OTP that holds the AST config data. Randomized for open source.
   //
   // These are written via backdoor to the OTP region that starts at
@@ -196,20 +200,6 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
 
     // create jtag agent config obj
     m_jtag_riscv_agent_cfg = jtag_riscv_agent_cfg::type_id::create("m_jtag_riscv_agent_cfg");
-    m_jtag_riscv_agent_cfg.use_jtag_dmi = use_jtag_dmi;
-    if (use_jtag_dmi == 1) begin
-      // Both, the regs only supports 1 outstanding.
-      m_tl_agent_cfgs[RAL_T::type_name].max_outstanding_req = 1;
-
-      m_jtag_agent_cfg = jtag_agent_cfg::type_id::create("m_jtag_agent_cfg");
-      m_jtag_agent_cfg.if_mode = dv_utils_pkg::Host;
-      m_jtag_agent_cfg.is_active = 1'b1;
-      m_jtag_agent_cfg.ir_len = JTAG_IR_LEN;
-
-      // Set the 'correct' IDCODE register value to the JTAG DTM RAL.
-      m_jtag_agent_cfg.jtag_dtm_ral.idcode.set_reset(RV_DM_JTAG_IDCODE);
-      m_jtag_riscv_agent_cfg.m_jtag_agent_cfg = m_jtag_agent_cfg;
-    end
 
     // create spi agent config obj
     m_spi_host_agent_cfg = spi_agent_cfg::type_id::create("m_spi_host_agent_cfg");
@@ -237,29 +227,9 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     `DV_CHECK_LE_FATAL(num_ram_ret_tiles, 16)
     `DV_CHECK_LE_FATAL(num_otbn_dmem_tiles, 16)
 
-    // ral_model_names = chip_reg_block // 1 entry
-    if (use_jtag_dmi == 1) begin
-      jtag_dmi_ral = create_jtag_dmi_reg_block(m_jtag_riscv_agent_cfg.m_jtag_agent_cfg);
-      // Fix the reset values of these fields based on our design.
-      `uvm_info(`gfn, "Fixing reset values in jtag_dmi_ral", UVM_LOW)
-      jtag_dmi_ral.hartinfo.dataaddr.set_reset(dm::DataAddr);
-      jtag_dmi_ral.hartinfo.datasize.set_reset(dm::DataCount);
-      jtag_dmi_ral.hartinfo.dataaccess.set_reset(1);
-      jtag_dmi_ral.hartinfo.nscratch.set_reset(2);
-      jtag_dmi_ral.abstractcs.datacount.set_reset(dm::DataCount);
-      jtag_dmi_ral.abstractcs.progbufsize.set_reset(dm::ProgBufSize);
-      jtag_dmi_ral.dmstatus.authenticated.set_reset(1);  // No authentication performed.
-      jtag_dmi_ral.sbcs.sbaccess32.set_reset(1);
-      jtag_dmi_ral.sbcs.sbaccess16.set_reset(1);
-      jtag_dmi_ral.sbcs.sbaccess8.set_reset(1);
-      jtag_dmi_ral.sbcs.sbasize.set_reset(32);
-      apply_jtag_dmi_ral_csr_excl();
-    end
-
     // Create the JTAG RV debugger instance.
     debugger = jtag_rv_debugger::type_id::create("debugger");
     debugger.set_cfg(m_jtag_agent_cfg);
-    debugger.set_ral(jtag_dmi_ral);
     debugger.num_harts = rv_dm_reg_pkg::NrHarts;
     debugger.num_triggers = 4;  // TODO: wire this from `top_earlgrey_pkg`.
 
@@ -273,6 +243,55 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     num_ram_main_tiles = 1;
     num_ram_ret_tiles = 1;
     num_otbn_dmem_tiles = 1;
+  endfunction
+
+  // Set the use_jtag_dmi field to be true, which will cause the chip environment to run a DMI agent
+  // over a JTAG connection.
+  //
+  // This should be called as part of build_phase in the test, before build_phase for the
+  // environment runs.
+  function void set_use_jtag_dmi();
+    if (this.use_jtag_dmi) return;
+
+    this.use_jtag_dmi = 1;
+    m_jtag_riscv_agent_cfg.use_jtag_dmi = 1;
+
+    // Both, the regs only supports 1 outstanding.
+    m_tl_agent_cfgs[RAL_T::type_name].max_outstanding_req = 1;
+
+    m_jtag_agent_cfg = jtag_agent_cfg::type_id::create("m_jtag_agent_cfg");
+    m_jtag_agent_cfg.if_mode = dv_utils_pkg::Host;
+    m_jtag_agent_cfg.is_active = 1'b1;
+    m_jtag_agent_cfg.ir_len = JTAG_IR_LEN;
+
+    // Set the 'correct' IDCODE register value to the JTAG DTM RAL.
+    m_jtag_agent_cfg.jtag_dtm_ral.idcode.set_reset(RV_DM_JTAG_IDCODE);
+    m_jtag_riscv_agent_cfg.m_jtag_agent_cfg = m_jtag_agent_cfg;
+
+    // Create the DMI register block. Because use_jtag_dmi was false at the start of the function,
+    // we know it is currently null.
+    if (jtag_dmi_ral != null) `uvm_fatal(`gfn, "jtag_dmi_ral unexpectedly set")
+
+    jtag_dmi_ral = create_jtag_dmi_reg_block(m_jtag_riscv_agent_cfg.m_jtag_agent_cfg);
+
+    // Fix the reset values of these fields based on our design.
+    `uvm_info(`gfn, "Fixing reset values in jtag_dmi_ral", UVM_LOW)
+    jtag_dmi_ral.hartinfo.dataaddr.set_reset(dm::DataAddr);
+    jtag_dmi_ral.hartinfo.datasize.set_reset(dm::DataCount);
+    jtag_dmi_ral.hartinfo.dataaccess.set_reset(1);  // TODO: verify this!
+    jtag_dmi_ral.hartinfo.nscratch.set_reset(2);  // TODO: verify this!
+    jtag_dmi_ral.abstractcs.datacount.set_reset(dm::DataCount);
+    jtag_dmi_ral.abstractcs.progbufsize.set_reset(dm::ProgBufSize);
+    jtag_dmi_ral.dmstatus.authenticated.set_reset(1);  // No authentication performed.
+    jtag_dmi_ral.sbcs.sbaccess32.set_reset(1);
+    jtag_dmi_ral.sbcs.sbaccess16.set_reset(1);
+    jtag_dmi_ral.sbcs.sbaccess8.set_reset(1);
+    jtag_dmi_ral.sbcs.sbasize.set_reset(32);
+    apply_jtag_dmi_ral_csr_excl();
+
+    // Finally, tell the debugger (which should already exist) about the register block we just
+    // created.
+    debugger.set_ral(jtag_dmi_ral);
   endfunction
 
   // Disable functional coverage of comportable IP-specific specialized registers.

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -19,6 +19,7 @@ class chip_base_test extends cip_base_test #(
   virtual function void build_phase(uvm_phase phase);
     string sw_images_plusarg;
     string use_otp_image_plusarg;
+    bit    use_jtag_dmi;
 
     super.build_phase(phase);
 
@@ -86,6 +87,11 @@ class chip_base_test extends cip_base_test #(
     test_timeout_ns = 50_000_000;
     test_timeout_ns = `DV_MAX2(test_timeout_ns, 5 * cfg.sw_test_timeout_ns);
     `uvm_info(`gfn, $sformatf("test_timeout_ns = %0d", test_timeout_ns), UVM_LOW)
+
+    void'($value$plusargs("use_jtag_dmi=%0b", use_jtag_dmi));
+    if (use_jtag_dmi) begin
+      cfg.set_use_jtag_dmi();
+    end
   endfunction : build_phase
 
 endclass : chip_base_test


### PR DESCRIPTION
This looks like a big PR, but that's because it builds on top of #28256 (to avoid annoying merge conflicts). Once that has been merged, there should be 5 commits in this PR.

The reason for writing this was to tidy up `dv_base_env_cfg`, switching to out-of-block definitions and adding documentation comments. The first four commits unique to this PR are examples of me noticing functionality that didn't belong in the base class and moving it out.