### PR TITLE
[dv] Simplify / document agent drivers

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_base_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_base_driver.sv
@@ -5,10 +5,8 @@
 // Virtual base class used for alert_sender_driver and alert_receiver_driver
 
 virtual class alert_base_driver extends dv_base_driver#(alert_esc_seq_item, alert_esc_agent_cfg);
-  alert_esc_seq_item r_alert_ping_send_q[$];
-  alert_esc_seq_item r_alert_rsp_q[$];
-  alert_esc_seq_item s_alert_send_q[$];
-  alert_esc_seq_item s_alert_ping_rsp_q[$];
+  protected uvm_tlm_analysis_fifo #(alert_esc_seq_item) m_sender_requests;
+  protected uvm_tlm_analysis_fifo #(alert_esc_seq_item) m_receiver_requests;
 
   extern function new (string name, uvm_component parent);
 
@@ -28,6 +26,8 @@ endclass
 
 function alert_base_driver::new (string name, uvm_component parent);
   super.new(name, parent);
+  m_sender_requests = new("m_sender_requests", this);
+  m_receiver_requests = new("m_receiver_requests", this);
 endfunction : new
 
 task alert_base_driver::get_and_drive();
@@ -45,11 +45,9 @@ task alert_base_driver::get_req();
     `downcast(req_clone, req.clone());
     req_clone.set_id_info(req);
     // receiver mode
-    if (req.r_alert_ping_send) r_alert_ping_send_q.push_back(req_clone);
-    if (req.r_alert_rsp)       r_alert_rsp_q.push_back(req_clone);
+    if (req.r_alert_ping_send || req.r_alert_rsp) m_receiver_requests.write(req_clone);
     // sender mode
-    if (req.s_alert_send)      s_alert_send_q.push_back(req_clone);
-    if (req.s_alert_ping_rsp)  s_alert_ping_rsp_q.push_back(req_clone);
+    if (req.s_alert_send || req.s_alert_ping_rsp) m_sender_requests.write(req_clone);
 
     if (req.r_esc_rsp) begin
       `uvm_error(get_full_name(), "Alert driver cannot drive an esc item")

--- a/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
@@ -183,6 +183,16 @@ interface alert_esc_if(input clk, input rst_n);
     end while (cycle_cnt > 1 || rst_n != 1'b1);
   endtask : wait_esc_ping
 
+  // Set the alert pins to the requested value (either 1;0 or 0;1) when the interface is active and
+  // configured to act as the alert sender.
+  //
+  // This uses a clocking drive to update the version of the signal in sender_cb (causing the update
+  // to have a lasting effect, and also to be synchronised with the next clock edge).
+  task automatic force_alert(bit alert_p, bit alert_n);
+    sender_cb.alert_tx_int.alert_p <= alert_p;
+    sender_cb.alert_tx_int.alert_n <= alert_n;
+  endtask
+
   // Return true if the current state is PingSt
   //
   // This rather trivial function is needed because we want to use the interface through a virtual

--- a/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
@@ -2,25 +2,104 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// A driver that receives alerts. This is used in alert_esc_agent when configured in "device mode"
-// (so the dut is a device and the agent is expecting to receive alerts and send occasional pings)
+// A driver that behaves as an alert_receiver. This is used in alert_esc_agent when configured in
+// "device mode"
+
 class alert_receiver_driver extends alert_base_driver;
   `uvm_component_utils(alert_receiver_driver)
 
-  bit working_on_alert;
+  // A pair of ids that can be used as a key for a sequence item. We need the sequence ID as well as
+  // the transaction ID so that we can distinguish items at the same position in different
+  // sequences. The types are chosen to match UVM's get_transaction_id and get_sequence_id.
+  typedef struct packed {
+    int     sequence_id;
+    integer transaction_id;
+  } id_pair_t;
+
+  // The drive_req_between_resets task will consume requests from m_receiver_requests and add these
+  // requests to this pair of FIFOs (to be consumed by the send_pings and send_alert_rsps tasks that
+  // it spawns).
+  //
+  // When reset is asserted, both of those tasks will exit after flushing their respective queues.
+  local uvm_tlm_analysis_fifo #(alert_esc_seq_item) m_pending_pings;
+  local uvm_tlm_analysis_fifo #(alert_esc_seq_item) m_pending_alert_rsps;
+
+  // A map from item transaction ID to the tasks that are pending for that item. If bit 0 is set,
+  // the item represents an alert that must be responded to. If bit 1 is set, the item represents a
+  // ping request.
+  //
+  // When the send_pings or send_alert_rsps task clears the final bit for an item, it should remove
+  // the item from this map. Because the base driver uses get (instead of get_next_item), we don't
+  // also have to call seq_item_port.item_done to tell the sequencer that the item has been fully
+  // driven, but we *do* send a response (by sending the original item), to allow the sequence to
+  // see that the item is done.
+  //
+  // When reset is asserted, both of those tasks will exit, clearing this map.
+  local bit [1:0] m_transaction_tasks[id_pair_t];
+
+  // When a ping gets an alert response or a genuine alert is sent, this driver needs to acknowledge
+  // the alert, but the two options need to be handled serially. The ack is handled by ack_alert,
+  // which uses this semaphore as a mutex.
+  local semaphore m_ack_semaphore;
 
   extern function new(string name, uvm_component parent);
 
-  extern task drive_req();
-  extern task reset_signals();
-  extern task alert_init_thread();
-  extern task send_ping(alert_esc_seq_item req);
+  // Clear interface signals because reset has been asserted
+  //
+  // This implements a task in dv_base_driver
+  extern task on_enter_reset();
 
-  // Handle a sequence item that demands an alert response (and was thus put in r_alert_rsp_q).
+  // Drive requests that have been seen by alert_base_driver::get_req. This task runs forever.
+  //
+  // This implements a task in alert_base_driver
+  extern task drive_req();
+
+  // Take items from m_receiver_requests and (depending on the type of the item) add them to
+  // m_pending_pings and m_pending_alert_rsps.
+  //
+  // Exits immediately on reset.
+  extern local task consume_requests_betwen_resets();
+
+  // Drive requests that have been seen by alert_base_driver::get_req, until the next reset. This is
+  // called by drive_req.
+  extern local task drive_req_between_resets();
+
+  // Clear the appropriate bit in m_transaction_tasks for the ID pair of item. If the resulting
+  // bitmap is zero, delete the entry from m_transaction_tasks.
+  extern local function void report_done(bit is_ping, alert_esc_seq_item item);
+
+  // Drive any items that were added to m_pending_pings.
+  //
+  // Exits early on reset.
+  extern local task send_pings();
+
+  // Drive any items that were added to m_pending_alert_rsps.
+  //
+  // Exits early on reset.
+  extern local task send_alert_rsps();
+
+  // Send a ping described by item.
+  //
+  // Exits early on reset.
+  extern local task send_ping(alert_esc_seq_item item);
+
+  // Handle a sequence item that demands an alert response
   //
   // An item should only be added to that queue in response to an alert being generated on the
-  // interface. We will wait a randomised time (in set_ack_pins) before acknowledging the alert.
-  extern task rsp_alert(alert_esc_seq_item req);
+  // interface. We will wait a randomised time (in ack_alert) before acknowledging the alert.
+  //
+  // Exits early on reset.
+  extern local task send_alert_rsp(alert_esc_seq_item item);
+
+  // Wait for a short time to allow an alert to propagate through the clocking blocks in the
+  // interface. The max_cycles argument is the maximum number of cycles to wait.
+  //
+  // The task will stop as soon as any of these events happens:
+  //
+  //    - The alert_p signal goes high in receiver_cb.
+  //    - There have been max_cycles edges of both clocks.
+  //    - A reset is asserted.
+  extern local task wait_for_alert_propagation(int unsigned max_cycles);
 
   // Drive an alert ping
   //
@@ -29,21 +108,26 @@ class alert_receiver_driver extends alert_base_driver;
   // ping_delay argument.
   //
   // Once the ping has gone out, we wait for an alert to arrive and then acknowledge it using
-  // set_ack_pins (and passing ack_delay and ack_stable).
+  // ack_alert (and passing ack_delay and ack_stable).
   //
   // The task allows to retract driving the ping. If there's an alert (r_alert_rsp_q.size > 0)
   // before the 'ping_delay' the ping is aborted and the driver moves to tackle the alert in
   // 'rsp_alert' task. This is notified by setting `item_not_driven=1`
   //
-  // This task can be safely killed on a reset.
-  extern task drive_alert_ping(int unsigned ping_delay,
-                               int unsigned ack_delay,
-                               int unsigned ack_stable,
-                               output bit item_not_driven);
+  // The task exits early on reset.
+  extern local task drive_alert_ping(int unsigned ping_delay,
+                                     int unsigned ack_delay,
+                                     int unsigned ack_stable);
 
-  // Acknowledge an alert.
+  // Acknowledge the next alert
   //
-  // The ack will come after a delay which is normally randomised in the range [cfg.ack_delay_min,
+  // This task waits until an alert is signalled, then waits a short time before acknowledging the
+  // alert. Once the ack has been asserted, the ack stays high for a time before it, in turn, drops.
+  //
+  // This task uses m_ack_semaphore as a mutex (to serialise ping response acks and other alert
+  // acks).
+  //
+  // The delay before the initial ack is normally randomised in the range [cfg.ack_delay_min,
   // cfg.ack_delay_max] cycles. If cfg.use_seq_item_ack_delay is true then the delay is from the
   // ack_delay argument.
   //
@@ -54,279 +138,313 @@ class alert_receiver_driver extends alert_base_driver;
   // Both of these times will be truncated if cfg.fast_rcvr is true. In that case, they will be
   // cfg.ack_delay_min, cfg.ack_stable_min respectively.
   //
-  // This task can be safely killed on a reset.
-  extern task set_ack_pins(int unsigned ack_delay,
-                           int unsigned ack_stable);
+  // The task will exit quickly on reset (replacing the token on the semaphore)
+  extern local task ack_alert(int unsigned ack_delay, int unsigned ack_stable);
 
-  extern task set_ack();
-  extern task reset_ack();
-  extern task set_ping();
-  extern task wait_alert();
+  // Set the ack signal to be the given boolean value (so either 0;1 or 1;0)
+  extern local task set_ack(bit asserted);
+
+  // Toggle the ping state
+  extern local task set_ping();
+
+  // Set the ping state to 0;1 (the reset value)
   extern task reset_ping();
-  extern task do_reset();
-  extern task do_alert_rx_init();
-  // Clears the items in queues `r_alert_rsp_q` and `r_alert_ping_send_q`.
-  // This gets used in the task `reset_signals` to clear the queues on reset
-  // This task prevents the scenario of accidentally driving ACK after reset
-  extern function void clear_item_queues();
-  extern task ping_and_alert_thread();
 
+  // Perform the alert init handshake, exiting early on reset
+  extern task do_alert_rx_init();
 endclass : alert_receiver_driver
 
 function alert_receiver_driver::new(string name, uvm_component parent);
   super.new(name, parent);
+  m_ack_semaphore = new(1);
+  m_pending_pings = new("m_pending_pings", this);
+  m_pending_alert_rsps = new("m_pending_alert_rsps", this);
 endfunction
 
+task alert_receiver_driver::on_enter_reset();
+  // Clear ping and ack signals (both the actual signals and the clocking block values)
+  cfg.vif.alert_rx_int.ping_p <= 1'b0;
+  cfg.vif.alert_rx_int.ping_n <= 1'b1;
+  cfg.vif.alert_rx_int.ack_p <= 1'b0;
+  cfg.vif.alert_rx_int.ack_n <= 1'b1;
+  cfg.vif.receiver_cb.alert_rx_int.ping_p <= 1'b0;
+  cfg.vif.receiver_cb.alert_rx_int.ping_n <= 1'b1;
+  cfg.vif.receiver_cb.alert_rx_int.ack_p <= 1'b0;
+  cfg.vif.receiver_cb.alert_rx_int.ack_n <= 1'b1;
+endtask
+
 task alert_receiver_driver::drive_req();
-  fork
-    ping_and_alert_thread();
-    alert_init_thread();
-  join_none
-endtask : drive_req
-
-// Controls whether 'send_ping' or 'rsp_alert' is called depending on the seq_items received
-// If ping/alert occur close to each other, there's a chance the driver may believe a ping is
-// happening whereas the alert sender is actually sending an alert.
-// This situation doesn't affect behavior since the driver would just ack the ping and the
-// RTL would believe the ack was for the alert, but the next alert request would be for the ping
-// and the handshake would look the same either way.
-task alert_receiver_driver::ping_and_alert_thread();
   forever begin
-    wait (((r_alert_ping_send_q.size() > 0) || (r_alert_rsp_q.size() > 0)) && !cfg.in_reset);
-    `uvm_info(`gfn, $sformatf({"%m - Queues: r_alert_ping_send_q.size=%0d | ",
-                               "r_alert_rsp_q.size()=%0d"}, r_alert_ping_send_q.size,
-                               r_alert_rsp_q.size()), UVM_DEBUG)
-
-    if (r_alert_rsp_q.size() > 0)
-      rsp_alert(r_alert_rsp_q.pop_front());
-    else if (r_alert_ping_send_q.size() > 0)
-      send_ping(r_alert_ping_send_q.pop_front());
-    else begin
-      `uvm_fatal(`gfn, $sformatf({"%m - no items in r_alert_ping_send_q.size=%0d ",
-                                  " nor r_alert_ping_send_q.size=%0d"}, r_alert_ping_send_q.size))
-    end
-  end
-endtask
-
-task alert_receiver_driver::reset_signals();
-  do_reset();
-  forever begin
-    @(negedge cfg.vif.rst_n);
-    clear_item_queues();
-    working_on_alert = 0;
-    do_reset();
-    @(posedge cfg.vif.rst_n);
-  end
-endtask
-
-task alert_receiver_driver::alert_init_thread();
-  do_alert_rx_init();
-  forever @(posedge cfg.vif.rst_n) begin
-    do_alert_rx_init();
-  end
-endtask : alert_init_thread
-
-task alert_receiver_driver::send_ping(alert_esc_seq_item req);
-  alert_esc_seq_item  rsp;
-  bit item_not_driven;
-  `downcast(rsp, req.clone());
-  rsp.set_id_info(req);
-
-  `uvm_info(`gfn, $sformatf("%m - Item received: \n%0s",req.sprint), UVM_DEBUG)
-
-  if (!req.int_err) begin
-    `uvm_info(`gfn, $sformatf({"starting to send receiver item, ping_send=%0b, alert_rsp=%0b, ",
-                               "int_fail=%0b"}, req.r_alert_ping_send, req.r_alert_rsp,
-                              req.int_err), UVM_HIGH)
-    fork
-      begin : isolation_fork
+    // Wait until we are out of reset. Until that happens, respond instantly to any sequence items
+    // that come in.
+    while (cfg.in_reset) begin
+      fork : isolation_fork begin
+        alert_esc_seq_item item;
         fork
-          begin
-            while (working_on_alert) begin
-              `uvm_info(`gfn, $sformatf("%m - Waiting for alert to complete"), UVM_DEBUG)
-              @(cfg.vif.receiver_cb);
-            end
-            drive_alert_ping(req.ping_delay, req.ack_delay, req.ack_stable, item_not_driven);
-          end
-          wait (cfg.in_reset);
+          wait (!cfg.in_reset);
+          m_receiver_requests.get(item);
         join_any
         disable fork;
-      end
-    join
+        // Since we are in reset, we ignore any item that we see. Because it was fetched by get() in
+        // alert_base_driver (instead of with get_next_item()), we do not have to declare it done.
+      end join
+    end
 
-    if (item_not_driven) begin
-      `uvm_info(`gfn, {"Ping sequence item not driven because there's been an alert with no",
-                       "previous ping - pushing back to its queue"}, UVM_DEBUG)
-      // Note item is pushed to the front since it was the oldest in the queue
-      r_alert_ping_send_q.push_front(req);
-      // A delay is needed to avoid a potential infinite loop if the monitor doesn't have time to sample the next alert
-      @(cfg.vif.receiver_cb);
-      return;
+    drive_req_between_resets();
+  end
+endtask
+
+task alert_receiver_driver::consume_requests_betwen_resets();
+  fork : isolation_fork begin
+    fork
+      wait (cfg.in_reset);
+      forever begin
+        alert_esc_seq_item item;
+        id_pair_t ids;
+        bit [1:0] jobs;
+
+        m_receiver_requests.get(item);
+        jobs[0] = item.r_alert_rsp;
+        jobs[1] = item.r_alert_ping_send;
+
+        if (!jobs) begin
+          `uvm_fatal(get_full_name(),
+                     $sformatf("Item sent to driver doesn't have any tasks for us: %0s",
+                               item.sprint()))
+        end
+
+        ids.transaction_id = item.get_transaction_id();
+        ids.sequence_id    = item.get_sequence_id();
+
+        if (m_transaction_tasks.exists(ids)) begin
+          `uvm_fatal(get_full_name(),
+                     $sformatf("Repeated transaction ID: %0d / sequence ID 0x%0x",
+                               ids.transaction_id, ids.sequence_id))
+        end
+
+        m_transaction_tasks[ids] = jobs;
+        if (jobs[1]) m_pending_pings.write(item);
+        if (jobs[0]) m_pending_alert_rsps.write(item);
+      end
+    join_any
+    disable fork;
+  end join
+endtask
+
+task alert_receiver_driver::drive_req_between_resets();
+  // Drive the init protocol from the receiver side. do_alert_rx_init will exit early if it sees
+  // reset.
+  do_alert_rx_init();
+  if (cfg.in_reset) return;
+
+  // Fetch items to drive and drive them. The first task takes items from the m_receiver_requests
+  // fifo and uses them to populate m_pending_pings and m_pending_alert_rsps. The second two tasks
+  // take (and drive) items from those two fifos.
+  //
+  // All three tasks exit on reset.
+  fork
+    consume_requests_betwen_resets();
+    send_alert_rsps();
+    send_pings();
+  join
+
+  // As a consistency check, make sure that m_pending_pings, m_pending_alert_rsps and
+  // m_transaction_tasks were been cleared by send_alert_rsps and send_pings before they exited.
+  if (m_pending_pings.size())
+    `uvm_error(get_full_name(),
+               $sformatf("m_pending_pings nonempty after reset: %0p", m_pending_pings))
+  if (m_pending_alert_rsps.size())
+    `uvm_error(get_full_name(),
+               $sformatf("m_pending_alert_rsps nonempty after reset: %0p", m_pending_alert_rsps))
+  if (m_transaction_tasks.size())
+    `uvm_error(get_full_name(),
+               $sformatf("m_transaction_tasks nonempty after reset: %0p", m_transaction_tasks))
+
+endtask
+
+function void alert_receiver_driver::report_done(bit is_ping, alert_esc_seq_item item);
+  id_pair_t ids;
+  ids.transaction_id = item.get_transaction_id();
+  ids.sequence_id    = item.get_sequence_id();
+
+  if (!m_transaction_tasks.exists(ids))
+    `uvm_fatal(get_full_name(),
+               $sformatf("Cannot check if item is done: %0s", item.sprint()))
+
+  if (!m_transaction_tasks[ids][is_ping])
+    `uvm_fatal(get_full_name(),
+               $sformatf("Cannot clear unset bit %0s for item in m_transaction_tasks: %0s",
+                         is_ping, item.sprint()))
+  m_transaction_tasks[ids][is_ping] = 0;
+
+  if (~|m_transaction_tasks[ids]) begin
+    // If we had originally got the item with get_next_item, this would be the right place to call
+    // item_done. Since we used get instead (allowing alerts and pings to be driven in parallel), we
+    // just send a response (the original item), which allows the sequence that sent the item to
+    // know driving it is completed.
+    m_transaction_tasks.delete(ids);
+    seq_item_port.put_response(item);
+  end
+endfunction
+
+task alert_receiver_driver::send_pings();
+  alert_esc_seq_item item;
+
+  while(!cfg.in_reset) begin
+    // Clear the item variable (so that we can tell whether the fork below gets an item or sees a
+    // reset)
+    item = null;
+
+    fork : isolation_fork begin
+      fork
+        wait (cfg.in_reset);
+        m_pending_pings.get(item);
+      join_any
+      disable fork;
+    end join
+
+    // If there is an item, send it with send_ping. The task will exit early on reset.
+    if (item != null) begin
+      send_ping(item);
+
+      // Now that the item has been sent, report this to the sequencer (if this was the last job to
+      // do for the item)
+      report_done(1, item);
     end
   end
 
-  `uvm_info(`gfn,
-            $sformatf("finished sending receiver item, ping_send=%0b, alert_rsp=%0b, int_fail=%0b",
-                      req.r_alert_ping_send, req.r_alert_rsp, req.int_err), UVM_HIGH)
-  seq_item_port.put_response(rsp);
-endtask : send_ping
+  // When we get here, we must be in reset. m_pending_pings might be nonempty (if reset was asserted
+  // when there were lots of pending pings). Report all the items done (in a trivial way) before
+  // returning.
+  while(m_pending_pings.try_get(item)) report_done(1, item);
+endtask
 
-task alert_receiver_driver::rsp_alert(alert_esc_seq_item req);
-  bit unset_working_on_alerts;
-  bit exit_delay_fork;
-  int unsigned num_iter = 7;
-  alert_esc_seq_item rsp;
-  unset_working_on_alerts = 0;
-  `uvm_info(`gfn, $sformatf("%m - Item received: \n%0s",req.sprint), UVM_DEBUG)
+task alert_receiver_driver::send_alert_rsps();
+  alert_esc_seq_item item;
+
+  while (!cfg.in_reset) begin
+    // Clear the item variable (so that we can tell whether the fork below gets an item or sees a
+    // reset)
+    item = null;
+
+    fork : isolation_fork begin
+      fork
+        wait (cfg.in_reset);
+        m_pending_alert_rsps.get(item);
+      join_any
+      disable fork;
+    end join
+
+    // If there is an item, send it with send_alert_rsp. The task will exit early on reset.
+    if (item != null) begin
+      send_alert_rsp(item);
+
+      // Now that the item has been sent, report this to the sequencer (if this was the last job to
+      // do for the item)
+      report_done(0, item);
+    end
+  end
+
+  // When we get here, we must be in reset. m_pending_alert_rsps might be nonempty. (This probably
+  // shouldn't actually be possible, but let's not worry too much about it). Report all the items
+  // done (in a trivial way) before returning.
+  while(m_pending_alert_rsps.try_get(item)) report_done(0, item);
+endtask
+
+task alert_receiver_driver::send_ping(alert_esc_seq_item item);
+  `uvm_info(get_full_name(), "Sending ping", UVM_HIGH)
+
+  if (item.int_err) begin
+    `uvm_info(get_full_name(), "Not actually sending ping (because int_err is true)", UVM_HIGH)
+  end else begin
+    drive_alert_ping(item.ping_delay, item.ack_delay, item.ack_stable);
+  end
+endtask
+
+task alert_receiver_driver::send_alert_rsp(alert_esc_seq_item item);
+  `uvm_info(get_full_name(), "Responding to alert", UVM_HIGH)
+
   // If we get here then something should have been pushed onto the alert queue in response to
   // an alert being generated. Wait a short time to allow the alert to propagate through the
   // clocking blocks (which should only take a cycle, but give it a couple more to make sure).
-  // Stop early if we go into reset.
-  fork
-    begin : isolation_fork_1
-      fork
-        wait (cfg.in_reset);
+  // The count of 7 cycles was chosen as an upper bound: an alert should be visible in at most that
+  // time.
+  //
+  // Either way, we stop as soon as the alert propagates through, or if we see a reset.
+  wait_for_alert_propagation(7);
+  if (cfg.in_reset) return;
+
+  // Check that the alert really has arrived (which is a consistency check for the testbench, rather
+  // than a check about the dut).
+  if (cfg.vif.receiver_cb.alert_tx.alert_p !== 1'b1) begin
+    `uvm_fatal(get_full_name(), "alert_p not high, despite an item from the monitor")
+  end
+
+  // Now send an ack with ack_alert. This then waits for the alert to drop, then clears the ack
+  // again.
+  //
+  // The task exits early on reset.
+  ack_alert(item.ack_delay, item.ack_stable);
+endtask
+
+task alert_receiver_driver::wait_for_alert_propagation(int unsigned max_cycles);
+  fork : isolation_fork begin
+    fork
+      wait (cfg.in_reset);
+      fork : isolation_fork begin
+        bit seen_alert;
+
         fork
-          // Wait for num_iter cycles on the slower of the two clocks (by
-          // waiting for both of them in parallel).
-          // 'exit_delay_fork' is used as an escape flag if an alert is detected during the wait
-          repeat (num_iter) begin
-            if (cfg.vif.receiver_cb.alert_tx.alert_p || exit_delay_fork) begin
-              exit_delay_fork = 1;
-              break;
+          repeat (max_cycles) begin
+            if (cfg.vif.receiver_cb.alert_tx.alert_p) begin
+              seen_alert = 1;
             end
+            if (seen_alert) break;
             @(cfg.vif.receiver_cb);
           end
-          repeat (num_iter) begin
-            if (cfg.vif.monitor_cb.alert_tx_final.alert_p || exit_delay_fork) begin
-              exit_delay_fork = 1;
-              break;
+          repeat (max_cycles) begin
+            if (cfg.vif.monitor_cb.alert_tx_final.alert_p) begin
+              seen_alert = 1;
             end
+            if (seen_alert) break;
             @(cfg.vif.monitor_cb);
           end
         join
-      join_any
-      disable fork;
-    end  : isolation_fork_1
-  join
-
-  if (!cfg.in_reset) begin
-    // If we haven't gone into reset, we have an item and have waited a bit for the alert to be
-    // visible. Check that it really has arrived.
-    working_on_alert = 1;
-
-    `DV_CHECK_FATAL(cfg.vif.receiver_cb.alert_tx.alert_p,
-                    "alert_p not high, despite an item in r_alert_rsp_q")
-
-    `uvm_info(`gfn, $sformatf("rsp_alert item (ping_send=%0b, alert_rsp=%0b, int_fail=%0b)",
-                              req.r_alert_ping_send, req.r_alert_rsp, req.int_err), UVM_DEBUG)
-
-    fork
-      begin : isolation_fork_2
-        fork
-          set_ack_pins(req.ack_delay, req.ack_stable);
-          wait (cfg.in_reset);
-        join_any
-        disable fork;
-      end : isolation_fork_2
-    join
-  end // if (!cfg.in_reset)
-
-
-  `uvm_info(`gfn,
-            $sformatf("%0s rsp_alert item (ping_send=%0b, alert_rsp=%0b, int_fail=%0b)",
-                      cfg.in_reset ? "aborting" : "finished",
-                      req.r_alert_ping_send, req.r_alert_rsp, req.int_err),
-            UVM_DEBUG)
-
-  fork
-    begin : isolation_fork_3
-      fork
-        wait (cfg.in_reset);
-        repeat (10) begin
-          if (cfg.vif.receiver_cb.alert_tx.alert_p) begin
-            unset_working_on_alerts = 1;
-            break;
-          end
-          @(cfg.vif.receiver_cb);
-          unset_working_on_alerts = 1;
-        end
-      join_any
-      disable fork;
-    end : isolation_fork_3
-  join
-  if (unset_working_on_alerts)
-    working_on_alert = 0;
-
-  `downcast(rsp, req.clone());
-  rsp.set_id_info(req);
-  seq_item_port.put_response(rsp);
-endtask : rsp_alert
+      end join
+    join_any
+    disable fork;
+  end join
+endtask
 
 task alert_receiver_driver::drive_alert_ping(int unsigned ping_delay,
                                              int unsigned ack_delay,
-                                             int unsigned ack_stable,
-                                             output bit item_not_driven
-                                             );
-  item_not_driven = 0;
-  if (!cfg.use_seq_item_ping_delay) begin
-    ping_delay = $urandom_range(cfg.ping_delay_max, cfg.ping_delay_min);
-  end
-  @(cfg.vif.receiver_cb);
-  // Ping fail and differential signal fail scenarios are not implemented now.
-  // This driver is used for IP (instantiate prim_alert_sender) to finish alert handshake.
-  // The current use-case does not test ping fail and differential signal fail scenarios.
-  // These scenarios are check in prim_alert direct sequences.
-
-  `uvm_info(`gfn, $sformatf("%m - Wait for ping_delay=%0d clock cycles before driving ping",
-                            ping_delay), UVM_DEBUG)
-
-  fork
-    begin : delay_isolation_fork
-      fork
+                                             int unsigned ack_stable);
+  // Wait for ping_delay cycles (which might be quite a while) before sending the ping. There may be
+  // other alerts happening in the meantime, but this task doesn't need to worry about them. Exit
+  // early on reset
+  fork : isolation_fork begin
+    fork
+      wait(cfg.in_reset);
+      begin
         repeat (ping_delay) @(cfg.vif.receiver_cb);
-        begin
-          wait (cfg.vif.receiver_cb.alert_tx.alert_p);
-          item_not_driven = 1;
-        end
-      join_any
-      disable fork;
-    end : delay_isolation_fork
-  join
+        set_ping();
+      end
+    join_any
+    disable fork;
+  end join
+  if (cfg.in_reset) return;
 
-  if (item_not_driven)
-    return; // Printout added in caller task
-
-  `uvm_info(`gfn, "Sending ping", UVM_DEBUG)
-  set_ping();
-
-  fork
-    begin : isolation_fork
-      fork
-        begin : ping_timeout
-          // Finally, hold the driver for handshake_timeout_cycle cycles to give the alert
-          // sender time to respond to the ping.
-          repeat (cfg.handshake_timeout_cycle) @(cfg.vif.receiver_cb);
-        end
-        begin : wait_ping_handshake
-          wait_alert();
-          `uvm_info(`gfn, "PING: alert has happened, setting ack signals", UVM_DEBUG)
-          // If we have sent the ping then the alert we have just seen will be a response to it.
-          // Call the set_ack_pins task to wait a randomised time and then ack the response. If
-          // we haven't sent the ping yet, immediately finish handling the sequence item
-          // instead. Another item will be driven through rsp_alert to respond to the alert
-          // properly.
-          set_ack_pins(ack_delay, ack_stable);
-          `uvm_info(`gfn, $sformatf("%m - Ack finished"), UVM_DEBUG)
-        end
-      join_any
-      disable fork;
-    end
-  join
+  // After waiting (possibly for a long time), we finally sent a ping. The alert sender should
+  // respond with an alert, which we ack here, treating it as the ping response.
+  //
+  // If the sender decided to send an alert at the same time as we sent the ping then we'll treat
+  // that alert as a ping response. But the sender will then respond to the ping with an alert that
+  // we'll treat as a genuine alert: the end result will be that we and the sender agree on the set
+  // of things that happened (one ping response and one genuine alert).
+  ack_alert(ack_delay, ack_stable);
 endtask
 
-task alert_receiver_driver::set_ack_pins(int unsigned ack_delay,
-                                         int unsigned ack_stable);
+task alert_receiver_driver::ack_alert(int unsigned ack_delay, int unsigned ack_stable);
   if (!cfg.use_seq_item_ack_delay) begin
     ack_delay = $urandom_range(cfg.ack_delay_max, cfg.ack_delay_min);
   end
@@ -339,34 +457,60 @@ task alert_receiver_driver::set_ack_pins(int unsigned ack_delay,
     ack_stable = cfg.ack_stable_min;
   end
 
-  @(cfg.vif.receiver_cb);
-  repeat (ack_delay) @(cfg.vif.receiver_cb);
-  set_ack();
-  fork
-    begin : isolation_fork
-      fork
-        begin : ack_timeout
-          repeat (cfg.handshake_timeout_cycle) @(cfg.vif.sender_cb);
-        end
-        begin : wait_ack_handshake
-          while (cfg.vif.receiver_cb.alert_tx.alert_p !== 1'b0) @(cfg.vif.receiver_cb);
-          repeat (ack_stable) @(cfg.vif.receiver_cb);
-          reset_ack();
-        end
-      join_any
-      disable fork;
-    end : isolation_fork
-  join
-endtask : set_ack_pins
+  m_ack_semaphore.get();
 
-task alert_receiver_driver::set_ack();
-  cfg.vif.receiver_cb.alert_rx_int.ack_p <= 1'b1;
-  cfg.vif.receiver_cb.alert_rx_int.ack_n <= 1'b0;
+  // Wait for the alert to appear (up to cfg.handshake_timeout_cycle cycles)
+  fork : isolation_fork1 begin
+    fork
+      wait(cfg.in_reset);
+      repeat(cfg.handshake_timeout_cycle) @(cfg.vif.receiver_cb);
+      wait(cfg.vif.receiver_cb.alert_tx.alert_p);
+    join_any
+    disable fork;
+  end join
+
+  // If there has been a reset or no alert came out, there is nothing more to do.
+  if (cfg.in_reset || (cfg.vif.receiver_cb.alert_tx.alert_p !== 1'b1)) begin
+    m_ack_semaphore.put();
+    return;
+  end
+
+  // Now wait a short time and set the ack (dropping out early on reset)
+  fork : isolation_fork2 begin
+    fork
+      wait(cfg.in_reset);
+      begin
+        repeat (ack_delay + 1) @(cfg.vif.receiver_cb);
+        set_ack(1'b1);
+      end
+    join_any
+    disable fork;
+  end join
+  if (cfg.in_reset) begin
+    m_ack_semaphore.put();
+    return;
+  end
+
+  // Finally, wait for the alert to be cleared again (up to cfg.handshake_timeout_cycle cycles)
+  fork : isolation_fork3 begin
+    fork
+      wait(cfg.in_reset);
+      repeat(cfg.handshake_timeout_cycle) @(cfg.vif.receiver_cb);
+      begin
+        wait(!cfg.vif.receiver_cb.alert_tx.alert_p);
+        repeat (ack_stable) @(cfg.vif.receiver_cb);
+        set_ack(1'b0);
+      end
+    join_any
+    disable fork;
+  end join
+
+  m_ack_semaphore.put();
 endtask
 
-task alert_receiver_driver::reset_ack();
-  cfg.vif.receiver_cb.alert_rx_int.ack_p <= 1'b0;
-  cfg.vif.receiver_cb.alert_rx_int.ack_n <= 1'b1;
+task alert_receiver_driver::set_ack(bit asserted);
+  cfg.vif.receiver_cb.alert_rx_int.ack_p <= asserted;
+  cfg.vif.receiver_cb.alert_rx_int.ack_n <= !asserted;
 endtask
 
 task alert_receiver_driver::set_ping();
@@ -374,71 +518,27 @@ task alert_receiver_driver::set_ping();
   cfg.vif.receiver_cb.alert_rx_int.ping_n <= !cfg.vif.alert_rx.ping_n;
 endtask
 
-task alert_receiver_driver::wait_alert();
-  while (cfg.vif.receiver_cb.alert_tx.alert_p !== 1'b1) @(cfg.vif.receiver_cb);
-endtask : wait_alert
-
 task alert_receiver_driver::reset_ping();
   cfg.vif.receiver_cb.alert_rx_int.ping_p <= 1'b0;
   cfg.vif.receiver_cb.alert_rx_int.ping_n <= 1'b1;
 endtask
 
-task alert_receiver_driver::do_reset();
-  cfg.vif.alert_rx_int.ping_p <= 1'b0;
-  cfg.vif.alert_rx_int.ping_n <= 1'b1;
-  cfg.vif.alert_rx_int.ack_p <= 1'b0;
-  cfg.vif.alert_rx_int.ack_n <= 1'b1;
-endtask
-
-function void alert_receiver_driver::clear_item_queues();
-  fork
-    begin
-      alert_esc_seq_item rsp, req;
-      int unsigned size;
-
-      // There may be a race condition if we call this task directly on reset
-      // since it can clear its queues here but then in the next delta it may
-      // receive a new item
-      // Wait 4 clock cycles here until clearing to ensure any potential item on
-      // the edge is still cleared
-      // The 4 ticks is because the signals are observed via a clocking block
-      // which looks at a delayed signal by 2 cycles, plus an extra cycle in the
-      // monitor before sending the alert_rsp item.
-      repeat (4)
-        @(cfg.vif.receiver_cb);
-
-
-      `uvm_info(`gfn, $sformatf("%m Clearing send and response queues due to reset"), UVM_DEBUG)
-      `uvm_info(`gfn, $sformatf({"%m - Clearing queues: r_alert_ping_send_q.size=%0d | ",
-                                 "r_alert_rsp_q.size()=%0d"}, r_alert_ping_send_q.size,
-                                r_alert_rsp_q.size()), UVM_DEBUG)
-      size = r_alert_rsp_q.size();
-      for(int i=0 ; i < size; i++) begin
-        req = r_alert_rsp_q.pop_front();
-        `downcast(rsp, req.clone());
-        rsp.set_id_info(req);
-        seq_item_port.put_response(rsp);
-      end
-
-      size = r_alert_ping_send_q.size();
-      for(int i=0 ; i < size; i++) begin
-        req = r_alert_ping_send_q.pop_front();
-        `downcast(rsp, req.clone());
-        rsp.set_id_info(req);
-        seq_item_port.put_response(rsp);
-      end
-    end // fork begin
-  join_none
-endfunction
-
 task alert_receiver_driver::do_alert_rx_init();
-  `DV_SPINWAIT_EXIT(
-      // Drive alert init signal integrity error handshake.
-      repeat ($urandom_range(1, 10)) @(cfg.vif.receiver_cb);
-      cfg.vif.alert_rx_int.ack_n <= 1'b0;
-      wait (cfg.vif.receiver_cb.alert_tx.alert_p == cfg.vif.receiver_cb.alert_tx.alert_n);
-      repeat ($urandom_range(1, 10)) @(cfg.vif.receiver_cb);
-      cfg.vif.alert_rx_int.ack_n  <= 1'b1;
-      wait (cfg.vif.receiver_cb.alert_tx.alert_p != cfg.vif.receiver_cb.alert_tx.alert_n);,
-      wait (cfg.in_reset);)
+  fork : isolation_fork begin
+    fork
+      wait(cfg.in_reset);
+      begin
+        repeat ($urandom_range(1, 10)) @(cfg.vif.receiver_cb);
+        cfg.vif.alert_rx_int.ack_p <= 1'b0;
+        cfg.vif.alert_rx_int.ack_n <= 1'b0;
+
+        wait (cfg.vif.receiver_cb.alert_tx.alert_p == cfg.vif.receiver_cb.alert_tx.alert_n);
+        repeat ($urandom_range(1, 10)) @(cfg.vif.receiver_cb);
+        cfg.vif.alert_rx_int.ack_n <= 1'b1;
+
+        wait (cfg.vif.receiver_cb.alert_tx.alert_p != cfg.vif.receiver_cb.alert_tx.alert_n);
+      end
+    join_any
+    disable fork;
+  end join
 endtask

--- a/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
@@ -10,12 +10,16 @@ class alert_sender_driver extends alert_base_driver;
 
   `uvm_component_utils(alert_sender_driver)
 
+  // An event that can be triggered (by functions as well as tasks). This is monitored by
+  // maintain_alert_drive, which will call cfg.vif.force_alert with m_desired_alert_val.
+  uvm_event m_update_alert_val;
+  bit [1:0] m_desired_alert_val;
+
   extern function new (string name, uvm_component parent);
 
-  // Monitor resets and reset all driven signals when a reset occurs.
-  //
-  // An implementation of dv_base_driver::reset_signals.
-  extern virtual task reset_signals();
+  // This function gets called by dv_base_driver::reset_signals when the interface enters reset.
+  // Clear any alert signal.
+  extern virtual task on_enter_reset();
 
   // Drive sequence items for alerts and pings that have been retrieved by get_req (and therefore
   // have started) and have been pushed to the various queues. This also does the alert init
@@ -62,8 +66,9 @@ class alert_sender_driver extends alert_base_driver;
   // Set the alert pins to be (alert_p=1; alert_n=0) if enabled=1 and (alert_p=0; alert_n=1)
   // otherwise.
   //
-  // This task takes zero time (but needs to be a task because it uses non-blocking assignment)
-  extern local task set_alert(bit enabled);
+  // Because the alert signals are set through a clocking block (using cfg.vif.force_alert()), this
+  // works by setting m_desired_alert_val and triggering the m_update_alert_val event.
+  extern local function void set_alert(bit enabled);
 
   // Set the alert pins to 11 or 00 (depending on the high argument).
   //
@@ -84,62 +89,53 @@ class alert_sender_driver extends alert_base_driver;
   // This task exits early on reset or if cfg.en_alert_lpg is asserted (in which case, the receiver
   // won't reply to the init)
   extern local task do_alert_tx_init();
+
+  // This task runs forever, calling cfg.vif.set_alert() each time the m_update_alert_val event is
+  // triggered.
+  extern local task maintain_alert_drive();
 endclass : alert_sender_driver
 
 function alert_sender_driver::new (string name, uvm_component parent);
   super.new(name, parent);
+  m_update_alert_val = new("m_update_alert_val");
 endfunction : new
 
-task alert_sender_driver::reset_signals();
+task alert_sender_driver::on_enter_reset();
   set_alert(1'b0);
-  forever begin
-    wait(!cfg.in_reset);
-    wait(cfg.in_reset);
-    set_alert(1'b0);
-  end
 endtask
 
 task alert_sender_driver::drive_req();
-  forever begin
-    // Wait until we are out of reset. Until that happens, respond instantly to any sequence items
-    // that come in.
-    while (cfg.in_reset) begin
-      fork : isolation_fork begin
-        alert_esc_seq_item item;
-        fork
-          wait (!cfg.in_reset);
-          begin
-            wait(s_alert_send_q.size());
-            item = s_alert_send_q.pop_front();
-          end
-          begin
-            wait(s_alert_ping_rsp_q.size());
-            item = s_alert_ping_rsp_q.pop_front();
-          end
-        join_any
-        disable fork;
-        if (item != null) begin
-          alert_esc_seq_item rsp;
-          `downcast(rsp, item.clone());
-          rsp.set_id_info(item);
-          seq_item_port.put_response(rsp);
-        end
-      end join
-    end
-
-    while(!cfg.in_reset) begin
-      bit en_alert_lpg = cfg.en_alert_lpg;
-
-      // If LPG is not enabled, initialise the alert interface
-      if (!en_alert_lpg) begin
-        do_alert_tx_init();
+  fork
+    maintain_alert_drive();
+    forever begin
+      // Wait until we are out of reset. Until that happens, respond instantly to any sequence items
+      // that come in.
+      while (cfg.in_reset) begin
+        fork : isolation_fork begin
+          alert_esc_seq_item item;
+          fork
+            wait(!cfg.in_reset);
+            m_sender_requests.get(item);
+          join_any
+          disable fork;
+          if (item != null) seq_item_port.put_response(item);
+        end join
       end
 
-      // Drive any requests that we see. The task will exit on reset or if the LPG flag changes,
-      // letting us initialise the alert interface (if LPG is disabled) and continue.
-      drive_reqs_with_lpg_mode(en_alert_lpg);
+      while(!cfg.in_reset) begin
+        bit en_alert_lpg = cfg.en_alert_lpg;
+
+        // If LPG is not enabled, initialise the alert interface
+        if (!en_alert_lpg) begin
+          do_alert_tx_init();
+        end
+
+        // Drive any requests that we see. The task will exit on reset or if the LPG flag changes,
+        // letting us initialise the alert interface (if LPG is disabled) and continue.
+        drive_reqs_with_lpg_mode(en_alert_lpg);
+      end
     end
-  end
+  join
 endtask
 
 task alert_sender_driver::drive_reqs_with_lpg_mode(bit en_alert_lpg);
@@ -150,30 +146,22 @@ task alert_sender_driver::drive_reqs_with_lpg_mode(bit en_alert_lpg);
     // Pick an item to drive, but keep track of resets and any change to the LPG flag.
     fork : isolation_fork begin
       fork
-        wait (cfg.en_alert_lpg != en_alert_lpg);
-        wait (cfg.in_reset);
-        begin
-          wait(s_alert_send_q.size());
-          item = s_alert_send_q.pop_front();
-          is_alert = 1;
-        end
-        begin
-          wait(s_alert_ping_rsp_q.size());
-          item = s_alert_ping_rsp_q.pop_front();
-          is_ping = 1;
-        end
+        wait(cfg.en_alert_lpg != en_alert_lpg);
+        wait(cfg.in_reset);
+        m_sender_requests.get(item);
       join_any
       disable fork;
     end join
 
-    // Handle the alert or ping response. If there is no item, there has been a reset or the LPG
-    // flag has changed. Return from the task.
-    //
-    // The send_alert and send_ping_rsp tasks both exit early when they see a reset, but ignore any
-    // further changes to en_alert_lpg.
-    if (is_alert) send_item(1'b0, item);
-    else if (is_ping) send_item(1'b1, item);
-    else return;
+    // If there is no item, there has been a reset or the LPG flag has changed. Return from the
+    // task.
+    if (item == null) return;
+
+    // Handle the alert request or ping response. If the item requests both, send the ping response
+    // first and then the real alert.
+    if (item.s_alert_ping_rsp) send_item(1'b1, item);
+    if (item.s_alert_send) send_item(1'b0, item);
+    seq_item_port.put_response(item);
   end
 endtask
 
@@ -196,7 +184,6 @@ task alert_sender_driver::send_item(bit is_ping_rsp, alert_esc_seq_item item);
     join_any
     disable fork;
   end join
-
   `uvm_info(`gfn,
             $sformatf("finished sending sender item, alert_send=%0b, ping_rsp=%0b, int_err=%0b",
                       item.s_alert_send, item.s_alert_ping_rsp, item.int_err), UVM_HIGH)
@@ -257,10 +244,10 @@ task alert_sender_driver::random_drive_int_fail(int int_err_cyc);
   end
 endtask
 
-task alert_sender_driver::set_alert(bit enabled);
-  cfg.vif.sender_cb.alert_tx_int.alert_p <= enabled;
-  cfg.vif.sender_cb.alert_tx_int.alert_n <= !enabled;
-endtask
+function void alert_sender_driver::set_alert(bit enabled);
+  m_desired_alert_val = {enabled, !enabled};
+  m_update_alert_val.trigger();
+endfunction
 
 task alert_sender_driver::drive_invalid_alert(bit high);
   cfg.vif.sender_cb.alert_tx_int.alert_p <= high;
@@ -284,4 +271,12 @@ task alert_sender_driver::do_alert_tx_init();
     join_any
     disable fork;
   end join
+endtask
+
+task alert_sender_driver::maintain_alert_drive();
+  forever begin
+    m_update_alert_val.wait_ptrigger();
+    cfg.vif.force_alert(m_desired_alert_val[1], m_desired_alert_val[0]);
+    m_update_alert_val.reset();
+  end
 endtask

--- a/hw/dv/sv/alert_esc_agent/esc_receiver_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_receiver_driver.sv
@@ -15,11 +15,6 @@ class esc_receiver_driver extends dv_base_driver#(alert_esc_seq_item, alert_esc_
 
   extern function new (string name, uvm_component parent);
 
-  // This task runs forever calls do_reset at the start of every reset.
-  //
-  // Overridden from dv_base_driver.
-  extern virtual task reset_signals();
-
   // This task runs forever. It works by running rsp_escalator (which consumes and drives items from
   // seq_item_port) and esc_ping_detector (which responds to ping requests).
   //
@@ -56,22 +51,13 @@ class esc_receiver_driver extends dv_base_driver#(alert_esc_seq_item, alert_esc_
   extern virtual task wait_esc_complete();
   extern virtual task wait_esc();
   // Set the values driven through resp_p / resp_n to 0/1 and clear the is_ping flag
-  extern virtual task do_reset();
+  extern task on_enter_reset();
 
 endclass : esc_receiver_driver
 
 function esc_receiver_driver::new (string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
-
-task esc_receiver_driver::reset_signals();
-  do_reset();
-  forever begin
-    wait (cfg.in_reset);
-    do_reset();
-    wait (!cfg.in_reset);
-  end
-endtask : reset_signals
 
 task esc_receiver_driver::get_and_drive();
   fork
@@ -229,8 +215,8 @@ task esc_receiver_driver::wait_esc();
   while (cfg.vif.esc_tx.esc_p === 1'b0 && cfg.vif.esc_tx.esc_n === 1'b1) @(cfg.vif.receiver_cb);
 endtask : wait_esc
 
-task esc_receiver_driver::do_reset();
+task esc_receiver_driver::on_enter_reset();
   cfg.vif.esc_rx_int.resp_p <= 1'b0;
   cfg.vif.esc_rx_int.resp_n <= 1'b1;
   is_ping = 0;
-endtask : do_reset
+endtask : on_enter_reset

--- a/hw/dv/sv/alert_esc_agent/esc_sender_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_sender_driver.sv
@@ -8,24 +8,13 @@ class esc_sender_driver extends dv_base_driver#(alert_esc_seq_item, alert_esc_ag
   `uvm_component_utils(esc_sender_driver)
 
   extern function new (string name, uvm_component parent);
-  extern virtual task reset_signals();
   extern virtual task get_and_drive();
-
-  extern local task reset_esc();
+  extern virtual task on_enter_reset();
 endclass : esc_sender_driver
 
 function esc_sender_driver::new (string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
-
-task esc_sender_driver::reset_signals();
-  wait(cfg.vif.rst_n !== 1'b1);
-  forever begin
-    reset_esc();
-    wait (!cfg.in_reset);
-    wait (cfg.in_reset);
-  end
-endtask : reset_signals
 
 task esc_sender_driver::get_and_drive();
   // LC_CTRL uses virtual interface to directly drive escalation requests.
@@ -34,7 +23,7 @@ task esc_sender_driver::get_and_drive();
   wait (!cfg.in_reset);
 endtask : get_and_drive
 
-task esc_sender_driver::reset_esc();
+task esc_sender_driver::on_enter_reset();
   cfg.vif.esc_tx_int.esc_p <= 1'b0;
   cfg.vif.esc_tx_int.esc_n <= 1'b1;
-endtask : reset_esc
+endtask

--- a/hw/dv/sv/csrng_agent/csrng_device_driver.sv
+++ b/hw/dv/sv/csrng_agent/csrng_device_driver.sv
@@ -9,7 +9,7 @@ class csrng_device_driver extends csrng_driver;
   uint   cmd_ack_dly;
   bit    rsp_sts;
 
-  virtual task reset_signals();
+  task on_enter_reset();
     cfg.vif.cmd_rsp_int.csrng_rsp_ack <= 1'b0;
     cfg.vif.cmd_rsp_int.csrng_rsp_sts <= CMD_STS_SUCCESS;
   endtask
@@ -55,7 +55,7 @@ class csrng_device_driver extends csrng_driver;
         seq_item_port.item_done(rsp);
       end
 
-      // Write ack bit again in case the race condition with `reset_signals`.
+      // Write ack bit again to avoid a race with reset tracking
       if (cfg.in_reset) cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_ack <= 1'b0;
 
     end

--- a/hw/dv/sv/csrng_agent/csrng_host_driver.sv
+++ b/hw/dv/sv/csrng_agent/csrng_host_driver.sv
@@ -9,11 +9,6 @@ class csrng_host_driver extends csrng_driver;
   // Break down the data and send it to push_pull_host_driver through its sequencer
   csrng_sequencer   m_csrng_sequencer;
 
-  // reset signals
-  virtual task reset_signals();
-//    `uvm_fatal(`gtn, "FIXME")
-  endtask
-
   // drive trans received from sequencer
   virtual task get_and_drive();
     forever begin

--- a/hw/dv/sv/dv_lib/dv_base_driver.sv
+++ b/hw/dv/sv/dv_lib/dv_base_driver.sv
@@ -4,6 +4,15 @@
 
 // A base class for a driver. This drives sequence items of type ITEM_T. If the subclass is designed
 // to do so, it responds with items of type RSP_ITEM_T.
+//
+// NOTE: This class would make more sense as an abstract base class (with a pure virtual
+//       implementation of get_and_drive). Unfortunately, this isn't possible at the moment because
+//       dv_base_agent ends up needing to instantiate a uvm_driver instance unless parameters are
+//       overridden. This would be reasonable except that uvm_driver::create is not implemented in
+//       UVM 1.2 (the version that OpenTitan currently depends on).
+//
+//       If we bump the UVM version past 1800.2-2020, we can switch this over to an abstract base
+//       class.
 
 class dv_base_driver #(type ITEM_T     = uvm_sequence_item,
                        type CFG_T      = dv_base_agent_cfg,
@@ -14,7 +23,6 @@ class dv_base_driver #(type ITEM_T     = uvm_sequence_item,
                                               .CFG_T      (CFG_T),
                                               .RSP_ITEM_T (RSP_ITEM_T)))
 
-  bit   under_reset;
   CFG_T cfg;
 
   extern function new (string name, uvm_component parent);
@@ -23,13 +31,28 @@ class dv_base_driver #(type ITEM_T     = uvm_sequence_item,
   // Subclasses might not need to implement run_phase directly.
   extern task run_phase(uvm_phase phase);
 
-  // The reset_signals task should be implemented in any subclass and is responsible for monitoring
-  // reset on the interface, then resetting the driven signals when a reset happens.
+  // A task that runs forever, monitoring the cfg.in_reset flag and calling on_enter_reset when it
+  // becomes true. Subclasses shouldn't normally need to override this.
   extern virtual task reset_signals();
 
   // The get_and_drive task should be implemented in any subclass. It must repeatedly call
   // get_next_item to consume items from the sequencer and, driving each.
+  //
+  // NOTE: Any implementation must implement this or fail at runtime. See note above for why this
+  //       can't be enforced at build time.
   extern virtual task get_and_drive();
+
+  // A task that is run at the start of any reset. It can be implemented by any subclass to clear
+  // any driven signals back to their "reset value".
+  //
+  // Note that this task should not consume any simulation time: it is a task to allow it to
+  // interact properly with clocking blocks.
+  extern virtual task on_enter_reset();
+
+  // A function that is run at the end of any reset. It may be implemented by any subclass and gives
+  // the class an opportunity to set up values before the start of a run, but without a race
+  // condition at the start of the reset.
+  extern virtual function void on_leave_reset();
 endclass
 
 function dv_base_driver::new (string name, uvm_component parent);
@@ -45,9 +68,24 @@ task dv_base_driver::run_phase(uvm_phase phase);
 endtask
 
 task dv_base_driver::reset_signals();
-  // Empty - to be populated in child class
+  forever begin
+    `uvm_info(get_full_name(), "Driver entering reset", UVM_HIGH)
+    on_enter_reset();
+    wait(!cfg.in_reset);
+    `uvm_info(get_full_name(), "Driver leaving reset", UVM_HIGH)
+    on_leave_reset();
+    wait(cfg.in_reset);
+  end
 endtask
 
 task dv_base_driver::get_and_drive();
-  // Empty - to be populated in child class
+  `uvm_fatal(get_full_name(), "This task must be implemented by base classes.")
 endtask
+
+task dv_base_driver::on_enter_reset();
+  // The default behaviour of this task is to do nothing
+endtask
+
+function void dv_base_driver::on_leave_reset();
+  // The default behaviour of this function is to do nothing
+endfunction

--- a/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_device_driver.sv
+++ b/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_device_driver.sv
@@ -10,15 +10,14 @@ class entropy_src_xht_device_driver extends dv_base_driver #(
   `uvm_component_utils(entropy_src_xht_device_driver)
   `uvm_component_new
 
-  virtual task reset_signals();
-    forever begin
-      @(negedge cfg.vif.rst_n);
-      `uvm_info(`gfn, "Driver is under reset", UVM_DEBUG)
-      cfg.vif.xht_cb.rsp <= ENTROPY_SRC_XHT_META_RSP_DEFAULT;
-      @(posedge cfg.vif.rst_n);
-      `uvm_info(`gfn, "Driver is out of reset", UVM_DEBUG)
-    end
+  task on_enter_reset();
+    `uvm_info(`gfn, "Driver is under reset", UVM_DEBUG)
+    cfg.vif.xht_cb.rsp <= ENTROPY_SRC_XHT_META_RSP_DEFAULT;
   endtask
+
+  function void on_leave_reset();
+    `uvm_info(`gfn, "Driver is out of reset", UVM_DEBUG)
+  endfunction
 
   virtual task get_and_drive();
     forever begin

--- a/hw/dv/sv/flash_phy_prim_agent/flash_phy_prim_driver.sv
+++ b/hw/dv/sv/flash_phy_prim_agent/flash_phy_prim_driver.sv
@@ -11,10 +11,6 @@ class flash_phy_prim_driver extends dv_base_driver #(.ITEM_T(flash_phy_prim_item
 
   `uvm_component_new
 
-  // reset signals
-  virtual task reset_signals();
-  endtask
-
   // drive trans received from sequencer
   virtual task get_and_drive();
     forever begin

--- a/hw/dv/sv/i2c_agent/i2c_driver.sv
+++ b/hw/dv/sv/i2c_agent/i2c_driver.sv
@@ -15,15 +15,14 @@ class i2c_driver extends dv_base_driver #(i2c_item, i2c_agent_cfg);
   // get an array with unique read data
   constraint rd_data_c { unique { rd_data }; }
 
-  virtual task reset_signals();
-    forever begin
-      @(negedge cfg.vif.rst_ni);
-      `uvm_info(`gfn, "\ndriver in reset progress", UVM_DEBUG)
-      release_bus();
-      @(posedge cfg.vif.rst_ni);
-      `uvm_info(`gfn, "\ndriver out of reset", UVM_DEBUG)
-    end
-  endtask : reset_signals
+  task on_enter_reset();
+    `uvm_info(`gfn, "\ndriver in reset progress", UVM_DEBUG)
+    release_bus();
+  endtask
+
+  function void on_leave_reset();
+    `uvm_info(`gfn, "\ndriver out of reset", UVM_DEBUG)
+  endfunction
 
   virtual task run_phase(uvm_phase phase);
     fork
@@ -215,15 +214,15 @@ class i2c_driver extends dv_base_driver #(i2c_item, i2c_agent_cfg);
 
   virtual task process_reset();
     @(negedge cfg.vif.rst_ni);
-    release_bus();
+    on_enter_reset();
     `uvm_info(`gfn, "\n  driver is reset", UVM_DEBUG)
   endtask : process_reset
 
-  virtual task release_bus();
+  function void release_bus();
     `uvm_info(`gfn, "Driver released the bus", UVM_DEBUG)
     cfg.vif.scl_o = 1'b1;
     cfg.vif.sda_o = 1'b1;
-  endtask : release_bus
+  endfunction : release_bus
 
   task drive_scl();
     // This timeout is extremely long since read transactions will stretch

--- a/hw/dv/sv/jtag_agent/jtag_driver.sv
+++ b/hw/dv/sv/jtag_agent/jtag_driver.sv
@@ -37,8 +37,7 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
     selected_ir_len = 0;
   endfunction
 
-  // do reset signals (function)
-  virtual function void do_reset_signals();
+  task on_enter_reset();
     `DV_CHECK_FATAL(cfg.if_mode == Host, "Only Host mode is supported", "jtag_driver")
 
     reset_internal_state();
@@ -46,7 +45,7 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
     cfg.vif.tck_en <= 1'b0;
     cfg.vif._tms_internal <= 1'b0;
     cfg.vif._tdi_internal <= 1'b0;
-  endfunction
+  endtask
 
   // Turn on TCK in the jtag_if
   //
@@ -79,16 +78,11 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
     end join_none
   endtask
 
-  virtual task reset_signals();
+  // Overriding the task from dv_base_driver. That tracks cfg.in_reset (which, in turn, follows
+  // cfg.vif.trst_n), but we also want to trigger a reset when jtag_if_connected is triggered.
+  task reset_signals();
     fork
-      begin
-        do_reset_signals();
-        forever begin
-          @(negedge cfg.vif.trst_n);
-          do_reset_signals();
-          @(posedge cfg.vif.trst_n);
-        end
-      end
+      super.reset_signals();
       forever begin
         cfg.jtag_if_connected.wait_trigger();
         reset_internal_state();

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_driver.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_driver.sv
@@ -12,21 +12,28 @@ class jtag_riscv_driver extends dv_base_driver #(jtag_riscv_item, jtag_riscv_age
     super.new(name, parent);
   endfunction
 
-  virtual task reset_signals();
-    forever begin
-      wait (cfg.in_reset == 1);
-      `uvm_info(`gfn, "reset_signals: cfg.in_reset=1'b1", UVM_MEDIUM)
-
-      do_hard_reset = 1;
-      // Assert JTAG TRST
-      // This clears the DMI Request and Response FIFOs.
-      cfg.m_jtag_agent_cfg.vif.do_trst_n(2);
-      cfg.rv_dm_activated = 0;
-
-      wait (cfg.in_reset == 0);
-      `uvm_info(`gfn, "reset_signals: cfg.in_reset=1'b0", UVM_MEDIUM)
-    end
+  task reset_signals();
+    fork
+      super.reset_signals();
+      forever begin
+        wait(cfg.in_reset);
+        // Assert JTAG TRST
+        // This clears the DMI Request and Response FIFOs.
+        cfg.m_jtag_agent_cfg.vif.do_trst_n(2);
+        wait(!cfg.in_reset);
+      end
+    join
   endtask
+
+  task on_enter_reset();
+    `uvm_info(`gfn, "on_enter_reset: cfg.in_reset=1'b1", UVM_MEDIUM)
+    do_hard_reset = 1;
+    cfg.rv_dm_activated = 0;
+  endtask
+
+  function void on_leave_reset();
+    `uvm_info(`gfn, "on_leave_reset: cfg.in_reset=1'b0", UVM_MEDIUM)
+  endfunction
 
   // drive trans received from sequencer
   virtual task get_and_drive();

--- a/hw/dv/sv/key_sideload_agent/key_sideload_driver.sv
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_driver.sv
@@ -15,8 +15,7 @@ class key_sideload_driver#(
     super.new(name, parent);
   endfunction
 
-  // reset signals
-  virtual task reset_signals();
+  task on_enter_reset();
     cfg.vif.sideload_key.valid = 0;
     cfg.vif.sideload_key.key[0] = 'x;
     cfg.vif.sideload_key.key[1] = 'x;

--- a/hw/dv/sv/kmac_app_agent/kmac_app_device_driver.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_device_driver.sv
@@ -6,9 +6,7 @@ class kmac_app_device_driver extends kmac_app_driver;
   `uvm_component_utils(kmac_app_device_driver)
   `uvm_component_new
 
-
-  // reset signals
-  virtual task reset_signals();
+  task on_enter_reset();
     invalidate_signals();
   endtask
 

--- a/hw/dv/sv/kmac_app_agent/kmac_app_host_driver.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_host_driver.sv
@@ -6,9 +6,6 @@ class kmac_app_host_driver extends kmac_app_driver;
   `uvm_component_utils(kmac_app_host_driver)
   `uvm_component_new
 
-  virtual task reset_signals();
-  endtask
-
   virtual task get_and_drive();
   endtask
 

--- a/hw/dv/sv/pattgen_agent/pattgen_driver.sv
+++ b/hw/dv/sv/pattgen_agent/pattgen_driver.sv
@@ -6,18 +6,13 @@ class pattgen_driver extends dv_base_driver #(pattgen_item, pattgen_agent_cfg);
   `uvm_component_utils(pattgen_driver)
   `uvm_component_new
 
-  virtual task reset_signals();
-    forever begin
-      @(negedge cfg.vif.rst_ni);
-      `uvm_info(`gfn, "\ndriver in reset progress", UVM_DEBUG)
-      @(posedge cfg.vif.rst_ni);
-      `uvm_info(`gfn, "\ndriver out of reset", UVM_DEBUG)
-    end
-  endtask : reset_signals
-
   virtual task get_and_drive();
     @(posedge cfg.vif.rst_ni);
     // pattgen does not require responses from pattgen_agent thus this task is kept to a minimum
   endtask : get_and_drive
+
+  virtual task on_enter_reset();
+    // pattgen does not require responses from pattgen_agent thus this task is kept to a minimum
+  endtask
 
 endclass : pattgen_driver

--- a/hw/dv/sv/push_pull_agent/push_pull_driver_lib.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_driver_lib.sv
@@ -51,15 +51,8 @@ class push_pull_driver #(
     sub_driver.cfg = cfg;
   endfunction
 
-  virtual task reset_signals();
+  virtual task on_enter_reset();
     sub_driver.reset_signals();
-    forever begin
-      @(negedge cfg.vif.rst_n);
-      `uvm_info(`gfn, "Driver is under reset", UVM_HIGH)
-      sub_driver.reset_signals();
-      @(posedge cfg.vif.rst_n);
-      `uvm_info(`gfn, "Driver is out of reset", UVM_HIGH)
-    end
   endtask
 
   // Drive trans received from sequencer.

--- a/hw/dv/sv/rng_agent/rng_driver.sv
+++ b/hw/dv/sv/rng_agent/rng_driver.sv
@@ -13,10 +13,6 @@ class rng_driver extends dv_base_driver #(.ITEM_T(rng_item),
 
   `uvm_component_new
 
-  // reset signals
-  virtual task reset_signals();
-  endtask
-
   // drive outputs based on inputs
   virtual task get_and_drive();
     forever begin

--- a/hw/dv/sv/spi_agent/spi_device_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_device_driver.sv
@@ -24,16 +24,8 @@ class spi_device_driver extends spi_driver;
 
   bit [CSB_WIDTH-1:0] active_csb = 0;
 
-  virtual task reset_signals();
-    forever begin
-      @(negedge cfg.vif.rst_n);
-      `uvm_info(`gfn, "\n  dev_drv: in reset progress", UVM_DEBUG)
-      under_reset = 1'b1;
-      cfg.vif.sio_out = 'z;
-      @(posedge cfg.vif.rst_n);
-      under_reset = 1'b0;
-      `uvm_info(`gfn, "\n  dev_drv: out of reset", UVM_DEBUG)
-    end
+  task on_enter_reset();
+    cfg.vif.sio_out = 'z;
   endtask
 
   virtual task get_and_drive();
@@ -52,7 +44,7 @@ class spi_device_driver extends spi_driver;
       // it filled out.
       rsp.payload_q.delete();
       `uvm_info(`gfn, $sformatf("Received item - %s",req.sprint), UVM_DEBUG)
-      wait (!under_reset && !cfg.vif.csb[active_csb]);
+      wait (!cfg.in_reset && !cfg.vif.csb[active_csb]);
       fork
         begin: iso_fork
           fork

--- a/hw/dv/sv/spi_agent/spi_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_driver.sv
@@ -4,14 +4,7 @@
 
 class spi_driver extends dv_base_driver #(spi_item, spi_agent_cfg);
   `uvm_component_utils(spi_driver)
-
-  bit under_reset;
-
   `uvm_component_new
-
-  virtual task reset_signals();
-    `uvm_fatal(`gfn, "this is implemented as pure virtual task - please extend")
-  endtask
 
   virtual task get_and_drive();
     `uvm_fatal(`gfn, "this is implemented as pure virtual task - please extend")

--- a/hw/dv/sv/spi_agent/spi_host_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_host_driver.sv
@@ -16,20 +16,12 @@ class spi_host_driver extends spi_driver;
     join
   endtask
 
-  // Resets signals
-  virtual task reset_signals();
-    forever begin
-      @(negedge cfg.vif.rst_n or negedge cfg.vif.disconnected);
-      if (cfg.vif.disconnected) continue;
-      under_reset = 1'b1;
-      active_csb  = 1'b0;
-      cfg.vif.sck <= cfg.sck_polarity[0];
-      cfg.vif.sio_out <= 'x;
-      cfg.vif.csb <= '1;
-      sck_pulses = 0;
-      @(posedge cfg.vif.rst_n);
-      under_reset = 1'b0;
-    end
+  task on_enter_reset();
+    active_csb  = 1'b0;
+    cfg.vif.sck <= cfg.sck_polarity[0];
+    cfg.vif.sio_out <= 'x;
+    cfg.vif.csb <= '1;
+    sck_pulses = 0;
   endtask
 
   // generate sck

--- a/hw/dv/sv/tl_agent/tl_device_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_device_driver.sv
@@ -19,20 +19,14 @@ class tl_device_driver extends tl_base_driver;
       a_channel_thread();
       d_channel_thread();
     join_none
- endtask
+  endtask
 
-  // reset signals every time reset occurs.
-  virtual task reset_signals();
+  task on_enter_reset();
     invalidate_d_channel();
     cfg.vif.d2h_int.a_ready <= 1'b0;
-    forever begin
-      @(negedge cfg.vif.rst_n);
-      invalidate_d_channel();
-      cfg.vif.d2h_int.a_ready <= 1'b0;
-      // Check for seq_item_port FIFO is empty when coming out of reset
-      `DV_CHECK_EQ(seq_item_port.has_do_available(), 0);
-      @(posedge cfg.vif.rst_n);
-    end
+
+    // Make sure that seq_item_port FIFO will be empty when coming out of reset
+    `DV_CHECK_EQ(seq_item_port.has_do_available(), 0);
   endtask
 
   virtual task a_channel_thread();

--- a/hw/dv/sv/tl_agent/tl_host_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_host_driver.sv
@@ -15,12 +15,13 @@ class tl_host_driver extends tl_base_driver;
   // Drive items received from the sequencer. This implements a task declared in dv_base_driver.
   extern task get_and_drive();
 
-  // Clear output signals and internal state whenever a reset happens. This task runs forever,
-  // looping over resets.
-  //
-  // This also controls an internal reset_asserted flag, which is used by other tasks in the class
-  // to detect resets. This implements a task declared in dv_base_driver.
-  extern task reset_signals();
+  // Called at the start of a reset. Clear output signals and internal state. This implements a task
+  // declared in dv_base_driver.
+  extern task on_enter_reset();
+
+  // Called at the end of a reset. Make sure that all sequence items have been properly flushed
+  // while we were in reset.
+  extern function void on_leave_reset();
 
   // Wait for the next edge of host_cb. Stops early if reset is asserted.
   extern protected task wait_clk_or_rst();
@@ -98,34 +99,25 @@ task tl_host_driver::get_and_drive();
   join_none
 endtask
 
-task tl_host_driver::reset_signals();
-  forever begin
-    // At the start of the loop body, we should either be at the start of the simulation or have
-    // just entered reset. Invalidate all signals and mark ourselves as not ready on the D channel.
-    invalidate_a_channel();
-    cfg.vif.h2d_int.d_ready <= 1'b0;
-
-    // Now wait to come out of reset. Note that if the simulation didn't start in reset then this
-    // first wait will take zero time.
-    wait(!cfg.in_reset);
-
-    // When we were in reset, we should have flushed all sequence items immediately. To check this
-    // has worked correctly, the following things should be true when we leave reset:
-    //
-    //  - The pending_a_req queue should be empty (d_channel_thread should have sent responses and
-    //    flushed the requests).
-    //
-    //  - The sequencer shouldn't have any items available through seq_item_port. If an item had
-    //    been available, we should have taken it immediately in get_and_drive.
-    `DV_CHECK_EQ(pending_a_req.size(), 0)
-    `DV_CHECK_EQ(seq_item_port.has_do_available(), 0)
-
-    // At this point, we're in the main part of the simulation and the get_and_drive task will be
-    // driving sequence items over the bus. Wait until reset is asserted before going back to the
-    // start of the loop.
-    wait(cfg.in_reset);
-  end
+task tl_host_driver::on_enter_reset();
+  // Since we've just started a period of reset, invalidate all signals and mark ourselves as not
+  // ready on the D channel.
+  invalidate_a_channel();
+  cfg.vif.h2d_int.d_ready <= 1'b0;
 endtask
+
+function void tl_host_driver::on_leave_reset();
+  // We should have flushed all sequence items immediately when we were in reset. To check this has
+  // worked correctly, the following things should be true when we leave reset:
+  //
+  //  - The pending_a_req queue should be empty (d_channel_thread should have sent responses and
+  //    flushed the requests).
+  //
+  //  - The sequencer shouldn't have any items available through seq_item_port. If an item had been
+  //    available, we should have taken it immediately in get_and_drive.
+  `DV_CHECK_EQ(pending_a_req.size(), 0)
+  `DV_CHECK_EQ(seq_item_port.has_do_available(), 0)
+endfunction
 
 task tl_host_driver::wait_clk_or_rst();
   `DV_SPINWAIT_EXIT(@(cfg.vif.host_cb);, wait(cfg.in_reset);)

--- a/hw/dv/sv/uart_agent/uart_driver.sv
+++ b/hw/dv/sv/uart_agent/uart_driver.sv
@@ -7,8 +7,7 @@ class uart_driver extends dv_base_driver #(uart_item, uart_agent_cfg);
 
   `uvm_component_new
 
-  // Resets signals.
-  virtual task reset_signals();
+  task on_enter_reset();
     cfg.vif.reset_uart_rx();
   endtask
 

--- a/hw/dv/sv/usb20_agent/usb20_device_driver.sv
+++ b/hw/dv/sv/usb20_agent/usb20_device_driver.sv
@@ -10,10 +10,6 @@ class usb20_device_driver extends usb20_driver;
 
   `uvm_component_new
 
-  // reset signals
-  virtual task reset_signals();
-  endtask
-
   // drive trans received from sequencer
   virtual task get_and_drive();
   endtask

--- a/hw/dv/sv/usb20_agent/usb20_driver.sv
+++ b/hw/dv/sv/usb20_agent/usb20_driver.sv
@@ -380,15 +380,14 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
     end
   endtask
 
-  // RESET signals  Task
-  // -------------------------------
-  virtual task reset_signals();
+  // Clear all bus signals, setting outputs to a high-impedance state, because this is the start of
+  // a reset. An implementation of dv_base_driver::on_enter_reset.
+  task on_enter_reset();
     // Bus is unpowered and inactive.
     cfg.bif.drive_vbus = 1'b0;
     cfg.bif.usb_rx_d_i = 1'b0;
     cfg.bif.drive_p    = 1'bZ;
     cfg.bif.drive_n    = 1'bZ;
-    @(posedge cfg.bif.rst_ni);
   endtask
 
   // USB Bus Reset

--- a/hw/dv/sv/usb20_agent/usb20_host_driver.sv
+++ b/hw/dv/sv/usb20_agent/usb20_host_driver.sv
@@ -10,10 +10,6 @@ class usb20_host_driver extends usb20_driver;
 
   `uvm_component_new
 
-  // reset signals
-  virtual task reset_signals();
-  endtask
-
   // drive trans received from sequencer
   virtual task get_and_drive();
     forever begin

--- a/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_driver.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_driver.sv
@@ -18,10 +18,6 @@ class racl_error_log_driver extends dv_base_driver #(.ITEM_T (racl_error_log_vec
   // dv_base_driver.
   extern task get_and_drive();
 
-  // Watch for resets, clearing the error log signals when one is asserted. This runs forever
-  // implementing a task declared in dv_base_driver.
-  extern task reset_signals();
-
   // Drive this item over the interface.
   //
   // If this task starts in reset, it clears the error log input, then waits until reset is cleared
@@ -33,7 +29,7 @@ class racl_error_log_driver extends dv_base_driver #(.ITEM_T (racl_error_log_vec
   //
   // This is used on reset so drives the interface signals directly (instead of using a clocking
   // block)
-  extern local task reset_lines();
+  extern task on_enter_reset();
 
   // Clear the error log signal from subscriber i
   //
@@ -59,14 +55,6 @@ task racl_error_log_driver::get_and_drive();
   end
 endtask
 
-task racl_error_log_driver::reset_signals();
-  forever begin
-    wait(!vif.rst_ni);
-    reset_lines();
-    wait(vif.rst_ni);
-  end
-endtask
-
 task racl_error_log_driver::drive_item(racl_error_log_vec_driver_item item);
   if (!vif.rst_ni) begin
     vif.subscriber_cb.errors <= '0;
@@ -89,7 +77,7 @@ task racl_error_log_driver::drive_item(racl_error_log_vec_driver_item item);
   for (int i = 0; i < 63; i++) clear_line(i);
 endtask
 
-task racl_error_log_driver::reset_lines();
+task racl_error_log_driver::on_enter_reset();
   // Reset the signals through subscriber_cb as well as the raw signals. This ensures that we clear
   // any "pending value" that was written on the final clock edge before reset.
 

--- a/util/uvmdvgen/device_driver.sv.tpl
+++ b/util/uvmdvgen/device_driver.sv.tpl
@@ -10,10 +10,6 @@ class ${name}_device_driver extends ${name}_driver;
 
   `uvm_component_new
 
-  // reset signals
-  virtual task reset_signals();
-  endtask
-
   // drive trans received from sequencer
   virtual task get_and_drive();
   endtask

--- a/util/uvmdvgen/driver.sv.tpl
+++ b/util/uvmdvgen/driver.sv.tpl
@@ -11,10 +11,6 @@ class ${name}_driver extends dv_base_driver #(.ITEM_T(${name}_item),
 
   `uvm_component_new
 
-  // reset signals
-  virtual task reset_signals();
-  endtask
-
   // drive trans received from sequencer
   virtual task get_and_drive();
     forever begin

--- a/util/uvmdvgen/host_driver.sv.tpl
+++ b/util/uvmdvgen/host_driver.sv.tpl
@@ -10,10 +10,6 @@ class ${name}_host_driver extends ${name}_driver;
 
   `uvm_component_new
 
-  // reset signals
-  virtual task reset_signals();
-  endtask
-
   // drive trans received from sequencer
   virtual task get_and_drive();
     forever begin


### PR DESCRIPTION
Now that lots of setup PRs have been, the only commit that remains is the last commit in the PR, which has the following commit message:

> **[dv] Rationalise dv_base_driver reset tracking**
The subclasses all implemented a reset_signals task (incorrectly in
two cases), which is a bit silly: each agent should be doing the same
thing. Move the forever loop into the base class and provide hooks
instead.
>
> Also, get rid of the driver's under_reset flag entirely: we can just
use dv_base_agent_cfg::in_reset instead, which should make things a
bit more uniform.
>
> Most of the changes across the different IPs' agents are simple
enough, but the alert_esc_agent was quite tricky! This commit rewrites
the alert receiver and sender drivers (which weren't trivial to switch
across to the new mechanism). I strongly suspect that they were full
of race conditions before, and the new implementations should be a bit
easier to reason about.