### PR TITLE
[rv_timer,dv] Fix subtly broken fork/join tree

### DIFF
--- a/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_base_vseq.sv
+++ b/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_base_vseq.sv
@@ -155,8 +155,8 @@ class rv_timer_base_vseq extends cip_base_vseq #(
         fork
           while (1) begin
             csr_rd(.ptr(intr_state_rg), .value(read_data));
+            if (read_data == exp_data) break;
             if (spinwait_delay_ns) #(spinwait_delay_ns * 1ns);
-            if ((read_data == exp_data)) break;
           end
           wait (cfg.under_reset);
           begin


### PR DESCRIPTION
With the previous version, we had something of this form:
```
  fork
    for (...) begin
      fork
        something_or_other();
      join_none
    end
    wait fork;
  join
```
This means the "wait fork" ends up starting in parallel with the thing that was supposed to start sub-processes. This was all rather confusing when I ran things with Xcelium because we end up with the "wait fork" completing immediately, but then the something_or_other process starting afterwards (no longer being waited for). This gets followed by a "disable fork", leaving a process being killed when it is trying to get a sequencer, causing a failure a cycle later.

I think the author probably intended something like this:
```
  begin
    for (...) begin
      fork
        something_or_other();
      join_none
    end
    wait fork;
  end
```
(where the outer begin/end is necessary to make this a single item in a surrounding fork).

The only other change is to pull out a complicated expression, which lets us indent it properly.