### PR TITLE
[hw,dv] Add missing includes to prim_assert.sv

### DIFF
--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_core.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_core.sv
@@ -4,6 +4,8 @@
 //
 // adc_ctrl core module
 
+`include "prim_assert.sv"
+
 module adc_ctrl_core import adc_ctrl_reg_pkg::* ; (
   input  clk_aon_i,//Always-on 200KHz clock(logic)
   input  rst_aon_ni,//power-on reset for the 200KHz clock(logic)

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_fsm.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_fsm.sv
@@ -4,6 +4,8 @@
 //
 // Description adc_ctrl detection FSM module
 
+`include "prim_assert.sv"
+
 module adc_ctrl_fsm
   import adc_ctrl_reg_pkg::*;
   import adc_ctrl_pkg::*;

--- a/hw/ip/csrng/rtl/csrng_cmd_stage.sv
+++ b/hw/ip/csrng/rtl/csrng_cmd_stage.sv
@@ -4,6 +4,7 @@
 //
 // Description: CSRNG command staging module.
 //
+`include "prim_assert.sv"
 
 module csrng_cmd_stage import csrng_pkg::*; (
   input logic                        clk_i,

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
@@ -8,6 +8,8 @@
 // It takes in the key, v, and reseed counter values processed by the
 // ctr_drbg cmd module.
 
+`include "prim_assert.sv"
+
 module csrng_ctr_drbg_gen import csrng_pkg::*; (
   input  logic clk_i,
   input  logic rst_ni,

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
@@ -6,6 +6,8 @@
 //
 // implementation using security_strength = 256
 
+`include "prim_assert.sv"
+
 module csrng_ctr_drbg_upd import csrng_pkg::*; (
   input  logic clk_i,
   input  logic rst_ni,

--- a/hw/ip/csrng/rtl/csrng_main_sm.sv
+++ b/hw/ip/csrng/rtl/csrng_main_sm.sv
@@ -6,6 +6,8 @@
 //
 //  - handles all app cmd requests from all requesting interfaces
 
+`include "prim_assert.sv"
+
 module csrng_main_sm import csrng_pkg::*; (
   input logic                         clk_i,
   input logic                         rst_ni,

--- a/hw/ip/edn/rtl/edn_ack_sm.sv
+++ b/hw/ip/edn/rtl/edn_ack_sm.sv
@@ -5,6 +5,8 @@
 // Description: interface between a req/ack interface and a fifo
 //
 
+`include "prim_assert.sv"
+
 module edn_ack_sm (
   input logic                clk_i,
   input logic                rst_ni,

--- a/hw/ip/edn/rtl/edn_main_sm.sv
+++ b/hw/ip/edn/rtl/edn_main_sm.sv
@@ -6,6 +6,8 @@
 //
 //   does hardware-based csrng app interface command requests
 
+`include "prim_assert.sv"
+
 module edn_main_sm import edn_pkg::*;
 (
   input logic                   clk_i,

--- a/hw/ip/entropy_src/rtl/entropy_src_ack_sm.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_ack_sm.sv
@@ -5,6 +5,8 @@
 // Description: interface between a req/ack interface and a fifo
 //
 
+`include "prim_assert.sv"
+
 module entropy_src_ack_sm (
   input logic                clk_i,
   input logic                rst_ni,

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -4,6 +4,7 @@
 //
 // Description: entropy_src core module
 //
+`include "prim_assert.sv"
 
 module entropy_src_core import entropy_src_pkg::*; #(
   parameter int RngBusWidth           = 4,

--- a/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
@@ -6,6 +6,8 @@
 //
 //   determines when new entropy is ready to be forwarded
 
+`include "prim_assert.sv"
+
 module entropy_src_main_sm
   import entropy_src_main_sm_pkg::*;
 (

--- a/hw/ip/hmac/rtl/hmac_core.sv
+++ b/hw/ip/hmac/rtl/hmac_core.sv
@@ -4,6 +4,8 @@
 //
 // HMAC Core implementation
 
+`include "prim_assert.sv"
+
 module hmac_core import prim_sha2_pkg::*; (
   input clk_i,
   input rst_ni,

--- a/hw/ip/i2c/rtl/i2c_controller_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_controller_fsm.sv
@@ -4,6 +4,8 @@
 //
 // Description: I2C finite state machine
 
+`include "prim_assert.sv"
+
 module i2c_controller_fsm import i2c_pkg::*;
 #(
   parameter int FifoDepth = 64,

--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -4,6 +4,8 @@
 //
 // Description: I2C core module
 
+`include "prim_assert.sv"
+
 module i2c_core import i2c_pkg::*;
 #(
   parameter int unsigned InputDelayCycles = 0

--- a/hw/ip/i2c/rtl/i2c_fifo_sync_sram_adapter.sv
+++ b/hw/ip/i2c/rtl/i2c_fifo_sync_sram_adapter.sv
@@ -5,6 +5,8 @@
 // This adapter module allows using a single-port SRAM like a FIFO.  It has been written for I2C,
 // but it could later be generalized into a prim.
 
+`include "prim_assert.sv"
+
 module i2c_fifo_sync_sram_adapter #(
   // Width of each entry (in bits)
   parameter int unsigned Width = 1,

--- a/hw/ip/i2c/rtl/i2c_target_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_target_fsm.sv
@@ -4,6 +4,8 @@
 //
 // Description: I2C finite state machine
 
+`include "prim_assert.sv"
+
 module i2c_target_fsm import i2c_pkg::*;
 #(
   parameter int AcqFifoDepth = 64,

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_signal_decode.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_signal_decode.sv
@@ -4,6 +4,8 @@
 //
 // Life cycle signal decoder and sender module.
 
+`include "prim_assert.sv"
+
 module lc_ctrl_signal_decode
   import lc_ctrl_pkg::*;
   import lc_ctrl_state_pkg::*;

--- a/hw/ip/mbx/rtl/mbx_hostif.sv
+++ b/hw/ip/mbx/rtl/mbx_hostif.sv
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`include "prim_assert.sv"
+
 module mbx_hostif
   import mbx_reg_pkg::*;
 #(

--- a/hw/ip/mbx/rtl/mbx_sramrwarb.sv
+++ b/hw/ip/mbx/rtl/mbx_sramrwarb.sv
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`include "prim_assert.sv"
+
 module mbx_sramrwarb
   import  tlul_pkg::*;
 #(

--- a/hw/ip/mbx/rtl/mbx_sysif.sv
+++ b/hw/ip/mbx/rtl/mbx_sysif.sv
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`include "prim_assert.sv"
+
 module mbx_sysif
   import tlul_pkg::*;
   import mbx_reg_pkg::*;

--- a/hw/ip/otbn/rtl/otbn_loop_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_loop_controller.sv
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`include "prim_assert.sv"
+
 module otbn_loop_controller
   import otbn_pkg::*;
 #(

--- a/hw/ip/otbn/rtl/otbn_rf_base.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_base.sv
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`include "prim_assert.sv"
+
 /**
  * 32b General Purpose Register File (GPRs) with integrity code detecting triple bit errors.
  *

--- a/hw/ip/otbn/rtl/otbn_rf_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_bignum.sv
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`include "prim_assert.sv"
+
 /**
  * 256b General Purpose Register File (GPRs) with integrity code detecting triple bit errors on a
  * 32-bit granule (312 bits total).

--- a/hw/ip/otbn/rtl/otbn_rf_bignum_ff.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_bignum_ff.sv
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`include "prim_assert.sv"
+
 /**
  * ExtWLEN (312b) Wide Register File (WDRs)
  *

--- a/hw/ip/otp_macro/rtl/otp_macro.sv
+++ b/hw/ip/otp_macro/rtl/otp_macro.sv
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`include "prim_assert.sv"
+
 module otp_macro
   import otp_ctrl_macro_pkg::*;
   import otp_macro_reg_pkg::*;

--- a/hw/ip/prim/rtl/prim_intr_hw.sv
+++ b/hw/ip/prim/rtl/prim_intr_hw.sv
@@ -14,6 +14,8 @@
 // - INTR_STATE  : the current state of the interrupt (may be RO or W1C depending on "IntrT")
 // - INTR_TEST   : sw-access-only register which asserts the interrupt for testing purposes
 
+`include "prim_assert.sv"
+
 module prim_intr_hw # (
   // This module can be instantiated once per interrupt field (Width == 1), or
   // "bussified" with all fields of the interrupt vector (Width == $width(vec)).

--- a/hw/ip/spi_device/rtl/spi_p2s.sv
+++ b/hw/ip/spi_device/rtl/spi_p2s.sv
@@ -4,6 +4,8 @@
 //
 // SPI byte to SPI (Single/ Dual/ Quad)
 
+`include "prim_assert.sv"
+
 module spi_p2s
   import spi_device_pkg::*;
 (

--- a/hw/ip/spi_device/rtl/spi_passthrough.sv
+++ b/hw/ip/spi_device/rtl/spi_passthrough.sv
@@ -70,6 +70,9 @@
  * attacks or reliability issues, then SW in RoT can redirect the host system's
  * requests to the other half partitions in the flash device.
  */
+
+`include "prim_assert.sv"
+
 module spi_passthrough
   import spi_device_pkg::*;
 (

--- a/hw/ip/spi_device/rtl/spi_s2p.sv
+++ b/hw/ip/spi_device/rtl/spi_s2p.sv
@@ -4,6 +4,8 @@
 //
 // SPI Serial-to-Parallel interface
 
+`include "prim_assert.sv"
+
 module spi_s2p
   import spi_device_pkg::*;
 (

--- a/hw/ip/spi_device/rtl/spi_tpm.sv
+++ b/hw/ip/spi_device/rtl/spi_tpm.sv
@@ -6,6 +6,8 @@
 /*
 */
 
+`include "prim_assert.sv"
+
 module spi_tpm
   import spi_device_pkg::*;
   import spi_device_reg_pkg::NumLocality;

--- a/hw/ip/spi_device/rtl/spid_fifo2sram_adapter.sv
+++ b/hw/ip/spi_device/rtl/spid_fifo2sram_adapter.sv
@@ -9,6 +9,8 @@
   (empty/ full).
 */
 
+`include "prim_assert.sv"
+
 module spid_fifo2sram_adapter #(
   parameter int unsigned FifoWidth = 8,
   parameter int unsigned FifoDepth = 256,

--- a/hw/ip/spi_host/rtl/spi_host_data_fifos.sv
+++ b/hw/ip/spi_host/rtl/spi_host_data_fifos.sv
@@ -5,6 +5,8 @@
 // Module for SPI_HOST RX and TX queues
 //
 
+`include "prim_assert.sv"
+
 module spi_host_data_fifos #(
   parameter int         TxDepth   = 72,
   parameter int         RxDepth   = 64,

--- a/hw/ip/spi_host/rtl/spi_host_shift_register.sv
+++ b/hw/ip/spi_host/rtl/spi_host_shift_register.sv
@@ -5,6 +5,8 @@
 // Shift Register for Serial Peripheral Interface (SPI) Host IP.
 //
 
+`include "prim_assert.sv"
+
 module spi_host_shift_register (
   input              clk_i,
   input              rst_ni,

--- a/hw/ip/spi_host/rtl/spi_host_window.sv
+++ b/hw/ip/spi_host/rtl/spi_host_window.sv
@@ -5,6 +5,8 @@
 // Module to manage TX & RX FIFO windows for Serial Peripheral Interface (SPI) host IP.
 //
 
+`include "prim_assert.sv"
+
 module spi_host_window
 #(
   parameter bit                             EnableRacl             = 1'b0,

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_detect.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_detect.sv
@@ -19,6 +19,8 @@
 // and enabled again in order to reset the internal FSM into its idle state.
 //
 
+`include "prim_assert.sv"
+
 module sysrst_ctrl_detect
   import sysrst_ctrl_pkg::*;
 #(

--- a/hw/ip/uart/rtl/uart_core.sv
+++ b/hw/ip/uart/rtl/uart_core.sv
@@ -5,6 +5,8 @@
 // Description: UART core module
 //
 
+`include "prim_assert.sv"
+
 module uart_core (
   input                  clk_i,
   input                  rst_ni,

--- a/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
+++ b/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`include "prim_assert.sv"
+
 module ${module_instance_name}
   import tlul_pkg::*;
   import ${module_instance_name}_reg_pkg::*;

--- a/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_dai.sv
+++ b/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_dai.sv
@@ -5,7 +5,7 @@
 // Direct access interface for OTP controller.
 //
 
-`include "prim_flop_macros.sv"
+`include "prim_assert.sv"
 
 module otp_ctrl_dai
   import otp_ctrl_pkg::*;

--- a/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_kdi.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_kdi.sv.tpl
@@ -6,7 +6,7 @@
 //
 <% otbn_idx = 2 if enable_flash_key else 0 %>\
 
-`include "prim_flop_macros.sv"
+`include "prim_assert.sv"
 
 module otp_ctrl_kdi
   import otp_ctrl_pkg::*;

--- a/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_lci.sv
+++ b/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_lci.sv
@@ -5,7 +5,7 @@
 // Life cycle interface for performing life cycle transitions in OTP.
 //
 
-`include "prim_flop_macros.sv"
+`include "prim_assert.sv"
 
 module otp_ctrl_lci
   import otp_ctrl_pkg::*;

--- a/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
+++ b/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
@@ -26,7 +26,7 @@
 // This can be useful if SW chooses to leave the periodic checks disabled.
 //
 
-`include "prim_flop_macros.sv"
+`include "prim_assert.sv"
 
 module otp_ctrl_lfsr_timer
   import otp_ctrl_pkg::*;

--- a/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -5,7 +5,7 @@
 // Buffered partition for OTP controller.
 //
 
-`include "prim_flop_macros.sv"
+`include "prim_assert.sv"
 
 module otp_ctrl_part_buf
   import otp_ctrl_pkg::*;

--- a/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -5,7 +5,7 @@
 // Unbuffered partition for OTP controller.
 //
 
-`include "prim_flop_macros.sv"
+`include "prim_assert.sv"
 
 module otp_ctrl_part_unbuf
   import otp_ctrl_pkg::*;

--- a/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
+++ b/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
@@ -69,7 +69,7 @@
 //  - http://www.lightweightcrypto.org/present/present_ches2007.pdf
 //
 
-`include "prim_flop_macros.sv"
+`include "prim_assert.sv"
 
 module otp_ctrl_scrmbl
   import otp_ctrl_pkg::*;

--- a/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
+++ b/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`include "prim_assert.sv"
+
 module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn              = {NumAlerts{1'b1}},
   // Number of cycles a differential skew is tolerated on the alert signal

--- a/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex.sv.tpl
+++ b/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex.sv.tpl
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`include "prim_assert.sv"
+
 /**
  * Ibex RISC-V core
  *

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check.sv
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`include "prim_assert.sv"
+
 module ac_range_check
   import tlul_pkg::*;
   import ac_range_check_reg_pkg::*;

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_dai.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_dai.sv
@@ -5,7 +5,7 @@
 // Direct access interface for OTP controller.
 //
 
-`include "prim_flop_macros.sv"
+`include "prim_assert.sv"
 
 module otp_ctrl_dai
   import otp_ctrl_pkg::*;

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_kdi.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_kdi.sv
@@ -5,7 +5,7 @@
 // Scrambling key derivation module for OTP.
 //
 
-`include "prim_flop_macros.sv"
+`include "prim_assert.sv"
 
 module otp_ctrl_kdi
   import otp_ctrl_pkg::*;

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_lci.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_lci.sv
@@ -5,7 +5,7 @@
 // Life cycle interface for performing life cycle transitions in OTP.
 //
 
-`include "prim_flop_macros.sv"
+`include "prim_assert.sv"
 
 module otp_ctrl_lci
   import otp_ctrl_pkg::*;

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
@@ -26,7 +26,7 @@
 // This can be useful if SW chooses to leave the periodic checks disabled.
 //
 
-`include "prim_flop_macros.sv"
+`include "prim_assert.sv"
 
 module otp_ctrl_lfsr_timer
   import otp_ctrl_pkg::*;

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -5,7 +5,7 @@
 // Buffered partition for OTP controller.
 //
 
-`include "prim_flop_macros.sv"
+`include "prim_assert.sv"
 
 module otp_ctrl_part_buf
   import otp_ctrl_pkg::*;

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -5,7 +5,7 @@
 // Unbuffered partition for OTP controller.
 //
 
-`include "prim_flop_macros.sv"
+`include "prim_assert.sv"
 
 module otp_ctrl_part_unbuf
   import otp_ctrl_pkg::*;

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
@@ -69,7 +69,7 @@
 //  - http://www.lightweightcrypto.org/present/present_ches2007.pdf
 //
 
-`include "prim_flop_macros.sv"
+`include "prim_assert.sv"
 
 module otp_ctrl_scrmbl
   import otp_ctrl_pkg::*;

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`include "prim_assert.sv"
+
 module racl_ctrl import racl_ctrl_reg_pkg::*; #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn              = {NumAlerts{1'b1}},
   // Number of cycles a differential skew is tolerated on the alert signal

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`include "prim_assert.sv"
+
 /**
  * Ibex RISC-V core
  *

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_dai.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_dai.sv
@@ -5,7 +5,7 @@
 // Direct access interface for OTP controller.
 //
 
-`include "prim_flop_macros.sv"
+`include "prim_assert.sv"
 
 module otp_ctrl_dai
   import otp_ctrl_pkg::*;

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_kdi.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_kdi.sv
@@ -5,7 +5,7 @@
 // Scrambling key derivation module for OTP.
 //
 
-`include "prim_flop_macros.sv"
+`include "prim_assert.sv"
 
 module otp_ctrl_kdi
   import otp_ctrl_pkg::*;

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_lci.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_lci.sv
@@ -5,7 +5,7 @@
 // Life cycle interface for performing life cycle transitions in OTP.
 //
 
-`include "prim_flop_macros.sv"
+`include "prim_assert.sv"
 
 module otp_ctrl_lci
   import otp_ctrl_pkg::*;

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
@@ -26,7 +26,7 @@
 // This can be useful if SW chooses to leave the periodic checks disabled.
 //
 
-`include "prim_flop_macros.sv"
+`include "prim_assert.sv"
 
 module otp_ctrl_lfsr_timer
   import otp_ctrl_pkg::*;

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -5,7 +5,7 @@
 // Buffered partition for OTP controller.
 //
 
-`include "prim_flop_macros.sv"
+`include "prim_assert.sv"
 
 module otp_ctrl_part_buf
   import otp_ctrl_pkg::*;

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -5,7 +5,7 @@
 // Unbuffered partition for OTP controller.
 //
 
-`include "prim_flop_macros.sv"
+`include "prim_assert.sv"
 
 module otp_ctrl_part_unbuf
   import otp_ctrl_pkg::*;

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
@@ -69,7 +69,7 @@
 //  - http://www.lightweightcrypto.org/present/present_ches2007.pdf
 //
 
-`include "prim_flop_macros.sv"
+`include "prim_assert.sv"
 
 module otp_ctrl_scrmbl
   import otp_ctrl_pkg::*;

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`include "prim_assert.sv"
+
 /**
  * Ibex RISC-V core
  *

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`include "prim_assert.sv"
+
 /**
  * Ibex RISC-V core
  *


### PR DESCRIPTION
Many SV files are using asserts but miss including `prim_assert.h`. This change adds explicit includes to all files that use asserts but don't have the include yet in place.