### PR TITLE
[hw,darjeeling,corefile] Remove adc_ctrl/sysctrl from fusesoc deps

### DIFF
--- a/hw/top_darjeeling/top_darjeeling.core
+++ b/hw/top_darjeeling/top_darjeeling.core
@@ -54,8 +54,6 @@ filesets:
       - lowrisc:darjeeling_ip:racl_ctrl
       - lowrisc:darjeeling_ip:gpio
       - lowrisc:ip:aon_timer
-      - lowrisc:ip:adc_ctrl
-      - lowrisc:ip:sysrst_ctrl
       - lowrisc:ip:rom_ctrl
       - lowrisc:ip:soc_dbg_ctrl
       - lowrisc:systems:soc_proxy


### PR DESCRIPTION
Darjeeling does not instantiate those IPs, no need to have them in the core file and add more files than needed.