### PR TITLE
[otp_ctrl] Clarify *_DIGEST register description.

### DIFF
--- a/hw/ip_templates/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip_templates/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -1145,7 +1145,7 @@ otp_size_as_uint32 = otp_size_as_bytes // 4
           name:     "${part["name"]}_DIGEST",
           desc:     '''
                     Integrity digest for the ${part["name"]} partition.
-                    The integrity digest is 0 by default. Software must write this
+                    The integrity digest is 0 by default. Software must write a non-zero
                     digest value via the direct access interface in order to lock the partition.
                     After a reset, write access to the ${part["name"]} partition is locked and
                     the digest becomes visible in this CSR.

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/data/otp_ctrl.hjson
@@ -3213,7 +3213,7 @@
           name:     "VENDOR_TEST_DIGEST",
           desc:     '''
                     Integrity digest for the VENDOR_TEST partition.
-                    The integrity digest is 0 by default. Software must write this
+                    The integrity digest is 0 by default. Software must write a non-zero
                     digest value via the direct access interface in order to lock the partition.
                     After a reset, write access to the VENDOR_TEST partition is locked and
                     the digest becomes visible in this CSR.
@@ -3236,7 +3236,7 @@
           name:     "CREATOR_SW_CFG_DIGEST",
           desc:     '''
                     Integrity digest for the CREATOR_SW_CFG partition.
-                    The integrity digest is 0 by default. Software must write this
+                    The integrity digest is 0 by default. Software must write a non-zero
                     digest value via the direct access interface in order to lock the partition.
                     After a reset, write access to the CREATOR_SW_CFG partition is locked and
                     the digest becomes visible in this CSR.
@@ -3259,7 +3259,7 @@
           name:     "OWNER_SW_CFG_DIGEST",
           desc:     '''
                     Integrity digest for the OWNER_SW_CFG partition.
-                    The integrity digest is 0 by default. Software must write this
+                    The integrity digest is 0 by default. Software must write a non-zero
                     digest value via the direct access interface in order to lock the partition.
                     After a reset, write access to the OWNER_SW_CFG partition is locked and
                     the digest becomes visible in this CSR.
@@ -3282,7 +3282,7 @@
           name:     "ROT_CREATOR_AUTH_DIGEST",
           desc:     '''
                     Integrity digest for the ROT_CREATOR_AUTH partition.
-                    The integrity digest is 0 by default. Software must write this
+                    The integrity digest is 0 by default. Software must write a non-zero
                     digest value via the direct access interface in order to lock the partition.
                     After a reset, write access to the ROT_CREATOR_AUTH partition is locked and
                     the digest becomes visible in this CSR.
@@ -3305,7 +3305,7 @@
           name:     "ROT_OWNER_AUTH_SLOT0_DIGEST",
           desc:     '''
                     Integrity digest for the ROT_OWNER_AUTH_SLOT0 partition.
-                    The integrity digest is 0 by default. Software must write this
+                    The integrity digest is 0 by default. Software must write a non-zero
                     digest value via the direct access interface in order to lock the partition.
                     After a reset, write access to the ROT_OWNER_AUTH_SLOT0 partition is locked and
                     the digest becomes visible in this CSR.
@@ -3328,7 +3328,7 @@
           name:     "ROT_OWNER_AUTH_SLOT1_DIGEST",
           desc:     '''
                     Integrity digest for the ROT_OWNER_AUTH_SLOT1 partition.
-                    The integrity digest is 0 by default. Software must write this
+                    The integrity digest is 0 by default. Software must write a non-zero
                     digest value via the direct access interface in order to lock the partition.
                     After a reset, write access to the ROT_OWNER_AUTH_SLOT1 partition is locked and
                     the digest becomes visible in this CSR.
@@ -3351,7 +3351,7 @@
           name:     "PLAT_INTEG_AUTH_SLOT0_DIGEST",
           desc:     '''
                     Integrity digest for the PLAT_INTEG_AUTH_SLOT0 partition.
-                    The integrity digest is 0 by default. Software must write this
+                    The integrity digest is 0 by default. Software must write a non-zero
                     digest value via the direct access interface in order to lock the partition.
                     After a reset, write access to the PLAT_INTEG_AUTH_SLOT0 partition is locked and
                     the digest becomes visible in this CSR.
@@ -3374,7 +3374,7 @@
           name:     "PLAT_INTEG_AUTH_SLOT1_DIGEST",
           desc:     '''
                     Integrity digest for the PLAT_INTEG_AUTH_SLOT1 partition.
-                    The integrity digest is 0 by default. Software must write this
+                    The integrity digest is 0 by default. Software must write a non-zero
                     digest value via the direct access interface in order to lock the partition.
                     After a reset, write access to the PLAT_INTEG_AUTH_SLOT1 partition is locked and
                     the digest becomes visible in this CSR.
@@ -3397,7 +3397,7 @@
           name:     "PLAT_OWNER_AUTH_SLOT0_DIGEST",
           desc:     '''
                     Integrity digest for the PLAT_OWNER_AUTH_SLOT0 partition.
-                    The integrity digest is 0 by default. Software must write this
+                    The integrity digest is 0 by default. Software must write a non-zero
                     digest value via the direct access interface in order to lock the partition.
                     After a reset, write access to the PLAT_OWNER_AUTH_SLOT0 partition is locked and
                     the digest becomes visible in this CSR.
@@ -3420,7 +3420,7 @@
           name:     "PLAT_OWNER_AUTH_SLOT1_DIGEST",
           desc:     '''
                     Integrity digest for the PLAT_OWNER_AUTH_SLOT1 partition.
-                    The integrity digest is 0 by default. Software must write this
+                    The integrity digest is 0 by default. Software must write a non-zero
                     digest value via the direct access interface in order to lock the partition.
                     After a reset, write access to the PLAT_OWNER_AUTH_SLOT1 partition is locked and
                     the digest becomes visible in this CSR.
@@ -3443,7 +3443,7 @@
           name:     "PLAT_OWNER_AUTH_SLOT2_DIGEST",
           desc:     '''
                     Integrity digest for the PLAT_OWNER_AUTH_SLOT2 partition.
-                    The integrity digest is 0 by default. Software must write this
+                    The integrity digest is 0 by default. Software must write a non-zero
                     digest value via the direct access interface in order to lock the partition.
                     After a reset, write access to the PLAT_OWNER_AUTH_SLOT2 partition is locked and
                     the digest becomes visible in this CSR.
@@ -3466,7 +3466,7 @@
           name:     "PLAT_OWNER_AUTH_SLOT3_DIGEST",
           desc:     '''
                     Integrity digest for the PLAT_OWNER_AUTH_SLOT3 partition.
-                    The integrity digest is 0 by default. Software must write this
+                    The integrity digest is 0 by default. Software must write a non-zero
                     digest value via the direct access interface in order to lock the partition.
                     After a reset, write access to the PLAT_OWNER_AUTH_SLOT3 partition is locked and
                     the digest becomes visible in this CSR.
@@ -3489,7 +3489,7 @@
           name:     "ROM_PATCH_DIGEST",
           desc:     '''
                     Integrity digest for the ROM_PATCH partition.
-                    The integrity digest is 0 by default. Software must write this
+                    The integrity digest is 0 by default. Software must write a non-zero
                     digest value via the direct access interface in order to lock the partition.
                     After a reset, write access to the ROM_PATCH partition is locked and
                     the digest becomes visible in this CSR.

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/doc/registers.md
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/doc/registers.md
@@ -826,7 +826,7 @@ Runtime read lock for the ROM_PATCH partition.
 
 ## VENDOR_TEST_DIGEST
 Integrity digest for the VENDOR_TEST partition.
-The integrity digest is 0 by default. Software must write this
+The integrity digest is 0 by default. Software must write a non-zero
 digest value via the direct access interface in order to lock the partition.
 After a reset, write access to the VENDOR_TEST partition is locked and
 the digest becomes visible in this CSR.
@@ -853,7 +853,7 @@ the digest becomes visible in this CSR.
 
 ## CREATOR_SW_CFG_DIGEST
 Integrity digest for the CREATOR_SW_CFG partition.
-The integrity digest is 0 by default. Software must write this
+The integrity digest is 0 by default. Software must write a non-zero
 digest value via the direct access interface in order to lock the partition.
 After a reset, write access to the CREATOR_SW_CFG partition is locked and
 the digest becomes visible in this CSR.
@@ -880,7 +880,7 @@ the digest becomes visible in this CSR.
 
 ## OWNER_SW_CFG_DIGEST
 Integrity digest for the OWNER_SW_CFG partition.
-The integrity digest is 0 by default. Software must write this
+The integrity digest is 0 by default. Software must write a non-zero
 digest value via the direct access interface in order to lock the partition.
 After a reset, write access to the OWNER_SW_CFG partition is locked and
 the digest becomes visible in this CSR.
@@ -907,7 +907,7 @@ the digest becomes visible in this CSR.
 
 ## ROT_CREATOR_AUTH_DIGEST
 Integrity digest for the ROT_CREATOR_AUTH partition.
-The integrity digest is 0 by default. Software must write this
+The integrity digest is 0 by default. Software must write a non-zero
 digest value via the direct access interface in order to lock the partition.
 After a reset, write access to the ROT_CREATOR_AUTH partition is locked and
 the digest becomes visible in this CSR.
@@ -934,7 +934,7 @@ the digest becomes visible in this CSR.
 
 ## ROT_OWNER_AUTH_SLOT0_DIGEST
 Integrity digest for the ROT_OWNER_AUTH_SLOT0 partition.
-The integrity digest is 0 by default. Software must write this
+The integrity digest is 0 by default. Software must write a non-zero
 digest value via the direct access interface in order to lock the partition.
 After a reset, write access to the ROT_OWNER_AUTH_SLOT0 partition is locked and
 the digest becomes visible in this CSR.
@@ -961,7 +961,7 @@ the digest becomes visible in this CSR.
 
 ## ROT_OWNER_AUTH_SLOT1_DIGEST
 Integrity digest for the ROT_OWNER_AUTH_SLOT1 partition.
-The integrity digest is 0 by default. Software must write this
+The integrity digest is 0 by default. Software must write a non-zero
 digest value via the direct access interface in order to lock the partition.
 After a reset, write access to the ROT_OWNER_AUTH_SLOT1 partition is locked and
 the digest becomes visible in this CSR.
@@ -988,7 +988,7 @@ the digest becomes visible in this CSR.
 
 ## PLAT_INTEG_AUTH_SLOT0_DIGEST
 Integrity digest for the PLAT_INTEG_AUTH_SLOT0 partition.
-The integrity digest is 0 by default. Software must write this
+The integrity digest is 0 by default. Software must write a non-zero
 digest value via the direct access interface in order to lock the partition.
 After a reset, write access to the PLAT_INTEG_AUTH_SLOT0 partition is locked and
 the digest becomes visible in this CSR.
@@ -1015,7 +1015,7 @@ the digest becomes visible in this CSR.
 
 ## PLAT_INTEG_AUTH_SLOT1_DIGEST
 Integrity digest for the PLAT_INTEG_AUTH_SLOT1 partition.
-The integrity digest is 0 by default. Software must write this
+The integrity digest is 0 by default. Software must write a non-zero
 digest value via the direct access interface in order to lock the partition.
 After a reset, write access to the PLAT_INTEG_AUTH_SLOT1 partition is locked and
 the digest becomes visible in this CSR.
@@ -1042,7 +1042,7 @@ the digest becomes visible in this CSR.
 
 ## PLAT_OWNER_AUTH_SLOT0_DIGEST
 Integrity digest for the PLAT_OWNER_AUTH_SLOT0 partition.
-The integrity digest is 0 by default. Software must write this
+The integrity digest is 0 by default. Software must write a non-zero
 digest value via the direct access interface in order to lock the partition.
 After a reset, write access to the PLAT_OWNER_AUTH_SLOT0 partition is locked and
 the digest becomes visible in this CSR.
@@ -1069,7 +1069,7 @@ the digest becomes visible in this CSR.
 
 ## PLAT_OWNER_AUTH_SLOT1_DIGEST
 Integrity digest for the PLAT_OWNER_AUTH_SLOT1 partition.
-The integrity digest is 0 by default. Software must write this
+The integrity digest is 0 by default. Software must write a non-zero
 digest value via the direct access interface in order to lock the partition.
 After a reset, write access to the PLAT_OWNER_AUTH_SLOT1 partition is locked and
 the digest becomes visible in this CSR.
@@ -1096,7 +1096,7 @@ the digest becomes visible in this CSR.
 
 ## PLAT_OWNER_AUTH_SLOT2_DIGEST
 Integrity digest for the PLAT_OWNER_AUTH_SLOT2 partition.
-The integrity digest is 0 by default. Software must write this
+The integrity digest is 0 by default. Software must write a non-zero
 digest value via the direct access interface in order to lock the partition.
 After a reset, write access to the PLAT_OWNER_AUTH_SLOT2 partition is locked and
 the digest becomes visible in this CSR.
@@ -1123,7 +1123,7 @@ the digest becomes visible in this CSR.
 
 ## PLAT_OWNER_AUTH_SLOT3_DIGEST
 Integrity digest for the PLAT_OWNER_AUTH_SLOT3 partition.
-The integrity digest is 0 by default. Software must write this
+The integrity digest is 0 by default. Software must write a non-zero
 digest value via the direct access interface in order to lock the partition.
 After a reset, write access to the PLAT_OWNER_AUTH_SLOT3 partition is locked and
 the digest becomes visible in this CSR.
@@ -1150,7 +1150,7 @@ the digest becomes visible in this CSR.
 
 ## ROM_PATCH_DIGEST
 Integrity digest for the ROM_PATCH partition.
-The integrity digest is 0 by default. Software must write this
+The integrity digest is 0 by default. Software must write a non-zero
 digest value via the direct access interface in order to lock the partition.
 After a reset, write access to the ROM_PATCH partition is locked and
 the digest becomes visible in this CSR.

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/data/otp_ctrl.hjson
@@ -2797,7 +2797,7 @@
           name:     "VENDOR_TEST_DIGEST",
           desc:     '''
                     Integrity digest for the VENDOR_TEST partition.
-                    The integrity digest is 0 by default. Software must write this
+                    The integrity digest is 0 by default. Software must write a non-zero
                     digest value via the direct access interface in order to lock the partition.
                     After a reset, write access to the VENDOR_TEST partition is locked and
                     the digest becomes visible in this CSR.
@@ -2820,7 +2820,7 @@
           name:     "CREATOR_SW_CFG_DIGEST",
           desc:     '''
                     Integrity digest for the CREATOR_SW_CFG partition.
-                    The integrity digest is 0 by default. Software must write this
+                    The integrity digest is 0 by default. Software must write a non-zero
                     digest value via the direct access interface in order to lock the partition.
                     After a reset, write access to the CREATOR_SW_CFG partition is locked and
                     the digest becomes visible in this CSR.
@@ -2843,7 +2843,7 @@
           name:     "OWNER_SW_CFG_DIGEST",
           desc:     '''
                     Integrity digest for the OWNER_SW_CFG partition.
-                    The integrity digest is 0 by default. Software must write this
+                    The integrity digest is 0 by default. Software must write a non-zero
                     digest value via the direct access interface in order to lock the partition.
                     After a reset, write access to the OWNER_SW_CFG partition is locked and
                     the digest becomes visible in this CSR.
@@ -2866,7 +2866,7 @@
           name:     "ROT_CREATOR_AUTH_CODESIGN_DIGEST",
           desc:     '''
                     Integrity digest for the ROT_CREATOR_AUTH_CODESIGN partition.
-                    The integrity digest is 0 by default. Software must write this
+                    The integrity digest is 0 by default. Software must write a non-zero
                     digest value via the direct access interface in order to lock the partition.
                     After a reset, write access to the ROT_CREATOR_AUTH_CODESIGN partition is locked and
                     the digest becomes visible in this CSR.
@@ -2889,7 +2889,7 @@
           name:     "ROT_CREATOR_AUTH_STATE_DIGEST",
           desc:     '''
                     Integrity digest for the ROT_CREATOR_AUTH_STATE partition.
-                    The integrity digest is 0 by default. Software must write this
+                    The integrity digest is 0 by default. Software must write a non-zero
                     digest value via the direct access interface in order to lock the partition.
                     After a reset, write access to the ROT_CREATOR_AUTH_STATE partition is locked and
                     the digest becomes visible in this CSR.

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/doc/registers.md
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/doc/registers.md
@@ -585,7 +585,7 @@ Runtime read lock for the ROT_CREATOR_AUTH_STATE partition.
 
 ## VENDOR_TEST_DIGEST
 Integrity digest for the VENDOR_TEST partition.
-The integrity digest is 0 by default. Software must write this
+The integrity digest is 0 by default. Software must write a non-zero
 digest value via the direct access interface in order to lock the partition.
 After a reset, write access to the VENDOR_TEST partition is locked and
 the digest becomes visible in this CSR.
@@ -612,7 +612,7 @@ the digest becomes visible in this CSR.
 
 ## CREATOR_SW_CFG_DIGEST
 Integrity digest for the CREATOR_SW_CFG partition.
-The integrity digest is 0 by default. Software must write this
+The integrity digest is 0 by default. Software must write a non-zero
 digest value via the direct access interface in order to lock the partition.
 After a reset, write access to the CREATOR_SW_CFG partition is locked and
 the digest becomes visible in this CSR.
@@ -639,7 +639,7 @@ the digest becomes visible in this CSR.
 
 ## OWNER_SW_CFG_DIGEST
 Integrity digest for the OWNER_SW_CFG partition.
-The integrity digest is 0 by default. Software must write this
+The integrity digest is 0 by default. Software must write a non-zero
 digest value via the direct access interface in order to lock the partition.
 After a reset, write access to the OWNER_SW_CFG partition is locked and
 the digest becomes visible in this CSR.
@@ -666,7 +666,7 @@ the digest becomes visible in this CSR.
 
 ## ROT_CREATOR_AUTH_CODESIGN_DIGEST
 Integrity digest for the ROT_CREATOR_AUTH_CODESIGN partition.
-The integrity digest is 0 by default. Software must write this
+The integrity digest is 0 by default. Software must write a non-zero
 digest value via the direct access interface in order to lock the partition.
 After a reset, write access to the ROT_CREATOR_AUTH_CODESIGN partition is locked and
 the digest becomes visible in this CSR.
@@ -693,7 +693,7 @@ the digest becomes visible in this CSR.
 
 ## ROT_CREATOR_AUTH_STATE_DIGEST
 Integrity digest for the ROT_CREATOR_AUTH_STATE partition.
-The integrity digest is 0 by default. Software must write this
+The integrity digest is 0 by default. Software must write a non-zero
 digest value via the direct access interface in order to lock the partition.
 After a reset, write access to the ROT_CREATOR_AUTH_STATE partition is locked and
 the digest becomes visible in this CSR.


### PR DESCRIPTION
The previous description `Software must write this digest value` made it sound like the exact value from this register was supposed to be used for locking a partition. But that's not correct and also not possible since the value would be `0` before the partition is locked, which means that the partition wont get locked.