### PR TITLE
[entropy_src/dv] Improve do_entropy_data_read() for testing higher rates

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_env.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env.sv
@@ -97,7 +97,12 @@ class entropy_src_env extends cip_base_env #(
     // reaching coverage metrics) we reduce the maximum d_ready delay of the TL-UL host to speed up
     // e.g. the reading out of the Observe FIFO.
     if (cfg.rng_max_delay == 1) begin
-      cfg.m_tl_agent_cfg.d_ready_delay_max = 5;
+      if (`RNG_BUS_WIDTH == 16) begin
+        cfg.m_tl_agent_cfg.a_valid_delay_max = 6;
+        cfg.m_tl_agent_cfg.d_ready_delay_max = 0;
+      end else begin
+        cfg.m_tl_agent_cfg.d_ready_delay_max = 5;
+      end
     end
 
     if (!uvm_config_db#(virtual entropy_subsys_fifo_exception_if#(1))::get(this, "",


### PR DESCRIPTION
Previously, this function erroneously used the interrupt threshold to determine the number of words to read. This is not suitable for testing higher entropy rates (the Observe FIFO always overflows). This PR changes the function as follows:

1. The current FIFO depth is used to determine the number of words to read (for coverage, the threshold is still used but with low probability only).
2. Once the previously determined number of words have been read, the routine again checks the depth and continues reading. This is what also firmware would be doing.

In addition, the PR also tunes the TL-UL timing for the max rate test and the Darjeeling configuration.

With this PR, the pass rates for the two different ENTROPY_SRC configurations get very close. This resolves lowRISC/OpenTitan#27471. 
