### PR TITLE
[bazel] blackhole stdin when running QEMU

### DIFF
--- a/rules/scripts/qemu_pass.py
+++ b/rules/scripts/qemu_pass.py
@@ -20,6 +20,7 @@ def main() -> int:
     # Run the process streaming (echoing) `stdout` and `stderr`.
     proc = subprocess.Popen(
         " ".join([qemu_bin] + sys.argv[1:]),
+        stdin=subprocess.DEVNULL,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         bufsize=1,


### PR DESCRIPTION
Connecting `stdin` prevents QEMU from exiting (or using ^C to quit) when run with `bazel run`. We don't normally want to talk to the OpenTitan UART over stdin anyway, so I'm going to disable that.

When we have OpenTitanTool support we can communicate with the UART through pipes separately from stdio.