### PR TITLE
Cherry-pick to master: [sw,sram_program] Add stack region overlapping check

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/sram_program.ld
+++ b/sw/device/silicon_creator/manuf/lib/sram_program.ld
@@ -113,6 +113,11 @@ SECTIONS {
     /* Ensure section end is word-aligned. */
     . = ALIGN(4);
     _bss_end = .;
+
+    ASSERT(
+      ABSOLUTE(_stack_start) >= ABSOLUTE(_bss_end),
+      "bss section overflowed to stack region");
+
   } > ram_main : sram_segment
 
   INCLUDE sw/device/info_sections.ld


### PR DESCRIPTION
This is a manual cherrypick of the overlap assertion from #27933.
* #27933