### PR TITLE
[cryptolib] Move aes driver to DT

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -33,7 +33,7 @@ cc_library(
         ":entropy",
         ":rv_core_ibex",
         "//hw/top:aes_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt_aes",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:crc32",


### PR DESCRIPTION
The cryptolib uses hard-coded drivers, which only work for Earlgrey. This PR moves the aes driver to the generic DT-API.

Long term, the drivers need to be consolidated without duplicating it in the silicon creator lib.