### PR TITLE
[cryptolib] Move entropy_kat driver to DT

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -165,7 +165,7 @@ cc_library(
     deps = [
         ":entropy",
         "//hw/top:csrng_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt_csrng",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:macros",

--- a/sw/device/lib/crypto/drivers/entropy_kat.c
+++ b/sw/device/lib/crypto/drivers/entropy_kat.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "sw/device/lib/crypto/drivers/entropy_kat.h"
 
+#include "hw/top/dt/dt_csrng.h"
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/memory.h"
@@ -10,13 +11,14 @@
 #include "sw/device/lib/runtime/log.h"
 
 #include "hw/top/csrng_regs.h"  // Generated
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 #define MODULE_ID MAKE_MODULE_ID('e', 'n', 'k')
 
-enum {
-  kBaseCsrng = TOP_EARLGREY_CSRNG_BASE_ADDR,
-};
+static const dt_csrng_t kCsrngDt = kDtCsrng;
+
+static inline uint32_t csrng_base(void) {
+  return dt_csrng_primary_reg_block(kCsrngDt);
+}
 
 /**
  * CSRNG internal state selector ID.
@@ -67,26 +69,26 @@ typedef struct entropy_csrng_internal_state {
 static void entropy_csrng_internal_state_get(
     entropy_csrng_internal_state_id_t instance_id,
     entropy_csrng_internal_state_t *state) {
+  const uint32_t kBase = csrng_base();
   // Select the instance id to read the internal state from, request a state
   // machine halt, and wait for the internal registers to be ready to be read.
   uint32_t reg = bitfield_field32_write(
       0, CSRNG_INT_STATE_NUM_INT_STATE_NUM_FIELD, instance_id);
-  abs_mmio_write32(kBaseCsrng + CSRNG_INT_STATE_NUM_REG_OFFSET, reg);
+  abs_mmio_write32(kBase + CSRNG_INT_STATE_NUM_REG_OFFSET, reg);
 
   // Read the internal state.
   state->reseed_counter =
-      abs_mmio_read32(kBaseCsrng + CSRNG_INT_STATE_VAL_REG_OFFSET);
+      abs_mmio_read32(kBase + CSRNG_INT_STATE_VAL_REG_OFFSET);
 
   for (size_t i = 0; i < ARRAYSIZE(state->v); ++i) {
-    state->v[i] = abs_mmio_read32(kBaseCsrng + CSRNG_INT_STATE_VAL_REG_OFFSET);
+    state->v[i] = abs_mmio_read32(kBase + CSRNG_INT_STATE_VAL_REG_OFFSET);
   }
 
   for (size_t i = 0; i < ARRAYSIZE(state->key); ++i) {
-    state->key[i] =
-        abs_mmio_read32(kBaseCsrng + CSRNG_INT_STATE_VAL_REG_OFFSET);
+    state->key[i] = abs_mmio_read32(kBase + CSRNG_INT_STATE_VAL_REG_OFFSET);
   }
 
-  uint32_t flags = abs_mmio_read32(kBaseCsrng + CSRNG_INT_STATE_VAL_REG_OFFSET);
+  uint32_t flags = abs_mmio_read32(kBase + CSRNG_INT_STATE_VAL_REG_OFFSET);
 
   // The following bit indexes are defined in
   // https://opentitan.org/book/hw/ip/csrng/doc/theory_of_operation.html#working-state-values


### PR DESCRIPTION
The cryptolib uses hard-coded drivers, which only work for Earlgrey. This PR moves the entropy_kat driver to the generic DT-API.

Long term, the drivers need to be consolidated without duplicating it in the silicon creator lib.