### PR TITLE
[cryptolib] Move otbn driver to DT

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -265,8 +265,8 @@ cc_library(
     hdrs = ["otbn.h"],
     deps = [
         ":entropy",
+        "//hw/top:dt_otbn",
         "//hw/top:otbn_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:crc32",


### PR DESCRIPTION
The cryptolib uses hard-coded drivers, which only work for Earlgrey. This PR moves the otbn driver to the generic DT-API.

Long term, the drivers need to be consolidated without duplicating it in the silicon creator lib.