### PR TITLE
[crypto/rsa] Fix public-key exponent to F4

### DIFF
--- a/sw/device/lib/crypto/impl/rsa/rsa_datatypes.h
+++ b/sw/device/lib/crypto/impl/rsa/rsa_datatypes.h
@@ -69,31 +69,31 @@ typedef struct rsa_4096_int_t {
 /**
  * A type that holds an RSA-2048 public key.
  *
- * The public key consists of a 2048-bit modulus n and a public exponent e.
+ * The public key consists of a 2048-bit modulus n and an implicit constant
+ * public exponent e=2^16+1.
  */
 typedef struct rsa_2048_public_key_t {
   rsa_2048_int_t n;
-  uint32_t e;
 } rsa_2048_public_key_t;
 
 /**
  * A type that holds an RSA-3072 public key.
  *
- * The public key consists of a 3072-bit modulus n and a public exponent e.
+ * The public key consists of a 3072-bit modulus n and an implicit constant
+ * public exponent e=2^16+1.
  */
 typedef struct rsa_3072_public_key_t {
   rsa_3072_int_t n;
-  uint32_t e;
 } rsa_3072_public_key_t;
 
 /**
  * A type that holds an RSA-4096 public key.
  *
- * The public key consists of a 4096-bit modulus n and a public exponent e.
+ * The public key consists of a 4096-bit modulus n and an implicit constant
+ * public exponent e=2^16+1.
  */
 typedef struct rsa_4096_public_key_t {
   rsa_4096_int_t n;
-  uint32_t e;
 } rsa_4096_public_key_t;
 
 /**

--- a/sw/device/lib/crypto/impl/rsa/rsa_encryption.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_encryption.c
@@ -29,8 +29,7 @@ status_t rsa_encrypt_2048_start(const rsa_2048_public_key_t *public_key,
 
   // Start computing (encoded_message ^ e) mod n with a variable-time
   // exponentiation.
-  return rsa_modexp_vartime_2048_start(&encoded_message, public_key->e,
-                                       &public_key->n);
+  return rsa_modexp_vartime_2048_start(&encoded_message, &public_key->n);
 }
 
 status_t rsa_encrypt_2048_finalize(rsa_2048_int_t *ciphertext) {
@@ -120,8 +119,7 @@ status_t rsa_encrypt_3072_start(const rsa_3072_public_key_t *public_key,
 
   // Start computing (encoded_message ^ e) mod n with a variable-time
   // exponentiation.
-  return rsa_modexp_vartime_3072_start(&encoded_message, public_key->e,
-                                       &public_key->n);
+  return rsa_modexp_vartime_3072_start(&encoded_message, &public_key->n);
 }
 
 status_t rsa_encrypt_3072_finalize(rsa_3072_int_t *ciphertext) {
@@ -149,8 +147,7 @@ status_t rsa_encrypt_4096_start(const rsa_4096_public_key_t *public_key,
 
   // Start computing (encoded_message ^ e) mod n with a variable-time
   // exponentiation.
-  return rsa_modexp_vartime_4096_start(&encoded_message, public_key->e,
-                                       &public_key->n);
+  return rsa_modexp_vartime_4096_start(&encoded_message, &public_key->n);
 }
 
 status_t rsa_encrypt_4096_finalize(rsa_4096_int_t *ciphertext) {

--- a/sw/device/lib/crypto/impl/rsa/rsa_keygen.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_keygen.c
@@ -116,10 +116,6 @@ status_t rsa_keygen_2048_finalize(rsa_2048_public_key_t *public_key,
   HARDENED_TRY(hardened_memcpy(public_key->n.data, private_key->n.data,
                                ARRAYSIZE(private_key->n.data)));
 
-  // Set the public exponent to F4, the only exponent our key generation
-  // algorithm supports.
-  public_key->e = kFixedPublicExponent;
-
   return OTCRYPTO_OK;
 }
 
@@ -135,10 +131,6 @@ status_t rsa_keygen_3072_finalize(rsa_3072_public_key_t *public_key,
   // Copy the modulus to the public key.
   HARDENED_TRY(hardened_memcpy(public_key->n.data, private_key->n.data,
                                ARRAYSIZE(private_key->n.data)));
-
-  // Set the public exponent to F4, the only exponent our key generation
-  // algorithm supports.
-  public_key->e = kFixedPublicExponent;
 
   return OTCRYPTO_OK;
 }
@@ -156,21 +148,12 @@ status_t rsa_keygen_4096_finalize(rsa_4096_public_key_t *public_key,
   HARDENED_TRY(hardened_memcpy(public_key->n.data, private_key->n.data,
                                ARRAYSIZE(private_key->n.data)));
 
-  // Set the public exponent to F4, the only exponent our key generation
-  // algorithm supports.
-  public_key->e = kFixedPublicExponent;
-
   return OTCRYPTO_OK;
 }
 
 status_t rsa_keygen_from_cofactor_2048_start(
     const rsa_2048_public_key_t *public_key,
     const rsa_2048_cofactor_t *cofactor) {
-  // Only the exponent F4 is supported.
-  if (public_key->e != kFixedPublicExponent) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-
   // Load the RSA key generation app. Fails if OTBN is non-idle.
   HARDENED_TRY(otbn_load_app(kOtbnAppRsaKeygen));
 
@@ -194,10 +177,6 @@ status_t rsa_keygen_from_cofactor_2048_finalize(
   // Copy the modulus to the public key.
   HARDENED_TRY(hardened_memcpy(public_key->n.data, private_key->n.data,
                                ARRAYSIZE(private_key->n.data)));
-
-  // Set the public exponent to F4, the only exponent our key generation
-  // algorithm supports.
-  public_key->e = kFixedPublicExponent;
 
   return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/impl/rsa/rsa_modexp.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_modexp.c
@@ -130,17 +130,7 @@ status_t rsa_modexp_consttime_2048_start(const rsa_2048_int_t *base,
 }
 
 status_t rsa_modexp_vartime_2048_start(const rsa_2048_int_t *base,
-                                       const uint32_t exp,
                                        const rsa_2048_int_t *modulus) {
-  if (exp != kExponentF4) {
-    // TODO for other exponents, we temporarily fall back to the constant-time
-    // implementation until a variable-time implementation is supported.
-    rsa_2048_int_t exp_rsa;
-    memset(exp_rsa.data, 0, kRsa2048NumWords * sizeof(uint32_t));
-    exp_rsa.data[0] = exp;
-    return rsa_modexp_consttime_2048_start(base, &exp_rsa, modulus);
-  }
-
   // Load the OTBN app. Fails if OTBN is not idle.
   HARDENED_TRY(otbn_load_app(kOtbnAppRsaModexp));
 
@@ -180,17 +170,7 @@ status_t rsa_modexp_consttime_3072_start(const rsa_3072_int_t *base,
 }
 
 status_t rsa_modexp_vartime_3072_start(const rsa_3072_int_t *base,
-                                       const uint32_t exp,
                                        const rsa_3072_int_t *modulus) {
-  if (exp != kExponentF4) {
-    // TODO for other exponents, we temporarily fall back to the constant-time
-    // implementation until a variable-time implementation is supported.
-    rsa_3072_int_t exp_rsa;
-    memset(exp_rsa.data, 0, kRsa3072NumWords * sizeof(uint32_t));
-    exp_rsa.data[0] = exp;
-    return rsa_modexp_consttime_3072_start(base, &exp_rsa, modulus);
-  }
-
   // Load the OTBN app. Fails if OTBN is not idle.
   HARDENED_TRY(otbn_load_app(kOtbnAppRsaModexp));
 
@@ -230,17 +210,7 @@ status_t rsa_modexp_consttime_4096_start(const rsa_4096_int_t *base,
 }
 
 status_t rsa_modexp_vartime_4096_start(const rsa_4096_int_t *base,
-                                       const uint32_t exp,
                                        const rsa_4096_int_t *modulus) {
-  if (exp != kExponentF4) {
-    // TODO for other exponents, we temporarily fall back to the constant-time
-    // implementation until a variable-time implementation is supported.
-    rsa_4096_int_t exp_rsa;
-    memset(exp_rsa.data, 0, kRsa4096NumWords * sizeof(uint32_t));
-    exp_rsa.data[0] = exp;
-    return rsa_modexp_consttime_4096_start(base, &exp_rsa, modulus);
-  }
-
   // Load the OTBN app. Fails if OTBN is not idle.
   HARDENED_TRY(otbn_load_app(kOtbnAppRsaModexp));
 

--- a/sw/device/lib/crypto/impl/rsa/rsa_modexp.h
+++ b/sw/device/lib/crypto/impl/rsa/rsa_modexp.h
@@ -61,7 +61,6 @@ status_t rsa_modexp_consttime_2048_start(const rsa_2048_int_t *base,
  * @return Status of the operation (OK or error).
  */
 status_t rsa_modexp_vartime_2048_start(const rsa_2048_int_t *base,
-                                       const uint32_t exp,
                                        const rsa_2048_int_t *modulus);
 
 /**
@@ -107,7 +106,6 @@ status_t rsa_modexp_consttime_3072_start(const rsa_3072_int_t *base,
  * @return Status of the operation (OK or error).
  */
 status_t rsa_modexp_vartime_3072_start(const rsa_3072_int_t *base,
-                                       const uint32_t exp,
                                        const rsa_3072_int_t *modulus);
 
 /**
@@ -153,7 +151,6 @@ status_t rsa_modexp_consttime_4096_start(const rsa_4096_int_t *base,
  * @return Status of the operation (OK or error).
  */
 status_t rsa_modexp_vartime_4096_start(const rsa_4096_int_t *base,
-                                       const uint32_t exp,
                                        const rsa_4096_int_t *modulus);
 
 /**

--- a/sw/device/lib/crypto/impl/rsa/rsa_signature.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_signature.c
@@ -169,8 +169,7 @@ status_t rsa_signature_generate_2048_finalize(rsa_2048_int_t *signature) {
 status_t rsa_signature_verify_2048_start(
     const rsa_2048_public_key_t *public_key, const rsa_2048_int_t *signature) {
   // Start computing (sig ^ e) mod n with a variable-time exponentiation.
-  return rsa_modexp_vartime_2048_start(signature, public_key->e,
-                                       &public_key->n);
+  return rsa_modexp_vartime_2048_start(signature, &public_key->n);
 }
 
 status_t rsa_signature_verify_finalize(
@@ -237,8 +236,7 @@ status_t rsa_signature_generate_3072_finalize(rsa_3072_int_t *signature) {
 status_t rsa_signature_verify_3072_start(
     const rsa_3072_public_key_t *public_key, const rsa_3072_int_t *signature) {
   // Start computing (sig ^ e) mod n with a variable-time exponentiation.
-  return rsa_modexp_vartime_3072_start(signature, public_key->e,
-                                       &public_key->n);
+  return rsa_modexp_vartime_3072_start(signature, &public_key->n);
 }
 
 status_t rsa_signature_generate_4096_start(
@@ -263,6 +261,5 @@ status_t rsa_signature_generate_4096_finalize(rsa_4096_int_t *signature) {
 status_t rsa_signature_verify_4096_start(
     const rsa_4096_public_key_t *public_key, const rsa_4096_int_t *signature) {
   // Start computing (sig ^ e) mod n with a variable-time exponentiation.
-  return rsa_modexp_vartime_4096_start(signature, public_key->e,
-                                       &public_key->n);
+  return rsa_modexp_vartime_4096_start(signature, &public_key->n);
 }

--- a/sw/device/lib/crypto/include/rsa.h
+++ b/sw/device/lib/crypto/include/rsa.h
@@ -52,9 +52,9 @@ enum {
    * to change. This is the length that the caller should set as `key_length`
    * and allocate for the `key` buffer in unblinded keys.
    */
-  kOtcryptoRsa2048PublicKeyBytes = 260,
-  kOtcryptoRsa3072PublicKeyBytes = 388,
-  kOtcryptoRsa4096PublicKeyBytes = 516,
+  kOtcryptoRsa2048PublicKeyBytes = 256,
+  kOtcryptoRsa3072PublicKeyBytes = 384,
+  kOtcryptoRsa4096PublicKeyBytes = 512,
   /**
    * Number of bytes needed for RSA private keys.
    *
@@ -80,8 +80,7 @@ enum {
 /**
  * Performs the RSA key generation.
  *
- * Computes RSA private key (d) and RSA public key exponent (e) and
- * modulus (n).
+ * Computes RSA private key (d) and the public key modulus (n).
  *
  * The caller should allocate space for the public key and set the `key` and
  * `key_length` fields accordingly.
@@ -106,7 +105,8 @@ otcrypto_status_t otcrypto_rsa_keygen(otcrypto_rsa_size_t size,
  * Constructs an RSA public key from the modulus and public exponent.
  *
  * The caller should allocate space for the public key and set the `key` and
- * `key_length` fields accordingly.
+ * `key_length` fields accordingly. The public exponent is implicitly fixed
+ * to e=2^16+1.
  *
  * @param size RSA size parameter.
  * @param modulus RSA modulus (n).
@@ -116,7 +116,7 @@ otcrypto_status_t otcrypto_rsa_keygen(otcrypto_rsa_size_t size,
  */
 otcrypto_status_t otcrypto_rsa_public_key_construct(
     otcrypto_rsa_size_t size, otcrypto_const_word32_buf_t modulus,
-    uint32_t exponent, otcrypto_unblinded_key_t *public_key);
+    otcrypto_unblinded_key_t *public_key);
 
 /**
  * Constructs an RSA private key from the modulus and public/private exponents.
@@ -126,14 +126,13 @@ otcrypto_status_t otcrypto_rsa_public_key_construct(
  *
  * @param size RSA size parameter.
  * @param modulus RSA modulus (n).
- * @param exponent RSA public exponent (e).
  * @param d_share0 First share of the RSA private exponent d.
  * @param d_share1 Second share of the RSA private exponent d.
  * @param[out] public_key Destination public key struct.
  * @return Result of the RSA key construction.
  */
 otcrypto_status_t otcrypto_rsa_private_key_from_exponents(
-    otcrypto_rsa_size_t size, otcrypto_const_word32_buf_t modulus, uint32_t e,
+    otcrypto_rsa_size_t size, otcrypto_const_word32_buf_t modulus,
     otcrypto_const_word32_buf_t d_share0, otcrypto_const_word32_buf_t d_share1,
     otcrypto_blinded_key_t *private_key);
 
@@ -147,7 +146,6 @@ otcrypto_status_t otcrypto_rsa_private_key_from_exponents(
  *
  * @param size RSA size parameter.
  * @param modulus RSA modulus (n).
- * @param exponent RSA public exponent (e).
  * @param cofactor_share0 First share of the prime cofactor (p or q).
  * @param cofactor_share1 Second share of the prime cofactor (p or q).
  * @param[out] public_key Destination public key struct.
@@ -155,7 +153,7 @@ otcrypto_status_t otcrypto_rsa_private_key_from_exponents(
  * @return Result of the RSA key construction.
  */
 otcrypto_status_t otcrypto_rsa_keypair_from_cofactor(
-    otcrypto_rsa_size_t size, otcrypto_const_word32_buf_t modulus, uint32_t e,
+    otcrypto_rsa_size_t size, otcrypto_const_word32_buf_t modulus,
     otcrypto_const_word32_buf_t cofactor_share0,
     otcrypto_const_word32_buf_t cofactor_share1,
     otcrypto_unblinded_key_t *public_key, otcrypto_blinded_key_t *private_key);
@@ -302,13 +300,12 @@ otcrypto_status_t otcrypto_rsa_keygen_async_finalize(
  *
  * @param size RSA size parameter.
  * @param modulus RSA modulus (n).
- * @param exponent RSA public exponent (e).
  * @param cofactor_share0 First share of the prime cofactor (p or q).
  * @param cofactor_share1 Second share of the prime cofactor (p or q).
  * @return Result of the RSA key construction.
  */
 otcrypto_status_t otcrypto_rsa_keypair_from_cofactor_async_start(
-    otcrypto_rsa_size_t size, otcrypto_const_word32_buf_t modulus, uint32_t e,
+    otcrypto_rsa_size_t size, otcrypto_const_word32_buf_t modulus,
     otcrypto_const_word32_buf_t cofactor_share0,
     otcrypto_const_word32_buf_t cofactor_share1);
 

--- a/sw/device/tests/crypto/otcrypto_interface.h
+++ b/sw/device/tests/crypto/otcrypto_interface.h
@@ -210,16 +210,17 @@ typedef struct otcrypto_interface_t {
                                   otcrypto_blinded_key_t *);
   otcrypto_status_t (*rsa_public_key_construct)(otcrypto_rsa_size_t,
                                                 otcrypto_const_word32_buf_t,
-                                                uint32_t,
                                                 otcrypto_unblinded_key_t *);
   otcrypto_status_t (*rsa_private_key_from_exponents)(
-      otcrypto_rsa_size_t, otcrypto_const_word32_buf_t, uint32_t,
+      otcrypto_rsa_size_t, otcrypto_const_word32_buf_t,
       otcrypto_const_word32_buf_t, otcrypto_const_word32_buf_t,
       otcrypto_blinded_key_t *);
-  otcrypto_status_t (*rsa_keypair_from_cofactor)(
-      otcrypto_rsa_size_t, otcrypto_const_word32_buf_t, uint32_t,
-      otcrypto_const_word32_buf_t, otcrypto_const_word32_buf_t,
-      otcrypto_unblinded_key_t *, otcrypto_blinded_key_t *);
+  otcrypto_status_t (*rsa_keypair_from_cofactor)(otcrypto_rsa_size_t,
+                                                 otcrypto_const_word32_buf_t,
+                                                 otcrypto_const_word32_buf_t,
+                                                 otcrypto_const_word32_buf_t,
+                                                 otcrypto_unblinded_key_t *,
+                                                 otcrypto_blinded_key_t *);
   otcrypto_status_t (*rsa_sign)(const otcrypto_blinded_key_t *,
                                 const otcrypto_hash_digest_t,
                                 otcrypto_rsa_padding_t, otcrypto_word32_buf_t);
@@ -242,7 +243,7 @@ typedef struct otcrypto_interface_t {
   otcrypto_status_t (*rsa_keygen_async_finalize)(otcrypto_unblinded_key_t *,
                                                  otcrypto_blinded_key_t *);
   otcrypto_status_t (*rsa_keypair_from_cofactor_async_start)(
-      otcrypto_rsa_size_t, otcrypto_const_word32_buf_t, uint32_t,
+      otcrypto_rsa_size_t, otcrypto_const_word32_buf_t,
       otcrypto_const_word32_buf_t cofactor_share0,
       otcrypto_const_word32_buf_t cofactor_share1);
   otcrypto_status_t (*rsa_keypair_from_cofactor_async_finalize)(

--- a/sw/device/tests/crypto/rsa_2048_encryption_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_encryption_functest.c
@@ -50,7 +50,6 @@ static uint32_t kTestPrivateExponent[kRsa2048NumWords] = {
     0xcaa6815c, 0x08ca0fd3, 0x8f996093, 0x30b7c446, 0xf69b11f7, 0xa298dd00,
     0xfd4e8120, 0x059df602, 0x25feb268, 0x0f3f749e,
 };
-static uint32_t kTestPublicExponent = 65537;
 
 // Message data for testing.
 static const unsigned char kTestMessage[] = "Test message.";
@@ -113,7 +112,7 @@ static status_t run_rsa_2048_encrypt(const uint8_t *msg, size_t msg_len,
       .key = public_key_data,
   };
   TRY(otcrypto_rsa_public_key_construct(kOtcryptoRsaSize2048, modulus,
-                                        kTestPublicExponent, &public_key));
+                                        &public_key));
 
   otcrypto_const_byte_buf_t msg_buf = {.data = msg, .len = msg_len};
   otcrypto_const_byte_buf_t label_buf = {.data = label, .len = label_len};
@@ -180,9 +179,8 @@ static status_t run_rsa_2048_decrypt(const uint8_t *label, size_t label_len,
       .data = kTestModulus,
       .len = ARRAYSIZE(kTestModulus),
   };
-  TRY(otcrypto_rsa_private_key_from_exponents(kOtcryptoRsaSize2048, modulus,
-                                              kTestPublicExponent, d_share0,
-                                              d_share1, &private_key));
+  TRY(otcrypto_rsa_private_key_from_exponents(
+      kOtcryptoRsaSize2048, modulus, d_share0, d_share1, &private_key));
 
   otcrypto_byte_buf_t plaintext_buf = {.data = msg, .len = kMaxPlaintextBytes};
   otcrypto_const_byte_buf_t label_buf = {.data = label, .len = label_len};

--- a/sw/device/tests/crypto/rsa_2048_key_from_cofactor_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_key_from_cofactor_functest.c
@@ -49,7 +49,6 @@ static uint32_t kTestPrivateExponent[kRsa2048NumWords] = {
     0xcaa6815c, 0x08ca0fd3, 0x8f996093, 0x30b7c446, 0xf69b11f7, 0xa298dd00,
     0xfd4e8120, 0x059df602, 0x25feb268, 0x0f3f749e,
 };
-static uint32_t kTestPublicExponent = 65537;
 
 // Key mode for testing.
 static otcrypto_key_mode_t kTestKeyMode = kOtcryptoKeyModeRsaSignPss;
@@ -131,9 +130,9 @@ static status_t run_key_from_cofactor(const uint32_t *cofactor) {
 
   // Construct the RSA key pair using the cofactor.
   uint64_t t_start = profile_start();
-  TRY(otcrypto_rsa_keypair_from_cofactor(
-      kOtcryptoRsaSize2048, modulus, kTestPublicExponent, cofactor_share0,
-      cofactor_share1, &public_key, &private_key));
+  TRY(otcrypto_rsa_keypair_from_cofactor(kOtcryptoRsaSize2048, modulus,
+                                         cofactor_share0, cofactor_share1,
+                                         &public_key, &private_key));
   profile_end_and_print(t_start, "RSA keypair from cofactor");
 
   // Interpret the private key and ensure the private exponent matches the
@@ -149,7 +148,6 @@ static status_t run_key_from_cofactor(const uint32_t *cofactor) {
   TRY_CHECK(public_key.key_length == sizeof(rsa_2048_public_key_t));
   rsa_2048_public_key_t *pk = (rsa_2048_public_key_t *)public_key.key;
   TRY_CHECK_ARRAYS_EQ(pk->n.data, kTestModulus, ARRAYSIZE(kTestModulus));
-  TRY_CHECK(pk->e == kTestPublicExponent);
   return OK_STATUS();
 }
 

--- a/sw/device/tests/crypto/rsa_2048_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_keygen_functest.c
@@ -66,9 +66,6 @@ status_t keygen_then_sign_test(void) {
   TRY_CHECK(private_key.keyblob_length == sizeof(rsa_2048_private_key_t));
   rsa_2048_private_key_t *sk = (rsa_2048_private_key_t *)private_key.keyblob;
 
-  // Check that the key uses the F4 exponent.
-  TRY_CHECK(pk->e == 65537);
-
   // Check that the moduli match.
   TRY_CHECK(ARRAYSIZE(pk->n.data) == ARRAYSIZE(sk->n.data));
   TRY_CHECK_ARRAYS_EQ(pk->n.data, sk->n.data, ARRAYSIZE(pk->n.data));

--- a/sw/device/tests/crypto/rsa_2048_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_signature_functest.c
@@ -50,7 +50,6 @@ static uint32_t kTestPrivateExponent[kRsa2048NumWords] = {
     0xcaa6815c, 0x08ca0fd3, 0x8f996093, 0x30b7c446, 0xf69b11f7, 0xa298dd00,
     0xfd4e8120, 0x059df602, 0x25feb268, 0x0f3f749e,
 };
-static uint32_t kTestPublicExponent = 65537;
 
 // Message data for testing.
 static const unsigned char kTestMessage[] = "Test message.";
@@ -147,9 +146,8 @@ static status_t run_rsa_2048_sign(const uint8_t *msg, size_t msg_len,
       .data = kTestModulus,
       .len = ARRAYSIZE(kTestModulus),
   };
-  TRY(otcrypto_rsa_private_key_from_exponents(kOtcryptoRsaSize2048, modulus,
-                                              kTestPublicExponent, d_share0,
-                                              d_share1, &private_key));
+  TRY(otcrypto_rsa_private_key_from_exponents(
+      kOtcryptoRsaSize2048, modulus, d_share0, d_share1, &private_key));
 
   // Hash the message.
   otcrypto_const_byte_buf_t msg_buf = {.data = msg, .len = msg_len};
@@ -214,7 +212,7 @@ static status_t run_rsa_2048_verify(const uint8_t *msg, size_t msg_len,
       .key = public_key_data,
   };
   TRY(otcrypto_rsa_public_key_construct(kOtcryptoRsaSize2048, modulus,
-                                        kTestPublicExponent, &public_key));
+                                        &public_key));
 
   // Hash the message.
   otcrypto_const_byte_buf_t msg_buf = {.data = msg, .len = msg_len};

--- a/sw/device/tests/crypto/rsa_3072_encryption_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_encryption_functest.c
@@ -67,7 +67,6 @@ static uint32_t kTestPrivateExponent[kRsa3072NumWords] = {
     0x31837e6a, 0xb02d0228, 0x9be7eb6e, 0xe1746942, 0xb6b48e76, 0xbf8c79d3,
     0xd81b2383, 0x9e277621, 0x8c4ca670, 0xcfa2b928, 0xd60f0279, 0x2e1fdefe,
 };
-static uint32_t kTestPublicExponent = 65537;
 
 // Message data for testing.
 static const unsigned char kTestMessage[] = "Test message.";
@@ -135,7 +134,7 @@ static status_t run_rsa_3072_encrypt(const uint8_t *msg, size_t msg_len,
       .key = public_key_data,
   };
   TRY(otcrypto_rsa_public_key_construct(kOtcryptoRsaSize3072, modulus,
-                                        kTestPublicExponent, &public_key));
+                                        &public_key));
 
   otcrypto_const_byte_buf_t msg_buf = {.data = msg, .len = msg_len};
   otcrypto_const_byte_buf_t label_buf = {.data = label, .len = label_len};
@@ -202,9 +201,8 @@ static status_t run_rsa_3072_decrypt(const uint8_t *label, size_t label_len,
       .data = kTestModulus,
       .len = ARRAYSIZE(kTestModulus),
   };
-  TRY(otcrypto_rsa_private_key_from_exponents(kOtcryptoRsaSize3072, modulus,
-                                              kTestPublicExponent, d_share0,
-                                              d_share1, &private_key));
+  TRY(otcrypto_rsa_private_key_from_exponents(
+      kOtcryptoRsaSize3072, modulus, d_share0, d_share1, &private_key));
 
   otcrypto_byte_buf_t plaintext_buf = {.data = msg, .len = kMaxPlaintextBytes};
   otcrypto_const_byte_buf_t label_buf = {.data = label, .len = label_len};

--- a/sw/device/tests/crypto/rsa_3072_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_keygen_functest.c
@@ -66,9 +66,6 @@ status_t keygen_then_sign_test(void) {
   TRY_CHECK(private_key.keyblob_length == sizeof(rsa_3072_private_key_t));
   rsa_3072_private_key_t *sk = (rsa_3072_private_key_t *)private_key.keyblob;
 
-  // Check that the key uses the F4 exponent.
-  TRY_CHECK(pk->e == 65537);
-
   // Check that the moduli match.
   TRY_CHECK(ARRAYSIZE(pk->n.data) == ARRAYSIZE(sk->n.data));
   TRY_CHECK_ARRAYS_EQ(pk->n.data, sk->n.data, ARRAYSIZE(pk->n.data));

--- a/sw/device/tests/crypto/rsa_3072_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_signature_functest.c
@@ -68,7 +68,6 @@ static uint32_t kTestPrivateExponent[kRsa3072NumWords] = {
     0x31837e6a, 0xb02d0228, 0x9be7eb6e, 0xe1746942, 0xb6b48e76, 0xbf8c79d3,
     0xd81b2383, 0x9e277621, 0x8c4ca670, 0xcfa2b928, 0xd60f0279, 0x2e1fdefe,
 };
-static uint32_t kTestPublicExponent = 65537;
 
 // Message data for testing.
 static const unsigned char kTestMessage[] = "Test message.";
@@ -174,9 +173,8 @@ static status_t run_rsa_3072_sign(const uint8_t *msg, size_t msg_len,
       .data = kTestModulus,
       .len = ARRAYSIZE(kTestModulus),
   };
-  TRY(otcrypto_rsa_private_key_from_exponents(kOtcryptoRsaSize3072, modulus,
-                                              kTestPublicExponent, d_share0,
-                                              d_share1, &private_key));
+  TRY(otcrypto_rsa_private_key_from_exponents(
+      kOtcryptoRsaSize3072, modulus, d_share0, d_share1, &private_key));
 
   // Hash the message.
   otcrypto_const_byte_buf_t msg_buf = {.data = msg, .len = msg_len};
@@ -242,7 +240,7 @@ static status_t run_rsa_3072_verify(const uint8_t *msg, size_t msg_len,
       .key = public_key_data,
   };
   TRY(otcrypto_rsa_public_key_construct(kOtcryptoRsaSize3072, modulus,
-                                        kTestPublicExponent, &public_key));
+                                        &public_key));
 
   // Hash the message.
   otcrypto_const_byte_buf_t msg_buf = {.data = msg, .len = msg_len};

--- a/sw/device/tests/crypto/rsa_4096_encryption_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_encryption_functest.c
@@ -81,7 +81,6 @@ static uint32_t kTestPrivateExponent[kRsa4096NumWords] = {
     0x965d9408, 0x19aacb83,
 
 };
-static uint32_t kTestPublicExponent = 65537;
 
 // Message data for testing.
 static const unsigned char kTestMessage[] = "Test message.";
@@ -155,7 +154,7 @@ static status_t run_rsa_4096_encrypt(const uint8_t *msg, size_t msg_len,
       .key = public_key_data,
   };
   TRY(otcrypto_rsa_public_key_construct(kOtcryptoRsaSize4096, modulus,
-                                        kTestPublicExponent, &public_key));
+                                        &public_key));
 
   otcrypto_const_byte_buf_t msg_buf = {.data = msg, .len = msg_len};
   otcrypto_const_byte_buf_t label_buf = {.data = label, .len = label_len};
@@ -222,9 +221,8 @@ static status_t run_rsa_4096_decrypt(const uint8_t *label, size_t label_len,
       .data = kTestModulus,
       .len = ARRAYSIZE(kTestModulus),
   };
-  TRY(otcrypto_rsa_private_key_from_exponents(kOtcryptoRsaSize4096, modulus,
-                                              kTestPublicExponent, d_share0,
-                                              d_share1, &private_key));
+  TRY(otcrypto_rsa_private_key_from_exponents(
+      kOtcryptoRsaSize4096, modulus, d_share0, d_share1, &private_key));
 
   otcrypto_byte_buf_t plaintext_buf = {.data = msg, .len = kMaxPlaintextBytes};
   otcrypto_const_byte_buf_t label_buf = {.data = label, .len = label_len};

--- a/sw/device/tests/crypto/rsa_4096_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_keygen_functest.c
@@ -66,9 +66,6 @@ status_t keygen_then_sign_test(void) {
   TRY_CHECK(private_key.keyblob_length == sizeof(rsa_4096_private_key_t));
   rsa_4096_private_key_t *sk = (rsa_4096_private_key_t *)private_key.keyblob;
 
-  // Check that the key uses the F4 exponent.
-  TRY_CHECK(pk->e == 65537);
-
   // Check that the moduli match.
   TRY_CHECK(ARRAYSIZE(pk->n.data) == ARRAYSIZE(sk->n.data));
   TRY_CHECK_ARRAYS_EQ(pk->n.data, sk->n.data, ARRAYSIZE(pk->n.data));

--- a/sw/device/tests/crypto/rsa_4096_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_signature_functest.c
@@ -82,7 +82,6 @@ static uint32_t kTestPrivateExponent[kRsa4096NumWords] = {
     0x965d9408, 0x19aacb83,
 
 };
-static uint32_t kTestPublicExponent = 65537;
 
 // Message data for testing.
 static const unsigned char kTestMessage[] = "Test message.";
@@ -203,9 +202,8 @@ static status_t run_rsa_4096_sign(const uint8_t *msg, size_t msg_len,
       .data = kTestModulus,
       .len = ARRAYSIZE(kTestModulus),
   };
-  TRY(otcrypto_rsa_private_key_from_exponents(kOtcryptoRsaSize4096, modulus,
-                                              kTestPublicExponent, d_share0,
-                                              d_share1, &private_key));
+  TRY(otcrypto_rsa_private_key_from_exponents(
+      kOtcryptoRsaSize4096, modulus, d_share0, d_share1, &private_key));
 
   // Hash the message.
   otcrypto_const_byte_buf_t msg_buf = {.data = msg, .len = msg_len};
@@ -271,7 +269,7 @@ static status_t run_rsa_4096_verify(const uint8_t *msg, size_t msg_len,
       .key = public_key_data,
   };
   TRY(otcrypto_rsa_public_key_construct(kOtcryptoRsaSize4096, modulus,
-                                        kTestPublicExponent, &public_key));
+                                        &public_key));
 
   // Hash the message.
   otcrypto_const_byte_buf_t msg_buf = {.data = msg, .len = msg_len};

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
@@ -120,8 +120,7 @@ status_t cryptolib_fi_rsa_enc_impl(cryptolib_fi_asym_rsa_enc_in_t uj_input,
         .key_length = public_key_bytes,
         .key = public_key_data,
     };
-    TRY(otcrypto_rsa_public_key_construct(rsa_size, modulus, uj_input.e,
-                                          &public_key));
+    TRY(otcrypto_rsa_public_key_construct(rsa_size, modulus, &public_key));
 
     // Create input message.
     uint8_t msg_buf[num_words];
@@ -198,8 +197,8 @@ status_t cryptolib_fi_rsa_enc_impl(cryptolib_fi_asym_rsa_enc_in_t uj_input,
     if (uj_input.trigger & kPentestTrigger1) {
       pentest_set_trigger_high();
     }
-    TRY(otcrypto_rsa_private_key_from_exponents(
-        rsa_size, modulus, uj_input.e, d_share0, d_share1, &private_key));
+    TRY(otcrypto_rsa_private_key_from_exponents(rsa_size, modulus, d_share0,
+                                                d_share1, &private_key));
     if (uj_input.trigger & kPentestTrigger1) {
       pentest_set_trigger_low();
     }
@@ -359,8 +358,8 @@ status_t cryptolib_fi_rsa_sign_impl(
   if (uj_input.trigger & kPentestTrigger1) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_rsa_private_key_from_exponents(
-      rsa_size, modulus, uj_input.e, d_share0, d_share1, &private_key));
+  TRY(otcrypto_rsa_private_key_from_exponents(rsa_size, modulus, d_share0,
+                                              d_share1, &private_key));
   if (uj_input.trigger & kPentestTrigger1) {
     pentest_set_trigger_low();
   }
@@ -511,8 +510,7 @@ status_t cryptolib_fi_rsa_verify_impl(
   if (uj_input.trigger & kPentestTrigger1) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_rsa_public_key_construct(rsa_size, modulus, uj_input.e,
-                                        &public_key));
+  TRY(otcrypto_rsa_public_key_construct(rsa_size, modulus, &public_key));
   // Trigger window.
   if (uj_input.trigger & kPentestTrigger1) {
     pentest_set_trigger_low();

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym.c
@@ -19,7 +19,7 @@
 
 status_t trigger_cryptolib_sca_asym_rsa_dec(
     uint8_t data[RSA_CMD_MAX_MESSAGE_BYTES], size_t data_len, size_t mode,
-    uint32_t e, uint8_t n[RSA_CMD_MAX_N_BYTES], uint8_t d[RSA_CMD_MAX_N_BYTES],
+    uint8_t n[RSA_CMD_MAX_N_BYTES], uint8_t d[RSA_CMD_MAX_N_BYTES],
     size_t *n_len, uint8_t data_out[RSA_CMD_MAX_MESSAGE_BYTES],
     size_t *data_out_len, size_t hashing, size_t padding, size_t cfg_in,
     size_t *cfg_out, size_t *status, size_t trigger) {
@@ -28,7 +28,7 @@ status_t trigger_cryptolib_sca_asym_rsa_dec(
   // Adjust the hashing and the padding mode.
   // Triggers are over the API calls.
   *status = (size_t)cryptolib_sca_rsa_dec_impl(
-                data, data_len, mode, e, n, d, n_len, data_out, data_out_len,
+                data, data_len, mode, n, d, n_len, data_out, data_out_len,
                 hashing, padding, cfg_in, cfg_out, trigger)
                 .value;
   /////////////// STUB END ///////////////
@@ -54,9 +54,9 @@ status_t handle_cryptolib_sca_asym_rsa_dec(ujson_t *uj) {
   memset(d, 0, RSA_CMD_MAX_N_BYTES);
   memcpy(d, uj_input.d, n_len);
   TRY(trigger_cryptolib_sca_asym_rsa_dec(
-      datain, uj_input.data_len, uj_input.mode, uj_input.e, n, d, &n_len,
-      data_out_buf, &data_out_len, uj_input.hashing, uj_input.padding,
-      uj_input.cfg, &cfg_out, &status, uj_input.trigger));
+      datain, uj_input.data_len, uj_input.mode, n, d, &n_len, data_out_buf,
+      &data_out_len, uj_input.hashing, uj_input.padding, uj_input.cfg, &cfg_out,
+      &status, uj_input.trigger));
 
   // Send the last data_out to host via UART.
   cryptolib_sca_asym_rsa_dec_out_t uj_output;
@@ -74,7 +74,7 @@ status_t handle_cryptolib_sca_asym_rsa_dec(ujson_t *uj) {
 }
 
 status_t trigger_cryptolib_sca_asym_rsa_sign(
-    uint8_t data[RSA_CMD_MAX_MESSAGE_BYTES], size_t data_len, uint32_t e,
+    uint8_t data[RSA_CMD_MAX_MESSAGE_BYTES], size_t data_len,
     uint8_t n[RSA_CMD_MAX_N_BYTES], uint8_t d[RSA_CMD_MAX_N_BYTES],
     size_t *n_len, uint8_t sig[RSA_CMD_MAX_SIGNATURE_BYTES], size_t *sig_len,
     size_t hashing, size_t padding, size_t cfg_in, size_t *cfg_out,
@@ -83,7 +83,7 @@ status_t trigger_cryptolib_sca_asym_rsa_sign(
   // Perform an RSA sign.
   // Adjust the hashing and the padding mode.
   // Triggers are over the API calls.
-  *status = (size_t)cryptolib_sca_rsa_sign_impl(data, data_len, e, n, d, n_len,
+  *status = (size_t)cryptolib_sca_rsa_sign_impl(data, data_len, n, d, n_len,
                                                 sig, sig_len, hashing, padding,
                                                 cfg_in, cfg_out, trigger)
                 .value;
@@ -127,9 +127,9 @@ status_t handle_cryptolib_sca_asym_rsa_sign(ujson_t *uj) {
   size_t cfg_out;
   size_t status;
   TRY(trigger_cryptolib_sca_asym_rsa_sign(
-      data_in_buf, uj_input.data_len, uj_input.e, n, d, &n_len, sig_buf,
-      &sig_len, uj_input.hashing, uj_input.padding, uj_input.cfg, &cfg_out,
-      &status, uj_input.trigger));
+      data_in_buf, uj_input.data_len, n, d, &n_len, sig_buf, &sig_len,
+      uj_input.hashing, uj_input.padding, uj_input.cfg, &cfg_out, &status,
+      uj_input.trigger));
 
   cryptolib_sca_asym_rsa_sign_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym_impl.c
@@ -32,7 +32,7 @@ static const size_t kTestLabelLen = sizeof(kTestLabel) - 1;
 
 status_t cryptolib_sca_rsa_dec_impl(
     uint8_t data[RSA_CMD_MAX_MESSAGE_BYTES], size_t data_len, size_t mode,
-    uint32_t e, uint8_t n[RSA_CMD_MAX_N_BYTES], uint8_t d[RSA_CMD_MAX_N_BYTES],
+    uint8_t n[RSA_CMD_MAX_N_BYTES], uint8_t d[RSA_CMD_MAX_N_BYTES],
     size_t *n_len, uint8_t data_out[RSA_CMD_MAX_MESSAGE_BYTES],
     size_t *data_out_len, size_t hashing, size_t padding, size_t cfg_in,
     size_t *cfg_out, size_t trigger) {
@@ -143,7 +143,7 @@ status_t cryptolib_sca_rsa_dec_impl(
   if (trigger & kPentestTrigger1) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_rsa_private_key_from_exponents(rsa_size, modulus, e, d_share0,
+  TRY(otcrypto_rsa_private_key_from_exponents(rsa_size, modulus, d_share0,
                                               d_share1, &private_key));
   if (trigger & kPentestTrigger1) {
     pentest_set_trigger_low();
@@ -270,7 +270,7 @@ status_t cryptolib_sca_p256_ecdh_impl(
 }
 
 status_t cryptolib_sca_rsa_sign_impl(
-    uint8_t data[RSA_CMD_MAX_MESSAGE_BYTES], size_t data_len, uint32_t e,
+    uint8_t data[RSA_CMD_MAX_MESSAGE_BYTES], size_t data_len,
     uint8_t n[RSA_CMD_MAX_N_BYTES], uint8_t d[RSA_CMD_MAX_N_BYTES],
     size_t *n_len, uint8_t sig[RSA_CMD_MAX_SIGNATURE_BYTES], size_t *sig_len,
     size_t hashing, size_t padding, size_t cfg_in, size_t *cfg_out,
@@ -383,7 +383,7 @@ status_t cryptolib_sca_rsa_sign_impl(
   if (trigger & kPentestTrigger1) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_rsa_private_key_from_exponents(rsa_size, modulus, e, d_share0,
+  TRY(otcrypto_rsa_private_key_from_exponents(rsa_size, modulus, d_share0,
                                               d_share1, &private_key));
   if (trigger & kPentestTrigger1) {
     pentest_set_trigger_low();

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym_impl.h
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym_impl.h
@@ -15,7 +15,6 @@
  * @param data Input data.
  * @param data_len Input data length.
  * @param mode Mode.
- * @param e RSA public exponent.
  * @param n RSA modulus.
  * @param d RSA private key.
  * @param[out] n_len RSA length.
@@ -30,7 +29,7 @@
  */
 status_t cryptolib_sca_rsa_dec_impl(
     uint8_t data[RSA_CMD_MAX_MESSAGE_BYTES], size_t data_len, size_t mode,
-    uint32_t e, uint8_t n[RSA_CMD_MAX_N_BYTES], uint8_t d[RSA_CMD_MAX_N_BYTES],
+    uint8_t n[RSA_CMD_MAX_N_BYTES], uint8_t d[RSA_CMD_MAX_N_BYTES],
     size_t *n_len, uint8_t data_out[RSA_CMD_MAX_MESSAGE_BYTES],
     size_t *data_out_len, size_t hashing, size_t padding, size_t cfg_in,
     size_t *cfg_out, size_t trigger);
@@ -40,7 +39,6 @@ status_t cryptolib_sca_rsa_dec_impl(
  *
  * @param data Input data.
  * @param data_len Input data length.
- * @param e RSA public exponent.
  * @param n RSA modulus.
  * @param d RSA private key.
  * @param[out] n_len RSA length.
@@ -54,7 +52,7 @@ status_t cryptolib_sca_rsa_dec_impl(
  * @return OK or error.
  */
 status_t cryptolib_sca_rsa_sign_impl(
-    uint8_t data[RSA_CMD_MAX_MESSAGE_BYTES], size_t data_len, uint32_t e,
+    uint8_t data[RSA_CMD_MAX_MESSAGE_BYTES], size_t data_len,
     uint8_t n[RSA_CMD_MAX_N_BYTES], uint8_t d[RSA_CMD_MAX_N_BYTES],
     size_t *n_len, uint8_t sig[RSA_CMD_MAX_SIGNATURE_BYTES], size_t *sig_len,
     size_t hashing, size_t padding, size_t cfg_in, size_t *cfg_out,


### PR DESCRIPTION
F4=2^16+1 is the de-facto standard public-key exponent for all standardized RSA encryption/signature schemes. The cryptolib supported a haphazard implementation for arbitrary exponents that reverted back to F4 in many places. This commit removes all the residuals with regards to arbitrary values.