### PR TITLE
[cryptolib] Move kmac driver to DT

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -122,8 +122,8 @@ cc_library(
     deps = [
         ":entropy",
         ":rv_core_ibex",
+        "//hw/top:dt_kmac",
         "//hw/top:kmac_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:hardened",


### PR DESCRIPTION
The cryptolib uses hard-coded drivers, which only work for Earlgrey. This PR moves the kmac driver to the generic DT-API.

Long term, the drivers need to be consolidated without duplicating it in the silicon creator lib.