### PR TITLE
[signing] Remove the key_{ecdsa, sphincsplus} rules

### DIFF
--- a/hw/ip/otp_ctrl/data/earlgrey_skus/sival/keys/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/sival/keys/BUILD
@@ -13,8 +13,6 @@ load(
 
 package(default_visibility = ["//visibility:public"])
 
-# TODO(#22155, #18313): Decide on keyset vs. keyinfo for supplying signing info to the
-# offline/token signing flows.  Currently, only keyset supports tokens.
 keyset(
     name = "keyset",
     build_setting_default = "",

--- a/rules/opentitan/keyutils.bzl
+++ b/rules/opentitan/keyutils.bzl
@@ -2,89 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:signing.bzl", "KeyInfo")
 load("//rules:const.bzl", "CONST")
 load("@bazel_skylib//lib:structs.bzl", "structs")
-
-def _build_key_info_handler(id):
-    """Return a handler that creates a KeyInfo provider.
-
-    Args:
-        id: Identifier used by the consumers of the provider to determine the key algorithm.
-    Returns:
-        A handler that creates a KeyInfo provider.
-    """
-
-    def key_info_handler(ctx):
-        return [KeyInfo(
-            id = id,
-            config = ctx.attr.config,
-            method = ctx.attr.method,
-            pub_key = ctx.file.pub_key,
-            private_key = ctx.file.private_key,
-            type = ctx.attr.type,
-        )]
-
-    return key_info_handler
-
-key_sphincs_plus = rule(
-    implementation = _build_key_info_handler("sphincs_plus"),
-    attrs = {
-        "pub_key": attr.label(
-            allow_single_file = [".pem"],
-            doc = "Public key in pem format.",
-        ),
-        "private_key": attr.label(
-            allow_single_file = [".pem"],
-            doc = "Private key in pem format.",
-        ),
-        "type": attr.string(
-            default = "TestKey",
-            doc = "The type of the key. Can be TestKey, DevKey or ProdKey.",
-            values = ["TestKey", "DevKey", "ProdKey"],
-        ),
-        "config": attr.string_dict(
-            doc = "The config properties of the key.  `domain` can be `Pure` or `PreHashedSha256`.",
-        ),
-        "method": attr.string(
-            doc = "Mechanism used to access the key. Can be local or hsmtool.",
-            values = ["local", "hsmtool"],
-        ),
-    },
-)
-
-key_ecdsa = rule(
-    implementation = _build_key_info_handler("ecdsa"),
-    attrs = {
-        "pub_key": attr.label(
-            allow_single_file = [".der"],
-            doc = "Public key in DER format.",
-        ),
-        "private_key": attr.label(
-            allow_single_file = [".der"],
-            doc = "Private key in DER format.",
-        ),
-        "type": attr.string(
-            default = "TestKey",
-            doc = "The type of the key. Can be TestKey, DevKey or ProdKey.",
-            values = ["TestKey", "DevKey", "ProdKey"],
-        ),
-        "config": attr.string_dict(
-            doc = "The config properties of the key.  Currently, there are no properties for ECDSA keys.",
-        ),
-        # TODO(cfrantz, moidx, #22155): To support signing with opentitantool or
-        # hsmtool, the `method` should be replaced with a `token` and `profile`
-        # similar to the `keyset` rule.  The `token` is used to get access to
-        # the appropriate PKCS11 resources (shared libs, config files, etc) and
-        # the `profile` refers to a configuration in
-        # $XDG_CONFIG_HOME/hsmtool/profiles.json that refers to the user's
-        # physical token name and credentials.
-        "method": attr.string(
-            doc = "Mechanism used to access the key. Can be local or hsmtool.",
-            values = ["local", "hsmtool"],
-        ),
-    },
-)
 
 def ecdsa_key_for_lc_state(key_structs, hw_lc_state):
     """Return a dictionary containing a single key that can be used in the given

--- a/sw/device/silicon_creator/rom_ext/sival/keys/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/keys/BUILD
@@ -6,8 +6,6 @@ load("//rules:signing.bzl", "keyset")
 
 package(default_visibility = ["//visibility:public"])
 
-# TODO(#22155, #18313): Decide on keyset vs. keyinfo for supplying signing info to the
-# offline/token signing flows.  Currently, only keyset supports tokens.
 keyset(
     name = "keyset",
     build_setting_default = "",


### PR DESCRIPTION
Since all key definitions have migrated to keyset, we can remove the
starlark rules definitions for key_{ecdsa,sphincsplus} as well as their
associated providers.