### PR TITLE
[bazel,dt] Remove translated testutils from exception list

### DIFF
--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -626,8 +626,6 @@ cc_library(
 
 # Some testutils are not multitop yet.
 TESTUTILS_EXCEPTIONS = [
-    "aes",
-    "csrng",
     "i2c",
     "uart",
     "rstmgr",


### PR DESCRIPTION
Those testutils already support all tops, lets remove it here.