### PR TITLE
[sw,test] Move all AES tests to DT

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -283,6 +283,7 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        DARJEELING_TEST_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:sim_verilator": None,
@@ -295,7 +296,7 @@ opentitan_test(
     ),
     deps = [
         "//hw/ip/aes:model",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:aes",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -248,6 +248,7 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        DARJEELING_TEST_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:sim_verilator": None,
@@ -260,7 +261,7 @@ opentitan_test(
     ),
     deps = [
         "//hw/ip/aes:model",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:aes",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -215,6 +215,7 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        DARJEELING_TEST_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:sim_verilator": None,
@@ -227,7 +228,7 @@ opentitan_test(
     ),
     deps = [
         "//hw/ip/aes:model",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:aes",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -146,6 +146,7 @@ opentitan_test(
     name = "aes_interrupt_encryption_test",
     srcs = ["aes_interrupt_encryption_test.c"],
     exec_env = dicts.add(
+        DARJEELING_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:sim_verilator": None,
@@ -157,7 +158,7 @@ opentitan_test(
     ),
     deps = [
         "//hw/ip/aes:model",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:aes",

--- a/sw/device/tests/aes_force_prng_reseed_test.c
+++ b/sw/device/tests/aes_force_prng_reseed_test.c
@@ -22,8 +22,6 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/sca/lib/simple_serial.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-
 OTTF_DEFINE_TEST_CONFIG();
 
 static dif_aes_t aes;
@@ -86,7 +84,7 @@ status_t execute_test(void) {
       ": %d",
       kAesNumBlocks, kAesNumBlocks - 1, kDisableEntropyAtStartEn);
   // Initialize AES
-  TRY(dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));
+  TRY(dif_aes_init_from_dt(kDtAes, &aes));
   TRY(dif_aes_reset(&aes));
   // Initialize EDN0, EDN1, CSRNG and Entropy Source
   TRY(dif_edn_init(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR), &edn0));

--- a/sw/device/tests/aes_interrupt_encryption_test.c
+++ b/sw/device/tests/aes_interrupt_encryption_test.c
@@ -16,8 +16,6 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-
 enum {
   kTestTimeout = (1000 * 1000),
 };
@@ -76,7 +74,7 @@ status_t execute_test(void) {
     }
     // Initialise AES.
     dif_aes_t aes;
-    TRY(dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));
+    TRY(dif_aes_init_from_dt(kDtAes, &aes));
     TRY(dif_aes_reset(&aes));
 
     // Mask the key. Note that this should not be done manually. Software is
@@ -142,7 +140,7 @@ status_t execute_test(void) {
     //***************  Perform an trial encryption using a different data and
     // key. Message size, key size and mode can be chosen arbitrarily.
 
-    TRY(dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));
+    TRY(dif_aes_init_from_dt(kDtAes, &aes));
 
     // Mask the key. Note that this should not be done manually. Software is
     // expected to get the key in two shares right from the beginning.

--- a/sw/device/tests/aes_prng_reseed_test.c
+++ b/sw/device/tests/aes_prng_reseed_test.c
@@ -14,14 +14,13 @@
 #include "sw/device/lib/dif/dif_rv_core_ibex.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/aes_testutils.h"
 #include "sw/device/lib/testing/csrng_testutils.h"
 #include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/rv_core_ibex_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/sca/lib/simple_serial.h"
-
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -110,7 +109,7 @@ status_t execute_test(aes_test_config_t *config) {
       config->kAesNumBlocks, config->kAesNumBlocks - 1,
       config->disable_entropy_after_block - 1);
   // Initialize AES
-  TRY(dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));
+  TRY(dif_aes_init_from_dt(kDtAes, &aes));
   TRY(dif_aes_reset(&aes));
   // Initialize EDN0, EDN1, CSRNG and Entropy Source
   TRY(dif_edn_init(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR), &edn0));

--- a/sw/device/tests/aes_stall_test.c
+++ b/sw/device/tests/aes_stall_test.c
@@ -18,8 +18,6 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/sca/lib/simple_serial.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-
 OTTF_DEFINE_TEST_CONFIG();
 
 static dif_aes_t aes;
@@ -54,7 +52,7 @@ status_t execute_test(void) {
   bool output_valid = false;
 
   // Initialize AES
-  TRY(dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));
+  TRY(dif_aes_init_from_dt(kDtAes, &aes));
   TRY(dif_aes_reset(&aes));
 
   // Generate key with index 0


### PR DESCRIPTION
This PR moves all remaining AES tests to the DT API and enables them for Darjeeling.