### PR TITLE
[sw,test] Move all KMAC tests to DT

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2722,6 +2722,7 @@ opentitan_test(
     srcs = ["kmac_error_conditions_test.c"],
     exec_env = dicts.add(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        DARJEELING_TEST_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:fpga_cw340_sival": None,
@@ -2731,7 +2732,7 @@ opentitan_test(
     ),
     verilator = verilator_params(timeout = "long"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:clkmgr",
         "//sw/device/lib/dif:keymgr",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2749,6 +2749,7 @@ opentitan_test(
     srcs = ["kmac_entropy_stress_test.c"],
     exec_env = dicts.add(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        DARJEELING_TEST_ENVS,
         {
             "//hw/top_earlgrey:sim_dv": None,
             "//hw/top_earlgrey:sim_verilator": None,
@@ -2756,7 +2757,7 @@ opentitan_test(
     ),
     verilator = verilator_params(timeout = "eternal"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:kmac",
         "//sw/device/lib/runtime:log",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2677,12 +2677,13 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        DARJEELING_TEST_ENVS,
         {
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:mmio",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2793,6 +2793,7 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        DARJEELING_TEST_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:silicon_creator": None,
@@ -2806,7 +2807,7 @@ opentitan_test(
     ),
     verilator = verilator_params(timeout = "long"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:keymgr",
         "//sw/device/lib/dif:kmac",

--- a/sw/device/tests/kmac_endianess_test.c
+++ b/sw/device/tests/kmac_endianess_test.c
@@ -10,8 +10,6 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-
 OTTF_DEFINE_TEST_CONFIG();
 
 /**
@@ -92,8 +90,7 @@ status_t test_endianess(void) {
   // Intialize KMAC hardware.
   dif_kmac_t kmac;
   dif_kmac_operation_state_t kmac_operation_state;
-  CHECK_DIF_OK(
-      dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
+  CHECK_DIF_OK(dif_kmac_init_from_dt(kDtKmac, &kmac));
 
   // Test configurations.
   char msg_log[4][7] = {"little", "little", "big", "big"};

--- a/sw/device/tests/kmac_entropy_stress_test.c
+++ b/sw/device/tests/kmac_entropy_stress_test.c
@@ -10,7 +10,6 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 #include "hw/top/kmac_regs.h"  // Generated.
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -175,7 +174,7 @@ status_t test_kmac_config(dif_kmac_config_t *test_case) {
       kHashCntMax);
 
   dif_kmac_t kmac;
-  TRY(dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
+  TRY(dif_kmac_init_from_dt(kDtKmac, &kmac));
 
   // Handle customization string
   dif_kmac_customization_string_t cust_str;

--- a/sw/device/tests/kmac_error_conditions_test.c
+++ b/sw/device/tests/kmac_error_conditions_test.c
@@ -15,7 +15,6 @@
 
 #include "hw/top/keymgr_regs.h"  // Generated.
 #include "hw/top/kmac_regs.h"    // Generated.
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 static dif_kmac_t kmac;
 static dif_keymgr_t keymgr;
@@ -178,7 +177,7 @@ status_t test_err_wait_timer_expired(void) {
   LOG_INFO("Testing ErrWaitTimerExpired error.");
 
   // Init the KMAC block.
-  TRY(dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
+  TRY(dif_kmac_init_from_dt(kDtKmac, &kmac));
 
   const dif_kmac_config_t config = (dif_kmac_config_t){
       .entropy_mode = kDifKmacEntropyModeEdn,
@@ -267,7 +266,7 @@ status_t test_err_incorrect_entropy_mode(void) {
   LOG_INFO("Testing ErrIncorrectEntropyMode error.");
 
   // Re-init KMAC for the test.
-  TRY(dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
+  TRY(dif_kmac_init_from_dt(kDtKmac, &kmac));
 
   // Write configuration register.
   uint32_t cfg_reg = 0;
@@ -307,7 +306,7 @@ status_t test_err_incorrect_entropy_mode(void) {
 status_t test_err_sw_hashing_without_entropy_ready(void) {
   LOG_INFO("Testing ErrSwHashingWithoutEntropyReady error.");
 
-  TRY(dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
+  TRY(dif_kmac_init_from_dt(kDtKmac, &kmac));
 
   // Manually init the KMAC block and do not set entropy_ready bit.
   // Write entropy period register.
@@ -402,7 +401,7 @@ status_t test_err_sw_hashing_without_entropy_ready(void) {
 status_t test_err_incorrect_fnc_name(void) {
   LOG_INFO("Testing kDifErrorIncorrectFunctionName error.");
   // Re-init KMAC for the test.
-  TRY(dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
+  TRY(dif_kmac_init_from_dt(kDtKmac, &kmac));
   TRY(kmac_testutils_config(&kmac, false));
 
   // Configure cSHAKE mode with the given strength and enable KMAC mode.
@@ -468,7 +467,7 @@ status_t test_err_incorrect_fnc_name(void) {
 status_t test_err_key_not_valid(void) {
   LOG_INFO("Testing ErrKeyNotValid error.");
   // Re-init KMAC for the test.
-  TRY(dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
+  TRY(dif_kmac_init_from_dt(kDtKmac, &kmac));
   // Configure KMAC to use the sideloaded key.
   TRY(kmac_testutils_config(&kmac, true));
 
@@ -496,7 +495,7 @@ status_t test_err_shadow_reg_update(void) {
   LOG_INFO("Testing shadow register update error.");
 
   // Init the KMAC block.
-  TRY(dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
+  TRY(dif_kmac_init_from_dt(kDtKmac, &kmac));
 
   // Configure KMAC hardware.
   TRY(kmac_testutils_config(&kmac, false));
@@ -547,8 +546,7 @@ status_t test_err_sw_cmd_sequence(void) {
 
   for (int it = 0; it < ARRAYSIZE(cmds); it++) {
     // Re-init KMAC for the test.
-    TRY(dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR),
-                      &kmac));
+    TRY(dif_kmac_init_from_dt(kDtKmac, &kmac));
     // Configure KMAC hardware (using software key and software entropy).
     TRY(kmac_testutils_config(&kmac, false));
 
@@ -582,8 +580,7 @@ status_t test_err_unexpected_mode_strength(void) {
 
   for (int it = 0; it < ARRAYSIZE(mode); it++) {
     // Re-init KMAC for the test.
-    TRY(dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR),
-                      &kmac));
+    TRY(dif_kmac_init_from_dt(kDtKmac, &kmac));
     TRY(kmac_testutils_config(&kmac, false));
 
     uint32_t cfg_reg =

--- a/sw/device/tests/kmac_kmac_key_sideload_test.c
+++ b/sw/device/tests/kmac_kmac_key_sideload_test.c
@@ -17,8 +17,6 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-
 // The KMAC dif expects a secret key, even though if the configuration is set
 // to use the sideloaded key then it will be ignored. We will write a software
 // key and then ensure that the output does NOT match the expected value for
@@ -40,17 +38,6 @@ static const size_t kCustomStringLen = 0;
 static const char kKmacMessage[] = "\x00\x01\x02\x03";
 static const size_t kKmacMessageLen = 4;
 
-enum {
-  /**
-   * Retention SRAM start address (inclusive).
-   */
-  kRetSramBaseAddr = TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR,
-
-  kRetSramOwnerAddr = kRetSramBaseAddr + offsetof(retention_sram_t, owner),
-  kRetRamLastAddr =
-      kRetSramBaseAddr + TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_SIZE_BYTES - 1,
-};
-
 static dif_keymgr_t keymgr;
 static dif_kmac_t kmac;
 static dif_sram_ctrl_t ret_sram;
@@ -62,15 +49,10 @@ OTTF_DEFINE_TEST_CONFIG();
  * Initializes all DIF handles for each peripheral used in this test.
  */
 static void init_peripheral_handles(void) {
-  CHECK_DIF_OK(
-      dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
-  CHECK_DIF_OK(dif_keymgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_KEYMGR_BASE_ADDR), &keymgr));
-  CHECK_DIF_OK(dif_rstmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
-  CHECK_DIF_OK(dif_sram_ctrl_init(
-      mmio_region_from_addr(TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_BASE_ADDR),
-      &ret_sram));
+  CHECK_DIF_OK(dif_kmac_init_from_dt(kDtKmac, &kmac));
+  CHECK_DIF_OK(dif_keymgr_init_from_dt(kDtKeymgr, &keymgr));
+  CHECK_DIF_OK(dif_rstmgr_init_from_dt(kDtRstmgrAon, &rstmgr));
+  CHECK_DIF_OK(dif_sram_ctrl_init_from_dt(kDtSramCtrlRetAon, &ret_sram));
 }
 
 /**
@@ -130,11 +112,15 @@ static void test_kmac_key_sideload(dif_keymgr_t *keymgr, dif_kmac_t *kmac,
   LOG_INFO("Computed KMAC output for sideloaded key.");
 
   if (!test_phase) {
+    uint32_t sram_start =
+        dt_sram_ctrl_reg_block(kDtSramCtrlRetAon, kDtSramCtrlRegBlockRam);
     // In test phase 0, store the KMAC digest into the retention SRAM.
     for (size_t it = 0; it < ARRAYSIZE(kKmacModes); it++) {
-      // Use kRetSramOwnerAddr + 4 to avoid overwriting test_phase_cnt.
+      // Use offsetof(retention_sram_t, owner) + 4 to avoid overwriting
+      // test_phase_cnt.
       sram_ctrl_testutils_write(
-          kRetSramOwnerAddr + 4 + 4 * it * kKmacOutputLen,
+          sram_start + offsetof(retention_sram_t, owner) + 4 +
+              4 * it * kKmacOutputLen,
           (sram_ctrl_testutils_data_t){.words = output_sideload[it],
                                        .len = kKmacOutputLen});
     }
@@ -174,10 +160,13 @@ static void test_kmac_key_sideload(dif_keymgr_t *keymgr, dif_kmac_t *kmac,
   } else {
     // In test phase 1, read the previous KMAC digests from the retention SRAM
     // and compare them with the calculated ones.
+    uint32_t sram_start =
+        dt_sram_ctrl_reg_block(kDtSramCtrlRetAon, kDtSramCtrlRegBlockRam);
     for (size_t it = 0; it < ARRAYSIZE(kKmacModes); it++) {
       uint32_t prev_digest[kKmacOutputLen];
       memcpy(prev_digest,
-             (uint8_t *)(kRetSramOwnerAddr + 4 + 4 * it * kKmacOutputLen),
+             (uint8_t *)(sram_start + offsetof(retention_sram_t, owner) + 4 +
+                         4 * it * kKmacOutputLen),
              sizeof(prev_digest));
       CHECK_ARRAYS_EQ(output_sideload[it], prev_digest, kKmacOutputLen);
     }


### PR DESCRIPTION
This PR moves all remaining kmac tests to the DT API and enables them for Darjeeling.