### PR TITLE
[crypto/rsa] Move Montgomery constant from DMEM to register

### DIFF
--- a/sw/otbn/crypto/modexp.s
+++ b/sw/otbn/crypto/modexp.s
@@ -79,9 +79,9 @@ sel_sqr_or_sqrmul:
  * @param[in]  x14: dptr_a, dmem pointer to first limb of input A
  * @param[in]  x15: dptr_e, dmem pointer to first limb of exponent E
  * @param[in]  x16: dptr_M, dmem pointer to first limb of modulus M
- * @param[in]  x17: dptr_m0d, dmem pointer to first limb of m0'
- * @param[in]  x18: dptr_RR, dmem pointer to first limb of RR
+ * @param[in]  x17: dptr_RR, dmem pointer to first limb of RR
  * @param[in]  x30: N, number of limbs per bignum
+ * @param[in]   w1: m0d', Montgomery constant
  * @param[in]  w31: all-zero
  * @param[out] dmem[dptr_c:dptr_c+N*32] C, A^E mod M
  *
@@ -104,7 +104,7 @@ modexp:
   /* Convert input to montgomery domain.
        dmem[dptr_a] <= montmul(A,RR) = A*R mod M */
   addi      x19, x14, 0
-  addi      x20, x18, 0
+  addi      x20, x17, 0
   addi      x21, x14, 0
   jal       x1, montmul
   loop      x30, 2
@@ -198,9 +198,9 @@ modexp:
  * @param[in]   x2: dptr_c, dmem pointer to buffer for output C
  * @param[in]  x14: dptr_a, dmem pointer to first linb of input A
  * @param[in]  x16: dptr_M, dmem pointer to first limb of modulus M
- * @param[in]  x17: dptr_m0d, dmem pointer to Mongtgomery constant m0'
- * @param[in]  x18: dptr_RR, dmem pointer to Montgmery constant RR
+ * @param[in]  x17: dptr_RR, dmem pointer to Montgmery constant RR
  * @param[in]  x30: N, number of limbs per bignum
+ * @param[in]   w1: m0d', Montgomery constant
  * @param[in]  w31: all-zero
  * @param[out] dmem[dptr_c:dptr_c+N*32] C, A^65537 mod M
  *
@@ -223,7 +223,7 @@ modexp_65537:
   /* convert to montgomery domain montmul(A,RR)
   in = montmul(A,RR) montmul(A,RR) = C*R mod M */
   addi      x19, x14, 0
-  addi      x20, x18, 0
+  addi      x20, x17, 0
   addi      x21, x14, 0
   jal       x1, montmul
   /* Store result in dmem starting at dmem[dptr_a] */
@@ -375,7 +375,6 @@ cond_sub_to_dmem:
  *        not usable after return.
  *
  * @param[in]  x16: dmem pointer to first limb of modulus M
- * @param[in]  x17: dptr_m0d, dmem pointer to Montgomery Constant m0'
  * @param[in]  x19: dmem pointer to first limb of operand A
  * @param[in]  x21: dmem pointer to first limb of result C
  * @param[in]  x30: N, number of limbs
@@ -384,6 +383,7 @@ cond_sub_to_dmem:
  * @param[in]  x9: pointer to temp reg, must be set to 3
  * @param[in]  x10: pointer to temp reg, must be set to 4
  * @param[in]  x11: pointer to temp reg, must be set to 2
+ * @param[in]   w1: m0d', Montgomery constant
  * @param[in]  w31: all-zero
  *
  * clobbered registers: x6, x7, x8, x12, x13, x21, x22,
@@ -391,9 +391,6 @@ cond_sub_to_dmem:
  * clobbered Flag Groups: FG0, FG1
  */
 montmul_mul1:
-  /* load Montgomery constant: w3 = dmem[x17] = dmem[dptr_m0d] = m0' */
-  bn.lid    x9, 0(x17)
-
   /* init regfile bigint buffer with zeros */
   bn.mov    w2, w31
   loop      x30, 1

--- a/sw/otbn/crypto/primality.s
+++ b/sw/otbn/crypto/primality.s
@@ -34,10 +34,10 @@
  * @param[in] x14: dptr_b, pointer to temporary working buffer in dmem (n*32 bytes)
  * @param[in] x15: dptr_z, pointer to temporary working buffer in dmem (n*32 bytes)
  * @param[in] x16: dptr_w, pointer to candidate prime w in dmem, w mod 4 = 3
- * @param[in] x17: dptr_m0inv, pointer to Montgomery constant m0' (for w) in dmem
- * @param[in] x18: dptr_rr, pointer to Montgomery constant RR = R^2 mod w in dmem
+ * @param[in] x17: dptr_rr, pointer to Montgomery constant RR = R^2 mod w in dmem
  * @param[in] x30: n, number of limbs for all bignums (wlen / 256; n <= 16)
  * @param[in] x31: n-1, number of limbs minus 1
+ * @param[in]  w1: m0d', Montgomery constant
  * @param[in] w31: all-zero
  * @param[out] w21: result, 2^256-1 or 0
  *
@@ -96,10 +96,10 @@ miller_rabin:
  * @param[in] x14: dptr_b, pointer to temporary working buffer in dmem (n*32 bytes)
  * @param[in] x15: dptr_z, pointer to temporary working buffer in dmem (n*32 bytes)
  * @param[in] x16: dptr_w, pointer to candidate prime w in dmem, w mod 4 = 3
- * @param[in] x17: dptr_m0inv, pointer to Montgomery constant m0' (for w) in dmem
- * @param[in] x18: dptr_rr, pointer to Montgomery constant RR = R^2 mod w in dmem
+ * @param[in] x17: dptr_rr, pointer to Montgomery constant RR = R^2 mod w in dmem
  * @param[in] x30: n, number of limbs for all bignums (wlen / 256; n <= 16)
  * @param[in] x31: n-1, number of limbs minus 1
+ * @param[in]  w1: m0d', Montgomery constant
  * @param[in] w31: all-zero
  * @param[out] w21: result, 2^256-1 or 0
  *
@@ -219,10 +219,10 @@ miller_rabin_round:
  * @param[in] x14: dptr_b, pointer to randomly-generated witness to use for testing
  * @param[in] x15: dptr_z, pointer to temporary working buffer in dmem (n*32 bytes)
  * @param[in] x16: dptr_w, pointer to candidate prime w in dmem, w mod 4 = 3
- * @param[in] x17: dptr_m0inv, pointer to Montgomery constant m0' (for w) in dmem
- * @param[in] x18: dptr_rr, pointer to Montgomery constant RR = R^2 mod w in dmem
+ * @param[in] x17: dptr_rr, pointer to Montgomery constant RR = R^2 mod w in dmem
  * @param[in] x30: n, number of limbs for all bignums (wlen / 256; n <= 16)
  * @param[in] x31: n-1, number of limbs minus 1
+ * @param[in]  w1: m0d', Montgomery constant
  * @param[in] w31: all-zero
  * @param[out] w21: result, 2^256-1 or 0
  *
@@ -240,7 +240,7 @@ test_witness:
   /* Convert the witness to Montgomery form.
        dmem[dptr_b:dptr_b+n*32] <= montmul(b, RR) = (b * R) mod w */
   addi      x19, x14, 0
-  addi      x20, x18, 0
+  addi      x20, x17, 0
   jal       x1, montmul
   addi      x21, x14, 0
   loop      x30, 2

--- a/sw/otbn/crypto/rsa_keygen.s
+++ b/sw/otbn/crypto/rsa_keygen.s
@@ -1033,10 +1033,9 @@ check_p:
   bn.sid   x20, 0(x16)
 
   /* Load Montgomery constants for p.
-       dmem[mont_m0inv] <= Montgomery constant m0'
+                  w1 <= Montgomery constant m0'
        dmem[mont_rr] <= Montgomery constant RR */
-  la       x17, mont_m0inv
-  la       x18, mont_rr
+  la       x17, mont_rr
   jal      x1, modload
 
   /* Load pointers to temporary buffers for Miller-Rabin. Each buffer needs to

--- a/sw/otbn/crypto/run_rsa_keygen_mem.s
+++ b/sw/otbn/crypto/run_rsa_keygen_mem.s
@@ -27,12 +27,6 @@ rsa_d:
 rsa_cofactor:
 .zero 512
 
-/* Montgomery constant m0' (256 bits). */
-.balign 32
-.globl mont_m0inv
-mont_m0inv:
-.zero 32
-
 /* Montgomery constant R^2 (up to 2048 bits). */
 .balign 32
 .globl mont_rr

--- a/sw/otbn/crypto/run_rsa_modexp.s
+++ b/sw/otbn/crypto/run_rsa_modexp.s
@@ -139,8 +139,7 @@ rsa_4096_modexp_f4:
 do_modexp:
   /* Load pointers to modulus and Montgomery constant buffers. */
   la    x16, n
-  la    x17, m0d
-  la    x18, RR
+  la    x17, RR
 
   /* Compute Montgomery constants. */
   jal      x1, modload
@@ -175,8 +174,7 @@ do_modexp:
 do_modexp_f4:
   /* Load pointers to modulus and Montgomery constant buffers. */
   la    x16, n
-  la    x17, m0d
-  la    x18, RR
+  la    x17, RR
 
   /* Compute Montgomery constants. */
   jal      x1, modload

--- a/sw/otbn/crypto/run_rsa_modexp_mem.s
+++ b/sw/otbn/crypto/run_rsa_modexp_mem.s
@@ -37,14 +37,6 @@ d:
 inout:
 .zero 512
 
-
-/* Montgomery constant m0'. Filled by `modload`. */
-/* Note: m0' could go in scratchpad if there was space. */
-.balign 32
-.globl m0d
-m0d:
-.zero 32
-
 .section .scratchpad
 
 /* Montgomery constant RR. Filled by `modload`. */

--- a/sw/otbn/crypto/tests/modinv_f4_test.s
+++ b/sw/otbn/crypto/tests/modinv_f4_test.s
@@ -17,7 +17,7 @@ main:
 
   /* Load DMEM pointers. */
   la        x12, rsa_n
-  la        x13, mont_m0inv
+  la        x13, rsa_d
   la        x14, tmp0
   la        x15, tmp2
 

--- a/sw/otbn/crypto/tests/primality_negative_test.s
+++ b/sw/otbn/crypto/tests/primality_negative_test.s
@@ -22,11 +22,10 @@ main:
   li        x31, 3
 
   /* Compute Montgomery constants for the candidate prime.
-       dmem[mont_m0inv] <= (- dmem[rsa_p]) mod 2^256
+                  w1 <= (- dmem[rsa_p]) mod 2^256
        dmem[mont_rr] <= (2^1024) mod dmem[input] */
   la         x16, rsa_p
-  la         x17, mont_m0inv
-  la         x18, mont_rr
+  la         x17, mont_rr
   jal        x1, modload
 
   /* Load pointers to temporary work buffers. */

--- a/sw/otbn/crypto/tests/primality_test.s
+++ b/sw/otbn/crypto/tests/primality_test.s
@@ -23,11 +23,10 @@ main:
   li        x31, 1
 
   /* Compute Montgomery constants for the candidate prime.
-       dmem[mont_m0inv] <= (- dmem[rsa_p]) mod 2^256
+                  w1 <= (- dmem[rsa_p]) mod 2^256
        dmem[mont_rr] <= (2^1024) mod dmem[rsa_p] */
   la         x16, rsa_p
-  la         x17, mont_m0inv
-  la         x18, mont_rr
+  la         x17, mont_rr
   jal        x1, modload
 
 
@@ -42,15 +41,5 @@ main:
   /* Call primality test.
        w21 <= all 1s if dmem[rsa_p] is probably prime, otherwise 0 */
   jal        x1, miller_rabin
-
-  /* Load Mont constants.
-       w0 <= m0_inv
-       w1, w2 <= rr */
-  la         x17, mont_m0inv
-  la         x18, mont_rr
-  li         x2, 0
-  bn.lid     x2++, 0(x17)
-  bn.lid     x2++, 0(x18)
-  bn.lid     x2++, 32(x18)
 
   ecall

--- a/sw/otbn/crypto/tests/primality_test_witness_negative_test.hjson
+++ b/sw/otbn/crypto/tests/primality_test_witness_negative_test.hjson
@@ -10,11 +10,13 @@
       "rsa_p": "0xf7b5cc32e3c7c3ff6f220312fe4be4af76c9e51e8c17648c863751d70359bab17c1d7b4844e01d1ec0cd695ff3bae05dc51d95a001ab7b69f66d0c056c2dec3b",
       # Random witness for testing:
       "tmp0": "0x256943a781a24e5509455e2a4e4e957580ea393b9d7863bb082fb7fd72a5ce33e8a0ed3cf7252c678ab79fd24387fc64d0f601d098b111681262ef4d4080769c",
-      # Precomputed Montgomery constant m0' (256 bits):
-      "mont_m0inv": "0xce44dadc9ae7984c6e5afd69acafa4f9b6e8621245c4b2aff47b30a4bb5df30d",
       # Precomputed Montgomery constant RR (512 bits):
       "mont_rr": "0xdf10ee865d9d6071a53b263423cbc23103cc62ac126593d5163b312e78f6cf4150805ac84e5c6583a11300bd10d84741bbd4bbb9cd184ada6f9be028c1e31e17"
-    }
+    },
+    "regs": {
+      # Precomputed Montgomery constant m0' (256 bits):
+      "w1": "0xce44dadc9ae7984c6e5afd69acafa4f9b6e8621245c4b2aff47b30a4bb5df30d",
+    },
   }
 
   "output": {

--- a/sw/otbn/crypto/tests/primality_test_witness_negative_test.s
+++ b/sw/otbn/crypto/tests/primality_test_witness_negative_test.s
@@ -26,8 +26,7 @@ main:
   la         x14, tmp0 /* witness */
   la         x15, tmp2 /* tmp buffer */
   la         x16, rsa_p
-  la         x17, mont_m0inv
-  la         x18, mont_rr
+  la         x17, mont_rr
   jal        x1, test_witness
 
   ecall

--- a/sw/otbn/crypto/tests/primality_test_witness_test.hjson
+++ b/sw/otbn/crypto/tests/primality_test_witness_test.hjson
@@ -10,10 +10,12 @@
       "rsa_p": "0x8d1c0da1ce6567c69d6bce68028081e582089688137149491c26e47e660463930ea957af990577b9f0cddcbab3a74f47873a9f41a6f40ea9c9c6ca41293edc0b",
       # Random witness for testing:
       "tmp0":    "0x256943a781a24e5509455e2a4e4e957580ea393b9d7863bb082fb7fd72a5ce33e8a0ed3cf7252c678ab79fd24387fc64d0f601d098b111681262ef4d4080769c",
-      # Precomputed Montgomery constant m0' (256 bits):
-      "mont_m0inv": "0x3da16a0485db6e31c6fea5cb09f82d11d0d2fa8c641931c662b7e8e719b8305d",
       # Precomputed Montgomery constant RR (512 bits):
       "mont_rr": "0x2bd6414c084be9c3c8277904c33f14ed6be6c4a81e3966f15f4d0e22c1edcb016424c41f28cc1d74403da1b46f17717a67ee4a0e4abf694505dbf5697cace161"
+    },
+    "regs": {
+      # Precomputed Montgomery constant m0' (256 bits):
+      "w1": "0x3da16a0485db6e31c6fea5cb09f82d11d0d2fa8c641931c662b7e8e719b8305d",
     }
   }
 

--- a/sw/otbn/crypto/tests/primality_test_witness_test.s
+++ b/sw/otbn/crypto/tests/primality_test_witness_test.s
@@ -26,8 +26,7 @@ main:
   la         x14, tmp0 /* witness */
   la         x15, tmp2 /* tmp buffer */
   la         x16, rsa_p
-  la         x17, mont_m0inv
-  la         x18, mont_rr
+  la         x17, mont_rr
   jal        x1, test_witness
 
   /* Load the value from the working buffer into registers. Since the candidate

--- a/sw/otbn/crypto/tests/rsa_1024_dec_test.s
+++ b/sw/otbn/crypto/tests/rsa_1024_dec_test.s
@@ -23,8 +23,7 @@
 
   /* Load pointers to modulus and Montgomery constant buffers. */
   la    x16, n
-  la    x17, m0d
-  la    x18, RR
+  la    x17, RR
 
   /* Compute Montgomery constants. */
   jal      x1, modload

--- a/sw/otbn/crypto/tests/rsa_1024_enc_test.s
+++ b/sw/otbn/crypto/tests/rsa_1024_enc_test.s
@@ -24,8 +24,7 @@ main:
 
   /* Load pointers to modulus and Montgomery constant buffers. */
   la    x16, n
-  la    x17, m0d
-  la    x18, RR
+  la    x17, RR
 
   /* Compute Montgomery constants. */
   jal      x1, modload

--- a/sw/otbn/crypto/tests/rsa_2048_dec_test.s
+++ b/sw/otbn/crypto/tests/rsa_2048_dec_test.s
@@ -17,8 +17,7 @@ main:
 
   /* Load pointers to modulus and Montgomery constant buffers. */
   la    x16, n
-  la    x17, m0d
-  la    x18, RR
+  la    x17, RR
 
   /* Compute Montgomery constants. */
   jal      x1, modload

--- a/sw/otbn/crypto/tests/rsa_2048_enc_test.s
+++ b/sw/otbn/crypto/tests/rsa_2048_enc_test.s
@@ -17,8 +17,7 @@ main:
 
   /* Load pointers to modulus and Montgomery constant buffers. */
   la    x16, n
-  la    x17, m0d
-  la    x18, RR
+  la    x17, RR
 
   /* Compute Montgomery constants. */
   jal      x1, modload

--- a/sw/otbn/crypto/tests/rsa_3072_dec_test.s
+++ b/sw/otbn/crypto/tests/rsa_3072_dec_test.s
@@ -17,8 +17,7 @@ main:
 
   /* Load pointers to modulus and Montgomery constant buffers. */
   la    x16, n
-  la    x17, m0d
-  la    x18, RR
+  la    x17, RR
 
   /* Compute Montgomery constants. */
   jal      x1, modload

--- a/sw/otbn/crypto/tests/rsa_3072_enc_test.s
+++ b/sw/otbn/crypto/tests/rsa_3072_enc_test.s
@@ -17,8 +17,7 @@ main:
 
   /* Load pointers to modulus and Montgomery constant buffers. */
   la    x16, n
-  la    x17, m0d
-  la    x18, RR
+  la    x17, RR
 
   /* Compute Montgomery constants. */
   jal      x1, modload

--- a/sw/otbn/crypto/tests/rsa_4096_enc_test.s
+++ b/sw/otbn/crypto/tests/rsa_4096_enc_test.s
@@ -17,8 +17,7 @@ main:
 
   /* Load pointers to modulus and Montgomery constant buffers. */
   la    x16, n
-  la    x17, m0d
-  la    x18, RR
+  la    x17, RR
 
   /* Compute Montgomery constants. */
   jal      x1, modload


### PR DESCRIPTION
Move Montgomery constant from DMEM to a register to liberate memory space.
