### PR TITLE
[sw] Misc fixes for QEMU transport

### DIFF
--- a/sw/host/opentitanlib/src/transport/qemu/mod.rs
+++ b/sw/host/opentitanlib/src/transport/qemu/mod.rs
@@ -144,7 +144,7 @@ impl Transport for Qemu {
             "0" => Ok(Rc::clone(
                 self.console.as_ref().context("uart 0 not connected")?,
             )),
-            "log" => Ok(Rc::clone(
+            "LOG" => Ok(Rc::clone(
                 self.log.as_ref().context("QEMU log not connected")?,
             )),
             _ => Err(TransportError::InvalidInstance(

--- a/sw/host/opentitanlib/src/transport/qemu/mod.rs
+++ b/sw/host/opentitanlib/src/transport/qemu/mod.rs
@@ -21,6 +21,7 @@ use crate::transport::{
     Capabilities, Capability, Transport, TransportError, TransportInterfaceType,
 };
 
+/// ID of the fake pin we use to model resets.
 const QEMU_RESET_PIN_IDX: u8 = u8::MAX;
 
 /// Represents a connection to a running QEMU emulation.

--- a/sw/host/opentitanlib/src/transport/qemu/mod.rs
+++ b/sw/host/opentitanlib/src/transport/qemu/mod.rs
@@ -24,6 +24,11 @@ use crate::transport::{
 /// ID of the fake pin we use to model resets.
 const QEMU_RESET_PIN_IDX: u8 = u8::MAX;
 
+/// Baudrate for QEMU's consoles. These are PTYs so it currently doesn't matter,
+/// but we must use a non-zero value because the pacing calculations divide by
+/// this number.
+const CONSOLE_BAUDRATE: u32 = 115200;
+
 /// Represents a connection to a running QEMU emulation.
 pub struct Qemu {
     /// Connection to the QEMU monitor which can control the emulator.
@@ -69,7 +74,7 @@ impl Qemu {
         let console = match find_chardev(&chardevs, "console") {
             Some(ChardevKind::Pty { path }) => {
                 let uart: Rc<dyn Uart> = Rc::new(
-                    SerialPortUart::open_pseudo(path.to_str().unwrap(), 0)
+                    SerialPortUart::open_pseudo(path.to_str().unwrap(), CONSOLE_BAUDRATE)
                         .context("failed to open QEMU console PTY")?,
                 );
                 Some(uart)
@@ -84,7 +89,7 @@ impl Qemu {
         let log = match find_chardev(&chardevs, "log") {
             Some(ChardevKind::Pty { path }) => {
                 let log: Rc<dyn Uart> = Rc::new(
-                    SerialPortUart::open_pseudo(path.to_str().unwrap(), 0)
+                    SerialPortUart::open_pseudo(path.to_str().unwrap(), CONSOLE_BAUDRATE)
                         .context("failed to open QEMU log PTY")?,
                 );
                 Some(log)

--- a/sw/host/tests/qemu/src/test_status.rs
+++ b/sw/host/tests/qemu/src/test_status.rs
@@ -40,7 +40,7 @@ fn main() -> anyhow::Result<()> {
 
     monitor.cont()?;
 
-    let log = qemu.uart("log")?;
+    let log = qemu.uart("LOG")?;
     let res = UartConsole::wait_for(&*log, "PASSED|FAILED", Duration::from_secs(60))?;
     match res[0].as_str() {
         "PASSED" => Ok(()),


### PR DESCRIPTION
* Uses a non-zero baudrate for the console PTYs to avoid a divide-by-zero.
* Uses a capitalized name for the `LOG` uart to support `console --uart log`.