### PR TITLE
[hw,prim_sha2,rtl] Add missing includes of prim_assert.h

### DIFF
--- a/hw/ip/prim/rtl/prim_sha2.sv
+++ b/hw/ip/prim/rtl/prim_sha2.sv
@@ -4,6 +4,8 @@
 //
 // SHA-256/384/512 configurable mode engine (64-bit word datapath)
 
+`include "prim_assert.sv"
+
 module prim_sha2 import prim_sha2_pkg::*;
 #(
   parameter bit MultimodeEn = 0, // assert to enable multi-mode digest feature


### PR DESCRIPTION
Assert is used within the file but the include is missing.