### PR TITLE
[entropy_src/doc] Clarify counting of continous HT failures and maximum noise source rate

### DIFF
--- a/hw/ip/entropy_src/README.md
+++ b/hw/ip/entropy_src/README.md
@@ -17,6 +17,7 @@ This module conforms to the [Comportable guideline for peripheral functionality.
 The PTRNG external source is a physical true random noise source.
 A noise source and its relation to an entropy source are defined by [SP 800-90B.](https://csrc.nist.gov/publications/detail/sp/800-90b/final)
 - Configurable noise source bus width, supporting 4-256 bits.
+- Variable noise source rate with a maximum rate of one symbol every second clock cycle.
 - A set of registers is provided for firmware to obtain entropy bits.
 - Interrupts are supported:
   - Entropy bits are available for firmware consumption.

--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -1229,6 +1229,8 @@
             Alert threshold register
 
             This register determines during how many subsequent health test windows one or more health test failures can occur before a recoverable alert is raised and the ENTROPY_SRC block stops operating.
+            Note that continuous health tests such as the repetition count test or the repetition count symbol test can trigger multiple test failures within a single window.
+            Each symbol for which at least one continuous health test fails counts separately towards the threshold.
             In case the configured threshold is reached, firmware needs to disable/re-enable the block to restart operation including the startup health testing.
 
             Note that when reaching the threshold while running in Firmware Override: Extract & Insert mode, the recoverable alert is not raised nor does the block stop operating.
@@ -1263,6 +1265,8 @@
 
             This register holds the total number of subsequent health test windows during which one or more health test failures occurred.
             For information on which health tests failed specifically, refer to !!ALERT_FAIL_COUNTS and !!EXTHT_FAIL_COUNTS.
+            Note that continuous health tests such as the repetition count test or the repetition count symbol test can trigger multiple test failures within a single window.
+            Each symbol for which at least one continuous health test fails is counted separately.
 
             If the value of this register reaches the value configured in the !!ALERT_THRESHOLD register, a recoverable alert is raised and the ENTROPY_SRC block stops operating.
             If an alert is signaled, the value persists until it is cleared by firmware.
@@ -1288,7 +1292,7 @@
 
             This register holds the number of health test failures since the last passing health test window.
             The values are reported on a per-test basis.
-            Note that if multiple health tests fail for a certain window, the value in !!ALERT_SUMMARY_FAIL_COUNTS is incremented by just one whereas multiple fields in this register may get incremented.
+            Note that if multiple health tests fail for a certain symbol or window, the value in !!ALERT_SUMMARY_FAIL_COUNTS is incremented by just one whereas multiple fields in this register may get incremented.
 
             All fields of this register are automatically cleared after every passing health test window unless the ENTROPY_SRC is configured in Firmware Override: Extract & Insert mode.
             The fields are also cleared after re-enabling the block.
@@ -1300,7 +1304,7 @@
         { bits: "7:4",
           name: "REPCNT_FAIL_COUNT",
           desc: '''
-                The number of health test windows during which this test failed since the last passing health test window.
+                The number of symbols during which this test failed since the last passing health test window.
                 '''
         }
         { bits: "11:8",
@@ -1336,7 +1340,7 @@
         { bits: "31:28",
           name: "REPCNTS_FAIL_COUNT",
           desc: '''
-                The number of health test windows during which this test failed since the last passing health test window.
+                The number of symbols during which this test failed since the last passing health test window.
                 '''
         }
       ]
@@ -1347,7 +1351,7 @@
 
             This register holds the number of external health test failures since the last passing health test window.
             The values are reported on a per-test basis.
-            Note that if multiple health tests fail for a certain window, the value in !!ALERT_SUMMARY_FAIL_COUNTS is incremented by just one whereas multiple fields in this register may get incremented.
+            Note that if multiple health tests fail for a certain symbol or window, the value in !!ALERT_SUMMARY_FAIL_COUNTS is incremented by just one whereas multiple fields in this register may get incremented.
 
             All fields of this register are automatically cleared after every passing health test window unless the ENTROPY_SRC is configured in Firmware Override: Extract & Insert mode.
             The fields are also cleared after re-enabling the block.
@@ -1359,13 +1363,13 @@
         { bits: "3:0",
           name: "EXTHT_HI_FAIL_COUNT",
           desc: '''
-                The number of health test windows during which this test failed since the last passing health test window.
+                The number of symbols for continuous tests or health test windows for window-based tests during which this test failed since the last passing health test window.
                 '''
         }
         { bits: "7:4",
           name: "EXTHT_LO_FAIL_COUNT",
           desc: '''
-                The number of health test windows during which this test failed since the last passing health test window.
+                The number of symbols for continuous tests or health test windows for window-based tests during which this test failed since the last passing health test window.
                 '''
         }
       ]

--- a/hw/ip/entropy_src/doc/registers.md
+++ b/hw/ip/entropy_src/doc/registers.md
@@ -982,6 +982,8 @@ External health test low threshold failure counter register
 Alert threshold register
 
 This register determines during how many subsequent health test windows one or more health test failures can occur before a recoverable alert is raised and the ENTROPY_SRC block stops operating.
+Note that continuous health tests such as the repetition count test or the repetition count symbol test can trigger multiple test failures within a single window.
+Each symbol for which at least one continuous health test fails counts separately towards the threshold.
 In case the configured threshold is reached, firmware needs to disable/re-enable the block to restart operation including the startup health testing.
 
 Note that when reaching the threshold while running in Firmware Override: Extract & Insert mode, the recoverable alert is not raised nor does the block stop operating.
@@ -1008,6 +1010,8 @@ Alert summary failure counts register
 
 This register holds the total number of subsequent health test windows during which one or more health test failures occurred.
 For information on which health tests failed specifically, refer to [`ALERT_FAIL_COUNTS`](#alert_fail_counts) and [`EXTHT_FAIL_COUNTS.`](#extht_fail_counts)
+Note that continuous health tests such as the repetition count test or the repetition count symbol test can trigger multiple test failures within a single window.
+Each symbol for which at least one continuous health test fails is counted separately.
 
 If the value of this register reaches the value configured in the [`ALERT_THRESHOLD`](#alert_threshold) register, a recoverable alert is raised and the ENTROPY_SRC block stops operating.
 If an alert is signaled, the value persists until it is cleared by firmware.
@@ -1034,7 +1038,7 @@ Alert failure counts register
 
 This register holds the number of health test failures since the last passing health test window.
 The values are reported on a per-test basis.
-Note that if multiple health tests fail for a certain window, the value in [`ALERT_SUMMARY_FAIL_COUNTS`](#alert_summary_fail_counts) is incremented by just one whereas multiple fields in this register may get incremented.
+Note that if multiple health tests fail for a certain symbol or window, the value in [`ALERT_SUMMARY_FAIL_COUNTS`](#alert_summary_fail_counts) is incremented by just one whereas multiple fields in this register may get incremented.
 
 All fields of this register are automatically cleared after every passing health test window unless the ENTROPY_SRC is configured in Firmware Override: Extract & Insert mode.
 The fields are also cleared after re-enabling the block.
@@ -1050,13 +1054,13 @@ The fields are also cleared after re-enabling the block.
 
 |  Bits  |  Type  |  Reset  | Name                 | Description                                                                                                |
 |:------:|:------:|:-------:|:---------------------|:-----------------------------------------------------------------------------------------------------------|
-| 31:28  |   ro   |    x    | REPCNTS_FAIL_COUNT   | The number of health test windows during which this test failed since the last passing health test window. |
+| 31:28  |   ro   |    x    | REPCNTS_FAIL_COUNT   | The number of symbols during which this test failed since the last passing health test window.             |
 | 27:24  |   ro   |    x    | MARKOV_LO_FAIL_COUNT | The number of health test windows during which this test failed since the last passing health test window. |
 | 23:20  |   ro   |    x    | MARKOV_HI_FAIL_COUNT | The number of health test windows during which this test failed since the last passing health test window. |
 | 19:16  |   ro   |    x    | BUCKET_FAIL_COUNT    | The number of health test windows during which this test failed since the last passing health test window. |
 | 15:12  |   ro   |    x    | ADAPTP_LO_FAIL_COUNT | The number of health test windows during which this test failed since the last passing health test window. |
 |  11:8  |   ro   |    x    | ADAPTP_HI_FAIL_COUNT | The number of health test windows during which this test failed since the last passing health test window. |
-|  7:4   |   ro   |    x    | REPCNT_FAIL_COUNT    | The number of health test windows during which this test failed since the last passing health test window. |
+|  7:4   |   ro   |    x    | REPCNT_FAIL_COUNT    | The number of symbols during which this test failed since the last passing health test window.             |
 |  3:0   |        |         |                      | Reserved                                                                                                   |
 
 ## EXTHT_FAIL_COUNTS
@@ -1064,7 +1068,7 @@ External health test alert failure counts register
 
 This register holds the number of external health test failures since the last passing health test window.
 The values are reported on a per-test basis.
-Note that if multiple health tests fail for a certain window, the value in [`ALERT_SUMMARY_FAIL_COUNTS`](#alert_summary_fail_counts) is incremented by just one whereas multiple fields in this register may get incremented.
+Note that if multiple health tests fail for a certain symbol or window, the value in [`ALERT_SUMMARY_FAIL_COUNTS`](#alert_summary_fail_counts) is incremented by just one whereas multiple fields in this register may get incremented.
 
 All fields of this register are automatically cleared after every passing health test window unless the ENTROPY_SRC is configured in Firmware Override: Extract & Insert mode.
 The fields are also cleared after re-enabling the block.
@@ -1078,11 +1082,11 @@ The fields are also cleared after re-enabling the block.
 {"reg": [{"name": "EXTHT_HI_FAIL_COUNT", "bits": 4, "attr": ["ro"], "rotate": -90}, {"name": "EXTHT_LO_FAIL_COUNT", "bits": 4, "attr": ["ro"], "rotate": -90}, {"bits": 24}], "config": {"lanes": 1, "fontsize": 10, "vspace": 210}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                | Description                                                                                                |
-|:------:|:------:|:-------:|:--------------------|:-----------------------------------------------------------------------------------------------------------|
-|  31:8  |        |         |                     | Reserved                                                                                                   |
-|  7:4   |   ro   |    x    | EXTHT_LO_FAIL_COUNT | The number of health test windows during which this test failed since the last passing health test window. |
-|  3:0   |   ro   |    x    | EXTHT_HI_FAIL_COUNT | The number of health test windows during which this test failed since the last passing health test window. |
+|  Bits  |  Type  |  Reset  | Name                | Description                                                                                                                                                       |
+|:------:|:------:|:-------:|:--------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|  31:8  |        |         |                     | Reserved                                                                                                                                                          |
+|  7:4   |   ro   |    x    | EXTHT_LO_FAIL_COUNT | The number of symbols for continuous tests or health test windows for window-based tests during which this test failed since the last passing health test window. |
+|  3:0   |   ro   |    x    | EXTHT_HI_FAIL_COUNT | The number of symbols for continuous tests or health test windows for window-based tests during which this test failed since the last passing health test window. |
 
 ## FW_OV_CONTROL
 Firmware override control register

--- a/hw/ip/entropy_src/doc/theory_of_operation.md
+++ b/hw/ip/entropy_src/doc/theory_of_operation.md
@@ -223,6 +223,10 @@ The following waveform shows an example of what the PTRNG timing looks like.
 ]}
 ```
 
+Whenever the `rng_enable` signal is asserted, the ENTROPY_SRC accepts every `rng_b` value marked by an asserted `rng_valid` bit.
+`rng_b` values get ignored whenever the `rng_valid` bit is de-asserted.
+The maximum rate at which the ENTROPY_SRC can operate is one `rng_b` value (i.e. a symbol) every two clock cycles.
+
 ### Repetition Count Test
 The following waveform shows how a sampling of a data pattern will be tested by the Repetition Count test.
 Operating on each bit stream, this test will count when a signal is at a stuck level.

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -1601,6 +1601,12 @@ module entropy_src_core import entropy_src_pkg::*; #(
   );
 
   // Window wrap condition
+  // The counter is incremented with every tested symbol and when we've tested sufficiently many
+  // symbols, we decide whether the current window passed or failed the tests. Using the
+  // health_test_done_pulse, we then restart the counter, we update the watermark registers, and
+  // we clear the window-based health tests to get ready for the next window. This means, we can't
+  // actually test another symbol in this cycle, i.e., the maximum rate of the noise source is
+  // limited to one symbol every two clock cycles.
   assign health_test_done_pulse = (window_cntr >= health_test_window);
 
   // Summary of counter errors


### PR DESCRIPTION
See commit messages for details.