### PR TITLE
[entropy_src] Lock up Ack SM upon fatal local events, align scoreboard

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -1985,12 +1985,13 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
               msg = $sformatf("Predicted value of ERR_CODE: %08x", err_code);
               `uvm_info(`gfn, msg, UVM_MEDIUM)
               case(bit_num)
-                22: begin // es_cntr_err
+                20, 21, 22, 23, 24: begin
+                  // Counter and FSM errors are structural errors and are always active.
                   is_fatal = 1;
                   is_logged = 1;
                   main_sm_escalates = 1;
                 end
-                0, 1, 2, 20, 21, 28, 29, 30: begin // other valid err_code bits
+                0, 1, 2, 3, 28, 29, 30: begin // other valid err_code bits
                   // These test bits correspond to events that are always logged
                   // in err_code, but only create fatal alerts if they occur
                   // when the DUT is enabled
@@ -2013,11 +2014,11 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
               end
               fork
                 // Implementation timing detail:
-                // If a particular error is escalated it also becomes a main_sm error.
+                // If a particular error is escalated it also becomes a main_sm and an ack_sm error.
                 if (main_sm_escalates) begin
-                  int main_sm_err_mask = 1 << 21;
+                  int sm_err_mask = 1 << 21 | 1 << 20;
                   cfg.clk_rst_vif.wait_clks(1);
-                  err_code |= main_sm_err_mask;
+                  err_code |= sm_err_mask;
                   `DV_CHECK_FATAL(ral.err_code.predict(.value(err_code), .kind(UVM_PREDICT_READ)));
                 end
               join_none

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -3094,7 +3094,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .req_i            (es_hw_if_req),
     .ack_o            (es_hw_if_ack),
     .fifo_not_empty_i (sfifo_esfinal_not_empty && !es_route_to_sw),
-    .local_escalate_i (es_cntr_err),
+    .local_escalate_i (fatal_loc_events),
     .fifo_pop_o       (es_hw_if_fifo_pop),
     .ack_sm_err_o     (es_ack_sm_err)
   );


### PR DESCRIPTION
This commit modifies the RTL to move the Ack SM into the terminal error state whenever a fatal local event is observed. Previously, the Ack SM would only move to this state upon observing one particular fatal error event, namely the counter error event. As the fatal alert was signaled already before, this is not a very critical issue. But the new behavior is more desirable as it means the ENTROPY_SRC immediately stops serving entropy whenever a fatal local event is observed.

In addition, the modeling in the scoreboard is re-aligned with the actual RTL implementation which fixes a notable amount of test failures.

This resolves lowRISC/OpenTitan#24410.