### PR TITLE
[opentitantool] Add initial SPI device support for QEMU

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -309,6 +309,7 @@ rust_library(
         "//sw/host/ot_transports/proxy",
         "//sw/host/ot_transports/ti50emulator",
         "//sw/host/ot_transports/verilator",
+        "//sw/host/ot_transports/qemu",
     ],
 )
 

--- a/sw/host/opentitanlib/reexport.rs
+++ b/sw/host/opentitanlib/reexport.rs
@@ -10,5 +10,6 @@ extern crate ot_transport_hyperdebug;
 extern crate ot_transport_proxy;
 extern crate ot_transport_ti50emulator;
 extern crate ot_transport_verilator;
+extern crate ot_transport_qemu;
 
 pub use opentitanlib_base::*;

--- a/sw/host/ot_transports/qemu/BUILD
+++ b/sw/host/ot_transports/qemu/BUILD
@@ -1,0 +1,33 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_doc", "rust_library", "rust_test")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_library(
+    name = "qemu",
+    srcs = [
+        "src/lib.rs",
+        "src/spi.rs",
+    ],
+    compile_data = glob(["config/*.json5"]),
+    crate_name = "ot_transport_qemu",
+    deps = [
+        "//sw/host/opentitanlib:opentitanlib_base",
+        "@crate_index//:anyhow",
+        "@crate_index//:log",
+    ],
+)
+
+rust_doc(
+    name = "qemu_doc",
+    crate = ":qemu",
+)
+
+rust_test(
+    name = "qemu_test",
+    crate = ":qemu",
+)
+

--- a/sw/host/ot_transports/qemu/config/qemu.json5
+++ b/sw/host/ot_transports/qemu/config/qemu.json5
@@ -1,0 +1,12 @@
+{
+  "includes": [
+    "/__builtin__/opentitan.json5"
+  ],
+  "interface": "qemu",
+  "spi": [
+    {
+      "name": "BOOTSTRAP",
+      "alias_of": "0"
+    }
+  ]
+}

--- a/sw/host/ot_transports/qemu/src/lib.rs
+++ b/sw/host/ot_transports/qemu/src/lib.rs
@@ -1,0 +1,123 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(unused)]
+
+use anyhow::{bail, ensure, Context, Result};
+use std::cell::{Cell, RefCell};
+use std::io::{self, ErrorKind, Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::rc::Rc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use opentitanlib::backend::{Backend, BackendOpts, define_interface};
+use opentitanlib::util::fs::builtin_file;
+use opentitanlib::io::spi::Target;
+use opentitanlib::transport::{
+    Capabilities, Capability, Transport, TransportError, TransportInterfaceType,
+};
+
+pub mod spi;
+
+pub struct Inner {
+    spi: Option<Rc<dyn Target>>,
+    stream: TcpStream,
+}
+
+impl Inner {
+    fn new(stream: TcpStream) -> Self {
+        Self {
+            spi: None,
+            stream: stream
+        }
+    }
+}
+
+pub struct QEMU {
+    inner: Rc<RefCell<Inner>>,
+}
+
+impl QEMU {
+    const POLL_DELAY: Duration = Duration::from_millis(250);
+    const CONN_DELAY: Duration = Duration::from_secs(2);
+
+    pub fn new() -> anyhow::Result<Self> {
+        let addr = format!("localhost:{}", 8004);
+        let stream = Self::wait_for_socket(addr, QEMU::CONN_DELAY)
+            .context("failed to connect to QEMU SPI_device socket")?;
+        stream.set_read_timeout(Some(QEMU::POLL_DELAY))?;
+        stream.set_write_timeout(Some(QEMU::POLL_DELAY))?;
+        let inner = Inner::new(stream);
+        let board = Self {
+            inner: Rc::new(RefCell::new(inner)),
+        };
+        Ok(board)
+    }
+
+    /// Poll `addr` until it is bound and a socket can connect.
+    fn wait_for_socket<A: ToSocketAddrs>(addr: A, timeout: Duration) -> io::Result<TcpStream> {
+        let start = Instant::now();
+        loop {
+            log::info!("Attempting to make tcp connection...");
+            match TcpStream::connect(&addr) {
+                // This is the error for addresses that aren't bound
+                Err(e) if e.kind() == ErrorKind::ConnectionRefused => (),
+                // This is error has been observed in CQ.
+                Err(e) if e.kind() == ErrorKind::AddrNotAvailable => {
+                    log::warn!("Got ErrorKind::AddrInUse on client socket, odd...");
+                }
+                // All other errors (and `Ok`s) we want to know about
+                Err(e) => {
+                    log::warn!("Error: {:?}", e.kind());
+
+                    return Err(e);
+                }
+                socket => {
+                    log::info!("Connected");
+                    return socket
+                }
+            }
+
+            // Delay between loops if there's enough time before timeout.
+            if start.elapsed() + Self::POLL_DELAY < timeout {
+                thread::sleep(Self::POLL_DELAY);
+            } else {
+                log::warn!("timeout");
+                return Err(ErrorKind::TimedOut.into());
+            }
+        }
+    }
+}
+
+impl Transport for QEMU {
+    fn capabilities(&self) -> Result<Capabilities> {
+        Ok(Capabilities::new(Capability::SPI))
+    }
+
+    fn spi(&self, instance: &str) -> Result<Rc<dyn Target>> {
+        ensure!(
+            instance == "0",
+            TransportError::InvalidInstance(TransportInterfaceType::Spi, instance.to_string())
+        );
+        if self.inner.borrow().spi.is_none() {
+            self.inner.borrow_mut().spi =
+                Some(Rc::new(spi::QEMUSpi::open(Rc::clone(&self.inner))?));
+        }
+        Ok(Rc::clone(self.inner.borrow().spi.as_ref().unwrap()))
+    }
+}
+
+struct QemuBackend;
+
+impl Backend for QemuBackend {
+    type Opts = ();
+
+    fn create_transport(_: &BackendOpts, _: &()) -> Result<Box<dyn Transport>> {
+        Ok(Box::new(QEMU::new()?))
+    }
+}
+
+define_interface!("qemu", QemuBackend, "/__builtin__/qemu.json5");
+builtin_file!("qemu.json5", include_str!("../config/qemu.json5"));

--- a/sw/host/ot_transports/qemu/src/spi.rs
+++ b/sw/host/ot_transports/qemu/src/spi.rs
@@ -1,0 +1,266 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, ensure, Context, Result};
+use std::cell::RefCell;
+use std::io::{self, Error, ErrorKind, Read, Write};
+use std::rc::Rc;
+use std::time::{Duration, Instant};
+
+use opentitanlib::io::eeprom;
+use opentitanlib::io::eeprom::Transaction::{Read as SpiRead, WaitForBusyClear, Write as SpiWrite};
+use opentitanlib::io::spi::{AssertChipSelect, MaxSizes, SpiError, Target, Transfer, TransferMode};
+use opentitanlib::spiflash::flash::SpiFlash;
+use opentitanlib::util::voltage::Voltage;
+use crate::Inner;
+
+pub struct QEMUSpi {
+    inner: Rc<RefCell<Inner>>,
+    buffer: Rc<RefCell<Vec<u8>>>,
+    max_chunk_size: usize,
+    spi_mode: u8,
+    addr4b_enable: bool,
+}
+
+impl QEMUSpi {
+    const MAX_FLASH_DATA_LEN: usize = 65536;
+    const COMM_TIMEOUT: Duration = Duration::from_millis(2000);
+
+    pub fn open(inner: Rc<RefCell<Inner>>) -> Result<Self> {
+        let this = Self {
+            inner,
+            buffer: Rc::new(RefCell::new(Vec::new())),
+            max_chunk_size: 65535 * 256,
+            spi_mode: 0,
+            addr4b_enable: false,
+        };
+        Ok(this)
+    }
+
+    fn eeprom_read_transaction(&self, cmd: &eeprom::Cmd, rbuf: &mut [u8]) -> Result<()> {
+        let cmdbuf = cmd.to_bytes()?;
+        self.transmit(cmdbuf, rbuf, true)
+    }
+
+    fn eeprom_write_transaction(&self, cmd: &eeprom::Cmd, wbuf: &[u8],
+                                _wait_for_busy_clear: bool) -> Result<()> {
+        let cmdbuf = cmd.to_bytes()?;
+        let mut rbuf = [0u8; 0];
+        self.transmit(cmdbuf, &mut rbuf, false)?;
+        self.transmit(wbuf, &mut rbuf, true)
+    }
+
+    fn do_run_eeprom_transactions(
+        &self,
+        mut transactions: &mut [eeprom::Transaction],
+    ) -> Result<()> {
+        loop {
+            match transactions {
+                [eeprom::Transaction::Command(pre_cmd), SpiWrite(cmd, wbuf), WaitForBusyClear, rest @ ..] =>
+                {
+                    transactions = rest;
+                    if pre_cmd.get_opcode() == [SpiFlash::WRITE_ENABLE] {
+                        // Write enable is done by eeprom_write_transaction()
+                    } else {
+                        self.run_transaction(&mut [Transfer::Write(cmd.to_bytes()?)])?
+                    }
+                    self.eeprom_write_transaction(cmd, wbuf, true)?;
+                }
+                [eeprom::Transaction::Command(cmd), rest @ ..] => {
+                    transactions = rest;
+                    self.run_transaction(&mut [Transfer::Write(cmd.to_bytes()?)])?
+                }
+                &mut [SpiRead(ref mut cmd, ref mut rbuf), ref mut rest @ ..] => {
+                    transactions = rest;
+                    self.eeprom_read_transaction(cmd, rbuf)?;
+                }
+                [SpiWrite(cmd, wbuf), WaitForBusyClear, rest @ ..] => {
+                    transactions = rest;
+                    self.eeprom_write_transaction(cmd, wbuf, true)?;
+                }
+                [SpiWrite(cmd, wbuf), rest @ ..] => {
+                    transactions = rest;
+                    self.eeprom_write_transaction(cmd, wbuf, false)?;
+                }
+                [WaitForBusyClear, rest @ ..] => {
+                    transactions = rest;
+                    let mut status = eeprom::STATUS_WIP;
+                    while status & eeprom::STATUS_WIP != 0 {
+                        self.run_transaction(&mut [
+                            Transfer::Write(&[eeprom::READ_STATUS]),
+                            Transfer::Read(std::slice::from_mut(&mut status)),
+                        ])?;
+                    }
+                }
+                [] => return Ok(()),
+            }
+        }
+        Ok(())
+    }
+
+    fn build_cs_header(&self, size: usize, release: bool) -> [u8; 8] {
+        let mut mode = self.spi_mode & 0xf;
+        if !release {
+            mode |= 0x80;
+        }
+        let mut header = [0u8; 8];
+        header[0..3].clone_from_slice(b"/CS");
+        header[3] = 0; // version
+        header[4] = mode;
+        header[6..8].clone_from_slice(&(size as u16).to_le_bytes());
+        header
+    }
+
+    fn send(&self, txbuf: &[u8], release: bool) -> Result<()> {
+        let size = txbuf.len();
+        let header = self.build_cs_header(size, release);
+        {
+            let stream = &mut self.inner.borrow_mut().stream;
+            stream.write_all(&header[..])
+                .with_context(|| "Cannot send SPI CS header")?;
+            stream.write_all(txbuf)
+                .with_context(|| "Cannot send SPI TX data")
+        }
+    }
+
+    fn receive(&self, rxbuf: &mut [u8]) -> Result<()> {
+        let length = rxbuf.len();
+        let mut rx_len = 0usize;
+        let timeout = Instant::now() + QEMUSpi::COMM_TIMEOUT;
+        while rx_len < length {
+            match self.inner.borrow_mut().stream.read(&mut rxbuf[rx_len..length]) {
+                Ok(0) => (),
+                Ok(n) => { rx_len += n; continue; },
+                Err(err) => match err.kind() {
+                    ErrorKind::TimedOut | ErrorKind::WouldBlock => (),
+                    _ => {
+                        return Err(err).with_context(|| "Cannot receive SPI RX data");
+                    }
+                }
+            }
+            if Instant::now() > timeout {
+                return Err(Error::new(ErrorKind::TimedOut, ""))
+                    .with_context(|| "Timeout on SPI RX data");
+            }
+        }
+        Ok(())
+    }
+
+    fn transmit(&self, txbuf: &[u8], rxbuf: &mut [u8], release: bool) -> Result<()> {
+        let txlen = txbuf.len();
+        let rxlen = rxbuf.len();
+        let length = txlen+rxlen;
+        let mut buffer = self.buffer.borrow_mut();
+        buffer.resize(length, 0xffu8);
+        buffer[..txlen].clone_from_slice(txbuf);
+        log::debug!("TX: {:x?}", buffer);
+        self.send(&buffer, release)?;
+        buffer.resize(length, 0xffu8);
+        self.receive(&mut buffer)?;
+        log::debug!("RX: {:x?}", buffer);
+        rxbuf.clone_from_slice(&buffer[txlen..]);
+        if rxlen != rxbuf.len() {
+            return Err(Error::new(ErrorKind::TimedOut, ""))
+                .with_context(|| format!("Response truncated {}/{}", rxlen, txlen))
+        }
+        Ok(())
+    }
+}
+
+impl Target for QEMUSpi {
+    fn get_transfer_mode(&self) -> Result<TransferMode> {
+        unimplemented!();
+    }
+
+    fn set_transfer_mode(&self, _mode: TransferMode) -> Result<()> {
+        unimplemented!();
+    }
+
+    fn supports_tpm_poll(&self) -> Result<bool> {
+        unimplemented!();
+    }
+
+    fn get_bits_per_word(&self) -> Result<u32> {
+        Ok(8)
+    }
+
+    fn set_bits_per_word(&self, bits_per_word: u32) -> Result<()> {
+        match bits_per_word {
+            8 => Ok(()),
+            _ => Err(SpiError::InvalidWordSize(bits_per_word).into()),
+        }
+    }
+
+    fn get_max_speed(&self) -> Result<u32> {
+        Ok(10_000_000)
+    }
+
+    fn set_max_speed(&self, frequency: u32) -> Result<()> {
+        Ok(())
+    }
+
+    fn get_max_transfer_count(&self) -> Result<usize> {
+        // Arbitrary value
+        Ok(42)
+    }
+
+    fn get_max_transfer_sizes(&self) -> Result<MaxSizes> {
+        Ok(MaxSizes {
+            read: Self::MAX_FLASH_DATA_LEN,
+            write: Self::MAX_FLASH_DATA_LEN,
+        })
+    }
+
+    fn set_voltage(&self, voltage: Voltage) -> Result<()> {
+        Ok(())
+    }
+
+    fn run_transaction(&self, transaction: &mut [Transfer]) -> Result<()> {
+        match transaction {
+            [] => (),
+            [Transfer::Write(wbuf), Transfer::Read(rbuf)] => {
+                ensure!(
+                    wbuf.len() <= Self::MAX_FLASH_DATA_LEN,
+                    SpiError::InvalidDataLength(wbuf.len())
+                );
+                ensure!(
+                    rbuf.len() <= Self::MAX_FLASH_DATA_LEN,
+                    SpiError::InvalidDataLength(rbuf.len())
+                );
+                self.transmit(wbuf, rbuf, true)?;
+            }
+            [Transfer::Write(wbuf)] => {
+                ensure!(
+                    wbuf.len() <= Self::MAX_FLASH_DATA_LEN,
+                    SpiError::InvalidDataLength(wbuf.len())
+                );
+                let mut rbuf = [0u8; 0];
+                self.transmit(wbuf, &mut rbuf, true)?;
+            }
+            _ => bail!(SpiError::InvalidTransferMode(
+                "Unsupported combination".to_string()
+            )),
+        }
+        Ok(())
+    }
+
+    fn get_eeprom_max_transfer_sizes(&self) -> Result<MaxSizes> {
+        Ok(MaxSizes {
+            read: self.max_chunk_size,
+            write: self.max_chunk_size,
+        })
+    }
+
+    fn run_eeprom_transactions(&self, transactions: &mut [eeprom::Transaction]) -> Result<()> {
+        self.do_run_eeprom_transactions(transactions)
+    }
+
+    fn assert_cs(self: Rc<Self>) -> Result<AssertChipSelect> {
+        unimplemented!();
+    }
+
+    fn supports_bidirectional_transfer(&self) -> Result<bool> {
+        Ok(true)
+    }
+}


### PR DESCRIPTION
This PR adds QEMU connectivity for SPI device to opentitanlib / opentitantool.

It can be tested with lowRISC/qemu/tree/ot-earlgrey-9.2.0

To enable SPI dev support on Earlgrey, two options should be defined:

./qemu-system-riscv32 -M ot-earlgrey,no_epmp_cfg=true -nographic -chardev socket,id=spidev,host=localhost,port=8004,server=on,wait=off \ -global ot-spi_device.chardev=spidev \
-kernel spidev-flash-test

Test example:

bazel-out/k8-fastbuild/bin/sw/host/opentitantool/opentitantool --logging info --interface qemu spi sfdp bazel-out/k8-fastbuild/bin/sw/host/opentitantool/opentitantool --logging info --interface qemu spi program LICENSE

Side note: this is renewal of PR created by @rivos-eblot some time ago here: https://github.com/lowRISC/opentitan/pull/20334 . The code has been aligned with lowRISC master top and tested