### PR TITLE
[crypto] CTRL regs hardening: AES, HMAC, KeyMngr, CSRNG

### DIFF
--- a/sw/device/lib/crypto/drivers/aes.c
+++ b/sw/device/lib/crypto/drivers/aes.c
@@ -88,6 +88,163 @@ static status_t aes_write_key(aes_key_t key) {
 }
 
 /**
+ * Compute the ctrl register value for the given parameters.
+ *
+ * @param key AES key.
+ * @param encrypt True for encryption, false for decryption.
+ * @return result, OK or error.
+ */
+static status_t compute_ctrl_reg(aes_key_t key, hardened_bool_t encrypt,
+                                 uint32_t *ctrl_reg) {
+  *ctrl_reg = AES_CTRL_SHADOWED_REG_RESVAL;
+
+  // Set the operation (encrypt or decrypt).
+  hardened_bool_t operation_enc = launder32(0);
+  switch (encrypt) {
+    case kHardenedBoolTrue:
+      *ctrl_reg =
+          bitfield_field32_write(*ctrl_reg, AES_CTRL_SHADOWED_OPERATION_FIELD,
+                                 AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC);
+      operation_enc = launder32(operation_enc) | kHardenedBoolTrue;
+      break;
+    case kHardenedBoolFalse:
+      *ctrl_reg =
+          bitfield_field32_write(*ctrl_reg, AES_CTRL_SHADOWED_OPERATION_FIELD,
+                                 AES_CTRL_SHADOWED_OPERATION_VALUE_AES_DEC);
+      operation_enc = launder32(operation_enc) | kHardenedBoolFalse;
+      break;
+    default:
+      // Invalid value.
+      return OTCRYPTO_BAD_ARGS;
+  }
+  // Check if we landed in the correct case statement. Use ORs for this to
+  // avoid that multiple cases were executed.
+  HARDENED_CHECK_EQ(launder32(operation_enc), encrypt);
+
+  // Indicate whether the key will be sideloaded.
+  hardened_bool_t which_sideload = launder32(0);
+  switch (key.sideload) {
+    case kHardenedBoolTrue:
+      *ctrl_reg =
+          bitfield_bit32_write(*ctrl_reg, AES_CTRL_SHADOWED_SIDELOAD_BIT, true);
+      which_sideload = launder32(which_sideload) | kHardenedBoolTrue;
+      break;
+    case kHardenedBoolFalse:
+      *ctrl_reg = bitfield_bit32_write(*ctrl_reg,
+                                       AES_CTRL_SHADOWED_SIDELOAD_BIT, false);
+      which_sideload = launder32(which_sideload) | kHardenedBoolFalse;
+      break;
+    default:
+      // Invalid value.
+      return OTCRYPTO_BAD_ARGS;
+  }
+  // Check if we landed in the correct case statement. Use ORs for this to
+  // avoid that multiple cases were executed.
+  HARDENED_CHECK_EQ(launder32(which_sideload), key.sideload);
+
+  // Translate the cipher mode to the hardware-encoding value and write the
+  // control reg field.
+  aes_cipher_mode_t mode_written = launder32(0);
+  switch (launder32(key.mode)) {
+    case kAesCipherModeEcb:
+      *ctrl_reg =
+          bitfield_field32_write(*ctrl_reg, AES_CTRL_SHADOWED_MODE_FIELD,
+                                 AES_CTRL_SHADOWED_MODE_VALUE_AES_ECB);
+      mode_written = launder32(mode_written) | kAesCipherModeEcb;
+      break;
+    case kAesCipherModeCbc:
+      *ctrl_reg =
+          bitfield_field32_write(*ctrl_reg, AES_CTRL_SHADOWED_MODE_FIELD,
+                                 AES_CTRL_SHADOWED_MODE_VALUE_AES_CBC);
+      mode_written = launder32(mode_written) | kAesCipherModeCbc;
+      break;
+    case kAesCipherModeCfb:
+      *ctrl_reg =
+          bitfield_field32_write(*ctrl_reg, AES_CTRL_SHADOWED_MODE_FIELD,
+                                 AES_CTRL_SHADOWED_MODE_VALUE_AES_CFB);
+      mode_written = launder32(mode_written) | kAesCipherModeCfb;
+      break;
+    case kAesCipherModeOfb:
+      *ctrl_reg =
+          bitfield_field32_write(*ctrl_reg, AES_CTRL_SHADOWED_MODE_FIELD,
+                                 AES_CTRL_SHADOWED_MODE_VALUE_AES_OFB);
+      mode_written = launder32(mode_written) | kAesCipherModeOfb;
+      break;
+    case kAesCipherModeCtr:
+      *ctrl_reg =
+          bitfield_field32_write(*ctrl_reg, AES_CTRL_SHADOWED_MODE_FIELD,
+                                 AES_CTRL_SHADOWED_MODE_VALUE_AES_CTR);
+      mode_written = launder32(mode_written) | kAesCipherModeCtr;
+      break;
+    default:
+      // Invalid value.
+      return OTCRYPTO_BAD_ARGS;
+  }
+  // Check if we landed in the correct case statement. Use ORs for this to
+  // avoid that multiple cases were executed.
+  HARDENED_CHECK_EQ(launder32(mode_written), key.mode);
+
+  // Translate the key length to the hardware-encoding value and write the
+  // control reg field.
+  size_t key_len_written;
+  switch (key.key_len) {
+    case kAesKeyWordLen128:
+      *ctrl_reg =
+          bitfield_field32_write(*ctrl_reg, AES_CTRL_SHADOWED_KEY_LEN_FIELD,
+                                 AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128);
+      key_len_written = launder32(kAesKeyWordLen128);
+      break;
+    case kAesKeyWordLen192:
+      *ctrl_reg =
+          bitfield_field32_write(*ctrl_reg, AES_CTRL_SHADOWED_KEY_LEN_FIELD,
+                                 AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_192);
+      key_len_written = launder32(kAesKeyWordLen192);
+      break;
+    case kAesKeyWordLen256:
+      *ctrl_reg =
+          bitfield_field32_write(*ctrl_reg, AES_CTRL_SHADOWED_KEY_LEN_FIELD,
+                                 AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_256);
+      key_len_written = launder32(kAesKeyWordLen256);
+      break;
+    default:
+      // Invalid value.
+      return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(key_len_written, key.key_len);
+
+  // Never enable manual operation.
+  *ctrl_reg = bitfield_bit32_write(
+      *ctrl_reg, AES_CTRL_SHADOWED_MANUAL_OPERATION_BIT, false);
+
+  // Always set the PRNG reseed rate to once per 64 blocks.
+  *ctrl_reg = bitfield_field32_write(
+      *ctrl_reg, AES_CTRL_SHADOWED_PRNG_RESEED_RATE_FIELD,
+      AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_64);
+  return OTCRYPTO_OK;
+}
+
+status_t aes_verify_ctrl_reg(aes_key_t key, hardened_bool_t encrypt) {
+  uint32_t ctrl_reg;
+
+  HARDENED_TRY(compute_ctrl_reg(key, encrypt, &ctrl_reg));
+  HARDENED_CHECK_EQ(abs_mmio_read32(aes_base() + AES_CTRL_SHADOWED_REG_OFFSET),
+                    launder32(ctrl_reg));
+
+  return OTCRYPTO_OK;
+}
+
+status_t aes_verify_ctrl_aux_reg(void) {
+  // This has not been configured, so it is at its reset state.
+  uint32_t ctrl_aux_reg = 0x1;
+
+  HARDENED_CHECK_EQ(
+      abs_mmio_read32(aes_base() + AES_CTRL_AUX_SHADOWED_REG_OFFSET),
+      launder32(ctrl_aux_reg));
+
+  return OTCRYPTO_OK;
+}
+
+/**
  * Configure the AES block and write the key and IV if applicable.
  *
  * @param key AES key.
@@ -104,125 +261,9 @@ static status_t aes_begin(aes_key_t key, const aes_block_t *iv,
   // Wait for the AES block to be idle.
   HARDENED_TRY(spin_until(AES_STATUS_IDLE_BIT));
 
-  uint32_t ctrl_reg = AES_CTRL_SHADOWED_REG_RESVAL;
+  uint32_t ctrl_reg;
 
-  // Set the operation (encrypt or decrypt).
-  hardened_bool_t operation_enc = launder32(0);
-  switch (encrypt) {
-    case kHardenedBoolTrue:
-      ctrl_reg =
-          bitfield_field32_write(ctrl_reg, AES_CTRL_SHADOWED_OPERATION_FIELD,
-                                 AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC);
-      operation_enc = launder32(operation_enc) | kHardenedBoolTrue;
-      break;
-    case kHardenedBoolFalse:
-      ctrl_reg =
-          bitfield_field32_write(ctrl_reg, AES_CTRL_SHADOWED_OPERATION_FIELD,
-                                 AES_CTRL_SHADOWED_OPERATION_VALUE_AES_DEC);
-      operation_enc = launder32(operation_enc) | kHardenedBoolFalse;
-      break;
-    default:
-      // Invalid value.
-      return OTCRYPTO_BAD_ARGS;
-  }
-  // Check if we landed in the correct case statement. Use ORs for this to
-  // avoid that multiple cases were executed.
-  HARDENED_CHECK_EQ(launder32(operation_enc), encrypt);
-
-  // Indicate whether the key will be sideloaded.
-  hardened_bool_t which_sideload = launder32(0);
-  switch (key.sideload) {
-    case kHardenedBoolTrue:
-      ctrl_reg =
-          bitfield_bit32_write(ctrl_reg, AES_CTRL_SHADOWED_SIDELOAD_BIT, true);
-      which_sideload = launder32(which_sideload) | kHardenedBoolTrue;
-      break;
-    case kHardenedBoolFalse:
-      ctrl_reg =
-          bitfield_bit32_write(ctrl_reg, AES_CTRL_SHADOWED_SIDELOAD_BIT, false);
-      which_sideload = launder32(which_sideload) | kHardenedBoolFalse;
-      break;
-    default:
-      // Invalid value.
-      return OTCRYPTO_BAD_ARGS;
-  }
-  // Check if we landed in the correct case statement. Use ORs for this to
-  // avoid that multiple cases were executed.
-  HARDENED_CHECK_EQ(launder32(which_sideload), key.sideload);
-
-  // Translate the cipher mode to the hardware-encoding value and write the
-  // control reg field.
-  aes_cipher_mode_t mode_written = launder32(0);
-  switch (launder32(key.mode)) {
-    case kAesCipherModeEcb:
-      ctrl_reg = bitfield_field32_write(ctrl_reg, AES_CTRL_SHADOWED_MODE_FIELD,
-                                        AES_CTRL_SHADOWED_MODE_VALUE_AES_ECB);
-      mode_written = launder32(mode_written) | kAesCipherModeEcb;
-      break;
-    case kAesCipherModeCbc:
-      ctrl_reg = bitfield_field32_write(ctrl_reg, AES_CTRL_SHADOWED_MODE_FIELD,
-                                        AES_CTRL_SHADOWED_MODE_VALUE_AES_CBC);
-      mode_written = launder32(mode_written) | kAesCipherModeCbc;
-      break;
-    case kAesCipherModeCfb:
-      ctrl_reg = bitfield_field32_write(ctrl_reg, AES_CTRL_SHADOWED_MODE_FIELD,
-                                        AES_CTRL_SHADOWED_MODE_VALUE_AES_CFB);
-      mode_written = launder32(mode_written) | kAesCipherModeCfb;
-      break;
-    case kAesCipherModeOfb:
-      ctrl_reg = bitfield_field32_write(ctrl_reg, AES_CTRL_SHADOWED_MODE_FIELD,
-                                        AES_CTRL_SHADOWED_MODE_VALUE_AES_OFB);
-      mode_written = launder32(mode_written) | kAesCipherModeOfb;
-      break;
-    case kAesCipherModeCtr:
-      ctrl_reg = bitfield_field32_write(ctrl_reg, AES_CTRL_SHADOWED_MODE_FIELD,
-                                        AES_CTRL_SHADOWED_MODE_VALUE_AES_CTR);
-      mode_written = launder32(mode_written) | kAesCipherModeCtr;
-      break;
-    default:
-      // Invalid value.
-      return OTCRYPTO_BAD_ARGS;
-  }
-  // Check if we landed in the correct case statement. Use ORs for this to
-  // avoid that multiple cases were executed.
-  HARDENED_CHECK_EQ(launder32(mode_written), key.mode);
-
-  // Translate the key length to the hardware-encoding value and write the
-  // control reg field.
-  size_t key_len_written;
-  switch (key.key_len) {
-    case kAesKeyWordLen128:
-      ctrl_reg =
-          bitfield_field32_write(ctrl_reg, AES_CTRL_SHADOWED_KEY_LEN_FIELD,
-                                 AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128);
-      key_len_written = launder32(kAesKeyWordLen128);
-      break;
-    case kAesKeyWordLen192:
-      ctrl_reg =
-          bitfield_field32_write(ctrl_reg, AES_CTRL_SHADOWED_KEY_LEN_FIELD,
-                                 AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_192);
-      key_len_written = launder32(kAesKeyWordLen192);
-      break;
-    case kAesKeyWordLen256:
-      ctrl_reg =
-          bitfield_field32_write(ctrl_reg, AES_CTRL_SHADOWED_KEY_LEN_FIELD,
-                                 AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_256);
-      key_len_written = launder32(kAesKeyWordLen256);
-      break;
-    default:
-      // Invalid value.
-      return OTCRYPTO_BAD_ARGS;
-  }
-  HARDENED_CHECK_EQ(key_len_written, key.key_len);
-
-  // Never enable manual operation.
-  ctrl_reg = bitfield_bit32_write(
-      ctrl_reg, AES_CTRL_SHADOWED_MANUAL_OPERATION_BIT, false);
-
-  // Always set the PRNG reseed rate to once per 64 blocks.
-  ctrl_reg =
-      bitfield_field32_write(ctrl_reg, AES_CTRL_SHADOWED_PRNG_RESEED_RATE_FIELD,
-                             AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_64);
+  HARDENED_TRY(compute_ctrl_reg(key, encrypt, &ctrl_reg));
 
   abs_mmio_write32_shadowed(aes_base() + AES_CTRL_SHADOWED_REG_OFFSET,
                             ctrl_reg);

--- a/sw/device/lib/crypto/drivers/aes.h
+++ b/sw/device/lib/crypto/drivers/aes.h
@@ -81,6 +81,22 @@ typedef struct aes_key {
 } aes_key_t;
 
 /**
+ * Verify the ctrl register value for the given parameters.
+ *
+ * @param key AES key.
+ * @param encrypt True for encryption, false for decryption.
+ * @return result, OK or error.
+ */
+status_t aes_verify_ctrl_reg(aes_key_t key, hardened_bool_t encrypt);
+
+/**
+ * Verify the ctrl aux register value whether it is at the reset state.
+ *
+ * @return result, OK or error.
+ */
+status_t aes_verify_ctrl_aux_reg(void);
+
+/**
  * Prepares the AES hardware to perform an encryption operation.
  *
  * If `key.sideload` is true, then this routine does not load the key; the

--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -491,6 +491,21 @@ static void csrng_configure(void) {
 }
 
 /**
+ * Verify the CTRL register from the CSRNG.
+ */
+static void csrng_verify(void) {
+  uint32_t reg =
+      bitfield_field32_write(0, CSRNG_CTRL_ENABLE_FIELD, kMultiBitBool4True);
+  reg = bitfield_field32_write(reg, CSRNG_CTRL_SW_APP_ENABLE_FIELD,
+                               kMultiBitBool4True);
+  reg = bitfield_field32_write(reg, CSRNG_CTRL_READ_INT_STATE_FIELD,
+                               kMultiBitBool4True);
+  reg = bitfield_field32_write(reg, CSRNG_CTRL_FIPS_FORCE_ENABLE_FIELD,
+                               kMultiBitBool4False);
+  HARDENED_CHECK_EQ(abs_mmio_read32(csrng_base() + CSRNG_CTRL_REG_OFFSET), reg);
+}
+
+/**
  * Stops a given EDN instance.
  *
  * It also resets the EDN CSRNG command buffer to avoid synchronization issues
@@ -976,6 +991,9 @@ status_t entropy_csrng_generate_data_get(uint32_t *buf, size_t len,
       }
     }
   }
+
+  // Check the CTRL register from the CSRNG to protect against fault attacks.
+  csrng_verify();
 
   return res;
 }

--- a/sw/device/lib/crypto/drivers/hmac.c
+++ b/sw/device/lib/crypto/drivers/hmac.c
@@ -433,10 +433,6 @@ static status_t oneshot(const uint32_t cfg, const hmac_key_t *key,
   // Write the key (no-op if the key length is 0, e.g. for hashing).
   HARDENED_TRY(key_write(key));
 
-  // Read back the HMAC configuration and compare to the expected configuration.
-  HARDENED_CHECK_EQ(abs_mmio_read32(hmac_base() + HMAC_CFG_REG_OFFSET),
-                    launder32(cfg));
-
   // Send the START command.
   uint32_t cmd =
       bitfield_bit32_write(HMAC_CMD_REG_RESVAL, HMAC_CMD_HASH_START_BIT, 1);
@@ -452,6 +448,10 @@ static status_t oneshot(const uint32_t cfg, const hmac_key_t *key,
   // Wait for the digest to be ready, then read it.
   HARDENED_TRY(hmac_idle_wait());
   digest_read(digest, digest_wordlen);
+
+  // Read back the HMAC configuration and compare to the expected configuration.
+  HARDENED_CHECK_EQ(abs_mmio_read32(hmac_base() + HMAC_CFG_REG_OFFSET),
+                    launder32(cfg));
 
   HARDENED_TRY(clear());
   return OTCRYPTO_OK;

--- a/sw/device/lib/crypto/drivers/keymgr.c
+++ b/sw/device/lib/crypto/drivers/keymgr.c
@@ -56,7 +56,7 @@ static status_t keymgr_is_idle(void) {
  *
  * @param diversification Diversification input for the key derivation.
  */
-static void keymgr_start(keymgr_diversification_t diversification) {
+static status_t keymgr_start(keymgr_diversification_t diversification) {
   const uint32_t kBase = keymgr_base();
   // Set the version.
   abs_mmio_write32(kBase + KEYMGR_KEY_VERSION_REG_OFFSET,
@@ -69,6 +69,8 @@ static void keymgr_start(keymgr_diversification_t diversification) {
 
   // Issue the start command.
   abs_mmio_write32(kBase + KEYMGR_START_REG_OFFSET, 1 << KEYMGR_START_EN_BIT);
+
+  return OTCRYPTO_OK;
 }
 
 /**
@@ -139,6 +141,27 @@ static status_t keymgr_wait_until_done(void) {
         keymgr_base() + KEYMGR_CONTROL_SHADOWED_REG_OFFSET, ctrl);             \
   } while (false);
 
+/**
+ * Verify the control register of the key manager.
+ *
+ * @param dest (NONE, AES, OTBN, or KMAC)
+ * @param operation (GENERATE_SW or GENERATE_HW)
+ */
+#define VERIFY_CTRL(dest, operation)                                           \
+  do {                                                                         \
+    uint32_t ctrl =                                                            \
+        bitfield_field32_write(0, KEYMGR_CONTROL_SHADOWED_DEST_SEL_FIELD,      \
+                               KEYMGR_CONTROL_SHADOWED_DEST_SEL_VALUE_##dest); \
+    ctrl = bitfield_bit32_write(ctrl, KEYMGR_CONTROL_SHADOWED_CDI_SEL_BIT,     \
+                                false);                                        \
+    ctrl = bitfield_field32_write(                                             \
+        ctrl, KEYMGR_CONTROL_SHADOWED_OPERATION_FIELD,                         \
+        KEYMGR_CONTROL_SHADOWED_OPERATION_VALUE_##operation##_OUTPUT);         \
+    HARDENED_CHECK_EQ(                                                         \
+        abs_mmio_read32(keymgr_base() + KEYMGR_CONTROL_SHADOWED_REG_OFFSET),   \
+        ctrl);                                                                 \
+  } while (false);
+
 status_t keymgr_generate_key_sw(keymgr_diversification_t diversification,
                                 keymgr_output_t *key) {
   // Ensure that the entropy complex has been initialized and keymgr is idle.
@@ -149,8 +172,11 @@ status_t keymgr_generate_key_sw(keymgr_diversification_t diversification,
   WRITE_CTRL(NONE, GENERATE_SW);
 
   // Start the operation and wait for it to complete.
-  keymgr_start(diversification);
+  HARDENED_TRY(keymgr_start(diversification));
   HARDENED_TRY(keymgr_wait_until_done());
+
+  // Check the control register.
+  VERIFY_CTRL(NONE, GENERATE_SW);
 
   // Collect the output. To avoid side-channel lekage, first randomize the
   // destination buffers using memshred. Then copy the key using a hardened
@@ -176,8 +202,12 @@ status_t keymgr_generate_key_aes(keymgr_diversification_t diversification) {
   WRITE_CTRL(AES, GENERATE_HW);
 
   // Start the operation and wait for it to complete.
-  keymgr_start(diversification);
-  return keymgr_wait_until_done();
+  HARDENED_TRY(keymgr_start(diversification));
+  HARDENED_TRY(keymgr_wait_until_done());
+  // Check the control register.
+  VERIFY_CTRL(AES, GENERATE_HW);
+
+  return OTCRYPTO_OK;
 }
 
 status_t keymgr_generate_key_kmac(keymgr_diversification_t diversification) {
@@ -189,8 +219,11 @@ status_t keymgr_generate_key_kmac(keymgr_diversification_t diversification) {
   WRITE_CTRL(KMAC, GENERATE_HW);
 
   // Start the operation and wait for it to complete.
-  keymgr_start(diversification);
-  return keymgr_wait_until_done();
+  HARDENED_TRY(keymgr_start(diversification));
+  HARDENED_TRY(keymgr_wait_until_done());
+  // Check the control register.
+  VERIFY_CTRL(KMAC, GENERATE_HW);
+  return OTCRYPTO_OK;
 }
 
 status_t keymgr_generate_key_otbn(keymgr_diversification_t diversification) {
@@ -202,8 +235,11 @@ status_t keymgr_generate_key_otbn(keymgr_diversification_t diversification) {
   WRITE_CTRL(OTBN, GENERATE_HW);
 
   // Start the operation and wait for it to complete.
-  keymgr_start(diversification);
-  return keymgr_wait_until_done();
+  HARDENED_TRY(keymgr_start(diversification));
+  HARDENED_TRY(keymgr_wait_until_done());
+  // Check the control register.
+  VERIFY_CTRL(OTBN, GENERATE_HW);
+  return OTCRYPTO_OK;
 }
 
 /**

--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -425,6 +425,16 @@ static otcrypto_status_t otcrypto_aes_impl(
   // Check that the loop ran for the correct number of iterations.
   HARDENED_CHECK_EQ(launder32(i), 0);
 
+  // Verify the CTRL and CTRL_AUX registers.
+
+  // Since this is a checking mechanism itself, we do not add extra redundancy
+  // to the if loop.
+  hardened_bool_t encrypt = kHardenedBoolTrue;
+  if (aes_operation == kOtcryptoAesOperationDecrypt)
+    encrypt = kHardenedBoolFalse;
+  HARDENED_TRY(aes_verify_ctrl_reg(aes_key, encrypt));
+  HARDENED_TRY(aes_verify_ctrl_aux_reg());
+
   // Deinitialize the AES block and update the IV (in ECB mode, skip the IV).
   if (aes_mode == kAesCipherModeEcb) {
     HARDENED_TRY(aes_end(NULL));

--- a/sw/device/lib/crypto/impl/aes_gcm/aes_gcm.c
+++ b/sw/device/lib/crypto/impl/aes_gcm/aes_gcm.c
@@ -79,6 +79,10 @@ static status_t aes_encrypt_block(
     HARDENED_TRY(aes_update(/*dest=*/NULL, input));
     HARDENED_TRY(aes_update(output, /*src=*/NULL));
 
+    // Verify the CTRL and CTRL_AUX registers of the encryption.
+    HARDENED_TRY(aes_verify_ctrl_reg(key, kHardenedBoolTrue));
+    HARDENED_TRY(aes_verify_ctrl_aux_reg());
+
     // Second AES operation. Decrypt the output of the first AES operation and
     // check whether the same input is retrieved.
     aes_block_t input_recalculated = (aes_block_t){.data = {0}};
@@ -91,6 +95,7 @@ static status_t aes_encrypt_block(
         hardened_memeq((const uint32_t *)input_recalculated.data,
                        (const uint32_t *)input->data, kAesBlockNumWords),
         kHardenedBoolTrue);
+
     return OTCRYPTO_OK;
   }
 }


### PR DESCRIPTION
Reread the CTRL and CTRL_AUX registers from the AES once it is done with its operation.
Move HMAC's verification of the CFG registers to the end of the computation.
Reread the CTRL register from the CSRNG after generating data.
Reread the CONTROL register from the key manager when generating a key.
This is to stop potential fault attacks on the security critical registers.