### PR TITLE
Fix merge skew in `earlgrey_1.0.0` from zerocopy update

### DIFF
--- a/sw/host/opentitanlib/src/image/manifest.rs
+++ b/sw/host/opentitanlib/src/image/manifest.rs
@@ -215,7 +215,7 @@ pub struct ManifestExtIsfbErasePolicy {
 }
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, FromZeroes, Debug, Default)]
+#[derive(Immutable, IntoBytes, FromBytes, Debug, Default)]
 pub struct ManifestExtImageType {
     pub header: ManifestExtHeader,
     pub image_type: u32,


### PR DESCRIPTION
Fix merge skew introduced to `earlgrey_1.0.0` which is currently breaking CI as a result of https://github.com/lowRISC/opentitan/pull/28324 being merged based on CI results that were not rebased on the previously merged https://github.com/lowRISC/opentitan/pull/28228. The latter backport PR performed a major version update of `zerocopy` with breaking API changes to the `AsBytes`, `.as_bytes()` and `FromZeroes` public APIs used in the former PR, as is described in the original PR to `master` that bumped the zerocopy version (https://github.com/lowRISC/opentitan/pull/25912).

Fix the merge skew by removing the outdated API definitions (`AsBytes` is now `IntoBytes`, `FromZeroes` is implied by `FromBytes`, and `.as_bytes()` requires `Immutable`).