### PR TITLE
[opentitanlib] update derives for ManifestExtImageType

### DIFF
--- a/sw/host/opentitanlib/src/image/manifest.rs
+++ b/sw/host/opentitanlib/src/image/manifest.rs
@@ -215,7 +215,7 @@ pub struct ManifestExtIsfbErasePolicy {
 }
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, FromZeroes, Debug, Default)]
+#[derive(Immutable, IntoBytes, FromBytes, Debug, Default)]
 pub struct ManifestExtImageType {
     pub header: ManifestExtHeader,
     pub image_type: u32,


### PR DESCRIPTION
Due to automated rebase derives for the ManifestExtImageType structure were left behind, this patch fixes the problem.

As a result build does not fail any more