### PR TITLE
[opentitantool] introduce ImageType manifest extension

### DIFF
--- a/sw/host/opentitanlib/src/image/manifest.rs
+++ b/sw/host/opentitanlib/src/image/manifest.rs
@@ -37,8 +37,10 @@ pub const CHIP_MANIFEST_EXT_TABLE_COUNT: usize = 15;
 pub const MANIFEST_USAGE_CONSTRAINT_UNSELECTED_WORD_VAL: u32 = 0xa5a5a5a5;
 pub const MANIFEST_EXT_ID_SPX_KEY: u32 = 0x94ac01ec;
 pub const MANIFEST_EXT_ID_SPX_SIGNATURE: u32 = 0xad77f84a;
+pub const MANIFEST_EXT_ID_IMAGE_TYPE: u32 = 0x494d4754;
 pub const MANIFEST_EXT_NAME_SPX_KEY: u32 = 0x30545845;
 pub const MANIFEST_EXT_NAME_SPX_SIGNATURE: u32 = 0x31545845;
+pub const MANIFEST_EXT_NAME_IMAGE_TYPE: u32 = 0x494d4754;
 pub const CHIP_ROM_EXT_IDENTIFIER: u32 = 0x4552544f;
 pub const CHIP_BL0_IDENTIFIER: u32 = 0x3042544f;
 pub const CHIP_ROM_EXT_SIZE_MIN: u32 = 8788;
@@ -142,6 +144,13 @@ impl Default for SigverifyBuffer {
     fn default() -> Self {
         Self { data: [0; 96usize] }
     }
+}
+
+#[repr(C)]
+#[derive(Immutable, IntoBytes, FromBytes, Debug, Default)]
+pub struct ManifestExtImageType {
+    pub header: ManifestExtHeader,
+    pub image_type: u32,
 }
 
 /// A type that holds the 256-bit device identifier.

--- a/sw/host/opentitantool/src/command/image.rs
+++ b/sw/host/opentitantool/src/command/image.rs
@@ -282,7 +282,10 @@ impl CommandDispatch for ManifestUpdateCommand {
             .signed_region
             .iter()
             .map(|e| e.id())
-            .chain(vec![ManifestExtId::spx_key.into()])
+            .chain(vec![
+                ManifestExtId::spx_key.into(),
+                ManifestExtId::image_type.into(),
+            ])
             .collect::<HashSet<u32>>();
         image.update_signed_region(&signed_ids)?;
 


### PR DESCRIPTION
The new extension contents is a 32 bit value which can be used by the owner to mark image for different applications built for the same chip.

Tested by creating a manifest including the new extension and observing the generated binary.

Change-Id: I16c5dca791b379adf98c6d4e2dfd6845844c8d65

(cherry picked from commit 49336140f07297c0131dd35b263275e5674d95de)