### PR TITLE
Cherry-pick to master: [toolchain,cov] Upgrade lowrisc clang version and add coverage flags #28250

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -38,37 +38,27 @@ build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing
 build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzzer
 build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
 
-# Shared configuration for clang's source-based coverage instrumentation.
-# Bazel seems to support this only partially, thus we have to perform some
-# additional processing. See
-# https://github.com/bazelbuild/bazel/commit/21b5eb627d78c09d47c4de957e9e6b56a9ae6fad
-# and `util/coverage/coverage_off_target.py`.
-build:ot_coverage --repo_env='CC=clang'
-build:ot_coverage --repo_env='BAZEL_USE_LLVM_NATIVE_COVERAGE=1'
-build:ot_coverage --java_runtime_version='remotejdk_11'
-# Docs state that bazel will fail to create coverage information if tests have
-# been cached previously. See
-# https://bazel.build/configure/coverage?hl=en#remote-execution
-coverage:ot_coverage --nocache_test_results
+# Configuration for clang's source-based coverage instrumentation.
+coverage:ot_coverage --java_runtime_version='remotejdk_11'
+coverage:ot_coverage --instrumentation_filter="^//sw/device"
+coverage:ot_coverage --repo_env='BAZEL_USE_LLVM_NATIVE_COVERAGE=1'
+coverage:ot_coverage --experimental_use_llvm_covmap
+coverage:ot_coverage --experimental_generate_llvm_lcov
+coverage:ot_coverage --combined_report=lcov
 
-# Configuration for measuring off-target coverage. Enable with
-# `--config=ot_coverage_off_target`.
-build:ot_coverage_off_target --config='ot_coverage'
-build:ot_coverage_off_target --collect_code_coverage
-coverage:ot_coverage_off_target --repo_env='GCOV=/usr/bin/llvm-profdata'
-coverage:ot_coverage_off_target --repo_env='BAZEL_LLVM_COV=/usr/bin/llvm-cov'
+# Set coverage mode indicators
+coverage:ot_coverage --define='ot_coverage_enabled=true'
+coverage:ot_coverage --@rules_rust//:extra_rustc_flag='--cfg=feature="ot_coverage_enabled"'
+coverage:ot_coverage --@rules_rust//:extra_exec_rustc_flag='--cfg=feature="ot_coverage_enabled"'
+coverage:ot_coverage --//rules/coverage:enabled_flag
+coverage:ot_coverage --copt='-DOT_COVERAGE_ENABLED=1'
 
-# Configuration for measuring on-target coverage. Enable with
-# `--config=ot_coverage_on_target`.
-build:ot_coverage_on_target --config='ot_coverage'
-build:ot_coverage_on_target --platforms="@//toolchain:opentitan_platform"
-build:ot_coverage_on_target --define='measure_coverage_on_target=true'
-# Instrument selectively to limit size overhead when measuring on-target coverage.
-# Note: We have to disable optimizations until the corresponding item in #16761 is
-# resolved.
-build:ot_coverage_on_target --per_file_copt='//sw/device/silicon_creator[/:].*,//sw/device/lib/base:.*@-fprofile-instr-generate,-fcoverage-mapping,-O0'
-# Needed to be able to build host binaries while collecting coverage.
-coverage:ot_coverage_on_target --platforms=""
+# Host-side toolchain flags for unit tests
+# https://github.com/bazelbuild/bazel/blob/release-8.0.1/src/test/shell/bazel/bazel_coverage_cc_test_llvm.sh#L59-L64
+coverage:ot_coverage --repo_env='BAZEL_LLVM_COV=llvm-cov'
+coverage:ot_coverage --repo_env='BAZEL_LLVM_PROFDATA=llvm-profdata'
+coverage:ot_coverage --repo_env='CC=clang'
+coverage:ot_coverage --repo_env='GCOV=llvm-profdata'
 
 # Disable ccache if it happens to be installed
 build --define=CCACHE_DISABLE=true

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -522,7 +522,7 @@
     },
     "//third_party/lowrisc:extensions.bzl%lowrisc_rv32imcb_toolchain": {
       "general": {
-        "bzlTransitiveDigest": "O3rv6gZfM1SUTuKGbRZ5N308+YhSoNzYnPFuLAEq/Hw=",
+        "bzlTransitiveDigest": "JQbQTIYu73LMiVSvNwltZuucnHJABYNTmyRfgu5/iT0=",
         "usagesDigest": "N+I4Z8BUhFKs8r1sm2Tm4NjFkNo8NTAmaYNX1+nchZg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -531,9 +531,9 @@
           "lowrisc_rv32imcb_toolchain": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
-              "url": "https://github.com/lowRISC/lowrisc-toolchains/releases/download/20240923-1/lowrisc-toolchain-rv32imcb-20240923-1.tar.xz",
-              "sha256": "aeea1983553f4c81c6409abcf0d6ca33b5ed4716b2b694e7ff030523cf13486a",
-              "strip_prefix": "lowrisc-toolchain-rv32imcb-20240923-1",
+              "url": "https://github.com/lowRISC/lowrisc-toolchains/releases/download/20250710-1/lowrisc-toolchain-rv32imcb-x86_64-20250710-1.tar.xz",
+              "sha256": "6f02aae27c097c71a2875a215896a0301e32ab56d6d26e917dae59d124c573fb",
+              "strip_prefix": "lowrisc-toolchain-rv32imcb-x86_64-20250710-1",
               "build_file": "@@//third_party/lowrisc:BUILD.lowrisc_rv32imcb_toolchain.bazel"
             }
           }

--- a/rules/actions.bzl
+++ b/rules/actions.bzl
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 OT_ACTION_OBJDUMP = "objdump"
+OT_ACTION_LLVM_PROFDATA = "llvm-profdata"

--- a/rules/coverage/BUILD
+++ b/rules/coverage/BUILD
@@ -1,0 +1,25 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
+package(default_visibility = ["//visibility:public"])
+
+config_setting(
+    name = "enabled",
+    define_values = {"ot_coverage_enabled": "true"},
+)
+
+# Instrumented setting should include all constraints from the "enabled"
+# setting, allowing both to be used within the same select statement.
+config_setting(
+    name = "instrumented",
+    define_values = {"ot_coverage_enabled": "true"},
+    values = {"collect_code_coverage": "true"},
+)
+
+bool_flag(
+    name = "enabled_flag",
+    build_setting_default = False,
+)

--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -109,6 +109,9 @@ def ot_binary(ctx, **kwargs):
         "-nostdlib",
     ] + _expand(ctx, "linkopts", extra_linkopts)
 
+    if ctx.var.get("ot_coverage_enabled", "false") == "true":
+        linkopts.append("-Wl,--defsym=_ot_coverage_enabled=1")
+
     lout = cc_common.link(
         name = name + ".elf",
         actions = ctx.actions,

--- a/sw/device/BUILD
+++ b/sw/device/BUILD
@@ -23,8 +23,9 @@ config_setting(
 config_setting(
     name = "measure_coverage_on_target",
     define_values = {
-        "measure_coverage_on_target": "true",
+        "ot_coverage_enabled": "true",
     },
+    deprecation = "Please use //rules/coverage:enabled instead.",
 )
 
 cc_library(

--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -161,7 +161,7 @@ cc_test(
 alias(
     name = "math_builtins",
     actual = select({
-        "//sw/device:measure_coverage_on_target": "//sw/device:nothing",
+        "//rules/coverage:enabled": "//sw/device:nothing",
         "//conditions:default": ":math_polyfills",
     }),
     visibility = ["//visibility:private"],

--- a/third_party/lowrisc/BUILD.lowrisc_rv32imcb_toolchain.bazel
+++ b/third_party/lowrisc/BUILD.lowrisc_rv32imcb_toolchain.bazel
@@ -29,6 +29,18 @@ exports_files(glob(["**"]))
     ]
 ]
 
+[
+    cc_tool(
+        name = "llvm_{}".format(tool),
+        src = ":bin/llvm-{}".format(tool),
+        data = [":root"],
+    )
+    for tool in [
+        "profdata",
+        "cov",
+    ]
+]
+
 directory(
     name = "root",
     srcs = glob(["**/*"]),

--- a/third_party/lowrisc/extensions.bzl
+++ b/third_party/lowrisc/extensions.bzl
@@ -5,12 +5,12 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def _lowrisc_repos():
-    VERSION = "20240923-1"
+    VERSION = "20250710-1"
     http_archive(
         name = "lowrisc_rv32imcb_toolchain",
-        url = "https://github.com/lowRISC/lowrisc-toolchains/releases/download/{v}/lowrisc-toolchain-rv32imcb-{v}.tar.xz".format(v = VERSION),
-        sha256 = "aeea1983553f4c81c6409abcf0d6ca33b5ed4716b2b694e7ff030523cf13486a",
-        strip_prefix = "lowrisc-toolchain-rv32imcb-{}".format(VERSION),
+        url = "https://github.com/lowRISC/lowrisc-toolchains/releases/download/{v}/lowrisc-toolchain-rv32imcb-x86_64-{v}.tar.xz".format(v = VERSION),
+        sha256 = "6f02aae27c097c71a2875a215896a0301e32ab56d6d26e917dae59d124c573fb",
+        strip_prefix = "lowrisc-toolchain-rv32imcb-x86_64-{}".format(VERSION),
         build_file = ":BUILD.lowrisc_rv32imcb_toolchain.bazel",
     )
 

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -60,6 +60,7 @@ cc_toolchain(
         "@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features",
         ":feat_warnings_as_errors",
         ":feat_guards",
+        ":feat_coverage",
         ":feat_use_lld",
         ":feat_lto",
         ":feat_minsize",
@@ -343,6 +344,57 @@ cc_args(
     name = "guards",
     actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
     args = ["-mguards"],
+)
+
+cc_feature(
+    name = "feat_coverage",
+    args = [
+        ":coverage_indicator_cc",
+        ":coverage_indicator_ld",
+        ":coverage_profile",
+        ":coverage_single_byte",
+        ":sha1_build_id",
+    ],
+    overrides = "@rules_cc//cc/toolchains/features/legacy:coverage",
+)
+
+cc_args(
+    name = "coverage_single_byte",
+    actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
+    args = [
+        "-mllvm",
+        "--enable-single-byte-coverage",
+    ],
+)
+
+cc_args(
+    name = "coverage_profile",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+        "@rules_cc//cc/toolchains/actions:link_actions",
+    ],
+    args = [
+        "-fprofile-instr-generate",
+        "-fcoverage-mapping",
+    ],
+)
+
+cc_args(
+    name = "coverage_indicator_cc",
+    actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
+    args = ["-DOT_COVERAGE_INSTRUMENTED=1"],
+)
+
+cc_args(
+    name = "coverage_indicator_ld",
+    actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
+    args = ["-Wl,--defsym=_ot_coverage_instrumented=1"],
+)
+
+cc_args(
+    name = "sha1_build_id",
+    actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
+    args = ["-Wl,--build-id=sha1"],
 )
 
 cc_feature(

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -10,7 +10,7 @@ load("@rules_cc//cc/toolchains:feature_set.bzl", "cc_feature_set")
 load("@rules_cc//cc/toolchains:feature_constraint.bzl", "cc_feature_constraint")
 load("@rules_cc//cc/toolchains:toolchain.bzl", "cc_toolchain")
 load("@rules_cc//cc/toolchains:tool_map.bzl", "cc_tool_map")
-load("//rules:actions.bzl", "OT_ACTION_OBJDUMP")
+load("//rules:actions.bzl", "OT_ACTION_LLVM_PROFDATA", "OT_ACTION_OBJDUMP")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -80,10 +80,17 @@ cc_tool_map(
         "@rules_cc//cc/toolchains/actions:c_compile": "@lowrisc_rv32imcb_toolchain//:clang",
         "@rules_cc//cc/toolchains/actions:cpp_compile_actions": "@lowrisc_rv32imcb_toolchain//:clang++",
         "@rules_cc//cc/toolchains/actions:link_actions": "@lowrisc_rv32imcb_toolchain//:clang",
+        "@rules_cc//cc/toolchains/actions:llvm_cov": "@lowrisc_rv32imcb_toolchain//:llvm_cov",
         "@rules_cc//cc/toolchains/actions:objcopy_embed_data": "@lowrisc_rv32imcb_toolchain//:objcopy",
         "@rules_cc//cc/toolchains/actions:strip": "@lowrisc_rv32imcb_toolchain//:strip",
+        ":action_llvm_profdata": "@lowrisc_rv32imcb_toolchain//:llvm_profdata",
         ":action_objdump": "@lowrisc_rv32imcb_toolchain//:objdump",
     },
+)
+
+cc_action_type(
+    name = "action_llvm_profdata",
+    action_name = OT_ACTION_LLVM_PROFDATA,
 )
 
 cc_action_type(


### PR DESCRIPTION
This is manual cherry pick the toolchain update to master.

The only conflict resolved is lines around cc_tool_map load, which isn't exist on earlgrey_1.0.0.
```
load("@rules_cc//cc/toolchains:tool_map.bzl", "cc_tool_map")
```

---

ROM / ROM_EXT is the same before and after this change.
```bash
$ ./bazelisk.sh build //sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_virtual && \
  sha256sum bazel-bin/sw/device/silicon_creator/rom_ext/rom_ext_dice_x509_slot_virtual_silicon_creator.bin

619e07265c7697ac48c7cbdcf05a59cfa8fd1a6c78d0634bdb3ae496b682ab42  bazel-bin/sw/device/silicon_creator/rom_ext/rom_ext_dice_x509_slot_virtual_silicon_creator.bin

$ ./bazelisk.sh build //sw/device/silicon_creator/rom:mask_rom && \
  sha256sum bazel-bin/sw/device/silicon_creator/rom/instrumented_mask_rom_silicon_creator.64.scr.vmem

08ec4cdf888466bb71755f892d69798b3ef519354783582d468c3753e3d1fb2f  bazel-bin/sw/device/silicon_creator/rom/instrumented_mask_rom_silicon_creator.64.scr.vmem
```