### PR TITLE
[bazel] Disable OTT config file in modid check

### DIFF
--- a/rules/scripts/modid_check.sh
+++ b/rules/scripts/modid_check.sh
@@ -19,8 +19,8 @@ out_file="$2"
 # forget first two arguments so we can access elf files
 shift 2
 
-# run tool, capture output to avoid polutting the CI log
-if ! "$ott" status lint "$@" >"$out_file" 2>&1; then
+# run tool, capture output to avoid polluting the CI log
+if ! "$ott" --rcfile= status lint "$@" >"$out_file" 2>&1; then
     if ! cat "$out_file"; then
         echo "Unable to print the output log, something is very wrong"
         exit 43


### PR DESCRIPTION
Without this flag, OTT will pick up your local ~/.config/opentitan flags and if those include an `--interface` it will try to connect and fail if that's not found.

This causes problems if you have, for example, `--interface cw310` in your config and don't have one connected when using the script.