### PR TITLE
[ci] Enable slow cryptotests in nightlies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -654,7 +654,7 @@ jobs:
         if: success() || failure()
         run: |
           # Find and display tests that did not run:
-          ./ci/scripts/run-bazel-test-query.sh all_fpga.txt fpga,-manual,-broken,-skip_in_ci //... @manufacturer_test_hooks//...
+          ./ci/scripts/run-bazel-test-query.sh all_fpga.txt fpga,-manual,-broken,-slow_test,-skip_in_ci //... @manufacturer_test_hooks//...
           sort -o all_fpga.txt all_fpga.txt
           pattern_files=$(find verify_fpga_jobs -name target_pattern_file.txt)
           sort $pattern_files > all_run.txt

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -40,7 +40,7 @@ on:
       add_default_filters:
         default: true
         type: boolean
-        description: Include additional test filters for "manual", "broken", and "skip_in_ci" tests.
+        description: Include additional test filters for "manual", "broken", "slow_test", and "skip_in_ci" tests.
       cache_test_results:
         default: true
         type: boolean
@@ -78,7 +78,7 @@ jobs:
 
           tag_filters="${{ inputs.tag_filters }}"
           if ${{ inputs.add_default_filters }}; then
-            tag_filters+=",-manual,-broken,-skip_in_ci"
+            tag_filters+=",-manual,-broken,-slow_test,-skip_in_ci"
           fi
 
           # Execute a query to find all targets that match the test tags and store them in a file.

--- a/ci/scripts/run-fpga-tests.sh
+++ b/ci/scripts/run-fpga-tests.sh
@@ -51,7 +51,6 @@ trap './bazelisk.sh run //sw/host/opentitantool -- --rcfile= --interface=${fpga}
     --run_under=//ci/scripts:run_test \
     --define DISABLE_VERILATOR_BUILD=true \
     --nokeep_going \
-    --test_timeout_filters=short,moderate \
     --test_output=all \
     --build_tests_only \
     --define "$fpga"=lowrisc \

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -354,6 +354,7 @@ ownership_transfer_test(
         # We boot on Side B since rescue will rewrite side A.
         assemble = "{rom_ext}@0 {firmware}@0x90000",
         changes_otp = True,
+        tags = ["slow_test"],
         test_cmd = """
             --clear-bitstream
             --bootstrap={firmware}

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -5138,7 +5138,10 @@ opentitan_test(
     },
     fpga = fpga_params(
         timeout = "eternal",
-        tags = ["manual"],
+        tags = [
+            "manual",
+            "slow_test",
+        ],
     ),
     verilator = verilator_params(
         timeout = "long",
@@ -5307,7 +5310,10 @@ opentitan_test(
     ],
     cw310 = fpga_params(
         timeout = "eternal",
-        tags = ["manual"],
+        tags = [
+            "manual",
+            "slow_test",
+        ],
         test_cmd = """
             --bootstrap="{firmware}"
             --fin-phase=deep-resume
@@ -5796,6 +5802,7 @@ opentitan_test(
     ),
     fpga = fpga_params(
         timeout = "long",
+        tags = ["slow_test"],
         test_cmd = """
             --bootstrap="{firmware}"
             "{firmware:elf}"

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -212,7 +212,10 @@ opentitan_test(
     exec_env = EARLGREY_TEST_ENVS,
     fpga = fpga_params(
         timeout = "long",
-        tags = ["broken"],  # https://github.com/lowRISC/opentitan/issues/15788
+        tags = [
+            "broken",  # https://github.com/lowRISC/opentitan/issues/15788
+            "slow_test",
+        ],
         # [test-triage] test not constant time with icache enabled
     ),
     verilator = verilator_params(
@@ -740,6 +743,7 @@ opentitan_test(
     exec_env = CRYPTOTEST_EXEC_ENVS,
     fpga = fpga_params(
         timeout = "long",
+        tags = ["slow_test"],
     ),
     verilator = verilator_params(
         timeout = "eternal",
@@ -785,6 +789,7 @@ opentitan_test(
     exec_env = CRYPTOTEST_EXEC_ENVS,
     fpga = fpga_params(
         timeout = "long",
+        tags = ["slow_test"],
     ),
     silicon = silicon_params(
         timeout = "long",
@@ -829,6 +834,7 @@ opentitan_test(
     exec_env = CRYPTOTEST_EXEC_ENVS,
     fpga = fpga_params(
         timeout = "long",
+        tags = ["slow_test"],
     ),
     silicon = silicon_params(
         timeout = "long",

--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -92,6 +92,7 @@ ECDH_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "ecdh_kat",
+    slow_test = True,
     test_args = ECDH_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/ecdh_kat:harness",
     test_vectors = ECDH_TESTVECTOR_TARGETS,
@@ -183,6 +184,7 @@ SHA3_224_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "sha3_224_kat",
+    slow_test = True,
     test_args = SHA3_224_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/hash_kat:harness",
     test_vectors = SHA3_224_TESTVECTOR_TARGETS,
@@ -316,6 +318,7 @@ CSHAKE_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "cshake_kat",
+    slow_test = True,
     test_args = CSHAKE_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/hash_kat:harness",
     test_vectors = CSHAKE_TESTVECTOR_TARGETS,
@@ -408,6 +411,7 @@ KMAC_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "kmac_kat",
+    slow_test = True,
     test_args = KMAC_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/kmac_kat:harness",
     test_vectors = KMAC_TESTVECTOR_TARGETS,


### PR DESCRIPTION
This PR changes CI to filtering FPGA tests on the `slow_test` tag rather than timeouts.

This allows us to run longer tests in nightlies and also ensures that the pattern file uploaded as an artifact accurately lists the tests being run and isn't being filtered further.