### PR TITLE
[hw,otp_ctrl] Assert that secret partitions must be buffered.

### DIFF
--- a/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -117,6 +117,7 @@ module otp_ctrl_part_buf
   `ASSERT_INIT(SizeMustBeBlockAligned_A, (Info.size % (ScrmblBlockWidth/8)) == 0)
   `ASSERT_INIT(DigestOffsetMustBeRepresentable_A, DigestOffsetInt == int'(DigestOffset))
   `ASSERT_INIT(ZeroizeOffsetMustBeRepresentable_A, ZeroizeOffsetInt == int'(ZeroizeOffset))
+  `ASSERT(ScrambledImpliesBuffered_A, Info.secret |-> Info.variant == Buffered)
   `ASSERT(ScrambledImpliesDigest_A, Info.secret |-> Info.hw_digest)
   `ASSERT(WriteLockImpliesDigest_A, Info.read_lock |-> Info.hw_digest)
   `ASSERT(ReadLockImpliesDigest_A, Info.write_lock |-> Info.hw_digest)

--- a/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -92,6 +92,7 @@ module otp_ctrl_part_unbuf
   `ASSERT_INIT(SizeMustBeBlockAligned_A, (Info.size % (ScrmblBlockWidth/8)) == 0)
   `ASSERT_INIT(DigestOffsetMustBeRepresentable_A, DigestOffsetInt == int'(DigestOffset))
   `ASSERT_INIT(ZeroizeOffsetMustBeRepresentable_A, ZeroizeOffsetInt == int'(ZeroizeOffset))
+  `ASSERT(ScrambledImpliesBuffered_A, Info.secret |-> Info.variant == Buffered)
 
   ///////////////////////
   // OTP Partition FSM //

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -117,6 +117,7 @@ module otp_ctrl_part_buf
   `ASSERT_INIT(SizeMustBeBlockAligned_A, (Info.size % (ScrmblBlockWidth/8)) == 0)
   `ASSERT_INIT(DigestOffsetMustBeRepresentable_A, DigestOffsetInt == int'(DigestOffset))
   `ASSERT_INIT(ZeroizeOffsetMustBeRepresentable_A, ZeroizeOffsetInt == int'(ZeroizeOffset))
+  `ASSERT(ScrambledImpliesBuffered_A, Info.secret |-> Info.variant == Buffered)
   `ASSERT(ScrambledImpliesDigest_A, Info.secret |-> Info.hw_digest)
   `ASSERT(WriteLockImpliesDigest_A, Info.read_lock |-> Info.hw_digest)
   `ASSERT(ReadLockImpliesDigest_A, Info.write_lock |-> Info.hw_digest)

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -92,6 +92,7 @@ module otp_ctrl_part_unbuf
   `ASSERT_INIT(SizeMustBeBlockAligned_A, (Info.size % (ScrmblBlockWidth/8)) == 0)
   `ASSERT_INIT(DigestOffsetMustBeRepresentable_A, DigestOffsetInt == int'(DigestOffset))
   `ASSERT_INIT(ZeroizeOffsetMustBeRepresentable_A, ZeroizeOffsetInt == int'(ZeroizeOffset))
+  `ASSERT(ScrambledImpliesBuffered_A, Info.secret |-> Info.variant == Buffered)
 
   ///////////////////////
   // OTP Partition FSM //

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -117,6 +117,7 @@ module otp_ctrl_part_buf
   `ASSERT_INIT(SizeMustBeBlockAligned_A, (Info.size % (ScrmblBlockWidth/8)) == 0)
   `ASSERT_INIT(DigestOffsetMustBeRepresentable_A, DigestOffsetInt == int'(DigestOffset))
   `ASSERT_INIT(ZeroizeOffsetMustBeRepresentable_A, ZeroizeOffsetInt == int'(ZeroizeOffset))
+  `ASSERT(ScrambledImpliesBuffered_A, Info.secret |-> Info.variant == Buffered)
   `ASSERT(ScrambledImpliesDigest_A, Info.secret |-> Info.hw_digest)
   `ASSERT(WriteLockImpliesDigest_A, Info.read_lock |-> Info.hw_digest)
   `ASSERT(ReadLockImpliesDigest_A, Info.write_lock |-> Info.hw_digest)

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -92,6 +92,7 @@ module otp_ctrl_part_unbuf
   `ASSERT_INIT(SizeMustBeBlockAligned_A, (Info.size % (ScrmblBlockWidth/8)) == 0)
   `ASSERT_INIT(DigestOffsetMustBeRepresentable_A, DigestOffsetInt == int'(DigestOffset))
   `ASSERT_INIT(ZeroizeOffsetMustBeRepresentable_A, ZeroizeOffsetInt == int'(ZeroizeOffset))
+  `ASSERT(ScrambledImpliesBuffered_A, Info.secret |-> Info.variant == Buffered)
 
   ///////////////////////
   // OTP Partition FSM //


### PR DESCRIPTION
otp_ctrl_dai.sv checks this while writing but not during read. This assert prevents accidental breakage until we change otp_ctrl to fully support unbuffered secret partitions.