### PR TITLE
[rescue,dfu,test] Add dfu error handle tests

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/test_owner.c
+++ b/sw/device/silicon_creator/lib/ownership/test_owner.c
@@ -131,6 +131,12 @@
       kBootSvcMinBl0SecVerReqType, kBootSvcOwnershipActivateReqType,         \
       kBootSvcOwnershipUnlockReqType,
 #endif
+#ifndef WITH_RESCUE_START
+#define WITH_RESCUE_START (32)
+#endif
+#ifndef WITH_RESCUE_SIZE
+#define WITH_RESCUE_SIZE (224)
+#endif
 
 rom_error_t sku_creator_owner_init(boot_data_t *bootdata) {
   owner_keydata_t owner = OWNER_KEYDATA;
@@ -276,8 +282,8 @@ rom_error_t sku_creator_owner_init(boot_data_t *bootdata) {
       .gpio = WITH_RESCUE_GPIO_PARAM,
       .timeout = WITH_RESCUE_TIMEOUT,
       .detect = (WITH_RESCUE_TRIGGER << 6) | WITH_RESCUE_INDEX,
-      .start = 32,
-      .size = 224,
+      .start = WITH_RESCUE_START,
+      .size = WITH_RESCUE_SIZE,
   };
   const uint32_t commands[] = {WITH_RESCUE_COMMAND_ALLOW};
   memcpy(&rescue->command_allow, commands, sizeof(commands));
@@ -319,10 +325,12 @@ rom_error_t sku_creator_owner_init(boot_data_t *bootdata) {
                (uintptr_t)end;
   memset((void *)end, 0x5a, len);
 
+#ifndef TEST_OWNER_DISABLE_OWNER_BLOCK_CHECK
   // Check that the owner_block will parse correctly.
   RETURN_IF_ERROR(owner_block_parse(&owner_page[0],
                                     /*check_only=*/kHardenedBoolTrue, NULL,
                                     NULL));
+#endif
   ownership_seal_page(/*page=*/0);
 
   // Since this module should only get linked in to FPGA builds, we can simply

--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -196,6 +196,28 @@ TEST_OWNER_CONFIGS = {
         ],
         "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_spidfu"],
     },
+    "spidfu_flash_limit_zero": {
+        "owner_defines": [
+            # 0x53 is 'S'pi.
+            "WITH_RESCUE_PROTOCOL=0x53",
+            # Trigger 3 is GPIO pin.
+            "WITH_RESCUE_TRIGGER=3",
+            # When the trigger is GPIO, the index is the MuxedPad to us as the sense
+            # input. Index 2 is kTopEarlgreyMuxedPadsIoa2.
+            "WITH_RESCUE_INDEX=2",
+            # GPIO param 3 means enable the internal pull resistor and trigger
+            # rescue when the GPIO is high.
+            "WITH_RESCUE_GPIO_PARAM=3",
+            # Timeout: 0x80=enter_on_fail, 0x05 = 5 seconds.
+            "WITH_RESCUE_TIMEOUT=0x85",
+            # Set rescue start and size to 0 to test writing past the end of the flash.
+            "WITH_RESCUE_START=0",
+            "WITH_RESCUE_SIZE=0",
+            # Disable the owner block check in test_owner.c so that the rescue start addr can be 0.
+            "TEST_OWNER_DISABLE_OWNER_BLOCK_CHECK=1",
+        ],
+        "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_spidfu"],
+    },
     "isfb": {
         "owner_defines": [
             "WITH_ISFB=1",

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -730,3 +730,25 @@ opentitan_test(
         test_harness = "//sw/host/tests/rescue:dfu_rescue_error_handling",
     ),
 )
+
+opentitan_test(
+    name = "spidfu_invalid_dfu_requests",
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+    },
+    fpga = fpga_params(
+        assemble = "{romext}@{rom_ext_slot_a} {firmware}@{owner_slot_a}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_spidfu": "romext",
+            ":boot_test_slot_a": "firmware",
+        },
+        params = "-p spi-dfu -t gpio -v +Ioa2",
+        test_cmd = """
+        --clear-bitstream
+        --bootstrap={firmware}
+        rescue {params} --action=invalid-spi-dfu-requests
+        """,
+        test_harness = "//sw/host/tests/rescue:dfu_rescue_error_handling",
+    ),
+)

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -708,3 +708,25 @@ opentitan_test(
         test_harness = "//sw/host/tests/rescue:xmodem_rescue_error_handling",
     ),
 )
+
+opentitan_test(
+    name = "spidfu_dfu_state_transitions",
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+    },
+    fpga = fpga_params(
+        assemble = "{romext}@{rom_ext_slot_a} {firmware}@{owner_slot_a}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_spidfu_flash_limit_zero": "romext",
+            ":boot_test_slot_a": "firmware",
+        },
+        params = "-p spi-dfu -t gpio -v +Ioa2",
+        test_cmd = """
+        --clear-bitstream
+        --bootstrap={firmware}
+        rescue {params} --action=spi-dfu-state-transitions
+        """,
+        test_harness = "//sw/host/tests/rescue:dfu_rescue_error_handling",
+    ),
+)

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -774,3 +774,25 @@ opentitan_test(
         test_harness = "//sw/host/tests/rescue:dfu_rescue_error_handling",
     ),
 )
+
+opentitan_test(
+    name = "usbdfu_out_chunk_too_big",
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+    },
+    fpga = fpga_params(
+        assemble = "{romext}@{rom_ext_slot_a} {firmware}@{owner_slot_a}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_usbdfu": "romext",
+            ":boot_test_slot_a": "firmware",
+        },
+        params = "-p usb-dfu -t strap -v 3",
+        test_cmd = """
+        --clear-bitstream
+        --bootstrap={firmware}
+        rescue {params} --action=usb-dfu-out-chunk-too-big
+        """,
+        test_harness = "//sw/host/tests/rescue:dfu_rescue_error_handling",
+    ),
+)

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -752,3 +752,25 @@ opentitan_test(
         test_harness = "//sw/host/tests/rescue:dfu_rescue_error_handling",
     ),
 )
+
+opentitan_test(
+    name = "spidfu_invalid_flash_transaction",
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+    },
+    fpga = fpga_params(
+        assemble = "{romext}@{rom_ext_slot_a} {firmware}@{owner_slot_a}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_spidfu": "romext",
+            ":boot_test_slot_a": "firmware",
+        },
+        params = "-p spi-dfu -t gpio -v +Ioa2",
+        test_cmd = """
+        --clear-bitstream
+        --bootstrap={firmware}
+        rescue {params} --action=invalid-spi-flash-transaction
+        """,
+        test_harness = "//sw/host/tests/rescue:dfu_rescue_error_handling",
+    ),
+)

--- a/sw/host/tests/rescue/BUILD
+++ b/sw/host/tests/rescue/BUILD
@@ -63,3 +63,17 @@ rust_binary(
         "@lowrisc_serde_annotate//serde_annotate",
     ],
 )
+
+rust_binary(
+    name = "dfu_rescue_error_handling",
+    srcs = ["dfu_rescue_error_handling.rs"],
+    deps = [
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:regex",
+        "@lowrisc_serde_annotate//serde_annotate",
+    ],
+)

--- a/sw/host/tests/rescue/dfu_rescue_error_handling.rs
+++ b/sw/host/tests/rescue/dfu_rescue_error_handling.rs
@@ -1,0 +1,196 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::bool_assert_comparison)]
+use anyhow::{anyhow, Result};
+use clap::{Args, Parser, Subcommand, ValueEnum};
+
+use std::time::Duration;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::io::spi::SpiParams;
+use opentitanlib::rescue::dfu::{DfuOperations, DfuRequestType};
+use opentitanlib::rescue::{EntryMode, Rescue, RescueMode, RescueParams, SpiDfu};
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct RescueCommand {
+    #[command(flatten)]
+    params: RescueParams,
+
+    #[arg(long)]
+    action: DfuRescueTestActions,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    Rescue(RescueCommand),
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq)]
+pub enum DfuRescueTestActions {
+    SpiDfuStateTransitions,
+}
+
+const SET_INTERFACE: u8 = 0x0b;
+
+const DFU_REQ_DN_LOAD: u8 = 0x01;
+const DFU_REQ_CLR_STATUS: u8 = 0x04;
+const DFU_REQ_GET_STATE: u8 = 0x05;
+const DFU_REQ_ABORT: u8 = 0x06;
+const DFU_REQ_INVALID: u8 = 0xff;
+
+fn expect_usb_bad_mode_write_control(
+    rescue: &SpiDfu,
+    request_type: u8,
+    request: u8,
+    value: u16,
+    index: u16,
+) -> Result<()> {
+    let result = rescue.write_control(request_type, request, value, index, &[]);
+    match result {
+        Ok(_) => Err(anyhow!("Invalid write control should fail")),
+        Err(e) => {
+            if e.to_string().contains("UsbBadSetup") {
+                Ok(())
+            } else {
+                Err(anyhow!("Unexpected error: {}", e.to_string()))
+            }
+        }
+    }
+}
+
+fn expect_usb_bad_mode_read_control(
+    rescue: &SpiDfu,
+    request_type: u8,
+    request: u8,
+    value: u16,
+    index: u16,
+    data: &mut [u8],
+) -> Result<()> {
+    let result = rescue.read_control(request_type, request, value, index, data);
+    match result {
+        Ok(_) => Err(anyhow!("Invalid read control should fail")),
+        Err(e) => {
+            if e.to_string().contains("UsbBadSetup") {
+                Ok(())
+            } else {
+                Err(anyhow!("Unexpected error: {}", e.to_string()))
+            }
+        }
+    }
+}
+
+fn spi_dfu_state_transitions(params: &RescueParams, transport: &TransportWrapper) -> Result<()> {
+    let spi_params = SpiParams::default();
+    let spi = spi_params.create(transport, "BOOTSTRAP")?;
+    let rescue = SpiDfu::new(spi.clone(), params.clone());
+    rescue.enter(transport, EntryMode::Reset)?;
+
+    let setting = u32::from(RescueMode::BootSvcRsp);
+    rescue.write_control(
+        DfuRequestType::Vendor.into(),
+        SET_INTERFACE,
+        (setting >> 16) as u16,
+        setting as u16,
+        &[],
+    )?;
+
+    // Test a `kDfuReqAbort` request. This should trigger the `kDfuActionNone`
+    // action, causing a state transition from `kDfuStateIdle` to `kDfuStateIdle`.
+    rescue.write_control(DfuRequestType::Out.into(), DFU_REQ_ABORT, 0, 0, &[])?;
+
+    // Test a `kDfuReqGetState` request. This should trigger the
+    // `kDfuActionStateResponse` action, causing a state transition from
+    // `kDfuStateIdle` to `kDfuStateUpLoadIdle`.
+    rescue.write_control(DfuRequestType::Out.into(), DFU_REQ_GET_STATE, 0, 0, &[])?;
+
+    // Test a `kDfuReqClrStatus` request when not in the error state. This should
+    // trigger the `kDfuActionStall` action, causing a state transition from
+    // `kDfuStateUpLoadIdle` to `kDfuStateError`.
+    expect_usb_bad_mode_write_control(
+        &rescue,
+        DfuRequestType::Out.into(),
+        DFU_REQ_CLR_STATUS,
+        0,
+        0,
+    )?;
+    // Test a `kDfuReqClrStatus` request in the error state. This should trigger
+    // the `kDfuActionClearError` action, causing a state transition from
+    // `kDfuStateError` to `kDfuStateIdle`.
+    rescue.write_control(DfuRequestType::Out.into(), DFU_REQ_CLR_STATUS, 0, 0, &[])?;
+
+    // Test a `kDfuReqDnLoad` request with a payload larger than the DFU buffer.
+    // This should cause a state transition from `kDfuStateIdle` to `kDfuStateError`.
+    let mut payload_too_big = [0u8; 2050];
+    expect_usb_bad_mode_read_control(
+        &rescue,
+        DfuRequestType::Out.into(),
+        DFU_REQ_DN_LOAD,
+        0,
+        0,
+        &mut payload_too_big,
+    )?;
+
+    // Clear the error state, transitioning from `kDfuStateError` to `kDfuStateIdle`.
+    rescue.write_control(DfuRequestType::Out.into(), DFU_REQ_CLR_STATUS, 0, 0, &[])?;
+
+    // Test a `kDfuReqDnLoad` request that would write past the end of flash.
+    // This should cause a state transition from `kDfuStateIdle` to `kDfuStateError`.
+    let mut payload = [0u8; 1];
+    expect_usb_bad_mode_read_control(
+        &rescue,
+        DfuRequestType::Out.into(),
+        DFU_REQ_DN_LOAD,
+        0,
+        0,
+        &mut payload,
+    )?;
+
+    // Test an invalid DFU request.
+    expect_usb_bad_mode_write_control(
+        &rescue,
+        DfuRequestType::Out.into(),
+        DFU_REQ_INVALID,
+        (setting >> 16) as u16,
+        setting as u16,
+    )?;
+
+    rescue.reboot()?;
+
+    let uart = transport.uart("console")?;
+    UartConsole::wait_for(&*uart, r"Finished", Duration::from_secs(5))?;
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    match opts.command {
+        Commands::Rescue(rescue) => match rescue.action {
+            DfuRescueTestActions::SpiDfuStateTransitions => {
+                spi_dfu_state_transitions(&rescue.params, &transport)?
+            }
+        },
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This PR includes 4 commits that

- Add a test to validate SPI DFU state machine transitions with both valid and invalid requests.
- Add a test to ensure correct error handling and unsupported SPI DFU requests.
- Add a test to verify robustness against invalid flash transactions during SPI DFU rescue mode.
- Add a test to verify that the USB DFU implementation correctly rejects download requests where the data chunk size exceeds the allowed maximum.