### PR TITLE
[chip, dv] Unrecognized hierarchical path argument in  task

### DIFF
--- a/hw/dv/tools/dvsim/xcelium.hjson
+++ b/hw/dv/tools/dvsim/xcelium.hjson
@@ -50,7 +50,9 @@
                // This warning is thrown when a scalar enum variable is assigned to an enum array.
                // Other tools (e.g., FPV) treat such assignments as an error, hence we bump it to
                // an error in simulation so that this can be caught early in CI.
-               "-xmerror ENUMERR"
+               "-xmerror ENUMERR",
+               // Enables LRM compliant behavior for $asserton, $assertoff and $assertkill tasks.
+               "-enable_abv_asrtctrl_enh"
                ]
 
   // We want to allow the possibility of passing no test or no test sequence. Unfortunately,


### PR DESCRIPTION
Xcelium throws an error of having an invalid scope argument in $assertoff task if we use a relative path instead of an absolute path. This switch resolves that issue.

Below is the failure bucket where the assertion path is relative (not starting with `tb.dut.blah`).

> $assertoff(1, top_earlgrey.u_pwrmgr_aon.u_slow_fsm.IntRstReq_A);
>                                                                     |
> xmsim: *W,ACTBDN (scratch/HEAD/chip_earlgrey_asic-sim-xcelium/default/fusesoc-work/src/lowrisc_dv_top_earlgrey_chip_env_0.1/ast_supply_if.sv,67|68): Invalid assertion or scope name argument to $assertoff assertion control task.
> xmsim: *E,ASRTST (scratch/HEAD/chip_earlgrey_asic-sim-xcelium/default/fusesoc-work/src/lowrisc_earlgrey_ip_pwrmgr_0.1/rtl/pwrmgr_slow_fsm.sv,362): (time 21579146 NS) Assertion tb.dut.top_earlgrey.u_pwrmgr_aon.u_slow_fsm.IntRstReq_A has failed 
> UVM_ERROR @ 21579.146000 us: (pwrmgr_slow_fsm.sv:362) [ASSERT FAILED] IntRstReq_A
> UVM_INFO @ 21579.146000 us: (uvm_report_catcher.svh:705) [UVM/REPORT/CATCHER] 
> --- UVM Report catcher Summary ---