### PR TITLE
[bazel,dtgen] Ensure that ipgen params are picked by dtgen

### DIFF
--- a/hw/ip_templates/ac_range_check/defs.bzl.tpl
+++ b/hw/ip_templates/ac_range_check/defs.bzl.tpl
@@ -6,4 +6,5 @@ load("//rules/opentitan:hw.bzl", "opentitan_ip")
 ${module_instance_name.upper()} = opentitan_ip(
     name = "${module_instance_name}",
     hjson = "//hw/top_${topname}/ip_autogen/${module_instance_name}/data:${module_instance_name}.hjson",
+    ipconfig = "//hw/top_${topname}/ip_autogen/${module_instance_name}/data:top_${topname}_${module_instance_name}.ipconfig.hjson",
 )

--- a/hw/ip_templates/rv_core_ibex/defs.bzl.tpl
+++ b/hw/ip_templates/rv_core_ibex/defs.bzl.tpl
@@ -6,4 +6,5 @@ load("//rules/opentitan:hw.bzl", "opentitan_ip")
 ${module_instance_name.upper()} = opentitan_ip(
     name = "${module_instance_name}",
     hjson = "//hw/top_${topname}/ip_autogen/${module_instance_name}/data:${module_instance_name}.hjson",
+    ipconfig = "//hw/top_${topname}/ip_autogen/${module_instance_name}/data:top_${topname}_${module_instance_name}.ipconfig.hjson",
 )

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/defs.bzl
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/defs.bzl
@@ -6,4 +6,5 @@ load("//rules/opentitan:hw.bzl", "opentitan_ip")
 AC_RANGE_CHECK = opentitan_ip(
     name = "ac_range_check",
     hjson = "//hw/top_darjeeling/ip_autogen/ac_range_check/data:ac_range_check.hjson",
+    ipconfig = "//hw/top_darjeeling/ip_autogen/ac_range_check/data:top_darjeeling_ac_range_check.ipconfig.hjson",
 )

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/defs.bzl
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/defs.bzl
@@ -6,4 +6,5 @@ load("//rules/opentitan:hw.bzl", "opentitan_ip")
 RV_CORE_IBEX = opentitan_ip(
     name = "rv_core_ibex",
     hjson = "//hw/top_darjeeling/ip_autogen/rv_core_ibex/data:rv_core_ibex.hjson",
+    ipconfig = "//hw/top_darjeeling/ip_autogen/rv_core_ibex/data:top_darjeeling_rv_core_ibex.ipconfig.hjson",
 )

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/defs.bzl
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/defs.bzl
@@ -6,4 +6,5 @@ load("//rules/opentitan:hw.bzl", "opentitan_ip")
 RV_CORE_IBEX = opentitan_ip(
     name = "rv_core_ibex",
     hjson = "//hw/top_earlgrey/ip_autogen/rv_core_ibex/data:rv_core_ibex.hjson",
+    ipconfig = "//hw/top_earlgrey/ip_autogen/rv_core_ibex/data:top_earlgrey_rv_core_ibex.ipconfig.hjson",
 )

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/defs.bzl
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/defs.bzl
@@ -6,4 +6,5 @@ load("//rules/opentitan:hw.bzl", "opentitan_ip")
 RV_CORE_IBEX = opentitan_ip(
     name = "rv_core_ibex",
     hjson = "//hw/top_englishbreakfast/ip_autogen/rv_core_ibex/data:rv_core_ibex.hjson",
+    ipconfig = "//hw/top_englishbreakfast/ip_autogen/rv_core_ibex/data:top_englishbreakfast_rv_core_ibex.ipconfig.hjson",
 )


### PR DESCRIPTION
Those IPs are missing the ipconfig entry in the bazel definition causitng DTgen to not pick up their params and render them properly.