### PR TITLE
[sw,silicon_creator] Generalize the ibex driver API

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/ibex.c
+++ b/sw/device/silicon_creator/lib/drivers/ibex.c
@@ -27,68 +27,130 @@ uint32_t ibex_fpga_version(void) {
   return abs_mmio_read32(kBase + RV_CORE_IBEX_FPGA_INFO_REG_OFFSET);
 }
 
-void ibex_addr_remap_0_set(uint32_t matching_addr, uint32_t remap_addr,
-                           size_t size) {
+size_t ibex_addr_remap_slots(void) { return RV_CORE_IBEX_PARAM_NUM_REGIONS; }
+
+void ibex_addr_remap_set(size_t slot, uint32_t matching_addr,
+                         uint32_t remap_addr, size_t size) {
+  HARDENED_CHECK_LT(slot, RV_CORE_IBEX_PARAM_NUM_REGIONS);
   const uint32_t kBase = rv_core_ibex_base();
+  slot *= sizeof(uint32_t);
   // Work-around for opentitan#22884: Mask off bits below the alignment size
   // prior to programming the REMAP_ADDR register.
   size = size - 1;
   uint32_t match = (matching_addr & ~size) | size >> 1;
   remap_addr &= ~size;
 
-  sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_ADDR_MATCHING_0_REG_OFFSET, match);
-  sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_ADDR_MATCHING_0_REG_OFFSET, match);
+  sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_ADDR_MATCHING_0_REG_OFFSET + slot,
+                   match);
+  sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_ADDR_MATCHING_0_REG_OFFSET + slot,
+                   match);
 
-  sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_REMAP_ADDR_0_REG_OFFSET,
+  sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_REMAP_ADDR_0_REG_OFFSET + slot,
                    remap_addr);
-  sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_REMAP_ADDR_0_REG_OFFSET,
+  sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_REMAP_ADDR_0_REG_OFFSET + slot,
                    remap_addr);
 
-  sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_ADDR_EN_0_REG_OFFSET, 1);
-  sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_ADDR_EN_0_REG_OFFSET, 1);
+  sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_ADDR_EN_0_REG_OFFSET + slot, 1);
+  sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_ADDR_EN_0_REG_OFFSET + slot, 1);
   icache_invalidate();
 }
 
-void ibex_addr_remap_1_set(uint32_t matching_addr, uint32_t remap_addr,
-                           size_t size) {
+uint32_t ibex_addr_remap_get(size_t slot) {
   const uint32_t kBase = rv_core_ibex_base();
-  // Work-around for opentitan#22884: Mask off bits below the alignment size
-  // prior to programming the REMAP_ADDR register.
-  size = size - 1;
-  uint32_t match = (matching_addr & ~size) | size >> 1;
-  remap_addr &= ~size;
-
-  sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_ADDR_MATCHING_1_REG_OFFSET, match);
-  sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_ADDR_MATCHING_1_REG_OFFSET, match);
-
-  sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_REMAP_ADDR_1_REG_OFFSET,
-                   remap_addr);
-  sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_REMAP_ADDR_1_REG_OFFSET,
-                   remap_addr);
-
-  sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_ADDR_EN_1_REG_OFFSET, 1);
-  sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_ADDR_EN_1_REG_OFFSET, 1);
-  icache_invalidate();
-}
-
-uint32_t ibex_addr_remap_get(uint32_t index) {
-  const uint32_t kBase = rv_core_ibex_base();
-  HARDENED_CHECK_LT(index, 2);
-  index *= sizeof(uint32_t);
-  if (abs_mmio_read32(kBase + RV_CORE_IBEX_IBUS_ADDR_EN_0_REG_OFFSET + index)) {
+  HARDENED_CHECK_LT(slot, RV_CORE_IBEX_PARAM_NUM_REGIONS);
+  slot *= sizeof(uint32_t);
+  if (abs_mmio_read32(kBase + RV_CORE_IBEX_IBUS_ADDR_EN_0_REG_OFFSET + slot)) {
     return abs_mmio_read32(kBase + RV_CORE_IBEX_IBUS_REMAP_ADDR_0_REG_OFFSET +
-                           index);
+                           slot);
   } else {
     return 0;
   }
 }
 
-void ibex_addr_remap_lockdown(uint32_t index) {
+void ibex_addr_remap_lockdown(size_t slot) {
   const uint32_t kBase = rv_core_ibex_base();
-  HARDENED_CHECK_LT(index, 2);
-  index *= sizeof(uint32_t);
-  sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_REGWEN_0_REG_OFFSET + index, 0);
-  sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_REGWEN_0_REG_OFFSET + index, 0);
+  HARDENED_CHECK_LT(slot, RV_CORE_IBEX_PARAM_NUM_REGIONS);
+  slot *= sizeof(uint32_t);
+  sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_REGWEN_0_REG_OFFSET + slot, 0);
+  sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_REGWEN_0_REG_OFFSET + slot, 0);
+}
+
+bool ibex_addr_remap_is_enabled(size_t slot) {
+  const uint32_t kBase = rv_core_ibex_base();
+  HARDENED_CHECK_LT(slot, RV_CORE_IBEX_PARAM_NUM_REGIONS);
+  slot *= sizeof(uint32_t);
+
+  uint32_t reg_en_i =
+      sec_mmio_read32(kBase + RV_CORE_IBEX_IBUS_ADDR_EN_0_REG_OFFSET + slot);
+  uint32_t reg_en_i_mask = 1 << RV_CORE_IBEX_DBUS_ADDR_EN_0_EN_0_BIT;
+  uint32_t reg_en_d =
+      sec_mmio_read32(kBase + RV_CORE_IBEX_DBUS_ADDR_EN_0_REG_OFFSET + slot);
+  uint32_t reg_en_d_mask = 1 << RV_CORE_IBEX_IBUS_ADDR_EN_0_EN_0_BIT;
+
+  return (reg_en_i & reg_en_i_mask) && (reg_en_d & reg_en_d_mask);
+}
+
+static bool remap_verify(uint32_t reg_matching, uint32_t reg_remap,
+                         uint32_t matching_addr, uint32_t remap_addr,
+                         size_t size) {
+  /* Check that matching register is non-zero
+   * (otherwise the NAPOT formula below does not work) */
+  if (reg_matching == 0) {
+    return false;
+  }
+
+  /* decode NAPOT encoding */
+  uint32_t reg_matching_size =
+      1 << bitfield_count_trailing_zeroes32(~reg_matching);
+  uint32_t reg_matching_addr = reg_matching & ~(reg_matching_size - 1);
+
+  /* Check that the matching address is within the remap range */
+  if (matching_addr < reg_matching_addr ||
+      matching_addr - reg_matching_addr >= reg_matching_size) {
+    return false;
+  }
+
+  /* We know that the matching address is withing the remap range, we can now
+     safely check for the size validity */
+  if (size > reg_matching_size - (matching_addr - reg_matching_addr)) {
+    return false;
+  }
+
+  /* Check that remapping offset is identical */
+  if (remap_addr - matching_addr != reg_remap - reg_matching_addr) {
+    return false;
+  }
+
+  return true;
+}
+
+bool ibex_addr_remap_verify(size_t slot, uint32_t matching_addr,
+                            uint32_t remap_addr, size_t size) {
+  const uint32_t kBase = rv_core_ibex_base();
+  HARDENED_CHECK_LT(slot, RV_CORE_IBEX_PARAM_NUM_REGIONS);
+  slot *= sizeof(uint32_t);
+
+  /* Check IBUS remapping */
+  uint32_t reg_matching = sec_mmio_read32(
+      kBase + RV_CORE_IBEX_IBUS_ADDR_MATCHING_0_REG_OFFSET + slot);
+  uint32_t reg_remap_addr =
+      sec_mmio_read32(kBase + RV_CORE_IBEX_IBUS_REMAP_ADDR_0_REG_OFFSET + slot);
+  if (!remap_verify(reg_matching, reg_remap_addr, matching_addr, remap_addr,
+                    size)) {
+    return false;
+  }
+
+  /* Check DBUS remapping */
+  reg_matching = sec_mmio_read32(
+      kBase + RV_CORE_IBEX_DBUS_ADDR_MATCHING_0_REG_OFFSET + slot);
+  reg_remap_addr =
+      sec_mmio_read32(kBase + RV_CORE_IBEX_DBUS_REMAP_ADDR_0_REG_OFFSET + slot);
+  if (!remap_verify(reg_matching, reg_remap_addr, matching_addr, remap_addr,
+                    size)) {
+    return false;
+  }
+
+  return true;
 }
 
 // `extern` declarations to give the inline functions in the corresponding

--- a/sw/device/silicon_creator/lib/drivers/ibex.h
+++ b/sw/device/silicon_creator/lib/drivers/ibex.h
@@ -24,6 +24,14 @@ extern "C" {
 OT_WARN_UNUSED_RESULT
 uint32_t ibex_fpga_version(void);
 
+/**
+ * Get the number of address remapper slots.
+ *
+ * @return Number of remapper slots.
+ */
+OT_WARN_UNUSED_RESULT
+size_t ibex_addr_remap_slots(void);
+
 #ifdef OT_PLATFORM_RV32
 /**
  * Set the MCYCLE counter register to zero.
@@ -97,8 +105,9 @@ enum {
 };
 
 /**
- * Configure the instruction and data bus in the address translation slot 0.
+ * Configure the instruction and data bus in an address translation slot.
  *
+ * @param slot Index of the address translation slot to configure.
  * @param matching_addr When an incoming transaction matches the matching
  * region, it is redirected to the new address. If a transaction does not match,
  * then it is directly passed through.
@@ -106,39 +115,61 @@ enum {
  * redirected to.
  * @param size The size of the regions mapped.
  */
-void ibex_addr_remap_0_set(uint32_t matching_addr, uint32_t remap_addr,
-                           size_t size);
-
-/**
- * Configure the instruction and data bus in the address translation slot 1.
- *
- * @param matching_addr When an incoming transaction matches the matching
- * region, it is redirected to the new address. If a transaction does not match,
- * then it is directly passed through.
- * @param remap_addr  The region where the matched transtaction will be
- * redirected to.
- * @param size The size of the regions mapped.
- */
-void ibex_addr_remap_1_set(uint32_t matching_addr, uint32_t remap_addr,
-                           size_t size);
+void ibex_addr_remap_set(size_t slot, uint32_t matching_addr,
+                         uint32_t remap_addr, size_t size);
 
 /**
  * Get the remap target address.
  *
- * Returns zero if the remap window is not in use.
+ * Returns zero if the address translation slot is not in use.
  *
- * @param index Which window to lock (0 or 1).
+ * @param slot Index of the addresss translation slot.
  * @return The remap target address.
  */
-uint32_t ibex_addr_remap_get(uint32_t index);
+uint32_t ibex_addr_remap_get(size_t slot);
 
 /**
- * Lock the remap windows so they cannot be reprogrammed.
- * This function locks the given the IBUS and DBUS windows simultaneously.
+ * Lock a addresss translation so that it cannot be reprogrammed.
+ * This function locks the given IBUS and DBUS addresss translations
+ * simultaneously.
  *
- * @param index Which window to lock (0 or 1).
+ * @param slot Index of the addresss translation slot to lock.
  */
-void ibex_addr_remap_lockdown(uint32_t index);
+void ibex_addr_remap_lockdown(size_t slot);
+
+/**
+ * Verify that an address translation slot is enabled.
+ * The slot is considered enabled if both IBUS and DBUS are remapped for this
+ * slot index.
+ *
+ * @param slot Index of the address translation slot to check.
+ * @return True if the slot is enabled, false otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+bool ibex_addr_remap_is_enabled(size_t slot);
+
+/**
+ * Verify that an address translation slot remaps an address region to another
+ * one.
+ *
+ * This function checks that the region defined by (matching_addr, size) is
+ * redirected to remap_addr by the current address translation slot
+ * configuration.
+ *
+ * Both IBUS and DBUS address translations are checked but this function does
+ * not check if the slot is enabled.
+ *
+ * @param slot Index of the address translation slot to check.
+ * @param matching_addr Start address for the region to match for incoming
+ * transactions.
+ * @param remap_addr Start address for the region where the matched transaction
+ * will be redirected to.
+ * @param size The size of the regions mapped.
+ * @return True if the slot is matching expectations, false otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+bool ibex_addr_remap_verify(size_t slot, uint32_t matching_addr,
+                            uint32_t remap_addr, size_t size);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/drivers/ibex_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/ibex_unittest.cc
@@ -40,7 +40,7 @@ TEST_F(AddressTranslationTest, Slot0Sucess) {
   EXPECT_SEC_WRITE32(base_ + RV_CORE_IBEX_IBUS_ADDR_EN_0_REG_OFFSET, 1);
   EXPECT_SEC_WRITE32(base_ + RV_CORE_IBEX_DBUS_ADDR_EN_0_REG_OFFSET, 1);
 
-  ibex_addr_remap_0_set(matching_addr, remap_addr, size);
+  ibex_addr_remap_set(0, matching_addr, remap_addr, size);
 }
 
 TEST_F(AddressTranslationTest, Slot1Sucess) {
@@ -62,7 +62,7 @@ TEST_F(AddressTranslationTest, Slot1Sucess) {
   EXPECT_SEC_WRITE32(base_ + RV_CORE_IBEX_IBUS_ADDR_EN_1_REG_OFFSET, 1);
   EXPECT_SEC_WRITE32(base_ + RV_CORE_IBEX_DBUS_ADDR_EN_1_REG_OFFSET, 1);
 
-  ibex_addr_remap_1_set(matching_addr, remap_addr, size);
+  ibex_addr_remap_set(1, matching_addr, remap_addr, size);
 }
 }  // namespace
 }  // namespace ibex_unittest

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -580,8 +580,8 @@ static rom_error_t rom_boot(const manifest_t *manifest, uint32_t flash_exec) {
   switch (launder32(manifest->address_translation)) {
     case kHardenedBoolTrue:
       HARDENED_CHECK_EQ(manifest->address_translation, kHardenedBoolTrue);
-      ibex_addr_remap_0_set((uintptr_t)_rom_ext_virtual_start_address,
-                            (uintptr_t)manifest, (size_t)_rom_ext_virtual_size);
+      ibex_addr_remap_set(0, (uintptr_t)_rom_ext_virtual_start_address,
+                          (uintptr_t)manifest, (size_t)_rom_ext_virtual_size);
       SEC_MMIO_WRITE_INCREMENT(kAddressTranslationSecMmioConfigure);
 
       // Unlock read-only for the whole rom_ext virtual memory.

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -439,8 +439,8 @@ static rom_error_t rom_ext_boot(boot_data_t *boot_data, boot_log_t *boot_log,
   switch (launder32(manifest->address_translation)) {
     case kHardenedBoolTrue:
       HARDENED_CHECK_EQ(manifest->address_translation, kHardenedBoolTrue);
-      ibex_addr_remap_1_set((uintptr_t)_owner_virtual_start_address,
-                            (uintptr_t)manifest, (size_t)_owner_virtual_size);
+      ibex_addr_remap_set(1, (uintptr_t)_owner_virtual_start_address,
+                          (uintptr_t)manifest, (size_t)_owner_virtual_size);
       SEC_MMIO_WRITE_INCREMENT(kAddressTranslationSecMmioConfigure);
 
       // Unlock read-only for the whole rom_ext virtual memory.


### PR DESCRIPTION
Generalize the address translation API to support the number slots defined by the hardware top.

Extend the API with helpers to get those number of slots and verify a slot translation configuration.

Fixed #28369

Co-developed-by: Loic Lefort <loic@rivosinc.com>