### PR TITLE
[bazel,qemu] Add initial support for `sival_rom_ext` for `sim_qemu` environments.

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -174,6 +174,29 @@ sim_qemu(
     rom = "//sw/device/silicon_creator/rom:mask_rom",
 )
 
+sim_qemu(
+    name = "sim_qemu_sival_rom_ext",
+    testonly = True,
+    base = ":sim_qemu_base",
+    ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0"},
+    exec_env = "sim_qemu_sival_rom_ext",
+    libs = [
+        "//sw/device/lib/arch:boot_stage_owner",
+        "//sw/device/lib/arch:sim_qemu",
+    ],
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
+    manifest = "//sw/device/silicon_owner:manifest",
+    otp = "//hw/ip/otp_ctrl/data/earlgrey_skus/emulation:otp_img_prod_manuf_personalized",
+    param = {
+        "interface": "qemu",
+        "exit_success": DEFAULT_TEST_SUCCESS_MSG,
+        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
+        "assemble": "{rom_ext}@{rom_ext_slot_a} {firmware}@{owner_slot_a}",
+    },
+    rom = "//sw/device/silicon_creator/rom:mask_rom",
+    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
+)
+
 fpga_cw310(
     name = "fpga_cw310_rom_ext",
     testonly = True,

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -113,6 +113,7 @@ EARLGREY_TEST_ENVS = {
     "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
     "//hw/top_earlgrey:sim_dv": None,
     "//hw/top_earlgrey:sim_verilator": None,
+    "//hw/top_earlgrey:sim_qemu_sival_rom_ext": None,
     "//hw/top_earlgrey:sim_qemu_rom_with_fake_keys": None,
 }
 

--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -11,6 +11,7 @@ load(
     "cw310_params",
     "fpga_params",
     "opentitan_test",
+    "qemu_params",
     "verilator_params",
 )
 load(
@@ -78,8 +79,10 @@ opentitan_test(
         {
             # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
             "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
+            "//hw/top_earlgrey:sim_qemu_sival_rom_ext": "qemu_broken",
         },
     ),
+    qemu_broken = qemu_params(tags = ["broken"]),
     verilator = verilator_params(
         timeout = "long",
     ),

--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -32,6 +32,7 @@ opentitan_binary(
         "//hw/top_earlgrey:fpga_cw305",
         "//hw/top_earlgrey:fpga_cw340",
         "//hw/top_earlgrey:sim_dv_base",
+        "//hw/top_earlgrey:sim_qemu_base",
         "//hw/top_earlgrey:sim_verilator_base",
     ],
     kind = "rom",

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -19,6 +19,7 @@ load(
     "EARLGREY_TEST_ENVS",
     "fpga_params",
     "opentitan_test",
+    "qemu_params",
     "silicon_params",
     "verilator_params",
 )
@@ -318,8 +319,10 @@ opentitan_test(
             "//hw/top_earlgrey:silicon_creator": None,
             # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
             "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
+            "//hw/top_earlgrey:sim_qemu_sival_rom_ext": "qemu_broken",
         },
     ),
+    qemu_broken = qemu_params(tags = ["broken"]),
     verilator = verilator_params(
         timeout = "long",
     ),

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -304,6 +304,7 @@ manifest(d = {
             "//hw/top_earlgrey:fpga_cw310",
             "//hw/top_earlgrey:fpga_cw340",
             "//hw/top_earlgrey:sim_dv_base",
+            "//hw/top_earlgrey:sim_qemu_base",
             "//hw/top_earlgrey:sim_verilator_base",
             "//hw/top_earlgrey:silicon_creator",
         ],
@@ -369,6 +370,7 @@ opentitan_binary(
         "//hw/top_earlgrey:fpga_cw310",
         "//hw/top_earlgrey:fpga_cw340",
         "//hw/top_earlgrey:sim_dv_base",
+        "//hw/top_earlgrey:sim_qemu_base",
         "//hw/top_earlgrey:sim_verilator_base",
     ],
     extra_bazel_features = [

--- a/sw/device/silicon_creator/rom_ext/imm_section/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/imm_section/defs.bzl
@@ -12,6 +12,7 @@ DEFAULT_EXEC_ENV = [
     "//hw/top_earlgrey:fpga_cw310",
     "//hw/top_earlgrey:fpga_cw340",
     "//hw/top_earlgrey:sim_dv_base",
+    "//hw/top_earlgrey:sim_qemu_base",
     "//hw/top_earlgrey:sim_verilator_base",
     "//hw/top_earlgrey:silicon_creator",
 ]

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4336,13 +4336,9 @@ opentitan_test(
 opentitan_test(
     name = "sram_ctrl_execution_test",
     srcs = ["sram_ctrl_execution_test.c"],
-    exec_env = dicts.omit(
-        dicts.add(
-            EARLGREY_TEST_ENVS,
-            EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
-        ),
-        # TODO (#26100): QEMU's `flashgen.py` script does not like this test.
-        ["//hw/top_earlgrey:sim_qemu_rom_with_fake_keys"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",


### PR DESCRIPTION
This PR adds initial support for SiVal ROM_EXT tests running in QEMU. It makes use of the latest release QEMU binaries that are pinned in OpenTitan already, so no overriding is needed.

One notable limitation is a result of QEMU's `flashgen.py` script which generates a QEMU flash backend image for emulation, which can only take two binaries and places restrictions on what these binaries can be and where they can be stored (essentially, ROM_EXT at 0x0 and some firmware at 0x10000). This also does not properly support using multiple banks at the moment, as this use case is not adequately supported in QEMU.

This can be tested by running most existing tests that pass in the `sim_qemu_rom_with_fake_keys` environment and the `fpga_cw310_sival_rom_ext` environment. I've run a local regression using `scripts/opentitan/run-bazel-tests.sh` in `lowRISC/qemu` and got 0 regressions in existing passing tests, with ~218 new passing tests (excluding flaky tests) which are passing versions of tests already passing in `sim_qemu_rom_with_fake_keys`.

Also note that many tests marked as broken in `fpga_cw310_sival_rom_ext` environments (due to issues in ROM_EXT, but not on FPGA specifically) will need to be appropriately marked broken in QEMU as well. I've added a commit that addresses this for two specific keymgr tests I investigated as part of the QEMU keymgr implementation, but this is still needed for all other tests that this applies to.

*Aside*: I'm not super familiar with Bazel itself or OpenTitan's current exec env / test dispatching system, so please do leave any remarks on the Bazel code!