### PR TITLE
[crypto] Checksums in key structures

### DIFF
--- a/sw/device/lib/base/crc32.h
+++ b/sw/device/lib/base/crc32.h
@@ -42,7 +42,7 @@ void crc32_add32(uint32_t *ctx, uint32_t word);
  *
  * @param[in, out] ctx Context variable.
  * @param buf A buffer, little-endian.
- * @param len Size of the buffer.
+ * @param len Byte length of the buffer.
  */
 void crc32_add(uint32_t *ctx, const void *buf, size_t len);
 

--- a/sw/device/lib/crypto/drivers/aes.c
+++ b/sw/device/lib/crypto/drivers/aes.c
@@ -347,7 +347,6 @@ uint32_t aes_key_integrity_checksum(const aes_key_t *key) {
 
 hardened_bool_t aes_key_integrity_checksum_check(const aes_key_t *key) {
   if (key->checksum == launder32(aes_key_integrity_checksum(key))) {
-    HARDENED_CHECK_EQ(key->checksum, aes_key_integrity_checksum(key));
     return kHardenedBoolTrue;
   }
   return kHardenedBoolFalse;

--- a/sw/device/lib/crypto/drivers/hmac.c
+++ b/sw/device/lib/crypto/drivers/hmac.c
@@ -708,7 +708,6 @@ uint32_t hmac_key_integrity_checksum(const hmac_key_t *key) {
 
 hardened_bool_t hmac_key_integrity_checksum_check(const hmac_key_t *key) {
   if (key->checksum == launder32(hmac_key_integrity_checksum(key))) {
-    HARDENED_CHECK_EQ(key->checksum, hmac_key_integrity_checksum(key));
     return kHardenedBoolTrue;
   }
   return kHardenedBoolFalse;

--- a/sw/device/lib/crypto/impl/aes_gcm/BUILD
+++ b/sw/device/lib/crypto/impl/aes_gcm/BUILD
@@ -24,6 +24,7 @@ cc_library(
     srcs = ["ghash.c"],
     hdrs = ["ghash.h"],
     deps = [
+        "//sw/device/lib/base:crc32",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",
@@ -36,6 +37,7 @@ cc_test(
     srcs = ["ghash_unittest.cc"],
     deps = [
         ":ghash",
+        "//sw/device/lib/base:crc32",
         "@googletest//:gtest_main",
     ],
 )

--- a/sw/device/lib/crypto/impl/aes_gcm/ghash.h
+++ b/sw/device/lib/crypto/impl/aes_gcm/ghash.h
@@ -8,6 +8,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "sw/device/lib/base/hardened.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
@@ -71,7 +73,33 @@ typedef struct ghash_context {
    * Number of processed ghash blocks.
    */
   size_t ghash_block_cnt;
+  /**
+   * Checksum of the structure.
+   */
+  uint32_t checksum;
 } ghash_context_t;
+
+/**
+ * Compute the checksum of a ghash context.
+ *
+ * Call this routine after creating or modifying the structure.
+ *
+ * @param ghash_ctx ghash context.
+ * @returns Checksum value.
+ */
+uint32_t ghash_context_integrity_checksum(const ghash_context_t *ghash_ctx);
+
+/**
+ * Perform an integrity check on the ghash context.
+ *
+ * Returns `kHardenedBoolTrue` if the check passed and `kHardenedBoolFalse`
+ * otherwise.
+ *
+ * @param ghash_ctx ghash context.
+ * @returns Whether the integrity check passed.
+ */
+hardened_bool_t ghash_context_integrity_checksum_check(
+    const ghash_context_t *ghash_ctx);
 
 /**
  * Precompute hash subkey information for GHASH.

--- a/sw/device/lib/crypto/impl/ecc/BUILD
+++ b/sw/device/lib/crypto/impl/ecc/BUILD
@@ -12,6 +12,7 @@ cc_library(
     hdrs = ["p256.h"],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
+        "//sw/device/lib/base:crc32",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/crypto/drivers:otbn",
@@ -27,6 +28,7 @@ cc_library(
     hdrs = ["p384.h"],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
+        "//sw/device/lib/base:crc32",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/crypto/drivers:otbn",

--- a/sw/device/lib/crypto/impl/ecc/p256.c
+++ b/sw/device/lib/crypto/impl/ecc/p256.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/crypto/impl/ecc/p256.h"
 
+#include "sw/device/lib/base/crc32.h"
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/crypto/drivers/otbn.h"
@@ -89,13 +90,14 @@ enum {
   kModeEcdsaSignSideloadInsCnt = 607471,
 };
 
-static status_t p256_masked_scalar_write(const p256_masked_scalar_t *src,
+static status_t p256_masked_scalar_write(p256_masked_scalar_t *src,
                                          const otbn_addr_t share0_addr,
                                          const otbn_addr_t share1_addr) {
   HARDENED_TRY(
       otbn_dmem_write(kP256MaskedScalarShareWords, src->share0, share0_addr));
   HARDENED_TRY(
       otbn_dmem_write(kP256MaskedScalarShareWords, src->share1, share1_addr));
+  HARDENED_CHECK_EQ(p256_masked_scalar_checksum_check(src), kHardenedBoolTrue);
 
   // Write trailing 0s so that OTBN's 256-bit read of the second share does not
   // cause an error.
@@ -103,6 +105,46 @@ static status_t p256_masked_scalar_write(const p256_masked_scalar_t *src,
                              share0_addr + kP256MaskedScalarShareBytes));
   return otbn_dmem_set(kMaskedScalarPaddingWords, 0,
                        share1_addr + kP256MaskedScalarShareBytes);
+}
+
+uint32_t p256_masked_scalar_checksum(const p256_masked_scalar_t *scalar) {
+  uint32_t ctx;
+  crc32_init(&ctx);
+  // Compute the checksum only over a single share to avoid side-channel
+  // leakage. From a FI perspective only covering one key share is fine as
+  // (a) manipulating the second share with FI has only limited use to an
+  // adversary and (b) when manipulating the entire pointer to the key structure
+  // the checksum check fails.
+  crc32_add(&ctx, (unsigned char *)scalar->share0, kP256CoordBytes);
+  return crc32_finish(&ctx);
+}
+
+hardened_bool_t p256_masked_scalar_checksum_check(
+    const p256_masked_scalar_t *scalar) {
+  if (scalar->checksum == launder32(p256_masked_scalar_checksum(scalar))) {
+    return kHardenedBoolTrue;
+  }
+  return kHardenedBoolFalse;
+}
+
+uint32_t p256_ecdh_shared_key_checksum(const p256_ecdh_shared_key_t *key) {
+  uint32_t ctx;
+  crc32_init(&ctx);
+  // Compute the checksum only over a single share to avoid side-channel
+  // leakage. From a FI perspective only covering one key share is fine as
+  // (a) manipulating the second share with FI has only limited use to an
+  // adversary and (b) when manipulating the entire pointer to the key structure
+  // the checksum check fails.
+  crc32_add(&ctx, (unsigned char *)key->share0, kP256CoordBytes);
+  return crc32_finish(&ctx);
+}
+
+hardened_bool_t p256_ecdh_shared_key_checksum_check(
+    const p256_ecdh_shared_key_t *key) {
+  if (key->checksum == launder32(p256_ecdh_shared_key_checksum(key))) {
+    return kHardenedBoolTrue;
+  }
+  return kHardenedBoolFalse;
 }
 
 status_t p256_keygen_start(void) {
@@ -140,6 +182,7 @@ status_t p256_keygen_finalize(p256_masked_scalar_t *private_key,
                                         private_key->share0));
   HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(kP256MaskedScalarShareWords, kOtbnVarD1,
                                         private_key->share1));
+  private_key->checksum = p256_masked_scalar_checksum(private_key);
 
   // Read the public key from OTBN dmem.
   HARDENED_TRY_WIPE_DMEM(
@@ -191,7 +234,7 @@ static status_t set_message_digest(const uint32_t digest[kP256ScalarWords]) {
 }
 
 status_t p256_ecdsa_sign_start(const uint32_t digest[kP256ScalarWords],
-                               const p256_masked_scalar_t *private_key) {
+                               p256_masked_scalar_t *private_key) {
   // Load the P-256 app. Fails if OTBN is non-idle.
   HARDENED_TRY(otbn_load_app(kOtbnAppP256));
 
@@ -302,7 +345,7 @@ status_t p256_ecdsa_verify_finalize(const p256_ecdsa_signature_t *signature,
   return otbn_dmem_sec_wipe();
 }
 
-status_t p256_ecdh_start(const p256_masked_scalar_t *private_key,
+status_t p256_ecdh_start(p256_masked_scalar_t *private_key,
                          const p256_point_t *public_key) {
   // Load the P-256 app. Fails if OTBN is non-idle.
   HARDENED_TRY(otbn_load_app(kOtbnAppP256));
@@ -349,6 +392,8 @@ status_t p256_ecdh_finalize(p256_ecdh_shared_key_t *shared_key) {
       otbn_dmem_read(kP256CoordWords, kOtbnVarX, shared_key->share0));
   HARDENED_TRY_WIPE_DMEM(
       otbn_dmem_read(kP256CoordWords, kOtbnVarY, shared_key->share1));
+
+  shared_key->checksum = p256_ecdh_shared_key_checksum(shared_key);
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();

--- a/sw/device/lib/crypto/impl/ecc/p384.c
+++ b/sw/device/lib/crypto/impl/ecc/p384.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/crypto/impl/ecc/p384.h"
 
+#include "sw/device/lib/base/crc32.h"
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/crypto/drivers/otbn.h"
@@ -99,13 +100,14 @@ enum {
   kModeEcdsaSignSideloadInsCnt = 1509844,
 };
 
-static status_t p384_masked_scalar_write(const p384_masked_scalar_t *src,
+static status_t p384_masked_scalar_write(p384_masked_scalar_t *src,
                                          const otbn_addr_t share0_addr,
                                          const otbn_addr_t share1_addr) {
   HARDENED_TRY(
       otbn_dmem_write(kP384MaskedScalarShareWords, src->share0, share0_addr));
   HARDENED_TRY(
       otbn_dmem_write(kP384MaskedScalarShareWords, src->share1, share1_addr));
+  HARDENED_CHECK_EQ(p384_masked_scalar_checksum_check(src), kHardenedBoolTrue);
 
   // Write trailing 0s so that OTBN's 384-bit read of the second share does not
   // cause an error.
@@ -113,6 +115,26 @@ static status_t p384_masked_scalar_write(const p384_masked_scalar_t *src,
                              share0_addr + kP384MaskedScalarShareBytes));
   return otbn_dmem_set(kMaskedScalarPaddingWords, 0,
                        share1_addr + kP384MaskedScalarShareBytes);
+}
+
+uint32_t p384_masked_scalar_checksum(const p384_masked_scalar_t *scalar) {
+  uint32_t ctx;
+  crc32_init(&ctx);
+  // Compute the checksum only over a single share to avoid side-channel
+  // leakage. From a FI perspective only covering one key share is fine as
+  // (a) manipulating the second share with FI has only limited use to an
+  // adversary and (b) when manipulating the entire pointer to the key structure
+  // the checksum check fails.
+  crc32_add(&ctx, (unsigned char *)scalar->share0, kP384CoordBytes);
+  return crc32_finish(&ctx);
+}
+
+hardened_bool_t p384_masked_scalar_checksum_check(
+    const p384_masked_scalar_t *scalar) {
+  if (scalar->checksum == launder32(p384_masked_scalar_checksum(scalar))) {
+    return kHardenedBoolTrue;
+  }
+  return kHardenedBoolFalse;
 }
 
 /**
@@ -158,6 +180,26 @@ static status_t set_message_digest(const uint32_t digest[kP384ScalarWords],
   return p384_scalar_write(digest_little_endian, dst);
 }
 
+uint32_t p384_ecdh_shared_key_checksum(const p384_ecdh_shared_key_t *key) {
+  uint32_t ctx;
+  crc32_init(&ctx);
+  // Compute the checksum only over a single share to avoid side-channel
+  // leakage. From a FI perspective only covering one key share is fine as
+  // (a) manipulating the second share with FI has only limited use to an
+  // adversary and (b) when manipulating the entire pointer to the key structure
+  // the checksum check fails.
+  crc32_add(&ctx, (unsigned char *)key->share0, kP384CoordBytes);
+  return crc32_finish(&ctx);
+}
+
+hardened_bool_t p384_ecdh_shared_key_checksum_check(
+    const p384_ecdh_shared_key_t *key) {
+  if (key->checksum == launder32(p384_ecdh_shared_key_checksum(key))) {
+    return kHardenedBoolTrue;
+  }
+  return kHardenedBoolFalse;
+}
+
 status_t p384_keygen_start(void) {
   // Load the ECDH/P-384 app. Fails if OTBN is non-idle.
   HARDENED_TRY(otbn_load_app(kOtbnAppP384));
@@ -181,6 +223,7 @@ status_t p384_keygen_finalize(p384_masked_scalar_t *private_key,
                                         private_key->share0));
   HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(kP384MaskedScalarShareWords, kOtbnVarD1,
                                         private_key->share1));
+  private_key->checksum = p384_masked_scalar_checksum(private_key);
 
   // Read the public key from OTBN dmem.
   HARDENED_TRY_WIPE_DMEM(
@@ -220,7 +263,7 @@ status_t p384_sideload_keygen_finalize(p384_point_t *public_key) {
 }
 
 status_t p384_ecdsa_sign_start(const uint32_t digest[kP384ScalarWords],
-                               const p384_masked_scalar_t *private_key) {
+                               p384_masked_scalar_t *private_key) {
   // Load the ECDSA/P-384 app. Fails if OTBN is non-idle.
   HARDENED_TRY(otbn_load_app(kOtbnAppP384));
 
@@ -328,7 +371,7 @@ status_t p384_ecdsa_verify_finalize(const p384_ecdsa_signature_t *signature,
   return otbn_dmem_sec_wipe();
 }
 
-status_t p384_ecdh_start(const p384_masked_scalar_t *private_key,
+status_t p384_ecdh_start(p384_masked_scalar_t *private_key,
                          const p384_point_t *public_key) {
   // Load the ECDH/P-384 app. Fails if OTBN is non-idle.
   HARDENED_TRY(otbn_load_app(kOtbnAppP384));
@@ -373,6 +416,8 @@ status_t p384_ecdh_finalize(p384_ecdh_shared_key_t *shared_key) {
       otbn_dmem_read(kP384CoordWords, kOtbnVarX, shared_key->share0));
   HARDENED_TRY_WIPE_DMEM(
       otbn_dmem_read(kP384CoordWords, kOtbnVarY, shared_key->share1));
+
+  shared_key->checksum = p384_ecdh_shared_key_checksum(shared_key);
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();

--- a/sw/device/lib/crypto/impl/ecc/p384.h
+++ b/sw/device/lib/crypto/impl/ecc/p384.h
@@ -54,6 +54,25 @@ enum {
    * Length of masked secret scalar share in words.
    */
   kP384MaskedScalarShareWords = kP384MaskedScalarShareBytes / sizeof(uint32_t),
+  /**
+   * Number of shares for the scalar.
+   */
+  kP384MaskedScalarNumShares = 2,
+  /**
+   * Length of the full masked secret scalar share in bits.
+   */
+  kP384MaskedScalarTotalShareBits =
+      kP384MaskedScalarNumShares * kP384MaskedScalarShareBits,
+  /**
+   * Length of the full masked secret scalar share in bytes.
+   */
+  kP384MaskedScalarTotalShareBytes =
+      kP384MaskedScalarNumShares * kP384MaskedScalarShareBytes,
+  /**
+   * Length of the full masked secret scalar share in words.
+   */
+  kP384MaskedScalarTotalShareWords =
+      kP384MaskedScalarNumShares * kP384MaskedScalarShareWords,
 };
 
 /**
@@ -73,6 +92,10 @@ typedef struct p384_masked_scalar {
    * Second share of the secret scalar.
    */
   uint32_t share1[kP384MaskedScalarShareWords];
+  /**
+   * Checksum over share0.
+   */
+  uint32_t checksum;
 } p384_masked_scalar_t;
 
 /**
@@ -107,7 +130,55 @@ typedef struct p384_ecdsa_signature_t {
 typedef struct p384_ecdh_shared_key {
   uint32_t share0[kP384CoordWords];
   uint32_t share1[kP384CoordWords];
+  // Checksum over share0.
+  uint32_t checksum;
 } p384_ecdh_shared_key_t;
+
+/**
+ * Compute the checksum of an p384 masked scalar.
+ *
+ * Call this routine after creating or modifying the p384 scalar structure.
+ *
+ * @param key p384 masked scalar.
+ * @returns Checksum value.
+ */
+uint32_t p384_masked_scalar_checksum(const p384_masked_scalar_t *scalar);
+
+/**
+ * Perform an integrity check on the p384 masked scalar.
+ *
+ * Returns `kHardenedBoolTrue` if the check passed and `kHardenedBoolFalse`
+ * otherwise.
+ *
+ * @param key p384 masked scalar.
+ * @returns Whether the integrity check passed.
+ */
+OT_WARN_UNUSED_RESULT
+hardened_bool_t p384_masked_scalar_checksum_check(
+    const p384_masked_scalar_t *scalar);
+
+/**
+ * Compute the checksum of an p384 ecdh key.
+ *
+ * Call this routine after creating or modifying the p384 key structure.
+ *
+ * @param key p384 ecdh shared key.
+ * @returns Checksum value.
+ */
+uint32_t p384_ecdh_shared_key_checksum(const p384_ecdh_shared_key_t *key);
+
+/**
+ * Perform an integrity check on the p384 ecdh key.
+ *
+ * Returns `kHardenedBoolTrue` if the check passed and `kHardenedBoolFalse`
+ * otherwise.
+ *
+ * @param key p384 ecdh shared key.
+ * @returns Whether the integrity check passed.
+ */
+OT_WARN_UNUSED_RESULT
+hardened_bool_t p384_ecdh_shared_key_checksum_check(
+    const p384_ecdh_shared_key_t *key);
 
 /**
  * Start an async P-384 keypair generation operation on OTBN.
@@ -170,7 +241,7 @@ status_t p384_sideload_keygen_finalize(p384_point_t *public_key);
  */
 OT_WARN_UNUSED_RESULT
 status_t p384_ecdsa_sign_start(const uint32_t digest[kP384ScalarWords],
-                               const p384_masked_scalar_t *private_key);
+                               p384_masked_scalar_t *private_key);
 
 /**
  * Start an async ECDSA/P-384 signature generation operation on OTBN.
@@ -249,7 +320,7 @@ status_t p384_ecdsa_verify_finalize(const p384_ecdsa_signature_t *signature,
  * @return Result of the operation (OK or error).
  */
 OT_WARN_UNUSED_RESULT
-status_t p384_ecdh_start(const p384_masked_scalar_t *private_key,
+status_t p384_ecdh_start(p384_masked_scalar_t *private_key,
                          const p384_point_t *public_key);
 
 /**

--- a/sw/device/lib/crypto/include/aes_gcm.h
+++ b/sw/device/lib/crypto/include/aes_gcm.h
@@ -39,7 +39,8 @@ typedef enum otcrypto_aes_gcm_tag_len {
  * change.
  */
 typedef struct otcrypto_aes_gcm_context {
-  uint32_t data[192];
+  // TODO: update the size and the restore and save context functions.
+  uint32_t data[194];
 } otcrypto_aes_gcm_context_t;
 
 /**

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
@@ -671,7 +671,7 @@ status_t cryptolib_fi_p256_sign_impl(
   p256_masked_scalar_t private_key_masked;
   otcrypto_blinded_key_t private_key = {
       .config = kP256PrivateKeyConfig,
-      .keyblob_length = sizeof(private_key_masked),
+      .keyblob_length = kP256MaskedScalarTotalShareBytes,
       .keyblob = (uint32_t *)&private_key_masked,
   };
   memset(private_key_masked.share0, 0, kP256MaskedScalarShareBytes);
@@ -897,7 +897,7 @@ status_t cryptolib_fi_p384_sign_impl(
   p384_masked_scalar_t private_key_masked;
   otcrypto_blinded_key_t private_key = {
       .config = kP384PrivateKeyConfig,
-      .keyblob_length = sizeof(private_key_masked),
+      .keyblob_length = kP384MaskedScalarTotalShareBytes,
       .keyblob = (uint32_t *)&private_key_masked,
   };
   memset(private_key_masked.share0, 0, kP384MaskedScalarShareBytes);

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym_impl.c
@@ -460,7 +460,7 @@ status_t cryptolib_sca_p256_sign_impl(
   p256_masked_scalar_t private_key_masked;
   otcrypto_blinded_key_t private_key = {
       .config = kP256PrivateKeyConfig,
-      .keyblob_length = sizeof(private_key_masked),
+      .keyblob_length = kP256MaskedScalarTotalShareBytes,
       .keyblob = (uint32_t *)&private_key_masked,
   };
   memset(private_key_masked.share0, 0, kP256MaskedScalarShareBytes);
@@ -632,7 +632,7 @@ status_t cryptolib_sca_p384_sign_impl(
   p384_masked_scalar_t private_key_masked;
   otcrypto_blinded_key_t private_key = {
       .config = kP384PrivateKeyConfig,
-      .keyblob_length = sizeof(private_key_masked),
+      .keyblob_length = kP384MaskedScalarTotalShareBytes,
       .keyblob = (uint32_t *)&private_key_masked,
   };
   memset(private_key_masked.share0, 0, kP384MaskedScalarShareBytes);


### PR DESCRIPTION
General check whether checksums were missing in security critical structures in the cryptolib for fault protection.

In general:
- ECC keys do not have checksums
- GCM's H does not have a checksum