### PR TITLE
[otpmemimg] Use name of soc_dbg_state field to encode the value

### DIFF
--- a/util/design/lib/OtpMemImg.py
+++ b/util/design/lib/OtpMemImg.py
@@ -320,6 +320,8 @@ class OtpMemImg(OtpMemMap):
 
         item_size = mmap_item['size']
         item_width = item_size * 8
+        mubi_str = ""
+        mubi_val_str = ""
 
         # if needed, resolve the mubi value first
         if mmap_item['ismubi']:
@@ -329,12 +331,10 @@ class OtpMemImg(OtpMemMap):
             item["value"] = common.check_bool(item["value"])
             mubi_val_str += "True" if item["value"] else "False"
             item["value"] = mubi_value_as_int(item["value"], item_width)
-        elif item["value"] in ["SOC_DBG_RAW", "SOC_DBG_PRE_PROD", "SOC_DBG_PROD"]:
+        elif item["name"] == "SOC_DBG_STATE":
             item.setdefault("value", "0x0")
             item["value"] = self.lc_state.encode("soc_dbg_state", item["value"])
         else:
-            mubi_str = ""
-            mubi_val_str = ""
             item.setdefault('value', '0x0')
             prng = SecurePrngFactory.get("otpmemimg")
             common.random_or_hexvalue(prng, item, 'value', item_width)


### PR DESCRIPTION
Don't rely on the value as this yields a parsing error.