### PR TITLE
[rescue,test] add more e2e rescue tests

### DIFF
--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -196,6 +196,34 @@ TEST_OWNER_CONFIGS = {
         ],
         "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_spidfu"],
     },
+    "rescue_config_module_mismatch": {
+        "owner_defines": [
+            # 0x53 is 'S'pi.
+            "WITH_RESCUE_PROTOCOL=0x53",
+            # Timeout: 0x80=enter_on_fail, 0x05 = 5 seconds.
+            "WITH_RESCUE_TIMEOUT=0x85",
+        ],
+        # Set a rescue module that is not matched with the specified rescue protocol.
+        "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_xmodem"],
+    },
+    "spidfu_rescue_boot_svc_req_disability": {
+        "owner_defines": [
+            # 0x53 is 'S'pi.
+            "WITH_RESCUE_PROTOCOL=0x53",
+            # Trigger 3 is GPIO pin.
+            "WITH_RESCUE_TRIGGER=3",
+            # When the trigger is GPIO, the index is the MuxedPad to us as the sense
+            # input. Index 2 is kTopEarlgreyMuxedPadsIoa2.
+            "WITH_RESCUE_INDEX=2",
+            # GPIO param 3 means enable the internal pull resistor and trigger
+            # rescue when the GPIO is high.
+            "WITH_RESCUE_GPIO_PARAM=3",
+            # Timeout: 0x80=enter_on_fail, 0x05 = 5 seconds.
+            "WITH_RESCUE_TIMEOUT=0x85",
+            "WITH_RESCUE_COMMAND_ALLOW=kRescueModeBootSvcReq",
+        ],
+        "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_spidfu"],
+    },
     "spidfu_flash_limit_zero": {
         "owner_defines": [
             # 0x53 is 'S'pi.

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -690,6 +690,81 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "rescue_user_error",
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+    },
+    fpga = fpga_params(
+        assemble = "",
+        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
+        test_cmd = """
+            --exec="transport init"
+            --exec="fpga clear-bitstream"
+            --exec="fpga load-bitstream {bitstream}"
+            --exec="bootstrap --clear-uart=true {rom_ext}"
+            # Trigger rescue and make sure we can get the device ID.
+            --exec="rescue get-device-id --reboot=false"
+            # Send Invalid rescue command.
+            --exec="console --non-interactive --send='XYZ\r' --exit-success='error: unrecognized mode'"
+            # Try the `REBO` mode and make sure we reboot without crash.
+            --exec="console --non-interactive --send='REBO\r' --exit-success='ROM:' --exit-failure='BFV:.*\r\n'"
+            no-op
+        """,
+    ),
+)
+
+opentitan_test(
+    name = "rescue_config_module_mismatch",
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+    },
+    fpga = fpga_params(
+        assemble = "{romext}@{rom_ext_slot_a} {firmware}@{owner_slot_a}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_rescue_config_module_mismatch": "romext",
+            ":boot_test_slot_a": "firmware",
+        },
+        test_cmd = """
+            --exec="transport init"
+            --exec="fpga clear-bitstream"
+            --exec="fpga load-bitstream {bitstream}"
+            --exec="bootstrap --clear-uart=true {firmware}"
+            --exec="console --non-interactive --exit-success='warning: rescue' --exit-failure='{exit_failure}'"
+            # Trigger rescue and make sure we can get the device ID even if the protocol specified in the rescue
+            # config doesn't match the ROM_EXT implementation.
+            --exec="rescue get-device-id --reboot=false"
+            # Try the `REBO` mode and make sure we reboot without crash.
+            --exec="console --non-interactive --send='REBO\r' --exit-success='Finished' --exit-failure='BFV:.*\r\n'"
+            no-op
+        """,
+    ),
+)
+
+opentitan_test(
+    name = "spidfu_rescue_boot_svc_req_disability",
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+    },
+    fpga = fpga_params(
+        assemble = "{romext}@{rom_ext_slot_a} {firmware}@{owner_slot_a}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_spidfu_rescue_boot_svc_req_disability": "romext",
+            "//sw/device/silicon_creator/rom_ext/e2e/attestation:print_certs": "firmware",
+        },
+        params = "-p spi-dfu -t gpio -v +Ioa2",
+        test_cmd = """
+        --clear-bitstream
+        --bootstrap={firmware}
+        rescue {params} --action=disability
+        """,
+        test_harness = "//sw/host/tests/rescue:rescue_test",
+    ),
+)
+
+opentitan_test(
     name = "xmodem_rescue_error_handling_test",
     exec_env = {
         "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,


### PR DESCRIPTION
This adds three e2e tests for the rom_ext rescue feature to increase test coverage.

The new tests are:
- rescue_user_error: tests the case where the user sends an invalid command to the rescue console.
- rescue_config_module_mismatch: tests the case where the rescue protocol and the rescue module are mismatched.
- spidfu_rescue_boot_svc_req_disability: tests the case where the boot service request is enable but the associated sub-requests are disabled in SPI DFU rescue mode.