### PR TITLE
[corefiles] Remove PRIM_DEFAULT_IMPL from tops's corefiles

### DIFF
--- a/hw/top_earlgrey/chip_earlgrey_cw310.core
+++ b/hw/top_earlgrey/chip_earlgrey_cw310.core
@@ -67,11 +67,6 @@ parameters:
     description: OTP initialization file in vmem hex format
     default: "../../../../../build-bin/sw/device/otp_img/otp_img_fpga_cw310.vmem"
     paramtype: vlogparam
-  # For value definition, please see ip/prim/rtl/prim_pkg.sv
-  PRIM_DEFAULT_IMPL:
-    datatype: str
-    paramtype: vlogdefine
-    description: Primitives implementation to use, e.g. "prim_pkg::ImplGeneric".
   AST_BYPASS_CLK:
     datatype: bool
     paramtype: vlogdefine
@@ -95,7 +90,6 @@ targets:
     parameters:
       - BootRomInitFile
       - OtpMacroMemInitFile
-      - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
       - AST_BYPASS_CLK=true
     tools:
       vivado:

--- a/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug.core
+++ b/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug.core
@@ -69,11 +69,6 @@ parameters:
     description: OTP initialization file in vmem hex format
     default: "../../../../../build-bin/sw/device/otp_img/otp_img_fpga_cw310.vmem"
     paramtype: vlogparam
-  # For value definition, please see ip/prim/rtl/prim_pkg.sv
-  PRIM_DEFAULT_IMPL:
-    datatype: str
-    paramtype: vlogdefine
-    description: Primitives implementation to use, e.g. "prim_pkg::ImplGeneric".
   AST_BYPASS_CLK:
     datatype: bool
     paramtype: vlogdefine
@@ -97,7 +92,6 @@ targets:
     parameters:
       - BootRomInitFile
       - OtpMacroMemInitFile
-      - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
       - AST_BYPASS_CLK=true
     tools:
       vivado:

--- a/hw/top_earlgrey/chip_earlgrey_cw340.core
+++ b/hw/top_earlgrey/chip_earlgrey_cw340.core
@@ -64,11 +64,6 @@ parameters:
     description: OTP initialization file in vmem hex format
     default: ""
     paramtype: vlogparam
-  # For value definition, please see ip/prim/rtl/prim_pkg.sv
-  PRIM_DEFAULT_IMPL:
-    datatype: str
-    paramtype: vlogdefine
-    description: Primitives implementation to use, e.g. "prim_pkg::ImplGeneric".
   AST_BYPASS_CLK:
     datatype: bool
     paramtype: vlogdefine
@@ -92,7 +87,6 @@ targets:
     parameters:
       - BootRomInitFile
       - OtpMacroMemInitFile
-      - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx_ultrascale
       - AST_BYPASS_CLK=true
     tools:
       vivado:

--- a/hw/top_earlgrey/dv/verilator/chip_sim.core
+++ b/hw/top_earlgrey/dv/verilator/chip_sim.core
@@ -33,11 +33,6 @@ filesets:
       - chip_sim_tb.cc: { file_type: cppSource }
 
 parameters:
-  # For value definition, please see ip/prim/rtl/prim_pkg.sv
-  PRIM_DEFAULT_IMPL:
-    datatype: str
-    paramtype: vlogdefine
-    description: Primitives implementation to use, e.g. "prim_pkg::ImplGeneric".
   RVFI:
     datatype: bool
     paramtype: vlogdefine
@@ -84,7 +79,6 @@ targets:
 
   sim:
     parameters:
-      - PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric
       - RVFI=true
       - VERILATOR_MEM_BASE=0x10000000
       - VERILATOR_TEST_STATUS_ADDR=0x411f0080

--- a/hw/top_englishbreakfast/chip_englishbreakfast_cw305.core
+++ b/hw/top_englishbreakfast/chip_englishbreakfast_cw305.core
@@ -53,11 +53,6 @@ parameters:
     description: Boot ROM initialization file in 32 bit vmem hex format
     default: ""
     paramtype: vlogparam
-  # For value definition, please see ip/prim/rtl/prim_pkg.sv
-  PRIM_DEFAULT_IMPL:
-    datatype: str
-    paramtype: vlogdefine
-    description: Primitives implementation to use, e.g. "prim_pkg::ImplGeneric".
   AST_BYPASS_CLK:
     datatype: bool
     paramtype: vlogdefine
@@ -77,7 +72,6 @@ targets:
     toplevel: chip_englishbreakfast_cw305
     parameters:
       - BootRomInitFile
-      - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
       - AST_BYPASS_CLK=true
     tools:
       vivado:

--- a/hw/top_englishbreakfast/chip_englishbreakfast_verilator.core
+++ b/hw/top_englishbreakfast/chip_englishbreakfast_verilator.core
@@ -38,11 +38,6 @@ filesets:
       - chip_englishbreakfast_verilator.cc: { file_type: cppSource }
 
 parameters:
-  # For value definition, please see ip/prim/rtl/prim_pkg.sv
-  PRIM_DEFAULT_IMPL:
-    datatype: str
-    paramtype: vlogdefine
-    description: Primitives implementation to use, e.g. "prim_pkg::ImplGeneric".
   RVFI:
     datatype: bool
     paramtype: vlogdefine
@@ -85,7 +80,6 @@ targets:
 
   sim:
     parameters:
-      - PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric
       - RVFI=true
       - VERILATOR_MEM_BASE=0x10000000
       - VERILATOR_TEST_STATUS_ADDR=0x411f0080

--- a/hw/top_englishbreakfast/top_englishbreakfast.core
+++ b/hw/top_englishbreakfast/top_englishbreakfast.core
@@ -89,12 +89,6 @@ parameters:
   SYNTHESIS:
     datatype: bool
     paramtype: vlogdefine
-  # For value definition, please see ip/prim/rtl/prim_pkg.sv
-  PRIM_DEFAULT_IMPL:
-    datatype: str
-    paramtype: vlogdefine
-    description: Primitives implementation to use, e.g. "prim_pkg::ImplGeneric".
-    default: prim_pkg::ImplGeneric
 
 
 targets:
@@ -106,8 +100,6 @@ targets:
       - fileset_tapeout   ? (files_rtl_tapeout)
       - "!fileset_tapeout ? (files_rtl_testing)"
       - files_rtl_generic
-    parameters:
-      - PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric
     toplevel: top_englishbreakfast
 
   sim:
@@ -116,8 +108,6 @@ targets:
       - fileset_tapeout   ? (files_rtl_tapeout)
       - "!fileset_tapeout ? (files_rtl_testing)"
       - files_rtl_generic
-    parameters:
-      - PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric
     toplevel: top_englishbreakfast
 
   lint:


### PR DESCRIPTION
PRIM_DEFAULT_IMPL is only used in TB code now. Remove those fusesoc parameters from all RTL cores.