### PR TITLE
[test] Add pass/fail silicon param for ottf alert catch test

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -7725,6 +7725,10 @@ opentitan_test(
         exit_failure = "FAIL!",
         exit_success = "Alert 3 is asserted",
     ),
+    silicon = silicon_params(
+        exit_failure = "FAIL!",
+        exit_success = "Alert 3 is asserted",
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/dif:alert_handler",


### PR DESCRIPTION
This test is expected to fail so we need to look for a specific message. Previously only the FPGA was configured to look for it.