### PR TITLE
[darjeeling,otp] Generate proper OTP images for Darjeeling

### DIFF
--- a/hw/top_darjeeling/data/otp/BUILD
+++ b/hw/top_darjeeling/data/otp/BUILD
@@ -42,6 +42,9 @@ otp_json(
                 # Enable use of entropy for countermeasures. See the definition
                 # of `hardened_bool_t` in sw/device/lib/base/hardened.h.
                 "CREATOR_SW_CFG_RNG_EN": otp_hex(CONST.HARDENED_TRUE),
+                # ROM execution is enabled if this item is set to a non-zero
+                # value.
+                "CREATOR_SW_CFG_ROM_EXEC_EN": otp_hex(0xffffffff),
                 # Value to write to the cpuctrl CSR in `rom_init()`.
                 # See:
                 # https://ibex-core.readthedocs.io/en/latest/03_reference/cs_registers.html#cpu-control-register-cpuctrl
@@ -68,11 +71,8 @@ otp_json(
             name = "OWNER_SW_CFG",
             items = {
                 # Enable bootstrap. See `hardened_bool_t` in
-                # sw/lib/sw/device/base/hardened.h.
+                # sw/device/lib/base/hardened.h.
                 "OWNER_SW_CFG_ROM_BOOTSTRAP_DIS": otp_hex(CONST.HARDENED_FALSE),
-                # Set to 0x739 to use the ROM_EXT hash measurement as the key
-                # manager attestation binding value.
-                "OWNER_SW_CFG_ROM_KEYMGR_OTP_MEAS_EN": otp_hex(0x0),
                 # Report errors without any redaction.
                 "OWNER_SW_CFG_ROM_ERROR_REPORTING": otp_hex(CONST.SHUTDOWN.REDACT.NONE),
                 # Set the enables to kAlertEnableNone.
@@ -157,21 +157,9 @@ otp_json(
         otp_partition(
             name = "HW_CFG1",
             items = {
+                "SOC_DBG_STATE": "PRE_PROD",
+                # Enable code execution from SRAM.
                 "EN_SRAM_IFETCH": True,
-            },
-            lock = True,
-        ),
-    ],
-    target_compatible_with = TARGET_COMPATIBLE_WITH,
-)
-
-otp_json(
-    name = "otp_json_hw_cfg2",
-    partitions = [
-        otp_partition(
-            name = "HW_CFG2",
-            items = {
-                "SOC_DBG_STATE": "SOC_DBG_PROD",
             },
             lock = True,
         ),
@@ -247,14 +235,8 @@ otp_json(
         otp_partition(
             name = "HW_CFG1",
             items = {
+                "SOC_DBG_STATE": "BLANK",
                 "EN_SRAM_IFETCH": True,
-            },
-            lock = True,
-        ),
-        otp_partition(
-            name = "HW_CFG2",
-            items = {
-                "SOC_DBG_STATE": "SOC_DBG_RAW",
             },
             lock = True,
         ),
@@ -268,14 +250,8 @@ otp_json(
         otp_partition(
             name = "HW_CFG1",
             items = {
+                "SOC_DBG_STATE": "PRE_PROD",
                 "EN_SRAM_IFETCH": True,
-            },
-            lock = True,
-        ),
-        otp_partition(
-            name = "HW_CFG2",
-            items = {
-                "SOC_DBG_STATE": "SOC_DBG_PRE_PROD",
             },
             lock = True,
         ),
@@ -289,14 +265,8 @@ otp_json(
         otp_partition(
             name = "HW_CFG1",
             items = {
+                "SOC_DBG_STATE": "PROD",
                 "EN_SRAM_IFETCH": True,
-            },
-            lock = True,
-        ),
-        otp_partition(
-            name = "HW_CFG2",
-            items = {
-                "SOC_DBG_STATE": "SOC_DBG_PROD",
             },
             lock = True,
         ),

--- a/hw/top_darjeeling/data/otp/defs.bzl
+++ b/hw/top_darjeeling/data/otp/defs.bzl
@@ -7,5 +7,19 @@ DARJEELING_OTP_SIGVERIFY_FAKE_KEYS = [
 
 # This is a set of overlays to generate a generic, standard OTP image.
 # Additional overlays can be applied on top to further customize the OTP.
-DARJEELING_STD_OTP_OVERLAYS = [
+# This set of overlays does not include any of the SECRET[0-2] partitions.
+DARJEELING_STD_OTP_OVERLAYS_WITHOUT_SECRET_PARTITIONS = DARJEELING_OTP_SIGVERIFY_FAKE_KEYS + [
+    "@//hw/top_darjeeling/data/otp:otp_json_creator_sw_cfg",
+    "@//hw/top_darjeeling/data/otp:otp_json_owner_sw_cfg",
+    "@//hw/top_darjeeling/data/otp:otp_json_alert_digest_cfg",
+    "@//hw/top_darjeeling/data/otp:otp_json_hw_cfg0",
+    "@//hw/top_darjeeling/data/otp:otp_json_hw_cfg1",
+]
+
+# This is a set of overlays to generate a generic, standard OTP image.
+# Additional overlays can be applied on top to further customize the OTP.
+DARJEELING_STD_OTP_OVERLAYS = DARJEELING_STD_OTP_OVERLAYS_WITHOUT_SECRET_PARTITIONS + [
+    "@//hw/top_darjeeling/data/otp:otp_json_secret0",
+    "@//hw/top_darjeeling/data/otp:otp_json_secret1",
+    "@//hw/top_darjeeling/data/otp:otp_json_secret2_unlocked",
 ]


### PR DESCRIPTION
Update OTP build scripts to include actual data in OTP images. Otherwise the images would end up containing only LIFECYCLE_STATE. Also update configuration to match the latest Darjeeling OTP map.