### PR TITLE
[hw,darjeeling] Move doc_files target

### DIFF
--- a/hw/top_darjeeling/BUILD
+++ b/hw/top_darjeeling/BUILD
@@ -11,6 +11,23 @@ load(
 
 package(default_visibility = ["//visibility:public"])
 
+filegroup(
+    name = "doc_files",
+    srcs = glob(["**/*.md"]) + [
+        "//hw/top_darjeeling/ip_autogen/ac_range_check:doc_files",
+        "//hw/top_darjeeling/ip_autogen/alert_handler:doc_files",
+        "//hw/top_darjeeling/ip_autogen/clkmgr:doc_files",
+        "//hw/top_darjeeling/ip_autogen/gpio:doc_files",
+        "//hw/top_darjeeling/ip_autogen/otp_ctrl:doc_files",
+        "//hw/top_darjeeling/ip_autogen/pinmux:doc_files",
+        "//hw/top_darjeeling/ip_autogen/pwrmgr:doc_files",
+        "//hw/top_darjeeling/ip_autogen/racl_ctrl:doc_files",
+        "//hw/top_darjeeling/ip_autogen/rstmgr:doc_files",
+        "//hw/top_darjeeling/ip_autogen/rv_core_ibex:doc_files",
+        "//hw/top_darjeeling/ip_autogen/rv_plic:doc_files",
+    ],
+)
+
 ###########################################################################
 # Sim DV Environments
 #
@@ -40,21 +57,4 @@ sim_dv(
     base = ":sim_dv_base",
     exec_env = "sim_dv",
     rom = "//sw/device/lib/testing/test_rom:test_rom",
-)
-
-filegroup(
-    name = "doc_files",
-    srcs = glob(["**/*.md"]) + [
-        "//hw/top_darjeeling/ip_autogen/ac_range_check:doc_files",
-        "//hw/top_darjeeling/ip_autogen/alert_handler:doc_files",
-        "//hw/top_darjeeling/ip_autogen/clkmgr:doc_files",
-        "//hw/top_darjeeling/ip_autogen/gpio:doc_files",
-        "//hw/top_darjeeling/ip_autogen/otp_ctrl:doc_files",
-        "//hw/top_darjeeling/ip_autogen/pinmux:doc_files",
-        "//hw/top_darjeeling/ip_autogen/pwrmgr:doc_files",
-        "//hw/top_darjeeling/ip_autogen/racl_ctrl:doc_files",
-        "//hw/top_darjeeling/ip_autogen/rstmgr:doc_files",
-        "//hw/top_darjeeling/ip_autogen/rv_core_ibex:doc_files",
-        "//hw/top_darjeeling/ip_autogen/rv_plic:doc_files",
-    ],
 )


### PR DESCRIPTION
Move doc_files target before sim_dv targets, this make the BUILD file easier to compare with Earlgrey one.