### PR TITLE
[sw,opentitanlib] Add support for multiple ROMs to opentitantool

### DIFF
--- a/hw/top_earlgrey/dv/verilator/chip_sim_tb.cc
+++ b/hw/top_earlgrey/dv/verilator/chip_sim_tb.cc
@@ -21,9 +21,9 @@ int main(int argc, char **argv) {
   std::string top_scope("TOP.chip_sim_tb.u_dut.top_earlgrey");
   std::string ram1p_adv_scope("u_prim_ram_1p_adv.gen_ram_inst[0].u_mem");
 
-  MemArea rom(top_scope + (".u_rom_ctrl.gen_rom_scramble_enabled.u_rom.u_rom."
-                           "u_prim_rom"),
-              0x8000 / 4, 4);
+  MemArea rom0(top_scope + (".u_rom_ctrl.gen_rom_scramble_enabled.u_rom.u_rom."
+                            "u_prim_rom"),
+               0x8000 / 4, 4);
   MemArea ram(top_scope + ".u_ram1p_ram_main." + ram1p_adv_scope, 0x20000 / 4,
               4);
   // Only handle the lower bank of flash for now.
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
 
   MemArea otp(top_scope + ".u_otp_macro." + ram1p_adv_scope, 0x4000 / 4, 4);
 
-  memutil.RegisterMemoryArea("rom", 0x8000, &rom);
+  memutil.RegisterMemoryArea("rom0", 0x8000, &rom0);
   memutil.RegisterMemoryArea("ram", 0x10000000u, &ram);
   memutil.RegisterMemoryArea("flash0", 0x20000000u, &flash0);
   memutil.RegisterMemoryArea("flash1", 0x20080000u, &flash1);

--- a/sw/host/opentitanlib/src/backend/verilator.rs
+++ b/sw/host/opentitanlib/src/backend/verilator.rs
@@ -16,10 +16,12 @@ pub struct VerilatorOpts {
     #[arg(long, default_value_t)]
     verilator_bin: String,
 
-    #[arg(long, default_value_t)]
-    verilator_rom: String,
+    #[arg(long, required = false)]
+    verilator_rom: Vec<String>,
     #[arg(long, required = false)]
     verilator_flash: Vec<String>,
+    #[arg(long, default_value_t)]
+    verilator_ctn_ram: String,
     #[arg(long, default_value_t)]
     verilator_otp: String,
 
@@ -39,8 +41,9 @@ impl Backend for VerilatorBackend {
     fn create_transport(_: &BackendOpts, args: &VerilatorOpts) -> Result<Box<dyn Transport>> {
         let options = Options {
             executable: args.verilator_bin.clone(),
-            rom_image: args.verilator_rom.clone(),
+            rom_images: args.verilator_rom.clone(),
             flash_images: args.verilator_flash.clone(),
+            ctn_ram_image: args.verilator_ctn_ram.clone(),
             otp_image: args.verilator_otp.clone(),
             extra_args: args.verilator_args.clone(),
             timeout: args.verilator_timeout,


### PR DESCRIPTION
Add support for loading multiple ROM images that will be required for Darjeeling.  This replaces the single 'rom' memory by multiple 'romX' (X=0..n) memories.

Code is based on the existing handling of multiple flash images.

Also, Earlgrey chip_sim_tb.cc is updated to support 'rom0' instead of 'rom'.