### PR TITLE
[hw,otp_ctrl,rtl] Replace mubi8_and_lo with mubi8_or_hi.

### DIFF
--- a/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -866,7 +866,7 @@ module otp_ctrl_part_buf
   ) u_prim_mubi8_sender_write_lock_pre (
     .clk_i,
     .rst_ni,
-    .mubi_i(mubi8_and_lo(dout_locked_q, access_i.write_lock)),
+    .mubi_i(mubi8_or_hi(dout_locked_q, access_i.write_lock)),
     .mubi_o(access_pre.write_lock)
   );
   prim_mubi8_sender #(
@@ -874,7 +874,7 @@ module otp_ctrl_part_buf
   ) u_prim_mubi8_sender_read_lock_pre (
     .clk_i,
     .rst_ni,
-    .mubi_i(mubi8_and_lo(dout_locked_q, access_i.read_lock)),
+    .mubi_i(mubi8_or_hi(dout_locked_q, access_i.read_lock)),
     .mubi_o(access_pre.read_lock)
   );
 
@@ -889,7 +889,7 @@ module otp_ctrl_part_buf
     ) u_prim_mubi8_sender_write_lock (
       .clk_i,
       .rst_ni,
-      .mubi_i(mubi8_and_lo(access_pre.write_lock, digest_locked)),
+      .mubi_i(mubi8_or_hi(access_pre.write_lock, digest_locked)),
       .mubi_o(access_o.write_lock)
     );
 
@@ -909,7 +909,7 @@ module otp_ctrl_part_buf
     ) u_prim_mubi8_sender_read_lock (
       .clk_i,
       .rst_ni,
-      .mubi_i(mubi8_and_lo(access_pre.read_lock, digest_locked)),
+      .mubi_i(mubi8_or_hi(access_pre.read_lock, digest_locked)),
       .mubi_o(access_o.read_lock)
     );
 

--- a/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -566,7 +566,7 @@ module otp_ctrl_part_unbuf
   ) u_prim_mubi8_sender_write_lock_pre (
     .clk_i,
     .rst_ni,
-    .mubi_i(mubi8_and_lo(init_locked, access_i.write_lock)),
+    .mubi_i(mubi8_or_hi(init_locked, access_i.write_lock)),
     .mubi_o(access_pre.write_lock)
   );
   prim_mubi8_sender #(
@@ -574,7 +574,7 @@ module otp_ctrl_part_unbuf
   ) u_prim_mubi8_sender_read_lock_pre (
     .clk_i,
     .rst_ni,
-    .mubi_i(mubi8_and_lo(init_locked, access_i.read_lock)),
+    .mubi_i(mubi8_or_hi(init_locked, access_i.read_lock)),
     .mubi_o(access_pre.read_lock)
   );
 
@@ -589,7 +589,7 @@ module otp_ctrl_part_unbuf
     ) u_prim_mubi8_sender_write_lock (
       .clk_i,
       .rst_ni,
-      .mubi_i(mubi8_and_lo(access_pre.write_lock, digest_locked)),
+      .mubi_i(mubi8_or_hi(access_pre.write_lock, digest_locked)),
       .mubi_o(access_o.write_lock)
     );
 
@@ -609,7 +609,7 @@ module otp_ctrl_part_unbuf
     ) u_prim_mubi8_sender_read_lock (
       .clk_i,
       .rst_ni,
-      .mubi_i(mubi8_and_lo(access_pre.read_lock, digest_locked)),
+      .mubi_i(mubi8_or_hi(access_pre.read_lock, digest_locked)),
       .mubi_o(access_o.read_lock)
     );
 

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -866,7 +866,7 @@ module otp_ctrl_part_buf
   ) u_prim_mubi8_sender_write_lock_pre (
     .clk_i,
     .rst_ni,
-    .mubi_i(mubi8_and_lo(dout_locked_q, access_i.write_lock)),
+    .mubi_i(mubi8_or_hi(dout_locked_q, access_i.write_lock)),
     .mubi_o(access_pre.write_lock)
   );
   prim_mubi8_sender #(
@@ -874,7 +874,7 @@ module otp_ctrl_part_buf
   ) u_prim_mubi8_sender_read_lock_pre (
     .clk_i,
     .rst_ni,
-    .mubi_i(mubi8_and_lo(dout_locked_q, access_i.read_lock)),
+    .mubi_i(mubi8_or_hi(dout_locked_q, access_i.read_lock)),
     .mubi_o(access_pre.read_lock)
   );
 
@@ -889,7 +889,7 @@ module otp_ctrl_part_buf
     ) u_prim_mubi8_sender_write_lock (
       .clk_i,
       .rst_ni,
-      .mubi_i(mubi8_and_lo(access_pre.write_lock, digest_locked)),
+      .mubi_i(mubi8_or_hi(access_pre.write_lock, digest_locked)),
       .mubi_o(access_o.write_lock)
     );
 
@@ -909,7 +909,7 @@ module otp_ctrl_part_buf
     ) u_prim_mubi8_sender_read_lock (
       .clk_i,
       .rst_ni,
-      .mubi_i(mubi8_and_lo(access_pre.read_lock, digest_locked)),
+      .mubi_i(mubi8_or_hi(access_pre.read_lock, digest_locked)),
       .mubi_o(access_o.read_lock)
     );
 

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -566,7 +566,7 @@ module otp_ctrl_part_unbuf
   ) u_prim_mubi8_sender_write_lock_pre (
     .clk_i,
     .rst_ni,
-    .mubi_i(mubi8_and_lo(init_locked, access_i.write_lock)),
+    .mubi_i(mubi8_or_hi(init_locked, access_i.write_lock)),
     .mubi_o(access_pre.write_lock)
   );
   prim_mubi8_sender #(
@@ -574,7 +574,7 @@ module otp_ctrl_part_unbuf
   ) u_prim_mubi8_sender_read_lock_pre (
     .clk_i,
     .rst_ni,
-    .mubi_i(mubi8_and_lo(init_locked, access_i.read_lock)),
+    .mubi_i(mubi8_or_hi(init_locked, access_i.read_lock)),
     .mubi_o(access_pre.read_lock)
   );
 
@@ -589,7 +589,7 @@ module otp_ctrl_part_unbuf
     ) u_prim_mubi8_sender_write_lock (
       .clk_i,
       .rst_ni,
-      .mubi_i(mubi8_and_lo(access_pre.write_lock, digest_locked)),
+      .mubi_i(mubi8_or_hi(access_pre.write_lock, digest_locked)),
       .mubi_o(access_o.write_lock)
     );
 
@@ -609,7 +609,7 @@ module otp_ctrl_part_unbuf
     ) u_prim_mubi8_sender_read_lock (
       .clk_i,
       .rst_ni,
-      .mubi_i(mubi8_and_lo(access_pre.read_lock, digest_locked)),
+      .mubi_i(mubi8_or_hi(access_pre.read_lock, digest_locked)),
       .mubi_o(access_o.read_lock)
     );
 

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -866,7 +866,7 @@ module otp_ctrl_part_buf
   ) u_prim_mubi8_sender_write_lock_pre (
     .clk_i,
     .rst_ni,
-    .mubi_i(mubi8_and_lo(dout_locked_q, access_i.write_lock)),
+    .mubi_i(mubi8_or_hi(dout_locked_q, access_i.write_lock)),
     .mubi_o(access_pre.write_lock)
   );
   prim_mubi8_sender #(
@@ -874,7 +874,7 @@ module otp_ctrl_part_buf
   ) u_prim_mubi8_sender_read_lock_pre (
     .clk_i,
     .rst_ni,
-    .mubi_i(mubi8_and_lo(dout_locked_q, access_i.read_lock)),
+    .mubi_i(mubi8_or_hi(dout_locked_q, access_i.read_lock)),
     .mubi_o(access_pre.read_lock)
   );
 
@@ -889,7 +889,7 @@ module otp_ctrl_part_buf
     ) u_prim_mubi8_sender_write_lock (
       .clk_i,
       .rst_ni,
-      .mubi_i(mubi8_and_lo(access_pre.write_lock, digest_locked)),
+      .mubi_i(mubi8_or_hi(access_pre.write_lock, digest_locked)),
       .mubi_o(access_o.write_lock)
     );
 
@@ -909,7 +909,7 @@ module otp_ctrl_part_buf
     ) u_prim_mubi8_sender_read_lock (
       .clk_i,
       .rst_ni,
-      .mubi_i(mubi8_and_lo(access_pre.read_lock, digest_locked)),
+      .mubi_i(mubi8_or_hi(access_pre.read_lock, digest_locked)),
       .mubi_o(access_o.read_lock)
     );
 

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -566,7 +566,7 @@ module otp_ctrl_part_unbuf
   ) u_prim_mubi8_sender_write_lock_pre (
     .clk_i,
     .rst_ni,
-    .mubi_i(mubi8_and_lo(init_locked, access_i.write_lock)),
+    .mubi_i(mubi8_or_hi(init_locked, access_i.write_lock)),
     .mubi_o(access_pre.write_lock)
   );
   prim_mubi8_sender #(
@@ -574,7 +574,7 @@ module otp_ctrl_part_unbuf
   ) u_prim_mubi8_sender_read_lock_pre (
     .clk_i,
     .rst_ni,
-    .mubi_i(mubi8_and_lo(init_locked, access_i.read_lock)),
+    .mubi_i(mubi8_or_hi(init_locked, access_i.read_lock)),
     .mubi_o(access_pre.read_lock)
   );
 
@@ -589,7 +589,7 @@ module otp_ctrl_part_unbuf
     ) u_prim_mubi8_sender_write_lock (
       .clk_i,
       .rst_ni,
-      .mubi_i(mubi8_and_lo(access_pre.write_lock, digest_locked)),
+      .mubi_i(mubi8_or_hi(access_pre.write_lock, digest_locked)),
       .mubi_o(access_o.write_lock)
     );
 
@@ -609,7 +609,7 @@ module otp_ctrl_part_unbuf
     ) u_prim_mubi8_sender_read_lock (
       .clk_i,
       .rst_ni,
-      .mubi_i(mubi8_and_lo(access_pre.read_lock, digest_locked)),
+      .mubi_i(mubi8_or_hi(access_pre.read_lock, digest_locked)),
       .mubi_o(access_o.read_lock)
     );
 


### PR DESCRIPTION
mubi8_and_lo and mubi8_or_hi do exactly the same thing but I think using mubi8_or_hi here makes the code more intuitive and easier to understand.

(After this change no other consumers for `mubi[0-9]*_[a-z]+_lo` exist.)

However, I'm open to discuss this. Maybe others find the previous code better?

~~Set as draft because I may not fully understand the intention/history of the previous code~~