### PR TITLE
[sw,cryptolib] Only return input errors on user errors

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/p384.c
+++ b/sw/device/lib/crypto/impl/ecc/p384.c
@@ -92,12 +92,12 @@ enum {
   /*
    * The expected instruction counts for constant time functions.
    */
-  kModeKeygenInsCnt = 1899010,
-  kModeKeygenSideloadInsCnt = 1898904,
-  kModeEcdhInsCnt = 1910613,
-  kModeEcdhSideloadInsCnt = 1910762,
-  kModeEcdsaSignInsCnt = 1546539,
-  kModeEcdsaSignSideloadInsCnt = 1546688,
+  kModeKeygenInsCnt = 1899012,
+  kModeKeygenSideloadInsCnt = 1898906,
+  kModeEcdhInsCnt = 1910611,
+  kModeEcdhSideloadInsCnt = 1910760,
+  kModeEcdsaSignInsCnt = 1546541,
+  kModeEcdsaSignSideloadInsCnt = 1546690,
 };
 
 static status_t p384_masked_scalar_write(p384_masked_scalar_t *src,

--- a/sw/otbn/crypto/p384_isoncurve_proj.s
+++ b/sw/otbn/crypto/p384_isoncurve_proj.s
@@ -58,16 +58,11 @@ p384_isoncurve_proj_check:
 
   /* Compare the two sides of the equation.
        FG0.Z <= (y^2) mod p == (x^2 + ax + b) mod p */
-  bn.sub    w0, w4, w2
-  bn.subb   w1, w5, w3
-
-  bn.cmp    w0, w31
-
+  bn.cmp    w4, w2
   /* Fail if FG0.Z is false. */
   jal       x1, trigger_fault_if_fg0_not_z
 
-  bn.cmp    w1, w31
-
+  bn.cmp    w5, w3
   /* Fail if FG0.Z is false. */
   jal       x1, trigger_fault_if_fg0_not_z
 


### PR DESCRIPTION
The error reported in case of the is on curve check should only be an input error when the initial public key check is executed. After the initial check, the is on curve check would only return an error in case of an FI attack. In that case we should not report the error as a user error.