### PR TITLE
[ci] Fix the Vivado report directory

### DIFF
--- a/.github/workflows/bitstream.yml
+++ b/.github/workflows/bitstream.yml
@@ -87,16 +87,16 @@ jobs:
           design_name=chip_${{ inputs.top_name }}_${{ inputs.design_suffix }}
 
           echo "Synthesis log"
-          cat $OBJ_DIR/hw/top_${{ inputs.top_name }}/${design_name}/build.fpga_${{ inputs.design_suffix }}/${vlnv_path}/synth-vivado/${vlnv_path}.runs/synth_1/runme.log || true
+          cat $OBJ_DIR/hw/top_${{ inputs.top_name }}/${design_name}/${vlnv_path}.runs/synth_1/runme.log || true
 
           echo "Implementation log"
-          cat $OBJ_DIR/hw/top_${{ inputs.top_name }}/${design_name}/build.fpga_${{ inputs.design_suffix }}/${vlnv_path}/synth-vivado/${vlnv_path}.runs/impl_1/runme.log || true
+          cat $OBJ_DIR/hw/top_${{ inputs.top_name }}/${design_name}/${vlnv_path}.runs/impl_1/runme.log || true
 
           echo "Utilization report"
-          cat $OBJ_DIR/hw/top_${{ inputs.top_name }}/${design_name}/build.fpga_${{ inputs.design_suffix }}/${vlnv_path}/synth-vivado/${vlnv_path}.runs/impl_1/${design_name}_utilization_placed.rpt || true
+          cat $OBJ_DIR/hw/top_${{ inputs.top_name }}/${design_name}/${vlnv_path}.runs/impl_1/${design_name}_utilization_placed.rpt || true
 
           echo "Timing summary report"
-          cat $OBJ_DIR/hw/top_${{ inputs.top_name }}/${design_name}/build.fpga_${{ inputs.design_suffix }}/${vlnv_path}/synth-vivado/${vlnv_path}.runs/impl_1/${design_name}_timing_summary_routed.rpt || true
+          cat $OBJ_DIR/hw/top_${{ inputs.top_name }}/${design_name}/${vlnv_path}.runs/impl_1/${design_name}_timing_summary_routed.rpt || true
 
       - name: Upload step outputs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
It's useful to see the Vivado logs and utilization/timing reports after synthesizing a new bitstream. Therefore, the workflow includes the "Display synthesis & implementation logs" stage. However, it appears to be reading the reports from the wrong directory.

For example, the [CI that built the latest bitstream for CW340](https://github.com/lowRISC/opentitan/actions/runs/18219649875/job/51876792872) didn't find the reports in the specified directories. During the build stage, it indicates that the reports are instead located in the directory specified by this PR.

