### PR TITLE
[bazel] Enable `--discard-locals` explicitly for linker

### DIFF
--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -46,6 +46,7 @@ cc_toolchain(
         ":symbol_garbage_collection",
         ":constructor_destructor",
         ":nostdinc",
+        ":discard_locals",
     ],
     enabled_features = [
         "@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features",
@@ -456,6 +457,13 @@ cc_args(
         # Instantiate global variables only once.
         "-fno-common",
     ],
+)
+
+# Strip local `.L` symbols at link time:
+cc_args(
+    name = "discard_locals",
+    actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
+    args = ["-Wl,--discard-locals"],
 )
 
 filegroup(


### PR DESCRIPTION
This flag is implicitly added when the toolchain is in "RISCVToolChain" mode (distinct from Baremetal mode) [^1] which is enabled if `crt0.o` is included in the toolchain [^2].

This may change in future builds of the toolchain, so we want to make this flag explicit now.

The hash of the ROM and ROM_EXT ELFs are unchanged with this commit, so I think there are no functional changes.

[^1]: https://github.com/llvm/llvm-project/blob/185b81e034ba60081023b6e59504dfffb560f3e3/clang/lib/Driver/ToolChains/RISCVToolchain.cpp#L166
[^2]: https://github.com/llvm/llvm-project/blob/e9f3be63d3928b24f3667d8aaadfbee9d325015f/clang/lib/Driver/ToolChains/BareMetal.cpp#L151