### PR TITLE
[doc,otbn] Update documentation on how to build OTBN software

### DIFF
--- a/hw/ip/otbn/doc/developing_otbn.md
+++ b/hw/ip/otbn/doc/developing_otbn.md
@@ -15,15 +15,15 @@ through the [GitHub issue tracker](https://github.com/lowRISC/opentitan/issues).
 
 ### Build OTBN software
 
-An assembler, linker and disassembler for OTBN can be found in
-`hw/ip/otbn/util`. These are wrappers around a RISC-V GCC and binutils toolchain
-so one must be available (see the OpenTitan documentation on [obtaining a
-toolchain](../../../../doc/getting_started/README.md#step-3-install-the-lowrisc-risc-v-toolchain).
-For more details about the toolchain, see the [user
-guide](../../../../doc/contributing/sw/otbn_sw.md)).
+An assembler, linker and disassembler for OTBN can be found in `hw/ip/otbn/util`
+(For more details about these tools see the [user guide](../../../../doc/contributing/sw/otbn_sw.md)).
 
-`otbn_as.py` and `otbn_ld.py` can be used to build .elf files for use with
-simulations. They work similarly to binutils programs they wrap.
+These tools are wrappers around a RISC-V and binutils toolchain so one must be available.
+The toolchain can be installed with the [`util/get-toolchain.py`](../../../../util/get-toolchain.py) script.
+Simply call the script from `$REPO_TOP` and make sure to select the correct architecture.
+
+When the toolchain is installed, the `otbn_as.py` and `otbn_ld.py` can be used to build .elf files for use with simulations.
+They work similarly to binutils programs they wrap.
 
 ```
 hw/ip/otbn/util/otbn_as.py -o prog_bin/prog.o prog.s


### PR DESCRIPTION
To build OTBN software a RISC-V toolchain must be installed as the assembler etc. are wrappers around it.
This commit updates the instructions how to install one using the `util/get-toolchain.py` script. The old documentation pointed to a dead link on how to install one.