### PR TITLE
[pentest] Add fpga_cw340_rom_ext targets for pentest

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/BUILD
@@ -23,6 +23,7 @@ PENTEST_EXEC_ENVS = dicts.add(
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
         "//hw/top_earlgrey:fpga_cw340_test_rom": None,
         "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
 )

--- a/sw/device/tests/penetrationtests/pentest.bzl
+++ b/sw/device/tests/penetrationtests/pentest.bzl
@@ -21,6 +21,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 PENTEST_EXEC_ENVS = {
     "//hw/top_earlgrey:fpga_cw340_test_rom": "fpga_cw340",
     "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": "fpga_cw340",
+    "//hw/top_earlgrey:fpga_cw340_rom_ext": "fpga_cw340",
 } | EARLGREY_SILICON_OWNER_ROM_EXT_ENVS
 
 FIRMWARE_DEPS_FI = [


### PR DESCRIPTION
The fpga_cw340_rom_ext targets include an RMA lifecycle test target for the CW340 FPGA which allows for GDB testing.