### PR TITLE
toolchains_llvm: patch to accept cros_sdk as a valid distro

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -56,6 +56,16 @@ single_version_override(
     version = "0.59.2",
 )
 
+# Support ChromeOS SDK environment as a Debian variant
+single_version_override(
+    module_name = "toolchains_llvm",
+    patch_strip = 1,
+    patches = [
+        "@lowrisc_opentitan//third_party/toolchains_llvm/patches:toolchains_llvm-distroname.patch",
+    ],
+    version = "1.1.2",
+)
+
 # Rust toolchain:
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.repository_set(

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -12444,7 +12444,7 @@
     },
     "@@toolchains_llvm+//toolchain/extensions:llvm.bzl%llvm": {
       "general": {
-        "bzlTransitiveDigest": "gIValQjM+EWFJiJontPjnV18YMBMwraBayY+hWCfPzA=",
+        "bzlTransitiveDigest": "HxwEOKblzgkrBdJaod2DqZgHCmDnoIAnw4pLFpW2a/4=",
         "usagesDigest": "Jb6PotMQZN8Bkcci0RaeWREszi3XXYBWBTFcB5sQmMw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/third_party/toolchains_llvm/patches/BUILD
+++ b/third_party/toolchains_llvm/patches/BUILD
@@ -1,0 +1,3 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0

--- a/third_party/toolchains_llvm/patches/toolchains_llvm-distroname.patch
+++ b/third_party/toolchains_llvm/patches/toolchains_llvm-distroname.patch
@@ -1,0 +1,13 @@
+diff --git a/toolchain/internal/release_name.bzl b/toolchain/internal/release_name.bzl
+index e3d4a54..d2e5a92 100755
+--- a/toolchain/internal/release_name.bzl
++++ b/toolchain/internal/release_name.bzl
+@@ -151,7 +151,7 @@ def _linux(llvm_version, distname, version, arch):
+         os_name = _ubuntu_osname(arch, "20.04", major_llvm_version, llvm_version)
+     elif distname == "linuxmint" and version.startswith("18"):
+         os_name = "linux-gnu-ubuntu-16.04"
+-    elif distname == "debian":
++    elif distname in ["cros_sdk", "debian"]:
+         int_version = 0
+         if version.isdigit():
+             int_version = int(version)


### PR DESCRIPTION
cros_sdk is the ChromeOS build environment which is a close match for Debian Linux distros.

Tested by building opentitantool in ChromeOS SDK environment.

Change-Id: Ic50e8cf57b6758fb1053a390e919beeefaabe7be