### PR TITLE
[crypto] Patch edge case in modinv_f4 yielding invalid private exponents

### DIFF
--- a/sw/otbn/crypto/rsa_keygen.s
+++ b/sw/otbn/crypto/rsa_keygen.s
@@ -1,3 +1,7 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 /* Copyright lowRISC contributors (OpenTitan project). */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
@@ -441,7 +445,7 @@ modinv_f4:
   addi     x31, x31, 17
 
   /* Main loop. */
-  loop     x31, 120
+  loop     x31, 122
     /* Load the least significant limb of v.
          w20 <= dmem[dptr_v] = v[255:0] */
     bn.lid   x20, 0(x15)
@@ -535,10 +539,13 @@ modinv_f4:
       /* FG1.C <= w23 <? m[i] + FG1.C */
       bn.cmpb  w23, w20, FG1
 
-    /* Capture FG1.C as a mask that is all 1s if we should subtract the modulus.
-         w26 <= FG1.C ? 0 : 2^256 - 1 */
+    /* Capture ~FG0.C & FG1.C as a mask that is all 1s if we should subtract
+       the modulus.
+         w26 <= (~FG0.C & FG1.C) ? 0 : 2^256 - 1 */
+    bn.subb  w23, w31, w31, FG0
     bn.subb  w26, w31, w31, FG1
     bn.not   w26, w26
+    bn.or    w26, w23, w26
 
     /* Clear flags for both groups. */
     bn.sub   w31, w31, w31, FG0


### PR DESCRIPTION
This PR introduces a small fix to a bug in the `modinv_f4` routine in `rsa_keygen.s` to prevent invalid RSA private keys from being computed. 

When computing a modular inverse, `modinv_f4` performs a version of the binary extended Euclidean algorithm (see HAC 14.61) which maintains a handful of intermediate values. See the block comment above `modinv_f4` for detailed pseudocode of the algorithm.

As part of the main loop of `modinv_f4`, the value `(A + C) mod m` is conditionally computed, where `A` and `C` are intermediate values and `m` is the modulus. To compute the modular reduction, a conditional subtraction is used in turn: `A + C` is  compared to `m` to determine whether a subtraction is needed.

To do this, a loop presently computes `A + C - m` limb by limb, tracking the carry of the addition in `FG0.C` and the borrow of the subtraction in `FG1.C`. If `w` is the modulus size in bits, then in the edge case where

- `(A + C) % 2^w < m` 
- but also `A + C > 2^w`, 

the result of the conditional subtraction will be the negative value `((A + C) % 2^w) - m` instead of the desired `A + C - m`. This represents the case where both `FG0.C` and `FG1.C` are set in the loop; as a fix, we exclude this case from triggering a conditional subtraction, setting the conditional subtraction mask to `(~FG0.C & FG1.C) ? 0 : 2^256 - 1` instead of `FG1.C ? 0 : 2^256 - 1`.

Based on simulation scripts, I've found that this edge does not trigger in the existing `modinv_f4_test.s` test case, but does trigger in a number of other cases. For an example value demonstrating the existing bug, the modulus

```m = 0xa1f2ca9b5cfaa6a3cc0f58c0505a44b7898874f88a9faee8de008a3e1323b8957506623de6da5976589ed46e82df1eb91f76c7a7b439f36721f8a349ba9b4785e1de7c51d5b52cb56efbf6d731f50578fa02d94591377cd73cd9c0364c8e4d943e3bc2779ab4901795adc515d5355bb4d5c4fb18dfaa27983ba43010805a81ee```

may be used.

Many thanks to @jadephilipoom for both refining the explanation of this bug, and for checking my work to make sure I wasn't missing anything.