### PR TITLE
[crypto] Fix trigger_fault_if_fg0_not_z implementation to properly fault

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/p256.c
+++ b/sw/device/lib/crypto/impl/ecc/p256.c
@@ -82,12 +82,12 @@ enum {
   /*
    * The expected instruction counts for constant time functions.
    */
-  kModeKeygenInsCnt = 574237,
-  kModeKeygenSideloadInsCnt = 574122,
-  kModeEcdhInsCnt = 581920,
-  kModeEcdhSideloadInsCnt = 581980,
-  kModeEcdsaSignInsCnt = 607411,
-  kModeEcdsaSignSideloadInsCnt = 607471,
+  kModeKeygenInsCnt = 574238,
+  kModeKeygenSideloadInsCnt = 574123,
+  kModeEcdhInsCnt = 581921,
+  kModeEcdhSideloadInsCnt = 581981,
+  kModeEcdsaSignInsCnt = 607412,
+  kModeEcdsaSignSideloadInsCnt = 607472,
 };
 
 static status_t p256_masked_scalar_write(p256_masked_scalar_t *src,

--- a/sw/device/lib/crypto/impl/ecc/p384.c
+++ b/sw/device/lib/crypto/impl/ecc/p384.c
@@ -92,12 +92,12 @@ enum {
   /*
    * The expected instruction counts for constant time functions.
    */
-  kModeKeygenInsCnt = 1899012,
-  kModeKeygenSideloadInsCnt = 1898906,
-  kModeEcdhInsCnt = 1910611,
-  kModeEcdhSideloadInsCnt = 1910760,
-  kModeEcdsaSignInsCnt = 1546541,
-  kModeEcdsaSignSideloadInsCnt = 1546690,
+  kModeKeygenInsCnt = 1899014,
+  kModeKeygenSideloadInsCnt = 1898908,
+  kModeEcdhInsCnt = 1910613,
+  kModeEcdhSideloadInsCnt = 1910762,
+  kModeEcdsaSignInsCnt = 1546543,
+  kModeEcdsaSignSideloadInsCnt = 1546692,
 };
 
 static status_t p384_masked_scalar_write(p384_masked_scalar_t *src,

--- a/sw/otbn/crypto/p256_base.s
+++ b/sw/otbn/crypto/p256_base.s
@@ -1,3 +1,7 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 /* Copyright lowRISC contributors (OpenTitan project). */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
@@ -95,7 +99,11 @@ trigger_fault_if_fg0_not_z:
        x2 <= FG0.Z */
   csrrw     x2, FG0, x0
   andi      x2, x2, 8
-  slli      x2, x2, 3
+  srli      x2, x2, 3
+
+  /* Subtract 1 from FG0.Z.
+       x2 <= x2 - 1 = FG0.Z ? 0 : 2^32 - 1 */
+  addi      x2, x2, -1
 
   /* The `bn.lid` instruction causes an `BAD_DATA_ADDR` error if the
      memory address is out of bounds. Therefore, if FG0.Z is 1, this

--- a/sw/otbn/crypto/p384_isoncurve.s
+++ b/sw/otbn/crypto/p384_isoncurve.s
@@ -1,3 +1,7 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 /* Copyright lowRISC contributors (OpenTitan project). */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
@@ -39,7 +43,11 @@ trigger_fault_if_fg0_not_z:
        x2 <= FG0.Z */
   csrrw     x2, FG0, x0
   andi      x2, x2, 8
-  slli      x2, x2, 3
+  srli      x2, x2, 3
+
+  /* Subtract 1 from FG0.Z.
+       x2 <= x2 - 1 = FG0.Z ? 0 : 2^32 - 1 */
+  addi      x2, x2, -1
 
   /* The `bn.lid` instruction causes an `BAD_DATA_ADDR` error if the
      memory address is out of bounds. Therefore, if FG0.Z is 1, this


### PR DESCRIPTION
Presently, `trigger_fault_if_fg0_not_z` fails to fault whether or not `FG0.Z` is set; this is because the present implementation 

- masks out the `FG0.Z` bit (bit 3 of `FG0`)
- performs a logical left-shift by 3 bits
- uses the result as the byte address for a `bn.lid` instruction.

If `FG0.Z` is unset, this accesses address 0, which doesn't fault. If `FG0.Z` is set, this accesses address `0b100 << 3 = 64`, also not yielding a fault.

This PR replaces the above logic with:

- masks out the `FG0.Z` bit (bit 3 of `FG0`)
- performs a logical right-shift by 3 bits
- subtracts 1 from the result,
- uses the result as the byte address for a `bn.lid` instruction.

If `FG0.Z` is unset, this yields a `bn.lid` with source byte address 0xFFFFFFFF, triggering a `BAD_DATA_ADDR` error. If `FG0.Z` is set, the byte address is 0, which doesn't trigger a fault.