### PR TITLE
[rom_ext] Deref symlinks in imm_section release tarball

### DIFF
--- a/util/gen_stamped_tarball.py
+++ b/util/gen_stamped_tarball.py
@@ -27,7 +27,7 @@ def main(args):
     if commit_status != 'clean':
         package_dir += f'-{commit_status}'
 
-    with tarfile.open(args.out, 'w') as tar:
+    with tarfile.open(args.out, 'w', dereference=True) as tar:
         for path in args.files:
             path = Path(path)
             tar.add(path, arcname=f'{package_dir}/{path.name}')


### PR DESCRIPTION
The `gen_stamped_tarball.py` script is used to create a release tarball for the imm_section rom_ext. By default, `tarfile.open()` does not dereference symbolic links, which means the tarball would contain broken symlinks if the imm_section rom_ext are symlinks.

This change adds `dereference=True` to `tarfile.open()` to ensure that symbolic links are followed and their target files are added to the tarball instead of the symlinks themselves.