### PR TITLE
[rules,qemu] Make the qemu test runner accepts qemu arguments

### DIFF
--- a/rules/scripts/qemu_test.sh
+++ b/rules/scripts/qemu_test.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# WARNING This is a template where some x strings will be expanded by
+# the rules in qemu.bzl.
+set -e
+
+qemu=__qemu__
+qemu_args=( __qemu_args__  )
+test_harness="__test_harness__"
+mutable_flash="__mutable_flash__"
+mutable_otp="__mutable_otp__"
+otp="__otp__"
+flash="__flash__"
+test_cmd=( __test_cmd__ )
+args=( __args__ )
+
+test_args=( "$@" )
+qemu_test_args=()
+harness_test_args=()
+# Intercept all test args of the form --qemu-arg=X
+# and pass X to qemu directly.
+# For convenience, a variant with "--qemu-args=X Y Z" is also
+# supported when all space-separated substrings of the arguments
+# will be expanded to different QEMU arguments.
+# Everything else will be passed as-in to the test harness.
+for this_arg in "${test_args[@]}"; do
+    if [[ $this_arg == --qemu-arg=* ]]; then
+        qemu_test_args+=( "${this_arg#--qemu-arg=}" )
+    elif [[ $this_arg == --qemu-args=* ]]; then
+        # See https://stackoverflow.com/a/45201229
+        # and https://unix.stackexchange.com/a/519917
+        readarray -t -d ' ' a < <(printf '%s' "${this_arg#--qemu-args=}")
+        qemu_test_args+=( "${a[@]}" )
+    else
+        harness_test_args+=( "$this_arg" )
+    fi
+done
+
+cleanup() {
+    rm -f "${mutable_otp}" "${mutable_flash}"
+    rm -f qemu-monitor qemu.log
+}
+trap cleanup EXIT
+
+# QEMU requires mutable flash and OTP files but Bazel only provides RO
+# files so we have to create copies unique to this test run.
+cp "${otp}" "${mutable_otp}" && chmod +w "${mutable_otp}"
+if [ -n "${flash}" ]; then
+    cp "${flash}" "${mutable_flash}" && chmod +w "${mutable_flash}"
+fi
+
+# QEMU disconnects from `stdout` when it daemonizes so we need to stream
+# the log through a pipe:
+mkfifo qemu.log && cat qemu.log &
+
+echo "Starting QEMU: ${qemu} ${qemu_test_args[*]} ${qemu_args[*]}"
+"${qemu}" "${qemu_test_args[@]}" "${qemu_args[@]}"
+
+echo "Invoking test: ${test_harness} ${args[*]} ${harness_test_args[*]} ${test_cmd[*]}"
+"${test_harness}" "${args[@]}" "${harness_test_args[@]}" "${test_cmd[@]}"


### PR DESCRIPTION
This commit changes the qemu test script in two ways. First, it is moved to a dedicated file. This has several advantages: it is more readable and can be checked by shellcheck. Since it's a template, I had to resort to some slight ugliness to make it work but the overall result is at least quite readable.

Second, the test script parses its arguments are forwards then to either qemu or the test harness. Specifically, any argument of the form:
`--qemu-arg=X` will forward X to qemu, and any argument of the form `--qemu-args=X,Y,Z`
will forward X, Y, Z (and so on) as *different* arguments to qemu.

This allows one to do, for example:
bazel test //path/to/qemu:test --test_arg=--qemu-args=--trace,ot_usbdev*

**Disclaimer:** I am not a bash expert, feel free to suggest improvements

**Open question:** where to document that?