### PR TITLE
[hw,pinmux,rtl] Remove sys reset when no strap sampling

### DIFF
--- a/hw/ip_templates/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip_templates/pinmux/data/pinmux.hjson.tpl
@@ -37,7 +37,9 @@
   clocking: [
     {clock: "clk_i", reset: "rst_ni", primary: true},
     {clock: "clk_aon_i", reset: "rst_aon_ni"},
+  % if enable_strap_sampling:
     {reset: "rst_sys_ni"}
+  % endif
   ]
   bus_interfaces: [
     { protocol: "tlul", direction: "device" }

--- a/hw/ip_templates/pinmux/rtl/pinmux.sv.tpl
+++ b/hw/ip_templates/pinmux/rtl/pinmux.sv.tpl
@@ -24,7 +24,9 @@ module pinmux
 ) (
   input                            clk_i,
   input                            rst_ni,
+% if enable_strap_sampling:
   input                            rst_sys_ni,
+% endif
   // Scan enable
   input  prim_mubi_pkg::mubi4_t    scanmode_i,
   // Slow always-on clock

--- a/hw/ip_templates/rstmgr/dv/env/seq_lib/rstmgr_leaf_rst_shadow_attack_vseq.sv.tpl
+++ b/hw/ip_templates/rstmgr/dv/env/seq_lib/rstmgr_leaf_rst_shadow_attack_vseq.sv.tpl
@@ -4,6 +4,7 @@
 // Description:
 // Test assert glitch to shadow leaf reset module and
 // check if nomal reset module got affected or vice versa
+<% has_sys_io_div4 = any(d.get('name') == 'sys_io_div4' for d in output_rsts) if output_rsts else False %>\
 class rstmgr_leaf_rst_shadow_attack_vseq extends rstmgr_base_vseq;
   `uvm_object_utils(rstmgr_leaf_rst_shadow_attack_vseq)
 
@@ -22,8 +23,10 @@ class rstmgr_leaf_rst_shadow_attack_vseq extends rstmgr_base_vseq;
   endtask : body
 
   task leaf_rst_attack(string npath, string gpath);
+% if has_sys_io_div4:
     // Wait for any bit in rst_sys_io_div4_n to become inactive.
     wait(|cfg.rstmgr_vif.resets_o.rst_sys_io_div4_n);
+% endif
     // Disable cascading reset assertions, since forcing related signals causes failures.
     cfg.rstmgr_cascading_sva_vif.disable_sva = 1'b1;
     `uvm_info(`gfn, $sformatf("Starting leaf attack between %s and %s", npath, gpath), UVM_MEDIUM)

--- a/hw/ip_templates/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv.tpl
+++ b/hw/ip_templates/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv.tpl
@@ -2,7 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-<% sorted_clks = sorted(list(clk_freqs.keys())) %>\
+<% 
+sorted_clks = sorted(list(clk_freqs.keys())) 
+has_sys_io_div4 = any(d.get('name') == 'sys_io_div4' for d in output_rsts) if output_rsts else False
+%>\
 // This has assertions that check the reset outputs of rstmgr cascade properly.
 // This means higher level resets always cause the lower level ones to assert.
 // The hierarchy is
@@ -151,11 +154,13 @@ interface rstmgr_cascading_sva_if (
     // The latter is checked independently in pwrmgr_rstmgr_sva_if.
     `CASCADED_ASSERTS(CascadeLcToSys, lc_rst_or_sys_req_n[pd], rst_sys_src_n[pd], SysCycles, clk_i)
 
+% if has_sys_io_div4:
     // Controlled by rst_sys_src_n.
     if (pd == rstmgr_pkg::DomainAonSel) begin : gen_sys_io_div4_chk
       `CASCADED_ASSERTS(CascadeSysToSysIoDiv4, rst_sys_src_n[pd], resets_o.rst_sys_io_div4_n[pd],
                         SysCycles, clk_io_div4_i)
     end
+% endif
   end
 
   // Aon to POR

--- a/hw/ip_templates/rstmgr/lint/rstmgr.waiver
+++ b/hw/ip_templates/rstmgr/lint/rstmgr.waiver
@@ -15,6 +15,9 @@ waive -rules TERMINAL_STATE -location {rstmgr_cnsty_chk.sv} -regexp {Terminal st
 waive -rules RESET_MUX -location {rstmgr.sv rstmgr_por.sv rstmgr_ctrl.sv} -regexp {Asynchronous reset '(resets_o\.)?rst_[A-Za-z_0-9]+_n(\[[0-9:]+\])?' is driven by a multiplexer} \
       -comment "This is dedicated reset infrastructure, and hence permissible"
 
+waive -rules RESET_MUX -location {rstmgr.sv} -regexp {Asynchronous reset 'scan_rst_ni' reaches a multiplexer here, used as a reset 'rst_dst_ni' at} \
+      -comment "This is dedicated reset infrastructure, and hence permissible"
+
 waive -rules RESET_MUX -location {rstmgr_leaf_rst.sv} -regexp {Asynchronous reset 'leaf_rst_o' is driven by a multiplexer} \
       -comment "This is dedicated reset infrastructure, and hence permissible"
 

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -347,20 +347,6 @@
         clock: main
       }
       {
-        name: sys_io_div4
-        gen: true
-        type: top
-        domains:
-        [
-          Aon
-        ]
-        shadowed: false
-        sw: false
-        path: rstmgr_aon_resets.rst_sys_io_div4_n
-        parent: sys_src
-        clock: io_div4
-      }
-      {
         name: spi_device
         gen: true
         type: top
@@ -3522,11 +3508,6 @@
         rst_aon_ni:
         {
           name: lc_aon
-          domain: Aon
-        }
-        rst_sys_ni:
-        {
-          name: sys_io_div4
           domain: Aon
         }
       }

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -158,7 +158,6 @@
       { name: "lc_io_div2",     gen: true,  type: "top", parent: "lc_src",  clock: "io_div2" }
       { name: "lc_io_div4",     gen: true,  type: "top", parent: "lc_src",  clock: "io_div4" }
       { name: "sys",            gen: true,  type: "top", parent: "sys_src", clock: "main"    }
-      { name: "sys_io_div4",    gen: true,  type: "top", parent: "sys_src", clock: "io_div4" }
       { name: "spi_device",     gen: true,  type: "top", parent: "lc_src", clock: "io_div4", sw: true }
       { name: "spi_host0",      gen: true,  type: "top", parent: "lc_src", clock: "io_div4", sw: true }
       { name: "i2c0",           gen: true,  type: "top", parent: "lc_src", clock: "io_div4", sw: true },
@@ -542,7 +541,6 @@
       clock_group: "powerup",
       reset_connections: {rst_ni: "lc_io_div4",
                           rst_aon_ni: "lc_aon",
-                          rst_sys_ni: "sys_io_div4"
                          },
       domain: ["Aon"],
       base_addr: {

--- a/hw/top_darjeeling/dv/autogen/rstmgr_tgl_excl.cfg
+++ b/hw/top_darjeeling/dv/autogen/rstmgr_tgl_excl.cfg
@@ -21,7 +21,6 @@
 -node tb.dut*.u_rstmgr_aon.resets_o.rst_lc_io_n[1]
 -node tb.dut*.u_rstmgr_aon.resets_o.rst_lc_io_div2_n[1]
 -node tb.dut*.u_rstmgr_aon.resets_o.rst_sys_n[0]
--node tb.dut*.u_rstmgr_aon.resets_o.rst_sys_io_div4_n[1]
 -node tb.dut*.u_rstmgr_aon.resets_o.rst_spi_device_n[0]
 -node tb.dut*.u_rstmgr_aon.resets_o.rst_spi_host0_n[0]
 -node tb.dut*.u_rstmgr_aon.resets_o.rst_i2c0_n[0]

--- a/hw/top_darjeeling/ip_autogen/pinmux/data/pinmux.hjson
+++ b/hw/top_darjeeling/ip_autogen/pinmux/data/pinmux.hjson
@@ -26,7 +26,6 @@
   clocking: [
     {clock: "clk_i", reset: "rst_ni", primary: true},
     {clock: "clk_aon_i", reset: "rst_aon_ni"},
-    {reset: "rst_sys_ni"}
   ]
   bus_interfaces: [
     { protocol: "tlul", direction: "device" }

--- a/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux.sv
+++ b/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux.sv
@@ -21,7 +21,6 @@ module pinmux
 ) (
   input                            clk_i,
   input                            rst_ni,
-  input                            rst_sys_ni,
   // Scan enable
   input  prim_mubi_pkg::mubi4_t    scanmode_i,
   // Slow always-on clock

--- a/hw/top_darjeeling/ip_autogen/rstmgr/data/top_darjeeling_rstmgr.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/data/top_darjeeling_rstmgr.ipconfig.hjson
@@ -223,20 +223,6 @@
         clock: main
       }
       {
-        name: sys_io_div4
-        gen: true
-        type: top
-        domains:
-        [
-          Aon
-        ]
-        shadowed: false
-        sw: false
-        path: rstmgr_aon_resets.rst_sys_io_div4_n
-        parent: sys_src
-        clock: io_div4
-      }
-      {
         name: spi_device
         gen: true
         type: top
@@ -422,20 +408,6 @@
         path: rstmgr_aon_resets.rst_sys_n
         parent: sys_src
         clock: main
-      }
-      {
-        name: sys_io_div4
-        gen: true
-        type: top
-        domains:
-        [
-          Aon
-        ]
-        shadowed: false
-        sw: false
-        path: rstmgr_aon_resets.rst_sys_io_div4_n
-        parent: sys_src
-        clock: io_div4
       }
       {
         name: spi_device

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/cov/rstmgr_tgl_excl.cfg
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/cov/rstmgr_tgl_excl.cfg
@@ -22,8 +22,6 @@
 -module_node rstmgr rst_en_o.lc_io_div2[Domain0Sel]
 -module_node rstmgr resets_o.rst_sys_n[DomainAonSel]
 -module_node rstmgr rst_en_o.sys[DomainAonSel]
--module_node rstmgr resets_o.rst_sys_io_div4_n[Domain0Sel]
--module_node rstmgr rst_en_o.sys_io_div4[Domain0Sel]
 -module_node rstmgr resets_o.rst_spi_device_n[DomainAonSel]
 -module_node rstmgr rst_en_o.spi_device[DomainAonSel]
 -module_node rstmgr resets_o.rst_spi_host0_n[DomainAonSel]

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/rstmgr_env_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/rstmgr_env_pkg.sv
@@ -49,8 +49,7 @@ package rstmgr_env_pkg;
     "u_daon_por",
     "u_daon_por_io",
     "u_daon_por_io_div2",
-    "u_daon_por_io_div4",
-    "u_daon_sys_io_div4"
+    "u_daon_por_io_div4"
   };
 
   // Instances of rstmgr_leaf_rst modules which have a shadow pair.

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/seq_lib/rstmgr_leaf_rst_shadow_attack_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/seq_lib/rstmgr_leaf_rst_shadow_attack_vseq.sv
@@ -22,8 +22,6 @@ class rstmgr_leaf_rst_shadow_attack_vseq extends rstmgr_base_vseq;
   endtask : body
 
   task leaf_rst_attack(string npath, string gpath);
-    // Wait for any bit in rst_sys_io_div4_n to become inactive.
-    wait(|cfg.rstmgr_vif.resets_o.rst_sys_io_div4_n);
     // Disable cascading reset assertions, since forcing related signals causes failures.
     cfg.rstmgr_cascading_sva_vif.disable_sva = 1'b1;
     `uvm_info(`gfn, $sformatf("Starting leaf attack between %s and %s", npath, gpath), UVM_MEDIUM)

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
@@ -152,11 +152,6 @@ interface rstmgr_cascading_sva_if (
     // The latter is checked independently in pwrmgr_rstmgr_sva_if.
     `CASCADED_ASSERTS(CascadeLcToSys, lc_rst_or_sys_req_n[pd], rst_sys_src_n[pd], SysCycles, clk_i)
 
-    // Controlled by rst_sys_src_n.
-    if (pd == rstmgr_pkg::DomainAonSel) begin : gen_sys_io_div4_chk
-      `CASCADED_ASSERTS(CascadeSysToSysIoDiv4, rst_sys_src_n[pd], resets_o.rst_sys_io_div4_n[pd],
-                        SysCycles, clk_io_div4_i)
-    end
   end
 
   // Aon to POR

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_rst_en_track_sva_if.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_rst_en_track_sva_if.sv
@@ -200,19 +200,6 @@ interface rstmgr_rst_en_track_sva_if (
           clk_main_i,
           !rst_por_ni)
 
-  `ASSERT(DAonRstSysIoDiv4EnTracksRstSysIoDiv4Active_A,
-          $fell(resets_i.rst_sys_io_div4_n[DomainAonSel]) |-> ##[0:DELAY]
-          reset_en_i.sys_io_div4[DomainAonSel] == prim_mubi_pkg::MuBi4True,
-          clk_io_div4_i,
-          !rst_por_ni)
-
-  `ASSERT(DAonRstSysIoDiv4EnTracksRstSysIoDiv4Inactive_A,
-          $rose(resets_i.rst_sys_io_div4_n[DomainAonSel]) |-> ##DELAY
-          !resets_i.rst_sys_io_div4_n[DomainAonSel] ||
-          reset_en_i.sys_io_div4[DomainAonSel] == prim_mubi_pkg::MuBi4False,
-          clk_io_div4_i,
-          !rst_por_ni)
-
   `ASSERT(D0RstSpiDeviceEnTracksRstSpiDeviceActive_A,
           $fell(resets_i.rst_spi_device_n[Domain0Sel]) |-> ##[0:DELAY]
           reset_en_i.spi_device[Domain0Sel] == prim_mubi_pkg::MuBi4True,

--- a/hw/top_darjeeling/ip_autogen/rstmgr/lint/rstmgr.waiver
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/lint/rstmgr.waiver
@@ -15,6 +15,9 @@ waive -rules TERMINAL_STATE -location {rstmgr_cnsty_chk.sv} -regexp {Terminal st
 waive -rules RESET_MUX -location {rstmgr.sv rstmgr_por.sv rstmgr_ctrl.sv} -regexp {Asynchronous reset '(resets_o\.)?rst_[A-Za-z_0-9]+_n(\[[0-9:]+\])?' is driven by a multiplexer} \
       -comment "This is dedicated reset infrastructure, and hence permissible"
 
+waive -rules RESET_MUX -location {rstmgr.sv} -regexp {Asynchronous reset 'scan_rst_ni' reaches a multiplexer here, used as a reset 'rst_dst_ni' at} \
+      -comment "This is dedicated reset infrastructure, and hence permissible"
+
 waive -rules RESET_MUX -location {rstmgr_leaf_rst.sv} -regexp {Asynchronous reset 'leaf_rst_o' is driven by a multiplexer} \
       -comment "This is dedicated reset infrastructure, and hence permissible"
 

--- a/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr.sv
@@ -186,12 +186,12 @@ module rstmgr
   ////////////////////////////////////////////////////
 
   // consistency check errors
-  logic [13:0][PowerDomains-1:0] cnsty_chk_errs;
-  logic [13:0][PowerDomains-1:0] shadow_cnsty_chk_errs;
+  logic [12:0][PowerDomains-1:0] cnsty_chk_errs;
+  logic [12:0][PowerDomains-1:0] shadow_cnsty_chk_errs;
 
   // consistency sparse fsm errors
-  logic [13:0][PowerDomains-1:0] fsm_errs;
-  logic [13:0][PowerDomains-1:0] shadow_fsm_errs;
+  logic [12:0][PowerDomains-1:0] fsm_errs;
+  logic [12:0][PowerDomains-1:0] shadow_fsm_errs;
 
   assign hw2reg.err_code.reg_intg_err.d  = 1'b1;
   assign hw2reg.err_code.reg_intg_err.de = reg_intg_err;
@@ -737,46 +737,12 @@ module rstmgr
   assign shadow_cnsty_chk_errs[9] = '0;
   assign shadow_fsm_errs[9] = '0;
 
-  // Generating resets for sys_io_div4
-  // Power Domains: ['Aon']
-  // Shadowed: False
-  rstmgr_leaf_rst #(
-    .SecCheck(SecCheck),
-    .SecMaxSyncDelay(SecMaxSyncDelay),
-    .SwRstReq(1'b0)
-  ) u_daon_sys_io_div4 (
-    .clk_i,
-    .rst_ni,
-    .leaf_clk_i(clk_io_div4_i),
-    .parent_rst_ni(rst_sys_src_n[DomainAonSel]),
-    .sw_rst_req_ni(1'b1),
-    .scan_rst_ni,
-    .scanmode_i,
-    .rst_en_o(rst_en_o.sys_io_div4[DomainAonSel]),
-    .leaf_rst_o(resets_o.rst_sys_io_div4_n[DomainAonSel]),
-    .err_o(cnsty_chk_errs[10][DomainAonSel]),
-    .fsm_err_o(fsm_errs[10][DomainAonSel])
-  );
-
-  if (SecCheck) begin : gen_daon_sys_io_div4_assert
-  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(
-    DAonSysIoDiv4FsmCheck_A,
-    u_daon_sys_io_div4.gen_rst_chk.u_rst_chk.u_state_regs,
-    alert_tx_o[0])
-  end
-  assign resets_o.rst_sys_io_div4_n[Domain0Sel] = '0;
-  assign cnsty_chk_errs[10][Domain0Sel] = '0;
-  assign fsm_errs[10][Domain0Sel] = '0;
-  assign rst_en_o.sys_io_div4[Domain0Sel] = MuBi4True;
-  assign shadow_cnsty_chk_errs[10] = '0;
-  assign shadow_fsm_errs[10] = '0;
-
   // Generating resets for spi_device
   // Power Domains: ['0']
   // Shadowed: False
   assign resets_o.rst_spi_device_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[11][DomainAonSel] = '0;
-  assign fsm_errs[11][DomainAonSel] = '0;
+  assign cnsty_chk_errs[10][DomainAonSel] = '0;
+  assign fsm_errs[10][DomainAonSel] = '0;
   assign rst_en_o.spi_device[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
@@ -792,8 +758,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.spi_device[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_spi_device_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[11][Domain0Sel]),
-    .fsm_err_o(fsm_errs[11][Domain0Sel])
+    .err_o(cnsty_chk_errs[10][Domain0Sel]),
+    .fsm_err_o(fsm_errs[10][Domain0Sel])
   );
 
   if (SecCheck) begin : gen_d0_spi_device_assert
@@ -802,15 +768,15 @@ module rstmgr
     u_d0_spi_device.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-  assign shadow_cnsty_chk_errs[11] = '0;
-  assign shadow_fsm_errs[11] = '0;
+  assign shadow_cnsty_chk_errs[10] = '0;
+  assign shadow_fsm_errs[10] = '0;
 
   // Generating resets for spi_host0
   // Power Domains: ['0']
   // Shadowed: False
   assign resets_o.rst_spi_host0_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[12][DomainAonSel] = '0;
-  assign fsm_errs[12][DomainAonSel] = '0;
+  assign cnsty_chk_errs[11][DomainAonSel] = '0;
+  assign fsm_errs[11][DomainAonSel] = '0;
   assign rst_en_o.spi_host0[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
@@ -826,8 +792,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.spi_host0[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_spi_host0_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[12][Domain0Sel]),
-    .fsm_err_o(fsm_errs[12][Domain0Sel])
+    .err_o(cnsty_chk_errs[11][Domain0Sel]),
+    .fsm_err_o(fsm_errs[11][Domain0Sel])
   );
 
   if (SecCheck) begin : gen_d0_spi_host0_assert
@@ -836,15 +802,15 @@ module rstmgr
     u_d0_spi_host0.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-  assign shadow_cnsty_chk_errs[12] = '0;
-  assign shadow_fsm_errs[12] = '0;
+  assign shadow_cnsty_chk_errs[11] = '0;
+  assign shadow_fsm_errs[11] = '0;
 
   // Generating resets for i2c0
   // Power Domains: ['0']
   // Shadowed: False
   assign resets_o.rst_i2c0_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[13][DomainAonSel] = '0;
-  assign fsm_errs[13][DomainAonSel] = '0;
+  assign cnsty_chk_errs[12][DomainAonSel] = '0;
+  assign fsm_errs[12][DomainAonSel] = '0;
   assign rst_en_o.i2c0[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
@@ -860,8 +826,8 @@ module rstmgr
     .scanmode_i,
     .rst_en_o(rst_en_o.i2c0[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_i2c0_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[13][Domain0Sel]),
-    .fsm_err_o(fsm_errs[13][Domain0Sel])
+    .err_o(cnsty_chk_errs[12][Domain0Sel]),
+    .fsm_err_o(fsm_errs[12][Domain0Sel])
   );
 
   if (SecCheck) begin : gen_d0_i2c0_assert
@@ -870,8 +836,8 @@ module rstmgr
     u_d0_i2c0.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-  assign shadow_cnsty_chk_errs[13] = '0;
-  assign shadow_fsm_errs[13] = '0;
+  assign shadow_cnsty_chk_errs[12] = '0;
+  assign shadow_fsm_errs[12] = '0;
 
 
   ////////////////////////////////////////////////////

--- a/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_pkg.sv
@@ -34,7 +34,6 @@ package rstmgr_pkg;
     logic [PowerDomains-1:0] rst_lc_io_div4_shadowed_n;
     logic [PowerDomains-1:0] rst_lc_io_div4_n;
     logic [PowerDomains-1:0] rst_sys_n;
-    logic [PowerDomains-1:0] rst_sys_io_div4_n;
     logic [PowerDomains-1:0] rst_spi_device_n;
     logic [PowerDomains-1:0] rst_spi_host0_n;
     logic [PowerDomains-1:0] rst_i2c0_n;
@@ -55,13 +54,12 @@ package rstmgr_pkg;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] lc_io_div4_shadowed;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] lc_io_div4;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] sys;
-    prim_mubi_pkg::mubi4_t [PowerDomains-1:0] sys_io_div4;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] spi_device;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] spi_host0;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] i2c0;
   } rstmgr_rst_en_t;
 
-  parameter int NumOutputRst = 17 * PowerDomains;
+  parameter int NumOutputRst = 16 * PowerDomains;
 
   // cpu reset requests and status
   typedef struct packed {

--- a/hw/top_darjeeling/lint/top_darjeeling.waiver
+++ b/hw/top_darjeeling/lint/top_darjeeling.waiver
@@ -19,22 +19,19 @@ waive -rules {HIER_BRANCH_NOT_READ INPUT_NOT_READ} -location {xbar_main.sv} \
 waive -rules RESET_MUX -location {top_darjeeling.sv} -regexp {Asynchronous reset .*rstmgr_aon_resets\.rst.* is driven by a multiplexer} \
       -comment "This is dedicated reset infrastructure, and hence permissible"
 
+waive -rules RESET_MUX -location {rstmgr.sv} -msg {Asynchronous reset 'scan_rst_ni' reaches a multiplexer here, used as a reset 'rst_dst_ni' at} \
+      -comment "This is dedicated reset infrastructure, and hence permissible"
+
 # scan reset is a legal asynchronous reset
 waive -rules RESET_USE -location {top_darjeeling.sv} -regexp {'scan_rst_ni' is connected to .* port 'scan_rst_ni', and used as an asynchronous reset or set 'rst_.*ni' at} \
       -comment "Scan reset is a legal asynchronous reset"
 
-# TODO: Remove waiver when #25410 is resolved
-waive -rules {HIER_BRANCH_NOT_READ} -location {pinmux.sv} \
-      -msg {Net 'rst_sys_ni' is not read from in module 'pinmux'} \
-      -comment "This signal is unused but cannot yet be gated in ipgen"
-
-# TODO: Remove waiver when #25410 is resolved
 waive -rules {HIER_BRANCH_NOT_READ} -location {pinmux.sv} \
       -msg {Net 'scanmode_i' is not read from in module 'pinmux'} \
-      -comment "This signal is unused but cannot yet be gated in ipgen"
+      -comment "scanmode_i is not used in the Darjeeling pad configuration"
 
-waive -rules INPUT_NOT_READ -location {pinmux.sv} -regexp {Input port '(rst_sys_ni|scanmode_i)' is not read from} \
-      -comment "This signal is unused but cannot yet be gated in ipgen."
+waive -rules INPUT_NOT_READ -location {pinmux.sv} -regexp {Input port 'scanmode_i' is not read from} \
+      -comment "scanmode_i is not used in the Darjeeling pad configuration"
 
 waive -rules {HIER_NET_NOT_READ NOT_READ} -location {clkmgr.sv} \
       -regexp {(Net|Signal) 'clk_io_root' is not read from in module 'clkmgr'} \

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -1007,15 +1007,11 @@ module top_darjeeling #(
     prim_mubi_pkg::mubi4_t unused_rst_en_20;
     assign unused_rst_en_20 = rstmgr_aon_rst_en.sys[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_21;
-    assign unused_rst_en_21 = rstmgr_aon_rst_en.sys_io_div4[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_21 = rstmgr_aon_rst_en.spi_device[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_22;
-    assign unused_rst_en_22 = rstmgr_aon_rst_en.sys_io_div4[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_22 = rstmgr_aon_rst_en.spi_host0[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_23;
-    assign unused_rst_en_23 = rstmgr_aon_rst_en.spi_device[rstmgr_pkg::DomainAonSel];
-    prim_mubi_pkg::mubi4_t unused_rst_en_24;
-    assign unused_rst_en_24 = rstmgr_aon_rst_en.spi_host0[rstmgr_pkg::DomainAonSel];
-    prim_mubi_pkg::mubi4_t unused_rst_en_25;
-    assign unused_rst_en_25 = rstmgr_aon_rst_en.i2c0[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_23 = rstmgr_aon_rst_en.i2c0[rstmgr_pkg::DomainAonSel];
 //VCS coverage on
 // pragma coverage on
 
@@ -1634,8 +1630,7 @@ module top_darjeeling #(
       .clk_i (clkmgr_aon_clocks.clk_io_div4_powerup),
       .clk_aon_i (clkmgr_aon_clocks.clk_aon_powerup),
       .rst_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::DomainAonSel]),
-      .rst_aon_ni (rstmgr_aon_resets.rst_lc_aon_n[rstmgr_pkg::DomainAonSel]),
-      .rst_sys_ni (rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel])
+      .rst_aon_ni (rstmgr_aon_resets.rst_lc_aon_n[rstmgr_pkg::DomainAonSel])
   );
   aon_timer #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[20:20]),

--- a/hw/top_earlgrey/ip_autogen/rstmgr/lint/rstmgr.waiver
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/lint/rstmgr.waiver
@@ -15,6 +15,9 @@ waive -rules TERMINAL_STATE -location {rstmgr_cnsty_chk.sv} -regexp {Terminal st
 waive -rules RESET_MUX -location {rstmgr.sv rstmgr_por.sv rstmgr_ctrl.sv} -regexp {Asynchronous reset '(resets_o\.)?rst_[A-Za-z_0-9]+_n(\[[0-9:]+\])?' is driven by a multiplexer} \
       -comment "This is dedicated reset infrastructure, and hence permissible"
 
+waive -rules RESET_MUX -location {rstmgr.sv} -regexp {Asynchronous reset 'scan_rst_ni' reaches a multiplexer here, used as a reset 'rst_dst_ni' at} \
+      -comment "This is dedicated reset infrastructure, and hence permissible"
+
 waive -rules RESET_MUX -location {rstmgr_leaf_rst.sv} -regexp {Asynchronous reset 'leaf_rst_o' is driven by a multiplexer} \
       -comment "This is dedicated reset infrastructure, and hence permissible"
 

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/lint/rstmgr.waiver
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/lint/rstmgr.waiver
@@ -15,6 +15,9 @@ waive -rules TERMINAL_STATE -location {rstmgr_cnsty_chk.sv} -regexp {Terminal st
 waive -rules RESET_MUX -location {rstmgr.sv rstmgr_por.sv rstmgr_ctrl.sv} -regexp {Asynchronous reset '(resets_o\.)?rst_[A-Za-z_0-9]+_n(\[[0-9:]+\])?' is driven by a multiplexer} \
       -comment "This is dedicated reset infrastructure, and hence permissible"
 
+waive -rules RESET_MUX -location {rstmgr.sv} -regexp {Asynchronous reset 'scan_rst_ni' reaches a multiplexer here, used as a reset 'rst_dst_ni' at} \
+      -comment "This is dedicated reset infrastructure, and hence permissible"
+
 waive -rules RESET_MUX -location {rstmgr_leaf_rst.sv} -regexp {Asynchronous reset 'leaf_rst_o' is driven by a multiplexer} \
       -comment "This is dedicated reset infrastructure, and hence permissible"
 


### PR DESCRIPTION
The sys reset in pinmux is only needed for the strap sampling logic. Since that feature is gated behind an ipgen parameter, also gate the reset with this flag and remove it for Darjeeling.

Closes https://github.com/lowRISC/opentitan/issues/25410