### PR TITLE
[doc] fix incorrect register references in FIFO watermark description

### DIFF
--- a/hw/ip/uart/doc/theory_of_operation.md
+++ b/hw/ip/uart/doc/theory_of_operation.md
@@ -166,9 +166,9 @@ UART module has a few interrupts including general data flow interrupts
 and unexpected event interrupts.
 
 #### tx_watermark / tx_empty / rx_watermark
-If the TX FIFO level becomes smaller than the TX water mark level (configurable via [`FIFO_CTRL.TXILVL`](registers.md#fifo_ctrl)), the `tx_watermark` interrupt is raised to inform SW.
+If the TX FIFO level becomes smaller than the TX water mark level (configurable via [`FIFO_CTRL.TXILVL`](registers.md#fifo_ctrl--txilvl)), the `tx_watermark` interrupt is raised to inform SW.
 If the TX FIFO is empty, the `tx_empty` interrupt is raised to inform SW.
-If the RX FIFO level becomes greater than or equal to RX water mark level (configurable via [`FIFO_CTRL.RXILVL`](registers.md#fifo_ctrl)), the `rx_watermark` interrupt is raised to inform SW.
+If the RX FIFO level becomes greater than or equal to RX water mark level (configurable via [`FIFO_CTRL.RXILVL`](registers.md#fifo_ctrl--rxilvl)), the `rx_watermark` interrupt is raised to inform SW.
 
 Note that the watermark interrupts and the empty interrupt are level-based status interrupts.
 They will stay asserted for as long as the FIFO levels are in violation of the configured level and cannot be cleared by writing to the status register.


### PR DESCRIPTION
This PR fixes incorrect register references in `hw/ip/uart/doc/theory_of_operation.md`.

Previously, both TX and RX watermark interrupt descriptions mentioned
`FIFO_CTRL.RXILVL` and `FIFO_CTRL.TXILVL`. Each interrupt should only reference
its relevant register:

- `tx_watermark` → `FIFO_CTRL.TXILVL`
- `rx_watermark` → `FIFO_CTRL.RXILVL`

This change corrects the documentation for accuracy and clarity.
