### PR TITLE
[sw,cov] Disable segment allocation for coverage bss sections

### DIFF
--- a/sw/device/lib/coverage/bss.ld
+++ b/sw/device/lib/coverage/bss.ld
@@ -22,7 +22,7 @@ __ot_coverage_bss (NOLOAD) : ALIGN(8) {
   ASSERT(
     DEFINED(_ot_coverage_enabled) || SIZEOF(__ot_coverage_bss) == 0,
     "__ot_coverage_bss section must be empty when coverage is disabled.");
-} > ram_main
+} > ram_main :NONE
 
 /* LLVM coverage counters. */
 . = ALIGN(8);
@@ -45,4 +45,4 @@ __llvm_prf_cnts : AT(0x0) ALIGN(8) {
   ASSERT(
     DEFINED(_ot_coverage_enabled) || SIZEOF(__llvm_prf_cnts) == 0,
     "__llvm_prf_cnts section must be empty when coverage is disabled.");
-} > ram_main
+} > ram_main :NONE


### PR DESCRIPTION
The `__llvm_prf_cnts` section is stripped during conversion to `.bin` files to save firmware size, as it's always filled with `0xff`.

However, unlike standard BSS, this section contains non-zero initial contents, leading the compiler to mark it as `PROGBITS` and loadable. This PR modifies the linker script to explicitly allocate this section to `NONE` segment, preventing the `qemu flashgen` tool from loading it.

The special `NONE` segment tells the linker to not put the section in any segment at all.