### PR TITLE
[cryptotest] Test AES-GCM using nist_cavp_aes_gcm vectors

### DIFF
--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -31,6 +31,25 @@ cryptotest(
     test_vectors = AES_TESTVECTOR_TARGETS,
 )
 
+AES_GCM_TESTVECTOR_TARGETS = [
+    "//sw/host/cryptotest/testvectors/data:nist_cavp_aes_gcm_{}_{}_json".format(operation, key_len)
+    for operation in ("encryptextiv", "decrypt")
+    for key_len in ("128", "192", "256")
+]
+
+AES_GCM_TESTVECTOR_ARGS = " ".join([
+    "--aes-gcm-json=\"$(rootpath {})\"".format(target)
+    for target in AES_GCM_TESTVECTOR_TARGETS
+])
+
+cryptotest(
+    name = "aes_gcm_kat",
+    slow_test = True,
+    test_args = AES_GCM_TESTVECTOR_ARGS,
+    test_harness = "//sw/host/tests/crypto/aes_gcm_nist_kat:harness",
+    test_vectors = AES_GCM_TESTVECTOR_TARGETS,
+)
+
 ECDSA_TESTVECTOR_TARGETS = [
     "//sw/host/cryptotest/testvectors/data:wycheproof_ecdsa_{}.json".format(config)
     for config in [

--- a/sw/device/tests/crypto/cryptotest/cryptotest.bzl
+++ b/sw/device/tests/crypto/cryptotest/cryptotest.bzl
@@ -27,6 +27,7 @@ CRYPTOTEST_EXEC_ENVS = {
 
 FIRMWARE_DEPS = [
     "//sw/device/tests/crypto/cryptotest/firmware:aes",
+    "//sw/device/tests/crypto/cryptotest/firmware:aes_gcm",
     "//sw/device/tests/crypto/cryptotest/firmware:drbg",
     "//sw/device/tests/crypto/cryptotest/firmware:ecdh",
     "//sw/device/tests/crypto/cryptotest/firmware:ecdsa",

--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -30,6 +30,25 @@ cc_library(
 )
 
 cc_library(
+    name = "aes_gcm",
+    srcs = ["aes_gcm.c"],
+    hdrs = ["aes_gcm.h"],
+    deps = [
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/crypto/impl:aes_gcm",
+        "//sw/device/lib/crypto/impl:integrity",
+        "//sw/device/lib/crypto/impl:keyblob",
+        "//sw/device/lib/crypto/include:datatypes",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:rand_testutils",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/tests/crypto/cryptotest/json:aes_gcm_commands",
+    ],
+)
+
+cc_library(
     name = "ecdsa",
     srcs = ["ecdsa.c"],
     hdrs = ["ecdsa.h"],
@@ -163,6 +182,7 @@ cc_library(
 
 FIRMWARE_DEPS = [
     ":aes",
+    ":aes_gcm",
     ":drbg",
     ":ecdh",
     ":ecdsa",

--- a/sw/device/tests/crypto/cryptotest/firmware/aes_gcm.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/aes_gcm.c
@@ -1,0 +1,203 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/include/aes_gcm.h"
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/impl/integrity.h"
+#include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/aes_gcm.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/rand_testutils.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/tests/crypto/cryptotest/json/aes_gcm_commands.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('m', 'c', 'g')
+
+enum {
+  kAesBlockBytes = 128 / 8,
+  kAesBlockWords = kAesBlockBytes / sizeof(uint32_t),
+  kAesMaxKeyBytes = 256 / 8,
+  kAesMaxKeyWords = kAesMaxKeyBytes / 4,
+};
+
+// Arbitrary mask for testing (borrowed from aes_functest.c).
+static const uint32_t kKeyMask[8] = {
+    0x1b81540c, 0x220733c9, 0x8bf85383, 0x05ab50b4,
+    0x8acdcb7e, 0x15e76440, 0x8459b2ce, 0xdc2110cc,
+};
+
+// Available security levels. The test randomly chooses one.
+static const otcrypto_key_security_level_t security_level[3] = {
+    kOtcryptoKeySecurityLevelLow,
+    kOtcryptoKeySecurityLevelMedium,
+    kOtcryptoKeySecurityLevelHigh,
+};
+
+status_t handle_aes_gcm_op(ujson_t *uj) {
+  cryptotest_aes_gcm_operation_t uj_op;
+  cryptotest_aes_gcm_data_t uj_data;
+  TRY(ujson_deserialize_cryptotest_aes_gcm_operation_t(uj, &uj_op));
+  TRY(ujson_deserialize_cryptotest_aes_gcm_data_t(uj, &uj_data));
+
+  // Encryption or decryption
+  bool op_enc;
+  switch (uj_op) {
+    case kCryptotestAesGcmOperationEncrypt:
+      op_enc = true;
+      break;
+    case kCryptotestAesGcmOperationDecrypt:
+      op_enc = false;
+      break;
+    default:
+      LOG_ERROR("Unrecognized AES operation: %d", uj_op);
+      return INVALID_ARGUMENT();
+  }
+
+  // Tag length.
+  otcrypto_aes_gcm_tag_len_t tag_len;
+  size_t tag_num_words;
+  switch (uj_data.tag_length) {
+    case (128 / 8):
+      tag_len = kOtcryptoAesGcmTagLen128;
+      tag_num_words = 4;
+      break;
+    case (96 / 8):
+      tag_len = kOtcryptoAesGcmTagLen96;
+      tag_num_words = 3;
+      break;
+    case (64 / 8):
+      tag_len = kOtcryptoAesGcmTagLen64;
+      tag_num_words = 2;
+      break;
+    case (32 / 8):
+      tag_len = kOtcryptoAesGcmTagLen32;
+      tag_num_words = 1;
+      break;
+    default:
+      LOG_ERROR("Unrecognized AES-GCM tag length: %d", uj_data.tag_length);
+      return INVALID_ARGUMENT();
+  }
+
+  // IV length. Only support 96- and 128-bit IV length.
+  size_t iv_num_words;
+  switch (uj_data.iv_length) {
+    case (12):
+      iv_num_words = 3;
+      break;
+    case (16):
+      iv_num_words = 4;
+      break;
+    default:
+      LOG_ERROR("Unrecognized AES-GCM IV length: %d", uj_data.iv_length);
+      return INVALID_ARGUMENT();
+  }
+
+  // Convert the data struct into cryptolib types
+  uint32_t iv_buf[iv_num_words];
+  memcpy(iv_buf, uj_data.iv, uj_data.iv_length);
+  otcrypto_const_word32_buf_t iv = {
+      .data = iv_buf,
+      .len = iv_num_words,
+  };
+
+  otcrypto_const_byte_buf_t input = {
+      .data = uj_data.input,
+      .len = (size_t)uj_data.input_length,
+  };
+
+  otcrypto_const_byte_buf_t aad = {
+      .data = uj_data.aad,
+      .len = uj_data.aad_length,
+  };
+
+  // Select a random security level.
+  size_t sec_lvl_idx = rand_testutils_gen32_range(
+      /*min=*/0, /*max=*/ARRAYSIZE(security_level) - 1);
+
+  // Build the key configuration
+  otcrypto_key_config_t config = {
+      .version = kOtcryptoLibVersion1,
+      .key_mode = kOtcryptoKeyModeAesGcm,
+      .key_length = uj_data.key_length,
+      .hw_backed = kHardenedBoolFalse,
+      .security_level = security_level[sec_lvl_idx],
+  };
+
+  // Create buffer to store key
+  uint32_t key_buf[kAesMaxKeyWords];
+  memcpy(key_buf, uj_data.key, kAesMaxKeyBytes);
+  // Create keyblob
+  uint32_t keyblob[keyblob_num_words(config)];
+  // Create blinded key
+  TRY(keyblob_from_key_and_mask(key_buf, kKeyMask, config, keyblob));
+  otcrypto_blinded_key_t key = {
+      .config = config,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+  };
+  key.checksum = integrity_blinded_checksum(&key);
+
+  uint8_t output_data[AES_GCM_CMD_MAX_MSG_BYTES];
+  otcrypto_byte_buf_t output = {
+      .data = output_data,
+      .len = uj_data.input_length,
+  };
+
+  uint32_t tag_data[tag_num_words];
+
+  hardened_bool_t tag_valid = kHardenedBoolTrue;
+
+  if (op_enc) {
+    otcrypto_word32_buf_t tag = {
+        .data = tag_data,
+        .len = tag_num_words,
+    };
+    TRY(otcrypto_aes_gcm_encrypt(&key, input, iv, aad, tag_len, output, tag));
+  } else {
+    memcpy(tag_data, uj_data.tag, uj_data.tag_length);
+    otcrypto_const_word32_buf_t tag = {
+        .data = tag_data,
+        .len = tag_num_words,
+    };
+    TRY(otcrypto_aes_gcm_decrypt(&key, input, iv, aad, tag_len, tag, output,
+                                 &tag_valid));
+  }
+
+  cryptotest_aes_gcm_output_t uj_output;
+  uj_output.output_len = uj_data.input_length;
+  memset(uj_output.output, 0, AES_GCM_CMD_MAX_MSG_BYTES);
+  memcpy(uj_output.output, output_data, uj_output.output_len);
+
+  uj_output.tag_len = uj_data.tag_length;
+  memset(uj_output.tag, 0, AES_GCM_CMD_MAX_TAG_BYTES);
+  memcpy(uj_output.tag, tag_data, uj_output.tag_len);
+
+  if (tag_valid == kHardenedBoolTrue) {
+    uj_output.tag_valid = true;
+  } else {
+    uj_output.tag_valid = false;
+  }
+
+  RESP_OK(ujson_serialize_cryptotest_aes_gcm_output_t, uj, &uj_output);
+  return OK_STATUS();
+}
+
+status_t handle_aes_gcm(ujson_t *uj) {
+  aes_gcm_subcommand_t cmd;
+  TRY(ujson_deserialize_aes_gcm_subcommand_t(uj, &cmd));
+  switch (cmd) {
+    case kAesGcmSubcommandAesGcmOp:
+      return handle_aes_gcm_op(uj);
+      break;
+    default:
+      LOG_ERROR("Unrecognized AES GCM subcommand: %d", cmd);
+      return INVALID_ARGUMENT();
+  }
+  return OK_STATUS();
+}

--- a/sw/device/tests/crypto/cryptotest/firmware/aes_gcm.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/aes_gcm.h
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_AES_GCM_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_AES_GCM_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+status_t handle_aes_gcm_op(ujson_t *uj);
+status_t handle_aes_gcm(ujson_t *uj);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_AES_GCM_H_

--- a/sw/device/tests/crypto/cryptotest/firmware/firmware.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/firmware.c
@@ -14,6 +14,7 @@
 
 // Include commands
 #include "sw/device/tests/crypto/cryptotest/json/aes_commands.h"
+#include "sw/device/tests/crypto/cryptotest/json/aes_gcm_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/drbg_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/ecdh_commands.h"
@@ -25,6 +26,7 @@
 
 // Include handlers
 #include "aes.h"
+#include "aes_gcm.h"
 #include "drbg.h"
 #include "ecdh.h"
 #include "ecdsa.h"
@@ -44,6 +46,9 @@ status_t process_cmd(ujson_t *uj) {
     switch (cmd) {
       case kCryptotestCommandAes:
         RESP_ERR(uj, handle_aes(uj));
+        break;
+      case kCryptotestCommandAesGcm:
+        RESP_ERR(uj, handle_aes_gcm(uj));
         break;
       case kCryptotestCommandDrbg:
         RESP_ERR(uj, handle_drbg(uj));

--- a/sw/device/tests/crypto/cryptotest/json/BUILD
+++ b/sw/device/tests/crypto/cryptotest/json/BUILD
@@ -10,6 +10,7 @@ cc_library(
     hdrs = ["commands.h"],
     deps = [
         ":aes_commands",
+        ":aes_gcm_commands",
         ":drbg_commands",
         ":ecdh_commands",
         ":ecdsa_commands",
@@ -24,6 +25,13 @@ cc_library(
     name = "aes_commands",
     srcs = ["aes_commands.c"],
     hdrs = ["aes_commands.h"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
+    name = "aes_gcm_commands",
+    srcs = ["aes_gcm_commands.c"],
+    hdrs = ["aes_gcm_commands.h"],
     deps = ["//sw/device/lib/ujson"],
 )
 

--- a/sw/device/tests/crypto/cryptotest/json/aes_gcm_commands.c
+++ b/sw/device/tests/crypto/cryptotest/json/aes_gcm_commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "aes_gcm_commands.h"

--- a/sw/device/tests/crypto/cryptotest/json/aes_gcm_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/aes_gcm_commands.h
@@ -1,0 +1,57 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_AES_GCM_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_AES_GCM_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MODULE_ID MAKE_MODULE_ID('j', 'b', 'e')
+
+#define AES_GCM_CMD_MAX_MSG_BYTES 64
+#define AES_GCM_CMD_MAX_KEY_BYTES 32  // 256 / 8
+#define AES_GCM_CMD_MAX_TAG_BYTES 16  // 128 / 8
+
+// clang-format off
+
+#define AES_GCM_SUBCOMMAND(_, value) \
+    value(_, AesGcmOp)
+UJSON_SERDE_ENUM(AesGcmSubcommand, aes_gcm_subcommand_t, AES_GCM_SUBCOMMAND);
+
+#define AES_GCM_OPERATION(_, value) \
+    value(_, Encrypt) \
+    value(_, Decrypt)
+UJSON_SERDE_ENUM(CryptotestAesGcmOperation, cryptotest_aes_gcm_operation_t, AES_GCM_OPERATION);
+
+#define AES_GCM_DATA(field, string) \
+    field(key, uint8_t, AES_GCM_CMD_MAX_KEY_BYTES) \
+    field(key_length, size_t) \
+    field(iv, uint8_t, 16) \
+    field(iv_length, size_t) \
+    field(input, uint8_t, AES_GCM_CMD_MAX_MSG_BYTES) \
+    field(input_length, size_t) \
+    field(aad, uint8_t, AES_GCM_CMD_MAX_MSG_BYTES) \
+    field(aad_length, size_t) \
+    field(tag, uint8_t, AES_GCM_CMD_MAX_TAG_BYTES) \
+    field(tag_length, size_t)
+UJSON_SERDE_STRUCT(CryptotestAesGcmData, cryptotest_aes_gcm_data_t, AES_GCM_DATA);
+
+#define AES_GCM_OUTPUT(field, string) \
+    field(output, uint8_t, AES_GCM_CMD_MAX_MSG_BYTES) \
+    field(output_len, size_t) \
+    field(tag, uint8_t, AES_GCM_CMD_MAX_TAG_BYTES) \
+    field(tag_len, size_t) \
+    field(tag_valid, bool)
+UJSON_SERDE_STRUCT(CryptotestAesGcmOutput, cryptotest_aes_gcm_output_t, AES_GCM_OUTPUT);
+
+#undef MODULE_ID
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_AES_GCM_COMMANDS_H_

--- a/sw/device/tests/crypto/cryptotest/json/commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/commands.h
@@ -13,6 +13,7 @@ extern "C" {
 
 #define COMMAND(_, value) \
     value(_, Aes) \
+    value(_, AesGcm) \
     value(_, Drbg) \
     value(_, Ecdsa) \
     value(_, Ecdh) \

--- a/sw/host/cryptotest/testvectors/parsers/nist_cavp_aes_gcm_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/nist_cavp_aes_gcm_parser.py
@@ -40,7 +40,32 @@ def parse_testcases(args) -> None:
         # https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/mac/gcmvs.pdf
         # Section 6.6.2
 
-        test_cases.append(test_case)
+        # The cryptolib currently supports tag lengths of (4,8,12,16)
+        # bytes and iv lengths of (12,16) bytes. Only select those
+        # tests.
+        tag_length_valid = False
+        if len(test_case["tag"]) in (4, 8, 12, 16):
+            tag_length_valid = True
+
+        iv_length_valid = False
+        if len(test_case["iv"]) in (12, 16):
+            iv_length_valid = True
+
+        aad_length_valid = False
+        if len(test_case["aad"]) < 64:
+            aad_length_valid = True
+
+        ciphertext_length_valid = False
+        if len(test_case["ciphertext"]) < 64:
+            ciphertext_length_valid = True
+
+        plaintext_length_valid = False
+        if len(test_case["plaintext"]) < 64:
+            plaintext_length_valid = True
+
+        if (tag_length_valid & iv_length_valid & aad_length_valid &
+                ciphertext_length_valid & plaintext_length_valid):
+            test_cases.append(test_case)
 
     json_filename = args.dst
     with open(json_filename, "w") as file:

--- a/sw/host/cryptotest/ujson_lib/BUILD
+++ b/sw/host/cryptotest/ujson_lib/BUILD
@@ -18,6 +18,11 @@ ujson_rust(
 )
 
 ujson_rust(
+    name = "aes_gcm_commands_rust",
+    srcs = ["//sw/device/tests/crypto/cryptotest/json:aes_gcm_commands"],
+)
+
+ujson_rust(
     name = "drbg_commands_rust",
     srcs = ["//sw/device/tests/crypto/cryptotest/json:drbg_commands"],
 )
@@ -56,6 +61,7 @@ rust_library(
     name = "cryptotest_commands",
     srcs = [
         "src/aes_commands.rs",
+        "src/aes_gcm_commands.rs",
         "src/commands.rs",
         "src/drbg_commands.rs",
         "src/ecdh_commands.rs",
@@ -69,6 +75,7 @@ rust_library(
     compile_data = [
         ":commands_rust",
         ":aes_commands_rust",
+        ":aes_gcm_commands_rust",
         ":ecdh_commands_rust",
         ":drbg_commands_rust",
         ":ecdsa_commands_rust",
@@ -80,6 +87,7 @@ rust_library(
     rustc_env = {
         "commands_loc": "$(execpath :commands_rust)",
         "aes_commands_loc": "$(execpath :aes_commands_rust)",
+        "aes_gcm_commands_loc": "$(execpath :aes_gcm_commands_rust)",
         "ecdh_commands_loc": "$(execpath :ecdh_commands_rust)",
         "drbg_commands_loc": "$(execpath :drbg_commands_rust)",
         "ecdsa_commands_loc": "$(execpath :ecdsa_commands_rust)",

--- a/sw/host/cryptotest/ujson_lib/src/aes_gcm_commands.rs
+++ b/sw/host/cryptotest/ujson_lib/src/aes_gcm_commands.rs
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+include!(env!("aes_gcm_commands_loc"));

--- a/sw/host/cryptotest/ujson_lib/src/lib.rs
+++ b/sw/host/cryptotest/ujson_lib/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 pub mod aes_commands;
+pub mod aes_gcm_commands;
 pub mod commands;
 pub mod drbg_commands;
 pub mod ecdh_commands;

--- a/sw/host/tests/crypto/aes_gcm_nist_kat/BUILD
+++ b/sw/host/tests/crypto/aes_gcm_nist_kat/BUILD
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:ujson.bzl", "ujson_rust")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "harness",
+    srcs = ["src/main.rs"],
+    deps = [
+        "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/crypto/aes_gcm_nist_kat/src/main.rs
+++ b/sw/host/tests/crypto/aes_gcm_nist_kat/src/main.rs
@@ -1,0 +1,165 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use arrayvec::ArrayVec;
+use clap::Parser;
+use std::fs;
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use cryptotest_commands::aes_gcm_commands::{
+    AesGcmSubcommand, CryptotestAesGcmData, CryptotestAesGcmOperation, CryptotestAesGcmOutput,
+};
+use cryptotest_commands::commands::CryptotestCommand;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::console::spi::SpiConsoleDevice;
+use opentitanlib::execute_test;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    // Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+
+    #[arg(long, num_args = 1..)]
+    aes_gcm_json: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AesGcmTestCase {
+    mode: String,
+    operation: String,
+    key_len: usize,
+    key: Vec<u8>,
+    aad: Vec<u8>,
+    iv: Vec<u8>,
+    tag: Vec<u8>,
+    ciphertext: Vec<u8>,
+    plaintext: Vec<u8>,
+    result: bool,
+}
+
+const AES_GCM_CMD_MAX_MSG_BYTES: usize = 64;
+const AES_GCM_CMD_MAX_KEY_BYTES: usize = 256 / 8;
+const AES_BLOCK_BYTES: usize = 128 / 8;
+
+fn run_aes_gcm_testcase(
+    test_case: &AesGcmTestCase,
+    opts: &Opts,
+    spi_console: &SpiConsoleDevice,
+) -> Result<()> {
+    assert_eq!(test_case.mode.as_str(), "gcm");
+    CryptotestCommand::AesGcm.send(spi_console)?;
+    AesGcmSubcommand::AesGcmOp.send(spi_console)?;
+
+    match test_case.operation.as_str() {
+        "encrypt" => CryptotestAesGcmOperation::Encrypt.send(spi_console)?,
+        "decrypt" => CryptotestAesGcmOperation::Decrypt.send(spi_console)?,
+        _ => panic!("Invalid AES-GCM operation"),
+    }
+
+    let mut iv: ArrayVec<u8, AES_BLOCK_BYTES> = ArrayVec::new();
+    iv.try_extend_from_slice(&test_case.iv)?;
+
+    let mut key: ArrayVec<u8, AES_GCM_CMD_MAX_KEY_BYTES> = ArrayVec::new();
+    key.try_extend_from_slice(&test_case.key)?;
+
+    // Configure input and output based on operation
+    let input_length;
+    let mut input: ArrayVec<u8, AES_GCM_CMD_MAX_MSG_BYTES> = ArrayVec::new();
+    let expected_output;
+    let expected_tag;
+    let expected_tag_check;
+    match test_case.operation.as_str() {
+        "encrypt" => {
+            input.try_extend_from_slice(&test_case.plaintext)?;
+            input_length = test_case.plaintext.len();
+            expected_output = &test_case.ciphertext;
+            expected_tag = &test_case.tag;
+            expected_tag_check = test_case.result;
+        }
+        "decrypt" => {
+            input.try_extend_from_slice(&test_case.ciphertext)?;
+            input_length = test_case.ciphertext.len();
+            expected_output = &test_case.plaintext;
+            expected_tag = &test_case.tag;
+            expected_tag_check = test_case.result;
+        }
+        _ => panic!("Invalid AES-GCM operation"),
+    }
+
+    CryptotestAesGcmData {
+        key,
+        key_length: test_case.key_len / 8,
+        iv,
+        iv_length: test_case.iv.len(),
+        input,
+        input_length,
+        aad: ArrayVec::try_from(test_case.aad.as_slice()).unwrap(),
+        aad_length: test_case.aad.len(),
+        tag: ArrayVec::try_from(test_case.tag.as_slice()).unwrap(),
+        tag_length: test_case.tag.len(),
+    }
+    .send(spi_console)?;
+
+    let aes_gcm_output = CryptotestAesGcmOutput::recv(spi_console, opts.timeout, false)?;
+
+    // Check if the tag comparison matches.
+    assert_eq!(aes_gcm_output.tag_valid, expected_tag_check);
+
+    // Check if the tag output matches.
+    assert_eq!(
+        aes_gcm_output.tag[0..test_case.tag.len()],
+        expected_tag[0..test_case.tag.len()]
+    );
+
+    if expected_tag_check {
+        // Only check output if the tag is valid as the testvectors don't
+        // have an output if the tag is invalid.
+        assert_eq!(
+            aes_gcm_output.output[0..input_length],
+            expected_output[0..input_length]
+        );
+    }
+
+    Ok(())
+}
+
+fn test_aes_gcm(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let spi = transport.spi("BOOTSTRAP")?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
+
+    let mut test_counter = 0u32;
+    let test_vector_files = &opts.aes_gcm_json;
+    for file in test_vector_files {
+        let raw_json = fs::read_to_string(file)?;
+        let aes_gcm_tests: Vec<AesGcmTestCase> = serde_json::from_str(&raw_json)?;
+
+        for aes_gcm_test in &aes_gcm_tests {
+            test_counter += 1;
+            log::info!("Test counter: {}", test_counter);
+            run_aes_gcm_testcase(aes_gcm_test, opts, &spi_console_device)?;
+        }
+    }
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    let transport = opts.init.init_target()?;
+    execute_test!(test_aes_gcm, &opts, &transport);
+    Ok(())
+}


### PR DESCRIPTION
This commit adds AES-GCM to the cryptotest framework. The test vectors are the [nist_cavp_aes_gcm](https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/mac/gcmtestvectors.zip) with 128, 192, 256 encrypt and decrypt.

As the cryptolib only supports tag sizes of 4,8,12,16 and iv sizes of 12, 16 bytes, other test vectors are filtered. Also, for performance reasons, only AAD, CTX, PTX sizes of 64 bytes and less are tested.