### PR TITLE
[crypto] Redundant GHASH computation as FI mitigation

### DIFF
--- a/sw/device/lib/crypto/impl/aes_gcm/aes_gcm.c
+++ b/sw/device/lib/crypto/impl/aes_gcm/aes_gcm.c
@@ -331,7 +331,16 @@ static status_t aes_gcm_get_tag(aes_gcm_context_t *ctx, size_t tag_len,
 
   // Append (len64(A) || len64(C)) and XOR the result with S1 to get the final
   // tag.
-  ghash_update(&ctx->ghash_ctx, kAesBlockNumBytes, (unsigned char *)last_block);
+  if (ctx->security_level != kOtcryptoKeySecurityLevelLow) {
+    // To mitigate FI, perform the GHASH update twice and compare the result.
+    ghash_update_redundant(&ctx->ghash_ctx, kAesBlockNumBytes,
+                           (unsigned char *)last_block);
+  } else {
+    HARDENED_CHECK_EQ(ctx->security_level, kOtcryptoKeySecurityLevelLow);
+    ghash_update(&ctx->ghash_ctx, kAesBlockNumBytes,
+                 (unsigned char *)last_block);
+  }
+
   aes_block_t full_tag;
   ghash_final(&ctx->ghash_ctx, full_tag.data);
 
@@ -497,8 +506,15 @@ status_t aes_gcm_update_encrypted_data(aes_gcm_context_t *ctx, size_t input_len,
   // yet, process the remaining partial AAD and update the state.
   size_t partial_ghash_block_len = ctx->aad_len % kGhashBlockNumBytes;
   if (ctx->input_len == 0 && partial_ghash_block_len != 0) {
-    ghash_update(&ctx->ghash_ctx, partial_ghash_block_len,
-                 (unsigned char *)ctx->partial_ghash_block.data);
+    if (ctx->security_level != kOtcryptoKeySecurityLevelLow) {
+      // To mitigate FI, perform the GHASH update twice and compare the result.
+      ghash_update_redundant(&ctx->ghash_ctx, partial_ghash_block_len,
+                             (unsigned char *)ctx->partial_ghash_block.data);
+    } else {
+      HARDENED_CHECK_EQ(ctx->security_level, kOtcryptoKeySecurityLevelLow);
+      ghash_update(&ctx->ghash_ctx, partial_ghash_block_len,
+                   (unsigned char *)ctx->partial_ghash_block.data);
+    }
   }
 
   // Process any full blocks of input with GCTR to generate more ciphertext.
@@ -553,8 +569,15 @@ status_t aes_gcm_final(aes_gcm_context_t *ctx, size_t tag_len, uint32_t *tag,
   size_t partial_ghash_block_len = ctx->aad_len % kGhashBlockNumBytes;
   if (ctx->input_len == 0 && partial_ghash_block_len != 0) {
     size_t partial_ghash_block_len = ctx->aad_len % kGhashBlockNumBytes;
-    ghash_update(&ctx->ghash_ctx, partial_ghash_block_len,
-                 (unsigned char *)ctx->partial_ghash_block.data);
+    if (ctx->security_level != kOtcryptoKeySecurityLevelLow) {
+      // To mitigate FI, perform the GHASH update twice and compare the result.
+      ghash_update_redundant(&ctx->ghash_ctx, partial_ghash_block_len,
+                             (unsigned char *)ctx->partial_ghash_block.data);
+    } else {
+      HARDENED_CHECK_EQ(ctx->security_level, kOtcryptoKeySecurityLevelLow);
+      ghash_update(&ctx->ghash_ctx, partial_ghash_block_len,
+                   (unsigned char *)ctx->partial_ghash_block.data);
+    }
   }
 
   // If a partial block of input data remains, pad it with zeroes and generate
@@ -580,14 +603,30 @@ status_t aes_gcm_final(aes_gcm_context_t *ctx, size_t tag_len, uint32_t *tag,
     // If a partial block of ciphertext (output for encryption) was generated,
     // accumulate in GHASH.
     if (*output_len > 0) {
-      ghash_update(&ctx->ghash_ctx, *output_len, (unsigned char *)output);
+      if (ctx->security_level != kOtcryptoKeySecurityLevelLow) {
+        // To mitigate FI, perform the GHASH update twice and compare the
+        // result.
+        ghash_update_redundant(&ctx->ghash_ctx, *output_len,
+                               (unsigned char *)output);
+      } else {
+        HARDENED_CHECK_EQ(ctx->security_level, kOtcryptoKeySecurityLevelLow);
+        ghash_update(&ctx->ghash_ctx, *output_len, (unsigned char *)output);
+      }
     }
   } else if (ctx->is_encrypt == kHardenedBoolFalse) {
     // If a partial block of ciphertext (input for decryption) remains,
     // accumulate it in GHASH.
     size_t partial_ghash_block_len = ctx->input_len % kGhashBlockNumBytes;
-    ghash_update(&ctx->ghash_ctx, partial_ghash_block_len,
-                 (unsigned char *)ctx->partial_ghash_block.data);
+    if (ctx->security_level != kOtcryptoKeySecurityLevelLow) {
+      // To mitigate FI, perform the GHASH update twice and compare the result.
+      ghash_update_redundant(&ctx->ghash_ctx, partial_ghash_block_len,
+                             (unsigned char *)ctx->partial_ghash_block.data);
+    } else {
+      HARDENED_CHECK_EQ(ctx->security_level, kOtcryptoKeySecurityLevelLow);
+      ghash_update(&ctx->ghash_ctx, partial_ghash_block_len,
+                   (unsigned char *)ctx->partial_ghash_block.data);
+    }
+
   } else {
     return OTCRYPTO_BAD_ARGS;
   }

--- a/sw/device/lib/crypto/impl/aes_gcm/ghash.h
+++ b/sw/device/lib/crypto/impl/aes_gcm/ghash.h
@@ -167,6 +167,21 @@ void ghash_process_full_blocks(ghash_context_t *ctx, size_t partial_len,
 void ghash_update(ghash_context_t *ctx, size_t input_len, const uint8_t *input);
 
 /**
+ * Redundant version of ghash_update().
+ *
+ * Creates a copy of ctx and executes ghash_update() twice.
+ * Compares the GHASH state stored in ctx after the redundant comparison.
+ * The comparison is done on share s0 to avoid introducing SCA leakage.
+ * If the comparison fails, trap.
+ *
+ * @param ctx Context object.
+ * @param input_len Number of bytes in the input.
+ * @param input Pointer to input buffer.
+ */
+void ghash_update_redundant(ghash_context_t *ctx, size_t input_len,
+                            const uint8_t *input);
+
+/**
  * Computes the correction terms needed for the masking scheme.
  *
  * correction_term0 = S0 * (H0 + 1).


### PR DESCRIPTION
Compute the GHASH state twice and compare it. When a mismatch due to a FI attack is detected, trap. The redundant check is only conducted for key.security_level > kOtcryptoKeySecurityLevelLow.