### PR TITLE
SpiFlash: Make skip-ff pages optimization optional.

### DIFF
--- a/sw/host/opentitanlib/src/spiflash/flash.rs
+++ b/sw/host/opentitanlib/src/spiflash/flash.rs
@@ -127,6 +127,7 @@ pub struct SpiFlash {
     pub sfdp: Option<Sfdp>,
     pub read_type: ReadTypes,
     pub erase: Vec<SectorErase>,
+    pub program_ff_optimization: bool,
 }
 
 impl Default for SpiFlash {
@@ -144,6 +145,7 @@ impl Default for SpiFlash {
                 opcode: SpiFlash::SECTOR_ERASE,
                 time: None,
             }],
+            program_ff_optimization: true,
         }
     }
 }
@@ -316,6 +318,7 @@ impl SpiFlash {
             sfdp: Some(sfdp),
             read_type,
             erase,
+            program_ff_optimization: true,
         }
     }
 
@@ -507,7 +510,7 @@ impl SpiFlash {
             let chunk_end = chunk_start + chunk_size;
             let chunk = &buffer[chunk_start..chunk_end];
             // Skip this chunk if all bytes are 0xff.
-            if !chunk.iter().all(|&x| x == 0xff) {
+            if !self.program_ff_optimization || !chunk.iter().all(|&x| x == 0xff) {
                 spi.run_eeprom_transactions(&mut [
                     Transaction::Command(MODE_111.cmd(SpiFlash::WRITE_ENABLE)),
                     Transaction::Write(


### PR DESCRIPTION
In some cases, we actually need to be able to send these transactions.