### PR TITLE
[bazel] Use absolute path in EARLGREY_SLOTS definition

### DIFF
--- a/hw/top_earlgrey/defs.bzl
+++ b/hw/top_earlgrey/defs.bzl
@@ -19,6 +19,6 @@ EARLGREY_SLOTS_COVERAGE = {
 }
 
 EARLGREY_SLOTS = select({
-    "//rules/coverage:enabled": EARLGREY_SLOTS_COVERAGE,
+    "@lowrisc_opentitan//rules/coverage:enabled": EARLGREY_SLOTS_COVERAGE,
     "//conditions:default": EARLGREY_SLOTS_NORMAL,
 })


### PR DESCRIPTION
The build failed when a target from an external repository depended on the `EARLGREY_SLOTS` variable. This was caused by a `select()` statement in the `EARLGREY_SLOTS` definition (`hw/top_earlgrey/defs.bzl`) that used a relative path (`//rules/coverage:enabled`) as a configuration key.

When evaluated from an external repository, Bazel incorrectly tried to resolve this path within that repository, leading to the error:
```
ERROR: no such package '@@+hooks+provisioning_exts//rules/coverage': ...
```
This commit fixes the immediate issue by making the path in the `EARLGREY_SLOTS` definition absolute, pointing to the main `@lowrisc_opentitan` repository.