### PR TITLE
[rescue] Update rescue GPIO param to unblock CI

### DIFF
--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -227,7 +227,7 @@ TEST_OWNER_CONFIGS = {
             "WITH_RESCUE_INDEX=2",
             # GPIO param 3 means enable the internal pull resistor and trigger
             # rescue when the GPIO is high.
-            "WITH_RESCUE_GPIO_PARAM=3",
+            "WITH_RESCUE_MISC_GPIO_PARAM=3",
             # Timeout: 0x80=enter_on_fail, 0x05 = 5 seconds.
             "WITH_RESCUE_TIMEOUT=0x85",
             "WITH_RESCUE_COMMAND_ALLOW=kRescueModeBootSvcReq",


### PR DESCRIPTION
The `spidfu_rescue_boot_svc_req_disability` test was introduced in #28385 and was passing its checks. However, a concurrent change in #28440 renamed the RESCUE_GPIO parameter to WITH_RESCUE_GPIO_PARAM.

This renaming was not propagated to the spidfu_rescue_boot_svc_req_disability owner config, causing CI to keep failing on `spidfu_rescue_boot_svc_req_disability` test and blocking the check.

This updates the parameter name to WITH_RESCUE_GPIO_PARAM in the configuration to resolve the CI failures.