### PR TITLE
[cryptotest] Test RSA verify using wycheproof vectors

### DIFF
--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -98,6 +98,70 @@ cryptotest(
     test_vectors = ECDH_TESTVECTOR_TARGETS,
 )
 
+RSA_TESTVECTOR_TARGETS = [
+    "//sw/host/cryptotest/testvectors/data:wycheproof_rsa_pkcs1_1.5_2048_{}.json".format(hash)
+    for hash in [
+        "sha256",
+        "sha384",
+        "sha512",
+        "sha3_256",
+        "sha3_384",
+        "sha3_512",
+    ]
+] + [
+    "//sw/host/cryptotest/testvectors/data:wycheproof_rsa_pkcs1_1.5_3072_{}.json".format(hash)
+    for hash in [
+        "sha256",
+        "sha384",
+        "sha512",
+        "sha3_256",
+        "sha3_384",
+        "sha3_512",
+    ]
+] + [
+    "//sw/host/cryptotest/testvectors/data:wycheproof_rsa_pkcs1_1.5_4096_{}.json".format(hash)
+    for hash in [
+        "sha256",
+        "sha384",
+        "sha512",
+    ]
+] + [
+    "//sw/host/cryptotest/testvectors/data:wycheproof_rsa_pss_2048_{}.json".format(hash)
+    for hash in [
+        "sha256_mgf1_0",
+        "sha256_mgf1_32",
+        "sha384_mgf1_48",
+    ]
+] + [
+    "//sw/host/cryptotest/testvectors/data:wycheproof_rsa_pss_3072_{}.json".format(hash)
+    for hash in [
+        "sha256_mgf1_32",
+        "shake128",
+    ]
+] + [
+    "//sw/host/cryptotest/testvectors/data:wycheproof_rsa_pss_4096_{}.json".format(hash)
+    for hash in [
+        "sha256_mgf1_32",
+        "sha384_mgf1_48",
+        "sha512_mgf1_32",
+        "sha512_mgf1_64",
+        "shake256",
+    ]
+]
+
+RSA_TESTVECTOR_ARGS = " ".join([
+    "--rsa-json=\"$(rootpath {})\"".format(target)
+    for target in RSA_TESTVECTOR_TARGETS
+])
+
+cryptotest(
+    name = "rsa_kat",
+    slow_test = True,
+    test_args = RSA_TESTVECTOR_ARGS,
+    test_harness = "//sw/host/tests/crypto/rsa_kat:harness",
+    test_vectors = RSA_TESTVECTOR_TARGETS,
+)
+
 SHA256_TESTVECTOR_TARGETS = [
     "//sw/host/cryptotest/testvectors/data:nist_cavp_sha2_fips_180_4_sha256_{}_json".format(
         msg_type.lower(),

--- a/sw/device/tests/crypto/cryptotest/cryptotest.bzl
+++ b/sw/device/tests/crypto/cryptotest/cryptotest.bzl
@@ -33,6 +33,7 @@ FIRMWARE_DEPS = [
     "//sw/device/tests/crypto/cryptotest/firmware:hash",
     "//sw/device/tests/crypto/cryptotest/firmware:hmac",
     "//sw/device/tests/crypto/cryptotest/firmware:kmac",
+    "//sw/device/tests/crypto/cryptotest/firmware:rsa",
     "//sw/device/tests/crypto/cryptotest/firmware:sphincsplus",
     "//sw/device/lib/base:csr",
     "//sw/device/lib/base:status",

--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -126,6 +126,28 @@ cc_library(
 )
 
 cc_library(
+    name = "rsa",
+    srcs = ["rsa.c"],
+    hdrs = ["rsa.h"],
+    deps = [
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/crypto/impl:integrity",
+        "//sw/device/lib/crypto/impl:keyblob",
+        "//sw/device/lib/crypto/impl:rsa",
+        "//sw/device/lib/crypto/impl:sha2",
+        "//sw/device/lib/crypto/impl:sha3",
+        "//sw/device/lib/crypto/include:crypto_hdrs",
+        "//sw/device/lib/crypto/include:datatypes",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:rand_testutils",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/tests/crypto/cryptotest/json:rsa_commands",
+    ],
+)
+
+cc_library(
     name = "sphincsplus",
     srcs = ["sphincsplus.c"],
     hdrs = ["sphincsplus.h"],
@@ -169,6 +191,7 @@ FIRMWARE_DEPS = [
     ":hash",
     ":hmac",
     ":kmac",
+    ":rsa",
     ":sphincsplus",
     "//sw/device/lib/base:csr",
     "//sw/device/lib/base:status",

--- a/sw/device/tests/crypto/cryptotest/firmware/firmware.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/firmware.c
@@ -21,6 +21,7 @@
 #include "sw/device/tests/crypto/cryptotest/json/hash_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/hmac_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/kmac_commands.h"
+#include "sw/device/tests/crypto/cryptotest/json/rsa_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/sphincsplus_commands.h"
 
 // Include handlers
@@ -31,6 +32,7 @@
 #include "hash.h"
 #include "hmac.h"
 #include "kmac.h"
+#include "rsa.h"
 #include "sphincsplus.h"
 
 OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
@@ -62,6 +64,9 @@ status_t process_cmd(ujson_t *uj) {
         break;
       case kCryptotestCommandKmac:
         RESP_ERR(uj, handle_kmac(uj));
+        break;
+      case kCryptotestCommandRsa:
+        RESP_ERR(uj, handle_rsa(uj));
         break;
       case kCryptotestCommandSphincsPlus:
         RESP_ERR(uj, handle_sphincsplus(uj));

--- a/sw/device/tests/crypto/cryptotest/firmware/rsa.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/rsa.c
@@ -1,0 +1,241 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/include/rsa.h"
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/impl/integrity.h"
+#include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/sha2.h"
+#include "sw/device/lib/crypto/include/sha3.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/rand_testutils.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/tests/crypto/cryptotest/json/rsa_commands.h"
+
+enum {
+  /**
+   * Supported public exponent.
+   */
+  kCryptotestRsaSupportedE = 65537,
+  /**
+   * RSA padding modes.
+   */
+  kCryptotestRsaPaddingPkcs = 0,
+  kCryptotestRsaPaddingPss = 1,
+  /**
+   * Number of words for different RSA modes.
+   */
+  kCryptotestRsa2048NumWords =
+      kOtcryptoRsa2048PublicKeyBytes / sizeof(uint32_t),
+  kCryptotestRsa3072NumWords =
+      kOtcryptoRsa3072PublicKeyBytes / sizeof(uint32_t),
+  kCryptotestRsa4096NumWords =
+      kOtcryptoRsa4096PublicKeyBytes / sizeof(uint32_t),
+  /**
+   * Different hashing modes.
+   */
+  kCryptotestRsaSha256 = 0,
+  kCryptotestRsaSha384 = 1,
+  kCryptotestRsaSha512 = 2,
+  kCryptotestRsaSha3_256 = 3,
+  kCryptotestRsaSha3_384 = 4,
+  kCryptotestRsaSha3_512 = 5,
+  kCryptotestRsaShake128 = 6,
+  kCryptotestRsaShake256 = 7,
+};
+
+status_t handle_rsa_verify(ujson_t *uj) {
+  cryptotest_rsa_verify_t uj_input;
+  TRY(ujson_deserialize_cryptotest_rsa_verify_t(uj, &uj_input));
+
+  if (uj_input.e != kCryptotestRsaSupportedE) {
+    LOG_ERROR("Unsupported RSA public exponent e: %d", uj_input.e);
+    return INVALID_ARGUMENT();
+  }
+
+  size_t rsa_num_words;
+  size_t n_bytes = uj_input.security_level / 8;
+  otcrypto_rsa_size_t rsa_size;
+  switch (n_bytes) {
+    case kOtcryptoRsa2048PublicKeyBytes:
+      rsa_size = kOtcryptoRsaSize2048;
+      rsa_num_words = kCryptotestRsa2048NumWords;
+      break;
+    case kOtcryptoRsa3072PublicKeyBytes:
+      rsa_size = kOtcryptoRsaSize3072;
+      rsa_num_words = kCryptotestRsa3072NumWords;
+      break;
+    case kOtcryptoRsa4096PublicKeyBytes:
+      rsa_size = kOtcryptoRsaSize4096;
+      rsa_num_words = kCryptotestRsa4096NumWords;
+      break;
+    default:
+      LOG_ERROR("Unsupported RSA security_level: %d", uj_input.security_level);
+      return INVALID_ARGUMENT();
+  }
+
+  otcrypto_hash_mode_t hash_mode;
+  size_t hash_digest_words;
+  switch (uj_input.hashing) {
+    case kCryptotestRsaSha256:
+      hash_mode = kOtcryptoHashModeSha256;
+      hash_digest_words = 256 / 32;
+      break;
+    case kCryptotestRsaSha384:
+      hash_mode = kOtcryptoHashModeSha384;
+      hash_digest_words = 384 / 32;
+      break;
+    case kCryptotestRsaSha512:
+      hash_mode = kOtcryptoHashModeSha512;
+      hash_digest_words = 512 / 32;
+      break;
+    case kCryptotestRsaSha3_256:
+      hash_mode = kOtcryptoHashModeSha3_256;
+      hash_digest_words = 256 / 32;
+      break;
+    case kCryptotestRsaSha3_384:
+      hash_mode = kOtcryptoHashModeSha3_384;
+      hash_digest_words = 384 / 32;
+      break;
+    case kCryptotestRsaSha3_512:
+      hash_mode = kOtcryptoHashModeSha3_512;
+      hash_digest_words = 512 / 32;
+      break;
+    case kCryptotestRsaShake128:
+      hash_mode = kOtcryptoHashXofModeShake128;
+      hash_digest_words = 128 / 32;
+      break;
+    case kCryptotestRsaShake256:
+      hash_mode = kOtcryptoHashXofModeShake256;
+      hash_digest_words = 256 / 32;
+      break;
+    default:
+      LOG_ERROR("Unsupported RSA hash mode: %d", uj_input.hashing);
+      return INVALID_ARGUMENT();
+  }
+
+  otcrypto_key_mode_t key_mode;
+  otcrypto_rsa_padding_t padding_mode;
+  switch (uj_input.padding) {
+    case kCryptotestRsaPaddingPkcs:
+      padding_mode = kOtcryptoRsaPaddingPkcs;
+      key_mode = kOtcryptoKeyModeRsaSignPkcs;
+      break;
+    case kCryptotestRsaPaddingPss:
+      padding_mode = kOtcryptoRsaPaddingPss;
+      key_mode = kOtcryptoKeyModeRsaSignPss;
+      break;
+    default:
+      LOG_ERROR("Unsupported RSA padding mode: %d", uj_input.padding);
+      return INVALID_ARGUMENT();
+  };
+
+  // Create the modulus N buffer.
+  uint32_t n_buf[rsa_num_words];
+  memset(n_buf, 0, sizeof(n_buf));
+  memcpy(n_buf, uj_input.n, n_bytes);
+
+  otcrypto_const_word32_buf_t modulus = {
+      .data = n_buf,
+      .len = rsa_num_words,
+  };
+
+  // Create the public key.
+  uint32_t public_key_data[rsa_num_words];
+  otcrypto_unblinded_key_t public_key = {
+      .key_mode = key_mode,
+      .key_length = n_bytes,
+      .key = public_key_data,
+  };
+  TRY(otcrypto_rsa_public_key_construct(rsa_size, modulus, &public_key));
+
+  // Create the signature buffer.
+  uint32_t sig_buf[rsa_num_words];
+  memset(sig_buf, 0, sizeof(sig_buf));
+  memcpy(sig_buf, uj_input.sig, uj_input.sig_len);
+
+  otcrypto_const_word32_buf_t sig = {
+      .data = sig_buf,
+      .len = rsa_num_words,
+  };
+
+  // Copy the message into the buffer.
+  uint8_t msg[uj_input.msg_len];
+  memcpy(msg, uj_input.msg, uj_input.msg_len);
+  otcrypto_const_byte_buf_t msg_buf = {
+      .len = uj_input.msg_len,
+      .data = msg,
+  };
+
+  // Buffer to store the digest.
+  uint32_t msg_digest_data[hash_digest_words];
+  otcrypto_hash_digest_t msg_digest = {
+      .data = msg_digest_data,
+      .len = ARRAYSIZE(msg_digest_data),
+      .mode = hash_mode,
+  };
+
+  // Hash the message.
+  switch (hash_mode) {
+    case kOtcryptoHashModeSha256:
+      TRY(otcrypto_sha2_256(msg_buf, &msg_digest));
+      break;
+    case kOtcryptoHashModeSha384:
+      TRY(otcrypto_sha2_384(msg_buf, &msg_digest));
+      break;
+    case kOtcryptoHashModeSha512:
+      TRY(otcrypto_sha2_512(msg_buf, &msg_digest));
+      break;
+    case kOtcryptoHashModeSha3_256:
+      TRY(otcrypto_sha3_256(msg_buf, &msg_digest));
+      break;
+    case kOtcryptoHashModeSha3_384:
+      TRY(otcrypto_sha3_384(msg_buf, &msg_digest));
+      break;
+    case kOtcryptoHashModeSha3_512:
+      TRY(otcrypto_sha3_512(msg_buf, &msg_digest));
+      break;
+    case kOtcryptoHashXofModeShake128:
+      TRY(otcrypto_shake128(msg_buf, &msg_digest));
+      break;
+    case kOtcryptoHashXofModeShake256:
+      TRY(otcrypto_shake256(msg_buf, &msg_digest));
+      break;
+    default:
+      LOG_ERROR("Unsupported RSA hash mode: %d", uj_input.hashing);
+      return INVALID_ARGUMENT();
+  }
+
+  hardened_bool_t verification_result;
+  TRY(otcrypto_rsa_verify(&public_key, msg_digest, padding_mode, sig,
+                          &verification_result));
+
+  // Return verification result back to host.
+  cryptotest_rsa_verify_resp_t uj_output;
+
+  uj_output.result = true;
+  if (verification_result != kHardenedBoolTrue) {
+    uj_output.result = false;
+  }
+
+  RESP_OK(ujson_serialize_cryptotest_rsa_verify_resp_t, uj, &uj_output);
+  return OK_STATUS();
+}
+
+status_t handle_rsa(ujson_t *uj) {
+  rsa_subcommand_t cmd;
+  TRY(ujson_deserialize_rsa_subcommand_t(uj, &cmd));
+  switch (cmd) {
+    case kRsaSubcommandRsaVerify:
+      return handle_rsa_verify(uj);
+    default:
+      LOG_ERROR("Unrecognized RSA subcommand: %d", cmd);
+      return INVALID_ARGUMENT();
+  }
+  return OK_STATUS();
+}

--- a/sw/device/tests/crypto/cryptotest/firmware/rsa.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/rsa.h
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_RSA_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_RSA_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+status_t handle_rsa_verify(ujson_t *uj);
+status_t handle_rsa(ujson_t *uj);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_RSA_H_

--- a/sw/device/tests/crypto/cryptotest/json/BUILD
+++ b/sw/device/tests/crypto/cryptotest/json/BUILD
@@ -16,6 +16,7 @@ cc_library(
         ":hash_commands",
         ":hmac_commands",
         ":kmac_commands",
+        ":rsa_commands",
         "//sw/device/lib/ujson",
     ],
 )
@@ -66,6 +67,13 @@ cc_library(
     name = "kmac_commands",
     srcs = ["kmac_commands.c"],
     hdrs = ["kmac_commands.h"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
+    name = "rsa_commands",
+    srcs = ["rsa_commands.c"],
+    hdrs = ["rsa_commands.h"],
     deps = ["//sw/device/lib/ujson"],
 )
 

--- a/sw/device/tests/crypto/cryptotest/json/commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/commands.h
@@ -19,6 +19,7 @@ extern "C" {
     value(_, Hash) \
     value(_, Hmac) \
     value(_, Kmac) \
+    value(_, Rsa) \
     value(_, SphincsPlus)
 UJSON_SERDE_ENUM(CryptotestCommand, cryptotest_cmd_t, COMMAND);
 

--- a/sw/device/tests/crypto/cryptotest/json/rsa_commands.c
+++ b/sw/device/tests/crypto/cryptotest/json/rsa_commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "rsa_commands.h"

--- a/sw/device/tests/crypto/cryptotest/json/rsa_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/rsa_commands.h
@@ -1,0 +1,47 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_RSA_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_RSA_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MODULE_ID MAKE_MODULE_ID('r', 'a', 's')
+
+#define RSA_CMD_MAX_MESSAGE_BYTES 512
+#define RSA_CMD_MAX_N_BYTES 512
+#define RSA_CMD_MAX_SIGNATURE_BYTES 512
+
+// clang-format off
+
+#define RSA_SUBCOMMAND(_, value) \
+    value(_, RsaVerify)
+UJSON_SERDE_ENUM(RsaSubcommand, rsa_subcommand_t, RSA_SUBCOMMAND);
+
+#define RSA_VERIFY(field, string) \
+    field(msg, uint8_t, RSA_CMD_MAX_MESSAGE_BYTES) \
+    field(msg_len, size_t) \
+    field(e, uint32_t) \
+    field(n, uint8_t, RSA_CMD_MAX_N_BYTES) \
+    field(security_level, size_t) \
+    field(sig, uint8_t, RSA_CMD_MAX_SIGNATURE_BYTES) \
+    field(sig_len, size_t) \
+    field(hashing, size_t) \
+    field(padding, size_t)
+UJSON_SERDE_STRUCT(CryptotestRsaVerify, cryptotest_rsa_verify_t, RSA_VERIFY);
+
+#define RSA_VERIFY_RESP(field, string) \
+    field(result, bool)
+UJSON_SERDE_STRUCT(CryptotestRsaVerifyResp, cryptotest_rsa_verify_resp_t, RSA_VERIFY_RESP);
+
+#undef MODULE_ID
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_RSA_COMMANDS_H_

--- a/sw/host/cryptotest/ujson_lib/BUILD
+++ b/sw/host/cryptotest/ujson_lib/BUILD
@@ -48,6 +48,11 @@ ujson_rust(
 )
 
 ujson_rust(
+    name = "rsa_commands_rust",
+    srcs = ["//sw/device/tests/crypto/cryptotest/json:rsa_commands"],
+)
+
+ujson_rust(
     name = "sphincsplus_commands_rust",
     srcs = ["//sw/device/tests/crypto/cryptotest/json:sphincsplus_commands"],
 )
@@ -64,6 +69,7 @@ rust_library(
         "src/hmac_commands.rs",
         "src/kmac_commands.rs",
         "src/lib.rs",
+        "src/rsa_commands.rs",
         "src/sphincsplus_commands.rs",
     ],
     compile_data = [
@@ -75,6 +81,7 @@ rust_library(
         ":hash_commands_rust",
         ":hmac_commands_rust",
         ":kmac_commands_rust",
+        ":rsa_commands_rust",
         ":sphincsplus_commands_rust",
     ],
     rustc_env = {
@@ -86,6 +93,7 @@ rust_library(
         "hash_commands_loc": "$(execpath :hash_commands_rust)",
         "hmac_commands_loc": "$(execpath :hmac_commands_rust)",
         "kmac_commands_loc": "$(execpath :kmac_commands_rust)",
+        "rsa_commands_loc": "$(execpath :rsa_commands_rust)",
         "sphincsplus_commands_loc": "$(execpath :sphincsplus_commands_rust)",
     },
     deps = [

--- a/sw/host/cryptotest/ujson_lib/src/lib.rs
+++ b/sw/host/cryptotest/ujson_lib/src/lib.rs
@@ -9,4 +9,5 @@ pub mod ecdsa_commands;
 pub mod hash_commands;
 pub mod hmac_commands;
 pub mod kmac_commands;
+pub mod rsa_commands;
 pub mod sphincsplus_commands;

--- a/sw/host/cryptotest/ujson_lib/src/rsa_commands.rs
+++ b/sw/host/cryptotest/ujson_lib/src/rsa_commands.rs
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+include!(env!("rsa_commands_loc"));

--- a/sw/host/tests/crypto/rsa_kat/BUILD
+++ b/sw/host/tests/crypto/rsa_kat/BUILD
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:ujson.bzl", "ujson_rust")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "harness",
+    srcs = ["src/main.rs"],
+    deps = [
+        "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/crypto/rsa_kat/src/main.rs
+++ b/sw/host/tests/crypto/rsa_kat/src/main.rs
@@ -1,0 +1,130 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use arrayvec::ArrayVec;
+use clap::Parser;
+use std::fs;
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use cryptotest_commands::commands::CryptotestCommand;
+use cryptotest_commands::rsa_commands::{
+    CryptotestRsaVerify, CryptotestRsaVerifyResp, RsaSubcommand,
+};
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::console::spi::SpiConsoleDevice;
+use opentitanlib::execute_test;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    // Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+
+    #[arg(long, num_args = 1..)]
+    rsa_json: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RsaTestCase {
+    algorithm: String,
+    padding: String,
+    security_level: usize,
+    hash_alg: String,
+    message: Vec<u8>,
+    n: Vec<u8>,
+    e: u32,
+    signature: Vec<u8>,
+    result: bool,
+}
+
+fn run_rsa_testcase(
+    test_case: &RsaTestCase,
+    opts: &Opts,
+    spi_console: &SpiConsoleDevice,
+) -> Result<()> {
+    assert_eq!(test_case.algorithm.as_str(), "rsa");
+    CryptotestCommand::Rsa.send(spi_console)?;
+    RsaSubcommand::RsaVerify.send(spi_console)?;
+
+    // Configure hashing.
+    let hashing = match test_case.hash_alg.as_str() {
+        "sha-256" => 0,
+        "sha-384" => 1,
+        "sha-512" => 2,
+        "sha3-256" => 3,
+        "sha3-384" => 4,
+        "sha3-512" => 5,
+        "shake-128" => 6,
+        "shake-256" => 7,
+        _ => panic!("Invalid hashing mode"),
+    };
+
+    // Configure padding mode.
+    let padding = match test_case.padding.as_str() {
+        "pkcs1_1.5" => 0,
+        "pss" => 1,
+        _ => panic!("Invalid padding mode"),
+    };
+
+    // Convert the inputs into the expected format for the CL.
+    let n: Vec<_> = test_case.n.iter().copied().rev().collect();
+    let signature: Vec<_> = test_case.signature.iter().copied().rev().collect();
+
+    CryptotestRsaVerify {
+        msg: ArrayVec::try_from(test_case.message.as_slice()).unwrap(),
+        msg_len: test_case.message.len(),
+        e: test_case.e,
+        n: ArrayVec::try_from(n.as_slice()).unwrap(),
+        security_level: test_case.security_level,
+        sig: ArrayVec::try_from(signature.as_slice()).unwrap(),
+        sig_len: test_case.signature.len(),
+        hashing,
+        padding,
+    }
+    .send(spi_console)?;
+
+    let rsa_verify_resp = CryptotestRsaVerifyResp::recv(spi_console, opts.timeout, false)?;
+    assert_eq!(rsa_verify_resp.result, test_case.result);
+
+    Ok(())
+}
+
+fn test_rsa(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let spi = transport.spi("BOOTSTRAP")?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
+
+    let mut test_counter = 0u32;
+    let test_vector_files = &opts.rsa_json;
+    for file in test_vector_files {
+        let raw_json = fs::read_to_string(file)?;
+        let rsa_tests: Vec<RsaTestCase> = serde_json::from_str(&raw_json)?;
+
+        for rsa_test in &rsa_tests {
+            test_counter += 1;
+            log::info!("Test counter: {}", test_counter);
+            run_rsa_testcase(rsa_test, opts, &spi_console_device)?;
+        }
+    }
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    let transport = opts.init.init_target()?;
+    execute_test!(test_rsa, &opts, &transport);
+    Ok(())
+}


### PR DESCRIPTION
This commit extends the cryptotest framework to test the RSA verify function using the wycheproof test vectors.