### PR TITLE
[hw,pwrmgr,rtl] Correct the rom integrity bypass on rom_done signal

### DIFF
--- a/hw/ip_templates/pwrmgr/rtl/pwrmgr_fsm.sv.tpl
+++ b/hw/ip_templates/pwrmgr/rtl/pwrmgr_fsm.sv.tpl
@@ -80,7 +80,6 @@ module pwrmgr_fsm import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;(
   import prim_mubi_pkg::mubi4_t;
   import prim_mubi_pkg::mubi4_test_true_strict;
   import prim_mubi_pkg::mubi4_or_hi;
-  import prim_mubi_pkg::mubi4_and_hi;
   import lc_ctrl_pkg::lc_tx_and_hi;
   import lc_ctrl_pkg::lc_tx_test_true_strict;
 
@@ -291,8 +290,7 @@ module pwrmgr_fsm import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;(
 
   mubi4_t rom_intg_chk_done;
   mubi4_t rom_intg_chk_good;
-  assign rom_intg_chk_done = mubi4_or_hi(mubi4_and_hi(rom_intg_chk_dis, rom_ctrl_done_i),
-                                         rom_ctrl_done_i);
+  assign rom_intg_chk_done = rom_ctrl_done_i;
   assign rom_intg_chk_good = mubi4_or_hi(rom_intg_chk_dis, rom_ctrl_good_i);
 
   always_comb begin

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr_fsm.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr_fsm.sv
@@ -74,7 +74,6 @@ module pwrmgr_fsm import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;(
   import prim_mubi_pkg::mubi4_t;
   import prim_mubi_pkg::mubi4_test_true_strict;
   import prim_mubi_pkg::mubi4_or_hi;
-  import prim_mubi_pkg::mubi4_and_hi;
   import lc_ctrl_pkg::lc_tx_and_hi;
   import lc_ctrl_pkg::lc_tx_test_true_strict;
 
@@ -283,8 +282,7 @@ module pwrmgr_fsm import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;(
 
   mubi4_t rom_intg_chk_done;
   mubi4_t rom_intg_chk_good;
-  assign rom_intg_chk_done = mubi4_or_hi(mubi4_and_hi(rom_intg_chk_dis, rom_ctrl_done_i),
-                                         rom_ctrl_done_i);
+  assign rom_intg_chk_done = rom_ctrl_done_i;
   assign rom_intg_chk_good = mubi4_or_hi(rom_intg_chk_dis, rom_ctrl_good_i);
 
   always_comb begin

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_fsm.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_fsm.sv
@@ -73,7 +73,6 @@ module pwrmgr_fsm import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;(
   import prim_mubi_pkg::mubi4_t;
   import prim_mubi_pkg::mubi4_test_true_strict;
   import prim_mubi_pkg::mubi4_or_hi;
-  import prim_mubi_pkg::mubi4_and_hi;
   import lc_ctrl_pkg::lc_tx_and_hi;
   import lc_ctrl_pkg::lc_tx_test_true_strict;
 
@@ -253,8 +252,7 @@ module pwrmgr_fsm import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;(
 
   mubi4_t rom_intg_chk_done;
   mubi4_t rom_intg_chk_good;
-  assign rom_intg_chk_done = mubi4_or_hi(mubi4_and_hi(rom_intg_chk_dis, rom_ctrl_done_i),
-                                         rom_ctrl_done_i);
+  assign rom_intg_chk_done = rom_ctrl_done_i;
   assign rom_intg_chk_good = mubi4_or_hi(rom_intg_chk_dis, rom_ctrl_good_i);
 
   always_comb begin

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr_fsm.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr_fsm.sv
@@ -73,7 +73,6 @@ module pwrmgr_fsm import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;(
   import prim_mubi_pkg::mubi4_t;
   import prim_mubi_pkg::mubi4_test_true_strict;
   import prim_mubi_pkg::mubi4_or_hi;
-  import prim_mubi_pkg::mubi4_and_hi;
   import lc_ctrl_pkg::lc_tx_and_hi;
   import lc_ctrl_pkg::lc_tx_test_true_strict;
 
@@ -253,8 +252,7 @@ module pwrmgr_fsm import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;(
 
   mubi4_t rom_intg_chk_done;
   mubi4_t rom_intg_chk_good;
-  assign rom_intg_chk_done = mubi4_or_hi(mubi4_and_hi(rom_intg_chk_dis, rom_ctrl_done_i),
-                                         rom_ctrl_done_i);
+  assign rom_intg_chk_done = rom_ctrl_done_i;
   assign rom_intg_chk_good = mubi4_or_hi(rom_intg_chk_dis, rom_ctrl_good_i);
 
   always_comb begin


### PR DESCRIPTION
The pwrmgr supports to bypass the rom integrity checks when in RMA or TEST_UNLOCKED (lc_dft_en_i, lc_hw_debug_en_i are asserted). Then it should bypass the check on the rom done and rom good signal. While for the good signal, this check is properly implemented, the done signal seems to have an issue:

```systemverilog
assign rom_intg_chk_done = mubi4_or_hi(mubi4_and_hi(rom_intg_chk_dis, rom_ctrl_done_i),
                                       rom_ctrl_done_i);
````

The bypass via `rom_intg_chk_dis` is only honored if `rom_ctrl_done_i` is asserted. If so, I don't need a bypass. Thus, this boils down to:

```systemverilog
assign rom_intg_chk_done = rom_ctrl_done_i;
````

With no bypass at all.

This is probably fine. It means the bypass only bypasses the value checks. If the ROM is stuck? and done is never asserted, no bypass is applied and pwrmgr is stuck.