### PR TITLE
[cryptotest] Test RSA encrypt/decrypt using wycheproof vectors

### DIFF
--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -166,6 +166,25 @@ RSA_TESTVECTOR_TARGETS = [
         "sha512_mgf1_64",
         "shake256",
     ]
+] + [
+    "//sw/host/cryptotest/testvectors/data:wycheproof_rsa_oaep_2048_{}.json".format(hash)
+    for hash in [
+        "sha256_mgf1sha256",
+        "sha384_mgf1sha384",
+        "sha512_mgf1sha512",
+    ]
+] + [
+    "//sw/host/cryptotest/testvectors/data:wycheproof_rsa_oaep_3072_{}.json".format(hash)
+    for hash in [
+        "sha256_mgf1sha256",
+        "sha512_mgf1sha512",
+    ]
+] + [
+    "//sw/host/cryptotest/testvectors/data:wycheproof_rsa_oaep_4096_{}.json".format(hash)
+    for hash in [
+        "sha256_mgf1sha256",
+        "sha512_mgf1sha512",
+    ]
 ]
 
 RSA_TESTVECTOR_ARGS = " ".join([

--- a/sw/device/tests/crypto/cryptotest/firmware/rsa.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/rsa.h
@@ -9,6 +9,7 @@
 #include "sw/device/lib/ujson/ujson.h"
 
 status_t handle_rsa_decrypt(ujson_t *uj);
+status_t handle_rsa_encrypt(ujson_t *uj);
 status_t handle_rsa_verify(ujson_t *uj);
 status_t handle_rsa(ujson_t *uj);
 

--- a/sw/device/tests/crypto/cryptotest/json/rsa_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/rsa_commands.h
@@ -18,6 +18,7 @@ extern "C" {
 // clang-format off
 
 #define RSA_SUBCOMMAND(_, value) \
+    value(_, RsaEncrypt) \
     value(_, RsaDecrypt) \
     value(_, RsaVerify)
 UJSON_SERDE_ENUM(RsaSubcommand, rsa_subcommand_t, RSA_SUBCOMMAND);
@@ -47,6 +48,18 @@ UJSON_SERDE_STRUCT(CryptotestRsaVerify, cryptotest_rsa_verify_t, RSA_VERIFY);
     field(padding, size_t)
 UJSON_SERDE_STRUCT(CryptotestRsaDecrypt, cryptotest_rsa_decrypt_t, RSA_DECRYPT);
 
+#define RSA_ENCRYPT(field, string) \
+    field(plaintext, uint8_t, RSA_CMD_MAX_MESSAGE_BYTES) \
+    field(plaintext_len, size_t) \
+    field(e, uint32_t) \
+    field(n, uint8_t, RSA_CMD_MAX_N_BYTES) \
+    field(security_level, size_t) \
+    field(label, uint8_t, RSA_CMD_MAX_MESSAGE_BYTES) \
+    field(label_len, size_t) \
+    field(hashing, size_t) \
+    field(padding, size_t)
+UJSON_SERDE_STRUCT(CryptotestRsaEncrypt, cryptotest_rsa_encrypt_t, RSA_ENCRYPT);
+
 #define RSA_VERIFY_RESP(field, string) \
     field(result, bool)
 UJSON_SERDE_STRUCT(CryptotestRsaVerifyResp, cryptotest_rsa_verify_resp_t, RSA_VERIFY_RESP);
@@ -56,6 +69,12 @@ UJSON_SERDE_STRUCT(CryptotestRsaVerifyResp, cryptotest_rsa_verify_resp_t, RSA_VE
     field(plaintext_len, size_t) \
     field(result, bool)
 UJSON_SERDE_STRUCT(CryptotestRsaDecryptResp, cryptotest_rsa_decrypt_resp_t, RSA_DECRYPT_RESP);
+
+#define RSA_ENCRYPT_RESP(field, string) \
+    field(ciphertext, uint8_t, RSA_CMD_MAX_MESSAGE_BYTES) \
+    field(ciphertext_len, size_t) \
+    field(result, bool)
+UJSON_SERDE_STRUCT(CryptotestRsaEncryptResp, cryptotest_rsa_encrypt_resp_t, RSA_ENCRYPT_RESP);
 
 #undef MODULE_ID
 

--- a/sw/host/tests/crypto/rsa_kat/src/main.rs
+++ b/sw/host/tests/crypto/rsa_kat/src/main.rs
@@ -12,8 +12,8 @@ use serde::Deserialize;
 
 use cryptotest_commands::commands::CryptotestCommand;
 use cryptotest_commands::rsa_commands::{
-    CryptotestRsaDecrypt, CryptotestRsaDecryptResp, CryptotestRsaVerify, CryptotestRsaVerifyResp,
-    RsaSubcommand,
+    CryptotestRsaDecrypt, CryptotestRsaDecryptResp, CryptotestRsaEncrypt, CryptotestRsaEncryptResp,
+    CryptotestRsaVerify, CryptotestRsaVerifyResp, RsaSubcommand,
 };
 
 use opentitanlib::app::TransportWrapper;
@@ -150,6 +150,76 @@ fn run_rsa_testcase(
                     rsa_decrypt_resp.plaintext[0..test_case.message.len()],
                     test_case.message[0..test_case.message.len()]
                 );
+            }
+        }
+        "encrypt" => {
+            // Send RsaEncrypt command.
+            RsaSubcommand::RsaEncrypt.send(spi_console)?;
+
+            // Convert the inputs into the expected format for the CL.
+            let ptx: Vec<_> = test_case.message.iter().copied().rev().collect();
+
+            // Assemble the input.
+            CryptotestRsaEncrypt {
+                plaintext: ArrayVec::try_from(ptx.as_slice()).unwrap(),
+                plaintext_len: test_case.message.len(),
+                e: test_case.e,
+                n: ArrayVec::try_from(n.as_slice()).unwrap(),
+                security_level: test_case.security_level,
+                label: ArrayVec::try_from(test_case.label.as_slice()).unwrap(),
+                label_len: test_case.label.len(),
+                hashing,
+                padding,
+            }
+            .send(spi_console)?;
+
+            // Get and evaluate the response.
+            let rsa_encrypt_resp =
+                CryptotestRsaEncryptResp::recv(spi_console, opts.timeout, false)?;
+            // Check if the encryption was successful.
+            assert_eq!(rsa_encrypt_resp.result, test_case.result);
+
+            // Use the received ciphertext, decrypt it, and compare it to the
+            // plaintext in the test vector.
+            if test_case.result {
+                // Decrypt it again and check if the plaintext matches.
+                // Send RsaDecrypt command.
+                CryptotestCommand::Rsa.send(spi_console)?;
+                RsaSubcommand::RsaDecrypt.send(spi_console)?;
+
+                // Convert the inputs into the expected format for the CL.
+                let d: Vec<_> = test_case.d.iter().copied().rev().collect();
+                let ctx: Vec<_> =
+                    Vec::from(&rsa_encrypt_resp.ciphertext[..rsa_encrypt_resp.ciphertext_len]);
+
+                // Assemble the input.
+                CryptotestRsaDecrypt {
+                    ciphertext: ArrayVec::try_from(ctx.as_slice()).unwrap(),
+                    ciphertext_len: rsa_encrypt_resp.ciphertext_len,
+                    e: test_case.e,
+                    d: ArrayVec::try_from(d.as_slice()).unwrap(),
+                    n: ArrayVec::try_from(n.as_slice()).unwrap(),
+                    security_level: test_case.security_level,
+                    label: ArrayVec::try_from(test_case.label.as_slice()).unwrap(),
+                    label_len: test_case.label.len(),
+                    hashing,
+                    padding,
+                }
+                .send(spi_console)?;
+
+                // Get and evaluate the response.
+                let rsa_decrypt_resp =
+                    CryptotestRsaDecryptResp::recv(spi_console, opts.timeout, false)?;
+                // Check if the decryption was successful.
+                assert_eq!(rsa_decrypt_resp.result, test_case.result);
+
+                if test_case.result {
+                    // Only check plaintext if the response is valid.
+                    assert_eq!(
+                        rsa_decrypt_resp.plaintext[0..test_case.message.len()],
+                        test_case.message[0..test_case.message.len()]
+                    );
+                }
             }
         }
         _ => panic!("Invalid operation"),


### PR DESCRIPTION
This PR consists of two commits that enable testing of the RSA decrypt and encrypt. For the decryption, the received plaintext is compared to the test vector. For the encryption, the plaintext is encrypted and the ciphertext is then fed into the decryption and the output is compared to the input plaintext.

Based on #28507.