### PR TITLE
[dif,clkmgr] Remove top-specific clock measurement names

### DIFF
--- a/sw/device/lib/dif/dif_clkmgr.h
+++ b/sw/device/lib/dif/dif_clkmgr.h
@@ -40,38 +40,7 @@ typedef uint32_t dif_clkmgr_gateable_clock_t;
  */
 typedef uint32_t dif_clkmgr_hintable_clock_t;
 
-typedef enum dif_clkmgr_measure_clock {
-#if defined(OPENTITAN_IS_EARLGREY)
-  /**
-   * The Io clock.
-   */
-  kDifClkmgrMeasureClockIo,
-  /**
-   * The Io_div2 clock.
-   */
-  kDifClkmgrMeasureClockIoDiv2,
-#elif defined(OPENTITAN_IS_DARJEELING)
-// Darjeeling doesn't have Io / Io_div2 clock measurements.
-#else
-#error "dif_clkmgr does not support this top"
-#endif
-  /**
-   * The Io div4 clock.
-   */
-  kDifClkmgrMeasureClockIoDiv4,
-  /**
-   * The Main clock.
-   */
-  kDifClkmgrMeasureClockMain,
-  /**
-   * The Usb clock.
-   */
-  kDifClkmgrMeasureClockUsb,
-  /**
-   * Total number of clock measurements.
-   */
-  kDifClkmgrMeasureClockCount,
-} dif_clkmgr_measure_clock_t;
+typedef uint32_t dif_clkmgr_measure_clock_t;
 
 typedef enum dif_clkmgr_recov_err_type {
 #if defined(OPENTITAN_IS_EARLGREY)

--- a/sw/device/lib/dif/dif_clkmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_clkmgr_unittest.cc
@@ -19,6 +19,34 @@ using mock_mmio::MmioTest;
 using mock_mmio::MockDevice;
 using testing::Test;
 
+// Matches the Earlgrey layout.
+enum {
+  /**
+   * The Io clock.
+   */
+  kDifClkmgrMeasureClockIo,
+  /**
+   * The Io_div2 clock.
+   */
+  kDifClkmgrMeasureClockIoDiv2,
+  /**
+   * The Io div4 clock.
+   */
+  kDifClkmgrMeasureClockIoDiv4,
+  /**
+   * The Main clock.
+   */
+  kDifClkmgrMeasureClockMain,
+  /**
+   * The Usb clock.
+   */
+  kDifClkmgrMeasureClockUsb,
+  /**
+   * Total number of clock measurements.
+   */
+  kDifClkmgrMeasureClockCount,
+};
+
 const dif_clkmgr_measure_clock_t kBadMeasClock =
     static_cast<dif_clkmgr_measure_clock_t>(27);
 

--- a/sw/device/lib/testing/clkmgr_testutils.c
+++ b/sw/device/lib/testing/clkmgr_testutils.c
@@ -234,7 +234,9 @@ status_t clkmgr_testutils_enable_clock_counts_with_expected_thresholds(
 status_t clkmgr_testutils_check_measurement_enables(
     const dif_clkmgr_t *clkmgr, dif_toggle_t expected_status) {
   bool success = true;
-  for (int i = 0; i < kDifClkmgrMeasureClockCount; ++i) {
+  dt_clkmgr_t clkmgr_dt;
+  TRY(dif_clkmgr_get_dt(clkmgr, &clkmgr_dt));
+  for (size_t i = 0; i < dt_clkmgr_measurable_clock_count(clkmgr_dt); ++i) {
     dif_clkmgr_measure_clock_t clock = (dif_clkmgr_measure_clock_t)i;
     dif_toggle_t actual_status;
     TRY(dif_clkmgr_measure_counts_get_enable(clkmgr, clock, &actual_status));
@@ -249,7 +251,9 @@ status_t clkmgr_testutils_check_measurement_enables(
 
 status_t clkmgr_testutils_disable_clock_counts(const dif_clkmgr_t *clkmgr) {
   LOG_INFO("Disabling all clock count measurements");
-  for (int i = 0; i < kDifClkmgrMeasureClockCount; ++i) {
+  dt_clkmgr_t clkmgr_dt;
+  TRY(dif_clkmgr_get_dt(clkmgr, &clkmgr_dt));
+  for (size_t i = 0; i < dt_clkmgr_measurable_clock_count(clkmgr_dt); ++i) {
     dif_clkmgr_measure_clock_t clock = (dif_clkmgr_measure_clock_t)i;
     TRY(dif_clkmgr_disable_measure_counts(clkmgr, clock));
   }


### PR DESCRIPTION
After the clock measurement work to make it top independent, the top-specific information was left probably by mistake. This commit removes the top-specific list entirely. The unittest, which earlgrey specific, is modified to have a hardcoded list so that it is easier to understand the code.

**Note:** the DIF header still contains a top-specific list for `dif_clkmgr_recov_err_type_t`. This one is a bit more tricky to remove so this will be done in a different PR.