### PR TITLE
[kmsp11] Update libkmsp11 to v1.8

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -398,7 +398,7 @@
     },
     "//third_party/hsm:extensions.bzl%hsm": {
       "general": {
-        "bzlTransitiveDigest": "j2GwGdc7Oxlja02plc7IXvFl0HZEyDDmWbrXkP9J/ns=",
+        "bzlTransitiveDigest": "2vzJYK+vywiCbF9s0lHu/wrZWmgeAz0wXuHdAO2k+5w=",
         "usagesDigest": "uEk6dTktgdMfLQN5bAE4Sorkuuxcz3nEbPEKZLUjpak=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -441,9 +441,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//third_party/hsm:BUILD.cloud_kms_hsm.bazel",
-              "url": "https://github.com/GoogleCloudPlatform/kms-integrations/releases/download/pkcs11-v1.2/libkmsp11-1.2-linux-amd64.tar.gz",
-              "strip_prefix": "libkmsp11-1.2-linux-amd64",
-              "sha256": "81fff58d5835f05d550ff86c88fa6fb92a733bde8b232e1482d85a3cf07c6396"
+              "url": "https://github.com/GoogleCloudPlatform/kms-integrations/releases/download/pkcs11-v1.8/libkmsp11-1.8-linux-amd64.tar.gz",
+              "strip_prefix": "libkmsp11-1.8-linux-amd64",
+              "sha256": "3b932f22a8abb631442c3276e9c309554c81855526b74fbc9edaddcb57a557f7"
             }
           }
         },

--- a/third_party/hsm/extensions.bzl
+++ b/third_party/hsm/extensions.bzl
@@ -37,7 +37,7 @@ def _hsm_repos():
     http_archive(
         name = "cloud_kms_hsm",
         build_file = Label("//third_party/hsm:BUILD.cloud_kms_hsm.bazel"),
-        url = "https://github.com/GoogleCloudPlatform/kms-integrations/releases/download/pkcs11-v1.2/libkmsp11-1.2-linux-amd64.tar.gz",
-        strip_prefix = "libkmsp11-1.2-linux-amd64",
-        sha256 = "81fff58d5835f05d550ff86c88fa6fb92a733bde8b232e1482d85a3cf07c6396",
+        url = "https://github.com/GoogleCloudPlatform/kms-integrations/releases/download/pkcs11-v1.8/libkmsp11-1.8-linux-amd64.tar.gz",
+        strip_prefix = "libkmsp11-1.8-linux-amd64",
+        sha256 = "3b932f22a8abb631442c3276e9c309554c81855526b74fbc9edaddcb57a557f7",
     )


### PR DESCRIPTION
The latest libkmsp11 release adds support for authenticating with Cloud KMS using Google Compute Engine credentials. This allows a VM runing as a service account to query the GCE metadata server for its credentials instead of using an Application Default Credentials file.