### PR TITLE
[crypto] Remove unused otbn_write() function

### DIFF
--- a/sw/device/lib/crypto/drivers/otbn.c
+++ b/sw/device/lib/crypto/drivers/otbn.c
@@ -116,31 +116,6 @@ static status_t otbn_assert_idle(void) {
   return OTCRYPTO_ASYNC_INCOMPLETE;
 }
 
-/**
- * Helper function for writing to OTBN's DMEM or IMEM.
- *
- * @param dest_addr Destination address.
- * @param src Source buffer.
- * @param num_words Number of words to copy.
- */
-static void otbn_write(uint32_t dest_addr, const uint32_t *src,
-                       size_t num_words) {
-  // TODO: replace 0 with a random index like the silicon_creator driver
-  // (requires an interface to Ibex's RND valid bit and data register).
-  size_t i = ((uint64_t)0 * (uint64_t)num_words) >> 32;
-  enum { kStep = 1 };
-  size_t iter_cnt = 0;
-  for (; launder32(iter_cnt) < num_words; ++iter_cnt) {
-    abs_mmio_write32(dest_addr + i * sizeof(uint32_t), src[i]);
-    i += kStep;
-    if (launder32(i) >= num_words) {
-      i -= num_words;
-    }
-    HARDENED_CHECK_LT(i, num_words);
-  }
-  HARDENED_CHECK_EQ(iter_cnt, num_words);
-}
-
 status_t otbn_dmem_write(size_t num_words, const uint32_t *src,
                          otbn_addr_t dest) {
   HARDENED_TRY(check_offset_len(dest, num_words, kOtbnDMemSizeBytes));


### PR DESCRIPTION
PR #28126 added a new hardened otbn_dmem_write() function to the code base. With this, the old, unprotected otbn_write() function is no longer in use.

Closes lowRISC/opentitan#28525