### PR TITLE
[darjeeling,dv] Wait for at least 5 cycles when de-asserting an external rst

### DIFF
--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -94,6 +94,8 @@ class chip_sw_base_vseq extends chip_base_vseq;
     cfg.chip_vif.aon_clk_por_rst_if.wait_clks(clks);
     // Deactivate external reset request.
     void'(cfg.chip_vif.signal_probe_soc_rst_req_async(.kind(dv_utils_pkg::SignalProbeRelease)));
+    // Wait for at least 5 AON clock cycles to ensure the reset request is deasserted.
+    cfg.chip_vif.aon_clk_por_rst_if.wait_clks(clks);
   endtask
 
   virtual task dut_init(string reset_kind = "HARD");


### PR DESCRIPTION
If not, the de-assertion is filtered by the DJ-internal glitch filter and internally to the power manager, the external is never de-asserted.

This change also makes chip_rv_dm_ndm_reset_req to pass on Darjeeling.

```
### Test Results
|  Stage  |             Name              | Tests                    |  Max Job Runtime  |  Simulated Time  |  Passing  |  Total  |  Pass Rate  |
|:-------:|:-----------------------------:|:-------------------------|:-----------------:|:----------------:|:---------:|:-------:|:-----------:|
|   V2    |   chip_rv_dm_ndm_reset_req    | chip_rv_dm_ndm_reset_req |      54.967m      |     7.231ms      |     3     |    3    |  100.00 %   |
|   V2    | chip_sw_rstmgr_sys_reset_info | chip_rv_dm_ndm_reset_req |      54.967m      |     7.231ms      |     3     |    3    |  100.00 %   |
|   V2    |                               | **TOTAL**                |                   |                  |     3     |    3    |  100.00 %   |
|         |                               | **TOTAL**                |                   |                  |     3     |    3    |  100.00 %   |
```