### PR TITLE
[sw,test_rom] Fix chip_info location in test_rom

### DIFF
--- a/sw/device/lib/testing/test_rom/test_rom.ld
+++ b/sw/device/lib/testing/test_rom/test_rom.ld
@@ -31,9 +31,6 @@ _rom_ext_virtual_size = LENGTH(rom_ext_virtual);
 ASSERT((_rom_ext_virtual_size <= (LENGTH(eflash) / 2)),
   "Error: rom ext flash is bigger than slot.");
 
-_rom_digest_size = 32;
-_chip_info_start = ORIGIN(rom) + LENGTH(rom) - _rom_digest_size - _chip_info_size;
-
 /* DV Log offset (has to be different to other boot stages). */
 _dv_log_offset = 0x0;
 

--- a/sw/device/silicon_creator/rom/e2e/chip_info/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/chip_info/BUILD
@@ -1,0 +1,21 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//rules/opentitan:defs.bzl",
+    "opentitan_test",
+)
+
+opentitan_test(
+    name = "chip_info_test",
+    srcs = ["chip_info_test.c"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_cw340_test_rom": None,
+    },
+    deps = [
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:chip_info",
+    ],
+)

--- a/sw/device/silicon_creator/rom/e2e/chip_info/chip_info_test.c
+++ b/sw/device/silicon_creator/rom/e2e/chip_info/chip_info_test.c
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/chip_info.h"
+
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+extern const char _chip_info_start[];
+
+bool test_main(void) {
+  chip_info_t *rom_chip_info = (chip_info_t *)_chip_info_start;
+  LOG_INFO("rom_chip_info @ %p:", rom_chip_info);
+  LOG_INFO("scm_revision = %08x%08x",
+           rom_chip_info->scm_revision.scm_revision_high,
+           rom_chip_info->scm_revision.scm_revision_low);
+  LOG_INFO("version = %08x", rom_chip_info->version);
+
+  return rom_chip_info->version == kChipInfoVersion1;
+}


### PR DESCRIPTION
The `chip_info` structure is currently located inconsistently between the `mask_rom` and `test_rom`. In `mask_rom`, it resides in the last 128 bytes, but in `test_rom`, it's offset by an additional 32 bytes (to `last 160 bytes`).

Given `chip_info`'s small size (12 bytes), it can safely occupy bytes 116-128 from the end of the ROM, leaving the final 32 bytes (0-31) for the scrambling tool's digest.

This change aligns `test_rom`'s `chip_info` placement with `mask_rom`'s. Before this change, the added chip_info_test will fail when reading chip_info from test_rom.