### PR TITLE
[reggen] Support IPs with no register block

### DIFF
--- a/util/reggen/README.md
+++ b/util/reggen/README.md
@@ -96,7 +96,6 @@ name | required | string | name of the component
 cip_id | required | int | unique comportable IP identifier
 clocking | required | list | clocking for the device
 bus_interfaces | required | list | bus interfaces for the device
-registers | required | list | list of register definition groups and offset control groups
 human_name | optional | string | human-readable name of the component
 one_line_desc | optional | string | one-line description of the component
 one_paragraph_desc | optional | string | one-paragraph description of the component
@@ -122,6 +121,7 @@ inter_signal_list | optional | list | list of inter-module signals
 no_auto_alert_regs | optional | string | Set to true to suppress automatic generation of alert test registers. Defaults to true if no alert_list is present. Otherwise this defaults to false.
 no_auto_intr_regs | optional | string | Set to true to suppress automatic generation of interrupt registers. Defaults to true if no interrupt_list is present. Otherwise this defaults to false.
 param_list | optional | parameter list | list of parameters of the IP
+registers | optional | list | list of register definition groups and offset control groups
 regwidth | optional | int | width of registers in bits (default 32)
 reset_request_list | optional | list | list of signals requesting reset
 scan | optional | python Bool | Indicates the module have `scanmode_i`

--- a/util/reggen/gen_rtl.py
+++ b/util/reggen/gen_rtl.py
@@ -44,7 +44,7 @@ def get_addr_widths(block: IpBlock) -> Dict[Optional[str], Tuple[str, int]]:
     the more general parameter name "BlockAw".
 
     '''
-    assert block.reg_blocks
+    assert isinstance(block.reg_blocks, dict)
     if len(block.reg_blocks) == 1 and None in block.reg_blocks:
         return {None: ('BlockAw', block.reg_blocks[None].get_addr_width())}
 

--- a/util/reggen/ip_block.py
+++ b/util/reggen/ip_block.py
@@ -87,9 +87,6 @@ REQUIRED_FIELDS = {
     'cip_id': ['d', "unique comportable IP identifier"],
     'clocking': ['l', "clocking for the device"],
     'bus_interfaces': ['l', "bus interfaces for the device"],
-    'registers':
-    ['l', "list of register definition groups and "
-     "offset control groups"]
 }
 
 OPTIONAL_FIELDS = {
@@ -130,6 +127,9 @@ OPTIONAL_FIELDS = {
         "Otherwise this defaults to false."
     ],
     'param_list': ['lp', "list of parameters of the IP"],
+    'registers':
+    ['l', "list of register definition groups and "
+     "offset control groups"],
     'regwidth': ['d', "width of registers in bits (default 32)"],
     'reset_request_list': ['l', 'list of signals requesting reset'],
     'scan': ['pb', 'Indicates the module have `scanmode_i`'],
@@ -191,7 +191,7 @@ class IpBlock:
     alias_impl: str | None = None
 
     def __post_init__(self) -> None:
-        assert self.reg_blocks
+        assert isinstance(self.reg_blocks, dict)
 
         # Filter the interfaces and reg_blocks if request to build only for a
         # specific reg_block node.
@@ -348,8 +348,12 @@ class IpBlock:
         clocking = Clocking.from_raw(rd['clocking'],
                                      'clocking field of ' + what)
 
-        reg_blocks = RegBlock.build_blocks(init_block, rd['registers'],
-                                           bus_interfaces, clocking, False)
+        # Build register block if IP really defined registers.
+        if rd.get("registers"):
+            reg_blocks = RegBlock.build_blocks(init_block, rd["registers"],
+                                               bus_interfaces, clocking, False)
+        else:
+            reg_blocks = {}
 
         memories = {
             name: Memory.from_raw(desc)


### PR DESCRIPTION
https://github.com/lowRISC/opentitan/pull/28011 changed reggen such that memory blocks are not part of the register definition anymore. This creates a problem for IPs that don't have registers (but had a memory). After that change, the register portion of the IP is empty causing reggen to fail.

With this change, we support IPs that don't define a register block, for example IPs such as soc_proxy (which may not even have alert test registers).