### PR TITLE
[CIP] Rename prim_otp to otp_macro

### DIFF
--- a/util/reggen/ip_block.py
+++ b/util/reggen/ip_block.py
@@ -68,7 +68,7 @@ KNOWN_CIP_IDS = {
     41: 'ac_range_check',
     42: 'soc_dbg_ctrl',
     43: 'racl_ctrl',
-    44: 'prim_otp',
+    44: 'otp_macro',
 }
 
 REQUIRED_ALIAS_FIELDS = {


### PR DESCRIPTION
While looking at the file I noticed the CIP definition of the otp_macro is wrong. It still refers to the old prim_otp name.