### PR TITLE
[rules,qemu] Always stop QEMU after the test

### DIFF
--- a/rules/scripts/qemu_test.sh
+++ b/rules/scripts/qemu_test.sh
@@ -41,7 +41,16 @@ for this_arg in "${test_args[@]}"; do
     fi
 done
 
+qemu_pid=""
+
 cleanup() {
+    set +e
+    echo "Stopping QEMU: $qemu_pid"
+    # Ask nicely QEMU to stop and then kill it after one second.
+    ( sleep 1 ; echo "Killing QEMU"; kill -KILL "$qemu_pid" ) &
+    kill "$qemu_pid"
+    wait "$qemu_pid"
+
     rm -f "${mutable_otp}" "${mutable_flash}"
     rm -f qemu-monitor qemu.log
 }
@@ -60,6 +69,7 @@ mkfifo qemu.log && cat qemu.log &
 
 echo "Starting QEMU: ${qemu} ${qemu_test_args[*]} ${qemu_args[*]}"
 "${qemu}" "${qemu_test_args[@]}" "${qemu_args[@]}"
+qemu_pid=$!
 
 echo "Invoking test: ${test_harness} ${args[*]} ${harness_test_args[*]} ${test_cmd[*]}"
 "${test_harness}" "${args[@]}" "${harness_test_args[@]}" "${test_cmd[@]}"


### PR DESCRIPTION
Even though opentitanlib supports asking QEMU to shutdown, it is (1) optional, (2) relies on the test harness stopping cleanly. One may argue that it is not really the responsability of the test harness to shutdown QEMU anyway since it is not spawn by the harness but rather by the qemu_test.sh script.

This commit makes the qemu_test.sh script always shutdown QEMU on exit. It first sends a SIGINT and after one second a SIGKILL.