### PR TITLE
[opentitanlib,qemu] Fix UART break functionality

### DIFF
--- a/sw/host/opentitanlib/src/transport/qemu/mod.rs
+++ b/sw/host/opentitanlib/src/transport/qemu/mod.rs
@@ -109,7 +109,7 @@ impl Qemu {
             let serial_port = SerialPortUart::open_pseudo(path.to_str().unwrap(), CONSOLE_BAUDRATE)
                 .context("failed to open QEMU console PTY")?;
             let uart: Rc<dyn Uart> =
-                Rc::new(QemuUart::new(Rc::clone(&monitor), "console", serial_port));
+                Rc::new(QemuUart::new(Rc::clone(&monitor), &chardev.id, serial_port));
 
             uarts.insert(id.to_string(), uart);
         }


### PR DESCRIPTION
Fixes a regression that I missed when reviewing https://github.com/lowRISC/opentitan/pull/28527.

This always passed the `console` ID despite there no longer being a UART called `console`, causing the UART break mechanism which used the CharDev ID to communicate with the monitor to break. Create the UART with the correct ID so that this will still work correctly, even when sending breaks to other UARTs.