### PR TITLE
Fix OTP descrambling test (`otp_ctrl_descrambling_test`)

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2454,10 +2454,19 @@ opentitan_test(
             "//hw/top_earlgrey:sim_dv": None,
             "//hw/top_earlgrey:sim_verilator": None,
             "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw340_test_rom": None,
+            "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
+            "//hw/top_earlgrey:sim_qemu_rom_with_fake_keys": None,
             # This test is not expected to run on silicon, as it would require a very specific OTP configuration that is only useful for this test.
         },
     ),
     fpga = fpga_params(
+        otp = ":otp_ctrl_descrambling_otp_image",
+    ),
+    qemu = qemu_params(
         otp = ":otp_ctrl_descrambling_otp_image",
     ),
     deps = [

--- a/sw/device/tests/otp_ctrl_descrambling_test.c
+++ b/sw/device/tests/otp_ctrl_descrambling_test.c
@@ -50,7 +50,7 @@ size_t compare_dword(const uint64_t *actual_arr, uint32_t part_idx,
   if (actual == expected) {
     return 0;
   } else {
-    LOG_WARNING("SECRET%0d, dword %0d: 0x%08x%08x != 0x%08x%08x", part_idx,
+    LOG_WARNING("SECRET%d, dword %d: 0x%08x%08x != 0x%08x%08x", part_idx,
                 dword_idx, upper(actual), lower(actual), upper(expected),
                 lower(expected));
     return 1;
@@ -74,7 +74,7 @@ bool test_main(void) {
     const partition_data_t *partition = &kPartitions[i];
     uint64_t readout[partition->size];
 
-    LOG_INFO("Checking partition SECRET%0d.", i);
+    LOG_INFO("Checking partition SECRET%d.", i);
     CHECK_STATUS_OK(otp_ctrl_testutils_dai_read64_array(
         &otp_ctrl, partition->partition, 0, readout, ARRAYSIZE(readout)));
 


### PR DESCRIPTION
Fixes some prints in `otp_ctrl_descrambling_test.c` and updates the list of supported execution environments.