### PR TITLE
[crypto] Use hardened_xor in keyblob_from_key_and_mask()

### DIFF
--- a/sw/device/lib/crypto/impl/keyblob.c
+++ b/sw/device/lib/crypto/impl/keyblob.c
@@ -207,11 +207,7 @@ status_t keyblob_from_key_and_mask(const uint32_t *key, const uint32_t *mask,
   // share0 = key ^ mask, share1 = mask
   size_t key_words = keyblob_share_num_words(config);
   uint32_t share0[key_words];
-  size_t i = 0;
-  for (; launder32(i) < key_words; i++) {
-    share0[i] = key[i] ^ mask[i];
-  }
-  HARDENED_CHECK_EQ(i, key_words);
+  HARDENED_TRY(hardened_xor(key, mask, key_words, share0));
 
   return keyblob_from_shares(share0, mask, config, keyblob);
 }


### PR DESCRIPTION
Currently, the keyblob_from_key_and_mask() function XORs the key with the mask using an XOR. We should switch to a hardened_xor() that is protected against FI and SCA.