### PR TITLE
[crypto] Cryptolib versioning

### DIFF
--- a/rules/autogen.bzl
+++ b/rules/autogen.bzl
@@ -207,6 +207,73 @@ def autogen_build_info(name):
         alwayslink = True,
     )
 
+def _cryptolib_build_info_src(ctx):
+    stamp_args = []
+    stamp_files = []
+    if stamping_enabled(ctx):
+        stamp_files = [ctx.version_file]
+        stamp_args.append("--ot_version_file")
+        stamp_args.append(ctx.version_file.path)
+    else:
+        print("NOTE: stamping is disabled, the build_info section will use a fixed version string")
+        stamp_args.append("--default_version")
+
+        # The script expects a 20-character long hash: "OpenTitanOpenTitanOT"
+        stamp_args.append("4f70656e546974616e4f70656e546974616e4f54")
+
+    out_source = ctx.actions.declare_file("cryptolib_build_info.c")
+    ctx.actions.run(
+        outputs = [
+            out_source,
+        ],
+        inputs = [
+            ctx.executable._tool,
+        ] + stamp_files,
+        arguments = [
+            "-o",
+            out_source.dirname,
+        ] + stamp_args,
+        executable = ctx.executable._tool,
+    )
+
+    return [
+        DefaultInfo(files = depset([out_source])),
+    ]
+
+autogen_cryptolib_build_info_src = rule(
+    implementation = _cryptolib_build_info_src,
+    attrs = {
+        "_tool": attr.label(
+            default = "//util:cryptolib_build_info",
+            executable = True,
+            cfg = "exec",
+        ),
+    } | stamp_attr(-1, "//rules:stamp_flag"),
+)
+
+def autogen_cryptolib_build_info(name):
+    """Generates a cc_library named `name` that defines the cryptolib ID."""
+
+    # Generate a C source file that defines the build ID struct. This is an
+    # implementation detail and should not be depended on externally.
+    cryptolib_build_info_src_target = name + "_gen_src"
+    autogen_cryptolib_build_info_src(name = cryptolib_build_info_src_target)
+
+    # Package up the generated source file with its corresponding header file
+    # and dependencies. Any target that wants access to the build ID should
+    # depend on this.
+    native.cc_library(
+        name = name,
+        srcs = [cryptolib_build_info_src_target],
+        hdrs = ["//sw/device/lib/crypto/drivers:cryptolib_build_info.h"],
+        deps = [
+            "//sw/device/lib/crypto/include:datatypes",
+        ],
+        # Make sure to participate in linking so that the symbol is not discarded
+        # (since it is not meant to be directly used).
+        alwayslink = True,
+    )
+
 def _cryptotest_hjson_external(ctx):
     """
     Implementation of the Bazel rule for parsing externally-sourced test vectors.

--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -4,6 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
+load("//rules:autogen.bzl", "autogen_cryptolib_build_info")
 load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
 load(
     "//rules:cross_platform.bzl",
@@ -24,6 +25,8 @@ load(
     "@bazel_skylib//lib:dicts.bzl",
     "dicts",
 )
+
+autogen_cryptolib_build_info(name = "cryptolib_build_info")
 
 cc_library(
     name = "aes",

--- a/sw/device/lib/crypto/drivers/cryptolib_build_info.h
+++ b/sw/device/lib/crypto/drivers/cryptolib_build_info.h
@@ -1,0 +1,61 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_CRYPTOLIB_BUILD_INFO_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_CRYPTOLIB_BUILD_INFO_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/crypto/include/datatypes.h"
+
+/**
+ * A truncated commit hash from the sw/device/lib/crypto directory from
+ * the open-source OpenTitan repo that can be used to reproduce the
+ * cryptolib binary.
+ */
+typedef struct cryptolib_build_info_scm_revision {
+  /**
+   * Least significant word of the truncated commit hash.
+   */
+  uint32_t scm_revision_low;
+  /**
+   * Most significant word of the truncated commit hash.
+   */
+  uint32_t scm_revision_high;
+} cryptolib_build_info_scm_revision_t;
+
+typedef struct cryptolib_build_info {
+  /**
+   * Truncated commit hash.
+   */
+  cryptolib_build_info_scm_revision_t scm_revision;
+  /**
+   * Cryptolib version.
+   */
+  uint32_t version;
+  /**
+   * Cryptolib released.
+   */
+  bool released;
+} cryptolib_build_info_t;
+
+enum {
+  /**
+   * Cryptolib version.
+   * Currently the CL is in development, so this version is not
+   * frozen.
+   */
+  kCryptoLibVersion = kOtcryptoLibVersion1,
+  /**
+   * Indicates whether the cryptolib is released or not.
+   */
+  kCryptoLibReleased = false,
+};
+
+/**
+ * The build information.
+ */
+extern const cryptolib_build_info_t kCryptoLibBuildInfo;
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_CRYPTOLIB_BUILD_INFO_H_

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -47,6 +47,17 @@ cc_library(
 )
 
 cc_library(
+    name = "cryptolib_build_info",
+    srcs = ["cryptolib_build_info.c"],
+    hdrs = ["//sw/device/lib/crypto/include:cryptolib_build_info.h"],
+    deps = [
+        ":status",
+        "//sw/device/lib/crypto/drivers:cryptolib_build_info",
+        "//sw/device/lib/crypto/include:datatypes",
+    ],
+)
+
+cc_library(
     name = "drbg",
     srcs = ["drbg.c"],
     hdrs = ["//sw/device/lib/crypto/include:drbg.h"],

--- a/sw/device/lib/crypto/impl/cryptolib_build_info.c
+++ b/sw/device/lib/crypto/impl/cryptolib_build_info.c
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
+
+#include "sw/device/lib/crypto/drivers/cryptolib_build_info.h"
+#include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('c', 'b', 'i')
+
+otcrypto_status_t otcrypto_build_info(uint32_t *version, bool *released,
+                                      uint32_t *build_hash_low,
+                                      uint32_t *build_hash_high) {
+  *version = kCryptoLibBuildInfo.version;
+  *released = kCryptoLibBuildInfo.released;
+  *build_hash_low = kCryptoLibBuildInfo.scm_revision.scm_revision_low;
+  *build_hash_high = kCryptoLibBuildInfo.scm_revision.scm_revision_high;
+
+  return OTCRYPTO_OK;
+}

--- a/sw/device/lib/crypto/include/BUILD
+++ b/sw/device/lib/crypto/include/BUILD
@@ -25,6 +25,7 @@ cc_library(
     hdrs = [
         "aes.h",
         "aes_gcm.h",
+        "cryptolib_build_info.h",
         "datatypes.h",
         "drbg.h",
         "ecc_p256.h",
@@ -57,6 +58,7 @@ cc_library(
     hdrs = [
         "aes.h",
         "aes_gcm.h",
+        "cryptolib_build_info.h",
         "datatypes.h",
         "drbg.h",
         "ecc_p256.h",

--- a/sw/device/lib/crypto/include/cryptolib_build_info.h
+++ b/sw/device/lib/crypto/include/cryptolib_build_info.h
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_CRYPTOLIB_BUILD_INFO_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_CRYPTOLIB_BUILD_INFO_H_
+
+#include "datatypes.h"
+
+/**
+ * @file
+ * @brief Cryptolib build information.
+ *
+ * Returns the version of the cryptolib as well as the git hash.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Read the cryptolib build information.
+ *
+ * Returns the current version of the cryptolib as well as the
+ * latest git commit hash of the `sw/device/lib/crypto` directory.
+ *
+ * @param ctx Pointer to the generic HMAC context struct.
+ * @param[out] version The current version of the cryptolib.
+ * @param[out] build_hash_low The low portion of the git commit hash of
+ * `sw/device/lib/crypto`.
+ * @param[out] build_hash_high The high portion of the git commit hash of
+ * `sw/device/lib/crypto`.
+ * @return Result of the HMAC final operation.
+ */
+otcrypto_status_t otcrypto_build_info(uint32_t *version, bool *released,
+                                      uint32_t *build_hash_low,
+                                      uint32_t *build_hash_high);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_CRYPTOLIB_BUILD_INFO_H_

--- a/sw/device/lib/crypto/include/otcrypto.h
+++ b/sw/device/lib/crypto/include/otcrypto.h
@@ -7,6 +7,7 @@
 
 #include "aes.h"
 #include "aes_gcm.h"
+#include "cryptolib_build_info.h"
 #include "datatypes.h"
 #include "drbg.h"
 #include "ecc_p256.h"

--- a/util/BUILD
+++ b/util/BUILD
@@ -34,6 +34,11 @@ py_test(
 )
 
 py_binary(
+    name = "cryptolib_build_info",
+    srcs = ["cryptolib_build_info.py"],
+)
+
+py_binary(
     name = "regtool",
     srcs = ["regtool.py"],
     deps = [

--- a/util/cryptolib_build_info.py
+++ b/util/cryptolib_build_info.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""Generates cryptolib_build_info.c for cryptolib build."""
+
+import argparse
+import logging as log
+from pathlib import Path
+
+import version_file
+
+
+def generate_build_info_c_source(scm_revision: int) -> str:
+    """Return the contents of a C source file that defines `kCryptoLibBuildInfo`.
+
+    Args:
+        scm_revision: SHA1 sum identifying the current SCM revision.
+    """
+    SHA1_BYTE_CNT = 20
+    assert 0 < scm_revision < 2**(SHA1_BYTE_CNT * 8)
+    scm_rev_byte_be = scm_revision.to_bytes(SHA1_BYTE_CNT, "big")
+    scm_revision_high = int.from_bytes(scm_rev_byte_be[0:4], "big")
+    scm_revision_low = int.from_bytes(scm_rev_byte_be[4:8], "big")
+
+    return f"""
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// --------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! ---------//
+
+#include "sw/device/lib/crypto/drivers/cryptolib_build_info.h"
+
+#include "sw/device/lib/crypto/include/datatypes.h"
+
+OT_USED
+const cryptolib_build_info_t kCryptoLibBuildInfo = {{
+  .scm_revision = (cryptolib_build_info_scm_revision_t){{
+    .scm_revision_low = {scm_revision_low:#010x},
+    .scm_revision_high = {scm_revision_high:#010x},
+  }},
+  .version = (uint32_t)kCryptoLibVersion,
+  .released = (bool)kCryptoLibReleased,
+}};
+"""
+
+
+def read_version_file(version_info_path, default_version) -> int:
+    """
+    Search for the scm revision variable and interprets
+    the contents as a big-endian hex literal. Return an error
+    if the revision cannot be found.
+    """
+
+    version_info = version_file.VersionInformation(version_info_path)
+    version = version_info.cryptolib_scm_revision(default_version)
+    return int(version, base=16)
+
+
+def write_source_file(outdir: Path, contents: str) -> Path:
+    """Creates cryptolib_build_info.c in `outdir`. Returns the path to the new file."""
+
+    source_out_path = outdir / "cryptolib_build_info.c"
+
+    outdir.mkdir(parents=True, exist_ok=True)
+    with source_out_path.open(mode='w', encoding='utf-8') as fout:
+        fout.write(contents)
+
+    return source_out_path
+
+
+def main():
+    log.basicConfig(format="%(levelname)s: %(message)s")
+
+    parser = argparse.ArgumentParser(prog="cryptolib_build_info")
+    parser.add_argument('--outdir',
+                        '-o',
+                        required=True,
+                        type=Path,
+                        help='Output Directory')
+    parser.add_argument('--ot_version_file',
+                        type=Path,
+                        help='Path to a file with the OpenTitan Version')
+    parser.add_argument('--default_version',
+                        type=str,
+                        help='Version to use if the version file does not indicate a version')
+
+    args = parser.parse_args()
+
+    # Extract version stamp from file
+    version = read_version_file(args.ot_version_file, args.default_version)
+    log.info("Version: %x" % (version, ))
+
+    generated_source = generate_build_info_c_source(version)
+    out_path = write_source_file(args.outdir, generated_source)
+    log.info("Generated new source file: %s" % (out_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/util/get_workspace_status.sh
+++ b/util/get_workspace_status.sh
@@ -53,3 +53,10 @@ else
 fi
 echo "BUILD_SCM_STATUS ${tree_status}"
 echo "STABLE_BUILD_SCM_STATUS ${tree_status}"
+
+git_cl_rev=$(git log --pretty=tformat:"%H" -n 1 sw/device/lib/crypto/)
+if [[ $? != 0 ]];
+then
+  exit 1
+fi
+echo "BUILD_CRYPTOLIB_SCM_REVISION ${git_cl_rev}"

--- a/util/version_file.py
+++ b/util/version_file.py
@@ -33,3 +33,6 @@ class VersionInformation():
 
     def scm_status(self, default: Union[str, None] = None) -> Union[str, None]:
         return self.version_stamp.get('BUILD_SCM_STATUS', default)
+
+    def cryptolib_scm_revision(self, default: Union[str, None] = None) -> Union[str, None]:
+        return self.version_stamp.get('BUILD_CRYPTOLIB_SCM_REVISION', default)


### PR DESCRIPTION
This commit adds a versioning concept to the cryptolib. cryptolib_build_info_t contains:
- released - is the CL version released or not?
- version - pinned version of the CL
- scm_revision_low/high - truncated commit hash of sw/device/lib/crypto