### PR TITLE
[dma] fix typo in "bits" field

### DIFF
--- a/hw/ip/dma/data/dma.hjson
+++ b/hw/ip/dma/data/dma.hjson
@@ -558,7 +558,7 @@
                 When 1: Source address wraps back to the starting address when finishing a chunk.
                 '''
         }
-        { bits: 0
+        { bits: "0"
           name: "increment"
           resval: 0x0
           desc: '''


### PR DESCRIPTION
The "bits" field should be surrounded with quote signs to be text value. Fix the field "verbose" (index 0) in the "SRC_CONFIG" register.