### PR TITLE
[crypto] Fix conditional subtraction in p384_key_from_seed

### DIFF
--- a/sw/otbn/crypto/p384_keygen_from_seed.s
+++ b/sw/otbn/crypto/p384_keygen_from_seed.s
@@ -1,3 +1,7 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 /* Copyright lowRISC contributors (OpenTitan project). */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
@@ -98,9 +102,6 @@ p384_key_from_seed:
   bn.sub    w24, w10, w16
   bn.subb   w25, w11, w17
 
-  /* Clear flags. */
-  bn.sub    w31, w31, w31
-
   /* Compute d1. Because 2^384 < 2 * n, a conditional subtraction is
      sufficient to reduce. Similarly to the carry bit, the conditional bit here
      is not very sensitive because the shares are large relative to n.
@@ -108,7 +109,7 @@ p384_key_from_seed:
   bn.sel    w5, w10, w24, FG0.C
   bn.sel    w6, w11, w25, FG0.C
 
-  /* Clear w25 before over writing it with a different share. */
+  /* Clear w25 before over writing it with a different share and clear flags. */
   bn.xor    w25, w25, w25
 
   /* Dummy instruction to avoid consecutive share access. */


### PR DESCRIPTION
This small PR removes a flag clear in `p384_keygen_from_seed.s` to re-enable a conditional subtraction in `p384_key_from_seed`. Without this conditional subtraction, a small bias is introduced into the generated key distribution as the modified function will no longer always compute `d = (d0' + d1') mod n` for `d0'`, `d1'` congruent to `d0`, `d1` modulo `n` respectively.

For side channel purposes, the existing `bn.xor` after the conditional subtraction already handles clearing flags, so no further changes are needed.