### PR TITLE
[csrng/sw] Add NIST generate KAT with additional_data

### DIFF
--- a/sw/device/lib/dif/dif_csrng.c
+++ b/sw/device/lib/dif/dif_csrng.c
@@ -98,7 +98,9 @@ dif_result_t dif_csrng_update(const dif_csrng_t *csrng,
                             });
 }
 
-dif_result_t dif_csrng_generate_start(const dif_csrng_t *csrng, size_t len) {
+dif_result_t dif_csrng_generate_start(
+    const dif_csrng_t *csrng, const dif_csrng_seed_material_t *additional_data,
+    size_t len) {
   if (csrng == NULL || len == 0) {
     return kDifBadArg;
   }
@@ -109,6 +111,7 @@ dif_result_t dif_csrng_generate_start(const dif_csrng_t *csrng, size_t len) {
   return csrng_send_app_cmd(csrng->base_addr, kCsrngAppCmdTypeCsrng,
                             (csrng_app_cmd_t){
                                 .id = kCsrngAppCmdGenerate,
+                                .seed_material = additional_data,
                                 .generate_len = num_128bit_blocks,
                             });
 }

--- a/sw/device/lib/dif/dif_csrng.h
+++ b/sw/device/lib/dif/dif_csrng.h
@@ -431,12 +431,16 @@ dif_result_t dif_csrng_update(const dif_csrng_t *csrng,
  * of the request to align it to the nearest 128-bit boundary.
  *
  * @param csrng A CSRNG handle.
+ * @param additional_data Additional data for the generate command. Set to NULL
+ * if unused.
  * @param len Number of uint32_t words to generate.
  * @return The result of the operation. KDifOutOfRange if the `len` parameter
  * results in a 128bit block level size greater than 0x800.
  */
 OT_WARN_UNUSED_RESULT
-dif_result_t dif_csrng_generate_start(const dif_csrng_t *csrng, size_t len);
+dif_result_t dif_csrng_generate_start(
+    const dif_csrng_t *csrng, const dif_csrng_seed_material_t *additional_data,
+    size_t len);
 
 /**
  * Reads the output of the last CSRNG generate call.

--- a/sw/device/lib/dif/dif_csrng_unittest.cc
+++ b/sw/device/lib/dif/dif_csrng_unittest.cc
@@ -294,19 +294,19 @@ TEST_F(CommandTest, GenerateOk) {
                 {{CSRNG_SW_CMD_STS_CMD_RDY_BIT, true}});
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET,
                  0x00004003 | kMultiBitBool4False << 8);
-  EXPECT_DIF_OK(dif_csrng_generate_start(&csrng_, /*len=*/16));
+  EXPECT_DIF_OK(dif_csrng_generate_start(&csrng_, nullptr, /*len=*/16));
 
   // 576bits = 18 x 32bit = 5 x 128bit blocks (rounded up)
   EXPECT_READ32(CSRNG_SW_CMD_STS_REG_OFFSET,
                 {{CSRNG_SW_CMD_STS_CMD_RDY_BIT, true}});
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET,
                  0x00005003 | kMultiBitBool4False << 8);
-  EXPECT_DIF_OK(dif_csrng_generate_start(&csrng_, /*len=*/18));
+  EXPECT_DIF_OK(dif_csrng_generate_start(&csrng_, nullptr, /*len=*/18));
 }
 
 TEST_F(CommandTest, GenerateBadArgs) {
-  EXPECT_DIF_BADARG(dif_csrng_generate_start(nullptr, /*len=*/1));
-  EXPECT_DIF_BADARG(dif_csrng_generate_start(&csrng_, /*len=*/0));
+  EXPECT_DIF_BADARG(dif_csrng_generate_start(nullptr, nullptr, /*len=*/1));
+  EXPECT_DIF_BADARG(dif_csrng_generate_start(&csrng_, nullptr, /*len=*/0));
 }
 
 TEST_F(CommandTest, GenerateOutOfRange) {
@@ -316,7 +316,7 @@ TEST_F(CommandTest, GenerateOutOfRange) {
     kGenerateLenOutOfRange = 0x800 * 4 + 1,
   };
   EXPECT_DIF_OUTOFRANGE(
-      dif_csrng_generate_start(&csrng_, kGenerateLenOutOfRange));
+      dif_csrng_generate_start(&csrng_, nullptr, kGenerateLenOutOfRange));
 }
 
 TEST_F(CommandTest, UninstantiateOk) {

--- a/sw/device/lib/testing/aes_testutils.c
+++ b/sw/device/lib/testing/aes_testutils.c
@@ -173,7 +173,7 @@ status_t aes_testutils_csrng_kat(const dif_csrng_t *csrng) {
   memcpy(expected_state_generate.v, kCsrngVGenerate, sizeof(kCsrngVGenerate));
   memcpy(expected_state_generate.key, kCsrngKeyGenerate,
          sizeof(kCsrngKeyGenerate));
-  TRY(csrng_testutils_kat_generate(csrng, 1, kCsrngBlockLen,
+  TRY(csrng_testutils_kat_generate(csrng, 1, kCsrngBlockLen, NULL,
                                    kAesMaskingPrngZeroOutputSeed,
                                    &expected_state_generate));
 
@@ -198,7 +198,7 @@ status_t aes_testutils_csrng_kat(const dif_csrng_t *csrng) {
 
   // Generate one block containing the required seed for the AES masking PRNG
   // to output an all-zero vector.
-  TRY(csrng_testutils_kat_generate(csrng, 1, kCsrngBlockLen,
+  TRY(csrng_testutils_kat_generate(csrng, 1, kCsrngBlockLen, NULL,
                                    kAesMaskingPrngZeroOutputSeed,
                                    &expected_state_generate));
   return OK_STATUS();

--- a/sw/device/lib/testing/csrng_testutils.h
+++ b/sw/device/lib/testing/csrng_testutils.h
@@ -48,12 +48,14 @@ status_t csrng_testutils_cmd_ready_wait(const dif_csrng_t *csrng);
  * Runs CSRNG generate command.
  *
  * @param csrng A CSRNG handle.
+ * @param additional_data Additional data, set to NULL if unused.
  * @param output Output buffer.
  * @param output_len Number of words of entropy to write to output buffer.
  */
 OT_WARN_UNUSED_RESULT
-status_t csrng_testutils_cmd_generate_run(const dif_csrng_t *csrng,
-                                          uint32_t *output, size_t output_len);
+status_t csrng_testutils_cmd_generate_run(
+    const dif_csrng_t *csrng, const dif_csrng_seed_material_t *additional_data,
+    uint32_t *output, size_t output_len);
 
 /**
  * Checks the CSRNG internal state against `expected` values.
@@ -86,12 +88,14 @@ status_t csrng_testutils_kat_instantiate(
  * @param num_generates Number of GENERATE commands to run.
  * @param output_len Number of output words to read from CSRNG after the last
  * command.
+ * @param additional_data Additional data, set to NULL if unused.
  * @param expected_output Expected CSRNG output after the last command.
  * @param expected_state Expected CSRNG internal state after the last command.
  */
 OT_WARN_UNUSED_RESULT
 status_t csrng_testutils_kat_generate(
-    const dif_csrng_t *csrng, uint32_t num_generates, uint32_t output_len,
+    const dif_csrng_t *csrng, size_t num_generates, size_t output_len,
+    const dif_csrng_seed_material_t *additional_data,
     const uint32_t *expected_output,
     const dif_csrng_internal_state_t *expected_state);
 
@@ -108,7 +112,8 @@ status_t csrng_testutils_kat_reseed(
     const dif_csrng_internal_state_t *expected_state);
 
 /**
- * CTR DRBG Known-Answer-Test (KAT) for INSTANTIATE command.
+ * CTR DRBG Known-Answer-Test (KAT) for INSTANTIATE command for a NIST test
+ * vector without additional data.
  *
  * @param csrng Handle.
  * @param fail_expected Expected fail.
@@ -118,12 +123,42 @@ status_t csrng_testutils_fips_instantiate_kat(const dif_csrng_t *csrng,
                                               bool fail_expected);
 
 /**
- * CTR DRBG Known-Answer-Test (KAT) for GENERATE command.
+ * CTR DRBG Known-Answer-Test (KAT) for INSTANTIATE command for a NIST test
+ * vector using additional data for the GENERATE command.
+ *
+ * @param csrng Handle.
+ * @param fail_expected Expected fail.
+ */
+OT_WARN_UNUSED_RESULT
+status_t csrng_testutils_fips_instantiate_kat_adata(const dif_csrng_t *csrng,
+                                                    bool fail_expected);
+
+/**
+ * CTR DRBG Known-Answer-Test (KAT) for GENERATE command for a NIST test
+ * vector without additional data.
  *
  * @param csrng Handle.
  */
 OT_WARN_UNUSED_RESULT
 status_t csrng_testutils_fips_generate_kat(const dif_csrng_t *csrng);
+
+/**
+ * CTR DRBG Known-Answer-Test (KAT) for GENERATE command for a NIST test
+ * vector with additional data, first call.
+ *
+ * @param csrng Handle.
+ */
+OT_WARN_UNUSED_RESULT
+status_t csrng_testutils_fips_generate_kat_adata1(const dif_csrng_t *csrng);
+
+/**
+ * CTR DRBG Known-Answer-Test (KAT) for GENERATE command for a NIST test
+ * vector with additional data, second call.
+ *
+ * @param csrng Handle.
+ */
+OT_WARN_UNUSED_RESULT
+status_t csrng_testutils_fips_generate_kat_adata2(const dif_csrng_t *csrng);
 
 /**
  * Checks CSRNG command status.

--- a/sw/device/tests/csrng_kat_test.c
+++ b/sw/device/tests/csrng_kat_test.c
@@ -18,6 +18,13 @@ status_t test_ctr_drbg_ctr0(const dif_csrng_t *csrng) {
   TRY(dif_csrng_uninstantiate(csrng));
   TRY(csrng_testutils_fips_instantiate_kat(csrng, /*fail_expected=*/false));
   TRY(csrng_testutils_fips_generate_kat(csrng));
+
+  // Additional test with adata supplied
+  TRY(dif_csrng_uninstantiate(csrng));
+  TRY(csrng_testutils_fips_instantiate_kat_adata(csrng, false));
+  TRY(csrng_testutils_fips_generate_kat_adata1(csrng));
+  TRY(csrng_testutils_fips_generate_kat_adata2(csrng));
+
   return OK_STATUS();
 }
 

--- a/sw/device/tests/csrng_smoketest.c
+++ b/sw/device/tests/csrng_smoketest.c
@@ -42,8 +42,8 @@ status_t test_ctr_drbg_ctr0_smoke(const dif_csrng_t *csrng) {
                                      &kEntropyInput));
 
   uint32_t got[kExpectedOutputLen];
-  TRY(csrng_testutils_cmd_generate_run(csrng, got, kExpectedOutputLen));
-  TRY(csrng_testutils_cmd_generate_run(csrng, got, kExpectedOutputLen));
+  TRY(csrng_testutils_cmd_generate_run(csrng, NULL, got, kExpectedOutputLen));
+  TRY(csrng_testutils_cmd_generate_run(csrng, NULL, got, kExpectedOutputLen));
 
   const uint32_t kExpectedOutput[kExpectedOutputLen] = {
       0xe48bb8cb, 0x1012c84c, 0x5af8a7f1, 0xd1c07cd9, 0xdf82ab22, 0x771c619b,

--- a/sw/device/tests/entropy_src_csrng_test.c
+++ b/sw/device/tests/entropy_src_csrng_test.c
@@ -141,8 +141,8 @@ static void irq_block_wait(irq_flag_id_t isr_id) {
  */
 static void csrng_generate_output_check(void) {
   uint32_t output[kTestParamFifoBufferSize] = {0};
-  CHECK_STATUS_OK(
-      csrng_testutils_cmd_generate_run(&csrng, output, ARRAYSIZE(output)));
+  CHECK_STATUS_OK(csrng_testutils_cmd_generate_run(&csrng, NULL, output,
+                                                   ARRAYSIZE(output)));
 
   uint32_t prev_data = 0;
   for (size_t i = 0; i < ARRAYSIZE(output); ++i) {

--- a/sw/device/tests/penetrationtests/firmware/fi/rng_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/rng_fi.c
@@ -487,7 +487,7 @@ status_t handle_rng_fi_csrng_bias(ujson_t *uj) {
   if (uj_data.all_trigger || uj_data.start_trigger) {
     pentest_set_trigger_high();
   }
-  TRY(dif_csrng_generate_start(&csrng, kCsrngExpectedOutputLen));
+  TRY(dif_csrng_generate_start(&csrng, NULL, kCsrngExpectedOutputLen));
   if (uj_data.start_trigger) {
     pentest_set_trigger_low();
   }
@@ -598,7 +598,7 @@ status_t handle_rng_fi_csrng_bias_fw_override(ujson_t *uj, bool static_seed) {
   CHECK_DIF_OK(dif_csrng_instantiate(&csrng, kDifCsrngEntropySrcToggleEnable,
                                      &kEmptySeedMaterial));
 
-  CHECK_STATUS_OK(csrng_testutils_cmd_generate_run(&csrng, received_data,
+  CHECK_STATUS_OK(csrng_testutils_cmd_generate_run(&csrng, NULL, received_data,
                                                    ARRAYSIZE(received_data)));
 
   asm volatile(NOP30);

--- a/sw/device/tests/sim_dv/csrng_lc_hw_debug_en_test.c
+++ b/sw/device/tests/sim_dv/csrng_lc_hw_debug_en_test.c
@@ -278,7 +278,8 @@ static void csrng_static_generate_run(uint32_t *output, size_t output_len) {
   CHECK_DIF_OK(dif_csrng_instantiate(&csrng, kDifCsrngEntropySrcToggleEnable,
                                      &kEmptySeedMaterial));
 
-  CHECK_STATUS_OK(csrng_testutils_cmd_generate_run(&csrng, output, output_len));
+  CHECK_STATUS_OK(
+      csrng_testutils_cmd_generate_run(&csrng, NULL, output, output_len));
   uint32_t prev_word = 0;
   for (size_t i = 0; i < output_len; ++i) {
     CHECK(prev_word != output[i],


### PR DESCRIPTION
See commit message. This PR extends the software test coverage of the CSRNG.