### PR TITLE
[test] Ignore bus integrity alert for scrambled SRAM test

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -7386,6 +7386,7 @@ opentitan_test(
         "//sw/device/lib/testing:flash_ctrl_testutils",
         "//sw/device/lib/testing:rstmgr_testutils",
         "//sw/device/lib/testing:sram_ctrl_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_alerts",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/tests/sram_ctrl_scrambled_access_test.c
+++ b/sw/device/tests/sram_ctrl_scrambled_access_test.c
@@ -16,6 +16,7 @@
 #include "sw/device/lib/testing/rstmgr_testutils.h"
 #include "sw/device/lib/testing/sram_ctrl_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_alerts.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -126,6 +127,26 @@ static const uint32_t kRamTestPattern2[kTestBufferSizeWords] = {
  */
 static const uint8_t kBackdoorExpectedBytes[kTestBufferSizeBytes];
 
+// This is not done on CW305/CW310 FPGAs because interrupts for ECC errors are
+// only triggered when the SecureIbex parameter is enabled. This parameter is
+// disabled for these boards due to resource constraints. On CW340 and the other
+// targets, this parameter is enabled.
+static bool expect_ecc_errors(void) {
+  switch (kDeviceType) {
+    case kDeviceFpgaCw305:
+    case kDeviceFpgaCw310:
+      return false;
+    case kDeviceFpgaCw340:
+    case kDeviceSilicon:
+    case kDeviceSimDV:
+    case kDeviceSimVerilator:
+      return true;
+    default:
+      CHECK(false, "Device type not handled: %d", kDeviceType);
+      return false;
+  }
+}
+
 /**
  * Performs scrambling, saves the test relevant data and resets the system.
  *
@@ -146,6 +167,14 @@ static noreturn void main_sram_scramble(void) {
   // platforms and the number of ECC errors will be doubled.
   if (kDeviceType == kDeviceSimDV) {
     copy_len += sizeof(reference_frame->backdoor);
+  }
+
+  // If we expect ECC errors from copying our pattern buffers then we have to
+  // disable the fatal alert associated with bus integrity checks. This is a
+  // fatal alert so we cannot "expect" it.
+  if (expect_ecc_errors()) {
+    CHECK_STATUS_OK(
+        ottf_alerts_ignore_alert(kTopEarlgreyAlertIdRvCoreIbexFatalHwErr));
   }
 
   asm volatile(
@@ -256,6 +285,17 @@ static void execute_main_sram_test(void) {
 }
 
 static void check_sram_data(scramble_test_frame *mem_frame) {
+  // Decide whether to perform ECC error count checks after memory is scrambled.
+  bool check_ecc_errors = expect_ecc_errors();
+
+  // If we expect ECC errors from copying our pattern buffers then we have to
+  // disable the fatal alert associated with bus integrity checks. This is a
+  // fatal alert so we cannot "expect" it.
+  if (check_ecc_errors) {
+    CHECK_STATUS_OK(
+        ottf_alerts_ignore_alert(kTopEarlgreyAlertIdRvCoreIbexFatalHwErr));
+  }
+
   LOG_INFO("Checking addr 0x%x", mem_frame->pattern);
   uint32_t tmp_buffer[kTestBufferSizeWords];
   memcpy(tmp_buffer, (const uint8_t *)mem_frame->pattern, sizeof(tmp_buffer));
@@ -264,29 +304,6 @@ static void check_sram_data(scramble_test_frame *mem_frame) {
                   kTestBufferSizeWords);
   CHECK_ARRAYS_NE((uint32_t *)tmp_buffer, kRamTestPattern2,
                   kTestBufferSizeWords);
-
-  // Decide whether to perform ECC error count checks after memory is scrambled.
-  //
-  // This is not done on CW305/CW310 FPGAs because interrupts for ECC errors are
-  // only triggered when the SecureIbex parameter is enabled. This parameter is
-  // disabled for these boards due to resource constraints. On CW340 and the
-  // other targets, this parameter is enabled.
-  bool check_ecc_errors = false;
-  switch (kDeviceType) {
-    case kDeviceFpgaCw305:
-    case kDeviceFpgaCw310:
-      check_ecc_errors = false;
-      break;
-    case kDeviceFpgaCw340:
-    case kDeviceSilicon:
-    case kDeviceSimDV:
-    case kDeviceSimVerilator:
-      check_ecc_errors = true;
-      break;
-    default:
-      CHECK(false, "Device type not handled: %d", kDeviceType);
-      return;
-  }
 
   if (check_ecc_errors) {
     LOG_INFO("Checking ECC error count of %d",


### PR DESCRIPTION
When we expect ECC errors we have to ignore the fatal bus integrity alerts from Ibex otherwise the chip will repeatedly be interrupted.

This was missed by CI because the CW310 does not enable `SecureIbex` and the CW340 tests are not being run properly on this branch.