### PR TITLE
[test] Prevent creator secret being re-written

### DIFF
--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -246,6 +246,7 @@ cc_library(
         ":kmac_testutils",
         ":otp_ctrl_testutils",
         ":rstmgr_testutils",
+        "//hw/top:dt",
         "//hw/top:keymgr_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:boot_stage",

--- a/sw/device/lib/testing/keymgr_testutils.c
+++ b/sw/device/lib/testing/keymgr_testutils.c
@@ -4,13 +4,12 @@
 
 #include "sw/device/lib/testing/keymgr_testutils.h"
 
+#include "hw/top/dt/dt_otp_ctrl.h"
 #include "sw/device/lib/arch/boot_stage.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
 #include "sw/device/lib/dif/dif_keymgr.h"
-#include "sw/device/lib/dif/dif_kmac.h"
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
 #include "sw/device/lib/dif/dif_rstmgr.h"
-#include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/flash_ctrl_testutils.h"
@@ -78,8 +77,10 @@ status_t keymgr_testutils_flash_init(
     const keymgr_testutils_secret_t *creator_secret,
     const keymgr_testutils_secret_t *owner_secret) {
   // Initialize flash secrets.
-  write_info_page(flash, kFlashInfoPageIdCreatorSecret, creator_secret,
-                  /*scramble=*/true);
+  if (creator_secret) {
+    write_info_page(flash, kFlashInfoPageIdCreatorSecret, creator_secret,
+                    /*scramble=*/true);
+  }
   write_info_page(flash, kFlashInfoPageIdOwnerSecret, owner_secret,
                   /*scramble=*/true);
   return OK_STATUS();
@@ -87,8 +88,7 @@ status_t keymgr_testutils_flash_init(
 
 static status_t check_lock_otp_partition(void) {
   dif_otp_ctrl_t otp;
-  TRY(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), &otp));
+  TRY(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp));
 
   bool is_computed;
   TRY(dif_otp_ctrl_is_digest_computed(&otp, kDifOtpCtrlPartitionSecret2,
@@ -189,6 +189,7 @@ status_t keymgr_testutils_try_startup(dif_keymgr_t *keymgr, dif_kmac_t *kmac,
 status_t keymgr_testutils_init_nvm_then_reset(void) {
   dif_flash_ctrl_state_t flash;
   dif_rstmgr_t rstmgr;
+  dif_otp_ctrl_t otp_ctrl;
 
   TRY(dif_rstmgr_init(mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR),
                       &rstmgr));
@@ -201,8 +202,22 @@ status_t keymgr_testutils_init_nvm_then_reset(void) {
 
     TRY(dif_flash_ctrl_init_state(
         &flash, mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
+    TRY(dif_otp_ctrl_init(
+        mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR),
+        &otp_ctrl));
 
-    TRY(keymgr_testutils_flash_init(&flash, &kCreatorSecret, &kOwnerSecret));
+    bool secret2_computed = false;
+    TRY(dif_otp_ctrl_is_digest_computed(&otp_ctrl, kDifOtpCtrlPartitionSecret2,
+                                        &secret2_computed));
+
+    // Only initialise the creator secret if `SECRET2` digest has not been
+    // computed. `flash_ctrl` will throw a recoverable error if we try to write
+    // this afterwards.
+    const keymgr_testutils_secret_t *creator_secret = NULL;
+    if (!secret2_computed) {
+      creator_secret = &kCreatorSecret;
+    }
+    TRY(keymgr_testutils_flash_init(&flash, creator_secret, &kOwnerSecret));
 
     TRY(check_lock_otp_partition());
 


### PR DESCRIPTION
`keymgr` testutils tries to write the creator secret to flash even if it's locked, triggering a recoverable flash_ctrl alert. This is normally ignored but soon we want to start catching alerts.

(cherry picked from commit cbaf5e36413fd9d457547be0967c004effca4471)