### PR TITLE
[sw,cryptolib] Fix trigger_fault_if_fg0 functions

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/p256.c
+++ b/sw/device/lib/crypto/impl/ecc/p256.c
@@ -82,12 +82,12 @@ enum {
   /*
    * The expected instruction counts for constant time functions.
    */
-  kModeKeygenInsCnt = 574237,
-  kModeKeygenSideloadInsCnt = 574122,
-  kModeEcdhInsCnt = 581920,
-  kModeEcdhSideloadInsCnt = 581980,
-  kModeEcdsaSignInsCnt = 607411,
-  kModeEcdsaSignSideloadInsCnt = 607471,
+  kModeKeygenInsCnt = 573915,
+  kModeKeygenSideloadInsCnt = 573800,
+  kModeEcdhInsCnt = 581598,
+  kModeEcdhSideloadInsCnt = 581658,
+  kModeEcdsaSignInsCnt = 607087,
+  kModeEcdsaSignSideloadInsCnt = 607147,
 };
 
 static status_t p256_masked_scalar_write(p256_masked_scalar_t *src,

--- a/sw/otbn/crypto/boot.s
+++ b/sw/otbn/crypto/boot.s
@@ -168,7 +168,7 @@ attestation_keygen:
      The check fails if both sides are not equal.
      FG0.Z <= (y^2) mod p == (x^2 + ax + b) mod p */
   bn.cmp   w18, w19
-  jal      x1, trigger_fault_if_fg0_not_z
+  jal      x1, trigger_fault_if_fg0_z
 
   ecall
 

--- a/sw/otbn/crypto/p256_shared_key.s
+++ b/sw/otbn/crypto/p256_shared_key.s
@@ -89,7 +89,7 @@ p256_shared_key:
      The check fails if both sides are not equal.
      FG0.Z <= (y^2) mod p == (x^2 + ax + b) mod p */
   bn.cmp   w18, w19
-  jal      x1, trigger_fault_if_fg0_not_z
+  jal      x1, trigger_fault_if_fg0_z
 
   /* Arithmetic masking:
    1. Generate a random mask

--- a/sw/otbn/crypto/p256_sign.s
+++ b/sw/otbn/crypto/p256_sign.s
@@ -126,7 +126,7 @@ p256_sign:
      The check fails if both sides are not equal.
      FG0.Z <= (y^2) mod p == (x^2 + ax + b) mod p */
   bn.cmp   w18, w19
-  jal      x1, trigger_fault_if_fg0_not_z
+  jal      x1, trigger_fault_if_fg0_z
 
   /* setup modulus n (curve order) and Barrett constant
      MOD <= w29 <= n = dmem[p256_n]; w28 <= u_n = dmem[p256_u_n]  */
@@ -288,7 +288,7 @@ p256_sign:
      which violates ECDSA private key requirements. This could technically be
      triggered by an unlucky key manager seed, but the probability is so low (~1/n)
      that it more likely indicates a fault attack. */
-  jal       x1, trigger_fault_if_fg0_z
+  jal       x1, trigger_fault_if_fg0_not_z
 
   /* w24 = r <= w11  mod n */
   bn.addm   w24, w11, w31

--- a/sw/otbn/crypto/p384_isoncurve_proj.s
+++ b/sw/otbn/crypto/p384_isoncurve_proj.s
@@ -60,11 +60,11 @@ p384_isoncurve_proj_check:
        FG0.Z <= (y^2) mod p == (x^2 + ax + b) mod p */
   bn.cmp    w4, w2
   /* Fail if FG0.Z is false. */
-  jal       x1, trigger_fault_if_fg0_not_z
+  jal       x1, trigger_fault_if_fg0_z
 
   bn.cmp    w5, w3
   /* Fail if FG0.Z is false. */
-  jal       x1, trigger_fault_if_fg0_not_z
+  jal       x1, trigger_fault_if_fg0_z
 
   ret
 

--- a/sw/otbn/crypto/tests/BUILD
+++ b/sw/otbn/crypto/tests/BUILD
@@ -207,6 +207,10 @@ otbn_sim_test(
 
 otbn_consttime_test(
     name = "p256_base_mult_consttime",
+    ignore = [
+        "trigger_fault_if_fg0_z",
+        "trigger_fault_if_fg0_not_z",
+    ],
     subroutine = "p256_base_mult",
     deps = [
         "//sw/otbn/crypto:run_p256",
@@ -275,6 +279,10 @@ otbn_sim_test(
 
 otbn_consttime_test(
     name = "p256_shared_key_consttime",
+    ignore = [
+        "trigger_fault_if_fg0_z",
+        "trigger_fault_if_fg0_not_z",
+    ],
     subroutine = "p256_shared_key",
     deps = [
         "//sw/otbn/crypto:run_p256",
@@ -674,6 +682,7 @@ otbn_consttime_test(
 otbn_consttime_test(
     name = "p384_scalar_mult_consttime",
     ignore = [
+        "trigger_fault_if_fg0_z",
         "trigger_fault_if_fg0_not_z",
     ],
     subroutine = "p384_scalar_mult",


### PR DESCRIPTION
The trigger_fault_if_fg0 functions had a bug where we never trigger a fault. This new implementation should now correctly trigger the fault.

For the case where no fault is triggered, we load address 0 into w31. For the error case we try to load address 0 into w39 (which doesn't exist), which triggers a ILLEGAL_INSN error.

This PR is based on https://github.com/lowRISC/opentitan/pull/28592