### PR TITLE
[sw,cryptolib] Remove AES todos for using hardened memcpy

### DIFF
--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -246,7 +246,9 @@ static status_t get_block(otcrypto_const_byte_buf_t input,
     HARDENED_CHECK_LT(index, num_full_blocks);
     // No need to worry about padding, just copy the data into the output
     // block.
-    // TODO(#17711) Change to `hardened_memcpy`.
+    // Byte buffers passed as input may not be word-aligned, so we cannot
+    // use `hardened_memcpy`.
+    // This is acceptable because the data is non-sensitive.
     memcpy(block->data, &input.data[index * kAesBlockNumBytes],
            kAesBlockNumBytes);
     return OTCRYPTO_OK;
@@ -407,7 +409,9 @@ static otcrypto_status_t otcrypto_aes_impl(
     HARDENED_TRY(get_block(cipher_input, aes_padding, i, &block_in));
     HARDENED_TRY(hardened_memshred(block_out.data, ARRAYSIZE(block_out.data)));
     HARDENED_TRY(aes_update(&block_out, &block_in));
-    // TODO(#17711) Change to `hardened_memcpy`.
+    // Byte buffers passed as input may not be word-aligned, so we cannot
+    // use `hardened_memcpy`.
+    // This is acceptable because the data is non-sensitive.
     memcpy(&cipher_output.data[(i - block_offset) * kAesBlockNumBytes],
            block_out.data, kAesBlockNumBytes);
   }
@@ -418,7 +422,9 @@ static otcrypto_status_t otcrypto_aes_impl(
   // input).
   for (i = block_offset; i > 0; --i) {
     HARDENED_TRY(aes_update(&block_out, /*src=*/NULL));
-    // TODO(#17711) Change to `hardened_memcpy`.
+    // Byte buffers passed as input may not be word-aligned, so we cannot
+    // use `hardened_memcpy`.
+    // This is acceptable because the data is non-sensitive.
     memcpy(&cipher_output.data[(input_nblocks - i) * kAesBlockNumBytes],
            block_out.data, kAesBlockNumBytes);
   }


### PR DESCRIPTION
This PR removes TODOs in aes.c that have to do with using hardened mem copy for byte aligned buffers. This is not necessary and we can remove the TODOs.

resolves [#17711](https://github.com/lowRISC/opentitan/issues/17711)