### PR TITLE
[sw,otbn] Fix earlgrey otbn patch offset

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/otbn.c
+++ b/sw/device/silicon_creator/lib/drivers/otbn.c
@@ -268,7 +268,7 @@ rom_error_t sc_otbn_load_app(const sc_otbn_app_t app) {
 void sc_otbn_patch(void) {
   enum {
     // Offset in the code of the bad instruction:
-    kBugOffset = 0x958,
+    kBugOffset = 0x888,
     // The bad instruction is:
     // bn.rshi   w16, w20, w31 >> 192
     kBadInstr = 0xc1fa387b,


### PR DESCRIPTION
The older OTBN boot binary in the `Earlgrey-PROD-A2-M6-ROM-RC1` ROM release is different from the one when PR #27679 was authored.

The instruction to be patched in the binary built on `Earlgrey-PROD-A2-M6-ROM-RC1` tag is 0x888:
```
git checkout --detach Earlgrey-PROD-A2-M6-ROM-RC1
./bazelisk.sh build //sw/otbn/crypto:boot
ar x --output=/tmp/ bazel-bin/sw/otbn/crypto/boot.rv32embed.a
llvm-objcopy-19 -O binary /tmp/boot.rv32embed.o /tmp/boot.bin

xxd /tmp/boot.bin | grep '7b38 fac1'
00000880: 7bb9 0fc1 7b3a f841 7b38 fac1 0b77 2000  {...{:.A{8...w .
```