### PR TITLE
[sw/base] Fix incorrect `ct_sltu32`

### DIFF
--- a/sw/device/lib/base/hardened.h
+++ b/sw/device/lib/base/hardened.h
@@ -414,7 +414,7 @@ inline ct_bool32_t ct_sltz32(int32_t a) {
 OT_WARN_UNUSED_RESULT
 inline ct_bool32_t ct_sltu32(uint32_t a, uint32_t b) {
   // Proof. See Hacker's Delight page 23.
-  return ct_sltz32(OT_SIGNED(((a & ~b) | ((a ^ ~b) & (a - b)))));
+  return ct_sltz32(OT_SIGNED(((~a & b) | ((~a | b) & (a - b)))));
 }
 
 /**


### PR DESCRIPTION
This function is supposed to compute a < b for two unsigned 32-bit integers in a constant-time manner. Its implementation was wrongly copied from Hacker's Delight (page 23).

Counterexample: a=0x3ca3dec3, b=0xa2b451a0

This function is only used at a single place (unclear whether the error was triggered or not).

https://github.com/lowRISC/opentitan/blob/cb622e033949a2168e762d5c6b1c3ce661c42bf9/sw/device/lib/base/random_order.c#L29