### PR TITLE
[dv] Unpack some randomised structs in DV code

### DIFF
--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env.core
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:dv:cip_lib
     files:
       - adc_ctrl_env_pkg.sv
+      - adc_ctrl_filter_cfg.sv: {is_include_file: true}
       - adc_ctrl_env_cfg.sv: {is_include_file: true}
       - adc_ctrl_env_var_filter_cfg.sv : {is_include_file: true}
       - adc_ctrl_env_cov.sv: {is_include_file: true}

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cov.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cov.sv
@@ -20,12 +20,12 @@ class adc_ctrl_filter_cg_wrapper #(
   covergroup adc_ctrl_filter_cg(
       int channel, int filter
   ) with function sample (
-      adc_ctrl_filter_cfg_t cfg, bit is_interrupt = 0, bit is_wakeup = 0, bit clk_gate = 0
+      adc_ctrl_filter_cfg cfg, bit is_interrupt = 0, bit is_wakeup = 0, bit clk_gate = 0
   );
     option.name = $sformatf("adc_ctrl_filter_cg_%0d_%0d", channel, filter);
     option.per_instance = 1;
 
-    cond_cp: coverpoint cfg.cond;
+    match_outside_cp: coverpoint cfg.match_outside;
     min_v_cp: coverpoint cfg.min_v {
       bins minimum = {0};
       bins values[NUMBER_VALUES] = {[1 : (2 ** FILTER_WIDTH - 2)]};
@@ -36,14 +36,14 @@ class adc_ctrl_filter_cg_wrapper #(
       bins values[NUMBER_VALUES] = {[1 : (2 ** FILTER_WIDTH - 2)]};
       bins maximum = {2 ** FILTER_WIDTH - 1};
     }
-    en_cp: coverpoint cfg.en;
+    en_cp: coverpoint cfg.enabled;
     interrupt_cp: coverpoint is_interrupt;
     wakeup_cp: coverpoint is_wakeup;
     clk_gate_cp: coverpoint clk_gate;
-    intr_min_v_cond_xp: cross interrupt_cp, min_v_cp, cond_cp;
-    intr_max_v_cond_xp: cross interrupt_cp, max_v_cp, cond_cp;
-    wakeup_min_v_cond_xp: cross wakeup_cp, min_v_cp, cond_cp;
-    wakeup_max_v_cond_xp: cross wakeup_cp, max_v_cp, cond_cp;
+    intr_min_v_cond_xp: cross interrupt_cp, min_v_cp, match_outside_cp;
+    intr_max_v_cond_xp: cross interrupt_cp, max_v_cp, match_outside_cp;
+    wakeup_min_v_cond_xp: cross wakeup_cp, min_v_cp, match_outside_cp;
+    wakeup_max_v_cond_xp: cross wakeup_cp, max_v_cp, match_outside_cp;
     wakeup_gated_xp : cross wakeup_cp, clk_gate_cp;
   endgroup
 
@@ -96,7 +96,7 @@ class adc_ctrl_env_cov extends cip_base_env_cov #(
   endfunction : build_phase
 
   // Sample filter coverage
-  virtual function void sample_filter_cov(int channel, int filter, adc_ctrl_filter_cfg_t cfg,
+  virtual function void sample_filter_cov(int channel, int filter, adc_ctrl_filter_cfg cfg,
                                           bit is_interrupt = 0, bit is_wakeup = 0,
                                           bit clk_gate = 0);
     adc_ctrl_filter_cg_wrapper_insts[channel][filter].adc_ctrl_filter_cg.sample(cfg, is_interrupt,

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_pkg.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_pkg.sv
@@ -74,39 +74,25 @@ package adc_ctrl_env_pkg;
     AdcCtrlResetModeHw
   } adc_ctrl_reset_mode_e;
 
-  // Filter condition coding
-  typedef enum bit {
-    ADC_CTRL_FILTER_COND_IN  = 0,
-    ADC_CTRL_FILTER_COND_OUT = 1
-  } adc_ctrl_filter_cond_e;
-
-  // Filter configuration
-  typedef struct {
-    adc_ctrl_filter_cond_e cond;  // Condition
-    int min_v;  // Minimum value
-    int max_v;  // Maximum value
-    bit en;  // Enable
-  } adc_ctrl_filter_cfg_t;
+  typedef class adc_ctrl_filter_cfg;
 
   // Constants
   // Filter defaults - applies to all channels
-  const
-  adc_ctrl_filter_cfg_t
-  FILTER_CFG_DEFAULTS[] = '{
-      '{min_v: 149, max_v: 279, cond: ADC_CTRL_FILTER_COND_IN, en: 1},
-      '{min_v: 391, max_v: 524, cond: ADC_CTRL_FILTER_COND_IN, en: 1},
-      '{min_v: 712, max_v: 931, cond: ADC_CTRL_FILTER_COND_IN, en: 1},
-      '{min_v: 712, max_v: 847, cond: ADC_CTRL_FILTER_COND_IN, en: 1},
-      '{min_v: 349, max_v: 512, cond: ADC_CTRL_FILTER_COND_IN, en: 1},
-      '{min_v: 405, max_v: 503, cond: ADC_CTRL_FILTER_COND_IN, en: 1},
-      '{min_v: 186, max_v: 279, cond: ADC_CTRL_FILTER_COND_IN, en: 1},
-      '{min_v: 116, max_v: 954, cond: ADC_CTRL_FILTER_COND_OUT, en: 1}
+  const adc_ctrl_filter_cfg FILTER_CFG_DEFAULTS[] = '{
+      adc_ctrl_filter_cfg::make("default0", 149, 279, 1),
+      adc_ctrl_filter_cfg::make("default1", 391, 524, 1),
+      adc_ctrl_filter_cfg::make("default2", 712, 931, 1),
+      adc_ctrl_filter_cfg::make("default3", 712, 847, 1),
+      adc_ctrl_filter_cfg::make("default4", 349, 512, 1),
+      adc_ctrl_filter_cfg::make("default5", 405, 503, 1),
+      adc_ctrl_filter_cfg::make("default6", 186, 279, 1),
+      adc_ctrl_filter_cfg::make("default7", 116, 954, 0)
   };
-  // functions and tasks
 
   // package sources
   `include "adc_ctrl_env_cfg.sv"
   `include "adc_ctrl_env_var_filter_cfg.sv"
+  `include "adc_ctrl_filter_cfg.sv"
   `include "adc_ctrl_env_cov.sv"
   `include "adc_ctrl_virtual_sequencer.sv"
   `include "adc_ctrl_scoreboard.sv"

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_pkg.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_pkg.sv
@@ -81,7 +81,7 @@ package adc_ctrl_env_pkg;
   } adc_ctrl_filter_cond_e;
 
   // Filter configuration
-  typedef struct packed {
+  typedef struct {
     adc_ctrl_filter_cond_e cond;  // Condition
     int min_v;  // Minimum value
     int max_v;  // Maximum value

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_filter_cfg.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_filter_cfg.sv
@@ -1,0 +1,67 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// The configuration for a single filter
+
+class adc_ctrl_filter_cfg extends uvm_object;
+  // An interval of values (inclusive).
+  rand bit [ADC_CTRL_DATA_WIDTH-1:0] min_v;
+  rand bit [ADC_CTRL_DATA_WIDTH-1:0] max_v;
+
+  // If match_outside is true, the filter matches a value iff it is not in [min_v, max_v]. If not,
+  // the filter matches a value iff it is *inside* [min_v, max_v].
+  rand bit match_outside;
+
+  // Control whether the filter is enabled
+  rand bit enabled;
+
+  `uvm_object_utils_begin(adc_ctrl_filter_cfg)
+    `uvm_field_int(min_v,        UVM_DEFAULT)
+    `uvm_field_int(max_v,        UVM_DEFAULT)
+    `uvm_field_int(match_outside, UVM_DEFAULT)
+    `uvm_field_int(enabled,      UVM_DEFAULT)
+  `uvm_object_utils_end
+
+  // Ensure that min_v <= max_v
+  extern constraint min_le_max_c;
+
+  extern function new (string name="");
+
+  // A static factory method that returns a filter with the range [min_v, max_v] and the
+  // given match_outside / enabled values.
+  extern static function adc_ctrl_filter_cfg make(string                        name,
+                                                  bit [ADC_CTRL_DATA_WIDTH-1:0] min_v,
+                                                  bit [ADC_CTRL_DATA_WIDTH-1:0] max_v,
+                                                  bit                           match_outside,
+                                                  bit                           enabled = 1'b1);
+endclass
+
+constraint adc_ctrl_filter_cfg::min_le_max_c {
+  min_v <= max_v;
+}
+
+function adc_ctrl_filter_cfg::new (string name="");
+  super.new(name);
+endfunction
+
+function adc_ctrl_filter_cfg
+  adc_ctrl_filter_cfg::make(string                        name,
+                            bit [ADC_CTRL_DATA_WIDTH-1:0] min_v,
+                            bit [ADC_CTRL_DATA_WIDTH-1:0] max_v,
+                            bit                           match_outside,
+                            bit                           enabled = 1'b1);
+  adc_ctrl_filter_cfg ret;
+
+  if (max_v < min_v) begin
+    `uvm_fatal("adc_ctrl_filter_cfg::make",
+               $sformatf("Backwards min_v/max_v range of [%0x, %0x]", min_v, max_v))
+  end
+
+  ret = adc_ctrl_filter_cfg::type_id::create(name);
+  ret.min_v = min_v;
+  ret.max_v = max_v;
+  ret.match_outside = match_outside;
+  ret.enabled = enabled;
+  return ret;
+endfunction

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_base_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_base_vseq.sv
@@ -87,8 +87,8 @@ class adc_ctrl_base_vseq extends cip_base_vseq #(
         // Set values from config object
         min_v_fld.set(cfg.filter_cfg[channel][filter].min_v);
         max_v_fld.set(cfg.filter_cfg[channel][filter].max_v);
-        cond_fld.set(cfg.filter_cfg[channel][filter].cond);
-        en_fld.set(cfg.filter_cfg[channel][filter].en);
+        cond_fld.set(cfg.filter_cfg[channel][filter].match_outside);
+        en_fld.set(cfg.filter_cfg[channel][filter].enabled);
         // Write register
         csr_wr(r, r.get());
       end

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_fsm_reset_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_fsm_reset_vseq.sv
@@ -102,11 +102,11 @@ class adc_ctrl_fsm_reset_vseq extends adc_ctrl_base_vseq;
     // Make sure filters will always match
     ral.adc_chn0_filter_ctl[0].min_v.set(0);
     ral.adc_chn0_filter_ctl[0].max_v.set(1023);
-    ral.adc_chn0_filter_ctl[0].cond.set(ADC_CTRL_FILTER_COND_IN);
+    ral.adc_chn0_filter_ctl[0].cond.set(1);
     ral.adc_chn0_filter_ctl[0].en.set(1);
     ral.adc_chn1_filter_ctl[0].min_v.set(0);
     ral.adc_chn1_filter_ctl[0].max_v.set(1023);
-    ral.adc_chn1_filter_ctl[0].cond.set(ADC_CTRL_FILTER_COND_IN);
+    ral.adc_chn1_filter_ctl[0].cond.set(1);
     ral.adc_chn1_filter_ctl[0].en.set(1);
     csr_wr(ral.adc_chn0_filter_ctl[0], ral.adc_chn0_filter_ctl[0].get());
     csr_wr(ral.adc_chn1_filter_ctl[0], ral.adc_chn1_filter_ctl[0].get());

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -36,7 +36,7 @@ class otbn_base_vseq extends cip_base_vseq #(
   protected int unsigned stop_tokens = 0;
 
   // Saved TL agent configuration
-  typedef struct packed {
+  typedef struct {
     bit          valid;
     int unsigned a_valid_delay_min;
     int unsigned a_valid_delay_max;

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -269,26 +269,26 @@ package flash_ctrl_env_pkg;
     NumReadTask  = 2
   } read_task_e;
 
-  typedef struct packed {
-    mubi4_t en;           // enable this region
-    mubi4_t read_en;      // enable reads
-    mubi4_t program_en;   // enable write
-    mubi4_t erase_en;     // enable erase
-    mubi4_t scramble_en;  // enable scramble
-    mubi4_t ecc_en;       // enable ecc
-    mubi4_t he_en;        // enable high endurance
-    uint    num_pages;    // 0:NumPages % start_page
-    uint    start_page;   // 0:NumPages-1
+  typedef struct {
+    rand mubi4_t en;           // enable this region
+    rand mubi4_t read_en;      // enable reads
+    rand mubi4_t program_en;   // enable write
+    rand mubi4_t erase_en;     // enable erase
+    rand mubi4_t scramble_en;  // enable scramble
+    rand mubi4_t ecc_en;       // enable ecc
+    rand mubi4_t he_en;        // enable high endurance
+    rand uint    num_pages;    // 0:NumPages % start_page
+    rand uint    start_page;   // 0:NumPages-1
   } flash_mp_region_cfg_t;
 
-  typedef struct packed {
-    mubi4_t en;           // enable this page
-    mubi4_t read_en;      // enable reads
-    mubi4_t program_en;   // enable write
-    mubi4_t erase_en;     // enable erase
-    mubi4_t scramble_en;  // enable scramble
-    mubi4_t ecc_en;       // enable ecc
-    mubi4_t he_en;        // enable high endurance
+  typedef struct {
+    rand mubi4_t en;           // enable this page
+    rand mubi4_t read_en;      // enable reads
+    rand mubi4_t program_en;   // enable write
+    rand mubi4_t erase_en;     // enable erase
+    rand mubi4_t scramble_en;  // enable scramble
+    rand mubi4_t ecc_en;       // enable ecc
+    rand mubi4_t he_en;        // enable high endurance
   } flash_bank_mp_info_page_cfg_t;
 
   // 2-states flash data type
@@ -307,20 +307,20 @@ package flash_ctrl_env_pkg;
   // Otf address in a bank.
   typedef bit [flash_ctrl_top_specific_pkg::BusAddrByteW-FlashBankWidth-1 : 0] otf_addr_t;
 
-  typedef struct packed {
-    flash_dv_part_e  partition;   // data or one of the info partitions
-    flash_erase_e    erase_type;  // erase page or the whole bank
-    flash_op_e       op;          // read / program or erase
-    flash_prog_sel_e prog_sel;    // program select: normal or repair
-    uint             num_words;   // number of words to read or program (TL_DW)
-    addr_t           addr;        // starting addr for the op
+  typedef struct {
+    rand flash_dv_part_e  partition;   // data or one of the info partitions
+    rand flash_erase_e    erase_type;  // erase page or the whole bank
+    rand flash_op_e       op;          // read / program or erase
+    rand flash_prog_sel_e prog_sel;    // program select: normal or repair
+    rand uint             num_words;   // number of words to read or program (TL_DW)
+    rand addr_t           addr;        // starting addr for the op
     // address for the ctrl interface per bank, 18:0
-    bit [flash_ctrl_top_specific_pkg::BusAddrByteW-2:0] otf_addr;
+    rand bit [flash_ctrl_top_specific_pkg::BusAddrByteW-2:0] otf_addr;
   } flash_op_t;
 
   // Address combined with region
   // Need for error injection.
-  typedef struct packed {
+  typedef struct {
     bit          bank;
     addr_t addr;
     flash_dv_part_e part;

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_basic_rw_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_basic_rw_vseq.sv
@@ -32,7 +32,7 @@ class flash_ctrl_basic_rw_vseq extends flash_ctrl_base_vseq;
 
   // Constraint for controller address to be in relevant range for the selected partition.
   constraint addr_c {
-    solve bank before flash_op;
+    solve bank before flash_op.addr;
     flash_op.addr inside {[BytesPerBank * bank : BytesPerBank * (bank + 1)]};
     flash_op.addr[2:0] == '0;
   }
@@ -52,7 +52,7 @@ class flash_ctrl_basic_rw_vseq extends flash_ctrl_base_vseq;
 
   // Flash ctrl operation data queue - used for programming or reading the flash.
   constraint flash_op_data_c {
-    solve flash_op before flash_op_data;
+    solve flash_op.num_words before flash_op_data;
 
     flash_op_data.size() == flash_op.num_words;
   }

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
@@ -71,8 +71,6 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
   rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
-    solve en_mp_regions before mp_regions;
-
     foreach (mp_regions[i]) {
       mp_regions[i].en == mubi4_bool_to_mubi(en_mp_regions[i]);
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
@@ -45,7 +45,7 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
   // Constraint for controller address to be in the relevant range for
   // the selected partition.
   constraint addr_c {
-    solve bank before flash_op;
+    solve bank before flash_op.partition, flash_op.addr;
     flash_op.addr inside {[BytesPerBank * bank : BytesPerBank * (bank + 1)]};
     if (flash_op.partition != FlashPartData) {
       flash_op.addr inside
@@ -93,7 +93,7 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
   // Flash ctrl operation data queue - used for programming or reading the flash.
   constraint flash_op_data_c {
-    solve flash_op before flash_op_data;
+    solve flash_op.op, flash_op.num_words before flash_op_data;
     if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead,
                             flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
@@ -41,7 +41,7 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
 
   // Constraint for controller address to be in relevant range the for the selected partition.
   constraint addr_c {
-    solve bank before flash_op;
+    solve bank before flash_op.addr;
     flash_op.addr inside {[BytesPerBank * bank : BytesPerBank * (bank + 1)]};
   }
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
@@ -52,7 +52,7 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
 
   // Constraint for controller address to be in relevant range for the selected partition.
   constraint addr_c {
-    solve bank before flash_op;
+    solve bank before flash_op.partition, flash_op.addr;
     flash_op.addr inside {[BytesPerBank * bank : BytesPerBank * (bank + 1)]};
     if (flash_op.partition != FlashPartData) {
       flash_op.addr inside
@@ -97,7 +97,7 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
 
   // Flash ctrl operation data queue - used for programming or reading the flash.
   constraint flash_op_data_c {
-    solve flash_op before flash_op_data;
+    solve flash_op.op, flash_op.num_words before flash_op_data;
     if (flash_op.op inside {
         flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
@@ -115,8 +115,6 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
   rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
-    solve en_mp_regions before mp_regions;
-
     foreach (mp_regions[i]) {
       mp_regions[i].en == mubi4_bool_to_mubi(en_mp_regions[i]);
       mp_regions[i].read_en == MuBi4True;

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_host_dir_rd_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_host_dir_rd_vseq.sv
@@ -29,7 +29,7 @@ class flash_ctrl_host_dir_rd_vseq extends flash_ctrl_fetch_code_vseq;
 
   // Constraint address to be in relevant range for the selected partition.
   constraint addr_c {
-    solve bank before flash_op;
+    solve bank before flash_op.addr;
     flash_op.addr inside {[BytesPerBank * bank : BytesPerBank * (bank + 1) - BytesPerBank / 2]};
   }
 
@@ -45,8 +45,6 @@ class flash_ctrl_host_dir_rd_vseq extends flash_ctrl_fetch_code_vseq;
   data_t flash_rd_one_data;
 
   constraint mp_regions_c {
-    solve en_mp_regions before mp_regions;
-
     foreach (mp_regions[i]) {
       mp_regions[i].en == mubi4_bool_to_mubi(en_mp_regions[i]);
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
@@ -29,7 +29,7 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
   bit expect_alert;
 
   constraint flash_op_data_c {
-    solve flash_op before flash_op_data;
+    solve flash_op.num_words before flash_op_data;
     flash_op_data.size() == flash_op.num_words;
   }
 
@@ -74,7 +74,7 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i][j][k]) {
+      foreach (mp_info_pages[i, j, k]) {
         mp_info_pages[i][j][k].en == MuBi4True;
         mp_info_pages[i][j][k].read_en == MuBi4True;
         mp_info_pages[i][j][k].program_en == MuBi4True;

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
@@ -11,7 +11,7 @@ class flash_ctrl_legacy_base_vseq extends flash_ctrl_otf_base_vseq;
 
   constraint rand_op_c {
     solve fractions before rand_op.addr;
-    solve flash_program_data before rand_op;
+    solve flash_program_data before rand_op.partition, rand_op.addr;
     solve rand_op.partition before rand_op.prog_sel, rand_op.addr;
     solve rand_op.addr before rand_op.otf_addr;
     solve rand_op.addr before rand_op.num_words;

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
@@ -50,7 +50,7 @@ class flash_ctrl_mid_op_rst_vseq extends flash_ctrl_base_vseq;
   }
 
   constraint flash_op_data_c {
-    solve flash_op before flash_op_data;
+    solve flash_op.num_words before flash_op_data;
     flash_op_data.size() == flash_op.num_words;
   }
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
@@ -39,9 +39,6 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
   flash_bank_mp_info_page_cfg_t
   mp_info_pages[NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
-  constraint solv_order_c {
-    solve mp_regions, mp_info_pages before flash_op;
-  }
   // Constraint address to be in relevant range for the selected partition.
   constraint addr_c {
     if (flash_op.partition != FlashPartData) {

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -46,7 +46,6 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
   flash_mem_init_e otf_flash_init = FlashMemInitEccMode;
 
   constraint all_ent_c {
-    solve all_entry_en before rand_regions, rand_info;
     if (cfg.en_always_any) all_entry_en == 1;
     else all_entry_en dist { 1 := 1, 0 := 4};
   }
@@ -88,19 +87,18 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     cfg.seq_cfg.addr_flash_word_aligned -> fractions[0] == 1'b0;
   }
   constraint ctrl_info_num_c {
-    solve rand_op before ctrl_info_num;
+    solve rand_op.partition before ctrl_info_num;
     ctrl_info_num inside {[1 : InfoTypeSize[rand_op.partition >> 1]]};
     if (cfg.ecc_mode > FlashEccEnabled) ctrl_info_num * fractions <= 128;
   }
   constraint ctrl_num_c {
-    solve ctrl_data_num, ctrl_info_num, rand_op before ctrl_num;
+    solve ctrl_data_num, ctrl_info_num, rand_op.partition before ctrl_num;
     if (rand_op.partition == FlashPartData) ctrl_num == ctrl_data_num;
     else ctrl_num == ctrl_info_num;
   }
 
   constraint rand_op_c {
     solve fractions before rand_op.addr;
-    solve flash_program_data before rand_op;
     solve rand_op.partition before rand_op.prog_sel, rand_op.addr;
     solve rand_op.addr before rand_op.otf_addr;
     solve rand_op.addr before rand_op.num_words;
@@ -710,7 +708,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       if (cfg.ecc_mode > FlashEccEnabled) begin
         if (drop == 0) begin
           if (cfg.ecc_mode == FlashSerrTestMode || flash_op.addr[2] == 0) begin
-            cfg.add_bit_err(flash_op.addr, ReadTaskCtrl, exp_item);
+            cfg.add_bit_err(flash_op, ReadTaskCtrl, exp_item);
             derr_is_set = cfg.address_has_derr(flash_op.addr, flash_op.partition);
             `uvm_info(`gfn, $sformatf("derr_is_set:%b, addr:0x%x", derr_is_set, flash_op.addr),
                       UVM_MEDIUM)

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_vseq.sv
@@ -30,7 +30,7 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
 
   // Constraint host read address to be in relevant range for the selected partition.
   constraint addr_rd_c {
-    solve bank_rd before flash_op_host_rd;
+    solve bank_rd before flash_op_host_rd.addr;
     flash_op_host_rd.addr inside {[BytesPerBank * bank_rd :
                                    BytesPerBank * (bank_rd + 1) - BytesPerBank / 2]};
   }

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
@@ -83,7 +83,7 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
   // Flash ctrl operation data queue - used for programming or reading the flash.
   rand data_q_t             flash_op_data;
   constraint flash_op_data_c {
-    solve flash_op before flash_op_data;
+    solve flash_op.op, flash_op.num_words before flash_op_data;
     if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead,
                             flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
@@ -101,8 +101,6 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
   rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
-    solve en_mp_regions before mp_regions;
-
     foreach (mp_regions[i]) {
       mp_regions[i].en == mubi4_bool_to_mubi(en_mp_regions[i]);
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_buff_evict_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_buff_evict_vseq.sv
@@ -31,7 +31,7 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
 
   // Constraint address to be in relevant range for the selected partition.
   constraint addr_c {
-    solve bank before flash_op;
+    solve bank before flash_op.addr;
     bank inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};
     flash_op.addr inside {[BytesPerBank * bank : BytesPerBank * (bank + 1) - BytesPerBank / 2]};
   }
@@ -56,7 +56,7 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
   data_t flash_rd_one_data;
 
   constraint flash_op_data_c {
-    solve flash_op before flash_op_data;
+    solve flash_op.num_words before flash_op_data;
     flash_op_data.size() == flash_op.num_words;
   }
 
@@ -69,8 +69,6 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
   rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
-    solve en_mp_regions before mp_regions;
-
     foreach (mp_regions[i]) {
       mp_regions[i].en == mubi4_bool_to_mubi(en_mp_regions[i]);
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -269,26 +269,26 @@ package flash_ctrl_env_pkg;
     NumReadTask  = 2
   } read_task_e;
 
-  typedef struct packed {
-    mubi4_t en;           // enable this region
-    mubi4_t read_en;      // enable reads
-    mubi4_t program_en;   // enable write
-    mubi4_t erase_en;     // enable erase
-    mubi4_t scramble_en;  // enable scramble
-    mubi4_t ecc_en;       // enable ecc
-    mubi4_t he_en;        // enable high endurance
-    uint    num_pages;    // 0:NumPages % start_page
-    uint    start_page;   // 0:NumPages-1
+  typedef struct {
+    rand mubi4_t en;           // enable this region
+    rand mubi4_t read_en;      // enable reads
+    rand mubi4_t program_en;   // enable write
+    rand mubi4_t erase_en;     // enable erase
+    rand mubi4_t scramble_en;  // enable scramble
+    rand mubi4_t ecc_en;       // enable ecc
+    rand mubi4_t he_en;        // enable high endurance
+    rand uint    num_pages;    // 0:NumPages % start_page
+    rand uint    start_page;   // 0:NumPages-1
   } flash_mp_region_cfg_t;
 
-  typedef struct packed {
-    mubi4_t en;           // enable this page
-    mubi4_t read_en;      // enable reads
-    mubi4_t program_en;   // enable write
-    mubi4_t erase_en;     // enable erase
-    mubi4_t scramble_en;  // enable scramble
-    mubi4_t ecc_en;       // enable ecc
-    mubi4_t he_en;        // enable high endurance
+  typedef struct {
+    rand mubi4_t en;           // enable this page
+    rand mubi4_t read_en;      // enable reads
+    rand mubi4_t program_en;   // enable write
+    rand mubi4_t erase_en;     // enable erase
+    rand mubi4_t scramble_en;  // enable scramble
+    rand mubi4_t ecc_en;       // enable ecc
+    rand mubi4_t he_en;        // enable high endurance
   } flash_bank_mp_info_page_cfg_t;
 
   // 2-states flash data type
@@ -307,20 +307,20 @@ package flash_ctrl_env_pkg;
   // Otf address in a bank.
   typedef bit [flash_ctrl_top_specific_pkg::BusAddrByteW-FlashBankWidth-1 : 0] otf_addr_t;
 
-  typedef struct packed {
-    flash_dv_part_e  partition;   // data or one of the info partitions
-    flash_erase_e    erase_type;  // erase page or the whole bank
-    flash_op_e       op;          // read / program or erase
-    flash_prog_sel_e prog_sel;    // program select: normal or repair
-    uint             num_words;   // number of words to read or program (TL_DW)
-    addr_t           addr;        // starting addr for the op
+  typedef struct {
+    rand flash_dv_part_e  partition;   // data or one of the info partitions
+    rand flash_erase_e    erase_type;  // erase page or the whole bank
+    rand flash_op_e       op;          // read / program or erase
+    rand flash_prog_sel_e prog_sel;    // program select: normal or repair
+    rand uint             num_words;   // number of words to read or program (TL_DW)
+    rand addr_t           addr;        // starting addr for the op
     // address for the ctrl interface per bank, 18:0
-    bit [flash_ctrl_top_specific_pkg::BusAddrByteW-2:0] otf_addr;
+    rand bit [flash_ctrl_top_specific_pkg::BusAddrByteW-2:0] otf_addr;
   } flash_op_t;
 
   // Address combined with region
   // Need for error injection.
-  typedef struct packed {
+  typedef struct {
     bit          bank;
     addr_t addr;
     flash_dv_part_e part;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_basic_rw_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_basic_rw_vseq.sv
@@ -32,7 +32,7 @@ class flash_ctrl_basic_rw_vseq extends flash_ctrl_base_vseq;
 
   // Constraint for controller address to be in relevant range for the selected partition.
   constraint addr_c {
-    solve bank before flash_op;
+    solve bank before flash_op.addr;
     flash_op.addr inside {[BytesPerBank * bank : BytesPerBank * (bank + 1)]};
     flash_op.addr[2:0] == '0;
   }
@@ -52,7 +52,7 @@ class flash_ctrl_basic_rw_vseq extends flash_ctrl_base_vseq;
 
   // Flash ctrl operation data queue - used for programming or reading the flash.
   constraint flash_op_data_c {
-    solve flash_op before flash_op_data;
+    solve flash_op.num_words before flash_op_data;
 
     flash_op_data.size() == flash_op.num_words;
   }

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
@@ -71,8 +71,6 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
   rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
-    solve en_mp_regions before mp_regions;
-
     foreach (mp_regions[i]) {
       mp_regions[i].en == mubi4_bool_to_mubi(en_mp_regions[i]);
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
@@ -45,7 +45,7 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
   // Constraint for controller address to be in the relevant range for
   // the selected partition.
   constraint addr_c {
-    solve bank before flash_op;
+    solve bank before flash_op.partition, flash_op.addr;
     flash_op.addr inside {[BytesPerBank * bank : BytesPerBank * (bank + 1)]};
     if (flash_op.partition != FlashPartData) {
       flash_op.addr inside
@@ -93,7 +93,7 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
   // Flash ctrl operation data queue - used for programming or reading the flash.
   constraint flash_op_data_c {
-    solve flash_op before flash_op_data;
+    solve flash_op.op, flash_op.num_words before flash_op_data;
     if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead,
                             flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
@@ -41,7 +41,7 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
 
   // Constraint for controller address to be in relevant range the for the selected partition.
   constraint addr_c {
-    solve bank before flash_op;
+    solve bank before flash_op.addr;
     flash_op.addr inside {[BytesPerBank * bank : BytesPerBank * (bank + 1)]};
   }
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
@@ -52,7 +52,7 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
 
   // Constraint for controller address to be in relevant range for the selected partition.
   constraint addr_c {
-    solve bank before flash_op;
+    solve bank before flash_op.partition, flash_op.addr;
     flash_op.addr inside {[BytesPerBank * bank : BytesPerBank * (bank + 1)]};
     if (flash_op.partition != FlashPartData) {
       flash_op.addr inside
@@ -97,7 +97,7 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
 
   // Flash ctrl operation data queue - used for programming or reading the flash.
   constraint flash_op_data_c {
-    solve flash_op before flash_op_data;
+    solve flash_op.op, flash_op.num_words before flash_op_data;
     if (flash_op.op inside {
         flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
@@ -115,8 +115,6 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
   rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
-    solve en_mp_regions before mp_regions;
-
     foreach (mp_regions[i]) {
       mp_regions[i].en == mubi4_bool_to_mubi(en_mp_regions[i]);
       mp_regions[i].read_en == MuBi4True;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_host_dir_rd_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_host_dir_rd_vseq.sv
@@ -29,7 +29,7 @@ class flash_ctrl_host_dir_rd_vseq extends flash_ctrl_fetch_code_vseq;
 
   // Constraint address to be in relevant range for the selected partition.
   constraint addr_c {
-    solve bank before flash_op;
+    solve bank before flash_op.addr;
     flash_op.addr inside {[BytesPerBank * bank : BytesPerBank * (bank + 1) - BytesPerBank / 2]};
   }
 
@@ -45,8 +45,6 @@ class flash_ctrl_host_dir_rd_vseq extends flash_ctrl_fetch_code_vseq;
   data_t flash_rd_one_data;
 
   constraint mp_regions_c {
-    solve en_mp_regions before mp_regions;
-
     foreach (mp_regions[i]) {
       mp_regions[i].en == mubi4_bool_to_mubi(en_mp_regions[i]);
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
@@ -29,7 +29,7 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
   bit expect_alert;
 
   constraint flash_op_data_c {
-    solve flash_op before flash_op_data;
+    solve flash_op.num_words before flash_op_data;
     flash_op_data.size() == flash_op.num_words;
   }
 
@@ -74,7 +74,7 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i][j][k]) {
+      foreach (mp_info_pages[i, j, k]) {
         mp_info_pages[i][j][k].en == MuBi4True;
         mp_info_pages[i][j][k].read_en == MuBi4True;
         mp_info_pages[i][j][k].program_en == MuBi4True;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
@@ -11,7 +11,7 @@ class flash_ctrl_legacy_base_vseq extends flash_ctrl_otf_base_vseq;
 
   constraint rand_op_c {
     solve fractions before rand_op.addr;
-    solve flash_program_data before rand_op;
+    solve flash_program_data before rand_op.partition, rand_op.addr;
     solve rand_op.partition before rand_op.prog_sel, rand_op.addr;
     solve rand_op.addr before rand_op.otf_addr;
     solve rand_op.addr before rand_op.num_words;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
@@ -50,7 +50,7 @@ class flash_ctrl_mid_op_rst_vseq extends flash_ctrl_base_vseq;
   }
 
   constraint flash_op_data_c {
-    solve flash_op before flash_op_data;
+    solve flash_op.num_words before flash_op_data;
     flash_op_data.size() == flash_op.num_words;
   }
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
@@ -39,9 +39,6 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
   flash_bank_mp_info_page_cfg_t
   mp_info_pages[NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
-  constraint solv_order_c {
-    solve mp_regions, mp_info_pages before flash_op;
-  }
   // Constraint address to be in relevant range for the selected partition.
   constraint addr_c {
     if (flash_op.partition != FlashPartData) {

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -46,7 +46,6 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
   flash_mem_init_e otf_flash_init = FlashMemInitEccMode;
 
   constraint all_ent_c {
-    solve all_entry_en before rand_regions, rand_info;
     if (cfg.en_always_any) all_entry_en == 1;
     else all_entry_en dist { 1 := 1, 0 := 4};
   }
@@ -88,19 +87,18 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     cfg.seq_cfg.addr_flash_word_aligned -> fractions[0] == 1'b0;
   }
   constraint ctrl_info_num_c {
-    solve rand_op before ctrl_info_num;
+    solve rand_op.partition before ctrl_info_num;
     ctrl_info_num inside {[1 : InfoTypeSize[rand_op.partition >> 1]]};
     if (cfg.ecc_mode > FlashEccEnabled) ctrl_info_num * fractions <= 128;
   }
   constraint ctrl_num_c {
-    solve ctrl_data_num, ctrl_info_num, rand_op before ctrl_num;
+    solve ctrl_data_num, ctrl_info_num, rand_op.partition before ctrl_num;
     if (rand_op.partition == FlashPartData) ctrl_num == ctrl_data_num;
     else ctrl_num == ctrl_info_num;
   }
 
   constraint rand_op_c {
     solve fractions before rand_op.addr;
-    solve flash_program_data before rand_op;
     solve rand_op.partition before rand_op.prog_sel, rand_op.addr;
     solve rand_op.addr before rand_op.otf_addr;
     solve rand_op.addr before rand_op.num_words;
@@ -710,7 +708,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       if (cfg.ecc_mode > FlashEccEnabled) begin
         if (drop == 0) begin
           if (cfg.ecc_mode == FlashSerrTestMode || flash_op.addr[2] == 0) begin
-            cfg.add_bit_err(flash_op.addr, ReadTaskCtrl, exp_item);
+            cfg.add_bit_err(flash_op, ReadTaskCtrl, exp_item);
             derr_is_set = cfg.address_has_derr(flash_op.addr, flash_op.partition);
             `uvm_info(`gfn, $sformatf("derr_is_set:%b, addr:0x%x", derr_is_set, flash_op.addr),
                       UVM_MEDIUM)

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_vseq.sv
@@ -30,7 +30,7 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
 
   // Constraint host read address to be in relevant range for the selected partition.
   constraint addr_rd_c {
-    solve bank_rd before flash_op_host_rd;
+    solve bank_rd before flash_op_host_rd.addr;
     flash_op_host_rd.addr inside {[BytesPerBank * bank_rd :
                                    BytesPerBank * (bank_rd + 1) - BytesPerBank / 2]};
   }

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
@@ -83,7 +83,7 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
   // Flash ctrl operation data queue - used for programming or reading the flash.
   rand data_q_t             flash_op_data;
   constraint flash_op_data_c {
-    solve flash_op before flash_op_data;
+    solve flash_op.op, flash_op.num_words before flash_op_data;
     if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead,
                             flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
@@ -101,8 +101,6 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
   rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
-    solve en_mp_regions before mp_regions;
-
     foreach (mp_regions[i]) {
       mp_regions[i].en == mubi4_bool_to_mubi(en_mp_regions[i]);
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_buff_evict_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_buff_evict_vseq.sv
@@ -31,7 +31,7 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
 
   // Constraint address to be in relevant range for the selected partition.
   constraint addr_c {
-    solve bank before flash_op;
+    solve bank before flash_op.addr;
     bank inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};
     flash_op.addr inside {[BytesPerBank * bank : BytesPerBank * (bank + 1) - BytesPerBank / 2]};
   }
@@ -56,7 +56,7 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
   data_t flash_rd_one_data;
 
   constraint flash_op_data_c {
-    solve flash_op before flash_op_data;
+    solve flash_op.num_words before flash_op_data;
     flash_op_data.size() == flash_op.num_words;
   }
 
@@ -69,8 +69,6 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
   rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
-    solve en_mp_regions before mp_regions;
-
     foreach (mp_regions[i]) {
       mp_regions[i].en == mubi4_bool_to_mubi(en_mp_regions[i]);
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -269,26 +269,26 @@ package flash_ctrl_env_pkg;
     NumReadTask  = 2
   } read_task_e;
 
-  typedef struct packed {
-    mubi4_t en;           // enable this region
-    mubi4_t read_en;      // enable reads
-    mubi4_t program_en;   // enable write
-    mubi4_t erase_en;     // enable erase
-    mubi4_t scramble_en;  // enable scramble
-    mubi4_t ecc_en;       // enable ecc
-    mubi4_t he_en;        // enable high endurance
-    uint    num_pages;    // 0:NumPages % start_page
-    uint    start_page;   // 0:NumPages-1
+  typedef struct {
+    rand mubi4_t en;           // enable this region
+    rand mubi4_t read_en;      // enable reads
+    rand mubi4_t program_en;   // enable write
+    rand mubi4_t erase_en;     // enable erase
+    rand mubi4_t scramble_en;  // enable scramble
+    rand mubi4_t ecc_en;       // enable ecc
+    rand mubi4_t he_en;        // enable high endurance
+    rand uint    num_pages;    // 0:NumPages % start_page
+    rand uint    start_page;   // 0:NumPages-1
   } flash_mp_region_cfg_t;
 
-  typedef struct packed {
-    mubi4_t en;           // enable this page
-    mubi4_t read_en;      // enable reads
-    mubi4_t program_en;   // enable write
-    mubi4_t erase_en;     // enable erase
-    mubi4_t scramble_en;  // enable scramble
-    mubi4_t ecc_en;       // enable ecc
-    mubi4_t he_en;        // enable high endurance
+  typedef struct {
+    rand mubi4_t en;           // enable this page
+    rand mubi4_t read_en;      // enable reads
+    rand mubi4_t program_en;   // enable write
+    rand mubi4_t erase_en;     // enable erase
+    rand mubi4_t scramble_en;  // enable scramble
+    rand mubi4_t ecc_en;       // enable ecc
+    rand mubi4_t he_en;        // enable high endurance
   } flash_bank_mp_info_page_cfg_t;
 
   // 2-states flash data type
@@ -307,20 +307,20 @@ package flash_ctrl_env_pkg;
   // Otf address in a bank.
   typedef bit [flash_ctrl_top_specific_pkg::BusAddrByteW-FlashBankWidth-1 : 0] otf_addr_t;
 
-  typedef struct packed {
-    flash_dv_part_e  partition;   // data or one of the info partitions
-    flash_erase_e    erase_type;  // erase page or the whole bank
-    flash_op_e       op;          // read / program or erase
-    flash_prog_sel_e prog_sel;    // program select: normal or repair
-    uint             num_words;   // number of words to read or program (TL_DW)
-    addr_t           addr;        // starting addr for the op
+  typedef struct {
+    rand flash_dv_part_e  partition;   // data or one of the info partitions
+    rand flash_erase_e    erase_type;  // erase page or the whole bank
+    rand flash_op_e       op;          // read / program or erase
+    rand flash_prog_sel_e prog_sel;    // program select: normal or repair
+    rand uint             num_words;   // number of words to read or program (TL_DW)
+    rand addr_t           addr;        // starting addr for the op
     // address for the ctrl interface per bank, 18:0
-    bit [flash_ctrl_top_specific_pkg::BusAddrByteW-2:0] otf_addr;
+    rand bit [flash_ctrl_top_specific_pkg::BusAddrByteW-2:0] otf_addr;
   } flash_op_t;
 
   // Address combined with region
   // Need for error injection.
-  typedef struct packed {
+  typedef struct {
     bit          bank;
     addr_t addr;
     flash_dv_part_e part;

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_basic_rw_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_basic_rw_vseq.sv
@@ -32,7 +32,7 @@ class flash_ctrl_basic_rw_vseq extends flash_ctrl_base_vseq;
 
   // Constraint for controller address to be in relevant range for the selected partition.
   constraint addr_c {
-    solve bank before flash_op;
+    solve bank before flash_op.addr;
     flash_op.addr inside {[BytesPerBank * bank : BytesPerBank * (bank + 1)]};
     flash_op.addr[2:0] == '0;
   }
@@ -52,7 +52,7 @@ class flash_ctrl_basic_rw_vseq extends flash_ctrl_base_vseq;
 
   // Flash ctrl operation data queue - used for programming or reading the flash.
   constraint flash_op_data_c {
-    solve flash_op before flash_op_data;
+    solve flash_op.num_words before flash_op_data;
 
     flash_op_data.size() == flash_op.num_words;
   }

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
@@ -71,8 +71,6 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
   rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
-    solve en_mp_regions before mp_regions;
-
     foreach (mp_regions[i]) {
       mp_regions[i].en == mubi4_bool_to_mubi(en_mp_regions[i]);
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
@@ -45,7 +45,7 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
   // Constraint for controller address to be in the relevant range for
   // the selected partition.
   constraint addr_c {
-    solve bank before flash_op;
+    solve bank before flash_op.partition, flash_op.addr;
     flash_op.addr inside {[BytesPerBank * bank : BytesPerBank * (bank + 1)]};
     if (flash_op.partition != FlashPartData) {
       flash_op.addr inside
@@ -93,7 +93,7 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
   // Flash ctrl operation data queue - used for programming or reading the flash.
   constraint flash_op_data_c {
-    solve flash_op before flash_op_data;
+    solve flash_op.op, flash_op.num_words before flash_op_data;
     if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead,
                             flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
@@ -41,7 +41,7 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
 
   // Constraint for controller address to be in relevant range the for the selected partition.
   constraint addr_c {
-    solve bank before flash_op;
+    solve bank before flash_op.addr;
     flash_op.addr inside {[BytesPerBank * bank : BytesPerBank * (bank + 1)]};
   }
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
@@ -52,7 +52,7 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
 
   // Constraint for controller address to be in relevant range for the selected partition.
   constraint addr_c {
-    solve bank before flash_op;
+    solve bank before flash_op.partition, flash_op.addr;
     flash_op.addr inside {[BytesPerBank * bank : BytesPerBank * (bank + 1)]};
     if (flash_op.partition != FlashPartData) {
       flash_op.addr inside
@@ -97,7 +97,7 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
 
   // Flash ctrl operation data queue - used for programming or reading the flash.
   constraint flash_op_data_c {
-    solve flash_op before flash_op_data;
+    solve flash_op.op, flash_op.num_words before flash_op_data;
     if (flash_op.op inside {
         flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
@@ -115,8 +115,6 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
   rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
-    solve en_mp_regions before mp_regions;
-
     foreach (mp_regions[i]) {
       mp_regions[i].en == mubi4_bool_to_mubi(en_mp_regions[i]);
       mp_regions[i].read_en == MuBi4True;

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_host_dir_rd_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_host_dir_rd_vseq.sv
@@ -29,7 +29,7 @@ class flash_ctrl_host_dir_rd_vseq extends flash_ctrl_fetch_code_vseq;
 
   // Constraint address to be in relevant range for the selected partition.
   constraint addr_c {
-    solve bank before flash_op;
+    solve bank before flash_op.addr;
     flash_op.addr inside {[BytesPerBank * bank : BytesPerBank * (bank + 1) - BytesPerBank / 2]};
   }
 
@@ -45,8 +45,6 @@ class flash_ctrl_host_dir_rd_vseq extends flash_ctrl_fetch_code_vseq;
   data_t flash_rd_one_data;
 
   constraint mp_regions_c {
-    solve en_mp_regions before mp_regions;
-
     foreach (mp_regions[i]) {
       mp_regions[i].en == mubi4_bool_to_mubi(en_mp_regions[i]);
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
@@ -29,7 +29,7 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
   bit expect_alert;
 
   constraint flash_op_data_c {
-    solve flash_op before flash_op_data;
+    solve flash_op.num_words before flash_op_data;
     flash_op_data.size() == flash_op.num_words;
   }
 
@@ -74,7 +74,7 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i][j][k]) {
+      foreach (mp_info_pages[i, j, k]) {
         mp_info_pages[i][j][k].en == MuBi4True;
         mp_info_pages[i][j][k].read_en == MuBi4True;
         mp_info_pages[i][j][k].program_en == MuBi4True;

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
@@ -11,7 +11,7 @@ class flash_ctrl_legacy_base_vseq extends flash_ctrl_otf_base_vseq;
 
   constraint rand_op_c {
     solve fractions before rand_op.addr;
-    solve flash_program_data before rand_op;
+    solve flash_program_data before rand_op.partition, rand_op.addr;
     solve rand_op.partition before rand_op.prog_sel, rand_op.addr;
     solve rand_op.addr before rand_op.otf_addr;
     solve rand_op.addr before rand_op.num_words;

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
@@ -50,7 +50,7 @@ class flash_ctrl_mid_op_rst_vseq extends flash_ctrl_base_vseq;
   }
 
   constraint flash_op_data_c {
-    solve flash_op before flash_op_data;
+    solve flash_op.num_words before flash_op_data;
     flash_op_data.size() == flash_op.num_words;
   }
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
@@ -39,9 +39,6 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
   flash_bank_mp_info_page_cfg_t
   mp_info_pages[NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
-  constraint solv_order_c {
-    solve mp_regions, mp_info_pages before flash_op;
-  }
   // Constraint address to be in relevant range for the selected partition.
   constraint addr_c {
     if (flash_op.partition != FlashPartData) {

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -46,7 +46,6 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
   flash_mem_init_e otf_flash_init = FlashMemInitEccMode;
 
   constraint all_ent_c {
-    solve all_entry_en before rand_regions, rand_info;
     if (cfg.en_always_any) all_entry_en == 1;
     else all_entry_en dist { 1 := 1, 0 := 4};
   }
@@ -88,19 +87,18 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     cfg.seq_cfg.addr_flash_word_aligned -> fractions[0] == 1'b0;
   }
   constraint ctrl_info_num_c {
-    solve rand_op before ctrl_info_num;
+    solve rand_op.partition before ctrl_info_num;
     ctrl_info_num inside {[1 : InfoTypeSize[rand_op.partition >> 1]]};
     if (cfg.ecc_mode > FlashEccEnabled) ctrl_info_num * fractions <= 128;
   }
   constraint ctrl_num_c {
-    solve ctrl_data_num, ctrl_info_num, rand_op before ctrl_num;
+    solve ctrl_data_num, ctrl_info_num, rand_op.partition before ctrl_num;
     if (rand_op.partition == FlashPartData) ctrl_num == ctrl_data_num;
     else ctrl_num == ctrl_info_num;
   }
 
   constraint rand_op_c {
     solve fractions before rand_op.addr;
-    solve flash_program_data before rand_op;
     solve rand_op.partition before rand_op.prog_sel, rand_op.addr;
     solve rand_op.addr before rand_op.otf_addr;
     solve rand_op.addr before rand_op.num_words;
@@ -710,7 +708,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       if (cfg.ecc_mode > FlashEccEnabled) begin
         if (drop == 0) begin
           if (cfg.ecc_mode == FlashSerrTestMode || flash_op.addr[2] == 0) begin
-            cfg.add_bit_err(flash_op.addr, ReadTaskCtrl, exp_item);
+            cfg.add_bit_err(flash_op, ReadTaskCtrl, exp_item);
             derr_is_set = cfg.address_has_derr(flash_op.addr, flash_op.partition);
             `uvm_info(`gfn, $sformatf("derr_is_set:%b, addr:0x%x", derr_is_set, flash_op.addr),
                       UVM_MEDIUM)

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_vseq.sv
@@ -30,7 +30,7 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
 
   // Constraint host read address to be in relevant range for the selected partition.
   constraint addr_rd_c {
-    solve bank_rd before flash_op_host_rd;
+    solve bank_rd before flash_op_host_rd.addr;
     flash_op_host_rd.addr inside {[BytesPerBank * bank_rd :
                                    BytesPerBank * (bank_rd + 1) - BytesPerBank / 2]};
   }

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
@@ -83,7 +83,7 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
   // Flash ctrl operation data queue - used for programming or reading the flash.
   rand data_q_t             flash_op_data;
   constraint flash_op_data_c {
-    solve flash_op before flash_op_data;
+    solve flash_op.op, flash_op.num_words before flash_op_data;
     if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead,
                             flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
@@ -101,8 +101,6 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
   rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
-    solve en_mp_regions before mp_regions;
-
     foreach (mp_regions[i]) {
       mp_regions[i].en == mubi4_bool_to_mubi(en_mp_regions[i]);
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_buff_evict_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_buff_evict_vseq.sv
@@ -31,7 +31,7 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
 
   // Constraint address to be in relevant range for the selected partition.
   constraint addr_c {
-    solve bank before flash_op;
+    solve bank before flash_op.addr;
     bank inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};
     flash_op.addr inside {[BytesPerBank * bank : BytesPerBank * (bank + 1) - BytesPerBank / 2]};
   }
@@ -56,7 +56,7 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
   data_t flash_rd_one_data;
 
   constraint flash_op_data_c {
-    solve flash_op before flash_op_data;
+    solve flash_op.num_words before flash_op_data;
     flash_op_data.size() == flash_op.num_words;
   }
 
@@ -69,8 +69,6 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
   rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
-    solve en_mp_regions before mp_regions;
-
     foreach (mp_regions[i]) {
       mp_regions[i].en == mubi4_bool_to_mubi(en_mp_regions[i]);
 


### PR DESCRIPTION
This was triggered by a rather long hunt yesterday evening trying to figure out why a variable of type `flash_op_t` was randomising to a silly value in `flash_ctrl_error_mp_vseq`. This was quite a SystemVerilog learning experience for me!

I now know that randomising a packed struct in SystemVerilog is essentially the same as randomising a bit vector and then casting the result back to the structure type. In particular, this will merrily trash any enum fields.

I *think* this PR catches all the similar occurrences in the codebase: I manually hunted through the hits in `git grep 'struct packed' -- '*dv*.sv*'` and I don't *think* I've missed anything.