### PR TITLE
[rv_timer] Move V3 review date to notes in hjson

### DIFF
--- a/hw/ip/rv_timer/data/rv_timer.hjson
+++ b/hw/ip/rv_timer/data/rv_timer.hjson
@@ -29,9 +29,9 @@
       version:            "1.0.0",
       life_stage:         "L1",
       design_stage:       "D3",
-      verification_stage: "V3 Reviewed @ 2025-05-09",
+      verification_stage: "V3",
       dif_stage:          "S2",
-      notes:              "D3 Reviewed @ 2025-05-09",
+      notes:              "D3 Reviewed @ 2025-05-09, V3 Reviewed @ 2025-05-09",
     }
   ]
   clocking: [{clock: "clk_i", reset: "rst_ni"}],


### PR DESCRIPTION
The `verification_stage` field is parsed by some tools which expect it to match `(V1|V2|V2S|V3)`. This commit moves the review date to the notes where the D3 date was added.