### PR TITLE
[rom_ext] Run boot_svc after a wakeup according to owner config

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/datatypes.h
+++ b/sw/device/silicon_creator/lib/ownership/datatypes.h
@@ -181,8 +181,10 @@ typedef struct owner_block {
   uint32_t lock_constraint;
   /** The device ID to which this config applies */
   uint32_t device_id[8];
+  /** Perform ROM_EXT boot services after wakeup (hardened_bool_t). */
+  uint32_t boot_svc_after_wakeup;
   /** Reserved space for future use. */
-  uint32_t reserved[16];
+  uint32_t reserved[15];
   /** Owner public key. */
   owner_keydata_t owner_key;
   /** Owner's Activate public key. */
@@ -205,7 +207,8 @@ OT_ASSERT_MEMBER_OFFSET(owner_block_t, update_mode, 20);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, min_security_version_bl0, 24);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, lock_constraint, 28);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, device_id, 32);
-OT_ASSERT_MEMBER_OFFSET(owner_block_t, reserved, 64);
+OT_ASSERT_MEMBER_OFFSET(owner_block_t, boot_svc_after_wakeup, 64);
+OT_ASSERT_MEMBER_OFFSET(owner_block_t, reserved, 68);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, owner_key, 128);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, activate_key, 224);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, unlock_key, 320);

--- a/sw/device/silicon_creator/lib/ownership/owner_block.c
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.c
@@ -195,6 +195,7 @@ void owner_config_default(owner_config_t *config) {
   config->rescue = (const owner_rescue_config_t *)kHardenedBoolFalse;
   config->isfb = (const owner_isfb_config_t *)kHardenedBoolFalse;
   config->sram_exec = kOwnerSramExecModeDisabledLocked;
+  config->boot_svc_after_wakeup = kHardenedBoolFalse;
 }
 
 rom_error_t owner_block_parse(const owner_block_t *block,
@@ -211,6 +212,7 @@ rom_error_t owner_block_parse(const owner_block_t *block,
   if (check_only == kHardenedBoolFalse) {
     owner_config_default(config);
     config->sram_exec = block->sram_exec_mode;
+    config->boot_svc_after_wakeup = block->boot_svc_after_wakeup;
   }
 
   uint32_t remain = sizeof(block->data);

--- a/sw/device/silicon_creator/lib/ownership/owner_block.h
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.h
@@ -39,6 +39,8 @@ extern owner_page_status_t owner_page_valid[2];
 typedef struct owner_config {
   /** The requested SRAM execution configuration. */
   owner_sram_exec_mode_t sram_exec;
+  /** Allow boot_svc after wakeup. */
+  hardened_bool_t boot_svc_after_wakeup;
   /** The requested flash configuration. */
   const owner_flash_config_t *flash;
   /** The requested flash INFO configuration. */

--- a/sw/device/silicon_creator/lib/ownership/test_owner.c
+++ b/sw/device/silicon_creator/lib/ownership/test_owner.c
@@ -108,6 +108,10 @@
 #define TEST_OWNER_SRAM_EXEC_MODE kOwnerSramExecModeDisabledLocked
 #endif
 
+#ifndef TEST_OWNER_BOOT_SVC_AFTER_WAKEUP
+#define TEST_OWNER_BOOT_SVC_AFTER_WAKEUP kHardenedBoolFalse
+#endif
+
 // The following preprocessor symbols are only relevant when
 // WITH_RESCUE_PROTOCOL is defined.
 #ifndef WITH_RESCUE_MISC_GPIO_PARAM
@@ -165,6 +169,7 @@ rom_error_t sku_creator_owner_init(boot_data_t *bootdata) {
   owner_page[0].header.version = (struct_version_t){0, 0};
   owner_page[0].config_version = TEST_OWNER_CONFIG_VERSION;
   owner_page[0].sram_exec_mode = TEST_OWNER_SRAM_EXEC_MODE;
+  owner_page[0].boot_svc_after_wakeup = TEST_OWNER_BOOT_SVC_AFTER_WAKEUP;
   owner_page[0].ownership_key_alg = TEST_OWNER_KEY_ALG;
   owner_page[0].update_mode = TEST_OWNER_UPDATE_MODE;
   owner_page[0].min_security_version_bl0 = UINT32_MAX;

--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -34,6 +34,10 @@ SLOTS = [
 ]
 
 TEST_OWNER_CONFIGS = {
+    "boot_svc_after_wakeup": {
+        "owner_defines": ["TEST_OWNER_BOOT_SVC_AFTER_WAKEUP=kHardenedBoolTrue"],
+        "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_xmodem"],
+    },
     "hybrid_owner_keys": {
         # Enable hybrid ECDSA/SPX+ ownership.
         "owner_defines": ["TEST_OWNER_KEY_ALG_HYBRID_SPX_PURE=1"],

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/BUILD
@@ -119,8 +119,9 @@ opentitan_test(
 )
 
 opentitan_test(
-    name = "boot_svc_wakeup_test",
+    name = "boot_svc_after_wakeup_disabled_test",
     srcs = ["boot_svc_wakeup_test.c"],
+    defines = ["BOOT_SVC_AFTER_WAKEUP_ENABLED=0"],
     exec_env = {
         "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
@@ -130,6 +131,45 @@ opentitan_test(
         assemble = "{rom_ext}@{rom_ext_slot_a} {firmware}@{owner_slot_a}",
         #exit_failure = "BFV|PASS|FAIL",
         #exit_success = "FinalBootLog: 2:AA\r\n",
+    ),
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
+    deps = [
+        ":boot_svc_test_lib",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:aon_timer",
+        "//sw/device/lib/dif:pwrmgr",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:pwrmgr_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/boot_svc:boot_svc_empty",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        "//sw/device/silicon_creator/lib/drivers:rstmgr",
+    ],
+)
+
+opentitan_test(
+    name = "boot_svc_after_wakeup_enabled_test",
+    srcs = ["boot_svc_wakeup_test.c"],
+    defines = ["BOOT_SVC_AFTER_WAKEUP_ENABLED=1"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+        # Not supported in QEMU whilst low power is not modelled
+    },
+    fpga = fpga_params(
+        assemble = "{rom_ext}@{rom_ext_slot_a} {firmware}@{owner_slot_a}",
+        changes_otp = True,
+        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_boot_svc_after_wakeup",
+        test_cmd = """
+            --exec="transport init"
+            --exec="fpga clear-bitstream"
+            --exec="fpga load-bitstream {bitstream}"
+            --exec="bootstrap --clear-uart=true {firmware}"
+            --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+            no-op
+        """,
     ),
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
     deps = [

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_wakeup_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_wakeup_test.c
@@ -67,9 +67,15 @@ static status_t check_empty(retention_sram_t *retram,
   }
   boot_svc_msg_t msg = retram->creator.boot_svc_msg;
   TRY(boot_svc_header_check(&msg.header));
+#if BOOT_SVC_AFTER_WAKEUP_ENABLED == 0
   // We expect the `EmptyReqType` here because the ROM_EXT should not process
   // boot_svc requests when waking from deep sleep.
   TRY_CHECK(msg.header.type == kBootSvcEmptyReqType);
+#else  // WAKEUP_ENABLED == 1
+  // We expect the `EmptyResType` here because the ROM_EXT should process
+  // boot_svc requests when waking from deep sleep.
+  TRY_CHECK(msg.header.type == kBootSvcEmptyResType);
+#endif
   state->state = kBootSvcTestStateFinal;
   return OK_STATUS();
 }


### PR DESCRIPTION
Initial customers requested that boot services not run when the ROM_EXT detects a low-power wakeup.  A new customer has requested the opposite behavior.

1. Add a configuration item to the ownership config to enable or disable boot_svc on low-power wakeups.  Default to `False` (disabled).
2. Use a weak function to retrieve the ownership configuration value. This allows a down-stream ROM_EXT build to override this function with their preferred behavior (to account for chips that don't have the setting in their ownership config).