### PR TITLE
[perso,rom_ext] bump version numbers

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -292,8 +292,8 @@ manifest(d = {
     "manuf_state_creator": hex(CONST.MANUF_STATE.PERSO_INITIAL),
     "visibility": ["//visibility:private"],
     "version_major": "0",
-    # Release: 2025-09-16-RC00
-    "version_minor": "2025091600",
+    # Release: 2025-10-29-RC00
+    "version_minor": "2025102900",
     "security_version": "0xFFFFFFFF",
 })
 

--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -14,7 +14,7 @@ def secver_write_selection():
 # because of how the bazel rule accepts attributes.
 ROM_EXT_VERSION = struct(
     MAJOR = "0",
-    MINOR = "115",
+    MINOR = "116",
     SECURITY = "0",
 )
 


### PR DESCRIPTION
This bumps the ROM_EXT and perso version numbers to prepare for the next signing operation.