### PR TITLE
[sw,otbnsim] Replace ignored subfunction by nops

### DIFF
--- a/hw/ip/otbn/util/analyze_information_flow.py
+++ b/hw/ip/otbn/util/analyze_information_flow.py
@@ -53,7 +53,7 @@ def main() -> int:
             'Initially secret information-flow nodes. If provided, the final '
             'secrets will be printed.'))
     args = parser.parse_args()
-    program = decode_elf(args.elf)
+    program = decode_elf(args.elf, [])
 
     # Compute control-flow graph.
     if args.subroutine is None:

--- a/hw/ip/otbn/util/check_call_stack.py
+++ b/hw/ip/otbn/util/check_call_stack.py
@@ -51,7 +51,7 @@ def main() -> int:
     parser.add_argument('elf', help=('The .elf file to check.'))
     parser.add_argument('-v', '--verbose', action='store_true')
     args = parser.parse_args()
-    program = decode_elf(args.elf)
+    program = decode_elf(args.elf, [])
     result = check_call_stack(program)
     if args.verbose or result.has_errors() or result.has_warnings():
         print(result.report())

--- a/hw/ip/otbn/util/check_loop.py
+++ b/hw/ip/otbn/util/check_loop.py
@@ -224,7 +224,7 @@ def main() -> int:
     parser.add_argument('elf', help=('The .elf file to check.'))
     parser.add_argument('-v', '--verbose', action='store_true')
     args = parser.parse_args()
-    program = decode_elf(args.elf)
+    program = decode_elf(args.elf, [])
     result = check_loop(program)
     if args.verbose or result.has_errors() or result.has_warnings():
         print(result.report())

--- a/hw/ip/otbn/util/get_instruction_count_range.py
+++ b/hw/ip/otbn/util/get_instruction_count_range.py
@@ -23,7 +23,7 @@ def main() -> int:
         help=('The specific subroutine to check. If not provided, the start '
               'point is _imem_start (whole program).'))
     args = parser.parse_args()
-    program = decode_elf(args.elf)
+    program = decode_elf(args.elf, [])
 
     # Compute instruction count range.
     if args.subroutine is None:


### PR DESCRIPTION
This allows subfunctions to be replaced by NOPs for constant time tests.

This is useful for the case where a function runs in constant time under normal conditions but is not
necessarily constant time in case of FI.

The issue I was facing was that we have constant time tests in the CI which check whether assembly functions have a constant execution time. For example [p384_isoncurve_check](https://github.com/lowRISC/opentitan/blob/d635d4e4b6f7ef454055bd0344889684668e2140/sw/otbn/crypto/p384_isoncurve.s#L193) is a function that should, under normal conditions, execute in constant time. However it calls `trigger_fault_if_fg0_not_z` which is not constant time in the case of fault injection. This trips up the consttime check, since all of a sudden it is possible to terminate earlier.

For this reason this PR makes it possible to replace the function body of `trigger_fault_if_fg0_not_z` by NOPs. This way the constant time can still check the rest of `p384_isoncurve_check` for constant-time-ness.