### PR TITLE
[sw,cryptolib] p384 move flag clear in keygen

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/p384.c
+++ b/sw/device/lib/crypto/impl/ecc/p384.c
@@ -93,11 +93,11 @@ enum {
    * The expected instruction counts for constant time functions.
    */
   kModeKeygenInsCnt = 1899012,
-  kModeKeygenSideloadInsCnt = 1898906,
+  kModeKeygenSideloadInsCnt = 1898905,
   kModeEcdhInsCnt = 1910611,
-  kModeEcdhSideloadInsCnt = 1910760,
+  kModeEcdhSideloadInsCnt = 1910759,
   kModeEcdsaSignInsCnt = 1546541,
-  kModeEcdsaSignSideloadInsCnt = 1546690,
+  kModeEcdsaSignSideloadInsCnt = 1546689,
 };
 
 static status_t p384_masked_scalar_write(p384_masked_scalar_t *src,

--- a/sw/otbn/crypto/p384_keygen_from_seed.s
+++ b/sw/otbn/crypto/p384_keygen_from_seed.s
@@ -98,9 +98,6 @@ p384_key_from_seed:
   bn.sub    w24, w10, w16
   bn.subb   w25, w11, w17
 
-  /* Clear flags. */
-  bn.sub    w31, w31, w31
-
   /* Compute d1. Because 2^384 < 2 * n, a conditional subtraction is
      sufficient to reduce. Similarly to the carry bit, the conditional bit here
      is not very sensitive because the shares are large relative to n.
@@ -111,8 +108,9 @@ p384_key_from_seed:
   /* Clear w25 before over writing it with a different share. */
   bn.xor    w25, w25, w25
 
-  /* Dummy instruction to avoid consecutive share access. */
-  bn.xor    w31, w31, w31
+  /* Dummy instruction to avoid consecutive share access.
+     Clear all flags. */
+  bn.sub    w31, w31, w31
 
   /* Isolate the carry bit and shift it back into position.
        w25 <= x0[384] << 128 */


### PR DESCRIPTION
To follow the OTBN styleguide I added an instruction to clear the flags after a subtraction. The flags however are still needed in the subsequent instructions for the bn.sel. I moved the clear sub instruction down to clear all 4 flags.