### PR TITLE
[adc_ctrl,dv] Get things working with Xcelium too

### DIFF
--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_fsm_reset_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_fsm_reset_vseq.sv
@@ -102,11 +102,11 @@ class adc_ctrl_fsm_reset_vseq extends adc_ctrl_base_vseq;
     // Make sure filters will always match
     ral.adc_chn0_filter_ctl[0].min_v.set(0);
     ral.adc_chn0_filter_ctl[0].max_v.set(1023);
-    ral.adc_chn0_filter_ctl[0].cond.set(1);
+    ral.adc_chn0_filter_ctl[0].cond.set(0);
     ral.adc_chn0_filter_ctl[0].en.set(1);
     ral.adc_chn1_filter_ctl[0].min_v.set(0);
     ral.adc_chn1_filter_ctl[0].max_v.set(1023);
-    ral.adc_chn1_filter_ctl[0].cond.set(1);
+    ral.adc_chn1_filter_ctl[0].cond.set(0);
     ral.adc_chn1_filter_ctl[0].en.set(1);
     csr_wr(ral.adc_chn0_filter_ctl[0], ral.adc_chn0_filter_ctl[0].get());
     csr_wr(ral.adc_chn1_filter_ctl[0], ral.adc_chn1_filter_ctl[0].get());

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_fsm_reset_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_fsm_reset_vseq.sv
@@ -93,23 +93,39 @@ class adc_ctrl_fsm_reset_vseq extends adc_ctrl_base_vseq;
     `DV_ASSERT_CTRL_REQ("ADC_CTRL_FSM_A_CTRL", 1)
   endtask
 
+  function void set_named_field(uvm_reg csr, string name, uvm_reg_data_t value);
+    uvm_reg_field fld = csr.get_field_by_name(name);
+    if (!fld) begin
+      `uvm_fatal(`gfn, $sformatf("Register %s has no field called %s.", csr.get_name(), name))
+    end
+
+    fld.set(value);
+  endfunction
+
+  // Configure a filter so that it will match every possible input.
+  task set_filter_to_always_match(uvm_reg filter_ctrl_csr);
+    uvm_status_e status;
+
+    set_named_field(filter_ctrl_csr, "min_v", 0);
+    set_named_field(filter_ctrl_csr, "max_v", 1023);
+    set_named_field(filter_ctrl_csr, "cond",  0);
+    set_named_field(filter_ctrl_csr, "en",    1);
+    filter_ctrl_csr.update(status);
+
+    if (status != UVM_IS_OK) begin
+      `uvm_error(`gfn,
+                 $sformatf("Failed to update filter register (in %s)", filter_ctrl_csr.get_name()))
+    end
+  endtask
 
   virtual task body();
     uvm_reg_data_t rdata;
     // Make sure ADC is off
     csr_wr(ral.adc_en_ctl, 'h0);
 
-    // Make sure filters will always match
-    ral.adc_chn0_filter_ctl[0].min_v.set(0);
-    ral.adc_chn0_filter_ctl[0].max_v.set(1023);
-    ral.adc_chn0_filter_ctl[0].cond.set(0);
-    ral.adc_chn0_filter_ctl[0].en.set(1);
-    ral.adc_chn1_filter_ctl[0].min_v.set(0);
-    ral.adc_chn1_filter_ctl[0].max_v.set(1023);
-    ral.adc_chn1_filter_ctl[0].cond.set(0);
-    ral.adc_chn1_filter_ctl[0].en.set(1);
-    csr_wr(ral.adc_chn0_filter_ctl[0], ral.adc_chn0_filter_ctl[0].get());
-    csr_wr(ral.adc_chn1_filter_ctl[0], ral.adc_chn1_filter_ctl[0].get());
+    // Make sure ony filter on each channel will always match
+    set_filter_to_always_match(ral.adc_chn0_filter_ctl[0]);
+    set_filter_to_always_match(ral.adc_chn1_filter_ctl[0]);
 
     repeat (num_trans) begin
       // Set up sample counts

--- a/hw/ip/adc_ctrl/dv/sva/adc_ctrl_fsm_sva_if.sv
+++ b/hw/ip/adc_ctrl/dv/sva/adc_ctrl_fsm_sva_if.sv
@@ -2,44 +2,83 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 // System verilog assertions for the adc_ctrl_fsm module
+
+// An interface that is bound into adc_ctrl_fsm, capturing ports with .* (so the input ports are
+// named to match signals inside that module).
+
 interface adc_ctrl_fsm_sva_if
   import adc_ctrl_pkg::*;
-  (
+(
   // adc_ctrl_fsm ports
   input logic clk_aon_i,
   input logic rst_aon_ni,
   input logic cfg_fsm_rst_i,
+
   // adc_ctrl_fsm signals
-  input fsm_state_e fsm_state_q,
-  input logic [3:0] pwrup_timer_cnt_q,
+  input fsm_state_e  fsm_state_q,
+  input logic [3:0]  pwrup_timer_cnt_q,
   input logic [23:0] wakeup_timer_cnt_q,
   input logic [15:0] np_sample_cnt_q,
-  input logic [7:0] lp_sample_cnt_q
+  input logic [7:0]  lp_sample_cnt_q
 );
 
   localparam fsm_state_e FsmResetState = PWRDN;
 
-  // FSM software reset
-  `ASSERT(FsmStateSwReset_A, cfg_fsm_rst_i |=> fsm_state_q == FsmResetState, clk_aon_i, !rst_aon_ni)
-  `ASSERT(PwrupTimerCntSwReset_A, cfg_fsm_rst_i |=> pwrup_timer_cnt_q == 0, clk_aon_i, !rst_aon_ni)
-  `ASSERT(WakeupTimerCntSwReset_A, cfg_fsm_rst_i |=> wakeup_timer_cnt_q == 0, clk_aon_i,
-          !rst_aon_ni)
-  `ASSERT(NpSampleCntSwReset_A, cfg_fsm_rst_i |=> np_sample_cnt_q == 0, clk_aon_i, !rst_aon_ni)
-  `ASSERT(LpSampleCntSwReset_A, cfg_fsm_rst_i |=> lp_sample_cnt_q == 0, clk_aon_i, !rst_aon_ni)
+  default clocking @(posedge clk_aon_i); endclocking
 
+  if (1) begin : gen_aon_assertions
+    default disable iff !rst_aon_ni;
 
-  // FSM hardware reset - checks first clk_aon_i after every hardware reset
-  `ASSERT(FsmStateHwReset_A, 1 |=> (@(posedge clk_aon_i) fsm_state_q == FsmResetState), !rst_aon_ni,
-          0)
-  `ASSERT(PwrupTimerCntHwReset_A, 1 |=> (@(posedge clk_aon_i) pwrup_timer_cnt_q == 0), !rst_aon_ni,
-          0)
-  `ASSERT(WakeupTimerCntHwReset_A, 1 |=> (@(posedge clk_aon_i) wakeup_timer_cnt_q == 0),
-          !rst_aon_ni, 0)
-  `ASSERT(NpSampleCntHwReset_A, 1 |=> (@(posedge clk_aon_i) np_sample_cnt_q == 0), !rst_aon_ni, 0)
-  `ASSERT(LpSampleCntHwReset_A, 1 |=> (@(posedge clk_aon_i) lp_sample_cnt_q == 0), !rst_aon_ni, 0)
+    // FSM software reset
+    FsmStateSwReset_A:
+      assert property (cfg_fsm_rst_i |=> fsm_state_q == FsmResetState)
+      else `ASSERT_ERROR(FsmStateSwReset_A)
+    PwrupTimerCntSwReset_A:
+      assert property (cfg_fsm_rst_i |=> pwrup_timer_cnt_q == 0)
+      else `ASSERT_ERROR(PwrupTimerCntSwReset_A)
+    WakeupTimerCntSwReset_A:
+      assert property (cfg_fsm_rst_i |=> wakeup_timer_cnt_q == 0)
+      else `ASSERT_ERROR(WakeupTimerCntSwReset_A)
+    NpSampleCntSwReset_A:
+      assert property (cfg_fsm_rst_i |=> np_sample_cnt_q == 0)
+      else `ASSERT_ERROR(NpSampleCntSwReset_A)
+    LpSampleCntSwReset_A:
+      assert property (cfg_fsm_rst_i |=> lp_sample_cnt_q == 0)
+      else `ASSERT_ERROR(LpSampleCntSwReset_A)
 
-  // Check connectivity of the state output register (this is used for debug only).
-  `ASSERT(FsmDebugOut_A, fsm_state_q === tb.dut.u_reg.hw2reg.adc_fsm_state.d,
-      clk_aon_i, !rst_aon_ni)
+    // Check connectivity of the state output register (this is used for debug only).
+    FsmDebugOut_A:
+      assert property (fsm_state_q === tb.dut.u_reg.hw2reg.adc_fsm_state.d)
+      else `ASSERT_ERROR(FsmDebugOut_A)
+  end
 
+  // FSM hardware reset
+  //
+  // These assertions contain properties that have a check on the first posedge of clk_aon_i after
+  // the hardware reset is applied. Note that this clock edge may happen during or after the reset
+  // (and the assertions are expected to be true either way).
+
+  bit start_of_reset;
+  always @(negedge rst_aon_ni) begin
+    start_of_reset <= 1;
+  end
+  always @(posedge clk_aon_i) begin
+    start_of_reset <= 0;
+  end
+
+  FsmStateHwReset_A:
+    assert property (start_of_reset -> fsm_state_q == FsmResetState)
+    else `ASSERT_ERROR(FsmStateHwReset_A)
+  PwrupTimerCntHwReset_A:
+    assert property (start_of_reset -> pwrup_timer_cnt_q == 0)
+    else `ASSERT_ERROR(PwrupTimerCntHwReset_A)
+  WakeupTimerCntHwReset_A:
+    assert property (start_of_reset -> wakeup_timer_cnt_q == 0)
+    else `ASSERT_ERROR(WakeupTimerCntHwReset_A)
+  NpSampleCntHwReset_A:
+    assert property (start_of_reset -> np_sample_cnt_q == 0)
+    else `ASSERT_ERROR(NpSampleCntHwReset_A)
+  LpSampleCntHwReset_A:
+    assert property (start_of_reset -> lp_sample_cnt_q == 0)
+    else `ASSERT_ERROR(LpSampleCntHwReset_A)
 endinterface

--- a/hw/ip/adc_ctrl/dv/sva/adc_ctrl_sva_if.sv
+++ b/hw/ip/adc_ctrl/dv/sva/adc_ctrl_sva_if.sv
@@ -118,6 +118,6 @@ interface adc_ctrl_sva_if
   `DV_ASSERT_CTRL("PwrupTime_A_CTRL", PwrupTime_A)
   `DV_ASSERT_CTRL("WakeupTime_A_CTRL", WakeupTime_A)
   `DV_ASSERT_CTRL("EnterLowPower_A_CTRL", EnterLowPower_A)
-  `DV_ASSERT_CTRL("ADC_CTRL_FSM_A_CTRL", dut.u_adc_ctrl_core.u_adc_ctrl_fsm)
+  `DV_ASSERT_CTRL("ADC_CTRL_FSM_A_CTRL", tb.dut.u_adc_ctrl_core.u_adc_ctrl_fsm)
 
 endinterface : adc_ctrl_sva_if


### PR DESCRIPTION
This was inspired by debugging some bogus randomisation (my fault) when I was writing #28581. I tried running the `adc_ctrl` test with Xcelium and it failed miserably! It turns out that this is just because the author had implemented it with VCS. This PR builds on #28581 and then gets `adc_ctrl` DV working with Xcelium too.

As a quick sanity check, I now get every ADC test passing when running with `--fixed-seed 1 --tool xcelium`.

Note that much of this PR comes from the linked one. Only the last 5 commits are unique to this PR.