### PR TITLE
[topgen] No backslash in gencmd

### DIFF
--- a/hw/top_darjeeling/data/autogen/BUILD
+++ b/hw/top_darjeeling/data/autogen/BUILD
@@ -4,7 +4,7 @@
 #
 # ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------#
 # PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-# util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+# util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 #                -o hw/top_darjeeling/
 
 exports_files(glob(["*.hjson"]))

--- a/hw/top_darjeeling/data/autogen/defs.bzl
+++ b/hw/top_darjeeling/data/autogen/defs.bzl
@@ -4,7 +4,7 @@
 #
 # ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------#
 # PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-# util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+# util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 #                -o hw/top_darjeeling/
 
 load("//hw/top_darjeeling/ip_autogen/ac_range_check:defs.bzl", "AC_RANGE_CHECK")

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 {
   name: darjeeling

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.secrets.testing.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.secrets.testing.gen.hjson
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 {
   seed:

--- a/hw/top_darjeeling/dv/autogen/rstmgr_tgl_excl.cfg
+++ b/hw/top_darjeeling/dv/autogen/rstmgr_tgl_excl.cfg
@@ -7,7 +7,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 
 //=========================================================

--- a/hw/top_darjeeling/rtl/autogen/chip_darjeeling_asic.sv
+++ b/hw/top_darjeeling/rtl/autogen/chip_darjeeling_asic.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 
 

--- a/hw/top_darjeeling/rtl/autogen/chip_darjeeling_cw310.sv
+++ b/hw/top_darjeeling/rtl/autogen/chip_darjeeling_cw310.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 
 

--- a/hw/top_darjeeling/rtl/autogen/testing/top_darjeeling_rnd_cnst_pkg.sv
+++ b/hw/top_darjeeling/rtl/autogen/testing/top_darjeeling_rnd_cnst_pkg.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 //
 // File is generated based on the following seed configuration:

--- a/hw/top_darjeeling/rtl/autogen/testing/top_darjeeling_rnd_cnst_pkg.vbl
+++ b/hw/top_darjeeling/rtl/autogen/testing/top_darjeeling_rnd_cnst_pkg.vbl
@@ -5,7 +5,7 @@
 # ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------#
 # PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 #
-# util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+# util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 #                -o hw/top_darjeeling/
 #
 # File is generated based on the following seed configuration:

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 
 `include "prim_assert.sv"

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling_pkg.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling_pkg.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 
 package top_darjeeling_pkg;

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling_racl_pkg.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling_racl_pkg.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 
 

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling_soc_dbg_pkg.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling_soc_dbg_pkg.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 
 package top_darjeeling_soc_dbg_pkg;

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling_soc_mbx_pkg.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling_soc_mbx_pkg.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 
 package top_darjeeling_soc_mbx_pkg;

--- a/hw/top_darjeeling/rtl/autogen/top_racl_pkg.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_racl_pkg.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 
 

--- a/hw/top_darjeeling/sw/autogen/BUILD
+++ b/hw/top_darjeeling/sw/autogen/BUILD
@@ -4,7 +4,7 @@
 #
 # ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------#
 # PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-# util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+# util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 #                -o hw/top_darjeeling/
 
 load("//rules:linker.bzl", "ld_library")

--- a/hw/top_darjeeling/sw/autogen/tests/BUILD
+++ b/hw/top_darjeeling/sw/autogen/tests/BUILD
@@ -4,7 +4,7 @@
 #
 # ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------#
 # PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-# util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+# util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 #                -o hw/top_darjeeling/
 
 load(

--- a/hw/top_darjeeling/sw/autogen/tests/alert_test.c
+++ b/hw/top_darjeeling/sw/autogen/tests/alert_test.c
@@ -6,7 +6,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 #include "sw/device/lib/arch/boot_stage.h"
 #include "sw/device/lib/base/mmio.h"

--- a/hw/top_darjeeling/sw/autogen/tests/plic_all_irqs_test.c
+++ b/hw/top_darjeeling/sw/autogen/tests/plic_all_irqs_test.c
@@ -5,7 +5,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 #include <limits.h>
 

--- a/hw/top_darjeeling/sw/autogen/top_darjeeling.c
+++ b/hw/top_darjeeling/sw/autogen/top_darjeeling.c
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 
 #include "hw/top_darjeeling/sw/autogen/top_darjeeling.h"

--- a/hw/top_darjeeling/sw/autogen/top_darjeeling.h
+++ b/hw/top_darjeeling/sw/autogen/top_darjeeling.h
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 
 #ifndef OPENTITAN_HW_TOP_DARJEELING_SW_AUTOGEN_TOP_DARJEELING_H_

--- a/hw/top_darjeeling/sw/autogen/top_darjeeling_memory.h
+++ b/hw/top_darjeeling/sw/autogen/top_darjeeling_memory.h
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 
 #ifndef OPENTITAN_HW_TOP_DARJEELING_SW_AUTOGEN_TOP_DARJEELING_MEMORY_H_

--- a/hw/top_darjeeling/sw/autogen/top_darjeeling_memory.ld
+++ b/hw/top_darjeeling/sw/autogen/top_darjeeling_memory.ld
@@ -4,7 +4,7 @@
 /*
  * ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! ------------------- *
  * PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
- * util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+ * util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
  *                -o hw/top_darjeeling/
  */
 

--- a/hw/top_darjeeling/sw/autogen/top_darjeeling_soc_dbg.c
+++ b/hw/top_darjeeling/sw/autogen/top_darjeeling_soc_dbg.c
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 
 #include "hw/top_darjeeling/sw/autogen/top_darjeeling_soc_dbg.h"

--- a/hw/top_darjeeling/sw/autogen/top_darjeeling_soc_dbg.h
+++ b/hw/top_darjeeling/sw/autogen/top_darjeeling_soc_dbg.h
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 
 #ifndef OPENTITAN_HW_TOP_DARJEELING_SW_AUTOGEN_TOP_DARJEELING_SOC_DBG_H_

--- a/hw/top_darjeeling/sw/autogen/top_darjeeling_soc_dbg_memory.h
+++ b/hw/top_darjeeling/sw/autogen/top_darjeeling_soc_dbg_memory.h
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 
 #ifndef OPENTITAN_HW_TOP_DARJEELING_SW_AUTOGEN_TOP_DARJEELING_SOC_DBG_MEMORY_H_

--- a/hw/top_darjeeling/sw/autogen/top_darjeeling_soc_mbx.c
+++ b/hw/top_darjeeling/sw/autogen/top_darjeeling_soc_mbx.c
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 
 #include "hw/top_darjeeling/sw/autogen/top_darjeeling_soc_mbx.h"

--- a/hw/top_darjeeling/sw/autogen/top_darjeeling_soc_mbx.h
+++ b/hw/top_darjeeling/sw/autogen/top_darjeeling_soc_mbx.h
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 
 #ifndef OPENTITAN_HW_TOP_DARJEELING_SW_AUTOGEN_TOP_DARJEELING_SOC_MBX_H_

--- a/hw/top_darjeeling/sw/autogen/top_darjeeling_soc_mbx_memory.h
+++ b/hw/top_darjeeling/sw/autogen/top_darjeeling_soc_mbx_memory.h
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson \
+// util/topgen.py -t hw/top_darjeeling/data/top_darjeeling.hjson
 //                -o hw/top_darjeeling/
 
 #ifndef OPENTITAN_HW_TOP_DARJEELING_SW_AUTOGEN_TOP_DARJEELING_SOC_MBX_MEMORY_H_

--- a/hw/top_earlgrey/data/autogen/BUILD
+++ b/hw/top_earlgrey/data/autogen/BUILD
@@ -4,7 +4,7 @@
 #
 # ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------#
 # PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-# util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
+# util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 #                -o hw/top_earlgrey/
 
 exports_files(glob(["*.hjson"]))

--- a/hw/top_earlgrey/data/autogen/defs.bzl
+++ b/hw/top_earlgrey/data/autogen/defs.bzl
@@ -4,7 +4,7 @@
 #
 # ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------#
 # PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-# util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
+# util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 #                -o hw/top_earlgrey/
 
 load("//hw/ip/adc_ctrl:defs.bzl", "ADC_CTRL")

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
+// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 //                -o hw/top_earlgrey/
 {
   name: earlgrey

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.secrets.testing.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.secrets.testing.gen.hjson
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
+// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 //                -o hw/top_earlgrey/
 {
   seed:

--- a/hw/top_earlgrey/dv/autogen/rstmgr_tgl_excl.cfg
+++ b/hw/top_earlgrey/dv/autogen/rstmgr_tgl_excl.cfg
@@ -7,7 +7,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
+// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 //                -o hw/top_earlgrey/
 
 //=========================================================

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
+// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 //                -o hw/top_earlgrey/
 
 

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
+// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 //                -o hw/top_earlgrey/
 
 

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw340.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw340.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
+// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 //                -o hw/top_earlgrey/
 
 

--- a/hw/top_earlgrey/rtl/autogen/testing/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/testing/top_earlgrey_rnd_cnst_pkg.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
+// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 //                -o hw/top_earlgrey/
 //
 // File is generated based on the following seed configuration:

--- a/hw/top_earlgrey/rtl/autogen/testing/top_earlgrey_rnd_cnst_pkg.vbl
+++ b/hw/top_earlgrey/rtl/autogen/testing/top_earlgrey_rnd_cnst_pkg.vbl
@@ -5,7 +5,7 @@
 # ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------#
 # PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 #
-# util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
+# util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 #                -o hw/top_earlgrey/
 #
 # File is generated based on the following seed configuration:

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
+// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 //                -o hw/top_earlgrey/
 
 module top_earlgrey #(

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
+// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 //                -o hw/top_earlgrey/
 
 package top_earlgrey_pkg;

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_racl_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_racl_pkg.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
+// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 //                -o hw/top_earlgrey/
 
 

--- a/hw/top_earlgrey/rtl/autogen/top_racl_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_racl_pkg.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
+// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 //                -o hw/top_earlgrey/
 
 

--- a/hw/top_earlgrey/sw/autogen/BUILD
+++ b/hw/top_earlgrey/sw/autogen/BUILD
@@ -4,7 +4,7 @@
 #
 # ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------#
 # PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-# util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
+# util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 #                -o hw/top_earlgrey/
 
 load("//rules:linker.bzl", "ld_library")

--- a/hw/top_earlgrey/sw/autogen/tests/BUILD
+++ b/hw/top_earlgrey/sw/autogen/tests/BUILD
@@ -4,7 +4,7 @@
 #
 # ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------#
 # PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-# util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
+# util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 #                -o hw/top_earlgrey/
 
 load(

--- a/hw/top_earlgrey/sw/autogen/tests/alert_test.c
+++ b/hw/top_earlgrey/sw/autogen/tests/alert_test.c
@@ -6,7 +6,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
+// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 //                -o hw/top_earlgrey/
 #include "sw/device/lib/arch/boot_stage.h"
 #include "sw/device/lib/base/mmio.h"

--- a/hw/top_earlgrey/sw/autogen/tests/plic_all_irqs_test.c
+++ b/hw/top_earlgrey/sw/autogen/tests/plic_all_irqs_test.c
@@ -5,7 +5,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
+// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 //                -o hw/top_earlgrey/
 #include <limits.h>
 

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.c
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.c
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
+// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 //                -o hw/top_earlgrey/
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
+// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 //                -o hw/top_earlgrey/
 
 #ifndef OPENTITAN_HW_TOP_EARLGREY_SW_AUTOGEN_TOP_EARLGREY_H_

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
+// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 //                -o hw/top_earlgrey/
 
 #ifndef OPENTITAN_HW_TOP_EARLGREY_SW_AUTOGEN_TOP_EARLGREY_MEMORY_H_

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
@@ -4,7 +4,7 @@
 /*
  * ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! ------------------- *
  * PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
- * util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
+ * util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
  *                -o hw/top_earlgrey/
  */
 

--- a/hw/top_englishbreakfast/data/autogen/BUILD
+++ b/hw/top_englishbreakfast/data/autogen/BUILD
@@ -4,7 +4,7 @@
 #
 # ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------#
 # PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-# util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
+# util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson
 #                -o hw/top_englishbreakfast/
 
 exports_files(glob(["*.hjson"]))

--- a/hw/top_englishbreakfast/data/autogen/defs.bzl
+++ b/hw/top_englishbreakfast/data/autogen/defs.bzl
@@ -4,7 +4,7 @@
 #
 # ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------#
 # PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-# util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
+# util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson
 #                -o hw/top_englishbreakfast/
 
 load("//hw/ip/aes:defs.bzl", "AES")

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
+// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson
 //                -o hw/top_englishbreakfast/
 {
   name: englishbreakfast

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.secrets.testing.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.secrets.testing.gen.hjson
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
+// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson
 //                -o hw/top_englishbreakfast/
 {
   seed:

--- a/hw/top_englishbreakfast/dv/autogen/rstmgr_tgl_excl.cfg
+++ b/hw/top_englishbreakfast/dv/autogen/rstmgr_tgl_excl.cfg
@@ -7,7 +7,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
+// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson
 //                -o hw/top_englishbreakfast/
 
 //=========================================================

--- a/hw/top_englishbreakfast/rtl/autogen/chip_englishbreakfast_cw305.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/chip_englishbreakfast_cw305.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
+// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson
 //                -o hw/top_englishbreakfast/
 
 

--- a/hw/top_englishbreakfast/rtl/autogen/testing/top_englishbreakfast_rnd_cnst_pkg.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/testing/top_englishbreakfast_rnd_cnst_pkg.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
+// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson
 //                -o hw/top_englishbreakfast/
 //
 // File is generated based on the following seed configuration:

--- a/hw/top_englishbreakfast/rtl/autogen/testing/top_englishbreakfast_rnd_cnst_pkg.vbl
+++ b/hw/top_englishbreakfast/rtl/autogen/testing/top_englishbreakfast_rnd_cnst_pkg.vbl
@@ -5,7 +5,7 @@
 # ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------#
 # PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 #
-# util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
+# util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson
 #                -o hw/top_englishbreakfast/
 #
 # File is generated based on the following seed configuration:

--- a/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
+// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson
 //                -o hw/top_englishbreakfast/
 
 module top_englishbreakfast #(

--- a/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast_pkg.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast_pkg.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
+// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson
 //                -o hw/top_englishbreakfast/
 
 package top_englishbreakfast_pkg;

--- a/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast_racl_pkg.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast_racl_pkg.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
+// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson
 //                -o hw/top_englishbreakfast/
 
 

--- a/hw/top_englishbreakfast/rtl/autogen/top_racl_pkg.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_racl_pkg.sv
@@ -5,7 +5,7 @@
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 //
-// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
+// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson
 //                -o hw/top_englishbreakfast/
 
 

--- a/hw/top_englishbreakfast/sw/autogen/BUILD
+++ b/hw/top_englishbreakfast/sw/autogen/BUILD
@@ -4,7 +4,7 @@
 #
 # ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------#
 # PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-# util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
+# util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson
 #                -o hw/top_englishbreakfast/
 
 load("//rules:linker.bzl", "ld_library")

--- a/hw/top_englishbreakfast/sw/autogen/tests/BUILD
+++ b/hw/top_englishbreakfast/sw/autogen/tests/BUILD
@@ -4,7 +4,7 @@
 #
 # ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------#
 # PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-# util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
+# util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson
 #                -o hw/top_englishbreakfast/
 
 load(

--- a/hw/top_englishbreakfast/sw/autogen/tests/plic_all_irqs_test.c
+++ b/hw/top_englishbreakfast/sw/autogen/tests/plic_all_irqs_test.c
@@ -5,7 +5,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
+// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson
 //                -o hw/top_englishbreakfast/
 #include <limits.h>
 

--- a/hw/top_englishbreakfast/sw/autogen/top_englishbreakfast.c
+++ b/hw/top_englishbreakfast/sw/autogen/top_englishbreakfast.c
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
+// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson
 //                -o hw/top_englishbreakfast/
 
 #include "hw/top_englishbreakfast/sw/autogen/top_englishbreakfast.h"

--- a/hw/top_englishbreakfast/sw/autogen/top_englishbreakfast.h
+++ b/hw/top_englishbreakfast/sw/autogen/top_englishbreakfast.h
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
+// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson
 //                -o hw/top_englishbreakfast/
 
 #ifndef OPENTITAN_HW_TOP_ENGLISHBREAKFAST_SW_AUTOGEN_TOP_ENGLISHBREAKFAST_H_

--- a/hw/top_englishbreakfast/sw/autogen/top_englishbreakfast_memory.h
+++ b/hw/top_englishbreakfast/sw/autogen/top_englishbreakfast_memory.h
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
+// util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson
 //                -o hw/top_englishbreakfast/
 
 #ifndef OPENTITAN_HW_TOP_ENGLISHBREAKFAST_SW_AUTOGEN_TOP_ENGLISHBREAKFAST_MEMORY_H_

--- a/hw/top_englishbreakfast/sw/autogen/top_englishbreakfast_memory.ld
+++ b/hw/top_englishbreakfast/sw/autogen/top_englishbreakfast_memory.ld
@@ -4,7 +4,7 @@
 /*
  * ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! ------------------- *
  * PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
- * util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
+ * util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson
  *                -o hw/top_englishbreakfast/
  */
 

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -66,7 +66,7 @@ lichdr = """// Copyright lowRISC contributors (OpenTitan project).
 """
 genhdr = lichdr + warnhdr
 
-GENCMD = ("// util/topgen.py -t hw/{top_name}/data/{top_name}.hjson \\\n"
+GENCMD = ("// util/topgen.py -t hw/{top_name}/data/{top_name}.hjson\n"
           "//                -o hw/{top_name}/")
 
 SRCTREE_TOP = Path(__file__).parents[1].resolve()


### PR DESCRIPTION
There is a backslash in the gencmd, breaking the long lines of the generate command. When rendering a C file with a single-line comment (`//`), the backslash is considered a line continuation character, causing the compiler to issue a warning.

```
(16:07:06) INFO: From Compiling hw/top_earlgrey/sw/autogen/top_earlgrey.c:
hw/top_earlgrey/sw/autogen/top_earlgrey.c:7:1: warning: multi-line comment [-Wcomment]
    7 | // util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
      | ^
In file included from hw/top_earlgrey/sw/autogen/top_earlgrey.c:10:
./hw/top_earlgrey/sw/autogen/top_earlgrey.h:7:1: warning: multi-line comment [-Wcomment]
    7 | // util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
      | ^
```

These messages are really annoying and it makes finding the real issue in a build log quite hard.