### PR TITLE
[racl_ctrl,topgen] Make racl_group an ipgen param.

### DIFF
--- a/hw/ip_templates/racl_ctrl/data/racl_ctrl.tpldesc.hjson
+++ b/hw/ip_templates/racl_ctrl/data/racl_ctrl.tpldesc.hjson
@@ -57,5 +57,11 @@
       type: "object"
       default: []
     }
+    {
+      name: "racl_group"
+      desc: "The RACL Group"
+      type: "string"
+      default: "Null"
+    }
   ]
 }

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/data/top_darjeeling_racl_ctrl.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/data/top_darjeeling_racl_ctrl.ipconfig.hjson
@@ -10,6 +10,7 @@
     nr_ctn_uid_bits: 5
     nr_policies: 3
     nr_subscribing_ips: 11
+    racl_group: Null
     policies:
     [
       {

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -776,7 +776,7 @@ def _get_ac_range_check_params(top: ConfigT) -> ParamsT:
 def _get_racl_params(top: ConfigT) -> ParamsT:
     """Extracts parameters for racl_ctrl ipgen."""
     module = lib.find_module(top["module"], "racl_ctrl")
-    racl_group = module.get("racl_group", "Null")
+    racl_group = module.get("ipgen_params", {}).get("racl_group", "Null")
     if len(top["racl"]["policies"]) == 1:
         # If there is only one set of policies, take the first one
         policies = list(top["racl"]["policies"].values())[0]
@@ -801,6 +801,7 @@ def _get_racl_params(top: ConfigT) -> ParamsT:
         "nr_ctn_uid_bits": top["racl"]["nr_ctn_uid_bits"],
         "nr_policies": top["racl"]["nr_policies"],
         'nr_subscribing_ips': num_subscribing_ips[racl_group],
+        "racl_group": racl_group,
         "policies": policies
     })
     return ipgen_params


### PR DESCRIPTION
Right now this PR does not make use of the ipgen param, but it allows generating the racl_ctrl (rtl, hjson, etc) based on the racl group.