### PR TITLE
[hw,pwrmgr,dv] Determine clk ratio in assertion based on top

### DIFF
--- a/hw/ip_templates/pwrmgr/dv/sva/pwrmgr_rstreqs_sva_if.sv.tpl
+++ b/hw/ip_templates/pwrmgr/dv/sva/pwrmgr_rstreqs_sva_if.sv.tpl
@@ -33,7 +33,14 @@ interface pwrmgr_rstreqs_sva_if
   // The timing of the escalation reset is determined by the slow clock, but will not propagate if
   // the non-slow clock is off. We use the regular clock and multiply the clock cycles times the
   // clock ratio.
+% if topname in ["earlgrey", "englishbreakfast"]:
   localparam int FastToSlowFreqRatio = 120;
+% elif topname == "darjeeling":
+  // Darjeeling has a 16x clock ratio between the slow and fast clocks. (1GHz / 62.5MHz = 16)
+  localparam int FastToSlowFreqRatio = 16;
+% else:
+<% assert False, f"Unsupported top: {topname}" %>\
+% endif
 
   localparam int MinEscRstCycles = 0;
   localparam int MaxEscRstCycles = 4 * FastToSlowFreqRatio;

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstreqs_sva_if.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstreqs_sva_if.sv
@@ -33,7 +33,8 @@ interface pwrmgr_rstreqs_sva_if
   // The timing of the escalation reset is determined by the slow clock, but will not propagate if
   // the non-slow clock is off. We use the regular clock and multiply the clock cycles times the
   // clock ratio.
-  localparam int FastToSlowFreqRatio = 120;
+  // Darjeeling has a 16x clock ratio between the slow and fast clocks. (1GHz / 62.5MHz = 16)
+  localparam int FastToSlowFreqRatio = 16;
 
   localparam int MinEscRstCycles = 0;
   localparam int MaxEscRstCycles = 4 * FastToSlowFreqRatio;


### PR DESCRIPTION
Darjeeling has a 1Ghz main clock and a 62.5MHz slow AON clock, yielding a clock ratio of 16. Use that stricter value for the escalation delay.