### PR TITLE
[cryptotest] ACVP test harness with HMAC-SHA2-256 vectors

### DIFF
--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -11,6 +11,35 @@ filegroup(
     srcs = glob(["**/*.md"]),
 )
 
+# Special Cryptotest firmware and harness used to run ACVP test vectors. The
+# test_args are left empty by default. This allows the user to manually specify
+# paths to the input and output ACVP JSON files that should be used.
+#
+# Example usage:
+# ./bazelisk.sh run \
+#     //sw/device/tests/crypto/cryptotest:acvp_fpga_cw340_sival_rom_ext -- \
+#         --input=${ACVP_DIR}/hmac_sha2_256_vectors.json \
+#         --output=${ACVP_DIR}/hmac_sha2_256_results.json
+cryptotest(
+    name = "acvp",
+    test_args = "",
+    test_harness = "//sw/host/tests/crypto/acvp:harness",
+    test_vectors = [],
+)
+
+cryptotest(
+    name = "acvp_hmac_sha256",
+    test_args = " ".join([
+        "--input=\"$(rootpath //sw/host/cryptotest/testvectors/acvp:hmac_sha256_vectors.json)\"",
+        "--expected=\"$(rootpath //sw/host/cryptotest/testvectors/acvp:hmac_sha256_expected.json)\"",
+    ]),
+    test_harness = "//sw/host/tests/crypto/acvp:harness",
+    test_vectors = [
+        "//sw/host/cryptotest/testvectors/acvp:hmac_sha256_vectors.json",
+        "//sw/host/cryptotest/testvectors/acvp:hmac_sha256_expected.json",
+    ],
+)
+
 AES_TESTVECTOR_TARGETS = [
     "//sw/host/cryptotest/testvectors/data:nist_cavp_aes_kat_{}_{}_{}_json".format(alg, kat_type, key_len)
     for alg in ("cbc", "cfb128", "ecb", "ofb")

--- a/sw/host/cryptotest/testvectors/acvp/BUILD
+++ b/sw/host/cryptotest/testvectors/acvp/BUILD
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "hmac_sha256_expected.json",
+    "hmac_sha256_vectors.json",
+])

--- a/sw/host/cryptotest/testvectors/acvp/hmac_sha256_expected.json
+++ b/sw/host/cryptotest/testvectors/acvp/hmac_sha256_expected.json
@@ -1,0 +1,2457 @@
+[
+  {
+    "url": "acvp/v1/testSessions/666842",
+    "vectorSetUrls": [
+      "/acvp/v1/testSessions/666842/vectorSets/3493042"
+    ],
+    "time": "2025-11-04T21:00:46-08:00"
+  },
+  {
+    "vsId": 3493042,
+    "algorithm": "HMAC-SHA2-256",
+    "revision": "1.0",
+    "isSample": true,
+    "testGroups": [
+      {
+        "tgId": 1,
+        "tests": [
+          {
+            "tcId": 1,
+            "mac": "9974e8ed5c7f"
+          },
+          {
+            "tcId": 2,
+            "mac": "548d457904a3"
+          },
+          {
+            "tcId": 3,
+            "mac": "0dd384ba72e8"
+          },
+          {
+            "tcId": 4,
+            "mac": "46803fc675f0"
+          },
+          {
+            "tcId": 5,
+            "mac": "60b9de8ec594"
+          },
+          {
+            "tcId": 6,
+            "mac": "d91f200ba873"
+          },
+          {
+            "tcId": 7,
+            "mac": "097f42e5c686"
+          },
+          {
+            "tcId": 8,
+            "mac": "52d74a8d1b50"
+          },
+          {
+            "tcId": 9,
+            "mac": "685d9139bd08"
+          },
+          {
+            "tcId": 10,
+            "mac": "89ef342928d1"
+          },
+          {
+            "tcId": 11,
+            "mac": "83438059b26e"
+          },
+          {
+            "tcId": 12,
+            "mac": "3a755ed78a89"
+          },
+          {
+            "tcId": 13,
+            "mac": "3a70bbed07f0"
+          },
+          {
+            "tcId": 14,
+            "mac": "3471553871ee"
+          },
+          {
+            "tcId": 15,
+            "mac": "5d075ce621f9"
+          },
+          {
+            "tcId": 16,
+            "mac": "e685ec8d7903"
+          },
+          {
+            "tcId": 17,
+            "mac": "2361b6d76552"
+          },
+          {
+            "tcId": 18,
+            "mac": "e3bb29ab82cc"
+          },
+          {
+            "tcId": 19,
+            "mac": "7c1bcc81fece"
+          },
+          {
+            "tcId": 20,
+            "mac": "4ac7c5611e05"
+          },
+          {
+            "tcId": 21,
+            "mac": "74ce5df6f500"
+          },
+          {
+            "tcId": 22,
+            "mac": "43754864e62c"
+          },
+          {
+            "tcId": 23,
+            "mac": "c1302280bb82"
+          },
+          {
+            "tcId": 24,
+            "mac": "045966bb9fbf"
+          },
+          {
+            "tcId": 25,
+            "mac": "e074fa47395c"
+          },
+          {
+            "tcId": 26,
+            "mac": "cdb46fd00ec2"
+          },
+          {
+            "tcId": 27,
+            "mac": "acc362eb66aa"
+          },
+          {
+            "tcId": 28,
+            "mac": "cc61aa9768f7"
+          },
+          {
+            "tcId": 29,
+            "mac": "ea5f8897d867"
+          },
+          {
+            "tcId": 30,
+            "mac": "d055229e38d4"
+          },
+          {
+            "tcId": 31,
+            "mac": "bca5ac08d355"
+          },
+          {
+            "tcId": 32,
+            "mac": "5779eef145c5"
+          },
+          {
+            "tcId": 33,
+            "mac": "b30ba381318a"
+          },
+          {
+            "tcId": 34,
+            "mac": "c9deba7c0b37"
+          },
+          {
+            "tcId": 35,
+            "mac": "6a466d8512f0"
+          },
+          {
+            "tcId": 36,
+            "mac": "b6a3e8ad35b0"
+          },
+          {
+            "tcId": 37,
+            "mac": "998812d9aca7"
+          },
+          {
+            "tcId": 38,
+            "mac": "daa3ca8f79a1"
+          },
+          {
+            "tcId": 39,
+            "mac": "aff54b6baab9"
+          },
+          {
+            "tcId": 40,
+            "mac": "db22813901bd"
+          },
+          {
+            "tcId": 41,
+            "mac": "1d69383b1754"
+          },
+          {
+            "tcId": 42,
+            "mac": "3d90bc462c51"
+          },
+          {
+            "tcId": 43,
+            "mac": "b6c801ebb3c6"
+          },
+          {
+            "tcId": 44,
+            "mac": "c620c4434d77"
+          },
+          {
+            "tcId": 45,
+            "mac": "b2882a828ffa"
+          },
+          {
+            "tcId": 46,
+            "mac": "7472f27cdb91"
+          },
+          {
+            "tcId": 47,
+            "mac": "bc846c33013b"
+          },
+          {
+            "tcId": 48,
+            "mac": "60e824644ba2"
+          },
+          {
+            "tcId": 49,
+            "mac": "fad4bbfefd75"
+          },
+          {
+            "tcId": 50,
+            "mac": "8fd9e429abb2"
+          },
+          {
+            "tcId": 51,
+            "mac": "c6d832a06454"
+          },
+          {
+            "tcId": 52,
+            "mac": "97c1e7446e55"
+          },
+          {
+            "tcId": 53,
+            "mac": "420737770bbd"
+          },
+          {
+            "tcId": 54,
+            "mac": "f7098773dd9f"
+          },
+          {
+            "tcId": 55,
+            "mac": "0d7a80d0860c"
+          },
+          {
+            "tcId": 56,
+            "mac": "6d621dbfe757"
+          },
+          {
+            "tcId": 57,
+            "mac": "b8edee0a558c"
+          },
+          {
+            "tcId": 58,
+            "mac": "be870a5fb43f"
+          },
+          {
+            "tcId": 59,
+            "mac": "69bdebc54968"
+          },
+          {
+            "tcId": 60,
+            "mac": "4ec31f0a105f"
+          },
+          {
+            "tcId": 61,
+            "mac": "45936e50ee6c"
+          },
+          {
+            "tcId": 62,
+            "mac": "e899f773f586"
+          },
+          {
+            "tcId": 63,
+            "mac": "21f98e66d8b4"
+          },
+          {
+            "tcId": 64,
+            "mac": "855b9fca0637"
+          },
+          {
+            "tcId": 65,
+            "mac": "96d9f2fd0ff7"
+          },
+          {
+            "tcId": 66,
+            "mac": "0b154f616061"
+          },
+          {
+            "tcId": 67,
+            "mac": "d7f315aa34b8"
+          },
+          {
+            "tcId": 68,
+            "mac": "6a0ef5214646"
+          },
+          {
+            "tcId": 69,
+            "mac": "3384ba156c51"
+          },
+          {
+            "tcId": 70,
+            "mac": "def3d10e795a"
+          },
+          {
+            "tcId": 71,
+            "mac": "702352713f82"
+          },
+          {
+            "tcId": 72,
+            "mac": "e4e64ece7238"
+          },
+          {
+            "tcId": 73,
+            "mac": "1b4e6d5a41de"
+          },
+          {
+            "tcId": 74,
+            "mac": "c6e94002d084"
+          },
+          {
+            "tcId": 75,
+            "mac": "481c26c62651"
+          }
+        ]
+      },
+      {
+        "tgId": 2,
+        "tests": [
+          {
+            "tcId": 76,
+            "mac": "73fc274e"
+          },
+          {
+            "tcId": 77,
+            "mac": "67ca6c4d"
+          },
+          {
+            "tcId": 78,
+            "mac": "705452e3"
+          },
+          {
+            "tcId": 79,
+            "mac": "02bec4c3"
+          },
+          {
+            "tcId": 80,
+            "mac": "c16fa071"
+          },
+          {
+            "tcId": 81,
+            "mac": "d83f1630"
+          },
+          {
+            "tcId": 82,
+            "mac": "2e522b2d"
+          },
+          {
+            "tcId": 83,
+            "mac": "ad2202a6"
+          },
+          {
+            "tcId": 84,
+            "mac": "7a239e59"
+          },
+          {
+            "tcId": 85,
+            "mac": "f8fbc3eb"
+          },
+          {
+            "tcId": 86,
+            "mac": "0f73cb16"
+          },
+          {
+            "tcId": 87,
+            "mac": "22715ed8"
+          },
+          {
+            "tcId": 88,
+            "mac": "2276ea98"
+          },
+          {
+            "tcId": 89,
+            "mac": "45d5026e"
+          },
+          {
+            "tcId": 90,
+            "mac": "2c7550e7"
+          },
+          {
+            "tcId": 91,
+            "mac": "858eeda6"
+          },
+          {
+            "tcId": 92,
+            "mac": "913f099f"
+          },
+          {
+            "tcId": 93,
+            "mac": "48c87915"
+          },
+          {
+            "tcId": 94,
+            "mac": "3d7d89dc"
+          },
+          {
+            "tcId": 95,
+            "mac": "e2003043"
+          },
+          {
+            "tcId": 96,
+            "mac": "af4260f7"
+          },
+          {
+            "tcId": 97,
+            "mac": "365611ee"
+          },
+          {
+            "tcId": 98,
+            "mac": "97b379c4"
+          },
+          {
+            "tcId": 99,
+            "mac": "b776ae63"
+          },
+          {
+            "tcId": 100,
+            "mac": "18e9f247"
+          },
+          {
+            "tcId": 101,
+            "mac": "3bae5023"
+          },
+          {
+            "tcId": 102,
+            "mac": "baf37c84"
+          },
+          {
+            "tcId": 103,
+            "mac": "79078191"
+          },
+          {
+            "tcId": 104,
+            "mac": "b3e68349"
+          },
+          {
+            "tcId": 105,
+            "mac": "93b4aa06"
+          },
+          {
+            "tcId": 106,
+            "mac": "fe7a5ae7"
+          },
+          {
+            "tcId": 107,
+            "mac": "7f1854e3"
+          },
+          {
+            "tcId": 108,
+            "mac": "7ab84859"
+          },
+          {
+            "tcId": 109,
+            "mac": "565023a3"
+          },
+          {
+            "tcId": 110,
+            "mac": "27e2d64d"
+          },
+          {
+            "tcId": 111,
+            "mac": "dd05aa43"
+          },
+          {
+            "tcId": 112,
+            "mac": "1c3ca482"
+          },
+          {
+            "tcId": 113,
+            "mac": "3fbaac8f"
+          },
+          {
+            "tcId": 114,
+            "mac": "e0eda9e5"
+          },
+          {
+            "tcId": 115,
+            "mac": "62d023a4"
+          },
+          {
+            "tcId": 116,
+            "mac": "8150623f"
+          },
+          {
+            "tcId": 117,
+            "mac": "28f0f7ee"
+          },
+          {
+            "tcId": 118,
+            "mac": "2bcf4105"
+          },
+          {
+            "tcId": 119,
+            "mac": "a746a329"
+          },
+          {
+            "tcId": 120,
+            "mac": "1a7de631"
+          },
+          {
+            "tcId": 121,
+            "mac": "4f7b59e9"
+          },
+          {
+            "tcId": 122,
+            "mac": "525c6412"
+          },
+          {
+            "tcId": 123,
+            "mac": "251641f1"
+          },
+          {
+            "tcId": 124,
+            "mac": "d6d873da"
+          },
+          {
+            "tcId": 125,
+            "mac": "3e0e5834"
+          },
+          {
+            "tcId": 126,
+            "mac": "a5b95a72"
+          },
+          {
+            "tcId": 127,
+            "mac": "9ef3989a"
+          },
+          {
+            "tcId": 128,
+            "mac": "04b4e418"
+          },
+          {
+            "tcId": 129,
+            "mac": "51d2b2ca"
+          },
+          {
+            "tcId": 130,
+            "mac": "ca880dad"
+          },
+          {
+            "tcId": 131,
+            "mac": "f3e1f2f0"
+          },
+          {
+            "tcId": 132,
+            "mac": "92852b5e"
+          },
+          {
+            "tcId": 133,
+            "mac": "55ae2d0d"
+          },
+          {
+            "tcId": 134,
+            "mac": "8a69b8e4"
+          },
+          {
+            "tcId": 135,
+            "mac": "c8774769"
+          },
+          {
+            "tcId": 136,
+            "mac": "284eea26"
+          },
+          {
+            "tcId": 137,
+            "mac": "63cb9ae4"
+          },
+          {
+            "tcId": 138,
+            "mac": "21b1d864"
+          },
+          {
+            "tcId": 139,
+            "mac": "09e7662a"
+          },
+          {
+            "tcId": 140,
+            "mac": "cd90fe5d"
+          },
+          {
+            "tcId": 141,
+            "mac": "5c44de65"
+          },
+          {
+            "tcId": 142,
+            "mac": "5dc602d9"
+          },
+          {
+            "tcId": 143,
+            "mac": "c42ed207"
+          },
+          {
+            "tcId": 144,
+            "mac": "31a78a33"
+          },
+          {
+            "tcId": 145,
+            "mac": "ce8e16a4"
+          },
+          {
+            "tcId": 146,
+            "mac": "1ceb074c"
+          },
+          {
+            "tcId": 147,
+            "mac": "db76b65d"
+          },
+          {
+            "tcId": 148,
+            "mac": "a4e36e89"
+          },
+          {
+            "tcId": 149,
+            "mac": "9bf3257a"
+          },
+          {
+            "tcId": 150,
+            "mac": "80d8a807"
+          }
+        ]
+      },
+      {
+        "tgId": 3,
+        "tests": [
+          {
+            "tcId": 151,
+            "mac": "7bb059b2dac93d1a1f3749914948b87fffd37dd2c9cb2275f6cf2d0807683efa"
+          },
+          {
+            "tcId": 152,
+            "mac": "709d2aad4c05d00b8bedcf3ab93828d42c9dcf1fe36aab3d718041d32f63ca36"
+          },
+          {
+            "tcId": 153,
+            "mac": "e3de3a4867106e9122fcbd0645450dc29759da4ff5a909f203282c23d3fcabcc"
+          },
+          {
+            "tcId": 154,
+            "mac": "9aa9ec13002635f14c6a22b2732b668b256e183ae755177cd0e1f5134c69b8b8"
+          },
+          {
+            "tcId": 155,
+            "mac": "0a756ca9f8a38f16ce5aecf8890f037f1d18e69f9104aab3005876204c8b9173"
+          },
+          {
+            "tcId": 156,
+            "mac": "2f8a4f1e1e96b6e7db5cf1076878e5c466548de33a74628a1b112634e2f40b31"
+          },
+          {
+            "tcId": 157,
+            "mac": "6351c56039e3cb92989a83a9cef6f5dadcf14b79e6ac461cf0092375a49627bc"
+          },
+          {
+            "tcId": 158,
+            "mac": "25c86c5f8b02a2ef1807139e308aa5eef8dd3e80c7bb51bbf53a2133c41fdbe6"
+          },
+          {
+            "tcId": 159,
+            "mac": "b38e2cc408eade5e8053e19701b4b87c739cfc4c78445c26c7d40056b798510f"
+          },
+          {
+            "tcId": 160,
+            "mac": "f05611087cd5108d2a3b9f8d0f3e265dba6498cc287ce74a6e02529b7d07c137"
+          },
+          {
+            "tcId": 161,
+            "mac": "446c62d50174ecf4975784f570e7c92133de8159c484be65fd0ec61e3edd7ca9"
+          },
+          {
+            "tcId": 162,
+            "mac": "e3ef46382e15647aef1cb3a2686978081759d581d95ff4bc1b6028caad2e03cd"
+          },
+          {
+            "tcId": 163,
+            "mac": "b7789d8e3bb3693e380e98bd0fada4e263dd6c1eb29b0ac4c528899a14a37722"
+          },
+          {
+            "tcId": 164,
+            "mac": "bd0b9b59f02cfae552ceaf1d5185324919c225e116b8594474e9cfc5d50ca5be"
+          },
+          {
+            "tcId": 165,
+            "mac": "7bb615d746e582346823e61abca0631f19d69f65546df24de025e69d02bdabdd"
+          },
+          {
+            "tcId": 166,
+            "mac": "74e25fe1b157283ac0c4ff033813360c3bdfbf51418e4879da0969787f330bf4"
+          },
+          {
+            "tcId": 167,
+            "mac": "f142b3405a5940987aecfe20675b6070f6847e90d94bfe2f42166f41dc94ccba"
+          },
+          {
+            "tcId": 168,
+            "mac": "16c974688ac454141400ab837a9fa401853bacc6e0397afda3ca4a2eb17f3e4a"
+          },
+          {
+            "tcId": 169,
+            "mac": "ff5b71cd7fa45cf8ff44ab93c114f980cfa01a43343201d9ead4d5155678b9ff"
+          },
+          {
+            "tcId": 170,
+            "mac": "7c3bda31d88733f6ad514be4331fc970ebc23d0398e93cdcf65daa627022bd59"
+          },
+          {
+            "tcId": 171,
+            "mac": "d97320dfaec3ff1e0201622e3a4c1d540fad884037eee2b33e5554d4d6f8abeb"
+          },
+          {
+            "tcId": 172,
+            "mac": "902dde4aa0b578a0694014f6fc040147c5b4de75f491ce3ab347932f9aa23135"
+          },
+          {
+            "tcId": 173,
+            "mac": "c925afd02cf947564ab99ff46abf35e095319c86e610eb81ea0853012d32ea3c"
+          },
+          {
+            "tcId": 174,
+            "mac": "f46e027a1388819bc104bf17b587d98067901115c2b28e92a5a4b2c7fcf7da3f"
+          },
+          {
+            "tcId": 175,
+            "mac": "d1e084ba124ab64c3a41357b0fe5b48a59897727fce0c55f70cc8dce667f0d18"
+          },
+          {
+            "tcId": 176,
+            "mac": "f2d88adca664be39a6769c9f172b2535a50f1b4a589af205aad72b90bc222c47"
+          },
+          {
+            "tcId": 177,
+            "mac": "c1ecfb42fb6bed7f38c02662fdb9d7d931881ec8c60e2bfdb9164c77588e7dcf"
+          },
+          {
+            "tcId": 178,
+            "mac": "82f35b0f84e315a33ce45d4b9d775ffb3c05da20008ca7df12ab9fb4cb58c8b4"
+          },
+          {
+            "tcId": 179,
+            "mac": "4bbbb0f3d4bf7151b618f46541eacbd5a428e8a57c4bc396cff1cb93c3493ccf"
+          },
+          {
+            "tcId": 180,
+            "mac": "620b31755475117f90a978c6d6172cd450ee88d2c9e0dcf1ee0c5101b9901e1d"
+          },
+          {
+            "tcId": 181,
+            "mac": "fac90e0ccbde2cfac001185c5fd25d55043ef5cdeb1f01c1db4c4a07d51eca81"
+          },
+          {
+            "tcId": 182,
+            "mac": "427322b47dc55d8ba0ffa67d4e62946883eab0fb2f71f536e867a4c029f3ae15"
+          },
+          {
+            "tcId": 183,
+            "mac": "af3d79aa65f3405fdbe125a81d634a68f483f1ea8b48362bee01f94f8b4e9273"
+          },
+          {
+            "tcId": 184,
+            "mac": "09877c7f19fe4e88cc38fbeedbd1671e34441bb0d75c230a07d224ebf5c4b707"
+          },
+          {
+            "tcId": 185,
+            "mac": "ad0ae0561cc0702ab4171ef1cf84193ab2b8c959a320a3cbedd4d14fe70da2e6"
+          },
+          {
+            "tcId": 186,
+            "mac": "2b209b83a2e1afe6b78d04a93016ccf7741ca59612e74ac86ed652d4604e437d"
+          },
+          {
+            "tcId": 187,
+            "mac": "a7e41b07ac6a74459bca61976670a816e0d8abe8dddac6886b40182843e0bcdf"
+          },
+          {
+            "tcId": 188,
+            "mac": "e746ef5fa71ac61e52850186d342e8fff9770cb49f963e52d2c7daf443badaa9"
+          },
+          {
+            "tcId": 189,
+            "mac": "1c7c8a772422b2727cba70dd8a91d8b35b58a1bd94805e10b771408c6071c6fc"
+          },
+          {
+            "tcId": 190,
+            "mac": "79418062a77986da90c18a317cdabf6b6c8277a1192880c4f1f2ebb8fe6a7206"
+          },
+          {
+            "tcId": 191,
+            "mac": "ba272e4d1f82f7ef1e93876574031ef48f74e411409e55a7f06ccfdc68bb3184"
+          },
+          {
+            "tcId": 192,
+            "mac": "a0b3dbbc1264c69a7b92c65ae976d81a636e85a7d88cf1f2f23dd4dd58bfa526"
+          },
+          {
+            "tcId": 193,
+            "mac": "a4106d467f875839bc66570d2b4d10127197106e78ec56e353f09f3b123d60c0"
+          },
+          {
+            "tcId": 194,
+            "mac": "79c4c00468b7107f3d12a6c20630c325742e9d6213e39f8ab33793e4a37ff521"
+          },
+          {
+            "tcId": 195,
+            "mac": "cde19b24c78a8def7faab7a5c9a560ce3013af41d29f86f4855ad7c1a23f2de5"
+          },
+          {
+            "tcId": 196,
+            "mac": "86e420862bbcbfcafe3478b2ee81f34c4f15c40e334cf52ecc19305c358a1a55"
+          },
+          {
+            "tcId": 197,
+            "mac": "afb83485927d195064eb656a49c3fd16c41faff6c000cb7a8d09c82fa6b7b902"
+          },
+          {
+            "tcId": 198,
+            "mac": "64bcf4701d3d0240a892f11d9d82aa63b343b18d3e7701847caa3c01965b287d"
+          },
+          {
+            "tcId": 199,
+            "mac": "8a701bb908f3322acf20cf2e94f75bec78b82902afc1997ff4edb7fbc592b3cc"
+          },
+          {
+            "tcId": 200,
+            "mac": "521dcf003e4df1ab92d70eff360f209a79a801cc484cab8bb27cd7cd2ca7593b"
+          },
+          {
+            "tcId": 201,
+            "mac": "213d7a1644f0c6cd60a725f6dbe6996be4bebbbe8cf0f4d352f5aac327f89484"
+          },
+          {
+            "tcId": 202,
+            "mac": "29d7bc0430ab922b7a7ba2aab8402afadc98242968a3ca1e57bf42c5b315b00e"
+          },
+          {
+            "tcId": 203,
+            "mac": "870e760856ceed9ce78a7c978e2daf595a472f1bf81b628f28542b50c92cca59"
+          },
+          {
+            "tcId": 204,
+            "mac": "84737fd2cd23784133077a70550222e2ab99795c8e143c8739bfadea4b500c74"
+          },
+          {
+            "tcId": 205,
+            "mac": "d02fda5d822a1fbbf963720a4c3f46349cc65d138a633863a809104d353de7cf"
+          },
+          {
+            "tcId": 206,
+            "mac": "0f3473b9029b22e9d6311be72e4b86dab1cb8d02325f0d798f5119d05741ec8d"
+          },
+          {
+            "tcId": 207,
+            "mac": "87bec91d48c1e5c40cf8d44e026b296bb74aff8c46a8230c327f97c8ee6a3ac5"
+          },
+          {
+            "tcId": 208,
+            "mac": "26b51a71f1c9b07ea7d60a925d52060a3e7f0170f3816aed35604ce3857c5d10"
+          },
+          {
+            "tcId": 209,
+            "mac": "6a35d2becb38830748d56fd060b246898cd84ac13830f6c6e163f9cb83d3292b"
+          },
+          {
+            "tcId": 210,
+            "mac": "ee600f6b41d4b96dd8f4ec7317b11e625a5482edce1d2b211d37f78c3f3fe030"
+          },
+          {
+            "tcId": 211,
+            "mac": "5da71333369aa09fcdc9244fe7f6b960d7ab2842a78cd84c5b31cb83340e29d0"
+          },
+          {
+            "tcId": 212,
+            "mac": "5985522e9774a7a9209d4c7bd3be36f635ffed3259633842db105c5f0bace908"
+          },
+          {
+            "tcId": 213,
+            "mac": "306556908f43aaa520f3f01e458f4d211f8e42c81029c59a62ee28f19665cdeb"
+          },
+          {
+            "tcId": 214,
+            "mac": "217a88c27e8917bca774000866a140f2a3d8cb61b6a10a05332331a0290f07dd"
+          },
+          {
+            "tcId": 215,
+            "mac": "3455de220f59df2a6b47ec92c447ca77ace6b5950eae4feba8ae25186e40558c"
+          },
+          {
+            "tcId": 216,
+            "mac": "965f4c7b6b119b29c65a7043edb3d8eb6b7a80a9c808639d12a22af8592c525e"
+          },
+          {
+            "tcId": 217,
+            "mac": "9076d5fb241393049d9f44fdedbadb672b4cc70177f27de28946d052b34acdc4"
+          },
+          {
+            "tcId": 218,
+            "mac": "bff611b802b7afdee9a46374200ed3800ea5ce82426861d31caa7179c982cdb2"
+          },
+          {
+            "tcId": 219,
+            "mac": "db94691340e6dd73f51f06003f3e82c830085980fb7d33c45c5eadc689a4a4a8"
+          },
+          {
+            "tcId": 220,
+            "mac": "6a8c6ac194a3e0289ec9e8e238c1cf874073acf7a8fc7492a25ae1a4d983fbbd"
+          },
+          {
+            "tcId": 221,
+            "mac": "99d32d29cb36c27ae5272a7def14feebd1fa00b0f0bed622cb81881ef570feea"
+          },
+          {
+            "tcId": 222,
+            "mac": "9ecd9462698c16fc754ecf36264479605f02d90093ba8c08db41e0cacc77f41a"
+          },
+          {
+            "tcId": 223,
+            "mac": "ee6ba048337bde252f1573d053707865dc537015afa5849ca6ee0971523f504a"
+          },
+          {
+            "tcId": 224,
+            "mac": "bd8af34ae4506a793ae765cc6514d43dedbbf0035853cdea4ac12a97f1f2d369"
+          },
+          {
+            "tcId": 225,
+            "mac": "b4c1e1bde638fd054bdf3b6b75de48e12064505186860077113af3f483dd95de"
+          }
+        ]
+      },
+      {
+        "tgId": 4,
+        "tests": [
+          {
+            "tcId": 226,
+            "mac": "289ece45b9"
+          },
+          {
+            "tcId": 227,
+            "mac": "960a753392"
+          },
+          {
+            "tcId": 228,
+            "mac": "8f331290e6"
+          },
+          {
+            "tcId": 229,
+            "mac": "ad0e9a273e"
+          },
+          {
+            "tcId": 230,
+            "mac": "456cebcb71"
+          },
+          {
+            "tcId": 231,
+            "mac": "cf48dab37b"
+          },
+          {
+            "tcId": 232,
+            "mac": "cdff0be04d"
+          },
+          {
+            "tcId": 233,
+            "mac": "72639c86fc"
+          },
+          {
+            "tcId": 234,
+            "mac": "07363953f4"
+          },
+          {
+            "tcId": 235,
+            "mac": "9f19e5dd89"
+          },
+          {
+            "tcId": 236,
+            "mac": "a70220bf60"
+          },
+          {
+            "tcId": 237,
+            "mac": "39fa5ec17c"
+          },
+          {
+            "tcId": 238,
+            "mac": "35535fde93"
+          },
+          {
+            "tcId": 239,
+            "mac": "aa1610ec47"
+          },
+          {
+            "tcId": 240,
+            "mac": "15c14d90eb"
+          },
+          {
+            "tcId": 241,
+            "mac": "3e5a935895"
+          },
+          {
+            "tcId": 242,
+            "mac": "242ea70fbb"
+          },
+          {
+            "tcId": 243,
+            "mac": "3386dff1eb"
+          },
+          {
+            "tcId": 244,
+            "mac": "378fe938be"
+          },
+          {
+            "tcId": 245,
+            "mac": "7451a69902"
+          },
+          {
+            "tcId": 246,
+            "mac": "fbad9a73fd"
+          },
+          {
+            "tcId": 247,
+            "mac": "8afbb6d77f"
+          },
+          {
+            "tcId": 248,
+            "mac": "ac64d83ce5"
+          },
+          {
+            "tcId": 249,
+            "mac": "27da7662c6"
+          },
+          {
+            "tcId": 250,
+            "mac": "f1b1981732"
+          },
+          {
+            "tcId": 251,
+            "mac": "3d1540a141"
+          },
+          {
+            "tcId": 252,
+            "mac": "b0a5dd8c72"
+          },
+          {
+            "tcId": 253,
+            "mac": "7b5ffdab85"
+          },
+          {
+            "tcId": 254,
+            "mac": "723c6743fc"
+          },
+          {
+            "tcId": 255,
+            "mac": "8fe72b4dce"
+          },
+          {
+            "tcId": 256,
+            "mac": "13f4acd6b5"
+          },
+          {
+            "tcId": 257,
+            "mac": "89ad4a0c4e"
+          },
+          {
+            "tcId": 258,
+            "mac": "93e87ba5b9"
+          },
+          {
+            "tcId": 259,
+            "mac": "0e15c5c316"
+          },
+          {
+            "tcId": 260,
+            "mac": "6014c0bf12"
+          },
+          {
+            "tcId": 261,
+            "mac": "1f5cad7a76"
+          },
+          {
+            "tcId": 262,
+            "mac": "7eb45bd5f5"
+          },
+          {
+            "tcId": 263,
+            "mac": "5ca044345c"
+          },
+          {
+            "tcId": 264,
+            "mac": "d232fed6a8"
+          },
+          {
+            "tcId": 265,
+            "mac": "decf46874c"
+          },
+          {
+            "tcId": 266,
+            "mac": "fa4010bfb3"
+          },
+          {
+            "tcId": 267,
+            "mac": "a592e26c2f"
+          },
+          {
+            "tcId": 268,
+            "mac": "3641ced09d"
+          },
+          {
+            "tcId": 269,
+            "mac": "8c46631d26"
+          },
+          {
+            "tcId": 270,
+            "mac": "700c5f737e"
+          },
+          {
+            "tcId": 271,
+            "mac": "6d864885c0"
+          },
+          {
+            "tcId": 272,
+            "mac": "6aa986285d"
+          },
+          {
+            "tcId": 273,
+            "mac": "328df77a79"
+          },
+          {
+            "tcId": 274,
+            "mac": "e952b309a8"
+          },
+          {
+            "tcId": 275,
+            "mac": "23df41594a"
+          },
+          {
+            "tcId": 276,
+            "mac": "86ceb4642e"
+          },
+          {
+            "tcId": 277,
+            "mac": "0cf7a12cfb"
+          },
+          {
+            "tcId": 278,
+            "mac": "c854eea5d9"
+          },
+          {
+            "tcId": 279,
+            "mac": "fb7e1559c9"
+          },
+          {
+            "tcId": 280,
+            "mac": "744ac51067"
+          },
+          {
+            "tcId": 281,
+            "mac": "309316d1a2"
+          },
+          {
+            "tcId": 282,
+            "mac": "464b540fa5"
+          },
+          {
+            "tcId": 283,
+            "mac": "535fe6de20"
+          },
+          {
+            "tcId": 284,
+            "mac": "0c96312652"
+          },
+          {
+            "tcId": 285,
+            "mac": "0eefb4c38c"
+          },
+          {
+            "tcId": 286,
+            "mac": "0fc12d74b4"
+          },
+          {
+            "tcId": 287,
+            "mac": "a6874ac026"
+          },
+          {
+            "tcId": 288,
+            "mac": "8630b248ef"
+          },
+          {
+            "tcId": 289,
+            "mac": "6b0ab26900"
+          },
+          {
+            "tcId": 290,
+            "mac": "d9307661ee"
+          },
+          {
+            "tcId": 291,
+            "mac": "83cfa954b6"
+          },
+          {
+            "tcId": 292,
+            "mac": "9df1ea3447"
+          },
+          {
+            "tcId": 293,
+            "mac": "a82f9b0735"
+          },
+          {
+            "tcId": 294,
+            "mac": "761ad1543f"
+          },
+          {
+            "tcId": 295,
+            "mac": "4dca011ccd"
+          },
+          {
+            "tcId": 296,
+            "mac": "98d9c20502"
+          },
+          {
+            "tcId": 297,
+            "mac": "581af1f68b"
+          },
+          {
+            "tcId": 298,
+            "mac": "4792bde50e"
+          },
+          {
+            "tcId": 299,
+            "mac": "232535ad39"
+          },
+          {
+            "tcId": 300,
+            "mac": "0a7f61bd14"
+          }
+        ]
+      },
+      {
+        "tgId": 5,
+        "tests": [
+          {
+            "tcId": 301,
+            "mac": "d8a765e839"
+          },
+          {
+            "tcId": 302,
+            "mac": "59723fcc93"
+          },
+          {
+            "tcId": 303,
+            "mac": "3c1e47ced4"
+          },
+          {
+            "tcId": 304,
+            "mac": "d5b100eb88"
+          },
+          {
+            "tcId": 305,
+            "mac": "3f3388aad3"
+          },
+          {
+            "tcId": 306,
+            "mac": "663a5fad32"
+          },
+          {
+            "tcId": 307,
+            "mac": "92723ed8b7"
+          },
+          {
+            "tcId": 308,
+            "mac": "7d198aeff4"
+          },
+          {
+            "tcId": 309,
+            "mac": "0fea0a7924"
+          },
+          {
+            "tcId": 310,
+            "mac": "96cbf7d412"
+          },
+          {
+            "tcId": 311,
+            "mac": "b31094c1fa"
+          },
+          {
+            "tcId": 312,
+            "mac": "374837a279"
+          },
+          {
+            "tcId": 313,
+            "mac": "908f0dbff0"
+          },
+          {
+            "tcId": 314,
+            "mac": "0e87d2df46"
+          },
+          {
+            "tcId": 315,
+            "mac": "b670b9ba8d"
+          },
+          {
+            "tcId": 316,
+            "mac": "7f56e3a233"
+          },
+          {
+            "tcId": 317,
+            "mac": "548916e90d"
+          },
+          {
+            "tcId": 318,
+            "mac": "f773a8bb7a"
+          },
+          {
+            "tcId": 319,
+            "mac": "91fa5d3c65"
+          },
+          {
+            "tcId": 320,
+            "mac": "ad4d62e8c7"
+          },
+          {
+            "tcId": 321,
+            "mac": "ff54b4dce4"
+          },
+          {
+            "tcId": 322,
+            "mac": "c15dc322f9"
+          },
+          {
+            "tcId": 323,
+            "mac": "a7516681a6"
+          },
+          {
+            "tcId": 324,
+            "mac": "315a1ff810"
+          },
+          {
+            "tcId": 325,
+            "mac": "d64c09a477"
+          },
+          {
+            "tcId": 326,
+            "mac": "068ec30ac1"
+          },
+          {
+            "tcId": 327,
+            "mac": "52a9098ce3"
+          },
+          {
+            "tcId": 328,
+            "mac": "92db616f10"
+          },
+          {
+            "tcId": 329,
+            "mac": "2cefd504c0"
+          },
+          {
+            "tcId": 330,
+            "mac": "b263ad5221"
+          },
+          {
+            "tcId": 331,
+            "mac": "f91cc433fc"
+          },
+          {
+            "tcId": 332,
+            "mac": "b90d091240"
+          },
+          {
+            "tcId": 333,
+            "mac": "0c305d0abe"
+          },
+          {
+            "tcId": 334,
+            "mac": "3215cea690"
+          },
+          {
+            "tcId": 335,
+            "mac": "6c2e8c9259"
+          },
+          {
+            "tcId": 336,
+            "mac": "6a10144164"
+          },
+          {
+            "tcId": 337,
+            "mac": "0e91151b4a"
+          },
+          {
+            "tcId": 338,
+            "mac": "bd3517957e"
+          },
+          {
+            "tcId": 339,
+            "mac": "ac368a8f7b"
+          },
+          {
+            "tcId": 340,
+            "mac": "4341aae746"
+          },
+          {
+            "tcId": 341,
+            "mac": "d79292d952"
+          },
+          {
+            "tcId": 342,
+            "mac": "305f326a69"
+          },
+          {
+            "tcId": 343,
+            "mac": "d55ea54bb3"
+          },
+          {
+            "tcId": 344,
+            "mac": "5b69368f01"
+          },
+          {
+            "tcId": 345,
+            "mac": "973b84ca4b"
+          },
+          {
+            "tcId": 346,
+            "mac": "1428d138e1"
+          },
+          {
+            "tcId": 347,
+            "mac": "da2a5ea07d"
+          },
+          {
+            "tcId": 348,
+            "mac": "09832cced1"
+          },
+          {
+            "tcId": 349,
+            "mac": "5a143411d1"
+          },
+          {
+            "tcId": 350,
+            "mac": "18de48a288"
+          },
+          {
+            "tcId": 351,
+            "mac": "ed8a5af6cf"
+          },
+          {
+            "tcId": 352,
+            "mac": "00809717cb"
+          },
+          {
+            "tcId": 353,
+            "mac": "0597e86d0e"
+          },
+          {
+            "tcId": 354,
+            "mac": "66055ac9ad"
+          },
+          {
+            "tcId": 355,
+            "mac": "7677429476"
+          },
+          {
+            "tcId": 356,
+            "mac": "530108923f"
+          },
+          {
+            "tcId": 357,
+            "mac": "5ea7b5e93f"
+          },
+          {
+            "tcId": 358,
+            "mac": "8ef4342dfa"
+          },
+          {
+            "tcId": 359,
+            "mac": "6635c0c5e2"
+          },
+          {
+            "tcId": 360,
+            "mac": "94423c4037"
+          },
+          {
+            "tcId": 361,
+            "mac": "9e497416ca"
+          },
+          {
+            "tcId": 362,
+            "mac": "ac403d9a3e"
+          },
+          {
+            "tcId": 363,
+            "mac": "f437796154"
+          },
+          {
+            "tcId": 364,
+            "mac": "1fed1499fe"
+          },
+          {
+            "tcId": 365,
+            "mac": "d4d99b38b7"
+          },
+          {
+            "tcId": 366,
+            "mac": "e7a139a0ac"
+          },
+          {
+            "tcId": 367,
+            "mac": "cf0892bb42"
+          },
+          {
+            "tcId": 368,
+            "mac": "a8b3d42523"
+          },
+          {
+            "tcId": 369,
+            "mac": "22cc36e9d7"
+          },
+          {
+            "tcId": 370,
+            "mac": "fcb9b115b8"
+          },
+          {
+            "tcId": 371,
+            "mac": "03045e6c39"
+          },
+          {
+            "tcId": 372,
+            "mac": "52197ed9a3"
+          },
+          {
+            "tcId": 373,
+            "mac": "5490b4e520"
+          },
+          {
+            "tcId": 374,
+            "mac": "224127960b"
+          },
+          {
+            "tcId": 375,
+            "mac": "9ee2a9af1a"
+          }
+        ]
+      },
+      {
+        "tgId": 6,
+        "tests": [
+          {
+            "tcId": 376,
+            "mac": "75db8d8d9e4d"
+          },
+          {
+            "tcId": 377,
+            "mac": "a71087ec19c7"
+          },
+          {
+            "tcId": 378,
+            "mac": "47fcada764c9"
+          },
+          {
+            "tcId": 379,
+            "mac": "a51776a9eb08"
+          },
+          {
+            "tcId": 380,
+            "mac": "7eee6435f4a6"
+          },
+          {
+            "tcId": 381,
+            "mac": "7d32ddeb8b84"
+          },
+          {
+            "tcId": 382,
+            "mac": "34a950f83549"
+          },
+          {
+            "tcId": 383,
+            "mac": "dc9e8309e83a"
+          },
+          {
+            "tcId": 384,
+            "mac": "557a918c7e70"
+          },
+          {
+            "tcId": 385,
+            "mac": "aa9c57cc9b20"
+          },
+          {
+            "tcId": 386,
+            "mac": "010856abf544"
+          },
+          {
+            "tcId": 387,
+            "mac": "5e12a6c3ce53"
+          },
+          {
+            "tcId": 388,
+            "mac": "0dd553697cd7"
+          },
+          {
+            "tcId": 389,
+            "mac": "8e0f1d5dbf5f"
+          },
+          {
+            "tcId": 390,
+            "mac": "db82b0bd6f0c"
+          },
+          {
+            "tcId": 391,
+            "mac": "1461ddd26a0b"
+          },
+          {
+            "tcId": 392,
+            "mac": "ff94deee6cdb"
+          },
+          {
+            "tcId": 393,
+            "mac": "6d647e2f2ba8"
+          },
+          {
+            "tcId": 394,
+            "mac": "c1842b10f3f3"
+          },
+          {
+            "tcId": 395,
+            "mac": "d6f61d46d094"
+          },
+          {
+            "tcId": 396,
+            "mac": "1632a5b54d33"
+          },
+          {
+            "tcId": 397,
+            "mac": "03b7d6e38895"
+          },
+          {
+            "tcId": 398,
+            "mac": "40af95d53bd6"
+          },
+          {
+            "tcId": 399,
+            "mac": "6925dfea7939"
+          },
+          {
+            "tcId": 400,
+            "mac": "9264cd215f0d"
+          },
+          {
+            "tcId": 401,
+            "mac": "28f5e67eda20"
+          },
+          {
+            "tcId": 402,
+            "mac": "37a7fd8309bb"
+          },
+          {
+            "tcId": 403,
+            "mac": "820cc645a84c"
+          },
+          {
+            "tcId": 404,
+            "mac": "c19a8b90a833"
+          },
+          {
+            "tcId": 405,
+            "mac": "583a89ca166c"
+          },
+          {
+            "tcId": 406,
+            "mac": "ed20736e0393"
+          },
+          {
+            "tcId": 407,
+            "mac": "110d6e201a58"
+          },
+          {
+            "tcId": 408,
+            "mac": "af23201cad7c"
+          },
+          {
+            "tcId": 409,
+            "mac": "92f7feb07958"
+          },
+          {
+            "tcId": 410,
+            "mac": "30a9f37688a6"
+          },
+          {
+            "tcId": 411,
+            "mac": "fb612db49ce1"
+          },
+          {
+            "tcId": 412,
+            "mac": "f3f263125e8f"
+          },
+          {
+            "tcId": 413,
+            "mac": "ae1fb64d4384"
+          },
+          {
+            "tcId": 414,
+            "mac": "4796094c10cd"
+          },
+          {
+            "tcId": 415,
+            "mac": "10bd9a910f80"
+          },
+          {
+            "tcId": 416,
+            "mac": "e5583da22142"
+          },
+          {
+            "tcId": 417,
+            "mac": "b497f5213a18"
+          },
+          {
+            "tcId": 418,
+            "mac": "b1c3b5fd8c1a"
+          },
+          {
+            "tcId": 419,
+            "mac": "c36bc37611b3"
+          },
+          {
+            "tcId": 420,
+            "mac": "c64314798ecc"
+          },
+          {
+            "tcId": 421,
+            "mac": "781a96797490"
+          },
+          {
+            "tcId": 422,
+            "mac": "200f12f6dabb"
+          },
+          {
+            "tcId": 423,
+            "mac": "02af1422879f"
+          },
+          {
+            "tcId": 424,
+            "mac": "d468fec5ebe8"
+          },
+          {
+            "tcId": 425,
+            "mac": "a17ed17f1189"
+          },
+          {
+            "tcId": 426,
+            "mac": "afb0c70e6112"
+          },
+          {
+            "tcId": 427,
+            "mac": "7a7a11a07cf1"
+          },
+          {
+            "tcId": 428,
+            "mac": "08345f038063"
+          },
+          {
+            "tcId": 429,
+            "mac": "d7f7893385de"
+          },
+          {
+            "tcId": 430,
+            "mac": "dd691e60b24b"
+          },
+          {
+            "tcId": 431,
+            "mac": "3ecac316de4f"
+          },
+          {
+            "tcId": 432,
+            "mac": "e17036b5a7ec"
+          },
+          {
+            "tcId": 433,
+            "mac": "f815d886fcfc"
+          },
+          {
+            "tcId": 434,
+            "mac": "538c7b58ad92"
+          },
+          {
+            "tcId": 435,
+            "mac": "5763e559d615"
+          },
+          {
+            "tcId": 436,
+            "mac": "5d0763c6f241"
+          },
+          {
+            "tcId": 437,
+            "mac": "31e44cc34348"
+          },
+          {
+            "tcId": 438,
+            "mac": "63a67a8f18f9"
+          },
+          {
+            "tcId": 439,
+            "mac": "c1070f1e2896"
+          },
+          {
+            "tcId": 440,
+            "mac": "ec85db51273a"
+          },
+          {
+            "tcId": 441,
+            "mac": "848e58c2482b"
+          },
+          {
+            "tcId": 442,
+            "mac": "776a667bc7cc"
+          },
+          {
+            "tcId": 443,
+            "mac": "3569f691a8fe"
+          },
+          {
+            "tcId": 444,
+            "mac": "dca3e0e471a9"
+          },
+          {
+            "tcId": 445,
+            "mac": "64633ce68953"
+          },
+          {
+            "tcId": 446,
+            "mac": "59f6b54f53c6"
+          },
+          {
+            "tcId": 447,
+            "mac": "bd9f56688f75"
+          },
+          {
+            "tcId": 448,
+            "mac": "6425880f6b1e"
+          },
+          {
+            "tcId": 449,
+            "mac": "7fe75bd6b7a7"
+          },
+          {
+            "tcId": 450,
+            "mac": "fa0607715455"
+          }
+        ]
+      },
+      {
+        "tgId": 7,
+        "tests": [
+          {
+            "tcId": 451,
+            "mac": "46f2d63c03b4d788b75fdd7225b886bc6ec8e58d216af865c2da5f09d998be1f"
+          },
+          {
+            "tcId": 452,
+            "mac": "d16bac81c380f3a132cedefc37028209c99f4ed5a81ece4bdd3938f38205fbb3"
+          },
+          {
+            "tcId": 453,
+            "mac": "456d1f1735d9effe71157819aa018b6a0dcd4eee26680726ebab9d8ec4c82164"
+          },
+          {
+            "tcId": 454,
+            "mac": "89a0f3ad36a9c3a98be8c158eaa9e8ac354cdeb5d9ceeed2d34ec9d1d0f3b57b"
+          },
+          {
+            "tcId": 455,
+            "mac": "3bef62dbc02d4b30904dd14d521cc8bd00642b80553fe3eadc3ec3991edc145c"
+          },
+          {
+            "tcId": 456,
+            "mac": "8f1a32ea7fe2462fd7aac41adedb18f7493e9bfaf30aba24a2c7515a2c521dd2"
+          },
+          {
+            "tcId": 457,
+            "mac": "b158c02b321b85658c121c754487aab28954aa09eb497308ca46bdab677728e2"
+          },
+          {
+            "tcId": 458,
+            "mac": "09f7684fcbfe6e6d9cc139a42312fb12e6e6676f7adca53147e5588a66b0ba8f"
+          },
+          {
+            "tcId": 459,
+            "mac": "04d6ad883b0118f5951b5a9261f872f66cbaba5b89fcdd352b3cd84a7bcafba6"
+          },
+          {
+            "tcId": 460,
+            "mac": "62b1c4f063770ce6a78a58b75c1443b109902797f6cf3805cc1f8c7657a60eda"
+          },
+          {
+            "tcId": 461,
+            "mac": "4e6d494941e6f7e154f1309194a4951ec74db8ae25922eea3a09f901f9971491"
+          },
+          {
+            "tcId": 462,
+            "mac": "57837e0fbdd5dcd8bb7e461fc125ec0ed41c8b43de3c59877d8910b6fb3218db"
+          },
+          {
+            "tcId": 463,
+            "mac": "8f34f43a9d69cb594c286b1ff5790a35c2986cc8a6c8a15685ccf6db4c2d2692"
+          },
+          {
+            "tcId": 464,
+            "mac": "60ba70911f60b946b1a34ea1e3a29904d0a47d3bc0581781dc83bfbe8e01e41b"
+          },
+          {
+            "tcId": 465,
+            "mac": "a3a49543799e81c7f392ddc644aae5371fed9dc10b4a8c106b8ec0f326d56b83"
+          },
+          {
+            "tcId": 466,
+            "mac": "05a64fbdc42c94ab15b5c2043bbedaca81528398f9307daaa68ac3adcccc4dec"
+          },
+          {
+            "tcId": 467,
+            "mac": "7f4d0830104b83308df85f304fab28824f49863f8ed57044db7713bc2ba96e9e"
+          },
+          {
+            "tcId": 468,
+            "mac": "5429700ffd03bdeeb4d48cab0dd90282a26e1c0189372febb0a2c3c9cc3a5314"
+          },
+          {
+            "tcId": 469,
+            "mac": "c79c300c4d3aff400f85a28aa620c91b322cf9fe90c5ac0eb1594ec92773e5c9"
+          },
+          {
+            "tcId": 470,
+            "mac": "75c39d6a5e5b0b73a74508c444e2780fe0baa3001b349b5629e9d332f1dbded0"
+          },
+          {
+            "tcId": 471,
+            "mac": "86e4e88f1ed627b8313bf8060d7003f1e56c6ff7d957232cbeef5225a41000df"
+          },
+          {
+            "tcId": 472,
+            "mac": "7f61f8b304ac6f56981be44de061bb44a0bee1e4aecdaba1e28142da861ea08a"
+          },
+          {
+            "tcId": 473,
+            "mac": "7f1f6674160b21d5fec3f5dd09f90bfc3de7ae366ebb38cd2867c557af58bb72"
+          },
+          {
+            "tcId": 474,
+            "mac": "589840684e710f7501dab8ecf0f81a2f35fbebdef62b3cea9f1bed82042ab383"
+          },
+          {
+            "tcId": 475,
+            "mac": "375fa3173570b307b494e518da1d6c97a7f02b1c65f17d721da47a786bc9039a"
+          },
+          {
+            "tcId": 476,
+            "mac": "76313acf11c64e8b1bc20db5ebeb1b1e9e43c840ed0b0a0ee7840a6b86382b1b"
+          },
+          {
+            "tcId": 477,
+            "mac": "38340e7d19ff0d14c8923a402dfa8ab0bdb68a005406cb5b819b3f81e423c1f5"
+          },
+          {
+            "tcId": 478,
+            "mac": "649933d540161de22287842ff1470a84176a48e30b0eb4416a5eceb2c74f7128"
+          },
+          {
+            "tcId": 479,
+            "mac": "2234c544d9fd7daf4f97be613d0f53dd22f7c047d8e56a34d788e14f832a71a6"
+          },
+          {
+            "tcId": 480,
+            "mac": "6d9746d199a7901b7ea38b9c86269158befd1077b958863cc8ef7d0c43b91752"
+          },
+          {
+            "tcId": 481,
+            "mac": "40506764f9190ebb642d7870aa905c906cf63da4d98e5e3329b8860aef89cd4c"
+          },
+          {
+            "tcId": 482,
+            "mac": "82b6f04cd1e671f24b14a9582bc388b0cef3beebe710a2069d81191f43e0665b"
+          },
+          {
+            "tcId": 483,
+            "mac": "fa28f9ee877ce14d7be26039cf3f2413c65f57a23062f793270d841ebfe5ba95"
+          },
+          {
+            "tcId": 484,
+            "mac": "76919dab8034aa67087ead5568f0fd161b5cd21288f87922e4c61a3a2a2cb96e"
+          },
+          {
+            "tcId": 485,
+            "mac": "50f06f3c23ff4bcd45ea157bd4e467a53e44d9abf1a3e23fa94b358f62292bb8"
+          },
+          {
+            "tcId": 486,
+            "mac": "95f40a9fe1d53b3a77a93d71402fb6cf45160ae431bb1d14fd9cff10b211cbc6"
+          },
+          {
+            "tcId": 487,
+            "mac": "ae63d40029e545ae971c08bd8a864258b05f15771f9f7db8eb4871235b7ebf2a"
+          },
+          {
+            "tcId": 488,
+            "mac": "b9b1e9793859323585877c10e14543d3ad408946ed2a4bc69b43a9dd0d953829"
+          },
+          {
+            "tcId": 489,
+            "mac": "3c43fa23965bfed78b2993218a77546a9bd85bdc72f38e6f172734286d7c36c5"
+          },
+          {
+            "tcId": 490,
+            "mac": "e055ee43f91448e5fd228fbe1bf53ec8a689718d225d87c62d099c00ba4568ee"
+          },
+          {
+            "tcId": 491,
+            "mac": "f5bed253b2414eeed3ac86ed06124d0c93fa3baefb25ebb5cdf1275c39c6f52a"
+          },
+          {
+            "tcId": 492,
+            "mac": "502382a4248e58474c62a2c681f2a255d98d9219e9e968c57d0f8e890740dd7f"
+          },
+          {
+            "tcId": 493,
+            "mac": "7fab86e9977ef67d35c364e566a536923a8fe2032714864d97d2ce1eaf8c7f3e"
+          },
+          {
+            "tcId": 494,
+            "mac": "b39b7c3510a93e250a6614978e33decfa86d854ce0b783e5e3bdd5bb4219f7a2"
+          },
+          {
+            "tcId": 495,
+            "mac": "daf4d90c1858831b9ffb842eca6e528acf176b82bb9f2b7cbdebb070d5c38fe1"
+          },
+          {
+            "tcId": 496,
+            "mac": "c03f8d94cc402c092171238650ebac66b8a7d9352893a240d3388bcd36c9da47"
+          },
+          {
+            "tcId": 497,
+            "mac": "a77dc97196f1430f5f1d516cbbcd6d6c6ba2605fcc487fbc73eb4057ccd54b02"
+          },
+          {
+            "tcId": 498,
+            "mac": "bb7232e9b30ac27f5d7a0558395db39c9a8d64945b0cedd2fb38ad7fc6e55cf6"
+          },
+          {
+            "tcId": 499,
+            "mac": "a258840a251b130190643b2f79c36ee0dc9f134db4d54822c89f399e9b1dbae5"
+          },
+          {
+            "tcId": 500,
+            "mac": "dff9091fd6726e7dc47d8c84421b1df54c1615633783e28b3f2fc3a6049d795b"
+          },
+          {
+            "tcId": 501,
+            "mac": "e3391799fc0f611b5469f220a3c127f8503ff36bfd7ad4236715d5cda818f0d9"
+          },
+          {
+            "tcId": 502,
+            "mac": "0807d23f0699eb6fa1edcc3bf296cd74e71f5dd41e1c027e12a99b67e2ece21d"
+          },
+          {
+            "tcId": 503,
+            "mac": "f3e0fb08bafac4e9f5ada1420d71ac7303f84e8aa7356a90adf78f2a754c6cc1"
+          },
+          {
+            "tcId": 504,
+            "mac": "463de6212020a95b3ce17ad247a96058263ebbb2130715f5c309060ee187f83f"
+          },
+          {
+            "tcId": 505,
+            "mac": "a577d7b0af4c2fc9b01e1cfa4ae2d5125b3d30531e2534f92a08164994b2e817"
+          },
+          {
+            "tcId": 506,
+            "mac": "a5fddad68be7a2104e070e40991ee33eaa0637c7c6f94f32eb699d03b7023e33"
+          },
+          {
+            "tcId": 507,
+            "mac": "de47f9cae5d1dfbbc283dfbd8ff58100ec753f4b9f6a40d6713cbf233d775844"
+          },
+          {
+            "tcId": 508,
+            "mac": "32dd44cf6839b8cc911c462bd5faf24d3e0a63805c0eb41c3d2a9574cca3003d"
+          },
+          {
+            "tcId": 509,
+            "mac": "7333d17db65b615ea8de9f66d50275db76f7bc38ac930fcc392ead83ba4dd2f8"
+          },
+          {
+            "tcId": 510,
+            "mac": "2c0b8c56ce89b63816189275589d1c7ea957d955c42976d7afae29320a69181f"
+          },
+          {
+            "tcId": 511,
+            "mac": "7a6ea716f9c909885e61c225b82285b33cea21dd236c01f2a64bdf5708765a89"
+          },
+          {
+            "tcId": 512,
+            "mac": "54337c3ed5139306a9f2ad0fa3d921b57d29baa0ac018c800e5bf604a771a3ba"
+          },
+          {
+            "tcId": 513,
+            "mac": "565b7d90ea3cf6804613b7d479bf7218622cccef31aec0af7f14419b94a49fa4"
+          },
+          {
+            "tcId": 514,
+            "mac": "632efdc1e7362aeb0be52133c38889e8bbb66ac7ae98a884c930ed908ff7e821"
+          },
+          {
+            "tcId": 515,
+            "mac": "8ef9bad0e4a3c20444dd295e96dfc42837465bcdcc486d3fa2574d6b26610fca"
+          },
+          {
+            "tcId": 516,
+            "mac": "d45e0ebe7e73b99f5ebe94b71f585d2408a69d9bc7aa6d9923aeae71ffcb9e89"
+          },
+          {
+            "tcId": 517,
+            "mac": "8478945069e365f3a5fab3752bd846add081fb8b5ac3b0fe27becd42ca4ea5d7"
+          },
+          {
+            "tcId": 518,
+            "mac": "382ba4ad0ec446484df0b65247e20cf8ab5df74f9a5dd913a0aa03a7a1950c32"
+          },
+          {
+            "tcId": 519,
+            "mac": "08650b77bd6efad683cd0187e0a6b8ce8a883e7d1fa729af97ba0b8cc6a44b90"
+          },
+          {
+            "tcId": 520,
+            "mac": "ceb8e588ca8ece1bb3450cb78d1f69d973cbd132c101c4710d8fd78fa848f45f"
+          },
+          {
+            "tcId": 521,
+            "mac": "4bc3b4d05f63eb89997b7df0dfbbfdd0a558f1f665eb5ed9f04b3f07027f39a4"
+          },
+          {
+            "tcId": 522,
+            "mac": "834ee716e935842f51f0e97d1c5496f91bea24d9d8368b31ec9337303fa4c6b2"
+          },
+          {
+            "tcId": 523,
+            "mac": "04b867af2bf2568e8967c238122c36d2c26d909efe56fc7decbfd924d526e33d"
+          },
+          {
+            "tcId": 524,
+            "mac": "2bb647267f1bf74daf97fb6ffa56da28d73ee714c9278aa91abf2d7a4c0aa6db"
+          },
+          {
+            "tcId": 525,
+            "mac": "9673c23e1f3e47fedce2e46fbcd8dc1c933b11e71abced1482d5fa369af6fdfa"
+          }
+        ]
+      },
+      {
+        "tgId": 8,
+        "tests": [
+          {
+            "tcId": 526,
+            "mac": "3b9dfc94"
+          },
+          {
+            "tcId": 527,
+            "mac": "574861bb"
+          },
+          {
+            "tcId": 528,
+            "mac": "f9c6f750"
+          },
+          {
+            "tcId": 529,
+            "mac": "481820b8"
+          },
+          {
+            "tcId": 530,
+            "mac": "b46b45b9"
+          },
+          {
+            "tcId": 531,
+            "mac": "6a140583"
+          },
+          {
+            "tcId": 532,
+            "mac": "74d02c83"
+          },
+          {
+            "tcId": 533,
+            "mac": "79701fdd"
+          },
+          {
+            "tcId": 534,
+            "mac": "7675dfa6"
+          },
+          {
+            "tcId": 535,
+            "mac": "e7bd7770"
+          },
+          {
+            "tcId": 536,
+            "mac": "10235a27"
+          },
+          {
+            "tcId": 537,
+            "mac": "8ccc510c"
+          },
+          {
+            "tcId": 538,
+            "mac": "5845879c"
+          },
+          {
+            "tcId": 539,
+            "mac": "ac7650da"
+          },
+          {
+            "tcId": 540,
+            "mac": "90fb7241"
+          },
+          {
+            "tcId": 541,
+            "mac": "c2e25e62"
+          },
+          {
+            "tcId": 542,
+            "mac": "26d14dcb"
+          },
+          {
+            "tcId": 543,
+            "mac": "25e782fd"
+          },
+          {
+            "tcId": 544,
+            "mac": "d22b8e36"
+          },
+          {
+            "tcId": 545,
+            "mac": "00c580ec"
+          },
+          {
+            "tcId": 546,
+            "mac": "af6dc83f"
+          },
+          {
+            "tcId": 547,
+            "mac": "0c51767e"
+          },
+          {
+            "tcId": 548,
+            "mac": "8611f8a6"
+          },
+          {
+            "tcId": 549,
+            "mac": "ec6d12fa"
+          },
+          {
+            "tcId": 550,
+            "mac": "4682b53d"
+          },
+          {
+            "tcId": 551,
+            "mac": "fdb88c06"
+          },
+          {
+            "tcId": 552,
+            "mac": "5a895063"
+          },
+          {
+            "tcId": 553,
+            "mac": "391c959f"
+          },
+          {
+            "tcId": 554,
+            "mac": "ba39ae43"
+          },
+          {
+            "tcId": 555,
+            "mac": "7743c5b1"
+          },
+          {
+            "tcId": 556,
+            "mac": "a97c1bd5"
+          },
+          {
+            "tcId": 557,
+            "mac": "b3c27082"
+          },
+          {
+            "tcId": 558,
+            "mac": "a9ef726b"
+          },
+          {
+            "tcId": 559,
+            "mac": "dfc5b9b1"
+          },
+          {
+            "tcId": 560,
+            "mac": "1a2c59f3"
+          },
+          {
+            "tcId": 561,
+            "mac": "4c3de60a"
+          },
+          {
+            "tcId": 562,
+            "mac": "49a6410e"
+          },
+          {
+            "tcId": 563,
+            "mac": "b7a40c24"
+          },
+          {
+            "tcId": 564,
+            "mac": "177b37f3"
+          },
+          {
+            "tcId": 565,
+            "mac": "1ba687b9"
+          },
+          {
+            "tcId": 566,
+            "mac": "99663250"
+          },
+          {
+            "tcId": 567,
+            "mac": "87866937"
+          },
+          {
+            "tcId": 568,
+            "mac": "b8d7edac"
+          },
+          {
+            "tcId": 569,
+            "mac": "6f3c8e36"
+          },
+          {
+            "tcId": 570,
+            "mac": "fced4e19"
+          },
+          {
+            "tcId": 571,
+            "mac": "7156e668"
+          },
+          {
+            "tcId": 572,
+            "mac": "033e3350"
+          },
+          {
+            "tcId": 573,
+            "mac": "45f0f3ad"
+          },
+          {
+            "tcId": 574,
+            "mac": "6fcb9fac"
+          },
+          {
+            "tcId": 575,
+            "mac": "adf61731"
+          },
+          {
+            "tcId": 576,
+            "mac": "fc14c5fb"
+          },
+          {
+            "tcId": 577,
+            "mac": "26c1bbd9"
+          },
+          {
+            "tcId": 578,
+            "mac": "0860af6c"
+          },
+          {
+            "tcId": 579,
+            "mac": "1acd5507"
+          },
+          {
+            "tcId": 580,
+            "mac": "f205c040"
+          },
+          {
+            "tcId": 581,
+            "mac": "e891b6c1"
+          },
+          {
+            "tcId": 582,
+            "mac": "505b2f73"
+          },
+          {
+            "tcId": 583,
+            "mac": "02623630"
+          },
+          {
+            "tcId": 584,
+            "mac": "6eed523f"
+          },
+          {
+            "tcId": 585,
+            "mac": "0833d5a0"
+          },
+          {
+            "tcId": 586,
+            "mac": "c65ff371"
+          },
+          {
+            "tcId": 587,
+            "mac": "a8ce2ac0"
+          },
+          {
+            "tcId": 588,
+            "mac": "2e372ddc"
+          },
+          {
+            "tcId": 589,
+            "mac": "0fb225b6"
+          },
+          {
+            "tcId": 590,
+            "mac": "8736aee4"
+          },
+          {
+            "tcId": 591,
+            "mac": "ac67a7b5"
+          },
+          {
+            "tcId": 592,
+            "mac": "25148e94"
+          },
+          {
+            "tcId": 593,
+            "mac": "3854e347"
+          },
+          {
+            "tcId": 594,
+            "mac": "578e4f40"
+          },
+          {
+            "tcId": 595,
+            "mac": "d6c1e1cb"
+          },
+          {
+            "tcId": 596,
+            "mac": "feb1d51c"
+          },
+          {
+            "tcId": 597,
+            "mac": "21a713a9"
+          },
+          {
+            "tcId": 598,
+            "mac": "baa55220"
+          },
+          {
+            "tcId": 599,
+            "mac": "50194dda"
+          },
+          {
+            "tcId": 600,
+            "mac": "e64afe9f"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/sw/host/cryptotest/testvectors/acvp/hmac_sha256_vectors.json
+++ b/sw/host/cryptotest/testvectors/acvp/hmac_sha256_vectors.json
@@ -1,0 +1,3084 @@
+[
+{"url":"acvp/v1/testSessions/666842","vectorSetUrls":["/acvp/v1/testSessions/666842/vectorSets/3493042"],"time":"2025-11-04T21:00:46-08:00"}
+,
+  {
+    "vsId": 3493042,
+    "algorithm": "HMAC-SHA2-256",
+    "revision": "1.0",
+    "isSample": true,
+    "testGroups": [
+      {
+        "tgId": 1,
+        "testType": "AFT",
+        "keyLen": 296,
+        "msgLen": 128,
+        "macLen": 48,
+        "tests": [
+          {
+            "tcId": 1,
+            "key": "53ECA89708FDFCA718E1A32C6B814E46264A2691F26DE9898F0AEB0971A2C0166B680BAD43",
+            "msg": "4B7D6DFFB1CBD9666A19AF29753BCAFF"
+          },
+          {
+            "tcId": 2,
+            "key": "3F7866F45BF8A7A3B1CB326BBDACD5D965363B76DCD0C184605E539F8A39C0AF1DEAC81627",
+            "msg": "F82457E6D726363FBCFA0E1C356EA039"
+          },
+          {
+            "tcId": 3,
+            "key": "F0616B478975DBC67F6D4273D0B4BA8193ED490B8A7BDB10256F1D92386CDA4CBAFECEB78D",
+            "msg": "541C7A20E0B67A7B4D04F23E0FB6C4D8"
+          },
+          {
+            "tcId": 4,
+            "key": "8471CB59F46791B70ECAA01742469FE8E63E9D34E4F39C6E5DA962887F40DE8B8B645BEE1C",
+            "msg": "6462B64F916B653EE5C17D7635308695"
+          },
+          {
+            "tcId": 5,
+            "key": "7531D22118B441306413CFEDC947ABEAF05E58F6023E5316CB9C5031A179A680C0A48022DA",
+            "msg": "56A972972F3993C56E25AA57D4A0A365"
+          },
+          {
+            "tcId": 6,
+            "key": "9EFDDC0D3CBB1B92117887C7D4FE9D631B7C0C505DDCC205DE943682EC57FF986370C8EA8A",
+            "msg": "DC10735F1FB938D344486383F2167A0B"
+          },
+          {
+            "tcId": 7,
+            "key": "EDB03F43B51CC25D20A2DAD410BDD84573C291776F88C5E277766D1E686D4B44BA58825C8B",
+            "msg": "23D68CC4C8317E29856A64128D734D7C"
+          },
+          {
+            "tcId": 8,
+            "key": "067C69C85D9A7E7834AF75A8529A5F06AAC90058823F93B69098427164D900F1C49290A0CC",
+            "msg": "149A42A7D165AC5F9F6A3531FF4F3381"
+          },
+          {
+            "tcId": 9,
+            "key": "C47A21260CEE0257ECE3AF9AC042AA6E0DC2A76F3323330CD00AB37900C914C637A2BB9DB3",
+            "msg": "2A1308CD999C9B9CACFDEA497B05E986"
+          },
+          {
+            "tcId": 10,
+            "key": "10232AA04029CA7A9C533B497B260AF5CF8CC315D53478095C8422F77D068DCF2606C452EE",
+            "msg": "96E82A2F85A67E0F081448D482CF5881"
+          },
+          {
+            "tcId": 11,
+            "key": "141FF6CAAAFC8C806A8BBB142D2B176B3584F909FADE61AB6949BD5DF678989ACE6A533A9F",
+            "msg": "C20DF44083278F9368777EDFF4E9CF9D"
+          },
+          {
+            "tcId": 12,
+            "key": "3B41232F109D13C45289CECB5A5828DD40D637ED353DF7D4F3E71FABFF4A66519EE517824A",
+            "msg": "C7E47F79F4774F529ED5657149AA7C0E"
+          },
+          {
+            "tcId": 13,
+            "key": "6838BEAFDE1A3651E67665E5DE5D3A5E252410ACE415F58BE9931CB7E459467C5688E6A1A7",
+            "msg": "675211A77AFEDF24BE52E7475378EA94"
+          },
+          {
+            "tcId": 14,
+            "key": "57F29CE6FB0DEE27C2EBC4CF3C34AD7957DA01B4C4CE3E7A899544B56189407F572FE62E9F",
+            "msg": "60929249124E359E3637111759A9592C"
+          },
+          {
+            "tcId": 15,
+            "key": "C6E3DB5FC7CA1820E69F5E02C726858E36BA77C160B11358923E4A7244706D973CC38F9DF9",
+            "msg": "7D2DDE3CA30D031B22D32A483909E2D7"
+          },
+          {
+            "tcId": 16,
+            "key": "E13226C147E0A76290066A63C811CCB9B1BA574D9E85298C8401E96F25BD330819BE766F81",
+            "msg": "9DDDC12B749F6E3A96A3A68BA373F056"
+          },
+          {
+            "tcId": 17,
+            "key": "6791978F497BCFFD6BE89659B566B25F39DCCF9B37EA2D43A05351CB11C9EBFCE4745A5849",
+            "msg": "402E3B32C44D846A0C625130B14275A6"
+          },
+          {
+            "tcId": 18,
+            "key": "E63A22205990687AC9E0093C6B06DE70D4B0B5F812DE0A1EB259CD8E01BA54FF978AF6D651",
+            "msg": "73D8469C5D3B942D420D9A0FF8277C9F"
+          },
+          {
+            "tcId": 19,
+            "key": "76FC392D5265650D109436EC786DE6C1156BFE6A1DFCBE6EDCFFD23B5CCEB5F04FFD4C9177",
+            "msg": "4DFB0042615E924117860BA0CD2EEDEE"
+          },
+          {
+            "tcId": 20,
+            "key": "E315475D98BDCCE4955904D985409989B8539DC92243A9839CEF711493B0D2DB3976EF0CD1",
+            "msg": "D5CE0CF6EA41D136394241EFD08A3BBA"
+          },
+          {
+            "tcId": 21,
+            "key": "99260C8A2FFC3CCA7E8D92C3210A422A20E9E697CC06958048CDCAC449518820E87A545643",
+            "msg": "4ADF6E3B1A7B94E89DCA7DDB1FE4CFD4"
+          },
+          {
+            "tcId": 22,
+            "key": "181577DE06268E71A2B08B742B77DBCB01D5B36D2F4930833B0E673F90079217B26C1A3F38",
+            "msg": "F8E03EDA7BA72A0DDCE5BA9E1545F60A"
+          },
+          {
+            "tcId": 23,
+            "key": "5688E9AE1E7EF2F45DB0697917FEC96472FBB0EE1849F747E5C52277D4A37A7434BBEC1A7E",
+            "msg": "E41571BB696A9FFE90EDF6F06B606409"
+          },
+          {
+            "tcId": 24,
+            "key": "8A1AC4AE7881FA9D6D3A52174395BE419B4BB8CC73017694B013C162C0C28EC133C626B603",
+            "msg": "334E81F175187A954F3C5D6387D34275"
+          },
+          {
+            "tcId": 25,
+            "key": "D18F09854B7BC38E2701A4E75D90FED93B19137CF465DF04191B895506217E5087676D9E44",
+            "msg": "4862986F0118BAC32236F85F8B22F0B0"
+          },
+          {
+            "tcId": 26,
+            "key": "71151EC35F63632779A949AB0239D7397FD7672D49CC1AA59576E536B7B29CCE862F3450A8",
+            "msg": "34FAE219AB0BB1245E9578DFD1C863D5"
+          },
+          {
+            "tcId": 27,
+            "key": "029C7FD411875BF41C13BC3216612536D68A706B03981E77F01618C5A1E3C154A2F40377F1",
+            "msg": "5C933AA1E56AC35FE709173765FD2673"
+          },
+          {
+            "tcId": 28,
+            "key": "88A52399A512060699FD0591EF7C6A885ED2DA676F18896CA54E7B44EE55B40CBD72F80737",
+            "msg": "EB0823EC7703310289A9E3E4F064B8C1"
+          },
+          {
+            "tcId": 29,
+            "key": "9E3E9DED5787BF2E0661375C2F159E35AE8D630CE484326DE1E0D1E93A5165660623530E4E",
+            "msg": "1083EC1F700D26DE9AE66E89F8656A2A"
+          },
+          {
+            "tcId": 30,
+            "key": "763381AD5B9478D876999EFD75684081585A97774BDEA29936C73AC654BA87F3B28125B279",
+            "msg": "FBD2C67093040070D75005EED139A571"
+          },
+          {
+            "tcId": 31,
+            "key": "962CAA538CDDED1786C2C1DA4027AAD93995BE424CB5C2343EAE56626FBE0A9E5BE4442E94",
+            "msg": "3ECDDA2B109ADD0EEBF09E683C657D8E"
+          },
+          {
+            "tcId": 32,
+            "key": "591AC1E9E0FFCF8C997088DB277E73C4E1C334790EF452AB17239F23DE658251C62362E71E",
+            "msg": "708510CA731CF29124BE5E2E63FA9D3E"
+          },
+          {
+            "tcId": 33,
+            "key": "F729DB8BAEC13BF34939348D0531FC0D8008B1281E10541EB21CB4CB9BCC34A37A99DB9BF1",
+            "msg": "E18B0C04989D02CB7B3BAF09886294CA"
+          },
+          {
+            "tcId": 34,
+            "key": "9D4AEBADF807A8918B38C10500179BCCEB0F641721249EDBCB572D9AD4789AC55D56DC5304",
+            "msg": "19EBDDA308BAB92B5A95BC873D9F4AF6"
+          },
+          {
+            "tcId": 35,
+            "key": "03258EC4BA2C2D9A4300F32E245F02E1FE5FF8490A8666732B5CF0B8EB25928F0A862A35A8",
+            "msg": "46FFCA6123FC8B80AA688444CE80E8FE"
+          },
+          {
+            "tcId": 36,
+            "key": "314BDD0847AE8CB97713AFDB46C561045A6D59D394B2744E6543DC86F1FE98B91366655342",
+            "msg": "6129B42737962E0A66412C45E2AFF107"
+          },
+          {
+            "tcId": 37,
+            "key": "B1A15CF4CBF581942627B9602026B971DC5527A33081FDAB1A6D83040EF129B20668345B38",
+            "msg": "ACDD7859AECA835E42652A631A47D161"
+          },
+          {
+            "tcId": 38,
+            "key": "E6C09DF4BDF029B2CF3DB0BAB10C973300643BD40E9B7D2BD4717A2F54E3A527A855EAC616",
+            "msg": "7DF930AAB8BAE69CF240129D5818A14D"
+          },
+          {
+            "tcId": 39,
+            "key": "2AEEFD8057BDB9ED052A1D5A2C1AEA0C051C27EFF1FEBC7033E4C7D60B7AB944237A62C967",
+            "msg": "C35A84A897D55966EF4075611D5FD31C"
+          },
+          {
+            "tcId": 40,
+            "key": "7A2A178B8BB6DF153E4A678D7530B799252B515CD0767999DF70D1A9B8171F4D37160A46C8",
+            "msg": "50080053580B0D2AF08A213EFB905FA0"
+          },
+          {
+            "tcId": 41,
+            "key": "A2F7F0773697071DEC26391A2170B5741B845980178915B3678750A266C115C3AFD1882181",
+            "msg": "14457D674D875F8A34A8155913DAAF1A"
+          },
+          {
+            "tcId": 42,
+            "key": "FBE17B70461D1A3534A22FA61EACAD257C18FFE89901AAF123B336ACA8289180640A7E38CD",
+            "msg": "F2D26CD8E5425B2015C834543CCD5F78"
+          },
+          {
+            "tcId": 43,
+            "key": "D5F74A2C69DBE88791CCA64CF8C144652CC6063C3A8B0A98083C2E5EE0C2CDD220BB0060DF",
+            "msg": "E1B4DBE76B20266D0AC6C35C1FE93D29"
+          },
+          {
+            "tcId": 44,
+            "key": "F7968CB7659A8CA80363AC7E63E777D1018DE1F3CAE6888B74D6CE7170D96F2738A70AF233",
+            "msg": "1935EA4A76A754468D4BB71681DBD6A3"
+          },
+          {
+            "tcId": 45,
+            "key": "1207F1BFD0464E0FBDB619FBDEC8871C33C46F19FA3EAFD4C862A6D9E52356EB8E3809CEE2",
+            "msg": "FC25FF21B988CAE55AEC46873FB9708F"
+          },
+          {
+            "tcId": 46,
+            "key": "2F74FB88D98D641FBBDABC1A2D312726B4395188C1112573DA699501269FB5BEC99237C193",
+            "msg": "519A0AEE0E3805EDA0B1F6B246D99295"
+          },
+          {
+            "tcId": 47,
+            "key": "F8329DC8110DDF8D80189EA9FA177E245D0F707401F18D2CD4C0D56EF23DB5F0C56AEF1156",
+            "msg": "51F5361502DBEE836208532CF9C329F3"
+          },
+          {
+            "tcId": 48,
+            "key": "E4FE09BB1D466E733934B170E4B09DE651295402891EC4AF3027B813EF01CDB878377E4B67",
+            "msg": "21EA52566ECF5CA972A91665CBCCF219"
+          },
+          {
+            "tcId": 49,
+            "key": "A671C74AB8479FC6BE90441B9298135DC9F901C1771251518D02ACA21AA3FD08192EBE6A93",
+            "msg": "8582C0DCFD4B008D73A4B865EEE3556B"
+          },
+          {
+            "tcId": 50,
+            "key": "79621EB9319A8A2101B7B02FB1492A9943939A937E0B0BF0729A8558FCB638BD3CCA0945DF",
+            "msg": "A1B6D51C713DEAD9C7F4CE456DBF3805"
+          },
+          {
+            "tcId": 51,
+            "key": "6FC9FE0156B7DD99AEB63EC17ED073E2C0B9091E4BCAD9E9C12210F6054F20DA4CF270C181",
+            "msg": "CDD0AF14D1A0766C87ED04583DC73618"
+          },
+          {
+            "tcId": 52,
+            "key": "A236FEB414722DCF3BF2ACBF5FA5994A5C8ACD028C0F3B68C9D7A7F6275F4155652EB97C2A",
+            "msg": "4808A04C6DA08DCE42EF285FAE519143"
+          },
+          {
+            "tcId": 53,
+            "key": "3CB971E3E2B855E9EDA853F8ED4BDA901BAF2CBA3E331E912B4A019997773B72F8B918ECD5",
+            "msg": "92108DB36F16587C60CEA770217B8FC0"
+          },
+          {
+            "tcId": 54,
+            "key": "A953A673D6BCC772ADD108975EE605E06A0E7D416447621DE52701609CDBBD5ABE5DD7B820",
+            "msg": "B6A16B847B51E25C344B49AF8D261C27"
+          },
+          {
+            "tcId": 55,
+            "key": "A70DEF051281E019225EA33A4C5B16F0753E2BFDAAC6825EB7E5CBD9E66049B70D886029C1",
+            "msg": "A5C360DADC96FB040C159673AF6411CF"
+          },
+          {
+            "tcId": 56,
+            "key": "99C443A368327513F67F62111BFFDAB22D2F06E08587DD8D9AB0183A366D53058B8F33969E",
+            "msg": "835795038A0460B185C3B364CB93E5D4"
+          },
+          {
+            "tcId": 57,
+            "key": "CE52A3E7F5FBB7A00E8AD46C863AAF02A9A52F3E1CD79BF6FF66638A33826B1B561561EFC1",
+            "msg": "1D5EAB9A7A6A5D860CA435FF06C1244C"
+          },
+          {
+            "tcId": 58,
+            "key": "5A1E3221F2BECAF58E09F001186DCFC606908A0259A1A7402435A745833DB46CC5F93B727D",
+            "msg": "B68616312B16AD4D7D939D636D54E320"
+          },
+          {
+            "tcId": 59,
+            "key": "91057E217242D666A499A59260B2FADAB995B9C8D6F0F1A83AE4C6376C714B821CD4942DCF",
+            "msg": "35ADF8DF04B42E25EBE8566F199F9F38"
+          },
+          {
+            "tcId": 60,
+            "key": "3D23E4BAABBC4CB5E4D168714A68320C95B36FBDA4CC17D7FF2391874137269C2660FC6440",
+            "msg": "ABC3D3244ECA94E15344952304727F32"
+          },
+          {
+            "tcId": 61,
+            "key": "A4AB1D7D1D5D8048921C2B24908776F61FDD9C6BCF5A481776CEAB07D64ACF42FD082556AA",
+            "msg": "7588A5B06A44E474C70F58EE9C34AF3D"
+          },
+          {
+            "tcId": 62,
+            "key": "D33F5318ADCD9EF77D4CB36A07919EF92C904D9F30C76920E6E21A7FB0E545C9D32571452A",
+            "msg": "704964A01E2E87887A46AEA1C21E1CF9"
+          },
+          {
+            "tcId": 63,
+            "key": "1FF02F07996E382DDC204BF3D9C5FD6C6C767B3B4F006AF95CA5ADF2174064BB9E8D60A11F",
+            "msg": "C9145281450DF215BD0DA8E88A6A9D38"
+          },
+          {
+            "tcId": 64,
+            "key": "8CBCDABB1F9751C4F027B2E12C260BA35DE55DD3A38D3E022D05E6131D8431227FF64340B7",
+            "msg": "326189F58FA510BEEBC2A7335B59F302"
+          },
+          {
+            "tcId": 65,
+            "key": "0478E4E7C92AEB2C801E24CFD04941796BDD9B9EF38E2EEC45C1832A36A5E5828BD6A99248",
+            "msg": "17C4515DD6553147E03927B5D958D182"
+          },
+          {
+            "tcId": 66,
+            "key": "F174DD7815CC14EBFB55A400A1BFF64E75067EF8CE6F79C085678044DE6F08A1D46794763C",
+            "msg": "741B203E0D1E9C0674DB45860F2D2E15"
+          },
+          {
+            "tcId": 67,
+            "key": "0E7C03BDE41F66157D492A0E98E04CBD92D2064F32BB0FFA88AAD1565AB90D5A1C28B2EBD0",
+            "msg": "14546503683252482715AA2D1EA561BA"
+          },
+          {
+            "tcId": 68,
+            "key": "735D0665951D2FCE38C93FF7AEC4B046D20EF9DFC10CED94E89D5311309AEB095E19DFE552",
+            "msg": "41BF774B670AAC92ADF00E505B07CD4F"
+          },
+          {
+            "tcId": 69,
+            "key": "7818A759556EDABD572BF0A02468ECE3672829C2526DF31DC903812C812025AF2F65DB9B09",
+            "msg": "167EBB31EA07804C2563F621777C4877"
+          },
+          {
+            "tcId": 70,
+            "key": "4AA2D187B4D293A8F7F114739675C079079981617A1FB16C04DFA604232746F818BD1E1564",
+            "msg": "DDD5B8CE3E4536E5BB0E6C6F6680FD3F"
+          },
+          {
+            "tcId": 71,
+            "key": "79F8BBED48469A90ADF8FFD4F366732348FDC02F5F4CDE2795E2615CAABA57195EF2CA869D",
+            "msg": "895393EA7BC44B88B1452C395CFBADB1"
+          },
+          {
+            "tcId": 72,
+            "key": "6B85B9BBEA576A15C2BA77B575D13116AD4A0DF95B8E0CAFC88E64BC9D521B6FD793324358",
+            "msg": "281CA64DE2D49979EE6F5B700D83209E"
+          },
+          {
+            "tcId": 73,
+            "key": "704EF24DEB42A9FB50FFAB03B263ED816EDE89EA2F7D327780592389CD393AFC69186A11D4",
+            "msg": "54517490D1A4A27A07BE6CCFA8DA5DCB"
+          },
+          {
+            "tcId": 74,
+            "key": "C5F146E6060F80DDB4DA6CF2416CAB6CB738BD4BFDF3BF2DD197BC7019A85921F295C31B74",
+            "msg": "057ED179D73B303B7CDA5252E4249F98"
+          },
+          {
+            "tcId": 75,
+            "key": "DA76BA65CA31FCA971091859038B539B602DAEDDF34B752E1518E1DE51CAE98A382B1E79F4",
+            "msg": "B2577B88965C63851EF38C0FA56EFCC5"
+          }
+        ]
+      },
+      {
+        "tgId": 2,
+        "testType": "AFT",
+        "keyLen": 8,
+        "msgLen": 128,
+        "macLen": 32,
+        "tests": [
+          {
+            "tcId": 76,
+            "key": "8F",
+            "msg": "83E18EF660849E7079659551DED863E9"
+          },
+          {
+            "tcId": 77,
+            "key": "BB",
+            "msg": "B986EF75CECFF65D690AB11FC2E06522"
+          },
+          {
+            "tcId": 78,
+            "key": "63",
+            "msg": "BC0BF61014178AFAE68E5D8FF36FA72B"
+          },
+          {
+            "tcId": 79,
+            "key": "02",
+            "msg": "66F8F314EFAD86DE226EF51F24F618CE"
+          },
+          {
+            "tcId": 80,
+            "key": "2C",
+            "msg": "113A9F201430AD9848B6E91ABA701AF3"
+          },
+          {
+            "tcId": 81,
+            "key": "21",
+            "msg": "0F47BC9750A4FA628E8566E556363BF4"
+          },
+          {
+            "tcId": 82,
+            "key": "AF",
+            "msg": "21166A58DD5776E420659E833A68D599"
+          },
+          {
+            "tcId": 83,
+            "key": "5F",
+            "msg": "134EDBD252755931012BD4C33E1B7AE2"
+          },
+          {
+            "tcId": 84,
+            "key": "BC",
+            "msg": "9BAE2BCF0ABF9495EFEB0F17E6926F92"
+          },
+          {
+            "tcId": 85,
+            "key": "3D",
+            "msg": "B1E0654E7052C075D6AEB57583CEA10C"
+          },
+          {
+            "tcId": 86,
+            "key": "8D",
+            "msg": "232D9F46EA724BECD3E96D04929D01DB"
+          },
+          {
+            "tcId": 87,
+            "key": "7D",
+            "msg": "33411AA497BF772CDAF3F86B04E72BFF"
+          },
+          {
+            "tcId": 88,
+            "key": "07",
+            "msg": "F3F34578D53A8B535433B4169332333E"
+          },
+          {
+            "tcId": 89,
+            "key": "CB",
+            "msg": "A9D1B968EACDDAB5800C0D18BF1A46EC"
+          },
+          {
+            "tcId": 90,
+            "key": "7F",
+            "msg": "36835AFDFF64FEB0DB942A0CC6DA109E"
+          },
+          {
+            "tcId": 91,
+            "key": "30",
+            "msg": "E6FD94B531C9023C01D22EFEECEC24AA"
+          },
+          {
+            "tcId": 92,
+            "key": "20",
+            "msg": "644E07E1150A7162A7495D593FCD1A6A"
+          },
+          {
+            "tcId": 93,
+            "key": "9D",
+            "msg": "0525072956B7B402B1BA96BB8157253D"
+          },
+          {
+            "tcId": 94,
+            "key": "F0",
+            "msg": "EC2A1972836005CCB2DD8974E133F5FF"
+          },
+          {
+            "tcId": 95,
+            "key": "46",
+            "msg": "F7C0DD60633915D99DCCEAE404723BD6"
+          },
+          {
+            "tcId": 96,
+            "key": "39",
+            "msg": "B10744DF5DDEDA54CBF03C29A322361F"
+          },
+          {
+            "tcId": 97,
+            "key": "0D",
+            "msg": "60A31ECEFCD6607A6FDE679480F2AF7B"
+          },
+          {
+            "tcId": 98,
+            "key": "F1",
+            "msg": "04E20D52B330F274B3FDD3C5D480EEF0"
+          },
+          {
+            "tcId": 99,
+            "key": "DA",
+            "msg": "8B6634E3D0CCDD6EC78335ACE68A4B81"
+          },
+          {
+            "tcId": 100,
+            "key": "EF",
+            "msg": "2C20C8C8916CD5ED4429CA34E860F3C4"
+          },
+          {
+            "tcId": 101,
+            "key": "88",
+            "msg": "27EA2F077DD08AE7116906AD2E742437"
+          },
+          {
+            "tcId": 102,
+            "key": "DD",
+            "msg": "CC95AB1BB8AC37678811EDFEE9E6E3F0"
+          },
+          {
+            "tcId": 103,
+            "key": "43",
+            "msg": "875B3C1A406211B598421A31558CE50C"
+          },
+          {
+            "tcId": 104,
+            "key": "72",
+            "msg": "1CC2D237354EA5E81EA3AC9756CA4D5F"
+          },
+          {
+            "tcId": 105,
+            "key": "F2",
+            "msg": "3288466F37E41A861BEA5F51E2B30E44"
+          },
+          {
+            "tcId": 106,
+            "key": "0F",
+            "msg": "1D73F66E3160AD259F2F51E1AE2B7CC4"
+          },
+          {
+            "tcId": 107,
+            "key": "AA",
+            "msg": "86F50CA40D52889061F8221D611241A4"
+          },
+          {
+            "tcId": 108,
+            "key": "B7",
+            "msg": "62497103D7BC5B50AE6730FDB5DB5AEC"
+          },
+          {
+            "tcId": 109,
+            "key": "0C",
+            "msg": "3D67D8F289E3CD5BEFB679609ECD07A0"
+          },
+          {
+            "tcId": 110,
+            "key": "00",
+            "msg": "0293446E513193205C0311C5860B248C"
+          },
+          {
+            "tcId": 111,
+            "key": "57",
+            "msg": "0E7771504599292DEB5226FEF1B23F20"
+          },
+          {
+            "tcId": 112,
+            "key": "C4",
+            "msg": "3658396D5FD49ACBD306461C875DCA68"
+          },
+          {
+            "tcId": 113,
+            "key": "83",
+            "msg": "9DD44D0BD8582E39AC90F04B6A3817E3"
+          },
+          {
+            "tcId": 114,
+            "key": "E0",
+            "msg": "38A856BC1EC2A1ABDFBF9F7DA22A3742"
+          },
+          {
+            "tcId": 115,
+            "key": "00",
+            "msg": "E3480CA8693EE7BBB7072C827C9DAE9D"
+          },
+          {
+            "tcId": 116,
+            "key": "6B",
+            "msg": "72A3ED2FB97C833E4E679DEEF4936CD2"
+          },
+          {
+            "tcId": 117,
+            "key": "09",
+            "msg": "0339783E635F020B1454F79CEFFA01FA"
+          },
+          {
+            "tcId": 118,
+            "key": "54",
+            "msg": "21D881A0E8461CA933259C660D6611A4"
+          },
+          {
+            "tcId": 119,
+            "key": "FA",
+            "msg": "53A56A2DD020C588BC575379D1CF41A0"
+          },
+          {
+            "tcId": 120,
+            "key": "E8",
+            "msg": "D65C834C886BD7DD63090FA228488DC2"
+          },
+          {
+            "tcId": 121,
+            "key": "E2",
+            "msg": "FDE1F801EE0CC989DF723FFC8A5FFC1E"
+          },
+          {
+            "tcId": 122,
+            "key": "BE",
+            "msg": "C451349A33B799AA979E109A9855F61E"
+          },
+          {
+            "tcId": 123,
+            "key": "44",
+            "msg": "B51E848575B32CBAC06DC239EA21A161"
+          },
+          {
+            "tcId": 124,
+            "key": "9F",
+            "msg": "AE0E112F694560FE3DF9DDDB42C09F06"
+          },
+          {
+            "tcId": 125,
+            "key": "66",
+            "msg": "5E49E08DC5429F2F49DE96227C06B5CA"
+          },
+          {
+            "tcId": 126,
+            "key": "22",
+            "msg": "907E4F5C2FF5BBB46B0FFAE928438E89"
+          },
+          {
+            "tcId": 127,
+            "key": "85",
+            "msg": "56FC8AB00CA36392803A2BCFC266F328"
+          },
+          {
+            "tcId": 128,
+            "key": "65",
+            "msg": "1A0B5D0840B01E64E18B3D41A2636C29"
+          },
+          {
+            "tcId": 129,
+            "key": "DC",
+            "msg": "44E5DB2DECE97A5BB61840D1AA9D926D"
+          },
+          {
+            "tcId": 130,
+            "key": "30",
+            "msg": "2EAD33C835E44A1E9BF51163C06D7624"
+          },
+          {
+            "tcId": 131,
+            "key": "8C",
+            "msg": "4B095544AACFEA165D64709F446E823E"
+          },
+          {
+            "tcId": 132,
+            "key": "7E",
+            "msg": "27431ADCEB0259482BD3185B5DFB1FFB"
+          },
+          {
+            "tcId": 133,
+            "key": "DF",
+            "msg": "8335AB10F55B2B3E9BD71216C25B6ECB"
+          },
+          {
+            "tcId": 134,
+            "key": "EF",
+            "msg": "A0E62037D732CE46D130793D02EB2476"
+          },
+          {
+            "tcId": 135,
+            "key": "3D",
+            "msg": "E66BA7991BC2190D5E1A89FE63137947"
+          },
+          {
+            "tcId": 136,
+            "key": "86",
+            "msg": "87B2A1320D483F2EF057AC2C4DF3000B"
+          },
+          {
+            "tcId": 137,
+            "key": "FB",
+            "msg": "8EF59CD7EF5971643B9FBAA67BE47530"
+          },
+          {
+            "tcId": 138,
+            "key": "A6",
+            "msg": "A8A6207E952DC6E5C29A425C32A4C6A2"
+          },
+          {
+            "tcId": 139,
+            "key": "70",
+            "msg": "534E20F0FB98C4701812DB2F8FAB2514"
+          },
+          {
+            "tcId": 140,
+            "key": "C1",
+            "msg": "E3C168D4F1263A0AAD3CC157E98BD8B8"
+          },
+          {
+            "tcId": 141,
+            "key": "2B",
+            "msg": "79CD724AF666FFA0CFD48E6D0FBF0C71"
+          },
+          {
+            "tcId": 142,
+            "key": "BD",
+            "msg": "AD862665650D183451E9199594F315B5"
+          },
+          {
+            "tcId": 143,
+            "key": "1B",
+            "msg": "3A9D54F8E374EB5B942FA25F3709F6E1"
+          },
+          {
+            "tcId": 144,
+            "key": "63",
+            "msg": "92BBA56DC7E9C483519000502380FCEC"
+          },
+          {
+            "tcId": 145,
+            "key": "9D",
+            "msg": "3837BC16EE1EE5D2F9DD25D475578C83"
+          },
+          {
+            "tcId": 146,
+            "key": "A6",
+            "msg": "C4A8AE5691828543CE2BF275F40EC8F0"
+          },
+          {
+            "tcId": 147,
+            "key": "5F",
+            "msg": "0C296EC595F0633AC711844A7C1A299E"
+          },
+          {
+            "tcId": 148,
+            "key": "16",
+            "msg": "6830D7B603A98730420A12AC6D52B6D7"
+          },
+          {
+            "tcId": 149,
+            "key": "72",
+            "msg": "ED759C0510FCC216DC27943354932686"
+          },
+          {
+            "tcId": 150,
+            "key": "A0",
+            "msg": "2160E956DE3823A26E4A18983DAE812D"
+          }
+        ]
+      },
+      {
+        "tgId": 3,
+        "testType": "AFT",
+        "keyLen": 16,
+        "msgLen": 128,
+        "macLen": 256,
+        "tests": [
+          {
+            "tcId": 151,
+            "key": "EDED",
+            "msg": "AC7361524E86D16CE763285CACDA574C"
+          },
+          {
+            "tcId": 152,
+            "key": "1418",
+            "msg": "D4CE72B28D0A1C1E758E26C94D47DE5B"
+          },
+          {
+            "tcId": 153,
+            "key": "B8F2",
+            "msg": "238F37292B768AEE194E599B3CC0B9FF"
+          },
+          {
+            "tcId": 154,
+            "key": "AD7E",
+            "msg": "7C0D91C2D6C79566129C95A54D7F51A2"
+          },
+          {
+            "tcId": 155,
+            "key": "73FC",
+            "msg": "318118E3DDA7E1C6FDA169C218FFC14B"
+          },
+          {
+            "tcId": 156,
+            "key": "C33B",
+            "msg": "29FFC11801F8ACA170DBA408E55D9D58"
+          },
+          {
+            "tcId": 157,
+            "key": "9822",
+            "msg": "0934C1F66372A4C82E54E6A28CFD4898"
+          },
+          {
+            "tcId": 158,
+            "key": "7B5A",
+            "msg": "DCEAA208A90994190FB4C2D81E3F8D7B"
+          },
+          {
+            "tcId": 159,
+            "key": "48E8",
+            "msg": "D9B0C1EB3CDF5E6FB6356A90DDE6E84B"
+          },
+          {
+            "tcId": 160,
+            "key": "1895",
+            "msg": "B4558E08CA3B6102279441F0EF0B2337"
+          },
+          {
+            "tcId": 161,
+            "key": "283C",
+            "msg": "F2CE1CD76760D6E2A31D932F8CC0216B"
+          },
+          {
+            "tcId": 162,
+            "key": "A75E",
+            "msg": "A1EFF8DC7C5B20E70307F0290C21BF4B"
+          },
+          {
+            "tcId": 163,
+            "key": "2039",
+            "msg": "96478AC819A9514007D26EFCC33D0C72"
+          },
+          {
+            "tcId": 164,
+            "key": "B636",
+            "msg": "E08AE66B7F3031D69FFBE5296DF64036"
+          },
+          {
+            "tcId": 165,
+            "key": "3CE6",
+            "msg": "6BE08A4249650254E56CC4FD9B265636"
+          },
+          {
+            "tcId": 166,
+            "key": "B258",
+            "msg": "D87CF01A1E1422A7F08809CDC23A2797"
+          },
+          {
+            "tcId": 167,
+            "key": "B4A1",
+            "msg": "A9609BCC049B359B3934B9B8C975B10A"
+          },
+          {
+            "tcId": 168,
+            "key": "1138",
+            "msg": "74241BF64D8F7B9A97B145F381BC8233"
+          },
+          {
+            "tcId": 169,
+            "key": "7891",
+            "msg": "66F9D44BE4467344D78235CAFE26DB5B"
+          },
+          {
+            "tcId": 170,
+            "key": "750D",
+            "msg": "7FE15F212CAEF5ED4DE91B53AB146A10"
+          },
+          {
+            "tcId": 171,
+            "key": "8D5B",
+            "msg": "804B9F990D2CE0BFEE12E81BD632B991"
+          },
+          {
+            "tcId": 172,
+            "key": "D3CF",
+            "msg": "7FBA4714E33863BDBD6C8E623FB9CD0E"
+          },
+          {
+            "tcId": 173,
+            "key": "CC41",
+            "msg": "BA38427DC4FCCC493990E25285D7E6E2"
+          },
+          {
+            "tcId": 174,
+            "key": "6B50",
+            "msg": "48B976ECDC75327F8CD02ABC06669985"
+          },
+          {
+            "tcId": 175,
+            "key": "1DD6",
+            "msg": "1629300DCD14F9CD49EBC27888CA35E9"
+          },
+          {
+            "tcId": 176,
+            "key": "9200",
+            "msg": "349EC363C601AF69377C929C98BD3EC0"
+          },
+          {
+            "tcId": 177,
+            "key": "76C6",
+            "msg": "D82389866881586CB36E1C05EE2966E0"
+          },
+          {
+            "tcId": 178,
+            "key": "852D",
+            "msg": "A333B4F15F5C4C1B48D14A4F1F776E1F"
+          },
+          {
+            "tcId": 179,
+            "key": "589E",
+            "msg": "2B1F407D2A47CBEF082296473769ACB9"
+          },
+          {
+            "tcId": 180,
+            "key": "1E87",
+            "msg": "D9FE4267DDDC3B397E89A8994F41CE23"
+          },
+          {
+            "tcId": 181,
+            "key": "B4F8",
+            "msg": "46F9266E6A2FC20AA7F091526017073C"
+          },
+          {
+            "tcId": 182,
+            "key": "F6F2",
+            "msg": "D6523A43ED30C06C57D98401EE0A0559"
+          },
+          {
+            "tcId": 183,
+            "key": "AE4E",
+            "msg": "ACEB022F00BE3835B20461DD6B6F086D"
+          },
+          {
+            "tcId": 184,
+            "key": "1EC9",
+            "msg": "8E953F9F9AB5DECEAF2D1729563359EA"
+          },
+          {
+            "tcId": 185,
+            "key": "BD90",
+            "msg": "FDA805195D791ECD28C2ABC3DC83D05C"
+          },
+          {
+            "tcId": 186,
+            "key": "7B64",
+            "msg": "C0C88A4CCCD610D0019E4115FAF8D22F"
+          },
+          {
+            "tcId": 187,
+            "key": "D7B6",
+            "msg": "7DA1AB13C5900A8D11070F055809C356"
+          },
+          {
+            "tcId": 188,
+            "key": "395C",
+            "msg": "C6F63A7E8C2A08938499C3A0ED559010"
+          },
+          {
+            "tcId": 189,
+            "key": "B05C",
+            "msg": "0A546247571851C9BF337AED72A09928"
+          },
+          {
+            "tcId": 190,
+            "key": "6A1A",
+            "msg": "A8671202EB9CABA6F323076D5BC6A58A"
+          },
+          {
+            "tcId": 191,
+            "key": "AA8B",
+            "msg": "E0B0973C6F1BBAEB29ECC9A06D361D7D"
+          },
+          {
+            "tcId": 192,
+            "key": "654E",
+            "msg": "0AC6F4BE84537B69A1F5E0284A5BFBB7"
+          },
+          {
+            "tcId": 193,
+            "key": "E164",
+            "msg": "DAC416C62CF099214783618D98EBB845"
+          },
+          {
+            "tcId": 194,
+            "key": "7817",
+            "msg": "E9295CDF8DD4E01DD3DFAC8BFE810A73"
+          },
+          {
+            "tcId": 195,
+            "key": "BC23",
+            "msg": "3F2E4D6E75D7A31BFCE2C1BA3C3C8AD8"
+          },
+          {
+            "tcId": 196,
+            "key": "C741",
+            "msg": "46890E0343E97A8DAEAB7CC4E0CDA2B6"
+          },
+          {
+            "tcId": 197,
+            "key": "CE09",
+            "msg": "47135C2B164C54251E2BADC561FC55CE"
+          },
+          {
+            "tcId": 198,
+            "key": "B543",
+            "msg": "766C1F2F1D74347127A793F2781925F9"
+          },
+          {
+            "tcId": 199,
+            "key": "E19D",
+            "msg": "52353AF26A997625D44BD4710631C692"
+          },
+          {
+            "tcId": 200,
+            "key": "2627",
+            "msg": "176920F0E4AC88FA3B54DDF0F6A3BE9C"
+          },
+          {
+            "tcId": 201,
+            "key": "25EC",
+            "msg": "05409D2FB83DAB58F6C343AAB9231D2A"
+          },
+          {
+            "tcId": 202,
+            "key": "0442",
+            "msg": "27140A881326DA2247CE9E89690851B5"
+          },
+          {
+            "tcId": 203,
+            "key": "7738",
+            "msg": "E96EAD475A865B04051B426E9BB83C7E"
+          },
+          {
+            "tcId": 204,
+            "key": "34D7",
+            "msg": "98AFCD301D5EBCEBB980A6B70244AA16"
+          },
+          {
+            "tcId": 205,
+            "key": "1429",
+            "msg": "3EC528D0587B675A4686109B9BC94D27"
+          },
+          {
+            "tcId": 206,
+            "key": "E0B7",
+            "msg": "F36AE680C033FEBA944B53ABE826B7C5"
+          },
+          {
+            "tcId": 207,
+            "key": "EA5C",
+            "msg": "CF4F1B384B9B7A8A2EBF0ECC5AA7D7BD"
+          },
+          {
+            "tcId": 208,
+            "key": "2062",
+            "msg": "8FD7C7C1DF3EFF5726B5FB2AF9BA9720"
+          },
+          {
+            "tcId": 209,
+            "key": "AD08",
+            "msg": "6F2BA204B5FBF6C73214EA7421154E34"
+          },
+          {
+            "tcId": 210,
+            "key": "E0CD",
+            "msg": "901D1970FE7CAEE69C411EE89D3FD2DE"
+          },
+          {
+            "tcId": 211,
+            "key": "96CA",
+            "msg": "CC2CF7854D2ADF48B5D5B3FA139E2DB7"
+          },
+          {
+            "tcId": 212,
+            "key": "B366",
+            "msg": "05AF50A7DE94C1E137513F1867003DBA"
+          },
+          {
+            "tcId": 213,
+            "key": "1803",
+            "msg": "99B391B0D87EE419A14EEF340D239C9E"
+          },
+          {
+            "tcId": 214,
+            "key": "589B",
+            "msg": "8FE80177C8864A16DD7F5D733A774171"
+          },
+          {
+            "tcId": 215,
+            "key": "1F47",
+            "msg": "28C1D9C6F5C122DF544AD518A30946B1"
+          },
+          {
+            "tcId": 216,
+            "key": "5D87",
+            "msg": "4EB37D47839325B9128BFF89C26818C4"
+          },
+          {
+            "tcId": 217,
+            "key": "A693",
+            "msg": "D3BB1A8077F165A29304E5CCD65A2A0F"
+          },
+          {
+            "tcId": 218,
+            "key": "1B08",
+            "msg": "B68460D4775B3606D9B7E61556DC29F6"
+          },
+          {
+            "tcId": 219,
+            "key": "1BFF",
+            "msg": "EA03C2D90C2287C9261506FFFA61B8FD"
+          },
+          {
+            "tcId": 220,
+            "key": "03B3",
+            "msg": "C942B59F9FC0D0760D0CDEB93D272234"
+          },
+          {
+            "tcId": 221,
+            "key": "3FB9",
+            "msg": "E8D52FD27C02D566751F42A75CA849A9"
+          },
+          {
+            "tcId": 222,
+            "key": "3832",
+            "msg": "790E6FCBDFC65C237BB52E6C0C8EFA34"
+          },
+          {
+            "tcId": 223,
+            "key": "F01B",
+            "msg": "ED56D53C8782752565F15B75532B3CDD"
+          },
+          {
+            "tcId": 224,
+            "key": "D7CA",
+            "msg": "C066D380A8DBAB759ECBC66A385443F9"
+          },
+          {
+            "tcId": 225,
+            "key": "3B48",
+            "msg": "4D4AB97637CA0A9A057E20DF06B7BD3B"
+          }
+        ]
+      },
+      {
+        "tgId": 4,
+        "testType": "AFT",
+        "keyLen": 152,
+        "msgLen": 128,
+        "macLen": 40,
+        "tests": [
+          {
+            "tcId": 226,
+            "key": "F2852E5B3727B66B776F2A8964E501FA235167",
+            "msg": "63FC3E49D4E78970B6DC9A216F696110"
+          },
+          {
+            "tcId": 227,
+            "key": "83D3EB1850F2536901798657C888CB6ABA167B",
+            "msg": "69E1A89F006C92F7FD814AE0FC936491"
+          },
+          {
+            "tcId": 228,
+            "key": "06626AF2925E02297D605EF649263E754B8801",
+            "msg": "6013C787902230F352009B9C3C96AC92"
+          },
+          {
+            "tcId": 229,
+            "key": "C6F559FE1BEAC86EE4E364F10BDF556CD21D40",
+            "msg": "85810CC6FE3DF0AA437AAF775FE21BB2"
+          },
+          {
+            "tcId": 230,
+            "key": "FD775BD0029A40672255546E1C8291F7C1B492",
+            "msg": "E64DAC1C7BC43A9CAE4582E437C4E58A"
+          },
+          {
+            "tcId": 231,
+            "key": "D38FEB0745953C58E8215B015FAF2CA1B32676",
+            "msg": "7F9C4509DBC95B71B1ACEF0E336571B9"
+          },
+          {
+            "tcId": 232,
+            "key": "652DCDE6EB90ACEF3BF47FB40054576F0859E8",
+            "msg": "1E09020C3A0231C105EFD11A655499AB"
+          },
+          {
+            "tcId": 233,
+            "key": "1E570737B1A3E052A224C3BD99ED3534046E49",
+            "msg": "9DCED0C10BA05EF5B2E9D8EE7DD3F81C"
+          },
+          {
+            "tcId": 234,
+            "key": "0675C9451E068BF482B281B3FE62CB3E55A5B3",
+            "msg": "A2B1ED07ACE2AD4F5241381D4A4DEC89"
+          },
+          {
+            "tcId": 235,
+            "key": "47EFE73DC070B6A8D078E3D102CA0D422D58FA",
+            "msg": "A13B2266A4EBE77868739B2051C9B539"
+          },
+          {
+            "tcId": 236,
+            "key": "348C07B4788FAEFA99FD3C2FADC0BD213E06D2",
+            "msg": "5B031A42C788115BC426C4169F9CD8BD"
+          },
+          {
+            "tcId": 237,
+            "key": "A291481D6C035BF8E787F47DB12D1C414E5F1A",
+            "msg": "40FF834CCAF40C357DEFDACA4900CCD5"
+          },
+          {
+            "tcId": 238,
+            "key": "E67D02F379068D8CD7407E725CF6CF947F27D4",
+            "msg": "873F02469B6D116D9E8EE061594F681D"
+          },
+          {
+            "tcId": 239,
+            "key": "0EB85F8A8E5A21C87FA52784BE6DE21487A99C",
+            "msg": "4BDC1C9A54C300B95D99464174D97146"
+          },
+          {
+            "tcId": 240,
+            "key": "3F82D9CFC9529858F1048643136C88FC7E4F9E",
+            "msg": "3A7D6ABF37F62F7ACD148E000656EC1E"
+          },
+          {
+            "tcId": 241,
+            "key": "9AB91D78CB07AFE1AFBC666144BAF799DE4B69",
+            "msg": "6473ACC81A0AAF60C26FF5B3B611C835"
+          },
+          {
+            "tcId": 242,
+            "key": "71327B0EC98B9EAA1FA9B68728A054C15A3246",
+            "msg": "B0B7DE7EF1E337CF6C1C3E218C5C514C"
+          },
+          {
+            "tcId": 243,
+            "key": "976A7066D3D91ADCEE1728C62C33B0B1956233",
+            "msg": "D5D87C73752D5D22E7FDEEFA42D12112"
+          },
+          {
+            "tcId": 244,
+            "key": "420B7869BE4AC103A09C1686D40CE5C12A1E6E",
+            "msg": "46DF1AE5AACEAE03C5141E8D475ADD80"
+          },
+          {
+            "tcId": 245,
+            "key": "AAD3E6FDB6C86EE63746916AD81A2F4140FD45",
+            "msg": "E00AC5FE79938AF7C58FAF823987E321"
+          },
+          {
+            "tcId": 246,
+            "key": "5AAF4C1A1FFC5923EF23B37C1D9D0152C1875C",
+            "msg": "6DDAE7CCA0B8D24F5834388238A5E957"
+          },
+          {
+            "tcId": 247,
+            "key": "1CF10CEA911B8FCFB769C0C745DA9FCD0D3DD9",
+            "msg": "F5E37C79B904E8B6CFBABF57365EB87D"
+          },
+          {
+            "tcId": 248,
+            "key": "0FAA19A0CE3E637A0ECD871C39CC56407BD37C",
+            "msg": "CAB6B1F3C2D8BB775D618CC4C2B3F785"
+          },
+          {
+            "tcId": 249,
+            "key": "A758586500F9C99A39D6A157B919CFFE80D7F9",
+            "msg": "1B1F37EDA3DB3EAC1C098B579FCEE8FB"
+          },
+          {
+            "tcId": 250,
+            "key": "8F9581F71B059069ADC6AD9870DEA152BA3C72",
+            "msg": "9E2BC8B97A2E526EB77A1B1F9F247244"
+          },
+          {
+            "tcId": 251,
+            "key": "26CB1F54E065AC7B7D3CF68F11CC8F23C052A4",
+            "msg": "35AD36436CD6A1BBF0D9952C6F60CB21"
+          },
+          {
+            "tcId": 252,
+            "key": "4FACBCCC39B402819272CF1671A988674899A8",
+            "msg": "36B2E33F3FFB6605BA9FE877DDD197C2"
+          },
+          {
+            "tcId": 253,
+            "key": "AE90DDC8B9C0A60F50CFE92B1E7F947AE37EE5",
+            "msg": "3D29B21D2AE831A019C9ABBF0907474D"
+          },
+          {
+            "tcId": 254,
+            "key": "CF084852187168D29373E147E98F273FBEA38F",
+            "msg": "65DD59F4730F690FFF2E0BCDAA9F6E19"
+          },
+          {
+            "tcId": 255,
+            "key": "619A738A02D7C93BB63173369D8EC77F21B6D6",
+            "msg": "29DEA9634B33C6190CFDC57228382A3F"
+          },
+          {
+            "tcId": 256,
+            "key": "E4D181163EED75E6984E6FBA6ECF13D28A2ACD",
+            "msg": "F2CF7B8569D3F7E98A6199A70C0631DA"
+          },
+          {
+            "tcId": 257,
+            "key": "C4837A1A4878FA0FD53B0E326426F3F82202F9",
+            "msg": "08B3F2BA05D990347FD44B75DC7DCE4E"
+          },
+          {
+            "tcId": 258,
+            "key": "90C1FABE32A570BCD054D5836179EBE0D17616",
+            "msg": "237E4F9E5232D4AF6BEFE97FD0BBD6CF"
+          },
+          {
+            "tcId": 259,
+            "key": "FBDA2075AA91A34B40A7DAE89337A4BB753027",
+            "msg": "54C4ECD0F0A57E025ABED229E73F20EA"
+          },
+          {
+            "tcId": 260,
+            "key": "2FFB4F8153E41ACAA3D8D4E5AAA0D98F2F19C7",
+            "msg": "C365D614EAF15C7F4B3F2C77E630C0FD"
+          },
+          {
+            "tcId": 261,
+            "key": "613E9423D4A98AF28C02D2E20E4769331C5C13",
+            "msg": "2AFBA66B12E49CC38445B239E31DC770"
+          },
+          {
+            "tcId": 262,
+            "key": "2C68534358722159CE06901FDE8CDDC5B185BE",
+            "msg": "0C8C3B9F3858559F952F00013EEB4611"
+          },
+          {
+            "tcId": 263,
+            "key": "8CAE4FB156C78CD013D50CA8BD137851BEA011",
+            "msg": "7F9AFEB6B7DD38F6986F78FDD635F1EB"
+          },
+          {
+            "tcId": 264,
+            "key": "3B9C88C607AF4C1DC948F5C6C0E104E2DFCB5A",
+            "msg": "29066C03A5F36FD234C18253763788B3"
+          },
+          {
+            "tcId": 265,
+            "key": "13DEDB95B5521F7EB3593E455BF8D66CA3CDA8",
+            "msg": "F9EC57C991BCF8D0B5E262D1054DB182"
+          },
+          {
+            "tcId": 266,
+            "key": "26E6CD97DF6127027EDC2FFE2E0D4B2107264A",
+            "msg": "D11F3F3AA4B8B8C45E9632A93E06C068"
+          },
+          {
+            "tcId": 267,
+            "key": "D72A4023F4F1FF7524381FB36E39122AFA5142",
+            "msg": "2326E6DDB4663BCA04BBE56EE1DCC0B1"
+          },
+          {
+            "tcId": 268,
+            "key": "1105D7C25B749ABC00717CAF2C678315192B4E",
+            "msg": "34987565036A418DD8A3B4BFDCE5976E"
+          },
+          {
+            "tcId": 269,
+            "key": "919BDD7F4E8A90A51061EE5741B31DCD84CB7B",
+            "msg": "87B7B36C9AA51744CA84DAF2F5E26E3B"
+          },
+          {
+            "tcId": 270,
+            "key": "9A82E40AC266F62BE006E1104B3C463B7D2CE3",
+            "msg": "F7AEB756FF45D1D41A56FB4020F38238"
+          },
+          {
+            "tcId": 271,
+            "key": "4EAB0B6372A75A56A06970B765B6956149C597",
+            "msg": "846665A0F44C7F46022627379A9D4DE9"
+          },
+          {
+            "tcId": 272,
+            "key": "97F6DC0573FB8ADB31BEDCC553F90EC5B5C52B",
+            "msg": "AA5FD17EDE9A7F08A8B5967CE96B6012"
+          },
+          {
+            "tcId": 273,
+            "key": "B84FEE7C50C03D2CB305C03D8FA0D772D1F14D",
+            "msg": "350D30773B41AFFCDDB5688EC62CA804"
+          },
+          {
+            "tcId": 274,
+            "key": "77AC92F6CBC5B1F0443BC32F0D8FD19E13A16F",
+            "msg": "750A11B07AE1F7BC50B9371264B461ED"
+          },
+          {
+            "tcId": 275,
+            "key": "D602B9A752FA1411269CD390785989B4846366",
+            "msg": "C169FADA25266D2AF3E38C9BE9731D0A"
+          },
+          {
+            "tcId": 276,
+            "key": "80163AA560F06FAE7FDD085B52B2CB17113A54",
+            "msg": "76A23B34E6A15BB1E3F788A32A945802"
+          },
+          {
+            "tcId": 277,
+            "key": "90973DBEA8DFC039CD448D402DD303BFD5E2C2",
+            "msg": "CC0E45ACE4516384041049CD4535C2EA"
+          },
+          {
+            "tcId": 278,
+            "key": "7EF6642048674844AD8A921EFFCCCD124580B8",
+            "msg": "2A26445B39383CA070EA0BE8AA8DB02B"
+          },
+          {
+            "tcId": 279,
+            "key": "8B29CAAC59C1009B9AE71ED421DDE9977B015F",
+            "msg": "E23262D3BE1E8F81A1B7A0CFC2D1E90B"
+          },
+          {
+            "tcId": 280,
+            "key": "6B2BA8E20991608BD565A0D193594147C6DBDD",
+            "msg": "F349290F9CFC9130F96E9AD6AC85B6A9"
+          },
+          {
+            "tcId": 281,
+            "key": "814597F8A2CDCE35C11566B9713A086AA67C39",
+            "msg": "E1766C2F596EE8BC58A698A12E88FCCE"
+          },
+          {
+            "tcId": 282,
+            "key": "10C859A2974C8345573EE9DFEC4B3095094770",
+            "msg": "DFB37D53BA5BD23C6409FE75B147BC83"
+          },
+          {
+            "tcId": 283,
+            "key": "96A6B31B8F024EFD6D90E23D7071A9D33D217B",
+            "msg": "AACCFE3DD2C80D83B3B8A0A3635FF186"
+          },
+          {
+            "tcId": 284,
+            "key": "485C2ED2DC82F26C3201A2AFB20DFBF652A65A",
+            "msg": "C91E6D4BD4ED967A0CA50667ADB38899"
+          },
+          {
+            "tcId": 285,
+            "key": "E61E3042F8581D75CD5AD252F9B4CD4D42D4FF",
+            "msg": "5284F73FAABEE51AD2CB4B4A19CC5AA2"
+          },
+          {
+            "tcId": 286,
+            "key": "9AE121059C7E12FF92A4C1E6794F219B13598F",
+            "msg": "BF55AF60E8F8BDD65E8977888119343F"
+          },
+          {
+            "tcId": 287,
+            "key": "4AEB054CFF681DACB3B38FA449095F6C8E28CB",
+            "msg": "EAC909CD7BE58C827C20E9A82B939EFE"
+          },
+          {
+            "tcId": 288,
+            "key": "73F8CFFC91FF3C2686F174F55A1FF0F7E16915",
+            "msg": "441D8F342C83CEA83DC3D1D5C5B78D7B"
+          },
+          {
+            "tcId": 289,
+            "key": "8A38B45143E3822777CB9075BA01232BA2AFB8",
+            "msg": "096F48738A069C3F7721F03F3C0CF099"
+          },
+          {
+            "tcId": 290,
+            "key": "A343191FD5497D19FFBF75298BB4BD5BBB6801",
+            "msg": "99249D8833B09D8812C5A56D44AEEEFB"
+          },
+          {
+            "tcId": 291,
+            "key": "872458F9CABD4785649B4A1B08EFF751CAB97D",
+            "msg": "C0083C8FB4C1AB52125C305A4F1CF4EF"
+          },
+          {
+            "tcId": 292,
+            "key": "3E15D1954F33D19DD57C1B71D45553CA61C7CC",
+            "msg": "DE223DEC845D9B75CBDB41DFAD98614B"
+          },
+          {
+            "tcId": 293,
+            "key": "3209C969E3502B09B3DF41454B51582E38DCBF",
+            "msg": "EBCC7B51C7E14417F41C8429A2A87F1E"
+          },
+          {
+            "tcId": 294,
+            "key": "395F0576D8E8350E58623A91245D5065A8D806",
+            "msg": "6BCB4E216C0A165749C164A2811919AB"
+          },
+          {
+            "tcId": 295,
+            "key": "F358517DD833693828E548F042A1D5ABD9F42B",
+            "msg": "8A583326E9C7814D8A43F30AD1C85A2F"
+          },
+          {
+            "tcId": 296,
+            "key": "3BC580924F9CCCB388CF5ED052429430FD2D95",
+            "msg": "95324450A182B0064FBA6B00C029EE25"
+          },
+          {
+            "tcId": 297,
+            "key": "6D36F09B7A2A5C300705E66C55F01AA2E29988",
+            "msg": "F6BD1912E78154E13C24FBDB720A87B3"
+          },
+          {
+            "tcId": 298,
+            "key": "952CA8CBA80A040E546D66763A5F253DF62EB2",
+            "msg": "AD9FD998D33FD8077DDDDA4A8C5E5EC9"
+          },
+          {
+            "tcId": 299,
+            "key": "BEADE6382CFCE7A3E7ED60F506E450988A9C2F",
+            "msg": "BD8DCA83A6C1F347B6EAECA343C5498C"
+          },
+          {
+            "tcId": 300,
+            "key": "67B74F6629AAA969AB043BC9BAFB4520618AE5",
+            "msg": "029660C2338C7283DC3564392A54427A"
+          }
+        ]
+      },
+      {
+        "tgId": 5,
+        "testType": "AFT",
+        "keyLen": 512,
+        "msgLen": 128,
+        "macLen": 40,
+        "tests": [
+          {
+            "tcId": 301,
+            "key": "830AE08B8075AD8ECC948C61C8FA0C6957EC6816ABA155AA646936CF9EC299DC82A246FFD9196DDC6D828F50890FF26F5D36A6A484E045CA0ABAA4ED511A105B",
+            "msg": "7356D6EEFADEAB89388E98E30AA75DA2"
+          },
+          {
+            "tcId": 302,
+            "key": "5D58AE0A2D30E8DD4F716D236646D9ADA5D6C79C75FB4C3D381976AA607AA71208E8D1AF56371F10BB285F91293D5BEDB3C4DE056EC7C32E0705414D41A405AF",
+            "msg": "491FB26345EC0442760863635D5BBFDA"
+          },
+          {
+            "tcId": 303,
+            "key": "56F3674D63C11322F34EF1E858606205EE86122F72041B527C6B3FE4ACDB5F5BEE058ED729250FD9CB47F77DA3C2C35849327802FFBD8BE5CA9173729BDF69EB",
+            "msg": "C69CD4F3625145581864859DA2A4CF85"
+          },
+          {
+            "tcId": 304,
+            "key": "C16211E7F4CF0A841550C9C0D301C7BE852340B188415F54C84302F36C249AAC322F3637CC5D0051B6F305CDEBACF378890BF596C8232DF79ADE44F421C0771B",
+            "msg": "11046AC36D97E4B076969ED0FC1BF1FE"
+          },
+          {
+            "tcId": 305,
+            "key": "A2B10D69B81E3FDF4623562BF3E3A33BEB0193C215C67C6450B68AB5B29071DE7BB80424431DA8A1B90B9044DAACC320064B4541764F97A6D6518660C0F9EBD7",
+            "msg": "0DF7F6C9C7755B0D955099B5D098D4DE"
+          },
+          {
+            "tcId": 306,
+            "key": "84F1B729B497D565ECC6B8C0A9A568296B90A492855FB283E38970453616895750288694DDD5468801275CD61C8C6132F004CD1BEB5DC50B8694FFFA20D78C49",
+            "msg": "E46EA1FC2499A9D8C2ABCDB792940D9D"
+          },
+          {
+            "tcId": 307,
+            "key": "40EA27C7EA161E88218AEDCA8CF70375DD37ABF79E010D93F4F4BA9A5452AEEB9153E540708481C9BAAE8E9EF0DFD65330503BD552CED4262B974B6CE0D836AF",
+            "msg": "1EC30F8C915DEBE19895FCE827673D80"
+          },
+          {
+            "tcId": 308,
+            "key": "6E9A65DC5B5198CEE3FEACDFE1A922B85A31D2E5EE3011772DADDF9A7B851950DCEAC25077C4C5D8C4757449667D496C2A9BCBEC59C8D731EBDDA1212A5D4457",
+            "msg": "06DF874437EE4F9C8D8F2046D308EBEC"
+          },
+          {
+            "tcId": 309,
+            "key": "130473A3C3B851803012E133397B3D32554FBC613EF437C0365FCE844792763C41E7F12A36517AB8C72594FDA2B9E6F4D0F3884A290C4A042EAAF43E7018A6C4",
+            "msg": "FB66E6A0C6E28386264BACF5D3EDCA62"
+          },
+          {
+            "tcId": 310,
+            "key": "9D99FADC84E31625F614DCF883A2E5DB86173FF9476D5380CBFAB2E61B547DE7AAA364C640A8D34C1F7BBB2D79FD46E75AAB5779520FBC02603B84573035A0B2",
+            "msg": "0D26334EDAF8324C35748F03FB6A6419"
+          },
+          {
+            "tcId": 311,
+            "key": "0E73D4F619441607172A91C015184FDDBB2FC43E14259F52E4A83A70395CB38C8EC94CDF889F4B92B25EAC36125EB9E38783BF4019287F5B535D9665D7C965C4",
+            "msg": "CD73498797BF7911A91649638C8C9AB6"
+          },
+          {
+            "tcId": 312,
+            "key": "65BC5B83A7950EE3D51CD41ECB719B86460D921F72E000007BC4C2FCF4D77F901E97B12EDC8EE5DF20A9037EBC9F4D58F755086AD9792D16EB37118C742E8CD9",
+            "msg": "4D0036227DBC238995FA6130EA495A96"
+          },
+          {
+            "tcId": 313,
+            "key": "961AF24D2F0D7D3437A4DC8B712D03A78D93A71BCC6E97E3674D229FDC272DE55833672A3E3FEBD776E15540B4415A49AA9FEEE7A8B883FE44318D1BE5F4168C",
+            "msg": "305B15E6A9D0D90C260BC3C6BAC25F4F"
+          },
+          {
+            "tcId": 314,
+            "key": "2121101533B4099FD2476B311974DE20B1B54F9C6596C851E2CE975A31DDB0587C768CC48C03A2F8B54E2452B96B6FBED27CD65C750908ADE69C19D5ACBEEDF7",
+            "msg": "A819E88E8A6788A027784BF9AC1C8D91"
+          },
+          {
+            "tcId": 315,
+            "key": "01C89B2E0AD400DF2E57E5197E5DBAAB379BC3E1960EA068C652BEC2B9EA2203D7A0CF2506EFB12242E1554B16F9BFEBE87A75B77ACE25D0EEA21EBBF643C184",
+            "msg": "5E614A47AAAD326D2C25C08A9477F684"
+          },
+          {
+            "tcId": 316,
+            "key": "60598C18CD243E98CD2BE8DFC2D3E74BD069D8707E7AB42A290DD9BCBE5AD35684514D3AD6800CD163AFADAB73A489B4838C0DF9319F24AD946299DAF6A2477A",
+            "msg": "F9F33132F7497A7CDBC7CEB226DA1AD3"
+          },
+          {
+            "tcId": 317,
+            "key": "16FD68B835546331CADCE5E1C6AD5AD7D3099E45F97877876AA15843D7CFFF0D27BEC618F5E96D6CF558AFAA755A53930739E28EA4D437DC155DA2A2C059897A",
+            "msg": "CDAF5E3733EDF0B23AC461138F97AC78"
+          },
+          {
+            "tcId": 318,
+            "key": "3DEBC38DB0549EB1CB2B4FB4035BB956A82984EE1DA709BF4C1F319D8306871E6AF3ABB6A23AA0AC3A690D27FE6CECA0DE6DC8EF8EED12E8A266C85100D81AD8",
+            "msg": "274C4C651E3E20CD6E40E9C1676F831E"
+          },
+          {
+            "tcId": 319,
+            "key": "9B71615B510EAFFFC63190F00724FA95FD4746EBDCB9A1A453A92C25CD2103E2E9BBF247D8D146D0A39CD6144E29DE85D418057ECE32B18DB8392C98DF539C9D",
+            "msg": "8AB8C01C73AAD63459AF4BE47AEB49F6"
+          },
+          {
+            "tcId": 320,
+            "key": "EEE2094D894BFE9D437C7ED1BC9F29E295AAB1BCE2AB7489699750841A71186A0CCE32D75A365560B6749DD07D2F85C235AFAC6CD54FBD21B96384DFABB512E1",
+            "msg": "AEFA92F25CF3C5ED71B1953B546A42EF"
+          },
+          {
+            "tcId": 321,
+            "key": "74326B6197234C5150398EE4D977D2CDACC38BA4F50C29F939F11A00AC53366849782AD053CBCD889B07191ED456551F50263E59D863469F02BF2D65ABE7596A",
+            "msg": "FCF6110DF4DB1C63054F79EB22701ACE"
+          },
+          {
+            "tcId": 322,
+            "key": "4CE3F876710339DDA5DE5683CA5064FF6B97BE3C1FABE86F4F5A3848360819E8A728A0C9A7439DF628DBE4BCAF7BDBC74793F1968E380EEDADA0BA0FF962B98A",
+            "msg": "37EBBC39D4402B818EFF5DE97DA591E5"
+          },
+          {
+            "tcId": 323,
+            "key": "F840AE1DFE893F769D4BB608B8F20154A853CB3959F0514CB3A3B77AC509C134A1109251796059BF87380A423F931EFD571DBCE7D3814C8B92287D5749C7AFA8",
+            "msg": "F34EDF1AF0F2E07B45DD57B2269EE03B"
+          },
+          {
+            "tcId": 324,
+            "key": "CA91869EC84FE506B942C62EACF361BA522D65F539C908B2DBF3972287255C5493DC2E84E27F17574B8BCE2E8336F42ACCCD354DE1B867F816691DDFA7319187",
+            "msg": "F255510525D05A0092A94610F08C258B"
+          },
+          {
+            "tcId": 325,
+            "key": "46D47002529A8E45639479B117A5E47D987343267380072F7297E02290A6B62C5CB916E744DF5EFD8909C8842A4E7E6BD5CC0BA889527B5CBBB4E1B098184E2B",
+            "msg": "B96296487DFBDBE78AB33B64F25CF5C2"
+          },
+          {
+            "tcId": 326,
+            "key": "4F229875B65739537AD5BA4457B9F2730A91AE7A893A27E5751F75E5062E655E8D61185F01335D3CAA0F39161237FA0DEFD10D636E099F67819AA91394E463B4",
+            "msg": "8D2F86FFEF2DC2DB9809CADFFE0F7C3E"
+          },
+          {
+            "tcId": 327,
+            "key": "78DD54B4B0B252AE1BCBF60914EA740F7C5AA9C5553B2FC1A7CD7B5630474C172EC31AD9EB186301C3957C3D6085F2C6A6D8D7C358CBF093B73FCC14B4164497",
+            "msg": "58FD40400D9EDE244A4FA78F77419C2C"
+          },
+          {
+            "tcId": 328,
+            "key": "FCEFECA2FBAC9C471EAF6253EA235D681D4846B7DA00A5DF652EB26DCA17B3285A03DE9BB53A52C1695E3974FE239356DD3583171505B9DA8AA1DC4D6D06A658",
+            "msg": "7BB28339CE1EBE65A36F6B6B64EDAAB6"
+          },
+          {
+            "tcId": 329,
+            "key": "4D444E10F2AEA199A85A2128C62A61F3D6A2EDA763216C0EB65FA9AC10289A782C3414537655CC971538C08AB60734B5054A3FA1752C8C6198C465BF46B7D268",
+            "msg": "AA6ED49F1EA750D40C58391707FDFF58"
+          },
+          {
+            "tcId": 330,
+            "key": "96B78571E0CA7F5844E6081D0C7A10F2EB727B472FF387FBEB79A9EF29EE9F1F3C5AB126FC323BB93BD15958C5BD1E958AEB227875573848DD81A31C83BA2A9E",
+            "msg": "3EF3A265D0C9D2A4EC9AC134D9551BDE"
+          },
+          {
+            "tcId": 331,
+            "key": "EDD145905056BAB1CD6EEA0B7B97DDD26D517B7613B62AE7279CDA00090B57CAF8C7C773DCB5C21DB371C93D00F7B368E066C86188EACAB544214512746E2297",
+            "msg": "A23D5D131318CF178EDF5DBC09BEF203"
+          },
+          {
+            "tcId": 332,
+            "key": "C216CE40E589FE143AEAC5F83477A3E64E03DACAE29501E790D7DC6816B4711DC1BD430EA1647F811F57D0801A910ED1C11C06E192F91B05246FA5640A1D6C0B",
+            "msg": "A755753A7E330037F55906517075385E"
+          },
+          {
+            "tcId": 333,
+            "key": "DE8BEC47515E3816067E6DCE0E62A752A1AB6D1021774D39A1F0D5E86A6E4287F9E1032F9E6E9581A3CB00FF33DC0462E9B8EC6599FEE3E1BB8AB5E7E0DBE206",
+            "msg": "1492AA89B1FA3B148D014D7E23120502"
+          },
+          {
+            "tcId": 334,
+            "key": "B5F00CABF672B8AFDDA6F08393D7D92BBB746CC26645DC14F18CAE1098FE02F2E342037ADFE2EB42340D47B9A9036DDAF9B58711EDEBD5B96BEB8EE2B4ECBD24",
+            "msg": "D572A601DD9412E12BE91D880FFB0893"
+          },
+          {
+            "tcId": 335,
+            "key": "58FAA679D6FE133BB49B02AD7BA7EBEB6EA57438658AE6CFCC345AE8B6259E1762C5C9A4406360D2ACF02F58467C94F511A5C153FA6170229FE7DC36D1BF2BE3",
+            "msg": "5E748AA57176AF609A29EF9CB5E3FFAA"
+          },
+          {
+            "tcId": 336,
+            "key": "3118D3538D2780B6F423A931A47C7CC8A173B489442EA1AC67019C475725FA9C99A84443538CA6CCC92225C65C8EC17175A8DA4AFD093F765B27DF33F449D91A",
+            "msg": "183FDEF624AF27C0D42D50B54F607096"
+          },
+          {
+            "tcId": 337,
+            "key": "091457A1A81DFED5D3C241A496560492E085FA91D457B2DCCA34A100BF42E7FED79E6FC2084F065648C882138D6760943C3F56B347AF1B79D75FF0AF73479E55",
+            "msg": "5BB6F42B60B09D2BF23C8013CC49D77C"
+          },
+          {
+            "tcId": 338,
+            "key": "D357A94FA719226F83DBD410024341050D3106CC9489DB09231F7559755D93BB25591F6AFB29395C8C3E0C0774FCA526FDE2AD85015FEDF2C1A579E176AEAE8F",
+            "msg": "56BFA9822C6AD886B0A46C50F2463A94"
+          },
+          {
+            "tcId": 339,
+            "key": "DE58AA7EDE3DB73A14880F4B83DEF007C17022EBB44DDFD6CF551C804033D04851CB0FECA04445432C3EE2A24ECEC4F6BF1B7E8F4C21EFED454BC32481E379F6",
+            "msg": "21408A95C377FF6ED93EDA4BBE03D024"
+          },
+          {
+            "tcId": 340,
+            "key": "D10760686B58EE32FC2DBE302B248377FDF3B1864C3913E5AEB723462441B3D72C222F4E90828D4DE9150DF358392CB8D3FFE72DB418370155F0EAF8A6D7480A",
+            "msg": "9C62C9D4E0728B75958DDAA579DDEB15"
+          },
+          {
+            "tcId": 341,
+            "key": "228272933A5050692621A65F35182BFB329C9EE8716027A29D41B19F86F131E9C3E4E14394857FEDFDB2E3590C2404B6F3C23206D182F903C50718BA3D4D1C0A",
+            "msg": "4E144083316987C304543B40D5E7BF14"
+          },
+          {
+            "tcId": 342,
+            "key": "2698E2708AF0411FBCB4E8B9A4DB83C5A92A668DAEC3FD0DA88DBE78BC829012691EE87AAB9EB634F710ED5116F76386FE153F561060480E138E0E41253930A9",
+            "msg": "CE6A612A53094ED5C88558BCC5FEF62A"
+          },
+          {
+            "tcId": 343,
+            "key": "472C56820506F541653A7359773EC68A7C1C3C2A796D27A9847CE7B61E1ED62F45D994567C07BA5378CF8D8D702601B6B1C4D682983AF8DC82D28ABF596D10F2",
+            "msg": "164D551F65C7A185CEFBA5B8AC68F51E"
+          },
+          {
+            "tcId": 344,
+            "key": "9C1C97E5CB5DDD83CAC198A7377A0BD43297615558BED0C57CDC2DDC15C6FAFEABDFF9A6C924CA630DE5682BDCF5CD95F0EDE444C63EDB96C2600996C0EA6833",
+            "msg": "02B78DAA5A1678F16814D81D4AC792FB"
+          },
+          {
+            "tcId": 345,
+            "key": "0C176A6A710DFBE07D1C570054FDEB8095F1927F1F6A250850C9F697CFA9F5EC6F23CC554A7040DAA3B6428F8209BFEDD2BC429EA6E760D86CB4DAB2E79F97BF",
+            "msg": "482397D7697AB9F6F63AED99A8BA773D"
+          },
+          {
+            "tcId": 346,
+            "key": "6FB43872DA337B700B45E5D11DF9915ADAFE865123832DF2F3F94996FF1946E0F9A90EB3BEA3AB3002E3012102EFF3566F52E0E841BD7B7D67F61686637D540C",
+            "msg": "A9B0C07DF310FBF90DD853C7A260C4D2"
+          },
+          {
+            "tcId": 347,
+            "key": "3823B4E440B8619FF7B08896D8BB5A8BA93FC61DB82C9C3DEF354F29C324A822751CAF7C4C205AE4D225F3168EB9B0093299DAE21CA829E89F00049A9D33C5EA",
+            "msg": "1EB46CC77A51C97BBA09D5B639F9320C"
+          },
+          {
+            "tcId": 348,
+            "key": "FE969083D96AB4EAAD1A85A206AEA41DD44A6DC5A4D5FFC15B8F6E5E71DD5D90B5B31CF6D3AC61B773423DD8CFAEFE762C3D2B473C816C1A8D64303A22282CEA",
+            "msg": "4AAE9E67D90E536F08CDCB4DEAACCCB8"
+          },
+          {
+            "tcId": 349,
+            "key": "84FD3F6256C8C04A218CE87CB9C1B6B6A12ED497B6D32CABA3CF7A604EB9E90DE999E49E4B124986DD687B41E7325A10EAC0CB59196CA1699B8A749F4E9EB39D",
+            "msg": "B145B2A7153B8F8A958972116F0C8207"
+          },
+          {
+            "tcId": 350,
+            "key": "C65480427234BD2166E23094760177B2E36062F536AE29B015EF379287DC02733BD2AAC15C231AEF605E00FAB90D92A892E136AE51CDA17015DD658C231E8067",
+            "msg": "8C6B2752D009F7A270FF5959ACDE91CF"
+          },
+          {
+            "tcId": 351,
+            "key": "66B19538AB3EEE22B5EB43E0437054036144AEB6C1B2377FA28BF2030F16BE061952E332DC238A311FB52725C08980FC42E04F32E8E80E49E3715B35700ED7DD",
+            "msg": "8269F374ED40E7F50A3ED13873E1CFBC"
+          },
+          {
+            "tcId": 352,
+            "key": "7F2389440A8555346449ACCCBEDD9465D867D09BD9462C82589EC4A74660BFBC5032BBC928A3F197248AD776A9E3A20A6358FEF6B8DCAF3BECB1E7FB1D79BE3C",
+            "msg": "C788B09149268B0346BC119D37FB8C7D"
+          },
+          {
+            "tcId": 353,
+            "key": "C70F346FE5C40CC82D4217FBFA6A739F0EEC39C8FF10AD09BDF19C65F667EFA7EB45D4ACB7F270CBE4C370D4355A25FB530276E1C1DDB89BBBEB61568FF18B9D",
+            "msg": "911CC35F262C9D345EED0B0FF219F173"
+          },
+          {
+            "tcId": 354,
+            "key": "97A3356C145CFBE92B1480A4273C2EEE71A5169EF114EDF19D89761568F0A90452F7903092F41A204A60450E0E9301EF489B7D7338BAA928D3C7612F7C464A70",
+            "msg": "09AC6F31211DF5787932328DCA3468B2"
+          },
+          {
+            "tcId": 355,
+            "key": "6932AAF092B5EEA5CFB8763BA0CB439E097E53BE8445F9F284844B7CDEDDA523DB5ADA3D00C308EFC483EC119E17E17AC9540B3EBAEA644470ABB49BA4B229BB",
+            "msg": "9B06FEA617AC935C2E4D752E99960F09"
+          },
+          {
+            "tcId": 356,
+            "key": "51372B81B11A22DCB07CC1B8DD5C4AB849FB6AF42C9F8F23D7BA84FB55DE93ADF0EFE9BFE7D6D40586EAB85AB6B309FB67EE7E8A99287D3AF71357851FA8C669",
+            "msg": "9A91BD19CA93DC4F776B98A0F7EC378D"
+          },
+          {
+            "tcId": 357,
+            "key": "7743218AAB06382F3F2BD5CB4392E7D1C506696BFA810915482F5AB499E121B5F48EEEE3892A559A62B73297900BD058098ABA45D5C07D6526AAB400A09BE772",
+            "msg": "30F7BDB08E7AC2A1FD55F0D82420CCEE"
+          },
+          {
+            "tcId": 358,
+            "key": "9C9CB80ADFA724687F52C349EBC13AF42DF1673619C5A412458F1251F30F07C40428BA392D2E2C916DC9D6E77498C90D73102C029AC14657D6E6380C38923155",
+            "msg": "2A37AF1043625239FB221D1DFBD6BD1D"
+          },
+          {
+            "tcId": 359,
+            "key": "0E7E9A2476253C00D1D9A3DE0C5DC0B35D9814F0CD6BD7E23028DA8E85143CCA15CCCC83144090752F01F377F62BE2B178528F089D06E4DA02AF64069A6C02C5",
+            "msg": "603F3487A013FBB9D7E9CC7ACCD3F117"
+          },
+          {
+            "tcId": 360,
+            "key": "F1D5E3C23BA6C78F9447AA7426AED073253731486F3501413D1067BE2A5975CFC02E514201F9693552F6D32EC2AA086FA3C04BEF764A824217E4BBA4DB1A8668",
+            "msg": "0309879E2D806CF807E496F27AA68A53"
+          },
+          {
+            "tcId": 361,
+            "key": "0A18FCE1AA71D88F89640FE7CB39B3E093561EC0E7281BEDF18CFE46A6944DABBB7922025121EA445F2BDEAA38D5CB17F119CF3766A6FE2D1A4D0394B637BB67",
+            "msg": "259F44B58F4BE33E19AA733BEABBEA84"
+          },
+          {
+            "tcId": 362,
+            "key": "E36A7702B9E3A1C7321AF1125A23E4275ADFBDD97CBA855D9F1D850F0A075CAC3CB9160CDE7C8DA0CBB3CBC6B418E178200E48A768D19EFA76557F47836C7AFD",
+            "msg": "E3F13611415679C3F31104404BBB94E5"
+          },
+          {
+            "tcId": 363,
+            "key": "74DC5C05CF8A03E1F3F48EAA5180B041AA27D8849DF87D8A36639A8D6253FDEF62F6CF3CC555D33ED9AF4B6B841C361071EE492B2816FF4418225BA3C8DC903F",
+            "msg": "66541153EDFAE6D376E48CF52D39B408"
+          },
+          {
+            "tcId": 364,
+            "key": "1D5A0980B462873FD4DF22585FB41017901102FADF7FC6CEBC29575493556F494E1C0684DD5C7F00B5A437BD169969AA0CCF9EBEDFE21724DEE6DD33623CE40C",
+            "msg": "FDBAC4B8F648DC4053B83B484F9593FB"
+          },
+          {
+            "tcId": 365,
+            "key": "5301D74FA84CD9F9A999AE5270033B100693C60E40D005F24220040908D7C523187614022C4F52B1411DE6A1EE0188DF38DA540069941F6703049FFAFE1B168F",
+            "msg": "EB33DD169CFBBF67DB2FD27D3B467BA9"
+          },
+          {
+            "tcId": 366,
+            "key": "4A03E003D5A0DA6F9DEE9706FCBDBA10483E3701A5E3954E3AD3600F7DDA02D9F2A4C7483FFCE899F392D69820AC70DCEB07FC8C4CD94C114C2000BD3ACD0273",
+            "msg": "61F1EDF203D2729D7BDB89218973E7A8"
+          },
+          {
+            "tcId": 367,
+            "key": "1EAAE4E3A3E25DFABC0029018E5E7A1C4AE2DF0093AEE581389CC5D1E5179559A4EE9683122BFDE124B316E542A50BBC47FDC27C3A896BB52DF70FA1C481ADD2",
+            "msg": "02241F6700C06D6EF77617AAE7E1E47C"
+          },
+          {
+            "tcId": 368,
+            "key": "DE1DB5729A56DB2D7EB209AAAF28A1736036663DD2AFDBEAE873EBAD58A13BA0C1392348D44B594F0D092A8D2591829CAC110AD6FB145D02668ABEF4A5E936A8",
+            "msg": "E8D0367BB23BA80FB0FEB8689B5B5224"
+          },
+          {
+            "tcId": 369,
+            "key": "D1C61A040B7C3A49AEDEF23BC95DEB8F5788F39B2FC133FBE8BBDCBF666B9F469898E1CCEE2300C24E0FD1B5A4423ABC06E960A61C92FCB29309270B3E895880",
+            "msg": "CFB2DF0F82A8597FE04783F407D5FA64"
+          },
+          {
+            "tcId": 370,
+            "key": "E18D117DA60346BB416B2B750066010928DC75A52581C54839BDF165A01465089BD4DB5996AB7A7E0D7F17C82AF26161EF11A27314EDC0BCE6A7292181543A59",
+            "msg": "0868599602E1B8A36F89708E0E0B51EB"
+          },
+          {
+            "tcId": 371,
+            "key": "B8269D29417A315E6AE16CEA74FD4D44090E9B1EE72596B52FC034E5428D2655404344B3C775728354C1A01B892798F78DD759F6B45B03FDDA659EB3FD861F0A",
+            "msg": "E836D97A85D3F8D7C2A895CCD05E1BBF"
+          },
+          {
+            "tcId": 372,
+            "key": "79A0204D9F220193479134DE9267448D8233C64E1C5B0DD48A6A92974F6F8EBD2A5ACC1545CD804B7982D420444D2C1319D18FA868A1C546B5651A206D7B161C",
+            "msg": "852A66781270C2C18182812019AB766B"
+          },
+          {
+            "tcId": 373,
+            "key": "F92BC72A9A6EFE3C56A1FC515621C3E7F43AA438EF3CEE79CAAB7A347E27B976C27787432DEDF749D0E50BFDC0121A1E7A37A9100501FC806EF51792B7CE2262",
+            "msg": "A497F6CF0F46486EA446B981578E3F84"
+          },
+          {
+            "tcId": 374,
+            "key": "41E3E6F6F08E4203774072528BC6F1099A82907308ED2B49B1C092CC8F36AB6A91891D0E7471E5ABEA283484D4A3FBE8E0DBF334CFE28C5FF15A67D53A2C2CAB",
+            "msg": "1A762047588AF23A55144CBC88655003"
+          },
+          {
+            "tcId": 375,
+            "key": "7FAD145325ACC9B9BA5EB36A5F92F9118202B6ECF9730383A506950A7736DC1B6175195D8ED60F1DD4BA84548452C17CD385D5DDB14A7E990AA22A34CA9D733E",
+            "msg": "66E8C0115000ACBBE7C80E9F0195E909"
+          }
+        ]
+      },
+      {
+        "tgId": 6,
+        "testType": "AFT",
+        "keyLen": 512,
+        "msgLen": 128,
+        "macLen": 48,
+        "tests": [
+          {
+            "tcId": 376,
+            "key": "3305A64CAD751CDEE95D6832466CBBA9B18589C1BCC87D72D153C15D10E7DA12DF04418AD87B89013A6372AC06152C1D4BF38EF1982F83748F7EC8377757415B",
+            "msg": "7879A7AA2E9443D95CEEE2A61785507F"
+          },
+          {
+            "tcId": 377,
+            "key": "690793F3B4127625FFDED786BB66274A31C21CC935C3503E93A3FA1FDD83DC1CB848820C3E484F015A028FC6ECDA1E756FB1D249F8CD3DEB14D23B0413D0278F",
+            "msg": "E490CCCC76AD477B7B50D34F6DDC15F4"
+          },
+          {
+            "tcId": 378,
+            "key": "96CCF9BBE270B08810CCE05AFE9C0B41BE81A078BB91B4D997D5A57F6A9D2BD1B46671466EEA2C65BEB11863AB7C635CDFC13378EE587E081367A60FD66E3A28",
+            "msg": "C446F686AED1E58DB76056954C1CA418"
+          },
+          {
+            "tcId": 379,
+            "key": "97E36CA200BE7256E60242C9D4C4B1A994D095D7AD7E44BCCC57AE8561955AD74E697E090ACFAF3ECB1BA9F1B07BA31189E2BF839EDD6815ED7671AFFC3D718F",
+            "msg": "A9F36E2AACF3AF4C6203812A29C68EFF"
+          },
+          {
+            "tcId": 380,
+            "key": "5FF1E99DA8F68A68F6484AB433386D3F75501B8B4B58E4136F22881B6348DFBB75019AB37C53C458C8D0B478F68F4F6BF47AAC86C6BC4FF9A565F16D4F5338AB",
+            "msg": "3D3D845C94E31F2CE3D91663A60A464E"
+          },
+          {
+            "tcId": 381,
+            "key": "0C54F936A30A0C841A19D1FE03F973474575BF7BB93BABB9EBE521D89E6446238DCFD777BBFDFC0106BD458962B5ED65E905D6D212CE96E4CCB4339F0C13415F",
+            "msg": "428B030ADDA9C907441066728CEF41C6"
+          },
+          {
+            "tcId": 382,
+            "key": "AD69839C5332961684A8A6192D82593CE725C963AEE677A4E5A4593DE7463A6716509A94FBB5903AC9D7287F4316DAFA774DFFEC9FA2FF47FD7F51E46D5FEDAD",
+            "msg": "71652942089E3135A13A66B9B1388CAE"
+          },
+          {
+            "tcId": 383,
+            "key": "44739795951A11D8BAD7F3FAD23459F12C8239A0971A95E7B9B05D01FE2A247A88AAB5EEA89E99060F0C0C03E8F3459077B89DE152ED63FA613F332E2020E5C7",
+            "msg": "CC6F75F16D003A943376B972BDD765B9"
+          },
+          {
+            "tcId": 384,
+            "key": "F62886B1C456168B7995CFEA716C418A82B3BC171E0291CC01DBE32912FD77A3BE9092D247036F399458A338A45E162B7DEE8EF559324489FACDB43390AAE41C",
+            "msg": "7C7C39A0A6D85D3B4753DC917DB673B3"
+          },
+          {
+            "tcId": 385,
+            "key": "02466B0C58A939D138DAAAC0424BA385F571EF767AD131086ADD8B0B6620147EE7BB554E1A8761AE276AA7CE48AEE7604F2A57F0130BAF58958594BA57603BDF",
+            "msg": "BFB1EFD59D3F430AD543C336DB9523F3"
+          },
+          {
+            "tcId": 386,
+            "key": "BAA60438E3EEB1B13A4877A73885855FA5EB623D34F6C6F332F9F42DCF9B87CE9A026ECB99633619645926B56A5E3984FA7151DDA64F9629729D9C1A07160A60",
+            "msg": "B7272430EF762C3F8FCDA2B555D8B593"
+          },
+          {
+            "tcId": 387,
+            "key": "08D56F0DCB9EB7D111596D30EECBB0B16112F39B497F44F8D2AE162E3F2FC1DB7B33850933BE9E4E9DFECE3F4561C10DCE33B88F5B54EB8DDEA3CB69ED55D0DF",
+            "msg": "5B01B54EFB4D8E13F6A0F389CD80D8B7"
+          },
+          {
+            "tcId": 388,
+            "key": "E6777FB0F8BA51E15BE9300358E7CF4D11E3EA6E7A11E715276116AAF03C167A987A76ACED2F2B2C438FBFC815AE4F2E6C4178B29F03975D246DDF23E795711A",
+            "msg": "42D515ADE00087ED17C1503C9C246B1D"
+          },
+          {
+            "tcId": 389,
+            "key": "7C20737070D789D18158D654DAB21D26F315A480650F7650A6F3EF9ED73B3261F5B7008B2C996DC8E1DC8DF08B44944FFB93D00D9177FA7CACA00ADDA06AAD0F",
+            "msg": "2460767E793A9EA05F5CBC94DB308142"
+          },
+          {
+            "tcId": 390,
+            "key": "DF7D22E4F2FF5676C27BBE5267FE919D0822FA0FE0240E999D8FE1A864267520929B2DB1BDEDE9D5EBCE3CD46A47594633F2218B17B9880C2EE0D2DCD44145FF",
+            "msg": "DADCEE17C5D0AAC9648B8EFB15F727EC"
+          },
+          {
+            "tcId": 391,
+            "key": "16D7D918DB5EAE2F3495757F7F2FC36F387A0DCB8323501A6A8A8BE3859082C1A085D8B2BB973C0D5FC1707FD0FDE71DC3F051B99A49D5EF8994B0176B0DF1A5",
+            "msg": "00933E4D2EB5935D92E06AC036D9A94F"
+          },
+          {
+            "tcId": 392,
+            "key": "7E7786EE0815704058E298B171879B58D5209D1B6C92114E34ED290150BACEC1F4D4A7EA30017E640B6E7BE4E5F955875845D88E15027B2562B6EF86797BAFD3",
+            "msg": "C6EF01E8D396C5675D56F51DC0540EA7"
+          },
+          {
+            "tcId": 393,
+            "key": "316372ED3AA6B564BFBF4A4CD21CCBA8B3FB36C15F4E7CA28C2956D4E3AB2A47C95BBCED4AFE97E4F127DB32882005C976B36D199273F4EE50BDEBD18BA78C9B",
+            "msg": "AE30C78DB5E593DB72A2CFC1EE4AA998"
+          },
+          {
+            "tcId": 394,
+            "key": "8210DEADE640ADF968EF531A9C11263769518BC0FD1D6D1105EAC67B1F8D73CBE330E8E7605070DCBDDDF92B2305AB4763BAD003898BBF6AF83FFE571D6AD662",
+            "msg": "51FCDFDBBE1100C081E89B4390BDA88F"
+          },
+          {
+            "tcId": 395,
+            "key": "AE326AAF016BED217A6E5810149578D11E376968B05F3ACC31DC536E9867662A21B04D47B5CF249500C17961162E62DAA5434D6DEA8462FB791F7F2600EDE2F4",
+            "msg": "2C97101A2649FC868637ABE507BF62B2"
+          },
+          {
+            "tcId": 396,
+            "key": "5336ADB847828CC05D84E3714061DEA8BCFC19741E0B45E0FAAB4EB5C6C7EFB0198D30421ADB8F3E9C26C1CD186E9B5C32570485CE26248478C894D6C128E71F",
+            "msg": "242708B6873873EF0D7C913C951D0D97"
+          },
+          {
+            "tcId": 397,
+            "key": "4F8653AE38F85AD494C2C3C0E72661B61EC53279A00F5C4D7AA4F90D8301A552D908AE83707C77C855D3195E14C1B8C2E5658B6EF223C5FD0AC32AAFC1B0A8AE",
+            "msg": "96DC330902C64713C9D7E289C9A04ABC"
+          },
+          {
+            "tcId": 398,
+            "key": "5ED2DD2711749A86DE5A29C3D1B152EB282363D721F6005D28146F4B310862D9A7F3B85CF7721F62C69B4F9B35029B6AEBE739C3817ECA172ED49930D760222D",
+            "msg": "FFEE7A589AD8DA87FB9FB53061A7D6D7"
+          },
+          {
+            "tcId": 399,
+            "key": "43DD5B8023DD9B56F527B728C5919C1EF3B2578F80D3BA2339E483AAA6C510E2464526160272980C78B99EF9A9C1904C9B05AFBCF288176AF35DF3BBE9131094",
+            "msg": "B4E839CA3E8587ACC8F15EE9AB0F42D2"
+          },
+          {
+            "tcId": 400,
+            "key": "0EEA89E9474F92F863E53580F41CA92B6CDDC17E8750B8B1674277C7D897F5B7ABE954D6F85A6A15ED1807C72162A60659ABCEF4BAA18462C08243B2657F116A",
+            "msg": "536E90B60E6FFB648E91D237FE03F59A"
+          },
+          {
+            "tcId": 401,
+            "key": "88C915E98204A6F488DCE588ABF40532361A2C8D4612C33B9BE3765387766D0BF70200CD01A078A2BAF79A0BEAADD0BD3575D895D12B2288971789FBA761EB23",
+            "msg": "752DB18848AF12EC47E1EE6127C63420"
+          },
+          {
+            "tcId": 402,
+            "key": "81A1BA332D4B6C0C230125F9263D4BAEF7FA75D32C77CAC9DCAC5B11FC091C76B07FC5974C1404B12D76B11F1B906E862B5076DFC8061F4739064831FC9982D4",
+            "msg": "3B594A395451B3C22A1A546CC352569F"
+          },
+          {
+            "tcId": 403,
+            "key": "64097B85053D5268F5B211141F15C675CF7FC3663745819C944DE5BB3994AC88699E5C4AE14A7DA40C63811DA1CBF06CE1E4AF60841CBDC1535DCF83E15FCB77",
+            "msg": "E1A52B3B9B0436A28725AA1BB4FCB21E"
+          },
+          {
+            "tcId": 404,
+            "key": "21919F4C2A98E5C8B603AD4F482CCC7BA7C824331DE711319BC764985085627DA18BC0FD79D45D89D495FB922FE4C0D5FACB6C00B3AE6CE28E18208722BA5DB2",
+            "msg": "65A0771480FD48F971617BE69E350DE1"
+          },
+          {
+            "tcId": 405,
+            "key": "8B0012658B403655194874A3DF5C7A696476E37EF2B8142C361BE89FF7DF8E2909FA7DE8E47B9395F71E778F8B952EC4CEE7C130ED429F08E8F7E11FD62E7491",
+            "msg": "B1792BBF7B5E5E12DB2EF0E1A2C339A5"
+          },
+          {
+            "tcId": 406,
+            "key": "02545C7B5C36996027BD65C93BCAE9EDD4D51502DF652F02BEA9A484E489B9DFE9BAF0EADBB7C9E5711DDCA020D3144AD8D19C1493D56BF33F3732261B0B7D03",
+            "msg": "D06F3E76701E146BA554ED135BB4ECB0"
+          },
+          {
+            "tcId": 407,
+            "key": "78E53BEF347E6CE55BD863C66DE774D5D4866731859C30A3160094E91721D359C85158B5CE180D966F14DEF8F9C55123D36E56DB02FC5BD19A09074115DBF939",
+            "msg": "2F3E8E41C755AE518EE9573507A8330A"
+          },
+          {
+            "tcId": 408,
+            "key": "912E890CBBF627D349AC2171D5F414A4F6D8B27603DD2B7CCBE9C8BE8FB9C6C9CBF6E7AA68114DC297C7A6FBE96252CB91C80432C4093C79D8F11E09B9BF9AF0",
+            "msg": "1021C3C9CF6C966802D2384A6CFA3D45"
+          },
+          {
+            "tcId": 409,
+            "key": "82DC3DF70BAA737A55186FB8ACB35450CE076B614409DDEFCAECEDFAD402546EFFAC33C2B3CB5D8EC3D07320A517AD136B70E49EB40056B69FF1C36839374BC9",
+            "msg": "23628C6A43B54DC025719CE1494600A9"
+          },
+          {
+            "tcId": 410,
+            "key": "BAD66F682F2638A9236904E13C1092119D111032587DBDB9360668826980585B012640E81FD84389ED46B0AC79DAF4DA756FAE1352C3C8FABF8F4172AF25F0D4",
+            "msg": "78BAED33EEC0A3EE72F3052EBBF6C1A2"
+          },
+          {
+            "tcId": 411,
+            "key": "D5475C0F54208F2D124CDB5C317548E8968E2A3CD41953D0B7710BE98A4906A46FE764C20A4BE61CDB4CF0B87FCF5DE471086408CB2DB63A0A675B3B3C6B7903",
+            "msg": "F19E77D765AF18EBD9877E1B0126BECF"
+          },
+          {
+            "tcId": 412,
+            "key": "7A622F4265342A485468819F35CA74AADF6C2B170CB97E07DD5B3491ABDE9C030B51208A0BCF2D784D59564679F2BC927F1B0E05857D2E9BEC3B1193AD77A1AA",
+            "msg": "4D354C9CC77215615DED6F2F698172DD"
+          },
+          {
+            "tcId": 413,
+            "key": "AD856ADCD3B024B59326AB3508D241ABA760C0801EEE5052133667D344EDF6DA12B355D86DD2706F84E92DAFEFD45D46B6F64B5ABF95C6025ED7AF4420A89EC0",
+            "msg": "AF04CA3E5E9DC126DFE3B25E64E58313"
+          },
+          {
+            "tcId": 414,
+            "key": "5AD7615AF3DD87A75092F7B8EB6E5ADB5D88AB08868DF3A8354D8BF66BDEDFB0E744A0978B39B5C15D77804E9353192A43276DF38FA782FB6EEC94A99EE41FD0",
+            "msg": "1555F1F35AEB1DCB9F4CBB8F13DFC03D"
+          },
+          {
+            "tcId": 415,
+            "key": "8FD76E9CF3A1FCB9833E1635759B3A106A05026FF0DF436316A027C376D337BB9B66088963A3B1C3B03562E7C5CFC2FEA4BD6D894514C79861D240A464ACEFE6",
+            "msg": "C1404482A462B922D6E1479A51897961"
+          },
+          {
+            "tcId": 416,
+            "key": "13FC43D9FC85AF9F73784B6A590022F12345EEFC2D4C803E4B4D6355EF09A2BD08F51A29072EA6EBDD33BD8ABE1C442C5E7BD4C1F69AC42D254B08A3718DD331",
+            "msg": "FDE105710A7FD0F6C9088CCA1F3891CE"
+          },
+          {
+            "tcId": 417,
+            "key": "AF436B663B7272F02D277DCE4FA4AD33759AD46F0FAA58C49E3C87CB65DCEAEC5FC480DFC4810530B59773DEDB0261041BA6FC32C1F056302230E841A32787A0",
+            "msg": "5C4688C8851663247C4F411F48D59091"
+          },
+          {
+            "tcId": 418,
+            "key": "7A877CE2ADCB751C186ED00FC52BEF9ACE1E5D1A97D8CE33D9F92634B2DF712EE7746F0F436CDE33B5A23DE82B7AEBE1B4C8C462DC1137EA97C04E8CFF2ABE56",
+            "msg": "D59A0A6519F8A1F2BA7F15E4F1AE2AC2"
+          },
+          {
+            "tcId": 419,
+            "key": "6CB5E9AA25C54A2D5D71754D1797E7B4376E11E4B6C5FB1D9D475061E6E57EA42EE973BCF57D6D600E518740E12D70FE74AF4EB0E1A858E072DF289325587EE4",
+            "msg": "4F299AC144C48F29AD12C868313D7A6F"
+          },
+          {
+            "tcId": 420,
+            "key": "7BDE366669A1C67A37B6138748D0130A3685223F343ACB0922AB3F6C61988F7F3C2382FBA9CD45CD193E4EB6C76084CFA4C818D312F84EFED9E034AE6FE0B986",
+            "msg": "ABDA0A14EABD3DD88F38677F4392BC2B"
+          },
+          {
+            "tcId": 421,
+            "key": "93DCF483E910DC1F8ECE9E2E81556313A787837E7FDEEA0638864CB49F4A38AB174C77AC224D66A528E879F3CACB58CFC35A826C600D1B0B8917D14FB6040807",
+            "msg": "22A9689B08C492D2830EBB3833B5F6CF"
+          },
+          {
+            "tcId": 422,
+            "key": "F4DC46E901A30E8F8477D9CF953C910D24BA40560D9AE2A094D097C93009D99951D8EEF78C3624EDADF13605A36A0B694650168D138683E2D3D31F2690BC80BB",
+            "msg": "AD57E39B2203D63BD17C1F0CB37934AB"
+          },
+          {
+            "tcId": 423,
+            "key": "6F961D2A76962902CE03015DBF971FE673242E90DCB93D8C199CF7EE9E1D2E9780369477F583560811D567A1B87551B9F3F43A68007351040E13ADCC9E3AD835",
+            "msg": "D981F9AE642B5BB5C204551C3969F21B"
+          },
+          {
+            "tcId": 424,
+            "key": "2D206CD61048F0E1EB68940ECF1BF3ACEC947A42D169C26CA03DF509DEF3FDBDB19763F32CC863258D675C161800D07648A1181BEE31CC9014999F736D7D4947",
+            "msg": "AA4A96F254AB5F92813EC3251D317F35"
+          },
+          {
+            "tcId": 425,
+            "key": "9C4BE4246541FBE6DE8AE7338721936628F3626D1665595735914396A824E1BD1AC02DCCF85A499CA4F81B28053BEA3898A084FE38133FCA17DC7FAEDDA0DFF9",
+            "msg": "3A37E1B5CFAE0559F401F85F1C7AF87E"
+          },
+          {
+            "tcId": 426,
+            "key": "1DE6D61041D66F0B0D1277383AD2E09A244263E6CFCA5938628F5C4077F5769F94E6AC37E7113094EBAC074BEA120DD8CD9848EAC1DABBCA1EBE21716B5AB715",
+            "msg": "3105DD3DF2B1AF7D7B8C2053732245D4"
+          },
+          {
+            "tcId": 427,
+            "key": "FE174D72806C8CFCE4C30A110BC878CCB1F311466B9B407957461CD396288F3AA3795F62D05759D93DF19ACCCCB5B516C533A532A3B5BE5E7A1DC9DA45C9ED7F",
+            "msg": "C7F785FF8C535E6FF9F29C7DA3691145"
+          },
+          {
+            "tcId": 428,
+            "key": "FDF0F8985FA38A946A0ED38BFE4F8A5F8AD5345B7396A0C5C87C01477F248F794300933576BFAC2444D5F36659258AF925B26171AD93ED91266E570CC8CE695D",
+            "msg": "F0E9615CC6945C0DF7DE323CE23350ED"
+          },
+          {
+            "tcId": 429,
+            "key": "D7F85C1F1F7712FE0EC42630F99AD7134C5F66AF84786D0992695149695A0F41D8FDFFFA0AE4A84F78EC245319ADFD89D8137474C6A130D7F26704C7C68AEA32",
+            "msg": "E8C867ABE60F1A93378FAA196585C832"
+          },
+          {
+            "tcId": 430,
+            "key": "AB4D2834236202093BF43F9C0FE95D3AD201FA92D256CF96A3A7B2B5CDC3066FA15B0499FE63703327DC7D590B1D664E6DCFC804838E0DAFE72797939629E6B9",
+            "msg": "38940A2789757ABF9CB70204FD14EDB1"
+          },
+          {
+            "tcId": 431,
+            "key": "DCA82AEE31BA5ABC08EE35B9B46F418208C23FA36170C98AD8879892DFAB5D7FD14CADF0043562AD6218C9FBCE08249DE004C064D5629E89982E249467BCD4D1",
+            "msg": "6DBEB6593243309C044E251506569051"
+          },
+          {
+            "tcId": 432,
+            "key": "F02A59CF28A293E49C725110DB86E814C52D444C275F9CB2FB2F4F857E1DC881810F3B2835FCB562E0D3E9D03AF32E57C0B54216CC1A4A2C528ECBDD0474B786",
+            "msg": "1D94AB893387F8FF073A36254E4B993A"
+          },
+          {
+            "tcId": 433,
+            "key": "072067C99039C9E214D408C0FE94B48AC32933220495B6A7682AEEA7B1C3011FEA54C80E74E1F25EF848FBDBFC0A40CAE83662B6AF8F59CF2EDCAB8297C22B10",
+            "msg": "2AD644662455A115DB40859FB490A505"
+          },
+          {
+            "tcId": 434,
+            "key": "41E2ED8F926CF700AFE096E24B3E2EFA4E2681CA39E20E3424F148B7F4E48EF3536F45172F017F8E1E7CF6477D273DD4F7E0D4204DD34F87FA1D9112FA157CA5",
+            "msg": "0D5343133948034B8C40EBEF925A7FE0"
+          },
+          {
+            "tcId": 435,
+            "key": "41AAC5115BA4B6550F62FD12446F009CF64DC3A6E393CD997FB27FB8516B34971B4BB11678F08693037051D7E1C3DEE0237E4DA262C969F3C03E01E237B9C561",
+            "msg": "D05C8CBE0A47442B616A2DE16ECBAD1E"
+          },
+          {
+            "tcId": 436,
+            "key": "C4A3048964F23133B6043B5BA639172A6C690D502F888D5BCB2429053BCF480EACB39E18FB42DBA025152248C4DB7B43A5F81C2CED110162BBFFCB40935648D8",
+            "msg": "93D4E69ABB6910561AA0BC4DE4DF644E"
+          },
+          {
+            "tcId": 437,
+            "key": "DC265759F60A7374FE7EE13BD439CE7E8248C5E5BBD42BCB435E28AEC2AA4E813F6F0F02EB09294463B75F480DC51499C846E514910F62EB284363204FD72B5D",
+            "msg": "7F7EFC8A1D4282B57119843AC60FCFF2"
+          },
+          {
+            "tcId": 438,
+            "key": "72CF414980330E9160FB9D86189DAA6A3B264AA8247F6B7443E70600682A2A4B679A349F6446F81F7D1E42FE55AB1A5A9E1040B47D258DA76EA58F79538BB0A3",
+            "msg": "D5D4F9C392E16733539DA7158931BEF3"
+          },
+          {
+            "tcId": 439,
+            "key": "86C56739E8021885D88E9D8B8B4C95A75D971176B03E14CE6393AB8131DDC966468791B509E77D7D2E73E316F96B43C3B1A0110C3542D0187A7021667F46F8BC",
+            "msg": "6BB7C2A5022B07AF17306E3343CEFC49"
+          },
+          {
+            "tcId": 440,
+            "key": "000F856E112B8E4984354E002BD7F58AA895347B30978CA0CE8DFF445F4C7C2C46905BD380EEC4FE539B8A87BDF5E43D21FF51515AE15E5CE2065DD52AE1E50F",
+            "msg": "CAD76BF3FA1C26573DDDA005D42E9ACE"
+          },
+          {
+            "tcId": 441,
+            "key": "A74D799EF01AEB85AB9053E0578A83A0CB5DEBE8C8BF6E9E3DCBE642B34564CC7B1CE8DA7C1E6158DB47C26D66E4616CC53C75F5CC53809027F5BD5273C6CC6E",
+            "msg": "6DF27E03FEC8A7958582882F9100D864"
+          },
+          {
+            "tcId": 442,
+            "key": "6C7D6FF4761A4292D317DBBD432B410A431A746486A900A047F9551C16221012C2E9ADD3466312315A8A36237D8CF6290FA97F10A5EFE61A51B658884B9D1D0A",
+            "msg": "BCF5048D23DD45FDD3F3935CFF922CFD"
+          },
+          {
+            "tcId": 443,
+            "key": "296CE81B8ED082B13BDA09F1CB6EF1BDD7F41930B7046976B952AD2C209FF75B7894F990DEAB5F6D78F40F43B91EC0226C2D09A47BCB3123FDC7C6EE3DFBA64A",
+            "msg": "53473D0BD942646E753F0C69AC20539D"
+          },
+          {
+            "tcId": 444,
+            "key": "41698CD5115213AF3DE591636215B4DD64679C290B35D47256D285126AD231E40F4B3C6CA2441FEF20D0A94B20D5D0A9BB67E12CAF1A167ED52F1A31413480E7",
+            "msg": "53F7C57477AD7FFD23A9FD0EFACA0BCB"
+          },
+          {
+            "tcId": 445,
+            "key": "A765E3FCCE958AC36B52EFE97B07070A3B4C043E7CEBE4E765901265A2B42A6DFF146ACA214F4DA538CE03E5A520AB816D6F834FB3C487122F054C1B3BC3916F",
+            "msg": "A1FA521701BDBB1A6F08CDCF2545C573"
+          },
+          {
+            "tcId": 446,
+            "key": "ECB3325D20B531786EB6EC1AF8EB097400A526F9DC5C87E671784C60C5505B9457E827CC523008BF58C94B8F6E54986DE906532519339A137F848D29758A42B9",
+            "msg": "995FEDEF0788E32021884003C985DBB2"
+          },
+          {
+            "tcId": 447,
+            "key": "AEC50AE5A5871C8A9DEAB88AD75FFB51B69AE2BA6098C392F5F7CA588EC21900709BB6F4ECC38350D5834D2C0F9241D0A39EF8849C310A64B9F6A929D8F20DEB",
+            "msg": "6E1A22B4697C9C49064A10366B9CC16E"
+          },
+          {
+            "tcId": 448,
+            "key": "E20A2BC60CB114CBC92DF88762A1B94DB151471B120F998580FDABABC034B94CE49AB466940755942812AA1044FDF9F229D27A9191FA519771C0CD61453DDD74",
+            "msg": "4C0CFF9B76BE7CFB467D1146D84416B7"
+          },
+          {
+            "tcId": 449,
+            "key": "EA4F64310CC1D32E25AB33B10C15BCF25808F5B1AA8A76C5F171C01BBDDD92FB85F05B99F19D3AA4AF3C3E3C02286D6F17067FB9B3E42245E855CE4765826B63",
+            "msg": "AFFD92B3C53D36FCAEFC48A127B75E32"
+          },
+          {
+            "tcId": 450,
+            "key": "FD68AA40924AD3D459645E6806B2A2E586F2712D4DA1C1FB7AF99CD67A68EA87E1623C6A7C38765FC1BE965A5387CEEA9D5D84E2D295E83AD3277809AA9492EF",
+            "msg": "EE9371F598570CD54EC6E31BF84AB386"
+          }
+        ]
+      },
+      {
+        "tgId": 7,
+        "testType": "AFT",
+        "keyLen": 32,
+        "msgLen": 128,
+        "macLen": 256,
+        "tests": [
+          {
+            "tcId": 451,
+            "key": "E47BEEA4",
+            "msg": "2F8BD761F9EB02F1F98ED13A99C8403D"
+          },
+          {
+            "tcId": 452,
+            "key": "21A24A9B",
+            "msg": "17C71C192F9FEFAF1E7FEC6BFD7C899F"
+          },
+          {
+            "tcId": 453,
+            "key": "800832A6",
+            "msg": "EE3623CA57E7FE6B75D3494D8750C520"
+          },
+          {
+            "tcId": 454,
+            "key": "83E5FD38",
+            "msg": "CB16FB4F42B27E54A2E638AA17C78D3E"
+          },
+          {
+            "tcId": 455,
+            "key": "25EBD8C5",
+            "msg": "67CAC3B4E7D0C605112E37E00D501479"
+          },
+          {
+            "tcId": 456,
+            "key": "A1C1EB08",
+            "msg": "465B6E9059F27A53CA402C776F076AFF"
+          },
+          {
+            "tcId": 457,
+            "key": "3782B3F1",
+            "msg": "E35828F92C18DB7057EC61354B1B17BF"
+          },
+          {
+            "tcId": 458,
+            "key": "6B821183",
+            "msg": "D22D65FC751208C0A5FD1E740E2ADAC5"
+          },
+          {
+            "tcId": 459,
+            "key": "6E63FD55",
+            "msg": "609A8601B1D2E143865AAD3CFF47007F"
+          },
+          {
+            "tcId": 460,
+            "key": "D8E4BB7C",
+            "msg": "F35B9AD6DD211F51FB0BB16406F7E4C6"
+          },
+          {
+            "tcId": 461,
+            "key": "E904A565",
+            "msg": "34259C282BE5C5B0469A43CC2F926D97"
+          },
+          {
+            "tcId": 462,
+            "key": "9A4C70B5",
+            "msg": "DDBA57AAC2230CBB35CD4412AC7259EB"
+          },
+          {
+            "tcId": 463,
+            "key": "07135C26",
+            "msg": "475B92D4A92D89CAB08D52D5D524ECB8"
+          },
+          {
+            "tcId": 464,
+            "key": "57C6E706",
+            "msg": "57623A2E9622F3EA1C64083BAB2BB867"
+          },
+          {
+            "tcId": 465,
+            "key": "14181524",
+            "msg": "C7F86C6E74BE9DCE877FD2FA8D25594A"
+          },
+          {
+            "tcId": 466,
+            "key": "D0B74A4C",
+            "msg": "D7B0E26DB43DCB7095BB27FD894CC765"
+          },
+          {
+            "tcId": 467,
+            "key": "786FB44E",
+            "msg": "CA735A0486D11681D38F38F385DA2DFA"
+          },
+          {
+            "tcId": 468,
+            "key": "74A37DFF",
+            "msg": "C77DABC60EF39EADAFB31EE8B8740524"
+          },
+          {
+            "tcId": 469,
+            "key": "3B5FA8EB",
+            "msg": "B238BD210FCC9757E06736780C0E26CF"
+          },
+          {
+            "tcId": 470,
+            "key": "F2827E2A",
+            "msg": "A70BD427C0A66CFA0B777F3F56046EEA"
+          },
+          {
+            "tcId": 471,
+            "key": "3F213687",
+            "msg": "B2ED6F72592B06ADF19A80552F7034B5"
+          },
+          {
+            "tcId": 472,
+            "key": "35F8C2BB",
+            "msg": "B457C9D1DC1575AB0C85C051E849B6B3"
+          },
+          {
+            "tcId": 473,
+            "key": "C3DE3063",
+            "msg": "1E2A6FD4B31457962E4CE1A4A73DF03B"
+          },
+          {
+            "tcId": 474,
+            "key": "7921B558",
+            "msg": "7E05440C73A71CEB595C36B9C912B6EF"
+          },
+          {
+            "tcId": 475,
+            "key": "0080DCCE",
+            "msg": "C29B3CA100C92DAD19FC079529A2C847"
+          },
+          {
+            "tcId": 476,
+            "key": "350C397D",
+            "msg": "117298908E820835E1626221C9666B1B"
+          },
+          {
+            "tcId": 477,
+            "key": "CEE3B1EC",
+            "msg": "06FEB0086181DAE88076EDF7D2119BB7"
+          },
+          {
+            "tcId": 478,
+            "key": "C35BD723",
+            "msg": "DA9E916B0238B0039F3B9CFE3F28D65E"
+          },
+          {
+            "tcId": 479,
+            "key": "F71B9252",
+            "msg": "E590FB365D62FAB1449E2C7EE80F76EF"
+          },
+          {
+            "tcId": 480,
+            "key": "C361E2F8",
+            "msg": "FFB65D58480CB1B4528543622637BF6F"
+          },
+          {
+            "tcId": 481,
+            "key": "342FB3EC",
+            "msg": "2B2AEE7C88957F473700889E8DFD1B5D"
+          },
+          {
+            "tcId": 482,
+            "key": "95B67216",
+            "msg": "3ADED5224F241B43EF266F4D868DD781"
+          },
+          {
+            "tcId": 483,
+            "key": "3D3202A1",
+            "msg": "9FBC6471403E1F9D4BA93AEBBD5D6FE1"
+          },
+          {
+            "tcId": 484,
+            "key": "2263C8AD",
+            "msg": "8D501379BA811E161B8E0E00FA278B14"
+          },
+          {
+            "tcId": 485,
+            "key": "8B83ABAB",
+            "msg": "D09584A02D3093108A80600860B7A54F"
+          },
+          {
+            "tcId": 486,
+            "key": "FBD85155",
+            "msg": "F268C40E954164AF24ED84059EA5475F"
+          },
+          {
+            "tcId": 487,
+            "key": "D5F30167",
+            "msg": "CF5E05D5A9B3089DD5A5AD5D70DB7252"
+          },
+          {
+            "tcId": 488,
+            "key": "0F5F9426",
+            "msg": "BC3AF9B8DC395EA4BD9BA64EDFFFB2EE"
+          },
+          {
+            "tcId": 489,
+            "key": "016FB4BE",
+            "msg": "A4BDB27C710CDBB22AE0B1CE192635B8"
+          },
+          {
+            "tcId": 490,
+            "key": "9A5BDD79",
+            "msg": "FB574AE5CCB0D192D706668EEAD60130"
+          },
+          {
+            "tcId": 491,
+            "key": "090B4AFC",
+            "msg": "014A982D800002FAB1AB2A07B0E42207"
+          },
+          {
+            "tcId": 492,
+            "key": "03C746EA",
+            "msg": "31B13932BE6F4445934B4321B3AAA270"
+          },
+          {
+            "tcId": 493,
+            "key": "8E9171FA",
+            "msg": "FE6D901AF2DDD11CBCD7116C6CE4AC65"
+          },
+          {
+            "tcId": 494,
+            "key": "31910C6A",
+            "msg": "DF7DFB15583700145975AFC36E9175DB"
+          },
+          {
+            "tcId": 495,
+            "key": "A23631FB",
+            "msg": "1882310537111148E87C5BE1CFE64E52"
+          },
+          {
+            "tcId": 496,
+            "key": "E834B258",
+            "msg": "4B58A02C47955FDBBFF435AD5C712406"
+          },
+          {
+            "tcId": 497,
+            "key": "64CCEB55",
+            "msg": "5FE2527E443D345F49E21722084E3648"
+          },
+          {
+            "tcId": 498,
+            "key": "4446AC54",
+            "msg": "F55FC66C1C3ED361E6E455EB0E2F32C1"
+          },
+          {
+            "tcId": 499,
+            "key": "7A9E64B9",
+            "msg": "2B5E1947D4AF2240FF6E0CA43A242292"
+          },
+          {
+            "tcId": 500,
+            "key": "34C2CA89",
+            "msg": "0E5CC609F913943E5112FC75108373DD"
+          },
+          {
+            "tcId": 501,
+            "key": "F7742A65",
+            "msg": "3E213BF05070357FDB3C8D8F70AF9AEC"
+          },
+          {
+            "tcId": 502,
+            "key": "AD45C902",
+            "msg": "7B4F11F3750BB25C5B4273162E396C77"
+          },
+          {
+            "tcId": 503,
+            "key": "D85790A6",
+            "msg": "22986AC34354D67437797D0C1858104C"
+          },
+          {
+            "tcId": 504,
+            "key": "BAE4FD0D",
+            "msg": "54FA2553C4E607EA730D016DEBB080F7"
+          },
+          {
+            "tcId": 505,
+            "key": "F1A681DF",
+            "msg": "78DDCAAEE96A1DA19951B0EC5A2DEACD"
+          },
+          {
+            "tcId": 506,
+            "key": "A166537E",
+            "msg": "7C2EE66DD9710BEFB11F81A1D4F529B7"
+          },
+          {
+            "tcId": 507,
+            "key": "AD475503",
+            "msg": "055B2C8E59BAF1FA97F56A8B535D3712"
+          },
+          {
+            "tcId": 508,
+            "key": "070E9224",
+            "msg": "6D17A5AF283E9C65328EB9257D1B379A"
+          },
+          {
+            "tcId": 509,
+            "key": "00D0D572",
+            "msg": "EBE0C3E95741C036D3081944D3510C64"
+          },
+          {
+            "tcId": 510,
+            "key": "B1628627",
+            "msg": "7FAC0E9F923B4D04B069739EFAD6053F"
+          },
+          {
+            "tcId": 511,
+            "key": "EC129C90",
+            "msg": "92552D17B83BF0B399125246C2E0F465"
+          },
+          {
+            "tcId": 512,
+            "key": "189952E3",
+            "msg": "295D3EA5300A06604F1CCB0F4264AFC9"
+          },
+          {
+            "tcId": 513,
+            "key": "BB332F16",
+            "msg": "500C247105997E8DB0136CDFE10202F8"
+          },
+          {
+            "tcId": 514,
+            "key": "490FA6DF",
+            "msg": "88B04A0D12B59D3CD880BC6A0CE8CA22"
+          },
+          {
+            "tcId": 515,
+            "key": "C71B48BE",
+            "msg": "93967D031AF278B82F0F2E2C74C60510"
+          },
+          {
+            "tcId": 516,
+            "key": "B855F4BA",
+            "msg": "38BB31EB28525E5CD57B710314B54A21"
+          },
+          {
+            "tcId": 517,
+            "key": "3ABFCD6B",
+            "msg": "D7FF390D21485126A7D0C192C0FC2317"
+          },
+          {
+            "tcId": 518,
+            "key": "FFC81CD5",
+            "msg": "0FA26C3EFA5F685C934700C62BAA96A4"
+          },
+          {
+            "tcId": 519,
+            "key": "DAAB8C35",
+            "msg": "62C244CBF3387EC70F329C5DFBC9E85B"
+          },
+          {
+            "tcId": 520,
+            "key": "EFB50A4D",
+            "msg": "EF313B13EAE0C2727A5D172B6E6B3334"
+          },
+          {
+            "tcId": 521,
+            "key": "533A2FD4",
+            "msg": "09A1EFC67980BECC84D2008541BA97D8"
+          },
+          {
+            "tcId": 522,
+            "key": "50CFDD41",
+            "msg": "CD7189B5085EF7583E0A24C75DBC055F"
+          },
+          {
+            "tcId": 523,
+            "key": "1EEF64E2",
+            "msg": "E4D72FFAE0673E164362D3F08304D31B"
+          },
+          {
+            "tcId": 524,
+            "key": "610D84AD",
+            "msg": "E7AE65E9ADE468421BD4A23B62F4B069"
+          },
+          {
+            "tcId": 525,
+            "key": "BA47D8CD",
+            "msg": "C65B5D8BC76B3170DC26F48FECB22BEC"
+          }
+        ]
+      },
+      {
+        "tgId": 8,
+        "testType": "AFT",
+        "keyLen": 192,
+        "msgLen": 128,
+        "macLen": 32,
+        "tests": [
+          {
+            "tcId": 526,
+            "key": "A020FF209105E79F99277530B4D760C3035F18B3C836B0B9",
+            "msg": "E2081BA4317C5B39A82A47D4C7CA04CB"
+          },
+          {
+            "tcId": 527,
+            "key": "40A3A31B4769255CD641728E9D5A09A29492E1ECE2499F0B",
+            "msg": "D6786CE657B2A6C786031CAAD987362E"
+          },
+          {
+            "tcId": 528,
+            "key": "5C2767358F3FD83186EBBB0F68FA8467DB440635E9E4E878",
+            "msg": "B6FEA322CB0034ABE05636B31D52FB97"
+          },
+          {
+            "tcId": 529,
+            "key": "6CFE131E80514C6CEEA32BD60C2FC7C2CB10E7456A483C7B",
+            "msg": "0D6790C0B7415CB079AE82FA654AB2FC"
+          },
+          {
+            "tcId": 530,
+            "key": "8463610B1BB2D6C57290DDE30BD5CF034904D0458D6410E7",
+            "msg": "7A2D6FB6711A4160F60F63CC62A60E4B"
+          },
+          {
+            "tcId": 531,
+            "key": "9056EAC59DC04AA66EEF2660C59C4F2B952376FC570F1032",
+            "msg": "A4723E0E1943BDA7081F9ED5010AD41A"
+          },
+          {
+            "tcId": 532,
+            "key": "05375B6697ACA49B2C150C3810E3906441A86F69137FBFB6",
+            "msg": "199C6149866863D9067A069E05AE0F89"
+          },
+          {
+            "tcId": 533,
+            "key": "C968061471E70D535A3156169FE68B61F4F0F0B1C2346B9E",
+            "msg": "12FCCCFE3D3A03E2B47500CFB91A2752"
+          },
+          {
+            "tcId": 534,
+            "key": "858C34E30B0B46E67DCC710A40B47441AE65AB1464498C88",
+            "msg": "38F014FAA799E99F91B39895CE1A6474"
+          },
+          {
+            "tcId": 535,
+            "key": "6AF04DF2A7EFA290B7E41A59D041DBD4C51FCAEF69BD2688",
+            "msg": "F652F703DFCB6E649092D0B2B562872E"
+          },
+          {
+            "tcId": 536,
+            "key": "F7A597D7CBE146AA61B9868CF0EEADE1751750F9165FF9DA",
+            "msg": "550B0B296030ED5BBFACE0362B0AE8EA"
+          },
+          {
+            "tcId": 537,
+            "key": "0EB5067B6EC5FEEADF18C82C9C0360F29D34DA21DECDA1EE",
+            "msg": "A3FB133E49A226AC523EAFBCDE8E0AE5"
+          },
+          {
+            "tcId": 538,
+            "key": "A606277E2E6A174E8417B18F633DBA3303B44C7029330DDB",
+            "msg": "67FC0CBD8E9F339E17F51D641873B3F5"
+          },
+          {
+            "tcId": 539,
+            "key": "814C68C4CCD50A06EE02FDEA1570EA3B2F046ADB904650A2",
+            "msg": "20223627FDEBBCDD8FDDEA1A8B44EFB7"
+          },
+          {
+            "tcId": 540,
+            "key": "FCF52C2D581DF8119D96A52D3A4E6C757E98579F5025B705",
+            "msg": "E358F08965F895F197825AC3283DAC23"
+          },
+          {
+            "tcId": 541,
+            "key": "9C5779D49A37670B85464BCA58F1448618FBF60ACA198499",
+            "msg": "1EC73D47E3D1BC8B69284C4BA5B68FF6"
+          },
+          {
+            "tcId": 542,
+            "key": "8F54DE9246B28A79A4DDE5A7B672EC6D09462E19FD0B626F",
+            "msg": "A9D7645FE51920BE4C5E8C8BF95567B6"
+          },
+          {
+            "tcId": 543,
+            "key": "85607CCF96DBE0324C939B1633C662645A0EAE75EC03FB2A",
+            "msg": "B49D176FA798BCEB9A8F4BFEB0B255F1"
+          },
+          {
+            "tcId": 544,
+            "key": "0478443322330D794152AE2D34565CEC4C2005A9EE4B5EC1",
+            "msg": "4A6DE88DB9195E1AF1E767BFEC229DE3"
+          },
+          {
+            "tcId": 545,
+            "key": "6933FAE1E752A074AC7249DA366A4C4B1BA8036423F69748",
+            "msg": "2E73D56688D78E4A9763DD1616666247"
+          },
+          {
+            "tcId": 546,
+            "key": "D872DA5B3FB7BFDAFD3E679590F6FD6AFDE860DBC21BBF90",
+            "msg": "6433FC1027E1D3CF1CBC42530E264604"
+          },
+          {
+            "tcId": 547,
+            "key": "AE25516628695CB55083236F6979567ADBF7BDC5B9A1659C",
+            "msg": "FB415ABAC0F008B8E7E5D7F18C50DD80"
+          },
+          {
+            "tcId": 548,
+            "key": "47793ADFD2CFCF5B4F26A28D837ACA02F8A5470EA2C6E410",
+            "msg": "19A3FF9510BA49A31CCD78EFDDC2E454"
+          },
+          {
+            "tcId": 549,
+            "key": "ACCA7F2AEE013F956B642C26E6FFCB15F9B4F1C2455D25A8",
+            "msg": "B2B935FBBA2DBAE546F56110C387FBCE"
+          },
+          {
+            "tcId": 550,
+            "key": "D0EC5D880F703AC6A6740971A47BC798070752CDAD80F690",
+            "msg": "C7175089C48D248421E2C6E1143B3EF4"
+          },
+          {
+            "tcId": 551,
+            "key": "84C447A286AD5FB8EAAAFDC477A8DC30179DE278F2458AD8",
+            "msg": "A34B87DC9B33C3EF4E1F4A12FE2396AD"
+          },
+          {
+            "tcId": 552,
+            "key": "0651DCC7624476C304FE11D0DC2BDC19E10DC537D069BBCF",
+            "msg": "31AF3C73DBE1DC892B407CA57718A5C9"
+          },
+          {
+            "tcId": 553,
+            "key": "99D2C168E87AB684E4B98078877C39AC818DDBE45F77D53B",
+            "msg": "4C2DC6A00D21E8266707AA6EC5FD21C7"
+          },
+          {
+            "tcId": 554,
+            "key": "22FDDC7B70496C056915C234C858244FA9A6CE14E3DF1EEB",
+            "msg": "748E531E96292A252EEF850B329062AA"
+          },
+          {
+            "tcId": 555,
+            "key": "726C1F4DFB4CF564DA6375406DBA19E423F7774A8DAFD217",
+            "msg": "7D86EB1ADE0DC029DBA9DC82220FB516"
+          },
+          {
+            "tcId": 556,
+            "key": "046E969E20DDCF68880251BF946F940728239EE8C2D70249",
+            "msg": "D488BAFC49D9ABE4934E42C71E447A69"
+          },
+          {
+            "tcId": 557,
+            "key": "458B7065B95D97A09FA268317B400A34EDDA8BFB25078914",
+            "msg": "25DC043899DFCED88F4783B878A43556"
+          },
+          {
+            "tcId": 558,
+            "key": "27C525650D7CA3903A341D7E6E94D451505BAFA3E2D5E7FD",
+            "msg": "BABE2BAFC62A5BA997CA8D26ABEEF23A"
+          },
+          {
+            "tcId": 559,
+            "key": "8E1628392ABA1009F85099B3054EEB6CB14804126A67673A",
+            "msg": "8DCE338FEABCB1A9917BF9F61CAADE6A"
+          },
+          {
+            "tcId": 560,
+            "key": "BCE3DBE1363E7C4ABC317419197FC49483AECF5401A38374",
+            "msg": "E243A191E9A0524F7AF9F363AFAEC3FB"
+          },
+          {
+            "tcId": 561,
+            "key": "7163CD5BE2EC16BCAD2E81E7F40C7C9DD89C004E9F52E954",
+            "msg": "48AE8A371A8B6891FB619DFDE9D21E99"
+          },
+          {
+            "tcId": 562,
+            "key": "8626B4C41AFD99916D36FEC0350D3D1342EBA8098E2FB4AA",
+            "msg": "004174B14F2A3EE882AAEBC4945E42DE"
+          },
+          {
+            "tcId": 563,
+            "key": "EC1FBDF5C8B76BF4D1061B05935E1A1FF4891AF04B70B0DA",
+            "msg": "5D7F1366F2792E9FAA051350449B98CD"
+          },
+          {
+            "tcId": 564,
+            "key": "0F64D2C5CD2B8753EF1E5E26F142ED62035856C4B83882E2",
+            "msg": "A0D892B32A15EDBCB4E730064BD5BC06"
+          },
+          {
+            "tcId": 565,
+            "key": "ACFA09F3BC532355DFBB43F82C03693A93DD8A9D47F967F7",
+            "msg": "F772DB30394992E2506DCD94CA6C1DF5"
+          },
+          {
+            "tcId": 566,
+            "key": "4F1F36AE144894306EBEA684DF0EDDC1E9A6DD4288A8779C",
+            "msg": "285C42CBE268D7C304516A4AD8F547E1"
+          },
+          {
+            "tcId": 567,
+            "key": "0522885A0B1E98C24C599E76B05367C3192AD2A0884BCDE9",
+            "msg": "303D03A079674AA56B7CCC7393FAD5A6"
+          },
+          {
+            "tcId": 568,
+            "key": "122517E35C48A3F765C2B909C7C22C2C9DB5F564A2C8AAFC",
+            "msg": "607D8F5D174B43CAA16492CBF48D7B28"
+          },
+          {
+            "tcId": 569,
+            "key": "B48F68050335F4BD32B0D2AE7BAF7732450F42C9640EEDB1",
+            "msg": "AD2DB68364B5E432B9B172640B60E999"
+          },
+          {
+            "tcId": 570,
+            "key": "F7AB3E8D5CEE9B45A0836949A654F76A4143E55ECA616F82",
+            "msg": "252C5E693CD7DECE39C7290045A03B32"
+          },
+          {
+            "tcId": 571,
+            "key": "401D4EDA656EAB923547A3E6EFAE9739442AC6BE05ED0264",
+            "msg": "BECD77FFF6BC6F89C9B8DB09CBA199F4"
+          },
+          {
+            "tcId": 572,
+            "key": "C415C6BBB40BC4053B1B31C78EA454E072299D82E6D08E30",
+            "msg": "2CAA20914D82C4C89036522ACEC001A4"
+          },
+          {
+            "tcId": 573,
+            "key": "34F1F9F0AF44DC9231174515A3D2A18B25793ABDA712E444",
+            "msg": "DF1261356ED30B8A799EFFD1DED98FF8"
+          },
+          {
+            "tcId": 574,
+            "key": "5DBA9077610B8240E466A1C38A50E1929CDB61CB33C6649D",
+            "msg": "9C38F2C85F1DE62ED0E1DDF7A3A4B499"
+          },
+          {
+            "tcId": 575,
+            "key": "0BA4447E587E83901D83E452EBB55D7A15FA3CB1D53A0391",
+            "msg": "903B4A82F2375AECE06A13A2D7F3B415"
+          },
+          {
+            "tcId": 576,
+            "key": "5EE5D657293B8FC4D99D0442607BA2FA69094CB3C29A1F61",
+            "msg": "0F26E8F1167375B92FA93925A41FEDBB"
+          },
+          {
+            "tcId": 577,
+            "key": "E5049EBFE245C1C691888C5A6EE0B1F19EE885416C4BEE4B",
+            "msg": "274257FCB43A0A13310E0EC9008859BD"
+          },
+          {
+            "tcId": 578,
+            "key": "4161C10554547718AB863EE5515205DD92B49965B0E4F279",
+            "msg": "E5128819B68C30EECBD673A167A7BDC0"
+          },
+          {
+            "tcId": 579,
+            "key": "CFBF8F628C1765860A05AC9929B38E4A68340F5AC4E40968",
+            "msg": "5D869C5014C1BE71E9A9D84A586F39F1"
+          },
+          {
+            "tcId": 580,
+            "key": "9D314067BB91B69CFAF9B14E868DB8B317D9789DE0B45B71",
+            "msg": "C506CB6821ABE8F7A3E2B1E63F1CBF66"
+          },
+          {
+            "tcId": 581,
+            "key": "75C6A55A64586AD94057013B29A3F03CD77213D6C0F1C7B6",
+            "msg": "B541D8601B98EAE3448C397DBCA3051E"
+          },
+          {
+            "tcId": 582,
+            "key": "A2E96A6CE738F2404AE1332877F4DC05A74023D87F5B49F5",
+            "msg": "5CD6A5F61D336E1A5A95C33267B19270"
+          },
+          {
+            "tcId": 583,
+            "key": "339ABD1BD59EB83358941D1D66C1CA007662918493DA1D9F",
+            "msg": "F51213D9FEF05781FF2FBD192FECBEF1"
+          },
+          {
+            "tcId": 584,
+            "key": "D078C9B0250139174CC73BA8F3EBA4507C1B40F640C6DDA4",
+            "msg": "41103BA3EBB885E3368DDE0FFCF2FAF4"
+          },
+          {
+            "tcId": 585,
+            "key": "BE942E2FE70518DD0C6E19050DAFF56988F6FF6E19169B66",
+            "msg": "37481C01CDBA0F5AC61D7B0A230651FB"
+          },
+          {
+            "tcId": 586,
+            "key": "72BA2C593400D85112190B80E160A1258C204686869A7F7D",
+            "msg": "23088F8EB9AC2C42D66865DC025BBD6F"
+          },
+          {
+            "tcId": 587,
+            "key": "FD0915F13E9D819AEA4CEDBE6AF650995E1FE74C73EA0CA8",
+            "msg": "3F78E9A52CCB8673C8EE6DC8CD2DBF13"
+          },
+          {
+            "tcId": 588,
+            "key": "EE5DE743F36A79CF4AC687A8A56D3E4FF469C7BE24635FD8",
+            "msg": "A167C16A38079007C34437764569AFB4"
+          },
+          {
+            "tcId": 589,
+            "key": "6F8466FF1CD312DA5AD0162B6864A2676A2A285EF15652FE",
+            "msg": "B3D39FB5185D670ACD70BD2C2467F5CB"
+          },
+          {
+            "tcId": 590,
+            "key": "FC2A8903DFA101822872E54EC2599309709EC91D3513E637",
+            "msg": "386F86C7D4E864EF3BFA980CD16E3A49"
+          },
+          {
+            "tcId": 591,
+            "key": "8B02C98CAC7926B17F3A192FD75305163597FCD5EBC6F319",
+            "msg": "210D60B67AE5B4EAE0647C0CE6A096C9"
+          },
+          {
+            "tcId": 592,
+            "key": "12FADF5FE8EC3B69285251F87ADA2A8EE8E49D535947DED3",
+            "msg": "934702969B432DD9C2E84849FCB714BC"
+          },
+          {
+            "tcId": 593,
+            "key": "E061341E2AF29A15A234C1515B0A4DA969E548C48446E73F",
+            "msg": "33292BF95B76F8ECD15CD9A955E6376D"
+          },
+          {
+            "tcId": 594,
+            "key": "34E173C9EDCC6F7BCB94591D0FA0C199870D81FDCD9CF0BB",
+            "msg": "B47E61FC5DF2771073A74C8478CAC611"
+          },
+          {
+            "tcId": 595,
+            "key": "7B2F984EAEFD9590BAC1B19BA94A062AD949451C02EBAB63",
+            "msg": "85841D13752D22DF84F4F6F8D57B2E36"
+          },
+          {
+            "tcId": 596,
+            "key": "0112C7DEC397DD0379F89415A79266894928DC1691480CEE",
+            "msg": "EA8341795CFA2D88BE44AC5F90611432"
+          },
+          {
+            "tcId": 597,
+            "key": "035AB56FD1A17C0111CEF8E53B56C9AE5F13F3281E058C3D",
+            "msg": "2B4DA79FCE26A32800DF3C6951465E63"
+          },
+          {
+            "tcId": 598,
+            "key": "A8199690AFEFC4FF546661DC46D39B92A8E7A7B34BAB7338",
+            "msg": "CDD2418970D3D356D18324D820A022C0"
+          },
+          {
+            "tcId": 599,
+            "key": "4A4D85FAF5C137A841C1A5093D5C2FC63FBBD969E42D6947",
+            "msg": "DD2CE5DBCA7929367A1F7A03749EECB7"
+          },
+          {
+            "tcId": 600,
+            "key": "016AF9267AC7A358503A665103A60F8529795B89C897B184",
+            "msg": "2A73A0138E0D5B3F6364CB065B3164DB"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/sw/host/tests/crypto/acvp/BUILD
+++ b/sw/host/tests/crypto/acvp/BUILD
@@ -1,0 +1,29 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:ujson.bzl", "ujson_rust")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "harness",
+    srcs = [
+        "src/hmac.rs",
+        "src/main.rs",
+    ],
+    deps = [
+        "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
+        "@crate_index//:clap",
+        "@crate_index//:hex",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:rand",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/crypto/acvp/src/hmac.rs
+++ b/sw/host/tests/crypto/acvp/src/hmac.rs
@@ -1,0 +1,166 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+
+use hex::FromHex;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+use cryptotest_commands::commands::CryptotestCommand;
+
+use cryptotest_commands::hmac_commands::{
+    CryptotestHmacHashAlg, CryptotestHmacKey, CryptotestHmacMessage, CryptotestHmacTag,
+};
+
+use opentitanlib::console::spi::SpiConsoleDevice;
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
+
+// NIST ACVP JSON schema definitions
+// Test vectors: https://pages.nist.gov/ACVP/draft-fussell-acvp-mac.html#name-hmac-test-vectors
+// Test results: https://pages.nist.gov/ACVP/draft-fussell-acvp-mac.html#name-hmac-test-vector-responses
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HmacTestCase {
+    tc_id: usize,
+    key: String,
+    msg: String,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HmacTestGroup {
+    tg_id: usize,
+    test_type: String,
+    key_len: usize,
+    msg_len: usize,
+    mac_len: usize,
+    tests: Vec<HmacTestCase>,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HmacTestVectorSet {
+    vs_id: usize,
+    algorithm: String,
+    revision: String,
+    #[serde(default)]
+    is_sample: bool,
+    test_groups: Vec<HmacTestGroup>,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HmacResultCase {
+    tc_id: usize,
+    mac: String,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HmacResultGroup {
+    tg_id: usize,
+    tests: Vec<HmacResultCase>,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HmacResultVectorSet {
+    vs_id: usize,
+    algorithm: String,
+    revision: String,
+    #[serde(default)]
+    is_sample: bool,
+    test_groups: Vec<HmacResultGroup>,
+}
+
+fn run_hmac_case(
+    timeout: Duration,
+    spi_console: &SpiConsoleDevice,
+    algorithm: &CryptotestHmacHashAlg,
+    mac_len: usize,
+    tc: &HmacTestCase,
+) -> Result<HmacResultCase> {
+    log::info!("tc_id: {}", tc.tc_id);
+    let key = Vec::<u8>::from_hex(tc.key.as_bytes())?;
+    let msg = Vec::<u8>::from_hex(tc.msg.as_bytes())?;
+
+    CryptotestCommand::Hmac.send(spi_console)?;
+    algorithm.send(spi_console)?;
+    CryptotestHmacKey {
+        key: arrayvec::ArrayVec::try_from(key.as_slice()).unwrap(),
+        key_len: key.len(),
+    }
+    .send(spi_console)?;
+
+    CryptotestHmacMessage {
+        message: arrayvec::ArrayVec::try_from(msg.as_slice()).unwrap(),
+        message_len: msg.len(),
+    }
+    .send(spi_console)?;
+
+    let hmac_output = CryptotestHmacTag::recv(spi_console, timeout, false)?;
+
+    let returned_bits = hmac_output.tag[..std::cmp::min(mac_len / 8, hmac_output.tag_len)]
+        .iter()
+        .try_fold(String::new(), |mut acc, w| {
+            core::fmt::write(&mut acc, core::format_args!("{:02x}", w))
+                .or(Err(std::io::Error::from(std::io::ErrorKind::Other)))?;
+            Ok::<String, std::io::Error>(acc)
+        })?;
+
+    Ok(HmacResultCase {
+        tc_id: tc.tc_id,
+        mac: returned_bits,
+    })
+}
+
+fn run_hmac_group(
+    timeout: Duration,
+    spi_console: &SpiConsoleDevice,
+    algorithm: &CryptotestHmacHashAlg,
+    tg: &HmacTestGroup,
+) -> Result<HmacResultGroup> {
+    log::info!("tg_id: {}", tg.tg_id);
+    let mut result_cases: Vec<HmacResultCase> = Vec::with_capacity(tg.tests.len());
+    for tc in &tg.tests {
+        result_cases.push(run_hmac_case(
+            timeout,
+            spi_console,
+            algorithm,
+            tg.mac_len,
+            tc,
+        )?);
+    }
+    Ok(HmacResultGroup {
+        tg_id: tg.tg_id,
+        tests: result_cases,
+    })
+}
+
+pub fn run_hmac_vector_set(
+    timeout: Duration,
+    spi_console: &SpiConsoleDevice,
+    vs: &HmacTestVectorSet,
+) -> Result<HmacResultVectorSet> {
+    log::info!("vs_id: {}", vs.vs_id);
+    let mut result_groups: Vec<HmacResultGroup> = Vec::with_capacity(vs.test_groups.len());
+    let algorithm = match vs.algorithm.as_str() {
+        "HMAC-SHA2-256" => CryptotestHmacHashAlg::Sha256,
+        "HMAC-SHA2-384" => CryptotestHmacHashAlg::Sha384,
+        "HMAC-SHA2-512" => CryptotestHmacHashAlg::Sha512,
+        _ => return Err(std::io::Error::from(std::io::ErrorKind::InvalidInput).into()),
+    };
+    for tg in &vs.test_groups {
+        result_groups.push(run_hmac_group(timeout, spi_console, &algorithm, tg)?);
+    }
+    Ok(HmacResultVectorSet {
+        vs_id: vs.vs_id,
+        algorithm: vs.algorithm.clone(),
+        revision: vs.revision.clone(),
+        is_sample: vs.is_sample,
+        test_groups: result_groups,
+    })
+}

--- a/sw/host/tests/crypto/acvp/src/main.rs
+++ b/sw/host/tests/crypto/acvp/src/main.rs
@@ -1,0 +1,146 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::console::spi::SpiConsoleDevice;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::uart::console::UartConsole;
+
+mod hmac;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    // Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+
+    // Input ACVP JSON test vector file.
+    #[arg(long)]
+    input: Option<std::path::PathBuf>,
+
+    // Output ACVP JSON result file.
+    #[arg(long)]
+    output: Option<std::path::PathBuf>,
+
+    // ACVP JSON result file containing expected outputs.
+    #[arg(long)]
+    expected: Option<std::path::PathBuf>,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all_fields = "camelCase")]
+#[serde(untagged)]
+enum AcvpVectors {
+    Header {
+        url: String,
+        vector_set_urls: Vec<String>,
+        time: String,
+    },
+    Hmac(hmac::HmacTestVectorSet),
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all_fields = "camelCase")]
+#[serde(untagged)]
+enum AcvpResults {
+    Header {
+        url: String,
+        vector_set_urls: Vec<String>,
+        time: String,
+    },
+    Hmac(hmac::HmacResultVectorSet),
+}
+
+fn run<R: std::io::Read, W: std::io::Write>(
+    opts: &Opts,
+    transport: &TransportWrapper,
+    input: R,
+    expected: Option<R>,
+    output: Option<W>,
+) -> Result<()> {
+    let spi = transport.spi("BOOTSTRAP")?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
+
+    let acvp_vectors: Vec<AcvpVectors> = serde_json::from_reader(input)?;
+    let mut acvp_results: Vec<AcvpResults> = Vec::with_capacity(acvp_vectors.len());
+
+    for v in acvp_vectors {
+        match v {
+            AcvpVectors::Header {
+                url,
+                vector_set_urls,
+                time,
+            } => acvp_results.push(AcvpResults::Header {
+                url,
+                vector_set_urls,
+                time,
+            }),
+            AcvpVectors::Hmac(vs) => acvp_results.push(AcvpResults::Hmac(
+                hmac::run_hmac_vector_set(opts.timeout, &spi_console_device, &vs)?,
+            )),
+        }
+    }
+    if let Some(w) = output {
+        serde_json::to_writer_pretty(w, &acvp_results)?;
+    }
+    if let Some(r) = expected {
+        let expected_results: Vec<AcvpResults> = serde_json::from_reader(r)?;
+        if acvp_results != expected_results {
+            return Err(std::io::Error::other("ACVP result mismatch").into());
+        }
+    }
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    let transport = opts.init.init_target()?;
+
+    // Note: Missing input, expected and output arguments are intentionally
+    // non-fatal to support running this test harness without arguments in test
+    // scripts. This ensures that the harness and firmware will successfully
+    // build and that the harness will bootstrap the target before discovering
+    // the "missing" arguments.
+    let Some(ref input_path) = opts.input else {
+        log::warn!("Missing input ACVP JSON file");
+        return Ok(());
+    };
+    if opts.expected.is_none() && opts.output.is_none() {
+        log::warn!("Missing expected/output ACVP JSON files");
+        return Ok(());
+    }
+
+    let f = std::fs::File::open(input_path).inspect_err(|e| log::error!("open input file: {e}"))?;
+    let input = std::io::BufReader::new(f);
+
+    let expected = match &opts.expected {
+        Some(expected_path) => {
+            let f = std::fs::File::open(expected_path)
+                .inspect_err(|e| log::error!("open expected file: {e}"))?;
+            Some(std::io::BufReader::new(f))
+        }
+        None => None,
+    };
+    let output = match &opts.output {
+        Some(output_path) => {
+            let f = std::fs::File::create(output_path)
+                .inspect_err(|e| log::error!("open output file: {e}"))?;
+            Some(std::io::BufWriter::new(f))
+        }
+        None => None,
+    };
+
+    run(&opts, &transport, input, expected, output)
+}


### PR DESCRIPTION
Introduce test harness capable of running ACVP test vectors on the Cryptotest firmware. Test outputs can be written to a result file for uploading to the NIST demo server or another verification authority. Also supports comparing results against a golden reference.

This initial version supports HMAC-SHA2, with test vectors and expected outputs that have been verified against the NIST demo server.