### PR TITLE
[cryptotest] Remove testing SHAKE in RSA

### DIFF
--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -180,11 +180,7 @@ RSA_TESTVECTOR_TARGETS = [
         "sha384_mgf1_48",
     ]
 ] + [
-    "//sw/host/cryptotest/testvectors/data:wycheproof_rsa_pss_3072_{}.json".format(hash)
-    for hash in [
-        "sha256_mgf1_32",
-        "shake128",
-    ]
+    "//sw/host/cryptotest/testvectors/data:wycheproof_rsa_pss_3072_sha256_mgf1_32.json",
 ] + [
     "//sw/host/cryptotest/testvectors/data:wycheproof_rsa_pss_4096_{}.json".format(hash)
     for hash in [
@@ -192,7 +188,6 @@ RSA_TESTVECTOR_TARGETS = [
         "sha384_mgf1_48",
         "sha512_mgf1_32",
         "sha512_mgf1_64",
-        "shake256",
     ]
 ] + [
     "//sw/host/cryptotest/testvectors/data:wycheproof_rsa_oaep_2048_{}.json".format(hash)

--- a/sw/device/tests/crypto/cryptotest/firmware/rsa.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/rsa.c
@@ -47,8 +47,6 @@ enum {
   kCryptotestRsaSha3_256 = 3,
   kCryptotestRsaSha3_384 = 4,
   kCryptotestRsaSha3_512 = 5,
-  kCryptotestRsaShake128 = 6,
-  kCryptotestRsaShake256 = 7,
 };
 
 // Use a constant Boolean mask to share the RSA private exponent.
@@ -134,12 +132,6 @@ status_t handle_rsa_encrypt(ujson_t *uj) {
       break;
     case kCryptotestRsaSha3_512:
       hash_mode = kOtcryptoHashModeSha3_512;
-      break;
-    case kCryptotestRsaShake128:
-      hash_mode = kOtcryptoHashXofModeShake128;
-      break;
-    case kCryptotestRsaShake256:
-      hash_mode = kOtcryptoHashXofModeShake256;
       break;
     default:
       LOG_ERROR("Unsupported RSA hash mode: %d", uj_input.hashing);
@@ -279,14 +271,6 @@ status_t handle_rsa_decrypt(ujson_t *uj) {
     case kCryptotestRsaSha3_512:
       hash_mode = kOtcryptoHashModeSha3_512;
       hash_digest_bytes = 512 / 8;
-      break;
-    case kCryptotestRsaShake128:
-      hash_mode = kOtcryptoHashXofModeShake128;
-      hash_digest_bytes = 128 / 8;
-      break;
-    case kCryptotestRsaShake256:
-      hash_mode = kOtcryptoHashXofModeShake256;
-      hash_digest_bytes = 256 / 8;
       break;
     default:
       LOG_ERROR("Unsupported RSA hash mode: %d", uj_input.hashing);
@@ -449,14 +433,6 @@ status_t handle_rsa_verify(ujson_t *uj) {
       hash_mode = kOtcryptoHashModeSha3_512;
       hash_digest_words = 512 / 32;
       break;
-    case kCryptotestRsaShake128:
-      hash_mode = kOtcryptoHashXofModeShake128;
-      hash_digest_words = 128 / 32;
-      break;
-    case kCryptotestRsaShake256:
-      hash_mode = kOtcryptoHashXofModeShake256;
-      hash_digest_words = 256 / 32;
-      break;
     default:
       LOG_ERROR("Unsupported RSA hash mode: %d", uj_input.hashing);
       return INVALID_ARGUMENT();
@@ -543,12 +519,6 @@ status_t handle_rsa_verify(ujson_t *uj) {
       break;
     case kOtcryptoHashModeSha3_512:
       TRY(otcrypto_sha3_512(msg_buf, &msg_digest));
-      break;
-    case kOtcryptoHashXofModeShake128:
-      TRY(otcrypto_shake128(msg_buf, &msg_digest));
-      break;
-    case kOtcryptoHashXofModeShake256:
-      TRY(otcrypto_shake256(msg_buf, &msg_digest));
       break;
     default:
       LOG_ERROR("Unsupported RSA hash mode: %d", uj_input.hashing);

--- a/sw/host/tests/crypto/rsa_kat/src/main.rs
+++ b/sw/host/tests/crypto/rsa_kat/src/main.rs
@@ -73,8 +73,6 @@ fn run_rsa_testcase(
         "sha3-256" => 3,
         "sha3-384" => 4,
         "sha3-512" => 5,
-        "shake-128" => 6,
-        "shake-256" => 7,
         _ => panic!("Invalid hashing mode"),
     };
 


### PR DESCRIPTION
Currently, we do not support SHAKE in RSA. This is in-line with RFC 8017, section [B.1](https://datatracker.ietf.org/doc/html/rfc8017#appendix-B.1) "Hash Functions".