### PR TITLE
[topgen,rtl] Fix param handling for AlertSkewCycles for alert_handler

### DIFF
--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -1355,6 +1355,7 @@ module top_darjeeling #(
       .rst_kmac_ni (rstmgr_aon_resets.rst_lc_n[rstmgr_pkg::Domain0Sel])
   );
   alert_handler #(
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .RndCnstLfsrSeed(RndCnstAlertHandlerLfsrSeed),
     .RndCnstLfsrPerm(RndCnstAlertHandlerLfsrPerm),
     .EscNumSeverities(AlertHandlerEscNumSeverities),

--- a/hw/top_darjeeling/templates/toplevel.sv.tpl
+++ b/hw/top_darjeeling/templates/toplevel.sv.tpl
@@ -515,16 +515,13 @@ max_sigwidth = max(len(x.name) for x in port_list) if port_list else 0
 max_intrwidth = (max(len(x.name) for x in block.interrupts)
                  if block.interrupts else 0)
 alert_info = top["alert_connections"].get("module_" + m["name"], {})
+has_params, param_items = lib.get_params(top, m)
 %>\
-  % if m["param_list"] or alert_info or m.get("racl_mappings"):
+  % if has_params:
   ${m["type"]} #(
 <%include file="/toplevel_racl_parameters.tpl" args="module=m,top=top,block=block"/>\
-  % if alert_info:
-    .AlertAsyncOn(${alert_info["async_expr"]}),
-    .AlertSkewCycles(top_pkg::AlertSkewCycles)${"," if m["param_list"] else ""}
-  % endif
-    % for i in m["param_list"]:
-    .${i["name"]}(${i["name_top" if i.get("expose") == "true" or i.get("randtype", "none") != "none" else "default"]})${"," if not loop.last else ""}
+    % for param_name, param_value in param_items:
+    ${param_name}(${param_value})${"," if not loop.last else ""}
     % endfor
   ) u_${m["name"]} (
   % else:

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1693,6 +1693,7 @@ module top_earlgrey #(
       .rst_kmac_ni (rstmgr_aon_resets.rst_lc_n[rstmgr_pkg::Domain0Sel])
   );
   alert_handler #(
+    .AlertSkewCycles(top_pkg::AlertSkewCycles),
     .RndCnstLfsrSeed(RndCnstAlertHandlerLfsrSeed),
     .RndCnstLfsrPerm(RndCnstAlertHandlerLfsrPerm),
     .EscNumSeverities(AlertHandlerEscNumSeverities),

--- a/hw/top_earlgrey/templates/toplevel.sv.tpl
+++ b/hw/top_earlgrey/templates/toplevel.sv.tpl
@@ -488,16 +488,13 @@ max_sigwidth = max(len(x.name) for x in port_list) if port_list else 0
 max_intrwidth = (max(len(x.name) for x in block.interrupts)
                  if block.interrupts else 0)
 alert_info = top["alert_connections"].get("module_" + m["name"], {})
+has_params, param_items = lib.get_params(top, m)
 %>\
-  % if m["param_list"] or alert_info or m.get("racl_mappings"):
+  % if has_params:
   ${m["type"]} #(
 <%include file="/toplevel_racl_parameters.tpl" args="module=m,top=top,block=block"/>\
-  % if alert_info:
-    .AlertAsyncOn(${alert_info["async_expr"]}),
-    .AlertSkewCycles(top_pkg::AlertSkewCycles)${"," if m["param_list"] else ""}
-  % endif
-    % for i in m["param_list"]:
-    .${i["name"]}(${i["name_top" if i.get("expose") == "true" or i.get("randtype", "none") != "none" else "default"]})${"," if not loop.last else ""}
+    % for param_name, param_value in param_items:
+    ${param_name}(${param_value})${"," if not loop.last else ""}
     % endfor
   ) u_${m["name"]} (
   % else:


### PR DESCRIPTION
Previously AlertSkewCycles is only set for modules that have alert_connections. However, the alert handler itself does not have alert_connections, so it was not getting the AlertSkewCycles parameter set. Thus the alert handler was using the default value of 1, causing an inconsistency if the parameter was set to a different value.

This commit fixes this by adding AlertSkewCycles to the alert handler parameters.