### PR TITLE
[ci] Do not run QEMU local dev test on merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -807,6 +807,7 @@ jobs:
     name: Test QEMU local development override
     runs-on: ubuntu-22.04
     needs: quick_lint
+    if: ${{ github.event_name != 'merge_group' }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Probably during backport, we forgot to gate this step, e.g. https://github.com/lowRISC/opentitan/actions/runs/19150819501 for a merge group run where it was not skipped.