### PR TITLE
[prim_sync] Add the ability for a customizable min delay on CDC prims

### DIFF
--- a/hw/ip/prim/prim_lc_sync.core
+++ b/hw/ip/prim/prim_lc_sync.core
@@ -9,6 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:prim:assert
+      - lowrisc:prim:prim_pkg
       - lowrisc:prim:flop_2sync
       - lowrisc:prim:buf
       - lowrisc:ip:lc_ctrl_pkg

--- a/hw/ip/prim/prim_mubi.core
+++ b/hw/ip/prim/prim_mubi.core
@@ -16,6 +16,7 @@ filesets:
       - lowrisc:prim:assert
       - lowrisc:prim:buf
       - lowrisc:prim:flop
+      - lowrisc:prim:prim_pkg
       - lowrisc:prim:mubi_pkg
     files:
       - rtl/prim_mubi4_sender.sv

--- a/hw/ip/prim/rtl/prim_mubi12_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi12_sync.sv
@@ -37,6 +37,9 @@ module prim_mubi12_sync
   input  mubi12_t                 mubi_i,
   output mubi12_t [NumCopies-1:0] mubi_o
 );
+`ifdef INC_ASSERT
+  localparam int MubiSyncMinDelayCycles = prim_pkg::get_cdc_min_delay_cycles();
+`endif
 
   `ASSERT_INIT(NumCopiesMustBeGreaterZero_A, NumCopies > 0)
 
@@ -117,8 +120,12 @@ module prim_mubi12_sync
         mubi_in_sva_q <= mubi_i;
       end
       `ASSERT(OutputIfUnstable_A, sig_unstable |-> mubi_o == {NumCopies{reset_value}})
+      // This assertion has a 3-stage data path: 2-stage sync + 1-stage stability flop.
+      // Delay = MubiSyncMinDelayCycles + 1. It may take an extra cycle to stabilize.
       `ASSERT(OutputDelay_A,
-              rst_ni |-> ##[3:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
+              rst_ni |-> ##[MubiSyncMinDelayCycles+1 : MubiSyncMinDelayCycles+2]
+                             sig_unstable ||
+                             mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}})
 `endif
     end else begin : gen_no_stable_chks
       assign mubi = mubi_sync;
@@ -127,9 +134,22 @@ module prim_mubi12_sync
       always_ff @(posedge clk_i) begin
         mubi_in_sva_q <= mubi_i;
       end
-      `ASSERT(OutputDelay_A,
-              rst_ni |-> ##3 (mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}} ||
-                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1)))
+      // This assertion has a 2-stage data path: 2-stage sync.
+      // Delay = MubiSyncMinDelayCycles. SVA checks 1 cycle later.
+      if (MubiSyncMinDelayCycles == 1) begin : gen_sva_delay_1
+        // Special case for N=1 to avoid illegal $past(..., 0)
+        `ASSERT(OutputDelay_A,
+          rst_ni |-> ##(MubiSyncMinDelayCycles + 1)
+                          (mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}} ||
+                          // $past(..., N-1) becomes the current value 'mubi_in_sva_q'
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles) != mubi_in_sva_q))
+      end else begin : gen_sva_delay_gt_1
+        `ASSERT(OutputDelay_A,
+          rst_ni |-> ##(MubiSyncMinDelayCycles + 1)
+                          (mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}} ||
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles) !=
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles - 1)))
+      end
 `endif
     end
   end else begin : gen_no_flops

--- a/hw/ip/prim/rtl/prim_mubi16_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi16_sync.sv
@@ -37,6 +37,9 @@ module prim_mubi16_sync
   input  mubi16_t                 mubi_i,
   output mubi16_t [NumCopies-1:0] mubi_o
 );
+`ifdef INC_ASSERT
+  localparam int MubiSyncMinDelayCycles = prim_pkg::get_cdc_min_delay_cycles();
+`endif
 
   `ASSERT_INIT(NumCopiesMustBeGreaterZero_A, NumCopies > 0)
 
@@ -117,8 +120,12 @@ module prim_mubi16_sync
         mubi_in_sva_q <= mubi_i;
       end
       `ASSERT(OutputIfUnstable_A, sig_unstable |-> mubi_o == {NumCopies{reset_value}})
+      // This assertion has a 3-stage data path: 2-stage sync + 1-stage stability flop.
+      // Delay = MubiSyncMinDelayCycles + 1. It may take an extra cycle to stabilize.
       `ASSERT(OutputDelay_A,
-              rst_ni |-> ##[3:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
+              rst_ni |-> ##[MubiSyncMinDelayCycles+1 : MubiSyncMinDelayCycles+2]
+                             sig_unstable ||
+                             mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}})
 `endif
     end else begin : gen_no_stable_chks
       assign mubi = mubi_sync;
@@ -127,9 +134,22 @@ module prim_mubi16_sync
       always_ff @(posedge clk_i) begin
         mubi_in_sva_q <= mubi_i;
       end
-      `ASSERT(OutputDelay_A,
-              rst_ni |-> ##3 (mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}} ||
-                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1)))
+      // This assertion has a 2-stage data path: 2-stage sync.
+      // Delay = MubiSyncMinDelayCycles. SVA checks 1 cycle later.
+      if (MubiSyncMinDelayCycles == 1) begin : gen_sva_delay_1
+        // Special case for N=1 to avoid illegal $past(..., 0)
+        `ASSERT(OutputDelay_A,
+          rst_ni |-> ##(MubiSyncMinDelayCycles + 1)
+                          (mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}} ||
+                          // $past(..., N-1) becomes the current value 'mubi_in_sva_q'
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles) != mubi_in_sva_q))
+      end else begin : gen_sva_delay_gt_1
+        `ASSERT(OutputDelay_A,
+          rst_ni |-> ##(MubiSyncMinDelayCycles + 1)
+                          (mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}} ||
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles) !=
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles - 1)))
+      end
 `endif
     end
   end else begin : gen_no_flops

--- a/hw/ip/prim/rtl/prim_mubi20_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi20_sync.sv
@@ -37,6 +37,9 @@ module prim_mubi20_sync
   input  mubi20_t                 mubi_i,
   output mubi20_t [NumCopies-1:0] mubi_o
 );
+`ifdef INC_ASSERT
+  localparam int MubiSyncMinDelayCycles = prim_pkg::get_cdc_min_delay_cycles();
+`endif
 
   `ASSERT_INIT(NumCopiesMustBeGreaterZero_A, NumCopies > 0)
 
@@ -117,8 +120,12 @@ module prim_mubi20_sync
         mubi_in_sva_q <= mubi_i;
       end
       `ASSERT(OutputIfUnstable_A, sig_unstable |-> mubi_o == {NumCopies{reset_value}})
+      // This assertion has a 3-stage data path: 2-stage sync + 1-stage stability flop.
+      // Delay = MubiSyncMinDelayCycles + 1. It may take an extra cycle to stabilize.
       `ASSERT(OutputDelay_A,
-              rst_ni |-> ##[3:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
+              rst_ni |-> ##[MubiSyncMinDelayCycles+1 : MubiSyncMinDelayCycles+2]
+                             sig_unstable ||
+                             mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}})
 `endif
     end else begin : gen_no_stable_chks
       assign mubi = mubi_sync;
@@ -127,9 +134,22 @@ module prim_mubi20_sync
       always_ff @(posedge clk_i) begin
         mubi_in_sva_q <= mubi_i;
       end
-      `ASSERT(OutputDelay_A,
-              rst_ni |-> ##3 (mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}} ||
-                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1)))
+      // This assertion has a 2-stage data path: 2-stage sync.
+      // Delay = MubiSyncMinDelayCycles. SVA checks 1 cycle later.
+      if (MubiSyncMinDelayCycles == 1) begin : gen_sva_delay_1
+        // Special case for N=1 to avoid illegal $past(..., 0)
+        `ASSERT(OutputDelay_A,
+          rst_ni |-> ##(MubiSyncMinDelayCycles + 1)
+                          (mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}} ||
+                          // $past(..., N-1) becomes the current value 'mubi_in_sva_q'
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles) != mubi_in_sva_q))
+      end else begin : gen_sva_delay_gt_1
+        `ASSERT(OutputDelay_A,
+          rst_ni |-> ##(MubiSyncMinDelayCycles + 1)
+                          (mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}} ||
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles) !=
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles - 1)))
+      end
 `endif
     end
   end else begin : gen_no_flops

--- a/hw/ip/prim/rtl/prim_mubi24_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi24_sync.sv
@@ -37,6 +37,9 @@ module prim_mubi24_sync
   input  mubi24_t                 mubi_i,
   output mubi24_t [NumCopies-1:0] mubi_o
 );
+`ifdef INC_ASSERT
+  localparam int MubiSyncMinDelayCycles = prim_pkg::get_cdc_min_delay_cycles();
+`endif
 
   `ASSERT_INIT(NumCopiesMustBeGreaterZero_A, NumCopies > 0)
 
@@ -117,8 +120,12 @@ module prim_mubi24_sync
         mubi_in_sva_q <= mubi_i;
       end
       `ASSERT(OutputIfUnstable_A, sig_unstable |-> mubi_o == {NumCopies{reset_value}})
+      // This assertion has a 3-stage data path: 2-stage sync + 1-stage stability flop.
+      // Delay = MubiSyncMinDelayCycles + 1. It may take an extra cycle to stabilize.
       `ASSERT(OutputDelay_A,
-              rst_ni |-> ##[3:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
+              rst_ni |-> ##[MubiSyncMinDelayCycles+1 : MubiSyncMinDelayCycles+2]
+                             sig_unstable ||
+                             mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}})
 `endif
     end else begin : gen_no_stable_chks
       assign mubi = mubi_sync;
@@ -127,9 +134,22 @@ module prim_mubi24_sync
       always_ff @(posedge clk_i) begin
         mubi_in_sva_q <= mubi_i;
       end
-      `ASSERT(OutputDelay_A,
-              rst_ni |-> ##3 (mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}} ||
-                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1)))
+      // This assertion has a 2-stage data path: 2-stage sync.
+      // Delay = MubiSyncMinDelayCycles. SVA checks 1 cycle later.
+      if (MubiSyncMinDelayCycles == 1) begin : gen_sva_delay_1
+        // Special case for N=1 to avoid illegal $past(..., 0)
+        `ASSERT(OutputDelay_A,
+          rst_ni |-> ##(MubiSyncMinDelayCycles + 1)
+                          (mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}} ||
+                          // $past(..., N-1) becomes the current value 'mubi_in_sva_q'
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles) != mubi_in_sva_q))
+      end else begin : gen_sva_delay_gt_1
+        `ASSERT(OutputDelay_A,
+          rst_ni |-> ##(MubiSyncMinDelayCycles + 1)
+                          (mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}} ||
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles) !=
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles - 1)))
+      end
 `endif
     end
   end else begin : gen_no_flops

--- a/hw/ip/prim/rtl/prim_mubi28_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi28_sync.sv
@@ -37,6 +37,9 @@ module prim_mubi28_sync
   input  mubi28_t                 mubi_i,
   output mubi28_t [NumCopies-1:0] mubi_o
 );
+`ifdef INC_ASSERT
+  localparam int MubiSyncMinDelayCycles = prim_pkg::get_cdc_min_delay_cycles();
+`endif
 
   `ASSERT_INIT(NumCopiesMustBeGreaterZero_A, NumCopies > 0)
 
@@ -117,8 +120,12 @@ module prim_mubi28_sync
         mubi_in_sva_q <= mubi_i;
       end
       `ASSERT(OutputIfUnstable_A, sig_unstable |-> mubi_o == {NumCopies{reset_value}})
+      // This assertion has a 3-stage data path: 2-stage sync + 1-stage stability flop.
+      // Delay = MubiSyncMinDelayCycles + 1. It may take an extra cycle to stabilize.
       `ASSERT(OutputDelay_A,
-              rst_ni |-> ##[3:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
+              rst_ni |-> ##[MubiSyncMinDelayCycles+1 : MubiSyncMinDelayCycles+2]
+                             sig_unstable ||
+                             mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}})
 `endif
     end else begin : gen_no_stable_chks
       assign mubi = mubi_sync;
@@ -127,9 +134,22 @@ module prim_mubi28_sync
       always_ff @(posedge clk_i) begin
         mubi_in_sva_q <= mubi_i;
       end
-      `ASSERT(OutputDelay_A,
-              rst_ni |-> ##3 (mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}} ||
-                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1)))
+      // This assertion has a 2-stage data path: 2-stage sync.
+      // Delay = MubiSyncMinDelayCycles. SVA checks 1 cycle later.
+      if (MubiSyncMinDelayCycles == 1) begin : gen_sva_delay_1
+        // Special case for N=1 to avoid illegal $past(..., 0)
+        `ASSERT(OutputDelay_A,
+          rst_ni |-> ##(MubiSyncMinDelayCycles + 1)
+                          (mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}} ||
+                          // $past(..., N-1) becomes the current value 'mubi_in_sva_q'
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles) != mubi_in_sva_q))
+      end else begin : gen_sva_delay_gt_1
+        `ASSERT(OutputDelay_A,
+          rst_ni |-> ##(MubiSyncMinDelayCycles + 1)
+                          (mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}} ||
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles) !=
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles - 1)))
+      end
 `endif
     end
   end else begin : gen_no_flops

--- a/hw/ip/prim/rtl/prim_mubi32_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi32_sync.sv
@@ -37,6 +37,9 @@ module prim_mubi32_sync
   input  mubi32_t                 mubi_i,
   output mubi32_t [NumCopies-1:0] mubi_o
 );
+`ifdef INC_ASSERT
+  localparam int MubiSyncMinDelayCycles = prim_pkg::get_cdc_min_delay_cycles();
+`endif
 
   `ASSERT_INIT(NumCopiesMustBeGreaterZero_A, NumCopies > 0)
 
@@ -117,8 +120,12 @@ module prim_mubi32_sync
         mubi_in_sva_q <= mubi_i;
       end
       `ASSERT(OutputIfUnstable_A, sig_unstable |-> mubi_o == {NumCopies{reset_value}})
+      // This assertion has a 3-stage data path: 2-stage sync + 1-stage stability flop.
+      // Delay = MubiSyncMinDelayCycles + 1. It may take an extra cycle to stabilize.
       `ASSERT(OutputDelay_A,
-              rst_ni |-> ##[3:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
+              rst_ni |-> ##[MubiSyncMinDelayCycles+1 : MubiSyncMinDelayCycles+2]
+                             sig_unstable ||
+                             mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}})
 `endif
     end else begin : gen_no_stable_chks
       assign mubi = mubi_sync;
@@ -127,9 +134,22 @@ module prim_mubi32_sync
       always_ff @(posedge clk_i) begin
         mubi_in_sva_q <= mubi_i;
       end
-      `ASSERT(OutputDelay_A,
-              rst_ni |-> ##3 (mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}} ||
-                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1)))
+      // This assertion has a 2-stage data path: 2-stage sync.
+      // Delay = MubiSyncMinDelayCycles. SVA checks 1 cycle later.
+      if (MubiSyncMinDelayCycles == 1) begin : gen_sva_delay_1
+        // Special case for N=1 to avoid illegal $past(..., 0)
+        `ASSERT(OutputDelay_A,
+          rst_ni |-> ##(MubiSyncMinDelayCycles + 1)
+                          (mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}} ||
+                          // $past(..., N-1) becomes the current value 'mubi_in_sva_q'
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles) != mubi_in_sva_q))
+      end else begin : gen_sva_delay_gt_1
+        `ASSERT(OutputDelay_A,
+          rst_ni |-> ##(MubiSyncMinDelayCycles + 1)
+                          (mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}} ||
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles) !=
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles - 1)))
+      end
 `endif
     end
   end else begin : gen_no_flops

--- a/hw/ip/prim/rtl/prim_mubi4_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi4_sync.sv
@@ -37,6 +37,9 @@ module prim_mubi4_sync
   input  mubi4_t                 mubi_i,
   output mubi4_t [NumCopies-1:0] mubi_o
 );
+`ifdef INC_ASSERT
+  localparam int MubiSyncMinDelayCycles = prim_pkg::get_cdc_min_delay_cycles();
+`endif
 
   `ASSERT_INIT(NumCopiesMustBeGreaterZero_A, NumCopies > 0)
 
@@ -117,8 +120,12 @@ module prim_mubi4_sync
         mubi_in_sva_q <= mubi_i;
       end
       `ASSERT(OutputIfUnstable_A, sig_unstable |-> mubi_o == {NumCopies{reset_value}})
+      // This assertion has a 3-stage data path: 2-stage sync + 1-stage stability flop.
+      // Delay = MubiSyncMinDelayCycles + 1. It may take an extra cycle to stabilize.
       `ASSERT(OutputDelay_A,
-              rst_ni |-> ##[3:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
+              rst_ni |-> ##[MubiSyncMinDelayCycles+1 : MubiSyncMinDelayCycles+2]
+                             sig_unstable ||
+                             mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}})
 `endif
     end else begin : gen_no_stable_chks
       assign mubi = mubi_sync;
@@ -127,9 +134,22 @@ module prim_mubi4_sync
       always_ff @(posedge clk_i) begin
         mubi_in_sva_q <= mubi_i;
       end
-      `ASSERT(OutputDelay_A,
-              rst_ni |-> ##3 (mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}} ||
-                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1)))
+      // This assertion has a 2-stage data path: 2-stage sync.
+      // Delay = MubiSyncMinDelayCycles. SVA checks 1 cycle later.
+      if (MubiSyncMinDelayCycles == 1) begin : gen_sva_delay_1
+        // Special case for N=1 to avoid illegal $past(..., 0)
+        `ASSERT(OutputDelay_A,
+          rst_ni |-> ##(MubiSyncMinDelayCycles + 1)
+                          (mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}} ||
+                          // $past(..., N-1) becomes the current value 'mubi_in_sva_q'
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles) != mubi_in_sva_q))
+      end else begin : gen_sva_delay_gt_1
+        `ASSERT(OutputDelay_A,
+          rst_ni |-> ##(MubiSyncMinDelayCycles + 1)
+                          (mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}} ||
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles) !=
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles - 1)))
+      end
 `endif
     end
   end else begin : gen_no_flops

--- a/hw/ip/prim_asap7/rtl/prim_pkg.sv
+++ b/hw/ip/prim_asap7/rtl/prim_pkg.sv
@@ -7,4 +7,11 @@ package prim_pkg;
   // The name of the technology implementation.
   parameter PrimTechName = "Asap7";
 
+  // The minimum delay in cycles it can take a signal to propagate through a CDC prim_2sync flop.
+  parameter int CdcMinDelayCycles = 1;
+
+  function automatic int get_cdc_min_delay_cycles();
+    return CdcMinDelayCycles;
+  endfunction
+
 endpackage // prim_pkg

--- a/hw/ip/prim_generic/rtl/prim_pkg.sv
+++ b/hw/ip/prim_generic/rtl/prim_pkg.sv
@@ -7,4 +7,11 @@ package prim_pkg;
   // The name of the technology implementation.
   parameter PrimTechName = "Generic";
 
+  // The minimum delay in cycles it can take a signal to propagate through a CDC prim_2sync flop.
+  parameter int CdcMinDelayCycles = 1;
+
+  function automatic int get_cdc_min_delay_cycles();
+    return CdcMinDelayCycles;
+  endfunction
+
 endpackage // prim_pkg

--- a/hw/ip/prim_xilinx/rtl/prim_pkg.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_pkg.sv
@@ -7,4 +7,11 @@ package prim_pkg;
   // The name of the technology implementation.
   parameter PrimTechName = "Xilinx";
 
+  // The minimum delay in cycles it can take a signal to propagate through a CDC prim_2sync flop.
+  parameter int CdcMinDelayCycles = 1;
+
+  function automatic int get_cdc_min_delay_cycles();
+    return CdcMinDelayCycles;
+  endfunction
+
 endpackage // prim_pkg

--- a/hw/ip/prim_xilinx_ultrascale/rtl/prim_pkg.sv
+++ b/hw/ip/prim_xilinx_ultrascale/rtl/prim_pkg.sv
@@ -7,4 +7,11 @@ package prim_pkg;
   // The name of the technology implementation.
   parameter PrimTechName = "XilinxUltrascale";
 
+  // The minimum delay in cycles it can take a signal to propagate through a CDC prim_2sync flop.
+  parameter int CdcMinDelayCycles = 1;
+
+  function automatic int get_cdc_min_delay_cycles();
+    return CdcMinDelayCycles;
+  endfunction
+
 endpackage // prim_pkg

--- a/util/design/data/prim_mubi.core.tpl
+++ b/util/design/data/prim_mubi.core.tpl
@@ -16,6 +16,7 @@ filesets:
       - lowrisc:prim:assert
       - lowrisc:prim:buf
       - lowrisc:prim:flop
+      - lowrisc:prim:prim_pkg
       - lowrisc:prim:mubi_pkg
     files:
 % for n in range(1, n_max_nibbles+1):

--- a/util/design/data/prim_mubi_sync.sv.tpl
+++ b/util/design/data/prim_mubi_sync.sv.tpl
@@ -37,6 +37,9 @@ module prim_mubi${n_bits}_sync
   input  mubi${n_bits}_t                 mubi_i,
   output mubi${n_bits}_t [NumCopies-1:0] mubi_o
 );
+`ifdef INC_ASSERT
+  localparam int MubiSyncMinDelayCycles = prim_pkg::get_cdc_min_delay_cycles();
+`endif
 
   `ASSERT_INIT(NumCopiesMustBeGreaterZero_A, NumCopies > 0)
 
@@ -117,8 +120,12 @@ module prim_mubi${n_bits}_sync
         mubi_in_sva_q <= mubi_i;
       end
       `ASSERT(OutputIfUnstable_A, sig_unstable |-> mubi_o == {NumCopies{reset_value}})
+      // This assertion has a 3-stage data path: 2-stage sync + 1-stage stability flop.
+      // Delay = MubiSyncMinDelayCycles + 1. It may take an extra cycle to stabilize.
       `ASSERT(OutputDelay_A,
-              rst_ni |-> ##[3:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
+              rst_ni |-> ##[MubiSyncMinDelayCycles+1 : MubiSyncMinDelayCycles+2]
+                             sig_unstable ||
+                             mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}})
 `endif
     end else begin : gen_no_stable_chks
       assign mubi = mubi_sync;
@@ -127,9 +134,22 @@ module prim_mubi${n_bits}_sync
       always_ff @(posedge clk_i) begin
         mubi_in_sva_q <= mubi_i;
       end
-      `ASSERT(OutputDelay_A,
-              rst_ni |-> ##3 (mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}} ||
-                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1)))
+      // This assertion has a 2-stage data path: 2-stage sync.
+      // Delay = MubiSyncMinDelayCycles. SVA checks 1 cycle later.
+      if (MubiSyncMinDelayCycles == 1) begin : gen_sva_delay_1
+        // Special case for N=1 to avoid illegal $past(..., 0)
+        `ASSERT(OutputDelay_A,
+          rst_ni |-> ##(MubiSyncMinDelayCycles + 1)
+                          (mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}} ||
+                          // $past(..., N-1) becomes the current value 'mubi_in_sva_q'
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles) != mubi_in_sva_q))
+      end else begin : gen_sva_delay_gt_1
+        `ASSERT(OutputDelay_A,
+          rst_ni |-> ##(MubiSyncMinDelayCycles + 1)
+                          (mubi_o == {NumCopies{$past(mubi_in_sva_q, MubiSyncMinDelayCycles)}} ||
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles) !=
+                          $past(mubi_in_sva_q, MubiSyncMinDelayCycles - 1)))
+      end
 `endif
     end
   end else begin : gen_no_flops


### PR DESCRIPTION
For CDC of a simple signal and mubi signals, a `prim_flop_2sync` primitive is used, a 2-flop synchronizer. These two flops, back-to-back, would have a signal delay of 2 cycles. Assertions in `prim_mubi_sync` and `prim_lc_sync` use this assumption of 2 cycles to model assertions around it with respect to signal stability.

However, CDC is _scary_! A more pessimistic assumption is that the signal delay through the 2-flop synchronizer is only 1 clock cycle. Due to a race, a signal between two clock domains can pass through the first flop, only yielding a 1 cycle delay.

To model that, I parameterized the assertions with a parameter `CdcMinDelayCycles`. This parameter is defined in a new, per-technology prim package. The fusesoc virtual core mapping feature is used to select the right package. In the default `prim_generic` version of this package, the parameter is set to 2, to have the same behavior. Asap7 and the Xilinx prims reuse the same package as they also reuse the `prim_flop_2sync` from `prim_generic`.

There is a cleanup commit ahead of this change. It moves the legacy `prim_pkg` to the tech lib. Instead of adding the tech lib to an enum, each tech lib defines a string parameter to identify itself. That is then used in the DV code to create tech library-specific code. The further benefit is that you can use out-of-tree prim libs without the need to change this enum.

Closes https://github.com/lowRISC/opentitan/issues/27347