### PR TITLE
[racl_ctrl,rtl] Use tighter assertion about alert generation

### DIFF
--- a/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
+++ b/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
@@ -243,6 +243,10 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
 
   `ASSERT_KNOWN(RaclErrorKnown_A, racl_policies_o)
 
-  // Alert assertions for reg_we onehot check
-  `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[0])
+  `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT_IN(
+      RegWeOnehotCheck_A,
+      u_reg,
+      gen_alert_tx[AlertFatalFaultIdx].u_prim_alert_sender.alert_req_i
+  )
+
 endmodule

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv
@@ -222,6 +222,10 @@ module racl_ctrl import racl_ctrl_reg_pkg::*; #(
 
   `ASSERT_KNOWN(RaclErrorKnown_A, racl_policies_o)
 
-  // Alert assertions for reg_we onehot check
-  `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[0])
+  `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT_IN(
+      RegWeOnehotCheck_A,
+      u_reg,
+      gen_alert_tx[AlertFatalFaultIdx].u_prim_alert_sender.alert_req_i
+  )
+
 endmodule


### PR DESCRIPTION
The ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT assertion isn't strictly true, which is seen a formal context because the FPV environment can drive the stateful alert bus so that the alert_p signal never goes high.

Fortunately, we have separately verified the alert_sender / alert_receiver pair, so we can change the assertion to just check that we *ask* the sender to send an alert.