### PR TITLE
[cryptotest] Fix bug in RSA testvector parser

### DIFF
--- a/sw/host/cryptotest/testvectors/parsers/wycheproof_rsa_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/wycheproof_rsa_parser.py
@@ -71,7 +71,7 @@ def parse_test_vectors(raw_data, args):
                     encrypt_test_vec["operation"] = "encrypt"
                     test_vectors.append(encrypt_test_vec)
 
-        return test_vectors
+    return test_vectors
 
 
 def main():


### PR DESCRIPTION
We only should abort parsing once we have iterated over all test_groups. Although this is a bug in the `wycheproof_rsa_parser` there was no impact on RSA testing as the wycheproof testvectors for RSA only consist of a single group.

However, it is better to fix this as it could be that future test vectors could have multiple groups.