### PR TITLE
[hw,prim_generic,core] Use generic version of prims in leaf cores

### DIFF
--- a/hw/ip/prim_generic/prim_generic_clock_div.core
+++ b/hw/ip/prim_generic/prim_generic_clock_div.core
@@ -12,9 +12,9 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:prim:assert
-      - lowrisc:prim:flop
-      - lowrisc:prim:clock_inv
-      - lowrisc:prim:clock_buf
+      - lowrisc:prim_generic:flop
+      - lowrisc:prim_generic:clock_inv
+      - lowrisc:prim_generic:clock_buf
     files:
       - rtl/prim_clock_div.sv
     file_type: systemVerilogSource

--- a/hw/ip/prim_generic/prim_generic_clock_inv.core
+++ b/hw/ip/prim_generic/prim_generic_clock_inv.core
@@ -12,7 +12,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:prim:assert
-      - lowrisc:prim:clock_mux2
+      - lowrisc:prim_generic:clock_mux2
     files:
       - rtl/prim_clock_inv.sv
     file_type: systemVerilogSource

--- a/hw/ip/prim_generic/prim_generic_flash.core
+++ b/hw/ip/prim_generic/prim_generic_flash.core
@@ -12,7 +12,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:tlul:headers
-      - lowrisc:prim:ram_1p
+      - lowrisc:prim_generic:ram_1p
       - "fileset_partner  ? (partner:systems:ast_pkg)"
       - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
       - lowrisc:virtual_ip:flash_ctrl_top_specific_pkg

--- a/hw/ip/prim_generic/prim_generic_flop_2sync.core
+++ b/hw/ip/prim_generic/prim_generic_flop_2sync.core
@@ -12,7 +12,7 @@ filesets:
   files_rtl:
     depend:
       # Needed because the generic impl instantiates prim_flop.
-      - lowrisc:prim:flop
+      - lowrisc:prim_generic:flop
       # Needed for DV.
       - lowrisc:prim:cdc_rand_delay
     files:


### PR DESCRIPTION
Within `prim_generic` one should not reference abstract prims. Here, we are technology-dependent. Use those.