### PR TITLE
[otp_ctrl,dv] Avoid reporting ECC errors reading Zeroize markers

### DIFF
--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv.tpl
@@ -215,33 +215,38 @@ package otp_ctrl_env_pkg;
     return PartInfo[part_idx].hw_digest;
   endfunction
 
+  // Return the address of the last 64 bits of the given partition
+  function automatic bit [TL_DW-1:0] last_64_addr(int unsigned part_idx);
+    return (PartInfo[part_idx].offset + PartInfo[part_idx].size) - 8;
+  endfunction
+
+  // Return true if the address points into the first 32 bits of a partition digest for the given
+  // partition (HW or SW)
+  function automatic bit is_digest_for(bit [TL_DW-1:0] addr, int unsigned part_idx);
+    if (!PartInfo[part_idx].sw_digest && !PartInfo[part_idx].hw_digest) return 0;
+
+    // If the partition contains a digest, it will be the last 64 bits of the partition, unless
+    // there is also a zeroization marker. When both are present, the digest comes just before the
+    // zeroisation marker.
+    return {addr[TL_DW-1:3], 3'b0} == (last_64_addr(part_idx) -
+                                       (PartInfo[part_idx].zeroizable ? 8 : 0));
+  endfunction
+
   function automatic bit is_sw_digest(bit [TL_DW-1:0] addr);
     int part_idx = get_part_index(addr);
-    if (PartInfo[part_idx].sw_digest) begin
-      // If the partition contains a digest, it will be located in the last 64bit of the partition.
-      return {addr[TL_DW-1:3], 3'b0} == ((PartInfo[part_idx].offset + PartInfo[part_idx].size) - 8);
-    end else begin
-      return 0;
-    end
+    return PartInfo[part_idx].sw_digest && is_digest_for(addr, part_idx);
   endfunction
 
   function automatic bit is_digest(bit [TL_DW-1:0] addr);
-    int part_idx = get_part_index(addr);
-    if (PartInfo[part_idx].sw_digest || PartInfo[part_idx].hw_digest) begin
-      // If the partition contains a digest, it will be located in the last 64bit of the partition.
-      return {addr[TL_DW-1:3], 3'b0} == ((PartInfo[part_idx].offset + PartInfo[part_idx].size) - 8);
-    end else begin
-      return 0;
-    end
+    return is_digest_for(addr, get_part_index(addr));
   endfunction
 
   // Return true if this is the address of the Zeroize marker for a partition with zeroization
   function automatic bit is_zeroize_marker(bit [TL_DW-1:0] addr);
     int unsigned part_idx = get_part_index(addr);
-    int unsigned marker_addr = PartInfo[part_idx].offset + PartInfo[part_idx].size - 8;
 
     // If the partition is zeroizable, its Zeroize status is in the last 64 bits of the partition.
-    return (PartInfo[part_idx].zeroizable && (addr == marker_addr));
+    return (PartInfo[part_idx].zeroizable && (addr == last_64_addr(part_idx)));
   endfunction
 
   function automatic bit is_sw_part(bit [TL_DW-1:0] addr);

--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv.tpl
@@ -235,6 +235,15 @@ package otp_ctrl_env_pkg;
     end
   endfunction
 
+  // Return true if this is the address of the Zeroize marker for a partition with zeroization
+  function automatic bit is_zeroize_marker(bit [TL_DW-1:0] addr);
+    int unsigned part_idx = get_part_index(addr);
+    int unsigned marker_addr = PartInfo[part_idx].offset + PartInfo[part_idx].size - 8;
+
+    // If the partition is zeroizable, its Zeroize status is in the last 64 bits of the partition.
+    return (PartInfo[part_idx].zeroizable && (addr == marker_addr));
+  endfunction
+
   function automatic bit is_sw_part(bit [TL_DW-1:0] addr);
     int part_idx = get_part_index(addr);
     return is_sw_part_idx(part_idx);

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -277,6 +277,15 @@ package otp_ctrl_env_pkg;
     end
   endfunction
 
+  // Return true if this is the address of the Zeroize marker for a partition with zeroization
+  function automatic bit is_zeroize_marker(bit [TL_DW-1:0] addr);
+    int unsigned part_idx = get_part_index(addr);
+    int unsigned marker_addr = PartInfo[part_idx].offset + PartInfo[part_idx].size - 8;
+
+    // If the partition is zeroizable, its Zeroize status is in the last 64 bits of the partition.
+    return (PartInfo[part_idx].zeroizable && (addr == marker_addr));
+  endfunction
+
   function automatic bit is_sw_part(bit [TL_DW-1:0] addr);
     int part_idx = get_part_index(addr);
     return is_sw_part_idx(part_idx);

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -765,26 +765,42 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
                 end else begin
                   bit [TL_DW-1:0] read_out0, read_out1;
                   bit [TL_AW-1:0] otp_addr = get_scb_otp_addr();
-                  int ecc_err = 0;
+                  int             ecc_err = 0;
 
-                  // Backdoor read to check if there is any ECC error.
+                  // Some addreses point at fuses that take 64 bits in the address space. Reading
+                  // such a fuse will pick up ECC errors from both 32-bit words. We also choose to
+                  // update our prediction for the whole 64 bits in this situation.
+                  bit is_64_bit_fuse = (is_secret(dai_addr) ||
+                                        is_digest(dai_addr) ||
+                                        is_zeroize_marker(dai_addr));
+
+                  // Backdoor read the fuse
+                  //
+                  // If this is a partition with integrity, we normally want to use
+                  // read_a_word_with_ecc, which will report any ECC error and correct it if
+                  // possible. If the partition doesn't have integrity, we use
+                  // read_a_word_with_ecc_raw instead.
+                  //
+                  // As a special case, if this is the Zeroize marker on a partition with integrity,
+                  // we use the second function (modelling the ReadRaw OTP command) and discard any
+                  // ECC errors.
                   if (part_has_integrity(part_idx)) begin
                     ecc_err = read_a_word_with_ecc(dai_addr, read_out0);
-                    if (is_secret(dai_addr) || is_digest(dai_addr)) begin
+                    if (is_64_bit_fuse) begin
                       ecc_err = max2(read_a_word_with_ecc(dai_addr + 4, read_out1), ecc_err);
                     end
+                    if (is_zeroize_marker(dai_addr)) ecc_err = 0;
                   end else begin
-                    ecc_err = read_a_word_with_ecc_raw(dai_addr, read_out0);
-                    if (is_secret(dai_addr) || is_digest(dai_addr)) begin
-                      ecc_err = max2(read_a_word_with_ecc_raw(dai_addr + 4, read_out1), ecc_err);
+                    read_a_word_with_ecc_raw(dai_addr, read_out0);
+                    if (is_64_bit_fuse) begin
+                      max2(read_a_word_with_ecc_raw(dai_addr + 4, read_out1), ecc_err);
                     end
                   end
 
                   if (ecc_err == OtpEccCorrErr && part_has_integrity(part_idx)) begin
                     predict_err(OtpDaiErrIdx, OtpMacroEccCorrError);
                     backdoor_update_otp_array(dai_addr);
-                    predict_rdata(is_secret(dai_addr) || is_digest(dai_addr),
-                                  otp_a[otp_addr], otp_a[otp_addr+1]);
+                    predict_rdata(is_64_bit_fuse, otp_a[otp_addr], otp_a[otp_addr+1]);
                   end else if (ecc_err == OtpEccUncorrErr && part_has_integrity(part_idx)) begin
                     predict_err(OtpDaiErrIdx, OtpMacroEccUncorrError);
                     // Max wait 20 clock cycles because scb did not know when exactly OTP will
@@ -796,15 +812,13 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
                   end else if (ecc_err inside {OtpEccCorrErr, OtpEccUncorrErr} &&
                                !part_has_integrity(part_idx)) begin
                     predict_no_err(OtpDaiErrIdx);
-                    predict_rdata(is_secret(dai_addr) || is_digest(dai_addr),
-                                  read_out0, read_out1);
+                    predict_rdata(is_64_bit_fuse, read_out0, read_out1);
                     // do not check direct_access_rdata_* on ECC errors in
                     // non-integrity partitions
                     check_dai_rd_data = 0;
                   end else begin
                     predict_no_err(OtpDaiErrIdx);
-                    predict_rdata(is_secret(dai_addr) || is_digest(dai_addr),
-                                  otp_a[otp_addr], otp_a[otp_addr+1]);
+                    predict_rdata(is_64_bit_fuse, otp_a[otp_addr], otp_a[otp_addr+1]);
                   end
                 end
               end

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -215,33 +215,38 @@ package otp_ctrl_env_pkg;
     return PartInfo[part_idx].hw_digest;
   endfunction
 
+  // Return the address of the last 64 bits of the given partition
+  function automatic bit [TL_DW-1:0] last_64_addr(int unsigned part_idx);
+    return (PartInfo[part_idx].offset + PartInfo[part_idx].size) - 8;
+  endfunction
+
+  // Return true if the address points into the first 32 bits of a partition digest for the given
+  // partition (HW or SW)
+  function automatic bit is_digest_for(bit [TL_DW-1:0] addr, int unsigned part_idx);
+    if (!PartInfo[part_idx].sw_digest && !PartInfo[part_idx].hw_digest) return 0;
+
+    // If the partition contains a digest, it will be the last 64 bits of the partition, unless
+    // there is also a zeroization marker. When both are present, the digest comes just before the
+    // zeroisation marker.
+    return {addr[TL_DW-1:3], 3'b0} == (last_64_addr(part_idx) -
+                                       (PartInfo[part_idx].zeroizable ? 8 : 0));
+  endfunction
+
   function automatic bit is_sw_digest(bit [TL_DW-1:0] addr);
     int part_idx = get_part_index(addr);
-    if (PartInfo[part_idx].sw_digest) begin
-      // If the partition contains a digest, it will be located in the last 64bit of the partition.
-      return {addr[TL_DW-1:3], 3'b0} == ((PartInfo[part_idx].offset + PartInfo[part_idx].size) - 8);
-    end else begin
-      return 0;
-    end
+    return PartInfo[part_idx].sw_digest && is_digest_for(addr, part_idx);
   endfunction
 
   function automatic bit is_digest(bit [TL_DW-1:0] addr);
-    int part_idx = get_part_index(addr);
-    if (PartInfo[part_idx].sw_digest || PartInfo[part_idx].hw_digest) begin
-      // If the partition contains a digest, it will be located in the last 64bit of the partition.
-      return {addr[TL_DW-1:3], 3'b0} == ((PartInfo[part_idx].offset + PartInfo[part_idx].size) - 8);
-    end else begin
-      return 0;
-    end
+    return is_digest_for(addr, get_part_index(addr));
   endfunction
 
   // Return true if this is the address of the Zeroize marker for a partition with zeroization
   function automatic bit is_zeroize_marker(bit [TL_DW-1:0] addr);
     int unsigned part_idx = get_part_index(addr);
-    int unsigned marker_addr = PartInfo[part_idx].offset + PartInfo[part_idx].size - 8;
 
     // If the partition is zeroizable, its Zeroize status is in the last 64 bits of the partition.
-    return (PartInfo[part_idx].zeroizable && (addr == marker_addr));
+    return (PartInfo[part_idx].zeroizable && (addr == last_64_addr(part_idx)));
   endfunction
 
   function automatic bit is_sw_part(bit [TL_DW-1:0] addr);

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -235,6 +235,15 @@ package otp_ctrl_env_pkg;
     end
   endfunction
 
+  // Return true if this is the address of the Zeroize marker for a partition with zeroization
+  function automatic bit is_zeroize_marker(bit [TL_DW-1:0] addr);
+    int unsigned part_idx = get_part_index(addr);
+    int unsigned marker_addr = PartInfo[part_idx].offset + PartInfo[part_idx].size - 8;
+
+    // If the partition is zeroizable, its Zeroize status is in the last 64 bits of the partition.
+    return (PartInfo[part_idx].zeroizable && (addr == marker_addr));
+  endfunction
+
   function automatic bit is_sw_part(bit [TL_DW-1:0] addr);
     int part_idx = get_part_index(addr);
     return is_sw_part_idx(part_idx);

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -765,26 +765,42 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
                 end else begin
                   bit [TL_DW-1:0] read_out0, read_out1;
                   bit [TL_AW-1:0] otp_addr = get_scb_otp_addr();
-                  int ecc_err = 0;
+                  int             ecc_err = 0;
 
-                  // Backdoor read to check if there is any ECC error.
+                  // Some addreses point at fuses that take 64 bits in the address space. Reading
+                  // such a fuse will pick up ECC errors from both 32-bit words. We also choose to
+                  // update our prediction for the whole 64 bits in this situation.
+                  bit is_64_bit_fuse = (is_secret(dai_addr) ||
+                                        is_digest(dai_addr) ||
+                                        is_zeroize_marker(dai_addr));
+
+                  // Backdoor read the fuse
+                  //
+                  // If this is a partition with integrity, we normally want to use
+                  // read_a_word_with_ecc, which will report any ECC error and correct it if
+                  // possible. If the partition doesn't have integrity, we use
+                  // read_a_word_with_ecc_raw instead.
+                  //
+                  // As a special case, if this is the Zeroize marker on a partition with integrity,
+                  // we use the second function (modelling the ReadRaw OTP command) and discard any
+                  // ECC errors.
                   if (part_has_integrity(part_idx)) begin
                     ecc_err = read_a_word_with_ecc(dai_addr, read_out0);
-                    if (is_secret(dai_addr) || is_digest(dai_addr)) begin
+                    if (is_64_bit_fuse) begin
                       ecc_err = max2(read_a_word_with_ecc(dai_addr + 4, read_out1), ecc_err);
                     end
+                    if (is_zeroize_marker(dai_addr)) ecc_err = 0;
                   end else begin
-                    ecc_err = read_a_word_with_ecc_raw(dai_addr, read_out0);
-                    if (is_secret(dai_addr) || is_digest(dai_addr)) begin
-                      ecc_err = max2(read_a_word_with_ecc_raw(dai_addr + 4, read_out1), ecc_err);
+                    read_a_word_with_ecc_raw(dai_addr, read_out0);
+                    if (is_64_bit_fuse) begin
+                      max2(read_a_word_with_ecc_raw(dai_addr + 4, read_out1), ecc_err);
                     end
                   end
 
                   if (ecc_err == OtpEccCorrErr && part_has_integrity(part_idx)) begin
                     predict_err(OtpDaiErrIdx, OtpMacroEccCorrError);
                     backdoor_update_otp_array(dai_addr);
-                    predict_rdata(is_secret(dai_addr) || is_digest(dai_addr),
-                                  otp_a[otp_addr], otp_a[otp_addr+1]);
+                    predict_rdata(is_64_bit_fuse, otp_a[otp_addr], otp_a[otp_addr+1]);
                   end else if (ecc_err == OtpEccUncorrErr && part_has_integrity(part_idx)) begin
                     predict_err(OtpDaiErrIdx, OtpMacroEccUncorrError);
                     // Max wait 20 clock cycles because scb did not know when exactly OTP will
@@ -796,15 +812,13 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
                   end else if (ecc_err inside {OtpEccCorrErr, OtpEccUncorrErr} &&
                                !part_has_integrity(part_idx)) begin
                     predict_no_err(OtpDaiErrIdx);
-                    predict_rdata(is_secret(dai_addr) || is_digest(dai_addr),
-                                  read_out0, read_out1);
+                    predict_rdata(is_64_bit_fuse, read_out0, read_out1);
                     // do not check direct_access_rdata_* on ECC errors in
                     // non-integrity partitions
                     check_dai_rd_data = 0;
                   end else begin
                     predict_no_err(OtpDaiErrIdx);
-                    predict_rdata(is_secret(dai_addr) || is_digest(dai_addr),
-                                  otp_a[otp_addr], otp_a[otp_addr+1]);
+                    predict_rdata(is_64_bit_fuse, otp_a[otp_addr], otp_a[otp_addr+1]);
                   end
                 end
               end


### PR DESCRIPTION
This fixes the first otp_ctrl_macro_errs test I ran. Upsettingly, the pass rate for this test is still terrible (roughly 50%). But I think *this* change makes sense.