### PR TITLE
Revert "[otbn,dv] Correctly stringify names in otbn_env_cov"

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -76,8 +76,12 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
 
   // A macro used for coverpoints for mnemonics. This expands to entries like
   //
-  //    bins mnem_add = {"mnem_add"};
-`define DEF_MNEM_BIN(NAME) bins NAME = {`"NAME`"}
+  //    bins mnem_add = {mnem_add};
+  //
+  // The right hand side here is a some string variable defined with DEF_MNEM in the previous block
+  // of code. This is sort of equivalent to something like bins mnem_add = {"add"}, but it wraps the
+  // string literal in a variable, which turns out to be needed for coverage with VCS.
+`define DEF_MNEM_BIN(NAME) bins NAME = {NAME}
 
   // Generate a bin for each mnemonic except ECALL
 `define DEF_MNEM_BINS_EXCEPT_ECALL                                     \
@@ -109,14 +113,16 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     `DEF_MNEM_BIN(mnem_bn_mov); `DEF_MNEM_BIN(mnem_bn_movr);           \
     `DEF_MNEM_BIN(mnem_bn_wsrr); `DEF_MNEM_BIN(mnem_bn_wsrw);
 
-  // Equivalents of DEF_MNEM and DEF_MNEM_BINp, but for external CSRs. Again, we want to use the CSR
+  // Equivalents of DEF_MNEM and DEF_MNEM_BIN, but for external CSRs. Again, we want to use the CSR
   // names as bins in coverpoints and need sized literals.
 `define DEF_CSR(CSR_NAME, STR) \
   csr_str_t CSR_NAME = csr_str_t'(STR)
   `DEF_CSR(csr_load_checksum, "load_checksum");
   `DEF_CSR(csr_ctrl, "ctrl");
 `undef DEF_CSR
-`define DEF_CSR_BIN(NAME) bins NAME = {`"NAME`"}
+  // Define a bin for a CSR. This is analogous to DEF_MNEM_BIN (which has a detailed explanation of
+  // how it works).
+`define DEF_CSR_BIN(NAME) bins NAME = {NAME}
 
   // Cross one, two or three coverpoints with mnemonic_cp.
   //


### PR DESCRIPTION
This reverts commit e9986ef486ed9a58064d7927ae574bb20a150af5, which was both "terribly clever" and wrong. Sigh.

To avoid someone making the same mistake again, I'm also expanding the documentation comment to explain how it was supposed to work.

Fixes #28657.