### PR TITLE
[keymgr/keymgr_dpe,rtl] Fix wrong cast

### DIFF
--- a/hw/ip/keymgr/rtl/keymgr_input_checks.sv
+++ b/hw/ip/keymgr/rtl/keymgr_input_checks.sv
@@ -98,10 +98,23 @@ module keymgr_input_checks import keymgr_pkg::*; #(
 
   assign key_vld_o = &key_chk;
 
+  logic [NumRomDigestInputs-1:0][MaxWidth-1:0] rom_digest_padded;
+
+  for (genvar k = 0; k < NumRomDigestInputs; k++) begin : gen_digest_pad
+    prim_msb_extend #(
+      .InWidth($bits(rom_digest_i[k].data)),
+      .OutWidth(MaxWidth)
+    ) u_rom_digest_pad (
+      .in_i(rom_digest_i[k].data),
+      .out_o(rom_digest_padded[k])
+    );
+  end
+
   always_comb begin
     rom_digest_vld_o = 1'b1;
     for (int k = 0; k < NumRomDigestInputs; k++) begin
-      rom_digest_vld_o &= rom_digest_i[k].valid && valid_chk(MaxWidth'(rom_digest_i[k].data));
+      rom_digest_vld_o &= rom_digest_i[k].valid &&
+                          valid_chk(rom_digest_padded[k]);
     end
   end
 


### PR DESCRIPTION
`rom_digest_i[k].data` is casted to `MaxWidth`. In SV, the cast fills up the MSBs with 0. This means that an all-1 vector is no  longer an all-1 vector after the cast. E.g., when casting 8'hFF to 16-bits, we would get 16'h00ff.

This is problematic as we use the casted value in the `valid_chk` function. This function checks if the value is an all-1 or all-0 vector.

So far this was not problematic as `MaxWidth` and `rom_digest_i[k].data` are both 256-bits. However, we should still fix this by sign-extending it.

This issue has been flagged by Muhammad Hafiz Abu Hassan from the Malaysian Cryptology Technology and Management Centre during the HACK@CHES'25 event.