### PR TITLE
[opentitanlib] make proxy_ops/emulator return reference

### DIFF
--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -996,7 +996,7 @@ impl TransportWrapper {
     }
 
     /// Returns a [`Emulator`] implementation.
-    pub fn emulator(&self) -> Result<Rc<dyn Emulator>> {
+    pub fn emulator(&self) -> Result<&dyn Emulator> {
         self.transport.emulator()
     }
 

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -134,7 +134,7 @@ pub trait Transport {
         Err(TransportError::InvalidInterface(TransportInterfaceType::GpioBitbanging).into())
     }
     /// Returns a [`Emulator`] implementation.
-    fn emulator(&self) -> Result<Rc<dyn Emulator>> {
+    fn emulator(&self) -> Result<&dyn Emulator> {
         Err(TransportError::InvalidInterface(TransportInterfaceType::Emulator).into())
     }
 

--- a/sw/host/ot_transports/proxy/src/lib.rs
+++ b/sw/host/ot_transports/proxy/src/lib.rs
@@ -345,8 +345,8 @@ impl Transport for Proxy {
     }
 
     // Create Emulator instance, or return one from a cache of previously created instances.
-    fn emulator(&self) -> Result<Rc<dyn Emulator>> {
-        Ok(Rc::new(emu::ProxyEmu::open(self)?))
+    fn emulator(&self) -> Result<&dyn Emulator> {
+        Ok(self)
     }
 
     // Create ProxyOps instance.

--- a/sw/host/ot_transports/ti50emulator/src/emu.rs
+++ b/sw/host/ot_transports/ti50emulator/src/emu.rs
@@ -21,8 +21,8 @@ use opentitanlib::io::emu::{EmuError, EmuState, EmuValue, Emulator};
 use opentitanlib::io::gpio::{self, GpioError, PinMode, PullMode};
 use opentitanlib::util::file;
 
-use super::Inner;
 use super::gpio::Logic;
+use super::{Inner, Ti50Emulator};
 
 const SPAWN_TIMEOUT: Duration = Duration::from_secs(10);
 const TIMEOUT: Duration = Duration::from_millis(1000);
@@ -487,21 +487,7 @@ impl EmulatorProcess {
     }
 }
 
-/// Structure representing `Emulator` sub-process based on TockOS host-emulation architecture.
-pub struct EmulatorImpl {
-    inner: Rc<Inner>,
-}
-
-impl EmulatorImpl {
-    /// Create a new `EmulatorImpl` instance.
-    pub fn open(inner: &Rc<Inner>) -> Result<Self> {
-        Ok(Self {
-            inner: Rc::clone(inner),
-        })
-    }
-}
-
-impl Emulator for EmulatorImpl {
+impl Emulator for Ti50Emulator {
     /// Simple function with return `EmuState` representing current state of Emulator instance.
     fn get_state(&self) -> Result<EmuState> {
         let mut process = self.inner.process.borrow_mut();

--- a/sw/host/ot_transports/ti50emulator/src/lib.rs
+++ b/sw/host/ot_transports/ti50emulator/src/lib.rs
@@ -31,7 +31,7 @@ mod gpio;
 mod i2c;
 mod uart;
 
-use crate::emu::{EmulatorImpl, EmulatorProcess, ResetPin};
+use crate::emu::{EmulatorProcess, ResetPin};
 use crate::gpio::Ti50GpioPin;
 use crate::i2c::Ti50I2cBus;
 use crate::uart::Ti50Uart;
@@ -43,8 +43,7 @@ pub struct Ti50Emulator {
     i2c_map: HashMap<String, Rc<dyn Bus>>,
     /// Mapping of UART handles to their symbolic names.
     uart_map: HashMap<String, Rc<dyn Uart>>,
-    /// Struct implementing the Emulator trait
-    emu: Rc<EmulatorImpl>,
+    inner: Rc<Inner>,
 }
 
 impl Ti50Emulator {
@@ -107,7 +106,7 @@ impl Ti50Emulator {
             gpio_map,
             i2c_map,
             uart_map,
-            emu: Rc::new(EmulatorImpl::open(&inner)?),
+            inner,
         };
         Ok(ti50_emu)
     }
@@ -176,8 +175,8 @@ impl Transport for Ti50Emulator {
     }
 
     // Create Emulator instance, or return one from a cache of previously created instances.
-    fn emulator(&self) -> Result<Rc<dyn Emulator>> {
-        Ok(self.emu.clone())
+    fn emulator(&self) -> Result<&dyn Emulator> {
+        Ok(self)
     }
 }
 


### PR DESCRIPTION
It is a common pattern for dyn-safe objects to have additional capabilities to be under an extension trait and have a method on the base trait to do the conversion. However, in such cases, the extension trait should be implemented on the base type itself and the dyn function should just be a `Ok(self)` return.