### PR TITLE
[bazel] Update lockfile on `earlgrey_1.0.0`

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -205,6 +205,42 @@
         ]
       }
     },
+    "//third_party/coremark:extensions.bzl%coremark": {
+      "general": {
+        "bzlTransitiveDigest": "ayJkp3wmO+LQ6BSJFIUNXr7n6tBZdE1YV9zrX4sjFd8=",
+        "usagesDigest": "ooUwffVR5D223jWxcXFXD9yOf7Kz96pnmEhr2Sp484o=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "coremark": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/coremark:BUILD.coremark.bazel",
+              "sha256": "a5964bf215786d65d08941b6f9a9a4f4e50524f5391fa3826db2994c47d5e7f3",
+              "strip_prefix": "coremark-eefc986ebd3452d6adde22eafaff3e5c859f29e4",
+              "urls": [
+                "https://github.com/eembc/coremark/archive/eefc986ebd3452d6adde22eafaff3e5c859f29e4.tar.gz"
+              ],
+              "patches": [
+                "@@//third_party/coremark/patches:use_ottf_main.patch",
+                "@@//third_party/coremark/patches:print_coremark_per_mhz.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "//third_party/freertos:extensions.bzl%freertos": {
       "general": {
         "bzlTransitiveDigest": "PUJzsWOE7C3+Bw/DAmv3qaXaycdxAoaCr68tQ8wWXsQ=",
@@ -230,6 +266,121 @@
               "patch_args": [
                 "-p1"
               ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "//third_party/github:extensions.bzl%github_tools": {
+      "general": {
+        "bzlTransitiveDigest": "XKIsMqhXyBbdwRxwLeZ7LYsa4fZYvo7KGlWdGN7GJ64=",
+        "usagesDigest": "6RU6AdmTT5RbBoClC9/ILlf7I1leJNCgJ0VbOGsvpdQ=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_github_gh": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://github.com/cli/cli/releases/download/v2.13.0/gh_2.13.0_linux_amd64.tar.gz",
+              "sha256": "9e833e02428cd49e0af73bc7dc4cafa329fe3ecba1bfe92f0859bf5b11916401",
+              "build_file": "@@//third_party/github:BUILD.gh.bazel",
+              "strip_prefix": "gh_2.13.0_linux_amd64"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "//third_party/hsm:extensions.bzl%hsm": {
+      "general": {
+        "bzlTransitiveDigest": "2vzJYK+vywiCbF9s0lHu/wrZWmgeAz0wXuHdAO2k+5w=",
+        "usagesDigest": "uEk6dTktgdMfLQN5bAE4Sorkuuxcz3nEbPEKZLUjpak=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "softhsm2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/hsm:BUILD.softhsm2.bazel",
+              "url": "https://github.com/opendnssec/SoftHSMv2/archive/4975c0df4c7090e97a3860ae21079a9597cfedc6.tar.gz",
+              "strip_prefix": "SoftHSMv2-4975c0df4c7090e97a3860ae21079a9597cfedc6",
+              "sha256": "72cf979ec4f74ca4555861dcae45cf7d1b667cc2e4f3ee3fb26e6ff1b99aec95",
+              "patches": [
+                "@@//third_party/hsm/patches:0001-Disable-filename-logging.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "sc_hsm": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/hsm:BUILD.sc_hsm.bazel",
+              "url": "https://github.com/CardContact/sc-hsm-embedded/archive/refs/tags/V2.12.tar.gz",
+              "strip_prefix": "sc-hsm-embedded-2.12",
+              "sha256": "707fca9df630708e0e59a7d4a8a7a016c56c83a585957f0fd9f806c0762f1944"
+            }
+          },
+          "opensc": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/hsm:BUILD.opensc.bazel",
+              "url": "https://github.com/OpenSC/OpenSC/archive/refs/tags/0.26.0.tar.gz",
+              "strip_prefix": "OpenSC-0.26.0",
+              "sha256": "c692ac7639fa398f7f07b1070ea5358344000d49d08dcb825296d4cec94c6b1f"
+            }
+          },
+          "cloud_kms_hsm": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/hsm:BUILD.cloud_kms_hsm.bazel",
+              "url": "https://github.com/GoogleCloudPlatform/kms-integrations/releases/download/pkcs11-v1.8/libkmsp11-1.8-linux-amd64.tar.gz",
+              "strip_prefix": "libkmsp11-1.8-linux-amd64",
+              "sha256": "3b932f22a8abb631442c3276e9c309554c81855526b74fbc9edaddcb57a557f7"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "//third_party/hwtrust:extensions.bzl%hwtrust": {
+      "general": {
+        "bzlTransitiveDigest": "k+eVkpIKKoll+00pC23CYyiPcbMEgx6k1EdN7iQxiCA=",
+        "usagesDigest": "E7yErwZF7b/bpM+r5XyMZeprKVdzGd+ET8BdGKkLXmE=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "hwtrust": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://android.googlesource.com/platform/tools/security/+archive/da7738aaf3ece666272adab6b3091f72ce027e9c.tar.gz"
+              ],
+              "strip_prefix": "remote_provisioning/hwtrust",
+              "build_file": "@@//third_party/hwtrust:BUILD.hwtrust.bazel"
             }
           }
         },
@@ -270,6 +421,42 @@
         ]
       }
     },
+    "//third_party/llvm_compiler_rt:extensions.bzl%llvm_compiler_rt": {
+      "general": {
+        "bzlTransitiveDigest": "ZEmlU/hkXRhDn/AkNKcrDSw1PmTFdyLKQTGh2+sow8w=",
+        "usagesDigest": "O9cWlBkZKfcS52QztXu0ImLAwZKyyJ3nvUJhmAwr9d0=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "llvm_compiler_rt": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/llvm_compiler_rt:BUILD.llvm_compiler_rt.bazel",
+              "sha256": "46abe68f006646c15f6d551a2be0ac27e681c5fcc646d712389a5e50ddf69c60",
+              "strip_prefix": "compiler-rt-16.0.2.src",
+              "urls": [
+                "https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.2/compiler-rt-16.0.2.src.tar.xz"
+              ],
+              "patches": [
+                "@@//third_party/llvm_compiler_rt/patches:0001-Headers.patch",
+                "@@//third_party/llvm_compiler_rt/patches:0002-invalid-data.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "//third_party/lowrisc:extensions.bzl%lowrisc_rv32imcb_toolchain": {
       "general": {
         "bzlTransitiveDigest": "JQbQTIYu73LMiVSvNwltZuucnHJABYNTmyRfgu5/iT0=",
@@ -285,6 +472,209 @@
               "sha256": "6f02aae27c097c71a2875a215896a0301e32ab56d6d26e917dae59d124c573fb",
               "strip_prefix": "lowrisc-toolchain-rv32imcb-x86_64-20250710-1",
               "build_file": "@@//third_party/lowrisc:BUILD.lowrisc_rv32imcb_toolchain.bazel"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "//third_party/lychee:extensions.bzl%lychee": {
+      "general": {
+        "bzlTransitiveDigest": "eDUwrwPEuegFKUHYzkWM8j1J/yJR3DDPEL2mQxJJsIA=",
+        "usagesDigest": "soPUExawxfl3++63DghuShqJao61DF42lQ9c+00pd/U=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "lychee": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://github.com/lycheeverse/lychee/releases/download/v0.14.3/lychee-v0.14.3-x86_64-unknown-linux-gnu.tar.gz",
+              "build_file_content": "\npackage(default_visibility = [\"//visibility:public\"])\nexports_files(glob([\"**\"]))\n",
+              "sha256": "2a47a11d7fd3498ea3e0f8f58909e1673d652f917205d41dcf852fed1ad56ff7"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "//third_party/nist_cavp_testvectors:extensions.bzl%nist_cavp": {
+      "general": {
+        "bzlTransitiveDigest": "gk5tWGGBwcXz9ES4XfiLFLRdL4BUlApptTMVbsfhkKw=",
+        "usagesDigest": "3tzIyJKQ5B86oXVMUgCsQRWpotUNe/G37MwhMsqR4hk=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "nist_cavp_drbg_sp_800_90a_root": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel",
+              "sha256": "5f7e5658ebd5b4e6785a7b12fa32333511d2acc2f2d9c5ae1ffa16b699377769",
+              "urls": [
+                "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/drbg/drbgtestvectors.zip",
+                "https://storage.googleapis.com/ot-crypto-test-vectors/nist/drbgtestvectors.zip"
+              ]
+            }
+          },
+          "nist_cavp_ecdsa_fips_186_4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel",
+              "strip_prefix": "186-4ecdsatestvectors",
+              "sha256": "fe47cc92b4cee418236125c9ffbcd9bb01c8c34e74a4ba195d954bcb72824752",
+              "urls": [
+                "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/dss/186-4ecdsatestvectors.zip",
+                "https://storage.googleapis.com/ot-crypto-test-vectors/nist/186-4ecdsatestvectors.zip"
+              ]
+            }
+          },
+          "nist_cavp_sha2_fips_180_4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel",
+              "strip_prefix": "shabytetestvectors",
+              "sha256": "929ef80b7b3418aca026643f6f248815913b60e01741a44bba9e118067f4c9b8",
+              "urls": [
+                "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/shs/shabytetestvectors.zip",
+                "https://storage.googleapis.com/ot-crypto-test-vectors/nist/shabytetestvectors.zip"
+              ]
+            }
+          },
+          "nist_cavp_sha3_fips_202": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel",
+              "sha256": "cd07701af2e47f5cc889d642528b4bf11f8b6eb55797c7307a96828ed8d8fc8c",
+              "urls": [
+                "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/sha3/sha-3bytetestvectors.zip",
+                "https://storage.googleapis.com/ot-crypto-test-vectors/nist/sha-3bytetestvectors.zip"
+              ]
+            }
+          },
+          "nist_cavp_shake_fips_202": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel",
+              "sha256": "debfebc3157b3ceea002b84ca38476420389a3bf7e97dc5f53ea4689a16de4c7",
+              "urls": [
+                "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/sha3/shakebytetestvectors.zip",
+                "https://storage.googleapis.com/ot-crypto-test-vectors/nist/shakebytetestvectors.zip"
+              ]
+            }
+          },
+          "nist_cavp_aes_kat": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel",
+              "sha256": "a203b16c9246b2ebae31dee5de21a606be80cf78ceabaca37150236fa098eb60",
+              "urls": [
+                "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/aes/KAT_AES.zip",
+                "https://storage.googleapis.com/ot-crypto-test-vectors/nist/KAT_AES.zip"
+              ]
+            }
+          },
+          "nist_cavp_aes_kw_sp_800_38f": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel",
+              "strip_prefix": "kwtestvectors",
+              "sha256": "04a4a82e4de65bca505125295003f9c75a5a815afda046dc83661b8b580dfdf3",
+              "urls": [
+                "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/mac/kwtestvectors.zip",
+                "https://storage.googleapis.com/ot-crypto-test-vectors/nist/kwtestvectors.zip"
+              ]
+            }
+          },
+          "nist_cavp_aes_gcm": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel",
+              "sha256": "f9fc479e134cde2980b3bb7cddbcb567b2cd96fd753835243ed067699f26a023",
+              "urls": [
+                "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/mac/gcmtestvectors.zip",
+                "https://storage.googleapis.com/ot-crypto-test-vectors/nist/gcmtestvectors.zip"
+              ]
+            }
+          },
+          "nist_cavp_ecdh_sp_800_56a": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel",
+              "sha256": "5fff092551f2d72e89a3d9362711878708f9a14b502f0dfae819649105b0ea39",
+              "urls": [
+                "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/components/ecccdhtestvectors.zip",
+                "https://storage.googleapis.com/ot-crypto-test-vectors/nist/ecccdhtestvectors.zip"
+              ]
+            }
+          },
+          "nist_cavp_rsa_fips_186_3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel",
+              "sha256": "8405aeb3572a4f98ed4b1a3ccb3f2f49e725462dd28ec4759d6a15d88855d19c",
+              "urls": [
+                "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/dss/186-3rsatestvectors.zip",
+                "https://storage.googleapis.com/ot-crypto-test-vectors/nist/186-3rsatestvectors.zip"
+              ]
+            }
+          },
+          "nist_cavp_hmac_fips_198_1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel",
+              "sha256": "418c3837d38f249d6668146bd0090db24dd3c02d2e6797e3de33860a387ae4bd",
+              "urls": [
+                "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/mac/hmactestvectors.zip",
+                "https://storage.googleapis.com/ot-crypto-test-vectors/nist/hmactestvectors.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "//third_party/open-dice:extensions.bzl%open_dice": {
+      "general": {
+        "bzlTransitiveDigest": "UhdXaJTUEbJuY/x/+01mDCYVaehypBWPdrNmR8Qq7Wo=",
+        "usagesDigest": "kf0UPInlDbj7VN2ND24/DhmWQvGxmNdhVLs1oe1iGP0=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "open-dice": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/open-dice:BUILD.open-dice.bazel",
+              "strip_prefix": "open-dice-cf3f4cc7a3506a33ee3a437544ef6f40056b3563",
+              "urls": [
+                "https://github.com/google/open-dice/archive/cf3f4cc7a3506a33ee3a437544ef6f40056b3563.zip"
+              ],
+              "sha256": "d7ce830111451afe2a255cac3b750f82e50efe2aaf6bac0b076881c964cfe78d",
+              "patches": [
+                "@@//third_party/open-dice/patches:Add-a-local-strlen-implementation.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
             }
           }
         },
@@ -375,6 +765,41 @@
         ]
       }
     },
+    "//third_party/riscv-compliance:extensions.bzl%riscv_compliance": {
+      "general": {
+        "bzlTransitiveDigest": "nfXk6mWWcrG8wwKEqszQVnP0AlbLhtVSYuZ6FjUBUz4=",
+        "usagesDigest": "K3fGtRwBV4FMxZEJNyaYMF8Sgv1MQoOzOaC8CPBgJqY=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "riscv-compliance": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/riscv-compliance:BUILD.riscv-compliance.bazel",
+              "sha256": "e77d823189c145314e48d4c29bcecc844b9c1582826ff406ec499cad7e95d0e4",
+              "strip_prefix": "riscv-arch-test-2636302c27557b42d99bed7e0537beffdf8e1ab4",
+              "urls": [
+                "https://github.com/riscv/riscv-compliance/archive/2636302c27557b42d99bed7e0537beffdf8e1ab4.tar.gz"
+              ],
+              "patches": [
+                "@@//third_party/riscv-compliance/patches:0001-Add-configurable-trap-alignment-and-entry-point-to-p.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "//third_party/rust:extensions.bzl%serde_annotate": {
       "general": {
         "bzlTransitiveDigest": "O9r8WKuFZnnqM1mSyOxmoqo+Cxns5tj86MbyhPhQB1o=",
@@ -389,6 +814,33 @@
               "sha256": "7300ed093fa3de679512ffdab7d0f1824be2b11f499bb852df29c3ae12e1348d",
               "strip_prefix": "serde-annotate-0.0.12",
               "url": "https://github.com/lowRISC/serde-annotate/archive/refs/tags/v0.0.12.tar.gz"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "//third_party/shellcheck:extensions.bzl%shellcheck": {
+      "general": {
+        "bzlTransitiveDigest": "IlBpyyqZzqlRuEYHnte79bOmeD9p4Yhzqynz822bqXU=",
+        "usagesDigest": "zkc2kS0YdM78P/M/BRtgUGZikBqOpUJh2kkAtj1UatE=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "shellcheck": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellcheck-v0.9.0.linux.x86_64.tar.xz",
+              "sha256": "700324c6dd0ebea0117591c6cc9d7350d9c7c5c287acbad7630fa17b1d4d9e2f",
+              "strip_prefix": "shellcheck-v0.9.0",
+              "build_file_content": "\npackage(default_visibility = [\"//visibility:public\"])\nexports_files(glob([\"**\"]))\n"
             }
           }
         },
@@ -455,6 +907,190 @@
             "",
             "lowrisc_opentitan",
             ""
+          ]
+        ]
+      }
+    },
+    "//third_party/system_libs:extensions.bzl%system_libs": {
+      "general": {
+        "bzlTransitiveDigest": "wcQYu1dZpYyGXIIbtQeVPI1qzQ0LQu3g9hxYIH2zAcg=",
+        "usagesDigest": "qjd0+Tgdi27wMz5qse8P7OKE8M5wWJ1wy1s+GXHmsiE=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "libudev_zero": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/system_libs:BUILD.libudev_zero.bazel",
+              "url": "https://github.com/illiliti/libudev-zero/archive/refs/tags/1.0.3.tar.gz",
+              "strip_prefix": "libudev-zero-1.0.3",
+              "sha256": "0bd89b657d62d019598e6c7ed726ff8fed80e8ba092a83b484d66afb80b77da5"
+            }
+          },
+          "libelf": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/system_libs:BUILD.libelf.bazel",
+              "url": "https://sourceware.org/elfutils/ftp/0.193/elfutils-0.193.tar.bz2",
+              "strip_prefix": "elfutils-0.193",
+              "sha256": "7857f44b624f4d8d421df851aaae7b1402cfe6bcdd2d8049f15fc07d3dde7635"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "//third_party/tock:extensions.bzl%tock": {
+      "general": {
+        "bzlTransitiveDigest": "C2f4NtX52o14R9TtkJwTl1wZ63j5YYUiTHoJdz0DUHE=",
+        "usagesDigest": "e7NaZ0MivPj7giGJo87Bmb8QIxCrekhQwj8CiSZ7w3s=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "tock": {
+            "repoRuleId": "@@//rules:repo.bzl%bare_repository",
+            "attributes": {
+              "strip_prefix": "tock-e81987f6a41e9b92f60fda1d5283f46b3cb597b5",
+              "url": "https://github.com/tock/tock/archive/e81987f6a41e9b92f60fda1d5283f46b3cb597b5.tar.gz",
+              "sha256": "b7c239f3bd7e7727eee99814661424e1e50587fe9068cec1943a7bb6743ed777",
+              "additional_files_content": {
+                "BUILD": "exports_files(glob([\"**\"]))",
+                "arch/riscv/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"riscv\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"riscv\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=riscv\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//kernel\",\n        \"//libraries/tock-register-interface:tock-registers\",\n        \"//libraries/riscv-csr\",\n    ],\n)\n\n\n",
+                "arch/rv32i/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"rv32i\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"rv32i\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=rv32i\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//arch/riscv\",\n        \"//kernel\",\n        \"//libraries/tock-register-interface:tock-registers\",\n        \"//libraries/riscv-csr\",\n    ],\n)\n\n\n",
+                "boards/BUILD": "\npackage(default_visibility = [\"//visibility:public\"])\n\nfilegroup(\n    name = \"kernel_layout\",\n    srcs = [\"kernel_layout.ld\"],\n)\n",
+                "boards/components/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"components\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"components\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=components\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//kernel\",\n        \"//capsules/core:capsules-core\",\n        \"//capsules/extra:capsules-extra\",\n    ],\n)\n\n\n",
+                "boards/opentitan/earlgrey-cw310/BUILD": "\npackage(default_visibility = [\"//visibility:public\"])\n\nfilegroup(\n    name = \"kernel_srcs\",\n    srcs = glob([\"**/*.rs\"]),\n)\n",
+                "capsules/aes_gcm/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"capsules-aes-gcm\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"capsules_aes_gcm\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=capsules_aes_gcm\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//kernel\",\n        \"//libraries/enum_primitive\",\n        \"//libraries/tickv\",\n        \"@tock_index//:ghash\",\n    ],\n)\n\n\n",
+                "capsules/core/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"capsules-core\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"capsules_core\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=capsules_core\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//kernel\",\n        \"//libraries/enum_primitive\",\n        \"//libraries/tickv\",\n    ],\n)\n\n\n",
+                "capsules/extra/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"capsules-extra\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"capsules_extra\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=capsules_extra\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//kernel\",\n        \"//libraries/enum_primitive\",\n        \"//libraries/tickv\",\n        \"//capsules/core:capsules-core\",\n    ],\n)\n\n\n",
+                "chips/earlgrey/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"earlgrey\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"earlgrey\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=earlgrey\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//chips/lowrisc\",\n        \"//arch/rv32i\",\n        \"//kernel\",\n    ],\n)\n\n\n",
+                "chips/lowrisc/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"lowrisc\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"lowrisc\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=lowrisc\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//arch/rv32i\",\n        \"//kernel\",\n    ],\n)\n\n\n",
+                "libraries/enum_primitive/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"enum_primitive\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"enum_primitive\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=enum_primitive\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \n    ],\n)\n\n\n",
+                "libraries/riscv-csr/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"riscv-csr\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"riscv_csr\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=riscv_csr\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//libraries/tock-register-interface:tock-registers\",\n    ],\n)\n\n\n",
+                "libraries/tickv/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"tickv\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"tickv\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=tickv\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \n    ],\n)\n\n\n",
+                "libraries/tock-cells/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"tock-cells\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"tock_cells\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=tock_cells\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \n    ],\n)\n\n\n",
+                "libraries/tock-tbf/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"tock-tbf\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"tock_tbf\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=tock_tbf\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \n    ],\n)\n\n\n",
+                "libraries/tock-register-interface/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"tock-registers\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"default\",\n        \"register_types\",\n    ],\n    crate_name = \"tock_registers\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=tock_registers\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \n    ],\n)\n\n\n",
+                "kernel/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"kernel\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"kernel\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=kernel\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//libraries/tock-register-interface:tock-registers\",\n        \"//libraries/tock-cells\",\n        \"//libraries/tock-tbf\",\n    ],\n)\n\n\n"
+              }
+            }
+          },
+          "libtock": {
+            "repoRuleId": "@@//rules:repo.bzl%bare_repository",
+            "attributes": {
+              "strip_prefix": "libtock-rs-a2c6ad80648e3ba073e7433b4330706df052a6ae",
+              "url": "https://github.com/tock/libtock-rs/archive/a2c6ad80648e3ba073e7433b4330706df052a6ae.tar.gz",
+              "sha256": "888d1925cd760e818385d13187286d6b87f763c548a4dc1bb26e55786dc95636",
+              "additional_files_content": {
+                "BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"libtock\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"libtock\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=libtock\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//apis/adc\",\n        \"//apis/air_quality\",\n        \"//apis/alarm\",\n        \"//apis/ambient_light\",\n        \"//apis/buttons\",\n        \"//apis/buzzer\",\n        \"//apis/console\",\n        \"//apis/gpio\",\n        \"//apis/leds\",\n        \"//apis/low_level_debug\",\n        \"//apis/ninedof\",\n        \"//apis/proximity\",\n        \"//apis/sound_pressure\",\n        \"//apis/temperature\",\n        \"//panic_handlers/debug_panic\",\n        \"//platform\",\n        \"//runtime\",\n    ],\n)\n\n\n",
+                "apis/adc/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"adc\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"libtock_adc\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=libtock_adc\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//platform\",\n    ],\n)\n\n\n",
+                "apis/air_quality/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"air_quality\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"libtock_air_quality\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=libtock_air_quality\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//platform\",\n    ],\n)\n\n\n",
+                "apis/alarm/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"alarm\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"libtock_alarm\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=libtock_alarm\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//platform\",\n    ],\n)\n\n\n",
+                "apis/ambient_light/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"ambient_light\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"libtock_ambient_light\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=libtock_ambient_light\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//platform\",\n    ],\n)\n\n\n",
+                "apis/buttons/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"buttons\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"libtock_buttons\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=libtock_buttons\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//platform\",\n    ],\n)\n\n\n",
+                "apis/buzzer/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"buzzer\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"libtock_buzzer\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=libtock_buzzer\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//platform\",\n    ],\n)\n\n\n",
+                "apis/console/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"console\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"libtock_console\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=libtock_console\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//platform\",\n    ],\n)\n\n\n",
+                "apis/gpio/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"gpio\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"libtock_gpio\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=libtock_gpio\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//platform\",\n    ],\n)\n\n\n",
+                "apis/leds/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"leds\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"libtock_leds\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=libtock_leds\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//platform\",\n    ],\n)\n\n\n",
+                "apis/low_level_debug/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"low_level_debug\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"libtock_low_level_debug\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=libtock_low_level_debug\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//platform\",\n    ],\n)\n\n\n",
+                "apis/ninedof/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"ninedof\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"libtock_ninedof\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=libtock_ninedof\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//platform\",\n        \"@tock_index//:libm\",\n    ],\n)\n\n\n",
+                "apis/proximity/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"proximity\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"libtock_proximity\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=libtock_proximity\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//platform\",\n    ],\n)\n\n\n",
+                "apis/sound_pressure/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"sound_pressure\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"libtock_sound_pressure\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=libtock_sound_pressure\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//platform\",\n    ],\n)\n\n\n",
+                "apis/temperature/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"temperature\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"libtock_temperature\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=libtock_temperature\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//platform\",\n    ],\n)\n\n\n",
+                "build_scripts/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"build_scripts\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"libtock_build_scripts\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=libtock_build_scripts\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \n    ],\n)\n\n\nfilegroup(\n    name = \"layout\",\n    srcs = [\"libtock_layout.ld\"],\n)\n\n",
+                "panic_handlers/debug_panic/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"debug_panic\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"libtock_debug_panic\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=libtock_debug_panic\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//apis/console\",\n        \"//apis/low_level_debug\",\n        \"//platform\",\n        \"//runtime\",\n    ],\n)\n\n\n",
+                "panic_handlers/small_panic/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"small_panic\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"libtock_small_panic\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=libtock_small_panic\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//apis/low_level_debug\",\n        \"//platform\",\n        \"//runtime\",\n    ],\n)\n\n\n",
+                "platform/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"platform\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"libtock_platform\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=libtock_platform\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \n    ],\n)\n\n\n",
+                "runtime/BUILD": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by the crate_build function in\n# //rules:rust.bzl.\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"runtime\",\n    srcs = glob([\"**/*.rs\"]),\n    compile_data = glob(\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \n    ],\n    crate_name = \"libtock_runtime\",\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=libtock_runtime\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    deps = [\n        \"//platform\",\n    ],\n)\n\n\n"
+              }
+            }
+          },
+          "elf2tab": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://github.com/tock/elf2tab/archive/2f0e2f0ef01e37799850d1b12f48b93a0b32a203.tar.gz",
+              "sha256": "b8b2ec7d8b9d052667d34190f98a0f5e69a0ba93ce69f00f2fdda7b5e241b963",
+              "strip_prefix": "elf2tab-2f0e2f0ef01e37799850d1b12f48b93a0b32a203",
+              "build_file": "@@//third_party/tock:BUILD.elf2tab.bazel"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "//third_party/wycheproof:extensions.bzl%wycheproof": {
+      "general": {
+        "bzlTransitiveDigest": "P/4xE9z72PWw4KN3Mzb9nTuKK1qFvLh8BSOcqZ7o2gk=",
+        "usagesDigest": "Gdz66kVX6D/N5Ctc5bWOnMAXuhBPCcytmyTtIzqrvIU=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "wycheproof": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/wycheproof:BUILD.wycheproof_common.bazel",
+              "sha256": "a7a4c18d0d5609b26f3341dc7a9dd6829174d542ee6f0434f5fa7319e0811b75",
+              "strip_prefix": "wycheproof-snapshot-d9f6ec7d8bd8c96da05368999094e4a75ba5cb3d",
+              "url": "https://github.com/lowRISC/wycheproof/archive/refs/tags/snapshot-d9f6ec7d8bd8c96da05368999094e4a75ba5cb3d.tar.gz"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "//third_party/xkcp:extensions.bzl%xkcp": {
+      "general": {
+        "bzlTransitiveDigest": "NoLxI6/+lFuBf/U0bul+x5HlBCH2tlIiGq44j3MgY7s=",
+        "usagesDigest": "mNfy9mjd8p7vDumRYe1bgTWgwKWNX7Nhf4GoSOUXTcw=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "xkcp": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/xkcp:BUILD.xkcp.bazel",
+              "sha256": "bfd50261e0196988f7c4f45871b82e5ec9c3a74e18276f50dda48ab51f3cdb53",
+              "strip_prefix": "XKCP-56ae09923153c3e801a6891eb19e4a3b5bb6f6e2/lib",
+              "urls": [
+                "https://github.com/XKCP/XKCP/archive/56ae09923153c3e801a6891eb19e4a3b5bb6f6e2.tar.gz"
+              ],
+              "patches": [
+                "@@//third_party/xkcp/patches:add_config_header.patch",
+                "@@//third_party/xkcp/patches:add_main_license.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
           ]
         ]
       }
@@ -623,6 +1259,40 @@
           ],
           [
             "buildifier_prebuilt+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@pybind11_bazel+//:python_configure.bzl%extension": {
+      "general": {
+        "bzlTransitiveDigest": "d4N/SZrl3ONcmzE98rcV0Fsro0iUbjNQFTIiLiGuH+k=",
+        "usagesDigest": "fycyB39YnXIJkfWCIXLUKJMZzANcuLy9ZE73hRucjFk=",
+        "recordedFileInputs": {
+          "@@pybind11_bazel+//MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e"
+        },
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_config_python": {
+            "repoRuleId": "@@pybind11_bazel+//:python_configure.bzl%python_configure",
+            "attributes": {}
+          },
+          "pybind11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@pybind11_bazel+//:pybind11.BUILD",
+              "strip_prefix": "pybind11-2.11.1",
+              "urls": [
+                "https://github.com/pybind/pybind11/archive/v2.11.1.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "pybind11_bazel+",
             "bazel_tools",
             "bazel_tools"
           ]
@@ -11661,6 +12331,149 @@
             "rules_rust+",
             "rust_host_tools",
             "rules_rust++rust_host_tools+rust_host_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_rust+//crate_universe/private:internal_extensions.bzl%cu_nr": {
+      "general": {
+        "bzlTransitiveDigest": "m7P4qjc3H2eVIeeKf7wz7/YcT71UlvP12qnbCYetQ4U=",
+        "usagesDigest": "VsWDZXUQBqQa0ho1SU+gICiR3/gHVjTHrV0OwJokhBc=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "cargo_bazel_bootstrap": {
+            "repoRuleId": "@@rules_rust+//cargo/private:cargo_bootstrap.bzl%cargo_bootstrap_repository",
+            "attributes": {
+              "srcs": [
+                "@@rules_rust+//crate_universe:src/api.rs",
+                "@@rules_rust+//crate_universe:src/api/lockfile.rs",
+                "@@rules_rust+//crate_universe:src/cli.rs",
+                "@@rules_rust+//crate_universe:src/cli/generate.rs",
+                "@@rules_rust+//crate_universe:src/cli/query.rs",
+                "@@rules_rust+//crate_universe:src/cli/render.rs",
+                "@@rules_rust+//crate_universe:src/cli/splice.rs",
+                "@@rules_rust+//crate_universe:src/cli/vendor.rs",
+                "@@rules_rust+//crate_universe:src/config.rs",
+                "@@rules_rust+//crate_universe:src/context.rs",
+                "@@rules_rust+//crate_universe:src/context/crate_context.rs",
+                "@@rules_rust+//crate_universe:src/context/platforms.rs",
+                "@@rules_rust+//crate_universe:src/lib.rs",
+                "@@rules_rust+//crate_universe:src/lockfile.rs",
+                "@@rules_rust+//crate_universe:src/main.rs",
+                "@@rules_rust+//crate_universe:src/metadata.rs",
+                "@@rules_rust+//crate_universe:src/metadata/cargo_bin.rs",
+                "@@rules_rust+//crate_universe:src/metadata/cargo_tree_resolver.rs",
+                "@@rules_rust+//crate_universe:src/metadata/cargo_tree_rustc_wrapper.bat",
+                "@@rules_rust+//crate_universe:src/metadata/cargo_tree_rustc_wrapper.sh",
+                "@@rules_rust+//crate_universe:src/metadata/dependency.rs",
+                "@@rules_rust+//crate_universe:src/metadata/metadata_annotation.rs",
+                "@@rules_rust+//crate_universe:src/metadata/workspace_discoverer.rs",
+                "@@rules_rust+//crate_universe:src/rendering.rs",
+                "@@rules_rust+//crate_universe:src/rendering/template_engine.rs",
+                "@@rules_rust+//crate_universe:src/rendering/templates/module_bzl.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/header.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/aliases_map.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/deps_map.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/repo_git.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/repo_http.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/vendor_module.j2",
+                "@@rules_rust+//crate_universe:src/rendering/verbatim/alias_rules.bzl",
+                "@@rules_rust+//crate_universe:src/select.rs",
+                "@@rules_rust+//crate_universe:src/splicing.rs",
+                "@@rules_rust+//crate_universe:src/splicing/cargo_config.rs",
+                "@@rules_rust+//crate_universe:src/splicing/crate_index_lookup.rs",
+                "@@rules_rust+//crate_universe:src/splicing/splicer.rs",
+                "@@rules_rust+//crate_universe:src/test.rs",
+                "@@rules_rust+//crate_universe:src/utils.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/glob.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/label.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select_dict.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select_list.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select_scalar.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select_set.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/serialize.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/target_compatible_with.rs",
+                "@@rules_rust+//crate_universe:src/utils/symlink.rs",
+                "@@rules_rust+//crate_universe:src/utils/target_triple.rs"
+              ],
+              "binary": "cargo-bazel",
+              "cargo_lockfile": "@@rules_rust+//crate_universe:Cargo.lock",
+              "cargo_toml": "@@rules_rust+//crate_universe:Cargo.toml",
+              "version": "1.85.1",
+              "timeout": 900,
+              "rust_toolchain_cargo_template": "@rust_host_tools//:bin/{tool}",
+              "rust_toolchain_rustc_template": "@rust_host_tools//:bin/{tool}",
+              "compressed_windows_toolchain_names": false
+            }
+          }
+        },
+        "moduleExtensionMetadata": {
+          "explicitRootModuleDirectDeps": [
+            "cargo_bazel_bootstrap"
+          ],
+          "explicitRootModuleDirectDevDeps": [],
+          "useAllRepos": "NO",
+          "reproducible": false
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_features+",
+            "bazel_features_globals",
+            "bazel_features++version_extension+bazel_features_globals"
+          ],
+          [
+            "bazel_features+",
+            "bazel_features_version",
+            "bazel_features++version_extension+bazel_features_version"
+          ],
+          [
+            "rules_cc+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_cc+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_features",
+            "bazel_features+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_rust+",
+            "cui",
+            "rules_rust++cu+cui"
+          ],
+          [
+            "rules_rust+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust",
+            "rules_rust+"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_ctve",
+            "rules_rust++i2+rules_rust_ctve"
           ]
         ]
       }


### PR DESCRIPTION
From bisecting, it seems like this came out of sync after https://github.com/lowRISC/opentitan/pull/28653

Fix the lockfile to stop diffs in the lockfile on local Bazel runs. Generated with
```
./bazelisk.sh fetch --configure --force
```