### PR TITLE
[reggen] Report the name of invalid register

### DIFF
--- a/util/reggen/lib.py
+++ b/util/reggen/lib.py
@@ -84,6 +84,8 @@ def check_keys(obj: object, what: str, required_keys: List[str],
             unexpected.append(key)
 
     if missing or unexpected:
+        if isinstance(obj, dict) and 'name' in obj:
+            what += f" '{obj['name']}'"
         mstr = ('The following required fields were missing: '
                 f'{", ".join(missing)}.') if missing else ''
         ustr = ('The following unexpected fields were found: '


### PR DESCRIPTION
Report the name of the register/other entity that has incorrect field descriptions, to aid in locating the fault.