### PR TITLE
[bazel] Bump RISC-V toolchain release

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -522,7 +522,7 @@
     },
     "//third_party/lowrisc:extensions.bzl%lowrisc_rv32imcb_toolchain": {
       "general": {
-        "bzlTransitiveDigest": "JQbQTIYu73LMiVSvNwltZuucnHJABYNTmyRfgu5/iT0=",
+        "bzlTransitiveDigest": "033ZAc9zojxrKdPMpWEtNhV8RxHk22vwfGTGSiQLLXY=",
         "usagesDigest": "N+I4Z8BUhFKs8r1sm2Tm4NjFkNo8NTAmaYNX1+nchZg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -531,9 +531,9 @@
           "lowrisc_rv32imcb_toolchain": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
-              "url": "https://github.com/lowRISC/lowrisc-toolchains/releases/download/20250710-1/lowrisc-toolchain-rv32imcb-x86_64-20250710-1.tar.xz",
-              "sha256": "6f02aae27c097c71a2875a215896a0301e32ab56d6d26e917dae59d124c573fb",
-              "strip_prefix": "lowrisc-toolchain-rv32imcb-x86_64-20250710-1",
+              "url": "https://github.com/lowRISC/lowrisc-toolchains/releases/download/20251111-1/lowrisc-toolchain-rv32imcb-x86_64-20251111-1.tar.xz",
+              "sha256": "42be8b4a7e2fe8ea9274759c8574eb3b763a5072741a75d22189c93b149b6fab",
+              "strip_prefix": "lowrisc-toolchain-rv32imcb-x86_64-20251111-1",
               "build_file": "@@//third_party/lowrisc:BUILD.lowrisc_rv32imcb_toolchain.bazel"
             }
           }

--- a/third_party/lowrisc/extensions.bzl
+++ b/third_party/lowrisc/extensions.bzl
@@ -5,11 +5,11 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def _lowrisc_repos():
-    VERSION = "20250710-1"
+    VERSION = "20251111-1"
     http_archive(
         name = "lowrisc_rv32imcb_toolchain",
         url = "https://github.com/lowRISC/lowrisc-toolchains/releases/download/{v}/lowrisc-toolchain-rv32imcb-x86_64-{v}.tar.xz".format(v = VERSION),
-        sha256 = "6f02aae27c097c71a2875a215896a0301e32ab56d6d26e917dae59d124c573fb",
+        sha256 = "42be8b4a7e2fe8ea9274759c8574eb3b763a5072741a75d22189c93b149b6fab",
         strip_prefix = "lowrisc-toolchain-rv32imcb-x86_64-{}".format(VERSION),
         build_file = ":BUILD.lowrisc_rv32imcb_toolchain.bazel",
     )


### PR DESCRIPTION
This toolchain release should contain the same binaries as before (*) but the release was prepared in a different way. We should not expect any functional changes from taking this release.

We would like to do this transitional version bump in preparation for updating the LLVM toolchain from version 16 to 21 which we will do using the new release preparation process. Doing this in two steps will help us identify problems with our new release process versus the LLVM update.

(*) with the exception that GCC was removed from the toolchain. We haven't been using GCC for a while in OpenTitan. GNU binutils / GDB / LD remain.