### PR TITLE
[hw,prim_rom,rtl] Move rvalid in prim_rom instead of generating it

### DIFF
--- a/hw/ip/prim/rtl/prim_rom_adv.sv
+++ b/hw/ip/prim/rtl/prim_rom_adv.sv
@@ -33,17 +33,10 @@ module prim_rom_adv import prim_rom_pkg::*; #(
     .rst_ni,
     .req_i,
     .addr_i,
+    .rvalid_o,
     .rdata_o,
     .cfg_i
   );
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      rvalid_o <= 1'b0;
-    end else begin
-      rvalid_o <= req_i;
-    end
-  end
 
   ////////////////
   // ASSERTIONS //

--- a/hw/ip/prim_generic/rtl/prim_rom.sv
+++ b/hw/ip/prim_generic/rtl/prim_rom.sv
@@ -15,14 +15,24 @@ module prim_rom import prim_rom_pkg::*; #(
   input  logic             rst_ni,
   input  logic             req_i,
   input  logic [Aw-1:0]    addr_i,
+  output logic             rvalid_o,
   output logic [Width-1:0] rdata_o,
   input rom_cfg_t          cfg_i
 );
 
   logic unused_signals;
-  assign unused_signals = ^{cfg_i, rst_ni};
+  assign unused_signals = ^{cfg_i};
 
   logic [Width-1:0] mem [Depth];
+
+  // Data always comes in the next cycle after a request
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rvalid_o <= 1'b0;
+    end else begin
+      rvalid_o <= req_i;
+    end
+  end
 
   always_ff @(posedge clk_i) begin
     if (req_i) begin

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_rom.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_rom.sv
@@ -15,12 +15,22 @@ module prim_rom import prim_rom_pkg::*; #(
   input  logic             rst_ni,
   input  logic             req_i,
   input  logic [Aw-1:0]    addr_i,
+  output logic             rvalid_o,
   output logic [Width-1:0] rdata_o,
   input rom_cfg_t          cfg_i
 );
 
   logic unused_signals;
-  assign unused_signals = ^{cfg_i, rst_ni};
+  assign unused_signals = ^{cfg_i};
+
+  // Data always comes in the next cycle after a request
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rvalid_o <= 1'b0;
+    end else begin
+      rvalid_o <= req_i;
+    end
+  end
 
   if (MemInitFile != "") begin : gen_generic
 


### PR DESCRIPTION
A ROM might not serve data on the next cycle. Let the tech specific ROM implementation decide when data is valid.