### PR TITLE
[codeowners] update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,12 +48,12 @@ formal/             @lowRISC/ot-dv-reviewers
 # lint/             # TBD
 
 # Common docs
-/doc/               @mundaym
+/doc/               @vogelpi
 
 # License related files
-LICENSE*            @mundaym
-COPYING*            @mundaym
-/util/licence-checker.hjson  @mundaym
+LICENSE*            @vogelpi
+COPYING*            @vogelpi
+/util/licence-checker.hjson  @vogelpi
 
 # CI and testing
 /ci/                @lowRISC/ot-ci-reviewers


### PR DESCRIPTION
GitHub is complaining about the current CODEOWNERS being ill-formed as code owners must have write access to the repo.