### PR TITLE
[otlib] Improve latency for OpenOCD communications

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/bootstrap/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/bootstrap/BUILD
@@ -74,6 +74,7 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
     },
     fpga = fpga_params(
         changes_otp = True,

--- a/sw/host/opentitanlib/src/debug/openocd.rs
+++ b/sw/host/opentitanlib/src/debug/openocd.rs
@@ -156,6 +156,13 @@ impl OpenOcd {
         let stream = TcpStream::connect(("localhost", openocd_port))
             .context("failed to connect to OpenOCD socket")?;
 
+        // Disable TCP Nagle delay to ensure minimal latency to OpenOCD.
+        // Without this, roundtrip communications can take 50ms which adds
+        // up to be longer than certain timeouts, e.g. the RMA loop in ROM.
+        stream
+            .set_nodelay(true)
+            .context("failed to disable TCP socket delay")?;
+
         let mut connection = Self {
             server_process: scopeguard::ScopeGuard::into_inner(kill_guard),
             reader: BufReader::new(stream.try_clone()?),

--- a/sw/host/opentitanlib/src/test_utils/lc_transition.rs
+++ b/sw/host/opentitanlib/src/test_utils/lc_transition.rs
@@ -292,7 +292,7 @@ pub fn wait_for_status(jtag: &mut dyn Jtag, timeout: Duration, status: LcCtrlSta
     let jtag_tap = jtag.tap();
 
     // Wait for LC controller to be ready.
-    poll::poll_until(timeout, Duration::from_millis(50), || {
+    poll::poll_until(timeout, Duration::from_millis(1), || {
         let polled_status = match jtag_tap {
             JtagTap::LcTap => jtag.read_lc_ctrl_reg(&LcCtrlReg::Status).unwrap(),
             JtagTap::RiscvTap => {


### PR DESCRIPTION
This PR disables Nagle's algorithm for TCP packet merging for the TCL socket between opentitanlib and OpenOCD to improve latency. It also reduces the polling delay for the LC status check from 50ms to 1ms.

Overall this improves the durations of lifecycle transactions by quite a bit and ensures they complete before certain timeouts, specifically the RMA loop inside the ROM.