### PR TITLE
[ottf,spi_console] Use `LAST_READ_ADDR` instead of CS for synchronization when using the TX-ready pin

### DIFF
--- a/sw/device/lib/testing/test_framework/ottf_console_spi.c
+++ b/sw/device/lib/testing/test_framework/ottf_console_spi.c
@@ -193,39 +193,52 @@ static size_t spi_device_send_frame(ottf_console_t *console, const char *buf,
   // reads out the entire frame. Clear the TX-ready indicator pin before
   // continuing.
   if (console->data.spi.tx_ready_gpio != kOttfSpiNoTxGpio) {
+    // Where possible, for synchronization use the last read address to
+    // determine whether the host has started/finished reading the data to avoid
+    // reliance on HW chip select signals, which could be missed depending on
+    // Ibex/SPI clock speeds and are difficult to handle in emulation
+    // environments.
+    uint32_t target_read_addr = 0;
+    if (next_write_address == 0) {
+      target_read_addr = kSpiDeviceReadBufferSizeBytes - 1;
+    } else {
+      target_read_addr = next_write_address - 1;
+    }
+
+    uint32_t initial_read_addr;
+    if (dif_spi_device_get_last_read_address(spi_device, &initial_read_addr) !=
+        kDifOk) {
+      return 0;
+    }
     OT_DISCARD(dif_gpio_write(&ottf_console_gpio,
                               console->data.spi.tx_ready_gpio, true));
-    bool cs_state = true;
-    bool target_cs_state = false;
-    // There will be two bulk transfers that can be synchronized by the
-    // chip-select action. First the host will read out the 12-byte frame
-    // header, followed by the N-byte payload. Each transfer is framed on the
-    // wire by observing the chip-select first toggling high->low then
-    // low->high.
-    //
-    // After the first toggle low, when the host begins reading out the frame
-    // header, we can deassert the TX-ready pin as the host will continue to
-    // complete two SPI transfers regardless.
-    for (size_t i = 0; i < 4; ++i) {
-      // Repeat four times, because there are 4 CSB-toggle events in two
-      // standard SPI transfers.
 
-      // Query the state of CSB until it changes.
-      do {
-        if (dif_spi_device_get_csb_status(spi_device, &cs_state) != kDifOk) {
-          return 0;
-        }
-      } while (cs_state != target_cs_state);
-      target_cs_state = !target_cs_state;
-
-      // After the first toggle of CSB (high->low, the start of the header
-      // transfer), the HOST is already going to queue up and complete 2 full
-      // transfers, so we can de-assert the TX-Ready indicator GPIO.
-      if (i == 0) {
-        OT_DISCARD(dif_gpio_write(&ottf_console_gpio,
-                                  console->data.spi.tx_ready_gpio, false));
+    // Wait until a /CS low or a read address change to toggle TX ready low
+    bool cs_state;
+    uint32_t last_read_addr;
+    do {
+      if (dif_spi_device_get_csb_status(spi_device, &cs_state) != kDifOk ||
+          dif_spi_device_get_last_read_address(spi_device, &last_read_addr) !=
+              kDifOk) {
+        return 0;
       }
-    }
+    } while (cs_state && last_read_addr == initial_read_addr);
+
+    // After the host begins reading out the frame header, we can deassert the
+    // TX-ready pin as the host will continue to complete two SPI transfers
+    // (the header and payload) regardless.
+    OT_DISCARD(dif_gpio_write(&ottf_console_gpio,
+                              console->data.spi.tx_ready_gpio, false));
+
+    // Finished only when the read address matches the last written byte of
+    // data, and /CS is high (deasserted).
+    do {
+      if (dif_spi_device_get_csb_status(spi_device, &cs_state) != kDifOk ||
+          dif_spi_device_get_last_read_address(spi_device, &last_read_addr) !=
+              kDifOk) {
+        return 0;
+      }
+    } while (!cs_state || last_read_addr != target_read_addr);
 
     // Reset the write_address before returning.
     next_write_address = 0;


### PR DESCRIPTION
The current OTTF SPI console implementation, when using a TX-ready GPIO indicator pin, watches to see the chip select signal (the SPI Device's [`STATUS.csb`](https://opentitan.org/book/hw/ip/spi_device/doc/registers.html#status)) toggle 4 times corresponding to asserting/deasserting for the header read and then the payload read. By using this, the device can determine when the host has started/finished reading and synchronize accordingly.

This is not ideal because it depends on a direct HW signal (CSb) which:
1. Could potentially be problematic for different clock speeds (/ ISR handling) if the CS is asserted for a short time and Ibex does not poll fast enough (since there is no interrupt here), and
2. Causes problems for DV which has to [insert additional arbitrary delays](https://github.com/lowRISC/opentitan/blob/740eb6196146e7956069c0895835efd17bbc0a2a/hw/dv/sv/ottf_spi_console/ottf_spi_console.sv#L294-L300) to allow software to see the CS changes.
3. Is very difficult for emulation flows to manage, such as in QEMU (IO transactions like SPI will be at least partially processed before yielding to the vCPU, meaning that the entire transactions can occur before guest SW can poll for the CS change).

Instead, since the SPI device exposes the last read address in [`LAST_READ_ADDR`](https://opentitan.org/book/hw/ip/spi_device/doc/registers.html#last_read_addr) (and the exact amount of data to be read is known ahead of time), we can just check the last read address to determine when the host is finished reading. We still deassert the TX ready pin after either seeing CS go low or a read address change, but we now know the transaction is finished when CS is high and we see a match on our target address.

I've tested and this seems to be working with `//sw/device/tests:ottf_console_with_gpio_tx_indicator_test` and `//sw/device/silicon_creator/manuf/base:cp_provision_functest` on FPGA.