### PR TITLE
[p256/p384/cryptolib] Memeq after Memcpy

### DIFF
--- a/sw/device/lib/crypto/impl/keyblob.c
+++ b/sw/device/lib/crypto/impl/keyblob.c
@@ -102,6 +102,10 @@ status_t keyblob_from_shares(const uint32_t *share0, const uint32_t *share1,
   size_t share_words = keyblob_share_num_words(config);
   HARDENED_TRY(hardened_memcpy(keyblob, share0, share_words));
   HARDENED_TRY(hardened_memcpy(keyblob + share_words, share1, share_words));
+  HARDENED_CHECK_EQ(hardened_memeq(share0, keyblob, share_words),
+                    kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(hardened_memeq(share1, keyblob + share_words, share_words),
+                    kHardenedBoolTrue);
   return OTCRYPTO_OK;
 }
 


### PR DESCRIPTION
The Fi simulation from https://github.com/lowRISC/opentitan/pull/28549 
found two vulnerabilities from instruction skips in ecdh p256 and two in p384.
These stem from offsetting pointers in the hardened_memcpy.
To protect against them a hardened_memeq is added.

In addition, the output shared secret from ecdh is randomized via memshred before it is being computed.