### PR TITLE
Partially fix pinmux FPV HJSON configs

### DIFF
--- a/hw/top_darjeeling/formal/top_darjeeling_fpv_ip_cfgs.hjson
+++ b/hw/top_darjeeling/formal/top_darjeeling_fpv_ip_cfgs.hjson
@@ -22,7 +22,7 @@
              {
                name: pinmux_fpv
                dut: pinmux_tb
-               fusesoc_core: lowrisc:fpv:pinmux_fpv
+               fusesoc_core: lowrisc:darjeeling_fpv:pinmux_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/ip/pinmux/{sub_flow}/{tool}"
                defines: "FPV_ALERT_NO_SIGINT_ERR"
@@ -34,7 +34,7 @@
              {
                name: pinmux_chip_fpv
                dut: pinmux_tb
-               fusesoc_core: lowrisc:systems:pinmux_chip_fpv
+               fusesoc_core: lowrisc:darjeeling_systems:pinmux_chip_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/{top_chip}/ip/pinmux/{sub_flow}/{tool}"
                defines: "FPV_ALERT_NO_SIGINT_ERR"
@@ -45,7 +45,7 @@
              {
                name: rv_plic_fpv
                dut: rv_plic_tb
-               fusesoc_core: lowrisc:darjeeling_fpv:rv_plic_fpv
+               fusesoc_core: lowrisc:darjeeling_ip:rv_plic_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/{top_chip}/ip_autogen/rv_plic/{sub_flow}/{tool}"
                cov: true

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_ip_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_ip_cfgs.hjson
@@ -35,7 +35,7 @@
              {
                name: pinmux_chip_fpv
                dut: pinmux_chip_tb
-               fusesoc_core: lowrisc:earlgrey_fpv:pinmux_chip_fpv
+               fusesoc_core: lowrisc:earlgrey_systems:pinmux_chip_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip_autogen/pinmux/{sub_flow}/{tool}"
                defines: "FPV_ALERT_NO_SIGINT_ERR"


### PR DESCRIPTION
The "library" part of the `fusesoc_core` names was missing the chip name.

The `pinmux_chip_fpv` configs still do not run because of

    import top_${topname}_pkg::*;

And unfortunately the fusesoc name for that package is e.g. `lowrisc:systems:top_earlgrey_pkg`, not `lowrisc:earlgrey_systems:top_pkg`, so you can't add a dependency using `- ${instance_vlnv("lowrisc:systems:top_pkg")}` in `pinmux_chip_fpv.core.tpl`.

I presume the intention was to rename it but it hasn't been done yet (probably super tedious!).