### PR TITLE
[hw,ac_range_check,rtl] Implement log_config as hwext to allow clearing it

### DIFF
--- a/hw/ip_templates/ac_range_check/data/ac_range_check.hjson.tpl
+++ b/hw/ip_templates/ac_range_check/data/ac_range_check.hjson.tpl
@@ -179,7 +179,9 @@ import math
     { name: "LOG_CONFIG"
       desc: ""
       swaccess: "rw"
-      hwaccess: "hro"
+      hwaccess: "hrw"
+      hwext: "true"
+      hwqe: "true"
       fields: [
         { bits: "9:2"
           name: "deny_cnt_threshold"
@@ -189,9 +191,7 @@ import math
         { bits: "1"
           name: "log_clear"
           resval: 0x0
-          hwqe: "true"
           swaccess: "r0w1c"
-          hwaccess: "hrw"
           desc: '''Clears all log information for the first denied access including:
                     - LOG_STATUS
                     - LOG_ADDRESS.

--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_predictor.sv.tpl
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_predictor.sv.tpl
@@ -192,41 +192,6 @@ function access_decision_e ${module_instance_name}_predictor::check_access(tl_se
   // Check if bypass is enabled
   bypass_enable = env_cfg.misc_vif.get_range_check_overwrite();
 
-  // Clear log status register if the log_clear regfield is set
-  if (`gmv(env_cfg.ral.log_config.log_clear)) begin
-    `uvm_info(`gfn, $sformatf("Clear performed to log_status and log_address"), UVM_MEDIUM)
-    `uvm_info(`gfn, $sformatf({"Cleared info in RAL:\n",
-            " - deny_range_index: %0d\n",
-            " - denied_ctn_uid: 0b%0b\n",
-            " - denied_source_role: 0b%0b\n",
-            " - denied_racl_write: %0b\n",
-            " - denied_racl_read: %0b\n",
-            " - denied_no_match: %0b\n",
-            " - denied_execute_access: %0b\n",
-            " - denied_write_access: %0b\n",
-            " - denied_read_access: %0b\n",
-            " - deny_cnt: %0d\n",
-            " - log_address: 0x%0x\n"},
-            `gmv(env_cfg.ral.log_status.deny_range_index),
-            `gmv(env_cfg.ral.log_status.denied_ctn_uid),
-            `gmv(env_cfg.ral.log_status.denied_source_role),
-            `gmv(env_cfg.ral.log_status.denied_racl_write),
-            `gmv(env_cfg.ral.log_status.denied_racl_read),
-            `gmv(env_cfg.ral.log_status.denied_no_match),
-            `gmv(env_cfg.ral.log_status.denied_execute_access),
-            `gmv(env_cfg.ral.log_status.denied_write_access),
-            `gmv(env_cfg.ral.log_status.denied_read_access),
-            `gmv(env_cfg.ral.log_status.deny_cnt),
-            `gmv(env_cfg.ral.log_address)),
-            UVM_MEDIUM)
-    deny_cnt = 0;
-    overflow_flag = 0;
-    void'(env_cfg.ral.log_status.predict
-          (.value(32'b0), .kind(UVM_PREDICT_DIRECT)));
-    void'(env_cfg.ral.log_address.predict
-          (.value(32'b0), .kind(UVM_PREDICT_DIRECT)));
-  end
-
   if (env_cfg.en_cov && !bypass_sampled) begin
     // bypass_sampled is set so that we only need to sample coverage once per test and not per
     // transaction

--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_scoreboard.sv.tpl
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_scoreboard.sv.tpl
@@ -307,13 +307,25 @@ task ${module_instance_name}_scoreboard::process_tl_access(tl_seq_item item,
       // FIXME TODO MVy
     end
     "log_config": begin
-      // FIXME TODO MVy
+      // log_config is hwext with mixed field types - check reads but handle log_clear specially
+      // Detect write to log_config with log_clear bit set and clear log status
+      if (tl_phase == AChanWrite &&
+          item.a_data[ral.log_config.log_clear.get_lsb_pos()] == 1'b1) begin
+        `uvm_info(`gfn, $sformatf({"Clear performed to log_status and log_address ",
+                                   "(detected in scoreboard)"}), UVM_MEDIUM)
+        void'(ral.log_status.predict(.value(32'b0), .kind(UVM_PREDICT_DIRECT)));
+        void'(ral.log_address.predict(.value(32'b0), .kind(UVM_PREDICT_DIRECT)));
+        predict.deny_cnt = 0;
+        predict.overflow_flag = 0;
+      end
     end
     "log_status": begin
-      // FIXME TODO MVy
+      // log_status is read-only for SW, so no need to update the RAL here.
+      // Read checks are done by default.
     end
     "log_address": begin
-      // FIXME TODO MVy
+      // log_address is read-only for SW, so no need to update the RAL here.
+      // Read checks are done by default.
     end
     "range_regwen": begin
       // FIXME TODO MVy

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/data/ac_range_check.hjson
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/data/ac_range_check.hjson
@@ -176,7 +176,9 @@
     { name: "LOG_CONFIG"
       desc: ""
       swaccess: "rw"
-      hwaccess: "hro"
+      hwaccess: "hrw"
+      hwext: "true"
+      hwqe: "true"
       fields: [
         { bits: "9:2"
           name: "deny_cnt_threshold"
@@ -186,9 +188,7 @@
         { bits: "1"
           name: "log_clear"
           resval: 0x0
-          hwqe: "true"
           swaccess: "r0w1c"
-          hwaccess: "hrw"
           desc: '''Clears all log information for the first denied access including:
                     - LOG_STATUS
                     - LOG_ADDRESS.

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_predictor.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_predictor.sv
@@ -192,41 +192,6 @@ function access_decision_e ac_range_check_predictor::check_access(tl_seq_item it
   // Check if bypass is enabled
   bypass_enable = env_cfg.misc_vif.get_range_check_overwrite();
 
-  // Clear log status register if the log_clear regfield is set
-  if (`gmv(env_cfg.ral.log_config.log_clear)) begin
-    `uvm_info(`gfn, $sformatf("Clear performed to log_status and log_address"), UVM_MEDIUM)
-    `uvm_info(`gfn, $sformatf({"Cleared info in RAL:\n",
-            " - deny_range_index: %0d\n",
-            " - denied_ctn_uid: 0b%0b\n",
-            " - denied_source_role: 0b%0b\n",
-            " - denied_racl_write: %0b\n",
-            " - denied_racl_read: %0b\n",
-            " - denied_no_match: %0b\n",
-            " - denied_execute_access: %0b\n",
-            " - denied_write_access: %0b\n",
-            " - denied_read_access: %0b\n",
-            " - deny_cnt: %0d\n",
-            " - log_address: 0x%0x\n"},
-            `gmv(env_cfg.ral.log_status.deny_range_index),
-            `gmv(env_cfg.ral.log_status.denied_ctn_uid),
-            `gmv(env_cfg.ral.log_status.denied_source_role),
-            `gmv(env_cfg.ral.log_status.denied_racl_write),
-            `gmv(env_cfg.ral.log_status.denied_racl_read),
-            `gmv(env_cfg.ral.log_status.denied_no_match),
-            `gmv(env_cfg.ral.log_status.denied_execute_access),
-            `gmv(env_cfg.ral.log_status.denied_write_access),
-            `gmv(env_cfg.ral.log_status.denied_read_access),
-            `gmv(env_cfg.ral.log_status.deny_cnt),
-            `gmv(env_cfg.ral.log_address)),
-            UVM_MEDIUM)
-    deny_cnt = 0;
-    overflow_flag = 0;
-    void'(env_cfg.ral.log_status.predict
-          (.value(32'b0), .kind(UVM_PREDICT_DIRECT)));
-    void'(env_cfg.ral.log_address.predict
-          (.value(32'b0), .kind(UVM_PREDICT_DIRECT)));
-  end
-
   if (env_cfg.en_cov && !bypass_sampled) begin
     // bypass_sampled is set so that we only need to sample coverage once per test and not per
     // transaction

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_scoreboard.sv
@@ -307,13 +307,25 @@ task ac_range_check_scoreboard::process_tl_access(tl_seq_item item,
       // FIXME TODO MVy
     end
     "log_config": begin
-      // FIXME TODO MVy
+      // log_config is hwext with mixed field types - check reads but handle log_clear specially
+      // Detect write to log_config with log_clear bit set and clear log status
+      if (tl_phase == AChanWrite &&
+          item.a_data[ral.log_config.log_clear.get_lsb_pos()] == 1'b1) begin
+        `uvm_info(`gfn, $sformatf({"Clear performed to log_status and log_address ",
+                                   "(detected in scoreboard)"}), UVM_MEDIUM)
+        void'(ral.log_status.predict(.value(32'b0), .kind(UVM_PREDICT_DIRECT)));
+        void'(ral.log_address.predict(.value(32'b0), .kind(UVM_PREDICT_DIRECT)));
+        predict.deny_cnt = 0;
+        predict.overflow_flag = 0;
+      end
     end
     "log_status": begin
-      // FIXME TODO MVy
+      // log_status is read-only for SW, so no need to update the RAL here.
+      // Read checks are done by default.
     end
     "log_address": begin
-      // FIXME TODO MVy
+      // log_address is read-only for SW, so no need to update the RAL here.
+      // Read checks are done by default.
     end
     "range_regwen": begin
       // FIXME TODO MVy

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check.sv
@@ -260,8 +260,33 @@ module ac_range_check
   // Range Check Deny Counting Logic
   //////////////////////////////////////////////////////////////////////////////
 
-  logic [DenyCountWidth-1:0] deny_cnt;
+  logic [DenyCountWidth-1:0] deny_cnt, deny_cnt_threshold_q;
   logic deny_cnt_incr;
+  logic log_enable_q;
+
+  // Manual implementation of the SW-RW fields of log_status. The register is implemented as hwext
+  // to allow the rising edge of log_clear to clear the log_status register without setting it.
+  prim_flop_en #(
+    .Width(DenyCountWidth)
+  ) u_deny_cnt_threshold (
+    .clk_i  ( clk_i                                   ),
+    .rst_ni ( rst_ni                                  ),
+    .en_i   ( reg2hw.log_config.deny_cnt_threshold.qe ),
+    .d_i    ( reg2hw.log_config.deny_cnt_threshold.q  ),
+    .q_o    ( deny_cnt_threshold_q                    )
+  );
+
+  assign hw2reg.log_config.deny_cnt_threshold.d = deny_cnt_threshold_q;
+
+  prim_flop_en u_log_enable (
+    .clk_i  ( clk_i                           ),
+    .rst_ni ( rst_ni                          ),
+    .en_i   ( reg2hw.log_config.log_enable.qe ),
+    .d_i    ( reg2hw.log_config.log_enable.q  ),
+    .q_o    ( log_enable_q                    )
+  );
+
+  assign hw2reg.log_config.log_enable.d = log_enable_q;
 
   // Clear log information when clearing the log manually via the writing of a 1 to the
   // log_clear bit.
@@ -269,14 +294,13 @@ module ac_range_check
   assign clear_log = (reg2hw.log_config.log_clear.qe & reg2hw.log_config.log_clear.q);
 
   // Always clear the log_clear bit from hardware
-  assign hw2reg.log_config.log_clear.de = 1'b1;
   assign hw2reg.log_config.log_clear.d  = 1'b0;
 
   // Only increment the deny counter if logging is globally enabled and for the particular range,
   // we are not clearing the counter in this cycle, and see a failing range check
-  assign deny_cnt_incr = reg2hw.log_config.log_enable.q &
-                         log_enable_mask[deny_index]    &
-                         ~clear_log                     &
+  assign deny_cnt_incr = log_enable_q                &
+                         log_enable_mask[deny_index] &
+                         ~clear_log                  &
                          range_check_fail;
   // Determine if we are doing the first log. This one is special, since it also needs to log
   // diagnostics data
@@ -348,7 +372,7 @@ module ac_range_check
 
   // Create the IRQ condition when the deny counter is above the configured threshold.
   logic deny_cnt_threshold_reached;
-  assign deny_cnt_threshold_reached = deny_cnt > reg2hw.log_config.deny_cnt_threshold.q;
+  assign deny_cnt_threshold_reached = deny_cnt > deny_cnt_threshold_q;
 
   prim_intr_hw #(
     .Width ( 1        ),

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_pkg.sv
@@ -54,6 +54,7 @@ package ac_range_check_reg_pkg;
   typedef struct packed {
     struct packed {
       logic [7:0]  q;
+      logic        qe;
     } deny_cnt_threshold;
     struct packed {
       logic        q;
@@ -61,6 +62,7 @@ package ac_range_check_reg_pkg;
     } log_clear;
     struct packed {
       logic        q;
+      logic        qe;
     } log_enable;
   } ac_range_check_reg2hw_log_config_reg_t;
 
@@ -125,9 +127,14 @@ package ac_range_check_reg_pkg;
 
   typedef struct packed {
     struct packed {
+      logic [7:0]  d;
+    } deny_cnt_threshold;
+    struct packed {
       logic        d;
-      logic        de;
     } log_clear;
+    struct packed {
+      logic        d;
+    } log_enable;
   } ac_range_check_hw2reg_log_config_reg_t;
 
   typedef struct packed {
@@ -180,11 +187,11 @@ package ac_range_check_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    ac_range_check_reg2hw_intr_state_reg_t intr_state; // [3602:3602]
-    ac_range_check_reg2hw_intr_enable_reg_t intr_enable; // [3601:3601]
-    ac_range_check_reg2hw_intr_test_reg_t intr_test; // [3600:3599]
-    ac_range_check_reg2hw_alert_test_reg_t alert_test; // [3598:3595]
-    ac_range_check_reg2hw_log_config_reg_t log_config; // [3594:3584]
+    ac_range_check_reg2hw_intr_state_reg_t intr_state; // [3604:3604]
+    ac_range_check_reg2hw_intr_enable_reg_t intr_enable; // [3603:3603]
+    ac_range_check_reg2hw_intr_test_reg_t intr_test; // [3602:3601]
+    ac_range_check_reg2hw_alert_test_reg_t alert_test; // [3600:3597]
+    ac_range_check_reg2hw_log_config_reg_t log_config; // [3596:3584]
     ac_range_check_reg2hw_range_base_mreg_t [31:0] range_base; // [3583:2624]
     ac_range_check_reg2hw_range_limit_mreg_t [31:0] range_limit; // [2623:1664]
     ac_range_check_reg2hw_range_attr_mreg_t [31:0] range_attr; // [1663:1024]
@@ -194,9 +201,9 @@ package ac_range_check_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    ac_range_check_hw2reg_intr_state_reg_t intr_state; // [82:81]
-    ac_range_check_hw2reg_alert_status_reg_t alert_status; // [80:73]
-    ac_range_check_hw2reg_log_config_reg_t log_config; // [72:71]
+    ac_range_check_hw2reg_intr_state_reg_t intr_state; // [90:89]
+    ac_range_check_hw2reg_alert_status_reg_t alert_status; // [88:81]
+    ac_range_check_hw2reg_log_config_reg_t log_config; // [80:71]
     ac_range_check_hw2reg_log_status_reg_t log_status; // [70:33]
     ac_range_check_hw2reg_log_address_reg_t log_address; // [32:0]
   } ac_range_check_hw2reg_t;
@@ -377,6 +384,10 @@ package ac_range_check_reg_pkg;
   parameter logic [1:0] AC_RANGE_CHECK_ALERT_TEST_RESVAL = 2'h 0;
   parameter logic [0:0] AC_RANGE_CHECK_ALERT_TEST_RECOV_CTRL_UPDATE_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] AC_RANGE_CHECK_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [9:0] AC_RANGE_CHECK_LOG_CONFIG_RESVAL = 10'h 0;
+  parameter logic [0:0] AC_RANGE_CHECK_LOG_CONFIG_LOG_ENABLE_RESVAL = 1'h 0;
+  parameter logic [0:0] AC_RANGE_CHECK_LOG_CONFIG_LOG_CLEAR_RESVAL = 1'h 0;
+  parameter logic [7:0] AC_RANGE_CHECK_LOG_CONFIG_DENY_CNT_THRESHOLD_RESVAL = 8'h 0;
 
   // Register index
   typedef enum int {

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_top.sv
@@ -151,6 +151,7 @@ module ac_range_check_reg_top
   logic alert_status_shadowed_storage_err_qs;
   logic alert_status_reg_intg_err_qs;
   logic alert_status_counter_err_qs;
+  logic log_config_re;
   logic log_config_we;
   logic log_config_log_enable_qs;
   logic log_config_log_enable_wd;
@@ -1353,99 +1354,57 @@ module ac_range_check_reg_top
   );
 
 
-  // R[log_config]: V(False)
+  // R[log_config]: V(True)
   logic log_config_qe;
   logic [2:0] log_config_flds_we;
-  prim_flop #(
-    .Width(1),
-    .ResetValue(0)
-  ) u_log_config0_qe (
-    .clk_i(clk_i),
-    .rst_ni(rst_ni),
-    .d_i(&log_config_flds_we),
-    .q_o(log_config_qe)
-  );
+  assign log_config_qe = &log_config_flds_we;
   //   F[log_enable]: 0:0
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+  prim_subreg_ext #(
+    .DW    (1)
   ) u_log_config_log_enable (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
+    .re     (log_config_re),
     .we     (log_config_we),
     .wd     (log_config_log_enable_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
+    .d      (hw2reg.log_config.log_enable.d),
+    .qre    (),
     .qe     (log_config_flds_we[0]),
     .q      (reg2hw.log_config.log_enable.q),
     .ds     (),
-
-    // to register interface (read)
     .qs     (log_config_log_enable_qs)
   );
+  assign reg2hw.log_config.log_enable.qe = log_config_qe;
 
   //   F[log_clear]: 1:1
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+  prim_subreg_ext #(
+    .DW    (1)
   ) u_log_config_log_clear (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
+    .re     (1'b0),
     .we     (log_config_we),
     .wd     (log_config_log_clear_wd),
-
-    // from internal hardware
-    .de     (hw2reg.log_config.log_clear.de),
     .d      (hw2reg.log_config.log_clear.d),
-
-    // to internal hardware
+    .qre    (),
     .qe     (log_config_flds_we[1]),
     .q      (reg2hw.log_config.log_clear.q),
     .ds     (),
-
-    // to register interface (read)
     .qs     ()
   );
   assign reg2hw.log_config.log_clear.qe = log_config_qe;
 
   //   F[deny_cnt_threshold]: 9:2
-  prim_subreg #(
-    .DW      (8),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+  prim_subreg_ext #(
+    .DW    (8)
   ) u_log_config_deny_cnt_threshold (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
+    .re     (log_config_re),
     .we     (log_config_we),
     .wd     (log_config_deny_cnt_threshold_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
+    .d      (hw2reg.log_config.deny_cnt_threshold.d),
+    .qre    (),
     .qe     (log_config_flds_we[2]),
     .q      (reg2hw.log_config.deny_cnt_threshold.q),
     .ds     (),
-
-    // to register interface (read)
     .qs     (log_config_deny_cnt_threshold_qs)
   );
+  assign reg2hw.log_config.deny_cnt_threshold.qe = log_config_qe;
 
 
   // R[log_status]: V(False)
@@ -12403,6 +12362,7 @@ module ac_range_check_reg_top
   assign alert_status_re = racl_addr_hit_read[4] & reg_re & !reg_error;
 
   assign alert_status_shadowed_update_err_wd = '1;
+  assign log_config_re = racl_addr_hit_read[5] & reg_re & !reg_error;
   assign log_config_we = racl_addr_hit_write[5] & reg_we & !reg_error;
 
   assign log_config_log_enable_wd = reg_wdata[0];


### PR DESCRIPTION
Previously, log_config was implemented as an ordinary register. log_config.log_clear was used to detect rising-edge writes to it, which should clear the log_status. However, clear_log is always tied to 0 (.de=1, .d=0), causing it to be always cleared, and rising edges cannot be detected.

To address this, the register is implemented as hwext (as in other IPs where the rising edge is relevant). Other fields need to be implemented as an ordinary register, though manually.