### PR TITLE
[cryptotest] Fix ACVP test name

### DIFF
--- a/sw/device/lib/crypto/data/crypto_testplan.hjson
+++ b/sw/device/lib/crypto/data/crypto_testplan.hjson
@@ -91,7 +91,7 @@
         "//sw/device/tests/crypto:hmac_sha512_functest",
         "//sw/device/tests/crypto:hmac_functest",
         "//sw/device/tests/crypto:hmac_multistream_functest",
-        "//sw/device/tests/crypto/cryptotest:acvp_hmac_sha256",
+        "//sw/device/tests/crypto/cryptotest:hmac_sha256_acvp",
         "//sw/device/tests/crypto/cryptotest:hmac_sha256_kat",
         "//sw/device/tests/crypto/cryptotest:hmac_sha384_kat",
         "//sw/device/tests/crypto/cryptotest:hmac_sha512_kat",

--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -28,7 +28,7 @@ cryptotest(
 )
 
 cryptotest(
-    name = "acvp_hmac_sha256",
+    name = "hmac_sha256_acvp",
     test_args = " ".join([
         "--input=\"$(rootpath //sw/host/cryptotest/testvectors/acvp:hmac_sha256_vectors.json)\"",
         "--expected=\"$(rootpath //sw/host/cryptotest/testvectors/acvp:hmac_sha256_expected.json)\"",
@@ -585,13 +585,13 @@ cryptotest(
 test_suite(
     name = "crypto_kat_test_suite",
     tests = [
-        ":acvp_hmac_sha256",
         ":aes_gcm_kat",
         ":aes_kat",
         ":cshake_kat",
         ":drbg_kat",
         ":ecdh_kat",
         ":ecdsa_kat",
+        ":hmac_sha256_acvp",
         ":hmac_sha256_kat",
         ":hmac_sha384_kat",
         ":hmac_sha512_kat",


### PR DESCRIPTION
Follow the Cryptotest naming convention of <algo>_<test_type>_<suffix>.