### PR TITLE
[rom_ctrl,rtl] Avoid backwards part-select in rom_ctrl_counter

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_counter.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_counter.sv
@@ -62,8 +62,8 @@ module rom_ctrl_counter
   localparam int unsigned TopAddrInt = RomDepth - 1;
   localparam int unsigned TNTAddrInt = RomNonTopCount - 2;
 
-  localparam bit [AW-1:0] TopAddr = TopAddrInt[AW-1:0];
-  localparam bit [AW-1:0] TNTAddr = TNTAddrInt[AW-1:0];
+  localparam bit [AW-1:0] TopAddr = TopAddrInt[0 +: AW];
+  localparam bit [AW-1:0] TNTAddr = TNTAddrInt[0 +: AW];
 
   logic          go;
   logic          req_q, vld_q;

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
@@ -101,7 +101,7 @@ module rom_ctrl_fsm
   localparam int TAW = vbits(TopCount);
 
   localparam int unsigned TopStartAddrInt = RomDepth - TopCount;
-  localparam bit [AW-1:0] TopStartAddr    = TopStartAddrInt[AW-1:0];
+  localparam bit [AW-1:0] TopStartAddr    = TopStartAddrInt[0 +: AW];
 
   // The counter / address generator
   logic          counter_done;


### PR DESCRIPTION
A part-select (defined in section 11.5.1 of IEEE 1800-2012) can either be indexed on non-indexed. The code that was here before used a non-indexed part-selects, which are defined as having the syntax "vect[msb_expr:lsb_expr]". Rather confusingly, "msb" here means "the left-most bit in the vector (as defined by it's data type). (see section 6.9.1 of the same reference).

As such, the msb of a variable defined as "bit [0:10] foo" is the one at index 0, not 10. Accessing foo[3:0] will seemingly work, but the EDA tool might throw a warning about the fact that 3 can't be an MSB if 0 is the LSB.

This is all rather mysterious! But we can cheat and make things easy for ourselves by using an indexed part-select instead. The [0 +: AW] range is equivalent to what we had before, but doesn't really care about the order of the LSB/MSB in the type of the integral variables that are being sliced.