### PR TITLE
[dv,dv_base] Improve bit_toggle_cg_wrap constructor API and documentation

### DIFF
--- a/hw/dv/sv/dv_lib/bit_toggle_cg_wrap.sv
+++ b/hw/dv/sv/dv_lib/bit_toggle_cg_wrap.sv
@@ -29,7 +29,7 @@ class bit_toggle_cg_wrap;
     }
   endgroup : bit_toggle_cg
 
-  function new(string name = "bit_toggle_cg_wrap", bit toggle_cov_en = 1);
+  function new(string name, bit toggle_cov_en = 1);
     bit_toggle_cg = new(name, toggle_cov_en);
   endfunction : new
 

--- a/hw/dv/sv/dv_lib/bit_toggle_cg_wrap.sv
+++ b/hw/dv/sv/dv_lib/bit_toggle_cg_wrap.sv
@@ -1,0 +1,44 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A class wrapping a covergroup that tracks a single bit signal (and covers transitions with it
+// toggling).
+//
+// Using a class like this allows the covergroup to be instantiated in multiple places (and in
+// arrays).
+
+class bit_toggle_cg_wrap;
+
+  // A covergroup that tracks the value of some single-bit value (with associated coverpoint
+  // cp_value). Tracking it explicitly with functional coverage allows transition bins (defined in
+  // cp_transitions).
+  //
+  // If toggle_cov_en is true, the transitions in cp_transitions have nonzero weight.
+  covergroup bit_toggle_cg(string name,
+                           string path = "",
+                           bit    toggle_cov_en = 1)
+    with function sample(bit value);
+
+    option.per_instance = 1;
+    option.name         = (path == "") ? name : {path, "::", name};
+
+    cp_value: coverpoint value;
+    cp_transitions: coverpoint value {
+      option.weight = toggle_cov_en;
+      bins rising  = (0 => 1);
+      bins falling = (1 => 0);
+    }
+  endgroup : bit_toggle_cg
+
+  function new(string name = "bit_toggle_cg_wrap", string path = "", bit toggle_cov_en = 1);
+    bit_toggle_cg = new(name, path, toggle_cov_en);
+  endfunction : new
+
+  // A wrapper around bit_toggle_cg.sample, allowing code using this class to call
+  // the_class_instance.sample() in the same way as it would have sampled the underlying covergroup.
+  function void sample(bit value);
+    bit_toggle_cg.sample(value);
+  endfunction : sample
+
+endclass : bit_toggle_cg_wrap

--- a/hw/dv/sv/dv_lib/bit_toggle_cg_wrap.sv
+++ b/hw/dv/sv/dv_lib/bit_toggle_cg_wrap.sv
@@ -15,13 +15,11 @@ class bit_toggle_cg_wrap;
   // cp_transitions).
   //
   // If toggle_cov_en is true, the transitions in cp_transitions have nonzero weight.
-  covergroup bit_toggle_cg(string name,
-                           string path = "",
-                           bit    toggle_cov_en = 1)
+  covergroup bit_toggle_cg(string name, bit toggle_cov_en = 1)
     with function sample(bit value);
 
     option.per_instance = 1;
-    option.name         = (path == "") ? name : {path, "::", name};
+    option.name         = name;
 
     cp_value: coverpoint value;
     cp_transitions: coverpoint value {
@@ -31,8 +29,8 @@ class bit_toggle_cg_wrap;
     }
   endgroup : bit_toggle_cg
 
-  function new(string name = "bit_toggle_cg_wrap", string path = "", bit toggle_cov_en = 1);
-    bit_toggle_cg = new(name, path, toggle_cov_en);
+  function new(string name = "bit_toggle_cg_wrap", bit toggle_cov_en = 1);
+    bit_toggle_cg = new(name, toggle_cov_en);
   endfunction : new
 
   // A wrapper around bit_toggle_cg.sample, allowing code using this class to call

--- a/hw/dv/sv/dv_lib/dv_base_env_cov.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cov.sv
@@ -2,35 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class bit_toggle_cg_wrap;
-
-  // Covergroup: bit_toggle_cg
-  // Generic covergroup definition
-  covergroup bit_toggle_cg(string name, string path = "", bit toggle_cov_en = 1) with function
-        sample(bit value);
-    option.per_instance = 1;
-    option.name         = (path == "") ? name : {path, "::", name};
-
-    cp_value: coverpoint value;
-    cp_transitions: coverpoint value {
-      option.weight = toggle_cov_en;
-      bins rising  = (0 => 1);
-      bins falling = (1 => 0);
-    }
-  endgroup : bit_toggle_cg
-
-  // Function: new
-  function new(string name = "bit_toggle_cg_wrap", string path = "", bit toggle_cov_en = 1);
-    bit_toggle_cg = new(name, path, toggle_cov_en);
-  endfunction : new
-
-  // Function: sample
-  function void sample(bit value);
-    bit_toggle_cg.sample(value);
-  endfunction : sample
-
-endclass : bit_toggle_cg_wrap
-
 class dv_base_env_cov #(type CFG_T = dv_base_env_cfg) extends uvm_component;
   `uvm_component_param_utils(dv_base_env_cov #(CFG_T))
 

--- a/hw/dv/sv/dv_lib/dv_base_env_cov.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cov.sv
@@ -2,11 +2,15 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// A base class for coverage collection. This base class only really contains the CFG_T handle, that
+// points to the config for the environment in use.
+
 class dv_base_env_cov #(type CFG_T = dv_base_env_cfg) extends uvm_component;
   `uvm_component_param_utils(dv_base_env_cov #(CFG_T))
 
   CFG_T cfg;
 
-  `uvm_component_new
-
+  function new(string name, uvm_component parent);
+    super.new(name, parent);
+  endfunction
 endclass

--- a/hw/dv/sv/dv_lib/dv_lib.core
+++ b/hw/dv/sv/dv_lib/dv_lib.core
@@ -25,6 +25,7 @@ filesets:
       - dv_base_seq.sv: {is_include_file: true}
 
       - dv_base_env_cfg.sv: {is_include_file: true}
+      - bit_toggle_cg_wrap.sv: {is_include_file: true}
       - dv_base_env_cov.sv: {is_include_file: true}
       - dv_base_virtual_sequencer.sv: {is_include_file: true}
       - dv_base_scoreboard.sv: {is_include_file: true}

--- a/hw/dv/sv/dv_lib/dv_lib_pkg.sv
+++ b/hw/dv/sv/dv_lib/dv_lib_pkg.sv
@@ -31,6 +31,7 @@ package dv_lib_pkg;
 
   // base env
   `include "dv_base_env_cfg.sv"
+  `include "bit_toggle_cg_wrap.sv"
   `include "dv_base_env_cov.sv"
   `include "dv_base_virtual_sequencer.sv"
   `include "dv_base_scoreboard.sv"

--- a/hw/dv/sv/tl_agent/tl_agent_cov.sv
+++ b/hw/dv/sv/tl_agent/tl_agent_cov.sv
@@ -94,14 +94,14 @@ class tl_agent_cov extends dv_base_agent_cov #(tl_agent_cfg);
     m_max_outstanding_cg    = new("m_max_outstanding_cg", cfg.max_outstanding_req, `gfn);
 
     if (cfg.max_outstanding_req > 1 && en_cov_outstanding_item_w_same_addr) begin
-      m_outstanding_item_w_same_addr_cov_obj = new(.name("m_outstanding_item_w_same_addr_cov_obj"),
-                                                   .path(`gfn));
+      m_outstanding_item_w_same_addr_cov_obj =
+          new({`gfn, "::m_outstanding_item_w_same_addr_cov_obj"});
     end
 
     if (cfg.if_mode == dv_utils_pkg::Host) begin
       m_tl_a_chan_cov_cg = new("m_tl_a_chan_cov_cg", cfg.valid_a_source_width, `gfn);
       foreach (tl_error_names[i]) begin
-        m_tl_error_cov_objs[tl_error_names[i]] = new(.name(tl_error_names[i]), .path(`gfn));
+        m_tl_error_cov_objs[tl_error_names[i]] = new({`gfn, "::", tl_error_names[i]});
       end
     end else begin // device mode
       m_tl_d_chan_cov_cg = new("m_tl_d_chan_cov_cg", `gfn);

--- a/hw/ip/rv_timer/dv/env/rv_timer_env_cov.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_env_cov.sv
@@ -76,10 +76,10 @@ class rv_timer_env_cov extends cip_base_env_cov #(.CFG_T(rv_timer_env_cfg));
     super.new(name, parent);
     //Create cfg coverage for each timer
     foreach (cfg_values_cov_obj[timer]) begin
+      string cov_name = intr_pin_cov_name(timer);
       cfg_values_cov_obj[timer] = rv_timer_cfg_cov_obj::type_id::create($sformatf("rv_timer-%0d",
                                                                                   timer));
-      sticky_intr_cov[{"rv_timer_sticky_intr_pin", $sformatf("%0d", timer)}] =
-            new(.name({"rv_timer_sticky_intr_pin", $sformatf("%0d", timer)}), .toggle_cov_en(0));
+      sticky_intr_cov[cov_name] = new(.name(cov_name), .toggle_cov_en(0));
     end
     //Create toggle coverage for each prescale bit
     foreach (rv_timer_prescale_values_cov_obj[timer, bit_num]) begin
@@ -93,4 +93,20 @@ class rv_timer_env_cov extends cip_base_env_cov #(.CFG_T(rv_timer_env_cfg));
     end
   endfunction : new
 
+  // Return the string used to name the object that will be used to track coverage for the interrupt
+  // pin for the given timer.
+  static local function string intr_pin_cov_name(int unsigned timer_idx);
+    return $sformatf("rv_timer_sticky_intr_pin%0d", timer_idx);
+  endfunction
+
+  // Return the bit_toggle_cg_wrap object that is used to track coverage for the interrupt pin for
+  // the given timer.
+  local function bit_toggle_cg_wrap intr_pin_cov(int unsigned timer_idx);
+    return sticky_intr_cov[intr_pin_cov_name(timer_idx)];
+  endfunction
+
+  // Sample the interrupt pin for the given timer.
+  function void sample_intr_pin(int unsigned timer_idx, logic value);
+    intr_pin_cov(timer_idx).sample(value);
+  endfunction
 endclass

--- a/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
@@ -113,17 +113,11 @@ class rv_timer_scoreboard extends cip_base_scoreboard #(.CFG_T (rv_timer_env_cfg
                 if (en_timers[i][j] == 0) begin
                   // Reset the interrupt when mtimecmp is updated and timer is not active
                   intr_status_exp[i][j] = 0;
-                  if (cfg.en_cov) begin
-                    cov.sticky_intr_cov[{"rv_timer_sticky_intr_pin",
-                                        $sformatf("%0d", timer_idx)}].sample(1'b0);
-                  end
+                  if (cfg.en_cov) cov.sample_intr_pin(timer_idx, 0);
                 end else begin
                   // intr stays sticky if timer is active
                   ctimecmp_update_on_fly = 1;
-                  if (cfg.en_cov) begin
-                    cov.sticky_intr_cov[{"rv_timer_sticky_intr_pin",
-                                        $sformatf("%0d", timer_idx)}].sample(intr_status_exp[i][j]);
-                  end
+                  if (cfg.en_cov) cov.sample_intr_pin(timer_idx, intr_status_exp[i][j]);
                 end
                 break;
               end
@@ -140,17 +134,11 @@ class rv_timer_scoreboard extends cip_base_scoreboard #(.CFG_T (rv_timer_env_cfg
                 if (en_timers[i][j] == 0) begin
                   // Reset the interrupt when mtimecmp is updated and timer is not active
                   intr_status_exp[i][j] = 0;
-                  if (cfg.en_cov) begin
-                    cov.sticky_intr_cov[{"rv_timer_sticky_intr_pin",
-                                        $sformatf("%0d", timer_idx)}].sample(1'b0);
-                  end
+                  if (cfg.en_cov) cov.sample_intr_pin(timer_idx, 0);
                 end else begin
                   // intr stays sticky if timer is active
                   ctimecmp_update_on_fly = 1;
-                  if (cfg.en_cov) begin
-                    cov.sticky_intr_cov[{"rv_timer_sticky_intr_pin",
-                                        $sformatf("%0d", timer_idx)}].sample(intr_status_exp[i][j]);
-                  end
+                  if (cfg.en_cov) cov.sample_intr_pin(timer_idx, intr_status_exp[i][j]);
                 end
                 break;
               end
@@ -175,15 +163,8 @@ class rv_timer_scoreboard extends cip_base_scoreboard #(.CFG_T (rv_timer_env_cfg
                 if (item.a_data[j] == 1) begin
                   if (en_timers[i][j] == 0) begin
                     intr_status_exp[i][j] = 0;
-                    if (cfg.en_cov) begin
-                      cov.sticky_intr_cov[{"rv_timer_sticky_intr_pin",
-                                          $sformatf("%0d", timer_idx)}].sample(1'b0);
-                    end
                   end
-                  else if (cfg.en_cov) begin // sticky interrupt
-                    cov.sticky_intr_cov[{"rv_timer_sticky_intr_pin",
-                                        $sformatf("%0d", timer_idx)}].sample(1'b1);
-                  end
+                  if (cfg.en_cov) cov.sample_intr_pin(timer_idx, en_timers[i][j]);
                 end
               end
               break;

--- a/hw/ip_templates/gpio/dv/env/gpio_scoreboard.sv.tpl
+++ b/hw/ip_templates/gpio/dv/env/gpio_scoreboard.sv.tpl
@@ -163,13 +163,7 @@ class ${module_instance_name}_scoreboard extends cip_base_scoreboard #(.CFG_T ($
               if (cfg.en_cov) begin
                 foreach (cleared_intr_bits[each_bit]) begin
                   if (cleared_intr_bits[each_bit]) begin
-                    if (last_intr_update_except_clearing[each_bit]) begin
-                      cov.sticky_intr_cov[{"gpio_sticky_intr_pin",
-                                          $sformatf("%0d", each_bit)}].sample(1'b1);
-                    end else begin
-                      cov.sticky_intr_cov[{"gpio_sticky_intr_pin",
-                                          $sformatf("%0d", each_bit)}].sample(1'b0);
-                    end
+                    cov.sample_intr_pin(each_bit, last_intr_update_except_clearing[each_bit]);
                   end
                 end
               end
@@ -748,11 +742,7 @@ class ${module_instance_name}_scoreboard extends cip_base_scoreboard #(.CFG_T ($
         // Coverage Sampling: cover a scenario wherein cleared interrupt state bit
         // is re-asserted due to still active interrupt event
         if (cleared_intr_bits[each_bit]) begin
-          if (exp_intr_status[each_bit]) begin
-            cov.sticky_intr_cov[{"gpio_sticky_intr_pin", $sformatf("%0d", each_bit)}].sample(1'b1);
-          end else begin
-            cov.sticky_intr_cov[{"gpio_sticky_intr_pin", $sformatf("%0d", each_bit)}].sample(1'b0);
-          end
+          cov.sample_intr_pin(each_bit, exp_intr_status[each_bit]);
           // Clear the flag
           cleared_intr_bits[each_bit] = 1'b0;
         end

--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env_cov.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env_cov.sv.tpl
@@ -293,11 +293,11 @@ class otp_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(otp_ctrl_env_cfg));
   virtual function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     // Create instances from bit_toggle_cg_wrapper.
-    lc_prog_cg  = new("lc_prog_cg", "", 0);
-    otbn_req_cg = new("otbn_req_cg", "", 0);
+    lc_prog_cg  = new("lc_prog_cg", .toggle_cov_en(0));
+    otbn_req_cg = new("otbn_req_cg", .toggle_cov_en(0));
     foreach (status_csr_cg[i]) begin
       otp_status_e index = otp_status_e'(i);
-      status_csr_cg[i]= new(index.name, "status_csr_cg", 0);
+      status_csr_cg[i]= new({"status_csr_cg::", index.name}, .toggle_cov_en(0));
     end
 
     // Create instances from external wrapper classes.

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_env_cov.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_env_cov.sv
@@ -110,6 +110,7 @@ class gpio_env_cov extends cip_base_env_cov #(.CFG_T(gpio_env_cfg));
                                      "masked_oe_lower",
                                      "masked_out_upper",
                                      "masked_oe_upper"};
+      string pin_cov_name;
       foreach (intr_state_cov_obj[each_pin]) begin
         // Create coverage for each gpio pin values and transitions
         gpio_pin_values_cov_obj[each_pin] = new($sformatf("gpio_values_cov_obj_pin%0d", each_pin));
@@ -135,8 +136,8 @@ class gpio_env_cov extends cip_base_env_cov #(.CFG_T(gpio_env_cfg));
         data_in_cov_obj[each_pin] = new($sformatf("data_in_cov_obj_pin%0d", each_pin));
         // Create sticky interrupt coverage per pin
         // No toggle coverage is required in this case, so specify toggle_cov_en = 0
-        sticky_intr_cov[{"gpio_sticky_intr_pin", $sformatf("%0d", each_pin)}] =
-            new(.name({"gpio_sticky_intr_pin", $sformatf("%0d", each_pin)}), .toggle_cov_en(0));
+        pin_cov_name = intr_pin_cov_name(each_pin);
+        sticky_intr_cov[pin_cov_name] = new(.name(pin_cov_name), .toggle_cov_en(0));
       end
       // Per pin coverage and cross coverage for mask and data
       // fields within masked_* registers
@@ -152,5 +153,22 @@ class gpio_env_cov extends cip_base_env_cov #(.CFG_T(gpio_env_cfg));
       gpio_pins_data_in_cross_cg = new("gpio_pins_data_in_cross_cg");
     end
   endfunction : new
+
+  // Return the string used to name the object that will be used to track coverage for the interrupt
+  // pin for the given GPIO pin.
+  static local function string intr_pin_cov_name(int unsigned pin_idx);
+    return $sformatf("gpio_sticky_intr_pin%0d", pin_idx);
+  endfunction
+
+  // Return the bit_toggle_cg_wrap object that is used to track coverage for the interrupt pin for
+  // the given GPIO pin.
+  local function bit_toggle_cg_wrap intr_pin_cov(int unsigned pin_idx);
+    return sticky_intr_cov[intr_pin_cov_name(pin_idx)];
+  endfunction
+
+  // Sample the interrupt pin for the given GPIO pin.
+  function void sample_intr_pin(int unsigned pin_idx, logic value);
+    intr_pin_cov(pin_idx).sample(value);
+  endfunction
 
 endclass

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
@@ -163,13 +163,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
               if (cfg.en_cov) begin
                 foreach (cleared_intr_bits[each_bit]) begin
                   if (cleared_intr_bits[each_bit]) begin
-                    if (last_intr_update_except_clearing[each_bit]) begin
-                      cov.sticky_intr_cov[{"gpio_sticky_intr_pin",
-                                          $sformatf("%0d", each_bit)}].sample(1'b1);
-                    end else begin
-                      cov.sticky_intr_cov[{"gpio_sticky_intr_pin",
-                                          $sformatf("%0d", each_bit)}].sample(1'b0);
-                    end
+                    cov.sample_intr_pin(each_bit, last_intr_update_except_clearing[each_bit]);
                   end
                 end
               end
@@ -793,11 +787,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
         // Coverage Sampling: cover a scenario wherein cleared interrupt state bit
         // is re-asserted due to still active interrupt event
         if (cleared_intr_bits[each_bit]) begin
-          if (exp_intr_status[each_bit]) begin
-            cov.sticky_intr_cov[{"gpio_sticky_intr_pin", $sformatf("%0d", each_bit)}].sample(1'b1);
-          end else begin
-            cov.sticky_intr_cov[{"gpio_sticky_intr_pin", $sformatf("%0d", each_bit)}].sample(1'b0);
-          end
+          cov.sample_intr_pin(each_bit, exp_intr_status[each_bit]);
           // Clear the flag
           cleared_intr_bits[each_bit] = 1'b0;
         end

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_cov.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_cov.sv
@@ -335,11 +335,11 @@ class otp_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(otp_ctrl_env_cfg));
   virtual function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     // Create instances from bit_toggle_cg_wrapper.
-    lc_prog_cg  = new("lc_prog_cg", "", 0);
-    otbn_req_cg = new("otbn_req_cg", "", 0);
+    lc_prog_cg  = new("lc_prog_cg", .toggle_cov_en(0));
+    otbn_req_cg = new("otbn_req_cg", .toggle_cov_en(0));
     foreach (status_csr_cg[i]) begin
       otp_status_e index = otp_status_e'(i);
-      status_csr_cg[i]= new(index.name, "status_csr_cg", 0);
+      status_csr_cg[i]= new({"status_csr_cg::", index.name}, .toggle_cov_en(0));
     end
 
     // Create instances from external wrapper classes.

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_env_cov.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_env_cov.sv
@@ -110,6 +110,7 @@ class gpio_env_cov extends cip_base_env_cov #(.CFG_T(gpio_env_cfg));
                                      "masked_oe_lower",
                                      "masked_out_upper",
                                      "masked_oe_upper"};
+      string pin_cov_name;
       foreach (intr_state_cov_obj[each_pin]) begin
         // Create coverage for each gpio pin values and transitions
         gpio_pin_values_cov_obj[each_pin] = new($sformatf("gpio_values_cov_obj_pin%0d", each_pin));
@@ -135,8 +136,8 @@ class gpio_env_cov extends cip_base_env_cov #(.CFG_T(gpio_env_cfg));
         data_in_cov_obj[each_pin] = new($sformatf("data_in_cov_obj_pin%0d", each_pin));
         // Create sticky interrupt coverage per pin
         // No toggle coverage is required in this case, so specify toggle_cov_en = 0
-        sticky_intr_cov[{"gpio_sticky_intr_pin", $sformatf("%0d", each_pin)}] =
-            new(.name({"gpio_sticky_intr_pin", $sformatf("%0d", each_pin)}), .toggle_cov_en(0));
+        pin_cov_name = intr_pin_cov_name(each_pin);
+        sticky_intr_cov[pin_cov_name] = new(.name(pin_cov_name), .toggle_cov_en(0));
       end
       // Per pin coverage and cross coverage for mask and data
       // fields within masked_* registers
@@ -152,5 +153,22 @@ class gpio_env_cov extends cip_base_env_cov #(.CFG_T(gpio_env_cfg));
       gpio_pins_data_in_cross_cg = new("gpio_pins_data_in_cross_cg");
     end
   endfunction : new
+
+  // Return the string used to name the object that will be used to track coverage for the interrupt
+  // pin for the given GPIO pin.
+  static local function string intr_pin_cov_name(int unsigned pin_idx);
+    return $sformatf("gpio_sticky_intr_pin%0d", pin_idx);
+  endfunction
+
+  // Return the bit_toggle_cg_wrap object that is used to track coverage for the interrupt pin for
+  // the given GPIO pin.
+  local function bit_toggle_cg_wrap intr_pin_cov(int unsigned pin_idx);
+    return sticky_intr_cov[intr_pin_cov_name(pin_idx)];
+  endfunction
+
+  // Sample the interrupt pin for the given GPIO pin.
+  function void sample_intr_pin(int unsigned pin_idx, logic value);
+    intr_pin_cov(pin_idx).sample(value);
+  endfunction
 
 endclass

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
@@ -163,13 +163,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
               if (cfg.en_cov) begin
                 foreach (cleared_intr_bits[each_bit]) begin
                   if (cleared_intr_bits[each_bit]) begin
-                    if (last_intr_update_except_clearing[each_bit]) begin
-                      cov.sticky_intr_cov[{"gpio_sticky_intr_pin",
-                                          $sformatf("%0d", each_bit)}].sample(1'b1);
-                    end else begin
-                      cov.sticky_intr_cov[{"gpio_sticky_intr_pin",
-                                          $sformatf("%0d", each_bit)}].sample(1'b0);
-                    end
+                    cov.sample_intr_pin(each_bit, last_intr_update_except_clearing[each_bit]);
                   end
                 end
               end
@@ -737,11 +731,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
         // Coverage Sampling: cover a scenario wherein cleared interrupt state bit
         // is re-asserted due to still active interrupt event
         if (cleared_intr_bits[each_bit]) begin
-          if (exp_intr_status[each_bit]) begin
-            cov.sticky_intr_cov[{"gpio_sticky_intr_pin", $sformatf("%0d", each_bit)}].sample(1'b1);
-          end else begin
-            cov.sticky_intr_cov[{"gpio_sticky_intr_pin", $sformatf("%0d", each_bit)}].sample(1'b0);
-          end
+          cov.sample_intr_pin(each_bit, exp_intr_status[each_bit]);
           // Clear the flag
           cleared_intr_bits[each_bit] = 1'b0;
         end

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_cov.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_cov.sv
@@ -296,11 +296,11 @@ class otp_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(otp_ctrl_env_cfg));
   virtual function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     // Create instances from bit_toggle_cg_wrapper.
-    lc_prog_cg  = new("lc_prog_cg", "", 0);
-    otbn_req_cg = new("otbn_req_cg", "", 0);
+    lc_prog_cg  = new("lc_prog_cg", .toggle_cov_en(0));
+    otbn_req_cg = new("otbn_req_cg", .toggle_cov_en(0));
     foreach (status_csr_cg[i]) begin
       otp_status_e index = otp_status_e'(i);
-      status_csr_cg[i]= new(index.name, "status_csr_cg", 0);
+      status_csr_cg[i]= new({"status_csr_cg::", index.name}, .toggle_cov_en(0));
     end
 
     // Create instances from external wrapper classes.

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_env_cov.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_env_cov.sv
@@ -110,6 +110,7 @@ class gpio_env_cov extends cip_base_env_cov #(.CFG_T(gpio_env_cfg));
                                      "masked_oe_lower",
                                      "masked_out_upper",
                                      "masked_oe_upper"};
+      string pin_cov_name;
       foreach (intr_state_cov_obj[each_pin]) begin
         // Create coverage for each gpio pin values and transitions
         gpio_pin_values_cov_obj[each_pin] = new($sformatf("gpio_values_cov_obj_pin%0d", each_pin));
@@ -135,8 +136,8 @@ class gpio_env_cov extends cip_base_env_cov #(.CFG_T(gpio_env_cfg));
         data_in_cov_obj[each_pin] = new($sformatf("data_in_cov_obj_pin%0d", each_pin));
         // Create sticky interrupt coverage per pin
         // No toggle coverage is required in this case, so specify toggle_cov_en = 0
-        sticky_intr_cov[{"gpio_sticky_intr_pin", $sformatf("%0d", each_pin)}] =
-            new(.name({"gpio_sticky_intr_pin", $sformatf("%0d", each_pin)}), .toggle_cov_en(0));
+        pin_cov_name = intr_pin_cov_name(each_pin);
+        sticky_intr_cov[pin_cov_name] = new(.name(pin_cov_name), .toggle_cov_en(0));
       end
       // Per pin coverage and cross coverage for mask and data
       // fields within masked_* registers
@@ -152,5 +153,22 @@ class gpio_env_cov extends cip_base_env_cov #(.CFG_T(gpio_env_cfg));
       gpio_pins_data_in_cross_cg = new("gpio_pins_data_in_cross_cg");
     end
   endfunction : new
+
+  // Return the string used to name the object that will be used to track coverage for the interrupt
+  // pin for the given GPIO pin.
+  static local function string intr_pin_cov_name(int unsigned pin_idx);
+    return $sformatf("gpio_sticky_intr_pin%0d", pin_idx);
+  endfunction
+
+  // Return the bit_toggle_cg_wrap object that is used to track coverage for the interrupt pin for
+  // the given GPIO pin.
+  local function bit_toggle_cg_wrap intr_pin_cov(int unsigned pin_idx);
+    return sticky_intr_cov[intr_pin_cov_name(pin_idx)];
+  endfunction
+
+  // Sample the interrupt pin for the given GPIO pin.
+  function void sample_intr_pin(int unsigned pin_idx, logic value);
+    intr_pin_cov(pin_idx).sample(value);
+  endfunction
 
 endclass

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
@@ -163,13 +163,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
               if (cfg.en_cov) begin
                 foreach (cleared_intr_bits[each_bit]) begin
                   if (cleared_intr_bits[each_bit]) begin
-                    if (last_intr_update_except_clearing[each_bit]) begin
-                      cov.sticky_intr_cov[{"gpio_sticky_intr_pin",
-                                          $sformatf("%0d", each_bit)}].sample(1'b1);
-                    end else begin
-                      cov.sticky_intr_cov[{"gpio_sticky_intr_pin",
-                                          $sformatf("%0d", each_bit)}].sample(1'b0);
-                    end
+                    cov.sample_intr_pin(each_bit, last_intr_update_except_clearing[each_bit]);
                   end
                 end
               end
@@ -737,11 +731,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
         // Coverage Sampling: cover a scenario wherein cleared interrupt state bit
         // is re-asserted due to still active interrupt event
         if (cleared_intr_bits[each_bit]) begin
-          if (exp_intr_status[each_bit]) begin
-            cov.sticky_intr_cov[{"gpio_sticky_intr_pin", $sformatf("%0d", each_bit)}].sample(1'b1);
-          end else begin
-            cov.sticky_intr_cov[{"gpio_sticky_intr_pin", $sformatf("%0d", each_bit)}].sample(1'b0);
-          end
+          cov.sample_intr_pin(each_bit, exp_intr_status[each_bit]);
           // Clear the flag
           cleared_intr_bits[each_bit] = 1'b0;
         end


### PR DESCRIPTION
This was initially prompted by me wondering whether we could avoid defining two different classes in `dv_base_env_cov.sv`. We can, but splitting the `bit_toggle_cg_wrap` class into its own file and documenting the class meant that I realised we were instantiating it in a more complicated way than necessary. This PR tidies that up as well.