### PR TITLE
[dv] Use the correct UVM macro in kmac_app_sequencer

### DIFF
--- a/hw/dv/sv/kmac_app_agent/kmac_app_sequencer.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_sequencer.sv
@@ -6,10 +6,11 @@ class kmac_app_sequencer extends dv_base_sequencer #(
     .ITEM_T (kmac_app_item),
     .CFG_T  (kmac_app_agent_cfg)
 );
-  `uvm_component_param_utils(kmac_app_sequencer)
+  `uvm_component_utils(kmac_app_sequencer)
 
   push_pull_sequencer#(`CONNECT_DATA_WIDTH) m_push_pull_sequencer;
 
-  `uvm_component_new
-
+  function new (string name, uvm_component parent);
+    super.new(name, parent);
+  endfunction
 endclass


### PR DESCRIPTION
No functional change, but this silences a lint warning (caused by the fact that kmac_app_sequencer isn't a parameterised class).