### PR TITLE
[dv] Use correct uvm_object_utils macro for mubi32_cov

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_mubi_cov.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_mubi_cov.sv
@@ -35,7 +35,7 @@ endclass : mubi_cov
 // enormous number of bins. Setting an explicit width here works around the problem. Fix this up
 // properly if we change tool version.
 class mubi32_cov extends uvm_object;
-  `uvm_object_param_utils(mubi32_cov)
+  `uvm_object_utils(mubi32_cov)
 
   // Collect true, false and at least N other values (N = 32)
   covergroup mubi_cg(string name) with function sample(bit [32-1:0] value);


### PR DESCRIPTION
This class isn't parameterised, so doesn't need
uvm_object_param_utils.