### PR TITLE
[dv] Avoid passing default name to uvm_component constructors

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent.sv
@@ -15,7 +15,7 @@ class alert_esc_agent extends dv_base_agent#(
 
   `uvm_component_utils(alert_esc_agent)
 
-  extern function new (string name="", uvm_component parent=null);
+  extern function new (string name, uvm_component parent);
   extern function void build_phase(uvm_phase phase);
   // Create automatic response (from monitor) to ping and alert requests.
   extern function void connect_phase(uvm_phase phase);
@@ -23,7 +23,7 @@ class alert_esc_agent extends dv_base_agent#(
 
 endclass : alert_esc_agent
 
-function alert_esc_agent::new (string name="", uvm_component parent=null);
+function alert_esc_agent::new (string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
 

--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_cov.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_cov.sv
@@ -56,12 +56,12 @@ class alert_esc_agent_cov extends dv_base_agent_cov #(alert_esc_agent_cfg);
 
   `uvm_component_utils(alert_esc_agent_cov)
 
-  extern function new (string name="", uvm_component parent=null);
+  extern function new (string name, uvm_component parent);
   extern function void build_phase(uvm_phase phase);
 
 endclass : alert_esc_agent_cov
 
-function alert_esc_agent_cov::new (string name="", uvm_component parent=null);
+function alert_esc_agent_cov::new (string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
 

--- a/hw/dv/sv/alert_esc_agent/alert_esc_base_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_base_driver.sv
@@ -12,7 +12,7 @@ class alert_esc_base_driver extends dv_base_driver#(alert_esc_seq_item, alert_es
 
   `uvm_component_utils(alert_esc_base_driver)
 
-  extern function new (string name="", uvm_component parent=null);
+  extern function new (string name, uvm_component parent);
   // drive trans received from sequencer
   extern virtual task get_and_drive();
   extern virtual task drive_req();
@@ -20,7 +20,7 @@ class alert_esc_base_driver extends dv_base_driver#(alert_esc_seq_item, alert_es
 
 endclass : alert_esc_base_driver
 
-function alert_esc_base_driver::new (string name="", uvm_component parent=null);
+function alert_esc_base_driver::new (string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
 

--- a/hw/dv/sv/alert_esc_agent/alert_esc_base_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_base_monitor.sv
@@ -18,7 +18,7 @@ class alert_esc_base_monitor extends dv_base_monitor #(
 
   bit under_reset;
 
-  extern function new (string name="", uvm_component parent=null);
+  extern function new (string name, uvm_component parent);
   extern function void build_phase(uvm_phase phase);
   extern virtual task run_phase(uvm_phase phase);
   extern virtual task wait_for_reset_done();
@@ -28,7 +28,7 @@ class alert_esc_base_monitor extends dv_base_monitor #(
 
 endclass : alert_esc_base_monitor
 
-function alert_esc_base_monitor::new (string name="", uvm_component parent=null);
+function alert_esc_base_monitor::new (string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
 

--- a/hw/dv/sv/alert_esc_agent/alert_esc_sequencer.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_sequencer.sv
@@ -5,10 +5,10 @@
 class alert_esc_sequencer extends dv_base_sequencer#(alert_esc_seq_item, alert_esc_agent_cfg);
   `uvm_component_utils(alert_esc_sequencer)
 
-  extern function new (string name="", uvm_component parent=null);
+  extern function new (string name, uvm_component parent);
 
 endclass : alert_esc_sequencer
 
-function alert_esc_sequencer::new (string name="", uvm_component parent=null);
+function alert_esc_sequencer::new (string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new

--- a/hw/dv/sv/alert_esc_agent/alert_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_monitor.sv
@@ -15,7 +15,7 @@ class alert_monitor extends alert_esc_base_monitor;
   // This flag is updated in the task `monitor_alert` when an alert is detected.
   bit active_alert = 1'b0;
 
-  extern function new (string name="", uvm_component parent=null);
+  extern function new (string name, uvm_component parent);
   extern virtual task run_phase(uvm_phase phase);
   // Monitors the alert interface and sets 'active_alert' when an alert is observed
   extern virtual task monitor_alerts();
@@ -51,7 +51,7 @@ class alert_monitor extends alert_esc_base_monitor;
 
 endclass : alert_monitor
 
-function alert_monitor::new (string name="", uvm_component parent=null);
+function alert_monitor::new (string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
 

--- a/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
@@ -9,7 +9,7 @@ class alert_receiver_driver extends alert_esc_base_driver;
 
   bit working_on_alert;
 
-  extern function new(string name="", uvm_component parent=null);
+  extern function new(string name, uvm_component parent);
 
   extern task drive_req();
   extern task reset_signals();
@@ -73,7 +73,7 @@ class alert_receiver_driver extends alert_esc_base_driver;
 
 endclass : alert_receiver_driver
 
-function alert_receiver_driver::new(string name="", uvm_component parent=null);
+function alert_receiver_driver::new(string name, uvm_component parent);
   super.new(name, parent);
 endfunction
 

--- a/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
@@ -13,7 +13,7 @@ class alert_sender_driver extends alert_esc_base_driver;
   // To guard alert ping response and real alert triggers won't trigger at the same time
   local semaphore alert_atomic = new(1);
 
-  extern function new (string name="", uvm_component parent=null);
+  extern function new (string name, uvm_component parent);
   extern virtual task reset_signals();
   // alert_sender drive responses by sending the alert_p and alert_n
   // one alert sent by sequence driving the alert_send signal
@@ -45,7 +45,7 @@ class alert_sender_driver extends alert_esc_base_driver;
 
 endclass : alert_sender_driver
 
-function alert_sender_driver::new (string name="", uvm_component parent=null);
+function alert_sender_driver::new (string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
 

--- a/hw/dv/sv/alert_esc_agent/esc_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_monitor.sv
@@ -11,7 +11,7 @@ class esc_monitor extends alert_esc_base_monitor;
 
   `uvm_component_utils(esc_monitor)
 
-  extern function new (string name="", uvm_component parent=null);
+  extern function new (string name, uvm_component parent);
   extern virtual task run_phase(uvm_phase phase);
   extern virtual task esc_thread();
   extern virtual task unexpected_resp_thread();
@@ -36,7 +36,7 @@ class esc_monitor extends alert_esc_base_monitor;
 
 endclass : esc_monitor
 
-function esc_monitor::new (string name="", uvm_component parent=null);
+function esc_monitor::new (string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
 

--- a/hw/dv/sv/alert_esc_agent/esc_receiver_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_receiver_driver.sv
@@ -15,7 +15,7 @@ class esc_receiver_driver extends alert_esc_base_driver;
   // receives a genuine escalation).
   bit is_ping;
 
-  extern function new (string name="", uvm_component parent=null);
+  extern function new (string name, uvm_component parent);
 
   // This task runs forever and maintains dv_base_driver::under_reset.
   //
@@ -61,7 +61,7 @@ class esc_receiver_driver extends alert_esc_base_driver;
 
 endclass : esc_receiver_driver
 
-function esc_receiver_driver::new (string name="", uvm_component parent=null);
+function esc_receiver_driver::new (string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
 

--- a/hw/dv/sv/alert_esc_agent/esc_sender_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_sender_driver.sv
@@ -11,7 +11,7 @@ class esc_sender_driver extends alert_esc_base_driver;
   `uvm_component_utils(esc_sender_driver)
 
 
-  extern function new (string name="", uvm_component parent=null);
+  extern function new (string name, uvm_component parent);
   extern virtual task reset_signals();
   extern virtual task get_and_drive();
   extern virtual task drive_esc();
@@ -19,7 +19,7 @@ class esc_sender_driver extends alert_esc_base_driver;
 
 endclass : esc_sender_driver
 
-function esc_sender_driver::new (string name="", uvm_component parent=null);
+function esc_sender_driver::new (string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
 

--- a/hw/dv/sv/dv_lib/dv_base_virtual_sequencer.sv
+++ b/hw/dv/sv/dv_lib/dv_base_virtual_sequencer.sv
@@ -9,7 +9,7 @@ class dv_base_virtual_sequencer #(type CFG_T = dv_base_env_cfg,
   CFG_T         cfg;
   COV_T         cov;
 
-  function new(string name = "", uvm_component parent);
+  function new(string name, uvm_component parent);
     super.new(name, parent);
   endfunction
 

--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -61,7 +61,7 @@
 
 `ifndef uvm_component_new
   `define uvm_component_new \
-    function new (string name="", uvm_component parent=null); \
+    function new (string name, uvm_component parent); \
       super.new(name, parent); \
     endfunction : new
 `endif

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_driver.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_driver.sv
@@ -8,7 +8,7 @@ class jtag_riscv_driver extends dv_base_driver #(jtag_riscv_item, jtag_riscv_age
 
   `uvm_component_utils(jtag_riscv_driver)
 
-  function new (string name="", uvm_component parent=null);
+  function new (string name, uvm_component parent);
     super.new(name, parent);
   endfunction
 

--- a/hw/dv/sv/pwm_monitor/pwm_monitor.sv
+++ b/hw/dv/sv/pwm_monitor/pwm_monitor.sv
@@ -30,7 +30,7 @@ class pwm_monitor extends dv_base_monitor #(
   // Have we received valid configuration and are we monitoring the PWM output?
   bit monitoring = 1'b0;
 
-  extern function new(string name = "", uvm_component parent = null);
+  extern function new(string name, uvm_component parent = null);
   extern function void build_phase(uvm_phase phase);
 
   // One or more of the phase counter configuration parameters has been changed; ensure that our
@@ -46,7 +46,7 @@ class pwm_monitor extends dv_base_monitor #(
   extern task monitor_ready_to_end();
 endclass
 
-function pwm_monitor::new(string name = "", uvm_component parent = null);
+function pwm_monitor::new(string name, uvm_component parent = null);
   super.new(name, parent);
 endfunction
 

--- a/hw/dv/sv/tl_agent/tl_host_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_host_driver.sv
@@ -14,7 +14,7 @@ class tl_host_driver extends tl_base_driver;
   // reset_signals task.
   protected bit reset_asserted;
 
-  extern function new (string name="", uvm_component parent=null);
+  extern function new (string name, uvm_component parent);
 
   // Drive items received from the sequencer. This implements a task declared in dv_base_driver.
   extern task get_and_drive();
@@ -87,7 +87,7 @@ class tl_host_driver extends tl_base_driver;
   extern protected function void invalidate_a_channel();
 endclass : tl_host_driver
 
-function tl_host_driver::new (string name="", uvm_component parent=null);
+function tl_host_driver::new (string name, uvm_component parent);
   super.new(name, parent);
 endfunction
 

--- a/hw/ip/aon_timer/dv/env/aon_timer_env.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_env.sv
@@ -10,12 +10,12 @@ class aon_timer_env extends cip_base_env #(
   );
   `uvm_component_utils(aon_timer_env)
 
-  extern function new (string name="", uvm_component parent=null);
+  extern function new (string name, uvm_component parent);
   extern function void build_phase(uvm_phase phase);
 
 endclass : aon_timer_env
 
-function aon_timer_env::new (string name="", uvm_component parent=null);
+function aon_timer_env::new (string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
 

--- a/hw/ip/aon_timer/dv/env/aon_timer_scoreboard.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_scoreboard.sv
@@ -77,7 +77,7 @@ class aon_timer_scoreboard extends cip_base_scoreboard #(
   int unsigned aon_clk_cycle = 0;
   int unsigned last_wkup_cause_write_aon_clk_cycle = 0;
 
-  extern function new (string name="", uvm_component parent=null);
+  extern function new (string name, uvm_component parent);
   extern function void build_phase(uvm_phase phase);
   extern task run_phase(uvm_phase phase);
   extern function void check_phase(uvm_phase phase);
@@ -201,7 +201,7 @@ class aon_timer_scoreboard extends cip_base_scoreboard #(
 
 endclass : aon_timer_scoreboard
 
-function aon_timer_scoreboard::new (string name="", uvm_component parent=null);
+function aon_timer_scoreboard::new (string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
 

--- a/hw/ip/aon_timer/dv/env/aon_timer_virtual_sequencer.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_virtual_sequencer.sv
@@ -8,10 +8,10 @@ class aon_timer_virtual_sequencer extends cip_base_virtual_sequencer #(
   );
   `uvm_component_utils(aon_timer_virtual_sequencer)
 
-  extern function new (string name = "", uvm_component parent=null);
+  extern function new (string name, uvm_component parent);
 
 endclass
 
-function aon_timer_virtual_sequencer::new (string name="", uvm_component parent=null);
+function aon_timer_virtual_sequencer::new (string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new

--- a/hw/ip/hmac/dv/env/hmac_env.sv
+++ b/hw/ip/hmac/dv/env/hmac_env.sv
@@ -9,13 +9,13 @@ class hmac_env extends cip_base_env #(.CFG_T               (hmac_env_cfg),
   `uvm_component_utils(hmac_env)
 
   // Standard SV/UVM methods
-  extern function new(string name="", uvm_component parent=null);
+  extern function new(string name, uvm_component parent);
   extern function void build_phase(uvm_phase phase);
   extern function void end_of_elaboration_phase(uvm_phase phase);
 endclass : hmac_env
 
 
-function hmac_env::new(string name="", uvm_component parent=null);
+function hmac_env::new(string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
 

--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -36,7 +36,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
   bit             hmac_done_seen;
 
   // Standard SV/UVM methods
-  extern function new(string name="", uvm_component parent=null);
+  extern function new(string name, uvm_component parent);
   extern function void build_phase(uvm_phase phase);
   extern task run_phase(uvm_phase phase);
   extern function void check_phase(uvm_phase phase);
@@ -75,7 +75,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
 endclass : hmac_scoreboard
 
 
-function hmac_scoreboard::new(string name="", uvm_component parent=null);
+function hmac_scoreboard::new(string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
 

--- a/hw/ip/hmac/dv/tests/hmac_base_test.sv
+++ b/hw/ip/hmac/dv/tests/hmac_base_test.sv
@@ -7,12 +7,12 @@ class hmac_base_test extends cip_base_test #(.ENV_T(hmac_env),
   `uvm_component_utils(hmac_base_test)
 
   // Standard SV/UVM methods
-  extern function new(string name="", uvm_component parent=null);
+  extern function new(string name, uvm_component parent);
   extern function void build_phase(uvm_phase phase);
 endclass : hmac_base_test
 
 
-function hmac_base_test::new(string name="", uvm_component parent=null);
+function hmac_base_test::new(string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
 

--- a/hw/ip/pattgen/dv/env/pattgen_scoreboard.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_scoreboard.sv
@@ -21,7 +21,7 @@ class pattgen_scoreboard extends cip_base_scoreboard #(.CFG_T(pattgen_env_cfg),
   // configuration registers.
   local pattgen_channel_cfg channel_cfg[NUM_PATTGEN_CHANNELS-1:0];
 
-  extern function new (string name="", uvm_component parent=null);
+  extern function new (string name, uvm_component parent);
 
   extern function void build_phase(uvm_phase phase);
   extern task run_phase(uvm_phase phase);
@@ -47,7 +47,7 @@ class pattgen_scoreboard extends cip_base_scoreboard #(.CFG_T(pattgen_env_cfg),
   extern function void reset(string kind = "HARD");
 endclass
 
-function pattgen_scoreboard::new (string name="", uvm_component parent=null);
+function pattgen_scoreboard::new (string name, uvm_component parent);
   super.new(name, parent);
 endfunction
 

--- a/hw/ip/racl_ctrl/dv/env/racl_ctrl_env.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_ctrl_env.sv
@@ -12,12 +12,12 @@ class racl_ctrl_env extends cip_base_env #(.CFG_T              (racl_ctrl_env_cf
   racl_error_log_agent internal_error_agent;
   racl_error_log_agent external_error_agent;
 
-  extern function new (string name="", uvm_component parent=null);
+  extern function new (string name, uvm_component parent);
   extern function void build_phase(uvm_phase phase);
   extern function void connect_phase(uvm_phase phase);
 endclass
 
-function racl_ctrl_env::new (string name="", uvm_component parent=null);
+function racl_ctrl_env::new (string name, uvm_component parent);
   super.new(name, parent);
 endfunction
 

--- a/hw/ip/racl_ctrl/dv/env/racl_ctrl_error_arb_predictor.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_ctrl_error_arb_predictor.sv
@@ -21,7 +21,7 @@ class racl_ctrl_error_arb_predictor extends uvm_component;
   // An output with merged errors
   error_fifo_t merged_errors_fifo;
 
-  extern function new(string name="", uvm_component parent=null);
+  extern function new(string name, uvm_component parent);
   extern function void build_phase(uvm_phase phase);
   extern task run_phase(uvm_phase phase);
 
@@ -36,7 +36,7 @@ class racl_ctrl_error_arb_predictor extends uvm_component;
   extern local function racl_error_log_vec_item flush_vec_fifo(error_vec_fifo_t fifo);
 endclass
 
-function racl_ctrl_error_arb_predictor::new(string name="", uvm_component parent=null);
+function racl_ctrl_error_arb_predictor::new(string name, uvm_component parent);
   super.new(name, parent);
 endfunction
 

--- a/hw/ip/racl_ctrl/dv/env/racl_ctrl_scoreboard.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_ctrl_scoreboard.sv
@@ -10,7 +10,7 @@ class racl_ctrl_scoreboard extends cip_base_scoreboard #(.CFG_T(racl_ctrl_env_cf
   uvm_analysis_export #(racl_error_log_vec_item) internal_errors_export;
   uvm_analysis_export #(racl_error_log_vec_item) external_errors_export;
 
-  extern function new (string name="", uvm_component parent=null);
+  extern function new (string name, uvm_component parent);
 
   extern function void build_phase(uvm_phase phase);
   extern function void connect_phase(uvm_phase phase);
@@ -131,7 +131,7 @@ class racl_ctrl_scoreboard extends cip_base_scoreboard #(.CFG_T(racl_ctrl_env_cf
   local tl_seq_item pending_csr_write;
 endclass
 
-function racl_ctrl_scoreboard::new (string name="", uvm_component parent=null);
+function racl_ctrl_scoreboard::new (string name, uvm_component parent);
   super.new(name, parent);
   check_interrupt_ev = new();
   error_log_pred_changed_ev = new();

--- a/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_agent.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_agent.sv
@@ -11,13 +11,13 @@ class racl_error_log_agent extends dv_base_agent#(.CFG_T      (racl_error_log_ag
   // An analysis export that exposes error log vector items that have been captured by the monitor
   uvm_analysis_export#(racl_error_log_vec_item) errors_seen;
 
-  extern function new (string name="", uvm_component parent=null);
+  extern function new (string name, uvm_component parent);
   extern function void build_phase(uvm_phase phase);
   extern function void connect_phase(uvm_phase phase);
   extern task run_phase(uvm_phase phase);
 endclass
 
-function racl_error_log_agent::new (string name="", uvm_component parent=null);
+function racl_error_log_agent::new (string name, uvm_component parent);
   super.new(name, parent);
   errors_seen = new("errors_seen", this);
 endfunction

--- a/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_driver.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_driver.sv
@@ -12,7 +12,7 @@ class racl_error_log_driver extends dv_base_driver #(.ITEM_T (racl_error_log_vec
   // The interface that gets driven. This is set up by the agent in the build phase.
   virtual racl_error_log_if vif;
 
-  extern function new (string name="", uvm_component parent=null);
+  extern function new (string name, uvm_component parent);
 
   // Drive items received from the sequencer. This runs forever implementing a task declared in
   // dv_base_driver.
@@ -44,7 +44,7 @@ class racl_error_log_driver extends dv_base_driver #(.ITEM_T (racl_error_log_vec
   extern local task set_line(int unsigned i, racl_error_log_item item);
 endclass
 
-function racl_error_log_driver::new (string name="", uvm_component parent=null);
+function racl_error_log_driver::new (string name, uvm_component parent);
   super.new(name, parent);
 endfunction
 

--- a/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_sequencer.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_sequencer.sv
@@ -6,9 +6,9 @@ class racl_error_log_sequencer extends dv_base_sequencer#(.ITEM_T (racl_error_lo
                                                           .CFG_T  (racl_error_log_agent_cfg));
   `uvm_component_utils(racl_error_log_sequencer)
 
-  extern function new (string name="", uvm_component parent=null);
+  extern function new (string name, uvm_component parent);
 endclass
 
-function racl_error_log_sequencer::new(string name="", uvm_component parent=null);
+function racl_error_log_sequencer::new(string name, uvm_component parent);
   super.new(name, parent);
 endfunction

--- a/hw/ip/racl_ctrl/dv/tests/racl_ctrl_base_test.sv
+++ b/hw/ip/racl_ctrl/dv/tests/racl_ctrl_base_test.sv
@@ -7,7 +7,7 @@ class racl_ctrl_base_test extends cip_base_test #(.CFG_T(racl_ctrl_env_cfg),
 
   `uvm_component_utils(racl_ctrl_base_test)
 
-  extern function new (string name="", uvm_component parent=null);
+  extern function new (string name, uvm_component parent);
   extern function void build_phase(uvm_phase phase);
 
   // Configure the given sequence, installing sequencers for the error log agents. This test can
@@ -17,7 +17,7 @@ class racl_ctrl_base_test extends cip_base_test #(.CFG_T(racl_ctrl_env_cfg),
   extern function void configure_sequence(uvm_sequence seq);
 endclass
 
-function racl_ctrl_base_test::new (string name="", uvm_component parent=null);
+function racl_ctrl_base_test::new (string name, uvm_component parent);
   super.new(name, parent);
 endfunction
 

--- a/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_env.sv
+++ b/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_env.sv
@@ -13,13 +13,13 @@ class soc_dbg_ctrl_env extends cip_base_env #(
   tl_agent tl_jtag_agt;
 
   // Standard SV/UVM methods
-  extern function new(string name="", uvm_component parent=null);
+  extern function new(string name, uvm_component parent);
   extern function void build_phase(uvm_phase phase);
   extern function void connect_phase(uvm_phase phase);
 endclass : soc_dbg_ctrl_env
 
 
-function soc_dbg_ctrl_env::new(string name="", uvm_component parent=null);
+function soc_dbg_ctrl_env::new(string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
 

--- a/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_scoreboard.sv
+++ b/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_scoreboard.sv
@@ -12,7 +12,7 @@ class soc_dbg_ctrl_scoreboard extends cip_base_scoreboard #(
   // Local variables
 
   // Standard SV/UVM methods
-  extern function new(string name="", uvm_component parent=null);
+  extern function new(string name, uvm_component parent);
   extern function void build_phase(uvm_phase phase);
   extern function void connect_phase(uvm_phase phase);
   extern task run_phase(uvm_phase phase);
@@ -28,7 +28,7 @@ class soc_dbg_ctrl_scoreboard extends cip_base_scoreboard #(
 endclass : soc_dbg_ctrl_scoreboard
 
 
-function soc_dbg_ctrl_scoreboard::new(string name="", uvm_component parent=null);
+function soc_dbg_ctrl_scoreboard::new(string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
 

--- a/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_virtual_sequencer.sv
+++ b/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_virtual_sequencer.sv
@@ -9,10 +9,10 @@ class soc_dbg_ctrl_virtual_sequencer extends cip_base_virtual_sequencer #(
   `uvm_component_utils(soc_dbg_ctrl_virtual_sequencer)
 
   // Standard SV/UVM methods
-  extern function new(string name="", uvm_component parent=null);
+  extern function new(string name, uvm_component parent);
 endclass : soc_dbg_ctrl_virtual_sequencer
 
 
-function soc_dbg_ctrl_virtual_sequencer::new(string name="", uvm_component parent=null);
+function soc_dbg_ctrl_virtual_sequencer::new(string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new

--- a/hw/ip/soc_dbg_ctrl/dv/tests/soc_dbg_ctrl_base_test.sv
+++ b/hw/ip/soc_dbg_ctrl/dv/tests/soc_dbg_ctrl_base_test.sv
@@ -17,10 +17,10 @@ class soc_dbg_ctrl_base_test extends cip_base_test #(
   // As such, nothing more needs to be done
 
   // Standard SV/UVM methods
-  extern function new(string name="", uvm_component parent=null);
+  extern function new(string name, uvm_component parent);
 endclass : soc_dbg_ctrl_base_test
 
 
-function soc_dbg_ctrl_base_test::new(string name="", uvm_component parent=null);
+function soc_dbg_ctrl_base_test::new(string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new

--- a/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
@@ -83,7 +83,7 @@ class usbdev_scoreboard extends cip_base_scoreboard #(
 
     super.build_phase(phase);
     // Bus Functional Model of USBDEV.
-    bfm = new();
+    bfm = usbdev_bfm::type_id::create("bfm", this);
     // Prediction and checking of loosely-timed registers.
     timed_regs = new("timed_regs");
     timed_regs.clk_rst_vif = cfg.clk_rst_vif;

--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env.sv.tpl
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env.sv.tpl
@@ -14,13 +14,13 @@ class ${module_instance_name}_env extends cip_base_env #(
   tl_agent tl_filt_agt;
 
   // Standard SV/UVM methods
-  extern function new(string name="", uvm_component parent=null);
+  extern function new(string name, uvm_component parent);
   extern function void build_phase(uvm_phase phase);
   extern function void connect_phase(uvm_phase phase);
 endclass : ${module_instance_name}_env
 
 
-function ${module_instance_name}_env::new(string name="", uvm_component parent=null);
+function ${module_instance_name}_env::new(string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
 

--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_predictor.sv.tpl
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_predictor.sv.tpl
@@ -39,7 +39,7 @@ class ${module_instance_name}_predictor extends uvm_component;
   uvm_blocking_put_port #(ac_range_check_scb_item) tl_unfilt_put;
 
   // Standard SV/UVM methods
-  extern function new(string name="", uvm_component parent=null);
+  extern function new(string name, uvm_component parent);
   extern function void build_phase(uvm_phase phase);
   extern function void check_phase(uvm_phase phase);
 
@@ -55,7 +55,7 @@ class ${module_instance_name}_predictor extends uvm_component;
 endclass : ${module_instance_name}_predictor
 
 
-function ${module_instance_name}_predictor::new(string name="", uvm_component parent=null);
+function ${module_instance_name}_predictor::new(string name, uvm_component parent);
   super.new(name, parent);
   dut_cfg = ac_range_check_dut_cfg::type_id::create("dut_cfg");
   bypass_sampled = 0;

--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_scoreboard.sv.tpl
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_scoreboard.sv.tpl
@@ -34,7 +34,7 @@ class ${module_instance_name}_scoreboard extends cip_base_scoreboard #(
   uvm_blocking_put_imp_unfilt #(ac_range_check_scb_item, ${module_instance_name}_scoreboard) tl_unfilt_imp;
 
   // Standard SV/UVM methods
-  extern function new(string name="", uvm_component parent=null);
+  extern function new(string name, uvm_component parent);
   extern function void build_phase(uvm_phase phase);
   extern function void connect_phase(uvm_phase phase);
   extern task run_phase(uvm_phase phase);
@@ -55,7 +55,7 @@ class ${module_instance_name}_scoreboard extends cip_base_scoreboard #(
 endclass : ${module_instance_name}_scoreboard
 
 
-function ${module_instance_name}_scoreboard::new(string name="", uvm_component parent=null);
+function ${module_instance_name}_scoreboard::new(string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
 

--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_virtual_sequencer.sv.tpl
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_virtual_sequencer.sv.tpl
@@ -12,9 +12,9 @@ class ${module_instance_name}_virtual_sequencer extends cip_base_virtual_sequenc
   tl_sequencer tl_filt_sqr;
 
   // Standard SV/UVM methods
-  extern function new(string name="", uvm_component parent=null);
+  extern function new(string name, uvm_component parent);
 endclass : ${module_instance_name}_virtual_sequencer
 
-function ${module_instance_name}_virtual_sequencer::new(string name="", uvm_component parent=null);
+function ${module_instance_name}_virtual_sequencer::new(string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new

--- a/hw/ip_templates/ac_range_check/dv/tests/ac_range_check_base_test.sv.tpl
+++ b/hw/ip_templates/ac_range_check/dv/tests/ac_range_check_base_test.sv.tpl
@@ -17,12 +17,12 @@ class ${module_instance_name}_base_test extends cip_base_test #(
   // As such, nothing more needs to be done
 
   // Standard SV/UVM methods
-  extern function new(string name="", uvm_component parent=null);
+  extern function new(string name, uvm_component parent);
   extern function void build_phase(uvm_phase phase);
 endclass : ${module_instance_name}_base_test
 
 
-function ${module_instance_name}_base_test::new(string name="", uvm_component parent=null);
+function ${module_instance_name}_base_test::new(string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
 

--- a/hw/ip_templates/gpio/dv/env/gpio_scoreboard.sv.tpl
+++ b/hw/ip_templates/gpio/dv/env/gpio_scoreboard.sv.tpl
@@ -42,7 +42,7 @@ class ${module_instance_name}_scoreboard extends cip_base_scoreboard #(.CFG_T ($
 
   `uvm_component_utils(${module_instance_name}_scoreboard)
 
-  function new (string name = "${module_instance_name}_scoreboard", uvm_component parent = null);
+  function new (string name, uvm_component parent = null);
     super.new (name, parent);
   endfunction
 

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env.sv
@@ -14,13 +14,13 @@ class ac_range_check_env extends cip_base_env #(
   tl_agent tl_filt_agt;
 
   // Standard SV/UVM methods
-  extern function new(string name="", uvm_component parent=null);
+  extern function new(string name, uvm_component parent);
   extern function void build_phase(uvm_phase phase);
   extern function void connect_phase(uvm_phase phase);
 endclass : ac_range_check_env
 
 
-function ac_range_check_env::new(string name="", uvm_component parent=null);
+function ac_range_check_env::new(string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
 

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_predictor.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_predictor.sv
@@ -39,7 +39,7 @@ class ac_range_check_predictor extends uvm_component;
   uvm_blocking_put_port #(ac_range_check_scb_item) tl_unfilt_put;
 
   // Standard SV/UVM methods
-  extern function new(string name="", uvm_component parent=null);
+  extern function new(string name, uvm_component parent);
   extern function void build_phase(uvm_phase phase);
   extern function void check_phase(uvm_phase phase);
 
@@ -55,7 +55,7 @@ class ac_range_check_predictor extends uvm_component;
 endclass : ac_range_check_predictor
 
 
-function ac_range_check_predictor::new(string name="", uvm_component parent=null);
+function ac_range_check_predictor::new(string name, uvm_component parent);
   super.new(name, parent);
   dut_cfg = ac_range_check_dut_cfg::type_id::create("dut_cfg");
   bypass_sampled = 0;

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_scoreboard.sv
@@ -34,7 +34,7 @@ class ac_range_check_scoreboard extends cip_base_scoreboard #(
   uvm_blocking_put_imp_unfilt #(ac_range_check_scb_item, ac_range_check_scoreboard) tl_unfilt_imp;
 
   // Standard SV/UVM methods
-  extern function new(string name="", uvm_component parent=null);
+  extern function new(string name, uvm_component parent);
   extern function void build_phase(uvm_phase phase);
   extern function void connect_phase(uvm_phase phase);
   extern task run_phase(uvm_phase phase);
@@ -55,7 +55,7 @@ class ac_range_check_scoreboard extends cip_base_scoreboard #(
 endclass : ac_range_check_scoreboard
 
 
-function ac_range_check_scoreboard::new(string name="", uvm_component parent=null);
+function ac_range_check_scoreboard::new(string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
 

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_virtual_sequencer.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_virtual_sequencer.sv
@@ -12,9 +12,9 @@ class ac_range_check_virtual_sequencer extends cip_base_virtual_sequencer #(
   tl_sequencer tl_filt_sqr;
 
   // Standard SV/UVM methods
-  extern function new(string name="", uvm_component parent=null);
+  extern function new(string name, uvm_component parent);
 endclass : ac_range_check_virtual_sequencer
 
-function ac_range_check_virtual_sequencer::new(string name="", uvm_component parent=null);
+function ac_range_check_virtual_sequencer::new(string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/tests/ac_range_check_base_test.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/tests/ac_range_check_base_test.sv
@@ -17,12 +17,12 @@ class ac_range_check_base_test extends cip_base_test #(
   // As such, nothing more needs to be done
 
   // Standard SV/UVM methods
-  extern function new(string name="", uvm_component parent=null);
+  extern function new(string name, uvm_component parent);
   extern function void build_phase(uvm_phase phase);
 endclass : ac_range_check_base_test
 
 
-function ac_range_check_base_test::new(string name="", uvm_component parent=null);
+function ac_range_check_base_test::new(string name, uvm_component parent);
   super.new(name, parent);
 endfunction : new
 

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
@@ -42,7 +42,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
 
   `uvm_component_utils(gpio_scoreboard)
 
-  function new (string name = "gpio_scoreboard", uvm_component parent = null);
+  function new (string name, uvm_component parent = null);
     super.new (name, parent);
   endfunction
 

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
@@ -42,7 +42,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
 
   `uvm_component_utils(gpio_scoreboard)
 
-  function new (string name = "gpio_scoreboard", uvm_component parent = null);
+  function new (string name, uvm_component parent = null);
     super.new (name, parent);
   endfunction
 

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
@@ -42,7 +42,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
 
   `uvm_component_utils(gpio_scoreboard)
 
-  function new (string name = "gpio_scoreboard", uvm_component parent = null);
+  function new (string name, uvm_component parent = null);
     super.new (name, parent);
   endfunction
 


### PR DESCRIPTION
This is frowned upon, because the default name (often ""!) ends up as part of the hierarchical name of the child components. Fix the various hand-written instances and fix the `uvm_component macro (which was doing it wrong).