### PR TITLE
Upload Nightly FPGA Test Results to GCloud Bucket

### DIFF
--- a/.github/actions/publish-bazel-test-results/action.yml
+++ b/.github/actions/publish-bazel-test-results/action.yml
@@ -7,14 +7,20 @@ description: Merge Bazel test results and publish the report
 
 inputs:
   merged-results:
-    description: Path to place merged JUnit report
+    description: Path to place merged JUnit report.
     default: test_results.xml
   artifact-name:
     description: Name of uploaded artifact. Leave empty to skip upload.
     default: ''
-  bucket-destination:
-    description: GCP bucket destination to upload report to.
-    default: ''
+  upload-to-bucket:
+    description: Whether to upload results to the Google Cloud Bucket.
+    default: "false"
+  bucket-job-folder-name:
+    description: Google Cloud Bucket folder name for uploaded test results.
+    default: "fpga"
+  branch:
+    description: Branch name.
+    default: "${{ github.ref }}"
 
 runs:
   using: composite
@@ -26,8 +32,8 @@ runs:
         if find -L bazel-out -name "test.xml" | grep -F '' >> /tmp/test-xmls; then
           cat /tmp/test-xmls | xargs merge-junit -o "${{ inputs.merged-results }}"
         else
-          # merge-junit doesn't handle 0 inputs.
-          echo '<?xml version="1.0" encoding="UTF-8"?><testsuites/>' >> "${{ inputs.merged-results }}"
+          # No test results to upload
+          exit 1
         fi
 
     - name: Add hostname to testsuites
@@ -36,7 +42,7 @@ runs:
         xmlstarlet ed --inplace -i '/testsuites/testsuite' -t attr -n hostname -v "${{ runner.name }}" "${{ inputs.merged-results }}"
 
     - name: Upload report as artifact
-      if: inputs.artifact-name != ''
+      if: ${{ success() && inputs.artifact-name != '' }}
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
@@ -45,10 +51,12 @@ runs:
         overwrite: true
 
     - name: Upload report to Google Cloud
-      if: inputs.bucket-destination != ''
+      if: ${{ success() && inputs.upload-to-bucket != 'false' }}
       shell: bash
       run: |
-        gcloud storage cp "${{ inputs.merged-results }}" "gs://${{ inputs.bucket-destination }}"
+        BUCKET_PATH=opentitan-test-results/job/${{ inputs.bucket-job-folder-name }}/branch/${{ inputs.branch }}/$(date +%Y-%m-%d-%H%M%S)_test_results.xml
+        printf "BUCKET_PATH=${BUCKET_PATH}\n" >> $GITHUB_OUTPUT
+        gcloud storage cp "${{ inputs.merged-results }}" "gs://${BUCKET_PATH}"
 
     - name: Publish job summary
       uses: mikepenz/action-junit-report@ec3a351c13e080dc4fa94c49ab7ad5bf778a9668 # v5

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -18,6 +18,10 @@ on:
         required: true
         type: string
         description: FPGA board to use
+      branch:
+        default: "${{ github.ref }}"
+        type: string
+        description: Branch to checkout
       interface:
         required: true
         type: string
@@ -45,6 +49,14 @@ on:
         default: true
         type: boolean
         description: Skip tests that previously passed and were cached by Bazel
+      upload_to_bucket:
+        default: false
+        type: boolean
+        description: Whether to upload FPGA results to Google Cloud Bucket
+      bucket_job_folder_name:
+        default: "fpga"
+        type: string
+        description: Google Cloud Bucket folder name for uploaded test results
 
 jobs:
   fpga:
@@ -54,7 +66,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.branch }}
           fetch-depth: 0
+
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
         with:
@@ -98,15 +112,25 @@ jobs:
             echo "No tests to run after filtering"
           fi
 
+      - uses: actions/checkout@v4
+        if: ${{ !cancelled() }}
+        with:
+          ref: ${{ github.ref }}
+          path: "upload-branch"
+          fetch-depth: 1
+
       - name: Publish Bazel test results
-        uses: ./.github/actions/publish-bazel-test-results
+        uses: ./upload-branch/.github/actions/publish-bazel-test-results
         if: ${{ !cancelled() }}
         with:
           artifact-name: ${{ inputs.job_name }}-test-results
+          upload-to-bucket: ${{ inputs.upload_to_bucket }}
+          bucket-job-folder-name: ${{ inputs.bucket_job_folder_name }}
+          branch: ${{ inputs.branch }}
 
       - name: Upload target pattern file
-        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
         with:
           name: ${{ inputs.job_name }}-targets
           path: target_pattern_file.txt

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,6 +59,9 @@ jobs:
       tag_filters: cw310_test_rom,-broken,-manual
       add_default_filters: false
       cache_test_results: false
+      upload_to_bucket: true
+      bucket_job_folder_name: "cw310_test_rom"
+      branch: "${{ inputs.branch }}"
 
   execute_fpga_cw310_rom_tests:
     name: CW310 ROM Tests
@@ -74,6 +77,9 @@ jobs:
       add_default_filters: false
       cache_test_results: false
       timeout: 240
+      upload_to_bucket: true
+      bucket_job_folder_name: "cw310_rom"
+      branch: "${{ inputs.branch }}"
 
   execute_fpga_cw310_rom_ext_tests:
     name: CW310 ROM_EXT Tests
@@ -88,6 +94,9 @@ jobs:
       tag_filters: cw310_rom_ext,-broken,-manual
       add_default_filters: false
       cache_test_results: false
+      upload_to_bucket: true
+      bucket_job_folder_name: "cw310_rom_ext"
+      branch: "${{ inputs.branch }}"
 
   execute_fpga_cw310_sival_tests:
     name: CW310 SiVal Tests
@@ -102,6 +111,9 @@ jobs:
       tag_filters: cw310_sival,-broken,-manual
       add_default_filters: false
       cache_test_results: false
+      upload_to_bucket: true
+      bucket_job_folder_name: "cw310_sival"
+      branch: "${{ inputs.branch }}"
 
   execute_fpga_cw310_sival_rom_ext_tests:
     name: CW310 SiVal ROM_EXT Tests
@@ -116,6 +128,9 @@ jobs:
       tag_filters: cw310_sival_rom_ext,-broken,-manual
       add_default_filters: false
       cache_test_results: false
+      upload_to_bucket: true
+      bucket_job_folder_name: "cw310_sival_rom_ext"
+      branch: "${{ inputs.branch }}"
 
   execute_fpga_cw310_bob_tests:
     name: CW310 BoB (SPI and I2C) Tests
@@ -131,9 +146,12 @@ jobs:
       tag_filters: cw310_sival_rom_ext_no_hyper,-broken,-manual
       add_default_filters: false
       cache_test_results: false
+      upload_to_bucket: true
+      bucket_job_folder_name: "cw310_bob"
+      branch: "${{ inputs.branch }}"
 
   execute_fpga_cw340_test_rom_tests:
-    name: CW340 SiVal Test ROM Tests
+    name: CW340 Test ROM Tests
     needs: chip_earlgrey_cw340
     uses: ./.github/workflows/fpga.yml
     secrets: inherit
@@ -145,9 +163,12 @@ jobs:
       tag_filters: cw340_test_rom,-broken,-manual
       add_default_filters: false
       cache_test_results: false
+      upload_to_bucket: true
+      bucket_job_folder_name: "cw340_test_rom"
+      branch: "${{ inputs.branch }}"
 
   execute_fpga_cw340_rom_tests:
-    name: CW340 SiVal ROM Tests
+    name: CW340 ROM Tests
     needs: chip_earlgrey_cw340
     uses: ./.github/workflows/fpga.yml
     secrets: inherit
@@ -159,9 +180,12 @@ jobs:
       tag_filters: cw340_rom_with_fake_keys,-broken,-manual
       add_default_filters: false
       cache_test_results: false
+      upload_to_bucket: true
+      bucket_job_folder_name: "cw340_rom"
+      branch: "${{ inputs.branch }}"
 
   execute_fpga_cw340_rom_ext_tests:
-    name: CW340 SiVal ROM_EXT Tests
+    name: CW340 ROM_EXT Tests
     needs: chip_earlgrey_cw340
     uses: ./.github/workflows/fpga.yml
     secrets: inherit
@@ -173,6 +197,9 @@ jobs:
       tag_filters: cw340_rom_ext,-broken,-manual
       add_default_filters: false
       cache_test_results: false
+      upload_to_bucket: true
+      bucket_job_folder_name: "cw340_rom_ext"
+      branch: "${{ inputs.branch }}"
 
   execute_fpga_cw340_sival_tests:
     name: CW340 SiVal Tests
@@ -187,6 +214,9 @@ jobs:
       tag_filters: cw340_sival,-broken,-manual
       add_default_filters: false
       cache_test_results: false
+      upload_to_bucket: true
+      bucket_job_folder_name: "cw340_sival"
+      branch: "${{ inputs.branch }}"
 
   execute_fpga_cw340_sival_rom_ext_tests:
     name: CW340 SiVal ROM_EXT Tests
@@ -202,6 +232,9 @@ jobs:
       add_default_filters: false
       cache_test_results: false
       timeout: 90
+      upload_to_bucket: true
+      bucket_job_folder_name: "cw340_sival_rom_ext"
+      branch: "${{ inputs.branch }}"
 
   slow_otbn_crypto_tests:
     name: Slow OTBN Crypto Tests


### PR DESCRIPTION
Fixes Nightly FPGA test results no longer being uploaded to the GCloud Bucket.