### PR TITLE
[hw/tlul] Adapter host prim dependencies

### DIFF
--- a/hw/ip/tlul/adapter_host.core
+++ b/hw/ip/tlul/adapter_host.core
@@ -8,7 +8,7 @@ description: "Req/Grant/RValid to TL-UL adapter (host)"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:prim:all
+      - lowrisc:prim:assert
       - lowrisc:tlul:common
       - lowrisc:tlul:trans_intg
       - lowrisc:virtual_constants:top_pkg


### PR DESCRIPTION
Tighten the prim dependencies of the Adapter host. It only uses the primitive assert library so not need to make it depend on the rest of the primitives as well. This helps with portability.

As you can see this is one of the patches we had to apply before importing into Sonata: https://github.com/lowRISC/sonata-system/blob/ef51ac1d3d7a4b5952bbb6a15785941b506349e2/vendor/patches/lowrisc_ip/tlul/0002-Tighten-TLUL-Host-Adapter-Prim-Dependency.patch