### PR TITLE
Make PLIC interrupt 0 (no interrupt) more robust

### DIFF
--- a/hw/ip_templates/rv_plic/README.md
+++ b/hw/ip_templates/rv_plic/README.md
@@ -21,6 +21,9 @@ The RV_PLIC module is designed to manage various interrupt sources from the
 peripherals. It receives interrupt events as either edge or level of the
 incoming interrupt signals (``intr_src_i``) and can notify multiple targets.
 
+Note that the lowest bit of ``intr_src_i`` is ignored because it corresponds
+interrupt ID 0 which is reserved to mean "no interrupt".
+
 ## Compatibility
 
 The RV_PLIC is compatible with any RISC-V core implementing the RISC-V privilege specification.

--- a/hw/ip_templates/rv_plic/data/rv_plic.hjson.tpl
+++ b/hw/ip_templates/rv_plic/data/rv_plic.hjson.tpl
@@ -54,7 +54,7 @@
 
   param_list: [
     { name: "NumSrc",
-      desc: "Number of interrupt sources",
+      desc: "Number of interrupt sources (including the 'no interrupt' ID 0)",
       type: "int",
       default: "${src}",
       local: "true"

--- a/hw/ip_templates/rv_plic/doc/theory_of_operation.md
+++ b/hw/ip_templates/rv_plic/doc/theory_of_operation.md
@@ -14,8 +14,8 @@
 
 Each interrupt source has a unique ID assigned based upon its bit position
 within the input `intr_src_i`. ID ranges from 0 to N, the number of interrupt
-sources. ID 0 is reserved and represents no interrupt. The bit 0 of
-`intr_src_i` shall be tied to 0 from the outside of RV_PLIC. The
+sources. ID 0 is reserved and represents no interrupt. Bit 0 of
+`intr_src_i` is ignored by RV_PLIC.
 `intr_src_i[i]` bit has an ID of `i`. This ID is used when targets "claim" the
 interrupt and to "complete" the interrupt event.
 

--- a/hw/ip_templates/rv_plic/lint/rv_plic.waiver.tpl
+++ b/hw/ip_templates/rv_plic/lint/rv_plic.waiver.tpl
@@ -20,3 +20,6 @@ waive -rules INTEGER -location {${module_instance_name}_target.sv} -regexp {'i' 
 
 waive -rules TWOS_COMP -location {${module_instance_name}_target.sv} -regexp {Explicit two's complement with terms} ${"\\"}
       -comment "This is permissible in this context"
+
+waive -rules INPUT_NOT_READ -location {${module_instance_name}.sv} -regexp {Input port 'intr_src_i\[0\]' is not read from.*} \
+      -comment "This bit is reserved for 'no interrupt'. Ideally it would be removed entirely."

--- a/hw/top_darjeeling/ip_autogen/rv_plic/README.md
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/README.md
@@ -21,6 +21,9 @@ The RV_PLIC module is designed to manage various interrupt sources from the
 peripherals. It receives interrupt events as either edge or level of the
 incoming interrupt signals (``intr_src_i``) and can notify multiple targets.
 
+Note that the lowest bit of ``intr_src_i`` is ignored because it corresponds
+interrupt ID 0 which is reserved to mean "no interrupt".
+
 ## Compatibility
 
 The RV_PLIC is compatible with any RISC-V core implementing the RISC-V privilege specification.

--- a/hw/top_darjeeling/ip_autogen/rv_plic/data/rv_plic.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/data/rv_plic.hjson
@@ -42,7 +42,7 @@
 
   param_list: [
     { name: "NumSrc",
-      desc: "Number of interrupt sources",
+      desc: "Number of interrupt sources (including the 'no interrupt' ID 0)",
       type: "int",
       default: "132",
       local: "true"

--- a/hw/top_darjeeling/ip_autogen/rv_plic/doc/theory_of_operation.md
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/doc/theory_of_operation.md
@@ -14,8 +14,8 @@
 
 Each interrupt source has a unique ID assigned based upon its bit position
 within the input `intr_src_i`. ID ranges from 0 to N, the number of interrupt
-sources. ID 0 is reserved and represents no interrupt. The bit 0 of
-`intr_src_i` shall be tied to 0 from the outside of RV_PLIC. The
+sources. ID 0 is reserved and represents no interrupt. Bit 0 of
+`intr_src_i` is ignored by RV_PLIC.
 `intr_src_i[i]` bit has an ID of `i`. This ID is used when targets "claim" the
 interrupt and to "complete" the interrupt event.
 

--- a/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic.sv
@@ -36,7 +36,9 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   input  tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o,
 
-  // Interrupt Sources
+  // Interrupt Sources. Note that the lowest bit is ignored because it
+  // is reserved for "no interrupt". Because the lowest bit is ignored,
+  // only NumSrc-1 interrupts are usable.
   input  [NumSrc-1:0] intr_src_i,
 
   // Alerts
@@ -278,7 +280,8 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ) u_prim_flop_2sync (
     .clk_i,
     .rst_ni,
-    .d_i(intr_src_i),
+    // Replace the lowest bit with 0 since it means "no interrupt".
+    .d_i({intr_src_i[$high(intr_src_i):1], 1'b0}),
     .q_o(intr_src_synced)
   );
 
@@ -375,9 +378,6 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   for (genvar k = 0; k < NumTarget; k++) begin : gen_irq_id_known
     `ASSERT_KNOWN(IrqIdKnownO_A, irq_id_o[k])
   end
-
-  // Assume
-  `ASSUME(Irq0Tied_A, intr_src_i[0] == 1'b0)
 
   // This assertion should be provable in FPV because we don't have a block-level DV environment. It
   // is trying to say that any integrity error detected inside the register block (u_reg) will cause

--- a/hw/top_earlgrey/ip_autogen/rv_plic/README.md
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/README.md
@@ -21,6 +21,9 @@ The RV_PLIC module is designed to manage various interrupt sources from the
 peripherals. It receives interrupt events as either edge or level of the
 incoming interrupt signals (``intr_src_i``) and can notify multiple targets.
 
+Note that the lowest bit of ``intr_src_i`` is ignored because it corresponds
+interrupt ID 0 which is reserved to mean "no interrupt".
+
 ## Compatibility
 
 The RV_PLIC is compatible with any RISC-V core implementing the RISC-V privilege specification.

--- a/hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic.hjson
@@ -42,7 +42,7 @@
 
   param_list: [
     { name: "NumSrc",
-      desc: "Number of interrupt sources",
+      desc: "Number of interrupt sources (including the 'no interrupt' ID 0)",
       type: "int",
       default: "186",
       local: "true"

--- a/hw/top_earlgrey/ip_autogen/rv_plic/doc/theory_of_operation.md
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/doc/theory_of_operation.md
@@ -14,8 +14,8 @@
 
 Each interrupt source has a unique ID assigned based upon its bit position
 within the input `intr_src_i`. ID ranges from 0 to N, the number of interrupt
-sources. ID 0 is reserved and represents no interrupt. The bit 0 of
-`intr_src_i` shall be tied to 0 from the outside of RV_PLIC. The
+sources. ID 0 is reserved and represents no interrupt. Bit 0 of
+`intr_src_i` is ignored by RV_PLIC.
 `intr_src_i[i]` bit has an ID of `i`. This ID is used when targets "claim" the
 interrupt and to "complete" the interrupt event.
 

--- a/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic.sv
@@ -36,7 +36,9 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   input  tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o,
 
-  // Interrupt Sources
+  // Interrupt Sources. Note that the lowest bit is ignored because it
+  // is reserved for "no interrupt". Because the lowest bit is ignored,
+  // only NumSrc-1 interrupts are usable.
   input  [NumSrc-1:0] intr_src_i,
 
   // Alerts
@@ -332,7 +334,8 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ) u_prim_flop_2sync (
     .clk_i,
     .rst_ni,
-    .d_i(intr_src_i),
+    // Replace the lowest bit with 0 since it means "no interrupt".
+    .d_i({intr_src_i[$high(intr_src_i):1], 1'b0}),
     .q_o(intr_src_synced)
   );
 
@@ -429,9 +432,6 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   for (genvar k = 0; k < NumTarget; k++) begin : gen_irq_id_known
     `ASSERT_KNOWN(IrqIdKnownO_A, irq_id_o[k])
   end
-
-  // Assume
-  `ASSUME(Irq0Tied_A, intr_src_i[0] == 1'b0)
 
   // This assertion should be provable in FPV because we don't have a block-level DV environment. It
   // is trying to say that any integrity error detected inside the register block (u_reg) will cause

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/README.md
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/README.md
@@ -21,6 +21,9 @@ The RV_PLIC module is designed to manage various interrupt sources from the
 peripherals. It receives interrupt events as either edge or level of the
 incoming interrupt signals (``intr_src_i``) and can notify multiple targets.
 
+Note that the lowest bit of ``intr_src_i`` is ignored because it corresponds
+interrupt ID 0 which is reserved to mean "no interrupt".
+
 ## Compatibility
 
 The RV_PLIC is compatible with any RISC-V core implementing the RISC-V privilege specification.

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/data/rv_plic.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/data/rv_plic.hjson
@@ -42,7 +42,7 @@
 
   param_list: [
     { name: "NumSrc",
-      desc: "Number of interrupt sources",
+      desc: "Number of interrupt sources (including the 'no interrupt' ID 0)",
       type: "int",
       default: "88",
       local: "true"

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/doc/theory_of_operation.md
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/doc/theory_of_operation.md
@@ -14,8 +14,8 @@
 
 Each interrupt source has a unique ID assigned based upon its bit position
 within the input `intr_src_i`. ID ranges from 0 to N, the number of interrupt
-sources. ID 0 is reserved and represents no interrupt. The bit 0 of
-`intr_src_i` shall be tied to 0 from the outside of RV_PLIC. The
+sources. ID 0 is reserved and represents no interrupt. Bit 0 of
+`intr_src_i` is ignored by RV_PLIC.
 `intr_src_i[i]` bit has an ID of `i`. This ID is used when targets "claim" the
 interrupt and to "complete" the interrupt event.
 

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/rtl/rv_plic.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/rtl/rv_plic.sv
@@ -36,7 +36,9 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   input  tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o,
 
-  // Interrupt Sources
+  // Interrupt Sources. Note that the lowest bit is ignored because it
+  // is reserved for "no interrupt". Because the lowest bit is ignored,
+  // only NumSrc-1 interrupts are usable.
   input  [NumSrc-1:0] intr_src_i,
 
   // Alerts
@@ -234,7 +236,8 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ) u_prim_flop_2sync (
     .clk_i,
     .rst_ni,
-    .d_i(intr_src_i),
+    // Replace the lowest bit with 0 since it means "no interrupt".
+    .d_i({intr_src_i[$high(intr_src_i):1], 1'b0}),
     .q_o(intr_src_synced)
   );
 
@@ -331,9 +334,6 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   for (genvar k = 0; k < NumTarget; k++) begin : gen_irq_id_known
     `ASSERT_KNOWN(IrqIdKnownO_A, irq_id_o[k])
   end
-
-  // Assume
-  `ASSUME(Irq0Tied_A, intr_src_i[0] == 1'b0)
 
   // This assertion should be provable in FPV because we don't have a block-level DV environment. It
   // is trying to say that any integrity error detected inside the register block (u_reg) will cause


### PR DESCRIPTION
In PLIC, interrupt ID 0 is special - it is reserved for "no interrupt". The way this is implemented in `rv_plic` is by simply asking nicely for integrators to tie the interrupt ID 0 input to 0.

This is suboptimal for a couple of reasons:

1. It requires adding a dangerous `assume` for FPV - this is directly added inside `rv_plic.sv`. Unless there's some flow magic to convert this to an `assert` (I didn't see anything) then this can cause nonsensical formal results if you accidentally violate that assumption.
2. It allows the possibility of integration mistakes causing an interrupt 0.

This change instead just ignores that input and ties it to 0 internally. I would have liked to remove it entirely so there is no chance of making that mistake, but that is a much bigger change that requires changing the external interface.

Tested with Jasper Gold for about 25 minutes via:

    $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/top_earlgrey/formal/top_earlgrey_fpv_ip_cfgs.hjson --select-cfgs rv_plic_fpv --gui

Results: 376 proven, 0 disproven, 173 undetermined