### PR TITLE
[pentest] Print out the rom_ext_imm digest

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/fi/alert_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/alert_fi.c
@@ -650,6 +650,9 @@ status_t handle_alert_fi_init(ujson_t *uj) {
   // Read rom digest.
   TRY(pentest_read_rom_digest(uj_output.rom_digest));
 
+  // Read rom_ext_imm digest.
+  TRY(pentest_read_rom_ext_imm_digest(uj_output.rom_ext_imm_digest));
+
   // Initialize all HW blocks
   TRY(init_peripherals());
 

--- a/sw/device/tests/penetrationtests/firmware/fi/crypto_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/crypto_fi.c
@@ -317,6 +317,9 @@ status_t handle_crypto_fi_init(ujson_t *uj) {
   // Read rom digest.
   TRY(pentest_read_rom_digest(uj_output.rom_digest));
 
+  // Read rom_ext_imm digest.
+  TRY(pentest_read_rom_ext_imm_digest(uj_output.rom_ext_imm_digest));
+
   // Read device ID and return to host.
   TRY(pentest_read_device_id(uj_output.device_id));
   RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym.c
@@ -497,6 +497,9 @@ status_t handle_cryptolib_fi_asym_init(ujson_t *uj) {
   // Read rom digest.
   TRY(pentest_read_rom_digest(uj_output.rom_digest));
 
+  // Read rom_ext_imm digest.
+  TRY(pentest_read_rom_ext_imm_digest(uj_output.rom_ext_imm_digest));
+
   // Read device ID and return to host.
   TRY(pentest_read_device_id(uj_output.device_id));
   RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym.c
@@ -211,6 +211,9 @@ status_t handle_cryptolib_fi_sym_init(ujson_t *uj) {
   // Read rom digest.
   TRY(pentest_read_rom_digest(uj_output.rom_digest));
 
+  // Read rom_ext_imm digest.
+  TRY(pentest_read_rom_ext_imm_digest(uj_output.rom_ext_imm_digest));
+
   // Read device ID and return to host.
   TRY(pentest_read_device_id(uj_output.device_id));
   RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);

--- a/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.c
@@ -4280,6 +4280,9 @@ status_t handle_ibex_fi_init(ujson_t *uj) {
   // Read rom digest.
   TRY(pentest_read_rom_digest(uj_output.rom_digest));
 
+  // Read rom_ext_imm digest.
+  TRY(pentest_read_rom_ext_imm_digest(uj_output.rom_ext_imm_digest));
+
   // Read device ID and return to host.
   TRY(pentest_read_device_id(uj_output.device_id));
   RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);

--- a/sw/device/tests/penetrationtests/firmware/fi/lc_ctrl_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/lc_ctrl_fi.c
@@ -67,6 +67,9 @@ status_t handle_lc_ctrl_fi_init(ujson_t *uj) {
   // Read rom digest.
   TRY(pentest_read_rom_digest(uj_output.rom_digest));
 
+  // Read rom_ext_imm digest.
+  TRY(pentest_read_rom_ext_imm_digest(uj_output.rom_ext_imm_digest));
+
   // Read device ID and return to host.
   TRY(pentest_read_device_id(uj_output.device_id));
   RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);

--- a/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.c
@@ -1283,6 +1283,9 @@ status_t handle_otbn_fi_init(ujson_t *uj) {
   // Read rom digest.
   TRY(pentest_read_rom_digest(uj_output.rom_digest));
 
+  // Read rom_ext_imm digest.
+  TRY(pentest_read_rom_ext_imm_digest(uj_output.rom_ext_imm_digest));
+
   // Read device ID and return to host.
   TRY(pentest_read_device_id(uj_output.device_id));
   RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);

--- a/sw/device/tests/penetrationtests/firmware/fi/otp_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/otp_fi.c
@@ -208,6 +208,9 @@ status_t handle_otp_fi_init(ujson_t *uj) {
   // Read rom digest.
   TRY(pentest_read_rom_digest(uj_output.rom_digest));
 
+  // Read rom_ext_imm digest.
+  TRY(pentest_read_rom_ext_imm_digest(uj_output.rom_ext_imm_digest));
+
   // Read device ID and return to host.
   TRY(pentest_read_device_id(uj_output.device_id));
   RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);

--- a/sw/device/tests/penetrationtests/firmware/fi/rng_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/rng_fi.c
@@ -439,6 +439,9 @@ status_t handle_rng_fi_edn_init(ujson_t *uj) {
   // Read rom digest.
   TRY(pentest_read_rom_digest(uj_output.rom_digest));
 
+  // Read rom_ext_imm digest.
+  TRY(pentest_read_rom_ext_imm_digest(uj_output.rom_ext_imm_digest));
+
   // Read device ID and return to host.
   TRY(pentest_read_device_id(uj_output.device_id));
   RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
@@ -675,6 +678,9 @@ status_t handle_rng_fi_csrng_init(ujson_t *uj) {
 
   // Read rom digest.
   TRY(pentest_read_rom_digest(uj_output.rom_digest));
+
+  // Read rom_ext_imm digest.
+  TRY(pentest_read_rom_ext_imm_digest(uj_output.rom_ext_imm_digest));
 
   // Read device ID and return to host.
   TRY(pentest_read_device_id(uj_output.device_id));

--- a/sw/device/tests/penetrationtests/firmware/fi/rom_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/rom_fi.c
@@ -122,6 +122,9 @@ status_t handle_rom_fi_init(ujson_t *uj) {
   // Read rom digest.
   TRY(pentest_read_rom_digest(uj_output.rom_digest));
 
+  // Read rom_ext_imm digest.
+  TRY(pentest_read_rom_ext_imm_digest(uj_output.rom_ext_imm_digest));
+
   // Read device ID and return to host.
   TRY(pentest_read_device_id(uj_output.device_id));
   RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);

--- a/sw/device/tests/penetrationtests/firmware/lib/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/lib/BUILD
@@ -45,6 +45,7 @@ cc_library(
         "//sw/device/lib/dif:entropy_src",
         "//sw/device/lib/dif:gpio",
         "//sw/device/lib/dif:lc_ctrl",
+        "//sw/device/lib/dif:otp_ctrl",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:rom_ctrl",
         "//sw/device/lib/dif:rstmgr",
@@ -57,6 +58,7 @@ cc_library(
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:irq",
         "//sw/device/lib/testing:alert_handler_testutils",
+        "//sw/device/lib/testing:otp_ctrl_testutils",
         "//sw/device/lib/testing:pinmux_testutils",
         "//sw/device/lib/testing:rv_plic_testutils",
         "//sw/device/lib/testing/test_framework:check",
@@ -75,6 +77,7 @@ cc_library(
             "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
             "//sw/device/silicon_creator/lib/drivers:retention_sram",
             "//sw/device/silicon_creator/lib/ownership",
+            "//sw/device/silicon_creator/lib/drivers:otp",
         ],
     }),
 )

--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
@@ -18,6 +18,7 @@
 #include "sw/device/lib/dif/dif_csrng_shared.h"
 #include "sw/device/lib/dif/dif_gpio.h"
 #include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
 #include "sw/device/lib/dif/dif_pinmux.h"
 #include "sw/device/lib/dif/dif_rom_ctrl.h"
 #include "sw/device/lib/dif/dif_rstmgr.h"
@@ -30,6 +31,7 @@
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/irq.h"
 #include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/otp_ctrl_testutils.h"
 #include "sw/device/lib/testing/pinmux_testutils.h"
 #include "sw/device/lib/testing/rv_plic_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
@@ -37,6 +39,11 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 #include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/silicon_creator/lib/base/boot_measurements.h"
+#include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
+#include "sw/device/silicon_creator/lib/drivers/otp.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+#include "sw/device/silicon_creator/lib/ownership/ownership.h"
 
 #include "clkmgr_regs.h"  // Generated
 #include "csrng_regs.h"   // Generated
@@ -552,6 +559,34 @@ status_t pentest_read_rom_digest(uint32_t rom_digest[]) {
   TRY(dif_rom_ctrl_get_expected_digest(&rom_ctrl, &expected_digest));
 
   memcpy(rom_digest, expected_digest.digest, 8 * sizeof(uint32_t));
+
+  return OK_STATUS();
+}
+
+status_t pentest_read_rom_ext_imm_digest(uint32_t rom_ext_imm_digest[]) {
+  dif_otp_ctrl_t otp;
+
+  TRY(dif_otp_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), &otp));
+
+  uint32_t hash_word_size =
+      OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_SHA256_HASH_SIZE /
+      sizeof(uint32_t);
+  uint32_t rom_ext_immutable_section_enabled;
+  TRY(dif_otp_ctrl_read_blocking(
+      &otp, kDifOtpCtrlPartitionOwnerSwCfg,
+      OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN_OFFSET,
+      &rom_ext_immutable_section_enabled, 1));
+
+  if (rom_ext_immutable_section_enabled == kHardenedBoolTrue) {
+    TRY(dif_otp_ctrl_read_blocking(
+        &otp, kDifOtpCtrlPartitionOwnerSwCfg,
+        OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_SHA256_HASH_OFFSET,
+        rom_ext_imm_digest, hash_word_size));
+  } else {
+    // ROM_EXT immutable is not enabled, hence we set its version to zero
+    memset(rom_ext_imm_digest, 0, hash_word_size * sizeof(uint32_t));
+  }
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h
@@ -363,6 +363,16 @@ status_t pentest_read_device_id(uint32_t device_id[]);
 status_t pentest_read_rom_digest(uint32_t rom_digest[]);
 
 /**
+ * Reads the rom_ext_imm digest from the otp.
+ *
+ * Can be used to version the rom_ext_imm.
+ *
+ * @param rom_ext_imm_digest A buffer available to store the rom digest.
+ * @return OK or error.
+ */
+status_t pentest_read_rom_ext_imm_digest(uint32_t rom_ext_imm_digest[]);
+
+/**
  * Configures CPU for SCA and FI penetration tests.
  *
  * If disable_icache is True, this functions disables the instruction cache. If

--- a/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
@@ -393,6 +393,9 @@ status_t handle_aes_pentest_init(ujson_t *uj) {
   // Read rom digest.
   TRY(pentest_read_rom_digest(uj_output.rom_digest));
 
+  // Read rom_ext_imm digest.
+  TRY(pentest_read_rom_ext_imm_digest(uj_output.rom_ext_imm_digest));
+
   // Read device ID and return to host.
   TRY(pentest_read_device_id(uj_output.device_id));
   RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym.c
@@ -859,6 +859,9 @@ status_t handle_cryptolib_sca_asym_init(ujson_t *uj) {
   // Read rom digest.
   TRY(pentest_read_rom_digest(uj_output.rom_digest));
 
+  // Read rom_ext_imm digest.
+  TRY(pentest_read_rom_ext_imm_digest(uj_output.rom_ext_imm_digest));
+
   // Read device ID and return to host.
   TRY(pentest_read_device_id(uj_output.device_id));
   RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_sym.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_sym.c
@@ -911,6 +911,9 @@ status_t handle_cryptolib_sca_sym_init(ujson_t *uj) {
   // Read rom digest.
   TRY(pentest_read_rom_digest(uj_output.rom_digest));
 
+  // Read rom_ext_imm digest.
+  TRY(pentest_read_rom_ext_imm_digest(uj_output.rom_ext_imm_digest));
+
   // Read device ID and return to host.
   TRY(pentest_read_device_id(uj_output.device_id));
   RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);

--- a/sw/device/tests/penetrationtests/firmware/sca/edn_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/edn_sca.c
@@ -156,6 +156,9 @@ status_t handle_edn_sca_init(ujson_t *uj) {
   // Read rom digest.
   TRY(pentest_read_rom_digest(uj_output.rom_digest));
 
+  // Read rom_ext_imm digest.
+  TRY(pentest_read_rom_ext_imm_digest(uj_output.rom_ext_imm_digest));
+
   // Read device ID and return to host.
   TRY(pentest_read_device_id(uj_output.device_id));
   RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);

--- a/sw/device/tests/penetrationtests/firmware/sca/hmac_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/hmac_sca.c
@@ -133,6 +133,9 @@ status_t handle_hmac_pentest_init(ujson_t *uj) {
   // Read rom digest.
   TRY(pentest_read_rom_digest(uj_output.rom_digest));
 
+  // Read rom_ext_imm digest.
+  TRY(pentest_read_rom_ext_imm_digest(uj_output.rom_ext_imm_digest));
+
   // Read device ID and return to host.
   TRY(pentest_read_device_id(uj_output.device_id));
   RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);

--- a/sw/device/tests/penetrationtests/firmware/sca/ibex_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/ibex_sca.c
@@ -182,6 +182,9 @@ status_t handle_ibex_pentest_init(ujson_t *uj) {
   // Read rom digest.
   TRY(pentest_read_rom_digest(uj_output.rom_digest));
 
+  // Read rom_ext_imm digest.
+  TRY(pentest_read_rom_ext_imm_digest(uj_output.rom_ext_imm_digest));
+
   // Read device ID and return to host.
   TRY(pentest_read_device_id(uj_output.device_id));
   RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);

--- a/sw/device/tests/penetrationtests/firmware/sca/kmac_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/kmac_sca.c
@@ -495,6 +495,9 @@ status_t handle_kmac_pentest_init(ujson_t *uj) {
   // Read rom digest.
   TRY(pentest_read_rom_digest(uj_output.rom_digest));
 
+  // Read rom_ext_imm digest.
+  TRY(pentest_read_rom_ext_imm_digest(uj_output.rom_ext_imm_digest));
+
   // Read device ID and return to host.
   TRY(pentest_read_device_id(uj_output.device_id));
   RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);

--- a/sw/device/tests/penetrationtests/firmware/sca/otbn_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/otbn_sca.c
@@ -517,6 +517,9 @@ status_t handle_otbn_pentest_init(ujson_t *uj) {
   // Read rom digest.
   TRY(pentest_read_rom_digest(uj_output.rom_digest));
 
+  // Read rom_ext_imm digest.
+  TRY(pentest_read_rom_ext_imm_digest(uj_output.rom_ext_imm_digest));
+
   // Read device ID and return to host.
   TRY(pentest_read_device_id(uj_output.device_id));
   RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);

--- a/sw/device/tests/penetrationtests/firmware/sca/sha3_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/sha3_sca.c
@@ -624,6 +624,9 @@ status_t handle_sha3_pentest_init(ujson_t *uj) {
   // Read rom digest.
   TRY(pentest_read_rom_digest(uj_output.rom_digest));
 
+  // Read rom_ext_imm digest.
+  TRY(pentest_read_rom_ext_imm_digest(uj_output.rom_ext_imm_digest));
+
   // Read device ID and return to host.
   TRY(pentest_read_device_id(uj_output.device_id));
   RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);

--- a/sw/device/tests/penetrationtests/json/pentest_lib_commands.h
+++ b/sw/device/tests/penetrationtests/json/pentest_lib_commands.h
@@ -20,6 +20,7 @@ extern "C" {
 #define PENETRATIONTEST_DEVICE_INFO(field, string) \
     field(device_id, uint32_t, 8) \
     field(rom_digest, uint32_t, 8) \
+    field(rom_ext_imm_digest, uint32_t, 8) \
     field(icache_en, bool) \
     field(dummy_instr_en, bool) \
     field(clock_jitter_locked, bool) \

--- a/sw/host/penetrationtests/python/fi/test_scripts/fi_alert_python_test.py
+++ b/sw/host/penetrationtests/python/fi/test_scripts/fi_alert_python_test.py
@@ -113,6 +113,7 @@ class AlertFiTest(unittest.TestCase):
         expected_device_id_keys = {
             "device_id",
             "rom_digest",
+            "rom_ext_imm_digest",
             "icache_en",
             "dummy_instr_en",
             "clock_jitter_locked",

--- a/sw/host/penetrationtests/python/fi/test_scripts/fi_asym_cryptolib_python_test.py
+++ b/sw/host/penetrationtests/python/fi/test_scripts/fi_asym_cryptolib_python_test.py
@@ -60,6 +60,7 @@ class SymCryptolibFiTest(unittest.TestCase):
         expected_device_id_keys = {
             "device_id",
             "rom_digest",
+            "rom_ext_imm_digest",
             "icache_en",
             "dummy_instr_en",
             "clock_jitter_locked",

--- a/sw/host/penetrationtests/python/fi/test_scripts/fi_crypto_python_test.py
+++ b/sw/host/penetrationtests/python/fi/test_scripts/fi_crypto_python_test.py
@@ -61,6 +61,7 @@ class CryptoFiTest(unittest.TestCase):
         expected_device_id_keys = {
             "device_id",
             "rom_digest",
+            "rom_ext_imm_digest",
             "icache_en",
             "dummy_instr_en",
             "clock_jitter_locked",

--- a/sw/host/penetrationtests/python/fi/test_scripts/fi_ibex_python_test.py
+++ b/sw/host/penetrationtests/python/fi/test_scripts/fi_ibex_python_test.py
@@ -61,6 +61,7 @@ class IbexFiTest(unittest.TestCase):
         expected_device_id_keys = {
             "device_id",
             "rom_digest",
+            "rom_ext_imm_digest",
             "icache_en",
             "dummy_instr_en",
             "clock_jitter_locked",

--- a/sw/host/penetrationtests/python/fi/test_scripts/fi_otbn_python_test.py
+++ b/sw/host/penetrationtests/python/fi/test_scripts/fi_otbn_python_test.py
@@ -58,6 +58,7 @@ class OtbnFiTest(unittest.TestCase):
         expected_device_id_keys = {
             "device_id",
             "rom_digest",
+            "rom_ext_imm_digest",
             "icache_en",
             "dummy_instr_en",
             "clock_jitter_locked",

--- a/sw/host/penetrationtests/python/fi/test_scripts/fi_otp_python_test.py
+++ b/sw/host/penetrationtests/python/fi/test_scripts/fi_otp_python_test.py
@@ -57,6 +57,7 @@ class OtpFiTest(unittest.TestCase):
         expected_device_id_keys = {
             "device_id",
             "rom_digest",
+            "rom_ext_imm_digest",
             "icache_en",
             "dummy_instr_en",
             "clock_jitter_locked",

--- a/sw/host/penetrationtests/python/fi/test_scripts/fi_rng_python_test.py
+++ b/sw/host/penetrationtests/python/fi/test_scripts/fi_rng_python_test.py
@@ -57,6 +57,7 @@ class RngFiTest(unittest.TestCase):
         expected_device_id_keys = {
             "device_id",
             "rom_digest",
+            "rom_ext_imm_digest",
             "icache_en",
             "dummy_instr_en",
             "clock_jitter_locked",

--- a/sw/host/penetrationtests/python/fi/test_scripts/fi_rom_python_test.py
+++ b/sw/host/penetrationtests/python/fi/test_scripts/fi_rom_python_test.py
@@ -57,6 +57,7 @@ class RomFiTest(unittest.TestCase):
         expected_device_id_keys = {
             "device_id",
             "rom_digest",
+            "rom_ext_imm_digest",
             "icache_en",
             "dummy_instr_en",
             "clock_jitter_locked",

--- a/sw/host/penetrationtests/python/fi/test_scripts/fi_sym_cryptolib_python_test.py
+++ b/sw/host/penetrationtests/python/fi/test_scripts/fi_sym_cryptolib_python_test.py
@@ -59,6 +59,7 @@ class SymCryptolibFiTest(unittest.TestCase):
         expected_device_id_keys = {
             "device_id",
             "rom_digest",
+            "rom_ext_imm_digest",
             "icache_en",
             "dummy_instr_en",
             "clock_jitter_locked",

--- a/sw/host/penetrationtests/python/sca/test_scripts/sca_aes_python_test.py
+++ b/sw/host/penetrationtests/python/sca/test_scripts/sca_aes_python_test.py
@@ -48,6 +48,7 @@ class AesScaTest(unittest.TestCase):
         expected_device_id_keys = {
             "device_id",
             "rom_digest",
+            "rom_ext_imm_digest",
             "icache_en",
             "dummy_instr_en",
             "clock_jitter_locked",

--- a/sw/host/penetrationtests/python/sca/test_scripts/sca_asym_cryptolib_python_test.py
+++ b/sw/host/penetrationtests/python/sca/test_scripts/sca_asym_cryptolib_python_test.py
@@ -57,6 +57,7 @@ class AsymCryptoScaTest(unittest.TestCase):
         expected_device_id_keys = {
             "device_id",
             "rom_digest",
+            "rom_ext_imm_digest",
             "icache_en",
             "dummy_instr_en",
             "clock_jitter_locked",

--- a/sw/host/penetrationtests/python/sca/test_scripts/sca_hmac_python_test.py
+++ b/sw/host/penetrationtests/python/sca/test_scripts/sca_hmac_python_test.py
@@ -46,6 +46,7 @@ class HmacScaTest(unittest.TestCase):
         expected_device_id_keys = {
             "device_id",
             "rom_digest",
+            "rom_ext_imm_digest",
             "icache_en",
             "dummy_instr_en",
             "clock_jitter_locked",

--- a/sw/host/penetrationtests/python/sca/test_scripts/sca_ibex_python_test.py
+++ b/sw/host/penetrationtests/python/sca/test_scripts/sca_ibex_python_test.py
@@ -44,6 +44,7 @@ class IbexScaTest(unittest.TestCase):
         expected_device_id_keys = {
             "device_id",
             "rom_digest",
+            "rom_ext_imm_digest",
             "icache_en",
             "dummy_instr_en",
             "clock_jitter_locked",

--- a/sw/host/penetrationtests/python/sca/test_scripts/sca_kmac_python_test.py
+++ b/sw/host/penetrationtests/python/sca/test_scripts/sca_kmac_python_test.py
@@ -49,6 +49,7 @@ class KmacScaTest(unittest.TestCase):
         expected_device_id_keys = {
             "device_id",
             "rom_digest",
+            "rom_ext_imm_digest",
             "icache_en",
             "dummy_instr_en",
             "clock_jitter_locked",

--- a/sw/host/penetrationtests/python/sca/test_scripts/sca_otbn_python_test.py
+++ b/sw/host/penetrationtests/python/sca/test_scripts/sca_otbn_python_test.py
@@ -44,6 +44,7 @@ class OtbnScaTest(unittest.TestCase):
         expected_device_id_keys = {
             "device_id",
             "rom_digest",
+            "rom_ext_imm_digest",
             "icache_en",
             "dummy_instr_en",
             "clock_jitter_locked",

--- a/sw/host/penetrationtests/python/sca/test_scripts/sca_sha3_python_test.py
+++ b/sw/host/penetrationtests/python/sca/test_scripts/sca_sha3_python_test.py
@@ -49,6 +49,7 @@ class Sha3ScaTest(unittest.TestCase):
         expected_device_id_keys = {
             "device_id",
             "rom_digest",
+            "rom_ext_imm_digest",
             "icache_en",
             "dummy_instr_en",
             "clock_jitter_locked",

--- a/sw/host/penetrationtests/python/sca/test_scripts/sca_sym_cryptolib_python_test.py
+++ b/sw/host/penetrationtests/python/sca/test_scripts/sca_sym_cryptolib_python_test.py
@@ -54,6 +54,7 @@ class SymCryptoScaTest(unittest.TestCase):
         expected_device_id_keys = {
             "device_id",
             "rom_digest",
+            "rom_ext_imm_digest",
             "icache_en",
             "dummy_instr_en",
             "clock_jitter_locked",

--- a/sw/host/tests/penetrationtests/pentest_lib/src/lib.rs
+++ b/sw/host/tests/penetrationtests/pentest_lib/src/lib.rs
@@ -19,8 +19,9 @@ pub fn filter_response_common(
     map.remove("err_status");
     // Device ID is different for each device.
     map.remove("device_id");
-    // Rom might be different between devices.
+    // Rom and rom_ext_imm might be different between devices.
     map.remove("rom_digest");
+    map.remove("rom_ext_imm_digest");
     // When setting an alert to false, the testOS leaves it unconfigured
     // meaning that teh response depends on the configuration in OTP
     map.remove("enabled_alerts");


### PR DESCRIPTION
For versioning of the rom_ext_imm, we print out the digest of the otp.