### PR TITLE
[rust] replace `Rc::clone` with `.clone()`

### DIFF
--- a/sw/host/hsmtool/src/module.rs
+++ b/sw/host/hsmtool/src/module.rs
@@ -64,11 +64,7 @@ impl Module {
         let module = match module {
             SpxModule::Acorn(libpath) => Acorn::new(libpath)? as Box<dyn SpxInterface>,
             SpxModule::Pkcs11Ef => {
-                let session = self
-                    .session
-                    .as_ref()
-                    .map(Rc::clone)
-                    .ok_or(HsmError::SessionRequired)?;
+                let session = self.session.clone().ok_or(HsmError::SessionRequired)?;
                 SpxEf::new(session) as Box<dyn SpxInterface>
             }
         };

--- a/sw/host/opentitanlib/src/app/i2c.rs
+++ b/sw/host/opentitanlib/src/app/i2c.rs
@@ -133,13 +133,13 @@ impl Bus for LogicalI2cWrapper {
     ) -> Result<()> {
         let mut inner = self.inner.borrow_mut();
         if serial_clock.is_some() {
-            inner.serial_clock = serial_clock.map(Rc::clone);
+            inner.serial_clock = serial_clock.cloned();
         }
         if serial_data.is_some() {
-            inner.serial_data = serial_data.map(Rc::clone);
+            inner.serial_data = serial_data.cloned();
         }
         if gsc_ready.is_some() {
-            inner.gsc_ready = gsc_ready.map(Rc::clone);
+            inner.gsc_ready = gsc_ready.cloned();
         }
         Ok(())
     }

--- a/sw/host/opentitanlib/src/app/spi.rs
+++ b/sw/host/opentitanlib/src/app/spi.rs
@@ -183,19 +183,19 @@ impl Target for LogicalSpiWrapper {
     ) -> Result<()> {
         let mut inner = self.inner.borrow_mut();
         if serial_clock.is_some() {
-            inner.serial_clock = serial_clock.map(Rc::clone);
+            inner.serial_clock = serial_clock.cloned();
         }
         if host_out_device_in.is_some() {
-            inner.host_out_device_in = host_out_device_in.map(Rc::clone);
+            inner.host_out_device_in = host_out_device_in.cloned();
         }
         if host_in_device_out.is_some() {
-            inner.host_in_device_out = host_in_device_out.map(Rc::clone);
+            inner.host_in_device_out = host_in_device_out.cloned();
         }
         if chip_select.is_some() {
-            inner.chip_select = chip_select.map(Rc::clone);
+            inner.chip_select = chip_select.cloned();
         }
         if gsc_ready.is_some() {
-            inner.gsc_ready = gsc_ready.map(Rc::clone);
+            inner.gsc_ready = gsc_ready.cloned();
         }
         Ok(())
     }
@@ -245,6 +245,6 @@ impl Target for LogicalSpiWrapper {
 
     fn assert_cs(self: Rc<Self>) -> Result<spi::AssertChipSelect> {
         self.apply_settings_to_underlying()?;
-        Rc::clone(&self.physical_wrapper.underlying_target).assert_cs()
+        self.physical_wrapper.underlying_target.clone().assert_cs()
     }
 }

--- a/sw/host/opentitanlib/src/tpm/driver.rs
+++ b/sw/host/opentitanlib/src/tpm/driver.rs
@@ -250,14 +250,14 @@ impl SpiDriver {
     }
 
     fn do_read_register(&self, register: Register, data: &mut [u8]) -> Result<()> {
-        let _cs_asserted = Rc::clone(&self.spi).assert_cs()?; // Deasserts when going out of scope.
+        let _cs_asserted = self.spi.clone().assert_cs()?; // Deasserts when going out of scope.
         self.write_header(register, data.len(), true)?;
         self.spi.run_transaction(&mut [spi::Transfer::Read(data)])?;
         Ok(())
     }
 
     fn do_write_register(&self, register: Register, data: &[u8]) -> Result<()> {
-        let _cs_asserted = Rc::clone(&self.spi).assert_cs()?; // Deasserts when going out of scope.
+        let _cs_asserted = self.spi.clone().assert_cs()?; // Deasserts when going out of scope.
         self.write_header(register, data.len(), false)?;
         self.spi
             .run_transaction(&mut [spi::Transfer::Write(data)])?;

--- a/sw/host/opentitantool/src/command/rescue.rs
+++ b/sw/host/opentitantool/src/command/rescue.rs
@@ -9,7 +9,6 @@ use serde_annotate::Annotate;
 use std::any::Any;
 use std::fs::File;
 use std::path::PathBuf;
-use std::rc::Rc;
 use std::time::Duration;
 
 use opentitanlib::app::TransportWrapper;
@@ -95,7 +94,7 @@ impl CommandDispatch for Firmware {
         };
         let uart = self.params.create(transport)?;
         let mut prev_baudrate = 0u32;
-        let rescue = RescueSerial::new(Rc::clone(&uart));
+        let rescue = RescueSerial::new(uart.clone());
         rescue.enter(transport, self.reset_target)?;
         if let Some(rate) = self.rate {
             prev_baudrate = uart.get_baudrate()?;

--- a/sw/host/ot_transports/dediprog/src/lib.rs
+++ b/sw/host/ot_transports/dediprog/src/lib.rs
@@ -287,14 +287,13 @@ impl Transport for Dediprog {
         }
         let mut inner = self.inner.borrow_mut();
         Ok(match inner.gpio.entry(pinname.to_string()) {
-            Entry::Vacant(v) => {
-                let u = v.insert(Rc::new(gpio::DediprogPin::open(
-                    Rc::clone(&self.inner),
+            Entry::Vacant(v) => v
+                .insert(Rc::new(gpio::DediprogPin::open(
+                    self.inner.clone(),
                     pinname,
-                )?));
-                Rc::clone(u)
-            }
-            Entry::Occupied(o) => Rc::clone(o.get()),
+                )?))
+                .clone(),
+            Entry::Occupied(o) => o.get().clone(),
         })
     }
 
@@ -305,9 +304,9 @@ impl Transport for Dediprog {
         );
         if self.inner.borrow().spi.is_none() {
             self.inner.borrow_mut().spi =
-                Some(Rc::new(spi::DediprogSpi::open(Rc::clone(&self.inner))?));
+                Some(Rc::new(spi::DediprogSpi::open(self.inner.clone())?));
         }
-        Ok(Rc::clone(self.inner.borrow().spi.as_ref().unwrap()))
+        Ok(self.inner.borrow().spi.as_ref().unwrap().clone())
     }
 }
 
@@ -319,7 +318,7 @@ pub struct VoltagePin {
 impl VoltagePin {
     pub fn open(inner: &Rc<RefCell<Inner>>) -> Result<Self> {
         Ok(Self {
-            inner: Rc::clone(inner),
+            inner: inner.clone(),
         })
     }
 }

--- a/sw/host/ot_transports/ftdi/src/gpio.rs
+++ b/sw/host/ot_transports/ftdi/src/gpio.rs
@@ -34,7 +34,7 @@ impl Pin {
     ) -> Result<Self> {
         Ok(Self {
             pin: RefCell::new(PinType::None),
-            ftdi: Rc::clone(ftdi),
+            ftdi: ftdi.clone(),
             pinname,
         })
     }

--- a/sw/host/ot_transports/hyperdebug/src/c2d2.rs
+++ b/sw/host/ot_transports/hyperdebug/src/c2d2.rs
@@ -60,7 +60,7 @@ pub struct C2d2ResetPin {
 impl C2d2ResetPin {
     pub fn open(inner: &Rc<Inner>) -> Result<Self> {
         Ok(Self {
-            inner: Rc::clone(inner),
+            inner: inner.clone(),
         })
     }
 }

--- a/sw/host/ot_transports/hyperdebug/src/gpio.rs
+++ b/sw/host/ot_transports/hyperdebug/src/gpio.rs
@@ -30,7 +30,7 @@ pub struct HyperdebugGpioPin {
 impl HyperdebugGpioPin {
     pub fn open(inner: &Rc<Inner>, pinname: &str) -> Result<Self> {
         let result = Self {
-            inner: Rc::clone(inner),
+            inner: inner.clone(),
             pinname: pinname.to_string(),
         };
         Ok(result)
@@ -209,7 +209,7 @@ impl HyperdebugGpioMonitoring {
 
     pub fn open(inner: &Rc<Inner>, cmsis_interface: Option<BulkInterface>) -> Result<Self> {
         Ok(Self {
-            inner: Rc::clone(inner),
+            inner: inner.clone(),
             cmsis_interface,
         })
     }
@@ -495,7 +495,7 @@ impl HyperdebugGpioBitbanging {
             .borrow_mut()
             .claim_interface(cmsis_interface.interface)?;
         Ok(Self {
-            inner: Rc::clone(inner),
+            inner: inner.clone(),
             cmsis_interface,
         })
     }
@@ -532,7 +532,7 @@ impl GpioBitbanging for HyperdebugGpioBitbanging {
         waveform: Box<[BitbangEntry<'a, 'a>]>,
     ) -> Result<Box<dyn GpioBitbangOperation<'a, 'a> + 'a>> {
         Ok(Box::new(HyperdebugGpioBitbangOperation::new(
-            Rc::clone(&self.inner),
+            self.inner.clone(),
             self.cmsis_interface,
             pins,
             clock_tick,
@@ -547,7 +547,7 @@ impl GpioBitbanging for HyperdebugGpioBitbanging {
         waveform: Box<[DacBangEntry]>,
     ) -> Result<Box<dyn GpioDacBangOperation>> {
         Ok(Box::new(HyperdebugGpioDacBangOperation::new(
-            Rc::clone(&self.inner),
+            self.inner.clone(),
             self.cmsis_interface,
             pins,
             clock_tick,

--- a/sw/host/ot_transports/hyperdebug/src/i2c.rs
+++ b/sw/host/ot_transports/hyperdebug/src/i2c.rs
@@ -167,7 +167,7 @@ impl HyperdebugI2cBus {
         usb_handle.claim_interface(i2c_interface.interface)?;
 
         Ok(Self {
-            inner: Rc::clone(inner),
+            inner: inner.clone(),
             interface: *i2c_interface,
             cmsis_encapsulation,
             supports_i2c_device,

--- a/sw/host/ot_transports/hyperdebug/src/servo_micro.rs
+++ b/sw/host/ot_transports/hyperdebug/src/servo_micro.rs
@@ -76,7 +76,7 @@ impl ServoMicroResetPin {
 
     pub fn open(inner: &Rc<Inner>) -> Result<Self> {
         Ok(Self {
-            inner: Rc::clone(inner),
+            inner: inner.clone(),
         })
     }
 

--- a/sw/host/ot_transports/hyperdebug/src/spi.rs
+++ b/sw/host/ot_transports/hyperdebug/src/spi.rs
@@ -294,7 +294,7 @@ impl HyperdebugSpiTarget {
         );
 
         Ok(Self {
-            inner: Rc::clone(inner),
+            inner: inner.clone(),
             interface: *spi_interface,
             target_enable_cmd: enable_cmd,
             target_idx: idx,

--- a/sw/host/ot_transports/hyperdebug/src/uart.rs
+++ b/sw/host/ot_transports/hyperdebug/src/uart.rs
@@ -47,7 +47,7 @@ impl HyperdebugUart {
         supports_clearing_queues: bool,
     ) -> Result<Self> {
         Ok(Self {
-            inner: Rc::clone(inner),
+            inner: inner.clone(),
             usb_interface: uart_interface.interface,
             supports_clearing_queues,
             serial_port: SoftwareFlowControl::new(SerialPortUart::open(

--- a/sw/host/ot_transports/proxy/src/gpio.rs
+++ b/sw/host/ot_transports/proxy/src/gpio.rs
@@ -27,7 +27,7 @@ pub struct ProxyGpioPin {
 impl ProxyGpioPin {
     pub fn open(proxy: &Proxy, pinname: &str) -> Result<Self> {
         let result = Self {
-            inner: Rc::clone(&proxy.inner),
+            inner: proxy.inner.clone(),
             pinname: pinname.to_string(),
         };
         Ok(result)
@@ -120,7 +120,7 @@ pub struct GpioMonitoringImpl {
 impl GpioMonitoringImpl {
     pub fn new(proxy: &Proxy) -> Result<Self> {
         Ok(Self {
-            inner: Rc::clone(&proxy.inner),
+            inner: proxy.inner.clone(),
         })
     }
 
@@ -181,7 +181,7 @@ pub struct GpioBitbangingImpl {
 impl GpioBitbangingImpl {
     pub fn new(proxy: &Proxy) -> Result<Self> {
         Ok(Self {
-            inner: Rc::clone(&proxy.inner),
+            inner: proxy.inner.clone(),
         })
     }
 
@@ -256,7 +256,7 @@ impl GpioBitbanging for GpioBitbangingImpl {
             entries: req,
         })? {
             GpioBitResponse::Start => Ok(Box::new(GpioBitbangOperationImpl {
-                inner: Rc::clone(&self.inner),
+                inner: self.inner.clone(),
                 waveform,
             })),
             _ => bail!(ProxyError::UnexpectedReply()),
@@ -297,7 +297,7 @@ impl GpioBitbanging for GpioBitbangingImpl {
             entries: req,
         })? {
             GpioDacResponse::Start => Ok(Box::new(GpioDacBangOperationImpl {
-                inner: Rc::clone(&self.inner),
+                inner: self.inner.clone(),
             })),
             _ => bail!(ProxyError::UnexpectedReply()),
         }

--- a/sw/host/ot_transports/proxy/src/i2c.rs
+++ b/sw/host/ot_transports/proxy/src/i2c.rs
@@ -24,7 +24,7 @@ pub struct ProxyI2c {
 impl ProxyI2c {
     pub fn open(proxy: &Proxy, instance: &str) -> Result<Self> {
         let result = Self {
-            inner: Rc::clone(&proxy.inner),
+            inner: proxy.inner.clone(),
             instance: instance.to_string(),
             default_address: Cell::new(None),
         };

--- a/sw/host/ot_transports/proxy/src/lib.rs
+++ b/sw/host/ot_transports/proxy/src/lib.rs
@@ -296,7 +296,7 @@ impl Transport for Proxy {
     // Create Uart instance, or return one from a cache of previously created instances.
     fn uart(&self, instance_name: &str) -> Result<Rc<dyn Uart>> {
         if let Some(instance) = self.inner.uarts.borrow().get(instance_name) {
-            return Ok(Rc::clone(&instance.uart));
+            return Ok(instance.uart.clone());
         }
 
         // All `Uart` instances that we create via proxy supports non-blocking.
@@ -321,7 +321,7 @@ impl Transport for Proxy {
         self.inner.uarts.borrow_mut().insert(
             instance_name.to_owned(),
             UartRecord {
-                uart: Rc::clone(&instance),
+                uart: instance.clone(),
                 pipe_sender,
                 pipe_receiver,
             },

--- a/sw/host/ot_transports/proxy/src/spi.rs
+++ b/sw/host/ot_transports/proxy/src/spi.rs
@@ -24,7 +24,7 @@ pub struct ProxySpi {
 impl ProxySpi {
     pub fn open(proxy: &Proxy, instance: &str) -> Result<Self> {
         let result = Self {
-            inner: Rc::clone(&proxy.inner),
+            inner: proxy.inner.clone(),
             instance: instance.to_string(),
         };
         Ok(result)

--- a/sw/host/ot_transports/proxy/src/uart.rs
+++ b/sw/host/ot_transports/proxy/src/uart.rs
@@ -25,7 +25,7 @@ pub struct ProxyUart {
 impl ProxyUart {
     pub fn open(proxy: &Proxy, instance: &str) -> Result<Self> {
         let result = Self {
-            inner: Rc::clone(&proxy.inner),
+            inner: proxy.inner.clone(),
             instance: instance.to_string(),
             multi_waker: MultiWaker::new(),
         };

--- a/sw/host/ot_transports/ti50emulator/src/emu.rs
+++ b/sw/host/ot_transports/ti50emulator/src/emu.rs
@@ -554,7 +554,7 @@ pub struct ResetPin {
 impl ResetPin {
     pub fn open(inner: &Rc<Inner>) -> Result<Self> {
         Ok(Self {
-            inner: Rc::clone(inner),
+            inner: inner.clone(),
         })
     }
 }

--- a/sw/host/ot_transports/verilator/src/subprocess.rs
+++ b/sw/host/ot_transports/verilator/src/subprocess.rs
@@ -104,7 +104,7 @@ impl Subprocess {
             .spawn()?;
         let accumulator: Arc<Mutex<String>> = Default::default();
         let stdout = child.stdout.take().unwrap();
-        let a = Arc::clone(&accumulator);
+        let a = accumulator.clone();
         std::thread::spawn(move || {
             printer::accumulate(stdout, concat!(module_path!(), "::stdout"), a)
         });

--- a/sw/host/tests/ownership/flash_permission_test.rs
+++ b/sw/host/tests/ownership/flash_permission_test.rs
@@ -7,7 +7,6 @@ use anyhow::{Result, anyhow};
 use clap::Parser;
 use regex::Regex;
 use std::path::PathBuf;
-use std::rc::Rc;
 use std::time::Duration;
 
 use opentitanlib::app::TransportWrapper;
@@ -150,7 +149,7 @@ fn flash_info_check(info: &[FlashRegion<'_>], unlocked: bool) -> Result<()> {
 
 fn flash_permission_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
-    let rescue = RescueSerial::new(Rc::clone(&uart));
+    let rescue = RescueSerial::new(uart.clone());
 
     log::info!("###### Get Boot Log (1/2) ######");
     let (data, devid) = transfer_lib::get_device_info(transport, &rescue)?;

--- a/sw/host/tests/ownership/newversion_test.rs
+++ b/sw/host/tests/ownership/newversion_test.rs
@@ -7,7 +7,6 @@ use anyhow::{Result, anyhow, ensure};
 use clap::Parser;
 use regex::Regex;
 use std::path::PathBuf;
-use std::rc::Rc;
 use std::time::Duration;
 
 use opentitanlib::app::TransportWrapper;
@@ -64,7 +63,7 @@ struct Opts {
 
 fn newversion_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
-    let rescue = RescueSerial::new(Rc::clone(&uart));
+    let rescue = RescueSerial::new(uart.clone());
 
     log::info!("###### Get Device Info ######");
     rescue.enter(transport, /*reset=*/ true)?;

--- a/sw/host/tests/ownership/rescue_limit_test.rs
+++ b/sw/host/tests/ownership/rescue_limit_test.rs
@@ -7,7 +7,6 @@ use anyhow::{Result, anyhow};
 use clap::Parser;
 use regex::Regex;
 use std::path::PathBuf;
-use std::rc::Rc;
 use std::time::Duration;
 
 use opentitanlib::app::TransportWrapper;
@@ -62,7 +61,7 @@ struct Opts {
 
 fn flash_limit_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
-    let rescue = RescueSerial::new(Rc::clone(&uart));
+    let rescue = RescueSerial::new(uart.clone());
 
     log::info!("###### Get Boot Log (1/2) ######");
     let (data, devid) = transfer_lib::get_device_info(transport, &rescue)?;

--- a/sw/host/tests/ownership/rescue_permission_test.rs
+++ b/sw/host/tests/ownership/rescue_permission_test.rs
@@ -7,7 +7,6 @@ use anyhow::{Result, anyhow};
 use clap::Parser;
 use regex::Regex;
 use std::path::PathBuf;
-use std::rc::Rc;
 use std::time::Duration;
 
 use opentitanlib::app::TransportWrapper;
@@ -54,7 +53,7 @@ struct Opts {
 
 fn rescue_permission_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
-    let rescue = RescueSerial::new(Rc::clone(&uart));
+    let rescue = RescueSerial::new(uart.clone());
 
     log::info!("###### Get Boot Log (1/2) ######");
     let (data, devid) = transfer_lib::get_device_info(transport, &rescue)?;

--- a/sw/host/tests/ownership/transfer_test.rs
+++ b/sw/host/tests/ownership/transfer_test.rs
@@ -7,7 +7,6 @@ use anyhow::{Result, anyhow};
 use clap::Parser;
 use regex::Regex;
 use std::path::PathBuf;
-use std::rc::Rc;
 use std::time::Duration;
 
 use opentitanlib::app::TransportWrapper;
@@ -87,7 +86,7 @@ fn remember(haystack: &str, re: &str, memory: &mut Vec<String>) -> bool {
 
 fn transfer_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
-    let rescue = RescueSerial::new(Rc::clone(&uart));
+    let rescue = RescueSerial::new(uart.clone());
 
     let mut keygen = Vec::new();
 


### PR DESCRIPTION
`Rc::clone` was previously a recommended way of cloning a reference-counted pointer however this is not the case anymore (relevant clippy warning has been moved to pedantic instead of enabled by default quite a while back, for example).

We use mostly `Rc<dyn Trait>` which can never be deeply copied anyway, as `Clone` is not dyn-safe.

This change makes it easier to replace `Rc` with `Arc` in the future.