### PR TITLE
[rom_ext] Print owner_block versions during boot

### DIFF
--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -294,6 +294,7 @@ cc_library(
             "//sw/device/silicon_creator/lib/drivers:watchdog",
             "//sw/device/silicon_creator/lib/ownership",
             "//sw/device/silicon_creator/lib/ownership:isfb",
+            "//sw/device/silicon_creator/lib/ownership:owner_block",
             "//sw/device/silicon_creator/lib/ownership:owner_verify",
             "//sw/device/silicon_creator/lib/ownership:ownership_activate",
             "//sw/device/silicon_creator/lib/ownership:ownership_unlock",

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -41,6 +41,7 @@
 #include "sw/device/silicon_creator/lib/manifest.h"
 #include "sw/device/silicon_creator/lib/manifest_def.h"
 #include "sw/device/silicon_creator/lib/ownership/isfb.h"
+#include "sw/device/silicon_creator/lib/ownership/owner_block.h"
 #include "sw/device/silicon_creator/lib/ownership/owner_verify.h"
 #include "sw/device/silicon_creator/lib/ownership/ownership.h"
 #include "sw/device/silicon_creator/lib/ownership/ownership_activate.h"
@@ -548,6 +549,9 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   // Initialize the chip ownership state.
   rom_error_t error;
   error = ownership_init(boot_data, &owner_config, &keyring);
+  dbg_printf("owner_page: %u-%C/%u-%C\r\n", owner_page[0].config_version,
+             owner_page_valid[0], owner_page[1].config_version,
+             owner_page_valid[1]);
   if (error == kErrorWriteBootdataThenReboot) {
     return error;
   }


### PR DESCRIPTION
This change prints the owner_page config versions to the debug UART during ROM_EXT boot to assist in debugging owner block issues.

The existing `ownership: %C\r\n", bootdata->ownership_state` line in `ownership.c` was preserved because it provides the ownership state before the updates. OTOH, a new line was added to specifically print the **finalized** owner_page config version and status, which is more relevant after all ownership operations.