### PR TITLE
[opentitanlib] make `UartConsole::wait_for` handle line buffering

### DIFF
--- a/sw/host/opentitanlib/src/uart/console.rs
+++ b/sw/host/opentitanlib/src/uart/console.rs
@@ -222,7 +222,10 @@ impl UartConsole {
         }
     }
 
-    pub fn wait_for<T>(device: &T, rx: &str, timeout: Duration) -> Result<Vec<String>>
+    /// Wait on the console until the regex matches the input.
+    ///
+    /// The input is processed one byte at a time, and is accumulated until match happens.
+    pub fn wait_for_bytes<T>(device: &T, rx: &str, timeout: Duration) -> Result<Vec<String>>
     where
         T: ConsoleDevice + ?Sized,
     {
@@ -251,5 +254,18 @@ impl UartConsole {
             ExitStatus::Timeout => Err(ConsoleError::GenericError("Timed Out".into()).into()),
             _ => Err(anyhow!("Impossible result: {:?}", result)),
         }
+    }
+
+    /// Wait on the console until the regex matches the input.
+    ///
+    /// The input is processed one line at a time. Lines that does not match the input is discarded.
+    pub fn wait_for<T>(device: &T, rx: &str, timeout: Duration) -> Result<Vec<String>>
+    where
+        T: ConsoleDevice + ?Sized,
+    {
+        // TODO: Optimize me to read a full line first.
+        let mut v = Self::wait_for_bytes(device, &format!("({rx}).*\n"), timeout)?;
+        v.remove(0);
+        Ok(v)
     }
 }

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -569,7 +569,7 @@ pub fn check_slot_b_boot_up(
 ) -> Result<()> {
     transport.reset_target(init.bootstrap.options.reset_delay, true)?;
     let uart_console = transport.uart("console")?;
-    let result = UartConsole::wait_for(&*uart_console, r"ROM_EXT:(.*)\r\n", timeout)?;
+    let result = UartConsole::wait_for(&*uart_console, r"ROM_EXT:(.*)\r", timeout)?;
     response.stats.log_string(
         "rom_ext-version",
         result

--- a/sw/host/tests/attestation/attestation_test.rs
+++ b/sw/host/tests/attestation/attestation_test.rs
@@ -91,7 +91,7 @@ fn check_public_key(key: &SubjectPublicKeyInfo, id: &[u8], subject: &Name) -> Re
 
 fn attestation_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
-    let capture = UartConsole::wait_for(
+    let capture = UartConsole::wait_for_bytes(
         &*uart,
         r"(?msR)Running.*PASS!$|FAIL!$|BFV:([0-9A-Fa-f]{8})$",
         opts.timeout,

--- a/sw/host/tests/chip/example_sival/main.rs
+++ b/sw/host/tests/chip/example_sival/main.rs
@@ -65,7 +65,7 @@ fn example_test(opts: &Opts, uart: &dyn Uart, phase_address: u32) -> Result<()> 
     /* Wait for device to be ready and change phase. */
     check_and_set_phase(uart, phase_address, Phase::WaitHost2, Phase::TestDone)?;
     /* Wait for test to end. */
-    let _ = UartConsole::wait_for(uart, r"PASS![^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(uart, r"PASS!", opts.timeout)?;
     Ok(())
 }
 
@@ -89,7 +89,7 @@ fn main() -> Result<()> {
     let transport = opts.init.init_target()?;
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     execute_test!(example_test, &opts, &*uart, *phase_address,);
     Ok(())

--- a/sw/host/tests/chip/flash_ctrl/src/main.rs
+++ b/sw/host/tests/chip/flash_ctrl/src/main.rs
@@ -46,7 +46,7 @@ fn test_update_phase(
 ) -> Result<()> {
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Starting [^\r\n]*", _opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Starting ", _opts.timeout)?;
     let _ = uart.clear_rx_buffer();
     MemWrite32Req::execute(&*uart, test_word_address, value)?;
     Ok(())
@@ -57,7 +57,7 @@ fn test_end(opts: &Opts, end_test_address: u32, transport: &TransportWrapper) ->
     let end_test_value = MemRead32Req::execute(&*uart, end_test_address)?;
     assert!(end_test_value == 0);
     MemWrite32Req::execute(&*uart, end_test_address, /*value=*/ 1)?;
-    let _ = UartConsole::wait_for(&*uart, r"test_end[^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"test_end", opts.timeout)?;
     Ok(())
 }
 

--- a/sw/host/tests/chip/gpio/src/gpio_intr.rs
+++ b/sw/host/tests/chip/gpio/src/gpio_intr.rs
@@ -375,7 +375,7 @@ fn main() -> Result<()> {
 
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"gpio_intr_test [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"gpio_intr_test ", opts.timeout)?;
 
     execute_test!(test_gpio_inputs, &opts, &transport);
     execute_test!(test_gpio_outputs, &opts, &transport);

--- a/sw/host/tests/chip/gpio/src/gpio_pinmux.rs
+++ b/sw/host/tests/chip/gpio/src/gpio_pinmux.rs
@@ -388,7 +388,7 @@ fn main() -> Result<()> {
 
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     execute_test!(test_gpio_outputs, &transport, &config);
     execute_test!(test_gpio_inputs, &transport, &config);

--- a/sw/host/tests/chip/gpio/src/sleep_pin_retention.rs
+++ b/sw/host/tests/chip/gpio/src/sleep_pin_retention.rs
@@ -50,7 +50,7 @@ fn sleep_pin_retention_test(opts: &Opts, transport: &TransportWrapper) -> Result
         transport.gpio_pin(pin)?.set_mode(PinMode::Input)?;
     }
 
-    let vec = UartConsole::wait_for(&*uart, r"Num Rounds: +([0-9]+)\r\n", opts.timeout)?;
+    let vec = UartConsole::wait_for(&*uart, r"Num Rounds: +([0-9]+)", opts.timeout)?;
     let num_rounds: i32 = vec[1].parse()?;
     log::info!("Doing {:?} rounds of testing", num_rounds);
 

--- a/sw/host/tests/chip/gpio/src/sleep_pin_wake.rs
+++ b/sw/host/tests/chip/gpio/src/sleep_pin_wake.rs
@@ -132,7 +132,7 @@ fn sleep_pin_wake_test(
     MemWriteReq::execute(&*uart, sival_mio_pad_addr, &[rand_pad_index as u8])?;
 
     let pad_sel_match =
-        UartConsole::wait_for(&*uart, r"Pad Selection: (\d) / (\d+)\r\n", opts.timeout)?;
+        UartConsole::wait_for(&*uart, r"Pad Selection: (\d) / (\d+)", opts.timeout)?;
     let pad_sel: usize = pad_sel_match[2].parse()?;
     let wake_pin = transport.gpio_pin(MIO_PADS[pad_sel].name)?;
 

--- a/sw/host/tests/chip/i2c_host_override/src/main.rs
+++ b/sw/host/tests/chip/i2c_host_override/src/main.rs
@@ -53,11 +53,7 @@ fn test_override(
     let output = &[0x03; SAMPLES];
     let waveform = Box::new([BitbangEntry::Both(output, &mut samples)]);
 
-    UartConsole::wait_for(
-        &*uart,
-        r".*SiVal: waiting for commands.*?[^\r\n]*",
-        opts.timeout,
-    )?;
+    UartConsole::wait_for(&*uart, r"SiVal: waiting for commands", opts.timeout)?;
     MemWriteReq::execute(&*uart, backdoor_start_addr, &[1u8])?;
 
     gpio_bitbanging.run(

--- a/sw/host/tests/chip/i2c_target/src/main.rs
+++ b/sw/host/tests/chip/i2c_target/src/main.rs
@@ -306,7 +306,7 @@ fn main() -> Result<()> {
 
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
     uart.clear_rx_buffer()?;
 
     for i2c_instance in 0..3 {
@@ -325,7 +325,7 @@ fn main() -> Result<()> {
 
     transport.pin_strapping("RESET")?.apply()?;
     transport.pin_strapping("RESET")?.remove()?;
-    UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     // The hyperdebug board does not like that pins mode are constantly changed,
     // so this commit separate the sub-tests that use the hyperdebug i2c from

--- a/sw/host/tests/chip/i2c_target/src/smbus_arp.rs
+++ b/sw/host/tests/chip/i2c_target/src/smbus_arp.rs
@@ -158,25 +158,25 @@ fn test_smbus_arp_sequence(
     log::info!("Prepare to ARP");
     if let Err(x) = prepare_to_arp(&i2c) {
         // These parts are mostly to print out more console info on failures.
-        let _ = UartConsole::wait_for(&*uart, r"FAIL[^\r\n]*", opts.timeout)?;
+        let _ = UartConsole::wait_for(&*uart, r"FAIL", opts.timeout)?;
         return Err(x);
     }
     if let Err(x) = reset_device(&i2c) {
-        let _ = UartConsole::wait_for(&*uart, r"FAIL[^\r\n]*", opts.timeout)?;
+        let _ = UartConsole::wait_for(&*uart, r"FAIL", opts.timeout)?;
         return Err(x);
     }
 
     log::info!("Get UDID");
     let mut udid = [0u8; 16];
     if let Err(x) = get_udid(&i2c, &mut udid) {
-        let _ = UartConsole::wait_for(&*uart, r"FAIL[^\r\n]*", opts.timeout)?;
+        let _ = UartConsole::wait_for(&*uart, r"FAIL", opts.timeout)?;
         return Err(x);
     }
     assert_eq!(udid, expected_udid);
 
     log::info!("Assign address");
     assign_address(&i2c, &udid, 0x57u8)?;
-    let _ = UartConsole::wait_for(&*uart, r"New i2c address assigned[^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"New i2c address assigned", opts.timeout)?;
 
     let msg_to_dut = [0xa5u8; 32];
     log::info!("Issue unsupported command");
@@ -189,17 +189,17 @@ fn test_smbus_arp_sequence(
     }
     log::info!("Write scratch");
     if let Err(x) = write_scratch(&i2c, 0x57u8, MESSAGE_REG, &msg_to_dut) {
-        let _ = UartConsole::wait_for(&*uart, r"FAIL[^\r\n]*", opts.timeout)?;
+        let _ = UartConsole::wait_for(&*uart, r"FAIL", opts.timeout)?;
         return Err(x);
     }
     log::info!("Read scratch");
     let mut msg_from_dut = [0u8; 32];
     if let Err(x) = read_scratch(&i2c, 0x57u8, MESSAGE_REG, &mut msg_from_dut) {
-        let _ = UartConsole::wait_for(&*uart, r"FAIL[^\r\n]*", opts.timeout)?;
+        let _ = UartConsole::wait_for(&*uart, r"FAIL", opts.timeout)?;
         return Err(x);
     }
     assert_eq!(msg_to_dut, msg_from_dut);
-    let _ = UartConsole::wait_for(&*uart, r"PASS[^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"PASS", opts.timeout)?;
     Ok(())
 }
 
@@ -228,7 +228,7 @@ fn main() -> Result<()> {
     let transport = opts.init.init_target()?;
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
     uart.clear_rx_buffer()?;
 
     execute_test!(

--- a/sw/host/tests/chip/mem/src/main.rs
+++ b/sw/host/tests/chip/mem/src/main.rs
@@ -70,7 +70,7 @@ fn test_end(opts: &Opts, end_test_address: u32, transport: &TransportWrapper) ->
     let end_test_value = MemRead32Req::execute(&*uart, end_test_address)?;
     assert!(end_test_value == 0);
     MemWrite32Req::execute(&*uart, end_test_address, /*value=*/ 1)?;
-    let _ = UartConsole::wait_for(&*uart, r"PASS![^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"PASS!", opts.timeout)?;
     Ok(())
 }
 
@@ -97,7 +97,7 @@ fn main() -> Result<()> {
     let transport = opts.init.init_target()?;
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
     let _ = uart.clear_rx_buffer();
 
     execute_test!(

--- a/sw/host/tests/chip/ottf_console_with_gpio_tx_indicator/src/main.rs
+++ b/sw/host/tests/chip/ottf_console_with_gpio_tx_indicator/src/main.rs
@@ -53,10 +53,10 @@ fn spi_device_console_test(opts: &Opts, transport: &TransportWrapper) -> Result<
     // Wait for generic strings to be transmitted.
     for _ in 0..2 {
         // Receive simple string from the device.
-        _ = UartConsole::wait_for(&spi_console_device, "ABC", opts.timeout)?;
+        _ = UartConsole::wait_for_bytes(&spi_console_device, "ABC", opts.timeout)?;
 
         // Receive 4K of data from the device.
-        _ = UartConsole::wait_for(&spi_console_device, data_str, opts.timeout)?;
+        _ = UartConsole::wait_for_bytes(&spi_console_device, data_str, opts.timeout)?;
     }
 
     // Receive the UJSON string transmitted and verify its contents.

--- a/sw/host/tests/chip/pattgen/pattgen_ios.rs
+++ b/sw/host/tests/chip/pattgen/pattgen_ios.rs
@@ -573,9 +573,9 @@ fn main() -> Result<()> {
 
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
-    let res = UartConsole::wait_for(&*uart, r"peripheral frequency: ([0-9]+)\r\n", opts.timeout)?;
+    let res = UartConsole::wait_for(&*uart, r"peripheral frequency: ([0-9]+)", opts.timeout)?;
     let clk_io_freq_hz: u64 = res[1]
         .parse()
         .context("could not parse peripheral frequency")?;

--- a/sw/host/tests/chip/power_virus/src/main.rs
+++ b/sw/host/tests/chip/power_virus/src/main.rs
@@ -67,7 +67,7 @@ fn main() -> Result<()> {
     let transport = opts.init.init_target()?;
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     execute_test!(power_virus_systemtest, &opts, &transport);
     Ok(())

--- a/sw/host/tests/chip/pwm_smoketest/src/main.rs
+++ b/sw/host/tests/chip/pwm_smoketest/src/main.rs
@@ -112,7 +112,7 @@ fn main() -> Result<()> {
 
     // Wait until test is running.
     let uart = transport.uart("console")?;
-    UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     /* Load the ELF binary and get the expect data.*/
     let elf_binary = fs::read(&opts.firmware_elf)?;

--- a/sw/host/tests/chip/rv_dm/src/access_after_hw_reset.rs
+++ b/sw/host/tests/chip/rv_dm/src/access_after_hw_reset.rs
@@ -41,7 +41,7 @@ fn test_access_after_hw_reset(
     // Enable console and wait for the message.
     let uart = &*transport.uart("console")?;
     uart.set_flow_control(true)?;
-    UartConsole::wait_for(uart, r"Running [^\r\n]*", opts.timeout)?;
+    UartConsole::wait_for(uart, r"Running ", opts.timeout)?;
     UartConsole::wait_for(uart, r"Waiting for commands", opts.timeout)?;
 
     // Check debugger is available.

--- a/sw/host/tests/chip/rv_dm/src/access_after_wakeup.rs
+++ b/sw/host/tests/chip/rv_dm/src/access_after_wakeup.rs
@@ -46,7 +46,7 @@ fn test_access_after_wakeup(
     // Enable console and wait for the message.
     let uart = &*transport.uart("console")?;
     uart.set_flow_control(true)?;
-    UartConsole::wait_for(uart, r"Running [^\r\n]*", opts.timeout)?;
+    UartConsole::wait_for(uart, r"Running ", opts.timeout)?;
     UartConsole::wait_for(uart, r"Software Setup.", opts.timeout)?;
 
     // Write to progbuf0 and and confirm readback.
@@ -74,7 +74,7 @@ fn test_access_after_wakeup(
     MemWriteReq::execute(uart, software_barrier_addr, &[1])?;
 
     // Wait for the software to fall asleep.
-    UartConsole::wait_for(uart, r"Entering normal sleep.\r\n", opts.timeout)?;
+    UartConsole::wait_for(uart, r"Entering normal sleep.", opts.timeout)?;
 
     // Press the power button to wake up the device.
     log::info!("Pushing power button.");
@@ -104,7 +104,7 @@ fn test_access_after_wakeup(
     MemWriteReq::execute(uart, software_barrier_addr, &[2])?;
 
     // Wait for the software to fall asleep.
-    UartConsole::wait_for(uart, r"Entering deep sleep.\r\n", opts.timeout)?;
+    UartConsole::wait_for(uart, r"Entering deep sleep.", opts.timeout)?;
 
     // Press the power button to wake up the device.
     log::info!("Pushing power button.");

--- a/sw/host/tests/chip/rv_dm/src/ndm_reset_req.rs
+++ b/sw/host/tests/chip/rv_dm/src/ndm_reset_req.rs
@@ -34,7 +34,7 @@ fn test_ndm_reset_req(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     // Enable console and wait for the message.
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     // Connect via JTAG and trigger a NDM reset
     let mut jtag = opts

--- a/sw/host/tests/chip/rv_dm/src/ndm_reset_req_when_cpu_halted.rs
+++ b/sw/host/tests/chip/rv_dm/src/ndm_reset_req_when_cpu_halted.rs
@@ -36,7 +36,7 @@ fn test_ndm_reset_req_when_halted(opts: &Opts, transport: &TransportWrapper) -> 
     // Enable console and wait for the message.
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     log::info!("Waiting for \"Ready for CPU halt request\" message");
     let _ = UartConsole::wait_for(&*uart, "Ready for CPU halt request", opts.timeout)?;

--- a/sw/host/tests/chip/spi_device/src/spi_device_flash_smoketest.rs
+++ b/sw/host/tests/chip/spi_device/src/spi_device_flash_smoketest.rs
@@ -35,7 +35,7 @@ struct Opts {
     firmware_elf: PathBuf,
 }
 
-const SYNC_MSG: &str = r"SYNC:.*\r\n";
+const SYNC_MSG: &str = r"SYNC:";
 
 fn device_tx_rx_test(
     opts: &Opts,

--- a/sw/host/tests/chip/spi_device/src/spi_device_sleep_test.rs
+++ b/sw/host/tests/chip/spi_device/src/spi_device_sleep_test.rs
@@ -114,13 +114,13 @@ fn main() -> Result<()> {
 }
 
 fn wait_sleep(gpio: &dyn GpioPin, uart: &dyn Uart, timeout: Duration) -> Result<()> {
-    let _ = UartConsole::wait_for(uart, r"SYNC: Sleeping\r\n", timeout)?;
+    let _ = UartConsole::wait_for(uart, r"SYNC: Sleeping", timeout)?;
     while gpio.read()? {}
     Ok(())
 }
 
 fn wait_awake(gpio: &dyn GpioPin, uart: &dyn Uart, timeout: Duration) -> Result<()> {
     while !gpio.read()? {}
-    let _ = UartConsole::wait_for(uart, r"SYNC: Awaked\r\n", timeout)?;
+    let _ = UartConsole::wait_for(uart, r"SYNC: Awaked", timeout)?;
     Ok(())
 }

--- a/sw/host/tests/chip/spi_device/src/spi_device_tpm_test.rs
+++ b/sw/host/tests/chip/spi_device/src/spi_device_tpm_test.rs
@@ -38,14 +38,14 @@ fn tpm_read_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     transport.pin_strapping("SPI_TPM")?.apply()?;
 
     /* Wait sync message. */
-    let _ = UartConsole::wait_for(&*uart, r"SYNC: Begin TPM Test\r\n", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"SYNC: Begin TPM Test", opts.timeout)?;
     let tpm = tpm::SpiDriver::new(spi, false)?;
     const SIZE: usize = 10;
 
     for _ in 0..10 {
         let test_data: Vec<u8> = (0..SIZE).map(|_| rand::random()).collect();
         tpm.write_register(tpm::Register::DATA_FIFO, &test_data)?;
-        let _ = UartConsole::wait_for(&*uart, r"SYNC: Waiting Read\r\n", opts.timeout)?;
+        let _ = UartConsole::wait_for(&*uart, r"SYNC: Waiting Read", opts.timeout)?;
         let mut buffer = [0xFFu8; SIZE];
         tpm.read_register(tpm::Register::DATA_FIFO, &mut buffer)?;
         assert_eq!(buffer, &test_data[0..SIZE]);

--- a/sw/host/tests/chip/spi_device/src/spi_host_config_test.rs
+++ b/sw/host/tests/chip/spi_device/src/spi_host_config_test.rs
@@ -65,25 +65,13 @@ fn spi_host_config_test(
     output[output.len() - 2] = 0x0f; // A rising edge on the D1 to indicate when the sampling finished, which is helpfull when debugging.
     let waveform = Box::new([BitbangEntry::Both(output, &mut samples)]);
 
-    UartConsole::wait_for(
-        &*uart,
-        r".*SiVal: waiting for commands.*?[^\r\n]*",
-        opts.timeout,
-    )?;
+    UartConsole::wait_for(&*uart, r"SiVal: waiting for commands", opts.timeout)?;
     MemWriteReq::execute(&*uart, ctx.backdoor_cpha, &[ctx.cpha])?;
 
-    UartConsole::wait_for(
-        &*uart,
-        r".*SiVal: waiting for commands.*?[^\r\n]*",
-        opts.timeout,
-    )?;
+    UartConsole::wait_for(&*uart, r"SiVal: waiting for commands", opts.timeout)?;
     MemWriteReq::execute(&*uart, ctx.backdoor_cpol, &[ctx.cpol])?;
 
-    UartConsole::wait_for(
-        &*uart,
-        r".*SiVal: waiting for commands.*?[^\r\n]*",
-        opts.timeout,
-    )?;
+    UartConsole::wait_for(&*uart, r"SiVal: waiting for commands", opts.timeout)?;
     MemWriteReq::execute(&*uart, ctx.backdoor_data, &[0xAB, 0xCD, 0xEF, 0xAB])?;
     gpio_bitbanging.run(
         &ctx.gpio_pins

--- a/sw/host/tests/chip/spi_device/src/spi_passthru.rs
+++ b/sw/host/tests/chip/spi_device/src/spi_passthru.rs
@@ -504,7 +504,7 @@ fn main() -> Result<()> {
 
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
     uart.clear_rx_buffer()?;
 
     execute_test!(

--- a/sw/host/tests/chip/spi_device_ujson_console_test/src/main.rs
+++ b/sw/host/tests/chip/spi_device_ujson_console_test/src/main.rs
@@ -36,7 +36,7 @@ struct Opts {
     firmware_elf: PathBuf,
 }
 
-const SYNC_MSG: &str = r"SYNC:.*\r\n";
+const SYNC_MSG: &str = r"SYNC:";
 
 fn test_perso_blob_strcut(opts: &Opts, spi_console: &SpiConsoleDevice) -> Result<()> {
     UartConsole::wait_for(spi_console, SYNC_MSG, opts.timeout)?;
@@ -83,7 +83,7 @@ fn test_end(opts: &Opts, end_test_address: u32, spi_console: &SpiConsoleDevice) 
     let end_test_value = MemRead32Req::execute(spi_console, end_test_address)?;
     assert!(end_test_value == 0);
     MemWrite32Req::execute(spi_console, end_test_address, /*value=*/ 1)?;
-    let _ = UartConsole::wait_for(spi_console, r"PASS![^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(spi_console, r"PASS!", opts.timeout)?;
     Ok(())
 }
 
@@ -110,7 +110,7 @@ fn main() -> Result<()> {
     let transport = opts.init.init_target()?;
     let spi = transport.spi(&opts.console_spi)?;
     let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
-    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     execute_test!(test_perso_blob_strcut, &opts, &spi_console_device);
     execute_test!(

--- a/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_ec_rst_l.rs
+++ b/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_ec_rst_l.rs
@@ -226,7 +226,7 @@ fn main() -> Result<()> {
 
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     execute_test!(
         chip_sw_sysrst_ctrl_input,

--- a/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_in_irq.rs
+++ b/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_in_irq.rs
@@ -171,7 +171,7 @@ fn main() -> Result<()> {
 
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     execute_test!(
         chip_sw_sysrst_ctrl_in_irq,

--- a/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_inputs.rs
+++ b/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_inputs.rs
@@ -131,7 +131,7 @@ fn main() -> Result<()> {
 
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     execute_test!(
         chip_sw_sysrst_ctrl_input,

--- a/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_outputs.rs
+++ b/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_outputs.rs
@@ -218,7 +218,7 @@ fn main() -> Result<()> {
 
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     execute_test!(
         chip_sw_sysrst_ctrl_input,

--- a/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_reset.rs
+++ b/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_reset.rs
@@ -165,7 +165,7 @@ fn main() -> Result<()> {
     let transport = opts.init.init_target()?;
 
     let uart = transport.uart("console")?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     execute_test!(
         chip_sw_sysrst_ctrl_reset,

--- a/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_ulp_z3_wakeup.rs
+++ b/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_ulp_z3_wakeup.rs
@@ -213,7 +213,7 @@ fn main() -> Result<()> {
 
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     // Setup transport pins.
     setup_pins(&transport, &CONFIG)?;

--- a/sw/host/tests/chip/uart/src/uart_baud_rate.rs
+++ b/sw/host/tests/chip/uart/src/uart_baud_rate.rs
@@ -117,11 +117,7 @@ fn uart_baud_rate(
     // Keep repeating the test for various Bauds until the device tells us it's
     // `PASS`ed.
     loop {
-        let msg = UartConsole::wait_for(
-            console,
-            r"PASS![^\r\n]*|Starting test[^\n]*\n",
-            opts.timeout,
-        )?;
+        let msg = UartConsole::wait_for(console, r"PASS!|Starting test", opts.timeout)?;
 
         if msg[0].as_str().contains("PASS") {
             break;
@@ -135,7 +131,7 @@ fn uart_baud_rate(
 
         // Ask the device to send us some data.
         MemWriteReq::execute(console, *test_phase_addr, &[TestPhase::Send as u8])?;
-        UartConsole::wait_for(console, r"Data sent[^\n]*\n", opts.timeout)?;
+        UartConsole::wait_for(console, r"Data sent", opts.timeout)?;
 
         log::info!("Reading data...");
 

--- a/sw/host/tests/chip/uart/src/uart_loopback.rs
+++ b/sw/host/tests/chip/uart/src/uart_loopback.rs
@@ -117,7 +117,7 @@ fn uart_loopback(
     MemWriteReq::execute(console, *test_phase_addr, &[TestPhase::System as u8])?;
     log::info!("Starting system loopback test");
 
-    UartConsole::wait_for(console, r"PASS![^\r\n]*", opts.timeout)?;
+    UartConsole::wait_for(console, r"PASS!", opts.timeout)?;
 
     Ok(())
 }

--- a/sw/host/tests/chip/uart/src/uart_parity_break.rs
+++ b/sw/host/tests/chip/uart/src/uart_parity_break.rs
@@ -118,7 +118,7 @@ fn uart_parity_break(
     };
 
     // Configure the UART under test and the parity to use.
-    UartConsole::wait_for(console, r"waiting for commands\r\n", opts.timeout)?;
+    UartConsole::wait_for(console, r"waiting for commands", opts.timeout)?;
     MemWriteReq::execute(console, *parity_addr, &[dif_parity])?;
     MemWriteReq::execute(console, *uart_id_addr, &[*uart_id])?;
 
@@ -132,7 +132,7 @@ fn uart_parity_break(
     uart.clear_rx_buffer()?;
 
     // Tell the device to send us some data and check it.
-    UartConsole::wait_for(console, r"waiting for commands\r\n", opts.timeout)?;
+    UartConsole::wait_for(console, r"waiting for commands", opts.timeout)?;
     MemWriteReq::execute(console, *test_phase_addr, &[TestPhase::Send as u8])?;
 
     log::info!("Reading data...");
@@ -144,7 +144,7 @@ fn uart_parity_break(
     assert_eq!(&received_data, tx_rx_data);
 
     // Tell the device to receive some correct data.
-    UartConsole::wait_for(console, r"waiting for commands\r\n", opts.timeout)?;
+    UartConsole::wait_for(console, r"waiting for commands", opts.timeout)?;
     MemWriteReq::execute(console, *test_phase_addr, &[TestPhase::Recv as u8])?;
 
     log::info!("Sending data...");
@@ -152,7 +152,7 @@ fn uart_parity_break(
 
     if *parity != Parity::None {
         // Tell the device to receive some data with the wrong parity.
-        UartConsole::wait_for(console, r"waiting for commands\r\n", opts.timeout)?;
+        UartConsole::wait_for(console, r"waiting for commands", opts.timeout)?;
         MemWriteReq::execute(console, *test_phase_addr, &[TestPhase::RecvErr as u8])?;
 
         let other_parity = match parity {
@@ -167,7 +167,7 @@ fn uart_parity_break(
 
     for _ in 0..4 {
         // Sync with the device.
-        UartConsole::wait_for(console, r"waiting for commands\r\n", opts.timeout)?;
+        UartConsole::wait_for(console, r"waiting for commands", opts.timeout)?;
         MemWriteReq::execute(console, *test_phase_addr, &[TestPhase::BreakErr as u8])?;
 
         // At 115200 baud each character spans ~800us. A 16 character break takes
@@ -179,6 +179,6 @@ fn uart_parity_break(
 
     // The device will tell us whether or not the data with the wrong parity
     // was received okay.
-    UartConsole::wait_for(console, r"PASS![^\r\n]*", opts.timeout)?;
+    UartConsole::wait_for(console, r"PASS!", opts.timeout)?;
     Ok(())
 }

--- a/sw/host/tests/chip/uart/src/uart_tx_rx.rs
+++ b/sw/host/tests/chip/uart/src/uart_tx_rx.rs
@@ -100,7 +100,7 @@ fn uart_tx_rx(
     uart.set_parity(Parity::None)
         .context("failed to set parity")?;
 
-    UartConsole::wait_for(console, r"Executing the test[^\n]*\n", opts.timeout)?;
+    UartConsole::wait_for(console, r"Executing the test", opts.timeout)?;
 
     log::info!("Sending data...");
     uart.write(&tx_rx_data.rx_data)
@@ -126,7 +126,7 @@ fn uart_tx_rx(
     uart.write(&too_much_data)
         .context("failed to write too much data")?;
 
-    UartConsole::wait_for(console, r"PASS![^\r\n]*", opts.timeout)?;
+    UartConsole::wait_for(console, r"PASS!", opts.timeout)?;
 
     Ok(())
 }

--- a/sw/host/tests/chip/usb/usb_harness.rs
+++ b/sw/host/tests/chip/usb/usb_harness.rs
@@ -78,7 +78,7 @@ fn main() -> Result<()> {
 
     // Wait until test is running.
     let uart = transport.uart("console")?;
-    UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     // Enable VBUS sense on the board if necessary.
     if opts.usb.vbus_control_available() {

--- a/sw/host/tests/chip/usb/usbdev_aon_wake.rs
+++ b/sw/host/tests/chip/usb/usbdev_aon_wake.rs
@@ -139,7 +139,7 @@ fn main() -> Result<()> {
     let transport = opts.init.init_target()?;
 
     let uart = transport.uart("console")?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     execute_test!(usbdev_aon_wake, &opts, &transport, &*uart);
 

--- a/sw/host/tests/chip/usb/usbdev_smoketest.rs
+++ b/sw/host/tests/chip/usb/usbdev_smoketest.rs
@@ -68,7 +68,7 @@ fn main() -> Result<()> {
     let transport = opts.init.init_target()?;
 
     let uart = transport.uart("console")?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     // Enable VBUS sense on the board if necessary.
     if opts.usb.vbus_control_available() {

--- a/sw/host/tests/chip/usb/usbdev_suspend.rs
+++ b/sw/host/tests/chip/usb/usbdev_suspend.rs
@@ -310,7 +310,7 @@ fn main() -> Result<()> {
 
     // Wait until test is running.
     let uart = transport.uart("console")?;
-    UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     execute_test!(usbdev_suspend, &opts, &transport, &*uart);
     Ok(())

--- a/sw/host/tests/crypto/acvp/src/main.rs
+++ b/sw/host/tests/crypto/acvp/src/main.rs
@@ -69,7 +69,7 @@ fn run<R: std::io::Read, W: std::io::Write>(
 ) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
     let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
-    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     let acvp_vectors: Vec<AcvpVectors> = serde_json::from_reader(input)?;
     let mut acvp_results: Vec<AcvpResults> = Vec::with_capacity(acvp_vectors.len());

--- a/sw/host/tests/crypto/aes_gcm_nist_kat/src/main.rs
+++ b/sw/host/tests/crypto/aes_gcm_nist_kat/src/main.rs
@@ -138,7 +138,7 @@ fn run_aes_gcm_testcase(
 fn test_aes_gcm(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
     let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
-    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let test_vector_files = &opts.aes_gcm_json;

--- a/sw/host/tests/crypto/aes_nist_kat/src/main.rs
+++ b/sw/host/tests/crypto/aes_nist_kat/src/main.rs
@@ -131,7 +131,7 @@ fn run_aes_testcase(
 fn test_aes(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
     let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
-    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let test_vector_files = &opts.aes_json;

--- a/sw/host/tests/crypto/drbg_kat/src/main.rs
+++ b/sw/host/tests/crypto/drbg_kat/src/main.rs
@@ -129,7 +129,7 @@ fn run_drbg_testcase(
 fn test_drbg(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
     let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
-    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/crypto/ecdh_kat/src/main.rs
+++ b/sw/host/tests/crypto/ecdh_kat/src/main.rs
@@ -221,7 +221,7 @@ fn run_ecdh_testcase(
 fn test_ecdh(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
     let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
-    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0usize;

--- a/sw/host/tests/crypto/ecdsa_kat/src/main.rs
+++ b/sw/host/tests/crypto/ecdsa_kat/src/main.rs
@@ -512,7 +512,7 @@ fn run_ecdsa_testcase(
 fn test_ecdsa(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
     let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
-    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut failures = vec![];

--- a/sw/host/tests/crypto/hash_kat/src/main.rs
+++ b/sw/host/tests/crypto/hash_kat/src/main.rs
@@ -159,7 +159,7 @@ fn run_hash_testcase(
 fn test_hash(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
     let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
-    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/crypto/hmac_kat/src/main.rs
+++ b/sw/host/tests/crypto/hmac_kat/src/main.rs
@@ -127,7 +127,7 @@ fn run_hmac_testcase(
 fn test_hmac(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
     let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
-    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/crypto/kmac_kat/src/main.rs
+++ b/sw/host/tests/crypto/kmac_kat/src/main.rs
@@ -142,7 +142,7 @@ fn run_kmac_testcase(
 fn test_kmac(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
     let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
-    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/crypto/rsa_kat/src/main.rs
+++ b/sw/host/tests/crypto/rsa_kat/src/main.rs
@@ -236,7 +236,7 @@ fn run_rsa_testcase(
 fn test_rsa(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
     let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
-    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     let test_vector_files = &opts.rsa_json;
     for file in test_vector_files {

--- a/sw/host/tests/crypto/sphincsplus_kat/src/main.rs
+++ b/sw/host/tests/crypto/sphincsplus_kat/src/main.rs
@@ -127,7 +127,7 @@ fn run_sphincsplus_testcase(
 fn test_sphincsplus(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
     let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
-    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/ownership/flash_permission_test.rs
+++ b/sw/host/tests/ownership/flash_permission_test.rs
@@ -188,7 +188,7 @@ fn flash_permission_test(opts: &Opts, transport: &TransportWrapper) -> Result<()
         // The flash configuration will be the previous owner in Side A and
         // the new owner in SideB.
         transport.reset_target(Duration::from_millis(50), /*clear_uart=*/ true)?;
-        let capture = UartConsole::wait_for(
+        let capture = UartConsole::wait_for_bytes(
             &*uart,
             r"(?msR)Running(.*)Finished.*PASS!$|BFV:([0-9A-Fa-f]{8})$",
             opts.timeout,
@@ -271,7 +271,7 @@ fn flash_permission_test(opts: &Opts, transport: &TransportWrapper) -> Result<()
     log::info!("###### Boot After Transfer Complete ######");
     // After the activate command, the device should report the ownership state as `OWND`.
     transport.reset_target(Duration::from_millis(50), /*clear_uart=*/ true)?;
-    let capture = UartConsole::wait_for(
+    let capture = UartConsole::wait_for_bytes(
         &*uart,
         r"(?msR)Running(.*)Finished.*PASS!$|BFV:([0-9A-Fa-f]{8})$",
         opts.timeout,

--- a/sw/host/tests/ownership/newversion_test.rs
+++ b/sw/host/tests/ownership/newversion_test.rs
@@ -95,7 +95,7 @@ fn newversion_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
 
     log::info!("###### Boot After Update Complete ######");
     transport.reset_target(Duration::from_millis(50), /*clear_uart=*/ true)?;
-    let capture = UartConsole::wait_for(
+    let capture = UartConsole::wait_for_bytes(
         &*uart,
         r"(?msR)Running.*PASS!$|BFV:([0-9A-Fa-f]{8})$",
         opts.timeout,

--- a/sw/host/tests/ownership/rescue_limit_test.rs
+++ b/sw/host/tests/ownership/rescue_limit_test.rs
@@ -129,7 +129,7 @@ fn flash_limit_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     // verify that the firmware segement is programmed (value 0) and the
     // filesystem segment remains unprogramed (value ffffffff).
     transport.reset_target(Duration::from_millis(50), /*clear_uart=*/ true)?;
-    let capture = UartConsole::wait_for(
+    let capture = UartConsole::wait_for_bytes(
         &*uart,
         r"(?msR)flash 0x2006f800 = (\w+)$.*flash 0x20070000 = (\w+)$.*PASS!$|BFV:([0-9A-Fa-f]{8})$",
         opts.timeout,

--- a/sw/host/tests/ownership/transfer_test.rs
+++ b/sw/host/tests/ownership/transfer_test.rs
@@ -92,7 +92,7 @@ fn transfer_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
 
     if opts.pre_transfer_boot_check {
         log::info!("###### Pre-transfer Boot Check ######");
-        let capture = UartConsole::wait_for(
+        let capture = UartConsole::wait_for_bytes(
             &*uart,
             r"(?msR)Running.*ownership_state = (\w+)$.*PASS!$|BFV:([0-9A-Fa-f]{8})$",
             opts.timeout,
@@ -143,7 +143,7 @@ fn transfer_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         // At this point, the device should be unlocked and should have accepted the owner
         // configuration.  Owner code should run and report the ownership state.
         transport.reset_target(Duration::from_millis(50), /*clear_uart=*/ true)?;
-        let capture = UartConsole::wait_for(
+        let capture = UartConsole::wait_for_bytes(
             &*uart,
             r"(?msR)Running.*ownership_state = (\w+)$.*ownership_transfers = (\d+)$.*PASS!$|BFV:([0-9A-Fa-f]{8})$",
             opts.timeout,
@@ -186,7 +186,7 @@ fn transfer_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     log::info!("###### Boot After Transfer Complete ######");
     // After the activate command, the device should report the ownership state as `OWND`.
     transport.reset_target(Duration::from_millis(50), /*clear_uart=*/ true)?;
-    let capture = UartConsole::wait_for(
+    let capture = UartConsole::wait_for_bytes(
         &*uart,
         r"(?msR)Running.*ownership_state = (\w+)$.*ownership_transfers = (\d+)$.*PASS!$|BFV:([0-9A-Fa-f]{8})$",
         opts.timeout,

--- a/sw/host/tests/penetrationtests/fi_asym_cryptolib/src/main.rs
+++ b/sw/host/tests/penetrationtests/fi_asym_cryptolib/src/main.rs
@@ -132,7 +132,7 @@ fn run_fi_asym_cryptolib_testcase(
 fn test_fi_asym_cryptolib(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/penetrationtests/fi_crypto/src/main.rs
+++ b/sw/host/tests/penetrationtests/fi_crypto/src/main.rs
@@ -138,7 +138,7 @@ fn run_fi_crypto_testcase(
 fn test_fi_crypto(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/penetrationtests/fi_ibex/src/main.rs
+++ b/sw/host/tests/penetrationtests/fi_ibex/src/main.rs
@@ -162,7 +162,7 @@ fn run_fi_ibex_testcase(
 fn test_fi_ibex(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/penetrationtests/fi_lc_ctrl/src/main.rs
+++ b/sw/host/tests/penetrationtests/fi_lc_ctrl/src/main.rs
@@ -164,7 +164,7 @@ fn run_fi_lc_ctrl_testcase(
 fn test_fi_lc_ctrl(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/penetrationtests/fi_otbn/src/main.rs
+++ b/sw/host/tests/penetrationtests/fi_otbn/src/main.rs
@@ -131,7 +131,7 @@ fn run_fi_otbn_testcase(
 fn test_fi_otbn(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/penetrationtests/fi_otp/src/main.rs
+++ b/sw/host/tests/penetrationtests/fi_otp/src/main.rs
@@ -167,7 +167,7 @@ fn run_fi_otp_testcase(
 fn test_fi_otp(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/penetrationtests/fi_rng/src/main.rs
+++ b/sw/host/tests/penetrationtests/fi_rng/src/main.rs
@@ -164,7 +164,7 @@ fn run_fi_rng_testcase(
 fn test_fi_rng(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/penetrationtests/fi_rom/src/main.rs
+++ b/sw/host/tests/penetrationtests/fi_rom/src/main.rs
@@ -119,7 +119,7 @@ fn run_fi_rom_testcase(
 fn test_fi_rom(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/penetrationtests/fi_sym_cryptolib/src/main.rs
+++ b/sw/host/tests/penetrationtests/fi_sym_cryptolib/src/main.rs
@@ -119,7 +119,7 @@ fn run_fi_sym_cryptolib_testcase(
 fn test_fi_sym_cryptolib(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/penetrationtests/sca_aes/src/main.rs
+++ b/sw/host/tests/penetrationtests/sca_aes/src/main.rs
@@ -133,7 +133,7 @@ fn run_sca_aes_testcase(
 fn test_sca_aes(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/penetrationtests/sca_asym_cryptolib/src/main.rs
+++ b/sw/host/tests/penetrationtests/sca_asym_cryptolib/src/main.rs
@@ -132,7 +132,7 @@ fn run_sca_asym_cryptolib_testcase(
 fn test_sca_asym_cryptolib(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/penetrationtests/sca_edn/src/main.rs
+++ b/sw/host/tests/penetrationtests/sca_edn/src/main.rs
@@ -120,7 +120,7 @@ fn run_sca_edn_testcase(
 fn test_sca_edn(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/penetrationtests/sca_hmac/src/main.rs
+++ b/sw/host/tests/penetrationtests/sca_hmac/src/main.rs
@@ -132,7 +132,7 @@ fn run_sca_hmac_testcase(
 fn test_sca_hmac(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/penetrationtests/sca_ibex/src/main.rs
+++ b/sw/host/tests/penetrationtests/sca_ibex/src/main.rs
@@ -110,7 +110,7 @@ fn run_sca_ibex_testcase(
 fn test_sca_ibex(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/penetrationtests/sca_kmac/src/main.rs
+++ b/sw/host/tests/penetrationtests/sca_kmac/src/main.rs
@@ -132,7 +132,7 @@ fn run_sca_kmac_testcase(
 fn test_sca_kmac(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/penetrationtests/sca_otbn/src/main.rs
+++ b/sw/host/tests/penetrationtests/sca_otbn/src/main.rs
@@ -126,7 +126,7 @@ fn run_sca_otbn_testcase(
 fn test_sca_otbn(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/penetrationtests/sca_sha3/src/main.rs
+++ b/sw/host/tests/penetrationtests/sca_sha3/src/main.rs
@@ -144,7 +144,7 @@ fn run_sca_sha3_testcase(
 fn test_sca_sha3(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/penetrationtests/sca_sym_cryptolib/src/main.rs
+++ b/sw/host/tests/penetrationtests/sca_sym_cryptolib/src/main.rs
@@ -119,7 +119,7 @@ fn run_sca_sym_cryptolib_testcase(
 fn test_sca_sym_cryptolib(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;

--- a/sw/host/tests/rom/e2e_chip_specific_startup/src/main.rs
+++ b/sw/host/tests/rom/e2e_chip_specific_startup/src/main.rs
@@ -324,7 +324,7 @@ fn test_chip_specific_startup(opts: &Opts, transport: &TransportWrapper) -> Resu
     // BootstrapOptions first.
     //let uart = opts.init.uart_params.create(&transport)?;
     let uart = transport.uart("console")?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     TestCommand::ChipStartup.send(&*uart)?;
     let response = ChipStartup::recv(&*uart, opts.timeout, false)?;

--- a/sw/host/tests/rom/sw_strap_value/src/main.rs
+++ b/sw/host/tests/rom/sw_strap_value/src/main.rs
@@ -104,7 +104,7 @@ fn test_sw_strap_values(opts: &Opts, transport: &TransportWrapper) -> Result<()>
     // BootstrapOptions first.
     //let uart = opts.init.uart_params.create(&transport)?;
     let uart = transport.uart("console")?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;
 
     for value in 0..64 {
         log::info!(


### PR DESCRIPTION
Majority of tests work on line-buffered data. Currently, many use `.*\r\n` to explicitly handle line ending which is non-ideal. Also, some have `[^\r\n]*` trying to consume until end of line, however this won't work as we are reading 1 byte at a time from UART, so this will match immediately after 1 character.

Make `UartConsole::wait_for` handle the complexity instead. For some tests that expects no line endings or expect multiple lines, `wait_for_bytes` can be used instead.

This also can make `UartConsole` more optimal by not having to do regex matching for each character (to be implemented in subsequent PRs)