### PR TITLE
[rescue,test] enhance rescue error handling tests

### DIFF
--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -777,6 +777,7 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
+        timeout = "long",
         assemble = "{romext}@{rom_ext_slot_a} {firmware}@{owner_slot_a}",
         binaries = {
             "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a": "romext",

--- a/sw/host/tests/rescue/dfu_rescue_error_handling.rs
+++ b/sw/host/tests/rescue/dfu_rescue_error_handling.rs
@@ -311,9 +311,12 @@ fn invalid_spi_flash_transaction(
 fn usb_dfu_out_chunk_too_big(params: &RescueParams, transport: &TransportWrapper) -> Result<()> {
     let rescue = UsbDfu::new(params.clone());
     rescue.enter(transport, EntryMode::Reset)?;
-    rescue.set_mode(RescueMode::Rescue)?;
-    let data = vec![0u8; 4096];
-    let result = rescue.download(&data);
+    rescue.set_mode(RescueMode::RescueB)?;
+    let chunk = vec![0u8; 2048];
+    let chunk_too_big = vec![0u8; 4096];
+
+    rescue.download(&chunk)?;
+    let result = rescue.download(&chunk_too_big);
 
     if result.is_ok() {
         return Err(anyhow!("USB transaction should fail"));


### PR DESCRIPTION
This expands end-to-end tests for rescue error handling to increase test coverage:

- Adds a rescue_image_too_big test for Xmodem to check the handling of oversized firmware images during rescue, ensuring the device correctly cancels the operation and remains functional.
- Modifies the `usb_dfu_out_chunk_too_big` test to first perform a successful chunk download before attempting an oversized one, improving test robustness.