### PR TITLE
[cryptotest] Remove rsa_pss_4096_sha512_mgf1_32 test

### DIFF
--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -186,7 +186,6 @@ RSA_TESTVECTOR_TARGETS = [
     for hash in [
         "sha256_mgf1_32",
         "sha384_mgf1_48",
-        "sha512_mgf1_32",
         "sha512_mgf1_64",
     ]
 ] + [


### PR DESCRIPTION
In `rsa_padding_pss_verify`, `salt_bytelen = digest_bytelen`. Hence, the test where we use a digest bytelen of 64 bytes (for SHA512) but only use a salt bytelen of 32 bytes cannot work.

According to RFC 8017, 9.1.4: "Typical salt lengths in octets are hLen (the length of the output of the hash function Hash) and 0."

Closes #28656.