### PR TITLE
Backport 25964 ([rom] Make the DEV key valid in TEST and RMA)

### DIFF
--- a/rules/opentitan/keyutils.bzl
+++ b/rules/opentitan/keyutils.bzl
@@ -194,6 +194,15 @@ def create_test_key(name, label):
 
 def create_dev_key(name, label):
     return create_key_(name, label, [
+        CONST.LCV.TEST_UNLOCKED0,
+        CONST.LCV.TEST_UNLOCKED1,
+        CONST.LCV.TEST_UNLOCKED2,
+        CONST.LCV.TEST_UNLOCKED3,
+        CONST.LCV.TEST_UNLOCKED4,
+        CONST.LCV.TEST_UNLOCKED5,
+        CONST.LCV.TEST_UNLOCKED6,
+        CONST.LCV.TEST_UNLOCKED7,
+        CONST.LCV.RMA,
         CONST.LCV.DEV,
     ])
 

--- a/sw/device/silicon_creator/rom/doc/sigverify.md
+++ b/sw/device/silicon_creator/rom/doc/sigverify.md
@@ -42,7 +42,7 @@ not depend on the OTP value since it may not have been programmed yet.
 |           | TEST_UNLOCKED | PROD, PROD_END | DEV | RMA |
 |-----------|---------------|----------------|-----|-----|
 | Test keys | Yes           | No             | No  | OTP |
-| Dev keys  | No            | No             | OTP | No  |
+| Dev keys  | Yes           | No             | OTP | OTP |
 | Prod keys | Yes           | OTP            | OTP | OTP |
 
 ### Digest Computation

--- a/sw/device/silicon_creator/rom/sigverify_otp_keys.c
+++ b/sw/device/silicon_creator/rom/sigverify_otp_keys.c
@@ -65,7 +65,7 @@ static rom_error_t key_is_valid_in_lc_state_rma(sigverify_key_type_t key_type) {
       return kErrorOk;
     case kSigverifyKeyTypeDev:
       HARDENED_CHECK_EQ(key_type, kSigverifyKeyTypeDev);
-      return kErrorSigverifyBadKey;
+      return kErrorOk;
     default:
       HARDENED_TRAP();
       OT_UNREACHABLE();
@@ -145,7 +145,7 @@ static rom_error_t key_is_valid_in_lc_state_test(
       return kErrorOk;
     case kSigverifyKeyTypeDev:
       HARDENED_CHECK_EQ(key_type, kSigverifyKeyTypeDev);
-      return kErrorSigverifyBadKey;
+      return kErrorOk;
     default:
       HARDENED_TRAP();
       OT_UNREACHABLE();


### PR DESCRIPTION
Backport #25964. Also update the documentation (this was not present in #25964 but fixed by #28545)