### PR TITLE
Backport #26007 ([rom_ext] Update the ROM_EXT minor version) 

### DIFF
--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -7,7 +7,7 @@
 # because of how the bazel rule accepts attributes.
 ROM_EXT_VERSION = struct(
     MAJOR = "0",
-    MINOR = "1",
+    MINOR = "102",
     SECURITY = "0",
 )
 


### PR DESCRIPTION
Backport #26007 ([rom_ext] Update the ROM_EXT minor version). It is not entirely clear of backporting the minor version change is meaningful or not for master but since some tests or tooling might later depend on reading this version, I think it's safer to backport this.