### PR TITLE
[dpi, verilator]: Upgrade SPI DPI implementation

### DIFF
--- a/hw/dv/dpi/spidpi/spidpi.h
+++ b/hw/dv/dpi/spidpi/spidpi.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_HW_DV_DPI_SPIDPI_SPIDPI_H_
 #define OPENTITAN_HW_DV_DPI_SPIDPI_SPIDPI_H_
 
+#include <stdint.h>
 #include <svdpi.h>
 
 #ifdef __cplusplus
@@ -21,7 +22,7 @@ extern "C" {
 #define P2D_SDI 0x4
 
 void *spidpi_create(const char *name, int mode, int loglevel);
-char spidpi_tick(void *ctx_void, const svLogicVecVal *d2p_data);
+uint8_t spidpi_tick(void *ctx_void, const svLogicVecVal *d2p_data);
 void spidpi_close(void *ctx_void);
 
 // monitor


### PR DESCRIPTION
* use a new protocol, incompatible with the legacy implementation
* the new protocol is much simpler and exposes existing SPI DPI device signals:
  * host-to-device: SCK, SDI, CS
  * device-to-host: SDO, SDO_EN
* there is no longer a limitation (32 bits) on transaction size
* use an ASCII protocol to ease debugging (no overhead)
* use environment variable to select whether to generate log files, and their kind:
  * `M` for "monitor" file, which are very verbose
  * `P` for "protocol" file, more compact to trace communication with SPI host
* tested with JEDEC_ID, SFDP, PAGE_PROGRAM, READ, and HW config commands.