### PR TITLE
[test] implement example CDI_1 key use test boilerplate

### DIFF
--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
@@ -274,3 +274,65 @@ DEBUG_MODE_TESTCASES = [
     for testcase in DEBUG_MODE_TESTCASES
     for variation in ROM_EXT_VARIATIONS.keys()
 ]
+
+[
+    opentitan_binary(
+        name = "cdi1_key_sign_for_assemble_{}".format(i),
+        testonly = True,
+        srcs = ["cdi1_key_sign_test.c"],
+        exec_env = [
+            "//hw/top_earlgrey:fpga_cw310_rom_ext",
+            "//hw/top_earlgrey:fpga_cw340_rom_ext",
+        ],
+        linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
+        local_defines = [
+            "EMPTY_TEST_MSG=\"Test Owner FW - {}.\"".format(i if i < 2 else 0),
+        ],
+        manifest = ":owner_manifest",
+        deps = [
+            "//sw/device/lib/base:status",
+            "//sw/device/lib/runtime:log",
+            "//sw/device/lib/testing/test_framework:check",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+        ],
+    )
+    for i in range(3)
+]
+
+[
+    opentitan_binary_assemble(
+        name = "cdi1_key_sign_rom_ext_owner_bundle_{}".format(i),
+        testonly = True,
+        bins = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a": SLOTS["a"],
+            ":cdi1_key_sign_for_assemble_{}".format(i): OWNER_SLOTS["a"],
+        },
+        exec_env = [
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys",
+            "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys",
+        ],
+    )
+    for i in range(3)
+]
+
+opentitan_test(
+    name = "cdi1_key_sign_test",
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
+    },
+    fpga = fpga_params(
+        binaries = {
+            ":cdi1_key_sign_rom_ext_owner_bundle_0": "firmware",
+            ":cdi1_key_sign_rom_ext_owner_bundle_1": "second",
+            ":cdi1_key_sign_rom_ext_owner_bundle_2": "third",
+        },
+        otp = "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_rma",
+        test_cmd = """
+            --bootstrap={firmware}
+            --second-bootstrap={second}
+            --third-bootstrap={third}
+        """,
+        test_harness = "//sw/host/tests/rom_ext/cdi1_key_sign",
+    ),
+)

--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/cdi1_key_sign_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/cdi1_key_sign_test.c
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/manifest_def.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+#ifdef EMPTY_TEST_MSG
+  LOG_INFO(EMPTY_TEST_MSG);
+#endif
+
+  // TODO: Insert signing operation with CDI_1 key.
+
+  return true;
+}

--- a/sw/host/tests/rom_ext/cdi1_key_sign/BUILD
+++ b/sw/host/tests/rom_ext/cdi1_key_sign/BUILD
@@ -1,0 +1,20 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "cdi1_key_sign",
+    srcs = ["src/main.rs"],
+    deps = [
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:regex",
+    ],
+)

--- a/sw/host/tests/rom_ext/cdi1_key_sign/src/main.rs
+++ b/sw/host/tests/rom_ext/cdi1_key_sign/src/main.rs
@@ -1,0 +1,92 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::uart::console::{ExitStatus, UartConsole};
+
+use anyhow::{anyhow, Context, Result};
+use clap::Parser;
+use regex::Regex;
+
+/// CLI args for this test.
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Second image (ROM_EXT + Owner FW bundle) to bootstrap.
+    #[arg(long)]
+    second_bootstrap: PathBuf,
+
+    /// Third image (ROM_EXT + Owner FW bundle) to bootstrap.
+    #[arg(long)]
+    third_bootstrap: PathBuf,
+
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "30s")]
+    timeout: Duration,
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    // Bootstrap first ROM_EXT + Owner FW.
+    let transport = opts.init.init_target()?;
+    let uart = transport.uart("console").context("failed to get UART")?;
+
+    // Wait for owner FW message.
+    let _ = UartConsole::wait_for(&*uart, r"Test Owner FW - 0", opts.timeout)?;
+
+    // Bootstrap second ROM_EXT + Owner FW.
+    opts.init
+        .bootstrap
+        .load(&transport, &opts.second_bootstrap)?;
+
+    // Wait for owner FW message.
+    let _ = UartConsole::wait_for(&*uart, r"Test Owner FW - 1", opts.timeout)?;
+
+    // Bootstrap second ROM_EXT + Owner FW.
+    opts.init
+        .bootstrap
+        .load(&transport, &opts.third_bootstrap)?;
+
+    // Wait for pass message from owner firmware stage.
+    let mut console = UartConsole {
+        timeout: Some(opts.timeout),
+        exit_success: Some(Regex::new(r"PASS.*\n")?),
+        exit_failure: Some(Regex::new(r"BFV.*\n")?),
+        newline: true,
+        ..Default::default()
+    };
+    let mut stdout = std::io::stdout();
+    let result = console.interact(&*uart, None, Some(&mut stdout))?;
+    match result {
+        ExitStatus::None | ExitStatus::CtrlC => Ok(()),
+        ExitStatus::Timeout => {
+            if console.exit_success.is_some() {
+                Err(anyhow!("Console timeout exceeded"))
+            } else {
+                Ok(())
+            }
+        }
+        ExitStatus::ExitSuccess => {
+            log::info!(
+                "ExitSuccess({:?})",
+                console.captures(result).unwrap().get(0).unwrap().as_str()
+            );
+            Ok(())
+        }
+        ExitStatus::ExitFailure => {
+            log::info!(
+                "ExitFailure({:?})",
+                console.captures(result).unwrap().get(0).unwrap().as_str()
+            );
+            Err(anyhow!("Matched exit_failure expression"))
+        }
+    }
+}


### PR DESCRIPTION
This adds boilerplate code to test the following scenario:
1. booting owner FW to sign something with the CDI_1 key,
2. booting a different owner FW to ensure the key changes and produces a different signature, and
3. booting the same owner FW in 1 to ensure the same signature in 1 can be reproduced.