### PR TITLE
[hmac/cryptolib] Randomize tag

### DIFF
--- a/sw/device/lib/crypto/impl/hmac.c
+++ b/sw/device/lib/crypto/impl/hmac.c
@@ -220,6 +220,8 @@ otcrypto_status_t otcrypto_hmac(const otcrypto_blinded_key_t *key,
       (input_message.data == NULL && input_message.len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
+  // Preload the tag with randomness.
+  HARDENED_TRY(hardened_memshred(tag.data, tag.len));
 
   // Check the security config of the device.
   HARDENED_TRY(security_config_check(key->config.security_level));


### PR DESCRIPTION
Memshred the tag at the start of the otcrypto_hmac call for fault protection. This clears the hmac from any found issue from instruction skip testing.