### PR TITLE
[memory/cryptolib] Launder status output

### DIFF
--- a/sw/device/lib/base/hardened_memory.c
+++ b/sw/device/lib/base/hardened_memory.c
@@ -47,7 +47,7 @@ status_t hardened_memcpy(uint32_t *restrict dest, const uint32_t *restrict src,
   RANDOM_ORDER_HARDENED_CHECK_DONE(order);
   HARDENED_CHECK_EQ(count, word_len);
 
-  return OTCRYPTO_OK;
+  return (status_t){.value = (int32_t)launder32((uint32_t)OTCRYPTO_OK.value)};
 }
 
 status_t hardened_memshred(uint32_t *dest, size_t word_len) {
@@ -72,7 +72,7 @@ status_t hardened_memshred(uint32_t *dest, size_t word_len) {
 
   HARDENED_CHECK_EQ(count, word_len);
 
-  return OTCRYPTO_OK;
+  return (status_t){.value = (int32_t)launder32((uint32_t)OTCRYPTO_OK.value)};
 }
 
 hardened_bool_t hardened_memeq(const uint32_t *lhs, const uint32_t *rhs,
@@ -207,7 +207,7 @@ status_t hardened_xor(const uint32_t *restrict x, const uint32_t *restrict y,
   RANDOM_ORDER_HARDENED_CHECK_DONE(order);
   HARDENED_CHECK_EQ(count, word_len);
 
-  return OTCRYPTO_OK;
+  return (status_t){.value = (int32_t)launder32((uint32_t)OTCRYPTO_OK.value)};
 }
 
 status_t hardened_xor_in_place(uint32_t *restrict x, const uint32_t *restrict y,
@@ -239,7 +239,7 @@ status_t hardened_xor_in_place(uint32_t *restrict x, const uint32_t *restrict y,
   RANDOM_ORDER_HARDENED_CHECK_DONE(order);
   HARDENED_CHECK_EQ(count, word_len);
 
-  return OTCRYPTO_OK;
+  return (status_t){.value = (int32_t)launder32((uint32_t)OTCRYPTO_OK.value)};
 }
 
 status_t randomized_bytecopy(void *restrict dest, const void *restrict src,
@@ -265,7 +265,7 @@ status_t randomized_bytecopy(void *restrict dest, const void *restrict src,
   RANDOM_ORDER_HARDENED_CHECK_DONE(order);
   HARDENED_CHECK_EQ(count, byte_len);
 
-  return OTCRYPTO_OK;
+  return (status_t){.value = (int32_t)launder32((uint32_t)OTCRYPTO_OK.value)};
 }
 
 status_t randomized_bytexor_in_place(void *restrict x, const void *restrict y,
@@ -291,5 +291,5 @@ status_t randomized_bytexor_in_place(void *restrict x, const void *restrict y,
   RANDOM_ORDER_HARDENED_CHECK_DONE(order);
   HARDENED_CHECK_EQ(count, byte_len);
 
-  return OTCRYPTO_OK;
+  return (status_t){.value = (int32_t)launder32((uint32_t)OTCRYPTO_OK.value)};
 }

--- a/sw/device/lib/base/hardened_memory.h
+++ b/sw/device/lib/base/hardened_memory.h
@@ -34,7 +34,7 @@ extern uint32_t hardened_memshred_random_word(void);
  * Unlike `memcpy()`, this function has important differences:
  * - It is significantly slower, since it mitigates power-analysis attacks.
  * - It performs operations on 32-bit words, rather than bytes.
- * - It returns void.
+ * - It returns a status.
  *
  * Input pointers *MUST* be 32-bit aligned, although they do not need to
  * actually point to memory declared as `uint32_t` per the C aliasing rules.
@@ -56,7 +56,7 @@ status_t hardened_memcpy(uint32_t *OT_RESTRICT dest,
  * - It is significantly slower, since it mitigates power-analysis attacks.
  * - It performs operations on 32-bit words, rather than bytes.
  * - A fill value cannot be specified.
- * - It returns void.
+ * - It returns a status.
  *
  * Input pointers *MUST* be 32-bit aligned, although they do not need to
  * actually point to memory declared as `uint32_t` per the C aliasing rules.

--- a/sw/device/lib/crypto/impl/rsa/rsa_padding.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_padding.c
@@ -407,7 +407,7 @@ static status_t reverse_bytes(size_t input_len, uint32_t *input) {
   RANDOM_ORDER_HARDENED_CHECK_DONE(order);
   HARDENED_CHECK_EQ(i, num_idx);
 
-  return OTCRYPTO_OK;
+  return (status_t){.value = (int32_t)launder32((uint32_t)OTCRYPTO_OK.value)};
 }
 
 /**


### PR DESCRIPTION
Since the hardened memory operations just return OTCRYPTO_OK the compiler optimizes the status output which circumvents the control flow integrity. An example is

20011276:             |     |         9e2080e7                  jalr
		      -1566(ra) # 2002bc54 <hardened_memcpy>

2001127a:             |     |         73900513                  li
a0,1849

Launder the status output to circumvent this. Once there is another call in place which makes the possibility to return a different status, this launder is no longer needed.

The assembly files were checked for similar patterns, only a single call in RSA had a similar result.