### PR TITLE
[pentest] Set invalid status at start

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym.c
@@ -27,7 +27,7 @@ status_t handle_cryptolib_fi_asym_rsa_enc(ujson_t *uj) {
   // You can give cfg a value such that the RSA generates its own private key.
   // Trigger are over the API calls.
   cryptolib_fi_asym_rsa_enc_out_t uj_output;
-  memset(&uj_output, 0, sizeof(uj_output));
+  uj_output.status = kUnknown;
   uj_output.status =
       (size_t)cryptolib_fi_rsa_enc_impl(uj_input, &uj_output).value;
   /////////////// STUB END ///////////////
@@ -45,7 +45,7 @@ status_t handle_cryptolib_fi_asym_rsa_sign(ujson_t *uj) {
   // You can give cfg a value such that the RSA generates its own private key.
   // Trigger are over the API calls.
   cryptolib_fi_asym_rsa_sign_out_t uj_output;
-  memset(&uj_output, 0, sizeof(uj_output));
+  uj_output.status = kUnknown;
   uj_output.status =
       (size_t)cryptolib_fi_rsa_sign_impl(uj_input, &uj_output).value;
   /////////////// STUB END ///////////////
@@ -62,7 +62,7 @@ status_t handle_cryptolib_fi_asym_rsa_verify(ujson_t *uj) {
   // Perform an RSA verification with hashing and padding options.
   // Trigger are over the API calls.
   cryptolib_fi_asym_rsa_verify_out_t uj_output;
-  memset(&uj_output, 0, sizeof(uj_output));
+  uj_output.status = kUnknown;
   uj_output.status =
       (size_t)cryptolib_fi_rsa_verify_impl(uj_input, &uj_output).value;
   /////////////// STUB END ///////////////
@@ -134,7 +134,7 @@ status_t handle_cryptolib_fi_asym_p256_ecdh(ujson_t *uj) {
   // Perform ecdh in P256.
   // Trigger are over the API calls.
   cryptolib_fi_asym_p256_ecdh_out_t uj_output;
-  memset(&uj_output, 0, sizeof(uj_output));
+  uj_output.status = kUnknown;
   uj_output.status =
       (size_t)cryptolib_fi_p256_ecdh_impl(uj_input, &uj_output).value;
   /////////////// STUB END ///////////////
@@ -151,7 +151,7 @@ status_t handle_cryptolib_fi_asym_p256_sign(ujson_t *uj) {
   // Perform a P256 signature.
   // Trigger are over the API calls.
   cryptolib_fi_asym_p256_sign_out_t uj_output;
-  memset(&uj_output, 0, sizeof(uj_output));
+  uj_output.status = kUnknown;
   uj_output.status =
       (size_t)cryptolib_fi_p256_sign_impl(uj_input, &uj_output).value;
   /////////////// STUB END ///////////////
@@ -168,7 +168,7 @@ status_t handle_cryptolib_fi_asym_p256_verify(ujson_t *uj) {
   // Perform a P256 verification.
   // Trigger are over the API calls.
   cryptolib_fi_asym_p256_verify_out_t uj_output;
-  memset(&uj_output, 0, sizeof(uj_output));
+  uj_output.status = kUnknown;
   uj_output.status =
       (size_t)cryptolib_fi_p256_verify_impl(uj_input, &uj_output).value;
   /////////////// STUB END ///////////////
@@ -220,7 +220,7 @@ status_t handle_cryptolib_fi_asym_p384_ecdh(ujson_t *uj) {
   // Perform ecdh in P384.
   // Trigger are over the API calls.
   cryptolib_fi_asym_p384_ecdh_out_t uj_output;
-  memset(&uj_output, 0, sizeof(uj_output));
+  uj_output.status = kUnknown;
   uj_output.status =
       (size_t)cryptolib_fi_p384_ecdh_impl(uj_input, &uj_output).value;
   /////////////// STUB END ///////////////
@@ -237,7 +237,7 @@ status_t handle_cryptolib_fi_asym_p384_sign(ujson_t *uj) {
   // Perform a p384 signature.
   // Trigger are over the API calls.
   cryptolib_fi_asym_p384_sign_out_t uj_output;
-  memset(&uj_output, 0, sizeof(uj_output));
+  uj_output.status = kUnknown;
   uj_output.status =
       (size_t)cryptolib_fi_p384_sign_impl(uj_input, &uj_output).value;
   /////////////// STUB END ///////////////
@@ -254,7 +254,7 @@ status_t handle_cryptolib_fi_asym_p384_verify(ujson_t *uj) {
   // Perform a p384 verification.
   // Trigger are over the API calls.
   cryptolib_fi_asym_p384_verify_out_t uj_output;
-  memset(&uj_output, 0, sizeof(uj_output));
+  uj_output.status = kUnknown;
   uj_output.status =
       (size_t)cryptolib_fi_p384_verify_impl(uj_input, &uj_output).value;
   /////////////// STUB END ///////////////

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym.c
@@ -26,7 +26,7 @@ status_t handle_cryptolib_fi_sym_aes(ujson_t *uj) {
   // The total size of this test can be large due to all these options.
   // Triggers are over the API calls.
   cryptolib_fi_sym_aes_out_t uj_output;
-  memset(&uj_output, 0, sizeof(uj_output));
+  uj_output.status = kUnknown;
   uj_output.status = (size_t)cryptolib_fi_aes_impl(uj_input, &uj_output).value;
   /////////////// STUB END ///////////////
 
@@ -61,7 +61,7 @@ status_t handle_cryptolib_fi_sym_gcm(ujson_t *uj) {
   // Then, verify that tag again, before sending the output.
   // Trigger are over the API calls.
   cryptolib_fi_sym_gcm_out_t uj_output;
-  memset(&uj_output, 0, sizeof(uj_output));
+  uj_output.status = kUnknown;
   uj_output.status = (size_t)cryptolib_fi_gcm_impl(uj_input, &uj_output).value;
   /////////////// STUB END ///////////////
 
@@ -94,7 +94,7 @@ status_t handle_cryptolib_fi_sym_hmac(ujson_t *uj) {
   // Perform an HMAC call.
   // Trigger are over the API calls.
   cryptolib_fi_sym_hmac_out_t uj_output;
-  memset(&uj_output, 0, sizeof(uj_output));
+  uj_output.status = kUnknown;
   uj_output.status = (size_t)cryptolib_fi_hmac_impl(uj_input, &uj_output).value;
   /////////////// STUB END ///////////////
 
@@ -110,7 +110,7 @@ status_t handle_cryptolib_fi_sym_drbg_generate(ujson_t *uj) {
   // Perform a DRBG call to generate random output.
   // Trigger are over the API calls.
   cryptolib_fi_sym_drbg_generate_out_t uj_output;
-  memset(&uj_output, 0, sizeof(uj_output));
+  uj_output.status = kUnknown;
   uj_output.status =
       (size_t)cryptolib_fi_drbg_generate_impl(uj_input, &uj_output).value;
   /////////////// STUB END ///////////////
@@ -127,7 +127,7 @@ status_t handle_cryptolib_fi_sym_drbg_reseed(ujson_t *uj) {
   // Perform a DRBG call to reseed/instantiate the DRBG.
   // Trigger are over the API calls.
   cryptolib_fi_sym_drbg_reseed_out_t uj_output;
-  memset(&uj_output, 0, sizeof(uj_output));
+  uj_output.status = kUnknown;
   uj_output.status =
       (size_t)cryptolib_fi_drbg_reseed_impl(uj_input, &uj_output).value;
   /////////////// STUB END ///////////////


### PR DESCRIPTION
Instead of setting the output to all zero, the output is randomized before starting the operations. Since this is an additional countermeasure to the use of the crypto library it means that we should guide that this countermeasure is always in place for its use.