### PR TITLE
[hmac/sha2/cryptolib] bytecopy and check

### DIFF
--- a/sw/device/lib/crypto/drivers/hmac.c
+++ b/sw/device/lib/crypto/drivers/hmac.c
@@ -677,6 +677,9 @@ void hmac_hmac_sha256_init(const hmac_key_t key, hmac_ctx_t *ctx) {
   ctx->key.key_len = key.key_len;
   ctx->key.checksum = key.checksum;
   hardened_memcpy(ctx->key.key_block, key.key_block, key.key_len);
+  HARDENED_CHECK_EQ(
+      hardened_memeq(key.key_block, ctx->key.key_block, key.key_len),
+      kHardenedBoolTrue);
   hmac_init(kKeyLength512, kDigestLengthSha256, ctx);
 }
 
@@ -686,6 +689,9 @@ void hmac_hmac_sha384_init(const hmac_key_t key, hmac_ctx_t *ctx) {
   ctx->key.key_len = key.key_len;
   ctx->key.checksum = key.checksum;
   hardened_memcpy(ctx->key.key_block, key.key_block, key.key_len);
+  HARDENED_CHECK_EQ(
+      hardened_memeq(key.key_block, ctx->key.key_block, key.key_len),
+      kHardenedBoolTrue);
   hmac_init(kKeyLength1024, kDigestLengthSha384, ctx);
 }
 
@@ -695,6 +701,9 @@ void hmac_hmac_sha512_init(const hmac_key_t key, hmac_ctx_t *ctx) {
   ctx->key.key_len = key.key_len;
   ctx->key.checksum = key.checksum;
   hardened_memcpy(ctx->key.key_block, key.key_block, key.key_len);
+  HARDENED_CHECK_EQ(
+      hardened_memeq(key.key_block, ctx->key.key_block, key.key_len),
+      kHardenedBoolTrue);
   hmac_init(kKeyLength1024, kDigestLengthSha512, ctx);
 }
 

--- a/sw/device/lib/crypto/impl/hmac.c
+++ b/sw/device/lib/crypto/impl/hmac.c
@@ -162,6 +162,9 @@ static status_t hmac_key_construct(const otcrypto_blinded_key_t *key,
                       key_block_wordlen * sizeof(uint32_t));
     HARDENED_TRY(
         hardened_memcpy(hmac_key->key_block, unmasked_key, unmasked_key_len));
+    HARDENED_CHECK_EQ(
+        hardened_memeq(unmasked_key, hmac_key->key_block, unmasked_key_len),
+        kHardenedBoolTrue);
     // If the key size isn't a multiple of the word size, zero the last few
     // bytes.
     size_t offset = key->config.key_length % sizeof(uint32_t);
@@ -451,7 +454,10 @@ otcrypto_status_t otcrypto_hmac_init(otcrypto_hmac_context_t *ctx,
   // avoid that multiple cases were executed.
   HARDENED_CHECK_EQ(launder32(key_mode_used), key->config.key_mode);
 
-  memcpy(ctx->data, &hmac_ctx, sizeof(hmac_ctx));
+  randomized_bytecopy(ctx->data, &hmac_ctx, sizeof(hmac_ctx));
+  HARDENED_CHECK_EQ(
+      consttime_memeq_byte(&hmac_ctx, ctx->data, sizeof(hmac_ctx)),
+      kHardenedBoolTrue);
   return OTCRYPTO_OK;
 }
 

--- a/sw/device/lib/crypto/impl/sha2.c
+++ b/sw/device/lib/crypto/impl/sha2.c
@@ -98,7 +98,10 @@ otcrypto_status_t otcrypto_sha2_init(otcrypto_hash_mode_t hash_mode,
   // avoid that multiple cases were executed.
   HARDENED_CHECK_EQ(launder32(hash_mode_used), hash_mode);
 
-  memcpy(ctx->data, &hmac_ctx, sizeof(hmac_ctx));
+  randomized_bytecopy(ctx->data, &hmac_ctx, sizeof(hmac_ctx));
+  HARDENED_CHECK_EQ(
+      consttime_memeq_byte(&hmac_ctx, ctx->data, sizeof(hmac_ctx)),
+      kHardenedBoolTrue);
   return OTCRYPTO_OK;
 }
 


### PR DESCRIPTION
Recheck the copying of the context or key using the bytecopy and memeq functions.
This is after https://github.com/lowRISC/opentitan/pull/28746. This also concludes where memeq after a memcpy can be used in the cryptolib.