### PR TITLE
[test] Replace AES alert with status read

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -985,6 +985,8 @@ opentitan_test(
         DARJEELING_TEST_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
+            "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
@@ -1000,6 +1002,8 @@ opentitan_test(
         DARJEELING_TEST_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
+            "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
@@ -1015,6 +1019,8 @@ opentitan_test(
         DARJEELING_TEST_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
+            "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
@@ -1030,6 +1036,8 @@ opentitan_test(
         DARJEELING_TEST_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
+            "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
         },
     ),
     deps = ["clkmgr_off_trans_impl"],

--- a/sw/device/tests/clkmgr_off_trans_impl.c
+++ b/sw/device/tests/clkmgr_off_trans_impl.c
@@ -114,7 +114,8 @@ static clock_error_info_t info[kTestTransCount];
  * Send CSR access to aes, expecting to timeout.
  */
 OT_NOINLINE void aes_csr_access(void) {
-  CHECK_DIF_OK(dif_aes_alert_force(&aes, kDifAesAlertRecovCtrlUpdateErr));
+  bool status;
+  CHECK_DIF_OK(dif_aes_get_status(&aes, kDifAesStatusIdle, &status));
 }
 
 OT_NOINLINE static void hmac_csr_access(void) {
@@ -204,7 +205,7 @@ bool execute_off_trans_test(test_trans_block_t block) {
         inst = dt_aes_instance_id(kTestAes);
         info[trans].name = "aes";
         info[trans].csr_offset =
-            addr_as_offset(aes.base_addr, AES_ALERT_TEST_REG_OFFSET);
+            addr_as_offset(aes.base_addr, AES_STATUS_REG_OFFSET);
         info[trans].crash_function = aes_csr_access;
         break;
 


### PR DESCRIPTION
This test needs to read a CSR from the AES block. `dif_aes_alert_force` was chosen because the instruction that writes to the `ALERT_TEST` CSR comes close to the beginning of the function and makes the crash dump accurate

> The address of the function causing the error.  The functions
> that cause the error are chosen so they perform a CSR read
> shortly after the function entry, so crash_dump's mcpc is
> expected to be past the possible error pc by no more than about 8
> instructions, meaning 8 * 4 bytes.

However triggering an alert will be problematic once OTTF starts catching alerts triggered by tests.

Switch to `dif_aes_get_status` instead which I have confirmed does the CSR access within two instructions from `aes_csr_access`.

```
200107a0 <aes_csr_access>:
200107a0: 41100537 lui a0,0x41100
200107a4: 08452503 lw  a0,132(a0) # 41100084
200107a8: 8082     ret
```

Cross reference with 3250128b4d19662e4b873dfc6fc260e415ca59bb which changed from `_get_status` to `_alert_force` presumably because the CSR access was generated further away at the time.