### PR TITLE
Backport 26053 ([sival] Use `EARLGREY_SILICON_OWNER_ROM_EXT_ENVS` in cryptotests.)

### DIFF
--- a/sw/device/tests/crypto/cryptotest/cryptotest.bzl
+++ b/sw/device/tests/crypto/cryptotest/cryptotest.bzl
@@ -6,6 +6,7 @@
 
 load(
     "//rules/opentitan:defs.bzl",
+    "EARLGREY_SILICON_OWNER_ROM_EXT_ENVS",
     "fpga_params",
     "opentitan_test",
     "silicon_params",
@@ -22,8 +23,7 @@ CRYPTOTEST_EXEC_ENVS = {
     "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
     "//hw/top_earlgrey:fpga_cw340_test_rom": "fpga_cw340",
     "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": "fpga_cw340",
-    "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon",
-}
+} | EARLGREY_SILICON_OWNER_ROM_EXT_ENVS
 
 FIRMWARE_DEPS = [
     "//sw/device/tests/crypto/cryptotest/firmware:aes",


### PR DESCRIPTION
Backport #26053