### PR TITLE
Backport #26065 ([sram-exec] Avoid using compressed instructions when loading sp.)

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/sram_start.S
+++ b/sw/device/silicon_creator/manuf/lib/sram_start.S
@@ -133,7 +133,10 @@ sram_start:
 
 .L_crc_match:
   // Set up the stack.
+  .option push
+  .option norelax
   la  sp, _stack_end
+  .option pop
 
   /**
    * Setup the interrupt/exception handlers.


### PR DESCRIPTION
Backport #26065