### PR TITLE
Partial backport of ([bazel,bitstream] Add support for non-master branch)

### DIFF
--- a/rules/scripts/bitstreams_workspace.py
+++ b/rules/scripts/bitstreams_workspace.py
@@ -59,6 +59,9 @@ parser.add_argument('--create-symlink', default=True,
 parser.add_argument('--latest-update',
                     default='latest.txt',
                     help='Last time the cache was updated')
+parser.add_argument('--branch',
+                    default="master",
+                    help='Upstream git branch to search for bitstreams.')
 parser.add_argument('--bucket-url', default=BUCKET_URL, help='GCP Bucket URL')
 parser.add_argument('--build-file',
                     default='BUILD.bazel',
@@ -217,7 +220,7 @@ class BitstreamCache(object):
             time.sleep(wait_time)
             wait_time *= 2.0
 
-    def GetBitstreamsAvailable(self, refresh, load_latest_update=True):
+    def GetBitstreamsAvailable(self, branch, refresh, load_latest_update=True):
         """Inventory which bitstreams are available.
 
         Args:
@@ -265,7 +268,7 @@ class BitstreamCache(object):
             else:
                 break
 
-        latest = self.Get('master/latest.txt').decode('utf-8').split('\n')
+        latest = self.Get(f'{branch}/latest.txt').decode('utf-8').split('\n')
         self.available['latest'] = latest[1]
 
     def GetClosest(self, repodir, key):
@@ -600,7 +603,7 @@ def main(argv):
                     cache.NeedRefresh(args.refresh_time))
     # Do we need to load the latest_update file?
     load_latest_update = (desired_bitstream == 'latest')
-    cache.GetBitstreamsAvailable(need_refresh and not args.offline,
+    cache.GetBitstreamsAvailable(args.branch, need_refresh and not args.offline,
                                  load_latest_update)
 
     # If commanded to print bitstream availability, do so.

--- a/rules/scripts/bitstreams_workspace_test.py
+++ b/rules/scripts/bitstreams_workspace_test.py
@@ -213,7 +213,7 @@ class TestFetchAvailableBitstreams(unittest.TestCase):
             name='cache.Get',
             side_effect=MOCKED_GET_RETURN,
         )
-        self.cache.GetBitstreamsAvailable(refresh=True)
+        self.cache.GetBitstreamsAvailable(branch="master", refresh=True)
         self.assertEqual(self.cache.Get.call_count, 2)
         self.assertEqual(self.cache.available, {
             "0": "master/bitstream-0.tar.gz",
@@ -269,7 +269,7 @@ class TestFetchAvailableBitstreams(unittest.TestCase):
             name='cache.Get',
             side_effect=MOCKED_GET_RETURN,
         )
-        self.cache.GetBitstreamsAvailable(refresh=True)
+        self.cache.GetBitstreamsAvailable(branch="master", refresh=True)
         self.assertEqual(self.cache.Get.call_count, 3)
         self.assertEqual(
             self.cache.available, {

--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -147,7 +147,7 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
   readonly LATEST_BISTREAM_HASH_FILE="${SYSTEM_BITSTREAM_CACHE}/latest.txt"
   # The revision named in latest.txt is not necessarily on disk. Induce the
   # cache backend to fetch the latest bitstreams.
-  BITSTREAM=latest ${BAZELISK} fetch @bitstreams//...
+  BITSTREAM="latest" ${BAZELISK} fetch @bitstreams//...
   cp "${LATEST_BISTREAM_HASH_FILE}" \
     "${BAZEL_AIRGAPPED_DIR}/${BAZEL_BITSTREAMS_CACHE}/"
   LATEST_BISTREAM_HASH=$(cat "${LATEST_BISTREAM_HASH_FILE}")


### PR DESCRIPTION
Partial backport of #26062. Does not include the change to make the bazel always get the `earlgrey_1.0.0` branch bitstream (which obviously does not apply to the master branch).