### PR TITLE
[rom_ext] Make signature verification more verbose

### DIFF
--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -388,11 +388,15 @@ static rom_error_t rom_ext_try_next_stage(boot_data_t *boot_data,
   rom_error_t slot[2] = {0, 0};
   for (size_t i = 0; i < ARRAYSIZE(manifests.ordered); ++i) {
     uint32_t flash_exec = 0;
+    char slot_id =
+        (manifests.ordered[i] == rom_ext_boot_policy_manifest_a_get()) ? 'A'
+                                                                       : 'B';
     error =
-        rom_ext_verify(manifests.ordered[i], boot_data, &flash_exec, &keyring,
-                       &verify_key, &owner_config, &isfb_check_count);
+        rom_ext_verify(manifests.ordered[i], slot_id, boot_data, &flash_exec,
+                       &keyring, &verify_key, &owner_config, &isfb_check_count);
     slot[i] = error;
     if (error != kErrorOk) {
+      dbg_printf("verifyfail: Slot%c;%x\r\n", slot_id, error);
       continue;
     }
     HARDENED_CHECK_EQ(flash_exec, kSigverifyFlashExec);

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_services.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_services.c
@@ -95,14 +95,14 @@ static rom_error_t boot_svc_min_sec_ver_handler(
     const manifest_t *manifest = rom_ext_boot_policy_manifest_a_get();
     uint32_t flash_exec = 0;
     rom_error_t error =
-        rom_ext_verify(manifest, boot_data, &flash_exec, keyring, verify_key,
-                       owner_config, isfb_check_count);
+        rom_ext_verify(manifest, /*slot_id=*/0, boot_data, &flash_exec, keyring,
+                       verify_key, owner_config, isfb_check_count);
     if (error == kErrorOk) {
       slot_a_max_sec_ver = manifest->security_version;
     }
     manifest = rom_ext_boot_policy_manifest_b_get();
-    error = rom_ext_verify(manifest, boot_data, &flash_exec, keyring,
-                           verify_key, owner_config, isfb_check_count);
+    error = rom_ext_verify(manifest, /*slot_id=*/0, boot_data, &flash_exec,
+                           keyring, verify_key, owner_config, isfb_check_count);
     if (error == kErrorOk) {
       slot_b_max_sec_ver = manifest->security_version;
     }

--- a/sw/device/silicon_creator/rom_ext/rom_ext_verify.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_verify.c
@@ -20,7 +20,7 @@
 #include "sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.h"
 
 OT_WARN_UNUSED_RESULT
-rom_error_t rom_ext_verify(const manifest_t *manifest,
+rom_error_t rom_ext_verify(const manifest_t *manifest, char slot_id,
                            const boot_data_t *boot_data, uint32_t *flash_exec,
                            owner_application_keyring_t *keyring,
                            size_t *verify_key, owner_config_t *owner_config,
@@ -50,8 +50,10 @@ rom_error_t rom_ext_verify(const manifest_t *manifest,
   RETURN_IF_ERROR(owner_keyring_find_key(keyring, key_id, verify_key));
   uint32_t key_alg = keyring->key[*verify_key]->key_alg;
 
-  dbg_printf("verify: key%u;%C;%C\r\n", (uint32_t)*verify_key, key_alg,
-             keyring->key[*verify_key]->key_domain);
+  if (slot_id) {
+    dbg_printf("verify: Slot%c;key%u;%C;%C\r\n", slot_id, (uint32_t)*verify_key,
+               key_alg, keyring->key[*verify_key]->key_domain);
+  }
 
   memset(boot_measurements.bl0.data, (int)rnd_uint32(),
          sizeof(boot_measurements.bl0.data));

--- a/sw/device/silicon_creator/rom_ext/rom_ext_verify.h
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_verify.h
@@ -14,8 +14,24 @@
 extern "C" {
 #endif  // __cplusplus
 
+/**
+ * Verify the the next boot stage according to the owner configuration.
+ *
+ * @param manifest Pointer to the manifest being examined.
+ * @param slot_id Name of the slot being examined ('A', 'B' or 0).  This
+ *                parameter controls the "verify" debug print, but is not used
+ *                for any verification purpose.
+ * @param boot_data Pointer to the boot_data struct.
+ * @param flash_exec[out] Redundant check word for image validity.
+ * @param keyring A list of valid owner Application keys.
+ * @param verify_key[out] Key selected for verification.
+ * @param owner_config The owner configuration.
+ * @param isfb_check_count[out] The number of checks performed by ISFB (if
+ *                              present).
+ * @return kErrorOk or a validation error.
+ */
 OT_WARN_UNUSED_RESULT
-rom_error_t rom_ext_verify(const manifest_t *manifest,
+rom_error_t rom_ext_verify(const manifest_t *manifest, char slot_id,
                            const boot_data_t *boot_data, uint32_t *flash_exec,
                            owner_application_keyring_t *keyring,
                            size_t *verify_key, owner_config_t *owner_config,


### PR DESCRIPTION
1. Print the slot being verified as part of the `verify` message.
2. If there is a verification failure in one slot, print the reason.