### PR TITLE
[silicon_creator,ownership] Fix expression with missing parenthesis

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/owner_block.c
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.c
@@ -467,10 +467,10 @@ rom_error_t owner_block_flash_apply(const owner_flash_config_t *flash,
         flash_ctrl_data_region_protect(kRomExtRegions + *mp_index,
                                        config->start, config->size, perm, cfg,
                                        lock);
-        SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioDataRegionProtect + lock ==
-                                         kHardenedBoolTrue
-                                     ? kFlashCtrlSecMmioDataRegionProtectLock
-                                     : 0);
+        SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioDataRegionProtect +
+                                 (lock == kHardenedBoolTrue
+                                      ? kFlashCtrlSecMmioDataRegionProtectLock
+                                      : 0));
       }
       *mp_index += 1;
     }


### PR DESCRIPTION
This expression was not doing what it was intended for. Since the counters are not checked yet in the ROM_EXT, this wasn't noticed before. Issue identified by @AlexJones0  when reviewing #28875