### PR TITLE
[cryptolib] Include checksum in ECC scalar size

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/p256.h
+++ b/sw/device/lib/crypto/impl/ecc/p256.h
@@ -59,20 +59,35 @@ enum {
    */
   kP256MaskedScalarNumShares = 2,
   /**
+   * Length of checksum for the scalar in bits.
+   */
+  kP256ChecksumBits = 32,
+  /**
+   * Length of checksum for the scalar in bytes.
+   */
+  kP256ChecksumBytes = kP256ChecksumBits / 8,
+  /**
+   * Length of checksum for the scalar in words.
+   */
+  kP256ChecksumWords = kP256ChecksumBytes / sizeof(uint32_t),
+  /**
    * Length of the full masked secret scalar share in bits.
    */
   kP256MaskedScalarTotalShareBits =
-      kP256MaskedScalarNumShares * kP256MaskedScalarShareBits,
+      kP256MaskedScalarNumShares * kP256MaskedScalarShareBits +
+      kP256ChecksumBits,
   /**
    * Length of the full masked secret scalar share in bytes.
    */
   kP256MaskedScalarTotalShareBytes =
-      kP256MaskedScalarNumShares * kP256MaskedScalarShareBytes,
+      kP256MaskedScalarNumShares * kP256MaskedScalarShareBytes +
+      kP256ChecksumBytes,
   /**
    * Length of the full masked secret scalar share in words.
    */
   kP256MaskedScalarTotalShareWords =
-      kP256MaskedScalarNumShares * kP256MaskedScalarShareWords,
+      kP256MaskedScalarNumShares * kP256MaskedScalarShareWords +
+      kP256ChecksumWords,
 };
 
 /**

--- a/sw/device/lib/crypto/impl/ecc/p384.h
+++ b/sw/device/lib/crypto/impl/ecc/p384.h
@@ -59,20 +59,35 @@ enum {
    */
   kP384MaskedScalarNumShares = 2,
   /**
+   * Length of checksum for the scalar in bits.
+   */
+  kP384ChecksumBits = 32,
+  /**
+   * Length of checksum for the scalar in bytes.
+   */
+  kP384ChecksumBytes = kP384ChecksumBits / 8,
+  /**
+   * Length of checksum for the scalar in words.
+   */
+  kP384ChecksumWords = kP384ChecksumBytes / sizeof(uint32_t),
+  /**
    * Length of the full masked secret scalar share in bits.
    */
   kP384MaskedScalarTotalShareBits =
-      kP384MaskedScalarNumShares * kP384MaskedScalarShareBits,
+      kP384MaskedScalarNumShares * kP384MaskedScalarShareBits +
+      kP384ChecksumBits,
   /**
    * Length of the full masked secret scalar share in bytes.
    */
   kP384MaskedScalarTotalShareBytes =
-      kP384MaskedScalarNumShares * kP384MaskedScalarShareBytes,
+      kP384MaskedScalarNumShares * kP384MaskedScalarShareBytes +
+      kP384ChecksumBytes,
   /**
    * Length of the full masked secret scalar share in words.
    */
   kP384MaskedScalarTotalShareWords =
-      kP384MaskedScalarNumShares * kP384MaskedScalarShareWords,
+      kP384MaskedScalarNumShares * kP384MaskedScalarShareWords +
+      kP384ChecksumWords,
 };
 
 /**


### PR DESCRIPTION
Checksums were added to the scalars in 0593bd2315995be869382541c7e54ec0db02f907 and the sizes were checked, but they did not include the size of the checksum. This caused `p*_private_key_length_check` to fail.

This commit does cause the checksum to be copied in `internal_p256_keygen_finalize`, however it is recomputed afterwards anyway.

With this change (and something unrelated), the ECDSA KAT test starts passing.

```
//sw/device/tests/crypto/cryptotest:ecdsa_kat_fpga_cw340_sival_rom_ext   PASSED in 392.7s
```