### PR TITLE
[ci] Pass default branch to Nightly CI

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
         with:
-          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
+          service_account_json: "${{ secrets.BAZEL_CACHE_CREDS }}"
       - name: Download bitstream
         uses: ./.github/actions/download-partial-build-bin
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch to run the nightly (for SiVal job only)'
+        description: "Branch to run the nightly on"
         required: true
         type: string
 
@@ -61,7 +61,7 @@ jobs:
       cache_test_results: false
       upload_to_bucket: true
       bucket_job_folder_name: "cw310_test_rom"
-      branch: "${{ inputs.branch }}"
+      branch: "${{ inputs.branch || 'earlgrey_1.0.0' }}"
 
   execute_fpga_cw310_rom_tests:
     name: CW310 ROM Tests
@@ -79,7 +79,7 @@ jobs:
       timeout: 240
       upload_to_bucket: true
       bucket_job_folder_name: "cw310_rom"
-      branch: "${{ inputs.branch }}"
+      branch: "${{ inputs.branch || 'earlgrey_1.0.0' }}"
 
   execute_fpga_cw310_rom_ext_tests:
     name: CW310 ROM_EXT Tests
@@ -96,7 +96,7 @@ jobs:
       cache_test_results: false
       upload_to_bucket: true
       bucket_job_folder_name: "cw310_rom_ext"
-      branch: "${{ inputs.branch }}"
+      branch: "${{ inputs.branch || 'earlgrey_1.0.0' }}"
 
   execute_fpga_cw310_sival_tests:
     name: CW310 SiVal Tests
@@ -113,7 +113,7 @@ jobs:
       cache_test_results: false
       upload_to_bucket: true
       bucket_job_folder_name: "cw310_sival"
-      branch: "${{ inputs.branch }}"
+      branch: "${{ inputs.branch || 'earlgrey_1.0.0' }}"
 
   execute_fpga_cw310_sival_rom_ext_tests:
     name: CW310 SiVal ROM_EXT Tests
@@ -130,7 +130,7 @@ jobs:
       cache_test_results: false
       upload_to_bucket: true
       bucket_job_folder_name: "cw310_sival_rom_ext"
-      branch: "${{ inputs.branch }}"
+      branch: "${{ inputs.branch || 'earlgrey_1.0.0' }}"
 
   execute_fpga_cw310_bob_tests:
     name: CW310 BoB (SPI and I2C) Tests
@@ -148,7 +148,7 @@ jobs:
       cache_test_results: false
       upload_to_bucket: true
       bucket_job_folder_name: "cw310_bob"
-      branch: "${{ inputs.branch }}"
+      branch: "${{ inputs.branch || 'earlgrey_1.0.0' }}"
 
   execute_fpga_cw340_test_rom_tests:
     name: CW340 Test ROM Tests
@@ -165,7 +165,7 @@ jobs:
       cache_test_results: false
       upload_to_bucket: true
       bucket_job_folder_name: "cw340_test_rom"
-      branch: "${{ inputs.branch }}"
+      branch: "${{ inputs.branch || 'earlgrey_1.0.0' }}"
 
   execute_fpga_cw340_rom_tests:
     name: CW340 ROM Tests
@@ -182,7 +182,7 @@ jobs:
       cache_test_results: false
       upload_to_bucket: true
       bucket_job_folder_name: "cw340_rom"
-      branch: "${{ inputs.branch }}"
+      branch: "${{ inputs.branch || 'earlgrey_1.0.0' }}"
 
   execute_fpga_cw340_rom_ext_tests:
     name: CW340 ROM_EXT Tests
@@ -199,7 +199,7 @@ jobs:
       cache_test_results: false
       upload_to_bucket: true
       bucket_job_folder_name: "cw340_rom_ext"
-      branch: "${{ inputs.branch }}"
+      branch: "${{ inputs.branch || 'earlgrey_1.0.0' }}"
 
   execute_fpga_cw340_sival_tests:
     name: CW340 SiVal Tests
@@ -216,7 +216,7 @@ jobs:
       cache_test_results: false
       upload_to_bucket: true
       bucket_job_folder_name: "cw340_sival"
-      branch: "${{ inputs.branch }}"
+      branch: "${{ inputs.branch || 'earlgrey_1.0.0' }}"
 
   execute_fpga_cw340_sival_rom_ext_tests:
     name: CW340 SiVal ROM_EXT Tests
@@ -234,7 +234,7 @@ jobs:
       timeout: 90
       upload_to_bucket: true
       bucket_job_folder_name: "cw340_sival_rom_ext"
-      branch: "${{ inputs.branch }}"
+      branch: "${{ inputs.branch || 'earlgrey_1.0.0' }}"
 
   slow_otbn_crypto_tests:
     name: Slow OTBN Crypto Tests
@@ -247,7 +247,7 @@ jobs:
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
         with:
-          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
+          service_account_json: "${{ secrets.BAZEL_CACHE_CREDS }}"
       - name: Run the tests
         run: |
           ./bazelisk.sh test \


### PR DESCRIPTION
Fixes automatic runs of Nightly CI running with no given "branch" argument, causing the results to be uploaded to a "/" folder, instead of "earlgrey_1.0.0".