### PR TITLE
[toolchain] Disable compiler jump guards

### DIFF
--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -70,7 +70,6 @@ cc_toolchain(
         "@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features",
         ":feat_rv32_bitmanip",
         ":feat_warnings_as_errors",
-        ":feat_guards",
         ":feat_use_lld",
         ":feat_lto",
         ":feat_minsize",


### PR DESCRIPTION
Similar to https://github.com/lowRISC/opentitan/pull/26636, remove the
guards feature from enabled in the toolchain.

The compiler guards feature is meant as a control flow integrity feature that inserts unimp sequences around branches to protect against instruction skips.

Disabling this saves ~4% ROM size, ~12% ROM_EXT size, and ~1% size of
the crypto library.

From instruction skip simulations in
https://github.com/lowRISC/opentitan/pull/28850 and
https://github.com/lowRISC/opentitan/pull/28549, there is no noticable
security difference between the option enabled or disabled.