### PR TITLE
[doc,sram_ctrl] Update sram_ctrl `EXEC` register description

### DIFF
--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -427,10 +427,16 @@
             name: "EN",
             mubi: true,
             desc: '''
-                  Write kMultiBitBool4True to this field to enable execution from SRAM.
-                  Note that this register only takes effect if the EN_SRAM_IFETCH switch
-                  in the OTP HW_CFG1 partition is set to kMultiBitBool8True. Otherwise execution
-                  from SRAM cannot be enabled via this register.
+                  This register only has any effect if the value of the incoming
+                  otp_en_sram_ifetch_i signal is set to kMultiBitBool8True (in
+                  Earlgrey, this comes from the OTP HW_CFG1 partition).
+
+                  If so, execution from SRAM requires this register to contain
+                  kMultiBitBool4True.
+
+                  If otp_en_sram_ifetch_i is not kMultiBitBool8True, execution
+                  from SRAM is instead controlled by a signal from lc_ctrl. See
+                  "Theory of Operation" for more details.
                   ''',
             resval: false
           },

--- a/hw/ip/sram_ctrl/doc/registers.md
+++ b/hw/ip/sram_ctrl/doc/registers.md
@@ -1,4 +1,7 @@
-## Summary of the **`regs`** interface's registers
+# Registers
+
+<!-- BEGIN CMDGEN util/regtool.py -d ./hw/ip/sram_ctrl/data/sram_ctrl.hjson -->
+## Summary
 
 | Name                                            | Offset   |   Length | Description                                  |
 |:------------------------------------------------|:---------|---------:|:---------------------------------------------|
@@ -252,4 +255,5 @@ Write kMultiBitBool4True to this field to enable the readback security feature f
 A readback of each memory write or read request will be performed and a comparison happens.
 Any other value than kMultiBitBool4False written to this field is interpreted as kMultiBitBool4True.
 
-This interface does not expose any registers.
+
+<!-- END CMDGEN -->

--- a/hw/ip/sram_ctrl/doc/registers.md
+++ b/hw/ip/sram_ctrl/doc/registers.md
@@ -133,10 +133,16 @@ Sram execution enable.
 |  3:0   |   rw   |   0x9   | [EN](#exec--en) |
 
 ### EXEC . EN
-Write kMultiBitBool4True to this field to enable execution from SRAM.
-Note that this register only takes effect if the EN_SRAM_IFETCH switch
-in the OTP HW_CFG1 partition is set to kMultiBitBool8True. Otherwise execution
-from SRAM cannot be enabled via this register.
+This register only has any effect if the value of the incoming
+otp_en_sram_ifetch_i signal is set to kMultiBitBool8True (in
+Earlgrey, this comes from the OTP HW_CFG1 partition).
+
+If so, execution from SRAM requires this register to contain
+kMultiBitBool4True.
+
+If otp_en_sram_ifetch_i is not kMultiBitBool8True, execution
+from SRAM is instead controlled by a signal from lc_ctrl. See
+"Theory of Operation" for more details.
 
 ## CTRL_REGWEN
 Lock register for control register.


### PR DESCRIPTION
This PR slightly extends the SRAM controller's `EXEC` field description to better reflect the hardware, based on difficulties encountered during emulation - see the diff & commit message for more details.

Also see the relevant [RTL](https://github.com/lowRISC/opentitan/blob/5da2042067deaface38c8b8b102c007032d121ed/hw/ip/sram_ctrl/rtl/sram_ctrl.sv#L434-L442):
```sv
    assign en_ifetch = (mubi8_test_true_strict(otp_en_sram_ifetch)) ? reg_ifetch_en :
                                                                      lc_ifetch_en;
```