### PR TITLE
[docs] Re-add OpenTitanLib Bitbanging docs to `SUMMARY.md`

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -659,6 +659,7 @@
 
   - [Host Software](./sw/host/README.md)
     - [OpenTitanLib](./sw/host/opentitanlib/README.md)
+      - [Bitbanging](./sw/host/opentitanlib/doc/bitbanging.md)
     - [OpenTitanTool](./sw/host/opentitantool/README.md)
     - [OpenTitanSession](./sw/host/opentitansession/README.md)
     - [OpenTitan Certificate Generator](./sw/host/ot_certs/README.md)


### PR DESCRIPTION
These docs were seemingly accidentally dropped in 49efe55 (I suspect lost during a rebase). We want this bitbanging documentation available on the website to provide guidance for using bitbanging utils in testing/provisioning flows.