### PR TITLE
[cryptotest] Fix private key `keyblob_length`

### DIFF
--- a/sw/device/tests/crypto/cryptotest/firmware/ecdsa.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/ecdsa.c
@@ -197,7 +197,7 @@ status_t p256_sign(ujson_t *uj, cryptotest_ecdsa_private_key_t *uj_private_key,
   p256_masked_scalar_t private_key_masked;
   otcrypto_blinded_key_t private_key = {
       .config = kP256PrivateKeyConfig,
-      .keyblob_length = sizeof(private_key_masked),
+      .keyblob_length = kP256MaskedScalarTotalShareBytes,
       .keyblob = (uint32_t *)&private_key_masked,
   };
   memset(private_key_masked.share0, 0, kP256MaskedScalarShareBytes);
@@ -233,7 +233,7 @@ status_t p384_sign(ujson_t *uj, cryptotest_ecdsa_private_key_t *uj_private_key,
   p384_masked_scalar_t private_key_masked;
   otcrypto_blinded_key_t private_key = {
       .config = kP384PrivateKeyConfig,
-      .keyblob_length = sizeof(private_key_masked),
+      .keyblob_length = kP384MaskedScalarTotalShareBytes,
       .keyblob = (uint32_t *)&private_key_masked,
   };
   memset(private_key_masked.share0, 0, kP384MaskedScalarShareBytes);


### PR DESCRIPTION
The ecdsa cryptotest used `sizeof(private_key_masked)` as the `keyblob_length`. However, this is not correct as this sizeof contains the entire size of the private key, which includes the checksum. However, in `keyblob_length` we just expect the keyblob length, with is the length of both key shares.

Now, the tests are passing:
```
552:Finished test test_ecdsa: Ok(())
```

Thanks @jwnrt for raising this issue!