### PR TITLE
[util] add REUSE-ignore comments around code generating license text

### DIFF
--- a/util/autogen_banner.py
+++ b/util/autogen_banner.py
@@ -7,7 +7,9 @@ from textwrap import fill
 LICENSE_BANNER = (
     "Copyright lowRISC contributors (OpenTitan project).\n"
     "Licensed under the Apache License, Version 2.0, see LICENSE for details.\n"
+    # REUSE-IgnoreStart
     "SPDX-License-Identifier: Apache-2.0")
+# REUSE-IgnoreEnd
 
 AUTOGEN_BANNER = (
     "THIS FILE HAS BEEN GENERATED, DO NOT EDIT MANUALLY. COMMAND:\n{command}")

--- a/util/reggen/gen_tock.py
+++ b/util/reggen/gen_tock.py
@@ -393,8 +393,10 @@ def gen_tock(block: IpBlock, outfile: TextIO, src_file: Optional[str],
         outfile,
         "// Licensed under the Apache License, Version 2.0 or the MIT License.\n"
     )
+    # REUSE-IgnoreStart
     genout(outfile, "// SPDX-License-Identifier: Apache-2.0 OR MIT\n")
     genout(outfile, "// Copyright lowRISC contributors (OpenTitan project).\n")
+    # REUSE-IgnoreEnd
     genout(outfile, '\n')
     genout(outfile, '// Generated register constants for {}.\n', block.name)
 

--- a/util/regtool.py
+++ b/util/regtool.py
@@ -280,7 +280,9 @@ def main():
         found_spdx = None
         found_lunder = None
         copy = re.compile(r'.*(copyright.*)|(.*\(c\).*)', re.IGNORECASE)
+        # REUSE-IgnoreStart
         spdx = re.compile(r'.*(SPDX-License-Identifier:.+)')
+        # REUSE-IgnoreEnd
         lunder = re.compile(r'.*(Licensed under.+)', re.IGNORECASE)
         for line in srcfull.splitlines():
             mat = copy.match(line)

--- a/util/sh/lib/banners.sh
+++ b/util/sh/lib/banners.sh
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # shellcheck shell=bash
 
+# REUSE-IgnoreStart
 add_license_banner() {
   local outfile="$1"
   local license_banner="# Copyright lowRISC contributors (OpenTitan project).
@@ -14,6 +15,7 @@ add_license_banner() {
   cat "$TMP" > "$outfile"
   rm -f "$TMP"
 }
+# REUSE-IgnoreEnd
 
 add_autogen_banner() {
   local outfile="$1"

--- a/util/sh/scripts/bin2c.sh
+++ b/util/sh/scripts/bin2c.sh
@@ -60,7 +60,9 @@ fi
 echo -n "" > ${OUTPUT}
 echo "// Copyright lowRISC contributors (OpenTitan project)." >> ${OUTPUT}
 echo "// Licensed under the Apache License, Version 2.0, see LICENSE for details." >> ${OUTPUT}
+# REUSE-IgnoreStart
 echo "// SPDX-License-Identifier: Apache-2.0" >> ${OUTPUT}
+# REUSE-IgnoreEnd
 echo "" >> ${OUTPUT}
 echo "// clang-format off" >> ${OUTPUT}
 echo "const unsigned char ${NAME}[] = {" >> ${OUTPUT}


### PR DESCRIPTION
[`reuse`](https://pypi.org/project/reuse) is a Python package and specification that can be used to check projects for license compliance.

These files are used to generate code in the repository and emit license and copyright comments. However, if these scripts are vendored, the `reuse` tool can erroneously pick up code emitting an `SPDX-License-Identifier` string as an invalid license for the file itself. Wrapping those lines with `# REUSE-IgnoreStart` and `# REUSE-IgnoreEnd` tells the tool to ignore those lines.