### PR TITLE
[ci] Only run Private CI on `master`

### DIFF
--- a/.github/workflows/private-ci.yml
+++ b/.github/workflows/private-ci.yml
@@ -13,7 +13,8 @@ on:
       - "*"
   pull_request_target:
     branches:
-      - "*"
+      # We should only run Private CI on `master` currently.
+      - "master"
 
 permissions:
   contents: write # For repository dispatch


### PR DESCRIPTION
Previously this workflow has been fine - even when PRs were made that targeted `earlgrey_1.0.0`, private CI would not be run, with this workflow being ignored. On 2025/12/08, [changes were made to Github Actions](https://github.blog/changelog/2025-11-07-actions-pull_request_target-and-environment-branch-protections-changes/) for security which changed the default behaviour of `pull_request_target`, such that now:

> The `pull_request_target` event now always uses the default branch for workflow source and reference ... The workflow file and checkout commit will always be taken from the repository’s default branch, regardless of the pull request’s base branch ... `GITHUB_REF` for `pull_request_target` will resolve to the default branch, and `GITHUB_SHA` will point to the latest commit on that branch.

Our current CI setup relies on this behaviour, so PRs to `earlgrey_1.0.0` are now unintentionally picking up private CI runs (which fail on Darjeeling steps, as Darjeeling doesn't exist on `earlgrey_1.0.0`). We can keep the other `pull_request_targets` on master workflows, but since RTL is frozen on `earlgrey_1.0.0`, it doesn't make sense to run private CI on this branch. Generally, we probably only want to run private CI on `master`, at the moment. To resolve CI failures, this PR explicitly makes this the case.

This should fix failing Private CI on PRs to `earlgrey_1.0.0`. A separate PR will be made to `earlgrey_1.0.0` to drop redundant workflows, for the sake of clarity about which workflow is actually being run.