### PR TITLE
[ci] Run nightly FPGA tests against `master`

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,7 +61,7 @@ jobs:
       cache_test_results: false
       upload_to_bucket: true
       bucket_job_folder_name: "cw310_test_rom"
-      branch: "${{ inputs.branch || 'earlgrey_1.0.0' }}"
+      branch: "${{ inputs.branch || 'master' }}"
 
   execute_fpga_cw310_rom_tests:
     name: CW310 ROM Tests
@@ -79,7 +79,7 @@ jobs:
       timeout: 240
       upload_to_bucket: true
       bucket_job_folder_name: "cw310_rom"
-      branch: "${{ inputs.branch || 'earlgrey_1.0.0' }}"
+      branch: "${{ inputs.branch || 'master' }}"
 
   execute_fpga_cw310_rom_ext_tests:
     name: CW310 ROM_EXT Tests
@@ -96,7 +96,7 @@ jobs:
       cache_test_results: false
       upload_to_bucket: true
       bucket_job_folder_name: "cw310_rom_ext"
-      branch: "${{ inputs.branch || 'earlgrey_1.0.0' }}"
+      branch: "${{ inputs.branch || 'master' }}"
 
   execute_fpga_cw310_sival_tests:
     name: CW310 SiVal Tests
@@ -113,7 +113,7 @@ jobs:
       cache_test_results: false
       upload_to_bucket: true
       bucket_job_folder_name: "cw310_sival"
-      branch: "${{ inputs.branch || 'earlgrey_1.0.0' }}"
+      branch: "${{ inputs.branch || 'master' }}"
 
   execute_fpga_cw310_sival_rom_ext_tests:
     name: CW310 SiVal ROM_EXT Tests
@@ -130,7 +130,7 @@ jobs:
       cache_test_results: false
       upload_to_bucket: true
       bucket_job_folder_name: "cw310_sival_rom_ext"
-      branch: "${{ inputs.branch || 'earlgrey_1.0.0' }}"
+      branch: "${{ inputs.branch || 'master' }}"
 
   execute_fpga_cw310_bob_tests:
     name: CW310 BoB (SPI and I2C) Tests
@@ -148,7 +148,7 @@ jobs:
       cache_test_results: false
       upload_to_bucket: true
       bucket_job_folder_name: "cw310_bob"
-      branch: "${{ inputs.branch || 'earlgrey_1.0.0' }}"
+      branch: "${{ inputs.branch || 'master' }}"
 
   execute_fpga_cw340_test_rom_tests:
     name: CW340 Test ROM Tests
@@ -165,7 +165,7 @@ jobs:
       cache_test_results: false
       upload_to_bucket: true
       bucket_job_folder_name: "cw340_test_rom"
-      branch: "${{ inputs.branch || 'earlgrey_1.0.0' }}"
+      branch: "${{ inputs.branch || 'master' }}"
 
   execute_fpga_cw340_rom_tests:
     name: CW340 ROM Tests
@@ -182,7 +182,7 @@ jobs:
       cache_test_results: false
       upload_to_bucket: true
       bucket_job_folder_name: "cw340_rom"
-      branch: "${{ inputs.branch || 'earlgrey_1.0.0' }}"
+      branch: "${{ inputs.branch || 'master' }}"
 
   execute_fpga_cw340_rom_ext_tests:
     name: CW340 ROM_EXT Tests
@@ -199,7 +199,7 @@ jobs:
       cache_test_results: false
       upload_to_bucket: true
       bucket_job_folder_name: "cw340_rom_ext"
-      branch: "${{ inputs.branch || 'earlgrey_1.0.0' }}"
+      branch: "${{ inputs.branch || 'master' }}"
 
   execute_fpga_cw340_sival_tests:
     name: CW340 SiVal Tests
@@ -216,7 +216,7 @@ jobs:
       cache_test_results: false
       upload_to_bucket: true
       bucket_job_folder_name: "cw340_sival"
-      branch: "${{ inputs.branch || 'earlgrey_1.0.0' }}"
+      branch: "${{ inputs.branch || 'master' }}"
 
   execute_fpga_cw340_sival_rom_ext_tests:
     name: CW340 SiVal ROM_EXT Tests
@@ -234,7 +234,7 @@ jobs:
       timeout: 90
       upload_to_bucket: true
       bucket_job_folder_name: "cw340_sival_rom_ext"
-      branch: "${{ inputs.branch || 'earlgrey_1.0.0' }}"
+      branch: "${{ inputs.branch || 'master' }}"
 
   slow_otbn_crypto_tests:
     name: Slow OTBN Crypto Tests


### PR DESCRIPTION
We have the ability to run `nightly` against `earlgrey_1.0.0` as a `workflow_dispatch`, but we want the CRON to run against the `master` branch.

Nightly is currently failing because bitstreams are built against `master` but tested against `earlgrey_1.0.0`.