### PR TITLE
[ci] Use `BLOCKFILE` of PR target branch instead of the default branch

### DIFF
--- a/.github/workflows/pr_change_check.yml
+++ b/.github/workflows/pr_change_check.yml
@@ -15,8 +15,18 @@ jobs:
   check-changes:
     runs-on: "ubuntu-latest"
     steps:
-      - name: Checkout
+      - name: Checkout the default branch
         uses: actions/checkout@v4
+
+      - name: Checkout the target branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          path: "target-branch"
+          fetch-depth: 1
+
+      - name: Show target branch BLOCKFILE
+        run: cat target-branch/BLOCKFILE
 
       - name: Determine changed files
         run: |
@@ -32,6 +42,7 @@ jobs:
       - name: Check for blocked changes
         run: |
           ./ci/scripts/check-pr-changes-allowed.py $HOME/changed_files \
+            --block-file target-branch/BLOCKFILE \
             --gh-repo ${{ github.repository }} \
             --gh-token ${{ secrets.GITHUB_TOKEN }} \
             --pr-number ${{ github.event.number }}


### PR DESCRIPTION
Related to #28920. On 2025/12/08, [changes were made to Github Actions](https://github.blog/changelog/2025-11-07-actions-pull_request_target-and-environment-branch-protections-changes/) for security which changed the default behaviour of `pull_request_target`. After these changes to Github Actions took effect, all PRs to *any* branch of OpenTitan changed to use the `master` workflow for protection via the PR change check script, instead of that branch's workflow. While this remains fine for calculating the PR diff (using the Github CLI), it also means that the `BLOCKFILE` being used by the check script was the `BLOCKFILE` on `master`. See the original comment on this from @jwnrt [here](https://github.com/lowRISC/opentitan/pull/28921#pullrequestreview-3568286010).

This is not ideal, as we want each non-default branch to be able to specify a `BLOCKFILE` for files that should be blocked specifically on that branch. For example, on `earlgrey_1.0.0`, we do not want to permit any further RTL changes. This change ensures that the PR target branch's `BLOCKFILE` is used to provide appropriate protections, so that this CI check continues functioning as it has been.