### PR TITLE
[pentest] Enable Verilator exec environment

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/BUILD
@@ -14,6 +14,7 @@ load(
     "opentitan_binary",
     "opentitan_test",
     "silicon_params",
+    "verilator_params",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -190,6 +191,12 @@ opentitan_test(
             "skip_in_ci",
         ],
     ),
+    verilator = verilator_params(
+        tags = [
+            "manual",
+            "skip_in_ci",
+        ],
+    ),
     deps = FIRMWARE_DEPS_FI,
 )
 
@@ -204,6 +211,12 @@ opentitan_test(
         "skip_in_ci",
     ]),
     silicon = silicon_params(
+        tags = [
+            "manual",
+            "skip_in_ci",
+        ],
+    ),
+    verilator = verilator_params(
         tags = [
             "manual",
             "skip_in_ci",
@@ -228,6 +241,12 @@ opentitan_test(
             "skip_in_ci",
         ],
     ),
+    verilator = verilator_params(
+        tags = [
+            "manual",
+            "skip_in_ci",
+        ],
+    ),
     deps = FIRMWARE_DEPS_FI_OTBN,
 )
 
@@ -242,6 +261,12 @@ opentitan_test(
         "skip_in_ci",
     ]),
     silicon = silicon_params(
+        tags = [
+            "manual",
+            "skip_in_ci",
+        ],
+    ),
+    verilator = verilator_params(
         tags = [
             "manual",
             "skip_in_ci",
@@ -266,6 +291,12 @@ opentitan_test(
             "skip_in_ci",
         ],
     ),
+    verilator = verilator_params(
+        tags = [
+            "manual",
+            "skip_in_ci",
+        ],
+    ),
     deps = FIRMWARE_DEPS_CRYPTOLIB_FI_SYM,
 )
 
@@ -280,6 +311,12 @@ opentitan_test(
         "skip_in_ci",
     ]),
     silicon = silicon_params(
+        tags = [
+            "manual",
+            "skip_in_ci",
+        ],
+    ),
+    verilator = verilator_params(
         tags = [
             "manual",
             "skip_in_ci",
@@ -304,6 +341,12 @@ opentitan_test(
             "skip_in_ci",
         ],
     ),
+    verilator = verilator_params(
+        tags = [
+            "manual",
+            "skip_in_ci",
+        ],
+    ),
     deps = FIRMWARE_DEPS_CRYPTOLIB_SCA_SYM,
 )
 
@@ -318,6 +361,12 @@ opentitan_test(
         "skip_in_ci",
     ]),
     silicon = silicon_params(
+        tags = [
+            "manual",
+            "skip_in_ci",
+        ],
+    ),
+    verilator = verilator_params(
         tags = [
             "manual",
             "skip_in_ci",

--- a/sw/device/tests/penetrationtests/pentest.bzl
+++ b/sw/device/tests/penetrationtests/pentest.bzl
@@ -10,6 +10,7 @@ load(
     "fpga_params",
     "opentitan_test",
     "silicon_params",
+    "verilator_params",
 )
 load("@rules_python//python:defs.bzl", "py_test")
 
@@ -18,10 +19,12 @@ load("@rules_python//python:defs.bzl", "py_test")
 # each execution environment:
 # - cw340
 # - silicon
+# - verilator
 PENTEST_EXEC_ENVS = {
     "//hw/top_earlgrey:fpga_cw340_test_rom": "fpga_cw340",
     "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": "fpga_cw340",
     "//hw/top_earlgrey:fpga_cw340_rom_ext": "fpga_cw340",
+    "//hw/top_earlgrey:sim_verilator": "verilator",
 } | EARLGREY_SILICON_OWNER_ROM_EXT_ENVS
 
 GDB_EXEC_ENVS = {
@@ -213,6 +216,15 @@ def pentest_fi(name, test_vectors, test_args, test_harness, tags):
             """ + test_args,
             test_harness = test_harness,
         ),
+        verilator = verilator_params(
+            timeout = "long",
+            tags = ["manual"],
+            data = test_vectors,
+            test_cmd = """
+                --bootstrap={firmware}
+            """ + test_args,
+            test_harness = test_harness,
+        ),
         deps = FIRMWARE_DEPS_FI,
     )
 
@@ -251,6 +263,15 @@ def pentest_fi_ibex(name, test_vectors, test_args, test_harness, tags):
         silicon = silicon_params(
             timeout = "eternal",
             tags = tags,
+            data = test_vectors,
+            test_cmd = """
+                --bootstrap={firmware}
+            """ + test_args,
+            test_harness = test_harness,
+        ),
+        verilator = verilator_params(
+            timeout = "long",
+            tags = ["manual"],
             data = test_vectors,
             test_cmd = """
                 --bootstrap={firmware}
@@ -301,6 +322,15 @@ def pentest_fi_otbn(name, test_vectors, test_args, test_harness, tags):
             """ + test_args,
             test_harness = test_harness,
         ),
+        verilator = verilator_params(
+            timeout = "long",
+            tags = ["manual"],
+            data = test_vectors,
+            test_cmd = """
+                --bootstrap={firmware}
+            """ + test_args,
+            test_harness = test_harness,
+        ),
         deps = FIRMWARE_DEPS_FI_OTBN,
     )
 
@@ -339,6 +369,15 @@ def pentest_sca(name, test_vectors, test_args, test_harness, tags):
         silicon = silicon_params(
             timeout = "eternal",
             tags = tags,
+            data = test_vectors,
+            test_cmd = """
+                --bootstrap={firmware}
+            """ + test_args,
+            test_harness = test_harness,
+        ),
+        verilator = verilator_params(
+            timeout = "long",
+            tags = ["manual"],
             data = test_vectors,
             test_cmd = """
                 --bootstrap={firmware}
@@ -389,6 +428,15 @@ def pentest_cryptolib_fi_sym(name, test_vectors, test_args, test_harness, tags):
             """ + test_args,
             test_harness = test_harness,
         ),
+        verilator = verilator_params(
+            timeout = "long",
+            tags = ["manual"],
+            data = test_vectors,
+            test_cmd = """
+                --bootstrap={firmware}
+            """ + test_args,
+            test_harness = test_harness,
+        ),
         deps = FIRMWARE_DEPS_CRYPTOLIB_FI_SYM,
     )
 
@@ -427,6 +475,15 @@ def pentest_cryptolib_fi_gdb_sym(name, test_vectors, test_args, test_harness, ta
         silicon = silicon_params(
             timeout = "eternal",
             tags = tags,
+            data = test_vectors,
+            test_cmd = """
+                --bootstrap={firmware}
+            """ + test_args,
+            test_harness = test_harness,
+        ),
+        verilator = verilator_params(
+            timeout = "long",
+            tags = ["manual"],
             data = test_vectors,
             test_cmd = """
                 --bootstrap={firmware}
@@ -477,6 +534,15 @@ def pentest_cryptolib_fi_asym(name, test_vectors, test_args, test_harness, tags)
             """ + test_args,
             test_harness = test_harness,
         ),
+        verilator = verilator_params(
+            timeout = "long",
+            tags = ["manual"],
+            data = test_vectors,
+            test_cmd = """
+                --bootstrap={firmware}
+            """ + test_args,
+            test_harness = test_harness,
+        ),
         deps = FIRMWARE_DEPS_CRYPTOLIB_FI_ASYM,
     )
 
@@ -515,6 +581,15 @@ def pentest_cryptolib_fi_gdb_asym(name, test_vectors, test_args, test_harness, t
         silicon = silicon_params(
             timeout = "eternal",
             tags = tags,
+            data = test_vectors,
+            test_cmd = """
+                --bootstrap={firmware}
+            """ + test_args,
+            test_harness = test_harness,
+        ),
+        verilator = verilator_params(
+            timeout = "long",
+            tags = ["manual"],
             data = test_vectors,
             test_cmd = """
                 --bootstrap={firmware}
@@ -565,6 +640,15 @@ def pentest_cryptolib_sca_sym(name, test_vectors, test_args, test_harness, tags)
             """ + test_args,
             test_harness = test_harness,
         ),
+        verilator = verilator_params(
+            timeout = "long",
+            tags = ["manual"],
+            data = test_vectors,
+            test_cmd = """
+                --bootstrap={firmware}
+            """ + test_args,
+            test_harness = test_harness,
+        ),
         deps = FIRMWARE_DEPS_CRYPTOLIB_SCA_SYM,
     )
 
@@ -603,6 +687,15 @@ def pentest_cryptolib_sca_asym(name, test_vectors, test_args, test_harness, tags
         silicon = silicon_params(
             timeout = "eternal",
             tags = tags,
+            data = test_vectors,
+            test_cmd = """
+                --bootstrap={firmware}
+            """ + test_args,
+            test_harness = test_harness,
+        ),
+        verilator = verilator_params(
+            timeout = "long",
+            tags = ["manual"],
             data = test_vectors,
             test_cmd = """
                 --bootstrap={firmware}


### PR DESCRIPTION
To prepare for the Verilator FI setup, enable running the pentest framework in Verilator.