### PR TITLE
[bazel] Evaluate enablement of -ftrivial-auto-var-init=zero

### DIFF
--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -74,6 +74,7 @@ cc_toolchain(
         "@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features",
         ":feat_rv32_bitmanip",
         ":feat_warnings_as_errors",
+        ":feat_zero_init",
     ],
     known_features = [
         "@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features",
@@ -87,6 +88,7 @@ cc_toolchain(
         ":feat_fastbuild",
         ":feat_opt",
         ":feat_rv32_bitmanip",
+        ":feat_zero_init",
     ],
     tool_map = ":tool_map",
 )
@@ -451,6 +453,18 @@ cc_args(
         "@rules_cc//cc/toolchains/actions:link_actions",
     ],
     args = ["-flto"],
+)
+
+cc_args(
+    name = "zero_init",
+    actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
+    args = ["-ftrivial-auto-var-init=zero"],
+)
+
+cc_feature(
+    name = "feat_zero_init",
+    args = [":zero_init"],
+    feature_name = "zero_init",
 )
 
 cc_args(


### PR DESCRIPTION
DRAFT. DO NOT MERGE.

This change is used to check if all existing tests will pass on the CI after enabling this compiler flag.