### PR TITLE
[doc] Reorganising contributor pages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,13 @@
 # Contributing code to the opentitan repository
 
+Please see [Contributing to OpenTitan](https://opentitan.org/book/doc/contributing)
+for more detailed guidance.
+
 ## Contributor License Agreement
 
 Contributions to OpenTitan must be accompanied by sign-off text that indicates
-acceptance of the Contributor License Agreement (see [CLA](CLA) for full
-text), which is closely derived from the Apache Individual Contributor License
+acceptance of the Contributor License Agreement (see [CLA](CLA) for full text),
+which is closely derived from the Apache Individual Contributor License
 Agreement. The sign-off text must be included once per commit, in the commit
 message. The sign-off can be automatically inserted using a command such as
 `git commit -s`, which will generate the text in the form:
@@ -23,29 +26,22 @@ with it, including a sign-off) is maintained indefinitely and may be
 redistributed consistent with this project or the open source license(s)
 involved.
 
-## Quick guidelines
+### Organisational Agreement
 
-* Keep a clean commit history. This means no merge commits, and no long series
-  of "fixup" patches (rebase or squash as appropriate). Structure work as a
-  series of logically ordered, atomic patches. `git rebase -i` is your friend.
-* Changes should be made via pull request, with review. A pull request will be
-  committed by a "committer" (an account listed in `COMMITTERS`) once it has
-  had an explicit positive review.
-* When changes are restricted to a specific area, you are recommended to add a
-  tag to the beginning of the first line of the commit message in square
-  brackets. e.g. "[uart] Fix bug #157".
-* Code review is not design review and doesn't remove the need for discussing
-  implementation options. If you would like to make a large-scale change or
-  discuss multiple implementation options, discuss on the mailing list.
-* Create pull requests from a fork rather than making new branches in
-  `github.com/lowrisc/opentitan`.
-* Do not attempt to commit code with a non-Apache license without discussing
-  first.
-* If a relevant bug or tracking issue exists, reference it in the pull request
-  and commits.
-* Do not report security vulnerabilities through public GitHub issues or pull
-  requests. For instructions on how to report vulnerabilities, please consult
-  SECURITY.md.
+Under the [CLA](CLA) a Grant of Copyright License is given by the individual to the Project.
+To ensure that the individual is authorised to give this grant, individuals need to be identified as
+a [Partner Individual](./doc/project_governance/useraccounts.md#partner-individuals)
+or an [Individual Collaborator](./doc/project_governance/useraccounts.md#individual-collaborators) with an appropriate agreement.
 
-Please see [Contributing to OpenTitan](https://opentitan.org/book/doc/contributing)
-for more general guidance.
+## Copyright messages
+
+More than 200 individuals from more than 25 organizations and more than 20 non-organizational individuals have contributed to OpenTitan to date.
+If all of them would add their own attribution or copyright notices, that would clutter the code base.
+Copyright is therefore indicated in OpenTitan files by a generic header:
+
+`Copyright lowRISC contributors (OpenTitan project).`
+
+Detailed and up-to-date attribution for all contributions is available via the Git version control system:
+- `git shortlog --author "<your name>"` lists all contributions under your name.
+- `git shortlog --author "<organization's domain>"` lists all contributions by an organization.
+- `git shortlog -- <path>` lists all contributors for a file or directory tree.

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,6 +1,7 @@
 - [About OpenTitan](./doc/sections/opentitan.md)
 
   - [Introduction](./README.md)
+  - [Why Open Source?](./doc/project_governance/opensource.md)
   - [OpenTitan News](./doc/project_governance/news.md))
   - [Product Architecture](./doc/productarchitecture.md)
   - [History](./doc/project_governance/history.md)

--- a/doc/contributing/README.md
+++ b/doc/contributing/README.md
@@ -22,17 +22,6 @@ Important points before getting started:
 **Important**: Please read the next three, short sections on reporting bugs, reporting security issues, and contributing code in preparation for making your first contribution to OpenTitan.
 If you would like more details, see the [Detailed Contribution Guide](./detailed_contribution_guide/README.md).
 
-## Bug reports
-
-**To report a security issue, please follow the [Security Issues Process](#security-issues)**.
-
-Ideally, all designs are bug free.
-Realistically, each piece of collateral in our repository is in a different state of maturity with some still under active testing and development.
-See the [Hardware Development Stages](../project_governance/development_stages.md) for an example of how hardware progress is tracked.
-
-We are happy to receive bug reports and eager to fix them.
-Please make reports by opening a new issue in our [GitHub issue tracker](https://github.com/lowRISC/opentitan/issues).
-
 ## Security issues
 
 Security is of major importance to the OpenTitan project.
@@ -44,7 +33,16 @@ For example,
 If you intend to work on potentially security sensitive matters, please first reach out to our experienced security team at security@opentitan.org before starting a public discussion.
 That will enable us to engage successfully without creating undue risk to the project or its consumers.
 
-Please refer to https://opentitan.org/cvd-policy for a description of our disclosure process.
+Please refer to [https://opentitan.org/cvd-policy](https://opentitan.org/cvd-policy) for a description of our disclosure process.
+
+## (Non-security) bug reports
+
+Ideally, all designs are bug free.
+Realistically, each piece of collateral in our repository is in a different state of maturity with some still under active testing and development.
+See the [Hardware Development Stages](../project_governance/development_stages.md) for an example of how hardware progress is tracked.
+
+We are happy to receive bug reports and eager to fix them.
+Please make reports by opening a new issue in the [GitHub issue tracker](https://github.com/lowRISC/opentitan/issues).
 
 ## Contributing code
 
@@ -59,4 +57,29 @@ For larger proposed changes we ask contributors to:
 * Implement the contribution, i.e., the solution previously agreed on, and reference the discussion when submitting the contribution.
 * Have the implementation reviewed by the team, address any feedback, and finally have it integrated into the project.
 
-Note that contributions must be accompanied by sign-off text which indicates acceptance of the project's Contributor License Agreement - see [CONTRIBUTING.md](https://github.com/lowRISC/opentitan/blob/master/CONTRIBUTING.md) for details.
+### Quick guidelines for code contribution
+
+* Keep a clean commit history. This means no merge commits, and no long series
+  of "fixup" patches (rebase or squash as appropriate). Structure work as a
+  series of logically ordered, atomic patches. `git rebase -i` is your friend.
+* Changes should be made via pull request, with review. A pull request will be
+  committed by a "committer" (an account listed in `COMMITTERS`) once it has
+  had an explicit positive review.
+* When changes are restricted to a specific area, you are recommended to add a
+  tag to the beginning of the first line of the commit message in square
+  brackets. e.g. "[uart] Fix bug #157".
+* Code review is not design review and doesn't remove the need for discussing
+  implementation options. If you would like to make a large-scale change or
+  discuss multiple implementation options, discuss on the mailing list.
+* Create pull requests from a fork rather than making new branches in
+  `github.com/lowrisc/opentitan`.
+* Do not attempt to commit code with a non-Apache license without discussing
+  first.
+* If a relevant bug or tracking issue exists, reference it in the pull request
+  and commits.
+
+## License agreements
+The following information is detailed in the [CONTRIBUTING.md](../../CONTRIBUTING.md) file
+* Contributor License agreement
+* Organisational Agreement
+* Use of Copyright messages

--- a/doc/project_governance/opensource.md
+++ b/doc/project_governance/opensource.md
@@ -1,0 +1,13 @@
+## Why Open Source?
+
+**Open sourcing the silicon design makes it more transparent, trustworthy, and ultimately, secure.**
+
+- Enhances trust and security
+- Enables and encourages innovation
+- Shares open infrastructure technology
+- Shares investment costs
+- Reduces supplier risk
+
+Our work is open and permissively licensed, moving the whole industry forward with flexible, accessible and effective systems and tools.
+
+We work closely and [respectfully](./code_of_conduct.md) with others, testing new ideas and developing systems together, and sharing what we learn and build.

--- a/doc/project_governance/useraccounts.md
+++ b/doc/project_governance/useraccounts.md
@@ -1,30 +1,9 @@
 # OpenTitan user accounts
 
-## Contributor License Agreement (CLA)
-
-All contributions to the project are under the terms of the [Contributor License Agreement](https://github.com/lowRISC/opentitan/blob/master/CLA) (CLA) which is referenced on every commit.
-This grants patent and copyright licenses to the project so that any submissions can legally be used by OpenTitan and downstream users.
-Copyright remains unchanged.
-
-More than 200 individuals from more than 25 organizations and more than 20 non-organizational individuals have contributed to OpenTitan to date.
-If all of them would add their own attribution or copyright notices, that would clutter the code base.
-Copyright is therefore indicated in OpenTitan files by a generic header:
-
-`Copyright lowRISC contributors (OpenTitan project).`
-
-Detailed and up-to-date attribution for all contributions is available via the Git version control system:
-- `git shortlog --author "<your name>"` lists all contributions under your name.
-- `git shortlog --author "<organization's domain>"` lists all contributions by an organization.
-- `git shortlog -- <path>` lists all contributors for a file or directory tree.
-
 ## Project Participants
-
-Submitters must be legally entitled to grant patent or copyright licenses for their own work.
-There are different categories of submitter who use different mechanisms for this.
 
 - **Partner Individuals** are individuals working for a Project Partner and designated by that Partner.
 - **Individual Collaborators** are individuals who are not working for any organisation.
-- **Non-partner individuals** exist for the unusual case of individuals who are working for an organisation which is not a Project Partner.
 
 *lowRISC reserves the right to refuse, or revoke, Project Participant status to any individual where, in the opinion of lowRISC C.I.C. (following consultation with the respective Project Partner in the case of Partner Individuals),*
 *the actions, inactions, conduct or connections of the Project Participant have harmed or risk harming the perception or reputation of lowRISC, the OpenTitan Project and/or any Project Partner.*
@@ -38,7 +17,7 @@ There are different categories of submitter who use different mechanisms for thi
 Partner Individuals are those working for an OpenTitan Project Partner and designated by that Project Partner as one of its contributors to the OpenTitan project.
 No separate legal agreement beyond the partner agreement is required.
 
-Partners may identify individuals as Partner Individuals by requesting an OpenTitan account (see below).
+Partners may identify individuals as Partner Individuals by requesting an [OpenTitan account](./useraccounts.md#requesting-a-partner-individual-account).
 A number of OpenTitan accounts are available according to the Partnership agreement.
 By identifying an individual as a Partner Individual, the Partner authorises them to agree to the terms in the OpenTitan CLA when making contributions.
 
@@ -47,15 +26,15 @@ If a Partner Individual leaves the employment of a Project Partner, the Project 
 ### Individual Collaborators
 
 Individual Collaborators are individuals who wish to make a significant contribution to the OpenTitan project, either on their own or as part of a team.
+They will need to sign an Individual Collaborator license agreement to contribute to OpenTitan.
+
 They should not be associated with any company.
-An individual can be 'associated with' a company or other institution by being an employee, consultant or director of the institution, or because they are primarily funded by an institution.
+An individual is 'associated with' a company or other institution by being an employee, consultant or director of the institution, or because they are primarily funded by an institution.
 
-They will need to sign an Individual Collaborator license agreement to gain access to OpenTitan.
+In most cases where an individual is associated with an organisation, the organisation will join as a Partner and the individual as a Partner Individual.
 
-### Non-Partner Individuals
-
-In unusual cases, participants may be associated with an organisation which is not an OpenTitan Project Partner.
-As the individuals are assigning licenses to the project, the organisation will need to sign a [corporate contributor license agreement](./corporate_cla.txt).
+If an individual is contributing as an individual collaborator, and is associated with an organisation which is not a Partner, as the individual is assigning licenses to the project,
+the associated organisation will need to sign a [corporate contributor license agreement](./corporate_cla.txt).
 
 ## Account Management
 
@@ -69,8 +48,6 @@ If an account is not needed, it can be closed by contacting get-involved@opentit
 
 ### Requesting other accounts
 Individual Collaborators should be proposed by lowRISC or a Project Partner, a decision by the Governing Board and approval by lowRISC after an Individual Collaborator agreement is signed.
-
-Non-Partner individuals should be discussed directly with lowRISC.
 
 ### Using an OpenTitan account
 All communications using your OpenTitan account are as part of the OpenTitan community.


### PR DESCRIPTION
Previously there were conflicting descriptions around individual and corporate CLAs.  
Rules have not been changed, but duplicated and conflicting data have been removed.
- Simplified the root CONTRIBUTING.md file
- Added this to the Website
- Put the extended information into contributing\README
- Removed the duplicate data from useraccounts 
Also added a new page on open source silicon

From review comments:
- Corrected broken links not flagged on local build
- Added bookmarks to hyperlinks