### PR TITLE
Backport 26295 ([cherry-pick] immutable rom ext implementation & size reduction to `earlgrey_1.0.0`)

### DIFF
--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -565,6 +565,7 @@ pub fn check_slot_b_boot_up(
     transport.reset(UartRx::Clear)?;
     let uart_console = transport.uart("console")?;
     let result = UartConsole::wait_for(&*uart_console, r"ROM_EXT:(.*)\r", timeout)?;
+    log::info!("ROM_EXT started.");
     response.stats.log_string(
         "rom_ext-version",
         result
@@ -573,6 +574,17 @@ pub fn check_slot_b_boot_up(
             .map(|s| s.as_str())
             .unwrap_or("unknown"),
     );
+    let result = UartConsole::wait_for(&*uart_console, r"IMM_SECTION:(.*)\r\n", timeout)?;
+    log::info!("IMM_ROM_EXT started.");
+    response.stats.log_string(
+        "imm_rom_ext-version",
+        result
+            .get(1)
+            .as_ref()
+            .map(|s| s.as_str())
+            .unwrap_or("unknown"),
+    );
+
     let t0 = Instant::now();
 
     // Timeout for waiting for a potential error message indicating invalid UDS


### PR DESCRIPTION
Backport 2 commits of #26295. 2 others were backported in #27714, the rest was already a master > earlgrey_1.0.0 cherry-pick