### PR TITLE
[aes] Upstream support for GCM - Part 8

### DIFF
--- a/hw/ip/aes/pre_dv/aes_tlul_shim_tb/README.md
+++ b/hw/ip/aes/pre_dv/aes_tlul_shim_tb/README.md
@@ -1,12 +1,38 @@
-TLUL/Shim Verilator Testbench
-=======================
+# TLUL/Shim Verilator Testbench
 
-This directory contains the Verilator testbench for the TLUL shim adapter that is attached
-to the AES IP block, run in the GCM mode.
+This directory contains the Verilator testbench for the TLUL shim adapter that is attached to the AES IP block.
+Out of the box, the testbench contains test vectors for most of the salient use cases, nonetheless extending the testbench with further tests is straightforward as detailed below.
 
+## Current Test Vectors
 
-How to build and run the example
---------------------------------
+The `./data` directory contains an array of `.svh` files each of them containing a single set of input stimuli that constitute a test:
+
+```
+data
+├── gcm_k128_a0_d0.svh    # AES-GCM-128 Encryption; 0 AD Bytes; 0 Msg Bytes
+├── gcm_k128_a0_d16.svh   # AES-GCM-128 Encryption; 0 AD Bytes; 16 Msg Bytes
+├── gcm_k128_a20_d60.svh  # AES-GCM-128 Encryption/Decryption/Save/Restore; 20 AD Bytes; 60 Msg Bytes
+├── gcm_k128_a20_d64.svh  # AES-GCM-128 Encryption; 20 AD Bytes; 64 Msg Bytes
+└── modes_d64.svh         # AES-{128,192,256}-{ECB,CBC,OFB,CFB,CTR} Encryption/Decryption
+```
+
+### Adding/Modifying Tests
+
+Each test vector file `./data/*.svh` starts with a preamble that instruments both the testbench RTL as well as the `c_dpi` model:
+
+```systemverilog
+`define AD_LENGTH    // Number of AD bytes
+`define MSG_LENGTH   // Number of Msg bytes
+`define NUM_REQUESTS // Total number of requests
+```
+
+Here, `NUM_REQUESTS` denotes the number of `read_request`, `write_request` and `c_dpi_load` invocations within the file.
+Having written a new test vector file, the `fusesoc` configuration needs to be made aware of it.
+
+1. Add the `.svh` filename to the list of RTL files under `files_rtl/files`.
+2. Add the `.svh` filename to the `DREQUESTS_FILE` Verilator variable under `verilator/verilator_options`.
+
+## Building and Running the Verilator Testbench
 
 To build the testbench, execute from the OpenTitan top level:
 
@@ -19,11 +45,11 @@ To execute the obtained Verilator binary and with trace generation, run:
 ./build/lowrisc_dv_verilator_aes_tlul_shim_tb_0/default-verilator/Vaes_tlul_shim_tb --trace
 ```
 
-Details of the testbench
-------------------------
+## Details of the testbench
 
 - cpp/aes\_tlul\_shim\_tb.cc: contains main function and instantiation of SimCtrl
 - rtl/aes\_tlul\_shim\_tb.sv: contains the testbench logic
 - rtl/aes\_tlul\_delayer\_tb.sv: contains an optional delayer module to artificially induce random delays between the Shim and the TLUL bus.
 - rtl/aes\_tlul\_shim\_tb_reqs.sv: contains requests (stimuli) that are fed to the testbench.
 - rtl/aes\_tlul\_shim\_tb_pkg.sv: contains common parameters and functions.
+- data/*: contains test vector files.

--- a/hw/ip/aes/pre_dv/aes_tlul_shim_tb/aes_tlul_shim_tb.core
+++ b/hw/ip/aes/pre_dv/aes_tlul_shim_tb/aes_tlul_shim_tb.core
@@ -11,8 +11,14 @@ filesets:
       - lowrisc:dv:aes_model_dpi
       - lowrisc:tlul:adapter_shim
     files:
+      - data/gcm_k128_a20_d60.svh : {is_include_file : true}
+      - data/gcm_k128_a20_d64.svh : {is_include_file : true}
+      - data/gcm_k128_a0_d16.svh : {is_include_file : true}
+      - data/gcm_k128_a0_d0.svh : {is_include_file : true}
+      - data/modes_d64.svh : {is_include_file : true}
       - rtl/aes_tlul_shim_tb_pkg.sv
       - rtl/aes_tlul_shim_tb_reqs.sv
+      - rtl/aes_tlul_shim_tb_c_dpi.sv
       - rtl/aes_tlul_shim_delayer.sv
       - rtl/aes_tlul_shim_tb.sv
     file_type: systemVerilogSource
@@ -38,6 +44,7 @@ targets:
         verilator_options:
 # Disabling tracing reduces compile times by multiple times, but doesn't have a
 # huge influence on runtime performance. (Based on early observations.)
+          - '-DREQUESTS_FILE=\"gcm_k128_a20_d60.svh\"'
           - '--trace'
           - '--trace-fst' # this requires -DVM_TRACE_FMT_FST in CFLAGS below!
           - '--trace-structs'

--- a/hw/ip/aes/pre_dv/aes_tlul_shim_tb/data/gcm_k128_a0_d0.svh
+++ b/hw/ip/aes/pre_dv/aes_tlul_shim_tb/data/gcm_k128_a0_d0.svh
@@ -1,0 +1,111 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// AES-GCM-128 Test Case #1
+// https://csrc.nist.rip/groups/ST/toolkit/BCM/documents/proposedmodes/gcm/gcm-spec.pdf
+
+// Preamble:
+`define AD_LENGTH 0
+`define DATA_LENGTH 0
+`define NUM_REQUESTS 42
+
+`define REQUESTS shim_request_t requests[`NUM_REQUESTS] = '{                                        \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_ENC,                                                                          \
+      mode:       AES_GCM,                                                                          \
+      key_length: AES_128,                                                                          \
+      key:        256'h0000000000000000000000000000000000000000000000000000000000000000,            \
+      iv:         128'h0000000000000000000000000000000000,                                          \
+      data:       '0,                                                                               \
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers  */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core, config GCM in `INIT` mode  */                                                 \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_GCM) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_GCM) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_INIT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_INIT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h00000000),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h00000000),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h00000000),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h00000000),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TAG` mode and write len(ad) || len(pt) to trigger tag computation */            \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)      << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_TAG) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)      << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_TAG) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h00000000),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read back the authentication tag */                                                            \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+                                                                                                    \
+  /* Read Caliptra-specific register */                                                             \
+  read_caliptra(CALIPTRA_NAME_0_OFFSET),                                                            \
+  read_caliptra(CALIPTRA_VERSION_0_OFFSET)                                                          \
+};

--- a/hw/ip/aes/pre_dv/aes_tlul_shim_tb/data/gcm_k128_a0_d16.svh
+++ b/hw/ip/aes/pre_dv/aes_tlul_shim_tb/data/gcm_k128_a0_d16.svh
@@ -1,0 +1,137 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// AES-GCM-128 Test Case #2
+// https://csrc.nist.rip/groups/ST/toolkit/BCM/documents/proposedmodes/gcm/gcm-spec.pdf
+
+// Preamble:
+`define AD_LENGTH 0
+`define DATA_LENGTH 16
+`define NUM_REQUESTS 55
+
+`define REQUESTS shim_request_t requests[`NUM_REQUESTS] = '{                                        \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_ENC,                                                                          \
+      mode:       AES_GCM,                                                                          \
+      key_length: AES_128,                                                                          \
+      key:        256'h0000000000000000000000000000000000000000000000000000000000000000,            \
+      iv:         128'h0000000000000000000000000000000000,                                          \
+      data:       128'h0000000000000000000000000000000000,                                          \
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers  */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core, config GCM in `INIT` mode */                                                  \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_GCM) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_GCM) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_INIT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_INIT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers.*/                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h00000000),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h00000000),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h00000000),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h00000000),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TEXT` mode and write plaintext block 1 into the data registers */               \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h00000000),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read out ciphertext */                                                                         \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TAG` mode and write len(ad) || len(pt) to trigger tag computation */            \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)      << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_TAG) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)      << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_TAG) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h80000000),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read back the authentication tag */                                                            \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+                                                                                                    \
+  /* Read Caliptra-specific register */                                                             \
+  read_caliptra(CALIPTRA_NAME_0_OFFSET),                                                            \
+  read_caliptra(CALIPTRA_VERSION_0_OFFSET)                                                          \
+};

--- a/hw/ip/aes/pre_dv/aes_tlul_shim_tb/data/gcm_k128_a20_d60.svh
+++ b/hw/ip/aes/pre_dv/aes_tlul_shim_tb/data/gcm_k128_a20_d60.svh
@@ -1,0 +1,842 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// AES-GCM-128 Test Case #4
+// https://csrc.nist.rip/groups/ST/toolkit/BCM/documents/proposedmodes/gcm/gcm-spec.pdf
+
+// Preamble:
+`define AD_LENGTH 20
+`define DATA_LENGTH 60
+`define NUM_REQUESTS 370
+
+`define REQUESTS shim_request_t requests[`NUM_REQUESTS] = '{                                        \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-GCM-128 Encryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_ENC,                                                                          \
+      mode:       AES_GCM,                                                                          \
+      key_length: AES_128,                                                                          \
+      key:        256'h0000000000000000000000000000000008833067948f6a6d1c73658692e9fffe,            \
+      iv:         128'h0000000088f8cadeaddbcefabebafeca,                                            \
+      data:       480'h397b63ba57e60daaf5ed6ab125b5a649240ecf2f53096895950c3c1c728a318a3d304c2edaf7341553a9a7869a26f5afc50959a5e50684f8253231d9,\
+      ad:         160'hd2daadabefbeaddecefaedfeefbeaddecefaedfe,                                    \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core, config GCM in `INIT` mode */                                                  \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_GCM) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_GCM) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_INIT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_INIT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h92e9fffe),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'h1c736586),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h948f6a6d),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h08833067),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'hbebafeca),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'haddbcefa),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h88f8cade),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h00000000),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `AAD` mode and write AD block 1 into the data registers */                       \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)      << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_AAD) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)      << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_AAD) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hcefaedfe),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hefbeadde),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hcefaedfe),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hefbeadde),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `AAD` mode and write AD block 2 into the data registers */                       \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(4)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_AAD) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(4)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_AAD) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hd2daadab),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h00000000),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TEXT` mode and write plaintext block 1 into the data registers */               \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h253231d9),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'he50684f8),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hc50959a5),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h9a26f5af),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read out ciphertext */                                                                         \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TEXT` mode and write plaintext block 2 into the data registers */               \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h53a9a786),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hdaf73415),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h3d304c2e),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h728a318a),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read out ciphertext */                                                                         \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TEXT` mode and write plaintext block 3 into the data registers */               \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h950c3c1c),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h53096895),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h240ecf2f),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h25b5a649),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read out ciphertext */                                                                         \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TEXT` mode and write plaintext block 4 into the data registers */               \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(12)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(12)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hf5ed6ab1),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h57e60daa),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h397b63ba),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h00000000),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read out ciphertext */                                                                         \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TAG` mode and write len(ad) || len(pt) to trigger tag computation */            \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)      << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_TAG) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)      << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_TAG) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'ha0000000),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'he0010000),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read back the authentication tag */                                                            \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-GCM-128 Decryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_DEC,                                                                          \
+      mode:       AES_GCM,                                                                          \
+      key_length: AES_128,                                                                          \
+      key:        256'h0000000000000000000000000000000008833067948f6a6d1c73658692e9fffe,            \
+      iv:         128'h0000000088f8cadeaddbcefabebafeca,                                            \
+      data:       480'h91e0583d97ac0a6a390ba31b05aa84ac5a6a8f7d1c936654b214d5212ea1ac29237ec135e0a4022c2f21aae39cd4d084b721724b24747721c21e8342,\
+      ad:         160'hd2daadabefbeaddecefaedfeefbeaddecefaedfe,                                    \
+      tag:        128'h471a12e75ae9fa94dba52132bc4fc95b                                             \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core, config GCM in `INIT` mode */                                                  \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_GCM) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_GCM) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_INIT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_INIT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h92e9fffe),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'h1c736586),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h948f6a6d),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h08833067),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'hbebafeca),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'haddbcefa),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h88f8cade),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h00000000),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `AAD` mode and write AD block 1 into the data registers */                       \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)      << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_AAD) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)      << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_AAD) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hcefaedfe),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hefbeadde),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hcefaedfe),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hefbeadde),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `AAD` mode and write AD block 2 into the data registers */                       \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(4)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_AAD) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(4)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_AAD) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hd2daadab),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h00000000),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TEXT` mode and write ciphertext block 1 into the data registers */              \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hc21e8342),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h24747721),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hb721724b),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h9cd4d084),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read out ciphertext */                                                                         \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TEXT` mode and write ciphertext block 2 into the data registers */              \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h2f21aae3),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'he0a4022c),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h237ec135),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h2ea1ac29),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read out ciphertext */                                                                         \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TEXT` mode and write ciphertext block 3 into the data registers */              \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hb214d521),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h1c936654),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h5a6a8f7d),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h05aa84ac),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read out ciphertext */                                                                         \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TEXT` mode and write ciphertext block 4 into the data registers */              \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(12)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(12)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h390ba31b),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h97ac0a6a),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h91e0583d),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h00000000),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read out ciphertext */                                                                         \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TAG` mode and write len(ad) || len(pt) to trigger tag computation */            \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)      << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_TAG) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)      << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_TAG) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'ha0000000),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'he0010000),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read back the authentication tag */                                                            \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-GCM-128 Save/Restore                                                **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_ENC,                                                                          \
+      mode:       AES_GCM,                                                                          \
+      key_length: AES_128,                                                                          \
+      key:        256'h0000000000000000000000000000000008833067948f6a6d1c73658692e9fffe,            \
+      iv:         128'h0000000088f8cadeaddbcefabebafeca,                                            \
+      data:       480'h397b63ba57e60daaf5ed6ab125b5a649240ecf2f53096895950c3c1c728a318a3d304c2edaf7341553a9a7869a26f5afc50959a5e50684f8253231d9,\
+      ad:         160'hd2daadabefbeaddecefaedfeefbeaddecefaedfe,                                    \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core, config GCM in `INIT` mode */                                                  \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_GCM) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_GCM) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_INIT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_INIT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h92e9fffe),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'h1c736586),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h948f6a6d),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h08833067),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'hbebafeca),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'haddbcefa),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h88f8cade),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h00000000),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `AAD` mode and write AD block 1 into the data registers */                       \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)      << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_AAD) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)      << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_AAD) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hcefaedfe),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hefbeadde),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hcefaedfe),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hefbeadde),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Save GCM State */                                                                              \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_SAVE) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_SAVE) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Read out GCM state */                                                                          \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Clear and reseed state */                                                                      \
+  write_request(                                                                                    \
+      AES_TRIGGER_OFFSET,                                                                           \
+      32'(1) << AES_TRIGGER_PRNG_RESEED_OFFSET          |                                           \
+      32'(1) << AES_TRIGGER_DATA_OUT_CLEAR_OFFSET       |                                           \
+      32'(1) << AES_TRIGGER_KEY_IV_DATA_IN_CLEAR_OFFSET |                                           \
+      32'(0) << AES_TRIGGER_START_OFFSET                                                            \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core, config GCM in `INIT` mode */                                                  \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_GCM) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_GCM) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_INIT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_INIT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h92e9fffe),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'h1c736586),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h948f6a6d),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h08833067),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'hbebafeca),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'haddbcefa),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h88f8cade),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h00000000),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Restore GCM State */                                                                           \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)          << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                     \
+      32'(GCM_RESTORE) << AES_CTRL_GCM_PHASE_OFFSET                                                 \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)          << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                     \
+      32'(GCM_RESTORE) << AES_CTRL_GCM_PHASE_OFFSET                                                 \
+  ),                                                                                                \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hb3b211df),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'ha00e629b),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h004067d2),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h3aa7016a),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `AAD` mode and write AD block 2 into the data registers */                       \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(4)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_AAD) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(4)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_AAD) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hd2daadab),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h00000000),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TEXT` mode and write plaintext block 1 into the data registers */               \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h253231d9),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'he50684f8),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hc50959a5),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h9a26f5af),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read out ciphertext */                                                                         \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TEXT` mode and write plaintext block 2 into the data registers */               \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h53a9a786),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hdaf73415),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h3d304c2e),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h728a318a),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read out ciphertext */                                                                         \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TEXT` mode and write plaintext block 3 into the data registers */               \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h950c3c1c),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h53096895),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h240ecf2f),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h25b5a649),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read out ciphertext */                                                                         \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TEXT` mode and write plaintext block 4 into the data registers */               \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(12)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(12)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hf5ed6ab1),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h57e60daa),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h397b63ba),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h00000000),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read out ciphertext */                                                                         \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TAG` mode and write len(ad) || len(pt) to trigger tag computation */            \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)      << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_TAG) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)      << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_TAG) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'ha0000000),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'he0010000),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read back the authentication tag */                                                            \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+                                                                                                    \
+  /* Read Caliptra-specific register */                                                             \
+  read_caliptra(CALIPTRA_NAME_0_OFFSET),                                                            \
+  read_caliptra(CALIPTRA_VERSION_0_OFFSET)                                                          \
+};

--- a/hw/ip/aes/pre_dv/aes_tlul_shim_tb/data/gcm_k128_a20_d64.svh
+++ b/hw/ip/aes/pre_dv/aes_tlul_shim_tb/data/gcm_k128_a20_d64.svh
@@ -1,0 +1,253 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// AES-GCM-128 Test Case #3
+// https://csrc.nist.rip/groups/ST/toolkit/BCM/documents/proposedmodes/gcm/gcm-spec.pdf
+
+// Preamble:
+`define AD_LENGTH 20
+`define DATA_LENGTH 64
+`define NUM_REQUESTS 110
+
+`define REQUESTS shim_request_t requests[`NUM_REQUESTS] = '{                                        \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_ENC,                                                                          \
+      mode:       AES_GCM,                                                                          \
+      key_length: AES_128,                                                                          \
+      key:        256'h0000000000000000000000000000000008833067948f6a6d1c73658692e9fffe,            \
+      iv:         128'h0000000088f8cadeaddbcefabebafeca,                                            \
+      data:       512'h55d2af1a397b63ba57e60daaf5ed6ab125b5a649240ecf2f53096895950c3c1c728a318a3d304c2edaf7341553a9a7869a26f5afc50959a5e50684f8253231d9,\
+      ad:         160'hd2daadabefbeaddecefaedfeefbeaddecefaedfe,                                    \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers  */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core, config GCM in `INIT` mode */                                                  \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_GCM) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_GCM) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_INIT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_INIT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h92e9fffe),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'h1c736586),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h948f6a6d),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h08833067),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'hbebafeca),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'haddbcefa),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h88f8cade),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h00000000),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `AAD` mode and write AD block 1 into the data registers */                       \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)      << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_AAD) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)      << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_AAD) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hcefaedfe),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hefbeadde),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hcefaedfe),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hefbeadde),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `AAD` mode and write AD block 2 into the data registers */                       \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(4)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_AAD) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(4)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_AAD) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hd2daadab),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h00000000),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TEXT` mode and write plaintext block 1 into the data registers */               \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h253231d9),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'he50684f8),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hc50959a5),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h9a26f5af),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read out ciphertext */                                                                         \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TEXT` mode and write plaintext block 2 into the data registers */               \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h53a9a786),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hdaf73415),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h3d304c2e),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h728a318a),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read out ciphertext */                                                                         \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TEXT` mode and write plaintext block 3 into the data registers */               \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h950c3c1c),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h53096895),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h240ecf2f),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h25b5a649),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read out ciphertext  */                                                                        \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TEXT` mode and write plaintext block 4 into the data registers */               \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)       << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                        \
+      32'(GCM_TEXT) << AES_CTRL_GCM_PHASE_OFFSET                                                    \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hf5ed6ab1),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h57e60daa),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h397b63ba),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h55d2af1a),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read out ciphertext */                                                                         \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config GCM in `TAG` mode and write len(ad) || len(pt) to trigger tag computation */            \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)      << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_TAG) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_GCM_SHADOWED_OFFSET,                                                                 \
+      32'(16)      << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |                                         \
+      32'(GCM_TAG) << AES_CTRL_GCM_PHASE_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'ha0000000),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h00000000),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h00020000),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read back the authentication tag */                                                            \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+                                                                                                    \
+  /* Read Caliptra-specific register */                                                             \
+  read_caliptra(CALIPTRA_NAME_0_OFFSET),                                                            \
+  read_caliptra(CALIPTRA_VERSION_0_OFFSET)                                                          \
+};

--- a/hw/ip/aes/pre_dv/aes_tlul_shim_tb/data/modes_d64.svh
+++ b/hw/ip/aes/pre_dv/aes_tlul_shim_tb/data/modes_d64.svh
@@ -1,0 +1,3606 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// AES Modes of Operation Test Vectors
+// https://nvlpubs.nist.gov/nistpubs/legacy/sp/nistspecialpublication800-38a.pdf
+
+// Preamble:
+`define AD_LENGTH 0
+`define DATA_LENGTH 64
+`define NUM_REQUESTS 1982
+
+`define REQUESTS shim_request_t requests[`NUM_REQUESTS] = '{                                        \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-ECB-128 Encryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_ENC,                                                                          \
+      mode:       AES_ECB,                                                                          \
+      key_length: AES_128,                                                                          \
+      key:        256'h000000000000000000000000000000003c4fcf098815f7aba6d2ae2816157e2b,            \
+      iv:         '0,                                                                               \
+      data:       512'h10376ce67b412bad179b4fdf45249ff6ef520a1a19c1fbe511e45ca3461cc830518eaf45ac6fb79e9cac031e578a2dae6bc1bee22e409f96e93d7e117393172a,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_ECB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_ECB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h16157e2b),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'ha6d2ae28),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h8815f7ab),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h3c4fcf09),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h7393172a),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'he93d7e11),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h2e409f96),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h6bc1bee2),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h578a2dae),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h9cac031e),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hac6fb79e),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h518eaf45),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h461cc830),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h11e45ca3),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h19c1fbe5),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hef520a1a),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h45249ff6),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h179b4fdf),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h7b412bad),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h10376ce6),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-CBC-128 Encryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_ENC,                                                                          \
+      mode:       AES_CBC,                                                                          \
+      key_length: AES_128,                                                                          \
+      key:        256'h000000000000000000000000000000003c4fcf098815f7aba6d2ae2816157e2b,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'h10376ce67b412bad179b4fdf45249ff6ef520a1a19c1fbe511e45ca3461cc830518eaf45ac6fb79e9cac031e578a2dae6bc1bee22e409f96e93d7e117393172a,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CBC) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CBC) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h16157e2b),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'ha6d2ae28),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h8815f7ab),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h3c4fcf09),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h7393172a),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'he93d7e11),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h2e409f96),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h6bc1bee2),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h578a2dae),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h9cac031e),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hac6fb79e),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h518eaf45),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h461cc830),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h11e45ca3),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h19c1fbe5),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hef520a1a),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h45249ff6),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h179b4fdf),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h7b412bad),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h10376ce6),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-CFB-128 Encryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_ENC,                                                                          \
+      mode:       AES_CFB,                                                                          \
+      key_length: AES_128,                                                                          \
+      key:        256'h000000000000000000000000000000003c4fcf098815f7aba6d2ae2816157e2b,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'h10376ce67b412bad179b4fdf45249ff6ef520a1a19c1fbe511e45ca3461cc830518eaf45ac6fb79e9cac031e578a2dae6bc1bee22e409f96e93d7e117393172a,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h16157e2b),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'ha6d2ae28),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h8815f7ab),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h3c4fcf09),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h7393172a),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'he93d7e11),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h2e409f96),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h6bc1bee2),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h578a2dae),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h9cac031e),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hac6fb79e),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h518eaf45),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h461cc830),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h11e45ca3),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h19c1fbe5),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hef520a1a),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h45249ff6),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h179b4fdf),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h7b412bad),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h10376ce6),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-OFB-128 Encryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_ENC,                                                                          \
+      mode:       AES_OFB,                                                                          \
+      key_length: AES_128,                                                                          \
+      key:        256'h000000000000000000000000000000003c4fcf098815f7aba6d2ae2816157e2b,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'h10376ce67b412bad179b4fdf45249ff6ef520a1a19c1fbe511e45ca3461cc830518eaf45ac6fb79e9cac031e578a2dae6bc1bee22e409f96e93d7e117393172a,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_OFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_OFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h16157e2b),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'ha6d2ae28),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h8815f7ab),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h3c4fcf09),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h7393172a),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'he93d7e11),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h2e409f96),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h6bc1bee2),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h578a2dae),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h9cac031e),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hac6fb79e),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h518eaf45),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h461cc830),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h11e45ca3),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h19c1fbe5),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hef520a1a),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h45249ff6),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h179b4fdf),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h7b412bad),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h10376ce6),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-CTR-128 Encryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_ENC,                                                                          \
+      mode:       AES_CTR,                                                                          \
+      key_length: AES_128,                                                                          \
+      key:        256'h000000000000000000000000000000003c4fcf098815f7aba6d2ae2816157e2b,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'h10376ce67b412bad179b4fdf45249ff6ef520a1a19c1fbe511e45ca3461cc830518eaf45ac6fb79e9cac031e578a2dae6bc1bee22e409f96e93d7e117393172a,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CTR) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CTR) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h16157e2b),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'ha6d2ae28),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h8815f7ab),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h3c4fcf09),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h7393172a),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'he93d7e11),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h2e409f96),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h6bc1bee2),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h578a2dae),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h9cac031e),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hac6fb79e),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h518eaf45),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h461cc830),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h11e45ca3),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h19c1fbe5),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hef520a1a),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h45249ff6),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h179b4fdf),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h7b412bad),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h10376ce6),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-ECB-128 Decryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_DEC,                                                                          \
+      mode:       AES_ECB,                                                                          \
+      key_length: AES_128,                                                                          \
+      key:        256'h000000000000000000000000000000003c4fcf098815f7aba6d2ae2816157e2b,            \
+      iv:         '0,                                                                               \
+      data:       512'hd45d7204712023823fade8275e780c7b880603ede3001b8823ce8e597fcdb143afbafd965a8985e79d69b90385d5d3f597ef6624f3ca9ea860367a0db47bd73a,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_ECB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+ write_request(                                                                                     \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_ECB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h16157e2b),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'ha6d2ae28),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h8815f7ab),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h3c4fcf09),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hb47bd73a),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h60367a0d),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hf3ca9ea8),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h97ef6624),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h85d5d3f5),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h9d69b903),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h5a8985e7),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hafbafd96),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h7fcdb143),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h23ce8e59),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'he3001b88),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h880603ed),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h5e780c7b),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h3fade827),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h71202382),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hd45d7204),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-CBC-128 Decryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+ c_dpi_load('{                                                                                      \
+      operation:  AES_DEC,                                                                          \
+      mode:       AES_CBC,                                                                          \
+      key_length: AES_128,                                                                          \
+      key:        256'h000000000000000000000000000000003c4fcf098815f7aba6d2ae2816157e2b,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'ha7e1867530ca0e1209ac1f68a1caf13f169522229ee616713b74c1e3b8d6be73b27876913a11db95ee1972509bcb86507d19e9129b8ee9ce46b21981acab4976,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CBC) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CBC) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h16157e2b),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'ha6d2ae28),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h8815f7ab),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h3c4fcf09),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hacab4976),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h46b21981),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h9b8ee9ce),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h7d19e912),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h9bcb8650),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hee197250),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h3a11db95),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hb2787691),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hb8d6be73),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h3b74c1e3),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h9ee61671),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h16952222),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'ha1caf13f),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h09ac1f68),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h30ca0e12),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'ha7e18675),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-CFB-128 Decryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_DEC,                                                                          \
+      mode:       AES_CFB,                                                                          \
+      key_length: AES_128,                                                                          \
+      key:        256'h000000000000000000000000000000003c4fcf098815f7aba6d2ae2816157e2b,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'he6f2f79f6fc6c4ea0e1c5d7c35054bc0dff4a487f18c80b140b1cba3671f75268be51c9fadcde3cd3fa9b3a03745a6c84afb3ce8f849343320ad2db72ed93f3b,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h16157e2b),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'ha6d2ae28),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h8815f7ab),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h3c4fcf09),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h2ed93f3b),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h20ad2db7),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hf8493433),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h4afb3ce8),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h3745a6c8),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h3fa9b3a0),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hadcde3cd),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h8be51c9f),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h671f7526),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h40b1cba3),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hf18c80b1),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hdff4a487),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h35054bc0),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h0e1c5d7c),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h6fc6c4ea),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'he6f2f79f),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-OFB-128 Decryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_DEC,                                                                          \
+      mode:       AES_OFB,                                                                          \
+      key_length: AES_128,                                                                          \
+      key:        256'h000000000000000000000000000000003c4fcf098815f7aba6d2ae2816157e2b,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'h5eaed6c1d910a56678c759f628654c30cced6022a8f74443f6ec5f9c1e05409725d84ec5da523cf5038f91168d5089774afb3ce8f849343320ad2db72ed93f3b,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_OFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_OFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h16157e2b),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'ha6d2ae28),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h8815f7ab),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h3c4fcf09),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h2ed93f3b),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h20ad2db7),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hf8493433),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h4afb3ce8),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h8d508977),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h038f9116),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hda523cf5),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h25d84ec5),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h1e054097),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hf6ec5f9c),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'ha8f74443),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hcced6022),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h28654c30),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h78c759f6),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hd910a566),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h5eaed6c1),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-CTR-128 Decryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_DEC,                                                                          \
+      mode:       AES_CTR,                                                                          \
+      key_length: AES_128,                                                                          \
+      key:        256'h000000000000000000000000000000003c4fcf098815f7aba6d2ae2816157e2b,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'hee9c00f3a0702179d103be2fda1d031eab3eb00d02094f5b5ed3d5db3edfe45afffdffb97b181786fffd70796bf60698ceb60d996468ef1b26e320b691614d87,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CTR) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_128) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CTR) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h16157e2b),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'ha6d2ae28),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h8815f7ab),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h3c4fcf09),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h91614d87),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h26e320b6),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h6468ef1b),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hceb60d99),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h6bf60698),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hfffd7079),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h7b181786),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hfffdffb9),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h3edfe45a),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h5ed3d5db),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h02094f5b),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hab3eb00d),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hda1d031e),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hd103be2f),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'ha0702179),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hee9c00f3),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-ECB-192 Encryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_ENC,                                                                          \
+      mode:       AES_ECB,                                                                          \
+      key_length: AES_192,                                                                          \
+      key:        256'h00000000000000007b6b2c52d2eaf862e57990802bf310c852640edaf7b0738e,            \
+      iv:         '0,                                                                               \
+      data:       512'h10376ce67b412bad179b4fdf45249ff6ef520a1a19c1fbe511e45ca3461cc830518eaf45ac6fb79e9cac031e578a2dae6bc1bee22e409f96e93d7e117393172a,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_192) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_ECB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_192) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_ECB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'hf7b0738e),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'h52640eda),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h2bf310c8),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'he5799080),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'hd2eaf862),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h7b6b2c52),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h7393172a),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'he93d7e11),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h2e409f96),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h6bc1bee2),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h578a2dae),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h9cac031e),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hac6fb79e),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h518eaf45),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h461cc830),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h11e45ca3),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h19c1fbe5),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hef520a1a),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h45249ff6),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h179b4fdf),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h7b412bad),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h10376ce6),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-CBC-192 Encryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_ENC,                                                                          \
+      mode:       AES_CBC,                                                                          \
+      key_length: AES_192,                                                                          \
+      key:        256'h00000000000000007b6b2c52d2eaf862e57990802bf310c852640edaf7b0738e,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'h10376ce67b412bad179b4fdf45249ff6ef520a1a19c1fbe511e45ca3461cc830518eaf45ac6fb79e9cac031e578a2dae6bc1bee22e409f96e93d7e117393172a,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_192) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CBC) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_192) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CBC) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'hf7b0738e),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'h52640eda),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h2bf310c8),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'he5799080),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'hd2eaf862),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h7b6b2c52),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h7393172a),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'he93d7e11),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h2e409f96),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h6bc1bee2),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h578a2dae),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h9cac031e),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hac6fb79e),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h518eaf45),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h461cc830),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h11e45ca3),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h19c1fbe5),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hef520a1a),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h45249ff6),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h179b4fdf),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h7b412bad),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h10376ce6),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-CFB-192 Encryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_ENC,                                                                          \
+      mode:       AES_CFB,                                                                          \
+      key_length: AES_192,                                                                          \
+      key:        256'h00000000000000007b6b2c52d2eaf862e57990802bf310c852640edaf7b0738e,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'h10376ce67b412bad179b4fdf45249ff6ef520a1a19c1fbe511e45ca3461cc830518eaf45ac6fb79e9cac031e578a2dae6bc1bee22e409f96e93d7e117393172a,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_192) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_192) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'hf7b0738e),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'h52640eda),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h2bf310c8),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'he5799080),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'hd2eaf862),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h7b6b2c52),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h7393172a),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'he93d7e11),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h2e409f96),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h6bc1bee2),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h578a2dae),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h9cac031e),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hac6fb79e),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h518eaf45),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h461cc830),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h11e45ca3),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h19c1fbe5),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hef520a1a),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h45249ff6),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h179b4fdf),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h7b412bad),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h10376ce6),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-OFB-192 Encryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_ENC,                                                                          \
+      mode:       AES_OFB,                                                                          \
+      key_length: AES_192,                                                                          \
+      key:        256'h00000000000000007b6b2c52d2eaf862e57990802bf310c852640edaf7b0738e,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'h10376ce67b412bad179b4fdf45249ff6ef520a1a19c1fbe511e45ca3461cc830518eaf45ac6fb79e9cac031e578a2dae6bc1bee22e409f96e93d7e117393172a,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_192) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_OFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_192) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_OFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'hf7b0738e),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'h52640eda),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h2bf310c8),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'he5799080),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'hd2eaf862),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h7b6b2c52),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h7393172a),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'he93d7e11),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h2e409f96),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h6bc1bee2),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h578a2dae),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h9cac031e),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hac6fb79e),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h518eaf45),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h461cc830),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h11e45ca3),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h19c1fbe5),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hef520a1a),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h45249ff6),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h179b4fdf),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h7b412bad),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h10376ce6),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-CTR-192 Encryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_ENC,                                                                          \
+      mode:       AES_CTR,                                                                          \
+      key_length: AES_192,                                                                          \
+      key:        256'h00000000000000007b6b2c52d2eaf862e57990802bf310c852640edaf7b0738e,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'h10376ce67b412bad179b4fdf45249ff6ef520a1a19c1fbe511e45ca3461cc830518eaf45ac6fb79e9cac031e578a2dae6bc1bee22e409f96e93d7e117393172a,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_192) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CTR) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_192) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CTR) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'hf7b0738e),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'h52640eda),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h2bf310c8),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'he5799080),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'hd2eaf862),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h7b6b2c52),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h7393172a),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'he93d7e11),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h2e409f96),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h6bc1bee2),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h578a2dae),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h9cac031e),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hac6fb79e),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h518eaf45),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h461cc830),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h11e45ca3),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h19c1fbe5),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hef520a1a),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h45249ff6),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h179b4fdf),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h7b412bad),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h10376ce6),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-ECB-192 Decryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_DEC,                                                                          \
+      mode:       AES_ECB,                                                                          \
+      key_length: AES_192,                                                                          \
+      key:        256'h00000000000000007b6b2c52d2eaf862e57990802bf310c852640edaf7b0738e,            \
+      iv:         '0,                                                                               \
+      data:       512'h0e8ec103166916fb726c8d73ba414b9a4e44e6ac2fbae0dc0ae6e27022fd7aefef4eeeecb3ec3477add30a6d84044197cca51f5714a212f75ff2456e1d4f33bd,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_192) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_ECB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_192) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_ECB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'hf7b0738e),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'h52640eda),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h2bf310c8),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'he5799080),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'hd2eaf862),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h7b6b2c52),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h1d4f33bd),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h5ff2456e),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h14a212f7),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hcca51f57),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h84044197),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hadd30a6d),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hb3ec3477),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hef4eeeec),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h22fd7aef),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h0ae6e270),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h2fbae0dc),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h4e44e6ac),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hba414b9a),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h726c8d73),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h166916fb),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h0e8ec103),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-CBC-192 Decryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_DEC,                                                                          \
+      mode:       AES_CBC,                                                                          \
+      key_length: AES_192,                                                                          \
+      key:        256'h00000000000000007b6b2c52d2eaf862e57990802bf310c852640edaf7b0738e,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'hcd15564fe6a920d98188598879e2b008e002f13dacbaa97fe07afb1220241b575a14693f7638e7e5f4ed7dada9add9b4974104846d0ad3ad7734ecb3ecee4eef,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_192) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CBC) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_192) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CBC) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'hf7b0738e),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'h52640eda),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h2bf310c8),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'he5799080),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'hd2eaf862),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h7b6b2c52),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hecee4eef),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h7734ecb3),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h6d0ad3ad),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h97410484),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'ha9add9b4),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hf4ed7dad),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h7638e7e5),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h5a14693f),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h20241b57),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'he07afb12),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hacbaa97f),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'he002f13d),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h79e2b008),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h81885988),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'he6a920d9),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hcd15564f),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-CFB-192 Decryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_DEC,                                                                          \
+      mode:       AES_CFB,                                                                          \
+      key_length: AES_192,                                                                          \
+      key:        256'h00000000000000007b6b2c52d2eaf862e57990802bf310c852640edaf7b0738e,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'hff094b58ba8fae42a04f83a99c9f5fc0c9c4fa1eed0fe6c8b1889bd51d8a1e2e7a3d1d17702b1a96213617817f7fce6774419ac90959c234ab8cf1dd6f0dc8cd,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_192) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_192) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'hf7b0738e),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'h52640eda),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h2bf310c8),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'he5799080),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'hd2eaf862),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h7b6b2c52),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h6f0dc8cd),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hab8cf1dd),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h0959c234),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h74419ac9),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h7f7fce67),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h21361781),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h702b1a96),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h7a3d1d17),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h1d8a1e2e),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hb1889bd5),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hed0fe6c8),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hc9c4fa1e),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h9c9f5fc0),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'ha04f83a9),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hba8fae42),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hff094b58),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-OFB-192 Decryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_DEC,                                                                          \
+      mode:       AES_OFB,                                                                          \
+      key_length: AES_192,                                                                          \
+      key:        256'h00000000000000007b6b2c52d2eaf862e57990802bf310c852640edaf7b0738e,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'h2ac9acd94b52ac9c3e6cca5708209f6df2a559af4d6d9c556f59f6c0ea9a9a8d010410c10017e8097c83634c8d8bc2fc74419ac90959c234ab8cf1dd6f0dc8cd,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_192) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_OFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_192) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_OFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'hf7b0738e),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'h52640eda),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h2bf310c8),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'he5799080),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'hd2eaf862),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h7b6b2c52),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h6f0dc8cd),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hab8cf1dd),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h0959c234),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h74419ac9),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h8d8bc2fc),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h7c83634c),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h0017e809),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h010410c1),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hea9a9a8d),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h6f59f6c0),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h4d6d9c55),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hf2a559af),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h08209f6d),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h3e6cca57),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h4b52ac9c),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h2ac9acd9),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-CTR-192 Decryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_DEC,                                                                          \
+      mode:       AES_CTR,                                                                          \
+      key_length: AES_192,                                                                          \
+      key:        256'h00000000000000007b6b2c52d2eaf862e57990802bf310c852640edaf7b0738e,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'h50b0c658ecda975a580998d2f6a7784ff7ab2056661dbdd170c6ebd16bb2361e948ecef4c6c2ccd5effaa60aec3903090b6e7efe59042b4fa21c52172493bc1a,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_192) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CTR) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_192) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CTR) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'hf7b0738e),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'h52640eda),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'h2bf310c8),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'he5799080),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'hd2eaf862),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'h7b6b2c52),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h2493bc1a),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'ha21c5217),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h59042b4f),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h0b6e7efe),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hec390309),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'heffaa60a),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hc6c2ccd5),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h948ecef4),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h6bb2361e),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h70c6ebd1),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h661dbdd1),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hf7ab2056),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write CT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hf6a7784f),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h580998d2),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hecda975a),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h50b0c658),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read PT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-ECB-256 Encryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_ENC,                                                                          \
+      mode:       AES_ECB,                                                                          \
+      key_length: AES_256,                                                                          \
+      key:        256'hf4df1409a310982dd708613b072c351f81777d85f0ae732bbe71ca1510eb3d60,            \
+      iv:         '0,                                                                               \
+      data:       512'h10376ce67b412bad179b4fdf45249ff6ef520a1a19c1fbe511e45ca3461cc830518eaf45ac6fb79e9cac031e578a2dae6bc1bee22e409f96e93d7e117393172a,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_256) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_ECB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_256) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_ECB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h10eb3d60),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'hbe71ca15),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'hf0ae732b),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h81777d85),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h072c351f),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'hd708613b),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'ha310982d),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'hf4df1409),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h7393172a),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'he93d7e11),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h2e409f96),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h6bc1bee2),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h578a2dae),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h9cac031e),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hac6fb79e),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h518eaf45),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h461cc830),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h11e45ca3),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h19c1fbe5),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hef520a1a),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h45249ff6),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h179b4fdf),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h7b412bad),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h10376ce6),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-CBC-256 Encryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_ENC,                                                                          \
+      mode:       AES_CBC,                                                                          \
+      key_length: AES_256,                                                                          \
+      key:        256'hf4df1409a310982dd708613b072c351f81777d85f0ae732bbe71ca1510eb3d60,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'h10376ce67b412bad179b4fdf45249ff6ef520a1a19c1fbe511e45ca3461cc830518eaf45ac6fb79e9cac031e578a2dae6bc1bee22e409f96e93d7e117393172a,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_256) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CBC) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_256) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CBC) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h10eb3d60),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'hbe71ca15),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'hf0ae732b),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h81777d85),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h072c351f),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'hd708613b),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'ha310982d),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'hf4df1409),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h7393172a),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'he93d7e11),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h2e409f96),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h6bc1bee2),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h578a2dae),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h9cac031e),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hac6fb79e),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h518eaf45),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h461cc830),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h11e45ca3),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h19c1fbe5),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hef520a1a),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h45249ff6),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h179b4fdf),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h7b412bad),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h10376ce6),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-CFB-256 Encryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_ENC,                                                                          \
+      mode:       AES_CFB,                                                                          \
+      key_length: AES_256,                                                                          \
+      key:        256'hf4df1409a310982dd708613b072c351f81777d85f0ae732bbe71ca1510eb3d60,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'h10376ce67b412bad179b4fdf45249ff6ef520a1a19c1fbe511e45ca3461cc830518eaf45ac6fb79e9cac031e578a2dae6bc1bee22e409f96e93d7e117393172a,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_256) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_256) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h10eb3d60),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'hbe71ca15),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'hf0ae732b),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h81777d85),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h072c351f),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'hd708613b),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'ha310982d),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'hf4df1409),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h7393172a),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'he93d7e11),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h2e409f96),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h6bc1bee2),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h578a2dae),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h9cac031e),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hac6fb79e),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h518eaf45),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h461cc830),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h11e45ca3),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h19c1fbe5),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hef520a1a),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h45249ff6),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h179b4fdf),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h7b412bad),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h10376ce6),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-OFB-256 Encryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_ENC,                                                                          \
+      mode:       AES_OFB,                                                                          \
+      key_length: AES_256,                                                                          \
+      key:        256'hf4df1409a310982dd708613b072c351f81777d85f0ae732bbe71ca1510eb3d60,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'h10376ce67b412bad179b4fdf45249ff6ef520a1a19c1fbe511e45ca3461cc830518eaf45ac6fb79e9cac031e578a2dae6bc1bee22e409f96e93d7e117393172a,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_256) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_OFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_256) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_OFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h10eb3d60),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'hbe71ca15),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'hf0ae732b),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h81777d85),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h072c351f),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'hd708613b),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'ha310982d),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'hf4df1409),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h7393172a),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'he93d7e11),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h2e409f96),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h6bc1bee2),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h578a2dae),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h9cac031e),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hac6fb79e),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h518eaf45),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h461cc830),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h11e45ca3),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h19c1fbe5),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hef520a1a),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h45249ff6),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h179b4fdf),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h7b412bad),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h10376ce6),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-CTR-256 Encryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_ENC,                                                                          \
+      mode:       AES_CTR,                                                                          \
+      key_length: AES_256,                                                                          \
+      key:        256'hf4df1409a310982dd708613b072c351f81777d85f0ae732bbe71ca1510eb3d60,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'h10376ce67b412bad179b4fdf45249ff6ef520a1a19c1fbe511e45ca3461cc830518eaf45ac6fb79e9cac031e578a2dae6bc1bee22e409f96e93d7e117393172a,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_256) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CTR) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_256) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CTR) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_ENC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h10eb3d60),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'hbe71ca15),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'hf0ae732b),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h81777d85),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h072c351f),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'hd708613b),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'ha310982d),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'hf4df1409),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h7393172a),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'he93d7e11),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h2e409f96),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h6bc1bee2),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h578a2dae),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h9cac031e),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hac6fb79e),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h518eaf45),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h461cc830),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h11e45ca3),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h19c1fbe5),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hef520a1a),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h45249ff6),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h179b4fdf),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h7b412bad),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h10376ce6),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-ECB-256 Decryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_DEC,                                                                          \
+      mode:       AES_ECB,                                                                          \
+      key_length: AES_256,                                                                          \
+      key:        256'hf4df1409a310982dd708613b072c351f81777d85f0ae732bbe71ca1510eb3d60,            \
+      iv:         '0,                                                                               \
+      data:       512'hc7ec249e8f8d7d06fff3f9397a4b30231dedafbeb1e753f1f9f4a69cb921edb6702836314aa75bdc26ed10d410cb1c59f881b13d7e5a4b063ca0d2b5bdd1eef3,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_256) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_ECB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_256) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_ECB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h10eb3d60),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'hbe71ca15),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'hf0ae732b),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h81777d85),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h072c351f),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'hd708613b),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'ha310982d),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'hf4df1409),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hbdd1eef3),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h3ca0d2b5),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h7e5a4b06),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hf881b13d),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h10cb1c59),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h26ed10d4),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h4aa75bdc),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h70283631),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hb921edb6),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hf9f4a69c),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hb1e753f1),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h1dedafbe),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h7a4b3023),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hfff3f939),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h8f8d7d06),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hc7ec249e),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-CBC-256 Decryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_DEC,                                                                          \
+      mode:       AES_CBC,                                                                          \
+      key_length: AES_256,                                                                          \
+      key:        256'hf4df1409a310982dd708613b072c351f81777d85f0ae732bbe71ca1510eb3d60,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'h1b9d6a8c07196cdafce99bc3e205ebb26114230463e230a5cfbad9a96933f2397d2c70c67b779f678d80db7e964efc9cd6fb7b5ffbab9e77baf1e5d6044c8cf5,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_256) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CBC) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_256) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CBC) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h10eb3d60),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'hbe71ca15),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'hf0ae732b),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h81777d85),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h072c351f),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'hd708613b),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'ha310982d),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'hf4df1409),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h044c8cf5),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hbaf1e5d6),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hfbab9e77),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hd6fb7b5f),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h964efc9c),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h8d80db7e),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h7b779f67),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h7d2c70c6),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h6933f239),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hcfbad9a9),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h63e230a5),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h61142304),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'he205ebb2),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hfce99bc3),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h07196cda),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h1b9d6a8c),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-CFB-256 Decryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_DEC,                                                                          \
+      mode:       AES_CFB,                                                                          \
+      key_length: AES_256,                                                                          \
+      key:        256'hf4df1409a310982dd708613b072c351f81777d85f0ae732bbe71ca1510eb3d60,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'h71e4b1553d623120f8ceb91a7485a375f9e27a26a8d03ea1924be515241310df7b40e531633c1132c8b1283b14edff3960385d988684cd7e4b1679dabf847edc,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_256) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_256) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h10eb3d60),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'hbe71ca15),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'hf0ae732b),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h81777d85),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h072c351f),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'hd708613b),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'ha310982d),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'hf4df1409),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hbf847edc),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h4b1679da),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h8684cd7e),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h60385d98),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h14edff39),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hc8b1283b),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h633c1132),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h7b40e531),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h241310df),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h924be515),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'ha8d03ea1),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hf9e27a26),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h7485a375),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hf8ceb91a),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h3d623120),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h71e4b155),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-OFB-256 Decryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_DEC,                                                                          \
+      mode:       AES_OFB,                                                                          \
+      key_length: AES_256,                                                                          \
+      key:        256'hf4df1409a310982dd708613b072c351f81777d85f0ae732bbe71ca1510eb3d60,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'h84e440e78b5a8f53e87bf3671d14260108c497ba5b1c9df3ed6ee886a047ab718db04f2ad86a8fc83a0bd24067dceb4fdf10132415e54b92a13ed0a8267ae2f9,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_256) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_OFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_256) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_OFB) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h10eb3d60),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'hbe71ca15),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'hf0ae732b),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h81777d85),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h072c351f),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'hd708613b),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'ha310982d),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'hf4df1409),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h267ae2f9),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'ha13ed0a8),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h15e54b92),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hdf101324),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h67dceb4f),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h3a0bd240),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hd86a8fc8),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h8db04f2a),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'ha047ab71),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'hed6ee886),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h5b1c9df3),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h08c497ba),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h1d142601),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'he87bf367),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h8b5a8f53),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h84e440e7),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /*****************************************************************************/                   \
+  /** AES-CTR-256 Decryption                                                  **/                   \
+  /*****************************************************************************/                   \
+                                                                                                    \
+  c_dpi_load('{                                                                                     \
+      operation:  AES_DEC,                                                                          \
+      mode:       AES_CTR,                                                                          \
+      key_length: AES_256,                                                                          \
+      key:        256'hf4df1409a310982dd708613b072c351f81777d85f0ae732bbe71ca1510eb3d60,            \
+      iv:         128'h0f0e0d0c0b0a09080706050403020100,                                            \
+      data:       512'ha641794508ddc213a6ad7ab68dc5c9df8d98842dba1770e84ce93da2da30092bc5f5caca90e984ca9ab5624dcae343f428d2f3bb04f5a7b7a589577713c31e60,\
+      ad:         '0,                                                                               \
+      tag:        '0                                                                                \
+  }),                                                                                               \
+                                                                                                    \
+  /* Check AES core is idle before writing the control registers. */                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Config AES core */                                                                             \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_256) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CTR) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  write_request(                                                                                    \
+      AES_CTRL_SHADOWED_OFFSET,                                                                     \
+      32'(0)       << AES_CTRL_MANUAL_OPERATION_OFFSET |                                            \
+      32'(PER_1)   << AES_CTRL_PRNG_RESEED_RATE_OFFSET |                                            \
+      32'(0)       << AES_CTRL_SIDELOAD_OFFSET         |                                            \
+      32'(AES_256) << AES_CTRL_KEY_LEN_OFFSET          |                                            \
+      32'(AES_CTR) << AES_CTRL_MODE_OFFSET             |                                            \
+      32'(AES_DEC) << AES_CTRL_OPERATION_OFFSET                                                     \
+  ),                                                                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write key registers */                                                                         \
+  write_request(AES_KEY_SHARE0_0_OFFSET, 32'h10eb3d60),                                             \
+  write_request(AES_KEY_SHARE0_1_OFFSET, 32'hbe71ca15),                                             \
+  write_request(AES_KEY_SHARE0_2_OFFSET, 32'hf0ae732b),                                             \
+  write_request(AES_KEY_SHARE0_3_OFFSET, 32'h81777d85),                                             \
+  write_request(AES_KEY_SHARE0_4_OFFSET, 32'h072c351f),                                             \
+  write_request(AES_KEY_SHARE0_5_OFFSET, 32'hd708613b),                                             \
+  write_request(AES_KEY_SHARE0_6_OFFSET, 32'ha310982d),                                             \
+  write_request(AES_KEY_SHARE0_7_OFFSET, 32'hf4df1409),                                             \
+  write_request(AES_KEY_SHARE1_0_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_1_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_2_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_3_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_4_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_5_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_6_OFFSET, 32'h00000000),                                             \
+  write_request(AES_KEY_SHARE1_7_OFFSET, 32'h00000000),                                             \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write IV registers */                                                                          \
+  write_request(AES_IV_0_OFFSET, 32'h03020100),                                                     \
+  write_request(AES_IV_1_OFFSET, 32'h07060504),                                                     \
+  write_request(AES_IV_2_OFFSET, 32'h0b0a0908),                                                     \
+  write_request(AES_IV_3_OFFSET, 32'h0f0e0d0c),                                                     \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 1 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h13c31e60),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'ha5895777),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h04f5a7b7),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h28d2f3bb),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 1 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 2 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hcae343f4),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h9ab5624d),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h90e984ca),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'hc5f5caca),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 2 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 3 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'hda30092b),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'h4ce93da2),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'hba1770e8),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'h8d98842d),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 3 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Write PT Block 4 */                                                                            \
+  write_request(AES_DATA_IN_0_OFFSET, 32'h8dc5c9df),                                                \
+  write_request(AES_DATA_IN_1_OFFSET, 32'ha6ad7ab6),                                                \
+  write_request(AES_DATA_IN_2_OFFSET, 32'h08ddc213),                                                \
+  write_request(AES_DATA_IN_3_OFFSET, 32'ha6417945),                                                \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),                     \
+                                                                                                    \
+  /* Read CT Block 4 */                                                                             \
+  read_request(AES_DATA_OUT_0_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_1_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_2_OFFSET),                                                              \
+  read_request(AES_DATA_OUT_3_OFFSET),                                                              \
+  read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),                             \
+                                                                                                    \
+  /* Read Caliptra-specific register */                                                             \
+  read_caliptra(CALIPTRA_NAME_0_OFFSET),                                                            \
+  read_caliptra(CALIPTRA_VERSION_0_OFFSET)                                                          \
+};

--- a/hw/ip/aes/pre_dv/aes_tlul_shim_tb/rtl/aes_tlul_shim_tb_c_dpi.sv
+++ b/hw/ip/aes/pre_dv/aes_tlul_shim_tb/rtl/aes_tlul_shim_tb_c_dpi.sv
@@ -1,0 +1,165 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This module serves as the interface to the `c_dpi` API by instantiating the function call as a
+// combinatorial block. The `c_dpi` output (data and tag) is flopped and the 32 least significant
+// bits of data and tag become visible at the module's output ports in the next clock cycle. The
+// flopped data and tag can be rotated by 32 positions to the right to make other bits visible.
+
+module aes_tlul_shim_tb_c_dpi
+  import aes_pkg::*;
+  import aes_tlul_shim_tb_pkg::*;
+  import aes_model_dpi_pkg::*;
+#(
+    parameter int ADLength = 0,
+    parameter int DataLength = 16
+) (
+   input logic clk_i,
+   input logic rst_ni,
+
+   input c_dpi_input_t c_dpi_input_i,
+
+   input logic c_dpi_load_i,         // Flop `c_dpi` output.
+   input logic c_dpi_rotate_data_i,  // Rotate data >> 32.
+   input logic c_dpi_rotate_tag_i,   // Rotate tag  >> 32.
+
+   output logic [31:0] c_dpi_data_o,
+   output logic [31:0] c_dpi_tag_o
+);
+
+  // Make the 32 least signification bits of data and tag visible at the output ports.
+
+  assign c_dpi_data_o = {c_dpi_data_q[3], c_dpi_data_q[2], c_dpi_data_q[1], c_dpi_data_q[0]};
+  assign c_dpi_tag_o  = c_dpi_tag_q[31:0];
+
+  // Flop the output data acquired from the `c_dpi` API in an unpacked array of at least 4 bytes.
+
+  logic [7:0] c_dpi_data   [max(4, DataLength)];
+  logic [7:0] c_dpi_data_d [max(4, DataLength)];
+  logic [7:0] c_dpi_data_q [max(4, DataLength)];
+
+  always_comb begin
+    c_dpi_data_d = c_dpi_data_q;
+    if (c_dpi_load_i) begin
+      c_dpi_data_d = c_dpi_data;
+    end else if (c_dpi_rotate_data_i) begin
+      for (int i = 0; i < DataLength; i++) begin
+        c_dpi_data_d[i] = c_dpi_data_q[(i + 4) % DataLength];
+      end
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      c_dpi_data_q <= '{default: '0};
+    end else begin
+      c_dpi_data_q <= c_dpi_data_d;
+    end
+  end
+
+  // Flop the output tag acquired from the `c_dpi` API in the encryption case. The `c_dpi` API does
+  // not output the tag in the decryption case, consequently it needs to be input by the testbench
+  // itself. Note that the byte ordering of the `c_dpi` and HW tag differ.
+
+  logic [127:0] c_dpi_tag;
+  logic [127:0] c_dpi_tag_d;
+  logic [127:0] c_dpi_tag_q;
+
+  always_comb begin
+    c_dpi_tag_d = c_dpi_tag_q;
+    if (c_dpi_load_i) begin
+      if (c_dpi_input_i.operation == AES_ENC) begin
+        c_dpi_tag_d = aes_transpose(c_dpi_tag);
+      end else begin
+        c_dpi_tag_d = c_dpi_input_i.tag;
+      end
+    end else if (c_dpi_rotate_tag_i) begin
+      c_dpi_tag_d = {c_dpi_tag_q[31:0], c_dpi_tag_q[127:32]};
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      c_dpi_tag_q <= '0;
+    end else begin
+      c_dpi_tag_q <= c_dpi_tag_d;
+    end
+  end
+
+  // As of version 4.210, the only way of transforming a packed array into an unpacked one (required
+  // by the `c_dpi`) in a Verilator simulation is by manually reassigning the signals.
+
+  logic [7:0] c_dpi_ad_unp   [max(1, ADLength)];
+  logic [7:0] c_dpi_data_unp [max(1, DataLength)];
+
+  always_comb begin
+    for (int i = 0; i < ADLength; i++) begin
+      c_dpi_ad_unp[i] = c_dpi_input_i.ad[i];
+    end
+    for (int i = 0; i < DataLength; i++) begin
+      c_dpi_data_unp[i] = c_dpi_input_i.data[i];
+    end
+  end
+
+  always_comb begin
+    if (ADLength == 0 && DataLength == 0) begin
+      c_dpi_aes_crypt_message(
+        1'b1,
+        c_dpi_input_i.operation[1],
+        c_dpi_input_i.mode,
+        c_dpi_input_i.iv,
+        c_dpi_input_i.key_length,
+        c_dpi_input_i.key,
+        '0,
+        '0,
+        c_dpi_input_i.tag,
+        c_dpi_data,
+        c_dpi_tag
+      );
+    end else if (ADLength == 0 && DataLength > 0) begin
+      c_dpi_aes_crypt_message(
+        1'b1,
+        c_dpi_input_i.operation[1],
+        c_dpi_input_i.mode,
+        c_dpi_input_i.iv,
+        c_dpi_input_i.key_length,
+        c_dpi_input_i.key,
+        c_dpi_data_unp,
+        '0,
+        c_dpi_input_i.tag,
+        c_dpi_data,
+        c_dpi_tag
+      );
+    end else if (ADLength > 0 && DataLength == 0) begin
+      c_dpi_aes_crypt_message(
+        1'b1,
+        c_dpi_input_i.operation[1],
+        c_dpi_input_i.mode,
+        c_dpi_input_i.iv,
+        c_dpi_input_i.key_length,
+        c_dpi_input_i.key,
+        '0,
+        c_dpi_ad_unp,
+        c_dpi_input_i.tag,
+        c_dpi_data,
+        c_dpi_tag
+      );
+    end else begin
+      c_dpi_aes_crypt_message(
+        1'b1,
+        c_dpi_input_i.operation[1],
+        c_dpi_input_i.mode,
+        c_dpi_input_i.iv,
+        c_dpi_input_i.key_length,
+        c_dpi_input_i.key,
+        c_dpi_data_unp,
+        c_dpi_ad_unp,
+        c_dpi_input_i.tag,
+        c_dpi_data,
+        c_dpi_tag
+      );
+    end
+  end
+
+endmodule

--- a/hw/ip/aes/pre_dv/aes_tlul_shim_tb/rtl/aes_tlul_shim_tb_pkg.sv
+++ b/hw/ip/aes/pre_dv/aes_tlul_shim_tb/rtl/aes_tlul_shim_tb_pkg.sv
@@ -5,11 +5,10 @@
 package aes_tlul_shim_tb_pkg;
 
   import tlul_pkg::*;
+  import aes_pkg::*;
+  import aes_reg_pkg::*;
 
-  parameter bit AES_MANUAL_OPERATION    = 0;
-  parameter bit AES_SIDELOAD            = 0;
-  parameter int AES_GCM_NUM_VALID_BYTES = 16;
-
+  // AES register fields offsets.
   parameter int AES_CTRL_OPERATION_OFFSET        = 0;
   parameter int AES_CTRL_MODE_OFFSET             = 2;
   parameter int AES_CTRL_KEY_LEN_OFFSET          = 8;
@@ -26,6 +25,36 @@ package aes_tlul_shim_tb_pkg;
   parameter int AES_STATUS_OUTPUT_VALID_OFFSET = 3;
   parameter int AES_STATUS_INPUT_READY_OFFSET  = 4;
 
+  parameter int AES_TRIGGER_START_OFFSET                = 0;
+  parameter int AES_TRIGGER_KEY_IV_DATA_IN_CLEAR_OFFSET = 1;
+  parameter int AES_TRIGGER_DATA_OUT_CLEAR_OFFSET       = 2;
+  parameter int AES_TRIGGER_PRNG_RESEED_OFFSET          = 3;
+
+  // Caliptra register offsets
+  parameter logic [11:0] CALIPTRA_NAME_0_OFFSET    = 12'h100;
+  parameter logic [11:0] CALIPTRA_NAME_1_OFFSET    = 12'h104;
+  parameter logic [11:0] CALIPTRA_VERSION_0_OFFSET = 12'h108;
+  parameter logic [11:0] CALIPTRA_VERSION_1_OFFSET = 12'h10c;
+
+  `include `REQUESTS_FILE
+
+  // Grouping of all signals required for a `c_dpi` API call.
+  typedef struct packed {
+    aes_op_e operation;
+    aes_mode_e mode;
+    key_len_e key_length;
+
+    logic [255:0] key;
+    logic [127:0] iv;
+    // Unfortunately, Verilator v4.210 does not allow unpacked arrays in structs, hence both AD and
+    // data need to be unpacked later.
+    logic [max(1, `AD_LENGTH)-1:0][7:0] ad;
+    logic [max(1, `DATA_LENGTH)-1:0][7:0] data;
+    logic [127:0] tag; // Only used in the GCM decryption case.
+   } c_dpi_input_t;
+
+  // Grouping of all signals required for a shim read/write request and to instrument the `c_dpi`
+  // API.
   typedef struct packed {
     logic                       dv;
     logic [top_pkg::TL_AW-1:0]  addr;
@@ -38,9 +67,13 @@ package aes_tlul_shim_tb_pkg;
     logic [top_pkg::TL_AIW-1:0] id;
 
     // Internal signal to verify status bits.
-    logic [top_pkg::TL_DW-1:0]  mask;
+    logic [top_pkg::TL_DW-1:0] mask;
+
+    // Internal signal: AD and PT inputs to the `c_dpi` model.
+    c_dpi_input_t c_dpi_input;
   } shim_request_t;
 
+  // write_request returns a filled out `shim_request_t` struct for a shim write request.
   function automatic shim_request_t write_request (logic [7:0] addr,
                                                    logic [top_pkg::TL_DW-1:0] wdata);
     shim_request_t req = '{
@@ -53,17 +86,18 @@ package aes_tlul_shim_tb_pkg;
       last: 1'b0,
       user: 32'(TL_A_USER_DEFAULT),
       id: '{default: '0},
-      mask: '{default: '0}
+      mask: '{default: '0},
+      c_dpi_input: '0
     };
     return req;
   endfunction
 
+  // read_request returns a filled out `shim_request_t` struct for a shim read request.
   function automatic shim_request_t read_request (logic [7:0] addr,
-                                                  logic [top_pkg::TL_DW-1:0] mask = '0,
-                                                  bit calyptra = 1'b0);
+                                                  logic [top_pkg::TL_DW-1:0] mask = '0);
     shim_request_t req = '{
       dv: 1'b1,
-      addr: {23'b0, calyptra, addr},
+      addr: 32'(addr),
       write: 1'b0,
       wdata: '{default: '0},
       wstrb: top_pkg::TL_DBW'(4'b1111),
@@ -71,9 +105,35 @@ package aes_tlul_shim_tb_pkg;
       last: 1'b0,
       user: 32'(TL_A_USER_DEFAULT),
       id: '{default: '0},
-      mask: mask
+      mask: mask,
+      c_dpi_input: '0
     };
     return req;
   endfunction
+
+  // read_caliptra returns a filled out `shim_request_t` struct for an internal Caliptra register.
+  function automatic shim_request_t read_caliptra (logic [11:0] addr);
+    shim_request_t req = '{
+      dv: 1'b1,
+      addr: 32'(addr),
+      default: '0
+    };
+    return req;
+  endfunction
+
+  // c_dpi_load assigns a `c_dpi_input_t` to an empty `shim_request_t` struct. This type of
+  // request is used to instrument the `c_dpi` API at the beginning of a test.
+  function automatic shim_request_t c_dpi_load (c_dpi_input_t c_dpi_input);
+    shim_request_t req = '0;
+    req.c_dpi_input = c_dpi_input;
+    return req;
+  endfunction
+
+  // Convenience helper function.
+  function automatic int unsigned max (int unsigned a, int unsigned b);
+    return (a > b) ? a : b;
+  endfunction
+
+  `REQUESTS
 
 endpackage

--- a/hw/ip/aes/pre_dv/aes_tlul_shim_tb/rtl/aes_tlul_shim_tb_reqs.sv
+++ b/hw/ip/aes/pre_dv/aes_tlul_shim_tb/rtl/aes_tlul_shim_tb_reqs.sv
@@ -14,128 +14,9 @@ module aes_tlul_shim_tb_reqs
   input logic pop_req_i,
 
   output shim_request_t req_o,
+  //output c_dpi_input_t c_dpi_input_o,
   output logic done_o
 );
-
-  localparam int NumRequests = 54;
-  shim_request_t requests[NumRequests];
-
-  initial begin
-    requests = '{
-      // Check AES core is idle before writing the control registers.
-      read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),
-
-      // Config AES core. Config GCM in `INIT` mode.
-      write_request(
-          AES_CTRL_SHADOWED_OFFSET,
-          32'(AES_MANUAL_OPERATION) << AES_CTRL_MANUAL_OPERATION_OFFSET |
-          32'(PER_1)                << AES_CTRL_PRNG_RESEED_RATE_OFFSET |
-          32'(AES_SIDELOAD)         << AES_CTRL_SIDELOAD_OFFSET         |
-          32'(AES_128)              << AES_CTRL_KEY_LEN_OFFSET          |
-          32'(AES_GCM)              << AES_CTRL_MODE_OFFSET             |
-          32'(AES_ENC)              << AES_CTRL_OPERATION_OFFSET
-      ),
-      write_request(
-          AES_CTRL_SHADOWED_OFFSET,
-          32'(AES_MANUAL_OPERATION) << AES_CTRL_MANUAL_OPERATION_OFFSET |
-          32'(PER_1)                << AES_CTRL_PRNG_RESEED_RATE_OFFSET |
-          32'(AES_SIDELOAD)         << AES_CTRL_SIDELOAD_OFFSET         |
-          32'(AES_128)              << AES_CTRL_KEY_LEN_OFFSET          |
-          32'(AES_GCM)              << AES_CTRL_MODE_OFFSET             |
-          32'(AES_ENC)              << AES_CTRL_OPERATION_OFFSET
-      ),
-      write_request(
-          AES_CTRL_GCM_SHADOWED_OFFSET,
-          32'(AES_GCM_NUM_VALID_BYTES) << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |
-          32'(GCM_INIT)                << AES_CTRL_GCM_PHASE_OFFSET
-      ),
-      write_request(
-          AES_CTRL_GCM_SHADOWED_OFFSET,
-          32'(AES_GCM_NUM_VALID_BYTES) << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |
-          32'(GCM_INIT)                << AES_CTRL_GCM_PHASE_OFFSET
-      ),
-      read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),
-
-      // Write key registers.
-      write_request(AES_KEY_SHARE0_0_OFFSET, 32'h03020100),
-      write_request(AES_KEY_SHARE0_1_OFFSET, 32'h07060504),
-      write_request(AES_KEY_SHARE0_2_OFFSET, 32'h0B0A0908),
-      write_request(AES_KEY_SHARE0_3_OFFSET, 32'h0F0E0D0C),
-      write_request(AES_KEY_SHARE0_4_OFFSET, 32'h13121110),
-      write_request(AES_KEY_SHARE0_5_OFFSET, 32'h17161514),
-      write_request(AES_KEY_SHARE0_6_OFFSET, 32'h1B1A1918),
-      write_request(AES_KEY_SHARE0_7_OFFSET, 32'h1F1E1D1C),
-      write_request(AES_KEY_SHARE1_0_OFFSET, 32'h03020100),
-      write_request(AES_KEY_SHARE1_1_OFFSET, 32'h07060504),
-      write_request(AES_KEY_SHARE1_2_OFFSET, 32'h0B0A0908),
-      write_request(AES_KEY_SHARE1_3_OFFSET, 32'h0F0E0D0C),
-      write_request(AES_KEY_SHARE1_4_OFFSET, 32'h13121110),
-      write_request(AES_KEY_SHARE1_5_OFFSET, 32'h17161514),
-      write_request(AES_KEY_SHARE1_6_OFFSET, 32'h1B1A1918),
-      write_request(AES_KEY_SHARE1_7_OFFSET, 32'h1F1E1D1C),
-      read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),
-
-      // Write IV registers.
-      write_request(AES_IV_0_OFFSET, 32'h00000000),
-      write_request(AES_IV_1_OFFSET, 32'h00000000),
-      write_request(AES_IV_2_OFFSET, 32'h00000000),
-      write_request(AES_IV_3_OFFSET, 32'h00000000),
-      read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),
-
-      // Config GCM in `TEXT` mode and write plaintext into the data registers.
-      write_request(
-          AES_CTRL_GCM_SHADOWED_OFFSET,
-          32'(AES_GCM_NUM_VALID_BYTES) << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |
-          32'(GCM_TEXT)                << AES_CTRL_GCM_PHASE_OFFSET
-      ),
-      write_request(
-          AES_CTRL_GCM_SHADOWED_OFFSET,
-          32'(AES_GCM_NUM_VALID_BYTES) << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |
-          32'(GCM_TEXT)                << AES_CTRL_GCM_PHASE_OFFSET
-      ),
-      read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),
-
-      write_request(AES_DATA_IN_0_OFFSET, 32'h00000000),
-      write_request(AES_DATA_IN_1_OFFSET, 32'h00000000),
-      write_request(AES_DATA_IN_2_OFFSET, 32'h00000000),
-      write_request(AES_DATA_IN_3_OFFSET, 32'h00000000),
-      read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),
-
-      // Read out ciphertext
-      read_request(AES_DATA_OUT_0_OFFSET),
-      read_request(AES_DATA_OUT_1_OFFSET),
-      read_request(AES_DATA_OUT_2_OFFSET),
-      read_request(AES_DATA_OUT_3_OFFSET),
-      read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_IDLE_OFFSET),
-
-      // Config GCM in `TAG` mode and write len(ad) || len(pt) to trigger tag computation.
-      write_request(
-          AES_CTRL_GCM_SHADOWED_OFFSET,
-          32'(AES_GCM_NUM_VALID_BYTES) << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |
-          32'(GCM_TAG)                 << AES_CTRL_GCM_PHASE_OFFSET
-      ),
-      write_request(
-          AES_CTRL_GCM_SHADOWED_OFFSET,
-          32'(AES_GCM_NUM_VALID_BYTES) << AES_CTRL_GCM_NUM_VALID_BYTES_OFFSET |
-          32'(GCM_TAG)                 << AES_CTRL_GCM_PHASE_OFFSET
-      ),
-      write_request(AES_DATA_IN_0_OFFSET, 32'h00000000),
-      write_request(AES_DATA_IN_1_OFFSET, 32'h00000000),
-      write_request(AES_DATA_IN_2_OFFSET, 32'h00000000),
-      write_request(AES_DATA_IN_3_OFFSET, 32'h80000000), // 1 Block
-      read_request(AES_STATUS_OFFSET, 32'(1'b1) << AES_STATUS_OUTPUT_VALID_OFFSET),
-
-      // Read back the authentication tag.
-      read_request(AES_DATA_OUT_0_OFFSET),
-      read_request(AES_DATA_OUT_1_OFFSET),
-      read_request(AES_DATA_OUT_2_OFFSET),
-      read_request(AES_DATA_OUT_3_OFFSET),
-
-      // Read Caliptra name and version registers.
-      read_request(8'h00,, 1'b1),
-      read_request(8'h04,, 1'b1)
-    };
-  end
 
   int request_cntr_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -147,13 +28,15 @@ module aes_tlul_shim_tb_reqs
   end
 
   always_comb begin
-    if (request_cntr_q < NumRequests) begin
+    if (request_cntr_q < `NUM_REQUESTS) begin
       req_o = requests[request_cntr_q];
+      //c_dpi_input_o = requests[request_cntr_q].c_dpi_input;
     end else begin
       req_o = '0;
+      //c_dpi_input_o = '0;
     end
   end
 
-  assign done_o = (request_cntr_q >= NumRequests) ? 1'b1 : 1'b0;
+ assign done_o = (request_cntr_q >= `NUM_REQUESTS) ? 1'b1 : 1'b0;
 
 endmodule


### PR DESCRIPTION
This is the eight PR of a series of PRs to upstream support for AES-GCM. The original PR can be found here: https://github.com/vogelpi/opentitan/pull/9

---

[tlul,shim] Expand `pre_dv` to handle arbitrary test cases

This commit generalizes the `pre_dv` testbench to arbitrary test cases and adds an array of tests covering both AES-GCM and its modes of operation. The process of adding/modify tests is now streamlined reducing the feedback loop.