### PR TITLE
Backport 26494 ([manuf] remove unused UJSON measurment inputs)

### DIFF
--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -93,11 +93,6 @@ UJSON_SERDE_STRUCT(LcTokenHash, \
  */
 // clang-format off
 #define STRUCT_MANUF_CERTGEN_INPUTS(field, string) \
-    field(rom_ext_measurement, uint32_t, 8) \
-    field(rom_ext_security_version, uint32_t) \
-    field(owner_manifest_measurement, uint32_t, 8) \
-    field(owner_measurement, uint32_t, 8) \
-    field(owner_security_version, uint32_t) \
     field(dice_auth_key_key_id, uint8_t, 20) \
     field(ext_auth_key_key_id, uint8_t, 20)
 UJSON_SERDE_STRUCT(ManufCertgenInputs, \

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -93,6 +93,7 @@ static keymgr_binding_value_t sealing_binding_value = {.data = {0}};
 /**
  * Certificate data.
  */
+static hmac_digest_t kZeroDigest = {.digest = {0, 0, 0, 0, 0, 0, 0, 0}};
 static hmac_digest_t otp_creator_sw_cfg_measurement;
 static hmac_digest_t otp_owner_sw_cfg_measurement;
 static hmac_digest_t otp_rot_creator_auth_codesign_measurement;
@@ -327,15 +328,13 @@ static status_t personalize_otp_and_flash_secrets(ujson_t *uj) {
 }
 
 /**
- * Sets the attestation binding to the ROM_EXT measurement, and the sealing
- * binding to all zeros.
+ * Sets the attestation and sealing binding to all zeros.
  *
- * The sealing binding value is set to all zeros as it is unused in the current
- * personalization flow. This may be changed in the future.
+ * The attestation binding (and subsequently CDI_0) will be updated later when
+ * the ROM_EXT boots for the first time.
  */
-static void compute_keymgr_owner_int_binding(manuf_certgen_inputs_t *inputs) {
-  memcpy(attestation_binding_value.data, inputs->rom_ext_measurement,
-         kDiceMeasurementSizeInBytes);
+static void compute_keymgr_owner_int_binding(void) {
+  memset(attestation_binding_value.data, 0, kDiceMeasurementSizeInBytes);
   // In the silicon_creator stage, we set the sealing binding to the
   // manifest->identifier of the ROM_EXT stage.
   memset(sealing_binding_value.data, 0, kDiceMeasurementSizeInBytes);
@@ -343,22 +342,13 @@ static void compute_keymgr_owner_int_binding(manuf_certgen_inputs_t *inputs) {
 }
 
 /**
- * Sets the attestation binding to a combination of the Owner firmware and
- * Ownership Manifest measurements, and the sealing binding to all zeros.
+ * Sets the attestation binding to all zeros as it (and subsequently CDI_1) will
+ * be updated later when the ROM_EXT boots for the first time.
  *
- * The sealing binding value is set to the TEST application key domain.
+ * The sealing binding value is set to the PROD application key domain.
  */
-static void compute_keymgr_owner_binding(manuf_certgen_inputs_t *inputs) {
-  hmac_digest_t combined_measurements;
-  hmac_sha256_init();
-  hmac_sha256_update((unsigned char *)inputs->owner_measurement,
-                     kDiceMeasurementSizeInBytes);
-  hmac_sha256_update((unsigned char *)inputs->owner_manifest_measurement,
-                     kDiceMeasurementSizeInBytes);
-  hmac_sha256_process();
-  hmac_sha256_final(&combined_measurements);
-  memcpy(attestation_binding_value.data, combined_measurements.digest,
-         kDiceMeasurementSizeInBytes);
+static void compute_keymgr_owner_binding(void) {
+  memset(attestation_binding_value.data, 0, kDiceMeasurementSizeInBytes);
   // We expect the owner to use a Application Key binding  of
   // {`prod`, 0, ... }.
   memset(sealing_binding_value.data, 0, kDiceMeasurementSizeInBytes);
@@ -528,16 +518,14 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
 
   // Generate CDI_0 keys and cert.
   curr_cert_size = kCdi0MaxCertSizeBytes;
-  compute_keymgr_owner_int_binding(&certgen_inputs);
+  compute_keymgr_owner_int_binding();
   TRY(sc_keymgr_owner_int_advance(&sealing_binding_value,
                                   &attestation_binding_value,
                                   /*max_key_version=*/0));
   TRY(otbn_boot_cert_ecc_p256_keygen(kDiceKeyCdi0, &cdi_0_pubkey_id,
                                      &curr_pubkey));
-  TRY(dice_cdi_0_cert_build((hmac_digest_t *)certgen_inputs.rom_ext_measurement,
-                            certgen_inputs.rom_ext_security_version,
-                            &cdi_0_key_ids, &curr_pubkey, all_certs,
-                            &curr_cert_size));
+  TRY(dice_cdi_0_cert_build(&kZeroDigest, 0, &cdi_0_key_ids, &curr_pubkey,
+                            all_certs, &curr_cert_size));
   cdi_0_offset = perso_blob_to_host.next_free;
   // DO NOT CHANGE THE "CDI_0" STRING BELOW with modifying the `dice_cert_names`
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
@@ -548,17 +536,15 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
 
   // Generate CDI_1 keys and cert.
   curr_cert_size = kCdi1MaxCertSizeBytes;
-  compute_keymgr_owner_binding(&certgen_inputs);
+  compute_keymgr_owner_binding();
   TRY(sc_keymgr_owner_advance(&sealing_binding_value,
                               &attestation_binding_value,
                               /*max_key_version=*/0));
   TRY(otbn_boot_cert_ecc_p256_keygen(kDiceKeyCdi1, &cdi_1_pubkey_id,
                                      &curr_pubkey));
-  TRY(dice_cdi_1_cert_build(
-      (hmac_digest_t *)certgen_inputs.owner_measurement,
-      (hmac_digest_t *)certgen_inputs.owner_manifest_measurement,
-      certgen_inputs.owner_security_version, kOwnerAppDomainProd,
-      &cdi_1_key_ids, &curr_pubkey, all_certs, &curr_cert_size));
+  TRY(dice_cdi_1_cert_build(&kZeroDigest, &kZeroDigest, 0, kOwnerAppDomainProd,
+                            &cdi_1_key_ids, &curr_pubkey, all_certs,
+                            &curr_cert_size));
   cdi_1_offset = perso_blob_to_host.next_free;
   // DO NOT CHANGE THE "CDI_1" STRING BELOW with modifying the `dice_cert_names`
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.

--- a/sw/host/provisioning/ft/src/main.rs
+++ b/sw/host/provisioning/ft/src/main.rs
@@ -62,26 +62,6 @@ pub struct ManufFtProvisioningDataInput {
     #[arg(long, value_parser = DifLcCtrlState::parse_lc_state_str)]
     target_mission_mode_lc_state: DifLcCtrlState,
 
-    /// Measurement of the ROM_EXT image to be loaded onto the device.
-    #[arg(long)]
-    pub rom_ext_measurement: String,
-
-    /// Security version the ROM_EXT image to be loaded onto the device.
-    #[arg(long, default_value = "0")]
-    pub rom_ext_security_version: u32,
-
-    /// Measurement of the Ownership Manifest to be loaded onto the device.
-    #[arg(long)]
-    pub owner_manifest_measurement: String,
-
-    /// Measurement of the Owner image to be loaded onto the device.
-    #[arg(long)]
-    pub owner_measurement: String,
-
-    /// Security version the Owner image to be loaded onto the device.
-    #[arg(long, default_value = "0")]
-    pub owner_security_version: u32,
-
     /// Token Encryption public key (RSA) DER file path.
     #[arg(long)]
     token_encrypt_key_der_file: PathBuf,
@@ -192,15 +172,6 @@ fn main() -> Result<()> {
     }
 
     // Parse and prepare personalization ujson data payload.
-    let rom_ext_measurement =
-        hex_string_to_u32_arrayvec::<8>(opts.provisioning_data.rom_ext_measurement.as_str())?;
-    let rom_ext_security_version = opts.provisioning_data.rom_ext_security_version;
-    let owner_manifest_measurement = hex_string_to_u32_arrayvec::<8>(
-        opts.provisioning_data.owner_manifest_measurement.as_str(),
-    )?;
-    let owner_measurement =
-        hex_string_to_u32_arrayvec::<8>(opts.provisioning_data.owner_measurement.as_str())?;
-    let owner_security_version = opts.provisioning_data.owner_security_version;
     let dice_ca_key_id = hex_string_to_u8_arrayvec::<20>(ca_cfgs["dice"].key_id.as_str())?;
     let ext_ca_key_id = if let Some(ext) = ca_cfgs.get("ext") {
         hex_string_to_u8_arrayvec::<20>(ext.key_id.as_str())?
@@ -208,11 +179,6 @@ fn main() -> Result<()> {
         ArrayVec::<u8, 20>::new()
     };
     let _perso_certgen_inputs = ManufCertgenInputs {
-        rom_ext_measurement: rom_ext_measurement.clone(),
-        rom_ext_security_version,
-        owner_manifest_measurement: owner_manifest_measurement.clone(),
-        owner_measurement: owner_measurement.clone(),
-        owner_security_version,
         dice_auth_key_key_id: dice_ca_key_id.clone(),
         ext_auth_key_key_id: ext_ca_key_id.clone(),
     };

--- a/sw/host/provisioning/orchestrator/src/ot_dut.py
+++ b/sw/host/provisioning/orchestrator/src/ot_dut.py
@@ -273,11 +273,6 @@ class OtDut():
             --test-unlock-token="{format_hex(self.test_unlock_token, width=32)}" \
             --test-exit-token="{format_hex(self.test_exit_token, width=32)}" \
             --target-mission-mode-lc-state="{self.sku_config.target_lc_state}" \
-            --rom-ext-measurement="{_ZERO_256BIT_HEXSTR}" \
-            --owner-manifest-measurement="{_ZERO_256BIT_HEXSTR}" \
-            --owner-measurement="{_ZERO_256BIT_HEXSTR}" \
-            --rom-ext-security-version="0" \
-            --owner-security-version="0" \
             --ca-config={ca_config_file.name} \
             --token-encrypt-key-der-file={self.sku_config.token_encrypt_key} \
             """


### PR DESCRIPTION
Backport #26494. Several nontrivial conflicts which I hopefully got right.