### PR TITLE
[pentest] Move alert handling cryptolib to wrapper

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/crypto/include/security_config.h"
+#include "sw/device/lib/dif/dif_rv_core_ibex.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
@@ -19,6 +20,9 @@
 
 #define MODULE_ID MAKE_MODULE_ID('c', 'f', 'a')
 
+// Interface to Ibex.
+static dif_rv_core_ibex_t rv_core_ibex;
+
 status_t handle_cryptolib_fi_asym_rsa_enc(ujson_t *uj) {
   cryptolib_fi_asym_rsa_enc_in_t uj_input;
   TRY(ujson_deserialize_cryptolib_fi_asym_rsa_enc_in_t(uj, &uj_input));
@@ -27,10 +31,37 @@ status_t handle_cryptolib_fi_asym_rsa_enc(ujson_t *uj) {
   // Perform an RSA encryption with hashing and padding options.
   // You can give cfg a value such that the RSA generates its own private key.
   // Trigger are over the API calls.
+
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_rsa_enc_out_t uj_output;
   uj_output.status = kUnknown;
   uj_output.status =
       (size_t)cryptolib_fi_rsa_enc_impl(uj_input, &uj_output).value;
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
 
   RESP_OK(ujson_serialize_cryptolib_fi_asym_rsa_enc_out_t, uj, &uj_output);
@@ -45,10 +76,37 @@ status_t handle_cryptolib_fi_asym_rsa_sign(ujson_t *uj) {
   // Perform an RSA signing with hashing and padding options.
   // You can give cfg a value such that the RSA generates its own private key.
   // Trigger are over the API calls.
+
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_rsa_sign_out_t uj_output;
   uj_output.status = kUnknown;
   uj_output.status =
       (size_t)cryptolib_fi_rsa_sign_impl(uj_input, &uj_output).value;
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
 
   RESP_OK(ujson_serialize_cryptolib_fi_asym_rsa_sign_out_t, uj, &uj_output);
@@ -62,10 +120,37 @@ status_t handle_cryptolib_fi_asym_rsa_verify(ujson_t *uj) {
   /////////////// STUB START ///////////////
   // Perform an RSA verification with hashing and padding options.
   // Trigger are over the API calls.
+
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_rsa_verify_out_t uj_output;
   uj_output.status = kUnknown;
   uj_output.status =
       (size_t)cryptolib_fi_rsa_verify_impl(uj_input, &uj_output).value;
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
 
   RESP_OK(ujson_serialize_cryptolib_fi_asym_rsa_verify_out_t, uj, &uj_output);
@@ -80,12 +165,39 @@ status_t handle_cryptolib_fi_asym_prime(ujson_t *uj) {
   // Generate a prime.
   // Trigger are over the API calls.
 
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_prime_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
   memset(uj_output.prime, 0, RSA_CMD_MAX_MESSAGE_BYTES);
   uj_output.prime_len = RSA_CMD_MAX_MESSAGE_BYTES;
   uj_output.cfg = 0;
   uj_output.status = 0;
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
   RESP_OK(ujson_serialize_cryptolib_fi_asym_prime_out_t, uj, &uj_output);
 
@@ -100,8 +212,35 @@ status_t handle_cryptolib_fi_asym_p256_base_mul(ujson_t *uj) {
   // Perform a base point multiplication in P256.
   // Trigger are over the API calls.
 
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_p256_base_mul_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
   RESP_OK(ujson_serialize_cryptolib_fi_asym_p256_base_mul_out_t, uj,
           &uj_output);
@@ -118,8 +257,35 @@ status_t handle_cryptolib_fi_asym_p256_point_mul(ujson_t *uj) {
   // The Bob scalar is transformed to a public key to then be multiplied to the
   // Alice scalar. Trigger are over the API calls.
 
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_p256_point_mul_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
   RESP_OK(ujson_serialize_cryptolib_fi_asym_p256_point_mul_out_t, uj,
           &uj_output);
@@ -134,10 +300,38 @@ status_t handle_cryptolib_fi_asym_p256_ecdh(ujson_t *uj) {
   /////////////// STUB START ///////////////
   // Perform ecdh in P256.
   // Trigger are over the API calls.
+
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_p256_ecdh_out_t uj_output;
   uj_output.status = kUnknown;
   uj_output.status =
       (size_t)cryptolib_fi_p256_ecdh_impl(uj_input, &uj_output).value;
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
 
   RESP_OK(ujson_serialize_cryptolib_fi_asym_p256_ecdh_out_t, uj, &uj_output);
@@ -151,10 +345,38 @@ status_t handle_cryptolib_fi_asym_p256_sign(ujson_t *uj) {
   /////////////// STUB START ///////////////
   // Perform a P256 signature.
   // Trigger are over the API calls.
+
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_p256_sign_out_t uj_output;
   uj_output.status = kUnknown;
   uj_output.status =
       (size_t)cryptolib_fi_p256_sign_impl(uj_input, &uj_output).value;
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
 
   RESP_OK(ujson_serialize_cryptolib_fi_asym_p256_sign_out_t, uj, &uj_output);
@@ -168,10 +390,38 @@ status_t handle_cryptolib_fi_asym_p256_verify(ujson_t *uj) {
   /////////////// STUB START ///////////////
   // Perform a P256 verification.
   // Trigger are over the API calls.
+
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_p256_verify_out_t uj_output;
   uj_output.status = kUnknown;
   uj_output.status =
       (size_t)cryptolib_fi_p256_verify_impl(uj_input, &uj_output).value;
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
 
   RESP_OK(ujson_serialize_cryptolib_fi_asym_p256_verify_out_t, uj, &uj_output);
@@ -186,8 +436,35 @@ status_t handle_cryptolib_fi_asym_p384_base_mul(ujson_t *uj) {
   // Perform a base point multiplication in p384.
   // Trigger are over the API calls.
 
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_p384_base_mul_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
   RESP_OK(ujson_serialize_cryptolib_fi_asym_p384_base_mul_out_t, uj,
           &uj_output);
@@ -204,8 +481,35 @@ status_t handle_cryptolib_fi_asym_p384_point_mul(ujson_t *uj) {
   // The Bob scalar is transformed to a public key to then be multiplied to the
   // Alice scalar. Trigger are over the API calls.
 
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_p384_point_mul_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
   RESP_OK(ujson_serialize_cryptolib_fi_asym_p384_point_mul_out_t, uj,
           &uj_output);
@@ -220,10 +524,38 @@ status_t handle_cryptolib_fi_asym_p384_ecdh(ujson_t *uj) {
   /////////////// STUB START ///////////////
   // Perform ecdh in P384.
   // Trigger are over the API calls.
+
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_p384_ecdh_out_t uj_output;
   uj_output.status = kUnknown;
   uj_output.status =
       (size_t)cryptolib_fi_p384_ecdh_impl(uj_input, &uj_output).value;
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
 
   RESP_OK(ujson_serialize_cryptolib_fi_asym_p384_ecdh_out_t, uj, &uj_output);
@@ -237,10 +569,38 @@ status_t handle_cryptolib_fi_asym_p384_sign(ujson_t *uj) {
   /////////////// STUB START ///////////////
   // Perform a p384 signature.
   // Trigger are over the API calls.
+
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_p384_sign_out_t uj_output;
   uj_output.status = kUnknown;
   uj_output.status =
       (size_t)cryptolib_fi_p384_sign_impl(uj_input, &uj_output).value;
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
 
   RESP_OK(ujson_serialize_cryptolib_fi_asym_p384_sign_out_t, uj, &uj_output);
@@ -254,10 +614,38 @@ status_t handle_cryptolib_fi_asym_p384_verify(ujson_t *uj) {
   /////////////// STUB START ///////////////
   // Perform a p384 verification.
   // Trigger are over the API calls.
+
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_p384_verify_out_t uj_output;
   uj_output.status = kUnknown;
   uj_output.status =
       (size_t)cryptolib_fi_p384_verify_impl(uj_input, &uj_output).value;
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
 
   RESP_OK(ujson_serialize_cryptolib_fi_asym_p384_verify_out_t, uj, &uj_output);
@@ -273,8 +661,35 @@ status_t handle_cryptolib_fi_asym_secp256k1_base_mul(ujson_t *uj) {
   // Perform a base point multiplication in secp256k1.
   // Trigger are over the API calls.
 
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_secp256k1_base_mul_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
   RESP_OK(ujson_serialize_cryptolib_fi_asym_secp256k1_base_mul_out_t, uj,
           &uj_output);
@@ -292,8 +707,35 @@ status_t handle_cryptolib_fi_asym_secp256k1_point_mul(ujson_t *uj) {
   // The Bob scalar is transformed to a public key to then be multiplied to the
   // Alice scalar. Trigger are over the API calls.
 
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_secp256k1_point_mul_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
   RESP_OK(ujson_serialize_cryptolib_fi_asym_secp256k1_point_mul_out_t, uj,
           &uj_output);
@@ -309,8 +751,35 @@ status_t handle_cryptolib_fi_asym_secp256k1_ecdh(ujson_t *uj) {
   // Perform ecdh in secp256k1.
   // Trigger are over the API calls.
 
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_secp256k1_ecdh_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
   RESP_OK(ujson_serialize_cryptolib_fi_asym_secp256k1_ecdh_out_t, uj,
           &uj_output);
@@ -326,8 +795,35 @@ status_t handle_cryptolib_fi_asym_secp256k1_sign(ujson_t *uj) {
   // Perform a secp256k1 signature.
   // Trigger are over the API calls.
 
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_secp256k1_sign_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
   RESP_OK(ujson_serialize_cryptolib_fi_asym_secp256k1_sign_out_t, uj,
           &uj_output);
@@ -343,8 +839,35 @@ status_t handle_cryptolib_fi_asym_secp256k1_verify(ujson_t *uj) {
   // Perform a secp256k1 verification.
   // Trigger are over the API calls.
 
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_secp256k1_verify_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   uj_output.result = true;
   /////////////// STUB END ///////////////
   RESP_OK(ujson_serialize_cryptolib_fi_asym_secp256k1_verify_out_t, uj,
@@ -361,8 +884,35 @@ status_t handle_cryptolib_fi_asym_x25519_base_mul(ujson_t *uj) {
   // Perform a base point multiplication in X25519.
   // Trigger are over the API calls.
 
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_x25519_base_mul_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
   RESP_OK(ujson_serialize_cryptolib_fi_asym_x25519_base_mul_out_t, uj,
           &uj_output);
@@ -379,8 +929,35 @@ status_t handle_cryptolib_fi_asym_x25519_point_mul(ujson_t *uj) {
   // The Bob scalar is transformed to a public key to then be multiplied to the
   // Alice scalar. Trigger are over the API calls.
 
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_x25519_point_mul_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
   RESP_OK(ujson_serialize_cryptolib_fi_asym_x25519_point_mul_out_t, uj,
           &uj_output);
@@ -396,8 +973,35 @@ status_t handle_cryptolib_fi_asym_x25519_ecdh(ujson_t *uj) {
   // Perform ecdh in x25519.
   // Trigger are over the API calls.
 
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_x25519_ecdh_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
   RESP_OK(ujson_serialize_cryptolib_fi_asym_x25519_ecdh_out_t, uj, &uj_output);
 
@@ -412,8 +1016,35 @@ status_t handle_cryptolib_fi_asym_ed25519_base_mul(ujson_t *uj) {
   // Perform a base point multiplication in ED25519.
   // Trigger are over the API calls.
 
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_ed25519_base_mul_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
   RESP_OK(ujson_serialize_cryptolib_fi_asym_ed25519_base_mul_out_t, uj,
           &uj_output);
@@ -429,8 +1060,35 @@ status_t handle_cryptolib_fi_asym_ed25519_sign(ujson_t *uj) {
   // Perform a ED25519 signature.
   // Trigger are over the API calls.
 
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_ed25519_sign_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
   RESP_OK(ujson_serialize_cryptolib_fi_asym_ed25519_sign_out_t, uj, &uj_output);
 
@@ -445,9 +1103,36 @@ status_t handle_cryptolib_fi_asym_ed25519_verify(ujson_t *uj) {
   // Perform a ED25519 verification.
   // Trigger are over the API calls.
 
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_asym_ed25519_verify_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
   uj_output.result = true;
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
   RESP_OK(ujson_serialize_cryptolib_fi_asym_ed25519_verify_out_t, uj,
           &uj_output);

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
@@ -17,7 +17,6 @@
 #include "sw/device/lib/crypto/include/key_transport.h"
 #include "sw/device/lib/crypto/include/rsa.h"
 #include "sw/device/lib/crypto/include/sha2.h"
-#include "sw/device/lib/dif/dif_rv_core_ibex.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
@@ -34,23 +33,8 @@
 static const unsigned char kTestLabel[] = "Test label.";
 static const size_t kTestLabelLen = sizeof(kTestLabel) - 1;
 
-// Interface to Ibex.
-static dif_rv_core_ibex_t rv_core_ibex;
-
 status_t cryptolib_fi_rsa_enc_impl(cryptolib_fi_asym_rsa_enc_in_t uj_input,
                                    cryptolib_fi_asym_rsa_enc_out_t *uj_output) {
-  // Clear registered alerts in alert handler.
-  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
-  // Clear registered local alerts in alert handler.
-  pentest_registered_loc_alerts_t reg_loc_alerts =
-      pentest_get_triggered_loc_alerts();
-  // Clear the AST recoverable alerts.
-  pentest_clear_sensor_recov_alerts();
-  // Configure Ibex to allow reading ERR_STATUS register.
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
-
   size_t public_key_bytes;
   size_t private_key_bytes;
   size_t private_key_blob_bytes;
@@ -264,39 +248,12 @@ status_t cryptolib_fi_rsa_enc_impl(cryptolib_fi_asym_rsa_enc_in_t uj_input,
     memcpy(uj_output->d, uj_input.d, uj_input.n_len);
   }
 
-  // Get registered alerts from alert handler.
-  reg_alerts = pentest_get_triggered_alerts();
-  // Get registered local alerts from alert handler.
-  reg_loc_alerts = pentest_get_triggered_loc_alerts();
-  // Get fatal and recoverable AST alerts from sensor controller.
-  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
-  // Read ERR_STATUS register.
-  dif_rv_core_ibex_error_status_t codes;
-  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
-  uj_output->err_status = codes;
-  memcpy(uj_output->alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
-  uj_output->loc_alerts = reg_loc_alerts.loc_alerts;
-  memcpy(uj_output->ast_alerts, sensor_alerts.alerts,
-         sizeof(sensor_alerts.alerts));
-
   return OK_STATUS();
 }
 
 status_t cryptolib_fi_rsa_sign_impl(
     cryptolib_fi_asym_rsa_sign_in_t uj_input,
     cryptolib_fi_asym_rsa_sign_out_t *uj_output) {
-  // Clear registered alerts in alert handler.
-  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
-  // Clear registered local alerts in alert handler.
-  pentest_registered_loc_alerts_t reg_loc_alerts =
-      pentest_get_triggered_loc_alerts();
-  // Clear the AST recoverable alerts.
-  pentest_clear_sensor_recov_alerts();
-  // Configure Ibex to allow reading ERR_STATUS register.
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
-
   size_t private_key_bytes;
   size_t private_key_blob_bytes;
   size_t num_words;
@@ -473,39 +430,12 @@ status_t cryptolib_fi_rsa_sign_impl(
   memset(uj_output->d, 0, RSA_CMD_MAX_N_BYTES);
   memcpy(uj_output->d, uj_input.d, uj_input.n_len);
 
-  // Get registered alerts from alert handler.
-  reg_alerts = pentest_get_triggered_alerts();
-  // Get registered local alerts from alert handler.
-  reg_loc_alerts = pentest_get_triggered_loc_alerts();
-  // Get fatal and recoverable AST alerts from sensor controller.
-  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
-  // Read ERR_STATUS register.
-  dif_rv_core_ibex_error_status_t codes;
-  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
-  uj_output->err_status = codes;
-  memcpy(uj_output->alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
-  uj_output->loc_alerts = reg_loc_alerts.loc_alerts;
-  memcpy(uj_output->ast_alerts, sensor_alerts.alerts,
-         sizeof(sensor_alerts.alerts));
-
   return OK_STATUS();
 }
 
 status_t cryptolib_fi_rsa_verify_impl(
     cryptolib_fi_asym_rsa_verify_in_t uj_input,
     cryptolib_fi_asym_rsa_verify_out_t *uj_output) {
-  // Clear registered alerts in alert handler.
-  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
-  // Clear registered local alerts in alert handler.
-  pentest_registered_loc_alerts_t reg_loc_alerts =
-      pentest_get_triggered_loc_alerts();
-  // Clear the AST recoverable alerts.
-  pentest_clear_sensor_recov_alerts();
-  // Configure Ibex to allow reading ERR_STATUS register.
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
-
   size_t public_key_bytes;
   size_t num_words;
   otcrypto_rsa_size_t rsa_size;
@@ -656,39 +586,12 @@ status_t cryptolib_fi_rsa_verify_impl(
   }
   uj_output->cfg = 0;
 
-  // Get registered alerts from alert handler.
-  reg_alerts = pentest_get_triggered_alerts();
-  // Get registered local alerts from alert handler.
-  reg_loc_alerts = pentest_get_triggered_loc_alerts();
-  // Get fatal and recoverable AST alerts from sensor controller.
-  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
-  // Read ERR_STATUS register.
-  dif_rv_core_ibex_error_status_t codes;
-  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
-  uj_output->err_status = codes;
-  memcpy(uj_output->alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
-  uj_output->loc_alerts = reg_loc_alerts.loc_alerts;
-  memcpy(uj_output->ast_alerts, sensor_alerts.alerts,
-         sizeof(sensor_alerts.alerts));
-
   return OK_STATUS();
 }
 
 status_t cryptolib_fi_p256_ecdh_impl(
     cryptolib_fi_asym_p256_ecdh_in_t uj_input,
     cryptolib_fi_asym_p256_ecdh_out_t *uj_output) {
-  // Clear registered alerts in alert handler.
-  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
-  // Clear registered local alerts in alert handler.
-  pentest_registered_loc_alerts_t reg_loc_alerts =
-      pentest_get_triggered_loc_alerts();
-  // Clear the AST recoverable alerts.
-  pentest_clear_sensor_recov_alerts();
-  // Configure Ibex to allow reading ERR_STATUS register.
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
-
   // Construct the private key object.
   uint32_t private_keyblob[kPentestP256MaskedPrivateKeyWords * 2];
   memset(private_keyblob, 0, sizeof(private_keyblob));
@@ -762,39 +665,12 @@ status_t cryptolib_fi_p256_ecdh_impl(
   memset(uj_output->shared_key, 0, P256_CMD_BYTES);
   memcpy(uj_output->shared_key, ss, P256_CMD_BYTES);
 
-  // Get registered alerts from alert handler.
-  reg_alerts = pentest_get_triggered_alerts();
-  // Get registered local alerts from alert handler.
-  reg_loc_alerts = pentest_get_triggered_loc_alerts();
-  // Get fatal and recoverable AST alerts from sensor controller.
-  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
-  // Read ERR_STATUS register.
-  dif_rv_core_ibex_error_status_t codes;
-  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
-  uj_output->err_status = codes;
-  memcpy(uj_output->alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
-  uj_output->loc_alerts = reg_loc_alerts.loc_alerts;
-  memcpy(uj_output->ast_alerts, sensor_alerts.alerts,
-         sizeof(sensor_alerts.alerts));
-
   return OK_STATUS();
 }
 
 status_t cryptolib_fi_p256_sign_impl(
     cryptolib_fi_asym_p256_sign_in_t uj_input,
     cryptolib_fi_asym_p256_sign_out_t *uj_output) {
-  // Clear registered alerts in alert handler.
-  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
-  // Clear registered local alerts in alert handler.
-  pentest_registered_loc_alerts_t reg_loc_alerts =
-      pentest_get_triggered_loc_alerts();
-  // Clear the AST recoverable alerts.
-  pentest_clear_sensor_recov_alerts();
-  // Configure Ibex to allow reading ERR_STATUS register.
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
-
   static const otcrypto_key_config_t kP256PrivateKeyConfig = {
       .version = kOtcryptoLibVersion1,
       .key_mode = kOtcryptoKeyModeEcdsaP256,
@@ -887,39 +763,12 @@ status_t cryptolib_fi_p256_sign_impl(
   memcpy(uj_output->pubx, pub->x, P256_CMD_BYTES);
   memcpy(uj_output->puby, pub->y, P256_CMD_BYTES);
 
-  // Get registered alerts from alert handler.
-  reg_alerts = pentest_get_triggered_alerts();
-  // Get registered local alerts from alert handler.
-  reg_loc_alerts = pentest_get_triggered_loc_alerts();
-  // Get fatal and recoverable AST alerts from sensor controller.
-  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
-  // Read ERR_STATUS register.
-  dif_rv_core_ibex_error_status_t codes;
-  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
-  uj_output->err_status = codes;
-  memcpy(uj_output->alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
-  uj_output->loc_alerts = reg_loc_alerts.loc_alerts;
-  memcpy(uj_output->ast_alerts, sensor_alerts.alerts,
-         sizeof(sensor_alerts.alerts));
-
   return OK_STATUS();
 }
 
 status_t cryptolib_fi_p256_verify_impl(
     cryptolib_fi_asym_p256_verify_in_t uj_input,
     cryptolib_fi_asym_p256_verify_out_t *uj_output) {
-  // Clear registered alerts in alert handler.
-  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
-  // Clear registered local alerts in alert handler.
-  pentest_registered_loc_alerts_t reg_loc_alerts =
-      pentest_get_triggered_loc_alerts();
-  // Clear the AST recoverable alerts.
-  pentest_clear_sensor_recov_alerts();
-  // Configure Ibex to allow reading ERR_STATUS register.
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
-
   // Set up the message buffer.
   uint32_t message_buf[kPentestP256Words];
   memset(message_buf, 0, sizeof(message_buf));
@@ -969,39 +818,12 @@ status_t cryptolib_fi_p256_verify_impl(
   }
   uj_output->cfg = 0;
 
-  // Get registered alerts from alert handler.
-  reg_alerts = pentest_get_triggered_alerts();
-  // Get registered local alerts from alert handler.
-  reg_loc_alerts = pentest_get_triggered_loc_alerts();
-  // Get fatal and recoverable AST alerts from sensor controller.
-  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
-  // Read ERR_STATUS register.
-  dif_rv_core_ibex_error_status_t codes;
-  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
-  uj_output->err_status = codes;
-  memcpy(uj_output->alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
-  uj_output->loc_alerts = reg_loc_alerts.loc_alerts;
-  memcpy(uj_output->ast_alerts, sensor_alerts.alerts,
-         sizeof(sensor_alerts.alerts));
-
   return OK_STATUS();
 }
 
 status_t cryptolib_fi_p384_ecdh_impl(
     cryptolib_fi_asym_p384_ecdh_in_t uj_input,
     cryptolib_fi_asym_p384_ecdh_out_t *uj_output) {
-  // Clear registered alerts in alert handler.
-  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
-  // Clear registered local alerts in alert handler.
-  pentest_registered_loc_alerts_t reg_loc_alerts =
-      pentest_get_triggered_loc_alerts();
-  // Clear the AST recoverable alerts.
-  pentest_clear_sensor_recov_alerts();
-  // Configure Ibex to allow reading ERR_STATUS register.
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
-
   // Construct the private key object.
   uint32_t private_keyblob[kPentestP384MaskedPrivateKeyWords * 2];
   memset(private_keyblob, 0, sizeof(private_keyblob));
@@ -1075,39 +897,12 @@ status_t cryptolib_fi_p384_ecdh_impl(
   memset(uj_output->shared_key, 0, P384_CMD_BYTES);
   memcpy(uj_output->shared_key, ss, P384_CMD_BYTES);
 
-  // Get registered alerts from alert handler.
-  reg_alerts = pentest_get_triggered_alerts();
-  // Get registered local alerts from alert handler.
-  reg_loc_alerts = pentest_get_triggered_loc_alerts();
-  // Get fatal and recoverable AST alerts from sensor controller.
-  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
-  // Read ERR_STATUS register.
-  dif_rv_core_ibex_error_status_t codes;
-  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
-  uj_output->err_status = codes;
-  memcpy(uj_output->alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
-  uj_output->loc_alerts = reg_loc_alerts.loc_alerts;
-  memcpy(uj_output->ast_alerts, sensor_alerts.alerts,
-         sizeof(sensor_alerts.alerts));
-
   return OK_STATUS();
 }
 
 status_t cryptolib_fi_p384_sign_impl(
     cryptolib_fi_asym_p384_sign_in_t uj_input,
     cryptolib_fi_asym_p384_sign_out_t *uj_output) {
-  // Clear registered alerts in alert handler.
-  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
-  // Clear registered local alerts in alert handler.
-  pentest_registered_loc_alerts_t reg_loc_alerts =
-      pentest_get_triggered_loc_alerts();
-  // Clear the AST recoverable alerts.
-  pentest_clear_sensor_recov_alerts();
-  // Configure Ibex to allow reading ERR_STATUS register.
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
-
   static const otcrypto_key_config_t kP384PrivateKeyConfig = {
       .version = kOtcryptoLibVersion1,
       .key_mode = kOtcryptoKeyModeEcdsaP384,
@@ -1199,39 +994,12 @@ status_t cryptolib_fi_p384_sign_impl(
   memcpy(uj_output->pubx, pub->x, P384_CMD_BYTES);
   memcpy(uj_output->puby, pub->y, P384_CMD_BYTES);
 
-  // Get registered alerts from alert handler.
-  reg_alerts = pentest_get_triggered_alerts();
-  // Get registered local alerts from alert handler.
-  reg_loc_alerts = pentest_get_triggered_loc_alerts();
-  // Get fatal and recoverable AST alerts from sensor controller.
-  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
-  // Read ERR_STATUS register.
-  dif_rv_core_ibex_error_status_t codes;
-  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
-  uj_output->err_status = codes;
-  memcpy(uj_output->alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
-  uj_output->loc_alerts = reg_loc_alerts.loc_alerts;
-  memcpy(uj_output->ast_alerts, sensor_alerts.alerts,
-         sizeof(sensor_alerts.alerts));
-
   return OK_STATUS();
 }
 
 status_t cryptolib_fi_p384_verify_impl(
     cryptolib_fi_asym_p384_verify_in_t uj_input,
     cryptolib_fi_asym_p384_verify_out_t *uj_output) {
-  // Clear registered alerts in alert handler.
-  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
-  // Clear registered local alerts in alert handler.
-  pentest_registered_loc_alerts_t reg_loc_alerts =
-      pentest_get_triggered_loc_alerts();
-  // Clear the AST recoverable alerts.
-  pentest_clear_sensor_recov_alerts();
-  // Configure Ibex to allow reading ERR_STATUS register.
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
-
   // Set up the message buffer.
   uint32_t message_buf[kPentestP384Words];
   memset(message_buf, 0, sizeof(message_buf));
@@ -1280,21 +1048,6 @@ status_t cryptolib_fi_p384_verify_impl(
     uj_output->result = false;
   }
   uj_output->cfg = 0;
-
-  // Get registered alerts from alert handler.
-  reg_alerts = pentest_get_triggered_alerts();
-  // Get registered local alerts from alert handler.
-  reg_loc_alerts = pentest_get_triggered_loc_alerts();
-  // Get fatal and recoverable AST alerts from sensor controller.
-  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
-  // Read ERR_STATUS register.
-  dif_rv_core_ibex_error_status_t codes;
-  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
-  uj_output->err_status = codes;
-  memcpy(uj_output->alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
-  uj_output->loc_alerts = reg_loc_alerts.loc_alerts;
-  memcpy(uj_output->ast_alerts, sensor_alerts.alerts,
-         sizeof(sensor_alerts.alerts));
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/crypto/include/security_config.h"
+#include "sw/device/lib/dif/dif_rv_core_ibex.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
@@ -17,6 +18,9 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+// Interface to Ibex.
+static dif_rv_core_ibex_t rv_core_ibex;
+
 status_t handle_cryptolib_fi_sym_aes(ujson_t *uj) {
   cryptolib_fi_sym_aes_in_t uj_input;
   TRY(ujson_deserialize_cryptolib_fi_sym_aes_in_t(uj, &uj_input));
@@ -26,9 +30,37 @@ status_t handle_cryptolib_fi_sym_aes(ujson_t *uj) {
   // Adjust the mode of operation and the padding mode.
   // The total size of this test can be large due to all these options.
   // Triggers are over the API calls.
+
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_sym_aes_out_t uj_output;
   uj_output.status = kUnknown;
   uj_output.status = (size_t)cryptolib_fi_aes_impl(uj_input, &uj_output).value;
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
 
   RESP_OK(ujson_serialize_cryptolib_fi_sym_aes_out_t, uj, &uj_output);
@@ -45,8 +77,35 @@ status_t handle_cryptolib_fi_sym_cmac(ujson_t *uj) {
   // Verify the tag before sending the output.
   // Triggers are over the API calls.
 
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_sym_cmac_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
   RESP_OK(ujson_serialize_cryptolib_fi_sym_cmac_out_t, uj, &uj_output);
 
@@ -61,9 +120,37 @@ status_t handle_cryptolib_fi_sym_gcm(ujson_t *uj) {
   // Perform a GCM encryption with aad and generate a tag.
   // Then, verify that tag again, before sending the output.
   // Trigger are over the API calls.
+
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_sym_gcm_out_t uj_output;
   uj_output.status = kUnknown;
   uj_output.status = (size_t)cryptolib_fi_gcm_impl(uj_input, &uj_output).value;
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
 
   RESP_OK(ujson_serialize_cryptolib_fi_sym_gcm_out_t, uj, &uj_output);
@@ -79,8 +166,35 @@ status_t handle_cryptolib_fi_sym_tdes(ujson_t *uj) {
   // Adjust the mode of operation and the padding mode.
   // Triggers are over the API calls.
 
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_sym_tdes_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
   RESP_OK(ujson_serialize_cryptolib_fi_sym_tdes_out_t, uj, &uj_output);
 
@@ -94,9 +208,37 @@ status_t handle_cryptolib_fi_sym_hmac(ujson_t *uj) {
   /////////////// STUB START ///////////////
   // Perform an HMAC call.
   // Trigger are over the API calls.
+
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_sym_hmac_out_t uj_output;
   uj_output.status = kUnknown;
   uj_output.status = (size_t)cryptolib_fi_hmac_impl(uj_input, &uj_output).value;
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
 
   RESP_OK(ujson_serialize_cryptolib_fi_sym_hmac_out_t, uj, &uj_output);
@@ -110,10 +252,38 @@ status_t handle_cryptolib_fi_sym_drbg_generate(ujson_t *uj) {
   /////////////// STUB START ///////////////
   // Perform a DRBG call to generate random output.
   // Trigger are over the API calls.
+
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_sym_drbg_generate_out_t uj_output;
   uj_output.status = kUnknown;
   uj_output.status =
       (size_t)cryptolib_fi_drbg_generate_impl(uj_input, &uj_output).value;
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
 
   RESP_OK(ujson_serialize_cryptolib_fi_sym_drbg_generate_out_t, uj, &uj_output);
@@ -127,10 +297,38 @@ status_t handle_cryptolib_fi_sym_drbg_reseed(ujson_t *uj) {
   /////////////// STUB START ///////////////
   // Perform a DRBG call to reseed/instantiate the DRBG.
   // Trigger are over the API calls.
+
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_sym_drbg_reseed_out_t uj_output;
   uj_output.status = kUnknown;
   uj_output.status =
       (size_t)cryptolib_fi_drbg_reseed_impl(uj_input, &uj_output).value;
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
 
   RESP_OK(ujson_serialize_cryptolib_fi_sym_drbg_reseed_out_t, uj, &uj_output);
@@ -144,8 +342,36 @@ status_t handle_cryptolib_fi_sym_trng_generate(ujson_t *uj) {
   /////////////// STUB START ///////////////
   // Perform a TRNG call to generate random output.
   // Trigger are over the API calls.
+
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_sym_trng_generate_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
 
   RESP_OK(ujson_serialize_cryptolib_fi_sym_trng_generate_out_t, uj, &uj_output);
@@ -159,8 +385,36 @@ status_t handle_cryptolib_fi_sym_trng_init(ujson_t *uj) {
   /////////////// STUB START ///////////////
   // Perform a TRNG call to instantiate the TRNG.
   // Trigger are over the API calls.
+
+  // Clear registered alerts in alert handler.
+  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear registered local alerts in alert handler.
+  pentest_registered_loc_alerts_t reg_loc_alerts =
+      pentest_get_triggered_loc_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
   cryptolib_fi_sym_trng_init_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
+
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get registered local alerts from alert handler.
+  reg_loc_alerts = pentest_get_triggered_loc_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+  uj_output.err_status = codes;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   /////////////// STUB END ///////////////
 
   RESP_OK(ujson_serialize_cryptolib_fi_sym_trng_init_out_t, uj, &uj_output);

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym_impl.c
@@ -13,7 +13,6 @@
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/drbg.h"
 #include "sw/device/lib/crypto/include/hmac.h"
-#include "sw/device/lib/dif/dif_rv_core_ibex.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
@@ -26,23 +25,8 @@
 // Markers in the dis file to be able to trace certain functions
 #define PENTEST_MARKER_LABEL(name) asm volatile(#name ":" ::: "memory")
 
-// Interface to Ibex.
-static dif_rv_core_ibex_t rv_core_ibex;
-
 status_t cryptolib_fi_aes_impl(cryptolib_fi_sym_aes_in_t uj_input,
                                cryptolib_fi_sym_aes_out_t *uj_output) {
-  // Clear registered alerts in alert handler.
-  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
-  // Clear registered local alerts in alert handler.
-  pentest_registered_loc_alerts_t reg_loc_alerts =
-      pentest_get_triggered_loc_alerts();
-  // Clear the AST recoverable alerts.
-  pentest_clear_sensor_recov_alerts();
-  // Configure Ibex to allow reading ERR_STATUS register.
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
-
   // Set the AES mode.
   otcrypto_aes_mode_t mode;
   otcrypto_key_mode_t key_mode;
@@ -166,39 +150,12 @@ status_t cryptolib_fi_aes_impl(cryptolib_fi_sym_aes_in_t uj_input,
   memset(uj_output->data, 0, AES_CMD_MAX_MSG_BYTES);
   memcpy(uj_output->data, output_buf, uj_output->data_len);
 
-  // Get registered alerts from alert handler.
-  reg_alerts = pentest_get_triggered_alerts();
-  // Get registered local alerts from alert handler.
-  reg_loc_alerts = pentest_get_triggered_loc_alerts();
-  // Get fatal and recoverable AST alerts from sensor controller.
-  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
-  // Read ERR_STATUS register.
-  dif_rv_core_ibex_error_status_t codes;
-  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
-  uj_output->err_status = codes;
-  memcpy(uj_output->alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
-  uj_output->loc_alerts = reg_loc_alerts.loc_alerts;
-  memcpy(uj_output->ast_alerts, sensor_alerts.alerts,
-         sizeof(sensor_alerts.alerts));
-
   return OK_STATUS();
 }
 
 status_t cryptolib_fi_drbg_generate_impl(
     cryptolib_fi_sym_drbg_generate_in_t uj_input,
     cryptolib_fi_sym_drbg_generate_out_t *uj_output) {
-  // Clear registered alerts in alert handler.
-  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
-  // Clear registered local alerts in alert handler.
-  pentest_registered_loc_alerts_t reg_loc_alerts =
-      pentest_get_triggered_loc_alerts();
-  // Clear the AST recoverable alerts.
-  pentest_clear_sensor_recov_alerts();
-  // Configure Ibex to allow reading ERR_STATUS register.
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
-
   // Nonce buffer used for the generate command of the DRBG.
   uint8_t nonce_buf[uj_input.nonce_len];
   memcpy(nonce_buf, uj_input.nonce, uj_input.nonce_len);
@@ -231,39 +188,12 @@ status_t cryptolib_fi_drbg_generate_impl(
   memset(uj_output->data, 0, DRBG_CMD_MAX_OUTPUT_BYTES);
   memcpy(uj_output->data, output_data, uj_input.data_len);
 
-  // Get registered alerts from alert handler.
-  reg_alerts = pentest_get_triggered_alerts();
-  // Get registered local alerts from alert handler.
-  reg_loc_alerts = pentest_get_triggered_loc_alerts();
-  // Get fatal and recoverable AST alerts from sensor controller.
-  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
-  // Read ERR_STATUS register.
-  dif_rv_core_ibex_error_status_t codes;
-  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
-  uj_output->err_status = codes;
-  memcpy(uj_output->alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
-  uj_output->loc_alerts = reg_loc_alerts.loc_alerts;
-  memcpy(uj_output->ast_alerts, sensor_alerts.alerts,
-         sizeof(sensor_alerts.alerts));
-
   return OK_STATUS();
 }
 
 status_t cryptolib_fi_drbg_reseed_impl(
     cryptolib_fi_sym_drbg_reseed_in_t uj_input,
     cryptolib_fi_sym_drbg_reseed_out_t *uj_output) {
-  // Clear registered alerts in alert handler.
-  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
-  // Clear registered local alerts in alert handler.
-  pentest_registered_loc_alerts_t reg_loc_alerts =
-      pentest_get_triggered_loc_alerts();
-  // Clear the AST recoverable alerts.
-  pentest_clear_sensor_recov_alerts();
-  // Configure Ibex to allow reading ERR_STATUS register.
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
-
   // Entropy buffer used for the instantiation of the DRBG.
   uint8_t entropy_buf[uj_input.entropy_len];
   memcpy(entropy_buf, uj_input.entropy, uj_input.entropy_len);
@@ -287,38 +217,11 @@ status_t cryptolib_fi_drbg_reseed_impl(
   // Return data back to host.
   uj_output->cfg = 0;
 
-  // Get registered alerts from alert handler.
-  reg_alerts = pentest_get_triggered_alerts();
-  // Get registered local alerts from alert handler.
-  reg_loc_alerts = pentest_get_triggered_loc_alerts();
-  // Get fatal and recoverable AST alerts from sensor controller.
-  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
-  // Read ERR_STATUS register.
-  dif_rv_core_ibex_error_status_t codes;
-  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
-  uj_output->err_status = codes;
-  memcpy(uj_output->alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
-  uj_output->loc_alerts = reg_loc_alerts.loc_alerts;
-  memcpy(uj_output->ast_alerts, sensor_alerts.alerts,
-         sizeof(sensor_alerts.alerts));
-
   return OK_STATUS();
 }
 
 status_t cryptolib_fi_gcm_impl(cryptolib_fi_sym_gcm_in_t uj_input,
                                cryptolib_fi_sym_gcm_out_t *uj_output) {
-  // Clear registered alerts in alert handler.
-  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
-  // Clear registered local alerts in alert handler.
-  pentest_registered_loc_alerts_t reg_loc_alerts =
-      pentest_get_triggered_loc_alerts();
-  // Clear the AST recoverable alerts.
-  pentest_clear_sensor_recov_alerts();
-  // Configure Ibex to allow reading ERR_STATUS register.
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
-
   // Construct the blinded key configuration.
   otcrypto_key_config_t config = {
       .version = kOtcryptoLibVersion1,
@@ -424,38 +327,11 @@ status_t cryptolib_fi_gcm_impl(cryptolib_fi_sym_gcm_in_t uj_input,
   memset(uj_output->tag, 0, AES_CMD_MAX_MSG_BYTES);
   memcpy(uj_output->tag, actual_tag_data, uj_output->tag_len);
 
-  // Get registered alerts from alert handler.
-  reg_alerts = pentest_get_triggered_alerts();
-  // Get registered local alerts from alert handler.
-  reg_loc_alerts = pentest_get_triggered_loc_alerts();
-  // Get fatal and recoverable AST alerts from sensor controller.
-  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
-  // Read ERR_STATUS register.
-  dif_rv_core_ibex_error_status_t codes;
-  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
-  uj_output->err_status = codes;
-  memcpy(uj_output->alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
-  uj_output->loc_alerts = reg_loc_alerts.loc_alerts;
-  memcpy(uj_output->ast_alerts, sensor_alerts.alerts,
-         sizeof(sensor_alerts.alerts));
-
   return OK_STATUS();
 }
 
 status_t cryptolib_fi_hmac_impl(cryptolib_fi_sym_hmac_in_t uj_input,
                                 cryptolib_fi_sym_hmac_out_t *uj_output) {
-  // Clear registered alerts in alert handler.
-  pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
-  // Clear registered local alerts in alert handler.
-  pentest_registered_loc_alerts_t reg_loc_alerts =
-      pentest_get_triggered_loc_alerts();
-  // Clear the AST recoverable alerts.
-  pentest_clear_sensor_recov_alerts();
-  // Configure Ibex to allow reading ERR_STATUS register.
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
-
   // Set the HMAC mode.
   otcrypto_key_mode_t key_mode;
   unsigned int tag_bytes;
@@ -534,21 +410,6 @@ status_t cryptolib_fi_hmac_impl(cryptolib_fi_sym_hmac_in_t uj_input,
   uj_output->cfg = 0;
   memset(uj_output->data, 0, HMAC_CMD_MAX_TAG_BYTES);
   memcpy(uj_output->data, tag_buf, uj_output->data_len);
-
-  // Get registered alerts from alert handler.
-  reg_alerts = pentest_get_triggered_alerts();
-  // Get registered local alerts from alert handler.
-  reg_loc_alerts = pentest_get_triggered_loc_alerts();
-  // Get fatal and recoverable AST alerts from sensor controller.
-  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
-  // Read ERR_STATUS register.
-  dif_rv_core_ibex_error_status_t codes;
-  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
-  uj_output->err_status = codes;
-  memcpy(uj_output->alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
-  uj_output->loc_alerts = reg_loc_alerts.loc_alerts;
-  memcpy(uj_output->ast_alerts, sensor_alerts.alerts,
-         sizeof(sensor_alerts.alerts));
 
   return OK_STATUS();
 }


### PR DESCRIPTION
In the pentest calling of the cryptolib we use TRY functions that return early if a bad status is detected. However, if we return early the alerts are left unset. In order to prevent this, we set the alerts in the wrapper logic instead.