### PR TITLE
[provisioning,e2e] Run the multistage test on all SKUs

### DIFF
--- a/sw/host/provisioning/orchestrator/tests/BUILD
+++ b/sw/host/provisioning/orchestrator/tests/BUILD
@@ -90,23 +90,34 @@ sh_test(
     ],
 )
 
-sh_test(
-    name = "e2e_multistage_test",
-    srcs = ["e2e_multistage.sh"],
-    data = [
-        ":orchestrator_hyper310_zip",
-        "@python3",
-    ],
-    env = {
-        "PYTHON": "$(location @python3//:python3)",
-    },
-    tags = [
-        "changes_otp",
-        "exclusive",
+[
+    sh_test(
+        name = "e2e_multistage_{}_{}_test".format(sku, fpga),
+        srcs = ["e2e_multistage.sh"],
+        data = [
+            ":orchestrator_{}_zip".format(fpga),
+            "@python3",
+            cfg["orchestrator_cfg"],
+        ],
+        env = {
+            "PYTHON": "$(location @python3//:python3)",
+            "SKU_CONFIG_PATH": "$(location {})".format(cfg["orchestrator_cfg"]),
+            "FPGA": "{}".format(fpga),
+        },
+        tags = [
+            "changes_otp",
+            "exclusive",
+            "manuf",
+        ] + [fpga] + ([
+            "manual",
+        ] if cfg.get("offline", False) else []),
+    )
+    for sku, cfg in EARLGREY_SKUS.items()
+    for fpga in [
         "hyper310",
-        "manuf",
-    ],
-)
+        "cw340",
+    ]
+]
 
 sh_test(
     name = "e2e_ate_individ_test",

--- a/sw/host/provisioning/orchestrator/tests/e2e_multistage.sh
+++ b/sw/host/provisioning/orchestrator/tests/e2e_multistage.sh
@@ -27,10 +27,10 @@ unset RUNFILES_DIR
 # Run tool in CP-only mode first. The path to the --sku-config parameter is
 # relative to the runfiles-dir.
 $PYTHON ${ORCHESTRATOR_PATH} \
-  --sku-config=sw/host/provisioning/orchestrator/configs/skus/emulation.hjson \
+  --sku-config=${SKU_CONFIG_PATH} \
   --test-unlock-token="0x11111111_11111111_11111111_11111111" \
   --test-exit-token="0x22222222_22222222_22222222_22222222" \
-  --fpga=hyper310 \
+  --fpga=${FPGA} \
   --non-interactive \
   --cp-only \
   --db-path=$TEST_TMPDIR/registry.sqlite
@@ -39,10 +39,10 @@ $PYTHON ${ORCHESTRATOR_PATH} \
 # when executing CP mode as we want to simulate a chip that has already had CP
 # run, but just needs to run FT.
 $PYTHON ${ORCHESTRATOR_PATH} \
-  --sku-config=sw/host/provisioning/orchestrator/configs/skus/emulation.hjson \
+  --sku-config=${SKU_CONFIG_PATH} \
   --test-unlock-token="0x11111111_11111111_11111111_11111111" \
   --test-exit-token="0x22222222_22222222_22222222_22222222" \
-  --fpga=hyper310 \
+  --fpga=${FPGA} \
   --fpga-dont-clear-bitstream \
   --non-interactive \
   --db-path=$TEST_TMPDIR/registry.sqlite


### PR DESCRIPTION
This is particularly useful to make it runnable on all FPGAs, but I think it's generally useful to have it run on all SKUs just like the single stage test.