### PR TITLE
[pentest,fi] Adapt pentests for Verilator FI

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
@@ -260,16 +260,20 @@ status_t pentest_configure_entropy_source_max_reseed_interval(void) {
 pentest_sensor_alerts_t pentest_get_sensor_alerts(void) {
   pentest_sensor_alerts_t registered;
   memset(registered.alerts, 0, sizeof(registered.alerts));
-  CHECK_DIF_OK(
-      dif_sensor_ctrl_get_fatal_events(&sensor_ctrl, &registered.alerts[0]));
-  CHECK_DIF_OK(
-      dif_sensor_ctrl_get_recov_events(&sensor_ctrl, &registered.alerts[1]));
+  if (kDeviceType != kDeviceSimVerilator) {
+    CHECK_DIF_OK(
+        dif_sensor_ctrl_get_fatal_events(&sensor_ctrl, &registered.alerts[0]));
+    CHECK_DIF_OK(
+        dif_sensor_ctrl_get_recov_events(&sensor_ctrl, &registered.alerts[1]));
+  }
   return registered;
 }
 
 void pentest_clear_sensor_recov_alerts(void) {
-  for (size_t it = 0; it < SENSOR_CTRL_PARAM_NUM_ALERT_EVENTS; it++) {
-    CHECK_DIF_OK(dif_sensor_ctrl_clear_recov_event(&sensor_ctrl, it));
+  if (kDeviceType != kDeviceSimVerilator) {
+    for (size_t it = 0; it < SENSOR_CTRL_PARAM_NUM_ALERT_EVENTS; it++) {
+      CHECK_DIF_OK(dif_sensor_ctrl_clear_recov_event(&sensor_ctrl, it));
+    }
   }
 }
 


### PR DESCRIPTION
To enable FI experiments in Verilator, this PR:
- Adapts the pentest framework to not read out the AST alerts in Verilator as those are not available in the model