### PR TITLE
[FiSim] ROM_EXT_IMM skip

### DIFF
--- a/sw/device/tests/penetrationtests/BUILD
+++ b/sw/device/tests/penetrationtests/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load(":pentest.bzl", "pentest_cryptolib_fi_asym", "pentest_cryptolib_fi_gdb_asym", "pentest_cryptolib_fi_gdb_sym", "pentest_cryptolib_fi_sym", "pentest_cryptolib_sca_asym", "pentest_cryptolib_sca_sym", "pentest_fi", "pentest_fi_ibex", "pentest_fi_otbn", "pentest_gdb_unit", "pentest_rom_ext_fi_gdb", "pentest_rom_ext_rollback_fi_gdb", "pentest_rom_fi_gdb", "pentest_rom_rollback_fi_gdb", "pentest_sca")
+load(":pentest.bzl", "pentest_cryptolib_fi_asym", "pentest_cryptolib_fi_gdb_asym", "pentest_cryptolib_fi_gdb_sym", "pentest_cryptolib_fi_sym", "pentest_cryptolib_sca_asym", "pentest_cryptolib_sca_sym", "pentest_fi", "pentest_fi_ibex", "pentest_fi_otbn", "pentest_rom_ext_fi_gdb", "pentest_rom_ext_imm_skip_fi_gdb", "pentest_rom_ext_rollback_fi_gdb", "pentest_rom_fi_gdb", "pentest_rom_rollback_fi_gdb", "pentest_sca")
 load("@ot_python_deps//:requirements.bzl", "requirement")
 
 package(default_visibility = ["//visibility:public"])
@@ -518,21 +518,13 @@ pentest_rom_ext_rollback_fi_gdb(
     test_vectors = [],
 )
 
-# This test is to perform unit tests of instruction skipping (also in CI).
-# The functional test
-pentest_gdb_unit(
-    name = "fi_unit_gdb_python_test",
-    tags = [],
+pentest_rom_ext_imm_skip_fi_gdb(
+    name = "fi_rom_ext_imm_skip_python_gdb_test",
+    tags = [
+        "manual",
+        "skip_in_ci",
+    ],
     test_args = "",
-    test_harness = "//sw/host/penetrationtests/python/fi:fi_unit_gdb_python_test",
-    test_vectors = [],
-)
-
-# The instruction skipping test
-pentest_gdb_unit(
-    name = "fi_unit_gdb_python_gdb_test",
-    tags = [],
-    test_args = "",
-    test_harness = "//sw/host/penetrationtests/python/fi:fi_unit_gdb_python_gdb_test",
+    test_harness = "//sw/host/penetrationtests/python/fi:fi_rom_ext_imm_skip_python_gdb_test",
     test_vectors = [],
 )

--- a/sw/device/tests/penetrationtests/firmware/testdata/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/testdata/BUILD
@@ -19,6 +19,7 @@ load(
     "otp_hex",
     "otp_image",
     "otp_json",
+    "otp_json_immutable_rom_ext",
     "otp_partition",
 )
 
@@ -190,5 +191,45 @@ otp_image(
     src = "//hw/top_earlgrey/data/otp:otp_json_rma",
     overlays = STD_OTP_OVERLAYS + [
         ":otp_json_rom_ext_rollback_fi",
+    ],
+)
+
+otp_json_immutable_rom_ext(
+    name = "otp_json_rom_ext_imm_skip_fi",
+    testonly = True,
+    partitions = [
+        otp_partition(
+            name = "CREATOR_SW_CFG",
+            items = {
+                "CREATOR_SW_CFG_RMA_SPIN_EN": otp_hex(CONST.HARDENED_TRUE),
+                # Number of Ibex cycles to spin: we set this to the highest value
+                "CREATOR_SW_CFG_RMA_SPIN_CYCLES": "0xffffffff",
+                # Enable the immutable ROM_EXT
+                "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_TRUE),
+                # Set the hash to a bogus value
+                "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_SHA256_HASH": otp_hex(0x1234),
+            },
+        ),
+        otp_partition(
+            name = "SECRET2",
+            items = {
+                # We set reproducible bitstreams for the tests
+                "RMA_TOKEN": "0000000000000005",
+                "CREATOR_ROOT_KEY_SHARE0": "1111111111111111111111111111111111111111111111111111111111111111",
+                "CREATOR_ROOT_KEY_SHARE1": "2222222222222222222222222222222222222222222222222222222222222222",
+            },
+            lock = True,
+        ),
+    ],
+    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_virtual",
+    visibility = ["//visibility:private"],
+)
+
+otp_image(
+    name = "otp_img_rom_ext_imm_skip_fi",
+    testonly = True,
+    src = "//hw/top_earlgrey/data/otp:otp_json_rma",
+    overlays = STD_OTP_OVERLAYS + [
+        ":otp_json_rom_ext_imm_skip_fi",
     ],
 )

--- a/sw/device/tests/penetrationtests/pentest.bzl
+++ b/sw/device/tests/penetrationtests/pentest.bzl
@@ -888,3 +888,36 @@ def pentest_rom_ext_rollback_fi_gdb(name, test_vectors, test_args, test_harness,
         ),
         deps = FIRMWARE_DEPS_CRYPTOLIB_FI_ASYM,
     )
+
+def pentest_rom_ext_imm_skip_fi_gdb(name, test_vectors, test_args, test_harness, tags):
+    """A macro for defining a CryptoTest test case.
+
+    Args:
+        name: the name of the test.
+        test_vectors: the test vectors to use.
+        test_args: additional arguments to pass to the test.
+        test_harness: the test harness to use.
+        tags: indicate the tags for CI.
+    """
+    opentitan_test(
+        name = name,
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+        },
+        # Provide a correctly signed binary
+        srcs = ["//sw/device/tests/penetrationtests/firmware:firmware_cryptolib_fi_asym.c"],
+        manifest = "//sw/device/silicon_owner:manifest",
+        fpga = fpga_params(
+            timeout = "eternal",
+            # We set an OTP with the RMA lifecycle, ensure ROM_EXT can still boot, but give a bogus ROM_EXT_IMM hash
+            otp = "//sw/device/tests/penetrationtests/firmware/testdata:otp_img_rom_ext_imm_skip_fi",
+            data = test_vectors,
+            tags = tags,
+            test_cmd = """
+                --bootstrap={firmware} --rom_ext={rom_ext} --rom={rom}
+            """ + test_args,
+            test_harness = test_harness,
+            rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_virtual",
+        ),
+        deps = FIRMWARE_DEPS_CRYPTOLIB_FI_ASYM,
+    )

--- a/sw/host/penetrationtests/python/fi/BUILD
+++ b/sw/host/penetrationtests/python/fi/BUILD
@@ -243,6 +243,25 @@ py_binary(
 )
 
 py_binary(
+    name = "fi_rom_ext_imm_skip_python_gdb_test",
+    testonly = True,
+    srcs = ["gdb_testing/fi_rom_ext_imm_skip_python_gdb_test.py"],
+    data = [
+        "//sw/host/opentitantool",
+        "//third_party/openocd:jtag_cmsis_dap_adapter_cfg",
+        "//third_party/openocd:openocd_bin",
+        "//util/openocd/target:lowrisc-earlgrey.cfg",
+        "@lowrisc_rv32imcb_toolchain//:bin/riscv32-unknown-elf-gdb",
+    ],
+    deps = [
+        "//sw/host/penetrationtests/python/util:dis_parser",
+        "//sw/host/penetrationtests/python/util:gdb_controller",
+        "//sw/host/penetrationtests/python/util:targets",
+        "@rules_python//python/runfiles",
+    ],
+)
+
+py_binary(
     name = "fi_sym_cryptolib_python_gdb_test",
     testonly = True,
     srcs = ["gdb_testing/fi_sym_cryptolib_python_gdb_test.py"],

--- a/sw/host/penetrationtests/python/fi/gdb_testing/fi_rom_ext_imm_skip_python_gdb_test.py
+++ b/sw/host/penetrationtests/python/fi/gdb_testing/fi_rom_ext_imm_skip_python_gdb_test.py
@@ -1,0 +1,392 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+########################################################################################
+# Note, to make this test work, set uintptr_t immutable_rom_ext_start_offset = 0x400;
+# instead of an otp_read32 in rom.c. GDB hangs on consecutive otp reads.
+# Check the tests in
+# //sw/device/silicon_creator/rom/e2e/immutable_rom_ext_section
+# for the standard immutable_rom_ext_start_offset.
+########################################################################################
+
+# What to do when running into errors:
+# - If device is busy or seeing "rejected 'gdb' connection, no more connections allowed",
+# cut the USB connection, e.g., sudo fuser /dev/ttyUSB0 and kill the PID
+# - If the port is busy check sudo lsof -i :3333 and then kill the PID
+
+from python.runfiles import Runfiles
+from sw.host.penetrationtests.python.util import targets
+from sw.host.penetrationtests.python.util.gdb_controller import GDBController
+from sw.host.penetrationtests.python.util.dis_parser import DisParser
+from collections import Counter
+import argparse
+import unittest
+import sys
+import os
+import time
+import signal
+import serial
+
+ignored_keys_set = set(["status"])
+opentitantool_path = ""
+log_dir = ""
+rom_elf_path = ""
+rom_parser = None
+target = None
+
+# We set to only apply instruction skips in the first
+# MAX_SKIPS_PER_LOOP iterations of a loop
+MAX_SKIPS_PER_LOOP = 2
+
+# Read in the extra arguments from the opentitan_test.
+parser = argparse.ArgumentParser()
+parser.add_argument("--bitstream", type=str)
+parser.add_argument("--bootstrap", type=str)
+parser.add_argument("--rom_ext", type=str)
+parser.add_argument("--rom", type=str)
+
+args, config_args = parser.parse_known_args()
+
+BITSTREAM = args.bitstream
+BOOTSTRAP = args.bootstrap
+ROM_EXT = args.rom_ext
+ROM = args.rom
+
+original_stdout = sys.stdout
+
+
+class IterationTimeout:
+    def __init__(self, seconds, error_message="Iteration timed out"):
+        self.seconds = seconds
+        self.error_message = error_message
+
+    def handle_timeout(self, signum, frame):
+        raise TimeoutError(self.error_message)
+
+    def __enter__(self):
+        signal.signal(signal.SIGALRM, self.handle_timeout)
+        signal.alarm(self.seconds)
+
+    def __exit__(self, type, value, traceback):
+        signal.alarm(0)
+
+
+def read_uart_output():
+    # Read the output from the chip
+    response = target.read_all(max_tries=100)
+    return response
+
+
+def reset_target_and_gdb(gdb, jump_address, print_output=False):
+    gdb.close_gdb()
+    target.start_openocd(startup_delay=0.2, print_output=False)
+    gdb = GDBController(gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=rom_elf_path)
+    gdb.reset_target()
+    gdb.send_command(f"set $pc={jump_address}")
+    target.dump_all()
+    return gdb
+
+
+# Only called when we encounter an issue where we want to re-flash everything
+def re_initialize(gdb, jump_address, print_output=False):
+    gdb.close_gdb()
+    target.close_openocd()
+    target.clear_bitstream()
+    target.initialize_target(print_output=print_output)
+    gdb = GDBController(gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=rom_elf_path)
+    gdb.reset_target()
+    gdb.send_command(f"set $pc={jump_address}")
+    target.dump_all()
+    return gdb
+
+
+class RomExtImmSkipFiSim(unittest.TestCase):
+    def test_rom_ext_imm_skip_fi(self):
+        print("Starting the rom_ext immutable check skip test")
+
+        # Directory for the trace log files
+        pc_trace_file_1 = os.path.join(log_dir, "rom_ext_imm_skip_pc_trace_1.log")
+        pc_trace_file_2 = os.path.join(log_dir, "rom_ext_imm_skip_pc_trace_2.log")
+        # Directory for the the log of the campaign
+        campaign_file = os.path.join(log_dir, "rom_ext_imm_skip_test_campaign.log")
+
+        successful_faults = 0
+        total_attacks = 0
+
+        gdb = None
+        started = False
+        with open(campaign_file, "w") as campaign:
+            print(f"Switching terminal output to {campaign_file}", flush=True)
+            sys.stdout = campaign
+            try:
+                # Program the bitstream, flash the target, and set up OpenOCD
+                target.initialize_target()
+
+                # We set the RMA spin cycles to a long timeout to be able to halt before ROM starts.
+                # Jump over the spin cycles
+                jump_address = rom_parser.get_function_start_address("kRomStartRmaSpinSkip")
+
+                # Connect to GDB
+                gdb = GDBController(gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=rom_elf_path)
+
+                # Reset the device and halt it immediately
+                gdb.reset_target()
+                gdb.send_command(f"set $pc={jump_address}")
+
+                # Tracing in done in two steps to jump over sc_otbn_cmd_run which makes GDB hang
+
+                # Functions where we can get GDB to jump over
+                upsert_register_address = rom_parser.get_function_start_address("upsert_register")
+
+                # We start from rom_state_boot_rom_ext since we want to skip the
+                # loading of the first app in OTBN for efficiency purposes
+                trace_start_address = rom_parser.get_inlined_function_address(
+                    "rom_state_boot_rom_ext"
+                )
+
+                # We stop tracing when we execute the sc_otbn_busy_wait_for_done
+                trace_end_address = rom_parser.get_function_start_address(
+                    "sc_otbn_busy_wait_for_done"
+                )
+
+                print(
+                    "Start and stop addresses for the rom for trace 1: ",
+                    trace_start_address,
+                    trace_end_address,
+                    flush=True,
+                )
+                print("First trace data is logged in ", pc_trace_file_1, flush=True)
+
+                # Start the tracing
+                # We set a short timeout to detect whether GDB has connected properly
+                # and a long timeout for the entire tracing
+                initial_timeout = 20
+                total_timeout = 60 * 60 * 5
+
+                gdb.setup_pc_trace(
+                    pc_trace_file_1,
+                    trace_start_address,
+                    trace_end_address,
+                    skip_addrs=[upsert_register_address],
+                )
+                gdb.send_command("c", check_response=False)
+
+                start_time = time.time()
+                initial_timeout_stopped = False
+                total_timeout_stopped = False
+
+                # Run the tracing to get the trace log
+                # Sometimes the tracing fails due to race conditions,
+                # we have a quick initial timeout to catch this
+                while time.time() - start_time < initial_timeout:
+                    output = gdb.read_output()
+                    if "breakpoint 1, " in output:
+                        initial_timeout_stopped = True
+                        break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again")
+                    sys.exit(1)
+                while time.time() - start_time < total_timeout:
+                    output = gdb.read_output()
+                    if "PC trace complete" in output:
+                        print("\nTrace complete")
+                        total_timeout_stopped = True
+                        break
+                if not total_timeout_stopped:
+                    print("Final tracing timeout reached")
+                    sys.exit(1)
+
+                # Reset the target, flush the output, and close gdb
+                gdb = reset_target_and_gdb(gdb, jump_address)
+
+                # We ready the second part of the trace
+
+                # We start from sc_otbn_dmem_read which reads p256 verify's results from otbn
+                trace_start_address = rom_parser.get_function_start_address("sc_otbn_dmem_read")
+
+                # We expect with the test that we end up in shutdown_finalize
+                trace_end_address = rom_parser.get_function_start_address("shutdown_finalize")
+
+                print(
+                    "Start and stop addresses for the rom for trace 2: ",
+                    trace_start_address,
+                    trace_end_address,
+                    flush=True,
+                )
+                print("Second trace data is logged in ", pc_trace_file_2, flush=True)
+
+                # Start the tracing
+                # We set a short timeout to detect whether GDB has connected properly
+                # and a long timeout for the entire tracing
+                initial_timeout = 20
+                total_timeout = 60 * 60 * 5
+
+                gdb.setup_pc_trace(
+                    pc_trace_file_2,
+                    trace_start_address,
+                    trace_end_address,
+                    skip_addrs=[upsert_register_address],
+                )
+                gdb.send_command("c", check_response=False)
+
+                start_time = time.time()
+                initial_timeout_stopped = False
+                total_timeout_stopped = False
+
+                # Run the tracing to get the trace log
+                # Sometimes the tracing fails due to race conditions,
+                # we have a quick initial timeout to catch this
+                while time.time() - start_time < initial_timeout:
+                    output = gdb.read_output()
+                    if "breakpoint 1, " in output:
+                        initial_timeout_stopped = True
+                        break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again")
+                    sys.exit(1)
+                while time.time() - start_time < total_timeout:
+                    output = gdb.read_output()
+                    if "PC trace complete" in output:
+                        print("\nTrace complete")
+                        total_timeout_stopped = True
+                        break
+                if not total_timeout_stopped:
+                    print("Final tracing timeout reached")
+                    sys.exit(1)
+
+                # Parse and truncate the trace log to get all PCs in a list
+                pc_list = gdb.parse_pc_trace_file(pc_trace_file_1)
+                pc_list.extend(gdb.parse_pc_trace_file(pc_trace_file_2))
+                # Get the unique PCs and annotate their occurence count
+                pc_count_dict = Counter(pc_list)
+                if len(pc_count_dict) <= 0:
+                    print("Found no tracing, stopping")
+                    sys.exit(1)
+                print("Tracing has a total of", len(pc_count_dict), "unique PCs", flush=True)
+
+                # Reset the target, flush the output, and close gdb
+                gdb = reset_target_and_gdb(gdb, jump_address)
+
+                started = True
+                for pc, count in pc_count_dict.items():
+                    for i_count in range(min(MAX_SKIPS_PER_LOOP, count)):
+                        print("-" * 80)
+                        print("Applying instruction skip in ", pc, "occurence", i_count)
+                        print("-" * 80)
+
+                        try:
+                            # If we have a timeout, we continue to the next iteration
+                            with IterationTimeout(seconds=60):
+                                gdb.apply_instruction_skip(
+                                    pc, rom_parser.parse_next_instruction(pc), i_count
+                                )
+                                gdb.send_command("c", check_response=False)
+
+                                response = read_uart_output()
+                                gdb_response = gdb.read_output()
+
+                                if "instruction skip applied" in gdb_response:
+                                    total_attacks += 1
+
+                                    print("Output:", response, flush=True)
+
+                                    if "Running" in response:
+                                        successful_faults += 1
+                                        print("-" * 80)
+                                        print("Successful FI attack!")
+                                        print("Location:", pc, "iteration", i_count)
+                                        print(gdb_response)
+                                        print("Response:", response)
+                                        print("-" * 80)
+
+                                        try:
+                                            gdb = reset_target_and_gdb(gdb, jump_address)
+                                        except TimeoutError:
+                                            print("Timeout, reflashing", flush=True)
+                                            gdb = re_initialize(gdb, jump_address)
+                                    elif "saved" in response:
+                                        # Here we know that something was changed in flash
+                                        print("Seeing a flash change, reflashing", flush=True)
+                                        gdb = re_initialize(gdb, jump_address)
+                                    else:
+                                        try:
+                                            gdb = reset_target_and_gdb(gdb, jump_address)
+                                        except TimeoutError:
+                                            print("Timeout, reflashing", flush=True)
+                                            gdb = re_initialize(gdb, jump_address)
+                                else:
+                                    print("No break point found, something went wrong", flush=True)
+                                    # Just to be safe that nothing went into flash, we reflash
+                                    gdb = re_initialize(gdb, jump_address)
+
+                        except (TimeoutError, serial.SerialException) as e:
+                            print("Timeout error, retrying", flush=True)
+                            print(e, flush=True)
+                            signal.alarm(0)
+                            gdb = re_initialize(gdb, jump_address)
+
+            finally:
+                print("-" * 80)
+                print(f"Total attacks {total_attacks}, successful attacks {successful_faults}")
+                # Close the OpenOCD and GDB connection at the end
+                if gdb:
+                    gdb.close_gdb()
+                target.close_openocd()
+                sys.stdout = original_stdout
+                self.assertEqual(successful_faults, 0)
+                self.assertEqual(started, True)
+
+
+if __name__ == "__main__":
+    r = Runfiles.Create()
+    # Get the openocd path.
+    openocd_path = r.Rlocation("lowrisc_opentitan/third_party/openocd/build_openocd/bin/openocd")
+    # Get the openocd config files.
+    # The config file for jtag
+    CONFIG_FILE_CHIP = r.Rlocation("openocd/tcl/interface/cmsis-dap.cfg")
+    # The config for the earlgrey design
+    CONFIG_FILE_DESIGN = r.Rlocation("lowrisc_opentitan/util/openocd/target/lowrisc-earlgrey.cfg")
+    # Get the opentitantool path.
+    opentitantool_path = r.Rlocation("lowrisc_opentitan/sw/host/opentitantool/opentitantool")
+    # The path for GDB and the default port (set up by OpenOCD)
+    GDB_PATH = r.Rlocation("lowrisc_rv32imcb_toolchain/bin/riscv32-unknown-elf-gdb")
+    GDB_PORT = 3333
+    # Program the bitstream for FPGAs.
+    bitstream_path = None
+    if BITSTREAM:
+        bitstream_path = r.Rlocation("lowrisc_opentitan/" + BITSTREAM)
+    # Get the test result path
+    log_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR")
+    # Get the firmware path.
+    firmware_path = r.Rlocation("lowrisc_opentitan/" + BOOTSTRAP)
+    # Get the rom path.
+    rom_path = r.Rlocation("lowrisc_opentitan/" + ROM)
+    # Get the disassembly path.
+    rom_dis_path = rom_path.replace(".39.scr.vmem", ".dis")
+    # And the path for the elf.
+    rom_elf_path = rom_path.replace(".39.scr.vmem", ".elf")
+
+    if "fpga" in BOOTSTRAP:
+        target_type = "fpga"
+    else:
+        target_type = "chip"
+
+    target_cfg = targets.TargetConfig(
+        target_type=target_type,
+        interface_type="hyperdebug",
+        fw_bin=firmware_path,
+        opentitantool=opentitantool_path,
+        bitstream=bitstream_path,
+        tool_args=config_args,
+        openocd=openocd_path,
+        openocd_chip_config=CONFIG_FILE_CHIP,
+        openocd_design_config=CONFIG_FILE_DESIGN,
+    )
+
+    target = targets.Target(target_cfg)
+    rom_parser = DisParser(rom_dis_path)
+
+    print("ROM disassembly is found in ", rom_dis_path, flush=True)
+
+    unittest.main(argv=[sys.argv[0]])


### PR DESCRIPTION
Set up a test where the goal is to skip the rom_ext immutable check via simulaton using GDB.
This test does not work by itself, GDB hangs on consecutive otp reads which happen in rom_verify_immutable_section. Instead, to run the test, set uintptr_t immutable_rom_ext_start_offset = (uintptr_t)0x400; in this function instead of the otp read.
A note at the top of the test is added for future use.