### PR TITLE
[otbn,rtl] Clean up naming of predecoded signals

### DIFF
--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -329,10 +329,10 @@ interface otbn_trace_if
 
   for (genvar i_fg = 0; i_fg < NFlagGroups; i_fg++) begin : g_flag_group_acceses
     assign flags_write[i_fg] = (sec_wipe_zero |
-        ((u_otbn_alu_bignum.alu_predec_bignum_i.flags_adder_update[i_fg] |
-          u_otbn_alu_bignum.alu_predec_bignum_i.flags_logic_update[i_fg] |
-          u_otbn_alu_bignum.alu_predec_bignum_i.flags_mac_update[i_fg] |
-          (|u_otbn_alu_bignum.alu_predec_bignum_i.flags_ispr_wr)) &
+        ((u_otbn_alu_bignum.alu_bignum_predec_i.flags_adder_update[i_fg] |
+          u_otbn_alu_bignum.alu_bignum_predec_i.flags_logic_update[i_fg] |
+          u_otbn_alu_bignum.alu_bignum_predec_i.flags_mac_update[i_fg] |
+          (|u_otbn_alu_bignum.alu_bignum_predec_i.flags_ispr_wr)) &
           u_otbn_alu_bignum.operation_commit_i)) & ~ispr_init;
     assign flags_write_data[i_fg] = u_otbn_alu_bignum.flags_d[i_fg];
 

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
@@ -201,7 +201,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
           0: begin
             bit [31:0] bad_rf_ren_a;
             bit [31:0] good_rf_ren_a;
-            err_path = "tb.dut.u_otbn_core.rf_predec_bignum.rf_ren_a";
+            err_path = "tb.dut.u_otbn_core.rf_bignum_predec.rf_ren_a";
             `DV_CHECK_FATAL(uvm_hdl_read(err_path, good_rf_ren_a));
             `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(bad_rf_ren_a,  $countones(bad_rf_ren_a) == 1;
                                                bad_rf_ren_a != good_rf_ren_a;)
@@ -210,7 +210,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
           1: begin
             bit [31:0] bad_rf_ren_b;
             bit [31:0] good_rf_ren_b;
-            err_path = "tb.dut.u_otbn_core.rf_predec_bignum.rf_ren_b";
+            err_path = "tb.dut.u_otbn_core.rf_bignum_predec.rf_ren_b";
             `DV_CHECK_FATAL(uvm_hdl_read(err_path, good_rf_ren_b));
             `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(bad_rf_ren_b,  $countones(bad_rf_ren_b) == 1;
                                                bad_rf_ren_b != good_rf_ren_b;)
@@ -219,7 +219,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
           2: begin
             bit [8:0] bad_ispr_rd_en;
             bit [8:0] good_ispr_rd_en;
-            err_path = "tb.dut.u_otbn_core.ispr_predec_bignum.ispr_rd_en";
+            err_path = "tb.dut.u_otbn_core.ispr_bignum_predec.ispr_rd_en";
             `DV_CHECK_FATAL(uvm_hdl_read(err_path, good_ispr_rd_en));
             `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(bad_ispr_rd_en,  $countones(bad_ispr_rd_en) == 1;
                                                bad_ispr_rd_en != good_ispr_rd_en;)

--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -80,8 +80,8 @@ module otbn_alu_bignum
   output logic [WLEN-1:0]       operation_result_o,
   output logic                  selection_flag_o,
 
-  input  alu_predec_bignum_t  alu_predec_bignum_i,
-  input  ispr_predec_bignum_t ispr_predec_bignum_i,
+  input  alu_bignum_predec_t  alu_bignum_predec_i,
+  input  ispr_bignum_predec_t ispr_bignum_predec_i,
 
   input  ispr_e                       ispr_addr_i,
   input  logic [31:0]                 ispr_base_wdata_i,
@@ -168,7 +168,7 @@ module otbn_alu_bignum
     .clk_i,
     .rst_ni,
     .in_i  (flags_q),
-    .sel_i (alu_predec_bignum_i.flag_group_sel),
+    .sel_i (alu_bignum_predec_i.flag_group_sel),
     .out_o (selected_flags)
   );
 
@@ -182,10 +182,10 @@ module otbn_alu_bignum
                          selected_flags.M,
                          selected_flags.L,
                          selected_flags.Z};
-  assign flag_mux_sel = {alu_predec_bignum_i.flag_sel.Z,
-                         alu_predec_bignum_i.flag_sel.L,
-                         alu_predec_bignum_i.flag_sel.M,
-                         alu_predec_bignum_i.flag_sel.C};
+  assign flag_mux_sel = {alu_bignum_predec_i.flag_sel.Z,
+                         alu_bignum_predec_i.flag_sel.L,
+                         alu_bignum_predec_i.flag_sel.M,
+                         alu_bignum_predec_i.flag_sel.C};
 
   // SEC_CM: DATA_REG_SW.SCA
   prim_onehot_mux #(
@@ -275,7 +275,7 @@ module otbn_alu_bignum
     // SEC_CM: DATA_REG_SW.SCA
     prim_blanker #(.Width(1)) u_mac_z_flag_en_blanker (
       .in_i (mac_operation_flags_en_i.Z),
-      .en_i (alu_predec_bignum_i.flags_mac_update[i_fg]),
+      .en_i (alu_bignum_predec_i.flags_mac_update[i_fg]),
       .out_o(mac_update_z_flag_en_blanked[i_fg])
     );
     assign mac_update_flags[i_fg].Z = mac_update_z_flag_en_blanked[i_fg] ?
@@ -296,11 +296,11 @@ module otbn_alu_bignum
                               logic_update_flags[i_fg],
                               adder_update_flags,
                               flags_q[i_fg]};
-    assign flags_d_mux_sel = {alu_predec_bignum_i.flags_keep[i_fg],
-                              alu_predec_bignum_i.flags_adder_update[i_fg],
-                              alu_predec_bignum_i.flags_logic_update[i_fg],
-                              alu_predec_bignum_i.flags_mac_update[i_fg],
-                              alu_predec_bignum_i.flags_ispr_wr[i_fg]};
+    assign flags_d_mux_sel = {alu_bignum_predec_i.flags_keep[i_fg],
+                              alu_bignum_predec_i.flags_adder_update[i_fg],
+                              alu_bignum_predec_i.flags_logic_update[i_fg],
+                              alu_bignum_predec_i.flags_mac_update[i_fg],
+                              alu_bignum_predec_i.flags_ispr_wr[i_fg]};
 
     // SEC_CM: DATA_REG_SW.SCA
     prim_onehot_mux #(
@@ -339,7 +339,7 @@ module otbn_alu_bignum
   // SEC_CM: DATA_REG_SW.SCA
   prim_blanker #(.Width(ExtWLEN)) u_ispr_mod_bignum_wdata_blanker (
     .in_i (ispr_bignum_wdata_intg_i),
-    .en_i (ispr_predec_bignum_i.ispr_wr_en[IsprMod]),
+    .en_i (ispr_bignum_predec_i.ispr_wr_en[IsprMod]),
     .out_o(ispr_mod_bignum_wdata_intg_blanked)
   );
   // If the blanker is enabled, the output will not carry the correct ECC bits.  This is not
@@ -418,7 +418,7 @@ module otbn_alu_bignum
   // SEC_CM: DATA_REG_SW.SCA
   prim_blanker #(.Width(ExtWLEN)) u_ispr_acc_bignum_wdata_intg_blanker (
     .in_i (ispr_bignum_wdata_intg_i),
-    .en_i (ispr_predec_bignum_i.ispr_wr_en[IsprAcc]),
+    .en_i (ispr_bignum_predec_i.ispr_wr_en[IsprAcc]),
     .out_o(ispr_acc_bignum_wdata_intg_blanked)
   );
   // If the blanker is enabled, the output will not carry the correct ECC bits.  This is not
@@ -473,7 +473,7 @@ module otbn_alu_bignum
     .clk_i,
     .rst_ni,
     .in_i  (ispr_rdata_no_intg_mux_in),
-    .sel_i (ispr_predec_bignum_i.ispr_rd_en),
+    .sel_i (ispr_bignum_predec_i.ispr_rd_en),
     .out_o (ispr_rdata_no_intg)
   );
 
@@ -489,26 +489,26 @@ module otbn_alu_bignum
   assign ispr_rdata_intg_mux_in[IsprAccIntg] = ispr_acc_intg_i;
   assign ispr_rdata_intg_mux_in[IsprNoIntg]  = ispr_rdata_intg_calc;
 
-  assign ispr_rdata_intg_mux_sel[IsprModIntg] = ispr_predec_bignum_i.ispr_rd_en[IsprMod];
-  assign ispr_rdata_intg_mux_sel[IsprAccIntg] = ispr_predec_bignum_i.ispr_rd_en[IsprAcc];
+  assign ispr_rdata_intg_mux_sel[IsprModIntg] = ispr_bignum_predec_i.ispr_rd_en[IsprMod];
+  assign ispr_rdata_intg_mux_sel[IsprAccIntg] = ispr_bignum_predec_i.ispr_rd_en[IsprAcc];
 
   assign ispr_rdata_intg_mux_sel[IsprNoIntg]  =
-    |{ispr_predec_bignum_i.ispr_rd_en[IsprKeyS1H:IsprKeyS0L],
-      ispr_predec_bignum_i.ispr_rd_en[IsprUrnd],
-      ispr_predec_bignum_i.ispr_rd_en[IsprFlags],
-      ispr_predec_bignum_i.ispr_rd_en[IsprRnd]};
+    |{ispr_bignum_predec_i.ispr_rd_en[IsprKeyS1H:IsprKeyS0L],
+      ispr_bignum_predec_i.ispr_rd_en[IsprUrnd],
+      ispr_bignum_predec_i.ispr_rd_en[IsprFlags],
+      ispr_bignum_predec_i.ispr_rd_en[IsprRnd]};
 
   // If we're reading from an ISPR we must be using the ispr_rdata_intg_mux
   `ASSERT(IsprRDataIntgMuxSelIfIsprRd_A,
-    |ispr_predec_bignum_i.ispr_rd_en |-> |ispr_rdata_intg_mux_sel)
+    |ispr_bignum_predec_i.ispr_rd_en |-> |ispr_rdata_intg_mux_sel)
 
   // If we're reading from MOD or ACC we must not take the read data from the calculated integrity
   // path
   `ASSERT(IsprModMustTakeIntg_A,
-    ispr_predec_bignum_i.ispr_rd_en[IsprMod] |-> !ispr_rdata_intg_mux_sel[IsprNoIntg])
+    ispr_bignum_predec_i.ispr_rd_en[IsprMod] |-> !ispr_rdata_intg_mux_sel[IsprNoIntg])
 
   `ASSERT(IsprAccMustTakeIntg_A,
-    ispr_predec_bignum_i.ispr_rd_en[IsprAcc] |-> !ispr_rdata_intg_mux_sel[IsprNoIntg])
+    ispr_bignum_predec_i.ispr_rd_en[IsprAcc] |-> !ispr_rdata_intg_mux_sel[IsprNoIntg])
 
 
   prim_onehot_mux #(
@@ -542,8 +542,8 @@ module otbn_alu_bignum
 
   // SEC_CM: CTRL.REDUN
   assign ispr_predec_error_o =
-    |{expected_ispr_rd_en_onehot != ispr_predec_bignum_i.ispr_rd_en,
-      expected_ispr_wr_en_onehot != ispr_predec_bignum_i.ispr_wr_en};
+    |{expected_ispr_rd_en_onehot != ispr_bignum_predec_i.ispr_rd_en,
+      expected_ispr_wr_en_onehot != ispr_bignum_predec_i.ispr_wr_en};
 
   /////////////
   // Shifter //
@@ -559,19 +559,19 @@ module otbn_alu_bignum
   // SEC_CM: DATA_REG_SW.SCA
   prim_blanker #(.Width(WLEN)) u_shifter_operand_a_blanker (
     .in_i (operation_i.operand_a),
-    .en_i (alu_predec_bignum_i.shifter_a_en),
+    .en_i (alu_bignum_predec_i.shifter_a_en),
     .out_o(shifter_operand_a_blanked)
   );
 
   // SEC_CM: DATA_REG_SW.SCA
   prim_blanker #(.Width(WLEN)) u_shifter_operand_b_blanker (
     .in_i (operation_i.operand_b),
-    .en_i (alu_predec_bignum_i.shifter_b_en),
+    .en_i (alu_bignum_predec_i.shifter_b_en),
     .out_o(shifter_operand_b_blanked)
   );
 
   // Operand A is only used for BN.RSHI, otherwise the upper input is 0. For all instructions other
-  // than BN.RHSI alu_predec_bignum_i.shifter_a_en will be 0, resulting in 0 for the upper input.
+  // than BN.RHSI alu_bignum_predec_i.shifter_a_en will be 0, resulting in 0 for the upper input.
   assign shifter_in_upper = shifter_operand_a_blanked;
   assign shifter_in_lower = shifter_operand_b_blanked;
 
@@ -580,16 +580,16 @@ module otbn_alu_bignum
   end
 
   assign shifter_in = {shifter_in_upper,
-      alu_predec_bignum_i.shift_right ? shifter_in_lower : shifter_in_lower_reverse};
+      alu_bignum_predec_i.shift_right ? shifter_in_lower : shifter_in_lower_reverse};
 
-  assign shifter_out = shifter_in >> alu_predec_bignum_i.shift_amt;
+  assign shifter_out = shifter_in >> alu_bignum_predec_i.shift_amt;
 
   for (genvar i = 0; i < WLEN; i++) begin : g_shifter_out_lower_reverse
     assign shifter_out_lower_reverse[i] = shifter_out[WLEN-i-1];
   end
 
   assign shifter_res =
-      alu_predec_bignum_i.shift_right ? shifter_out[WLEN-1:0] : shifter_out_lower_reverse;
+      alu_bignum_predec_i.shift_right ? shifter_out[WLEN-1:0] : shifter_out_lower_reverse;
 
   // Only the lower WLEN bits of the shift result are returned.
   assign unused_shifter_out_upper = shifter_out[WLEN*2-1:WLEN];
@@ -615,7 +615,7 @@ module otbn_alu_bignum
   // SEC_CM: DATA_REG_SW.SCA
   prim_blanker #(.Width(WLEN+1)) u_adder_x_op_a_blanked (
     .in_i ({operation_i.operand_a, 1'b1}),
-    .en_i (alu_predec_bignum_i.adder_x_en),
+    .en_i (alu_bignum_predec_i.adder_x_en),
     .out_o(adder_x_op_a_blanked)
   );
 
@@ -625,7 +625,7 @@ module otbn_alu_bignum
   // SEC_CM: DATA_REG_SW.SCA
   prim_blanker #(.Width(WLEN+1)) u_adder_x_op_b_blanked (
     .in_i (adder_x_op_b),
-    .en_i (alu_predec_bignum_i.adder_x_en),
+    .en_i (alu_bignum_predec_i.adder_x_en),
     .out_o(adder_x_op_b_blanked)
   );
 
@@ -634,22 +634,22 @@ module otbn_alu_bignum
   // SEC_CM: DATA_REG_SW.SCA
   prim_blanker #(.Width(WLEN)) u_adder_y_op_a_blanked (
     .in_i (operation_i.operand_a),
-    .en_i (alu_predec_bignum_i.adder_y_op_a_en),
+    .en_i (alu_bignum_predec_i.adder_y_op_a_en),
     .out_o(adder_y_op_a_blanked)
   );
 
   assign x_res_operand_a_mux_out =
-      alu_predec_bignum_i.x_res_operand_a_sel ? adder_x_res[WLEN:1] : adder_y_op_a_blanked;
+      alu_bignum_predec_i.x_res_operand_a_sel ? adder_x_res[WLEN:1] : adder_y_op_a_blanked;
 
   // SEC_CM: DATA_REG_SW.SCA
   prim_blanker #(.Width(WLEN)) u_adder_y_op_shifter_blanked (
     .in_i (shifter_res),
-    .en_i (alu_predec_bignum_i.adder_y_op_shifter_en),
+    .en_i (alu_bignum_predec_i.adder_y_op_shifter_en),
     .out_o(adder_y_op_shifter_res_blanked)
   );
 
   assign shift_mod_mux_out =
-      alu_predec_bignum_i.shift_mod_sel ? adder_y_op_shifter_res_blanked : mod_no_intg_q;
+      alu_bignum_predec_i.shift_mod_sel ? adder_y_op_shifter_res_blanked : mod_no_intg_q;
 
   assign adder_y_op_a = {x_res_operand_a_mux_out, 1'b1};
   assign adder_y_op_b = {adder_y_op_b_invert ? ~shift_mod_mux_out : shift_mod_mux_out,
@@ -820,25 +820,25 @@ module otbn_alu_bignum
 
   // SEC_CM: CTRL.REDUN
   assign alu_predec_error_o =
-    |{expected_adder_x_en != alu_predec_bignum_i.adder_x_en,
-      expected_x_res_operand_a_sel != alu_predec_bignum_i.x_res_operand_a_sel,
-      expected_adder_y_op_a_en != alu_predec_bignum_i.adder_y_op_a_en,
-      expected_adder_y_op_shifter_en != alu_predec_bignum_i.adder_y_op_shifter_en,
-      expected_shifter_a_en != alu_predec_bignum_i.shifter_a_en,
-      expected_shifter_b_en != alu_predec_bignum_i.shifter_b_en,
-      expected_shift_right != alu_predec_bignum_i.shift_right,
-      expected_shift_amt != alu_predec_bignum_i.shift_amt,
-      expected_shift_mod_sel != alu_predec_bignum_i.shift_mod_sel,
-      expected_logic_a_en != alu_predec_bignum_i.logic_a_en,
-      expected_logic_shifter_en != alu_predec_bignum_i.logic_shifter_en,
-      expected_logic_res_sel != alu_predec_bignum_i.logic_res_sel,
-      expected_flag_group_sel != alu_predec_bignum_i.flag_group_sel,
-      expected_flag_sel != alu_predec_bignum_i.flag_sel,
-      expected_flags_keep != alu_predec_bignum_i.flags_keep,
-      expected_flags_adder_update != alu_predec_bignum_i.flags_adder_update,
-      expected_flags_logic_update != alu_predec_bignum_i.flags_logic_update,
-      expected_flags_mac_update != alu_predec_bignum_i.flags_mac_update,
-      expected_flags_ispr_wr != alu_predec_bignum_i.flags_ispr_wr};
+    |{expected_adder_x_en != alu_bignum_predec_i.adder_x_en,
+      expected_x_res_operand_a_sel != alu_bignum_predec_i.x_res_operand_a_sel,
+      expected_adder_y_op_a_en != alu_bignum_predec_i.adder_y_op_a_en,
+      expected_adder_y_op_shifter_en != alu_bignum_predec_i.adder_y_op_shifter_en,
+      expected_shifter_a_en != alu_bignum_predec_i.shifter_a_en,
+      expected_shifter_b_en != alu_bignum_predec_i.shifter_b_en,
+      expected_shift_right != alu_bignum_predec_i.shift_right,
+      expected_shift_amt != alu_bignum_predec_i.shift_amt,
+      expected_shift_mod_sel != alu_bignum_predec_i.shift_mod_sel,
+      expected_logic_a_en != alu_bignum_predec_i.logic_a_en,
+      expected_logic_shifter_en != alu_bignum_predec_i.logic_shifter_en,
+      expected_logic_res_sel != alu_bignum_predec_i.logic_res_sel,
+      expected_flag_group_sel != alu_bignum_predec_i.flag_group_sel,
+      expected_flag_sel != alu_bignum_predec_i.flag_sel,
+      expected_flags_keep != alu_bignum_predec_i.flags_keep,
+      expected_flags_adder_update != alu_bignum_predec_i.flags_adder_update,
+      expected_flags_logic_update != alu_bignum_predec_i.flags_logic_update,
+      expected_flags_mac_update != alu_bignum_predec_i.flags_mac_update,
+      expected_flags_ispr_wr != alu_bignum_predec_i.flags_ispr_wr};
 
   ////////////////////////
   // Logical operations //
@@ -851,14 +851,14 @@ module otbn_alu_bignum
   // SEC_CM: DATA_REG_SW.SCA
   prim_blanker #(.Width(WLEN)) u_logical_op_a_blanker (
     .in_i (operation_i.operand_a),
-    .en_i (alu_predec_bignum_i.logic_a_en),
+    .en_i (alu_bignum_predec_i.logic_a_en),
     .out_o(logical_op_a_blanked)
   );
 
   // SEC_CM: DATA_REG_SW.SCA
   prim_blanker #(.Width(WLEN)) u_logical_op_shifter_res_blanker (
     .in_i (shifter_res),
-    .en_i (alu_predec_bignum_i.logic_shifter_en),
+    .en_i (alu_bignum_predec_i.logic_shifter_en),
     .out_o(logical_op_shifter_res_blanked)
   );
 
@@ -875,7 +875,7 @@ module otbn_alu_bignum
     .clk_i,
     .rst_ni,
     .in_i  (logical_res_mux_in),
-    .sel_i (alu_predec_bignum_i.logic_res_sel),
+    .sel_i (alu_bignum_predec_i.logic_res_sel),
     .out_o (logical_res)
   );
 
@@ -957,7 +957,7 @@ module otbn_alu_bignum
   // `operation_result_o`.
   logic mod_used;
   assign mod_used = operation_valid_i & (operation_i.op != AluOpBignumNone)
-                    & !alu_predec_bignum_i.shift_mod_sel & adder_y_res_used;
+                    & !alu_bignum_predec_i.shift_mod_sel & adder_y_res_used;
   `ASSERT_KNOWN(ModUsed_A, mod_used)
 
   // Raise a register integrity violation error iff `mod_intg_q` is used and (at least partially)

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -115,12 +115,12 @@ module otbn_core
   logic                     insn_fetch_err;
   logic                     insn_addr_err;
 
-  rf_predec_bignum_t        rf_predec_bignum;
-  alu_predec_bignum_t       alu_predec_bignum;
+  rf_bignum_predec_t        rf_bignum_predec;
+  alu_bignum_predec_t       alu_bignum_predec;
   ctrl_flow_predec_t        ctrl_flow_predec;
   logic [ImemAddrWidth-1:0] ctrl_flow_target_predec;
-  ispr_predec_bignum_t      ispr_predec_bignum;
-  mac_predec_bignum_t       mac_predec_bignum;
+  ispr_bignum_predec_t      ispr_bignum_predec;
+  mac_bignum_predec_t       mac_bignum_predec;
   logic                     lsu_addr_en_predec;
 
   logic [NWdr-1:0] rf_bignum_rd_a_indirect_onehot;
@@ -363,12 +363,12 @@ module otbn_core
     .insn_fetch_err_o       (insn_fetch_err),
     .insn_addr_err_o        (insn_addr_err),
 
-    .rf_predec_bignum_o       (rf_predec_bignum),
-    .alu_predec_bignum_o      (alu_predec_bignum),
+    .rf_bignum_predec_o       (rf_bignum_predec),
+    .alu_bignum_predec_o      (alu_bignum_predec),
     .ctrl_flow_predec_o       (ctrl_flow_predec),
     .ctrl_flow_target_predec_o(ctrl_flow_target_predec),
-    .ispr_predec_bignum_o     (ispr_predec_bignum),
-    .mac_predec_bignum_o      (mac_predec_bignum),
+    .ispr_bignum_predec_o     (ispr_bignum_predec),
+    .mac_bignum_predec_o      (mac_bignum_predec),
     .lsu_addr_en_predec_o     (lsu_addr_en_predec),
 
     .rf_bignum_rd_a_indirect_onehot_i(rf_bignum_rd_a_indirect_onehot),
@@ -412,9 +412,9 @@ module otbn_core
   // guaranteed there are no register reads (hence no sensitive data bits being fed into the blanked
   // data paths). RF and ISPR predecode must always be checked to ensure read and write data paths
   // are always correctly blanked.
-  assign rd_predec_error = |{rf_predec_bignum.rf_ren_a,
-                             rf_predec_bignum.rf_ren_b,
-                             ispr_predec_bignum.ispr_rd_en} & ~insn_valid;
+  assign rd_predec_error = |{rf_bignum_predec.rf_ren_a,
+                             rf_bignum_predec.rf_ren_b,
+                             ispr_bignum_predec.ispr_rd_en} & ~insn_valid;
 
   assign predec_error =
     ((alu_bignum_predec_error | mac_bignum_predec_error | controller_predec_error) & insn_valid) |
@@ -775,7 +775,7 @@ module otbn_core
 
     .intg_err_o(rf_bignum_intg_err),
 
-    .rf_predec_bignum_i(rf_predec_bignum),
+    .rf_bignum_predec_i(rf_bignum_predec),
     .predec_error_o    (rf_bignum_predec_error),
 
     .spurious_we_err_o(rf_bignum_spurious_we_err)
@@ -828,8 +828,8 @@ module otbn_core
     .operation_result_o(alu_bignum_operation_result),
     .selection_flag_o  (alu_bignum_selection_flag),
 
-    .alu_predec_bignum_i (alu_predec_bignum),
-    .ispr_predec_bignum_i(ispr_predec_bignum),
+    .alu_bignum_predec_i (alu_bignum_predec),
+    .ispr_bignum_predec_i(ispr_bignum_predec),
 
     .ispr_addr_i             (ispr_addr),
     .ispr_base_wdata_i       (ispr_base_wdata),
@@ -874,8 +874,8 @@ module otbn_core
     .operation_flags_en_o           (mac_bignum_operation_flags_en),
     .operation_intg_violation_err_o (mac_bignum_reg_intg_violation_err),
 
-    .mac_predec_bignum_i(mac_predec_bignum),
-    .predec_error_o     (mac_bignum_predec_error),
+    .predec_i      (mac_bignum_predec),
+    .predec_error_o(mac_bignum_predec_error),
 
     .urnd_data_i        (urnd_data),
     .sec_wipe_acc_urnd_i(sec_wipe_acc_urnd),
@@ -926,10 +926,10 @@ module otbn_core
   // Advance URND either when the start_stop_control commands it or when temporary secure wipe keys
   // are requested.
   // When SecMuteUrnd is enabled, signal urnd_advance_start_stop_control is muted. Therefore, it is
-  // necessary to enable urnd_advance using ispr_predec_bignum.ispr_rd_en[IsprUrnd] whenever URND
+  // necessary to enable urnd_advance using ispr_bignum_predec.ispr_rd_en[IsprUrnd] whenever URND
   // data are consumed by the ALU.
   assign urnd_advance = urnd_advance_start_stop_control | req_sec_wipe_urnd_keys_q |
-                        (SecMuteUrnd & ispr_predec_bignum.ispr_rd_en[IsprUrnd]);
+                        (SecMuteUrnd & ispr_bignum_predec.ispr_rd_en[IsprUrnd]);
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin

--- a/hw/ip/otbn/rtl/otbn_instruction_fetch.sv
+++ b/hw/ip/otbn/rtl/otbn_instruction_fetch.sv
@@ -36,12 +36,12 @@ module otbn_instruction_fetch
   output logic [31:0]              insn_fetch_resp_data_o,
   input  logic                     insn_fetch_resp_clear_i,
 
-  output rf_predec_bignum_t        rf_predec_bignum_o,
-  output alu_predec_bignum_t       alu_predec_bignum_o,
+  output rf_bignum_predec_t        rf_bignum_predec_o,
+  output alu_bignum_predec_t       alu_bignum_predec_o,
   output ctrl_flow_predec_t        ctrl_flow_predec_o,
   output logic [ImemAddrWidth-1:0] ctrl_flow_target_predec_o,
-  output ispr_predec_bignum_t      ispr_predec_bignum_o,
-  output mac_predec_bignum_t       mac_predec_bignum_o,
+  output ispr_bignum_predec_t      ispr_bignum_predec_o,
+  output mac_bignum_predec_t       mac_bignum_predec_o,
   output logic                     lsu_addr_en_predec_o,
 
   input logic [NWdr-1:0] rf_bignum_rd_a_indirect_onehot_i,
@@ -86,13 +86,13 @@ module otbn_instruction_fetch
   logic                     imem_rvalid_final;
   logic                     imem_rvalid_kill_q, imem_rvalid_kill_d;
 
-  rf_predec_bignum_t   rf_predec_bignum_indirect, rf_predec_bignum_sec_wipe;
-  rf_predec_bignum_t   rf_predec_bignum_q, rf_predec_bignum_d, rf_predec_bignum_insn;
-  alu_predec_bignum_t  alu_predec_bignum_zero_flags;
-  alu_predec_bignum_t  alu_predec_bignum_q, alu_predec_bignum_d, alu_predec_bignum_insn;
-  ispr_predec_bignum_t ispr_predec_bignum_q, ispr_predec_bignum_d;
-  ispr_predec_bignum_t ispr_predec_bignum;
-  mac_predec_bignum_t  mac_predec_bignum, mac_predec_bignum_q, mac_predec_bignum_d;
+  rf_bignum_predec_t   rf_bignum_predec_indirect, rf_bignum_predec_sec_wipe;
+  rf_bignum_predec_t   rf_bignum_predec_q, rf_bignum_predec_d, rf_bignum_predec_insn;
+  alu_bignum_predec_t  alu_bignum_predec_zero_flags;
+  alu_bignum_predec_t  alu_bignum_predec_q, alu_bignum_predec_d, alu_bignum_predec_insn;
+  ispr_bignum_predec_t ispr_bignum_predec_q, ispr_bignum_predec_d;
+  ispr_bignum_predec_t ispr_bignum_predec;
+  mac_bignum_predec_t  mac_bignum_predec, mac_bignum_predec_q, mac_bignum_predec_d;
   logic                lsu_addr_en_predec_q, lsu_addr_en_predec_d;
   logic                lsu_addr_en_predec_insn;
   logic                insn_addr_err_unbuf;
@@ -138,13 +138,13 @@ module otbn_instruction_fetch
     .imem_raddr_i (insn_prefetch_addr),
     .imem_rvalid_i(imem_rvalid_final),
 
-    .rf_predec_bignum_o        (rf_predec_bignum_insn),
-    .alu_predec_bignum_o       (alu_predec_bignum_insn),
-    .ctrl_flow_predec_o        (ctrl_flow_predec),
-    .ctrl_flow_target_predec_o (ctrl_flow_target_predec),
-    .ispr_predec_bignum_o      (ispr_predec_bignum),
-    .mac_predec_bignum_o       (mac_predec_bignum),
-    .lsu_addr_en_predec_o      (lsu_addr_en_predec_insn)
+    .rf_bignum_predec_o       (rf_bignum_predec_insn),
+    .alu_bignum_predec_o      (alu_bignum_predec_insn),
+    .ctrl_flow_predec_o       (ctrl_flow_predec),
+    .ctrl_flow_target_predec_o(ctrl_flow_target_predec),
+    .ispr_bignum_predec_o     (ispr_bignum_predec),
+    .mac_bignum_predec_o      (mac_bignum_predec),
+    .lsu_addr_en_predec_o     (lsu_addr_en_predec_insn)
   );
 
   prim_onehot_enc #(
@@ -160,24 +160,24 @@ module otbn_instruction_fetch
   // determine which bignum register is used occurs in the first cycle of the instruction
   // execution. The onehot encoded version of the register index is passed back here (via the
   // `rf_bignum_*_indirect_onehot_i` signals to set the enables for the following cycle.
-  assign rf_predec_bignum_indirect = '{rf_ren_a : rf_bignum_rd_a_indirect_onehot_i,
+  assign rf_bignum_predec_indirect = '{rf_ren_a : rf_bignum_rd_a_indirect_onehot_i,
                                        rf_ren_b : rf_bignum_rd_b_indirect_onehot_i,
                                        rf_we    : rf_bignum_wr_indirect_onehot_i};
 
-  assign rf_predec_bignum_sec_wipe = '{rf_ren_a : '0,
+  assign rf_bignum_predec_sec_wipe = '{rf_ren_a : '0,
                                        rf_ren_b : '0,
                                        rf_we    : rf_bignum_wr_sec_wipe_onehot};
 
   // Register enables for bignum come from precode unless indirect register accesses are used
-  assign rf_predec_bignum_d = sec_wipe_wdr_en_i       ? rf_predec_bignum_sec_wipe :
-                              rf_bignum_indirect_en_i ? rf_predec_bignum_indirect :
-                              insn_fetch_en           ? rf_predec_bignum_insn     :
+  assign rf_bignum_predec_d = sec_wipe_wdr_en_i       ? rf_bignum_predec_sec_wipe :
+                              rf_bignum_indirect_en_i ? rf_bignum_predec_indirect :
+                              insn_fetch_en           ? rf_bignum_predec_insn     :
                               insn_fetch_resp_clear_i ? '0                        :
-                                                        rf_predec_bignum_q;
+                                                        rf_bignum_predec_q;
 
-  assign ispr_predec_bignum_d = insn_fetch_en           ? ispr_predec_bignum :
+  assign ispr_bignum_predec_d = insn_fetch_en           ? ispr_bignum_predec :
                                 insn_fetch_resp_clear_i ? '0                 :
-                                                          ispr_predec_bignum_q;
+                                                          ispr_bignum_predec_q;
 
   assign lsu_addr_en_predec_d = insn_fetch_en           ? lsu_addr_en_predec_insn :
                                 insn_fetch_resp_clear_i ? 1'b0:
@@ -209,20 +209,20 @@ module otbn_instruction_fetch
   // For secure wipe and ISPR initialization, flags need to be set to 0. This is achieved
   // by setting all selector inputs for the corresponding one-hot mux in the ALU to zero.
   always_comb begin
-    alu_predec_bignum_zero_flags = alu_predec_bignum_insn;
+    alu_bignum_predec_zero_flags = alu_bignum_predec_insn;
 
-    alu_predec_bignum_zero_flags.flags_keep         = '0;
-    alu_predec_bignum_zero_flags.flags_adder_update = '0;
-    alu_predec_bignum_zero_flags.flags_logic_update = '0;
-    alu_predec_bignum_zero_flags.flags_mac_update   = '0;
-    alu_predec_bignum_zero_flags.flags_ispr_wr      = '0;
+    alu_bignum_predec_zero_flags.flags_keep         = '0;
+    alu_bignum_predec_zero_flags.flags_adder_update = '0;
+    alu_bignum_predec_zero_flags.flags_logic_update = '0;
+    alu_bignum_predec_zero_flags.flags_mac_update   = '0;
+    alu_bignum_predec_zero_flags.flags_ispr_wr      = '0;
   end
 
-  assign alu_predec_bignum_d = zero_flags_i  ? alu_predec_bignum_zero_flags :
-                               insn_fetch_en ? alu_predec_bignum_insn       :
-                                               alu_predec_bignum_q;
+  assign alu_bignum_predec_d = zero_flags_i  ? alu_bignum_predec_zero_flags :
+                               insn_fetch_en ? alu_bignum_predec_insn       :
+                                               alu_bignum_predec_q;
 
-  assign mac_predec_bignum_d = insn_fetch_en ? mac_predec_bignum : mac_predec_bignum_q;
+  assign mac_bignum_predec_d = insn_fetch_en ? mac_bignum_predec : mac_bignum_predec_q;
 
   assign ctrl_flow_predec_d = insn_fetch_en           ? ctrl_flow_predec   :
                               insn_fetch_resp_clear_i ? '0                 :
@@ -233,25 +233,25 @@ module otbn_instruction_fetch
 
 
   prim_flop #(
-    .Width($bits(alu_predec_bignum_t)),
+    .Width($bits(alu_bignum_predec_t)),
     .ResetValue('0)
-  ) u_alu_predec_bignum_flop(
+  ) u_alu_bignum_predec_flop(
     .clk_i,
     .rst_ni,
 
-    .d_i(alu_predec_bignum_d),
-    .q_o(alu_predec_bignum_q)
+    .d_i(alu_bignum_predec_d),
+    .q_o(alu_bignum_predec_q)
   );
 
   prim_flop #(
-    .Width($bits(mac_predec_bignum_t)),
+    .Width($bits(mac_bignum_predec_t)),
     .ResetValue('0)
-  ) u_mac_predec_bignum_flop (
+  ) u_mac_bignum_predec_flop (
     .clk_i,
     .rst_ni,
 
-    .d_i(mac_predec_bignum_d),
-    .q_o(mac_predec_bignum_q)
+    .d_i(mac_bignum_predec_d),
+    .q_o(mac_bignum_predec_q)
   );
 
   prim_flop #(
@@ -277,25 +277,25 @@ module otbn_instruction_fetch
   );
 
   prim_flop #(
-    .Width($bits(rf_predec_bignum_t)),
+    .Width($bits(rf_bignum_predec_t)),
     .ResetValue('0)
-  ) u_rf_predec_bignum_flop (
+  ) u_rf_bignum_predec_flop (
     .clk_i,
     .rst_ni,
 
-    .d_i(rf_predec_bignum_d),
-    .q_o(rf_predec_bignum_q)
+    .d_i(rf_bignum_predec_d),
+    .q_o(rf_bignum_predec_q)
   );
 
   prim_flop #(
-    .Width($bits(ispr_predec_bignum_t)),
+    .Width($bits(ispr_bignum_predec_t)),
     .ResetValue('0)
-  ) u_ispr_predec_bignum_flop (
+  ) u_ispr_bignum_predec_flop (
     .clk_i,
     .rst_ni,
 
-    .d_i(ispr_predec_bignum_d),
-    .q_o(ispr_predec_bignum_q)
+    .d_i(ispr_bignum_predec_d),
+    .q_o(ispr_bignum_predec_q)
   );
 
   prim_flop #(
@@ -407,12 +407,12 @@ module otbn_instruction_fetch
     .out_o(insn_addr_err_o)
   );
 
-  assign rf_predec_bignum_o        = rf_predec_bignum_q;
-  assign alu_predec_bignum_o       = alu_predec_bignum_q;
+  assign rf_bignum_predec_o        = rf_bignum_predec_q;
+  assign alu_bignum_predec_o       = alu_bignum_predec_q;
   assign ctrl_flow_predec_o        = ctrl_flow_predec_q;
   assign ctrl_flow_target_predec_o = ctrl_flow_target_predec_q;
-  assign ispr_predec_bignum_o      = ispr_predec_bignum_q;
-  assign mac_predec_bignum_o       = mac_predec_bignum_q;
+  assign ispr_bignum_predec_o      = ispr_bignum_predec_q;
+  assign mac_bignum_predec_o       = mac_bignum_predec_q;
   assign lsu_addr_en_predec_o      = lsu_addr_en_predec_q;
 
   `ASSERT(FetchEnOnlyIfValidIMem, insn_fetch_en |-> imem_rvalid_i)

--- a/hw/ip/otbn/rtl/otbn_mac_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_mac_bignum.sv
@@ -19,7 +19,7 @@ module otbn_mac_bignum
   output flags_t          operation_flags_en_o,
   output logic            operation_intg_violation_err_o,
 
-  input  mac_predec_bignum_t mac_predec_bignum_i,
+  input  mac_bignum_predec_t predec_i,
   output logic               predec_error_o,
 
   input  logic [WLEN-1:0] urnd_data_i,
@@ -56,14 +56,14 @@ module otbn_mac_bignum
   // SEC_CM: DATA_REG_SW.SCA
   prim_blanker #(.Width(WLEN)) u_operand_a_blanker (
     .in_i (operation_i.operand_a),
-    .en_i (mac_predec_bignum_i.op_en),
+    .en_i (predec_i.op_en),
     .out_o(operand_a_blanked)
   );
 
   // SEC_CM: DATA_REG_SW.SCA
   prim_blanker #(.Width(WLEN)) u_operand_b_blanker (
     .in_i (operation_i.operand_b),
-    .en_i (mac_predec_bignum_i.op_en),
+    .en_i (predec_i.op_en),
     .out_o(operand_b_blanked)
   );
 
@@ -150,7 +150,7 @@ module otbn_mac_bignum
   // acc_rd_en is so if .Z set in MULQACC (zero_acc) so accumulator reads as 0
   prim_blanker #(.Width(WLEN)) u_acc_blanker (
     .in_i (acc_no_intg_q),
-    .en_i (mac_predec_bignum_i.acc_rd_en),
+    .en_i (predec_i.acc_rd_en),
     .out_o(acc_blanked)
   );
 
@@ -235,8 +235,8 @@ module otbn_mac_bignum
   assign expected_acc_rd_en = ~operation_i.zero_acc & mac_en_i;
 
   // SEC_CM: CTRL.REDUN
-  assign predec_error_o = |{expected_op_en     != mac_predec_bignum_i.op_en,
-                            expected_acc_rd_en != mac_predec_bignum_i.acc_rd_en};
+  assign predec_error_o = |{expected_op_en     != predec_i.op_en,
+                            expected_acc_rd_en != predec_i.acc_rd_en};
 
   assign sec_wipe_err_o = sec_wipe_acc_urnd_i & ~sec_wipe_running_i;
 

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -467,7 +467,7 @@ package otbn_pkg;
     logic [NWdr-1:0] rf_ren_a;
     logic [NWdr-1:0] rf_ren_b;
     logic [NWdr-1:0] rf_we;
-  } rf_predec_bignum_t;
+  } rf_bignum_predec_t;
 
   typedef struct packed {
     logic                    adder_x_en;
@@ -489,17 +489,17 @@ package otbn_pkg;
     logic [NFlagGroups-1:0]  flags_logic_update;
     logic [NFlagGroups-1:0]  flags_mac_update;
     logic [NFlagGroups-1:0]  flags_ispr_wr;
-  } alu_predec_bignum_t;
+  } alu_bignum_predec_t;
 
   typedef struct packed {
     logic [NIspr-1:0] ispr_rd_en;
     logic [NIspr-1:0] ispr_wr_en;
-  } ispr_predec_bignum_t;
+  } ispr_bignum_predec_t;
 
   typedef struct packed {
     logic op_en;
     logic acc_rd_en;
-  } mac_predec_bignum_t;
+  } mac_bignum_predec_t;
 
   typedef struct packed {
     logic call_stack_pop;

--- a/hw/ip/otbn/rtl/otbn_predecode.sv
+++ b/hw/ip/otbn/rtl/otbn_predecode.sv
@@ -18,10 +18,10 @@ module otbn_predecode
   input  logic                     imem_rvalid_i,
   input  logic [ImemAddrWidth-1:0] imem_raddr_i,
 
-  output rf_predec_bignum_t        rf_predec_bignum_o,
-  output alu_predec_bignum_t       alu_predec_bignum_o,
-  output ispr_predec_bignum_t      ispr_predec_bignum_o,
-  output mac_predec_bignum_t       mac_predec_bignum_o,
+  output rf_bignum_predec_t        rf_bignum_predec_o,
+  output alu_bignum_predec_t       alu_bignum_predec_o,
+  output ispr_bignum_predec_t      ispr_bignum_predec_o,
+  output mac_bignum_predec_t       mac_bignum_predec_o,
   output logic                     lsu_addr_en_predec_o,
   output ctrl_flow_predec_t        ctrl_flow_predec_o,
   output logic [ImemAddrWidth-1:0] ctrl_flow_target_predec_o
@@ -498,28 +498,28 @@ module otbn_predecode
     end
   end
 
-  assign alu_predec_bignum_o.adder_x_en            = alu_bignum_adder_x_en;
-  assign alu_predec_bignum_o.x_res_operand_a_sel   = alu_bignum_x_res_operand_a_sel;
-  assign alu_predec_bignum_o.adder_y_op_a_en       = alu_bignum_adder_y_op_a_en;
-  assign alu_predec_bignum_o.adder_y_op_shifter_en = alu_bignum_adder_y_op_shifter_en;
-  assign alu_predec_bignum_o.shifter_a_en          = alu_bignum_shifter_a_en;
-  assign alu_predec_bignum_o.shifter_b_en          = alu_bignum_shifter_b_en;
-  assign alu_predec_bignum_o.shift_right           = alu_bignum_shift_right;
-  assign alu_predec_bignum_o.shift_amt             = alu_bignum_shift_amt;
-  assign alu_predec_bignum_o.shift_mod_sel         = alu_bignum_shift_mod_sel;
-  assign alu_predec_bignum_o.logic_a_en            = alu_bignum_logic_a_en;
-  assign alu_predec_bignum_o.logic_shifter_en      = alu_bignum_logic_shifter_en;
-  assign alu_predec_bignum_o.logic_res_sel         = alu_bignum_logic_res_sel;
-  assign alu_predec_bignum_o.flag_group_sel        = flag_group_sel;
-  assign alu_predec_bignum_o.flag_sel              = flag_sel;
-  assign alu_predec_bignum_o.flags_keep            = flags_keep;
-  assign alu_predec_bignum_o.flags_adder_update    = flags_adder_update;
-  assign alu_predec_bignum_o.flags_logic_update    = flags_logic_update;
-  assign alu_predec_bignum_o.flags_mac_update      = flags_mac_update;
-  assign alu_predec_bignum_o.flags_ispr_wr         = flags_ispr_wr;
+  assign alu_bignum_predec_o.adder_x_en            = alu_bignum_adder_x_en;
+  assign alu_bignum_predec_o.x_res_operand_a_sel   = alu_bignum_x_res_operand_a_sel;
+  assign alu_bignum_predec_o.adder_y_op_a_en       = alu_bignum_adder_y_op_a_en;
+  assign alu_bignum_predec_o.adder_y_op_shifter_en = alu_bignum_adder_y_op_shifter_en;
+  assign alu_bignum_predec_o.shifter_a_en          = alu_bignum_shifter_a_en;
+  assign alu_bignum_predec_o.shifter_b_en          = alu_bignum_shifter_b_en;
+  assign alu_bignum_predec_o.shift_right           = alu_bignum_shift_right;
+  assign alu_bignum_predec_o.shift_amt             = alu_bignum_shift_amt;
+  assign alu_bignum_predec_o.shift_mod_sel         = alu_bignum_shift_mod_sel;
+  assign alu_bignum_predec_o.logic_a_en            = alu_bignum_logic_a_en;
+  assign alu_bignum_predec_o.logic_shifter_en      = alu_bignum_logic_shifter_en;
+  assign alu_bignum_predec_o.logic_res_sel         = alu_bignum_logic_res_sel;
+  assign alu_bignum_predec_o.flag_group_sel        = flag_group_sel;
+  assign alu_bignum_predec_o.flag_sel              = flag_sel;
+  assign alu_bignum_predec_o.flags_keep            = flags_keep;
+  assign alu_bignum_predec_o.flags_adder_update    = flags_adder_update;
+  assign alu_bignum_predec_o.flags_logic_update    = flags_logic_update;
+  assign alu_bignum_predec_o.flags_mac_update      = flags_mac_update;
+  assign alu_bignum_predec_o.flags_ispr_wr         = flags_ispr_wr;
 
-  assign mac_predec_bignum_o.op_en     = mac_bignum_op_en;
-  assign mac_predec_bignum_o.acc_rd_en = mac_bignum_acc_rd_en;
+  assign mac_bignum_predec_o.op_en     = mac_bignum_op_en;
+  assign mac_bignum_predec_o.acc_rd_en = mac_bignum_acc_rd_en;
 
   assign insn_rs1 = imem_rdata_i[19:15];
   assign insn_rs2 = imem_rdata_i[24:20];
@@ -530,7 +530,7 @@ module otbn_predecode
   ) rf_ren_a_bignum_onehot_enc (
     .in_i  (insn_rs1),
     .en_i  (rf_ren_a_bignum),
-    .out_o (rf_predec_bignum_o.rf_ren_a)
+    .out_o (rf_bignum_predec_o.rf_ren_a)
   );
 
   prim_onehot_enc #(
@@ -538,7 +538,7 @@ module otbn_predecode
   ) rf_ren_b_bignum_onehot_enc (
     .in_i  (insn_rs2),
     .en_i  (rf_ren_b_bignum),
-    .out_o (rf_predec_bignum_o.rf_ren_b)
+    .out_o (rf_bignum_predec_o.rf_ren_b)
   );
 
   prim_onehot_enc #(
@@ -546,7 +546,7 @@ module otbn_predecode
   ) rf_we_bignum_onehot_enc (
     .in_i  (insn_rd),
     .en_i  (rf_we_bignum),
-    .out_o (rf_predec_bignum_o.rf_we)
+    .out_o (rf_bignum_predec_o.rf_we)
   );
 
   prim_onehot_enc #(
@@ -554,7 +554,7 @@ module otbn_predecode
   ) ispr_rd_en_onehot_enc (
     .in_i  (ispr_addr),
     .en_i  (ispr_rd_en),
-    .out_o (ispr_predec_bignum_o.ispr_rd_en)
+    .out_o (ispr_bignum_predec_o.ispr_rd_en)
   );
 
   prim_onehot_enc #(
@@ -562,7 +562,7 @@ module otbn_predecode
   ) ispr_wr_en_onehot_enc (
     .in_i  (ispr_addr),
     .en_i  (ispr_wr_en),
-    .out_o (ispr_predec_bignum_o.ispr_wr_en)
+    .out_o (ispr_bignum_predec_o.ispr_wr_en)
   );
 
   assign ctrl_flow_predec_o.call_stack_pop = (rf_ren_a_base & insn_rs1 == 5'd1) |
@@ -582,7 +582,7 @@ module otbn_predecode
   assign unused_clk = clk_i;
   assign unused_rst = rst_ni;
 
-  `ASSERT(RFRenABignumOnehot, $onehot0(rf_predec_bignum_o.rf_ren_a))
-  `ASSERT(RFRenBBignumOnehot, $onehot0(rf_predec_bignum_o.rf_ren_b))
-  `ASSERT(RFWeBignumOnehot,   $onehot0(rf_predec_bignum_o.rf_we))
+  `ASSERT(RFRenABignumOnehot, $onehot0(rf_bignum_predec_o.rf_ren_a))
+  `ASSERT(RFRenBBignumOnehot, $onehot0(rf_bignum_predec_o.rf_ren_b))
+  `ASSERT(RFWeBignumOnehot,   $onehot0(rf_bignum_predec_o.rf_we))
 endmodule

--- a/hw/ip/otbn/rtl/otbn_rf_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_bignum.sv
@@ -49,7 +49,7 @@ module otbn_rf_bignum
 
   output logic                   intg_err_o,
 
-  input  rf_predec_bignum_t      rf_predec_bignum_i,
+  input  rf_bignum_predec_t      rf_bignum_predec_i,
   output logic                   predec_error_o,
 
   output logic                   spurious_we_err_o
@@ -79,7 +79,7 @@ module otbn_rf_bignum
       .rd_addr_b_i,
       .rd_data_b_o(rd_data_b_intg_o),
 
-      .rf_predec_bignum_i,
+      .rf_bignum_predec_i,
 
       .we_err_o(spurious_we_err_o)
     );
@@ -129,9 +129,9 @@ module otbn_rf_bignum
   );
 
   // SEC_CM: CTRL.REDUN
-  assign rd_en_a_mismatch = expected_rd_en_a_onehot != rf_predec_bignum_i.rf_ren_a;
-  assign rd_en_b_mismatch = expected_rd_en_b_onehot != rf_predec_bignum_i.rf_ren_b;
-  assign wr_en_mismatch   = expected_wr_en_onehot   != rf_predec_bignum_i.rf_we;
+  assign rd_en_a_mismatch = expected_rd_en_a_onehot != rf_bignum_predec_i.rf_ren_a;
+  assign rd_en_b_mismatch = expected_rd_en_b_onehot != rf_bignum_predec_i.rf_ren_b;
+  assign wr_en_mismatch   = expected_wr_en_onehot   != rf_bignum_predec_i.rf_we;
 
   assign predec_error_o = rd_en_a_mismatch | rd_en_b_mismatch | wr_en_mismatch;
 

--- a/hw/ip/otbn/rtl/otbn_rf_bignum_ff.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_bignum_ff.sv
@@ -34,7 +34,7 @@ module otbn_rf_bignum_ff
   // Indicates whether a spurious WE has been seen in the last cycle.
   output logic               we_err_o,
 
-  input  rf_predec_bignum_t  rf_predec_bignum_i
+  input  rf_bignum_predec_t  rf_bignum_predec_i
 );
   logic [ExtWLEN-1:0] rf [NWdr];
   logic [1:0]         we_onehot [NWdr];
@@ -48,19 +48,19 @@ module otbn_rf_bignum_ff
     // SEC_CM: DATA_REG_SW.SCA
     prim_blanker #(.Width(ExtWLEN)) u_wdata_blanker(
       .in_i (wr_data_i),
-      .en_i (rf_predec_bignum_i.rf_we[i]),
+      .en_i (rf_bignum_predec_i.rf_we[i]),
       .out_o(wr_data_blanked)
     );
 
     // Split registers into halves for clear separation for the enable terms
     always_ff @(posedge clk_i) begin
-      if (rf_predec_bignum_i.rf_we[i] & we_onehot[i][0]) begin
+      if (rf_bignum_predec_i.rf_we[i] & we_onehot[i][0]) begin
         rf[i][0+:ExtWLEN/2] <= wr_data_blanked[0+:ExtWLEN/2];
       end
     end
 
     always_ff @(posedge clk_i) begin
-      if (rf_predec_bignum_i.rf_we[i] & we_onehot[i][1]) begin
+      if (rf_bignum_predec_i.rf_we[i] & we_onehot[i][1]) begin
         rf[i][ExtWLEN/2+:ExtWLEN/2] <= wr_data_blanked[ExtWLEN/2+:ExtWLEN/2];
       end
     end
@@ -76,7 +76,7 @@ module otbn_rf_bignum_ff
     .clk_i,
     .rst_ni,
     .in_i  (rf),
-    .sel_i (rf_predec_bignum_i.rf_ren_a),
+    .sel_i (rf_bignum_predec_i.rf_ren_a),
     .out_o (rd_data_a_o)
   );
 
@@ -87,7 +87,7 @@ module otbn_rf_bignum_ff
     .clk_i,
     .rst_ni,
     .in_i  (rf),
-    .sel_i (rf_predec_bignum_i.rf_ren_b),
+    .sel_i (rf_bignum_predec_i.rf_ren_b),
     .out_o (rd_data_b_o)
   );
 


### PR DESCRIPTION
This unifies the naming scheme of all predecoded signals and aligns the names with the non predecoded signals.

Previously, the naming was inconsistent and either `<component>_predec_bignum` or `<component>_bignum_predec`. Now it is `<component>_bignum_predec` which matches with `<component>_bignum_operation` signal naming as well as other signals like `<component>_predec_error`.

This relates to #4166