### PR TITLE
[pentes] Set pacing higher

### DIFF
--- a/sw/host/penetrationtests/python/util/targets.py
+++ b/sw/host/penetrationtests/python/util/targets.py
@@ -44,7 +44,7 @@ class Target:
     # Due to a bug in the UART of the CW340, we need to send each byte separately
     # and add a small timeout before sending the next one.
     # This contains the calculation of the delay.
-    pacing = 10 / baudrate
+    pacing = 20 / baudrate
 
     def __init__(self, target_cfg: TargetConfig):
         self.target_cfg = target_cfg


### PR DESCRIPTION
We found that the python_tests in earlgrey_1.0.0 were flaky causing json errors (no output). Bisecting through commits did not reveal a change causing the flaky result and testing reveals master is stable, but earlgrey_1.0.0 is not, and that all python_tests were flaky but not the rust tests.
After additional debugging, doubling the pacing value seems to clear this up.

Unsure why this was in eg100 but not in master, but I am copying the change in both branches.