### PR TITLE
[pentest] Add clobber list to ASM based trigger

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h
@@ -36,19 +36,19 @@ static const char PENTEST_VERSION[16] = "PENTEST: v1.0.3";
 // - Disassembled `dif_gpio_write(&gpio, kTriggerSwBitIndex, true)`
 // - 10 NOPS to give the trigger time to raise
 // Use with caution as the trigger pin index could change.
-#define PENTEST_ASM_TRIGGER_HIGH_IMPL \
-  asm volatile(NOP10);                \
-  asm volatile("lui a0, 0x1000;");    \
-  asm volatile("addi a0, a0, 256;");  \
-  asm volatile("lui a1, 0x40040;");   \
-  asm volatile("sw a0, 24(a1);");     \
+#define PENTEST_ASM_TRIGGER_HIGH_IMPL           \
+  asm volatile(NOP10);                          \
+  asm volatile("lui a0, 0x1000;" : : : "a0");   \
+  asm volatile("addi a0, a0, 256;" : : : "a0"); \
+  asm volatile("lui a1, 0x40040;" : : : "a1");  \
+  asm volatile("sw a0, 24(a1);");               \
   asm volatile(NOP10);
 
 #define PENTEST_ASM_TRIGGER_HIGH_IMPL_VERILATOR \
   asm volatile(NOP10);                          \
-  asm volatile("lui a0, 0x2000;");              \
-  asm volatile("addi a0, a0, 512;");            \
-  asm volatile("lui a1, 0x40040;");             \
+  asm volatile("lui a0, 0x2000;" : : : "a0");   \
+  asm volatile("addi a0, a0, 512;" : : : "a0"); \
+  asm volatile("lui a1, 0x40040;" : : : "a1");  \
   asm volatile("sw a0, 24(a1);");               \
   asm volatile(NOP10);
 
@@ -65,17 +65,17 @@ static const char PENTEST_VERSION[16] = "PENTEST: v1.0.3";
 // - Disassembled `dif_gpio_write(&gpio, kTriggerSwBitIndex, false)`
 // - 10 NOPS to give the trigger time to fall
 // Use with caution as the trigger pin index could change.
-#define PENTEST_ASM_TRIGGER_LOW_IMPL \
-  asm volatile(NOP10);               \
-  asm volatile("lui a0, 0x1000;");   \
-  asm volatile("lui a1, 0x40040;");  \
-  asm volatile("sw a0, 24(a1);");    \
+#define PENTEST_ASM_TRIGGER_LOW_IMPL           \
+  asm volatile(NOP10);                         \
+  asm volatile("lui a0, 0x1000;" : : : "a0");  \
+  asm volatile("lui a1, 0x40040;" : : : "a1"); \
+  asm volatile("sw a0, 24(a1);");              \
   asm volatile(NOP10);
 
 #define PENTEST_ASM_TRIGGER_LOW_IMPL_VERILATOR \
   asm volatile(NOP10);                         \
-  asm volatile("lui a0, 0x2000;");             \
-  asm volatile("lui a1, 0x40040;");            \
+  asm volatile("lui a0, 0x2000;" : : : "a0");  \
+  asm volatile("lui a1, 0x40040;" : : : "a1"); \
   asm volatile("sw a0, 24(a1);");              \
   asm volatile(NOP10);
 


### PR DESCRIPTION
For the pentests, we use an ASM based trigger to minimize to code overhead during the trigger window.

However, as this ASM snippets modify register contents, we should add the registers we are modifying to the clobber list. With this, we tell the compiler which of the registers we are modifying during the ASM trigger snippet.