### PR TITLE
[bazel] Allow manufactoring code to be used by downstream repos.

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -2,8 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@//rules:manuf.bzl", "device_id_header")
-load("@//rules:signing.bzl", "offline_presigning_artifacts", "offline_signature_attach")
+load("@lowrisc_opentitan//rules:manuf.bzl", "device_id_header")
+load("@lowrisc_opentitan//rules:signing.bzl", "offline_presigning_artifacts", "offline_signature_attach")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//rules:const.bzl", "CONST", "hex")
 load("//rules:manifest.bzl", "manifest")

--- a/sw/device/silicon_creator/rom/e2e/ate/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/ate/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@//rules:signing.bzl", "offline_presigning_artifacts", "offline_signature_attach")
+load("@lowrisc_opentitan//rules:signing.bzl", "offline_presigning_artifacts", "offline_signature_attach")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load(
     "//rules/opentitan:defs.bzl",


### PR DESCRIPTION
Use the module name '@lowrisc_opentitan' instead of '@' when referencing targets in the same workspace. This is the approach recommended by https://bazel.build/external/migration#specify-repo-name and allows manufactoring code (e.g. perso_tlv_data) to be used in downstream repos that use the opentitan repo as a submodule.

Change-Id: I30401894b71a230e3144f9ec564d42a170e3218e