### PR TITLE
Backport 26593 ([opentitanlib] Prepare detached signatures for ownership)

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -120,6 +120,7 @@ rust_library(
         "src/ownership/mod.rs",
         "src/ownership/owner.rs",
         "src/ownership/rescue.rs",
+        "src/ownership/signature.rs",
         "src/rescue/mod.rs",
         "src/rescue/serial.rs",
         "src/rescue/xmodem.rs",

--- a/sw/host/opentitanlib/src/crypto/ecdsa.rs
+++ b/sw/host/opentitanlib/src/crypto/ecdsa.rs
@@ -77,7 +77,7 @@ impl EcdsaPrivateKey {
     }
 }
 
-#[derive(Debug, Deserialize, Annotate)]
+#[derive(Debug, Clone, Deserialize, Annotate)]
 pub struct EcdsaRawSignature {
     #[serde(with = "serde_bytes")]
     #[annotate(format = hexstr)]
@@ -142,7 +142,7 @@ impl EcdsaRawSignature {
         }
     }
 
-    pub fn write(&self, dest: &mut impl Write) -> Result<()> {
+    pub fn write(&self, dest: &mut impl Write) -> Result<usize> {
         ensure!(
             self.r.len() == 32,
             Error::InvalidSignature(anyhow!("bad r length: {}", self.r.len()))
@@ -153,7 +153,7 @@ impl EcdsaRawSignature {
         );
         dest.write_all(&self.r)?;
         dest.write_all(&self.s)?;
-        Ok(())
+        Ok(64)
     }
 
     pub fn to_vec(&self) -> Result<Vec<u8>> {

--- a/sw/host/opentitanlib/src/crypto/spx.rs
+++ b/sw/host/opentitanlib/src/crypto/spx.rs
@@ -34,6 +34,13 @@ impl TryFrom<&sphincsplus::SpxPublicKey> for SpxRawPublicKey {
     }
 }
 
+impl TryFrom<sphincsplus::SpxPublicKey> for SpxRawPublicKey {
+    type Error = Error;
+    fn try_from(v: SpxPublicKey) -> Result<Self, Self::Error> {
+        (&v).try_into()
+    }
+}
+
 impl FromStr for SpxRawPublicKey {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/sw/host/opentitanlib/src/ownership/misc.rs
+++ b/sw/host/opentitanlib/src/ownership/misc.rs
@@ -24,6 +24,7 @@ with_unknown! {
         FlashConfig = u32::from_le_bytes(*b"FLSH"),
         FlashInfoConfig = u32::from_le_bytes(*b"INFO"),
         Rescue = u32::from_le_bytes(*b"RESQ"),
+        DetachedSignature = u32::from_le_bytes(*b"SIGN"),
         NotPresent = u32::from_le_bytes(*b"ZZZZ"),
     }
 
@@ -35,6 +36,34 @@ with_unknown! {
         SpxPrehash = u32::from_le_bytes(*b"S+S2"),
         HybridSpxPure = u32::from_le_bytes(*b"H+Pu"),
         HybridSpxPrehash = u32::from_le_bytes(*b"H+S2"),
+    }
+}
+
+impl OwnershipKeyAlg {
+    pub fn is_detached(self) -> bool {
+        !matches!(self, Self::EcdsaP256)
+    }
+
+    pub fn is_ecdsa(self) -> bool {
+        matches!(
+            self,
+            Self::EcdsaP256 | Self::HybridSpxPure | Self::HybridSpxPrehash
+        )
+    }
+
+    pub fn is_spx(self) -> bool {
+        matches!(
+            self,
+            Self::SpxPure | Self::SpxPrehash | Self::HybridSpxPure | Self::HybridSpxPrehash
+        )
+    }
+
+    pub fn is_hybrid(self) -> bool {
+        matches!(self, Self::HybridSpxPure | Self::HybridSpxPrehash)
+    }
+
+    pub fn is_prehashed(self) -> bool {
+        matches!(self, Self::SpxPrehash | Self::HybridSpxPrehash)
     }
 }
 

--- a/sw/host/opentitanlib/src/ownership/mod.rs
+++ b/sw/host/opentitanlib/src/ownership/mod.rs
@@ -10,13 +10,15 @@ mod flash_info;
 mod misc;
 pub mod owner;
 mod rescue;
+mod signature;
 
 pub use application_key::{ApplicationKeyDomain, OwnerApplicationKey};
 pub use flash::{FlashFlags, OwnerFlashConfig, OwnerFlashRegion};
 pub use flash_info::{OwnerFlashInfoConfig, OwnerInfoPage};
-pub use misc::{KeyMaterial, OwnershipKeyAlg, TlvHeader, TlvTag};
+pub use misc::{HybridRawPublicKey, KeyMaterial, OwnershipKeyAlg, TlvHeader, TlvTag};
 pub use owner::{OwnerBlock, OwnerConfigItem, SramExecMode};
 pub use rescue::{CommandTag, OwnerRescueConfig, RescueProtocol};
+pub use signature::DetachedSignature;
 
 pub struct GlobalFlags;
 

--- a/sw/host/opentitanlib/src/ownership/signature.rs
+++ b/sw/host/opentitanlib/src/ownership/signature.rs
@@ -1,0 +1,175 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Result, anyhow};
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use serde::Deserialize;
+use serde_annotate::Annotate;
+use sphincsplus::{SpxDomain, SpxSecretKey};
+use std::io::{Read, Write};
+
+use super::GlobalFlags;
+use super::misc::{OwnershipKeyAlg, TlvHeader, TlvTag};
+use crate::crypto::Error;
+use crate::crypto::ecdsa::{EcdsaPrivateKey, EcdsaRawSignature};
+use crate::crypto::sha256::Sha256Digest;
+
+#[derive(Debug, Deserialize, Annotate)]
+pub struct DetachedSignature {
+    #[serde(
+        skip_serializing_if = "GlobalFlags::not_debug",
+        default = "DetachedSignature::default_header"
+    )]
+    pub header: TlvHeader,
+    #[serde(default, skip_serializing_if = "GlobalFlags::not_debug")]
+    #[annotate(format=hex)]
+    pub reserved: [u32; 2],
+    #[serde(default)]
+    pub command: u32,
+    #[serde(default)]
+    pub algorithm: OwnershipKeyAlg,
+    #[serde(default)]
+    pub nonce: u64,
+    #[serde(default)]
+    pub ecdsa: Option<EcdsaRawSignature>,
+    #[serde(default)]
+    pub spx: Option<Vec<u8>>,
+}
+
+impl Default for DetachedSignature {
+    fn default() -> Self {
+        Self {
+            header: Self::default_header(),
+            reserved: [0, 0],
+            command: 0,
+            algorithm: OwnershipKeyAlg::Unknown,
+            nonce: 0,
+            ecdsa: None,
+            spx: None,
+        }
+    }
+}
+
+impl DetachedSignature {
+    const SIZE: usize = 8192;
+    const SPX_SIZE: usize = 7856;
+
+    fn default_header() -> TlvHeader {
+        TlvHeader::new(TlvTag::DetachedSignature, 0, "0.0")
+    }
+
+    pub fn read(src: &mut impl Read, header: TlvHeader) -> Result<Self> {
+        let mut reserved = [0u32; 2];
+        src.read_u32_into::<LittleEndian>(&mut reserved)?;
+        let command = src.read_u32::<LittleEndian>()?;
+        let algorithm = OwnershipKeyAlg(src.read_u32::<LittleEndian>()?);
+        let nonce = src.read_u64::<LittleEndian>()?;
+        let ecdsa = if algorithm.is_ecdsa() {
+            Some(EcdsaRawSignature::read(src)?)
+        } else {
+            None
+        };
+        let spx = if algorithm.is_spx() {
+            let mut spx = vec![0u8; Self::SPX_SIZE];
+            src.read_exact(&mut spx)?;
+            Some(spx)
+        } else {
+            None
+        };
+        Ok(Self {
+            header,
+            reserved,
+            command,
+            algorithm,
+            nonce,
+            ecdsa,
+            spx,
+        })
+    }
+
+    pub fn write(&self, dest: &mut impl Write) -> Result<()> {
+        let header = TlvHeader::new(TlvTag::DetachedSignature, Self::SIZE, "0.0");
+        header.write(dest)?;
+        for x in &self.reserved {
+            dest.write_u32::<LittleEndian>(*x)?;
+        }
+        dest.write_u32::<LittleEndian>(self.command)?;
+        dest.write_u32::<LittleEndian>(u32::from(self.algorithm))?;
+        dest.write_u64::<LittleEndian>(self.nonce)?;
+        let mut len = 32;
+        if self.algorithm.is_ecdsa() {
+            let ecdsa = self.ecdsa.as_ref().ok_or_else(|| {
+                Error::InvalidSignature(anyhow!(
+                    "Algorithm {} requires an ECDSA signature",
+                    self.algorithm
+                ))
+            })?;
+            len += ecdsa.write(dest)?;
+        }
+        if self.algorithm.is_spx() {
+            let spx = self.spx.as_ref().ok_or_else(|| {
+                Error::InvalidSignature(anyhow!(
+                    "Algorithm {} requires an SPX signature",
+                    self.algorithm
+                ))
+            })?;
+            dest.write_all(spx.as_slice())?;
+            len += spx.len();
+        }
+
+        let pad = vec![0xffu8; Self::SIZE - len];
+        dest.write_all(&pad)?;
+        Ok(())
+    }
+
+    pub fn to_vec(&self) -> Result<Vec<u8>> {
+        let mut result = Vec::new();
+        self.write(&mut result)?;
+        Ok(result)
+    }
+
+    pub fn new(
+        data: &[u8],
+        command: u32,
+        algorithm: OwnershipKeyAlg,
+        nonce: u64,
+        ecdsa_key: Option<&EcdsaPrivateKey>,
+        spx_key: Option<&SpxSecretKey>,
+    ) -> Result<Self> {
+        let digest = Sha256Digest::hash(data);
+        let ecdsa = if algorithm.is_ecdsa() {
+            let key = ecdsa_key.ok_or_else(|| {
+                Error::SignFailed(anyhow!("Algorithm {algorithm} requires an ECDSA key"))
+            })?;
+            Some(key.sign(&digest)?)
+        } else {
+            None
+        };
+        let spx = if algorithm.is_spx() {
+            let key = spx_key.ok_or_else(|| {
+                Error::SignFailed(anyhow!("Algorithm {algorithm} requires an SPX key"))
+            })?;
+            let (domain, msg) = if algorithm.is_prehashed() {
+                let domain = SpxDomain::PreHashedSha256;
+                (domain, digest.as_ref())
+            } else {
+                let domain = SpxDomain::Pure;
+                (domain, data)
+            };
+            Some(key.sign(domain, msg)?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            header: Self::default_header(),
+            command,
+            algorithm,
+            nonce,
+            ecdsa,
+            spx,
+            ..Default::default()
+        })
+    }
+}

--- a/sw/host/opentitantool/src/command/ownership.rs
+++ b/sw/host/opentitantool/src/command/ownership.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use anyhow::{Result, anyhow, ensure};
 use clap::{Args, Subcommand, ValueEnum};
 use std::any::Any;
 use std::fs::{File, OpenOptions};
@@ -104,6 +104,8 @@ impl CommandDispatch for OwnershipConfigCommand {
 pub struct OwnershipUnlockCommand {
     #[command(flatten)]
     params: OwnershipUnlockParams,
+    #[arg(short, long, help = "Filename to write the detached signature")]
+    detached: Option<PathBuf>,
     #[arg(short, long, help = "A file containing a binary unlock request")]
     input: Option<PathBuf>,
     #[arg(
@@ -119,7 +121,7 @@ impl CommandDispatch for OwnershipUnlockCommand {
         _context: &dyn Any,
         _transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
-        let unlock = self
+        let (unlock, signature) = self
             .params
             .apply_to(self.input.as_ref().map(File::open).transpose()?.as_mut())?;
         if let Some(output) = &self.output {
@@ -128,8 +130,30 @@ impl CommandDispatch for OwnershipUnlockCommand {
                 .create(true)
                 .truncate(true)
                 .open(output)?;
+
             unlock.write(&mut f)?;
         }
+        if self.params.algorithm.is_detached() && signature.is_some() && self.detached.is_none() {
+            log::warn!(
+                "The algorithm {} requires a detached signature, but no detach signature file was specified.",
+                self.params.algorithm
+            );
+        }
+        if let Some(detached) = &self.detached {
+            ensure!(
+                signature.is_some(),
+                anyhow!(
+                    "Requested to save the detached signature, but there is no detached signature."
+                )
+            );
+            let mut f = OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(detached)?;
+            signature.unwrap().write(&mut f)?;
+        }
+
         Ok(Some(Box::new(unlock)))
     }
 }
@@ -138,6 +162,8 @@ impl CommandDispatch for OwnershipUnlockCommand {
 pub struct OwnershipActivateCommand {
     #[command(flatten)]
     params: OwnershipActivateParams,
+    #[arg(short, long, help = "Filename to write the detached signature")]
+    detached: Option<PathBuf>,
     #[arg(short, long, help = "A file containing a binary unlock request")]
     input: Option<PathBuf>,
     #[arg(
@@ -153,7 +179,7 @@ impl CommandDispatch for OwnershipActivateCommand {
         _context: &dyn Any,
         _transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
-        let activate = self
+        let (activate, signature) = self
             .params
             .apply_to(self.input.as_ref().map(File::open).transpose()?.as_mut())?;
         if let Some(output) = &self.output {
@@ -163,6 +189,26 @@ impl CommandDispatch for OwnershipActivateCommand {
                 .truncate(true)
                 .open(output)?;
             activate.write(&mut f)?;
+        }
+        if self.params.algorithm.is_detached() && signature.is_some() && self.detached.is_none() {
+            log::warn!(
+                "The algorithm {} requires a detached signature, but no detach signature file was specified.",
+                self.params.algorithm
+            );
+        }
+        if let Some(detached) = &self.detached {
+            ensure!(
+                signature.is_some(),
+                anyhow!(
+                    "Requested to save the detached signature, but there is no detached signature."
+                )
+            );
+            let mut f = OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(detached)?;
+            signature.unwrap().write(&mut f)?;
         }
         Ok(Some(Box::new(activate)))
     }

--- a/sw/host/opentitantool/src/command/rescue.rs
+++ b/sw/host/opentitantool/src/command/rescue.rs
@@ -294,10 +294,16 @@ impl CommandDispatch for OwnershipUnlock {
         context: &dyn Any,
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
-        let unlock = self
+        let (unlock, signature) = self
             .unlock
             .apply_to(self.input.as_ref().map(File::open).transpose()?.as_mut())?;
 
+        if self.unlock.algorithm.is_detached() && signature.is_some() {
+            log::warn!(
+                "The algorithm {} requires a detached signature, but rescue cannot deliver the detached signature as part of boot services.",
+                self.unlock.algorithm
+            );
+        }
         let context = context.downcast_ref::<RescueCommand>().unwrap();
         let rescue = context.params.create(transport)?;
         rescue.enter(transport, self.reset_target)?;
@@ -341,10 +347,16 @@ impl CommandDispatch for OwnershipActivate {
         context: &dyn Any,
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
-        let activate = self
+        let (activate, signature) = self
             .activate
             .apply_to(self.input.as_ref().map(File::open).transpose()?.as_mut())?;
 
+        if self.activate.algorithm.is_detached() && signature.is_some() {
+            log::warn!(
+                "The algorithm {} requires a detached signature, but rescue cannot deliver the detached signature as part of boot services.",
+                self.activate.algorithm
+            );
+        }
         let context = context.downcast_ref::<RescueCommand>().unwrap();
         let rescue = context.params.create(transport)?;
         rescue.enter(transport, self.reset_target)?;

--- a/sw/host/tests/ownership/transfer_lib.rs
+++ b/sw/host/tests/ownership/transfer_lib.rs
@@ -42,12 +42,13 @@ pub fn ownership_unlock(
     unlock_key: &Path,
     next_owner: Option<&Path>,
 ) -> Result<()> {
-    let unlock = OwnershipUnlockParams {
+    let (unlock, _) = OwnershipUnlockParams {
         mode: Some(mode),
         nonce: Some(nonce),
         din: Some(din),
         next_owner: next_owner.map(|p| p.into()),
-        sign: Some(unlock_key.into()),
+        algorithm: OwnershipKeyAlg::EcdsaP256,
+        ecdsa_key: Some(unlock_key.into()),
         ..Default::default()
     }
     .apply_to(Option::<&mut std::fs::File>::None)?;
@@ -89,10 +90,11 @@ pub fn ownership_activate(
     din: u64,
     activate_key: &Path,
 ) -> Result<()> {
-    let activate = OwnershipActivateParams {
+    let (activate, _) = OwnershipActivateParams {
         nonce: Some(nonce),
         din: Some(din),
-        sign: Some(activate_key.into()),
+        algorithm: OwnershipKeyAlg::EcdsaP256,
+        ecdsa_key: Some(activate_key.into()),
         ..Default::default()
     }
     .apply_to(Option::<&mut std::fs::File>::None)?;


### PR DESCRIPTION
Backport #26593. Depends on https://github.com/lowRISC/opentitan/pull/29004, only review the last commit