### PR TITLE
[otbn,fpv] Get the OTBN SecCm FPV tests working properly

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -1222,7 +1222,7 @@ module otbn
 
   // Asserts ===================================================================
   for (genvar i = 0; i < LoopStackDepth; ++i) begin : gen_loop_stack_cntr_asserts
-    `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(
+    `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT_IN(
       LoopStackCntAlertCheck_A,
       u_otbn_core.u_otbn_controller.u_otbn_loop_controller.g_loop_counters[i].u_loop_count,
       alert_tx_o[AlertFatal]
@@ -1414,47 +1414,80 @@ module otbn
   // Constraint from package, check here as we cannot have `ASSERT_INIT in package
   `ASSERT_INIT(WsrESizeMatchesParameter_A, $bits(wsr_e) == WsrNumWidth)
 
-  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(OtbnStartStopFsmCheck_A,
-    u_otbn_core.u_otbn_start_stop_control.u_state_regs, alert_tx_o[AlertFatal])
-  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(OtbnControllerFsmCheck_A,
-    u_otbn_core.u_otbn_controller.u_state_regs, alert_tx_o[AlertFatal])
-  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(OtbnScrambleCtrlFsmCheck_A,
-    u_otbn_scramble_ctrl.u_state_regs, alert_tx_o[AlertFatal])
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT_IN(
+    OtbnStartStopFsmCheck_A,
+    u_otbn_core.u_otbn_start_stop_control.u_state_regs,
+    gen_alert_tx[AlertFatalIdx].u_prim_alert_sender.alert_req_i
+  )
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT_IN(
+    OtbnControllerFsmCheck_A,
+    u_otbn_core.u_otbn_controller.u_state_regs,
+    gen_alert_tx[AlertFatalIdx].u_prim_alert_sender.alert_req_i
+  )
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT_IN(
+    OtbnScrambleCtrlFsmCheck_A,
+    u_otbn_scramble_ctrl.u_state_regs,
+    gen_alert_tx[AlertFatalIdx].u_prim_alert_sender.alert_req_i
+  )
 
-  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(OtbnCallStackWrPtrAlertCheck_A,
-    u_otbn_core.u_otbn_rf_base.u_call_stack.u_stack_wr_ptr, alert_tx_o[AlertFatal])
-  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(OtbnLoopInfoStackWrPtrAlertCheck_A,
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT_IN(
+    OtbnCallStackWrPtrAlertCheck_A,
+    u_otbn_core.u_otbn_rf_base.u_call_stack.u_stack_wr_ptr,
+    gen_alert_tx[AlertFatalIdx].u_prim_alert_sender.alert_req_i
+  )
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT_IN(
+    OtbnLoopInfoStackWrPtrAlertCheck_A,
     u_otbn_core.u_otbn_controller.u_otbn_loop_controller.loop_info_stack.u_stack_wr_ptr,
-    alert_tx_o[AlertFatal])
+    gen_alert_tx[AlertFatalIdx].u_prim_alert_sender.alert_req_i
+  )
 
   // Alert assertions for reg_we onehot check
-  `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A,
-      u_reg, alert_tx_o[AlertFatal])
+  `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT_IN(
+    RegWeOnehotCheck_A,
+    u_reg,
+    gen_alert_tx[AlertFatalIdx].u_prim_alert_sender.alert_req_i
+  )
   // other onehot checks
-  `ASSERT_PRIM_ONEHOT_ERROR_TRIGGER_ALERT(RfBaseOnehotCheck_A,
-      u_otbn_core.u_otbn_rf_base.gen_rf_base_ff.u_otbn_rf_base_inner.u_prim_onehot_check,
-      alert_tx_o[AlertFatal])
-  `ASSERT_PRIM_ONEHOT_ERROR_TRIGGER_ALERT(RfBignumOnehotCheck_A,
-      u_otbn_core.u_otbn_rf_bignum.gen_rf_bignum_ff.u_otbn_rf_bignum_inner.u_prim_onehot_check,
-      alert_tx_o[AlertFatal])
+  `ASSERT_PRIM_ONEHOT_ERROR_TRIGGER_ALERT_IN(
+    RfBaseOnehotCheck_A,
+    u_otbn_core.u_otbn_rf_base.gen_rf_base_ff.u_otbn_rf_base_inner.u_prim_onehot_check,
+    gen_alert_tx[AlertFatalIdx].u_prim_alert_sender.alert_req_i
+  )
+  `ASSERT_PRIM_ONEHOT_ERROR_TRIGGER_ALERT_IN(
+    RfBignumOnehotCheck_A,
+    u_otbn_core.u_otbn_rf_bignum.gen_rf_bignum_ff.u_otbn_rf_bignum_inner.u_prim_onehot_check,
+    gen_alert_tx[AlertFatalIdx].u_prim_alert_sender.alert_req_i
+  )
 
-  `ASSERT_PRIM_FIFO_SYNC_ERROR_TRIGGERS_ALERT1(DmemRspFifo,
-                                               u_tlul_adapter_sram_dmem.u_rspfifo,
-                                               alert_tx_o[AlertFatal])
-  `ASSERT_PRIM_FIFO_SYNC_ERROR_TRIGGERS_ALERT1(DmemSramReqFifo,
-                                               u_tlul_adapter_sram_dmem.u_sramreqfifo,
-                                               alert_tx_o[AlertFatal])
-  `ASSERT_PRIM_FIFO_SYNC_ERROR_TRIGGERS_ALERT1(DmemReqFifo,
-                                               u_tlul_adapter_sram_dmem.u_reqfifo,
-                                               alert_tx_o[AlertFatal])
+  `ASSERT_PRIM_FIFO_SYNC_ERROR_TRIGGERS_ALERT1_IN(
+    DmemRspFifo,
+    u_tlul_adapter_sram_dmem.u_rspfifo,
+    gen_alert_tx[AlertFatalIdx].u_prim_alert_sender.alert_req_i
+  )
+  `ASSERT_PRIM_FIFO_SYNC_ERROR_TRIGGERS_ALERT1_IN(
+    DmemSramReqFifo,
+    u_tlul_adapter_sram_dmem.u_sramreqfifo,
+    gen_alert_tx[AlertFatalIdx].u_prim_alert_sender.alert_req_i
+  )
+  `ASSERT_PRIM_FIFO_SYNC_ERROR_TRIGGERS_ALERT1_IN(
+    DmemReqFifo,
+    u_tlul_adapter_sram_dmem.u_reqfifo,
+    gen_alert_tx[AlertFatalIdx].u_prim_alert_sender.alert_req_i
+  )
 
-  `ASSERT_PRIM_FIFO_SYNC_ERROR_TRIGGERS_ALERT1(ImemRspFifo,
-                                               u_tlul_adapter_sram_imem.u_rspfifo,
-                                               alert_tx_o[AlertFatal])
-  `ASSERT_PRIM_FIFO_SYNC_ERROR_TRIGGERS_ALERT1(ImemSramReqFifo,
-                                               u_tlul_adapter_sram_imem.u_sramreqfifo,
-                                               alert_tx_o[AlertFatal])
-  `ASSERT_PRIM_FIFO_SYNC_ERROR_TRIGGERS_ALERT1(ImemReqFifo,
-                                               u_tlul_adapter_sram_imem.u_reqfifo,
-                                               alert_tx_o[AlertFatal])
+  `ASSERT_PRIM_FIFO_SYNC_ERROR_TRIGGERS_ALERT1_IN(
+    ImemRspFifo,
+    u_tlul_adapter_sram_imem.u_rspfifo,
+    gen_alert_tx[AlertFatalIdx].u_prim_alert_sender.alert_req_i
+  )
+  `ASSERT_PRIM_FIFO_SYNC_ERROR_TRIGGERS_ALERT1_IN(
+    ImemSramReqFifo,
+    u_tlul_adapter_sram_imem.u_sramreqfifo,
+    gen_alert_tx[AlertFatalIdx].u_prim_alert_sender.alert_req_i
+  )
+  `ASSERT_PRIM_FIFO_SYNC_ERROR_TRIGGERS_ALERT1_IN(
+    ImemReqFifo,
+    u_tlul_adapter_sram_imem.u_reqfifo,
+    gen_alert_tx[AlertFatalIdx].u_prim_alert_sender.alert_req_i
+  )
 endmodule

--- a/hw/ip/prim/rtl/prim_fifo_assert.svh
+++ b/hw/ip/prim/rtl/prim_fifo_assert.svh
@@ -44,4 +44,15 @@
                               MAX_CYCLES_,                                                                                 \
                               err_o)
 
+// A version of ASSERT_PRIM_FIFO_SYNC_ERROR_TRIGGERS_ALERT1, except that it uses
+// ASSERT_ERROR_TRIGGER_ALERT_IN instead of ASSERT_ERROR_TRIGGER_ALERT. See description in
+// prim_assert_se_cm.svh.
+`define ASSERT_PRIM_FIFO_SYNC_ERROR_TRIGGERS_ALERT1_IN(NAME_, HIER_, ALERT_, GATE_ = 0, MAX_CYCLES_ = 2) \
+  `ASSERT_ERROR_TRIGGER_ALERT_IN(``NAME_``FullCheck_A,                                                   \
+                                 HIER_,                                                                  \
+                                 ALERT_,                                                                 \
+                                 GATE_,                                                                  \
+                                 MAX_CYCLES_,                                                            \
+                                 err_o)
+
 `endif // PRIM_FIFO_ASSERT_SVH

--- a/hw/top_earlgrey/formal/after_load_tcl/otbn.tcl
+++ b/hw/top_earlgrey/formal/after_load_tcl/otbn.tcl
@@ -1,0 +1,39 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# This is used as an "after_load" file for the otbn_sec_cm job
+
+proc move_to_task {task_name assert_name} {
+    task -edit ${task_name} -copy "${assert_name}*"
+    assert -disable ${assert_name}
+}
+
+# There are various request and response FIFOs in the design and there are top-level checks (in
+# otbn.sv) that make sure that if any of those FIFOs reports an error then an alert comes out.
+#
+# These errors are generated if the counter in the FIFO gets corrupted. Normally, this is made
+# possible by black-boxing the contents of prim_count (which gets done in fpv.tcl if the TASK
+# environment variable is FpvSecCm). Unfortunately, that doesn't work if you have a one-entry FIFO.
+#
+# Rather than trying to black-box the (rather trivial) body of the counter in this case, use a
+# stopat on the err_o signals.
+#
+# Call the task "pre0", which means that fpv.tcl will try to prove it, before just proving the
+# FpvSecCm task that it would do otherwise.
+task -create pre0
+stopat -task pre0 "u_tlul_adapter_sram_dmem.u_rspfifo.err_o"
+move_to_task pre0 "otbn.FpvSecCmDmemRspFifoFullCheck_A"
+stopat -task pre0 "u_tlul_adapter_sram_dmem.u_sramreqfifo"
+move_to_task pre0 "otbn.FpvSecCmDmemSramReqFifoFullCheck_A"
+stopat -task pre0 "u_tlul_adapter_sram_dmem.u_reqfifo"
+move_to_task pre0 "otbn.FpvSecCmDmemReqFifoFullCheck_A"
+stopat -task pre0 "u_tlul_adapter_sram_imem.u_rspfifo.err_o"
+move_to_task pre0 "otbn.FpvSecCmImemRspFifoFullCheck_A"
+stopat -task pre0 "u_tlul_adapter_sram_imem.u_sramreqfifo"
+move_to_task pre0 "otbn.FpvSecCmImemSramReqFifoFullCheck_A"
+stopat -task pre0 "u_tlul_adapter_sram_imem.u_reqfifo"
+move_to_task pre0 "otbn.FpvSecCmImemReqFifoFullCheck_A"
+
+# Make the runner try to prove these assertions too
+set pre_phases 1

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_sec_cm_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_sec_cm_cfgs.hjson
@@ -141,6 +141,7 @@
                rel_path: "hw/ip/otbn/{sub_flow}/{tool}"
                stopats: ["*u_state_regs.state_o"]
                task: "FpvSecCm"
+               after_load: ["{proj_root}/hw/top_earlgrey/formal/after_load_tcl/otbn.tcl"]
              }
              {
                name: pwrmgr_sec_cm


### PR DESCRIPTION
The use of `ASSERT_*_TRIGGER_ALERT` means that they were never really doing anything sensible (but were presumably burning lots of energy!) Since we prove correctness of the alert system separately, we can make this all prove in a minute or two using the "_IN" variants.

The tweak I made to `prim_fifo_sync` when depth=1 stopped the hack that this FPV test previously used from working. Rather than figure out something to black-box, let's just use a stopat and put those assertions into a separate task.

I'd love to say that this now works... Unfortunately, `FpvSecCmRBignumOnehotCheck_A` sees a counterexample. That's because the assertion is just false: the bignum write-enable failure can be squashed for a cycle by a reported SW error and the stopats in use then make a counterexample possible.

Tidying that up properly will be quite a bit of work, which I'll do in a follow-up PR.
