### PR TITLE
Fix OT_DISABLE_HARDENING -Werror,-Wundef error

### DIFF
--- a/sw/device/lib/base/hardened.h
+++ b/sw/device/lib/base/hardened.h
@@ -241,7 +241,8 @@ inline uint32_t launder32(uint32_t val) {
 
   // When we're building for static analysis, reduce false positives by
   // short-circuiting the inline assembly block.
-#if OT_BUILD_FOR_STATIC_ANALYZER || OT_DISABLE_HARDENING
+#if OT_BUILD_FOR_STATIC_ANALYZER || \
+    (defined(OT_DISABLE_HARDENING) && OT_DISABLE_HARDENING)
   return val;
 #endif
 
@@ -263,7 +264,8 @@ inline uint32_t launder32(uint32_t val) {
  */
 OT_WARN_UNUSED_RESULT
 inline uintptr_t launderw(uintptr_t val) {
-#if OT_BUILD_FOR_STATIC_ANALYZER || OT_DISABLE_HARDENING
+#if OT_BUILD_FOR_STATIC_ANALYZER || \
+    (defined(OT_DISABLE_HARDENING) && OT_DISABLE_HARDENING)
   return val;
 #endif
   asm volatile("" : "+r"(val));


### PR DESCRIPTION
In file included from lib/crypto/crypto_ipc.c:10:
In file included from external/lowrisc_opentitan+/sw/device/lib/crypto/include/ecc_p256.h:8: In file included from external/lowrisc_opentitan+/sw/device/lib/crypto/include/datatypes.h:12: external/lowrisc_opentitan+/sw/device/lib/base/hardened.h:244:37: error: 'OT_DISABLE_HARDENING' is not defined, evaluates to 0 [-Werror,-Wundef]

This change was already applied in the past but was reverted by https://github.com/lowRISC/opentitan/pull/28625.

(cherry picked from commit 0dfcda19ca8ba516febbf263407e58d3e89a37bf)