### PR TITLE
[bazel] Increase timeout for `ecdsa_to_pq` QEMU test

### DIFF
--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -976,6 +976,7 @@ ownership_transfer_test(
     name = "transfer_ecdsa_to_pq_test",
     ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0"},
     fpga = {"changes_otp": True},
+    qemu = {"timeout": "long"},
     shared_params = {
         "binaries": {
             ":boot_test": "boot_test",


### PR DESCRIPTION
This test takes a little over 60 seconds in QEMU but passes when given longer. We don't need to increase the timeout for FPGA or silicon.