### PR TITLE
Backport 26817 ([silicon_creator,hmac] add HMAC-SHA256 driver function)

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/hmac.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac.c
@@ -19,7 +19,7 @@ static inline uint32_t hmac_base(void) {
   return dt_hmac_primary_reg_block(kHmacDt);
 }
 
-void hmac_sha256_configure(bool big_endian_digest) {
+static void hmac_configure(bool big_endian_digest, bool hmac_mode) {
   // Clear the config, stopping the SHA engine.
   abs_mmio_write32(hmac_base() + HMAC_CFG_REG_OFFSET, 0u);
 
@@ -31,13 +31,25 @@ void hmac_sha256_configure(bool big_endian_digest) {
   reg = bitfield_bit32_write(reg, HMAC_CFG_DIGEST_SWAP_BIT, big_endian_digest);
   reg = bitfield_bit32_write(reg, HMAC_CFG_ENDIAN_SWAP_BIT, false);
   reg = bitfield_bit32_write(reg, HMAC_CFG_SHA_EN_BIT, true);
-  reg = bitfield_bit32_write(reg, HMAC_CFG_HMAC_EN_BIT, false);
+  reg = bitfield_bit32_write(reg, HMAC_CFG_HMAC_EN_BIT, hmac_mode);
   // configure to run SHA-2 256 with 256-bit key
   reg = bitfield_field32_write(reg, HMAC_CFG_DIGEST_SIZE_FIELD,
                                HMAC_CFG_DIGEST_SIZE_VALUE_SHA2_256);
   reg = bitfield_field32_write(reg, HMAC_CFG_KEY_LENGTH_FIELD,
                                HMAC_CFG_KEY_LENGTH_VALUE_KEY_256);
   abs_mmio_write32(hmac_base() + HMAC_CFG_REG_OFFSET, reg);
+}
+
+void sc_hmac_hmac_sha256_configure(bool big_endian_digest, hmac_key_t key) {
+  hmac_configure(big_endian_digest, /*hmac_mode=*/true);
+  for (size_t i = 0; i < kHmacKeyNumWords; ++i) {
+    abs_mmio_write32(hmac_base() + HMAC_KEY_0_REG_OFFSET + i * sizeof(uint32_t),
+                     key.key[i]);
+  }
+}
+
+void hmac_sha256_configure(bool big_endian_digest) {
+  hmac_configure(big_endian_digest, /*hmac_mode=*/false);
 }
 
 inline void hmac_sha256_start(void) {
@@ -122,6 +134,14 @@ void hmac_sha256(const void *data, size_t len, hmac_digest_t *digest) {
   hmac_sha256_final(digest);
 }
 
+void sc_hmac_hmac_sha256(const void *data, size_t len, hmac_key_t key,
+                         bool big_endian_digest, hmac_digest_t *digest) {
+  sc_hmac_hmac_sha256_init(key, big_endian_digest);
+  hmac_sha256_update(data, len);
+  hmac_sha256_process();
+  hmac_sha256_final(digest);
+}
+
 void hmac_sha256_save(hmac_context_t *ctx) {
   // Issue the STOP command to halt the operation and compute the intermediate
   // digest.
@@ -183,5 +203,6 @@ void hmac_sha256_restore(const hmac_context_t *ctx) {
   abs_mmio_write32(hmac_base() + HMAC_CMD_REG_OFFSET, cmd);
 }
 
+extern void sc_hmac_hmac_sha256_init(hmac_key_t key, bool big_endian_digest);
 extern void hmac_sha256_init(void);
 extern void hmac_sha256_final(hmac_digest_t *digest);

--- a/sw/device/silicon_creator/lib/drivers/hmac_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac_functest.c
@@ -56,7 +56,7 @@ static const uint32_t kGettysburgDigest[] = {
 static const char kGettysburgDigestBigEndian[] =
     "1e6fd4030f9034cd775708a396c324ed420ec587eb3dd433e29f6ac08b8cc7ba";
 
-rom_error_t hmac_test(void) {
+rom_error_t hmac_sha256_test(void) {
   hmac_digest_t digest;
   hmac_sha256(kGettysburgPrelude, sizeof(kGettysburgPrelude) - 1, &digest);
 
@@ -64,6 +64,39 @@ rom_error_t hmac_test(void) {
   for (int i = 0; i < len; ++i) {
     LOG_INFO("word %d = 0x%08x", i, digest.digest[i]);
     if (digest.digest[i] != kGettysburgDigest[i]) {
+      return kErrorUnknown;
+    }
+  }
+  return kErrorOk;
+}
+
+static const hmac_key_t kHmacKey = {.key = {0x11112222, 0x33334444, 0x55556666,
+                                            0x77778888, 0x9999aaaa, 0xbbbbcccc,
+                                            0xddddeeee, 0xffff0000}};
+
+// The following shell command will produce the HMAC-SHA256 digest, and convert
+// it into valid C hexadecimal constants:
+//
+// $ echo -n "Four score and seven years ago our fathers brought forth on this
+// continent, a new nation, conceived in Liberty, and dedicated to the
+// proposition that all men are created equal." | openssl dgst \
+//     -sha256 -mac HMAC -macopt \
+//     hexkey:111122223333444455556666777788889999aaaabbbbccccddddeeeeffff0000 \
+//     | cut -f2 -d' ' | sed -e "s/......../0x&,\n/g" | tac
+static const uint32_t kGettysburgHmacSha256Digest[] = {
+    0xa63131bc, 0xeb1cb98b, 0xa0888a13, 0x497f2087,
+    0xb54e0af5, 0x9d85e15b, 0xa9a3bafe, 0x9d115197,
+};
+
+rom_error_t hmac_hmac_sha256_test(void) {
+  hmac_digest_t digest;
+  sc_hmac_hmac_sha256(kGettysburgPrelude, sizeof(kGettysburgPrelude) - 1,
+                      kHmacKey,
+                      /*big_endian_digest=*/false, &digest);
+  const size_t len = ARRAYSIZE(digest.digest);
+  for (int i = 0; i < len; ++i) {
+    LOG_INFO("word %d = 0x%08x", i, digest.digest[i]);
+    if (digest.digest[i] != kGettysburgHmacSha256Digest[i]) {
       return kErrorUnknown;
     }
   }
@@ -258,7 +291,8 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t result = OK_STATUS();
-  EXECUTE_TEST(result, hmac_test);
+  EXECUTE_TEST(result, hmac_sha256_test);
+  EXECUTE_TEST(result, hmac_hmac_sha256_test);
   EXECUTE_TEST(result, hmac_process_nowait_test);
   EXECUTE_TEST(result, hmac_process_wait_test);
   EXECUTE_TEST(result, hmac_truncated_test);


### PR DESCRIPTION
Backport #26817. To avoid a name conflict, I renamed `hmac_hmac_sha256_configure` to `sc_hmac_hmac_sha256_configure`, and similarly `hmac_hmac_sha256` and `hmac_hmac_sha256_init` in the PR.