### PR TITLE
Backport 26886 ([perso] add GPIO test start / done ATE indicators)

### DIFF
--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -62,7 +62,8 @@
 
 OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
                         .console.base_addr = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR,
-                        .console.test_may_clobber = false);
+                        .console.test_may_clobber = false,
+                        .silence_console_prints = true);
 
 enum {
   /**


### PR DESCRIPTION
Backport #26886. Depends on #29066. Review last 2 commits.