### PR TITLE
[cryptolib] Move second `integrity_blinded_key_check` after the key a…

### DIFF
--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -50,8 +50,6 @@ static status_t aes_key_construct(otcrypto_blinded_key_t *blinded_key,
   if (integrity_blinded_key_check(blinded_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(integrity_blinded_key_check(blinded_key)),
-                    kHardenedBoolTrue);
 
   if (blinded_key->config.hw_backed == kHardenedBoolTrue) {
     // Call keymgr to sideload the key into AES.
@@ -130,6 +128,12 @@ static status_t aes_key_construct(otcrypto_blinded_key_t *blinded_key,
     // Create the checksum of the key and store it in the key structure.
     aes_key->checksum = aes_key_integrity_checksum(aes_key);
   }
+
+  // Second integrity check of the key we got passed into the cryptolib.
+  // This check is placed here to catch any corruptions that might have
+  // happen after the first check when assembling the `aes_key`.
+  HARDENED_CHECK_EQ(launder32(integrity_blinded_key_check(blinded_key)),
+                    kHardenedBoolTrue);
 
   return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/impl/aes_gcm.c
+++ b/sw/device/lib/crypto/impl/aes_gcm.c
@@ -118,8 +118,6 @@ static status_t aes_gcm_key_construct(otcrypto_blinded_key_t *blinded_key,
       kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(blinded_key),
-                    kHardenedBoolTrue);
 
   // Check the key mode.
   if (launder32((uint32_t)blinded_key->config.key_mode) !=
@@ -170,6 +168,12 @@ static status_t aes_gcm_key_construct(otcrypto_blinded_key_t *blinded_key,
 
   // Create the checksum of the key and store it in the key structure.
   aes_key->checksum = aes_key_integrity_checksum(aes_key);
+
+  // Second integrity check of the key we got passed into the cryptolib.
+  // This check is placed here to catch any corruptions that might have
+  // happen after the first check when assembling the `aes_key`.
+  HARDENED_CHECK_EQ(integrity_blinded_key_check(blinded_key),
+                    kHardenedBoolTrue);
 
   return OTCRYPTO_OK;
 }


### PR DESCRIPTION
…ssembly

Previously, we checked the integrity of the passed key using the function `integrity_blinded_key_check` twice before assembling the final `aes_key`.

Hence, a fault injected after the second check during the assembly of the `aes_key` would have been not noticed.

This commit moves the second `integrity_blinded_key_check` after we have assembled the `aes_key. If a fault would have manipulted `blinded_key` we now can detect this at the end.