### PR TITLE
Backport 26930 ([rescue, rom_ext] Lockdown before entering rescue)

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/epmp.c
+++ b/sw/device/silicon_creator/lib/drivers/epmp.c
@@ -64,6 +64,19 @@ void epmp_clear_lock_bits(void) {
   }
 }
 
+void epmp_set_lock_bits(void) {
+  const uint32_t mask =
+      ((uint32_t)EPMP_CFG_L << 0 * 8) | ((uint32_t)EPMP_CFG_L << 1 * 8) |
+      ((uint32_t)EPMP_CFG_L << 2 * 8) | ((uint32_t)EPMP_CFG_L << 3 * 8);
+  CSR_SET_BITS(CSR_REG_PMPCFG0, mask);
+  CSR_SET_BITS(CSR_REG_PMPCFG1, mask);
+  CSR_SET_BITS(CSR_REG_PMPCFG2, mask);
+  CSR_SET_BITS(CSR_REG_PMPCFG3, mask);
+  for (int cfgent = 0; cfgent < 4; ++cfgent) {
+    epmp_state.pmpcfg[cfgent] |= mask;
+  }
+}
+
 uint32_t epmp_encode_napot(epmp_region_t region) {
   const uint32_t length = region.end - region.start;
   // The length must be 4 or more.

--- a/sw/device/silicon_creator/lib/drivers/epmp.h
+++ b/sw/device/silicon_creator/lib/drivers/epmp.h
@@ -49,6 +49,11 @@ void epmp_clear(uint8_t entry);
 void epmp_clear_lock_bits(void);
 
 /**
+ * Set the lock bit in all ePMP entries.
+ */
+void epmp_set_lock_bits(void);
+
+/**
  * Encode a start/end address pair to NAPOT address.
  *
  * The region start must have an alignment consistent with the region size.  The

--- a/sw/device/silicon_creator/lib/drivers/keymgr.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.c
@@ -328,7 +328,10 @@ void sc_keymgr_disable(void) {
       sc_keymgr_base() + KEYMGR_CONTROL_SHADOWED_REG_OFFSET, reg);
 
   abs_mmio_write32(sc_keymgr_base() + KEYMGR_START_REG_OFFSET, 1);
-  abs_mmio_write32(sc_keymgr_base() + KEYMGR_SIDELOAD_CLEAR_REG_OFFSET, 1);
+  // According to the documentation for the SIDELOAD_CLEAR register, an invalid
+  // destination will enable continuous clearing of all destinations.
+  abs_mmio_write32(sc_keymgr_base() + KEYMGR_SIDELOAD_CLEAR_REG_OFFSET,
+                   UINT32_MAX);
 }
 
 extern rom_error_t sc_keymgr_generate_key_otbn(

--- a/sw/device/silicon_creator/lib/drivers/keymgr.h
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.h
@@ -328,7 +328,7 @@ rom_error_t sc_keymgr_owner_advance(keymgr_binding_value_t *attest_binding,
                                     uint32_t max_key_version);
 
 /**
- * Disable the keymgr controller.
+ * Disables the keymgr and clears all sideload slots.
  */
 void sc_keymgr_disable(void);
 

--- a/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
@@ -256,6 +256,13 @@ rom_error_t keymgr_rom_ext_test(void) {
   return kErrorOk;
 }
 
+rom_error_t keymgr_disable_test(void) {
+  sc_keymgr_disable();
+  CHECK(sc_keymgr_state_check(kScKeymgrStateDisabled) == kErrorOk,
+        "Keymgr should be in the disabled state.");
+  return kErrorOk;
+}
+
 bool test_main(void) {
   status_t result = OK_STATUS();
   dif_rstmgr_t rstmgr;
@@ -295,6 +302,7 @@ bool test_main(void) {
 
     EXECUTE_TEST(result, keymgr_rom_test);
     EXECUTE_TEST(result, keymgr_rom_ext_test);
+    EXECUTE_TEST(result, keymgr_disable_test);
     return status_ok(result);
   } else {
     LOG_FATAL("Unexpected reset reason unexpected: %08x", info);

--- a/sw/device/silicon_creator/lib/ownership/ownership_key.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_key.c
@@ -125,6 +125,10 @@ rom_error_t ownership_seal_init(void) {
   return kErrorOk;
 }
 
+rom_error_t ownership_seal_clear(void) {
+  return sc_keymgr_sideload_clear(kScKeymgrDestKmac);
+}
+
 static rom_error_t seal_generate(const owner_block_t *page, uint32_t *seal) {
   size_t sealed_len = offsetof(owner_block_t, seal);
   HARDENED_RETURN_IF_ERROR(kmac_kmac256_start());

--- a/sw/device/silicon_creator/lib/ownership/ownership_key.h
+++ b/sw/device/silicon_creator/lib/ownership/ownership_key.h
@@ -69,6 +69,13 @@ rom_error_t ownership_key_validate(size_t page, ownership_key_t key,
 rom_error_t ownership_seal_init(void);
 
 /**
+ * Clear the sideloaded key in the KMAC block.
+ *
+ * @return Success or error code.
+ */
+rom_error_t ownership_seal_clear(void);
+
+/**
  * Generate a seal for an ownership page.
  *
  * @param page Owner page for which to generate the sealing value.


### PR DESCRIPTION
Backport #26930. Note: the original PR adds a `sc_keymgr_disable` function but one was added independently on master in https://github.com/lowRISC/opentitan/pull/27996. However there is a slight difference between them (which side slots they clear), I opted to take the version of earlgrey_1.0.0 which clears all slots since that seems safer. @cfrantz do you agree?