### PR TITLE
Manualy cherry-pick to eg100: [cryptotest] Only use e=65537 for RSA tests

### DIFF
--- a/sw/host/tests/crypto/rsa_kat/src/main.rs
+++ b/sw/host/tests/crypto/rsa_kat/src/main.rs
@@ -93,115 +93,47 @@ fn run_rsa_testcase(
     }
     assert_eq!(n.len() * u8::BITS as usize, test_case.security_level);
 
-    CryptotestCommand::Rsa.send(spi_console)?;
-    let _operation = &match test_case.operation.as_str() {
-        "verify" => {
-            // Send RsaVerify command.
-            RsaSubcommand::RsaVerify.send(spi_console)?;
+    if test_case.e == 65537 {
+        CryptotestCommand::Rsa.send(spi_console)?;
+        let _operation = &match test_case.operation.as_str() {
+            "verify" => {
+                // Send RsaVerify command.
+                RsaSubcommand::RsaVerify.send(spi_console)?;
 
-            // Convert the inputs into the expected format for the CL.
-            let signature: Vec<_> = test_case.signature.iter().copied().rev().collect();
+                // Convert the inputs into the expected format for the CL.
+                let signature: Vec<_> = test_case.signature.iter().copied().rev().collect();
 
-            // Assemble the input.
-            CryptotestRsaVerify {
-                msg: ArrayVec::try_from(test_case.message.as_slice()).unwrap(),
-                msg_len: test_case.message.len(),
-                e: test_case.e,
-                n: ArrayVec::try_from(n.as_slice()).unwrap(),
-                security_level: test_case.security_level,
-                sig: ArrayVec::try_from(signature.as_slice()).unwrap(),
-                sig_len: test_case.signature.len(),
-                hashing,
-                padding,
+                // Assemble the input.
+                CryptotestRsaVerify {
+                    msg: ArrayVec::try_from(test_case.message.as_slice()).unwrap(),
+                    msg_len: test_case.message.len(),
+                    e: test_case.e,
+                    n: ArrayVec::try_from(n.as_slice()).unwrap(),
+                    security_level: test_case.security_level,
+                    sig: ArrayVec::try_from(signature.as_slice()).unwrap(),
+                    sig_len: test_case.signature.len(),
+                    hashing,
+                    padding,
+                }
+                .send(spi_console)?;
+
+                // Get and evaluate the response.
+                let rsa_verify_resp =
+                    CryptotestRsaVerifyResp::recv(spi_console, opts.timeout, false, false)?;
+                assert_eq!(rsa_verify_resp.result, test_case.result);
             }
-            .send(spi_console)?;
-
-            // Get and evaluate the response.
-            let rsa_verify_resp =
-                CryptotestRsaVerifyResp::recv(spi_console, opts.timeout, false, false)?;
-            assert_eq!(rsa_verify_resp.result, test_case.result);
-        }
-        "decrypt" => {
-            // Send RsaDecrypt command.
-            RsaSubcommand::RsaDecrypt.send(spi_console)?;
-
-            // Convert the inputs into the expected format for the CL.
-            let d: Vec<_> = test_case.d.iter().copied().rev().collect();
-            let ctx: Vec<_> = test_case.ciphertext.iter().copied().rev().collect();
-
-            // Assemble the input.
-            CryptotestRsaDecrypt {
-                ciphertext: ArrayVec::try_from(ctx.as_slice()).unwrap(),
-                ciphertext_len: test_case.ciphertext.len(),
-                e: test_case.e,
-                d: ArrayVec::try_from(d.as_slice()).unwrap(),
-                n: ArrayVec::try_from(n.as_slice()).unwrap(),
-                security_level: test_case.security_level,
-                label: ArrayVec::try_from(test_case.label.as_slice()).unwrap(),
-                label_len: test_case.label.len(),
-                hashing,
-                padding,
-            }
-            .send(spi_console)?;
-
-            // Get and evaluate the response.
-            let rsa_decrypt_resp =
-                CryptotestRsaDecryptResp::recv(spi_console, opts.timeout, false, false)?;
-            // Check if the decryption was successful.
-            assert_eq!(rsa_decrypt_resp.result, test_case.result);
-
-            if test_case.result {
-                // Only check plaintext if the response is valid.
-                assert_eq!(
-                    rsa_decrypt_resp.plaintext[0..test_case.message.len()],
-                    test_case.message[0..test_case.message.len()]
-                );
-            }
-        }
-        "encrypt" => {
-            // Send RsaEncrypt command.
-            RsaSubcommand::RsaEncrypt.send(spi_console)?;
-
-            // Convert the inputs into the expected format for the CL.
-            let ptx: Vec<_> = test_case.message.iter().copied().rev().collect();
-
-            // Assemble the input.
-            CryptotestRsaEncrypt {
-                plaintext: ArrayVec::try_from(ptx.as_slice()).unwrap(),
-                plaintext_len: test_case.message.len(),
-                e: test_case.e,
-                n: ArrayVec::try_from(n.as_slice()).unwrap(),
-                security_level: test_case.security_level,
-                label: ArrayVec::try_from(test_case.label.as_slice()).unwrap(),
-                label_len: test_case.label.len(),
-                hashing,
-                padding,
-            }
-            .send(spi_console)?;
-
-            // Get and evaluate the response.
-            let rsa_encrypt_resp =
-                CryptotestRsaEncryptResp::recv(spi_console, opts.timeout, false, false)?;
-            // Check if the encryption was successful.
-            assert_eq!(rsa_encrypt_resp.result, test_case.result);
-
-            // Use the received ciphertext, decrypt it, and compare it to the
-            // plaintext in the test vector.
-            if test_case.result {
-                // Decrypt it again and check if the plaintext matches.
+            "decrypt" => {
                 // Send RsaDecrypt command.
-                CryptotestCommand::Rsa.send(spi_console)?;
                 RsaSubcommand::RsaDecrypt.send(spi_console)?;
 
                 // Convert the inputs into the expected format for the CL.
                 let d: Vec<_> = test_case.d.iter().copied().rev().collect();
-                let ctx: Vec<_> =
-                    Vec::from(&rsa_encrypt_resp.ciphertext[..rsa_encrypt_resp.ciphertext_len]);
+                let ctx: Vec<_> = test_case.ciphertext.iter().copied().rev().collect();
 
                 // Assemble the input.
                 CryptotestRsaDecrypt {
                     ciphertext: ArrayVec::try_from(ctx.as_slice()).unwrap(),
-                    ciphertext_len: rsa_encrypt_resp.ciphertext_len,
+                    ciphertext_len: test_case.ciphertext.len(),
                     e: test_case.e,
                     d: ArrayVec::try_from(d.as_slice()).unwrap(),
                     n: ArrayVec::try_from(n.as_slice()).unwrap(),
@@ -223,13 +155,83 @@ fn run_rsa_testcase(
                     // Only check plaintext if the response is valid.
                     assert_eq!(
                         rsa_decrypt_resp.plaintext[0..test_case.message.len()],
-                        ptx[0..test_case.message.len()]
+                        test_case.message[0..test_case.message.len()]
                     );
                 }
             }
-        }
-        _ => panic!("Invalid operation"),
-    };
+            "encrypt" => {
+                // Send RsaEncrypt command.
+                RsaSubcommand::RsaEncrypt.send(spi_console)?;
+
+                // Convert the inputs into the expected format for the CL.
+                let ptx: Vec<_> = test_case.message.iter().copied().rev().collect();
+
+                // Assemble the input.
+                CryptotestRsaEncrypt {
+                    plaintext: ArrayVec::try_from(ptx.as_slice()).unwrap(),
+                    plaintext_len: test_case.message.len(),
+                    e: test_case.e,
+                    n: ArrayVec::try_from(n.as_slice()).unwrap(),
+                    security_level: test_case.security_level,
+                    label: ArrayVec::try_from(test_case.label.as_slice()).unwrap(),
+                    label_len: test_case.label.len(),
+                    hashing,
+                    padding,
+                }
+                .send(spi_console)?;
+
+                // Get and evaluate the response.
+                let rsa_encrypt_resp =
+                    CryptotestRsaEncryptResp::recv(spi_console, opts.timeout, false, false)?;
+                // Check if the encryption was successful.
+                assert_eq!(rsa_encrypt_resp.result, test_case.result);
+
+                // Use the received ciphertext, decrypt it, and compare it to the
+                // plaintext in the test vector.
+                if test_case.result {
+                    // Decrypt it again and check if the plaintext matches.
+                    // Send RsaDecrypt command.
+                    CryptotestCommand::Rsa.send(spi_console)?;
+                    RsaSubcommand::RsaDecrypt.send(spi_console)?;
+
+                    // Convert the inputs into the expected format for the CL.
+                    let d: Vec<_> = test_case.d.iter().copied().rev().collect();
+                    let ctx: Vec<_> =
+                        Vec::from(&rsa_encrypt_resp.ciphertext[..rsa_encrypt_resp.ciphertext_len]);
+
+                    // Assemble the input.
+                    CryptotestRsaDecrypt {
+                        ciphertext: ArrayVec::try_from(ctx.as_slice()).unwrap(),
+                        ciphertext_len: rsa_encrypt_resp.ciphertext_len,
+                        e: test_case.e,
+                        d: ArrayVec::try_from(d.as_slice()).unwrap(),
+                        n: ArrayVec::try_from(n.as_slice()).unwrap(),
+                        security_level: test_case.security_level,
+                        label: ArrayVec::try_from(test_case.label.as_slice()).unwrap(),
+                        label_len: test_case.label.len(),
+                        hashing,
+                        padding,
+                    }
+                    .send(spi_console)?;
+
+                    // Get and evaluate the response.
+                    let rsa_decrypt_resp =
+                        CryptotestRsaDecryptResp::recv(spi_console, opts.timeout, false, false)?;
+                    // Check if the decryption was successful.
+                    assert_eq!(rsa_decrypt_resp.result, test_case.result);
+
+                    if test_case.result {
+                        // Only check plaintext if the response is valid.
+                        assert_eq!(
+                            rsa_decrypt_resp.plaintext[0..test_case.message.len()],
+                            ptx[0..test_case.message.len()]
+                        );
+                    }
+                }
+            }
+            _ => panic!("Invalid operation"),
+        };
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Manual cherry pick of #29088.