### PR TITLE
[manuf] Provision default boot data in FT individualize

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -219,6 +219,7 @@ opentitan_test(
             "//sw/device/lib/testing/test_framework:ottf_test_config",
             "//sw/device/lib/testing/test_framework:status",
             "//sw/device/lib/testing/test_framework:ujson_ottf",
+            "//sw/device/silicon_creator/lib:boot_data",
             "//sw/device/silicon_creator/manuf/lib:individualize",
             "//sw/device/silicon_creator/manuf/lib:otp_fields",
             "//sw/device/silicon_creator/manuf/lib:sram_start",


### PR DESCRIPTION
This change ensures the perso is bootable when the `DEFAULT_BOOT_DATA_IN_PROD_EN` OTP is disabled by explicitly provisioning the default boot data during FT individualize.

This change has no impact when `DEFAULT_BOOT_DATA_IN_PROD_EN` is enabled, as the initial boot data read in perso retrieves the same default values prior to this change.