### PR TITLE
Backport 27047 ([opentitantool] Add `ownership detached-signature` command)

### DIFF
--- a/sw/host/opentitanlib/src/ownership/misc.rs
+++ b/sw/host/opentitanlib/src/ownership/misc.rs
@@ -38,6 +38,12 @@ with_unknown! {
         HybridSpxPure = u32::from_le_bytes(*b"H+Pu"),
         HybridSpxPrehash = u32::from_le_bytes(*b"H+S2"),
     }
+    pub enum DetachedSignatureCommand: u32 [default = Self::Unknown] {
+        Unknown = 0,
+        Owner = u32::from_le_bytes(*b"OWNR"),
+        Unlock = u32::from_le_bytes(*b"UNLK"),
+        Activate = u32::from_le_bytes(*b"ACTV"),
+    }
 }
 
 impl OwnershipKeyAlg {

--- a/sw/host/opentitanlib/src/ownership/mod.rs
+++ b/sw/host/opentitanlib/src/ownership/mod.rs
@@ -17,7 +17,9 @@ pub use application_key::{ApplicationKeyDomain, OwnerApplicationKey};
 pub use flash::{FlashFlags, OwnerFlashConfig, OwnerFlashRegion};
 pub use flash_info::{OwnerFlashInfoConfig, OwnerInfoPage};
 pub use isfb::OwnerIsfbConfig;
-pub use misc::{HybridRawPublicKey, KeyMaterial, OwnershipKeyAlg, TlvHeader, TlvTag};
+pub use misc::{
+    DetachedSignatureCommand, HybridRawPublicKey, KeyMaterial, OwnershipKeyAlg, TlvHeader, TlvTag,
+};
 pub use owner::{OwnerBlock, OwnerConfigItem, SramExecMode};
 pub use rescue::{CommandTag, OwnerRescueConfig, RescueProtocol};
 pub use signature::DetachedSignature;


### PR DESCRIPTION
Backport #27047. Depends on #29113, only review the last commit