### PR TITLE
[bazel] Bump QEMU to v10.2.0-2026-01-15

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -732,7 +732,7 @@
     },
     "//third_party/qemu:extensions.bzl%qemu": {
       "general": {
-        "bzlTransitiveDigest": "eHaG03C2K0d3c4A/PVMZ6YueTG/Cvla10nM+/Nuaa+o=",
+        "bzlTransitiveDigest": "2qfNixzcRI/HwlDT8rsXTQ/403atHBOavIuUfE3VJ/A=",
         "usagesDigest": "le4nFQIsMEytUZA5Dz/GdRTwr0Ri5kyC+VIeW4HnJLI=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -741,9 +741,9 @@
           "qemu_opentitan_src": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
-              "url": "https://github.com/lowRISC/qemu/releases/download/v9.2.0-2025-12-01/qemu-ot-earlgrey-v9.2.0-2025-12-01-x86_64-unknown-linux-gnu.tar.gz",
+              "url": "https://github.com/lowRISC/qemu/releases/download/v10.2.0-2026-01-15/qemu-ot-earlgrey-v10.2.0-2026-01-15-x86_64-unknown-linux-gnu.tar.gz",
               "build_file": "@@//third_party/qemu:BUILD.qemu_opentitan.bazel",
-              "sha256": "eecdbfb57aaf2e24372d3c0fe249b5faa21571f40e7a2e54a5062ae89a2ec4d9",
+              "sha256": "9e97f93b09912c904e84f06571e7b49023ccb405dd3caa232ad1e82a3f7b381c",
               "patch_cmds": [
                 "touch .this.is.the.archive"
               ]

--- a/third_party/qemu/extensions.bzl
+++ b/third_party/qemu/extensions.bzl
@@ -81,7 +81,7 @@ qemu_bazel_build_or_forward = repository_rule(
 )
 
 def _qemu_opentitan_repos():
-    QEMU_VERSION = "v9.2.0-2025-12-01"
+    QEMU_VERSION = "v10.2.0-2026-01-15"
 
     url = "/".join([
         "https://github.com/lowRISC/qemu/releases/download",
@@ -93,7 +93,7 @@ def _qemu_opentitan_repos():
         name = "qemu_opentitan_src",
         url = url,
         build_file = Label(":BUILD.qemu_opentitan.bazel"),
-        sha256 = "eecdbfb57aaf2e24372d3c0fe249b5faa21571f40e7a2e54a5062ae89a2ec4d9",
+        sha256 = "9e97f93b09912c904e84f06571e7b49023ccb405dd3caa232ad1e82a3f7b381c",
         patch_cmds = ["touch {}".format(_ARCHIVE_MARKER_FILE)],
     )
 


### PR DESCRIPTION
Includes a major version bump of QEMU upstream and a couple of fixes on our fork. This is the latest upstream QEMU version at time of submission.