### PR TITLE
[silicon_creator,usb] Fix functest on rom_with_fake_keys

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -693,6 +693,7 @@ opentitan_test(
         ":rnd",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:crc32",
+        "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/dif:entropy_src",
         "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing:rand_testutils",
@@ -1022,6 +1023,7 @@ opentitan_test(
         ":rnd",
         ":usb",
         "//sw/device/lib/base:macros",
+        "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/silicon_creator/lib/drivers/usb_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/usb_functest.c
@@ -7,6 +7,7 @@
 
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/runtime/print.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
@@ -239,6 +240,7 @@ rom_error_t usb_test(void) {
 }
 
 bool test_main(void) {
+  CHECK_STATUS_OK(entropy_complex_init());
   pinmux_init_usb();
   status_t result = OK_STATUS();
   EXECUTE_TEST(result, usb_test);


### PR DESCRIPTION
This tests uses some random data and therefore requires that the entropy complex be initialized, which is not the case by default in all execution environments.

Fixes #29123