### PR TITLE
[rom_ext] Add security version self-check

### DIFF
--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -501,6 +501,10 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   HARDENED_RETURN_IF_ERROR(rom_ext_init(boot_data));
   const manifest_t *self = rom_ext_manifest();
 
+  // Security version self-check
+  HARDENED_CHECK_GE(self->security_version,
+                    boot_data->min_security_version_rom_ext);
+
   lifecycle_claim(kMultiBitBool8True);
   lifecycle_set_status(kLifecycleStatusWordRomExtVersion, self->version_minor);
   lifecycle_set_status(kLifecycleStatusWordRomExtSecVersion,


### PR DESCRIPTION
This change adds a hardened check to ensure that the ROM_EXT security version is greater than or equal to the minimum security version specified in the boot data.