### PR TITLE
[rom_ext] Postpone dice chain stuff to rom_ext_boot

### DIFF
--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -252,6 +252,10 @@ static rom_error_t rom_ext_boot(boot_data_t *boot_data, boot_log_t *boot_log,
     memset(&sealing_binding, 0x55, sizeof(sealing_binding));
   }
 
+  // Prepare dice chain builder for CDI_1.
+  HARDENED_RETURN_IF_ERROR(dice_chain_init());
+  HARDENED_RETURN_IF_ERROR(dice_chain_rom_ext_check());
+
   // Generate CDI_1 attestation keys and certificate.
   HARDENED_RETURN_IF_ERROR(dice_chain_attestation_owner(
       manifest, &boot_measurements.bl0, &owner_measurement, &owner_history_hash,
@@ -538,10 +542,6 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
     // Ignore the result to prevent unnecessary bootloop.
     OT_DISCARD(boot_data_write(boot_data));
   }
-
-  // Prepare dice chain builder for CDI_1.
-  HARDENED_RETURN_IF_ERROR(dice_chain_init());
-  HARDENED_RETURN_IF_ERROR(dice_chain_rom_ext_check());
 
   // Initialize the boot_log in retention RAM.
   const build_info_t *rom_chip_info = (const build_info_t *)_chip_info_start;


### PR DESCRIPTION
This change postpones DICE chain initialization and verification from `rom_ext_start` to `rom_ext_boot`. This ensures that DICE chain related errors do not prevent the system from entering rescue mode for reliability.

Side-effect: this PR makes the dice related logs printed in the later stage.