### PR TITLE
[pentest] Add initial timeout to read response

### DIFF
--- a/sw/host/penetrationtests/python/sca/host_scripts/sca_asym_cryptolib_functions.py
+++ b/sw/host/penetrationtests/python/sca/host_scripts/sca_asym_cryptolib_functions.py
@@ -30,26 +30,12 @@ def char_rsa_dec(
         # Clear the output from the reset
         target.dump_all()
     # Initialize our chip and catch its output
-    device_id, owner_page, boot_log, boot_measurements, version = (
-        asymsca.init()
-    )
+    device_id, owner_page, boot_log, boot_measurements, version = asymsca.init()
     # Set the internal prng
     ot_prng = OTPRNG(target=target)
     ot_prng.seed_prng([1, 0, 0, 0])
     for _ in range(iterations):
-        asymsca.handle_rsa_dec(
-            data,
-            data_len,
-            e,
-            n,
-            n_len,
-            d,
-            padding,
-            hashing,
-            mode,
-            cfg,
-            trigger
-        )
+        asymsca.handle_rsa_dec(data, data_len, e, n, n_len, d, padding, hashing, mode, cfg, trigger)
         response = target.read_response()
     return response
 
@@ -75,26 +61,13 @@ def char_rsa_sign(
         # Clear the output from the reset
         target.dump_all()
     # Initialize our chip and catch its output
-    device_id, owner_page, boot_log, boot_measurements, version = (
-        asymsca.init()
-    )
+    device_id, owner_page, boot_log, boot_measurements, version = asymsca.init()
     # Set the internal prng
     ot_prng = OTPRNG(target=target)
     ot_prng.seed_prng([1, 0, 0, 0])
 
     for _ in range(iterations):
-        asymsca.handle_rsa_sign(
-            data,
-            data_len,
-            e,
-            n,
-            n_len,
-            d,
-            padding,
-            hashing,
-            cfg,
-            trigger
-        )
+        asymsca.handle_rsa_sign(data, data_len, e, n, n_len, d, padding, hashing, cfg, trigger)
         response = target.read_response()
     return response
 
@@ -113,9 +86,7 @@ def char_prime_generation(
         # Clear the output from the reset
         target.dump_all()
     # Initialize our chip and catch its output
-    device_id, owner_page, boot_log, boot_measurements, version = (
-        asymsca.init()
-    )
+    device_id, owner_page, boot_log, boot_measurements, version = asymsca.init()
     for _ in range(iterations):
         asymsca.handle_prime_generation(
             e,
@@ -141,21 +112,14 @@ def char_p256_base_mult_fvsr(
         # Clear the output from the reset
         target.dump_all()
     # Initialize our chip and catch its output
-    device_id, owner_page, boot_log, boot_measurements, version = (
-        asymsca.init()
-    )
+    device_id, owner_page, boot_log, boot_measurements, version = asymsca.init()
     # Set the internal prng
     ot_prng = OTPRNG(target=target)
     ot_prng.seed_prng([1, 0, 0, 0])
 
     for _ in range(iterations):
-        asymsca.handle_p256_base_mult_fvsr(
-            scalar,
-            cfg,
-            trigger,
-            num_iterations
-        )
-        response = target.read_response()
+        asymsca.handle_p256_base_mult_fvsr(scalar, cfg, trigger, num_iterations)
+        response = target.read_response(init_timeout=0.01 * num_iterations)
     return response
 
 
@@ -174,17 +138,10 @@ def char_p256_base_mult_daisy(
         # Clear the output from the reset
         target.dump_all()
     # Initialize our chip and catch its output
-    device_id, owner_page, boot_log, boot_measurements, version = (
-        asymsca.init()
-    )
+    device_id, owner_page, boot_log, boot_measurements, version = asymsca.init()
     for _ in range(iterations):
-        asymsca.handle_p256_base_mult_daisy(
-            scalar,
-            cfg,
-            trigger,
-            num_iterations
-        )
-        response = target.read_response()
+        asymsca.handle_p256_base_mult_daisy(scalar, cfg, trigger, num_iterations)
+        response = target.read_response(init_timeout=0.01 * num_iterations)
     return response
 
 
@@ -203,16 +160,9 @@ def char_p256_point_mult(
         # Clear the output from the reset
         target.dump_all()
     # Initialize our chip and catch its output
-    device_id, owner_page, boot_log, boot_measurements, version = (
-        asymsca.init()
-    )
+    device_id, owner_page, boot_log, boot_measurements, version = asymsca.init()
     for _ in range(iterations):
-        asymsca.handle_p256_point_mult(
-            scalar_alice,
-            scalar_bob,
-            cfg,
-            trigger
-        )
+        asymsca.handle_p256_point_mult(scalar_alice, scalar_bob, cfg, trigger)
         response = target.read_response()
     return response
 
@@ -233,17 +183,9 @@ def char_p256_ecdh(
         # Clear the output from the reset
         target.dump_all()
     # Initialize our chip and catch its output
-    device_id, owner_page, boot_log, boot_measurements, version = (
-        asymsca.init()
-    )
+    device_id, owner_page, boot_log, boot_measurements, version = asymsca.init()
     for _ in range(iterations):
-        asymsca.handle_p256_ecdh(
-            private_key,
-            public_x,
-            public_y,
-            cfg,
-            trigger
-        )
+        asymsca.handle_p256_ecdh(private_key, public_x, public_y, cfg, trigger)
         response = target.read_response()
     return response
 
@@ -265,18 +207,9 @@ def char_p256_sign(
         # Clear the output from the reset
         target.dump_all()
     # Initialize our chip and catch its output
-    device_id, owner_page, boot_log, boot_measurements, version = (
-        asymsca.init()
-    )
+    device_id, owner_page, boot_log, boot_measurements, version = asymsca.init()
     for _ in range(iterations):
-        asymsca.handle_p256_sign(
-            scalar,
-            pubx,
-            puby,
-            message,
-            cfg,
-            trigger
-        )
+        asymsca.handle_p256_sign(scalar, pubx, puby, message, cfg, trigger)
         response = target.read_response()
     return response
 
@@ -296,20 +229,13 @@ def char_p384_base_mult_fvsr(
         # Clear the output from the reset
         target.dump_all()
     # Initialize our chip and catch its output
-    device_id, owner_page, boot_log, boot_measurements, version = (
-        asymsca.init()
-    )
+    device_id, owner_page, boot_log, boot_measurements, version = asymsca.init()
     # Set the internal prng
     ot_prng = OTPRNG(target=target)
     ot_prng.seed_prng([1, 0, 0, 0])
     for _ in range(iterations):
-        asymsca.handle_p384_base_mult_fvsr(
-            scalar,
-            cfg,
-            trigger,
-            num_iterations
-        )
-        response = target.read_response()
+        asymsca.handle_p384_base_mult_fvsr(scalar, cfg, trigger, num_iterations)
+        response = target.read_response(init_timeout=0.01 * num_iterations)
     return response
 
 
@@ -328,17 +254,10 @@ def char_p384_base_mult_daisy(
         # Clear the output from the reset
         target.dump_all()
     # Initialize our chip and catch its output
-    device_id, owner_page, boot_log, boot_measurements, version = (
-        asymsca.init()
-    )
+    device_id, owner_page, boot_log, boot_measurements, version = asymsca.init()
     for _ in range(iterations):
-        asymsca.handle_p384_base_mult_daisy(
-            scalar,
-            cfg,
-            trigger,
-            num_iterations
-        )
-        response = target.read_response()
+        asymsca.handle_p384_base_mult_daisy(scalar, cfg, trigger, num_iterations)
+        response = target.read_response(init_timeout=0.01 * num_iterations)
     return response
 
 
@@ -357,16 +276,9 @@ def char_p384_point_mult(
         # Clear the output from the reset
         target.dump_all()
     # Initialize our chip and catch its output
-    device_id, owner_page, boot_log, boot_measurements, version = (
-        asymsca.init()
-    )
+    device_id, owner_page, boot_log, boot_measurements, version = asymsca.init()
     for _ in range(iterations):
-        asymsca.handle_p384_point_mult(
-            scalar_alice,
-            scalar_bob,
-            cfg,
-            trigger
-        )
+        asymsca.handle_p384_point_mult(scalar_alice, scalar_bob, cfg, trigger)
         response = target.read_response()
     return response
 
@@ -387,17 +299,9 @@ def char_p384_ecdh(
         # Clear the output from the reset
         target.dump_all()
     # Initialize our chip and catch its output
-    device_id, owner_page, boot_log, boot_measurements, version = (
-        asymsca.init()
-    )
+    device_id, owner_page, boot_log, boot_measurements, version = asymsca.init()
     for _ in range(iterations):
-        asymsca.handle_p384_ecdh(
-            private_key,
-            public_x,
-            public_y,
-            cfg,
-            trigger
-        )
+        asymsca.handle_p384_ecdh(private_key, public_x, public_y, cfg, trigger)
         response = target.read_response()
     return response
 
@@ -419,17 +323,8 @@ def char_p384_sign(
         # Clear the output from the reset
         target.dump_all()
     # Initialize our chip and catch its output
-    device_id, owner_page, boot_log, boot_measurements, version = (
-        asymsca.init()
-    )
+    device_id, owner_page, boot_log, boot_measurements, version = asymsca.init()
     for _ in range(iterations):
-        asymsca.handle_p384_sign(
-            scalar,
-            pubx,
-            puby,
-            message,
-            cfg,
-            trigger
-        )
+        asymsca.handle_p384_sign(scalar, pubx, puby, message, cfg, trigger)
         response = target.read_response()
     return response

--- a/sw/host/penetrationtests/python/util/targets.py
+++ b/sw/host/penetrationtests/python/util/targets.py
@@ -154,7 +154,7 @@ class Target:
                 continue
         return "", False
 
-    def read_response(self, max_tries: Optional[int] = 50):
+    def read_response(self, init_timeout: Optional[int] = 0, max_tries: Optional[int] = 250):
         """
         Args:
             max_tries: Maximum number of attempts to read from UART.
@@ -162,6 +162,7 @@ class Target:
         Returns:
             The JSON response of OpenTitan.
         """
+        time.sleep(init_timeout)
         it = 0
         while it < max_tries:
             try:


### PR DESCRIPTION
For long tests in the pentest framework such as batched operations, the UART readout is shorter than the operational time. To account for this, we add an initial timeout option in this command.
We can adapt batched tests to account for the number of iterations (taking a rough timeout in this case to be on the safe side).