### PR TITLE
[rom_ext] Hardened the boot policy security version check

### DIFF
--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.c
@@ -70,7 +70,12 @@ rom_error_t rom_ext_boot_policy_manifest_check(const manifest_t *manifest,
       manifest->length > CHIP_BL0_SIZE_MAX) {
     return kErrorBootPolicyBadLength;
   }
-  if (manifest->security_version < boot_data->min_security_version_bl0) {
+  // Sanity check boot_data to reject a bogus pointer.
+  HARDENED_CHECK_EQ(boot_data->identifier, kBootDataIdentifier);
+  // Launder both values to ensure they are reloaded from memory for the
+  // hardened check.
+  if (launder32(manifest->security_version) <
+      launder32(boot_data->min_security_version_bl0)) {
     return kErrorBootPolicyRollback;
   }
   HARDENED_CHECK_GE(manifest->security_version,

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_unittest.cc
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_unittest.cc
@@ -24,6 +24,7 @@ class RomExtBootPolicyTest : public rom_test::RomTest {
 // TODO(#21204): Refactor to use `manifest_check` from `lib/manifest.h`.
 TEST_F(RomExtBootPolicyTest, DISABLED_ManifestCheck) {
   boot_data_t boot_data{{0}};
+  boot_data.identifier = kBootDataIdentifier;
 
   manifest_t manifest{};
   manifest.identifier = CHIP_BL0_IDENTIFIER;
@@ -46,6 +47,7 @@ TEST_F(RomExtBootPolicyTest, DISABLED_ManifestCheck) {
 
 TEST_F(RomExtBootPolicyTest, ManifestCheckBadIdentifier) {
   boot_data_t boot_data{};
+  boot_data.identifier = kBootDataIdentifier;
   manifest_t manifest{};
 
   EXPECT_EQ(rom_ext_boot_policy_manifest_check(&manifest, &boot_data),
@@ -54,6 +56,7 @@ TEST_F(RomExtBootPolicyTest, ManifestCheckBadIdentifier) {
 
 TEST_F(RomExtBootPolicyTest, ManifestCheckBadLength) {
   boot_data_t boot_data{};
+  boot_data.identifier = kBootDataIdentifier;
   manifest_t manifest{};
   manifest.identifier = CHIP_BL0_IDENTIFIER;
 
@@ -68,6 +71,7 @@ TEST_F(RomExtBootPolicyTest, ManifestCheckBadLength) {
 
 TEST_F(RomExtBootPolicyTest, ManifestCheckBadBl0SecVer) {
   boot_data_t boot_data{};
+  boot_data.identifier = kBootDataIdentifier;
   boot_data.min_security_version_bl0 = 1;
 
   manifest_t manifest{};
@@ -81,6 +85,7 @@ TEST_F(RomExtBootPolicyTest, ManifestCheckBadBl0SecVer) {
 
 TEST_F(RomExtBootPolicyTest, ManifestCheckBadSignedRegion) {
   boot_data_t boot_data{};
+  boot_data.identifier = kBootDataIdentifier;
   boot_data.min_security_version_bl0 = 1;
 
   manifest_t manifest{};
@@ -96,6 +101,7 @@ TEST_F(RomExtBootPolicyTest, ManifestCheckBadSignedRegion) {
 
 TEST_F(RomExtBootPolicyTest, ManifestCheckBadEntryPoint) {
   boot_data_t boot_data{};
+  boot_data.identifier = kBootDataIdentifier;
   boot_data.min_security_version_bl0 = 1;
 
   manifest_t manifest{};
@@ -132,6 +138,7 @@ TEST_P(ManifestOrderTest, ManifestsGet) {
       .WillOnce(Return(&manifest_b));
 
   boot_data_t boot_data{};
+  boot_data.identifier = kBootDataIdentifier;
   if (GetParam().primary == kBootSlotA) {
     boot_data.primary_bl0_slot = kBootSlotA;
   } else {

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_services_unittest.cc
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_services_unittest.cc
@@ -40,7 +40,7 @@ constexpr uint32_t kUnlock =
 class RomExtBootServicesTest : public rom_test::RomTest {
  protected:
   boot_svc_msg_t boot_svc_msg{};
-  boot_data_t boot_data{};
+  boot_data_t boot_data{.identifier = kBootDataIdentifier};
   boot_log_t boot_log{};
   lifecycle_state_t lc_state{};
   owner_application_keyring_t keyring{};

--- a/sw/device/silicon_creator/rom_ext/rom_ext_verify.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_verify.c
@@ -25,7 +25,8 @@ rom_error_t rom_ext_verify(const manifest_t *manifest, char slot_id,
                            owner_application_keyring_t *keyring,
                            size_t *verify_key, owner_config_t *owner_config,
                            uint32_t *isfb_check_count) {
-  RETURN_IF_ERROR(rom_ext_boot_policy_manifest_check(manifest, boot_data));
+  HARDENED_RETURN_IF_ERROR(
+      rom_ext_boot_policy_manifest_check(manifest, boot_data));
 
   uint32_t key_id =
       sigverify_ecdsa_p256_key_id_get(&manifest->ecdsa_public_key);


### PR DESCRIPTION
This change introduces several hardening improvements to the ROM_EXT boot policy:

1.  Adds a sanity check to `rom_ext_boot_policy_manifest_check` to ensure the `boot_data` identifier is valid, using a hardened trap on failure.
2.  Fixes the hardened security version rollback check by laundering the values before comparison.
3.  Updates `rom_ext_verify` to use `HARDENED_RETURN_IF_ERROR` when checking the manifest.