### PR TITLE
[bazel] Add `cw340_rom_with_fake_keys` to default envs

### DIFF
--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -120,6 +120,7 @@ EARLGREY_TEST_ENVS = {
     "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
     "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
     "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+    "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
     "//hw/top_earlgrey:sim_dv": None,
     "//hw/top_earlgrey:sim_verilator": None,
     "//hw/top_earlgrey:sim_qemu_rom_with_fake_keys": None,

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -862,7 +862,10 @@ opentitan_test(
         # changing the key for a single environment.
         dicts.omit(
             EARLGREY_TEST_ENVS,
-            ["//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys"],
+            [
+                "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys",
+                "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys",
+            ],
         ),
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,

--- a/sw/device/tests/alert_handler_lpg_sleep_mode_pings.c
+++ b/sw/device/tests/alert_handler_lpg_sleep_mode_pings.c
@@ -504,7 +504,7 @@ bool test_main(void) {
     // We need to initialize the info FLASH partitions storing the Creator and
     // Owner secrets to avoid getting the flash controller into a fatal error
     // state.
-    if (kDeviceType == kDeviceFpgaCw310) {
+    if (kDeviceType == kDeviceFpgaCw310 || kDeviceType == kDeviceFpgaCw340) {
       CHECK_STATUS_OK(keymgr_testutils_flash_init(&flash_ctrl, &kCreatorSecret,
                                                   &kOwnerSecret));
       chip_sw_reset();

--- a/sw/device/tests/alert_handler_reverse_ping_in_deep_sleep_test.c
+++ b/sw/device/tests/alert_handler_reverse_ping_in_deep_sleep_test.c
@@ -210,7 +210,7 @@ bool test_main(void) {
   // We need to initialize the info FLASH partitions storing the Creator and
   // Owner secrets to avoid getting the flash controller into a fatal error
   // state.
-  if (kDeviceType == kDeviceFpgaCw310) {
+  if (kDeviceType == kDeviceFpgaCw310 || kDeviceType == kDeviceFpgaCw340) {
     dif_rstmgr_reset_info_bitfield_t rst_info = rstmgr_testutils_reason_get();
     if (rst_info & kDifRstmgrResetInfoPor) {
       CHECK_STATUS_OK(keymgr_testutils_flash_init(&flash_ctrl, &kCreatorSecret,
@@ -226,7 +226,7 @@ bool test_main(void) {
 
     // Update the expected `reset_info` value for the FPGA target, as we have
     // a soft reset required to apply the info flash page configuration.
-    if (kDeviceType == kDeviceFpgaCw310) {
+    if (kDeviceType == kDeviceFpgaCw310 || kDeviceType == kDeviceFpgaCw340) {
       reset_info = kDifRstmgrResetInfoSw;
     }
 


### PR DESCRIPTION
Matches the `cw310_rom_with_fake_keys` environment in the default set. Configurations are copied over.

FYI I did a manual run of all these tests since some of them are skipped by CI because they support `fpga_cw340_sival_rom_ext`.