### PR TITLE
[cryptolib] Check loop counter in KMAC driver

### DIFF
--- a/sw/device/lib/crypto/drivers/kmac.c
+++ b/sw/device/lib/crypto/drivers/kmac.c
@@ -650,12 +650,16 @@ static status_t kmac_process_msg_blocks(kmac_operation_t operation,
     uint32_t next_word = read_32(&message[i]);
     abs_mmio_write32(kBase + KMAC_MSG_FIFO_REG_OFFSET, next_word);
   }
+  // Check that the loops ran for the correct number of iterations.
+  HARDENED_CHECK_LT(message_len, i + sizeof(uint32_t));
 
   // For the last few bytes, we need to write one byte at a time again.
   for (; i < message_len; i++) {
     HARDENED_TRY(wait_status_bit(KMAC_STATUS_FIFO_FULL_BIT, 0));
     abs_mmio_write8(kmac_base() + KMAC_MSG_FIFO_REG_OFFSET, message[i]);
   }
+  // Check that the loops ran for the correct number of iterations.
+  HARDENED_CHECK_EQ(i, message_len);
 
   // If operation=KMAC, then we need to write `right_encode(digest->len)`
   if (operation == kKmacOperationKmac) {


### PR DESCRIPTION
To mitigate fault attacks, check if we have executed the number of expected loop rounds.