### PR TITLE
[doc] Include CryptoLib API into doxygen build

### DIFF
--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -29,6 +29,7 @@ doxygen_gather_cc(
         "//hw/top:doxy_target",
         "//sw/device/lib/arch:doxy_target",
         "//sw/device/lib/base:doxy_target",
+        "//sw/device/lib/crypto/include:doxy_target",
         "//sw/device/lib/dif:doxy_target",
         "//sw/device/lib/testing:doxy_target",
     ],

--- a/sw/device/lib/crypto/include/BUILD
+++ b/sw/device/lib/crypto/include/BUILD
@@ -4,6 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
+load("//rules:doxygen.bzl", "doxygen_gather_all_package_cc")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 # Export all headers.
@@ -85,4 +86,8 @@ pkg_files(
     name = "package",
     srcs = glob(["*.h"]),
     prefix = "crypto/include",
+)
+
+doxygen_gather_all_package_cc(
+    name = "doxy_target",
 )


### PR DESCRIPTION
Build the doxygen documentation of the CryptoLib public API.