### PR TITLE
[signing] Fix signature_test failure due to manifest serialization changes

### DIFF
--- a/rules/scripts/sival_signature_test.template.sh
+++ b/rules/scripts/sival_signature_test.template.sh
@@ -34,13 +34,20 @@ do
   # If there are keys to verify, perform manifest update
   if [[ ${#KEY_ARGS[@]} -ne 0 ]]; then
     echo -n "Checking key material in ${file}..."
+        # We process the original file through the tool to ensure it has the
+        # same serialization (e.g. null extension handling) as the version
+        # with updated public keys we are about to generate.
+        ${OPENTITANTOOL}  --rcfile= image manifest update \
+          --private-keys-sign=false \
+          --output=/tmp/manifest_test_original.$$ \
+          ${file}
         ${OPENTITANTOOL}  --rcfile= image manifest update \
           --private-keys-sign=false \
           "${KEY_ARGS[@]}" \
           --output=/tmp/manifest_test_key_verify.$$ \
           ${file}
 
-    cmp ${file} /tmp/manifest_test_key_verify.$$
+    cmp /tmp/manifest_test_original.$$ /tmp/manifest_test_key_verify.$$
 
     if [[ $? -eq 0 ]]; then
       echo "ok."


### PR DESCRIPTION
The recent change to `opentitantool` (specifically `drop_null_extensions` behavior in #29097) altered how manifests are serialized. This caused `signature_test` to fail when comparing pre-existing signed binaries (generated with the old tool) against binaries re-generated by the test (using the new tool). Even if the keys were identical, the binary comparison failed due to differences in manifest extensions fields.

This commit updates `signature_test` to normalize the original binary by passing it through `opentitantool image manifest update` (without changes) before comparison. This ensures both the "original" and the "verified" binaries are serialized using the current tool's logic, allowing `cmp` to correctly verify that the keys match.