### PR TITLE
[otbn,doc] Extend ISR description with bit fields

### DIFF
--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -135,10 +135,36 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
             <tr><th>Bit</th><th>Description</th></tr>
           </thead>
           <tbody>
-            <tr><td>0</td><td>Carry of flag group 0</td></tr>
-            <tr><td>1</td><td>MSb of flag group 0</td></tr>
-            <tr><td>2</td><td>LSb of flag group 0</td></tr>
-            <tr><td>3</td><td>Zero of flag group 0</td></tr>
+            <tr>
+              <td>0</td>
+              <td>
+                Carry of flag group 0
+              </td>
+            </tr>
+            <tr>
+              <td>1</td>
+              <td>
+                MSb of flag group 0
+              </td>
+            </tr>
+            <tr>
+              <td>2</td>
+              <td>
+                LSb of flag group 0
+              </td>
+            </tr>
+            <tr>
+              <td>3</td>
+              <td>
+                Zero of flag group 0
+              </td>
+            </tr>
+            <tr>
+              <td>31:4</td>
+              <td>
+                Reserved. Always reads as 0. Any write is ignored.
+              </td>
+            </tr>
           </tbody>
         </table>
       </td>
@@ -156,10 +182,36 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
             <tr><th>Bit</th><th>Description</th></tr>
           </thead>
           <tbody>
-            <tr><td>0</td><td>Carry of flag group 1</td></tr>
-            <tr><td>1</td><td>MSb of flag group 1</td></tr>
-            <tr><td>2</td><td>LSb of flag group 1</td></tr>
-            <tr><td>3</td><td>Zero of flag group 1</td></tr>
+            <tr>
+              <td>0</td>
+              <td>
+                Carry of flag group 1
+              </td>
+            </tr>
+            <tr>
+              <td>1</td>
+              <td>
+                MSb of flag group 1
+              </td>
+            </tr>
+            <tr>
+              <td>2</td>
+              <td>
+                LSb of flag group 1
+              </td>
+            </tr>
+            <tr>
+              <td>3</td>
+              <td>
+                Zero of flag group 1
+              </td>
+            </tr>
+            <tr>
+              <td>31:4</td>
+              <td>
+                Reserved. Always reads as 0. Any write is ignored.
+              </td>
+            </tr>
           </tbody>
         </table>
       </td>
@@ -177,14 +229,60 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
             <tr><th>Bit</th><th>Description</th></tr>
           </thead>
           <tbody>
-            <tr><td>0</td><td>Carry of flag group 0</td></tr>
-            <tr><td>1</td><td>MSb of flag group 0</td></tr>
-            <tr><td>2</td><td>LSb of flag group 0</td></tr>
-            <tr><td>3</td><td>Zero of flag group 0</td></tr>
-            <tr><td>4</td><td>Carry of flag group 1</td></tr>
-            <tr><td>5</td><td>MSb of flag group 1</td></tr>
-            <tr><td>6</td><td>LSb of flag group 1</td></tr>
-            <tr><td>7</td><td>Zero of flag group 1</td></tr>
+            <tr>
+              <td>0</td>
+              <td>
+                Carry of flag group 0
+              </td>
+            </tr>
+            <tr>
+              <td>1</td>
+              <td>
+                MSb of flag group 0
+              </td>
+            </tr>
+            <tr>
+              <td>2</td>
+              <td>
+                LSb of flag group 0
+              </td>
+            </tr>
+            <tr>
+              <td>3</td>
+              <td>
+                Zero of flag group 0
+              </td>
+            </tr>
+            <tr>
+              <td>4</td>
+              <td>
+                Carry of flag group 1
+              </td>
+            </tr>
+            <tr>
+              <td>5</td>
+              <td>
+                MSb of flag group 1
+              </td>
+            </tr>
+            <tr>
+              <td>6</td>
+              <td>
+                LSb of flag group 1
+              </td>
+            </tr>
+            <tr>
+              <td>7</td>
+              <td>
+                Zero of flag group 1
+              </td>
+            </tr>
+            <tr>
+              <td>31:8</td>
+              <td>
+                Reserved. Always reads as 0. Any write is ignored.
+              </td>
+            </tr>
           </tbody>
         </table>
       </td>

--- a/hw/ip/otbn/data/csr.yml
+++ b/hw/ip/otbn/data/csr.yml
@@ -13,6 +13,7 @@
     1: MSb of flag group 0
     2: LSb of flag group 0
     3: Zero of flag group 0
+    31-4: Reserved. Always reads as 0. Any write is ignored.
 
 - name: fg1
   address: 0x7c1
@@ -25,6 +26,7 @@
     1: MSb of flag group 1
     2: LSb of flag group 1
     3: Zero of flag group 1
+    31-4: Reserved. Always reads as 0. Any write is ignored.
 
 - name: flags
   address: 0x7c8
@@ -41,6 +43,7 @@
     5: MSb of flag group 1
     6: LSb of flag group 1
     7: Zero of flag group 1
+    31-8: Reserved. Always reads as 0. Any write is ignored.
 
 - name: mod0
   address: 0x7d0

--- a/hw/ip/otbn/util/docs/md_isrs.py
+++ b/hw/ip/otbn/util/docs/md_isrs.py
@@ -9,7 +9,15 @@
 import argparse
 import os
 import sys
-from typing import List
+from typing import Dict, List
+
+# Ensure that the OpenTitan utils directory is on sys.path. This will allow us
+# to import serialize.parse_helpers.
+_OTBN_DIR = os.path.normpath(os.path.join(os.path.dirname(__file__), '../..'))
+_OT_DIR = os.path.normpath(os.path.join(_OTBN_DIR, '../../..'))
+_OT_UTIL_DIR = os.path.join(_OT_DIR, 'util')
+sys.path.append(_OT_UTIL_DIR)
+from serialize.parse_helpers import check_keys, check_str, check_int  # noqa: E402
 
 sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__),
                                               '../../util')))
@@ -24,6 +32,26 @@ def print_thead(indent: str, columns: List[str]) -> None:
         print(f'{indent}    <th>{column}</th>')
     print(f'{indent}  </tr>')
     print(f'{indent}</thead>')
+
+
+def validate_bits(name: str, bits: Dict[str, object]) -> None:
+    for idx, doc in bits.items():
+        # For the actual bit description, we expect either:
+        # - a string for a single bit or a field without values
+        # - a dict for a field with values
+        if not (isinstance(doc, str) or isinstance(doc, dict)):
+            raise ValueError(f'Invalid description format for bit {idx!r} in ISR {name!r}.')
+
+        # If it is a single bit or a field without values, there is nothing more to check.
+        # If we have a bit field with values, check it.
+        if isinstance(doc, dict):
+            doc = check_keys(doc, f'bit field {idx} of ISR {name!r}', ['doc', 'values'], [])
+            # Check the description and values format
+            check_str(doc['doc'], f'description of bit field {idx} of ISR {name!r}')
+            assert isinstance(doc['values'], dict)
+            for k, v in doc['values'].items():
+                check_int(k, f'value index of ISR {name!r}')
+                check_str(v, f'description of value {v} in bit field of ISR {name!r}')
 
 
 def print_isr(indent: str, isr: Isr, add_anchors: bool) -> None:
@@ -41,13 +69,44 @@ def print_isr(indent: str, isr: Isr, add_anchors: bool) -> None:
 
     doc_lines = isr.doc.splitlines()
     if isr.bits:
+        validate_bits(uc_name, isr.bits)
+
         doc_lines += ['<table>',
                       '  <thead>',
                       '    <tr><th>Bit</th><th>Description</th></tr>',
                       '  </thead>',
                       '  <tbody>']
-        for k, v in isr.bits.items():
-            doc_lines.append(f'    <tr><td>{k}</td><td>{v}</td></tr>')
+
+        bit_lines = []
+        for idx, doc in isr.bits.items():
+            idx_formatted = idx.replace("-", ":")
+            doc_raw = doc["doc"] if isinstance(doc, dict) else doc
+            doc_no_newlines = doc_raw.replace("\n", " ").strip()
+
+            bit_lines += ['<tr>']
+            if isinstance(doc, str):
+                # We have a single bit or a bit field without values
+                bit_lines += [f'  <td>{idx_formatted}</td>',
+                              '  <td>',
+                              f'    {doc_no_newlines}',
+                              '  </td>']
+            elif isinstance(doc, dict):
+                # We have a bit field with values
+                line_items = [f'<li>{value}: {desc}</li>' for value, desc in doc['values'].items()]
+
+                bit_lines += [f'  <td>{idx_formatted}</td>',
+                              '  <td>',
+                              f'    {doc_no_newlines}',
+                              '    <p>Values:</p><ul>']
+                bit_lines += [f'      {item}' for item in line_items]
+                bit_lines += ['    </ul>',
+                              '  </td>']
+            else:
+                raise ValueError(f'Invalid description format for bit {idx!r} in ISR {uc_name!r}.')
+            bit_lines += ['</tr>']
+
+        for bit in bit_lines:
+            doc_lines.append(' ' * 4 + bit)
         doc_lines += ['  </tbody>', '</table>']
 
     for line in doc_lines:


### PR DESCRIPTION
This extends the CSR/WSR description such that bit fields can be described. Previously only single bits could be described. This is useful for both, #29109 and #29025 as both changes will introduce CSRs with bitfields.

The CSR documentation looks now like this:
<img width="836" height="383" alt="image" src="https://github.com/user-attachments/assets/fdb4c72a-e175-4315-a265-ab4aa65b1db0" />

When there are values defined for the bitfields, it will look like this (This is a CSR from #29109, see [here](https://github.com/lowRISC/opentitan/pull/29109/changes#diff-89119be0044be096df62c14c90063bc916be067c4baede44500a3a35ff1430aaR109) for how the values are specified).
<img width="842" height="691" alt="image" src="https://github.com/user-attachments/assets/737aa9b8-21b6-4e39-955f-3a3b06a7ec9f" />

