### PR TITLE
Backport 27092 ([rom_ext] Advance the security version if requested)

### DIFF
--- a/rules/manifest.bzl
+++ b/rules/manifest.bzl
@@ -186,6 +186,21 @@ def _manifest_impl(ctx):
             },
         )
 
+    secver_write = ctx.attr.secver_write
+    if secver_write == "none":
+        # nothing to do
+        pass
+    elif secver_write in ("false", "true"):
+        mf["extension_params"].append(
+            {
+                "secver_write": {
+                    "secver_write": json.decode(secver_write),
+                },
+            },
+        )
+    else:
+        fail("Unknown value for secver_write:", secver_write)
+
     if ctx.attr.isfb_erase_allowed_policy:
         mf["extension_params"].append(
             {
@@ -229,6 +244,7 @@ _manifest = rule(
         "extensions": attr.string_list(doc = "Names of the manifest extensions as an array of strings"),
         "integrator_specific_firmware_binding": attr.string(doc = "Create an Integrator Specific Firmware Block (ISFB) JSON object"),
         "isfb_erase_allowed_policy": attr.string(doc = "Create an ISFB Erase Allowed Policy JSON object"),
+        "secver_write": attr.string(default = "none", values = ["none", "false", "true"], doc = "Add the secver_write extension with the specified value"),
     },
 )
 

--- a/sw/device/silicon_creator/lib/manifest.c
+++ b/sw/device/silicon_creator/lib/manifest.c
@@ -48,3 +48,6 @@ extern rom_error_t manifest_ext_get_isfb(const manifest_t *manifest,
                                          const manifest_ext_isfb_t **isfb);
 extern rom_error_t manifest_ext_get_isfb_erase(
     const manifest_t *manifest, const manifest_ext_isfb_erase_t **isfb_erase);
+extern rom_error_t manifest_ext_get_secver_write(
+    const manifest_t *manifest,
+    const manifest_ext_secver_write_t **secver_write);

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -14,12 +14,27 @@ load(
     "SLOTS",
     "TEST_OWNER_CONFIGS",
 )
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "doc_files",
     srcs = glob(["**/*.md"]),
+)
+
+string_flag(
+    name = "secver_write",
+    build_setting_default = "false",
+    values = [
+        "false",
+        "true",
+    ],
+)
+
+config_setting(
+    name = "secver_write_true",
+    flag_values = {":secver_write": "true"},
 )
 
 cc_library(

--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -2,6 +2,13 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+def secver_write_selection():
+    """Return the secver_write value based on the configuration setting."""
+    return select({
+        "//sw/device/silicon_creator/rom_ext:secver_write_true": "true",
+        "//conditions:default": "false",
+    })
+
 # The ROM_EXT version number to encode into the manifest.
 # NOTE: the version numbers are integers, but have to be encoded as strings
 # because of how the bazel rule accepts attributes.

--- a/sw/device/silicon_creator/rom_ext/e2e/secver/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/secver/BUILD
@@ -1,0 +1,176 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:const.bzl", "CONST", "hex", "hex_digits")
+load("//rules:cross_platform.bzl", "dual_cc_library", "dual_inputs")
+load("//rules:linker.bzl", "ld_library")
+load("//rules:manifest.bzl", "manifest")
+load("//rules/opentitan:defs.bzl", "fpga_params", "opentitan_binary", "opentitan_test")
+load(
+    "//sw/device/silicon_creator/rom_ext:defs.bzl",
+    "ROM_EXT_VARIATIONS",
+    "ROM_EXT_VERSION",
+    "SLOTS",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+manifest(d = {
+    "name": "manifest0",
+    "identifier": hex(CONST.ROM_EXT),
+    "visibility": ["//visibility:public"],
+    "version_major": "0",
+    "version_minor": "0",
+    "security_version": "0",
+    "secver_write": "false",
+})
+
+manifest(d = {
+    "name": "manifest1",
+    "identifier": hex(CONST.ROM_EXT),
+    "visibility": ["//visibility:public"],
+    "version_major": "0",
+    "version_minor": "1",
+    "security_version": "1",
+    "secver_write": "true",
+})
+
+manifest(d = {
+    "name": "manifest2",
+    "identifier": hex(CONST.ROM_EXT),
+    "visibility": ["//visibility:public"],
+    "version_major": "0",
+    "version_minor": "2",
+    "security_version": "2",
+    "secver_write": "false",
+})
+
+manifest(d = {
+    "name": "manifest3",
+    "identifier": hex(CONST.ROM_EXT),
+    "visibility": ["//visibility:public"],
+    "version_major": "0",
+    "version_minor": "3",
+    "security_version": "3",
+    "secver_write": "true",
+})
+
+_TEST_ROM_EXTS = {
+    "0": {
+        "manifest": ":manifest0",
+    },
+    "1": {
+        "manifest": ":manifest1",
+    },
+    "2": {
+        "manifest": ":manifest2",
+    },
+    "3": {
+        "manifest": ":manifest3",
+    },
+}
+
+[
+    opentitan_binary(
+        name = "rom_ext_{}".format(name),
+        testonly = True,
+        ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
+        exec_env = [
+            "//hw/top_earlgrey:fpga_cw310",
+            "//hw/top_earlgrey:fpga_cw340",
+        ],
+        linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_virtual",
+        manifest = param["manifest"],
+        spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
+        transitive_features = [
+            "minsize",
+            "use_lld",
+        ],
+        deps = [
+            "//sw/device/lib/crt",
+            "//sw/device/silicon_creator/lib:manifest_def",
+            "//sw/device/silicon_creator/lib/ownership:test_owner",
+            "//sw/device/silicon_creator/lib/ownership/keys/fake",
+            "//sw/device/silicon_creator/lib/rescue:rescue_xmodem",
+            "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509",
+            "//sw/device/silicon_creator/rom_ext/imm_section:main_section_dice_x509_slot_virtual",
+        ],
+    )
+    for name, param in _TEST_ROM_EXTS.items()
+]
+
+opentitan_test(
+    name = "secver_write_test",
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+    },
+    fpga = fpga_params(
+        timeout = "moderate",
+        assemble = "{rom_ext}@0 {boot_test_a}@0x10000",
+        binaries = {
+            ":boot_test_slot_a": "boot_test_a",
+            ":boot_test_slot_b": "boot_test_b",
+            ":rom_ext_1": "rom_ext1",
+            ":rom_ext_2": "rom_ext2",
+            ":rom_ext_3": "rom_ext3",
+        },
+        changes_otp = True,
+        exit_success = "BFV:{}".format(hex_digits(CONST.BFV.BOOT_POLICY.ROLLBACK)),
+        rom_ext = ":rom_ext_0",
+        test_cmd = """
+            # First, assemble the additional images we'll need for this test.
+            --exec="image assemble -s 131072 --mirror=false -o fw1.bin {rom_ext1}@0 {boot_test_b}@0x10000"
+            --exec="image assemble -s 131072 --mirror=false -o fw2.bin {rom_ext2}@0 {boot_test_a}@0x10000"
+            --exec="image assemble -s 131072 --mirror=false -o fw3.bin {rom_ext3}@0 {boot_test_b}@0x10000"
+            --exec="transport init"
+            --exec="fpga clear-bitstream"
+            --exec="fpga load-bitstream {bitstream}"
+
+            # Bootstrap the initial version 0 into SlotA
+            --exec="bootstrap --clear-uart=true {firmware}"
+            --exec="console --non-interactive --exit-success='rom_ext_min_sec_ver = 0'"
+
+            # Rescue and update to SlotB.  We expect to update the secver.
+            --exec="rescue firmware --raw --slot=SlotB fw1.bin"
+            --exec="console --non-interactive --exit-success='rom_ext_min_sec_ver = 1'"
+
+            # Rescue and update to SlotA.  We expect NOT to update the secver.
+            --exec="rescue firmware --raw --slot=SlotA fw2.bin"
+            --exec="console --non-interactive --exit-success='rom_ext_min_sec_ver = 1'"
+
+            # Rescue and update to SlotB.  We expect to update the secver.
+            --exec="rescue firmware --raw --slot=SlotB fw3.bin"
+            --exec="console --non-interactive --exit-success='rom_ext_min_sec_ver = 3'"
+
+            # Finally, bootstrap back to version 0, which we expect NOT to work.
+            --exec="bootstrap --clear-uart=true {firmware}"
+            --exec="console --non-interactive --exit-success='{exit_success}' --timeout=10s"
+            no-op
+        """,
+    ),
+)
+
+[
+    opentitan_binary(
+        name = "boot_test_slot_{}".format(slot),
+        testonly = True,
+        srcs = ["//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test"],
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+            "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+        },
+        linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_{}".format(slot),
+        deps = [
+            "//sw/device/lib/base:status",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib:boot_log",
+            "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        ],
+    )
+    for slot in [
+        "a",
+        "b",
+    ]
+]

--- a/sw/device/silicon_creator/rom_ext/sival/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/BUILD
@@ -12,6 +12,7 @@ load(
     "ROM_EXT_VARIATIONS",
     "ROM_EXT_VERSION",
     "SLOTS",
+    "secver_write_selection",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -22,6 +23,7 @@ manifest(d = {
     "version_major": ROM_EXT_VERSION.MAJOR,
     "version_minor": ROM_EXT_VERSION.MINOR,
     "security_version": ROM_EXT_VERSION.SECURITY,
+    "secver_write": secver_write_selection(),
     "visibility": ["//visibility:private"],
 })
 


### PR DESCRIPTION
Backport #27092, depends on #29163.

**Important note:** this backport contains a fix for the test not present on the earlgrey_1.0.0. The test is linking `boot_test` for slot A but writing it to slot B. This works on the earlgrey_1.0.0, probably by pure chance, but not on master. This fix should be backported to earlgrey_1.0.0 @cfrantz 