### PR TITLE
Backport 27255 ([test] add test to print UJSON payload max sizes)

### DIFF
--- a/sw/device/lib/testing/json/provisioning_data.c
+++ b/sw/device/lib/testing/json/provisioning_data.c
@@ -4,3 +4,17 @@
 
 #define UJSON_SERDE_IMPL 1
 #include "sw/device/lib/testing/json/provisioning_data.h"
+
+/**
+ * Max sizes of the UJSON structs below when they are serialized.
+ *
+ * The are obtained by running the following FPGA test:
+ * bazel test --test_output=streamed \
+ *  //sw/device/silicon_creator/manuf/tests:ujson_msg_size_functest
+ */
+enum {
+  kSerdesSha256HashSerializedMaxSize = 98,
+  kLcTokenHashSerializedMaxSize = 52,
+  kManufCertgenInputsSerializedMaxSize = 210,
+  kPersoBlobSerializedMaxSize = 20535,
+};

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -550,3 +550,26 @@ alias(
     name = "multislot_empty_test_sim_dv",
     actual = "multislot_empty_test",
 )
+
+opentitan_test(
+    name = "ujson_msg_size_functest",
+    srcs = ["ujson_msg_size_functest.c"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw340_sival": None,
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+    },
+    fpga = fpga_params(
+        tags = ["manuf"],
+        test_cmd = """
+            --clear-bitstream
+            --bootstrap={firmware}
+        """,
+        test_harness = "//sw/host/tests/manuf/manuf_ujson_msg_size",
+    ),
+    deps = [
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/json:provisioning_data",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+    ],
+)

--- a/sw/device/silicon_creator/manuf/tests/ujson_msg_size_functest.c
+++ b/sw/device/silicon_creator/manuf/tests/ujson_msg_size_functest.c
@@ -1,0 +1,98 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "sw/device/lib/dif/dif_gpio.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/json/provisioning_data.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+/**
+ * Peripheral handles.
+ */
+static dif_gpio_t gpio;
+static dif_pinmux_t pinmux;
+
+/**
+ * ATE Indicator GPIOs.
+ */
+static const dif_gpio_pin_t kGpioPinSpiConsoleTxReady = 0;
+static const dif_gpio_pin_t kGpioPinSpiConsoleRxReady = 1;
+
+/**
+ * UJSON payloads.
+ */
+static serdes_sha256_hash_t sha256_hash_msg;
+static lc_token_hash_t lc_token_hash_msg;
+static manuf_certgen_inputs_t certgen_inputs_msg;
+static perso_blob_t perso_blob_msg;
+
+OTTF_DEFINE_TEST_CONFIG(
+        .console.type = kOttfConsoleSpiDevice,
+        .console.base_addr = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR,
+        .console.test_may_clobber = false, .console.putbuf_buffered = true,
+        .silence_console_prints = true, .console_tx_indicator.enable = true,
+        .console_tx_indicator.spi_console_tx_ready_mio = kDtPadIoa5,
+        .console_tx_indicator.spi_console_tx_ready_gpio =
+            kGpioPinSpiConsoleTxReady);
+
+static status_t peripheral_handles_init(void) {
+  TRY(dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR), &gpio));
+  TRY(dif_pinmux_init(mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR),
+                      &pinmux));
+  return OK_STATUS();
+}
+
+static status_t configure_ate_gpio_indicators(void) {
+  // IOA6 / GPIO4 is for SPI console RX ready signal.
+  TRY(dif_pinmux_output_select(
+      &pinmux, kTopEarlgreyPinmuxMioOutIoa6,
+      kTopEarlgreyPinmuxOutselGpioGpio0 + kGpioPinSpiConsoleRxReady));
+  // IOA5 / GPIO3 is for SPI console TX ready signal.
+  TRY(dif_pinmux_output_select(
+      &pinmux, kTopEarlgreyPinmuxMioOutIoa5,
+      kTopEarlgreyPinmuxOutselGpioGpio0 + kGpioPinSpiConsoleTxReady));
+  TRY(dif_gpio_output_set_enabled_all(&gpio, 0x3));  // Enable first 2 GPIOs.
+  TRY(dif_gpio_write_all(&gpio, /*write_val=*/0));   // Intialize all to 0.
+  return OK_STATUS();
+}
+
+static status_t send_ujson_msgs(ujson_t *uj) {
+  // Set all fields in each UJSON payload to the max value
+  memset(&sha256_hash_msg.data, UINT8_MAX, sizeof(sha256_hash_msg));
+  memset(&lc_token_hash_msg.hash, UINT8_MAX, sizeof(lc_token_hash_msg));
+  memset(&certgen_inputs_msg, UINT8_MAX, sizeof(certgen_inputs_msg));
+  memset(&perso_blob_msg.num_objs, UINT8_MAX, sizeof(perso_blob_msg.num_objs));
+  memset(&perso_blob_msg.next_free, UINT8_MAX,
+         sizeof(perso_blob_msg.next_free));
+  memset(&perso_blob_msg.body, UINT8_MAX, sizeof(perso_blob_msg.body));
+
+  // TX payloads to the host.
+  RESP_OK(ujson_serialize_serdes_sha256_hash_t, uj, &sha256_hash_msg);
+  RESP_OK(ujson_serialize_lc_token_hash_t, uj, &lc_token_hash_msg);
+  RESP_OK(ujson_serialize_manuf_certgen_inputs_t, uj, &certgen_inputs_msg);
+  RESP_OK(ujson_serialize_perso_blob_t, uj, &perso_blob_msg);
+
+  // RX payloads echoed back by host.
+  TRY(ujson_deserialize_serdes_sha256_hash_t(uj, &sha256_hash_msg));
+  TRY(ujson_deserialize_lc_token_hash_t(uj, &lc_token_hash_msg));
+  TRY(ujson_deserialize_manuf_certgen_inputs_t(uj, &certgen_inputs_msg));
+  TRY(ujson_deserialize_perso_blob_t(uj, &perso_blob_msg));
+
+  return OK_STATUS();
+};
+
+bool test_main(void) {
+  CHECK_STATUS_OK(peripheral_handles_init());
+  CHECK_STATUS_OK(configure_ate_gpio_indicators());
+  ujson_t uj = ujson_ottf_console();
+  CHECK_STATUS_OK(send_ujson_msgs(&uj));
+  return true;
+}

--- a/sw/host/tests/manuf/manuf_ujson_msg_size/BUILD
+++ b/sw/host/tests/manuf/manuf_ujson_msg_size/BUILD
@@ -1,0 +1,21 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "manuf_ujson_msg_size",
+    srcs = ["src/main.rs"],
+    deps = [
+        "//sw/host/opentitanlib",
+        "//sw/host/provisioning/ujson_lib",
+        "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+    ],
+)

--- a/sw/host/tests/manuf/manuf_ujson_msg_size/src/main.rs
+++ b/sw/host/tests/manuf/manuf_ujson_msg_size/src/main.rs
@@ -1,0 +1,75 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use anyhow::Result;
+//use arrayvec::ArrayVec;
+use clap::Parser;
+
+use opentitanlib::console::spi::SpiConsoleDevice;
+use opentitanlib::io::gpio::{PinMode, PullMode};
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
+use ujson_lib::provisioning_data::{LcTokenHash, ManufCertgenInputs, PersoBlob, SerdesSha256Hash};
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "20s")]
+    timeout: Duration,
+
+    /// Name of the SPI interface to connect to the OTTF console.
+    #[arg(long, default_value = "BOOTSTRAP")]
+    console_spi: String,
+
+    /// Name of the SPI interface to connect to the OTTF console.
+    #[arg(long, default_value = "IOA5")]
+    console_tx_indicator_pin: String,
+}
+
+fn main() -> Result<()> {
+    // Load bitstream and bootstrap test.
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    // Initialize the console.
+    let spi = transport.spi(&opts.console_spi)?;
+    let device_console_tx_ready_pin = &transport.gpio_pin(&opts.console_tx_indicator_pin)?;
+    device_console_tx_ready_pin.set_mode(PinMode::Input)?;
+    device_console_tx_ready_pin.set_pull_mode(PullMode::None)?;
+    let spi_console = SpiConsoleDevice::new(
+        &*spi,
+        Some(device_console_tx_ready_pin),
+        /*ignore_frame_num=*/ false,
+    )?;
+
+    // Receive the payloads from the device.
+    let sha256_hash = SerdesSha256Hash::recv(&spi_console, opts.timeout, /*quiet=*/ true)?;
+    let lc_token_hash = LcTokenHash::recv(&spi_console, opts.timeout, /*quiet=*/ true)?;
+    let certgen_inputs =
+        ManufCertgenInputs::recv(&spi_console, opts.timeout, /*quiet=*/ true)?;
+    let perso_blob = PersoBlob::recv(&spi_console, opts.timeout, /*quiet=*/ true)?;
+
+    // Send the payloads back to the device.
+    let sha256_hash_str = sha256_hash.send(&spi_console)?;
+    let lc_token_hash_str = lc_token_hash.send(&spi_console)?;
+    let certgen_inputs_str = certgen_inputs.send(&spi_console)?;
+    let perso_blob_str = perso_blob.send(&spi_console)?;
+
+    // Print UJSON payload sizes to the console.
+    println!("Sha256Hash Size:         {} bytes", sha256_hash_str.len());
+    println!("LcTokenHash Size:        {} bytes", lc_token_hash_str.len());
+    println!(
+        "ManufCertgenInputs Size: {} bytes",
+        certgen_inputs_str.len()
+    );
+    println!("PersoBlob Size:          {} bytes", perso_blob_str.len());
+
+    Ok(())
+}


### PR DESCRIPTION
Backport #27255, depends on https://github.com/lowRISC/opentitan/pull/29178, only review last commit