### PR TITLE
Backport 27235 ([opentitanlib] add option to ignore SPI console frame numbers)

### DIFF
--- a/sw/host/provisioning/cp/src/main.rs
+++ b/sw/host/provisioning/cp/src/main.rs
@@ -50,7 +50,11 @@ fn main() -> Result<()> {
     let device_console_tx_ready_pin = &transport.gpio_pin(&opts.console_tx_indicator_pin)?;
     device_console_tx_ready_pin.set_mode(PinMode::Input)?;
     device_console_tx_ready_pin.set_pull_mode(PullMode::None)?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi, Some(device_console_tx_ready_pin))?;
+    let spi_console_device = SpiConsoleDevice::new(
+        &*spi,
+        Some(device_console_tx_ready_pin),
+        /*ignore_frame_num=*/ false,
+    )?;
 
     let provisioning_data = ManufCpProvisioningData {
         wafer_auth_secret: hex_string_to_u32_arrayvec::<8>(

--- a/sw/host/provisioning/ft/src/main.rs
+++ b/sw/host/provisioning/ft/src/main.rs
@@ -129,7 +129,11 @@ fn main() -> Result<()> {
     let device_console_tx_ready_pin = &transport.gpio_pin(&opts.console_tx_indicator_pin)?;
     device_console_tx_ready_pin.set_mode(PinMode::Input)?;
     device_console_tx_ready_pin.set_pull_mode(PullMode::None)?;
-    let spi_console = SpiConsoleDevice::new(&*spi, Some(device_console_tx_ready_pin))?;
+    let spi_console = SpiConsoleDevice::new(
+        &*spi,
+        Some(device_console_tx_ready_pin),
+        /*ignore_frame_num=*/ false,
+    )?;
     InitializeTest::print_result(
         "load_bitstream",
         opts.init.load_bitstream.init(&transport).map(|_| None),

--- a/sw/host/tests/chip/ottf_console_with_gpio_tx_indicator/src/main.rs
+++ b/sw/host/tests/chip/ottf_console_with_gpio_tx_indicator/src/main.rs
@@ -42,7 +42,11 @@ fn spi_device_console_test(opts: &Opts, transport: &TransportWrapper) -> Result<
     let device_console_tx_ready_pin = &transport.gpio_pin("IOA5")?;
     device_console_tx_ready_pin.set_mode(PinMode::Input)?;
     device_console_tx_ready_pin.set_pull_mode(PullMode::None)?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi, Some(device_console_tx_ready_pin))?;
+    let spi_console_device = SpiConsoleDevice::new(
+        &*spi,
+        Some(device_console_tx_ready_pin),
+        /*ignore_frame_num=*/ false,
+    )?;
 
     // Load the ELF binary and get the expect data.
     let elf_binary = fs::read(&opts.firmware_elf)?;

--- a/sw/host/tests/chip/spi_device_ottf_console/src/main.rs
+++ b/sw/host/tests/chip/spi_device_ottf_console/src/main.rs
@@ -45,7 +45,7 @@ fn spi_device_console_test(opts: &Opts, transport: &TransportWrapper) -> Result<
     );
     let spi = transport.spi(&opts.console_spi)?;
 
-    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None, /*ignore_frame_num=*/ false)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     /* Load the ELF binary and get the expect data.*/

--- a/sw/host/tests/chip/spi_device_ujson_console_test/src/main.rs
+++ b/sw/host/tests/chip/spi_device_ujson_console_test/src/main.rs
@@ -109,7 +109,7 @@ fn main() -> Result<()> {
 
     let transport = opts.init.init_target()?;
     let spi = transport.spi(&opts.console_spi)?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None, /*ignore_frame_num=*/ false)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     execute_test!(test_perso_blob_strcut, &opts, &spi_console_device);

--- a/sw/host/tests/crypto/acvp/src/main.rs
+++ b/sw/host/tests/crypto/acvp/src/main.rs
@@ -68,7 +68,7 @@ fn run<R: std::io::Read, W: std::io::Write>(
     output: Option<W>,
 ) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None, /*ignore_frame_num=*/ false)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     let acvp_vectors: Vec<AcvpVectors> = serde_json::from_reader(input)?;

--- a/sw/host/tests/crypto/aes_gcm_nist_kat/src/main.rs
+++ b/sw/host/tests/crypto/aes_gcm_nist_kat/src/main.rs
@@ -137,7 +137,7 @@ fn run_aes_gcm_testcase(
 
 fn test_aes_gcm(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None, /*ignore_frame_num=*/ false)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;

--- a/sw/host/tests/crypto/aes_nist_kat/src/main.rs
+++ b/sw/host/tests/crypto/aes_nist_kat/src/main.rs
@@ -130,7 +130,7 @@ fn run_aes_testcase(
 
 fn test_aes(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None, /*ignore_frame_num=*/ false)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;

--- a/sw/host/tests/crypto/drbg_kat/src/main.rs
+++ b/sw/host/tests/crypto/drbg_kat/src/main.rs
@@ -128,7 +128,7 @@ fn run_drbg_testcase(
 
 fn test_drbg(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None, /*ignore_frame_num=*/ false)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;

--- a/sw/host/tests/crypto/ecdh_kat/src/main.rs
+++ b/sw/host/tests/crypto/ecdh_kat/src/main.rs
@@ -220,7 +220,7 @@ fn run_ecdh_testcase(
 
 fn test_ecdh(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None, /*ignore_frame_num=*/ false)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;

--- a/sw/host/tests/crypto/ecdsa_kat/src/main.rs
+++ b/sw/host/tests/crypto/ecdsa_kat/src/main.rs
@@ -511,7 +511,7 @@ fn run_ecdsa_testcase(
 
 fn test_ecdsa(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None, /*ignore_frame_num=*/ false)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;

--- a/sw/host/tests/crypto/hash_kat/src/main.rs
+++ b/sw/host/tests/crypto/hash_kat/src/main.rs
@@ -158,7 +158,7 @@ fn run_hash_testcase(
 
 fn test_hash(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None, /*ignore_frame_num=*/ false)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;

--- a/sw/host/tests/crypto/hmac_kat/src/main.rs
+++ b/sw/host/tests/crypto/hmac_kat/src/main.rs
@@ -126,7 +126,7 @@ fn run_hmac_testcase(
 
 fn test_hmac(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None, /*ignore_frame_num=*/ false)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;

--- a/sw/host/tests/crypto/kmac_kat/src/main.rs
+++ b/sw/host/tests/crypto/kmac_kat/src/main.rs
@@ -141,7 +141,7 @@ fn run_kmac_testcase(
 
 fn test_kmac(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None, /*ignore_frame_num=*/ false)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;

--- a/sw/host/tests/crypto/rsa_kat/src/main.rs
+++ b/sw/host/tests/crypto/rsa_kat/src/main.rs
@@ -238,7 +238,7 @@ fn run_rsa_testcase(
 
 fn test_rsa(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None, /*ignore_frame_num=*/ false)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     let test_vector_files = &opts.rsa_json;

--- a/sw/host/tests/crypto/sphincsplus_kat/src/main.rs
+++ b/sw/host/tests/crypto/sphincsplus_kat/src/main.rs
@@ -126,7 +126,7 @@ fn run_sphincsplus_testcase(
 
 fn test_sphincsplus(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None, /*ignore_frame_num=*/ false)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
 
     let mut test_counter = 0u32;

--- a/sw/host/tests/manuf/cp_provision_functest/src/main.rs
+++ b/sw/host/tests/manuf/cp_provision_functest/src/main.rs
@@ -228,7 +228,11 @@ fn main() -> Result<()> {
     let device_console_tx_ready_pin = &transport.gpio_pin(&opts.console_tx_indicator_pin)?;
     device_console_tx_ready_pin.set_mode(PinMode::Input)?;
     device_console_tx_ready_pin.set_pull_mode(PullMode::None)?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi, Some(device_console_tx_ready_pin))?;
+    let spi_console_device = SpiConsoleDevice::new(
+        &*spi,
+        Some(device_console_tx_ready_pin),
+        /*ignore_frame_num=*/ false,
+    )?;
 
     // Transition from RAW to TEST_UNLOCKED0.
     unlock_raw(&transport, &opts.init.jtag_params)?;


### PR DESCRIPTION
Backport #27235. Depends on #29173 and #29167, only review last commit