### PR TITLE
[bazel] Modify Bazel configs to support OpenTitan being a nonroot module (backport)

### DIFF
--- a/rules/BUILD
+++ b/rules/BUILD
@@ -2,16 +2,11 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules/opentitan:defs.bzl", "OPENTITAN_PLATFORM")
-load("//rules:stamp.bzl", "stamp_flag")
 load("//rules:autogen.bzl", "autogen_stamp_include")
+load("//rules:stamp.bzl", "stamp_flag")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_PLATFORM")
 
 package(default_visibility = ["//visibility:public"])
-
-config_setting(
-    name = "opentitan_platform",
-    values = {"platforms": OPENTITAN_PLATFORM},
-)
 
 # See stamp.bzl for explanation.
 stamp_flag(name = "stamp_flag")

--- a/rules/cross_platform.bzl
+++ b/rules/cross_platform.bzl
@@ -22,7 +22,7 @@ def _merge_and_split_inputs(inputs):
 
 def dual_cc_library(
         name,
-        on_device_config_setting = "//rules:opentitan_platform",
+        on_device_config_setting = "//toolchain:on_device_config",
         srcs = [],
         hdrs = [],
         copts = [],

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -6,8 +6,8 @@ load("@rules_cc//cc/toolchains:actions.bzl", "cc_action_type")
 load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
 load("@rules_cc//cc/toolchains:args_list.bzl", "cc_args_list")
 load("@rules_cc//cc/toolchains:feature.bzl", "cc_feature")
-load("@rules_cc//cc/toolchains:feature_set.bzl", "cc_feature_set")
 load("@rules_cc//cc/toolchains:feature_constraint.bzl", "cc_feature_constraint")
+load("@rules_cc//cc/toolchains:feature_set.bzl", "cc_feature_set")
 load("@rules_cc//cc/toolchains:toolchain.bzl", "cc_toolchain")
 load("@rules_cc//cc/toolchains:tool_map.bzl", "cc_tool_map")
 load("//rules:actions.bzl", "OT_ACTION_LLVM_PROFDATA", "OT_ACTION_OBJDUMP")
@@ -19,7 +19,25 @@ platform(
     constraint_values = [
         "@platforms//cpu:riscv32",
         "@platforms//os:none",
+        ":device",
     ],
+)
+
+constraint_setting(name = "target")
+
+constraint_value(
+    name = "host",
+    constraint_setting = "target",
+)
+
+constraint_value(
+    name = "device",
+    constraint_setting = "target",
+)
+
+config_setting(
+    name = "on_device_config",
+    constraint_values = [":device"],
 )
 
 toolchain(


### PR DESCRIPTION
Manual backport of https://github.com/lowRISC/opentitan/pull/28144 (only one commit needed).

---

This change tweaks Bazel configs to support the repository's use as a nonroot Bazel module. Changes include

    Using absolute/explicit labels as opposed to relative
    Inlining include calls
    removing raw string comparisons of labels

Changes have been tested in a parent build environment.