### PR TITLE
[rescue, xmodem] Remove use of stdio.h

### DIFF
--- a/sw/device/silicon_creator/lib/rescue/rescue_xmodem.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue_xmodem.c
@@ -1,7 +1,6 @@
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-#include <stdio.h>
 
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/memory.h"


### PR DESCRIPTION
We don't link against libc, and including stdio.h prevents the use of a freestanding environment.