### PR TITLE
[otlib,rescue] Increase USBDFU enter delay

### DIFF
--- a/sw/host/opentitanlib/src/rescue/usbdfu.rs
+++ b/sw/host/opentitanlib/src/rescue/usbdfu.rs
@@ -29,7 +29,7 @@ impl UsbDfu {
             interface: Cell::default(),
             params,
             reset_delay: Duration::from_millis(50),
-            enter_delay: Duration::from_secs(5),
+            enter_delay: Duration::from_secs(20),
         }
     }
 


### PR DESCRIPTION
I have observed some very large delays in CI under heavy loads where it takes close to 10 seconds before the device is available in the container. See https://github.com/lowRISC/opentitan/pull/29177 (I have run the PR several times and printed the time it took until the device is available).
