### PR TITLE
[sw,cov] Fix gp in ISRs when coverage is enabled

### DIFF
--- a/sw/device/silicon_creator/rom/rom_isrs.c
+++ b/sw/device/silicon_creator/rom/rom_isrs.c
@@ -28,6 +28,15 @@ static rom_error_t rom_irq_error(void) {
 }
 
 void rom_interrupt_handler(void) {
+#ifdef OT_COVERAGE_INSTRUMENTED
+  // Fix gp first in case it's modified by later boot stages.
+  asm volatile(
+      ".option push\n"
+      ".option norelax\n"
+      "la gp, __global_pointer$\n"
+      ".option pop\n");
+#endif
+
   register rom_error_t error asm("a0") = rom_irq_error();
   asm volatile("tail shutdown_finalize;" ::"r"(error));
   OT_UNREACHABLE();

--- a/sw/device/silicon_creator/rom_ext/rom_ext_isrs.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_isrs.c
@@ -36,6 +36,15 @@ static rom_error_t rom_ext_irq_error(void) {
 
 OT_USED
 void rom_ext_interrupt_handler(void) {
+#ifdef OT_COVERAGE_INSTRUMENTED
+  // Fix gp first in case it's modified by later boot stages.
+  asm volatile(
+      ".option push\n"
+      ".option norelax\n"
+      "la gp, __global_pointer$\n"
+      ".option pop\n");
+#endif
+
   register rom_error_t error asm("a0") = rom_ext_irq_error();
   asm volatile("tail shutdown_finalize;" ::"r"(error));
   OT_UNREACHABLE();


### PR DESCRIPTION
When LLVM coverage is enabled, the compiler may use the global pointer (gp) to access coverage counters. However, in some tests, the later boot stages might have modified gp and trigger ISR before it reconfigure the vector table. For example, immutable section relies on ROM's shutdown ISR to reduce firmware size.

This commit ensures that gp is correctly restored at the beginning of the ROM and ROM_EXT interrupt handlers when coverage instrumentation is active.