### PR TITLE
[sw,cov] Update version banner for instrumented ROM

### DIFF
--- a/sw/device/lib/arch/device_fpga_cw305.c
+++ b/sw/device/lib/arch/device_fpga_cw305.c
@@ -61,9 +61,17 @@ const uintptr_t kDeviceLogBypassUartAddress = 0;
 void device_fpga_version_print(void) {
   // This value is guaranteed to be zero on all non-FPGA implementations.
   uint32_t fpga = ibex_fpga_version();
-  //                       : M O R
-  const uint32_t kRom = 0x3a4d4f52;
-  uart_write_imm(kRom);
+
+#ifdef OT_COVERAGE_INSTRUMENTED
+  // print("InsROM:")
+  //                  : M O R s n I
+  uart_write_imm(0x003a4d4f52736e49);
+#else
+  // print("ROM:")
+  //                        : M O R
+  uart_write_imm(0x000000003a4d4f52);
+#endif
+
   // The cast to unsigned int stops GCC from complaining about uint32_t
   // being a `long unsigned int` while the %x specifier takes `unsigned int`.
   const uint32_t kNewline = 0x0a0d;

--- a/sw/device/lib/arch/device_fpga_cw310.c
+++ b/sw/device/lib/arch/device_fpga_cw310.c
@@ -63,9 +63,17 @@ const uintptr_t kDeviceLogBypassUartAddress = 0;
 void device_fpga_version_print(void) {
   // This value is guaranteed to be zero on all non-FPGA implementations.
   uint32_t fpga = ibex_fpga_version();
-  //                       : M O R
-  const uint32_t kRom = 0x3a4d4f52;
-  uart_write_imm(kRom);
+
+#ifdef OT_COVERAGE_INSTRUMENTED
+  // print("InsROM:")
+  //                  : M O R s n I
+  uart_write_imm(0x003a4d4f52736e49);
+#else
+  // print("ROM:")
+  //                        : M O R
+  uart_write_imm(0x000000003a4d4f52);
+#endif
+
   // The cast to unsigned int stops GCC from complaining about uint32_t
   // being a `long unsigned int` while the %x specifier takes `unsigned int`.
   const uint32_t kNewline = 0x0a0d;

--- a/sw/device/lib/arch/device_fpga_cw340.c
+++ b/sw/device/lib/arch/device_fpga_cw340.c
@@ -65,9 +65,17 @@ const bool kJitterEnabled = false;
 void device_fpga_version_print(void) {
   // This value is guaranteed to be zero on all non-FPGA implementations.
   uint32_t fpga = ibex_fpga_version();
-  //                       : M O R
-  const uint32_t kRom = 0x3a4d4f52;
-  uart_write_imm(kRom);
+
+#ifdef OT_COVERAGE_INSTRUMENTED
+  // print("InsROM:")
+  //                  : M O R s n I
+  uart_write_imm(0x003a4d4f52736e49);
+#else
+  // print("ROM:")
+  //                        : M O R
+  uart_write_imm(0x000000003a4d4f52);
+#endif
+
   // The cast to unsigned int stops GCC from complaining about uint32_t
   // being a `long unsigned int` while the %x specifier takes `unsigned int`.
   const uint32_t kNewline = 0x0a0d;

--- a/sw/device/lib/arch/device_sim_qemu.c
+++ b/sw/device/lib/arch/device_sim_qemu.c
@@ -69,9 +69,17 @@ const uintptr_t kDeviceLogBypassUartAddress = 0;
 // Although QEMU isn't an FPGA, there's no harm in us printing the version here.
 void device_fpga_version_print(void) {
   uint32_t version = ibex_fpga_version();
-  //                       : M O R
-  const uint32_t kRom = 0x3a4d4f52;
-  uart_write_imm(kRom);
+
+#ifdef OT_COVERAGE_INSTRUMENTED
+  // print("InsROM:")
+  //                  : M O R s n I
+  uart_write_imm(0x003a4d4f52736e49);
+#else
+  // print("ROM:")
+  //                        : M O R
+  uart_write_imm(0x000000003a4d4f52);
+#endif
+
   // The cast to unsigned int stops GCC from complaining about uint32_t
   // being a `long unsigned int` while the %x specifier takes `unsigned int`.
   const uint32_t kNewline = 0x0a0d;


### PR DESCRIPTION
When the ROM is instrumented for coverage, the UART banner is updated to prefix the version with "InsROM:" rather than the standard "ROM:". This enables clear identification of instrumented ROM execution in the test logs.

This change has no effect on normal builds.