### PR TITLE
[cov,rom] Add coverage reporting and invalidation

### DIFF
--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -161,6 +161,8 @@ cc_library(
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:stdasm",
+        "//sw/device/lib/coverage:api",
+        "//sw/device/lib/coverage:uart_runtime",
         "//sw/device/lib/crt",
         "//sw/device/lib/runtime:hart",
         "//sw/device/silicon_creator/lib:boot_log",

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -15,6 +15,7 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/stdasm.h"
+#include "sw/device/lib/coverage/api.h"
 #include "sw/device/silicon_creator/lib/base/boot_measurements.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/base/static_critical_version.h"
@@ -677,10 +678,17 @@ static rom_error_t rom_boot(const manifest_t *manifest,
   stack_utilization_print();
 
   if (imm_section_entry_point != kHardenedBoolFalse) {
+    coverage_report();
+    coverage_invalidate();
     ((rom_ext_entry_point *)imm_section_entry_point)();
+    coverage_init();  // re-init after invalidate.
   }
+
   // Jump to ROM_EXT.
+  coverage_report();
+  coverage_invalidate();
   ((rom_ext_entry_point *)entry_point)();
+  coverage_init();  // re-init after invalidate.
   return kErrorRomBootFailed;
 }
 


### PR DESCRIPTION
This change adds calls to `coverage_report()` and `coverage_invalidate()` before jumping to the ROM_EXT in `rom_boot` to collect code coverage from instrumented ROM. It also re-initializes coverage after the jump returns (if applicable).

Under normal builds, these `coverage_*` functions will be removed by C-preprocessor. The mask ROM hashes remain the same before and after this PR.