### PR TITLE
Backport 27400 ([sw,tests] Cleanup various nits in the OTTF dual console test)

### DIFF
--- a/sw/device/tests/ottf_dual_console_test.c
+++ b/sw/device/tests/ottf_dual_console_test.c
@@ -13,7 +13,9 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 /**
- * Tests ...
+ * Test the ability to have several independent consoles. The main
+ * console is connected to the "console" UART and a secondary console
+ * is created which is connected to the "dut" UART.
  */
 
 OTTF_DEFINE_TEST_CONFIG();
@@ -24,7 +26,7 @@ static ottf_console_t debug_console;
 bool test_main(void) {
   CHECK_DIF_OK(dif_pinmux_init(
       mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
-  CHECK_STATUS_OK(uart_testutils_select_pinmux(&pinmux, /* UART */ 1,
+  CHECK_STATUS_OK(uart_testutils_select_pinmux(&pinmux, /* uart= */ 1,
                                                kUartPinmuxChannelDut));
   ottf_console_configure_uart(&debug_console, TOP_EARLGREY_UART1_BASE_ADDR);
   LOG_INFO("Main UART console");

--- a/sw/host/tests/chip/ottf_dual_console/BUILD
+++ b/sw/host/tests/chip/ottf_dual_console/BUILD
@@ -17,7 +17,5 @@ rust_binary(
         "@crate_index//:clap",
         "@crate_index//:humantime",
         "@crate_index//:log",
-        "@crate_index//:object",
-        "@crate_index//:regex",
     ],
 )


### PR DESCRIPTION
Backport #27400. Depends on #29187, only review last commit.