### PR TITLE
[ci] Merge merge-blocker jobs into one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,6 +430,11 @@ jobs:
       - chip_earlgrey_cw310_hyperdebug
       - chip_earlgrey_cw340
     steps:
+      - name: Skipped message
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          echo ":information_source: Bitstream caching is skipped for this pull request job" \
+            >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/checkout@v4
         if: ${{ github.event_name != 'pull_request' }}
       - name: Prepare environment


### PR DESCRIPTION
We currently need two "merge blocker" jobs because the PR one is gated on `quick_lint` and the merge queue is gated on uploading bitstreams. Uploading bitstreams is skipped entirely on PRs, so we can't use the same dependency/job on both triggers.

Instead of skipping the bitstream upload job on pull requests, skip all of its steps instead. This allows the job to still run and complete on pull requests even though it won't do anything.

The two merge blockers can then be merged as it's okay for them to have the same dependency in both pull requests and merge queues.