### PR TITLE
[git] Add .venv/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ opentitan-docs
 
 # Python
 __pycache__
+.venv/
 
 # fusesoc result
 build/


### PR DESCRIPTION
Adds Python virtual environment directory to .gitignore to prevent accidental commits.

Fixes: #29169 