### PR TITLE
[ownership] Use empty config in parser instead of default config

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/owner_block.c
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.c
@@ -188,10 +188,7 @@ rom_error_t owner_block_rescue_check(const owner_rescue_config_t *rescue) {
   return kErrorOk;
 }
 
-// This weak function allows downstream ROM_EXT builds to provide
-// sku-specific default config.
-OT_WEAK
-void owner_config_default(owner_config_t *config) {
+void owner_config_clear(owner_config_t *config) {
   // Use a bogus pointer value to avoid the all-zeros pattern of NULL.
   config->flash = (const owner_flash_config_t *)kHardenedBoolFalse;
   config->info = (const owner_flash_info_config_t *)kHardenedBoolFalse;
@@ -199,6 +196,13 @@ void owner_config_default(owner_config_t *config) {
   config->isfb = (const owner_isfb_config_t *)kHardenedBoolFalse;
   config->sram_exec = kOwnerSramExecModeDisabledLocked;
   config->boot_svc_after_wakeup = kHardenedBoolFalse;
+}
+
+// This weak function allows downstream ROM_EXT builds to provide
+// sku-specific default config.
+OT_WEAK
+void owner_config_default(owner_config_t *config) {
+  owner_config_clear(config);
 }
 
 rom_error_t owner_block_parse(const owner_block_t *block,
@@ -213,7 +217,7 @@ rom_error_t owner_block_parse(const owner_block_t *block,
     return kErrorOwnershipOWNRVersion;
 
   if (check_only == kHardenedBoolFalse) {
-    owner_config_default(config);
+    owner_config_clear(config);
     config->sram_exec = block->sram_exec_mode;
     config->boot_svc_after_wakeup = block->boot_svc_after_wakeup;
   }

--- a/sw/device/silicon_creator/lib/ownership/owner_block.h
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.h
@@ -87,13 +87,20 @@ hardened_bool_t owner_block_newversion_mode(void);
 hardened_bool_t owner_block_page1_valid_for_transfer(boot_data_t *bootdata);
 
 /**
- * Initialize the owner config with default values.
+ * Clear all settings in the owner config.
  *
  * The sram_exec mode is set to DisabledLocked and the three configuration
  * pointers are set to kHardenedBoolFalse.
  *
- * The default implementation is weak and can be overridden for SKU-specific
- * defaults.
+ * @param config A pointer to a config struct holding pointers to config items.
+ */
+void owner_config_clear(owner_config_t *config);
+
+/**
+ * Initialize the owner config with default fallback values.
+ *
+ * The default implementation calls `owner_config_clear`, and is weak so it can
+ * be overridden for SKU-specific defaults.
  *
  * @param config A pointer to a config struct holding pointers to config items.
  */

--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -266,4 +266,45 @@ TEST_OWNER_CONFIGS = {
         ],
         "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_xmodem"],
     },
+    "custom_fallback_owner": {
+        "owner_defines": [
+            # Enable fallback default owner override.
+            "WITH_FALLBACK_OWNER=1",
+            # 0x53 is 'S'pi.
+            "WITH_RESCUE_PROTOCOL=0x53",
+            # Trigger 3 is GPIO pin.
+            "WITH_RESCUE_TRIGGER=3",
+            # When the trigger is GPIO, the index is the MuxedPad to us as the sense
+            # input. Index 2 is kTopEarlgreyMuxedPadsIoa2.
+            "WITH_RESCUE_INDEX=2",
+            # GPIO param 3 means enable the internal pull resistor and trigger
+            # rescue when the GPIO is high.
+            "WITH_RESCUE_MISC_GPIO_PARAM=3",
+            # Timeout: 0x80=enter_on_fail, 0x05 = 5 seconds.
+            "WITH_RESCUE_TIMEOUT=0x85",
+        ],
+        "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_spidfu"],
+    },
+    "fault_to_fallback_owner": {
+        "owner_defines": [
+            # Fault to skip parsing owner blocks.
+            # (e.g. simulating boot data corruption)
+            "TEST_FAULT_NO_OWNER=1",
+            # Enable fallback default owner override.
+            "WITH_FALLBACK_OWNER=1",
+            # 0x53 is 'S'pi.
+            "WITH_RESCUE_PROTOCOL=0x53",
+            # Trigger 3 is GPIO pin.
+            "WITH_RESCUE_TRIGGER=3",
+            # When the trigger is GPIO, the index is the MuxedPad to us as the sense
+            # input. Index 2 is kTopEarlgreyMuxedPadsIoa2.
+            "WITH_RESCUE_INDEX=2",
+            # GPIO param 3 means enable the internal pull resistor and trigger
+            # rescue when the GPIO is high.
+            "WITH_RESCUE_MISC_GPIO_PARAM=3",
+            # No timeout.
+            "WITH_RESCUE_TIMEOUT=0",
+        ],
+        "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_spidfu"],
+    },
 }

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -70,6 +70,23 @@ _CONFIGS = {
         "setup": "--exec=\"gpio set --mode OpenDrain Ioa2\"",
         "tags": [],
     },
+    "spidfu_custom_fallback_owner": {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_custom_fallback_owner",
+        # Use spi-dfu, trigger with GPIO IOA2 high.
+        "params": "-p spi-dfu -t gpio -v +Ioa2",
+        "setup": "--exec=\"gpio set --mode OpenDrain Ioa2\"",
+        "tags": [],
+    },
+}
+
+_FAULT_CONFIG = {
+    "spidfu_fault_to_fallback_owner": {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_fault_to_fallback_owner",
+        # Use spi-dfu, trigger with GPIO IOA2 high.
+        "params": "-p spi-dfu -t gpio -v +Ioa2",
+        "setup": "--exec=\"gpio set --mode OpenDrain Ioa2\"",
+        "tags": [],
+    },
 }
 
 [
@@ -634,7 +651,7 @@ opentitan_test(
             test_harness = "//sw/host/tests/rescue:rescue_test",
         ),
     )
-    for protocol, config in _CONFIGS.items()
+    for protocol, config in (_CONFIGS | _FAULT_CONFIG).items()
 ]
 
 [


### PR DESCRIPTION
The `owner_block_parse` function should start with an empty configuration rather than the default configuration due to its duplicated item checks.
https://github.com/lowRISC/opentitan/blob/299b97ac2f81409e33f5764c740acf4987996e3d/sw/device/silicon_creator/lib/ownership/owner_block.c#L280-L285

This change introduces `owner_config_clear` which initializes the `owner_config_t` struct with safe, bogus values, and redirect other `owner_config_default` calls to `owner_config_clear` to maintain consistent initialization. (except the one that loads the default config)

This allows us to override the default config with the hook introduced in #29127 
* #29127