### PR TITLE
[pentest] Fix fw override rng

### DIFF
--- a/sw/host/penetrationtests/python/fi/host_scripts/fi_rng_functions.py
+++ b/sw/host/penetrationtests/python/fi/host_scripts/fi_rng_functions.py
@@ -74,19 +74,18 @@ def char_entropy_bias(target, iterations, reset = False):
     return response
 
 
-def char_fw_overwrite(target, iterations, disable_health_check):
+def char_fw_overwrite(target, iterations, disable_health_check, reset = False):
     rngfi = OTFIRng(target)
-
-    for _ in range(iterations):
+    if reset:
         target.reset_target()
         # Clear the output from the reset
         target.dump_all()
-
-        # Initialize our chip and catch its output
-        device_id, sensors, alerts, owner_page, boot_log, boot_measurements, version = (
-            rngfi.init("char_fw_overwrite",
-                       alert_config=common_library.default_fpga_friendly_alert_config)
-        )
+    # Initialize our chip and catch its output
+    device_id, sensors, alerts, owner_page, boot_log, boot_measurements, version = (
+        rngfi.init("char_fw_overwrite",
+                   alert_config=common_library.default_fpga_friendly_alert_config)
+    )
+    for _ in range(iterations):
         rngfi.rng_fw_overwrite(disable_health_check)
         response = target.read_response()
     return response


### PR DESCRIPTION
Fix the fi rng test of using fw override. The test would only work more than once in case the device is reset in between. Instead, we re-initialize the fw override every call (we would like consecutive bits so we stop the fifo after every call).
There was also a bug causing stack overflow by asking for bits in a for loop whereas the full buffer was filled in a single loop.


(cherry picked from commit 7f481298d7bdf68837c3f67247380818f99940b6)