### PR TITLE
[otlib] Fix typo

### DIFF
--- a/sw/host/opentitanlib/src/otp/alert_handler.rs
+++ b/sw/host/opentitanlib/src/otp/alert_handler.rs
@@ -316,7 +316,7 @@ impl AlertRegs {
 }
 
 trait Crc32Add {
-    fn crc32_add(self, diegst: &mut Digest<u32>);
+    fn crc32_add(self, digest: &mut Digest<u32>);
 }
 
 impl Crc32Add for u32 {


### PR DESCRIPTION
Mergeback from https://github.com/lowRISC/opentitan/pull/29097, the other commits are already here.