### PR TITLE
[otbn,smoke] Make smoke test independent of REPO_TOP

### DIFF
--- a/hw/ip/otbn/dv/smoke/run_smoke.sh
+++ b/hw/ip/otbn/dv/smoke/run_smoke.sh
@@ -15,24 +15,26 @@ set -o pipefail
 set -e
 
 SCRIPT_DIR="$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")"
-UTIL_DIR="$(readlink -e "$SCRIPT_DIR/../../../../../util")" || \
+ROOT_DIR="$(readlink -e "$SCRIPT_DIR/../../../../..")" || \
+  fail "Can't find OpenTitan root dir"
+UTIL_DIR="$(readlink -e "$ROOT_DIR/util")" || \
   fail "Can't find OpenTitan util dir"
 
 source "$UTIL_DIR/build_consts.sh"
 
 SMOKE_BIN_DIR=$BIN_DIR/otbn/smoke_test
-SMOKE_SRC_DIR=$REPO_TOP/hw/ip/otbn/dv/smoke
+SMOKE_SRC_DIR=$ROOT_DIR/hw/ip/otbn/dv/smoke
 
 mkdir -p $SMOKE_BIN_DIR
 
-OTBN_UTIL=$REPO_TOP/hw/ip/otbn/util
+OTBN_UTIL=$ROOT_DIR/hw/ip/otbn/util
 
 $OTBN_UTIL/otbn_as.py -o $SMOKE_BIN_DIR/smoke_test.o $SMOKE_SRC_DIR/smoke_test.s || \
     fail "Failed to assemble smoke_test.s"
 $OTBN_UTIL/otbn_ld.py -o $SMOKE_BIN_DIR/smoke.elf $SMOKE_BIN_DIR/smoke_test.o || \
     fail "Failed to link smoke_test.o"
 
-(cd $REPO_TOP;
+(cd $ROOT_DIR;
  fusesoc --cores-root=. run --target=sim --setup --build \
     --mapping=lowrisc:prim_generic:all:0.1 lowrisc:ip:otbn_top_sim \
     --make_options="-j$(nproc)" || fail "HW Sim build failed")
@@ -43,7 +45,7 @@ readonly RUN_LOG
 trap "rm -rf $RUN_LOG" EXIT
 
 timeout 5s \
-  $REPO_TOP/build/lowrisc_ip_otbn_top_sim_0.1/sim-verilator/Votbn_top_sim \
+  $ROOT_DIR/build/lowrisc_ip_otbn_top_sim_0.1/sim-verilator/Votbn_top_sim \
   --load-elf=$SMOKE_BIN_DIR/smoke.elf -t | tee $RUN_LOG
 
 if [ $? -eq 124 ]; then


### PR DESCRIPTION
This makes the OTBN smoke test script independent of the REPO_TOP environment variable. This is helpful when one has multiple clones of the OpenTitan repo.