### PR TITLE
[ast] split ast os to power domains

### DIFF
--- a/hw/top_earlgrey/data/clocks.xdc
+++ b/hw/top_earlgrey/data/clocks.xdc
@@ -10,7 +10,7 @@ create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports IO_
 create_generated_clock -name clk_main [get_pin clkgen/pll/CLKOUT0]
 create_generated_clock -name clk_usb_48 [get_pin clkgen/pll/CLKOUT1]
 create_generated_clock -name clk_aon [get_pin clkgen/pll/CLKOUT4]
-set clk_io_pin [get_pin u_ast/u_ast_clks_byp/u_no_scan_clk_src_io_d1ord2/u_clk_div_buf/gen_fpga_buf.gen_bufg.bufg_i/O]
+set clk_io_pin [get_pin u_ast/u_ast_main/u_ast_clks_byp_main/u_no_scan_clk_src_io_d1ord2/u_clk_div_buf/gen_fpga_buf.gen_bufg.bufg_i/O]
 create_generated_clock -name clk_io -divide_by 1 -add \
     -master_clock [get_clocks clk_main] \
     -source [get_pins clkgen/pll/CLKOUT0] \
@@ -35,7 +35,7 @@ set u_div4 top_*/u_clkmgr_aon/u_no_scan_io_div4_div
 create_generated_clock -name clk_io_div4 -divide_by 4 -source [get_pins ${u_div4}/gen_div.clk_int_reg/C] [get_pins ${u_div4}/gen_div.clk_int_reg/Q]
 
 
-set ast_src_io u_ast/u_ast_clks_byp/u_no_scan_clk_src_io_d1ord2
+set ast_src_io u_ast/u_ast_main/u_ast_clks_byp_main/u_no_scan_clk_src_io_d1ord2
 #create_generated_clock -name clk_src_io -divide_by 1 -source [get_pins ${u_pll}/CLKOUT0] \
 #  [get_pins ${ast_src_io}/gen_div2.u_div2/q_o[0]]
 
@@ -324,7 +324,7 @@ set_multicycle_path -hold -end -from [get_clocks clk_spi_tpm] \
 
 ## The usb calibration handling inside ast is assumed to be async to the outside world
 ## even though its interface is also a usb clock.
-set_false_path -from ${clks_48_unbuf} -to [get_pins u_ast/u_usb_clk/u_ref_pulse_sync/u_sync*/u_sync_1/q_o_reg[0]/D]
+set_false_path -from ${clks_48_unbuf} -to [get_pins u_ast/u_ast_main/u_usb_clk/u_ref_pulse_sync/u_sync*/u_sync_1/q_o_reg[0]/D]
 
 ## USB input delay to accommodate T_FST (full-speed transition time) and the
 ## PHY's sampling logic. The PHY expects to only see up to one transient / fake

--- a/hw/top_earlgrey/data/clocks_cw341.xdc
+++ b/hw/top_earlgrey/data/clocks_cw341.xdc
@@ -17,13 +17,13 @@ create_generated_clock -name clk_aon [get_pin clkgen/pll/CLKOUT4]
 # invalid combinations.
 # The 48 MHz ext clocks all have a _lc suffix.
 create_generated_clock -name clk_io -divide_by 1 \
-    -source [get_pins u_ast/u_ast_clks_byp/u_no_scan_clk_src_io_d1ord2/gen_div_bufg.u_bufg_div_stepdown/I] \
-    [get_pins u_ast/u_ast_clks_byp/u_no_scan_clk_src_io_d1ord2/gen_div_bufg.u_bufg_div_stepdown/O]
+    -source [get_pins u_ast/u_ast_main/u_ast_clks_byp_main/u_no_scan_clk_src_io_d1ord2/gen_div_bufg.u_bufg_div_stepdown/I] \
+    [get_pins u_ast/u_ast_main/u_ast_clks_byp_main/u_no_scan_clk_src_io_d1ord2/gen_div_bufg.u_bufg_div_stepdown/O]
 
 set u_div2 top_*/u_clkmgr_aon/u_no_scan_io_div2_div
 create_generated_clock -name clk_io_div2 -divide_by 2 \
     -add -master_clock clk_io \
-    -source [get_pins u_ast/u_ast_clks_byp/u_no_scan_clk_src_io_d1ord2/gen_div_bufg.u_bufg_div_mux/O] \
+    -source [get_pins u_ast/u_ast_main/u_ast_clks_byp_main/u_no_scan_clk_src_io_d1ord2/gen_div_bufg.u_bufg_div_mux/O] \
     [get_pins ${u_div2}/gen_div_bufg.u_bufg_div_full/O]
 set_clock_sense -stop_propagation -clocks clk_io \
     [get_pins ${u_div2}/gen_div_bufg.u_bufg_div_stepdown/I]
@@ -32,19 +32,19 @@ set_clock_sense -stop_propagation -clocks clk_io \
 set u_div4 top_*/u_clkmgr_aon/u_no_scan_io_div4_div
 create_generated_clock -name clk_io_div4 -divide_by 4 \
     -add -master_clock clk_io \
-    -source [get_pins u_ast/u_ast_clks_byp/u_no_scan_clk_src_io_d1ord2/gen_div_bufg.u_bufg_div_mux/O] \
+    -source [get_pins u_ast/u_ast_main/u_ast_clks_byp_main/u_no_scan_clk_src_io_d1ord2/gen_div_bufg.u_bufg_div_mux/O] \
     [get_pins ${u_div4}/gen_div_bufg.u_bufg_div_full/O]
 set_clock_sense -stop_propagation -clocks clk_io \
     [get_pins ${u_div4}/gen_div_bufg.u_bufg_div_stepdown/I]
 
 
 create_generated_clock -name clk_io_ext_lc -divide_by 2 \
-    -source [get_pins u_ast/u_ast_clks_byp/u_no_scan_clk_src_io_d1ord2/gen_div_bufg.u_bufg_div_full/I] \
-    [get_pins u_ast/u_ast_clks_byp/u_no_scan_clk_src_io_d1ord2/gen_div_bufg.u_bufg_div_full/O]
+    -source [get_pins u_ast/u_ast_main/u_ast_clks_byp_main/u_no_scan_clk_src_io_d1ord2/gen_div_bufg.u_bufg_div_full/I] \
+    [get_pins u_ast/u_ast_main/u_ast_clks_byp_main/u_no_scan_clk_src_io_d1ord2/gen_div_bufg.u_bufg_div_full/O]
 
 create_generated_clock -name clk_io_div2_ext_lc -divide_by 1 \
     -add -master_clock clk_io_ext_lc \
-    -source [get_pins u_ast/u_ast_clks_byp/u_no_scan_clk_src_io_d1ord2/gen_div_bufg.u_bufg_div_mux/O] \
+    -source [get_pins u_ast/u_ast_main/u_ast_clks_byp_main/u_no_scan_clk_src_io_d1ord2/gen_div_bufg.u_bufg_div_mux/O] \
     [get_pins ${u_div2}/gen_div_bufg.u_bufg_div_stepdown/O]
 
 set_clock_sense -stop_propagation -clocks clk_io_ext_lc \
@@ -52,7 +52,7 @@ set_clock_sense -stop_propagation -clocks clk_io_ext_lc \
 
 create_generated_clock -name clk_io_div4_ext_lc -divide_by 2 \
     -add -master_clock clk_io_ext_lc \
-    -source [get_pins u_ast/u_ast_clks_byp/u_no_scan_clk_src_io_d1ord2/gen_div_bufg.u_bufg_div_mux/O] \
+    -source [get_pins u_ast/u_ast_main/u_ast_clks_byp_main/u_no_scan_clk_src_io_d1ord2/gen_div_bufg.u_bufg_div_mux/O] \
     [get_pins ${u_div4}/gen_div_bufg.u_bufg_div_stepdown/O]
 
 set_clock_sense -stop_propagation -clocks clk_io_ext_lc \
@@ -350,4 +350,4 @@ set_multicycle_path -hold -end -from [get_clocks clk_spi_tpm] \
 
 ## The usb calibration handling inside ast is assumed to be async to the outside world
 ## even though its interface is also a usb clock.
-set_false_path -from [get_clocks clk_usb_48] -to [get_pins u_ast/u_usb_clk/u_ref_pulse_sync/u_sync*/u_sync_1/q_o_reg[0]/D]
+set_false_path -from [get_clocks clk_usb_48] -to [get_pins u_ast/u_ast_main/u_usb_clk/u_ref_pulse_sync/u_sync*/u_sync_1/q_o_reg[0]/D]

--- a/hw/top_earlgrey/dv/env/ast_ext_clk_if.sv
+++ b/hw/top_earlgrey/dv/env/ast_ext_clk_if.sv
@@ -15,11 +15,11 @@ interface ast_ext_clk_if ();
   // This task returns once the external clock has gone through an active cycle.
   // Notice it will fail if the active cycle has already started.
   task automatic span_external_clock_active_window();
-    `DV_WAIT(u_ast.u_ast_clks_byp.u_io_clk_byp_en.out_o == 1'b1,
+    `DV_WAIT(u_ast.u_ast_main.u_ast_clks_byp_main.u_io_clk_byp_en.out_o == 1'b1,
                  "Took too long to enable external clock", WaitForExctClkSelChangeInNs,
                  "ast_ext_clk_if")
     `uvm_info("ast_ext_clk_if", "External clk became active for io clk", UVM_MEDIUM)
-    `DV_WAIT(u_ast.u_ast_clks_byp.u_io_clk_byp_en.out_o == 1'b0,
+    `DV_WAIT(u_ast.u_ast_main.u_ast_clks_byp_main.u_io_clk_byp_en.out_o == 1'b0,
                  "Took too long to disable external clock", WaitForExctClkSelChangeInNs,
                  "ast_ext_clk_if")
     `uvm_info("ast_ext_clk_if", "External clk back to inactive for io clk", UVM_MEDIUM)
@@ -27,7 +27,7 @@ interface ast_ext_clk_if ();
 
   // Returns 1 if the external clock is in use.
   function automatic logic is_ext_clk_in_use();
-    return u_ast.u_ast_clks_byp.u_io_clk_byp_en.out_o;
+    return u_ast.u_ast_main.u_ast_clks_byp_main.u_io_clk_byp_en.out_o;
   endfunction
 
 endinterface : ast_ext_clk_if

--- a/hw/top_earlgrey/dv/env/ast_supply_if.sv
+++ b/hw/top_earlgrey/dv/env/ast_supply_if.sv
@@ -36,7 +36,7 @@ interface ast_supply_if (
   localparam int MioInSysrstCtrlAonKey0In = 46;
 
   function static void force_vcaon_pok(bit value);
-    force u_ast.u_rglts_pdm_3p3v.vcaon_pok_h_o = value;
+    force u_ast.u_ast_aon.u_rglts_pdm_3p3v.vcaon_pok_h_o = value;
   endfunction
 
   // Create glitch in vcaon_pok_h_o some cycles after this is invoked. Hold vcaon_pok_h_o low for

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -700,14 +700,14 @@ interface chip_if;
 
   wire flash_core1_host_req = `FLASH_CTRL_HIER.u_eflash.gen_flash_cores[1].u_core.host_req_i;
 `endif
-  wire adc_data_valid = `AST_HIER.u_adc.adc_d_val_o;
+  wire adc_data_valid = `AST_HIER.u_ast_aon.u_adc.adc_d_val_o;
 
   task static force_adc_d_o(input bit [9:0] channel_val);
-    force `AST_HIER.adc_d_o = channel_val;
+    force `AST_HIER.u_ast_aon.adc_d_o = channel_val;
   endtask
 
   task static release_adc_d_o();
-    release `AST_HIER.adc_d_o;
+    release `AST_HIER.u_ast_aon.adc_d_o;
   endtask
 
   // This task triggers a wakeup by forcing an incoming alert from AST to sensor_ctrl.

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq.sv
@@ -7,9 +7,9 @@ class chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq extends chip_sw_base_vseq;
 
   `uvm_object_new
 
-  localparam string ADC_CHANNEL_OUT_HDL_PATH = "tb.dut.u_ast.adc_d_o[9:0]";
-  localparam string ADC_DATA_VALID = "tb.dut.u_ast.adc_d_val_o";
-  localparam string ADC_POWERDOWN = "tb.dut.u_ast.adc_pd_i";
+  localparam string ADC_CHANNEL_OUT_HDL_PATH = "tb.dut.u_ast.u_ast_aon.adc_d_o[9:0]";
+  localparam string ADC_DATA_VALID = "tb.dut.u_ast.u_ast_aon.adc_d_val_o";
+  localparam string ADC_POWERDOWN = "tb.dut.u_ast.u_ast_aon.adc_pd_i";
 
   localparam string ADC_CTRL_WAKEUP_REQ = "tb.dut.top_earlgrey_pd_aon.u_pwrmgr_aon.wakeups_i[1]";
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_ast_clk_rst_inputs_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_ast_clk_rst_inputs_vseq.sv
@@ -7,11 +7,11 @@ class chip_sw_ast_clk_rst_inputs_vseq extends chip_sw_base_vseq;
 
   `uvm_object_new
 
-  localparam string ADC_CHANNEL_OUT_HDL_PATH = "tb.dut.u_ast.adc_d_o[9:0]";
-  localparam string ADC_CHANNEL_IN_SEL_HDL_PATH = "tb.dut.u_ast.adc_chnsel_i[1:0]";
+  localparam string ADC_CHANNEL_OUT_HDL_PATH = "tb.dut.u_ast.u_ast_aon.adc_d_o[9:0]";
+  localparam string ADC_CHANNEL_IN_SEL_HDL_PATH = "tb.dut.u_ast.u_ast_aon.adc_chnsel_i[1:0]";
 
-  localparam string ADC_DATA_VALID = "tb.dut.u_ast.adc_d_val_o";
-  localparam string ADC_POWERDOWN = "tb.dut.u_ast.adc_pd_i";
+  localparam string ADC_DATA_VALID = "tb.dut.u_ast.u_ast_aon.adc_d_val_o";
+  localparam string ADC_POWERDOWN = "tb.dut.u_ast.u_ast_aon.adc_pd_i";
   localparam string ADC_CTRL_WAKEUP_REQ = "tb.dut.top_earlgrey_pd_aon.u_pwrmgr_aon.wakeups_i[1]";
   localparam uint NUM_ADC_CHANNELS = 2;
   localparam uint NUM_LOW_POWER_SAMPLES = 3;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq.sv
@@ -6,8 +6,8 @@ class chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq extends chip_sw_base_vseq;
   `uvm_object_utils(chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq)
   `uvm_object_new
 
-  localparam string ADC_CHANNEL_OUT_HDL_PATH = "tb.dut.u_ast.adc_d_o[9:0]";
-  localparam string ADC_CHANNEL_IN_SEL_HDL_PATH = "tb.dut.u_ast.adc_chnsel_i[1:0]";
+  localparam string ADC_CHANNEL_OUT_HDL_PATH = "tb.dut.u_ast.u_ast_aon.adc_d_o[9:0]";
+  localparam string ADC_CHANNEL_IN_SEL_HDL_PATH = "tb.dut.u_ast.u_ast_aon.adc_chnsel_i[1:0]";
 
   event adc_valid_rising_edge_event;
   event adc_channel1_event;

--- a/hw/top_earlgrey/ip/ast/ast.core
+++ b/hw/top_earlgrey/ip/ast/ast.core
@@ -4,7 +4,6 @@ CAPI=2:
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:systems:top_earlgrey_ast:0.1"
 description: "Analog Sensor Top generic views"
-
 filesets:
   files_rtl:
     depend:
@@ -18,8 +17,8 @@ filesets:
       - lowrisc:prim:lfsr
       - lowrisc:earlgrey_ip:pinmux_pkg
       - lowrisc:prim:assert
+      - lowrisc:prim:prim_pkg
       - lowrisc:prim:mubi
-      - lowrisc:prim:multibit_sync
       - lowrisc:prim:multibit_sync
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:ip:edn_pkg
@@ -27,11 +26,14 @@ filesets:
       - lowrisc:earlgrey_ip:clkmgr_pkg
       - lowrisc:earlgrey_ip:rstmgr_pkg
       - lowrisc:systems:top_earlgrey_ast_pkg
-      - lowrisc:prim:prim_pkg
     files:
       - rtl/ast_reg_pkg.sv
+      - rtl/ast_pkg.sv
       - rtl/ast_bhv_pkg.sv
+      - rtl/ast_aon_main_pkg.sv
       - rtl/ast.sv
+      - rtl/ast_aon.sv
+      - rtl/ast_main.sv
       - rtl/ast_reg_top.sv
       - rtl/adc.sv
       - rtl/adc_ana.sv
@@ -49,7 +51,8 @@ filesets:
       - rtl/usb_clk.sv
       - rtl/usb_osc.sv
       - rtl/gfr_clk_mux2.sv
-      - rtl/ast_clks_byp.sv
+      - rtl/ast_clks_byp_aon.sv
+      - rtl/ast_clks_byp_main.sv
       - rtl/rglts_pdm_3p3v.sv
       - rtl/ast_pulse_sync.sv
       - rtl/ast_entropy.sv

--- a/hw/top_earlgrey/ip/ast/data/ast.hjson
+++ b/hw/top_earlgrey/ip/ast/data/ast.hjson
@@ -12,9 +12,9 @@
   dv_doc:             "",
   hw_checklist:       "",
   sw_checklist:       "",
-  version:            "1.0.0",
+  version:            "2.0.0",
   life_stage:         "L1",
-  design_stage:       "D2",
+  design_stage:       "D1",
   verification_stage: "V2S",
   dif_stage:          "",
   clocking: [

--- a/hw/top_earlgrey/ip/ast/lint/ast.vlt
+++ b/hw/top_earlgrey/ip/ast/lint/ast.vlt
@@ -9,9 +9,9 @@
 // ast_clks_byp.sv has an always_latch block which doesn't actually do anything
 // because the enable signal (!scan_mode_i) is always true. Verilator notices
 // and complains, but we're doing this on purpose.
-lint_off -rule NOLATCH -file "*/rtl/ast_clks_byp.sv"
+lint_off -rule NOLATCH -file "*/rtl/ast_clks_byp_main.sv"
 
 // Manually mark a clock enable: if we don't tell Verilator we're doing it on
 // purpose, it will warn us that there's a path from "normal" logic through to
 // a clock signal.
-clock_enable -module "ast_clks_byp" -var "clk_ext_en"
+clock_enable -module "ast_clks_byp_main" -var "clk_ext_en"

--- a/hw/top_earlgrey/ip/ast/lint/ast.waiver
+++ b/hw/top_earlgrey/ip/ast/lint/ast.waiver
@@ -4,12 +4,12 @@
 #
 # waiver file for ast
 
-waive -rules CONST_FF -location {ast_clks_byp.sv} \
+waive -rules CONST_FF -location {ast_clks_byp_main.sv} \
       -msg {Flip-flop 'sw_clk_byp_en' is driven by constant one} \
       -comment {This flip flop is supposed to change to 1 on the first clock cycle and remain there afterwards.}
 
-waive -rules IFDEF_CODE -location {ast.sv} \
-      -msg {Assignment to 'ast2pad_t0_ao' contained within `else block at ast.sv} \
+waive -rules IFDEF_CODE -location {ast_aon.sv} \
+      -msg {Assignment to 'ast2pad_t0_ao' contained within `else block at} \
       -comment {This ifdef statement is used for analog simulations and is OK.}
 
 waive -rules IFDEF_CODE -location {ast.sv} \
@@ -32,7 +32,7 @@ waive -rules IFDEF_CODE -location {aon_osc.sv} \
       -regexp {Assignment to 'clk' contained within} \
       -comment {This ifdef statement is fine as it is part of the FPGA/Verilator clock bypass mechanism.}
 
-waive -rules DUAL_EDGE_CLOCK -location {ast_clks_byp.sv} \
+waive -rules DUAL_EDGE_CLOCK -location {ast_clks_byp_main.sv} \
       -msg {Clock 'clk_ast_ext_scn' uses falling edge here and rising edge 'clk_i' at} \
       -comment {Posedge sync aon_clk reset to clk_ast_ext_scn while negedge drives the sw_clk_byp_en.}
 
@@ -40,75 +40,91 @@ waive -rules CLOCK_EDGE -location {aon_osc.sv io_osc.sv sys_osc.sv usb_osc.sv} \
       -msg {Falling edge of clock 'clk' used here, should use rising edge} \
       -comment {This negedge trigger is done on purpose.}
 
-waive -rules CLOCK_EDGE -location {ast_clks_byp.sv} \
+waive -rules CLOCK_EDGE -location {ast_clks_byp_main.sv} \
       -msg {Falling edge of clock 'clk_ast_ext_scn' used here, should use rising edge} \
       -comment {This negedge trigger is done on purpose.}
 
-waive -rules CLOCK_EDGE -location {ast_clks_byp.sv} \
+waive -rules CLOCK_EDGE -location {ast_clks_byp_main.sv} \
       -msg {'prim_flop_2sync' instance 'u_no_scan_ext_freq_is_96m_sync' contained within `ifndef 'AST_BYPASS_CLK' block at} \
       -comment {This ifdef statement is fine as it is part of the FPGA/Verilator clock bypass mechanism.}
 
-waive -rules CLOCK_DRIVER -location {ast.sv} \
-      -regexp {'clk_src_(aon|io|sys|usb)' is driven by instance 'u_ast_clks_byp' of module 'ast_clks_byp', and used as a clock 'clk_i' at} \
+waive -rules CLOCK_DRIVER -location {ast_main.sv} \
+      -regexp {'clk_src_(io|sys|usb)' is driven by instance 'u_ast_clks_byp_main' of module 'ast_clks_byp_main', and used as a clock 'clk_i' at} \
       -comment {This is clock generation logic, hence it needs to drive this clock signal.}
 
-waive -rules CLOCK_DRIVER -location {ast.sv} \
-      -regexp {'clk_src_(aon|io|sys)' in module 'ast_clks_byp' by port} \
+waive -rules CLOCK_DRIVER -location {ast_aon.sv} \
+      -regexp {'clk_src_aon' is driven by instance 'u_ast_clks_byp_aon' of module 'ast_clks_byp_aon', and used as a clock 'clk_i' at} \
       -comment {This is clock generation logic, hence it needs to drive this clock signal.}
 
-waive -rules CLOCK_DRIVER -location {ast.sv} \
+waive -rules CLOCK_DRIVER -location {ast_main.sv} \
+      -regexp {'clk_src_(io|sys)' in module 'ast_clks_byp_main' by port} \
+      -comment {This is clock generation logic, hence it needs to drive this clock signal.}
+
+waive -rules CLOCK_DRIVER -location {ast_aon.sv} \
+      -regexp {'clk_src_aon' in module 'ast_clks_byp_aon' by port} \
+      -comment {This is clock generation logic, hence it needs to drive this clock signal.}
+
+waive -rules CLOCK_DRIVER -location {ast_main.sv} \
       -msg {'clk_o' driven in module 'gfr_clk_mux2' at} \
       -comment {This is clock generation logic, hence it needs to drive this clock signal.}
 
-waive -rules CLOCK_DRIVER -location {ast_clks_byp.sv} \
+waive -rules CLOCK_DRIVER -location {ast_aon.sv} \
       -msg {'clk_o' driven in module 'gfr_clk_mux2' at} \
       -comment {This is clock generation logic, hence it needs to drive this clock signal.}
 
-waive -rules CLOCK_DRIVER -location {ast_clks_byp.sv} \
-      -regexp {'clk_src_(aon|io)_o' is driven by instance 'u_clk_src_(aon|io)_sel' of module 'gfr_clk_mux2', and used as a clock 'clk_i' at} \
+waive -rules CLOCK_DRIVER -location {ast_clks_byp_main.sv} \
+      -regexp {'clk_src_io_o' is driven by instance 'u_clk_src_io_sel' of module 'gfr_clk_mux2', and used as a clock 'clk_i' at} \
       -comment {This is clock generation logic, hence it needs to drive this clock signal.}
 
-waive -rules CLOCK_DRIVER -location {ast_clks_byp.sv} \
+waive -rules CLOCK_DRIVER -location {ast_clks_byp_aon.sv} \
+      -regexp {'clk_src_aon' is driven by instance 'u_clk_src_aon_sel' of module 'gfr_clk_mux2', and used as a clock 'clk_i' at} \
+      -comment {This is clock generation logic, hence it needs to drive this clock signal.}
+
+waive -rules CLOCK_DRIVER -location {ast_clks_byp_main.sv} \
       -regexp {'clk_src_io' is driven by instance 'u_clk_src_io_sel' of module 'gfr_clk_mux2', and used as a clock 'clk_i' at} \
       -comment {This is clock generation logic, hence it needs to drive this clock signal.}
 
-waive -rules CLOCK_DRIVER -location {ast_clks_byp.sv} \
+waive -rules CLOCK_DRIVER -location {ast_clks_byp_main.sv} \
       -regexp {'clk_ext_scn' is driven here, and used as a clock 'clk_i' at} \
       -comment {This is clock generation logic, hence it needs to drive this clock signal.}
 
-waive -rules CLOCK_MUX -location {ast_clks_byp.sv} \
-      -regexp {Clock '(clk_ast_ext_scn|clk_ext_scn|clk_src_ext_usb|clk_ext_aon)' is driven by a multiplexer here, used as a clock} \
+waive -rules CLOCK_MUX -location {ast_clks_byp_main.sv} \
+      -regexp {Clock '(clk_ast_ext_scn|clk_ext_scn|clk_src_ext_usb|clks_byp_main_to_aon.clk_ext_aon)' is driven by a multiplexer here, used as a clock} \
       -comment {This is clock generation logic, hence it needs to drive this clock signal.}
 
-waive -rules CLOCK_MUX -location {ast_clks_byp.sv} \
-      -regexp {Clock 'clk_ast_ext' reaches a multiplexer here, used as a clock} \
+waive -rules CLOCK_MUX -location {ast_clks_byp_main.sv} \
+      -regexp {Clock 'clk_ast_ext|clk_src_ext_usb' reaches a multiplexer here, used as a clock} \
       -comment {This is clock generation logic, hence it needs to drive this clock signal.}
 
-waive -rules IFDEF_CODE -location {ast_clks_byp.sv} \
-      -regexp {Assignment to 'clk_ast_ext_scn' contained within `ifndef 'AST_BYPASS_CLK' block at} \
+waive -rules CLOCK_MUX -location {ast_main.sv} \
+      -regexp {Clock 'clk_osc_sys' reaches a multiplexer here, used as a clock} \
+      -comment {This is clock generation logic, hence it needs to drive this clock signal.}
+
+waive -rules IFDEF_CODE -location {ast_clks_byp_main.sv} \
+      -regexp {Assignment to 'clk_ast_ext_scn' contained within `else block at} \
       -comment {This ifndef statement is fine as it is part of the FPGA/Verilator clock bypass mechanism.}
 
-waive -rules IFDEF_CODE -location {ast_clks_byp.sv} \
+waive -rules IFDEF_CODE -location {ast_clks_byp_main.sv} \
       -regexp {Assignment to 'clk_ext_scn' contained within `else block at} \
       -comment {This ifndef statement is fine as it is part of the FPGA/Verilator clock bypass mechanism.}
 
-waive -rules IFDEF_CODE -location {ast_clks_byp.sv} \
+waive -rules IFDEF_CODE -location {ast_clks_byp_main.sv} \
       -regexp {Assignment to 'clk_src_io_val_o' contained within `ifndef 'AST_BYPASS_CLK' block at} \
       -comment {This ifndef statement is fine as it is part of the FPGA/Verilator clock bypass mechanism.}
 
-waive -rules IFDEF_CODE -location {ast_clks_byp.sv} \
-      -regexp {'prim_clock_div' instance 'u_no_scan_clk_(ext_d1ord2|usb_div240_div)' contained within `ifndef 'AST_BYPASS_CLK' block at} \
+waive -rules IFDEF_CODE -location {ast_clks_byp_main.sv} \
+      -regexp {'prim_clock_div' instance 'u_no_scan_clk_(ext_d1ord2|usb_div240_div)' contained within `else block at} \
       -comment {This ifndef statement is fine as it is part of the FPGA/Verilator clock bypass mechanism.}
 
-waive -rules IFDEF_CODE -location {ast_clks_byp.sv} \
-      -regexp {'prim_flop_2sync' instance 'u_no_scan_ext_freq_is_96m_sync' contained within `ifndef 'AST_BYPASS_CLK' block at} \
+waive -rules IFDEF_CODE -location {ast_clks_byp_main.sv} \
+      -regexp {'prim_flop_2sync' instance 'u_no_scan_ext_freq_is_96m_sync' contained within `else block at} \
       -comment {This ifndef statement is fine as it is part of the FPGA/Verilator clock bypass mechanism.}
 
-waive -rules IFDEF_CODE -location {ast_clks_byp.sv} \
-      -regexp {always_latch block contained within `ifndef 'AST_BYPASS_CLK' block at} \
+waive -rules IFDEF_CODE -location {ast_clks_byp_main.sv} \
+      -regexp {always_latch block contained within `else block at} \
       -comment {This ifndef statement is fine as it is part of the FPGA/Verilator clock bypass mechanism.}
 
-waive -rules CLOCK_MUX -location {ast.sv} \
+waive -rules CLOCK_MUX -location {ast_aon.sv} \
       -regexp {Clock 'clk_aon_n' is driven by a multiplexer here, used as a clock} \
       -comment {This clock inverter has a DFT mux.}
 
@@ -120,23 +136,39 @@ waive -rules CLOCK_USE -location {gfr_clk_mux2.sv} \
       -regexp {('clk_ext'|'clk_osc') is used for some other purpose, and as clock ('clk_ext_i'|'clk_osc_i') at gfr_clk_mux2.sv} \
       -comment {This message pops up due to a clock OR operation.}
 
-waive -rules CLOCK_USE -location {ast.sv} \
+waive -rules CLOCK_USE -location {ast_aon.sv} \
       -regexp {'clk_ast_tlul_i' is connected to 'ast_dft' port 'clk_i', and used as a clock 'clk_i' at prim_lfsr} \
       -comment {This is a valid clock signal and the LFSR runs on the bus clock here.}
 
-waive -rules CLOCK_USE -location {ast.sv} \
+waive -rules CLOCK_USE -location {ast_main.sv} \
+      -regexp {'aon_to_main_i.clk_rst.clk_ast_tlul' is connected to 'ast_clks_byp_main' port 'clk_ast_tlul_i', and used as a clock} \
+      -comment {This is a valid clock signal and the LFSR runs on the bus clock here.}
+
+waive -rules CLOCK_USE -location {ast_aon.sv} \
       -regexp {'clk_aon' is connected to 'rglts_pdm_3p3v' port 'clk_src_aon_h_i', and used as a clock} \
       -comment {This is a valid clock signal and the connection is ok here.}
 
 waive -rules CLOCK_USE -location {ast.sv} \
+      -regexp {'clk_ast_ext_i' is connected to 'ast_aon' port 'clk_ast_ext_i', and used as a clock} \
+      -comment {This is a valid clock signal and the connection is ok here.}
+
+waive -rules CLOCK_USE -location {ast.sv} \
+      -regexp {'clk_ast_usb_i' is connected to 'ast_aon' port 'clk_ast_usb_i', and used as a clock} \
+      -comment {This is a valid clock signal and the connection is ok here.}
+
+waive -rules CLOCK_USE -location {ast_main.sv} \
       -regexp {'clk_ast_usb_i' is used for some other purpose, and as clock 'clk_i' at prim_flop.sv} \
+      -comment {This is a valid clock signal and the connection is ok here.}
+
+waive -rules CLOCK_USE -location {ast_clks_byp_main.sv} \
+      -regexp {'clk_ast_ext_i' is used for some other purpose, and as clock 'clk_i' at prim_flop.sv} \
       -comment {This is a valid clock signal and the connection is ok here.}
 
 waive -rules INV_CLOCK -location {ast.sv rglts_pdm_3p3v.sv} \
       -regexp {'(clk_aon|clk_src_aon_h_i)' is inverted, used as clock} \
       -comment {These clocks are inverted.}
 
-waive -rules INV_CLOCK -location {ast_clks_byp.sv} \
+waive -rules INV_CLOCK -location {ast_clks_byp_main.sv} \
       -regexp {'clk_src_ext_usb' is inverted, used as clock 'clk_i'} \
       -comment {Needed to sample clk_src_ext_usb enable signal with the clock negedge.}
 
@@ -152,23 +184,24 @@ waive -rules RESET_DRIVER -location {rng.sv} \
       -msg {'rst_n' is driven here, and used as an asynchronous reset at rng.sv} \
       -comment {This is reset generation logic, hence it needs to drive this reset signal.}
 
-waive -rules RESET_DRIVER -location {ast.sv} \
-      -regexp {'(vcaon_pok_h|por_rst_n|vcmain_pok_por|vcmain_pok_por_src)' is driven here, and used as an asynchronous reset} \
-      -comment {This is reset generation logic, hence it needs to drive this reset signal.}
+#TODO update
+#  waive -rules RESET_DRIVER -location {ast.sv} \
+#        -regexp {'(vcaon_pok_h|por_rst_n|vcmain_pok_por|vcmain_pok_por_src)' is driven here, and used as an asynchronous reset} \
+#        -comment {This is reset generation logic, hence it needs to drive this reset signal.}
 
-waive -rules RESET_DRIVER -location {ast.sv} \
+waive -rules RESET_DRIVER -location {ast_main.sv} \
       -msg {'clk_io_osc_val' is driven by instance 'u_io_clk' of module 'io_clk', and used as an asynchronous reset 'rst_clk_osc_n' at ast_dft.sv} \
       -comment {This is reset generation logic, hence it needs to drive this reset signal.}
 
-waive -rules RESET_DRIVER -location {ast.sv} \
+waive -rules RESET_DRIVER -location {ast_main.sv} \
       -msg {'clk_src_io_val_o' driven in module 'io_clk' by port 'u_val_sync.q_o[0]' at io_clk.sv} \
       -comment {This is reset generation logic, hence it needs to drive this reset signal.}
 
-waive -rules RESET_DRIVER -location {ast.sv dev_entropy.sv ast_clks_byp.sv} \
+waive -rules RESET_DRIVER -location {ast_aon.sv dev_entropy.sv ast_clks_byp_main.sv} \
       -regexp {'q_o[0]' driven in module 'prim_flop_2sync' by port .* at prim_flop_2sync.sv} \
       -comment {This is reset generation logic, hence it needs to drive this reset signal.}
 
-waive -rules RESET_DRIVER -location {ast.sv} \
+waive -rules RESET_DRIVER -location {ast_main.sv} \
       -msg {'vcmain_pok_por_sys' is driven by instance 'u_rst_sys_dasrt' of module 'prim_flop_2sync', and used as an asynchronous reset 'rst_dev_ni' at dev_entropy.sv} \
       -comment {This is reset generation logic, hence it needs to drive this reset signal.}
 
@@ -192,27 +225,28 @@ waive -rules RESET_DRIVER -location {ast_pulse_sync.sv} \
       -regexp {'(rst_src_n|rst_dst_n)' is driven here, and used as an asynchronous reset at} \
       -comment {This is reset generation logic, hence it needs to drive this reset signal.}
 
-waive -rules RESET_DRIVER -location {ast_clks_byp.sv} \
+waive -rules RESET_DRIVER -location {ast_clks_byp_main.sv} \
       -regexp {'rst_aon_n_(ioda|exda)' is driven by instance 'u_rst_aon_n_(ioda|exda)_sync' of module} \
       -comment {This is reset generation logic, hence it needs to drive this reset signal.}
 
-waive -rules RESET_DRIVER -location {ast_clks_byp.sv} \
+waive -rules RESET_DRIVER -location {ast_clks_byp_main.sv} \
       -regexp {'rst_sw_clk_byp_en' is driven here, and used as an asynchronous reset 'rst_ni'} \
       -comment {This is reset generation logic, hence it needs to drive this reset signal.}
 
-waive -rules RESET_DRIVER -location {ast_clks_byp.sv} \
+waive -rules RESET_DRIVER -location {ast_clks_byp_main.sv} \
       -regexp {'da_rst_sw_ckbpe_n' is driven by instance 'u_no_scan_rst_sw_ckbpe_dasrt' of module 'prim_flop_2sync'} \
       -comment {Used as synced reset signal for clk_ast_ext_scn reset.}
 
-waive -rules RESET_DRIVER -location {ast.sv} \
-      -regexp {'(vcc_pok|rst_poks_n|rst_poks_por_n|vcaon_pok_por_lat)' is driven here, and used as an asynchronous reset} \
-      -comment {This is reset generation logic, hence it needs to drive this reset signal.}
+#TODO update
+#  waive -rules RESET_DRIVER -location {ast.sv} \
+#        -regexp {'(vcc_pok|rst_poks_n|rst_poks_por_n|vcaon_pok_por_lat)' is driven here, and used as an asynchronous reset} \
+#        -comment {This is reset generation logic, hence it needs to drive this reset signal.}
 
-waive -rules RESET_DRIVER -location {ast.sv} \
+waive -rules RESET_DRIVER -location {ast_main.sv} \
       -msg {'vcmain_pok_por_sys' is driven by instance 'u_rst_sys_dasrt' of module} \
       -comment {This is reset generation logic, hence it needs to drive this reset signal.}
 
-waive -rules RESET_DRIVER -location {ast.sv} \
+waive -rules RESET_DRIVER -location {ast_aon.sv} \
       -msg {'rst_aon_clk_n' is driven here, and used as an asynchronous reset 'rst_ni' at} \
       -comment {This is reset generation logic, hence it needs to drive this reset signal.}
 
@@ -220,23 +254,23 @@ waive -rules RESET_DRIVER -location {rglts_pdm_3p3v.sv} \
       -regexp {'(vcc_pok_rst_h_n|vcc_pok_set_h|vcc_pok_str_.*|)' is driven here, and used as an asynchronous reset} \
       -comment {This is reset generation logic, hence reset muxes are allowed.}
 
-waive -rules RESET_DRIVER -location {ast.sv} \
+waive -rules RESET_DRIVER -location {ast_aon.sv} \
       -regexp {'(vcaon_pok|vcaon_pok_h)' is driven by instance 'u_rglts_pdm_3p3v'} \
       -comment {This is reset generation logic, hence reset muxes are allowed.}
 
-waive -rules RESET_DRIVER -location {ast.sv} \
+waive -rules RESET_DRIVER -location {ast_aon.sv} \
       -regexp {'(vcaon_pok_1p1_h_o|vcaon_pok_h_o)' driven in module 'rglts_pdm_3p3v'} \
       -comment {This is reset generation logic, hence reset muxes are allowed.}
 
-waive -rules RESET_DRIVER -location {ast.sv} \
+waive -rules RESET_DRIVER -location {ast_main.sv} \
       -regexp {'rst_sys_clk_n' is driven here, and used as an asynchronous reset 'rst_ni' at prim_flop.sv} \
       -comment {This is reset generation logic, hence reset muxes are allowed.}
 
-waive -rules RESET_DRIVER -location {ast.sv} \
+waive -rules RESET_DRIVER -location {ast_main.sv} \
       -regexp {'rst_usb_clk_n' is driven here, and used as an asynchronous reset 'rst_ni' at prim_flop.sv} \
       -comment {This is reset generation logic, hence reset muxes are allowed.}
 
-waive -rules RESET_DRIVER -location {ast.sv} \
+waive -rules RESET_DRIVER -location {ast_main.sv} \
       -regexp {'rst_io_clk_n' is driven here, and used as an asynchronous reset 'rst_ni' at prim_flop.sv} \
       -comment {This is reset generation logic, hence reset muxes are allowed.}
 
@@ -268,15 +302,15 @@ waive -rules RESET_DRIVER -location {usb_clk.sv} \
       -regexp {'rst_usb_n' is driven by instance 'u_rst_ast_usb_da' of module 'prim_flop_2sync', and used as an asynchronous reset 'rst_ni' at prim_flop.sv} \
       -comment {This is reset generation logic, hence reset muxes are allowed.}
 
-waive -rules RESET_DRIVER -location {ast_clks_byp.sv} \
+waive -rules RESET_DRIVER -location {ast_clks_byp_main.sv} \
       -regexp {'q_o[0]' driven in module 'prim_flop_2sync' by port 'u_sync_2.q_o[0]' at prim_flop_2sync.sv} \
       -comment {This is reset generation logic, hence reset muxes are allowed.}
 
-waive -rules RESET_DRIVER -location {ast_clks_byp.sv} \
+waive -rules RESET_DRIVER -location {ast_clks_byp_main.sv} \
       -regexp {'q_o[0]' driven in module 'prim_flop' at prim_flop.sv} \
       -comment {This is reset generation logic, hence reset muxes are allowed.}
 
-waive -rules RESET_DRIVER -location {ast_clks_byp.sv} \
+waive -rules RESET_DRIVER -location {ast_clks_byp_main.sv} \
       -regexp {'sw_ckbpe_sync_n' is driven by instance 'u_no_scan_rst_sw_ckbpe_dasrt' of module 'prim_flop_2sync', and used as an asynchronous reset 'rst_sw_ckbpe_syn_n' at ast_clks_byp.sv} \
       -comment {This is reset generation logic, hence reset muxes are allowed.}
 
@@ -284,15 +318,16 @@ waive -rules RESET_MUX -location {aon_clk.sv io_clk.sv sys_clk.sv usb_clk.sv} \
       -msg {Asynchronous reset 'rst_val_n' is driven by a multiplexer here, used as a reset} \
       -comment {This is reset generation logic, hence reset muxes are allowed.}
 
-waive -rules RESET_MUX -location {ast.sv} \
-      -regexp {Asynchronous reset '(rst_poks_n|rst_poks_por_n|vcmain_pok_por|rst_src_sys_n|vcaon_pok_por)' is driven by a multiplexer here, used as a reset} \
-      -comment {This is reset generation logic, hence reset muxes are allowed.}
+#TODO update
+#  waive -rules RESET_MUX -location {ast.sv} \
+#        -regexp {Asynchronous reset '(rst_poks_n|rst_poks_por_n|vcmain_pok_por|rst_src_sys_n|vcaon_pok_por)' is driven by a multiplexer here, used as a reset} \
+#        -comment {This is reset generation logic, hence reset muxes are allowed.}
 
 waive -rules RESET_MUX -location {rng.sv} \
       -msg {Asynchronous reset 'rst_n' is driven by a multiplexer here, used as a reset at rng.sv} \
       -comment {This is reset generation logic, hence reset muxes are allowed.}
 
-waive -rules RESET_MUX -location {ast_clks_byp.sv} \
+waive -rules RESET_MUX -location {ast_clks_byp_main.sv} \
       -regexp {Asynchronous reset '(rst_aon_n|rst_aon_exda_n|rst_aon_ioda_n|rst_sw_ckbpe_n)' is driven by a multiplexer here, used as a reset} \
       -comment {This is reset generation logic, hence reset muxes are allowed.}
 
@@ -308,13 +343,16 @@ waive -rules RESET_MUX -location {usb_clk.sv} \
       -regexp {Asynchronous reset 'rst_n' is driven by a multiplexer here, used as a reset 'rst_ni' at prim_flop.sv} \
       -comment {This is reset generation logic, hence reset muxes are allowed.}
 
-waive -rules RESET_MUX -location {ast_clks_byp.sv} \
+waive -rules RESET_MUX -location {ast_clks_byp_main.sv} \
       -regexp {Asynchronous reset 'rst_sw_ckbpe_syn_n' is driven by a multiplexer here, used as a reset at ast_clks_byp.sv} \
       -comment {This is reset generation logic, hence reset muxes are allowed.}
 
-waive -rules RESET_USE -location {ast.sv} \
-      -regexp {('vcore_pok_h_i'|'vcaon_pok') is used for some other purpose, and as asynchronous reset} \
-      -comment {This is reset / clock generation logic, hence special reset usage is allowed.}
+#TODO update
+#  waive -rules RESET_USE -location {ast.sv} \
+#        -regexp {('vcore_pok_h_i'|'vcaon_pok') is used for some other purpose, and as asynchronous reset} \
+#        -comment {This is reset / clock generation logic, hence special reset usage is allowed.}
+
+************************************************
 
 waive -rules RESET_USE -location {ast.sv} \
       -regexp {'(vcmain_pok_por|vcmain_pok_por_src)' is connected to 'rglts_pdm_3p3v' port 'vcmain_pok_por_h_i', and used as an asynchronous reset or set} \

--- a/hw/top_earlgrey/ip/ast/rtl/aon_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/aon_osc.sv
@@ -126,7 +126,7 @@ prim_clock_buf #(
 // Unused Signals
 ///////////////////////
 logic unused_sigs;
-assign unused_sigs = ^{ aon_osc_cal_i };
+assign unused_sigs = ^{ aon_osc_cal_i, en_osc, en_osc_fe };
 `endif
 
 endmodule : aon_osc

--- a/hw/top_earlgrey/ip/ast/rtl/ast.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast.sv
@@ -38,12 +38,10 @@ module ast (
   input clkmgr_pkg::clkmgr_out_t sns_clks_i,  // Sensed Clocks
   input rstmgr_pkg::rstmgr_out_t sns_rsts_i,  // Sensed Resets
   input sns_spi_ext_clk_i,                    // Sensed SPI External Clock
-
 `ifdef AST_BYPASS_CLK
   // Clocks' Oschillator bypass for OS FPGA
   input ast_pkg::clks_osc_byp_t clk_osc_byp_i,  // Clocks' Oschillator bypass for OS FPGA/VERILATOR
 `endif
-
   // power OK control
   // In non-power aware DV environment, the <>_supp_i is for debug only!
   // POK signal follow this input.
@@ -126,7 +124,7 @@ module ast (
   output logic [ast_pkg::Ast2PadOutWidth-1:0] ast2padmux_o,  // DFT_2_IO Output Signals
   output logic [4-1:0] mux_iob_sel_o, // iob or spi selector
 
-
+  // analog test outputs
 `ifdef ANALOGSIM
   output real ast2pad_t0_ao,                  // AST_2_PAD Analog T0 Output Signal
   output real ast2pad_t1_ao,                  // AST_2_PAD Analog T1 Output Signal
@@ -156,918 +154,130 @@ module ast (
   output scan_reset_no                          // Scan Reset output
 );
 
-import ast_pkg::* ;
-import ast_reg_pkg::* ;
-import ast_bhv_pkg::* ;
+import ast_aon_main_pkg::*;
 
-logic scan_mode, shift_en, scan_reset_n;
-logic vcc_pok, vcc_pok_h, vcc_pok_str;
-logic vcaon_pok, vcaon_pok_h, vcmain_pok;
-logic vcaon_pok_por, vcmain_pok_por;
-
-// Local (AST) System clock buffer
-////////////////////////////////////////
-logic clk_sys;
-
-prim_clock_buf #(
-  .NoFpgaBuf ( 1'b1 )
-) u_clk_sys_buf (
-  .clk_i ( clk_src_sys_o ),
-  .clk_o ( clk_sys )
-);
-
-// Local (AST) AON clock buffer
-////////////////////////////////////////
-logic clk_aon;
-
-prim_clock_buf #(
-  .NoFpgaBuf ( 1'b1 )
-) u_clk_aon_buf (
-  .clk_i ( clk_src_aon_o ),
-  .clk_o ( clk_aon )
-);
+// Inter-domain communication signals
+ast_aon_main_pkg::aon_to_main_t aon_to_main;
+ast_aon_main_pkg::main_to_aon_t main_to_aon;
 
 
-assign flash_bist_en_o  = prim_mubi_pkg::MuBi4False;
-//
-assign dft_scan_md_o    = prim_mubi_pkg::MuBi4False;
-assign scan_shift_en_o  = 1'b0;
-assign scan_reset_no    = 1'b1;
-assign scan_mode        = 1'b0;
-assign shift_en         = 1'b0;
-assign scan_reset_n     = 1'b1;
-
-
-///////////////////////////////////////
-// VCC POK (Always ON)
-///////////////////////////////////////
-logic vcc_pok_int;
-
-vcc_pgd u_vcc_pok (
-  .vcc_pok_o ( vcc_pok_int )
-);
-
-assign vcc_pok = vcc_pok_int && vcc_supp_i;
-assign vcc_pok_h = vcc_pok;     // "Level Shifter"
-
-
-////////////////////////////////////////
-// VCAON POK POR (Always ON)
-///////////////////////////////////////
-logic rst_poks_n, rst_poks_por_n, por_sync_n;
-logic vcaon_pok_por_src, vcaon_pok_por_lat, poks_por_ack, rglssm_vcmon, rglssm_brout;
-
-assign rst_poks_n = vcc_pok_str && vcaon_pok;
-assign rst_poks_por_n = vcc_pok_str && vcaon_pok && por_ni;
-assign poks_por_ack = vcaon_pok_por_src || rglssm_vcmon;
-
-// Reset De-Assert Sync
-prim_flop_2sync #(
-  .Width ( 1 ),
-  .ResetValue ( 1'b0 )
-) u_no_scan_poks_por_dasrt (
-  .clk_i ( clk_aon ),
-  .rst_ni ( rst_poks_por_n ),
-  .d_i ( poks_por_ack ),
-  .q_o ( vcaon_pok_por_src )
-);
-
-logic clk_aon_n;
-
-prim_clock_inv #(
-  .HasScanMode ( 1 )
-) u_clk_aon_inv (
-  .clk_i ( clk_aon ),
-  .scanmode_i ( scan_mode ),
-  .clk_no ( clk_aon_n )
-);
-
-prim_flop #(
-  .Width ( 1 ),
-  .ResetValue ( 1'b0 )
-) u_no_scan_por_sync_n (
-  .clk_i ( clk_aon_n ),
-  .rst_ni ( rst_poks_n ),
-  .d_i ( vcaon_pok_por_src ),
-  .q_o ( por_sync_n )
-);
-
-// Replace Latch for the OS code
-assign vcaon_pok_por_lat = rglssm_brout || por_sync_n;
-assign vcaon_pok_por = scan_mode ? scan_reset_n : vcaon_pok_por_lat;
-assign ast_pwst_o.aon_pok = vcaon_pok_por;
-
-
-////////////////////////////////////////
-// VCMAIN POK POR (Always ON)
-///////////////////////////////////////
-logic rglssm_vmppr, vcmain_pok_por_src;
-
-assign vcmain_pok_por_src = vcaon_pok_por_lat && vcmain_pok && !rglssm_vmppr;
-assign vcmain_pok_por = scan_mode ? scan_reset_n : vcmain_pok_por_src;
-assign ast_pwst_o.main_pok = vcmain_pok_por;
-
-
-///////////////////////////////////////
-// VIOA POK (Always ON)
-///////////////////////////////////////
-logic vioa_pok;
-logic vioa_pok_int;
-
-vio_pgd u_vioa_pok (
-  .vio_pok_o ( vioa_pok_int )
-);
-
-assign vioa_pok = vioa_pok_int && vioa_supp_i;
-assign ast_pwst_o.io_pok[0] = vcaon_pok && vioa_pok;
-
-
-///////////////////////////////////////
-// VIOB POK (Always ON)
-///////////////////////////////////////
-logic viob_pok;
-logic viob_pok_int;
-
-vio_pgd u_viob_pok (
-  .vio_pok_o ( viob_pok_int )
-);
-
-assign viob_pok = viob_pok_int && viob_supp_i;
-assign ast_pwst_o.io_pok[1] = vcaon_pok && viob_pok;
-assign mux_iob_sel_o = 4'h0;
-
-
-///////////////////////////////////////
-// Regulators & PDM Logic (VCC)
-///////////////////////////////////////
-logic deep_sleep;
-logic main_pd, por_sync;
-
-assign main_pd = !main_pd_ni;
-assign por_sync = !por_sync_n;
-
-rglts_pdm_3p3v u_rglts_pdm_3p3v (
-  .vcc_pok_h_i ( vcc_pok_h ),
-  .vcaon_pok_por_h_i ( vcaon_pok_por_src ),
-  .vcmain_pok_por_h_i ( vcmain_pok_por_src ),
-  .vio_pok_h_i ( ast_pwst_o.io_pok[1:0] ),
-  .clk_src_aon_h_i ( clk_aon ),
-  .main_pd_h_i ( main_pd ),
-  .por_sync_h_i ( por_sync ),
-  .scan_mode_h_i ( scan_mode ),
-  .otp_power_seq_h_i ( otp_power_seq_i[2-1:0] ),
-  .vcaon_supp_i ( vcaon_supp_i ),
-  .vcmain_supp_i ( vcmain_supp_i ),
-  .rglssm_vmppr_h_o ( rglssm_vmppr ),
-  .rglssm_vcmon_h_o ( rglssm_vcmon ),
-  .rglssm_brout_h_o ( rglssm_brout ),
-  .vcmain_pok_h_o ( vcmain_pok ),
-  .vcmain_pok_por_h_o ( ast_pwst_h_o.main_pok ),
-  .vcaon_pok_h_o ( vcaon_pok_h ),
-  .vcaon_pok_1p1_h_o ( vcaon_pok ),
-  .vcaon_pok_por_h_o ( ast_pwst_h_o.aon_pok ),
-  .vio_pok_h_o ( ast_pwst_h_o.io_pok[2-1:0] ),
-  .vcc_pok_str_h_o ( ast_pwst_h_o.vcc_pok ),
-  .vcc_pok_str_1p1_h_o ( vcc_pok_str ),
-  .deep_sleep_h_o ( deep_sleep ),
-  .flash_power_down_h_o ( flash_power_down_h_o ),
-  .flash_power_ready_h_o ( flash_power_ready_h_o ),
-  .otp_power_seq_h_o ( otp_power_seq_h_o[2-1:0] )
-);
-
-assign ast_pwst_o.vcc_pok = vcc_pok_str;
-
-
-///////////////////////////////////////
-///////////////////////////////////////
-// Clocks Oscillattors
-///////////////////////////////////////
-///////////////////////////////////////
-
-
-///////////////////////////////////////
-// System Clock (Always ON)
-///////////////////////////////////////
-logic rst_sys_clk_n, clk_sys_pd_n;
-logic clk_sys_en, clk_osc_sys, clk_osc_sys_val;
-prim_mubi_pkg::mubi4_t clk_src_sys_jen;
-
-assign rst_sys_clk_n = vcmain_pok_por && vcc_pok;
-assign clk_sys_pd_n  = scan_mode || !deep_sleep;
-
-logic sys_io_osc_cal;
-
-assign clk_sys_en = clk_src_sys_en_i;
-
+// AON Domain instantiation
+ast_aon u_ast_aon (
+  .clk_ast_adc_i           ( clk_ast_adc_i ),
+  .rst_ast_adc_ni          ( rst_ast_adc_ni ),
+  .clk_ast_alert_i         ( clk_ast_alert_i ),
+  .rst_ast_alert_ni        ( rst_ast_alert_ni ),
+  .clk_ast_es_i            ( clk_ast_es_i ),
+  .rst_ast_es_ni           ( rst_ast_es_ni ),
+  .clk_ast_rng_i           ( clk_ast_rng_i ),
+  .rst_ast_rng_ni          ( rst_ast_rng_ni ),
+  .clk_ast_tlul_i          ( clk_ast_tlul_i ),
+  .rst_ast_tlul_ni         ( rst_ast_tlul_ni ),
+  .clk_ast_ext_i           ( clk_ast_ext_i ),
+  .por_ni                  ( por_ni ),
+  .sns_clks_i              ( sns_clks_i ),
+  .sns_rsts_i              ( sns_rsts_i ),
+  .sns_spi_ext_clk_i       ( sns_spi_ext_clk_i ),
+  .vcc_supp_i              ( vcc_supp_i ),
+  .vcaon_supp_i            ( vcaon_supp_i ),
+  .vcmain_supp_i           ( vcmain_supp_i ),
+  .vioa_supp_i             ( vioa_supp_i ),
+  .viob_supp_i             ( viob_supp_i ),
+  .ast_pwst_o              ( ast_pwst_o ),
+  .ast_pwst_h_o            ( ast_pwst_h_o ),
+  .main_pd_ni              ( main_pd_ni ),
+  .main_env_iso_en_i       ( main_env_iso_en_i ),
+  .flash_power_down_h_o    ( flash_power_down_h_o ),
+  .flash_power_ready_h_o   ( flash_power_ready_h_o ),
+  .otp_power_seq_i         ( otp_power_seq_i ),
+  .otp_power_seq_h_o       ( otp_power_seq_h_o ),
+  .clk_src_aon_o           ( clk_src_aon_o ),
+  .clk_src_aon_val_o       ( clk_src_aon_val_o ),
+  .usb_ref_pulse_i         ( usb_ref_pulse_i ),
+  .usb_ref_val_i           ( usb_ref_val_i ),
+  .clk_ast_usb_i           ( clk_ast_usb_i ),
+  .rst_ast_usb_ni          ( rst_ast_usb_ni ),
+  .clk_src_usb_en_i        ( clk_src_usb_en_i ),
+  .usb_io_pu_cal_o         ( usb_io_pu_cal_o ),
+  .adc_pd_i                ( adc_pd_i ),
+  .adc_a0_ai               ( adc_a0_ai ),
+  .adc_a1_ai               ( adc_a1_ai ),
+  .adc_chnsel_i            ( adc_chnsel_i ),
+  .adc_d_o                 ( adc_d_o ),
+  .adc_d_val_o             ( adc_d_val_o ),
+  .alert_rsp_i             ( alert_rsp_i ),
+  .alert_req_o             ( alert_req_o ),
+  .dft_strap_test_i        ( dft_strap_test_i ),
+  .lc_dft_en_i             ( lc_dft_en_i ),
+  .fla_obs_i               ( fla_obs_i ),
+  .otp_obs_i               ( otp_obs_i ),
+  .otm_obs_i               ( otm_obs_i ),
+  .usb_obs_i               ( usb_obs_i ),
+  .obs_ctrl_o              ( obs_ctrl_o ),
+  .padmux2ast_i            ( padmux2ast_i ),
+  .ast2padmux_o            ( ast2padmux_o ),
+  .mux_iob_sel_o           ( mux_iob_sel_o ),
+  .ast2pad_t0_ao           ( ast2pad_t0_ao ),
+  .ast2pad_t1_ao           ( ast2pad_t1_ao ),
+  .ext_freq_is_96m_i       ( ext_freq_is_96m_i ),
+  .all_clk_byp_req_i       ( all_clk_byp_req_i ),
+  .io_clk_byp_req_i        ( io_clk_byp_req_i ),
 `ifdef AST_BYPASS_CLK
-logic clk_sys_ext;
-assign clk_sys_ext = clk_osc_byp_i.sys;
+  .clk_osc_byp_i           ( clk_osc_byp_i ),
 `endif
+  .flash_bist_en_o         ( flash_bist_en_o ),
+  .dpram_rmf_o             ( dpram_rmf_o ),
+  .dpram_rml_o             ( dpram_rml_o ),
+  .spram_rm_o              ( spram_rm_o ),
+  .sprgf_rm_o              ( sprgf_rm_o ),
+  .sprom_rm_o              ( sprom_rm_o ),
+  .dft_scan_md_o           ( dft_scan_md_o ),
+  .scan_shift_en_o         ( scan_shift_en_o ),
+  .scan_reset_no           ( scan_reset_no ),
+  .aon_to_main_o           ( aon_to_main ),
+  .main_to_aon_i           ( main_to_aon )
+);
 
-sys_clk u_sys_clk (
-  .clk_src_sys_jen_i ( prim_mubi_pkg::mubi4_test_true_loose(clk_src_sys_jen) ),
-  .clk_src_sys_en_i ( clk_sys_en ),
-  .clk_sys_pd_ni ( clk_sys_pd_n ),
-  .rst_sys_clk_ni ( rst_sys_clk_n ),
-  .vcore_pok_h_i ( vcaon_pok_h ),
-  .scan_mode_i ( scan_mode ),
-  .sys_osc_cal_i ( sys_io_osc_cal ),
+// Main Domain instantiation
+ast_main u_ast_main (
+  .tl_i                    ( tl_i ),
+  .tl_o                    ( tl_o ),
+  .clk_ast_tlul_i          ( clk_ast_tlul_i ),
+  .rst_ast_tlul_ni         ( rst_ast_tlul_ni ),
+  .ast_init_done_o         ( ast_init_done_o ),
+  .rng_en_i                ( rng_en_i ),
+  .rng_fips_i              ( rng_fips_i ),
+  .rng_val_o               ( rng_val_o ),
+  .rng_b_o                 ( rng_b_o ),
+  .entropy_rsp_i           ( entropy_rsp_i ),
+  .entropy_req_o           ( entropy_req_o ),
+  .clk_src_sys_jen_i       ( clk_src_sys_jen_i ),
+  .clk_ast_es_i            ( clk_ast_es_i ),
+  .rst_ast_es_ni           ( rst_ast_es_ni ),
+  .aon_to_main_i           ( aon_to_main ),
+  .main_to_aon_o           ( main_to_aon ),
+  // Clock bypass interface
+  .clk_ast_ext_i           ( clk_ast_ext_i ),
+  .clk_src_sys_en_i        ( clk_src_sys_en_i ),
+  .clk_src_io_en_i         ( clk_src_io_en_i ),
+  .clk_src_usb_en_i        ( clk_src_usb_en_i ),
+  .clk_ast_usb_i           ( clk_ast_usb_i ),
+  .rst_ast_usb_ni          ( rst_ast_usb_ni ),
+  .io_clk_byp_req_i        ( io_clk_byp_req_i ),
+  .all_clk_byp_req_i       ( all_clk_byp_req_i ),
+  .ext_freq_is_96m_i       ( ext_freq_is_96m_i ),
 `ifdef AST_BYPASS_CLK
-  .clk_sys_ext_i ( clk_sys_ext ),
+  .clk_osc_byp_i           ( clk_osc_byp_i ),
 `endif
-  .clk_src_sys_o ( clk_osc_sys ),
-  .clk_src_sys_val_o ( clk_osc_sys_val )
+  .clk_src_sys_o           ( clk_src_sys_o ),
+  .clk_src_sys_val_o       ( clk_src_sys_val_o ),
+  .clk_src_io_o            ( clk_src_io_o ),
+  .clk_src_io_val_o        ( clk_src_io_val_o ),
+  .clk_src_io_48m_o        ( clk_src_io_48m_o ),
+  .clk_src_usb_o           ( clk_src_usb_o ),
+  .clk_src_usb_val_o       ( clk_src_usb_val_o ),
+  .io_clk_byp_ack_o        ( io_clk_byp_ack_o ),
+  .all_clk_byp_ack_o       ( all_clk_byp_ack_o )
 );
-
-
-///////////////////////////////////////
-// USB Clock (Always ON)
-///////////////////////////////////////
-logic rst_usb_clk_n, clk_usb_pd_n;
-logic clk_usb_en, clk_osc_usb, clk_osc_usb_val;
-logic usb_ref_val, usb_ref_pulse;
-
-assign rst_usb_clk_n = vcmain_pok_por && vcc_pok;
-assign clk_usb_pd_n  = scan_mode || !deep_sleep;
-
-logic usb_osc_cal;
-
-`ifdef AST_BYPASS_CLK
-logic clk_usb_ext;
-assign clk_usb_ext = clk_osc_byp_i.usb;
-`endif
-
-assign clk_usb_en = clk_src_usb_en_i;
-assign usb_ref_val = usb_ref_val_i;
-assign usb_ref_pulse = usb_ref_pulse_i;
-
-usb_clk u_usb_clk (
-  .vcore_pok_h_i ( vcaon_pok_h ),
-  .clk_usb_pd_ni ( clk_usb_pd_n ),
-  .rst_usb_clk_ni ( rst_usb_clk_n ),
-  .clk_src_usb_en_i ( clk_usb_en ),
-  .usb_ref_val_i ( usb_ref_val ),
-  .usb_ref_pulse_i ( usb_ref_pulse ),
-  .clk_ast_usb_i ( clk_ast_usb_i ),
-  .rst_ast_usb_ni ( rst_ast_usb_ni ),
-  .scan_mode_i ( scan_mode ),
-  .usb_osc_cal_i ( usb_osc_cal ),
-`ifdef AST_BYPASS_CLK
-  .clk_usb_ext_i ( clk_usb_ext ),
-`endif
-  .clk_src_usb_o ( clk_osc_usb ),
-  .clk_src_usb_val_o ( clk_osc_usb_val )
-);
-
-
-///////////////////////////////////////
-// AON Clock (Always ON)
-///////////////////////////////////////
-logic rst_aon_clk_n;
-logic clk_src_aon_en, clk_osc_aon, clk_osc_aon_val;
-logic aon_osc_cal;
-
-`ifdef AST_BYPASS_CLK
-logic clk_aon_ext;
-assign clk_aon_ext = clk_osc_byp_i.aon;
-`endif
-
-assign rst_aon_clk_n = vcc_pok_str && vcaon_pok;
-assign clk_src_aon_en = 1'b1;  // Always Enabled
-
-aon_clk  u_aon_clk (
-  .vcore_pok_h_i ( vcaon_pok_h ),
-  .clk_aon_pd_ni ( 1'b1 ),     // Always Enabled
-  .rst_aon_clk_ni ( rst_aon_clk_n ),
-  .clk_src_aon_en_i ( clk_src_aon_en ),
-  .scan_mode_i ( scan_mode ),
-  .aon_osc_cal_i ( aon_osc_cal ),
-`ifdef AST_BYPASS_CLK
-  .clk_aon_ext_i ( clk_aon_ext ),
-`endif
-  .clk_src_aon_o ( clk_osc_aon ),
-  .clk_src_aon_val_o ( clk_osc_aon_val )
-);
-
-logic vcmpp_aon_sync_n, rst_vcmpp_aon_n;
-
-// Reset De-Assert Sync
-prim_flop_2sync #(
-  .Width ( 1 ),
-  .ResetValue ( 1'b0 )
-) u_rst_vcmpp_aon_dasrt (
-  .clk_i ( clk_aon ),
-  .rst_ni ( vcmain_pok_por ),
-  .d_i ( 1'b1 ),
-  .q_o ( vcmpp_aon_sync_n )
-);
-
-assign rst_vcmpp_aon_n = scan_mode ? scan_reset_n : vcmpp_aon_sync_n;
-
-
-///////////////////////////////////////
-// IO Clock (Always ON)
-///////////////////////////////////////
-logic rst_io_clk_n, clk_io_pd_n;
-logic clk_src_io_en, clk_osc_io, clk_osc_io_val;
-
-assign rst_io_clk_n = vcmain_pok_por && vcc_pok;
-assign clk_io_pd_n  = scan_mode || !deep_sleep;
-
-`ifdef AST_BYPASS_CLK
-logic clk_io_ext;
-assign clk_io_ext = clk_osc_byp_i.io;
-`endif
-
-assign clk_src_io_en = clk_src_io_en_i;
-
-io_clk u_io_clk (
-  .vcore_pok_h_i ( vcaon_pok_h ),
-  .clk_io_pd_ni ( clk_io_pd_n ),
-  .rst_io_clk_ni ( rst_io_clk_n ),
-  .clk_src_io_en_i ( clk_src_io_en ),
-  .scan_mode_i ( scan_mode ),
-  .io_osc_cal_i ( sys_io_osc_cal ),
-`ifdef AST_BYPASS_CLK
-  .clk_io_ext_i ( clk_io_ext ),
-`endif
-  .clk_src_io_o ( clk_osc_io ),
-  .clk_src_io_val_o ( clk_osc_io_val )
-);
-
-
-///////////////////////////////////////
-// AST Clocks Bypass
-///////////////////////////////////////
-logic clk_src_sys, clk_src_io, clk_src_usb, clk_src_aon;
-
-ast_clks_byp u_ast_clks_byp (
-  .vcaon_pok_i ( vcaon_pok ),
-  .vcaon_pok_por_i ( vcaon_pok_por ),
-  .deep_sleep_i ( deep_sleep ),
-  .clk_src_sys_en_i ( clk_src_sys_en_i ),
-  .clk_osc_sys_i ( clk_osc_sys ),
-  .clk_osc_sys_val_i ( clk_osc_sys_val ),
-  .clk_src_io_en_i ( clk_src_io_en_i ),
-  .clk_osc_io_i ( clk_osc_io ),
-  .clk_osc_io_val_i ( clk_osc_io_val ),
-  .clk_src_usb_en_i ( clk_src_usb_en_i ),
-  .clk_osc_usb_i ( clk_osc_usb ),
-  .clk_osc_usb_val_i ( clk_osc_usb_val ),
-  .clk_osc_aon_i ( clk_osc_aon ),
-  .clk_osc_aon_val_i ( clk_osc_aon_val ),
-  .clk_ast_ext_i ( clk_ast_ext_i ),
-`ifdef AST_BYPASS_CLK
-  .clk_ext_sys_i( clk_sys_ext ),
-  .clk_ext_io_i( clk_io_ext ),
-  .clk_ext_usb_i( clk_usb_ext ),
-  .clk_ext_aon_i( clk_aon_ext ),
-`endif
-  .io_clk_byp_req_i ( io_clk_byp_req_i ),
-  .all_clk_byp_req_i ( all_clk_byp_req_i ),
-  .ext_freq_is_96m_i ( ext_freq_is_96m_i ),
-  .io_clk_byp_ack_o ( io_clk_byp_ack_o ),
-  .all_clk_byp_ack_o ( all_clk_byp_ack_o ),
-  .clk_src_sys_o ( clk_src_sys ),
-  .clk_src_sys_val_o ( clk_src_sys_val_o ),
-  .clk_src_io_o ( clk_src_io ),
-  .clk_src_io_val_o ( clk_src_io_val_o ),
-  .clk_src_io_48m_o ( clk_src_io_48m_o ),
-  .clk_src_usb_o ( clk_src_usb ),
-  .clk_src_usb_val_o ( clk_src_usb_val_o ),
-  .clk_src_aon_o ( clk_src_aon ),
-  .clk_src_aon_val_o ( clk_src_aon_val_o )
-);
-
-// System source clock buffer
-////////////////////////////////////////
-prim_clock_buf #(
-  .NoFpgaBuf ( 1'b1 )
-) u_clk_src_sys_buf (
-  .clk_i ( clk_src_sys ),
-  .clk_o ( clk_src_sys_o )
-);
-
-// IO source clock buffer
-////////////////////////////////////////
-prim_clock_buf #(
-  .NoFpgaBuf ( 1'b1 )
-) u_clk_src_io_buf (
-  .clk_i ( clk_src_io ),
-  .clk_o ( clk_src_io_o )
-);
-
-// USB source clock buffer
-////////////////////////////////////////
-prim_clock_buf #(
-  .NoFpgaBuf ( 1'b1 )
-) u_clk_src_usb_buf (
-  .clk_i ( clk_src_usb ),
-  .clk_o ( clk_src_usb_o )
-);
-
-// AON source clock buffer
-////////////////////////////////////////
-prim_clock_buf #(
-  .NoFpgaBuf ( 1'b1 )
-) u_clk_src_aon_buf (
-  .clk_i ( clk_src_aon ),
-  .clk_o ( clk_src_aon_o )
-);
-
-
-///////////////////////////////////////
-// ADC (Always ON)
-///////////////////////////////////////
-adc #(
-  .AdcCnvtClks ( AdcCnvtClks ),
-  .AdcChannels ( ast_pkg::AdcChannels ),
-  .AdcDataWidth ( ast_pkg::AdcDataWidth )
-) u_adc (
-  .adc_a0_ai ( adc_a0_ai ),
-  .adc_a1_ai ( adc_a1_ai ),
-  .adc_chnsel_i ( adc_chnsel_i[ast_pkg::AdcChannels-1:0] ),
-  .adc_pd_i ( adc_pd_i ),
-  .clk_adc_i ( clk_ast_adc_i ),
-  .rst_adc_ni ( rst_ast_adc_ni ),
-  .adc_d_o ( adc_d_o[ast_pkg::AdcDataWidth-1:0] ),
-  .adc_d_val_o ( adc_d_val_o )
-);
-
-
-///////////////////////////////////////
-// Entropy (Always ON)
-///////////////////////////////////////
-localparam int EntropyRateWidth = 4;
-logic [EntropyRateWidth-1:0] entropy_rate;
-logic vcmain_pok_por_sys, rst_src_sys_n;
-
-// Sync clk_src_sys_jen_i to clk_sys
-prim_mubi4_sync #(
-  .NumCopies ( 1 ),
-  .AsyncOn ( 1 ),
-  .StabilityCheck ( 1 ),
-  .ResetValue (prim_mubi_pkg::MuBi4False )
-) u_jitter_en_sync (
-  .clk_i ( clk_sys ),
-  .rst_ni ( rst_src_sys_n ),
-  .mubi_i ( clk_src_sys_jen_i ),
-  .mubi_o ( {clk_src_sys_jen} )
-);
-
-// Reset De-Assert Sync
-prim_flop_2sync #(
-  .Width ( 1 ),
-  .ResetValue ( 1'b0 )
-) u_rst_sys_dasrt (
-  .clk_i ( clk_sys ),
-  .rst_ni ( vcmain_pok_por ),
-  .d_i ( 1'b1 ),
-  .q_o ( vcmain_pok_por_sys )
-);
-
-assign rst_src_sys_n = scan_mode ? scan_reset_n : vcmain_pok_por_sys;
-
-`ifndef SYNTHESIS
-logic [EntropyRateWidth-1:0] dv_entropy_rate_value;
-
-initial begin : erate_plusargs
-  dv_entropy_rate_value = EntropyRateWidth'($urandom_range(0, (2**EntropyRateWidth -1)));
-  void'($value$plusargs("entropy_rate_value=%0d", dv_entropy_rate_value));
-  `ASSERT_I(DvErateValueCheck, dv_entropy_rate_value inside {[0:(2**EntropyRateWidth -1)]})
-end
-
-assign entropy_rate = dv_entropy_rate_value;
-`else
-assign entropy_rate = EntropyRateWidth'(5);
-`endif
-
-ast_entropy #(
-  .EntropyRateWidth ( EntropyRateWidth )
-) u_entropy (
-  .entropy_rsp_i ( entropy_rsp_i ),
-  .entropy_rate_i ( entropy_rate[EntropyRateWidth-1:0] ),
-  .clk_ast_es_i ( clk_ast_es_i ),
-  .rst_ast_es_ni ( rst_ast_es_ni ),
-  .clk_src_sys_i ( clk_sys ),
-  .rst_src_sys_ni ( rst_src_sys_n ),
-  .clk_src_sys_val_i ( clk_src_sys_val_o ),
-  .clk_src_sys_jen_i ( prim_mubi_pkg::mubi4_test_true_loose(clk_src_sys_jen) ),
-  .entropy_req_o ( entropy_req_o )
-);
-
-
-///////////////////////////////////////
-// RNG (Always ON)
-///////////////////////////////////////
-ast_pkg::ast_dif_t ot1_alert_src;
-
-rng #(
-  .EntropyStreams ( ast_pkg::EntropyStreams )
-) u_rng (
-  .clk_i ( clk_ast_tlul_i ),
-  .rst_ni ( rst_ast_tlul_ni ),
-  .clk_ast_rng_i ( clk_ast_rng_i ),
-  .rst_ast_rng_ni ( rst_ast_rng_ni ),
-  .rng_en_i ( rng_en_i ),
-  .rng_fips_i ( rng_fips_i ),
-  .scan_mode_i ( scan_mode ),
-  .rng_b_o ( rng_b_o[ast_pkg::EntropyStreams-1:0] ),
-  .rng_val_o ( rng_val_o )
-);
-
-
-///////////////////////////////////////
-// Alerts (Always ON)
-///////////////////////////////////////
-ast_pkg::ast_dif_t as_alert_src;
-ast_pkg::ast_dif_t cgc_alert_src;
-ast_pkg::ast_dif_t gd_alert_src;
-ast_pkg::ast_dif_t ts_alert_hi_src;
-ast_pkg::ast_dif_t ts_alert_lo_src;
-ast_pkg::ast_dif_t ot0_alert_src;
-ast_pkg::ast_dif_t ot2_alert_src;
-ast_pkg::ast_dif_t ot3_alert_src;
-ast_pkg::ast_dif_t ot4_alert_src;
-ast_pkg::ast_dif_t ot5_alert_src;
-
-
-// Active Shield (AS)
-///////////////////////////////////////
-ast_alert u_alert_as (
-  .clk_i ( clk_ast_alert_i ),
-  .rst_ni ( rst_ast_alert_ni ),
-  .alert_src_i ( as_alert_src ),
-  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::AsSel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::AsSel] ),
-  .alert_req_o ( alert_req_o.alerts[ast_pkg::AsSel] )
-);
-
-// Clock Glitch (CG)
-///////////////////////////////////////
-ast_alert u_alert_cg (
-  .clk_i ( clk_ast_alert_i ),
-  .rst_ni ( rst_ast_alert_ni ),
-  .alert_src_i ( cgc_alert_src ),
-  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::CgSel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::CgSel] ),
-  .alert_req_o ( alert_req_o.alerts[ast_pkg::CgSel] )
-);
-
-// Glitch Detector (GD)
-///////////////////////////////////////
-ast_alert u_alert_gd (
-  .clk_i ( clk_ast_alert_i ),
-  .rst_ni ( rst_ast_alert_ni ),
-  .alert_src_i ( gd_alert_src ),
-  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::GdSel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::GdSel] ),
-  .alert_req_o ( alert_req_o.alerts[ast_pkg::GdSel] )
-);
-
-// Temprature Sensor High (TS Hi)
-///////////////////////////////////////
-ast_alert u_alert_ts_hi (
-  .clk_i ( clk_ast_alert_i ),
-  .rst_ni ( rst_ast_alert_ni ),
-  .alert_src_i ( ts_alert_hi_src ),
-  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::TsHiSel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::TsHiSel] ),
-  .alert_req_o ( alert_req_o.alerts[ast_pkg::TsHiSel] )
-);
-
-// Temprature Sensor Low (TS Lo)
-///////////////////////////////////////
-ast_alert u_alert_ts_lo (
-  .clk_i ( clk_ast_alert_i ),
-  .rst_ni ( rst_ast_alert_ni ),
-  .alert_src_i ( ts_alert_lo_src ),
-  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::TsLoSel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::TsLoSel] ),
-  .alert_req_o ( alert_req_o.alerts[ast_pkg::TsLoSel] )
-);
-
-// Other-0 Alert (OT0)
-///////////////////////////////////////
-ast_alert u_alert_ot0 (
-  .clk_i ( clk_ast_alert_i ),
-  .rst_ni ( rst_ast_alert_ni ),
-  .alert_src_i ( ot0_alert_src ),
-  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::Ot0Sel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::Ot0Sel] ),
-  .alert_req_o ( alert_req_o.alerts[ast_pkg::Ot0Sel] )
-); // of u_alert_ot0
-
-// Other-1 Alert (OT1)
-///////////////////////////////////////
-ast_alert u_alert_ot1 (
-  .clk_i ( clk_ast_alert_i ),
-  .rst_ni ( rst_ast_alert_ni ),
-  .alert_src_i ( ot1_alert_src ),
-  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::Ot1Sel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::Ot1Sel] ),
-  .alert_req_o ( alert_req_o.alerts[ast_pkg::Ot1Sel] )
-); // of u_alert_ot1
-
-// Other-2 Alert (OT2)
-///////////////////////////////////////
-ast_alert u_alert_ot2 (
-  .clk_i ( clk_ast_alert_i ),
-  .rst_ni ( rst_ast_alert_ni ),
-  .alert_src_i ( ot2_alert_src ),
-  .alert_trig_i ( alert_rsp_i.alerts_trig[Ot2Sel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[Ot2Sel] ),
-  .alert_req_o ( alert_req_o.alerts[Ot2Sel] )
-); // of u_alert_ot2
-
-// Other-3 Alert (OT3)
-///////////////////////////////////////
-ast_alert u_alert_ot3 (
-  .clk_i ( clk_ast_alert_i ),
-  .rst_ni ( rst_ast_alert_ni ),
-  .alert_src_i ( ot3_alert_src ),
-  .alert_trig_i ( alert_rsp_i.alerts_trig[Ot3Sel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[Ot3Sel] ),
-  .alert_req_o ( alert_req_o.alerts[Ot3Sel] )
-); // of u_alert_ot3
-
-// Other-4 Alert (OT4)
-///////////////////////////////////////
-ast_alert u_alert_ot4 (
-  .clk_i ( clk_ast_alert_i ),
-  .rst_ni ( rst_ast_alert_ni ),
-  .alert_src_i ( ot4_alert_src ),
-  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::Ot4Sel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::Ot4Sel] ),
-  .alert_req_o ( alert_req_o.alerts[ast_pkg::Ot4Sel] )
-); // of u_alert_ot4
-
-// Other-5 Alert (OT5)
-///////////////////////////////////////
-ast_alert u_alert_ot5 (
-  .clk_i ( clk_ast_alert_i ),
-  .rst_ni ( rst_ast_alert_ni ),
-  .alert_src_i ( ot5_alert_src ),
-  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::Ot5Sel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::Ot5Sel] ),
-  .alert_req_o ( alert_req_o.alerts[ast_pkg::Ot5Sel] )
-); // of u_alert_ot5
-
-// Alerts Open-Source Selection
-////////////////////////////////////////
-assign as_alert_src    = '{p: 1'b0, n: 1'b1};
-assign cgc_alert_src   = '{p: 1'b0, n: 1'b1};
-assign gd_alert_src    = '{p: 1'b0, n: 1'b1};
-assign ts_alert_hi_src = '{p: 1'b0, n: 1'b1};
-assign ts_alert_lo_src = '{p: 1'b0, n: 1'b1};
-assign ot1_alert_src   = '{p: 1'b0, n: 1'b1};
-assign ot2_alert_src   = '{p: 1'b0, n: 1'b1};
-assign ot3_alert_src   = '{p: 1'b0, n: 1'b1};
-assign ot4_alert_src   = '{p: 1'b0, n: 1'b1};
-assign ot5_alert_src   = '{p: 1'b0, n: 1'b1};
-
-
-///////////////////////////////////////
-// AST Registers (Always ON)
-///////////////////////////////////////
-ast_reg_pkg::ast_reg2hw_t reg2hw; // Write (To HW)
-ast_reg_pkg::ast_hw2reg_t hw2reg; // Read  (From HW)
-logic intg_err;
-
-ast_reg_top u_reg (
-  .clk_i ( clk_ast_tlul_i ),
-  .rst_ni ( rst_ast_tlul_ni ),
-  .tl_i ( tl_i ),
-  .tl_o ( tl_o ),
-  .reg2hw ( reg2hw ),
-  .hw2reg ( hw2reg ),
-  .intg_err_o ( intg_err )
-);
-
-
-///////////////////////////////////////
-// REGAL Register
-///////////////////////////////////////
-logic regal_rst_n;
-assign regal_rst_n = rst_ast_tlul_ni;
-
-logic regal_we;
-logic [32-1:0] regal, regal_di;
-
-assign regal_we = reg2hw.regal.qe;
-assign regal_di = reg2hw.regal.q;
-assign hw2reg.regal.d = regal;
-
-// REGAL & AST init done indication
-always_ff @( posedge clk_ast_tlul_i, negedge regal_rst_n ) begin
-  if ( !regal_rst_n ) begin
-    regal           <= ast_reg_pkg::AST_REGAL_RESVAL;
-    ast_init_done_o <= prim_mubi_pkg::MuBi4False;
-  end else if ( regal_we ) begin
-    regal           <= regal_di;
-    ast_init_done_o <= prim_mubi_pkg::MuBi4True;
-  end
-end
-
-always_ff @( posedge clk_ast_tlul_i, negedge rst_ast_tlul_ni ) begin
-  if ( !rst_ast_tlul_ni ) begin
-    sys_io_osc_cal <= 1'b0;
-  end else if ( regal_we ) begin
-    sys_io_osc_cal <= 1'b1;
-  end
-end
-
-always_ff @( posedge clk_ast_tlul_i, negedge vcaon_pok_por ) begin
-  if ( !vcaon_pok_por ) begin
-    usb_osc_cal <= 1'b0;
-  end else if ( regal_we ) begin
-    usb_osc_cal <= 1'b1;
-  end
-end
-
-always_ff @( posedge clk_ast_tlul_i, negedge vcaon_pok ) begin
-  if ( !vcaon_pok ) begin
-    aon_osc_cal <= 1'b0;
-  end else if ( regal_we ) begin
-    aon_osc_cal <= 1'b1;
-  end
-end
-
-// TLUL Integrity Error
-assign ot0_alert_src = '{p: intg_err, n: !intg_err};
-
-// USB PU-P and PU-N value selection
-assign usb_io_pu_cal_o = ast_pkg::UsbCalibWidth'(1 << (ast_pkg::UsbCalibWidth[5-1:0]/2));
-
-
-///////////////////////////////////////
-// DFT (Main | Always ON)
-///////////////////////////////////////
-ast_dft u_ast_dft (
-  .obs_ctrl_o ( obs_ctrl_o ),
-  .ast2padmux_o ( ast2padmux_o[ast_pkg::Ast2PadOutWidth-1:0] ),
-  .dpram_rmf_o ( dpram_rmf_o ),
-  .dpram_rml_o ( dpram_rml_o ),
-  .spram_rm_o ( spram_rm_o ),
-  .sprgf_rm_o ( sprgf_rm_o ),
-  .sprom_rm_o ( sprom_rm_o )
-);
-
-
-////////////////////////////////////////
-// DFT Misc Logic
-////////////////////////////////////////
-`ifdef ANALOGSIM
-assign ast2pad_t0_ao = 0.0;
-assign ast2pad_t1_ao = 0.1;
-`else
-assign ast2pad_t0_ao = 1'bz;
-assign ast2pad_t1_ao = 1'bz;
-`endif
-
-
-////////////////
-// Assertions //
-////////////////
-
-// Clocks
-`ASSERT_KNOWN(ClkSrcAonKnownO_A, clk_src_aon_o, 1, ast_pwst_o.aon_pok)
-`ASSERT_KNOWN(ClkSrcAonValKnownO_A, clk_src_aon_val_o, clk_src_aon_o, rst_aon_clk_n)
-`ASSERT_KNOWN(ClkSrcIoKnownO_A, clk_src_io_o, 1, ast_pwst_o.main_pok)
-`ASSERT_KNOWN(ClkSrcIoValKnownO_A, clk_src_io_val_o, clk_src_io_o, rst_io_clk_n)
-`ASSERT_KNOWN(ClkSrcIo48mKnownO_A, clk_src_io_48m_o, clk_src_io_o, rst_io_clk_n)
-`ASSERT_KNOWN(ClkSrcSysKnownO_A, clk_src_sys_o, 1, ast_pwst_o.main_pok)
-`ASSERT_KNOWN(ClkSrcSysValKnownO_A, clk_src_sys_val_o, clk_src_sys_o, rst_sys_clk_n)
-`ASSERT_KNOWN(ClkSrcUsbKnownO_A, clk_src_usb_o, 1, ast_pwst_o.main_pok)
-`ASSERT_KNOWN(ClkSrcUsbValKnownO_A, clk_src_usb_val_o, clk_src_usb_o, rst_usb_clk_n)
-//
-`ASSERT_KNOWN(UsbIoPuCalKnownO_A, usb_io_pu_cal_o, clk_ast_tlul_i, ast_pwst_o.aon_pok)
-`ASSERT_KNOWN(LcClkBypAckEnKnownO_A, io_clk_byp_ack_o, clk_ast_tlul_i, rst_ast_tlul_ni)
-`ASSERT_KNOWN(AllClkBypAckEnKnownO_A, all_clk_byp_ack_o, clk_ast_tlul_i, rst_ast_tlul_ni)
-// ADC
-`ASSERT_KNOWN(AdcDKnownO_A, adc_d_o, clk_ast_adc_i, rst_ast_adc_ni)
-`ASSERT_KNOWN(AdcDValKnownO_A, adc_d_val_o, clk_ast_adc_i, rst_ast_adc_ni)
-// RNG
-`ASSERT_KNOWN(RngBKnownO_A, rng_b_o, clk_ast_rng_i, rst_ast_rng_ni)
-`ASSERT_KNOWN(RngValKnownO_A, rng_val_o, clk_ast_rng_i, rst_ast_rng_ni)
-// TLUL
-`ASSERT_KNOWN(TlDValidKnownO_A, tl_o.d_valid, clk_ast_tlul_i, rst_ast_tlul_ni)
-`ASSERT_KNOWN(TlAReadyKnownO_A, tl_o.a_ready, clk_ast_tlul_i, rst_ast_tlul_ni)
-//
-`ASSERT_KNOWN(InitDoneKnownO_A, ast_init_done_o, clk_ast_tlul_i, rst_ast_tlul_ni)
-// POs
-`ASSERT_KNOWN(VcaonPokKnownO_A, ast_pwst_o.aon_pok, clk_src_aon_o, por_ni)
-`ASSERT_KNOWN(VcmainPokKnownO_A, ast_pwst_o.main_pok, clk_src_aon_o, por_ni)
-`ASSERT_KNOWN(VioaPokKnownO_A, ast_pwst_o.io_pok[0], clk_src_aon_o, por_ni)
-`ASSERT_KNOWN(ViobPokKnownO_A, ast_pwst_o.io_pok[1], clk_src_aon_o, por_ni)
-`ASSERT_KNOWN(VcaonPokHKnownO_A, ast_pwst_h_o.aon_pok, clk_src_aon_o, por_ni)
-`ASSERT_KNOWN(VcmainPokHKnownO_A, ast_pwst_h_o.main_pok, clk_src_aon_o, por_ni)
-`ASSERT_KNOWN(VioaPokHKnownO_A, ast_pwst_h_o.io_pok[0], clk_src_aon_o, por_ni)
-`ASSERT_KNOWN(ViobPokHKnownO_A, ast_pwst_h_o.io_pok[1], clk_src_aon_o, por_ni)
-// FLASH/OTP
-`ASSERT_KNOWN(FlashPowerDownKnownO_A, flash_power_down_h_o, 1, ast_pwst_o.main_pok)
-`ASSERT_KNOWN(FlashPowerReadyKnownO_A, flash_power_ready_h_o, 1, ast_pwst_o.main_pok)
-`ASSERT_KNOWN(OtpPowerSeqKnownO_A, otp_power_seq_h_o, 1, ast_pwst_o.main_pok)
-//
-// ES
-`ASSERT_KNOWN(EntropyReeqKnownO_A, entropy_req_o, clk_ast_es_i,rst_ast_es_ni)
-// Alerts
-`ASSERT_KNOWN(AlertReqKnownO_A, alert_req_o, clk_ast_alert_i, rst_ast_alert_ni)
-// DPRAM/SPRAM
-`ASSERT_KNOWN(DpramRmfKnownO_A, dpram_rmf_o, clk_ast_tlul_i, ast_pwst_o.aon_pok)
-`ASSERT_KNOWN(DpramRmlKnownO_A, dpram_rml_o, clk_ast_tlul_i, ast_pwst_o.aon_pok)
-`ASSERT_KNOWN(SpramRmKnownO_A, spram_rm_o, clk_ast_tlul_i, ast_pwst_o.aon_pok)
-`ASSERT_KNOWN(SprgfRmKnownO_A, sprgf_rm_o, clk_ast_tlul_i, ast_pwst_o.aon_pok)
-`ASSERT_KNOWN(SpromRmKnownO_A, sprom_rm_o, clk_ast_tlul_i, ast_pwst_o.aon_pok)
-// DFT
-`ASSERT_KNOWN(Ast2PadmuxKnownO_A, ast2padmux_o, clk_ast_tlul_i, ast_pwst_o.aon_pok)
-// SCAN
-`ASSERT_KNOWN(DftScanMdKnownO_A, dft_scan_md_o, clk_ast_tlul_i, ast_pwst_o.aon_pok)
-`ASSERT_KNOWN(ScanShiftEnKnownO_A, scan_shift_en_o, clk_ast_tlul_i, ast_pwst_o.aon_pok)
-`ASSERT_KNOWN(ScanResetKnownO_A, scan_reset_no, clk_ast_tlul_i, ast_pwst_o.aon_pok)
-`ASSERT_KNOWN(FlashBistEnKnownO_A, flash_bist_en_o, clk_ast_tlul_i, ast_pwst_o.aon_pok)
-
-// Alert assertions for reg_we onehot check
-`ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ERR(RegWeOnehot_A,
-   u_reg, alert_req_o.alerts[ast_pkg::Ot0Sel].p, , , clk_ast_alert_i, rst_ast_alert_ni)
-
-
-/////////////////////
-// Unused Signals  //
-/////////////////////
-logic unused_sigs;
-
-assign unused_sigs = ^{ clk_ast_usb_i,
-                        rst_ast_usb_ni,
-                        sns_spi_ext_clk_i,
-                        sns_clks_i,
-                        sns_rsts_i,
-                        intg_err,
-                        shift_en,
-                        main_env_iso_en_i,
-                        rst_vcmpp_aon_n,
-                        padmux2ast_i[ast_pkg::Pad2AstInWidth-1:0],
-                        dft_strap_test_i.valid,
-                        dft_strap_test_i.straps[1:0],
-                        lc_dft_en_i[3:0],
-                        fla_obs_i[8-1:0],
-                        otp_obs_i[8-1:0],
-                        otm_obs_i[8-1:0],
-                        usb_obs_i,
-                        reg2hw.rega0,
-                        reg2hw.rega1,
-                        reg2hw.rega2,
-                        reg2hw.rega3,
-                        reg2hw.rega4,
-                        reg2hw.rega5,
-                        reg2hw.rega6,
-                        reg2hw.rega7,
-                        reg2hw.rega8,
-                        reg2hw.rega9,
-                        reg2hw.rega10,
-                        reg2hw.rega11,
-                        reg2hw.rega12,
-                        reg2hw.rega13,
-                        reg2hw.rega14,
-                        reg2hw.rega15,
-                        reg2hw.rega16,
-                        reg2hw.rega17,
-                        reg2hw.rega18,
-                        reg2hw.rega19,
-                        reg2hw.rega20,
-                        reg2hw.rega21,
-                        reg2hw.rega22,
-                        reg2hw.rega23,
-                        reg2hw.rega24,
-                        reg2hw.rega25,
-                        reg2hw.rega26,
-                        reg2hw.rega27,
-                        reg2hw.rega28,
-                        reg2hw.rega29,
-                        reg2hw.rega30,
-                        reg2hw.rega31,
-                        reg2hw.rega32,
-                        reg2hw.rega33,
-                        reg2hw.rega34,
-                        reg2hw.rega35,
-                        reg2hw.rega36,
-                        reg2hw.rega37,
-                        reg2hw.rega38,
-                        reg2hw.rega39,
-                        reg2hw.rega40,
-                        reg2hw.rega41,
-                        reg2hw.rega42,
-                        reg2hw.rega43,
-                        reg2hw.rega44,
-                        reg2hw.rega45,
-                        reg2hw.rega46,
-                        reg2hw.rega47,
-                        reg2hw.rega48,
-                        reg2hw.rega49,
-                        reg2hw.rega50,
-                        reg2hw.rega51,
-                        reg2hw.rega52,
-                        reg2hw.regb   // [0:3]
-                      };
 
 endmodule : ast

--- a/hw/top_earlgrey/ip/ast/rtl/ast_alert.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_alert.sv
@@ -24,14 +24,6 @@ logic p_alert_src, n_alert_src;
 assign p_alert_src = alert_src_i.p;
 assign n_alert_src = alert_src_i.n;
 
-logic p_alert_ack, n_alert_ack;
-assign p_alert_ack = alert_ack_i.p;
-assign n_alert_ack = alert_ack_i.n;
-
-logic p_alert_trig, n_alert_trig;
-assign p_alert_trig = alert_trig_i.p;
-assign n_alert_trig = alert_trig_i.n;
-
 // Pack outputs
 logic p_alert_req, n_alert_req;
 
@@ -41,8 +33,8 @@ assign alert_req_o.n = n_alert_req;
 // P Alert
 logic p_alert, set_p_alert, clr_p_alert;
 
-assign set_p_alert =  p_alert_src || p_alert_trig;
-assign clr_p_alert = !set_p_alert && p_alert_ack;
+assign set_p_alert =  p_alert_src || alert_trig_i.p;
+assign clr_p_alert = !set_p_alert && alert_ack_i.p;
 
 always_ff @( posedge clk_i, negedge rst_ni ) begin
   if ( !rst_ni ) begin
@@ -59,8 +51,8 @@ assign p_alert_req = p_alert;
 // N Alert
 logic n_alert, set_n_alert, clr_n_alert;
 
-assign set_n_alert = !(n_alert_src && n_alert_trig);
-assign clr_n_alert = !(set_n_alert || n_alert_ack);
+assign set_n_alert = !(n_alert_src && alert_trig_i.n);
+assign clr_n_alert = !(set_n_alert || alert_ack_i.n);
 
 always_ff @( posedge clk_i, negedge rst_ni ) begin
   if ( !rst_ni ) begin

--- a/hw/top_earlgrey/ip/ast/rtl/ast_aon.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_aon.sv
@@ -1,0 +1,735 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// -------- W A R N I N G: A U T O - G E N E R A T E D  C O D E !! -------- //
+// PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED (by closed source generator).
+//
+//############################################################################
+// *Name: ast
+// *Module Description: Analog Sensors Top
+//############################################################################
+
+`include "prim_assert.sv"
+
+module ast_aon (
+  // clocks / resets
+  input clk_ast_adc_i,                        // Buffered AST ADC Clock
+  input rst_ast_adc_ni,                       // Buffered AST ADC Reset
+  input clk_ast_alert_i,                      // Buffered AST Alert Clock
+  input rst_ast_alert_ni,                     // Buffered AST Alert Reset
+  input clk_ast_es_i,                         // Buffered AST Entropy Source Clock
+  input rst_ast_es_ni,                        // Buffered AST Entropy Source Reset
+  input clk_ast_rng_i,                        // Buffered AST RNG Clock
+  input rst_ast_rng_ni,                       // Buffered AST RNG Reset
+  input clk_ast_tlul_i,                       // Buffered AST TLUL Clock
+  input rst_ast_tlul_ni,                      // Buffered AST TLUL Reset
+  input clk_ast_usb_i,                        // Buffered AST USB Clock
+  input rst_ast_usb_ni,                       // Buffered AST USB Reset
+  input clk_ast_ext_i,                        // Buffered AST External Clock
+  input por_ni,                               // Power ON Reset
+
+  // sensed clocks / resets
+  input clkmgr_pkg::clkmgr_out_t sns_clks_i,  // Sensed Clocks
+  input rstmgr_pkg::rstmgr_out_t sns_rsts_i,  // Sensed Resets
+  input sns_spi_ext_clk_i,                    // Sensed SPI External Clock
+
+`ifdef AST_BYPASS_CLK
+  // Clocks' Oschillator bypass for OS FPGA
+  input ast_pkg::clks_osc_byp_t clk_osc_byp_i,  // Clocks' Oschillator bypass for OS FPGA/VERILATOR
+`endif
+
+  // power OK control
+  // In non-power aware DV environment, the <>_supp_i is for debug only!
+  // POK signal follow this input.
+  // In a power aware environment this signal should be connected to constant '1'
+  input vcc_supp_i,                           // VCC Supply Test for OS FPGA
+  input vcaon_supp_i,                         // VCAON Supply Test for OS FPGA
+  input vcmain_supp_i,                        // VCMAIN Supply Test for OS FPGA
+  input vioa_supp_i,                          // VIOA Rail Supply Test for OS FPGA
+  input viob_supp_i,                          // VIOB Rail Supply Test for OS FPGA
+  output ast_pkg::ast_pwst_t ast_pwst_o,      // AON, MAIN, IO-0 Rail, IO-1 Rail Power OK @1.1V
+  output ast_pkg::ast_pwst_t ast_pwst_h_o,    // AON, MAIN, IO-9 Rail, IO-1 Rail Power OK @3.3V
+
+  // Power and IO pin connections
+  input main_pd_ni,                           // MAIN Regulator Power Down
+  input main_env_iso_en_i,                    // Enveloped ISOlation ENable for MAIN
+
+  // power down monitor logic - flash/otp related
+  output logic flash_power_down_h_o,          // Flash Power Down
+  output logic flash_power_ready_h_o,         // Flash Power Ready
+  input [1:0] otp_power_seq_i,                // MMR0,24 in (VDD)
+  output logic [1:0] otp_power_seq_h_o,       // MMR0,24 masked by PDM, out (VCC)
+
+  // aon source clock
+  output logic clk_src_aon_o,                 // AON Source Clock
+  output logic clk_src_aon_val_o,             // AON Source Clock Valid
+
+  // USB reference and calibration (clock outputs moved to ast_main)
+  input usb_ref_pulse_i,                      // USB Reference Pulse
+  input usb_ref_val_i,                        // USB Reference Valid
+  input clk_src_usb_en_i,                     // USB Source Clock Enable
+  output logic [ast_pkg::UsbCalibWidth-1:0] usb_io_pu_cal_o,  // USB IO Pull-up Calibration Setting
+
+  // adc interface
+  input adc_pd_i,                             // ADC Power Down
+  input ast_pkg::awire_t adc_a0_ai,           // ADC A0 Analog Input
+  input ast_pkg::awire_t adc_a1_ai,           // ADC A1 Analog Input
+  input [ast_pkg::AdcChannels-1:0] adc_chnsel_i,       // ADC Channel Select
+  output [ast_pkg::AdcDataWidth-1:0] adc_d_o,          // ADC Digital (per channel)
+  output adc_d_val_o,                         // ADC Digital Valid
+
+  // alerts
+  input ast_pkg::ast_alert_rsp_t alert_rsp_i,  // Alerts Trigger & Acknowledge Inputs
+  output ast_pkg::ast_alert_req_t alert_req_o, // Alerts Output
+
+  // dft interface
+  input pinmux_pkg::dft_strap_test_req_t dft_strap_test_i,  // DFT Straps
+  input lc_ctrl_pkg::lc_tx_t lc_dft_en_i,     // DFT enable (secure bus)
+  input [8-1:0] fla_obs_i,                    // FLASH Observe Bus
+  input [8-1:0] otp_obs_i,                    // OTP Observe Bus
+  input [8-1:0] otm_obs_i,                    // OT Modules Observe Bus
+  input usb_obs_i,                            // USB DIFF RX Observe
+  output ast_pkg::ast_obs_ctrl_t obs_ctrl_o,  // Observe Control
+
+  // pad mux/pad related
+  input [ast_pkg::Pad2AstInWidth-1:0] padmux2ast_i,    // IO_2_DFT Input Signals
+  output logic [ast_pkg::Ast2PadOutWidth-1:0] ast2padmux_o,  // DFT_2_IO Output Signals
+  output logic [4-1:0] mux_iob_sel_o, // iob or spi selector
+
+`ifdef ANALOGSIM
+  output real ast2pad_t0_ao,                  // AST_2_PAD Analog T0 Output Signal
+  output real ast2pad_t1_ao,                  // AST_2_PAD Analog T1 Output Signal
+`else
+  output wire ast2pad_t0_ao,                  // AST_2_PAD Analog T0 Output Signal
+  output wire ast2pad_t1_ao,                  // AST_2_PAD Analog T1 Output Signal
+`endif
+
+  // flash and external clocks (clock bypass acks moved to ast_main)
+  input prim_mubi_pkg::mubi4_t ext_freq_is_96m_i,   // External clock frequecy is 96MHz
+  input prim_mubi_pkg::mubi4_t all_clk_byp_req_i,   // All clocks bypass request
+  input prim_mubi_pkg::mubi4_t io_clk_byp_req_i,    // IO clock bypass request
+  output prim_mubi_pkg::mubi4_t flash_bist_en_o,    // Flush BIST (TAP) Enable
+
+  // memories read-write margins
+  output ast_pkg::dpm_rm_t dpram_rmf_o,       // Dual Port RAM Read-write Margin Fast
+  output ast_pkg::dpm_rm_t dpram_rml_o,       // Dual Port RAM Read-write Margin sLow
+  output ast_pkg::spm_rm_t spram_rm_o,        // Single Port RAM Read-write Margin
+  output ast_pkg::spm_rm_t sprgf_rm_o,        // Single Port Reg-File Read-write Margin
+  output ast_pkg::spm_rm_t sprom_rm_o,        // Single Port ROM Read-write Margin
+
+  // Scan interface
+  output prim_mubi_pkg::mubi4_t dft_scan_md_o,  // Scan Mode output
+  output scan_shift_en_o,                       // Scan Shift Enable output
+  output scan_reset_no,                          // Scan Reset output
+
+  // Inter-domain communication
+  output ast_aon_main_pkg::aon_to_main_t aon_to_main_o,
+  input ast_aon_main_pkg::main_to_aon_t main_to_aon_i
+);
+
+import ast_pkg::* ;
+import ast_reg_pkg::* ;
+import ast_aon_main_pkg::* ;
+import ast_bhv_pkg::* ;
+
+///////////////////////////////////////
+// Inter-domain Interface Unpacking (OS simplified)
+///////////////////////////////////////
+ast_aon_main_pkg::clks_byp_main_to_aon_t clks_byp_main_to_aon;
+assign clks_byp_main_to_aon = main_to_aon_i.clks_byp;
+
+logic scan_mode, shift_en, scan_reset_n;
+logic vcc_pok, vcc_pok_h, vcc_pok_str;
+logic vcaon_pok, vcaon_pok_h, vcmain_pok_h;
+logic vcaon_pok_por, vcmain_pok_por;
+
+// Local (AST) AON clock buffer
+////////////////////////////////////////
+logic clk_aon;
+
+prim_clock_buf #(
+  .NoFpgaBuf ( 1'b1 )
+) u_clk_aon_buf (
+  .clk_i ( clk_src_aon_o ),
+  .clk_o ( clk_aon )
+);
+
+assign flash_bist_en_o  = prim_mubi_pkg::MuBi4False;
+assign dft_scan_md_o    = prim_mubi_pkg::MuBi4False;
+assign scan_shift_en_o  = 1'b0;
+assign scan_reset_no    = 1'b1;
+assign scan_mode        = 1'b0;
+assign shift_en         = 1'b0;
+assign scan_reset_n     = 1'b1;
+
+///////////////////////////////////////
+// VCC POK (Always ON)
+///////////////////////////////////////
+logic vcc_pok_int;
+
+vcc_pgd u_vcc_pok (
+  .vcc_pok_o ( vcc_pok_int )
+);
+
+assign vcc_pok = vcc_pok_int && vcc_supp_i;
+assign vcc_pok_h = vcc_pok;     // "Level Shifter"
+
+
+////////////////////////////////////////
+// VCAON POK POR (Always ON)
+///////////////////////////////////////
+logic rst_poks_n, rst_poks_por_n, por_sync_n;
+logic vcaon_pok_por_src, vcaon_pok_por_lat, poks_por_ack, rglssm_vcmon, rglssm_brout;
+
+assign rst_poks_n = vcc_pok_str && vcaon_pok;
+assign rst_poks_por_n = vcc_pok_str && vcaon_pok && por_ni;
+assign poks_por_ack = vcaon_pok_por_src || rglssm_vcmon;
+
+// Reset De-Assert Sync
+prim_flop_2sync #(
+  .Width ( 1 ),
+  .ResetValue ( 1'b0 )
+) u_no_scan_poks_por_dasrt (
+  .clk_i ( clk_aon ),
+  .rst_ni ( rst_poks_por_n ),
+  .d_i ( poks_por_ack ),
+  .q_o ( vcaon_pok_por_src )
+);
+
+logic clk_aon_n;
+
+prim_clock_inv #(
+  .HasScanMode ( 1 )
+) u_clk_aon_inv (
+  .clk_i ( clk_aon ),
+  .scanmode_i ( scan_mode ),
+  .clk_no ( clk_aon_n )
+);
+
+prim_flop #(
+  .Width ( 1 ),
+  .ResetValue ( 1'b0 )
+) u_no_scan_por_sync_n (
+  .clk_i ( clk_aon_n ),
+  .rst_ni ( rst_poks_n ),
+  .d_i ( vcaon_pok_por_src ),
+  .q_o ( por_sync_n )
+);
+
+// Replace Latch for the OS code
+assign vcaon_pok_por_lat = rglssm_brout || por_sync_n;
+assign vcaon_pok_por = scan_mode ? scan_reset_n : vcaon_pok_por_lat;
+assign ast_pwst_o.aon_pok = vcaon_pok_por;
+
+////////////////////////////////////////
+// VCMAIN POK POR (Always ON)
+///////////////////////////////////////
+logic rglssm_vmppr, vcmain_pok_por_src;
+
+assign vcmain_pok_por_src = vcaon_pok_por_lat && vcmain_pok_h && !rglssm_vmppr;
+assign vcmain_pok_por = scan_mode ? scan_reset_n : vcmain_pok_por_src;
+assign ast_pwst_o.main_pok = vcmain_pok_por;
+
+///////////////////////////////////////
+// VIOA POK (Always ON)
+///////////////////////////////////////
+logic vioa_pok;
+logic vioa_pok_int;
+
+vio_pgd u_vioa_pok (
+  .vio_pok_o ( vioa_pok_int )
+);
+
+assign vioa_pok = vioa_pok_int && vioa_supp_i;
+assign ast_pwst_o.io_pok[0] = vcaon_pok && vioa_pok;
+
+///////////////////////////////////////
+// VIOB POK (Always ON)
+///////////////////////////////////////
+logic viob_pok;
+logic viob_pok_int;
+
+vio_pgd u_viob_pok (
+  .vio_pok_o ( viob_pok_int )
+);
+
+assign viob_pok = viob_pok_int && viob_supp_i;
+assign ast_pwst_o.io_pok[1] = vcaon_pok && viob_pok;
+assign mux_iob_sel_o = 4'h0;
+
+///////////////////////////////////////
+// Regulators & PDM Logic (VCC)
+///////////////////////////////////////
+logic deep_sleep;
+logic main_pd, por_sync;
+
+assign main_pd = !main_pd_ni;
+assign por_sync = !por_sync_n;
+
+rglts_pdm_3p3v u_rglts_pdm_3p3v (
+  .vcc_pok_h_i ( vcc_pok_h ),
+  .vcaon_pok_por_h_i ( vcaon_pok_por_src ),
+  .vcmain_pok_por_h_i ( vcmain_pok_por_src ),
+  .vio_pok_h_i ( ast_pwst_o.io_pok[1:0] ),
+  .clk_src_aon_h_i ( clk_aon ),
+  .main_pd_h_i ( main_pd ),
+  .por_sync_h_i ( por_sync ),
+  .scan_mode_h_i ( scan_mode ),
+  .otp_power_seq_h_i ( otp_power_seq_i[2-1:0] ),
+  .vcaon_supp_i ( vcaon_supp_i ),
+  .vcmain_supp_i ( vcmain_supp_i ),
+  .rglssm_vmppr_h_o ( rglssm_vmppr ),
+  .rglssm_vcmon_h_o ( rglssm_vcmon ),
+  .rglssm_brout_h_o ( rglssm_brout ),
+  .vcmain_pok_h_o ( vcmain_pok_h ),
+  .vcmain_pok_por_h_o ( ast_pwst_h_o.main_pok ),
+  .vcaon_pok_h_o ( vcaon_pok_h ),
+  .vcaon_pok_1p1_h_o ( vcaon_pok ),
+  .vcaon_pok_por_h_o ( ast_pwst_h_o.aon_pok ),
+  .vio_pok_h_o ( ast_pwst_h_o.io_pok[2-1:0] ),
+  .vcc_pok_str_h_o ( ast_pwst_h_o.vcc_pok ),
+  .vcc_pok_str_1p1_h_o ( vcc_pok_str ),
+  .deep_sleep_h_o ( deep_sleep ),
+  .flash_power_down_h_o ( flash_power_down_h_o ),
+  .flash_power_ready_h_o ( flash_power_ready_h_o ),
+  .otp_power_seq_h_o ( otp_power_seq_h_o[2-1:0] )
+);
+
+assign ast_pwst_o.vcc_pok = vcc_pok_str;
+
+///////////////////////////////////////
+///////////////////////////////////////
+// Clocks Oscillattors
+///////////////////////////////////////
+///////////////////////////////////////
+
+// System Clock, USB Clock, IO Clock moved to ast_main.sv
+// Keep reset signals for inter-domain communication
+logic rst_sys_clk_n, rst_io_clk_n, rst_usb_clk_n;
+assign rst_sys_clk_n = vcmain_pok_por && vcc_pok;
+assign rst_io_clk_n  = vcmain_pok_por && vcc_pok;
+assign rst_usb_clk_n = vcmain_pok_por && vcc_pok;
+
+logic sys_io_osc_cal;
+logic usb_osc_cal;
+
+///////////////////////////////////////
+// AON Clock (Always ON)
+///////////////////////////////////////
+logic rst_aon_clk_n;
+logic clk_src_aon_en, clk_osc_aon, clk_osc_aon_val;
+logic aon_osc_cal;
+
+`ifdef AST_BYPASS_CLK
+logic clk_aon_ext;
+assign clk_aon_ext = clk_osc_byp_i.aon;
+`endif
+
+assign rst_aon_clk_n = vcc_pok_str && vcaon_pok;
+assign clk_src_aon_en = 1'b1;  // Always Enabled
+
+aon_clk  u_aon_clk (
+  .vcore_pok_h_i ( vcaon_pok_h ),
+  .clk_aon_pd_ni ( 1'b1 ),     // Always Enabled
+  .rst_aon_clk_ni ( rst_aon_clk_n ),
+  .clk_src_aon_en_i ( clk_src_aon_en ),
+  .scan_mode_i ( scan_mode ),
+  .aon_osc_cal_i ( aon_osc_cal ),
+`ifdef AST_BYPASS_CLK
+  .clk_aon_ext_i ( clk_aon_ext ),
+`endif
+  .clk_src_aon_o ( clk_osc_aon ),
+  .clk_src_aon_val_o ( clk_osc_aon_val )
+);
+
+logic vcmpp_aon_sync_n, rst_vcmpp_aon_n;
+
+// Reset De-Assert Sync
+prim_flop_2sync #(
+  .Width ( 1 ),
+  .ResetValue ( 1'b0 )
+) u_rst_vcmpp_aon_dasrt (
+  .clk_i ( clk_aon ),
+  .rst_ni ( vcmain_pok_por ),
+  .d_i ( 1'b1 ),
+  .q_o ( vcmpp_aon_sync_n )
+);
+
+assign rst_vcmpp_aon_n = scan_mode ? scan_reset_n : vcmpp_aon_sync_n;
+// IO Clock moved to ast_main.sv
+
+///////////////////////////////////////
+// AST Clocks Bypass
+///////////////////////////////////////
+// AON clock only in ast_aon, SYS/IO/USB handled by ast_main
+logic clk_src_aon;
+
+// Inter-domain interface signal for clock bypass (clks_byp_main_to_aon declared earlier)
+ast_aon_main_pkg::clks_byp_aon_to_main_t clks_byp_aon_to_main;
+
+// AON clock bypass - simplified for OS domain-split
+ast_clks_byp_aon u_ast_clks_byp_aon (
+  .vcaon_pok_i ( vcaon_pok ),
+  .vcmain_pok_i ( vcmain_pok_h ),
+  .scan_mode_i ( scan_mode ),
+  .scan_reset_ni ( scan_reset_n ),
+  .clk_osc_aon_i ( clk_osc_aon ),
+  .clk_osc_aon_val_i ( clk_osc_aon_val ),
+  .main_to_aon_i ( clks_byp_main_to_aon ),
+  .aon_to_main_o ( clks_byp_aon_to_main )
+);
+
+assign clk_src_aon = clks_byp_aon_to_main.clk_src_aon_o;
+assign clk_src_aon_val_o = clks_byp_aon_to_main.clk_src_aon_val_o;
+
+// AON source clock buffer
+////////////////////////////////////////
+prim_clock_buf #(
+  .NoFpgaBuf ( 1'b1 )
+) u_clk_src_aon_buf (
+  .clk_i ( clk_src_aon ),
+  .clk_o ( clk_src_aon_o )
+);
+
+///////////////////////////////////////
+// ADC (Always ON)
+///////////////////////////////////////
+adc #(
+  .AdcCnvtClks ( AdcCnvtClks ),
+  .AdcChannels ( ast_pkg::AdcChannels ),
+  .AdcDataWidth ( ast_pkg::AdcDataWidth )
+) u_adc (
+  .adc_a0_ai ( adc_a0_ai ),
+  .adc_a1_ai ( adc_a1_ai ),
+  .adc_chnsel_i ( adc_chnsel_i[ast_pkg::AdcChannels-1:0] ),
+  .adc_pd_i ( adc_pd_i ),
+  .clk_adc_i ( clk_ast_adc_i ),
+  .rst_adc_ni ( rst_ast_adc_ni ),
+  .adc_d_o ( adc_d_o[ast_pkg::AdcDataWidth-1:0] ),
+  .adc_d_val_o ( adc_d_val_o )
+);
+
+///////////////////////////////////////
+// Alerts (Always ON)
+///////////////////////////////////////
+ast_pkg::ast_dif_t as_alert_src;
+ast_pkg::ast_dif_t cgc_alert_src;
+ast_pkg::ast_dif_t gd_alert_src;
+ast_pkg::ast_dif_t ot0_alert_src;
+ast_pkg::ast_dif_t ts_alert_hi_src;
+ast_pkg::ast_dif_t ts_alert_lo_src;
+ast_pkg::ast_dif_t ot1_alert_src;
+ast_pkg::ast_dif_t ot2_alert_src;
+ast_pkg::ast_dif_t ot3_alert_src;
+ast_pkg::ast_dif_t ot4_alert_src;
+ast_pkg::ast_dif_t ot5_alert_src;
+
+
+// Active Shield (AS)
+///////////////////////////////////////
+ast_alert u_alert_as (
+  .clk_i ( clk_ast_alert_i ),
+  .rst_ni ( rst_ast_alert_ni ),
+  .alert_src_i ( as_alert_src ),
+  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::AsSel] ),
+  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::AsSel] ),
+  .alert_req_o ( alert_req_o.alerts[ast_pkg::AsSel] )
+);
+
+// Clock Glitch (CG)
+///////////////////////////////////////
+ast_alert u_alert_cg (
+  .clk_i ( clk_ast_alert_i ),
+  .rst_ni ( rst_ast_alert_ni ),
+  .alert_src_i ( cgc_alert_src ),
+  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::CgSel] ),
+  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::CgSel] ),
+  .alert_req_o ( alert_req_o.alerts[ast_pkg::CgSel] )
+);
+
+// Glitch Detector (GD)
+///////////////////////////////////////
+ast_alert u_alert_gd (
+  .clk_i ( clk_ast_alert_i ),
+  .rst_ni ( rst_ast_alert_ni ),
+  .alert_src_i ( gd_alert_src ),
+  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::GdSel] ),
+  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::GdSel] ),
+  .alert_req_o ( alert_req_o.alerts[ast_pkg::GdSel] )
+);
+
+// Temprature Sensor High (TS Hi)
+///////////////////////////////////////
+ast_alert u_alert_ts_hi (
+  .clk_i ( clk_ast_alert_i ),
+  .rst_ni ( rst_ast_alert_ni ),
+  .alert_src_i ( ts_alert_hi_src ),
+  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::TsHiSel] ),
+  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::TsHiSel] ),
+  .alert_req_o ( alert_req_o.alerts[ast_pkg::TsHiSel] )
+);
+
+// Temprature Sensor Low (TS Lo)
+///////////////////////////////////////
+ast_alert u_alert_ts_lo (
+  .clk_i ( clk_ast_alert_i ),
+  .rst_ni ( rst_ast_alert_ni ),
+  .alert_src_i ( ts_alert_lo_src ),
+  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::TsLoSel] ),
+  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::TsLoSel] ),
+  .alert_req_o ( alert_req_o.alerts[ast_pkg::TsLoSel] )
+);
+
+// Other-0 Alert (OT0)
+///////////////////////////////////////
+ast_alert u_alert_ot0 (
+  .clk_i ( clk_ast_alert_i ),
+  .rst_ni ( rst_ast_alert_ni ),
+  .alert_src_i ( ot0_alert_src ),
+  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::Ot0Sel] ),
+  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::Ot0Sel] ),
+  .alert_req_o ( alert_req_o.alerts[ast_pkg::Ot0Sel] )
+); // of u_alert_ot0
+
+// Other-1 Alert (OT1)
+///////////////////////////////////////
+ast_alert u_alert_ot1 (
+  .clk_i ( clk_ast_alert_i ),
+  .rst_ni ( rst_ast_alert_ni ),
+  .alert_src_i ( ot1_alert_src ),
+  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::Ot1Sel] ),
+  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::Ot1Sel] ),
+  .alert_req_o ( alert_req_o.alerts[ast_pkg::Ot1Sel] )
+); // of u_alert_ot1
+
+// Other-2 Alert (OT2)
+///////////////////////////////////////
+ast_alert u_alert_ot2 (
+  .clk_i ( clk_ast_alert_i ),
+  .rst_ni ( rst_ast_alert_ni ),
+  .alert_src_i ( ot2_alert_src ),
+  .alert_trig_i ( alert_rsp_i.alerts_trig[Ot2Sel] ),
+  .alert_ack_i ( alert_rsp_i.alerts_ack[Ot2Sel] ),
+  .alert_req_o ( alert_req_o.alerts[Ot2Sel] )
+); // of u_alert_ot2
+
+// Other-3 Alert (OT3)
+///////////////////////////////////////
+ast_alert u_alert_ot3 (
+  .clk_i ( clk_ast_alert_i ),
+  .rst_ni ( rst_ast_alert_ni ),
+  .alert_src_i ( ot3_alert_src ),
+  .alert_trig_i ( alert_rsp_i.alerts_trig[Ot3Sel] ),
+  .alert_ack_i ( alert_rsp_i.alerts_ack[Ot3Sel] ),
+  .alert_req_o ( alert_req_o.alerts[Ot3Sel] )
+); // of u_alert_ot3
+
+// Other-4 Alert (OT4)
+///////////////////////////////////////
+ast_alert u_alert_ot4 (
+  .clk_i ( clk_ast_alert_i ),
+  .rst_ni ( rst_ast_alert_ni ),
+  .alert_src_i ( ot4_alert_src ),
+  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::Ot4Sel] ),
+  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::Ot4Sel] ),
+  .alert_req_o ( alert_req_o.alerts[ast_pkg::Ot4Sel] )
+); // of u_alert_ot4
+
+// Other-5 Alert (OT5)
+///////////////////////////////////////
+ast_alert u_alert_ot5 (
+  .clk_i ( clk_ast_alert_i ),
+  .rst_ni ( rst_ast_alert_ni ),
+  .alert_src_i ( ot5_alert_src ),
+  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::Ot5Sel] ),
+  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::Ot5Sel] ),
+  .alert_req_o ( alert_req_o.alerts[ast_pkg::Ot5Sel] )
+); // of u_alert_ot5
+
+// Alerts Open-Source Selection
+////////////////////////////////////////
+assign as_alert_src    = '{p: 1'b0, n: 1'b1};
+assign cgc_alert_src   = '{p: 1'b0, n: 1'b1};
+assign gd_alert_src    = '{p: 1'b0, n: 1'b1};
+assign ts_alert_hi_src = '{p: 1'b0, n: 1'b1};
+assign ts_alert_lo_src = '{p: 1'b0, n: 1'b1};
+assign ot1_alert_src   = '{p: 1'b0, n: 1'b1};
+assign ot2_alert_src   = '{p: 1'b0, n: 1'b1};
+assign ot3_alert_src   = '{p: 1'b0, n: 1'b1};
+assign ot4_alert_src   = '{p: 1'b0, n: 1'b1};
+assign ot5_alert_src   = '{p: 1'b0, n: 1'b1};
+
+///////////////////////////////////////
+// AST Registers (Always ON)
+///////////////////////////////////////
+
+// TLUL Integrity Error (from main domain)
+assign ot0_alert_src = main_to_aon_i.ot0_alert_src;
+
+// Calibration signals - simple initialization for OS
+// (REGAL register and ast_init_done_o are now in ast_main.sv)
+always_ff @( posedge clk_ast_tlul_i, negedge rst_ast_tlul_ni ) begin
+  if ( !rst_ast_tlul_ni ) begin
+    sys_io_osc_cal <= 1'b0;
+  end else if (main_to_aon_i.regal_we) begin
+    sys_io_osc_cal <= 1'b1;
+  end
+end
+
+always_ff @( posedge clk_ast_tlul_i, negedge vcaon_pok_por ) begin
+  if ( !vcaon_pok_por ) begin
+    usb_osc_cal <= 1'b0;
+  end else if (main_to_aon_i.regal_we) begin
+    usb_osc_cal <= 1'b1;
+  end
+end
+
+always_ff @( posedge clk_ast_tlul_i, negedge vcaon_pok ) begin
+  if ( !vcaon_pok ) begin
+    aon_osc_cal <= 1'b0;
+  end else if (main_to_aon_i.regal_we) begin
+    aon_osc_cal <= 1'b1;
+  end
+end
+
+// USB PU-P and PU-N value selection
+assign usb_io_pu_cal_o = ast_pkg::UsbCalibWidth'(1 << (ast_pkg::UsbCalibWidth[5-1:0]/2));
+
+///////////////////////////////////////
+// DFT (Main | Always ON)
+///////////////////////////////////////
+ast_dft u_ast_dft (
+  .obs_ctrl_o ( obs_ctrl_o ),
+  .ast2padmux_o ( ast2padmux_o[ast_pkg::Ast2PadOutWidth-1:0] ),
+  .dpram_rmf_o ( dpram_rmf_o ),
+  .dpram_rml_o ( dpram_rml_o ),
+  .spram_rm_o ( spram_rm_o ),
+  .sprgf_rm_o ( sprgf_rm_o ),
+  .sprom_rm_o ( sprom_rm_o )
+);
+
+////////////////////////////////////////
+// DFT Misc Logic
+////////////////////////////////////////
+`ifdef ANALOGSIM
+assign ast2pad_t0_ao = 0.0;
+assign ast2pad_t1_ao = 0.1;
+`else
+assign ast2pad_t0_ao = 1'bz;
+assign ast2pad_t1_ao = 1'bz;
+`endif
+
+////////////////////////////////////////
+// Inter-domain communication (OS simplified)
+////////////////////////////////////////
+// Power signals
+assign aon_to_main_o.pwr.vcc_pok = vcc_pok;
+assign aon_to_main_o.pwr.vcaon_pok = vcaon_pok;
+assign aon_to_main_o.pwr.vcmain_pok_h = vcmain_pok_h;
+assign aon_to_main_o.pwr.vcmain_pok_por = vcmain_pok_por;
+assign aon_to_main_o.pwr.vcc_pok_str = vcc_pok_str;
+
+// Clock and reset signals
+assign aon_to_main_o.clk_rst.clk_aon = clk_aon;
+assign aon_to_main_o.clk_rst.clk_ast_tlul = clk_ast_tlul_i;
+assign aon_to_main_o.clk_rst.rst_ast_tlul_n = rst_ast_tlul_ni;
+assign aon_to_main_o.clk_rst.clk_ast_rng = clk_ast_rng_i;
+assign aon_to_main_o.clk_rst.rst_ast_rng_n = rst_ast_rng_ni;
+assign aon_to_main_o.clk_rst.clk_ast_es = clk_ast_es_i;
+assign aon_to_main_o.clk_rst.rst_ast_es_n = rst_ast_es_ni;
+assign aon_to_main_o.clk_rst.rst_sys_clk_n = rst_sys_clk_n;
+assign aon_to_main_o.clk_rst.rst_io_clk_n = rst_io_clk_n;
+assign aon_to_main_o.clk_rst.rst_usb_clk_n = rst_usb_clk_n;
+
+// Clock bypass interface (OS uses monolithic ast_clks_byp, provide defaults)
+assign aon_to_main_o.clks_byp = clks_byp_aon_to_main;
+
+// Oscillator control interface
+assign aon_to_main_o.clk_osc.deep_sleep = deep_sleep;
+assign aon_to_main_o.clk_osc.usb_ref_pulse = usb_ref_pulse_i;
+assign aon_to_main_o.clk_osc.usb_ref_val = usb_ref_val_i;
+
+// Scan signals
+assign aon_to_main_o.scan_mode = scan_mode;
+assign aon_to_main_o.scan_reset_n = scan_reset_n;
+
+// Calibration signals
+assign aon_to_main_o.sys_io_osc_cal = sys_io_osc_cal;
+assign aon_to_main_o.usb_osc_cal = usb_osc_cal;
+
+// Clock outputs and bypass acks now directly output from ast_main
+
+////////////////
+// Assertions //
+////////////////
+
+// Clocks
+`ASSERT_KNOWN(ClkSrcAonKnownO_A, clk_src_aon_o, 1, ast_pwst_o.aon_pok)
+`ASSERT_KNOWN(ClkSrcAonValKnownO_A, clk_src_aon_val_o, clk_src_aon_o, rst_aon_clk_n)
+//
+`ASSERT_KNOWN(UsbIoPuCalKnownO_A, usb_io_pu_cal_o, clk_ast_tlul_i, ast_pwst_o.aon_pok)
+// ADC
+`ASSERT_KNOWN(AdcDKnownO_A, adc_d_o, clk_ast_adc_i, rst_ast_adc_ni)
+`ASSERT_KNOWN(AdcDValKnownO_A, adc_d_val_o, clk_ast_adc_i, rst_ast_adc_ni)
+// Note: RNG assertions moved to ast_main.sv
+// TLUL and InitDone asserts are now in ast_main.sv
+// POs
+`ASSERT_KNOWN(VcaonPokKnownO_A, ast_pwst_o.aon_pok, clk_src_aon_o, por_ni)
+`ASSERT_KNOWN(VcmainPokKnownO_A, ast_pwst_o.main_pok, clk_src_aon_o, por_ni)
+`ASSERT_KNOWN(VioaPokKnownO_A, ast_pwst_o.io_pok[0], clk_src_aon_o, por_ni)
+`ASSERT_KNOWN(ViobPokKnownO_A, ast_pwst_o.io_pok[1], clk_src_aon_o, por_ni)
+`ASSERT_KNOWN(VcaonPokHKnownO_A, ast_pwst_h_o.aon_pok, clk_src_aon_o, por_ni)
+`ASSERT_KNOWN(VcmainPokHKnownO_A, ast_pwst_h_o.main_pok, clk_src_aon_o, por_ni)
+`ASSERT_KNOWN(VioaPokHKnownO_A, ast_pwst_h_o.io_pok[0], clk_src_aon_o, por_ni)
+`ASSERT_KNOWN(ViobPokHKnownO_A, ast_pwst_h_o.io_pok[1], clk_src_aon_o, por_ni)
+// FLASH/OTP
+`ASSERT_KNOWN(FlashPowerDownKnownO_A, flash_power_down_h_o, 1, ast_pwst_o.main_pok)
+`ASSERT_KNOWN(FlashPowerReadyKnownO_A, flash_power_ready_h_o, 1, ast_pwst_o.main_pok)
+`ASSERT_KNOWN(OtpPowerSeqKnownO_A, otp_power_seq_h_o, 1, ast_pwst_o.main_pok)
+// Alerts
+`ASSERT_KNOWN(AlertReqKnownO_A, alert_req_o, clk_ast_alert_i, rst_ast_alert_ni)
+// DPRAM/SPRAM
+`ASSERT_KNOWN(DpramRmfKnownO_A, dpram_rmf_o, clk_ast_tlul_i, ast_pwst_o.aon_pok)
+`ASSERT_KNOWN(DpramRmlKnownO_A, dpram_rml_o, clk_ast_tlul_i, ast_pwst_o.aon_pok)
+`ASSERT_KNOWN(SpramRmKnownO_A, spram_rm_o, clk_ast_tlul_i, ast_pwst_o.aon_pok)
+`ASSERT_KNOWN(SprgfRmKnownO_A, sprgf_rm_o, clk_ast_tlul_i, ast_pwst_o.aon_pok)
+`ASSERT_KNOWN(SpromRmKnownO_A, sprom_rm_o, clk_ast_tlul_i, ast_pwst_o.aon_pok)
+// DFT
+`ASSERT_KNOWN(Ast2PadmuxKnownO_A, ast2padmux_o, clk_ast_tlul_i, ast_pwst_o.aon_pok)
+// SCAN
+`ASSERT_KNOWN(DftScanMdKnownO_A, dft_scan_md_o, clk_ast_tlul_i, ast_pwst_o.aon_pok)
+`ASSERT_KNOWN(ScanShiftEnKnownO_A, scan_shift_en_o, clk_ast_tlul_i, ast_pwst_o.aon_pok)
+`ASSERT_KNOWN(ScanResetKnownO_A, scan_reset_no, clk_ast_tlul_i, ast_pwst_o.aon_pok)
+`ASSERT_KNOWN(FlashBistEnKnownO_A, flash_bist_en_o, clk_ast_tlul_i, ast_pwst_o.aon_pok)
+
+// Note: reg_we onehot assertion moved to ast_main.sv along with u_reg
+/////////////////////
+// Unused Signals  //
+/////////////////////
+logic unused_sigs;
+
+assign unused_sigs = ^{ clk_ast_usb_i,
+                        rst_ast_usb_ni,
+                        sns_spi_ext_clk_i,
+                        sns_clks_i,
+                        sns_rsts_i,
+                        shift_en,
+                        main_env_iso_en_i,
+                        rst_vcmpp_aon_n,
+                        padmux2ast_i[ast_pkg::Pad2AstInWidth-1:0],
+                        dft_strap_test_i.valid,
+                        dft_strap_test_i.straps[1:0],
+                        lc_dft_en_i[3:0],
+                        fla_obs_i[8-1:0],
+                        otp_obs_i[8-1:0],
+                        otm_obs_i[8-1:0],
+                        usb_obs_i,
+                        clk_ast_ext_i,
+                        clk_src_usb_en_i,
+                        ext_freq_is_96m_i,
+                        all_clk_byp_req_i,
+                        io_clk_byp_req_i
+                      };
+
+endmodule : ast_aon

--- a/hw/top_earlgrey/ip/ast/rtl/ast_aon_main_pkg.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_aon_main_pkg.sv
@@ -1,0 +1,98 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// AST AON-Main Domain Communication Package
+// Defines structured communication between AON and Main power domains
+//
+//############################################################################
+
+package ast_aon_main_pkg;
+
+  import ast_pkg::*;
+  import ast_reg_pkg::*;
+
+
+  //////////////////////////////////////////////////////////////////////////
+  // OS Simplified Inter-domain Communication Structures
+  //////////////////////////////////////////////////////////////////////////
+
+  // Power signals: AON to Main
+  typedef struct packed {
+    logic vcc_pok;
+    logic vcaon_pok;
+    logic vcmain_pok_h;
+    logic vcmain_pok_por;
+    logic vcc_pok_str;
+  } pwr_aon_to_main_t;
+
+  // Clock and reset signals for AON to Main domain communication
+  typedef struct packed {
+    logic clk_aon;
+    logic clk_ast_tlul;
+    logic rst_ast_tlul_n;
+    logic clk_ast_rng;
+    logic rst_ast_rng_n;
+    logic clk_ast_es;
+    logic rst_ast_es_n;
+    logic rst_sys_clk_n;
+    logic rst_io_clk_n;
+    logic rst_usb_clk_n;
+  } aon_to_main_clk_rst_t;
+
+  // Clock bypass interface: Main to AON domain
+  typedef struct packed {
+    logic clk_ext_aon;        // Divided external clock for AON (from main dividers)
+    logic aon_select_ext;     // AON bypass select (1=external, 0=internal)
+  } clks_byp_main_to_aon_t;
+
+  // Clock bypass interface: AON to Main domain
+  typedef struct packed {
+    logic clk_src_aon_o;      // Selected AON clock output
+    logic clk_src_aon_val_o;  // AON clock valid
+    logic aon_clk_byp_en;     // AON bypass enabled (for ack generation)
+  } clks_byp_aon_to_main_t;
+
+  // Oscillator control: AON to Main
+  typedef struct packed {
+    logic deep_sleep;
+    logic usb_ref_pulse;
+    logic usb_ref_val;
+  } clk_osc_aon_to_main_t;
+
+  // AON to Main Domain Communication Structure (OS simplified)
+  typedef struct packed {
+    // Clock bypass interface
+    clks_byp_aon_to_main_t clks_byp;
+
+    // Oscillator control interface
+    clk_osc_aon_to_main_t clk_osc;
+
+    // Clock and reset signals
+    aon_to_main_clk_rst_t clk_rst;
+
+    // Power signals
+    pwr_aon_to_main_t pwr;
+
+    // Scan signals
+    logic scan_mode;
+    logic scan_reset_n;
+
+    // Calibration signals
+    logic sys_io_osc_cal;
+    logic usb_osc_cal;
+  } aon_to_main_t;
+
+  // Main to AON Domain Communication Structure (OS simplified)
+  typedef struct packed {
+    // Clock bypass interface
+    clks_byp_main_to_aon_t clks_byp;
+
+    // Alert source from main (TLUL integrity error)
+    ast_pkg::ast_dif_t ot0_alert_src;
+
+    logic regal_we;
+  } main_to_aon_t;
+
+
+endpackage : ast_aon_main_pkg

--- a/hw/top_earlgrey/ip/ast/rtl/ast_clks_byp_aon.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_clks_byp_aon.sv
@@ -1,0 +1,94 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+//############################################################################
+// *Name: ast_clks_byp_aon
+// *Module Description: AST Clocks Bypass - AON Power Domain
+//
+// Contains AON clock mux and associated reset logic. Self-sufficient when
+// main domain is powered down - automatically selects internal oscillator
+// via rst_clk_ext_aon_n tied directly to vcmain_pok_i.
+//############################################################################
+
+`include "prim_assert.sv"
+
+module ast_clks_byp_aon
+  import ast_aon_main_pkg::*;
+(
+  // Power OK signals
+  input  logic vcaon_pok_i,                 // VCAON POK
+  input  logic vcmain_pok_i,                // VCMAIN POK (direct - safety mechanism)
+  // Scan signals
+  input  logic scan_mode_i,                 // Scan Mode
+  input  logic scan_reset_ni,               // Scan Reset
+  // Oscillator clock inputs
+  input  logic clk_osc_aon_i,               // AON Oscillator Clock
+  input  logic clk_osc_aon_val_i,           // AON Oscillator Clock Valid
+  // Interface from main domain
+  input  clks_byp_main_to_aon_t main_to_aon_i,
+  // Interface to main domain
+  output clks_byp_aon_to_main_t aon_to_main_o
+);
+
+////////////////////////////////////////
+// Reset Generation
+////////////////////////////////////////
+// Key safety mechanism: rst_clk_ext_aon_n is directly tied to vcmain_pok_i
+// When main powers down, this immediately disables external clock path
+// in the mux, forcing internal oscillator selection regardless of control signals.
+
+logic vcaon_pok;  // For Spyglass waiver
+assign vcaon_pok = vcaon_pok_i;
+
+logic rst_clk_osc_n, aon_rst_clk_ext_n;
+assign rst_clk_osc_n = scan_mode_i ? scan_reset_ni : vcaon_pok;
+assign aon_rst_clk_ext_n = scan_mode_i ? scan_reset_ni : vcmain_pok_i;
+
+////////////////////////////////////////
+// Reset Buffers
+////////////////////////////////////////
+logic rst_clk_osc_aon_n, rst_clk_ext_aon_n;
+
+prim_buf u_rst_clk_osc_aon (
+  .in_i ( rst_clk_osc_n ),
+  .out_o ( rst_clk_osc_aon_n )
+);
+
+prim_buf u_rst_clk_ext_aon (
+  .in_i ( aon_rst_clk_ext_n ),
+  .out_o ( rst_clk_ext_aon_n )
+);
+
+////////////////////////////////////////
+// AON Clock Bypass Mux
+////////////////////////////////////////
+logic clk_src_aon, clk_src_aon_val;
+logic aon_clk_osc_en, aon_clk_byp_en;
+
+gfr_clk_mux2 u_clk_src_aon_sel (
+  .clk_osc_i ( clk_osc_aon_i ),
+  .clk_osc_val_i ( clk_osc_aon_val_i ),
+  .rst_clk_osc_ni ( rst_clk_osc_aon_n ),
+  .clk_ext_i ( main_to_aon_i.clk_ext_aon ),
+  .clk_ext_val_i ( 1'b1 ),  // Always ON clock
+  .rst_clk_ext_ni ( rst_clk_ext_aon_n ),
+  .ext_sel_i ( main_to_aon_i.aon_select_ext ),
+  .clk_osc_en_o ( aon_clk_osc_en ),
+  .clk_ext_en_o ( aon_clk_byp_en ),
+  .clk_val_o ( clk_src_aon_val ),
+  .clk_o ( clk_src_aon )
+);
+
+////////////////////////////////////////
+// Output Assignments
+////////////////////////////////////////
+assign aon_to_main_o.clk_src_aon_o = clk_src_aon;
+assign aon_to_main_o.clk_src_aon_val_o = clk_src_aon_val;
+assign aon_to_main_o.aon_clk_byp_en = aon_clk_byp_en;
+
+// Unused signal
+logic unused_aon_clk_osc_en;
+assign unused_aon_clk_osc_en = aon_clk_osc_en;
+
+endmodule : ast_clks_byp_aon

--- a/hw/top_earlgrey/ip/ast/rtl/ast_dft.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_dft.sv
@@ -36,10 +36,10 @@ assign obs_ctrl_o = '{
 ////////////////////////////////////////
 // Memories Read-write Margins
 ////////////////////////////////////////
-assign dpram_rmf_o = 10'h000;
-assign dpram_rml_o = 10'h000;
-assign spram_rm_o  = 5'h00;
-assign sprgf_rm_o  = 5'h00;
-assign sprom_rm_o  = 5'h00;
+assign dpram_rmf_o = 12'h000;
+assign dpram_rml_o = 12'h000;
+assign spram_rm_o  = 6'h00;
+assign sprgf_rm_o  = 6'h00;
+assign sprom_rm_o  = 6'h00;
 
 endmodule : ast_dft

--- a/hw/top_earlgrey/ip/ast/rtl/ast_entropy.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_entropy.sv
@@ -35,13 +35,10 @@ typedef enum logic [2-1:0] {
 
 erq_sm_e erq_sm;
 logic dev0_wready, dev0_ack;
-logic edn_ack, edn_req;
-logic [32-1:0] edn_bus;
+logic edn_req;
 
 // Pack/Un-pack
 assign entropy_req_o.edn_req = edn_req;
-assign edn_ack = entropy_rsp_i.edn_ack;
-assign edn_bus = entropy_rsp_i.edn_bus;
 
 always_ff @( posedge clk_ast_es_i, negedge rst_ast_es_ni ) begin
   if ( !rst_ast_es_ni ) begin
@@ -60,7 +57,7 @@ always_ff @( posedge clk_ast_es_i, negedge rst_ast_es_ni ) begin
       end
 
       ERQ_REQ0: begin
-        if ( edn_ack ) begin
+        if ( entropy_rsp_i.edn_ack ) begin
           edn_req <= 1'b0;
           erq_sm  <= ERQ_ACK0;
         end else begin
@@ -87,7 +84,7 @@ always_ff @( posedge clk_ast_es_i, negedge rst_ast_es_ni ) begin
   end
 end
 
-assign dev0_ack = edn_ack && ((erq_sm == ERQ_REQ0) || (erq_sm == ERQ_ACK0));
+assign dev0_ack = entropy_rsp_i.edn_ack && ((erq_sm == ERQ_REQ0) || (erq_sm == ERQ_ACK0));
 
 
 ////////////////////////////////////////
@@ -107,7 +104,7 @@ dev_entropy #(
   .dev_en_i ( dev0_en ),
   .dev_rate_i ( entropy_rate_i[EntropyRateWidth-1:0] ),
   .dev_ack_i ( dev0_ack ),
-  .dev_data_i ( edn_bus[32-1:0] ),
+  .dev_data_i ( entropy_rsp_i.edn_bus[32-1:0] ),
   .dev_wready_o ( dev0_wready ),
   .dev_data_o ( dev0_entropy )
 );

--- a/hw/top_earlgrey/ip/ast/rtl/ast_main.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_main.sv
@@ -1,0 +1,467 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Created for AST domain separation - Main Domain
+//
+//############################################################################
+// *Name: ast_main
+// *Module Description: Analog Sensors Top - Main Domain
+//############################################################################
+
+`include "prim_assert.sv"
+
+module ast_main (
+  // TLUL interface
+  input tlul_pkg::tl_h2d_t tl_i,
+  output tlul_pkg::tl_d2h_t tl_o,
+  input clk_ast_tlul_i,
+  input rst_ast_tlul_ni,
+  output prim_mubi_pkg::mubi4_t ast_init_done_o,
+  // RNG interface
+  input rng_en_i,
+  input rng_fips_i,
+  output logic rng_val_o,
+  output logic [ast_pkg::EntropyStreams-1:0] rng_b_o,
+  // Entropy interface
+  input edn_pkg::edn_rsp_t entropy_rsp_i,
+  output edn_pkg::edn_req_t entropy_req_o,
+  // Entropy source clock/reset
+  input logic clk_ast_es_i,
+  input logic rst_ast_es_ni,
+  input prim_mubi_pkg::mubi4_t clk_src_sys_jen_i,
+  // Inter-domain communication
+  input ast_aon_main_pkg::aon_to_main_t aon_to_main_i,
+  output ast_aon_main_pkg::main_to_aon_t main_to_aon_o,
+  // Clock bypass interface
+  input  logic clk_ast_ext_i,
+  input  logic clk_src_sys_en_i,
+  input  logic clk_src_io_en_i,
+  input  logic clk_src_usb_en_i,
+  input  logic clk_ast_usb_i,                      // Buffered AST USB Clock
+  input  logic rst_ast_usb_ni,                     // Buffered AST USB Reset
+  input  prim_mubi_pkg::mubi4_t io_clk_byp_req_i,
+  input  prim_mubi_pkg::mubi4_t all_clk_byp_req_i,
+  input  prim_mubi_pkg::mubi4_t ext_freq_is_96m_i,
+
+`ifdef AST_BYPASS_CLK
+  // Clocks' Oschillator bypass for OS FPGA
+  input ast_pkg::clks_osc_byp_t clk_osc_byp_i,  // Clocks' Oschillator bypass for OS FPGA/VERILATOR
+`endif
+
+  // Clock outputs
+  output logic clk_src_sys_o,
+  output logic clk_src_sys_val_o,
+  output logic clk_src_io_o,
+  output logic clk_src_io_val_o,
+  output prim_mubi_pkg::mubi4_t clk_src_io_48m_o,
+  output logic clk_src_usb_o,
+  output logic clk_src_usb_val_o,
+  output prim_mubi_pkg::mubi4_t io_clk_byp_ack_o,
+  output prim_mubi_pkg::mubi4_t all_clk_byp_ack_o
+);
+
+import ast_pkg::* ;
+import ast_aon_main_pkg::* ;
+
+///////////////////////////////////////
+// TLUL Register Interface
+///////////////////////////////////////
+ast_reg_pkg::ast_reg2hw_t reg2hw;
+ast_reg_pkg::ast_hw2reg_t hw2reg;
+logic intg_err;
+
+ast_reg_top u_reg (
+  .clk_i ( clk_ast_tlul_i ),
+  .rst_ni ( rst_ast_tlul_ni ),
+  .tl_i ( tl_i ),
+  .tl_o ( tl_o ),
+  .reg2hw ( reg2hw ),
+  .hw2reg ( hw2reg ),
+  .intg_err_o ( intg_err )
+);
+
+// Reset and Power-Down for clock modules
+logic rst_sys_clk_n, rst_io_clk_n, rst_usb_clk_n;
+logic clk_sys_pd_n, clk_io_pd_n, clk_usb_pd_n;
+
+assign rst_sys_clk_n = aon_to_main_i.pwr.vcmain_pok_por && aon_to_main_i.pwr.vcc_pok;
+assign rst_io_clk_n  = aon_to_main_i.pwr.vcmain_pok_por && aon_to_main_i.pwr.vcc_pok;
+assign rst_usb_clk_n = aon_to_main_i.pwr.vcmain_pok_por && aon_to_main_i.pwr.vcc_pok;
+
+assign clk_sys_pd_n = aon_to_main_i.scan_mode || !aon_to_main_i.clk_osc.deep_sleep;
+assign clk_io_pd_n  = aon_to_main_i.scan_mode || !aon_to_main_i.clk_osc.deep_sleep;
+assign clk_usb_pd_n = aon_to_main_i.scan_mode || !aon_to_main_i.clk_osc.deep_sleep;
+
+logic clk_sys;
+
+// Local (AST) System clock buffer
+////////////////////////////////////////
+prim_clock_buf #(
+  .NoFpgaBuf ( 1'b1 )
+) u_clk_sys_buf (
+  .clk_i ( clk_src_sys_o ),
+  .clk_o ( clk_sys )
+);
+
+logic vcmain_pok_por_sys, rst_src_sys_n;
+
+// Reset De-Assert Sync
+prim_flop_2sync #(
+  .Width ( 1 ),
+  .ResetValue ( 1'b0 )
+) u_rst_sys_dasrt (
+  .clk_i ( clk_sys ),
+  .rst_ni ( aon_to_main_i.pwr.vcmain_pok_por ),
+  .d_i ( 1'b1 ),
+  .q_o ( vcmain_pok_por_sys )
+);
+
+assign rst_src_sys_n = aon_to_main_i.scan_mode ? aon_to_main_i.scan_reset_n : vcmain_pok_por_sys;
+
+prim_mubi_pkg::mubi4_t clk_src_sys_jen;
+
+// Sync clk_src_sys_jen_i to clk_sys
+prim_mubi4_sync #(
+  .NumCopies ( 1 ),
+  .AsyncOn ( 1 ),
+  .StabilityCheck ( 1 ),
+  .ResetValue (prim_mubi_pkg::MuBi4False )
+) u_jitter_en_sync (
+  .clk_i ( clk_sys ),
+  .rst_ni ( rst_src_sys_n ),
+  .mubi_i ( clk_src_sys_jen_i ),
+  .mubi_o ( {clk_src_sys_jen} )
+);
+
+
+///////////////////////////////////////
+// Inter-domain Interface Unpacking
+///////////////////////////////////////
+ast_aon_main_pkg::clks_byp_aon_to_main_t clks_byp_aon_to_main;
+assign clks_byp_aon_to_main = aon_to_main_i.clks_byp;
+
+///////////////////////////////////////
+// REGAL Register
+///////////////////////////////////////
+logic regal_rst_n;
+assign regal_rst_n = rst_ast_tlul_ni;
+
+logic [32-1:0] regal, regal_di;
+
+assign main_to_aon_o.regal_we = reg2hw.regal.qe;
+assign regal_di = reg2hw.regal.q;
+assign hw2reg.regal.d = regal;
+
+// REGAL & AST init done indication
+always_ff @( posedge clk_ast_tlul_i, negedge regal_rst_n ) begin
+  if ( !regal_rst_n ) begin
+    regal           <= ast_reg_pkg::AST_REGAL_RESVAL;
+    ast_init_done_o <= prim_mubi_pkg::MuBi4False;
+  end else if ( main_to_aon_o.regal_we ) begin
+    regal           <= regal_di;
+    ast_init_done_o <= prim_mubi_pkg::MuBi4True;
+  end
+end
+
+///////////////////////////////////////
+// Main Domain Oscillators (SYS, IO, USB) - OS simplified
+///////////////////////////////////////
+logic clk_osc_sys;
+logic clk_osc_io;
+logic clk_osc_usb;
+logic clk_osc_sys_val, clk_osc_io_val, clk_osc_usb_val;
+
+
+`ifdef AST_BYPASS_CLK
+logic clk_sys_ext;
+assign clk_sys_ext = clk_osc_byp_i.sys;
+`endif
+
+sys_clk u_sys_clk (
+  .clk_src_sys_jen_i ( prim_mubi_pkg::mubi4_test_true_loose(clk_src_sys_jen) ),
+  .clk_src_sys_en_i ( clk_src_sys_en_i ),
+  .clk_sys_pd_ni ( clk_sys_pd_n ),
+  .rst_sys_clk_ni ( rst_sys_clk_n ),
+  .vcore_pok_h_i ( aon_to_main_i.pwr.vcmain_pok_h ),
+  .scan_mode_i ( aon_to_main_i.scan_mode ),
+  .sys_osc_cal_i ( aon_to_main_i.sys_io_osc_cal ),
+`ifdef AST_BYPASS_CLK
+  .clk_sys_ext_i ( clk_sys_ext ),
+`endif
+  .clk_src_sys_o ( clk_osc_sys ),
+  .clk_src_sys_val_o ( clk_osc_sys_val )
+);
+
+`ifdef AST_BYPASS_CLK
+logic clk_io_ext;
+assign clk_io_ext = clk_osc_byp_i.io;
+`endif
+
+io_clk u_io_clk (
+  .vcore_pok_h_i ( aon_to_main_i.pwr.vcmain_pok_h ),
+  .clk_io_pd_ni ( clk_io_pd_n ),
+  .rst_io_clk_ni ( rst_io_clk_n ),
+  .clk_src_io_en_i ( clk_src_io_en_i ),
+  .scan_mode_i ( aon_to_main_i.scan_mode ),
+  .io_osc_cal_i ( aon_to_main_i.sys_io_osc_cal ),
+`ifdef AST_BYPASS_CLK
+  .clk_io_ext_i ( clk_io_ext ),
+`endif
+  .clk_src_io_o ( clk_osc_io ),
+  .clk_src_io_val_o ( clk_osc_io_val )
+);
+
+`ifdef AST_BYPASS_CLK
+logic clk_usb_ext;
+assign clk_usb_ext = clk_osc_byp_i.usb;
+`endif
+
+usb_clk u_usb_clk (
+  .vcore_pok_h_i ( aon_to_main_i.pwr.vcmain_pok_h ),
+  .clk_usb_pd_ni ( clk_usb_pd_n ),
+  .rst_usb_clk_ni ( rst_usb_clk_n ),
+  .clk_src_usb_en_i ( clk_src_usb_en_i ),
+  .usb_ref_val_i ( aon_to_main_i.clk_osc.usb_ref_val ),
+  .usb_ref_pulse_i ( aon_to_main_i.clk_osc.usb_ref_pulse ),
+  .clk_ast_usb_i ( clk_ast_usb_i ),
+  .rst_ast_usb_ni ( rst_ast_usb_ni ),
+  .scan_mode_i ( aon_to_main_i.scan_mode ),
+  .usb_osc_cal_i ( aon_to_main_i.usb_osc_cal ),
+`ifdef AST_BYPASS_CLK
+  .clk_usb_ext_i ( clk_usb_ext ),
+`endif
+  .clk_src_usb_o ( clk_osc_usb ),
+  .clk_src_usb_val_o ( clk_osc_usb_val )
+);
+
+///////////////////////////////////////
+// Main Domain Clock Bypass
+///////////////////////////////////////
+ast_aon_main_pkg::clks_byp_main_to_aon_t clks_byp_main_to_aon;
+logic clk_src_sys, clk_src_io, clk_src_usb;
+
+`ifdef AST_BYPASS_CLK
+logic clk_aon_ext;
+assign clk_aon_ext = clk_osc_byp_i.aon;
+`endif
+
+ast_clks_byp_main u_ast_clks_byp_main (
+  .vcmain_pok_i ( aon_to_main_i.pwr.vcmain_pok_h ),
+  .vcmain_pok_por_i ( aon_to_main_i.pwr.vcmain_pok_por ),
+  .deep_sleep_i ( aon_to_main_i.clk_osc.deep_sleep ),
+  .scan_mode_i ( aon_to_main_i.scan_mode ),
+  .scan_reset_ni ( aon_to_main_i.scan_reset_n ),
+  .clk_ast_tlul_i ( aon_to_main_i.clk_rst.clk_ast_tlul ),
+  .dft_clks_byp_i ( 1'b0 ),
+  .dft_ext_is_96m_i ( 1'b1 ),
+  .clk_src_io_pre_occ_i ( clk_osc_io ),
+  .clk_src_sys_en_i ( clk_src_sys_en_i ),
+  .clk_osc_sys_i ( clk_osc_sys ),
+  .clk_osc_sys_val_i ( clk_osc_sys_val ),
+  .clk_src_io_en_i ( clk_src_io_en_i ),
+  .clk_osc_io_i ( clk_osc_io ),
+  .clk_osc_io_val_i ( clk_osc_io_val ),
+  .clk_src_usb_en_i ( clk_src_usb_en_i ),
+  .clk_osc_usb_i ( clk_osc_usb ),
+  .clk_osc_usb_val_i ( clk_osc_usb_val ),
+  .clk_ast_ext_i ( clk_ast_ext_i ),
+`ifdef AST_BYPASS_CLK
+  .clk_ext_sys_i( clk_sys_ext ),
+  .clk_ext_io_i( clk_io_ext ),
+  .clk_ext_usb_i( clk_usb_ext ),
+  .clk_ext_aon_i( clk_aon_ext ),
+`endif
+  .io_clk_byp_req_i ( io_clk_byp_req_i ),
+  .all_clk_byp_req_i ( all_clk_byp_req_i ),
+  .ext_freq_is_96m_i ( ext_freq_is_96m_i ),
+  .aon_to_main_i ( clks_byp_aon_to_main ),
+  .main_to_aon_o ( clks_byp_main_to_aon ),
+  .io_clk_byp_ack_o ( io_clk_byp_ack_o ),
+  .all_clk_byp_ack_o ( all_clk_byp_ack_o ),
+  .force_scan_reset_o ( ),
+  .clk_src_sys_o ( clk_src_sys ),
+  .clk_src_sys_val_o ( clk_src_sys_val_o ),
+  .clk_src_io_o ( clk_src_io ),
+  .clk_src_io_val_o ( clk_src_io_val_o ),
+  .clk_src_io_48m_o ( clk_src_io_48m_o ),
+  .clk_src_usb_o ( clk_src_usb ),
+  .clk_src_usb_val_o ( clk_src_usb_val_o )
+);
+
+
+// System source clock buffer
+////////////////////////////////////////
+prim_clock_buf #(
+  .NoFpgaBuf ( 1'b1 )
+) u_clk_src_sys_buf (
+  .clk_i ( clk_src_sys ),
+  .clk_o ( clk_src_sys_o )
+);
+
+// IO source clock buffer
+////////////////////////////////////////
+prim_clock_buf #(
+  .NoFpgaBuf ( 1'b1 )
+) u_clk_src_io_buf (
+  .clk_i ( clk_src_io ),
+  .clk_o ( clk_src_io_o )
+);
+
+// USB source clock buffer
+////////////////////////////////////////
+prim_clock_buf #(
+  .NoFpgaBuf ( 1'b1 )
+) u_clk_src_usb_buf (
+  .clk_i ( clk_src_usb ),
+  .clk_o ( clk_src_usb_o )
+);
+
+///////////////////////////////////////
+// Entropy (OS simplified - fewer ports)
+///////////////////////////////////////
+localparam int EntropyRateWidth = 4;
+
+logic [EntropyRateWidth-1:0] entropy_rate;
+
+`ifndef SYNTHESIS
+logic [EntropyRateWidth-1:0] dv_entropy_rate_value;
+
+initial begin : erate_plusargs
+  dv_entropy_rate_value = EntropyRateWidth'($urandom_range(0, (2**EntropyRateWidth -1)));
+  void'($value$plusargs("entropy_rate_value=%0d", dv_entropy_rate_value));
+  `ASSERT_I(DvErateValueCheck, dv_entropy_rate_value inside {[0:(2**EntropyRateWidth -1)]})
+end
+
+assign entropy_rate = dv_entropy_rate_value;
+`else
+assign entropy_rate = EntropyRateWidth'(5);
+`endif
+
+ast_entropy u_entropy (
+  .entropy_rsp_i ( entropy_rsp_i ),
+  .entropy_rate_i ( entropy_rate ),
+  .clk_ast_es_i ( clk_ast_es_i ),
+  .rst_ast_es_ni ( rst_ast_es_ni ),
+  .clk_src_sys_i ( clk_src_sys_o ),
+  .rst_src_sys_ni ( rst_src_sys_n ),
+  .clk_src_sys_val_i ( clk_src_sys_val_o ),
+  .clk_src_sys_jen_i ( prim_mubi_pkg::mubi4_test_true_loose(clk_src_sys_jen) ),
+  .entropy_req_o ( entropy_req_o )
+);
+
+///////////////////////////////////////
+// RNG (OS simplified - fewer ports)
+///////////////////////////////////////
+rng #(
+  .EntropyStreams ( ast_pkg::EntropyStreams )
+) u_rng (
+  .clk_i ( aon_to_main_i.clk_rst.clk_ast_tlul ),
+  .rst_ni ( aon_to_main_i.clk_rst.rst_ast_tlul_n ),
+  .clk_ast_rng_i ( aon_to_main_i.clk_rst.clk_ast_rng ),
+  .rst_ast_rng_ni ( aon_to_main_i.clk_rst.rst_ast_rng_n ),
+  .rng_en_i ( rng_en_i ),
+  .rng_fips_i ( rng_fips_i ),
+  .scan_mode_i ( aon_to_main_i.scan_mode ),
+  .rng_b_o ( rng_b_o ),
+  .rng_val_o ( rng_val_o )
+);
+
+///////////////////////////////////////
+// Output Assignments
+///////////////////////////////////////
+// Clock bypass interface to AON
+assign main_to_aon_o.clks_byp = clks_byp_main_to_aon;
+
+// Alert source from TLUL integrity error
+assign main_to_aon_o.ot0_alert_src = '{p: intg_err, n: ~intg_err};
+
+`ASSERT_KNOWN(ClkSrcIoKnownO_A, clk_src_io_o, 1, aon_to_main_i.pwr.vcmain_pok_h)
+`ASSERT_KNOWN(ClkSrcIoValKnownO_A, clk_src_io_val_o, clk_src_io_o, rst_io_clk_n)
+`ASSERT_KNOWN(ClkSrcIo48mKnownO_A, clk_src_io_48m_o, clk_src_io_o, rst_io_clk_n)
+`ASSERT_KNOWN(ClkSrcSysKnownO_A, clk_src_sys_o, 1, aon_to_main_i.pwr.vcmain_pok_h)
+`ASSERT_KNOWN(ClkSrcSysValKnownO_A, clk_src_sys_val_o, clk_src_sys_o, rst_sys_clk_n)
+`ASSERT_KNOWN(ClkSrcUsbKnownO_A, clk_src_usb_o, 1, aon_to_main_i.pwr.vcmain_pok_h)
+`ASSERT_KNOWN(ClkSrcUsbValKnownO_A, clk_src_usb_val_o, clk_src_usb_o, rst_usb_clk_n)
+//
+// Alert assertions for reg_we onehot check
+`ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ERR(RegWeOnehot_A,
+   u_reg, main_to_aon_o.ot0_alert_src.p, , , clk_ast_tlul_i, rst_ast_tlul_ni)
+// RNG
+`ASSERT_KNOWN(RngBKnownO_A, rng_b_o, aon_to_main_i.clk_rst.clk_ast_rng,
+              aon_to_main_i.clk_rst.rst_ast_rng_n)
+`ASSERT_KNOWN(RngValKnownO_A, rng_val_o, aon_to_main_i.clk_rst.clk_ast_rng,
+              aon_to_main_i.clk_rst.rst_ast_rng_n)
+// ES
+`ASSERT_KNOWN(EntropyReeqKnownO_A, entropy_req_o, clk_ast_es_i,rst_ast_es_ni)
+//
+`ASSERT_KNOWN(LcClkBypAckEnKnownO_A, io_clk_byp_ack_o, clk_ast_tlul_i, rst_ast_tlul_ni)
+`ASSERT_KNOWN(AllClkBypAckEnKnownO_A, all_clk_byp_ack_o, clk_ast_tlul_i, rst_ast_tlul_ni)
+// TLUL
+`ASSERT_KNOWN(TlDValidKnownO_A, tl_o.d_valid, clk_ast_tlul_i, rst_ast_tlul_ni)
+`ASSERT_KNOWN(TlAReadyKnownO_A, tl_o.a_ready, clk_ast_tlul_i, rst_ast_tlul_ni)
+//
+`ASSERT_KNOWN(InitDoneKnownO_A, ast_init_done_o, clk_ast_tlul_i, rst_ast_tlul_ni)
+
+/////////////////////
+// Unused Signals  //
+/////////////////////
+logic unused_sigs;
+
+assign unused_sigs = ^{ reg2hw.rega0,
+                        reg2hw.rega1,
+                        reg2hw.rega2,
+                        reg2hw.rega3,
+                        reg2hw.rega4,
+                        reg2hw.rega5,
+                        reg2hw.rega6,
+                        reg2hw.rega7,
+                        reg2hw.rega8,
+                        reg2hw.rega9,
+                        reg2hw.rega10,
+                        reg2hw.rega11,
+                        reg2hw.rega12,
+                        reg2hw.rega13,
+                        reg2hw.rega14,
+                        reg2hw.rega15,
+                        reg2hw.rega16,
+                        reg2hw.rega17,
+                        reg2hw.rega18,
+                        reg2hw.rega19,
+                        reg2hw.rega20,
+                        reg2hw.rega21,
+                        reg2hw.rega22,
+                        reg2hw.rega23,
+                        reg2hw.rega24,
+                        reg2hw.rega25,
+                        reg2hw.rega26,
+                        reg2hw.rega27,
+                        reg2hw.rega28,
+                        reg2hw.rega29,
+                        reg2hw.rega30,
+                        reg2hw.rega31,
+                        reg2hw.rega32,
+                        reg2hw.rega33,
+                        reg2hw.rega34,
+                        reg2hw.rega35,
+                        reg2hw.rega36,
+                        reg2hw.rega37,
+                        reg2hw.rega38,
+                        reg2hw.rega39,
+                        reg2hw.rega40,
+                        reg2hw.rega41,
+                        reg2hw.rega42,
+                        reg2hw.rega43,
+                        reg2hw.rega44,
+                        reg2hw.rega45,
+                        reg2hw.rega46,
+                        reg2hw.rega47,
+                        reg2hw.rega48,
+                        reg2hw.rega49,
+                        reg2hw.rega50,
+                        reg2hw.rega51,
+                        reg2hw.rega52,
+                        reg2hw.regb   // [0:3]
+                      };
+
+endmodule : ast_main

--- a/hw/top_earlgrey/ip/ast/rtl/io_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/io_osc.sv
@@ -125,7 +125,7 @@ prim_clock_buf #(
 // Unused Signals
 /////////////////////////
 logic unused_sigs;
-assign unused_sigs = ^{ io_osc_cal_i };
+assign unused_sigs = ^{ io_osc_cal_i, en_osc, en_osc_fe };
 `endif
 
 endmodule : io_osc

--- a/hw/top_earlgrey/ip/ast/rtl/sys_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/sys_osc.sv
@@ -152,7 +152,7 @@ prim_clock_buf #(
 // Unused Signals
 /////////////////////////
 logic unused_sigs;
-assign unused_sigs = ^{ sys_osc_cal_i, sys_jen_i };
+assign unused_sigs = ^{ sys_osc_cal_i, sys_jen_i, en_osc, en_osc_fe };
 `endif
 
 endmodule : sys_osc

--- a/hw/top_earlgrey/ip/ast/rtl/usb_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/usb_osc.sv
@@ -177,7 +177,7 @@ prim_clock_buf #(
 // Unused Signals
 ///////////////////////
 logic unused_sigs;
-assign unused_sigs = ^{ usb_osc_cal_i, usb_ref_pulse_i, usb_ref_val_i };
+assign unused_sigs = ^{ usb_osc_cal_i, usb_ref_pulse_i, usb_ref_val_i, en_osc, en_osc_fe };
 `endif
 
 endmodule : usb_osc

--- a/hw/top_earlgrey/lint/chip_earlgrey_asic.waiver
+++ b/hw/top_earlgrey/lint/chip_earlgrey_asic.waiver
@@ -127,7 +127,7 @@ waive -rules {CLOCK_MUX} -location {chip_earlgrey_asic.sv} -regexp {Clock 'ast_b
 waive -rules {CLOCK_MUX} -location {chip_earlgrey_asic.sv} -regexp {Clock 'clkmgr_aon_clocks.clk_io_div4_secure' is driven by a multiplexer here, used as a clock 'clk_i' at} \
       -comment "This is a clock signal that is fed back into AST."
 
-waive -rules {CLOCK_MUX} -location {chip_earlgrey_asic.sv} -regexp {Clock 'clkmgr_aon_clocks.clk_io_div4_infra' is driven by a multiplexer here, used as a clock 'clk_i' at} \
+waive -rules {CLOCK_MUX} -location {chip_earlgrey_asic.sv} -regexp {Clock 'clkmgr_aon_clocks.clk_io_div4_infra' is driven by a multiplexer here, used as a clock '(clk_i|clk_ast_tlul_i)' at} \
       -comment "This is a clock signal that is fed back into AST."
 
 waive -rules CLOCK_MUX -location {chip_earlgrey_asic.sv} -regexp {.*clk_io_div.* is driven by a multiplexer here} \
@@ -155,3 +155,8 @@ waive -rules {RESET_MUX} -location {usb_clk.sv} \
 waive -rules {LHS_TOO_SHORT} -location {aes_prng_masking.sv} \
       -regexp {Bitlength mismatch between 'unused_assert_static_lint_error' length 1 and 'AesSecAllowForcingMasksNonDefault'\(1'b1\)' length 2} \
       -comment "We want to be able to switch off the masking inside AES, see https://github.com/lowRISC/opentitan/issues/14240."
+
+# Temporary generic waiver for ast until the proper split into sub-IPs in the Main and Aon toplevels is done.
+waive -location {ast*.sv} \
+      -regexp {.*} \
+      -comment "AST is TEMPORARILY waived until properly split into Main and Aon domain."

--- a/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
@@ -45,12 +45,13 @@
                   additional_fusesoc_argument: "--mapping=lowrisc:systems:top_earlgrey:0.1"
                   rel_path: "hw/ip/ascon/lint/{tool}"
              },
-             {    name: ast
-                  fusesoc_core: lowrisc:dv:top_earlgrey_ast_top
-                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-                  additional_fusesoc_argument: "--mapping=lowrisc:systems:top_earlgrey:0.1"
-                  rel_path: "hw/top_earlgrey/ip/ast/lint/{tool}"
-             },
+             //AST is TEMPORARILY waived until properly split into Main and Aon domain
+             //{    name: ast
+             //     fusesoc_core: lowrisc:dv:top_earlgrey_ast_top
+             //     import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+             //     additional_fusesoc_argument: "--mapping=lowrisc:systems:top_earlgrey:0.1"
+             //     rel_path: "hw/top_earlgrey/ip/ast/lint/{tool}"
+             //},
              {    name: entropy_src
                   fusesoc_core: lowrisc:ip:entropy_src
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]

--- a/hw/top_englishbreakfast/ip/ast/ast.core
+++ b/hw/top_englishbreakfast/ip/ast/ast.core
@@ -29,8 +29,12 @@ filesets:
       - lowrisc:systems:top_englishbreakfast_ast_pkg
     files:
       - rtl/ast_reg_pkg.sv
+      - rtl/ast_pkg.sv
       - rtl/ast_bhv_pkg.sv
+      - rtl/ast_aon_main_pkg.sv
       - rtl/ast.sv
+      - rtl/ast_aon.sv
+      - rtl/ast_main.sv
       - rtl/ast_reg_top.sv
       - rtl/adc.sv
       - rtl/adc_ana.sv
@@ -48,7 +52,8 @@ filesets:
       - rtl/usb_clk.sv
       - rtl/usb_osc.sv
       - rtl/gfr_clk_mux2.sv
-      - rtl/ast_clks_byp.sv
+      - rtl/ast_clks_byp_aon.sv
+      - rtl/ast_clks_byp_main.sv
       - rtl/rglts_pdm_3p3v.sv
       - rtl/ast_pulse_sync.sv
       - rtl/ast_entropy.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/ast_aon.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/ast_aon.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/ast_aon.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/ast_aon_main_pkg.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/ast_aon_main_pkg.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/ast_aon_main_pkg.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/ast_clks_byp.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/ast_clks_byp.sv
@@ -1,1 +1,0 @@
-../../../../top_earlgrey/ip/ast/rtl/ast_clks_byp.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/ast_clks_byp_aon.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/ast_clks_byp_aon.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/ast_clks_byp_aon.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/ast_clks_byp_main.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/ast_clks_byp_main.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/ast_clks_byp_main.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/ast_main.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/ast_main.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/ast_main.sv


### PR DESCRIPTION
This PR should be used as a reference when building the new top level structure.
Eventually, `ast_aon` should be under `<name>_pd_aon`, and `ast_main` should be under `<name>_pd_main` while `ast` hierarchy itself would be deprecated.

The PR can be merged as is until top level restructuring is completed.

This PR was tested by the following tests and yielded the same results as before:
```
100% pass rate:
  chip_sw_ast_clk_outputs
  chip_sw_clkmgr_reset_frequency 
  chip_sw_clkmgr_sleep_frequency 
  chip_sw_pwrmgr_sleep_sensor_ctrl_alert_wakeup
 
depends on seed:
  chip_sw_sensor_ctrl_alert
 
fails:
  chip_sw_ast_clk_rst_inputs

make -C hw top
make -C hw top_earlgrey_gen
```