### PR TITLE
[bazel] Update binutils to 2.44

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -553,7 +553,7 @@
     },
     "//third_party/lowrisc:extensions.bzl%lowrisc_rv32imcb_toolchain": {
       "general": {
-        "bzlTransitiveDigest": "033ZAc9zojxrKdPMpWEtNhV8RxHk22vwfGTGSiQLLXY=",
+        "bzlTransitiveDigest": "7wLkeBu4tNxCIbOM1tZVlIHYHjeVBNZK7LYR7Et7wBc=",
         "usagesDigest": "N+I4Z8BUhFKs8r1sm2Tm4NjFkNo8NTAmaYNX1+nchZg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -562,9 +562,9 @@
           "lowrisc_rv32imcb_toolchain": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
-              "url": "https://github.com/lowRISC/lowrisc-toolchains/releases/download/20251111-1/lowrisc-toolchain-rv32imcb-x86_64-20251111-1.tar.xz",
-              "sha256": "42be8b4a7e2fe8ea9274759c8574eb3b763a5072741a75d22189c93b149b6fab",
-              "strip_prefix": "lowrisc-toolchain-rv32imcb-x86_64-20251111-1",
+              "url": "https://github.com/lowRISC/lowrisc-toolchains/releases/download/20260204-1/lowrisc-toolchain-rv32imcb-x86_64-20260204-1.tar.xz",
+              "sha256": "7738ad05bb996f71581d79e22822d762ab090ef63c2fae9355f642b135c5fcbe",
+              "strip_prefix": "lowrisc-toolchain-rv32imcb-x86_64-20260204-1",
               "build_file": "@@//third_party/lowrisc:BUILD.lowrisc_rv32imcb_toolchain.bazel"
             }
           }

--- a/third_party/lowrisc/extensions.bzl
+++ b/third_party/lowrisc/extensions.bzl
@@ -5,11 +5,11 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def _lowrisc_repos():
-    VERSION = "20251111-1"
+    VERSION = "20260204-1"
     http_archive(
         name = "lowrisc_rv32imcb_toolchain",
         url = "https://github.com/lowRISC/lowrisc-toolchains/releases/download/{v}/lowrisc-toolchain-rv32imcb-x86_64-{v}.tar.xz".format(v = VERSION),
-        sha256 = "42be8b4a7e2fe8ea9274759c8574eb3b763a5072741a75d22189c93b149b6fab",
+        sha256 = "7738ad05bb996f71581d79e22822d762ab090ef63c2fae9355f642b135c5fcbe",
         strip_prefix = "lowrisc-toolchain-rv32imcb-x86_64-{}".format(VERSION),
         build_file = ":BUILD.lowrisc_rv32imcb_toolchain.bazel",
     )


### PR DESCRIPTION
Binary hashes are unchanged:

ROM:
```
$ bazel build //sw/device/silicon_creator/rom:mask_rom --config riscv32
$ sha256sum bazel-bin/sw/device/silicon_creator/rom/mask_rom_silicon_creator.39.scr.vmem
ee3198da4616a1e94e9156ddcb532fc5208653fc8077278a33a1d098d3c6d58f  bazel-bin/sw/device/silicon_creator/rom/mask_rom_silicon_creator.39.scr.vmem
```

ROM_EXT:
```
$ bazel build //sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_virtual
$ sha256sum bazel-bin/sw/device/silicon_creator/rom_ext/rom_ext_dice_x509_slot_virtual_silicon_creator.64.scr.vmem
f145100c70ec2815a46ee3764baf27f53626338e4417e9a3942c4d37b245cd6b  bazel-bin/sw/device/silicon_creator/rom_ext/rom_ext_dice_x509_slot_virtual_silicon_creator.64.scr.vmem
```