### PR TITLE
[bazel] fix/add patches to enable downstream builds

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,6 +49,7 @@ single_version_override(
     module_name = "rules_rust",
     patch_strip = 1,
     patches = [
+        "@lowrisc_opentitan//third_party/rust/patches:rules_rust.experimental.patch",
         "@lowrisc_opentitan//third_party/rust/patches:rules_rust.extra_rustc_toolchain_dirs.patch",
     ],
     version = "0.59.2",
@@ -59,6 +60,7 @@ single_version_override(
     patch_strip = 3,
     patches = [
         "@lowrisc_opentitan//third_party/rust/patches:rules_rust.bindgen_static_lib.patch",
+        "@lowrisc_opentitan//third_party/rust/patches:rules_rust.transition.patch",
     ],
     version = "0.59.2",
 )

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -6301,7 +6301,7 @@
     },
     "@@rules_rust+//crate_universe:extension.bzl%crate": {
       "general": {
-        "bzlTransitiveDigest": "+vQ3ysy3luy+pewmwYh/aYCLTj9TKU7tzRunKUCIanU=",
+        "bzlTransitiveDigest": "tTZ5psFukCVz4oibDQ/H/c8PaeLW75dVz297sraRj+s=",
         "usagesDigest": "LDrdeyD7KUQDI/3lRf56mPIKTGSREOEcYCxVnHGzVbE=",
         "recordedFileInputs": {
           "@@+tock+elf2tab//Cargo.lock": "e16f9727336cfe996bfec5b8ddbc0a34bc4042e4c62a373176d02337fefeb3c3",
@@ -16678,7 +16678,7 @@
     },
     "@@rules_rust+//crate_universe/private:internal_extensions.bzl%cu_nr": {
       "general": {
-        "bzlTransitiveDigest": "2oNynQragWF/09943su7fX5M7RCflDGUKipKKZOSYWo=",
+        "bzlTransitiveDigest": "m7P4qjc3H2eVIeeKf7wz7/YcT71UlvP12qnbCYetQ4U=",
         "usagesDigest": "VsWDZXUQBqQa0ho1SU+gICiR3/gHVjTHrV0OwJokhBc=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/third_party/rust/patches/rules_rust.experimental.patch
+++ b/third_party/rust/patches/rules_rust.experimental.patch
@@ -1,0 +1,15 @@
+diff --git a/rust/private/rustc.bzl b/rust/private/rustc.bzl
+--- a/rust/private/rustc.bzl
++++ b/rust/private/rustc.bzl
+@@ -1518,11 +1518,6 @@ def rustc_compile_action(
+         "source_attributes": ["srcs"],
+     }
+ 
+-    if experimental_use_coverage_metadata_files:
+-        instrumented_files_kwargs.update({
+-            "metadata_files": coverage_runfiles + [executable] if executable else [],
+-        })
+-
+     providers = [
+         DefaultInfo(
+             # nb. This field is required for cc_library to depend on our output.

--- a/third_party/rust/patches/rules_rust.transition.patch
+++ b/third_party/rust/patches/rules_rust.transition.patch
@@ -1,0 +1,13 @@
+diff --git a/extensions/bindgen/private/llvm_utils.bzl b/extensions/bindgen/private/llvm_utils.bzl
+--- a/extensions/bindgen/private/llvm_utils.bzl
++++ b/extensions/bindgen/private/llvm_utils.bzl
+@@ -42,6 +42,9 @@ _COMMON_ATTRS = {
+         doc = "The target to transition.",
+         mandatory = True,
+     ),
++    "_allowlist_function_transition": attr.label(
++        default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
++    ),
+ }
+ 
+ def _cc_stdcc17_transitioned_target_impl(ctx):


### PR DESCRIPTION
The opentitan-provisioning loads this repo as a bazel dependency to build opentitanlib. Minor updates to rules rust in this repo broke builds downstream. This should fix them.


(cherry picked from commit 6e8e395e98fb403b1d656d50cf9dccd2794b3d8f)