### PR TITLE
[util] Improve `sparse-fsm-encode.py` reproducibility + small cleanups

### DIFF
--- a/util/design/sparse-fsm-encode.py
+++ b/util/design/sparse-fsm-encode.py
@@ -129,7 +129,7 @@ class EncodingGenerator:
         num_restarts = 0
 
         rand = random.Random()
-        rand.seed(self.seed)
+        rand.seed(self.seed, version=2)
         rnd = rand.getrandbits(self.encoding_len)
 
         while len(self.encodings) < self.num_states:


### PR DESCRIPTION
This PR makes a few changes to the `sparse-fsm-encode.py` util script with the primary goals of improving the reproducibility of the generated encodings, as well as cleaning up a few other miscellaneous things (long arguments, code formatting). See the commit messages for more details.

Importantly:
 * We record the git hash (where it exists), as otherwise we could have issues where encodings are generated on one version of the script but committed after some meaningful change to the script. This was motivated by the encodings in https://github.com/lowRISC/opentitan/blob/b70dde65943eb0dc10b4a1efaf9282b808e8fd6c/sw/device/silicon_creator/lib/drivers/alert.h, which were generated before the changes in https://github.com/lowRISC/opentitan/commit/f2c848c7e1f09018e4cae16d2b30ffd5eca6c3c2 but committed after, making this difficult to reproduce without bisecting.
 * We record the Python version to account for changes in the standard library (e.g. to handle the case where `random` could unexpectedly have a breaking change).
 * We record whether the `--avoid-zero` option was given, as this changes the script's operation.
 * We pin the random seed version to 2 ([the current version](https://docs.python.org/3/library/random.html#random.seed)), to avoid breakages if a new seed version is implemented in the future.

Generated encodings now look something like:
```
/*
 * Encoding generated at commit c0750210a1 using Python 3.10.19 with:
 * $ ./util/design/sparse-fsm-encode.py --language=c \
 *     --seed 3775359077 --distance 2 --states 5 --bits 8
 *
 * Hamming distance histogram:
 *
 *  0: --
 *  1: --
 *  2: ||||||||||||| (20.00%)
 *  3: ||||||||||||| (20.00%)
 *  4: |||||||||||||||||||| (30.00%)
 *  5: ||||||||||||| (20.00%)
 *  6: |||||| (10.00%)
 *  7: --
 *  8: --
 *
 * Minimum Hamming distance: 2
 * Maximum Hamming distance: 6
 * Minimum Hamming weight: 3
 * Maximum Hamming weight: 6
 */
typedef enum my_state {
  kMyState0 = 0xee,
  kMyState1 = 0x64,
  kMyState2 = 0xa7,
  kMyState3 = 0x32,
  kMyState4 = 0x70,
} my_state_t;
```