### PR TITLE
[sw] Fix cast of ujson_putbuf to sink_func_ptr

### DIFF
--- a/sw/device/lib/ujson/ujson.c
+++ b/sw/device/lib/ujson/ujson.c
@@ -435,10 +435,18 @@ status_t ujson_deserialize_status_t(ujson_t *uj, status_t *value) {
   return OK_STATUS();
 }
 
+static size_t ujson_putbuf_sink(ujson_t *uj, const char *buf, size_t len) {
+  status_t result = ujson_putbuf(uj, buf, len);
+  if (!status_ok(result)) {
+    return 0;
+  }
+  return (size_t)result.value;
+}
+
 status_t ujson_serialize_status_t(ujson_t *uj, const status_t *value) {
   buffer_sink_t out = {
       .data = uj,
-      .sink = (size_t(*)(void *, const char *, size_t))ujson_putbuf,
+      .sink = (sink_func_ptr)ujson_putbuf_sink,
   };
   base_fprintf(out, "%!r", *value);
   return OK_STATUS();


### PR DESCRIPTION
The function ujson_putbuf has the type sink_func_ptr except that it returns a status_t instead of a size_t. Although those are the same at an ABI level, at the C level they are different types. More recent versions of Clang warn about casting betwen such incompatible types. This commit fixes such a casting warning by introducing a wrapper function ujson_putbuf_sink with the appropriate sink_func_ptr type.

Change-Id: Ia6ed7241304453882c60fe3400c9da312264b4f8

(cherry picked from commit 5e10315d184fc92d2f499b404d7fa85a7d2bfa45)