### PR TITLE
[opentitanlib] fix detached signature ECDSA processing

### DIFF
--- a/sw/host/opentitanlib/src/ownership/signature.rs
+++ b/sw/host/opentitanlib/src/ownership/signature.rs
@@ -187,8 +187,7 @@ impl DetachedSignature {
         if algorithm.is_ecdsa() {
             let path =
                 ecdsa_signature_path.ok_or_else(|| anyhow!("No ecdsa signature provided"))?;
-            let mut file = std::fs::File::open(path)?;
-            ecdsa_sig = Some(EcdsaRawSignature::read(&mut file)?);
+            ecdsa_sig = Some(EcdsaRawSignature::read_from_file(path)?);
         }
 
         if algorithm.is_spx() {


### PR DESCRIPTION
When presented with the ECDSA signature in a canonical form the X and Y values endianness needs to be reverted. There is a raw signature method for this, use it.

Tested by switching Owner configuration back and forth, using both raw signatures generated by 'opentitan ecdsa sign' and DER formatted signatures generated by 'openssl pkeyutl -sign'