### PR TITLE
[cov] Increase watchdog timeout for reset reason tests

### DIFF
--- a/sw/device/silicon_creator/rom_ext/e2e/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/BUILD
@@ -60,7 +60,7 @@ otp_json(
             name = "OWNER_SW_CFG",
             items = {
                 "OWNER_SW_CFG_ROM_PRESERVE_RESET_REASON_EN": otp_hex(CONST.HARDENED_TRUE),
-                "OWNER_SW_CFG_ROM_WATCHDOG_BITE_THRESHOLD_CYCLES": otp_hex(200000),
+                "OWNER_SW_CFG_ROM_WATCHDOG_BITE_THRESHOLD_CYCLES": otp_hex(600000),
             },
         ),
     ],


### PR DESCRIPTION
The watchdog bite threshold was increased from 200,000 to 600,000 cycles to prevent premature timeouts due to the coverage collection overhead.