### PR TITLE
[cov] Wait for coverage reports in rescue tests

### DIFF
--- a/sw/host/opentitanlib/src/rescue/serial.rs
+++ b/sw/host/opentitanlib/src/rescue/serial.rs
@@ -151,6 +151,8 @@ impl Rescue for RescueSerial {
 
     fn reboot(&self) -> Result<()> {
         self.set_mode(Self::REBOOT)?;
+        #[cfg(feature = "ot_coverage_enabled")]
+        UartConsole::wait_for_coverage(&*self.uart, Self::ONE_SECOND)?;
         Ok(())
     }
 


### PR DESCRIPTION
In some rescue tests, the tests will exit before the coverage report is received. This change adds a wait for coverage report in the rescue tests when the `ot_coverage_enabled` feature is enabled.