### PR TITLE
[sival/flash_ctrl] Modify flash_ctrl test scripts for checking read/write (backport)

### DIFF
--- a/sw/device/lib/testing/flash_ctrl_testutils.c
+++ b/sw/device/lib/testing/flash_ctrl_testutils.c
@@ -352,3 +352,19 @@ void flash_ctrl_testutils_info_region_print(
            mubi_prop(p->ecc_en, "EC"), mubi_prop(p->high_endurance_en, "HE"),
            locked ? "LK" : "UN");
 }
+
+status_t flash_ctrl_testutils_find_unlocked_region(
+    dif_flash_ctrl_state_t *flash, uint32_t start, uint32_t end,
+    uint32_t *region) {
+  for (uint32_t data_region = start; data_region <= end; data_region++) {
+    bool locked;
+    CHECK_DIF_OK(
+        dif_flash_ctrl_data_region_is_locked(flash, data_region, &locked));
+    if (!locked) {
+      LOG_INFO("Region %u is unlocked", data_region);
+      *region = data_region;
+      return OK_STATUS();
+    }
+  }
+  return INTERNAL();
+}

--- a/sw/device/lib/testing/flash_ctrl_testutils.h
+++ b/sw/device/lib/testing/flash_ctrl_testutils.h
@@ -284,4 +284,19 @@ void flash_ctrl_testutils_data_region_print(
 void flash_ctrl_testutils_info_region_print(
     dif_flash_ctrl_info_region_t region, dif_flash_ctrl_region_properties_t *p,
     bool locked);
+
+/**
+ * Check for unlocked flash data regions
+ *
+ * This prints the unlocked region that is found
+ *
+ * @param flash A flash_ctrl state handle.
+ * @param start Start of the region range to search
+ * @param end End of the region range to search
+ * @param region The data protection region
+ */
+status_t flash_ctrl_testutils_find_unlocked_region(
+    dif_flash_ctrl_state_t *flash, uint32_t start, uint32_t end,
+    uint32_t *region);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_FLASH_CTRL_TESTUTILS_H_

--- a/sw/device/tests/rv_core_ibex_mem_test.c
+++ b/sw/device/tests/rv_core_ibex_mem_test.c
@@ -60,9 +60,9 @@ enum {
 
   kFlashTestLoc = TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR +
                   kBank1StartPageNum * kFlashBytesPerPage,
-  // The ROM_EXT protects itself using regions 0-1.
-  kFlashRegionNum = 2,
 };
+
+static uint32_t flash_region_index;
 
 // The flash test location is set to the encoding of `jalr x0, 0(x1)`
 // so execution can be tested.
@@ -150,10 +150,14 @@ static void setup_flash(void) {
   dif_flash_ctrl_data_region_properties_t data_region = {
       .base = kBank1StartPageNum, .size = 0x1, .properties = region_properties};
 
+  // Find the first unlocked flash region and use that for testing
+  CHECK_STATUS_OK(flash_ctrl_testutils_find_unlocked_region(
+      &flash_ctrl, 0, FLASH_CTRL_PARAM_NUM_REGIONS - 1, &flash_region_index));
+
   CHECK_DIF_OK(dif_flash_ctrl_set_data_region_properties(
-      &flash_ctrl, kFlashRegionNum, data_region));
+      &flash_ctrl, flash_region_index, data_region));
   CHECK_DIF_OK(dif_flash_ctrl_set_data_region_enablement(
-      &flash_ctrl, kFlashRegionNum, kDifToggleEnabled));
+      &flash_ctrl, flash_region_index, kDifToggleEnabled));
 
   // Make flash executable
   CHECK_DIF_OK(


### PR DESCRIPTION
Manual backport of https://github.com/lowRISC/opentitan/pull/28627

---

This commit updates the flash_ctrl test files and flash_ctrl test_utils for read/write access before flash operations.


(cherry picked from commit 740eb6196146e7956069c0895835efd17bbc0a2a)