### PR TITLE
[aes] Upstream support for GCM - Part 22

### DIFF
--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -133,6 +133,7 @@ class aes_base_vseq extends cip_base_vseq #(
     if (ral.ctrl_shadowed.operation.get_mirrored_value() != operation) begin
       ral.ctrl_shadowed.operation.set(operation);
       csr_update(.csr(ral.ctrl_shadowed), .en_shadow_wr(1'b1), .blocking(1));
+      void'(ral.ctrl_shadowed.operation.predict(operation));
     end
   endtask // set_operation
 
@@ -141,6 +142,7 @@ class aes_base_vseq extends cip_base_vseq #(
     if (ral.ctrl_shadowed.mode.get_mirrored_value() != mode) begin
       ral.ctrl_shadowed.mode.set(mode);
       csr_update(.csr(ral.ctrl_shadowed), .en_shadow_wr(1'b1), .blocking(1));
+      void'(ral.ctrl_shadowed.mode.predict(mode));
     end
   endtask
 
@@ -149,6 +151,7 @@ class aes_base_vseq extends cip_base_vseq #(
     if (ral.ctrl_shadowed.key_len.get_mirrored_value() != key_len) begin
       ral.ctrl_shadowed.key_len.set(key_len);
       csr_update(.csr(ral.ctrl_shadowed), .en_shadow_wr(1'b1), .blocking(1));
+      void'(ral.ctrl_shadowed.key_len.predict(key_len));
     end
   endtask // set_key_len
 
@@ -157,6 +160,7 @@ class aes_base_vseq extends cip_base_vseq #(
     if (ral.ctrl_shadowed.sideload.get_mirrored_value() != sideload) begin
       ral.ctrl_shadowed.sideload.set(sideload);
       csr_update(.csr(ral.ctrl_shadowed), .en_shadow_wr(1'b1), .blocking(1));
+      void'(ral.ctrl_shadowed.sideload.predict(sideload));
     end
   endtask
 
@@ -165,6 +169,7 @@ class aes_base_vseq extends cip_base_vseq #(
     if (ral.ctrl_shadowed.prng_reseed_rate.get_mirrored_value() != reseed_rate) begin
       ral.ctrl_shadowed.prng_reseed_rate.set(reseed_rate);
       csr_update(.csr(ral.ctrl_shadowed), .en_shadow_wr(1'b1), .blocking(1));
+      void'(ral.ctrl_shadowed.prng_reseed_rate.predict(reseed_rate));
     end
   endtask
 
@@ -173,6 +178,7 @@ class aes_base_vseq extends cip_base_vseq #(
     if (ral.ctrl_shadowed.manual_operation.get_mirrored_value() != manual_operation) begin
       ral.ctrl_shadowed.manual_operation.set(manual_operation);
       csr_update(.csr(ral.ctrl_shadowed), .en_shadow_wr(1'b1), .blocking(1));
+      void'(ral.ctrl_shadowed.manual_operation.predict(manual_operation));
     end
   endtask
 
@@ -209,6 +215,8 @@ class aes_base_vseq extends cip_base_vseq #(
     ral.ctrl_gcm_shadowed.phase.set(phase);
     ral.ctrl_gcm_shadowed.num_valid_bytes.set(num_bytes);
     csr_update(.csr(ral.ctrl_gcm_shadowed), .en_shadow_wr(1'b1), .blocking(1));
+    void'(ral.ctrl_gcm_shadowed.phase.predict(phase));
+    void'(ral.ctrl_gcm_shadowed.num_valid_bytes.set(num_bytes));
   endtask
 
   virtual task add_data(ref bit [3:0] [31:0] data, bit do_b2b);
@@ -1028,6 +1036,11 @@ class aes_base_vseq extends cip_base_vseq #(
       // if alert just try to update ctrl and everything else
       csr_update(.csr(ral.ctrl_shadowed), .en_shadow_wr(1'b1), .blocking(is_blocking));
     end
+
+    // Read the main control register. This will update the mirrored values thereby getting them
+    // back in sync with the DUT (updated via csr_update() above) and the predicted values (updated
+    // via set() above).
+    csr_rd(.ptr(ral.ctrl_shadowed), .value(ctrl), .backdoor(1));
 
     if (cfg_item.mode == AES_GCM && !status.alert_fatal_fault) begin
       // As we are splitting the message, we also need to recalculate the length

--- a/hw/ip/aes/dv/env/seq_lib/aes_nist_vectors_gcm_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_nist_vectors_gcm_vseq.sv
@@ -64,6 +64,10 @@ class aes_nist_vectors_gcm_vseq extends aes_base_vseq;
       ral.ctrl_shadowed.mode.set(nist_vectors[i].mode);
       ral.ctrl_shadowed.prng_reseed_rate.set(PER_8K);
       csr_update(.csr(ral.ctrl_shadowed), .en_shadow_wr(1'b1), .blocking(1));
+      void'(ral.ctrl_shadowed.operation.predict(AES_ENC));
+      void'(ral.ctrl_shadowed.key_len.predict(nist_vectors[i].key_len));
+      void'(ral.ctrl_shadowed.mode.predict(nist_vectors[i].mode));
+      void'(ral.ctrl_shadowed.prng_reseed_rate.predict(PER_8K));
 
       // Put AES-GCM into init phase.
       cov_if.cg_ctrl_gcm_reg_sample(GCM_INIT);
@@ -191,6 +195,9 @@ class aes_nist_vectors_gcm_vseq extends aes_base_vseq;
       ral.ctrl_shadowed.key_len.set(nist_vectors[i].key_len);
       ral.ctrl_shadowed.mode.set(nist_vectors[i].mode);
       csr_update(.csr(ral.ctrl_shadowed), .en_shadow_wr(1'b1), .blocking(1));
+      void'(ral.ctrl_shadowed.operation.predict(AES_DEC));
+      void'(ral.ctrl_shadowed.key_len.predict(nist_vectors[i].key_len));
+      void'(ral.ctrl_shadowed.mode.predict(nist_vectors[i].mode));
 
       // Put AES-GCM into init phase.
       cov_if.cg_ctrl_gcm_reg_sample(GCM_INIT);

--- a/hw/ip/aes/dv/env/seq_lib/aes_nist_vectors_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_nist_vectors_vseq.sv
@@ -46,6 +46,9 @@ class aes_nist_vectors_vseq extends aes_base_vseq;
       ral.ctrl_shadowed.key_len.set(nist_vectors[i].key_len);
       ral.ctrl_shadowed.mode.set(nist_vectors[i].mode);
       csr_update(.csr(ral.ctrl_shadowed), .en_shadow_wr(1'b1), .blocking(1));
+      void'(ral.ctrl_shadowed.operation.predict(AES_ENC));
+      void'(ral.ctrl_shadowed.key_len.predict(nist_vectors[i].key_len));
+      void'(ral.ctrl_shadowed.mode.predict(nist_vectors[i].mode));
       // transpose key To match NIST format ( little endian)
       init_key = '{ {<<8{nist_vectors[i].key}} ,  256'h0 };
       write_key(init_key, do_b2b);
@@ -84,6 +87,9 @@ class aes_nist_vectors_vseq extends aes_base_vseq;
       ral.ctrl_shadowed.key_len.set(nist_vectors[i].key_len);
       ral.ctrl_shadowed.mode.set(nist_vectors[i].mode);
       csr_update(.csr(ral.ctrl_shadowed), .en_shadow_wr(1'b1), .blocking(1));
+      void'(ral.ctrl_shadowed.operation.predict(AES_DEC));
+      void'(ral.ctrl_shadowed.key_len.predict(nist_vectors[i].key_len));
+      void'(ral.ctrl_shadowed.mode.predict(nist_vectors[i].mode));
 
       // transpose key To match NIST format ( little endian)
       init_key = '{ {<<8{nist_vectors[i].key}} ,  256'h0 };


### PR DESCRIPTION
This is the 22nd PR of a series of PRs to upstream support for AES-GCM. The original PR can be found here: https://github.com/vogelpi/opentitan/pull/30

---

[aes/dv] Add missing predict() calls to update mirrored RAL values

When using .set() method of the uvm_reg_field base class (this only updates the desired value in the abstraction class) followed by a csr_update() call (this updates the DUT in case the desired value doesn't match the mirrored value), we also need to explicitly update the mirrored value. This can happen either by using the .predict() method, or by calling csr_rd() or csr_wr(). This commit adds missing calls to the .predict() method were required.

Without these calls, the mirrored values can get out of sync and since in some cases we use the mirrored value to decide whether we need to update register values, the DUT and the DV environment can get out of sync.