### PR TITLE
doc: Fix American English spelling in UART documentation

### DIFF
--- a/hw/ip/uart/doc/theory_of_operation.md
+++ b/hw/ip/uart/doc/theory_of_operation.md
@@ -70,7 +70,7 @@ detected as high and the optional parity bit is correct the data byte
 is pushed into a 32 byte deep RX FIFO. The data can be read out by
 reading [`RDATA`](registers.md#rdata) register.
 
-This behaviour of the receiver can be used to compute the approximate
+This behavior of the receiver can be used to compute the approximate
 baud clock frequency error that can be tolerated between the
 transmitter at the other end of the cable and the receiver. The
 initial sample point is aligned with the center of the START bit. The


### PR DESCRIPTION
This PR fixes a minor documentation typo by replacing British English spelling
with American English spelling for consistency. No functional behavior is changed.