### PR TITLE
[spi_device,lint] Fix verilator lint issue

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -84,8 +84,6 @@ module spi_device
   localparam int unsigned ReadBufferDepth = spi_device_pkg::SramMsgDepth;
   localparam int unsigned BufferAw        = $clog2(ReadBufferDepth);
 
-  localparam int unsigned TpmRdFifoWidth  = spi_device_reg_pkg::TpmRdFifoWidth;
-
   // Derived parameters
   localparam top_racl_pkg::racl_range_t [0:0] RaclPolicySelRangesEgressbuffer = '{
     '{


### PR DESCRIPTION
This fixes the verilator VARHIDDEN warning, caused by TpmRdFifoWidth being overwritten on [spi_device.sv line 87](https://github.com/lowRISC/opentitan/blob/b7082bd0569133cc536b6bd4450dc61fed430736/hw/ip/spi_device/rtl/spi_device.sv#L87).