### PR TITLE
[entropy_src/doc] Cherry-pick PR #29265 to earlgrey_1.0.0

### DIFF
--- a/hw/ip/entropy_src/README.md
+++ b/hw/ip/entropy_src/README.md
@@ -50,7 +50,7 @@ These tests include:
 The Repetition Count and Adaptive Proportion test are specifically recommended by SP 800-90B, and are implemented in accordance with those recommendations.
 In FIPS/CC compliant mode, all checks except the Repetition Count test are performed on a fixed window of data of configurable size, by default consisting of 2048 bits each.
 Per the definition in SP 800-90B, the Repetition Count test does not operate on a fixed window.
-The repetition count test fails if any sequence of bits continuously asserts the same value for too many samples, as determined by the programmable threshold, regardless of whether that sequence crosses any window boundaries.
+The Repetition Count Test fails if any sequence of bits continuously asserts the same value for too many samples, as determined by the programmable threshold, regardless of whether that sequence crosses any window boundaries.
 The thresholds for these tests should be chosen to achieve a low false-positive rate (&alpha;) given a conservative estimate of the manufacturing tolerances of the PTRNG noise source.
 The combined choice of threshold and window size then determine the false-negative rate (&beta;), or the probability of missing statistical defects at any particular magnitude.
 

--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -521,7 +521,7 @@
                 The only exception is the startup seed which is produced using the bits of two subsequent windows, i.e., 2 x window size x 4 tested bits.
                 The factor of 4 relates to the number of noise source channels (i.e. symbol size) and applies both in single-channel and multi-channel mode (see !!ENTROPY_SRC.RNG_BIT_ENABLE).
 
-                Note that NIST SP 800-90B (Table 2) requires the adaptive proportion test to be run on 1024 or 512 samples in single-channel or multi-channel mode, respectively (see !!ENTROPY_SRC.RNG_BIT_ENABLE).
+                Note that NIST SP 800-90B (Table 2) requires the Adaptive Proportion Test to be run on 1024 or 512 samples in single-channel or multi-channel mode, respectively (see !!ENTROPY_SRC.RNG_BIT_ENABLE).
                 The startup tests must be run on at least 1024 consecutive samples (see Section 4.3 Requirements for Health Tests of NIST SP 800-90B) and this block always uses two subsequent windows for startup health testing.
                 The use of window sizes below 512 samples is thus not recommended as this may not comply with NIST SP 800-90B.
                 '''
@@ -542,7 +542,7 @@
       ]
     },
     { name: "REPCNT_THRESHOLDS",
-      desc: "Repetition count test thresholds register",
+      desc: "Repetition Count Test thresholds register",
       swaccess: "rw",
       hwaccess: "hrw",
       hwext: "true",
@@ -553,7 +553,7 @@
       fields: [
         { bits: "15:0",
           name: "FIPS_THRESH",
-          desc: '''This is the threshold size for the repetition count health test.
+          desc: '''This is the threshold for the Repetition Count Test.
                    This value is used in FIPS mode.
                    This register must be written before the module is enabled.
                    Writing to this register will only update the register if the
@@ -564,7 +564,7 @@
         }
         { bits: "31:16",
           name: "BYPASS_THRESH",
-          desc: '''This is the threshold size for the repetition count health test
+          desc: '''This is the threshold for the Repetition Count Test
                    running in bypass mode. This mode is active after reset for the
                    first and only test run, or when this mode is programmed by firmware.
                    This register must be written before the module is enabled.
@@ -577,7 +577,7 @@
       ]
     },
     { name: "REPCNTS_THRESHOLDS",
-      desc: "Repetition count symbol test thresholds register",
+      desc: "Repetition Count Symbol Test thresholds register",
       swaccess: "rw",
       hwaccess: "hrw",
       hwext: "true",
@@ -588,7 +588,7 @@
       fields: [
         { bits: "15:0",
           name: "FIPS_THRESH",
-          desc: '''This is the threshold size for the repetition count symbol health test.
+          desc: '''This is the threshold for the Repetition Count Symbol Test.
                    This value is used in FIPS mode.
                    This register must be written before the module is enabled.
                    Writing to this register will only update the register if the
@@ -599,7 +599,7 @@
         }
         { bits: "31:16",
           name: "BYPASS_THRESH",
-          desc: '''This is the threshold size for the repetition count symbol health test
+          desc: '''This is the threshold for the Repetition Count Symbol Test
                    running in bypass mode. This mode is active after reset for the
                    first and only test run, or when this mode is programmed by firmware.
                    This register must be written before the module is enabled.
@@ -623,7 +623,7 @@
       fields: [
         { bits: "15:0",
           name: "FIPS_THRESH",
-          desc: '''This is the threshold size for the adaptive proportion health test.
+          desc: '''This is the threshold for the Adaptive Proportion Test.
                    This value is used in FIPS mode.
                    This register must be written before the module is enabled.
                    Writing to this register will only update the register if the
@@ -634,7 +634,7 @@
         }
         { bits: "31:16",
           name: "BYPASS_THRESH",
-          desc: '''This is the threshold size for the adaptive proportion health test
+          desc: '''This is the threshold for the Adaptive Proportion Test
                    running in bypass mode. This mode is active after reset for the
                    first and only test run, or when this mode is programmed by firmware.
                    This register must be written before the module is enabled.
@@ -658,7 +658,7 @@
       fields: [
         { bits: "15:0",
           name: "FIPS_THRESH",
-          desc: '''This is the threshold size for the adaptive proportion health test.
+          desc: '''This is the threshold for the Adaptive Proportion Test.
                    This value is used in FIPS mode.
                    This register must be written before the module is enabled.
                    Writing to this register will only update the register if the
@@ -669,7 +669,7 @@
         }
         { bits: "31:16",
           name: "BYPASS_THRESH",
-          desc: '''This is the threshold size for the adaptive proportion health test
+          desc: '''This is the threshold for the Adaptive Proportion Test
                    running in bypass mode. This mode is active after reset for the
                    first and only test run, or when this mode is programmed by firmware.
                    This register must be written before the module is enabled.
@@ -1025,7 +1025,7 @@
       ]
     },
     { name:     "REPCNT_TOTAL_FAILS",
-      desc:     "Repetition count test failure counter register",
+      desc:     "Repetition Count Test failure counter register",
       swaccess: "ro",
       hwaccess: "hwo",
       hwext: "true",
@@ -1039,7 +1039,7 @@
       ]
     },
     { name:     "REPCNTS_TOTAL_FAILS",
-      desc:     "Repetition count symbol test failure counter register",
+      desc:     "Repetition Count Symbol Test failure counter register",
       swaccess: "ro",
       hwaccess: "hwo",
       hwext: "true",
@@ -1155,6 +1155,8 @@
             Alert threshold register
 
             This register determines during how many subsequent health test windows one or more health test failures can occur before a recoverable alert is raised and the ENTROPY_SRC block stops operating.
+            Note that continuous health tests such as the Repetition Count Test or the Repetition Count Symbol Test can trigger multiple test failures within a single window.
+            Each symbol for which at least one continuous health test fails counts separately towards the threshold.
             In case the configured threshold is reached, firmware needs to disable/re-enable the block to restart operation including the startup health testing.
 
             Note that when reaching the threshold while running in Firmware Override: Extract & Insert mode, the recoverable alert is not raised nor does the block stop operating.
@@ -1189,6 +1191,8 @@
 
             This register holds the total number of subsequent health test windows during which one or more health test failures occurred.
             For information on which health tests failed specifically, refer to !!ALERT_FAIL_COUNTS and !!EXTHT_FAIL_COUNTS.
+            Note that continuous health tests such as the Repetition Count Test or the Repetition Count Symbol Test can trigger multiple test failures within a single window.
+            Each symbol for which at least one continuous health test fails is counted separately.
 
             If the value of this register reaches the value configured in the !!ALERT_THRESHOLD register, a recoverable alert is raised and the ENTROPY_SRC block stops operating.
             If an alert is signaled, the value persists until it is cleared by firmware.

--- a/hw/ip/entropy_src/data/entropy_src_testplan.hjson
+++ b/hw/ip/entropy_src/data/entropy_src_testplan.hjson
@@ -350,7 +350,7 @@
       name: cont_ht_cg
       desc: '''
             Covers a range of thresholds and configurations for the continuous health tests: REPCNT
-            (the repetition count test), and REPCNTS (the symbol based repetition count test).
+            (the Repetition Count Test), and REPCNTS (the Repetition Count Symbol Test).
             The primary cover points are the test_type (REPCNT vs. REPCNTS), the pass or fail value
             of the test, and the "score". The score is a generalization of the numerical value of
             the test output, which accounts for the fact it is far more likely to see high values

--- a/hw/ip/entropy_src/doc/programmers_guide.md
+++ b/hw/ip/entropy_src/doc/programmers_guide.md
@@ -99,10 +99,10 @@ To select which specific bit should be used, the `RNG_BIT_SEL` field in the [`CO
 
 When ENTROPY_SRC is configured in RNG bit mode, only a subset of the health tests are applicable and the health test thresholds need to be set to account for this.
 For this reason, the thresholds for both the bypass and the FIPS values must be set accordingly.
-The repetition count test, Markov test and adaptive proportion test can all still be performed on a single lane.
+The Repetition Count Test, Markov test and Adaptive Proportion Test can all still be performed on a single lane.
 However, to get the same number of entropy bits, we now must collect four times as many individual symbols from the PTRNG.
 This should be considered when choosing the health test thresholds, whereas the health test window size is adjusted internally.
-In contrast, the symbol repetition count test and the bucket test are not applicable to a single lane.
+In contrast, the Repetition Count Symbol Test and the bucket test are not applicable to a single lane.
 They need to be disabled by setting the corresponding thresholds to the maximum value.
 The `THRESHOLD_SCOPE` field in the [`CONF`](registers.md#conf) register is also not applicable to the single lane mode and must be set to `kMultiBitBool4False`.
 

--- a/hw/ip/entropy_src/doc/registers.md
+++ b/hw/ip/entropy_src/doc/registers.md
@@ -18,8 +18,8 @@
 | entropy_src.[`ENTROPY_CONTROL`](#entropy_control)                     | 0x28     |        4 | Entropy control register                                     |
 | entropy_src.[`ENTROPY_DATA`](#entropy_data)                           | 0x2c     |        4 | Entropy data bits                                            |
 | entropy_src.[`HEALTH_TEST_WINDOWS`](#health_test_windows)             | 0x30     |        4 | Health test windows register                                 |
-| entropy_src.[`REPCNT_THRESHOLDS`](#repcnt_thresholds)                 | 0x34     |        4 | Repetition count test thresholds register                    |
-| entropy_src.[`REPCNTS_THRESHOLDS`](#repcnts_thresholds)               | 0x38     |        4 | Repetition count symbol test thresholds register             |
+| entropy_src.[`REPCNT_THRESHOLDS`](#repcnt_thresholds)                 | 0x34     |        4 | Repetition Count Test thresholds register                    |
+| entropy_src.[`REPCNTS_THRESHOLDS`](#repcnts_thresholds)               | 0x38     |        4 | Repetition Count Symbol Test thresholds register             |
 | entropy_src.[`ADAPTP_HI_THRESHOLDS`](#adaptp_hi_thresholds)           | 0x3c     |        4 | Adaptive proportion test high thresholds register            |
 | entropy_src.[`ADAPTP_LO_THRESHOLDS`](#adaptp_lo_thresholds)           | 0x40     |        4 | Adaptive proportion test low thresholds register             |
 | entropy_src.[`BUCKET_THRESHOLDS`](#bucket_thresholds)                 | 0x44     |        4 | Bucket test thresholds register                              |
@@ -36,8 +36,8 @@
 | entropy_src.[`BUCKET_HI_WATERMARKS`](#bucket_hi_watermarks)           | 0x70     |        4 | Bucket test high watermarks register                         |
 | entropy_src.[`MARKOV_HI_WATERMARKS`](#markov_hi_watermarks)           | 0x74     |        4 | Markov test high watermarks register                         |
 | entropy_src.[`MARKOV_LO_WATERMARKS`](#markov_lo_watermarks)           | 0x78     |        4 | Markov test low watermarks register                          |
-| entropy_src.[`REPCNT_TOTAL_FAILS`](#repcnt_total_fails)               | 0x7c     |        4 | Repetition count test failure counter register               |
-| entropy_src.[`REPCNTS_TOTAL_FAILS`](#repcnts_total_fails)             | 0x80     |        4 | Repetition count symbol test failure counter register        |
+| entropy_src.[`REPCNT_TOTAL_FAILS`](#repcnt_total_fails)               | 0x7c     |        4 | Repetition Count Test failure counter register               |
+| entropy_src.[`REPCNTS_TOTAL_FAILS`](#repcnts_total_fails)             | 0x80     |        4 | Repetition Count Symbol Test failure counter register        |
 | entropy_src.[`ADAPTP_HI_TOTAL_FAILS`](#adaptp_hi_total_fails)         | 0x84     |        4 | Adaptive proportion high test failure counter register       |
 | entropy_src.[`ADAPTP_LO_TOTAL_FAILS`](#adaptp_lo_total_fails)         | 0x88     |        4 | Adaptive proportion low test failure counter register        |
 | entropy_src.[`BUCKET_TOTAL_FAILS`](#bucket_total_fails)               | 0x8c     |        4 | Bucket test failure counter register                         |
@@ -393,12 +393,12 @@ Note that the number of tested bits taken by the conditioner to produce a seed i
 The only exception is the startup seed which is produced using the bits of two subsequent windows, i.e., 2 x window size x 4 tested bits.
 The factor of 4 relates to the number of noise source channels (i.e. symbol size) and applies both in single-channel and multi-channel mode (see [`ENTROPY_SRC.RNG_BIT_ENABLE`](#entropy_src)).
 
-Note that NIST SP 800-90B (Table 2) requires the adaptive proportion test to be run on 1024 or 512 samples in single-channel or multi-channel mode, respectively (see [`ENTROPY_SRC.RNG_BIT_ENABLE`](#entropy_src)).
+Note that NIST SP 800-90B (Table 2) requires the Adaptive Proportion Test to be run on 1024 or 512 samples in single-channel or multi-channel mode, respectively (see [`ENTROPY_SRC.RNG_BIT_ENABLE`](#entropy_src)).
 The startup tests must be run on at least 1024 consecutive samples (see Section 4.3 Requirements for Health Tests of NIST SP 800-90B) and this block always uses two subsequent windows for startup health testing.
 The use of window sizes below 512 samples is thus not recommended as this may not comply with NIST SP 800-90B.
 
 ## REPCNT_THRESHOLDS
-Repetition count test thresholds register
+Repetition Count Test thresholds register
 - Offset: `0x34`
 - Reset default: `0xffffffff`
 - Reset mask: `0xffffffff`
@@ -416,7 +416,7 @@ Repetition count test thresholds register
 |  15:0  |   rw   | 0xffff  | [FIPS_THRESH](#repcnt_thresholds--fips_thresh)     |
 
 ### REPCNT_THRESHOLDS . BYPASS_THRESH
-This is the threshold size for the repetition count health test
+This is the threshold for the Repetition Count Test
    running in bypass mode. This mode is active after reset for the
    first and only test run, or when this mode is programmed by firmware.
    This register must be written before the module is enabled.
@@ -425,7 +425,7 @@ This is the threshold size for the repetition count health test
    A read from this register always reflects the current value.
 
 ### REPCNT_THRESHOLDS . FIPS_THRESH
-This is the threshold size for the repetition count health test.
+This is the threshold for the Repetition Count Test.
    This value is used in FIPS mode.
    This register must be written before the module is enabled.
    Writing to this register will only update the register if the
@@ -433,7 +433,7 @@ This is the threshold size for the repetition count health test.
    A read from this register always reflects the current value.
 
 ## REPCNTS_THRESHOLDS
-Repetition count symbol test thresholds register
+Repetition Count Symbol Test thresholds register
 - Offset: `0x38`
 - Reset default: `0xffffffff`
 - Reset mask: `0xffffffff`
@@ -451,7 +451,7 @@ Repetition count symbol test thresholds register
 |  15:0  |   rw   | 0xffff  | [FIPS_THRESH](#repcnts_thresholds--fips_thresh)     |
 
 ### REPCNTS_THRESHOLDS . BYPASS_THRESH
-This is the threshold size for the repetition count symbol health test
+This is the threshold for the Repetition Count Symbol Test
    running in bypass mode. This mode is active after reset for the
    first and only test run, or when this mode is programmed by firmware.
    This register must be written before the module is enabled.
@@ -460,7 +460,7 @@ This is the threshold size for the repetition count symbol health test
    A read from this register always reflects the current value.
 
 ### REPCNTS_THRESHOLDS . FIPS_THRESH
-This is the threshold size for the repetition count symbol health test.
+This is the threshold for the Repetition Count Symbol Test.
    This value is used in FIPS mode.
    This register must be written before the module is enabled.
    Writing to this register will only update the register if the
@@ -486,7 +486,7 @@ Adaptive proportion test high thresholds register
 |  15:0  |   rw   | 0xffff  | [FIPS_THRESH](#adaptp_hi_thresholds--fips_thresh)     |
 
 ### ADAPTP_HI_THRESHOLDS . BYPASS_THRESH
-This is the threshold size for the adaptive proportion health test
+This is the threshold for the Adaptive Proportion Test
    running in bypass mode. This mode is active after reset for the
    first and only test run, or when this mode is programmed by firmware.
    This register must be written before the module is enabled.
@@ -495,7 +495,7 @@ This is the threshold size for the adaptive proportion health test
    A read from this register always reflects the current value.
 
 ### ADAPTP_HI_THRESHOLDS . FIPS_THRESH
-This is the threshold size for the adaptive proportion health test.
+This is the threshold for the Adaptive Proportion Test.
    This value is used in FIPS mode.
    This register must be written before the module is enabled.
    Writing to this register will only update the register if the
@@ -521,7 +521,7 @@ Adaptive proportion test low thresholds register
 |  15:0  |   rw   |   0x0   | [FIPS_THRESH](#adaptp_lo_thresholds--fips_thresh)     |
 
 ### ADAPTP_LO_THRESHOLDS . BYPASS_THRESH
-This is the threshold size for the adaptive proportion health test
+This is the threshold for the Adaptive Proportion Test
    running in bypass mode. This mode is active after reset for the
    first and only test run, or when this mode is programmed by firmware.
    This register must be written before the module is enabled.
@@ -530,7 +530,7 @@ This is the threshold size for the adaptive proportion health test
    A read from this register always reflects the current value.
 
 ### ADAPTP_LO_THRESHOLDS . FIPS_THRESH
-This is the threshold size for the adaptive proportion health test.
+This is the threshold for the Adaptive Proportion Test.
    This value is used in FIPS mode.
    This register must be written before the module is enabled.
    Writing to this register will only update the register if the
@@ -866,7 +866,7 @@ Markov test low watermarks register
 |  15:0  |   ro   | 0xffff  | FIPS_WATERMARK   | Low watermark value of the Markov test in FIPS mode.   |
 
 ## REPCNT_TOTAL_FAILS
-Repetition count test failure counter register
+Repetition Count Test failure counter register
 - Offset: `0x7c`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
@@ -882,7 +882,7 @@ Repetition count test failure counter register
 |  31:0  |   ro   |    x    | REPCNT_TOTAL_FAILS | This register will hold a running count of test failures observed during normal operation. It will persist until cleared. |
 
 ## REPCNTS_TOTAL_FAILS
-Repetition count symbol test failure counter register
+Repetition Count Symbol Test failure counter register
 - Offset: `0x80`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
@@ -1013,6 +1013,8 @@ External health test low threshold failure counter register
 Alert threshold register
 
 This register determines during how many subsequent health test windows one or more health test failures can occur before a recoverable alert is raised and the ENTROPY_SRC block stops operating.
+Note that continuous health tests such as the Repetition Count Test or the Repetition Count Symbol Test can trigger multiple test failures within a single window.
+Each symbol for which at least one continuous health test fails counts separately towards the threshold.
 In case the configured threshold is reached, firmware needs to disable/re-enable the block to restart operation including the startup health testing.
 
 Note that when reaching the threshold while running in Firmware Override: Extract & Insert mode, the recoverable alert is not raised nor does the block stop operating.
@@ -1039,6 +1041,8 @@ Alert summary failure counts register
 
 This register holds the total number of subsequent health test windows during which one or more health test failures occurred.
 For information on which health tests failed specifically, refer to [`ALERT_FAIL_COUNTS`](#alert_fail_counts) and [`EXTHT_FAIL_COUNTS.`](#extht_fail_counts)
+Note that continuous health tests such as the Repetition Count Test or the Repetition Count Symbol Test can trigger multiple test failures within a single window.
+Each symbol for which at least one continuous health test fails is counted separately.
 
 If the value of this register reaches the value configured in the [`ALERT_THRESHOLD`](#alert_threshold) register, a recoverable alert is raised and the ENTROPY_SRC block stops operating.
 If an alert is signaled, the value persists until it is cleared by firmware.

--- a/hw/ip/entropy_src/doc/theory_of_operation.md
+++ b/hw/ip/entropy_src/doc/theory_of_operation.md
@@ -76,16 +76,16 @@ For more details, refer to the [programmer's guide](programmers_guide.md/#firmwa
 ### Health Tests
 
 Health checks are performed on the input raw data from the PTRNG noise source when in that mode.
-There are four health tests that will be performed: repetitive count, adaptive proportion, bucket, and Markov tests.
+There are four health tests that will be performed: Repetition Count Test, Adaptive Proportion Test, bucket test, and Markov test.
 Each test has a pair of threshold values that determine that pass/fail of the test, one threshold for boot-time / bypass mode, and one for FIPS mode.
 By default, all tests are enabled, but can be turned off by setting the thresholds to the maximum value.
 Because of the variability of the PTRNG noise source, there are several registers that log statistics associated with the health tests.
-For example, the adaptive proportion test has a high watermark register that logs the highest measured number of ones.
+For example, the Adaptive Proportion Test has a high watermark register that logs the highest measured number of ones.
 The [`ADAPTP_HI_WATERMARKS`](registers.md#adaptp_hi_watermarks) register has an entry for both FIPS and boot-time modes.
 This register allows for determining how close the threshold value should be set to the fail over value.
-Specific to the adaptive proportion test, there is also the [`ADAPTP_LO_WATERMARKS`](registers.md#adaptp_lo_watermarks) register, which will hold the lowest number of ones measured.
+Specific to the Adaptive Proportion Test, there is also the [`ADAPTP_LO_WATERMARKS`](registers.md#adaptp_lo_watermarks) register, which will hold the lowest number of ones measured.
 To help understand how well the thresholds work through time, a running count of test fails is kept in the [`ADAPTP_HI_TOTAL_FAILS`](registers.md#adaptp_hi_total_fails) register.
-The above example for the adaptive proportion test also applies to the other health tests, with the exception of the low watermark registers.
+The above example for the Adaptive Proportion Test also applies to the other health tests, with the exception of the low watermark registers.
 See the timing diagrams below for more details on how the health tests work.
 It should be noted that for all error counter registers, they are sized for 16 bits, which prevents any case where counters might wrap.
 
@@ -229,7 +229,7 @@ Operating on each bit stream, this test will count when a signal is at a stuck l
 This NIST test is intended to signal a catastrophic failure with the PTRNG noise source.
 
 Note that as per definition in SP 800-90B, the Repetition Count test does not operate on a fixed window.
-The repetition count test fails if any sequence of bits continuously asserts the same value for too many samples, as determined by the programmable threshold, regardless of whether that sequence crosses any window boundaries.
+The Repetition Count Test fails if any sequence of bits continuously asserts the same value for too many samples, as determined by the programmable threshold, regardless of whether that sequence crosses any window boundaries.
 
 
 ```wavejson
@@ -285,7 +285,7 @@ In this example, the sum is taken over all RNG lines (i.e., [`CONF.THRESHOLD_SCO
 ```
 
 ### Bucket Test
-The following waveform shows how a sampling of a data pattern will be tested by the Bucket test.
+The following waveform shows how a sampling of a data pattern will be tested by the bucket test.
 Operating on all four bit streams, this test will identify the symbol and sort it into bin counters, or "buckets".
 This test is intended to find bias with a symbol or symbols.
 
@@ -327,7 +327,7 @@ For instance the string: "010101010101010101" has almost zero entropy, even thou
 The test counts the number of changes in the a fixed number of RNG samples, and comparing the number of "01"/"10" pairs to the number of "00"/"11" pairs.
 On average, the number of switching (e.g., "01") vs. non-switching (e.g., "00") pairs should be 50% of the total, with a variance proportional to the sample size.
 
-Like the Adaptive Proportion test, the Markov Test can be computed either cumulatively (summing the results over all RNG lines) or on a per-line basis.
+Like the Adaptive Proportion test, the Markov test can be computed either cumulatively (summing the results over all RNG lines) or on a per-line basis.
 In this example, the RNG lines are scored individually (i.e., [`CONF.THRESHOLD_SCOPE`](registers.md#conf) is False).
 
 ```wavejson

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
@@ -267,7 +267,7 @@ package entropy_src_env_pkg;
   // rounded down for low threholds
   //
   // The function computes the mean and standard deviation of the test result, assuming a binomial
-  // distribution (or multinomial distribution in the case of the Bucket test).  Then the min/max
+  // distribution (or multinomial distribution in the case of the bucket test).  Then the min/max
   // range is generated assuming that the window size is large enough to apply a gaussian
   // approximation.
   //
@@ -293,7 +293,7 @@ package entropy_src_env_pkg;
   //               4.9    1e-6
   //
   // The table above can be used to estimate the likelihood of failure for the AdaptP and Markov
-  // tests, which have both high and low thresholds.  Since the Bucket test has only a single
+  // tests, which have both high and low thresholds.  Since the bucket test has only a single
   // threshold, the likelihood of chance bucket-test failure is 1/2 the above value for the same
   // sigma value.
   //

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_err_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_err_vseq.sv
@@ -136,7 +136,7 @@ class entropy_src_err_vseq extends entropy_src_base_vseq;
           repcnts_ht_cntr: begin // repcnts ht test counter
             repcnts_ht_cntr_test(m_rng_push_seq, fld);
           end
-          adaptp_ht_cntr: begin // adaptive proportion test counter
+          adaptp_ht_cntr: begin // Adaptive Proportion Test counter
             adaptp_ht_cntr_test(m_rng_push_seq, fld);
           end
           bucket_ht_cntr: begin // Bucket test counter


### PR DESCRIPTION
This PR cherry-picks two commits from master (PR #29265) over to earlgrey_1.0.0:

- [entropy_src/doc] Clarify purpose of CONF.THRESHOLD_SCOPE field
- [entropy_src] Align spelling of health tests