### PR TITLE
use prim_sec_anchor_const in keymgr[_dpe]

### DIFF
--- a/hw/ip/keymgr/rtl/keymgr.sv
+++ b/hw/ip/keymgr/rtl/keymgr.sv
@@ -107,19 +107,21 @@ module keymgr
   seed_t kmac_seed;
   seed_t none_seed;
 
-  prim_sec_anchor_buf #(
-    .Width(TotalSeedWidth)
-  ) u_seed_anchor (
-    .in_i({RndCnstRevisionSeed,
-           RndCnstCreatorIdentitySeed,
-           RndCnstOwnerIntIdentitySeed,
-           RndCnstOwnerIdentitySeed,
-           RndCnstSoftOutputSeed,
-           RndCnstHardOutputSeed,
-           RndCnstAesSeed,
-           RndCnstOtbnSeed,
-           RndCnstKmacSeed,
-           RndCnstNoneSeed}),
+  localparam logic [TotalSeedWidth-1:0] RndConstSeed = {RndCnstRevisionSeed,
+                                                        RndCnstCreatorIdentitySeed,
+                                                        RndCnstOwnerIntIdentitySeed,
+                                                        RndCnstOwnerIdentitySeed,
+                                                        RndCnstSoftOutputSeed,
+                                                        RndCnstHardOutputSeed,
+                                                        RndCnstAesSeed,
+                                                        RndCnstOtbnSeed,
+                                                        RndCnstKmacSeed,
+                                                        RndCnstNoneSeed};
+
+  prim_sec_anchor_const #(
+    .Width(TotalSeedWidth),
+    .ConstVal(RndConstSeed)
+  ) u_seed_anchor_const (
     .out_o({revision_seed,
             creator_identity_seed,
             owner_int_identity_seed,

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe.sv
@@ -94,27 +94,25 @@ module keymgr_dpe
   seed_t kmac_seed;
   seed_t none_seed;
 
-  prim_sec_anchor_buf #(
-    .Width(TotalSeedWidth)
-  ) u_seed_anchor (
-    .in_i({
-      RndCnstRevisionSeed,
-      RndCnstSoftOutputSeed,
-      RndCnstHardOutputSeed,
-      RndCnstAesSeed,
-      RndCnstOtbnSeed,
-      RndCnstKmacSeed,
-      RndCnstNoneSeed
-    }),
-    .out_o({
-      revision_seed,
-      soft_output_seed,
-      hard_output_seed,
-      aes_seed,
-      otbn_seed,
-      kmac_seed,
-      none_seed
-    })
+  localparam logic [TotalSeedWidth-1:0] RndConstSeed = {RndCnstRevisionSeed,
+                                                        RndCnstSoftOutputSeed,
+                                                        RndCnstHardOutputSeed,
+                                                        RndCnstAesSeed,
+                                                        RndCnstOtbnSeed,
+                                                        RndCnstKmacSeed,
+                                                        RndCnstNoneSeed};
+
+  prim_sec_anchor_const #(
+    .Width(TotalSeedWidth),
+    .ConstVal(RndConstSeed)
+  ) u_seed_anchor_const (
+    .out_o({revision_seed,
+            soft_output_seed,
+            hard_output_seed,
+            aes_seed,
+            otbn_seed,
+            kmac_seed,
+            none_seed})
   );
 
   // Register module


### PR DESCRIPTION
This commit replaces the prim_sec_anchor_buf with the new prim_const module (see https://github.com/lowRISC/opentitan/pull/29284, https://github.com/lowRISC/opentitan/issues/29271) 

The first three commits are part of a separate PR (https://github.com/lowRISC/opentitan/pull/29284)