### PR TITLE
[test,rom_ext] Add watchdog rescue test without external trigger

### DIFF
--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -156,6 +156,8 @@ TEST_OWNER_CONFIGS = {
         "owner_defines": [
             # 0x58 is 'X'modem.
             "WITH_RESCUE_PROTOCOL=0x58",
+            # Rescue can be triggered by watchdog even if rescue detect is set to None.
+            "WITH_RESCUE_TRIGGER=0",
             # misc_gpio: 0x80=enter_on_watchdog.
             "WITH_RESCUE_MISC_GPIO_PARAM=0x80",
         ],


### PR DESCRIPTION
This PR enhances the watchdog test case by setting `WITH_RESCUE_TRIGGER=0` to cover the branch that enters rescue mode even when rescue detection is disabled.