### PR TITLE
Backport 27148 ([rom_ext] Bump version to 0.108)

### DIFF
--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -14,7 +14,7 @@ def secver_write_selection():
 # because of how the bazel rule accepts attributes.
 ROM_EXT_VERSION = struct(
     MAJOR = "0",
-    MINOR = "107",
+    MINOR = "108",
     SECURITY = "0",
 )
 


### PR DESCRIPTION
Backport #27148, depends on https://github.com/lowRISC/opentitan/pull/29236, only review last commit.