### PR TITLE
Backport 27172 ([rom_ext] Bump the ROM_EXT version number)

### DIFF
--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -14,7 +14,7 @@ def secver_write_selection():
 # because of how the bazel rule accepts attributes.
 ROM_EXT_VERSION = struct(
     MAJOR = "0",
-    MINOR = "108",
+    MINOR = "109",
     SECURITY = "0",
 )
 


### PR DESCRIPTION
Backport #27172, depends on https://github.com/lowRISC/opentitan/pull/29302, only review last commit.