### PR TITLE
[lc_ctrl,dv] Disable the new LcInitDoneSticky_A in error tests

### DIFF
--- a/hw/ip/lc_ctrl/dv/tb.sv
+++ b/hw/ip/lc_ctrl/dv/tb.sv
@@ -325,6 +325,7 @@ module tb;
   `DV_ASSERT_CTRL("StateRegs_A", tb.dut.FpvSecCmCtrlLcStateCheck_A)
   `DV_ASSERT_CTRL("FsmStateRegs_A", tb.dut.u_lc_ctrl_fsm.u_fsm_state_regs_A)
   `DV_ASSERT_CTRL("FsmStateRegs_A", tb.dut.FpvSecCmCtrlLcFsmCheck_A)
+  `DV_ASSERT_CTRL("FsmStateRegs_A", tb.dut.LcInitDoneSticky_A)
   `DV_ASSERT_CTRL("CountRegs_A", tb.dut.u_lc_ctrl_fsm.u_cnt_regs_A)
   `DV_ASSERT_CTRL("CountRegs_A", tb.dut.FpvSecCmCtrlLcCntCheck_A)
   `DV_ASSERT_CTRL("KmacFsmStateRegs_A", tb.dut.u_lc_ctrl_kmac_if.u_state_regs_A)


### PR DESCRIPTION
This assertion requires that lc_init_done_o never stops being true. For an error test that injects FSM errors, it does! Use the existing infrastructure to disable it if we're disabling the other assertions that depend on FSM states.

This will fix lots of failures in the overnight tests.