### PR TITLE
[lc_ctrl,assert] Express LcInitDoneSticky_A more comfortably

### DIFF
--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -882,9 +882,7 @@ module lc_ctrl
   `ASSERT_KNOWN(HwRevKnown_A,           hw_rev_o                   )
 
   `ASSERT(LcInitDoneSticky_A,
-      lc_tx_test_true_strict(lc_init_done_o)
-      |=>
-      ##1 !$fell(lc_tx_test_true_strict(lc_init_done_o)))
+          ##1 !$fell(lc_tx_test_true_strict(lc_init_done_o)))
 
   // Alert assertions for sparse FSMs.
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlLcFsmCheck_A,


### PR DESCRIPTION
This is equivalent, but rather easier to read (and avoids generating a pointless coverpoint).

(It's a pity that this sort of assertion is in our not-to-be-hacked-on RTL!)