### PR TITLE
[dv] Fix calculation of has_mem_byte_access_err

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_pkg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_pkg.sv
@@ -70,7 +70,9 @@ package cip_base_pkg;
     foreach (mems[i]) begin
       dv_base_mem dv_mem;
       `downcast(dv_mem, mems[i], , , msg_id)
-      if (!dv_mem.get_mem_partial_write_support() && dv_mem.get_access() == "RO") begin
+      // If the memory supports write (WO or RW) and doesn't have partial write support then it can
+      // generate a memory byte access error.
+      if (!dv_mem.get_mem_partial_write_support() && dv_mem.get_access() != "RO") begin
         has_mem_byte_access_err = 1;
       end
       if (dv_mem.get_access() == "WO") has_wo_mem = 1;


### PR DESCRIPTION
I found this because an error sequence was sending partial writes to the debug ROM and expecting them to fail because there wasn't a full mask.

Looking at the change that added this code (b4f912b), it looks a lot like a "quick fix" and my suspicion is that it fixed the problem they were having, but not in the way they expected.

Change the code to something that I think might be right and add a comment that explains what the code is doing.