### PR TITLE
[rv_dm,dv] Fix bug in rv_dm_csr_mem_rw_with_rand_reset

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -246,7 +246,9 @@ endfunction
 // reset), stop generating transactions and return.
 virtual task tl_instr_type_err(string ral_name);
   dv_base_reg_block ral_model = cfg.ral_models[ral_name];
-  bit has_csrs = (ral_model.csr_addrs.size() > 0);
+  bit has_nofetch_csrs = ((ral_model.csr_addrs.size() > 0) &&
+                          !ral_model.get_allows_csr_fetch());
+
   repeat ($urandom_range(10, 100)) begin
     bit [BUS_AW-1:0] addr;
     bit              write;
@@ -271,7 +273,7 @@ virtual task tl_instr_type_err(string ral_name);
         write = 1'b1;
         instr_type = MuBi4True;
       end
-      has_csrs: begin
+      has_nofetch_csrs: begin
         write = 1'b0;
         instr_type = MuBi4True;
         addr = pick_rand_csr_addr(ral_name, ral_model);

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -66,6 +66,11 @@ class dv_base_reg_block extends uvm_reg_block;
   // This is added for ease of rv_dm testbench development.
   protected bit supports_byte_enable = 1'b1;
 
+  // Indicates whether an instruction fetch is allowed from a CSR. This isn't something you'd
+  // normally expect, but it allows us to model a block that contains both registers and memory and
+  // doesn't make a distinction between read and fetch.
+  local bit     allows_csr_fetch = 1'b0;
+
   // Custom RAL models may support sub-word CSR writes smaller than CSR width.
   protected bit supports_sub_word_csr_writes = 1'b0;
 
@@ -130,6 +135,14 @@ class dv_base_reg_block extends uvm_reg_block;
 
   function bit get_supports_sub_word_csr_writes();
     return supports_sub_word_csr_writes;
+  endfunction
+
+  function void set_allows_csr_fetch(bit allowed);
+    allows_csr_fetch = allowed;
+  endfunction
+
+  function bit get_allows_csr_fetch();
+    return allows_csr_fetch;
   endfunction
 
   // provide build function to supply base addr

--- a/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
@@ -57,6 +57,12 @@ class rv_dm_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_dm_regs_reg_block));
     super.initialize(csr_base_addr);
     `uvm_info(`gfn, $sformatf("ral_model_names: %0p", ral_model_names), UVM_LOW)
 
+    // Configure the RAL model for the mem register block (rv_dm_mem_reg_block) so that it doesn't
+    // disallow fetches from CSRs. In the design, accesses to both CSRs and the debug ROM are passed
+    // straight to dm_top (without information about whether this is a read or a fetch), so there is
+    // nothing to stop fetches from CSRs.
+    ral_models[mem_ral_name].set_allows_csr_fetch(1'b1);
+
     // Both, the regs and the debug mem TL device (in the DUT) only support 1 outstanding.
     m_tl_agent_cfgs[RAL_T::type_name].max_outstanding_req = 1;
     m_tl_agent_cfgs[mem_ral_name].max_outstanding_req = 1;


### PR DESCRIPTION
The virtual sequence in question tries to send lots of TL accesses that should do nothing except respond with an error. One of the "bad" things it tries is to send instruction fetches from CSRs.

The debug module doesn't know about this whole fetch vs. read malarky and will merrily respond to either. We can't catch this in rv_dm.sv either, because dm_top contains both the debug ROM (which should allow fetches) and CSRs (which ideally wouldn't).

The change in this commit just allows us to tell the base class that we're a special type of register block which is happy to fetch CSRs.