### PR TITLE
Backport 27468 ([rescue,opentitanlib,test] Add functional test for `GetOwnerPage`)

### DIFF
--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -537,6 +537,33 @@ opentitan_test(
     for protocol, config in _CONFIGS.items()
 ]
 
+[
+    opentitan_test(
+        name = "rescue_get_owner_page_{}".format(protocol),
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+            "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+        },
+        fpga = fpga_params(
+            assemble = "{romext}@{romext_offset} {firmware}@{owner_offset}",
+            binaries = {
+                config["rom_ext"]: "romext",
+                "//sw/device/silicon_creator/rom_ext/e2e/attestation:print_certs": "firmware",
+            },
+            owner_offset = "0x10000",
+            params = config["params"],
+            romext_offset = "0",
+            test_cmd = """
+            --clear-bitstream
+            --bootstrap={firmware}
+            rescue {params} --action=get-owner-page
+            """,
+            test_harness = "//sw/host/tests/rescue:rescue_test",
+        ),
+    )
+    for protocol, config in _CONFIGS.items()
+]
+
 opentitan_test(
     name = "rescue_disability_xmodem",
     exec_env = {

--- a/sw/host/opentitanlib/src/crypto/ecdsa.rs
+++ b/sw/host/opentitanlib/src/crypto/ecdsa.rs
@@ -79,7 +79,7 @@ impl EcdsaPrivateKey {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Annotate)]
+#[derive(Debug, Clone, Deserialize, Annotate, PartialEq)]
 pub struct EcdsaRawSignature {
     #[serde(with = "serde_bytes")]
     #[annotate(format = hexstr)]
@@ -255,7 +255,7 @@ impl TryFrom<&EcdsaRawPublicKey> for EcdsaPublicKey {
     }
 }
 
-#[derive(Debug, Deserialize, Annotate)]
+#[derive(Debug, Deserialize, Annotate, PartialEq)]
 pub struct EcdsaRawPublicKey {
     #[serde(with = "serde_bytes")]
     #[annotate(format = hexstr)]

--- a/sw/host/opentitanlib/src/crypto/rsa.rs
+++ b/sw/host/opentitanlib/src/crypto/rsa.rs
@@ -244,7 +244,7 @@ impl Deref for RsaPrivateKey {
     }
 }
 
-#[derive(Debug, Deserialize, Annotate)]
+#[derive(Debug, Deserialize, Annotate, PartialEq)]
 pub struct RsaRawPublicKey {
     #[serde(with = "serde_bytes")]
     #[annotate(format = hexstr)]

--- a/sw/host/opentitanlib/src/crypto/spx.rs
+++ b/sw/host/opentitanlib/src/crypto/spx.rs
@@ -12,7 +12,7 @@ use sphincsplus::{DecodeKey, SpxPublicKey};
 
 use super::Error;
 
-#[derive(Debug, Deserialize, Annotate)]
+#[derive(Debug, Deserialize, Annotate, PartialEq)]
 pub struct SpxRawPublicKey {
     #[serde(with = "serde_bytes")]
     #[annotate(format = hexstr)]

--- a/sw/host/opentitanlib/src/ownership/application_key.rs
+++ b/sw/host/opentitanlib/src/ownership/application_key.rs
@@ -23,7 +23,7 @@ with_unknown! {
 }
 
 /// The OwnerApplicationKey is used to verify the owner's firmware payload.
-#[derive(Debug, Deserialize, Annotate)]
+#[derive(Debug, Deserialize, Annotate, PartialEq)]
 pub struct OwnerApplicationKey {
     /// Header identifying this struct.
     #[serde(

--- a/sw/host/opentitanlib/src/ownership/flash.rs
+++ b/sw/host/opentitanlib/src/ownership/flash.rs
@@ -14,7 +14,7 @@ use super::GlobalFlags;
 use super::misc::{TlvHeader, TlvTag};
 
 /// Describes the proprerties of a flash region.
-#[derive(Debug, Default, Clone, Copy, Deserialize, Annotate)]
+#[derive(Debug, Default, Clone, Copy, Deserialize, Annotate, PartialEq)]
 pub struct FlashFlags {
     /// Read operations are allowed in this region.
     #[serde(default)]
@@ -147,7 +147,7 @@ impl From<FlashFlags> for u64 {
 }
 
 /// Describes a region to which a set of flags apply.
-#[derive(Debug, Default, Deserialize, Annotate)]
+#[derive(Debug, Default, Deserialize, Annotate, PartialEq)]
 pub struct OwnerFlashRegion {
     /// The start of the region (in pages).
     pub start: u16,
@@ -177,7 +177,7 @@ impl OwnerFlashRegion {
 }
 
 /// Describes the overall flash configuration for data pages.
-#[derive(Debug, Deserialize, Annotate)]
+#[derive(Debug, Deserialize, Annotate, PartialEq)]
 pub struct OwnerFlashConfig {
     /// Header identifying this struct.
     #[serde(

--- a/sw/host/opentitanlib/src/ownership/flash_info.rs
+++ b/sw/host/opentitanlib/src/ownership/flash_info.rs
@@ -13,7 +13,7 @@ use super::flash::FlashFlags;
 use super::misc::{TlvHeader, TlvTag};
 
 /// Describes an INFO page to which a set of flags apply.
-#[derive(Debug, Default, Deserialize, Annotate)]
+#[derive(Debug, Default, Deserialize, Annotate, PartialEq)]
 pub struct OwnerInfoPage {
     /// The bank in which the info page resides.
     pub bank: u8,
@@ -57,7 +57,7 @@ impl OwnerInfoPage {
 }
 
 /// Describes the overall flash configuration for owner-accesssable INFO pages.
-#[derive(Debug, Deserialize, Annotate)]
+#[derive(Debug, Deserialize, Annotate, PartialEq)]
 pub struct OwnerFlashInfoConfig {
     /// Header identifying this struct.
     #[serde(

--- a/sw/host/opentitanlib/src/ownership/isfb.rs
+++ b/sw/host/opentitanlib/src/ownership/isfb.rs
@@ -14,7 +14,7 @@ use super::misc::{TlvHeader, TlvTag};
 
 /// The owner Integration Specific Firmware Binding (ISFB) configuration
 /// describes the configuration parameters for the ISFB region.
-#[derive(Debug, Deserialize, Annotate)]
+#[derive(Debug, Deserialize, Annotate, PartialEq)]
 pub struct OwnerIsfbConfig {
     /// Header identifying this struct.
     #[serde(

--- a/sw/host/opentitanlib/src/ownership/misc.rs
+++ b/sw/host/opentitanlib/src/ownership/misc.rs
@@ -74,7 +74,7 @@ impl OwnershipKeyAlg {
     }
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 #[serde(try_from = "String", into = "String")]
 pub struct StructVersion {
     pub major: u8,
@@ -126,7 +126,7 @@ impl StructVersion {
     }
 }
 
-#[derive(Debug, Default, Deserialize, Annotate)]
+#[derive(Debug, Default, Deserialize, Annotate, PartialEq)]
 pub struct TlvHeader {
     #[serde(default)]
     pub identifier: TlvTag,
@@ -168,7 +168,7 @@ impl TlvHeader {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct HybridRawPublicKey {
     #[serde(deserialize_with = "string_or_struct")]
     pub ecdsa: EcdsaRawPublicKey,
@@ -194,7 +194,7 @@ impl HybridRawPublicKey {
 }
 
 /// Low-level key material (ie: bit representation).
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[allow(clippy::len_without_is_empty)]
 pub enum KeyMaterial {
     #[serde(alias = "unknown")]

--- a/sw/host/opentitanlib/src/ownership/owner.rs
+++ b/sw/host/opentitanlib/src/ownership/owner.rs
@@ -40,7 +40,7 @@ with_unknown! {
 }
 
 /// Describes the owner configuration and key material.
-#[derive(Debug, Deserialize, Annotate)]
+#[derive(Debug, Deserialize, Annotate, PartialEq)]
 pub struct OwnerBlock {
     /// Header identifying this struct.
     #[serde(
@@ -265,7 +265,7 @@ impl OwnerBlock {
     }
 }
 
-#[derive(Debug, Deserialize, Annotate)]
+#[derive(Debug, Deserialize, Annotate, PartialEq)]
 pub enum OwnerConfigItem {
     #[serde(alias = "application_key")]
     ApplicationKey(OwnerApplicationKey),

--- a/sw/host/opentitanlib/src/ownership/rescue.rs
+++ b/sw/host/opentitanlib/src/ownership/rescue.rs
@@ -53,7 +53,7 @@ with_unknown! {
 }
 
 /// Describes the configuration of the rescue feature of the ROM_EXT.
-#[derive(Debug, Deserialize, Annotate)]
+#[derive(Debug, Deserialize, Annotate, PartialEq)]
 pub struct OwnerRescueConfig {
     /// Header identifying this struct.
     #[serde(


### PR DESCRIPTION
Backport #27468, depends on #29319. Also includes a fix for the SPIDFU rescue test which causes the test to fail (this was missed in a previous PR) due to a difference between `master` and `earlgrey_1.0.0`