### PR TITLE
[ci] Bump timeout of CW340 ROM_EXT job to 80 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,6 +585,7 @@ jobs:
       board: cw340
       interface: cw340
       tag_filters: cw340_rom_ext
+      timeout: 80
 
   execute_sival_fpga_tests_cw340:
     name: CW340 SiVal Tests


### PR DESCRIPTION
Currently, the job runs all tests (without any cache) in about 58 minutes. This can make the job go over the 60 minute limit due to the extra steps involved.