### PR TITLE
[dv,cip] Rewrite `_DV_MUBI_DIST to avoid warnings

### DIFF
--- a/hw/dv/sv/cip_lib/cip_macros.svh
+++ b/hw/dv/sv/cip_lib/cip_macros.svh
@@ -49,28 +49,49 @@
   end
 `endif
 
-// A macro to simplify the distribution constraint of mubi type variable
-// Don't use this macro directly, use DV_MUBI4|8|16_DIST.
-// The weights of both TRUE and FALSE are scaled by the number of other
-// values, and this uses ":=" for the distribution of other values, so they
-// are truly uniform.
-// The MAX_ argument is the maximum value that VAR_ can take, which means
-// (MAX_ - 1) is the scaling factor.
+// Macros that expand to a ternary expression giving the smaller / larger of the two values.
+//
+// These make no guarantee to only evaluate arguments once.
+`ifndef _DV_TERNARY_MIN
+`define _DV_TERNARY_MIN(a_, b_) (((a_) < (b_)) ? (a_) : (b_))
+`endif
+`ifndef _DV_TERNARY_MAX
+`define _DV_TERNARY_MAX(a_, b_) (((a_) < (b_)) ? (b_) : (a_))
+`endif
+
+// A macro that expands to a constraint giving distribution for a mubi-type variable
+// Don't use this macro directly: use DV_MUBI4|8|16_DIST instead.
+//
+// Arguments:
+//
+//  VAR_           The variable whose distribution is being constrained
+//  TRUE_          MuBi true value
+//  FALSE_         MuBi false value
+//  MAX_           The maximum value in the bit-vector range for the value
+//  T_WEIGHT_      The weight to give the "true" value
+//  F_WEIGHT_      The weight to give the "false" value
+//  OTHER_WEIGHT_  The weight spread among all other values
+//
+// This macro uses ":=" to give weights for the other cases in order that the individual values
+// won't have a weight that depends on the length of the range containing them. There are (MAX_ - 2)
+// items in these other ranges, so we scale T_WEIGHT_ and F_WEIGHT_ by that value to ensure that
+// T_WEIGHT_/F_WEIGHT_/OTHER_WEIGHT_ give the relative weights for true/false/something-else. For
+// example, if T_WEIGHT_, F_WEIGHT_ and OTHER_WEIGHT_ are all equal then the probabilities of
+// getting "true" and "false" and getting something else are all 1/3.
+//
+// Some tools generate a warning if there is a backwards range ([big:little]) in the distribution,
+// even if an if/else check ensures that it isn't used. To avoid this warning, we use a ternary
+// operator to extract the larger/smaller value.
 `ifndef _DV_MUBI_DIST
-`define _DV_MUBI_DIST(VAR_, TRUE_, FALSE_, MAX_, T_WEIGHT_, F_WEIGHT_, OTHER_WEIGHT_) \
-  if (TRUE_ > FALSE_) { \
-    VAR_ dist {TRUE_                         := (T_WEIGHT_) * ((MAX_) - 1), \
-               FALSE_                        := (F_WEIGHT_) * ((MAX_) - 1), \
-               [0 : FALSE_ - 1]              := (OTHER_WEIGHT_),            \
-               [FALSE_ + 1 : TRUE_ - 1]      := (OTHER_WEIGHT_),            \
-               [TRUE_ + 1 : (MAX_)]          := (OTHER_WEIGHT_)};           \
-  } else {                                                                  \
-    VAR_ dist {TRUE_                         := (T_WEIGHT_) * ((MAX_) - 1), \
-               FALSE_                        := (F_WEIGHT_) * ((MAX_) - 1), \
-               [0 : TRUE_ - 1]               := (OTHER_WEIGHT_),            \
-               [TRUE_ + 1 : FALSE_ - 1]      := (OTHER_WEIGHT_),            \
-               [FALSE_+ 1 : (MAX_)]          := (OTHER_WEIGHT_)};           \
-  }
+`define _DV_MUBI_DIST(VAR_, TRUE_, FALSE_, MAX_, T_WEIGHT_, F_WEIGHT_, OTHER_WEIGHT_)  \
+  VAR_ dist {                                                                          \
+    TRUE_                                        := (T_WEIGHT_) * ((MAX_) - 1),        \
+    FALSE_                                       := (F_WEIGHT_) * ((MAX_) - 1),        \
+    [0 : `_DV_TERNARY_MIN(TRUE_, FALSE_)-1]      := (OTHER_WEIGHT_),                   \
+    [(`_DV_TERNARY_MIN(TRUE_, FALSE_)+1) :                                             \
+     (`_DV_TERNARY_MAX(TRUE_, FALSE_)-1)]        := (OTHER_WEIGHT_),                   \
+    [(`_DV_TERNARY_MAX(TRUE_, FALSE_)+1):(MAX_)] := (OTHER_WEIGHT_)                    \
+  };
 `endif
 
 // inputs of these macros


### PR DESCRIPTION
It turns out that randomising with a distribution like this

```
  if (0) {
    XYZ dist { [1:0] := 1; };
  }
```

generates a runtime warning from Xcelium (even though the distribution expression isn't actually used).

Fortunately, range endpoints can be general expressions, so we can do everything with ternary operators instead. We can also avoid repeating stuff if we define MIN / MAX macros.

This commit also fixes the weighting for true/false. Suppose we want to distribute with weights ZeroW, OneW, OtherW for 0, 1, other in a way that e.g. the fraction of ones is OneW / (ZeroW + OneW + OtherW).

The following would definitely be wrong:

```
 value dist { 0      := ZeroW,
              1      := OneW,
              [2:9] := OtherW };
```

Because there are eight "other" values, the fractions end up looking like OneW / (ZeroW + OneW + 8 * OtherW). Oops!

To make everything line up properly, we multiply by 8:

```
 value dist { 0      := 8 * ZeroW,
              1      := 8 * OneW,
              [2:9] := OtherW };
```

and will now have fractions like

```
 8 * OneW / (8 * ZeroW + 8 * OneW + 8 * OtherW
  =
 OneW / (ZeroW + OneW + OtherW)
```

Generalising to the macro, there are (MAX_ - 1) possible values (instead of 10), so we need to scale up by (MAX_ - 3).