### PR TITLE
Backport 27696 ([rom_ext] Do not clear `RLB` in the ROM_EXT)

### DIFF
--- a/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
@@ -118,7 +118,7 @@ opentitan_test(
             "13: 00010000 NAPOT -XWR sz=00001000",  # RvDM regionn
             "14: 40000000 NAPOT --WR sz=10000000",  # MMIO for peripherals.
             "15: 10000000 NAPOT --WR sz=00020000",  # All of RAM.
-            "mseccfg = 00000002",
+            "mseccfg = 00000006",  # rlb=true, mmwp=true, mml=false
             ".*",
             ".*PASS!",
             "",

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -395,25 +395,13 @@ static rom_error_t rom_ext_boot(boot_data_t *boot_data, boot_log_t *boot_log,
       break;
     case kHardenedBoolFalse:
       HARDENED_CHECK_EQ(manifest->address_translation, kHardenedBoolFalse);
-      // Normally we'd want to clear the ROM region since we aren't using it
-      // anymore and since it isn't being used to encode access to the virtual
-      // window.  However, for SiVal, we want to keep low entries locked to
-      // prevent using low entries to override policy in higher entries.
-      // epmp_clear_rom_region();
       break;
     default:
       HARDENED_TRAP();
   }
 
-  // Allow execution of owner stage executable code (text) sections,
-  // unlock the ROM_EXT code regions so the next stage can re-use those
-  // entries and clear RLB to prevent further changes to locked ePMP regions.
-  HARDENED_RETURN_IF_ERROR(epmp_state_check());
+  // Allow execution of owner stage executable code (text) sections.
   epmp_set_tor(2, text_region, kEpmpPermReadExecute);
-
-  // Now that we're done reconfiguring the ePMP, we'll clear the RLB bit to
-  // prevent any modification to locked entries.
-  epmp_clear_rlb();
   HARDENED_RETURN_IF_ERROR(epmp_state_check());
 
   // Lock the address translation windows.


### PR DESCRIPTION
Backport #27696