### PR TITLE
Backport 27527 ([perso] rev perso version)

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -293,8 +293,8 @@ manifest(d = {
     "manuf_state_creator": hex(CONST.MANUF_STATE.PERSO_INITIAL),
     "visibility": ["//visibility:private"],
     "version_major": ROM_EXT_VERSION.MAJOR,
-    # Release: 2025-06-18-RC00
-    "version_minor": "2025061800",
+    # Release: 2025-07-01-RC00
+    "version_minor": "2025070100",
     "security_version": "0xFFFFFFFF",
 })
 


### PR DESCRIPTION
Backport #27527. The version date is meaningless for master but allows for clean backporting