### PR TITLE
[sw] Warn on sign conversions

### DIFF
--- a/sw/device/lib/base/hardened_memory.c
+++ b/sw/device/lib/base/hardened_memory.c
@@ -153,7 +153,7 @@ hardened_bool_t consttime_memeq_byte(const void *lhs, const void *rhs,
 
     // Same as above. The compiler can cache the value of `a[offset]`, but it
     // has no chance to strength-reduce this operation.
-    ones = launder32(ones) & (launder32((uint32_t)*a) ^ ~*b);
+    ones = launder32(ones) & (launder32((uint32_t)*a) ^ ~(uint32_t)*b);
   }
 
   HARDENED_CHECK_EQ(count, len);

--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -716,7 +716,7 @@ static status_t entropy_src_configure(const entropy_src_config_t *config) {
       config->alert_threshold);
   reg = bitfield_field32_write(
       reg, ENTROPY_SRC_ALERT_THRESHOLD_ALERT_THRESHOLD_INV_FIELD,
-      ~config->alert_threshold);
+      ~(uint32_t)(config->alert_threshold));
   abs_mmio_write32(entropy_src_base() + ENTROPY_SRC_ALERT_THRESHOLD_REG_OFFSET,
                    reg);
 

--- a/sw/device/lib/testing/test_framework/ottf_alerts.c
+++ b/sw/device/lib/testing/test_framework/ottf_alerts.c
@@ -233,7 +233,7 @@ status_t ottf_alerts_expect_alert_finish(dif_alert_handler_alert_t alert) {
   }
 
   // Forget that the alert was caught.
-  alert_caught[alert_word_idx] &= ~(1 << alert_bit_idx);
+  alert_caught[alert_word_idx] &= ~(1u << alert_bit_idx);
 
   return OK_STATUS();
 }

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -332,6 +332,7 @@ cc_args(
         "-Wswitch-default",
         "-Wtype-limits",
         "-Wno-gnu-auto-type",
+        "-Wsign-conversion",
     ],
 )
 


### PR DESCRIPTION
Recent versions of Clang default to warning on sign conversions (`-Wsign-conversion`) when `-Wconversion` is enabled, which we do enable in OpenTitan. We can either resolve those cases (by making the conversion explicit) or disable the warning. This PR tries to resolve the warnings.