### PR TITLE
[gpiodpi] Remove unused signal

### DIFF
--- a/hw/dv/dpi/gpiodpi/gpiodpi.sv
+++ b/hw/dv/dpi/gpiodpi/gpiodpi.sv
@@ -64,8 +64,6 @@ module gpiodpi
      end
    end
 
-   logic gpio_write_pulse;
-
    always_ff @(posedge eff_clk or negedge rst_ni) begin
      if (!rst_ni) begin
        gpio_p2d <= '0; // default value


### PR DESCRIPTION
It seems all usage of this signal was removed in commit 2fbc7eb but not the signal itself.
Let's fix that.