### PR TITLE
[dtgen] Improve enum handling

### DIFF
--- a/util/dtgen/dt_api.c.tpl
+++ b/util/dtgen/dt_api.c.tpl
@@ -65,7 +65,7 @@ dt_instance_id_t dt_alert_id_to_instance_id(dt_alert_id_t alert) {
 static const ${helper.dev_type_map.render_var_def(Name.from_snake_case("device_type"), helper.dev_type_values)}
 
 dt_device_type_t dt_device_type(dt_instance_id_t dev) {
-  if (dev < kDtInstanceIdCount) {
+  if ((int)dev < kDtInstanceIdCount) {
     return device_type[dev];
   }
   return kDtDeviceTypeUnknown;
@@ -91,7 +91,7 @@ static const ${helper.pad_dt_map.render_var_def(dt_pad_array_name, helper.pad_dt
 
 #define TRY_GET_PAD(pad, default) \
   ({ \
-    if ((pad) < (dt_pad_t)0 || (pad) >= kDtPadCount) \
+    if ((pad) < (dt_pad_t)0 || (int)(pad) >= kDtPadCount) \
       return (default); \
     &dt_pad[pad]; \
   })

--- a/util/dtgen/dt_api.h.tpl
+++ b/util/dtgen/dt_api.h.tpl
@@ -48,14 +48,14 @@ extern "C" {
  *
  * Device types are guaranteed to be numbered consecutively from 0.
  */
-${helper.device_type_enum.render()}
+${helper.device_type_enum.render_type_def()}
 
 /**
  * List of instance IDs.
  *
  * Instance IDs are guaranteed to be numbered consecutively from 0.
  */
-${helper.instance_id_enum.render()}
+${helper.instance_id_enum.render_type_def()}
 
 /**
  * Get the instance type of a device instance.
@@ -126,7 +126,7 @@ dt_instance_id_t dt_alert_id_to_instance_id(dt_alert_id_t alert);
  *
  * Clocks are guaranteed to be numbered consecutively from 0.
  */
-${helper.clock_enum.render()}
+${helper.clock_enum.render_type_def()}
 
 /**
  * Get the frequency of a clock.
@@ -141,12 +141,12 @@ uint32_t dt_clock_frequency(dt_clock_t clk);
  *
  * Resets are guaranteed to be numbered consecutively from 0.
  */
-${helper.reset_enum.render()}
+${helper.reset_enum.render_type_def()}
 
 /**
  * List of pads names.
  */
-${helper.pad_enum.render()}
+${helper.pad_enum.render_type_def()}
 
 /** Type of peripheral I/O. */
 typedef enum dt_periph_io_type {

--- a/util/dtgen/dt_ip.c.tpl
+++ b/util/dtgen/dt_ip.c.tpl
@@ -41,7 +41,7 @@ static const ${helper.inst_dt_map.render_var_def(dt_array_name, helper.inst_dt_v
  */
 #define TRY_GET_DT(dt, default) \
   ({ \
-    if ((dt) < (dt_${device_name}_t)0 || (dt) >= ${dt_array_count.as_c_enum()}) \
+    if ((dt) < (dt_${device_name}_t)0 || (int)(dt) >= ${dt_array_count.as_c_enum()}) \
       return (default); \
     &${dt_array}[dt]; \
   })

--- a/util/dtgen/dt_ip.h.tpl
+++ b/util/dtgen/dt_ip.h.tpl
@@ -36,7 +36,7 @@ ${helper.render_extension(Extension.DtIpPos.HeaderIncludes)}
 /**
  * List of instances.
  */
-${helper.inst_enum.render()}
+${helper.inst_enum.render_type_def()}
 
 % if helper.has_reg_blocks():
 /**
@@ -44,7 +44,7 @@ ${helper.inst_enum.render()}
  *
  * Register blocks are guaranteed to start at 0 and to be consecutively numbered.
  */
-${helper.reg_block_enum.render()}
+${helper.reg_block_enum.render_type_def()}
 
 /** Primary register block (associated with the "primary" set of registers that control the IP). */
 <%
@@ -60,7 +60,7 @@ static const ${helper.reg_block_enum.name.as_c_type()} ${default_reg_block_name}
  *
  * Memories are guaranteed to start at 0 and to be consecutively numbered.
  */
-${helper.memory_enum.render()}
+${helper.memory_enum.render_type_def()}
 
 % endif
 % if helper.has_irqs():
@@ -69,7 +69,7 @@ ${helper.memory_enum.render()}
  *
  * IRQs are guaranteed to be numbered consecutively from 0.
  */
-${helper.irq_enum.render()}
+${helper.irq_enum.render_type_def()}
 
 % endif
 % if helper.has_alerts() and helper.has_alert_handler():
@@ -78,7 +78,7 @@ ${helper.irq_enum.render()}
  *
  * Alerts are guaranteed to be numbered consecutively from 0.
  */
-${helper.alert_enum.render()}
+${helper.alert_enum.render_type_def()}
 
 % endif
 % if helper.has_clocks():
@@ -87,7 +87,7 @@ ${helper.alert_enum.render()}
  *
  * Clock ports are guaranteed to be numbered consecutively from 0.
  */
-${helper.clock_enum.render()}
+${helper.clock_enum.render_type_def()}
 
 % endif
 % if helper.has_reset_requests():
@@ -96,7 +96,7 @@ ${helper.clock_enum.render()}
  *
  * Reset requests are guaranteed to be numbered consecutively from 0.
  */
-${helper.reset_req_enum.render()}
+${helper.reset_req_enum.render_type_def()}
 
 % endif
 % if helper.has_resets():
@@ -105,7 +105,7 @@ ${helper.reset_req_enum.render()}
  *
  * Reset ports are guaranteed to be numbered consecutively from 0.
  */
-${helper.reset_enum.render()}
+${helper.reset_enum.render_type_def()}
 
 % endif
 % if helper.has_periph_io():
@@ -114,7 +114,7 @@ ${helper.reset_enum.render()}
  *
  * Peripheral I/O are guaranteed to be numbered consecutively from 0.
  */
-${helper.periph_io_enum.render()}
+${helper.periph_io_enum.render_type_def()}
 
 % endif
 % if helper.has_wakeups():
@@ -123,7 +123,7 @@ ${helper.periph_io_enum.render()}
  *
  * Wakeups are guaranteed to be numbered consecutively from 0.
  */
-${helper.wakeup_enum.render()}
+${helper.wakeup_enum.render_type_def()}
 
 % endif
 % if helper.has_features():

--- a/util/dttool.py
+++ b/util/dttool.py
@@ -16,7 +16,6 @@ from importlib.util import module_from_spec, spec_from_file_location
 from reggen.ip_block import IpBlock
 from dtgen.helper import TopHelper, IpHelper, Extension
 from dtgen.ipgen_ext import IpgenExt
-from topgen.lib import CEnum
 
 TOPGEN_TEMPLATE_PATH = Path(__file__).parents[1].resolve() / "util" / "dtgen"
 
@@ -161,7 +160,7 @@ def main():
     else:
         ext_mod = None
 
-    top_helper = TopHelper(topcfg, CEnum)
+    top_helper = TopHelper(topcfg)
 
     if args.gen_top:
         top_lib_header = "hw/top_{0}/sw/autogen/top_{0}.h".format(topcfg["name"])
@@ -197,8 +196,7 @@ def main():
             # The instance name is 'top_{topname}_{ipname}'.
             ipconfig = name_to_ipconfig.get('top_{}_{}'.format(topcfg["name"], ipname), None)
 
-            helper = IpHelper(top_helper, ip, ipconfig, default_node, CEnum,
-                              extension_cls)
+            helper = IpHelper(top_helper, ip, ipconfig, default_node, extension_cls)
 
             render_template(
                 TOPGEN_TEMPLATE_PATH / "dt_ip.h.tpl",

--- a/util/make_new_dif/templates/dif_autogen.c.tpl
+++ b/util/make_new_dif/templates/dif_autogen.c.tpl
@@ -88,7 +88,7 @@ dif_result_t dif_${ip.name_snake}_init_from_dt(
 dif_result_t dif_${ip.name_snake}_get_dt(
   const dif_${ip.name_snake}_t *${ip.name_snake},
   dt_${ip.name_snake}_t *dt) {
-  if (${ip.name_snake}->dt == kDt${ip.name_camel}Count || dt == NULL) {
+  if ((int)${ip.name_snake}->dt == kDt${ip.name_camel}Count || dt == NULL) {
     return kDifBadArg;
   }
   *dt = ${ip.name_snake}->dt;


### PR DESCRIPTION
See commits for details. In short, this replaces the toplib `CEnum` by a custom type in dtgen (this was the last non-custom type anyway). The enum generation is modified to put the `Count` constant outside of the enum:
```c
dt_device_type_t dt_device_type(dt_instance_id_t dev) {
  if (dev < kDtInstanceIdCount) {
    return device_type[dev];
  }
  return kDtDeviceTypeUnknown;
}
```

TODO:

- [ ] Replace usage of `ScalarType` for enum value with the new `EnumType`