### PR TITLE
[sram_ctrl,rtl] Fix typo in sram_ctrl.sv

### DIFF
--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -620,8 +620,8 @@ module sram_ctrl
     assign sram_rerror[1] = uncorrectable_error_q;
 
     // Error log if any error happened
-    assign sram_rerror_o.valid   = sram_rvalid_scr & |ecc_error;
-    assign ecc_error.correctable = sram_rvalid_scr & ~ecc_error[1];
+    assign sram_rerror_o.valid       = sram_rvalid_scr & |ecc_error;
+    assign sram_rerror_o.correctable = sram_rvalid_scr & ~ecc_error[1];
 
     // Translate word address to byte address and fill remaining bits with 0
     always_comb begin


### PR DESCRIPTION
Commit 6619597f316 had an error (setting a named field of a 2-bit array!). This doesn't kill the simulation because we don't actually enable the code (with the EccCorrection parameter), but it's probably still worth fixing.

Set the port that was presumably intended. This passes a "bare minimum" test, where I set EccCorrection in tb.sv and run a smoke test.