### PR TITLE
[dv,spi_device,tlt] Cherry-pick to allow 2-stage read pipeline TLT

### DIFF
--- a/hw/dv/sv/spi_agent/seq_lib/spi_device_flash_seq.sv
+++ b/hw/dv/sv/spi_agent/seq_lib/spi_device_flash_seq.sv
@@ -21,6 +21,8 @@ class spi_device_flash_seq extends dv_base_seq #(
   task body();
     cfg.spi_func_mode = SpiModeFlash;
     do begin
+      // It takes the sequence item from the monitor after the opcode and address (plus
+      // Dummy cycles+read_pipeline delay if it applies for a given command).
       p_sequencer.req_analysis_fifo.peek(req);
       if (req.csb_sel == csb_sel) begin
         `DV_CHECK(p_sequencer.req_analysis_fifo.try_get(req))

--- a/hw/dv/sv/spi_agent/spi_agent.sv
+++ b/hw/dv/sv/spi_agent/spi_agent.sv
@@ -31,4 +31,9 @@ class spi_agent extends dv_base_agent#(
     cfg.has_req_fifo = 1;
   endfunction : build_phase
 
+  function void connect_phase(uvm_phase phase);
+    super.connect_phase(phase);
+    monitor.host_analysis_port.connect(sequencer.host_mon_analysis_imp);
+  endfunction
+
 endclass

--- a/hw/dv/sv/spi_agent/spi_device_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_device_driver.sv
@@ -13,8 +13,8 @@
 // the driver is to begin driving the response. The driver sends the contents
 // of spi_item.payload_q sequentially, timed with the SPI host's clock output.
 // Note that spi_device_driver does NOT observe the command, address, or dummy
-// cycles, and it assumes those phases have already passed. For this mode,
-// spi_device_driver is anticipated to be used in conjunction with the
+// cycles+read_pipeline delay, and it assumes those phases have already passed.
+// For this mode, spi_device_driver is anticipated to be used in conjunction with the
 // spi_monitor's req_analysis_port, which writes a spi_item into the
 // spi_sequencer's connected req_analysis_fifo at the moment those phases have
 // completed.
@@ -50,8 +50,8 @@ class spi_device_driver extends spi_driver;
       rsp.set_id_info(req);
       // The response should read the payload actually consumed, not start with
       // it filled out.
-      rsp.payload_q = '{};
-
+      rsp.payload_q.delete();
+      `uvm_info(`gfn, $sformatf("Received item - %s",req.sprint), UVM_DEBUG)
       wait (!under_reset && !cfg.vif.csb[active_csb]);
       fork
         begin: iso_fork
@@ -152,6 +152,7 @@ class spi_device_driver extends spi_driver;
   endtask : send_tpm_item
 
   virtual task send_data_to_sio(spi_mode_e mode, input logic [3:0] sio_bits);
+    `uvm_info(`gfn, $sformatf("%m: spi_mode = %p, sio_bits = 0x%0x", mode, sio_bits), UVM_DEBUG)
     case (mode)
       Standard: cfg.vif.sio_out[1]   <= sio_bits[0];
       Dual:     cfg.vif.sio_out[1:0] <= sio_bits[1:0];

--- a/hw/dv/sv/spi_agent/spi_sequencer.sv
+++ b/hw/dv/sv/spi_agent/spi_sequencer.sv
@@ -5,5 +5,22 @@
 class spi_sequencer extends dv_base_sequencer#(spi_item, spi_agent_cfg, spi_item);
   `uvm_component_utils(spi_sequencer)
 
-  `uvm_component_new
+  // Analysis imp to receive items from host AP in monitor
+  uvm_analysis_imp#(spi_item, spi_sequencer) host_mon_analysis_imp;
+
+  // Holds up to 1 item at a time sent by the monitor
+  spi_item host_mon_item_q[$];
+
+  function new(string name, uvm_component parent);
+    super.new(name, parent);
+    host_mon_analysis_imp = new("mon_analysis_imp", this);
+  endfunction : new
+
+  virtual function void write(spi_item item);
+    `uvm_info(`gfn, $sformatf("Received host item from monitor: \n%0s", item.sprint), UVM_DEBUG)
+    // Clear the queue then push the item
+    host_mon_item_q = {};
+    host_mon_item_q.push_back(item);
+  endfunction
+
 endclass : spi_sequencer

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_read_buffer_direct_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_read_buffer_direct_vseq.sv
@@ -8,10 +8,19 @@ class spi_device_read_buffer_direct_vseq extends spi_device_flash_mode_vseq;
   `uvm_object_utils(spi_device_read_buffer_direct_vseq)
   `uvm_object_new
 
+  // Needed in order to track when a given read command will raise the watermark
+  // depending on whether the previous command had the read pipeline enabled, and
+  // whether the command may have finished just crossing the threshold but never
+  // output due to the pipeline delay
+  bit [31:0] computed_last_addr;
+  bit [31:0] last_cmd_computed_last_addr;
+  bit        watermark_set_last;
+
   task body();
     int start_addr = 0;
     int payload_size;
-
+    bit [1:0] readpipeline;
+    bit [2:0] num_lanes;
     // scb is off for this test. Enable CSR auto_predict, otherwise, csr_update doesn't work
     // correctly as `needs_update` may be wrong due to the incorrect mirrored value.
     ral.default_map.set_auto_predict(1);
@@ -23,31 +32,37 @@ class spi_device_read_buffer_direct_vseq extends spi_device_flash_mode_vseq;
 
     `uvm_info(`gfn, "reading from 0 to half size", UVM_MEDIUM)
     payload_size = READ_BUFFER_SIZE / 2;
-    send_read_cmd(start_addr, payload_size);
+    send_read_cmd(start_addr, payload_size, readpipeline, num_lanes);
+
     check_interrupts(.interrupts((1 << ReadbufFlip)), .check_set(1));
     start_addr += payload_size;
 
     `uvm_info(`gfn, "reading from half size to max size", UVM_MEDIUM)
     // start_addr need to be kept increasing which is how we track the flip bit event
-    send_read_cmd(start_addr, payload_size);
+    send_read_cmd(start_addr, payload_size, readpipeline, num_lanes);
+
     check_interrupts(.interrupts((1 << ReadbufFlip)), .check_set(1));
     start_addr += payload_size;
 
     start_addr += READ_BUFFER_SIZE / 2 - 1;
     `uvm_info(`gfn, $sformatf("reading only the last byte of the 1st half at 0x%0x", start_addr),
               UVM_MEDIUM)
-    send_read_cmd(.start_addr(start_addr), .payload_size(1));
+    payload_size = 1;
+    send_read_cmd(start_addr, payload_size, readpipeline, num_lanes);
+
     check_interrupts(.interrupts((1 << ReadbufFlip)), .check_set(1));
     start_addr += 1;
 
     start_addr += READ_BUFFER_SIZE / 2 - 1;
     `uvm_info(`gfn, $sformatf("reading only the last byte of the 2nd half at 0x%0x", start_addr),
               UVM_MEDIUM)
-    send_read_cmd(.start_addr(start_addr), .payload_size(1));
+    payload_size = 1;
+    send_read_cmd(start_addr, payload_size, readpipeline, num_lanes);
+
     check_interrupts(.interrupts((1 << ReadbufFlip)), .check_set(1));
     start_addr += 1;
 
-    // no watermark event as threshold is 0
+    // no watermark event as threshold is 0 (disabled)
     check_interrupts(.interrupts((1 << ReadbufWatermark)), .check_set(0));
 
     // testing ReadbufWatermark
@@ -57,41 +72,108 @@ class spi_device_read_buffer_direct_vseq extends spi_device_flash_mode_vseq;
 
     if (read_threshold_val > 1) begin
       `uvm_info(`gfn, "reading from 0 to read_threshold_val - 2", UVM_MEDIUM)
-      payload_size = read_threshold_val - 1;
-      send_read_cmd(.start_addr(start_addr), .payload_size(payload_size));
-      check_interrupts(.interrupts((1 << ReadbufWatermark)), .check_set(0));
+      payload_size = read_threshold_val - 2;
+      send_read_cmd(start_addr, payload_size, readpipeline, num_lanes);
+
+      watermark_set_last = 0;
+      // Start address before the threshold but after all payload we've gone over threshold
+      if (is_read_overlap_threshold(num_lanes, readpipeline, start_addr[9:0],
+                                    ral.read_threshold.get(), payload_size)) begin
+        check_interrupts(.interrupts((1 << ReadbufWatermark)), .check_set(1));
+        watermark_set_last = 1;
+      end
+      else
+        check_interrupts(.interrupts((1 << ReadbufWatermark)), .check_set(0));
+
       start_addr += payload_size;
-    end
+    end // if (read_threshold_val > 1)
 
     `uvm_info(`gfn, "reading 1 more byte at read_threshold_val - 1", UVM_MEDIUM)
-    send_read_cmd(.start_addr(start_addr), .payload_size(1));
-    check_interrupts(.interrupts((1 << ReadbufWatermark)), .check_set(1));
+    payload_size = 1;
+    send_read_cmd(start_addr, payload_size, readpipeline, num_lanes);
+    // Only check for watermark set if the previous read didn't set the watermark
+    // If it did, reading one more byte won't set the watermark again
+    if (watermark_set_last == 0 &&
+        is_read_overlap_threshold(num_lanes, readpipeline, start_addr[9:0],
+                                  ral.read_threshold.get(), payload_size)) begin
+      check_interrupts(.interrupts((1 << ReadbufWatermark)), .check_set(1));
+      watermark_set_last = 1;
+    end
+    else begin
+      check_interrupts(.interrupts((1 << ReadbufWatermark)), .check_set(0));
+      // Reset the flag - the next read command may go over the threshold next
+      watermark_set_last = 0;
+    end
     check_interrupts(.interrupts((1 << ReadbufFlip)), .check_set(0));
     start_addr += 1;
 
     payload_size = READ_BUFFER_SIZE / 2 - 1;
     `uvm_info(`gfn, "reading from read_threshold_val for 1k", UVM_MEDIUM)
-    send_read_cmd(.start_addr(start_addr), .payload_size(payload_size));
-    // no watermark as watermark event isn't sticky
-    check_interrupts(.interrupts((1 << ReadbufWatermark)), .check_set(0));
+    send_read_cmd(start_addr, payload_size, readpipeline, num_lanes);
+    if (watermark_set_last == 0 &&
+        is_read_overlap_threshold(num_lanes, readpipeline, start_addr[9:0],
+                                  ral.read_threshold.get(), payload_size)) begin
+      check_interrupts(.interrupts((1 << ReadbufWatermark)), .check_set(1));
+    end
+    else
+      check_interrupts(.interrupts((1 << ReadbufWatermark)), .check_set(0));
+    // Clearing the flag since we just went over the half buffer side
+    watermark_set_last = 0;
     check_interrupts(.interrupts((1 << ReadbufFlip)), .check_set(1));
+
     start_addr += payload_size;
 
-    `uvm_info(`gfn, "reading 1 more byte at read_threshold_val - 1 in 2nd half", UVM_MEDIUM)
-    send_read_cmd(.start_addr(start_addr), .payload_size(1));
-    check_interrupts(.interrupts((1 << ReadbufWatermark)), .check_set(1));
+    `uvm_info(`gfn, $sformatf("reading 1 more byte at addr=0x%0x",start_addr), UVM_MEDIUM)
+    payload_size = 1;
+    send_read_cmd(start_addr, payload_size, readpipeline, num_lanes);
+
+    // Only reading 1-byte: if the watermark was set it won't be set now
+    if (watermark_set_last == 0 &&
+        is_read_overlap_threshold(num_lanes, readpipeline, start_addr[9:0],
+                                  ral.read_threshold.get(), payload_size)) begin
+      check_interrupts(.interrupts((1 << ReadbufWatermark)), .check_set(1));
+    end
+    else
+      check_interrupts(.interrupts((1 << ReadbufWatermark)), .check_set(0));
+
     check_interrupts(.interrupts((1 << ReadbufFlip)), .check_set(0));
   endtask
 
-  task send_read_cmd(bit[31:0] start_addr, int payload_size);
-    bit [7:0] opcode;
+  function bit is_read_overlap_threshold(bit [2:0] num_lanes, bit [1:0] readpipeline,
+                                         bit [9:0] start_addr, bit [9:0] threshold,
+                                         int       payload_size);
 
+    bit extra_due_to_pipeline = num_lanes==4 && readpipeline>0;
+
+    if ( (start_addr[9:0] <= ral.read_threshold.get()) &&
+         (start_addr[9:0] + payload_size + extra_due_to_pipeline) >= (ral.read_threshold.get()))
+      return 1;
+    else
+      return 0;
+  endfunction
+
+  task send_read_cmd(input bit [31:0] start_addr, input int payload_size,
+                     output bit [1:0] readpipeline, output bit [2:0] num_lanes);
+    bit [7:0] opcode;
+    bit [2:0] num_addr_bytes;
+    bit       write_command;
+    int dummy_cycles;
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(opcode,
         opcode inside {READ_CMD_LIST} && opcode inside {valid_opcode_q};)
 
     spi_host_xfer_flash_item(opcode, payload_size, start_addr);
     cfg.clk_rst_vif.wait_clks(10);
 
-    csr_rd_check(.ptr(ral.last_read_addr), .compare_value(start_addr + payload_size - 1));
+    cfg.spi_host_agent_cfg.extract_cmd_info_from_opcode(opcode,
+                                     // output
+                                     num_addr_bytes, write_command, num_lanes,
+                                     dummy_cycles, readpipeline);
+
+    last_cmd_computed_last_addr = computed_last_addr;
+    computed_last_addr = start_addr + payload_size - 1;
+    if (readpipeline > 0 && num_lanes == 4)
+      computed_last_addr++;
+    csr_rd_check(.ptr(ral.last_read_addr), .compare_value(computed_last_addr));
+    `uvm_info(`gfn, $sformatf("Updated last_read_addr = 0x%0x",computed_last_addr[9:0]), UVM_DEBUG)
   endtask
 endclass : spi_device_read_buffer_direct_vseq

--- a/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
@@ -816,9 +816,8 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
       else begin
         int unsigned dn_item_payload_size = dn_item.payload_q.size;
         // We expect the payload for up_item to be one byte shorter than the payload for dn_item,
-        // unless dn_item had an empty payload or we're in read_pipeline mode.
-        if (dn_item.payload_q.size>0 &&  !(!up_item.read_pipeline_mode ||
-            up_item.payload_q.size == 0))  //Read terminated before any data was returned
+        // in some cases with the read pipeline mode enabled
+        if (up_item.read_pipeline_mode>0 && (dn_item.payload_q.size > up_item.payload_q.size))
           dn_item_payload_size--;
 
         `DV_CHECK_EQ(up_item.payload_q.size, dn_item_payload_size)
@@ -1796,7 +1795,7 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
     bit [31:0] start_addr, offset, read_buffer_addr;
     event      interrupt_update_ev;
     bit        reading_readbuffer=1;
-
+    bit        predict_interrupts=0;
     item = spi_txn;
 
     if (cfg.spi_host_agent_cfg.spi_func_mode == SpiModeTpm) begin
@@ -1841,7 +1840,8 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
       fork begin
         `uvm_info(`gfn, "Blocking on SV event 'interrupt_update_ev'", UVM_DEBUG)
         wait (interrupt_update_ev.triggered);
-        while (reading_readbuffer) begin
+
+        while (reading_readbuffer || (item.payload_q.size == 0 && predict_interrupts)) begin
           `uvm_info(`gfn,
                     $sformatf("'interrupt_update_ev' event is triggered (buffer_addr=0x%0x)",
                               read_buffer_addr + 1 ), UVM_DEBUG)
@@ -1861,6 +1861,12 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
           // Adding some "SPI-side" clk_delay to ensure the triggering events are noticed
           #(cfg.spi_host_agent_cfg.sck_period_ps/2 * 1ps);
 
+          if(item.payload_q.size == 0 && predict_interrupts) begin
+            // Transaction finished exiting:
+            predict_interrupts = 0;
+            `uvm_info(`gfn, "Exiting the readbuf/watermark interrupt prediction loop", UVM_DEBUG)
+            break;
+          end
           `uvm_info(`gfn, "Blocking on SV event 'interrupt_update_ev'", UVM_DEBUG)
           wait (interrupt_update_ev.triggered);
         end
@@ -1915,27 +1921,31 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
       read_pipeline_read_buffer_cmd_last = read_pipeline_ongoing_read_buffer_cmd;
       read_pipeline_ongoing_read_buffer_cmd = 0;
       ongoing_read_buffer_cmd = 0;
+      if (item.payload_q.size == 0 && start_addr == read_buffer_addr)
+        predict_interrupts = 1;
       reading_readbuffer = 0;
       -> interrupt_update_ev;
 
       if(item.payload_q.size == 0) begin
         last_read_cmd_no_payload = 1;
-        if (item.read_pipeline_mode > 0) begin
-          //setting here, in case the CMd doesn't have any payload , the RTL will have already
-          //fetched from memory In some cases, depending on the start_addr that may trigger a
-          // readbufflip/readwatermark interrupt
+        // No payload, hence the start address was never read. Setting to old last_read_addr
+        read_buffer_addr = `gmv(ral.last_read_addr);
+        if (item.read_pipeline_mode > 0 && item.opcode inside {READ_QUAD,READ_QUADIO }) begin
+          // setting here, in case the CMd doesn't have any payload , the RTL will have already
+          // fetched from memory In some cases, depending on the start_addr that may trigger a
+          // readbufflip/readwatermark interrupt when the read pipeline is enabled
           last_read_buffer_addr = start_addr;
         end
       end
 
-      // only update when it has payload
-      if ( (payload_idx > 0) ||
-           //Incomplete read command, but RTL has already fetched data and some of it it's in the read pipeline
-           ((item.read_pipeline_mode > 0) && payload_idx==0 && item.read_size==0)
-          ) begin
+      // Only update when it has payload OR
+      // When Incomplete read command, but RTL has already fetched data and some of it it's in
+      // the read pipeline. In addition, start_addr must be different to prior recorded address
+      // otherwise the update won't happen
+      if ((payload_idx > 0) || (start_addr != `gmv(ral.last_read_addr) &&
+         (item.read_pipeline_mode > 0) && payload_idx==0 && item.read_size==0)) begin
         bit updating_last_read_addr=1;
-        if(payload_idx>0 && item.read_pipeline_mode > 0 /*&&
-           item.opcode inside {READ_QUAD,READ_QUADIO }*/) begin
+        if(item.read_pipeline_mode > 0 && item.opcode inside {READ_QUAD, READ_QUADIO }) begin
           string print_str =
                            "Opcode is inside {READ_QUAD, READ_QUADIO} and read_pipeline is enabled";
           print_str = {print_str, ".\n", "The RTL believes the read_addr is 1 unit above because",
@@ -1945,12 +1955,13 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
                     UVM_DEBUG)
           read_buffer_addr++;
         end // if (payload_idx>0 && item.read_pipeline_mode > 0...
-        else if(item.terminated_before_read_pipeline) begin
-          // SPI Txn was terminated before the dummy cycles started, hence the RTL didn't even fetch the first address
+        else if (item.terminated_before_read_pipeline) begin
+          // SPI Txn was terminated before the dummy cycles/read_pipeline started, hence the RTL
+          // didn't even fetch the first address
           updating_last_read_addr = 0;
         end
 
-        if(updating_last_read_addr) begin
+        if (updating_last_read_addr) begin
           // Update read_buffer_addr predicted value
           `DV_CHECK_EQ_FATAL( ral.last_read_addr.predict(.value(read_buffer_addr),
                                                          .kind(UVM_PREDICT_READ)), 1,

--- a/hw/top_earlgrey/dv/env/chip_env_cov.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cov.sv
@@ -23,6 +23,35 @@ class chip_alert_cg_wrap;
   endfunction
 endclass
 
+class chip_spi_device_cg_wrap;
+
+  // This covergroup is only relevanf for those command info slots which have
+  // the read pipeline available (5 <= slots <= 10): READ_NORMAL, READ_FAST,
+  // READ_DUAL, READ_QUAD READ_DUALIO READ_QUADIO
+  covergroup read_pipeline_cg(string name = "read_pipeline_cg")
+    with function sample (bit [1:0] read_pipeline_mode);
+
+    option.name         = name;
+    option.per_instance = 1;
+
+    read_pipeline_mode_cp: coverpoint read_pipeline_mode {
+      bins zero_stages           = {0};
+      bins two_stages_half_cycle = {1};
+      bins two_stages_full_cycle = {2};
+      ignore_bins ignore         = {3};
+    }
+  endgroup
+
+  function new (string name = "chip_spi_device_cg_wrap");
+    read_pipeline_cg = new("read_pipeline_cg");
+  endfunction
+
+  function void sample_read_pipeline (bit [1:0] read_pipeline_mode);
+    read_pipeline_cg.sample(read_pipeline_mode);
+  endfunction
+endclass
+
+
 class chip_env_cov extends cip_base_env_cov #(.CFG_T(chip_env_cfg));
   `uvm_component_utils(chip_env_cov)
 
@@ -31,6 +60,7 @@ class chip_env_cov extends cip_base_env_cov #(.CFG_T(chip_env_cfg));
 
   // covergroups
   chip_alert_cg_wrap alert_cg_wrap[NUM_ALERTS];
+  chip_spi_device_cg_wrap spi_device_cg_wrap;
 
   function new(string name, uvm_component parent);
     super.new(name, parent);
@@ -40,6 +70,8 @@ class chip_env_cov extends cip_base_env_cov #(.CFG_T(chip_env_cfg));
     foreach (alert_cg_wrap[i]) begin
       alert_cg_wrap[i] = new(LIST_OF_ALERTS[i]);
     end
+
+    spi_device_cg_wrap = new("spi_device_cg_wrap");
   endfunction : new
 
 endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -321,13 +321,15 @@ class chip_sw_base_vseq extends chip_base_vseq;
   // Configure the provided spi_agent_cfg to use flash mode, and add the
   // specification for the following common commands:
   //   ReadSFDP, ReadStatus1, WriteEnable, ChipErase, and PageProgram.
-  virtual function void spi_agent_configure_flash_cmds(spi_agent_cfg agent_cfg);
+  virtual function void spi_agent_configure_flash_cmds(spi_agent_cfg agent_cfg,
+                                                       bit [1:0] read_pipeline_mode = 0);
     spi_flash_cmd_info info = spi_flash_cmd_info::type_id::create("info");
     info.addr_mode = SpiFlashAddrDisabled;
     info.opcode = SpiFlashReadSfdp;
     info.num_lanes = 1;
     info.dummy_cycles = 8;
     info.write_command = 0;
+    info.read_pipeline_mode = read_pipeline_mode;
     agent_cfg.add_cmd_info(info);
 
     info = spi_flash_cmd_info::type_id::create("info");
@@ -360,6 +362,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
     info.num_lanes = 1;
     info.dummy_cycles = 0;
     info.write_command = 0;
+    info.read_pipeline_mode = read_pipeline_mode;
     agent_cfg.add_cmd_info(info);
 
     info = spi_flash_cmd_info::type_id::create("info");
@@ -368,6 +371,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
     info.num_lanes = 1;
     info.dummy_cycles = 0;
     info.write_command = 0;
+    info.read_pipeline_mode = read_pipeline_mode;
     agent_cfg.add_cmd_info(info);
 
     info = spi_flash_cmd_info::type_id::create("info");
@@ -376,6 +380,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
     info.num_lanes = 1;
     info.dummy_cycles = 8;
     info.write_command = 0;
+    info.read_pipeline_mode = read_pipeline_mode;
     agent_cfg.add_cmd_info(info);
 
     info = spi_flash_cmd_info::type_id::create("info");
@@ -384,6 +389,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
     info.num_lanes = 2;
     info.dummy_cycles = 8;
     info.write_command = 0;
+    info.read_pipeline_mode = read_pipeline_mode;
     agent_cfg.add_cmd_info(info);
 
     info = spi_flash_cmd_info::type_id::create("info");
@@ -392,6 +398,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
     info.num_lanes = 4;
     info.dummy_cycles = 8;
     info.write_command = 0;
+    info.read_pipeline_mode = read_pipeline_mode;
     agent_cfg.add_cmd_info(info);
 
     info = spi_flash_cmd_info::type_id::create("info");

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_passthrough_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_passthrough_vseq.sv
@@ -24,6 +24,14 @@ class chip_sw_spi_passthrough_vseq extends chip_sw_base_vseq;
   // A bit map of command slots that will have passthrough filters enabled.
   rand bit [spi_device_pkg::NumTotalCmdInfo-1:0] passthrough_filters;
 
+
+  // Configures the read pipeline when set to non-zero
+  rand bit [1:0] read_pipeline_mode;
+
+  constraint read_pipeline_mode_c {
+    read_pipeline_mode <= 2;
+  }
+
   // Generate a random permutation of the following opcodes, and place them in
   // the test_opcodes queue:
   //   - SpiFlashReadNormal
@@ -114,8 +122,22 @@ class chip_sw_spi_passthrough_vseq extends chip_sw_base_vseq;
         if (!filter_map[opcode]) begin
           // Check that the command, address, and data sent matches on both sides.
           `DV_CHECK_EQ(device_rsp_q.size(), 1);
-          host_rsp = m_spi_host_seq.rsp;
           device_rsp = device_rsp_q.pop_front();
+
+          wait (p_sequencer.spi_host_sequencer_h.host_mon_item_q.size() > 0);
+          host_rsp = p_sequencer.spi_host_sequencer_h.host_mon_item_q.pop_front();
+
+          if (device_rsp.read_pipeline_mode > 0 && device_rsp.num_lanes==4) begin
+            // It means the read pipeline mode is enabled, hence the 'device_rsp' side which is
+            // connected to the passthrough will have a couple of extra cycles of data, which
+            // translates into an extra item in the queue when reading 4 lanes
+            `uvm_info(`gfn, {"[Passtrhough sampled side] Last item in queue dropped due to",
+                             $sformatf(" read_pipeline enabled - : 0x%0x",device_rsp.payload_q[$])},
+                      UVM_DEBUG)
+            void'(device_rsp.payload_q.pop_back());
+            if (device_rsp.read_size > 0)
+              device_rsp.read_size--;
+          end
           if (!host_rsp.compare(device_rsp)) begin
             `uvm_error(`gfn, $sformatf("Compare mismatch\nhost_rsp:\n%sdevice_rsp:\n%s",
                                        host_rsp.sprint(), device_rsp.sprint()))
@@ -130,8 +152,17 @@ class chip_sw_spi_passthrough_vseq extends chip_sw_base_vseq;
 
   virtual task cpu_init();
     bit [7:0] sw_filter_config[4];
+    bit [7:0] read_pipeline_mode_data[1];
     super.cpu_init();
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(passthrough_filters);
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(read_pipeline_mode);
+`ifdef GATE_LEVEL
+    // Two stages full cycle is forced since GLS fails for freqs over 24MHz
+    // TODO: does GLS gets satisfied equally for "two stages half cycle" read pipeline value?
+    read_pipeline_mode = 2;
+`endif
+    read_pipeline_mode_data[0] = {read_pipeline_mode};
+    sw_symbol_backdoor_overwrite("kReadPipelineMode", read_pipeline_mode_data);
     sw_filter_config = {<<byte{passthrough_filters}};
     sw_symbol_backdoor_overwrite("kFilteredCommands", sw_filter_config);
   endtask
@@ -151,8 +182,8 @@ class chip_sw_spi_passthrough_vseq extends chip_sw_base_vseq;
     cfg.m_spi_host_agent_cfg.min_idle_ns_after_csb_drop = 50;
     cfg.m_spi_host_agent_cfg.max_idle_ns_after_csb_drop = 200;
 
-    spi_agent_configure_flash_cmds(cfg.m_spi_host_agent_cfg);
-    spi_agent_configure_flash_cmds(cfg.m_spi_device_agent_cfgs[0]);
+    spi_agent_configure_flash_cmds(cfg.m_spi_host_agent_cfg, read_pipeline_mode);
+    spi_agent_configure_flash_cmds(cfg.m_spi_device_agent_cfgs[0], read_pipeline_mode);
     // Enable the spi agents.
     cfg.chip_vif.enable_spi_host = 1;
     cfg.chip_vif.enable_spi_device(.inst_num(0), .enable(1));

--- a/sw/device/lib/testing/spi_device_testutils.c
+++ b/sw/device/lib/testing/spi_device_testutils.c
@@ -299,6 +299,26 @@ status_t spi_device_testutils_configure_read_pipeline(
     return INVALID_ARGUMENT();
   }
 
+  const dif_spi_device_flash_command_t normal_read_cmd = {
+      // Slot 5: ReadNormal
+      .opcode = kSpiDeviceFlashOpReadNormal,
+      .address_type = kDifSpiDeviceFlashAddrCfg,
+      .passthrough_swap_address = true,
+      .dummy_cycles = 0,
+      .payload_io_type = kDifSpiDevicePayloadIoSingle,
+      .payload_dir_to_host = true,
+      .read_pipeline_mode = dual_mode,
+  };
+  const dif_spi_device_flash_command_t fast_read_cmd = {
+      // Slot 6: ReadFast
+      .opcode = kSpiDeviceFlashOpReadFast,
+      .address_type = kDifSpiDeviceFlashAddrCfg,
+      .passthrough_swap_address = true,
+      .dummy_cycles = 8,
+      .payload_io_type = kDifSpiDevicePayloadIoSingle,
+      .payload_dir_to_host = true,
+      .read_pipeline_mode = dual_mode,
+  };
   const dif_spi_device_flash_command_t dual_read_cmd = {
       // Slot 7: ReadDual
       .opcode = kSpiDeviceFlashOpReadDual,
@@ -319,6 +339,10 @@ status_t spi_device_testutils_configure_read_pipeline(
       .payload_dir_to_host = true,
       .read_pipeline_mode = quad_mode,
   };
+  TRY(dif_spi_device_set_flash_command_slot(
+      spi_device, /*slot=*/5, kDifToggleEnabled, normal_read_cmd));
+  TRY(dif_spi_device_set_flash_command_slot(spi_device, /*slot=*/6,
+                                            kDifToggleEnabled, fast_read_cmd));
   TRY(dif_spi_device_set_flash_command_slot(spi_device, /*slot=*/7,
                                             kDifToggleEnabled, dual_read_cmd));
   TRY(dif_spi_device_set_flash_command_slot(spi_device, /*slot=*/8,

--- a/sw/device/tests/sim_dv/spi_passthrough_test.c
+++ b/sw/device/tests/sim_dv/spi_passthrough_test.c
@@ -29,10 +29,13 @@ OTTF_DEFINE_TEST_CONFIG();
 
 // Bit map of command slots to be filtered. This is supplied by the DV
 // environment.
-const volatile uint32_t kFilteredCommands;
+static const volatile uint32_t kFilteredCommands;
 
 // Whether to upload write commands and have software relay them.
-const volatile uint8_t kUploadWriteCommands;
+static const volatile uint8_t kUploadWriteCommands;
+
+// Which readpipeline_mode should be used for read commands.
+static const volatile uint8_t kReadPipelineMode;
 
 static dif_pinmux_t pinmux;
 static dif_rv_plic_t rv_plic;
@@ -402,8 +405,12 @@ bool test_main(void) {
       mmio_region_from_addr(TOP_EARLGREY_SPI_DEVICE_BASE_ADDR);
   CHECK_DIF_OK(dif_spi_device_init_handle(spi_device_base_addr, &spi_device));
   bool upload_write_commands = (kUploadWriteCommands != 0);
+
   CHECK_STATUS_OK(spi_device_testutils_configure_passthrough(
       &spi_device, kFilteredCommands, upload_write_commands));
+  CHECK_STATUS_OK(spi_device_testutils_configure_read_pipeline(
+      &spi_device, (dif_spi_device_read_pipeline_mode_t)kReadPipelineMode,
+      (dif_spi_device_read_pipeline_mode_t)kReadPipelineMode));
 
   // Enable all spi_device and spi_host interrupts, and check that they do not
   // trigger unless command upload is enabled.


### PR DESCRIPTION
This is a cherry-pick of the commits from #24733, which were merged to master as

  - d50a548 [dv, spi_device] read_buffer_direct_vseq read_pipeline adjustment
  - dd75cba [dv, spi_device] SCB adjustment after spi_host driver read fix
  - e98f526 [dv, spi_devive, tlt] Randomly enabling read pipeline for TLT
  - 003171c [dv, TLT/spi_device] Passthrough VSEQ looking at monitor sampled data
  - 14c419d [dv, spi_monitor] Sample 'read_size' field before broadcasting item
  - 1ef2a58 [dv, spi_agent] Connect sequencer's host analysis imp to monitor
  - 5054ce0 [dv, spi_agent] adding host analysis port to sequencer
  - e74d72f [dv, spi] adding slots 5 and 6 when configuring read_pipeline

The motivation is to allow a DV top-level test to test the read pipeline with two stages on this earlgrey_1.0.0 branch.

I just ran `chip_sw_spi_device_pass_through` manually and it has passed.