### PR TITLE
[rv_dm,tlt] Remove invalid SystemVerilog syntax ('{})

### DIFF
--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_rv_dm_ndm_reset_when_cpu_halted_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_rv_dm_ndm_reset_when_cpu_halted_vseq.sv
@@ -59,7 +59,6 @@ class chip_sw_rv_dm_ndm_reset_when_cpu_halted_vseq extends chip_sw_base_vseq;
     end
 
     // Read DCSR and verify the cause field.
-    cmd_data = '{};
     cfg.debugger.abstract_cmd_reg_read(.regno(jtag_rv_debugger_pkg::RvCoreCsrDcsr),
                                        .value_q(cmd_data), .status(status));
     `DV_CHECK_EQ(status, jtag_rv_debugger_pkg::AbstractCmdErrNone)

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rv_dm_ndm_reset_when_cpu_halted_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rv_dm_ndm_reset_when_cpu_halted_vseq.sv
@@ -64,7 +64,6 @@ class chip_sw_rv_dm_ndm_reset_when_cpu_halted_vseq extends chip_sw_base_vseq;
     end
 
     // Read DCSR and verify the cause field.
-    cmd_data = '{};
     cfg.debugger.abstract_cmd_reg_read(.regno(jtag_rv_debugger_pkg::RvCoreCsrDcsr),
                                        .value_q(cmd_data), .status(status));
     `DV_CHECK_EQ(status, jtag_rv_debugger_pkg::AbstractCmdErrNone)


### PR DESCRIPTION
This code was trying to make a zero-length queue, but '{...} syntax (looking at A.6.7.1 in IEEE 1800) *requires* at least one argument.

Fortunately, the variable is next used for the value_q argument to abstract_cmd_reg_read. That's an output argument (not ref), so cmd_data gets overwritten at this point anyway.