### PR TITLE
[csrng,rtl] Add bounds check to register access interface

### DIFF
--- a/hw/ip/csrng/rtl/csrng_state_db.sv
+++ b/hw/ip/csrng/rtl/csrng_state_db.sv
@@ -102,11 +102,12 @@ module csrng_state_db
   end
 
   // Pad the logic representation of the selected state with zeros to the next multiple of 32
-  assign state_reg_readout = {{NumRegPadBits{1'b0}}, state_q[reg_rd_id_q]};
+  assign state_reg_readout = (reg_rd_id_q < NumApps) ?
+                             {{NumRegPadBits{1'b0}}, state_q[reg_rd_id_q]} : '0;
 
   always_comb begin
     reg_rd_val_o = '0;
-    if (reg_rd_otp_en_i && reg_rd_regfile_en_i[reg_rd_id_q] &&
+    if (reg_rd_otp_en_i && (reg_rd_id_q < NumApps ? reg_rd_regfile_en_i[reg_rd_id_q] : 1'b0) &&
         (reg_rd_ptr_q < NumRegState)) begin
       reg_rd_val_o = state_reg_readout[reg_rd_ptr_q * RegWidth +: RegWidth];
     end


### PR DESCRIPTION
This commit adds a bounds check to the register access interface in the CSRNG. Currenty, `NumApps` is set to `3`. However, `reg_rd_id_i`, which is accessible by software, is a 2-bit signal. Hence, valid values are 0...3. We should check whether the SW input tries to access the valid range, which is 0...NumApps-1, i.e., 0...2.

This was introduced during a recent refactoring in commit lowRISC/opentitan@add768a. Note that since this change the CSRNG IP block has not been signed-off for tapeout.

Thanks to Shaked Florentin for reporting this issue.