### PR TITLE
[crypto] ML-DSA-87: XOF driver absorption (7/24)

### DIFF
--- a/sw/otbn/crypto/mldsa87/mldsa87_xof.s
+++ b/sw/otbn/crypto/mldsa87/mldsa87_xof.s
@@ -6,6 +6,7 @@
 
 .globl xof_shake128_init
 .globl xof_shake256_init
+.globl xof_absorb
 .globl xof_finish
 
 /*
@@ -173,4 +174,99 @@ _xof_fail:
 xof_finish:
   addi x24, x0, KMAC_CMD_FINISH
   csrrw x0, KMAC_CMD, x24
+  ret
+
+/**
+ * Absorb a message of size n bytes.
+ *
+ * Supports the absorption of both masked (two equally-sized Boolean shares at
+ * DMEM[x21], DMEM[x22]) and unmasked (message at DMEM[x21] and x22 = 0) input
+ * messages. This routine *must* only be called after the initialization of the
+ * KMAC interface (see `xof_{shake128,shake256}_init`)
+ *
+ * @param[in] x20: n, size of the input message.
+ * @param[in] x21: DMEM address of the 1st message share.
+ * @param[in] x22: DMEM address of the 2nd message share (0 if unmasked)
+ */
+xof_absorb:
+  /* Exit the absorption loop, if n == 0.  */
+  beq x20, x0, _xof_absorb_end
+
+  /*
+   * Set the strobe register value such that
+   *
+   *    KMAC_BYTE_STROBE = 2^32-1 >> (32 - x),
+   *
+   * where x = 32, if n >= 32, else x = n.
+   */
+
+  /* x = n - 32. */
+  addi  x24, x20, -32
+
+  /* n = 0, if x < 32, else n = n - 32. */
+  srai x25, x24, 31
+  and x25, x24, x25
+  sub x20, x24, x25
+
+  /* x = 2^32-1 >> (32 - x). */
+  sub   x24, x0, x25
+  addi  x25, x0, -1
+  srl   x24, x25, x24
+
+  csrrw x0, KMAC_BYTE_STROBE, x24
+
+  /* Make sure KMAC is ready to absorb data. */
+  addi x24, x0, KMAC_IF_STATUS_MSG_WRITE_RDY
+  jal x1, _xof_kmac_if_status_poll
+
+  bne x22, x0, _xof_absorb_masked_begin
+
+  /* Pass the unshared message to the KMAC interface. */
+  addi x24, x0, 26
+  bn.lid x24, 0(x21++)
+  bn.wsrw KMAC_DATA_S0, w26
+  bn.wsrw KMAC_DATA_S1, w31
+  jal x0, _xof_absorb_masked_end
+
+_xof_absorb_masked_begin:
+
+  /* Pass the message word to the KMAC interface, ensuring that the shares are
+     not combined in an unsecure fashion. */
+  addi x24, x0, 26
+  bn.lid x24, 0(x21++)
+  bn.wsrw KMAC_DATA_S0, w26
+
+  addi x24, x0, 27
+  bn.lid x24, 0(x22++)
+  bn.wsrw KMAC_DATA_S1, w27
+
+_xof_absorb_masked_end:
+
+  /* Trigger the absorption of the written message word. */
+  addi x24, x0, 1
+  csrrw x0, KMAC_MSG_SEND, x24
+
+  /* Absorb the next chunk of <= 32 message bytes. */
+  jal x0, xof_absorb
+
+_xof_absorb_end:
+  ret
+
+/**
+ * Send the `PROCESS` command to the KMAC interface to process the absorbed
+ * message and transfer the module into the `SQUEEZE` state.
+ *
+ * This routine *must* only be called after the initialization of the KMAC
+ * interface (see `xof_{shake128,shake256}_init`) and *must* be called even if
+ * there was no message absorption in order to be able to squeeze the digest.
+ */
+xof_process:
+  /* Trigger the processing of the absorbed message. */
+  addi x24, x0, KMAC_CMD_PROCESS
+  csrrw x0, KMAC_CMD, x24
+
+  /* Poll until the first 64-bit digest is ready to be read out. */
+  addi x24, x0, KMAC_IF_STATUS_DIGEST_VALID
+  jal x1, _xof_kmac_if_status_poll
+
   ret


### PR DESCRIPTION
This commit adds an absorption routine to the XOF driver to absorb arbitrarily-sized messages (both shared and unshared).

---

This is a series of PRs that in their composition result in FIPS-204-compliant OTBN implementation of ML-DSA-87 verify.

#### Resources

  - https://nvlpubs.nist.gov/nistpubs/fips/nist.fips.204.pdf
  - https://tches.iacr.org/index.php/TCHES/article/view/11158/10597
  - https://github.com/pq-crystals/dilithium

####  Preamble

1. ~`doc`~ #29299 

#### Number-theoretic transform

2. ~`NTT`~ #29333
3. ~`INTT`~ #29334

#### Polynomial arithmetic

4. ~`poly_add`, `poly_sub`, `poly_mul`~ #29335
5. ~`poly_mul_add`~ #29345

#### XOF

6. ~`xof_init`, `xof_poll`, `xof_finish`~ #29347
7. `xof_absorb`
8. `xof_squeeze`

#### Rounding

9. `shift_left`
10. `decompose`

#### Reduction

11. `reduce`

#### Infinity norm

12. `norm_check`

#### Sampling

13. `rej_ntt_poly`, `expand_a`
14. `sample_in-ball`
15. `challenge_hash`

#### Encoding

16. `decode_z`
17. `decode_t1`
18. `decode_hint`
19. `encode_w1`

#### Vector operations

20. `sig_decode`
21. `norm_check_z`
22. `A*z`, `c * t1`, `Az - ct1`
23. `use_hint`

#### Epilogue

24. `app`