### PR TITLE
[dv] Fail much more cleanly on timeout in cip_base_vseq

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -626,8 +626,15 @@ task cip_base_vseq::tl_access_sub(
 
         // Now wait a bounded time to check that the bus hasn't locked up for some reason.
         #(tl_access_timeout_ns * 1ns);
+
+        `uvm_fatal(get_name(),
+                   $sformatf("Timeout (%0d ns) when trying to access address 0x%0h.",
+                              tl_access_timeout_ns, addr))
       end
     join_any
+    // This disable will only kill the timeout process. That process can never complete first
+    // (because it will die with a uvm_fatal instead). As a result, there is no danger of killing
+    // the sequence that is being run.
     disable fork;
   end join
   csr_utils_pkg::decrement_outstanding_access();


### PR DESCRIPTION
My code in d6eff63d384 was rather broken: if we timed out, we'd kill the sequence (tut, tut) and then dereference a null pointer. Oops!