### PR TITLE
[sw] Ensure switch statement enum coverage

### DIFF
--- a/hw/top_darjeeling/sw/autogen/tests/plic_all_irqs_test.c
+++ b/hw/top_darjeeling/sw/autogen/tests/plic_all_irqs_test.c
@@ -311,6 +311,7 @@ void ottf_external_isr(uint32_t *exc_info) {
         "Interrupt from incorrect peripheral: exp = %d, obs = %d",
         peripheral_expected, peripheral);
 
+  OT_NO_SWITCH_ENUM_COVERAGE_START
   switch (peripheral) {
 #if TEST_MIN_IRQ_PERIPHERAL <= 0 && 0 < TEST_MAX_IRQ_PERIPHERAL
     case kTopDarjeelingPlicPeripheralAlertHandler: {
@@ -1074,6 +1075,8 @@ void ottf_external_isr(uint32_t *exc_info) {
       LOG_FATAL("ISR is not implemented!");
       test_status_set(kTestStatusFailed);
   }
+  OT_NO_SWITCH_ENUM_COVERAGE_END
+
   // Complete the IRQ at PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(&plic, kHart, plic_irq_id));
 }

--- a/hw/top_earlgrey/sw/autogen/tests/plic_all_irqs_test.c
+++ b/hw/top_earlgrey/sw/autogen/tests/plic_all_irqs_test.c
@@ -339,6 +339,7 @@ void ottf_external_isr(uint32_t *exc_info) {
         "Interrupt from incorrect peripheral: exp = %d, obs = %d",
         peripheral_expected, peripheral);
 
+  OT_NO_SWITCH_ENUM_COVERAGE_START
   switch (peripheral) {
 #if TEST_MIN_IRQ_PERIPHERAL <= 0 && 0 < TEST_MAX_IRQ_PERIPHERAL
     case kTopEarlgreyPlicPeripheralAdcCtrlAon: {
@@ -1242,6 +1243,8 @@ void ottf_external_isr(uint32_t *exc_info) {
       LOG_FATAL("ISR is not implemented!");
       test_status_set(kTestStatusFailed);
   }
+  OT_NO_SWITCH_ENUM_COVERAGE_END
+
   // Complete the IRQ at PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(&plic, kHart, plic_irq_id));
 }

--- a/hw/top_englishbreakfast/sw/autogen/tests/plic_all_irqs_test.c
+++ b/hw/top_englishbreakfast/sw/autogen/tests/plic_all_irqs_test.c
@@ -165,6 +165,7 @@ void ottf_external_isr(uint32_t *exc_info) {
         "Interrupt from incorrect peripheral: exp = %d, obs = %d",
         peripheral_expected, peripheral);
 
+  OT_NO_SWITCH_ENUM_COVERAGE_START
   switch (peripheral) {
 #if TEST_MIN_IRQ_PERIPHERAL <= 0 && 0 < TEST_MAX_IRQ_PERIPHERAL
     case kTopEnglishbreakfastPlicPeripheralAonTimerAon: {
@@ -455,6 +456,8 @@ void ottf_external_isr(uint32_t *exc_info) {
       LOG_FATAL("ISR is not implemented!");
       test_status_set(kTestStatusFailed);
   }
+  OT_NO_SWITCH_ENUM_COVERAGE_END
+
   // Complete the IRQ at PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(&plic, kHart, plic_irq_id));
 }

--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -523,6 +523,22 @@ extern "C++" {
 #define OT_ALIAS(name) __attribute__((alias(name)))
 
 /**
+ * Pragma to start a range of code where the compiler should not warn about
+ * unhandled enum values in switch statements. Terminate that range with
+ * `OT_NO_SWITCH_ENUM_COVERAGE_END`.
+ */
+#define OT_NO_SWITCH_ENUM_COVERAGE_START \
+  _Pragma("GCC diagnostic push")         \
+      _Pragma("GCC diagnostic ignored \"-Wswitch-enum\"")
+
+/**
+ * Pragma to end a range of code where the compiler should not warn about
+ * unhandled enum values in switch statements. Start that range with
+ * `OT_NO_SWITCH_ENUM_COVERAGE_START`.
+ */
+#define OT_NO_SWITCH_ENUM_COVERAGE_END _Pragma("GCC diagnostic pop")
+
+/**
  * Defines a local symbol named `kName_` whose address resolves to the
  * program counter value an inline assembly block at this location would
  * see.

--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -81,6 +81,7 @@ static status_t aes_key_construct(otcrypto_blinded_key_t *blinded_key,
 
   // Set the block cipher mode based on the key mode.
   otcrypto_key_mode_t blinded_key_mode_used = launder32(0);
+  OT_NO_SWITCH_ENUM_COVERAGE_START
   switch (blinded_key->config.key_mode) {
     case kOtcryptoKeyModeAesEcb:
       aes_key->mode = kAesCipherModeEcb;
@@ -110,6 +111,7 @@ static status_t aes_key_construct(otcrypto_blinded_key_t *blinded_key,
     default:
       return OTCRYPTO_BAD_ARGS;
   }
+  OT_NO_SWITCH_ENUM_COVERAGE_END
   // Check if we landed in the correct case statement. Use ORs for this to
   // avoid that multiple cases were executed.
   HARDENED_CHECK_EQ(launder32(blinded_key_mode_used),

--- a/sw/device/lib/crypto/impl/hmac.c
+++ b/sw/device/lib/crypto/impl/hmac.c
@@ -62,6 +62,7 @@ static status_t hmac_key_construct(const otcrypto_blinded_key_t *key,
   if (launder32(key->config.key_length) >
       key_block_wordlen * sizeof(uint32_t)) {
     otcrypto_hmac_key_mode_t used_key_mode = launder32(0);
+    OT_NO_SWITCH_ENUM_COVERAGE_START
     switch (key->config.key_mode) {
       case kOtcryptoKeyModeHmacSha256:
         if (key->config.security_level == kOtcryptoKeySecurityLevelHigh) {
@@ -156,6 +157,7 @@ static status_t hmac_key_construct(const otcrypto_blinded_key_t *key,
       default:
         return OTCRYPTO_BAD_ARGS;
     }
+    OT_NO_SWITCH_ENUM_COVERAGE_END
     HARDENED_CHECK_EQ(used_key_mode, key->config.key_mode);
   } else {
     HARDENED_CHECK_LE(key->config.key_length,
@@ -236,6 +238,7 @@ otcrypto_status_t otcrypto_hmac(const otcrypto_blinded_key_t *key,
 
   // Call the appropriate function from the HMAC driver.
   hmac_key_t hmac_key;
+  OT_NO_SWITCH_ENUM_COVERAGE_START
   switch (key->config.key_mode) {
     case kOtcryptoKeyModeHmacSha256: {
       HARDENED_CHECK_EQ(launder32(key->config.key_mode),
@@ -401,6 +404,7 @@ otcrypto_status_t otcrypto_hmac(const otcrypto_blinded_key_t *key,
     default:
       return OTCRYPTO_BAD_ARGS;
   }
+  OT_NO_SWITCH_ENUM_COVERAGE_END
 
   // Should be unreachable.
   HARDENED_TRAP();

--- a/sw/device/lib/crypto/impl/rsa/rsa_padding.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_padding.c
@@ -91,6 +91,10 @@ static status_t digest_info_length_get(const otcrypto_hash_mode_t hash_mode,
     case kOtcryptoHashModeSha3_512:
       *len = sizeof(kSha512DigestIdentifier) + kKmacSha3512DigestBytes;
       break;
+    case kOtcryptoHashXofModeShake128:
+    case kOtcryptoHashXofModeShake256:
+    case kOtcryptoHashXofModeCshake128:
+    case kOtcryptoHashXofModeCshake256:
     default:
       // Unsupported or unrecognized hash function.
       return OTCRYPTO_BAD_ARGS;
@@ -158,6 +162,10 @@ static status_t digest_info_write(const otcrypto_hash_digest_t message_digest,
       memcpy(encoding + digest_wordlen, &kSha3_512DigestIdentifier,
              sizeof(kSha3_512DigestIdentifier));
       break;
+    case kOtcryptoHashXofModeShake128:
+    case kOtcryptoHashXofModeShake256:
+    case kOtcryptoHashXofModeCshake128:
+    case kOtcryptoHashXofModeCshake256:
     default:
       // Unsupported or unrecognized hash function.
       return OTCRYPTO_BAD_ARGS;
@@ -274,6 +282,10 @@ static status_t digest_wordlen_get(otcrypto_hash_mode_t hash_mode,
       hash_mode_used = launder32(hash_mode_used) | kOtcryptoHashModeSha3_512;
       *num_words = 512 / 32;
       break;
+    case kOtcryptoHashXofModeShake128:
+    case kOtcryptoHashXofModeShake256:
+    case kOtcryptoHashXofModeCshake128:
+    case kOtcryptoHashXofModeCshake256:
     default:
       return OTCRYPTO_BAD_ARGS;
   }

--- a/sw/device/lib/crypto/impl/rsa/rsa_signature.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_signature.c
@@ -57,6 +57,10 @@ static status_t digest_check(const otcrypto_hash_digest_t digest) {
       used_mode = launder32(used_mode) | kOtcryptoHashModeSha3_512;
       num_words = 512 / 32;
       break;
+    case kOtcryptoHashXofModeShake128:
+    case kOtcryptoHashXofModeShake256:
+    case kOtcryptoHashXofModeCshake128:
+    case kOtcryptoHashXofModeCshake256:
     default:
       return OTCRYPTO_BAD_ARGS;
   }

--- a/sw/device/lib/dif/dif_adc_ctrl.c
+++ b/sw/device/lib/dif/dif_adc_ctrl.c
@@ -128,6 +128,7 @@ dif_result_t dif_adc_ctrl_configure_filter(const dif_adc_ctrl_t *adc_ctrl,
     case kDifAdcCtrlChannel0:
       switch (config.filter) {
         DIF_ADC_CTRL_FILTER_LIST(DIF_ADC_CTRL_CHANNEL0_FILTER_CONFIG_CASE_)
+        case kDifAdcCtrlTrans:
         default:
           return kDifBadArg;
       }
@@ -135,6 +136,7 @@ dif_result_t dif_adc_ctrl_configure_filter(const dif_adc_ctrl_t *adc_ctrl,
     case kDifAdcCtrlChannel1:
       switch (config.filter) {
         DIF_ADC_CTRL_FILTER_LIST(DIF_ADC_CTRL_CHANNEL1_FILTER_CONFIG_CASE_)
+        case kDifAdcCtrlTrans:
         default:
           return kDifBadArg;
       }
@@ -227,6 +229,7 @@ static bool get_filter_offset(dif_adc_ctrl_channel_t channel,
     case kDifAdcCtrlChannel0:
       switch (filter) {
         DIF_ADC_CTRL_FILTER_LIST(DIF_ADC_CTRL_CHANNEL0_FILTER_CTRL_REG_CASE_)
+        case kDifAdcCtrlTrans:
         default:
           return false;
       }
@@ -234,6 +237,7 @@ static bool get_filter_offset(dif_adc_ctrl_channel_t channel,
     case kDifAdcCtrlChannel1:
       switch (filter) {
         DIF_ADC_CTRL_FILTER_LIST(DIF_ADC_CTRL_CHANNEL1_FILTER_CTRL_REG_CASE_)
+        case kDifAdcCtrlTrans:
         default:
           return false;
       }
@@ -265,6 +269,7 @@ static bool get_filter_enable_bit(dif_adc_ctrl_channel_t channel,
     case kDifAdcCtrlChannel0:
       switch (filter) {
         DIF_ADC_CTRL_FILTER_LIST(DIF_ADC_CTRL_CHANNEL0_FILTER_ENABLE_CASE_)
+        case kDifAdcCtrlTrans:
         default:
           return false;
       }
@@ -272,6 +277,7 @@ static bool get_filter_enable_bit(dif_adc_ctrl_channel_t channel,
     case kDifAdcCtrlChannel1:
       switch (filter) {
         DIF_ADC_CTRL_FILTER_LIST(DIF_ADC_CTRL_CHANNEL1_FILTER_ENABLE_CASE_)
+        case kDifAdcCtrlTrans:
         default:
           return false;
       }

--- a/sw/device/lib/dif/dif_alert_handler.c
+++ b/sw/device/lib/dif/dif_alert_handler.c
@@ -267,6 +267,10 @@ dif_result_t dif_alert_handler_configure_class(
       case kDifAlertHandlerClassStatePhase3:
         continue;
         break;
+      case kDifAlertHandlerClassStateIdle:
+      case kDifAlertHandlerClassStateTimeout:
+      case kDifAlertHandlerClassStateFsmError:
+      case kDifAlertHandlerClassStateTerminal:
       default:
         return kDifBadArg;
     }
@@ -423,6 +427,10 @@ dif_result_t dif_alert_handler_configure_class(
             alert_handler->base_addr, phase3_cycles_reg_offset,
             config.escalation_phases[i].duration_cycles);
         break;
+      case kDifAlertHandlerClassStateIdle:
+      case kDifAlertHandlerClassStateTimeout:
+      case kDifAlertHandlerClassStateFsmError:
+      case kDifAlertHandlerClassStateTerminal:
       default:
         return kDifBadArg;
     }

--- a/sw/device/lib/dif/dif_base.h
+++ b/sw/device/lib/dif/dif_base.h
@@ -184,7 +184,19 @@ inline dif_toggle_t dif_multi_bit_bool_to_toggle(multi_bit_bool_t val) {
     case kMultiBitBool8True:
     case kMultiBitBool12True:
     case kMultiBitBool16True:
+    case kMultiBitBool20True:
+    case kMultiBitBool24True:
+    case kMultiBitBool28True:
+    case kMultiBitBool32True:
       return kDifToggleEnabled;
+    case kMultiBitBool4False:
+    case kMultiBitBool8False:
+    case kMultiBitBool12False:
+    case kMultiBitBool16False:
+    case kMultiBitBool20False:
+    case kMultiBitBool24False:
+    case kMultiBitBool28False:
+    case kMultiBitBool32False:
     default:
       return kDifToggleDisabled;
   }

--- a/sw/device/lib/dif/dif_dma.c
+++ b/sw/device/lib/dif/dif_dma.c
@@ -254,6 +254,7 @@ dif_result_t dif_dma_get_digest_length(dif_dma_transaction_opcode_t opcode,
     case kDifDmaSha512Opcode:
       *digest_len = 16;
       break;
+    case kDifDmaCopyOpcode:
     default:
       return kDifBadArg;
       break;

--- a/sw/device/lib/dif/dif_entropy_src.h
+++ b/sw/device/lib/dif/dif_entropy_src.h
@@ -210,9 +210,11 @@ typedef enum dif_entropy_src_test {
    * potential concerns to the hardware.
    */
   kDifEntropySrcTestMailbox = 5,
-  /** \internal */
-  kDifEntropySrcTestNumVariants = 6,
 } dif_entropy_src_test_t;
+
+enum {
+  kDifEntropySrcTestNumVariants = 6,
+};
 
 /**
  * Criteria used by various entropy source health tests to decide whether the

--- a/sw/device/lib/dif/dif_entropy_src_unittest.cc
+++ b/sw/device/lib/dif/dif_entropy_src_unittest.cc
@@ -265,7 +265,7 @@ TEST_F(HealthTestConfigTest, Locked) {
 }
 
 TEST_F(HealthTestConfigTest, BadTestType) {
-  config_.test_type = kDifEntropySrcTestNumVariants;
+  config_.test_type = (dif_entropy_src_test_t)kDifEntropySrcTestNumVariants;
   EXPECT_READ32(ENTROPY_SRC_REGWEN_REG_OFFSET, 1);
   EXPECT_DIF_BADARG(
       dif_entropy_src_health_test_configure(&entropy_src_, config_));

--- a/sw/device/lib/dif/dif_i2c.c
+++ b/sw/device/lib/dif/dif_i2c.c
@@ -748,6 +748,9 @@ dif_result_t dif_i2c_write_byte(const dif_i2c_t *i2c, uint8_t byte,
       case kDifI2cFmtRxContinue:
       case kDifI2cFmtRxStop:
         return kDifBadArg;
+      case kDifI2cFmtStart:
+      case kDifI2cFmtTx:
+      case kDifI2cFmtTxStop:
       default:
         break;
     }

--- a/sw/device/lib/dif/dif_lc_ctrl.c
+++ b/sw/device/lib/dif/dif_lc_ctrl.c
@@ -359,6 +359,9 @@ dif_result_t dif_lc_ctrl_configure(const dif_lc_ctrl_t *lc,
       target = LC_CTRL_TRANSITION_TARGET_STATE_VALUE_SCRAP;
       break;
 
+    case kDifLcCtrlStatePostTransition:
+    case kDifLcCtrlStateEscalate:
+    case kDifLcCtrlStateInvalid:
     default:
       return kDifBadArg;
   }

--- a/sw/device/lib/dif/dif_otp_ctrl.c
+++ b/sw/device/lib/dif/dif_otp_ctrl.c
@@ -288,6 +288,18 @@ static bool sw_read_lock_reg_offset(dif_otp_ctrl_partition_t partition,
 #else
 #error "dif_otp_ctrl does not support this top"
 #endif
+    case kDifOtpCtrlPartitionHwCfg0:
+    case kDifOtpCtrlPartitionHwCfg1:
+    case kDifOtpCtrlPartitionSecret0:
+    case kDifOtpCtrlPartitionSecret1:
+    case kDifOtpCtrlPartitionSecret2:
+#if defined(OPENTITAN_IS_DARJEELING)
+    case kDifOtpCtrlPartitionSecret3:
+#endif
+    case kDifOtpCtrlPartitionLifeCycle:
+    case kDifOtpCtrlPartitionDaiError:
+    case kDifOtpCtrlPartitionLciError:
+    case kDifOtpCtrlNumberOfCauses:
     default:
       return false;
   }
@@ -949,6 +961,14 @@ static bool get_digest_regs(dif_otp_ctrl_partition_t partition, ptrdiff_t *reg0,
 // Earlgrey only has 3 secret partitions.
 #else
 #error "dif_otp_ctrl does not support this top"
+#endif
+    case kDifOtpCtrlPartitionLifeCycle:
+    case kDifOtpCtrlPartitionDaiError:
+    case kDifOtpCtrlPartitionLciError:
+    case kDifOtpCtrlNumberOfCauses:
+#if defined(OPENTITAN_IS_DARJEELING)
+    case kDifOtpCtrlPartitionOwnershipSlotState:
+    case kDifOtpCtrlPartitionExtNvm:
 #endif
     default:
       return false;

--- a/sw/device/lib/dif/dif_pinmux.c
+++ b/sw/device/lib/dif/dif_pinmux.c
@@ -363,6 +363,7 @@ dif_result_t dif_pinmux_pad_from_dt_pad(dt_pad_t pad,
       *type_out = kDifPinmuxPadKindDio;
       *index_out = dt_pad_dio_pad_index(pad);
       return kDifOk;
+    case kDtPadTypeUnspecified:
     default:
       return kDifError;
   }

--- a/sw/device/lib/dif/dif_pinmux.h
+++ b/sw/device/lib/dif/dif_pinmux.h
@@ -51,7 +51,6 @@ typedef enum dif_pinmux_pad_kind {
    * or output, bypassing the multiplexer matrix.
    */
   kDifPinmuxPadKindDio,
-  kDifPinmuxPadKindCount,
 } dif_pinmux_pad_kind_t;
 
 /**
@@ -196,7 +195,6 @@ typedef enum dif_pinmux_sleep_mode {
    * Keep last driven value (including high-Z).
    */
   kDifPinmuxSleepModeKeep,
-  kDifPinmuxSleepModeCount,
 } dif_pinmux_sleep_mode_t;
 
 /**
@@ -227,7 +225,6 @@ typedef enum dif_pinmux_wakeup_mode {
    * `dif_pinmux_wakeup_timed_config_t`, `counter_threshold` field.
    */
   kDifPinmuxWakeupModeTimedLow,
-  kDifPinmuxWakeupModeCount,
 } dif_pinmux_wakeup_mode_t;
 
 /**

--- a/sw/device/lib/dif/dif_spi_device.c
+++ b/sw/device/lib/dif/dif_spi_device.c
@@ -371,6 +371,7 @@ dif_result_t dif_spi_device_set_flash_command_slot(
       case kDifSpiDeviceFlashAddr4Byte:
         address_mode = SPI_DEVICE_CMD_INFO_0_ADDR_MODE_0_VALUE_ADDR4B;
         break;
+      case kDifSpiDeviceFlashAddrCount:
       default:
         return kDifBadArg;
     }
@@ -397,6 +398,7 @@ dif_result_t dif_spi_device_set_flash_command_slot(
       case kDifSpiDevicePayloadIoQuad:
         payload_en = 0xf;
         break;
+      case kDifSpiDevicePayloadIoInvalid:
       default:
         return kDifBadArg;
     }
@@ -415,6 +417,7 @@ dif_result_t dif_spi_device_set_flash_command_slot(
         read_pipeline_mode =
             SPI_DEVICE_CMD_INFO_0_READ_PIPELINE_MODE_0_VALUE_TWO_STAGES_FULL_CYCLE;
         break;
+      case kDifSpiDeviceReadPipelineModeCount:
       default:
         return kDifBadArg;
     }
@@ -736,6 +739,7 @@ static dif_result_t dif_spi_device_get_flash_buffer_info(
       info->buffer_len = kDifSpiDeviceSfdpLen;
       info->buffer_offset = kDifSpiDeviceSfdpOffset;
       break;
+    case kDifSpiDeviceFlashBufferTypes:
     default:
       return kDifBadArg;
   }
@@ -906,6 +910,7 @@ dif_result_t dif_spi_device_tpm_configure(dif_spi_device_handle_t *spi,
       case kDifSpiDeviceTpmInterfaceCrb:
         use_crb = true;
         break;
+      case kDifSpiDeviceTpmInterfaceCount:
       default:
         return kDifBadArg;
     }

--- a/sw/device/lib/dif/dif_spi_host.c
+++ b/sw/device/lib/dif/dif_spi_host.c
@@ -360,6 +360,9 @@ static dif_result_t issue_data_phase(const dif_spi_host_t *spi_host,
                         segment->rx.width, kDifSpiHostDirectionRx,
                         last_segment);
       break;
+    case kDifSpiHostSegmentTypeOpcode:
+    case kDifSpiHostSegmentTypeAddress:
+    case kDifSpiHostSegmentTypeDummy:
     default:
       // Programming error (within this file).  We should never get here.
       // `issue_data_phase` should only get called for segment types which
@@ -431,6 +434,10 @@ dif_result_t dif_spi_host_transaction(const dif_spi_host_t *spi_host,
         spi_host_fifo_read_alias(spi_host, segment->bidir.rxbuf,
                                  (uint16_t)segment->bidir.length);
         break;
+      case kDifSpiHostSegmentTypeOpcode:
+      case kDifSpiHostSegmentTypeAddress:
+      case kDifSpiHostSegmentTypeDummy:
+      case kDifSpiHostSegmentTypeTx:
       default:
           /* do nothing */;
     }

--- a/sw/device/lib/dif/dif_sysrst_ctrl.c
+++ b/sw/device/lib/dif/dif_sysrst_ctrl.c
@@ -71,6 +71,7 @@ dif_result_t dif_sysrst_ctrl_key_combo_detect_configure(
       combo_detect_ctl_reg_offset = SYSRST_CTRL_COM_DET_CTL_3_REG_OFFSET;
       combo_action_ctl_reg_offset = SYSRST_CTRL_COM_OUT_CTL_3_REG_OFFSET;
       break;
+    case kDifSysrstCtrlKeyComboAll:
     default:
       return kDifBadArg;
   }
@@ -188,6 +189,13 @@ dif_result_t dif_sysrst_ctrl_output_pin_override_configure(
       pin_out_allow_0_bit_index = SYSRST_CTRL_PIN_ALLOWED_CTL_FLASH_WP_L_0_BIT;
       pin_out_allow_1_bit_index = SYSRST_CTRL_PIN_ALLOWED_CTL_FLASH_WP_L_1_BIT;
       break;
+    case kDifSysrstCtrlPinKey0In:
+    case kDifSysrstCtrlPinKey1In:
+    case kDifSysrstCtrlPinKey2In:
+    case kDifSysrstCtrlPinPowerButtonIn:
+    case kDifSysrstCtrlPinAcPowerPresentIn:
+    case kDifSysrstCtrlPinLidOpenIn:
+    case kDifSysrstCtrlPinAllNonOpenDrain:
     default:
       return kDifBadArg;
   }
@@ -352,6 +360,13 @@ static bool get_output_pin_allowed_bit_indices(dif_sysrst_ctrl_pin_t pin,
       *allow_0_bit_index = SYSRST_CTRL_PIN_ALLOWED_CTL_FLASH_WP_L_0_BIT;
       *allow_1_bit_index = SYSRST_CTRL_PIN_ALLOWED_CTL_FLASH_WP_L_1_BIT;
       break;
+    case kDifSysrstCtrlPinKey0In:
+    case kDifSysrstCtrlPinKey1In:
+    case kDifSysrstCtrlPinKey2In:
+    case kDifSysrstCtrlPinPowerButtonIn:
+    case kDifSysrstCtrlPinAcPowerPresentIn:
+    case kDifSysrstCtrlPinLidOpenIn:
+    case kDifSysrstCtrlPinAllNonOpenDrain:
     default:
       return false;
   }
@@ -439,6 +454,13 @@ static bool get_output_pin_ctl_bit_index(dif_sysrst_ctrl_pin_t pin,
     case kDifSysrstCtrlPinFlashWriteProtectInOut:
       *pin_out_ctl_bit_index = SYSRST_CTRL_PIN_OUT_CTL_FLASH_WP_L_BIT;
       break;
+    case kDifSysrstCtrlPinKey0In:
+    case kDifSysrstCtrlPinKey1In:
+    case kDifSysrstCtrlPinKey2In:
+    case kDifSysrstCtrlPinPowerButtonIn:
+    case kDifSysrstCtrlPinAcPowerPresentIn:
+    case kDifSysrstCtrlPinLidOpenIn:
+    case kDifSysrstCtrlPinAllNonOpenDrain:
     default:
       return false;
   }
@@ -513,6 +535,13 @@ static bool get_output_pin_value_bit_index(dif_sysrst_ctrl_pin_t pin,
     case kDifSysrstCtrlPinFlashWriteProtectInOut:
       *pin_out_value_bit_index = SYSRST_CTRL_PIN_OUT_VALUE_FLASH_WP_L_BIT;
       break;
+    case kDifSysrstCtrlPinKey0In:
+    case kDifSysrstCtrlPinKey1In:
+    case kDifSysrstCtrlPinKey2In:
+    case kDifSysrstCtrlPinPowerButtonIn:
+    case kDifSysrstCtrlPinAcPowerPresentIn:
+    case kDifSysrstCtrlPinLidOpenIn:
+    case kDifSysrstCtrlPinAllNonOpenDrain:
     default:
       return false;
   }
@@ -587,6 +616,13 @@ static bool get_input_pin_value_bit_index(dif_sysrst_ctrl_pin_t pin,
     case kDifSysrstCtrlPinFlashWriteProtectInOut:
       *pin_in_value_bit_index = SYSRST_CTRL_PIN_IN_VALUE_FLASH_WP_L_BIT;
       break;
+    case kDifSysrstCtrlPinKey0Out:
+    case kDifSysrstCtrlPinKey1Out:
+    case kDifSysrstCtrlPinKey2Out:
+    case kDifSysrstCtrlPinPowerButtonOut:
+    case kDifSysrstCtrlPinBatteryDisableOut:
+    case kDifSysrstCtrlPinZ3WakeupOut:
+    case kDifSysrstCtrlPinAllNonOpenDrain:
     default:
       return false;
   }
@@ -677,6 +713,9 @@ static bool get_key_auto_override_en_bit_index(dif_sysrst_ctrl_key_t key,
     case kDifSysrstCtrlKey2:
       *en_bit_index = SYSRST_CTRL_AUTO_BLOCK_OUT_CTL_KEY2_OUT_SEL_BIT;
       break;
+    case kDifSysrstCtrlKeyPowerButton:
+    case kDifSysrstCtrlKeyAcPowerPresent:
+    case kDifSysrstCtrlKeyAll:
     default:
       return false;
   }

--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -239,6 +239,8 @@ dif_result_t dif_uart_watermark_tx_set(const dif_uart_t *uart,
     case kDifUartWatermarkByte16:
       value = UART_FIFO_CTRL_TXILVL_VALUE_TXLVL16;
       break;
+    case kDifUartWatermarkByte32:
+    case kDifUartWatermarkByte62:
     default:
       // The minimal TX watermark is 1 byte, maximal 16 bytes.
       return kDifError;

--- a/sw/device/lib/dif/dif_uart.h
+++ b/sw/device/lib/dif/dif_uart.h
@@ -112,7 +112,7 @@ typedef enum dif_uart_watermark {
    */
   kDifUartWatermarkByte32,
   /**
-   * Indicates a sixty-four-byte watermark.
+   * Indicates a sixty-two-byte watermark.
    */
   kDifUartWatermarkByte62,
 } dif_uart_watermark_t;

--- a/sw/device/lib/dif/dif_usbdev.c
+++ b/sw/device/lib/dif/dif_usbdev.c
@@ -497,6 +497,7 @@ dif_result_t dif_usbdev_buffer_return(const dif_usbdev_t *usbdev,
       // Mark the buffer as stale
       buffer->type = kDifUsbdevBufferTypeStale;
       return kDifOk;
+    case kDifUsbdevBufferTypeStale:
     default:
       return kDifBadArg;
   }

--- a/sw/device/lib/testing/clkmgr_testutils.c
+++ b/sw/device/lib/testing/clkmgr_testutils.c
@@ -100,6 +100,7 @@ static const char *measure_clock_name(const dif_clkmgr_t *clkmgr,
     case kDtClockUsb:
       return "usb_clk";
 #endif
+    case kDtClockAon:
     default:
       return "<unknown>";
   }

--- a/sw/device/lib/testing/flash_ctrl_testutils.c
+++ b/sw/device/lib/testing/flash_ctrl_testutils.c
@@ -325,6 +325,20 @@ static const char *mubi_prop(multi_bit_bool_t val, const char *name) {
       return name;
     case kMultiBitBool4False:
       return "xx";
+    case kMultiBitBool8False:
+    case kMultiBitBool8True:
+    case kMultiBitBool12False:
+    case kMultiBitBool12True:
+    case kMultiBitBool16False:
+    case kMultiBitBool16True:
+    case kMultiBitBool20False:
+    case kMultiBitBool20True:
+    case kMultiBitBool24False:
+    case kMultiBitBool24True:
+    case kMultiBitBool28False:
+    case kMultiBitBool28True:
+    case kMultiBitBool32False:
+    case kMultiBitBool32True:
     default:
       return "uu";
   }

--- a/sw/device/lib/testing/i2c_testutils.h
+++ b/sw/device/lib/testing/i2c_testutils.h
@@ -127,8 +127,10 @@ typedef enum i2c_pinmux_platform_id {
   I2cPinmuxPlatformIdHyper310 = 0,
   I2cPinmuxPlatformIdDvsim,
   I2cPinmuxPlatformIdCw310Pmod,
-  I2cPinmuxPlatformIdCount,
+  I2cPinmuxPlatformIdLast = I2cPinmuxPlatformIdCw310Pmod,
 } i2c_pinmux_platform_id_t;
+
+enum { I2cPinmuxPlatformIdCount = I2cPinmuxPlatformIdLast + 1 };
 
 /**
  * Connect the i2c pins to mio pins via pinmux based on the platform the test is

--- a/sw/device/lib/testing/keymgr_testutils.c
+++ b/sw/device/lib/testing/keymgr_testutils.c
@@ -366,6 +366,10 @@ status_t keymgr_testutils_max_key_version_get(const dif_keymgr_t *keymgr,
     case kDifKeymgrStateOwnerRootKey:
       *max_key_version = versions.owner_max_key_version;
       break;
+    case kDifKeymgrStateReset:
+    case kDifKeymgrStateInitialized:
+    case kDifKeymgrStateDisabled:
+    case kDifKeymgrStateInvalid:
     default:
       return INTERNAL();
   }

--- a/sw/device/lib/testing/kmac_testutils.c
+++ b/sw/device/lib/testing/kmac_testutils.c
@@ -91,10 +91,9 @@ status_t kmac_testutils_check_error(const dif_kmac_t *kmac) {
   TRY(dif_kmac_err_processed(kmac));
 
   // Return with a status based on the error code.
-  switch (err) {
-    case kDifErrorKeyNotValid:
-      return FAILED_PRECONDITION();
-    default:
-      return INTERNAL();
+  if (err == kDifErrorKeyNotValid) {
+    return FAILED_PRECONDITION();
+  } else {
+    return INTERNAL();
   }
 }

--- a/sw/device/lib/testing/lc_ctrl_testutils.c
+++ b/sw/device/lib/testing/lc_ctrl_testutils.c
@@ -48,6 +48,18 @@ status_t lc_ctrl_testutils_lc_state_log(const dif_lc_ctrl_state_t *state) {
     case kDifLcCtrlStateRma:
       LOG_INFO("Life cycle state: RMA");
       break;
+    case kDifLcCtrlStateRaw:
+    case kDifLcCtrlStateTestLocked0:
+    case kDifLcCtrlStateTestLocked1:
+    case kDifLcCtrlStateTestLocked2:
+    case kDifLcCtrlStateTestLocked3:
+    case kDifLcCtrlStateTestLocked4:
+    case kDifLcCtrlStateTestLocked5:
+    case kDifLcCtrlStateTestLocked6:
+    case kDifLcCtrlStateScrap:
+    case kDifLcCtrlStatePostTransition:
+    case kDifLcCtrlStateEscalate:
+    case kDifLcCtrlStateInvalid:
     default:
       LOG_ERROR("CPU is executing in locked/invalid life cycle state: %d",
                 (uint32_t)state);
@@ -74,6 +86,20 @@ status_t lc_ctrl_testutils_debug_func_enabled(const dif_lc_ctrl_t *lc_ctrl,
     case kDifLcCtrlStateRma:
       *debug_enabled = true;
       break;
+    case kDifLcCtrlStateRaw:
+    case kDifLcCtrlStateTestLocked0:
+    case kDifLcCtrlStateTestLocked1:
+    case kDifLcCtrlStateTestLocked2:
+    case kDifLcCtrlStateTestLocked3:
+    case kDifLcCtrlStateTestLocked4:
+    case kDifLcCtrlStateTestLocked5:
+    case kDifLcCtrlStateTestLocked6:
+    case kDifLcCtrlStateProd:
+    case kDifLcCtrlStateProdEnd:
+    case kDifLcCtrlStateScrap:
+    case kDifLcCtrlStatePostTransition:
+    case kDifLcCtrlStateEscalate:
+    case kDifLcCtrlStateInvalid:
     default:
       *debug_enabled = false;
       break;

--- a/sw/device/lib/testing/pinmux_testutils.c
+++ b/sw/device/lib/testing/pinmux_testutils.c
@@ -153,6 +153,7 @@ status_t pinmux_testutils_connect(const dif_pinmux_t *pinmux,
         return INVALID_ARGUMENT();
       }
       return OK_STATUS();
+    case kDtPeriphIoTypeUnspecified:
     default:
       return INVALID_ARGUMENT();
   }
@@ -205,6 +206,8 @@ uint32_t pinmux_testutils_get_testable_gpios_mask(void) {
     case kDeviceSilicon:
       // IOA3/6, IOB6, IOC9-12, IOR5-7 and IOR10-13.
       return 0xfe0f0248;
+    case kDeviceFpgaCw305:
+    case kDeviceSimQemu:
     default:
       CHECK(false);
       return 0;

--- a/sw/device/lib/testing/spi_flash_testutils.h
+++ b/sw/device/lib/testing/spi_flash_testutils.h
@@ -362,6 +362,11 @@ inline static dif_spi_host_width_t spi_flash_testutils_get_opcode_width(
       return kDifSpiHostWidthDual;
     case kTransactionWidthMode444:
       return kDifSpiHostWidthQuad;
+    case kTransactionWidthMode111:
+    case kTransactionWidthMode112:
+    case kTransactionWidthMode122:
+    case kTransactionWidthMode114:
+    case kTransactionWidthMode144:
     default:
       return kDifSpiHostWidthStandard;
   }
@@ -384,6 +389,9 @@ inline static dif_spi_host_width_t spi_flash_testutils_get_address_width(
       return kDifSpiHostWidthQuad;
     case kTransactionWidthMode444:
       return kDifSpiHostWidthQuad;
+    case kTransactionWidthMode111:
+    case kTransactionWidthMode112:
+    case kTransactionWidthMode114:
     default:
       return kDifSpiHostWidthStandard;
   }
@@ -406,6 +414,9 @@ inline static dif_spi_host_width_t spi_flash_testutils_get_data_width(
       return kDifSpiHostWidthDual;
     case kTransactionWidthMode222:
       return kDifSpiHostWidthDual;
+    case kTransactionWidthMode114:
+    case kTransactionWidthMode144:
+    case kTransactionWidthMode444:
     default:
       return kDifSpiHostWidthQuad;
   }

--- a/sw/device/lib/testing/test_framework/ottf_isrs.c
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.c
@@ -150,6 +150,7 @@ void ottf_exception_handler(uint32_t *exc_info) {
     case kIbexExcUserECall:
       ottf_user_ecall_handler(exc_info);
       break;
+    case kIbexExcMax:
     default:
       generic_fault_handler(exc_info);
   }

--- a/sw/device/lib/testing/test_framework/status.c
+++ b/sw/device/lib/testing/test_framework/status.c
@@ -45,6 +45,10 @@ void test_status_set(test_status_t test_status) {
       abort();
       break;
     }
+    case kTestStatusInWfi:
+    case kTestStatusInBootRom:
+    case kTestStatusInBootRomHalt:
+    case kTestStatusInTest:
     default: {
       LOG_INFO("test_status_set to 0x%x", test_status);
       test_status_device_write(test_status);

--- a/sw/device/lib/testing/test_framework/ujson_ottf_commands.c
+++ b/sw/device/lib/testing/test_framework/ujson_ottf_commands.c
@@ -11,6 +11,7 @@ status_t ujson_ottf_dispatch(ujson_t *uj, test_command_t command) {
   if (uj == NULL) {
     return INVALID_ARGUMENT();
   }
+  OT_NO_SWITCH_ENUM_COVERAGE_START
   switch (command) {
     case kTestCommandMemRead32:
       RESP_ERR(uj, ujcmd_mem_read32(uj));
@@ -28,4 +29,5 @@ status_t ujson_ottf_dispatch(ujson_t *uj, test_command_t command) {
       return UNIMPLEMENTED();
   }
   return OK_STATUS();
+  OT_NO_SWITCH_ENUM_COVERAGE_END
 }

--- a/sw/device/lib/testing/uart_testutils.h
+++ b/sw/device/lib/testing/uart_testutils.h
@@ -28,8 +28,9 @@ typedef enum uart_pinmux_platform_id {
 typedef enum uart_pinmux_channel {
   kUartPinmuxChannelConsole,
   kUartPinmuxChannelDut,
-  kUartPinmuxChannelCount,
 } uart_pinmux_channel_t;
+
+enum { kUartPinmuxChannelCount = 2 };
 
 /**
  * Connect the uart pins to mio pins via pinmux based on the platform the test

--- a/sw/device/lib/testing/usb_testutils_controlep.c
+++ b/sw/device/lib/testing/usb_testutils_controlep.c
@@ -325,6 +325,9 @@ static status_t ctrl_tx_done(void *ctctx_v, usb_testutils_xfr_result_t result) {
       ctctx->ctrlstate = kUsbTestutilsCtStatOut;
       return OK_STATUS();
 
+    case kUsbTestutilsCtIdle:
+    case kUsbTestutilsCtStatOut:
+    case kUsbTestutilsCtError:
     default:
       break;
   }
@@ -382,6 +385,11 @@ static status_t ctrl_rx(void *ctctx_v, dif_usbdev_rx_packet_info_t packet_info,
       // anything else is unexpected
       break;
 
+    case kUsbTestutilsCtWaitIn:
+    case kUsbTestutilsCtAddrStatIn:
+    case kUsbTestutilsCtCfgStatIn:
+    case kUsbTestutilsCtStatIn:
+    case kUsbTestutilsCtError:
     default:
       // Error
       break;
@@ -463,6 +471,11 @@ status_t usb_testutils_controlep_config_wait(
       timeout_usecs =
           (uint32_t)udiv64_slow(clk_cycles * 1000000, kClockFreqCpuHz, NULL);
     } break;
+    case kDeviceFpgaCw310:
+    case kDeviceFpgaCw305:
+    case kDeviceFpgaCw340:
+    case kDeviceSilicon:
+    case kDeviceSimQemu:
     default:
       // With an FGPA build the host software will respond more slowly and there
       // may even be a requirement for user intervention such as cabling.

--- a/sw/device/silicon_creator/lib/bootstrap.c
+++ b/sw/device/silicon_creator/lib/bootstrap.c
@@ -225,9 +225,16 @@ static rom_error_t bootstrap_handle_erase(bootstrap_state_t *state) {
       // Note: We clear WIP and WEN bits in `bootstrap_handle_erase_verify()`
       // after checking that both data banks have been erased.
       break;
+    case kSpiDeviceOpcodeRead:
+    case kSpiDeviceOpcodeReadStatus:
+    case kSpiDeviceOpcodeReadJedecId:
+    case kSpiDeviceOpcodeReadSfdp:
+    case kSpiDeviceOpcodePageProgram:
+    case kSpiDeviceOpcodeReset:
+    case kSpiDeviceOpcodeWriteEnable:
+    case kSpiDeviceOpcodeWriteDisable:
     default:
-      // Ignore any other command, e.g. PAGE_PROGRAM, RESET, and clear WIP and
-      // WEN bits right away.
+      // Ignore any other command and clear WIP and WEN bits right away.
       spi_device_flash_status_clear();
       error = kErrorOk;
   }
@@ -306,6 +313,12 @@ static rom_error_t bootstrap_handle_program(bootstrap_state_t *state) {
       error = kErrorUnknown;
 #endif
       break;
+    case kSpiDeviceOpcodeRead:
+    case kSpiDeviceOpcodeReadStatus:
+    case kSpiDeviceOpcodeReadJedecId:
+    case kSpiDeviceOpcodeReadSfdp:
+    case kSpiDeviceOpcodeWriteEnable:
+    case kSpiDeviceOpcodeWriteDisable:
     default:
       // We don't expect any other commands but we can potentially end up
       // here with a 0x0 opcode due to glitches on SPI or strap lines (see

--- a/sw/device/silicon_creator/lib/ownership/owner_block.c
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.c
@@ -563,6 +563,9 @@ rom_error_t owner_block_rescue_apply(const owner_rescue_config_t *rescue) {
         pinmux_enable_pull(index, pull_en, !gpio_value);
       }
       break;
+    case kRescueDetectNone:
+    case kRescueDetectBreak:
+    case kRescueDetectStrap:
     default:
         /* nothing to do */;
   }

--- a/sw/device/silicon_creator/lib/rescue/dfu.c
+++ b/sw/device/silicon_creator/lib/rescue/dfu.c
@@ -315,6 +315,7 @@ void dfu_protocol_handler(void *_ctx, uint8_t ep, usb_transfer_flags_t flags,
       }
       // Pass the rescue buffer to the rescue receive handler.
       rom_error_t error = rescue_recv_handler(&ctx->state);
+      OT_NO_SWITCH_ENUM_COVERAGE_START
       switch (error) {
         case kErrorOk:
           ctx->dfu_error = kDfuErrOk;
@@ -322,6 +323,7 @@ void dfu_protocol_handler(void *_ctx, uint8_t ep, usb_transfer_flags_t flags,
         default:
           ctx->dfu_error = kDfuErrVendor;
       }
+      OT_NO_SWITCH_ENUM_COVERAGE_END
       // Back to DnLoadIdle state.
       ctx->dfu_state = kDfuStateDnLoadIdle;
     } else if (ctx->dfu_state == kDfuStateUpLoadIdle) {

--- a/sw/device/silicon_creator/lib/rescue/rescue.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue.c
@@ -235,6 +235,18 @@ rom_error_t rescue_send_handler(rescue_state_t *state) {
     case kRescueModeNoOp:
       // The No-Op mode is always allowed and does nothing.
       return kErrorOk;
+    case kRescueModeBaud:
+    case kRescueModeBootLog:
+    case kRescueModeBootSvcRsp:
+    case kRescueModeBootSvcReq:
+    case kRescueModeKlobber:
+    case kRescueModeOwnerBlock:
+    case kRescueModeOwnerPage0:
+    case kRescueModeOwnerPage1:
+    case kRescueModeOpenTitanID:
+    case kRescueModeFirmware:
+    case kRescueModeFirmwareSlotB:
+    case kRescueModeWait:
     default:
         /* do nothing */;
   }
@@ -276,8 +288,13 @@ rom_error_t rescue_send_handler(rescue_state_t *state) {
     case kRescueModeFirmwareSlotB:
       // Nothing to do for receive modes.
       return kErrorOk;
+    case kRescueModeBaud:
+    case kRescueModeKlobber:
+    case kRescueModeNoOp:
+    case kRescueModeReboot:
+    case kRescueModeWait:
     default:
-      // This state should be impossible.
+      // These states should be impossible.
       return kErrorRescueBadMode;
   }
   return kErrorRescueSendStart;
@@ -325,9 +342,12 @@ rom_error_t rescue_recv_handler(rescue_state_t *state) {
         state->offset = 0;
       }
       break;
+    case kRescueModeBaud:
+    case kRescueModeKlobber:
     case kRescueModeReboot:
+    case kRescueModeWait:
     default:
-      // This state should be impossible.
+      // These states should be impossible.
       return kErrorRescueBadMode;
   }
   return kErrorOk;
@@ -403,6 +423,7 @@ hardened_bool_t rescue_detect_entry(const owner_rescue_config_t *config) {
       return kHardenedBoolTrue;
     case kRescueRequestSkip:
       return kHardenedBoolFalse;
+    case kRescueRequestNone:
     default:
         /* do nothing and continue with trigger detection */;
   }
@@ -438,6 +459,8 @@ hardened_bool_t rescue_detect_entry(const owner_rescue_config_t *config) {
       if (pinmux_read_straps() == index) {
         return kHardenedBoolTrue;
       }
+      break;
+    default:
       break;
   }
   return kHardenedBoolFalse;

--- a/sw/device/silicon_creator/lib/rescue/rescue_spi.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue_spi.c
@@ -94,6 +94,7 @@ rom_error_t rescue_protocol(boot_data_t *bootdata, boot_log_t *boot_log,
   while (true) {
     RETURN_IF_ERROR(rescue_inactivity(&ctx.state));
     rom_error_t result = spi_device_cmd_get(&cmd, /*blocking=*/false);
+    OT_NO_SWITCH_ENUM_COVERAGE_START
     switch (result) {
       case kErrorOk:
         break;
@@ -135,5 +136,6 @@ rom_error_t rescue_protocol(boot_data_t *bootdata, boot_log_t *boot_log,
       default:
         dfu_transport_result(&ctx, kErrorUsbBadSetup);
     }
+    OT_NO_SWITCH_ENUM_COVERAGE_END
   }
 }

--- a/sw/device/silicon_creator/lib/rescue/rescue_xmodem.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue_xmodem.c
@@ -103,6 +103,7 @@ static rom_error_t protocol(rescue_state_t *state) {
       continue;
     }
 
+    OT_NO_SWITCH_ENUM_COVERAGE_START
     switch (result) {
       case kErrorOk:
         // Packet ok. Cancel the inactivity deadline.
@@ -146,6 +147,7 @@ static rom_error_t protocol(rescue_state_t *state) {
       default:
         return result;
     }
+    OT_NO_SWITCH_ENUM_COVERAGE_END
     state->frame += 1;
   }
 }

--- a/sw/device/silicon_creator/lib/shutdown.c
+++ b/sw/device/silicon_creator/lib/shutdown.c
@@ -89,6 +89,7 @@ static size_t clsindex(alert_class_t cls) {
       return 2;
     case kAlertClassD:
       return 3;
+    case kAlertClassX:
     default:
       return 0;
   }

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -824,6 +824,7 @@ static status_t extract_next_cert(uint8_t **dest, size_t *free_room) {
     rom_error_t err = perso_tlv_get_cert_obj(
         perso_blob_from_host.body + perso_blob_from_host.next_free,
         max_available(), &block);
+    OT_NO_SWITCH_ENUM_COVERAGE_START
     switch (err) {
       case kErrorOk:
         break;
@@ -836,6 +837,7 @@ static status_t extract_next_cert(uint8_t **dest, size_t *free_room) {
       default:
         return INTERNAL();
     }
+    OT_NO_SWITCH_ENUM_COVERAGE_END
 
     // Check there is enough room in the destination buffer to copy the
     // certificate perso LTV object.

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
@@ -339,6 +339,7 @@ status_t manuf_individualize_device_owner_sw_cfg(
 
 status_t manuf_individualize_device_partition_expected_read(
     dif_otp_ctrl_partition_t partition, uint8_t *buffer) {
+  OT_NO_SWITCH_ENUM_COVERAGE_START
   switch (partition) {
     case kDifOtpCtrlPartitionOwnerSwCfg:
       TRY(otp_img_expected_value_read(
@@ -359,6 +360,7 @@ status_t manuf_individualize_device_partition_expected_read(
     default:
       return INTERNAL();
   }
+  OT_NO_SWITCH_ENUM_COVERAGE_END
 
   return OK_STATUS();
 }

--- a/sw/device/silicon_creator/manuf/lib/util.c
+++ b/sw/device/silicon_creator/manuf/lib/util.c
@@ -165,6 +165,15 @@ status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
       };
       TRY(otcrypto_sha2_256(input, &digest));
     } break;
+    case kDifOtpCtrlPartitionHwCfg0:
+    case kDifOtpCtrlPartitionHwCfg1:
+    case kDifOtpCtrlPartitionSecret0:
+    case kDifOtpCtrlPartitionSecret1:
+    case kDifOtpCtrlPartitionSecret2:
+    case kDifOtpCtrlPartitionLifeCycle:
+    case kDifOtpCtrlPartitionDaiError:
+    case kDifOtpCtrlPartitionLciError:
+    case kDifOtpCtrlNumberOfCauses:
     default:
       return INVALID_ARGUMENT();
   }

--- a/sw/device/silicon_creator/manuf/tests/sram_device_info_flash_wr_functest.c
+++ b/sw/device/silicon_creator/manuf/tests/sram_device_info_flash_wr_functest.c
@@ -59,6 +59,7 @@ bool test_main(void) {
   dif_lc_ctrl_state_t lc_state = kDifLcCtrlStateInvalid;
   CHECK_DIF_OK(dif_lc_ctrl_get_state(&lc_ctrl, &lc_state));
 
+  OT_NO_SWITCH_ENUM_COVERAGE_START
   switch (lc_state) {
     case kDifLcCtrlStateTestUnlocked0:
     case kDifLcCtrlStateTestUnlocked1:
@@ -88,6 +89,7 @@ bool test_main(void) {
     default:
       return false;
   }
+  OT_NO_SWITCH_ENUM_COVERAGE_END
 
   return true;
 }

--- a/sw/device/silicon_creator/rom/e2e/rom_e2e_static_critical_test.c
+++ b/sw/device/silicon_creator/rom/e2e/rom_e2e_static_critical_test.c
@@ -92,15 +92,13 @@ void ottf_exception_handler(uint32_t *exc_info) {
   // subroutine in `sw/device/lib/testing/testing/ottf_isrs.S` for more details.
   uintptr_t *mepc_stack_addr = (uintptr_t *)OT_FRAME_ADDR();
   ibex_exc_t exception = ibex_mcause_read();
-  switch (exception) {
-    case kIbexExcIllegalInstrFault:
-      LOG_INFO("Observed illegal instruction fault");
-      exception_observed = true;
-      *mepc_stack_addr = (uintptr_t)kSecMmioNegTestReturn;
-      break;
-    default:
-      LOG_FATAL("Unexpected exception id = 0x%x", exception);
-      abort();
+  if (exception == kIbexExcIllegalInstrFault) {
+    LOG_INFO("Observed illegal instruction fault");
+    exception_observed = true;
+    *mepc_stack_addr = (uintptr_t)kSecMmioNegTestReturn;
+  } else {
+    LOG_FATAL("Unexpected exception id = 0x%x", exception);
+    abort();
   }
 }
 

--- a/sw/device/silicon_creator/rom/e2e/weak_straps/sw_straps_test.c
+++ b/sw/device/silicon_creator/rom/e2e/weak_straps/sw_straps_test.c
@@ -37,6 +37,7 @@ status_t command_processor(ujson_t *uj) {
   while (true) {
     test_command_t command;
     TRY(ujson_deserialize_test_command_t(uj, &command));
+    OT_NO_SWITCH_ENUM_COVERAGE_START
     switch (command) {
       case kTestCommandSwStrapRead:
         RESP_ERR(uj, test_sw_strap_read(uj));
@@ -45,6 +46,7 @@ status_t command_processor(ujson_t *uj) {
         LOG_ERROR("Unrecognized command: %d", command);
         RESP_ERR(uj, INVALID_ARGUMENT());
     }
+    OT_NO_SWITCH_ENUM_COVERAGE_END
   }
   return OK_STATUS(0);
 }

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_empty_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_empty_test.c
@@ -49,6 +49,12 @@ static status_t empty_message_test(void) {
       case kBootSvcTestStateFinal:
         LOG_INFO("FinalBootLog: %d:%s", state->boots, state->partition);
         return OK_STATUS();
+      case kBootSvcTestStateNextSideB:
+      case kBootSvcTestStateReturnSideA:
+      case kBootSvcTestStateMinSecAdvance:
+      case kBootSvcTestStateMinSecTooFar:
+      case kBootSvcTestStateMinSecGoBack:
+      case kBootSvcTestStateEnterRescue:
       default:
         return UNKNOWN();
     }

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_min_sec_ver_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_min_sec_ver_test.c
@@ -119,6 +119,10 @@ static status_t min_sec_ver_test(void) {
       case kBootSvcTestStateFinal:
         LOG_INFO("FinalBootLog: %d:%s", state->boots, state->partition);
         return OK_STATUS();
+      case kBootSvcTestStateCheckEmpty:
+      case kBootSvcTestStateNextSideB:
+      case kBootSvcTestStateReturnSideA:
+      case kBootSvcTestStateEnterRescue:
       default:
         return UNKNOWN();
     }

--- a/sw/device/tests/alert_handler_lpg_sleep_mode_pings.c
+++ b/sw/device/tests/alert_handler_lpg_sleep_mode_pings.c
@@ -94,6 +94,7 @@ static void init_peripherals(void) {
 void wait_enough_for_alert_ping(void) {
   // wait enough
   switch (kDeviceType) {
+    case kDeviceFpgaCw305:  // TODO: verify timing on CW305
     case kDeviceFpgaCw310:
     case kDeviceFpgaCw340:
       // 2*margin_of_safety*(2**DW)*(1/kClockFreqPeripheralHz)
@@ -117,6 +118,7 @@ void wait_enough_for_alert_ping(void) {
       // This seems to be impractical for the current clock frequency config
       // of the Verilator tests (kClockFreqPeripheralHz = 125K).
       OT_FALLTHROUGH_INTENDED;
+    case kDeviceSimQemu:
     default:
       LOG_FATAL("SUPPORTED PLATFORMS: DV and FPGA");
       LOG_FATAL("TO SUPPORT THE PLATFORM %d, COMPUTE THE RIGHT WAIT-TIME",

--- a/sw/device/tests/clkmgr_off_trans_impl.h
+++ b/sw/device/tests/clkmgr_off_trans_impl.h
@@ -24,8 +24,10 @@ typedef enum test_trans_block {
   kTestTransKmac,
   kTestTransOtbn,
   // Number of types of IP block.
-  kTestTransCount
+  kTestTransLast = kTestTransOtbn,
 } test_trans_block_t;
+
+enum { kTestTransCount = kTestTransLast + 1 };
 
 bool execute_off_trans_test(test_trans_block_t block);
 

--- a/sw/device/tests/crypto/cryptotest/firmware/aes.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/aes.c
@@ -164,6 +164,7 @@ status_t handle_aes(ujson_t *uj) {
     case kAesSubcommandAesBlock:
       return handle_aes_block(uj);
       break;
+    case kAesSubcommandAesGcm:
     default:
       LOG_ERROR("Unrecognized AES subcommand: %d", cmd);
       return INVALID_ARGUMENT();

--- a/sw/device/tests/crypto/cryptotest/firmware/hash.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/hash.c
@@ -134,6 +134,15 @@ status_t handle_hash(ujson_t *uj) {
       status = otcrypto_cshake256(input_message, cshake_function_name,
                                   customization_string, &digest);
       break;
+    case kCryptotestHashAlgorithmSha256:
+    case kCryptotestHashAlgorithmSha384:
+    case kCryptotestHashAlgorithmSha512:
+    case kCryptotestHashAlgorithmSha3_224:
+    case kCryptotestHashAlgorithmSha3_256:
+    case kCryptotestHashAlgorithmSha3_384:
+    case kCryptotestHashAlgorithmSha3_512:
+    case kCryptotestHashAlgorithmShake128:
+    case kCryptotestHashAlgorithmShake256:
     default:
       status = hash_oneshot(input_message, &digest);
   }

--- a/sw/device/tests/crypto/cryptotest/firmware/hmac.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/hmac.c
@@ -61,6 +61,9 @@ status_t handle_hmac(ujson_t *uj) {
       key_mode = kOtcryptoKeyModeHmacSha512;
       tag_bytes = kOtcryptoHmacTagBytesSha512;
       break;
+    case kCryptotestHmacHashAlgSha3_256:
+    case kCryptotestHmacHashAlgSha3_384:
+    case kCryptotestHmacHashAlgSha3_512:
     default:
       LOG_ERROR("Unsupported HMAC key mode: %d", uj_hash_alg);
       return INVALID_ARGUMENT();

--- a/sw/device/tests/crypto/cryptotest/firmware/rsa.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/rsa.c
@@ -520,6 +520,11 @@ status_t handle_rsa_verify(ujson_t *uj) {
     case kOtcryptoHashModeSha3_512:
       TRY(otcrypto_sha3_512(msg_buf, &msg_digest));
       break;
+    case kOtcryptoHashXofModeShake128:
+    case kOtcryptoHashXofModeShake256:
+    case kOtcryptoHashXofModeCshake128:
+    case kOtcryptoHashXofModeCshake256:
+    case kOtcryptoHashModeSha3_224:
     default:
       LOG_ERROR("Unsupported RSA hash mode: %d", uj_input.hashing);
       return INVALID_ARGUMENT();

--- a/sw/device/tests/crypto/cryptotest/firmware/sphincsplus.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/sphincsplus.c
@@ -56,6 +56,7 @@ status_t handle_sphincsplus_verify(ujson_t *uj) {
                  (uint8_t *)uj_message.message, uj_message.message_len,
                  (uint32_t *)uj_public_key.public, act_root);
   cryptotest_sphincsplus_verify_output_t uj_output;
+  OT_NO_SWITCH_ENUM_COVERAGE_START
   switch (error) {
     case kErrorOk:
       uj_output = kCryptotestSphincsPlusVerifyOutputSuccess;
@@ -83,6 +84,7 @@ status_t handle_sphincsplus_verify(ujson_t *uj) {
           error);
       return INTERNAL();
   }
+  OT_NO_SWITCH_ENUM_COVERAGE_END
   return OK_STATUS(0);
 }
 

--- a/sw/device/tests/crypto/hmac_multistream_functest.c
+++ b/sw/device/tests/crypto/hmac_multistream_functest.c
@@ -164,6 +164,9 @@ static status_t get_hash_mode(hmac_test_vector_t *test_vec,
     case kHmacTestOperationSha512:
       *hash_mode = kOtcryptoHashModeSha512;
       return OK_STATUS();
+    case kHmacTestOperationHmacSha256:
+    case kHmacTestOperationHmacSha384:
+    case kHmacTestOperationHmacSha512:
     default:
       return INVALID_ARGUMENT();
   }

--- a/sw/device/tests/crypto/kdf_hmac_ctr_functest.c
+++ b/sw/device/tests/crypto/kdf_hmac_ctr_functest.c
@@ -129,6 +129,7 @@ static status_t run_test(kdf_test_vector_t *test) {
   };
 
   // Run the KDF specified by the key mode.
+  OT_NO_SWITCH_ENUM_COVERAGE_START
   switch (test->key_mode) {
     case kOtcryptoKeyModeHmacSha256:
     case kOtcryptoKeyModeHmacSha384:
@@ -139,6 +140,7 @@ static status_t run_test(kdf_test_vector_t *test) {
       LOG_INFO("Should never end up here.");
       return INVALID_ARGUMENT();
   }
+  OT_NO_SWITCH_ENUM_COVERAGE_END
 
   LOG_INFO("KDF operation completed.");
 

--- a/sw/device/tests/entropy_src_csrng_test.c
+++ b/sw/device/tests/entropy_src_csrng_test.c
@@ -56,8 +56,10 @@ typedef enum irq_flag_id {
   kTestIrqFlagIdCsrngEntropyReq,
   kTestIrqFlagIdEdn1CmdDone,
   kTestIrqFlagIdEdn0CmdDone,
-  kTestIrqFlagCount,
+  kTestIrqFlagLast = kTestIrqFlagIdEdn0CmdDone
 } irq_flag_id_t;
+
+enum { kTestIrqFlagCount = kTestIrqFlagLast + 1 };
 
 /**
  * Interrupt flags. Set by `ottf_external_isr()` and cleared by

--- a/sw/device/tests/entropy_src_fips_mode_health_test.c
+++ b/sw/device/tests/entropy_src_fips_mode_health_test.c
@@ -202,6 +202,8 @@ status_t log_entropy_src_failures_and_alerts(
         LOG_INFO("Alert Fails (Markov): high=%u, low=%u",
                  fail_counts.high_fails[i], fail_counts.low_fails[i]);
         break;
+      case kDifEntropySrcTestRepetitionCountSymbol:
+      case kDifEntropySrcTestMailbox:
       default:
         LOG_INFO("Test %u: Unused test type, moving on...", i);
         break;

--- a/sw/device/tests/flash_ctrl_info_access_lc.c
+++ b/sw/device/tests/flash_ctrl_info_access_lc.c
@@ -285,6 +285,25 @@ bool test_main(void) {
       test_info_part(kFlashInfoPageIdIsoPart, kRandomData3, /*write_allowed=*/1,
                      /*read_allowed=*/1);
       break;
+    case kDifLcCtrlStateRaw:
+    case kDifLcCtrlStateTestLocked0:
+    case kDifLcCtrlStateTestLocked1:
+    case kDifLcCtrlStateTestLocked2:
+    case kDifLcCtrlStateTestLocked3:
+    case kDifLcCtrlStateTestLocked4:
+    case kDifLcCtrlStateTestLocked5:
+    case kDifLcCtrlStateTestLocked6:
+    case kDifLcCtrlStateTestUnlocked1:
+    case kDifLcCtrlStateTestUnlocked2:
+    case kDifLcCtrlStateTestUnlocked3:
+    case kDifLcCtrlStateTestUnlocked4:
+    case kDifLcCtrlStateTestUnlocked5:
+    case kDifLcCtrlStateTestUnlocked6:
+    case kDifLcCtrlStateTestUnlocked7:
+    case kDifLcCtrlStateScrap:
+    case kDifLcCtrlStatePostTransition:
+    case kDifLcCtrlStateEscalate:
+    case kDifLcCtrlStateInvalid:
     default:
       LOG_ERROR("Unexpected lc state 0x%x", lc_state);
   }

--- a/sw/device/tests/gpio_intr_test.c
+++ b/sw/device/tests/gpio_intr_test.c
@@ -39,6 +39,7 @@ status_t command_processor(ujson_t *uj) {
   while (true) {
     test_command_t command;
     TRY(ujson_deserialize_test_command_t(uj, &command));
+    OT_NO_SWITCH_ENUM_COVERAGE_START
     switch (command) {
       case kTestCommandGpioSet:
         RESP_ERR(uj, gpio_set(uj, &gpio));
@@ -53,6 +54,7 @@ status_t command_processor(ujson_t *uj) {
         LOG_ERROR("Unrecognized command: %d", command);
         RESP_ERR(uj, INVALID_ARGUMENT());
     }
+    OT_NO_SWITCH_ENUM_COVERAGE_END
   }
   // We should never reach here.
   return INTERNAL();

--- a/sw/device/tests/gpio_pinmux_test.c
+++ b/sw/device/tests/gpio_pinmux_test.c
@@ -28,6 +28,7 @@ status_t command_processor(ujson_t *uj) {
   while (true) {
     test_command_t command;
     TRY(ujson_deserialize_test_command_t(uj, &command));
+    OT_NO_SWITCH_ENUM_COVERAGE_START
     switch (command) {
       case kTestCommandGpioSet:
         RESP_ERR(uj, gpio_set(uj, &gpio));
@@ -38,11 +39,15 @@ status_t command_processor(ujson_t *uj) {
       case kTestCommandPinmuxConfig:
         RESP_ERR(uj, pinmux_config(uj, &pinmux));
         break;
+      case kTestCommandChipStartup:
+      case kTestCommandEnterNormalSleep:
+      case kTestCommandEnterDeepSleep:
       default:
         LOG_ERROR("Unrecognized command: %d", command);
         RESP_ERR(uj, INVALID_ARGUMENT());
     }
   }
+  OT_NO_SWITCH_ENUM_COVERAGE_END
   // We should never reach here.
   return INTERNAL();
 }

--- a/sw/device/tests/i2c_target_smbus_arp_test.c
+++ b/sw/device/tests/i2c_target_smbus_arp_test.c
@@ -257,6 +257,35 @@ void ottf_external_isr(uint32_t *exc_info) {
           (dif_i2c_irq_t)(plic_irq_id - kTopEarlgreyPlicIrqIdI2c0FmtThreshold);
       i2c_isr(irq);
     } break;
+    case kTopEarlgreyPlicPeripheralUnknown:
+    case kTopEarlgreyPlicPeripheralUart1:
+    case kTopEarlgreyPlicPeripheralUart2:
+    case kTopEarlgreyPlicPeripheralUart3:
+    case kTopEarlgreyPlicPeripheralGpio:
+    case kTopEarlgreyPlicPeripheralSpiDevice:
+    case kTopEarlgreyPlicPeripheralI2c1:
+    case kTopEarlgreyPlicPeripheralI2c2:
+    case kTopEarlgreyPlicPeripheralPattgen:
+    case kTopEarlgreyPlicPeripheralRvTimer:
+    case kTopEarlgreyPlicPeripheralOtpCtrl:
+    case kTopEarlgreyPlicPeripheralAlertHandler:
+    case kTopEarlgreyPlicPeripheralSpiHost0:
+    case kTopEarlgreyPlicPeripheralSpiHost1:
+    case kTopEarlgreyPlicPeripheralUsbdev:
+    case kTopEarlgreyPlicPeripheralPwrmgrAon:
+    case kTopEarlgreyPlicPeripheralSysrstCtrlAon:
+    case kTopEarlgreyPlicPeripheralAdcCtrlAon:
+    case kTopEarlgreyPlicPeripheralAonTimerAon:
+    case kTopEarlgreyPlicPeripheralSensorCtrlAon:
+    case kTopEarlgreyPlicPeripheralFlashCtrl:
+    case kTopEarlgreyPlicPeripheralHmac:
+    case kTopEarlgreyPlicPeripheralKmac:
+    case kTopEarlgreyPlicPeripheralOtbn:
+    case kTopEarlgreyPlicPeripheralKeymgr:
+    case kTopEarlgreyPlicPeripheralCsrng:
+    case kTopEarlgreyPlicPeripheralEntropySrc:
+    case kTopEarlgreyPlicPeripheralEdn0:
+    case kTopEarlgreyPlicPeripheralEdn1:
     default:
       goto unexpected_irq;
   }

--- a/sw/device/tests/i2c_target_test.c
+++ b/sw/device/tests/i2c_target_test.c
@@ -173,6 +173,11 @@ static status_t recv_write_transfer(dif_i2c_t *i2c, i2c_transfer_start_t *txn,
       txn->stop = false;
       // Repeated start, return the address of the next operation.
       return OK_STATUS(txn->address);
+    case kDifI2cSignalNone:
+    case kDifI2cSignalStart:
+    case kDifI2cSignalNack:
+    case kDifI2cSignalNackStart:
+    case kDifI2cSignalNackStop:
     default:
       return INTERNAL();
   }
@@ -275,6 +280,7 @@ static status_t command_processor(ujson_t *uj) {
   while (true) {
     test_command_t command;
     TRY(UJSON_WITH_CRC(ujson_deserialize_test_command_t, uj, &command));
+    OT_NO_SWITCH_ENUM_COVERAGE_START
     switch (command) {
       case kTestCommandEnterNormalSleep:
         RESP_ERR(uj, enter_sleep(uj, &i2c, true));
@@ -310,6 +316,7 @@ static status_t command_processor(ujson_t *uj) {
         LOG_ERROR("Unrecognized command: %d", command);
         RESP_ERR(uj, INVALID_ARGUMENT());
     }
+    OT_NO_SWITCH_ENUM_COVERAGE_END
   }
   // We should never reach here.
   return INTERNAL();

--- a/sw/device/tests/keymgr_derive_cdi_test.c
+++ b/sw/device/tests/keymgr_derive_cdi_test.c
@@ -413,6 +413,10 @@ static void test_derive_cdi(size_t reset_counter) {
           &offset, write, &next_outputs);
 
       break;
+    case kDifKeymgrStateReset:
+    case kDifKeymgrStateInitialized:
+    case kDifKeymgrStateDisabled:
+    case kDifKeymgrStateInvalid:
     default:
       // Theoretically, the key manager can boot into an earlier state
       // (`kDifKeymgrStateReset` or `kDifKeymgrStateInitialized`). This is not

--- a/sw/device/tests/pattgen_ios_test.c
+++ b/sw/device/tests/pattgen_ios_test.c
@@ -125,6 +125,7 @@ void ottf_external_isr(uint32_t *exc_info) {
   LOG_INFO("IRQ detected %d", irq_id);
 
   bool is_pending;
+  OT_NO_SWITCH_ENUM_COVERAGE_START
   switch (irq_id) {
     case kTopEarlgreyPlicIrqIdPattgenDoneCh0:
       LOG_INFO("Channel 0");
@@ -150,6 +151,7 @@ void ottf_external_isr(uint32_t *exc_info) {
       LOG_FATAL("IRQ: unknown irq %d", irq_id);
       break;
   }
+  OT_NO_SWITCH_ENUM_COVERAGE_END
   // Complete the IRQ by writing the IRQ source to the Ibex specific CC.
   // register.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(&plic, kPlicTarget, irq_id));

--- a/sw/device/tests/penetrationtests/firmware/firmware_cryptolib_fi_sym.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware_cryptolib_fi_sym.c
@@ -24,6 +24,7 @@ status_t process_cmd(ujson_t *uj) {
   while (true) {
     penetrationtest_cmd_t cmd;
     TRY(ujson_deserialize_penetrationtest_cmd_t(uj, &cmd));
+    OT_NO_SWITCH_ENUM_COVERAGE_START
     switch (cmd) {
       case kPenetrationtestCommandCryptoLibFiSym:
         RESP_ERR(uj, handle_cryptolib_fi_sym(uj));
@@ -33,6 +34,7 @@ status_t process_cmd(ujson_t *uj) {
         RESP_ERR(uj, INVALID_ARGUMENT());
     }
   }
+  OT_NO_SWITCH_ENUM_COVERAGE_END
 
   return OK_STATUS();
 }

--- a/sw/device/tests/pmod/spi_host_macronix1Gb_flash_test.c
+++ b/sw/device/tests/pmod/spi_host_macronix1Gb_flash_test.c
@@ -42,6 +42,10 @@ static void init_test(dif_spi_host_t *spi_host) {
     case kDeviceFpgaCw340:
       platform_id = kSpiPinmuxPlatformIdCw340;
       break;
+    case kDeviceSimDV:
+    case kDeviceSimVerilator:
+    case kDeviceFpgaCw305:
+    case kDeviceSimQemu:
     default:
       CHECK(false, "Device not supported %u", kDeviceType);
       break;

--- a/sw/device/tests/power_virus_systemtest.c
+++ b/sw/device/tests/power_virus_systemtest.c
@@ -334,6 +334,7 @@ void ottf_external_isr(uint32_t *exc_info) {
 
   top_earlgrey_plic_peripheral_t periph =
       top_earlgrey_plic_interrupt_for_peripheral[irq_id];
+  OT_NO_SWITCH_ENUM_COVERAGE_START
   switch (periph) {
     case kTopEarlgreyPlicPeripheralEntropySrc:
       log_entropy_src_alert_failures();
@@ -343,6 +344,7 @@ void ottf_external_isr(uint32_t *exc_info) {
       CHECK(false, "Unexpected IRQ fired with ID: %d", irq_id);
       break;
   }
+  OT_NO_SWITCH_ENUM_COVERAGE_END
 }
 
 /**

--- a/sw/device/tests/rstmgr_alert_info_test.c
+++ b/sw/device/tests/rstmgr_alert_info_test.c
@@ -280,6 +280,7 @@ static test_alert_info_t expected_info[kRoundTotal] = {
 static node_t test_node(dt_instance_id_t inst_id) {
   dt_device_type_t device_type = dt_device_type(inst_id);
 
+  OT_NO_SWITCH_ENUM_COVERAGE_START
   switch (device_type) {
     case kDtDeviceTypeSpiHost:
       return (node_t){
@@ -316,6 +317,7 @@ static node_t test_node(dt_instance_id_t inst_id) {
       CHECK(false, "unhandled device type");
       abort();
   }
+  OT_NO_SWITCH_ENUM_COVERAGE_END
 }
 
 static void set_extra_alert(volatile uint32_t *set) {
@@ -477,6 +479,7 @@ static void prgm_alert_handler_round3(void) {
     dt_device_type_t device_type = dt_device_type(inst_id);
 
     dif_alert_handler_class_t alert_class;
+    OT_NO_SWITCH_ENUM_COVERAGE_START
     switch (device_type) {
       case kDtDeviceTypeSpiHost:
         alert_class = kDifAlertHandlerClassB;
@@ -491,6 +494,7 @@ static void prgm_alert_handler_round3(void) {
         alert_class = kDifAlertHandlerClassD;
         break;
     }
+    OT_NO_SWITCH_ENUM_COVERAGE_END
 
     CHECK_DIF_OK(dif_alert_handler_configure_alert(
         &alert_handler, i, alert_class, /*enabled=*/kDifToggleEnabled,

--- a/sw/device/tests/rv_core_ibex_address_translation_test.c
+++ b/sw/device/tests/rv_core_ibex_address_translation_test.c
@@ -115,15 +115,13 @@ void ottf_exception_handler(uint32_t *exc_info) {
   uint32_t mcause = ibex_mcause_read();
   ibex_exc_t exception = mcause & kIbexExcMax;
 
-  switch (exception) {
-    case kIbexExcIllegalInstrFault:
-      LOG_INFO("Illegal instruction fault handler");
-      illegal_instr_fault = true;
-      *(uintptr_t *)mepc_stack_addr = ret_addr;
-      break;
-    default:
-      LOG_FATAL("Unexpected exception id = 0x%x", exception);
-      CHECK(false);
+  if (exception == kIbexExcIllegalInstrFault) {
+    LOG_INFO("Illegal instruction fault handler");
+    illegal_instr_fault = true;
+    *(uintptr_t *)mepc_stack_addr = ret_addr;
+  } else {
+    LOG_FATAL("Unexpected exception id = 0x%x", exception);
+    CHECK(false);
   }
 }
 

--- a/sw/device/tests/rv_core_ibex_epmp_test.c
+++ b/sw/device/tests/rv_core_ibex_epmp_test.c
@@ -133,6 +133,11 @@ void ottf_exception_handler(uint32_t *exc_info) {
       test_status_set(kTestStatusPassed);
       finish_test();
       OT_UNREACHABLE();
+    case kIbexExcInstrMisaligned:
+    case kIbexExcIllegalInstrFault:
+    case kIbexExcBreakpoint:
+    case kIbexExcMachineECall:
+    case kIbexExcMax:
     default:
       CHECK(false,
             "Unexpected Exception:"

--- a/sw/device/tests/rv_plic_smoketest.c
+++ b/sw/device/tests/rv_plic_smoketest.c
@@ -52,6 +52,13 @@ static void handle_uart_isr(const dif_rv_plic_irq_id_t plic_irq_id) {
 
       uart_tx_done_handled = true;
       break;
+    case kDtUartIrqTxWatermark:
+    case kDtUartIrqRxWatermark:
+    case kDtUartIrqRxFrameErr:
+    case kDtUartIrqRxBreakErr:
+    case kDtUartIrqRxTimeout:
+    case kDtUartIrqRxParityErr:
+    case kDtUartIrqTxEmpty:
     default:
       LOG_FATAL("ISR is not implemented!");
       test_status_set(kTestStatusFailed);

--- a/sw/device/tests/spi_device_tpm_tx_rx_test.c
+++ b/sw/device/tests/spi_device_tpm_tx_rx_test.c
@@ -103,6 +103,7 @@ void ottf_external_isr(uint32_t *exc_info) {
   isr_testutils_spi_device_isr(plic_ctx, spi_device_ctx, false, &peripheral,
                                &spi_device_irq);
 
+  OT_NO_SWITCH_ENUM_COVERAGE_START
   switch (spi_device_irq) {
     case kDifSpiDeviceIrqTpmHeaderNotEmpty:
       header_interrupt_received = true;
@@ -115,6 +116,7 @@ void ottf_external_isr(uint32_t *exc_info) {
       LOG_ERROR("Unexpected interrupt: %d", spi_device_irq);
       break;
   }
+  OT_NO_SWITCH_ENUM_COVERAGE_END
 }
 
 static void ack_spi_tpm_header_irq(dif_spi_device_handle_t *spi_device) {

--- a/sw/device/tests/spi_passthru_test.c
+++ b/sw/device/tests/spi_passthru_test.c
@@ -187,6 +187,7 @@ status_t command_processor(ujson_t *uj) {
     } else if (status_err(result) != kUnimplemented) {
       return result;
     }
+    OT_NO_SWITCH_ENUM_COVERAGE_START
     switch (command) {
       case kTestCommandSpiConfigureJedecId:
         RESP_ERR(uj, configure_jedec_id(uj, &spid));
@@ -235,6 +236,7 @@ status_t command_processor(ujson_t *uj) {
         LOG_ERROR("Unrecognized command: %d", command);
         RESP_ERR(uj, INVALID_ARGUMENT());
     }
+    OT_NO_SWITCH_ENUM_COVERAGE_END
   }
   // We should never reach here.
   return INTERNAL();

--- a/sw/device/tests/sram_ctrl_execution_test.c
+++ b/sw/device/tests/sram_ctrl_execution_test.c
@@ -46,14 +46,12 @@ void ottf_exception_handler(uint32_t *exc_info) {
   // subroutine in `sw/device/lib/testing/testing/ottf_isrs.S` for more details.
   uintptr_t *mepc_stack_addr = (uintptr_t *)OT_FRAME_ADDR();
   ibex_exc_t exception = ibex_mcause_read();
-  switch (exception) {
-    case kIbexExcInstrAccessFault:
-      LOG_INFO("Detected instruction access fault");
-      *mepc_stack_addr = (uintptr_t)kSramRetNegTestReturn;
-      break;
-    default:
-      LOG_FATAL("Unexpected exception id = 0x%x", exception);
-      abort();
+  if (exception == kIbexExcInstrAccessFault) {
+    LOG_INFO("Detected instruction access fault");
+    *mepc_stack_addr = (uintptr_t)kSramRetNegTestReturn;
+  } else {
+    LOG_FATAL("Unexpected exception id = 0x%x", exception);
+    abort();
   }
 }
 

--- a/sw/device/tests/sram_ctrl_scrambled_access_test.c
+++ b/sw/device/tests/sram_ctrl_scrambled_access_test.c
@@ -154,6 +154,7 @@ static bool expect_ecc_errors(void) {
     case kDeviceSimDV:
     case kDeviceSimVerilator:
       return true;
+    case kDeviceSimQemu:
     default:
       CHECK(false, "Device type not handled: %d", kDeviceType);
       return false;

--- a/sw/device/tests/sram_ctrl_smoketest.c
+++ b/sw/device/tests/sram_ctrl_smoketest.c
@@ -96,6 +96,10 @@ bool test_main(void) {
         sram_ctrl[sc].name = SRAM_CTRL_NAME(kDtSramCtrlMain);
         break;
 
+      case kDtSramCtrlRetAon:
+#if defined(OPENTITAN_IS_DARJEELING)
+      case kDtSramCtrlMbox:
+#endif
       default:
         // Ret SRAM can start at the beginning of the owner section.
         sram_ctrl[sc].buf =

--- a/sw/device/tests/sysrst_ctrl_in_irq_test.c
+++ b/sw/device/tests/sysrst_ctrl_in_irq_test.c
@@ -217,6 +217,7 @@ void ottf_external_isr(uint32_t *exc_info) {
   top_earlgrey_plic_peripheral_t peripheral = (top_earlgrey_plic_peripheral_t)
       top_earlgrey_plic_interrupt_for_peripheral[plic_irq_id];
 
+  OT_NO_SWITCH_ENUM_COVERAGE_START
   switch (peripheral) {
     case kTopEarlgreyPlicPeripheralUart0:
       if (!ottf_console_flow_control_isr(exc_info)) {
@@ -238,6 +239,7 @@ void ottf_external_isr(uint32_t *exc_info) {
     default:
       goto unexpected_irq;
   }
+  OT_NO_SWITCH_ENUM_COVERAGE_END
 
   // Complete the IRQ at PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(&plic, kPlicTarget, plic_irq_id));

--- a/sw/device/tests/uart_parity_break_test.c
+++ b/sw/device/tests/uart_parity_break_test.c
@@ -157,6 +157,13 @@ bool ottf_handle_irq(uint32_t *exc_info, dt_instance_id_t devid,
       uart_irq_rx_break_err_fired = true;
       dif_uart_irq = kDifUartIrqRxBreakErr;
       break;
+    case kDtUartIrqTxWatermark:
+    case kDtUartIrqRxWatermark:
+    case kDtUartIrqTxDone:
+    case kDtUartIrqRxOverflow:
+    case kDtUartIrqRxFrameErr:
+    case kDtUartIrqRxTimeout:
+    case kDtUartIrqTxEmpty:
     default:
       // Not our interrupt, let OTTF handle it (e.g., console UART)
       return false;

--- a/sw/device/tests/uart_tx_rx_test.c
+++ b/sw/device/tests/uart_tx_rx_test.c
@@ -197,6 +197,10 @@ bool ottf_handle_irq(uint32_t *exc_info, dt_instance_id_t devid,
       uart_irq_rx_overflow_fired = true;
       dif_uart_irq = kDifUartIrqRxOverflow;
       break;
+    case kDtUartIrqRxFrameErr:
+    case kDtUartIrqRxBreakErr:
+    case kDtUartIrqRxTimeout:
+    case kDtUartIrqRxParityErr:
     default:
       LOG_ERROR("Unexpected interrupt (at PLIC): %d", plic_irq_id);
       test_status_set(kTestStatusFailed);

--- a/sw/device/tests/usbdev_iso_test.c
+++ b/sw/device/tests/usbdev_iso_test.c
@@ -176,6 +176,9 @@ bool test_main(void) {
       break;
     case kDeviceFpgaCw340:
       break;
+    case kDeviceFpgaCw310:
+    case kDeviceFpgaCw305:
+    case kDeviceSimQemu:
     default:
       CHECK(kDeviceType == kDeviceFpgaCw310);
       break;

--- a/sw/device/tests/usbdev_mixed_test.c
+++ b/sw/device/tests/usbdev_mixed_test.c
@@ -188,6 +188,9 @@ bool test_main(void) {
       break;
     case kDeviceFpgaCw340:
       break;
+    case kDeviceFpgaCw310:
+    case kDeviceFpgaCw305:
+    case kDeviceSimQemu:
     default:
       CHECK(kDeviceType == kDeviceFpgaCw310);
       break;

--- a/sw/device/tests/usbdev_pincfg_test.c
+++ b/sw/device/tests/usbdev_pincfg_test.c
@@ -144,6 +144,9 @@ bool test_main(void) {
 
     // Verilator can operate with any pin/bus configuration because it has
     // ready access to the configuration information.
+    case kDeviceSimVerilator:
+    case kDeviceFpgaCw305:
+    case kDeviceSimQemu:
     default:
       CHECK(kDeviceType == kDeviceSimVerilator);
       ntests = 8U;

--- a/sw/device/tests/usbdev_stream_test.c
+++ b/sw/device/tests/usbdev_stream_test.c
@@ -200,6 +200,9 @@ bool test_main(void) {
       break;
     case kDeviceFpgaCw340:
       break;
+    case kDeviceFpgaCw310:
+    case kDeviceFpgaCw305:
+    case kDeviceSimQemu:
     default:
       CHECK(kDeviceType == kDeviceFpgaCw310);
       break;

--- a/sw/device/tests/usbdev_toggle_restore_test.c
+++ b/sw/device/tests/usbdev_toggle_restore_test.c
@@ -115,6 +115,11 @@ bool test_main(void) {
       // avoid logging with Verilator because it does not have the back door.
       timeout_micros = 1000u;
       break;
+    case kDeviceFpgaCw310:
+    case kDeviceFpgaCw305:
+    case kDeviceFpgaCw340:
+    case kDeviceSilicon:
+    case kDeviceSimQemu:
     default:
       // FPGA platforms where user intervention may be required.
       timeout_micros = 30 * 1000 * 1000u;

--- a/sw/device/tests/usbdev_vbus_test.c
+++ b/sw/device/tests/usbdev_vbus_test.c
@@ -65,6 +65,11 @@ bool test_main(void) {
     case kDeviceSimVerilator:
       timeout_micros = 1000u;
       break;
+    case kDeviceFpgaCw310:
+    case kDeviceFpgaCw305:
+    case kDeviceFpgaCw340:
+    case kDeviceSilicon:
+    case kDeviceSimQemu:
     default:
       // FPGA platforms where user intervention may be required.
       timeout_micros = 30 * 1000 * 1000u;

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -330,6 +330,7 @@ cc_args(
         "-Wno-zero-length-array",
         "-Wstrict-prototypes",
         "-Wswitch-default",
+        "-Wswitch-enum",
         "-Wtype-limits",
         "-Wno-gnu-auto-type",
         "-Wsign-conversion",

--- a/util/topgen/templates/plic_all_irqs_test.c.tpl
+++ b/util/topgen/templates/plic_all_irqs_test.c.tpl
@@ -128,6 +128,7 @@ void ottf_external_isr(uint32_t *exc_info) {
         "Interrupt from incorrect peripheral: exp = %d, obs = %d",
         peripheral_expected, peripheral);
 
+  OT_NO_SWITCH_ENUM_COVERAGE_START
   switch (peripheral) {
 % for p in irq_peripherals:
 <%
@@ -188,6 +189,8 @@ ${indent}                           ${p.plic_start_irq});
       LOG_FATAL("ISR is not implemented!");
       test_status_set(kTestStatusFailed);
   }
+  OT_NO_SWITCH_ENUM_COVERAGE_END
+
   // Complete the IRQ at PLIC.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(&plic, kHart, plic_irq_id));
 }


### PR DESCRIPTION
Although we have `-Wswitch-default` enabled in OpenTitan, only more recent versions of Clang have started enforcing it, warning when switch statements don't have a default case handler. We could address those warnings by just ensuring we always have default case handlers. One potential problem with that is when we add new values to an enumeration, and the default handlers aren't appropriate for those new case, but no one notices that. For robustness, this patch enables a warning for when switch statements don't cover all enumerated cases and updates the relevant switch statments to cover all cases (or to, selectively, disable the warning). It also adds some missing default case handlers and updates some related comments and identifiers.