### PR TITLE
[cryptolib, ecc] Pre register with randomness before shifting in scalar

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/p256.c
+++ b/sw/device/lib/crypto/impl/ecc/p256.c
@@ -89,13 +89,13 @@ enum {
   /*
    * The expected instruction counts for constant time functions.
    */
-  kModeKeygenInsCnt = 573915,
-  kModeKeygenSideloadInsCnt = 573800,
-  kModeEcdhInsCnt = 581598,
-  kModeEcdhSideloadInsCnt = 581658,
-  kModeEcdsaSignConfigKInsCnt = 606933,
-  kModeEcdsaSignInsCnt = 607087,
-  kModeEcdsaSignSideloadInsCnt = 607147,
+  kModeKeygenInsCnt = 573922,
+  kModeKeygenSideloadInsCnt = 573807,
+  kModeEcdhInsCnt = 581605,
+  kModeEcdhSideloadInsCnt = 581665,
+  kModeEcdsaSignConfigKInsCnt = 606940,
+  kModeEcdsaSignInsCnt = 607094,
+  kModeEcdsaSignSideloadInsCnt = 607154,
 };
 
 static status_t p256_masked_scalar_write(p256_masked_scalar_t *src,

--- a/sw/otbn/crypto/p256_base.s
+++ b/sw/otbn/crypto/p256_base.s
@@ -1334,8 +1334,11 @@ scalar_mult_int:
 
      w0,w1 <= [w0, w1] << 191 = k0 << 191 */
   bn.wsrr   w20, URND
-  bn.rshi   w1, w1, w0 >> 65
-  bn.rshi   w0, w0, w20 >> 65
+  bn.rshi   w20, w1,  w20 >> 65
+  bn.rshi   w1,  w20, w20 >> 191
+  bn.rshi   w1,  w1,  w0 >> 65
+  bn.wsrr   w20, URND
+  bn.rshi   w0,  w0,  w20 >> 65
 
   /* init double-and-add with point in infinity
      Q = (w8, w9, w10) <= (0, 1, 0) */
@@ -1347,8 +1350,12 @@ scalar_mult_int:
      word as well.
 
      w2,w3 <= [w2, w3] << 191 = k1 << 191 */
-  bn.rshi   w3, w3, w2 >> 65
-  bn.rshi   w2, w2, w20 >> 65
+  bn.wsrr   w20, URND
+  bn.rshi   w20, w3,  w20 >> 65
+  bn.rshi   w3,  w20, w20 >> 191
+  bn.rshi   w3,  w3,  w2 >> 65
+  bn.wsrr   w20, URND
+  bn.rshi   w2,  w2,  w20 >> 65
 
   /* double-and-add loop with decreasing index */
   loopi     321, 63


### PR DESCRIPTION
This PR first loads randomness into a register before shifting in 65 bits of the scalar. This acts as an SCA countermeasure.