### PR TITLE
[crypto] ML-DSA-87: XOF driver squeezing (8/24)

### DIFF
--- a/sw/otbn/crypto/mldsa87/mldsa87_xof.s
+++ b/sw/otbn/crypto/mldsa87/mldsa87_xof.s
@@ -7,6 +7,7 @@
 .globl xof_shake128_init
 .globl xof_shake256_init
 .globl xof_absorb
+.globl xof_squeeze32
 .globl xof_finish
 
 /*
@@ -268,5 +269,47 @@ xof_process:
   /* Poll until the first 64-bit digest is ready to be read out. */
   addi x24, x0, KMAC_IF_STATUS_DIGEST_VALID
   jal x1, _xof_kmac_if_status_poll
+
+  ret
+
+/**
+ * Squeeze out 32 Boolean-shared bytes into w29 and w30.
+ *
+ * Depending on how many bytes are remaining in the KMAC-internal rate buffer,
+ * this routine might trigger a `RUN` command that starts a new KMAC round
+ * computation repopulating the rate buffer. This routine *must* only be
+ * called after having issued the `PROCESS` command (see `xof_process`).
+ */
+xof_squeeze32:
+  /* Preload the run command. */
+  addi x26, x0, KMAC_CMD_RUN
+
+  /* Squeeze the 32 bytes in chunks of 64 bits from the KMAC-internal rate
+     buffer. */
+  loopi 4, 10
+
+    /* Only issue the `RUN` command if there are fewer than 64 bits remaining in
+       the rate buffer. */
+    bne x28, x0, _xof_squeeze32_recharge
+
+    csrrw x0, KMAC_CMD, x26
+
+    addi x24, x0, KMAC_IF_STATUS_DIGEST_VALID
+    jal x1, _xof_kmac_if_status_poll
+
+    /* Reset the rate counter. */
+    addi x28, x29, 0
+
+_xof_squeeze32_recharge:
+
+    /* Transfer the 32 squeezed and Boolean shared bytes to w29 and w30. */
+    bn.wsrr w27, KMAC_DATA_S0
+    bn.rshi w29, w27, w29 >> 64
+
+    addi x28, x28, -1
+
+    bn.wsrr w28, KMAC_DATA_S1
+    bn.rshi w30, w28, w30 >> 64
+    /* End of loop */
 
   ret

--- a/sw/otbn/crypto/mldsa87/tests/BUILD
+++ b/sw/otbn/crypto/mldsa87/tests/BUILD
@@ -9,6 +9,7 @@ load("@ot_python_deps//:requirements.bzl", "requirement")
 package(default_visibility = ["//visibility:public"])
 
 mldsa87_srcs = [
+    "//sw/otbn/crypto/mldsa87:mldsa87_xof.s",
     "//sw/otbn/crypto/mldsa87:mldsa87_ntt.s",
     "//sw/otbn/crypto/mldsa87:mldsa87_arith.s",
 ]
@@ -23,6 +24,8 @@ mldsa87_unit_tests = [
     "mldsa87_poly_add_test",
     "mldsa87_poly_sub_test",
     "mldsa87_poly_mul_add_test",
+    "mldsa87_xof_shake128_test",
+    "mldsa87_xof_shake256_test",
 ]
 
 [

--- a/sw/otbn/crypto/mldsa87/tests/mldsa87_xof_shake128_test.hjson
+++ b/sw/otbn/crypto/mldsa87/tests/mldsa87_xof_shake128_test.hjson
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+{
+  "entrypoint": "main",
+  "input": {
+    "dmem": {
+      "_xof_shake128_msg_3b": "0x00020100",
+      "_xof_shake128_msg_32b": "0x1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100",
+      "_xof_shake128_msg_48b": "0x2f2e2d2c2b2a292827262524232221201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100",
+      "_xof_shake128_msg_128b": "0x7f7e7d7c7b7a797877767574737271706f6e6d6c6b6a696867666564636261605f5e5d5c5b5a595857565554535251504f4e4d4c4b4a494847464544434241403f3e3d3c3b3a393837363534333231302f2e2d2c2b2a292827262524232221201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100",
+    }
+  },
+
+  "output": {
+    "regs": {
+      // _xof_shake128_msg_3b
+      "w1": "0x96a8221023fdbf94cfd1918854ee4ffcea489ab39776ce8bd51a7343754b3d20",
+      "w2": "0xe09d7a692b2045038249300bd12b44ee7c9895ca8cc9fb6cf8dc4ea96e4db827",
+      // _xof_shake128_msg_32b
+      "w3": "0x927a84e509d4c3fec09e8579cfcec0ce108a21252bc0cdce56f875c61d366a06",
+      "w4": "0x0822f2710510b4468a07812b170943a51bb405d2bdb139cc443a6ad1334e9dba",
+      // _xof_shake128_msg_48b
+      "w5": "0x3b8cbebec3ba3c4cd0b82d4b44977e74753da590b3ed321324238b5b00950eaa",
+      "w6": "0x1aac658261915452258442a5e4d9833557aea2175311d1290c0c9445ecfe156f",
+      // _xof_shake128_msg_128b
+      "w7": "0xbfdf3c518d7feaf10ee165086ec3db0e8399b9b91ee09981614adf3330d45fcd",
+      "w8": "0x603c5193a3a9d793d0c977a6dab2dca9ce314bbdc7c6a7fc448594ca8d2cc2ff",
+      "w9": "0x0f647c1ef1562e5dbe0fbd5a4acefe0775ecdb30fa5d5386f64d6dba7c0eb878",
+      "w10": "0xedeb713b993dca15017895dc0ca23b14648aff78e3d7b29a4b92a9f510102f18",
+    }
+  }
+}

--- a/sw/otbn/crypto/mldsa87/tests/mldsa87_xof_shake128_test.s
+++ b/sw/otbn/crypto/mldsa87/tests/mldsa87_xof_shake128_test.s
@@ -1,0 +1,115 @@
+/* Copyright lowRISC contributors (OpenTitan project). */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* Test that the SHAKE128 XOF interface can correctly absorb and squeeze data. */
+
+.section .text.start
+
+main:
+  la x31, _stack
+  bn.xor w31, w31, w31
+
+  /*
+   * Test case 1: Absorb 3 bytes, squeeze 1 + 32 bytes.
+   */
+  jal x1, xof_shake128_init
+
+  addi x20, x0, 3
+  la x21, _xof_shake128_msg_3b
+  addi x22, x0, 0
+  jal x1, xof_absorb
+  jal x1, xof_process
+
+  jal x1, xof_squeeze32
+  bn.xor w1, w29, w30
+
+  jal x1, xof_squeeze32
+  bn.xor w2, w29, w30
+
+  jal x1, xof_finish
+
+  /*
+   * Test case 2: Absorb 32 bytes, squeeze 32 + 32 bytes
+   */
+
+  jal x1, xof_shake128_init
+
+  addi x20, x0, 32
+  la x21, _xof_shake128_msg_32b
+  jal x1, xof_absorb
+  addi x22, x0, 0
+  jal x1, xof_process
+
+  jal x1, xof_squeeze32
+  bn.xor w3, w29, w30
+
+  jal x1, xof_squeeze32
+  bn.xor w4, w29, w30
+
+  jal x1, xof_finish
+
+  /*
+   * Test case 3: Absorb 48 bytes, squeeze 16 + 32 bytes.
+   */
+
+  jal x1, xof_shake128_init
+
+  addi x20, x0, 48
+  la x21, _xof_shake128_msg_48b
+  jal x1, xof_absorb
+  addi x22, x0, 0
+  jal x1, xof_process
+
+  jal x1, xof_squeeze32
+  bn.xor w5, w29, w30
+
+  jal x1, xof_squeeze32
+  bn.xor w6, w29, w30
+
+  jal x1, xof_finish
+
+  /*
+   * Test case 4: Absorb 128 bytes, squeeze 4 * 32 bytes.
+   */
+
+  jal x1, xof_shake128_init
+
+  addi x20, x0, 128
+  la x21, _xof_shake128_msg_128b
+  jal x1, xof_absorb
+  addi x22, x0, 0
+  jal x1, xof_process
+
+  jal x1, xof_squeeze32
+  bn.xor w7, w29, w30
+
+  jal x1, xof_squeeze32
+  bn.xor w8, w29, w30
+
+  jal x1, xof_squeeze32
+  bn.xor w9, w29, w30
+
+  jal x1, xof_squeeze32
+  bn.xor w10, w29, w30
+
+  jal x1, xof_finish
+
+  ecall
+
+.data
+.balign 32
+
+_xof_shake128_msg_3b:
+.zero 3
+.zero 29 /* Padding */
+_xof_shake128_msg_32b:
+.zero 32
+_xof_shake128_msg_48b:
+.zero 48
+.zero 16 /* Padding */
+_xof_shake128_msg_128b:
+.zero 128
+
+_stack:
+.zero 4

--- a/sw/otbn/crypto/mldsa87/tests/mldsa87_xof_shake256_test.hjson
+++ b/sw/otbn/crypto/mldsa87/tests/mldsa87_xof_shake256_test.hjson
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+{
+  "entrypoint": "main",
+  "input": {
+    "dmem": {
+      "_xof_shake256_msg_3b": "0x00020100",
+      "_xof_shake256_msg_32b": "0x1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100",
+      "_xof_shake256_msg_48b": "0x2f2e2d2c2b2a292827262524232221201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100",
+      "_xof_shake256_msg_128b": "0x7f7e7d7c7b7a797877767574737271706f6e6d6c6b6a696867666564636261605f5e5d5c5b5a595857565554535251504f4e4d4c4b4a494847464544434241403f3e3d3c3b3a393837363534333231302f2e2d2c2b2a292827262524232221201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100",
+    }
+  },
+
+  "output": {
+    "regs": {
+      // _xof_shake256_msg_3b
+      "w1": "0xaa0ad566fb709410c14031b9d7eaf07de6a1ee9329427ea84e92ad7e16014571",
+      "w2": "0x09ed2c20958a154c805fcfb2514ae510fa29be814a1f8bb981b404d1afdd04ff",
+      // _xof_shake256_msg_32b
+      "w3": "0xd3cd03459bcad2eb13451ee3b3989cbc5b3d2c883909b34d0280ce40887cf069",
+      "w4": "0x3f339b09f17a9ad172b23570ef24cce04ee16391c45aa7d473712c454207c9c9",
+      // _xof_shake256_msg_48b
+      "w5": "0xc30dd72970b41d02bd1109dee86c899715c9d4379f20c0de8ccdd1b4b19b450c",
+      "w6": "0xe78d67efbca388d9d340f7464d83aa41f8e4ffbe635b328fe2df208e7039ad32",
+      // _xof_shake256_msg_128b
+      "w7":  "0xec15ee65051cf30a79c9be76059d3bb35fc8a266cd5f15ded99d98eb493a3a8d",
+      "w8":  "0x5ca16dcc3d26234bcbd8cdfd3fe75f5614b11891e311cbdf487f8dd20a87e51d",
+      "w9":  "0xd79765b558e84e2f0c5961ac100ad6b79a2a1ada153a0962e94d47d35e976518",
+      "w10": "0x06db9686228cd01984b5d4d2883a0267873000c2b99f6cbc1856320b0d416c53",
+    }
+  }
+}

--- a/sw/otbn/crypto/mldsa87/tests/mldsa87_xof_shake256_test.s
+++ b/sw/otbn/crypto/mldsa87/tests/mldsa87_xof_shake256_test.s
@@ -1,0 +1,114 @@
+/* Copyright lowRISC contributors (OpenTitan project). */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* Test that the SHAKE256 XOF interface can correctly absorb and squeeze data. */
+
+.section .text.start
+
+main:
+  bn.xor w31, w31, w31
+
+  /*
+   * Test case 1: Absorb 3 bytes, squeeze 1 + 32 bytes.
+   */
+  jal x1, xof_shake256_init
+
+  addi x20, x0, 3
+  la x21, _xof_shake256_msg_3b
+  addi x22, x0, 0
+  jal x1, xof_absorb
+  jal x1, xof_process
+
+  jal x1, xof_squeeze32
+  bn.xor w1, w29, w30
+
+  jal x1, xof_squeeze32
+  bn.xor w2, w29, w30
+
+  jal x1, xof_finish
+
+  /*
+   * Test case 2: Absorb 32 bytes, squeeze 32 + 32 bytes
+   */
+
+  jal x1, xof_shake256_init
+
+  addi x20, x0, 32
+  la x21, _xof_shake256_msg_32b
+  addi x22, x0, 0
+  jal x1, xof_absorb
+  jal x1, xof_process
+
+  jal x1, xof_squeeze32
+  bn.xor w3, w29, w30
+
+  jal x1, xof_squeeze32
+  bn.xor w4, w29, w30
+
+  jal x1, xof_finish
+
+  /*
+   * Test case 3: Absorb 48 bytes, squeeze 16 + 32 bytes.
+   */
+
+  jal x1, xof_shake256_init
+
+  addi x20, x0, 48
+  la x21, _xof_shake256_msg_48b
+  addi x22, x0, 0
+  jal x1, xof_absorb
+  jal x1, xof_process
+
+  jal x1, xof_squeeze32
+  bn.xor w5, w29, w30
+
+  jal x1, xof_squeeze32
+  bn.xor w6, w29, w30
+
+  jal x1, xof_finish
+
+  /*
+   * Test case 4: Absorb 128 bytes, squeeze 4 * 32 bytes.
+   */
+
+  jal x1, xof_shake256_init
+
+  addi x20, x0, 128
+  la x21, _xof_shake256_msg_128b
+  addi x22, x0, 0
+  jal x1, xof_absorb
+  jal x1, xof_process
+
+  jal x1, xof_squeeze32
+  bn.xor w7, w29, w30
+
+  jal x1, xof_squeeze32
+  bn.xor w8, w29, w30
+
+  jal x1, xof_squeeze32
+  bn.xor w9, w29, w30
+
+  jal x1, xof_squeeze32
+  bn.xor w10, w29, w30
+
+  jal x1, xof_finish
+
+  ecall
+
+.data
+.balign 32
+
+_xof_shake256_msg_3b:
+.zero 3
+.zero 29 /* Padding */
+_xof_shake256_msg_32b:
+.zero 32
+_xof_shake256_msg_48b:
+.zero 48
+.zero 16 /* Padding */
+_xof_shake256_msg_128b:
+.zero 128
+
+_stack:
+.zero 4


### PR DESCRIPTION
Squeezing for the XOF driver.

---

This is a series of PRs that in their composition result in FIPS-204-compliant OTBN implementation of ML-DSA-87 verify.

#### Resources

  - https://nvlpubs.nist.gov/nistpubs/fips/nist.fips.204.pdf
  - https://tches.iacr.org/index.php/TCHES/article/view/11158/10597
  - https://github.com/pq-crystals/dilithium

####  Preamble

1. ~`doc`~ #29299 

#### Number-theoretic transform

2. ~`NTT`~ #29333
3. ~`INTT`~ #29334

#### Polynomial arithmetic

4. ~`poly_add`, `poly_sub`, `poly_mul`~ #29335
5. ~`poly_mul_add`~ #29345

#### XOF

6. ~`xof_init`, `xof_poll`, `xof_finish`~ #29347
7. ~`xof_absorb`~ #29376
8. `xof_squeeze`

#### Rounding

9. `shift_left`
10. `decompose`

#### Reduction

11. `reduce`

#### Infinity norm

12. `norm_check`

#### Sampling

13. `rej_ntt_poly`, `expand_a`
14. `sample_in-ball`
15. `challenge_hash`

#### Encoding

16. `decode_z`
17. `decode_t1`
18. `decode_hint`
19. `encode_w1`

#### Vector operations

20. `sig_decode`
21. `norm_check_z`
22. `A*z`, `c * t1`, `Az - ct1`
23. `use_hint`

#### Epilogue

24. `app`