### PR TITLE
[opentitantool] bootstrap: add sanity check of the ID of the SPI device

### DIFF
--- a/sw/host/opentitanlib/src/bootstrap/eeprom.rs
+++ b/sw/host/opentitanlib/src/bootstrap/eeprom.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
 use crate::app::TransportWrapper;
 use crate::bootstrap::{Bootstrap, UpdateProtocol};
@@ -43,24 +43,27 @@ impl UpdateProtocol for Eeprom {
         transport: &TransportWrapper,
         payload: &[u8],
         progress: &dyn ProgressIndicator,
+        check_jedec_id: bool,
     ) -> Result<()> {
         let spi = container.spi_params.create(transport, "BOOTSTRAP")?;
         let flash = SpiFlash::from_spi(&*spi)?;
-        // Just in case, verify that we're talking to a lowRISC chip. Jedec ID
-        // size of lowRISC SPI Flash impersonation is 15 bytes long.
-        let v = SpiFlash::read_jedec_id(&*spi, 15)?;
-        match (v[11], v[12], v[14]) {
-            (127, 239, 20) => (), // The preamble is 12 bytes long, 239 is lowRISC assigned ID, 2^20 is flash size.
-            (_, _, _) => {
-                // Print meaningful fileds from the collected ID.
-                let trimmed_jedec_id = match v.iter().rposition(|&x| x != 0) {
-                    Some(idx) => &v[..=idx],
-                    None => &[],
-                };
-                return Err(anyhow!(
-                    "Unexpected JedecID on SPI bus: {:?}",
-                    trimmed_jedec_id
-                ));
+        if check_jedec_id {
+            // Just in case, verify that we're talking to a lowRISC chip. Jedec ID
+            // size of lowRISC SPI Flash impersonation is 15 bytes long.
+            let v = SpiFlash::read_jedec_id(&*spi, 15)?;
+            match (v[11], v[12], v[14]) {
+                (127, 239, 20) => (), // The preamble is 12 bytes long, 239 is lowRISC assigned ID, 2^20 is flash size.
+                (_, _, _) => {
+                    // Print meaningful fileds from the collected ID.
+                    let trimmed_jedec_id = match v.iter().rposition(|&x| x != 0) {
+                        Some(idx) => &v[..=idx],
+                        None => &[],
+                    };
+                    return Err(anyhow!(
+                        "Unexpected JedecID on SPI bus: {:?}",
+                        trimmed_jedec_id
+                    ));
+                }
             }
         }
         flash.chip_erase(&*spi)?;

--- a/sw/host/opentitanlib/src/bootstrap/legacy.rs
+++ b/sw/host/opentitanlib/src/bootstrap/legacy.rs
@@ -228,6 +228,7 @@ impl UpdateProtocol for Legacy {
         transport: &TransportWrapper,
         payload: &[u8],
         progress: &dyn ProgressIndicator,
+        _check_jedec_id: bool,
     ) -> Result<()> {
         let spi = container.spi_params.create(transport, "BOOTSTRAP")?;
 

--- a/sw/host/opentitanlib/src/bootstrap/legacy_rescue.rs
+++ b/sw/host/opentitanlib/src/bootstrap/legacy_rescue.rs
@@ -312,6 +312,7 @@ impl UpdateProtocol for LegacyRescue {
         transport: &TransportWrapper,
         payload: &[u8],
         progress: &dyn ProgressIndicator,
+        _check_jedec_id: bool,
     ) -> Result<()> {
         let frames = Frame::from_payload(payload)?;
         let uart = container.uart_params.create(transport)?;

--- a/sw/host/opentitanlib/src/bootstrap/mod.rs
+++ b/sw/host/opentitanlib/src/bootstrap/mod.rs
@@ -69,6 +69,7 @@ trait UpdateProtocol {
         transport: &TransportWrapper,
         payload: &[u8],
         progress: &dyn ProgressIndicator,
+        check_jedec_id: bool,
     ) -> Result<()>;
 }
 
@@ -99,6 +100,9 @@ pub struct BootstrapOptions {
     /// Duration of the flash-erase delay.
     #[arg(long, value_parser = parse_duration)]
     pub flash_erase_delay: Option<Duration>,
+    /// Check the SPI slave Jedec ID before proceeding.
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
+    pub check_jedec_id: bool,
 }
 
 /// Bootstrap wraps and drives the various bootstrap protocols.
@@ -163,7 +167,7 @@ impl<'a> Bootstrap<'a> {
             leave_in_reset: options.leave_in_reset,
             leave_in_bootstrap: options.leave_in_bootstrap,
         }
-        .do_update(updater, transport, payload, progress)
+        .do_update(updater, transport, payload, progress, options.check_jedec_id)
     }
 
     fn do_update(
@@ -172,6 +176,7 @@ impl<'a> Bootstrap<'a> {
         transport: &TransportWrapper,
         payload: &[u8],
         progress: &dyn ProgressIndicator,
+        check_jedec_id: bool,
     ) -> Result<()> {
         updater.verify_capabilities(self, transport)?;
         let perform_bootstrap_reset = updater.uses_common_bootstrap_reset();
@@ -187,7 +192,7 @@ impl<'a> Bootstrap<'a> {
             transport.reset(uart_rx)?;
             log::info!("Performing bootstrap...");
         }
-        let result = updater.update(self, transport, payload, progress);
+        let result = updater.update(self, transport, payload, progress, check_jedec_id);
 
         if !self.leave_in_bootstrap && perform_bootstrap_reset {
             if self.leave_in_reset {

--- a/sw/host/opentitanlib/src/bootstrap/primitive.rs
+++ b/sw/host/opentitanlib/src/bootstrap/primitive.rs
@@ -130,6 +130,7 @@ impl UpdateProtocol for Primitive {
         transport: &TransportWrapper,
         payload: &[u8],
         progress: &dyn ProgressIndicator,
+        _check_jedec_id: bool,
     ) -> Result<()> {
         let spi = container.spi_params.create(transport, "BOOTSTRAP")?;
 


### PR DESCRIPTION
In certain hardware configurations there are more than one SPI flash devices in the system, and the bootstrap operation could end up talking to a wrong SPI flash chip.

Let's add a validation of the Jedec ID of the device.

TEST=successfully ran bootstrap of an NT chip, Observed the expected
     error message when tried to do the same in a misconfigured setup:

    Error: Unexpected JedecID on SPI bus: [239, 112, 24]