### PR TITLE
[cov,ci] Add presubmit coverage smoketest

### DIFF
--- a/.github/workflows/coverage-quick.yml
+++ b/.github/workflows/coverage-quick.yml
@@ -92,3 +92,20 @@ jobs:
       - name: Check for unrunnable tests
         run: ./ci/scripts/check-unrunnable-tests.sh
         continue-on-error: true
+
+  coverage_smoketest:
+    name: Coverage smoketest
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
+        with:
+          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
+      - name: Execute coverage smoketest
+        run: |
+          python3 util/coverage/run_smoke_test.py \
+            --target_filter='qemu|simtest|unittest' \
+            sw/device/lib/coverage/smoke/*.coverage.json

--- a/sw/device/lib/coverage/smoke/BUILD
+++ b/sw/device/lib/coverage/smoke/BUILD
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//rules:otbn.bzl", "otbn_sim_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -17,4 +19,10 @@ cc_test(
         ":target",
         "@googletest//:gtest_main",
     ],
+)
+
+otbn_sim_test(
+    name = "otbn_simtest",
+    srcs = ["target_otbn.s"],
+    testcase = "otbn_simtest.hjson",
 )

--- a/sw/device/lib/coverage/smoke/BUILD
+++ b/sw/device/lib/coverage/smoke/BUILD
@@ -2,6 +2,15 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load(
+    "//rules/opentitan:defs.bzl",
+    "EARLGREY_CW340_TEST_ENVS",
+    "EARLGREY_SILICON_OWNER_ROM_EXT_ENVS",
+    "EARLGREY_TEST_ENVS",
+    "OPENTITAN_CPU",
+    "opentitan_test",
+)
 load("//rules:otbn.bzl", "otbn_sim_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -25,4 +34,21 @@ otbn_sim_test(
     name = "otbn_simtest",
     srcs = ["target_otbn.s"],
     testcase = "otbn_simtest.hjson",
+)
+
+opentitan_test(
+    name = "ottf_functest",
+    srcs = ["ottf_functest.c"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        EARLGREY_CW340_TEST_ENVS,
+        {
+            "//hw/top_earlgrey:silicon_creator": None,
+        },
+    ),
+    deps = [
+        ":target",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
 )

--- a/sw/device/lib/coverage/smoke/BUILD
+++ b/sw/device/lib/coverage/smoke/BUILD
@@ -11,6 +11,7 @@ load(
     "OPENTITAN_CPU",
     "opentitan_test",
 )
+load("//rules/coverage:asm.bzl", "asm_library_with_coverage")
 load("//rules:otbn.bzl", "otbn_sim_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -49,6 +50,33 @@ opentitan_test(
     ),
     deps = [
         ":target",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+asm_library_with_coverage(
+    name = "target_asm",
+    srcs = ["target_asm.S"],
+    hdrs = ["target.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//sw/device/lib/coverage:api_asm",
+    ],
+)
+
+opentitan_test(
+    name = "asm_functest",
+    srcs = ["ottf_functest.c"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        EARLGREY_CW340_TEST_ENVS,
+        {
+            "//hw/top_earlgrey:silicon_creator": None,
+        },
+    ),
+    deps = [
+        ":target_asm",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/lib/coverage/smoke/BUILD
+++ b/sw/device/lib/coverage/smoke/BUILD
@@ -1,0 +1,20 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "target",
+    srcs = ["target.c"],
+    hdrs = ["target.h"],
+)
+
+cc_test(
+    name = "host_unittest",
+    srcs = ["host_unittest.cc"],
+    deps = [
+        ":target",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/sw/device/lib/coverage/smoke/asm_functest.coverage.json
+++ b/sw/device/lib/coverage/smoke/asm_functest.coverage.json
@@ -1,0 +1,36 @@
+{
+  "tests": [
+    "//sw/device/lib/coverage/smoke:asm_functest_sim_qemu_sival_rom_ext",
+    "//sw/device/lib/coverage/smoke:asm_functest_sim_qemu_rom_with_fake_keys"
+  ],
+  "coverage": {
+    "sw/device/lib/coverage/smoke/target_asm.S": {
+      "funcs": {
+        "covfunc_hit": "hit",
+        "covfunc_nested_hit": "hit",
+        "covfunc_miss": "miss",
+        "covfunc_nested_miss": "miss"
+      },
+      "lines": {
+        "covfunc_hit:": "hit",
+        "covfunc_nested_hit:": "hit",
+        "covfunc_miss:": "miss",
+        "covfunc_nested_miss:": "miss"
+      }
+    },
+    "sw/device/lib/coverage/smoke/target.h": {
+      "funcs": {
+        "inline_covfunc_hit": "hit",
+        "inline_covfunc_miss": "miss",
+        "static_inline_covfunc_hit": "hit",
+        "static_inline_covfunc_miss": "miss"
+      },
+      "lines": {
+        "inline_covfunc_hit(void) {": "hit",
+        "inline_covfunc_miss(void) {": "miss",
+        "static_inline_covfunc_hit(void) {": "hit",
+        "static_inline_covfunc_miss(void) {": "miss"
+      }
+    }
+  }
+}

--- a/sw/device/lib/coverage/smoke/host_unittest.cc
+++ b/sw/device/lib/coverage/smoke/host_unittest.cc
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/coverage/smoke/target.h"
+
+namespace coverage_smoke_unittest {
+
+TEST(CoverageTest, RunCovfuncCovered) { covfunc_hit(); }
+
+TEST(CoverageTest, RunInlineCovfuncCovered) { inline_covfunc_hit(); }
+
+TEST(CoverageTest, RunStaticInlineCovfuncCovered) {
+  static_inline_covfunc_hit();
+}
+
+}  // namespace coverage_smoke_unittest

--- a/sw/device/lib/coverage/smoke/host_unittest.coverage.json
+++ b/sw/device/lib/coverage/smoke/host_unittest.coverage.json
@@ -1,0 +1,35 @@
+{
+  "tests": [
+    "//sw/device/lib/coverage/smoke:host_unittest"
+  ],
+  "coverage": {
+    "sw/device/lib/coverage/smoke/target.c": {
+      "funcs": {
+        "covfunc_hit": "hit",
+        "covfunc_nested_hit": "hit",
+        "covfunc_miss": "miss",
+        "covfunc_nested_miss": "miss"
+      },
+      "lines": {
+        "covfunc_hit(void) {": "hit",
+        "covfunc_nested_hit(void) {": "hit",
+        "covfunc_miss(void) {": "miss",
+        "covfunc_nested_miss(void) {": "miss"
+      }
+    },
+    "sw/device/lib/coverage/smoke/target.h": {
+      "funcs": {
+        "inline_covfunc_hit": "hit",
+        "inline_covfunc_miss": "miss",
+        "_ZL25static_inline_covfunc_hitv": "hit",
+        "_ZL26static_inline_covfunc_missv": "miss"
+      },
+      "lines": {
+        "inline_covfunc_hit(void) {": "hit",
+        "inline_covfunc_miss(void) {": "miss",
+        "static_inline_covfunc_hit(void) {": "hit",
+        "static_inline_covfunc_miss(void) {": "miss"
+      }
+    }
+  }
+}

--- a/sw/device/lib/coverage/smoke/otbn_simtest.coverage.json
+++ b/sw/device/lib/coverage/smoke/otbn_simtest.coverage.json
@@ -1,0 +1,18 @@
+{
+  "tests": [
+    "//sw/device/lib/coverage/smoke:otbn_simtest"
+  ],
+  "coverage": {
+    "sw/device/lib/coverage/smoke/target_otbn.s": {
+      "funcs": {},
+      "lines": {
+        "addi  x5, x5, START": "hit",
+        "addi  x5, x5, COVFUNC_NESTED_HIT": "hit",
+        "addi  x5, x5, COVFUNC_HIT": "hit",
+        "addi  x5, x5, COVFUNC_NESTED_MISS": "miss",
+        "addi  x5, x5, COVFUNC_MISS": "miss",
+        ".zero COVFUNC_BSS_SKIP": "skip"
+      }
+    }
+  }
+}

--- a/sw/device/lib/coverage/smoke/otbn_simtest.hjson
+++ b/sw/device/lib/coverage/smoke/otbn_simtest.hjson
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  "input": {
+    "regs": {
+      "x5": "0x00000000"
+    }
+  }
+  "output": {
+    "regs": {
+      # Sum of:
+      #  - 1 = start
+      #  - 2 = covfunc_hit
+      #  - 4 = covfunc_nested_hit
+      "x5": "0x00000007"
+    }
+  }
+}

--- a/sw/device/lib/coverage/smoke/ottf_functest.c
+++ b/sw/device/lib/coverage/smoke/ottf_functest.c
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/coverage/smoke/target.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  covfunc_hit();
+  inline_covfunc_hit();
+  static_inline_covfunc_hit();
+  return true;
+}

--- a/sw/device/lib/coverage/smoke/ottf_functest.coverage.json
+++ b/sw/device/lib/coverage/smoke/ottf_functest.coverage.json
@@ -1,0 +1,36 @@
+{
+  "tests": [
+    "//sw/device/lib/coverage/smoke:ottf_functest_sim_qemu_sival_rom_ext",
+    "//sw/device/lib/coverage/smoke:ottf_functest_sim_qemu_rom_with_fake_keys"
+  ],
+  "coverage": {
+    "sw/device/lib/coverage/smoke/target.c": {
+      "funcs": {
+        "covfunc_hit": "hit",
+        "covfunc_nested_hit": "hit",
+        "covfunc_miss": "miss",
+        "covfunc_nested_miss": "miss"
+      },
+      "lines": {
+        "covfunc_hit(void) {": "hit",
+        "covfunc_nested_hit(void) {": "hit",
+        "covfunc_miss(void) {": "miss",
+        "covfunc_nested_miss(void) {": "miss"
+      }
+    },
+    "sw/device/lib/coverage/smoke/target.h": {
+      "funcs": {
+        "inline_covfunc_hit": "hit",
+        "inline_covfunc_miss": "miss",
+        "static_inline_covfunc_hit": "hit",
+        "static_inline_covfunc_miss": "miss"
+      },
+      "lines": {
+        "inline_covfunc_hit(void) {": "hit",
+        "inline_covfunc_miss(void) {": "miss",
+        "static_inline_covfunc_hit(void) {": "hit",
+        "static_inline_covfunc_miss(void) {": "miss"
+      }
+    }
+  }
+}

--- a/sw/device/lib/coverage/smoke/rom_ext_functest.coverage.json
+++ b/sw/device/lib/coverage/smoke/rom_ext_functest.coverage.json
@@ -1,0 +1,23 @@
+{
+  "tests": [
+    "//sw/device/lib/coverage/smoke:ottf_functest_sim_qemu_sival_rom_ext"
+  ],
+  "coverage": {
+    "sw/device/silicon_creator/rom_ext/imm_section/imm_section.c": {
+      "funcs": {
+        "imm_section_main": "hit"
+      },
+      "lines": {
+        "imm_section_main(void) {": "hit"
+      }
+    },
+    "sw/device/silicon_creator/rom_ext/rom_ext.c": {
+      "funcs": {
+        "rom_ext_main": "hit"
+      },
+      "lines": {
+        "rom_ext_main(void) {": "hit"
+      }
+    }
+  }
+}

--- a/sw/device/lib/coverage/smoke/target.c
+++ b/sw/device/lib/coverage/smoke/target.c
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/coverage/smoke/target.h"
+
+void covfunc_nested_hit(void) {}
+
+void covfunc_hit(void) { covfunc_nested_hit(); }
+
+void covfunc_nested_miss(void) {}
+
+void covfunc_miss(void) { covfunc_nested_miss(); }

--- a/sw/device/lib/coverage/smoke/target.h
+++ b/sw/device/lib/coverage/smoke/target.h
@@ -1,0 +1,28 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_COVERAGE_SMOKE_TARGET_H_
+#define OPENTITAN_SW_DEVICE_LIB_COVERAGE_SMOKE_TARGET_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+void covfunc_hit(void);
+
+inline void inline_covfunc_hit(void) {}
+
+static inline void static_inline_covfunc_hit(void) {}
+
+void covfunc_miss(void);
+
+inline void inline_covfunc_miss(void) {}
+
+static inline void static_inline_covfunc_miss(void) {}
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_COVERAGE_SMOKE_TARGET_H_

--- a/sw/device/lib/coverage/smoke/target_asm.S
+++ b/sw/device/lib/coverage/smoke/target_asm.S
@@ -1,0 +1,38 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/coverage/api_asm.h"
+
+// PRAGMA_COVERAGE: section(__llvm_prf_cnts_head)
+// PRAGMA_COVERAGE: autogen start
+
+  .section .text, "ax"
+
+  .global covfunc_nested_hit
+  .type covfunc_nested_hit, @function
+covfunc_nested_hit:
+  COVERAGE_ASM_AUTOGEN_MARK(t6,0)
+  ret
+  .size covfunc_nested_hit, .-covfunc_nested_hit
+
+  .global covfunc_hit
+  .type covfunc_hit, @function
+covfunc_hit:
+  COVERAGE_ASM_AUTOGEN_MARK(t6,1)
+  j covfunc_nested_hit
+  .size covfunc_hit, .-covfunc_hit
+
+  .global covfunc_nested_miss
+  .type covfunc_nested_miss, @function
+covfunc_nested_miss:
+  COVERAGE_ASM_AUTOGEN_MARK(t6,2)
+  ret
+  .size covfunc_nested_miss, .-covfunc_nested_miss
+
+  .global covfunc_miss
+  .type covfunc_miss, @function
+covfunc_miss:
+  COVERAGE_ASM_AUTOGEN_MARK(t6,3)
+  j covfunc_nested_miss
+  .size covfunc_miss, .-covfunc_miss

--- a/sw/device/lib/coverage/smoke/target_otbn.s
+++ b/sw/device/lib/coverage/smoke/target_otbn.s
@@ -1,0 +1,42 @@
+/* Copyright lowRISC contributors (OpenTitan project). */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.equ START,               1
+.equ COVFUNC_NESTED_HIT,  2
+.equ COVFUNC_HIT,         4
+.equ COVFUNC_NESTED_MISS, 8
+.equ COVFUNC_MISS,        16
+.equ COVFUNC_BSS_SKIP,    32
+
+
+.section .text.start
+start:
+  addi  x5, x5, START
+  jal   x1, covfunc_hit
+  ecall
+
+covfunc_nested_hit:
+  addi  x5, x5, COVFUNC_NESTED_HIT
+  ret
+
+covfunc_hit:
+  addi  x5, x5, COVFUNC_HIT
+  jal   x1, covfunc_nested_hit
+  ret
+
+covfunc_nested_miss:
+  addi  x5, x5, COVFUNC_NESTED_MISS
+  ret
+
+covfunc_miss:
+  addi  x5, x5, COVFUNC_MISS
+  jal   x1, covfunc_nested_miss
+  ret
+
+.bss
+
+.globl covfunc_bss_skip
+.balign 4
+covfunc_bss_skip:
+.zero COVFUNC_BSS_SKIP

--- a/util/coverage/run_smoke_test.py
+++ b/util/coverage/run_smoke_test.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""Runs coverage smoke tests with JSON expectations.
+
+This script runs coverage tests and checks for expected coverage
+status (hit, miss, or skip) for functions and lines
+based on a JSON configuration.
+"""
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path
+
+MERGED_REPORT = Path("bazel-out/_coverage/_coverage_report.dat")
+LCOV_LIST = Path("bazel-out/_coverage/lcov_files.tmp")
+
+
+def _get_func_lineno(file_path: Path, pattern: str) -> int:
+    """Finds the line number for a given pattern in a file.
+
+    Returns:
+        The 1-based line number where the function is found.
+    """
+    file_content = file_path.read_text()
+    try:
+        # Find the start of the pattern.
+        start_index = file_content.index(pattern)
+        # Count newlines up to the end of the pattern.
+        return file_content[:start_index + len(pattern)].count('\n') + 1
+    except ValueError:
+        raise ValueError(f"Pattern '{pattern}' not found in file {file_path}")
+
+
+def _check_ans(name: str, ans: str, is_hit: bool, is_miss: bool) -> bool:
+    """Compares the actual coverage status with the expected status."""
+    if ans == 'hit' and is_hit:
+        print(f" PASS: {name} correctly marked as {ans}.")
+    elif ans == 'miss' and not is_hit and is_miss:
+        print(f" PASS: {name} correctly marked as {ans}.")
+    elif ans == 'skip' and not is_hit and not is_miss:
+        print(f" PASS: {name} correctly marked as {ans}.")
+    else:
+        print(f" FAIL: {name} should be {ans}, "
+              f"but is_hit={is_hit}, is_miss={is_miss}.")
+        return False
+    return True
+
+
+def _run_smoke_test(path: Path, target_filter: str) -> bool:
+    """Runs a single smoke test defined by an expectation JSON file."""
+    file_pass = True
+    print(f"Smoke test with expectation file: {path}")
+
+    with open(path, 'r') as f:
+        config = json.load(f)
+
+    for test_target in config["tests"]:
+        if not re.search(target_filter, test_target):
+            continue
+        print(f"Running bazel coverage for: {test_target}")
+        print()
+        cmd = [
+            "./bazelisk.sh", "coverage", "--test_output=errors",
+            "--config=ot_coverage", test_target
+        ]
+        try:
+            subprocess.run(cmd, check=True)
+        except subprocess.CalledProcessError as e:
+            print(f"FAIL: Bazel command failed with error: {e}")
+            file_pass = False
+            continue
+        print()
+
+        # Check for the single coverage.dat file.
+        lcov_files = LCOV_LIST.read_text().splitlines()
+        lcov_files = [e for e in lcov_files if e.endswith('/coverage.dat')]
+        if len(lcov_files) != 1:
+            print("FAIL: Expected exactly one coverage.dat file.")
+            file_pass = False
+            continue
+        if not Path(lcov_files[0]).is_file():
+            print(f"FAIL: Coverage report {lcov_files[0]} not found.")
+            file_pass = False
+            continue
+
+        # Check contents in merged report.
+        if not MERGED_REPORT.is_file():
+            print(f"FAIL: Coverage report {MERGED_REPORT} not found.")
+            file_pass = False
+            continue
+
+        contents = MERGED_REPORT.read_text()
+
+        for filename, coverage in config["coverage"].items():
+            print(f"Checking expectations for file: {filename}")
+
+            # Extract content for the specific file
+            file_regex = fr"^SF:{re.escape(filename)}\n(.*?)^end_of_record"
+            record_match = re.search(file_regex, contents, re.M | re.S)
+            if not record_match:
+                print(f" FAIL: No '{filename}' in coverage report.")
+                file_pass = False
+                continue
+            record = record_match.group(1)
+
+            # Assert function coverage (FNDA records)
+            for func_name, ans in coverage['funcs'].items():
+                re_pattern = fr'(?:.*:)?{re.escape(func_name)}'
+                re_hit = fr"^FNDA:[1-9][0-9]*,{re_pattern}$"
+                re_miss = fr"^FNDA:0,{re_pattern}$"
+                name = f"Func '{func_name}'"
+                is_hit = bool(re.search(re_hit, record, re.M))
+                is_miss = bool(re.search(re_miss, record, re.M))
+                file_pass &= _check_ans(name, ans, is_hit, is_miss)
+
+            # Assert line coverage (DA records)
+            for line_pattern, ans in coverage['lines'].items():
+                lineno = _get_func_lineno(Path(filename), line_pattern)
+                re_hit = fr"^DA:{lineno},[1-9][0-9]*$"
+                re_miss = fr"^DA:{lineno},0$"
+                name = f"Line {lineno} for '{line_pattern}'"
+                is_hit = bool(re.search(re_hit, record, re.M))
+                is_miss = bool(re.search(re_miss, record, re.M))
+                file_pass &= _check_ans(name, ans, is_hit, is_miss)
+            print()
+
+    if not file_pass:
+        print(f" FAIL: Coverage check for {path} failed.")
+    print()
+
+    return file_pass
+
+
+def main() -> None:
+    overall_pass = True
+
+    parser = argparse.ArgumentParser(description="Run coverage smoke tests.")
+    parser.add_argument("json_files",
+                        nargs="+",
+                        type=Path,
+                        help="Specific JSON expectation files to run.")
+    parser.add_argument("--target_filter",
+                        type=str,
+                        default=r'',
+                        help="Regex to filter test targets to run.")
+    args = parser.parse_args()
+
+    for path in args.json_files:
+        overall_pass &= _run_smoke_test(path, args.target_filter)
+
+    if not overall_pass:
+        print("FAIL: Some coverage smoke tests failed.")
+        exit(1)
+    else:
+        print("PASS: All coverage smoke tests passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This change introduces a coverage smoke test framework to ensure the coverage instrumentation and collection pipeline works correctly in presubmit CI.
(Framework user guide is documented in a separate #29433: sw/device/lib/coverage/smoke/README.md)

The framework checks the coverage data meets the line and func hit/miss expectations listed in the testcase. Several known-answer testcases are developed to cover the OpenTitan sw test stack, including:

1. Host-side C/C++ unittest
2. Ibex C functest
3. Ibex asm functest
4. OTBN asm simtest
5. ROM_EXT e2e test
6. (ROM e2e test case will be added later once the ROM coverage is ready)

A new presubmit CI job `coverage_smoketest` is added to automate this check.  To minimize the resource burden of FPGA workers, the current testcases are based on either host-side unittest or QEMU platform.