### PR TITLE
[cov,opentitantool] Add clear-flash-rom command

### DIFF
--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -14,6 +14,7 @@ rust_binary(
         "src/command/bootstrap.rs",
         "src/command/certificate.rs",
         "src/command/clear_bitstream.rs",
+        "src/command/clear_flash_rom.rs",
         "src/command/console.rs",
         "src/command/ecdsa.rs",
         "src/command/emulator.rs",

--- a/sw/host/opentitantool/src/command/clear_flash_rom.rs
+++ b/sw/host/opentitantool/src/command/clear_flash_rom.rs
@@ -1,0 +1,51 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use clap::Args;
+use std::any::Any;
+
+use opentitanlib::app::command::CommandDispatch;
+use opentitanlib::app::{StagedProgressBar, TransportWrapper};
+use opentitanlib::bootstrap::{Bootstrap, BootstrapOptions};
+use opentitanlib::transport::common::fpga;
+use opentitanlib::util::parse_int::ParseInt;
+
+/// Clear the flash ROM.
+#[derive(Debug, Args)]
+pub struct ClearFlashRomCommand {
+    #[command(flatten)]
+    bootstrap_options: BootstrapOptions,
+    /// The byte offset of the magic bytes from the beginning of the flash.
+    #[arg(long, value_parser = usize::from_str)]
+    magic_bytes_offset: usize,
+}
+
+impl ClearFlashRomCommand {
+    fn clear_by_bootstrap(&self, transport: &TransportWrapper) -> Result<()> {
+        // Pad to magic bytes
+        let mut payload = vec![0xff; self.magic_bytes_offset];
+        // Clear magic bytes with zeros
+        payload.extend_from_slice(&[0x00; 4]);
+
+        let progress = StagedProgressBar::new();
+        Bootstrap::update_with_progress(transport, &self.bootstrap_options, &payload, &progress)
+    }
+}
+
+impl CommandDispatch for ClearFlashRomCommand {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
+        if let Err(e) = self.clear_by_bootstrap(transport) {
+            log::warn!(
+                "Could not clear flash ROM via bootstrap, falling back to clear bitstream: {e}"
+            );
+            transport.dispatch(&fpga::ClearBitstream)?;
+        }
+        Ok(None)
+    }
+}

--- a/sw/host/opentitantool/src/command/fpga.rs
+++ b/sw/host/opentitantool/src/command/fpga.rs
@@ -15,4 +15,5 @@ pub enum FpgaCommand {
     ResetSam3x(crate::command::sam3x::Reset),
     SetPll(crate::command::set_pll::SetPll),
     UpdateUsrAccess(crate::command::update_usr_access::UpdateUsrAccess),
+    ClearFlashRom(crate::command::clear_flash_rom::ClearFlashRomCommand),
 }

--- a/sw/host/opentitantool/src/command/mod.rs
+++ b/sw/host/opentitantool/src/command/mod.rs
@@ -6,6 +6,7 @@ pub mod bfv;
 pub mod bootstrap;
 pub mod certificate;
 pub mod clear_bitstream;
+pub mod clear_flash_rom;
 pub mod console;
 pub mod ecdsa;
 pub mod emulator;


### PR DESCRIPTION
This adds the `clear-flash-rom` command to `opentitantool` under the `fpga` subcommand. This command allows clearing the flash ROM by sending an empty payload via bootstrap. If the bootstrap method fails, it falls back to clearing the bitstream on the FPGA.

This command can cleanup the flash ROM (#29162) downloaded by the flash ROM loader (#29030) after tests without time time-consuming FPGA bitstream reprogramming.
* #29162
* #29030