### PR TITLE
[prim,tlul] Update TL-UL FIFO code descriptions

### DIFF
--- a/hw/ip/tlul/rtl/tlul_fifo_async.sv
+++ b/hw/ip/tlul/rtl/tlul_fifo_async.sv
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// TL-UL fifo, used to add elasticity or an asynchronous clock crossing
-// to an TL-UL bus.  This instantiates two FIFOs, one for the request side,
+// Asynchronous TL-UL FIFO, used to cross asynchronous clock domains.
+// This instantiates two FIFOs, one for the request side,
 // and one for the response side.
 
 `include "prim_assert.sv"

--- a/hw/ip/tlul/rtl/tlul_fifo_sync.sv
+++ b/hw/ip/tlul/rtl/tlul_fifo_sync.sv
@@ -2,9 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// TL-UL fifo, used to add elasticity or an asynchronous clock crossing
-// to an TL-UL bus.  This instantiates two FIFOs, one for the request side,
-// and one for the response side.
+// Synchronous TL-UL FIFO, used to add elasticity (the ability for
+// transactions to stall on one side without affecting the other side)
+// to a TL-UL bus. This instantiates two pairs (data + integrity) of FIFOs:
+// one pair for the request side, and another pair for the response side.
 
 module tlul_fifo_sync #(
   parameter bit          ReqPass = 1'b1,


### PR DESCRIPTION
Both `tlul_fifo_sync` and `tlul_fifo_async` seemed to use identical descriptions at the top of their implementations, despite being distinctly different.

Update each to better reflect their use case and current implementation.