### PR TITLE
[hw/ip/dma] Fix inverted increment check in multi-chunk address update

### DIFF
--- a/hw/ip/dma/rtl/dma.sv
+++ b/hw/ip/dma/rtl/dma.sv
@@ -1180,11 +1180,11 @@ module dma
     update_dst_addr_reg = 1'b0;
     update_src_addr_reg = 1'b0;
     if (data_move_state && (ctrl_state_d == DmaIdle)) begin
-      if (reg2hw.src_config.increment.q == AddrNoIncrement &&
+      if (reg2hw.src_config.increment.q == AddrIncrement &&
           reg2hw.src_config.wrap.q == AddrNoWrapChunk) begin
         update_src_addr_reg = 1'b1;
       end
-      if (reg2hw.dst_config.increment.q == AddrNoIncrement &&
+      if (reg2hw.dst_config.increment.q == AddrIncrement &&
           reg2hw.dst_config.wrap.q == AddrNoWrapChunk) begin
         update_dst_addr_reg = 1'b1;
       end


### PR DESCRIPTION
# Description:
This PR fixes a logic bug in `dma.sv` where the address register update conditions for multi-chunk transfers were inverted.

# Motivation and Context:
While running DV tests on multi-chunk DMA transfers, we observed data mismatches specifically in chunk 2 when using non-canonical Fixed addressing mode (`INC=0, WRAP=0)`.

Upon investigation, the multi-chunk address register update logic in `dma.sv` had inverted conditions for the increment check. The inline comments accurately describe the intent (_"update when incrementing and not doing wrap-around"_), but the RTL checked for `== AddrNoIncrement`.

## Because of this bug:

* **Fixed Mode (**`INC=0, WRAP=0`**):** The DMA erroneously updates the base address register after chunk 1. This corrupts the register for subsequent chunks, causing them to read/write from the wrong address (`base_addr + chunk_data_size`) instead of remaining fixed.

* **Linear Mode (**`INC=1, WRAP=0`**):** The register incorrectly skips the update. However, this is functionally benign because an internal working address flop (`src_addr_q`) correctly carries the incremented address forward anyway.

# The Fix:
Changed the condition from `== AddrNoIncrement` to `!= AddrNoIncrement` for both `src_config` and `dst_config` checks. This ensures the address registers are only updated when genuinely incrementing, matching the original design intent.

# Testing:
Verified this fix internally using a DV test sequence exercising all 16 combinations of `src/dst` addressing mode bits (`increment`, `wrap`) across multi-chunk transfers. All combinations now pass cleanly.