### PR TITLE
[cov] Add coverage view for ROM_EXT imm section variants

### DIFF
--- a/sw/device/silicon_creator/rom_ext/imm_section/BUILD
+++ b/sw/device/silicon_creator/rom_ext/imm_section/BUILD
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@lowrisc_opentitan//rules/opentitan:transform.bzl", "obj_transform")
+load("//rules/coverage:view.bzl", "coverage_view_test")
 load("//rules/coverage:asm.bzl", "asm_library_with_coverage")
 load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU", "opentitan_binary")
 load("//rules:linker.bzl", "ld_library")
@@ -149,6 +150,14 @@ ld_library(
     )
     for variation_name, variation_deps in ROM_EXT_VARIATIONS.items()
     for slot in SLOTS
+]
+
+[
+    coverage_view_test(
+        name = "imm_section_{}_coverage_view".format(variation_name),
+        elf = "main_binaries_{}_slot_virtual".format(variation_name),
+    )
+    for variation_name in ROM_EXT_VARIATIONS.keys()
 ]
 
 [


### PR DESCRIPTION
This PR adds the coverage view targets for the ROM_EXT immutable section for analyzing the test coverage of this firmware.