### PR TITLE
[manuf,orchestrator] Allow tagging individual SKUs

### DIFF
--- a/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
@@ -49,6 +49,8 @@ EARLGREY_SKUS = {
         "spx_key": {},
         "signature_prefix": None,
         "orchestrator_cfg": "@//sw/host/provisioning/orchestrator/configs/skus:emulation_dice_cwt.hjson",
+        # FIXME (#29412) The ROM_EXT is bigger than 64k which breaks the perso binaries.
+        "tags": ["broken"],
     },
     # OTP Config: Emulation; DICE Certs: X.509; Additional Certs: TPM EK
     "emulation_tpm": {

--- a/sw/host/provisioning/orchestrator/tests/BUILD
+++ b/sw/host/provisioning/orchestrator/tests/BUILD
@@ -85,7 +85,6 @@ orchestrator_cw340_test_settings_transition(
             "FPGA": "{}".format(fpga),
         },
         tags = [
-            "broken",
             "changes_otp",
             "exclusive",
             "fpga",
@@ -114,7 +113,6 @@ orchestrator_cw340_test_settings_transition(
             "FPGA": "{}".format(fpga),
         },
         tags = [
-            "broken",
             "changes_otp",
             "exclusive",
             "fpga",
@@ -142,11 +140,10 @@ orchestrator_cw340_test_settings_transition(
             "FPGA": "{}".format(fpga),
         },
         tags = [
-            "broken",
             "changes_otp",
             "exclusive",
             "manuf",
-        ] + [fpga] + ([
+        ] + [fpga] + cfg.get("tags", []) + ([
             "manual",
         ] if cfg.get("offline", False) else []),
     )
@@ -173,11 +170,10 @@ orchestrator_cw340_test_settings_transition(
             "FPGA": "{}".format(fpga),
         },
         tags = [
-            "broken",
             "changes_otp",
             "exclusive",
             "manuf",
-        ] + [fpga] + ([
+        ] + [fpga] + cfg.get("tags", []) + ([
             "manual",
         ] if cfg.get("offline", False) else []),
     )


### PR DESCRIPTION
Some SKUs currently have a broken e2e orchestrator flow and the current approach of marking all tests as broken is too coarse. This commit introduces a per-sku, optional, "tags" attribute which is used to tag e2e tests. Only the CWT SKU (which is too large) is tagged as broken.

Related to #29412