### PR TITLE
[pentest] Create a boot fi test

### DIFF
--- a/sw/device/tests/penetrationtests/BUILD
+++ b/sw/device/tests/penetrationtests/BUILD
@@ -456,6 +456,14 @@ pentest_fi(
 )
 
 pentest_fi(
+    name = "fi_boot_python_test",
+    tags = [],
+    test_args = "",
+    test_harness = "//sw/host/penetrationtests/python/fi:fi_boot_python_test",
+    test_vectors = [],
+)
+
+pentest_fi(
     name = "fi_alert_python_test",
     tags = [
         "manual",

--- a/sw/device/tests/penetrationtests/firmware/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/BUILD
@@ -31,6 +31,7 @@ PENTEST_EXEC_ENVS = dicts.add(
 
 FIRMWARE_DEPS_FI = [
     "//sw/device/tests/penetrationtests/firmware/fi:alert_fi",
+    "//sw/device/tests/penetrationtests/firmware/fi:boot_fi",
     "//sw/device/tests/penetrationtests/firmware/fi:crypto_fi",
     "//sw/device/tests/penetrationtests/firmware/fi:lc_ctrl_fi",
     "//sw/device/tests/penetrationtests/firmware/fi:otp_fi",

--- a/sw/device/tests/penetrationtests/firmware/fi/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/fi/BUILD
@@ -280,6 +280,36 @@ cc_library(
 )
 
 cc_library(
+    name = "boot_fi",
+    srcs = ["boot_fi.c"],
+    hdrs = ["boot_fi.h"],
+    deps = [
+        "//hw/top:flash_ctrl_c_regs",
+        "//hw/top:rom_ctrl_c_regs",
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:csr",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:multibits",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:rom_ctrl",
+        "//sw/device/lib/dif:rv_core_ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib:epmp_state",
+        "//sw/device/silicon_creator/lib:manifest",
+        "//sw/device/silicon_creator/lib/boot_svc:boot_svc_next_boot_bl0_slot",
+        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        "//sw/device/silicon_creator/lib/drivers:rstmgr",
+        "//sw/device/silicon_creator/rom_ext:rom_ext_manifest",
+        "//sw/device/tests/penetrationtests/firmware/lib:pentest_lib",
+        "//sw/device/tests/penetrationtests/json:boot_fi_commands",
+    ],
+)
+
+cc_library(
     name = "alert_fi",
     srcs = ["alert_fi.c"],
     hdrs = ["alert_fi.h"],

--- a/sw/device/tests/penetrationtests/firmware/fi/boot_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/boot_fi.c
@@ -1,0 +1,288 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/tests/penetrationtests/firmware/fi/boot_fi.h"
+
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/csr.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/multibits.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_rom_ctrl.h"
+#include "sw/device/lib/dif/dif_rv_core_ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ottf_test_config.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/silicon_creator/lib/boot_log.h"
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_next_boot_bl0_slot.h"
+#include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
+#include "sw/device/silicon_creator/lib/epmp_state.h"
+#include "sw/device/silicon_creator/lib/manifest.h"
+#include "sw/device/silicon_creator/rom_ext/rom_ext_manifest.h"
+#include "sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h"
+#include "sw/device/tests/penetrationtests/json/boot_fi_commands.h"
+
+#include "hw/top/flash_ctrl_regs.h"
+#include "hw/top/rom_ctrl_regs.h"
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// Interface to Ibex.
+static dif_rv_core_ibex_t rv_core_ibex;
+
+static manifest_t *get_rom_ext_manifest_a(void) {
+  return (manifest_t *)TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR;
+}
+
+static manifest_t *get_rom_ext_manifest_b(void) {
+  return (manifest_t *)(TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR +
+                        (TOP_EARLGREY_FLASH_CTRL_MEM_SIZE_BYTES / 2));
+}
+
+static manifest_t *get_firmware_manifest_a(void) {
+  return (manifest_t *)(TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR +
+                        CHIP_ROM_EXT_SIZE_MAX);
+}
+
+static manifest_t *get_firmware_manifest_b(void) {
+  return (manifest_t *)(TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR +
+                        CHIP_ROM_EXT_SIZE_MAX +
+                        (TOP_EARLGREY_FLASH_CTRL_MEM_SIZE_BYTES / 2));
+}
+
+status_t handle_inactive_firmware_invalidation(ujson_t *uj) {
+  manifest_t *manifest;
+
+  boot_log_t boot_log = retention_sram_get()->creator.boot_log;
+
+  boot_fi_status_t uj_output;
+  uj_output.status = true;
+
+  // Get the inactive manifest.
+  if (boot_log.bl0_slot == kBootSlotA) {
+    manifest = get_firmware_manifest_b();
+  } else {
+    manifest = get_firmware_manifest_a();
+  }
+
+  flash_ctrl_data_default_perms_set(
+      (flash_ctrl_perms_t){.read = kMultiBitBool4True,
+                           .write = kMultiBitBool4True,
+                           .erase = kMultiBitBool4False});
+
+  uint32_t sig_offset = (uint32_t)&manifest->ecdsa_signature.r[0] -
+                        TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR;
+
+  uint32_t zero_val = 0;
+  rom_error_t err = flash_ctrl_data_write(sig_offset, 1, &zero_val);
+
+  if (err != kErrorOk) {
+    LOG_ERROR("Failed to corrupt ECDSA signature: 0x%08x", err);
+    uj_output.status = false;
+  }
+
+  const manifest_ext_spx_signature_t *spx_ext;
+  err = manifest_ext_get_spx_signature(manifest, &spx_ext);
+
+  if (err == kErrorOk && spx_ext != NULL) {
+    uint32_t spx_offset =
+        (uint32_t)&spx_ext->signature - TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR;
+
+    err = flash_ctrl_data_write(spx_offset, 1, &zero_val);
+
+    if (err != kErrorOk) {
+      LOG_ERROR("Failed to corrupt SPX signature: 0x%08x", err);
+      uj_output.status = false;
+    }
+  }
+
+  RESP_OK(ujson_serialize_boot_fi_status_t, uj, &uj_output);
+  return OK_STATUS();
+}
+
+status_t handle_next_boot_slot(ujson_t *uj) {
+  retention_sram_t *ret_sram = retention_sram_get();
+
+  boot_log_t boot_log = retention_sram_get()->creator.boot_log;
+  uint32_t target_slot =
+      (boot_log.primary_bl0_slot == kBootSlotA) ? kBootSlotB : kBootSlotA;
+
+  boot_svc_msg_t msg = {0};
+
+  boot_svc_next_boot_bl0_slot_req_init(
+      /*primary_slot=*/target_slot,
+      /*next_slot=*/kBootSlotUnspecified, &msg.next_boot_bl0_slot_req);
+
+  ret_sram->creator.boot_svc_msg = msg;
+
+  LOG_INFO("Boot services executed. Next boot will prioritize slot %c.",
+           (target_slot == kBootSlotA) ? 'A' : 'B');
+
+  // Reset to get the boot service to take effect.
+  rstmgr_reset();
+  return OK_STATUS();
+}
+
+status_t handle_boot_status(ujson_t *uj) {
+  LOG_INFO("===================================");
+  LOG_INFO("Component | Status  | Version      ");
+  LOG_INFO("-----------------------------------");
+
+  // ROM_EXT A
+  if (get_rom_ext_manifest_a()->identifier == CHIP_ROM_EXT_IDENTIFIER) {
+    LOG_INFO("ROM_EXT A | Present | %u.%u",
+             get_rom_ext_manifest_a()->version_major,
+             get_rom_ext_manifest_a()->version_minor);
+  } else {
+    LOG_ERROR("ROM_EXT A | Missing | N/A");
+  }
+
+  // ROM_EXT B
+  if (get_rom_ext_manifest_b()->identifier == CHIP_ROM_EXT_IDENTIFIER) {
+    LOG_INFO("ROM_EXT B | Present | %u.%u",
+             get_rom_ext_manifest_b()->version_major,
+             get_rom_ext_manifest_b()->version_minor);
+  } else {
+    LOG_ERROR("ROM_EXT B | Missing | N/A");
+  }
+
+  // BL0 A
+  if (get_firmware_manifest_a()->identifier == CHIP_BL0_IDENTIFIER) {
+    LOG_INFO("BL0 A     | Present | N/A");
+  } else {
+    LOG_ERROR("BL0 A     | Missing | N/A");
+  }
+
+  // BL0 B
+  if (get_firmware_manifest_b()->identifier == CHIP_BL0_IDENTIFIER) {
+    LOG_INFO("BL0 B     | Present | N/A");
+  } else {
+    LOG_ERROR("BL0 B     | Missing | N/A");
+  }
+
+  LOG_INFO("===================================");
+
+  boot_log_t boot_log = retention_sram_get()->creator.boot_log;
+  LOG_INFO("Booting from ROM_EXT slot %s and BL0 slot %s",
+           boot_log.rom_ext_slot == kBootSlotA ? "A" : "B",
+           boot_log.bl0_slot == kBootSlotA ? "A" : "B");
+  LOG_INFO("Primary slot for BL0 is %s",
+           boot_log.primary_bl0_slot == kBootSlotA ? "A" : "B");
+
+  return OK_STATUS();
+}
+
+status_t handle_epmp_status(ujson_t *uj) {
+  uint32_t pmpcfg[4];
+  CSR_READ(CSR_REG_PMPCFG0, &pmpcfg[0]);
+  CSR_READ(CSR_REG_PMPCFG1, &pmpcfg[1]);
+  CSR_READ(CSR_REG_PMPCFG2, &pmpcfg[2]);
+  CSR_READ(CSR_REG_PMPCFG3, &pmpcfg[3]);
+
+  uint32_t pmpaddr[16];
+  CSR_READ(CSR_REG_PMPADDR0, &pmpaddr[0]);
+  CSR_READ(CSR_REG_PMPADDR1, &pmpaddr[1]);
+  CSR_READ(CSR_REG_PMPADDR2, &pmpaddr[2]);
+  CSR_READ(CSR_REG_PMPADDR3, &pmpaddr[3]);
+  CSR_READ(CSR_REG_PMPADDR4, &pmpaddr[4]);
+  CSR_READ(CSR_REG_PMPADDR5, &pmpaddr[5]);
+  CSR_READ(CSR_REG_PMPADDR6, &pmpaddr[6]);
+  CSR_READ(CSR_REG_PMPADDR7, &pmpaddr[7]);
+  CSR_READ(CSR_REG_PMPADDR8, &pmpaddr[8]);
+  CSR_READ(CSR_REG_PMPADDR9, &pmpaddr[9]);
+  CSR_READ(CSR_REG_PMPADDR10, &pmpaddr[10]);
+  CSR_READ(CSR_REG_PMPADDR11, &pmpaddr[11]);
+  CSR_READ(CSR_REG_PMPADDR12, &pmpaddr[12]);
+  CSR_READ(CSR_REG_PMPADDR13, &pmpaddr[13]);
+  CSR_READ(CSR_REG_PMPADDR14, &pmpaddr[14]);
+  CSR_READ(CSR_REG_PMPADDR15, &pmpaddr[15]);
+
+  uint32_t mseccfg;
+  CSR_READ(CSR_REG_MSECCFG, &mseccfg);
+
+  LOG_INFO("=== Hardware ePMP State ===");
+
+  for (int i = 0; i < 16; ++i) {
+    uint32_t addr = pmpaddr[i];
+    uint32_t cfg_reg = pmpcfg[i / 4];
+    uint8_t cfg = (cfg_reg >> ((i % 4) * 8)) & 0xFF;
+
+    int r = (cfg & 0x01) != 0;
+    int w = (cfg & 0x02) != 0;
+    int x = (cfg & 0x04) != 0;
+    int l = (cfg & 0x80) != 0;
+
+    uint8_t mode_bits = (cfg >> 3) & 0x03;
+
+    if (mode_bits == 0) {
+      LOG_INFO("Entry %2d: OFF", i);
+    } else {
+      const char *mode_str;
+      switch (mode_bits) {
+        case 1:
+          mode_str = "TOR  ";
+          break;
+        case 2:
+          mode_str = "NA4  ";
+          break;
+        case 3:
+          mode_str = "NAPOT";
+          break;
+        default:
+          mode_str = "UNKN ";
+          break;
+      }
+
+      char perms[4] = {r ? 'R' : '-', w ? 'W' : '-', x ? 'X' : '-', '\0'};
+
+      LOG_INFO("Entry %2d: %s | Addr=0x%08x | Mode=%s | Locked=%d", i, perms,
+               addr, mode_str, l);
+    }
+  }
+  LOG_INFO("MSECCFG: 0x%08x", mseccfg);
+  LOG_INFO("===========================");
+
+  return OK_STATUS();
+}
+
+status_t handle_boot_fi_init(ujson_t *uj) {
+  // Configure the device.
+  pentest_setup_device(uj, true, false);
+
+  pentest_select_trigger_type(kPentestTriggerTypeSw);
+  pentest_init(kPentestTriggerSourceAes,
+               kPentestPeripheralIoDiv4 | kPentestPeripheralEdn |
+                   kPentestPeripheralCsrng | kPentestPeripheralEntropy |
+                   kPentestPeripheralKmac | kPentestPeripheralHmac);
+
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
+  return OK_STATUS();
+}
+
+status_t handle_boot_fi(ujson_t *uj) {
+  boot_fi_subcommand_t cmd;
+  TRY(ujson_deserialize_boot_fi_subcommand_t(uj, &cmd));
+  switch (cmd) {
+    case kBootFiSubcommandInit:
+      return handle_boot_fi_init(uj);
+    case kBootFiSubcommandInactiveFirmwareInvalidate:
+      return handle_inactive_firmware_invalidation(uj);
+    case kBootFiSubcommandNextSlot:
+      return handle_next_boot_slot(uj);
+    case kBootFiSubcommandBootStatus:
+      return handle_boot_status(uj);
+    case kBootFiSubcommandEpmpStatus:
+      return handle_epmp_status(uj);
+    default:
+      LOG_ERROR("Unrecognized Boot FI subcommand: %d", cmd);
+      return INVALID_ARGUMENT();
+  }
+  return OK_STATUS();
+}

--- a/sw/device/tests/penetrationtests/firmware/fi/boot_fi.h
+++ b/sw/device/tests/penetrationtests/firmware/fi/boot_fi.h
@@ -1,0 +1,61 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_FI_BOOT_FI_H_
+#define OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_FI_BOOT_FI_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+/**
+ * Invalidates the signatures of the inactive BL0 slot.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_inactive_firmware_invalidation(ujson_t *uj);
+
+/**
+ * Sets the next boot slot.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_next_boot_slot(ujson_t *uj);
+
+/**
+ * Get the status of the boot, namely which slots are filled.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_boot_status(ujson_t *uj);
+
+/**
+ * Get the status of the epmp, namely which entries are set.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_epmp_status(ujson_t *uj);
+
+/**
+ * Initializes the trigger and configures the device for the Boot FI test.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_boot_fi_init(ujson_t *uj);
+
+/**
+ * Boot FI command handler.
+ *
+ * Command handler for the Boot FI command.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_boot_fi(ujson_t *uj);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_FI_BOOT_FI_H_

--- a/sw/device/tests/penetrationtests/firmware/firmware_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware_fi.c
@@ -12,6 +12,7 @@
 
 // Include commands
 #include "sw/device/tests/penetrationtests/json/alert_fi_commands.h"
+#include "sw/device/tests/penetrationtests/json/boot_fi_commands.h"
 #include "sw/device/tests/penetrationtests/json/commands.h"
 #include "sw/device/tests/penetrationtests/json/crypto_fi_commands.h"
 #include "sw/device/tests/penetrationtests/json/lc_ctrl_fi_commands.h"
@@ -22,6 +23,7 @@
 
 // Include handlers
 #include "sw/device/tests/penetrationtests/firmware/fi/alert_fi.h"
+#include "sw/device/tests/penetrationtests/firmware/fi/boot_fi.h"
 #include "sw/device/tests/penetrationtests/firmware/fi/crypto_fi.h"
 #include "sw/device/tests/penetrationtests/firmware/fi/lc_ctrl_fi.h"
 #include "sw/device/tests/penetrationtests/firmware/fi/otp_fi.h"
@@ -60,6 +62,9 @@ status_t process_cmd(ujson_t *uj) {
         break;
       case kPenetrationtestCommandAlertFi:
         RESP_ERR(uj, handle_alert_fi(uj));
+        break;
+      case kPenetrationtestCommandBootFi:
+        RESP_ERR(uj, handle_boot_fi(uj));
         break;
       default:
         LOG_ERROR("Unrecognized command: %d", cmd);

--- a/sw/device/tests/penetrationtests/json/BUILD
+++ b/sw/device/tests/penetrationtests/json/BUILD
@@ -11,6 +11,7 @@ cc_library(
     deps = [
         ":aes_sca_commands",
         ":alert_fi_commands",
+        ":boot_fi_commands",
         ":crypto_fi_commands",
         ":cryptolib_fi_asym_commands",
         ":cryptolib_fi_sym_commands",
@@ -163,6 +164,13 @@ cc_library(
     name = "rom_fi_commands",
     srcs = ["rom_fi_commands.c"],
     hdrs = ["rom_fi_commands.h"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
+    name = "boot_fi_commands",
+    srcs = ["boot_fi_commands.c"],
+    hdrs = ["boot_fi_commands.h"],
     deps = ["//sw/device/lib/ujson"],
 )
 

--- a/sw/device/tests/penetrationtests/json/boot_fi_commands.c
+++ b/sw/device/tests/penetrationtests/json/boot_fi_commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "boot_fi_commands.h"

--- a/sw/device/tests/penetrationtests/json/boot_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/boot_fi_commands.h
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_JSON_BOOT_FI_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_JSON_BOOT_FI_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// clang-format off
+
+#define BOOTFI_SUBCOMMAND(_, value) \
+    value(_, Init) \
+    value(_, InactiveFirmwareInvalidate) \
+    value(_, NextSlot) \
+    value(_, BootStatus) \
+    value(_, EpmpStatus)
+C_ONLY(UJSON_SERDE_ENUM(BootFiSubcommand, boot_fi_subcommand_t, BOOTFI_SUBCOMMAND));
+RUST_ONLY(UJSON_SERDE_ENUM(BootFiSubcommand, boot_fi_subcommand_t, BOOTFI_SUBCOMMAND, RUST_DEFAULT_DERIVE, strum::EnumString));
+
+#define BOOTFI_STATUS(field, string) \
+    field(status, bool)
+UJSON_SERDE_STRUCT(BootFiStatus, boot_fi_status_t, BOOTFI_STATUS);
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_JSON_BOOT_FI_COMMANDS_H_

--- a/sw/device/tests/penetrationtests/json/commands.h
+++ b/sw/device/tests/penetrationtests/json/commands.h
@@ -34,7 +34,8 @@ extern "C" {
     value(_, RomFi) \
     value(_, Sha3Sca) \
     value(_, TriggerSca) \
-    value(_, AlertFi)
+    value(_, AlertFi) \
+    value(_, BootFi)
 UJSON_SERDE_ENUM(PenetrationtestCommand, penetrationtest_cmd_t, COMMAND);
 
 #define PENTEST_NUM_ENC(field, string) \

--- a/sw/device/tests/penetrationtests/pentest.bzl
+++ b/sw/device/tests/penetrationtests/pentest.bzl
@@ -39,6 +39,7 @@ FIRMWARE_DEPS_FI = [
     "//sw/device/tests/penetrationtests/firmware/fi:otp_fi",
     "//sw/device/tests/penetrationtests/firmware/fi:rng_fi",
     "//sw/device/tests/penetrationtests/firmware/fi:rom_fi",
+    "//sw/device/tests/penetrationtests/firmware/fi:boot_fi",
     "//sw/device/tests/penetrationtests/firmware/lib:extclk_sca_fi",
     "//sw/device/tests/penetrationtests/firmware/lib:pentest_lib",
     "//sw/device/lib/base:csr",

--- a/sw/host/penetrationtests/python/fi/BUILD
+++ b/sw/host/penetrationtests/python/fi/BUILD
@@ -98,6 +98,22 @@ py_binary(
 )
 
 py_binary(
+    name = "fi_boot_python_test",
+    testonly = True,
+    srcs = ["test_scripts/fi_boot_python_test.py"],
+    data = [
+        "//sw/host/opentitantool",
+    ],
+    deps = [
+        "//sw/host/penetrationtests/python/fi:fi_boot_commands",
+        "//sw/host/penetrationtests/python/fi:fi_boot_functions",
+        "//sw/host/penetrationtests/python/util:common_library",
+        "//sw/host/penetrationtests/python/util:targets",
+        "@rules_python//python/runfiles",
+    ],
+)
+
+py_binary(
     name = "fi_alert_python_test",
     testonly = True,
     srcs = ["test_scripts/fi_alert_python_test.py"],
@@ -395,6 +411,16 @@ py_library(
 )
 
 py_library(
+    name = "fi_boot_functions",
+    srcs = ["host_scripts/fi_boot_functions.py"],
+    deps = [
+        ":fi_boot_commands",
+        "//sw/host/penetrationtests/python/util:common_library",
+        "//sw/host/penetrationtests/python/util:targets",
+    ],
+)
+
+py_library(
     name = "fi_alert_functions",
     srcs = ["host_scripts/fi_alert_functions.py"],
     deps = [
@@ -467,6 +493,12 @@ py_library(
 py_library(
     name = "fi_rom_commands",
     srcs = ["communication/fi_rom_commands.py"],
+    deps = ["//sw/host/penetrationtests/python/util:common_library"],
+)
+
+py_library(
+    name = "fi_boot_commands",
+    srcs = ["communication/fi_boot_commands.py"],
     deps = ["//sw/host/penetrationtests/python/util:common_library"],
 )
 

--- a/sw/host/penetrationtests/python/fi/communication/fi_boot_commands.py
+++ b/sw/host/penetrationtests/python/fi/communication/fi_boot_commands.py
@@ -1,0 +1,92 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""Communication interface for OpenTitan Boot FI framework.
+
+Communication with OpenTitan happens over the uJSON command interface.
+"""
+import json
+import time
+from sw.host.penetrationtests.python.util import common_library
+
+
+class OTFIBoot:
+    def __init__(self, target) -> None:
+        self.target = target
+
+    def _ujson_boot_fi_cmd(self) -> None:
+        self.target.write(json.dumps("BootFi").encode("ascii"))
+        time.sleep(0.003)
+
+    def handle_inactive_firmware_invalidate(self) -> None:
+        """Invalidate the inactive firmware."""
+        # BootFi command.
+        self._ujson_boot_fi_cmd()
+        # Invalidate command.
+        self.target.write(json.dumps("InactiveFirmwareInvalidate").encode("ascii"))
+
+    def handle_next_slot(self) -> None:
+        """Sets the next slot as the primary."""
+        # BootFi command.
+        self._ujson_boot_fi_cmd()
+        # NextSlot command.
+        self.target.write(json.dumps("NextSlot").encode("ascii"))
+
+    def handle_boot_status(self) -> None:
+        """Get status of boot slots."""
+        # BootFi command.
+        self._ujson_boot_fi_cmd()
+        # BootStatus command.
+        self.target.write(json.dumps("BootStatus").encode("ascii"))
+
+    def handle_epmp_status(self) -> None:
+        """Get status of epmp entries."""
+        # BootFi command.
+        self._ujson_boot_fi_cmd()
+        # EpmpStatus command.
+        self.target.write(json.dumps("EpmpStatus").encode("ascii"))
+
+    def init(
+        self,
+        core_config: dict = common_library.default_core_config,
+        sensor_config: dict = common_library.default_sensor_config,
+        alert_config: dict = common_library.default_alert_config,
+    ) -> tuple:
+        """Initialize the Boot FI code on the chip.
+        Args:
+            cfg: Config dict containing the selected test.
+
+        Returns:
+            Device id
+            The owner info page
+            The boot log
+            The boot measurements
+            The testOS version
+        """
+
+        # BootFi command.
+        self._ujson_boot_fi_cmd()
+        # Init command.
+        self.target.write(json.dumps("Init").encode("ascii"))
+
+        # Write each configuration block to the target.
+        self.target.write(json.dumps(core_config).encode("ascii"))
+        self.target.write(json.dumps(sensor_config).encode("ascii"))
+        self.target.write(json.dumps(alert_config).encode("ascii"))
+
+        device_id = self.target.read_response()
+        sensors = self.target.read_response()
+        alerts = self.target.read_response()
+        owner_page = self.target.read_response()
+        boot_log = self.target.read_response()
+        boot_measurements = self.target.read_response()
+        version = self.target.read_response()
+        return (
+            device_id,
+            sensors,
+            alerts,
+            owner_page,
+            boot_log,
+            boot_measurements,
+            version,
+        )

--- a/sw/host/penetrationtests/python/fi/host_scripts/fi_boot_functions.py
+++ b/sw/host/penetrationtests/python/fi/host_scripts/fi_boot_functions.py
@@ -1,0 +1,60 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from sw.host.penetrationtests.python.fi.communication.fi_boot_commands import OTFIBoot
+from sw.host.penetrationtests.python.util import common_library
+
+
+def char_inactive_firmware_invalidate(target, reset=False):
+    bootfi = OTFIBoot(target)
+    if reset:
+        target.reset_target()
+        # Clear the output from the reset
+        target.dump_all()
+    # Initialize our chip and catch its output
+    device_id, sensors, alerts, owner_page, boot_log, boot_measurements, version = (
+        bootfi.init(alert_config=common_library.default_fpga_friendly_alert_config)
+    )
+    bootfi.handle_inactive_firmware_invalidate()
+    return target.read_response()
+
+
+def char_next_slot(target, reset=False):
+    bootfi = OTFIBoot(target)
+    if reset:
+        target.reset_target()
+        # Clear the output from the reset
+        target.dump_all()
+    # Initialize our chip and catch its output
+    device_id, sensors, alerts, owner_page, boot_log, boot_measurements, version = (
+        bootfi.init(alert_config=common_library.default_fpga_friendly_alert_config)
+    )
+    # Target resets after this
+    bootfi.handle_next_slot()
+
+
+def char_boot_status(target, reset=False):
+    bootfi = OTFIBoot(target)
+    if reset:
+        target.reset_target()
+        # Clear the output from the reset
+        target.dump_all()
+    # Initialize our chip and catch its output
+    device_id, sensors, alerts, owner_page, boot_log, boot_measurements, version = (
+        bootfi.init(alert_config=common_library.default_fpga_friendly_alert_config)
+    )
+    bootfi.handle_boot_status()
+
+
+def char_epmp_status(target, reset=False):
+    bootfi = OTFIBoot(target)
+    if reset:
+        target.reset_target()
+        # Clear the output from the reset
+        target.dump_all()
+    # Initialize our chip and catch its output
+    device_id, sensors, alerts, owner_page, boot_log, boot_measurements, version = (
+        bootfi.init(alert_config=common_library.default_fpga_friendly_alert_config)
+    )
+    bootfi.handle_epmp_status()

--- a/sw/host/penetrationtests/python/fi/test_scripts/fi_boot_python_test.py
+++ b/sw/host/penetrationtests/python/fi/test_scripts/fi_boot_python_test.py
@@ -1,0 +1,184 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from sw.host.penetrationtests.python.fi.host_scripts import fi_boot_functions
+from sw.host.penetrationtests.python.fi.communication.fi_boot_commands import OTFIBoot
+from python.runfiles import Runfiles
+from sw.host.penetrationtests.python.util import targets
+from sw.host.penetrationtests.python.util import common_library
+import json
+import unittest
+import argparse
+import sys
+
+ignored_keys_set = set([])
+opentitantool_path = ""
+iterations = 3
+
+target = None
+
+# Read in the extra arguments from the opentitan_test.
+parser = argparse.ArgumentParser()
+parser.add_argument("--bitstream", type=str)
+parser.add_argument("--bootstrap", type=str)
+
+args, config_args = parser.parse_known_args()
+
+BITSTREAM = args.bitstream
+BOOTSTRAP = args.bootstrap
+
+
+class BootFiTest(unittest.TestCase):
+    def test_init(self):
+        bootfi = OTFIBoot(target)
+        device_id, sensors, alerts, owner_page, boot_log, boot_measurements, version = bootfi.init(
+            alert_config=common_library.default_fpga_friendly_alert_config
+        )
+        device_id_json = json.loads(device_id)
+        sensors_json = json.loads(sensors)
+        alerts_json = json.loads(alerts)
+        owner_page_json = json.loads(owner_page)
+        boot_log_json = json.loads(boot_log)
+        boot_measurements_json = json.loads(boot_measurements)
+
+        expected_device_id_keys = {
+            "device_id",
+            "rom_digest",
+            "icache_en",
+            "dummy_instr_en",
+            "clock_jitter_locked",
+            "clock_jitter_en",
+            "sram_main_readback_locked",
+            "sram_main_readback_en",
+            "sram_ret_readback_locked",
+            "sram_ret_readback_en",
+            "data_ind_timing_en",
+        }
+        actual_device_id_keys = set(device_id_json.keys())
+
+        self.assertEqual(
+            expected_device_id_keys,
+            actual_device_id_keys,
+            "device_id keys do not match",
+        )
+
+        expected_sensors_keys = {"sensor_ctrl_en", "sensor_ctrl_fatal"}
+        actual_sensors_keys = set(sensors_json.keys())
+
+        self.assertEqual(expected_sensors_keys, actual_sensors_keys, "sensor keys do not match")
+
+        expected_alerts_keys = {
+            "alert_classes",
+            "loc_alert_classes",
+            "enabled_alerts",
+            "enabled_loc_alerts",
+            "enabled_classes",
+            "accumulation_thresholds",
+            "duration_cycles",
+            "escalation_signals_en",
+            "escalation_signals_map",
+        }
+        actual_alerts_keys = set(alerts_json.keys())
+
+        self.assertEqual(expected_alerts_keys, actual_alerts_keys, "alert keys do not match")
+
+        expected_owner_page_keys = {
+            "config_version",
+            "sram_exec_mode",
+            "ownership_key_alg",
+            "update_mode",
+            "min_security_version_bl0",
+            "lock_constraint",
+        }
+        actual_owner_page_keys = set(owner_page_json.keys())
+
+        self.assertEqual(
+            expected_owner_page_keys,
+            actual_owner_page_keys,
+            "owner_page keys do not match",
+        )
+
+        expected_boot_log_keys = {
+            "digest",
+            "identifier",
+            "scm_revision_low",
+            "scm_revision_high",
+            "rom_ext_slot",
+            "rom_ext_major",
+            "rom_ext_minor",
+            "rom_ext_size",
+            "bl0_slot",
+            "ownership_state",
+            "ownership_transfers",
+            "rom_ext_min_sec_ver",
+            "bl0_min_sec_ver",
+            "primary_bl0_slot",
+            "retention_ram_initialized",
+        }
+        actual_boot_log_keys = set(boot_log_json.keys())
+
+        self.assertEqual(expected_boot_log_keys, actual_boot_log_keys, "boot_log keys do not match")
+
+        expected_boot_measurements_keys = {"bl0", "rom_ext"}
+        actual_boot_measurements_keys = set(boot_measurements_json.keys())
+
+        self.assertEqual(
+            expected_boot_measurements_keys,
+            actual_boot_measurements_keys,
+            "boot_measurements keys do not match",
+        )
+
+        self.assertIn("PENTEST", version)
+
+    def test_char_inactive_firmware_invalidate(self):
+        actual_result = fi_boot_functions.char_inactive_firmware_invalidate(target)
+        actual_result_json = json.loads(actual_result)
+        assert actual_result_json["status"], "Firmware invalidate failed"
+
+    @unittest.skip
+    def test_char_next_slot(self):
+        # The target simply resets and sets the next slot here, nothing to test
+        fi_boot_functions.char_next_slot(target)
+
+    @unittest.skip
+    def test_char_boot_status(self):
+        fi_boot_functions.char_boot_status(target)
+        target.print_all()
+
+    @unittest.skip
+    def test_char_epmp_status(self):
+        fi_boot_functions.char_epmp_status(target)
+        target.print_all()
+
+
+if __name__ == "__main__":
+    r = Runfiles.Create()
+    # Get the opentitantool path.
+    opentitantool_path = r.Rlocation("lowrisc_opentitan/sw/host/opentitantool/opentitantool")
+    # Program the bitstream for FPGAs.
+    bitstream_path = None
+    if BITSTREAM:
+        bitstream_path = r.Rlocation("lowrisc_opentitan/" + BITSTREAM)
+    # Get the firmware path.
+    firmware_path = r.Rlocation("lowrisc_opentitan/" + BOOTSTRAP)
+
+    if "fpga" in BOOTSTRAP:
+        target_type = "fpga"
+    else:
+        target_type = "chip"
+
+    target_cfg = targets.TargetConfig(
+        target_type=target_type,
+        interface_type="hyperdebug",
+        fw_bin=firmware_path,
+        opentitantool=opentitantool_path,
+        bitstream=bitstream_path,
+        tool_args=config_args,
+    )
+
+    target = targets.Target(target_cfg)
+
+    target.initialize_target()
+
+    unittest.main(argv=[sys.argv[0]])


### PR DESCRIPTION
Create a part in the pentest framework to help testing the ROM/ROM_EXT. To that end, there is a status check on the ePMP and which slots were booted.
Then, create a function to invalidate the inactive slot. This is mainly useful when there is no bootstrap and only rescue functionality where the pentest firmware can ensure it is the only valid firmware in the chip.
Also create a function to switch the primary boot slot.


(cherry picked from commit 77f1f025bbae7beec5fe65929f06e8349890c993)