### PR TITLE
[pentest] Fix boot_fi sending config twice

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/fi/boot_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/boot_fi.c
@@ -261,9 +261,6 @@ status_t handle_boot_fi_init(ujson_t *uj) {
       mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
       &rv_core_ibex));
 
-  // Read different SKU config fields and return to host.
-  TRY(pentest_send_sku_config(uj));
-
   return OK_STATUS();
 }
 


### PR DESCRIPTION
Boot_fi was sending its config back twice.