### PR TITLE
[crypto] RSA keygen: Harden Miller-Rabin test against skips

### DIFF
--- a/sw/device/lib/crypto/impl/rsa/run_rsa.c
+++ b/sw/device/lib/crypto/impl/rsa/run_rsa.c
@@ -22,11 +22,20 @@ OTBN_DECLARE_SYMBOL_ADDR(run_rsa, rsa_d0);  // Private exponent d0.
 OTBN_DECLARE_SYMBOL_ADDR(run_rsa, rsa_d1);  // Private exponent d1.
 OTBN_DECLARE_SYMBOL_ADDR(run_rsa, inout);   // Input/output buffer.
 
+// Miller-Rabin iteration counter for p.
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa, mr_iter_p);
+// Miller-Rabin iteration counter for q.
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa, mr_iter_q);
+
 static const otbn_addr_t kOtbnVarRsaMode = OTBN_ADDR_T_INIT(run_rsa, mode);
 static const otbn_addr_t kOtbnVarRsaN = OTBN_ADDR_T_INIT(run_rsa, rsa_n);
 static const otbn_addr_t kOtbnVarRsaD0 = OTBN_ADDR_T_INIT(run_rsa, rsa_d0);
 static const otbn_addr_t kOtbnVarRsaD1 = OTBN_ADDR_T_INIT(run_rsa, rsa_d1);
 static const otbn_addr_t kOtbnVarRsaInOut = OTBN_ADDR_T_INIT(run_rsa, inout);
+static const otbn_addr_t kOtbnVarRsaMrIterP =
+    OTBN_ADDR_T_INIT(run_rsa, mr_iter_p);
+static const otbn_addr_t kOtbnVarRsaMrIterQ =
+    OTBN_ADDR_T_INIT(run_rsa, mr_iter_q);
 
 // Declare mode constants.
 OTBN_DECLARE_SYMBOL_ADDR(run_rsa, MODE_RSA_2048_KEYGEN);
@@ -64,7 +73,17 @@ enum {
    * This exponent is 2^16 + 1, and called "F4" because it's the fourth Fermat
    * number.
    */
-  kExponentF4 = 65537
+  kExponentF4 = 65537,
+  /**
+   * Number of expected Miller-Rabin iterations.
+   *
+   * To have strong guarantees on the generated RSA primes, a sufficient number
+   * of iterations in the Miller-Rabin primality test have to be computed.
+   *
+   * This value is a runtime constant in the OTBN app and is in accordance
+   * with Table B.1 of FIPS 186-5.
+   */
+  kMrIters = 4
 };
 
 status_t rsa_modexp_wait(size_t *num_words) {
@@ -292,6 +311,27 @@ static status_t keygen_finalize(uint32_t exp_mode, size_t num_words,
     return OTCRYPTO_FATAL_ERR;
   }
   HARDENED_CHECK_EQ(launder32(act_mode), exp_mode);
+
+  // Make sure that an exact amount of Miller-Rabin iterations have been
+  // performed for both primes p and q.
+  uint32_t mr_iters = 0;
+
+  // Prime p.
+  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(1, kOtbnVarRsaMrIterP, &mr_iters));
+  if (mr_iters != kMrIters) {
+    HARDENED_TRY(otbn_dmem_sec_wipe());
+    return OTCRYPTO_FATAL_ERR;
+  }
+  HARDENED_CHECK_EQ(launder32(mr_iters), kMrIters);
+
+  // Prime q.
+  mr_iters = 0;
+  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(1, kOtbnVarRsaMrIterQ, &mr_iters));
+  if (mr_iters != kMrIters) {
+    HARDENED_TRY(otbn_dmem_sec_wipe());
+    return OTCRYPTO_FATAL_ERR;
+  }
+  HARDENED_CHECK_EQ(launder32(mr_iters), kMrIters);
 
   // Read the public modulus (n) from OTBN dmem.
   HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(num_words, kOtbnVarRsaN, n));

--- a/sw/otbn/crypto/rsa_keygen.s
+++ b/sw/otbn/crypto/rsa_keygen.s
@@ -53,7 +53,7 @@
  */
 rsa_keygen:
   # Temporarily store the limb count in DMEM.
-  la x16, buf7
+  la x16, nlimbs_tmp
   sw x30, 0(x16)
 
   # Generate the RSA primes.
@@ -73,7 +73,7 @@ rsa_keygen:
   jal x1, gen_prime
 
   # Restore limb count.
-  la x16, buf7
+  la x16, nlimbs_tmp
   lw x30, 0(x16)
 
   jal x1, gen_d
@@ -341,8 +341,15 @@ _gen_p_body:
   jal x1, fermat_test
   beq x2, x0, _gen_p_loop
 
+  # Set up Miller-Rabin loop counter.
+  addi x28, x0, 0
+
   jal x1, miller_rabin_test
   beq x2, x0, _gen_p_loop
+
+  # Store the number of executed Miller-Rabin rounds in the scratchpad.
+  la x29, mr_iter_p_tmp
+  sw x28, 0(x29)
 
   # Move the generate prime into dmem[rsa_p].
   li x8, 2
@@ -408,8 +415,15 @@ _gen_q_body_inner:
   jal x1, fermat_test
   beq x2, x0, _gen_q_loop
 
+  # Set up Miller-Rabin loop counter.
+  addi x28, x0, 0
+
   jal x1, miller_rabin_test
   beq x2, x0, _gen_q_loop
+
+  # Store the number of executed Miller-Rabin rounds in the scratchpad.
+  la x29, mr_iter_q_tmp
+  sw x28, 0(x29)
 
   # Move the generate prime into dmem[rsa_q].
   li x8, 2

--- a/sw/otbn/crypto/rsa_primality.s
+++ b/sw/otbn/crypto/rsa_primality.s
@@ -171,7 +171,7 @@ miller_rabin_test:
   bn.sid  x8,  0(x14++)
 
   # Fix the number of iterations to 4 in accordance with Table B.1 of
-  # FIPS 186-5 to reach an error probability of less than 2^100 for
+  # FIPS 186-5 to reach an error probability of less than 2^-100 for
   # RSA-{2048,3072,4096}.
   loopi 4, 33
     # Generate a witness w as the exponentation base point.
@@ -216,7 +216,9 @@ miller_rabin_test:
       bn.lid  x8, 0(x14)
       bn.xor  w2, w2, w3
       bn.sid  x8, 0(x14++)
-    nop
+    # Increment the iteration counter. To be written to DMEM after the
+    # Miller-Rabin test to make sure all rounds have been executed.
+    addi x28, x28, 1
 
 _miller_rabin_epilogue:
   ret

--- a/sw/otbn/crypto/run_rsa.s
+++ b/sw/otbn/crypto/run_rsa.s
@@ -244,15 +244,33 @@ rsa_4096_modexp_f4:
  * @param[out] dmem[d1]: d1, second share of secret exponent
  */
 do_keygen:
-  # Save mode indicator in register.
+  # Save mode indicator in the scratchpad.
   la x16, mode
-  lw x28, 0(x16)
+  la x17, mode_tmp
+  lw x18, 0(x16)
+  sw x18, 0(x17)
 
   jal x1, rsa_keygen
 
-  # Restore mode indicator in DMEM.
+  # Restore mode indicator from the scratchpad.
   la x16, mode
-  sw x28, 0(x16)
+  la x17, mode_tmp
+  lw x18, 0(x17)
+  sw x18, 0(x16)
+
+  # Move the Miller-Rabin counter from the scratchpad.
+
+  # Prime p.
+  la x16, mr_iter_p
+  la x17, mr_iter_p_tmp
+  lw x18, 0(x17)
+  sw x18, 0(x16)
+
+  # Prime q.
+  la x16, mr_iter_q
+  la x17, mr_iter_q_tmp
+  lw x18, 0(x17)
+  sw x18, 0(x16)
 
   ecall
 

--- a/sw/otbn/crypto/run_rsa_mem.s
+++ b/sw/otbn/crypto/run_rsa_mem.s
@@ -75,7 +75,7 @@ mode:
 rsa_g:
 .zero 256
 
-.globl r2, rsa_h
+.globl r2, rsa_h, mr_iter_p, mr_iter_q
 .balign 32
 /*----------------+----------+----------*
  |                |          |          |
@@ -87,7 +87,11 @@ rsa_g:
  |                |          |          |
  *----------------+----------+----------*/
 r2:
-.zero 256
+mr_iter_p:
+.zero 4
+mr_iter_q:
+.zero 4
+.zero 248
 rsa_h:
 .zero 256
 
@@ -101,21 +105,15 @@ RR:
 
 /* Scratchpad working buffer. */
 .balign 32
-.globl work_buf, buf0, buf1, buf2, buf3, buf4, buf5, buf6, buf7
+.globl work_buf, nlimbs_tmp, mode_tmp, mr_iter_p_tmp, mr_iter_q_tmp
 work_buf:
-buf0:
-.zero 64
-buf1:
-.zero 64
-buf2:
-.zero 64
-buf3:
-.zero 64
-buf4:
-.zero 64
-buf5:
-.zero 64
-buf6:
-.zero 64
-buf7:
-.zero 64
+.zero 448
+nlimbs_tmp:
+.zero 4
+mode_tmp:
+.zero 4
+mr_iter_p_tmp:
+.zero 4
+mr_iter_q_tmp:
+.zero 4
+.zero 48


### PR DESCRIPTION
In the case the Miller-Rabin primality is skipped, the RSA key generation algorithm produces a composite number instead of a prime which is synonymous with a break of the cryptosystem. In this commit, the number of Miller-Rabin iterations per prime number are counted and ultimately checked by the host CPU making sure that a correct amount of iterations has been executed.