### PR TITLE
[otbn,sim] Enable register dump of bazel test

### DIFF
--- a/hw/ip/otbn/util/otbn_sim_test.py
+++ b/hw/ip/otbn/util/otbn_sim_test.py
@@ -79,6 +79,7 @@ def main() -> int:
                         help='Path to a testcase hjson file.')
     parser.add_argument('elf',
                         help='Path to the .elf file for the OTBN program.')
+    parser.add_argument('--dump-regs', action='store_true')
     parser.add_argument('-v', '--verbose', action='store_true')
     args = parser.parse_args()
 
@@ -119,6 +120,10 @@ def main() -> int:
         dmem_file.seek(0)
         actual_dmem = parse_actual_dmem(dmem_file.read())
         actual_regs = parse_reg_dump(regs_file.read().decode('utf-8'))
+
+        if args.dump_regs:
+            regs_file.seek(0)
+            print(regs_file.read().decode('utf-8'))
 
     expected_err = 0
     expected_regs = {}

--- a/rules/otbn.bzl
+++ b/rules/otbn.bzl
@@ -174,7 +174,7 @@ def _run_sim_test(ctx, exp, dexp, testcase = None, additional_srcs = []):
     simulator = ctx.executable._simulator
     ctx.actions.write(
         output = ctx.outputs.executable,
-        content = "{} {} -- {} {}".format(sim_test_wrapper.short_path, exp_content, simulator.short_path, elf.short_path),
+        content = "{} {} {} -- {} {}".format(sim_test_wrapper.short_path, exp_content, '"$@"', simulator.short_path, elf.short_path),
     )
 
     # Runfiles include sources, the .elf file, the simulator and test wrapper


### PR DESCRIPTION
This allows to dump the register content at the end of a simulation when an OTBN test is started with Bazel.

Credits go to @andrea-caforio .