### PR TITLE
[manuf] Permit manuf payloads without owner_fw

### DIFF
--- a/rules/opentitan/util.bzl
+++ b/rules/opentitan/util.bzl
@@ -119,3 +119,13 @@ def recursive_format(spec, variables, max_depth = 10):
         fail("RecursionError: the spec cannot be fully evaluated after ", max_depth, " levels: ", spec)
 
     return spec.format()
+
+def dict_from_pairs(pairs):
+    """Construct a dict from a list of (k, v) pairs.
+
+    Args:
+      pairs: A list of (k, v) tuples.  A pair is skipped if the key is None.
+    Returns
+      A dict
+    """
+    return {k: v for (k, v) in pairs if k}

--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -16,6 +16,10 @@ load(
     "qemu_params",
 )
 load(
+    "//rules/opentitan:util.bzl",
+    "dict_from_pairs",
+)
+load(
     "//sw/device/silicon_creator/manuf/base:provisioning_inputs.bzl",
     "EARLGREY_SKUS",
     "disqualified_for_signing",
@@ -404,9 +408,16 @@ manifest(d = {
                 "perso_bin",
                 ":ft_personalize_{}".format(sku),
             ): SLOTS["a"],
-            config["rom_ext"]: SLOTS["b"],
-            config["owner_fw"]: OWNER_SLOTS["b"],
-        },
+        } | dict_from_pairs([
+            (
+                config["rom_ext"],
+                SLOTS["b"],
+            ),
+            (
+                config["owner_fw"],
+                OWNER_SLOTS["b"],
+            ),
+        ]),
         exec_env = [
             "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys",
             "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys",


### PR DESCRIPTION
Allow the `owner_fw` to be `None` when building a manufacturing payload.