### PR TITLE
[chip,dv] Consistency (protected) in some chip-level code

### DIFF
--- a/hw/top_darjeeling/dv/env/chip_scoreboard.sv
+++ b/hw/top_darjeeling/dv/env/chip_scoreboard.sv
@@ -75,7 +75,9 @@ class chip_scoreboard #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_b
     // post test checks - ensure that all local fifos and queues are empty
   endfunction
 
-  virtual function bit predict_tl_err(tl_seq_item item, tl_channels_e channel, string ral_name);
+  virtual protected function bit predict_tl_err(tl_seq_item item,
+                                                tl_channels_e channel,
+                                                string ral_name);
     uvm_reg_addr_t addr = cfg.ral_models[ral_name].get_normalized_addr(item.a_addr);
     uvm_mem mem = cfg.ral_models[ral_name].default_map.get_mem_by_offset(addr);
 

--- a/hw/top_earlgrey/dv/env/chip_scoreboard.sv
+++ b/hw/top_earlgrey/dv/env/chip_scoreboard.sv
@@ -75,7 +75,9 @@ class chip_scoreboard #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_b
     // post test checks - ensure that all local fifos and queues are empty
   endfunction
 
-  virtual function bit predict_tl_err(tl_seq_item item, tl_channels_e channel, string ral_name);
+  virtual protected function bit predict_tl_err(tl_seq_item item,
+                                                tl_channels_e channel,
+                                                string ral_name);
     uvm_reg_addr_t addr = cfg.ral_models[ral_name].get_normalized_addr(item.a_addr);
     uvm_mem mem = cfg.ral_models[ral_name].default_map.get_mem_by_offset(addr);
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -62,7 +62,7 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
 
   // Wait for cpu fetch enable before primary sequence start
   // in stub cpu test.
-  virtual task run_common_vseq_wrapper(int num_times = 1);
+  virtual protected task run_common_vseq_wrapper(int num_times = 1);
     wait(cfg.chip_vif.pwrmgr_cpu_fetch_en == 1);
     super.run_common_vseq_wrapper(num_times);
   endtask


### PR DESCRIPTION
For both top-levels, chip_scoreboard::predict_tl_err needs a "protected" keyword. For top_earlgrey, the same is true for chip_common_vseq.

The cip_base_scoreboard::predict_tl_err function has been protected since ff023656fdf and it looks like I didn't notice it was implemented in the two toplevels' chip_scoreboard.

Similarly, cip_base_vseq::run_common_vseq_wrapper gained a protected keyword in 83d178b949d and (again) I didn't notice this implementation.