### PR TITLE
[dv,chip] Remove dead variable from chip_env_cfg

### DIFF
--- a/hw/top_darjeeling/dv/env/chip_env_cfg.sv
+++ b/hw/top_darjeeling/dv/env/chip_env_cfg.sv
@@ -9,7 +9,6 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // Testbench settings
   bit                 en_uart_logger;
   uart_agent_pkg::baud_rate_e uart_baud_rate = uart_agent_pkg::BaudRate1Mbps;
-  bit                 use_gpio_for_sw_test_status;
 
   // Write logs from sw test to separate log file as well, in addition to the simulator log file.
   bit                 write_sw_logs_to_file = 1'b1;

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -9,7 +9,6 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // Testbench settings
   bit                 en_uart_logger;
   uart_agent_pkg::baud_rate_e uart_baud_rate = uart_agent_pkg::BaudRate1Mbps;
-  bit                 use_gpio_for_sw_test_status;
 
   // Write logs from sw test to separate log file as well, in addition to the simulator log file.
   bit                 write_sw_logs_to_file = 1'b1;


### PR DESCRIPTION
This was added in 2020 by commit 97fe0d8, but the commit doesn't seem to have actually done anything but declare the variable. And no-one seems to have noticed it since... Drop it.