### PR TITLE
[chip,dv] Get rid of chip_env_cfg::use_jtag_dmi

### DIFF
--- a/hw/top_darjeeling/dv/env/chip_env.sv
+++ b/hw/top_darjeeling/dv/env/chip_env.sv
@@ -22,6 +22,8 @@ class chip_env extends cip_base_env #(
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
+    bit use_tl_agent_dmi;
+
     super.build_phase(phase);
     // configure the cpu d tl agent
     // get the vifs from config db
@@ -34,9 +36,10 @@ class chip_env extends cip_base_env #(
 
     // Set DMI tl_agent's is_active bit only when in stub_cpu mode *and* the
     // JTAG DMI agent is not in use.
-    cfg.m_tl_agent_cfgs["chip_soc_dbg_reg_block"].is_active =
-      !cfg.use_jtag_dmi && cfg.chip_vif.stub_cpu;
-    cfg.chip_vif.configure_jtag_dmi(cfg.use_jtag_dmi || !cfg.chip_vif.stub_cpu);
+    use_tl_agent_dmi = cfg.chip_vif.stub_cpu && !cfg.m_jtag_riscv_agent_cfg.use_jtag_dmi;
+
+    cfg.m_tl_agent_cfgs["chip_soc_dbg_reg_block"].is_active = use_tl_agent_dmi;
+    cfg.chip_vif.configure_jtag_dmi(!use_tl_agent_dmi);
 
     if (cfg.use_mbx_if || !cfg.chip_vif.stub_cpu) cfg.chip_vif.connect_mbx_if();
 

--- a/hw/top_darjeeling/dv/env/chip_env_cfg.sv
+++ b/hw/top_darjeeling/dv/env/chip_env_cfg.sv
@@ -24,10 +24,6 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // Memory backdoor util instances for all memory instances in the chip.
   mem_bkdr_util mem_bkdr_util_h[chip_mem_e];
 
-  // If this is true, the environment will connect DMI over JTAG. If this is enabled through a
-  // plusarg, the test calls set_use_jtag_dmi() to set this bit as part of the build phase.
-  bit use_jtag_dmi = 0;
-
   // Creator SW config region in OTP that holds the AST config data. Randomized for open source.
   //
   // These are written via backdoor to the OTP region that starts at
@@ -231,15 +227,13 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     num_otbn_dmem_tiles = 1;
   endfunction
 
-  // Set the use_jtag_dmi field to be true, which will cause the chip environment to run a DMI agent
-  // over a JTAG connection.
+  // Configure the environment to run a DMI agent over a JTAG connection.
   //
-  // This should be called as part of build_phase in the test, before build_phase for the
-  // environment runs.
+  // To enable DMI over JTAG, the testbench or test must call this function before the chip
+  // environment's build_phase.
   function void set_use_jtag_dmi();
-    if (this.use_jtag_dmi) return;
+    if (m_jtag_riscv_agent_cfg.use_jtag_dmi) return;
 
-    this.use_jtag_dmi = 1;
     m_jtag_riscv_agent_cfg.use_jtag_dmi = 1;
 
     // Both, the regs only supports 1 outstanding.

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
@@ -26,7 +26,7 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
   task post_start();
     super.post_start();
 
-    if (cfg.use_jtag_dmi == 0) begin
+    if (cfg.m_jtag_riscv_agent_cfg.use_jtag_dmi == 0) begin
       // Random CSR rw might trigger alert. Some alerts will continuously be triggered until reset
       // applied, which will cause alert_monitor phase_ready_to_end timeout.
       apply_reset();
@@ -50,7 +50,7 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
     super.dut_init(reset_kind);
     // Program the AST with the configuration data loaded in OTP creator SW config region.
     `uvm_info(`gfn, "Perform AST configuration", UVM_MEDIUM)
-    if (cfg.use_jtag_dmi == 0) do_ast_cfg();
+    if (cfg.m_jtag_riscv_agent_cfg.use_jtag_dmi == 0) do_ast_cfg();
   endtask
 
   // Write AST registers with the configuration data backdoor loaded into OTP creator SW cfg region.

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -30,10 +30,6 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // Memory backdoor util instances for all memory instances in the chip.
   mem_bkdr_util mem_bkdr_util_h[chip_mem_e];
 
-  // If this is true, the environment will connect DMI over JTAG. If this is enabled through a
-  // plusarg, the test calls set_use_jtag_dmi() to set this bit as part of the build phase.
-  bit use_jtag_dmi = 0;
-
   // Creator SW config region in OTP that holds the AST config data. Randomized for open source.
   //
   // These are written via backdoor to the OTP region that starts at
@@ -239,15 +235,13 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     num_otbn_dmem_tiles = 1;
   endfunction
 
-  // Set the use_jtag_dmi field to be true, which will cause the chip environment to run a DMI agent
-  // over a JTAG connection.
+  // Configure the environment to run a DMI agent over a JTAG connection.
   //
-  // This should be called as part of build_phase in the test, before build_phase for the
-  // environment runs.
+  // To enable DMI over JTAG, the testbench or test must call this function before the chip
+  // environment's build_phase.
   function void set_use_jtag_dmi();
-    if (this.use_jtag_dmi) return;
+    if (m_jtag_riscv_agent_cfg.use_jtag_dmi) return;
 
-    this.use_jtag_dmi = 1;
     m_jtag_riscv_agent_cfg.use_jtag_dmi = 1;
 
     // Both, the regs only supports 1 outstanding.

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
@@ -20,7 +20,7 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
     foreach (cfg.m_uart_agent_cfgs[i]) cfg.m_uart_agent_cfgs[i].en_tx_monitor = 0;
 
     // Select/Deselect JTAG interface.
-    if (cfg.jtag_riscv_map != null || cfg.use_jtag_dmi == 1) begin
+    if (cfg.jtag_riscv_map != null || cfg.m_jtag_riscv_agent_cfg.use_jtag_dmi == 1) begin
       `DV_GET_ENUM_PLUSARG(chip_common_pkg::chip_jtag_tap_e, cfg.select_jtag, select_jtag)
       cfg.chip_vif.tap_straps_if.drive(cfg.select_jtag);
     end
@@ -31,7 +31,7 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
   task post_start();
     super.post_start();
 
-    if (cfg.use_jtag_dmi == 0) begin
+    if (cfg.m_jtag_riscv_agent_cfg.use_jtag_dmi == 0) begin
       // Random CSR rw might trigger alert. Some alerts will continuously be triggered until reset
       // applied, which will cause alert_monitor phase_ready_to_end timeout.
       apply_reset();
@@ -62,7 +62,7 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
     super.dut_init(reset_kind);
     // Program the AST with the configuration data loaded in OTP creator SW config region.
     `uvm_info(`gfn, "Perform AST configuration", UVM_MEDIUM)
-    if (cfg.use_jtag_dmi == 0) do_ast_cfg();
+    if (cfg.m_jtag_riscv_agent_cfg.use_jtag_dmi == 0) do_ast_cfg();
   endtask
 
   // Write AST registers with the configuration data backdoor loaded into OTP creator SW cfg region.


### PR DESCRIPTION
This was just a wrapper around an equivalent flag in m_jtag_riscv_agent_cfg. No need to duplicate it.