### PR TITLE
[chip,dv] Get rid of chip_env_cfg::en_uart_logger

### DIFF
--- a/hw/top_darjeeling/dv/env/chip_env_cfg.sv
+++ b/hw/top_darjeeling/dv/env/chip_env_cfg.sv
@@ -7,7 +7,6 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   );
 
   // Testbench settings
-  bit                 en_uart_logger;
   uart_agent_pkg::baud_rate_e uart_baud_rate = uart_agent_pkg::BaudRate1Mbps;
   bit                 use_gpio_for_sw_test_status;
 

--- a/hw/top_darjeeling/dv/tests/chip_base_test.sv
+++ b/hw/top_darjeeling/dv/tests/chip_base_test.sv
@@ -35,11 +35,10 @@ class chip_base_test extends cip_base_test #(
     // The following plusargs are only valid for SW based tests (i.e., no stubbed CPU).
     // Knob to configure writing sw logs to a separate file (enabled by default).
     void'($value$plusargs("write_sw_logs_to_file=%0b", cfg.write_sw_logs_to_file));
+    cfg.m_uart_agent_cfgs[0].write_logs_to_file = cfg.write_sw_logs_to_file;
 
     // Knob to enable logging over UART (disabled by default).
-    void'($value$plusargs("en_uart_logger=%0b", cfg.en_uart_logger));
-    cfg.m_uart_agent_cfgs[0].en_logger = cfg.en_uart_logger;
-    cfg.m_uart_agent_cfgs[0].write_logs_to_file = cfg.write_sw_logs_to_file;
+    void'($value$plusargs("en_uart_logger=%0b", cfg.m_uart_agent_cfgs[0].en_logger));
 
     // Knob to set the sw_test_timeout_ns (set to 12ms by default).
     void'($value$plusargs("sw_test_timeout_ns=%0d", cfg.sw_test_timeout_ns));

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -7,7 +7,6 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   );
 
   // Testbench settings
-  bit                 en_uart_logger;
   uart_agent_pkg::baud_rate_e uart_baud_rate = uart_agent_pkg::BaudRate1Mbps;
   bit                 use_gpio_for_sw_test_status;
 

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -35,11 +35,10 @@ class chip_base_test extends cip_base_test #(
     // The following plusargs are only valid for SW based tests (i.e., no stubbed CPU).
     // Knob to configure writing sw logs to a separate file (enabled by default).
     void'($value$plusargs("write_sw_logs_to_file=%0b", cfg.write_sw_logs_to_file));
+    cfg.m_uart_agent_cfgs[0].write_logs_to_file = cfg.write_sw_logs_to_file;
 
     // Knob to enable logging over UART (disabled by default).
-    void'($value$plusargs("en_uart_logger=%0b", cfg.en_uart_logger));
-    cfg.m_uart_agent_cfgs[0].en_logger = cfg.en_uart_logger;
-    cfg.m_uart_agent_cfgs[0].write_logs_to_file = cfg.write_sw_logs_to_file;
+    void'($value$plusargs("en_uart_logger=%0b", cfg.m_uart_agent_cfgs[0].en_logger));
 
     // Knob to set the sw_test_timeout_ns (set to 12ms by default).
     void'($value$plusargs("sw_test_timeout_ns=%0d", cfg.sw_test_timeout_ns));


### PR DESCRIPTION
This is just a copy of the en_logger value from the config for the first uart agent. Use that instead.