### PR TITLE
[chip,dv] Remove unused arg in chip_base_vseq::configure_uart_agent

### DIFF
--- a/hw/top_darjeeling/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_base_vseq.sv
@@ -275,8 +275,7 @@ class chip_base_vseq #(
                                              bit enable_tx_monitor = 1'b1,
                                              bit enable_rx_monitor = 1'b0,
                                              bit en_parity = 1'b0,
-                                             bit odd_parity = 1'b0,
-                                             baud_rate_e baud_rate = cfg.uart_baud_rate);
+                                             bit odd_parity = 1'b0);
     if (enable) begin
       `uvm_info(`gfn, $sformatf("Configuring and connecting UART%0d", uart_idx), UVM_LOW)
       cfg.m_uart_agent_cfgs[uart_idx].set_parity(en_parity, odd_parity);

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -239,8 +239,7 @@ class chip_base_vseq #(
                                              bit enable_tx_monitor = 1'b1,
                                              bit enable_rx_monitor = 1'b0,
                                              bit en_parity = 1'b0,
-                                             bit odd_parity = 1'b0,
-                                             baud_rate_e baud_rate = cfg.uart_baud_rate);
+                                             bit odd_parity = 1'b0);
     if (enable) begin
       `uvm_info(`gfn, $sformatf("Configuring and connecting UART%0d", uart_idx), UVM_LOW)
       cfg.m_uart_agent_cfgs[uart_idx].set_parity(en_parity, odd_parity);


### PR DESCRIPTION
This was never passed and (more amusingly) was also ignored: the body of the function just uses the default value. That bug was present in the initial version of the code from 0eea8054b78.