### PR TITLE
[chip,dv] Tweak ifdefs around dut definition

### DIFF
--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -109,10 +109,11 @@ module tb;
     // integrity check, so full chip simulation runs don't do it for each
     // reset.
     .SecRomCtrlDisableScrambling(1'b1)
-) dut (
+  )
 `else
-  chip_earlgrey_asic dut (
+  chip_earlgrey_asic
 `endif
+  dut (
     // Dedicated Pads
     .POR_N(dut.chip_if.dios[top_earlgrey_pkg::DioPadPorN]),
     .USB_P(dut.chip_if.dios[top_earlgrey_pkg::DioPadUsbP]),


### PR DESCRIPTION
No change in behaviour, but the result is slightly easier for editors (Emacs!!!) to parse and this avoids making a mess of indentation suggestions.