### PR TITLE
[jtag,dv] Allow jtag_if to be used passively

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_driver.sv
+++ b/hw/dv/sv/jtag_agent/jtag_driver.sv
@@ -44,8 +44,8 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
     reset_internal_state();
 
     cfg.vif.tck_en <= 1'b0;
-    cfg.vif.tms <= 1'b0;
-    cfg.vif.tdi <= 1'b0;
+    cfg.vif._tms_internal <= 1'b0;
+    cfg.vif._tdi_internal <= 1'b0;
   endfunction
 
   // Turn on TCK in the jtag_if
@@ -118,7 +118,7 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
         // Send a TCK cycle with tms=0. If we were in Run-Test/Idle, this is a no-op. If we were in
         // Test-Logic-Reset, this steps to Run-Test/Idle. As a side-effect, this also lines us up
         // again with the negedge of tck. Drop out early if trst_n goes low.
-        cfg.vif.tms <= 1'b0;
+        cfg.vif._tms_internal <= 1'b0;
         @(posedge cfg.vif.tck);
         @(`HOST_CB);
         // Now drive the JTAG request itself.

--- a/hw/dv/sv/jtag_agent/jtag_if.sv
+++ b/hw/dv/sv/jtag_agent/jtag_if.sv
@@ -12,24 +12,44 @@
 `endif
 
   // interface pins
-  // TODO; make these wires and add `_oe` versions to internally control the driving of these
-  // signals.
-  logic tck;
-  logic trst_n;
-  logic tms;
-  logic tdi;
-  logic tdo;
-  // generate local tck
+  wire tck;
+  wire trst_n;
+  wire tms;
+  wire tdi;
+  wire tdo;
+
+  // Is this interface being driven (through _drive_active and the clocking blocks), or is it just
+  // observing some signals from the wider simulation?
+  //
+  // The flag is defined as a wire with a weak pull-up. This ensures that a testbench that doesn't
+  // customise is_active will see the interface be driven actively, but allows a testbench that
+  // *does* want to customise the signal to pull it low.
+  wire is_active;
+  assign (weak0, weak1) is_active = 1'b1;
+
+  // Should this interface generate a local tck signal? To enable that, set tck_en as well as
+  // is_active.
   bit tck_en;
-  int clk_hi_ps;
-  int clk_lo_ps;
-  int unsigned tck_period_ps = JtagDefaultTckPeriodPs;
+
+  // Output-enable flags for tms, tdi, tdo (which only have an effect if is_active is true). The
+  // default configuration enables tms and tdi, so acts as the root of the JTAG tree plus the
+  // "previous device in the scan chain".
+  bit tms_oe = 1'b1;
+  bit tdi_oe = 1'b1;
+  bit tdo_oe = 1'b0;
+
+  logic _tck_internal, _trst_n_internal, _tms_internal, _tdi_internal, _tdo_internal;
+  assign tck    = (is_active === 1'b1)             ? _tck_internal : 'z;
+  assign trst_n = (is_active === 1'b1)             ? _trst_n_internal : 'z;
+  assign tms    = ((is_active === 1'b1) && tms_oe) ? _tms_internal : 'z;
+  assign tdi    = ((is_active === 1'b1) && tdi_oe) ? _tdi_internal : 'z;
+  assign tdo    = ((is_active === 1'b1) && tdo_oe) ? _tdo_internal : 'z;
 
   // Use negedge to drive jtag inputs because design also use posedge clock edge to sample.
   clocking host_cb @(negedge tck);
     default output #1ns;
-    output  tms;
-    output  tdi;
+    output  tms = _tms_internal;
+    output  tdi = _tdi_internal;
     input   tdo;
   endclocking
   modport host_mp(clocking host_cb, output trst_n);
@@ -37,7 +57,7 @@
   clocking device_cb @(posedge tck);
     input  tms;
     input  tdi;
-    // output tdo; TODO: add this back later once device mode is supported.
+    output tdo = _tdo_internal;
   endclocking
   modport device_mp(clocking device_cb, input trst_n);
 
@@ -48,11 +68,19 @@
   endclocking
   modport mon_mp (clocking mon_cb, input trst_n);
 
-  // debug signals
+  // Signals for local tck
+  int unsigned _tck_period_ps = JtagDefaultTckPeriodPs;
+  int unsigned _clk_hi_ps, _clk_lo_ps;
+  assign _clk_hi_ps = _tck_period_ps / 2;
+  assign _clk_lo_ps = _tck_period_ps - _clk_hi_ps;
 
   // Sets the TCK frequency.
   function automatic void set_tck_period_ps(int unsigned value);
-    tck_period_ps = value;
+    _tck_period_ps = value;
+  endfunction
+
+  function automatic int unsigned get_tck_period_ps();
+    return _tck_period_ps;
   endfunction
 
   // Wait for one TCK cycle
@@ -80,28 +108,54 @@
     repeat (cycles) wait_one_tck();
   endtask
 
-  // task to issue trst_n
+  // Start asserting a test reset through trst_n (no effect if the interface is not active)
+  function automatic void assert_test_reset();
+    _trst_n_internal <= 1'b0;
+  endfunction
+
+  // Clear any test reset asserted through trst_n (no effect if the interface is not active)
+  function automatic void clear_test_reset();
+    _trst_n_internal <= 1'b1;
+  endfunction
+
+  // Assert a test reset through trst_n (no effect if the interface is not active)
   task automatic do_trst_n(int cycles = $urandom_range(5, 20));
-    trst_n <= 1'b0;
+    assert_test_reset();
     wait_tck(cycles);
-    trst_n <= 1'b1;
+    clear_test_reset();
   endtask
 
-  // Generate the tck, with UartDefaultClkPeriodNs period as default
-  assign clk_hi_ps = tck_period_ps / 2;
-  assign clk_lo_ps = tck_period_ps - clk_hi_ps;
+  // Drive _tck_internal with period _tck_period_ps whenever tck_en is high. If active is true, this
+  // gets used to drive the tck signal.
+  task automatic _drive_active();
+    forever begin
+      wait(tck_en);
+      fork : isolation_fork begin
+        fork
+          wait(!tck_en);
+          forever begin
+            _tck_internal = 1'b1;
+            #(_clk_hi_ps * 1ps);
+            _tck_internal = 1'b0;
+            #(_clk_lo_ps * 1ps);
+          end
+        join_any
+        disable fork;
+      end join
+    end
+  endtask
 
   initial begin
-    tck = 1'b1;
+    _tck_internal = 1'b1;
     forever begin
-      if (tck_en) begin
-        #(clk_hi_ps * 1ps);
-        tck = ~tck;
-        #(clk_lo_ps * 1ps);
-        tck = ~tck;
-      end else begin
-        @(tck_en);
-      end
+      wait(is_active === 1'b1);
+      fork : isolation_fork begin
+        fork
+          wait(is_active !== 1'b1);
+          _drive_active();
+        join_any
+        disable fork;
+      end join
     end
   end
 

--- a/hw/dv/sv/jtag_agent/jtag_if.sv
+++ b/hw/dv/sv/jtag_agent/jtag_if.sv
@@ -55,12 +55,29 @@
     tck_period_ps = value;
   endfunction
 
-  // task to wait for tck cycles
+  // Wait for one TCK cycle
+  //
+  // This waits for TCK to clear and then be asserted (so is waiting for the next posedge), but
+  // bounds the wait by _tck_period_ps (in case the clock has stopped).
+  //
+  // Waiting for !tck, then for tck ensures that we don't get any strange races when the clock is
+  // enabled: no matter what the relative phase, we will definitely wait at least a half cycle.
+  task automatic wait_one_tck();
+    fork : isolation_fork begin
+      fork
+        begin
+          wait(!tck);
+          wait(tck);
+        end
+        #(_tck_period_ps * 1ps);
+      join_any
+      disable fork;
+    end join
+  endtask
+
+  // Wait for the given number of cycles of TCK
   task automatic wait_tck(int cycles);
-    repeat (cycles) begin
-      if (tck_en) @(posedge tck);
-      else        #(tck_period_ps * 1ps);
-    end
+    repeat (cycles) wait_one_tck();
   endtask
 
   // task to issue trst_n

--- a/hw/dv/sv/jtag_dmi_agent/jtag_rv_debugger.sv
+++ b/hw/dv/sv/jtag_dmi_agent/jtag_rv_debugger.sv
@@ -1116,11 +1116,8 @@ class jtag_rv_debugger extends uvm_object;
           wait(cfg.in_reset);
           begin
             // TODO: Make this timeout controllable.
+            cfg.vif.wait_tck(100000);
 
-            longint unsigned timeout_ps = cfg.vif.tck_period_ps;
-            timeout_ps = timeout_ps * 100000;
-
-            #(timeout_ps * 1ps);
             req.timed_out = 1'b1;
             `uvm_info(`gfn, $sformatf("SBA req timed out: %0s",
                                       req.sprint(uvm_default_line_printer)), UVM_LOW)

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -241,11 +241,11 @@ class rv_dm_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task apply_resets_concurrently(int reset_duration_ps = 0);
-    int trst_n_duration_ps = cfg.m_jtag_agent_cfg.vif.tck_period_ps * $urandom_range(5, 20);
+    int trst_n_duration_ps = cfg.m_jtag_agent_cfg.vif.get_tck_period_ps() * $urandom_range(5, 20);
     cfg.rv_dm_vif.cb.scan_rst_n <= 1'b0;
-    cfg.m_jtag_agent_cfg.vif.trst_n <= 1'b0;
+    cfg.m_jtag_agent_cfg.vif.assert_test_reset();
     super.apply_resets_concurrently(dv_utils_pkg::max2(reset_duration_ps, trst_n_duration_ps));
-    cfg.m_jtag_agent_cfg.vif.trst_n <= 1'b1;
+    cfg.m_jtag_agent_cfg.vif.clear_test_reset();
     cfg.rv_dm_vif.cb.scan_rst_n <= 1'b1;
   endtask
 

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_scanmode_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_scanmode_vseq.sv
@@ -18,8 +18,8 @@ class rv_dm_scanmode_vseq extends rv_dm_base_vseq;
   // Set tms/tdi as requested and then wait for the next negedge of clk (which gets to the
   // corresponding negedge of TCK because we are in scanmode).
   task tms_tdi(bit tms, bit tdi);
-    cfg.m_jtag_agent_cfg.vif.tms = tms;
-    cfg.m_jtag_agent_cfg.vif.tdi = tdi;
+    cfg.m_jtag_agent_cfg.vif._tms_internal = tms;
+    cfg.m_jtag_agent_cfg.vif._tdi_internal = tdi;
     cfg.clk_rst_vif.wait_n_clks(1);
   endtask
 
@@ -41,7 +41,7 @@ class rv_dm_scanmode_vseq extends rv_dm_base_vseq;
     dout = '0;
 
     for (int i = 0; i < len; i++) begin
-      dout[i] = cfg.m_jtag_agent_cfg.vif.tdo;
+      dout[i] = cfg.m_jtag_agent_cfg.vif._tdo_internal;
       tms_tdi(i == len - 1, value[i]);
     end
 


### PR DESCRIPTION
This PR has two commits. The first avoids some slight fragility in the `wait_tck` task (where things would go wrong if `tck` stopped toggling at the wrong moment).

The second is the more interesting part. It defines an `is_active` flag and allows it to be false, in which case the interface won't drive its `tck`, `trst_n`, ..., `tdi` signals. This is required if you want to allow a testbench component to connect passively to a running test and monitor the behaviour of the interface.