### PR TITLE
[cov,e2e] Reduce several test timeouts from long to moderate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,6 +438,7 @@ jobs:
       board: cw310
       interface: hyper310
       tag_filters: hyper310_rom_ext
+      timeout: 90
 
   # CW340 FPGA jobs
   execute_test_rom_fpga_tests_cw340:

--- a/sw/device/silicon_creator/rom_ext/e2e/isfb/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/isfb/BUILD
@@ -220,7 +220,7 @@ _ISFB_CONTRAINT_TESTS = {
             "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
         },
         fpga = fpga_params(
-            timeout = "long",
+            timeout = "moderate",
             binaries = {
                 ":isfb_page_init": "isfb_page_init",
             },

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -575,7 +575,7 @@ ownership_transfer_test(
     srcs = ["flash_contents.c"],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_b",
     shared_params = {
-        "timeout": "long",
+        "timeout": "moderate",
         # We boot on Side B since rescue will rewrite side A.
         "assemble": "{rom_ext}@{rom_ext_slot_a} {firmware}@{owner_slot_b}",
         "test_cmd": """

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -192,7 +192,7 @@ genrule(
             "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
         },
         fpga = fpga_params(
-            timeout = "long",
+            timeout = "moderate",
             assemble = "{rom_ext}@{rom_ext_offset}",
             binaries = {
                 ":boot_test_{}".format(name): "payload",
@@ -873,7 +873,7 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        timeout = "long",
+        timeout = "moderate",
         assemble = "{romext}@{rom_ext_slot_a} {firmware}@{owner_slot_a}",
         binaries = {
             "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a": "romext",

--- a/sw/device/silicon_creator/rom_ext/e2e/secver/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/secver/BUILD
@@ -108,7 +108,7 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        timeout = "long",
+        timeout = "moderate",
         assemble = "{rom_ext}@{rom_ext_slot_a} {boot_test}@{owner_slot_a}",
         binaries = {
             ":boot_test": "boot_test",


### PR DESCRIPTION
This change reduces the `timeout` setting from "long" to "moderate" for various end-to-end tests in the `rom_ext/e2e` directory (isfb, ownership, rescue, and secver).

These tests are well-suited for moderate durations and provide coverage for paths that are otherwise bypassed. By adjusting the timeout, these tests can now be included in the presubmit phase, as the current CI configuration excludes tests marked with "long" timeouts.

This change is applied to the following test targets:

```
//sw/device/silicon_creator/rom_ext/e2e/isfb:isfb_bad_product_expr_test_fpga_hyper310_rom_ext
//sw/device/silicon_creator/rom_ext/e2e/isfb:isfb_bad_strike_mask_test_fpga_hyper310_rom_ext
//sw/device/silicon_creator/rom_ext/e2e/isfb:isfb_product_expr_test_fpga_hyper310_rom_ext
//sw/device/silicon_creator/rom_ext/e2e/isfb:isfb_unconstrained_test_fpga_hyper310_rom_ext
//sw/device/silicon_creator/rom_ext/e2e/ownership:rescue_limit_test_fpga_hyper310_rom_ext
//sw/device/silicon_creator/rom_ext/e2e/rescue:rescue_rom_ext_slot_a_update_slot_a_fpga_hyper310_rom_ext
//sw/device/silicon_creator/rom_ext/e2e/rescue:rescue_rom_ext_slot_a_update_slot_b_fpga_hyper310_rom_ext
//sw/device/silicon_creator/rom_ext/e2e/rescue:rescue_rom_ext_slot_b_update_slot_a_fpga_hyper310_rom_ext
//sw/device/silicon_creator/rom_ext/e2e/rescue:rescue_rom_ext_slot_b_update_slot_b_fpga_hyper310_rom_ext
//sw/device/silicon_creator/rom_ext/e2e/rescue:xmodem_rescue_error_handling_test_fpga_hyper310_rom_ext
//sw/device/silicon_creator/rom_ext/e2e/secver:secver_write_test_fpga_hyper310_rom_ext
```