### PR TITLE
[doc,i2c] Improve i2c documentation

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -9,8 +9,8 @@
   one_paragraph_desc: '''
   I2C Interface implements the I2C serial communication protocol.
   It can be configured in host (master) or device (slave) mode and supports standard data rate (100 kbaud), fast data rate (400 kbaud), and fast plus data rate (1 Mbaud).
-  In addition to supporting all mandatory I2C features, this block supports clock stretching in host mode and automatic clock stretching in device mode.
-  I2C Interface uses a 7-bit address space and is compatible with any device covered by I2C specification operating at speeds up to 1 Mbaud.
+  In addition to supporting all mandatory I<sup>2</sup>C features, this block supports clock stretching in host mode and automatic clock stretching in device mode.
+  I2C Interface uses a 7-bit address space and is compatible with any device covered by I<sup>2</sup>C specification operating at speeds up to 1 Mbaud.
   '''
   // Unique comportable IP identifier defined under KNOWN_CIP_IDS in the regtool.
   cip_id:             "11",
@@ -283,7 +283,7 @@
           resval: "0"
           name: "LLPBK"
           desc: '''
-                Enable I2C line loopback test
+                Enable I2C line loopback test.
                 If line loopback is enabled, the internal design sees ACQ and RX data as "1"
                 '''
           tags: [// Exclude from write-checks: writing 1'b1 to this bit causes interrupts unexpectedly asserted
@@ -635,7 +635,7 @@
 
     { name: "TIMING0"
       desc: '''
-            Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).
+            Detailed I2C Timings (directly corresponding to table 10 in the I<sup>2</sup>C Specification (rev. 6)).
             All values are expressed in units of the input clock period.
             These must be greater than 2 in order for the change in SCL to propagate to the input of the FSM so that acknowledgements are detected correctly.
             '''
@@ -660,7 +660,7 @@
     }
     { name: "TIMING1",
       desc: '''
-            Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).
+            Detailed I2C Timings (directly corresponding to table 10 in the I<sup>2</sup>C Specification (rev. 6)).
             All values are expressed in units of the input clock period.
             '''
       swaccess: "rw"
@@ -684,7 +684,7 @@
     }
     { name: "TIMING2"
       desc: '''
-            Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).
+            Detailed I2C Timings (directly corresponding to table 10 in the I<sup>2</sup>C Specification (rev. 6)).
             All values are expressed in units of the input clock period.
             '''
       swaccess: "rw"
@@ -708,7 +708,7 @@
     }
     { name: "TIMING3"
       desc: '''
-            Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification).
+            Detailed I2C Timings (directly corresponding to table 10 in the I<sup>2</sup>C Specification (rev. 6)).
             All values are expressed in units of the input clock period.
             '''
       swaccess: "rw"
@@ -735,7 +735,7 @@
     }
     { name: "TIMING4"
       desc: '''
-            Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification).
+            Detailed I2C Timings (directly corresponding to table 10 in the I<sup>2</sup>C Specification (rev. 6)).
             All values are expressed in units of the input clock period.
             '''
       swaccess: "rw"
@@ -872,7 +872,7 @@
               name: "START",
               desc: '''
                     A START condition preceded the ABYTE to start a new transaction.
-                    ABYTE contains the 7-bit I2C address plus R/W command bit in the order received on the bus, MSB first.
+                    ABYTE contains the 7-bit I<sup>2</sup>C address plus R/W command bit in the order received on the bus, MSB first.
                     '''
             },
             { value: "2",
@@ -887,7 +887,7 @@
               name: "RESTART",
               desc: '''
                     A repeated START condition preceded the ABYTE, extending the current transaction with a new transfer.
-                    ABYTE contains the 7-bit I2C address plus R/W command bit in the order received on the bus, MSB first.
+                    ABYTE contains the 7-bit I<sup>2</sup>C address plus R/W command bit in the order received on the bus, MSB first.
                     '''
             },
             { value: "4",
@@ -898,7 +898,7 @@
               name: "NACK_START",
               desc: '''
                     A START condition preceded the ABYTE (including repeated START) that was part of a NACK'd transfer.
-                    The ABYTE contains the matching I2C address and command bit.
+                    The ABYTE contains the matching I<sup>2</sup>C address and command bit.
                     The ABYTE was ACK'd, but the rest of the transaction was NACK'ed.
                     '''
             },

--- a/hw/ip/i2c/doc/programmers_guide.md
+++ b/hw/ip/i2c/doc/programmers_guide.md
@@ -18,16 +18,16 @@ The values of these parameters will depend primarily on three bus details:
 - The expected signal rise time, t<sub>r</sub>, in ns.
     - This is not a firmware-controlled parameter.
     Rather, it is a function of the capacitance and physical design of the bus.
-    The specification provides detailed guidelines on how to manage capacitance in an I2C system:
-    - Section 5.2 of the I2C specification indicates that Fast-mode Plus devices may operate at reduced clock speeds if the bus capacitance drives signal rise times (t<sub>r</sub>) outside the nominal 120ns limit.
-    Excess capacitance can also be compensated for by reducing the size of the bus pullup resistor, so long as the total open-drain current does not exceed 20mA for Fast-mode Plus devices (as described in section 7.1 of the I2C specification).
+    The specification provides detailed guidelines on how to manage capacitance in an I<sup>2</sup>C system:
+    - Section 5.2 of the I<sup>2</sup>C specification indicates that Fast-mode Plus devices may operate at reduced clock speeds if the bus capacitance drives signal rise times (t<sub>r</sub>) outside the nominal 120ns limit.
+    Excess capacitance can also be compensated for by reducing the size of the bus pullup resistor, so long as the total open-drain current does not exceed 20mA for Fast-mode Plus devices (as described in section 7.1 of the I<sup>2</sup>C specification).
     However the specification places a hard limit on rise times capping them at 1000ns.
     - If there are Standard- or Fast-mode target devices on the bus, the specified open-drain current limit is reduced to 3mA (section 7.1), thus further restricting the minimum value of the pull-up resistor.
     - In Fast-mode bus designs, where the total line capacitance exceeds 200pF, the specification recommends replacing the pull-up resistor with an active current source, supplying 3mA or less (section 5.1).
     Regardless of the physical construction of the bus, the rise time (t<sub>r</sub>) is a system dependent, parameter that needs to be made known to firmware for I2C initialization.
 - The expected fall time, t<sub>f</sub>, in ns.
     - Like t<sub>r</sub>, this parameter is not firmware controlled rather it is a function of the SCL driver, which in a strictly compliant device is expected to manage the slew-rate for the falling edge of the SDA and SCL signals, through proper design of the SCL output buffer.
-    - See table 10 of the I2C specification for more details.
+    - See table 10 (rev. 6) of the I<sup>2</sup>C specification for more details.
 - (optional) The desired SCL cycle period, t<sub>SCL,user</sub> in ns.
     - By default the device should operate at the maximum frequency for that mode.
     However, If the system developer wishes to operate at slower than the mode-specific maximum, a larger than minimum period could be allowed as an additional functional parameter when calculating the timing parameters.
@@ -116,11 +116,11 @@ All other parameters in registers `TIMING2`, `TIMING3`, `TIMING4` are unchanged 
 ### Writing `n` bytes to a device:
 1. Address the device for writing by writing to:
   - `FDATA.START` = 1;
-  - `FDATA.FBYTE` = <7-bit address + write bit>.
+  - `FDATA.FBYTE` = < 7-bit address + write bit >.
 2. Fill the FMT FIFO by writing to `FDATA.FBYTE` `n`-1 times.
 3. Send last byte with the stop bit by writing to:
   - `FDATA.STOP` = 1;
-  - `FDATA.FBYTE` = <last byte>.
+  - `FDATA.FBYTE` = < last byte >.
 4. Wait for and check the result of the transaction.
   - If `INTR_STATE.CONTROLLER_HALT` is 1, the transaction failed.
     - Check `CONTROLLER_EVENTS` for the reason, reset the FMT FIFO with `FIFO_CTRL.FMTRST`, and clear the latched events.
@@ -129,11 +129,11 @@ All other parameters in registers `TIMING2`, `TIMING3`, `TIMING4` are unchanged 
 ### Reading `n` bytes from a device:
 1. Address the device for reading by writing to the FMT FIFO:
   - `FDATA.START` = 1;
-  - `FDATA.FBYTE` = <7-bit address + read bit>.
+  - `FDATA.FBYTE` = < 7-bit address + read bit >.
 2. Issue a read transfer by writing to the FMT FIFO.
-  - `FDATA.READ` = 1;
+  - `FDATA.READB` = 1;
   - `FDATA.STOP` = 1;
-  - `FDATA.FBYTE` = <`n`>.
+  - `FDATA.FBYTE` = < `n` >.
 3. Wait for the transfer to finish or interrupt by checking:
   - If `STATUS.FMTEMPTY` bit is 1.
     - **Or** if `INTR_STATE.FMT_THRESHOLD` bit is 1 ( as long as `FIFO_CTRL.FMTILVL` is set to 1).

--- a/hw/ip/i2c/doc/registers.md
+++ b/hw/ip/i2c/doc/registers.md
@@ -20,11 +20,11 @@
 | i2c.[`TARGET_FIFO_STATUS`](#target_fifo_status)               | 0x30     |        4 | Target mode FIFO status register                                                                          |
 | i2c.[`OVRD`](#ovrd)                                           | 0x34     |        4 | I2C Override Control Register                                                                             |
 | i2c.[`VAL`](#val)                                             | 0x38     |        4 | Oversampled RX values                                                                                     |
-| i2c.[`TIMING0`](#timing0)                                     | 0x3c     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).                       |
-| i2c.[`TIMING1`](#timing1)                                     | 0x40     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).                       |
-| i2c.[`TIMING2`](#timing2)                                     | 0x44     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).                       |
-| i2c.[`TIMING3`](#timing3)                                     | 0x48     |        4 | Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification).                      |
-| i2c.[`TIMING4`](#timing4)                                     | 0x4c     |        4 | Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification).                      |
+| i2c.[`TIMING0`](#timing0)                                     | 0x3c     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I<sup>2</sup>C Specification (rev. 6)).   |
+| i2c.[`TIMING1`](#timing1)                                     | 0x40     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I<sup>2</sup>C Specification (rev. 6)).   |
+| i2c.[`TIMING2`](#timing2)                                     | 0x44     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I<sup>2</sup>C Specification (rev. 6)).   |
+| i2c.[`TIMING3`](#timing3)                                     | 0x48     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I<sup>2</sup>C Specification (rev. 6)).   |
+| i2c.[`TIMING4`](#timing4)                                     | 0x4c     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I<sup>2</sup>C Specification (rev. 6)).   |
 | i2c.[`TIMEOUT_CTRL`](#timeout_ctrl)                           | 0x50     |        4 | I2C clock stretching and bus timeout control.                                                             |
 | i2c.[`TARGET_ID`](#target_id)                                 | 0x54     |        4 | I2C target address and mask pairs                                                                         |
 | i2c.[`ACQDATA`](#acqdata)                                     | 0x58     |        4 | I2C target acquired data                                                                                  |
@@ -216,7 +216,7 @@ For writes, the Target module will NACK all subsequent data bytes until it recei
 For reads, the Target module will release SDA, causing 0xff to be returned for all data bytes until it receives a Stop.
 
 ### CTRL . LLPBK
-Enable I2C line loopback test
+Enable I2C line loopback test.
 If line loopback is enabled, the internal design sees ACQ and RX data as "1"
 
 ### CTRL . ENABLETARGET
@@ -459,7 +459,7 @@ Oversampled RX values
 |  15:0  |   ro   |    x    | SCL_RX | Last 16 oversampled values of SCL. Most recent bit is bit 0, oldest 15.  |
 
 ## TIMING0
-Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).
+Detailed I2C Timings (directly corresponding to table 10 in the I<sup>2</sup>C Specification (rev. 6)).
 All values are expressed in units of the input clock period.
 These must be greater than 2 in order for the change in SCL to propagate to the input of the FSM so that acknowledgements are detected correctly.
 - Offset: `0x3c`
@@ -480,7 +480,7 @@ These must be greater than 2 in order for the change in SCL to propagate to the 
 |  12:0  |   rw   |   0x0   | THIGH  | The actual time to hold SCL high in a given pulse. This field is sized to have a range of at least Standard Mode's 4.0 us max with a core clock at 1 GHz.          |
 
 ## TIMING1
-Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).
+Detailed I2C Timings (directly corresponding to table 10 in the I<sup>2</sup>C Specification (rev. 6)).
 All values are expressed in units of the input clock period.
 - Offset: `0x40`
 - Reset default: `0x0`
@@ -500,7 +500,7 @@ All values are expressed in units of the input clock period.
 |  9:0   |   rw   |   0x0   | T_R    | The nominal rise time to anticipate for the bus (depends on capacitance). This field is sized to have a range of at least Standard Mode's 1000 ns max with a core clock at 1 GHz.   |
 
 ## TIMING2
-Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).
+Detailed I2C Timings (directly corresponding to table 10 in the I<sup>2</sup>C Specification (rev. 6)).
 All values are expressed in units of the input clock period.
 - Offset: `0x44`
 - Reset default: `0x0`
@@ -520,7 +520,7 @@ All values are expressed in units of the input clock period.
 |  12:0  |   rw   |   0x0   | TSU_STA | Actual setup time for repeated start signals. This field is sized to have a range of at least Standard Mode's 4.7 us max with a core clock at 1 GHz. |
 
 ## TIMING3
-Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification).
+Detailed I2C Timings (directly corresponding to table 10 in the I<sup>2</sup>C Specification (rev. 6)).
 All values are expressed in units of the input clock period.
 - Offset: `0x48`
 - Reset default: `0x0`
@@ -551,7 +551,7 @@ Actual setup time for data (or ack) bits.
 This field is sized to have a range of at least Standard Mode's 250 ns max with a core clock at 1 GHz.
 
 ## TIMING4
-Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification).
+Detailed I2C Timings (directly corresponding to table 10 in the I<sup>2</sup>C Specification (rev. 6)).
 All values are expressed in units of the input clock period.
 - Offset: `0x4c`
 - Reset default: `0x0`
@@ -668,11 +668,11 @@ See the associated values for more information about the contents.
 | Value   | Name       | Description                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 |:--------|:-----------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | 0x0     | NONE       | ABYTE contains an ordinary data byte that was received and ACK'd.                                                                                                                                                                                                                                                                                                                                                                                   |
-| 0x1     | START      | A START condition preceded the ABYTE to start a new transaction. ABYTE contains the 7-bit I2C address plus R/W command bit in the order received on the bus, MSB first.                                                                                                                                                                                                                                                                             |
+| 0x1     | START      | A START condition preceded the ABYTE to start a new transaction. ABYTE contains the 7-bit I<sup>2</sup>C address plus R/W command bit in the order received on the bus, MSB first.                                                                                                                                                                                                                                                                  |
 | 0x2     | STOP       | A STOP condition was received for a transaction including a transfer that addressed this Target. No transfers addressing this Target in that transaction were NACK'd. ABYTE contains no data.                                                                                                                                                                                                                                                       |
-| 0x3     | RESTART    | A repeated START condition preceded the ABYTE, extending the current transaction with a new transfer. ABYTE contains the 7-bit I2C address plus R/W command bit in the order received on the bus, MSB first.                                                                                                                                                                                                                                        |
+| 0x3     | RESTART    | A repeated START condition preceded the ABYTE, extending the current transaction with a new transfer. ABYTE contains the 7-bit I<sup>2</sup>C address plus R/W command bit in the order received on the bus, MSB first.                                                                                                                                                                                                                             |
 | 0x4     | NACK       | ABYTE contains an ordinary data byte that was received and NACK'd.                                                                                                                                                                                                                                                                                                                                                                                  |
-| 0x5     | NACK_START | A START condition preceded the ABYTE (including repeated START) that was part of a NACK'd transfer. The ABYTE contains the matching I2C address and command bit. The ABYTE was ACK'd, but the rest of the transaction was NACK'ed.                                                                                                                                                                                                                  |
+| 0x5     | NACK_START | A START condition preceded the ABYTE (including repeated START) that was part of a NACK'd transfer. The ABYTE contains the matching I<sup>2</sup>C address and command bit. The ABYTE was ACK'd, but the rest of the transaction was NACK'ed.                                                                                                                                                                                                       |
 | 0x6     | NACK_STOP  | A transaction including a transfer that addressed this Target was ended, but the transaction ended abnormally and/or the transfer was NACK'd. The end can be due to a STOP condition or unexpected events, such as a bus timeout (if enabled). ABYTE contains no data. NACKing can occur for multiple reasons, including a stretch timeout, a SW-directed NACK, or lost arbitration. This signal is a bucket for all these error-type terminations. |
 
 Other values are reserved.

--- a/hw/ip/i2c/doc/theory_of_operation.md
+++ b/hw/ip/i2c/doc/theory_of_operation.md
@@ -6,13 +6,13 @@
 
 ## Functional Description
 
-I2C IP is a controller-target combo that can function as an I2C controller and/or an I2C target.
+The I2C IP is a controller-target combo that can function as an I<sup>2</sup>C controller and/or an I<sup>2</sup>C target.
 These functional modules are enabled at runtime by setting the register fields [`CTRL.ENABLEHOST`](registers.md#ctrl) and [`CTRL.ENABLETARGET`](registers.md#ctrl).
 If the Controller Module is to be used in a multi-controller environment, [`CTRL.MULTI_CONTROLLER_MONITOR_EN`](registers.md#ctrl) would also need to be set.
 Note the ordering requirements in the register description for multi-controller configurations.
 
 The SCL and SDA outputs from the block combine the SCL and SDA outputs from the Controller Module and Target Module.
-The modules operate as though they were independent devices on the same I2C bus, with any logic low value taking priority.
+The modules operate as though they were independent devices on the same I<sup>2</sup>C bus, with any logic low value taking priority.
 
 On the input path, the IP's clock samples SCL and SDA after a 2-flop synchronizer.
 However, the IP's input pins do not reflect the start point for the full input path delay, since pads and nets from I/O buffers also contribute.
@@ -39,7 +39,7 @@ To make this happen, [`HOST_TIMEOUT_CTRL`](registers.md#host_timeout_ctrl) shoul
 
 ### Controller Module
 
-The Controller Module implements all mandatory controller features of the I2C protocol for multi-controller configurations, including clock synchronization and bus arbitration.
+The Controller Module implements all mandatory controller features of the I<sup>2</sup>C protocol for multi-controller configurations, including clock synchronization and bus arbitration.
 It also implements support for handling clock stretching.
 
 The state-machine-controlled Controller Module allows for higher-speed operation with less frequent software interaction.
@@ -75,7 +75,7 @@ Issue a STOP signal after processing this current entry in the FMT FIFO.
 Note that this flag is not compatible with (READB & RCONT), and will cause bus conflicts.
 - NAKOK (corresponds to [`FDATA.NAKOK`](registers.md#fdata), Not compatible with READB):
 Typically every byte transmitted must also receive an ACK signal, and the IP will raise an exception if no ACK is received.
-However, there are some I2C commands which do not require an ACK.
+However, there are some I<sup>2</sup>C commands which do not require an ACK.
 In those cases this flag should be asserted with FBYTE indicating no ACK is expected and no interrupt should be raised if the ACK is not received.
 
 The Controller Module may proceed through all commands in the FMT FIFO as long as no exceptional event occurs.
@@ -123,7 +123,7 @@ All bits in [`CONTROLLER_EVENTS`](registers.md#controller_events) must be cleare
 
 ### Target Module
 
-The Target Module implements all mandatory features for targets in multi-controller configurations, as enumerated in the I2C specification.
+The Target Module implements all mandatory features for targets in multi-controller configurations, as enumerated in the I<sup>2</sup>C specification.
 It also supports clock stretching from that same specification.
 
 In addition, the Target Module has the necessary mechanisms to support mandatory SMBus 3.0 features, as well as dynamically-assigned addresses using the SMBus Address Resolution Protocol.
@@ -183,7 +183,7 @@ The following diagram shows consecutive entries inserted into ACQ FIFO during a 
 ![](../doc/i2c_acq_fifo_read.svg)
 
 #### Target Clock Stretching
-As described in the I2C specification, a target device can pause a transaction by holding SCL low.
+As described in the I<sup>2</sup>C specification, a target device can pause a transaction by holding SCL low.
 There are 3 cases in which this design stretches the clock:
 - After the target receives the address but before pushing it to the ACQ FIFO
 - Before the (N)ACK bit completes transmission during a write transfer
@@ -262,10 +262,10 @@ This feature is intended to support protocols that require mid-transfer NACK dec
 
 ### Timing Control Registers
 
-For Standard-mode, Fast-mode and Fast-mode Plus, the timing requirements for each transaction are detailed in Table 10 of the [I2C specification (rev. 6)](https://web.archive.org/web/20210813122132/https://www.nxp.com/docs/en/user-guide/UM10204.pdf).
+For Standard-mode, Fast-mode and Fast-mode Plus, the timing requirements for each transaction are detailed in Table 10 of the [I<sup>2</sup>C specification (rev. 6)](https://web.archive.org/web/20210813122132/https://www.nxp.com/docs/en/user-guide/UM10204.pdf).
 To claim complete compatibility at each mode, the state machine timings need to be adapted to whether there are Standard-mode, Fast-mode and Fast-mode Plus targets on the bus.
 Furthermore, depending on the actual capacitance of the bus, even a bus with all Fast-mode Plus capable targets may have to operate at slower speeds than 1 Mbaud.
-For example, the controller may need to run at lower frequencies, as discussed in Section 5.2 of the specification, but the computation of the nominal frequency will depend on timing specifications in Table 10, in this case particularly, the limits on t<sub>LOW</sub>, t<sub>HIGH</sub>, t<sub>r</sub>, and t<sub>f</sub>.
+For example, the controller may need to run at lower frequencies, as discussed in Section 5.2 of the specification, but the computation of the nominal frequency will depend on timing specifications in Table 10 (rev. 6), in this case particularly, the limits on t<sub>LOW</sub>, t<sub>HIGH</sub>, t<sub>r</sub>, and t<sub>f</sub>.
 Assuming no clock stretching, for a given set of these four parameters the baud rate is then given to be:
 $$ 1/f\_{SCL}=t\_{LOW}+t\_{HIGH}+t\_{r}+t\_{f}. $$
 
@@ -278,7 +278,7 @@ Thus this parameter is largely budgetary, meaning that it tells the state machin
 - t<sub>f</sub>: set in register [`TIMING1.T_F`](registers.md#timing1).
 (Note: The fall time cannot be explicitly controlled by internal hardware, and is a function of the pin driver.
 Thus this parameter is also budgetary.
-Given that the actual fall time cannot be controlled to stay above the minimum values set in Table 10 of the specification, and so this in this regard this module currently is not strictly compliant to the I2C spec.
+Given that the actual fall time cannot be controlled to stay above the minimum values set in Table 10 of the specification (rev. 6), and so this in this regard this module currently is not strictly compliant to the I<sup>2</sup>C spec.
 The system design is responsible for meeting the spec's minimum fall time.
 )
 - t<sub>SU,STA</sub>: set in register [`TIMING2.TSU_STA`](registers.md#timing2)
@@ -295,7 +295,7 @@ In addition, when the IP operates as a target, the parameter specifies the requi
 
 The values programmed into the registers [`TIMING0`](registers.md#timing0) through [`TIMING4`](registers.md#timing4) are to be expressed in units of the input clock period.
 It is important that the internal clock is at least 50x the bus clock so that the proportions of the timings can be accurately captured.
-Note in order to ensure compliance with the I2C spec, firmware must program these registers with values within the ranges laid out in Table 10 of the specification.
+Note in order to ensure compliance with the I<sup>2</sup>C spec, firmware must program these registers with values within the ranges laid out in Table 10 of the specification (rev. 6).
 These values can be directly computed using DIFs given the desired speed standard, the desired operating frequency, and the actual line capacitance.
 These timing parameters are then fed directly to the I2C state machine to control the bus timing.
 
@@ -413,7 +413,7 @@ This interrupt is suppressed, however, if [`TIMEOUT_CTRL.EN`](registers.md#timeo
   head: {text: 'SCL Timeout Example',tick:-3}}
 ```
 
-Except for START and STOP symbols, the I2C specification requires that the SDA signal remains constant whenever SCL is high.
+Except for START and STOP symbols, the I<sup>2</sup>C specification requires that the SDA signal remains constant whenever SCL is high.
 The `sda_unstable` interrupt is asserted if, when receiving data or acknowledgement pulse, the value of the SDA signal does not remain constant over the duration of the SCL pulse, causing an unexpected START or STOP symbol.
 
 Transactions are terminated by a STOP signal, but individual transfers within a transaction can be completed by a STOP signal *or* a repeated START signal.
@@ -569,7 +569,7 @@ For full spec compliance, the glitch filter must be added to the system design.
 
 ### Override Mode for Direct Pin Access
 
-The I2C hardware interface consists of two external pins, SCL and SDA, whose behavior is described in the [I2C specification (rev. 6)](https://web.archive.org/web/20210813122132/https://www.nxp.com/docs/en/user-guide/UM10204.pdf).
+The I2C hardware interface consists of two external pins, SCL and SDA, whose behavior is described in the [I<sup>2</sup>C specification (rev. 6)](https://web.archive.org/web/20210813122132/https://www.nxp.com/docs/en/user-guide/UM10204.pdf).
 These pins are typically controlled by an internal state machine.
 However, there is a simpler "override" mode, by which these pins can be directly manipulated by software.
 This override mode is useful for both troubleshooting and error recovery.
@@ -586,9 +586,9 @@ Since SCL is directly decoded from the states, it can have short glitches during
 To counter this, the SCL and SDA outputs from the internal state machine are flopped before they are emitted.
 
 This adds a one cycle module clock delay to both signals.
-If the module clock is sufficiently faster than I2C line speeds (for example 24MHz), this is not an issue.
+If the module clock is sufficiently faster than I<sup>2</sup>C line speeds (for example 24MHz), this is not an issue.
 However if the line speeds and the module clock speeds become very close (2x), the 1 cycle delay may have an impact, as the internal state machine may mistakenly think it has sampled an SDA that has not yet been updated.
 
 Therefore, it is recommended that the internal module clock frequency is much higher than the line speeds.
-Another reason to have this higher internal clock frequency is that the timing parameters can be more accurately defined, which helps attain the desired I2C clock rate.
-Since there are currently also a few cycles discrepancy between the specified timings and the actual ones (as described in the [Programmer's Guide](./programmers_guide.md#timing-parameter-tuning-algorithm)), it is recommended that the internal module clock frequency is at least 24x higher than the I2C line speeds.
+Another reason to have this higher internal clock frequency is that the timing parameters can be more accurately defined, which helps attain the desired I<sup>2</sup>C clock rate.
+Since there are currently also a few cycles discrepancy between the specified timings and the actual ones (as described in the [Programmer's Guide](./programmers_guide.md#timing-parameter-tuning-algorithm)), it is recommended that the internal module clock frequency is at least 24x higher than the I<sup>2</sup>C line speeds.


### PR DESCRIPTION
- Use a superscript "2" in "I2C" when talking about the protocol, and plain "I2C" when talking about this IP.
- Pad the contents of angle brackets when not intended as a formatting tag to avoid accidental machine interpretation (i.e. "<last byte>" disappearing when rendered).
- Update references to "table 10" of the spec to specify the version of the spec meant, as the latest version changed the table number.
- Add missing period at the end of a sentence.
- Correct/update `FDATA.READ` to `FDATA.READB`.