### PR TITLE
[chip,dv] Move do_creator_sw_cfg_ast_cfg out of chip_env_cfg

### DIFF
--- a/hw/top_darjeeling/dv/env/chip_env_cfg.sv
+++ b/hw/top_darjeeling/dv/env/chip_env_cfg.sv
@@ -40,10 +40,6 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // before invoking super.dut_init(), or any other suitable place.
   rand uint creator_sw_cfg_ast_cfg_data[ast_pkg::AstRegsNum];
 
-  // A knob that controls whether the AST initialization is done, enabled by default.
-  // Can be updated with plusarg.
-  bit do_creator_sw_cfg_ast_cfg = 1;
-
   // sw related
   // In OpenTitan, the same SW test image can be built for DV, Verilator and FPGA. SW build for
   // other platforms can be run on DV as well. We allow that by specifying the SW build device.

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_base_vseq.sv
@@ -28,6 +28,9 @@ class chip_base_vseq #(
   // You have to set this knob before or within dut_init task
   bit early_cpu_init = 0;
 
+  // Should the AST actually be programmed?
+  bit do_creator_sw_cfg_ast_cfg = 1;
+
   `uvm_object_new
 
   virtual function void set_handles();
@@ -326,11 +329,9 @@ class chip_base_vseq #(
 
   // Initialize the OTP creator SW cfg region with AST configuration data.
   virtual function void initialize_otp_creator_sw_cfg_ast_cfg();
-    // The knob controls whether the AST is actually programmed.
-    if (cfg.do_creator_sw_cfg_ast_cfg) begin
-      cfg.mem_bkdr_util_h[Otp].write32(otp_ctrl_reg_pkg::CreatorSwCfgAstInitEnOffset,
-                                       prim_mubi_pkg::MuBi4True);
-    end
+    cfg.mem_bkdr_util_h[Otp].write32(otp_ctrl_reg_pkg::CreatorSwCfgAstInitEnOffset,
+                                     (do_creator_sw_cfg_ast_cfg ?
+                                      prim_mubi_pkg::MuBi4True : prim_mubi_pkg::MuBi4False));
 
     // Ensure that the allocated size of the AST cfg region in OTP is equal to the number of AST
     // registers to be programmed.

--- a/hw/top_darjeeling/dv/tests/chip_base_test.sv
+++ b/hw/top_darjeeling/dv/tests/chip_base_test.sv
@@ -55,9 +55,6 @@ class chip_base_test extends cip_base_test #(
       cfg.parse_sw_images_string(sw_images_plusarg);
     end
 
-    // Knob to perform the AST configuration.
-    void'($value$plusargs("do_creator_sw_cfg_ast_cfg=%0b", cfg.do_creator_sw_cfg_ast_cfg));
-
     // Knob to use small page rma
     void'($value$plusargs("en_small_rma=%0b", cfg.en_small_rma));
 
@@ -85,5 +82,21 @@ class chip_base_test extends cip_base_test #(
       cfg.set_use_jtag_dmi();
     end
   endfunction : build_phase
+
+  virtual function void configure_sequence(uvm_sequence seq);
+    chip_base_vseq vseq;
+
+    super.configure_sequence(seq);
+
+    if (!$cast(vseq, seq)) begin
+      `uvm_fatal(get_full_name(),
+                 $sformatf("Cannot configure sequence that isn't a chip_base_vseq: %0s.",
+                           seq.sprint()))
+    end
+
+    // Should the AST actually be programmed in the vseq? By default, it should, but this can be
+    // disabled with the do_creator_sw_cfg_ast_cfg plusarg.
+    void'($value$plusargs("do_creator_sw_cfg_ast_cfg=%0b", vseq.do_creator_sw_cfg_ast_cfg));
+  endfunction
 
 endclass : chip_base_test

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -46,10 +46,6 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // before invoking super.dut_init(), or any other suitable place.
   rand uint creator_sw_cfg_ast_cfg_data[ast_pkg::AstRegsNum];
 
-  // A knob that controls whether the AST initialization is done, enabled by default.
-  // Can be updated with plusarg.
-  bit do_creator_sw_cfg_ast_cfg = 1;
-
   // sw related
   // In OpenTitan, the same SW test image can be built for DV, Verilator and FPGA. SW build for
   // other platforms can be run on DV as well. We allow that by specifying the SW build device.

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -23,6 +23,9 @@ class chip_base_vseq #(
   // Skip POR_N : required for closed source test
   bit skip_por_n_during_first_pwrup = 0;
 
+  // Should the AST actually be programmed?
+  bit do_creator_sw_cfg_ast_cfg = 1;
+
   `uvm_object_new
 
   virtual function void set_handles();
@@ -287,14 +290,9 @@ class chip_base_vseq #(
 
   // Initialize the OTP creator SW cfg region with AST configuration data.
   virtual function void initialize_otp_creator_sw_cfg_ast_cfg();
-    // The knob controls whether the AST is actually programmed.
-    if (cfg.do_creator_sw_cfg_ast_cfg) begin
-      cfg.mem_bkdr_util_h[Otp].write32(otp_ctrl_reg_pkg::CreatorSwCfgAstInitEnOffset,
-                                       prim_mubi_pkg::MuBi4True);
-    end else begin
-      cfg.mem_bkdr_util_h[Otp].write32(otp_ctrl_reg_pkg::CreatorSwCfgAstInitEnOffset,
-                                       prim_mubi_pkg::MuBi4False);
-    end
+    cfg.mem_bkdr_util_h[Otp].write32(otp_ctrl_reg_pkg::CreatorSwCfgAstInitEnOffset,
+                                     (do_creator_sw_cfg_ast_cfg ?
+                                      prim_mubi_pkg::MuBi4True : prim_mubi_pkg::MuBi4False));
 
     // Ensure that the allocated size of the AST cfg region in OTP is equal to the number of AST
     // registers to be programmed.

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -55,9 +55,6 @@ class chip_base_test extends cip_base_test #(
       cfg.parse_sw_images_string(sw_images_plusarg);
     end
 
-    // Knob to perform the AST configuration.
-    void'($value$plusargs("do_creator_sw_cfg_ast_cfg=%0b", cfg.do_creator_sw_cfg_ast_cfg));
-
     // Knob to use small page rma
     void'($value$plusargs("en_small_rma=%0b", cfg.en_small_rma));
 
@@ -92,5 +89,21 @@ class chip_base_test extends cip_base_test #(
       cfg.set_use_jtag_dmi();
     end
   endfunction : build_phase
+
+  virtual function void configure_sequence(uvm_sequence seq);
+    chip_base_vseq vseq;
+
+    super.configure_sequence(seq);
+
+    if (!$cast(vseq, seq)) begin
+      `uvm_fatal(get_full_name(),
+                 $sformatf("Cannot configure sequence that isn't a chip_base_vseq: %0s.",
+                           seq.sprint()))
+    end
+
+    // Should the AST actually be programmed in the vseq? By default, it should, but this can be
+    // disabled with the do_creator_sw_cfg_ast_cfg plusarg.
+    void'($value$plusargs("do_creator_sw_cfg_ast_cfg=%0b", vseq.do_creator_sw_cfg_ast_cfg));
+  endfunction
 
 endclass : chip_base_test


### PR DESCRIPTION
This flag controls the behaviour of the vseq (when configuring the environment). As such, it doesn't really belong in the environment config.

Move it to the vseq that uses it, and move the $value$plusargs call to chip_base_test (we shouldn't be adding *more* calls to plusargs in the sequence itself).

One extra change is that the darjeeling version of the base vseq now sets a valid mubi4 value either way. This was implemented for earlgrey in commit 051b3a54d54, but it appears the snapshot for integration-dev was taken before that.