### PR TITLE
[dv] Allow dv_base_env to work if clk_rst_ifs are already in cfg

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_env.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env.sv
@@ -16,7 +16,6 @@ class dv_base_env #(type CFG_T               = dv_base_env_cfg,
   `uvm_component_new
 
   virtual function void build_phase(uvm_phase phase);
-    string default_ral_name;
     string ral_models[$];
 
     super.build_phase(phase);
@@ -25,20 +24,14 @@ class dv_base_env #(type CFG_T               = dv_base_env_cfg,
       `uvm_fatal(`gfn, $sformatf("failed to get %s from uvm_config_db", cfg.get_type_name()))
     end
 
+    // Make sure the map in cfg from RAL name to clk_rst_if is populated. Copy the clock frequencies
+    // chosen by cfg to the interfaces.
     ral_models = cfg.get_ral_model_names();
     if (ral_models.size() > 0) begin
-      default_ral_name = cfg.ral.get_type_name();
+      string default_ral_name = cfg.ral.get_type_name();
       foreach (ral_models[i]) begin
         string ral_name = ral_models[i];
-        string if_name;
-
-        if (ral_name == default_ral_name) if_name = "clk_rst_vif";
-        else                              if_name = {"clk_rst_vif_", ral_name};
-        if (!uvm_config_db#(virtual clk_rst_if)::get(this, "", if_name,
-            cfg.clk_rst_vifs[ral_name])) begin
-          `uvm_fatal(`gfn, $sformatf("failed to get clk_rst_if for %0s from uvm_config_db", ral_name))
-        end
-        cfg.clk_rst_vifs[ral_name].set_freq_mhz(cfg.clk_freqs_mhz[ral_name]);
+        configure_clk_rst_vif(ral_name, (ral_name == default_ral_name));
       end
 
       // assign default clk_rst_vif
@@ -47,13 +40,12 @@ class dv_base_env #(type CFG_T               = dv_base_env_cfg,
     end else begin
       // no RAL model, get the default clk_rst_vif for the block
       // such as xbar, it doesn't has ral model, but it also needs a default clk_rst_vif
-      if (!uvm_config_db#(virtual clk_rst_if)::get(this, "", "clk_rst_vif", cfg.clk_rst_vif))
-      begin
-        `uvm_fatal(`gfn, "failed to get clk_rst_if from uvm_config_db")
+      if (cfg.clk_rst_vif == null &&
+          !uvm_config_db#(virtual clk_rst_if)::get(this, "", "clk_rst_vif", cfg.clk_rst_vif)) begin
+        `uvm_fatal(get_full_name(), "Failed to get clk_rst_if from uvm_config_db")
       end
       cfg.clk_rst_vif.set_freq_mhz(cfg.clk_freq_mhz);
     end
-
 
     // create components
     if (cfg.en_cov) begin
@@ -71,6 +63,24 @@ class dv_base_env #(type CFG_T               = dv_base_env_cfg,
     scoreboard = SCOREBOARD_T::type_id::create("scoreboard", this);
     scoreboard.cfg = cfg;
     scoreboard.cov = cov;
+  endfunction
+
+  // If cfg doesn't already have the vif, look up a clk_rst_if for ral_name in uvm_config_db. Either
+  // way, copy the selected clock frequency to the interface.
+  //
+  // This should be called after the frequency has been selected for ral_name (which happens as part
+  // of randomisation after setup with initialize())
+  local function void configure_clk_rst_vif(string ral_name, bit is_default_ral_name);
+    string if_name = is_default_ral_name ? "clk_rst_vif" : {"clk_rst_vif_", ral_name};
+
+    // If cfg doesn't already have the interface look one up in the config_db
+    if (!cfg.clk_rst_vifs.exists(ral_name) &&
+        !uvm_config_db#(virtual clk_rst_if)::get(this, "",
+                                                 if_name, cfg.clk_rst_vifs[ral_name])) begin
+      `uvm_fatal(get_full_name(), $sformatf("No clk_rst_if called %0s in uvm_config_db", ral_name))
+    end
+
+    cfg.clk_rst_vifs[ral_name].set_freq_mhz(cfg.clk_freqs_mhz[ral_name]);
   endfunction
 
 endclass


### PR DESCRIPTION
This way, it's possible to build a testbench where the environment doesn't modify the configuration. This change doesn't force code to use that structure, but makes it possible to work that way.