### PR TITLE
[dv] Remove the IfName parameter from clk_rst_if

### DIFF
--- a/hw/dv/sv/common_ifs/clk_rst_if.sv
+++ b/hw/dv/sv/common_ifs/clk_rst_if.sv
@@ -12,9 +12,7 @@
 // inout clk
 // inout rst_n
 
-interface clk_rst_if #(
-  parameter string IfName = "main"
-) (
+interface clk_rst_if (
   inout clk,
   inout rst_n
 );
@@ -101,8 +99,7 @@ interface clk_rst_if #(
   // If true, this is the only clock in the system; there is no need to add initial jitter.
   bit sole_clock = 1'b0;
 
-  // use IfName as a part of msgs to indicate which clk_rst_vif instance
-  string msg_id = $sformatf("[%m(clk_rst_if):%s]", IfName);
+  string msg_id = $sformatf("[%m(clk_rst_if)]");
 
   clocking cb @(posedge clk);
   endclocking

--- a/hw/top_darjeeling/dv/env/chip_if.sv
+++ b/hw/top_darjeeling/dv/env/chip_if.sv
@@ -463,7 +463,7 @@ interface chip_if;
   // Functional (muxed) interface: external clock source.
   //
   // The reset port is passive only.
-  clk_rst_if#("ExtClkDriver") ext_clk_if(
+  clk_rst_if ext_clk_if(
      .clk (mios[top_darjeeling_pkg::MioPadMio11]),
     .rst_n(dios[top_darjeeling_pkg::DioPadPorN])
   );

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -620,7 +620,7 @@ interface chip_if;
   // Functional (muxed) interface: external clock source.
   //
   // The reset port is passive only.
-  clk_rst_if#("ExtClkDriver") ext_clk_if(
+  clk_rst_if ext_clk_if(
      .clk (mios[top_earlgrey_pkg::MioPadIoc6]),
     .rst_n(dios[top_earlgrey_pkg::DioPadPorN])
   );


### PR DESCRIPTION
Having the parameter is problematic because it's not technically correct to assign one of these interfaces to a variable of type "virtual clk_rst_if".

It turns out that there is exactly on place where the parameter is supplied (and copy-pasted into Darjeeling).

I think this change will have no effect. In particular, there are no hits when searching for "ExtClkDriver". The only use I can find for IfName in this interface is the computation of msg_id. These identifiers will already be distinct (and hopefully helpfully named) because they are derived with %m.