### PR TITLE
[dv,ate] add ATE test to perform bootstrap erase [merge-back]

### DIFF
--- a/hw/top_earlgrey/dv/chip_manuf_ate_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_manuf_ate_tests.hjson
@@ -8,6 +8,19 @@
   # Note: Please maintain alphabetical order.
   tests: [
     {
+      name: ate_bootstrap_flash_erase
+      uvm_test_seq: chip_sw_ate_bootstrap_flash_erase_vseq
+      # We do not need to load any flash images as this test is entirely host driven.
+      sw_images: []
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=160_000_000"
+        "+skip_flash_bkdr_load=1",
+        "+use_spi_load_bootstrap=1",
+      ]
+      run_timeout_mins: 180
+    }
+    {
       name: ate_bootstrap_disjoint
       uvm_test_seq: chip_sw_ate_bootstrap_disjoint_vseq
       sw_images: ["//sw/device/silicon_creator/manuf/tests:multislot_empty_test:1:new_rules"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -141,6 +141,7 @@ filesets:
       - seq_lib/chip_sw_aes_masking_off_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_flash_host_gnt_err_inj_vseq.sv: {is_include_file: true}
       - seq_lib/chip_padctrl_attributes_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_ate_bootstrap_flash_erase_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_ate_bootstrap_disjoint_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_e2e_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_e2e_shutdown_exception_c_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_ate_bootstrap_flash_erase_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_ate_bootstrap_flash_erase_vseq.sv
@@ -1,0 +1,57 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This test performs a the first step of a ROM bootstrap operation, i.e., flash erase. It then
+// confirms flash has been erased by reading back a few SPI flash frames to check they are all 1s
+// (which matches the erased state).
+
+class chip_sw_ate_bootstrap_flash_erase_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_ate_bootstrap_flash_erase_vseq)
+
+  function new (string name="");
+    super.new(name);
+  endfunction
+
+  local function automatic void _check_flash_data_page(input int unsigned address,
+                                                       input bit [31:0]   expected);
+    logic [TL_DW-1:0] actual;
+    actual = cfg.mem_bkdr_util_h[FlashBank0Data].read32(address);
+    `DV_CHECK_EQ(actual, expected)
+  endfunction
+
+  virtual task body();
+    spi_host_flash_seq m_spi_host_seq;
+
+    super.body();
+
+    // Drive SW straps for bootstrap.
+    `uvm_info(get_name(), "Driving SW straps high for bootstrap.", UVM_LOW)
+    cfg.chip_vif.sw_straps_if.drive(3'h7);
+
+    // Set CSB inactive times to reasonable values. sys_clk is at 24 MHz, and
+    // it needs to capture CSB pulses.
+    cfg.m_spi_host_agent_cfg.min_idle_ns_after_csb_drop = 50;
+    cfg.m_spi_host_agent_cfg.max_idle_ns_after_csb_drop = 200;
+
+    // Configure the spi_agent for flash mode and add command info.
+    `uvm_info(get_name(), "Configuring SPI flash commands", UVM_LOW)
+    spi_agent_configure_flash_cmds(cfg.m_spi_host_agent_cfg);
+
+    // Wait for the SPI flash commands to be configured by the (test) ROM.
+    `uvm_info(get_name(), "Waiting for SPI flash cmds on device to load", UVM_LOW)
+    wait_for_flash_command_load();
+
+    `uvm_info(get_name(), "Sending SPI flash erase command", UVM_LOW)
+    erase_flash_over_spi();
+
+    // Read first flash data word to confirm they are erased.
+    `uvm_info(get_name(), "Checking the first data word was erased", UVM_LOW)
+    _check_flash_data_page('h0, 32'hFFFF_FFFF);
+
+    // Set test passed.
+    cfg.chip_vif.sw_straps_if.drive(3'h0);
+    assert_por_reset();
+    override_test_status_and_finish(.passed(1'b1));
+  endtask
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -509,30 +509,8 @@ class chip_sw_base_vseq extends chip_base_vseq;
     spi_host_wait_on_busy(busy_timeout_ns, busy_poll_interval_ns);
   endtask
 
-  // Load the flash binary specified by the `sw_image` path by sending a chip erase, then
-  // programming pages in sequence via the SPI flash interface presented by the ROM. Afterwards,
-  // bring the software straps back to 0, and issue a power-on reset.
-  //
-  // The `sw_image` path should point to an image usable by the `read_sw_frames` task.
-  //
-  // This task assumes the device was booted with software straps set before entry. In addition, it
-  // expects that the spi_agent was connected to the spi_device and is ready to issue flash
-  // transactions.
-  task spi_device_load_bootstrap(string sw_image);
-    spi_host_flash_seq m_spi_host_seq;
-    byte sw_byte_q[$];
-    uint bytes_to_write;
-    uint SPI_FLASH_PAGE_SIZE = 256;
-
-    // Set CSB inactive times to reasonable values. sys_clk is at 24 MHz, and
-    // it needs to capture CSB pulses.
-    cfg.m_spi_host_agent_cfg.min_idle_ns_after_csb_drop = 50;
-    cfg.m_spi_host_agent_cfg.max_idle_ns_after_csb_drop = 200;
-
-    // Configure the spi_agent for flash mode and add command info.
-    spi_agent_configure_flash_cmds(cfg.m_spi_host_agent_cfg);
-
-    // Wait for the commands to be ready
+  // Wait for each of the SPI flash commands on the device to be loaded
+  protected task wait_for_flash_command_load();
     csr_spinwait(
       .ptr(ral.spi_device.cmd_info[spi_device_pkg::CmdInfoReadSfdp].opcode),
       .exp_data(SpiFlashReadSfdp),
@@ -548,15 +526,47 @@ class chip_sw_base_vseq extends chip_base_vseq;
       .exp_data(SpiFlashWriteEnable),
       .backdoor(1),
       .spinwait_delay_ns(5000));
+  endtask
+
+  // Send a SPI command to request that flash is erased
+  protected task erase_flash_over_spi();
+    spi_host_flash_seq erase_seq;
+
+    erase_seq = spi_host_flash_seq::type_id::create("erase_seq");
+    erase_seq.opcode = SpiFlashChipErase;
+    spi_host_flash_issue_write_cmd(.write_command(erase_seq),
+                                   .busy_timeout_ns(200_000_000),
+                                   .busy_poll_interval_ns(1_000_000));
+  endtask
+
+  // Load the flash binary specified by the `sw_image` path by sending a chip erase, then
+  // programming pages in sequence via the SPI flash interface presented by the ROM. Afterwards,
+  // bring the software straps back to 0, and issue a power-on reset.
+  //
+  // The `sw_image` path should point to an image usable by the `read_sw_frames` task.
+  //
+  // This task assumes the device was booted with software straps set before entry. In addition, it
+  // expects that the spi_agent was connected to the spi_device and is ready to issue flash
+  // transactions.
+  task spi_device_load_bootstrap(string sw_image);
+    byte sw_byte_q[$];
+    uint bytes_to_write;
+    uint SPI_FLASH_PAGE_SIZE = 256;
+
+    // Set CSB inactive times to reasonable values. sys_clk is at 24 MHz, and
+    // it needs to capture CSB pulses.
+    cfg.m_spi_host_agent_cfg.min_idle_ns_after_csb_drop = 50;
+    cfg.m_spi_host_agent_cfg.max_idle_ns_after_csb_drop = 200;
+
+    // Configure the spi_agent for flash mode and add command info.
+    spi_agent_configure_flash_cmds(cfg.m_spi_host_agent_cfg);
+
+    // Wait for the commands to be ready
+    wait_for_flash_command_load();
 
     read_sw_frames(sw_image, sw_byte_q);
 
-    `uvm_create_on(m_spi_host_seq, p_sequencer.spi_host_sequencer_h)
-    m_spi_host_seq.opcode = SpiFlashChipErase;
-    spi_host_flash_issue_write_cmd(
-      .write_command(m_spi_host_seq),
-      .busy_timeout_ns(200_000_000),
-      .busy_poll_interval_ns(1_000_000));
+    erase_flash_over_spi();
 
     for (int unsigned idx = 0; idx < sw_byte_q.size(); idx += SPI_FLASH_PAGE_SIZE) begin
       spi_write_flash_page(sw_byte_q, idx, SPI_FLASH_PAGE_SIZE);

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -104,6 +104,7 @@
 `include "chip_sw_rom_e2e_jtag_debug_vseq.sv"
 `include "chip_sw_rom_e2e_jtag_inject_vseq.sv"
 `include "chip_sw_rom_e2e_self_hash_gls_vseq.sv"
+`include "chip_sw_ate_bootstrap_flash_erase_vseq.sv"
 `include "chip_sw_ate_bootstrap_disjoint_vseq.sv"
 `include "chip_sw_power_idle_load_vseq.sv"
 `include "chip_sw_power_sleep_load_vseq.sv"


### PR DESCRIPTION
*This PR is in draft because it depends on #29475 and #29476.*

This adds a simple ATE DV test that puts the DUT in bootstrap mode and
then drives the correct SPI sequence to erase all of flash, which is the
first part of performing a bootstrap operation. This will aid ATE
bringup work.

This is a cherry-picked version of commit b59973a6e1, which was
added to the earlgrey_1.0.0 branch in May 2025.
