### PR TITLE
[ci] Temporarily disable USB deep reset test (earlgrey_1.0.0)

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -5398,6 +5398,8 @@ opentitan_test(
         "usbdev_deep_reset_test.c",
     ],
     cw310 = fpga_params(
+        # FIXME (#29490) - we are temporarily experiencing USB issues in CI.
+        tags = ["broken"],
         test_cmd = """
             --bootstrap="{firmware}"
             --fin-phase=deep-reset


### PR DESCRIPTION
See https://github.com/lowRISC/opentitan/issues/29490

Backport of https://github.com/lowRISC/opentitan/pull/29491