### PR TITLE
[crypto/kat] Add skip_stride to KATs

### DIFF
--- a/sw/host/tests/crypto/aes_gcm_nist_kat/BUILD
+++ b/sw/host/tests/crypto/aes_gcm_nist_kat/BUILD
@@ -18,6 +18,8 @@ rust_binary(
         "@crate_index//:clap",
         "@crate_index//:humantime",
         "@crate_index//:log",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
         "@crate_index//:serde",
         "@crate_index//:serde_json",
     ],

--- a/sw/host/tests/crypto/aes_gcm_nist_kat/src/main.rs
+++ b/sw/host/tests/crypto/aes_gcm_nist_kat/src/main.rs
@@ -5,6 +5,7 @@
 use anyhow::Result;
 use arrayvec::ArrayVec;
 use clap::Parser;
+use std::cmp::min;
 use std::fs;
 use std::time::Duration;
 
@@ -21,6 +22,9 @@ use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
+use rand::RngCore;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
 
 #[derive(Debug, Parser)]
 struct Opts {
@@ -30,6 +34,17 @@ struct Opts {
     // Console receive timeout.
     #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
     timeout: Duration,
+
+    // Reduce number of tests that are run by this factor.
+    // 1 out of skip_stride tests are run. The ID of the first test to run is
+    // (pseudo-)randomly chosen between 0 and skip_stride.
+    // If skip_stride is set to 0, all the tests are run
+    #[arg(long, default_value_t = 0usize)]
+    skip_stride: usize,
+
+    // Seed value for random number generator.
+    #[arg(long)]
+    seed: Option<u64>,
 
     #[arg(long, num_args = 1..)]
     aes_gcm_json: Vec<String>,
@@ -145,14 +160,37 @@ fn test_aes_gcm(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     )?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
+    let seed = opts.seed.unwrap_or_else(rand::random::<u64>);
+    log::info!("Using seed {}", seed);
+
+    // Create a determinitistic RNG from the seed for skipping
+    let mut drng = ChaCha8Rng::seed_from_u64(seed);
+    let (skip_stride, start_offset) = match (drng.next_u32() as usize).checked_rem(opts.skip_stride)
+    {
+        Some(offset) => (opts.skip_stride, offset),
+        // if opts.skip_stride is 0, skip_stride is set to 1 to execute all the tests
+        None => (1usize, 0usize),
+    };
+
     let mut test_counter = 0u32;
     let test_vector_files = &opts.aes_gcm_json;
     for file in test_vector_files {
         let raw_json = fs::read_to_string(file)?;
         let aes_gcm_tests: Vec<AesGcmTestCase> = serde_json::from_str(&raw_json)?;
 
+        // Ensure that at least one test per JSON file is run
+        let stride = min(skip_stride, aes_gcm_tests.len());
+        let offset = start_offset % stride;
+        log::info!("Tests options: skip_stride: {}, offset: {}", stride, offset);
+
         for aes_gcm_test in &aes_gcm_tests {
             test_counter += 1;
+
+            if (test_counter as usize % stride) != offset {
+                // Skip test
+                continue;
+            }
+
             log::info!("Test counter: {}", test_counter);
             run_aes_gcm_testcase(aes_gcm_test, opts, &spi_console_device)?;
         }

--- a/sw/host/tests/crypto/aes_nist_kat/BUILD
+++ b/sw/host/tests/crypto/aes_nist_kat/BUILD
@@ -18,6 +18,8 @@ rust_binary(
         "@crate_index//:clap",
         "@crate_index//:humantime",
         "@crate_index//:log",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
         "@crate_index//:serde",
         "@crate_index//:serde_json",
     ],

--- a/sw/host/tests/crypto/aes_nist_kat/src/main.rs
+++ b/sw/host/tests/crypto/aes_nist_kat/src/main.rs
@@ -5,6 +5,7 @@
 use anyhow::Result;
 use arrayvec::ArrayVec;
 use clap::Parser;
+use std::cmp::min;
 use std::fs;
 use std::time::Duration;
 
@@ -22,6 +23,9 @@ use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
+use rand::RngCore;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
 
 #[derive(Debug, Parser)]
 struct Opts {
@@ -31,6 +35,17 @@ struct Opts {
     // Console receive timeout.
     #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
     timeout: Duration,
+
+    // Reduce number of tests that are run by this factor.
+    // 1 out of skip_stride tests are run. The ID of the first test to run is
+    // (pseudo-)randomly chosen between 0 and skip_stride.
+    // If skip_stride is set to 0, all the tests are run
+    #[arg(long, default_value_t = 0usize)]
+    skip_stride: usize,
+
+    // Seed value for random number generator.
+    #[arg(long)]
+    seed: Option<u64>,
 
     #[arg(long, num_args = 1..)]
     aes_json: Vec<String>,
@@ -138,14 +153,37 @@ fn test_aes(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     )?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
+    let seed = opts.seed.unwrap_or_else(rand::random::<u64>);
+    log::info!("Using seed {}", seed);
+
+    // Create a deterministic RNG from the seed for skipping
+    let mut drng = ChaCha8Rng::seed_from_u64(seed);
+    let (skip_stride, start_offset) = match (drng.next_u32() as usize).checked_rem(opts.skip_stride)
+    {
+        Some(offset) => (opts.skip_stride, offset),
+        // if opts.skip_stride is 0, skip_stride is set to 1 to execute all the tests
+        None => (1usize, 0usize),
+    };
+
     let mut test_counter = 0u32;
     let test_vector_files = &opts.aes_json;
     for file in test_vector_files {
         let raw_json = fs::read_to_string(file)?;
         let aes_tests: Vec<AesTestCase> = serde_json::from_str(&raw_json)?;
 
+        // Ensure that at least one test per JSON file is run
+        let stride = min(skip_stride, aes_tests.len());
+        let offset = start_offset % stride;
+        log::info!("Tests options: skip_stride: {}, offset: {}", stride, offset);
+
         for aes_test in &aes_tests {
             test_counter += 1;
+
+            if (test_counter as usize % stride) != offset {
+                // Skip test
+                continue;
+            }
+
             log::info!("Test counter: {}", test_counter);
             run_aes_testcase(aes_test, opts, &spi_console_device)?;
         }

--- a/sw/host/tests/crypto/drbg_kat/BUILD
+++ b/sw/host/tests/crypto/drbg_kat/BUILD
@@ -18,6 +18,8 @@ rust_binary(
         "@crate_index//:clap",
         "@crate_index//:humantime",
         "@crate_index//:log",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
         "@crate_index//:serde",
         "@crate_index//:serde_json",
     ],

--- a/sw/host/tests/crypto/drbg_kat/src/main.rs
+++ b/sw/host/tests/crypto/drbg_kat/src/main.rs
@@ -5,6 +5,7 @@
 use anyhow::Result;
 use arrayvec::ArrayVec;
 use clap::Parser;
+use std::cmp::min;
 use std::fs;
 use std::time::Duration;
 
@@ -19,6 +20,9 @@ use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
+use rand::RngCore;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
 
 #[derive(Debug, Parser)]
 struct Opts {
@@ -28,6 +32,17 @@ struct Opts {
     // Console receive timeout.
     #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
     timeout: Duration,
+
+    // Reduce number of tests that are run by this factor.
+    // 1 out of skip_stride tests are run. The ID of the first test to run is
+    // (pseudo-)randomly chosen between 0 and skip_stride.
+    // If skip_stride is set to 0, all the tests are run
+    #[arg(long, default_value_t = 0usize)]
+    skip_stride: usize,
+
+    // Seed value for random number generator.
+    #[arg(long)]
+    seed: Option<u64>,
 
     #[arg(long, num_args = 1..)]
     drbg_json: Vec<String>,
@@ -136,6 +151,18 @@ fn test_drbg(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     )?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
+    let seed = opts.seed.unwrap_or_else(rand::random::<u64>);
+    log::info!("Using seed {}", seed);
+
+    // Create a deterministic RNG from the seed for skipping
+    let mut drng = ChaCha8Rng::seed_from_u64(seed);
+    let (skip_stride, start_offset) = match (drng.next_u32() as usize).checked_rem(opts.skip_stride)
+    {
+        Some(offset) => (opts.skip_stride, offset),
+        // if opts.skip_stride is 0, skip_stride is set to 1 to execute all the tests
+        None => (1usize, 0usize),
+    };
+
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;
     let test_vector_files = &opts.drbg_json;
@@ -143,8 +170,19 @@ fn test_drbg(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         let raw_json = fs::read_to_string(file)?;
         let drbg_tests: Vec<DrbgTestCase> = serde_json::from_str(&raw_json)?;
 
+        // Ensure that at least one test per JSON file is run
+        let stride = min(skip_stride, drbg_tests.len());
+        let offset = start_offset % stride;
+        log::info!("Tests options: skip_stride: {}, offset: {}", stride, offset);
+
         for drbg_test in &drbg_tests {
             test_counter += 1;
+
+            if (drbg_test.test_case_id % stride) != offset {
+                // Skip test
+                continue;
+            }
+
             log::info!("Test counter: {}", test_counter);
             run_drbg_testcase(drbg_test, opts, &spi_console_device, &mut fail_counter)?;
         }

--- a/sw/host/tests/crypto/ecdh_kat/BUILD
+++ b/sw/host/tests/crypto/ecdh_kat/BUILD
@@ -21,6 +21,8 @@ rust_binary(
         "@crate_index//:num-bigint-dig",
         "@crate_index//:p256",
         "@crate_index//:p384",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
         "@crate_index//:serde",
         "@crate_index//:serde_json",
     ],

--- a/sw/host/tests/crypto/ecdh_kat/src/main.rs
+++ b/sw/host/tests/crypto/ecdh_kat/src/main.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use arrayvec::ArrayVec;
 use clap::Parser;
 use num_bigint_dig::BigUint;
+use std::cmp::min;
 use std::fs;
 use std::time::Duration;
 
@@ -26,6 +27,9 @@ use p256::U256;
 use p256::elliptic_curve::scalar::ScalarPrimitive as ScalarPrimitiveP256;
 use p384::U384;
 use p384::elliptic_curve::scalar::ScalarPrimitive as ScalarPrimitiveP384;
+use rand::RngCore;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
 
 const ECDH_CMD_MAX_COORDINATE_BYTES_P256: usize = 32;
 const ECDH_CMD_MAX_PRIVATE_KEY_BYTES_P256: usize = 32;
@@ -45,6 +49,17 @@ struct Opts {
     // Console receive timeout.
     #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
     timeout: Duration,
+
+    // Reduce number of tests that are run by this factor.
+    // 1 out of skip_stride tests are run. The ID of the first test to run is
+    // (pseudo-)randomly chosen between 0 and skip_stride.
+    // If skip_stride is set to 0, all the tests are run
+    #[arg(long, default_value_t = 0usize)]
+    skip_stride: usize,
+
+    // Seed value for random number generator.
+    #[arg(long)]
+    seed: Option<u64>,
 
     #[arg(long, num_args = 1..)]
     ecdh_json: Vec<String>,
@@ -228,6 +243,18 @@ fn test_ecdh(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     )?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
+    let seed = opts.seed.unwrap_or_else(rand::random::<u64>);
+    log::info!("Using seed {}", seed);
+
+    // Create a deterministic RNG from the seed for skipping
+    let mut drng = ChaCha8Rng::seed_from_u64(seed);
+    let (skip_stride, start_offset) = match (drng.next_u32() as usize).checked_rem(opts.skip_stride)
+    {
+        Some(offset) => (opts.skip_stride, offset),
+        // if opts.skip_stride is 0, skip_stride is set to 1 to execute all the tests
+        None => (1usize, 0usize),
+    };
+
     let mut test_counter = 0u32;
     let mut fail_counter = 0usize;
     let mut failures = vec![];
@@ -236,8 +263,19 @@ fn test_ecdh(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         let raw_json = fs::read_to_string(file)?;
         let ecdh_tests: Vec<EcdhTestCase> = serde_json::from_str(&raw_json)?;
 
+        // Ensure that at least one test per JSON file is run
+        let stride = min(skip_stride, ecdh_tests.len());
+        let offset = start_offset % stride;
+        log::info!("Tests options: skip_stride: {}, offset: {}", stride, offset);
+
         for ecdh_test in &ecdh_tests {
             test_counter += 1;
+
+            if (ecdh_test.test_case_id % stride) != offset {
+                // Skip test
+                continue;
+            }
+
             log::info!("Test counter: {}", test_counter);
             run_ecdh_testcase(
                 ecdh_test,

--- a/sw/host/tests/crypto/ecdsa_kat/BUILD
+++ b/sw/host/tests/crypto/ecdsa_kat/BUILD
@@ -23,6 +23,8 @@ rust_binary(
         "@crate_index//:num-traits",
         "@crate_index//:p256",
         "@crate_index//:p384",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
         "@crate_index//:serde",
         "@crate_index//:serde_json",
         "@crate_index//:sha2",

--- a/sw/host/tests/crypto/ecdsa_kat/src/main.rs
+++ b/sw/host/tests/crypto/ecdsa_kat/src/main.rs
@@ -18,6 +18,7 @@ use p384::elliptic_curve::scalar::ScalarPrimitive as ScalarPrimitiveP384;
 use serde::Deserialize;
 use sha2::digest::generic_array::GenericArray;
 use sha2::{Digest, Sha256, Sha384, Sha512};
+use std::cmp::min;
 use std::fs;
 use std::time::Duration;
 
@@ -34,6 +35,9 @@ use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
+use rand::RngCore;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
 
 #[derive(Debug, Parser)]
 struct Opts {
@@ -43,6 +47,17 @@ struct Opts {
     // Console receive timeout.
     #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
     timeout: Duration,
+
+    // Reduce number of tests that are run by this factor.
+    // 1 out of skip_stride tests are run. The ID of the first test to run is
+    // (pseudo-)randomly chosen between 0 and skip_stride.
+    // If skip_stride is set to 0, all the tests are run
+    #[arg(long, default_value_t = 0usize)]
+    skip_stride: usize,
+
+    // Seed value for random number generator.
+    #[arg(long)]
+    seed: Option<u64>,
 
     #[arg(long, num_args = 1..)]
     ecdsa_json: Vec<String>,
@@ -520,6 +535,18 @@ fn test_ecdsa(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     )?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
+    let seed = opts.seed.unwrap_or_else(rand::random::<u64>);
+    log::info!("Using seed {}", seed);
+
+    // Create a deterministic RNG from the seed for skipping
+    let mut drng = ChaCha8Rng::seed_from_u64(seed);
+    let (skip_stride, start_offset) = match (drng.next_u32() as usize).checked_rem(opts.skip_stride)
+    {
+        Some(offset) => (opts.skip_stride, offset),
+        // if opts.skip_stride is 0, skip_stride is set to 1 to execute all the tests
+        None => (1usize, 0usize),
+    };
+
     let mut test_counter = 0u32;
     let mut failures = vec![];
     let test_vector_files = &opts.ecdsa_json;
@@ -527,8 +554,19 @@ fn test_ecdsa(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         let raw_json = fs::read_to_string(file)?;
         let ecdsa_tests: Vec<EcdsaTestCase> = serde_json::from_str(&raw_json)?;
 
+        // Ensure that at least one test per JSON file is run
+        let stride = min(skip_stride, ecdsa_tests.len());
+        let offset = start_offset % stride;
+        log::info!("Tests options: skip_stride: {}, offset: {}", stride, offset);
+
         for ecdsa_test in &ecdsa_tests {
             test_counter += 1;
+
+            if (ecdsa_test.test_case_id % stride) != offset {
+                // Skip test
+                continue;
+            }
+
             log::info!("Test counter: {}", test_counter);
             run_ecdsa_testcase(ecdsa_test, opts, &spi_console_device, &mut failures)?;
         }

--- a/sw/host/tests/crypto/hash_kat/BUILD
+++ b/sw/host/tests/crypto/hash_kat/BUILD
@@ -18,6 +18,8 @@ rust_binary(
         "@crate_index//:clap",
         "@crate_index//:humantime",
         "@crate_index//:log",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
         "@crate_index//:serde",
         "@crate_index//:serde_json",
     ],

--- a/sw/host/tests/crypto/hash_kat/src/main.rs
+++ b/sw/host/tests/crypto/hash_kat/src/main.rs
@@ -5,6 +5,7 @@
 use anyhow::Result;
 use arrayvec::ArrayVec;
 use clap::Parser;
+use std::cmp::min;
 use std::fs;
 use std::time::Duration;
 
@@ -22,6 +23,9 @@ use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
+use rand::RngCore;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
 
 #[derive(Debug, Parser)]
 struct Opts {
@@ -31,6 +35,17 @@ struct Opts {
     // Console receive timeout.
     #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
     timeout: Duration,
+
+    // Reduce number of tests that are run by this factor.
+    // 1 out of skip_stride tests are run. The ID of the first test to run is
+    // (pseudo-)randomly chosen between 0 and skip_stride.
+    // If skip_stride is set to 0, all the tests are run
+    #[arg(long, default_value_t = 0usize)]
+    skip_stride: usize,
+
+    // Seed value for random number generator.
+    #[arg(long)]
+    seed: Option<u64>,
 
     #[arg(long, num_args = 1..)]
     hash_json: Vec<String>,
@@ -166,6 +181,18 @@ fn test_hash(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     )?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
+    let seed = opts.seed.unwrap_or_else(rand::random::<u64>);
+    log::info!("Using seed {}", seed);
+
+    // Create a deterministic RNG from the seed for skipping
+    let mut drng = ChaCha8Rng::seed_from_u64(seed);
+    let (skip_stride, start_offset) = match (drng.next_u32() as usize).checked_rem(opts.skip_stride)
+    {
+        Some(offset) => (opts.skip_stride, offset),
+        // if opts.skip_stride is 0, skip_stride is set to 1 to execute all the tests
+        None => (1usize, 0usize),
+    };
+
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;
     let test_vector_files = &opts.hash_json;
@@ -173,8 +200,19 @@ fn test_hash(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         let raw_json = fs::read_to_string(file)?;
         let hash_tests: Vec<HashTestCase> = serde_json::from_str(&raw_json)?;
 
+        // Ensure that at least one test per JSON file is run
+        let stride = min(skip_stride, hash_tests.len());
+        let offset = start_offset % stride;
+        log::info!("Tests options: skip_stride: {}, offset: {}", stride, offset);
+
         for hash_test in &hash_tests {
             test_counter += 1;
+
+            if (hash_test.test_case_id % stride) != offset {
+                // Skip test
+                continue;
+            }
+
             log::info!("Test counter: {}", test_counter);
             run_hash_testcase(hash_test, opts, &spi_console_device, &mut fail_counter)?;
         }

--- a/sw/host/tests/crypto/hmac_kat/BUILD
+++ b/sw/host/tests/crypto/hmac_kat/BUILD
@@ -18,6 +18,8 @@ rust_binary(
         "@crate_index//:clap",
         "@crate_index//:humantime",
         "@crate_index//:log",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
         "@crate_index//:serde",
         "@crate_index//:serde_json",
     ],

--- a/sw/host/tests/crypto/hmac_kat/src/main.rs
+++ b/sw/host/tests/crypto/hmac_kat/src/main.rs
@@ -5,6 +5,7 @@
 use anyhow::Result;
 use arrayvec::ArrayVec;
 use clap::Parser;
+use std::cmp::min;
 use std::fs;
 use std::time::Duration;
 
@@ -21,6 +22,9 @@ use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
+use rand::RngCore;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
 
 #[derive(Debug, Parser)]
 struct Opts {
@@ -30,6 +34,17 @@ struct Opts {
     // Console receive timeout.
     #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
     timeout: Duration,
+
+    // Reduce number of tests that are run by this factor.
+    // 1 out of skip_stride tests are run. The ID of the first test to run is
+    // (pseudo-)randomly chosen between 0 and skip_stride.
+    // If skip_stride is set to 0, all the tests are run
+    #[arg(long, default_value_t = 0usize)]
+    skip_stride: usize,
+
+    // Seed value for random number generator.
+    #[arg(long)]
+    seed: Option<u64>,
 
     #[arg(long, num_args = 1..)]
     hmac_json: Vec<String>,
@@ -134,6 +149,18 @@ fn test_hmac(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     )?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
+    let seed = opts.seed.unwrap_or_else(rand::random::<u64>);
+    log::info!("Using seed {}", seed);
+
+    // Create a deterministic RNG from the seed for skipping
+    let mut drng = ChaCha8Rng::seed_from_u64(seed);
+    let (skip_stride, start_offset) = match (drng.next_u32() as usize).checked_rem(opts.skip_stride)
+    {
+        Some(offset) => (opts.skip_stride, offset),
+        // if opts.skip_stride is 0, skip_stride is set to 1 to execute all the tests
+        None => (1usize, 0usize),
+    };
+
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;
     let test_vector_files = &opts.hmac_json;
@@ -141,8 +168,19 @@ fn test_hmac(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         let raw_json = fs::read_to_string(file)?;
         let hmac_tests: Vec<HmacTestCase> = serde_json::from_str(&raw_json)?;
 
+        // Ensure that at least one test per JSON file is run
+        let stride = min(skip_stride, hmac_tests.len());
+        let offset = start_offset % stride;
+        log::info!("Tests options: skip_stride: {}, offset: {}", stride, offset);
+
         for hmac_test in &hmac_tests {
             test_counter += 1;
+
+            if (hmac_test.test_case_id % stride) != offset {
+                // Skip test
+                continue;
+            }
+
             log::info!("Test counter: {}", test_counter);
             run_hmac_testcase(hmac_test, opts, &spi_console_device, &mut fail_counter)?;
         }

--- a/sw/host/tests/crypto/kmac_kat/BUILD
+++ b/sw/host/tests/crypto/kmac_kat/BUILD
@@ -18,6 +18,8 @@ rust_binary(
         "@crate_index//:clap",
         "@crate_index//:humantime",
         "@crate_index//:log",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
         "@crate_index//:serde",
         "@crate_index//:serde_json",
     ],

--- a/sw/host/tests/crypto/kmac_kat/src/main.rs
+++ b/sw/host/tests/crypto/kmac_kat/src/main.rs
@@ -5,6 +5,7 @@
 use anyhow::Result;
 use arrayvec::ArrayVec;
 use clap::Parser;
+use std::cmp::min;
 use std::fs;
 use std::time::Duration;
 
@@ -22,6 +23,9 @@ use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
+use rand::RngCore;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
 
 #[derive(Debug, Parser)]
 struct Opts {
@@ -31,6 +35,17 @@ struct Opts {
     // Console receive timeout.
     #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
     timeout: Duration,
+
+    // Reduce number of tests that are run by this factor.
+    // 1 out of skip_stride tests are run. The ID of the first test to run is
+    // (pseudo-)randomly chosen between 0 and skip_stride.
+    // If skip_stride is set to 0, all the tests are run
+    #[arg(long, default_value_t = 0usize)]
+    skip_stride: usize,
+
+    // Seed value for random number generator.
+    #[arg(long)]
+    seed: Option<u64>,
 
     #[arg(long, num_args = 1..)]
     kmac_json: Vec<String>,
@@ -149,6 +164,18 @@ fn test_kmac(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     )?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
+    let seed = opts.seed.unwrap_or_else(rand::random::<u64>);
+    log::info!("Using seed {}", seed);
+
+    // Create a deterministic RNG from the seed for skipping
+    let mut drng = ChaCha8Rng::seed_from_u64(seed);
+    let (skip_stride, start_offset) = match (drng.next_u32() as usize).checked_rem(opts.skip_stride)
+    {
+        Some(offset) => (opts.skip_stride, offset),
+        // if opts.skip_stride is 0, skip_stride is set to 1 to execute all the tests
+        None => (1usize, 0usize),
+    };
+
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;
     let test_vector_files = &opts.kmac_json;
@@ -156,8 +183,19 @@ fn test_kmac(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         let raw_json = fs::read_to_string(file)?;
         let kmac_tests: Vec<KmacTestCase> = serde_json::from_str(&raw_json)?;
 
+        // Ensure that at least one test per JSON file is run
+        let stride = min(skip_stride, kmac_tests.len());
+        let offset = start_offset % stride;
+        log::info!("Tests options: skip_stride: {}, offset: {}", stride, offset);
+
         for kmac_test in &kmac_tests {
             test_counter += 1;
+
+            if (kmac_test.test_case_id % stride) != offset {
+                // Skip test
+                continue;
+            }
+
             log::info!("Test counter: {}", test_counter);
             run_kmac_testcase(kmac_test, opts, &spi_console_device, &mut fail_counter)?;
         }

--- a/sw/host/tests/crypto/rsa_kat/BUILD
+++ b/sw/host/tests/crypto/rsa_kat/BUILD
@@ -18,6 +18,8 @@ rust_binary(
         "@crate_index//:clap",
         "@crate_index//:humantime",
         "@crate_index//:log",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
         "@crate_index//:serde",
         "@crate_index//:serde_json",
     ],

--- a/sw/host/tests/crypto/rsa_kat/src/main.rs
+++ b/sw/host/tests/crypto/rsa_kat/src/main.rs
@@ -5,6 +5,7 @@
 use anyhow::Result;
 use arrayvec::ArrayVec;
 use clap::Parser;
+use std::cmp::min;
 use std::fs;
 use std::time::Duration;
 
@@ -22,6 +23,9 @@ use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
+use rand::RngCore;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
 
 #[derive(Debug, Parser)]
 struct Opts {
@@ -31,6 +35,17 @@ struct Opts {
     // Console receive timeout.
     #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
     timeout: Duration,
+
+    // Reduce number of tests that are run by this factor.
+    // 1 out of skip_stride tests are run. The ID of the first test to run is
+    // (pseudo-)randomly chosen between 0 and skip_stride.
+    // If skip_stride is set to 0, all the tests are run
+    #[arg(long, default_value_t = 0usize)]
+    skip_stride: usize,
+
+    // Seed value for random number generator.
+    #[arg(long)]
+    seed: Option<u64>,
 
     #[arg(long, num_args = 1..)]
     rsa_json: Vec<String>,
@@ -246,12 +261,34 @@ fn test_rsa(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     )?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
+    let seed = opts.seed.unwrap_or_else(rand::random::<u64>);
+    log::info!("Using seed {}", seed);
+
+    // Create a deterministic RNG from the seed for skipping
+    let mut drng = ChaCha8Rng::seed_from_u64(seed);
+    let (skip_stride, start_offset) = match (drng.next_u32() as usize).checked_rem(opts.skip_stride)
+    {
+        Some(offset) => (opts.skip_stride, offset),
+        // if opts.skip_stride is 0, skip_stride is set to 1 to execute all the tests
+        None => (1usize, 0usize),
+    };
+
     let test_vector_files = &opts.rsa_json;
     for file in test_vector_files {
         let raw_json = fs::read_to_string(file)?;
         let rsa_tests: Vec<RsaTestCase> = serde_json::from_str(&raw_json)?;
 
+        // Ensure that at least one test per JSON file is run
+        let stride = min(skip_stride, rsa_tests.len());
+        let offset = start_offset % stride;
+        log::info!("Tests options: skip_stride: {}, offset: {}", stride, offset);
+
         for rsa_test in &rsa_tests {
+            if (rsa_test.test_case_id as usize % stride) != offset {
+                // Skip test
+                continue;
+            }
+
             log::info!("Test counter: {}", rsa_test.test_case_id);
             run_rsa_testcase(rsa_test, opts, &spi_console_device)?;
         }

--- a/sw/host/tests/crypto/sphincsplus_kat/BUILD
+++ b/sw/host/tests/crypto/sphincsplus_kat/BUILD
@@ -18,6 +18,8 @@ rust_binary(
         "@crate_index//:clap",
         "@crate_index//:humantime",
         "@crate_index//:log",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
         "@crate_index//:serde",
         "@crate_index//:serde_json",
     ],

--- a/sw/host/tests/crypto/sphincsplus_kat/src/main.rs
+++ b/sw/host/tests/crypto/sphincsplus_kat/src/main.rs
@@ -5,6 +5,7 @@
 use anyhow::Result;
 use arrayvec::ArrayVec;
 use clap::Parser;
+use std::cmp::min;
 use std::fs;
 use std::time::Duration;
 
@@ -23,6 +24,9 @@ use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
+use rand::RngCore;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
 
 #[derive(Debug, Parser)]
 struct Opts {
@@ -32,6 +36,17 @@ struct Opts {
     // Console receive timeout.
     #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
     timeout: Duration,
+
+    // Reduce number of tests that are run by this factor.
+    // 1 out of skip_stride tests are run. The ID of the first test to run is
+    // (pseudo-)randomly chosen between 0 and skip_stride.
+    // If skip_stride is set to 0, all the tests are run
+    #[arg(long, default_value_t = 0usize)]
+    skip_stride: usize,
+
+    // Seed value for random number generator.
+    #[arg(long)]
+    seed: Option<u64>,
 
     #[arg(long, num_args = 1..)]
     sphincsplus_json: Vec<String>,
@@ -135,6 +150,18 @@ fn test_sphincsplus(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     )?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
+    let seed = opts.seed.unwrap_or_else(rand::random::<u64>);
+    log::info!("Using seed {}", seed);
+
+    // Create a deterministic RNG from the seed for skipping
+    let mut drng = ChaCha8Rng::seed_from_u64(seed);
+    let (skip_stride, start_offset) = match (drng.next_u32() as usize).checked_rem(opts.skip_stride)
+    {
+        Some(offset) => (opts.skip_stride, offset),
+        // if opts.skip_stride is 0, skip_stride is set to 1 to execute all the tests
+        None => (1usize, 0usize),
+    };
+
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;
     let test_vector_files = &opts.sphincsplus_json;
@@ -142,8 +169,19 @@ fn test_sphincsplus(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         let raw_json = fs::read_to_string(file)?;
         let sphincsplus_tests: Vec<SphincsPlusTestCase> = serde_json::from_str(&raw_json)?;
 
+        // Ensure that at least one test per JSON file is run
+        let stride = min(skip_stride, sphincsplus_tests.len());
+        let offset = start_offset % stride;
+        log::info!("Tests options: skip_stride: {}, offset: {}", stride, offset);
+
         for sphincsplus_test in &sphincsplus_tests {
             test_counter += 1;
+
+            if (sphincsplus_test.test_case_id % stride) != offset {
+                // Skip test
+                continue;
+            }
+
             log::info!("Test counter: {}", test_counter);
             run_sphincsplus_testcase(
                 sphincsplus_test,


### PR DESCRIPTION
Add the skip_stride argument to the KATs in order to have the ability to
skip a certain number of tests to run tests quicker.
For example, add --test_arg=--skip-stride=15 to the test command.
    
With thanks to Elieva Pignat <elievap@google.com>