### PR TITLE
[cov,rescue] Remove unreachable return in usb rescue_protocol

### DIFF
--- a/sw/device/silicon_creator/lib/rescue/rescue_usb.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue_usb.c
@@ -184,5 +184,4 @@ rom_error_t rescue_protocol(boot_data_t *bootdata, boot_log_t *boot_log,
     RETURN_IF_ERROR(rescue_inactivity(&ctx.state));
     usb_poll();
   }
-  return kErrorOk;
 }


### PR DESCRIPTION
The loop in `rescue_protocol` is intended to be infinite, polling for USB events. This change removes the unnecessary and unreachable return statement to satisfy coverage analysis.