### PR TITLE
[rv_core_ibex] Bump to v2.2.0 at D0/V0/S0

### DIFF
--- a/hw/ip_templates/rv_core_ibex/data/rv_core_ibex.hjson.tpl
+++ b/hw/ip_templates/rv_core_ibex/data/rv_core_ibex.hjson.tpl
@@ -19,11 +19,25 @@
   hw_checklist:       "../doc/checklist",
   sw_checklist:       "/sw/device/lib/dif/dif_${module_instance_name}",
   dv_doc:             "../doc/dv",
-  version:            "2.1.0",
-  life_stage:         "L1",
-  design_stage:       "D2S",
-  verification_stage: "V2S",
-  dif_stage:          "S2",
+  revisions: [
+      {
+          version:            "2.1.0",
+          life_stage:         "L1",
+          design_stage:       "D2S",
+          verification_stage: "V2S",
+          dif_stage:          "S2",
+          commit_id:          "fddea1c8e8a97c6817cb091d80eb226d4f94934d",
+          notes:              ""
+      },
+      {
+          version:            "2.2.0",
+          life_stage:         "L1",
+          design_stage:       "D0",
+          verification_stage: "V0",
+          dif_stage:          "S0",
+          notes:              ""
+      },
+  ]
   notes:              "Ibex Verification is tracked in the [Ibex documentation](https://ibex-core.readthedocs.io/en/latest/03_reference/verification_stages.html)."
   clocking: [{clock: "clk_i", reset: "rst_ni", primary: true},
              {clock: "clk_edn_i", reset: "rst_edn_ni"}

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
@@ -19,11 +19,25 @@
   hw_checklist:       "../doc/checklist",
   sw_checklist:       "/sw/device/lib/dif/dif_rv_core_ibex",
   dv_doc:             "../doc/dv",
-  version:            "2.1.0",
-  life_stage:         "L1",
-  design_stage:       "D2S",
-  verification_stage: "V2S",
-  dif_stage:          "S2",
+  revisions: [
+      {
+          version:            "2.1.0",
+          life_stage:         "L1",
+          design_stage:       "D2S",
+          verification_stage: "V2S",
+          dif_stage:          "S2",
+          commit_id:          "fddea1c8e8a97c6817cb091d80eb226d4f94934d",
+          notes:              ""
+      },
+      {
+          version:            "2.2.0",
+          life_stage:         "L1",
+          design_stage:       "D0",
+          verification_stage: "V0",
+          dif_stage:          "S0",
+          notes:              ""
+      },
+  ]
   notes:              "Ibex Verification is tracked in the [Ibex documentation](https://ibex-core.readthedocs.io/en/latest/03_reference/verification_stages.html)."
   clocking: [{clock: "clk_i", reset: "rst_ni", primary: true},
              {clock: "clk_edn_i", reset: "rst_edn_ni"}

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
@@ -19,11 +19,25 @@
   hw_checklist:       "../doc/checklist",
   sw_checklist:       "/sw/device/lib/dif/dif_rv_core_ibex",
   dv_doc:             "../doc/dv",
-  version:            "2.1.0",
-  life_stage:         "L1",
-  design_stage:       "D2S",
-  verification_stage: "V2S",
-  dif_stage:          "S2",
+  revisions: [
+      {
+          version:            "2.1.0",
+          life_stage:         "L1",
+          design_stage:       "D2S",
+          verification_stage: "V2S",
+          dif_stage:          "S2",
+          commit_id:          "fddea1c8e8a97c6817cb091d80eb226d4f94934d",
+          notes:              ""
+      },
+      {
+          version:            "2.2.0",
+          life_stage:         "L1",
+          design_stage:       "D0",
+          verification_stage: "V0",
+          dif_stage:          "S0",
+          notes:              ""
+      },
+  ]
   notes:              "Ibex Verification is tracked in the [Ibex documentation](https://ibex-core.readthedocs.io/en/latest/03_reference/verification_stages.html)."
   clocking: [{clock: "clk_i", reset: "rst_ni", primary: true},
              {clock: "clk_edn_i", reset: "rst_edn_ni"}

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
@@ -19,11 +19,25 @@
   hw_checklist:       "../doc/checklist",
   sw_checklist:       "/sw/device/lib/dif/dif_rv_core_ibex",
   dv_doc:             "../doc/dv",
-  version:            "2.1.0",
-  life_stage:         "L1",
-  design_stage:       "D2S",
-  verification_stage: "V2S",
-  dif_stage:          "S2",
+  revisions: [
+      {
+          version:            "2.1.0",
+          life_stage:         "L1",
+          design_stage:       "D2S",
+          verification_stage: "V2S",
+          dif_stage:          "S2",
+          commit_id:          "fddea1c8e8a97c6817cb091d80eb226d4f94934d",
+          notes:              ""
+      },
+      {
+          version:            "2.2.0",
+          life_stage:         "L1",
+          design_stage:       "D0",
+          verification_stage: "V0",
+          dif_stage:          "S0",
+          notes:              ""
+      },
+  ]
   notes:              "Ibex Verification is tracked in the [Ibex documentation](https://ibex-core.readthedocs.io/en/latest/03_reference/verification_stages.html)."
   clocking: [{clock: "clk_i", reset: "rst_ni", primary: true},
              {clock: "clk_edn_i", reset: "rst_edn_ni"}


### PR DESCRIPTION
Lowering Ibex design/verification stages to reflect new extensions and ongoing work.

@andreaskurth @vogelpi Should we pin the previous D2S/V2S version and create a new entry for the current development, rather than just lowering the stages? Similar to how we did for OTBN?