### PR TITLE
[alert,dv] Make the alert/esc monitor control cfg.in_reset

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_base_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_base_monitor.sv
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-// ---------------------------------------------
-// Alert sender receiver interface base monitor
-// ---------------------------------------------
+// A base class for monitors that track alert/escalation items and watch an alert_esc_if.
 
 class alert_esc_base_monitor extends dv_base_monitor #(
   .ITEM_T(alert_esc_seq_item),
@@ -14,18 +12,16 @@ class alert_esc_base_monitor extends dv_base_monitor #(
 );
 
   `uvm_component_utils(alert_esc_base_monitor)
+
+  // The output port that reports alert/escalation items that have been seen
   uvm_analysis_port #(alert_esc_seq_item) alert_esc_port;
 
-  // A flag maintained by reset_thread. This is high when rst_n is low.
-  protected bit under_reset;
-
-  extern function new (string name, uvm_component parent);
-  extern function void build_phase(uvm_phase phase);
+  extern function new(string name, uvm_component parent);
+  extern virtual function void build_phase(uvm_phase phase);
   extern virtual task run_phase(uvm_phase phase);
-  extern local task reset_thread();
-  // this function can be used in derived classes to reset local signals/variables if needed
-  extern virtual function void reset_signals();
 
+  // Reset config flags to their initial values (at the end of a reset)
+  extern local function void reset_signals();
 endclass : alert_esc_base_monitor
 
 function alert_esc_base_monitor::new (string name, uvm_component parent);
@@ -38,20 +34,27 @@ function void alert_esc_base_monitor::build_phase(uvm_phase phase);
 endfunction : build_phase
 
 task alert_esc_base_monitor::run_phase(uvm_phase phase);
-  reset_thread();
-endtask : run_phase
+  fork
+    super.run_phase(phase);
+    begin
+      // Make sure that in_reset is correct at the start of the phase, then check that we are
+      // genuinely in reset by the start of the loop.
+      cfg.in_reset = (cfg.vif.rst_n !== 1'b1);
+      wait(!cfg.vif.rst_n);
 
-task alert_esc_base_monitor::reset_thread();
-  under_reset = 1;
-  forever begin
-    wait(!cfg.vif.rst_n);
-    under_reset = 1;
-    wait(cfg.vif.rst_n);
-    // reset signals at posedge rst_n to avoid race condition at negedge rst_n
-    reset_signals();
-    under_reset = 0;
-  end
-endtask : reset_thread
+      forever begin
+        cfg.in_reset = 1;
+        wait (cfg.vif.rst_n);
+
+        // reset signals at posedge rst_n to avoid race condition at negedge rst_n
+        reset_signals();
+        cfg.in_reset = 0;
+
+        wait (!cfg.vif.rst_n);
+      end
+    end
+  join
+endtask : run_phase
 
 function void alert_esc_base_monitor::reset_signals();
   cfg.under_ping_handshake = 0;

--- a/hw/dv/sv/alert_esc_agent/alert_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_monitor.sv
@@ -73,7 +73,7 @@ class alert_monitor extends alert_esc_base_monitor;
   //
   // Unlike ping_thread (which calls this task), monitor_ping_handshake doesn't wait for the ack.
   //
-  // This task ignores cfg.en_alert_lpg and under_reset: if either become true, this task will be
+  // This task ignores cfg.en_alert_lpg and cfg.in_reset: if either become true, this task will be
   // killed by something further up the stack.
   extern local task monitor_ping_handshake();
 
@@ -116,15 +116,15 @@ function alert_monitor::new (string name, uvm_component parent);
 endfunction : new
 
 task alert_monitor::run_phase(uvm_phase phase);
-  // Run the base class run_phase task in parallel (which maintains the under_reset flag).
+  // Run the base class run_phase task in parallel (which maintains the cfg.in_reset flag).
   fork
     super.run_phase(phase);
     forever begin
-      wait (!under_reset);
+      wait (!cfg.in_reset);
       fork begin : isolation_fork
         fork
           run_between_resets();
-          wait (under_reset);
+          wait (cfg.in_reset);
         join_any
         disable fork;
         on_reset();

--- a/hw/dv/sv/alert_esc_agent/esc_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_monitor.sv
@@ -41,13 +41,12 @@ function esc_monitor::new (string name, uvm_component parent);
 endfunction : new
 
 task esc_monitor::run_phase(uvm_phase phase);
-  // Run the base class run_phase task in parallel (which runs reset_thread, maintaining the
-  // under_reset flag). For the escalation monitor in particular, don't start all the tasks until
-  // reset has finished.
+  // Run the base class run_phase task in parallel (which maintains the cfg.in_reset flag). For the
+  // escalation monitor in particular, don't start all the tasks until reset has finished.
   fork
     super.run_phase(phase);
     begin
-      wait(!under_reset);
+      wait (!cfg.in_reset);
       fork
         esc_thread();
         unexpected_resp_thread();
@@ -60,7 +59,7 @@ endtask : run_phase
 task esc_monitor::esc_thread();
   alert_esc_seq_item req, req_clone;
   forever @(cfg.vif.monitor_cb) begin
-    if (!under_reset && get_esc() === 1'b1) begin
+    if (!cfg.in_reset && get_esc() === 1'b1) begin
       req = alert_esc_seq_item::type_id::create("req");
       req.sig_cycle_cnt++;
       if (is_sig_int_err()) req.esc_handshake_sta = EscIntFail;
@@ -77,12 +76,12 @@ task esc_monitor::esc_thread();
         while (req.esc_handshake_sta != EscRespComplete &&
                ping_cnter < cfg.ping_timeout_cycle &&
                !cfg.get_esc_en() &&
-               !under_reset) begin
+               !cfg.in_reset) begin
           @(cfg.vif.monitor_cb);
           check_esc_resp(.req(req), .is_ping(1), .ping_triggered(1));
           ping_cnter ++;
         end
-        if (under_reset) continue;
+        if (cfg.in_reset) continue;
         if (ping_cnter >= cfg.ping_timeout_cycle) begin
           alert_esc_seq_item req_clone;
           `downcast(req_clone, req.clone());
@@ -143,7 +142,7 @@ task esc_monitor::unexpected_resp_thread();
     while (get_esc() === 1'b0 && !cfg.under_ping_handshake) begin
       @(cfg.vif.monitor_cb);
       if (cfg.vif.monitor_cb.esc_rx.resp_p === 1'b1 &&
-          cfg.vif.monitor_cb.esc_rx.resp_n === 1'b0 && !under_reset) begin
+          cfg.vif.monitor_cb.esc_rx.resp_n === 1'b0 && !cfg.in_reset) begin
         req = alert_esc_seq_item::type_id::create("req");
         req.alert_esc_type = AlertEscIntFail;
         alert_esc_port.write(req);
@@ -155,7 +154,7 @@ endtask : unexpected_resp_thread
 task esc_monitor::sig_int_fail_thread();
   alert_esc_seq_item req;
   forever @(cfg.vif.monitor_cb) begin
-    if (is_sig_int_err() && !under_reset) begin
+    if (is_sig_int_err() && !cfg.in_reset) begin
       req = alert_esc_seq_item::type_id::create("req");
       req.alert_esc_type = AlertEscIntFail;
       alert_esc_port.write(req);


### PR DESCRIPTION
I think this is the behaviour expected by dv_base_monitor. It also avoids duplicating the signal as a local under_reset flag, which is a bit cleaner.
