### PR TITLE
[alert,dv] Avoid escalation drivers extending alert_esc_base_driver

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent.sv
@@ -7,7 +7,7 @@
 // ---------------------------------------------
 class alert_esc_agent extends dv_base_agent#(
     .CFG_T           (alert_esc_agent_cfg),
-    .DRIVER_T        (alert_esc_base_driver),
+    .DRIVER_T        (dv_base_driver#(alert_esc_seq_item, alert_esc_agent_cfg)),
     .SEQUENCER_T     (alert_esc_sequencer),
     .MONITOR_T       (alert_esc_base_monitor),
     .COV_T           (alert_esc_agent_cov)

--- a/hw/dv/sv/alert_esc_agent/esc_receiver_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_receiver_driver.sv
@@ -2,13 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// ---------------------------------------------
-// Alert_handler receiver driver
-// ---------------------------------------------
-class esc_receiver_driver extends alert_esc_base_driver;
+// Escalation receiver driver
+
+class esc_receiver_driver extends dv_base_driver#(alert_esc_seq_item, alert_esc_agent_cfg);
 
   `uvm_component_utils(esc_receiver_driver)
-
 
   // Set by esc_ping_detector if it sees a single-cycle pulse on esc_p/esc_n. If set, the receiver
   // will drive a 1010 pattern on resp_p/resp_n for a while in drive_esc_resp (stopping if it
@@ -22,10 +20,11 @@ class esc_receiver_driver extends alert_esc_base_driver;
   // Overridden from dv_base_driver.
   extern virtual task reset_signals();
 
-  // Run rsp_escalator and esc_ping_detector. Does not terminate.
+  // This task runs forever. It works by running rsp_escalator (which consumes and drives items from
+  // seq_item_port) and esc_ping_detector (which responds to ping requests).
   //
-  // Overridden from alert_esc_base_driver.
-  extern virtual task drive_req();
+  // Overridden from dv_base_driver.
+  extern virtual task get_and_drive();
 
   // Run forever, detect single-cycle escalation requests. These are ping requests. When one
   // happens, set is_ping, which tells drive_esc_resp to send the 1010... pattern.
@@ -76,12 +75,12 @@ task esc_receiver_driver::reset_signals();
   end
 endtask : reset_signals
 
-task esc_receiver_driver::drive_req();
+task esc_receiver_driver::get_and_drive();
   fork
     rsp_escalator();
     esc_ping_detector();
   join
-endtask : drive_req
+endtask : get_and_drive
 
 task esc_receiver_driver::esc_ping_detector();
   forever begin
@@ -115,11 +114,12 @@ endtask : esc_ping_detector
 
 task esc_receiver_driver::rsp_escalator();
   forever begin
-    alert_esc_seq_item req, rsp;
-    wait(r_esc_rsp_q.size() > 0 && !under_reset);
-    req = r_esc_rsp_q.pop_front();
+    alert_esc_seq_item rsp;
+
+    seq_item_port.get(req);
     `downcast(rsp, req.clone());
     rsp.set_id_info(req);
+
     `uvm_info(`gfn, $sformatf("starting to send receiver item, esc_rsp=%0b int_fail=%0b",
                               req.r_esc_rsp, req.int_err), UVM_HIGH)
     fork

--- a/hw/dv/sv/alert_esc_agent/esc_sender_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_sender_driver.sv
@@ -11,7 +11,7 @@ class esc_sender_driver extends dv_base_driver#(alert_esc_seq_item, alert_esc_ag
   extern virtual task reset_signals();
   extern virtual task get_and_drive();
 
-  extern local task do_reset();
+  extern local task reset_esc();
 endclass : esc_sender_driver
 
 function esc_sender_driver::new (string name, uvm_component parent);
@@ -22,7 +22,7 @@ task esc_sender_driver::reset_signals();
   wait(cfg.vif.rst_n !== 1'b1);
   forever begin
     under_reset = 1;
-    do_reset();
+    reset_esc();
     wait(cfg.vif.rst_n === 1'b1);
     under_reset = 0;
 
@@ -37,7 +37,7 @@ task esc_sender_driver::get_and_drive();
   wait(!under_reset);
 endtask : get_and_drive
 
-task esc_sender_driver::do_reset();
+task esc_sender_driver::reset_esc();
   cfg.vif.esc_tx_int.esc_p <= 1'b0;
   cfg.vif.esc_tx_int.esc_n <= 1'b1;
-endtask : do_reset
+endtask : reset_esc

--- a/hw/dv/sv/alert_esc_agent/esc_sender_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_sender_driver.sv
@@ -1,22 +1,17 @@
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-//
 
-// ---------------------------------------------
-// Esc sender driver
-// ---------------------------------------------
-class esc_sender_driver extends alert_esc_base_driver;
+// Escalation sender driver
 
+class esc_sender_driver extends dv_base_driver#(alert_esc_seq_item, alert_esc_agent_cfg);
   `uvm_component_utils(esc_sender_driver)
-
 
   extern function new (string name, uvm_component parent);
   extern virtual task reset_signals();
   extern virtual task get_and_drive();
-  extern virtual task drive_esc();
-  extern virtual task do_reset();
 
+  extern local task do_reset();
 endclass : esc_sender_driver
 
 function esc_sender_driver::new (string name, uvm_component parent);
@@ -24,13 +19,14 @@ function esc_sender_driver::new (string name, uvm_component parent);
 endfunction : new
 
 task esc_sender_driver::reset_signals();
-  do_reset();
+  wait(cfg.vif.rst_n !== 1'b1);
   forever begin
-    @(negedge cfg.vif.rst_n);
     under_reset = 1;
     do_reset();
-    @(posedge cfg.vif.rst_n);
+    wait(cfg.vif.rst_n === 1'b1);
     under_reset = 0;
+
+    wait(cfg.vif.rst_n !== 1'b1);
   end
 endtask : reset_signals
 
@@ -38,15 +34,8 @@ task esc_sender_driver::get_and_drive();
   // LC_CTRL uses virtual interface to directly drive escalation requests.
   // Other escalation handshakes are checked in prim_esc direct sequence.
   // So the following task is not implemented.
-  drive_esc();
-endtask : get_and_drive
-
-task esc_sender_driver::drive_esc();
-  // LC_CTRL uses virtual interface to directly drive escalation requests.
-  // Other escalation handshakes are checked in prim_esc direct sequence.
-  // So this task is not implemented.
   wait(!under_reset);
-endtask : drive_esc
+endtask : get_and_drive
 
 task esc_sender_driver::do_reset();
   cfg.vif.esc_tx_int.esc_p <= 1'b0;

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv.tpl
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv.tpl
@@ -342,6 +342,12 @@ class ${module_instance_name}_base_vseq extends cip_base_vseq #(
           `DV_CHECK_RANDOMIZE_WITH_FATAL(esc_seq, int_err == esc_int_err; standalone_int_err == 0;
                                          ping_timeout == ping_timeout_err;)
           esc_seq.start(p_sequencer.esc_device_seqr_h[index]);
+
+          // The sequence has finished, which either means that we have seen an escalation and sent
+          // a response, or it means that a reset has happened. Watch the agent's configuration to
+          // wait until it is out of reset before starting a sequence to respond to the next
+          // escalation.
+          wait(!cfg.esc_device_cfg[index].in_reset);
         end
       join_none
     end

--- a/hw/top_darjeeling/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -342,6 +342,12 @@ class alert_handler_base_vseq extends cip_base_vseq #(
           `DV_CHECK_RANDOMIZE_WITH_FATAL(esc_seq, int_err == esc_int_err; standalone_int_err == 0;
                                          ping_timeout == ping_timeout_err;)
           esc_seq.start(p_sequencer.esc_device_seqr_h[index]);
+
+          // The sequence has finished, which either means that we have seen an escalation and sent
+          // a response, or it means that a reset has happened. Watch the agent's configuration to
+          // wait until it is out of reset before starting a sequence to respond to the next
+          // escalation.
+          wait(!cfg.esc_device_cfg[index].in_reset);
         end
       join_none
     end

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -342,6 +342,12 @@ class alert_handler_base_vseq extends cip_base_vseq #(
           `DV_CHECK_RANDOMIZE_WITH_FATAL(esc_seq, int_err == esc_int_err; standalone_int_err == 0;
                                          ping_timeout == ping_timeout_err;)
           esc_seq.start(p_sequencer.esc_device_seqr_h[index]);
+
+          // The sequence has finished, which either means that we have seen an escalation and sent
+          // a response, or it means that a reset has happened. Watch the agent's configuration to
+          // wait until it is out of reset before starting a sequence to respond to the next
+          // escalation.
+          wait(!cfg.esc_device_cfg[index].in_reset);
         end
       join_none
     end


### PR DESCRIPTION
The two types of interface are pretty unrelated and the existing code had some strange corners. Make things more explicit and change `esc_receiver_driver` and `esc_sender_driver` to derive directly from `dv_base_driver` instead of `alert_esc_base_driver`.
