### PR TITLE
Upgrade toolchain to Clang/LLVM 21

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -553,7 +553,7 @@
     },
     "//third_party/lowrisc:extensions.bzl%lowrisc_rv32imcb_toolchain": {
       "general": {
-        "bzlTransitiveDigest": "033ZAc9zojxrKdPMpWEtNhV8RxHk22vwfGTGSiQLLXY=",
+        "bzlTransitiveDigest": "waHWAiD/jxd/FW7DbykWa1zWn8vJgAut39kjqgP+tLM=",
         "usagesDigest": "N+I4Z8BUhFKs8r1sm2Tm4NjFkNo8NTAmaYNX1+nchZg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -562,9 +562,9 @@
           "lowrisc_rv32imcb_toolchain": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
-              "url": "https://github.com/lowRISC/lowrisc-toolchains/releases/download/20251111-1/lowrisc-toolchain-rv32imcb-x86_64-20251111-1.tar.xz",
-              "sha256": "42be8b4a7e2fe8ea9274759c8574eb3b763a5072741a75d22189c93b149b6fab",
-              "strip_prefix": "lowrisc-toolchain-rv32imcb-x86_64-20251111-1",
+              "url": "https://github.com/lowRISC/lowrisc-toolchains/releases/download/20260224-1/lowrisc-toolchain-rv32imcb-x86_64-20260224-1.tar.xz",
+              "sha256": "528facbc6cb6f02667ce7613ab21383fca42b18cca6f4914b7160636080d3569",
+              "strip_prefix": "lowrisc-toolchain-rv32imcb-x86_64-20260224-1",
               "build_file": "@@//third_party/lowrisc:BUILD.lowrisc_rv32imcb_toolchain.bazel"
             }
           }

--- a/hw/dv/dpi/usbdpi/usbdpi_stream.c
+++ b/hw/dv/dpi/usbdpi/usbdpi_stream.c
@@ -11,16 +11,16 @@
 
 // Seed numbers for the LFSR generators in each transfer direction for
 // the given stream number
-#define USBTST_LFSR_SEED(s) (uint8_t)(0x10U + (s)*7U)
-#define USBDPI_LFSR_SEED(s) (uint8_t)(0x9BU - (s)*7U)
+#define USBTST_LFSR_SEED(s) (uint8_t)(0x10U + (s) * 7U)
+#define USBDPI_LFSR_SEED(s) (uint8_t)(0x9BU - (s) * 7U)
 // Seed number of packet retrying
-#define RETRY_LFSR_SEED(s) (uint8_t)(0x24U + (s)*7U)
+#define RETRY_LFSR_SEED(s) (uint8_t)(0x24U + (s) * 7U)
 
 // Simple LFSR for 8-bit sequences
-#define LFSR_ADVANCE(lfsr)     \
-  (uint8_t)(                   \
-      (uint8_t)((lfsr) << 1) ^ \
-      ((((lfsr) >> 1) ^ ((lfsr) >> 2) ^ ((lfsr) >> 3) ^ ((lfsr) >> 7)) & 1U))
+#define LFSR_ADVANCE(lfsr)                                                     \
+  (uint8_t)((uint8_t)((lfsr) << 1) ^                                           \
+            ((((lfsr) >> 1) ^ ((lfsr) >> 2) ^ ((lfsr) >> 3) ^ ((lfsr) >> 7)) & \
+             1U))
 
 // Stream signature words
 #define STREAM_SIGNATURE_HEAD 0x579EA01AU

--- a/hw/dv/verilator/simutil_verilator/cpp/verilated_toplevel.h
+++ b/hw/dv/verilator/simutil_verilator/cpp/verilated_toplevel.h
@@ -81,11 +81,11 @@ class VerilatedTracer {
  */
 class VerilatedTracer {
  public:
-  VerilatedTracer(){};
+  VerilatedTracer() {};
   ~VerilatedTracer() {}
   bool isOpen() const { return false; };
-  void open(const char *filename){};
-  void close(){};
+  void open(const char *filename) {};
+  void close() {};
   void dump(vluint64_t timeui) {}
 };
 #endif  // VM_TRACE == 1
@@ -115,8 +115,8 @@ class TOPLEVEL_NAME;
  */
 class VerilatedToplevel {
  public:
-  VerilatedToplevel(){};
-  virtual ~VerilatedToplevel(){};
+  VerilatedToplevel() {};
+  virtual ~VerilatedToplevel() {};
 
   virtual void eval() = 0;
   virtual void final() = 0;

--- a/hw/ip/otbn/dv/model/otbn_trace_entry.h
+++ b/hw/ip/otbn/dv/model/otbn_trace_entry.h
@@ -50,7 +50,7 @@ class OtbnTraceEntry {
     Stray,
   };
 
-  virtual ~OtbnTraceEntry(){};
+  virtual ~OtbnTraceEntry() {};
 
   // Parse a trace entry from the RTL into this object. On an error, print a
   // message to stderr and return false.

--- a/sw/device/lib/arch/device.h
+++ b/sw/device/lib/arch/device.h
@@ -162,7 +162,7 @@ extern const uint32_t kUartBaud1M50;
  * FIFO.
  */
 #define CALCULATE_UART_TX_FIFO_CPU_CYCLES(baud_rate_, cpu_freq_, fifo_depth_) \
-  ((cpu_freq_)*10 * (fifo_depth_) / (baud_rate_))
+  ((cpu_freq_) * 10 * (fifo_depth_) / (baud_rate_))
 
 /**
  * Helper macro to calculate the maximum duration of the AST initialization
@@ -171,7 +171,7 @@ extern const uint32_t kUartBaud1M50;
  * This macro assumes that the desired duration is 100us.
  */
 #define CALCULATE_AST_CHECK_POLL_CPU_CYCLES(cpu_freq_) \
-  ((cpu_freq_)*100 / 1000000)
+  ((cpu_freq_) * 100 / 1000000)
 
 /**
  * Maximum duration of the AST initialization check poll in CPU cycles. This

--- a/sw/device/lib/base/internal/status.h
+++ b/sw/device/lib/base/internal/status.h
@@ -60,7 +60,7 @@ extern "C" {
  * #define MODULE_ID MAKE_MODULE_ID('a', 'b', 'c')
  */
 #define MAKE_MODULE_ID(a, b, c) \
-  (uint32_t)(((((a)&0xff) << 16) | (((b)&0xff) << 8) | ((c)&0xff)))
+  (uint32_t)(((((a) & 0xff) << 16) | (((b) & 0xff) << 8) | ((c) & 0xff)))
 
 static inline uint8_t __status_ascii_5bit(uint8_t c) {
   if (c >= '@' && c <= '_') {

--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -650,7 +650,7 @@ extern "C++" {
 /**
  *  This macro is used to align an offset to point to a 32b value.
  */
-#define OT_ALIGN_MEM(x) (uint32_t)(4 + (((uintptr_t)(x)-1) & ~3u))
+#define OT_ALIGN_MEM(x) (uint32_t)(4 + (((uintptr_t)(x) - 1) & ~3u))
 
 #if !defined(__ASSEMBLER__) && !defined(NOSTDINC) && \
     !defined(RUST_PREPROCESSOR_EMIT)

--- a/sw/device/lib/dif/dif_clkmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_clkmgr_unittest.cc
@@ -384,15 +384,17 @@ TEST_F(ExternalClkTest, DisableError) {
 }
 
 TEST_F(ExternalClkTest, Enable) {
-#define EXTCLK_CTRL_REG_VALUE(enable_, low_speed_)                     \
-  {{                                                                   \
-       .offset = CLKMGR_EXTCLK_CTRL_SEL_OFFSET,                        \
-       .value = enable_ ? kMultiBitBool4True : kMultiBitBool4False,    \
-   },                                                                  \
-   {                                                                   \
-       .offset = CLKMGR_EXTCLK_CTRL_HI_SPEED_SEL_OFFSET,               \
-       .value = low_speed_ ? kMultiBitBool4False : kMultiBitBool4True, \
-   }}
+#define EXTCLK_CTRL_REG_VALUE(enable_, low_speed_)                    \
+  {                                                                   \
+    {                                                                 \
+        .offset = CLKMGR_EXTCLK_CTRL_SEL_OFFSET,                      \
+        .value = enable_ ? kMultiBitBool4True : kMultiBitBool4False,  \
+    },                                                                \
+    {                                                                 \
+      .offset = CLKMGR_EXTCLK_CTRL_HI_SPEED_SEL_OFFSET,               \
+      .value = low_speed_ ? kMultiBitBool4False : kMultiBitBool4True, \
+    }                                                                 \
+  }
   {  // low speed with control unlocked
     EXPECT_READ32(CLKMGR_EXTCLK_CTRL_REGWEN_REG_OFFSET, 1);
     EXPECT_WRITE32(CLKMGR_EXTCLK_CTRL_REG_OFFSET,

--- a/sw/device/lib/dif/dif_spi_host_unittest.cc
+++ b/sw/device/lib/dif/dif_spi_host_unittest.cc
@@ -50,7 +50,7 @@ using testing::Test;
 #define EXPECT_COMMAND_REG(length, width, direction, last_segment)   \
   EXPECT_WRITE32(SPI_HOST_COMMAND_REG_OFFSET,                        \
                  {                                                   \
-                     {SPI_HOST_COMMAND_LEN_OFFSET, (length)-1},      \
+                     {SPI_HOST_COMMAND_LEN_OFFSET, (length) - 1},    \
                      {SPI_HOST_COMMAND_SPEED_OFFSET, width},         \
                      {SPI_HOST_COMMAND_DIRECTION_OFFSET, direction}, \
                      {SPI_HOST_COMMAND_CSAAT_BIT, !(last_segment)},  \

--- a/sw/device/lib/runtime/log.h
+++ b/sw/device/lib/runtime/log.h
@@ -129,35 +129,36 @@ extern char _dv_log_offset[];
  *               string literal.
  * @param ... format parameters matching the format string.
  */
-#define LOG(severity, format, ...)                               \
-  do {                                                           \
-    OT_CHECK_VALID_LOG_ARGS(__VA_ARGS__);                        \
-    if (device_log_bypass_uart_address() != 0) {                 \
-      /* clang-format off */                                     \
-      /* Put DV-only log constants in .logs.* sections, which
-       * the linker will dutifully discard.
-       * Unfortunately, clang-format really mangles these
-       * declarations, so we format them manually. */            \
-      __attribute__((section(".logs.fields")))                   \
-      static const log_fields_t kLogFields =                     \
-          LOG_MAKE_FIELDS_(severity, format, ##__VA_ARGS__);     \
-      base_log_internal_dv((const log_fields_t*)((char*)&kLogFields + (uintptr_t)&_dv_log_offset), \
-                           OT_VA_ARGS_COUNT(format, ##__VA_ARGS__), \
-                           ##__VA_ARGS__); /* clang-format on */ \
-    } else {                                                     \
-      static const log_fields_t log_fields =                     \
-          LOG_MAKE_FIELDS_(severity, format, ##__VA_ARGS__);     \
-      base_log_internal_core(&log_fields, ##__VA_ARGS__);        \
-    }                                                            \
+#define LOG(severity, format, ...)                                             \
+  do {                                                                         \
+    OT_CHECK_VALID_LOG_ARGS(__VA_ARGS__);                                      \
+    if (device_log_bypass_uart_address() != 0) {                               \
+      /* Put DV-only log constants in .logs.* sections, which                  \
+       * the linker will dutifully discard. */                                 \
+      __attribute__((                                                          \
+          section(".logs.fields"))) static const log_fields_t kLogFields =     \
+          LOG_MAKE_FIELDS_(severity, format, ##__VA_ARGS__);                   \
+      base_log_internal_dv((const log_fields_t *)((char *)&kLogFields +        \
+                                                  (uintptr_t)&_dv_log_offset), \
+                           OT_VA_ARGS_COUNT(format, ##__VA_ARGS__),            \
+                           ##__VA_ARGS__);                                     \
+    } else {                                                                   \
+      static const log_fields_t log_fields =                                   \
+          LOG_MAKE_FIELDS_(severity, format, ##__VA_ARGS__);                   \
+      base_log_internal_core(&log_fields, ##__VA_ARGS__);                      \
+    }                                                                          \
   } while (false)
 
 /**
  * Implementation detail of `LOG`.
  */
-#define LOG_MAKE_FIELDS_(_severity, _format, ...)                         \
-  {                                                                       \
-    .severity = _severity, .file_name = "" __FILE__ "", .line = __LINE__, \
-    .nargs = OT_VA_ARGS_COUNT(_format, ##__VA_ARGS__), .format = _format, \
+#define LOG_MAKE_FIELDS_(_severity, _format, ...)        \
+  {                                                      \
+      .severity = _severity,                             \
+      .file_name = "" __FILE__ "",                       \
+      .line = __LINE__,                                  \
+      .nargs = OT_VA_ARGS_COUNT(_format, ##__VA_ARGS__), \
+      .format = _format,                                 \
   }
 
 /**

--- a/sw/device/lib/testing/usb_testutils_controlep.h
+++ b/sw/device/lib/testing/usb_testutils_controlep.h
@@ -112,14 +112,14 @@ status_t usb_testutils_controlep_config_wait(
 #define USB_CFG_DSCR_LEN 9
 #define USB_CFG_DSCR_HEAD(total_len, nint)                                   \
   /* This is the actual configuration descriptor                 */          \
-  USB_CFG_DSCR_LEN,     /* bLength                                   */      \
-      2,                /* bDescriptorType                           */      \
-      (total_len)&0xff, /* wTotalLength[0]                           */      \
-      (total_len) >> 8, /* wTotalLength[1]                           */      \
-      (nint),           /* bNumInterfaces                            */      \
-      1,                /* bConfigurationValue                       */      \
-      0,                /* iConfiguration                            */      \
-      0xC0,             /* bmAttributes: must-be-one, self-powered   */      \
+  USB_CFG_DSCR_LEN,       /* bLength                                   */    \
+      2,                  /* bDescriptorType                           */    \
+      (total_len) & 0xff, /* wTotalLength[0]                           */    \
+      (total_len) >> 8,   /* wTotalLength[1]                           */    \
+      (nint),             /* bNumInterfaces                            */    \
+      1,                  /* bConfigurationValue                       */    \
+      0,                  /* iConfiguration                            */    \
+      0xC0,               /* bmAttributes: must-be-one, self-powered   */    \
       50 /* bMaxPower                                 */ /* MUST be followed \
                                                             by (nint)        \
                                                             Interface +      \
@@ -152,7 +152,7 @@ status_t usb_testutils_controlep_config_wait(
       5,                           /* bDescriptorType                      */ \
       (ep) | (((in) << 7) & 0x80), /* bEndpointAddress, top bit set for IN */ \
       attr,                        /* bmAttributes                         */ \
-      (maxsize)&0xff,              /* wMaxPacketSize[0]                    */ \
+      (maxsize) & 0xff,            /* wMaxPacketSize[0]                    */ \
       (maxsize) >> 8,              /* wMaxPacketSize[1]                    */ \
       (interval)                   /* bInterval                            */
 
@@ -163,7 +163,7 @@ status_t usb_testutils_controlep_config_wait(
       5,                           /* bDescriptorType                      */ \
       (ep) | (((in) << 7) & 0x80), /* bEndpointAddress, top bit set for IN */ \
       kUsbTransferTypeBulk,        /* bmAttributes (0x02=bulk, data)       */ \
-      (maxsize)&0xff,              /* wMaxPacketSize[0]                    */ \
+      (maxsize) & 0xff,            /* wMaxPacketSize[0]                    */ \
       (maxsize) >> 8,              /* wMaxPacketSize[1]                    */ \
       (interval)                   /* bInterval                            */
 
@@ -173,14 +173,14 @@ status_t usb_testutils_controlep_config_wait(
 /* Below this point are macros used to construct the test descriptor   */
 /* Use them to initialize a uint8_t array for test_dscr                */
 #define USB_TESTUTILS_TEST_DSCR_LEN 0x10u
-#define USB_TESTUTILS_TEST_DSCR(num, arg0, arg1, arg2, arg3)            \
-  0x7e, 0x57, 0xc0, 0xf1u,                /* Header signature        */ \
-      (USB_TESTUTILS_TEST_DSCR_LEN)&0xff, /* Descriptor length[0]    */ \
-      (USB_TESTUTILS_TEST_DSCR_LEN) >> 8, /* Descriptor length[1]    */ \
-      (num)&0xff,                         /* Test number[0]          */ \
-      (num) >> 8,                         /* Test number[1]          */ \
-      (arg0), (arg1), (arg2), (arg3),     /* Test-specific arugments */ \
-      0x1fu, 0x0cu, 0x75, 0xe7u           /* Tail signature */
+#define USB_TESTUTILS_TEST_DSCR(num, arg0, arg1, arg2, arg3)              \
+  0x7e, 0x57, 0xc0, 0xf1u,                  /* Header signature        */ \
+      (USB_TESTUTILS_TEST_DSCR_LEN) & 0xff, /* Descriptor length[0]    */ \
+      (USB_TESTUTILS_TEST_DSCR_LEN) >> 8,   /* Descriptor length[1]    */ \
+      (num) & 0xff,                         /* Test number[0]          */ \
+      (num) >> 8,                           /* Test number[1]          */ \
+      (arg0), (arg1), (arg2), (arg3),       /* Test-specific arugments */ \
+      0x1fu, 0x0cu, 0x75, 0xe7u             /* Tail signature */
 
 // KEEP BLANK LINE ABOVE, it is in the macro!
 

--- a/sw/device/lib/testing/usb_testutils_streams.h
+++ b/sw/device/lib/testing/usb_testutils_streams.h
@@ -31,18 +31,18 @@
 
 // Seed numbers for the LFSR generators in each transfer direction for
 // the given stream number
-#define USBTST_LFSR_SEED(s) (uint8_t)(0x10U + (s)*7U)
-#define USBDPI_LFSR_SEED(s) (uint8_t)(0x9BU - (s)*7U)
+#define USBTST_LFSR_SEED(s) (uint8_t)(0x10U + (s) * 7U)
+#define USBDPI_LFSR_SEED(s) (uint8_t)(0x9BU - (s) * 7U)
 
 // Buffer size randomization
-#define BUFSZ_LFSR_SEED(s) (uint8_t)(0x17U + (s)*7U)
+#define BUFSZ_LFSR_SEED(s) (uint8_t)(0x17U + (s) * 7U)
 
 // Simple LFSR for 8-bit sequences
 /// Note: zero is an isolated state that shall be avoided
-#define LFSR_ADVANCE(lfsr)     \
-  (uint8_t)(                   \
-      (uint8_t)((lfsr) << 1) ^ \
-      ((((lfsr) >> 1) ^ ((lfsr) >> 2) ^ ((lfsr) >> 3) ^ ((lfsr) >> 7)) & 1U))
+#define LFSR_ADVANCE(lfsr)                                                     \
+  (uint8_t)((uint8_t)((lfsr) << 1) ^                                           \
+            ((((lfsr) >> 1) ^ ((lfsr) >> 2) ^ ((lfsr) >> 3) ^ ((lfsr) >> 7)) & \
+             1U))
 
 // Test/stream flags
 typedef enum {

--- a/sw/device/silicon_creator/lib/cert/asn1_unittest.cc
+++ b/sw/device/silicon_creator/lib/cert/asn1_unittest.cc
@@ -97,7 +97,9 @@ TEST(Asn1, PushEmptyTag) {
   size_t out_size;
   EXPECT_EQ(asn1_finish(&state, &out_size), kErrorOk);
   const std::array<uint8_t, 2> kExpectedResult = {
-      0x30, 0x00,  // Identifier octet, length, no contents.
+      0x30,  // Identifier octet.
+      0x00,  // Length.
+             // No contents.
   };
   EXPECT_EQ_CONST_ARRAY(buf, out_size, kExpectedResult);
 }

--- a/sw/device/silicon_creator/lib/cert/dice_cwt.c
+++ b/sw/device/silicon_creator/lib/cert/dice_cwt.c
@@ -105,6 +105,8 @@ enum cwt_cert_expectations {
                                   kDiceCwtCoseSign1IdSizeBytes,
 };
 
+/* clang-format off */
+
 // Reusable buffer for checking cose key identity.
 static char expected_cose_key_id[kDiceCwtCoseKeyIdSizeBytes] = {
     0x22,                                 // mapKey -3 (y-coord)
@@ -118,6 +120,8 @@ static char expected_cose_sign1_id[kDiceCwtCoseSign1IdSizeBytes] = {
     0x78, kIssuerSubjectNameLength,  // 64-byte text header
     // Remaining bytes will be filled during check.
 };
+
+/* clang-format on */
 
 // Reusable buffer for generating Configuration Descriptor
 static uint8_t config_desc_buf[kConfigDescBuffSize] = {0};

--- a/sw/device/silicon_creator/lib/cert/template.h
+++ b/sw/device/silicon_creator/lib/cert/template.h
@@ -87,7 +87,7 @@ static inline uint16_t template_finalize(template_state_t *state) {
  */
 static inline void template_set_bit(template_state_t *state, int byte_offset,
                                     int bit_offset, bool value) {
-  *(state->out_end - byte_offset) |= ((uint8_t) !!value) << bit_offset;
+  *(state->out_end - byte_offset) |= ((uint8_t)!!value) << bit_offset;
 }
 
 /**

--- a/sw/device/silicon_creator/lib/drivers/epmp.c
+++ b/sw/device/silicon_creator/lib/drivers/epmp.c
@@ -22,7 +22,7 @@ void epmp_set(uint8_t entry, uint32_t pmpcfg, uint32_t pmpaddr) {
   uint32_t cfg = (pmpcfg & 0xFFu) << shift;
   HARDENED_CHECK_LT(entry, 16);
   switch (entry) {
-    // clang-format off
+      // clang-format off
     case  0: EPMP_SET(0,  0, mask, cfg, pmpaddr); break;
     case  1: EPMP_SET(0,  1, mask, cfg, pmpaddr); break;
     case  2: EPMP_SET(0,  2, mask, cfg, pmpaddr); break;

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -137,11 +137,11 @@ FLASH_CTRL_INFO_PAGES_DEFINE(INFO_PAGE_STRUCT_DECL_);
  * Defined here to be able to use in tests.
  */
 #define FLASH_CTRL_OTP_FIELD_SCRAMBLING \
-  (bitfield_field32_t) { .mask = UINT8_MAX, .index = CHAR_BIT * 0 }
+  (bitfield_field32_t){.mask = UINT8_MAX, .index = CHAR_BIT * 0}
 #define FLASH_CTRL_OTP_FIELD_ECC \
-  (bitfield_field32_t) { .mask = UINT8_MAX, .index = CHAR_BIT * 1 }
+  (bitfield_field32_t){.mask = UINT8_MAX, .index = CHAR_BIT * 1}
 #define FLASH_CTRL_OTP_FIELD_HE \
-  (bitfield_field32_t) { .mask = UINT8_MAX, .index = CHAR_BIT * 2 }
+  (bitfield_field32_t){.mask = UINT8_MAX, .index = CHAR_BIT * 2}
 
 /**
  * Bitfields for `CREATOR_SW_CFG_FLASH_HW_INFO_CFG_OVERRIDE` OTP item.
@@ -149,9 +149,9 @@ FLASH_CTRL_INFO_PAGES_DEFINE(INFO_PAGE_STRUCT_DECL_);
  * Defined here to be able to use in tests.
  */
 #define FLASH_CTRL_OTP_FIELD_HW_INFO_CFG_OVERRIDE_SCRAMBLE_DIS \
-  (bitfield_field32_t) { .mask = UINT8_MAX, .index = CHAR_BIT * 0 }
+  (bitfield_field32_t){.mask = UINT8_MAX, .index = CHAR_BIT * 0}
 #define FLASH_CTRL_OTP_FIELD_HW_INFO_CFG_OVERRIDE_ECC_DIS \
-  (bitfield_field32_t) { .mask = UINT8_MAX, .index = CHAR_BIT * 1 }
+  (bitfield_field32_t){.mask = UINT8_MAX, .index = CHAR_BIT * 1}
 
 /**
  * The following constants represent the expected number of sec_mmio

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_info_pages.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_info_pages.c
@@ -8,8 +8,8 @@
 
 #define INFO_PAGE_STRUCT_(name_, bank_, page_)                          \
   const flash_ctrl_info_page_t name_ = {                                \
-      .base_addr = (bank_)*FLASH_CTRL_PARAM_BYTES_PER_BANK +            \
-                   (page_)*FLASH_CTRL_PARAM_BYTES_PER_PAGE,             \
+      .base_addr = (bank_) * FLASH_CTRL_PARAM_BYTES_PER_BANK +          \
+                   (page_) * FLASH_CTRL_PARAM_BYTES_PER_PAGE,           \
       .cfg_wen_offset =                                                 \
           FLASH_CTRL_BANK##bank_##_INFO0_REGWEN_##page_##_REG_OFFSET,   \
       .cfg_offset =                                                     \

--- a/sw/device/silicon_creator/lib/drivers/hmac.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac.c
@@ -115,7 +115,7 @@ void hmac_sha256_final_truncated(uint32_t *digest, size_t len) {
     // Note: we rely on 32-bit integer wraparound to cause the result register
     // index to count down from 7 to 0.
     result = HMAC_DIGEST_7_REG_OFFSET;
-    incr = (uint32_t) - sizeof(uint32_t);
+    incr = (uint32_t)-sizeof(uint32_t);
   }
 
   // Ensure len is at most the digest length; this function should never be

--- a/sw/device/silicon_creator/lib/drivers/rnd.c
+++ b/sw/device/silicon_creator/lib/drivers/rnd.c
@@ -43,11 +43,12 @@ static_assert(kNumHealthRegisters ==
 // Ensure the relative offsets of OTP versus entropy_src registers are
 // equivalent. This is imporant as rom_start.S uses a copy function to
 // copy the values from OTP into the entropy_src.
-#define ASSERT_REG_OFFSET(otp_offset_, entropy_src_offset_)                         \
-  static_assert(                                                                    \
-      ((otp_offset_)-OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_REPCNT_THRESHOLDS_OFFSET) == \
-          ((entropy_src_offset_)-ENTROPY_SRC_REPCNT_THRESHOLD_REG_OFFSET),          \
-      "OTP configuration offset does not match the expected entropy_src "           \
+#define ASSERT_REG_OFFSET(otp_offset_, entropy_src_offset_)                  \
+  static_assert(                                                             \
+      ((otp_offset_) -                                                       \
+       OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_REPCNT_THRESHOLDS_OFFSET) ==        \
+          ((entropy_src_offset_) - ENTROPY_SRC_REPCNT_THRESHOLD_REG_OFFSET), \
+      "OTP configuration offset does not match the expected entropy_src "    \
       "register offset")
 
 ASSERT_REG_OFFSET(OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_REPCNT_THRESHOLDS_OFFSET,

--- a/sw/device/silicon_creator/lib/drivers/rstmgr.h
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr.h
@@ -112,8 +112,7 @@ void rstmgr_cpu_info_enable(void);
 // Omit `noreturn` to be able to test this function in off-target tests.
 noreturn
 #endif
-    void
-    rstmgr_reset(void);
+    void rstmgr_reset(void);
 
 /**
  * Reboot the chip.
@@ -124,8 +123,7 @@ noreturn
 // Omit `noreturn` to be able to test this function in off-target tests.
 noreturn
 #endif
-    void
-    rstmgr_reboot(void);
+    void rstmgr_reboot(void);
 
 /**
  * Verifies that info collection is initialized properly.
@@ -161,9 +159,9 @@ bool rstmgr_is_hw_reset_reason(dt_rstmgr_t dt, uint32_t reasons,
  * Defined here to be able to use in tests.
  */
 #define RSTMGR_OTP_FIELD_ALERT_INFO_EN \
-  (bitfield_field32_t) { .mask = UINT8_MAX, .index = CHAR_BIT * 0 }
+  (bitfield_field32_t){.mask = UINT8_MAX, .index = CHAR_BIT * 0}
 #define RSTMGR_OTP_FIELD_CPU_INFO_EN \
-  (bitfield_field32_t) { .mask = UINT8_MAX, .index = CHAR_BIT * 1 }
+  (bitfield_field32_t){.mask = UINT8_MAX, .index = CHAR_BIT * 1}
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/drivers/stdusb.h
+++ b/sw/device/silicon_creator/lib/drivers/stdusb.h
@@ -191,14 +191,14 @@ rom_error_t usb_control_setupdata(usb_control_ctx_t *ctx,
 #define USB_CFG_DSCR_LEN 9
 #define USB_CFG_DSCR_HEAD(total_len, nint)                                   \
   /* This is the actual configuration descriptor                 */          \
-  USB_CFG_DSCR_LEN,     /* bLength                                   */      \
-      2,                /* bDescriptorType                           */      \
-      (total_len)&0xff, /* wTotalLength[0]                           */      \
-      (total_len) >> 8, /* wTotalLength[1]                           */      \
-      (nint),           /* bNumInterfaces                            */      \
-      1,                /* bConfigurationValue                       */      \
-      0,                /* iConfiguration                            */      \
-      0xC0,             /* bmAttributes: must-be-one, self-powered   */      \
+  USB_CFG_DSCR_LEN,       /* bLength                                   */    \
+      2,                  /* bDescriptorType                           */    \
+      (total_len) & 0xff, /* wTotalLength[0]                           */    \
+      (total_len) >> 8,   /* wTotalLength[1]                           */    \
+      (nint),             /* bNumInterfaces                            */    \
+      1,                  /* bConfigurationValue                       */    \
+      0,                  /* iConfiguration                            */    \
+      0xC0,               /* bmAttributes: must-be-one, self-powered   */    \
       50 /* bMaxPower                                 */ /* MUST be followed \
                                                             by (nint)        \
                                                             Interface +      \
@@ -231,7 +231,7 @@ rom_error_t usb_control_setupdata(usb_control_ctx_t *ctx,
       5,                           /* bDescriptorType                      */ \
       (ep) | (((in) << 7) & 0x80), /* bEndpointAddress, top bit set for IN */ \
       attr,                        /* bmAttributes                         */ \
-      (maxsize)&0xff,              /* wMaxPacketSize[0]                    */ \
+      (maxsize) & 0xff,            /* wMaxPacketSize[0]                    */ \
       (maxsize) >> 8,              /* wMaxPacketSize[1]                    */ \
       (interval)                   /* bInterval                            */
 
@@ -242,7 +242,7 @@ rom_error_t usb_control_setupdata(usb_control_ctx_t *ctx,
       5,                           /* bDescriptorType                      */ \
       (ep) | (((in) << 7) & 0x80), /* bEndpointAddress, top bit set for IN */ \
       0x02,                        /* bmAttributes (0x02=bulk, data)       */ \
-      (maxsize)&0xff,              /* wMaxPacketSize[0]                    */ \
+      (maxsize) & 0xff,            /* wMaxPacketSize[0]                    */ \
       (maxsize) >> 8,              /* wMaxPacketSize[1]                    */ \
       (interval)                   /* bInterval                            */
 

--- a/sw/device/silicon_creator/lib/error_unittest_util.h
+++ b/sw/device/silicon_creator/lib/error_unittest_util.h
@@ -16,7 +16,9 @@
 const inline std::map<std::string, uint32_t> &GetErrorMap() {
 #define STRINGIFY(x) #x
 #define ERROR_MAP_INIT(name, value) \
-  { STRINGIFY(name), value }
+  {                                 \
+    STRINGIFY(name), value          \
+  }
   static std::map<std::string, uint32_t> errors = {
       DEFINE_ERRORS(ERROR_MAP_INIT)};
   return errors;
@@ -27,7 +29,9 @@ const inline std::map<std::string, uint32_t> &GetErrorMap() {
 const inline std::map<uint32_t, std::string> &GetErrorToStringMap() {
 #define STRINGIFY(x) #x
 #define ERROR_MAP_INIT(name, value) \
-  { value, STRINGIFY(name) }
+  {                                 \
+    value, STRINGIFY(name)          \
+  }
   static std::map<uint32_t, std::string> errors = {
       DEFINE_ERRORS(ERROR_MAP_INIT)};
   return errors;

--- a/sw/device/silicon_creator/lib/ownership/keys/fake/activate_ecdsa_p256.h
+++ b/sw/device/silicon_creator/lib/ownership/keys/fake/activate_ecdsa_p256.h
@@ -5,12 +5,12 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_ACTIVATE_ECDSA_P256_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_ACTIVATE_ECDSA_P256_H_
 
-#define ACTIVATE_ECDSA_P256                                \
-  {                                                        \
-    .x = {0x63a31253, 0x04b237ba, 0x3738e9f4, 0x5882a207,  \
-          0x8c5dd770, 0xbc279ae3, 0x4f608694, 0xc7888656}, \
-    .y = {0xbbe32c57, 0x1528a35a, 0xf13f6916, 0xa3802d5e,  \
-          0xcf1f6f3d, 0x2f8b61a0, 0xa5e97f8f, 0x77328a26}, \
+#define ACTIVATE_ECDSA_P256                                             \
+  {                                                                     \
+      .x = {0x63a31253, 0x04b237ba, 0x3738e9f4, 0x5882a207, 0x8c5dd770, \
+            0xbc279ae3, 0x4f608694, 0xc7888656},                        \
+      .y = {0xbbe32c57, 0x1528a35a, 0xf13f6916, 0xa3802d5e, 0xcf1f6f3d, \
+            0x2f8b61a0, 0xa5e97f8f, 0x77328a26},                        \
   }
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_ACTIVATE_ECDSA_P256_H_

--- a/sw/device/silicon_creator/lib/ownership/keys/fake/activate_spx.h
+++ b/sw/device/silicon_creator/lib/ownership/keys/fake/activate_spx.h
@@ -5,18 +5,8 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_ACTIVATE_SPX_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_ACTIVATE_SPX_H_
 
-#define ACTIVATE_SPX \
-  {                  \
-    .data = {        \
-      3044129793,    \
-      1999364739,    \
-      1808675597,    \
-      4266956732,    \
-      3708088088,    \
-      4010151980,    \
-      3482134897,    \
-      3648113411     \
-    }                \
-  }
+#define ACTIVATE_SPX                                                    \
+  {.data = {3044129793, 1999364739, 1808675597, 4266956732, 3708088088, \
+            4010151980, 3482134897, 3648113411}}
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_ACTIVATE_SPX_H_

--- a/sw/device/silicon_creator/lib/ownership/keys/fake/app_dev_ecdsa_p256.h
+++ b/sw/device/silicon_creator/lib/ownership/keys/fake/app_dev_ecdsa_p256.h
@@ -5,12 +5,12 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_APP_DEV_ECDSA_P256_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_APP_DEV_ECDSA_P256_H_
 
-#define APP_DEV_ECDSA_P256                                 \
-  {                                                        \
-    .x = {0xddd43a0c, 0x622265ee, 0xae5b66d4, 0x94c06bca,  \
-          0x310493ae, 0x4ef6f61e, 0x7581813f, 0xac7b2ff9}, \
-    .y = {0xc5aa3b52, 0x07db1c51, 0x905148dc, 0xe5c458de,  \
-          0xebccfe4b, 0x317e5744, 0x863e76fd, 0xa08f1a90}, \
+#define APP_DEV_ECDSA_P256                                              \
+  {                                                                     \
+      .x = {0xddd43a0c, 0x622265ee, 0xae5b66d4, 0x94c06bca, 0x310493ae, \
+            0x4ef6f61e, 0x7581813f, 0xac7b2ff9},                        \
+      .y = {0xc5aa3b52, 0x07db1c51, 0x905148dc, 0xe5c458de, 0xebccfe4b, \
+            0x317e5744, 0x863e76fd, 0xa08f1a90},                        \
   }
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_APP_DEV_ECDSA_P256_H_

--- a/sw/device/silicon_creator/lib/ownership/keys/fake/app_dev_spx.h
+++ b/sw/device/silicon_creator/lib/ownership/keys/fake/app_dev_spx.h
@@ -5,18 +5,8 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_APP_DEV_SPX_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_APP_DEV_SPX_H_
 
-#define APP_DEV_SPX \
-  {                 \
-    .data = {       \
-      2635496609,   \
-      3094453936,   \
-      1095047114,   \
-      875270085,    \
-      1206311292,   \
-      2547787469,   \
-      354526470,    \
-      195185787     \
-    }               \
-  }
+#define APP_DEV_SPX                                                    \
+  {.data = {2635496609, 3094453936, 1095047114, 875270085, 1206311292, \
+            2547787469, 354526470, 195185787}}
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_APP_DEV_SPX_H_

--- a/sw/device/silicon_creator/lib/ownership/keys/fake/app_prod_ecdsa_p256.h
+++ b/sw/device/silicon_creator/lib/ownership/keys/fake/app_prod_ecdsa_p256.h
@@ -5,12 +5,12 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_APP_PROD_ECDSA_P256_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_APP_PROD_ECDSA_P256_H_
 
-#define APP_PROD_ECDSA_P256                                \
-  {                                                        \
-    .x = {0x265b676b, 0x656df11f, 0xe7268c24, 0xf7682b71,  \
-          0x1a5407bc, 0x60d64f8b, 0x0df3f0ea, 0x32de82c0}, \
-    .y = {0x248107b0, 0xdddf1364, 0xa99b1d58, 0x35897333,  \
-          0x661324da, 0x4ad9cfd4, 0xac55ca48, 0x47d456f4}, \
+#define APP_PROD_ECDSA_P256                                             \
+  {                                                                     \
+      .x = {0x265b676b, 0x656df11f, 0xe7268c24, 0xf7682b71, 0x1a5407bc, \
+            0x60d64f8b, 0x0df3f0ea, 0x32de82c0},                        \
+      .y = {0x248107b0, 0xdddf1364, 0xa99b1d58, 0x35897333, 0x661324da, \
+            0x4ad9cfd4, 0xac55ca48, 0x47d456f4},                        \
   }
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_APP_PROD_ECDSA_P256_H_

--- a/sw/device/silicon_creator/lib/ownership/keys/fake/app_prod_spx.h
+++ b/sw/device/silicon_creator/lib/ownership/keys/fake/app_prod_spx.h
@@ -5,18 +5,8 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_APP_PROD_SPX_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_APP_PROD_SPX_H_
 
-#define APP_PROD_SPX \
-  {                  \
-    .data = {        \
-      342329895,     \
-      2013107991,    \
-      2297648695,    \
-      3306667688,    \
-      2064727507,    \
-      1555686114,    \
-      1109351432,    \
-      3336892138     \
-    }                \
-  }
+#define APP_PROD_SPX                                                   \
+  {.data = {342329895, 2013107991, 2297648695, 3306667688, 2064727507, \
+            1555686114, 1109351432, 3336892138}}
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_APP_PROD_SPX_H_

--- a/sw/device/silicon_creator/lib/ownership/keys/fake/app_test_ecdsa_p256.h
+++ b/sw/device/silicon_creator/lib/ownership/keys/fake/app_test_ecdsa_p256.h
@@ -5,12 +5,12 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_APP_TEST_ECDSA_P256_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_APP_TEST_ECDSA_P256_H_
 
-#define APP_TEST_ECDSA_P256                                \
-  {                                                        \
-    .x = {0xced1f3c1, 0x8f31432e, 0x3bd9cc77, 0xb53f37f1,  \
-          0xd2eb4cdd, 0xeb3e0bf4, 0xed753db5, 0xdfcbc369}, \
-    .y = {0x230c28c5, 0xfd36977b, 0xe0a93eb8, 0x1c80d1b9,  \
-          0xbf7782d9, 0x0d3d6d7c, 0xaf133a0e, 0xefd36de6}, \
+#define APP_TEST_ECDSA_P256                                             \
+  {                                                                     \
+      .x = {0xced1f3c1, 0x8f31432e, 0x3bd9cc77, 0xb53f37f1, 0xd2eb4cdd, \
+            0xeb3e0bf4, 0xed753db5, 0xdfcbc369},                        \
+      .y = {0x230c28c5, 0xfd36977b, 0xe0a93eb8, 0x1c80d1b9, 0xbf7782d9, \
+            0x0d3d6d7c, 0xaf133a0e, 0xefd36de6},                        \
   }
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_APP_TEST_ECDSA_P256_H_

--- a/sw/device/silicon_creator/lib/ownership/keys/fake/owner_ecdsa_p256.h
+++ b/sw/device/silicon_creator/lib/ownership/keys/fake/owner_ecdsa_p256.h
@@ -5,12 +5,12 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_OWNER_ECDSA_P256_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_OWNER_ECDSA_P256_H_
 
-#define OWNER_ECDSA_P256                                   \
-  {                                                        \
-    .x = {0x8e3dcb50, 0x0036bafe, 0xe9ca771f, 0xbce13f2c,  \
-          0x8246d17a, 0x5949d6b1, 0x3a624c28, 0x7c5d8d08}, \
-    .y = {0xd664e861, 0xd07b1bf5, 0x6f437b27, 0x21696187,  \
-          0x123b6637, 0xee962e67, 0xaec24bf5, 0x529422ab}, \
+#define OWNER_ECDSA_P256                                                \
+  {                                                                     \
+      .x = {0x8e3dcb50, 0x0036bafe, 0xe9ca771f, 0xbce13f2c, 0x8246d17a, \
+            0x5949d6b1, 0x3a624c28, 0x7c5d8d08},                        \
+      .y = {0xd664e861, 0xd07b1bf5, 0x6f437b27, 0x21696187, 0x123b6637, \
+            0xee962e67, 0xaec24bf5, 0x529422ab},                        \
   }
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_OWNER_ECDSA_P256_H_

--- a/sw/device/silicon_creator/lib/ownership/keys/fake/owner_spx.h
+++ b/sw/device/silicon_creator/lib/ownership/keys/fake/owner_spx.h
@@ -5,18 +5,8 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_OWNER_SPX_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_OWNER_SPX_H_
 
-#define OWNER_SPX \
-  {               \
-    .data = {     \
-      2060225938, \
-      2906778233, \
-      1213194299, \
-      3760349346, \
-      3237819324, \
-      3174437600, \
-      577795037,  \
-      2762028488  \
-    }             \
-  }
+#define OWNER_SPX                                                       \
+  {.data = {2060225938, 2906778233, 1213194299, 3760349346, 3237819324, \
+            3174437600, 577795037, 2762028488}}
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_OWNER_SPX_H_

--- a/sw/device/silicon_creator/lib/ownership/keys/fake/unlock_ecdsa_p256.h
+++ b/sw/device/silicon_creator/lib/ownership/keys/fake/unlock_ecdsa_p256.h
@@ -5,12 +5,12 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_UNLOCK_ECDSA_P256_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_UNLOCK_ECDSA_P256_H_
 
-#define UNLOCK_ECDSA_P256                                  \
-  {                                                        \
-    .x = {0x113f87b2, 0x04711ce7, 0x6af306d9, 0xb80e76dd,  \
-          0x26e30fd2, 0xda71b86e, 0xa062c80f, 0x284f4eb2}, \
-    .y = {0xe5704f44, 0xb11098c5, 0xc31d48d5, 0x5895d10f,  \
-          0x7ac11545, 0x86031e92, 0x71c617c6, 0x1f8e3b14}, \
+#define UNLOCK_ECDSA_P256                                               \
+  {                                                                     \
+      .x = {0x113f87b2, 0x04711ce7, 0x6af306d9, 0xb80e76dd, 0x26e30fd2, \
+            0xda71b86e, 0xa062c80f, 0x284f4eb2},                        \
+      .y = {0xe5704f44, 0xb11098c5, 0xc31d48d5, 0x5895d10f, 0x7ac11545, \
+            0x86031e92, 0x71c617c6, 0x1f8e3b14},                        \
   }
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_UNLOCK_ECDSA_P256_H_

--- a/sw/device/silicon_creator/lib/ownership/keys/fake/unlock_spx.h
+++ b/sw/device/silicon_creator/lib/ownership/keys/fake/unlock_spx.h
@@ -5,18 +5,8 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_UNLOCK_SPX_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_UNLOCK_SPX_H_
 
-#define UNLOCK_SPX \
-  {                \
-    .data = {      \
-      702273659,   \
-      820410287,   \
-      1537134634,  \
-      1690599258,  \
-      2052755488,  \
-      3820914027,  \
-      1729429625,  \
-      2622665165   \
-    }              \
-  }
+#define UNLOCK_SPX                                                    \
+  {.data = {702273659, 820410287, 1537134634, 1690599258, 2052755488, \
+            3820914027, 1729429625, 2622665165}}
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_KEYS_FAKE_UNLOCK_SPX_H_

--- a/sw/device/silicon_creator/lib/shutdown.h
+++ b/sw/device/silicon_creator/lib/shutdown.h
@@ -120,8 +120,7 @@ uint32_t shutdown_redact(rom_error_t reason, shutdown_error_redact_t severity);
 // from within a test program.
 noreturn
 #endif
-    void
-    shutdown_finalize(rom_error_t reason);
+    void shutdown_finalize(rom_error_t reason);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/shutdown_unittest.cc
+++ b/sw/device/silicon_creator/lib/shutdown_unittest.cc
@@ -80,11 +80,9 @@ constexpr uint32_t Pack32(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
   return result;
 }
 
-#define FULL(name, prod, prodend, dev, rma)                          \
-  {                                                                  \
-    name, kAlertClass##prod, kAlertClass##prodend, kAlertClass##dev, \
-        kAlertClass##rma                                             \
-  }
+#define FULL(name, prod, prodend, dev, rma)                         \
+  {name, kAlertClass##prod, kAlertClass##prodend, kAlertClass##dev, \
+   kAlertClass##rma}
 
 #define CLASSIFY(name, prod, prodend, dev, rma)                     \
   Pack32(kAlertClass##prod, kAlertClass##prodend, kAlertClass##dev, \

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data_v0.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data_v0.h
@@ -47,7 +47,7 @@ typedef enum perso_tlv_cert_header_fields_v0 {
   {                                                                         \
     uint16_t mask = k##type_name##field_name##FieldMask;                    \
     uint16_t shift = k##type_name##field_name##FieldShift;                  \
-    uint16_t fieldv = (uint16_t)(field_value)&mask;                         \
+    uint16_t fieldv = (uint16_t)(field_value) & mask;                       \
     uint16_t fullv = __builtin_bswap16((uint16_t)(full_value));             \
     mask = (uint16_t)(mask << shift);                                       \
     (full_value) = __builtin_bswap16(                                       \

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data_v1.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data_v1.h
@@ -47,7 +47,7 @@ typedef enum perso_tlv_cert_header_fields_v1 {
   {                                                                            \
     uint32_t mask = k##type_name##field_name##FieldMask;                       \
     uint32_t shift = k##type_name##field_name##FieldShift;                     \
-    uint32_t fieldv = (uint32_t)(field_value)&mask;                            \
+    uint32_t fieldv = (uint32_t)(field_value) & mask;                          \
     uint32_t fullv = __builtin_bswap32((uint32_t)(full_value));                \
     mask = (uint32_t)(mask << shift);                                          \
     (full_value) = __builtin_bswap32(                                          \

--- a/sw/device/silicon_creator/rom/keys/fake/ecdsa/dev_key_0_ecdsa_p256.h
+++ b/sw/device/silicon_creator/rom/keys/fake/ecdsa/dev_key_0_ecdsa_p256.h
@@ -5,11 +5,11 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_DEV_KEY_0_ECDSA_P256_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_DEV_KEY_0_ECDSA_P256_H_
 
-#define DEV_KEY_0_ECDSA_P256                                                \
-  {                                                                         \
-    0xc11c931c, 0x4f7ed1a3, 0x8a01ceb0, 0x8ce15738, 0xa742ec25, 0xb9e7bf8a, \
-        0x65a85787, 0xd0b7ee13, 0x2fbccaaf, 0xba9eb917, 0x40529329,         \
-        0xb1dfa2cc, 0xf7a103fd, 0xc9dbc64b, 0x70df4ad0, 0xce8c4b5b,         \
+#define DEV_KEY_0_ECDSA_P256                                                  \
+  {                                                                           \
+      0xc11c931c, 0x4f7ed1a3, 0x8a01ceb0, 0x8ce15738, 0xa742ec25, 0xb9e7bf8a, \
+      0x65a85787, 0xd0b7ee13, 0x2fbccaaf, 0xba9eb917, 0x40529329, 0xb1dfa2cc, \
+      0xf7a103fd, 0xc9dbc64b, 0x70df4ad0, 0xce8c4b5b,                         \
   }
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_DEV_KEY_0_ECDSA_P256_H_

--- a/sw/device/silicon_creator/rom/keys/fake/ecdsa/prod_key_0_ecdsa_p256.h
+++ b/sw/device/silicon_creator/rom/keys/fake/ecdsa/prod_key_0_ecdsa_p256.h
@@ -5,11 +5,11 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_PROD_KEY_0_ECDSA_P256_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_PROD_KEY_0_ECDSA_P256_H_
 
-#define PROD_KEY_0_ECDSA_P256                                               \
-  {                                                                         \
-    0x9bf2dafd, 0x38daf96b, 0x0fa3a5a4, 0x28a525c1, 0x0eeeff00, 0x923499d9, \
-        0xe6557b33, 0x8277988c, 0x1ddda9bd, 0x0e3cd209, 0xef6d9014,         \
-        0x611a0325, 0x734ebd05, 0x0a5b3c2e, 0x866f12e0, 0x7e571d04,         \
+#define PROD_KEY_0_ECDSA_P256                                                 \
+  {                                                                           \
+      0x9bf2dafd, 0x38daf96b, 0x0fa3a5a4, 0x28a525c1, 0x0eeeff00, 0x923499d9, \
+      0xe6557b33, 0x8277988c, 0x1ddda9bd, 0x0e3cd209, 0xef6d9014, 0x611a0325, \
+      0x734ebd05, 0x0a5b3c2e, 0x866f12e0, 0x7e571d04,                         \
   }
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_PROD_KEY_0_ECDSA_P256_H_

--- a/sw/device/silicon_creator/rom/keys/fake/ecdsa/prod_key_1_ecdsa_p256.h
+++ b/sw/device/silicon_creator/rom/keys/fake/ecdsa/prod_key_1_ecdsa_p256.h
@@ -5,11 +5,11 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_PROD_KEY_1_ECDSA_P256_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_PROD_KEY_1_ECDSA_P256_H_
 
-#define PROD_KEY_1_ECDSA_P256                                               \
-  {                                                                         \
-    0x423e545e, 0xd80fe551, 0xad9f2278, 0x2fccd456, 0x204d2420, 0xec711f34, \
-        0xe2838f6c, 0xfbf0b76a, 0xac4d7547, 0xddd1167a, 0x2e8abaf1,         \
-        0xf120582d, 0xd3ea06e1, 0x87f974e6, 0xb1c79bbb, 0xb70fd07d,         \
+#define PROD_KEY_1_ECDSA_P256                                                 \
+  {                                                                           \
+      0x423e545e, 0xd80fe551, 0xad9f2278, 0x2fccd456, 0x204d2420, 0xec711f34, \
+      0xe2838f6c, 0xfbf0b76a, 0xac4d7547, 0xddd1167a, 0x2e8abaf1, 0xf120582d, \
+      0xd3ea06e1, 0x87f974e6, 0xb1c79bbb, 0xb70fd07d,                         \
   }
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_PROD_KEY_1_ECDSA_P256_H_

--- a/sw/device/silicon_creator/rom/keys/fake/ecdsa/test_key_0_ecdsa_p256.h
+++ b/sw/device/silicon_creator/rom/keys/fake/ecdsa/test_key_0_ecdsa_p256.h
@@ -5,11 +5,11 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_TEST_KEY_0_ECDSA_P256_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_TEST_KEY_0_ECDSA_P256_H_
 
-#define TEST_KEY_0_ECDSA_P256                                               \
-  {                                                                         \
-    0xee07109a, 0x0bba6de3, 0x7bfccca8, 0xe9e0f480, 0x845024cf, 0x5bcb453d, \
-        0x6937e237, 0x2e66e6cb, 0xd8e17e50, 0x444da9de, 0x3c413ac2,         \
-        0x012abb22, 0xf773fc51, 0xa5d7eb1d, 0xbb56aeb4, 0xdeb1e092,         \
+#define TEST_KEY_0_ECDSA_P256                                                 \
+  {                                                                           \
+      0xee07109a, 0x0bba6de3, 0x7bfccca8, 0xe9e0f480, 0x845024cf, 0x5bcb453d, \
+      0x6937e237, 0x2e66e6cb, 0xd8e17e50, 0x444da9de, 0x3c413ac2, 0x012abb22, \
+      0xf773fc51, 0xa5d7eb1d, 0xbb56aeb4, 0xdeb1e092,                         \
   }
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_TEST_KEY_0_ECDSA_P256_H_

--- a/sw/device/silicon_creator/rom/keys/fake/spx/prod_key_1_spx.h
+++ b/sw/device/silicon_creator/rom/keys/fake/spx/prod_key_1_spx.h
@@ -5,16 +5,10 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_SPX_PROD_KEY_1_SPX_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_SPX_PROD_KEY_1_SPX_H_
 
-#define PROD_KEY_1_SPX \
-  {                    \
-    .data = {          \
-      0xad63458a,      \
-      0x496271fa,      \
-      0x8c9a5579,      \
-      0x1f5a1a8b,      \
-      0x3ee242a2,      \
-      0x33ae5f9a,      \
-      0x0356fbb0,      \
-      0x4d83c8d1,      \
+#define PROD_KEY_1_SPX                                  \
+  {                                                     \
+    .data = {                                           \
+        0xad63458a, 0x496271fa, 0x8c9a5579, 0x1f5a1a8b, \
+        0x3ee242a2, 0x33ae5f9a, 0x0356fbb0, 0x4d83c8d1, \
     }
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_SPX_PROD_KEY_1_SPX_H_

--- a/sw/device/silicon_creator/rom/keys/fake/spx/test_key_0_spx.h
+++ b/sw/device/silicon_creator/rom/keys/fake/spx/test_key_0_spx.h
@@ -5,16 +5,10 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_SPX_TEST_KEY_0_SPX_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_SPX_TEST_KEY_0_SPX_H_
 
-#define TEST_KEY_0_SPX \
-  {                    \
-    .data = {          \
-      0xfa2a1ba6,      \
-      0x4fdc04ee,      \
-      0x73e009c7,      \
-      0x20ce5b2a,      \
-      0xaafa2282,      \
-      0xf172710e,      \
-      0x1005bf04,      \
-      0xa7fd9254,      \
+#define TEST_KEY_0_SPX                                  \
+  {                                                     \
+    .data = {                                           \
+        0xfa2a1ba6, 0x4fdc04ee, 0x73e009c7, 0x20ce5b2a, \
+        0xaafa2282, 0xf172710e, 0x1005bf04, 0xa7fd9254, \
     }
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_SPX_TEST_KEY_0_SPX_H_

--- a/sw/device/silicon_creator/rom_ext/sival/keys/appkey_dev_0.h
+++ b/sw/device/silicon_creator/rom_ext/sival/keys/appkey_dev_0.h
@@ -5,12 +5,12 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_SIVAL_KEYS_APPKEY_DEV_0_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_SIVAL_KEYS_APPKEY_DEV_0_H_
 
-#define APPKEY_DEV_0                                       \
-  {                                                        \
-    .x = {0x471b4b2c, 0xb41fed57, 0x99b552c6, 0x9015d9ed,  \
-          0x825f0c70, 0x068d88e5, 0x69993ee3, 0x9dfab76b}, \
-    .y = {0x9c7a9b58, 0xd1fdf9e5, 0x39fe85eb, 0x8f6215f7,  \
-          0x9e52b774, 0xd61c01d0, 0x400a4da6, 0x6ffe324e}, \
+#define APPKEY_DEV_0                                                    \
+  {                                                                     \
+      .x = {0x471b4b2c, 0xb41fed57, 0x99b552c6, 0x9015d9ed, 0x825f0c70, \
+            0x068d88e5, 0x69993ee3, 0x9dfab76b},                        \
+      .y = {0x9c7a9b58, 0xd1fdf9e5, 0x39fe85eb, 0x8f6215f7, 0x9e52b774, \
+            0xd61c01d0, 0x400a4da6, 0x6ffe324e},                        \
   }
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_SIVAL_KEYS_APPKEY_DEV_0_H_

--- a/sw/device/silicon_creator/rom_ext/sival/keys/appkey_prod_0.h
+++ b/sw/device/silicon_creator/rom_ext/sival/keys/appkey_prod_0.h
@@ -5,12 +5,12 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_SIVAL_KEYS_APPKEY_PROD_0_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_SIVAL_KEYS_APPKEY_PROD_0_H_
 
-#define APPKEY_PROD_0                                      \
-  {                                                        \
-    .x = {0x03340a84, 0x9aed01b4, 0x017cbd69, 0xdb2924af,  \
-          0xfa6ea854, 0xcd804134, 0xb5668540, 0x5305de4b}, \
-    .y = {0x135958d2, 0x0526bfdd, 0xc5574602, 0xc82e3dff,  \
-          0x861defab, 0xf7c94dea, 0x657a1eb9, 0x70ae605c}, \
+#define APPKEY_PROD_0                                                   \
+  {                                                                     \
+      .x = {0x03340a84, 0x9aed01b4, 0x017cbd69, 0xdb2924af, 0xfa6ea854, \
+            0xcd804134, 0xb5668540, 0x5305de4b},                        \
+      .y = {0x135958d2, 0x0526bfdd, 0xc5574602, 0xc82e3dff, 0x861defab, \
+            0xf7c94dea, 0x657a1eb9, 0x70ae605c},                        \
   }
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_SIVAL_KEYS_APPKEY_PROD_0_H_

--- a/sw/device/silicon_creator/rom_ext/sival/keys/appkey_test_0.h
+++ b/sw/device/silicon_creator/rom_ext/sival/keys/appkey_test_0.h
@@ -5,12 +5,12 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_SIVAL_KEYS_APPKEY_TEST_0_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_SIVAL_KEYS_APPKEY_TEST_0_H_
 
-#define APPKEY_TEST_0                                      \
-  {                                                        \
-    .x = {0x644e94f3, 0x74075e81, 0x9913e83f, 0xc77ae6d3,  \
-          0x00476998, 0x98f54835, 0x89478240, 0x98197460}, \
-    .y = {0x4812eddd, 0x93796b25, 0x6a2db917, 0x6e38f40d,  \
-          0xd414a8b5, 0x8fe3ebdb, 0x1bc1841c, 0xa040b4f5}, \
+#define APPKEY_TEST_0                                                   \
+  {                                                                     \
+      .x = {0x644e94f3, 0x74075e81, 0x9913e83f, 0xc77ae6d3, 0x00476998, \
+            0x98f54835, 0x89478240, 0x98197460},                        \
+      .y = {0x4812eddd, 0x93796b25, 0x6a2db917, 0x6e38f40d, 0xd414a8b5, \
+            0x8fe3ebdb, 0x1bc1841c, 0xa040b4f5},                        \
   }
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_SIVAL_KEYS_APPKEY_TEST_0_H_

--- a/sw/device/silicon_creator/rom_ext/sival/keys/earlgrey_z0_sival_1.h
+++ b/sw/device/silicon_creator/rom_ext/sival/keys/earlgrey_z0_sival_1.h
@@ -5,35 +5,41 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_SIVAL_KEYS_EARLGREY_Z0_SIVAL_1_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_SIVAL_KEYS_EARLGREY_Z0_SIVAL_1_H_
 
-#define EARLGREY_Z0_SIVAL_1                                             \
-  {                                                                     \
-    .n =                                                                \
-        {{                                                              \
-            0x244fec5d, 0x03bf7017, 0x651d68c3, 0x3374169d, 0x9805a84c, \
-            0x62f21102, 0xed908f32, 0xf71f8255, 0x78ef5741, 0xd26d0552, \
-            0xd2318013, 0xf28275a2, 0x4c916d97, 0xbdfce99b, 0x5ef69b79, \
-            0xd8b107fd, 0xe0212994, 0x1ab8c35a, 0x6ac74072, 0x60888896, \
-            0xcaab7ac0, 0xe61874d6, 0x52900627, 0xf9f10f13, 0xd983cb4e, \
-            0x5fe88069, 0x2d528eb4, 0xb0a4d29a, 0xc7e84cf2, 0x83f270b2, \
-            0x8d426b9e, 0x78d5e141, 0x8759e02b, 0x54749c6c, 0x74a2cda8, \
-            0x3814631f, 0xa056740a, 0x98b65ea7, 0x551433c7, 0xe47affa8, \
-            0x2492252c, 0xedcd058a, 0x8b0e0efc, 0x0ba12bdb, 0x21f225ae, \
-            0xa64dfe4d, 0x0eb4ca2c, 0x0c213dea, 0x6be70c60, 0xc3535e68, \
-            0x23318a0a, 0xa4affa8f, 0x07be0532, 0xc8921477, 0xf25dd77e, \
-            0x430b915e, 0xb116b20f, 0xb981d3f6, 0xb60217d1, 0x076c04c6, \
-            0x28cc4ad7, 0x59ac67f9, 0x816da846, 0xd1540726, 0xd4f0e019, \
-            0x299e5fe4, 0x6404de97, 0xa802ccb6, 0x2b7d6660, 0x0b4717e3, \
-            0xd650cd2f, 0xd3664047, 0x32b81c86, 0xd4f1dc37, 0x5654406e, \
-            0x3f0ac12d, 0x053d03d4, 0x16fe1c13, 0x8e56662f, 0xed8ee0d9, \
-            0x1c6d904a, 0x56656253, 0xa3405ff2, 0xb973e8aa, 0xe3f2069b, \
-            0xac0d103a, 0xd1f85484, 0x6103932c, 0x7fd5115c, 0xffc0d4d3, \
-            0xd50f5081, 0x678e9dec, 0xff838843, 0x74f11c20, 0xb748261d, \
-            0x93769b65,                                                 \
-        }},                                                             \
-    .n0_inv = {                                                         \
-        0xfe86b80b, 0x43f83fe6, 0x96163096, 0x261c4bba,                 \
-        0x4e69ab6e, 0x6e214b18, 0x9cf1da8f, 0x8183bfa0,                 \
-    },                                                                  \
+#define EARLGREY_Z0_SIVAL_1                                           \
+  {                                                                   \
+      .n = {{                                                         \
+          0x244fec5d, 0x03bf7017, 0x651d68c3, 0x3374169d, 0x9805a84c, \
+          0x62f21102, 0xed908f32, 0xf71f8255, 0x78ef5741, 0xd26d0552, \
+          0xd2318013, 0xf28275a2, 0x4c916d97, 0xbdfce99b, 0x5ef69b79, \
+          0xd8b107fd, 0xe0212994, 0x1ab8c35a, 0x6ac74072, 0x60888896, \
+          0xcaab7ac0, 0xe61874d6, 0x52900627, 0xf9f10f13, 0xd983cb4e, \
+          0x5fe88069, 0x2d528eb4, 0xb0a4d29a, 0xc7e84cf2, 0x83f270b2, \
+          0x8d426b9e, 0x78d5e141, 0x8759e02b, 0x54749c6c, 0x74a2cda8, \
+          0x3814631f, 0xa056740a, 0x98b65ea7, 0x551433c7, 0xe47affa8, \
+          0x2492252c, 0xedcd058a, 0x8b0e0efc, 0x0ba12bdb, 0x21f225ae, \
+          0xa64dfe4d, 0x0eb4ca2c, 0x0c213dea, 0x6be70c60, 0xc3535e68, \
+          0x23318a0a, 0xa4affa8f, 0x07be0532, 0xc8921477, 0xf25dd77e, \
+          0x430b915e, 0xb116b20f, 0xb981d3f6, 0xb60217d1, 0x076c04c6, \
+          0x28cc4ad7, 0x59ac67f9, 0x816da846, 0xd1540726, 0xd4f0e019, \
+          0x299e5fe4, 0x6404de97, 0xa802ccb6, 0x2b7d6660, 0x0b4717e3, \
+          0xd650cd2f, 0xd3664047, 0x32b81c86, 0xd4f1dc37, 0x5654406e, \
+          0x3f0ac12d, 0x053d03d4, 0x16fe1c13, 0x8e56662f, 0xed8ee0d9, \
+          0x1c6d904a, 0x56656253, 0xa3405ff2, 0xb973e8aa, 0xe3f2069b, \
+          0xac0d103a, 0xd1f85484, 0x6103932c, 0x7fd5115c, 0xffc0d4d3, \
+          0xd50f5081, 0x678e9dec, 0xff838843, 0x74f11c20, 0xb748261d, \
+          0x93769b65,                                                 \
+      }},                                                             \
+      .n0_inv =                                                       \
+          {                                                           \
+              0xfe86b80b,                                             \
+              0x43f83fe6,                                             \
+              0x96163096,                                             \
+              0x261c4bba,                                             \
+              0x4e69ab6e,                                             \
+              0x6e214b18,                                             \
+              0x9cf1da8f,                                             \
+              0x8183bfa0,                                             \
+          },                                                          \
   }
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_SIVAL_KEYS_EARLGREY_Z0_SIVAL_1_H_

--- a/sw/device/silicon_creator/rom_ext/sival/keys/ownership_activate_key.h
+++ b/sw/device/silicon_creator/rom_ext/sival/keys/ownership_activate_key.h
@@ -5,11 +5,11 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_SIVAL_KEYS_OWNERSHIP_ACTIVATE_KEY_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_SIVAL_KEYS_OWNERSHIP_ACTIVATE_KEY_H_
 
-#define OWNERSHIP_ACTIVATE_KEY                                              \
-  {                                                                         \
-    0x722fcac6, 0x11f2207a, 0xa406b0ca, 0x6f9d8ccb, 0x36034b0a, 0x5938db28, \
-        0x5e134f00, 0x8fca8f01, 0x65028265, 0x87c93df1, 0xcd12dd2e,         \
-        0x2aefda74, 0x353dadbb, 0x576cc96a, 0x28e5699a, 0x34b6b35c,         \
+#define OWNERSHIP_ACTIVATE_KEY                                                \
+  {                                                                           \
+      0x722fcac6, 0x11f2207a, 0xa406b0ca, 0x6f9d8ccb, 0x36034b0a, 0x5938db28, \
+      0x5e134f00, 0x8fca8f01, 0x65028265, 0x87c93df1, 0xcd12dd2e, 0x2aefda74, \
+      0x353dadbb, 0x576cc96a, 0x28e5699a, 0x34b6b35c,                         \
   }
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_SIVAL_KEYS_OWNERSHIP_ACTIVATE_KEY_H_

--- a/sw/device/silicon_creator/rom_ext/sival/keys/ownership_owner_key.h
+++ b/sw/device/silicon_creator/rom_ext/sival/keys/ownership_owner_key.h
@@ -5,11 +5,11 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_SIVAL_KEYS_OWNERSHIP_OWNER_KEY_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_SIVAL_KEYS_OWNERSHIP_OWNER_KEY_H_
 
-#define OWNERSHIP_OWNER_KEY                                                 \
-  {                                                                         \
-    0x25d3e660, 0x6b9401bb, 0x2d1f5aee, 0x875afd25, 0xaaec4927, 0xda4db14f, \
-        0x5d8589d7, 0xa1d16920, 0x3e1c985f, 0x2382ab29, 0x8691f8a4,         \
-        0xc23a8311, 0x1dc2bd4f, 0x52faf2a0, 0xecbd0854, 0x4c80901b,         \
+#define OWNERSHIP_OWNER_KEY                                                   \
+  {                                                                           \
+      0x25d3e660, 0x6b9401bb, 0x2d1f5aee, 0x875afd25, 0xaaec4927, 0xda4db14f, \
+      0x5d8589d7, 0xa1d16920, 0x3e1c985f, 0x2382ab29, 0x8691f8a4, 0xc23a8311, \
+      0x1dc2bd4f, 0x52faf2a0, 0xecbd0854, 0x4c80901b,                         \
   }
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_SIVAL_KEYS_OWNERSHIP_OWNER_KEY_H_

--- a/sw/device/silicon_creator/rom_ext/sival/keys/ownership_unlock_key.h
+++ b/sw/device/silicon_creator/rom_ext/sival/keys/ownership_unlock_key.h
@@ -5,11 +5,11 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_SIVAL_KEYS_OWNERSHIP_UNLOCK_KEY_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_SIVAL_KEYS_OWNERSHIP_UNLOCK_KEY_H_
 
-#define OWNERSHIP_UNLOCK_KEY                                                \
-  {                                                                         \
-    0xbba01e3e, 0x8fd4e130, 0x141168e0, 0x46bd37f7, 0x93998070, 0x455abb63, \
-        0xb3a97219, 0x3dc97b59, 0x37a94aba, 0x810a3baa, 0x83e294a8,         \
-        0xc414ec9e, 0x0b6dc453, 0xd7295f00, 0x9c21ea58, 0x3c0788fa,         \
+#define OWNERSHIP_UNLOCK_KEY                                                  \
+  {                                                                           \
+      0xbba01e3e, 0x8fd4e130, 0x141168e0, 0x46bd37f7, 0x93998070, 0x455abb63, \
+      0xb3a97219, 0x3dc97b59, 0x37a94aba, 0x810a3baa, 0x83e294a8, 0xc414ec9e, \
+      0x0b6dc453, 0xd7295f00, 0x9c21ea58, 0x3c0788fa,                         \
   }
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_SIVAL_KEYS_OWNERSHIP_UNLOCK_KEY_H_

--- a/sw/device/tests/flash_ctrl_clock_freqs_test.c
+++ b/sw/device/tests/flash_ctrl_clock_freqs_test.c
@@ -23,11 +23,11 @@
  * Defined here to be able to use in tests.
  */
 #define FLASH_CTRL_OTP_FIELD_SCRAMBLING \
-  (bitfield_field32_t) { .mask = UINT8_MAX, .index = CHAR_BIT * 0 }
+  (bitfield_field32_t){.mask = UINT8_MAX, .index = CHAR_BIT * 0}
 #define FLASH_CTRL_OTP_FIELD_ECC \
-  (bitfield_field32_t) { .mask = UINT8_MAX, .index = CHAR_BIT * 1 }
+  (bitfield_field32_t){.mask = UINT8_MAX, .index = CHAR_BIT * 1}
 #define FLASH_CTRL_OTP_FIELD_HE \
-  (bitfield_field32_t) { .mask = UINT8_MAX, .index = CHAR_BIT * 2 }
+  (bitfield_field32_t){.mask = UINT8_MAX, .index = CHAR_BIT * 2}
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/flash_ctrl_ops_test.c
+++ b/sw/device/tests/flash_ctrl_ops_test.c
@@ -27,11 +27,11 @@
  * Defined here to be able to use in tests.
  */
 #define FLASH_CTRL_OTP_FIELD_SCRAMBLING \
-  (bitfield_field32_t) { .mask = UINT8_MAX, .index = CHAR_BIT * 0 }
+  (bitfield_field32_t){.mask = UINT8_MAX, .index = CHAR_BIT * 0}
 #define FLASH_CTRL_OTP_FIELD_ECC \
-  (bitfield_field32_t) { .mask = UINT8_MAX, .index = CHAR_BIT * 1 }
+  (bitfield_field32_t){.mask = UINT8_MAX, .index = CHAR_BIT * 1}
 #define FLASH_CTRL_OTP_FIELD_HE \
-  (bitfield_field32_t) { .mask = UINT8_MAX, .index = CHAR_BIT * 2 }
+  (bitfield_field32_t){.mask = UINT8_MAX, .index = CHAR_BIT * 2}
 
 OTTF_DEFINE_TEST_CONFIG();
 

--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
@@ -418,7 +418,7 @@ void pentest_configure_alert_handler(
   // the threshold for how many alerts start the first escalation phase, and
   // which escalation phases it follows.
   for (dif_alert_handler_class_t class = 0;
-       class < ALERT_HANDLER_PARAM_N_CLASSES; class ++) {
+       class < ALERT_HANDLER_PARAM_N_CLASSES; class++) {
     dif_alert_handler_class_config_t class_config = {
         .auto_lock_accumulation_counter = kDifToggleDisabled,
         .accumulator_threshold = accumulation_thresholds[class],

--- a/sw/device/tests/rv_dm_ndm_reset_req.c
+++ b/sw/device/tests/rv_dm_ndm_reset_req.c
@@ -117,61 +117,61 @@ static void check_test_reg(test_register_t *regs, size_t reg_count) {
 
 bool test_main(void) {
   test_register_t regs[] = {
-    {
-        .name = "OTP_CTRL",
-        .base = dt_otp_ctrl_primary_reg_block(kDtOtpCtrl),
-        .offset = OTP_CTRL_DIRECT_ACCESS_WDATA_0_REG_OFFSET,
-        .write_val = 0x06092022,
-        .exp_read_val = OTP_CTRL_DIRECT_ACCESS_WDATA_0_REG_RESVAL,
-    },
-    {
-        .name = "PINMUX",
-        .base = dt_pinmux_primary_reg_block(kDtPinmuxAon),
-        .offset = PINMUX_WKUP_DETECTOR_CNT_TH_1_REG_OFFSET,
-        .write_val = 0x44,
-        .exp_read_val = PINMUX_WKUP_DETECTOR_CNT_TH_1_REG_RESVAL,
+      {
+          .name = "OTP_CTRL",
+          .base = dt_otp_ctrl_primary_reg_block(kDtOtpCtrl),
+          .offset = OTP_CTRL_DIRECT_ACCESS_WDATA_0_REG_OFFSET,
+          .write_val = 0x06092022,
+          .exp_read_val = OTP_CTRL_DIRECT_ACCESS_WDATA_0_REG_RESVAL,
+      },
+      {
+          .name = "PINMUX",
+          .base = dt_pinmux_primary_reg_block(kDtPinmuxAon),
+          .offset = PINMUX_WKUP_DETECTOR_CNT_TH_1_REG_OFFSET,
+          .write_val = 0x44,
+          .exp_read_val = PINMUX_WKUP_DETECTOR_CNT_TH_1_REG_RESVAL,
 
-    },
+      },
 #if defined(OPENTITAN_IS_EARLGREY)
-    {
-        .name = "ADC_CTRL",
-        .base = dt_adc_ctrl_primary_reg_block(kDtAdcCtrlAon),
-        .offset = ADC_CTRL_ADC_SAMPLE_CTL_REG_OFFSET,
-        .write_val = 0x37,
-        .exp_read_val = ADC_CTRL_ADC_SAMPLE_CTL_REG_RESVAL,
+      {
+          .name = "ADC_CTRL",
+          .base = dt_adc_ctrl_primary_reg_block(kDtAdcCtrlAon),
+          .offset = ADC_CTRL_ADC_SAMPLE_CTL_REG_OFFSET,
+          .write_val = 0x37,
+          .exp_read_val = ADC_CTRL_ADC_SAMPLE_CTL_REG_RESVAL,
 
-    },
-    {
-        .name = "SYSRST_CTRL",
-        .base = dt_sysrst_ctrl_primary_reg_block(kDtSysrstCtrlAon),
-        .offset = SYSRST_CTRL_EC_RST_CTL_REG_OFFSET,
-        .write_val = 0x567,
-        .exp_read_val = SYSRST_CTRL_EC_RST_CTL_REG_RESVAL,
+      },
+      {
+          .name = "SYSRST_CTRL",
+          .base = dt_sysrst_ctrl_primary_reg_block(kDtSysrstCtrlAon),
+          .offset = SYSRST_CTRL_EC_RST_CTL_REG_OFFSET,
+          .write_val = 0x567,
+          .exp_read_val = SYSRST_CTRL_EC_RST_CTL_REG_RESVAL,
 
-    },
-    {
-        .name = "KEYMGR",
-        .base = dt_keymgr_primary_reg_block(kDtKeymgr),
-        .offset = KEYMGR_MAX_OWNER_KEY_VER_SHADOWED_REG_OFFSET,
-        .write_val = 0x1600ABBA,
-        .exp_read_val = KEYMGR_MAX_OWNER_KEY_VER_SHADOWED_REG_RESVAL,
+      },
+      {
+          .name = "KEYMGR",
+          .base = dt_keymgr_primary_reg_block(kDtKeymgr),
+          .offset = KEYMGR_MAX_OWNER_KEY_VER_SHADOWED_REG_OFFSET,
+          .write_val = 0x1600ABBA,
+          .exp_read_val = KEYMGR_MAX_OWNER_KEY_VER_SHADOWED_REG_RESVAL,
 
-    },
-    {
-        .name = "FLASH_CTRL",
-        .base = dt_flash_ctrl_primary_reg_block(kDtFlashCtrl),
-        .offset = FLASH_CTRL_SCRATCH_REG_OFFSET,
-        .write_val = 0x3927,
-        .exp_read_val = FLASH_CTRL_SCRATCH_REG_RESVAL,
-    },
+      },
+      {
+          .name = "FLASH_CTRL",
+          .base = dt_flash_ctrl_primary_reg_block(kDtFlashCtrl),
+          .offset = FLASH_CTRL_SCRATCH_REG_OFFSET,
+          .write_val = 0x3927,
+          .exp_read_val = FLASH_CTRL_SCRATCH_REG_RESVAL,
+      },
 #elif defined(OPENTITAN_IS_DARJEELING)
-    {
-        .name = "KEYMGR_DPE",
-        .base = dt_keymgr_dpe_primary_reg_block(kDtKeymgrDpe),
-        .offset = KEYMGR_DPE_MAX_KEY_VER_SHADOWED_REG_OFFSET,
-        .write_val = 0x1600ABBA,
-        .exp_read_val = KEYMGR_DPE_MAX_KEY_VER_SHADOWED_REG_RESVAL,
-    },
+      {
+          .name = "KEYMGR_DPE",
+          .base = dt_keymgr_dpe_primary_reg_block(kDtKeymgrDpe),
+          .offset = KEYMGR_DPE_MAX_KEY_VER_SHADOWED_REG_OFFSET,
+          .write_val = 0x1600ABBA,
+          .exp_read_val = KEYMGR_DPE_MAX_KEY_VER_SHADOWED_REG_RESVAL,
+      },
 #else
 #error Unsupported top
 #endif

--- a/sw/device/tests/usbdev_mem_test.c
+++ b/sw/device/tests/usbdev_mem_test.c
@@ -31,10 +31,10 @@
 
 // Simple LFSR for 8-bit sequences
 /// Note: zero is an isolated state that shall be avoided
-#define LFSR_ADVANCE(lfsr)     \
-  (uint8_t)(                   \
-      (uint8_t)((lfsr) << 1) ^ \
-      ((((lfsr) >> 1) ^ ((lfsr) >> 2) ^ ((lfsr) >> 3) ^ ((lfsr) >> 7)) & 1U))
+#define LFSR_ADVANCE(lfsr)                                                     \
+  (uint8_t)((uint8_t)((lfsr) << 1) ^                                           \
+            ((((lfsr) >> 1) ^ ((lfsr) >> 2) ^ ((lfsr) >> 3) ^ ((lfsr) >> 7)) & \
+             1U))
 
 // Total size of packet buffer memory in bytes
 #define USBDEV_PACKET_MEM_SIZE (USBDEV_NUM_BUFFERS * USBDEV_MAX_PACKET_SIZE)

--- a/sw/device/tests/usbdev_suspend.c
+++ b/sw/device/tests/usbdev_suspend.c
@@ -1532,7 +1532,7 @@ static status_t state_service(usbdev_suspend_ctx_t *ctx) {
             // TODO: experimental test code! DO NOT MERGE
             if (false) {
               static uint8_t buf[4096];
-              extern void usbutils_gather(dif_usbdev_t * dev, uint8_t * buf,
+              extern void usbutils_gather(dif_usbdev_t * dev, uint8_t *buf,
                                           size_t n);
 
               while (!sense) {
@@ -1946,8 +1946,8 @@ bool usbdev_suspend_test(usbdev_suspend_phase_t init_phase,
     // Keep going if we're advancing to the next phase.
     //  (NextPhase means that we advance whilst still active and can thus skip
     //   device setup and configuratinon)
-  } while (ctx->test_state == kSuspendStateNextPhase ||    // from Resume
-           ctx->test_state == kSuspendStateBusReset ||     // after Bus Reset
+  } while (ctx->test_state == kSuspendStateNextPhase ||  // from Resume
+           ctx->test_state == kSuspendStateBusReset ||   // after Bus Reset
            ctx->test_state == kSuspendStatePowerOnReset);  // after Disconnect
 
   if (verbose) {

--- a/sw/host/tests/usbdev/usbdev_stream/usbdev_stream.cc
+++ b/sw/host/tests/usbdev/usbdev_stream/usbdev_stream.cc
@@ -18,8 +18,8 @@
 
 // Seed numbers for the LFSR generators in each transfer direction for
 // the given stream number.
-#define USBTST_LFSR_SEED(s) (uint8_t)(0x10U + (s)*7U)
-#define USBDPI_LFSR_SEED(s) (uint8_t)(0x9BU - (s)*7U)
+#define USBTST_LFSR_SEED(s) (uint8_t)(0x10U + (s) * 7U)
+#define USBDPI_LFSR_SEED(s) (uint8_t)(0x9BU - (s) * 7U)
 
 // Simple LFSR for 8-bit sequences.
 #define LFSR_ADVANCE(lfsr) \

--- a/third_party/lowrisc/BUILD.lowrisc_rv32imcb_toolchain.bazel
+++ b/third_party/lowrisc/BUILD.lowrisc_rv32imcb_toolchain.bazel
@@ -52,5 +52,5 @@ directory(
 subdirectory(
     name = "lib-clang-include",
     parent = ":root",
-    path = "lib/clang/16/include",
+    path = "lib/clang/21/include",
 )

--- a/third_party/lowrisc/extensions.bzl
+++ b/third_party/lowrisc/extensions.bzl
@@ -5,11 +5,11 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def _lowrisc_repos():
-    VERSION = "20251111-1"
+    VERSION = "20260224-1"
     http_archive(
         name = "lowrisc_rv32imcb_toolchain",
         url = "https://github.com/lowRISC/lowrisc-toolchains/releases/download/{v}/lowrisc-toolchain-rv32imcb-x86_64-{v}.tar.xz".format(v = VERSION),
-        sha256 = "42be8b4a7e2fe8ea9274759c8574eb3b763a5072741a75d22189c93b149b6fab",
+        sha256 = "528facbc6cb6f02667ce7613ab21383fca42b18cca6f4914b7160636080d3569",
         strip_prefix = "lowrisc-toolchain-rv32imcb-x86_64-{}".format(VERSION),
         build_file = ":BUILD.lowrisc_rv32imcb_toolchain.bazel",
     )

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -344,6 +344,7 @@ cc_args(
         "-Wtype-limits",
         "-Wno-gnu-auto-type",
         "-Wsign-conversion",
+        "-menable-experimental-extensions",
     ],
 )
 

--- a/util/bfv_decoder.c
+++ b/util/bfv_decoder.c
@@ -13,8 +13,7 @@ typedef struct {
   int value;
 } error_descriptor_t;
 
-#define ERROR_TABLE_ENTRY(name, value) \
-  { #name, value }
+#define ERROR_TABLE_ENTRY(name, value) {#name, value}
 
 // Add an empty element in the end to make it easier to stop iterating over the
 // table.


### PR DESCRIPTION
Upgrading Clang causes many clang-format formatting changes, due to more accurate parsing. There are no configuration options to work around that, so that churn has to be accepted.

`-menable-experimental-extensions` is necessary due to the usage of the `crc32.*` instructions in inline assembly.