### PR TITLE
[Reggen] Support vendor specific attributes

### DIFF
--- a/util/reggen/README.md
+++ b/util/reggen/README.md
@@ -517,6 +517,30 @@ For example the data bits and mask bits could be in the lower and upper parts of
 In this case instance 1 will use bits 1 and 17, instance 2 will use 2 and 18 and so on.
 Instance 16 does not fit, so will start a new register.
 
+#### Vendor-specific fields
+Regtool supports vendor-specific fields/attributes in the <IP>.hjson files.
+To add a vendor-specific field, one can use the argument `--vendor-specific-fields` when invoking `regtool.py`.
+These fields will not affect any of the regtool outputs.
+Therefore, they can be used by vendor-specific tools that also ingest the HJSON files; regtool merely tolerates these fields.
+
+This is a contrived example of how the vendor-specific HJSON configuration file:
+```hjson
+{
+  ip_block: {
+    lowrisc_block_field : ['s', 'This is Lowrisc awesome block field']
+  }
+  register: {
+    lowrisc_reg_field : ['s', 'This is Lowrisc awesome register field']
+  }
+  field: {
+    lowrisc_field : ['s', 'This is Lowrisc awesome field attr']
+  }
+  window: {
+    lowrisc_window_field : ['s', 'This is Lowrisc awesome window field']
+  }
+}
+```
+
 ### Verification Tags Definition and Format
 
 This section documents the usage of tags in the register Hjson file.

--- a/util/reggen/vendor_specific.py
+++ b/util/reggen/vendor_specific.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+import hjson  # type: ignore [import]
+import logging as log
+import sys
+
+from reggen import ip_block, register, multi_register, field, window
+
+
+def extend_optional_fields(arg_vendor_file: str) -> None:
+    """Extend the optional fields with vendor specific fields, in case it is defined."""
+
+    vendor_specific = import_fields(arg_vendor_file)
+
+    _extend_fields(vendor_specific, "ip_block", ip_block.OPTIONAL_FIELDS)
+    _extend_fields(vendor_specific, "register", register.OPTIONAL_FIELDS)
+    _extend_fields(vendor_specific, "register", multi_register.OPTIONAL_FIELDS)
+    _extend_fields(vendor_specific, "field", field.OPTIONAL_FIELDS)
+    _extend_fields(vendor_specific, "window", window.OPTIONAL_FIELDS)
+
+
+def _extend_fields(source: dict[str, str], name: str, dest: dict[str, list[str]]) -> None:
+    if name not in source:
+        return
+    data = source[name]
+
+    if not isinstance(data, dict):
+        log.error(
+            f"The following vendor specific attributes have the wrong type: {name}"
+        )
+        sys.exit(1)
+
+    # Find overlapping keys using set intersection
+    if overlap := data.keys() & dest.keys():
+        log.error(
+            f"The following vendor specific attributes are already defined: {', '.join(overlap)}"
+        )
+        sys.exit(1)
+
+    dest.update(data)
+
+
+def import_fields(vendor_file: str) -> dict[str, str]:
+    """Return vendor specific fields."""
+
+    vendor_specific = {}
+    arg_vendor_file = Path(vendor_file)
+    if arg_vendor_file.is_file():
+        vendor_specific = hjson.load(arg_vendor_file.open("r"))
+    else:
+        log.error("File {} does not exist".format(vendor_file))
+        sys.exit(1)
+
+    return vendor_specific

--- a/util/regtool.py
+++ b/util/regtool.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from reggen import (
     gen_cfg_md, gen_cheader, gen_dv, gen_fpv, gen_md, gen_html, gen_json, gen_rtl,
     gen_rust, gen_sec_cm_testplan, gen_selfdoc, systemrdl_exporter, gen_tock, version,
+    vendor_specific
 )
 from reggen.ip_block import IpBlock
 
@@ -148,6 +149,11 @@ def main():
         help=
         'If version stamping, the location of workspace version stamp file.')
 
+    parser.add_argument('--vendor-specific-fields',
+                        type=str,
+                        default=None,
+                        help='A hjson file describing vendor defined fields.')
+
     args = parser.parse_args()
 
     if args.version:
@@ -239,6 +245,9 @@ def main():
         with outfile:
             gen_selfdoc.document(outfile)
         exit(0)
+
+    if args.vendor_specific_fields:
+        vendor_specific.extend_optional_fields(args.vendor_specific_fields)
 
     srcfull = infile.read()
 

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -29,7 +29,7 @@ from mako import exceptions
 from mako.lookup import TemplateLookup
 from mako.template import Template
 from raclgen.lib import DEFAULT_RACL_CONFIG
-from reggen import access, gen_rtl, gen_sec_cm_testplan, params, reg_block, window
+from reggen import access, gen_rtl, gen_sec_cm_testplan, params, reg_block, window, vendor_specific
 from reggen.countermeasure import CounterMeasure
 from reggen.ip_block import IpBlock
 from topgen import get_hjsonobj_xbars
@@ -1563,7 +1563,15 @@ def main():
                         action="store_true",
                         help="Only return the list of blocks and exit.")
 
+    parser.add_argument('--vendor-specific-fields',
+                        type=str,
+                        default=None,
+                        help='A hjson file describing vendor defined fields.')
+
     args = parser.parse_args()
+
+    if args.vendor_specific_fields:
+        vendor_specific.extend_optional_fields(args.vendor_specific_fields)
 
     # check combinations
     if args.top_ral:


### PR DESCRIPTION
This PR addresses the issue https://github.com/lowRISC/opentitan/issues/28483.

To add vendor specific attributes when running the make to re-generate the top:
```sh
make -C hw top toolflags="--vendor-specific-fields=full/path/to/vendor_specific_fields.hjson"
```
When running regtool to generate a single IP
```sh
/home/doreis/git/opentitan.git/reggen/util/regtool.py  -r hw/top_earlgrey/ip/sensor_ctrl/data/sensor_ctrl.hjson --vendor-specific-ields=full/path/to/vendor_specific_fields.hjson
```

fix https://github.com/lowRISC/opentitan/issues/28483