### PR TITLE
[earlgrey_1.0.0,bazel] Fix Verilator static linking on NixOS

### DIFF
--- a/hw/BUILD
+++ b/hw/BUILD
@@ -46,7 +46,7 @@ fusesoc_build(
         # a build directory 6 levels down from where the location directives will
         # evaluate to.
         "CFLAGS_FOR_BUILD": "-I../../../../../../$(location @libelf//:gen_dir)/include",
-        "LDFLAGS_FOR_BUILD": "-static ../../../../../../$(location @libelf//:gen_dir)/lib/libelf.a",
+        "LDFLAGS_FOR_BUILD": "-Wl,-Bstatic ../../../../../../$(location @libelf//:gen_dir)/lib/libelf.a -Wl,-Bdynamic",
     },
     extra_deps = [
         # Note: the current debian/ubuntu `libelf1` package will not statically link.


### PR DESCRIPTION
The `LDFLAGS_FOR_BUILD` used `-static` which forced all libraries to link statically, including system libs (libz, libpthread, libm, libc, etc.) that are not available as static libraries on NixOS.

Use `-Wl,-Bstatic`/`-Wl,-Bdynamic` to link only libelf statically, letting system libraries resolve dynamically as normal.