### PR TITLE
[sw][drivers][kmac] Fix non-null-terminated string warning

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/kmac_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/kmac_functest.c
@@ -29,8 +29,8 @@ enum {
 
 typedef struct unalignedhash {
   char unused;
-  char short_payload[kShortMsgLen];
-  char long_payload[kLongMsgLen];
+  OT_NONSTRING char short_payload[kShortMsgLen];
+  OT_NONSTRING char long_payload[kLongMsgLen];
 } unalignedhash_t;
 
 static const alignas(uint32_t) unalignedhash_t kKmacTestData = {


### PR DESCRIPTION
Use `OT_NONSTRING` to silence a compiler warning about initializing a buffer with a C string, but not including the null terminator in that buffer (by sizing the buffer to only include the actual contents).