### PR TITLE
[crypto] Fix use of AES mode constant from incompatible enum

### DIFF
--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -340,10 +340,10 @@ static otcrypto_status_t otcrypto_aes_impl(
   // Construct the IV and check its length. ECB mode will ignore the IV, so in
   // this case it is left uninitialized.
   aes_block_t aes_iv;
-  if (aes_mode == kAesCipherModeEcb) {
-    HARDENED_CHECK_EQ(launder32(aes_mode), kAesCipherModeEcb);
+  if (aes_mode == kOtcryptoAesModeEcb) {
+    HARDENED_CHECK_EQ(launder32(aes_mode), kOtcryptoAesModeEcb);
   } else {
-    HARDENED_CHECK_NE(launder32(aes_mode), kAesCipherModeEcb);
+    HARDENED_CHECK_NE(launder32(aes_mode), kOtcryptoAesModeEcb);
 
     // The IV must be exactly one block long.
     if (iv->len != kAesBlockNumWords) {
@@ -457,7 +457,7 @@ static otcrypto_status_t otcrypto_aes_impl(
   HARDENED_TRY(aes_verify_ctrl_aux_reg());
 
   // Deinitialize the AES block and update the IV (in ECB mode, skip the IV).
-  if (aes_mode == kAesCipherModeEcb) {
+  if (aes_mode == kOtcryptoAesModeEcb) {
     HARDENED_TRY(aes_end(NULL));
   } else {
     HARDENED_TRY(aes_end(&aes_iv));


### PR DESCRIPTION
`kAesCipherModeEcb` and `kOtcryptoAesModeEcb` have the same numerical value but come from different enum types. More recent versions of Clang warn about this. Fix this by using the appropriate enum member.