### PR TITLE
[sw] Fix operations between different enum types

### DIFF
--- a/sw/device/silicon_creator/lib/boot_data.c
+++ b/sw/device/silicon_creator/lib/boot_data.c
@@ -514,11 +514,11 @@ static rom_error_t boot_data_default_get(lifecycle_state_t lc_state,
   switch (launder32(lc_state)) {
     case kLcStateTest:
       HARDENED_CHECK_EQ(lc_state, kLcStateTest);
-      res ^= kLcStateTest ^ kErrorBootDataNotFound ^ kErrorOk;
+      res ^= kLcStateTest ^ (uint32_t)kErrorBootDataNotFound ^ kErrorOk;
       break;
     case kLcStateDev:
       HARDENED_CHECK_EQ(lc_state, kLcStateDev);
-      res ^= kLcStateDev ^ kErrorBootDataNotFound ^ kErrorOk;
+      res ^= kLcStateDev ^ (uint32_t)kErrorBootDataNotFound ^ kErrorOk;
       break;
     case kLcStateProd:
       HARDENED_CHECK_EQ(lc_state, kLcStateProd);
@@ -538,7 +538,7 @@ static rom_error_t boot_data_default_get(lifecycle_state_t lc_state,
       break;
     case kLcStateRma:
       HARDENED_CHECK_EQ(lc_state, kLcStateRma);
-      res ^= kLcStateRma ^ kErrorBootDataNotFound ^ kErrorOk;
+      res ^= kLcStateRma ^ (uint32_t)kErrorBootDataNotFound ^ kErrorOk;
       break;
     default:
       HARDENED_TRAP();

--- a/sw/device/silicon_creator/lib/drivers/alert.c
+++ b/sw/device/silicon_creator/lib/drivers/alert.c
@@ -334,7 +334,7 @@ rom_error_t alert_config_check(lifecycle_state_t lc_state) {
     case kLcStateTest:
       HARDENED_CHECK_EQ(lc_state, kLcStateTest);
       enum {
-        kMask = kLcStateTest ^ kErrorOk,
+        kMask = (uint32_t)kLcStateTest ^ (uint32_t)kErrorOk,
       };
       res ^= crc32 ^ kMask;
       break;

--- a/sw/device/silicon_creator/lib/epmp_state.h
+++ b/sw/device/silicon_creator/lib/epmp_state.h
@@ -190,7 +190,7 @@ inline void epmp_state_configure_tor(uint32_t entry, epmp_region_t region,
   // Set configuration register.
   bitfield_field32_t field = {.mask = 0xff, .index = (entry % 4) * 8};
   epmp_state.pmpcfg[entry / 4] = bitfield_field32_write(
-      epmp_state.pmpcfg[entry / 4], field, kEpmpModeTor | perm);
+      epmp_state.pmpcfg[entry / 4], field, kEpmpModeTor | (epmp_mode_t)perm);
 }
 
 /**
@@ -210,7 +210,7 @@ inline void epmp_state_configure_na4(uint32_t entry, epmp_region_t region,
   // Set configuration register.
   bitfield_field32_t field = {.mask = 0xff, .index = (entry % 4) * 8};
   epmp_state.pmpcfg[entry / 4] = bitfield_field32_write(
-      epmp_state.pmpcfg[entry / 4], field, kEpmpModeNa4 | perm);
+      epmp_state.pmpcfg[entry / 4], field, kEpmpModeNa4 | (epmp_mode_t)perm);
 }
 
 /**
@@ -231,7 +231,7 @@ inline void epmp_state_configure_napot(uint32_t entry, epmp_region_t region,
   // Set configuration register.
   bitfield_field32_t field = {.mask = 0xff, .index = (entry % 4) * 8};
   epmp_state.pmpcfg[entry / 4] = bitfield_field32_write(
-      epmp_state.pmpcfg[entry / 4], field, kEpmpModeNapot | perm);
+      epmp_state.pmpcfg[entry / 4], field, kEpmpModeNapot | (epmp_mode_t)perm);
 }
 
 /**

--- a/sw/device/silicon_creator/lib/epmp_test_unlock.c
+++ b/sw/device/silicon_creator/lib/epmp_test_unlock.c
@@ -33,7 +33,7 @@ bool epmp_unlock_test_status(void) {
   // Update the hardware registers.
   static_assert(kEntry == 6, "PMP entry has changed, update CSR operations.");
   CSR_WRITE(CSR_REG_PMPADDR6, status_addr / sizeof(uint32_t));
-  CSR_SET_BITS(CSR_REG_PMPCFG1, (kEpmpModeNa4 | kPerm)
+  CSR_SET_BITS(CSR_REG_PMPCFG1, (kEpmpModeNa4 | (uint32_t)kPerm)
                                     << ((kEntry % sizeof(uint32_t)) * 8));
 
   // Double check that the shadow registers match.

--- a/sw/device/silicon_creator/rom/rom_epmp.c
+++ b/sw/device/silicon_creator/rom/rom_epmp.c
@@ -116,7 +116,8 @@ void rom_epmp_unlock_rom_ext_rx(epmp_region_t region) {
   CSR_WRITE(CSR_REG_PMPADDR3, region.start >> 2);
   CSR_WRITE(CSR_REG_PMPADDR4, region.end >> 2);
   CSR_CLEAR_BITS(CSR_REG_PMPCFG1, 0xff);
-  CSR_SET_BITS(CSR_REG_PMPCFG1, kEpmpModeTor | kEpmpPermLockedReadExecute);
+  CSR_SET_BITS(CSR_REG_PMPCFG1,
+               kEpmpModeTor | (uint32_t)kEpmpPermLockedReadExecute);
 }
 
 void rom_epmp_unlock_rom_ext_r(epmp_region_t region) {
@@ -139,7 +140,7 @@ void rom_epmp_unlock_rom_ext_r(epmp_region_t region) {
             region.start >> 2 | (region.end - region.start - 1) >> 3);
   CSR_CLEAR_BITS(CSR_REG_PMPCFG1, 0xff << 16);
   CSR_SET_BITS(CSR_REG_PMPCFG1,
-               ((kEpmpModeNapot | kEpmpPermLockedReadOnly) << 16));
+               ((kEpmpModeNapot | (uint32_t)kEpmpPermLockedReadOnly) << 16));
 }
 
 void rom_epmp_config_debug_rom(lifecycle_state_t lc_state) {
@@ -162,23 +163,26 @@ void rom_epmp_config_debug_rom(lifecycle_state_t lc_state) {
   switch (launder32(lc_state)) {
     case kLcStateTest:
       HARDENED_CHECK_EQ(lc_state, kLcStateTest);
-      pmpcfg = (kEpmpModeNapot | kEpmpPermLockedReadWriteExecute) << 8;
+      pmpcfg = ((uint32_t)kEpmpModeNapot | kEpmpPermLockedReadWriteExecute)
+               << 8;
       break;
     case kLcStateDev:
       HARDENED_CHECK_EQ(lc_state, kLcStateDev);
-      pmpcfg = (kEpmpModeNapot | kEpmpPermLockedReadWriteExecute) << 8;
+      pmpcfg = ((uint32_t)kEpmpModeNapot | kEpmpPermLockedReadWriteExecute)
+               << 8;
       break;
     case kLcStateProd:
       HARDENED_CHECK_EQ(lc_state, kLcStateProd);
-      pmpcfg = (kEpmpModeNapot | kEpmpPermLockedNoAccess) << 8;
+      pmpcfg = ((uint32_t)kEpmpModeNapot | kEpmpPermLockedNoAccess) << 8;
       break;
     case kLcStateProdEnd:
       HARDENED_CHECK_EQ(lc_state, kLcStateProdEnd);
-      pmpcfg = (kEpmpModeNapot | kEpmpPermLockedNoAccess) << 8;
+      pmpcfg = ((uint32_t)kEpmpModeNapot | kEpmpPermLockedNoAccess) << 8;
       break;
     case kLcStateRma:
       HARDENED_CHECK_EQ(lc_state, kLcStateRma);
-      pmpcfg = (kEpmpModeNapot | kEpmpPermLockedReadWriteExecute) << 8;
+      pmpcfg = ((uint32_t)kEpmpModeNapot | kEpmpPermLockedReadWriteExecute)
+               << 8;
       break;
     default:
       HARDENED_TRAP();

--- a/sw/device/tests/sim_dv/data_integrity_escalation_reset_test.c
+++ b/sw/device/tests/sim_dv/data_integrity_escalation_reset_test.c
@@ -243,9 +243,11 @@ void ottf_external_isr(uint32_t *exc_info) {
     CHECK(false, "Unexpected aon timer interrupt %d", irq);
   } else if (peripheral == kTopEarlgreyPlicPeripheralAlertHandler) {
     CHECK(
-        irq_id == kTopEarlgreyPlicIrqIdAlertHandlerClassa + alert_class_to_use,
+        irq_id == (uint32_t)kTopEarlgreyPlicIrqIdAlertHandlerClassa +
+                      alert_class_to_use,
         "Unexpected irq_id, expected %d, got %d",
-        kTopEarlgreyPlicIrqIdAlertHandlerClassa + alert_class_to_use, irq_id);
+        (uint32_t)kTopEarlgreyPlicIrqIdAlertHandlerClassa + alert_class_to_use,
+        irq_id);
 
     // Disable these interrupts from alert_handler so they don't keep happening
     // until NMI.

--- a/sw/device/tests/sram_ctrl_execution_test.c
+++ b/sw/device/tests/sram_ctrl_execution_test.c
@@ -85,7 +85,7 @@ bool test_main(void) {
         "expected PMPCFG1 to be unconfigured before changing it");
 
   CSR_SET_BITS(CSR_REG_PMPCFG1,
-               ((uint32_t)(kEpmpModeNapot | kEpmpPermLockedReadWriteExecute))
+               (((uint32_t)kEpmpModeNapot | kEpmpPermLockedReadWriteExecute))
                    << 24);
 
   // Note: We can test the negative case only using the retention SRAM since


### PR DESCRIPTION
More recent versions of Clang warn when you perform operations with values of different enum types. Fix those warnings by introducing the appropriate casts.