### PR TITLE
[dv] Remove unnecessary empty driver run_phase implementations

### DIFF
--- a/hw/dv/sv/csrng_agent/csrng_device_driver.sv
+++ b/hw/dv/sv/csrng_agent/csrng_device_driver.sv
@@ -9,11 +9,6 @@ class csrng_device_driver extends csrng_driver;
   uint   cmd_ack_dly;
   bit    rsp_sts;
 
-  virtual task run_phase(uvm_phase phase);
-    // base class forks off reset_signals() and get_and_drive() tasks
-    super.run_phase(phase);
-  endtask
-
   virtual task reset_signals();
     cfg.vif.cmd_rsp_int.csrng_rsp_ack <= 1'b0;
     cfg.vif.cmd_rsp_int.csrng_rsp_sts <= CMD_STS_SUCCESS;

--- a/hw/dv/sv/csrng_agent/csrng_host_driver.sv
+++ b/hw/dv/sv/csrng_agent/csrng_host_driver.sv
@@ -9,11 +9,6 @@ class csrng_host_driver extends csrng_driver;
   // Break down the data and send it to push_pull_host_driver through its sequencer
   csrng_sequencer   m_csrng_sequencer;
 
-  virtual task run_phase(uvm_phase phase);
-    // base class forks off reset_signals() and get_and_drive() tasks
-    super.run_phase(phase);
-  endtask
-
   // reset signals
   virtual task reset_signals();
 //    `uvm_fatal(`gtn, "FIXME")

--- a/hw/dv/sv/flash_phy_prim_agent/flash_phy_prim_driver.sv
+++ b/hw/dv/sv/flash_phy_prim_agent/flash_phy_prim_driver.sv
@@ -11,11 +11,6 @@ class flash_phy_prim_driver extends dv_base_driver #(.ITEM_T(flash_phy_prim_item
 
   `uvm_component_new
 
-  virtual task run_phase(uvm_phase phase);
-    // base class forks off reset_signals() and get_and_drive() tasks
-    super.run_phase(phase);
-  endtask
-
   // reset signals
   virtual task reset_signals();
   endtask

--- a/hw/dv/sv/i2c_agent/i2c_driver.sv
+++ b/hw/dv/sv/i2c_agent/i2c_driver.sv
@@ -27,15 +27,10 @@ class i2c_driver extends dv_base_driver #(i2c_item, i2c_agent_cfg);
 
   virtual task run_phase(uvm_phase phase);
     fork
-      reset_signals();
-      get_and_drive();
-      begin
-        if (cfg.if_mode == Host) drive_scl();
-      end
-      begin
-        if (cfg.if_mode == Host) host_scl_pause_ctrl();
-      end
-    join_none
+      super.run_phase(phase);
+      if (cfg.if_mode == Host) drive_scl();
+      if (cfg.if_mode == Host) host_scl_pause_ctrl();
+    join
   endtask
 
   virtual task get_and_drive();

--- a/hw/dv/sv/key_sideload_agent/key_sideload_driver.sv
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_driver.sv
@@ -13,11 +13,6 @@ class key_sideload_driver#(
 
   `uvm_component_new
 
-  virtual task run_phase(uvm_phase phase);
-    // base class forks off reset_signals() and get_and_drive() tasks
-    super.run_phase(phase);
-  endtask
-
   // reset signals
   virtual task reset_signals();
     cfg.vif.sideload_key.valid = 0;

--- a/hw/dv/sv/kmac_app_agent/kmac_app_device_driver.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_device_driver.sv
@@ -7,11 +7,6 @@ class kmac_app_device_driver extends kmac_app_driver;
   `uvm_component_new
 
 
-  virtual task run_phase(uvm_phase phase);
-    // base class forks off reset_signals() and get_and_drive() tasks
-    super.run_phase(phase);
-  endtask
-
   // reset signals
   virtual task reset_signals();
     invalidate_signals();

--- a/hw/dv/sv/kmac_app_agent/kmac_app_host_driver.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_host_driver.sv
@@ -6,12 +6,6 @@ class kmac_app_host_driver extends kmac_app_driver;
   `uvm_component_utils(kmac_app_host_driver)
   `uvm_component_new
 
-
-  virtual task run_phase(uvm_phase phase);
-    // base class forks off reset_signals() and get_and_drive() tasks
-    super.run_phase(phase);
-  endtask
-
   virtual task reset_signals();
   endtask
 

--- a/hw/dv/sv/rng_agent/rng_driver.sv
+++ b/hw/dv/sv/rng_agent/rng_driver.sv
@@ -13,11 +13,6 @@ class rng_driver extends dv_base_driver #(.ITEM_T(rng_item),
 
   `uvm_component_new
 
-  virtual task run_phase(uvm_phase phase);
-    // base class forks off reset_signals() and get_and_drive() tasks
-    super.run_phase(phase);
-  endtask
-
   // reset signals
   virtual task reset_signals();
   endtask

--- a/hw/dv/sv/spi_agent/spi_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_driver.sv
@@ -9,13 +9,6 @@ class spi_driver extends dv_base_driver #(spi_item, spi_agent_cfg);
 
   `uvm_component_new
 
-  virtual task run_phase(uvm_phase phase);
-    fork
-      reset_signals();
-      get_and_drive();
-    join
-  endtask
-
   virtual task reset_signals();
     `uvm_fatal(`gfn, "this is implemented as pure virtual task - please extend")
   endtask

--- a/hw/dv/sv/uart_agent/uart_driver.sv
+++ b/hw/dv/sv/uart_agent/uart_driver.sv
@@ -7,11 +7,6 @@ class uart_driver extends dv_base_driver #(uart_item, uart_agent_cfg);
 
   `uvm_component_new
 
-  task run_phase(uvm_phase phase);
-    reset_signals();
-    get_and_drive();
-  endtask
-
   // Resets signals.
   virtual task reset_signals();
     cfg.vif.reset_uart_rx();

--- a/hw/dv/sv/usb20_agent/usb20_device_driver.sv
+++ b/hw/dv/sv/usb20_agent/usb20_device_driver.sv
@@ -10,11 +10,6 @@ class usb20_device_driver extends usb20_driver;
 
   `uvm_component_new
 
-  virtual task run_phase(uvm_phase phase);
-    // base class forks off reset_signals() and get_and_drive() tasks
-    super.run_phase(phase);
-  endtask
-
   // reset signals
   virtual task reset_signals();
   endtask

--- a/hw/dv/sv/usb20_agent/usb20_driver.sv
+++ b/hw/dv/sv/usb20_agent/usb20_driver.sv
@@ -24,14 +24,6 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
     end
   endfunction
 
-  virtual task run_phase(uvm_phase phase);
-    super.run_phase(phase);
-    reset_signals();
-    forever begin
-      get_and_drive();
-    end
-  endtask
-
   // get_and_drive Task
   // -------------------------------
   virtual task get_and_drive();

--- a/hw/dv/sv/usb20_agent/usb20_host_driver.sv
+++ b/hw/dv/sv/usb20_agent/usb20_host_driver.sv
@@ -10,11 +10,6 @@ class usb20_host_driver extends usb20_driver;
 
   `uvm_component_new
 
-  virtual task run_phase(uvm_phase phase);
-    // base class forks off reset_signals() and get_and_drive() tasks
-    super.run_phase(phase);
-  endtask
-
   // reset signals
   virtual task reset_signals();
   endtask

--- a/util/uvmdvgen/device_driver.sv.tpl
+++ b/util/uvmdvgen/device_driver.sv.tpl
@@ -10,11 +10,6 @@ class ${name}_device_driver extends ${name}_driver;
 
   `uvm_component_new
 
-  virtual task run_phase(uvm_phase phase);
-    // base class forks off reset_signals() and get_and_drive() tasks
-    super.run_phase(phase);
-  endtask
-
   // reset signals
   virtual task reset_signals();
   endtask

--- a/util/uvmdvgen/driver.sv.tpl
+++ b/util/uvmdvgen/driver.sv.tpl
@@ -11,11 +11,6 @@ class ${name}_driver extends dv_base_driver #(.ITEM_T(${name}_item),
 
   `uvm_component_new
 
-  virtual task run_phase(uvm_phase phase);
-    // base class forks off reset_signals() and get_and_drive() tasks
-    super.run_phase(phase);
-  endtask
-
   // reset signals
   virtual task reset_signals();
   endtask

--- a/util/uvmdvgen/host_driver.sv.tpl
+++ b/util/uvmdvgen/host_driver.sv.tpl
@@ -10,11 +10,6 @@ class ${name}_host_driver extends ${name}_driver;
 
   `uvm_component_new
 
-  virtual task run_phase(uvm_phase phase);
-    // base class forks off reset_signals() and get_and_drive() tasks
-    super.run_phase(phase);
-  endtask
-
   // reset signals
   virtual task reset_signals();
   endtask


### PR DESCRIPTION
The fault here is in the template file that contained a trivial implementation (that just called the superclass) and almost never needed overriding.

There are a few drivers where this is changing the implementation slightly:

  - uart_driver
  - usb20_driver

In both cases, I think the author believed that "reset signals" was supposed to be called to reset the signals when a reset (or start of simulation) happened. This isn't correct with the current repository, but the rejig in this commit won't change behaviour at all.