### PR TITLE
[dv,csrng] Get rid of the agent's under_reset flag

### DIFF
--- a/hw/dv/sv/csrng_agent/csrng_agent_cfg.sv
+++ b/hw/dv/sv/csrng_agent/csrng_agent_cfg.sv
@@ -22,7 +22,6 @@ class csrng_agent_cfg extends dv_base_agent_cfg;
                     reseed_cnt, generate_cnt, generate_between_reseeds_cnt;
   bit               cmd_zero_delays;
   bit               cmd_force_ack;
-  bit               under_reset;
   csrng_cmd_sts_e   rsp_sts_err;
 
 endclass

--- a/hw/dv/sv/csrng_agent/csrng_device_driver.sv
+++ b/hw/dv/sv/csrng_agent/csrng_device_driver.sv
@@ -21,7 +21,7 @@ class csrng_device_driver extends csrng_driver;
 
   // drive trans received from sequencer
   virtual task get_and_drive();
-    wait (cfg.under_reset == 0);
+    wait (cfg.in_reset == 0);
     forever begin
       // Wait until the next request is ready or the acknowledgement is forced.
       `DV_SPINWAIT_EXIT(
@@ -54,14 +54,14 @@ class csrng_device_driver extends csrng_driver;
             @(cfg.vif.device_cb);
             cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_ack <= 1'b0;
             cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_sts <= CMD_STS_SUCCESS;,
-            wait (cfg.under_reset == 1);)
+            wait (cfg.in_reset == 1);)
 
-        `uvm_info(`gfn, cfg.under_reset ? "item sent during reset" : "item sent", UVM_HIGH)
+        `uvm_info(`gfn, cfg.in_reset ? "item sent during reset" : "item sent", UVM_HIGH)
         seq_item_port.item_done(rsp);
       end
 
       // Write ack bit again in case the race condition with `reset_signals`.
-      if (cfg.under_reset) cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_ack <= 1'b0;
+      if (cfg.in_reset) cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_ack <= 1'b0;
 
     end
   endtask

--- a/hw/dv/sv/csrng_agent/csrng_monitor.sv
+++ b/hw/dv/sv/csrng_agent/csrng_monitor.sv
@@ -44,18 +44,16 @@ class csrng_monitor extends dv_base_monitor #(
 
   virtual protected task handle_reset();
     forever begin
-      @(negedge cfg.vif.rst_n);
-      cfg.under_reset = 1;
+      wait (cfg.in_reset);
       csrng_cmd_fifo.flush();
       // TODO: sample any reset-related covergroups
-      @(posedge cfg.vif.rst_n);
-      cfg.under_reset = 0;
+      wait (!cfg.in_reset);
     end
   endtask
 
   virtual task collect_valid_trans();
     forever begin
-      wait (cfg.under_reset == 0);
+      wait (cfg.in_reset == 0);
 
       `DV_SPINWAIT_EXIT(
           push_pull_item#(.HostDataWidth(csrng_pkg::CmdBusWidth)) item;
@@ -97,7 +95,7 @@ class csrng_monitor extends dv_base_monitor #(
           ,
 
           // Wait reset
-          wait (cfg.under_reset);)
+          wait (cfg.in_reset);)
      end
   endtask
 
@@ -111,7 +109,7 @@ class csrng_monitor extends dv_base_monitor #(
   virtual protected task collect_request();
     csrng_item   cs_item;
     forever begin
-      wait(cfg.under_reset == 0);
+      wait (cfg.in_reset == 0);
       @(cfg.vif.cmd_push_if.mon_cb);
       if ((cfg.vif.cmd_push_if.mon_cb.valid) && (cfg.vif.cmd_push_if.mon_cb.ready)) begin
         // TODO: sample any covergroups
@@ -137,7 +135,7 @@ class csrng_monitor extends dv_base_monitor #(
               while (!(cfg.vif.cmd_push_if.mon_cb.valid) || !(cfg.vif.cmd_push_if.mon_cb.ready));
               cs_item.cmd_data_q.push_back(cfg.vif.mon_cb.cmd_req.csrng_req_bus);
             end,
-            wait(cfg.under_reset))
+            wait (cfg.in_reset))
 
         `uvm_info(`gfn, $sformatf("Writing req_analysis_port: %s", cs_item.convert2string()),
              UVM_HIGH)
@@ -145,10 +143,10 @@ class csrng_monitor extends dv_base_monitor #(
         // After picking up a request, wait until a response is sent before
         // detecting another request, as this is not a pipelined protocol.
         `DV_SPINWAIT_EXIT(while (!cfg.vif.mon_cb.cmd_rsp.csrng_rsp_ack) @(cfg.vif.mon_cb);,
-                          wait(cfg.under_reset))
+                          wait (cfg.in_reset))
 
         // Increment the counters only if ack is sent.
-        if (!cfg.under_reset) begin
+        if (!cfg.in_reset) begin
           if (cs_item.acmd == csrng_pkg::RES) cfg.reseed_cnt += 1;
           if (cs_item.acmd == csrng_pkg::GEN) begin
             cfg.generate_cnt += 1;

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
@@ -75,7 +75,7 @@ class csrng_base_vseq extends cip_base_vseq #(
   endtask
 
   function automatic bit edn_under_reset();
-    return cfg.m_edn_agent_cfg[0].under_reset;
+    return cfg.m_edn_agent_cfg[0].in_reset;
   endfunction
 
   // Wait for a CSR to contain an expected value or EDN to be reset, whichever happens first.  This


### PR DESCRIPTION
This is a duplicate of dv_base_agent_cfg::in_reset. Use that instead.