### PR TITLE
[dv,alert] Get rid of two under_reset flags

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
@@ -65,8 +65,6 @@ class alert_esc_agent_cfg extends dv_base_agent_cfg;
   int unsigned handshake_timeout_cycle = 100_000;
   int unsigned ping_timeout_cycle = 32;
 
-  bit under_reset;
-
   // Incremented by the monitor on each ping
   int unsigned ping_count = 0;
   // Needed for alert checks starting after a ping

--- a/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
@@ -92,7 +92,7 @@ endtask : drive_req
 // and the handshake would look the same either way.
 task alert_receiver_driver::ping_and_alert_thread();
   forever begin
-    wait( ((r_alert_ping_send_q.size() > 0) || (r_alert_rsp_q.size() > 0)) && !under_reset);
+    wait (((r_alert_ping_send_q.size() > 0) || (r_alert_rsp_q.size() > 0)) && !cfg.in_reset);
     `uvm_info(`gfn, $sformatf({"%m - Queues: r_alert_ping_send_q.size=%0d | ",
                                "r_alert_rsp_q.size()=%0d"}, r_alert_ping_send_q.size,
                                r_alert_rsp_q.size()), UVM_DEBUG)
@@ -112,7 +112,6 @@ task alert_receiver_driver::reset_signals();
   do_reset();
   forever begin
     @(negedge cfg.vif.rst_n);
-    under_reset = 1;
     clear_item_queues();
     working_on_alert = 0;
     do_reset();
@@ -149,7 +148,7 @@ task alert_receiver_driver::send_ping(alert_esc_seq_item req);
             end
             drive_alert_ping(req.ping_delay, req.ack_delay, req.ack_stable, item_not_driven);
           end
-          wait(under_reset);
+          wait (cfg.in_reset);
         join_any
         disable fork;
       end
@@ -186,7 +185,7 @@ task alert_receiver_driver::rsp_alert(alert_esc_seq_item req);
   fork
     begin : isolation_fork_1
       fork
-        wait(under_reset);
+        wait (cfg.in_reset);
         fork
           // Wait for num_iter cycles on the slower of the two clocks (by
           // waiting for both of them in parallel).
@@ -211,7 +210,7 @@ task alert_receiver_driver::rsp_alert(alert_esc_seq_item req);
     end  : isolation_fork_1
   join
 
-  if (!under_reset) begin
+  if (!cfg.in_reset) begin
     // If we haven't gone into reset, we have an item and have waited a bit for the alert to be
     // visible. Check that it really has arrived.
     working_on_alert = 1;
@@ -226,24 +225,24 @@ task alert_receiver_driver::rsp_alert(alert_esc_seq_item req);
       begin : isolation_fork_2
         fork
           set_ack_pins(req.ack_delay, req.ack_stable);
-          wait(under_reset);
+          wait (cfg.in_reset);
         join_any
         disable fork;
       end : isolation_fork_2
     join
-  end // if (!under_reset)
+  end // if (!cfg.in_reset)
 
 
   `uvm_info(`gfn,
             $sformatf("%0s rsp_alert item (ping_send=%0b, alert_rsp=%0b, int_fail=%0b)",
-                      under_reset ? "aborting" : "finished",
+                      cfg.in_reset ? "aborting" : "finished",
                       req.r_alert_ping_send, req.r_alert_rsp, req.int_err),
             UVM_DEBUG)
 
   fork
     begin : isolation_fork_3
       fork
-        wait (under_reset);
+        wait (cfg.in_reset);
         repeat (10) begin
           if (cfg.vif.receiver_cb.alert_tx.alert_p) begin
             unset_working_on_alerts = 1;
@@ -287,7 +286,7 @@ task alert_receiver_driver::drive_alert_ping(int unsigned ping_delay,
       fork
         repeat (ping_delay) @(cfg.vif.receiver_cb);
         begin
-          wait(cfg.vif.receiver_cb.alert_tx.alert_p);
+          wait (cfg.vif.receiver_cb.alert_tx.alert_p);
           item_not_driven = 1;
         end
       join_any
@@ -440,7 +439,6 @@ task alert_receiver_driver::do_alert_rx_init();
       wait (cfg.vif.receiver_cb.alert_tx.alert_p == cfg.vif.receiver_cb.alert_tx.alert_n);
       repeat ($urandom_range(1, 10)) @(cfg.vif.receiver_cb);
       cfg.vif.alert_rx_int.ack_n  <= 1'b1;
-      wait (cfg.vif.receiver_cb.alert_tx.alert_p != cfg.vif.receiver_cb.alert_tx.alert_n);
-      under_reset = 0;,
-      @(negedge cfg.vif.rst_n);)
+      wait (cfg.vif.receiver_cb.alert_tx.alert_p != cfg.vif.receiver_cb.alert_tx.alert_n);,
+      wait (cfg.in_reset);)
 endtask

--- a/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
@@ -91,14 +91,11 @@ function alert_sender_driver::new (string name, uvm_component parent);
 endfunction : new
 
 task alert_sender_driver::reset_signals();
-  under_reset = 1;
   set_alert(1'b0);
   forever begin
-    wait(!cfg.vif.rst_n);
-    under_reset = 1;
+    wait(!cfg.in_reset);
+    wait(cfg.in_reset);
     set_alert(1'b0);
-    wait(cfg.vif.rst_n);
-    under_reset = 0;
   end
 endtask
 
@@ -106,11 +103,11 @@ task alert_sender_driver::drive_req();
   forever begin
     // Wait until we are out of reset. Until that happens, respond instantly to any sequence items
     // that come in.
-    while (under_reset) begin
+    while (cfg.in_reset) begin
       fork : isolation_fork begin
         alert_esc_seq_item item;
         fork
-          wait (!under_reset);
+          wait (!cfg.in_reset);
           begin
             wait(s_alert_send_q.size());
             item = s_alert_send_q.pop_front();
@@ -130,7 +127,7 @@ task alert_sender_driver::drive_req();
       end join
     end
 
-    while(!under_reset) begin
+    while(!cfg.in_reset) begin
       bit en_alert_lpg = cfg.en_alert_lpg;
 
       // If LPG is not enabled, initialise the alert interface
@@ -154,7 +151,7 @@ task alert_sender_driver::drive_reqs_with_lpg_mode(bit en_alert_lpg);
     fork : isolation_fork begin
       fork
         wait (cfg.en_alert_lpg != en_alert_lpg);
-        wait (under_reset);
+        wait (cfg.in_reset);
         begin
           wait(s_alert_send_q.size());
           item = s_alert_send_q.pop_front();
@@ -190,7 +187,7 @@ task alert_sender_driver::send_item(bit is_ping_rsp, alert_esc_seq_item item);
                       item.s_alert_send, item.s_alert_ping_rsp, item.int_err), UVM_HIGH)
   fork : isolation_fork begin
     fork
-      wait (under_reset);
+      wait (cfg.in_reset);
       if (!is_ping_rsp || !cfg.ping_timeout) begin
         drive_alert_pins(item);
       end else begin
@@ -277,7 +274,7 @@ endtask
 task alert_sender_driver::do_alert_tx_init();
   fork : isolation_fork begin
     fork
-      wait (under_reset || cfg.en_alert_lpg);
+      wait (cfg.in_reset || cfg.en_alert_lpg);
       begin
         wait (cfg.vif.alert_rx.ack_p == cfg.vif.alert_rx.ack_n);
         drive_invalid_alert(1'b0);

--- a/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
@@ -10,39 +10,80 @@ class alert_sender_driver extends alert_base_driver;
 
   `uvm_component_utils(alert_sender_driver)
 
-  // To guard alert ping response and real alert triggers won't trigger at the same time
-  local semaphore alert_atomic = new(1);
-
   extern function new (string name, uvm_component parent);
-  extern virtual task reset_signals();
-  // alert_sender drive responses by sending the alert_p and alert_n
-  // one alert sent by sequence driving the alert_send signal
-  // another alert sent by responding to the ping signal
-  extern virtual task drive_req();
-  // Two conditions can trigger alert init:
-  // 1). Reset deassert;   2). LPG disabled.
-  extern virtual task alert_init_thread();
-  extern virtual task send_alert();
-  extern virtual task rsp_ping();
-  extern virtual task drive_alert_pins(alert_esc_seq_item req);
-  // this task set alert_p=1 and alert_n=0 after certain delay
-  extern virtual task set_alert_pins(int alert_delay);
-  // this task reset alert_p=0 and alert_n=1 after certain delay when:
-  // ack handshake is finished or when timeout
-  extern virtual task reset_alert_pins(int ack_delay);
-  extern virtual task random_drive_int_fail(int int_err_cyc);
-  extern virtual task set_alert();
-  extern virtual task reset_alert();
-  extern virtual task drive_alerts_high();
-  extern virtual task drive_alerts_low();
-  extern virtual task wait_sender_clk();
-  extern virtual task do_reset();
-  // This task handles alert init request.
-  //
-  // After alert_receiver is reset, it will send a signal integrity fail via `ping_n` and `ack_n`,
-  // alert_sender acknowledged the init via sending an `alert_n` integrity fail.
-  extern virtual task do_alert_tx_init();
 
+  // Monitor resets and reset all driven signals when a reset occurs.
+  //
+  // An implementation of dv_base_driver::reset_signals.
+  extern virtual task reset_signals();
+
+  // Drive sequence items for alerts and pings that have been retrieved by get_req (and therefore
+  // have started) and have been pushed to the various queues. This also does the alert init
+  // handshake (with no sequence item) after each reset.
+  //
+  // An implementation of alert_esc_base_driver::drive_req
+  extern virtual task drive_req();
+
+  // Drive sequence items for alerts and pings until either a reset or a change of cfg.en_alert_lpg
+  extern local task drive_reqs_with_lpg_mode(bit en_alert_lpg);
+
+  // Drive a single sequence item to send an alert, possibly responding to a ping. Once the item has
+  // been driven, mark it done in seq_item_port.
+  //
+  // This exits immediately on a reset.
+  extern local task send_item(bit is_ping_rsp, alert_esc_seq_item item);
+
+  // Drive the alert_p/alert_n pins for the sequence item. There may be a delay before asserting the
+  // alert or before de-asserting it (once an ack has been seen).
+  //
+  // This is safe to kill.
+  extern local task drive_alert_pins(alert_esc_seq_item req);
+
+  // Assert an alert (alert_p=1; alert_n=0) after alert_delay cycles.
+  //
+  // This is safe to kill.
+  extern local task set_alert_pins(int alert_delay);
+
+  // Wait for an ack from the receiver, then de-assert the alert (alert_p=0; alert_n=1) after an
+  // extra ack_delay cycles. Finally, wait for the receiver to de-assert ack.
+  //
+  // The handshake above has a timeout, and the task will exit if it is reached. If cfg.en_alert_lpg
+  // becomes false, this means that the receiver will no longer respond. We regard that as an
+  // immediate timeout.
+  //
+  // This is safe to kill.
+  extern local task reset_alert_pins(int ack_delay);
+
+  // Send invalid alert pin values (either 11 or 00) for int_err_cyc cycles
+  //
+  // This is safe to kill.
+  extern local task random_drive_int_fail(int int_err_cyc);
+
+  // Set the alert pins to be (alert_p=1; alert_n=0) if enabled=1 and (alert_p=0; alert_n=1)
+  // otherwise.
+  //
+  // This task takes zero time (but needs to be a task because it uses non-blocking assignment)
+  extern local task set_alert(bit enabled);
+
+  // Set the alert pins to 11 or 00 (depending on the high argument).
+  //
+  // This task takes zero time (but needs to be a task because it uses non-blocking assignment)
+  extern local task drive_invalid_alert(bit high);
+
+  // Wait for count cycles of the sender clock
+  //
+  // This is safe to kill.
+  extern local task wait_sender_clk(int unsigned count);
+
+  // Handle an alert init request.
+  //
+  // After alert_receiver is reset, it will send a signal integrity fail with a non-differential ack
+  // signal. The alert sender has to acknowledge the init by setting the alert pins to 00 until ack
+  // becomes differential again.
+  //
+  // This task exits early on reset or if cfg.en_alert_lpg is asserted (in which case, the receiver
+  // won't reply to the init)
+  extern local task do_alert_tx_init();
 endclass : alert_sender_driver
 
 function alert_sender_driver::new (string name, uvm_component parent);
@@ -51,96 +92,120 @@ endfunction : new
 
 task alert_sender_driver::reset_signals();
   under_reset = 1;
-  do_reset();
+  set_alert(1'b0);
   forever begin
-    @(negedge cfg.vif.rst_n);
+    wait(!cfg.vif.rst_n);
     under_reset = 1;
-    do_reset();
-    @(posedge cfg.vif.rst_n);
-    alert_atomic = new(1);
+    set_alert(1'b0);
+    wait(cfg.vif.rst_n);
+    under_reset = 0;
   end
 endtask
 
 task alert_sender_driver::drive_req();
-  fork
-    send_alert();
-    rsp_ping();
-    alert_init_thread();
-  join_none
-endtask : drive_req
-
-task alert_sender_driver::alert_init_thread();
-  do_alert_tx_init();
-  fork
-    forever @(posedge cfg.vif.rst_n) begin
-      do_alert_tx_init();
-    end
-    forever @(negedge cfg.en_alert_lpg) begin
-      do_alert_tx_init();
-    end
-  join_none
-endtask : alert_init_thread
-
-task alert_sender_driver::send_alert();
   forever begin
-    alert_esc_seq_item req, rsp;
-    wait (s_alert_send_q.size() > 0 && !under_reset);
-    req = s_alert_send_q.pop_front();
-    `downcast(rsp, req.clone());
-    rsp.set_id_info(req);
-    `uvm_info(`gfn,
-              $sformatf("starting to send sender item, alert_send=%0b, ping_rsp=%0b, int_err=%0b",
-                        req.s_alert_send, req.s_alert_ping_rsp, req.int_err), UVM_HIGH)
-    fork
-      begin : isolation_fork
+    // Wait until we are out of reset. Until that happens, respond instantly to any sequence items
+    // that come in.
+    while (under_reset) begin
+      fork : isolation_fork begin
+        alert_esc_seq_item item;
         fork
+          wait (!under_reset);
           begin
-            alert_atomic.get(1);
-            drive_alert_pins(req);
-            alert_atomic.put(1);
+            wait(s_alert_send_q.size());
+            item = s_alert_send_q.pop_front();
           end
           begin
-            wait (under_reset);
+            wait(s_alert_ping_rsp_q.size());
+            item = s_alert_ping_rsp_q.pop_front();
           end
         join_any
         disable fork;
+        if (item != null) begin
+          alert_esc_seq_item rsp;
+          `downcast(rsp, item.clone());
+          rsp.set_id_info(item);
+          seq_item_port.put_response(rsp);
+        end
+      end join
+    end
+
+    while(!under_reset) begin
+      bit en_alert_lpg = cfg.en_alert_lpg;
+
+      // If LPG is not enabled, initialise the alert interface
+      if (!en_alert_lpg) begin
+        do_alert_tx_init();
       end
-    join
 
-    `uvm_info(`gfn,
-              $sformatf("finished sending sender item, alert_send=%0b, ping_rsp=%0b, int_err=%0b",
-                        req.s_alert_send, req.s_alert_ping_rsp, req.int_err), UVM_HIGH)
-    seq_item_port.put_response(rsp);
-  end // end forever
-endtask : send_alert
-
-task alert_sender_driver::rsp_ping();
-  forever begin
-    alert_esc_seq_item req, rsp;
-    wait (s_alert_ping_rsp_q.size() > 0 && !under_reset && !cfg.en_alert_lpg);
-    req = s_alert_ping_rsp_q.pop_front();
-    `downcast(rsp, req.clone());
-    rsp.set_id_info(req);
-    `uvm_info(`gfn,
-              $sformatf("starting to send sender item, alert_send=%0b, ping_rsp=%0b, int_err=%0b",
-                        req.s_alert_send, req.s_alert_ping_rsp, req.int_err), UVM_HIGH)
-
-    `DV_SPINWAIT_EXIT(
-                      alert_atomic.get(1);
-                      if (!cfg.ping_timeout) begin
-                      drive_alert_pins(req);
-                      end else begin
-                      repeat (cfg.ping_timeout_cycle) wait_sender_clk();
-                      end
-                      alert_atomic.put(1);,
-                      wait (under_reset || cfg.en_alert_lpg);)
-
-    `uvm_info(`gfn,
-              $sformatf("finished sending sender item, alert_send=%0b, ping_rsp=%0b, int_err=%0b",
-                        req.s_alert_send, req.s_alert_ping_rsp, req.int_err), UVM_HIGH)
-    seq_item_port.put_response(rsp);
+      // Drive any requests that we see. The task will exit on reset or if the LPG flag changes,
+      // letting us initialise the alert interface (if LPG is disabled) and continue.
+      drive_reqs_with_lpg_mode(en_alert_lpg);
+    end
   end
-endtask : rsp_ping
+endtask
+
+task alert_sender_driver::drive_reqs_with_lpg_mode(bit en_alert_lpg);
+  forever begin
+    alert_esc_seq_item item;
+    bit is_alert, is_ping;
+
+    // Pick an item to drive, but keep track of resets and any change to the LPG flag.
+    fork : isolation_fork begin
+      fork
+        wait (cfg.en_alert_lpg != en_alert_lpg);
+        wait (under_reset);
+        begin
+          wait(s_alert_send_q.size());
+          item = s_alert_send_q.pop_front();
+          is_alert = 1;
+        end
+        begin
+          wait(s_alert_ping_rsp_q.size());
+          item = s_alert_ping_rsp_q.pop_front();
+          is_ping = 1;
+        end
+      join_any
+      disable fork;
+    end join
+
+    // Handle the alert or ping response. If there is no item, there has been a reset or the LPG
+    // flag has changed. Return from the task.
+    //
+    // The send_alert and send_ping_rsp tasks both exit early when they see a reset, but ignore any
+    // further changes to en_alert_lpg.
+    if (is_alert) send_item(1'b0, item);
+    else if (is_ping) send_item(1'b1, item);
+    else return;
+  end
+endtask
+
+task alert_sender_driver::send_item(bit is_ping_rsp, alert_esc_seq_item item);
+  alert_esc_seq_item rsp;
+  `downcast(rsp, item.clone());
+  rsp.set_id_info(item);
+
+  `uvm_info(`gfn,
+            $sformatf("starting to send sender item, alert_send=%0b, ping_rsp=%0b, int_err=%0b",
+                      item.s_alert_send, item.s_alert_ping_rsp, item.int_err), UVM_HIGH)
+  fork : isolation_fork begin
+    fork
+      wait (under_reset);
+      if (!is_ping_rsp || !cfg.ping_timeout) begin
+        drive_alert_pins(item);
+      end else begin
+        wait_sender_clk(cfg.ping_timeout_cycle);
+      end
+    join_any
+    disable fork;
+  end join
+
+  `uvm_info(`gfn,
+            $sformatf("finished sending sender item, alert_send=%0b, ping_rsp=%0b, int_err=%0b",
+                      item.s_alert_send, item.s_alert_ping_rsp, item.int_err), UVM_HIGH)
+
+  seq_item_port.put_response(rsp);
+endtask
 
 task alert_sender_driver::drive_alert_pins(alert_esc_seq_item req);
   int unsigned alert_delay, ack_delay;
@@ -152,116 +217,74 @@ task alert_sender_driver::drive_alert_pins(alert_esc_seq_item req);
   if (!req.int_err) begin
     set_alert_pins(alert_delay);
     reset_alert_pins(ack_delay);
-
-    // alert signals integrity fail
   end else begin
+    // Because req.int_err is true, cause the alert signal integrity check to fail.
     if (req.alert_int_err_type & HasAlertBeforeIntFailOnly) set_alert_pins(alert_delay);
     random_drive_int_fail(req.int_err_cyc);
     if (req.alert_int_err_type & HasAlertAfterIntFailOnly) begin
       set_alert_pins(alert_delay);
     end else begin
-      reset_alert();
+      set_alert(1'b0);
     end
   end
 
-  // there must have at least two sender clock delays before next alert_handshake
-  repeat(2) wait_sender_clk();
-endtask : drive_alert_pins
+  // There must be at least two sender clock delays before next alert_handshake
+  wait_sender_clk(2);
+endtask
 
 task alert_sender_driver::set_alert_pins(int alert_delay);
-  repeat (alert_delay + 1) begin
-    if (under_reset) return;
-    else wait_sender_clk();
-  end
-  set_alert();
-endtask : set_alert_pins
+  wait_sender_clk(alert_delay + 1);
+  set_alert(1'b1);
+endtask
 
 task alert_sender_driver::reset_alert_pins(int ack_delay);
-  fork
-    begin : isolation_fork
-      fork
-        begin : alert_timeout
-          repeat (cfg.handshake_timeout_cycle) begin
-            wait_sender_clk();
-            // If alert_lpg is enabled, alert rx request is ignored by the alert_receiver.
-            if (cfg.en_alert_lpg) break;
-          end
-        end
-        begin : wait_alert_handshake
-          wait (cfg.vif.alert_rx.ack_p == 1'b1);
-          wait_sender_clk();
-          repeat (ack_delay) wait_sender_clk();
-          reset_alert();
-          wait (cfg.vif.alert_rx.ack_p == 1'b0);
-        end
-      join_any
-      disable fork;
-    end
-  join
-endtask : reset_alert_pins
-
-task alert_sender_driver::random_drive_int_fail(int int_err_cyc);
-  repeat (req.int_err_cyc) begin
-    wait_sender_clk();
-    if (under_reset) break;
-    randcase
-      1: drive_alerts_low();
-      1: drive_alerts_high();
-    endcase
-  end
-endtask : random_drive_int_fail
-
-
-task alert_sender_driver::set_alert();
-  cfg.vif.sender_cb.alert_tx_int.alert_p <= 1'b1;
-  cfg.vif.sender_cb.alert_tx_int.alert_n <= 1'b0;
-endtask : set_alert
-
-task alert_sender_driver::reset_alert();
-  cfg.vif.sender_cb.alert_tx_int.alert_p <= 1'b0;
-  cfg.vif.sender_cb.alert_tx_int.alert_n <= 1'b1;
-endtask : reset_alert
-
-task alert_sender_driver::drive_alerts_high();
-  cfg.vif.sender_cb.alert_tx_int.alert_p <= 1'b1;
-  cfg.vif.sender_cb.alert_tx_int.alert_n <= 1'b1;
-endtask : drive_alerts_high
-
-task alert_sender_driver::drive_alerts_low();
-  cfg.vif.sender_cb.alert_tx_int.alert_p <= 1'b0;
-  cfg.vif.sender_cb.alert_tx_int.alert_n <= 1'b0;
-endtask : drive_alerts_low
-
-task alert_sender_driver::wait_sender_clk();
-  @(cfg.vif.sender_cb);
-endtask : wait_sender_clk
-
-task alert_sender_driver::do_reset();
-  cfg.vif.alert_tx_int.alert_p <= 1'b0;
-  cfg.vif.alert_tx_int.alert_n <= 1'b1;
-endtask : do_reset
-
-task alert_sender_driver::do_alert_tx_init();
-  fork begin
+  fork : isolation_fork begin
     fork
-      begin
-        wait (cfg.vif.alert_rx.ack_p == cfg.vif.alert_rx.ack_n);
-        cfg.vif.alert_tx_int.alert_n <= 1'b0;
-        wait (cfg.vif.alert_rx.ack_p != cfg.vif.alert_rx.ack_n);
-        cfg.vif.alert_tx_int.alert_n <= 1'b1;
-        under_reset = 0;
-      end
-      begin
-        @(negedge cfg.vif.rst_n);
-      end
-      begin
-        // Clear `under_reset` when en_alert_lpg is on, because alert_sender can still send
-        // alerts, and alert_handler should ignore the alert_tx request.
-        wait (cfg.en_alert_lpg == 1);
-        under_reset = 0;
+      wait (cfg.en_alert_lpg);
+      wait_sender_clk(cfg.handshake_timeout_cycle);
+      begin : wait_alert_handshake
+        wait (cfg.vif.alert_rx.ack_p == 1'b1);
+        wait_sender_clk(1 + ack_delay);
+        set_alert(1'b0);
+        wait (cfg.vif.alert_rx.ack_p == 1'b0);
       end
     join_any
     disable fork;
+  end join
+endtask
+
+task alert_sender_driver::random_drive_int_fail(int int_err_cyc);
+  repeat (int_err_cyc) begin
+    wait_sender_clk(1);
+    drive_invalid_alert($urandom & 1);
   end
-  join
-endtask : do_alert_tx_init
+endtask
+
+task alert_sender_driver::set_alert(bit enabled);
+  cfg.vif.sender_cb.alert_tx_int.alert_p <= enabled;
+  cfg.vif.sender_cb.alert_tx_int.alert_n <= !enabled;
+endtask
+
+task alert_sender_driver::drive_invalid_alert(bit high);
+  cfg.vif.sender_cb.alert_tx_int.alert_p <= high;
+  cfg.vif.sender_cb.alert_tx_int.alert_n <= high;
+endtask
+
+task alert_sender_driver::wait_sender_clk(int unsigned count);
+  repeat (count) @(cfg.vif.sender_cb);
+endtask
+
+task alert_sender_driver::do_alert_tx_init();
+  fork : isolation_fork begin
+    fork
+      wait (under_reset || cfg.en_alert_lpg);
+      begin
+        wait (cfg.vif.alert_rx.ack_p == cfg.vif.alert_rx.ack_n);
+        drive_invalid_alert(1'b0);
+        wait (cfg.vif.alert_rx.ack_p != cfg.vif.alert_rx.ack_n);
+        set_alert(1'b0);
+      end
+    join_any
+    disable fork;
+  end join
+endtask

--- a/hw/dv/sv/alert_esc_agent/esc_receiver_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_receiver_driver.sv
@@ -15,7 +15,7 @@ class esc_receiver_driver extends dv_base_driver#(alert_esc_seq_item, alert_esc_
 
   extern function new (string name, uvm_component parent);
 
-  // This task runs forever and maintains dv_base_driver::under_reset.
+  // This task runs forever calls do_reset at the start of every reset.
   //
   // Overridden from dv_base_driver.
   extern virtual task reset_signals();
@@ -67,11 +67,9 @@ endfunction : new
 task esc_receiver_driver::reset_signals();
   do_reset();
   forever begin
-    @(negedge cfg.vif.rst_n);
-    under_reset = 1;
+    wait (cfg.in_reset);
     do_reset();
-    @(posedge cfg.vif.rst_n);
-    under_reset = 0;
+    wait (!cfg.in_reset);
   end
 endtask : reset_signals
 
@@ -84,10 +82,10 @@ endtask : get_and_drive
 
 task esc_receiver_driver::esc_ping_detector();
   forever begin
-    wait(!under_reset);
+    wait (!cfg.in_reset);
     fork begin : isolation_fork
       fork
-        wait(under_reset);
+        wait (cfg.in_reset);
         begin
           int cnt;
 
@@ -126,7 +124,7 @@ task esc_receiver_driver::rsp_escalator();
       begin : non_blocking_fork
         fork
           drive_esc_resp(req);
-          wait(under_reset);
+          wait (cfg.in_reset);
         join_any
         disable fork;
         `uvm_info(`gfn, $sformatf("finished sending receiver item esc_rsp=%0b int_fail=%0b",

--- a/hw/dv/sv/alert_esc_agent/esc_sender_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_sender_driver.sv
@@ -21,12 +21,9 @@ endfunction : new
 task esc_sender_driver::reset_signals();
   wait(cfg.vif.rst_n !== 1'b1);
   forever begin
-    under_reset = 1;
     reset_esc();
-    wait(cfg.vif.rst_n === 1'b1);
-    under_reset = 0;
-
-    wait(cfg.vif.rst_n !== 1'b1);
+    wait (!cfg.in_reset);
+    wait (cfg.in_reset);
   end
 endtask : reset_signals
 
@@ -34,7 +31,7 @@ task esc_sender_driver::get_and_drive();
   // LC_CTRL uses virtual interface to directly drive escalation requests.
   // Other escalation handshakes are checked in prim_esc direct sequence.
   // So the following task is not implemented.
-  wait(!under_reset);
+  wait (!cfg.in_reset);
 endtask : get_and_drive
 
 task esc_sender_driver::reset_esc();


### PR DESCRIPTION
This was all rather confusing! There were the following signals:

- `alert_esc_agent_cfg::under_reset`
- `alert_esc_base_monitor::under_reset`
- `dv_base_driver::under_reset`

And the alert and escalation side of things maintained them differently(!): on the escalation side, `under_reset` meant "under
reset". On the alert side, it meant "has not been initialised since reset", which is the same as `! alert_esc_agent_cfg::alert_init_done`.

This commit gets rid of all three flags, relying on `dv_base_agent_cfg::in_reset` instead (which gets maintained properly by
the monitors).

Note that it's a little odd to ignore `dv_base_driver::under_reset`. It won't matter with this commit (because `dv_base_driver` doesn't use that flag directly and nothing subclasses the alert/escalation drivers), but things are still a little strange. A following commit will get rid of that flag entirely, but the alert agent was tricky, so I've done it separately.
