### PR TITLE
[dv,uart] Get rid of uart_agent_cfg::under_reset

### DIFF
--- a/hw/dv/sv/uart_agent/uart_driver.sv
+++ b/hw/dv/sv/uart_agent/uart_driver.sv
@@ -21,7 +21,7 @@ class uart_driver extends dv_base_driver #(uart_item, uart_agent_cfg);
   task set_rx(input bit val);
     uint glitch_ns = uint'(cfg.vif.uart_clk_period * cfg.get_uart_period_glitch_pct() / 100 / 1ns);
     repeat (glitch_ns) begin
-      if (!cfg.under_reset) begin
+      if (!cfg.in_reset) begin
         cfg.vif.uart_rx <= $urandom_range(0, 1);
         #1ns;
       end
@@ -36,7 +36,7 @@ class uart_driver extends dv_base_driver #(uart_item, uart_agent_cfg);
       seq_item_port.get(req);
       $cast(rsp, req.clone());
       rsp.set_id_info(req);
-      if (!cfg.under_reset) begin
+      if (!cfg.in_reset) begin
         `uvm_info(`gfn, $sformatf("starting to send rx item: %0s", rsp.sprint()), UVM_HIGH)
         // we send parity if enabled or if overridden in the req
         if (cfg.en_parity ^ req.ovrd_en_parity) begin
@@ -54,7 +54,7 @@ class uart_driver extends dv_base_driver #(uart_item, uart_agent_cfg);
         end
         `uvm_info(`gfn, $sformatf("finished sending rx item: %0s", rsp.sprint()), UVM_HIGH)
       end
-      if (cfg.under_reset) begin // under_reset
+      if (cfg.in_reset) begin
         `uvm_info(`gfn, $sformatf("Reset happens and drop rx item: %0s", rsp.sprint()), UVM_HIGH)
       end
       seq_item_port.put_response(rsp);
@@ -66,7 +66,7 @@ class uart_driver extends dv_base_driver #(uart_item, uart_agent_cfg);
       begin : isolation_fork
         fork
           begin
-            wait(cfg.under_reset);
+            wait(cfg.in_reset);
           end
           begin
             @(cfg.vif.drv_rx_mp.drv_rx_cb);

--- a/hw/dv/sv/uart_agent/uart_logger.sv
+++ b/hw/dv/sv/uart_agent/uart_logger.sv
@@ -56,8 +56,8 @@ class uart_logger extends uvm_component;
       end
       forever begin
         // reset thread - if reset occurs, reset the log to an empty string.
-        @(cfg.under_reset);
-        if (cfg.under_reset) log = "";
+        @(cfg.in_reset);
+        if (cfg.in_reset) log = "";
       end
     join
   endtask

--- a/hw/dv/sv/uart_agent/uart_monitor.sv
+++ b/hw/dv/sv/uart_agent/uart_monitor.sv
@@ -30,11 +30,11 @@ class uart_monitor extends dv_base_monitor#(
         drive_tx_clk();
         drive_rx_clk();
         mon_tx_stable();
-        wait(cfg.under_reset);
+        wait(cfg.in_reset);
       join_any
       disable fork;
 
-      if (cfg.under_reset) process_reset();
+      if (cfg.in_reset) process_reset();
     end
   endtask
 
@@ -205,7 +205,7 @@ class uart_monitor extends dv_base_monitor#(
     cfg.vif.uart_tx_clk        = 1;
     cfg.vif.uart_rx_clk_pulses = 0;
     cfg.vif.uart_rx_clk        = 1;
-    wait(!cfg.under_reset);
+    wait(!cfg.in_reset);
   endtask
 
 endclass


### PR DESCRIPTION
This was avoiding using the dv_base_agent_cfg::in_reset signal because there isn't actually a "rst_n" pin on the interface. But the logic that maintained the bit basically did the same thing, so let's re-use the signal, allowing everything to be more uniform.