### PR TITLE
Manual backport to master: [crypto] Remove `busy_spin` in keymgr

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -80,7 +80,6 @@ cc_library(
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/crypto/impl:status",
-        "//sw/device/lib/runtime:hart",
     ],
 )
 

--- a/sw/device/lib/crypto/drivers/keymgr.c
+++ b/sw/device/lib/crypto/drivers/keymgr.c
@@ -11,7 +11,6 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/status.h"
-#include "sw/device/lib/runtime/hart.h"
 
 #include "hw/top/keymgr_regs.h"
 
@@ -276,11 +275,6 @@ static status_t keymgr_sideload_clear(uint32_t slot) {
       slot) {
     return OTCRYPTO_FATAL_ERR;
   }
-
-  // Spin for 100 microseconds.
-  // TODO: this value seems to work for tests, but it would be good to run a
-  // more principled analysis.
-  busy_spin_micros(100);
 
   // Stop continuous clearing.
   abs_mmio_write32(


### PR DESCRIPTION
As `busy_spin` reads the `mcycle` register, which is only accessible in machine mode, cryptolib using the keymanager could not be run in user mode.

This commit removes the `busy_spin` as it is actually not needed. The flow is as following:
- SW writes the `SIDELOAD_CLEAR.VAL` register
- This register is forwarded to the `keymgr_sideload_key_ctrl` and `keymgr_sideload_key` module.
- In the first module, the signal is used to set `prng_en_o`, which triggers the LFSR instantiated in the `keymgr` module.
- This LFSR generates random data that is used by the `keymgr_sideload_key` module to overwrite they key to clear with the random data.

Hence, writing for two cycles to the `SIDELOAD_CLEAR.VAL` register is enough. As the keymgr cryptolib driver anyways reads back the `SIDELOAD_CLEAR.VAL` register after asserting and before clearing it again, we have already more than enough cycles in between.


(cherry picked from commit b95e722c08cd786a3394e4638c488efebe130e54)