### PR TITLE
Backport 28125 ([test,keymgr] Always initialize keymgr in keymgr_derive_cdi test)

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2380,6 +2380,11 @@ opentitan_test(
             "ot-rstmgr.fatal_reset": 0,
         },
     ),
+    # Run in both Owner and non-Owner envs to test the keymgr initialization
+    run_in_ci = [
+        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext",
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys",
+    ],
     verilator = verilator_params(timeout = "long"),
     deps = [
         "//sw/device/lib/testing:keymgr_testutils",
@@ -2405,6 +2410,11 @@ opentitan_test(
             "ot-rstmgr.fatal_reset": 0,
         },
     ),
+    # Run in both Owner and non-Owner envs to test the keymgr initialization
+    run_in_ci = [
+        "//hw/top_earlgrey:fpga_cw340_sival",
+        "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys",
+    ],
     verilator = verilator_params(timeout = "eternal"),
     deps = [
         "//sw/device/lib/testing:keymgr_testutils",
@@ -2438,6 +2448,11 @@ opentitan_test(
             "ot-rstmgr.fatal_reset": 0,
         },
     ),
+    # Run in both Owner and non-Owner envs to test the keymgr initialization
+    run_in_ci = [
+        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext",
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys",
+    ],
     verilator = verilator_params(timeout = "eternal"),
     deps = [
         "//sw/device/lib/testing:keymgr_testutils",
@@ -2568,6 +2583,11 @@ opentitan_test(
             "ot-rstmgr.fatal_reset": 0,
         },
     ),
+    # Run in both Owner and non-Owner envs to test the keymgr initialization
+    run_in_ci = [
+        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext",
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys",
+    ],
     deps = [
         "//hw/top:aes_c_regs",
         "//hw/top:keymgr_c_regs",
@@ -2604,6 +2624,11 @@ opentitan_test(
             "ot-rstmgr.fatal_reset": 0,
         },
     ),
+    # Run in both Owner and non-Owner envs to test the keymgr initialization
+    run_in_ci = [
+        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext",
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys",
+    ],
     verilator = verilator_params(timeout = "long"),
     deps = [
         "//hw/top:keymgr_c_regs",
@@ -2637,6 +2662,11 @@ opentitan_test(
             "ot-rstmgr.fatal_reset": 0,
         },
     ),
+    # Run in both Owner and non-Owner envs to test the keymgr initialization
+    run_in_ci = [
+        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext",
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys",
+    ],
     verilator = verilator_params(timeout = "long"),
     deps = [
         "//hw/top:otbn_c_regs",


### PR DESCRIPTION
Backport #28125. Note that I dropped the first commit because it was already kind of included in PR https://github.com/lowRISC/opentitan/pull/27694, along with other nontrivial changes to the test