### PR TITLE
Backport 28461 ([sw,cov] Move ROM_EXT assembly source to a separate cc_library)

### DIFF
--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -133,12 +133,8 @@ cc_test(
 )
 
 cc_library(
-    name = "rom_ext_isrs",
-    srcs = [
-        "rom_ext_isrs.c",
-        "//sw/device/silicon_creator/lib:flash_exc_handler",
-    ],
-    hdrs = ["rom_ext_isrs.h"],
+    name = "rom_ext_flash_exc_handler",
+    srcs = ["//sw/device/silicon_creator/lib:flash_exc_handler"],
     defines = [
         "INTERRUPT_HANDLER=rom_ext_interrupt_handler",
     ],
@@ -146,6 +142,18 @@ cc_library(
     deps = [
         "//hw/top:flash_ctrl_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:macros",
+    ],
+)
+
+cc_library(
+    name = "rom_ext_isrs",
+    srcs = ["rom_ext_isrs.c"],
+    hdrs = ["rom_ext_isrs.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        ":rom_ext_flash_exc_handler",
         "//sw/device/lib/base:csr",
         "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/lib:dbg_print",
@@ -208,13 +216,21 @@ ld_library(
     ],
 )
 
+cc_library(
+    name = "rom_ext_start",
+    srcs = ["rom_ext_start.S"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//hw/top:otp_ctrl_c_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:hardened",
+    ],
+)
+
 [
     cc_library(
         name = "rom_ext_{}".format(variation_name),
-        srcs = [
-            "rom_ext.c",
-            "rom_ext_start.S",
-        ],
+        srcs = ["rom_ext.c"],
         hdrs = ["rom_ext.h"],
         target_compatible_with = [OPENTITAN_CPU],
         deps = [
@@ -223,6 +239,7 @@ ld_library(
             ":rom_ext_boot_services",
             ":rom_ext_isrs",
             ":rom_ext_manifest",
+            ":rom_ext_start",
             "//hw/top:flash_ctrl_c_regs",
             "//hw/top:sram_ctrl_c_regs",
             "//hw/top/dt",


### PR DESCRIPTION
Backport #28461