### PR TITLE
[gpio,dv] Fix race condition in gpio_scoreboard

### DIFF
--- a/hw/ip_templates/gpio/dv/env/gpio_scoreboard.sv.tpl
+++ b/hw/ip_templates/gpio/dv/env/gpio_scoreboard.sv.tpl
@@ -364,44 +364,29 @@ class ${module_instance_name}_scoreboard extends cip_base_scoreboard #(.CFG_T ($
     end
   endtask : monitor_gpio_interrupt_pins
 
-  virtual task update_gpio_straps_regs(logic [NUM_GPIOS-1:0] gpio_i_sampled);
-    // Update data_in and data_in_valid ral register value based on result of input
-    `DV_CHECK_FATAL(ral.hw_straps_data_in.predict(.value(gpio_i_sampled),
-                                                  .kind(UVM_PREDICT_READ)));
-    `DV_CHECK_FATAL(ral.hw_straps_data_in_valid.predict(.value('b1),
-                                                        .kind(UVM_PREDICT_READ)));
-  endtask : update_gpio_straps_regs
-
   // Task: monitor_gpio_straps
   // The task monitors the gpio straps enable signal
   // and checks the straps output signal after the first strap trigger
   virtual task monitor_gpio_straps();
-    logic [NUM_GPIOS-1:0] gpio_i_sampled;
     forever begin : monitor_gpio_straps
-      // Wait for going out of reset operation.
+      // Wait to leave reset
       wait(!cfg.under_reset);
-      // Wait until the strap_en input be triggered
-      // if a reset comes in the middle, step-out of the loop.
-      while (!cfg.straps_vif_inst.tb_port.strap_en) begin
-        cfg.clk_rst_vif.wait_clks_or_rst(1);
-        if (cfg.under_reset) break;
-      end
-      // Step out to the next iteration if a reset happens.
-      if (cfg.under_reset) continue;
-      // Get the gpio_i input data from the pins interface.
-      gpio_i_sampled = cfg.gpio_vif.pins;
-      // Wait for one clock cycle to update the register model.
-      cfg.clk_rst_vif.wait_clks_or_rst(1);
-      // Step out from the loop if a reset comes.
-      if (cfg.under_reset) continue;
-      // Update the register model.
-      update_gpio_straps_regs(gpio_i_sampled);
 
-      // Checker: Compare actual values of gpio pins with straps register.
-      // Check the register hw_straps_data_in against gpio_i pins
-      `DV_CHECK_CASE_EQ(gpio_i_sampled, cfg.straps_vif_inst.tb_port.sampled_straps.data)
-      // Check the register hw_straps_data_in_valid
-      `DV_CHECK_CASE_EQ('b1, cfg.straps_vif_inst.tb_port.sampled_straps.valid)
+      // Now wait until strap_en goes high, dropping out if we go back into reset
+      fork : isolation_fork begin
+        fork
+          wait(cfg.straps_vif_inst.tb_port.strap_en);
+          wait(cfg.under_reset);
+        join_any
+        disable fork;
+      end join
+      if (cfg.under_reset) continue;
+
+      // Sample the pins, storing the value and a validity bit in the register model.
+      if (!ral.hw_straps_data_in.predict(.value(cfg.gpio_vif.pins), .kind(UVM_PREDICT_DIRECT)))
+        `uvm_fatal(get_full_name(), "Failed to update HW_STRAPS_DATA_IN prediction.")
+      if (!ral.hw_straps_data_in_valid.predict(.value(1), .kind(UVM_PREDICT_DIRECT)))
+        `uvm_fatal(get_full_name(), "Failed to update HW_STRAPS_DATA_IN_VALID prediction.")
 
       // Wait for the next reset, if it happens.
       wait(cfg.under_reset);

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
@@ -390,44 +390,29 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
     end
   endtask : monitor_gpio_interrupt_pins
 
-  virtual task update_gpio_straps_regs(logic [NUM_GPIOS-1:0] gpio_i_sampled);
-    // Update data_in and data_in_valid ral register value based on result of input
-    `DV_CHECK_FATAL(ral.hw_straps_data_in.predict(.value(gpio_i_sampled),
-                                                  .kind(UVM_PREDICT_READ)));
-    `DV_CHECK_FATAL(ral.hw_straps_data_in_valid.predict(.value('b1),
-                                                        .kind(UVM_PREDICT_READ)));
-  endtask : update_gpio_straps_regs
-
   // Task: monitor_gpio_straps
   // The task monitors the gpio straps enable signal
   // and checks the straps output signal after the first strap trigger
   virtual task monitor_gpio_straps();
-    logic [NUM_GPIOS-1:0] gpio_i_sampled;
     forever begin : monitor_gpio_straps
-      // Wait for going out of reset operation.
+      // Wait to leave reset
       wait(!cfg.under_reset);
-      // Wait until the strap_en input be triggered
-      // if a reset comes in the middle, step-out of the loop.
-      while (!cfg.straps_vif_inst.tb_port.strap_en) begin
-        cfg.clk_rst_vif.wait_clks_or_rst(1);
-        if (cfg.under_reset) break;
-      end
-      // Step out to the next iteration if a reset happens.
-      if (cfg.under_reset) continue;
-      // Get the gpio_i input data from the pins interface.
-      gpio_i_sampled = cfg.gpio_vif.pins;
-      // Wait for one clock cycle to update the register model.
-      cfg.clk_rst_vif.wait_clks_or_rst(1);
-      // Step out from the loop if a reset comes.
-      if (cfg.under_reset) continue;
-      // Update the register model.
-      update_gpio_straps_regs(gpio_i_sampled);
 
-      // Checker: Compare actual values of gpio pins with straps register.
-      // Check the register hw_straps_data_in against gpio_i pins
-      `DV_CHECK_CASE_EQ(gpio_i_sampled, cfg.straps_vif_inst.tb_port.sampled_straps.data)
-      // Check the register hw_straps_data_in_valid
-      `DV_CHECK_CASE_EQ('b1, cfg.straps_vif_inst.tb_port.sampled_straps.valid)
+      // Now wait until strap_en goes high, dropping out if we go back into reset
+      fork : isolation_fork begin
+        fork
+          wait(cfg.straps_vif_inst.tb_port.strap_en);
+          wait(cfg.under_reset);
+        join_any
+        disable fork;
+      end join
+      if (cfg.under_reset) continue;
+
+      // Sample the pins, storing the value and a validity bit in the register model.
+      if (!ral.hw_straps_data_in.predict(.value(cfg.gpio_vif.pins), .kind(UVM_PREDICT_DIRECT)))
+        `uvm_fatal(get_full_name(), "Failed to update HW_STRAPS_DATA_IN prediction.")
+      if (!ral.hw_straps_data_in_valid.predict(.value(1), .kind(UVM_PREDICT_DIRECT)))
+        `uvm_fatal(get_full_name(), "Failed to update HW_STRAPS_DATA_IN_VALID prediction.")
 
       // Wait for the next reset, if it happens.
       wait(cfg.under_reset);

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
@@ -358,44 +358,29 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
     end
   endtask : monitor_gpio_interrupt_pins
 
-  virtual task update_gpio_straps_regs(logic [NUM_GPIOS-1:0] gpio_i_sampled);
-    // Update data_in and data_in_valid ral register value based on result of input
-    `DV_CHECK_FATAL(ral.hw_straps_data_in.predict(.value(gpio_i_sampled),
-                                                  .kind(UVM_PREDICT_READ)));
-    `DV_CHECK_FATAL(ral.hw_straps_data_in_valid.predict(.value('b1),
-                                                        .kind(UVM_PREDICT_READ)));
-  endtask : update_gpio_straps_regs
-
   // Task: monitor_gpio_straps
   // The task monitors the gpio straps enable signal
   // and checks the straps output signal after the first strap trigger
   virtual task monitor_gpio_straps();
-    logic [NUM_GPIOS-1:0] gpio_i_sampled;
     forever begin : monitor_gpio_straps
-      // Wait for going out of reset operation.
+      // Wait to leave reset
       wait(!cfg.under_reset);
-      // Wait until the strap_en input be triggered
-      // if a reset comes in the middle, step-out of the loop.
-      while (!cfg.straps_vif_inst.tb_port.strap_en) begin
-        cfg.clk_rst_vif.wait_clks_or_rst(1);
-        if (cfg.under_reset) break;
-      end
-      // Step out to the next iteration if a reset happens.
-      if (cfg.under_reset) continue;
-      // Get the gpio_i input data from the pins interface.
-      gpio_i_sampled = cfg.gpio_vif.pins;
-      // Wait for one clock cycle to update the register model.
-      cfg.clk_rst_vif.wait_clks_or_rst(1);
-      // Step out from the loop if a reset comes.
-      if (cfg.under_reset) continue;
-      // Update the register model.
-      update_gpio_straps_regs(gpio_i_sampled);
 
-      // Checker: Compare actual values of gpio pins with straps register.
-      // Check the register hw_straps_data_in against gpio_i pins
-      `DV_CHECK_CASE_EQ(gpio_i_sampled, cfg.straps_vif_inst.tb_port.sampled_straps.data)
-      // Check the register hw_straps_data_in_valid
-      `DV_CHECK_CASE_EQ('b1, cfg.straps_vif_inst.tb_port.sampled_straps.valid)
+      // Now wait until strap_en goes high, dropping out if we go back into reset
+      fork : isolation_fork begin
+        fork
+          wait(cfg.straps_vif_inst.tb_port.strap_en);
+          wait(cfg.under_reset);
+        join_any
+        disable fork;
+      end join
+      if (cfg.under_reset) continue;
+
+      // Sample the pins, storing the value and a validity bit in the register model.
+      if (!ral.hw_straps_data_in.predict(.value(cfg.gpio_vif.pins), .kind(UVM_PREDICT_DIRECT)))
+        `uvm_fatal(get_full_name(), "Failed to update HW_STRAPS_DATA_IN prediction.")
+      if (!ral.hw_straps_data_in_valid.predict(.value(1), .kind(UVM_PREDICT_DIRECT)))
+        `uvm_fatal(get_full_name(), "Failed to update HW_STRAPS_DATA_IN_VALID prediction.")
 
       // Wait for the next reset, if it happens.
       wait(cfg.under_reset);

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
@@ -358,44 +358,29 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
     end
   endtask : monitor_gpio_interrupt_pins
 
-  virtual task update_gpio_straps_regs(logic [NUM_GPIOS-1:0] gpio_i_sampled);
-    // Update data_in and data_in_valid ral register value based on result of input
-    `DV_CHECK_FATAL(ral.hw_straps_data_in.predict(.value(gpio_i_sampled),
-                                                  .kind(UVM_PREDICT_READ)));
-    `DV_CHECK_FATAL(ral.hw_straps_data_in_valid.predict(.value('b1),
-                                                        .kind(UVM_PREDICT_READ)));
-  endtask : update_gpio_straps_regs
-
   // Task: monitor_gpio_straps
   // The task monitors the gpio straps enable signal
   // and checks the straps output signal after the first strap trigger
   virtual task monitor_gpio_straps();
-    logic [NUM_GPIOS-1:0] gpio_i_sampled;
     forever begin : monitor_gpio_straps
-      // Wait for going out of reset operation.
+      // Wait to leave reset
       wait(!cfg.under_reset);
-      // Wait until the strap_en input be triggered
-      // if a reset comes in the middle, step-out of the loop.
-      while (!cfg.straps_vif_inst.tb_port.strap_en) begin
-        cfg.clk_rst_vif.wait_clks_or_rst(1);
-        if (cfg.under_reset) break;
-      end
-      // Step out to the next iteration if a reset happens.
-      if (cfg.under_reset) continue;
-      // Get the gpio_i input data from the pins interface.
-      gpio_i_sampled = cfg.gpio_vif.pins;
-      // Wait for one clock cycle to update the register model.
-      cfg.clk_rst_vif.wait_clks_or_rst(1);
-      // Step out from the loop if a reset comes.
-      if (cfg.under_reset) continue;
-      // Update the register model.
-      update_gpio_straps_regs(gpio_i_sampled);
 
-      // Checker: Compare actual values of gpio pins with straps register.
-      // Check the register hw_straps_data_in against gpio_i pins
-      `DV_CHECK_CASE_EQ(gpio_i_sampled, cfg.straps_vif_inst.tb_port.sampled_straps.data)
-      // Check the register hw_straps_data_in_valid
-      `DV_CHECK_CASE_EQ('b1, cfg.straps_vif_inst.tb_port.sampled_straps.valid)
+      // Now wait until strap_en goes high, dropping out if we go back into reset
+      fork : isolation_fork begin
+        fork
+          wait(cfg.straps_vif_inst.tb_port.strap_en);
+          wait(cfg.under_reset);
+        join_any
+        disable fork;
+      end join
+      if (cfg.under_reset) continue;
+
+      // Sample the pins, storing the value and a validity bit in the register model.
+      if (!ral.hw_straps_data_in.predict(.value(cfg.gpio_vif.pins), .kind(UVM_PREDICT_DIRECT)))
+        `uvm_fatal(get_full_name(), "Failed to update HW_STRAPS_DATA_IN prediction.")
+      if (!ral.hw_straps_data_in_valid.predict(.value(1), .kind(UVM_PREDICT_DIRECT)))
+        `uvm_fatal(get_full_name(), "Failed to update HW_STRAPS_DATA_IN_VALID prediction.")
 
       // Wait for the next reset, if it happens.
       wait(cfg.under_reset);


### PR DESCRIPTION
This code was way more complicated than necessary (and also contained checks on the behaviour of the input ports, which seems a bit bizarre).

What's worse, there was a race condition at the start of time (assuming we started in reset). If
gpio_scoreboard::monitor_gpio_straps happens to run before dv_base_scoreboard::monitor_reset, then it would loop forever without consuming any time and without seeing cfg.under_reset go high, but without allowing anything else to run (no #0 or blocking action).

Rewrite the code in a less silly way.