### PR TITLE
[dv,chip] Fix OTP mmap `--topname` issues in `chip_sim_cfg`

### DIFF
--- a/hw/top_darjeeling/dv/chip_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_sim_cfg.hjson
@@ -187,7 +187,9 @@
         // Generate LC encoding
         "cd {proj_root} && ./util/design/gen-lc-state-enc.py --seed {seed}",
         // Generate OTP memory map and scrambling constants keys.
-        "cd {proj_root} && ./util/design/gen-otp-mmap.py --seed {seed}",
+        '''cd {proj_root} && ./util/design/gen-otp-mmap.py --seed {seed} \
+        --topname darjeeling
+''',
         // Use eval_cmd to save build_seed in a file and reuse that file during run phase.
         // Create the build directory first because eval_cmd runs before actual build phase command
         // execution.

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -188,7 +188,7 @@
         "cd {proj_root} && ./util/design/gen-lc-state-enc.py --seed {seed}",
         // Generate OTP memory map and scrambling constants keys.
         '''cd {proj_root} && ./util/design/gen-otp-mmap.py --seed {seed} \
-        --topname earlrey
+        --topname earlgrey
 	''',
         // Use eval_cmd to save build_seed in a file and reuse that file during run phase.
         // Create the build directory first because eval_cmd runs before actual build phase command


### PR DESCRIPTION
See [gen-otp-mmap.py](https://github.com/lowRISC/opentitan/blob/bbe4dbf28bbfe815dcd11d723dc3e38635b46704/util/design/gen-otp-mmap.py#L118-L132). I noticed this typo (for Earlgrey) and missing required argument (for Darjeeling) when running a regression locally.

I'm not sure if these cause any tangible failures (I'd assume they would, but perhaps the errors are silently ignored and don't cause cascading issues), but it seems prudent to fix it whilst I've noticed it.