### PR TITLE
[chip, gpio, dv] Let the vseq wait for the correct expected value

### DIFF
--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_gpio_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_gpio_vseq.sv
@@ -53,7 +53,7 @@ class chip_sw_gpio_vseq extends chip_sw_base_vseq;
     // Check for W0 pattern on the GPIO output pins.
     for (int i = 0; i < NUM_GPIOS; i++) begin
       logic [NUM_GPIOS-1:0] exp_gpios = ~(1 << i);
-      `DV_SPINWAIT(wait(cfg.chip_vif.gpios_if.pins === gpios_mask);,
+      `DV_SPINWAIT(wait(cfg.chip_vif.gpios_if.pins === exp_gpios);,
                    $sformatf("Timed out waiting for GPIOs == %0h", exp_gpios),
                    timeout_ns,
                   `gfn)

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_gpio_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_gpio_vseq.sv
@@ -53,7 +53,7 @@ class chip_sw_gpio_vseq extends chip_sw_base_vseq;
     // Check for W0 pattern on the GPIO output pins.
     for (int i = 0; i < NUM_GPIOS; i++) begin
       logic [NUM_GPIOS-1:0] exp_gpios = ~(1 << i);
-      `DV_SPINWAIT(wait(cfg.chip_vif.gpios_if.pins === gpios_mask);,
+      `DV_SPINWAIT(wait(cfg.chip_vif.gpios_if.pins === exp_gpios);,
                    $sformatf("Timed out waiting for GPIOs == %0h", exp_gpios),
                    timeout_ns,
                   `gfn)


### PR DESCRIPTION
If we follow the sequence for walking 1's, the vseq should expect a sequence of walking 0's present in exp_gpios.