### PR TITLE
[dv] Update DVSim shell path

### DIFF
--- a/hw/dv/tools/dvsim/sim.mk
+++ b/hw/dv/tools/dvsim/sim.mk
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-export SHELL  := /usr/bin/env bash
+export SHELL  := bash
 .DEFAULT_GOAL := all
 
 LOCK_ROOT_DIR ?= flock --timeout 3600 ${proj_root} --command


### PR DESCRIPTION
Follow-up fix from #29142. While that fix seems to work on NixOS, it causes issues for me locally running on e.g. Ubuntu. For any DV build targets that specify `pre_build_cmds`, e.g. the chip-level tests in the `build_seed` mode:
```
[make]: pre_build
mkdir -p /home/alexj/opentitan/scratch/chip_sim_cfg_typo/chip_earlgrey_asic-sim-vcs/default
# pre_build_cmds are likely changing the in-tree sources. We hence use FLOCK
# utility to prevent multiple builds that may be running in parallel from
# stepping on each other. TODO: Enforce the list of pre_build_cmds is
# identical across all build modes.
flock --timeout 3600 /home/alexj/opentitan --command "cd /home/alexj/opentitan/scratch/chip_sim_cfg_typo/chip_earlgrey_asic-sim-vcs/default && cd /home/alexj/opentitan && ./util/design/gen-lc-state-enc.py --seed 1 && cd /home/alexj/opentitan && ./util/design/gen-otp-mmap.py --seed 1 \
--topname earlgrey && echo create file /home/alexj/opentitan/scratch/chip_sim_cfg_typo/chip_earlgrey_asic-sim-vcs/default/build_seed.log"
flock: failed to execute /usr/bin/env bash: No such file or directory
make: *** [/home/alexj/opentitan/hw/dv/tools/dvsim/sim.mk:24: pre_build] Error 69
```

This `SHELL` var should be probably just be `bash` instead of `usr/bin/env bash`, which should be populated correctly by the user's individual `PATH` configuration, to avoid issues with the environment not always being available to the Makefile / flock and causing errors.