### PR TITLE
[bazel,cov] Fix missing generated files due to coverage remote-cache 

### DIFF
--- a/ci/scripts/collect-coverage-report.sh
+++ b/ci/scripts/collect-coverage-report.sh
@@ -9,6 +9,7 @@ OUTPUT_DIR="${1:-/tmp/$USER/coverage_report}"
 TESTS="${OUTPUT_DIR}/test_coverages"
 LOGS="${OUTPUT_DIR}/test_logs"
 SOURCES="${OUTPUT_DIR}/source_files"
+SOURCE_LIST="${OUTPUT_DIR}/source_list.txt"
 COVERAGE="${OUTPUT_DIR}/coverage.dat"
 
 LCOV_FILES="bazel-out/_coverage/lcov_files.tmp"
@@ -44,7 +45,8 @@ done
 
 echo "Collect all source files listed in coverage data"
 mkdir -p "${SOURCES}"
-grep -h '^SF:' "${COVERAGE}" | sed 's/^SF://' | sort -u \
-| rsync -a --ignore-missing-args --files-from=- . "${SOURCES}/"
+grep -h '^SF:' "${COVERAGE}" | sed 's/^SF://' | sort -u > "${SOURCE_LIST}"
+python3 util/fetch-remote-bazel-cache.py --file-list="${SOURCE_LIST}"
+rsync -a --ignore-missing-args --files-from="${SOURCE_LIST}" . "${SOURCES}/"
 
 echo "coverageReport=ok" >> "${GITHUB_OUTPUT:-/dev/null}"

--- a/ci/scripts/collect-coverage-report.sh
+++ b/ci/scripts/collect-coverage-report.sh
@@ -26,6 +26,7 @@ cp -r bazel-out/_coverage/* "${OUTPUT_DIR}" || true
 find "${OUTPUT_DIR}" -type f -exec chmod 644 {} +
 
 echo "Collect all test coverage data"
+rm -rf "${TESTS:?}"
 mkdir -p "${TESTS}"
 rsync -a --ignore-missing-args --files-from="${LCOV_FILES}" . "${TESTS}/"
 
@@ -33,6 +34,7 @@ echo "Merge all coverage data"
 find "${TESTS}" -type f -name "*.dat" -exec cat {} + > "${COVERAGE}"
 
 echo "Collect all test logs"
+rm -rf "${LOGS:?}"
 mkdir -p "${LOGS}"
 cat "${LCOV_FILES}" | while read -r lcov; do
   test_dir=$(dirname "${lcov}")
@@ -44,6 +46,7 @@ cat "${LCOV_FILES}" | while read -r lcov; do
 done
 
 echo "Collect all source files listed in coverage data"
+rm -rf "${SOURCES:?}"
 mkdir -p "${SOURCES}"
 grep -h '^SF:' "${COVERAGE}" | sed 's/^SF://' | sort -u > "${SOURCE_LIST}"
 python3 util/fetch-remote-bazel-cache.py --file-list="${SOURCE_LIST}"

--- a/util/fetch-remote-bazel-cache.py
+++ b/util/fetch-remote-bazel-cache.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""Fetches remote cached artifacts from a Bazel remote cache.
+
+This script identifies missing local files from a provided list, resolves their
+corresponding hashes by dumping the Bazel action cache, and attempts to
+download them from the remote cache URL.
+"""
+
+import argparse
+import logging
+import os
+import re
+import requests
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, Optional
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def get_remote_cache_url() -> Optional[str]:
+    """Resolves the remote cache URL from bazel configuration."""
+    try:
+        result = subprocess.run(
+            ["./bazelisk.sh", "config", "--announce_rc"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        # Search for --remote_cache=URL. We take the first match found in the config.
+        m = re.search(r"--remote_cache=(\S+)", result.stdout + result.stderr)
+        if m:
+            return m.group(1).rstrip("/")
+    except subprocess.CalledProcessError:
+        logger.warning("Failed to run bazelisk to resolve remote cache URL.")
+    except Exception as e:
+        logger.warning(f"Unexpected error resolving remote cache URL: {e}")
+    return None
+
+
+def get_action_cache_map() -> Dict[str, str]:
+    """Parses the action cache dump and returns a mapping from path to hash."""
+    try:
+        result = subprocess.run(
+            ["./bazelisk.sh", "dump", "--action_cache"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Error running bazelisk dump --action_cache: {e}")
+        if e.stderr:
+            logger.error(e.stderr)
+        sys.exit(1)
+
+    cache_map = {}
+    # Matches: <path> = ... <SHA-256 hash>
+    # We capture the path and the 64-character hex hash.
+    pattern = re.compile(
+        r"^\s*(?P<path>\S+)\s*=\s*.*?(?P<hash>[0-9a-fA-F]{64})")
+
+    for line in result.stdout.splitlines():
+        m = pattern.search(line)
+        if m:
+            cache_map[m.group("path")] = m.group("hash").lower()
+
+    return cache_map
+
+
+def fetch_artifact(path_str: str, artifact_hash: str,
+                   remote_cache: str) -> bool:
+    """Fetches an artifact from the remote cache and saves it to path_str."""
+    path = Path(path_str)
+    url = f"{remote_cache}/cas/{artifact_hash}"
+
+    try:
+        # Using a timeout to avoid hanging indefinitely
+        response = requests.get(url, stream=True, timeout=30)
+        if response.status_code == 200:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("wb") as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    f.write(chunk)
+            logger.info(f"Fetched {path_str}")
+            return True
+        elif response.status_code == 404:
+            logger.warning(
+                f"Artifact not found in cache: {path_str} ({artifact_hash})")
+        else:
+            logger.error(
+                f"Failed to fetch {path_str}: HTTP {response.status_code}")
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Error fetching {path_str} from {url}: {e}")
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=
+        "Fetch missing remote cached artifacts from a list of paths.")
+    parser.add_argument(
+        "--remote_cache",
+        help=
+        "Remote cache URL. If not provided, resolves from bazelisk config.",
+    )
+    parser.add_argument(
+        "--file-list",
+        help=
+        "File containing list of file paths to fetch. If not provided, reads from stdin."
+    )
+    args = parser.parse_args()
+
+    # Gather all paths from input source
+    if args.file_list:
+        logger.info(f"Reading file list from {args.file_list}")
+        with open(args.file_list, "r") as f:
+            paths = [line.strip() for line in f if line.strip()]
+    else:
+        logger.info("Reading file list from stdin")
+        paths = [line.strip() for line in sys.stdin if line.strip()]
+
+    # Pre-check: identify missing files
+    missing_paths = [p for p in paths if not os.path.exists(p)]
+    if not missing_paths:
+        logger.info("All files already exist locally. Nothing to fetch.")
+        return
+    logger.info(f"Found {len(missing_paths)} missing files to fetch.")
+
+    # Resolve remote cache URL only if there are missing files
+    remote_cache = args.remote_cache or get_remote_cache_url()
+    if not remote_cache:
+        parser.error(
+            "--remote_cache not provided and could not be resolved from config."
+        )
+
+    remote_cache = remote_cache.rstrip("/")
+    logger.info(f"Using remote cache: {remote_cache}")
+
+    # Load action cache map
+    cache_map = get_action_cache_map()
+    logger.info(f"Loaded {len(cache_map)} entries from action cache.")
+
+    # Process missing file paths
+    for path_str in missing_paths:
+        artifact_hash = cache_map.get(path_str)
+        if artifact_hash:
+            fetch_artifact(path_str, artifact_hash, remote_cache)
+        else:
+            logger.warning(f"No cache entry found for {path_str}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The coverage report generation requires source files to be present locally. When using remote caching, some source files might not be present in the local workspace.

This change adds a utility script `util/fetch-remote-cache.py` that:
1. Resolves the remote cache URL from Bazel configuration.
2. Parses the Bazel action cache to map file paths to content hashes.
3. Fetches missing files directly from the remote cache's CAS.

The `collect-coverage-report.sh` script is updated to invoke this utility before attempting to rsync source files into the report directory.