### PR TITLE
[ci,cov] Keep uploading coverage artifacts on error

### DIFF
--- a/.github/workflows/publish-coverage-report.yml
+++ b/.github/workflows/publish-coverage-report.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           ci/scripts/merge-coverage-report.sh /tmp/job_reports /tmp/report
       - name: Upload report as artifact
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.report-artifact-name }}

--- a/ci/scripts/merge-coverage-report.sh
+++ b/ci/scripts/merge-coverage-report.sh
@@ -85,7 +85,7 @@ GENHTML_ARGS=(
   cd "${SOURCES}"
   genhtml "${COVERAGE}" "${IGNORE_ERRORS[@]}" "${GENHTML_ARGS[@]}"
   lcov "${IGNORE_ERRORS[@]}" --summary "${COVERAGE}" > "${GITHUB_STEP_SUMMARY:-/dev/null}"
-)
+) || echo "WARNING: genhtml failed, continue"
 
 echo "Pack directories to reduce artifact size and count"
 function pack_dir() {


### PR DESCRIPTION
This change updates the coverage report merging script to ensure that artifact packing and uploading proceed even if `genhtml` or `lcov` encounter errors. This avoids losing coverage artifacts when the report rendering fails.

The partial artifacts help debugging and can also be rendered manually after fixing the corrupted parts.

This also "mutes" the current post-submit CI error in the "Publish Coverage Report" action due to the missing generated files from remote cache. (It will be fixed by a separate PR)