### PR TITLE
Backport 27428 ([rom_ext] bump version number)

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -301,9 +301,9 @@ manifest(d = {
     "identifier": hex(CONST.ROM_EXT),
     "manuf_state_creator": hex(CONST.MANUF_STATE.PERSO_INITIAL),
     "visibility": ["//visibility:private"],
-    "version_major": ROM_EXT_VERSION.MAJOR,
-    # Release: 2025-07-01-RC00
-    "version_minor": "2025070100",
+    "version_major": "0",
+    # Release: 2025-07-10-RC00
+    "version_minor": "2025071000",
     "security_version": "0xFFFFFFFF",
 })
 

--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -14,7 +14,7 @@ def secver_write_selection():
 # because of how the bazel rule accepts attributes.
 ROM_EXT_VERSION = struct(
     MAJOR = "0",
-    MINOR = "113",
+    MINOR = "114",
     SECURITY = "0",
 )
 


### PR DESCRIPTION
Backport #27428, #27509 and #27607