### PR TITLE
[ci,bazel] upload bazel execution log for analysis

### DIFF
--- a/.github/actions/publish-bazel-test-results/action.yml
+++ b/.github/actions/publish-bazel-test-results/action.yml
@@ -69,3 +69,10 @@ runs:
         name: ${{ inputs.artifact-name }}-coverage
         path: /tmp/coverage_report
         overwrite: true
+
+    - name: Upload bazel execution log
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}-exec-log
+        path: /tmp/bazel-exec-log/
+        overwrite: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,13 @@ jobs:
         with:
           service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
       - name: Execute tests
-        run: ./bazelisk.sh test --test_tag_filters=-nightly //sw/otbn/crypto/...
+        run: |
+          mkdir -p "/tmp/bazel-exec-log"
+          exec_log_file="$(mktemp /tmp/bazel-exec-log/exec-XXXXXX.log)"
+          ./bazelisk.sh test                                \
+            --test_tag_filters=-nightly                     \
+            --execution_log_compact_file="${exec_log_file}" \
+            //sw/otbn/crypto/...
 
   verilator_earlgrey:
     name: Verilated Earl Grey
@@ -646,10 +652,13 @@ jobs:
             --target_pattern_file="$target_pattern_file"
       - name: Run software unit tests
         run: |
+          mkdir -p "/tmp/bazel-exec-log"
+          exec_log_file="$(mktemp /tmp/bazel-exec-log/exec-XXXXXX.log)"
           ./bazelisk.sh test                                                \
             --build_tests_only=false                                        \
             --test_output=errors                                            \
             --define DISABLE_VERILATOR_BUILD=true                           \
+            --execution_log_compact_file="${exec_log_file}"                 \
             --test_tag_filters=-broken,-cw310,-verilator,-dv,-silicon,-qemu \
             --target_pattern_file="$target_pattern_file"
       - name: Publish Bazel test results

--- a/.github/workflows/coverage-quick.yml
+++ b/.github/workflows/coverage-quick.yml
@@ -21,7 +21,11 @@ jobs:
           service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
       - name: Execute tests
         run: |
-          ./bazelisk.sh coverage --config=ot_coverage --test_tag_filters=-nightly \
+          mkdir -p "/tmp/bazel-exec-log"
+          exec_log_file="$(mktemp /tmp/bazel-exec-log/exec-XXXXXX.log)"
+          ./bazelisk.sh coverage --config=ot_coverage       \
+            --test_tag_filters=-nightly                     \
+            --execution_log_compact_file="${exec_log_file}" \
             //sw/otbn/crypto/...
       - name: Publish Bazel test results
         uses: ./.github/actions/publish-bazel-test-results
@@ -76,6 +80,8 @@ jobs:
             >> "$target_pattern_file"
       - name: Run software unit tests coverage
         run: |
+          mkdir -p "/tmp/bazel-exec-log"
+          exec_log_file="$(mktemp /tmp/bazel-exec-log/exec-XXXXXX.log)"
           ./bazelisk.sh coverage                             \
             --build_tests_only                               \
             --keep_going                                     \
@@ -83,6 +89,7 @@ jobs:
             --test_output=errors                             \
             --define DISABLE_VERILATOR_BUILD=true            \
             --target_pattern_file="$target_pattern_file"     \
+            --execution_log_compact_file="${exec_log_file}"  \
             --test_tag_filters=-broken,-coverage_broken,-cw310,-verilator,-dv,-silicon,-qemu
       - name: Publish Bazel test results
         uses: ./.github/actions/publish-bazel-test-results

--- a/ci/scripts/run-fpga-tests.sh
+++ b/ci/scripts/run-fpga-tests.sh
@@ -68,6 +68,9 @@ trap './bazelisk.sh run //sw/host/opentitantool -- --rcfile= --interface=${fpga}
 # Print the SAM3X firmware version. HyperDebug transports don't currently support this, so we ignore errors.
 ./bazelisk.sh run //sw/host/opentitantool -- --rcfile= --interface="$fpga" fpga get-sam3x-fw-version || true
 
+mkdir -p "/tmp/bazel-exec-log"
+exec_log_file="$(mktemp /tmp/bazel-exec-log/exec-XXXXXX.log)"
+
 TEST_ARGS=(
     --define DISABLE_VERILATOR_BUILD=true
     --nokeep_going
@@ -77,6 +80,7 @@ TEST_ARGS=(
     --define "${fpga}=lowrisc"
     --flaky_test_attempts=2
     --target_pattern_file="${target_pattern_file}"
+    --execution_log_compact_file="${exec_log_file}"
 )
 
 if [[ "${mode}" == "coverage" ]]; then


### PR DESCRIPTION
The Bazel remote cache for `earlgrey_1.0.0` is currently misconfigured for presubmit CI jobs, resulting in redundant executions and excessive FPGA resource consumption. In contrast, post-submit and master CI jobs successfully utilize the cache, indicating significant potential for performance and stability gains.

While related to issue #20844, the fix from PR #25852 did not resolve this specific regression.

Following the [Bazel remote caching guide](https://bazel.build/remote/cache-remote), this change introduces the `--execution_log_compact_file` flag and uploaded as GitHub artifacts, enabling inspection of the post-submit logs for more effective debugging of cache misses in the CI environment.