### PR TITLE
[ci] Split bitstream job into find and build

### DIFF
--- a/.github/workflows/bitstream.yml
+++ b/.github/workflows/bitstream.yml
@@ -15,18 +15,15 @@ on:
         type: string
 
 jobs:
-  bitstream:
-    name: Build bitstream
-    runs-on: ubuntu-22.04-bitstream
-    timeout-minutes: 240
+  bitstream_find:
+    name: Find bitstream
+    runs-on: ubuntu-22.04
+    outputs:
+      bitstreamStrategy: ${{ steps.strategy.outputs.bitstreamStrategy }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required by get-bitstream-strategy.sh
-      - name: Prepare environment
-        uses: ./.github/actions/prepare-env
-        with:
-          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
 
       - name: Configure bitstream strategy
         id: strategy
@@ -56,8 +53,28 @@ jobs:
           bitstream_archive=$(./bazelisk.sh outquery "${cached_archive}")
           cp -Lv ${bitstream_archive} build-bin.tar
 
+      - name: Upload step outputs
+        if: steps.strategy.outputs.bitstreamStrategy == 'cached'
+        uses: actions/upload-artifact@v4
+        with:
+          name: partial-build-bin-chip_${{ inputs.top_name }}_${{ inputs.design_suffix }}
+          path: build-bin.tar
+
+  bitstream_build:
+    name: Build bitstream
+    runs-on: ubuntu-22.04-bitstream
+    timeout-minutes: 240
+    needs: bitstream_find
+    if: needs.bitstream_find.outputs.bitstreamStrategy != 'cached'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
+        with:
+          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
+
       - name: Build and splice bitstream with Vivado
-        if: steps.strategy.outputs.bitstreamStrategy != 'cached'
         run: |
           bazel_package=//hw/bitstream/vivado
           bitstream_target=${bazel_package}:fpga_${{ inputs.design_suffix }}
@@ -79,7 +96,6 @@ jobs:
           ./bazelisk.sh build ${archive_target}
 
       - name: Display synthesis & implementation logs
-        if: steps.strategy.outputs.bitstreamStrategy != 'cached'
         run: |
           . util/build_consts.sh
           echo "Synthesis log"


### PR DESCRIPTION
This split allows us to run the bitstream finding logic on a standard GitHub runner, and only spin up the more expensive bitstream runner if a build is actually required.

By separating these tasks, PRs that utilize cached bitstreams can bypass the limited-availability specialized runners. This optimization enhances CI efficiency, reduces resource strain, and improves overall workflow stability.

---

Test run for bitstream-build branch:
https://github.com/lowRISC/opentitan/actions/runs/23574284323/job/68643410608