### PR TITLE
Backport 28652 ([otlib] EEPROM use command constants from SPI Flash instead of redeclaring)

### DIFF
--- a/sw/host/ot_transports/dediprog/src/spi.rs
+++ b/sw/host/ot_transports/dediprog/src/spi.rs
@@ -284,10 +284,10 @@ impl DediprogSpi {
                 }
                 [WaitForBusyClear, rest @ ..] => {
                     transactions = rest;
-                    let mut status = eeprom::STATUS_WIP;
-                    while status & eeprom::STATUS_WIP != 0 {
+                    let mut status = SpiFlash::STATUS_WIP;
+                    while status & SpiFlash::STATUS_WIP != 0 {
                         self.run_transaction(&mut [
-                            Transfer::Write(&[eeprom::READ_STATUS]),
+                            Transfer::Write(&[SpiFlash::READ_STATUS]),
                             Transfer::Read(std::slice::from_mut(&mut status)),
                         ])?;
                     }

--- a/sw/host/ot_transports/hyperdebug/src/spi.rs
+++ b/sw/host/ot_transports/hyperdebug/src/spi.rs
@@ -16,6 +16,7 @@ use opentitanlib::io::gpio::GpioPin;
 use opentitanlib::io::spi::{
     AssertChipSelect, MaxSizes, SpiError, Target, TargetChipDeassert, Transfer, TransferMode,
 };
+use opentitanlib::spiflash::flash::SpiFlash;
 use opentitanlib::transport::TransportError;
 
 use super::{BulkInterface, Inner};
@@ -1054,10 +1055,10 @@ impl Target for HyperdebugSpiTarget {
                 }
                 [eeprom::Transaction::WaitForBusyClear, rest @ ..] => {
                     self.get_last_streamed_data(stream_state)?;
-                    let mut status = eeprom::STATUS_WIP;
-                    while status & eeprom::STATUS_WIP != 0 {
+                    let mut status = SpiFlash::STATUS_WIP;
+                    while status & SpiFlash::STATUS_WIP != 0 {
                         self.run_transaction(&mut [
-                            Transfer::Write(&[eeprom::READ_STATUS]),
+                            Transfer::Write(&[SpiFlash::READ_STATUS]),
                             Transfer::Read(std::slice::from_mut(&mut status)),
                         ])?;
                     }


### PR DESCRIPTION
Backport #28652