### PR TITLE
[sw/uart] Fix UART silicon migration failures

### DIFF
--- a/sw/device/lib/testing/uart_testutils.c
+++ b/sw/device/lib/testing/uart_testutils.c
@@ -59,8 +59,8 @@ static const pinmux_testutils_mio_pin_t
                 .insel = kTopEarlgreyPinmuxInselIoc3,
             },
         [kUartPinmuxChannelDut] = {
-            .mio_out = kTopEarlgreyPinmuxMioOutIob5,
-            .insel = kTopEarlgreyPinmuxInselIob4,
+            .mio_out = kTopEarlgreyPinmuxMioOutIoa1,
+            .insel = kTopEarlgreyPinmuxInselIoa0,
         }};
 
 /**

--- a/sw/host/opentitanlib/src/app/config/hyperdebug_teacup.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_teacup.json
@@ -465,7 +465,7 @@
     },
     {
       "name": "dut",
-      "alias_of": "UART3"
+      "alias_of": "UART4"
     }
   ],
   "strappings": [


### PR DESCRIPTION
These changes improve UART DUT configurability. Console pins
will now be adapted correctly for different packages.

Issue: https://github.com/lowRISC/opentitan/pull/28420

### Changes
* **Device:** Updated `uart_testutils.c` to improve DUT configurability.
* **Host:** Adapted `hyperdebug_teacup.json` console pins for better package support.