### PR TITLE
[ci] Bump the the version of github-script action to v8

### DIFF
--- a/.github/workflows/private-ci.yml
+++ b/.github/workflows/private-ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Private CI
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const payload = {


### PR DESCRIPTION
This will fix a warning on the private ci trigger.

https://github.com/lowRISC/opentitan/actions/runs/23495506038