### PR TITLE
[reggen] Two minor documentation tidy-ups

### DIFF
--- a/util/reggen/README.md
+++ b/util/reggen/README.md
@@ -679,8 +679,10 @@ Other error responses include for the following reasons:
 
 * TL-UL `a_opcode` illegal value
 * TL-UL writes of size smaller than register size
-  * I.e. writes of size 8b to registers > 8b will cause error (explicitly: if it has field bits within `[31:08]`)
-  * I.e. writes of size 16b to registers > 16b will cause error (explicitly: if it has field bits within `[31:16]`)
+  * Disallowing such writes makes the implementation simpler.
+  * It also strengthens the security of the system, by making it hard to use a fault injection to cause only part of a register to be updated.
+  * This can be seen with an 8b write to a register which is larger than 8 bits, or a 16b write to a register which is larger than 16 bits.
+  * The width of the register is determined by the location of its fields.
 * TL-UL writes of size smaller than 32b that are not word-aligned
   * I.e. writes of size 8b or 16b that are not to an address that is 4B aligned return in error.
 

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -756,9 +756,10 @@ ${finst_gen(sr, field, finst_name, fsig_name, fidx)}
 
   % if regs_flat:
 <%
-    # We want to signal wr_err if reg_be (the byte enable signal) is true for
-    # any bytes that aren't supported by a register. That's true if a
-    # addr_hit[i] and a bit is set in reg_be but not in *_PERMIT[i].
+    # Although partial writes are possible on the bus, the registers have a single write-enable bit.
+    # As such, all fields in the target register must be completely covered by the bytes being
+    # written. If a bit is high in *_PERMIT[i], this means that the corresponding byte contributes
+    # some field in register i.
 
     wr_addr_hit = 'racl_addr_hit_write' if racl_support else 'addr_hit'
     wr_err_terms = ['({wr_addr_hit}[{idx}] & (|({mod}_PERMIT[{idx}] & ~reg_be)))'


### PR DESCRIPTION
No functional change, but this makes a couple of bits of documentation more helpful. The second commit fixes a stupid mistake that I made in documentation comment in 2021. Oops!