### PR TITLE
[dv,jtag] Downgrade jtag monitor messages to UVM_HIGH

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_monitor.sv
+++ b/hw/dv/sv/jtag_agent/jtag_monitor.sv
@@ -127,7 +127,7 @@ class jtag_monitor extends dv_base_monitor #(
             item.dr     = dr;
             item.dout   = dout;
             analysis_port.write(item);
-            `uvm_info(`gfn, item.sprint(uvm_default_line_printer), UVM_MEDIUM)
+            `uvm_info(`gfn, item.sprint(uvm_default_line_printer), UVM_HIGH)
           end
         end
 
@@ -166,7 +166,7 @@ class jtag_monitor extends dv_base_monitor #(
             item.dr_len = 0;
             item.ir     = ir;
             analysis_port.write(item);
-            `uvm_info(`gfn, item.sprint(uvm_default_line_printer), UVM_MEDIUM)
+            `uvm_info(`gfn, item.sprint(uvm_default_line_printer), UVM_HIGH)
           end
         end
         default: `uvm_fatal(`gfn, $sformatf("Does not support jtag state: %0s", jtag_state.name))


### PR DESCRIPTION
These were previously UVM_MEDIUM, and a message is emitted on every JTAG item. This is pretty noisy if you're trying to debug something based on DMI or (worse) SBA.

Downgrade the messages to UVM_HIGH, to match the equivalent messages that come out of other buses.