### PR TITLE
Allow certificate_template to be used by downstream repos.

### DIFF
--- a/rules/certificates.bzl
+++ b/rules/certificates.bzl
@@ -119,12 +119,12 @@ def certificate_template(name, template, cert_format = "x509"):
 
     if cert_format == "x509":
         runtime_deps = [
-            "@//sw/device/silicon_creator/lib/cert:asn1",
-            "@//sw/device/silicon_creator/lib/cert:template",
+            "@lowrisc_opentitan//sw/device/silicon_creator/lib/cert:asn1",
+            "@lowrisc_opentitan//sw/device/silicon_creator/lib/cert:template",
         ]
     else:
         runtime_deps = [
-            "@//sw/device/silicon_creator/lib/cert:cbor",
+            "@lowrisc_opentitan//sw/device/silicon_creator/lib/cert:cbor",
         ]
 
     native.cc_library(


### PR DESCRIPTION
Use the module name '@lowrisc_opentitan' instead of '@' when referencing targets in the same workspace. This is the approach recommended by https://bazel.build/external/migration#specify-repo-name and allows downstream projects to reuse OpenTitan's certificate codegen.

Signed-off-by: Jason Young <jasonyoung@google.com>