### PR TITLE
[crypto/hmac] Use hardened_memcpy to read digest

### DIFF
--- a/sw/device/lib/crypto/drivers/hmac.c
+++ b/sw/device/lib/crypto/drivers/hmac.c
@@ -209,25 +209,6 @@ static status_t key_write(const hmac_key_t *key) {
 }
 
 /**
- * Copy the digest result from HMAC HWIP to given `digest` buffer.
- *
- * This function does not return error, so it is the responsibility of the
- * caller to check that `digest` and `digest_wordlen` are correctly set.
- * Moreover, the caller must ensure that HMAC HWIP is in a state that permits
- * reading the digest value, that is, either of stop or process commands is
- * issued.
- *
- * @param[out] digest The digest buffer to copy to the result.
- * @param digest_wordlen The length of the digest buffer in words.
- */
-static void digest_read(uint32_t *digest, size_t digest_wordlen) {
-  for (size_t i = 0; i < digest_wordlen; i++) {
-    digest[i] = abs_mmio_read32(kHmacBaseAddr + HMAC_DIGEST_0_REG_OFFSET +
-                                sizeof(uint32_t) * i);
-  }
-}
-
-/**
  * Resume a streaming operation from a saved context.
  *
  * @param ctx Context object from which to restore.
@@ -293,7 +274,9 @@ static status_t context_restore(hmac_ctx_t *ctx) {
 static void context_save(hmac_ctx_t *ctx) {
   // For SHA-256 and HMAC-256, we do not need to save to the second half of
   // DIGEST registers, but we do it anyway to keep the driver simple.
-  digest_read(ctx->H, kHmacMaxDigestWords);
+  hardened_memcpy(ctx->H,
+                  (const uint32_t *)(kHmacBaseAddr + HMAC_DIGEST_0_REG_OFFSET),
+                  kHmacMaxDigestWords);
   ctx->lower =
       abs_mmio_read32(kHmacBaseAddr + HMAC_MSG_LENGTH_LOWER_REG_OFFSET);
   ctx->upper =
@@ -483,7 +466,10 @@ static status_t oneshot(const uint32_t cfg, const hmac_key_t *key,
 
   // Wait for the digest to be ready, then read it.
   HARDENED_TRY(hmac_idle_wait());
-  digest_read(digest, digest_wordlen);
+  // Copy the digest result from HMAC HWIP to given `digest` buffer.
+  HARDENED_TRY(hardened_memcpy(
+      digest, (const uint32_t *)(kHmacBaseAddr + HMAC_DIGEST_0_REG_OFFSET),
+      digest_wordlen));
 
   // Read back the HMAC configuration and compare to the expected configuration.
   HARDENED_CHECK_EQ(abs_mmio_read32(kHmacBaseAddr + HMAC_CFG_REG_OFFSET),
@@ -835,7 +821,10 @@ status_t hmac_final(hmac_ctx_t *ctx, uint32_t *digest) {
 
   // Wait for HMAC to be done, then read the digest.
   HARDENED_TRY(hmac_idle_wait());
-  digest_read(digest, ctx->digest_wordlen);
+  // Copy the digest result from HMAC HWIP to given `digest` buffer.
+  HARDENED_TRY(hardened_memcpy(
+      digest, (const uint32_t *)(kHmacBaseAddr + HMAC_DIGEST_0_REG_OFFSET),
+      ctx->digest_wordlen));
 
   // Destroy sensitive values in the ctx object.
   HARDENED_TRY(hmac_context_wipe(ctx));


### PR DESCRIPTION
The hardened_memcpy function has two advantages over the read_digest function.
- It returns a status variable allowing our control flow integrity to clamp to it.
- It randomizes the read digest value which gives improved protection for SCA and FI. We can remove the static function and use the existing hardened one.