### PR TITLE
[earlgrey,dv] Remove bogus dbg device from TopEarlgrey

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -6505,10 +6505,6 @@
         {
           hart: 0x41200000
         }
-        dbg:
-        {
-          hart: 0x00001000
-        }
       }
       generate_dif: false
       clock_connections:

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -835,7 +835,6 @@
       base_addrs: {
         mem:  {hart: "0x00010000"},
         regs: {hart: "0x41200000"},
-        dbg:  {hart: "0x00001000"},  // Not used in Earlgrey
       },
       generate_dif: "False"
     },

--- a/hw/top_earlgrey/doc/memory_map.md
+++ b/hw/top_earlgrey/doc/memory_map.md
@@ -47,7 +47,6 @@ The main address space, shared between the CPU and DM
 | flash_ctrl        | prim        | `0x41008000`   | `0x80`         | `0x20`         | prim device on flash_ctrl        |
 | rv_dm             | regs        | `0x41200000`   | `0x10`         | `0x4`          | regs device on rv_dm             |
 | rv_dm             | mem         | `0x10000`      | `0x1000`       | `0x400`        | mem device on rv_dm              |
-| rv_dm             | dbg         | `0x1000`       | `0x200`        | `0x80`         | dbg device on rv_dm              |
 | rv_plic           | default     | `0x48000000`   | `0x8000000`    | `0x2000000`    | rv_plic                          |
 | aes               | default     | `0x41100000`   | `0x100`        | `0x40`         | aes                              |
 | hmac              | default     | `0x41110000`   | `0x2000`       | `0x800`        | hmac                             |

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
@@ -340,16 +340,6 @@ package top_earlgrey_pkg;
   parameter int unsigned TOP_EARLGREY_RV_DM_MEM_SIZE_BYTES = 32'h1000;
 
   /**
-   * Peripheral base address for dbg device on rv_dm in top earlgrey.
-   */
-  parameter int unsigned TOP_EARLGREY_RV_DM_DBG_BASE_ADDR = 32'h1000;
-
-  /**
-   * Peripheral size in bytes for dbg device on rv_dm in top earlgrey.
-   */
-  parameter int unsigned TOP_EARLGREY_RV_DM_DBG_SIZE_BYTES = 32'h200;
-
-  /**
    * Peripheral base address for rv_plic in top earlgrey.
    */
   parameter int unsigned TOP_EARLGREY_RV_PLIC_BASE_ADDR = 32'h48000000;

--- a/hw/top_earlgrey/sw/autogen/chip/top_earlgrey.rs
+++ b/hw/top_earlgrey/sw/autogen/chip/top_earlgrey.rs
@@ -483,20 +483,6 @@ pub const RV_DM_MEM_BASE_ADDR: usize = 0x10000;
 /// `RV_DM_MEM_BASE_ADDR + RV_DM_MEM_SIZE_BYTES`.
 pub const RV_DM_MEM_SIZE_BYTES: usize = 0x1000;
 
-/// Peripheral base address for dbg device on rv_dm in top earlgrey.
-///
-/// This should be used with #mmio_region_from_addr to access the memory-mapped
-/// registers associated with the peripheral (usually via a DIF).
-pub const RV_DM_DBG_BASE_ADDR: usize = 0x1000;
-
-/// Peripheral size for dbg device on rv_dm in top earlgrey.
-///
-/// This is the size (in bytes) of the peripheral's reserved memory area. All
-/// memory-mapped registers associated with this peripheral should have an
-/// address between #RV_DM_DBG_BASE_ADDR and
-/// `RV_DM_DBG_BASE_ADDR + RV_DM_DBG_SIZE_BYTES`.
-pub const RV_DM_DBG_SIZE_BYTES: usize = 0x200;
-
 /// Peripheral base address for rv_plic in top earlgrey.
 ///
 /// This should be used with #mmio_region_from_addr to access the memory-mapped

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -625,24 +625,6 @@ extern "C" {
 #define TOP_EARLGREY_RV_DM_MEM_SIZE_BYTES 0x1000u
 
 /**
- * Peripheral base address for dbg device on rv_dm in top earlgrey.
- *
- * This should be used with #mmio_region_from_addr to access the memory-mapped
- * registers associated with the peripheral (usually via a DIF).
- */
-#define TOP_EARLGREY_RV_DM_DBG_BASE_ADDR 0x1000u
-
-/**
- * Peripheral size for dbg device on rv_dm in top earlgrey.
- *
- * This is the size (in bytes) of the peripheral's reserved memory area. All
- * memory-mapped registers associated with this peripheral should have an
- * address between #TOP_EARLGREY_RV_DM_DBG_BASE_ADDR and
- * `TOP_EARLGREY_RV_DM_DBG_BASE_ADDR + TOP_EARLGREY_RV_DM_DBG_SIZE_BYTES`.
- */
-#define TOP_EARLGREY_RV_DM_DBG_SIZE_BYTES 0x200u
-
-/**
  * Peripheral base address for rv_plic in top earlgrey.
  *
  * This should be used with #mmio_region_from_addr to access the memory-mapped

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h
@@ -628,23 +628,6 @@
  */
 #define TOP_EARLGREY_RV_DM_MEM_SIZE_BYTES 0x1000
 /**
- * Peripheral base address for dbg device on rv_dm in top earlgrey.
- *
- * This should be used with #mmio_region_from_addr to access the memory-mapped
- * registers associated with the peripheral (usually via a DIF).
- */
-#define TOP_EARLGREY_RV_DM_DBG_BASE_ADDR 0x1000
-
-/**
- * Peripheral size for dbg device on rv_dm in top earlgrey.
- *
- * This is the size (in bytes) of the peripheral's reserved memory area. All
- * memory-mapped registers associated with this peripheral should have an
- * address between #TOP_EARLGREY_RV_DM_DBG_BASE_ADDR and
- * `TOP_EARLGREY_RV_DM_DBG_BASE_ADDR + TOP_EARLGREY_RV_DM_DBG_SIZE_BYTES`.
- */
-#define TOP_EARLGREY_RV_DM_DBG_SIZE_BYTES 0x200
-/**
  * Peripheral base address for rv_plic in top earlgrey.
  *
  * This should be used with #mmio_region_from_addr to access the memory-mapped


### PR DESCRIPTION
This is analogous to the commit that removes a nonexistent dmi device from lc_ctrl, but it's a much simpler commit, because all the engineering work is in that one. The only manual change in this commit is deleting a line from top_earlgrey.hjson.
