### PR TITLE
[doc] Add V2S scoping to V2 checklist

### DIFF
--- a/doc/project_governance/checklist/README.md
+++ b/doc/project_governance/checklist/README.md
@@ -514,9 +514,13 @@ The DV document and testplan are complete and have been reviewed by key stakehol
 This review will focus on the design deltas captured in the testplan since the last review.
 In addition, the fully implemented functional coverage plan, the observed coverage and the coverage exclusions are expected to be scrutinized to ensure there are no verification holes or any gaps in achieving the required verification quality, before the work towards progressing to V3 can commence.
 
-### V3_CHECKLIST_SCOPED
+### V2S_CHECKLIST_SCOPED
 
-The V3 checklist has been reviewed to understand the scope and estimate effort.
+The V2S checklist has been reviewed to understand the scope and estimate effort.
+
+### V3_FUNCTIONAL_CHECKLIST_SCOPED
+
+The functional verification parts of the V3 checklist have been reviewed to understand the scope and estimate effort.
 
 ## V2S
 
@@ -561,6 +565,10 @@ The security countermeasures testplan and the overall DV effort has been reviewe
 - Security architect (optional)
 
 This review may be waived if not deemed necessary.
+
+### V3_CHECKLIST_SCOPED
+
+The V3 checklist has been reviewed to understand the scope and estimate full V3 effort, building on the scoping already done as part of V2 signoff.
 
 ## V3
 

--- a/util/uvmdvgen/checklist.md.tpl
+++ b/util/uvmdvgen/checklist.md.tpl
@@ -201,7 +201,8 @@ Integration   | [PRE_VERIFIED_SUB_MODULES_V2][]         | Not Started |
 Issues        | [NO_HIGH_PRIORITY_ISSUES_PENDING][]     | Not Started |
 Issues        | [ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED][] | Not Started |
 Review        | [DV_DOC_TESTPLAN_REVIEWED][]            | Not Started |
-Review        | [V3_CHECKLIST_SCOPED][]                 | Not Started |
+Review        | [V2S_CHECKLIST_SCOPED][]                | Not Started |
+Review        | [V3_FUNCTIONAL_CHECKLIST_SCOPED][]      | Not Started |
 
 [DESIGN_DELTAS_CAPTURED_V2]:          /doc/project_governance/checklist/README.md#design_deltas_captured_v2
 [DV_DOC_COMPLETED]:                   /doc/project_governance/checklist/README.md#dv_doc_completed
@@ -222,7 +223,8 @@ Review        | [V3_CHECKLIST_SCOPED][]                 | Not Started |
 [NO_HIGH_PRIORITY_ISSUES_PENDING]:    /doc/project_governance/checklist/README.md#no_high_priority_issues_pending
 [ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED]:/doc/project_governance/checklist/README.md#all_low_priority_issues_root_caused
 [DV_DOC_TESTPLAN_REVIEWED]:           /doc/project_governance/checklist/README.md#dv_doc_testplan_reviewed
-[V3_CHECKLIST_SCOPED]:                /doc/project_governance/checklist/README.md#v3_checklist_scoped
+[V2S_CHECKLIST_SCOPED]:               /doc/project_governance/checklist/README.md#v2s_checklist_scoped
+[V3_FUNCTIONAL_CHECKLIST_SCOPED]:     /doc/project_governance/checklist/README.md#v3_functional_checklist_scoped
 
 <%text>### V2S</%text>
 
@@ -233,12 +235,14 @@ Tests         | [FPV_SEC_CM_VERIFIED][]                 | Not Started |
 Tests         | [SIM_SEC_CM_VERIFIED][]                 | Not Started |
 Coverage      | [SIM_COVERAGE_REVIEWED][]               | Not Started |
 Review        | [SEC_CM_DV_REVIEWED][]                  | Not Started |
+Review        | [V3_CHECKLIST_SCOPED][]                 | Not Started |
 
 [SEC_CM_TESTPLAN_COMPLETED]:          /doc/project_governance/checklist/README.md#sec_cm_testplan_completed
 [FPV_SEC_CM_VERIFIED]:                /doc/project_governance/checklist/README.md#fpv_sec_cm_verified
 [SIM_SEC_CM_VERIFIED]:                /doc/project_governance/checklist/README.md#sim_sec_cm_verified
 [SIM_COVERAGE_REVIEWED]:              /doc/project_governance/checklist/README.md#sim_coverage_reviewed
 [SEC_CM_DV_REVIEWED]:                 /doc/project_governance/checklist/README.md#sec_cm_dv_reviewed
+[V3_CHECKLIST_SCOPED]:                /doc/project_governance/checklist/README.md#v3_checklist_scoped
 
 <%text>### V3</%text>
 


### PR DESCRIPTION
The existing V2 checklist had an item (V3_CHECKLIST_SCOPED) to understand scope and estimate effort for V3. We added the V2S development stage since that was defined, and we're definitely going to need to estimate effort for that at some point!

Add the task to the V2 checklist accordingly. It will be a reasonably quick job for most blocks.

*It appears that I made this tidy-up locally last June and forgot that it was on my "work branch". Let's land the PR before I forget again...*