### PR TITLE
[alert,fpv] Strengthen AlertHs_A in prim_alert_rxtx_assert_fpv

### DIFF
--- a/hw/ip/prim/fpv/vip/prim_alert_rxtx_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_alert_rxtx_assert_fpv.sv
@@ -73,12 +73,15 @@ module prim_alert_rxtx_assert_fpv
       (prim_alert_rxtx_tb.i_prim_alert_receiver.state_q ==
       prim_alert_rxtx_tb.i_prim_alert_receiver.Idle) |=> FullHandshake_S,
       clk_i, !rst_ni || error_present || mubi4_test_true_strict(init_trig_i))
+
+  // If there is an alert request when both sides are in an idle state, then there will be an alert
+  // handshake which will finish with alert_ack_o being true.
   `ASSERT(AlertHs_A, alert_req_i &&
       (prim_alert_rxtx_tb.i_prim_alert_sender.state_q ==
       prim_alert_rxtx_tb.i_prim_alert_sender.Idle) &&
       (prim_alert_rxtx_tb.i_prim_alert_receiver.state_q ==
       prim_alert_rxtx_tb.i_prim_alert_receiver.Idle) |=>
-      FullHandshake_S |-> alert_ack_o,
+      FullHandshake_S ##0 alert_ack_o,
       clk_i, !rst_ni || error_present || mubi4_test_true_strict(init_trig_i))
   `ASSERT(AlertTestHs_A, alert_test_i &&
       (prim_alert_rxtx_tb.i_prim_alert_sender.state_q ==


### PR DESCRIPTION
Before this commit, the property in the AlertHs_A assertion looked something like
```
  alert_req_i && both_idle |=> FullHandshake_S |-> alert_ack_o
```
Noting that `|->` and `|=>` are right-associative, this means

> "Suppose there's an alert request when both are idle. Then any full
   handshake that starts on the following cycle will end with
   `alert_ack_o` being high"

That seems rather weak! I think the author intended it to say that there would be a full handshake and that handshake would end with `alert_ack_o` being high.

With the rewording in the commit, this becomes:

> "Suppose there's an alert request when both are idle. Then a full
  handshake will start on the following cycle, finishing with with
  `alert_ack_o` being high"