### PR TITLE
[otbn/hw] Add HPC gadgets to prims

### DIFF
--- a/hw/ip/otbn/pre_sca/alma/README.md
+++ b/hw/ip/otbn/pre_sca/alma/README.md
@@ -213,3 +213,87 @@ Run the following command to see the circuit diagramm if there is a leakage:
    ```sh
    xdot tmp/dbg-circuit-0.dot
    ```
+
+## Formally verifying the HPC Gadgets used in the OTBN core
+
+After completing the prerequisites above, source the build constants, activate the Alma virtual
+environment and run `verify_sec_add.sh` with the desired gadget:
+
+```sh
+cd ${REPO_TOP}
+source util/build_consts.sh
+cd ~/alma
+source dev/bin/activate
+${REPO_TOP}/hw/ip/otbn/pre_sca/alma/verify_sec_add.sh <gadget>
+```
+
+where `<gadget>` is one of `hpc2`, `hpc2o`, `hpc3`, or `hpc3o`.
+The script runs all steps (parse, label, trace, verify) automatically, using the synthesized
+netlist from `syn_out/latest/generated/`.
+
+A passing verification produces output similar to the following (shown for `hpc3`):
+
+```sh
+Verifying prim_hpc3_sca_wrapper using Alma
+Starting yosys synthesis...
+| CircuitGraph | Total:   35 | Linear:    6 | Non-linear:    4 | Registers:    6 | Mux:    6 |
+parse.py successful (1.62s)
+1: Running verilator on given netlist
+2: Compiling verilated netlist library
+3: Compiling provided verilator testbench
+4: Simulating circuit and generating VCD
+| CircuitGraph | Total:   35 | Linear:    6 | Non-linear:    4 | Registers:    6 | Mux:    6 |
+Building formula for cycle 0: vars 0 clauses 0
+Checking cycle 0:
+Building formula for cycle 1: vars 0 clauses 0
+Checking cycle 1:
+Building formula for cycle 2: vars 114 clauses 178
+Checking cycle 2:
+Checking probe (cycle 2, xor sum_o[0]): 0.00
+Checking probe (cycle 2, xor sum_o[1]): 0.00
+...
+Finished in 0.01
+The execution is secure
+```
+
+For `hpc2`, Alma reports a leak due to false positives.
+Alma's verification approach based on approximated Fourier coefficients is sound but not complete,
+meaning it can report leaks that do not exist in practice (see [Gigerl et al.](https://tugraz.elsevierpure.com/ws/portalfiles/portal/50728519/camera_ready.pdf)).
+The output looks as follows:
+
+```sh
+Verifying prim_hpc2_sca_wrapper using Alma
+Starting yosys synthesis...
+| CircuitGraph | Total:   51 | Linear:    6 | Non-linear:    6 | Registers:   14 | Mux:   11 |
+parse.py successful (1.40s)
+1: Running verilator on given netlist
+2: Compiling verilated netlist library
+3: Compiling provided verilator testbench
+4: Simulating circuit and generating VCD
+| CircuitGraph | Total:   51 | Linear:    6 | Non-linear:    6 | Registers:   14 | Mux:   11 |
+Building formula for cycle 0: vars 0 clauses 0
+Checking cycle 0:
+Building formula for cycle 1: vars 0 clauses 0
+Checking cycle 1:
+Building formula for cycle 2: vars 78 clauses 81
+Checking cycle 2:
+Building formula for cycle 3: vars 165 clauses 233
+Checking cycle 3:
+Checking probe (cycle 3, xor sum_o[0]): 0.00
+Finished in 0.01
+The execution is not secure, here are some leaks:
+leak 0: (cycle: 3, cell: xor sum_o[0], id: 10)
+3 stable xor sum_o[0] vars   : ['s1:0', 's1:1']
+3 stable xor sum_o[0] signals: share0_i[1] ^ share1_i[1]
+3 trans  xor sum_o[0] vars   : ['s1:0', 's1:1']
+3 trans  xor sum_o[0] signals: share0_i[1] ^ share1_i[1]
+```
+
+The design can still be verified using PROLEAD, where the leakage analysis passes successfully.
+For this, please follow the [PROLEAD README](../prolead/README.md).
+
+If a leak is found, generate a PNG of the leaking circuit with:
+
+```sh
+xdot ./tmp/dbg-circuit-0.dot
+```

--- a/hw/ip/otbn/pre_sca/alma/cpp/testbench.h
+++ b/hw/ip/otbn/pre_sca/alma/cpp/testbench.h
@@ -1,0 +1,73 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Copyright IAIK.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_HW_IP_OTBN_PRE_SCA_ALMA_CPP_TESTBENCH_H_
+#define OPENTITAN_HW_IP_OTBN_PRE_SCA_ALMA_CPP_TESTBENCH_H_
+
+#include "verilated.h"
+#include "verilated_vcd_c.h"
+
+template <class Module>
+struct Testbench {
+  unsigned long m_tickcount;
+  Module m_core;
+  VerilatedVcdC *m_trace = NULL;
+
+  Testbench() {
+    Verilated::traceEverOn(true);
+    m_tickcount = 0ul;
+  }
+
+  ~Testbench() { closetrace(); }
+
+  void opentrace(const char *vcdname) {
+    if (!m_trace) {
+      m_trace = new VerilatedVcdC;
+      m_core.trace(m_trace, 99);
+      m_trace->open(vcdname);
+    }
+  }
+
+  void closetrace() {
+    if (m_trace) {
+      m_trace->close();
+      delete m_trace;
+      m_trace = NULL;
+    }
+  }
+
+  void reset() {
+    m_core.rst_ni = 0;
+    this->tick();
+    this->tick();
+    m_core.rst_ni = 1;
+  }
+
+  void tick() {
+    // Falling edge
+    m_core.clk_i = 0;
+    m_core.eval();
+    if (m_trace)
+      m_trace->dump(20 * m_tickcount);
+
+    // Rising edge
+    m_core.clk_i = 1;
+    m_core.eval();
+    if (m_trace)
+      m_trace->dump(20 * m_tickcount + 10);
+
+    // Falling edge settle eval
+    m_core.clk_i = 0;
+    m_core.eval();
+
+    if (m_trace)
+      m_trace->flush();
+    m_tickcount++;
+  }
+
+  bool done() { return Verilated::gotFinish(); }
+};
+
+#endif  // OPENTITAN_HW_IP_OTBN_PRE_SCA_ALMA_CPP_TESTBENCH_H_

--- a/hw/ip/otbn/pre_sca/alma/cpp/verilator_tb_hpc_gadget_impl.h
+++ b/hw/ip/otbn/pre_sca/alma/cpp/verilator_tb_hpc_gadget_impl.h
@@ -1,0 +1,48 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Copyright IAIK.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_HW_IP_OTBN_PRE_SCA_ALMA_CPP_VERILATOR_TB_HPC_GADGET_IMPL_H_
+#define OPENTITAN_HW_IP_OTBN_PRE_SCA_ALMA_CPP_VERILATOR_TB_HPC_GADGET_IMPL_H_
+
+// Shared testbench implementation for HPC gadget Alma verification.
+// Include this file after defining HPC_RAND_MASK.
+
+#define HPC_SHARE0 0x2
+#define HPC_SHARE1 0x3
+
+#include <random>
+#include <stdio.h>
+
+#include "Vcircuit.h"
+#include "testbench.h"
+
+int main(int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Testbench<Vcircuit> tb;
+  tb.opentrace("tmp.vcd");
+
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<uint32_t> dis(0, 0xFFFFFFFF);
+
+  tb.reset();
+
+  tb.m_core.rand_i = dis(gen) & HPC_RAND_MASK;
+  tb.m_core.share0_i = HPC_SHARE0;
+  tb.m_core.share1_i = HPC_SHARE1;
+  tb.m_core.en_i = 0x0;
+  tb.tick();
+
+  tb.m_core.en_i = 0x1;
+  for (int i = 0; i < 7; i++) {
+    tb.tick();
+    tb.m_core.en_i = 0x0;
+  }
+
+  tb.closetrace();
+  return 0;
+}
+
+#endif  // OPENTITAN_HW_IP_OTBN_PRE_SCA_ALMA_CPP_VERILATOR_TB_HPC_GADGET_IMPL_H_

--- a/hw/ip/otbn/pre_sca/alma/cpp/verilator_tb_prim_hpc2_sca_wrapper.cpp
+++ b/hw/ip/otbn/pre_sca/alma/cpp/verilator_tb_prim_hpc2_sca_wrapper.cpp
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define HPC_RAND_MASK 0x1
+#include "verilator_tb_hpc_gadget_impl.h"

--- a/hw/ip/otbn/pre_sca/alma/cpp/verilator_tb_prim_hpc2o_sca_wrapper.cpp
+++ b/hw/ip/otbn/pre_sca/alma/cpp/verilator_tb_prim_hpc2o_sca_wrapper.cpp
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define HPC_RAND_MASK 0x1
+#include "verilator_tb_hpc_gadget_impl.h"

--- a/hw/ip/otbn/pre_sca/alma/cpp/verilator_tb_prim_hpc3_sca_wrapper.cpp
+++ b/hw/ip/otbn/pre_sca/alma/cpp/verilator_tb_prim_hpc3_sca_wrapper.cpp
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define HPC_RAND_MASK 0x3
+#include "verilator_tb_hpc_gadget_impl.h"

--- a/hw/ip/otbn/pre_sca/alma/cpp/verilator_tb_prim_hpc3o_sca_wrapper.cpp
+++ b/hw/ip/otbn/pre_sca/alma/cpp/verilator_tb_prim_hpc3o_sca_wrapper.cpp
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define HPC_RAND_MASK 0x3
+#include "verilator_tb_hpc_gadget_impl.h"

--- a/hw/ip/otbn/pre_sca/alma/verify_sec_add.sh
+++ b/hw/ip/otbn/pre_sca/alma/verify_sec_add.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Script to formally verify the masking of the SEC_ADD unit using Alma.
+
+set -e
+
+# Argument parsing
+TARGET_TYPE="${1:-mask_accelerator}"
+case "$TARGET_TYPE" in
+  hpc2)    export TOP_MODULE=prim_hpc2_sca_wrapper ;;
+  hpc2o)   export TOP_MODULE=prim_hpc2o_sca_wrapper ;;
+  hpc3)    export TOP_MODULE=prim_hpc3_sca_wrapper ;;
+  hpc3o)   export TOP_MODULE=prim_hpc3o_sca_wrapper ;;
+  *)       export TOP_MODULE=prim_hpc3o_sca_wrapper ;;
+esac
+
+TESTBENCH=${TOP_MODULE}
+
+echo "Verifying ${TOP_MODULE} using Alma"
+
+# Parse
+./parse.py --top-module ${TOP_MODULE} \
+--source ${REPO_TOP}/hw/ip/otbn/pre_syn/syn_out/latest/generated/${TOP_MODULE}.alma.v \
+--netlist tmp/circuit.v --log-yosys
+
+# Label
+sed -i 's/\(share0_i\s\[\)\([0-9]\+:0\)\(\]\s=\s\)unimportant/\1\2\3secret \2/g' tmp/labels.txt
+sed -i 's/\(share1_i\s\[\)\([0-9]\+:0\)\(\]\s=\s\)unimportant/\1\2\3secret \2/g' tmp/labels.txt
+sed -i 's/\(rand_i\(\s\[[0-9]\+:0\]\)\?\s=\s\)unimportant/\1random/g' tmp/labels.txt
+
+# Trace
+./trace.py --testbench ${REPO_TOP}/hw/ip/otbn/pre_sca/alma/cpp/verilator_tb_${TESTBENCH}.cpp \
+  --netlist tmp/circuit.v --c-compiler gcc -o tmp/circuit
+
+# Verify
+./verify.py --json tmp/circuit.json \
+  --label tmp/labels.txt \
+  --top-module ${TOP_MODULE} \
+  --vcd tmp/tmp.vcd \
+  --rst-name rst_ni --rst-phase 0 \
+  --probe-duration once \
+  --mode transient \
+  --glitch-behavior strict \
+  --cycles 7

--- a/hw/ip/otbn/pre_sca/prolead/README.md
+++ b/hw/ip/otbn/pre_sca/prolead/README.md
@@ -1,0 +1,87 @@
+# OTBN Masking Leakage Analysis Using PROLEAD
+
+This directory contains support files to perform leakage analysis on OTBN gadget implementations using [PROLEAD](https://github.com/ChairImpSec/PROLEAD), a probing-based leakage detection tool.
+
+
+## Prerequisites
+
+1. Clone the PROLEAD repository and check out the tested commit.
+   ```sh
+   git clone https://github.com/ChairImpSec/PROLEAD.git
+   cd PROLEAD
+   git checkout 5a433b10
+   ```
+
+1. If you are using nix-shell as your development environment, set it up as following:
+   Build the tool inside its Nix development shell.
+   ```sh
+   nix-shell
+   make release
+   ```
+   If you would like to set up PROLEAD differently, please refer to the README in the PROLEAD repository.
+
+1. If `nix-shell` fails to find packages, update the Nix channel metadata first.
+   ```sh
+   nix-channel --update
+   ```
+   Then re-run `nix-shell` and `make release`.
+
+1. Generate a gate-level netlist for the gadget under test using the synthesis flow from the OpenTitan repository.
+   From the OpenTitan top level, run
+   ```sh
+   cd hw/ip/otbn/pre_syn
+   ```
+   Set up the synthesis flow as described in the README in the pre_syn folder, then run
+   ```sh
+   ./syn_yosys_sec_add.sh <gadget>
+   ```
+   Supported gadgets are: `hpc2`, `hpc2o`, `hpc3`, `hpc3o`.
+
+
+## Running the leakage analysis
+
+After building PROLEAD and synthesizing the target gadget:
+
+1. Source the `build_consts.sh` script from the OpenTitan repository to set up the required shell variables.
+   ```sh
+   source ${REPO_TOP}/util/build_consts.sh
+   ```
+
+1. Change to this directory.
+   ```sh
+   cd ${REPO_TOP}/hw/ip/otbn/pre_sca/prolead
+   ```
+
+1. Launch the analysis script, passing the name of the gadget to evaluate.
+   ```sh
+   ./evaluate.sh <gadget>
+   ```
+   The default (no argument) runs the full `mask_accelerator` wrapper.
+
+   Results are written to `out/<gadget>_<timestamp>/` and a symlink `out/latest` points to the most recent run.
+
+   A successful run produces output similar to the following (shown for `hpc2`):
+
+   ```
+   [2026-04-30 12:26:28] Successfully validated the settings file.
+   [2026-04-30 12:26:28] Successfully read the library with name "nang45".
+   [2026-04-30 12:26:28] Successfully parsed 35 cells from the library.
+   [2026-04-30 12:26:28] Successfully read design file with topmodule "prim_hpc2_sca_wrapper"!
+   [2026-04-30 12:26:28] Successfully matched 1 fresh mask signals (for rising edge) [{rand_i}].
+   [2026-04-30 12:26:28] Successfully detected 372 possible probes in total.
+   [2026-04-30 12:26:28] Successfully initialized a univariate evaluation with 125 probing sets.
+   [2026-04-30 12:26:28] -------------------------------------------------------------------------------------------------------------------------------------
+   [2026-04-30 12:26:28] | #Standard Probes | #Extended Probes | #Probing Sets | Minimum #Probes per Set | Maximum #Probes per Set | Average #Probes per Set |
+   [2026-04-30 12:26:28] -------------------------------------------------------------------------------------------------------------------------------------
+   [2026-04-30 12:26:28] |              125 |              192 |           125 |                       2 |                       8 |                4.400000 |
+   [2026-04-30 12:26:28] -------------------------------------------------------------------------------------------------------------------------------------
+   [2026-04-30 12:26:28] -----------------------------------------------------------------------------------------------------------------------------------
+   [2026-04-30 12:26:28] | Elapsed Time |        Used Memory |          #Simulations | Probing Set with Highest Information Leakage |  -log10(p) |  Status |
+   [2026-04-30 12:26:28] -----------------------------------------------------------------------------------------------------------------------------------
+   [2026-04-30 12:26:29] |   0-00:00:01 |   0TB    0GB 104MB |         128000 / 9629 |                                      _20_(4) |   2.076636 |    OKAY |
+   ...
+   [2026-04-30 12:26:42] |   0-00:00:14 |   0TB    0GB 104MB |        1536000 / 9629 |                                      _10_(5) |   1.238617 |    OKAY |
+   ```
+
+   The `-log10(p)` column shows the statistical significance of the highest leakage observed.
+   A value consistently below 5 across all simulations indicates no detectable leakage.

--- a/hw/ip/otbn/pre_sca/prolead/evaluate.sh
+++ b/hw/ip/otbn/pre_sca/prolead/evaluate.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Script for evaluating secure gadget implementations in OTBN using PROLEAD.
+
+set -e
+
+case "$1" in
+  hpc2)
+    TOP_MODULE=prim_hpc2_sca_wrapper
+    ;;
+  hpc2o)
+    TOP_MODULE=prim_hpc2o_sca_wrapper
+    ;;
+  hpc3)
+    TOP_MODULE=prim_hpc3_sca_wrapper
+    ;;
+  hpc3o)
+    TOP_MODULE=prim_hpc3o_sca_wrapper
+    ;;
+  *)
+    # Default case.
+    TOP_MODULE=prim_hpc3o_sca_wrapper
+    ;;
+esac
+if [[ "$#" -gt 1 ]]; then
+  NETLIST_DIR=$2
+else
+  NETLIST_DIR="${REPO_TOP}/hw/ip/otbn/pre_syn/syn_out/latest/generated"
+fi
+
+perl -i -pe "s/(\d+)'h0+/ join(', ', ('1\\'b0') x \$1) /ge" ${NETLIST_DIR}/${TOP_MODULE}_netlist.v
+
+# Create results directory.
+OUT_DIR_PREFIX="out/${TOP_MODULE}"
+OUT_DIR=$(date +"${OUT_DIR_PREFIX}_%Y_%m_%d_%H_%M_%S")
+mkdir -p ${OUT_DIR}
+rm -f out/latest
+ln -s "${OUT_DIR#out/}" out/latest
+
+CONFIG_SRC=${REPO_TOP}/hw/ip/otbn/pre_sca/prolead/server_config_${TOP_MODULE}.json
+echo ${CONFIG_SRC}
+
+# Strip the _comment key (PROLEAD validates all JSON keys strictly).
+CONFIG_TMP=$(mktemp --suffix=.json)
+jq 'del(._comment)' "${CONFIG_SRC}" > "${CONFIG_TMP}"
+
+# Launch the tool.
+PROLEAD -l ${REPO_TOP}/hw/ip/otbn/pre_sca/prolead/nang45.json \
+        -n nang45 \
+        -d ${NETLIST_DIR}/${TOP_MODULE}_netlist.v \
+        -m ${TOP_MODULE} \
+        -rf ${OUT_DIR} \
+        -c "${CONFIG_TMP}"
+rm -f "${CONFIG_TMP}"

--- a/hw/ip/otbn/pre_sca/prolead/server_config_prim_hpc2_sca_wrapper.json
+++ b/hw/ip/otbn/pre_sca/prolead/server_config_prim_hpc2_sca_wrapper.json
@@ -1,0 +1,111 @@
+{
+  "_comment": "Copyright lowRISC contributors (OpenTitan project). Licensed under the Apache License, Version 2.0, see LICENSE for details. SPDX-License-Identifier: Apache-2.0",
+  "performance": {
+    "max_number_of_threads": "half",
+    "minimize_probing_sets": "aggressive"
+  },
+  "simulation": {
+    "groups": [
+      "2'h$",
+      "2'h0"
+    ],
+    "number_of_clock_cycles": 7,
+    "always_random_inputs": [
+      "rand_i"
+    ],
+    "input_sequence": [
+      {
+        "signals": [
+          {
+            "name": "share0_i[1:0]",
+            "value": "2'h0"
+          },
+          {
+            "name": "share1_i[1:0]",
+            "value": "2'h0"
+          },
+          {
+            "name": "en_i",
+            "value": "1'b0"
+          },
+          {
+            "name": "rst_ni",
+            "value": "1'b1"
+          }
+        ]
+      },
+      {
+        "signals": [
+          {
+            "name": "share0_i[1:0]",
+            "value": "2'h0"
+          },
+          {
+            "name": "share1_i[1:0]",
+            "value": "2'h0"
+          },
+          {
+            "name": "en_i",
+            "value": "1'b0"
+          },
+          {
+            "name": "rst_ni",
+            "value": "1'b0"
+          }
+        ]
+      },
+      {
+        "signals": [
+          {
+            "name": "share0_i[1:0]",
+            "value": "group_in0[1:0]"
+          },
+          {
+            "name": "share1_i[1:0]",
+            "value": "group_in1[1:0]"
+          },
+          {
+            "name": "en_i",
+            "value": "1'b1"
+          },
+          {
+            "name": "rst_ni",
+            "value": "1'b1"
+          }
+        ]
+      },
+      {
+        "signals": [
+          {
+            "name": "share0_i[1:0]",
+            "value": "2'h0"
+          },
+          {
+            "name": "share1_i[1:0]",
+            "value": "2'h0"
+          },
+          {
+            "name": "en_i",
+            "value": "1'b0"
+          },
+          {
+            "name": "rst_ni",
+            "value": "1'b1"
+          }
+        ]
+      }
+    ],
+    "number_of_simulations": 1536000,
+    "number_of_simulations_per_step": 128000
+  },
+  "hardware": {
+    "clock_signal_name": "clk_i"
+  },
+  "side_channel_analysis": {
+    "order": 1,
+    "transitional_leakage": true,
+    "clock_cycles": [
+        "3-7"
+    ]
+  }
+}

--- a/hw/ip/otbn/pre_sca/prolead/server_config_prim_hpc2o_sca_wrapper.json
+++ b/hw/ip/otbn/pre_sca/prolead/server_config_prim_hpc2o_sca_wrapper.json
@@ -1,0 +1,111 @@
+{
+  "_comment": "Copyright lowRISC contributors (OpenTitan project). Licensed under the Apache License, Version 2.0, see LICENSE for details. SPDX-License-Identifier: Apache-2.0",
+  "performance": {
+    "max_number_of_threads": "half",
+    "minimize_probing_sets": "aggressive"
+  },
+  "simulation": {
+    "groups": [
+      "3'h$",
+      "3'h0"
+    ],
+    "number_of_clock_cycles": 7,
+    "always_random_inputs": [
+      "rand_i"
+    ],
+    "input_sequence": [
+      {
+        "signals": [
+          {
+            "name": "share0_i[2:0]",
+            "value": "3'h0"
+          },
+          {
+            "name": "share1_i[2:0]",
+            "value": "3'h0"
+          },
+          {
+            "name": "en_i",
+            "value": "1'b0"
+          },
+          {
+            "name": "rst_ni",
+            "value": "1'b1"
+          }
+        ]
+      },
+      {
+        "signals": [
+          {
+            "name": "share0_i[2:0]",
+            "value": "3'h0"
+          },
+          {
+            "name": "share1_i[2:0]",
+            "value": "3'h0"
+          },
+          {
+            "name": "en_i",
+            "value": "1'b0"
+          },
+          {
+            "name": "rst_ni",
+            "value": "1'b0"
+          }
+        ]
+      },
+      {
+        "signals": [
+          {
+            "name": "share0_i[2:0]",
+            "value": "group_in0[2:0]"
+          },
+          {
+            "name": "share1_i[2:0]",
+            "value": "group_in1[2:0]"
+          },
+          {
+            "name": "en_i",
+            "value": "1'b1"
+          },
+          {
+            "name": "rst_ni",
+            "value": "1'b1"
+          }
+        ]
+      },
+      {
+        "signals": [
+          {
+            "name": "share0_i[2:0]",
+            "value": "3'h0"
+          },
+          {
+            "name": "share1_i[2:0]",
+            "value": "3'h0"
+          },
+          {
+            "name": "en_i",
+            "value": "1'b0"
+          },
+          {
+            "name": "rst_ni",
+            "value": "1'b1"
+          }
+        ]
+      }
+    ],
+    "number_of_simulations": 1536000,
+    "number_of_simulations_per_step": 128000
+  },
+  "hardware": {
+    "clock_signal_name": "clk_i"
+  },
+  "side_channel_analysis": {
+    "order": 1,
+    "transitional_leakage": true,
+    "clock_cycles": [
+        "3-7"
+    ]
+  }
+}

--- a/hw/ip/otbn/pre_sca/prolead/server_config_prim_hpc3_sca_wrapper.json
+++ b/hw/ip/otbn/pre_sca/prolead/server_config_prim_hpc3_sca_wrapper.json
@@ -1,0 +1,111 @@
+{
+  "_comment": "Copyright lowRISC contributors (OpenTitan project). Licensed under the Apache License, Version 2.0, see LICENSE for details. SPDX-License-Identifier: Apache-2.0",
+  "performance": {
+    "max_number_of_threads": "half",
+    "minimize_probing_sets": "aggressive"
+  },
+  "simulation": {
+    "groups": [
+      "2'h$",
+      "2'h0"
+    ],
+    "number_of_clock_cycles": 6,
+    "always_random_inputs": [
+      "rand_i[1:0]"
+    ],
+    "input_sequence": [
+      {
+        "signals": [
+          {
+            "name": "share0_i[1:0]",
+            "value": "2'h0"
+          },
+          {
+            "name": "share1_i[1:0]",
+            "value": "2'h0"
+          },
+          {
+            "name": "en_i",
+            "value": "1'b0"
+          },
+          {
+            "name": "rst_ni",
+            "value": "1'b1"
+          }
+        ]
+      },
+      {
+        "signals": [
+          {
+            "name": "share0_i[1:0]",
+            "value": "2'h0"
+          },
+          {
+            "name": "share1_i[1:0]",
+            "value": "2'h0"
+          },
+          {
+            "name": "en_i",
+            "value": "1'b0"
+          },
+          {
+            "name": "rst_ni",
+            "value": "1'b0"
+          }
+        ]
+      },
+      {
+        "signals": [
+          {
+            "name": "share0_i[1:0]",
+            "value": "group_in0[1:0]"
+          },
+          {
+            "name": "share1_i[1:0]",
+            "value": "group_in1[1:0]"
+          },
+          {
+            "name": "en_i",
+            "value": "1'b1"
+          },
+          {
+            "name": "rst_ni",
+            "value": "1'b1"
+          }
+        ]
+      },
+      {
+        "signals": [
+          {
+            "name": "share0_i[1:0]",
+            "value": "2'h0"
+          },
+          {
+            "name": "share1_i[1:0]",
+            "value": "2'h0"
+          },
+          {
+            "name": "en_i",
+            "value": "1'b0"
+          },
+          {
+            "name": "rst_ni",
+            "value": "1'b1"
+          }
+        ]
+      }
+    ],
+    "number_of_simulations": 1536000,
+    "number_of_simulations_per_step": 128000
+  },
+  "hardware": {
+    "clock_signal_name": "clk_i"
+  },
+  "side_channel_analysis": {
+    "order": 1,
+    "transitional_leakage": true,
+    "clock_cycles": [
+        "3-6"
+    ]
+  }
+}

--- a/hw/ip/otbn/pre_sca/prolead/server_config_prim_hpc3o_sca_wrapper.json
+++ b/hw/ip/otbn/pre_sca/prolead/server_config_prim_hpc3o_sca_wrapper.json
@@ -1,0 +1,111 @@
+{
+  "_comment": "Copyright lowRISC contributors (OpenTitan project). Licensed under the Apache License, Version 2.0, see LICENSE for details. SPDX-License-Identifier: Apache-2.0",
+  "performance": {
+    "max_number_of_threads": "half",
+    "minimize_probing_sets": "aggressive"
+  },
+  "simulation": {
+    "groups": [
+      "3'h$",
+      "3'h0"
+    ],
+    "number_of_clock_cycles": 6,
+    "always_random_inputs": [
+      "rand_i[1:0]"
+    ],
+    "input_sequence": [
+      {
+        "signals": [
+          {
+            "name": "share0_i[2:0]",
+            "value": "3'h0"
+          },
+          {
+            "name": "share1_i[2:0]",
+            "value": "3'h0"
+          },
+          {
+            "name": "en_i",
+            "value": "1'b0"
+          },
+          {
+            "name": "rst_ni",
+            "value": "1'b1"
+          }
+        ]
+      },
+      {
+        "signals": [
+          {
+            "name": "share0_i[2:0]",
+            "value": "3'h0"
+          },
+          {
+            "name": "share1_i[2:0]",
+            "value": "3'h0"
+          },
+          {
+            "name": "en_i",
+            "value": "1'b0"
+          },
+          {
+            "name": "rst_ni",
+            "value": "1'b0"
+          }
+        ]
+      },
+      {
+        "signals": [
+          {
+            "name": "share0_i[2:0]",
+            "value": "group_in0[2:0]"
+          },
+          {
+            "name": "share1_i[2:0]",
+            "value": "group_in1[2:0]"
+          },
+          {
+            "name": "en_i",
+            "value": "1'b1"
+          },
+          {
+            "name": "rst_ni",
+            "value": "1'b1"
+          }
+        ]
+      },
+      {
+        "signals": [
+          {
+            "name": "share0_i[2:0]",
+            "value": "3'h0"
+          },
+          {
+            "name": "share1_i[2:0]",
+            "value": "3'h0"
+          },
+          {
+            "name": "en_i",
+            "value": "1'b0"
+          },
+          {
+            "name": "rst_ni",
+            "value": "1'b1"
+          }
+        ]
+      }
+    ],
+    "number_of_simulations": 1536000,
+    "number_of_simulations_per_step": 128000
+  },
+  "hardware": {
+    "clock_signal_name": "clk_i"
+  },
+  "side_channel_analysis": {
+    "order": 1,
+    "transitional_leakage": true,
+    "clock_cycles": [
+        "3-6"
+    ]
+  }
+}

--- a/hw/ip/otbn/pre_sca/rtl/prim_hpc2_sca_wrapper.sv
+++ b/hw/ip/otbn/pre_sca/rtl/prim_hpc2_sca_wrapper.sv
@@ -1,0 +1,72 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Wrapper around the HPC2 AND gadget (prim_hpc2 with EnW=0) for side-channel
+// analysis. Exposes a 2-bit combined input interface: bit 0 carries input A,
+// bit 1 carries input B. Used as the top-level module for Alma and PROLEAD
+// leakage verification flows.
+
+module prim_hpc2_sca_wrapper #(
+  localparam int Width     = 2,
+  localparam int NumShares = 2
+) (
+  input clk_i,
+  input rst_ni,
+
+  input  logic en_i,
+  input  logic rand_i,
+  input  logic [Width-1:0] share0_i,
+  input  logic [Width-1:0] share1_i,
+  output logic [NumShares-1:0] sum_o
+);
+
+  logic [NumShares-1:0] a_shares;
+  logic [NumShares-1:0] b_shares;
+  logic [NumShares-1:0] sum;
+
+  // Extract shares for A and B from the combined share inputs.
+  assign a_shares[0] = share0_i[0];
+  assign a_shares[1] = share1_i[0];
+  assign b_shares[0] = share0_i[1];
+  assign b_shares[1] = share1_i[1];
+  assign sum_o = sum;
+
+  // Align x and en with HPC2's 2-cycle pipeline.
+  logic [NumShares-1:0] a_q;
+  prim_flop #(
+    .Width(NumShares),
+    .ResetValue('0)
+  ) u_prim_flop_a (
+    .clk_i (clk_i),
+    .rst_ni(rst_ni),
+    .d_i   (a_shares),
+    .q_o   (a_q)
+  );
+
+  logic en_q;
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_prim_flop_en (
+    .clk_i (clk_i),
+    .rst_ni(rst_ni),
+    .d_i   (en_i),
+    .q_o   (en_q)
+  );
+
+  prim_hpc2 #(
+    .EnW(1'b0)
+  ) u_prim_hpc2 (
+    .clk_i,
+    .rst_ni,
+    .en1_i(en_i),
+    .en2_i(en_q),
+    .x_i  (a_q),
+    .y_i  (b_shares),
+    .w_i  ('0),
+    .r_i  (rand_i),
+    .z_o  (sum)
+  );
+
+endmodule : prim_hpc2_sca_wrapper

--- a/hw/ip/otbn/pre_sca/rtl/prim_hpc2o_sca_wrapper.sv
+++ b/hw/ip/otbn/pre_sca/rtl/prim_hpc2o_sca_wrapper.sv
@@ -1,0 +1,75 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Wrapper around the HPC2o gadget (prim_hpc2 with EnW=1) for side-channel
+// analysis. Exposes a 3-bit combined input interface: bit 0 carries input A,
+// bit 1 carries input B, bit 2 carries input W. Used as the top-level module
+// for Alma and PROLEAD leakage verification flows.
+
+module prim_hpc2o_sca_wrapper #(
+  localparam int Width     = 3,
+  localparam int NumShares = 2
+) (
+  input clk_i,
+  input rst_ni,
+
+  input  logic en_i,
+  input  logic rand_i,
+  input  logic [Width-1:0] share0_i,
+  input  logic [Width-1:0] share1_i,
+  output logic [NumShares-1:0] sum_o
+);
+
+  logic [NumShares-1:0] a_shares;
+  logic [NumShares-1:0] b_shares;
+  logic [NumShares-1:0] w_shares;
+  logic [NumShares-1:0] sum;
+
+  // Extract shares for A, B, and W from the combined share inputs.
+  assign a_shares[0] = share0_i[0];
+  assign a_shares[1] = share1_i[0];
+  assign b_shares[0] = share0_i[1];
+  assign b_shares[1] = share1_i[1];
+  assign w_shares[0] = share0_i[2];
+  assign w_shares[1] = share1_i[2];
+  assign sum_o = sum;
+
+  // Align x and en with HPC2's 2-cycle pipeline.
+  logic [NumShares-1:0] a_q;
+  prim_flop #(
+    .Width(NumShares),
+    .ResetValue('0)
+  ) u_prim_flop_a (
+    .clk_i (clk_i),
+    .rst_ni(rst_ni),
+    .d_i   (a_shares),
+    .q_o   (a_q)
+  );
+
+  logic en_q;
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_prim_flop_en (
+    .clk_i (clk_i),
+    .rst_ni(rst_ni),
+    .d_i   (en_i),
+    .q_o   (en_q)
+  );
+
+  prim_hpc2 #(
+    .EnW(1'b1)
+  ) u_prim_hpc2o (
+    .clk_i,
+    .rst_ni,
+    .en1_i(en_i),
+    .en2_i(en_q),
+    .x_i  (a_q),
+    .y_i  (b_shares),
+    .w_i  (w_shares),
+    .r_i  (rand_i),
+    .z_o  (sum)
+  );
+
+endmodule : prim_hpc2o_sca_wrapper

--- a/hw/ip/otbn/pre_sca/rtl/prim_hpc3_sca_wrapper.sv
+++ b/hw/ip/otbn/pre_sca/rtl/prim_hpc3_sca_wrapper.sv
@@ -1,0 +1,50 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Wrapper around the HPC3 AND gadget (prim_hpc3 with EnW=0) for side-channel
+// analysis. Exposes a 2-bit combined input interface: bit 0 carries input A,
+// bit 1 carries input B. Uses 2-bit randomness (r and rp). Used as the
+// top-level module for Alma and PROLEAD leakage verification flows.
+
+module prim_hpc3_sca_wrapper #(
+  localparam int Width     = 2,
+  localparam int RandWidth = 2,
+  localparam int NumShares = 2
+) (
+  input clk_i,
+  input rst_ni,
+
+  input  logic                 en_i,
+  input  logic [RandWidth-1:0] rand_i,
+  input  logic [Width-1:0]     share0_i,
+  input  logic [Width-1:0]     share1_i,
+  output logic [NumShares-1:0] sum_o
+);
+
+  logic [NumShares-1:0] a_shares;
+  logic [NumShares-1:0] b_shares;
+  logic [NumShares-1:0] sum;
+
+  // Extract shares for A and B from the combined share inputs.
+  assign a_shares[0] = share0_i[0];
+  assign a_shares[1] = share1_i[0];
+  assign b_shares[0] = share0_i[1];
+  assign b_shares[1] = share1_i[1];
+  assign sum_o = sum;
+
+  prim_hpc3 #(
+    .EnW(1'b0)
+  ) u_prim_hpc3 (
+    .clk_i,
+    .rst_ni,
+    .en_i (en_i),
+    .x_i  (a_shares),
+    .y_i  (b_shares),
+    .w_i  ('0),
+    .r_i  (rand_i[0]),
+    .rp_i (rand_i[1]),
+    .z_o  (sum)
+  );
+
+endmodule : prim_hpc3_sca_wrapper

--- a/hw/ip/otbn/pre_sca/rtl/prim_hpc3o_sca_wrapper.sv
+++ b/hw/ip/otbn/pre_sca/rtl/prim_hpc3o_sca_wrapper.sv
@@ -1,0 +1,54 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Wrapper around the HPC3o gadget (prim_hpc3 with EnW=1) for side-channel
+// analysis. Exposes a 3-bit combined input interface: bit 0 carries input A,
+// bit 1 carries input B, bit 2 carries input W. Uses 2-bit randomness (r and
+// rp). Used as the top-level module for Alma and PROLEAD leakage verification
+// flows.
+
+module prim_hpc3o_sca_wrapper #(
+  localparam int Width     = 3,
+  localparam int RandWidth = 2,
+  localparam int NumShares = 2
+) (
+  input clk_i,
+  input rst_ni,
+
+  input  logic                 en_i,
+  input  logic [RandWidth-1:0] rand_i,
+  input  logic [Width-1:0]     share0_i,
+  input  logic [Width-1:0]     share1_i,
+  output logic [NumShares-1:0] sum_o
+);
+
+  logic [NumShares-1:0] a_shares;
+  logic [NumShares-1:0] b_shares;
+  logic [NumShares-1:0] w_shares;
+  logic [NumShares-1:0] sum;
+
+  // Extract shares for A, B, and W from the combined share inputs.
+  assign a_shares[0] = share0_i[0];
+  assign a_shares[1] = share1_i[0];
+  assign b_shares[0] = share0_i[1];
+  assign b_shares[1] = share1_i[1];
+  assign w_shares[0] = share0_i[2];
+  assign w_shares[1] = share1_i[2];
+  assign sum_o = sum;
+
+  prim_hpc3 #(
+    .EnW(1'b1)
+  ) u_prim_hpc3o (
+    .clk_i,
+    .rst_ni,
+    .en_i (en_i),
+    .x_i  (a_shares),
+    .y_i  (b_shares),
+    .w_i  (w_shares),
+    .r_i  (rand_i[0]),
+    .rp_i (rand_i[1]),
+    .z_o  (sum)
+  );
+
+endmodule : prim_hpc3o_sca_wrapper

--- a/hw/ip/otbn/pre_syn/syn_setup_sec_add.example.sh
+++ b/hw/ip/otbn/pre_syn/syn_setup_sec_add.example.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Setup IP name and top module.
+# When changing the top module, some parameters might not exist and
+# tcl/yosys_run_synth.tcl might need to be adjusted accordingly.
+export LR_SYNTH_IP_NAME=otbn
+
+case "$TARGET_TYPE" in
+  hpc2)        export LR_SYNTH_TOP_MODULE=prim_hpc2_sca_wrapper ;;
+  hpc2o)       export LR_SYNTH_TOP_MODULE=prim_hpc2o_sca_wrapper ;;
+  hpc3)        export LR_SYNTH_TOP_MODULE=prim_hpc3_sca_wrapper ;;
+  hpc3o)       export LR_SYNTH_TOP_MODULE=prim_hpc3o_sca_wrapper ;;
+  *)           export LR_SYNTH_TOP_MODULE=prim_hpc3o_sca_wrapper ;;
+esac
+
+# Setup cell library path.
+# Change the line below to set the path to an appropriate .lib file
+# export LR_SYNTH_CELL_LIBRARY_PATH=/path/to/NangateOpenCellLibrary_typical.lib
+export LR_SYNTH_CELL_LIBRARY_NAME=nangate
+if [ -z "$LR_SYNTH_CELL_LIBRARY_PATH" ]; then
+    echo >&2 "You forgot to set LR_SYNTH_CELL_LIBRARY_PATH!";
+    exit 1;
+fi
+if [ ! -f "$LR_SYNTH_CELL_LIBRARY_PATH" ]; then
+    echo >&2 "Cannot find cell library $LR_SYNTH_CELL_LIBRARY_PATH";
+    echo >&2 "Check your LR_SYNTH_CELL_LIBRARY_PATH variable!";
+    exit 1;
+fi
+if [ -z "$LR_SYNTH_CELL_LIBRARY_NAME" ]; then
+    echo >&2 "You forgot to set LR_SYNTH_CELL_LIBRARY_NAME!";
+    exit 1;
+fi
+
+# Control synthesis flow.
+export LR_SYNTH_TIMING_RUN=0
+export LR_SYNTH_FLATTEN=1
+
+# For timing runs, hierarchy flattening is needed.
+if [[ $LR_SYNTH_TIMING_RUN == 1 ]] && [[ $LR_SYNTH_FLATTEN == 0 ]]; then
+    echo >&2 "LR_SYNTH_TIMING_RUN requires LR_SYNTH_FLATTEN!";
+    exit 1;
+fi
+
+# Output directory
+export LR_SYNTH_OUT_DIR_PREFIX="syn_out/${LR_SYNTH_TOP_MODULE}"
+LR_SYNTH_OUT_DIR=$(date +"${LR_SYNTH_OUT_DIR_PREFIX}_%Y_%m_%d_%H_%M_%S")
+export LR_SYNTH_OUT_DIR

--- a/hw/ip/otbn/pre_syn/syn_yosys_sec_add.sh
+++ b/hw/ip/otbn/pre_syn/syn_yosys_sec_add.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script drives the experimental Yosys synthesis flow. More details can be found in README.md
+
+set -e
+set -o pipefail
+
+error () {
+    echo >&2 "$@"
+    exit 1
+}
+
+teelog () {
+    tee "$LR_SYNTH_OUT_DIR/log/$1.log"
+}
+
+if [ ! -f syn_setup_sec_add.sh ]; then
+    error "No syn_setup_sec_add.sh file: see README.md for instructions"
+fi
+
+#-------------------------------------------------------------------------
+# setup flow variables
+#-------------------------------------------------------------------------
+export TARGET_TYPE="${1:-mask_accelerator}"
+source syn_setup_sec_add.sh
+
+#-------------------------------------------------------------------------
+# prepare output folders
+#-------------------------------------------------------------------------
+mkdir -p "$LR_SYNTH_OUT_DIR/generated"
+mkdir -p "$LR_SYNTH_OUT_DIR/log"
+mkdir -p "$LR_SYNTH_OUT_DIR/reports/timing"
+
+rm -f syn_out/latest
+ln -s "${LR_SYNTH_OUT_DIR#syn_out/}" syn_out/latest
+
+#-------------------------------------------------------------------------
+# use sv2v to convert all SystemVerilog files to Verilog
+#-------------------------------------------------------------------------
+export LR_SYNTH_SRC_DIR="../../$LR_SYNTH_IP_NAME"
+
+# Get OpenTitan dependency sources.
+OT_DEP_SOURCES=(
+    "$LR_SYNTH_SRC_DIR/pre_sca/rtl/${LR_SYNTH_TOP_MODULE}.sv"
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_blanker.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_fifo_sync.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_fifo_sync_cnt.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_count.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_flop_x.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_hpc2.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_hpc3.sv
+    "$LR_SYNTH_SRC_DIR"/../prim_xilinx/rtl/prim_flop.sv
+    "$LR_SYNTH_SRC_DIR"/../prim_xilinx/rtl/prim_flop_en.sv
+    "$LR_SYNTH_SRC_DIR"/../prim_xilinx/rtl/prim_buf.sv
+    "$LR_SYNTH_SRC_DIR"/../prim_xilinx/rtl/prim_and2.sv
+    "$LR_SYNTH_SRC_DIR"/../prim_xilinx/rtl/prim_xor2.sv
+    "$LR_SYNTH_SRC_DIR"/../prim_xilinx/rtl/prim_inv.sv
+)
+
+# Get OpenTitan dependency packages.
+OT_DEP_PACKAGES=(
+    "$LR_SYNTH_SRC_DIR"/../../top_earlgrey/rtl/*_pkg.sv
+    "$LR_SYNTH_SRC_DIR"/../edn/rtl/*_pkg.sv
+    "$LR_SYNTH_SRC_DIR"/../csrng/rtl/*_pkg.sv
+    "$LR_SYNTH_SRC_DIR"/../entropy_src/rtl/*_pkg.sv
+    "$LR_SYNTH_SRC_DIR"/../lc_ctrl/rtl/*_pkg.sv
+    "$LR_SYNTH_SRC_DIR"/../tlul/rtl/*_pkg.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/*_pkg.sv
+    "$LR_SYNTH_SRC_DIR"/../prim_generic/rtl/*_pkg.sv
+    "$LR_SYNTH_SRC_DIR"/../keymgr/rtl/*_pkg.sv
+    "$LR_SYNTH_SRC_DIR"/../otp_ctrl/rtl/*_pkg.sv
+)
+
+# Convert OpenTitan dependency sources.
+for file in "${OT_DEP_SOURCES[@]}"; do
+    module=`basename -s .sv $file`
+
+    # Skip packages
+    if echo "$module" | grep -q '_pkg$'; then
+        continue
+    fi
+
+    sv2v \
+        --define=SYNTHESIS --define=SYNTHESIS_MEMORY_BLACK_BOXING --define=YOSYS \
+        "${OT_DEP_PACKAGES[@]}" \
+        "$LR_SYNTH_SRC_DIR"/rtl/*_pkg.sv \
+        -I"$LR_SYNTH_SRC_DIR"/../prim/rtl \
+        $file \
+        > "$LR_SYNTH_OUT_DIR/generated/${module}.v"
+
+    # Remove calls to $value$plusargs(). Yosys doesn't seem to support this.
+    sed -i '/$value$plusargs(.*/d' $LR_SYNTH_OUT_DIR/generated/${module}.v
+done
+
+# Get and convert core sources.
+for file in "$LR_SYNTH_SRC_DIR"/rtl/*.sv; do
+    module=`basename -s .sv $file`
+
+    # Skip packages
+    if echo "$module" | grep -q '_pkg$'; then
+        continue
+    fi
+
+    sv2v \
+        --define=SYNTHESIS \
+        "${OT_DEP_PACKAGES[@]}" \
+        "$LR_SYNTH_SRC_DIR"/rtl/*_pkg.sv \
+        -I"$LR_SYNTH_SRC_DIR"/../prim/rtl \
+        $file \
+        > "$LR_SYNTH_OUT_DIR/generated/${module}.v"
+
+done
+
+#-------------------------------------------------------------------------
+# run Yosys synthesis
+#-------------------------------------------------------------------------
+yosys -c ./tcl/yosys_run_synth_sec_add.tcl |& teelog syn || {
+    error "Failed to synthesize RTL with Yosys"
+}
+
+#-------------------------------------------------------------------------
+# run static timing analysis
+#-------------------------------------------------------------------------
+if [[ $LR_SYNTH_TIMING_RUN == 1 ]] ; then
+    sta ./tcl/sta_run_reports.tcl |& teelog sta || {
+        error "Failed to run static timing analysis"
+    }
+
+    ./translate_timing_rpts.sh
+fi
+
+#-------------------------------------------------------------------------
+# report kGE number
+#-------------------------------------------------------------------------
+python/get_kge.py $LR_SYNTH_CELL_LIBRARY_PATH $LR_SYNTH_OUT_DIR/reports/area.rpt

--- a/hw/ip/otbn/pre_syn/tcl/yosys_run_synth_sec_add.tcl
+++ b/hw/ip/otbn/pre_syn/tcl/yosys_run_synth_sec_add.tcl
@@ -1,0 +1,99 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+source ./tcl/yosys_common.tcl
+
+if { $lr_synth_flatten } {
+  set flatten_opt "-flatten"
+} else {
+  set flatten_opt ""
+}
+
+if { $lr_synth_timing_run } {
+  write_sdc_out $lr_synth_sdc_file_in $lr_synth_sdc_file_out
+}
+
+yosys "read_verilog -sv $lr_synth_out_dir/generated/*.v"
+
+# Remap Xilinx Vivado "dont_touch" attributes to Yosys "keep" attributes.
+yosys "attrmap -tocase keep -imap dont_touch=\"yes\" keep=1 -imap dont_touch=\"no\" keep=0 -remove keep=0"
+
+# Place keep_hierarchy constraints on relevant modules to prevent aggressive synthesis optimizations
+# across the boundaries of these modules.
+yosys "hierarchy -check -top $lr_synth_top_module"
+yosys "setattr -mod -set keep_hierarchy 1 *prim_and2*"
+yosys "setattr -mod -set keep_hierarchy 1 *prim_buf*"
+yosys "setattr -mod -set keep_hierarchy 1 *prim_clock*"
+yosys "setattr -mod -set keep_hierarchy 1 *prim_flop*"
+yosys "setattr -mod -set keep_hierarchy 1 *prim_xnor2*"
+yosys "setattr -mod -set keep_hierarchy 1 *prim_xor2*"
+yosys "setattr -mod -set keep_hierarchy 1 *prim_inv*"
+
+# Synthesize.
+yosys "synth -nofsm $flatten_opt -top $lr_synth_top_module"
+yosys "opt -purge"
+
+yosys "write_verilog $lr_synth_pre_map_out"
+
+# Remove keep_hierarchy constraints before writing out the netlist for Alma as it doesn't like
+# these constraints.
+yosys "setattr -mod -set keep_hierarchy 0 *prim_and2*"
+yosys "setattr -mod -set keep_hierarchy 0 *prim_buf*"
+yosys "setattr -mod -set keep_hierarchy 0 *prim_clock*"
+yosys "setattr -mod -set keep_hierarchy 0 *prim_flop*"
+yosys "setattr -mod -set keep_hierarchy 0 *prim_xnor2*"
+yosys "setattr -mod -set keep_hierarchy 0 *prim_xor2*"
+yosys "setattr -mod -set keep_hierarchy 0 *prim_inv*"
+
+yosys "write_verilog $lr_synth_alma_out"
+
+# Re-add keep_hierarchy constraints for further synthesis steps.
+yosys "setattr -mod -set keep_hierarchy 1 *prim_and2*"
+yosys "setattr -mod -set keep_hierarchy 1 *prim_buf*"
+yosys "setattr -mod -set keep_hierarchy 1 *prim_clock*"
+yosys "setattr -mod -set keep_hierarchy 1 *prim_flop*"
+yosys "setattr -mod -set keep_hierarchy 1 *prim_xnor2*"
+yosys "setattr -mod -set keep_hierarchy 1 *prim_xor2*"
+yosys "setattr -mod -set keep_hierarchy 1 *prim_inv*"
+
+yosys "dfflibmap -liberty $lr_synth_cell_library_path"
+yosys "opt"
+
+set yosys_abc_clk_period [expr $lr_synth_clk_period - $lr_synth_abc_clk_uprate]
+
+if { $lr_synth_timing_run } {
+  yosys "abc -liberty $lr_synth_cell_library_path -constr $lr_synth_abc_sdc_file_in -D $yosys_abc_clk_period"
+} else {
+  yosys "abc -liberty $lr_synth_cell_library_path"
+}
+
+# Remove keep_hierarchy constraints before the final flattening step. We're done optimizing.
+yosys "setattr -mod -set keep_hierarchy 0 *prim_and2*"
+yosys "setattr -mod -set keep_hierarchy 0 *prim_buf*"
+yosys "setattr -mod -set keep_hierarchy 0 *prim_clock*"
+yosys "setattr -mod -set keep_hierarchy 0 *prim_flop*"
+yosys "setattr -mod -set keep_hierarchy 0 *prim_xnor2*"
+yosys "setattr -mod -set keep_hierarchy 0 *prim_xor2*"
+yosys "setattr -mod -set keep_hierarchy 0 *prim_inv*"
+
+# Final flattening.
+if { $lr_synth_flatten } {
+  yosys "flatten"
+}
+
+yosys "clean -purge"
+yosys "write_verilog $lr_synth_netlist_out"
+
+if { $lr_synth_timing_run } {
+  # Produce netlist that OpenSTA can use
+  yosys "setundef -zero"
+  yosys "splitnets"
+  yosys "clean"
+  yosys "write_verilog -noattr -noexpr -nohex -nodec $lr_synth_sta_netlist_out"
+}
+
+yosys "check"
+yosys "log ======== Yosys Stat Report ========"
+yosys "tee -o $lr_synth_out_dir/reports/area.rpt stat -liberty $lr_synth_cell_library_path"
+yosys "log ====== End Yosys Stat Report ======"

--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -37,6 +37,8 @@ filesets:
       - lowrisc:prim:sha2
     files:
       - rtl/prim_clock_gating_sync.sv
+      - rtl/prim_hpc2.sv
+      - rtl/prim_hpc3.sv
       - rtl/prim_sram_arbiter.sv
       - rtl/prim_slicer.sv
       - rtl/prim_sync_reqack.sv

--- a/hw/ip/prim/rtl/prim_hpc2.sv
+++ b/hw/ip/prim/rtl/prim_hpc2.sv
@@ -1,0 +1,241 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+// Description: PINI-secure Hardware Private Circuit (HPC2) / Toffoli Gadget (HPC2o)
+//
+// This module implements a Probe-Isolating Non-Interference (PINI) secure AND gadget (HPC2) or a
+// Toffoli gadget (HPC2o), configured via the compile-time parameter `EnW`. All operands (W, X, Y)
+// and the result (Z) are represented as boolean-shared bits in `NumShares` shares.
+//
+// Compile time configurations:
+//   - EnW = 0 (HPC2)  : Computes the masked AND operation:     Z = X & Y
+//   - EnW = 1 (HPC2o) : Computes the masked Toffoli operation: Z = W ^ (X & Y)
+//
+// Pipeline & Timing Requirements:
+//   - Randomness: The gadget is fully pipelined and consumes 1 bit of fresh randomness (`r_i`) per
+//     active cycle.
+//   - Asymmetric Latency: Due to internal staging, `y_i` and `r_i` have a 2-cycle latency, whereas
+//     `x_i` and `w_i` have a 1-cycle latency. Consequently, `y_i` and `r_i` must be driven at
+//      least one cycle prior to their corresponding `x_i` and `w_i` inputs.
+//   - Stall Support: To support stallable pipelines, the `en1_i` and `en2_i` flip-flop enable
+//     signals can be safely deasserted to freeze the internal registers and halt data propagation.
+//
+// For details, see the following paper:
+// Cassiers, Gaetan, et al. "Compress: Generate small and fast masked pipelined circuits."
+// available at:
+// https://eprint.iacr.org/2023/1600.pdf
+
+module prim_hpc2 #(
+  parameter  bit          EnW = 1'b0,
+  parameter  bit          PrimFlopEn = 1'b1,
+  localparam int unsigned NumShares = 2
+) (
+  input clk_i,
+  input rst_ni,
+
+  // Pipeline stage enable signals.
+  input  logic en1_i,
+  input  logic en2_i,
+
+  // Masked data inputs.
+  input  logic [NumShares-1:0] x_i,
+  input  logic [NumShares-1:0] y_i,
+  input  logic [NumShares-1:0] w_i,
+
+  // Randomness input.
+  input  logic r_i,
+
+  // Masked data output.
+  output logic [NumShares-1:0] z_o
+);
+
+  // Stage 1 outputs.
+  logic                 r_q;
+  logic [NumShares-1:0] y_q;
+  logic [NumShares-1:0] y_masked_d;
+  logic [NumShares-1:0] y_masked_q;
+
+  // Stage 2 combinational nodes.
+  logic [NumShares-1:0] x_inv;
+  logic [NumShares-1:0] xy;            // x[Share] & y_q[Share]
+  logic [NumShares-1:0] x_inv_r_d;     // ~x[Share] & r_q
+  logic [NumShares-1:0] cross_prod_d;  // x[Share] & y_masked_q[OtherShare]
+  logic [NumShares-1:0] inner_prod_d;  // xy[Share] (^ w_i[Share] if EnW)
+
+  // Stage 2 outputs.
+  logic [NumShares-1:0] x_inv_r_q;
+  logic [NumShares-1:0] inner_prod_q;
+  logic [NumShares-1:0] cross_prod_q;
+  logic [NumShares-1:0] merge_cross;
+
+  // Stage 1: Register y, y^r, and r.
+  for (genvar Share = 0; Share < NumShares; Share++) begin : gen_y_masked
+    prim_xor2 #(
+      .Width(1)
+    ) u_prim_xor2 (
+      .in0_i(y_i[Share]),
+      .in1_i(r_i),
+      .out_o(y_masked_d[Share])
+    );
+  end
+
+  prim_flop_x #(
+    .Width(NumShares),
+    .ResetValue('0),
+    .PrimFlopEn(PrimFlopEn)
+  ) u_prim_flop_x_y_masked (
+    .clk_i (clk_i),
+    .rst_ni(rst_ni),
+    .en_i  (en1_i),
+    .d_i   (y_masked_d),
+    .q_o   (y_masked_q)
+  );
+
+  prim_flop_x #(
+    .Width(1),
+    .ResetValue('0),
+    .PrimFlopEn(PrimFlopEn)
+  ) u_prim_flop_x_r (
+    .clk_i (clk_i),
+    .rst_ni(rst_ni),
+    .en_i  (en1_i),
+    .d_i   (r_i),
+    .q_o   (r_q)
+  );
+
+  prim_flop_x #(
+    .Width(NumShares),
+    .ResetValue('0),
+    .PrimFlopEn(PrimFlopEn)
+  ) u_prim_flop_x_y (
+    .clk_i (clk_i),
+    .rst_ni(rst_ni),
+    .en_i  (en1_i),
+    .d_i   (y_i),
+    .q_o   (y_q)
+  );
+
+  // Stage 2: Compute xy_masked, x_inv_r, and cross products.
+  for (genvar Share = 0; Share < NumShares; Share++) begin : gen_xy_masked
+    prim_and2 u_prim_and2 (
+      .in0_i(x_i[Share]),
+      .in1_i(y_q[Share]),
+      .out_o(xy[Share])
+    );
+
+    prim_inv u_prim_inv (
+      .in_i (x_i[Share]),
+      .out_o(x_inv[Share])
+    );
+
+    prim_and2 u_prim_and2_x_masked (
+      .in0_i(x_inv[Share]),
+      .in1_i(r_q),
+      .out_o(x_inv_r_d[Share])
+    );
+  end
+
+  // Cross products use the opposite share's y_masked_q (OtherShare = ~Share).
+  for (genvar Share = 0; Share < NumShares; Share++) begin : gen_cross_prod
+    localparam int OtherShare = (Share == 0) ? 1 : 0;
+
+    prim_and2 u_prim_and2 (
+      .in0_i(x_i[Share]),
+      .in1_i(y_masked_q[OtherShare]),
+      .out_o(cross_prod_d[Share])
+    );
+  end
+
+  prim_flop_x #(
+    .Width(NumShares),
+    .ResetValue('0),
+    .PrimFlopEn(PrimFlopEn)
+  ) u_prim_flop_x_x_inv_r (
+    .clk_i (clk_i),
+    .rst_ni(rst_ni),
+    .en_i  (en2_i),
+    .d_i   (x_inv_r_d),
+    .q_o   (x_inv_r_q)
+  );
+
+  prim_flop_x #(
+    .Width(NumShares),
+    .ResetValue('0),
+    .PrimFlopEn(PrimFlopEn)
+  ) u_prim_flop_x_cross_prod (
+    .clk_i (clk_i),
+    .rst_ni(rst_ni),
+    .en_i  (en2_i),
+    .d_i   (cross_prod_d),
+    .q_o   (cross_prod_q)
+  );
+
+  // HPC2o (EnW=1): XOR w and xy_masked into the inner term before registering.
+  // HPC2  (EnW=0): register the inner term and xy_masked separately, XOR after.
+  if (EnW) begin : gen_xor_w
+    for (genvar Share = 0; Share < NumShares; Share++) begin : gen_inner_prod
+      prim_xor2 u_prim_xor2_w (
+        .in0_i(xy[Share]),
+        .in1_i(w_i[Share]),
+        .out_o(inner_prod_d[Share])
+      );
+    end
+
+  end else begin : gen_no_xor_w
+    for (genvar Share = 0; Share < NumShares; Share++) begin : gen_inner_prod
+      assign inner_prod_d[Share] = xy[Share];
+    end
+
+    // Consume unused w_i to avoid lint warnings.
+    logic unused_w;
+    assign unused_w = ^w_i;
+  end
+
+  prim_flop_x #(
+    .Width(NumShares),
+    .ResetValue('0),
+    .PrimFlopEn(PrimFlopEn)
+  ) u_prim_flop_x_inner_prod (
+    .clk_i (clk_i),
+    .rst_ni(rst_ni),
+    .en_i  (en2_i),
+    .d_i   (inner_prod_d),
+    .q_o   (inner_prod_q)
+  );
+
+  // Output: z[Share] = inner_prod_q[Share] ^ cross_prod_q[Share]
+  for (genvar Share = 0; Share < NumShares; Share++) begin : gen_z
+    prim_xor2 u_prim_xor2_merge_cross (
+      .in0_i(cross_prod_q[Share]),
+      .in1_i(x_inv_r_q[Share]),
+      .out_o(merge_cross[Share])
+    );
+
+    prim_xor2 u_prim_xor2_output (
+      .in0_i(merge_cross[Share]),
+      .in1_i(inner_prod_q[Share]),
+      .out_o(z_o[Share])
+    );
+  end
+
+  // Asymmetric latency: en1_i (y_i/r_i path) must have fired at least once
+  // before en2_i (x_i/w_i path) fires. Stalls are allowed between the two.
+  // Stage 1 must not be overwritten while its data is still pending in Stage 2.
+`ifndef SYNTHESIS
+  logic s_stage1_pending;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) s_stage1_pending <= 1'b0;
+    else         s_stage1_pending <= en1_i || (s_stage1_pending && !en2_i);
+  end
+
+  // Stage 2 may only fire if Stage 1 has been triggered since the last Stage 2.
+  `ASSERT(AsymLatencyEn1BeforeEn2, en2_i |-> s_stage1_pending, clk_i, !rst_ni)
+  // Stage 1 may not overwrite pending data unless Stage 2 is completing this cycle.
+  `ASSERT(AsymLatencyNoStage1Overwrite,
+      en1_i && s_stage1_pending |-> en2_i, clk_i, !rst_ni)
+`endif
+
+endmodule : prim_hpc2

--- a/hw/ip/prim/rtl/prim_hpc3.sv
+++ b/hw/ip/prim/rtl/prim_hpc3.sv
@@ -1,0 +1,169 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Description: PINI-secure Hardware Private Circuit (HPC3) / Toffoli Gadget (HPC3o)
+//
+// This module implements a Probe-Isolating Non-Interference (PINI) secure AND gadget (HPC3) or a
+// Toffoli gadget (HPC3o), configured via the compile-time parameter `EnW`. All operands (W, X, Y)
+// and the result (Z) are represented as boolean-shared bits in `NumShares` shares.
+//
+// Compile time configurations:
+//   - EnW = 0 (HPC3)  : Computes the masked AND operation:     Z = X & Y
+//   - EnW = 1 (HPC3o) : Computes the masked Toffoli operation: Z = W ^ (X & Y)
+//
+// Pipeline & Timing Requirements:
+//   - Randomness: The gadget is fully pipelined and consumes 2 bits of fresh randomness
+//     (`r_i` and `rp_i`) per active cycle.
+//   - Symmetric Latency: All inputs (x_i, y_i, w_i, r_i, rp_i) share a uniform 1-cycle latency.
+//     Unlike HPC2, no input needs to be presented early.
+//   - Stall Support: To support stallable pipelines, the `en_i` flip-flop enable signal can be
+//     safely deasserted to freeze the internal registers and halt data propagation.
+//
+// For details, see the following paper:
+// Cassiers, Gaetan, et al. "Compress: Generate small and fast masked pipelined circuits."
+// available at:
+// https://eprint.iacr.org/2023/1600.pdf
+
+module prim_hpc3 #(
+  parameter  bit          EnW = 1'b0,
+  parameter  bit          PrimFlopEn = 1'b1,
+  localparam int unsigned NumShares = 2
+) (
+  input clk_i,
+  input rst_ni,
+
+  // Pipeline stage enable signal.
+  input  logic en_i,
+
+  // Masked data inputs.
+  input  logic [NumShares-1:0] x_i,
+  input  logic [NumShares-1:0] y_i,
+  input  logic [NumShares-1:0] w_i,
+
+  // Fresh randomness (two bits per active cycle).
+  input  logic r_i,
+  input  logic rp_i,
+
+  // Masked data output.
+  output logic [NumShares-1:0] z_o
+);
+
+  // Stage outputs.
+  logic [NumShares-1:0] x_q;
+  logic [NumShares-1:0] y_masked_d;
+  logic [NumShares-1:0] y_masked_q;
+  logic [NumShares-1:0] inner_prod_q;
+
+  // Output-stage combinational nodes.
+  logic [NumShares-1:0] xy_masked;    // x[Share] & (y[Share] ^ r)
+  logic [NumShares-1:0] inner_prod_d; // ((x[Share] & (y[Share] ^ r)) ^ rp) (^ w_i[Share] if EnW)
+  logic [NumShares-1:0] cross_prod;   // x[Share] & (y[OtherShare] ^ r)
+
+  // Stage (en_i): register x, y^r, and the inner product
+  for (genvar Share = 0; Share < NumShares; Share++) begin : gen_y_masked
+    prim_xor2 u_prim_xor2 (
+      .in0_i(y_i[Share]),
+      .in1_i(r_i),
+      .out_o(y_masked_d[Share])
+    );
+  end
+
+  prim_flop_x #(
+    .Width(NumShares),
+    .ResetValue('0),
+    .PrimFlopEn(PrimFlopEn)
+  ) u_prim_flop_x_y_masked (
+    .clk_i (clk_i),
+    .rst_ni(rst_ni),
+    .en_i  (en_i),
+    .d_i   (y_masked_d),
+    .q_o   (y_masked_q)
+  );
+
+  prim_flop_x #(
+    .Width(NumShares),
+    .ResetValue('0),
+    .PrimFlopEn(PrimFlopEn)
+  ) u_prim_flop_x_x (
+    .clk_i (clk_i),
+    .rst_ni(rst_ni),
+    .en_i  (en_i),
+    .d_i   (x_i),
+    .q_o   (x_q)
+  );
+
+  for (genvar Share = 0; Share < NumShares; Share++) begin : gen_xy_masked
+    prim_and2 u_prim_and2 (
+      .in0_i(x_i[Share]),
+      .in1_i(y_masked_d[Share]),
+      .out_o(xy_masked[Share])
+    );
+  end
+
+  // HPC3o (EnW=1): XOR w into the inner term before registering.
+  // HPC3  (EnW=0): inner term is just (x&y_masked) ^ rp.
+  if (EnW) begin : gen_xor_w
+    logic [NumShares-1:0] xyw_masked;  // (x[Share] & (y[Share] ^ r)) ^ w[Share]
+
+    for (genvar Share = 0; Share < NumShares; Share++) begin : gen_inner_prod
+      prim_xor2 u_prim_xor2_w (
+        .in0_i(xy_masked[Share]),
+        .in1_i(w_i[Share]),
+        .out_o(xyw_masked[Share])
+      );
+
+      prim_xor2 u_prim_xor2_d (
+        .in0_i(xyw_masked[Share]),
+        .in1_i(rp_i),
+        .out_o(inner_prod_d[Share])
+      );
+    end
+
+  end else begin : gen_no_xor_w
+    for (genvar Share = 0; Share < NumShares; Share++) begin : gen_inner_prod
+      prim_xor2 u_prim_xor2_x_masked (
+        .in0_i(xy_masked[Share]),
+        .in1_i(rp_i),
+        .out_o(inner_prod_d[Share])
+      );
+    end
+
+    // Consume unused w_i to avoid lint warnings.
+    logic unused_w;
+    assign unused_w = ^w_i;
+  end
+
+  prim_flop_x #(
+    .Width(NumShares),
+    .ResetValue('0),
+    .PrimFlopEn(PrimFlopEn)
+  ) u_prim_flop_x_p_inner (
+    .clk_i (clk_i),
+    .rst_ni(rst_ni),
+    .en_i  (en_i),
+    .d_i   (inner_prod_d),
+    .q_o   (inner_prod_q)
+  );
+
+  // Output: cross products use the opposite share's y_masked_q (OtherShare = 1-Share),
+  //         then z[Share] = inner_prod_q[Share] ^ cross_prod[Share]
+  for (genvar Share = 0; Share < NumShares; Share++) begin : gen_cross_prod
+    localparam int OtherShare = (Share == 0) ? 1 : 0;
+
+    prim_and2 u_prim_and2 (
+      .in0_i(x_q[Share]),
+      .in1_i(y_masked_q[OtherShare]),
+      .out_o(cross_prod[Share])
+    );
+  end
+
+  for (genvar Share = 0; Share < NumShares; Share++) begin : gen_z
+    prim_xor2 u_prim_xor2 (
+      .in0_i(inner_prod_q[Share]),
+      .in1_i(cross_prod[Share]),
+      .out_o(z_o[Share])
+    );
+  end
+
+endmodule : prim_hpc3

--- a/quality/BUILD.bazel
+++ b/quality/BUILD.bazel
@@ -78,6 +78,8 @@ licence_test(
         "hw/ip/aes/pre_sca/alma/cpp/verilator_tb_aes_sbox.cpp",
         "hw/ip/aes/pre_sca/alma/cpp/verilator_tb_aes_sub_bytes.cpp",
         "hw/ip/kmac/pre_sca/alma/cpp/verilator_tb_keccak_2share.cpp",
+        "hw/ip/otbn/pre_sca/alma/cpp/testbench.h",
+        "hw/ip/otbn/pre_sca/alma/cpp/verilator_tb_hpc_gadget_impl.h",
     ],
     licence = """
     Copyright lowRISC contributors (OpenTitan project).


### PR DESCRIPTION
### Description
This PR adds HPC gadgets to opentitan primitives.

For details, see the following paper:
Cassiers, Gaëtan, et al. "Compress: Generate small and fast masked pipelined circuits." available [here](https://eprint.iacr.org/2023/1600.pdf).

The first commit adds the gadget themselves.
The following commits add scripts that are needed to evaluate the gadgets for leakage.

This PR provides the scripts to analyze the design using Coco Alma and PROLEAD.

In the following instructions `<gadget>` can be one of the following:
- hpc2o
- hpc2_and
- hpc3o
- hpc3_and

### Run Synthesis
To synthesize the design run the following commands:
```
cd <REPO_TOP>/hw/ip/otbn/pre_syn
./syn_yosys_sec_add.sh <gadget>
```

### Run Leakage Analysis with Alma
Make sure you have Alma installed. A guide on how to install Alma can be found in the `Prerequisites` section [here](https://github.com/lowRISC/opentitan/blob/master/hw/ip/aes/pre_sca/alma/README.md).

To start the leakage analysis using alma run the following commands in your nix shell:
```
cd <REPO_TOP>
source util/build_consts.sh
cd ~/alma
source dev/bin/activate
~/opentitan/hw/ip/otbn/pre_sca/alma/verify_sec_add.sh <gadget>
```

### Run Leakage Analysis with PROLEAD
To start the leakage analysis using PROLEAD run the following commands:
```
# Clone the PROLEAD repo
git clone https://github.com/ChairImpSec/PROLEAD.git

# Start the PROLEAD dev shell
cd PROLEAD
nix-shell
make release

# Make sure package metadata is up to date
nix-channel --update

# Set up shell variables
source ../opentitan/util/build_consts.sh
cd ../opentitan/hw/ip/otbn/pre_sca/prolead

# Run analysis
./evaluate.sh <gadget>

```