### PR TITLE
[prim,rtl] Expand out the assertions in prim_alert_sender.sv

### DIFF
--- a/hw/ip/prim/rtl/prim_alert_receiver.sv
+++ b/hw/ip/prim/rtl/prim_alert_receiver.sv
@@ -60,6 +60,9 @@ module prim_alert_receiver
 
   import prim_mubi_pkg::mubi4_test_true_strict;
 
+  default clocking @(posedge clk_i); endclocking
+  default disable iff !rst_ni;
+
   /////////////////////////////////
   // decode differential signals //
   /////////////////////////////////
@@ -303,28 +306,29 @@ module prim_alert_receiver
 
   if (AsyncOn) begin : gen_async_assert
     // signal integrity check propagation
-    `ASSERT(SigInt_A,
-        alert_tx_i.alert_p == alert_tx_i.alert_n [*2] ##2
-        !(state_q inside {InitReq, InitAckWait}) &&
-        mubi4_test_false_loose(init_trig_i)
-        |->
-        ##[0:SkewCycles] integ_fail_o)
-    `ASSERT(PingResponse1_A,
-        ##1 $rose(alert_tx_i.alert_p) &&
-        (alert_tx_i.alert_p ^ alert_tx_i.alert_n) ##2
-        state_q == Idle && ping_pending_q
-        |->
-        ##[0:SkewCycles] ping_ok_o,
-        clk_i, !rst_ni || integ_fail_o || mubi4_test_true_strict(init_trig_i))
+    SigInt_A: assert property (alert_tx_i.alert_p == alert_tx_i.alert_n [*(SkewCycles + 1)]
+                               |-> ##[1:3]
+                               ((state_q inside {InitReq, InitAckWait}) ||
+                                mubi4_test_true_strict(init_trig_i) ||
+                                integ_fail_o))
+      else `ASSERT_ERROR(SigInt_A)
+    PingResponse1_A: assert property (disable iff (!rst_ni || integ_fail_o ||
+                                                   mubi4_test_true_strict(init_trig_i))
+                                      ##1 $rose(alert_tx_i.alert_p) &&
+                                      (alert_tx_i.alert_p ^ alert_tx_i.alert_n) ##2
+                                      state_q == Idle && ping_pending_q
+                                      |->
+                                      ##[0:1] ping_ok_o)
+      else `ASSERT_ERROR(PingResponse1_A)
     // alert
-    `ASSERT(Alert_A,
-        ##1 $rose(alert_tx_i.alert_p) &&
-        (alert_tx_i.alert_p ^ alert_tx_i.alert_n) ##2
-        state_q == Idle &&
-        !ping_pending_q
-        |->
-        ##[0:SkewCycles] alert_o,
-        clk_i, !rst_ni || integ_fail_o || mubi4_test_true_strict(init_trig_i))
+    Alert_A: assert property (disable iff (!rst_ni || integ_fail_o ||
+                                           mubi4_test_true_strict(init_trig_i))
+                              ##1 $rose(alert_tx_i.alert_p) &&
+                              (alert_tx_i.alert_p ^ alert_tx_i.alert_n) ##2
+                              state_q == Idle && !ping_pending_q
+                              |->
+                              ##[0:1] alert_o)
+      else `ASSERT_ERROR(Alert_A)
   end else begin : gen_sync_assert
     // signal integrity check propagation
     `ASSERT(SigInt_A,

--- a/hw/ip/prim/rtl/prim_alert_sender.sv
+++ b/hw/ip/prim/rtl/prim_alert_sender.sv
@@ -67,6 +67,8 @@ module prim_alert_sender
   output alert_tx_t alert_tx_o
 );
 
+  default clocking @(posedge clk_i); endclocking
+  default disable iff !rst_ni;
 
   /////////////////////////////////
   // decode differential signals //
@@ -303,38 +305,53 @@ module prim_alert_sender
 
   if (AsyncOn) begin : gen_async_assert
     sequence PingSigInt_S;
-      alert_rx_i.ping_p == alert_rx_i.ping_n [*2];
+      alert_rx_i.ping_p == alert_rx_i.ping_n [*(SkewCycles + 1)];
     endsequence
     sequence AckSigInt_S;
-      alert_rx_i.ping_p == alert_rx_i.ping_n [*2];
+      alert_rx_i.ping_p == alert_rx_i.ping_n [*(SkewCycles + 1)];
     endsequence
 
-  `ifndef FPV_ALERT_NO_SIGINT_ERR
-    // check propagation of sigint issues to output within three cycles, or four due to CDC
-    // shift sequence to the right to avoid reset effects.
-    `ASSERT(SigIntPing_A, ##1 PingSigInt_S |->
-        ##[SkewCycles+2:SkewCycles+3] alert_tx_o.alert_p == alert_tx_o.alert_n)
-    `ASSERT(SigIntAck_A, ##1 AckSigInt_S |->
-        ##[SkewCycles+2:SkewCycles+3] alert_tx_o.alert_p == alert_tx_o.alert_n)
-  `endif
+`ifndef FPV_ALERT_NO_SIGINT_ERR
+    // Check that any sigint issue is propagated to the output within at most four cycles (this
+    // allows three cycles for the logic plus one for CDC uncertainty).
+    SigIntPing_A:
+      assert property (##1 PingSigInt_S |-> ##[3:4] alert_tx_o.alert_p == alert_tx_o.alert_n)
+        else `ASSERT_ERROR(SigIntPing_A)
+
+    SigIntAck_A:
+      assert property (##1 AckSigInt_S |-> ##[3:4] alert_tx_o.alert_p == alert_tx_o.alert_n)
+        else `ASSERT_ERROR(SigIntAck_A)
+`endif
 
     // Test in-band FSM reset request (via signal integrity error)
-    `ASSERT(InBandInitFsm_A, PingSigInt_S or AckSigInt_S |->
-        ##[SkewCycles+2:SkewCycles+3] state_q == Idle)
-    `ASSERT(InBandInitPing_A, PingSigInt_S or AckSigInt_S |->
-        ##[SkewCycles+2:SkewCycles+3] !ping_set_q)
-    // output must be driven diff unless sigint issue detected
-    `ASSERT(DiffEncoding_A, (alert_rx_i.ack_p ^ alert_rx_i.ack_n) &&
-        (alert_rx_i.ping_p ^ alert_rx_i.ping_n) |->
-        ##[SkewCycles+2:SkewCycles+4] alert_tx_o.alert_p ^ alert_tx_o.alert_n)
+    InBandInitFsm_A:
+      assert property (PingSigInt_S or AckSigInt_S |-> ##[3:4] state_q == Idle)
+        else `ASSERT_ERROR(InBandInitFsm_A)
+
+    InBandInitPing_A:
+      assert property (PingSigInt_S or AckSigInt_S |-> ##[3:4] !ping_set_q)
+        else `ASSERT_ERROR(InBandInitPing_A)
+
+    // Output must be driven diff unless sigint issue detected
+    DiffEncoding_A:
+      assert property ((alert_rx_i.ack_p ^ alert_rx_i.ack_n) &&
+                       (alert_rx_i.ping_p ^ alert_rx_i.ping_n) |->
+                       ##[3:5] alert_tx_o.alert_p ^ alert_tx_o.alert_n)
+        else `ASSERT_ERROR(DiffEncoding_A)
 
     // handshakes can take indefinite time if blocked due to sigint on outgoing
     // lines (which is not visible here). thus, we only check whether the
     // handshake is correctly initiated and defer the full handshake checking to the testbench.
-    `ASSERT(PingHs_A, ##1 $changed(alert_rx_i.ping_p) &&
-        (alert_rx_i.ping_p ^ alert_rx_i.ping_n) ##2 state_q == Idle |=>
-        ##[0:1] $rose(alert_tx_o.alert_p), clk_i,
-        !rst_ni || (alert_tx_o.alert_p == alert_tx_o.alert_n))
+    PingHs_A:
+      assert property (disable iff (!rst_ni || (alert_tx_o.alert_p == alert_tx_o.alert_n))
+                       ##1
+                       ($changed(alert_rx_i.ping_p) &&
+                        (alert_rx_i.ping_p ^ alert_rx_i.ping_n))
+                       ##2
+                       state_q == Idle |=>
+                       ##[0:1] $rose(alert_tx_o.alert_p))
+        else `ASSERT_ERROR(PingHs_A)
+
   end else begin : gen_sync_assert
     sequence PingSigInt_S;
       alert_rx_i.ping_p == alert_rx_i.ping_n;

--- a/hw/ip/prim/rtl/prim_alert_sender.sv
+++ b/hw/ip/prim/rtl/prim_alert_sender.sv
@@ -361,48 +361,79 @@ module prim_alert_sender
     endsequence
 
   `ifndef FPV_ALERT_NO_SIGINT_ERR
-    // check propagation of sigint issues to output within one cycle
-    `ASSERT(SigIntPing_A, PingSigInt_S |=>
-        alert_tx_o.alert_p == alert_tx_o.alert_n)
-    `ASSERT(SigIntAck_A,  AckSigInt_S |=>
-        alert_tx_o.alert_p == alert_tx_o.alert_n)
+    // A signal integrity issue on the ping input should propagate to the output in one cycle
+    SigIntPing_A:
+      assert property (PingSigInt_S |=> alert_tx_o.alert_p == alert_tx_o.alert_n)
+        else `ASSERT_ERROR(SigIntPing_A)
+
+    // A signal integrity issue on the ack input should propagate to the output in one cycle
+    SigIntAck_A:
+      assert property (AckSigInt_S |=> alert_tx_o.alert_p == alert_tx_o.alert_n)
+        else `ASSERT_ERROR(SigIntAck_A)
   `endif
 
-    // Test in-band FSM reset request (via signal integrity error)
-    `ASSERT(InBandInitFsm_A, PingSigInt_S or AckSigInt_S |=> state_q == Idle)
-    `ASSERT(InBandInitPing_A, PingSigInt_S or AckSigInt_S |=> !ping_set_q)
-    // output must be driven diff unless sigint issue detected
-    `ASSERT(DiffEncoding_A, (alert_rx_i.ack_p ^ alert_rx_i.ack_n) &&
-        (alert_rx_i.ping_p ^ alert_rx_i.ping_n) |=> alert_tx_o.alert_p ^ alert_tx_o.alert_n)
+    // Test in-band FSM reset request (via signal integrity error). After either type of signal
+    // integrity error, the FSM will revert to the Idle state and ping_set_q (which tracks if there
+    // is a ping in flight) will be cleared.
+    InBandInitFsm_A:
+      assert property (PingSigInt_S or AckSigInt_S |=> state_q == Idle)
+        else `ASSERT_ERROR(InBandInitFsm_A)
+
+    InBandInitPing_A:
+      assert property (PingSigInt_S or AckSigInt_S |=> !ping_set_q)
+        else `ASSERT_ERROR(InBandInitPing_A)
+
+    // The alert output is always differential unless an input has a signal integrity error.
+    DiffEncoding_A:
+      assert property ((alert_rx_i.ack_p ^ alert_rx_i.ack_n) &&
+                       (alert_rx_i.ping_p ^ alert_rx_i.ping_n) |=>
+                       alert_tx_o.alert_p ^ alert_tx_o.alert_n)
+        else `ASSERT_ERROR(DiffEncoding_A)
+
     // handshakes can take indefinite time if blocked due to sigint on outgoing
     // lines (which is not visible here). thus, we only check whether the handshake
     // is correctly initiated and defer the full handshake checking to the testbench.
-    `ASSERT(PingHs_A, ##1 $changed(alert_rx_i.ping_p) && state_q == Idle |=>
-        $rose(alert_tx_o.alert_p), clk_i, !rst_ni || (alert_tx_o.alert_p == alert_tx_o.alert_n))
+    PingHs_A:
+      assert property (disable iff (!rst_ni || (alert_tx_o.alert_p == alert_tx_o.alert_n))
+                       ##1
+                       $changed(alert_rx_i.ping_p) && state_q == Idle |=>
+                       $rose(alert_tx_o.alert_p))
+        else `ASSERT_ERROR(PingHs_A)
   end
 
-  // Test the alert state output.
-  `ASSERT(AlertState0_A, alert_set_q === alert_state_o)
+  // If an alert is requested, the sender's internal alert state (exposed as alert_state_o) will
+  // normally be set. The only time this isn't true is when the IsFatal parameter is false and the
+  // sender is seeing the end of a previous handshake.
+  AlertStateSet_A:
+    assert property (alert_req_i && (IsFatal || (state_q != AlertHsPhase2)) |=> alert_state_o)
+      else `ASSERT_ERROR(AlertStateSet_A)
 
-  if (IsFatal) begin : gen_fatal_assert
-    `ASSERT(AlertState1_A, alert_req_i |=> alert_state_o)
-    `ASSERT(AlertState2_A, alert_state_o |=> $stable(alert_state_o))
-    `ASSERT(AlertState3_A, alert_ack_o |=> alert_state_o)
-  end else begin : gen_recov_assert
-    `ASSERT(AlertState1_A, alert_req_i && !alert_clr |=> alert_state_o)
-    `ASSERT(AlertState2_A, alert_req_i && alert_ack_o |=> !alert_state_o)
-  end
+  // The alert_ack_o signal is asserted when an alert has been acknowledged by the receiver. If the
+  // alert is not fatal, the internal alert state is then cleared.
+  AlertStateClear_A:
+    assert property (alert_ack_o |=> alert_state_o == IsFatal)
+      else `ASSERT_ERROR(AlertStateClear_A)
 
-  // The alert test input should not set the alert state register.
-  `ASSERT(AlertTest1_A, alert_test_i && !alert_req_i && !alert_state_o |=> $stable(alert_state_o))
+  // The alert state register can be set by alert_req_i, but there is no other way to set it. In
+  // particular, alert_test_i does not do so.
+  AlertStateNeedsReq_A:
+    assert property (##1 $rose(alert_state_o) -> $past(alert_req_i))
+      else `ASSERT_ERROR(AlertTest_A)
 
-  // if alert_req_i is true, handshakes should be continuously repeated
-  `ASSERT(AlertHs_A, alert_req_i && state_q == Idle |=> $rose(alert_tx_o.alert_p),
-      clk_i, !rst_ni || (alert_tx_o.alert_p == alert_tx_o.alert_n))
+  // If alert_req_i is true, handshakes should be continuously repeated. This assertion checks that
+  // the sender doesn't remain in the Idle state without either asserting a new alert or reporting a
+  // signal integrity error.
+  AlertHs_A:
+    assert property (disable iff (!rst_ni || (alert_tx_o.alert_p == alert_tx_o.alert_n))
+                     alert_req_i && state_q == Idle |=> $rose(alert_tx_o.alert_p))
+      else `ASSERT_ERROR(AlertHs_A)
 
-  // if alert_test_i is true, handshakes should be continuously repeated
-  `ASSERT(AlertTestHs_A, alert_test_i && state_q == Idle |=> $rose(alert_tx_o.alert_p),
-      clk_i, !rst_ni || (alert_tx_o.alert_p == alert_tx_o.alert_n))
+  // If alert_test_i is true, handshakes should be continuously repeated. This assertion is
+  // analogous to AlertHs_A.
+  AlertTestHs_A:
+    assert property (disable iff (!rst_ni || (alert_tx_o.alert_p == alert_tx_o.alert_n))
+                     alert_test_i && state_q == Idle |=> $rose(alert_tx_o.alert_p))
+      else `ASSERT_ERROR(AlertHs_A)
 `endif
 
 `ifdef FPV_ALERT_NO_SIGINT_ERR


### PR DESCRIPTION
**NOTE: This is based on an existing PR (#28165). Merge that one first.**

The behaviour is same as before, although I've expanded out the \`ASSERT macro because I think it's a bit easier to understand the result.

But there are some changes:

- Various comments before the assertions have been extended, to explain what each assertion actually means.

- I've removed `AlertState0_A`, which just claims that an internal signal matches a port: true, but not relevant to any of the other assertions.

- I've merged the two copies of `AlertState1_A` (and renamed them to `AlertStateSet_A`). They were different because the non-fatal version had `!alert_clr` in the precondition. This is only true when in state `AlertHsPhase2`.

  Sadly, you can't really express this with values from the ports (because the test input allows handshakes without setting `alert_state_o`), so I've gone for the "least magic" version I can.

- I've also merged the two copies of `AlertState2_A` (just putting the parameter into the prediction about `alert_state_o`)

- I've removed `AlertState3_A` (defined for fatal alerts). The `alert_ack_o` signal in the precondition rather trivially implies
 alert_state_o, so the assertion doesn't really say anything. Replacing it with "`alert_ack_o -> alert_state_o`" (regardless of whether the alert is fatal) would be kind of reasonable, but I'm not convinced it's worth saying.

- The `AlertTest1` assertion was really an assertion about `alert_test_i` not having an effect. I've rephrased it to something slightly more general, which is now `AlertStateNeedsReq_A`.
