### PR TITLE
[ottf] Skip UART control flow on DV

### DIFF
--- a/sw/device/lib/testing/test_framework/ottf_isrs.c
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.c
@@ -211,7 +211,9 @@ void ottf_external_isr(uint32_t *exc_info) {
   // See if the test code wants to handle it.
   bool handled = ottf_handle_irq(exc_info, peripheral, plic_irq_id);
   // If not, see if that interrupt corresponds to an OTTF console IRQ.
-  if (handled || ottf_console_flow_control_isr(exc_info)) {
+  // We must skip flow control in DV-sim as the console is not initialized.
+  if (handled || (kDeviceType != kDeviceSimDV &&
+                  ottf_console_flow_control_isr(exc_info))) {
     // Complete the IRQ at PLIC.
     CHECK_DIF_OK(
         dif_rv_plic_irq_complete(&ottf_plic, kPlicTarget, plic_irq_id));


### PR DESCRIPTION
Unexpected interrupts hit this code path in dvsim which checks the UART for pending IRQs to handle control flow. dvsim does not initialise the UART for the console because it's backdoored by the test framework.