### PR TITLE
[ROM] Increase ROM size to 48 KiB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -574,23 +574,6 @@ jobs:
             --//hw/top=darjeeling                            \
             //sw/device/tests/...
 
-  qemu_smoketest:
-    name: QEMU smoketest
-    runs-on: ubuntu-22.04-vivado
-    needs: quick_lint
-    if: ${{ github.event_name != 'merge_group' }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: Prepare environment
-        uses: ./.github/actions/prepare-env
-        with:
-          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
-      - name: Execute QEMU smoketest
-        run: |
-          ./bazelisk.sh test //sw/device/tests:rom_exit_immediately_sim_qemu_base
-
   # Single job that we can gate pull requests and merge queues on:
   merge_blocker:
     name: Merge blocker

--- a/hw/ip/bkdr_loader/README.md
+++ b/hw/ip/bkdr_loader/README.md
@@ -11,6 +11,7 @@ This document specifies the FPGA-only memory Backdoor Loader which is used to pr
 - Up to 64 memory r/w targets supported
 - Automatic discovery of available targets by presenting a 32-bit target ID as well as width and depth
 - Access to raw BRAM data allowing to set both data and ECC arbitrarily for each target
+- Auto-increment mode for reading and writing
 
 ## Description
 

--- a/hw/ip/bkdr_loader/data/bkdr_loader.hjson
+++ b/hw/ip/bkdr_loader/data/bkdr_loader.hjson
@@ -99,6 +99,7 @@
             desc: '''
                   Write 1 to trigger the bkdr_loader to switch to mission mode.
                   After this, the bkdr_loader cannot be used until the next reset.
+                  Takes only effect if no clearing operation is running (STATUS.CLEAR_IDLE == 1).
                   ''',
           },
           { bits: "1"
@@ -106,7 +107,12 @@
             swaccess: "rw",
             hwaccess: "hro",
             desc: '''
-                  If set, a bkdr write is launched when writing to the index register.
+                  While `AUTO_INCR` is deasserted, setting this launches a bkdr write when
+                  writing to the `INDEX` register. While `AUTO_INCR` is asserted, this field
+                  instead selects which auto-increment trigger is active: set to 1, a write to
+                  the highest 32-bit field of `WRITE_DATA` launches a bkdr write and advances
+                  `INDEX`; set to 0, a read of the highest 32-bit field of `READ_DATA` advances
+                  `INDEX` without a bkdr write, see `AUTO_INCR`.
                   ''',
           },
           { bits: "2"
@@ -115,10 +121,28 @@
             hwaccess: "hrw"
             desc: '''
                   Write 1 to trigger the bkdr_loader to clear the entire target memory
-                  that is currently selected by `TARGET_IDX`.
-                  The word that is cleared with is selected by `WRITE_DATA`.
+                  that is currently selected by `TARGET_IDX`. Register self-clears and always reads
+                  back 0. The word that is cleared with is selected by `WRITE_DATA`.
                   Clear operation is completed if `STATUS.CLEAR_IDLE` becomes 1.
                   bkdr writes will not have any effects during an active clear operation.
+                  ''',
+          },
+          { bits: "3"
+            name: "AUTO_INCR"
+            swaccess: "rw",
+            hwaccess: "hro"
+            desc: '''
+                  If `AUTO_INCR` is set to 1, `INDEX` will automatically be increased by 1 on
+                  accessing the highest 32-bit field of `READ_DATA`/`WRITE_DATA` corresponding to
+                  a full line of the target selected by `TARGET_IDX`; `WRITE_ENA` selects which of
+                  `READ_DATA`/`WRITE_DATA` is the active trigger. To set up an auto increment
+                  write sequence; first `WRITE_ENA` and
+                  `AUTO_INCR` are set to 1, `INDEX` is written with the start index of the block to
+                  be written. For e.g., a 37-bit-wide target, writing `WRITE_DATA[0]` has no side
+                  effect, whereas writing `WRITE_DATA[1]` launches the bkdr write and `INDEX`
+                  increment. Writing to `WRITE_DATA[0]` and `WRITE_DATA[1]` can be repeated until
+                  the memory block has been written. Deasserting `AUTO_INCR` returns to the manual
+                  mode.
                   ''',
           },
           { bits: "15:8"
@@ -126,7 +150,7 @@
             swaccess: "rw",
             hwaccess: "hro",
             desc: '''
-                  The bkdr memory index to write to.
+                  The bkdr memory index to access.
                   The size of this field must match the parameter TargetIdxWidth.
                   ''',
           },
@@ -234,12 +258,18 @@
       { skipto: "0x400" }
       { multireg: {
         name: "READ_DATA",
-        desc: "Value to be read from the target memory.",
+        desc: '''
+              Value to be read from the target memory at the current `INDEX`. If
+              `CONTROL.AUTO_INCR` is asserted, reading from the highest 32-bit field corresponding
+              to the line length of the selected target issues an `INDEX` increment, but only
+              while `CONTROL.WRITE_ENA` is set to 0, see `WRITE_ENA`.
+              ''',
         count: "MaxWordWidthDiv32",
         cname: "VAL",
         swaccess: "ro",
-        hwaccess: "hwo",
+        hwaccess: "hrw",
         hwext:    "true",
+        hwre:     "true",
         fields: [
           { bits: "31:0",
             name: "VAL",
@@ -252,11 +282,18 @@
       { skipto: "0x500" }
       { multireg: {
         name: "WRITE_DATA",
-        desc: "Value to be written to the target memory.",
+        desc: '''
+              Value to be written to the target memory at the current `INDEX`. If
+              `CONTROL.AUTO_INCR` is asserted, writing to the highest 32-bit field corresponding to
+              the line length of the selected target issues an `INDEX` increment and a bkdr write
+              to the current value of `INDEX`, but only while `CONTROL.WRITE_ENA` is set to 1, see
+              `WRITE_ENA`.
+              ''',
         count: "MaxWordWidthDiv32",
         cname: "VAL",
         swaccess: "rw",
         hwaccess: "hro",
+        hwqe:     "true",
         fields: [
           { bits: "31:0",
             name: "VAL",
@@ -268,9 +305,15 @@
       } },
       { skipto: "0x600" }
       { name: "INDEX",
-        desc: "Index address of the SRAM word to be accessed.",
+        desc: '''
+              Index address of the SRAM word to be accessed. When `CONTROL.WRITE_ENA` is asserted
+              and `AUTO_INCR` is deasserted, writing an index value commands a bkdr write to the
+              target selected by `CONTROL.TARGET_IDX`.
+              While `AUTO_INCR` is asserted, this register is incremented by hardware by 1 after
+              each auto-triggered access, see `AUTO_INCR`.
+              ''',
         swaccess: "rw",
-        hwaccess: "hro",
+        hwaccess: "hrw",
         hwqe:     "true",
         fields: [
           { bits: "31:0",

--- a/hw/ip/bkdr_loader/doc/registers.md
+++ b/hw/ip/bkdr_loader/doc/registers.md
@@ -3,66 +3,66 @@
 <!-- BEGIN CMDGEN util/regtool.py -d ./hw/ip/bkdr_loader/data/bkdr_loader.hjson -->
 ## Summary
 
-| Name                                                                  | Offset   |   Length | Description                                                                       |
-|:----------------------------------------------------------------------|:---------|---------:|:----------------------------------------------------------------------------------|
-| bkdr_loader.[`STATUS`](#status)                                       | 0x0      |        4 | Status register                                                                   |
-| bkdr_loader.[`CONTROL`](#control)                                     | 0x4      |        4 | Control register                                                                  |
-| bkdr_loader.[`NUM_BKDR_TARGETS`](#num_bkdr_targets)                   | 0x8      |        4 | Number of bkdr targets available.                                                 |
-| bkdr_loader.[`MISSION_MODE_SWITCH_DELAY`](#mission_mode_switch_delay) | 0xc      |        4 | Number of SoC clock cycles to wait before executing switch to mission mode        |
-| bkdr_loader.[`USR_ACCESS_TIMESTAMP`](#usr_access_timestamp)           | 0x10     |        4 | TIMESTAMP value written to the USR_ACCESS register during bitstream generation.   |
-| bkdr_loader.[`TARGET_INFO_0`](#target_info)                           | 0x100    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory. |
-| bkdr_loader.[`TARGET_INFO_1`](#target_info)                           | 0x104    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory. |
-| bkdr_loader.[`TARGET_INFO_2`](#target_info)                           | 0x108    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory. |
-| bkdr_loader.[`TARGET_INFO_3`](#target_info)                           | 0x10c    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory. |
-| bkdr_loader.[`TARGET_INFO_4`](#target_info)                           | 0x110    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory. |
-| bkdr_loader.[`TARGET_INFO_5`](#target_info)                           | 0x114    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory. |
-| bkdr_loader.[`TARGET_INFO_6`](#target_info)                           | 0x118    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory. |
-| bkdr_loader.[`TARGET_INFO_7`](#target_info)                           | 0x11c    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory. |
-| bkdr_loader.[`TARGET_INFO_8`](#target_info)                           | 0x120    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory. |
-| bkdr_loader.[`TARGET_INFO_9`](#target_info)                           | 0x124    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory. |
-| bkdr_loader.[`TARGET_INFO_10`](#target_info)                          | 0x128    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory. |
-| bkdr_loader.[`TARGET_INFO_11`](#target_info)                          | 0x12c    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory. |
-| bkdr_loader.[`WIDTH_INFO_0`](#width_info)                             | 0x200    |        4 | The SRAM word width of a given bkdr target memory.                                |
-| bkdr_loader.[`WIDTH_INFO_1`](#width_info)                             | 0x204    |        4 | The SRAM word width of a given bkdr target memory.                                |
-| bkdr_loader.[`WIDTH_INFO_2`](#width_info)                             | 0x208    |        4 | The SRAM word width of a given bkdr target memory.                                |
-| bkdr_loader.[`WIDTH_INFO_3`](#width_info)                             | 0x20c    |        4 | The SRAM word width of a given bkdr target memory.                                |
-| bkdr_loader.[`WIDTH_INFO_4`](#width_info)                             | 0x210    |        4 | The SRAM word width of a given bkdr target memory.                                |
-| bkdr_loader.[`WIDTH_INFO_5`](#width_info)                             | 0x214    |        4 | The SRAM word width of a given bkdr target memory.                                |
-| bkdr_loader.[`WIDTH_INFO_6`](#width_info)                             | 0x218    |        4 | The SRAM word width of a given bkdr target memory.                                |
-| bkdr_loader.[`WIDTH_INFO_7`](#width_info)                             | 0x21c    |        4 | The SRAM word width of a given bkdr target memory.                                |
-| bkdr_loader.[`WIDTH_INFO_8`](#width_info)                             | 0x220    |        4 | The SRAM word width of a given bkdr target memory.                                |
-| bkdr_loader.[`WIDTH_INFO_9`](#width_info)                             | 0x224    |        4 | The SRAM word width of a given bkdr target memory.                                |
-| bkdr_loader.[`WIDTH_INFO_10`](#width_info)                            | 0x228    |        4 | The SRAM word width of a given bkdr target memory.                                |
-| bkdr_loader.[`WIDTH_INFO_11`](#width_info)                            | 0x22c    |        4 | The SRAM word width of a given bkdr target memory.                                |
-| bkdr_loader.[`DEPTH_INFO_0`](#depth_info)                             | 0x300    |        4 | The number of SRAM words of a given bkdr target memory.                           |
-| bkdr_loader.[`DEPTH_INFO_1`](#depth_info)                             | 0x304    |        4 | The number of SRAM words of a given bkdr target memory.                           |
-| bkdr_loader.[`DEPTH_INFO_2`](#depth_info)                             | 0x308    |        4 | The number of SRAM words of a given bkdr target memory.                           |
-| bkdr_loader.[`DEPTH_INFO_3`](#depth_info)                             | 0x30c    |        4 | The number of SRAM words of a given bkdr target memory.                           |
-| bkdr_loader.[`DEPTH_INFO_4`](#depth_info)                             | 0x310    |        4 | The number of SRAM words of a given bkdr target memory.                           |
-| bkdr_loader.[`DEPTH_INFO_5`](#depth_info)                             | 0x314    |        4 | The number of SRAM words of a given bkdr target memory.                           |
-| bkdr_loader.[`DEPTH_INFO_6`](#depth_info)                             | 0x318    |        4 | The number of SRAM words of a given bkdr target memory.                           |
-| bkdr_loader.[`DEPTH_INFO_7`](#depth_info)                             | 0x31c    |        4 | The number of SRAM words of a given bkdr target memory.                           |
-| bkdr_loader.[`DEPTH_INFO_8`](#depth_info)                             | 0x320    |        4 | The number of SRAM words of a given bkdr target memory.                           |
-| bkdr_loader.[`DEPTH_INFO_9`](#depth_info)                             | 0x324    |        4 | The number of SRAM words of a given bkdr target memory.                           |
-| bkdr_loader.[`DEPTH_INFO_10`](#depth_info)                            | 0x328    |        4 | The number of SRAM words of a given bkdr target memory.                           |
-| bkdr_loader.[`DEPTH_INFO_11`](#depth_info)                            | 0x32c    |        4 | The number of SRAM words of a given bkdr target memory.                           |
-| bkdr_loader.[`READ_DATA_0`](#read_data)                               | 0x400    |        4 | Value to be read from the target memory.                                          |
-| bkdr_loader.[`READ_DATA_1`](#read_data)                               | 0x404    |        4 | Value to be read from the target memory.                                          |
-| bkdr_loader.[`READ_DATA_2`](#read_data)                               | 0x408    |        4 | Value to be read from the target memory.                                          |
-| bkdr_loader.[`READ_DATA_3`](#read_data)                               | 0x40c    |        4 | Value to be read from the target memory.                                          |
-| bkdr_loader.[`READ_DATA_4`](#read_data)                               | 0x410    |        4 | Value to be read from the target memory.                                          |
-| bkdr_loader.[`READ_DATA_5`](#read_data)                               | 0x414    |        4 | Value to be read from the target memory.                                          |
-| bkdr_loader.[`READ_DATA_6`](#read_data)                               | 0x418    |        4 | Value to be read from the target memory.                                          |
-| bkdr_loader.[`READ_DATA_7`](#read_data)                               | 0x41c    |        4 | Value to be read from the target memory.                                          |
-| bkdr_loader.[`WRITE_DATA_0`](#write_data)                             | 0x500    |        4 | Value to be written to the target memory.                                         |
-| bkdr_loader.[`WRITE_DATA_1`](#write_data)                             | 0x504    |        4 | Value to be written to the target memory.                                         |
-| bkdr_loader.[`WRITE_DATA_2`](#write_data)                             | 0x508    |        4 | Value to be written to the target memory.                                         |
-| bkdr_loader.[`WRITE_DATA_3`](#write_data)                             | 0x50c    |        4 | Value to be written to the target memory.                                         |
-| bkdr_loader.[`WRITE_DATA_4`](#write_data)                             | 0x510    |        4 | Value to be written to the target memory.                                         |
-| bkdr_loader.[`WRITE_DATA_5`](#write_data)                             | 0x514    |        4 | Value to be written to the target memory.                                         |
-| bkdr_loader.[`WRITE_DATA_6`](#write_data)                             | 0x518    |        4 | Value to be written to the target memory.                                         |
-| bkdr_loader.[`WRITE_DATA_7`](#write_data)                             | 0x51c    |        4 | Value to be written to the target memory.                                         |
-| bkdr_loader.[`INDEX`](#index)                                         | 0x600    |        4 | Index address of the SRAM word to be accessed.                                    |
+| Name                                                                  | Offset   |   Length | Description                                                                         |
+|:----------------------------------------------------------------------|:---------|---------:|:------------------------------------------------------------------------------------|
+| bkdr_loader.[`STATUS`](#status)                                       | 0x0      |        4 | Status register                                                                     |
+| bkdr_loader.[`CONTROL`](#control)                                     | 0x4      |        4 | Control register                                                                    |
+| bkdr_loader.[`NUM_BKDR_TARGETS`](#num_bkdr_targets)                   | 0x8      |        4 | Number of bkdr targets available.                                                   |
+| bkdr_loader.[`MISSION_MODE_SWITCH_DELAY`](#mission_mode_switch_delay) | 0xc      |        4 | Number of SoC clock cycles to wait before executing switch to mission mode          |
+| bkdr_loader.[`USR_ACCESS_TIMESTAMP`](#usr_access_timestamp)           | 0x10     |        4 | TIMESTAMP value written to the USR_ACCESS register during bitstream generation.     |
+| bkdr_loader.[`TARGET_INFO_0`](#target_info)                           | 0x100    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory.   |
+| bkdr_loader.[`TARGET_INFO_1`](#target_info)                           | 0x104    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory.   |
+| bkdr_loader.[`TARGET_INFO_2`](#target_info)                           | 0x108    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory.   |
+| bkdr_loader.[`TARGET_INFO_3`](#target_info)                           | 0x10c    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory.   |
+| bkdr_loader.[`TARGET_INFO_4`](#target_info)                           | 0x110    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory.   |
+| bkdr_loader.[`TARGET_INFO_5`](#target_info)                           | 0x114    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory.   |
+| bkdr_loader.[`TARGET_INFO_6`](#target_info)                           | 0x118    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory.   |
+| bkdr_loader.[`TARGET_INFO_7`](#target_info)                           | 0x11c    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory.   |
+| bkdr_loader.[`TARGET_INFO_8`](#target_info)                           | 0x120    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory.   |
+| bkdr_loader.[`TARGET_INFO_9`](#target_info)                           | 0x124    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory.   |
+| bkdr_loader.[`TARGET_INFO_10`](#target_info)                          | 0x128    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory.   |
+| bkdr_loader.[`TARGET_INFO_11`](#target_info)                          | 0x12c    |        4 | ASCII 4-character string values (big endian) identifying each bkdr target memory.   |
+| bkdr_loader.[`WIDTH_INFO_0`](#width_info)                             | 0x200    |        4 | The SRAM word width of a given bkdr target memory.                                  |
+| bkdr_loader.[`WIDTH_INFO_1`](#width_info)                             | 0x204    |        4 | The SRAM word width of a given bkdr target memory.                                  |
+| bkdr_loader.[`WIDTH_INFO_2`](#width_info)                             | 0x208    |        4 | The SRAM word width of a given bkdr target memory.                                  |
+| bkdr_loader.[`WIDTH_INFO_3`](#width_info)                             | 0x20c    |        4 | The SRAM word width of a given bkdr target memory.                                  |
+| bkdr_loader.[`WIDTH_INFO_4`](#width_info)                             | 0x210    |        4 | The SRAM word width of a given bkdr target memory.                                  |
+| bkdr_loader.[`WIDTH_INFO_5`](#width_info)                             | 0x214    |        4 | The SRAM word width of a given bkdr target memory.                                  |
+| bkdr_loader.[`WIDTH_INFO_6`](#width_info)                             | 0x218    |        4 | The SRAM word width of a given bkdr target memory.                                  |
+| bkdr_loader.[`WIDTH_INFO_7`](#width_info)                             | 0x21c    |        4 | The SRAM word width of a given bkdr target memory.                                  |
+| bkdr_loader.[`WIDTH_INFO_8`](#width_info)                             | 0x220    |        4 | The SRAM word width of a given bkdr target memory.                                  |
+| bkdr_loader.[`WIDTH_INFO_9`](#width_info)                             | 0x224    |        4 | The SRAM word width of a given bkdr target memory.                                  |
+| bkdr_loader.[`WIDTH_INFO_10`](#width_info)                            | 0x228    |        4 | The SRAM word width of a given bkdr target memory.                                  |
+| bkdr_loader.[`WIDTH_INFO_11`](#width_info)                            | 0x22c    |        4 | The SRAM word width of a given bkdr target memory.                                  |
+| bkdr_loader.[`DEPTH_INFO_0`](#depth_info)                             | 0x300    |        4 | The number of SRAM words of a given bkdr target memory.                             |
+| bkdr_loader.[`DEPTH_INFO_1`](#depth_info)                             | 0x304    |        4 | The number of SRAM words of a given bkdr target memory.                             |
+| bkdr_loader.[`DEPTH_INFO_2`](#depth_info)                             | 0x308    |        4 | The number of SRAM words of a given bkdr target memory.                             |
+| bkdr_loader.[`DEPTH_INFO_3`](#depth_info)                             | 0x30c    |        4 | The number of SRAM words of a given bkdr target memory.                             |
+| bkdr_loader.[`DEPTH_INFO_4`](#depth_info)                             | 0x310    |        4 | The number of SRAM words of a given bkdr target memory.                             |
+| bkdr_loader.[`DEPTH_INFO_5`](#depth_info)                             | 0x314    |        4 | The number of SRAM words of a given bkdr target memory.                             |
+| bkdr_loader.[`DEPTH_INFO_6`](#depth_info)                             | 0x318    |        4 | The number of SRAM words of a given bkdr target memory.                             |
+| bkdr_loader.[`DEPTH_INFO_7`](#depth_info)                             | 0x31c    |        4 | The number of SRAM words of a given bkdr target memory.                             |
+| bkdr_loader.[`DEPTH_INFO_8`](#depth_info)                             | 0x320    |        4 | The number of SRAM words of a given bkdr target memory.                             |
+| bkdr_loader.[`DEPTH_INFO_9`](#depth_info)                             | 0x324    |        4 | The number of SRAM words of a given bkdr target memory.                             |
+| bkdr_loader.[`DEPTH_INFO_10`](#depth_info)                            | 0x328    |        4 | The number of SRAM words of a given bkdr target memory.                             |
+| bkdr_loader.[`DEPTH_INFO_11`](#depth_info)                            | 0x32c    |        4 | The number of SRAM words of a given bkdr target memory.                             |
+| bkdr_loader.[`READ_DATA_0`](#read_data)                               | 0x400    |        4 | Value to be read from the target memory at the current `INDEX`. If                  |
+| bkdr_loader.[`READ_DATA_1`](#read_data)                               | 0x404    |        4 | Value to be read from the target memory at the current `INDEX`. If                  |
+| bkdr_loader.[`READ_DATA_2`](#read_data)                               | 0x408    |        4 | Value to be read from the target memory at the current `INDEX`. If                  |
+| bkdr_loader.[`READ_DATA_3`](#read_data)                               | 0x40c    |        4 | Value to be read from the target memory at the current `INDEX`. If                  |
+| bkdr_loader.[`READ_DATA_4`](#read_data)                               | 0x410    |        4 | Value to be read from the target memory at the current `INDEX`. If                  |
+| bkdr_loader.[`READ_DATA_5`](#read_data)                               | 0x414    |        4 | Value to be read from the target memory at the current `INDEX`. If                  |
+| bkdr_loader.[`READ_DATA_6`](#read_data)                               | 0x418    |        4 | Value to be read from the target memory at the current `INDEX`. If                  |
+| bkdr_loader.[`READ_DATA_7`](#read_data)                               | 0x41c    |        4 | Value to be read from the target memory at the current `INDEX`. If                  |
+| bkdr_loader.[`WRITE_DATA_0`](#write_data)                             | 0x500    |        4 | Value to be written to the target memory at the current `INDEX`. If                 |
+| bkdr_loader.[`WRITE_DATA_1`](#write_data)                             | 0x504    |        4 | Value to be written to the target memory at the current `INDEX`. If                 |
+| bkdr_loader.[`WRITE_DATA_2`](#write_data)                             | 0x508    |        4 | Value to be written to the target memory at the current `INDEX`. If                 |
+| bkdr_loader.[`WRITE_DATA_3`](#write_data)                             | 0x50c    |        4 | Value to be written to the target memory at the current `INDEX`. If                 |
+| bkdr_loader.[`WRITE_DATA_4`](#write_data)                             | 0x510    |        4 | Value to be written to the target memory at the current `INDEX`. If                 |
+| bkdr_loader.[`WRITE_DATA_5`](#write_data)                             | 0x514    |        4 | Value to be written to the target memory at the current `INDEX`. If                 |
+| bkdr_loader.[`WRITE_DATA_6`](#write_data)                             | 0x518    |        4 | Value to be written to the target memory at the current `INDEX`. If                 |
+| bkdr_loader.[`WRITE_DATA_7`](#write_data)                             | 0x51c    |        4 | Value to be written to the target memory at the current `INDEX`. If                 |
+| bkdr_loader.[`INDEX`](#index)                                         | 0x600    |        4 | Index address of the SRAM word to be accessed. When `CONTROL.WRITE_ENA` is asserted |
 
 ## STATUS
 Status register
@@ -86,40 +86,60 @@ Status register
 Control register
 - Offset: `0x4`
 - Reset default: `0x0`
-- Reset mask: `0xff07`
+- Reset mask: `0xff0f`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "DONE", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "WRITE_ENA", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "CLEAR_START", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 5}, {"name": "TARGET_IDX", "bits": 8, "attr": ["rw"], "rotate": 0}, {"bits": 16}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "DONE", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "WRITE_ENA", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "CLEAR_START", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "AUTO_INCR", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 4}, {"name": "TARGET_IDX", "bits": 8, "attr": ["rw"], "rotate": 0}, {"bits": 16}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name                                 |
 |:------:|:------:|:-------:|:-------------------------------------|
 | 31:16  |        |         | Reserved                             |
 |  15:8  |   rw   |   0x0   | [TARGET_IDX](#control--target_idx)   |
-|  7:3   |        |         | Reserved                             |
+|  7:4   |        |         | Reserved                             |
+|   3    |   rw   |   0x0   | [AUTO_INCR](#control--auto_incr)     |
 |   2    |   rw   |   0x0   | [CLEAR_START](#control--clear_start) |
 |   1    |   rw   |   0x0   | [WRITE_ENA](#control--write_ena)     |
 |   0    |   rw   |   0x0   | [DONE](#control--done)               |
 
 ### CONTROL . TARGET_IDX
-The bkdr memory index to write to.
+The bkdr memory index to access.
 The size of this field must match the parameter TargetIdxWidth.
+
+### CONTROL . AUTO_INCR
+If `AUTO_INCR` is set to 1, `INDEX` will automatically be increased by 1 on
+accessing the highest 32-bit field of `READ_DATA`/`WRITE_DATA` corresponding to
+a full line of the target selected by `TARGET_IDX`; `WRITE_ENA` selects which of
+`READ_DATA`/`WRITE_DATA` is the active trigger. To set up an auto increment
+write sequence; first `WRITE_ENA` and
+`AUTO_INCR` are set to 1, `INDEX` is written with the start index of the block to
+be written. For e.g., a 37-bit-wide target, writing `WRITE_DATA[0]` has no side
+effect, whereas writing `WRITE_DATA[1]` launches the bkdr write and `INDEX`
+increment. Writing to `WRITE_DATA[0]` and `WRITE_DATA[1]` can be repeated until
+the memory block has been written. Deasserting `AUTO_INCR` returns to the manual
+mode.
 
 ### CONTROL . CLEAR_START
 Write 1 to trigger the bkdr_loader to clear the entire target memory
-that is currently selected by `TARGET_IDX`.
-The word that is cleared with is selected by `WRITE_DATA`.
+that is currently selected by `TARGET_IDX`. Register self-clears and always reads
+back 0. The word that is cleared with is selected by `WRITE_DATA`.
 Clear operation is completed if `STATUS.CLEAR_IDLE` becomes 1.
 bkdr writes will not have any effects during an active clear operation.
 
 ### CONTROL . WRITE_ENA
-If set, a bkdr write is launched when writing to the index register.
+While `AUTO_INCR` is deasserted, setting this launches a bkdr write when
+writing to the `INDEX` register. While `AUTO_INCR` is asserted, this field
+instead selects which auto-increment trigger is active: set to 1, a write to
+the highest 32-bit field of `WRITE_DATA` launches a bkdr write and advances
+`INDEX`; set to 0, a read of the highest 32-bit field of `READ_DATA` advances
+`INDEX` without a bkdr write, see `AUTO_INCR`.
 
 ### CONTROL . DONE
 Write 1 to trigger the bkdr_loader to switch to mission mode.
 After this, the bkdr_loader cannot be used until the next reset.
+Takes only effect if no clearing operation is running (STATUS.CLEAR_IDLE == 1).
 
 ## NUM_BKDR_TARGETS
 Number of bkdr targets available.
@@ -270,7 +290,10 @@ The number of SRAM words of a given bkdr target memory.
 |  31:0  |   ro   |    x    | VAL    |               |
 
 ## READ_DATA
-Value to be read from the target memory.
+Value to be read from the target memory at the current `INDEX`. If
+`CONTROL.AUTO_INCR` is asserted, reading from the highest 32-bit field corresponding
+to the line length of the selected target issues an `INDEX` increment, but only
+while `CONTROL.WRITE_ENA` is set to 0, see `WRITE_ENA`.
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -299,7 +322,11 @@ Value to be read from the target memory.
 |  31:0  |   ro   |   0x0   | VAL    |               |
 
 ## WRITE_DATA
-Value to be written to the target memory.
+Value to be written to the target memory at the current `INDEX`. If
+`CONTROL.AUTO_INCR` is asserted, writing to the highest 32-bit field corresponding to
+the line length of the selected target issues an `INDEX` increment and a bkdr write
+to the current value of `INDEX`, but only while `CONTROL.WRITE_ENA` is set to 1, see
+`WRITE_ENA`.
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -328,7 +355,11 @@ Value to be written to the target memory.
 |  31:0  |   rw   |   0x0   | VAL    |               |
 
 ## INDEX
-Index address of the SRAM word to be accessed.
+Index address of the SRAM word to be accessed. When `CONTROL.WRITE_ENA` is asserted
+and `AUTO_INCR` is deasserted, writing an index value commands a bkdr write to the
+target selected by `CONTROL.TARGET_IDX`.
+While `AUTO_INCR` is asserted, this register is incremented by hardware by 1 after
+each auto-triggered access, see `AUTO_INCR`.
 - Offset: `0x600`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`

--- a/hw/ip/bkdr_loader/rtl/bkdr_loader.sv
+++ b/hw/ip/bkdr_loader/rtl/bkdr_loader.sv
@@ -80,6 +80,19 @@ module bkdr_loader
   addr_t clear_addr_d, clear_addr_q;
   logic  clear_idle;
 
+  // Data reorganization
+  word_t                           write_data;
+  logic [MaxWordWidthDiv32-1:0]    write_data_qe;
+  logic [MaxWordWidthDiv32-1:0]    read_data_de;
+
+  // Auto increment signals
+  logic [MaxWordWidthIdxWidth-1:0] max_word_idx_tgt;
+  logic                            auto_incr_read;
+  logic                            auto_incr_write;
+
+  // Currently selected target index
+  tgt_idx_t tgt_idx_sel;
+
   logic [31:0] mission_mode_dly_d, mission_mode_dly_q;
 
   logic bkdr_en_q, bkdr_en_d;
@@ -172,7 +185,7 @@ module bkdr_loader
       CLEAR : begin
         clear_idle   = 1'b0;
         clear_addr_d = clear_addr_q + 'd1;
-        if (bkdr_rsp_i[reg2hw.control.target_idx.q].param_depth - 'd1 == clear_addr_q) begin
+        if (bkdr_rsp_i[tgt_idx_sel].param_depth - 'd1 == clear_addr_q) begin
           clear_state_d = IDLE;
         end
       end
@@ -280,12 +293,14 @@ module bkdr_loader
     .intg_err_o()
   );
 
+  assign tgt_idx_sel = reg2hw.control.target_idx.q;
+
   // Throw error if we address a non-existing target
-  assign tgt_idx_err = !(bkdr_idx_e'(reg2hw.control.target_idx.q) inside {BkdrValidTgts});
+  assign tgt_idx_err = !(bkdr_idx_e'(tgt_idx_sel) inside {BkdrValidTgts});
 
   assign hw2reg.usr_access_timestamp.d = fpga_info_i;
   assign hw2reg.status.target_error.d  = tgt_idx_err;
-  assign hw2reg.read_data              = bkdr_rsp_i[reg2hw.control.target_idx.q].rdata;
+  assign hw2reg.read_data              = bkdr_rsp_i[tgt_idx_sel].rdata;
 
   // assign target info registers
   assign hw2reg.num_bkdr_targets = NumBkdrTgts;
@@ -295,6 +310,31 @@ module bkdr_loader
     assign hw2reg.depth_info[i].d  = bkdr_rsp_i[i].param_depth;
   end
 
+  // The auto increment feature needs to know the index of the highest 32-bit word required to
+  // write a single line in the target. Writing on this word triggers the write and increment.
+  assign max_word_idx_tgt = (bkdr_rsp_i[tgt_idx_sel].param_width - 'd1) >> 'd5;
+
+  // Auto increment write is triggered iff, the feature is enabled, and a write to the highest
+  // 32-bit word describing the line width of the selected target happens. Write has to be enabled.
+  assign auto_incr_write = reg2hw.control.auto_incr.q && write_data_qe[max_word_idx_tgt] &&
+                           reg2hw.control.write_ena.q;
+
+  // Auto increment read is triggered iff, the feature is enabled, and a read to the highest
+  // 32-bit word describing the line width of the selected target happens. Write has to be disabled.
+  assign auto_incr_read = reg2hw.control.auto_incr.q && read_data_de[max_word_idx_tgt] &&
+                          !reg2hw.control.write_ena.q;
+
+  // Auto increment increments the index
+  assign hw2reg.index.d  = reg2hw.index.q + 'd1;
+  assign hw2reg.index.de = auto_incr_read || auto_incr_write;
+
+  // Assemble write_data
+  for (genvar i = 0; i < MaxWordWidthDiv32; i++) begin : gen_write_data_reorg
+    assign write_data[i]    = reg2hw.write_data[i].q;
+    assign write_data_qe[i] = reg2hw.write_data[i].qe;
+    assign read_data_de[i]  = reg2hw.read_data[i].re;
+   end
+
   always_comb begin : proc_format_req
     // Default: forward all data
     for (int unsigned i = 0; i < NumBkdrTgts; i++) begin
@@ -303,15 +343,17 @@ module bkdr_loader
         write:  1'b0,
         active: bkdr_active,
         addr:   !clear_idle ? clear_addr_q : reg2hw.index.q,
-        wdata:  reg2hw.write_data
+        wdata:  write_data
       };
     end
 
     // Strobe endpoint to be written
-    bkdr_req_o[reg2hw.control.target_idx.q].write = !clear_idle ||
-                                                    (reg2hw.control.write_ena.q &&
-                                                     reg2hw.index.qe            &&
-                                                     !tgt_idx_err);
+    bkdr_req_o[tgt_idx_sel].write = !tgt_idx_err     && // We have a valid index
+                                    (auto_incr_write || // Auto increment active
+                                    !clear_idle      || // Clearing active
+                                    (reg2hw.control.write_ena.q && // A manual write happens
+                                     reg2hw.index.qe            && // by writing the index register
+                                     !reg2hw.control.auto_incr.q));// while auto_incr is deactivated
   end
 
 

--- a/hw/ip/bkdr_loader/rtl/bkdr_loader_pkg.sv
+++ b/hw/ip/bkdr_loader/rtl/bkdr_loader_pkg.sv
@@ -8,9 +8,9 @@ package bkdr_loader_pkg;
 
   import bkdr_loader_reg_pkg::*;
 
-  localparam int unsigned MaxWordWidth = 32'd32 * MaxWordWidthDiv32;
-  localparam int unsigned AddrWidth    = 32'd32;
-  localparam int unsigned RegWidth     = 32'd32;
+  localparam int unsigned AddrWidth            = 32'd32;
+  localparam int unsigned RegWidth             = 32'd32;
+  localparam int unsigned MaxWordWidthIdxWidth = $clog2(MaxWordWidthDiv32);
 
   typedef struct packed {
     bit [ 3:0]  version;
@@ -26,9 +26,10 @@ package bkdr_loader_pkg;
     version:       4'h0                 /* 1st Version */
   };
 
-  typedef logic [AddrWidth-1:0]    addr_t;
-  typedef logic [RegWidth-1:0]     reg_t;
-  typedef logic [MaxWordWidth-1:0] word_t;
+  typedef logic [AddrWidth-1:0]               addr_t;
+  typedef logic [RegWidth-1:0]                reg_t;
+  typedef logic [MaxWordWidthDiv32-1:0][31:0] word_t;
+  typedef logic [TargetIdxWidth-1:0]          tgt_idx_t;
 
   // Target indices
   typedef enum logic [TargetIdxWidth-1:0] {

--- a/hw/ip/bkdr_loader/rtl/bkdr_loader_reg_pkg.sv
+++ b/hw/ip/bkdr_loader/rtl/bkdr_loader_reg_pkg.sv
@@ -29,6 +29,10 @@ package bkdr_loader_reg_pkg;
     struct packed {
       logic        q;
       logic        qe;
+    } auto_incr;
+    struct packed {
+      logic        q;
+      logic        qe;
     } clear_start;
     struct packed {
       logic        q;
@@ -46,6 +50,12 @@ package bkdr_loader_reg_pkg;
 
   typedef struct packed {
     logic [31:0] q;
+    logic        re;
+  } bkdr_loader_reg2hw_read_data_mreg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+    logic        qe;
   } bkdr_loader_reg2hw_write_data_mreg_t;
 
   typedef struct packed {
@@ -93,24 +103,31 @@ package bkdr_loader_reg_pkg;
     logic [31:0] d;
   } bkdr_loader_hw2reg_read_data_mreg_t;
 
+  typedef struct packed {
+    logic [31:0] d;
+    logic        de;
+  } bkdr_loader_hw2reg_index_reg_t;
+
   // Register -> HW type for regs interface
   typedef struct packed {
-    bkdr_loader_reg2hw_control_reg_t control; // [335:321]
-    bkdr_loader_reg2hw_mission_mode_switch_delay_reg_t mission_mode_switch_delay; // [320:289]
-    bkdr_loader_reg2hw_write_data_mreg_t [7:0] write_data; // [288:33]
+    bkdr_loader_reg2hw_control_reg_t control; // [609:593]
+    bkdr_loader_reg2hw_mission_mode_switch_delay_reg_t mission_mode_switch_delay; // [592:561]
+    bkdr_loader_reg2hw_read_data_mreg_t [7:0] read_data; // [560:297]
+    bkdr_loader_reg2hw_write_data_mreg_t [7:0] write_data; // [296:33]
     bkdr_loader_reg2hw_index_reg_t index; // [32:0]
   } bkdr_loader_regs_reg2hw_t;
 
   // HW -> register type for regs interface
   typedef struct packed {
-    bkdr_loader_hw2reg_status_reg_t status; // [1475:1474]
-    bkdr_loader_hw2reg_control_reg_t control; // [1473:1472]
-    bkdr_loader_hw2reg_num_bkdr_targets_reg_t num_bkdr_targets; // [1471:1440]
-    bkdr_loader_hw2reg_usr_access_timestamp_reg_t usr_access_timestamp; // [1439:1408]
-    bkdr_loader_hw2reg_target_info_mreg_t [11:0] target_info; // [1407:1024]
-    bkdr_loader_hw2reg_width_info_mreg_t [11:0] width_info; // [1023:640]
-    bkdr_loader_hw2reg_depth_info_mreg_t [11:0] depth_info; // [639:256]
-    bkdr_loader_hw2reg_read_data_mreg_t [7:0] read_data; // [255:0]
+    bkdr_loader_hw2reg_status_reg_t status; // [1508:1507]
+    bkdr_loader_hw2reg_control_reg_t control; // [1506:1505]
+    bkdr_loader_hw2reg_num_bkdr_targets_reg_t num_bkdr_targets; // [1504:1473]
+    bkdr_loader_hw2reg_usr_access_timestamp_reg_t usr_access_timestamp; // [1472:1441]
+    bkdr_loader_hw2reg_target_info_mreg_t [11:0] target_info; // [1440:1057]
+    bkdr_loader_hw2reg_width_info_mreg_t [11:0] width_info; // [1056:673]
+    bkdr_loader_hw2reg_depth_info_mreg_t [11:0] depth_info; // [672:289]
+    bkdr_loader_hw2reg_read_data_mreg_t [7:0] read_data; // [288:33]
+    bkdr_loader_hw2reg_index_reg_t index; // [32:0]
   } bkdr_loader_regs_hw2reg_t;
 
   // Register offsets for regs interface

--- a/hw/ip/bkdr_loader/rtl/bkdr_loader_regs_reg_top.sv
+++ b/hw/ip/bkdr_loader/rtl/bkdr_loader_regs_reg_top.sv
@@ -131,6 +131,8 @@ module bkdr_loader_regs_reg_top (
   logic control_write_ena_wd;
   logic control_clear_start_qs;
   logic control_clear_start_wd;
+  logic control_auto_incr_qs;
+  logic control_auto_incr_wd;
   logic [7:0] control_target_idx_qs;
   logic [7:0] control_target_idx_wd;
   logic num_bkdr_targets_re;
@@ -295,7 +297,7 @@ module bkdr_loader_regs_reg_top (
 
   // R[control]: V(False)
   logic control_qe;
-  logic [3:0] control_flds_we;
+  logic [4:0] control_flds_we;
   prim_flop #(
     .Width(1),
     .ResetValue(0)
@@ -389,6 +391,34 @@ module bkdr_loader_regs_reg_top (
   );
   assign reg2hw.control.clear_start.qe = control_qe;
 
+  //   F[auto_incr]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_control_auto_incr (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (control_we),
+    .wd     (control_auto_incr_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (control_flds_we[3]),
+    .q      (reg2hw.control.auto_incr.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (control_auto_incr_qs)
+  );
+  assign reg2hw.control.auto_incr.qe = control_qe;
+
   //   F[target_idx]: 15:8
   prim_subreg #(
     .DW      (8),
@@ -408,7 +438,7 @@ module bkdr_loader_regs_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (control_flds_we[3]),
+    .qe     (control_flds_we[4]),
     .q      (reg2hw.control.target_idx.q),
     .ds     (),
 
@@ -1099,9 +1129,9 @@ module bkdr_loader_regs_reg_top (
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.read_data[0].d),
-    .qre    (),
+    .qre    (reg2hw.read_data[0].re),
     .qe     (),
-    .q      (),
+    .q      (reg2hw.read_data[0].q),
     .ds     (),
     .qs     (read_data_0_qs)
   );
@@ -1116,9 +1146,9 @@ module bkdr_loader_regs_reg_top (
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.read_data[1].d),
-    .qre    (),
+    .qre    (reg2hw.read_data[1].re),
     .qe     (),
-    .q      (),
+    .q      (reg2hw.read_data[1].q),
     .ds     (),
     .qs     (read_data_1_qs)
   );
@@ -1133,9 +1163,9 @@ module bkdr_loader_regs_reg_top (
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.read_data[2].d),
-    .qre    (),
+    .qre    (reg2hw.read_data[2].re),
     .qe     (),
-    .q      (),
+    .q      (reg2hw.read_data[2].q),
     .ds     (),
     .qs     (read_data_2_qs)
   );
@@ -1150,9 +1180,9 @@ module bkdr_loader_regs_reg_top (
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.read_data[3].d),
-    .qre    (),
+    .qre    (reg2hw.read_data[3].re),
     .qe     (),
-    .q      (),
+    .q      (reg2hw.read_data[3].q),
     .ds     (),
     .qs     (read_data_3_qs)
   );
@@ -1167,9 +1197,9 @@ module bkdr_loader_regs_reg_top (
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.read_data[4].d),
-    .qre    (),
+    .qre    (reg2hw.read_data[4].re),
     .qe     (),
-    .q      (),
+    .q      (reg2hw.read_data[4].q),
     .ds     (),
     .qs     (read_data_4_qs)
   );
@@ -1184,9 +1214,9 @@ module bkdr_loader_regs_reg_top (
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.read_data[5].d),
-    .qre    (),
+    .qre    (reg2hw.read_data[5].re),
     .qe     (),
-    .q      (),
+    .q      (reg2hw.read_data[5].q),
     .ds     (),
     .qs     (read_data_5_qs)
   );
@@ -1201,9 +1231,9 @@ module bkdr_loader_regs_reg_top (
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.read_data[6].d),
-    .qre    (),
+    .qre    (reg2hw.read_data[6].re),
     .qe     (),
-    .q      (),
+    .q      (reg2hw.read_data[6].q),
     .ds     (),
     .qs     (read_data_6_qs)
   );
@@ -1218,9 +1248,9 @@ module bkdr_loader_regs_reg_top (
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.read_data[7].d),
-    .qre    (),
+    .qre    (reg2hw.read_data[7].re),
     .qe     (),
-    .q      (),
+    .q      (reg2hw.read_data[7].q),
     .ds     (),
     .qs     (read_data_7_qs)
   );
@@ -1228,6 +1258,17 @@ module bkdr_loader_regs_reg_top (
 
   // Subregister 0 of Multireg write_data
   // R[write_data_0]: V(False)
+  logic write_data_0_qe;
+  logic [0:0] write_data_0_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_write_data0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&write_data_0_flds_we),
+    .q_o(write_data_0_qe)
+  );
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1246,17 +1287,29 @@ module bkdr_loader_regs_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (write_data_0_flds_we[0]),
     .q      (reg2hw.write_data[0].q),
     .ds     (),
 
     // to register interface (read)
     .qs     (write_data_0_qs)
   );
+  assign reg2hw.write_data[0].qe = write_data_0_qe;
 
 
   // Subregister 1 of Multireg write_data
   // R[write_data_1]: V(False)
+  logic write_data_1_qe;
+  logic [0:0] write_data_1_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_write_data1_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&write_data_1_flds_we),
+    .q_o(write_data_1_qe)
+  );
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1275,17 +1328,29 @@ module bkdr_loader_regs_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (write_data_1_flds_we[0]),
     .q      (reg2hw.write_data[1].q),
     .ds     (),
 
     // to register interface (read)
     .qs     (write_data_1_qs)
   );
+  assign reg2hw.write_data[1].qe = write_data_1_qe;
 
 
   // Subregister 2 of Multireg write_data
   // R[write_data_2]: V(False)
+  logic write_data_2_qe;
+  logic [0:0] write_data_2_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_write_data2_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&write_data_2_flds_we),
+    .q_o(write_data_2_qe)
+  );
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1304,17 +1369,29 @@ module bkdr_loader_regs_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (write_data_2_flds_we[0]),
     .q      (reg2hw.write_data[2].q),
     .ds     (),
 
     // to register interface (read)
     .qs     (write_data_2_qs)
   );
+  assign reg2hw.write_data[2].qe = write_data_2_qe;
 
 
   // Subregister 3 of Multireg write_data
   // R[write_data_3]: V(False)
+  logic write_data_3_qe;
+  logic [0:0] write_data_3_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_write_data3_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&write_data_3_flds_we),
+    .q_o(write_data_3_qe)
+  );
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1333,17 +1410,29 @@ module bkdr_loader_regs_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (write_data_3_flds_we[0]),
     .q      (reg2hw.write_data[3].q),
     .ds     (),
 
     // to register interface (read)
     .qs     (write_data_3_qs)
   );
+  assign reg2hw.write_data[3].qe = write_data_3_qe;
 
 
   // Subregister 4 of Multireg write_data
   // R[write_data_4]: V(False)
+  logic write_data_4_qe;
+  logic [0:0] write_data_4_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_write_data4_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&write_data_4_flds_we),
+    .q_o(write_data_4_qe)
+  );
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1362,17 +1451,29 @@ module bkdr_loader_regs_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (write_data_4_flds_we[0]),
     .q      (reg2hw.write_data[4].q),
     .ds     (),
 
     // to register interface (read)
     .qs     (write_data_4_qs)
   );
+  assign reg2hw.write_data[4].qe = write_data_4_qe;
 
 
   // Subregister 5 of Multireg write_data
   // R[write_data_5]: V(False)
+  logic write_data_5_qe;
+  logic [0:0] write_data_5_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_write_data5_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&write_data_5_flds_we),
+    .q_o(write_data_5_qe)
+  );
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1391,17 +1492,29 @@ module bkdr_loader_regs_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (write_data_5_flds_we[0]),
     .q      (reg2hw.write_data[5].q),
     .ds     (),
 
     // to register interface (read)
     .qs     (write_data_5_qs)
   );
+  assign reg2hw.write_data[5].qe = write_data_5_qe;
 
 
   // Subregister 6 of Multireg write_data
   // R[write_data_6]: V(False)
+  logic write_data_6_qe;
+  logic [0:0] write_data_6_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_write_data6_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&write_data_6_flds_we),
+    .q_o(write_data_6_qe)
+  );
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1420,17 +1533,29 @@ module bkdr_loader_regs_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (write_data_6_flds_we[0]),
     .q      (reg2hw.write_data[6].q),
     .ds     (),
 
     // to register interface (read)
     .qs     (write_data_6_qs)
   );
+  assign reg2hw.write_data[6].qe = write_data_6_qe;
 
 
   // Subregister 7 of Multireg write_data
   // R[write_data_7]: V(False)
+  logic write_data_7_qe;
+  logic [0:0] write_data_7_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_write_data7_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&write_data_7_flds_we),
+    .q_o(write_data_7_qe)
+  );
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1449,13 +1574,14 @@ module bkdr_loader_regs_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (write_data_7_flds_we[0]),
     .q      (reg2hw.write_data[7].q),
     .ds     (),
 
     // to register interface (read)
     .qs     (write_data_7_qs)
   );
+  assign reg2hw.write_data[7].qe = write_data_7_qe;
 
 
   // R[index]: V(False)
@@ -1484,8 +1610,8 @@ module bkdr_loader_regs_reg_top (
     .wd     (index_wd),
 
     // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
+    .de     (hw2reg.index.de),
+    .d      (hw2reg.index.d),
 
     // to internal hardware
     .qe     (index_flds_we[0]),
@@ -1635,6 +1761,8 @@ module bkdr_loader_regs_reg_top (
   assign control_write_ena_wd = reg_wdata[1];
 
   assign control_clear_start_wd = reg_wdata[2];
+
+  assign control_auto_incr_wd = reg_wdata[3];
 
   assign control_target_idx_wd = reg_wdata[15:8];
   assign num_bkdr_targets_re = addr_hit[2] & reg_re & !reg_error;
@@ -1789,6 +1917,7 @@ module bkdr_loader_regs_reg_top (
         reg_rdata_next[0] = control_done_qs;
         reg_rdata_next[1] = control_write_ena_qs;
         reg_rdata_next[2] = control_clear_start_qs;
+        reg_rdata_next[3] = control_auto_incr_qs;
         reg_rdata_next[15:8] = control_target_idx_qs;
       end
 

--- a/hw/ip/rom_ctrl/data/rom_ctrl.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl.hjson
@@ -93,7 +93,7 @@
     { name:      "MemSizeRom",
       desc:      "Memory size of the ROM (in bytes).",
       type:      "int",
-      default:   "0x8000"
+      default:   "0xc000"
     },
   ]
   alert_list: [

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -9017,7 +9017,7 @@
       {
         rom:
         {
-          hart: 0x00008000
+          hart: 0x00040000
         }
         regs:
         {
@@ -9033,7 +9033,7 @@
           data_intg_passthru: True
           exec: True
           byte_write: False
-          size: 0x8000
+          size: 0xc000
         }
       }
       param_decl:
@@ -9089,7 +9089,7 @@
           desc: Memory size of the ROM (in bytes).
           type: int
           name_top: MemSizeRomCtrlRom
-          default: 32768
+          default: 49152
         }
       ]
       inter_signal_list:
@@ -10940,9 +10940,9 @@
             {
               base_addrs:
               {
-                hart: 0x8000
+                hart: 0x40000
               }
-              size_byte: 0x8000
+              size_byte: 0xc000
             }
           ]
           xbar: false

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.secrets.testing.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.secrets.testing.gen.hjson
@@ -3633,7 +3633,7 @@
       {
         rom:
         {
-          hart: 0x00008000
+          hart: 0x00040000
         }
         regs:
         {
@@ -3649,7 +3649,7 @@
           data_intg_passthru: True
           exec: True
           byte_write: False
-          size: 0x8000
+          size: 0xc000
         }
       }
       param_list:

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -964,8 +964,10 @@
       clock_srcs: {clk_i: "main"},
       clock_group: "infra",
       reset_connections: {rst_ni: "lc"},
+      // The ROM section is PMP protected. If either base addr or size is changed then
+      // the reset values for the PMP migth changes too (ibex_pmp_reset_pkg.sv).
       base_addrs: {
-        rom:  {hart: "0x00008000"},
+        rom:  {hart: "0x00040000"},
         regs: {hart: "0x411e0000"}
       }
       memory: {
@@ -975,7 +977,7 @@
           data_intg_passthru: "true",
           exec:               "True",
           byte_write:         "False",
-          size:               "0x8000",
+          size:               "0xc000",
           data_intg_passthru: "True"
         }
       },

--- a/hw/top_earlgrey/doc/memory_map.md
+++ b/hw/top_earlgrey/doc/memory_map.md
@@ -66,4 +66,4 @@ The main address space, shared between the CPU and DM
 | sram_ctrl_ret_aon | ram         | `0x40600000`   | `0x1000`       | `0x400`        |
 | flash_ctrl        | mem         | `0x20000000`   | `0x100000`     | `0x40000`      |
 | sram_ctrl_main    | ram         | `0x10000000`   | `0x20000`      | `0x8000`       |
-| rom_ctrl          | rom         | `0x8000`       | `0x8000`       | `0x2000`       |
+| rom_ctrl          | rom         | `0x40000`      | `0xC000`       | `0x3000`       |

--- a/hw/top_earlgrey/dv/autogen/xbar_env_pkg__params.sv
+++ b/hw/top_earlgrey/dv/autogen/xbar_env_pkg__params.sv
@@ -14,7 +14,7 @@ tl_device_t xbar_devices[$] = '{
         '{32'h00010000, 32'h00010fff}
     }},
     '{"rom_ctrl__rom", '{
-        '{32'h00008000, 32'h0000ffff}
+        '{32'h00040000, 32'h0004bfff}
     }},
     '{"rom_ctrl__regs", '{
         '{32'h411e0000, 32'h411e007f}

--- a/hw/top_earlgrey/dv/autogen/xbar_tgl_excl.cfg
+++ b/hw/top_earlgrey/dv/autogen/xbar_tgl_excl.cfg
@@ -31,7 +31,6 @@
 -node tb.dut*.u_rv_dm regs_tl_*i.a_address[31:31]
 -node tb.dut*.u_rv_dm mem_tl_*i.a_address[15:12]
 -node tb.dut*.u_rv_dm mem_tl_*i.a_address[31:17]
--node tb.dut*.u_rom_ctrl rom_tl_*i.a_address[31:16]
 -node tb.dut*.u_rom_ctrl regs_tl_*i.a_address[16:7]
 -node tb.dut*.u_rom_ctrl regs_tl_*i.a_address[23:21]
 -node tb.dut*.u_rom_ctrl regs_tl_*i.a_address[29:25]

--- a/hw/top_earlgrey/dv/verilator/chip_sim_tb.cc
+++ b/hw/top_earlgrey/dv/verilator/chip_sim_tb.cc
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
 
   MemArea rom0(top_scope + (".u_rom_ctrl.gen_rom_scramble_enabled.u_rom.u_rom."
                             "u_prim_rom"),
-               0x8000 / 4, 4);
+               0xc000 / 4, 4);
   MemArea ram(top_scope + ".u_ram1p_ram_main." + ram1p_adv_scope, 0x20000 / 4,
               4);
   // Only handle the lower bank of flash for now.
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
 
   MemArea otp(top_scope + ".u_otp_macro." + ram1p_adv_scope, 0x4000 / 4, 4);
 
-  memutil.RegisterMemoryArea("rom0", 0x8000, &rom0);
+  memutil.RegisterMemoryArea("rom0", 0x40000, &rom0);
   memutil.RegisterMemoryArea("ram", 0x10000000u, &ram);
   memutil.RegisterMemoryArea("flash0", 0x20000000u, &flash0);
   memutil.RegisterMemoryArea("flash1", 0x20080000u, &flash1);

--- a/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
@@ -217,9 +217,9 @@
         {
           base_addrs:
           {
-            hart: 0x8000
+            hart: 0x40000
           }
-          size_byte: 0x8000
+          size_byte: 0xc000
         }
       ]
       xbar: false

--- a/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_cover.cfg
+++ b/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_cover.cfg
@@ -27,7 +27,6 @@
 -node tb.dut tl_rv_dm__regs_o.a_address[31:31]
 -node tb.dut tl_rv_dm__mem_o.a_address[15:12]
 -node tb.dut tl_rv_dm__mem_o.a_address[31:17]
--node tb.dut tl_rom_ctrl__rom_o.a_address[31:16]
 -node tb.dut tl_rom_ctrl__regs_o.a_address[16:7]
 -node tb.dut tl_rom_ctrl__regs_o.a_address[23:21]
 -node tb.dut tl_rom_ctrl__regs_o.a_address[29:25]

--- a/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_env_pkg__params.sv
+++ b/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_env_pkg__params.sv
@@ -14,7 +14,7 @@ tl_device_t xbar_devices[$] = '{
         '{32'h00010000, 32'h00010fff}
     }},
     '{"rom_ctrl__rom", '{
-        '{32'h00008000, 32'h0000ffff}
+        '{32'h00040000, 32'h0004bfff}
     }},
     '{"rom_ctrl__regs", '{
         '{32'h411e0000, 32'h411e007f}

--- a/hw/top_earlgrey/ip/xbar_main/rtl/autogen/tl_main_pkg.sv
+++ b/hw/top_earlgrey/ip/xbar_main/rtl/autogen/tl_main_pkg.sv
@@ -8,7 +8,7 @@ package tl_main_pkg;
 
   localparam logic [31:0] ADDR_SPACE_RV_DM__REGS          = 32'h 41200000;
   localparam logic [31:0] ADDR_SPACE_RV_DM__MEM           = 32'h 00010000;
-  localparam logic [31:0] ADDR_SPACE_ROM_CTRL__ROM        = 32'h 00008000;
+  localparam logic [31:0] ADDR_SPACE_ROM_CTRL__ROM        = 32'h 00040000;
   localparam logic [31:0] ADDR_SPACE_ROM_CTRL__REGS       = 32'h 411e0000;
   localparam logic [1:0][31:0] ADDR_SPACE_PERI                 = {
     32'h 40400000,
@@ -36,7 +36,7 @@ package tl_main_pkg;
 
   localparam logic [31:0] ADDR_MASK_RV_DM__REGS          = 32'h 0000000f;
   localparam logic [31:0] ADDR_MASK_RV_DM__MEM           = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_ROM_CTRL__ROM        = 32'h 00007fff;
+  localparam logic [31:0] ADDR_SIZE_ROM_CTRL__ROM        = 32'h 0000c000;
   localparam logic [31:0] ADDR_MASK_ROM_CTRL__REGS       = 32'h 0000007f;
   localparam logic [1:0][31:0] ADDR_MASK_PERI                 = {
     32'h 003fffff,

--- a/hw/top_earlgrey/ip/xbar_main/rtl/autogen/xbar_main.sv
+++ b/hw/top_earlgrey/ip/xbar_main/rtl/autogen/xbar_main.sv
@@ -678,8 +678,8 @@ module xbar_main (
   always_comb begin
     // default steering to generate error response if address is not within the range
     dev_sel_s1n_27 = 3'd4;
-    if ((tl_s1n_27_us_h2d.a_address &
-         ~(ADDR_MASK_ROM_CTRL__ROM)) == ADDR_SPACE_ROM_CTRL__ROM) begin
+    if (((tl_s1n_27_us_h2d.a_address < (ADDR_SPACE_ROM_CTRL__ROM + ADDR_SIZE_ROM_CTRL__ROM)) &&
+       (tl_s1n_27_us_h2d.a_address >= ADDR_SPACE_ROM_CTRL__ROM))) begin
       dev_sel_s1n_27 = 3'd0;
 
     end else if ((tl_s1n_27_us_h2d.a_address &
@@ -699,8 +699,8 @@ end
   always_comb begin
     // default steering to generate error response if address is not within the range
     dev_sel_s1n_32 = 5'd24;
-    if ((tl_s1n_32_us_h2d.a_address &
-         ~(ADDR_MASK_ROM_CTRL__ROM)) == ADDR_SPACE_ROM_CTRL__ROM) begin
+    if (((tl_s1n_32_us_h2d.a_address < (ADDR_SPACE_ROM_CTRL__ROM + ADDR_SIZE_ROM_CTRL__ROM)) &&
+       (tl_s1n_32_us_h2d.a_address >= ADDR_SPACE_ROM_CTRL__ROM))) begin
       dev_sel_s1n_32 = 5'd0;
 
     end else if ((tl_s1n_32_us_h2d.a_address &
@@ -802,8 +802,8 @@ end
   always_comb begin
     // default steering to generate error response if address is not within the range
     dev_sel_s1n_57 = 5'd24;
-    if ((tl_s1n_57_us_h2d.a_address &
-         ~(ADDR_MASK_ROM_CTRL__ROM)) == ADDR_SPACE_ROM_CTRL__ROM) begin
+    if (((tl_s1n_57_us_h2d.a_address < (ADDR_SPACE_ROM_CTRL__ROM + ADDR_SIZE_ROM_CTRL__ROM)) &&
+       (tl_s1n_57_us_h2d.a_address >= ADDR_SPACE_ROM_CTRL__ROM))) begin
       dev_sel_s1n_57 = 5'd0;
 
     end else if ((tl_s1n_57_us_h2d.a_address &

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -2426,7 +2426,7 @@ module top_earlgrey #(
     .RndCnstScrNonce(RndCnstRomCtrlScrNonce),
     .RndCnstScrKey(RndCnstRomCtrlScrKey),
     .SecDisableScrambling(SecRomCtrlDisableScrambling),
-    .MemSizeRom(32768)
+    .MemSizeRom(49152)
   ) u_rom_ctrl (
     // Clock and reset connections
     .clk_i(clkmgr_aon_clocks_i.clk_main_infra),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
@@ -482,12 +482,12 @@ package top_earlgrey_pkg;
   /**
    * Memory base address for rom memory on rom_ctrl in top earlgrey.
    */
-  parameter int unsigned TOP_EARLGREY_ROM_CTRL_ROM_BASE_ADDR = 32'h8000;
+  parameter int unsigned TOP_EARLGREY_ROM_CTRL_ROM_BASE_ADDR = 32'h40000;
 
   /**
    * Memory size for rom memory on rom_ctrl in top earlgrey.
    */
-  parameter int unsigned TOP_EARLGREY_ROM_CTRL_ROM_SIZE_BYTES = 32'h8000;
+  parameter int unsigned TOP_EARLGREY_ROM_CTRL_ROM_SIZE_BYTES = 32'hc000;
 
 
   // Enumeration of alert modules

--- a/hw/top_earlgrey/rtl/ibex_pmp_reset_pkg.sv
+++ b/hw/top_earlgrey/rtl/ibex_pmp_reset_pkg.sv
@@ -38,7 +38,7 @@ package ibex_pmp_reset_pkg;
   localparam logic [33:0] PmpAddrRst[16] = '{
     34'h00000000, // rgn 0
     34'h00000000, // rgn 1
-    34'h000083fc, // rgn 2  [ROM: base=0x0000_8000 size=0x800 (2KiB)]
+    34'h000403fc, // rgn 2  [ROM: base=0x0004_0000 size=0x800 (2KiB)]
     34'h00000000, // rgn 3
     34'h00000000, // rgn 4
     34'h00000000, // rgn 5

--- a/hw/top_earlgrey/sw/autogen/chip/top_earlgrey.rs
+++ b/hw/top_earlgrey/sw/autogen/chip/top_earlgrey.rs
@@ -656,10 +656,10 @@ pub const SRAM_CTRL_MAIN_RAM_BASE_ADDR: usize = 0x10000000;
 pub const SRAM_CTRL_MAIN_RAM_SIZE_BYTES: usize = 0x20000;
 
 /// Memory base address for rom memory on rom_ctrl in top earlgrey.
-pub const ROM_CTRL_ROM_BASE_ADDR: usize = 0x8000;
+pub const ROM_CTRL_ROM_BASE_ADDR: usize = 0x40000;
 
 /// Memory size for rom memory on rom_ctrl in top earlgrey.
-pub const ROM_CTRL_ROM_SIZE_BYTES: usize = 0x8000;
+pub const ROM_CTRL_ROM_SIZE_BYTES: usize = 0xC000;
 
 /// PLIC Interrupt Source Peripheral.
 ///

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -856,12 +856,12 @@ extern "C" {
 /**
  * Memory base address for rom memory on rom_ctrl in top earlgrey.
  */
-#define TOP_EARLGREY_ROM_CTRL_ROM_BASE_ADDR 0x8000u
+#define TOP_EARLGREY_ROM_CTRL_ROM_BASE_ADDR 0x40000u
 
 /**
  * Memory size for rom memory on rom_ctrl in top earlgrey.
  */
-#define TOP_EARLGREY_ROM_CTRL_ROM_SIZE_BYTES 0x8000u
+#define TOP_EARLGREY_ROM_CTRL_ROM_SIZE_BYTES 0xC000u
 
 
 /**

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h
@@ -58,12 +58,12 @@
 /**
  * Memory base for rom memory on rom_ctrl in top earlgrey.
  */
-#define TOP_EARLGREY_ROM_CTRL_ROM_BASE_ADDR 0x8000
+#define TOP_EARLGREY_ROM_CTRL_ROM_BASE_ADDR 0x40000
 
 /**
  * Memory size for rom memory on rom_ctrl in top earlgrey.
  */
-#define TOP_EARLGREY_ROM_CTRL_ROM_SIZE_BYTES 0x8000
+#define TOP_EARLGREY_ROM_CTRL_ROM_SIZE_BYTES 0xC000
 
 
 /**

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
@@ -17,7 +17,7 @@ MEMORY {
   ram_ret_aon(rwx) : ORIGIN = 0x40600000, LENGTH = 0x1000
   eflash(rx) : ORIGIN = 0x20000000, LENGTH = 0x100000
   ram_main(rwx) : ORIGIN = 0x10000000, LENGTH = 0x20000
-  rom(rx) : ORIGIN = 0x00008000, LENGTH = 0x8000
+  rom(rx) : ORIGIN = 0x00040000, LENGTH = 0xc000
   rom_ext_virtual(rx) : ORIGIN = 0x90000000, LENGTH = 0x80000
   owner_virtual(rx) : ORIGIN = 0xa0000000, LENGTH = 0x80000
 }

--- a/sw/device/silicon_creator/rom/doc/memory_protection.md
+++ b/sw/device/silicon_creator/rom/doc/memory_protection.md
@@ -44,16 +44,19 @@ Once initially configured the PMP configuration is expected to remain static thr
 ## PMP Entry Allocation
 
 Each memory region the ROM is concerned with has its own dedicated PMP entry.
-The allocation here is arbitrary except that overlapping regions are placed next to one another with the smaller more specific region given a higher priority entry.
-For example, the ROM TEXT entry precedes the more general ROM entry of which it is a sub region.
+The allocation here is arbitrary except that overlapping or adjacent regions are placed next to one another, with the smaller more specific region given a higher priority entry.
+For example, the ROM TEXT entry precedes the ROM entry that covers the rest of the ROM.
+
+Entry 2 (ROM) uses the TOR addressing mode chained onto entry 1 (ROM TEXT) since the ROM size is not required to be a power of two and NAPOT can only encode naturally-aligned power-of-two regions.
+It therefore covers `[end of ROM TEXT, end of ROM)` rather than the whole ROM while the first entry already covers `[start of ROM, end of ROM TEXT)` with read permission.
 
 The entry allocation is shown here:
 
 | Entry | Description                   | Permissions | Addressing Mode |
 |-------|-------------------------------|-------------|-----------------|
 | 0     |                               |             | OFF\*           |
-| 1     | ROM TEXT                      | RX          | TOR             |
-| 2     | ROM                           | R           | NAPOT           |
+| 1     | ROM TEXT                      | RX          | TOR\*\*         |
+| 2     | ROM                           | R           | TOR             |
 | 3     |                               |             | OFF\*           |
 | 4     | `ROM_EXT` TEXT                | RX          | TOR             |
 | 5     | eFlash                        | R           | NAPOT           |
@@ -70,13 +73,14 @@ The entry allocation is shown here:
 
 Entries that use the Top-Of-Range (TOR) addressing mode use the address register of the preceding entry, effectively requiring two entries.
 Entries that are OFF but for which the address register is in use are marked with a \*.
+Entries used for two rules simultaneously are marked with a \*\*.
 
 ## Initial Configuration
 
 | Entry | Description                   | Permissions | Addressing Mode |
 |-------|-------------------------------|-------------|-----------------|
 | 1     | ROM TEXT                      | RX          | TOR             |
-| 2     | ROM                           | R           | NAPOT           |
+| 2     | ROM                           | R           | TOR             |
 | 5     | eFlash                        | R           | NAPOT           |
 | 11    | MMIO (includes retention RAM) | RW          | TOR             |
 | 14    | Stack Guard (4 bytes)         | \<none\>    | NA4             |
@@ -93,7 +97,7 @@ for the `ROM_EXT` virtual address.
 | Entry | Description                   | Permissions | Addressing Mode |
 |-------|-------------------------------|-------------|-----------------|
 | 1     | ROM TEXT                      | RX          | TOR             |
-| 2     | ROM                           | R           | NAPOT           |
+| 2     | ROM                           | R           | TOR             |
 | **4** | **`ROM_EXT` TEXT**            | **RX**      | **TOR**         |
 | 5     | eFlash                        | R           | NAPOT           |
 | **6** | **`ROM_EXT` section**         | **R**       | **NAPOT**       |

--- a/sw/device/silicon_creator/rom/e2e/release/rom_e2e_self_hash_test.c
+++ b/sw/device/silicon_creator/rom/e2e/release/rom_e2e_self_hash_test.c
@@ -38,18 +38,18 @@ enum {
  *    report.
  */
 
-const size_t kGoldenRomSizeBytes = 32652 - sizeof(build_info_t);
+const size_t kGoldenRomSizeBytes = 49152 - sizeof(build_info_t);
 const uint32_t kSimDvGoldenRomHash[kSha256HashSizeIn32BitWords] = {
-    0xc16e04d6, 0x2e94b881, 0x0759b405, 0xd0a28cde,
-    0xa8c900f3, 0x57b8c7f6, 0xacc910b0, 0x43000c0a,
+    0x1315e4ca, 0x3b1da3c7, 0x7491bd42, 0x1987e1d6,
+    0xb453a371, 0xe92492be, 0x4f970f78, 0x8ba6d31a,
 };
 const uint32_t kFpgaCw310GoldenRomHash[kSha256HashSizeIn32BitWords] = {
-    0xf3508c51, 0xef65a542, 0xc20e55d9, 0xada4c934,
-    0x8015bbca, 0xa863db5a, 0xd1ead827, 0x968d94cb,
+    0xef5a6046, 0x60259ea0, 0xf6a0410b, 0xf589598f,
+    0x0e865aac, 0x92a49b06, 0x1eacc920, 0xd0824322,
 };
 const uint32_t kSiliconGoldenRomHash[kSha256HashSizeIn32BitWords] = {
-    0x43b60e89, 0xbfa80347, 0xeeceb60a, 0x356bc7f1,
-    0xbd023b8a, 0xe5a4ddfc, 0xf66b45b5, 0x5b2ba0ba,
+    0x7e848236, 0xbb8d3f56, 0x1834212e, 0x7ebb699e,
+    0x71e52b2e, 0xce037bca, 0x6edf1f2e, 0xddfcaa7c,
 };
 
 extern const char _rom_chip_info_start[];
@@ -57,7 +57,7 @@ extern const char _rom_chip_info_start[];
 // We hash the ROM using the SHA256 algorithm and print the hash to the console.
 status_t hash_rom(void) {
   hmac_digest_t rom_hash;
-  hmac_sha256((void *)TOP_EARLGREY_ROM_BASE_ADDR, kGoldenRomSizeBytes,
+  hmac_sha256((void *)TOP_EARLGREY_ROM_CTRL_ROM_BASE_ADDR, kGoldenRomSizeBytes,
               &rom_hash);
   // Use printf directly here instead of the `LOG()` macros which print extra
   // filenames and line numbers which bloat DV and GLS runtimes.

--- a/sw/device/silicon_creator/rom/rom_epmp.c
+++ b/sw/device/silicon_creator/rom/rom_epmp.c
@@ -37,7 +37,7 @@ void rom_epmp_state_init(lifecycle_state_t lc_state) {
   // grows downward from _stack_end.
   const epmp_region_t rom_text = {.start = (uintptr_t)_text_start,
                                   .end = (uintptr_t)_text_end};
-  const epmp_region_t rom = {.start = TOP_EARLGREY_ROM_CTRL_ROM_BASE_ADDR,
+  const epmp_region_t rom = {.start = (uintptr_t)_text_end,
                              .end = TOP_EARLGREY_ROM_CTRL_ROM_BASE_ADDR +
                                     TOP_EARLGREY_ROM_CTRL_ROM_SIZE_BYTES};
   const epmp_region_t eflash = {.start = TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR,
@@ -88,7 +88,7 @@ void rom_epmp_state_init(lifecycle_state_t lc_state) {
   // to the hardware configuration.
   memset(&epmp_state, 0, sizeof(epmp_state));
   epmp_state_configure_tor(1, rom_text, kEpmpPermLockedReadExecute);
-  epmp_state_configure_napot(2, rom, kEpmpPermLockedReadOnly);
+  epmp_state_configure_tor(2, rom, kEpmpPermLockedReadOnly);
   epmp_state_configure_napot(5, eflash, kEpmpPermLockedReadOnly);
   epmp_state_configure_tor(11, mmio, kEpmpPermLockedReadWrite);
   epmp_state_configure_napot(13, debug_rom, debug_rom_access);

--- a/sw/device/silicon_creator/rom/rom_epmp_init.S
+++ b/sw/device/silicon_creator/rom/rom_epmp_init.S
@@ -61,8 +61,17 @@ rom_epmp_init:
   la   t0, _epmp_text_tor_hi
   csrw pmpaddr1, t0
 
-  // ROM
-  li   t0, NAPOT(TOP_EARLGREY_ROM_CTRL_ROM_BASE_ADDR, TOP_EARLGREY_ROM_CTRL_ROM_SIZE_BYTES)
+  // At chip reset entry 2 of the epmp register was responsible for read /
+  // executable permissions for the first 2KiB of ROM (see ibex_pmp_reset_pkg.sv).
+  // To avoid a deadlock, entry 1 must cover the initial section of the ROM before
+  // entry 2 is modified. Otherwise the executable permission for this file will
+  // be lost.
+  li   t0, CFG_INDEX(1  % 4, EPMP_CFG_A_TOR   | EPMP_CFG_LRX) | /* ROM TEXT    */ \
+           CFG_INDEX(2  % 4, EPMP_CFG_A_TOR   | EPMP_CFG_LR)    /* ROM         */
+  csrw pmpcfg0, t0
+
+  // ROM the lower bound for TOR is pmpaddr1, already set above to the end of ROM TEXT.
+  li   t0, TOR(TOP_EARLGREY_ROM_CTRL_ROM_BASE_ADDR + TOP_EARLGREY_ROM_CTRL_ROM_SIZE_BYTES)
   csrw pmpaddr2, t0
 
   // ROM_EXT TEXT (configured after signature verification)
@@ -91,15 +100,13 @@ rom_epmp_init:
   li   t0, NAPOT(TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_BASE_ADDR, TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_SIZE_BYTES)
   csrw pmpaddr15, t0
 
-  // Set PMP configuration registers.
-  li   t0, CFG_INDEX(1  % 4, EPMP_CFG_A_TOR   | EPMP_CFG_LRX) | /* ROM TEXT    */ \
-           CFG_INDEX(2  % 4, EPMP_CFG_A_NAPOT | EPMP_CFG_LR)    /* ROM         */
+  // Set the remaining PMP configuration registers (pmpcfg0 was already set
+  // above).
   li   t1, CFG_INDEX(5  % 4, EPMP_CFG_A_NAPOT | EPMP_CFG_LR)    /* eFLASH      */
   li   t2, CFG_INDEX(11 % 4, EPMP_CFG_A_TOR   | EPMP_CFG_LRW)   /* MMIO        */
   li   t3, CFG_INDEX(13 % 4, EPMP_CFG_A_NAPOT | EPMP_CFG_LRWX)| /* Debug ROM   */ \
            CFG_INDEX(14 % 4, EPMP_CFG_A_NA4   | EPMP_CFG_L)   | /* Stack Guard */ \
            CFG_INDEX(15 % 4, EPMP_CFG_A_NAPOT | EPMP_CFG_LRW)   /* RAM         */
-  csrw pmpcfg0, t0
   csrw pmpcfg1, t1
   csrw pmpcfg2, t2
   csrw pmpcfg3, t3

--- a/sw/host/opentitanlib/src/debug/dmi.rs
+++ b/sw/host/opentitanlib/src/debug/dmi.rs
@@ -5,7 +5,7 @@
 use std::ops::{Deref, DerefMut};
 use std::time::Duration;
 
-use anyhow::{Result, bail, ensure};
+use anyhow::{Context, Result, bail, ensure};
 use thiserror::Error;
 
 use super::openocd::OpenOcd;
@@ -84,6 +84,13 @@ pub trait Dmi {
             .iter()
             .try_for_each(|&(addr, data)| self.dmi_write(addr, data))
     }
+
+    /// Perform a batch of sequential reads from DMI registers, returning the read values
+    /// in the same order as the given addresses.
+    /// May or may not be more optimized depending on the underlying implementation.
+    fn batched_dmi_reads(&mut self, addrs: &[u32]) -> Result<Vec<u32>> {
+        addrs.iter().map(|&addr| self.dmi_read(addr)).collect()
+    }
 }
 
 impl<T: Dmi> Dmi for &mut T {
@@ -97,6 +104,10 @@ impl<T: Dmi> Dmi for &mut T {
 
     fn batched_dmi_writes(&mut self, writes: &[(u32, u32)]) -> Result<()> {
         T::batched_dmi_writes(self, writes)
+    }
+
+    fn batched_dmi_reads(&mut self, addrs: &[u32]) -> Result<Vec<u32>> {
+        T::batched_dmi_reads(self, addrs)
     }
 }
 
@@ -222,8 +233,81 @@ impl Dmi for OpenOcdDmi {
             )
             .as_str(),
         );
-        self.openocd.execute(&cmd)?;
+        let result = self.openocd.execute(&cmd)?;
+
+        // The final NOP scan's captured value carries the DMI status of the whole batch:
+        // failed or dropped-while-busy operations leave a sticky nonzero op field, so a
+        // clean status here means every write in the batch was accepted.
+        let res = u64::from_str_radix(result.trim(), 16)
+            .with_context(|| format!("unexpected DMI batched write response '{result}'"))?;
+        ensure!(
+            res & 3 == 0,
+            "DMI batched write failed with sticky status {res:#x}; at least one write was \
+             dropped (is the JTAG clock too fast for the DMI to keep up?)"
+        );
         Ok(())
+    }
+
+    fn batched_dmi_reads(&mut self, addrs: &[u32]) -> Result<Vec<u32>> {
+        // Pipelined DMI reads: each `drscan` shifts in the next read operation while shifting
+        // out the response of the previous one, so a chunk of N reads costs N+1 scans and a
+        // single TCL round trip instead of 3 round trips per read via `dmi_read`. Operations
+        // execute strictly in order at the DTM; the per-entry checks below turn any sticky
+        // busy/error status or response reordering into a hard error.
+        const CHUNK_SIZE: usize = 512;
+
+        let mut values = Vec::with_capacity(addrs.len());
+        for chunk in addrs.chunks(CHUNK_SIZE) {
+            let mut cmd = String::from("set _r {}");
+            for &addr in chunk {
+                let op = (addr as u64) << DMI_ADDRESS_SHIFT | DMI_OP_READ;
+                cmd.push_str(&format!(
+                    "\nlappend _r [{}]",
+                    self.openocd.drscan_cmd(&self.tap, self.drscan_bits(), op)
+                ));
+            }
+            // A trailing NOP scan collects the final read's response.
+            cmd.push_str(&format!(
+                "\nlappend _r [{}]\nset _r",
+                self.openocd.drscan_cmd(&self.tap, self.drscan_bits(), 0)
+            ));
+
+            let result = self.openocd.execute(&cmd)?;
+            let entries = result
+                .split_whitespace()
+                .map(|s| {
+                    u64::from_str_radix(s, 16)
+                        .with_context(|| format!("unexpected DMI batched read response '{s}'"))
+                })
+                .collect::<Result<Vec<u64>>>()?;
+            ensure!(
+                entries.len() == chunk.len() + 1,
+                "DMI batched read returned {} entries, expected {}",
+                entries.len(),
+                chunk.len() + 1
+            );
+
+            // Entry k is captured while scanning in operation k and holds the response of
+            // operation k-1: entry 0 belongs to whatever preceded this chunk (only its status
+            // matters), entries 1..=N are the responses of this chunk's reads, in order.
+            for (idx, &res) in entries.iter().enumerate() {
+                ensure!(
+                    res & 3 == 0,
+                    "DMI batched read failed with sticky status {res:#x} at entry {idx} \
+                     (is the JTAG clock too fast for the DMI to keep up?)"
+                );
+                if idx > 0 {
+                    let addr = chunk[idx - 1];
+                    ensure!(
+                        res >> DMI_ADDRESS_SHIFT == addr as u64,
+                        "DMI batched read address mismatch: expected {addr:#x}, response {res:#x}"
+                    );
+                    values.push((res >> DMI_DATA_SHIFT) as u32);
+                }
+            }
+        }
+
+        Ok(values)
     }
 }
 

--- a/sw/host/opentitanlib/src/io/fpga_backdoor.rs
+++ b/sw/host/opentitanlib/src/io/fpga_backdoor.rs
@@ -28,6 +28,7 @@ pub mod regs {
     pub const CONTROL_DONE_BIT: u32 = 0;
     pub const CONTROL_WRITE_ENA_BIT: u32 = 1;
     pub const CONTROL_CLEAR_START_BIT: u32 = 2;
+    pub const CONTROL_AUTO_INCR_BIT: u32 = 3;
     pub const CONTROL_TARGET_IDX_MASK: u32 = 0xff;
     pub const CONTROL_TARGET_IDX_OFFSET: usize = 8;
 
@@ -247,7 +248,7 @@ impl<'a> BackdoorTarget<'a> {
     /// Read a sequence of words at a given offset (word index) from the target's memory.
     ///
     /// The `check_status` parameter is used to control whether the status bit is polled
-    /// after each word read, to check for any errors.
+    /// after all words are read, to check for any errors.
     pub fn read(&mut self, start: u32, count: u32, check_status: bool) -> Result<Vec<Word>> {
         ensure!(
             start + count <= self.info.depth,
@@ -259,6 +260,34 @@ impl<'a> BackdoorTarget<'a> {
         );
         self.backdoor
             .read_target(self.index, start, count, check_status)
+    }
+
+    /// Write a single word at a given word index in the target's memory, without disturbing any
+    /// auto-increment cursor. See [`Backdoor::write_target_word`].
+    pub fn write_word(&mut self, index: u32, word: &Word, check_status: bool) -> Result<()> {
+        ensure!(
+            index < self.info.depth,
+            "fpga bkdr_loader write to word {:#x} of {} is out of bounds (depth: {:#x})",
+            index,
+            self.info.id_str(),
+            self.info.depth,
+        );
+        self.backdoor
+            .write_target_word(self.index, index, word, check_status)
+    }
+
+    /// Read a single word at a given word index from the target's memory, without disturbing any
+    /// auto-increment cursor. See [`Backdoor::read_target_word`].
+    pub fn read_word(&mut self, index: u32, check_status: bool) -> Result<Word> {
+        ensure!(
+            index < self.info.depth,
+            "fpga bkdr_loader read from word {:#x} of {} is out of bounds (depth: {:#x})",
+            index,
+            self.info.id_str(),
+            self.info.depth,
+        );
+        self.backdoor
+            .read_target_word(self.index, index, check_status)
     }
 
     /// Clear the entire memory of the target with a given word.
@@ -408,12 +437,19 @@ impl Backdoor {
         Ok(self.target_by_id(encoded_id))
     }
 
-    /// Write a sequence of words at a given offset (word index) to a specified target's memory.
+    /// Write a sequence of words at a given offset (word index) to a specified target's memory,
+    /// using the bkdr_loader's `AUTO_INCR` write mode.
     ///
-    /// The `write_all` parameter is used to control whether writes can be optimized by
-    /// maintaining shadow CSRs to determine when register contents have actually changed.
+    /// With `AUTO_INCR` set, writing the highest-indexed `WRITE_DATA` register needed for the
+    /// target's line width both commits a bkdr write at the current `INDEX` and advances `INDEX`
+    /// by one, so a full sequential range can be streamed without an `INDEX` write per word.
+    /// That top-word write must always happen (it's what fires the commit), but writes to any
+    /// lower-indexed `WRITE_DATA` registers can still be elided by the `write_all` parameter,
+    /// using shadow CSRs to determine when register contents have genuinely changed since the
+    /// previous word.
     /// The `check_status` parameter is used to control whether the status bit is polled
-    /// after all words are written, to check for any errors.
+    /// after all words are written, to check for any errors; it also reads back `INDEX` to
+    /// verify the cursor advanced exactly once per word (i.e. no commit was lost).
     pub fn write_target(
         &mut self,
         target_index: u8,
@@ -439,27 +475,41 @@ impl Backdoor {
             DATA_REGS_PER_WORD
         );
 
-        // Cache previous written values in Shadow CSRs
-        let mut prev_regs = [0u32; DATA_REGS_PER_WORD];
-        let mut word_idx = start;
-        let mut first = true;
+        if words.is_empty() {
+            return Ok(());
+        }
+
+        // The top `WRITE_DATA` register (i.e. `bkdr_loader`'s `max_word_idx_tgt`) is the one
+        // whose write commits the line and advances `INDEX`; it must be written every time.
+        let top_reg_idx = regs_used - 1;
 
         let mut control = (target_index as u32) << regs::CONTROL_TARGET_IDX_OFFSET;
         control |= 0b1 << regs::CONTROL_WRITE_ENA_BIT;
-        self.dmi_write(regs::CONTROL_REG_OFFSET, control)
-            .context("cannot write to control register")?;
+        control |= 0b1 << regs::CONTROL_AUTO_INCR_BIT;
 
-        // We batch together all the necessary writes so that we can perform a single
-        // batched write operation at the end, which is optimized for throughput.
-        let mut writes = Vec::new();
+        // Cache previous written values in Shadow CSRs
+        let mut prev_regs = [0u32; DATA_REGS_PER_WORD];
+        let mut first = true;
+
+        // We batch together all the necessary writes - including the CONTROL setup and the
+        // single INDEX seed - so that we can perform a single batched write operation at the
+        // end, which is optimized for throughput. Batched writes execute strictly in order,
+        // so CONTROL (selecting the target and enabling AUTO_INCR) and the INDEX seed land
+        // before any data; with AUTO_INCR already set, the INDEX write cannot trigger a
+        // manual write. From the seed on, INDEX auto-increments in hardware.
+        let mut writes = vec![
+            ((regs::CONTROL_REG_OFFSET >> 2) as u32, control),
+            ((regs::INDEX_REG_OFFSET >> 2) as u32, start),
+        ];
 
         for word in words {
             let regs = word.to_u32_chunks()?;
             for idx in 0..regs_used {
                 // Optimization - maintain shadow CSRs in software, and only write the
                 // data if there is a diff in that CSR from the previous contents. Vastly
-                // minimizes required operations for repetitive payloads.
-                if write_all || first || regs[idx] != prev_regs[idx] {
+                // minimizes required operations for repetitive payloads. The top register
+                // is exempted since its write is what commits the line and advances INDEX.
+                if idx == top_reg_idx || write_all || first || regs[idx] != prev_regs[idx] {
                     let addr_offset = idx * 4;
                     writes.push((
                         ((regs::WRITE_DATA_0_REG_OFFSET + addr_offset) >> 2) as u32,
@@ -468,10 +518,95 @@ impl Backdoor {
                     prev_regs[idx] = regs[idx];
                 }
             }
-            writes.push(((regs::INDEX_REG_OFFSET >> 2) as u32, word_idx));
             first = false;
-            word_idx += 1;
         }
+
+        self.dmi
+            .batched_dmi_writes(&writes)
+            .context("failed to perform DMI writes")?;
+
+        if check_status {
+            // The auto-increment cursor must have advanced exactly once per word; a mismatch
+            // means a commit (top-word write) was lost somewhere in the stream, which would
+            // shift every subsequent word by one address.
+            let end_index = self
+                .dmi_read(regs::INDEX_REG_OFFSET)
+                .context("cannot read back index")?;
+            ensure!(
+                end_index == start + words.len() as u32,
+                "fpga bkdr_loader index is {:#x} after writing {:#x} words at {:#x} of target {} (expected {:#x})",
+                end_index,
+                words.len(),
+                start,
+                info.id_str(),
+                start + words.len() as u32
+            );
+
+            let status = self
+                .dmi_read(regs::STATUS_REG_OFFSET)
+                .context("cannot read status")?;
+            ensure!(
+                status & (0b1 << regs::STATUS_ERROR_BIT) == 0,
+                "fpga bkdr_loader reported an error writing to target {}",
+                info.id_str()
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Write a single word at a given word index to a specified target's memory, using the
+    /// bkdr_loader's manual (non-`AUTO_INCR`) write mode: `WRITE_DATA` is loaded, then writing
+    /// `INDEX` itself commands the write to that exact address.
+    ///
+    /// Unlike [`Backdoor::write_target`], this does not move any auto-increment cursor and can
+    /// address any word directly, which is handy for one-off single-word pokes that don't want
+    /// to reason about a running `INDEX`. The `check_status` parameter is used to control whether
+    /// the status bit is polled afterwards, to check for any errors.
+    pub fn write_target_word(
+        &mut self,
+        target_index: u8,
+        index: u32,
+        word: &Word,
+        check_status: bool,
+    ) -> Result<()> {
+        ensure!(
+            usize::from(target_index) < self.targets.len(),
+            "Target index {} is out of range for {} targets",
+            target_index,
+            self.targets.len()
+        );
+        let info = self.targets[target_index as usize];
+        let width = info.width as usize;
+        let regs_used = width.div_ceil(u32::BITS as usize);
+        ensure!(
+            regs_used <= DATA_REGS_PER_WORD,
+            "Advertised target width {:#x} is too wide for the data registers (needs: {:#x}, has: {:#x})",
+            width,
+            regs_used,
+            DATA_REGS_PER_WORD
+        );
+
+        let mut control = (target_index as u32) << regs::CONTROL_TARGET_IDX_OFFSET;
+        control |= 0b1 << regs::CONTROL_WRITE_ENA_BIT;
+
+        // Batch everything into one round trip: CONTROL setup, the data registers, and the
+        // final INDEX write whose qe strobe (with AUTO_INCR clear) triggers the actual write.
+        let regs = word.to_u32_chunks()?;
+        let writes: Vec<(u32, u32)> =
+            std::iter::once(((regs::CONTROL_REG_OFFSET >> 2) as u32, control))
+                .chain(regs[..regs_used].iter().enumerate().map(|(idx, &reg)| {
+                    let addr_offset = idx * 4;
+                    (
+                        ((regs::WRITE_DATA_0_REG_OFFSET + addr_offset) >> 2) as u32,
+                        reg,
+                    )
+                }))
+                .chain(std::iter::once((
+                    (regs::INDEX_REG_OFFSET >> 2) as u32,
+                    index,
+                )))
+                .collect();
 
         self.dmi
             .batched_dmi_writes(&writes)
@@ -491,10 +626,18 @@ impl Backdoor {
         Ok(())
     }
 
-    /// Read a sequence of words at a given offset (word index) from a specified target's memory.
+    /// Read a sequence of words at a given offset (word index) from a specified target's memory,
+    /// using the bkdr_loader's `AUTO_INCR` read mode.
     ///
+    /// With `AUTO_INCR` set and `WRITE_ENA` clear, reading the highest-indexed `READ_DATA`
+    /// register needed for the target's line width advances `INDEX` by one (no bkdr write is
+    /// ever triggered on the read side), so a full sequential range can be streamed with a single
+    /// `INDEX` write up front rather than one per word. Because that top-word read is what
+    /// advances `INDEX`, each line's registers must be read in ascending order (topmost last),
+    /// reading it out of order would advance past data that hasn't been collected yet.
     /// The `check_status` parameter is used to control whether the status bit is polled
-    /// after each word read, to check for any errors.
+    /// after all words are read, to check for any errors; it also reads back `INDEX` to
+    /// verify the cursor advanced exactly once per word.
     pub fn read_target(
         &mut self,
         target_index: u8,
@@ -520,41 +663,141 @@ impl Backdoor {
             DATA_REGS_PER_WORD
         );
 
+        if count == 0 {
+            return Ok(Vec::new());
+        }
+
         let mut control = (target_index as u32) << regs::CONTROL_TARGET_IDX_OFFSET;
-        control &= !(0b1 << regs::CONTROL_WRITE_ENA_BIT);
-        self.dmi_write(regs::CONTROL_REG_OFFSET, control)
-            .context("cannot write to control register")?;
+        control |= 0b1 << regs::CONTROL_AUTO_INCR_BIT;
+        // WRITE_ENA is left clear: with AUTO_INCR set, this selects the read-side trigger.
+        // Batch the CONTROL setup and the single INDEX seed into one round trip; the writes
+        // execute strictly in order, and with WRITE_ENA clear the INDEX write cannot trigger
+        // a write. From the seed on, INDEX auto-increments in hardware.
+        self.dmi
+            .batched_dmi_writes(&[
+                ((regs::CONTROL_REG_OFFSET >> 2) as u32, control),
+                ((regs::INDEX_REG_OFFSET >> 2) as u32, start),
+            ])
+            .context("cannot set up control and index registers")?;
 
-        let mut words = Vec::new();
+        // Reading the top register advances INDEX, so within each word the registers must be
+        // read in ascending order (topmost last). The flattened address sequence preserves
+        // that order, and batched reads keep operation order, across chunks too.
+        let addrs: Vec<u32> = (0..count)
+            .flat_map(|_| {
+                (0..regs_used).map(|idx| ((regs::READ_DATA_0_REG_OFFSET + idx * 4) >> 2) as u32)
+            })
+            .collect();
+        let values = self
+            .dmi
+            .batched_dmi_reads(&addrs)
+            .context("cannot read from read_data registers")?;
 
-        for word_idx in start..(start + count) {
-            self.dmi_write(regs::INDEX_REG_OFFSET, word_idx)
-                .context("cannot write word index")?;
+        let words = values
+            .chunks_exact(regs_used)
+            .map(|chunk| {
+                let mut regs = [0u32; DATA_REGS_PER_WORD];
+                regs[..regs_used].copy_from_slice(chunk);
+                Word::from_u32_chunks(&regs, bytes_per_word)
+            })
+            .collect::<Vec<_>>();
 
-            if check_status {
-                let status = self
-                    .dmi_read(regs::STATUS_REG_OFFSET)
-                    .context("cannot read status")?;
-                ensure!(
-                    status & (0b1 << regs::STATUS_ERROR_BIT) == 0,
-                    "fpga bkdr_loader reported an error reading from word idx {} of target {}",
-                    word_idx,
-                    info.id_str()
-                );
-            }
+        if check_status {
+            // The auto-increment cursor must have advanced exactly once per word read; a
+            // mismatch means a top-word read strobe was lost or fired more than expected.
+            let end_index = self
+                .dmi_read(regs::INDEX_REG_OFFSET)
+                .context("cannot read back index")?;
+            ensure!(
+                end_index == start + count,
+                "fpga bkdr_loader index is {:#x} after reading {:#x} words at {:#x} of target {} (expected {:#x})",
+                end_index,
+                count,
+                start,
+                info.id_str(),
+                start + count
+            );
 
-            let mut regs = [0u32; DATA_REGS_PER_WORD];
-            for (idx, reg) in regs.iter_mut().enumerate().take(regs_used) {
-                let addr_offset = idx * 4;
-                *reg = self
-                    .dmi_read(regs::READ_DATA_0_REG_OFFSET + addr_offset)
-                    .context("cannot read from read_data register")?;
-            }
-
-            words.push(Word::from_u32_chunks(&regs, bytes_per_word));
+            let status = self
+                .dmi_read(regs::STATUS_REG_OFFSET)
+                .context("cannot read status")?;
+            ensure!(
+                status & (0b1 << regs::STATUS_ERROR_BIT) == 0,
+                "fpga bkdr_loader reported an error reading from target {} starting at word {}",
+                info.id_str(),
+                start
+            );
         }
 
         Ok(words)
+    }
+
+    /// Read a single word at a given word index from a specified target's memory, using the
+    /// bkdr_loader's manual (non-`AUTO_INCR`) read mode: writing `INDEX` addresses the word, then
+    /// `READ_DATA` is read back.
+    ///
+    /// Unlike [`Backdoor::read_target`], this does not move any auto-increment cursor and can
+    /// address any word directly, which is handy for one-off single-word peeks. The
+    /// `check_status` parameter is used to control whether the status bit is polled afterwards,
+    /// to check for any errors.
+    pub fn read_target_word(
+        &mut self,
+        target_index: u8,
+        index: u32,
+        check_status: bool,
+    ) -> Result<Word> {
+        ensure!(
+            usize::from(target_index) < self.targets.len(),
+            "Target index {} is out of range for {} targets",
+            target_index,
+            self.targets.len()
+        );
+        let info = self.targets[target_index as usize];
+        let width = info.width as usize;
+        let bytes_per_word = width.div_ceil(u8::BITS as usize);
+        let regs_used = width.div_ceil(u32::BITS as usize);
+        ensure!(
+            regs_used <= DATA_REGS_PER_WORD,
+            "Advertised target width {:#x} is too wide for the data registers (needs: {:#x}, has: {:#x})",
+            width,
+            regs_used,
+            DATA_REGS_PER_WORD
+        );
+
+        // Batch the CONTROL setup (WRITE_ENA and AUTO_INCR both clear: manual read mode, no
+        // side effects on READ_DATA reads) and the INDEX write into one round trip.
+        let control = (target_index as u32) << regs::CONTROL_TARGET_IDX_OFFSET;
+        self.dmi
+            .batched_dmi_writes(&[
+                ((regs::CONTROL_REG_OFFSET >> 2) as u32, control),
+                ((regs::INDEX_REG_OFFSET >> 2) as u32, index),
+            ])
+            .context("cannot set up control and index registers")?;
+
+        if check_status {
+            let status = self
+                .dmi_read(regs::STATUS_REG_OFFSET)
+                .context("cannot read status")?;
+            ensure!(
+                status & (0b1 << regs::STATUS_ERROR_BIT) == 0,
+                "fpga bkdr_loader reported an error reading from word idx {} of target {}",
+                index,
+                info.id_str()
+            );
+        }
+
+        let addrs: Vec<u32> = (0..regs_used)
+            .map(|idx| ((regs::READ_DATA_0_REG_OFFSET + idx * 4) >> 2) as u32)
+            .collect();
+        let values = self
+            .dmi
+            .batched_dmi_reads(&addrs)
+            .context("cannot read from read_data registers")?;
+
+        let mut regs = [0u32; DATA_REGS_PER_WORD];
+        regs[..regs_used].copy_from_slice(&values);
+
+        Ok(Word::from_u32_chunks(&regs, bytes_per_word))
     }
 
     /// Clear the entire memory of a specified target with a given word.

--- a/sw/host/opentitanlib/src/test_utils/epmp.rs
+++ b/sw/host/opentitanlib/src/test_utils/epmp.rs
@@ -142,11 +142,11 @@ mod tests {
     // This particular set of PMPCFG / PMPADDR values was captured from the ROM
     // and manually modified to encompass all of the decode options.
     // The modifications are:
-    // - Addition of entry 6: a duplicate of entry 2 with the perms set to RWX.
-    const PMPCFG: [u32; 4] = [0x998d00, 0x1f998d, 0x8b000000, 0x9b909f00];
+    // - Addition of entry 6: a duplicate of entry 13 with the perms set to RWX.
+    const PMPCFG: [u32; 4] = [0x898d00, 0x1f998d, 0x8b000000, 0x9b909f00];
     const PMPADDR: [u32; 16] = [
-        0x2000, 0x3411, 0x2fff, 0x8000100, 0x8001203, 0x801ffff, 0x2fff, 0x0, 0x0, 0x0, 0x10000000,
-        0x14000000, 0x0, 0x41ff, 0x4007000, 0x4003fff,
+        0x10000, 0x11411, 0x13000, 0x8000100, 0x8001203, 0x801ffff, 0x41ff, 0x0, 0x0, 0x0,
+        0x10000000, 0x14000000, 0x0, 0x41ff, 0x4007000, 0x4003fff,
     ];
 
     #[test]
@@ -169,26 +169,27 @@ mod tests {
             EpmpEntry {
                 cfg: EPMP_CFG_LRX,
                 kind: EpmpRegionKind::Tor,
-                range: EpmpAddressRange(0x8000, 0xd044)
+                range: EpmpAddressRange(0x40000, 0x45044)
             }
         ));
-        // The second entry is a Napot region representing the entire 32K of ROM.
+        // The second entry is a Tor region representing the rest of the 48k ROM beyond the
+        // .text section decoded in entry 1.
         assert!(matches!(
             epmp.entry[2],
             EpmpEntry {
                 cfg: EPMP_CFG_LRO,
-                kind: EpmpRegionKind::Napot,
-                range: EpmpAddressRange(0x8000, 0x10000)
+                kind: EpmpRegionKind::Tor,
+                range: EpmpAddressRange(0x45044, 0x4c000)
             }
         ));
-        // The sixth entry is a Napot region representing the entire 32K of ROM, but is set to
+        // The sixth entry is a Napot region representing the debug RVDM RAM, but is set to
         // RWX (tests the decode of the `cfg` field with lock bit clear).
         assert!(matches!(
             epmp.entry[6],
             EpmpEntry {
                 cfg: EPMP_CFG_RWX,
                 kind: EpmpRegionKind::Napot,
-                range: EpmpAddressRange(0x8000, 0x10000)
+                range: EpmpAddressRange(0x10000, 0x11000)
             }
         ));
 

--- a/sw/host/tests/rom/e2e_chip_specific_startup/src/main.rs
+++ b/sw/host/tests/rom/e2e_chip_specific_startup/src/main.rs
@@ -178,15 +178,15 @@ fn check_epmp(_opts: &Opts, cs: &ChipStartup) -> Result<()> {
         EpmpEntry {
             cfg: EPMP_CFG_LRX,
             kind: EpmpRegionKind::Tor,
-            range: EpmpAddressRange(0x8000, _)
+            range: EpmpAddressRange(0x40000, _)
         }
     ));
     assert!(matches!(
         epmp.entry[2],
         EpmpEntry {
             cfg: EPMP_CFG_LRO,
-            kind: EpmpRegionKind::Napot,
-            range: EpmpAddressRange(0x8000, 0x10000)
+            kind: EpmpRegionKind::Tor,
+            range: EpmpAddressRange(_, 0x4c000)
         }
     ));
     assert!(matches!(


### PR DESCRIPTION
This PR aims to increase the ROM size for Earl Grey from 32 kB to 48 KiB. Moves the ROM base address from **0x8000** to **0x40000** for power-of-two alignment (and to account for a future ROM size of 192kB).

Most of the changes are autogenerated from `top_earlgrey.hjson` however the default values in `ibex_pmp_reset_pkg.sv` and the size in `rom_e2e_self_hash_test.c` needs to be updated manually. In order to run the `rom_e2e_self_hash` test, the relevant line in the `BUILD` file needs to be uncommented.