### PR TITLE
[DV] Removed/Fixed hierarchical paths in $asserton/off

### DIFF
--- a/hw/ip/csrng/dv/env/seq_lib/csrng_err_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_err_vseq.sv
@@ -57,9 +57,6 @@ class csrng_err_vseq extends csrng_base_vseq;
     // Turn off assertions
     $assertoff(0, "tb.entropy_src_if.ReqHighUntilAck_A");
     $assertoff(0, "tb.entropy_src_if.AckAssertedOnlyWhenReqAsserted_A");
-    $assertoff(0, "tb.dut.u_csrng_core.u_prim_arbiter_ppc_updblk_arb.LockArbDecision_A");
-    $assertoff(0, "tb.dut.u_csrng_core.u_prim_arbiter_ppc_benblk_arb.ReqStaysHighUntilGranted0_M");
-    $assertoff(0, "tb.dut.u_csrng_core.u_prim_arbiter_ppc_updblk_arb.ReqStaysHighUntilGranted0_M");
     $assertoff(0, `HIER_PATH(`CMD_STAGE_0, u_state_regs_A));
     $assertoff(0, `HIER_PATH(`CMD_STAGE_1, u_state_regs_A));
     $assertoff(0, `HIER_PATH(`CMD_STAGE_2, u_state_regs_A));
@@ -274,9 +271,6 @@ class csrng_err_vseq extends csrng_base_vseq;
     // Turn assertions back on
     $asserton(0, "tb.entropy_src_if.ReqHighUntilAck_A");
     $asserton(0, "tb.entropy_src_if.AckAssertedOnlyWhenReqAsserted_A");
-    $asserton(0, "tb.dut.u_csrng_core.u_prim_arbiter_ppc_updblk_arb.LockArbDecision_A");
-    $asserton(0, "tb.dut.u_csrng_core.u_prim_arbiter_ppc_benblk_arb.ReqStaysHighUntilGranted0_M");
-    $asserton(0, "tb.dut.u_csrng_core.u_prim_arbiter_ppc_updblk_arb.ReqStaysHighUntilGranted0_M");
     $asserton(0, `HIER_PATH(`CMD_STAGE_0, u_state_regs_A));
     $asserton(0, `HIER_PATH(`CMD_STAGE_1, u_state_regs_A));
     $asserton(0, `HIER_PATH(`CMD_STAGE_2, u_state_regs_A));

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_intr_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_intr_vseq.sv
@@ -340,9 +340,6 @@ class csrng_intr_vseq extends csrng_base_vseq;
     `define HIER_PATH(prefix, suffix) `"prefix.suffix`"
     $assertoff(0, "tb.entropy_src_if.ReqHighUntilAck_A");
     $assertoff(0, "tb.entropy_src_if.AckAssertedOnlyWhenReqAsserted_A");
-    $assertoff(0, "tb.dut.u_csrng_core.u_prim_arbiter_ppc_updblk_arb.LockArbDecision_A");
-    $assertoff(0, "tb.dut.u_csrng_core.u_prim_arbiter_ppc_benblk_arb.ReqStaysHighUntilGranted0_M");
-    $assertoff(0, "tb.dut.u_csrng_core.u_prim_arbiter_ppc_updblk_arb.ReqStaysHighUntilGranted0_M");
     $assertoff(0, `HIER_PATH(`CMD_STAGE_0, CsrngCmdStageGenbitsFifoPushExpected_A));
     $assertoff(0, `HIER_PATH(`CMD_STAGE_1, CsrngCmdStageGenbitsFifoPushExpected_A));
     $assertoff(0, `HIER_PATH(`CMD_STAGE_2, CsrngCmdStageGenbitsFifoPushExpected_A));
@@ -378,9 +375,6 @@ class csrng_intr_vseq extends csrng_base_vseq;
     // Turn assertions back on
     $asserton(0, "tb.entropy_src_if.ReqHighUntilAck_A");
     $asserton(0, "tb.entropy_src_if.AckAssertedOnlyWhenReqAsserted_A");
-    $asserton(0, "tb.dut.u_csrng_core.u_prim_arbiter_ppc_updblk_arb.LockArbDecision_A");
-    $asserton(0, "tb.dut.u_csrng_core.u_prim_arbiter_ppc_benblk_arb.ReqStaysHighUntilGranted0_M");
-    $asserton(0, "tb.dut.u_csrng_core.u_prim_arbiter_ppc_updblk_arb.ReqStaysHighUntilGranted0_M");
     $asserton(0, `HIER_PATH(`CMD_STAGE_0, CsrngCmdStageGenbitsFifoPushExpected_A));
     $asserton(0, `HIER_PATH(`CMD_STAGE_1, CsrngCmdStageGenbitsFifoPushExpected_A));
     $asserton(0, `HIER_PATH(`CMD_STAGE_2, CsrngCmdStageGenbitsFifoPushExpected_A));

--- a/hw/ip/entropy_src/dv/env/entropy_src_path_if.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_path_if.sv
@@ -56,7 +56,7 @@ interface entropy_src_path_if ();
     $assertoff(0, tb.dut.IntrEsEntropyValidKnownO_A);
     $assertoff(0, tb.dut.IntrEsHealthTestFailedKnownO_A);
     $assertoff(0, tb.dut.tlul_assert_device.dKnown_A);
-    $assertoff(0, tb.dut.tlul_assert_device.gen_device.dDataKnown_A);
+    $assertoff(0, tb.dut.tlul_assert_device.gen_device.gen_d2h.dDataKnown_A);
     $assertoff(0, tb.dut.gen_alert_tx[0].u_prim_alert_sender.AlertPKnownO_A);
     $assertoff(0, tb.dut.gen_alert_tx[0].u_prim_alert_sender.gen_async_assert.DiffEncoding_A);
     $assertoff(0, `CORE.AtReset_ValidRngBitsPushedIntoEsrngFifo_A);


### PR DESCRIPTION
Some tests failed with the following errors as:
```
Hierarchical name component lookup failed for 'tb.dut.u_csrng_core.u_prim_arbiter_ppc_updblk_arb.LockArbDecision_A

or 

Hierarchical name component lookup failed for 'dDataKnown_A' at 'tb.entropy_src_path_if'
```
