### PR TITLE
[entropy_src,dv] Simplify stress all test

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
@@ -148,9 +148,8 @@ interface alert_esc_if(input clk, input rst_n);
                  ! ping_pending);
   endfunction : get_alert
 
-  function automatic bit is_alert_handshaking();
-    return alert_tx_final.alert_p === 1'b1 || alert_rx_final.ack_p === 1'b1;
-  endfunction : is_alert_handshaking
+  bit is_alert_handshaking;
+  assign is_alert_handshaking = alert_tx_final.alert_p === 1'b1 || alert_rx_final.ack_p === 1'b1;
 
   // this task wait for alert_ping request.
   // alert_ping request is detected by level triggered "alert_rx.ping_p/n" signals pairs

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -1017,9 +1017,9 @@ task cip_base_vseq::wait_alert_trigger(string alert_name,
                                        int    max_wait_cycle = 7,
                                        bit    wait_complete = 0);
   // wait until ping finishes before the dv_spinwait in case
-  // m_alert_agent_cfgs[alert_name].vif.is_alert_handshaking() is true due to a ping
+  // m_alert_agent_cfgs[alert_name].vif.is_alert_handshaking is true due to a ping
   wait_until_ping_is_finished(cfg.m_alert_agent_cfgs[alert_name]);
-  `DV_SPINWAIT_EXIT(while (!cfg.m_alert_agent_cfgs[alert_name].vif.is_alert_handshaking()) begin
+  `DV_SPINWAIT_EXIT(while (!cfg.m_alert_agent_cfgs[alert_name].vif.is_alert_handshaking) begin
                       cfg.clk_rst_vif.wait_clks(1);
                       wait_until_ping_is_finished(cfg.m_alert_agent_cfgs[alert_name]);
                     end,

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
@@ -68,20 +68,20 @@ class entropy_src_base_vseq extends cip_base_vseq #(
   // the test instead.
   //
   task check_ht_diagnostics();
-    int val;
-    string stat_regs [] = '{
-        "ht_watermark",
-        "repcnt_total_fails", "repcnts_total_fails", "adaptp_hi_total_fails",
-        "adaptp_lo_total_fails", "bucket_total_fails", "markov_hi_total_fails",
-        "markov_lo_total_fails", "extht_hi_total_fails", "extht_lo_total_fails",
-        "alert_summary_fail_counts", "alert_fail_counts", "extht_fail_counts"
+    uvm_reg stat_regs[] = '{
+      ral.ht_watermark,
+      ral.repcnt_total_fails, ral.repcnts_total_fails, ral.adaptp_hi_total_fails,
+      ral.adaptp_lo_total_fails, ral.bucket_total_fails, ral.markov_hi_total_fails,
+      ral.markov_lo_total_fails, ral.extht_hi_total_fails, ral.extht_lo_total_fails,
+      ral.alert_summary_fail_counts, ral.alert_fail_counts, ral.extht_fail_counts
     };
     foreach (stat_regs[i]) begin
-      int val;
-      uvm_reg csr = ral.get_reg_by_name(stat_regs[i]);
-      csr_rd(.ptr(csr), .value(val));
+      uvm_status_e status;
+      stat_regs[i].mirror(status);
+      if (cfg.m_rng_agent_cfg.in_reset) return;
+      if (status != UVM_IS_OK)
+        `uvm_error("mirror", $sformatf("Failed to mirror %0s", stat_regs[i].get_name()))
     end
-
   endtask
 
   virtual task apply_reset(string kind = "HARD");
@@ -119,18 +119,24 @@ class entropy_src_base_vseq extends cip_base_vseq #(
     csr_wr(.ptr(ral.module_enable.module_enable), .value(prim_mubi_pkg::MuBi4True));
   endtask
 
-  task disable_dut();
-    bit [TL_DW - 1:0] regval;
+  protected task disable_dut();
+    uvm_status_e status;
 
-    csr_wr(.ptr(ral.module_enable.module_enable), .value(MuBi4False));
+    ral.module_enable.module_enable.write(status, MuBi4False);
+    if (cfg.m_rng_agent_cfg.in_reset) return;
+    if (status != UVM_IS_OK) `uvm_error("write", "Writing MuBi4False to module_enable failed")
 
     // Disabling the module will clear the error state,
     // as well as the observe and entropy_data FIFOs
     // Clear all interrupts here
-    csr_wr(.ptr(ral.intr_state), .value(32'hf));
+    ral.intr_state.write(status, 32'hf);
+    if (cfg.m_rng_agent_cfg.in_reset) return;
+    if (status != UVM_IS_OK) `uvm_error("write", "Writing '1 to intr_state failed")
 
     // Check, but do not clear alert_sts, as the handlers for those conditions may need to see them.
-    csr_rd(.ptr(ral.recov_alert_sts.es_main_sm_alert), .value(regval));
+    ral.recov_alert_sts.es_main_sm_alert.mirror(status);
+    if (cfg.m_rng_agent_cfg.in_reset) return;
+    if (status != UVM_IS_OK) `uvm_error("mirror", "Mirroring recov_alert_sts failed")
 
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(do_check_ht_diag)
     if (do_check_ht_diag) begin
@@ -141,9 +147,38 @@ class entropy_src_base_vseq extends cip_base_vseq #(
     end
   endtask
 
+  // Wait the given time, but stop early if cfg.m_rng_agent_cfg.in_reset is asserted or if the stop_early flag
+  // (passed by reference) becomes true.
+  task pause_until_reset_or_flag(realtime pause, ref bit stop_early);
+    // The code here is a little complicated, because we are not allowed to access a reference
+    // argument in a fork/join_any. The trick is to make a manual version of fork/join_any with a
+    // done flag, which is asserted when either event happens. The genuine join_any is needed to
+    // kill the #(pause) process.
+    bit done;
+    fork
+      begin
+        wait (stop_early || done);
+        done = 1'b1;
+      end
+      fork : isolation_fork begin
+        fork
+          wait (cfg.m_rng_agent_cfg.in_reset);
+          wait (done);
+          #(pause);
+        join_any
+        disable fork;
+        done = 1'b1;
+      end join
+    join
+  endtask
+
   // Helper function to entropy_src_init. Tries to apply the new configuration
   // Does not check for invalid MuBi or threshold alert values
-  virtual task try_apply_base_configuration(entropy_src_dut_cfg newcfg, realtime pause,
+  //
+  // If stop_early or reset is asserted, stop the task when the next transaction finishes.
+  virtual task try_apply_base_configuration(entropy_src_dut_cfg newcfg,
+                                            realtime pause,
+                                            ref bit stop_early,
                                             output bit completed);
 
     completed = 0;
@@ -152,12 +187,14 @@ class entropy_src_base_vseq extends cip_base_vseq #(
     ral.entropy_control.es_type.set(newcfg.type_bypass);
     ral.entropy_control.es_route.set(newcfg.route_software);
     csr_update(.csr(ral.entropy_control));
-    #(pause);
+    pause_until_reset_or_flag(pause, stop_early);
+    if (stop_early || cfg.m_rng_agent_cfg.in_reset) return;
 
     ral.health_test_windows.fips_window.set(newcfg.fips_window_size);
     ral.health_test_windows.bypass_window.set(newcfg.bypass_window_size);
     csr_update(.csr(ral.health_test_windows));
-    #(pause);
+    pause_until_reset_or_flag(pause, stop_early);
+    if (stop_early || cfg.m_rng_agent_cfg.in_reset) return;
 
     // Thresholds for the continuous health checks:
     // REPCNT and REPCNTS
@@ -171,34 +208,41 @@ class entropy_src_base_vseq extends cip_base_vseq #(
         ral.repcnts_threshold.set(newcfg.repcnts_thresh_bypass);
       end
       csr_update(.csr(ral.repcnt_threshold));
+      if (stop_early || cfg.m_rng_agent_cfg.in_reset) return;
       csr_update(.csr(ral.repcnts_threshold));
     end
-    #(pause);
+    pause_until_reset_or_flag(pause, stop_early);
+    if (stop_early || cfg.m_rng_agent_cfg.in_reset) return;
 
     // Windowed health test thresholds managed in derived vseq classes
 
     ral.ht_watermark_num.set(newcfg.ht_watermark_num);
     csr_update(.csr(ral.ht_watermark_num));
-    #(pause);
+    pause_until_reset_or_flag(pause, stop_early);
+    if (stop_early || cfg.m_rng_agent_cfg.in_reset) return;
 
     // FW_OV registers
     ral.fw_ov_control.fw_ov_mode.set(newcfg.fw_read_enable);
     ral.fw_ov_control.fw_ov_entropy_insert.set(newcfg.fw_over_enable);
     csr_update(.csr(ral.fw_ov_control));
-    #(pause);
+    pause_until_reset_or_flag(pause, stop_early);
+    if (stop_early || cfg.m_rng_agent_cfg.in_reset) return;
 
     ral.fw_ov_sha3_start.fw_ov_insert_start.set(newcfg.fw_ov_insert_start);
     csr_update(.csr(ral.fw_ov_sha3_start));
-    #(pause);
+    pause_until_reset_or_flag(pause, stop_early);
+    if (stop_early || cfg.m_rng_agent_cfg.in_reset) return;
 
     ral.alert_threshold.alert_threshold.set(newcfg.alert_threshold);
     ral.alert_threshold.alert_threshold_inv.set(newcfg.alert_threshold_inv);
     csr_update(.csr(ral.alert_threshold));
-    #(pause);
+    pause_until_reset_or_flag(pause, stop_early);
+    if (stop_early || cfg.m_rng_agent_cfg.in_reset) return;
 
     ral.observe_fifo_thresh.observe_fifo_thresh.set(newcfg.observe_fifo_thresh);
     csr_update(ral.observe_fifo_thresh);
-    #(pause);
+    pause_until_reset_or_flag(pause, stop_early);
+    if (stop_early || cfg.m_rng_agent_cfg.in_reset) return;
 
     ral.conf.fips_enable.set(newcfg.fips_enable);
     ral.conf.entropy_data_reg_enable.set(newcfg.entropy_data_reg_enable);
@@ -208,7 +252,8 @@ class entropy_src_base_vseq extends cip_base_vseq #(
     ral.conf.rng_bit_sel.set(newcfg.rng_bit_sel);
     ral.conf.threshold_scope.set(newcfg.ht_threshold_scope);
     csr_update(.csr(ral.conf));
-    #(pause);
+    pause_until_reset_or_flag(pause, stop_early);
+    if (stop_early || cfg.m_rng_agent_cfg.in_reset) return;
 
     // The CSR write accesses above may trigger recoverable alerts (e.g. in case invalid MuBis are
     // written to the CSRs). To handle such cases, the calling entropy_src_init() task listens for
@@ -225,7 +270,8 @@ class entropy_src_base_vseq extends cip_base_vseq #(
     // Register write enable lock is on be default
     // Setting this to zero will lock future writes
     csr_wr(.ptr(ral.sw_regupd), .value(newcfg.sw_regupd));
-    #(pause);
+    pause_until_reset_or_flag(pause, stop_early);
+    if (stop_early || cfg.m_rng_agent_cfg.in_reset) return;
 
     // Module_enables (should be done last)
     if (newcfg.module_enable == MuBi4True) begin
@@ -239,20 +285,24 @@ class entropy_src_base_vseq extends cip_base_vseq #(
       ral.module_enable.set(newcfg.module_enable);
       csr_update(.csr(ral.module_enable));
     end
-    #(pause);
+    pause_until_reset_or_flag(pause, stop_early);
+    if (stop_early || cfg.m_rng_agent_cfg.in_reset) return;
 
     ral.me_regwen.set(newcfg.me_regwen);
     csr_update(.csr(ral.me_regwen));
-    #(pause);
+    pause_until_reset_or_flag(pause, stop_early);
+    if (stop_early || cfg.m_rng_agent_cfg.in_reset) return;
 
     if (do_interrupt) begin
       ral.intr_enable.set(newcfg.en_intr);
       csr_update(ral.intr_enable);
+      if (stop_early || cfg.m_rng_agent_cfg.in_reset) return;
     end
 
-    cfg.clk_rst_vif.wait_clks(2);
-    `uvm_info(`gfn, "Configuration Complete", UVM_MEDIUM)
+    cfg.clk_rst_vif.wait_clks_or_rst(2);
+    if (stop_early || cfg.m_rng_agent_cfg.in_reset) return;
 
+    `uvm_info(`gfn, "Configuration Complete", UVM_MEDIUM)
     completed = 1;
   endtask
 
@@ -281,51 +331,58 @@ class entropy_src_base_vseq extends cip_base_vseq #(
 
     csr_rd(.ptr(ral.regwen.regwen), .value(regwen));
 
-    wait_no_outstanding_access();
-
+    // Set up configuration for the block (with try_apply_base_configuration). If an alert handshake
+    // starts, set the stop_early bit, which causes the task to stop.
+    //
+    // If a reset is asserted, try_apply_base_configuration will exit immediately.
     `uvm_info(`gfn, "Applying configuration", UVM_MEDIUM)
+    fork : isolation_fork begin
+      bit stop_early = 0;
 
-    `DV_SPINWAIT_EXIT(
-      try_apply_base_configuration(newcfg, pause, completed);,
-      wait (cfg.m_alert_agent_cfgs["recov_alert"].vif.is_alert_handshaking);
-      wait_no_outstanding_access();
-    )
-
-    if (!completed) begin
-      bit [TL_DW - 1:0] value;
-      `uvm_info(`gfn, "Detected recoverable alert", UVM_LOW)
-
-      `uvm_info(`gfn, "Falling back on safe config", UVM_LOW)
-
-      // Set all fields with redundancy to safe values
-      entropy_src_safe_config();
-      // Read the alert sts register, let the scoreboard validate the value (if enabled)
-      csr_rd(.ptr(ral.recov_alert_sts), .value(value));
-      `uvm_info(`gfn, $sformatf("RECOV_ALERT_STS (pre): %08x", value), UVM_MEDIUM)
-      // clear the alert status register.
-      csr_wr(.ptr(ral.recov_alert_sts), .value('h0));
-      // Re-read the alert_status register to confirm that it has been cleared.
-      csr_rd(.ptr(ral.recov_alert_sts), .value(value));
-      `uvm_info(`gfn, $sformatf("RECOV_ALERT_STS: %08x", value), UVM_MEDIUM)
+      fork
+        try_apply_base_configuration(newcfg, pause, stop_early, completed);
+        begin
+          wait (cfg.m_alert_agent_cfgs["recov_alert"].vif.is_alert_handshaking);
+          stop_early = 1'b1;
+          wait (0);
+        end
+      join_any
+      disable fork;
+    end join
+    if (completed) begin
+      `uvm_info(get_full_name(), "Configuration applied.", UVM_MEDIUM)
+      return;
     end
 
-    `uvm_info(`gfn, $sformatf("Exiting configuration, status %d", completed) , UVM_MEDIUM)
+    if (cfg.m_rng_agent_cfg.in_reset) return;
 
+    // If we get here, we stopped early in try_apply_base_configuration because we saw an alert.
+    `uvm_info(`gfn, "Detected recoverable alert. Falling back on safe config", UVM_LOW)
+
+    // Set all fields with redundancy to safe values
+    entropy_src_safe_config();
+    if (cfg.m_rng_agent_cfg.in_reset) return;
+
+    `uvm_info(`gfn, $sformatf("Exiting configuration, status %d", completed) , UVM_MEDIUM)
   endtask
 
-  // helper task to clear any invalid configurations
-  task entropy_src_safe_config();
+  // Clear any invalid configurations, then read the alert status register and clear it if nonzero.
+  //
+  // This will exit early on reset
+  local task entropy_src_safe_config();
+    uvm_status_e status;
 
-    `uvm_info(`gfn, "Moving DUT into a safe configuration", UVM_MEDIUM)
     // explicitly clear module_enable to allow module writes
     disable_dut();
 
     // Clear all interrupts
     csr_wr(.ptr(ral.intr_state), .value(32'hf));
+    if (cfg.m_rng_agent_cfg.in_reset) return;
 
     ral.entropy_control.es_type.set(MuBi4False);
     ral.entropy_control.es_route.set(MuBi4False);
     csr_update(.csr(ral.entropy_control));
+    if (cfg.m_rng_agent_cfg.in_reset) return;
 
     ral.conf.fips_enable.set(MuBi4False);
     ral.conf.entropy_data_reg_enable.set(MuBi4False);
@@ -334,18 +391,39 @@ class entropy_src_base_vseq extends cip_base_vseq #(
     ral.conf.rng_bit_enable.set(MuBi4False);
     ral.conf.threshold_scope.set(MuBi4False);
     csr_update(.csr(ral.conf));
+    if (cfg.m_rng_agent_cfg.in_reset) return;
 
     ral.fw_ov_control.fw_ov_mode.set(MuBi4False);
     ral.fw_ov_control.fw_ov_entropy_insert.set(MuBi4False);
     csr_update(.csr(ral.fw_ov_control));
+    if (cfg.m_rng_agent_cfg.in_reset) return;
 
     ral.fw_ov_sha3_start.fw_ov_insert_start.set(MuBi4False);
     csr_update(.csr(ral.fw_ov_sha3_start));
+    if (cfg.m_rng_agent_cfg.in_reset) return;
 
     csr_wr(.ptr(ral.alert_threshold), .value(ral.alert_threshold.get_reset()));
+    if (cfg.m_rng_agent_cfg.in_reset) return;
+
+    // Read the alert_sts register (whose value will be checked by the scoreboard)
+    ral.recov_alert_sts.mirror(status);
+    if (cfg.m_rng_agent_cfg.in_reset) return;
+    if (status != UVM_IS_OK) `uvm_error("mirror", "Failed to mirror alert_sts")
+
+    // If the current status value is nonzero, clear it and then read it back (causing the
+    // scoreboard to check that it has indeed been cleared).
+    ral.recov_alert_sts.set(0);
+    if (ral.recov_alert_sts.needs_update()) begin
+      ral.recov_alert_sts.write(status, {32{1'b1}});
+      if (cfg.m_rng_agent_cfg.in_reset) return;
+      if (status != UVM_IS_OK) `uvm_error("update", "Failed to update alert_sts")
+
+      ral.recov_alert_sts.mirror(status);
+      if (cfg.m_rng_agent_cfg.in_reset) return;
+      if (status != UVM_IS_OK) `uvm_error("mirror", "Failed to mirror alert_sts")
+    end
 
     `uvm_info(`gfn, "Safe configuration", UVM_MEDIUM)
-
   endtask
 
   typedef enum int {

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
@@ -287,9 +287,7 @@ class entropy_src_base_vseq extends cip_base_vseq #(
 
     `DV_SPINWAIT_EXIT(
       try_apply_base_configuration(newcfg, pause, completed);,
-      while (!cfg.m_alert_agent_cfgs["recov_alert"].vif.is_alert_handshaking()) begin
-         cfg.clk_rst_vif.wait_clks(1);
-      end
+      wait (cfg.m_alert_agent_cfgs["recov_alert"].vif.is_alert_handshaking);
       wait_no_outstanding_access();
     )
 

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -138,8 +138,8 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
 
   virtual task try_apply_base_configuration(entropy_src_dut_cfg newcfg,
                                             realtime pause,
+                                            ref bit stop_early,
                                             output bit completed);
-
     int hi_thresh, lo_thresh;
     mubi4_t threshold_scope = newcfg.ht_threshold_scope;
     mubi4_t rng_bit_enable = newcfg.rng_bit_enable;
@@ -165,7 +165,9 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
       ral.adaptp_hi_threshold.set(hi_thresh[15:0]);
       ral.adaptp_lo_threshold.set(lo_thresh[15:0]);
       csr_update(.csr(ral.adaptp_hi_threshold));
+      if (stop_early || cfg.m_rng_agent_cfg.in_reset) return;
       csr_update(.csr(ral.adaptp_lo_threshold));
+      if (stop_early || cfg.m_rng_agent_cfg.in_reset) return;
 
       // Bucket thresholds
       // Disable the bucket health test if rng_bit_enable is not set to MuBi4False.
@@ -178,6 +180,7 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
         ral.bucket_threshold.set(hi_thresh[15:0]);
       end
       csr_update(.csr(ral.bucket_threshold));
+      if (stop_early || cfg.m_rng_agent_cfg.in_reset) return;
 
       // Markov Thresholds
       `uvm_info(`gfn, "Setting MARKOV thresholds", UVM_DEBUG)
@@ -188,14 +191,16 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
       ral.markov_hi_threshold.set(hi_thresh[15:0]);
       ral.markov_lo_threshold.set(lo_thresh[15:0]);
       csr_update(.csr(ral.markov_hi_threshold));
+      if (stop_early || cfg.m_rng_agent_cfg.in_reset) return;
       csr_update(.csr(ral.markov_lo_threshold));
+      if (stop_early || cfg.m_rng_agent_cfg.in_reset) return;
     end
 
     // configure the rest of the variables afterwards so that sw_regupd & module_enable
     // get written last
     // Note there is no need to disable the dut again for the remaining registers
     // it has already been done above.
-    super.try_apply_base_configuration(.newcfg(newcfg), .pause(pause), .completed(completed));
+    super.try_apply_base_configuration(newcfg, pause, stop_early, completed);
   endtask
 
   task pre_start();

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -548,13 +548,33 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
   // 2. Stops background processes
   task main_timer_thread();
     realtime delta = cfg.sim_duration - $realtime();
-    `uvm_info(`gfn, "Starting main timer", UVM_LOW)
+    `uvm_info("timer",
+              $sformatf("Starting main timer. Randomised sim duration is %0dms",
+                        cfg.sim_duration_ms), UVM_LOW)
 
-    // Assumes that continue_sim has already
-    // been set to 1
+    // If delta is positive then we have more expected time to wait. We assume that continue_sim has
+    // already been initialised to 1: a separate thread that wants to end the simulation can set it
+    // to 0.
+    //
+    // Since this might be quite a long wait, send roughly 20 progress messages, giving the amount
+    // of time left to wait.
     if (delta > 0) begin
-      `DV_SPINWAIT_EXIT(#(delta);, wait(~continue_sim))
+      fork : isolation_fork begin
+        fork
+          #(delta);
+          wait(~continue_sim);
+          forever begin
+            `uvm_info("timer",
+                      $sformatf("Waiting in main_timer_thread. %0.1f %% of total.",
+                                (100 * $realtime) / cfg.sim_duration),
+                      UVM_LOW)
+            #(delta / 20);
+          end
+        join_any
+        disable fork;
+      end join
     end
+
     do_background_procs = 0;
     continue_sim = 0;
     `uvm_info(`gfn, "Exiting main timer", UVM_LOW)

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -103,8 +103,8 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
   constraint dly_to_reenable_dut_c {
     dly_to_reenable_dut dist {
       [1      :10]       :/ 10,
-      [101    :100]      :/ 3,
-      [1001   :1000]     :/ 1
+      [11     :100]      :/ 3,
+      [101    :1000]     :/ 1
     };
   }
 


### PR DESCRIPTION
This has been taking a long time in the nightly tests and I think the root of the problem is the silly "wait for no outstanding accesses" trick that engineers have used in the past when injecting resets. Not a great idea!

The fix doesn't turn out to be complicated: you just have to put a little effort into exiting cleanly if something surprising happens. This seems to speed the tests up somewhat (a max job runtime under 350s instead of 475s).

There are other (orthogonal) tweaks that should also speed things up, but they can be in separate PRs.