### PR TITLE
[entropy_src,dv] Make test times a bit more uniform

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -155,7 +155,7 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   // Constraints //
   /////////////////
   constraint sim_duration_ms_c {
-    7 <= sim_duration_ms && sim_duration_ms <= 20;
+    13 <= sim_duration_ms && sim_duration_ms <= 14;
   }
 
   constraint which_ht_state_c {


### PR DESCRIPTION
The entropy_src_rng sequence runs for a randomised amount of time (governed by entropy_src_rng_vseq::main_timer_thread). This also usually governs the time taken by entropy_src_stress_vseq.

I'm not really convinced that there's any benefit to the wide range of timings that were requested (almost a factor of three!). Tweak things to have the same mean but a more predictable value, which should improve things like allocation of test runners.