### PR TITLE
Allow certificate_template to be used by downstream repos.

### DIFF
--- a/rules/certificates.bzl
+++ b/rules/certificates.bzl
@@ -123,12 +123,12 @@ def certificate_template(name, template, cert_format = "x509"):
 
     if cert_format == "x509":
         runtime_deps = [
-            "@//sw/device/silicon_creator/lib/cert:asn1",
-            "@//sw/device/silicon_creator/lib/cert:template",
+            "@lowrisc_opentitan//sw/device/silicon_creator/lib/cert:asn1",
+            "@lowrisc_opentitan//sw/device/silicon_creator/lib/cert:template",
         ]
     else:
         runtime_deps = [
-            "@//sw/device/silicon_creator/lib/cert:cbor",
+            "@lowrisc_opentitan//sw/device/silicon_creator/lib/cert:cbor",
         ]
 
     native.cc_library(


### PR DESCRIPTION
Use the module name '@lowrisc_opentitan' instead of '@' when referencing targets in the same workspace. This is the approach recommended by https://bazel.build/external/migration#specify-repo-name and allows downstream projects to reuse OpenTitan's certificate codegen.


(cherry picked from commit d01c9f91160b52c13fccdc80e58cad030cd46388)