### PR TITLE
[base/hardened_memory] Add a hardened_add, hardened_sub, and hardened_range_check

### DIFF
--- a/sw/device/lib/base/hardened_memory.c
+++ b/sw/device/lib/base/hardened_memory.c
@@ -353,3 +353,38 @@ status_t hardened_sub(const uint32_t *restrict x, const uint32_t *restrict y,
 
   return (status_t){.value = (int32_t)launder32((uint32_t)OTCRYPTO_OK.value)};
 }
+
+status_t hardened_range_check(const uint32_t *value, const uint32_t *N,
+                              size_t word_len) {
+  uint32_t borrow = 0;
+  uint32_t is_zero_acc = 0;
+  size_t count = 0;
+
+  for (; launderw(count) < word_len; count = launderw(count) + 1) {
+    uint32_t val_word = value[count];
+    uint32_t n_word = N[count];
+
+    // Accumulate bits to check if value is zero.
+    is_zero_acc = launder32(is_zero_acc) | launder32(val_word);
+
+    // Compute borrow to check if value < N.
+    uint32_t res = val_word - borrow;
+    uint32_t next_borrow = (val_word < borrow);
+    next_borrow += (res < n_word);
+
+    borrow = next_borrow;
+  }
+  HARDENED_CHECK_EQ(count, word_len);
+
+  uint32_t is_zero = (launder32(is_zero_acc) == 0);
+  uint32_t is_greater_or_eq = (launder32(borrow) == 0);
+  uint32_t is_bad = launder32(is_zero) | launder32(is_greater_or_eq);
+
+  if (launder32(is_bad) != 0) {
+    return (status_t){
+        .value = (int32_t)launder32((uint32_t)OTCRYPTO_BAD_ARGS.value)};
+  }
+  HARDENED_CHECK_EQ(is_bad, 0);
+
+  return (status_t){.value = (int32_t)launder32((uint32_t)OTCRYPTO_OK.value)};
+}

--- a/sw/device/lib/base/hardened_memory.h
+++ b/sw/device/lib/base/hardened_memory.h
@@ -182,9 +182,9 @@ status_t randomized_bytexor_in_place(void *OT_RESTRICT x,
 /**
  * Combines two word buffers with ADD and store the result in the dest. buffer.
  *
- * Warning: the side-channel protection of this function call can not be
- * guaranteed.
- * The function is hardened against fault injections.
+ * Warning: Only limited SCA hardening measures are applied due to the nature of
+ * arithmetic operations. guaranteed. The function is hardened against fault
+ * injections.
  *
  * This mimics the OTBN `add`.
  *
@@ -216,6 +216,23 @@ status_t hardened_add(const uint32_t *OT_RESTRICT x,
 status_t hardened_sub(const uint32_t *OT_RESTRICT x,
                       const uint32_t *OT_RESTRICT y, size_t word_len,
                       uint32_t *OT_RESTRICT dest);
+
+/**
+ * Perform a range check whether the value is larger than zero and smaller than
+ * N. Namely, it checks whether 0 < value < N. Values are expected to follow
+ * little-endian layout.
+ *
+ * Warning: the side-channel protection of this function call can not be
+ * guaranteed.
+ * The function is hardened against fault injections and is constant time.
+ *
+ * @param value Pointer to the value to check.
+ * @param N Pointer to the upper limit of the range.
+ * @param word_len Length in words of value and N.
+ * @return OK or error.
+ */
+status_t hardened_range_check(const uint32_t *value, const uint32_t *N,
+                              size_t word_len);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/base/hardened_memory_unittest.cc
+++ b/sw/device/lib/base/hardened_memory_unittest.cc
@@ -97,5 +97,54 @@ TEST(HardenedMemory, AddSubReversibility) {
   EXPECT_EQ(sub_second, xs);
 }
 
+TEST(HardenedMemory, RangeCheck) {
+  // Single-word tests
+  std::vector<uint32_t> n_single = {10};
+
+  std::vector<uint32_t> val_single_zero = {0};
+  std::vector<uint32_t> val_single_valid = {5};
+  std::vector<uint32_t> val_single_equal = {10};
+  std::vector<uint32_t> val_single_large = {15};
+
+  EXPECT_EQ(
+      hardened_range_check(val_single_zero.data(), n_single.data(), 1).value,
+      OTCRYPTO_BAD_ARGS.value);
+
+  EXPECT_EQ(
+      hardened_range_check(val_single_valid.data(), n_single.data(), 1).value,
+      OTCRYPTO_OK.value);
+
+  EXPECT_EQ(
+      hardened_range_check(val_single_equal.data(), n_single.data(), 1).value,
+      OTCRYPTO_BAD_ARGS.value);
+
+  EXPECT_EQ(
+      hardened_range_check(val_single_large.data(), n_single.data(), 1).value,
+      OTCRYPTO_BAD_ARGS.value);
+
+  // Multi-word tests
+  std::vector<uint32_t> n_multi = {0x00000000, 0x00000002};
+  std::vector<uint32_t> val_multi_zero = {0x00000000, 0x00000000};
+  std::vector<uint32_t> val_multi_valid = {0xFFFFFFFF, 0x00000001};
+  std::vector<uint32_t> val_multi_equal = {0x00000000, 0x00000002};
+  std::vector<uint32_t> val_multi_large = {0x00000001, 0x00000002};
+
+  EXPECT_EQ(
+      hardened_range_check(val_multi_zero.data(), n_multi.data(), 2).value,
+      OTCRYPTO_BAD_ARGS.value);
+
+  EXPECT_EQ(
+      hardened_range_check(val_multi_valid.data(), n_multi.data(), 2).value,
+      OTCRYPTO_OK.value);
+
+  EXPECT_EQ(
+      hardened_range_check(val_multi_equal.data(), n_multi.data(), 2).value,
+      OTCRYPTO_BAD_ARGS.value);
+
+  EXPECT_EQ(
+      hardened_range_check(val_multi_large.data(), n_multi.data(), 2).value,
+      OTCRYPTO_BAD_ARGS.value);
+}
+
 }  // namespace
 }  // namespace hardened_memory_unittest


### PR DESCRIPTION
The OTBN calculates with shared keys using arithmetic masking. When we require the same operation on Ibex, we implement the hardened_add and the hardened_sub.
Note that due to the addition/subtraction nature, this loop is not randomized against SCA.
We also provide a range check function to check whether a buffer is between a value N and 0. Again, this is not hardened against SCA but it provides fault countermeasures.

Implement a test that the hardened_sub of the hardened_add comes back to the same result.
hardened_xor's test was missing, implement the same reversibility test for that as well.
Tests are also added for the range check.