### PR TITLE
Uart: add assertion for TX FIFO read validity

### DIFF
--- a/hw/ip/uart/rtl/uart_core.sv
+++ b/hw/ip/uart/rtl/uart_core.sv
@@ -185,6 +185,10 @@ module uart_core (
 
   assign tx_fifo_rready = tx_uart_idle & tx_fifo_rvalid & tx_enable;
 
+  // Ensure TX FIFO is not read when empty
+`ASSERT(TxFifoReadValid_A, !
+(tx_fifo_rready && !tx_fifo_rvalid))
+
   prim_fifo_sync #(
     .Width   (8),
     .Pass    (1'b0),


### PR DESCRIPTION
This PR adds an assertion to ensure that the TX FIFO is not read when empty.

This helps detect invalid read conditions during simulation and improves
design robustness.