### PR TITLE
[crypto] P256: Share private key routine

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/p256.c
+++ b/sw/device/lib/crypto/impl/ecc/p256.c
@@ -56,6 +56,7 @@ OTBN_DECLARE_SYMBOL_ADDR(run_p256, MODE_SIDELOAD_SIGN);
 OTBN_DECLARE_SYMBOL_ADDR(run_p256, MODE_SIDELOAD_ECDH);
 OTBN_DECLARE_SYMBOL_ADDR(run_p256, MODE_POINTONCRV_CHECK);
 OTBN_DECLARE_SYMBOL_ADDR(run_p256, MODE_BASE_POINT_MULT);
+OTBN_DECLARE_SYMBOL_ADDR(run_p256, MODE_SHARE_SECRET_KEY);
 static const uint32_t kOtbnP256ModeKeygen =
     OTBN_ADDR_T_INIT(run_p256, MODE_KEYGEN);
 static const uint32_t kOtbnP256ModeSign = OTBN_ADDR_T_INIT(run_p256, MODE_SIGN);
@@ -74,6 +75,8 @@ static const uint32_t kOtbnP256ModePointOnCurveCheck =
     OTBN_ADDR_T_INIT(run_p256, MODE_POINTONCRV_CHECK);
 static const uint32_t kOtbnP256ModeBasePointMult =
     OTBN_ADDR_T_INIT(run_p256, MODE_BASE_POINT_MULT);
+static const uint32_t kOtbnP256ModeShareSecretKey =
+    OTBN_ADDR_T_INIT(run_p256, MODE_SHARE_SECRET_KEY);
 
 enum {
   /*
@@ -99,11 +102,12 @@ enum {
   kModeKeygenSideloadInsCnt = 573807,
   kModeEcdhInsCnt = 581607,
   kModeEcdhSideloadInsCnt = 581665,
-  kModeEcdsaSignConfigKInsCnt = 606944,
+  kModeEcdsaSignConfigKInsCnt = 606946,
   kModeEcdsaSignInsCnt = 607096,
   kModeEcdsaSignSideloadInsCnt = 607154,
   kModePointOnCurveCheckInsCnt = 224,
   kModeBasePointMultInsCnt = 573756,
+  kModeShareSecretKeyInsCnt = 147,
 };
 
 static status_t p256_masked_scalar_write(p256_masked_scalar_t *src,
@@ -519,5 +523,37 @@ status_t p256_base_point_mult(p256_masked_scalar_t *private_key,
       otbn_dmem_read(kP256CoordWords, kOtbnVarY, public_key->y));
 
   // Wipe DMEM.
+  return otbn_dmem_sec_wipe();
+}
+
+OT_WARN_UNUSED_RESULT
+status_t arith_share_private_key(p256_masked_scalar_t *boolean_private_key,
+                                 p256_masked_scalar_t *arith_private_key) {
+  // Load the P-256 app. Fails if OTBN is non-idle.
+  HARDENED_TRY(otbn_load_app(kOtbnAppP256));
+
+  // Set mode so start() will jump into the share secret key routine.
+  uint32_t mode = kOtbnP256ModeShareSecretKey;
+  HARDENED_TRY(otbn_dmem_write(kOtbnP256ModeWords, &mode, kOtbnVarMode));
+
+  // Write the Boolean-shared key to DMEM.
+  HARDENED_TRY(
+      p256_masked_scalar_write(boolean_private_key, kOtbnVarD0, kOtbnVarD1));
+
+  /* // Start the OTBN routine. */
+  HARDENED_TRY(otbn_execute());
+
+  /* // Spin here waiting for OTBN to complete. */
+  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+
+  // Check if we executed the expected number of OTBN instructions.
+  HARDENED_CHECK_EQ(otbn_instruction_count_get(), kModeShareSecretKeyInsCnt);
+
+  // Read back the shared private key.
+  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(kP256MaskedScalarShareWords, kOtbnVarD0,
+                                        arith_private_key->share0));
+  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(kP256MaskedScalarShareWords, kOtbnVarD1,
+                                        arith_private_key->share1));
+
   return otbn_dmem_sec_wipe();
 }

--- a/sw/device/lib/crypto/impl/ecc/p256.h
+++ b/sw/device/lib/crypto/impl/ecc/p256.h
@@ -404,6 +404,21 @@ OT_WARN_UNUSED_RESULT
 status_t p256_base_point_mult(p256_masked_scalar_t *private_key,
                               p256_point_t *public_key);
 
+/**
+ * Generate a secret key arithmetic sharing.
+ *
+ * The input can either be an unshared raw key (two 320-bit shares d0, d1 with
+ * the upper 64 bits of d0 being 0 and d1 being 0) or a Boolean-shared key (two
+ * 320 bit shares).
+ *
+ * @param boolean_private_key The key that is being arithmetically shared.
+ * @param arithmetic_private_key The resulting arithmetically shared key.
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t arith_share_private_key(p256_masked_scalar_t *boolean_private_key,
+                                 p256_masked_scalar_t *arith_private_key);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/crypto/impl/ecc_p256.c
+++ b/sw/device/lib/crypto/impl/ecc_p256.c
@@ -899,3 +899,76 @@ otcrypto_status_t otcrypto_ecc_p256_private_key_export(
 
   return OTCRYPTO_OK;
 }
+
+otcrypto_status_t otcrypto_ecc_p256_arith_share_private_key(
+    otcrypto_const_word32_buf_t *bool_private_key_share0,
+    otcrypto_const_word32_buf_t *bool_private_key_share1,
+    otcrypto_blinded_key_t *arith_private_key) {
+  if (bool_private_key_share0 == NULL || bool_private_key_share1 == NULL ||
+      arith_private_key == NULL || arith_private_key->keyblob == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  HARDENED_TRY(entropy_complex_check());
+
+  // The key shares must resided in 320-bit buffers.
+  if (bool_private_key_share0->len != kP256MaskedScalarShareWords ||
+      bool_private_key_share1->len != kP256MaskedScalarShareWords) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(launder32(bool_private_key_share0->len),
+                    kP256MaskedScalarShareWords);
+  HARDENED_CHECK_EQ(launder32(bool_private_key_share1->len),
+                    kP256MaskedScalarShareWords);
+
+  // Check the key mode; both ECDSA and ECDH P-256 modes are accepted since
+  // the private key representation is identical for both.
+  if (arith_private_key->config.key_mode != kOtcryptoKeyModeEcdsaP256 &&
+      arith_private_key->config.key_mode != kOtcryptoKeyModeEcdhP256) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  // Import is only supported for software-backed keys.
+  if (arith_private_key->config.hw_backed != kHardenedBoolFalse) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(launder32(arith_private_key->config.hw_backed),
+                    kHardenedBoolFalse);
+
+  // Check that the caller-allocated keyblob matches the expected P-256 layout.
+  HARDENED_TRY(p256_private_key_length_check(arith_private_key));
+
+  // Randomize the keyblob before writing secret data.
+  HARDENED_TRY(hardened_memshred(arith_private_key->keyblob,
+                                 kP256MaskedScalarTotalShareWords));
+
+  p256_masked_scalar_t boolean_private_scalar;
+  p256_masked_scalar_t arith_private_scalar;
+  HARDENED_TRY(hardened_memcpy(boolean_private_scalar.share0,
+                               bool_private_key_share0->data,
+                               kP256MaskedScalarShareWords));
+  HARDENED_TRY(hardened_memcpy(boolean_private_scalar.share1,
+                               bool_private_key_share1->data,
+                               kP256MaskedScalarShareWords));
+  boolean_private_scalar.checksum =
+      p256_masked_scalar_checksum(&boolean_private_scalar);
+
+  // Invoke the sharing routine.
+  HARDENED_TRY(
+      arith_share_private_key(&boolean_private_scalar, &arith_private_scalar));
+
+  // Copy the two arithmetic shares into the output buffer.
+  HARDENED_TRY(hardened_memcpy(arith_private_key->keyblob,
+                               arith_private_scalar.share0,
+                               kP256MaskedScalarTotalShareWords));
+
+  // Set the shared key checksum.
+  arith_private_key->checksum = integrity_blinded_checksum(arith_private_key);
+
+  HARDENED_CHECK_EQ(OTCRYPTO_CHECK_BUF(bool_private_key_share0),
+                    kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(OTCRYPTO_CHECK_BUF(bool_private_key_share1),
+                    kHardenedBoolTrue);
+
+  return OTCRYPTO_OK;
+}

--- a/sw/device/lib/crypto/include/ecc_p256.h
+++ b/sw/device/lib/crypto/include/ecc_p256.h
@@ -478,6 +478,33 @@ status_t otcrypto_p256_base_point_mult(
     const otcrypto_blinded_key_t *private_key,
     otcrypto_unblinded_key_t *public_key);
 
+/**
+ * Arithmetically share a private key provided as Boolean shares.
+ *
+ * Given a Boolean-shared private key d in the range [1, n-1] and shared, this
+ * routine arithmetically shares the key such that d = d0 + d1 mod n, where n
+ * is the curve order.
+ *
+ * It is allowed to pass the key in plain with the second share being set to 0.
+ *
+ * Note that no checks are performed to verify whether the input key d is in
+ * the interval, this is the responsibility of the caller. I.e., this routine
+ * does not (!) provide checks as per FIPS 186-5 for the case of generating a
+ * key without extra random bits. The routine will though reduce modulo n
+ * implicitly. The routine can be used to generate keys according to FIPS 186-5
+ * with extra random bits. The modulo n reduction will not introduce bias due
+ * to the extra bits. Note that the routine will not check for zero.
+ *
+ * @param bool_private_key_share0 First Boolean share of the private key.
+ * @param bool_private_key_share1 Second Boolean share of the private key.
+ * @param arith_shared_private_key The resulting arithmetically shared key.
+ * @return Result of the sharing operation.
+ */
+otcrypto_status_t otcrypto_ecc_p256_arith_share_private_key(
+    otcrypto_const_word32_buf_t *bool_private_key_share0,
+    otcrypto_const_word32_buf_t *bool_private_key_share1,
+    otcrypto_blinded_key_t *arith_private_key);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -276,6 +276,26 @@ opentitan_test(
         "//sw/device/lib/crypto/drivers:otbn",
         "//sw/device/lib/crypto/impl:ecc_p256",
         "//sw/device/lib/crypto/impl:keyblob",
+        "//sw/device/lib/crypto/impl:sha2",
+        "//sw/device/lib/crypto/include:datatypes",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_test(
+    name = "ecc_p256_arith_share_private_key_functest",
+    srcs = ["ecc_p256_arith_share_private_key_functest.c"],
+    exec_env = CRYPTOTEST_EXEC_ENVS,
+    verilator = verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl:ecc_p256",
+        "//sw/device/lib/crypto/impl:keyblob",
+        "//sw/device/lib/crypto/impl:sha2",
         "//sw/device/lib/crypto/include:datatypes",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:entropy_testutils",

--- a/sw/device/tests/crypto/ecc_p256_arith_share_private_key_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_arith_share_private_key_functest.c
@@ -1,0 +1,168 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/ecc/p256.h"
+#include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/ecc_p256.h"
+#include "sw/device/lib/crypto/include/integrity.h"
+#include "sw/device/lib/crypto/include/sha2.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+enum {
+  /* Number of 32-bit words in a P-256 public key. */
+  kP256PublicKeyWords = 512 / 32,
+  /* Number of bytes in a P-256 private key. */
+  kP256PrivateKeyBytes = 256 / 8,
+  /* Number of 32-bit words in a P-256 message digest. */
+  kP256DigestWords = 256 / 32,
+  /* Number of 32-bit words in a P-256 ECDSA signature. */
+  kP256SignatureWords = 512 / 32,
+};
+
+static const otcrypto_key_config_t kPrivateKeyConfig = {
+    .version = kOtcryptoLibVersion1,
+    .key_mode = kOtcryptoKeyModeEcdsaP256,
+    .key_length = kP256PrivateKeyBytes,
+    .hw_backed = kHardenedBoolFalse,
+    .security_level = kOtcryptoKeySecurityLevelLow,
+};
+
+static const char kMessage[] = "test message";
+
+// Generate a random plain private key in the interval [1, n - 1].
+void generate_random_key(uint32_t *key) {
+  hardened_memshred(key, kP256ScalarWords);
+
+  const uint32_t zero[kP256ScalarWords] = {0};
+
+  // n - 1
+  const uint32_t n1[kP256ScalarWords] = {0xfc632551, 0xf3b9cac2, 0xa7179e84,
+                                         0xbce6faad, 0xffffffff, 0xffffffff,
+                                         0x00000000, 0xffffffff};
+
+  while (1) {
+    // Generate a random scalar.
+    size_t i = 0;
+    for (; launder32(i) < kP256ScalarWords; i++) {
+      key[i] = hardened_memshred_random_word();
+    }
+    HARDENED_CHECK_EQ(i, kP256ScalarWords);
+
+    // If the generated key is 0, restart.
+    if (hardened_memeq(key, zero, kP256ScalarWords) == kHardenedBoolTrue) {
+      continue;
+    }
+    HARDENED_CHECK_EQ(hardened_memeq(key, zero, kP256ScalarWords),
+                      kHardenedBoolFalse);
+
+    // If the generated key is > n - 1, restart.
+    uint32_t borrow = 0;
+    i = 0;
+    for (; launder32(i) < kP256ScalarWords; i++) {
+      borrow = (n1[i] < borrow) + ((n1[i] - borrow) < key[i]);
+    }
+    HARDENED_CHECK_EQ(i, kP256ScalarWords);
+
+    if (borrow) {
+      continue;
+    }
+    HARDENED_CHECK_EQ(borrow, 0);
+
+    return;
+  }
+}
+
+// Verify that we can correctly arithmetically share a plain private key.
+status_t arith_share_private_key_test(void) {
+  // Part 1: Generate a random private key and arithmetically share it.
+
+  uint32_t key_share0[kP256MaskedScalarShareWords] = {0};
+  uint32_t key_share1[kP256MaskedScalarShareWords] = {0};
+  generate_random_key(key_share0);
+
+  otcrypto_const_word32_buf_t private_key_share0 = OTCRYPTO_MAKE_BUF(
+      otcrypto_const_word32_buf_t, key_share0, kP256MaskedScalarShareWords);
+  otcrypto_const_word32_buf_t private_key_share1 = OTCRYPTO_MAKE_BUF(
+      otcrypto_const_word32_buf_t, key_share1, kP256MaskedScalarShareWords);
+
+  uint32_t private_key_blob[kP256MaskedScalarTotalShareWords] = {0};
+  otcrypto_blinded_key_t arith_shared_private_key = {
+      .config = kPrivateKeyConfig,
+      .keyblob_length = sizeof(private_key_blob),
+      .keyblob = private_key_blob,
+  };
+
+  LOG_INFO("Sharing the private key...");
+  CHECK_STATUS_OK(otcrypto_ecc_p256_arith_share_private_key(
+      &private_key_share0, &private_key_share1, &arith_shared_private_key));
+
+  // Part 2: Derive the public key with a base point multiplication.
+
+  uint32_t public_key_blob[kP256PublicKeyWords] = {0};
+  otcrypto_unblinded_key_t ppp = {
+      .key_mode = kOtcryptoKeyModeEcdsaP256,
+      .key_length = sizeof(public_key_blob),
+      .key = public_key_blob,
+  };
+
+  LOG_INFO("Calculating the public key...");
+  CHECK_STATUS_OK(
+      otcrypto_p256_base_point_mult(&arith_shared_private_key, &ppp));
+
+  // Part 3: Sign a message with the arithmetically shared key.
+
+  otcrypto_const_byte_buf_t msg =
+      OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, (unsigned char *)kMessage,
+                        sizeof(kMessage) - 1);
+  uint32_t msg_digest_data[kP256DigestWords];
+  otcrypto_hash_digest_t msg_digest = {
+      .data = msg_digest_data,
+      .len = ARRAYSIZE(msg_digest_data),
+  };
+  TRY(otcrypto_sha2_256(&msg, &msg_digest));
+
+  uint32_t sig[kP256SignatureWords] = {0};
+  otcrypto_word32_buf_t sig_buf =
+      OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, sig, ARRAYSIZE(sig));
+
+  LOG_INFO("Signing with shared private key...");
+  TRY(otcrypto_ecdsa_p256_sign(&arith_shared_private_key, msg_digest,
+                               &sig_buf));
+
+  // Part 4: Verify the signature.
+
+  otcrypto_const_word32_buf_t const_sig_buf =
+      OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, sig, ARRAYSIZE(sig));
+  hardened_bool_t verification_result;
+
+  LOG_INFO("Verifying signature with calculated public key...");
+  TRY(otcrypto_ecdsa_p256_verify(&ppp, msg_digest, &const_sig_buf,
+                                 &verification_result));
+  TRY_CHECK(verification_result == kHardenedBoolTrue);
+
+  return OTCRYPTO_OK;
+}
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
+
+  status_t err = arith_share_private_key_test();
+  if (!status_ok(err)) {
+    // If there was an error, print the OTBN error bits and instruction count.
+    LOG_INFO("OTBN error bits: 0x%08x", otbn_err_bits_get());
+    LOG_INFO("OTBN instruction count: 0x%08x", otbn_instruction_count_get());
+    // Print the error.
+    CHECK_STATUS_OK(err);
+    return false;
+  }
+
+  return true;
+}

--- a/sw/otbn/crypto/run_p256.s
+++ b/sw/otbn/crypto/run_p256.s
@@ -17,7 +17,7 @@
 
 /**
  * Mode magic values, generated with
- * $ ./util/design/sparse-fsm-encode.py -d 6 -m 9 -n 11 \
+ * $ ./util/design/sparse-fsm-encode.py -d 6 -m 11 -n 11 \
  *     --avoid-zero -s 380925547
  *
  * Call the same utility with the same arguments and a higher -m to generate
@@ -38,6 +38,7 @@
 .equ MODE_SIDELOAD_ECDH, 0x2F1
 .equ MODE_POINTONCRV_CHECK, 0x6AA
 .equ MODE_BASE_POINT_MULT, 0x3C6
+.equ MODE_SHARE_SECRET_KEY, 0x31B
 
 /**
  * Make the mode constants visible to Ibex.
@@ -52,6 +53,7 @@
 .globl MODE_SIDELOAD_ECDH
 .globl MODE_POINTONCRV_CHECK
 .globl MODE_BASE_POINT_MULT
+.globl MODE_SHARE_SECRET_KEY
 
 /**
  * Hardened boolean values.
@@ -104,6 +106,9 @@ start:
 
   addi  x3, x0, MODE_BASE_POINT_MULT
   beq   x2, x3, base_point_mult
+
+  addi  x3, x0, MODE_SHARE_SECRET_KEY
+  beq   x2, x3, share_secret_key
 
   /* Copy the caller-provided secret scalar shares into scratchpad memory.
        dmem[k0] <= dmem[k0_io]
@@ -369,8 +374,73 @@ point_on_curve_check:
 
   ecall
 
+/**
+ * Calculate a base point multiplication.
+ *
+ * This routine runs in constant time.
+ *
+ * @param[in]  dmem[d0]: d0, first share of the secret key.
+ * @param[in]  dmem[d1]: d1, second share of the secret key.
+ * @param[out] dmem[x]: Public key (Q) x-coordinate.
+ * @param[out] dmem[y]: Public key (Q) y-coordinate.
+ */
 base_point_mult:
   jal x1, p256_base_mult
+
+  ecall
+
+/**
+ * Generate a secret key arithmetic sharing.
+ *
+ * The input is a Boolean-shared key (two 320 bit shares).
+ *
+ * This routine runs in constant time.
+ *
+ * @param[in]  dmem[d0]: d0, first share of the secret key.
+ * @param[in]  dmem[d1]: d1, second share of the secret key.
+ * @param[out] dmem[d0]: d0, first arithmetic share of the secret key.
+ * @param[out] dmem[d1]: d1, second arithmetic share of the secret key.
+ */
+share_secret_key:
+  /* w31 <= 0. */
+  bn.xor w31, w31, w31
+
+  /* Load the key shares:
+     w20, w21 <= d0
+     w10, w11 <= d1. */
+  li x2, 20
+  la x3, d0
+  bn.lid x2++, 0(x3)
+  bn.lid x2++, 32(x3)
+  li x2, 10
+  la x3, d1
+  bn.lid x2++, 0(x3)
+  bn.lid x2++, 32(x3)
+
+  /* Remask the shares. */
+  bn.wsrr w0, URND
+  bn.wsrr w1, URND
+  bn.rshi w1, w31, w1 >> 192
+
+  bn.xor w20, w20, w0
+  bn.xor w21, w21, w1
+  bn.xor w31, w31, w31 /* dummy */
+  bn.xor w10, w10, w0
+  bn.xor w11, w11, w1
+
+  /* Generate secret key shares.
+     w20, w21 <= d0
+     w10, w11 <= d1 */
+  jal x1, p256_key_from_seed
+
+  li       x2, 20
+  la       x3, d0_io
+  bn.sid   x2++, 0(x3)
+  bn.sid   x2++, 32(x3)
+  li       x2, 10
+  la       x3, d1_io
+  bn.sid   x2++, 0(x3)
+  bn.sid   x2++, 32(x3)
 
   ecall
 


### PR DESCRIPTION
This commits adds a new routine to the cryptolib API that faciliates the arithmetic sharing of a plain private key.