### PR TITLE
[sram_ctrl,rtl] FIFO duplication and split

### DIFF
--- a/hw/ip/tlul/rtl/tlul_sram_byte.sv
+++ b/hw/ip/tlul/rtl/tlul_sram_byte.sv
@@ -101,6 +101,8 @@ module tlul_sram_byte import tlul_pkg::*; #(
     logic rdback_wait;
     logic readback_err;
     logic sync_fifo_a_size_outputs_mismatch;
+    logic sync_fifo_outputs_mismatch;
+    logic tl_i_fifo_intg_err, tl_intg_err;
     state_e state_d, state_q;
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -125,16 +127,24 @@ module tlul_sram_byte import tlul_pkg::*; #(
 
     // prim fifo for capturing info
     typedef struct packed {
-      logic                  [2:0]  a_param;
-      logic  [top_pkg::TL_SZW-1:0]  a_size;
-      logic  [top_pkg::TL_AIW-1:0]  a_source;
-      logic   [top_pkg::TL_AW-1:0]  a_address;
-      logic  [top_pkg::TL_DBW-1:0]  a_mask;
-      logic   [top_pkg::TL_DW-1:0]  a_data;
-      tl_a_user_t                   a_user;
+      tl_a_op_e                       a_opcode;
+      logic                     [2:0] a_param;
+      logic     [top_pkg::TL_SZW-1:0] a_size;
+      logic     [top_pkg::TL_AIW-1:0] a_source;
+      logic      [top_pkg::TL_AW-1:0] a_address;
+      logic     [top_pkg::TL_DBW-1:0] a_mask;
+      logic      [top_pkg::TL_DW-1:0] a_data;
+      logic [tlul_pkg::RsvdWidth-1:0] a_user_rsvd;
+      prim_mubi_pkg::mubi4_t          a_user_instr_type;
     } tl_txn_data_t;
 
+    typedef struct packed {
+      logic [tlul_pkg::H2DCmdIntgWidth-1:0] a_user_cmd_intg;
+      logic   [tlul_pkg::DataIntgWidth-1:0] a_user_data_intg;
+    } tl_txn_intg_t;
+
     tl_txn_data_t held_data;
+    tl_txn_intg_t held_intg;
 
     // Outputs of the sync_fifo_a_size FIFOs.
     typedef struct packed {
@@ -156,7 +166,8 @@ module tlul_sram_byte import tlul_pkg::*; #(
     assign byte_wr_txn = tl_i.a_valid & ~&tl_i.a_mask & wr_txn;
 
     // Alert generation.
-    assign alert_o = readback_err | sync_fifo_a_size_outputs_mismatch;
+    assign alert_o = readback_err | sync_fifo_a_size_outputs_mismatch |
+      sync_fifo_outputs_mismatch | tl_intg_err;
 
     logic                     rdback_chk_ok;
     mubi4_t                   rdback_check_q, rdback_check_d;
@@ -348,7 +359,7 @@ module tlul_sram_byte import tlul_pkg::*; #(
             // was sent.
             rdback_check_d         = mubi4_test_true_loose(rdback_en_q) ? MuBi4True : MuBi4False;
             rdback_data_exp_d      = held_data.a_data;
-            rdback_data_exp_intg_d = held_data.a_user.data_intg;
+            rdback_data_exp_intg_d = held_intg.a_user_data_intg;
             if (d_ack) begin
               // Got an immediate TL-UL write response. Wait for one cycle until the holding
               // register is flushed and then perform the readback.
@@ -511,22 +522,30 @@ module tlul_sram_byte import tlul_pkg::*; #(
     end
 
     tl_txn_data_t txn_data;
-    logic fifo_rdy;
-    logic txn_data_wr;
+    tl_txn_intg_t txn_intg;
+    logic fifo_rdy_data, fifo_rdy_intg;
+    logic txn_data_intg_wr;
     localparam int TxnDataWidth = $bits(tl_txn_data_t);
+    localparam int TxnIntgWidth = $bits(tl_txn_intg_t);
 
     assign txn_data = '{
+      a_opcode: tl_i.a_opcode,
       a_param: tl_i.a_param,
       a_size: tl_i.a_size,
       a_source: tl_i.a_source,
       a_address: tl_i.a_address,
       a_mask: tl_i.a_mask,
       a_data: tl_i.a_data,
-      a_user: tl_i.a_user
+      a_user_rsvd: tl_i.a_user.rsvd,
+      a_user_instr_type: tl_i.a_user.instr_type
     };
 
+    assign txn_intg = '{
+      a_user_cmd_intg: tl_i.a_user.cmd_intg,
+      a_user_data_intg: tl_i.a_user.data_intg
+    };
 
-    assign txn_data_wr = hold_tx_data | byte_req_ack;
+    assign txn_data_intg_wr = hold_tx_data | byte_req_ack;
 
     prim_fifo_sync #(
       .Width(TxnDataWidth),
@@ -534,12 +553,12 @@ module tlul_sram_byte import tlul_pkg::*; #(
       .Depth(1),
       .OutputZeroIfEmpty(1'b0),
       .NeverClears(1'b1)
-    ) u_sync_fifo (
+    ) u_sync_fifo_data (
       .clk_i,
       .rst_ni,
       .clr_i(1'b0),
-      .wvalid_i(txn_data_wr),
-      .wready_o(fifo_rdy),
+      .wvalid_i(txn_data_intg_wr),
+      .wready_o(fifo_rdy_data),
       .wdata_i(txn_data),
       .rvalid_o(),
       .rready_i(sram_a_ack),
@@ -548,6 +567,100 @@ module tlul_sram_byte import tlul_pkg::*; #(
       .depth_o(),
       .err_o()
     );
+
+     // Buffer the inputs of the FIFO holding the integrity to avoid synthesis optimizations.
+    localparam int NumBufferBitsSyncIntg = $bits({
+      txn_data_intg_wr,
+      sram_a_ack
+    });
+
+    logic [NumBufferBitsSyncIntg-1:0] buf_sync_fifo_intg_in, buf_sync_fifo_intg_out;
+    logic txn_data_intg_wr_buf;
+    logic sram_a_ack_buf;
+
+    assign buf_sync_fifo_intg_in = {
+      txn_data_intg_wr,
+      sram_a_ack
+    };
+
+    assign {
+      txn_data_intg_wr_buf,
+      sram_a_ack_buf
+    } = buf_sync_fifo_intg_out;
+
+    prim_buf #(
+      .Width(NumBufferBitsSyncIntg)
+    ) u_sync_fifo_intg_prim_buf (
+      .in_i(buf_sync_fifo_intg_in),
+      .out_o(buf_sync_fifo_intg_out)
+    );
+
+    prim_fifo_sync #(
+      .Width(TxnIntgWidth),
+      .Pass(1'b0),
+      .Depth(1),
+      .OutputZeroIfEmpty(1'b0),
+      .NeverClears(1'b1)
+    ) u_sync_fifo_intg (
+      .clk_i,
+      .rst_ni,
+      .clr_i(1'b0),
+      .wvalid_i(txn_data_intg_wr_buf),
+      .wready_o(fifo_rdy_intg),
+      .wdata_i(txn_intg),
+      .rvalid_o(),
+      .rready_i(sram_a_ack_buf),
+      .rdata_o(held_intg),
+      .full_o(),
+      .depth_o(),
+      .err_o()
+    );
+
+    // Raise an alert if there is a mismatch in the duplicated FIFOs.
+    assign sync_fifo_outputs_mismatch = (fifo_rdy_data != fifo_rdy_intg);
+
+    // Re-assemble the incoming tl_i request after the FIFO to check its integrity.
+    tl_a_user_t tl_i_fifo_a_user;
+    tl_h2d_t tl_i_fifo;
+    assign tl_i_fifo_a_user = '{
+      rsvd: held_data.a_user_rsvd,
+      instr_type: held_data.a_user_instr_type,
+      cmd_intg: held_intg.a_user_cmd_intg,
+      data_intg: held_intg.a_user_data_intg
+    };
+
+    assign tl_i_fifo = '{
+      a_valid: sram_a_ack,
+      a_opcode: held_data.a_opcode,
+      a_param: held_data.a_param,
+      a_size: held_data.a_size,
+      a_source: held_data.a_source,
+      a_address: held_data.a_address,
+      a_mask: held_data.a_mask,
+      a_data: held_data.a_data,
+      a_user: tl_i_fifo_a_user,
+      d_ready:  1'b1
+    };
+
+    tlul_cmd_intg_chk u_cmd_intg_chk (
+      .tl_i(tl_i_fifo),
+      .err_o (tl_i_fifo_intg_err)
+    );
+
+    // Enable the integrity check comparison once we have seen the first write to the FIFO.
+    // This is necessary as the u_sync_fifo_data/intg FIFOs do not use the OutputZeroIfEmpty
+    // option. Hence, after reset, the FFs within the FIFO are not initialized, resulting in
+    // integrity and DV failures (firing X assertions).
+    logic enable_intg_check_cmp_q;
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        enable_intg_check_cmp_q <= 1'b0;
+      end else if (txn_data_intg_wr)begin
+        enable_intg_check_cmp_q <= 1'b1;
+      end
+    end
+
+    assign tl_intg_err = enable_intg_check_cmp_q & tl_i_fifo_intg_err;
 
     // captured read data
     logic [top_pkg::TL_DW-1:0] rsp_data;
@@ -582,8 +695,10 @@ module tlul_sram_byte import tlul_pkg::*; #(
 
     tl_a_user_t combined_user;
     always_comb begin
-      combined_user           = held_data.a_user;
-      combined_user.data_intg = data_intg;
+      combined_user.cmd_intg   = held_intg.a_user_cmd_intg;
+      combined_user.data_intg  = data_intg;
+      combined_user.rsvd       = held_data.a_user_rsvd;
+      combined_user.instr_type = held_data.a_user_instr_type;
     end
 
     localparam int unsigned AccessSize = $clog2(top_pkg::TL_DBW);
@@ -727,7 +842,7 @@ module tlul_sram_byte import tlul_pkg::*; #(
       tl_o = tl_sram_i;
 
       // pass a_ready through directly if we are not stalling
-      tl_o.a_ready = tl_sram_i.a_ready & ~stall_host & fifo_rdy &
+      tl_o.a_ready = tl_sram_i.a_ready & ~stall_host & fifo_rdy_data &
         sync_fifo_a_size_outputs.size_fifo_rdy;
 
       // when internal logic has taken over, do not show response to host during


### PR DESCRIPTION
As approved in this [RFC](https://docs.google.com/document/d/1I2UVPmG7k9fJ4jq8eoeQ3b-x3hFxxEUwNgrFth4aO88/edit?tab=t.0#heading=h.of98rfcbd97b), this PR duplicates one FIFO and splits up another one in data and ECC part.