### PR TITLE
[sram_ctrl,dv] Make running the sram_ctrl regression much quicker

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_bijection_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_bijection_vseq.sv
@@ -3,32 +3,40 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // This sequence tests the bijectivity of the SRAM address remapping.
-// To this, we iterate over every address in SRAM memory and write a unique value to it
-// (in this case we write the address to memory, e.g. write 0x0 to address 0x0,
-//  write 0x4 to address 0x4, etc...).
-// We then read out each address in memory and check that the read data is equal to the address
-// we read it from (this is done using the built-in checking capabilities of `tl_acess()` task.
 //
-// This helps us verify that the SRAM address scrambling does not lead to any address collisions,
-// e.g. addresses 0x4 and 0x8 do not both map to the same line in memory.
-// If there are any address collisions, then we will read out an incorrect value from memory.
+// To do this, use the following stimulus:
+//
+//  - Write a different value to every address in SRAM memory (using the address, so write 0x0 to
+//    address 0x0, write 0x4 to address 0x4, etc...).
+//
+//  - Read the value back from every address in SRAM memory. As well as any check from the
+//    scoreboard, the sequence knows the value it expects to read, so can check the value as well.
+//
+// The test helps us verify that the SRAM address scrambling does not lead to any address collisions
+// (e.g. addresses 0x4 and 0x8 do not both map to the same line in memory). If there are any address
+// collisions, then we will read out an incorrect value from memory.
+//
+// The sequence runs twice, requesting a new scrambling key between the two runs (to check that
+// nothing gets broken by switching scrambling key)
 class sram_ctrl_bijection_vseq extends sram_ctrl_smoke_vseq;
-
   `uvm_object_utils(sram_ctrl_bijection_vseq)
-  `uvm_object_new
 
-  constraint num_trans_c {
-    num_trans inside {[5 : 25]};
-  }
+  function new (string name="");
+    super.new(name);
+  endfunction
 
   virtual task body();
+    int unsigned sram_depth = cfg.sram_ctrl_bkdr_util_h.get_depth();
 
-    int sram_depth = cfg.sram_ctrl_bkdr_util_h.get_depth();
-
-    `uvm_info(`gfn, $sformatf("sram_depth: %0d", sram_depth), UVM_HIGH)
+    `uvm_info(get_name(),
+              $sformatf("Read-write bijection test with %0d iterations over SRAM with depth %0d.",
+                        num_trans, sram_depth),
+              UVM_LOW)
 
     for (int i = 0; i < num_trans; i++) begin
-      `uvm_info(`gfn, $sformatf("iteration: %0d", i), UVM_HIGH)
+      `uvm_info(get_name(),
+                $sformatf("Starting iteration %0d of %0d", i+1, num_trans),
+                UVM_LOW)
 
       // Write the corresponding address to each entry in the SRAM
       for (int j = 0; j < sram_depth; j++) begin
@@ -46,11 +54,13 @@ class sram_ctrl_bijection_vseq extends sram_ctrl_smoke_vseq;
 
       // request new scrambling key on all but the last iteration
       if (i != num_trans - 1) begin
+        `uvm_info(get_name(), "Rotating scrambling key", UVM_LOW)
         req_scr_key();
       end
-
     end
-
   endtask : body
 
+  // Only run two transactions: this will ensure we check a new scrambling key, but avoids spending
+  // too long in the (slow) sweep across the entire memory.
+  constraint num_trans_c { num_trans == 2; }
 endclass

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_smoke_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_smoke_vseq.sv
@@ -49,17 +49,19 @@ class sram_ctrl_smoke_vseq extends sram_ctrl_base_vseq;
     if (!do_sram_ctrl_init) cfg.disable_d_user_data_intg_check_for_passthru_mem = 1;
 
     // do some memory transactions right after reset (zeroed key and nonce)
-    `uvm_info(`gfn,
+    `uvm_info(get_name(),
               $sformatf("Performing %0d random memory accesses after reset!", num_ops_after_reset),
               UVM_LOW)
     do_rand_ops(.num_ops(num_ops_after_reset),
                 .en_ifetch(en_ifetch));
 
-    `uvm_info(`gfn, $sformatf("Starting %0d SRAM transactions", num_trans), UVM_LOW)
     for (int i = 0; i < num_trans; i++) begin
-      `uvm_info(`gfn, $sformatf("iteration: %0d", i), UVM_LOW)
-
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_ops)
+
+      `uvm_info(get_name(),
+                $sformatf("Iteration %0d / %0d (%0d random memory accesses)",
+                          i + 1, num_trans, num_ops),
+                UVM_LOW)
 
       if (access_during_key_req) begin
         // Request new key and issue mem init, in the meanwhile, do some random SRAM operations.
@@ -78,7 +80,7 @@ class sram_ctrl_smoke_vseq extends sram_ctrl_base_vseq;
             // Also need to enable zero_delays, otherwise, the CSR programming may take random
             // cycles to finish
             cfg.clk_rst_vif.wait_clks(2);
-            `uvm_info(`gfn, "accessing during key req", UVM_HIGH)
+            `uvm_info(get_name(), "Accessing during key req", UVM_HIGH)
 
             // SRAM init is basically to write all the mem with random value.
             // When a read happens right after init, it's read-after-write hazard. SCB expects the
@@ -96,9 +98,6 @@ class sram_ctrl_smoke_vseq extends sram_ctrl_base_vseq;
       end
 
       // Do some random memory accesses
-      `uvm_info(`gfn,
-                $sformatf("Performing %0d random memory accesses!", num_ops),
-                UVM_LOW)
       if (stress_pipeline) begin
         bit [TL_AW-1:0] stress_addr;
         for (int i = 0; i < num_ops; i++) begin


### PR DESCRIPTION
The total time was dominated by `sram_ctrl_bijection_vseq`. There's no need to make the different scrambling seeds all use the same simulation, so we can get dramatic parallelism improvements by lowering `num_trans` and then increasing the reseed count.

Moreover, I'm extremely unconvinced that the repetition was actually telling us anything useful anyway. I've cut `num_trans` down to 2 (so we still see a "new scrambling seed" each time). This will speed up that test by a factor of 7.5 and I suspect will have a similar effect on the `stress_all` sequence (which uses it as one of the possible tests to run).