### PR TITLE
util/usb: make error messages more useful when unable to find exactly 1 USB device

### DIFF
--- a/sw/host/opentitanlib/src/transport/errors.rs
+++ b/sw/host/opentitanlib/src/transport/errors.rs
@@ -13,12 +13,10 @@ use crate::impl_serializable_error;
 /// part of the session proxy functionality.
 #[derive(Error, Debug, Serialize, Deserialize)]
 pub enum TransportError {
-    #[error("USB device did not match")]
-    NoMatch,
-    #[error("Found no USB device")]
-    NoDevice,
-    #[error("Found multiple USB devices ({0}), use --usb-serial")]
-    MultipleDevices(String),
+    #[error("Found no USB device. Search criteria was: {0}")]
+    NoDevice(String),
+    #[error("Found multiple USB devices ({0}), use --usb-serial. Search criteria was: {1}")]
+    MultipleDevices(String, String),
     #[error("USB error: {0}")]
     UsbGenericError(String),
     #[error("Error opening USB device: {0}")]

--- a/sw/host/opentitanlib/src/util/usb.rs
+++ b/sw/host/opentitanlib/src/util/usb.rs
@@ -125,12 +125,26 @@ impl UsbBackend {
 
     /// Create a new UsbBackend.
     pub fn new(usb_vid: u16, usb_pid: u16, usb_serial: Option<&str>) -> Result<Self> {
+        let serial_str = if let Some(s) = usb_serial {
+            format!(" (serial={})", s)
+        } else {
+            String::new()
+        };
         let mut devices = UsbBackend::scan(Some((usb_vid, usb_pid)), None, usb_serial)?;
-        ensure!(!devices.is_empty(), TransportError::NoDevice);
-        ensure!(
-            devices.len() == 1,
-            TransportError::MultipleDevices(format!("{:?}", devices))
-        );
+        if devices.is_empty() {
+            return Err(TransportError::NoDevice(format!(
+                "vid:pid=0x{:04x}:0x{:04x}{}",
+                usb_vid, usb_pid, serial_str
+            ))
+            .into());
+        }
+        if devices.len() > 1 {
+            return Err(TransportError::MultipleDevices(
+                format!("{:?}", devices),
+                format!("vid:pid=0x{:04x}:0x{:04x}{}", usb_vid, usb_pid, serial_str),
+            )
+            .into());
+        }
 
         let (device, serial_number) = devices.remove(0);
         Ok(UsbBackend {
@@ -158,6 +172,11 @@ impl UsbBackend {
         timeout: Duration,
     ) -> Result<Self> {
         let deadline = Instant::now() + timeout;
+        let serial_str = if let Some(s) = usb_serial {
+            format!(" (serial={})", s)
+        } else {
+            String::new()
+        };
         loop {
             let mut devices =
                 UsbBackend::scan(None, Some((class, subclass, protocol)), usb_serial)?;
@@ -166,13 +185,23 @@ impl UsbBackend {
                     std::thread::sleep(Duration::from_millis(100));
                     continue;
                 } else {
-                    return Err(TransportError::NoDevice.into());
+                    return Err(TransportError::NoDevice(format!(
+                        "class:subclass:protocol=0x{:02x}:0x{:02x}:0x{:02x}{}",
+                        class, subclass, protocol, serial_str
+                    ))
+                    .into());
                 }
             }
-            ensure!(
-                devices.len() == 1,
-                TransportError::MultipleDevices(format!("{:?}", devices))
-            );
+            if devices.len() > 1 {
+                return Err(TransportError::MultipleDevices(
+                    format!("{:?}", devices),
+                    format!(
+                        "class:subclass:protocol=0x{:02x}:0x{:02x}:0x{:02x}{}",
+                        class, subclass, protocol, serial_str
+                    ),
+                )
+                .into());
+            }
 
             let (device, serial_number) = devices.remove(0);
             return Ok(UsbBackend {


### PR DESCRIPTION
it was difficult to debug initial setup issues without this, since it wasn't clear all the time what device was being searched for.

The "NoMatch" error is never used. I guess this isn't an important part of any external API and it's save to remove it?