### PR TITLE
[crypto] Update `entropy` documentation

### DIFF
--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -61,7 +61,6 @@ enum {
  * https://opentitan.org/book/hw/ip/csrng/doc/theory_of_operation.html#command-header
  * for details.
  */
-// TODO(#14542): Harden csrng/edn command fields.
 typedef enum entropy_csrng_op {
   kEntropyDrbgOpInstantiate = 1,
   kEntropyDrbgOpReseed = 2,


### PR DESCRIPTION
Point to the correct documentation and remove a FI hardening TODO.

Removing the FI hardening TODO is ok as:
- The issue lowRISC/opentitan#14542 is already closed
- Hardening of some fields was applied in lowRISC/opentitan#15165
- Although `acmd` is still encoded without any protection, exploiting this seems quite hard.