### PR TITLE
[prim_xilinx] Use typeless parameter for MemInitFile

### DIFF
--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_rom.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_rom.sv
@@ -7,7 +7,7 @@
 module prim_rom import prim_rom_pkg::*; #(
   parameter  int Width       = 32,
   parameter  int Depth       = 2048, // 8kB default
-  parameter  string MemInitFile = "", // VMEM file to initialize the memory with
+  parameter      MemInitFile = "", // VMEM file to initialize the memory with
 
   localparam int Aw          = $clog2(Depth)
 ) (


### PR DESCRIPTION
Using the string type for MemInitFile in prim_xilinx_rom causes the error "[Synth 8-27] string type not supported" during Vivado synthesis.

This PR fixes this error and keeps this consistent with other RAM and ROM primitives.