### PR TITLE
[crypto/alert] Connect alert management to cryptolib

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -37,22 +37,29 @@ CRYPTO_EXEC_ENVS = dicts.add(
 
 autogen_cryptolib_build_info(name = "cryptolib_build_info")
 
-cc_library(
+dual_cc_library(
     name = "alert",
-    srcs = ["alert.c"],
+    srcs = dual_inputs(
+        device = ["alert.c"],
+        host = ["mock_alert.cc"],
+    ),
     hdrs = [
         "alert.h",
     ],
-    deps = [
-        "//hw/top_earlgrey:alert_handler_c_regs",
-        "//hw/top_earlgrey/ip/sensor_ctrl/data:sensor_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
-        "//sw/device/lib/base:abs_mmio",
-        "//sw/device/lib/base:bitfield",
-        "//sw/device/lib/base:hardened_memory",
-        "//sw/device/lib/base:macros",
-        "//sw/device/lib/crypto/impl:status",
-    ],
+    deps = dual_inputs(
+        device = [
+            "//hw/top_earlgrey:alert_handler_c_regs",
+            "//hw/top_earlgrey/ip/sensor_ctrl/data:sensor_ctrl_c_regs",
+            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//sw/device/lib/base:abs_mmio",
+            "//sw/device/lib/base:bitfield",
+            "//sw/device/lib/base:hardened_memory",
+            "//sw/device/lib/base:macros",
+        ],
+        shared = [
+            "//sw/device/lib/crypto/impl:status",
+        ],
+    ),
 )
 
 opentitan_test(

--- a/sw/device/lib/crypto/drivers/mock_alert.cc
+++ b/sw/device/lib/crypto/drivers/mock_alert.cc
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/drivers/alert.h"
+#include "sw/device/lib/crypto/impl/status.h"
+
+/**
+ * Basic mock of the alert driver.
+ *
+ * Enables on-host unit tests of code that interacts with the alert handler
+ * or sensor control registers.
+ */
+
+namespace test {
+extern "C" {
+
+/**
+ * Base mock implementation of read_alert_registers.
+ *
+ * @return 0, indicating no alerts.
+ */
+uint32_t read_alert_registers(void) { return 0; }
+
+/**
+ * Basic mock implementation of init_alert_registers.
+ *
+ * @return OK, a successful clearing of all alerts.
+ */
+status_t init_alert_registers(void) { return OTCRYPTO_OK; }
+
+}  // extern "C"
+}  // namespace test

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -268,6 +268,7 @@ cc_library(
         "//hw/top_earlgrey/ip_autogen/clkmgr:clkmgr_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:hardened_memory",
+        "//sw/device/lib/crypto/drivers:alert",
         "//sw/device/lib/crypto/drivers:rv_core_ibex",
     ],
 )

--- a/sw/device/lib/crypto/impl/config.c
+++ b/sw/device/lib/crypto/impl/config.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/crypto/include/config.h"
 
 #include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/crypto/drivers/alert.h"
 #include "sw/device/lib/crypto/drivers/rv_core_ibex.h"
 
 #include "clkmgr_regs.h"
@@ -40,9 +41,16 @@ otcrypto_status_t otcrypto_security_config_check(
 otcrypto_status_t otcrypto_init(otcrypto_key_security_level_t security_level) {
   (void)security_level;
 
+  HARDENED_TRY(init_alert_registers());
+
   return OTCRYPTO_OK;
 }
 
 otcrypto_status_t otcrypto_eval_exit(otcrypto_status_t status) {
+  if (read_alert_registers()) {
+    return OTCRYPTO_FATAL_ERR;
+  }
+  HARDENED_CHECK_EQ(launder32(read_alert_registers()), 0);
+
   return status;
 }


### PR DESCRIPTION
The cryptolib resets the alert manager's CSRs upon init and reads the registers upon execution of any API.
In case an alert was raised, the cryptolib now returns a fatal error.

Important is that init is only called at startup where the init function can be provided the priviledge of setting registers. The cryptolib requires read access to the alert manager range of addresses during function but no write access.

This protects the cryptolib to provide a bad status in case even a recoverable alert is raised.