### PR TITLE
Backport 28399 ([e2e,cov] Enable code coverage for rom_ext)

### DIFF
--- a/hw/top_earlgrey/defs.bzl
+++ b/hw/top_earlgrey/defs.bzl
@@ -25,10 +25,23 @@ EARLGREY = opentitan_top(
     silicon_creator_hooks = "//hw/top_earlgrey/sw/device/silicon_creator:hooks",
 )
 
-EARLGREY_SLOTS = {
+EARLGREY_SLOTS_NORMAL = {
     "rom_ext_slot_a": "0x0",
     "rom_ext_slot_b": "0x80000",
     "owner_slot_a": "0x10000",
     "owner_slot_b": "0x90000",
     "rom_ext_size": "0x10000",
 }
+
+EARLGREY_SLOTS_COVERAGE = {
+    "rom_ext_slot_a": "0x0",
+    "rom_ext_slot_b": "0x80000",
+    "owner_slot_a": "0x20000",
+    "owner_slot_b": "0xa0000",
+    "rom_ext_size": "0x20000",
+}
+
+EARLGREY_SLOTS = select({
+    "//rules/coverage:enabled": EARLGREY_SLOTS_COVERAGE,
+    "//conditions:default": EARLGREY_SLOTS_NORMAL,
+})

--- a/sw/device/lib/coverage/BUILD
+++ b/sw/device/lib/coverage/BUILD
@@ -71,6 +71,43 @@ alias(
     }),
 )
 
+cc_library(
+    name = "uart_runtime_real",
+    srcs = ["uart_runtime.c"],
+    features = ["-coverage"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        ":printer",
+        "//sw/device/lib/arch:device",
+        "//sw/device/silicon_creator/lib:dbg_print",
+        "//sw/device/silicon_creator/lib/drivers:pinmux",
+        "//sw/device/silicon_creator/lib/drivers:uart",
+    ],
+    alwayslink = True,  # replacing weak symbol
+)
+
+cc_library(
+    name = "uart_runtime_skip",
+    srcs = ["uart_runtime_skip.c"],
+    features = ["-coverage"],
+    deps = [
+        "//sw/device/lib/arch:device",
+        "//sw/device/silicon_creator/lib:dbg_print",
+        "//sw/device/silicon_creator/lib/drivers:pinmux",
+        "//sw/device/silicon_creator/lib/drivers:uart",
+    ],
+    alwayslink = True,  # replacing weak symbol
+)
+
+alias(
+    name = "uart_runtime",
+    actual = select({
+        "//rules/coverage:instrumented": ":uart_runtime_real",
+        "//rules/coverage:enabled": ":uart_runtime_skip",
+        "//conditions:default": "//sw/device:nothing",
+    }),
+)
+
 ld_library(
     name = "coverage_sections",
     includes = [

--- a/sw/device/lib/coverage/uart_runtime.c
+++ b/sw/device/lib/coverage/uart_runtime.c
@@ -1,0 +1,38 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/coverage/printer.h"
+#include "sw/device/silicon_creator/lib/dbg_print.h"
+#include "sw/device/silicon_creator/lib/drivers/pinmux.h"
+#include "sw/device/silicon_creator/lib/drivers/uart.h"
+
+void coverage_transport_init(void) {
+  pinmux_init_uart0_tx();
+  uart_init(kUartNCOValue);
+
+  dbg_puts("COVERAGE:UART\r\n");
+  while (!uart_tx_idle()) {
+  }
+}
+
+void coverage_report(void) {
+  if (coverage_is_valid()) {
+    dbg_puts("== COVERAGE PROFILE START ==\r\n");
+    coverage_printer_run();
+    dbg_puts("== COVERAGE PROFILE END ==\r\n");
+  } else {
+    dbg_puts("== COVERAGE PROFILE INVALID ==\r\n");
+  }
+
+  // Wait until the report is sent.
+  while (!uart_tx_idle()) {
+  }
+}
+
+void coverage_printer_sink(const void *data, size_t size) {
+  for (size_t i = 0; i < size; ++i) {
+    uart_write_hex(((uint8_t *)data)[i], 1, 0);
+  }
+}

--- a/sw/device/lib/coverage/uart_runtime_skip.c
+++ b/sw/device/lib/coverage/uart_runtime_skip.c
@@ -1,0 +1,29 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/silicon_creator/lib/dbg_print.h"
+#include "sw/device/silicon_creator/lib/drivers/pinmux.h"
+#include "sw/device/silicon_creator/lib/drivers/uart.h"
+
+void coverage_transport_init(void) {
+  pinmux_init_uart0_tx();
+  uart_init(kUartNCOValue);
+
+  dbg_puts("COV_SKIP:UART\r\n");
+  while (!uart_tx_idle()) {
+  }
+}
+
+void coverage_init(void) {}
+
+void coverage_report(void) {
+  dbg_puts("== COVERAGE PROFILE SKIP ==\r\n");
+
+  // Wait until the report is sent.
+  while (!uart_tx_idle()) {
+  }
+}
+
+void coverage_invalidate(void) {}

--- a/sw/device/silicon_creator/lib/base/chip.h
+++ b/sw/device/silicon_creator/lib/base/chip.h
@@ -55,7 +55,11 @@
  * Allowed bounds for the `length` field of a first owner boot stage manifest.
  */
 #define CHIP_BL0_SIZE_MIN CHIP_MANIFEST_SIZE
+#ifndef OT_COVERAGE_ENABLED
 #define CHIP_BL0_SIZE_MAX 0x70000
+#else  // OT_COVERAGE_ENABLED
+#define CHIP_BL0_SIZE_MAX 0x60000
+#endif  // OT_COVERAGE_ENABLED
 
 /**
  * ROM_EXT manifest identifier (ASCII "OTRE").
@@ -66,7 +70,11 @@
  * Allowed bounds for the `length` field of a ROM_EXT manifest.
  */
 #define CHIP_ROM_EXT_SIZE_MIN CHIP_MANIFEST_SIZE
+#ifndef OT_COVERAGE_ENABLED
 #define CHIP_ROM_EXT_SIZE_MAX 0x10000
+#else  // OT_COVERAGE_ENABLED
+#define CHIP_ROM_EXT_SIZE_MAX 0x20000
+#endif  // OT_COVERAGE_ENABLED
 #define CHIP_ROM_EXT_RESIZABLE_SIZE_MAX \
   (CHIP_ROM_EXT_SIZE_MAX + CHIP_BL0_SIZE_MAX)
 

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -202,6 +202,7 @@ ld_library(
     includes = ["rom_ext_common.ld"],
     deps = [
         "//sw/device:info_sections",
+        "//sw/device/lib/coverage:coverage_sections",
         "//sw/device/silicon_creator/lib/base:static_critical_sections",
         "//sw/device/silicon_creator/lib/base:static_dice_sections",
     ],

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -243,6 +243,7 @@ cc_library(
         "//hw/top:otp_ctrl_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:hardened",
+        "//sw/device/lib/coverage:api_asm",
     ],
 )
 
@@ -267,7 +268,8 @@ cc_library(
             "//sw/device/lib/base:macros",
             "//sw/device/lib/base:memory",
             "//sw/device/lib/base:stdasm",
-            "//sw/device/lib/coverage:api_asm",
+            "//sw/device/lib/coverage:api",
+            "//sw/device/lib/coverage:uart_runtime",
             "//sw/device/lib/runtime:hart",
             "//sw/device/silicon_creator/lib:boot_data",
             "//sw/device/silicon_creator/lib:boot_log",

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -331,7 +331,6 @@ ROM_EXT_FEATURES = [
     opentitan_binary(
         name = "rom_ext_{}_slot_{}".format(variation_name, slot),
         testonly = True,
-        collect_code_coverage = 0,
         # TODO(#22780): Integrate real keys for A1 flows.
         ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:ecdsa_keyset": "prod_key_0"},
         exec_env = [

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -267,6 +267,7 @@ cc_library(
             "//sw/device/lib/base:macros",
             "//sw/device/lib/base:memory",
             "//sw/device/lib/base:stdasm",
+            "//sw/device/lib/coverage:api_asm",
             "//sw/device/lib/runtime:hart",
             "//sw/device/silicon_creator/lib:boot_data",
             "//sw/device/silicon_creator/lib:boot_log",

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -10,6 +10,7 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/multibits.h"
 #include "sw/device/lib/base/stdasm.h"
+#include "sw/device/lib/coverage/api.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/silicon_creator/lib/base/boot_measurements.h"
 #include "sw/device/silicon_creator/lib/base/chip.h"
@@ -372,7 +373,10 @@ static rom_error_t rom_ext_boot(boot_data_t *boot_data, boot_log_t *boot_log,
 
   // Jump to OWNER entry point.
   dbg_printf("entry: 0x%x\r\n", (unsigned int)entry_point);
+  coverage_report();
+  coverage_invalidate();
   ((owner_stage_entry_point *)entry_point)();
+  coverage_init();  // re-init after invalidate.
 
   return kErrorRomExtBootFailed;
 }

--- a/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
@@ -56,6 +56,7 @@ _manifest_address_translation = (_text_start >= ORIGIN(eflash) &&
                                  _text_start < (ORIGIN(eflash)
                                               + LENGTH(eflash))) ? 0x1d4 : 0x739;
 
+REGION_ALIAS("coverage_flash", rom_ext_flash);
 
 /**
  * NOTE: We have to align each section to word boundaries as our current
@@ -151,6 +152,8 @@ SECTIONS {
     *(.rodata.*)
   } > rom_ext_flash
 
+  INCLUDE sw/device/lib/coverage/rodata.ld
+
   /**
    * Critical static data that is accessible by both the ROM and the ROM
    * extension.
@@ -224,6 +227,8 @@ SECTIONS {
     . = ALIGN(4);
     _bss_end = .;
   } > ram_main
+
+  INCLUDE sw/device/lib/coverage/bss.ld
 
   INCLUDE sw/device/info_sections.ld
 }

--- a/sw/device/silicon_creator/rom_ext/rom_ext_start.S
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_start.S
@@ -4,6 +4,7 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
 #include "sw/device/lib/base/hardened_asm.h"
+#include "sw/device/lib/coverage/api_asm.h"
 #include "hw/top/otp_ctrl_regs.h"
 
 /**
@@ -188,6 +189,9 @@ _rom_ext_start_boot:
    */
   la   t0, (_rom_ext_interrupt_vector + 1)
   csrw mtvec, t0
+
+  COVERAGE_ASM_INIT()
+  COVERAGE_ASM_TRANSPORT_INIT()
 
   /**
    * Jump to C Code

--- a/sw/device/silicon_creator/rom_ext/sival/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/BUILD
@@ -42,7 +42,6 @@ ROM_EXT_FEATURES = [
 [
     opentitan_binary(
         name = "rom_ext_{}_fake_slot_{}".format(variation, slot),
-        collect_code_coverage = 0,
         ecdsa_key = select({
             "//signing:test_keys": {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:ecdsa_keyset": "prod_key_0"},
             "//conditions:default": {"//hw/ip/otp_ctrl/data/earlgrey_skus/sival/keys:keyset": "sv00-earlgrey-a1-root-ecdsa-test-0"},
@@ -81,7 +80,6 @@ ROM_EXT_FEATURES = [
 [
     opentitan_binary(
         name = "rom_ext_{}_prod_slot_{}".format(variation, slot),
-        collect_code_coverage = 0,
         exec_env = [
             "//hw/top_earlgrey:silicon_creator",
             "//hw/top_earlgrey:fpga_cw310",


### PR DESCRIPTION
Backport #28399

While backporting this, I ran into obscure issues due to the host clang being too old. The error message materialized as a segfault in the sandbox (?!):

> ERROR: /home/pamaury/opentitan/hw/top_earlgrey/data/otp/BUILD:433:17: Action hw/top_earlgrey/data/otp/otp_json_alert_digest_cfg.json failed: (Segmentation fault): opentitantool failed: error executing Action command (from target //hw/top_earlgrey/data/otp:otp_json_alert_digest_cfg) bazel-out/k8-fastbuild-ST-13d3ddad9198/bin/sw/host/opentitantool/opentitantool '--rcfile=' otp alert-digest ... (remaining 3 arguments skipped)

but when digging, it turns out that deep somewhere in the stack, some LLVM coverage merging was failing and bazel would not print an error message unless I specified used `--verbose_failures` and `--sandbox_debug` AND manually rerun the sandboxed step myself:

> LLVM Profile Warning: Unable to merge profile data: source profile file is not compatible.
> LLVM Profile Error: Profile Merging of file default_17642438069150949480_0_2.profraw failed: Success
> LLVM Profile Error: Failed to write file "default_17642438069150949480_0_2.profraw": Success

I can confirm that it works with LLVM 21 (on the host). For future reference, if one has the system clang which is not version 21 and another clang-21 installed, this is how the `.bazelrc` must be tweaked:
```
coverage:ot_coverage --repo_env='BAZEL_LLVM_COV=llvm-cov-21'
coverage:ot_coverage --repo_env='BAZEL_LLVM_PROFDATA=llvm-profdata-21'
coverage:ot_coverage --repo_env='CC=clang-21'
coverage:ot_coverage --repo_env='GCOV=llvm-profdata-21'
```
This highlights the fact that we should probably use a bazel toolchain for the host tooling as well, instead of relying on the dev environment.