### PR TITLE
[alert,dv] Simplify how we constrain ping_delay

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
@@ -53,9 +53,12 @@ class alert_esc_agent_cfg extends dv_base_agent_cfg;
   int unsigned ack_stable_min = 0;
   int unsigned ack_stable_max = 10;
 
-  bit use_seq_item_ping_delay = 1'b1;
-  int unsigned ping_delay_min = 0;
-  int unsigned ping_delay_max = 10;
+  // The minimum and maximum value that alert_receiver_ping_seq will use for ping_delay
+  //
+  // To enable a "stress test", which sends lots of back-to-back ping items, these can be made
+  // small.
+  int unsigned ping_delay_min = 10000;
+  int unsigned ping_delay_max = 20000;
 
   // When this bit is set, alert agent responds to alert without delay
   // This is set by plusarg "+fast_rcvr_{alert_name}"
@@ -80,7 +83,6 @@ class alert_esc_agent_cfg extends dv_base_agent_cfg;
     `uvm_field_int(ack_delay_max,   UVM_DEFAULT)
     `uvm_field_int(ack_stable_min,  UVM_DEFAULT)
     `uvm_field_int(ack_stable_max,  UVM_DEFAULT)
-    `uvm_field_int(ping_delay_min,  UVM_DEFAULT)
     `uvm_field_int(ping_delay_max,  UVM_DEFAULT)
   `uvm_object_utils_end
 

--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
@@ -53,9 +53,12 @@ class alert_esc_agent_cfg extends dv_base_agent_cfg;
   int unsigned ack_stable_min = 0;
   int unsigned ack_stable_max = 10;
 
-  bit use_seq_item_ping_delay = 1'b1;
-  int unsigned ping_delay_min = 0;
-  int unsigned ping_delay_max = 10;
+  // The minimum and maximum value that alert_receiver_ping_seq will use for ping_delay
+  //
+  // To enable a "stress test", which sends lots of back-to-back ping items, these can be made
+  // small.
+  int unsigned ping_delay_min = 10000;
+  int unsigned ping_delay_max = 20000;
 
   // When this bit is set, alert agent responds to alert without delay
   // This is set by plusarg "+fast_rcvr_{alert_name}"
@@ -78,7 +81,6 @@ class alert_esc_agent_cfg extends dv_base_agent_cfg;
     `uvm_field_int(ack_delay_max,   UVM_DEFAULT)
     `uvm_field_int(ack_stable_min,  UVM_DEFAULT)
     `uvm_field_int(ack_stable_max,  UVM_DEFAULT)
-    `uvm_field_int(ping_delay_min,  UVM_DEFAULT)
     `uvm_field_int(ping_delay_max,  UVM_DEFAULT)
   `uvm_object_utils_end
 

--- a/hw/dv/sv/alert_esc_agent/alert_esc_seq_item.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_seq_item.sv
@@ -25,14 +25,25 @@ class alert_esc_seq_item extends uvm_sequence_item;
   rand esc_handshake_e        esc_handshake_sta;
   rand int                    sig_cycle_cnt;
 
-  // delays
+  // A delay injected by alert_receiver_driver before it actually sends a ping request. This allows
+  // the driver to be sent a stream of back-to-back items without locking up the interface.
   rand int unsigned ping_delay;
+
+  // other delays
   rand int unsigned ack_delay;
   rand int unsigned ack_stable;
   rand int unsigned alert_delay;
   rand int unsigned int_err_cyc;
 
   extern constraint delay_c;
+
+  // An upper bound on ping_delay. This isn't really for a design reason but, instead, is to make
+  // sure that we do occasionally send pings.
+  //
+  // This is a soft constraint, so a sequence that uses these items can safely request an enormous
+  // delay.
+  extern constraint ping_delay_max_c;
+
   // if agent is alert mode, cannot send any esc_rsp signal
   // if agent is esc mode, cannot send any alert related signals
   extern constraint alert_esc_mode_c;
@@ -65,11 +76,14 @@ class alert_esc_seq_item extends uvm_sequence_item;
 endclass : alert_esc_seq_item
 
 constraint alert_esc_seq_item::delay_c {
-  soft ping_delay  dist {0 :/ 5, [1:10] :/ 5};
   soft ack_delay   dist {0 :/ 5, [1:10] :/ 5};
   soft alert_delay dist {0 :/ 5, [1:10] :/ 5};
   soft ack_stable  dist {1 :/ 5, [2:10] :/ 5};
   soft int_err_cyc dist {1 :/ 5, [2:10] :/ 5};
+}
+
+constraint alert_esc_seq_item::ping_delay_max_c {
+  soft ping_delay <= 50000;
 }
 
 constraint alert_esc_seq_item::alert_esc_mode_c {

--- a/hw/dv/sv/alert_esc_agent/alert_esc_seq_item.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_seq_item.sv
@@ -25,14 +25,25 @@ class alert_esc_seq_item extends uvm_sequence_item;
   rand esc_handshake_e        esc_handshake_sta;
   rand int                    sig_cycle_cnt;
 
-  // delays
+  // A delay injected by alert_receiver_driver before it actually sends a ping request. This allows
+  // the driver to be sent a stream of back-to-back items without locking up the interface.
   rand int unsigned ping_delay;
+
+  // Other delays
   rand int unsigned ack_delay;
   rand int unsigned ack_stable;
   rand int unsigned alert_delay;
   rand int unsigned int_err_cyc;
 
   extern constraint delay_c;
+
+  // An upper bound on ping_delay. This isn't really for a design reason but, instead, is to make
+  // sure that we do occasionally send pings.
+  //
+  // This is a soft constraint, so a sequence that uses these items can safely request an enormous
+  // delay.
+  extern constraint ping_delay_max_c;
+
   // if agent is alert mode, cannot send any esc_rsp signal
   // if agent is esc mode, cannot send any alert related signals
   extern constraint alert_esc_mode_c;
@@ -65,11 +76,14 @@ class alert_esc_seq_item extends uvm_sequence_item;
 endclass : alert_esc_seq_item
 
 constraint alert_esc_seq_item::delay_c {
-  soft ping_delay  dist {0 :/ 5, [1:10] :/ 5};
   soft ack_delay   dist {0 :/ 5, [1:10] :/ 5};
   soft alert_delay dist {0 :/ 5, [1:10] :/ 5};
   soft ack_stable  dist {1 :/ 5, [2:10] :/ 5};
   soft int_err_cyc dist {1 :/ 5, [2:10] :/ 5};
+}
+
+constraint alert_esc_seq_item::ping_delay_max_c {
+  soft ping_delay <= 50000;
 }
 
 constraint alert_esc_seq_item::alert_esc_mode_c {

--- a/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
@@ -24,12 +24,9 @@ class alert_receiver_driver extends alert_base_driver;
 
   // Drive an alert ping
   //
-  // This will start by waiting between cfg.ping_delay_min and cfg.ping_delay_max cycles before
-  // sending the ping request. If cfg.use_seq_item_ping_delay is true then the delay is from the
-  // ping_delay argument.
-  //
-  // Once the ping has gone out, we wait for an alert to arrive and then acknowledge it using
-  // set_ack_pins (and passing ack_delay and ack_stable).
+  // This will start by waiting ping_delay cycles before sending the ping request. Once the ping has
+  // gone out, we wait for an alert to arrive and then acknowledge it using set_ack_pins (and
+  // passing ack_delay and ack_stable).
   //
   // The task allows to retract driving the ping. If there's an alert (r_alert_rsp_q.size > 0)
   // before the 'ping_delay' the ping is aborted and the driver moves to tackle the alert in
@@ -270,9 +267,6 @@ task alert_receiver_driver::drive_alert_ping(int unsigned ping_delay,
                                              output bit item_not_driven
                                              );
   item_not_driven = 0;
-  if (!cfg.use_seq_item_ping_delay) begin
-    ping_delay = $urandom_range(cfg.ping_delay_max, cfg.ping_delay_min);
-  end
   @(cfg.vif.receiver_cb);
   // Ping fail and differential signal fail scenarios are not implemented now.
   // This driver is used for IP (instantiate prim_alert_sender) to finish alert handshake.

--- a/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
@@ -103,12 +103,9 @@ class alert_receiver_driver extends alert_base_driver;
 
   // Drive an alert ping
   //
-  // This will start by waiting between cfg.ping_delay_min and cfg.ping_delay_max cycles before
-  // sending the ping request. If cfg.use_seq_item_ping_delay is true then the delay is from the
-  // ping_delay argument.
-  //
-  // Once the ping has gone out, we wait for an alert to arrive and then acknowledge it using
-  // ack_alert (and passing ack_delay and ack_stable).
+  // This will start by waiting ping_delay cycles before sending the ping request. Once the ping has
+  // gone out, we wait for an alert to arrive and then acknowledge it using ack_alert (and
+  // passing ack_delay and ack_stable).
   //
   // The task allows to retract driving the ping. If there's an alert (r_alert_rsp_q.size > 0)
   // before the 'ping_delay' the ping is aborted and the driver moves to tackle the alert in

--- a/hw/dv/sv/alert_esc_agent/seq_lib/alert_receiver_ping_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/alert_receiver_ping_seq.sv
@@ -22,12 +22,14 @@ task alert_receiver_ping_seq::body();
   forever begin
     req = alert_esc_seq_item::type_id::create("req");
     start_item(req);
-    // Randomise the item to be a ping request, but with a large ping delay. This means that even
-    // enqueuing these back to back will leave in big gaps between the ping requests.
+    // Randomise the item to be a ping request. When driven, the item will "wait around" for
+    // ping_delay cycles before it actually sends the ping. Bound this to be in the interval
+    // cfg.ping_delay_min .. cfg.ping_delay_max.
     `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
                                    r_alert_ping_send == 1'b1;
                                    r_alert_rsp == 1'b0;
-                                   ping_delay dist {[10000:20000] :/ 1};)
+                                   cfg.ping_delay_min <= ping_delay;
+                                   ping_delay <= cfg.ping_delay_max;)
     finish_item(req);
     get_response(req);
   end

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
@@ -262,7 +262,6 @@ class entropy_src_base_vseq extends cip_base_vseq #(
     // Otherwise, we may lock invalid configurations which would require resetting the DUT.
     wait_no_outstanding_access();
     cfg.clk_rst_vif.wait_clks(
-        cfg.m_alert_agent_cfgs["recov_alert"].ping_delay_max +
         cfg.m_alert_agent_cfgs["recov_alert"].ack_delay_max +
         cfg.m_alert_agent_cfgs["recov_alert"].ack_stable_max +
         2); // Pause between back-to-back handshakes at sender end.

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_entropy_stress_vseq.sv.tpl
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_entropy_stress_vseq.sv.tpl
@@ -34,6 +34,7 @@ class ${module_instance_name}_entropy_stress_vseq extends ${module_instance_name
 
     foreach (cfg.alert_host_cfg[i]) begin
       cfg.alert_host_cfg[i].alert_delay_max = 0;
+      cfg.alert_host_cfg[i].ping_delay_min = 0;
       cfg.alert_host_cfg[i].ping_delay_max = 0;
     end
     super.pre_start();

--- a/hw/top_darjeeling/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_entropy_stress_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_entropy_stress_vseq.sv
@@ -34,6 +34,7 @@ class alert_handler_entropy_stress_vseq extends alert_handler_smoke_vseq;
 
     foreach (cfg.alert_host_cfg[i]) begin
       cfg.alert_host_cfg[i].alert_delay_max = 0;
+      cfg.alert_host_cfg[i].ping_delay_min = 0;
       cfg.alert_host_cfg[i].ping_delay_max = 0;
     end
     super.pre_start();

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_entropy_stress_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_entropy_stress_vseq.sv
@@ -34,6 +34,7 @@ class alert_handler_entropy_stress_vseq extends alert_handler_smoke_vseq;
 
     foreach (cfg.alert_host_cfg[i]) begin
       cfg.alert_host_cfg[i].alert_delay_max = 0;
+      cfg.alert_host_cfg[i].ping_delay_min = 0;
       cfg.alert_host_cfg[i].ping_delay_max = 0;
     end
     super.pre_start();


### PR DESCRIPTION
This number has been very confusing! At the start of 2024, functional
simulations weren't sending pings at all. When I made change
a771270fab3 that year, I interpreted ping_delay as "the number of
cycles to wait before sending a ping". So that we could send
back-to-back ping items but have reasonable gaps between pings, I was
configuring this to be large (> 10,000).

What I didn't notice is that some sequences constrained it to be more
like 10! I think the original idea was that a virtual sequence would
decide to send a ping (for some reason), which would then take a
handful of extra cycles before it was sent.

Unfortunately, this was meaning that some virtual sequences were
sending *lots* of ping transactions, with gaps of just 10 cycles. The
change in this commit switches everything across to the new meaning.
We now send back-to-back items, which translate into periodic ping
requests.

There are a couple of extra tidy-ups in the commit

 - Get rid of use_seq_item_ping_delay. I accidentally removed the code
   that was reading this in commit 1eb96b30. The new behaviour is
   probably better, so let's just use it.

 - Tweak a wait in entropy_src_base_vseq. This was added in commit
   a3f91eec28e, which wanted to make sure the sequence waited long
   enough to see alerts that would be triggered by the previous
   register write. With the new meaning of ping_delay, we definitely
   don't need to wait for it.
