### PR TITLE
[alert_handler,dv] Improve error messages on crashdump mismatch

### DIFF
--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_scoreboard.sv.tpl
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_scoreboard.sv.tpl
@@ -591,11 +591,27 @@ class ${module_instance_name}_scoreboard extends cip_base_scoreboard #(
              end
           end
 
+          // Check that the value that came from the crashdump reflects the alert_cause and
+          // loc_alert_cause registers that we have predicted in the register model.
           for (int i = 0; i < NUM_ALERTS; i++) begin
-            `DV_CHECK_EQ(crashdump_val.alert_cause[i], `gmv(ral.alert_cause[i]))
+            if (crashdump_val.alert_cause[i] != `gmv(ral.alert_cause[i])) begin
+              `uvm_error(get_full_name(),
+                         $sformatf({"Register/crashdump mismatch. alert_cause[%0d] is ",
+                                    "0x%0h in the crashdump and 0x%0h in the register model."},
+                                   i,
+                                   crashdump_val.alert_cause[i],
+                                   `gmv(ral.alert_cause[i])))
+            end
           end
           for (int i = 0; i < NUM_LOCAL_ALERTS; i++) begin
-            `DV_CHECK_EQ(crashdump_val.loc_alert_cause[i], `gmv(ral.loc_alert_cause[i]))
+            if (crashdump_val.loc_alert_cause[i] != `gmv(ral.loc_alert_cause[i])) begin
+              `uvm_error(get_full_name(),
+                         $sformatf({"Register/crashdump mismatch. loc_alert_cause[%0d] is ",
+                                    "0x%0h in the crashdump and 0x%0h in the register model."},
+                                   i,
+                                   crashdump_val.loc_alert_cause[i],
+                                   `gmv(ral.loc_alert_cause[i])))
+            end
           end
         end
       end

--- a/hw/top_darjeeling/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -591,11 +591,27 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
              end
           end
 
+          // Check that the value that came from the crashdump reflects the alert_cause and
+          // loc_alert_cause registers that we have predicted in the register model.
           for (int i = 0; i < NUM_ALERTS; i++) begin
-            `DV_CHECK_EQ(crashdump_val.alert_cause[i], `gmv(ral.alert_cause[i]))
+            if (crashdump_val.alert_cause[i] != `gmv(ral.alert_cause[i])) begin
+              `uvm_error(get_full_name(),
+                         $sformatf({"Register/crashdump mismatch. alert_cause[%0d] is ",
+                                    "0x%0h in the crashdump and 0x%0h in the register model."},
+                                   i,
+                                   crashdump_val.alert_cause[i],
+                                   `gmv(ral.alert_cause[i])))
+            end
           end
           for (int i = 0; i < NUM_LOCAL_ALERTS; i++) begin
-            `DV_CHECK_EQ(crashdump_val.loc_alert_cause[i], `gmv(ral.loc_alert_cause[i]))
+            if (crashdump_val.loc_alert_cause[i] != `gmv(ral.loc_alert_cause[i])) begin
+              `uvm_error(get_full_name(),
+                         $sformatf({"Register/crashdump mismatch. loc_alert_cause[%0d] is ",
+                                    "0x%0h in the crashdump and 0x%0h in the register model."},
+                                   i,
+                                   crashdump_val.loc_alert_cause[i],
+                                   `gmv(ral.loc_alert_cause[i])))
+            end
           end
         end
       end

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -591,11 +591,27 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
              end
           end
 
+          // Check that the value that came from the crashdump reflects the alert_cause and
+          // loc_alert_cause registers that we have predicted in the register model.
           for (int i = 0; i < NUM_ALERTS; i++) begin
-            `DV_CHECK_EQ(crashdump_val.alert_cause[i], `gmv(ral.alert_cause[i]))
+            if (crashdump_val.alert_cause[i] != `gmv(ral.alert_cause[i])) begin
+              `uvm_error(get_full_name(),
+                         $sformatf({"Register/crashdump mismatch. alert_cause[%0d] is ",
+                                    "0x%0h in the crashdump and 0x%0h in the register model."},
+                                   i,
+                                   crashdump_val.alert_cause[i],
+                                   `gmv(ral.alert_cause[i])))
+            end
           end
           for (int i = 0; i < NUM_LOCAL_ALERTS; i++) begin
-            `DV_CHECK_EQ(crashdump_val.loc_alert_cause[i], `gmv(ral.loc_alert_cause[i]))
+            if (crashdump_val.loc_alert_cause[i] != `gmv(ral.loc_alert_cause[i])) begin
+              `uvm_error(get_full_name(),
+                         $sformatf({"Register/crashdump mismatch. loc_alert_cause[%0d] is ",
+                                    "0x%0h in the crashdump and 0x%0h in the register model."},
+                                   i,
+                                   crashdump_val.loc_alert_cause[i],
+                                   `gmv(ral.loc_alert_cause[i])))
+            end
           end
         end
       end


### PR DESCRIPTION
No real change, except for the fact that the message now shows which index had the mismatch (the old version just talked about "[i]").