### PR TITLE
[chip,dv] Move select_jtag out of chip_env_cfg

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -24,9 +24,6 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // Indicates which clock source to use for chip simulations.
   chip_clock_source_e   chip_clock_source;
 
-  // Indicates which JTAG to mux on the pads, if any
-  chip_jtag_tap_e       select_jtag = JtagTapNone;
-
   // Memory backdoor util instances for all memory instances in the chip.
   mem_bkdr_util mem_bkdr_util_h[chip_mem_e];
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_csr_rw_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_csr_rw_vseq.sv
@@ -9,7 +9,7 @@ class chip_jtag_csr_rw_vseq extends chip_common_vseq;
   `uvm_object_new
 
   virtual task pre_start();
-    cfg.select_jtag = JtagTapRvDm;
+    select_jtag = JtagTapRvDm;
     cfg.m_jtag_riscv_agent_cfg.is_rv_dm = 1;
     super.pre_start();
   endtask

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_mem_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_mem_vseq.sv
@@ -13,7 +13,7 @@ class chip_jtag_mem_vseq extends chip_common_vseq;
   `uvm_object_new
 
   virtual task pre_start();
-    cfg.select_jtag = JtagTapRvDm;
+    select_jtag = JtagTapRvDm;
     cfg.m_jtag_riscv_agent_cfg.is_rv_dm = 1;
     void'($value$plusargs("skip_por_n_during_first_pwrup=%0b", skip_por_n_during_first_pwrup));
     // If we want to skip POR_N,

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_rv_dm_lc_disabled_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_rv_dm_lc_disabled_vseq.sv
@@ -41,7 +41,7 @@ class chip_rv_dm_lc_disabled_vseq extends chip_stub_cpu_base_vseq;
 
   virtual task pre_start();
     // Select RV_DM TAP via the TAP straps.
-    cfg.select_jtag = JtagTapRvDm;
+    select_jtag = JtagTapRvDm;
     super.pre_start();
     max_outstanding_accesses = 1;
   endtask

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
@@ -8,6 +8,9 @@
 class chip_stub_cpu_base_vseq extends chip_base_vseq;
   `uvm_object_utils(chip_stub_cpu_base_vseq)
 
+  // Control which JTAG to mux on the pads, if any. Subclasses may wish to override this choice.
+  protected chip_jtag_tap_e select_jtag = JtagTapNone;
+
   `uvm_object_new
 
   virtual task pre_start();
@@ -19,10 +22,35 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
     // monitor in block-level
     foreach (cfg.m_uart_agent_cfgs[i]) cfg.m_uart_agent_cfgs[i].en_tx_monitor = 0;
 
-    // Select/Deselect JTAG interface.
+    // The environment config might have an extra uvm_reg_map that represents registers accessible
+    // over JTAG. If so, and the JTAG riscv_agent is enabled, then drive TAP straps to configure
+    // which JTAG interface will be muxed onto the pads.
+    //
+    // Subclasses might pick that interface before calling super.pre_start. If not, allow the
+    // decision to be configured by passing a plusarg.
     if (cfg.jtag_riscv_map != null || cfg.m_jtag_riscv_agent_cfg.use_jtag_dmi == 1) begin
-      `DV_GET_ENUM_PLUSARG(chip_common_pkg::chip_jtag_tap_e, cfg.select_jtag, select_jtag)
-      cfg.chip_vif.tap_straps_if.drive(cfg.select_jtag);
+      // Set from_plusarg to equal select_jtag (which might have been set by a subclass). This gets
+      // overridden by the DV_GET_ENUM_PLUSARG macro below if the +select_jtag plusarg was provided.
+      chip_jtag_tap_e from_plusarg = select_jtag;
+
+      `DV_GET_ENUM_PLUSARG(chip_common_pkg::chip_jtag_tap_e, from_plusarg, select_jtag)
+
+      if (select_jtag != JtagTapNone) begin
+        // The select_jtag variable must have been set by the subclass. Check that there hasn't been
+        // a +select_jtag plusarg with a different value (we don't support that sort of override).
+        if (select_jtag != from_plusarg) begin
+          `uvm_error(get_name(),
+                     $sformatf({"Cannot use +select_jtag with this sequence: the JTAG interface ",
+                                "was already configured as %p."},
+                               select_jtag))
+        end
+      end else begin
+        // The select_jtag variable has not been overridden by the subclass. If there has been a
+        // +select_jtag plusarg, use the provided value.
+        select_jtag = from_plusarg;
+      end
+
+      cfg.chip_vif.tap_straps_if.drive(select_jtag);
     end
     enable_asserts_in_hw_reset_rand_wr = 0;
     super.pre_start();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_tap_straps_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_tap_straps_vseq.sv
@@ -23,8 +23,8 @@ class chip_tap_straps_vseq extends chip_sw_base_vseq;
 
   lc_ctrl_state_pkg::lc_state_e cur_lc_state;
 
-  local uvm_reg lc_csrs[$];
-  chip_jtag_tap_e select_jtag;
+  local uvm_reg         lc_csrs[$];
+  local chip_jtag_tap_e select_jtag;
 
   `uvm_object_utils(chip_tap_straps_vseq)
 


### PR DESCRIPTION
This variable was only used to configure chip_stub_cpu_base_vseq and its subclasses (and was actually duplicated in chip_tap_straps_vseq). Move it to the sequence, which probably makes a bit more sense.

Also, add a check to make sure we aren't overriding it with a plusarg for one of the subclasses. The plusarg doesn't appear in the open source project at all and was added by b8af7c71b3e in 2023, presumably to enable some downstream testing. Catch an obvious mistake before it happens.