### PR TITLE
[dv] Make subclasses' versions of predict_tl_err protected

### DIFF
--- a/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
@@ -434,7 +434,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
   // enabled, any TL request will respond with an error. This is what we expect, but the code in
   // cip_base_scoreboard fails because we're responding with an error to an access that would
   // otherwise be perfectly reasonable.
-  function bit predict_tl_err(tl_seq_item item, tl_channels_e channel, string ral_name);
+  protected function bit predict_tl_err(tl_seq_item item, tl_channels_e channel, string ral_name);
     if (!cfg.tl_err_prediction) begin
       return item.d_error;
     end

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -165,7 +165,7 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
     return is_tl_err;
   endfunction
 
-  virtual function bit predict_tl_err(tl_seq_item item, tl_channels_e channel, string ral_name);
+  protected function bit predict_tl_err(tl_seq_item item, tl_channels_e channel, string ral_name);
     if (ral_name == cfg.sram_ral_name && get_sram_predict_tl_err(item, channel)) begin
       return 1;
     end

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -821,7 +821,7 @@ class flash_ctrl_scoreboard #(
 
   // Overridden function from cip_base_scoreboard, to handle TL/UL Error seen on Hardware Interface
   // when using Code Access Restrictions (EXEC)
-  virtual function bit predict_tl_err(tl_seq_item item, tl_channels_e channel, string ral_name);
+  protected function bit predict_tl_err(tl_seq_item item, tl_channels_e channel, string ral_name);
     bit   ecc_err, in_err;
 
     // Skip this routine when fatal error event is asserted

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -821,7 +821,7 @@ class flash_ctrl_scoreboard #(
 
   // Overridden function from cip_base_scoreboard, to handle TL/UL Error seen on Hardware Interface
   // when using Code Access Restrictions (EXEC)
-  virtual function bit predict_tl_err(tl_seq_item item, tl_channels_e channel, string ral_name);
+  protected function bit predict_tl_err(tl_seq_item item, tl_channels_e channel, string ral_name);
     bit   ecc_err, in_err;
 
     // Skip this routine when fatal error event is asserted

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -821,7 +821,7 @@ class flash_ctrl_scoreboard #(
 
   // Overridden function from cip_base_scoreboard, to handle TL/UL Error seen on Hardware Interface
   // when using Code Access Restrictions (EXEC)
-  virtual function bit predict_tl_err(tl_seq_item item, tl_channels_e channel, string ral_name);
+  protected function bit predict_tl_err(tl_seq_item item, tl_channels_e channel, string ral_name);
     bit   ecc_err, in_err;
 
     // Skip this routine when fatal error event is asserted


### PR DESCRIPTION
It turns out that Xcelium spits out a warning message if you don't: apparently I should have been a little more careful when I made the function protected in ff023656fdf.