### PR TITLE
[dv] Add "Monitor" to if_mode_e

### DIFF
--- a/hw/dv/sv/dv_utils/dv_utils_pkg.sv
+++ b/hw/dv/sv/dv_utils/dv_utils_pkg.sv
@@ -37,10 +37,11 @@ package dv_utils_pkg;
   // typedef parameterized pins_if for ease of implementation for interrupts and alerts
   typedef virtual pins_if #(NUM_MAX_INTERRUPTS) intr_vif;
 
-  // interface direction / mode - Host or Device
-  typedef enum bit {
-    Host,
-    Device
+  // Interface direction / mode
+  typedef enum bit [1:0] {
+    Host,   // The interface is active and is driving signals as a host
+    Device, // The interface is active and is driving signals as a device
+    Monitor // The interface is passive and drives no signals
   } if_mode_e;
 
   // compare operator types


### PR DESCRIPTION
This is needed if you want to allow an interface to be passive (neither driving the host nor the device side of the communication).

(The motivation for this change is that I want to allow vertical re-use, where a block-level environment gets bound into a chip-level testbench in passive mode. This needs various agents and interfaces to be more passive)