### PR TITLE
[dv] Add a "chip_level" fusesoc flag

### DIFF
--- a/hw/dv/tools/ralgen/README.md
+++ b/hw/dv/tools/ralgen/README.md
@@ -54,7 +54,7 @@ targets:
   default:
     ...
     generate:
-      - ral
+      - "!chip_level ? (ral)"
 ```
 
 Note that the path to `hjson` specification in the snippet above is relative

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env.core
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env.core
@@ -48,4 +48,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env.core
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env.core
@@ -47,4 +47,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/aes/dv/env/aes_env.core
+++ b/hw/ip/aes/dv/env/aes_env.core
@@ -63,4 +63,4 @@ targets:
       - files_rtl
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/aes/dv/env/aes_env.core
+++ b/hw/ip/aes/dv/env/aes_env.core
@@ -64,4 +64,4 @@ targets:
       - files_rtl
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/aon_timer/dv/env/aon_timer_env.core
+++ b/hw/ip/aon_timer/dv/env/aon_timer_env.core
@@ -45,4 +45,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/csrng/dv/env/csrng_env.core
+++ b/hw/ip/csrng/dv/env/csrng_env.core
@@ -50,4 +50,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/dma/dv/env/dma_env.core
+++ b/hw/ip/dma/dv/env/dma_env.core
@@ -56,4 +56,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/edn/dv/env/edn_env.core
+++ b/hw/ip/edn/dv/env/edn_env.core
@@ -45,4 +45,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/entropy_src/dv/env/entropy_src_env.core
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env.core
@@ -53,4 +53,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/hmac/dv/env/hmac_env.core
+++ b/hw/ip/hmac/dv/env/hmac_env.core
@@ -51,4 +51,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -77,4 +77,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -76,4 +76,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/keymgr/dv/env/keymgr_env.core
+++ b/hw/ip/keymgr/dv/env/keymgr_env.core
@@ -52,4 +52,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env.core
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env.core
@@ -39,4 +39,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/kmac/dv/env/kmac_env.core
+++ b/hw/ip/kmac/dv/env/kmac_env.core
@@ -63,4 +63,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
@@ -55,4 +55,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/mbx/dv/env/mbx_env.core
+++ b/hw/ip/mbx/dv/env/mbx_env.core
@@ -41,4 +41,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -81,4 +81,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/otp_macro/dv/env/otp_macro_env.core
+++ b/hw/ip/otp_macro/dv/env/otp_macro_env.core
@@ -24,4 +24,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/pattgen/dv/env/pattgen_env.core
+++ b/hw/ip/pattgen/dv/env/pattgen_env.core
@@ -44,4 +44,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/racl_ctrl/dv/env/racl_ctrl_base_env.core
+++ b/hw/ip/racl_ctrl/dv/env/racl_ctrl_base_env.core
@@ -8,7 +8,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:dv:cip_lib
-      - lowrisc:dv:racl_ctrl_ral
+      - "!chip_level ? (lowrisc:dv:racl_ctrl_ral)"
       - lowrisc:dv:racl_error_log_agent
     files:
       - racl_ctrl_policies_if.sv

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env.core
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env.core
@@ -46,4 +46,4 @@ targets:
       - files_rtl
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/rv_dm/dv/env/rv_dm_env.core
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.core
@@ -70,4 +70,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/rv_timer/dv/env/rv_timer_env.core
+++ b/hw/ip/rv_timer/dv/env/rv_timer_env.core
@@ -41,4 +41,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_env.core
+++ b/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_env.core
@@ -37,4 +37,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/spi_device/dv/env/spi_device_env.core
+++ b/hw/ip/spi_device/dv/env/spi_device_env.core
@@ -58,4 +58,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/spi_host/dv/env/spi_host_env.core
+++ b/hw/ip/spi_host/dv/env/spi_host_env.core
@@ -54,4 +54,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.core
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.core
@@ -54,4 +54,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.core
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.core
@@ -53,4 +53,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_env.core
+++ b/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_env.core
@@ -50,4 +50,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/uart/dv/env/uart_env.core
+++ b/hw/ip/uart/dv/env/uart_env.core
@@ -52,4 +52,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -110,4 +110,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env.core.tpl
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env.core.tpl
@@ -46,4 +46,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_env.core.tpl
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_env.core.tpl
@@ -51,4 +51,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip_templates/clkmgr/dv/env/clkmgr_env.core.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/clkmgr_env.core.tpl
@@ -50,4 +50,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env.core.tpl
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env.core.tpl
@@ -113,4 +113,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip_templates/gpio/dv/env/gpio_env.core.tpl
+++ b/hw/ip_templates/gpio/dv/env/gpio_env.core.tpl
@@ -48,4 +48,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip_templates/gpio/dv/env/gpio_env.core.tpl
+++ b/hw/ip_templates/gpio/dv/env/gpio_env.core.tpl
@@ -47,4 +47,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env.core.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env.core.tpl
@@ -62,4 +62,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip_templates/pwm/dv/env/pwm_env.core.tpl
+++ b/hw/ip_templates/pwm/dv/env/pwm_env.core.tpl
@@ -43,4 +43,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip_templates/pwrmgr/dv/env/pwrmgr_env.core.tpl
+++ b/hw/ip_templates/pwrmgr/dv/env/pwrmgr_env.core.tpl
@@ -55,4 +55,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/ip_templates/rstmgr/dv/env/rstmgr_env.core.tpl
+++ b/hw/ip_templates/rstmgr/dv/env/rstmgr_env.core.tpl
@@ -52,4 +52,4 @@ targets:
       - files_dv
       - files_rtl
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_darjeeling/dv/chip_sim.core
+++ b/hw/top_darjeeling/dv/chip_sim.core
@@ -51,6 +51,8 @@ targets:
       - tool_veriblelint ? (files_veriblelint_waiver)
       - files_rtl
       - files_dv
+    flags:
+      chip_level: true
 
   sim:
     <<: *default_target

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env.core
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env.core
@@ -46,4 +46,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_darjeeling/ip_autogen/alert_handler/dv/env/alert_handler_env.core
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/dv/env/alert_handler_env.core
@@ -51,4 +51,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/clkmgr_env.core
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/clkmgr_env.core
@@ -47,4 +47,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_env.core
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_env.core
@@ -46,4 +46,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_env.core
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_env.core
@@ -45,4 +45,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -62,4 +62,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_env.core
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_env.core
@@ -55,4 +55,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/rstmgr_env.core
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/rstmgr_env.core
@@ -52,4 +52,4 @@ targets:
       - files_dv
       - files_rtl
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_earlgrey/dv/chip_sim.core
+++ b/hw/top_earlgrey/dv/chip_sim.core
@@ -62,6 +62,8 @@ targets:
       - tool_veriblelint ? (files_veriblelint_waiver)
       - files_rtl
       - files_dv
+    flags:
+      chip_level: true
 
   sim:
     <<: *default_target

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env.core
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env.core
@@ -51,4 +51,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/clkmgr_env.core
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/clkmgr_env.core
@@ -48,4 +48,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -113,4 +113,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_env.core
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_env.core
@@ -44,4 +44,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_env.core
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_env.core
@@ -45,4 +45,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -62,4 +62,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_earlgrey/ip_autogen/pwm/dv/env/pwm_env.core
+++ b/hw/top_earlgrey/ip_autogen/pwm/dv/env/pwm_env.core
@@ -43,4 +43,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_env.core
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_env.core
@@ -55,4 +55,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/rstmgr_env.core
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/rstmgr_env.core
@@ -52,4 +52,4 @@ targets:
       - files_dv
       - files_rtl
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/clkmgr_env.core
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/clkmgr_env.core
@@ -48,4 +48,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -113,4 +113,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_env.core
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_env.core
@@ -44,4 +44,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_env.core
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_env.core
@@ -45,4 +45,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/pwrmgr_env.core
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/pwrmgr_env.core
@@ -55,4 +55,4 @@ targets:
     filesets:
       - files_dv
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_env.core
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_env.core
@@ -52,4 +52,4 @@ targets:
       - files_dv
       - files_rtl
     generate:
-      - ral
+      - "!chip_level ? (ral)"

--- a/util/uvmdvgen/env.core.tpl
+++ b/util/uvmdvgen/env.core.tpl
@@ -46,5 +46,5 @@ targets:
       - files_dv
 % if has_ral:
     generate:
-      - ral
+      - "!chip_level ? (ral)"
 % endif


### PR DESCRIPTION
This gets defined in the cores for chip environments. The advantage is that these cores can now depend on the environments of IPs, which won't generate their own RAL definitions (because the chip-level environment has done it already).

Note that this is different from the existing skip_ral_gen flag. As far as I can tell, there's no way to set a flag for just the cores that get pulled in as a dependencies. As such, skip_ral_gen will let you turn everything off, but I don't think you can turn off just the RAL for the blocks.

To set the "chip_level" flag, it has to be set to true in the core file that gets invoked by fusesoc (I think). This is chip_sim.core.