### PR TITLE
[dv] Avoid null pointer dereference in dv_base_scoreboard

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_scoreboard.sv
+++ b/hw/dv/sv/dv_lib/dv_base_scoreboard.sv
@@ -69,6 +69,7 @@ class dv_base_scoreboard #(type RAL_T = dv_base_reg_block,
     // have errors in the check phase.
     if (has_uvm_fatal_occurred() &&
         !under_pre_abort &&
+        m_current_phase != null &&
         m_current_phase.is(uvm_run_phase::get())) begin
 
       under_pre_abort = 1;


### PR DESCRIPTION
If you get a fatal error at time zero, m_current_phase will not actually have been set yet.