### PR TITLE
[chip,dv] Factor out register model dependency

### DIFF
--- a/hw/top_darjeeling/dv/env/chip_env.core
+++ b/hw/top_darjeeling/dv/env/chip_env.core
@@ -23,7 +23,6 @@ filesets:
       - lowrisc:dv:lc_ctrl_dv_utils
       - lowrisc:dv:mem_bkdr_util
       - lowrisc:darjeeling_dv:otp_ctrl_mem_bkdr_util
-      - lowrisc:dv:ralgen
       - lowrisc:dv:spi_agent
       - lowrisc:dv:str_utils
       - lowrisc:dv:sw_test_status
@@ -33,6 +32,7 @@ filesets:
       - lowrisc:ip:otp_ctrl_pkg
       - lowrisc:darjeeling_ip:pwrmgr_pkg
       - lowrisc:dv:lc_ctrl_dv_utils
+      - lowrisc:dv:top_darjeeling_chip_ral
       - "!fileset_partner ? (lowrisc:systems:top_darjeeling_ast_pkg)"
       - "fileset_partner ? (partner:systems:top_darjeeling_ast_pkg)"
     files:
@@ -136,17 +136,7 @@ filesets:
       - mbx_if.sv
     file_type: systemVerilogSource
 
-generate:
-  ral:
-    generator: ralgen
-    parameters:
-      name: chip
-      top_hjson: ../../data/top_darjeeling.hjson
-    position: prepend
-
 targets:
   default:
     filesets:
       - files_dv
-    generate:
-      - "!skip_ral_gen ? (ral)"

--- a/hw/top_darjeeling/dv/env/chip_ral.core
+++ b/hw/top_darjeeling/dv/env/chip_ral.core
@@ -1,0 +1,27 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:top_darjeeling_chip_ral:0.1"
+description: "UVM register model for the chip"
+
+filesets:
+  ral_dep:
+    depend:
+      - lowrisc:dv:ralgen
+      - lowrisc:dv:dv_base_reg
+
+generate:
+  ral:
+    generator: ralgen
+    parameters:
+      name: chip
+      top_hjson: ../../data/top_darjeeling.hjson
+    position: prepend
+
+targets:
+  default:
+    filesets:
+      - ral_dep
+    generate:
+      - "!skip_ral_gen ? (ral)"

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -23,7 +23,6 @@ filesets:
       - lowrisc:dv:lc_ctrl_dv_utils
       - lowrisc:earlgrey_dv:flash_ctrl_bkdr_util
       - lowrisc:earlgrey_dv:otp_ctrl_mem_bkdr_util
-      - lowrisc:dv:ralgen
       - lowrisc:dv:spi_agent
       - lowrisc:dv:spi_host_sva
       - lowrisc:dv:str_utils
@@ -36,6 +35,7 @@ filesets:
       - lowrisc:ip:otp_ctrl_pkg
       - lowrisc:earlgrey_ip:pwrmgr_pkg
       - lowrisc:dv:lc_ctrl_dv_utils
+      - lowrisc:dv:top_earlgrey_chip_ral
       - "!fileset_partner ? (lowrisc:systems:top_earlgrey_ast_pkg)"
       - "fileset_partner ? (partner:systems:top_earlgrey_ast_pkg)"
     files:
@@ -164,17 +164,7 @@ filesets:
       - top_earlgrey_error_injection_ifs_bind.sv
     file_type: systemVerilogSource
 
-generate:
-  ral:
-    generator: ralgen
-    parameters:
-      name: chip
-      top_hjson: ../../data/top_earlgrey.hjson
-    position: prepend
-
 targets:
   default:
     filesets:
       - files_dv
-    generate:
-      - "!skip_ral_gen ? (ral)"

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -23,7 +23,6 @@ filesets:
       - lowrisc:dv:lc_ctrl_dv_utils
       - lowrisc:earlgrey_dv:flash_ctrl_bkdr_util
       - lowrisc:earlgrey_dv:otp_ctrl_mem_bkdr_util
-      - lowrisc:dv:ralgen
       - lowrisc:dv:spi_agent
       - lowrisc:dv:spi_host_sva
       - lowrisc:dv:str_utils
@@ -36,9 +35,9 @@ filesets:
       - lowrisc:ip:otp_ctrl_pkg
       - lowrisc:earlgrey_ip:pwrmgr_pkg
       - lowrisc:dv:lc_ctrl_dv_utils
+      - lowrisc:dv:top_earlgrey_chip_ral
       - "!fileset_partner ? (lowrisc:systems:top_earlgrey_ast_pkg)"
       - "fileset_partner ? (partner:systems:top_earlgrey_ast_pkg)"
-      - "skip_ral_gen ? (partner:dv:chip_ast_ral_pkg)"
     files:
       - chip_common_pkg.sv
       - chip_if.sv
@@ -168,17 +167,7 @@ filesets:
       - top_earlgrey_error_injection_ifs_bind.sv
     file_type: systemVerilogSource
 
-generate:
-  ral:
-    generator: ralgen
-    parameters:
-      name: chip
-      top_hjson: ../../data/top_earlgrey.hjson
-    position: prepend
-
 targets:
   default:
     filesets:
       - files_dv
-    generate:
-      - "!skip_ral_gen ? (ral)"

--- a/hw/top_earlgrey/dv/env/chip_ral.core
+++ b/hw/top_earlgrey/dv/env/chip_ral.core
@@ -1,0 +1,27 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:top_earlgrey_chip_ral:0.1"
+description: "UVM register model for the chip"
+
+filesets:
+  ral_dep:
+    depend:
+      - lowrisc:dv:ralgen
+      - lowrisc:dv:dv_base_reg
+
+generate:
+  ral:
+    generator: ralgen
+    parameters:
+      name: chip
+      top_hjson: ../../data/top_earlgrey.hjson
+    position: prepend
+
+targets:
+  default:
+    filesets:
+      - ral_dep
+    generate:
+      - "!skip_ral_gen ? (ral)"

--- a/hw/top_earlgrey/dv/env/chip_ral.core
+++ b/hw/top_earlgrey/dv/env/chip_ral.core
@@ -1,0 +1,28 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:top_earlgrey_chip_ral:0.1"
+description: "UVM register model for the chip"
+
+filesets:
+  ral_dep:
+    depend:
+      - lowrisc:dv:ralgen
+      - lowrisc:dv:dv_base_reg
+      - "skip_ral_gen ? (partner:dv:chip_ast_ral_pkg)"
+
+generate:
+  ral:
+    generator: ralgen
+    parameters:
+      name: chip
+      top_hjson: ../../data/top_earlgrey.hjson
+    position: prepend
+
+targets:
+  default:
+    filesets:
+      - ral_dep
+    generate:
+      - "!skip_ral_gen ? (ral)"


### PR DESCRIPTION
Splitting it up like this will allow us to integrate a block-level testbench, whose register model is generated in the chip-level RAL file.

We need to split that out of chip_env.core to avoid a circular dependency (because the chip environment depends on the block-level environment, which depends on the register model).