### PR TITLE
[dv] Pull the register model for JTAG DTM out of the agent

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_agent.sv
+++ b/hw/dv/sv/jtag_agent/jtag_agent.sv
@@ -30,25 +30,24 @@ class jtag_agent extends dv_base_agent #(
     end
 
     if (cfg.is_active) begin
-      uvm_reg_map maps[$];
-      cfg.jtag_dtm_ral.get_maps(maps);
-      if (maps.size() != 1) begin
-        `uvm_fatal(get_full_name(),
-                   $sformatf("Cannot create JTAG DTM reg adapter: there are %0d reg maps.",
-                             maps.size()))
-      end
-
       m_jtag_dtm_reg_adapter = jtag_dtm_reg_adapter::type_id::create("m_jtag_dtm_reg_adapter");
       m_jtag_dtm_reg_adapter.set_ir_len(cfg.ir_len);
-      m_jtag_dtm_reg_adapter.set_reg_map(maps[0]);
     end
   endfunction
 
-  virtual function void end_of_elaboration_phase(uvm_phase phase);
-    super.end_of_elaboration_phase(phase);
-    if (cfg.is_active) begin
-      cfg.jtag_dtm_ral.default_map.set_sequencer(sequencer, m_jtag_dtm_reg_adapter);
+  // Connect the agent to a uvm_reg_map that represents the DTM registers.
+  //
+  // The connection teaches reg_map to use this agent's sequencer when generating register accesses.
+  // It also teaches this register adapter how to pick sensible DR values for register reads. See
+  // jtag_dtm_reg_adapter::set_reg_map and jtag_dtm_reg_adapter::get_wdata_for_read for more
+  // information.
+  function void set_reg_map(uvm_reg_map reg_map);
+    if (m_jtag_dtm_reg_adapter == null) begin
+      `uvm_fatal(get_full_name(),
+                 "No reg adapter. This must be run after the build phase on an active agent.")
     end
-  endfunction : end_of_elaboration_phase
+    m_jtag_dtm_reg_adapter.set_reg_map(reg_map);
+    reg_map.set_sequencer(sequencer, m_jtag_dtm_reg_adapter);
+  endfunction
 
 endclass

--- a/hw/dv/sv/jtag_agent/jtag_agent_cfg.sv
+++ b/hw/dv/sv/jtag_agent/jtag_agent_cfg.sv
@@ -17,9 +17,6 @@ class jtag_agent_cfg extends dv_base_agent_cfg;
   // Length of IR register. Update this field based on the actual width used in the design.
   uint ir_len = JTAG_IRW;
 
-  // JTAG debug transport module (DTM) RAL model based off of RISCV spec 0.13.2 (section 6.1.2).
-  jtag_dtm_reg_block jtag_dtm_ral;
-
   // Option to minimize Run-Test/Idle duration
   // Current RVDM has hardcoded dtmcs.idle = 1, which requires a single cycle of Run-Test/Idle duration.
   // This knob can bypass default 1 cycle initial delay of 'driver.drive_jtag_req()' task.
@@ -34,21 +31,10 @@ class jtag_agent_cfg extends dv_base_agent_cfg;
   // between the JTAG clock and a system clock. This only works when TCK is running!
   int unsigned rtc_length = 0;
 
-
-  `uvm_object_utils_begin(jtag_agent_cfg)
-    `uvm_field_object(jtag_dtm_ral, UVM_DEFAULT)
-  `uvm_object_utils_end
+  `uvm_object_utils(jtag_agent_cfg)
 
   function new (string name = "");
     super.new(name);
     jtag_if_connected = new();
-    // Create the JTAG DTM RAL.
-    jtag_dtm_ral = jtag_dtm_reg_block::type_id::create("jtag_dtm_ral");
-    jtag_dtm_ral.build(.base_addr(0), .csr_excl(null));
-    jtag_dtm_ral.set_supports_byte_enable(1'b0);
-    jtag_dtm_ral.lock_model();
-    jtag_dtm_ral.set_base_addr(0);
-    // TODO: fix the computation of mapped and unmapped ranges.
   endfunction : new
-
 endclass

--- a/hw/dv/sv/jtag_agent/jtag_agent_cfg.sv
+++ b/hw/dv/sv/jtag_agent/jtag_agent_cfg.sv
@@ -17,9 +17,6 @@ class jtag_agent_cfg extends dv_base_agent_cfg;
   // Length of IR register. Update this field based on the actual width used in the design.
   uint ir_len = JTAG_IRW;
 
-  // JTAG debug transport module (DTM) RAL model based off of RISCV spec 0.13.2 (section 6.1.2).
-  jtag_dtm_reg_block jtag_dtm_ral;
-
   // Option to minimize Run-Test/Idle duration
   // Current RVDM has hardcoded dtmcs.idle = 1, which requires a single cycle of Run-Test/Idle duration.
   // This knob can bypass default 1 cycle initial delay of 'driver.drive_jtag_req()' task.
@@ -34,25 +31,10 @@ class jtag_agent_cfg extends dv_base_agent_cfg;
   // between the JTAG clock and a system clock. This only works when TCK is running!
   int unsigned rtc_length = 0;
 
-
-  `uvm_object_utils_begin(jtag_agent_cfg)
-    `uvm_field_object(jtag_dtm_ral, UVM_DEFAULT)
-  `uvm_object_utils_end
+  `uvm_object_utils(jtag_agent_cfg)
 
   function new (string name = "");
     super.new(name);
     jtag_if_connected = new();
-    // Create the JTAG DTM RAL.
-    jtag_dtm_ral = jtag_dtm_reg_block::type_id::create("jtag_dtm_ral");
-    jtag_dtm_ral.build(.base_addr(0),
-                       .csr_excl(null),
-                       .addr_width(`UVM_REG_ADDR_WIDTH),
-                       .data_width(`UVM_REG_DATA_WIDTH),
-                       .be_width(4));
-    jtag_dtm_ral.set_supports_byte_enable(1'b0);
-    jtag_dtm_ral.lock_model();
-    jtag_dtm_ral.set_base_addr(0);
-    // TODO: fix the computation of mapped and unmapped ranges.
   endfunction : new
-
 endclass

--- a/hw/dv/sv/jtag_agent/jtag_agent_pkg.sv
+++ b/hw/dv/sv/jtag_agent/jtag_agent_pkg.sv
@@ -61,4 +61,14 @@ package jtag_agent_pkg;
   `include "jtag_dtm_reg_block.sv"
   `include "jtag_dtm_reg_adapter.sv"
 
-  endpackage: jtag_agent_pkg
+  // Convenience function to create JTAG DTM register block
+  function automatic jtag_dtm_reg_block create_jtag_dtm_reg_block(string name);
+    jtag_dtm_reg_block ret = jtag_dtm_reg_block::type_id::create(name);
+    ret.build(.base_addr(0), .csr_excl(null));
+    ret.set_supports_byte_enable(1'b0);
+    ret.lock_model();
+    ret.set_base_addr(0);
+    return ret;
+  endfunction
+
+endpackage: jtag_agent_pkg

--- a/hw/dv/sv/jtag_agent/jtag_agent_pkg.sv
+++ b/hw/dv/sv/jtag_agent/jtag_agent_pkg.sv
@@ -61,4 +61,18 @@ package jtag_agent_pkg;
   `include "jtag_dtm_reg_block.sv"
   `include "jtag_dtm_reg_adapter.sv"
 
-  endpackage: jtag_agent_pkg
+  // Convenience function to create JTAG DTM register block
+  function automatic jtag_dtm_reg_block create_jtag_dtm_reg_block(string name);
+    jtag_dtm_reg_block ret = jtag_dtm_reg_block::type_id::create(name);
+    ret.build(.base_addr(0),
+              .csr_excl(null),
+              .addr_width(`UVM_REG_ADDR_WIDTH),
+              .data_width(`UVM_REG_DATA_WIDTH),
+              .be_width(4));
+    ret.set_supports_byte_enable(1'b0);
+    ret.lock_model();
+    ret.set_base_addr(0);
+    return ret;
+  endfunction
+
+endpackage: jtag_agent_pkg

--- a/hw/dv/sv/jtag_agent/jtag_monitor.sv
+++ b/hw/dv/sv/jtag_agent/jtag_monitor.sv
@@ -179,11 +179,7 @@ class jtag_monitor extends dv_base_monitor #(
   virtual protected task monitor_reset();
     forever begin
       @(cfg.vif.trst_n);
-
       cfg.in_reset = !cfg.vif.trst_n;
-      if (cfg.in_reset) begin
-        cfg.jtag_dtm_ral.reset("HARD");
-      end
     end
   endtask
 

--- a/hw/dv/sv/jtag_dmi_agent/jtag_dmi_agent_pkg.sv
+++ b/hw/dv/sv/jtag_dmi_agent/jtag_dmi_agent_pkg.sv
@@ -38,23 +38,22 @@ package jtag_dmi_agent_pkg;
   `include "jtag_dmi_monitor.sv"
 
   // Convenience function to create JTAG DMI RAL block.
-  function automatic jtag_dmi_reg_block create_jtag_dmi_reg_block(jtag_agent_cfg cfg);
-    jtag_dmi_reg_block jtag_dmi_ral = jtag_dmi_reg_block::type_id::create("jtag_dmi_ral");
-    jtag_dtm_reg_block jtag_dtm_ral = cfg.jtag_dtm_ral;
-    jtag_dtm_reg_dmi   dmi_reg      = jtag_dtm_ral.dmi;
-    jtag_dtm_reg_dtmcs dtmcs_reg    = jtag_dtm_ral.dtmcs;
-
-    jtag_dmi_ral.build(.base_addr(0), .csr_excl(null));
-    jtag_dmi_ral.set_supports_byte_enable(1'b0);
-    jtag_dmi_ral.lock_model();
-    jtag_dmi_ral.set_base_addr(0);
+  function automatic jtag_dmi_reg_block create_jtag_dmi_reg_block(string             name,
+                                                                  jtag_agent_cfg     cfg,
+                                                                  jtag_dtm_reg_dmi   dmi_reg,
+                                                                  jtag_dtm_reg_dtmcs dtmcs_reg);
+    jtag_dmi_reg_block reg_block = jtag_dmi_reg_block::type_id::create(name);
+    reg_block.build(.base_addr(0), .csr_excl(null));
+    reg_block.set_supports_byte_enable(1'b0);
+    reg_block.lock_model();
+    reg_block.set_base_addr(0);
     // TODO: fix the computation of mapped and unmapped ranges.
 
     // Attach JTAG DMI frontdoor to all registers.
     begin
       uvm_reg rg[$];
       semaphore sem = new(1);
-      jtag_dmi_ral.get_registers(rg);
+      reg_block.get_registers(rg);
       foreach (rg[i]) begin
         jtag_dmi_reg_frontdoor ftdr = jtag_dmi_reg_frontdoor::type_id::create("ftdr");
         ftdr.configure(cfg, dmi_reg, dtmcs_reg);
@@ -62,7 +61,7 @@ package jtag_dmi_agent_pkg;
         rg[i].set_frontdoor(ftdr);
       end
     end
-    return jtag_dmi_ral;
+    return reg_block;
   endfunction
 
 endpackage: jtag_dmi_agent_pkg

--- a/hw/dv/sv/jtag_dmi_agent/jtag_dmi_agent_pkg.sv
+++ b/hw/dv/sv/jtag_dmi_agent/jtag_dmi_agent_pkg.sv
@@ -37,28 +37,39 @@ package jtag_dmi_agent_pkg;
   `include "jtag_dmi_item.sv"
   `include "jtag_dmi_monitor.sv"
 
-  // Convenience function to create JTAG DMI RAL block.
-  function automatic jtag_dmi_reg_block create_jtag_dmi_reg_block(jtag_agent_cfg cfg);
-    jtag_dmi_reg_block jtag_dmi_ral = jtag_dmi_reg_block::type_id::create("jtag_dmi_ral");
-    jtag_dtm_reg_block jtag_dtm_ral = cfg.jtag_dtm_ral;
-    jtag_dtm_reg_dmi   dmi_reg      = jtag_dtm_ral.dmi;
-    jtag_dtm_reg_dtmcs dtmcs_reg    = jtag_dtm_ral.dtmcs;
+  // Convenience function to create a JTAG DMI register block.
+  function automatic jtag_dmi_reg_block create_jtag_dmi_reg_block(string             name,
+                                                                  jtag_agent_cfg     cfg,
+                                                                  jtag_dtm_reg_dmi   dmi_reg,
+                                                                  jtag_dtm_reg_dtmcs dtmcs_reg);
+    jtag_dmi_reg_block reg_block;
 
-    jtag_dmi_ral.build(.base_addr(0),
-                       .csr_excl(null),
-                       .addr_width(32),
-                       .data_width(32),
-                       .be_width(4));
-    jtag_dmi_ral.set_supports_byte_enable(1'b0);
-    jtag_dmi_ral.lock_model();
-    jtag_dmi_ral.set_base_addr(0);
+    if (cfg == null) begin
+      `uvm_fatal("no_cfg", "Cannot configure dmi reg block with no cfg.")
+    end
+    if (dmi_reg == null) begin
+      `uvm_fatal("do_dmi_reg", "Cannot create dmi reg block with no dmi reg.")
+    end
+    if (dtmcs_reg == null) begin
+      `uvm_fatal("do_dtmcs_reg", "Cannot create dmi reg block with no dtmcs reg.")
+    end
+
+    reg_block = jtag_dmi_reg_block::type_id::create(name);
+    reg_block.build(.base_addr(0),
+                    .csr_excl(null),
+                    .addr_width(32),
+                    .data_width(32),
+                    .be_width(4));
+    reg_block.set_supports_byte_enable(1'b0);
+    reg_block.lock_model();
+    reg_block.set_base_addr(0);
     // TODO: fix the computation of mapped and unmapped ranges.
 
     // Attach JTAG DMI frontdoor to all registers.
     begin
       uvm_reg rg[$];
       semaphore sem = new(1);
-      jtag_dmi_ral.get_registers(rg);
+      reg_block.get_registers(rg);
       foreach (rg[i]) begin
         jtag_dmi_reg_frontdoor ftdr = jtag_dmi_reg_frontdoor::type_id::create("ftdr");
         ftdr.configure(cfg, dmi_reg, dtmcs_reg);
@@ -66,7 +77,7 @@ package jtag_dmi_agent_pkg;
         rg[i].set_frontdoor(ftdr);
       end
     end
-    return jtag_dmi_ral;
+    return reg_block;
   endfunction
 
 endpackage: jtag_dmi_agent_pkg

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent.sv
@@ -29,6 +29,7 @@ class jtag_riscv_agent extends dv_base_agent #(
       `DV_CHECK_RANDOMIZE_FATAL(cfg.m_jtag_agent_cfg)
     end
     m_jtag_agent = jtag_agent::type_id::create("m_jtag_agent", this);
+
     uvm_config_db#(jtag_agent_cfg)::set(this, "m_jtag_agent", "cfg", cfg.m_jtag_agent_cfg);
     cfg.m_jtag_agent_cfg.en_cov = cfg.en_cov;
   endfunction
@@ -40,6 +41,17 @@ class jtag_riscv_agent extends dv_base_agent #(
     if (cfg.use_jtag_dmi == 0) begin
       m_jtag_agent.monitor.analysis_port.connect(monitor.jtag_item_fifo.analysis_export);
     end
+  endfunction
+
+  // Pass a handle to a uvm_reg_map that represents the DTM registers. This gets passed to the
+  // jtag_agent (which uses the reg map to predict register values in order to avoid perturbing
+  // register values on reads)
+  function void set_dtm_reg_map(uvm_reg_map reg_map);
+    if (m_jtag_agent == null)
+      `uvm_fatal(get_full_name(),
+                 "Cannot set reg map without a jtag_agent. This must be after build_phase.")
+
+    m_jtag_agent.set_reg_map(reg_map);
   endfunction
 
 endclass

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.sv
@@ -94,6 +94,9 @@ class lc_ctrl_env extends cip_base_env #(
           scoreboard.esc_scrap_state_fifo.analysis_export);
       m_jtag_riscv_agent.monitor.analysis_port.connect(scoreboard.jtag_riscv_fifo.analysis_export);
     end
+    if (cfg.is_active) begin
+      m_jtag_riscv_agent.set_dtm_reg_map(cfg.m_jtag_dtm_ral.get_default_map());
+    end
   endfunction
 
   virtual function void end_of_elaboration_phase(uvm_phase phase);

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.sv
@@ -92,6 +92,8 @@ class lc_ctrl_env extends cip_base_env #(
           scoreboard.esc_scrap_state_fifo.analysis_export);
       m_jtag_riscv_agent.monitor.analysis_port.connect(scoreboard.jtag_riscv_fifo.analysis_export);
     end
+
+    m_jtag_riscv_agent.set_dtm_reg_map(cfg.m_jtag_dtm_ral.get_default_map());
   endfunction
 
   virtual function void end_of_elaboration_phase(uvm_phase phase);

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
@@ -41,6 +41,9 @@ class lc_ctrl_env_cfg extends cip_base_env_cfg #(
   // Enable scoreboard ral update on write
   bit en_scb_ral_update_write = 1;
 
+  // The JTAG DTM register model.
+  rand jtag_dtm_reg_block m_jtag_dtm_ral;
+
   // OTP
   rand otp_device_id_t otp_device_id;
   rand otp_device_id_t otp_manuf_state;
@@ -95,6 +98,8 @@ class lc_ctrl_env_cfg extends cip_base_env_cfg #(
         alert_esc_agent_cfg::type_id::create("m_esc_scrap_state0_agent_cfg");
     `DV_CHECK_RANDOMIZE_FATAL(m_esc_scrap_state0_agent_cfg)
     m_esc_scrap_state0_agent_cfg.is_alert = 0;
+
+    m_jtag_dtm_ral = create_jtag_dtm_reg_block("m_jtag_dtm_ral");
 
     m_jtag_riscv_agent_cfg = jtag_riscv_agent_cfg::type_id::create("m_jtag_riscv_agent_cfg");
     `DV_CHECK_RANDOMIZE_FATAL(m_jtag_riscv_agent_cfg)

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
@@ -24,6 +24,9 @@ package lc_ctrl_env_pkg;
   import prim_mubi_pkg::MuBi8True;
   import sec_cm_pkg::*;
 
+  import jtag_agent_pkg::jtag_dtm_reg_block;
+  import jtag_agent_pkg::create_jtag_dtm_reg_block;
+
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
@@ -636,6 +636,9 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
     // Clear OTP program count
     m_otp_prog_cnt = 0;
     exp_clk_byp_req = lc_ctrl_pkg::Off;
+
+    // Update the JTAG DTM register model with the reset
+    cfg.m_jtag_dtm_ral.reset(kind);
   endfunction
 
   function void check_phase(uvm_phase phase);

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
@@ -637,6 +637,9 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
     // Clear OTP program count
     m_otp_prog_cnt = 0;
     exp_clk_byp_req = lc_ctrl_pkg::Off;
+
+    // Update the JTAG DTM register model with the reset
+    cfg.m_jtag_dtm_ral.reset(kind);
   endfunction
 
   function void check_phase(uvm_phase phase);

--- a/hw/ip/rv_dm/dv/env/rv_dm_env.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.sv
@@ -50,11 +50,12 @@ class rv_dm_env extends cip_base_env #(
 
     m_jtag_agent = jtag_agent::type_id::create("m_jtag_agent", this);
     uvm_config_db#(jtag_agent_cfg)::set(this, "m_jtag_agent*", "cfg", cfg.m_jtag_agent_cfg);
+
     cfg.m_jtag_agent_cfg.en_cov = cfg.en_cov;
 
     m_jtag_dmi_monitor = jtag_dmi_monitor#()::type_id::create("m_jtag_dmi_monitor", this);
     m_jtag_dmi_monitor.cfg = cfg.m_jtag_agent_cfg;
-    m_jtag_dmi_monitor.set_dmi_address(cfg.m_jtag_agent_cfg.jtag_dtm_ral.dmi.get_address());
+    m_jtag_dmi_monitor.set_dmi_address(cfg.m_jtag_dtm_ral.dmi.get_address());
 
     m_sba_access_monitor = sba_access_monitor#()::type_id::create("m_sba_access_monitor", this);
     m_sba_access_monitor.cfg = cfg.m_jtag_agent_cfg;
@@ -74,11 +75,14 @@ class rv_dm_env extends cip_base_env #(
       m_tl_sba_agent.monitor.a_chan_port.connect(scoreboard.tl_sba_a_chan_fifo.analysis_export);
       m_tl_sba_agent.monitor.d_chan_port.connect(scoreboard.tl_sba_d_chan_fifo.analysis_export);
     end
-    if (cfg.is_active && cfg.m_jtag_agent_cfg.is_active) begin
-      virtual_sequencer.jtag_sequencer_h = m_jtag_agent.sequencer;
-    end
-    if (cfg.is_active && cfg.m_tl_sba_agent_cfg.is_active) begin
-      virtual_sequencer.tl_sba_sequencer_h = m_tl_sba_agent.sequencer;
+    if (cfg.is_active) begin
+      if (cfg.m_jtag_agent_cfg.is_active) begin
+        virtual_sequencer.jtag_sequencer_h = m_jtag_agent.sequencer;
+        m_jtag_agent.set_reg_map(cfg.m_jtag_dtm_ral.default_map);
+      end
+      if (cfg.m_tl_sba_agent_cfg.is_active) begin
+        virtual_sequencer.tl_sba_sequencer_h = m_tl_sba_agent.sequencer;
+      end
     end
   endfunction
 

--- a/hw/ip/rv_dm/dv/env/rv_dm_env.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.sv
@@ -50,11 +50,12 @@ class rv_dm_env extends cip_base_env #(
 
     m_jtag_agent = jtag_agent::type_id::create("m_jtag_agent", this);
     uvm_config_db#(jtag_agent_cfg)::set(this, "m_jtag_agent*", "cfg", cfg.m_jtag_agent_cfg);
+
     cfg.m_jtag_agent_cfg.en_cov = cfg.en_cov;
 
     m_jtag_dmi_monitor = jtag_dmi_monitor#()::type_id::create("m_jtag_dmi_monitor", this);
     m_jtag_dmi_monitor.cfg = cfg.m_jtag_agent_cfg;
-    m_jtag_dmi_monitor.set_dmi_address(cfg.m_jtag_agent_cfg.jtag_dtm_ral.dmi.get_address());
+    m_jtag_dmi_monitor.set_dmi_address(cfg.m_jtag_dtm_ral.dmi.get_address());
 
     m_sba_access_monitor = sba_access_monitor#()::type_id::create("m_sba_access_monitor", this);
     m_sba_access_monitor.cfg = cfg.m_jtag_agent_cfg;
@@ -63,6 +64,7 @@ class rv_dm_env extends cip_base_env #(
 
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
+
     if (cfg.en_scb) begin
       m_jtag_agent.monitor.analysis_port.connect(m_jtag_dmi_monitor.jtag_item_fifo.analysis_export);
       m_jtag_dmi_monitor.analysis_port.connect(m_sba_access_monitor.jtag_dmi_fifo.analysis_export);
@@ -74,12 +76,17 @@ class rv_dm_env extends cip_base_env #(
       m_tl_sba_agent.monitor.a_chan_port.connect(scoreboard.tl_sba_a_chan_fifo.analysis_export);
       m_tl_sba_agent.monitor.d_chan_port.connect(scoreboard.tl_sba_d_chan_fifo.analysis_export);
     end
-    if (cfg.is_active && cfg.m_jtag_agent_cfg.is_active) begin
-      virtual_sequencer.jtag_sequencer_h = m_jtag_agent.sequencer;
+
+    if (cfg.is_active) begin
+      if (cfg.m_jtag_agent_cfg.is_active) begin
+        virtual_sequencer.jtag_sequencer_h = m_jtag_agent.sequencer;
+      end
+      if (cfg.m_tl_sba_agent_cfg.is_active) begin
+        virtual_sequencer.tl_sba_sequencer_h = m_tl_sba_agent.sequencer;
+      end
     end
-    if (cfg.is_active && cfg.m_tl_sba_agent_cfg.is_active) begin
-      virtual_sequencer.tl_sba_sequencer_h = m_tl_sba_agent.sequencer;
-    end
+
+    m_jtag_agent.set_reg_map(cfg.m_jtag_dtm_ral.default_map);
   endfunction
 
 endclass

--- a/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
@@ -23,6 +23,9 @@ class rv_dm_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_dm_regs_reg_block));
   // use the unsynchronised reset signal.
   virtual clk_rst_if clk_lc_rst_vif;
 
+  // The JTAG DTM register model.
+  rand jtag_dtm_reg_block m_jtag_dtm_ral;
+
   // The JTAG DMI register model.
   rand jtag_dmi_reg_block jtag_dmi_ral;
 
@@ -35,6 +38,7 @@ class rv_dm_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_dm_regs_reg_block));
   `uvm_object_utils_begin(rv_dm_env_cfg)
     `uvm_field_object(m_jtag_agent_cfg,   UVM_DEFAULT)
     `uvm_field_object(m_tl_sba_agent_cfg, UVM_DEFAULT)
+    `uvm_field_object(m_jtag_dtm_ral,     UVM_DEFAULT)
     `uvm_field_object(jtag_dmi_ral,       UVM_DEFAULT)
     `uvm_field_object(debugger,           UVM_DEFAULT)
   `uvm_object_utils_end
@@ -73,16 +77,20 @@ class rv_dm_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_dm_regs_reg_block));
     m_jtag_agent_cfg.is_active = 1'b1;
     m_jtag_agent_cfg.ir_len = JTAG_IR_LEN;
 
-    // Set the 'correct' IDCODE register value to the JTAG DTM RAL.
-    m_jtag_agent_cfg.jtag_dtm_ral.idcode.set_reset(RV_DM_JTAG_IDCODE);
-
     // Create TL agent config obj for the SBA port.
     m_tl_sba_agent_cfg = tl_agent_cfg::type_id::create("m_tl_sba_agent_cfg");
     m_tl_sba_agent_cfg.if_mode = dv_utils_pkg::Device;
     m_tl_sba_agent_cfg.is_active = 1'b1;
     m_tl_sba_agent_cfg.max_outstanding_req = 1;
 
-    jtag_dmi_ral = create_jtag_dmi_reg_block(m_jtag_agent_cfg);
+    // Create a JTAG DTM RAL and give it the right IDCODE register value.
+    m_jtag_dtm_ral = create_jtag_dtm_reg_block("m_jtag_dtm_ral");
+    m_jtag_dtm_ral.idcode.set_reset(RV_DM_JTAG_IDCODE);
+
+    jtag_dmi_ral = create_jtag_dmi_reg_block("jtag_dmi_ral",
+                                             m_jtag_agent_cfg,
+                                             m_jtag_dtm_ral.dmi,
+                                             m_jtag_dtm_ral.dtmcs);
     // Fix the reset values of these fields based on our design.
     `uvm_info(`gfn, "Fixing reset values in jtag_dmi_ral", UVM_LOW)
     jtag_dmi_ral.hartinfo.dataaddr.set_reset(dm::DataAddr);

--- a/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
@@ -23,6 +23,9 @@ class rv_dm_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_dm_regs_reg_block));
   // use the unsynchronised reset signal.
   virtual clk_rst_if clk_lc_rst_vif;
 
+  // The JTAG DTM register model.
+  rand jtag_dtm_reg_block m_jtag_dtm_ral;
+
   // The JTAG DMI register model.
   rand jtag_dmi_reg_block jtag_dmi_ral;
 
@@ -35,6 +38,7 @@ class rv_dm_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_dm_regs_reg_block));
   `uvm_object_utils_begin(rv_dm_env_cfg)
     `uvm_field_object(m_jtag_agent_cfg,   UVM_DEFAULT)
     `uvm_field_object(m_tl_sba_agent_cfg, UVM_DEFAULT)
+    `uvm_field_object(m_jtag_dtm_ral,     UVM_DEFAULT)
     `uvm_field_object(jtag_dmi_ral,       UVM_DEFAULT)
     `uvm_field_object(debugger,           UVM_DEFAULT)
   `uvm_object_utils_end
@@ -74,16 +78,20 @@ class rv_dm_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_dm_regs_reg_block));
     m_jtag_agent_cfg.is_active = 1'b1;
     m_jtag_agent_cfg.ir_len = JTAG_IR_LEN;
 
-    // Set the 'correct' IDCODE register value to the JTAG DTM RAL.
-    m_jtag_agent_cfg.jtag_dtm_ral.idcode.set_reset(RV_DM_JTAG_IDCODE);
-
     // Create TL agent config obj for the SBA port.
     m_tl_sba_agent_cfg = tl_agent_cfg::type_id::create("m_tl_sba_agent_cfg");
     m_tl_sba_agent_cfg.if_mode = dv_utils_pkg::Device;
     m_tl_sba_agent_cfg.is_active = 1'b1;
     m_tl_sba_agent_cfg.max_outstanding_req = 1;
 
-    jtag_dmi_ral = create_jtag_dmi_reg_block(m_jtag_agent_cfg);
+    // Create a JTAG DTM RAL and give it the right IDCODE register value.
+    m_jtag_dtm_ral = create_jtag_dtm_reg_block("m_jtag_dtm_ral");
+    m_jtag_dtm_ral.idcode.set_reset(RV_DM_JTAG_IDCODE);
+
+    jtag_dmi_ral = create_jtag_dmi_reg_block("jtag_dmi_ral",
+                                             m_jtag_agent_cfg,
+                                             m_jtag_dtm_ral.dmi,
+                                             m_jtag_dtm_ral.dtmcs);
     // Fix the reset values of these fields based on our design.
     `uvm_info(`gfn, "Fixing reset values in jtag_dmi_ral", UVM_LOW)
     jtag_dmi_ral.hartinfo.dataaddr.set_reset(dm::DataAddr);

--- a/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
@@ -38,7 +38,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
     tl_sba_d_chan_fifo = new("tl_sba_d_chan_fifo", this);
     // TODO: remove once support alert checking
     do_alert_check = 0;
-    selected_dtm_csr = cfg.m_jtag_agent_cfg.jtag_dtm_ral.default_map.get_reg_by_offset(0);
+    selected_dtm_csr = cfg.m_jtag_dtm_ral.default_map.get_reg_by_offset(0);
   endfunction
 
   function void connect_phase(uvm_phase phase);
@@ -65,7 +65,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
       `uvm_info(`gfn, $sformatf("Received jtag non-DMI DTM item:\n%0s",
                                 item.sprint(uvm_default_line_printer)), UVM_HIGH)
       if (item.ir_len) begin
-        selected_dtm_csr = cfg.m_jtag_agent_cfg.jtag_dtm_ral.default_map.get_reg_by_offset(item.ir);
+        selected_dtm_csr = cfg.m_jtag_dtm_ral.default_map.get_reg_by_offset(item.ir);
         continue;
       end
 
@@ -94,7 +94,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
           // design (dmi_jtag module) is probed. Instead of doing that, checking the correctness of
           // dmistat field can be offloaded to a directed test that generates DMI busy scenarios.
           uvm_reg_data_t mask = ~dv_base_reg_pkg::get_mask_from_fields(
-              {cfg.m_jtag_agent_cfg.jtag_dtm_ral.dtmcs.dmistat});
+              {cfg.m_jtag_dtm_ral.dtmcs.dmistat});
           `DV_CHECK_EQ(item.dout & mask, selected_dtm_csr.get_mirrored_value() & mask)
           void'(selected_dtm_csr.predict(.value(item.dr), .kind(UVM_PREDICT_WRITE)));
         end
@@ -400,8 +400,9 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
     jtag_non_sba_dmi_fifo.flush();
     tl_sba_a_chan_fifo.flush();
     tl_sba_d_chan_fifo.flush();
-    selected_dtm_csr = cfg.m_jtag_agent_cfg.jtag_dtm_ral.idcode;
+    selected_dtm_csr = cfg.m_jtag_dtm_ral.idcode;
     cfg.jtag_dmi_ral.reset(kind);
+    cfg.m_jtag_dtm_ral.reset(kind);
   endfunction
 
   function void check_phase(uvm_phase phase);

--- a/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
@@ -38,7 +38,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
     tl_sba_d_chan_fifo = new("tl_sba_d_chan_fifo", this);
     // TODO: remove once support alert checking
     do_alert_check = 0;
-    selected_dtm_csr = cfg.m_jtag_agent_cfg.jtag_dtm_ral.default_map.get_reg_by_offset(0);
+    selected_dtm_csr = cfg.m_jtag_dtm_ral.default_map.get_reg_by_offset(0);
   endfunction
 
   function void connect_phase(uvm_phase phase);
@@ -65,7 +65,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
       `uvm_info(`gfn, $sformatf("Received jtag non-DMI DTM item:\n%0s",
                                 item.sprint(uvm_default_line_printer)), UVM_HIGH)
       if (item.ir_len) begin
-        selected_dtm_csr = cfg.m_jtag_agent_cfg.jtag_dtm_ral.default_map.get_reg_by_offset(item.ir);
+        selected_dtm_csr = cfg.m_jtag_dtm_ral.default_map.get_reg_by_offset(item.ir);
         continue;
       end
 
@@ -94,7 +94,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
           // design (dmi_jtag module) is probed. Instead of doing that, checking the correctness of
           // dmistat field can be offloaded to a directed test that generates DMI busy scenarios.
           uvm_reg_data_t mask = ~dv_base_reg_pkg::get_mask_from_fields(
-              {cfg.m_jtag_agent_cfg.jtag_dtm_ral.dtmcs.dmistat});
+              {cfg.m_jtag_dtm_ral.dtmcs.dmistat});
           `DV_CHECK_EQ(item.dout & mask, selected_dtm_csr.get_mirrored_value() & mask)
           void'(selected_dtm_csr.predict(.value(item.dr), .kind(UVM_PREDICT_WRITE)));
         end
@@ -466,8 +466,9 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
     jtag_non_sba_dmi_fifo.flush();
     tl_sba_a_chan_fifo.flush();
     tl_sba_d_chan_fifo.flush();
-    selected_dtm_csr = cfg.m_jtag_agent_cfg.jtag_dtm_ral.idcode;
+    selected_dtm_csr = cfg.m_jtag_dtm_ral.idcode;
     cfg.jtag_dmi_ral.reset(kind);
+    cfg.m_jtag_dtm_ral.reset(kind);
   endfunction
 
   function void check_phase(uvm_phase phase);

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -118,7 +118,7 @@ class rv_dm_base_vseq extends cip_base_vseq #(
 
   virtual function void set_handles();
     super.set_handles();
-    jtag_dtm_ral = cfg.m_jtag_agent_cfg.jtag_dtm_ral;
+    jtag_dtm_ral = cfg.m_jtag_dtm_ral;
     jtag_dmi_ral = cfg.jtag_dmi_ral;
     dv_base_ral = cfg.ral_models["rv_dm_mem_reg_block"];
     `downcast(tl_mem_ral,dv_base_ral);

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_tap_fsm_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_tap_fsm_vseq.sv
@@ -32,7 +32,7 @@ class rv_dm_tap_fsm_vseq extends rv_dm_base_vseq;
       ir == 'h0;
       ir_len == 'd5;
       dr == 'h0;
-      dr_len == cfg.m_jtag_agent_cfg.jtag_dtm_ral.idcode.get_n_bits();
+      dr_len == jtag_dtm_ral.idcode.get_n_bits();
       ir_pause_count == 0;
       dr_pause_count == 0;
       exit_via_pause_dr == 0;

--- a/hw/top_darjeeling/dv/env/chip_env.sv
+++ b/hw/top_darjeeling/dv/env/chip_env.sv
@@ -158,6 +158,12 @@ class chip_env extends cip_base_env #(
       virtual_sequencer.jtag_sequencer_h = m_jtag_riscv_agent.sequencer;
     end
 
+    // If we are using JTAG DMI, cfg.m_jtag_dtm_ral will have been constructed (when the build_phase
+    // for the next level up called cfg.set_use_jtag_dmi). If not, it will be null.
+    if (cfg.m_jtag_dtm_ral != null) begin
+      m_jtag_riscv_agent.set_dtm_reg_map(cfg.m_jtag_dtm_ral.get_default_map());
+    end
+
     if (cfg.is_active && cfg.m_spi_host_agent_cfg.is_active) begin
       virtual_sequencer.spi_host_sequencer_h = m_spi_host_agent.sequencer;
     end

--- a/hw/top_darjeeling/dv/env/chip_env_cfg.sv
+++ b/hw/top_darjeeling/dv/env/chip_env_cfg.sv
@@ -76,6 +76,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   rand spi_agent_cfg        m_spi_device_agent_cfgs[NUM_SPI_HOSTS];
   rand jtag_riscv_agent_cfg m_jtag_riscv_agent_cfg;
   rand jtag_agent_cfg       m_jtag_agent_cfg;
+  rand jtag_dtm_reg_block   m_jtag_dtm_ral;
   rand spi_agent_cfg        m_spi_host_agent_cfg;
   rand i2c_agent_cfg        m_i2c_agent_cfgs[NUM_I2CS];
 
@@ -239,15 +240,20 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     m_jtag_agent_cfg.is_active = 1'b1;
     m_jtag_agent_cfg.ir_len = JTAG_IR_LEN;
 
-    // Set the 'correct' IDCODE register value to the JTAG DTM RAL.
-    m_jtag_agent_cfg.jtag_dtm_ral.idcode.set_reset(RV_DM_JTAG_IDCODE);
+    // Create a JTAG DTM RAL and give it the right IDCODE register value.
+    m_jtag_dtm_ral = create_jtag_dtm_reg_block("m_jtag_dtm_ral");
+    m_jtag_dtm_ral.idcode.set_reset(RV_DM_JTAG_IDCODE);
+
     m_jtag_riscv_agent_cfg.m_jtag_agent_cfg = m_jtag_agent_cfg;
 
     // Create the DMI register block. Because use_jtag_dmi was false at the start of the function,
     // we know it is currently null.
     if (jtag_dmi_ral != null) `uvm_fatal(`gfn, "jtag_dmi_ral unexpectedly set")
 
-    jtag_dmi_ral = create_jtag_dmi_reg_block(m_jtag_riscv_agent_cfg.m_jtag_agent_cfg);
+    jtag_dmi_ral = create_jtag_dmi_reg_block("jtag_dmi_ral",
+                                             m_jtag_agent_cfg,
+                                             m_jtag_dtm_ral.dmi,
+                                             m_jtag_dtm_ral.dtmcs);
 
     // Fix the reset values of these fields based on our design.
     `uvm_info(`gfn, "Fixing reset values in jtag_dmi_ral", UVM_LOW)

--- a/hw/top_darjeeling/dv/env/chip_env_cfg.sv
+++ b/hw/top_darjeeling/dv/env/chip_env_cfg.sv
@@ -76,6 +76,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   rand spi_agent_cfg        m_spi_device_agent_cfgs[NUM_SPI_HOSTS];
   rand jtag_riscv_agent_cfg m_jtag_riscv_agent_cfg;
   rand jtag_agent_cfg       m_jtag_agent_cfg;
+  rand jtag_dtm_reg_block   m_jtag_dtm_ral;
   rand spi_agent_cfg        m_spi_host_agent_cfg;
   rand i2c_agent_cfg        m_i2c_agent_cfgs[NUM_I2CS];
 
@@ -241,15 +242,20 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     m_jtag_agent_cfg.is_active = 1'b1;
     m_jtag_agent_cfg.ir_len = JTAG_IR_LEN;
 
-    // Set the 'correct' IDCODE register value to the JTAG DTM RAL.
-    m_jtag_agent_cfg.jtag_dtm_ral.idcode.set_reset(RV_DM_JTAG_IDCODE);
+    // Create a JTAG DTM RAL and give it the right IDCODE register value.
+    m_jtag_dtm_ral = create_jtag_dtm_reg_block("m_jtag_dtm_ral");
+    m_jtag_dtm_ral.idcode.set_reset(RV_DM_JTAG_IDCODE);
+
     m_jtag_riscv_agent_cfg.m_jtag_agent_cfg = m_jtag_agent_cfg;
 
     // Create the DMI register block. Because use_jtag_dmi was false at the start of the function,
     // we know it is currently null.
     if (jtag_dmi_ral != null) `uvm_fatal(`gfn, "jtag_dmi_ral unexpectedly set")
 
-    jtag_dmi_ral = create_jtag_dmi_reg_block(m_jtag_riscv_agent_cfg.m_jtag_agent_cfg);
+    jtag_dmi_ral = create_jtag_dmi_reg_block("jtag_dmi_ral",
+                                             m_jtag_agent_cfg,
+                                             m_jtag_dtm_ral.dmi,
+                                             m_jtag_dtm_ral.dtmcs);
 
     // Fix the reset values of these fields based on our design.
     `uvm_info(`gfn, "Fixing reset values in jtag_dmi_ral", UVM_LOW)

--- a/hw/top_darjeeling/dv/env/chip_scoreboard.sv
+++ b/hw/top_darjeeling/dv/env/chip_scoreboard.sv
@@ -67,6 +67,13 @@ class chip_scoreboard #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_b
 
   virtual function void reset(string kind = "HARD");
     super.reset(kind);
+
+    // If there is a JTAG DTM register model (created by calling cfg.set_use_jtag_dmi) then reset
+    // its values to match the reset event.
+    if (cfg.m_jtag_dtm_ral != null) begin
+      cfg.m_jtag_dtm_ral.reset(kind);
+    end
+
     // reset local fifos queues and variables
   endfunction
 

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -166,6 +166,12 @@ class chip_env extends cip_base_env #(
       virtual_sequencer.jtag_sequencer_h = m_jtag_riscv_agent.sequencer;
     end
 
+    // If we are using JTAG DMI, cfg.m_jtag_dtm_ral will have been constructed (when the build_phase
+    // for the test called cfg.set_use_jtag_dmi). If not, it will be null.
+    if (cfg.m_jtag_dtm_ral != null) begin
+      m_jtag_riscv_agent.set_dtm_reg_map(cfg.m_jtag_dtm_ral.get_default_map());
+    end
+
     if (cfg.is_active && cfg.m_spi_host_agent_cfg.is_active) begin
       virtual_sequencer.spi_host_sequencer_h = m_spi_host_agent.sequencer;
     end

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -152,6 +152,12 @@ class chip_env extends cip_base_env #(
       virtual_sequencer.jtag_sequencer_h = m_jtag_riscv_agent.sequencer;
     end
 
+    // If we are using JTAG DMI, cfg.m_jtag_dtm_ral will have been constructed (when the build_phase
+    // for the test called cfg.set_use_jtag_dmi). If not, it will be null.
+    if (cfg.m_jtag_dtm_ral != null) begin
+      m_jtag_riscv_agent.set_dtm_reg_map(cfg.m_jtag_dtm_ral.get_default_map());
+    end
+
     if (cfg.is_active && cfg.m_spi_host_agent_cfg.is_active) begin
       virtual_sequencer.spi_host_sequencer_h = m_spi_host_agent.sequencer;
     end

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -83,6 +83,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   rand spi_agent_cfg        m_spi_device_agent_cfgs[NUM_SPI_HOSTS];
   rand jtag_riscv_agent_cfg m_jtag_riscv_agent_cfg;
   rand jtag_agent_cfg       m_jtag_agent_cfg;
+  rand jtag_dtm_reg_block   m_jtag_dtm_ral;
   rand spi_agent_cfg        m_spi_host_agent_cfg;
   pwm_monitor_cfg           m_pwm_monitor_cfg[NUM_PWM_CHANNELS];
   rand i2c_agent_cfg        m_i2c_agent_cfgs[NUM_I2CS];
@@ -247,15 +248,20 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     m_jtag_agent_cfg.is_active = 1'b1;
     m_jtag_agent_cfg.ir_len = JTAG_IR_LEN;
 
-    // Set the 'correct' IDCODE register value to the JTAG DTM RAL.
-    m_jtag_agent_cfg.jtag_dtm_ral.idcode.set_reset(RV_DM_JTAG_IDCODE);
+    // Create a JTAG DTM RAL and give it the right IDCODE register value.
+    m_jtag_dtm_ral = create_jtag_dtm_reg_block("m_jtag_dtm_ral");
+    m_jtag_dtm_ral.idcode.set_reset(RV_DM_JTAG_IDCODE);
+
     m_jtag_riscv_agent_cfg.m_jtag_agent_cfg = m_jtag_agent_cfg;
 
     // Create the DMI register block. Because use_jtag_dmi was false at the start of the function,
     // we know it is currently null.
     if (jtag_dmi_ral != null) `uvm_fatal(`gfn, "jtag_dmi_ral unexpectedly set")
 
-    jtag_dmi_ral = create_jtag_dmi_reg_block(m_jtag_riscv_agent_cfg.m_jtag_agent_cfg);
+    jtag_dmi_ral = create_jtag_dmi_reg_block("jtag_dmi_ral",
+                                             m_jtag_agent_cfg,
+                                             m_jtag_dtm_ral.dmi,
+                                             m_jtag_dtm_ral.dtmcs);
 
     // Fix the reset values of these fields based on our design.
     `uvm_info(`gfn, "Fixing reset values in jtag_dmi_ral", UVM_LOW)

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -80,6 +80,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   rand spi_agent_cfg        m_spi_device_agent_cfgs[NUM_SPI_HOSTS];
   rand jtag_riscv_agent_cfg m_jtag_riscv_agent_cfg;
   rand jtag_agent_cfg       m_jtag_agent_cfg;
+  rand jtag_dtm_reg_block   m_jtag_dtm_ral;
   rand spi_agent_cfg        m_spi_host_agent_cfg;
   rand i2c_agent_cfg        m_i2c_agent_cfgs[NUM_I2CS];
 
@@ -232,15 +233,20 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     m_jtag_agent_cfg.is_active = 1'b1;
     m_jtag_agent_cfg.ir_len = JTAG_IR_LEN;
 
-    // Set the 'correct' IDCODE register value to the JTAG DTM RAL.
-    m_jtag_agent_cfg.jtag_dtm_ral.idcode.set_reset(RV_DM_JTAG_IDCODE);
+    // Create a JTAG DTM RAL and give it the right IDCODE register value.
+    m_jtag_dtm_ral = create_jtag_dtm_reg_block("m_jtag_dtm_ral");
+    m_jtag_dtm_ral.idcode.set_reset(RV_DM_JTAG_IDCODE);
+
     m_jtag_riscv_agent_cfg.m_jtag_agent_cfg = m_jtag_agent_cfg;
 
     // Create the DMI register block. Because use_jtag_dmi was false at the start of the function,
     // we know it is currently null.
     if (jtag_dmi_ral != null) `uvm_fatal(`gfn, "jtag_dmi_ral unexpectedly set")
 
-    jtag_dmi_ral = create_jtag_dmi_reg_block(m_jtag_riscv_agent_cfg.m_jtag_agent_cfg);
+    jtag_dmi_ral = create_jtag_dmi_reg_block("jtag_dmi_ral",
+                                             m_jtag_agent_cfg,
+                                             m_jtag_dtm_ral.dmi,
+                                             m_jtag_dtm_ral.dtmcs);
 
     // Fix the reset values of these fields based on our design.
     `uvm_info(`gfn, "Fixing reset values in jtag_dmi_ral", UVM_LOW)

--- a/hw/top_earlgrey/dv/env/chip_scoreboard.sv
+++ b/hw/top_earlgrey/dv/env/chip_scoreboard.sv
@@ -67,6 +67,13 @@ class chip_scoreboard #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_b
 
   virtual function void reset(string kind = "HARD");
     super.reset(kind);
+
+    // If there is a JTAG DTM register model (created by calling cfg.set_use_jtag_dmi) then reset
+    // its values to match the reset event.
+    if (cfg.m_jtag_dtm_ral != null) begin
+      cfg.m_jtag_dtm_ral.reset(kind);
+    end
+
     // reset local fifos queues and variables
   endfunction
 


### PR DESCRIPTION
*This PR was once a big draft, but its dependencies are now merged*

This probably wasn't really in the right place (if an agent is more like a "pipe" than an "endpoint"). The change in this commit moves the register model to live in the environment instead.

The work was actually prompted by trying to allow vertical reuse, where an IP block's environment gets bound into the chip-level environment. Splitting things up like this should make it perfectly ok to have two JTAG agents (one for the IP environment and one for the chip environment), only one of which is active.