### PR TITLE
[dv] Pass is_active from cip_base_env_cfg to alert and TL agents

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -137,7 +137,8 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
       string ral_name = ral_model_names[i];
 
       m_tl_agent_cfgs[ral_name] = tl_agent_cfg::type_id::create({"m_tl_agent_cfg_", ral_name});
-      m_tl_agent_cfgs[ral_name].if_mode = dv_utils_pkg::Host;
+      m_tl_agent_cfgs[ral_name].is_active = is_active;
+      m_tl_agent_cfgs[ral_name].if_mode = (is_active ? dv_utils_pkg::Host : dv_utils_pkg::Monitor);
       // TL host cannot support device same cycle response. Host may drive d_ready=0 when a_valid=1.
       m_tl_agent_cfgs[ral_name].host_can_stall_rsp_when_a_valid_high = $urandom_range(0, 1);
 
@@ -161,11 +162,13 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
         string alert_name = list_of_alerts[i];
         m_alert_agent_cfgs[alert_name] = alert_esc_agent_cfg::type_id::create(
             $sformatf("m_alert_agent_cfgs[%s]", alert_name));
-        `DV_CHECK_RANDOMIZE_FATAL(m_alert_agent_cfgs[alert_name])
-        m_alert_agent_cfgs[alert_name].if_mode = dv_utils_pkg::Device;
+        m_alert_agent_cfgs[alert_name].is_active = is_active;
+        m_alert_agent_cfgs[alert_name].if_mode = (is_active ?
+                                                  dv_utils_pkg::Device : dv_utils_pkg::Monitor);
         m_alert_agent_cfgs[alert_name].is_async = 1; // default async_on, can override this
         m_alert_agent_cfgs[alert_name].en_ping_cov = 0;
         m_alert_agent_cfgs[alert_name].en_lpg_cov = 0;
+        `DV_CHECK_RANDOMIZE_FATAL(m_alert_agent_cfgs[alert_name])
       end
     end
 


### PR DESCRIPTION
This means that an environment with is_active=0 will create alert_esc_agents and tl_agents that are also passive.

This is (yet another) change needed by the work I was doing to have an embedded passive block-level environment.