### PR TITLE
[tlul,assert] Fix hierarchical path in uvm_config_db

### DIFF
--- a/hw/ip/tlul/rtl/tlul_assert.sv
+++ b/hw/ip/tlul/rtl/tlul_assert.sv
@@ -425,10 +425,11 @@ module tlul_assert #(
 
   `ifdef UVM
     initial forever begin
+      automatic string hier_path = $sformatf("%m");
       bit tlul_assert_en;
-      uvm_config_db#(bit)::wait_modified(null, "%m", "tlul_assert_en");
-      if (!uvm_config_db#(bit)::get(null, "%m", "tlul_assert_en", tlul_assert_en)) begin
-        `uvm_fatal($sformatf("%m"), "Can't find tlul_assert_en")
+      uvm_config_db#(bit)::wait_modified(null, hier_path, "tlul_assert_en");
+      if (!uvm_config_db#(bit)::get(null, hier_path, "tlul_assert_en", tlul_assert_en)) begin
+        `uvm_fatal(hier_path, "Can't find tlul_assert_en")
       end
       disable_sva = !tlul_assert_en;
     end


### PR DESCRIPTION
Fix the path for items in the uvm_config_db: before this change, the path was actually the string "%m".

Practically speaking, this didn't really matter: the config_db connection hasn't actually been used yet. (But I noticed the percent signs in a log file when I was looking for something else)