### PR TITLE
[sram_ctrl,dv] Teach scoreboard about some injected faults

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.core
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.core
@@ -16,6 +16,7 @@ filesets:
       - sram_ctrl_env_pkg.sv
       - sram_ctrl_lc_if.sv
       - sram_ctrl_exec_if.sv
+      - sram_ctrl_fault_if.sv
       - sram_ctrl_env_cfg.sv: {is_include_file: true}
       - sram_ctrl_env_cov.sv: {is_include_file: true}
       - sram_ctrl_virtual_sequencer.sv: {is_include_file: true}

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.sv
@@ -41,6 +41,12 @@ class sram_ctrl_env #(parameter int AddrWidth = 10) extends cip_base_env #(
       `uvm_fatal(`gfn, "failed to get sram_ctrl_bkdr_util from uvm_config_db")
     end
 
+    // Get the fault injection interface
+    if (!uvm_config_db#(virtual sram_ctrl_fault_if)::get(this, "",
+                                                         "fault_vif", cfg.fault_vif)) begin
+      `uvm_fatal(get_full_name(), "Failed to get fault_vif from uvm_config_db")
+    end
+
     // Build the KDI agent
     m_kdi_agent = push_pull_agent#(.DeviceDataWidth(KDI_DATA_SIZE))::type_id
       ::create("m_kdi_agent", this);

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
@@ -30,6 +30,7 @@ class sram_ctrl_env_cfg #(parameter int AddrWidth = 10)
   virtual sram_ctrl_lc_if lc_vif;
   virtual sram_ctrl_exec_if exec_vif;
   sram_ctrl_bkdr_util sram_ctrl_bkdr_util_h;
+  virtual sram_ctrl_fault_if fault_vif;
 
   // Store the scb handle for seq. When seq initializes the mem, we should initialize mem_model in
   // scb as well.

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_fault_if.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_fault_if.sv
@@ -1,0 +1,78 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// An interface that can be bound into sram_ctrl in order to cleanly detect injected faults.
+//
+// To avoid needing to parameterise the interface, this uses a "max footprint" approach, with
+// sram_addr and sram_wdata using 64 bits each, rather than AddrWidth and DataWidth.
+
+interface sram_ctrl_fault_if (
+  input wire        clk_i,
+  input wire        rst_ni,
+
+  input wire        sram_req,
+  input wire        sram_we,
+  input wire [63:0] sram_addr,
+  input wire [63:0] sram_wdata
+);
+  import uvm_pkg::*;
+
+  // Wait until the negedge of the clock on a cycle where an SRAM read or write (depending on the
+  // write flag) is in progress.
+  //
+  // Exits early on reset
+  task automatic wait_one_operation(bit write);
+    fork : isolation_fork begin
+      fork
+        wait(!rst_ni);
+        @(negedge clk_i iff (write ? sram_we : sram_req));
+      join_any
+      disable fork;
+    end join
+  endtask
+
+`define WAIT_FOR_FORCED_SIGNAL(signal, qualifier)                                               \
+    fork : isolation_fork begin                                                                 \
+      fork                                                                                      \
+        wait(!rst_ni);                                                                          \
+        forever begin                                                                           \
+          // Wait to see a change to signal when qualifier is true. Next, wait a tiny time (to  \
+          // avoid races at the posedge) and then check whether clk_i is high. If not, we saw a \
+          // change to sram_we that was not on a posedge of the clock.                          \
+          @((signal) iff (qualifier));                                                          \
+          #1ps;                                                                                 \
+          if (!clk_i) break;                                                                    \
+        end                                                                                     \
+      join_any                                                                                  \
+      disable fork;                                                                             \
+    end join
+
+  // Wait for a change to sram_we when sram_req is true that happens at a time other than a positive
+  // edge of the clock (and therefore must have been caused by forcing a signal).
+  //
+  // Exits early on reset
+  task automatic wait_for_sram_we_corruption();
+    `WAIT_FOR_FORCED_SIGNAL(sram_we, sram_req)
+  endtask
+
+  // Wait for a change to sram_wdata when sram_req and sram_wdata are true that happens at a time
+  // other than a positive edge of the clock (and therefore must have been caused by forcing a
+  // signal).
+  //
+  // Exits early on reset
+  task automatic wait_for_sram_wdata_corruption();
+    `WAIT_FOR_FORCED_SIGNAL(sram_wdata, sram_req && sram_we)
+  endtask
+
+  // Wait for a change to sram_addr when sram_req is true that happens at a time other than a
+  // positive edge of the clock (and therefore must have been caused by forcing a signal).
+  //
+  // Exits early on reset
+  task automatic wait_for_sram_addr_corruption();
+    `WAIT_FOR_FORCED_SIGNAL(sram_addr, sram_req)
+  endtask
+
+`undef WAIT_FOR_FORCED_SIGNAL
+
+endinterface

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -90,6 +90,21 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
 
   bit [TL_AW-1:0] sram_addr_mask = (1 << (AddrWidth + 2)) - 1;
 
+  // Access to the SRAM is gated by an instance of tlul_lc_gate and we might not know the precise
+  // time that the gate closes after an error.
+  //
+  // To allow for this, we have "Open" (value 0), "Closed" (value 1) and "Closing" states. These are
+  // intended to model whether a TL response we see now is expected to have been caught by the gate
+  // (and thus report an error).
+  //
+  // Opening the gate is instant. An observed injected error moves the gate to "Closing" (some value
+  // greater than 1). If a TL response is seen when the gate is closed, we predict an error. After
+  // any TL response when the counter is greater than one, we decrement the counter towards
+  // "Closed".
+  //
+  // On a reset (including the start of the simulation), the counter is set to zero ("Open").
+  int unsigned m_gate_counter;
+
   // Only LSB is used in the sram, the other MSB bits will be ignored. Use the simplified
   // address for mem_bkdr_scb
   function bit [TL_AW-1:0] simplify_addr(bit [TL_AW-1:0] addr);
@@ -155,11 +170,28 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
     end
     if (status_lc_esc == EscFinal) is_tl_err |= 1;
 
-    if (channel == DataChannel && is_tl_err) begin
-      `DV_CHECK_EQ(item.d_error, 1,
-          $sformatf({"item_err: %0d, allow_ifetch : %0d, sram_ifetch: %0d, exec: %0d, ",
-                     "debug_en: %0d, lc_esc %0d"},
-                    is_tl_err, allow_ifetch, sram_ifetch, csr_exec, hw_debug_en, status_lc_esc))
+    // The position of the LC gate might affect the possible values of d_error.
+    //
+    //  - If it is open (m_gate_counter == 0), it will not affect any other errors.
+    //  - If it is closed (m_gate_counter == 1), an error is expected.
+    //  - In any other situation, an error is *possible*
+    //
+    // For that last case, update the prediction to match the observed d_error value if an error has
+    // been seen that we wouldn't predict otherwise.
+    if (channel == DataChannel) begin
+      if (m_gate_counter == 1) begin
+        is_tl_err = 1;
+      end else if (m_gate_counter > 1) begin
+        is_tl_err |= item.d_error;
+      end
+
+      if (is_tl_err) begin
+        `DV_CHECK_EQ(item.d_error, 1,
+                     $sformatf({"item_err: %0d, allow_ifetch : %0d, sram_ifetch: %0d, exec: %0d, ",
+                                "debug_en: %0d, lc_esc %0d"},
+                               is_tl_err, allow_ifetch, sram_ifetch,
+                               csr_exec, hw_debug_en, status_lc_esc))
+      end
     end
 
     return is_tl_err;
@@ -209,6 +241,7 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
       `RUN_FOREVR_W_RESET_EXIT(process_lc_escalation)
       process_kdi_fifo();
       `RUN_FOREVR_W_RESET_EXIT(process_write_done_and_check)
+      start_gate_closures();
     join_none
   endtask
 
@@ -484,6 +517,16 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
     end
   endtask
 
+  virtual task process_tl_d_item(string ral_name, tl_seq_item item);
+    super.process_tl_d_item(ral_name, item);
+
+    // If this is a D channel response to an access to the memory when the gate counter is closing
+    // (value greater than 1), step it closer to being closed.
+    if (ral_name == cfg.sram_ral_name) begin
+      if (m_gate_counter > 1) m_gate_counter--;
+    end
+  endtask
+
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
     string  csr_name;
@@ -621,6 +664,55 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
     end
   endtask
 
+  // Wait for a change to sram_we, sram_wdata or sram_addr which will have an effect (so sram_req
+  // and any other enable signals are true) but happens at a time other than a posedge of the clock.
+  // This must have been caused by an injected error.
+  //
+  // When this happens, set the gate counter to 3, meaning that the current TL transaction and next
+  // TL transaction *might* have the gate closed, and all future ones must.
+  //
+  // This task is oblivious to resets, but be safely killed at any time.
+  local task start_gate_closures_between_resets();
+    fork : isolation_fork begin
+      fork
+        cfg.fault_vif.wait_for_sram_we_corruption();
+        cfg.fault_vif.wait_for_sram_wdata_corruption();
+        cfg.fault_vif.wait_for_sram_addr_corruption();
+      join_any
+      disable fork;
+    end join
+
+    if (m_gate_counter == 0) begin
+      // Set the gate counter to 3
+      m_gate_counter = 3;
+
+      `uvm_info(get_full_name(),
+                $sformatf("Seen signal corruption when gate open. Setting gate counter to %0d.",
+                          m_gate_counter),
+                UVM_MEDIUM)
+    end
+  endtask
+
+  // This task runs forever and keeps track of observed injected faults on sram_we, sram_wdata and
+  // sram_addr, starting closure of the gate tracked by m_gate_counter when this happens. It will
+  // run start_gate_closures_between_resets in each window between resets.
+  local task start_gate_closures();
+    forever begin
+      wait(!cfg.under_reset);
+
+      fork : isolation_fork begin
+        fork
+          wait(cfg.under_reset);
+          begin
+            start_gate_closures_between_resets();
+            wait(cfg.under_reset);
+          end
+        join_any
+        disable fork;
+      end join
+    end
+  endtask
+
   virtual function void reset_key_nonce();
     key = sram_ctrl_pkg::RndCnstSramKeyDefault;
     nonce = sram_ctrl_pkg::RndCnstSramNonceDefault;
@@ -643,6 +735,9 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
     exp_scr_key_rotated = MuBi4False;
     write_item_q.delete();
     exp_mem[cfg.sram_ral_name].init();
+
+    // Set the gate back to its default "open" state.
+    m_gate_counter = 0;
 
     // Once esc happens, vseq will send enough transaction to make sure d_error occurs
     // so that scb updates to EscFinal

--- a/hw/ip/sram_ctrl/dv/tb.sv
+++ b/hw/ip/sram_ctrl/dv/tb.sv
@@ -109,6 +109,12 @@ module tb;
     .sram_rerror_o                (                           )
   );
 
+  // Bind in an interface that makes some fault injection easier.
+  //
+  // The sram_addr and sram_wdata signals need passing explicitly to avoid a warning from VCS about
+  // the fact that the (max footprint) interface ports don't match the design.
+  bind dut sram_ctrl_fault_if u_fault_if (.sram_addr(sram_addr), .sram_wdata(sram_wdata), .*);
+
   // KDI interface assignments
   assign kdi_if.req         = key_req.req;
   assign key_rsp.ack        = kdi_if.ack;
@@ -151,6 +157,7 @@ module tb;
         null, "*.env.m_tl_agent_sram_ctrl_regs_reg_block*", "vif", tl_if);
     uvm_config_db#(virtual tl_if)::set(
         null, "*.env.m_tl_agent_sram_ctrl_prim_reg_block*", "vif", sram_tl_if);
+    uvm_config_db#(virtual sram_ctrl_fault_if)::set(null, "*.env", "fault_vif", dut.u_fault_if);
     uvm_config_db#(sram_ctrl_bkdr_util)::set(null, "*.env", "sram_ctrl_bkdr_util",
                                              m_sram_ctrl_bkdr_util);
 


### PR DESCRIPTION
The existing testbench fails in mysterious ways if you allow a TL transaction after injecting a fault: a strong indication that the scoreboard has never been used for anything very randomised.

This commit adds another interface to make it a bit easier for the scoreboard to see when faults are injected (we cheat, and define an injected fault as "the signal changes just before the clock is low").

The scoreboard can then use this interface to see the injected faults. In order not to model (copy!) the precise timing for when the local escalation causes the LC gate to close, the scoreboard has a counter and allows a "might or might not be closed" state in the middle.