### PR TITLE
[sram_ctrl,dv] Tweak sram_ctrl_readback_err_vseq

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_readback_err_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_readback_err_vseq.sv
@@ -6,155 +6,201 @@
 class sram_ctrl_readback_err_vseq extends sram_ctrl_base_vseq;
   `uvm_object_utils(sram_ctrl_readback_err_vseq)
 
-  `uvm_object_new
+  // A tuple that describes an FI path.
+  typedef struct {
+    // The HDL path
+    string         path;
+
+    // All paths are relevant for write operations. If usable_for_read is true, it is also relevant
+    // for read operations.
+    bit            usable_for_read;
+
+    // A mask that gives the bits that should be flipped to inject a fault
+    uvm_hdl_data_t mask;
+  } fi_desc_t;
+
+  // If true, the generated memory operations will be writes. If false, they will be reads.
+  rand bit m_target_write;
 
   // Indicates the number of memory accesses to be performed in this test.
-  rand int num_ops;
+  rand int unsigned m_num_ops;
 
   // Indicates at which memory access the fault is injected.
-  rand int do_fi_op;
+  rand int unsigned m_fi_op_idx;
 
-  constraint num_ops_c {
-    num_ops inside {[10 : 200]};
+  // The index of the fi_desc that should be targeted. The targeted descriptor will be copied into
+  // m_targeted_desc in pre_start.
+  rand int unsigned m_targeted_desc_idx;
+
+  // The desc that is being targeted. Copied from m_fi_descs[m_targeted_desc_idx] in pre_start.
+  fi_desc_t m_targeted_desc;
+
+  local fi_desc_t m_fi_descs[$] = '{'{"sram_addr",  1'b1, 2},
+                                    '{"sram_wdata", 1'b0, 2},
+                                    '{"sram_we",    1'b0, 1}};
+
+  // The readback feature raises the fatal_error alert on a mismatch.
+  local string m_alert_signal = "fatal_error";
+
+  constraint m_num_ops_c { m_num_ops == 100; }
+
+  // Inject the fault after between 0 and m_num_ops - 20 tracked operations. The 20 operations at
+  // the end give time for an alert to be raised and seen.
+  constraint m_fi_op_idx_c {
+    m_fi_op_idx inside {[0 : m_num_ops - 20]};
   }
 
-  constraint do_fi_op_c {
-    do_fi_op inside {[10 : num_ops]};
+  // Pick a valid desc index. If m_target_write is false, the selected descriptor must be usable for
+  // reads.
+  constraint valid_desc_c {
+    m_targeted_desc_idx < m_fi_descs.size();
+    if (!m_target_write) { m_fi_descs[m_targeted_desc_idx].usable_for_read; }
   }
 
-  int fi_iteration_position = 0;
+  function new(string name="");
+    super.new(name);
+  endfunction
 
-  task drive_reqs(int iterations, bit write);
-    // Perform random read/write operations.
-    bit [TL_AW-1:0] addr;
+  // Send a single operation, that writes data to addr.
+  local task do_write(bit [TL_AW-1:0] addr, bit [TL_DW-1:0] data);
+    tl_access(.addr(addr), .write(1'b1), .data(data), .check_err_rsp(0), .blocking(1),
+              .tl_sequencer_h(p_sequencer.tl_sequencer_hs[cfg.sram_ral_name]));
+  endtask
+
+  // Send a single operation, that reads from addr.
+  local task do_read(bit [TL_AW-1:0] addr);
+    bit [TL_DW-1:0] _data;
+    tl_access(.addr(addr), .write(1'b0), .data(_data), .check_err_rsp(0), .blocking(1),
+              .tl_sequencer_h(p_sequencer.tl_sequencer_hs[cfg.sram_ral_name]));
+  endtask
+
+  // Pick a random address to use with a read or write operation
+  local function bit [TL_AW-1:0] pick_address();
     bit [TL_AW-1:0] sram_addr_mask = cfg.ral_models[cfg.sram_ral_name].get_addr_mask();
     bit [TL_AW-1:0] max_offset = {sram_addr_mask[TL_AW-1:2], 2'd0};
-    logic [TL_DW-1:0] rdata;
-    for (int iteration = 0; iteration < iterations; iteration++) begin
-        `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(addr, (addr & sram_addr_mask) < max_offset;)
-        if (write) begin
-          do_single_write(.addr(addr), .data(iteration + 1), .mask('1), .blocking(0));
-        end else begin
-          do_single_read(.addr(addr), .mask('1), .check_rdata(0), .blocking(0), .rdata(rdata));
-        end
+    bit [TL_AW-1:0] addr;
+
+    if (!std::randomize(addr) with { (addr & sram_addr_mask) < max_offset; }) begin
+      `uvm_fatal(get_name(), "Failed to randomise address.")
+    end
+
+    return addr;
+  endfunction
+
+  // Send a single random operation (either a read or a write, depending on m_target_write)
+  local task send_one_req(int unsigned iteration);
+    bit [TL_AW-1:0] addr = pick_address();
+
+    if (m_target_write) begin
+      do_write(addr, iteration + 1);
+    end else begin
+      do_read(addr);
     end
   endtask
 
-  task inject_fault(int iterations, int iteration_fi_position, string fi_path,
-                    int fi_mask, string sram_req_path, string sram_we_path,
-                    bit write_op, string alert_signal);
-    // Inject a fault into the signal indicated by fi_path & monitor the response.
-    bit req;
-    int value;
-    int value_faulty;
-    for (int iteration = 0; iteration < iterations; iteration++) begin
-      // Wait until the sram_we (for writes) or the sram_req (for reads) arrives.
-      `DV_SPINWAIT(
-        do begin
-          cfg.clk_rst_vif.wait_n_clks(1);
-          if (write_op) begin
-            `DV_CHECK(uvm_hdl_read(sram_we_path, req))
-          end else begin
-            `DV_CHECK(uvm_hdl_read(sram_req_path, req))
-          end
-        end while(!req);
-      )
+  // Perform m_num_ops operations (either reads or writes, depending on m_target_write), returning
+  // when a reset is asserted.
+  //
+  // If we get to the end without seeing a reset, fail with an error (because we seem not to have
+  // injected the fault)
+  local task send_reqs();
+    for (int unsigned iteration = 0; iteration < m_num_ops; iteration++) begin
+      send_one_req(iteration);
 
-      // Only inject if we reached the selected read/write transaction.
-      if (iteration == iteration_fi_position) begin
-        `uvm_info(`gfn, $sformatf(
-                  "Injecting fault into %s in memory operation %d and check the %s alert",
-                  fi_path, iteration_fi_position, alert_signal),
-                  UVM_LOW)
-        fork
-          begin : inject_fault
-            `DV_CHECK(uvm_hdl_read(fi_path, value))
-            value_faulty = value ^ fi_mask;
-            `DV_CHECK(uvm_hdl_force(fi_path, value_faulty))
-            // Release the faulty signal after one clock cycle.
-            cfg.clk_rst_vif.wait_n_clks(1);
-            `DV_CHECK(uvm_hdl_release(fi_path))
-          end : inject_fault
-          begin : monitor_response
-            // Check if alert_signal was triggered.
-            cfg.scb.set_exp_alert(alert_signal, .is_fatal(1'b1), .max_delay(20));
-            wait_alert_trigger (alert_signal, .max_wait_cycle(20), .wait_complete(0));
-            // Reset to get the DUT out of terminal state.
-            apply_resets_concurrently();
-          end : monitor_response
-        join
-      end
-      cfg.clk_rst_vif.wait_clks(1);
+      // A reset might have been applied. If so, there's no more work to do and we can just return.
+      if (!cfg.clk_rst_vif.rst_n) return;
     end
+
+    // If we get to here, we have successfully driven the requests but haven't seen a reset. That
+    // probably means the fault injector task is still counting requests, so will now wait forever.
+    // Fail immediately.
+    `uvm_error(get_name(), $sformatf("We drove %0d requests and never saw a reset", m_num_ops))
   endtask
 
-  task body();
-    // Define the signal we are targeting to inject a fault. This list covers the
-    // most relevant signals for SRAM read/write requests. The rdata signal for reads
-    // is indirectly covered by the addr as a faulty address triggers the same behavior
-    // as a faulted rdata.
-    string fi_paths[3] = {"tb.dut.sram_addr", "tb.dut.sram_wdata", "tb.dut.sram_we"};
-    int fi_masks[3] = {2, 2, 1};
-    // These variables hold the randomly selected target signal.
-    string fi_path;
-    int fi_mask;
-    // Used to keep track of the incoming TL-UL requests.
-    string sram_req_path = "tb.dut.sram_req";
-    // The readback feature raises the fatal_error alert on a mismatch.
-    string alert_signal = "fatal_error";
-    string sram_we_path = "tb.dut.sram_we";
-    // Are we targeting a read or write operation?
-    bit target_write = $urandom_range(0, 1);
+  // Wait past m_fi_op_idx operations (reads or writes, depending on m_target_write) and then inject
+  // a fault on the next, as described in m_targeted_desc. Finally, wait for the alert called
+  // m_alert_signal to be asserted, then apply a reset.
+  local task inject_fault();
+    // Wait until the operation on the requested side with the given position, stopping on the
+    // negedge of the clock in the middle of the operation.
+    `uvm_info(get_name(),
+              $sformatf("Waiting until %0s operation with index %0d",
+                        m_target_write ? "write" : "read",
+                        m_fi_op_idx),
+              UVM_LOW)
+    repeat(1 + m_fi_op_idx) begin
+      cfg.fault_vif.wait_one_operation(m_target_write);
+    end
 
-    // Disable certain checks for FI.
+    `uvm_info(get_name(),
+              $sformatf("Injecting fault into %s, which should trigger the %s alert.",
+                        m_targeted_desc.path, m_alert_signal),
+              UVM_LOW)
+    fork
+      cfg.fault_vif.fault_signal(m_targeted_desc.path, m_targeted_desc.mask);
+      wait_for_alert_then_reset();
+    join
+  endtask
+
+  // Wait m_alert_signal is asserted, which should take at most 20 cycles, then assert a reset,
+  // returning on a posedge of the main clock after it completes.
+  local task wait_for_alert_then_reset();
+    bit saw_reset;
+
+    // Tell the scoreboard that we expect an alert to happen, then wait for it to be asserted.
+    cfg.scb.set_exp_alert(m_alert_signal, .is_fatal(1'b1), .max_delay(20));
+    wait_alert_trigger(m_alert_signal, .max_wait_cycle(20), .wait_complete(0));
+
+    // Apply a reset
+    apply_resets_concurrently();
+
+    // Because the last reset signal to be deasserted might not have been synchronised with the main
+    // clock, wait for the next posedge of that clock.
+    cfg.clk_rst_vif.wait_clks(1);
+  endtask
+
+  function void post_randomize();
+    super.post_randomize();
+
+    // Copy the targeted descriptor into m_targeted_desc
+    m_targeted_desc = m_fi_descs[m_targeted_desc_idx];
+  endfunction
+
+  virtual task body();
+    uvm_status_e status;
+    bit old_is_fi_test = cfg.is_fi_test;
+    bit [2:0] old_check_tl_errs = {cfg.m_tl_agent_cfg.check_tl_errs,
+                                   cfg.m_tl_agent_cfgs["sram_ctrl_regs_reg_block"].check_tl_errs,
+                                   cfg.m_tl_agent_cfgs[cfg.sram_ral_name].check_tl_errs};
+
+
+    // Disable some sram_ctrl checks because this is an FI test. Also, clear the check_tl_errs flag
+    // for the TL agent for the memory: an injected data error might cause an integrity check to
+    // fail in an unpredictable way.
     cfg.is_fi_test = 1'b1;
     cfg.m_tl_agent_cfg.check_tl_errs = 0;
-    cfg.m_tl_agent_cfgs["sram_ctrl_regs_reg_block"].check_tl_errs = 0;
     cfg.m_tl_agent_cfgs["sram_ctrl_prim_reg_block"].check_tl_errs = 0;
-
-    // If we are faulting the sram_we signal, this assertion would trigger. Disable it.
-    $assertoff(0,
-      "tb.dut.u_tlul_adapter_sram_racl.tlul_adapter_sram.u_sram_byte.gen_integ_handling");
-
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_ops)
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(do_fi_op)
+    cfg.m_tl_agent_cfgs[cfg.sram_ral_name].check_tl_errs = 0;
 
     // Request memory init & enable SRAM readback feature.
     req_mem_init();
-    csr_wr(.ptr(ral.readback), .value(MuBi4True));
 
-    // Set the target FI path depending whether we are targeting a write or read.
-    if (target_write) begin
-      // Either target the adress, the write data, or the write enable signal.
-      int idx = $urandom_range(0, 2);
-      fi_path = fi_paths[idx];
-      fi_mask = fi_masks[idx];
-    end else begin
-      // Target the read address.
-      fi_path = fi_paths[0];
-      fi_mask = fi_masks[0];
+    ral.readback.write(status, MuBi4True);
+    if (status != UVM_IS_OK) begin
+      `uvm_error(get_name(), "Failed to enable readback feature")
     end
 
-    // Sanity check some static paths we use in this test.
-    `DV_CHECK(uvm_hdl_check_path(fi_path),
-              $sformatf("Hierarchical path %0s appears to be invalid.", fi_path))
-    `DV_CHECK(uvm_hdl_check_path(sram_req_path),
-              $sformatf("Hierarchical path %0s appears to be invalid.", sram_req_path))
-    `DV_CHECK(uvm_hdl_check_path(sram_we_path),
-              $sformatf("Hierarchical path %0s appears to be invalid.", sram_we_path))
-
-    // As we have at least 10 memory requests, correct the offset.
-    fi_iteration_position = do_fi_op - 10;
-
-    // Start the parallel threads.
+    // Start the parallel threads. One will drive lots of memory requests, and the other will inject
+    // a fault after a few have happened.
     fork
-      // Driver task.
-      drive_reqs(num_ops, target_write);
+      send_reqs();
+      inject_fault();
+    join
 
-      // Fault injector task.
-      inject_fault(num_ops, fi_iteration_position, fi_path, fi_mask, sram_req_path,
-                   sram_we_path, target_write, alert_signal);
-    join_any
+    cfg.m_tl_agent_cfgs[cfg.sram_ral_name].check_tl_errs = old_check_tl_errs[0];
+    cfg.m_tl_agent_cfgs["sram_ctrl_prim_reg_block"].check_tl_errs = old_check_tl_errs[1];
+    cfg.m_tl_agent_cfg.check_tl_errs = old_check_tl_errs[2];
+    cfg.is_fi_test = old_is_fi_test;
   endtask : body
 
 endclass : sram_ctrl_readback_err_vseq

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_fault_if.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_fault_if.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// An interface that can be bound into sram_ctrl in order to cleanly detect injected faults.
+// An interface that can be bound into sram_ctrl in order to inject (and cleanly detect) faults.
 //
 // To avoid needing to parameterise the interface, this uses a "max footprint" approach, with
 // sram_addr and sram_wdata using 64 bits each, rather than AddrWidth and DataWidth.
@@ -17,6 +17,48 @@ interface sram_ctrl_fault_if (
   input wire [63:0] sram_wdata
 );
   import uvm_pkg::*;
+
+  // Inject a fault by flipping fault_bits on the signal at rel_path until we have seen the clock
+  // low, high and then low again (meaning that we straddle a posedge). The path in rel_path is
+  // interpreted relative to the module instance into which this interface is bound.
+  //
+  // Exits early on reset.
+  task automatic fault_signal(string rel_path, uvm_hdl_data_t fault_bits);
+    uvm_hdl_data_t good_value;
+    string full_path;
+
+    full_path = $sformatf("%0s.%0s",
+                         dv_utils_pkg::get_parent_hier($sformatf("%m"), 2),
+                         rel_path);
+
+    if (!uvm_hdl_read(full_path, good_value)) begin
+      `uvm_fatal($sformatf("%m"), {"Failed to read ", full_path})
+    end
+
+    if (!uvm_hdl_force(full_path, good_value ^ fault_bits)) begin
+      `uvm_fatal($sformatf("%m"), {"Failed to force ", full_path})
+    end
+
+    // Wait for the clock to become high and then low again, exiting early on reset
+    fork : isolation_fork begin
+      fork
+        @(negedge clk_i);
+        wait(!rst_ni);
+      join_any
+      disable fork;
+    end join
+
+    // Release the forced signal
+    if (!uvm_hdl_release(full_path)) begin
+      `uvm_fatal($sformatf("%m"), {"Failed to release ", full_path})
+    end
+
+    // Use uvm_hdl_deposit to put back the original good_value (in case the target at full_path
+    // isn't driven by a continuous assignment)
+    if (!uvm_hdl_deposit(full_path, good_value)) begin
+      `uvm_fatal($sformatf("%m"), {"Failed to restore ", full_path})
+    end
+  endtask
 
   // Wait until the negedge of the clock on a cycle where an SRAM read or write (depending on the
   // write flag) is in progress.


### PR DESCRIPTION
This was originally motivated by trying to get the test to pass when
run under Xcelium as well as VCS, but there was some room for tidying
up the test.

Changes in this commit:

  - There are LOTS of comments that explain what is going on.

  - Sequence variables are now randomised in a slightly simpler
    manner (as rand class variables). The only hard bit was picking an
    unpacked config struct. The trick is to pick the index in the
    randomisation and then copy the value at that index in
    post_randomize.

  - We now allow a few extra TL reads after injecting the error. This
    wasn't done in the past. The scoreboard was fixed in the previous
    commit to allow such stimulus.

  - A check for integrity errors in cip_base_scoreboard needs
    disabling.
