### PR TITLE
[crypto] Fix cryptolib build with OT as submodule

### DIFF
--- a/rules/opentitan/static_library.bzl
+++ b/rules/opentitan/static_library.bzl
@@ -54,10 +54,12 @@ def _ot_static_library_impl(ctx):
     lib_paths = [lib.path for lib in libs]
 
     ctx.actions.run_shell(
-        command = "\"{0}\" rcT {1} {2} && echo -e 'create {1}\naddlib {1}\nsave\nend' | \"{0}\" -M".format(
+        command = "ARCHIVER=\"$(pwd)/{0}\" && \"$ARCHIVER\" rcT {1} {2} && cd {3} && echo -e 'create {4}\naddlib {4}\nsave\nend' | \"$ARCHIVER\" -M".format(
             archiver,
             output_lib.path,
             " ".join(lib_paths),
+            output_lib.dirname,
+            output_lib.basename,
         ),
         inputs = libs + cc_toolchain.all_files.to_list(),
         outputs = [output_lib],


### PR DESCRIPTION
While using the OT repository as a bazel module, I get this failure when trying to build cryptolib:

external/lowrisc_opentitan++lowrisc_rv32imcb_toolchain+lowrisc_rv32imcb_toolchain/bin/riscv32-unknown-elf-ar: bazel-out/k8-opt-ST-258efe09af48/bin/external/lowrisc_opentitan: No such file or directory +Syntax error in archive script, line 1

Seems like the archiver has trouble with the '+' that bazel puts in the path.  This patches works around it by building in the output path.