### PR TITLE
[crypto] Integrate config

### DIFF
--- a/sw/device/lib/crypto/drivers/mock_rv_core_ibex.cc
+++ b/sw/device/lib/crypto/drivers/mock_rv_core_ibex.cc
@@ -2,10 +2,24 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/crypto/drivers/rv_core_ibex.h"
+#include "sw/device/lib/crypto/impl/status.h"
 
 namespace test {
 extern "C" {
+
+hardened_bool_t ibex_check_security_config(void) { return kHardenedBoolTrue; }
+
+status_t ibex_set_security_config(void) { return OTCRYPTO_OK; }
+
+status_t ibex_disable_icache(hardened_bool_t *icache_enabled) {
+  return OTCRYPTO_OK;
+}
+
+void ibex_restore_icache(hardened_bool_t icache_enabled) {
+  asm volatile("nop");
+}
 
 // Since this mock library is for tests only, the randomness does not need to be
 // real. https://xkcd.com/221/

--- a/sw/device/lib/crypto/drivers/rv_core_ibex.c
+++ b/sw/device/lib/crypto/drivers/rv_core_ibex.c
@@ -51,6 +51,11 @@ hardened_bool_t ibex_check_security_config(void) {
   return kHardenedBoolTrue;
 }
 
+status_t ibex_set_security_config(void) {
+  CSR_SET_BITS(CSR_REG_CPUCTRL, kExpectedConfig << kIdx);
+  return OTCRYPTO_OK;
+}
+
 /**
  * Blocks until data is ready in the RND register.
  */

--- a/sw/device/lib/crypto/drivers/rv_core_ibex.h
+++ b/sw/device/lib/crypto/drivers/rv_core_ibex.h
@@ -45,6 +45,19 @@ OT_WARN_UNUSED_RESULT
 hardened_bool_t ibex_check_security_config(void);
 
 /**
+ * Enables the expected Ibex Security Features.
+ *
+ * This function enables the following security features in the Ibex cpuctrl
+ * register:
+ * - data_ind_timing
+ * - dummy_instr_en
+ *
+ * @returns Error status.
+ */
+OT_WARN_UNUSED_RESULT
+status_t ibex_set_security_config(void);
+
+/**
  * Get random data from the EDN0 interface.
  *
  * Important: this function will hang if the entropy complex is not

--- a/sw/device/lib/crypto/drivers/rv_core_ibex_test.c
+++ b/sw/device/lib/crypto/drivers/rv_core_ibex_test.c
@@ -6,6 +6,7 @@
 
 #include "sw/device/lib/base/csr.h"
 #include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
@@ -36,7 +37,9 @@ static status_t ibex_security_config_test(void) {
 
   uint32_t original_csr;
   CSR_READ(CSR_REG_CPUCTRL, &original_csr);
-  CSR_SET_BITS(CSR_REG_CPUCTRL, 0x6);
+
+  TRY(ibex_set_security_config());
+
   uint32_t current_csr;
   CSR_READ(CSR_REG_CPUCTRL, &current_csr);
 

--- a/sw/device/lib/crypto/impl/aes_gcm.c
+++ b/sw/device/lib/crypto/impl/aes_gcm.c
@@ -312,10 +312,6 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt(otcrypto_blinded_key_t *key,
   // Check the tag length.
   HARDENED_TRY(aes_gcm_check_tag_length(auth_tag->len, tag_len));
 
-  // Store the iCache state (on or off) and disable it when it is on.
-  hardened_bool_t icache_saved_state;
-  HARDENED_TRY(ibex_disable_icache(&icache_saved_state));
-
   // Construct the AES key.
   aes_key_t aes_key;
   HARDENED_TRY(aes_gcm_key_construct(key, &aes_key));
@@ -327,9 +323,6 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt(otcrypto_blinded_key_t *key,
       aad->data, auth_tag->len, auth_tag->data, ciphertext->data));
 
   HARDENED_TRY(clear_key_if_sideloaded(aes_key));
-
-  // Enable the iCache if it was previously enabled.
-  ibex_restore_icache(icache_saved_state);
 
   // Verify the input buffers
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(plaintext));
@@ -360,10 +353,6 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt(
     return OTCRYPTO_BAD_ARGS;
   }
 
-  // Store the iCache state (on or off) and disable it when it is on.
-  hardened_bool_t icache_saved_state;
-  HARDENED_TRY(ibex_disable_icache(&icache_saved_state));
-
   // Construct the AES key.
   aes_key_t aes_key;
   HARDENED_TRY(aes_gcm_key_construct(key, &aes_key));
@@ -385,9 +374,6 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt(
 
   HARDENED_TRY(clear_key_if_sideloaded(aes_key));
 
-  // Enable the iCache if it was previously enabled.
-  ibex_restore_icache(icache_saved_state);
-
   // Verify the input buffers
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(plaintext));
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(iv));
@@ -405,10 +391,6 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_init(
     return OTCRYPTO_BAD_ARGS;
   }
 
-  // Store the iCache state (on or off) and disable it when it is on.
-  hardened_bool_t icache_saved_state;
-  HARDENED_TRY(ibex_disable_icache(&icache_saved_state));
-
   // Construct the AES key.
   aes_key_t aes_key;
   HARDENED_TRY(aes_gcm_key_construct(key, &aes_key));
@@ -423,9 +405,6 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_init(
   HARDENED_TRY(gcm_context_save(&internal_ctx, ctx));
   HARDENED_TRY(clear_key_if_sideloaded(internal_ctx.key));
 
-  // Enable the iCache if it was previously enabled.
-  ibex_restore_icache(icache_saved_state);
-
   // Verify the input buffer
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(iv));
 
@@ -438,10 +417,6 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt_init(
   if (key == NULL || key->keyblob == NULL || iv->data == NULL || ctx == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
-
-  // Store the iCache state (on or off) and disable it when it is on.
-  hardened_bool_t icache_saved_state;
-  HARDENED_TRY(ibex_disable_icache(&icache_saved_state));
 
   // Construct the AES key.
   aes_key_t aes_key;
@@ -456,9 +431,6 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt_init(
   // Save the context and clear the key if needed.
   HARDENED_TRY(gcm_context_save(&internal_ctx, ctx));
   HARDENED_TRY(clear_key_if_sideloaded(internal_ctx.key));
-
-  // Enable the iCache if it was previously enabled.
-  ibex_restore_icache(icache_saved_state);
 
   // Verify the input buffer
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(iv));
@@ -477,10 +449,6 @@ otcrypto_status_t otcrypto_aes_gcm_update_aad(otcrypto_aes_gcm_context_t *ctx,
     return OTCRYPTO_OK;
   }
 
-  // Store the iCache state (on or off) and disable it when it is on.
-  hardened_bool_t icache_saved_state;
-  HARDENED_TRY(ibex_disable_icache(&icache_saved_state));
-
   // Restore the AES-GCM context object and load the key if needed.
   aes_gcm_context_t internal_ctx;
   HARDENED_TRY(gcm_context_restore(ctx, &internal_ctx));
@@ -492,9 +460,6 @@ otcrypto_status_t otcrypto_aes_gcm_update_aad(otcrypto_aes_gcm_context_t *ctx,
   // Save the context and clear the key if needed.
   HARDENED_TRY(gcm_context_save(&internal_ctx, ctx));
   HARDENED_TRY(clear_key_if_sideloaded(internal_ctx.key));
-
-  // Enable the iCache if it was previously enabled.
-  ibex_restore_icache(icache_saved_state);
 
   // Verify the input buffer
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(aad));
@@ -515,10 +480,6 @@ otcrypto_status_t otcrypto_aes_gcm_update_encrypted_data(
     // Nothing to do.
     return OTCRYPTO_OK;
   }
-
-  // Store the iCache state (on or off) and disable it when it is on.
-  hardened_bool_t icache_saved_state;
-  HARDENED_TRY(ibex_disable_icache(&icache_saved_state));
 
   // Restore the AES-GCM context object and load the key if needed.
   aes_gcm_context_t internal_ctx;
@@ -549,9 +510,6 @@ otcrypto_status_t otcrypto_aes_gcm_update_encrypted_data(
   HARDENED_TRY(gcm_context_save(&internal_ctx, ctx));
   HARDENED_TRY(clear_key_if_sideloaded(internal_ctx.key));
 
-  // Enable the iCache if it was previously enabled.
-  ibex_restore_icache(icache_saved_state);
-
   // Verify the input buffers
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(input));
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(output));
@@ -574,10 +532,6 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_final(
 
   // Randomize the tag before the operation.
   HARDENED_TRY(hardened_memshred(auth_tag->data, auth_tag->len));
-
-  // Store the iCache state (on or off) and disable it when it is on.
-  hardened_bool_t icache_saved_state;
-  HARDENED_TRY(ibex_disable_icache(&icache_saved_state));
 
   // Check the tag length.
   HARDENED_TRY(aes_gcm_check_tag_length(auth_tag->len, tag_len));
@@ -605,9 +559,6 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_final(
   HARDENED_TRY(hardened_memshred(ctx->data, ARRAYSIZE(ctx->data)));
   HARDENED_TRY(clear_key_if_sideloaded(internal_ctx.key));
 
-  // Enable the iCache if it was previously enabled.
-  ibex_restore_icache(icache_saved_state);
-
   // Verify the input buffers
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(ciphertext));
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(auth_tag));
@@ -628,10 +579,6 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt_final(
   }
   *plaintext_bytes_written = 0;
   *success = kHardenedBoolFalse;
-
-  // Store the iCache state (on or off) and disable it when it is on.
-  hardened_bool_t icache_saved_state;
-  HARDENED_TRY(ibex_disable_icache(&icache_saved_state));
 
   // Check the tag length.
   HARDENED_TRY(aes_gcm_check_tag_length(auth_tag->len, tag_len));
@@ -658,9 +605,6 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt_final(
   // Clear the context and the key if needed.
   HARDENED_TRY(hardened_memshred(ctx->data, ARRAYSIZE(ctx->data)));
   HARDENED_TRY(clear_key_if_sideloaded(internal_ctx.key));
-
-  // Enable the iCache if it was previously enabled.
-  ibex_restore_icache(icache_saved_state);
 
   // Verify the input buffers
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(auth_tag));

--- a/sw/device/lib/crypto/impl/config.c
+++ b/sw/device/lib/crypto/impl/config.c
@@ -58,6 +58,16 @@ otcrypto_status_t otcrypto_set_security_config(
   return OTCRYPTO_OK;
 }
 
+otcrypto_status_t otcrypto_disable_icache(hardened_bool_t *icache_enabled) {
+  HARDENED_TRY(ibex_disable_icache(icache_enabled));
+  return OTCRYPTO_OK;
+}
+
+otcrypto_status_t otcrypto_restore_icache(hardened_bool_t icache_enabled) {
+  ibex_restore_icache(icache_enabled);
+  return OTCRYPTO_OK;
+}
+
 otcrypto_status_t otcrypto_init(otcrypto_key_security_level_t security_level) {
   HARDENED_TRY(otcrypto_set_security_config(security_level));
 

--- a/sw/device/lib/crypto/impl/config.c
+++ b/sw/device/lib/crypto/impl/config.c
@@ -39,8 +39,27 @@ otcrypto_status_t otcrypto_security_config_check(
   return OTCRYPTO_OK;
 }
 
+otcrypto_status_t otcrypto_set_security_config(
+    otcrypto_key_security_level_t security_level) {
+#if defined(OPENTITAN_IS_EARLGREY)
+  if (launder32(security_level) != kOtcryptoKeySecurityLevelLow) {
+    // Enable the jittery clock in OpenTitan Earlgrey.
+    abs_mmio_write32(
+        TOP_EARLGREY_CLKMGR_AON_BASE_ADDR + CLKMGR_JITTER_ENABLE_REG_OFFSET,
+        kMultiBitBool4True);
+
+    // Enable the dummy instructions and the data independent timing in ibex.
+    HARDENED_TRY(ibex_set_security_config());
+  } else {
+    // Do not check the device config when security level is low.
+    HARDENED_CHECK_EQ(security_level, kOtcryptoKeySecurityLevelLow);
+  }
+#endif
+  return OTCRYPTO_OK;
+}
+
 otcrypto_status_t otcrypto_init(otcrypto_key_security_level_t security_level) {
-  (void)security_level;
+  HARDENED_TRY(otcrypto_set_security_config(security_level));
 
   HARDENED_TRY(init_alert_registers());
 

--- a/sw/device/lib/crypto/include/config.h
+++ b/sw/device/lib/crypto/include/config.h
@@ -34,7 +34,7 @@ otcrypto_status_t otcrypto_security_config_check(
  * and the data independent timing. On low security level, leaves the chip as it
  * is.
  *
- * This function writes to Ibex registers.
+ * This function writes to Ibex registers. Hence, it is only usable in M mode.
  *
  * @param security_level Security level of the used key.
  * @returns OK when the configuration is correctly set.
@@ -42,6 +42,33 @@ otcrypto_status_t otcrypto_security_config_check(
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_set_security_config(
     otcrypto_key_security_level_t security_level);
+
+/**
+ * Disable the Ibex Instruction Cache if it is enabled.
+ *
+ * Reads out the current state of the instruction cache. If it is enabled,
+ * disable it for the crypto lib.
+ * It is only usable in M mode.
+ *
+ * @param[out] icache_enabled kHardenedBoolTrue if the iCache was enabled before
+ * we disabled it.
+ * @return Error status.
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_disable_icache(hardened_bool_t *icache_enabled);
+
+/**
+ * Enables the Ibex Instruction Cache if icache_enabled is set.
+ *
+ * If icache_enabled == kHardenedBoolTrue, this function enables the iCache by
+ * writing to CPUCTRL.
+ * It is only usable in M mode.
+ *
+ * @param icache_enabled kHardenedBoolTrue to enable the iCache.
+ * @return Error status.
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_restore_icache(hardened_bool_t icache_enabled);
 
 /**
  * Initializes the crypto library for use.
@@ -52,6 +79,7 @@ otcrypto_status_t otcrypto_set_security_config(
  * Set up the entropy source
  *
  * This function writes to alert manager and Ibex registers.
+ * It is only usable in M mode.
  *
  * @param security_level Security level of the used key.
  * @returns OK when the security check passed.

--- a/sw/device/lib/crypto/include/config.h
+++ b/sw/device/lib/crypto/include/config.h
@@ -28,12 +28,30 @@ otcrypto_status_t otcrypto_security_config_check(
     otcrypto_key_security_level_t security_level);
 
 /**
+ * Set the chip in a secure configuration state.
+ *
+ * On non-low security level, enables the jittery clock, the dummy instructions,
+ * and the data independent timing. On low security level, leaves the chip as it
+ * is.
+ *
+ * This function writes to Ibex registers.
+ *
+ * @param security_level Security level of the used key.
+ * @returns OK when the configuration is correctly set.
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_set_security_config(
+    otcrypto_key_security_level_t security_level);
+
+/**
  * Initializes the crypto library for use.
  *
  * Check the security configuration
  * Set up alert management
  * Perform (some) KATs for FIPS
  * Set up the entropy source
+ *
+ * This function writes to alert manager and Ibex registers.
  *
  * @param security_level Security level of the used key.
  * @returns OK when the security check passed.

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -78,6 +78,7 @@ opentitan_test(
     ),
     deps = [
         ":aes_testvectors",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -92,6 +93,7 @@ opentitan_test(
         timeout = "long",
     ),
     deps = [
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl/aes_kwp",
         "//sw/device/lib/runtime:log",
@@ -108,6 +110,7 @@ opentitan_test(
     ),
     deps = [
         "//sw/device/lib/crypto/impl:aes",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/crypto/impl:key_transport",
@@ -125,6 +128,7 @@ opentitan_test(
     ),
     deps = [
         "//sw/device/lib/crypto/impl:aes",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/crypto/impl:key_transport",
@@ -145,6 +149,7 @@ opentitan_test(
         "//sw/device/lib/crypto/drivers:aes",
         "//sw/device/lib/crypto/drivers:keymgr",
         "//sw/device/lib/crypto/impl:aes",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:key_transport",
         "//sw/device/lib/runtime:log",
@@ -175,6 +180,7 @@ opentitan_test(
         ":aes_gcm_testutils",
         ":aes_gcm_testvectors",
         "//sw/device/lib/crypto/impl:aes_gcm",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/crypto/impl:status",
@@ -280,6 +286,7 @@ opentitan_test(
         timeout = "eternal",
     ),
     deps = [
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:drbg",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:integrity",
@@ -299,10 +306,11 @@ opentitan_test(
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:ecc_p256",
+        "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/include:datatypes",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
@@ -315,13 +323,14 @@ opentitan_test(
         timeout = "long",
     ),
     deps = [
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:ecc_p256",
+        "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/crypto/impl:keyblob",
         "//sw/device/lib/crypto/impl:sha2",
         "//sw/device/lib/crypto/impl/ecc:p256",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
@@ -335,12 +344,13 @@ opentitan_test(
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:ecc_p256",
+        "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:keyblob",
         "//sw/device/lib/crypto/impl:sha2",
         "//sw/device/lib/crypto/include:datatypes",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
@@ -354,6 +364,7 @@ opentitan_test(
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:drbg",
         "//sw/device/lib/crypto/impl:ecc_p256",
         "//sw/device/lib/crypto/impl:entropy_src",
@@ -361,7 +372,6 @@ opentitan_test(
         "//sw/device/lib/crypto/impl:sha2",
         "//sw/device/lib/crypto/include:datatypes",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
@@ -375,10 +385,11 @@ opentitan_test(
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:ecc_p384",
+        "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/include:datatypes",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
@@ -391,13 +402,14 @@ opentitan_test(
         timeout = "long",
     ),
     deps = [
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:ecc_p384",
+        "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/crypto/impl:keyblob",
         "//sw/device/lib/crypto/impl:sha2",
         "//sw/device/lib/crypto/impl/ecc:p384",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
@@ -411,11 +423,12 @@ opentitan_test(
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:ecc_p384",
+        "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:keyblob",
         "//sw/device/lib/crypto/include:datatypes",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
@@ -448,9 +461,10 @@ opentitan_test(
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:ecc_p256",
+        "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
@@ -467,9 +481,10 @@ opentitan_test(
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:ecc_p384",
+        "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
@@ -486,11 +501,11 @@ opentitan_test(
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:ecc_p256",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:key_transport",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing:keymgr_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
@@ -508,12 +523,12 @@ opentitan_test(
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:ecc_p384",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/crypto/impl:key_transport",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing:keymgr_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
@@ -528,12 +543,13 @@ opentitan_test(
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:ecc_p256",
+        "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:keyblob",
         "//sw/device/lib/crypto/impl:sha2",
         "//sw/device/lib/crypto/include:datatypes",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
@@ -550,12 +566,13 @@ opentitan_test(
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:ecc_p384",
+        "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:keyblob",
         "//sw/device/lib/crypto/impl:sha2",
         "//sw/device/lib/crypto/include:datatypes",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
@@ -573,6 +590,7 @@ opentitan_test(
     deps = [
         "//sw/device/lib/crypto/drivers:keymgr",
         "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:ecc_p256",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:integrity",
@@ -597,6 +615,7 @@ opentitan_test(
     deps = [
         "//sw/device/lib/crypto/drivers:keymgr",
         "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:ecc_p384",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:key_transport",
@@ -627,6 +646,7 @@ opentitan_test(
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:ecc_curve25519",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:integrity",
@@ -668,6 +688,7 @@ opentitan_test(
         ":kmac_testvectors_hardcoded_header",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/crypto/drivers:kmac",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/crypto/impl:kmac",
@@ -688,6 +709,7 @@ opentitan_test(
         tags = ["manual"],
     ),
     deps = [
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:kdf_ctr",
         "//sw/device/lib/crypto/impl:keyblob",
@@ -709,6 +731,7 @@ opentitan_test(
         ":kdf_testvectors_random_header",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/crypto/drivers:kmac",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:key_transport",
         "//sw/device/lib/crypto/impl:kmac",
@@ -729,6 +752,7 @@ opentitan_test(
     deps = [
         ":hmac_testvectors_random_header",
         "//sw/device/lib/base:macros",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:hmac",
         "//sw/device/lib/crypto/impl:sha2",
@@ -750,6 +774,7 @@ opentitan_test(
     deps = [
         ":hmac_testvectors_random_header",
         "//sw/device/lib/base:macros",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:hmac",
         "//sw/device/lib/crypto/impl:sha2",
         "//sw/device/lib/testing:rand_testutils",
@@ -766,7 +791,7 @@ opentitan_test(
         timeout = "long",
     ),
     deps = [
-        "//sw/device/lib/crypto/impl:entropy_src",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:kats",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -783,6 +808,7 @@ opentitan_test(
     deps = [
         "//sw/device/lib/base:macros",
         "//sw/device/lib/crypto/drivers:kmac",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:key_transport",
         "//sw/device/lib/crypto/impl:kmac_kdf",
@@ -805,6 +831,7 @@ opentitan_test(
     deps = [
         "//sw/device/lib/base:macros",
         "//sw/device/lib/crypto/drivers:kmac",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/crypto/impl:kmac",
@@ -827,6 +854,7 @@ opentitan_test(
     deps = [
         ":ecdsa_p256_verify_testvectors_hardcoded_header",
         "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/crypto/impl:sha2",
@@ -847,6 +875,7 @@ opentitan_test(
         tags = ["manual"],
     ),
     deps = [
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:rsa",
         "//sw/device/lib/crypto/impl:sha2",
@@ -867,6 +896,7 @@ opentitan_test(
         tags = ["manual"],
     ),
     deps = [
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:rsa",
         "//sw/device/lib/crypto/impl:sha2",
@@ -887,6 +917,7 @@ opentitan_test(
         tags = ["manual"],
     ),
     deps = [
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:rsa",
         "//sw/device/lib/crypto/impl:sha2",
@@ -907,6 +938,7 @@ opentitan_test(
         tags = ["manual"],
     ),
     deps = [
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:rsa",
         "//sw/device/lib/crypto/impl:sha2",
@@ -933,13 +965,13 @@ opentitan_test(
         tags = ["manual"],
     ),
     deps = [
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/crypto/impl:rsa",
         "//sw/device/lib/crypto/impl:sha2",
         "//sw/device/lib/crypto/impl/rsa:rsa_datatypes",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing:profile",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
@@ -956,6 +988,7 @@ opentitan_test(
         tags = ["manual"],
     ),
     deps = [
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/crypto/impl:rsa",
@@ -984,13 +1017,13 @@ opentitan_test(
         tags = ["manual"],
     ),
     deps = [
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/crypto/impl:rsa",
         "//sw/device/lib/crypto/impl:sha2",
         "//sw/device/lib/crypto/impl/rsa:rsa_datatypes",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing:profile",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
@@ -1005,6 +1038,7 @@ opentitan_test(
         tags = ["manual"],
     ),
     deps = [
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/crypto/impl:rsa",
@@ -1033,13 +1067,13 @@ opentitan_test(
         tags = ["manual"],
     ),
     deps = [
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/crypto/impl:rsa",
         "//sw/device/lib/crypto/impl:sha2",
         "//sw/device/lib/crypto/impl/rsa:rsa_datatypes",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing:profile",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
@@ -1054,6 +1088,7 @@ opentitan_test(
         tags = ["manual"],
     ),
     deps = [
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/crypto/impl:rsa",
@@ -1073,6 +1108,7 @@ opentitan_test(
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:entropy",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/crypto/impl:sha2",
@@ -1090,6 +1126,7 @@ opentitan_test(
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:entropy",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/crypto/impl:sha2",
@@ -1104,6 +1141,7 @@ opentitan_test(
     srcs = ["symmetric_keygen_functest.c"],
     exec_env = CRYPTOTEST_EXEC_ENVS,
     deps = [
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:drbg",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:key_transport",
@@ -1134,6 +1172,7 @@ opentitan_test(
         timeout = "long",
     ),
     deps = [
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:hkdf",
         "//sw/device/lib/crypto/impl:keyblob",
@@ -1151,6 +1190,7 @@ opentitan_test(
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:hmac",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:hmac",
         "//sw/device/lib/runtime:log",
@@ -1166,6 +1206,7 @@ opentitan_test(
         timeout = "long",
     ),
     deps = [
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:hmac",
         "//sw/device/lib/runtime:log",
@@ -1181,6 +1222,7 @@ opentitan_test(
         timeout = "long",
     ),
     deps = [
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:hmac",
         "//sw/device/lib/runtime:log",
@@ -1230,6 +1272,7 @@ opentitan_test(
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:hmac",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/crypto/impl:sha2",
@@ -1246,6 +1289,7 @@ opentitan_test(
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:status",
         "//sw/device/lib/crypto",
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -1277,6 +1321,7 @@ opentitan_test(
         timeout = "long",
     ),
     deps = [
+        "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:status",
         "//sw/device/lib/runtime:ibex",
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -219,13 +219,11 @@ opentitan_test(
     exec_env = CRYPTOTEST_EXEC_ENVS,
     fpga = fpga_params(
         timeout = "long",
-        tags = ["broken"],  # https://github.com/lowRISC/opentitan/issues/15788
-        # [test-triage] test not constant time with icache enabled
+        tags = ["broken"],
     ),
     verilator = verilator_params(
         timeout = "long",
-        tags = ["broken"],  # https://github.com/lowRISC/opentitan/issues/15788
-        # [test-triage] test not constant time with icache enabled
+        tags = ["broken"],
     ),
     deps = [
         ":aes_gcm_testutils",
@@ -1333,7 +1331,6 @@ test_suite(
     tests = [
         ":aes_functest",
         ":aes_gcm_functest",
-        ":aes_gcm_timing_functest",
         ":aes_kwp_functest",
         ":aes_kwp_kat_functest",
         ":aes_kwp_sideload_functest",

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -256,6 +256,23 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "config_functest",
+    srcs = ["config_functest.c"],
+    exec_env = CRYPTOTEST_EXEC_ENVS,
+    verilator = verilator_params(
+        timeout = "eternal",
+    ),
+    deps = [
+        "//sw/device/lib/crypto/impl:config",
+        "//sw/device/lib/crypto/impl:status",
+        "//sw/device/lib/crypto/include:datatypes",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:randomness_quality",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_test(
     name = "drbg_functest",
     srcs = ["drbg_functest.c"],
     exec_env = CRYPTOTEST_EXEC_ENVS,

--- a/sw/device/tests/crypto/aes_functest.c
+++ b/sw/device/tests/crypto/aes_functest.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/aes.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/runtime/log.h"
@@ -337,8 +338,7 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   status_t result = OK_STATUS();
 
-  // Start the entropy complex.
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
   for (size_t i = 0; i < ARRAYSIZE(kAesTests); i++) {
     LOG_INFO("Starting AES test %d of %d...", i + 1, ARRAYSIZE(kAesTests));

--- a/sw/device/tests/crypto/aes_gcm_functest.c
+++ b/sw/device/tests/crypto/aes_gcm_functest.c
@@ -8,6 +8,7 @@
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/aes_gcm.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/dif/dif_keymgr.h"
@@ -226,7 +227,7 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   status_t result = OK_STATUS();
 
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
   for (size_t i = 0; i < ARRAYSIZE(kAesGcmTestvectors); i++) {
     LOG_INFO("Starting AES-GCM test %d of %d...", i + 1,

--- a/sw/device/tests/crypto/aes_gcm_testutils.c
+++ b/sw/device/tests/crypto/aes_gcm_testutils.c
@@ -278,13 +278,11 @@ status_t aes_gcm_testutils_decrypt(const aes_gcm_test_t *test,
     *cycles = profile_end(t_start);
   } else {
     // Call decrypt() with a cycle count timing profile.
-    icache_invalidate();
     uint64_t t_start = profile_start();
     otcrypto_status_t err =
         otcrypto_aes_gcm_decrypt(&key, &ciphertext, &iv, &aad, tag_len, &tag,
                                  &actual_plaintext, tag_valid);
     *cycles = profile_end(t_start);
-    icache_invalidate();
 
     // Check for errors.
     TRY(err);

--- a/sw/device/tests/crypto/aes_gcm_timing_functest.c
+++ b/sw/device/tests/crypto/aes_gcm_timing_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/crypto/impl/aes_gcm/aes_gcm.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/log.h"
@@ -75,7 +76,7 @@ static status_t test_decrypt_timing(void) {
 OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   status_t result;
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelHigh));
   for (size_t i = 0; i < ARRAYSIZE(kAesGcmTestvectors); i++) {
     current_test = &kAesGcmTestvectors[i];
     LOG_INFO("Key length = %d", current_test->key_len * sizeof(uint32_t));

--- a/sw/device/tests/crypto/aes_gcm_timing_functest.c
+++ b/sw/device/tests/crypto/aes_gcm_timing_functest.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/crypto/drivers/rv_core_ibex.h"
 #include "sw/device/lib/crypto/impl/aes_gcm/aes_gcm.h"
 #include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
@@ -77,6 +78,8 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   status_t result;
   CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelHigh));
+  hardened_bool_t icache_enabled;
+  CHECK_STATUS_OK(otcrypto_disable_icache(&icache_enabled));
   for (size_t i = 0; i < ARRAYSIZE(kAesGcmTestvectors); i++) {
     current_test = &kAesGcmTestvectors[i];
     LOG_INFO("Key length = %d", current_test->key_len * sizeof(uint32_t));

--- a/sw/device/tests/crypto/aes_kwp_functest.c
+++ b/sw/device/tests/crypto/aes_kwp_functest.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/key_transport.h"
@@ -106,7 +107,7 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   status_t result = OK_STATUS();
 
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   EXECUTE_TEST(result, wrap_unwrap_random_test);
 
   return status_ok(result);

--- a/sw/device/tests/crypto/aes_kwp_kat_functest.c
+++ b/sw/device/tests/crypto/aes_kwp_kat_functest.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/crypto/impl/aes_kwp/aes_kwp.h"
 #include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
@@ -155,7 +156,7 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   status_t result = OK_STATUS();
 
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   EXECUTE_TEST(result, no_padding_test);
   EXECUTE_TEST(result, needs_padding_test);
 

--- a/sw/device/tests/crypto/aes_kwp_sideload_functest.c
+++ b/sw/device/tests/crypto/aes_kwp_sideload_functest.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/key_transport.h"
@@ -138,7 +139,7 @@ status_t test_setup(void) {
   // Initialize entropy complex for cryptolib, which the key manager uses to
   // clear sideloaded keys. The `keymgr_testutils_startup` function restarts
   // the device, so this should happen afterwards.
-  return otcrypto_entropy_init();
+  return otcrypto_init(kOtcryptoKeySecurityLevelLow);
 }
 
 OTTF_DEFINE_TEST_CONFIG();

--- a/sw/device/tests/crypto/aes_sideload_functest.c
+++ b/sw/device/tests/crypto/aes_sideload_functest.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/crypto/drivers/keymgr.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/aes.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/key_transport.h"
@@ -152,7 +153,7 @@ status_t test_setup(void) {
   // Initialize entropy complex for cryptolib, which the key manager uses to
   // clear sideloaded keys. The `keymgr_testutils_startup` function restarts
   // the device, so this should happen afterwards.
-  return otcrypto_entropy_init();
+  return otcrypto_init(kOtcryptoKeySecurityLevelLow);
 }
 
 /**

--- a/sw/device/tests/crypto/config_functest.c
+++ b/sw/device/tests/crypto/config_functest.c
@@ -1,0 +1,60 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#define MODULE_ID MAKE_MODULE_ID('t', 's', 't')
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static status_t test_set_and_check_config(void) {
+  LOG_INFO("Testing high security config");
+  TRY(otcrypto_set_security_config(kOtcryptoKeySecurityLevelHigh));
+  TRY(otcrypto_security_config_check(kOtcryptoKeySecurityLevelHigh));
+
+  LOG_INFO("Testing low security config");
+  TRY(otcrypto_set_security_config(kOtcryptoKeySecurityLevelLow));
+  TRY(otcrypto_security_config_check(kOtcryptoKeySecurityLevelLow));
+
+  return OK_STATUS();
+}
+
+static status_t test_init_and_exit(void) {
+  otcrypto_key_security_level_t sec_level = kOtcryptoKeySecurityLevelHigh;
+
+  TRY(otcrypto_init(sec_level));
+  TRY(otcrypto_security_config_check(sec_level));
+  TRY(otcrypto_eval_exit(OTCRYPTO_OK));
+
+  return OK_STATUS();
+}
+
+static status_t test_multiple_inits(void) {
+  otcrypto_key_security_level_t sec_level = kOtcryptoKeySecurityLevelHigh;
+
+  TRY(otcrypto_set_security_config(sec_level));
+
+  for (size_t i = 0; i < 50; i++) {
+    TRY(otcrypto_init(sec_level));
+  }
+
+  return OK_STATUS();
+}
+
+bool test_main(void) {
+  status_t result = OK_STATUS();
+
+  EXECUTE_TEST(result, test_set_and_check_config);
+  EXECUTE_TEST(result, test_init_and_exit);
+  EXECUTE_TEST(result, test_multiple_inits);
+
+  return status_ok(result);
+}

--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -184,6 +184,7 @@ FIRMWARE_DEPS = [
     "//sw/device/lib/testing/test_framework:ujson_ottf",
     "//sw/device/lib/ujson",
     "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+    "//sw/device/tests/crypto/lib:crypto_test_lib",
 
     # Include all JSON commands.
     "//sw/device/tests/crypto/cryptotest/json:commands",

--- a/sw/device/tests/crypto/cryptotest/firmware/firmware.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/firmware.c
@@ -3,10 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <stdbool.h>
 
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 #include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/tests/crypto/lib/crypto_test_lib.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
@@ -86,6 +88,10 @@ status_t process_cmd(ujson_t *uj) {
 }
 
 bool test_main(void) {
+  // We pick a random security level for the entire test run
+  otcrypto_key_security_level_t sec_level;
+  CHECK_STATUS_OK(determine_security_level(&sec_level));
+  CHECK_STATUS_OK(otcrypto_init(sec_level));
   ujson_t uj = ujson_ottf_console();
   return status_ok(process_cmd(&uj));
 }

--- a/sw/device/tests/crypto/drbg_functest.c
+++ b/sw/device/tests/crypto/drbg_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/drbg.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -190,9 +191,7 @@ static status_t run_negative_tests(void) {
 bool test_main(void) {
   status_t result = OK_STATUS();
 
-  // Initialize the entropy complex.
-  CHECK_STATUS_OK(otcrypto_entropy_init());
-  CHECK_STATUS_OK(otcrypto_entropy_check());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
   EXECUTE_TEST(result, kat_test);
   EXECUTE_TEST(result, random_test);

--- a/sw/device/tests/crypto/ecc_p256_arith_share_private_key_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_arith_share_private_key_functest.c
@@ -6,13 +6,13 @@
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/ecc/p256.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/drbg.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/sha2.h"
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
@@ -150,7 +150,7 @@ status_t arith_share_private_key_test(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
   status_t err = arith_share_private_key_test();
   if (!status_ok(err)) {

--- a/sw/device/tests/crypto/ecc_p256_base_point_mult_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_base_point_mult_functest.c
@@ -5,9 +5,10 @@
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/ecc/p256.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
+#include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
@@ -71,7 +72,7 @@ status_t base_point_mult_test(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
   status_t err = base_point_mult_test();
   if (!status_ok(err)) {

--- a/sw/device/tests/crypto/ecc_p256_key_import_export_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_key_import_export_functest.c
@@ -4,12 +4,13 @@
 
 #include "sw/device/lib/crypto/impl/ecc/p256.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
+#include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/sha2.h"
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
@@ -215,7 +216,7 @@ static status_t ecdh_key_mode_test(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
   CHECK_STATUS_OK(ecdh_key_mode_test());
 

--- a/sw/device/tests/crypto/ecc_p256_point_on_curve_check_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_point_on_curve_check_functest.c
@@ -4,9 +4,10 @@
 
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/ecc/p256.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
+#include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
@@ -74,7 +75,7 @@ status_t point_valid_test(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
   status_t err = point_valid_test();
   if (!status_ok(err)) {

--- a/sw/device/tests/crypto/ecc_p384_base_point_mult_functest.c
+++ b/sw/device/tests/crypto/ecc_p384_base_point_mult_functest.c
@@ -5,9 +5,10 @@
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/ecc/p384.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/ecc_p384.h"
+#include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
@@ -71,7 +72,7 @@ status_t base_point_mult_test(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
   status_t err = base_point_mult_test();
   if (!status_ok(err)) {

--- a/sw/device/tests/crypto/ecc_p384_key_import_export_functest.c
+++ b/sw/device/tests/crypto/ecc_p384_key_import_export_functest.c
@@ -4,12 +4,13 @@
 
 #include "sw/device/lib/crypto/impl/ecc/p384.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_p384.h"
+#include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/sha2.h"
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
@@ -213,7 +214,7 @@ static status_t ecdh_key_mode_test(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
   CHECK_STATUS_OK(ecdh_key_mode_test());
 

--- a/sw/device/tests/crypto/ecc_p384_point_on_curve_check_functest.c
+++ b/sw/device/tests/crypto/ecc_p384_point_on_curve_check_functest.c
@@ -4,9 +4,10 @@
 
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/ecc/p384.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/ecc_p384.h"
+#include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
@@ -82,7 +83,7 @@ status_t point_valid_test(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
   status_t err = point_valid_test();
   if (!status_ok(err)) {

--- a/sw/device/tests/crypto/ecdh_p256_functest.c
+++ b/sw/device/tests/crypto/ecdh_p256_functest.c
@@ -4,10 +4,11 @@
 
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
+#include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
@@ -256,7 +257,7 @@ static status_t run_ecdh_negative_tests(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
   status_t err = key_exchange_test();
   if (!status_ok(err)) {

--- a/sw/device/tests/crypto/ecdh_p256_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdh_p256_sideload_functest.c
@@ -4,12 +4,12 @@
 
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/key_transport.h"
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/keymgr_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
@@ -174,7 +174,7 @@ static status_t test_setup(void) {
   // Initialize entropy complex for cryptolib, which the key manager uses to
   // clear sideloaded keys. The `keymgr_testutils_startup` function restarts
   // the device, so this should happen afterwards.
-  return otcrypto_entropy_init();
+  return otcrypto_init(kOtcryptoKeySecurityLevelLow);
 }
 
 OTTF_DEFINE_TEST_CONFIG();

--- a/sw/device/tests/crypto/ecdh_p384_functest.c
+++ b/sw/device/tests/crypto/ecdh_p384_functest.c
@@ -4,10 +4,11 @@
 
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/ecc_p384.h"
+#include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
@@ -250,7 +251,7 @@ static status_t run_ecdh_negative_tests(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
   status_t err = key_exchange_test();
   if (!status_ok(err)) {

--- a/sw/device/tests/crypto/ecdh_p384_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdh_p384_sideload_functest.c
@@ -4,12 +4,12 @@
 
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/ecc_p384.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/key_transport.h"
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/keymgr_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
@@ -171,7 +171,7 @@ static status_t test_setup(void) {
   // Initialize entropy complex for cryptolib, which the key manager uses to
   // clear sideloaded keys. The `keymgr_testutils_startup` function restarts
   // the device, so this should happen afterwards.
-  return otcrypto_entropy_init();
+  return otcrypto_init(kOtcryptoKeySecurityLevelLow);
 }
 
 OTTF_DEFINE_TEST_CONFIG();

--- a/sw/device/tests/crypto/ecdsa_p256_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_functest.c
@@ -4,12 +4,13 @@
 
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
+#include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/sha2.h"
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
@@ -317,8 +318,7 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   status_t result = OK_STATUS();
 
-  // Initialize the entropy complex.
-  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   EXECUTE_TEST(result, sign_then_verify_test);
   EXECUTE_TEST(result, sign_kat);
   EXECUTE_TEST(result, run_ecdsa_negative_tests);

--- a/sw/device/tests/crypto/ecdsa_p256_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_sideload_functest.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
@@ -126,7 +127,7 @@ static status_t test_setup(void) {
   // Initialize entropy complex for cryptolib, which the key manager uses to
   // clear sideloaded keys. The `keymgr_testutils_startup` function restarts
   // the device, so this should happen afterwards.
-  return otcrypto_entropy_init();
+  return otcrypto_init(kOtcryptoKeySecurityLevelLow);
 }
 
 OTTF_DEFINE_TEST_CONFIG();

--- a/sw/device/tests/crypto/ecdsa_p256_verify_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_verify_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/ecc/p256.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/sha2.h"
@@ -52,7 +53,7 @@ bool test_main(void) {
   // Stays true only if all tests pass.
   bool result = true;
 
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
   // The definition of `RULE_NAME` comes from the autogen Bazel rule.
   LOG_INFO("Starting ecdsa_p256_verify_test:%s", RULE_NAME);

--- a/sw/device/tests/crypto/ecdsa_p384_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p384_functest.c
@@ -4,12 +4,13 @@
 
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_p384.h"
+#include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/sha2.h"
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
@@ -311,8 +312,7 @@ static status_t run_ecdsa_negative_tests(void) {
 bool test_main(void) {
   status_t result = OK_STATUS();
 
-  // Initialize the entropy complex.
-  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   EXECUTE_TEST(result, sign_then_verify_test);
   EXECUTE_TEST(result, sign_kat);
   EXECUTE_TEST(result, run_ecdsa_negative_tests);

--- a/sw/device/tests/crypto/ecdsa_p384_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p384_sideload_functest.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_p384.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
@@ -124,7 +125,7 @@ static status_t test_setup(void) {
   // Initialize entropy complex for cryptolib, which the key manager uses to
   // clear sideloaded keys. The `keymgr_testutils_startup` function restarts
   // the device, so this should happen afterwards.
-  return otcrypto_entropy_init();
+  return otcrypto_init(kOtcryptoKeySecurityLevelLow);
 }
 
 OTTF_DEFINE_TEST_CONFIG();

--- a/sw/device/tests/crypto/ed25519_functest.c
+++ b/sw/device/tests/crypto/ed25519_functest.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_curve25519.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
@@ -298,7 +299,7 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   status_t result = OK_STATUS();
 
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
   EXECUTE_TEST(result, ed25519_kat_test);
   EXECUTE_TEST(result, hasheddsa_test);

--- a/sw/device/tests/crypto/hkdf_functest.c
+++ b/sw/device/tests/crypto/hkdf_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/hkdf.h"
@@ -599,8 +600,7 @@ static status_t run_negative_tests(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  // Start the entropy complex.
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
   status_t test_result = OK_STATUS();
   EXECUTE_TEST(test_result, rfc_test1);

--- a/sw/device/tests/crypto/hmac_functest.c
+++ b/sw/device/tests/crypto/hmac_functest.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/hmac.h"
@@ -178,9 +179,7 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   LOG_INFO("Testing cryptolib HMAC/SHA-2 streaming implementations.");
   status_t test_result = OK_STATUS();
-  // Even though the HMAC IP itself does not need entropy, we need to initialize
-  // the entropy complex to be able to clear HMAC with randomness.
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   for (size_t i = 0; i < ARRAYSIZE(kHmacTestVectors); i++) {
     current_test_vector = &kHmacTestVectors[i];
     LOG_INFO("Running test %d of %d, test vector identifier: %s", i + 1,

--- a/sw/device/tests/crypto/hmac_multistream_functest.c
+++ b/sw/device/tests/crypto/hmac_multistream_functest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/hmac.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -449,6 +450,7 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   LOG_INFO("Testing cryptolib SHA-2/HMAC with parallel multiple streams.");
   status_t test_result = OK_STATUS();
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   EXECUTE_TEST(test_result, run_test);
   return status_ok(test_result);
 }

--- a/sw/device/tests/crypto/hmac_sha256_functest.c
+++ b/sw/device/tests/crypto/hmac_sha256_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/hmac.h"
@@ -213,7 +214,7 @@ static volatile status_t test_result;
 
 bool test_main(void) {
   test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   EXECUTE_TEST(test_result, simple_test);
   EXECUTE_TEST(test_result, empty_test);
   EXECUTE_TEST(test_result, long_key_test);

--- a/sw/device/tests/crypto/hmac_sha384_functest.c
+++ b/sw/device/tests/crypto/hmac_sha384_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/hmac.h"
@@ -150,7 +151,7 @@ static volatile status_t test_result;
 
 bool test_main(void) {
   test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   EXECUTE_TEST(test_result, empty_test);
   EXECUTE_TEST(test_result, simple_test);
   EXECUTE_TEST(test_result, long_key_test);

--- a/sw/device/tests/crypto/hmac_sha512_functest.c
+++ b/sw/device/tests/crypto/hmac_sha512_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/hmac.h"
@@ -159,7 +160,7 @@ static volatile status_t test_result;
 
 bool test_main(void) {
   test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   EXECUTE_TEST(test_result, empty_test);
   EXECUTE_TEST(test_result, simple_test);
   EXECUTE_TEST(test_result, long_key_test);

--- a/sw/device/tests/crypto/kats_functest.c
+++ b/sw/device/tests/crypto/kats_functest.c
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/crypto/impl/kats.h"
-#include "sw/device/lib/crypto/include/entropy_src.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
@@ -11,7 +11,7 @@
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
   CHECK_STATUS_OK(run_kats(OTCRYPTO_KAT_ALL_TESTS));
 

--- a/sw/device/tests/crypto/kdf_hmac_ctr_functest.c
+++ b/sw/device/tests/crypto/kdf_hmac_ctr_functest.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -1217,8 +1218,7 @@ static status_t run_hmac_kdf_negative_tests(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  // Start the entropy complex.
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
   status_t test_result = OK_STATUS();
 

--- a/sw/device/tests/crypto/kdf_kmac_functest.c
+++ b/sw/device/tests/crypto/kdf_kmac_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/crypto/drivers/kmac.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -186,8 +187,8 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   LOG_INFO("Testing cryptolib KMAC-KDF driver.");
 
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   // Initialize the core with default parameters
-  CHECK_STATUS_OK(otcrypto_entropy_init());
   CHECK_STATUS_OK(kmac_hwip_default_configure());
 
   status_t test_result = OK_STATUS();

--- a/sw/device/tests/crypto/kdf_kmac_sideload_functest.c
+++ b/sw/device/tests/crypto/kdf_kmac_sideload_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/crypto/drivers/kmac.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -438,8 +439,8 @@ bool test_main(void) {
   LOG_INFO("Keymgr entered %s State", state_name);
   LOG_INFO("Testing cryptolib KDF-KMAC driver with sideloaded key.");
 
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   // Initialize the core with default parameters
-  CHECK_STATUS_OK(otcrypto_entropy_init());
   CHECK_STATUS_OK(kmac_hwip_default_configure());
 
   status_t test_result = OK_STATUS();

--- a/sw/device/tests/crypto/kmac_functest.c
+++ b/sw/device/tests/crypto/kmac_functest.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/crypto/drivers/kmac.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -419,8 +420,8 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   LOG_INFO("Testing cryptolib KMAC driver.");
 
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   // Initialize the core with default parameters
-  CHECK_STATUS_OK(otcrypto_entropy_init());
   CHECK_STATUS_OK(kmac_hwip_default_configure());
 
   status_t test_result = OK_STATUS();

--- a/sw/device/tests/crypto/kmac_sideload_functest.c
+++ b/sw/device/tests/crypto/kmac_sideload_functest.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/crypto/drivers/kmac.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -356,8 +357,8 @@ bool test_main(void) {
   LOG_INFO("Keymgr entered %s State", state_name);
   LOG_INFO("Testing cryptolib KMAC driver with sideloaded key.");
 
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   // Initialize the core with default parameters
-  CHECK_STATUS_OK(otcrypto_entropy_init());
   CHECK_STATUS_OK(kmac_hwip_default_configure());
 
   status_t test_result = OK_STATUS();

--- a/sw/device/tests/crypto/otcrypto_hash_test.c
+++ b/sw/device/tests/crypto/otcrypto_hash_test.c
@@ -8,6 +8,7 @@
 #include "otcrypto.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
@@ -59,6 +60,7 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t result = OK_STATUS();
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   result = hash_test();
   return status_ok(result);
 }

--- a/sw/device/tests/crypto/rsa_2048_encryption_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_encryption_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/rsa.h"
@@ -356,7 +357,7 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   EXECUTE_TEST(test_result, oaep_decrypt_valid_test);
   EXECUTE_TEST(test_result, oaep_encrypt_decrypt_test);
   EXECUTE_TEST(test_result, run_encrypt_negative_tests);

--- a/sw/device/tests/crypto/rsa_2048_key_from_cofactor_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_key_from_cofactor_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/impl/rsa/rsa_datatypes.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/rsa.h"
@@ -256,7 +257,7 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   EXECUTE_TEST(test_result, keypair_from_p_test);
   EXECUTE_TEST(test_result, keypair_from_q_test);
   EXECUTE_TEST(test_result, run_cofactor_negative_tests);

--- a/sw/device/tests/crypto/rsa_2048_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_keygen_functest.c
@@ -5,12 +5,13 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/rsa/rsa_datatypes.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/rsa.h"
 #include "sw/device/lib/crypto/include/sha2.h"
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
@@ -181,7 +182,7 @@ static status_t run_keygen_negative_tests(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
   status_t test_result = OK_STATUS();
   EXECUTE_TEST(test_result, keygen_then_sign_test);

--- a/sw/device/tests/crypto/rsa_2048_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_signature_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/rsa.h"
@@ -397,7 +398,7 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   EXECUTE_TEST(test_result, pkcs1v15_sign_test);
   EXECUTE_TEST(test_result, pkcs1v15_verify_valid_test);
   EXECUTE_TEST(test_result, pkcs1v15_verify_invalid_test);

--- a/sw/device/tests/crypto/rsa_3072_encryption_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_encryption_functest.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/rsa.h"
@@ -248,7 +249,7 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   EXECUTE_TEST(test_result, oaep_decrypt_valid_test);
   EXECUTE_TEST(test_result, oaep_encrypt_decrypt_test);
   return status_ok(test_result);

--- a/sw/device/tests/crypto/rsa_3072_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_keygen_functest.c
@@ -5,12 +5,13 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/rsa/rsa_datatypes.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/rsa.h"
 #include "sw/device/lib/crypto/include/sha2.h"
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
@@ -121,7 +122,7 @@ status_t keygen_then_sign_test(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
   status_t test_result = OK_STATUS();
   EXECUTE_TEST(test_result, keygen_then_sign_test);

--- a/sw/device/tests/crypto/rsa_3072_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_signature_functest.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/rsa.h"
@@ -334,7 +335,7 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   EXECUTE_TEST(test_result, pkcs1v15_sign_test);
   EXECUTE_TEST(test_result, pkcs1v15_verify_valid_test);
   EXECUTE_TEST(test_result, pkcs1v15_verify_invalid_test);

--- a/sw/device/tests/crypto/rsa_4096_encryption_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_encryption_functest.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/rsa.h"
@@ -268,7 +269,7 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   EXECUTE_TEST(test_result, oaep_decrypt_valid_test);
   EXECUTE_TEST(test_result, oaep_encrypt_decrypt_test);
   return status_ok(test_result);

--- a/sw/device/tests/crypto/rsa_4096_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_keygen_functest.c
@@ -5,12 +5,13 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/rsa/rsa_datatypes.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/rsa.h"
 #include "sw/device/lib/crypto/include/sha2.h"
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
@@ -121,7 +122,7 @@ status_t keygen_then_sign_test(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
   status_t test_result = OK_STATUS();
   EXECUTE_TEST(test_result, keygen_then_sign_test);

--- a/sw/device/tests/crypto/rsa_4096_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_signature_functest.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/rsa.h"
@@ -363,7 +364,7 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   EXECUTE_TEST(test_result, pkcs1v15_sign_test);
   EXECUTE_TEST(test_result, pkcs1v15_verify_valid_test);
   EXECUTE_TEST(test_result, pkcs1v15_verify_invalid_test);

--- a/sw/device/tests/crypto/sha256_functest.c
+++ b/sw/device/tests/crypto/sha256_functest.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -230,9 +231,7 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t test_result = OK_STATUS();
-  // Even though the HMAC IP itself does not need entropy, we need to initialize
-  // the entropy complex to be able to clear HMAC with randomness.
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   EXECUTE_TEST(test_result, simple_test);
   EXECUTE_TEST(test_result, empty_test);
   EXECUTE_TEST(test_result, two_block_test);

--- a/sw/device/tests/crypto/sha384_functest.c
+++ b/sw/device/tests/crypto/sha384_functest.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/sha2.h"
@@ -161,9 +162,7 @@ static volatile status_t test_result;
 
 bool test_main(void) {
   test_result = OK_STATUS();
-  // Even though the HMAC IP itself does not need entropy, we need to initialize
-  // the entropy complex to be able to clear HMAC with randomness.
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   EXECUTE_TEST(test_result, empty_test);
   EXECUTE_TEST(test_result, one_block_test);
   EXECUTE_TEST(test_result, two_block_test);

--- a/sw/device/tests/crypto/sha512_functest.c
+++ b/sw/device/tests/crypto/sha512_functest.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/sha2.h"
@@ -150,9 +151,7 @@ static volatile status_t test_result;
 
 bool test_main(void) {
   test_result = OK_STATUS();
-  // Even though the HMAC IP itself does not need entropy, we need to initialize
-  // the entropy complex to be able to clear HMAC with randomness.
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   EXECUTE_TEST(test_result, one_block_test);
   EXECUTE_TEST(test_result, two_block_test);
   EXECUTE_TEST(test_result, streaming_test);

--- a/sw/device/tests/crypto/symmetric_keygen_functest.c
+++ b/sw/device/tests/crypto/symmetric_keygen_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/drbg.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -50,13 +51,6 @@ static otcrypto_key_config_t kKmacKeyConfig = {
     .hw_backed = kHardenedBoolFalse,
     .security_level = kOtcryptoKeySecurityLevelLow,
 };
-
-static status_t entropy_complex_init_test(void) {
-  TRY(otcrypto_entropy_init());
-
-  // Check the configuration.
-  return otcrypto_entropy_check();
-}
 
 /**
  * Basic test for generating a symmetric key.
@@ -155,7 +149,8 @@ static status_t generate_multiple_keys_test(void) {
 bool test_main(void) {
   status_t result = OK_STATUS();
 
-  EXECUTE_TEST(result, entropy_complex_init_test);
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+
   EXECUTE_TEST(result, aes_keygen_test);
   EXECUTE_TEST(result, hmac_keygen_test);
   EXECUTE_TEST(result, kmac_keygen_test);

--- a/sw/device/tests/penetrationtests/firmware/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/BUILD
@@ -45,6 +45,7 @@ FIRMWARE_DEPS_FI = [
     "//sw/device/lib/testing/test_framework:check",
     "//sw/device/lib/testing/test_framework:ottf_main",
     "//sw/device/lib/testing/test_framework:ujson_ottf",
+    "//sw/device/lib/testing:entropy_testutils",
     "//sw/device/lib/ujson",
 
     # Include all JSON commands.
@@ -60,6 +61,7 @@ FIRMWARE_DEPS_FI_IBEX = [
     "//sw/device/lib/testing/test_framework:check",
     "//sw/device/lib/testing/test_framework:ottf_main",
     "//sw/device/lib/testing/test_framework:ujson_ottf",
+    "//sw/device/lib/testing:entropy_testutils",
     "//sw/device/lib/ujson",
 
     # Include all JSON commands.
@@ -75,6 +77,7 @@ FIRMWARE_DEPS_FI_OTBN = [
     "//sw/device/lib/testing/test_framework:check",
     "//sw/device/lib/testing/test_framework:ottf_main",
     "//sw/device/lib/testing/test_framework:ujson_ottf",
+    "//sw/device/lib/testing:entropy_testutils",
     "//sw/device/lib/ujson",
 
     # Include all JSON commands.
@@ -93,6 +96,7 @@ FIRMWARE_DEPS_SCA = [
     "//sw/device/tests/penetrationtests/firmware/sca:trigger_sca",
     "//sw/device/tests/penetrationtests/firmware/lib:extclk_sca_fi",
     "//sw/device/tests/penetrationtests/firmware/lib:pentest_lib",
+    "//sw/device/lib/testing:entropy_testutils",
     "//sw/device/lib/base:csr",
     "//sw/device/lib/base:status",
     "//sw/device/lib/crypto",

--- a/sw/device/tests/penetrationtests/firmware/firmware_cryptolib_fi_asym.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware_cryptolib_fi_asym.c
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 
 #include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
@@ -38,7 +39,7 @@ status_t process_cmd(ujson_t *uj) {
 }
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   ujson_t uj = ujson_ottf_console();
   return status_ok(process_cmd(&uj));
 }

--- a/sw/device/tests/penetrationtests/firmware/firmware_cryptolib_fi_sym.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware_cryptolib_fi_sym.c
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 
 #include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
@@ -38,7 +39,7 @@ status_t process_cmd(ujson_t *uj) {
 }
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   ujson_t uj = ujson_ottf_console();
   return status_ok(process_cmd(&uj));
 }

--- a/sw/device/tests/penetrationtests/firmware/firmware_cryptolib_sca_asym.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware_cryptolib_sca_asym.c
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 
 #include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
@@ -44,7 +45,7 @@ status_t process_cmd(ujson_t *uj) {
 }
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   ujson_t uj = ujson_ottf_console();
   return status_ok(process_cmd(&uj));
 }

--- a/sw/device/tests/penetrationtests/firmware/firmware_cryptolib_sca_sym.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware_cryptolib_sca_sym.c
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 
 #include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
@@ -44,7 +45,7 @@ status_t process_cmd(ujson_t *uj) {
 }
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   ujson_t uj = ujson_ottf_console();
   return status_ok(process_cmd(&uj));
 }

--- a/sw/device/tests/penetrationtests/firmware/firmware_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware_fi.c
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 
 #include "sw/device/lib/base/status.h"
-#include "sw/device/lib/crypto/include/entropy_src.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
@@ -76,7 +76,7 @@ status_t process_cmd(ujson_t *uj) {
 }
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
   ujson_t uj = ujson_ottf_console();
   return status_ok(process_cmd(&uj));
 }

--- a/sw/device/tests/penetrationtests/firmware/firmware_fi_ibex.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware_fi_ibex.c
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 
 #include "sw/device/lib/base/status.h"
-#include "sw/device/lib/crypto/include/entropy_src.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
@@ -42,7 +42,7 @@ status_t process_cmd(ujson_t *uj) {
 }
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
   ujson_t uj = ujson_ottf_console();
   return status_ok(process_cmd(&uj));
 }

--- a/sw/device/tests/penetrationtests/firmware/firmware_fi_otbn.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware_fi_otbn.c
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 
 #include "sw/device/lib/base/status.h"
-#include "sw/device/lib/crypto/include/entropy_src.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
@@ -42,7 +42,7 @@ status_t process_cmd(ujson_t *uj) {
 }
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
   ujson_t uj = ujson_ottf_console();
   return status_ok(process_cmd(&uj));
 }

--- a/sw/device/tests/penetrationtests/firmware/firmware_gdb.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware_gdb.c
@@ -14,6 +14,7 @@
 #include <stdbool.h>
 
 #include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -276,7 +277,7 @@ status_t handle_gdb(ujson_t *uj) {
 }
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   ujson_t uj = ujson_ottf_console();
   return status_ok(handle_gdb(&uj));
 }

--- a/sw/device/tests/penetrationtests/firmware/firmware_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware_sca.c
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 
 #include "sw/device/lib/base/status.h"
-#include "sw/device/lib/crypto/include/entropy_src.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
@@ -86,7 +86,7 @@ status_t process_cmd(ujson_t *uj) {
 }
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_entropy_init());
+  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
   ujson_t uj = ujson_ottf_console();
   return status_ok(process_cmd(&uj));
 }


### PR DESCRIPTION
This PR does three things:
- We integrate otcrypto_security_config_check in otcrypto_init
- We call otcrypto_init for the functests and firmwares (KATs and pentest)
- We remove gcm's calls to rv_core_ibex (instead init takes a part of this role) and reintegrate the aes_gcm_timing_functest