### PR TITLE
[crypto/hmac] Create secure buffer in _redundant

### DIFF
--- a/sw/device/lib/crypto/drivers/hmac.c
+++ b/sw/device/lib/crypto/drivers/hmac.c
@@ -538,10 +538,8 @@ status_t hmac_hmac_sha256_redundant(const hmac_key_t *key,
 
   uint32_t h_i_key_pad_msg[kHmacSha256DigestWords];
   memset(h_i_key_pad_msg, 0, sizeof(h_i_key_pad_msg));
-  otcrypto_word32_buf_t inner_digest = {
-      .data = h_i_key_pad_msg,
-      .len = kHmacSha256DigestWords,
-  };
+  otcrypto_word32_buf_t inner_digest = OTCRYPTO_MAKE_BUF(
+      otcrypto_word32_buf_t, h_i_key_pad_msg, kHmacSha256DigestWords);
   HARDENED_TRY(hmac_final(&ctx, &inner_digest));
 
   // hmac = H(o_key_pad || h_i_key_pad_msg).
@@ -594,10 +592,8 @@ status_t hmac_hmac_sha384_redundant(const hmac_key_t *key,
 
   uint32_t h_i_key_pad_msg[kHmacSha384DigestWords];
   memset(h_i_key_pad_msg, 0, sizeof(h_i_key_pad_msg));
-  otcrypto_word32_buf_t inner_digest = {
-      .data = h_i_key_pad_msg,
-      .len = kHmacSha384DigestWords,
-  };
+  otcrypto_word32_buf_t inner_digest = OTCRYPTO_MAKE_BUF(
+      otcrypto_word32_buf_t, h_i_key_pad_msg, kHmacSha384DigestWords);
   HARDENED_TRY(hmac_final(&ctx, &inner_digest));
 
   // hmac = H(o_key_pad || h_i_key_pad_msg).
@@ -650,10 +646,8 @@ status_t hmac_hmac_sha512_redundant(const hmac_key_t *key,
 
   uint32_t h_i_key_pad_msg[kHmacSha512DigestWords];
   memset(h_i_key_pad_msg, 0, sizeof(h_i_key_pad_msg));
-  otcrypto_word32_buf_t inner_digest = {
-      .data = h_i_key_pad_msg,
-      .len = kHmacSha512DigestWords,
-  };
+  otcrypto_word32_buf_t inner_digest = OTCRYPTO_MAKE_BUF(
+      otcrypto_word32_buf_t, h_i_key_pad_msg, kHmacSha512DigestWords);
   HARDENED_TRY(hmac_final(&ctx, &inner_digest));
 
   // hmac = H(o_key_pad || h_i_key_pad_msg).

--- a/sw/device/lib/crypto/impl/hmac.c
+++ b/sw/device/lib/crypto/impl/hmac.c
@@ -254,7 +254,7 @@ otcrypto_status_t otcrypto_hmac(const otcrypto_blinded_key_t *key,
                           kOtcryptoKeySecurityLevelMedium);
         HARDENED_TRY(hmac_hmac_sha256_cl(&hmac_key, input_message, tag));
         // Second HMAC computation using the HMAC core.
-        uint32_t tag_redundant_data[tag->len];
+        uint32_t tag_redundant_data[kHmacSha256DigestWords];
         otcrypto_word32_buf_t tag_redundant = OTCRYPTO_MAKE_BUF(
             otcrypto_word32_buf_t, tag_redundant_data, tag->len);
         hmac_key_t hmac_key_redundant;
@@ -276,7 +276,7 @@ otcrypto_status_t otcrypto_hmac(const otcrypto_blinded_key_t *key,
         // First HMAC computation using the HMAC core.
         HARDENED_TRY(hmac_hmac_sha256_cl(&hmac_key, input_message, tag));
         // Second HMAC computation without using the HMAC core.
-        uint32_t tag_redundant_data[tag->len];
+        uint32_t tag_redundant_data[kHmacSha256DigestWords];
         otcrypto_word32_buf_t tag_redundant = OTCRYPTO_MAKE_BUF(
             otcrypto_word32_buf_t, tag_redundant_data, tag->len);
         hmac_key_t hmac_key_redundant;
@@ -308,7 +308,7 @@ otcrypto_status_t otcrypto_hmac(const otcrypto_blinded_key_t *key,
                           kOtcryptoKeySecurityLevelMedium);
         HARDENED_TRY(hmac_hmac_sha384(&hmac_key, input_message, tag));
         // Second HMAC computation using the HMAC core.
-        uint32_t tag_redundant_data[tag->len];
+        uint32_t tag_redundant_data[kHmacSha384DigestWords];
         otcrypto_word32_buf_t tag_redundant = OTCRYPTO_MAKE_BUF(
             otcrypto_word32_buf_t, tag_redundant_data, tag->len);
         hmac_key_t hmac_key_redundant;
@@ -330,7 +330,7 @@ otcrypto_status_t otcrypto_hmac(const otcrypto_blinded_key_t *key,
         // First HMAC computation using the HMAC core.
         HARDENED_TRY(hmac_hmac_sha384(&hmac_key, input_message, tag));
         // Second HMAC computation without using the HMAC core.
-        uint32_t tag_redundant_data[tag->len];
+        uint32_t tag_redundant_data[kHmacSha384DigestWords];
         otcrypto_word32_buf_t tag_redundant = OTCRYPTO_MAKE_BUF(
             otcrypto_word32_buf_t, tag_redundant_data, tag->len);
         hmac_key_t hmac_key_redundant;
@@ -362,7 +362,7 @@ otcrypto_status_t otcrypto_hmac(const otcrypto_blinded_key_t *key,
                           kOtcryptoKeySecurityLevelMedium);
         HARDENED_TRY(hmac_hmac_sha512(&hmac_key, input_message, tag));
         // Second HMAC computation using the HMAC core.
-        uint32_t tag_redundant_data[tag->len];
+        uint32_t tag_redundant_data[kHmacSha512DigestWords];
         otcrypto_word32_buf_t tag_redundant = OTCRYPTO_MAKE_BUF(
             otcrypto_word32_buf_t, tag_redundant_data, tag->len);
         hmac_key_t hmac_key_redundant;
@@ -384,7 +384,7 @@ otcrypto_status_t otcrypto_hmac(const otcrypto_blinded_key_t *key,
         // First HMAC computation using the HMAC core.
         HARDENED_TRY(hmac_hmac_sha512(&hmac_key, input_message, tag));
         // Second HMAC computation without using the HMAC core.
-        uint32_t tag_redundant_data[tag->len];
+        uint32_t tag_redundant_data[kHmacSha512DigestWords];
         otcrypto_word32_buf_t tag_redundant = OTCRYPTO_MAKE_BUF(
             otcrypto_word32_buf_t, tag_redundant_data, tag->len);
         hmac_key_t hmac_key_redundant;


### PR DESCRIPTION
There was a bug where in the _redundant call, the OTCRYPTO_MAKE_BUF macro was not used, hence hmac on high security failed on an integrity check.

Also fix the redundant_tag_data size to be the max size avoiding a VLA.