### PR TITLE
[DRAFT][silicon_creator] Space optimize checking for watchdog reset request

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/rstmgr.c
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr.c
@@ -169,6 +169,21 @@ bool rstmgr_is_hw_reset_reason(dt_rstmgr_t dt, uint32_t reasons,
   return false;
 }
 
+bool rstmgr_is_hw_reset_reason_aon_timer(uint32_t reasons) {
+#ifdef OPENTITAN_IS_EARLGREY
+  // Space optimized version to keep the ROM/ROM_EXT small.
+  // Unfortunately, there is no define in the top headers for this field field.
+  const size_t kRstmgrResetInfoHwReqAonTimer =
+      RSTMGR_RESET_INFO_HW_REQ_OFFSET + 0;
+  return !!(reasons & (1 << kRstmgrResetInfoHwReqAonTimer));
+#else
+  // Generic version working on any top.
+  return rstmgr_is_hw_reset_reason(kDtRstmgrAon, reset_reasons,
+                                   kDtInstanceIdAonTimerAon,
+                                   kDtAonTimerResetReqAonTimer);
+#endif
+}
+
 void rstmgr_reboot(void) {
   rstmgr_reason_clear(1 << kRstmgrReasonPowerOn);
   rstmgr_reset();

--- a/sw/device/silicon_creator/lib/drivers/rstmgr.h
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr.h
@@ -156,6 +156,17 @@ bool rstmgr_is_hw_reset_reason(dt_rstmgr_t dt, uint32_t reasons,
                                dt_instance_id_t inst_id, size_t reset_req);
 
 /**
+ * Check if the AON timer triggered a HW reset request.
+ *
+ * This is potentially more optimized version of rstmgr_is_hw_reset_reason
+ * for the special case of the AON timer, assuming there is a unique rstmgr.
+ *
+ * @param dt Instance of rstmgr.
+ * @param reasons Reset reasons bit field.
+ */
+bool rstmgr_is_hw_reset_reason_aon_timer(uint32_t reasons);
+
+/**
  * Bitfields for `OWNER_SW_CFG_ROM_RSTMGR_INFO_EN" OTP item.
  *
  * Defined here to be able to use in tests.

--- a/sw/device/silicon_creator/lib/rescue/rescue.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue.c
@@ -428,9 +428,7 @@ hardened_bool_t rescue_detect_entry(const owner_rescue_config_t *config,
     dbg_printf("warning: rescue configured for protocol %c\r\n", protocol);
   }
 
-  if (wdt_enable && rstmgr_is_hw_reset_reason(kDtRstmgrAon, reset_reasons,
-                                              kDtInstanceIdAonTimerAon,
-                                              kDtAonTimerResetReqAonTimer)) {
+  if (wdt_enable && rstmgr_is_hw_reset_reason_aon_timer(reset_reasons)) {
     return kHardenedBoolTrue;
   }
 


### PR DESCRIPTION
This is an attempt at reducing the size of the ROM_EXT, see #29747

The code currently uses a very generic function which requires the DT description of the rstmgr to find the bit offset in the register. This is quite costly in terms of space so create a watchdog-specific function for this task. The function has an Earlgrey-specific version which does not use the DT while keeping the generic version for other tops.

This reduces the size of `//sw/device/silicon_creator/rom_ext:rom_ext_dice_cwt_slot_a` from 66104 to 65932.