### PR TITLE
[sram_ctrl,dv] Cut down the time running (pointless) tests for sram_ctrl

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_smoke_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_smoke_vseq.sv
@@ -32,10 +32,8 @@ class sram_ctrl_smoke_vseq extends sram_ctrl_base_vseq;
       num_ops == 100;
     } else {
       num_ops dist {
-        [1    : 999 ] :/ 1,
-        [1000 : 4999] :/ 3,
-        [5000 : 9999] :/ 5,
-        10_000        :/ 1
+        [1 : 10]    :/ 1,
+        [250 : 300] :/ 4
       };
     }
   }

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -44,7 +44,7 @@
              "sec_cm_prim_onehot_check_bind", "sec_cm_prim_count_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 5
 
   vcs_cov_excl_files: ["{proj_root}/hw/ip/sram_ctrl/dv/cov/sram_ctrl_cov_excl.el",
                        "{proj_root}/hw/ip/sram_ctrl/dv/cov/sram_ctrl_unr_excl.el"]


### PR DESCRIPTION
This is sparked by me spending a bit of time on the block and getting upset at how long the tests take. They can be **much** quicker with (I think) no meaningful change in test quality.