### PR TITLE
[opentitantool,rules,signing]  Enhance ownership verification and add signature test rule

### DIFF
--- a/rules/scripts/ownership_signature_test.template.sh
+++ b/rules/scripts/ownership_signature_test.template.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+set -o pipefail
+
+FILES_TO_CHECK=(@FILES@)
+
+IS_NEGATIVE_TEST=@IS_NEGATIVE_TEST@
+OPENTITANTOOL=@OPENTITANTOOL@
+VERIFY_ARGS=(@VERIFY_ARGS@)
+ECDSA_KEY=@ECDSA_KEY@
+SPX_KEY=@SPX_KEY@
+ECDSA_SIG=@ECDSA_SIG@
+SPX_SIG=@SPX_SIG@
+KEY_ARGS=()
+RESULT_STATUS=0
+
+echo "___Starting ownership verification___"
+
+# If ECDSA key is provided, include it in the verify command
+if [[ ! -z "$ECDSA_KEY" ]]; then
+  KEY_ARGS+=("--ecdsa-pub-key=${ECDSA_KEY}")
+fi
+
+# If SPX key is provided, include it in the verify command
+if [[ ! -z "$SPX_KEY" ]]; then
+  KEY_ARGS+=("--spx-pub-key=${SPX_KEY}")
+fi
+
+# If ECDSA signature is provided, include it in the verify command
+if [[ ! -z "$ECDSA_SIG" ]]; then
+  VERIFY_ARGS+=("--ecdsa-sig=${ECDSA_SIG}")
+fi
+
+# If SPX signature is provided, include it in the verify command
+if [[ ! -z "$SPX_SIG" ]]; then
+  VERIFY_ARGS+=("--spx-sig=${SPX_SIG}")
+fi
+
+for file in "${FILES_TO_CHECK[@]}"
+do
+  echo -n "Checking signature of ${file} (with embedded keys)..."
+
+  # TEST 1: Ownership Verify without overriding public keys (extracts from config)
+  ${OPENTITANTOOL} --rcfile= ownership verify "${VERIFY_ARGS[@]}" ${file}
+
+  if [[ $? -eq 0 ]]; then
+    echo "ok."
+  else
+    echo "failed."
+    RESULT_STATUS=1
+  fi
+
+  if [[ ${#KEY_ARGS[@]} -ne 0 ]]; then
+    echo -n "Checking signature of ${file} (with explicit keys)..."
+
+    # TEST 2: Ownership Verify with explicit keys provided
+    ${OPENTITANTOOL} --rcfile= ownership verify "${KEY_ARGS[@]}" "${VERIFY_ARGS[@]}" ${file}
+
+    if [[ $? -eq 0 ]]; then
+      echo "ok."
+    else
+      echo "failed."
+      RESULT_STATUS=1
+    fi
+  fi
+done
+
+# If this is a negative test, invert the result status
+if [[ "$IS_NEGATIVE_TEST" == "True" ]]; then
+  echo "Negative test, inverting result status."
+  RESULT_STATUS=$((1 - $RESULT_STATUS))
+fi
+
+echo "Status: $RESULT_STATUS"
+
+exit $RESULT_STATUS

--- a/rules/signing.bzl
+++ b/rules/signing.bzl
@@ -904,10 +904,10 @@ def _signature_test_impl(ctx):
     if ctx.attr.spx_domain != "":
         verify_args = "--spx --domain " + ctx.attr.spx_domain
     if ecdsa_key:
-        selected_ecdsa_key_path = ecdsa_key.file.path
+        selected_ecdsa_key_path = ecdsa_key.file.short_path
         keys.append(ecdsa_key.file)
     if spx_key:
-        selected_spx_key_path = spx_key.file.path
+        selected_spx_key_path = spx_key.file.short_path
         keys.append(spx_key.file)
 
     files = [f.short_path for f in ctx.files.srcs]
@@ -957,6 +957,93 @@ signature_test = rule(
         ),
         "_script": attr.label(
             default = "//rules/scripts:sival_signature_test.template.sh",
+            doc = "The shell script to execute for the test.",
+            allow_single_file = True,
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+    toolchains = [LOCALTOOLS_TOOLCHAIN],
+    test = True,
+)
+
+def _ownership_signature_test_impl(ctx):
+    keys = []
+    tc = ctx.toolchains[LOCALTOOLS_TOOLCHAIN]
+    script = ctx.actions.declare_file("{}.bash".format(ctx.label.name))
+    verify_args = ""
+    ecdsa_key = ctx.attr.ecdsa_key
+    spx_key = ctx.attr.spx_key
+
+    selected_ecdsa_key_path = ""
+    selected_spx_key_path = ""
+    selected_ecdsa_sig_path = ""
+    selected_spx_sig_path = ""
+
+    if ctx.file.ecdsa_key:
+        selected_ecdsa_key_path = ctx.file.ecdsa_key.short_path
+        keys.append(ctx.file.ecdsa_key)
+    if ctx.file.spx_key:
+        selected_spx_key_path = ctx.file.spx_key.short_path
+        keys.append(ctx.file.spx_key)
+
+    if ctx.file.ecdsa_signature:
+        selected_ecdsa_sig_path = ctx.file.ecdsa_signature.short_path
+        keys.append(ctx.file.ecdsa_signature)
+    if ctx.file.spx_signature:
+        selected_spx_sig_path = ctx.file.spx_signature.short_path
+        keys.append(ctx.file.spx_signature)
+
+    files = [f.short_path for f in ctx.files.srcs]
+    ctx.actions.expand_template(
+        template = ctx.file._script,
+        output = script,
+        substitutions = {
+            "@FILES@": " ".join(files),
+            "@OPENTITANTOOL@": tc.tools.opentitantool.executable.short_path,
+            "@VERIFY_ARGS@": verify_args,
+            "@ECDSA_KEY@": selected_ecdsa_key_path,
+            "@SPX_KEY@": selected_spx_key_path,
+            "@ECDSA_SIG@": selected_ecdsa_sig_path,
+            "@SPX_SIG@": selected_spx_sig_path,
+            "@IS_NEGATIVE_TEST@": str(ctx.attr.negative_test),
+        },
+        is_executable = True,
+    )
+
+    return [
+        DefaultInfo(
+            runfiles = ctx.runfiles(files = ctx.files.srcs + keys + [tc.tools.opentitantool.executable]),
+            executable = script,
+        ),
+    ]
+
+ownership_signature_test = rule(
+    implementation = _ownership_signature_test_impl,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True, doc = "Owner blocks to verify"),
+        "ecdsa_key": attr.label(
+            allow_single_file = True,
+            doc = "ECDSA public key to validate this image",
+        ),
+        "spx_key": attr.label(
+            allow_single_file = True,
+            doc = "SPX public key to validate this image",
+        ),
+        "ecdsa_signature": attr.label(
+            allow_single_file = True,
+            doc = "File containing the detached ECDSA signature",
+        ),
+        "spx_signature": attr.label(
+            allow_single_file = True,
+            doc = "File containing the detached SPX signature",
+        ),
+        "negative_test": attr.bool(
+            default = False,
+            doc = "Whether this is a negative test case.",
+        ),
+        "_script": attr.label(
+            default = "//rules/scripts:ownership_signature_test.template.sh",
             doc = "The shell script to execute for the test.",
             allow_single_file = True,
             executable = True,

--- a/rules/tests/BUILD
+++ b/rules/tests/BUILD
@@ -4,7 +4,11 @@
 
 load("//rules/tests:const_unittest.bzl", "const_test_suite")
 load("//rules/tests:otp_unittest.bzl", "otp_test_suite")
-load("//rules:signing.bzl", "signature_test")
+load(
+    "//rules:signing.bzl",
+    "ownership_signature_test",
+    "signature_test",
+)
 
 const_test_suite()
 
@@ -41,4 +45,69 @@ signature_test(
     negative_test = True,
     spx_domain = "PrehashedSha256",  # "Pure", "PrehashedSha256"
     spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:spx_keyset": "prod_key_0"},
+)
+
+ownership_signature_test(
+    name = "valid_owner_signature_test",
+    srcs = ["//sw/device/silicon_creator/lib/ownership/testdata:hybrid_owner_bin"],
+    ecdsa_key = "//sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key_pub",
+    ecdsa_signature = "//sw/device/silicon_creator/lib/ownership/testdata:hybrid_owner_ecdsa_signature",
+    spx_key = "//sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key_spx_pub",
+    spx_signature = "//sw/device/silicon_creator/lib/ownership/testdata:hybrid_owner_spx_signature",
+)
+
+ownership_signature_test(
+    name = "wrong_owner_ecdsa_key_test",
+    srcs = ["//sw/device/silicon_creator/lib/ownership/testdata:hybrid_owner_bin"],
+    ecdsa_key = "//sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key_pub",
+    ecdsa_signature = "//sw/device/silicon_creator/lib/ownership/testdata:hybrid_owner_ecdsa_signature",
+    negative_test = True,
+    spx_key = "//sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key_spx_pub",
+    spx_signature = "//sw/device/silicon_creator/lib/ownership/testdata:hybrid_owner_spx_signature",
+)
+
+ownership_signature_test(
+    name = "wrong_owner_spx_key_test",
+    srcs = ["//sw/device/silicon_creator/lib/ownership/testdata:hybrid_owner_bin"],
+    ecdsa_key = "//sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key_pub",
+    ecdsa_signature = "//sw/device/silicon_creator/lib/ownership/testdata:hybrid_owner_ecdsa_signature",
+    negative_test = True,
+    spx_key = "//sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key_spx_pub",
+    spx_signature = "//sw/device/silicon_creator/lib/ownership/testdata:hybrid_owner_spx_signature",
+)
+
+genrule(
+    name = "corrupt_hybrid_owner_ecdsa_signature",
+    srcs = ["//sw/device/silicon_creator/lib/ownership/testdata:hybrid_owner_ecdsa_signature"],
+    outs = ["hybrid_owner.ecdsa_signature.corrupted.bin"],
+    cmd = "cp $(location //sw/device/silicon_creator/lib/ownership/testdata:hybrid_owner_ecdsa_signature) $(location hybrid_owner.ecdsa_signature.corrupted.bin) && " +
+          "sed -i '1s/^./\\x00/' $(location hybrid_owner.ecdsa_signature.corrupted.bin)",
+)
+
+ownership_signature_test(
+    name = "wrong_owner_ecdsa_signature_test",
+    srcs = ["//sw/device/silicon_creator/lib/ownership/testdata:hybrid_owner_bin"],
+    ecdsa_key = "//sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key_pub",
+    ecdsa_signature = ":corrupt_hybrid_owner_ecdsa_signature",
+    negative_test = True,
+    spx_key = "//sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key_spx_pub",
+    spx_signature = "//sw/device/silicon_creator/lib/ownership/testdata:hybrid_owner_spx_signature",
+)
+
+genrule(
+    name = "corrupt_hybrid_owner_spx_signature",
+    srcs = ["//sw/device/silicon_creator/lib/ownership/testdata:hybrid_owner_spx_signature"],
+    outs = ["hybrid_owner.spx_signature.corrupted.bin"],
+    cmd = "cp $(location //sw/device/silicon_creator/lib/ownership/testdata:hybrid_owner_spx_signature) $(location hybrid_owner.spx_signature.corrupted.bin) && " +
+          "sed -i '1s/^./\\x00/' $(location hybrid_owner.spx_signature.corrupted.bin)",
+)
+
+ownership_signature_test(
+    name = "wrong_owner_spx_signature_test",
+    srcs = ["//sw/device/silicon_creator/lib/ownership/testdata:hybrid_owner_bin"],
+    ecdsa_key = "//sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key_pub",
+    ecdsa_signature = "//sw/device/silicon_creator/lib/ownership/testdata:hybrid_owner_ecdsa_signature",
+    negative_test = True,
+    spx_key = "//sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key_spx_pub",
+    spx_signature = ":corrupt_hybrid_owner_spx_signature",
 )

--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -160,7 +160,7 @@ cc_test(
     name = "owner_block_unittest",
     srcs = [
         "owner_block_unittest.cc",
-        "testdata/basic_owner_testdata.h",
+        "//sw/device/silicon_creator/lib/ownership/testdata:basic_owner_testdata.h",
     ],
     deps = [
         ":datatypes",

--- a/sw/device/silicon_creator/lib/ownership/keys/dummy/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/keys/dummy/BUILD
@@ -21,6 +21,11 @@ filegroup(
 )
 
 filegroup(
+    name = "activate_key_pub",
+    srcs = ["activate_ecdsa_p256.pub.der"],
+)
+
+filegroup(
     name = "unlock_key",
     srcs = ["unlock_ecdsa_p256.der"],
 )
@@ -43,6 +48,11 @@ filegroup(
 filegroup(
     name = "activate_key_spx",
     srcs = ["activate_spx.pem"],
+)
+
+filegroup(
+    name = "activate_key_spx_pub",
+    srcs = ["activate_spx.pub.pem"],
 )
 
 filegroup(

--- a/sw/device/silicon_creator/lib/ownership/testdata/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/testdata/BUILD
@@ -1,0 +1,68 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "basic_owner.json5",
+    "basic_owner_testdata.h",
+    "hybrid_owner.json5",
+])
+
+genrule(
+    name = "hybrid_owner_bin",
+    srcs = [
+        "hybrid_owner.json5",
+        "//sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key_pub",
+        "//sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key_spx_pub",
+    ],
+    outs = ["hybrid_owner.bin"],
+    cmd = """
+        $(execpath //sw/host/opentitantool) --rcfile= \\
+            ownership config --input $(location hybrid_owner.json5) $@
+    """,
+    tools = ["//sw/host/opentitantool"],
+)
+
+genrule(
+    name = "hybrid_owner_digest",
+    srcs = [":hybrid_owner_bin"],
+    outs = ["hybrid_owner.digest"],
+    cmd = """
+        $(execpath //sw/host/opentitantool) --rcfile= \\
+            ownership digest $(location :hybrid_owner_bin) --bin $@
+    """,
+    tools = ["//sw/host/opentitantool"],
+)
+
+genrule(
+    name = "hybrid_owner_ecdsa_signature",
+    srcs = [
+        ":hybrid_owner_digest",
+        "//sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key",
+    ],
+    outs = ["hybrid_owner.ecdsa_signature"],
+    cmd = """
+        $(execpath //sw/host/opentitantool) --rcfile= \\
+            ecdsa sign  $(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key) \\
+            --input $(location :hybrid_owner_digest) --output $@
+    """,
+    tools = ["//sw/host/opentitantool"],
+)
+
+genrule(
+    name = "hybrid_owner_spx_signature",
+    srcs = [
+        ":hybrid_owner_digest",
+        "//sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key_spx",
+    ],
+    outs = ["hybrid_owner.spx_signature"],
+    cmd = """
+        $(execpath //sw/host/opentitantool) --rcfile= \\
+            spx sign $(location :hybrid_owner_digest) \\
+            $(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key_spx) \\
+            --output $@ --domain PrehashedSha256
+    """,
+    tools = ["//sw/host/opentitantool"],
+)

--- a/sw/device/silicon_creator/lib/ownership/testdata/hybrid_owner.json5
+++ b/sw/device/silicon_creator/lib/ownership/testdata/hybrid_owner.json5
@@ -1,0 +1,193 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This is a basic owner block with invalid key material.  It is used to
+// create the binary blocks used by the owner_block_unittest.
+//
+// To convert this file to binary form, use opentitantool:
+// $ opentitantool ownership config --input file.json file.bin
+{
+  sram_exec: "DisabledLocked",
+  ownership_key_alg: "HybridSpxPrehash",
+  owner_key: {
+    Hybrid: {
+      ecdsa: "sw/device/silicon_creator/lib/ownership/keys/dummy/owner_ecdsa_p256.pub.der",
+      spx: "sw/device/silicon_creator/lib/ownership/keys/dummy/owner_spx.pub.pem"
+    }
+  },
+  activate_key: {
+    Ecdsa: {
+        x: "0000000000000000000000000000000000000000000000000000000000000000",
+        y: "0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  },
+  unlock_key: {
+    Ecdsa: {
+        x: "0000000000000000000000000000000000000000000000000000000000000000",
+        y: "0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  },
+  data: [
+    {
+      ApplicationKey: {
+        key_alg: "EcdsaP256",
+        key_domain: "Prod",
+        key_diversifier: [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0
+        ],
+        usage_constraint: 0,
+        key: {
+          Ecdsa: {
+              x: "0000000000000000000000000000000000000000000000000000000000000000",
+              y: "0000000000000000000000000000000000000000000000000000000000000000"
+          }
+        }
+      }
+    },
+    {
+      FlashConfig: {
+        config: [
+          {
+            start: 32,
+            size: 192,
+            read: true,
+            program: true,
+            erase: true,
+            scramble: true,
+            ecc: true,
+            high_endurance: false,
+            protect_when_active: true
+          },
+          {
+            start: 224,
+            size: 32,
+            read: true,
+            program: true,
+            erase: true,
+            scramble: false,
+            ecc: false,
+            high_endurance: true,
+            protect_when_active: false
+          },
+          {
+            start: 288,
+            size: 192,
+            read: true,
+            program: true,
+            erase: true,
+            scramble: true,
+            ecc: true,
+            high_endurance: false,
+            protect_when_active: true
+          },
+          {
+            start: 480,
+            size: 32,
+            read: true,
+            program: true,
+            erase: true,
+            scramble: false,
+            ecc: false,
+            high_endurance: true,
+            protect_when_active: false
+          }
+        ]
+      }
+    },
+    {
+      FlashInfoConfig: {
+        config: [
+          {
+            bank: 0,
+            page: 5,
+            pad: 0,
+            read: true,
+            program: true,
+            erase: true,
+            scramble: true,
+            ecc: true,
+            high_endurance: false,
+            protect_when_active: false
+          },
+          {
+            bank: 0,
+            page: 6,
+            pad: 0,
+            read: true,
+            program: true,
+            erase: true,
+            scramble: true,
+            ecc: true,
+            high_endurance: false,
+            protect_when_active: false
+          },
+          {
+            bank: 0,
+            page: 7,
+            pad: 0,
+            read: true,
+            program: true,
+            erase: true,
+            scramble: true,
+            ecc: true,
+            high_endurance: false,
+            protect_when_active: false
+          },
+          {
+            bank: 0,
+            page: 8,
+            pad: 0,
+            read: true,
+            program: true,
+            erase: true,
+            scramble: true,
+            ecc: true,
+            high_endurance: false,
+            protect_when_active: false
+          }
+        ]
+      }
+    },
+    {
+      IsfbConfig: {
+        bank: 0,
+        page: 5,
+        erase_conditions: 0x666,
+        key_domain: "Dev",
+        product_words: 4
+      }
+    },
+    {
+      RescueConfig: {
+        rescue_type: "Xmodem",
+        trigger: "UartBreak",
+        trigger_index: 0,
+        gpio_pull_en: false,
+        gpio_value: false,
+        enter_on_failure: false,
+        timeout: 0,
+        start: 32,
+        size: 192,
+        command_allow: [
+          "Empty",
+          "MinBl0SecVerRequest",
+          "NextBl0SlotRequest",
+          "OwnershipUnlockRequest",
+          "OwnershipActivateRequest",
+          "Rescue",
+          "GetBootLog",
+          "BootSvcReq",
+          "BootSvcRsp",
+          "OwnerBlock"
+        ]
+      }
+    }
+  ],
+}

--- a/sw/host/opentitantool/src/command/ownership.rs
+++ b/sw/host/opentitantool/src/command/ownership.rs
@@ -19,6 +19,7 @@ use opentitanlib::ownership::{
     DetachedSignature, DetachedSignatureCommand, GlobalFlags, KeyMaterial, OwnerBlock,
     OwnershipKeyAlg, TlvHeader,
 };
+use sphincsplus::{DecodeKey, SphincsPlus, SpxDomain, SpxPublicKey, SpxRawSignature};
 
 #[derive(ValueEnum, Debug, Clone, Copy, PartialEq)]
 enum Format {
@@ -227,9 +228,17 @@ pub struct OwnershipVerifyCommand {
     #[arg(
         short,
         long,
-        help = "File containing the public key to verfify against"
+        help = "File containing the ECDSA public key to verify against"
     )]
-    signer_pub_key: Option<PathBuf>,
+    ecdsa_pub_key: Option<PathBuf>,
+    #[arg(long, help = "File containing the SPX public key to verify against")]
+    spx_pub_key: Option<PathBuf>,
+    #[arg(long, help = "File containing the detached ECDSA signature")]
+    ecdsa_sig: Option<PathBuf>,
+    #[arg(long, help = "File containing the detached SPX signature")]
+    spx_sig: Option<PathBuf>,
+    #[arg(long, default_value_t = SphincsPlus::Sha2128sSimple, help = "SPX algorithm")]
+    spx_algorithm: SphincsPlus,
 }
 
 impl CommandDispatch for OwnershipVerifyCommand {
@@ -243,29 +252,71 @@ impl CommandDispatch for OwnershipVerifyCommand {
         let header = TlvHeader::read(&mut cursor)?;
         let parsed_config = OwnerBlock::read(&mut cursor, header)?;
 
-        match parsed_config.ownership_key_alg {
-            OwnershipKeyAlg::EcdsaP256 => (),
-            _ => {
-                return Err(anyhow!(
-                    "The only supported verification algorithm is ECDSA"
-                ));
-            }
-        };
+        if !parsed_config.ownership_key_alg.is_ecdsa() && !parsed_config.ownership_key_alg.is_spx()
+        {
+            return Err(anyhow!(
+                "Unsupported verification algorithm: {}",
+                parsed_config.ownership_key_alg
+            ));
+        }
 
-        let ecdsa_key: EcdsaPublicKey = if let Some(key_file) = &self.signer_pub_key {
-            EcdsaPublicKey::load(key_file)?
-        } else {
-            // Retrieve the ECDSA key.
-            let pubk = match parsed_config.owner_key {
-                KeyMaterial::Ecdsa(ref raw_key) => raw_key,
-                _ => return Err(anyhow!("Owner key material does not match key algorithm!")),
-            };
-            pubk.try_into()?
-        };
         // Digest over the TBS section of the config.
         let digest = Sha256Digest::hash(&input[..OwnerBlock::SIGNATURE_OFFSET]);
 
-        ecdsa_key.verify(&digest, &parsed_config.signature)?;
+        if parsed_config.ownership_key_alg.is_ecdsa() {
+            let ecdsa_key: EcdsaPublicKey = if let Some(key_file) = &self.ecdsa_pub_key {
+                EcdsaPublicKey::load(key_file)?
+            } else {
+                let pubk = match parsed_config.owner_key {
+                    KeyMaterial::Ecdsa(ref raw_key) => raw_key,
+                    KeyMaterial::Hybrid(ref hybrid) => &hybrid.ecdsa,
+                    _ => return Err(anyhow!("Owner key material does not contain an ECDSA key!")),
+                };
+                pubk.try_into()?
+            };
+
+            let ecdsa_sig = if parsed_config.ownership_key_alg == OwnershipKeyAlg::EcdsaP256 {
+                parsed_config.signature.clone()
+            } else {
+                let sig_file = self.ecdsa_sig.as_ref().ok_or_else(|| {
+                    anyhow!("Algorithm {} requires a detached ECDSA signature, please provide --ecdsa-sig", parsed_config.ownership_key_alg)
+                })?;
+                EcdsaRawSignature::read_from_file(sig_file)?
+            };
+            ecdsa_key.verify(&digest, &ecdsa_sig)?;
+        }
+
+        if parsed_config.ownership_key_alg.is_spx() {
+            let spx_key = if let Some(key_file) = &self.spx_pub_key {
+                SpxPublicKey::read_pem_file(key_file)?
+            } else {
+                let pubk = match parsed_config.owner_key {
+                    KeyMaterial::Spx(ref raw_key) => raw_key,
+                    KeyMaterial::Hybrid(ref hybrid) => &hybrid.spx,
+                    _ => return Err(anyhow!("Owner key material does not contain an SPX key!")),
+                };
+                let mut key_bytes = Vec::new();
+                pubk.write(&mut key_bytes)?;
+                SpxPublicKey::from_bytes(self.spx_algorithm, &key_bytes)?
+            };
+
+            let sig_file = self.spx_sig.as_ref().ok_or_else(|| {
+                anyhow!(
+                    "Algorithm {} requires a detached SPX signature, please provide --spx-sig",
+                    parsed_config.ownership_key_alg
+                )
+            })?;
+            let spx_sig_bytes = SpxRawSignature::read_from_file(sig_file, self.spx_algorithm)?;
+
+            let (domain, msg) = if parsed_config.ownership_key_alg.is_prehashed() {
+                (SpxDomain::PreHashedSha256, digest.as_ref())
+            } else {
+                (SpxDomain::Pure, &input[..OwnerBlock::SIGNATURE_OFFSET])
+            };
+
+            spx_key.verify(domain, spx_sig_bytes.as_bytes(), msg)?;
+        }
+
         Ok(None)
     }
 }


### PR DESCRIPTION
This introduces a new Bazel test rule for ownership signature verification and enhances opentitantool to support SPX and Hybrid signature verification for owner block.

- Enhance opentitantool verification: The `ownership verify `command is updated to support SPX and Hybrid algorithms. Previously, only EcdsaP256 with embedded signatures was supported.
- Introduce `ownership_signature_test` rule: A new Bazel rule and corresponding bash template that orchestrates the verification of ownership blocks against ECDSA and SPX public keys.

