### PR TITLE
[manuf] Remove broken tag from emulation_dice_cwt

### DIFF
--- a/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
@@ -49,8 +49,6 @@ EARLGREY_SKUS = {
         "spx_key": {},
         "signature_prefix": None,
         "orchestrator_cfg": "@lowrisc_opentitan//sw/host/provisioning/orchestrator/configs/skus:emulation_dice_cwt.hjson",
-        # FIXME (#29412) The ROM_EXT is bigger than 64k which breaks the perso binaries.
-        "tags": ["broken"],
     },
     # OTP Config: Emulation; DICE Certs: X.509; Additional Certs: TPM EK
     "emulation_tpm": {


### PR DESCRIPTION
The ROM_EXT now fits within 64k in this configuration. These tests were marked as broken in #29422. Fixes #29412
