### PR TITLE
[fpv,tool] Revert "[fpv/tool] parse results calculation"

### DIFF
--- a/hw/formal/tools/jaspergold/parse-formal-report.py
+++ b/hw/formal/tools/jaspergold/parse-formal-report.py
@@ -109,10 +109,9 @@ def get_summary(str_buffer, exp_failures):
                         ("unreachable", r"^\[\d+\].*unreachable.*")]
     summary = extract_messages_count(str_buffer, message_patterns, exp_failures)
 
-    # Undetermined properties are categorized as pass because we could not find
-    # any counter-cases within the limited time of running.
-    summary["pass_rate"] = format_percentage(summary["proven"] + summary["undetermined"],
-                                             summary["cex"] + summary["unreachable"])
+    summary["pass_rate"] = format_percentage(summary["proven"],
+                                             summary["cex"] + summary["undetermined"] +
+                                             summary["unreachable"])
     summary["cov_rate"] = format_percentage(summary["covered"], summary["unreachable"])
 
     return summary


### PR DESCRIPTION
This reverts commit 8df2f2294bd3d61ab568e0dc6684f1d07804c3a9, which was made in 2022 and defined an undetermined FPV result as a pass.

This is very unsatisfactory and (from some experience) is likely to be incorrect: we have several properties that we believed had been proven in the sec_cm tests, but were actually false. These mistakes don't seem to have hidden any security bugs, but we had better ensure we don't make them again.