### PR TITLE
[dv] Remove keymgr config file from Darjeeling sim_cfg list

### DIFF
--- a/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
+++ b/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
@@ -29,7 +29,6 @@
              "{proj_root}/hw/ip/entropy_src/dv/entropy_src_rng16bits_sim_cfg.hjson",
              "{proj_root}/hw/ip/hmac/dv/hmac_sim_cfg.hjson",
              "{proj_root}/hw/ip/i2c/dv/i2c_sim_cfg.hjson",
-             "{proj_root}/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson",
              "{proj_root}/hw/ip/keymgr_dpe/dv/keymgr_dpe_sim_cfg.hjson",
              "{proj_root}/hw/ip/kmac/dv/kmac_masked_sim_cfg.hjson",
              "{proj_root}/hw/ip/kmac/dv/kmac_unmasked_sim_cfg.hjson",


### PR DESCRIPTION
From the history, it looks like this was added in https://github.com/lowRISC/opentitan/commit/28af81ab6e41d9ee6b270f28c7e62761d6c62c31 and then not subsequently removed by the relevant https://github.com/lowRISC/opentitan/commit/32a974b8a0bdd1660d2722d4f3186a7a9828fded commit, despite the fact that Darjeeling does not have a keymgr and instead uses the keymgr_dpe block (which it already has a SimCfg for). Running these block-level regressions for Darjeeling is pointless, and currently just wasting time in nightly/weekly runs given that they aren't needed for Darjeeling.

As far as I can tell, the Keymgr DPE tests currently just consist of the smoke test and don't use the keymgr tests in any way at all - but please do correct me if I've missed something here!