### PR TITLE
[crypto/tests] Add crt sections to export size

### DIFF
--- a/sw/device/tests/crypto/otcrypto_export_size.c
+++ b/sw/device/tests/crypto/otcrypto_export_size.c
@@ -4,5 +4,11 @@
 
 #include "sw/device/tests/crypto/otcrypto_interface.h"
 
+// Only here for coverage reporting.
+// Satisfy bare_metal_start.S so the linker doesn't crash.
+// These don't need to actually initialize RAM.
+void crt_section_copy(void) {}
+void crt_section_clear(void) {}
+
 // Simple main function so the linker doesn't discard the inerface struct.
 void bare_metal_main(void) { (void)otcrypto; }


### PR DESCRIPTION
Add the crt_section_copy and crt_section_clear to otcrypto_export_size such that it is possible to use the otcrypto_export_size as the baseline for coverage reporting.