### PR TITLE
[cov,crypto] Add coverage_view_test for otcrypto library

### DIFF
--- a/sw/device/silicon_owner/bare_metal/BUILD
+++ b/sw/device/silicon_owner/bare_metal/BUILD
@@ -19,6 +19,7 @@ ld_library(
     includes = ["bare_metal_common.ld"],
     deps = [
         "//sw/device:info_sections",
+        "//sw/device/lib/coverage:coverage_sections",
         "//sw/device/silicon_creator/lib/base:static_critical_sections",
     ],
 )

--- a/sw/device/silicon_owner/bare_metal/bare_metal_common.ld
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_common.ld
@@ -50,6 +50,8 @@ _manifest_address_translation = (_text_start >= ORIGIN(eflash) &&
                                  _text_start < (ORIGIN(eflash)
                                               + LENGTH(eflash))) ? 0x1d4 : 0x739;
 
+REGION_ALIAS("coverage_flash", owner_flash);
+
 /**
  * NOTE: We have to align each section to word boundaries as our current
  * s19->slm conversion scripts are not able to handle non-word aligned sections.
@@ -102,6 +104,8 @@ SECTIONS {
     *(.rodata)
     *(.rodata.*)
   } > owner_flash
+
+  INCLUDE sw/device/lib/coverage/rodata.ld
 
   /**
    * Mutable data section, at the bottom of ram_main. This will be initialized
@@ -164,6 +168,8 @@ SECTIONS {
     . = ALIGN(4);
     _bss_end = .;
   } > ram_main
+
+  INCLUDE sw/device/lib/coverage/bss.ld
 
   INCLUDE sw/device/info_sections.ld
 }

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -18,6 +18,7 @@ load(
     "verilator_params",
 )
 load("@ot_python_deps//:requirements.bzl", "requirement")
+load("//rules/coverage:view.bzl", "coverage_view_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -49,6 +50,7 @@ opentitan_binary(
     copts = ["-fno-lto"],
     exec_env = [
         "//hw/top_earlgrey:fpga_cw310_rom_ext",
+        "//hw/top_earlgrey:silicon_creator",
     ],
     linker_script = "//sw/device/silicon_owner/bare_metal:ld_slot_a",
     manifest = "//sw/device/silicon_owner/bare_metal:manifest",
@@ -57,6 +59,11 @@ opentitan_binary(
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",
     ],
+)
+
+coverage_view_test(
+    name = "otcrypto_coverage_view",
+    elf = "otcrypto_export_size",
 )
 
 opentitan_test(


### PR DESCRIPTION
This adds a `coverage_view_test` rule for the `otcrypto_export_size` binary to support coverage analysis of production code.

It also adds the `silicon_creator` execution environment to the binary since the `coverage_view_test` requires a silicon target.