### PR TITLE
[GPIO, dep] Move the dependency on gpio_straps_if to the correct place

### DIFF
--- a/hw/ip_templates/gpio/dv/env/gpio_env.core.tpl
+++ b/hw/ip_templates/gpio/dv/env/gpio_env.core.tpl
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
+      - ${instance_vlnv(f"lowrisc:dv:{module_instance_name}_if")}
     files:
       - ${module_instance_name}_env_pkg.sv
       - ${module_instance_name}_env_cfg.sv: {is_include_file: true}

--- a/hw/ip_templates/gpio/dv/gpio_sim.core.tpl
+++ b/hw/ip_templates/gpio/dv/gpio_sim.core.tpl
@@ -13,7 +13,6 @@ filesets:
     depend:
       - ${instance_vlnv(f"lowrisc:dv:{module_instance_name}_test")}
       - ${instance_vlnv(f"lowrisc:dv:{module_instance_name}_sva")}
-      - ${instance_vlnv(f"lowrisc:dv:{module_instance_name}_if")}
     files:
       - tb/tb.sv
     file_type: systemVerilogSource

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_env.core
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_env.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
+      - lowrisc:darjeeling_dv:gpio_if
     files:
       - gpio_env_pkg.sv
       - gpio_env_cfg.sv: {is_include_file: true}

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/gpio_sim.core
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/gpio_sim.core
@@ -13,7 +13,6 @@ filesets:
     depend:
       - lowrisc:darjeeling_dv:gpio_test
       - lowrisc:darjeeling_dv:gpio_sva
-      - lowrisc:darjeeling_dv:gpio_if
     files:
       - tb/tb.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_env.core
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_env.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
+      - lowrisc:earlgrey_dv:gpio_if
     files:
       - gpio_env_pkg.sv
       - gpio_env_cfg.sv: {is_include_file: true}

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/gpio_sim.core
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/gpio_sim.core
@@ -13,7 +13,6 @@ filesets:
     depend:
       - lowrisc:earlgrey_dv:gpio_test
       - lowrisc:earlgrey_dv:gpio_sva
-      - lowrisc:earlgrey_dv:gpio_if
     files:
       - tb/tb.sv
     file_type: systemVerilogSource

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_env.core
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_env.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
+      - lowrisc:englishbreakfast_dv:gpio_if
     files:
       - gpio_env_pkg.sv
       - gpio_env_cfg.sv: {is_include_file: true}

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/gpio_sim.core
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/gpio_sim.core
@@ -13,7 +13,6 @@ filesets:
     depend:
       - lowrisc:englishbreakfast_dv:gpio_test
       - lowrisc:englishbreakfast_dv:gpio_sva
-      - lowrisc:englishbreakfast_dv:gpio_if
     files:
       - tb/tb.sv
     file_type: systemVerilogSource


### PR DESCRIPTION
`gpio_if` core contains `gpio_straps_if` which the `gpio_env_pkg` use it as an import. Hence the right place for that dependency is in `gpio_env.core` instead of `gpio_sim.core`. Otherwise, if we are integrating a chip level gpio environment and only interested in gpio_env related things then a build error is expected saying "unknown interface `gpio_straps_if` in `gpio_env_pkg`".