### PR TITLE
[crypto] Restructure HARDENED_TRY_WIPE_DMEM

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc/curve25519.c
@@ -92,10 +92,10 @@ status_t curve25519_keygen_start(
 status_t curve25519_keygen_finalize(
     uint32_t public_key[kCurve25519PointWords]) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+  HARDENED_TRY(otbn_busy_wait_for_done());
 
   // Read the public key A from OTBN dmem.
-  HARDENED_TRY_WIPE_DMEM(
+  HARDENED_TRY(
       otbn_dmem_read(kCurve25519PointWords, kOtbnVarPubKey, public_key));
 
   // Wipe DMEM.
@@ -126,14 +126,13 @@ status_t curve25519_sign_stage1_start(
 status_t curve25519_sign_stage1_finalize(
     curve25519_signature_t *sig, uint32_t public_key[kCurve25519PointWords]) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+  HARDENED_TRY(otbn_busy_wait_for_done());
 
   // Read the signature commitment R from OTBN dmem.
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kCurve25519PointWords, kOtbnVarSigR, sig->r));
+  HARDENED_TRY(otbn_dmem_read(kCurve25519PointWords, kOtbnVarSigR, sig->r));
 
   // Read the public key A from OTBN dmem.
-  HARDENED_TRY_WIPE_DMEM(
+  HARDENED_TRY(
       otbn_dmem_read(kCurve25519PointWords, kOtbnVarPubKey, public_key));
 
   // Wipe DMEM.
@@ -167,11 +166,10 @@ status_t curve25519_sign_stage2_start(
 
 status_t curve25519_sign_stage2_finalize(curve25519_signature_t *sig) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+  HARDENED_TRY(otbn_busy_wait_for_done());
 
   // Read the signature response S from OTBN dmem.
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kCurve25519ScalarWords, kOtbnVarSigS, sig->s));
+  HARDENED_TRY(otbn_dmem_read(kCurve25519ScalarWords, kOtbnVarSigS, sig->s));
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();
@@ -206,10 +204,10 @@ status_t curve25519_verify_start(
 
 status_t curve25519_verify_finalize(hardened_bool_t *result) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+  HARDENED_TRY(otbn_busy_wait_for_done());
 
   uint32_t ok;
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(1, kOtbnVarVerifyRes, &ok));
+  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarVerifyRes, &ok));
   if (launder32(ok) != kHardenedBoolTrue) {
     HARDENED_TRY(otbn_dmem_sec_wipe());
     return OTCRYPTO_BAD_ARGS;
@@ -219,10 +217,8 @@ status_t curve25519_verify_finalize(hardened_bool_t *result) {
   // Read the computed LHS and RHS out of OTBN dmem.
   uint32_t lhs[kCurve25519PointWords];
   uint32_t rhs[kCurve25519PointWords];
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kCurve25519PointWords, kOtbnVarVerifyLhs, lhs));
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kCurve25519PointWords, kOtbnVarVerifyRhs, rhs));
+  HARDENED_TRY(otbn_dmem_read(kCurve25519PointWords, kOtbnVarVerifyLhs, lhs));
+  HARDENED_TRY(otbn_dmem_read(kCurve25519PointWords, kOtbnVarVerifyRhs, rhs));
 
   *result = hardened_memeq(lhs, rhs, kCurve25519PointWords);
 

--- a/sw/device/lib/crypto/impl/ecc/p256.c
+++ b/sw/device/lib/crypto/impl/ecc/p256.c
@@ -232,21 +232,19 @@ status_t p256_sideload_attestation_keygen_start(
 status_t p256_keygen_finalize(p256_masked_scalar_t *private_key,
                               p256_point_t *public_key) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+  HARDENED_TRY(otbn_busy_wait_for_done());
   HARDENED_CHECK_EQ(otbn_instruction_count_get(), kModeKeygenInsCnt);
 
   // Read the masked private key from OTBN dmem.
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(kP256MaskedScalarShareWords, kOtbnVarD0,
-                                        private_key->share0));
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(kP256MaskedScalarShareWords, kOtbnVarD1,
-                                        private_key->share1));
+  HARDENED_TRY(otbn_dmem_read(kP256MaskedScalarShareWords, kOtbnVarD0,
+                              private_key->share0));
+  HARDENED_TRY(otbn_dmem_read(kP256MaskedScalarShareWords, kOtbnVarD1,
+                              private_key->share1));
   private_key->checksum = p256_masked_scalar_checksum(private_key);
 
   // Read the public key from OTBN dmem.
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kP256CoordWords, kOtbnVarX, public_key->x));
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kP256CoordWords, kOtbnVarY, public_key->y));
+  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarX, public_key->x));
+  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarY, public_key->y));
 
   // Wipe DMEM.
   HARDENED_TRY(otbn_dmem_sec_wipe());
@@ -256,14 +254,12 @@ status_t p256_keygen_finalize(p256_masked_scalar_t *private_key,
 
 status_t p256_sideload_keygen_finalize(p256_point_t *public_key) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+  HARDENED_TRY(otbn_busy_wait_for_done());
   HARDENED_CHECK_EQ(otbn_instruction_count_get(), kModeKeygenSideloadInsCnt);
 
   // Read the public key from OTBN dmem.
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kP256CoordWords, kOtbnVarX, public_key->x));
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kP256CoordWords, kOtbnVarY, public_key->y));
+  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarX, public_key->x));
+  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarY, public_key->y));
 
   // Wipe DMEM.
   HARDENED_TRY(otbn_dmem_sec_wipe());
@@ -390,7 +386,7 @@ status_t p256_sideload_attestation_sign_start(
 status_t p256_ecdsa_sign_finalize(p256_ecdsa_signature_t *result) {
   uint32_t ins_cnt;
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+  HARDENED_TRY(otbn_busy_wait_for_done());
   ins_cnt = otbn_instruction_count_get();
   if (launder32(ins_cnt) == kModeEcdsaSignSideloadInsCnt) {
     HARDENED_CHECK_EQ(ins_cnt, kModeEcdsaSignSideloadInsCnt);
@@ -401,12 +397,10 @@ status_t p256_ecdsa_sign_finalize(p256_ecdsa_signature_t *result) {
   }
 
   // Read signature R out of OTBN dmem.
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kP256ScalarWords, kOtbnVarR, result->r));
+  HARDENED_TRY(otbn_dmem_read(kP256ScalarWords, kOtbnVarR, result->r));
 
   // Read signature S out of OTBN dmem.
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kP256ScalarWords, kOtbnVarS, result->s));
+  HARDENED_TRY(otbn_dmem_read(kP256ScalarWords, kOtbnVarS, result->s));
 
   // Wipe DMEM.
   HARDENED_TRY(otbn_dmem_sec_wipe());
@@ -446,12 +440,12 @@ status_t p256_ecdsa_verify_start(const p256_ecdsa_signature_t *signature,
 status_t p256_ecdsa_verify_finalize(const p256_ecdsa_signature_t *signature,
                                     hardened_bool_t *result) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+  HARDENED_TRY(otbn_busy_wait_for_done());
 
   // Read the status code out of DMEM (false if basic checks on the validity of
   // the signature and public key failed).
   uint32_t ok;
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(1, kOtbnVarOk, &ok));
+  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarOk, &ok));
   if (launder32(ok) != kHardenedBoolTrue) {
     HARDENED_TRY(otbn_dmem_sec_wipe());
     return OTCRYPTO_BAD_ARGS;
@@ -460,7 +454,7 @@ status_t p256_ecdsa_verify_finalize(const p256_ecdsa_signature_t *signature,
 
   // Read x_r (recovered R) out of OTBN dmem.
   uint32_t x_r[kP256ScalarWords];
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(kP256ScalarWords, kOtbnVarXr, x_r));
+  HARDENED_TRY(otbn_dmem_read(kP256ScalarWords, kOtbnVarXr, x_r));
 
   *result = hardened_memeq(x_r, signature->r, kP256ScalarWords);
 
@@ -494,11 +488,11 @@ status_t p256_ecdh_start(p256_masked_scalar_t *private_key,
 
 status_t p256_ecdh_finalize(p256_ecdh_shared_key_t *shared_key) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+  HARDENED_TRY(otbn_busy_wait_for_done());
 
   // Read the code indicating if the public key is valid.
   uint32_t ok;
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(1, kOtbnVarOk, &ok));
+  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarOk, &ok));
   if (launder32(ok) != kHardenedBoolTrue) {
     HARDENED_TRY(otbn_dmem_sec_wipe());
     return OTCRYPTO_BAD_ARGS;
@@ -515,10 +509,8 @@ status_t p256_ecdh_finalize(p256_ecdh_shared_key_t *shared_key) {
   }
 
   // Read the shares of the key from OTBN dmem (at vars x and y).
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kP256CoordWords, kOtbnVarX, shared_key->share0));
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kP256CoordWords, kOtbnVarY, shared_key->share1));
+  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarX, shared_key->share0));
+  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarY, shared_key->share1));
 
   shared_key->checksum = p256_ecdh_shared_key_checksum(shared_key);
 
@@ -569,13 +561,13 @@ status_t p256_point_on_curve_check(const p256_point_t *point,
   HARDENED_TRY(otbn_execute());
 
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+  HARDENED_TRY(otbn_busy_wait_for_done());
 
   // Check if we executed the expected number of OTBN instructions.
   HARDENED_CHECK_EQ(otbn_instruction_count_get(), kModePointOnCurveCheckInsCnt);
 
   // Read the result of the OTBN operation.
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(1, kOtbnVarOk, result));
+  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarOk, result));
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();
@@ -597,16 +589,14 @@ status_t p256_base_point_mult(p256_masked_scalar_t *private_key,
   HARDENED_TRY(otbn_execute());
 
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+  HARDENED_TRY(otbn_busy_wait_for_done());
 
   // Check if we executed the expected number of OTBN instructions.
   HARDENED_CHECK_EQ(otbn_instruction_count_get(), kModeBasePointMultInsCnt);
 
   // Read the public key from OTBN dmem.
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kP256CoordWords, kOtbnVarX, public_key->x));
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kP256CoordWords, kOtbnVarY, public_key->y));
+  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarX, public_key->x));
+  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarY, public_key->y));
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();
@@ -630,17 +620,17 @@ status_t p256_arith_share_private_key(p256_masked_scalar_t *boolean_private_key,
   HARDENED_TRY(otbn_execute());
 
   /* // Spin here waiting for OTBN to complete. */
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+  HARDENED_TRY(otbn_busy_wait_for_done());
 
   // Check if we executed the expected number of OTBN instructions.
   HARDENED_CHECK_EQ(otbn_instruction_count_get(),
                     kModeArithShareSecretKeyInsCnt);
 
   // Read back the shared private key.
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(kP256MaskedScalarShareWords, kOtbnVarD0,
-                                        arith_private_key->share0));
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(kP256MaskedScalarShareWords, kOtbnVarD1,
-                                        arith_private_key->share1));
+  HARDENED_TRY(otbn_dmem_read(kP256MaskedScalarShareWords, kOtbnVarD0,
+                              arith_private_key->share0));
+  HARDENED_TRY(otbn_dmem_read(kP256MaskedScalarShareWords, kOtbnVarD1,
+                              arith_private_key->share1));
 
   return otbn_dmem_sec_wipe();
 }

--- a/sw/device/lib/crypto/impl/ecc/p384.c
+++ b/sw/device/lib/crypto/impl/ecc/p384.c
@@ -241,21 +241,19 @@ status_t p384_keygen_start(void) {
 status_t p384_keygen_finalize(p384_masked_scalar_t *private_key,
                               p384_point_t *public_key) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+  HARDENED_TRY(otbn_busy_wait_for_done());
   HARDENED_CHECK_EQ(otbn_instruction_count_get(), kModeKeygenInsCnt);
 
   // Read the masked private key from OTBN dmem.
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(kP384MaskedScalarShareWords, kOtbnVarD0,
-                                        private_key->share0));
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(kP384MaskedScalarShareWords, kOtbnVarD1,
-                                        private_key->share1));
+  HARDENED_TRY(otbn_dmem_read(kP384MaskedScalarShareWords, kOtbnVarD0,
+                              private_key->share0));
+  HARDENED_TRY(otbn_dmem_read(kP384MaskedScalarShareWords, kOtbnVarD1,
+                              private_key->share1));
   private_key->checksum = p384_masked_scalar_checksum(private_key);
 
   // Read the public key from OTBN dmem.
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kP384CoordWords, kOtbnVarX, public_key->x));
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kP384CoordWords, kOtbnVarY, public_key->y));
+  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarX, public_key->x));
+  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarY, public_key->y));
 
   // Wipe DMEM.
   HARDENED_TRY(otbn_dmem_sec_wipe());
@@ -277,14 +275,12 @@ status_t p384_sideload_keygen_start(void) {
 
 status_t p384_sideload_keygen_finalize(p384_point_t *public_key) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+  HARDENED_TRY(otbn_busy_wait_for_done());
   HARDENED_CHECK_EQ(otbn_instruction_count_get(), kModeKeygenSideloadInsCnt);
 
   // Read the public key from OTBN dmem.
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kP384CoordWords, kOtbnVarX, public_key->x));
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kP384CoordWords, kOtbnVarY, public_key->y));
+  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarX, public_key->x));
+  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarY, public_key->y));
 
   // Wipe DMEM.
   HARDENED_TRY(otbn_dmem_sec_wipe());
@@ -353,7 +349,7 @@ status_t p384_ecdsa_sideload_sign_start(
 status_t p384_ecdsa_sign_finalize(p384_ecdsa_signature_t *result) {
   uint32_t ins_cnt;
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+  HARDENED_TRY(otbn_busy_wait_for_done());
   ins_cnt = otbn_instruction_count_get();
   if (launder32(ins_cnt) == kModeEcdsaSignSideloadInsCnt) {
     HARDENED_CHECK_EQ(ins_cnt, kModeEcdsaSignSideloadInsCnt);
@@ -364,12 +360,10 @@ status_t p384_ecdsa_sign_finalize(p384_ecdsa_signature_t *result) {
   }
 
   // Read signature R out of OTBN dmem.
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kP384ScalarWords, kOtbnVarR, result->r));
+  HARDENED_TRY(otbn_dmem_read(kP384ScalarWords, kOtbnVarR, result->r));
 
   // Read signature S out of OTBN dmem.
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kP384ScalarWords, kOtbnVarS, result->s));
+  HARDENED_TRY(otbn_dmem_read(kP384ScalarWords, kOtbnVarS, result->s));
 
   // Wipe DMEM.
   HARDENED_TRY(otbn_dmem_sec_wipe());
@@ -406,12 +400,12 @@ status_t p384_ecdsa_verify_start(const p384_ecdsa_signature_t *signature,
 status_t p384_ecdsa_verify_finalize(const p384_ecdsa_signature_t *signature,
                                     hardened_bool_t *result) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+  HARDENED_TRY(otbn_busy_wait_for_done());
 
   // Read the status code out of DMEM (false if basic checks on the validity of
   // the signature and public key failed).
   uint32_t ok;
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(1, kOtbnVarOk, &ok));
+  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarOk, &ok));
   if (launder32(ok) != kHardenedBoolTrue) {
     HARDENED_TRY(otbn_dmem_sec_wipe());
     return OTCRYPTO_BAD_ARGS;
@@ -420,7 +414,7 @@ status_t p384_ecdsa_verify_finalize(const p384_ecdsa_signature_t *signature,
 
   // Read x_r (recovered R) out of OTBN dmem.
   uint32_t x_r[kP384ScalarWords];
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(kP384ScalarWords, kOtbnVarXr, x_r));
+  HARDENED_TRY(otbn_dmem_read(kP384ScalarWords, kOtbnVarXr, x_r));
 
   *result = hardened_memeq(x_r, signature->r, kP384ScalarWords);
 
@@ -451,12 +445,12 @@ status_t p384_ecdh_start(p384_masked_scalar_t *private_key,
 
 status_t p384_ecdh_finalize(p384_ecdh_shared_key_t *shared_key) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+  HARDENED_TRY(otbn_busy_wait_for_done());
 
   // Read the status code out of DMEM (false if basic checks on the validity of
   // the signature and public key failed).
   uint32_t ok;
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(1, kOtbnVarOk, &ok));
+  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarOk, &ok));
   if (launder32(ok) != kHardenedBoolTrue) {
     HARDENED_TRY(otbn_dmem_sec_wipe());
     return OTCRYPTO_BAD_ARGS;
@@ -473,10 +467,8 @@ status_t p384_ecdh_finalize(p384_ecdh_shared_key_t *shared_key) {
   }
 
   // Read the shares of the key from OTBN dmem (at vars x and y).
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kP384CoordWords, kOtbnVarX, shared_key->share0));
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kP384CoordWords, kOtbnVarY, shared_key->share1));
+  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarX, shared_key->share0));
+  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarY, shared_key->share1));
 
   shared_key->checksum = p384_ecdh_shared_key_checksum(shared_key);
 
@@ -525,7 +517,7 @@ status_t p384_point_on_curve_check(const p384_point_t *point,
   HARDENED_TRY(otbn_execute());
 
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+  HARDENED_TRY(otbn_busy_wait_for_done());
 
   // Check if we executed the expected number of OTBN instructions.
   uint32_t ins_cnt = otbn_instruction_count_get();
@@ -538,7 +530,7 @@ status_t p384_point_on_curve_check(const p384_point_t *point,
   }
 
   // Read the result of the OTBN operation.
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(1, kOtbnVarOk, result));
+  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarOk, result));
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();
@@ -560,16 +552,14 @@ status_t p384_base_point_mult(p384_masked_scalar_t *private_key,
   HARDENED_TRY(otbn_execute());
 
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+  HARDENED_TRY(otbn_busy_wait_for_done());
 
   // Check if we executed the expected number of OTBN instructions.
   HARDENED_CHECK_EQ(otbn_instruction_count_get(), kModeBasePointMultInsCnt);
 
   // Read the public key from OTBN dmem.
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kP384CoordWords, kOtbnVarX, public_key->x));
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kP384CoordWords, kOtbnVarY, public_key->y));
+  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarX, public_key->x));
+  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarY, public_key->y));
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();
@@ -593,17 +583,17 @@ status_t p384_arith_share_private_key(p384_masked_scalar_t *boolean_private_key,
   HARDENED_TRY(otbn_execute());
 
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+  HARDENED_TRY(otbn_busy_wait_for_done());
 
   // Check if we executed the expected number of OTBN instructions.
   HARDENED_CHECK_EQ(otbn_instruction_count_get(),
                     kModeArithShareSecretKeyInsCnt);
 
   // Read back the shared private key.
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(kP384MaskedScalarShareWords, kOtbnVarD0,
-                                        arith_private_key->share0));
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(kP384MaskedScalarShareWords, kOtbnVarD1,
-                                        arith_private_key->share1));
+  HARDENED_TRY(otbn_dmem_read(kP384MaskedScalarShareWords, kOtbnVarD0,
+                              arith_private_key->share0));
+  HARDENED_TRY(otbn_dmem_read(kP384MaskedScalarShareWords, kOtbnVarD1,
+                              arith_private_key->share1));
 
   return otbn_dmem_sec_wipe();
 }

--- a/sw/device/lib/crypto/impl/ecc_curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc_curve25519.c
@@ -282,7 +282,7 @@ otcrypto_status_t otcrypto_ed25519_keygen_async_start(
   HARDENED_TRY(otcrypto_sha2_512(&key_buf, &key_digest));
 
   // Start the OTBN keygen app.
-  HARDENED_TRY(curve25519_keygen_start(key_digest.data));
+  HARDENED_TRY_WIPE_DMEM(curve25519_keygen_start(key_digest.data));
 
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
@@ -290,7 +290,7 @@ otcrypto_status_t otcrypto_ed25519_keygen_async_start(
 otcrypto_status_t otcrypto_ed25519_keygen_async_finalize(
     otcrypto_unblinded_key_t *public_key) {
   // Finalize the keygen operation and retrieve the public key.
-  HARDENED_TRY(curve25519_keygen_finalize(public_key->key));
+  HARDENED_TRY_WIPE_DMEM(curve25519_keygen_finalize(public_key->key));
   // Calculate the public key checksum.
   public_key->checksum = integrity_unblinded_checksum(public_key);
   return otcrypto_eval_exit(OTCRYPTO_OK);
@@ -336,7 +336,7 @@ otcrypto_status_t otcrypto_ed25519_sign_part1_async_start(
   HARDENED_TRY(otcrypto_sha2_512(&msg_buf, msg_digest));
 
   // Start the OTBN sign stage 1 app.
-  HARDENED_TRY(
+  HARDENED_TRY_WIPE_DMEM(
       curve25519_sign_stage1_start(msg_digest->data, key_digest->data));
 
   return otcrypto_eval_exit(OTCRYPTO_OK);
@@ -357,7 +357,7 @@ otcrypto_status_t otcrypto_ed25519_sign_part2_async_start(
   // public key A.
   curve25519_signature_t sig_curve25519;
   uint32_t public_key_buf[kCurve25519PointWords];
-  HARDENED_TRY(
+  HARDENED_TRY_WIPE_DMEM(
       curve25519_sign_stage1_finalize(&sig_curve25519, public_key_buf));
   reverse_bytecpy((uint8_t *)signature->data, (uint8_t *)sig_curve25519.r,
                   kCurve25519PointBytes);
@@ -391,7 +391,7 @@ otcrypto_status_t otcrypto_ed25519_sign_part2_async_start(
   HARDENED_TRY(otcrypto_sha2_512(&challenge_buf, &challenge_digest));
 
   // Start the OTBN sign stage 2 app.
-  HARDENED_TRY(curve25519_sign_stage2_start(
+  HARDENED_TRY_WIPE_DMEM(curve25519_sign_stage2_start(
       challenge_digest.data, msg_digest->data, key_digest->data));
 
   return otcrypto_eval_exit(OTCRYPTO_OK);
@@ -404,7 +404,7 @@ otcrypto_status_t otcrypto_ed25519_sign_async_finalize(
 
   // Finalize the signature stage 1 and retrieve the signature response S.
   curve25519_signature_t sig;
-  HARDENED_TRY(curve25519_sign_stage2_finalize(&sig));
+  HARDENED_TRY_WIPE_DMEM(curve25519_sign_stage2_finalize(&sig));
   memcpy(&(signature->data[kCurve25519PointWords]), sig.s,
          kCurve25519ScalarBytes);
 
@@ -461,8 +461,8 @@ otcrypto_status_t otcrypto_ed25519_verify_async_start(
   HARDENED_TRY(otcrypto_sha2_512(&challenge_buf, &challenge_digest));
 
   // Start the OTBN verify app.
-  HARDENED_TRY(curve25519_verify_start(challenge_digest.data, &sig_curve25519,
-                                       public_key->key));
+  HARDENED_TRY_WIPE_DMEM(curve25519_verify_start(
+      challenge_digest.data, &sig_curve25519, public_key->key));
 
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
@@ -470,6 +470,6 @@ otcrypto_status_t otcrypto_ed25519_verify_async_start(
 otcrypto_status_t otcrypto_ed25519_verify_async_finalize(
     hardened_bool_t *verification_result) {
   // Finalize the verify operation and retrieve the verification result.
-  HARDENED_TRY(curve25519_verify_finalize(verification_result));
+  HARDENED_TRY_WIPE_DMEM(curve25519_verify_finalize(verification_result));
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }

--- a/sw/device/lib/crypto/impl/ecc_p256.c
+++ b/sw/device/lib/crypto/impl/ecc_p256.c
@@ -342,7 +342,7 @@ status_t otcrypto_p256_base_point_mult(
   private_scalar.checksum = p256_masked_scalar_checksum(&private_scalar);
 
   p256_point_t *pk = (p256_point_t *)public_key->key;
-  HARDENED_TRY(p256_base_point_mult(&private_scalar, pk));
+  HARDENED_TRY_WIPE_DMEM(p256_base_point_mult(&private_scalar, pk));
 
   public_key->checksum = integrity_unblinded_checksum(public_key);
 
@@ -389,7 +389,9 @@ otcrypto_status_t otcrypto_ecdsa_p256_keygen_async_start(
   HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
                     kOtcryptoKeyModeEcdsaP256);
 
-  return otcrypto_eval_exit(internal_p256_keygen_start(private_key));
+  HARDENED_TRY_WIPE_DMEM(internal_p256_keygen_start(private_key));
+
+  return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
 otcrypto_status_t otcrypto_ecdsa_p256_keygen_async_finalize(
@@ -409,8 +411,10 @@ otcrypto_status_t otcrypto_ecdsa_p256_keygen_async_finalize(
                     kOtcryptoKeyModeEcdsaP256);
   HARDENED_CHECK_EQ(launder32(public_key->key_mode), kOtcryptoKeyModeEcdsaP256);
 
-  return otcrypto_eval_exit(
+  HARDENED_TRY_WIPE_DMEM(
       internal_p256_keygen_finalize(private_key, public_key));
+
+  return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
 otcrypto_status_t otcrypto_ecdsa_p256_dice_keygen_async_start(
@@ -431,7 +435,11 @@ otcrypto_status_t otcrypto_ecdsa_p256_dice_keygen_async_start(
   HARDENED_TRY(keyblob_to_keymgr_attestation_diversification(private_key,
                                                              &diversification));
   HARDENED_TRY(keymgr_generate_key_otbn(diversification, kHardenedBoolTrue));
-  return p256_sideload_attestation_keygen_start(attestation_seed);
+
+  HARDENED_TRY_WIPE_DMEM(
+      p256_sideload_attestation_keygen_start(attestation_seed));
+
+  return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
 otcrypto_status_t otcrypto_ecdsa_p256_dice_keygen_async_finalize(
@@ -496,7 +504,7 @@ otcrypto_status_t otcrypto_ecdsa_p256_sign_config_k_async_start(
   HARDENED_TRY(hardened_memcpy(config_k_scalar.share0, secret_scalar->keyblob,
                                kP256MaskedScalarTotalShareWords));
   config_k_scalar.checksum = p256_masked_scalar_checksum(&config_k_scalar);
-  HARDENED_TRY(p256_ecdsa_sign_config_k_start(
+  HARDENED_TRY_WIPE_DMEM(p256_ecdsa_sign_config_k_start(
       message_digest.data, &private_scalar, &config_k_scalar));
 
   // To detect forgeries of the pointer to the private key that we have passed
@@ -529,13 +537,14 @@ otcrypto_status_t otcrypto_ecdsa_p256_sign_async_start(
                        kP256MaskedScalarTotalShareWords),
         kHardenedBoolTrue);
     private_scalar.checksum = p256_masked_scalar_checksum(&private_scalar);
-    HARDENED_TRY(p256_ecdsa_sign_start(message_digest.data, &private_scalar));
+    HARDENED_TRY_WIPE_DMEM(
+        p256_ecdsa_sign_start(message_digest.data, &private_scalar));
   } else if (private_key->config.hw_backed == kHardenedBoolTrue) {
     // Load the key and start in sideloaded-key mode.
     HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
                       kHardenedBoolTrue);
-    HARDENED_TRY(keyblob_sideload_key_otbn(private_key));
-    HARDENED_TRY(p256_ecdsa_sideload_sign_start(message_digest.data));
+    HARDENED_TRY_WIPE_DMEM(keyblob_sideload_key_otbn(private_key));
+    HARDENED_TRY_WIPE_DMEM(p256_ecdsa_sideload_sign_start(message_digest.data));
   } else {
     // Invalid value for private_key->hw_backed.
     return OTCRYPTO_BAD_ARGS;
@@ -565,7 +574,7 @@ otcrypto_status_t otcrypto_ecdsa_p256_sign_async_finalize(
   // Note: This operation wipes DMEM, so if an error occurs after this
   // point then the signature would be unrecoverable. This should be the
   // last potentially error-causing line before returning to the caller.
-  HARDENED_TRY(p256_ecdsa_sign_finalize(sig_p256));
+  HARDENED_TRY_WIPE_DMEM(p256_ecdsa_sign_finalize(sig_p256));
 
   // Clear the OTBN sideload slot (in case the key was sideloaded).
   return otcrypto_eval_exit(keymgr_sideload_clear_otbn());
@@ -598,8 +607,10 @@ otcrypto_status_t otcrypto_ecdsa_p256_dice_sign_async_start(
                                                              &diversification));
   HARDENED_TRY(keymgr_generate_key_otbn(diversification, kHardenedBoolTrue));
 
-  return p256_sideload_attestation_sign_start(message_digest.data,
-                                              attestation_seed);
+  HARDENED_TRY_WIPE_DMEM(p256_sideload_attestation_sign_start(
+      message_digest.data, attestation_seed));
+
+  return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
 otcrypto_status_t otcrypto_ecdsa_p256_dice_sign_async_finalize(
@@ -682,7 +693,10 @@ otcrypto_status_t otcrypto_ecdh_p256_keygen_async_start(
   }
   HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
                     kOtcryptoKeyModeEcdhP256);
-  return otcrypto_eval_exit(internal_p256_keygen_start(private_key));
+
+  HARDENED_TRY_WIPE_DMEM(internal_p256_keygen_start(private_key));
+
+  return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
 otcrypto_status_t otcrypto_ecdh_p256_keygen_async_finalize(
@@ -700,7 +714,9 @@ otcrypto_status_t otcrypto_ecdh_p256_keygen_async_finalize(
   HARDENED_CHECK_EQ(launder32(public_key->key_mode), kOtcryptoKeyModeEcdhP256);
   HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
                     kOtcryptoKeyModeEcdhP256);
-  return internal_p256_keygen_finalize(private_key, public_key);
+  HARDENED_TRY_WIPE_DMEM(
+      internal_p256_keygen_finalize(private_key, public_key));
+  return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
 otcrypto_status_t otcrypto_ecdh_p256_async_start(
@@ -738,8 +754,8 @@ otcrypto_status_t otcrypto_ecdh_p256_async_start(
   if (private_key->config.hw_backed == kHardenedBoolTrue) {
     HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
                       kHardenedBoolTrue);
-    HARDENED_TRY(keyblob_sideload_key_otbn(private_key));
-    HARDENED_TRY(p256_sideload_ecdh_start(pk));
+    HARDENED_TRY_WIPE_DMEM(keyblob_sideload_key_otbn(private_key));
+    HARDENED_TRY_WIPE_DMEM(p256_sideload_ecdh_start(pk));
   } else if (private_key->config.hw_backed == kHardenedBoolFalse) {
     HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
                       kHardenedBoolFalse);
@@ -751,7 +767,7 @@ otcrypto_status_t otcrypto_ecdh_p256_async_start(
                        kP256MaskedScalarTotalShareWords),
         kHardenedBoolTrue);
     private_scalar.checksum = p256_masked_scalar_checksum(&private_scalar);
-    HARDENED_TRY(p256_ecdh_start(&private_scalar, pk));
+    HARDENED_TRY_WIPE_DMEM(p256_ecdh_start(&private_scalar, pk));
   } else {
     // Invalid value for `hw_backed`.
     return OTCRYPTO_BAD_ARGS;
@@ -805,7 +821,7 @@ otcrypto_status_t otcrypto_ecdh_p256_async_finalize(
   p256_ecdh_shared_key_t ss;
   HARDENED_TRY(hardened_memshred(ss.share0, ARRAYSIZE(ss.share0)));
   HARDENED_TRY(hardened_memshred(ss.share1, ARRAYSIZE(ss.share1)));
-  HARDENED_TRY(p256_ecdh_finalize(&ss));
+  HARDENED_TRY_WIPE_DMEM(p256_ecdh_finalize(&ss));
   HARDENED_CHECK_EQ(p256_ecdh_shared_key_checksum_check(&ss),
                     kHardenedBoolTrue);
   HARDENED_TRY(keyblob_from_shares(ss.share0, ss.share1, shared_secret->config,
@@ -1056,8 +1072,8 @@ otcrypto_status_t otcrypto_ecc_p256_arith_share_private_key(
       p256_masked_scalar_checksum(&boolean_private_scalar);
 
   // Invoke the sharing routine.
-  HARDENED_TRY(p256_arith_share_private_key(&boolean_private_scalar,
-                                            &arith_private_scalar));
+  HARDENED_TRY_WIPE_DMEM(p256_arith_share_private_key(&boolean_private_scalar,
+                                                      &arith_private_scalar));
 
   // Copy the two arithmetic shares into the output buffer.
   HARDENED_TRY(hardened_memcpy(arith_private_key->keyblob,

--- a/sw/device/lib/crypto/impl/ecc_p384.c
+++ b/sw/device/lib/crypto/impl/ecc_p384.c
@@ -55,7 +55,8 @@ otcrypto_status_t otcrypto_ecdsa_p384_keygen_async_start(
   HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
                     kOtcryptoKeyModeEcdsaP384);
 
-  return internal_p384_keygen_start(private_key);
+  HARDENED_TRY_WIPE_DMEM(internal_p384_keygen_start(private_key));
+  return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
 /**
@@ -377,7 +378,7 @@ status_t otcrypto_p384_base_point_mult(
   private_scalar.checksum = p384_masked_scalar_checksum(&private_scalar);
 
   p384_point_t *pk = (p384_point_t *)public_key->key;
-  HARDENED_TRY(p384_base_point_mult(&private_scalar, pk));
+  HARDENED_TRY_WIPE_DMEM(p384_base_point_mult(&private_scalar, pk));
 
   public_key->checksum = integrity_unblinded_checksum(public_key);
 
@@ -401,7 +402,8 @@ otcrypto_status_t otcrypto_ecdsa_p384_keygen_async_finalize(
                     kOtcryptoKeyModeEcdsaP384);
   HARDENED_CHECK_EQ(launder32(public_key->key_mode), kOtcryptoKeyModeEcdsaP384);
 
-  HARDENED_TRY(internal_p384_keygen_finalize(private_key, public_key));
+  HARDENED_TRY_WIPE_DMEM(
+      internal_p384_keygen_finalize(private_key, public_key));
 
   // Clear the OTBN sideload slot (in case the seed was sideloaded).
   return otcrypto_eval_exit(keymgr_sideload_clear_otbn());
@@ -464,7 +466,7 @@ otcrypto_status_t otcrypto_ecdsa_p384_sign_config_k_async_start(
   HARDENED_TRY(hardened_memcpy(config_k_scalar.share0, secret_scalar->keyblob,
                                kP384MaskedScalarTotalShareWords));
   config_k_scalar.checksum = p384_masked_scalar_checksum(&config_k_scalar);
-  HARDENED_TRY(p384_ecdsa_sign_config_k_start(
+  HARDENED_TRY_WIPE_DMEM(p384_ecdsa_sign_config_k_start(
       message_digest.data, &private_scalar, &config_k_scalar));
 
   // To detect forgeries of the pointer to the private key that we have passed
@@ -497,13 +499,14 @@ otcrypto_status_t otcrypto_ecdsa_p384_sign_async_start(
                        kP384MaskedScalarTotalShareWords),
         kHardenedBoolTrue);
     private_scalar.checksum = p384_masked_scalar_checksum(&private_scalar);
-    HARDENED_TRY(p384_ecdsa_sign_start(message_digest.data, &private_scalar));
+    HARDENED_TRY_WIPE_DMEM(
+        p384_ecdsa_sign_start(message_digest.data, &private_scalar));
   } else if (private_key->config.hw_backed == kHardenedBoolTrue) {
     // Load the key and start in sideloaded-key mode.
     HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
                       kHardenedBoolTrue);
-    HARDENED_TRY(keyblob_sideload_key_otbn(private_key));
-    HARDENED_TRY(p384_ecdsa_sideload_sign_start(message_digest.data));
+    HARDENED_TRY_WIPE_DMEM(keyblob_sideload_key_otbn(private_key));
+    HARDENED_TRY_WIPE_DMEM(p384_ecdsa_sideload_sign_start(message_digest.data));
   } else {
     // Invalid value for private_key->hw_backed.
     return OTCRYPTO_BAD_ARGS;
@@ -533,7 +536,7 @@ otcrypto_status_t otcrypto_ecdsa_p384_sign_async_finalize(
   // Note: This operation wipes DMEM, so if an error occurs after this
   // point then the signature would be unrecoverable. This should be the
   // last potentially error-causing line before returning to the caller.
-  HARDENED_TRY(p384_ecdsa_sign_finalize(sig_p384));
+  HARDENED_TRY_WIPE_DMEM(p384_ecdsa_sign_finalize(sig_p384));
 
   // Clear the OTBN sideload slot (in case the key was sideloaded).
   return otcrypto_eval_exit(keymgr_sideload_clear_otbn());
@@ -575,7 +578,7 @@ otcrypto_status_t otcrypto_ecdsa_p384_verify_async_start(
   p384_ecdsa_signature_t *sig = (p384_ecdsa_signature_t *)signature->data;
 
   // Start the asynchronous signature-verification routine.
-  HARDENED_TRY(p384_ecdsa_verify_start(sig, message_digest.data, pk));
+  HARDENED_TRY_WIPE_DMEM(p384_ecdsa_verify_start(sig, message_digest.data, pk));
 
   // To detect forgeries of the pointer to the public key that we have passed
   // to the ECC implementation, check again its integrity. If the pointer would
@@ -598,8 +601,11 @@ otcrypto_status_t otcrypto_ecdsa_p384_verify_async_finalize(
 
   HARDENED_TRY(p384_signature_length_check(signature->len));
   p384_ecdsa_signature_t *sig_p384 = (p384_ecdsa_signature_t *)signature->data;
-  return otcrypto_eval_exit(
+
+  HARDENED_TRY_WIPE_DMEM(
       p384_ecdsa_verify_finalize(sig_p384, verification_result));
+
+  return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
 otcrypto_status_t otcrypto_ecdh_p384_keygen_async_start(
@@ -613,7 +619,8 @@ otcrypto_status_t otcrypto_ecdh_p384_keygen_async_start(
   }
   HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
                     kOtcryptoKeyModeEcdhP384);
-  return otcrypto_eval_exit(internal_p384_keygen_start(private_key));
+  HARDENED_TRY_WIPE_DMEM(internal_p384_keygen_start(private_key));
+  return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
 otcrypto_status_t otcrypto_ecdh_p384_keygen_async_finalize(
@@ -631,8 +638,9 @@ otcrypto_status_t otcrypto_ecdh_p384_keygen_async_finalize(
   HARDENED_CHECK_EQ(launder32(public_key->key_mode), kOtcryptoKeyModeEcdhP384);
   HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
                     kOtcryptoKeyModeEcdhP384);
-  return otcrypto_eval_exit(
+  HARDENED_TRY_WIPE_DMEM(
       internal_p384_keygen_finalize(private_key, public_key));
+  return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
 otcrypto_status_t otcrypto_ecdh_p384_async_start(
@@ -670,8 +678,8 @@ otcrypto_status_t otcrypto_ecdh_p384_async_start(
   if (private_key->config.hw_backed == kHardenedBoolTrue) {
     HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
                       kHardenedBoolTrue);
-    HARDENED_TRY(keyblob_sideload_key_otbn(private_key));
-    HARDENED_TRY(p384_sideload_ecdh_start(pk));
+    HARDENED_TRY_WIPE_DMEM(keyblob_sideload_key_otbn(private_key));
+    HARDENED_TRY_WIPE_DMEM(p384_sideload_ecdh_start(pk));
   } else if (private_key->config.hw_backed == kHardenedBoolFalse) {
     HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
                       kHardenedBoolFalse);
@@ -683,7 +691,7 @@ otcrypto_status_t otcrypto_ecdh_p384_async_start(
                        kP384MaskedScalarTotalShareWords),
         kHardenedBoolTrue);
     private_scalar.checksum = p384_masked_scalar_checksum(&private_scalar);
-    HARDENED_TRY(p384_ecdh_start(&private_scalar, pk));
+    HARDENED_TRY_WIPE_DMEM(p384_ecdh_start(&private_scalar, pk));
   } else {
     // Invalid value for `hw_backed`.
     return OTCRYPTO_BAD_ARGS;
@@ -737,7 +745,7 @@ otcrypto_status_t otcrypto_ecdh_p384_async_finalize(
   p384_ecdh_shared_key_t ss;
   HARDENED_TRY(hardened_memshred(ss.share0, ARRAYSIZE(ss.share0)));
   HARDENED_TRY(hardened_memshred(ss.share1, ARRAYSIZE(ss.share1)));
-  HARDENED_TRY(p384_ecdh_finalize(&ss));
+  HARDENED_TRY_WIPE_DMEM(p384_ecdh_finalize(&ss));
   HARDENED_CHECK_EQ(p384_ecdh_shared_key_checksum_check(&ss),
                     kHardenedBoolTrue);
   HARDENED_TRY(keyblob_from_shares(ss.share0, ss.share1, shared_secret->config,
@@ -988,8 +996,8 @@ otcrypto_status_t otcrypto_ecc_p384_arith_share_private_key(
       p384_masked_scalar_checksum(&boolean_private_scalar);
 
   // Invoke the sharing routine.
-  HARDENED_TRY(p384_arith_share_private_key(&boolean_private_scalar,
-                                            &arith_private_scalar));
+  HARDENED_TRY_WIPE_DMEM(p384_arith_share_private_key(&boolean_private_scalar,
+                                                      &arith_private_scalar));
 
   // Copy the two arithmetic shares into the output buffer.
   HARDENED_TRY(hardened_memcpy(arith_private_key->keyblob,

--- a/sw/device/lib/crypto/impl/rsa.c
+++ b/sw/device/lib/crypto/impl/rsa.c
@@ -6,6 +6,7 @@
 
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/base/math.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/rsa/rsa_encryption.h"
 #include "sw/device/lib/crypto/impl/rsa/rsa_signature.h"
 #include "sw/device/lib/crypto/impl/rsa/run_rsa.h"
@@ -540,7 +541,7 @@ otcrypto_status_t otcrypto_rsa_keygen_async_finalize(
       rsa_2048_public_key_t *pk = (rsa_2048_public_key_t *)public_key->key;
       rsa_2048_private_key_t *sk =
           (rsa_2048_private_key_t *)private_key->keyblob;
-      HARDENED_TRY(rsa_keygen_2048_finalize(pk, sk));
+      HARDENED_TRY_WIPE_DMEM(rsa_keygen_2048_finalize(pk, sk));
       size_used = launder32(size_used) | kOtcryptoRsaSize2048;
       break;
     }
@@ -549,7 +550,7 @@ otcrypto_status_t otcrypto_rsa_keygen_async_finalize(
       rsa_3072_public_key_t *pk = (rsa_3072_public_key_t *)public_key->key;
       rsa_3072_private_key_t *sk =
           (rsa_3072_private_key_t *)private_key->keyblob;
-      HARDENED_TRY(rsa_keygen_3072_finalize(pk, sk));
+      HARDENED_TRY_WIPE_DMEM(rsa_keygen_3072_finalize(pk, sk));
       size_used = launder32(size_used) | kOtcryptoRsaSize3072;
       break;
     }
@@ -558,7 +559,7 @@ otcrypto_status_t otcrypto_rsa_keygen_async_finalize(
       rsa_4096_public_key_t *pk = (rsa_4096_public_key_t *)public_key->key;
       rsa_4096_private_key_t *sk =
           (rsa_4096_private_key_t *)private_key->keyblob;
-      HARDENED_TRY(rsa_keygen_4096_finalize(pk, sk));
+      HARDENED_TRY_WIPE_DMEM(rsa_keygen_4096_finalize(pk, sk));
       size_used = launder32(size_used) | kOtcryptoRsaSize4096;
       break;
     }
@@ -613,7 +614,8 @@ otcrypto_status_t otcrypto_rsa_keypair_from_cofactor_async_start(
       }
       rsa_2048_public_key_t pk;
       HARDENED_TRY(hardened_memcpy(pk.n.data, modulus->data, modulus->len));
-      return otcrypto_eval_exit(rsa_keygen_from_cofactor_2048_start(&pk, cf));
+      HARDENED_TRY_WIPE_DMEM(rsa_keygen_from_cofactor_2048_start(&pk, cf));
+      return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kOtcryptoRsaSize3072: {
       return OTCRYPTO_NOT_IMPLEMENTED;
@@ -660,7 +662,7 @@ otcrypto_status_t otcrypto_rsa_keypair_from_cofactor_async_finalize(
       rsa_2048_public_key_t *pk = (rsa_2048_public_key_t *)public_key->key;
       rsa_2048_private_key_t *sk =
           (rsa_2048_private_key_t *)private_key->keyblob;
-      HARDENED_TRY(rsa_keygen_from_cofactor_2048_finalize(pk, sk));
+      HARDENED_TRY_WIPE_DMEM(rsa_keygen_from_cofactor_2048_finalize(pk, sk));
       break;
     }
     case kOtcryptoRsaSize3072: {
@@ -749,22 +751,25 @@ otcrypto_status_t otcrypto_rsa_sign_async_start(
       HARDENED_CHECK_EQ(size, kOtcryptoRsaSize2048);
       rsa_2048_private_key_t *sk =
           (rsa_2048_private_key_t *)private_key->keyblob;
-      return otcrypto_eval_exit(rsa_signature_generate_2048_start(
+      HARDENED_TRY_WIPE_DMEM(rsa_signature_generate_2048_start(
           sk, message_digest, (rsa_signature_padding_t)padding_mode));
+      return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kOtcryptoRsaSize3072: {
       HARDENED_CHECK_EQ(size, kOtcryptoRsaSize3072);
       rsa_3072_private_key_t *sk =
           (rsa_3072_private_key_t *)private_key->keyblob;
-      return otcrypto_eval_exit(rsa_signature_generate_3072_start(
+      HARDENED_TRY_WIPE_DMEM(rsa_signature_generate_3072_start(
           sk, message_digest, (rsa_signature_padding_t)padding_mode));
+      return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kOtcryptoRsaSize4096: {
       HARDENED_CHECK_EQ(size, kOtcryptoRsaSize4096);
       rsa_4096_private_key_t *sk =
           (rsa_4096_private_key_t *)private_key->keyblob;
-      return otcrypto_eval_exit(rsa_signature_generate_4096_start(
+      HARDENED_TRY_WIPE_DMEM(rsa_signature_generate_4096_start(
           sk, message_digest, (rsa_signature_padding_t)padding_mode));
+      return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     default:
       // Invalid key size. Since the size was inferred, should be unreachable.
@@ -788,16 +793,20 @@ otcrypto_status_t otcrypto_rsa_sign_async_finalize(
   switch (launder32(signature->len)) {
     case kRsa2048NumWords:
       HARDENED_CHECK_EQ(signature->len, kRsa2048NumWords);
-      return rsa_signature_generate_2048_finalize(
-          (rsa_2048_int_t *)signature->data);
+      HARDENED_TRY_WIPE_DMEM(rsa_signature_generate_2048_finalize(
+          (rsa_2048_int_t *)signature->data));
+      return otcrypto_eval_exit(OTCRYPTO_OK);
     case kRsa3072NumWords:
       HARDENED_CHECK_EQ(signature->len, kRsa3072NumWords);
-      return rsa_signature_generate_3072_finalize(
-          (rsa_3072_int_t *)signature->data);
+      HARDENED_TRY_WIPE_DMEM(rsa_signature_generate_3072_finalize(
+          (rsa_3072_int_t *)signature->data));
+      return otcrypto_eval_exit(OTCRYPTO_OK);
     case kRsa4096NumWords:
       HARDENED_CHECK_EQ(signature->len, kRsa4096NumWords);
-      return otcrypto_eval_exit(rsa_signature_generate_4096_finalize(
-          (rsa_4096_int_t *)signature->data));
+      HARDENED_TRY_WIPE_DMEM(
+          otcrypto_eval_exit(rsa_signature_generate_4096_finalize(
+              (rsa_4096_int_t *)signature->data)));
+      return otcrypto_eval_exit(OTCRYPTO_OK);
     default:
       return OTCRYPTO_BAD_ARGS;
   }
@@ -848,7 +857,8 @@ otcrypto_status_t otcrypto_rsa_verify_async_start(
         return OTCRYPTO_BAD_ARGS;
       }
 
-      return rsa_signature_verify_2048_start(pk, sig);
+      HARDENED_TRY_WIPE_DMEM(rsa_signature_verify_2048_start(pk, sig));
+      return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kOtcryptoRsaSize3072: {
       if (signature->len != kRsa3072NumWords) {
@@ -863,7 +873,8 @@ otcrypto_status_t otcrypto_rsa_verify_async_start(
         return OTCRYPTO_BAD_ARGS;
       }
 
-      return rsa_signature_verify_3072_start(pk, sig);
+      HARDENED_TRY_WIPE_DMEM(rsa_signature_verify_3072_start(pk, sig));
+      return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kOtcryptoRsaSize4096: {
       if (signature->len != kRsa4096NumWords) {
@@ -878,7 +889,8 @@ otcrypto_status_t otcrypto_rsa_verify_async_start(
         return OTCRYPTO_BAD_ARGS;
       }
 
-      return otcrypto_eval_exit(rsa_signature_verify_4096_start(pk, sig));
+      HARDENED_TRY_WIPE_DMEM(rsa_signature_verify_4096_start(pk, sig));
+      return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     default:
       // Invalid key size. Since the size was inferred, should be unreachable.
@@ -904,9 +916,10 @@ otcrypto_status_t otcrypto_rsa_verify_async_finalize(
 
   // Call the unified `finalize` operation, which will determine the RSA size
   // based on the mode stored in OTBN.
-  return otcrypto_eval_exit(rsa_signature_verify_finalize(
+  HARDENED_TRY_WIPE_DMEM(rsa_signature_verify_finalize(
       message_digest, (rsa_signature_padding_t)padding_mode,
       verification_result));
+  return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
 otcrypto_status_t otcrypto_rsa_encrypt_async_start(
@@ -949,22 +962,26 @@ otcrypto_status_t otcrypto_rsa_encrypt_async_start(
       HARDENED_CHECK_EQ(size, kOtcryptoRsaSize2048);
       HARDENED_CHECK_EQ(public_key->key_length, sizeof(rsa_2048_public_key_t));
       rsa_2048_public_key_t *pk = (rsa_2048_public_key_t *)public_key->key;
-      return otcrypto_eval_exit(rsa_encrypt_2048_start(
+      HARDENED_TRY_WIPE_DMEM(rsa_encrypt_2048_start(
           pk, hash_mode, message->data, message->len, label->data, label->len));
+      return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kOtcryptoRsaSize3072: {
       HARDENED_CHECK_EQ(size, kOtcryptoRsaSize3072);
       HARDENED_CHECK_EQ(public_key->key_length, sizeof(rsa_3072_public_key_t));
       rsa_3072_public_key_t *pk = (rsa_3072_public_key_t *)public_key->key;
-      return otcrypto_eval_exit(rsa_encrypt_3072_start(
-          pk, hash_mode, message->data, message->len, label->data, label->len));
+      HARDENED_TRY_WIPE_DMEM(otcrypto_eval_exit(
+          rsa_encrypt_3072_start(pk, hash_mode, message->data, message->len,
+                                 label->data, label->len)));
+      return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kOtcryptoRsaSize4096: {
       HARDENED_CHECK_EQ(size, kOtcryptoRsaSize4096);
       HARDENED_CHECK_EQ(public_key->key_length, sizeof(rsa_4096_public_key_t));
       rsa_4096_public_key_t *pk = (rsa_4096_public_key_t *)public_key->key;
-      return otcrypto_eval_exit(rsa_encrypt_4096_start(
+      HARDENED_TRY_WIPE_DMEM(rsa_encrypt_4096_start(
           pk, hash_mode, message->data, message->len, label->data, label->len));
+      return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     default:
       // Invalid key size. Since the size was inferred, should be unreachable.
@@ -989,19 +1006,22 @@ otcrypto_status_t otcrypto_rsa_encrypt_async_finalize(
       HARDENED_CHECK_EQ(ciphertext->len * sizeof(uint32_t),
                         sizeof(rsa_2048_int_t));
       rsa_2048_int_t *ctext = (rsa_2048_int_t *)ciphertext->data;
-      return otcrypto_eval_exit(rsa_encrypt_2048_finalize(ctext));
+      HARDENED_TRY_WIPE_DMEM(rsa_encrypt_2048_finalize(ctext));
+      return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kRsa3072NumWords: {
       HARDENED_CHECK_EQ(ciphertext->len * sizeof(uint32_t),
                         sizeof(rsa_3072_int_t));
       rsa_3072_int_t *ctext = (rsa_3072_int_t *)ciphertext->data;
-      return otcrypto_eval_exit(rsa_encrypt_3072_finalize(ctext));
+      HARDENED_TRY_WIPE_DMEM(rsa_encrypt_3072_finalize(ctext));
+      return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kRsa4096NumWords: {
       HARDENED_CHECK_EQ(ciphertext->len * sizeof(uint32_t),
                         sizeof(rsa_4096_int_t));
       rsa_4096_int_t *ctext = (rsa_4096_int_t *)ciphertext->data;
-      return otcrypto_eval_exit(rsa_encrypt_4096_finalize(ctext));
+      HARDENED_TRY_WIPE_DMEM(rsa_encrypt_4096_finalize(ctext));
+      return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     default:
       return OTCRYPTO_BAD_ARGS;
@@ -1060,7 +1080,8 @@ otcrypto_status_t otcrypto_rsa_decrypt_async_start(
         return OTCRYPTO_BAD_ARGS;
       }
 
-      return otcrypto_eval_exit(rsa_decrypt_2048_start(sk, ctext));
+      HARDENED_TRY_WIPE_DMEM(rsa_decrypt_2048_start(sk, ctext));
+      return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kOtcryptoRsaSize3072: {
       HARDENED_CHECK_EQ(size, kOtcryptoRsaSize3072);
@@ -1079,7 +1100,8 @@ otcrypto_status_t otcrypto_rsa_decrypt_async_start(
         return OTCRYPTO_BAD_ARGS;
       }
 
-      return otcrypto_eval_exit(rsa_decrypt_3072_start(sk, ctext));
+      HARDENED_TRY_WIPE_DMEM(rsa_decrypt_3072_start(sk, ctext));
+      return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kOtcryptoRsaSize4096: {
       HARDENED_CHECK_EQ(size, kOtcryptoRsaSize4096);
@@ -1098,7 +1120,8 @@ otcrypto_status_t otcrypto_rsa_decrypt_async_start(
         return OTCRYPTO_BAD_ARGS;
       }
 
-      return otcrypto_eval_exit(rsa_decrypt_4096_start(sk, ctext));
+      HARDENED_TRY_WIPE_DMEM(rsa_decrypt_4096_start(sk, ctext));
+      return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     default:
       // Invalid key size. Since the size was inferred, should be unreachable.
@@ -1120,9 +1143,9 @@ otcrypto_status_t otcrypto_rsa_decrypt_async_finalize(
 
   // Call the unified `finalize()` operation, which will infer the RSA size
   // from OTBN.
-  HARDENED_TRY(rsa_decrypt_finalize(hash_mode, label->data, label->len,
-                                    plaintext->len, plaintext->data,
-                                    plaintext_bytelen));
+  HARDENED_TRY_WIPE_DMEM(
+      rsa_decrypt_finalize(hash_mode, label->data, label->len, plaintext->len,
+                           plaintext->data, plaintext_bytelen));
 
   // Consistency check; this should never happen.
   if (launder32(*plaintext_bytelen) > plaintext->len) {

--- a/sw/device/lib/crypto/impl/rsa/run_rsa.c
+++ b/sw/device/lib/crypto/impl/rsa/run_rsa.c
@@ -87,11 +87,11 @@ enum {
 
 status_t rsa_modexp_wait(size_t *num_words) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+  HARDENED_TRY(otbn_busy_wait_for_done());
 
   // Read the application mode.
   uint32_t mode;
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(1, kOtbnVarRsaMode, &mode));
+  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarRsaMode, &mode));
 
   *num_words = 0;
   if (mode == kMode2048Modexp || mode == kMode2048ModexpF4) {
@@ -123,7 +123,7 @@ status_t rsa_modexp_wait(size_t *num_words) {
 static status_t rsa_modexp_finalize(const size_t num_words, uint32_t *result) {
   // Wait for OTBN to complete and get the result size.
   size_t num_words_inferred;
-  HARDENED_TRY_WIPE_DMEM(rsa_modexp_wait(&num_words_inferred));
+  HARDENED_TRY(rsa_modexp_wait(&num_words_inferred));
 
   // Check that the inferred result size matches expectations.
   if (num_words != num_words_inferred) {
@@ -134,7 +134,7 @@ static status_t rsa_modexp_finalize(const size_t num_words, uint32_t *result) {
   HARDENED_CHECK_EQ(launder32(num_words), num_words_inferred);
 
   // Read the result.
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(num_words, kOtbnVarRsaInOut, result));
+  HARDENED_TRY(otbn_dmem_read(num_words, kOtbnVarRsaInOut, result));
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();
@@ -300,11 +300,11 @@ static status_t keygen_start(uint32_t mode) {
 static status_t keygen_finalize(uint32_t exp_mode, size_t num_words,
                                 uint32_t *n, uint32_t *d0, uint32_t *d1) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+  HARDENED_TRY(otbn_busy_wait_for_done());
 
   // Read the mode from OTBN dmem and panic if it's not as expected.
   uint32_t act_mode = 0;
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(1, kOtbnVarRsaMode, &act_mode));
+  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarRsaMode, &act_mode));
   if (act_mode != exp_mode) {
     HARDENED_TRY(otbn_dmem_sec_wipe());
     return OTCRYPTO_FATAL_ERR;
@@ -316,7 +316,7 @@ static status_t keygen_finalize(uint32_t exp_mode, size_t num_words,
   uint32_t mr_iters = 0;
 
   // Prime p.
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(1, kOtbnVarRsaMrIterP, &mr_iters));
+  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarRsaMrIterP, &mr_iters));
   if (mr_iters != kMrIters) {
     HARDENED_TRY(otbn_dmem_sec_wipe());
     return OTCRYPTO_FATAL_ERR;
@@ -325,7 +325,7 @@ static status_t keygen_finalize(uint32_t exp_mode, size_t num_words,
 
   // Prime q.
   mr_iters = 0;
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(1, kOtbnVarRsaMrIterQ, &mr_iters));
+  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarRsaMrIterQ, &mr_iters));
   if (mr_iters != kMrIters) {
     HARDENED_TRY(otbn_dmem_sec_wipe());
     return OTCRYPTO_FATAL_ERR;
@@ -333,13 +333,13 @@ static status_t keygen_finalize(uint32_t exp_mode, size_t num_words,
   HARDENED_CHECK_EQ(launder32(mr_iters), kMrIters);
 
   // Read the public modulus (n) from OTBN dmem.
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(num_words, kOtbnVarRsaN, n));
+  HARDENED_TRY(otbn_dmem_read(num_words, kOtbnVarRsaN, n));
 
   // Read the first share of the private exponent (d) from OTBN dmem.
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(num_words, kOtbnVarRsaD0, d0));
+  HARDENED_TRY(otbn_dmem_read(num_words, kOtbnVarRsaD0, d0));
 
   // Read the second share of the private exponent (d) from OTBN dmem.
-  HARDENED_TRY_WIPE_DMEM(otbn_dmem_read(num_words, kOtbnVarRsaD1, d1));
+  HARDENED_TRY(otbn_dmem_read(num_words, kOtbnVarRsaD1, d1));
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();


### PR DESCRIPTION
We should also call HARDENED_TRY_WIPE_DMEM when secret information is already written to OTBN in the _start functions. In order to improve this, call HARDENED_TRY_WIPE_DMEM on impl functions instead of the underlying primitives.

Thanks to @nasahlpa for the comment on it in a previous PR!