### PR TITLE
[ci] Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: Create Release
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: GitHub release tag
+        required: true
+        type: string
+      ref:
+        description: Git branch or commit hash to checkout
+        required: true
+        type: string
+        default: master
+      target:
+        description: Bazel target to add to the release
+        required: true
+        type: string
+        default: //release/devbundle:devbundle
+
+jobs:
+  release:
+    permissions:
+      # Necessary permission to create a release:
+      contents: write
+    runs-on: ubuntu-22.04-vivado
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # Required by bitstream cache script
+          ref: ${{ inputs.ref }}
+
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
+        with:
+          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
+
+      - name: Check target
+        run: |
+          output_file="$(./bazelisk.sh cquery --output=files ${{ inputs.target }} )"
+
+          num_files="$(echo "$output_file" | wc -l)"
+          if [[ "$num_files" -ne 1 ]]; then
+            echo "::error::Expected one file, got ${num_files}"
+            exit 1
+          fi
+
+          if [[ "$output_file" != *.tar* ]]; then
+            echo "::error::Expected tarball, got '${output_file}'"
+            exit 1
+          fi
+
+          echo "output_file=${output_file}" >> "$GITHUB_ENV"
+
+      - name: Build
+        run: |
+          module load xilinx/vivado
+          ./bazelisk.sh build '${{ inputs.target }}'
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Create the release if it doesn't already exist
+          gh release create '${{ inputs.release_tag }}' \
+            --prerelease                                \
+            --target '${{ inputs.ref }}'                \
+          || echo "release exists"
+
+          # Add the artifacts
+          gh release upload '${{ inputs.release_tag }}' \
+            --clobber \
+            "$output_file"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Create Release
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: GitHub release tag
+        required: true
+        type: string
+      ref:
+        description: Git branch or commit hash to checkout
+        required: true
+        type: string
+        default: master
+      target:
+        description: Bazel target to add to the release
+        required: true
+        type: string
+        default: //release/devbundle:devbundle
+
+jobs:
+  release:
+    permissions:
+      # Necessary permission to create a release:
+      contents: write
+    runs-on: ubuntu-22.04-vivado
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # Required by bitstream cache script
+          ref: ${{ inputs.ref }}
+
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
+        with:
+          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
+
+      - name: Check target
+        run: |
+          output_file="$(./bazelisk.sh cquery --output=files ${{ inputs.target }} )"
+
+          num_files="$(echo "$output_file" | wc -l)"
+          if [[ "$num_files" -ne 1 ]]; then
+            echo "::error::Expected one file, got ${num_files}"
+            exit 1
+          fi
+
+          if [[ "$output_file" != *.tar* ]]; then
+            echo "::error::Expected tarball, got '${output_file}'"
+            exit 1
+          fi
+
+          echo "output_file=${output_file}" >> "$GITHUB_ENV"
+
+      - name: Build
+        run: |
+          module load xilinx/vivado
+          ./bazelisk.sh build '${{ inputs.target }}'
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Create the release if it doesn't already exist
+          gh release create '${{ inputs.release_tag }}' \
+            --prerelease                                \
+            --target '${{ inputs.ref }}'                \
+            --title "${{ inputs.release_tag }}"         \
+            --notes ""                                  \
+          || echo "release exists"
+
+          # Add the artifacts
+          gh release upload '${{ inputs.release_tag }}' \
+            --clobber \
+            "$output_file"

--- a/release/devbundle/BUILD
+++ b/release/devbundle/BUILD
@@ -62,15 +62,6 @@ pkg_files(
     },
 )
 
-# TODO(cfrantz): Implement release automation so we don't have to publish the artifact manually.
-# Upload this to the GCS bucket `artifacts.opentitan.org` and name the file
-# with a date tag (e.g. devbundle-YYYYMMDD.tar.xz).
-#
-# For example:
-# $ gcloud --acount=foo@opentitan.org \
-#       storage cp \
-#           bazel-bin/release/devbundle/devbundle.tar.xz \
-#           gs://artifacts.opentitan.org/dev_bundle/devbundle-20250718.tar.xz
 pkg_tar(
     name = "devbundle",
     testonly = True,


### PR DESCRIPTION
This workflow can be manually run to create a GitHub release with a tarball built by Bazel attached. The intended use is distributing the dev bundle (`//release/devbundle`) at a regular cadence.

Test run here: https://github.com/lowRISC/opentitan/actions/runs/24462396903/job/71479969804
And the release that was created: https://github.com/lowRISC/opentitan/releases/tag/test-1

Closes #29776 