### PR TITLE
[Perso BlobV1 #2] Implement V1 TLV library and unit tests

### DIFF
--- a/sw/device/silicon_creator/lib/cert/dice_chain.c
+++ b/sw/device/silicon_creator/lib/cert/dice_chain.c
@@ -157,9 +157,9 @@ static void dice_chain_next_cert_obj(void) {
 OT_WARN_UNUSED_RESULT
 static rom_error_t dice_chain_load_cert_obj(const char *name,
                                             size_t name_size) {
-  rom_error_t err =
-      perso_tlv_get_cert_obj(dice_chain_get_tail_buffer(),
-                             dice_chain_get_tail_size(), &dice_chain.cert_obj);
+  rom_error_t err = perso_tlv_get_cert_obj(
+      dice_chain_get_tail_buffer(), dice_chain_get_tail_size(),
+      kPersoBlobVersionV0, &dice_chain.cert_obj);
 
   if (err != kErrorOk) {
     // Cleanup the stale value if error.
@@ -258,14 +258,14 @@ static rom_error_t dice_chain_push_cert(const char *name, const uint8_t *cert,
   perso_tlv_object_type_t cert_type =
       kDiceCertFormat == kDiceCertFormatX509TcbInfo ? kPersoObjectTypeX509Cert
                                                     : kPersoObjectTypeCwtCert;
-  RETURN_IF_ERROR(perso_tlv_cert_obj_build(name, cert_type, cert, cert_size,
-                                           dice_chain_get_tail_buffer(),
-                                           &cert_page_left));
+  RETURN_IF_ERROR(perso_tlv_cert_obj_build(
+      name, cert_type, cert, cert_size, kPersoBlobVersionV0,
+      dice_chain_get_tail_buffer(), &cert_page_left));
 
   // Move the offset to the new tail.
-  RETURN_IF_ERROR(perso_tlv_get_cert_obj(dice_chain_get_tail_buffer(),
-                                         dice_chain_get_tail_size(),
-                                         &dice_chain.cert_obj));
+  RETURN_IF_ERROR(perso_tlv_get_cert_obj(
+      dice_chain_get_tail_buffer(), dice_chain_get_tail_size(),
+      kPersoBlobVersionV0, &dice_chain.cert_obj));
   dice_chain_next_cert_obj();
   return kErrorOk;
 }

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -213,17 +213,9 @@ OT_WEAK rom_error_t sku_creator_owner_init(boot_data_t *bootdata) {
  * Pushes the hash of the personalization firmware to the perso blob.
  */
 static status_t log_self_hash(perso_blob_t *perso_blob_to_host) {
-  perso_tlv_object_header_t tlv_header = 0;
-  PERSO_TLV_SET_FIELD(Objh, Type, tlv_header, kPersoObjectTypePersoSha256Hash);
-  PERSO_TLV_SET_FIELD(
-      Objh, Size, tlv_header,
-      sizeof(perso_tlv_object_header_t) + sizeof(keymgr_binding_value_t));
-  TRY(perso_tlv_push_to_perso_blob(
-      &tlv_header, sizeof(perso_tlv_object_header_t), perso_blob_to_host));
-  TRY(perso_tlv_push_to_perso_blob(boot_measurements.rom_ext.data,
-                                   sizeof(keymgr_binding_value_t),
-                                   perso_blob_to_host));
-  perso_blob_to_host->num_objs++;
+  TRY(perso_tlv_push_object_to_perso_blob(
+      kPersoObjectTypePersoSha256Hash, boot_measurements.rom_ext.data,
+      sizeof(keymgr_binding_value_t), kPersoBlobVersionV0, perso_blob_to_host));
   return OK_STATUS();
 }
 
@@ -495,7 +487,8 @@ static status_t hash_certificate(const flash_ctrl_info_page_t *page,
   perso_tlv_cert_obj_t cert_obj;
   TRY(flash_ctrl_info_read(page, offset, util_size_to_words(obj_size),
                            cert_buffer));
-  TRY(perso_tlv_get_cert_obj(cert_buffer, kBufferSize, &cert_obj));
+  TRY(perso_tlv_get_cert_obj(cert_buffer, kBufferSize, kPersoBlobVersionV0,
+                             &cert_obj));
 
   hmac_sha256_update(cert_obj.cert_body_p, cert_obj.cert_body_size);
 
@@ -611,7 +604,8 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   TRY(perso_tlv_push_cert_to_perso_blob(
       "UDS",
       /*needs_endorsement=*/kDiceCertFormat == kDiceCertFormatX509TcbInfo,
-      kDiceCertFormat, all_certs, curr_cert_size, &perso_blob_to_host));
+      kDiceCertFormat, all_certs, curr_cert_size, kPersoBlobVersionV0,
+      &perso_blob_to_host));
 
   // After we have cranked the keymgr to the CreatorRootKey (UDS) stage, we now
   // can initialize and seal the ownership block.
@@ -630,9 +624,9 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   cdi_0_offset = perso_blob_to_host.next_free;
   // DO NOT CHANGE THE "CDI_0" STRING BELOW with modifying the `dice_cert_names`
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
-  TRY(perso_tlv_push_cert_to_perso_blob("CDI_0", /*needs_endorsement=*/false,
-                                        kDiceCertFormat, all_certs,
-                                        curr_cert_size, &perso_blob_to_host));
+  TRY(perso_tlv_push_cert_to_perso_blob(
+      "CDI_0", /*needs_endorsement=*/false, kDiceCertFormat, all_certs,
+      curr_cert_size, kPersoBlobVersionV0, &perso_blob_to_host));
 
   // Generate CDI_1 keys and cert.
   curr_cert_size = kCdi1MaxCertSizeBytes;
@@ -648,9 +642,9 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   cdi_1_offset = perso_blob_to_host.next_free;
   // DO NOT CHANGE THE "CDI_1" STRING BELOW with modifying the `dice_cert_names`
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
-  TRY(perso_tlv_push_cert_to_perso_blob("CDI_1", /*needs_endorsement=*/false,
-                                        kDiceCertFormat, all_certs,
-                                        curr_cert_size, &perso_blob_to_host));
+  TRY(perso_tlv_push_cert_to_perso_blob(
+      "CDI_1", /*needs_endorsement=*/false, kDiceCertFormat, all_certs,
+      curr_cert_size, kPersoBlobVersionV0, &perso_blob_to_host));
 
   return OK_STATUS();
 }
@@ -684,7 +678,8 @@ static status_t compute_tbs_was_hmac(perso_blob_t *perso_blob_to_host) {
     PERSO_TLV_GET_FIELD(Objh, Type, obj_header, &obj_type);
     PERSO_TLV_GET_FIELD(Objh, Size, obj_header, &obj_size);
     if (obj_type == kPersoObjectTypeX509Tbs) {
-      TRY(perso_tlv_get_cert_obj(tlv_buf, obj_size, &cert_obj));
+      TRY(perso_tlv_get_cert_obj(tlv_buf, obj_size, kPersoBlobVersionV0,
+                                 &cert_obj));
       hmac_sha256_update(cert_obj.cert_body_p, cert_obj.cert_body_size);
     }
     tlv_buf += obj_size;
@@ -694,17 +689,9 @@ static status_t compute_tbs_was_hmac(perso_blob_t *perso_blob_to_host) {
   hmac_sha256_final(&digest);
 
   // Push hash into perso blob.
-  perso_tlv_object_header_t was_hmac_tlv_header = 0;
-  obj_size = sizeof(perso_tlv_object_header_t) + sizeof(hmac_digest_t);
-  PERSO_TLV_SET_FIELD(Objh, Type, was_hmac_tlv_header,
-                      kPersoObjectTypeWasTbsHmac);
-  PERSO_TLV_SET_FIELD(Objh, Size, was_hmac_tlv_header, obj_size);
-  TRY(perso_tlv_push_to_perso_blob(&was_hmac_tlv_header,
-                                   sizeof(perso_tlv_object_header_t),
-                                   perso_blob_to_host));
-  TRY(perso_tlv_push_to_perso_blob(digest.digest, kHmacDigestNumBytes,
-                                   perso_blob_to_host));
-  perso_blob_to_host->num_objs++;
+  TRY(perso_tlv_push_object_to_perso_blob(
+      kPersoObjectTypeWasTbsHmac, digest.digest, kHmacDigestNumBytes,
+      kPersoBlobVersionV0, perso_blob_to_host));
 
   // Read complete device ID and push into perso blob. The host will need the
   // device ID to reconstruct the WAS.
@@ -712,16 +699,9 @@ static status_t compute_tbs_was_hmac(perso_blob_t *perso_blob_to_host) {
   TRY(otp_ctrl_testutils_dai_read32_array(&otp_ctrl, kDifOtpCtrlPartitionHwCfg0,
                                           kHwCfgDeviceIdOffset, device_id,
                                           ARRAYSIZE(device_id)));
-  perso_tlv_object_header_t device_id_header = 0;
-  obj_size = sizeof(perso_tlv_object_header_t) + kHwCfgDeviceIdSizeInBytes;
-  PERSO_TLV_SET_FIELD(Objh, Type, device_id_header, kPersoObjectTypeDeviceId);
-  PERSO_TLV_SET_FIELD(Objh, Size, device_id_header, obj_size);
-  TRY(perso_tlv_push_to_perso_blob(&device_id_header,
-                                   sizeof(perso_tlv_object_header_t),
-                                   perso_blob_to_host));
-  TRY(perso_tlv_push_to_perso_blob(device_id, kHwCfgDeviceIdSizeInBytes,
-                                   perso_blob_to_host));
-  perso_blob_to_host->num_objs++;
+  TRY(perso_tlv_push_object_to_perso_blob(
+      kPersoObjectTypeDeviceId, device_id, kHwCfgDeviceIdSizeInBytes,
+      kPersoBlobVersionV0, perso_blob_to_host));
 
   return OK_STATUS();
 }
@@ -831,7 +811,7 @@ static status_t extract_next_cert(uint8_t **dest, size_t *free_room) {
     // Extract the next perso LTV object, aborting if it is not a certificate.
     rom_error_t err = perso_tlv_get_cert_obj(
         perso_blob_from_host.body + perso_blob_from_host.next_free,
-        max_available(), &block);
+        max_available(), kPersoBlobVersionV0, &block);
     switch (err) {
       case kErrorOk:
         break;
@@ -960,10 +940,9 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
     size_t offset = cert_offsets[i];
     TRY(perso_tlv_get_cert_obj(perso_blob_to_host.body + offset,
                                sizeof(perso_blob_to_host.body) - offset,
-                               &block));
+                               kPersoBlobVersionV0, &block));
     if (block.obj_size > free_room)
       return RESOURCE_EXHAUSTED();
-
     memcpy(next_cert, block.obj_p, block.obj_size);
     next_cert += block.obj_size;
     free_room -= block.obj_size;
@@ -997,7 +976,8 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
     // endorsed extension certificates received from the host.
     for (size_t j = 0; j < curr_layout.num_certs; j++) {
       // Extract the cert block from the `all_certs` buffer.
-      TRY(perso_tlv_get_cert_obj(next_cert, free_room, &block));
+      TRY(perso_tlv_get_cert_obj(next_cert, free_room, kPersoBlobVersionV0,
+                                 &block));
       // Round up the size to the nearest word boundary.
       uint32_t cert_size_words = util_size_to_words(block.obj_size);
       uint32_t cert_size_bytes_ru = cert_size_words * sizeof(uint32_t);

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
@@ -7,62 +7,143 @@
 #include "sw/device/silicon_creator/lib/cert/cert.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
+rom_error_t perso_tlv_init_v1_blob(perso_blob_t *pb) {
+  if (pb->next_free != 0) {
+    return kErrorPersoTlvInternal;
+  }
+
+  // Add the Version Object (16-bit Type/Size header + 16-bit Version Payload).
+  uint16_t header = 0;
+  PERSO_TLV_SET_FIELD(Objh, Type, header, kPersoObjectTypeBlobVersion);
+  PERSO_TLV_SET_FIELD(
+      Objh, Size, header,
+      sizeof(perso_tlv_object_header_t) + sizeof(perso_tlv_blob_version_t));
+  memcpy(pb->body + pb->next_free, &header, sizeof(uint16_t));
+  pb->next_free += sizeof(uint16_t);
+
+  uint16_t version = __builtin_bswap16(kPersoBlobVersionV1);
+  memcpy(pb->body + pb->next_free, &version, sizeof(uint16_t));
+  pb->next_free += sizeof(uint16_t);
+
+  pb->num_objs = 1;
+
+  return kErrorOk;
+}
+
 rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
+                                   perso_blob_version_t blob_version,
                                    perso_tlv_cert_obj_t *obj) {
-  perso_tlv_object_header_t objh;
   perso_tlv_object_type_t obj_type;
-  uint16_t obj_size;
+  uint32_t obj_size;
+  size_t obj_header_size;
+  switch (blob_version) {
+    case kPersoBlobVersionV0:
+      obj_header_size = sizeof(perso_tlv_object_header_t);
+      break;
+    case kPersoBlobVersionV1:
+      obj_header_size = sizeof(perso_tlv_object_header_v1_t);
+      break;
+    default:
+      return kErrorPersoTlvInternal;
+  }
 
   // Extract LTV object header, including: size and type.
-  if (ltv_buf_size < sizeof(perso_tlv_object_header_t)) {
+  if (ltv_buf_size < obj_header_size) {
     return kErrorPersoTlvInternal;
   }
   obj->obj_p = buf;
-  memcpy(&objh, buf, sizeof(perso_tlv_object_header_t));
-  // Extract LTV object size.
-  PERSO_TLV_GET_FIELD(Objh, Size, objh, &obj_size);
+  switch (blob_version) {
+    case kPersoBlobVersionV0: {
+      perso_tlv_object_header_t objh;
+      uint16_t obj_size_v0;
+      memcpy(&objh, buf, sizeof(perso_tlv_object_header_t));
+      PERSO_TLV_GET_FIELD(Objh, Size, objh, &obj_size_v0);
+      PERSO_TLV_GET_FIELD(Objh, Type, objh, &obj_type);
+      obj_size = obj_size_v0;
+      break;
+    }
+    case kPersoBlobVersionV1: {
+      perso_tlv_object_header_v1_t objh;
+      memcpy(&objh, buf, sizeof(perso_tlv_object_header_v1_t));
+      PERSO_TLV_GET_FIELD_V1(ObjhV1, Size, objh, &obj_size);
+      PERSO_TLV_GET_FIELD_V1(ObjhV1, Type, objh, &obj_type);
+      break;
+    }
+    default:
+      return kErrorPersoTlvInternal;
+  }
+
   if (obj_size == 0)
     return kErrorPersoTlvCertObjNotFound;  // Object is empty.
   if (obj_size > ltv_buf_size)
     return kErrorPersoTlvInternal;  // Object exceeds the size of host buffer.
   obj->obj_size = obj_size;
-  // Extract LTV object type.
-  PERSO_TLV_GET_FIELD(Objh, Type, objh, &obj_type);
   obj->obj_type = obj_type;
   if (obj_type != kPersoObjectTypeX509Cert &&
       obj_type != kPersoObjectTypeCwtCert &&
       obj_type != kPersoObjectTypeX509Tbs) {
     return kErrorPersoTlvCertObjNotFound;
   }
-  buf += sizeof(perso_tlv_object_header_t);
-  ltv_buf_size -= sizeof(perso_tlv_object_header_t);
+  buf += obj_header_size;
+  ltv_buf_size -= obj_header_size;
 
   // If we made it this far, we found a certificate LTV object, so we will parse
   // the object's header and metadata next.
 
-  perso_tlv_cert_header_t crth;
-  uint16_t wrapped_cert_size;
-  uint16_t name_len;
+  uint32_t wrapped_cert_size;
+  uint32_t name_len;
+  size_t cert_header_size;
+  switch (blob_version) {
+    case kPersoBlobVersionV0:
+      cert_header_size = sizeof(perso_tlv_cert_header_t);
+      break;
+    case kPersoBlobVersionV1:
+      cert_header_size = sizeof(perso_tlv_cert_header_v1_t);
+      break;
+    default:
+      return kErrorPersoTlvInternal;
+  }
 
   // Extract the certificate object header, including: certificate object and
   // nameksizes, certificate name string, and pointer to the certificate body.
-  if (ltv_buf_size < sizeof(perso_tlv_cert_header_t)) {
+  if (ltv_buf_size < cert_header_size) {
     return kErrorPersoTlvInternal;
   }
-  memcpy(&crth, buf, sizeof(perso_tlv_cert_header_t));
-  // Extract certificate name size.
-  PERSO_TLV_GET_FIELD(Crth, NameSize, crth, &name_len);
-  // Extract wrapped certificate object size.
-  PERSO_TLV_GET_FIELD(Crth, Size, crth, &wrapped_cert_size);
+  switch (blob_version) {
+    case kPersoBlobVersionV0: {
+      perso_tlv_cert_header_t crth;
+      uint16_t name_len_v0;
+      uint16_t wrapped_cert_size_v0;
+      memcpy(&crth, buf, sizeof(perso_tlv_cert_header_t));
+      PERSO_TLV_GET_FIELD(Crth, NameSize, crth, &name_len_v0);
+      PERSO_TLV_GET_FIELD(Crth, Size, crth, &wrapped_cert_size_v0);
+      name_len = name_len_v0;
+      wrapped_cert_size = wrapped_cert_size_v0;
+      break;
+    }
+    case kPersoBlobVersionV1: {
+      perso_tlv_cert_header_v1_t crth;
+      memcpy(&crth, buf, sizeof(perso_tlv_cert_header_v1_t));
+      PERSO_TLV_GET_FIELD_V1(CrthV1, NameSize, crth, &name_len);
+      PERSO_TLV_GET_FIELD_V1(CrthV1, Size, crth, &wrapped_cert_size);
+      break;
+    }
+    default:
+      return kErrorPersoTlvInternal;
+  }
+
   // There are at least 4 bytes in an X.509 ASN.1 DER certificate: two bytes of
   // header and two bytes of size data.
-  if ((wrapped_cert_size < (sizeof(perso_tlv_cert_header_t) + name_len + 4)) ||
+  if ((wrapped_cert_size < (cert_header_size + name_len + 4)) ||
       (wrapped_cert_size > ltv_buf_size))
     return kErrorPersoTlvInternal;  // Something is really screwed up.
-  buf += sizeof(perso_tlv_cert_header_t);
-  ltv_buf_size -= sizeof(perso_tlv_cert_header_t);
+  buf += cert_header_size;
+  ltv_buf_size -= cert_header_size;
   // Extract certificate name string.
   if (ltv_buf_size < name_len) {
+    return kErrorPersoTlvInternal;
+  }
+  if (name_len > kCrthNameSizeFieldMask) {
     return kErrorPersoTlvInternal;
   }
   memcpy(obj->name, buf, name_len);
@@ -70,8 +151,7 @@ rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
   buf += name_len;
   ltv_buf_size -= name_len;
   // Set pointer to certificate body.
-  obj->cert_body_size =
-      wrapped_cert_size - sizeof(perso_tlv_cert_header_t) - name_len;
+  obj->cert_body_size = wrapped_cert_size - cert_header_size - name_len;
   obj->cert_body_p = buf;
 
   // Sanity check on the certificate body size.
@@ -90,9 +170,22 @@ rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
 rom_error_t perso_tlv_cert_obj_build(const char *name,
                                      const perso_tlv_object_type_t obj_type,
                                      const uint8_t *cert, size_t cert_size,
+                                     perso_blob_version_t blob_version,
                                      uint8_t *buf, size_t *buf_size) {
-  perso_tlv_object_header_t obj_header = 0;
-  perso_tlv_cert_header_t cert_header = 0;
+  size_t obj_header_size;
+  size_t cert_header_size;
+  switch (blob_version) {
+    case kPersoBlobVersionV0:
+      obj_header_size = sizeof(perso_tlv_object_header_t);
+      cert_header_size = sizeof(perso_tlv_cert_header_t);
+      break;
+    case kPersoBlobVersionV1:
+      obj_header_size = sizeof(perso_tlv_object_header_v1_t);
+      cert_header_size = sizeof(perso_tlv_cert_header_v1_t);
+      break;
+    default:
+      return kErrorPersoTlvInternal;
+  }
   size_t obj_size;
   size_t wrapped_cert_size;
 
@@ -105,28 +198,48 @@ rom_error_t perso_tlv_cert_obj_build(const char *name,
 
   // Compute the wrapped certificate object (cert header + cert data) and perso
   // LTV object sizes.
-  wrapped_cert_size = sizeof(perso_tlv_cert_header_t) + name_len + cert_size;
-  obj_size = wrapped_cert_size + sizeof(perso_tlv_object_header_t);
+  wrapped_cert_size = cert_header_size + name_len + cert_size;
+  obj_size = wrapped_cert_size + obj_header_size;
 
   // Check there is enough room in the buffer to store the perso LTV object.
   if (obj_size > *buf_size)
     return kErrorPersoTlvOutputBufTooSmall;
 
-  // Setup the perso LTV object header.
-  PERSO_TLV_SET_FIELD(Objh, Type, obj_header, obj_type);
-  PERSO_TLV_SET_FIELD(Objh, Size, obj_header, obj_size);
-
-  // Setup the cert object header.
-  PERSO_TLV_SET_FIELD(Crth, Size, cert_header, wrapped_cert_size);
-  PERSO_TLV_SET_FIELD(Crth, NameSize, cert_header, name_len);
-
   // Push the cert perso LTV object to the buffer.
   // Return the size of the buffer that was used up by this perso LTV object.
   *buf_size = 0;
-  memcpy(buf + *buf_size, &obj_header, sizeof(perso_tlv_object_header_t));
-  *buf_size += sizeof(perso_tlv_object_header_t);
-  memcpy(buf + *buf_size, &cert_header, sizeof(perso_tlv_cert_header_t));
-  *buf_size += sizeof(perso_tlv_cert_header_t);
+  switch (blob_version) {
+    case kPersoBlobVersionV0: {
+      perso_tlv_object_header_t obj_header = 0;
+      perso_tlv_cert_header_t cert_header = 0;
+      PERSO_TLV_SET_FIELD(Objh, Type, obj_header, obj_type);
+      PERSO_TLV_SET_FIELD(Objh, Size, obj_header, obj_size);
+      PERSO_TLV_SET_FIELD(Crth, Size, cert_header, wrapped_cert_size);
+      PERSO_TLV_SET_FIELD(Crth, NameSize, cert_header, name_len);
+      memcpy(buf + *buf_size, &obj_header, sizeof(perso_tlv_object_header_t));
+      *buf_size += sizeof(perso_tlv_object_header_t);
+      memcpy(buf + *buf_size, &cert_header, sizeof(perso_tlv_cert_header_t));
+      *buf_size += sizeof(perso_tlv_cert_header_t);
+      break;
+    }
+    case kPersoBlobVersionV1: {
+      perso_tlv_object_header_v1_t obj_header = 0;
+      perso_tlv_cert_header_v1_t cert_header = 0;
+      PERSO_TLV_SET_FIELD_V1(ObjhV1, Type, obj_header, obj_type);
+      PERSO_TLV_SET_FIELD_V1(ObjhV1, Size, obj_header, obj_size);
+      PERSO_TLV_SET_FIELD_V1(CrthV1, Size, cert_header, wrapped_cert_size);
+      PERSO_TLV_SET_FIELD_V1(CrthV1, NameSize, cert_header, name_len);
+      memcpy(buf + *buf_size, &obj_header,
+             sizeof(perso_tlv_object_header_v1_t));
+      *buf_size += sizeof(perso_tlv_object_header_v1_t);
+      memcpy(buf + *buf_size, &cert_header, sizeof(perso_tlv_cert_header_v1_t));
+      *buf_size += sizeof(perso_tlv_cert_header_v1_t);
+      break;
+    }
+    default:
+      return kErrorPersoTlvInternal;
+  }
+
   memcpy(buf + *buf_size, name, name_len);
   *buf_size += name_len;
   memcpy(buf + *buf_size, cert, cert_size);
@@ -138,7 +251,7 @@ rom_error_t perso_tlv_cert_obj_build(const char *name,
 rom_error_t perso_tlv_push_cert_to_perso_blob(
     const char *name, bool needs_endorsement,
     const dice_cert_format_t dice_format, const uint8_t *cert, size_t cert_size,
-    perso_blob_t *pb) {
+    perso_blob_version_t blob_version, perso_blob_t *pb) {
   if (pb->next_free > sizeof(pb->body)) {
     return kErrorPersoTlvInternal;
   }
@@ -152,8 +265,9 @@ rom_error_t perso_tlv_push_cert_to_perso_blob(
       obj_type = kPersoObjectTypeX509Cert;
     }
   }
-  HARDENED_RETURN_IF_ERROR(perso_tlv_cert_obj_build(
-      name, obj_type, cert, cert_size, pb->body + pb->next_free, &obj_size));
+  HARDENED_RETURN_IF_ERROR(
+      perso_tlv_cert_obj_build(name, obj_type, cert, cert_size, blob_version,
+                               pb->body + pb->next_free, &obj_size));
 
   // Update the perso blob offset and object count.
   pb->next_free += obj_size;
@@ -162,15 +276,127 @@ rom_error_t perso_tlv_push_cert_to_perso_blob(
   return kErrorOk;
 }
 
-rom_error_t perso_tlv_push_to_perso_blob(const void *data, size_t size,
-                                         perso_blob_t *perso_blob) {
+rom_error_t perso_tlv_get_blob_version(const uint8_t *data, size_t size,
+                                       perso_blob_version_t *version,
+                                       size_t *offset) {
+  *version = kPersoBlobVersionV0;
+  *offset = 0;
+
+  if (size <
+      sizeof(perso_tlv_object_header_t) + sizeof(perso_tlv_blob_version_t)) {
+    return kErrorOk;  // Too small to contain a version object, default to V0
+  }
+
+  perso_tlv_object_header_t header;
+  memcpy(&header, data, sizeof(perso_tlv_object_header_t));
+  perso_tlv_object_type_t type;
+  uint16_t obj_size;
+  PERSO_TLV_GET_FIELD(Objh, Type, header, &type);
+  PERSO_TLV_GET_FIELD(Objh, Size, header, &obj_size);
+
+  if (type == kPersoObjectTypeBlobVersion) {
+    if (obj_size !=
+        sizeof(perso_tlv_object_header_t) + sizeof(perso_tlv_blob_version_t)) {
+      return kErrorPersoTlvInternal;
+    }
+    uint16_t version_be;
+    memcpy(&version_be, data + sizeof(perso_tlv_object_header_t),
+           sizeof(uint16_t));
+    uint16_t parsed_version = __builtin_bswap16(version_be);
+    if (parsed_version == kPersoBlobVersionV1) {
+      *version = kPersoBlobVersionV1;
+      *offset =
+          sizeof(perso_tlv_object_header_t) + sizeof(perso_tlv_blob_version_t);
+    } else {
+      return kErrorPersoTlvInternal;  // Unknown version
+    }
+  }
+
+  return kErrorOk;
+}
+
+perso_tlv_object_type_t perso_tlv_object_type(const uint8_t *data,
+                                              perso_blob_version_t version) {
+  perso_tlv_object_type_t type;
+  switch (version) {
+    case kPersoBlobVersionV1: {
+      perso_tlv_object_header_v1_t header = *(const uint32_t *)data;
+      PERSO_TLV_GET_FIELD_V1(ObjhV1, Type, header, &type);
+      break;
+    }
+    case kPersoBlobVersionV0:
+    default: {
+      perso_tlv_object_header_t header = *(const uint16_t *)data;
+      PERSO_TLV_GET_FIELD(Objh, Type, header, &type);
+      break;
+    }
+  }
+  return type;
+}
+
+uint32_t perso_tlv_object_size(const uint8_t *data,
+                               perso_blob_version_t version) {
+  uint32_t size;
+  switch (version) {
+    case kPersoBlobVersionV1: {
+      perso_tlv_object_header_v1_t header = *(const uint32_t *)data;
+      PERSO_TLV_GET_FIELD_V1(ObjhV1, Size, header, &size);
+      break;
+    }
+    case kPersoBlobVersionV0:
+    default: {
+      perso_tlv_object_header_t header = *(const uint16_t *)data;
+      uint16_t size_v0;
+      PERSO_TLV_GET_FIELD(Objh, Size, header, &size_v0);
+      size = size_v0;
+      break;
+    }
+  }
+  return size;
+}
+
+rom_error_t perso_tlv_push_object_to_perso_blob(
+    perso_tlv_object_type_t obj_type, const void *data, size_t size,
+    perso_blob_version_t version, perso_blob_t *perso_blob) {
   if (perso_blob->next_free > sizeof(perso_blob->body)) {
     return kErrorPersoTlvInternal;
   }
-  size_t room = sizeof(perso_blob->body) - perso_blob->next_free;
-  if (room < size)
+
+  size_t header_size = (version == kPersoBlobVersionV1)
+                           ? sizeof(perso_tlv_object_header_v1_t)
+                           : sizeof(perso_tlv_object_header_t);
+
+  size_t total_size = header_size + size;
+  if (sizeof(perso_blob->body) - perso_blob->next_free < total_size) {
     return kErrorPersoTlvOutputBufTooSmall;
-  memcpy(perso_blob->body + perso_blob->next_free, data, size);
-  perso_blob->next_free += size;
+  }
+
+  switch (version) {
+    case kPersoBlobVersionV1: {
+      perso_tlv_object_header_v1_t header = 0;
+      PERSO_TLV_SET_FIELD_V1(ObjhV1, Type, header, obj_type);
+      PERSO_TLV_SET_FIELD_V1(ObjhV1, Size, header, total_size);
+      memcpy(perso_blob->body + perso_blob->next_free, &header, header_size);
+      break;
+    }
+    case kPersoBlobVersionV0: {
+      perso_tlv_object_header_t header = 0;
+      PERSO_TLV_SET_FIELD(Objh, Type, header, obj_type);
+      PERSO_TLV_SET_FIELD(Objh, Size, header, total_size);
+      memcpy(perso_blob->body + perso_blob->next_free, &header, header_size);
+      break;
+    }
+    default:
+      return kErrorPersoTlvInternal;
+  }
+
+  perso_blob->next_free += header_size;
+
+  if (size > 0 && data != NULL) {
+    memcpy(perso_blob->body + perso_blob->next_free, data, size);
+    perso_blob->next_free += size;
+  }
+
+  perso_blob->num_objs++;
   return kErrorOk;
 }

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -69,21 +69,51 @@ typedef enum perso_tlv_object_type {
   kPersoObjectTypePersoSha256Hash = 7,
 } perso_tlv_object_type_t;
 
+typedef uint16_t perso_tlv_object_header_v0_t;
+typedef uint16_t perso_tlv_cert_header_v0_t;
+typedef uint32_t perso_tlv_object_header_v1_t;
+typedef uint32_t perso_tlv_cert_header_v1_t;
+
 typedef uint16_t perso_tlv_object_header_t;
 typedef uint16_t perso_tlv_cert_header_t;
 typedef uint16_t perso_tlv_dev_seed_header_t;
 
-typedef enum perso_tlv_obj_header_fields {
+typedef enum perso_tlv_obj_header_fields_v0 {
   // Object size, total size, this header included.
-  kObjhSizeFieldShift = 0,
-  kObjhSizeFieldWidth = 12,
-  kObjhSizeFieldMask = (1 << kObjhSizeFieldWidth) - 1,
+  kObjhSizeFieldShiftV0 = 0,
+  kObjhSizeFieldWidthV0 = 12,
+  kObjhSizeFieldMaskV0 = (1 << kObjhSizeFieldWidthV0) - 1,
 
   // Object type, one of perso_tlv_object_type_t.
-  kObjhTypeFieldShift = kObjhSizeFieldWidth,
-  kObjhTypeFieldWidth =
-      sizeof(perso_tlv_object_header_t) * 8 - kObjhSizeFieldWidth,
-  kObjhTypeFieldMask = (1 << kObjhTypeFieldWidth) - 1,
+  kObjhTypeFieldShiftV0 = kObjhSizeFieldWidthV0,
+  kObjhTypeFieldWidthV0 =
+      sizeof(perso_tlv_object_header_v0_t) * 8 - kObjhSizeFieldWidthV0,
+  kObjhTypeFieldMaskV0 = (1 << kObjhTypeFieldWidthV0) - 1,
+} perso_tlv_obj_header_fields_v0_t;
+
+typedef enum perso_tlv_obj_header_fields_v1 {
+  // Object size, total size, this header included.
+  kObjhV1SizeFieldShift = 0,
+  kObjhV1SizeFieldWidth = 24,
+  kObjhV1SizeFieldMask = (1 << kObjhV1SizeFieldWidth) - 1,
+
+  // Object type, one of perso_tlv_object_type_t.
+  kObjhV1TypeFieldShift = kObjhV1SizeFieldWidth,
+  kObjhV1TypeFieldWidth =
+      sizeof(perso_tlv_object_header_v1_t) * 8 - kObjhV1SizeFieldWidth,
+  kObjhV1TypeFieldMask = (1 << kObjhV1TypeFieldWidth) - 1,
+} perso_tlv_obj_header_fields_v1_t;
+
+typedef enum perso_tlv_obj_header_fields {
+  // Object size, total size, this header included.
+  kObjhSizeFieldShift = kObjhSizeFieldShiftV0,
+  kObjhSizeFieldWidth = kObjhSizeFieldWidthV0,
+  kObjhSizeFieldMask = kObjhSizeFieldMaskV0,
+
+  // Object type, one of perso_tlv_object_type_t.
+  kObjhTypeFieldShift = kObjhTypeFieldShiftV0,
+  kObjhTypeFieldWidth = kObjhTypeFieldWidthV0,
+  kObjhTypeFieldMask = kObjhTypeFieldMaskV0,
 } perso_tlv_obj_header_fields_t;
 
 typedef struct perso_tlv_dev_seed_element {
@@ -112,17 +142,42 @@ typedef struct perso_tlv_dev_seed_set {
  *  | 4 bit length|       12 bits total size       |
  *  +-------------+--------------------------------+
  */
-typedef enum perso_tlv_cert_header_fields {
+typedef enum perso_tlv_cert_header_fields_v0 {
   // Certificate size, total size, this header and name length included.
-  kCrthSizeFieldShift = 0,
-  kCrthSizeFieldWidth = 12,
-  kCrthSizeFieldMask = (1 << kCrthSizeFieldWidth) - 1,
+  kCrthSizeFieldShiftV0 = 0,
+  kCrthSizeFieldWidthV0 = 12,
+  kCrthSizeFieldMaskV0 = (1 << kCrthSizeFieldWidthV0) - 1,
 
   // Length of the certificate name immediately following the header.
-  kCrthNameSizeFieldShift = kCrthSizeFieldWidth,
-  kCrthNameSizeFieldWidth =
-      sizeof(perso_tlv_cert_header_t) * 8 - kCrthSizeFieldWidth,
-  kCrthNameSizeFieldMask = (1 << kCrthNameSizeFieldWidth) - 1,
+  kCrthNameSizeFieldShiftV0 = kCrthSizeFieldWidthV0,
+  kCrthNameSizeFieldWidthV0 =
+      sizeof(perso_tlv_cert_header_v0_t) * 8 - kCrthSizeFieldWidthV0,
+  kCrthNameSizeFieldMaskV0 = (1 << kCrthNameSizeFieldWidthV0) - 1,
+} perso_tlv_cert_header_fields_v0_t;
+
+typedef enum perso_tlv_cert_header_fields_v1 {
+  // Certificate size, total size, this header and name length included.
+  kCrthV1SizeFieldShift = 0,
+  kCrthV1SizeFieldWidth = 24,
+  kCrthV1SizeFieldMask = (1 << kCrthV1SizeFieldWidth) - 1,
+
+  // Length of the certificate name immediately following the header.
+  kCrthV1NameSizeFieldShift = kCrthV1SizeFieldWidth,
+  kCrthV1NameSizeFieldWidth =
+      sizeof(perso_tlv_cert_header_v1_t) * 8 - kCrthV1SizeFieldWidth,
+  kCrthV1NameSizeFieldMask = (1 << kCrthV1NameSizeFieldWidth) - 1,
+} perso_tlv_cert_header_fields_v1_t;
+
+typedef enum perso_tlv_cert_header_fields {
+  // Certificate size, total size, this header and name length included.
+  kCrthSizeFieldShift = kCrthSizeFieldShiftV0,
+  kCrthSizeFieldWidth = kCrthSizeFieldWidthV0,
+  kCrthSizeFieldMask = kCrthSizeFieldMaskV0,
+
+  // Length of the certificate name immediately following the header.
+  kCrthNameSizeFieldShift = kCrthNameSizeFieldShiftV0,
+  kCrthNameSizeFieldWidth = kCrthNameSizeFieldWidthV0,
+  kCrthNameSizeFieldMask = kCrthNameSizeFieldMaskV0,
 } perso_tlv_cert_header_fields_t;
 
 // Helper macros allowing set or get various object and certificate header
@@ -144,6 +199,24 @@ typedef enum perso_tlv_cert_header_fields {
     uint16_t mask = k##type_name##field_name##FieldMask;                    \
     uint16_t shift = k##type_name##field_name##FieldShift;                  \
     *(field_value) = (__builtin_bswap16(full_value) >> shift) & mask;       \
+  }
+
+#define PERSO_TLV_SET_FIELD_V1(type_name, field_name, full_value, field_value) \
+  {                                                                            \
+    uint32_t mask = k##type_name##field_name##FieldMask;                       \
+    uint32_t shift = k##type_name##field_name##FieldShift;                     \
+    uint32_t fieldv = (uint32_t)(field_value)&mask;                            \
+    uint32_t fullv = __builtin_bswap32((uint32_t)(full_value));                \
+    mask = (uint32_t)(mask << shift);                                          \
+    (full_value) = __builtin_bswap32(                                          \
+        (uint32_t)((fullv & ~mask) | (((uint32_t)fieldv) << shift)));          \
+  }
+
+#define PERSO_TLV_GET_FIELD_V1(type_name, field_name, full_value, field_value) \
+  {                                                                            \
+    uint32_t mask = k##type_name##field_name##FieldMask;                       \
+    uint32_t shift = k##type_name##field_name##FieldShift;                     \
+    *(field_value) = (__builtin_bswap32(full_value) >> shift) & mask;          \
   }
 
 /**

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -69,11 +69,18 @@ typedef enum perso_tlv_object_type {
    * Personalization firmware SHA256 Hash.
    */
   kPersoObjectTypePersoSha256Hash = 7,
+  /**
+   * Personalization blob version.
+   */
+  kPersoObjectTypeBlobVersion = 15,
 } perso_tlv_object_type_t;
 
 typedef uint16_t perso_tlv_object_header_t;
 typedef uint16_t perso_tlv_cert_header_t;
 typedef uint16_t perso_tlv_dev_seed_header_t;
+
+typedef uint32_t perso_tlv_object_header_v1_t;
+typedef uint32_t perso_tlv_cert_header_v1_t;
 
 typedef enum perso_tlv_obj_header_fields {
   // Object size, total size, this header included.
@@ -99,6 +106,13 @@ typedef struct perso_tlv_dev_seed {
 typedef struct perso_tlv_dev_seed_set {
   perso_tlv_dev_seed_t seeds[2];
 } perso_tlv_dev_seed_set_t;
+
+/**
+ * Personalization blob version object payload.
+ */
+typedef struct perso_tlv_blob_version {
+  uint16_t version;
+} perso_tlv_blob_version_t;
 
 /**
  * The x509 certificate is prepended by a 16 bits header followed by the ASCII
@@ -160,12 +174,41 @@ typedef struct perso_tlv_cert_obj {
 } perso_tlv_cert_obj_t;
 
 /**
+ * Personalization blob versions.
+ */
+typedef enum perso_blob_version {
+  /**
+   * V0 is the original personalization blob format. It uses a 16-bit object
+   * header (4-bit type, 12-bit size), which limits the maximum size of any
+   * single object to 4KB.
+   */
+  kPersoBlobVersionV0 = 0,
+  /**
+   * V1 personalization blobs start with a version TLV object (which uses the V0
+   * header format for backwards compatibility). All subsequent objects in the
+   * blob use a larger 32-bit header (8-bit type, 24-bit size), allowing for
+   * significantly larger objects (up to 16MB).
+   */
+  kPersoBlobVersionV1 = 1,
+} perso_blob_version_t;
+
+/**
+ * Initializes the perso blob as a V1 blob.
+ *
+ * @param pb Pointer to the `perso_blob_t` to initialize.
+ * @return status of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t perso_tlv_init_v1_blob(perso_blob_t *pb);
+
+/**
  * Given the pointer to an LTV object, in case this is an endorsed certificate
  * set up the perso_tlv_cert_obj_t structure for it.
  *
  * @param buf Pointer to the LTV object buffer storing the certificate object.
  * @param ltv_buf_size Total number of bytes until the end of the LTV buffer
  *                     (cert LTV object must be <= the buffer size).
+ * @param blob_version The version of the perso blob.
  * @param[out] obj Pointer to the certificate perso LTV object to populate.
  *
  * @return OK_STATUS on success, NOT_FOUND if the object is not an endorsed
@@ -173,6 +216,7 @@ typedef struct perso_tlv_cert_obj {
  */
 OT_WARN_UNUSED_RESULT
 rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
+                                   perso_blob_version_t blob_version,
                                    perso_tlv_cert_obj_t *obj);
 
 /**
@@ -180,29 +224,43 @@ rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
  * buffer.
  *
  * The certificate perso LTV object is laid out as follows:
- * - 16 bit LTV object header
- * - 16 bit cert header
+ * - LTV object header (16-bit for V0, 32-bit for V1)
+ * - cert header (16-bit for V0, 32-bit for V1)
  * - Certificate name string
  * - Cerificate data
  *
- * Note that both certificate and object headers' are 16 bit integers in big
+ * Note that both certificate and object headers' are integers in big
  * endian format.
  *
- *  d15                                         d0
- * +-------------+--------------------------------+
- * | 4 bit type  |   12 bits total object size    | <-- Object Header
- * +-------------+--------------------------------+
- * | name length |12 bits total cert payload size | <-- Cert Header
- * +-------------+--------------------------------+
- * |             cert name string                 |
- * +----------------------------------------------+
- * |                   cert                       |
- * +----------------------------------------------+
+ * V0 header format:
+ *  d15         d12                              d0
+ * +-------------+---------------------------------+
+ * | 4 bit type  |    12 bits total object size    | <-- Object Header
+ * +-------------+---------------------------------+
+ * | name length | 12 bits total cert payload size | <-- Cert Header
+ * +-------------+---------------------------------+
+ * |             cert name string                  |
+ * +-----------------------------------------------+
+ * |                   cert                        |
+ * +-----------------------------------------------+
+ *
+ * V1 header format:
+ *  d31         d24                              d0
+ * +-------------+---------------------------------+
+ * | 8 bit type  |    24 bits total object size    | <-- Object Header
+ * +-------------+---------------------------------+
+ * | name length | 24 bits total cert payload size | <-- Cert Header
+ * +-------------+---------------------------------+
+ * |             cert name string                  |
+ * +-----------------------------------------------+
+ * |                   cert                        |
+ * +-----------------------------------------------+
  *
  * @param name The name of the certificate.
  * @param obj_type The object type that needs to encoded.
  * @param cert The binary certificate blob.
  * @param cert_size Size of the certificate blob in bytes.
+ * @param blob_version The version of the perso blob.
  * @param[out] buf Output buffer to copy the data into.
  * @param[inout] buf_size Input is size of the output buffer in bytes; output is
  *                        space of buffer that was consumed by the LTV object.
@@ -212,6 +270,7 @@ OT_WARN_UNUSED_RESULT
 rom_error_t perso_tlv_cert_obj_build(const char *name,
                                      const perso_tlv_object_type_t obj_type,
                                      const uint8_t *cert, size_t cert_size,
+                                     perso_blob_version_t blob_version,
                                      uint8_t *buf, size_t *buf_size);
 
 /**
@@ -225,6 +284,7 @@ rom_error_t perso_tlv_cert_obj_build(const char *name,
  * @param cert_format The format of the certificate.
  * @param cert The binary certificate blob.
  * @param cert_size Size of the certificate blob in bytes.
+ * @param blob_version The version of the perso blob.
  * @param perso_blob Pointer to the `perso_blob_t` to copy the object to.
  * @return status of the operation.
  */
@@ -232,19 +292,60 @@ OT_WARN_UNUSED_RESULT
 rom_error_t perso_tlv_push_cert_to_perso_blob(
     const char *name, bool needs_endorsement,
     const dice_cert_format_t cert_format, const uint8_t *cert, size_t cert_size,
-    perso_blob_t *pb);
+    perso_blob_version_t blob_version, perso_blob_t *pb);
 
 /**
- * Pushes arbitrary data to the perso blob that is sent between host and device.
+ * Parses the beginning of the buffer to detect the personalization blob
+ * version.
  *
- * @param data Pointer to the data to add to the blob.
+ * It looks for a `kPersoObjectTypeBlobVersion` object which always uses the V0
+ * 16-bit header. If found, it parses the version from the payload.
+ *
+ * @param data Pointer to the start of the perso blob.
+ * @param size Total size of the perso blob in bytes.
+ * @param[out] version Extracted version, or kPersoBlobVersionV0 if not present.
+ * @param[out] offset Pointer to the first object after the version object.
+ * @return status of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t perso_tlv_get_blob_version(const uint8_t *data, size_t size,
+                                       perso_blob_version_t *version,
+                                       size_t *offset);
+
+/**
+ * Returns the object type from the header.
+ *
+ * @param data Pointer to the start of the object.
+ * @param version The version of the perso blob.
+ * @return The type of the object.
+ */
+perso_tlv_object_type_t perso_tlv_object_type(const uint8_t *data,
+                                              perso_blob_version_t version);
+
+/**
+ * Returns the object size from the header.
+ *
+ * @param data Pointer to the start of the object.
+ * @param version The version of the perso blob.
+ * @return The size of the object in bytes.
+ */
+uint32_t perso_tlv_object_size(const uint8_t *data,
+                               perso_blob_version_t version);
+
+/**
+ * Wraps arbitrary data in a perso TLV object and pushes it to the perso blob.
+ *
+ * @param obj_type The type of the object to add.
+ * @param data Pointer to the data to add.
  * @param size Size of the data to add in bytes.
+ * @param version The version of the perso blob.
  * @param perso_blob Pointer to the perso blob to add the data to.
  * @return status of the operation.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t perso_tlv_push_to_perso_blob(const void *data, size_t size,
-                                         perso_blob_t *perso_blob);
+rom_error_t perso_tlv_push_object_to_perso_blob(
+    perso_tlv_object_type_t obj_type, const void *data, size_t size,
+    perso_blob_version_t version, perso_blob_t *perso_blob);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data_unittest.cc
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data_unittest.cc
@@ -7,6 +7,7 @@
 #include <array>
 #include <cstring>
 #include <gtest/gtest.h>
+#include <string>
 
 #include "sw/device/silicon_creator/lib/cert/cert.h"
 #include "sw/device/silicon_creator/lib/error.h"
@@ -36,17 +37,19 @@ TEST_F(PersoTlvDataTest, PersoTlvCertObjBuildX509Cert) {
   size_t buf_size = kScratchBufferSize;
 
   EXPECT_EQ(perso_tlv_cert_obj_build(name, obj_type, cert, cert_size,
-                                     scratch_buf_.data(), &buf_size),
+                                     kPersoBlobVersionV0, scratch_buf_.data(),
+                                     &buf_size),
             kErrorOk);
 
   perso_tlv_cert_obj_t obj;
-  size_t ltv_buf_size = buf_size;  // Simulate reading the built object back
+  size_t tlv_buf_size = buf_size;  // Simulate reading the built object back
 
   // Should be able to get the object from the built buffer
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), ltv_buf_size, &obj),
+  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size,
+                                   kPersoBlobVersionV0, &obj),
             kErrorOk);
 
-  EXPECT_EQ(obj.obj_type, obj_type);
+  EXPECT_EQ(obj.obj_type, (uint32_t)obj_type);
   EXPECT_EQ(obj.obj_size, buf_size);  // The reported size by build should match
                                       // the object's size field
   EXPECT_STREQ(obj.name, name);
@@ -62,7 +65,8 @@ TEST_F(PersoTlvDataTest, PersoTlvCertObjBuildBufTooSmall) {
   size_t buf_size = 10;  // Intentionally too small
 
   EXPECT_EQ(perso_tlv_cert_obj_build(name, obj_type, cert, cert_size,
-                                     scratch_buf_.data(), &buf_size),
+                                     kPersoBlobVersionV0, scratch_buf_.data(),
+                                     &buf_size),
             kErrorPersoTlvOutputBufTooSmall);
 }
 
@@ -75,21 +79,24 @@ TEST_F(PersoTlvDataTest, PersoTlvCertObjBuildNameTooLong) {
   size_t buf_size = kScratchBufferSize;
 
   EXPECT_EQ(perso_tlv_cert_obj_build(name, obj_type, cert, cert_size,
-                                     scratch_buf_.data(), &buf_size),
+                                     kPersoBlobVersionV0, scratch_buf_.data(),
+                                     &buf_size),
             kErrorPersoTlvCertNameTooLong);
 }
 
 TEST_F(PersoTlvDataTest, PersoTlvGetCertObjEmptyBuf) {
   perso_tlv_cert_obj_t obj;
-  size_t ltv_buf_size = 0;
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), ltv_buf_size, &obj),
+  size_t tlv_buf_size = 0;
+  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size,
+                                   kPersoBlobVersionV0, &obj),
             kErrorPersoTlvInternal);  // Not enough size for header
 }
 
 TEST_F(PersoTlvDataTest, PersoTlvGetCertObjBufTooSmallForHeader) {
   perso_tlv_cert_obj_t obj;
-  size_t ltv_buf_size = sizeof(perso_tlv_object_header_t) - 1;
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), ltv_buf_size, &obj),
+  size_t tlv_buf_size = sizeof(perso_tlv_object_header_t) - 1;
+  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size,
+                                   kPersoBlobVersionV0, &obj),
             kErrorPersoTlvInternal);
 }
 
@@ -102,8 +109,9 @@ TEST_F(PersoTlvDataTest, PersoTlvGetCertObjEmptyObject) {
   memcpy(scratch_buf_.data(), &obj_header, sizeof(obj_header));
 
   perso_tlv_cert_obj_t obj;
-  size_t ltv_buf_size = sizeof(obj_header);
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), ltv_buf_size, &obj),
+  size_t tlv_buf_size = sizeof(obj_header);
+  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size,
+                                   kPersoBlobVersionV0, &obj),
             kErrorPersoTlvCertObjNotFound);  // Object is empty
 }
 
@@ -112,13 +120,14 @@ TEST_F(PersoTlvDataTest, PersoTlvGetCertObjTooBigForBuf) {
   perso_tlv_object_header_t obj_header = 0;
   PERSO_TLV_SET_FIELD(Objh, Type, obj_header, kPersoObjectTypeX509Cert);
   PERSO_TLV_SET_FIELD(Objh, Size, obj_header,
-                      kScratchBufferSize + 1);  // Size too large
+                      (uint16_t)(kScratchBufferSize + 1));  // Size too large
 
   memcpy(scratch_buf_.data(), &obj_header, sizeof(obj_header));
 
   perso_tlv_cert_obj_t obj;
-  size_t ltv_buf_size = sizeof(obj_header);  // Only header is actually in buf
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), ltv_buf_size, &obj),
+  size_t tlv_buf_size = sizeof(obj_header);  // Only header is actually in buf
+  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size,
+                                   kPersoBlobVersionV0, &obj),
             kErrorPersoTlvInternal);  // Object exceeds buffer size
 }
 
@@ -126,15 +135,16 @@ TEST_F(PersoTlvDataTest, PersoTlvGetCertObjBufTooSmallForCertHeader) {
   // Create a minimal object header for a cert
   perso_tlv_object_header_t obj_header = 0;
   perso_tlv_object_type_t obj_type = kPersoObjectTypeX509Cert;
-  size_t ltv_buf_size = sizeof(obj_header) + 1;
+  size_t tlv_buf_size = sizeof(obj_header) + 1;
   PERSO_TLV_SET_FIELD(Objh, Type, obj_header, obj_type);
-  PERSO_TLV_SET_FIELD(Objh, Size, obj_header, ltv_buf_size);
+  PERSO_TLV_SET_FIELD(Objh, Size, obj_header, (uint16_t)tlv_buf_size);
 
   memcpy(scratch_buf_.data(), &obj_header, sizeof(obj_header));
 
   perso_tlv_cert_obj_t obj;
   // Provide buffer size just enough for object header
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), ltv_buf_size, &obj),
+  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size,
+                                   kPersoBlobVersionV0, &obj),
             kErrorPersoTlvInternal);  // Not enough size for cert header
 }
 
@@ -143,31 +153,32 @@ TEST_F(PersoTlvDataTest, PersoTlvGetCertObjSizeMismatch) {
   perso_tlv_object_header_t obj_header = 0;
   perso_tlv_cert_header_t cert_header = 0;
   perso_tlv_object_type_t obj_type = kPersoObjectTypeX509Cert;
-  std::string name("UDS", 3);
+  std::string name_str = "UDS";
   size_t cert_data_size = kX509CertTestdataSize;
-  size_t expected_total_size =
-      sizeof(obj_header) + sizeof(cert_header) + name.size() + cert_data_size;
+  size_t expected_total_size = sizeof(obj_header) + sizeof(cert_header) +
+                               name_str.size() + cert_data_size;
 
   PERSO_TLV_SET_FIELD(Objh, Type, obj_header, obj_type);
-  PERSO_TLV_SET_FIELD(Objh, Size, obj_header, expected_total_size);
-  PERSO_TLV_SET_FIELD(Crth, NameSize, cert_header, name.size());
+  PERSO_TLV_SET_FIELD(Objh, Size, obj_header, (uint16_t)expected_total_size);
+  PERSO_TLV_SET_FIELD(Crth, NameSize, cert_header, (uint16_t)name_str.size());
   // Set cert header size *incorrectly*
   PERSO_TLV_SET_FIELD(Crth, Size, cert_header,
-                      expected_total_size - sizeof(obj_header) - 1);
+                      (uint16_t)(expected_total_size - sizeof(obj_header) - 1));
 
   uint8_t *ptr = scratch_buf_.data();
   memcpy(ptr, &obj_header, sizeof(obj_header));
   ptr += sizeof(obj_header);
   memcpy(ptr, &cert_header, sizeof(cert_header));
   ptr += sizeof(cert_header);
-  memcpy(ptr, name.data(), name.size());
-  ptr += name.size();
+  memcpy(ptr, name_str.data(), name_str.size());
+  ptr += name_str.size();
   memcpy(ptr, kX509CertTestdata, cert_data_size);
 
   perso_tlv_cert_obj_t obj;
-  size_t ltv_buf_size =
+  size_t tlv_buf_size =
       expected_total_size;  // Buffer is large enough for actual data
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), ltv_buf_size, &obj),
+  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size,
+                                   kPersoBlobVersionV0, &obj),
             kErrorPersoTlvInternal);  // Size mismatch detected by sanity check
 }
 
@@ -179,14 +190,14 @@ TEST_F(PersoTlvDataTest, PersoTlvGetCertObjCertTooLong) {
   const size_t name_len = 7;  // Arbitrary name length
   // Total object size should account for headers and the name, but we will
   // provide a smaller buffer size to simulate the error condition.
-  size_t cert_size = sizeof(cert_header) + name_len + kX509CertTestdataSize;
+  size_t cert_obj_size = sizeof(cert_header) + name_len + kX509CertTestdataSize;
   // Provide buffer size enough for headers, but NOT the full cert body
-  size_t ltv_buf_size = sizeof(obj_header) + cert_size - 1;
+  size_t tlv_buf_size = sizeof(obj_header) + cert_obj_size - 1;
 
   PERSO_TLV_SET_FIELD(Objh, Type, obj_header, obj_type);
-  PERSO_TLV_SET_FIELD(Objh, Size, obj_header, ltv_buf_size);
-  PERSO_TLV_SET_FIELD(Crth, NameSize, cert_header, name_len);
-  PERSO_TLV_SET_FIELD(Crth, Size, cert_header, cert_size);
+  PERSO_TLV_SET_FIELD(Objh, Size, obj_header, (uint16_t)tlv_buf_size);
+  PERSO_TLV_SET_FIELD(Crth, NameSize, cert_header, (uint16_t)name_len);
+  PERSO_TLV_SET_FIELD(Crth, Size, cert_header, (uint16_t)cert_obj_size);
 
   memcpy(scratch_buf_.data(), &obj_header, sizeof(obj_header));
   memcpy(scratch_buf_.data() + sizeof(obj_header), &cert_header,
@@ -194,7 +205,8 @@ TEST_F(PersoTlvDataTest, PersoTlvGetCertObjCertTooLong) {
 
   perso_tlv_cert_obj_t obj;
   // Expected to fail due to wrapped_cert_size is too long.
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), ltv_buf_size, &obj),
+  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size,
+                                   kPersoBlobVersionV0, &obj),
             kErrorPersoTlvInternal);
 }
 
@@ -207,13 +219,15 @@ TEST_F(PersoTlvDataTest, PersoTlvGetCertObjX509SanityCheckPass) {
   size_t buf_size = kScratchBufferSize;
 
   EXPECT_EQ(perso_tlv_cert_obj_build(name, obj_type, cert, cert_size,
-                                     scratch_buf_.data(), &buf_size),
+                                     kPersoBlobVersionV0, scratch_buf_.data(),
+                                     &buf_size),
             kErrorOk);
 
   perso_tlv_cert_obj_t obj;
-  size_t ltv_buf_size = buf_size;
+  size_t tlv_buf_size = buf_size;
 
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), ltv_buf_size, &obj),
+  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size,
+                                   kPersoBlobVersionV0, &obj),
             kErrorOk);
 }
 
@@ -226,14 +240,75 @@ TEST_F(PersoTlvDataTest, PersoTlvGetCertObjInvalidObjType) {
   size_t buf_size = kScratchBufferSize;
 
   EXPECT_EQ(perso_tlv_cert_obj_build(name, obj_type, cert, cert_size,
-                                     scratch_buf_.data(), &buf_size),
+                                     kPersoBlobVersionV0, scratch_buf_.data(),
+                                     &buf_size),
             kErrorOk);
 
   perso_tlv_cert_obj_t obj;
-  size_t ltv_buf_size = buf_size;
+  size_t tlv_buf_size = buf_size;
 
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), ltv_buf_size, &obj),
+  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size,
+                                   kPersoBlobVersionV0, &obj),
             kErrorPersoTlvCertObjNotFound);
+}
+
+TEST_F(PersoTlvDataTest, PersoTlvCertObjBuildX509CertV1) {
+  const char *name = "MLDSA-CERT";
+  perso_tlv_object_type_t obj_type = kPersoObjectTypeX509Cert;
+  const uint8_t *cert = kX509CertTestdata;
+  size_t cert_size = kX509CertTestdataSize;
+  size_t buf_size = kScratchBufferSize;
+
+  EXPECT_EQ(perso_tlv_cert_obj_build(name, obj_type, cert, cert_size,
+                                     kPersoBlobVersionV1, scratch_buf_.data(),
+                                     &buf_size),
+            kErrorOk);
+
+  perso_tlv_cert_obj_t obj;
+  size_t tlv_buf_size = buf_size;
+
+  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size,
+                                   kPersoBlobVersionV1, &obj),
+            kErrorOk);
+
+  EXPECT_EQ(obj.obj_type, (uint32_t)obj_type);
+  EXPECT_EQ(obj.obj_size, buf_size);
+  EXPECT_STREQ(obj.name, name);
+  EXPECT_EQ(obj.cert_body_size, cert_size);
+  EXPECT_EQ(memcmp(obj.cert_body_p, cert, cert_size), 0);
+}
+
+TEST_F(PersoTlvDataTest, PersoTlvInitV1Blob) {
+  perso_blob_t pb = {0};
+  EXPECT_EQ(perso_tlv_init_v1_blob(&pb), kErrorOk);
+  EXPECT_EQ(pb.num_objs, (size_t)1);
+  EXPECT_EQ(pb.next_free, (size_t)(sizeof(perso_tlv_object_header_t) +
+                                   sizeof(perso_tlv_blob_version_t)));
+
+  perso_blob_version_t version;
+  size_t offset;
+  EXPECT_EQ(
+      perso_tlv_get_blob_version(pb.body, pb.next_free, &version, &offset),
+      kErrorOk);
+  EXPECT_EQ(version, kPersoBlobVersionV1);
+  EXPECT_EQ(offset, pb.next_free);
+}
+
+TEST_F(PersoTlvDataTest, PersoTlvPushObjectToPersoBlobV1) {
+  perso_blob_t pb = {0};
+  EXPECT_EQ(perso_tlv_init_v1_blob(&pb), kErrorOk);
+
+  uint32_t data[] = {0x11223344, 0x55667788};
+  EXPECT_EQ(perso_tlv_push_object_to_perso_blob(kPersoObjectTypeDeviceId, data,
+                                                sizeof(data),
+                                                kPersoBlobVersionV1, &pb),
+            kErrorOk);
+
+  EXPECT_EQ(pb.num_objs, (size_t)2);
+  EXPECT_EQ((uint32_t)perso_tlv_object_type(pb.body + 4, kPersoBlobVersionV1),
+            (uint32_t)kPersoObjectTypeDeviceId);
+  EXPECT_EQ(perso_tlv_object_size(pb.body + 4, kPersoBlobVersionV1),
+            (uint32_t)(sizeof(perso_tlv_object_header_v1_t) + sizeof(data)));
 }
 
 }  // namespace

--- a/sw/device/silicon_creator/manuf/base/tpm_personalize_ext.c
+++ b/sw/device/silicon_creator/manuf/base/tpm_personalize_ext.c
@@ -79,9 +79,9 @@ static status_t personalize_gen_tpm_ek_certificate(
   curr_cert_size = sizeof(cert_buffer);
   TRY(tpm_ek_tbs_cert_build(&tpm_key_ids, &curr_pubkey, cert_buffer,
                             &curr_cert_size));
-  TRY(perso_tlv_push_cert_to_perso_blob("TPM EK", /*needs_endorsement=*/true,
-                                        kDiceCertFormatX509TcbInfo, cert_buffer,
-                                        curr_cert_size, perso_blob));
+  TRY(perso_tlv_push_cert_to_perso_blob(
+      "TPM EK", /*needs_endorsement=*/true, kDiceCertFormatX509TcbInfo,
+      cert_buffer, curr_cert_size, kPersoBlobVersionV0, perso_blob));
   return OK_STATUS();
 }
 

--- a/sw/device/silicon_creator/rom_ext/e2e/attestation/print_certs.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/attestation/print_certs.c
@@ -39,7 +39,8 @@ static status_t print_cert(char *dest,
   size_t len = sizeof(data);
   while (true) {
     perso_tlv_cert_obj_t obj = {0};
-    rom_error_t err = perso_tlv_get_cert_obj(data + offset, len, &obj);
+    rom_error_t err =
+        perso_tlv_get_cert_obj(data + offset, len, kPersoBlobVersionV0, &obj);
     if (err != kErrorOk) {
       break;
     }

--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/debug_mode_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/debug_mode_test.c
@@ -71,7 +71,8 @@ static status_t test_debug_mode(void) {
   size_t len = sizeof(data);
   while (true) {
     perso_tlv_cert_obj_t obj = {0};
-    rom_error_t err = perso_tlv_get_cert_obj(data + offset, len, &obj);
+    rom_error_t err =
+        perso_tlv_get_cert_obj(data + offset, len, kPersoBlobVersionV0, &obj);
     if (err != kErrorOk) {
       break;
     }


### PR DESCRIPTION
This commit introduces the V1 personalization blob format logic in a centralized library. It includes version detection, bit-packing for the new 32-bit headers, and unit tests to verify both V0 and V1 encapsulation.

This PR is chained on https://github.com/lowRISC/opentitan/pull/29781