### PR TITLE
[Perso BlobV1 #3] Add host-to-device version selection plumbing

### DIFF
--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -122,7 +122,10 @@ UJSON_SERDE_STRUCT(ManufFtIndividualizeData, \
 #define STRUCT_MANUF_CERTGEN_INPUTS(field, string) \
     field(dice_auth_key_key_id, uint8_t, 20) \
     field(ext_auth_key_key_id, uint8_t, 20) \
-    field(blob_version, perso_blob_version_t)
+    /* TODO: This should be a perso_blob_version_t enum, but using a primitive \
+     * uint16_t to avoid a ujson deserialization bug with nested derived \
+     * types. */ \
+    field(blob_version, uint16_t)
 UJSON_SERDE_STRUCT(ManufCertgenInputs, \
                    manuf_certgen_inputs_t, \
                    STRUCT_MANUF_CERTGEN_INPUTS);

--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -27,10 +27,20 @@ extern "C" {
 enum {
   kSerdesSha256HashSerializedMaxSize = 98,
   kLcTokenHashSerializedMaxSize = 52,
-  kManufCertgenInputsSerializedMaxSize = 210,
+  kManufCertgenInputsSerializedMaxSize = 215,
   kPersoBlobSerializedMaxSize = 20535,
 };
 #endif
+
+/**
+ * Version of the personalization blob format.
+ */
+// clang-format off
+#define ENUM_PERSO_BLOB_VERSION(_, value) \
+    value(_, V0, 0) \
+    value(_, V1, 1)
+UJSON_SERDE_ENUM(PersoBlobVersion, perso_blob_version_t, ENUM_PERSO_BLOB_VERSION);
+// clang-format on
 
 /**
  * Provisioning data imported onto the device during CP.
@@ -111,7 +121,8 @@ UJSON_SERDE_STRUCT(ManufFtIndividualizeData, \
 // clang-format off
 #define STRUCT_MANUF_CERTGEN_INPUTS(field, string) \
     field(dice_auth_key_key_id, uint8_t, 20) \
-    field(ext_auth_key_key_id, uint8_t, 20)
+    field(ext_auth_key_key_id, uint8_t, 20) \
+    field(blob_version, perso_blob_version_t)
 UJSON_SERDE_STRUCT(ManufCertgenInputs, \
                    manuf_certgen_inputs_t, \
                    STRUCT_MANUF_CERTGEN_INPUTS);

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
@@ -15,9 +15,9 @@ rom_error_t perso_tlv_init_v1_blob(perso_blob_t *pb) {
   // Add the Version Object (16-bit Type/Size header + 16-bit Version Payload).
   uint16_t header = 0;
   PERSO_TLV_SET_FIELD(Objh, Type, header, kPersoObjectTypeBlobVersion);
-  PERSO_TLV_SET_FIELD(
-      Objh, Size, header,
-      sizeof(perso_tlv_object_header_t) + sizeof(perso_tlv_blob_version_t));
+  PERSO_TLV_SET_FIELD(Objh, Size, header,
+                      sizeof(perso_tlv_object_header_t) +
+                          sizeof(perso_tlv_blob_version_payload_t));
   memcpy(pb->body + pb->next_free, &header, sizeof(uint16_t));
   pb->next_free += sizeof(uint16_t);
 
@@ -282,8 +282,8 @@ rom_error_t perso_tlv_get_blob_version(const uint8_t *data, size_t size,
   *version = kPersoBlobVersionV0;
   *offset = 0;
 
-  if (size <
-      sizeof(perso_tlv_object_header_t) + sizeof(perso_tlv_blob_version_t)) {
+  if (size < sizeof(perso_tlv_object_header_t) +
+                 sizeof(perso_tlv_blob_version_payload_t)) {
     return kErrorOk;  // Too small to contain a version object, default to V0
   }
 
@@ -295,8 +295,8 @@ rom_error_t perso_tlv_get_blob_version(const uint8_t *data, size_t size,
   PERSO_TLV_GET_FIELD(Objh, Size, header, &obj_size);
 
   if (type == kPersoObjectTypeBlobVersion) {
-    if (obj_size !=
-        sizeof(perso_tlv_object_header_t) + sizeof(perso_tlv_blob_version_t)) {
+    if (obj_size != sizeof(perso_tlv_object_header_t) +
+                        sizeof(perso_tlv_blob_version_payload_t)) {
       return kErrorPersoTlvInternal;
     }
     uint16_t version_be;
@@ -305,8 +305,8 @@ rom_error_t perso_tlv_get_blob_version(const uint8_t *data, size_t size,
     uint16_t parsed_version = __builtin_bswap16(version_be);
     if (parsed_version == kPersoBlobVersionV1) {
       *version = kPersoBlobVersionV1;
-      *offset =
-          sizeof(perso_tlv_object_header_t) + sizeof(perso_tlv_blob_version_t);
+      *offset = sizeof(perso_tlv_object_header_t) +
+                sizeof(perso_tlv_blob_version_payload_t);
     } else {
       return kErrorPersoTlvInternal;  // Unknown version
     }

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -69,21 +69,51 @@ typedef enum perso_tlv_object_type {
   kPersoObjectTypePersoSha256Hash = 7,
 } perso_tlv_object_type_t;
 
+typedef uint16_t perso_tlv_object_header_v0_t;
+typedef uint16_t perso_tlv_cert_header_v0_t;
+typedef uint32_t perso_tlv_object_header_v1_t;
+typedef uint32_t perso_tlv_cert_header_v1_t;
+
 typedef uint16_t perso_tlv_object_header_t;
 typedef uint16_t perso_tlv_cert_header_t;
 typedef uint16_t perso_tlv_dev_seed_header_t;
 
-typedef enum perso_tlv_obj_header_fields {
+typedef enum perso_tlv_obj_header_fields_v0 {
   // Object size, total size, this header included.
-  kObjhSizeFieldShift = 0,
-  kObjhSizeFieldWidth = 12,
-  kObjhSizeFieldMask = (1 << kObjhSizeFieldWidth) - 1,
+  kObjhSizeFieldShiftV0 = 0,
+  kObjhSizeFieldWidthV0 = 12,
+  kObjhSizeFieldMaskV0 = (1 << kObjhSizeFieldWidthV0) - 1,
 
   // Object type, one of perso_tlv_object_type_t.
-  kObjhTypeFieldShift = kObjhSizeFieldWidth,
-  kObjhTypeFieldWidth =
-      sizeof(perso_tlv_object_header_t) * 8 - kObjhSizeFieldWidth,
-  kObjhTypeFieldMask = (1 << kObjhTypeFieldWidth) - 1,
+  kObjhTypeFieldShiftV0 = kObjhSizeFieldWidthV0,
+  kObjhTypeFieldWidthV0 =
+      sizeof(perso_tlv_object_header_v0_t) * 8 - kObjhSizeFieldWidthV0,
+  kObjhTypeFieldMaskV0 = (1 << kObjhTypeFieldWidthV0) - 1,
+} perso_tlv_obj_header_fields_v0_t;
+
+typedef enum perso_tlv_obj_header_fields_v1 {
+  // Object size, total size, this header included.
+  kObjhV1SizeFieldShift = 0,
+  kObjhV1SizeFieldWidth = 24,
+  kObjhV1SizeFieldMask = (1 << kObjhV1SizeFieldWidth) - 1,
+
+  // Object type, one of perso_tlv_object_type_t.
+  kObjhV1TypeFieldShift = kObjhV1SizeFieldWidth,
+  kObjhV1TypeFieldWidth =
+      sizeof(perso_tlv_object_header_v1_t) * 8 - kObjhV1SizeFieldWidth,
+  kObjhV1TypeFieldMask = (1 << kObjhV1TypeFieldWidth) - 1,
+} perso_tlv_obj_header_fields_v1_t;
+
+typedef enum perso_tlv_obj_header_fields {
+  // Object size, total size, this header included.
+  kObjhSizeFieldShift = kObjhSizeFieldShiftV0,
+  kObjhSizeFieldWidth = kObjhSizeFieldWidthV0,
+  kObjhSizeFieldMask = kObjhSizeFieldMaskV0,
+
+  // Object type, one of perso_tlv_object_type_t.
+  kObjhTypeFieldShift = kObjhTypeFieldShiftV0,
+  kObjhTypeFieldWidth = kObjhTypeFieldWidthV0,
+  kObjhTypeFieldMask = kObjhTypeFieldMaskV0,
 } perso_tlv_obj_header_fields_t;
 
 typedef struct perso_tlv_dev_seed_element {
@@ -112,17 +142,42 @@ typedef struct perso_tlv_dev_seed_set {
  *  | 4 bit length|       12 bits total size       |
  *  +-------------+--------------------------------+
  */
-typedef enum perso_tlv_cert_header_fields {
+typedef enum perso_tlv_cert_header_fields_v0 {
   // Certificate size, total size, this header and name length included.
-  kCrthSizeFieldShift = 0,
-  kCrthSizeFieldWidth = 12,
-  kCrthSizeFieldMask = (1 << kCrthSizeFieldWidth) - 1,
+  kCrthSizeFieldShiftV0 = 0,
+  kCrthSizeFieldWidthV0 = 12,
+  kCrthSizeFieldMaskV0 = (1 << kCrthSizeFieldWidthV0) - 1,
 
   // Length of the certificate name immediately following the header.
-  kCrthNameSizeFieldShift = kCrthSizeFieldWidth,
-  kCrthNameSizeFieldWidth =
-      sizeof(perso_tlv_cert_header_t) * 8 - kCrthSizeFieldWidth,
-  kCrthNameSizeFieldMask = (1 << kCrthNameSizeFieldWidth) - 1,
+  kCrthNameSizeFieldShiftV0 = kCrthSizeFieldWidthV0,
+  kCrthNameSizeFieldWidthV0 =
+      sizeof(perso_tlv_cert_header_v0_t) * 8 - kCrthSizeFieldWidthV0,
+  kCrthNameSizeFieldMaskV0 = (1 << kCrthNameSizeFieldWidthV0) - 1,
+} perso_tlv_cert_header_fields_v0_t;
+
+typedef enum perso_tlv_cert_header_fields_v1 {
+  // Certificate size, total size, this header and name length included.
+  kCrthV1SizeFieldShift = 0,
+  kCrthV1SizeFieldWidth = 24,
+  kCrthV1SizeFieldMask = (1 << kCrthV1SizeFieldWidth) - 1,
+
+  // Length of the certificate name immediately following the header.
+  kCrthV1NameSizeFieldShift = kCrthV1SizeFieldWidth,
+  kCrthV1NameSizeFieldWidth =
+      sizeof(perso_tlv_cert_header_v1_t) * 8 - kCrthV1SizeFieldWidth,
+  kCrthV1NameSizeFieldMask = (1 << kCrthV1NameSizeFieldWidth) - 1,
+} perso_tlv_cert_header_fields_v1_t;
+
+typedef enum perso_tlv_cert_header_fields {
+  // Certificate size, total size, this header and name length included.
+  kCrthSizeFieldShift = kCrthSizeFieldShiftV0,
+  kCrthSizeFieldWidth = kCrthSizeFieldWidthV0,
+  kCrthSizeFieldMask = kCrthSizeFieldMaskV0,
+
+  // Length of the certificate name immediately following the header.
+  kCrthNameSizeFieldShift = kCrthNameSizeFieldShiftV0,
+  kCrthNameSizeFieldWidth = kCrthNameSizeFieldWidthV0,
+  kCrthNameSizeFieldMask = kCrthNameSizeFieldMaskV0,
 } perso_tlv_cert_header_fields_t;
 
 // Helper macros allowing set or get various object and certificate header
@@ -144,6 +199,24 @@ typedef enum perso_tlv_cert_header_fields {
     uint16_t mask = k##type_name##field_name##FieldMask;                    \
     uint16_t shift = k##type_name##field_name##FieldShift;                  \
     *(field_value) = (__builtin_bswap16(full_value) >> shift) & mask;       \
+  }
+
+#define PERSO_TLV_SET_FIELD_V1(type_name, field_name, full_value, field_value) \
+  {                                                                            \
+    uint32_t mask = k##type_name##field_name##FieldMask;                       \
+    uint32_t shift = k##type_name##field_name##FieldShift;                     \
+    uint32_t fieldv = (uint32_t)(field_value)&mask;                            \
+    uint32_t fullv = __builtin_bswap32((uint32_t)(full_value));                \
+    mask = (uint32_t)(mask << shift);                                          \
+    (full_value) = __builtin_bswap32(                                          \
+        (uint32_t)((fullv & ~mask) | (((uint32_t)fieldv) << shift)));          \
+  }
+
+#define PERSO_TLV_GET_FIELD_V1(type_name, field_name, full_value, field_value) \
+  {                                                                            \
+    uint32_t mask = k##type_name##field_name##FieldMask;                       \
+    uint32_t shift = k##type_name##field_name##FieldShift;                     \
+    *(field_value) = (__builtin_bswap32(full_value) >> shift) & mask;          \
   }
 
 /**

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -110,9 +110,9 @@ typedef struct perso_tlv_dev_seed_set {
 /**
  * Personalization blob version object payload.
  */
-typedef struct perso_tlv_blob_version {
+typedef struct perso_tlv_blob_version_payload {
   uint16_t version;
-} perso_tlv_blob_version_t;
+} perso_tlv_blob_version_payload_t;
 
 /**
  * The x509 certificate is prepended by a 16 bits header followed by the ASCII

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -174,25 +174,6 @@ typedef struct perso_tlv_cert_obj {
 } perso_tlv_cert_obj_t;
 
 /**
- * Personalization blob versions.
- */
-typedef enum perso_blob_version {
-  /**
-   * V0 is the original personalization blob format. It uses a 16-bit object
-   * header (4-bit type, 12-bit size), which limits the maximum size of any
-   * single object to 4KB.
-   */
-  kPersoBlobVersionV0 = 0,
-  /**
-   * V1 personalization blobs start with a version TLV object (which uses the V0
-   * header format for backwards compatibility). All subsequent objects in the
-   * blob use a larger 32-bit header (8-bit type, 24-bit size), allowing for
-   * significantly larger objects (up to 16MB).
-   */
-  kPersoBlobVersionV1 = 1,
-} perso_blob_version_t;
-
-/**
  * Initializes the perso blob as a V1 blob.
  *
  * @param pb Pointer to the `perso_blob_t` to initialize.

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data_unittest.cc
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data_unittest.cc
@@ -283,7 +283,7 @@ TEST_F(PersoTlvDataTest, PersoTlvInitV1Blob) {
   EXPECT_EQ(perso_tlv_init_v1_blob(&pb), kErrorOk);
   EXPECT_EQ(pb.num_objs, (size_t)1);
   EXPECT_EQ(pb.next_free, (size_t)(sizeof(perso_tlv_object_header_t) +
-                                   sizeof(perso_tlv_blob_version_t)));
+                                   sizeof(perso_tlv_blob_version_payload_t)));
 
   perso_blob_version_t version;
   size_t offset;

--- a/sw/device/silicon_creator/manuf/tests/ujson_msg_padding_functest.c
+++ b/sw/device/silicon_creator/manuf/tests/ujson_msg_padding_functest.c
@@ -79,6 +79,7 @@ static status_t send_ujson_msgs(ujson_t *uj) {
       certgen_inputs_msg.dice_auth_key_key_id[i] = 0x5;
       certgen_inputs_msg.ext_auth_key_key_id[i] = 0x5;
     }
+    certgen_inputs_msg.blob_version = (uint16_t)kPersoBlobVersionV0;
     perso_blob_msg.body[i] = 0x5;
   }
 

--- a/sw/device/silicon_creator/manuf/tests/ujson_msg_size_functest.c
+++ b/sw/device/silicon_creator/manuf/tests/ujson_msg_size_functest.c
@@ -69,6 +69,7 @@ static status_t send_ujson_msgs(ujson_t *uj) {
   memset(&sha256_hash_msg.data, UINT8_MAX, sizeof(sha256_hash_msg));
   memset(&lc_token_hash_msg.hash, UINT8_MAX, sizeof(lc_token_hash_msg));
   memset(&certgen_inputs_msg, UINT8_MAX, sizeof(certgen_inputs_msg));
+  certgen_inputs_msg.blob_version = (uint16_t)kPersoBlobVersionV0;
   memset(&perso_blob_msg.num_objs, UINT8_MAX, sizeof(perso_blob_msg.num_objs));
   memset(&perso_blob_msg.next_free, UINT8_MAX,
          sizeof(perso_blob_msg.next_free));

--- a/sw/host/provisioning/ft/src/main.rs
+++ b/sw/host/provisioning/ft/src/main.rs
@@ -222,7 +222,10 @@ fn main() -> Result<()> {
     let _perso_certgen_inputs = ManufCertgenInputs {
         dice_auth_key_key_id: dice_ca_key_id.clone(),
         ext_auth_key_key_id: ext_ca_key_id.clone(),
-        blob_version: opts.provisioning_data.blob_version.into(),
+        blob_version: match opts.provisioning_data.blob_version {
+            BlobVersion::V0 => 0,
+            BlobVersion::V1 => 1,
+        },
     };
 
     // Only run test unlock operation if we are in a locked LC state.

--- a/sw/host/provisioning/ft/src/main.rs
+++ b/sw/host/provisioning/ft/src/main.rs
@@ -35,6 +35,23 @@ use util_lib::{
 };
 
 /// Provisioning data command-line parameters.
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BlobVersion {
+    #[value(alias = "0")]
+    V0,
+    #[value(alias = "1")]
+    V1,
+}
+
+impl From<BlobVersion> for ujson_lib::provisioning_data::PersoBlobVersion {
+    fn from(v: BlobVersion) -> Self {
+        match v {
+            BlobVersion::V0 => ujson_lib::provisioning_data::PersoBlobVersion::V0,
+            BlobVersion::V1 => ujson_lib::provisioning_data::PersoBlobVersion::V1,
+        }
+    }
+}
+
 #[derive(Debug, Args, Clone)]
 pub struct ManufFtProvisioningDataInput {
     /// FT Device ID to provision.
@@ -70,6 +87,10 @@ pub struct ManufFtProvisioningDataInput {
     /// Pretty-print the provisioning data output.
     #[arg(long, default_value = "false")]
     pretty: bool,
+
+    /// Version of the TLV blob format to use.
+    #[arg(long, value_enum, default_value_t = BlobVersion::V0)]
+    pub blob_version: BlobVersion,
 }
 
 #[derive(Debug, Parser)]
@@ -201,6 +222,7 @@ fn main() -> Result<()> {
     let _perso_certgen_inputs = ManufCertgenInputs {
         dice_auth_key_key_id: dice_ca_key_id.clone(),
         ext_auth_key_key_id: ext_ca_key_id.clone(),
+        blob_version: opts.provisioning_data.blob_version.into(),
     };
 
     // Only run test unlock operation if we are in a locked LC state.

--- a/sw/host/provisioning/orchestrator/src/ot_dut.py
+++ b/sw/host/provisioning/orchestrator/src/ot_dut.py
@@ -288,6 +288,8 @@ class OtDut():
             # Add owner FW boot success message check.
             if self.sku_config.owner_fw_boot_str:
                 cmd += f" --owner-success-text=\"{self.sku_config.owner_fw_boot_str}\""
+            if self.sku_config.blob_version > 0:
+                cmd += f" --blob-version {self.sku_config.blob_version}"
 
             # Enable UJSON message logging.
             if self.log_ujson_payloads:

--- a/sw/host/provisioning/orchestrator/src/sku_config.py
+++ b/sw/host/provisioning/orchestrator/src/sku_config.py
@@ -31,6 +31,7 @@ class SkuConfig:
     ast_cfg_version: int = 255  # valid: any positive integer < 256 (to fit in one byte)
     ext_ca: Optional[OrderedDict] = None  # valid: see CaConfig
     owner_fw_boot_str: str = None  # valid: any string
+    blob_version: int = 0  # valid: any unsigned integer
 
     def __post_init__(self):
         # Load CA configs.

--- a/sw/host/provisioning/ujson_lib/src/lib.rs
+++ b/sw/host/provisioning/ujson_lib/src/lib.rs
@@ -16,7 +16,7 @@ pub mod provisioning_data;
 /// sw/device/lib/testing/json/provisioning_data.h
 pub const SERDES_SHA256_HASH_SERIALIZED_MAX_SIZE: usize = 98;
 pub const LC_TOKEN_HASH_SERIALIZED_MAX_SIZE: usize = 52;
-pub const MANUF_CERTGEN_INPUTS_SERIALIZED_MAX_SIZE: usize = 210;
+pub const MANUF_CERTGEN_INPUTS_SERIALIZED_MAX_SIZE: usize = 215;
 pub const PERSO_BLOB_SERIALIZED_MAX_SIZE: usize = 20535;
 
 pub struct UjsonPayloads {


### PR DESCRIPTION
Updates the provisioning JSON schema and host orchestrator to allow selecting between blob versions V0 and V1. This enables the host to instruct the device on which format to use during personalization.

Chained on PR https://github.com/lowRISC/opentitan/pull/29791