### PR TITLE
[ci] Use lowrisc/ci-actions for token acquisition in cherrypick

### DIFF
--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -18,9 +18,6 @@ concurrency:
 
 jobs:
   cherrypick:
-    # NOTE: We currently need these permissions because we create pull request with the repo-scoped
-    # default token. We should in the future move to a PAT owned by lowrisc-bot and create pull request
-    # on its behalf.
     permissions:
       # Needed for authentication.
       id-token: write
@@ -37,14 +34,7 @@ jobs:
 
       - name: Obtain token to create PR
         id: pr_token
-        run: |
-          # Obtain OIDC token from GitHub
-          ID_TOKEN=$(curl -sSf -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://ca.lowrisc.org" | jq -r .value)
-          echo "::add-mask::$ID_TOKEN"
-          # Exchange for a token to create PR
-          PR_TOKEN=$(curl -sSf -X POST -H "Authorization: Bearer $ID_TOKEN" "https://ca.lowrisc.org/api/github/repos/${{ github.repository }}/token")
-          echo "::add-mask::$PR_TOKEN"
-          echo "pr_token=$PR_TOKEN" >> "$GITHUB_OUTPUT"
+        uses: lowrisc/ci-actions/ca-token@v1
 
       - name: Create backport PRs
         id: backport
@@ -52,13 +42,13 @@ jobs:
         with:
           label_pattern: "^CherryPick:([^ ]+)$"
           pull_title: "Cherry-pick to ${target_branch}: ${pull_title}"
-          github_token: ${{ steps.pr_token.outputs.pr_token }}
+          github_token: ${{ steps.pr_token.outputs.token }}
           pull_description: |
             This is an automatic cherry-pick of #${pull_number} to branch `${target_branch}`.
 
       - name: Apply label for manually cherry picking
         if: ${{ steps.backport.outputs.was_successful == 'false' }}
         env:
-          GH_TOKEN: ${{ steps.pr_token.outputs.pr_token }}
+          GH_TOKEN: ${{ steps.pr_token.outputs.token }}
         run: |
           gh pr edit ${{ github.event.pull_request.number }} --add-label 'Manually CherryPick'


### PR DESCRIPTION
Replace inline token acquisition shell code with a common reuseable action at lowrisc/ci-actions/ca-token. Use the (only) tagged release v1.