### PR TITLE
[crypto\kmac kdf] Add a cdi option for the kmac kdf

### DIFF
--- a/sw/device/lib/crypto/drivers/keymgr.c
+++ b/sw/device/lib/crypto/drivers/keymgr.c
@@ -208,17 +208,40 @@ status_t keymgr_generate_key_aes(keymgr_diversification_t diversification) {
   return OTCRYPTO_OK;
 }
 
-status_t keymgr_generate_key_kmac(keymgr_diversification_t diversification) {
+status_t keymgr_generate_key_kmac(keymgr_diversification_t diversification,
+                                  hardened_bool_t attestation) {
   HARDENED_TRY(keymgr_is_idle());
 
   // Set the control register to generate a KMAC key.
-  WRITE_CTRL(KMAC, GENERATE_HW, false);
+  // Set the control register to generate an OTBN key.
+  switch (attestation) {
+    case kHardenedBoolFalse:
+      WRITE_CTRL(KMAC, GENERATE_HW, false);
+      break;
+    case kHardenedBoolTrue:
+      WRITE_CTRL(KMAC, GENERATE_HW, true);
+      break;
+    default:
+      HARDENED_TRAP();
+      return OTCRYPTO_FATAL_ERR;
+  }
 
   // Start the operation and wait for it to complete.
   HARDENED_TRY(keymgr_start(diversification));
   HARDENED_TRY(keymgr_wait_until_done());
   // Check the control register.
-  VERIFY_CTRL(KMAC, GENERATE_HW, false);
+  // Check the control register.
+  switch (attestation) {
+    case kHardenedBoolFalse:
+      VERIFY_CTRL(KMAC, GENERATE_HW, false);
+      break;
+    case kHardenedBoolTrue:
+      VERIFY_CTRL(KMAC, GENERATE_HW, true);
+      break;
+    default:
+      HARDENED_TRAP();
+      return OTCRYPTO_FATAL_ERR;
+  }
   return OTCRYPTO_OK;
 }
 

--- a/sw/device/lib/crypto/drivers/keymgr.h
+++ b/sw/device/lib/crypto/drivers/keymgr.h
@@ -82,11 +82,13 @@ status_t keymgr_generate_key_aes(
  * waits until the operation is complete before returning.
  *
  * @param diversification Diversification input for the key derivation.
+ * @param attestation Whether to use the CDI key.
  * @return OK or error.
  */
 OT_WARN_UNUSED_RESULT
 status_t keymgr_generate_key_kmac(
-    const keymgr_diversification_t diversification);
+    const keymgr_diversification_t diversification,
+    hardened_bool_t attestation);
 
 /**
  * Derive a key manager key for the OTBN block.
@@ -95,7 +97,7 @@ status_t keymgr_generate_key_kmac(
  * waits until the operation is complete before returning.
  *
  * @param diversification Diversification input for the key derivation.
- * @param attestation Whether to use the DICE key.
+ * @param attestation Whether to use the CDI key.
  * @return OK or error.
  */
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/crypto/drivers/keymgr_test.c
+++ b/sw/device/lib/crypto/drivers/keymgr_test.c
@@ -71,7 +71,7 @@ status_t aes_basic_test(void) {
  * Test generating a single sideloaded KMAC key.
  */
 status_t kmac_basic_test(void) {
-  return keymgr_generate_key_kmac(kTestDiversification);
+  return keymgr_generate_key_kmac(kTestDiversification, kHardenedBoolFalse);
 }
 
 /**

--- a/sw/device/lib/crypto/impl/kmac.c
+++ b/sw/device/lib/crypto/impl/kmac.c
@@ -70,7 +70,7 @@ otcrypto_status_t otcrypto_kmac(otcrypto_blinded_key_t *key,
     // Diversification call also checks that `key->keyblob_length` is 8 words
     // long.
     HARDENED_TRY(keyblob_to_keymgr_diversification(key, &diversification));
-    HARDENED_TRY(keymgr_generate_key_kmac(diversification));
+    HARDENED_TRY(keymgr_generate_key_kmac(diversification, kHardenedBoolFalse));
   } else if (key->config.hw_backed == kHardenedBoolFalse) {
     // Remask the key.
     HARDENED_TRY(keyblob_remask(key));

--- a/sw/device/lib/crypto/impl/kmac_kdf.c
+++ b/sw/device/lib/crypto/impl/kmac_kdf.c
@@ -16,24 +16,27 @@
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('k', 'k', 'd')
 
-otcrypto_status_t otcrypto_kmac_kdf(
+/**
+ * Internal helper for KMAC-based KDF operations.
+ *
+ * @param key_derivation_key Key to use for derivation.
+ * @param label Customization string (label).
+ * @param context Context or measurement string.
+ * @param is_cdi Whether this is a CDI derivation (uses attestation branch).
+ * @param output_key_material Destination for the derived key.
+ * @return Status of the operation.
+ */
+static otcrypto_status_t kmac_kdf_common(
     otcrypto_blinded_key_t *key_derivation_key,
     const otcrypto_const_byte_buf_t *label,
-    const otcrypto_const_byte_buf_t *context,
+    const otcrypto_const_byte_buf_t *context, hardened_bool_t is_cdi,
     otcrypto_blinded_key_t *output_key_material) {
-  // Check NULL pointers.
   if (key_derivation_key->keyblob == NULL || output_key_material == NULL ||
       output_key_material->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
-
-  // Check for null label with nonzero length.
-  if (label->data == NULL && label->len != 0) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  // Because of KMAC HWIPs prefix limitation, `label` should not exceed
-  // `kKmacCustStrMaxSize` bytes.
-  if (label->len > kKmacCustStrMaxSize) {
+  if ((label->data == NULL && label->len != 0) ||
+      (label->len > kKmacCustStrMaxSize)) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -42,16 +45,12 @@ otcrypto_status_t otcrypto_kmac_kdf(
     return OTCRYPTO_BAD_ARGS;
   }
 
-  // Check the private key checksum.
   if (launder32(integrity_blinded_key_check(key_derivation_key)) !=
       kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_CHECK_EQ(integrity_blinded_key_check(key_derivation_key),
                     kHardenedBoolTrue);
-
-  // Check `key_len` is supported by KMAC HWIP.
-  // The set of supported key sizes is {128, 192, 256, 384, 512}.
   HARDENED_TRY(kmac_key_length_check(key_derivation_key->config.key_length));
 
   kmac_blinded_key_t kmac_key = {
@@ -61,72 +60,64 @@ otcrypto_status_t otcrypto_kmac_kdf(
       .len = key_derivation_key->config.key_length,
   };
 
-  // Validate key length of `key_derivation_key`.
-  if (key_derivation_key->config.hw_backed == kHardenedBoolTrue) {
-    // Check that 1) key size matches sideload port size, 2) keyblob length
-    // matches diversification length.
+  if (launder32(key_derivation_key->config.hw_backed) == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(key_derivation_key->config.hw_backed, kHardenedBoolTrue);
     if (keyblob_share_num_words(key_derivation_key->config) *
             sizeof(uint32_t) !=
         kKmacSideloadKeyLength / 8) {
       return OTCRYPTO_BAD_ARGS;
     }
-    // Configure keymgr with diversification input and then generate the
-    // sideload key.
-    keymgr_diversification_t diversification;
-    // Diversification call also checks that
-    // `key_derivation_key->keyblob_length` is 8 words long.
-    HARDENED_TRY(keyblob_to_keymgr_diversification(key_derivation_key,
-                                                   &diversification));
-    HARDENED_TRY(keymgr_generate_key_kmac(diversification));
-  } else if (key_derivation_key->config.hw_backed == kHardenedBoolFalse) {
-    // Remask the key.
-    HARDENED_TRY(keyblob_remask(key_derivation_key));
 
+    keymgr_diversification_t diversification;
+    if (launder32(is_cdi) == kHardenedBoolTrue) {
+      HARDENED_CHECK_EQ(is_cdi, kHardenedBoolTrue);
+      HARDENED_TRY(keyblob_to_keymgr_attestation_diversification(
+          key_derivation_key, &diversification));
+      HARDENED_TRY(
+          keymgr_generate_key_kmac(diversification, kHardenedBoolTrue));
+    } else {
+      HARDENED_TRY(keyblob_to_keymgr_diversification(key_derivation_key,
+                                                     &diversification));
+      HARDENED_TRY(
+          keymgr_generate_key_kmac(diversification, kHardenedBoolFalse));
+    }
+  } else {
+    // CDI derivations must be hardware-backed.
+    if (launder32(is_cdi) == kHardenedBoolTrue) {
+      return OTCRYPTO_BAD_ARGS;
+    }
+    HARDENED_TRY(keyblob_remask(key_derivation_key));
     if (key_derivation_key->keyblob_length !=
         keyblob_num_words(key_derivation_key->config) * sizeof(uint32_t)) {
       return OTCRYPTO_BAD_ARGS;
     }
     HARDENED_TRY(keyblob_to_shares(key_derivation_key, &kmac_key.share0,
                                    &kmac_key.share1));
-  } else {
-    return OTCRYPTO_BAD_ARGS;
   }
 
   // At the moment, `kmac_kmac_128/256` only supports word-sized digest lengths.
   if (output_key_material->config.key_length % sizeof(uint32_t) != 0) {
     return OTCRYPTO_NOT_IMPLEMENTED;
   }
-
-  // Output key cannot be hardware-backed.
-  if (output_key_material->config.hw_backed != kHardenedBoolFalse) {
+  if (output_key_material->config.hw_backed != kHardenedBoolFalse ||
+      output_key_material->keyblob_length !=
+          keyblob_num_words(output_key_material->config) * sizeof(uint32_t)) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(output_key_material->config.hw_backed, kHardenedBoolFalse);
-
-  // Check the keyblob length.
-  if (output_key_material->keyblob_length !=
-      keyblob_num_words(output_key_material->config) * sizeof(uint32_t)) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-
-  // Randomize the keyblob memory.
   HARDENED_TRY(
       hardened_memshred(output_key_material->keyblob,
                         keyblob_num_words(output_key_material->config)));
 
   otcrypto_key_mode_t key_mode_used = launder32(0);
   switch (launder32(key_derivation_key->config.key_mode)) {
-    case kOtcryptoKeyModeKdfKmac128: {
+    case kOtcryptoKeyModeKdfKmac128:
       key_mode_used = launder32(key_mode_used) | kOtcryptoKeyModeKdfKmac128;
-      // No need to further check key size against security level because
-      // `kmac_key_length_check` ensures that the key is at least 128-bit.
       HARDENED_TRY(kmac_kmac_128(
-          &kmac_key, /*masked_digest=*/kHardenedBoolTrue, context, label->data,
-          label->len, output_key_material->keyblob,
+          &kmac_key, kHardenedBoolTrue, context, label->data, label->len,
+          output_key_material->keyblob,
           output_key_material->config.key_length / sizeof(uint32_t)));
       break;
-    }
-    case kOtcryptoKeyModeKdfKmac256: {
+    case kOtcryptoKeyModeKdfKmac256:
       key_mode_used = launder32(key_mode_used) | kOtcryptoKeyModeKdfKmac256;
       // Check that key size matches the security strength. It should be at
       // least 256-bit.
@@ -134,22 +125,35 @@ otcrypto_status_t otcrypto_kmac_kdf(
         return OTCRYPTO_BAD_ARGS;
       }
       HARDENED_TRY(kmac_kmac_256(
-          &kmac_key, /*masked_digest=*/kHardenedBoolTrue, context, label->data,
-          label->len, output_key_material->keyblob,
+          &kmac_key, kHardenedBoolTrue, context, label->data, label->len,
+          output_key_material->keyblob,
           output_key_material->config.key_length / sizeof(uint32_t)));
       break;
-    }
     default:
       return OTCRYPTO_BAD_ARGS;
   }
-  // Check if we landed in the correct case statement. Use ORs for this to
-  // avoid that multiple cases were executed.
   HARDENED_CHECK_EQ(launder32(key_mode_used),
                     key_derivation_key->config.key_mode);
 
   output_key_material->checksum =
       integrity_blinded_checksum(output_key_material);
-
-  // Clear the KMAC sideload slot in case the key was sideloaded.
   return otcrypto_eval_exit(keymgr_sideload_clear_kmac());
+}
+
+otcrypto_status_t otcrypto_kmac_kdf(
+    otcrypto_blinded_key_t *key_derivation_key,
+    const otcrypto_const_byte_buf_t *label,
+    const otcrypto_const_byte_buf_t *context,
+    otcrypto_blinded_key_t *output_key_material) {
+  return kmac_kdf_common(key_derivation_key, label, context, kHardenedBoolFalse,
+                         output_key_material);
+}
+
+otcrypto_status_t otcrypto_cdi_kmac_kdf(
+    otcrypto_blinded_key_t *key_derivation_key,
+    const otcrypto_const_byte_buf_t *cdi_label,
+    const otcrypto_const_byte_buf_t *dice_measurement,
+    otcrypto_blinded_key_t *output_key_material) {
+  return kmac_kdf_common(key_derivation_key, cdi_label, dice_measurement,
+                         kHardenedBoolTrue, output_key_material);
 }

--- a/sw/device/lib/crypto/include/kmac_kdf.h
+++ b/sw/device/lib/crypto/include/kmac_kdf.h
@@ -47,6 +47,24 @@ otcrypto_status_t otcrypto_kmac_kdf(
     const otcrypto_const_byte_buf_t *context,
     otcrypto_blinded_key_t *output_key_material);
 
+/**
+ * Performs KMAC-KDF similar to otcrypto_kmac_kdf but uses CDI=1.
+ *
+ * @param key_derivation_key Blinded key with configuration and private key
+ * handle returned by `otcrypto_hw_backed_attestation_key`.
+ * @param kmac_mode Either KMAC128 or KMAC256 as PRF.
+ * @param cdi_label Label string (optional, may be empty).
+ * @param dice_measurement Measurement info which can be the combined
+ * seed/code/config (optional, may be empty).
+ * @param[out] output_key_material Blinded output key material.
+ * @return Result of the key derivation operation.
+ */
+otcrypto_status_t otcrypto_cdi_kmac_kdf(
+    otcrypto_blinded_key_t *key_derivation_key,
+    const otcrypto_const_byte_buf_t *cdi_label,
+    const otcrypto_const_byte_buf_t *dice_measurement,
+    otcrypto_blinded_key_t *output_key_material);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/tests/crypto/kdf_kmac_sideload_functest.c
+++ b/sw/device/tests/crypto/kdf_kmac_sideload_functest.c
@@ -30,6 +30,7 @@ typedef enum kdf_test_operation_t {
 typedef struct kdf_test_vector {
   char *vector_identifier;
   kdf_test_operation_t test_operation;
+  hardened_bool_t is_cdi;
   otcrypto_blinded_key_t key_derivation_key;
   otcrypto_const_byte_buf_t label;
   otcrypto_const_byte_buf_t context;
@@ -65,6 +66,7 @@ static kdf_kmac_test_vector_t kKdfTestVectors[] = {
     {
         .vector_identifier = "Manually edited KDF-KMAC sample #1",
         .test_operation = kKdfTestOperationKmac128,
+        .is_cdi = kHardenedBoolFalse,
         .key_derivation_key =
             {
                 .config =
@@ -124,6 +126,7 @@ static kdf_kmac_test_vector_t kKdfTestVectors[] = {
     {
         .vector_identifier = "Manually edited KDF-KMAC sample #2",
         .test_operation = kKdfTestOperationKmac128,
+        .is_cdi = kHardenedBoolFalse,
         .key_derivation_key =
             {
                 .config =
@@ -207,6 +210,7 @@ static kdf_kmac_test_vector_t kKdfTestVectors[] = {
     {
         .vector_identifier = "Manually edited KDF-KMAC sample #3",
         .test_operation = kKdfTestOperationKmac256,
+        .is_cdi = kHardenedBoolFalse,
         .key_derivation_key =
             {
                 .config =
@@ -259,6 +263,76 @@ static kdf_kmac_test_vector_t kKdfTestVectors[] = {
                 .config =
                     {
                         .key_length = 64,
+                    },
+            },
+    },
+    {
+        .vector_identifier = "Manually integrated CDI-KMAC DICE sample",
+        .test_operation = kKdfTestOperationKmac256,
+        .is_cdi = kHardenedBoolTrue,
+        .key_derivation_key =
+            {
+                .config =
+                    {
+                        .version = kOtcryptoLibVersion1,
+                        .key_mode = kOtcryptoKeyModeKdfKmac256,
+                        .key_length = 32,
+                        .hw_backed = kHardenedBoolTrue,
+                        .security_level = kOtcryptoKeySecurityLevelHigh,
+                        .exportable = kHardenedBoolFalse,
+                    },
+                .keyblob_length = 36,
+                .keyblob =
+                    (uint32_t[]){
+                        // Zeroes to be populated by
+                        // `otcrypto_hw_backed_attestation_key`
+                        0x00000000,
+                        0x00000000,
+                        0x00000000,
+                        0x00000000,
+                        0x00000000,
+                        0x00000000,
+                        0x00000000,
+                        0x00000000,
+                        0x00000000,
+                    },
+            },
+        .context =
+            {
+                // Simulated DICE Measurement (TcbInfo)
+                .data =
+                    (uint8_t[]){
+                        0x70,
+                        0x71,
+                        0x72,
+                        0x73,
+                        0x74,
+                        0x75,
+                        0x76,
+                        0x77,
+                        0x78,
+                        0x79,
+                        0x7a,
+                        0x7b,
+                        0x7c,
+                        0x7d,
+                        0x7e,
+                        0x7f,
+                    },
+                .len = 16,
+            },
+        .label =
+            {
+                // Domain separation for Attestation CDI
+                .data = (uint8_t[]){'D', 'I', 'C', 'E', '_', 'A', 't', 't', 'e',
+                                    's', 't'},
+                .len = 11,
+            },
+        .keying_material =
+            {
+                .config =
+                    {
+                        .key_length = 32,
                     },
             },
     },
@@ -318,6 +392,17 @@ static status_t run_test_vector(void) {
   uint32_t km_buffer1[km_keyblob_len];
   uint32_t km_buffer2[km_keyblob_len];
 
+  if (current_test_vector->is_cdi == kHardenedBoolTrue) {
+    const uint32_t kPrivateKeySalt[8] = {0x00010203, 0x04050607, 0x08090a0b,
+                                         0x0c0d0e0f, 0xf0f1f2f3, 0xf4f5f6f7,
+                                         0xf8f9fafb, 0xfcfdfeff};
+    const uint32_t kPrivateKeyVersion = 0x0;
+
+    TRY(otcrypto_hw_backed_attestation_key(
+        kPrivateKeyVersion, kPrivateKeySalt,
+        &current_test_vector->key_derivation_key));
+  }
+
   current_test_vector->key_derivation_key.checksum =
       integrity_blinded_checksum(&current_test_vector->key_derivation_key);
 
@@ -365,9 +450,15 @@ static status_t run_test_vector(void) {
       otcrypto_const_byte_buf_t, sha3_test_vector.input_msg.data,
       sha3_test_vector.input_msg.len);
 
-  LOG_INFO("Running the first KDF-KMAC sideload operation.");
-  TRY(otcrypto_kmac_kdf(&current_test_vector->key_derivation_key, &label_buf,
-                        &context_buf, &keying_material1));
+  if (current_test_vector->is_cdi == kHardenedBoolTrue) {
+    LOG_INFO("Running the first CDI-KMAC sideload operation.");
+    TRY(otcrypto_cdi_kmac_kdf(&current_test_vector->key_derivation_key,
+                              &label_buf, &context_buf, &keying_material1));
+  } else {
+    LOG_INFO("Running the first KDF-KMAC sideload operation.");
+    TRY(otcrypto_kmac_kdf(&current_test_vector->key_derivation_key, &label_buf,
+                          &context_buf, &keying_material1));
+  }
 
   // Export the derived blinded key
   uint32_t km_share0[km_keyblob_share_len];
@@ -406,9 +497,15 @@ static status_t run_test_vector(void) {
       return INVALID_ARGUMENT();
   }
 
-  LOG_INFO("Running the second KDF-KMAC sideload operation for comparison.");
-  TRY(otcrypto_kmac_kdf(&current_test_vector->key_derivation_key, &label_buf,
-                        &context_buf, &keying_material2));
+  if (current_test_vector->is_cdi == kHardenedBoolTrue) {
+    LOG_INFO("Running the second CDI-KMAC sideload operation for comparison.");
+    TRY(otcrypto_cdi_kmac_kdf(&current_test_vector->key_derivation_key,
+                              &label_buf, &context_buf, &keying_material2));
+  } else {
+    LOG_INFO("Running the second KDF-KMAC sideload operation for comparison.");
+    TRY(otcrypto_kmac_kdf(&current_test_vector->key_derivation_key, &label_buf,
+                          &context_buf, &keying_material2));
+  }
 
   // Export the second derived blinded key
   TRY(otcrypto_export_blinded_key(&keying_material2, &km_share0_buf,


### PR DESCRIPTION
Create a new function otcrypto_cdi_kmac_kdf that uses the kmac kdf with a sideloaded key with CDI=1. For that function we rename label and info to cdi_label and dice_measurement. The dice measurement can be empty, but the user can also concatenate the needed strings into it as it will be used as KMAC's customization string.
In order to save code size, we make a shared kmac_kdf_common helper function.

Expand the kdf_kmac_sideload_functest to include the new API function. It's use is similar to that of p256_dice in that
otcrypto_hw_backed_attestation_key is used to populate its private key.