### PR TITLE
[crypto] Ed25519: SCA hardening of the second sign stage

### DIFF
--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -99,6 +99,7 @@ cc_library(
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         ":config",
+        ":drbg",
         ":hmac",
         ":integrity",
         ":keyblob",

--- a/sw/device/lib/crypto/impl/ecc/curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc/curve25519.c
@@ -30,12 +30,14 @@ OTBN_DECLARE_SYMBOL_ADDR(run_curve25519,
                          ed25519_public_key);  // Public Key A.
 OTBN_DECLARE_SYMBOL_ADDR(run_curve25519,
                          ed25519_hash_k);  // Challenge hash k.
-OTBN_DECLARE_SYMBOL_ADDR(
-    run_curve25519,
-    ed25519_hash_h_low);  // 32 lowest bytes of the key hash.
-OTBN_DECLARE_SYMBOL_ADDR(run_curve25519, ed25519_hash_r);  // Message hash r.
 OTBN_DECLARE_SYMBOL_ADDR(run_curve25519, ed25519_verify_lhs);
 OTBN_DECLARE_SYMBOL_ADDR(run_curve25519, ed25519_verify_rhs);
+OTBN_DECLARE_SYMBOL_ADDR(run_curve25519,
+                         ed25519_s0);  // 384-bit first share of s.
+OTBN_DECLARE_SYMBOL_ADDR(run_curve25519,
+                         ed25519_s1);  // 384-bit second shares of s.
+OTBN_DECLARE_SYMBOL_ADDR(run_curve25519, ed25519_r0); // 640-bit first share of r.
+OTBN_DECLARE_SYMBOL_ADDR(run_curve25519, ed25519_r1); // 640-bit second share of r.
 
 static const otbn_addr_t kOtbnVarMode = OTBN_ADDR_T_INIT(run_curve25519, mode);
 static const otbn_addr_t kOtbnVarVerifyRes =
@@ -48,14 +50,18 @@ static const otbn_addr_t kOtbnVarPubKey =
     OTBN_ADDR_T_INIT(run_curve25519, ed25519_public_key);
 static const otbn_addr_t kOtbnVarHashK =
     OTBN_ADDR_T_INIT(run_curve25519, ed25519_hash_k);
-static const otbn_addr_t kOtbnVarHashHlow =
-    OTBN_ADDR_T_INIT(run_curve25519, ed25519_hash_h_low);
-static const otbn_addr_t kOtbnVarHashR =
-    OTBN_ADDR_T_INIT(run_curve25519, ed25519_hash_r);
 static const otbn_addr_t kOtbnVarVerifyLhs =
     OTBN_ADDR_T_INIT(run_curve25519, ed25519_verify_lhs);
 static const otbn_addr_t kOtbnVarVerifyRhs =
     OTBN_ADDR_T_INIT(run_curve25519, ed25519_verify_rhs);
+static const otbn_addr_t kOtbnVarS0 =
+    OTBN_ADDR_T_INIT(run_curve25519, ed25519_s0);
+static const otbn_addr_t kOtbnVarS1 =
+    OTBN_ADDR_T_INIT(run_curve25519, ed25519_s1);
+static const otbn_addr_t kOtbnVarR0 =
+    OTBN_ADDR_T_INIT(run_curve25519, ed25519_r0);
+static const otbn_addr_t kOtbnVarR1 =
+    OTBN_ADDR_T_INIT(run_curve25519, ed25519_r1);
 
 // Declare mode constants.
 OTBN_DECLARE_SYMBOL_ADDR(run_curve25519, MODE_KEYGEN);
@@ -81,9 +87,13 @@ status_t curve25519_keygen_start(
   uint32_t mode = kOtbnCurve25519ModeKeygen;
   HARDENED_TRY(otbn_dmem_write(kCurve25519ModeWords, &mode, kOtbnVarMode));
 
-  // Set lower 32 bytes of private key hash h.
+  // Set the shares of s.
   HARDENED_TRY(
-      otbn_dmem_write(kCurve25519HalfHashWords, hash_h_low, kOtbnVarHashHlow));
+      otbn_dmem_write(kCurve25519HalfHashWords, hash_h_low, kOtbnVarS0));
+
+  // TODO: Remove once s is properly arithmetically shared.
+  HARDENED_TRY(otbn_dmem_set(8, 0, kOtbnVarS0 + 32));
+  HARDENED_TRY(otbn_dmem_set(16, 0, kOtbnVarS1 + 0));
 
   // Start the OTBN routine.
   return otbn_execute();
@@ -113,11 +123,18 @@ status_t curve25519_sign_stage1_start(
   HARDENED_TRY(otbn_dmem_write(kCurve25519ModeWords, &mode, kOtbnVarMode));
 
   // Set 64 Byte hash r.
-  HARDENED_TRY(otbn_dmem_write(kCurve25519HashWords, hash_r, kOtbnVarHashR));
+  HARDENED_TRY(otbn_dmem_write(kCurve25519HashWords, hash_r, kOtbnVarR0));
 
-  // Set lower 32 bytes of private key hash h.
+  HARDENED_TRY(otbn_dmem_set(8, 0, kOtbnVarR0 + 64));
+  HARDENED_TRY(otbn_dmem_set(24, 0, kOtbnVarR1 + 0));
+
+  // Set the shares of s.
   HARDENED_TRY(
-      otbn_dmem_write(kCurve25519HalfHashWords, hash_h_low, kOtbnVarHashHlow));
+      otbn_dmem_write(kCurve25519HalfHashWords, hash_h_low, kOtbnVarS0));
+
+  // TODO: Remove once s is properly arithmetically shared.
+  HARDENED_TRY(otbn_dmem_set(8, 0, kOtbnVarS0 + 32));
+  HARDENED_TRY(otbn_dmem_set(16, 0, kOtbnVarS1 + 0));
 
   // Start the OTBN routine.
   return otbn_execute();
@@ -153,12 +170,20 @@ status_t curve25519_sign_stage2_start(
   // Set challenge hash k.
   HARDENED_TRY(otbn_dmem_write(kCurve25519HashWords, hash_k, kOtbnVarHashK));
 
-  // Set 64 Byte hash r.
-  HARDENED_TRY(otbn_dmem_write(kCurve25519HashWords, hash_r, kOtbnVarHashR));
+  // Set the shares of r.
+  HARDENED_TRY(otbn_dmem_write(kCurve25519HashWords, hash_r, kOtbnVarR0));
 
-  // Set lower half of precomputed secret key hash h.
+  // TODO: Remove once r is properly arithmetically masked.
+  HARDENED_TRY(otbn_dmem_set(8, 0, kOtbnVarR0 + 64));
+  HARDENED_TRY(otbn_dmem_set(24, 0, kOtbnVarR1 + 0));
+
+  // Set the shares of s.
   HARDENED_TRY(
-      otbn_dmem_write(kCurve25519HalfHashWords, hash_h_low, kOtbnVarHashHlow));
+      otbn_dmem_write(kCurve25519HalfHashWords, hash_h_low, kOtbnVarS0));
+
+  // TODO: Remove once s is properly arithmetically masked.
+  HARDENED_TRY(otbn_dmem_set(8, 0, kOtbnVarS0 + 32));
+  HARDENED_TRY(otbn_dmem_set(16, 0, kOtbnVarS1 + 0));
 
   // Start the OTBN routine.
   return otbn_execute();

--- a/sw/device/lib/crypto/impl/ecc/curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc/curve25519.c
@@ -36,8 +36,10 @@ OTBN_DECLARE_SYMBOL_ADDR(run_curve25519,
                          ed25519_s0);  // 384-bit first share of s.
 OTBN_DECLARE_SYMBOL_ADDR(run_curve25519,
                          ed25519_s1);  // 384-bit second shares of s.
-OTBN_DECLARE_SYMBOL_ADDR(run_curve25519, ed25519_r0); // 640-bit first share of r.
-OTBN_DECLARE_SYMBOL_ADDR(run_curve25519, ed25519_r1); // 640-bit second share of r.
+OTBN_DECLARE_SYMBOL_ADDR(run_curve25519,
+                         ed25519_r0);  // 640-bit first share of r.
+OTBN_DECLARE_SYMBOL_ADDR(run_curve25519,
+                         ed25519_r1);  // 640-bit second share of r.
 
 static const otbn_addr_t kOtbnVarMode = OTBN_ADDR_T_INIT(run_curve25519, mode);
 static const otbn_addr_t kOtbnVarVerifyRes =
@@ -78,8 +80,38 @@ static const uint32_t kOtbnCurve25519ModeSignStage2 =
 static const uint32_t kOtbnCurve25519ModeVerify =
     OTBN_ADDR_T_INIT(run_curve25519, MODE_VERIFY);
 
-status_t curve25519_keygen_start(
-    const uint32_t hash_h_low[kCurve25519HalfHashWords]) {
+/**
+ * Write a masked scalar to DMEM.
+ *
+ * This routine can be used for both s and r by passing the shares directly to
+ * this function and setting `share_len` accordingly.
+ *
+ * @param share0 The first share of the scalar.
+ * @param share1 The second share of the scalar.
+ * @param share_len The size of the scalar shares in number of 32-bit words.
+ * @param share0_addr The DMEM address of the first share.
+ * @param share1_addr The DMEM address of the second share.
+ * @return OK.
+ */
+static status_t curve25519_masked_scalar_write(const uint32_t *share0,
+                                               const uint32_t *share1,
+                                               size_t share_len,
+                                               const otbn_addr_t share0_addr,
+                                               const otbn_addr_t share1_addr) {
+  HARDENED_TRY(otbn_dmem_write(share_len, share0, share0_addr));
+  HARDENED_TRY(otbn_dmem_write(share_len, share1, share1_addr));
+
+  // Write trailing 0s so that OTBN's 256-bit read of the shares does not cause
+  // an error.
+  HARDENED_TRY(otbn_dmem_set(kCurve25519MaskedScalarPaddingWords, 0,
+                             share0_addr + (share_len << 2)));
+  HARDENED_TRY(otbn_dmem_set(kCurve25519MaskedScalarPaddingWords, 0,
+                             share1_addr + (share_len << 2)));
+
+  return OTCRYPTO_OK;
+}
+
+status_t curve25519_keygen_start(const curve25519_masked_scalar_s_t *s) {
   // Load the Curve25519 app. Fails if OTBN is non-idle.
   HARDENED_TRY(otbn_load_app(kOtbnAppCurve25519));
 
@@ -87,13 +119,10 @@ status_t curve25519_keygen_start(
   uint32_t mode = kOtbnCurve25519ModeKeygen;
   HARDENED_TRY(otbn_dmem_write(kCurve25519ModeWords, &mode, kOtbnVarMode));
 
-  // Set the shares of s.
-  HARDENED_TRY(
-      otbn_dmem_write(kCurve25519HalfHashWords, hash_h_low, kOtbnVarS0));
-
-  // TODO: Remove once s is properly arithmetically shared.
-  HARDENED_TRY(otbn_dmem_set(8, 0, kOtbnVarS0 + 32));
-  HARDENED_TRY(otbn_dmem_set(16, 0, kOtbnVarS1 + 0));
+  // Write the shares of s to DMEM.
+  HARDENED_TRY(curve25519_masked_scalar_write(s->share0, s->share1,
+                                              kCurve25519MaskedScalarSWords,
+                                              kOtbnVarS0, kOtbnVarS1));
 
   // Start the OTBN routine.
   return otbn_execute();
@@ -112,9 +141,8 @@ status_t curve25519_keygen_finalize(
   return otbn_dmem_sec_wipe();
 }
 
-status_t curve25519_sign_stage1_start(
-    const uint32_t hash_r[kCurve25519HashWords],
-    const uint32_t hash_h_low[kCurve25519HalfHashWords]) {
+status_t curve25519_sign_stage1_start(const curve25519_masked_scalar_r_t *r,
+                                      const curve25519_masked_scalar_s_t *s) {
   // Load the Curve25519 app. Fails if OTBN is non-idle.
   HARDENED_TRY(otbn_load_app(kOtbnAppCurve25519));
 
@@ -122,19 +150,13 @@ status_t curve25519_sign_stage1_start(
   uint32_t mode = kOtbnCurve25519ModeSignStage1;
   HARDENED_TRY(otbn_dmem_write(kCurve25519ModeWords, &mode, kOtbnVarMode));
 
-  // Set 64 Byte hash r.
-  HARDENED_TRY(otbn_dmem_write(kCurve25519HashWords, hash_r, kOtbnVarR0));
-
-  HARDENED_TRY(otbn_dmem_set(8, 0, kOtbnVarR0 + 64));
-  HARDENED_TRY(otbn_dmem_set(24, 0, kOtbnVarR1 + 0));
-
-  // Set the shares of s.
-  HARDENED_TRY(
-      otbn_dmem_write(kCurve25519HalfHashWords, hash_h_low, kOtbnVarS0));
-
-  // TODO: Remove once s is properly arithmetically shared.
-  HARDENED_TRY(otbn_dmem_set(8, 0, kOtbnVarS0 + 32));
-  HARDENED_TRY(otbn_dmem_set(16, 0, kOtbnVarS1 + 0));
+  // Write the shares of r and s to DMEM.
+  HARDENED_TRY(curve25519_masked_scalar_write(r->share0, r->share1,
+                                              kCurve25519MaskedScalarRWords,
+                                              kOtbnVarR0, kOtbnVarR1));
+  HARDENED_TRY(curve25519_masked_scalar_write(s->share0, s->share1,
+                                              kCurve25519MaskedScalarSWords,
+                                              kOtbnVarS0, kOtbnVarS1));
 
   // Start the OTBN routine.
   return otbn_execute();
@@ -158,8 +180,8 @@ status_t curve25519_sign_stage1_finalize(
 
 status_t curve25519_sign_stage2_start(
     const uint32_t hash_k[kCurve25519HashWords],
-    const uint32_t hash_r[kCurve25519HashWords],
-    const uint32_t hash_h_low[kCurve25519HalfHashWords]) {
+    const curve25519_masked_scalar_r_t *r,
+    const curve25519_masked_scalar_s_t *s) {
   // Load the Curve25519 app. Fails if OTBN is non-idle.
   HARDENED_TRY(otbn_load_app(kOtbnAppCurve25519));
 
@@ -170,20 +192,13 @@ status_t curve25519_sign_stage2_start(
   // Set challenge hash k.
   HARDENED_TRY(otbn_dmem_write(kCurve25519HashWords, hash_k, kOtbnVarHashK));
 
-  // Set the shares of r.
-  HARDENED_TRY(otbn_dmem_write(kCurve25519HashWords, hash_r, kOtbnVarR0));
-
-  // TODO: Remove once r is properly arithmetically masked.
-  HARDENED_TRY(otbn_dmem_set(8, 0, kOtbnVarR0 + 64));
-  HARDENED_TRY(otbn_dmem_set(24, 0, kOtbnVarR1 + 0));
-
-  // Set the shares of s.
-  HARDENED_TRY(
-      otbn_dmem_write(kCurve25519HalfHashWords, hash_h_low, kOtbnVarS0));
-
-  // TODO: Remove once s is properly arithmetically masked.
-  HARDENED_TRY(otbn_dmem_set(8, 0, kOtbnVarS0 + 32));
-  HARDENED_TRY(otbn_dmem_set(16, 0, kOtbnVarS1 + 0));
+  // Write the shares of r and s to DMEM.
+  HARDENED_TRY(curve25519_masked_scalar_write(r->share0, r->share1,
+                                              kCurve25519MaskedScalarRWords,
+                                              kOtbnVarR0, kOtbnVarR1));
+  HARDENED_TRY(curve25519_masked_scalar_write(s->share0, s->share1,
+                                              kCurve25519MaskedScalarSWords,
+                                              kOtbnVarS0, kOtbnVarS1));
 
   // Start the OTBN routine.
   return otbn_execute();

--- a/sw/device/lib/crypto/impl/ecc/curve25519.h
+++ b/sw/device/lib/crypto/impl/ecc/curve25519.h
@@ -93,6 +93,40 @@ typedef struct curve25519_signature_t {
 } curve25519_signature_t;
 
 /**
+ * A type that holds the arithmetically masked shares of s.
+ *
+ * s is a 256-bit value secret scalar represesented by two 384-bit arithmetic
+ * shares (s0, s1) such that s = s0 - s1.
+ */
+typedef struct curve25519_masked_scalar_s {
+  /**
+   * First share of the secret scalar.
+   */
+  uint32_t share0[kCurve25519MaskedScalarSWords];
+  /**
+   * Second share of the secret scalar.
+   */
+  uint32_t share1[kCurve25519MaskedScalarSWords];
+} curve25519_masked_scalar_s_t;
+
+/**
+ * A type that holds the arithmetically masked shares of r.
+ *
+ * s is a 512-bit value secret scalar represesented by two 640-bit arithmetic
+ * shares (r0, r1) such that r = r0 - r1.
+ */
+typedef struct curve25519_masked_scalar_r {
+  /**
+   * First share of the secret scalar.
+   */
+  uint32_t share0[kCurve25519MaskedScalarRWords];
+  /**
+   * Second share of the secret scalar.
+   */
+  uint32_t share1[kCurve25519MaskedScalarRWords];
+} curve25519_masked_scalar_r_t;
+
+/**
  * Start an async Ed25519 keygen operation on OTBN.
  *
  * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
@@ -100,8 +134,7 @@ typedef struct curve25519_signature_t {
  * @param hash_h_low 32 low bytes of the key hash.
  * @return Result of the operation (OK or error).
  */
-status_t curve25519_keygen_start(
-    const uint32_t hash_h_low[kCurve25519HalfHashWords]);
+status_t curve25519_keygen_start(const curve25519_masked_scalar_s_t *s);
 
 /**
  * Finish an async Ed25519 keygen operation on OTBN.
@@ -118,14 +151,13 @@ status_t curve25519_keygen_finalize(uint32_t public_key[kCurve25519PointWords]);
  *
  * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
  *
- * @param hash_r Message hash r.
- * @param hash_h_low 32 low bytes of the key hash.
+ * @param r The masked scalar r.
+ * @param s The masked scalar s.
  * @return Result of the operation (OK or error).
  */
 OT_WARN_UNUSED_RESULT
-status_t curve25519_sign_stage1_start(
-    const uint32_t hash_r[kCurve25519HashWords],
-    const uint32_t hash_h_low[kCurve25519HalfHashWords]);
+status_t curve25519_sign_stage1_start(const curve25519_masked_scalar_r_t *r,
+                                      const curve25519_masked_scalar_s_t *s);
 
 /**
  * Finish stage 1 of an async Ed25519 sign operation on OTBN.
@@ -146,15 +178,15 @@ status_t curve25519_sign_stage1_finalize(
  * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
  *
  * @param hash_k Challenge hash k.
- * @param hash_r Message hash r.
- * @param hash_h_low 32 low bytes of the key hash.
+ * @param r The masked scalar r.
+ * @param s The masked scalar s.
  * @return Result of the operation (OK or error).
  */
 OT_WARN_UNUSED_RESULT
 status_t curve25519_sign_stage2_start(
     const uint32_t hash_k[kCurve25519HashWords],
-    const uint32_t hash_r[kCurve25519HashWords],
-    const uint32_t hash_h_low[kCurve25519HalfHashWords]);
+    const curve25519_masked_scalar_r_t *r,
+    const curve25519_masked_scalar_s_t *s);
 
 /**
  * Finish stage 2 of an async Ed25519 sign operation on OTBN.

--- a/sw/device/lib/crypto/impl/ecc/curve25519.h
+++ b/sw/device/lib/crypto/impl/ecc/curve25519.h
@@ -56,6 +56,30 @@ enum {
    * Number of words needed to hold a scalar.
    */
   kCurve25519ScalarWords = kCurve25519ScalarBytes / 4,
+  /**
+   * Number of bytes needed to hold a masked scalar s.
+   */
+  kCurve25519MaskedScalarSBytes = 48,
+  /**
+   * Number of words needed to hold a masked scalar s.
+   */
+  kCurve25519MaskedScalarSWords = kCurve25519MaskedScalarSBytes / 4,
+  /**
+   * Number of bytes needed to hold a masked scalar r.
+   */
+  kCurve25519MaskedScalarRBytes = 80,
+  /**
+   * Number of words needed to hold a masked scalar r.
+   */
+  kCurve25519MaskedScalarRWords = kCurve25519MaskedScalarRBytes / 4,
+  /**
+   * Number of zero padding words after a masked scalar share.
+   */
+  kCurve25519MaskedScalarPaddingWords = 4,
+  /**
+   * Magic value for verify success response.
+   */
+  kCurve25519VerifySuccess = 0xf77fe650,
 };
 
 /**

--- a/sw/device/lib/crypto/impl/ecc_curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc_curve25519.c
@@ -11,6 +11,7 @@
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/drbg.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/sha2.h"
 
@@ -181,6 +182,55 @@ static status_t ed25519_clamp(uint32_t hash_h_low[kCurve25519HalfHashWords]) {
   return OTCRYPTO_OK;
 }
 
+/**
+ * Create an arithmetic sharing of a scalar x such that x0 - x1 = x and
+ * x0 > x1.
+ *
+ * Given a scalar of size at most 32 * `scalar_len` bits and a `share_len`
+ * with `share_len >= scalar_len`, this function first randonmly chooses a
+ * random share x1 of size (32 * `share_len`) - 1 bits, then computes
+ * x0 = x + x1. Since the MSB of x1 is unset, we are sure that x0 is of at most
+ * 32 * `scalar_len` bits.
+ *
+ * Importantly, the MSB of x0 is the carry bit of the addition x + x1 which, if
+ * observed, leaks the information about the size of x. To alleviate this,
+ * `share_len` should be significantly larger than `scalar_len` which reduces
+ * the probability that the carry bit is set.
+ *
+ * @param scalar The scalar to be arithmetically masked.
+ * @param scalar_len The size of the scalar in number of 32-bit words.
+ * @param[out] share0 The first share of the arithmetic sharing.
+ * @param[out] share1 The second share of the arithmetic sharing.
+ * @param share_len The size of of the shared scalars in number of 32-bit words.
+ * @return OK.
+ */
+OT_WARN_UNUSED_RESULT
+static status_t ed25519_mask_scalar(uint32_t *scalar, size_t scalar_len,
+                                    uint32_t *share0, uint32_t *share1,
+                                    size_t share_len) {
+  // Copy the unmasked share into a larger buffer and set the
+  // `share_len - scalar_len` upper words to 0. Since the scalars in Ed25519
+  // can be of different sizes, we resort here to a VLA.
+  uint32_t buf[share_len];
+  memset(buf, 0, share_len << 2);
+  HARDENED_TRY(hardened_memshred(buf, scalar_len));
+  HARDENED_TRY(hardened_memcpy(buf, scalar, scalar_len));
+
+  // Set share1 to a random value and unset its MSB.
+  otcrypto_word32_buf_t share1_buf =
+      OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, share1, share_len);
+  otcrypto_const_byte_buf_t kEmptyBuffer =
+      OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, NULL, 0);
+  HARDENED_TRY(otcrypto_drbg_instantiate(&kEmptyBuffer));
+  HARDENED_TRY(otcrypto_drbg_generate(&kEmptyBuffer, &share1_buf));
+  share1[share_len - 1] &= 0x7fffffff;
+
+  // Compute share0 = share + share1.
+  HARDENED_TRY(hardened_add(buf, share1, share_len, share0));
+
+  return OTCRYPTO_OK;
+}
+
 otcrypto_status_t otcrypto_ed25519_keygen(
     const otcrypto_unblinded_key_t *private_key,
     otcrypto_unblinded_key_t *public_key) {
@@ -200,18 +250,21 @@ otcrypto_status_t otcrypto_ed25519_sign(
   // Validate signature buffer
   HARDENED_TRY(ed25519_signature_check(signature));
 
-  // Instantiate struct to store the secret key digest.
-  uint32_t key_digest_data[kCurve25519HashWords];
-  otcrypto_hash_digest_t key_digest = {
-      .data = key_digest_data,
-      .len = ARRAYSIZE(key_digest_data),
-  };
-  // Instantiate struct to store the message digest.
-  uint32_t msg_digest_data[kCurve25519HashWords];
-  otcrypto_hash_digest_t msg_digest = {
-      .data = msg_digest_data,
-      .len = ARRAYSIZE(msg_digest_data),
-  };
+  // Allocate the buffers for the shared r scalar.
+  uint32_t r0_data[kCurve25519MaskedScalarRWords];
+  uint32_t r1_data[kCurve25519MaskedScalarRWords];
+  otcrypto_word32_buf_t r0 = OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, r0_data,
+                                               kCurve25519MaskedScalarRWords);
+  otcrypto_word32_buf_t r1 = OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, r1_data,
+                                               kCurve25519MaskedScalarRWords);
+
+  // Allocate the buffers for the shared s scalar.
+  uint32_t s0_data[kCurve25519MaskedScalarSWords];
+  uint32_t s1_data[kCurve25519MaskedScalarSWords];
+  otcrypto_word32_buf_t s0 = OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, s0_data,
+                                               kCurve25519MaskedScalarSWords);
+  otcrypto_word32_buf_t s1 = OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, s1_data,
+                                               kCurve25519MaskedScalarSWords);
 
   uint32_t prehash_buffer[kCurve25519HashWords];
   otcrypto_byte_buf_t message_ph;
@@ -226,11 +279,11 @@ otcrypto_status_t otcrypto_ed25519_sign(
   // Start sign part 1 to calculate the public key and the signature commitment
   // R.
   HARDENED_TRY(otcrypto_ed25519_sign_part1_async_start(
-      private_key, &input_message_ph, sign_mode, &key_digest, &msg_digest));
+      private_key, &input_message_ph, sign_mode, &s0, &s1, &r0, &r1));
   // Start sign part 2 to calculate the signature response S.
   HARDENED_TRY(otcrypto_ed25519_sign_part2_async_start(
-      private_key, &input_message_ph, sign_mode, signature, &key_digest,
-      &msg_digest));
+      private_key, &input_message_ph, sign_mode, signature, &s0, &s1, &r0,
+      &r1));
   // Finish the execution and retrieve the signature.
   return otcrypto_ed25519_sign_async_finalize(signature);
 }
@@ -293,16 +346,23 @@ otcrypto_status_t otcrypto_ed25519_keygen_async_start(
       .len = ARRAYSIZE(key_digest_data),
   };
 
-  // Compute hash_h_low.
+  // Compute hash_h.
   otcrypto_const_byte_buf_t key_buf = OTCRYPTO_MAKE_BUF(
       otcrypto_const_byte_buf_t, (const uint8_t *const)private_key->key,
       private_key->key_length);
   HARDENED_TRY(otcrypto_sha2_512(&key_buf, &key_digest));
 
+  // Immediately clamp the lower half of hash_h to create the secret scalar s.
   HARDENED_TRY(ed25519_clamp(key_digest.data));
 
+  // Arithmetically mask s before passing it to the OTBN app.
+  curve25519_masked_scalar_s_t s;
+  HARDENED_TRY(ed25519_mask_scalar(key_digest.data, kCurve25519ScalarWords,
+                                   s.share0, s.share1,
+                                   kCurve25519MaskedScalarSWords));
+
   // Start the OTBN keygen app.
-  HARDENED_TRY_WIPE_DMEM(curve25519_keygen_start(key_digest.data));
+  HARDENED_TRY(curve25519_keygen_start(&s));
 
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
@@ -319,19 +379,39 @@ otcrypto_status_t otcrypto_ed25519_keygen_async_finalize(
 otcrypto_status_t otcrypto_ed25519_sign_part1_async_start(
     const otcrypto_unblinded_key_t *private_key,
     otcrypto_const_byte_buf_t *input_message_ph,
-    otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_hash_digest_t *key_digest,
-    otcrypto_hash_digest_t *msg_digest) {
+    otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t *s0,
+    otcrypto_word32_buf_t *s1, otcrypto_word32_buf_t *r0,
+    otcrypto_word32_buf_t *r1) {
   // Check the private key.
   HARDENED_TRY(ed25519_key_check(private_key));
 
-  // Compute hash_h_low.
+  // Instantiate struct to store the secret key digest.
+  uint32_t key_digest_data[kCurve25519HashWords];
+  otcrypto_hash_digest_t key_digest = {
+      .data = key_digest_data,
+      .len = ARRAYSIZE(key_digest_data),
+  };
+
+  // Compute hash_h.
   // TODO(#28964) Check SCA hardening of the key digest.
   otcrypto_const_byte_buf_t key_buf = OTCRYPTO_MAKE_BUF(
       otcrypto_const_byte_buf_t, (const uint8_t *const)private_key->key,
       private_key->key_length);
-  HARDENED_TRY(otcrypto_sha2_512(&key_buf, key_digest));
+  HARDENED_TRY(otcrypto_sha2_512(&key_buf, &key_digest));
 
-  HARDENED_TRY(ed25519_clamp(key_digest->data));
+  // Immediately clamp the lower half of hash_h to create the secret scalar s.
+  HARDENED_TRY(ed25519_clamp(key_digest.data));
+
+  // Arithmetically mask s before passing it to the OTBN app.
+  HARDENED_TRY(ed25519_mask_scalar(key_digest.data, kCurve25519ScalarWords,
+                                   s0->data, s1->data,
+                                   kCurve25519MaskedScalarSWords));
+
+  curve25519_masked_scalar_s_t s;
+  HARDENED_TRY(
+      hardened_memcpy(s.share0, s0->data, kCurve25519MaskedScalarSWords));
+  HARDENED_TRY(
+      hardened_memcpy(s.share1, s1->data, kCurve25519MaskedScalarSWords));
 
   // Prepend the dom2 prefix
   size_t dom2_len =
@@ -348,18 +428,35 @@ otcrypto_status_t otcrypto_ed25519_sign_part1_async_start(
 
   // Compute SHA-512(prefix || PH(M)).
   uint32_t *prefix =
-      key_digest->data + kCurve25519ScalarBytes / sizeof(uint32_t);
+      key_digest.data + kCurve25519ScalarBytes / sizeof(uint32_t);
   memcpy(&msg_bytes[offset], prefix, kCurve25519ScalarBytes);
   offset += kCurve25519ScalarBytes;
   memcpy(&msg_bytes[offset], input_message_ph->data, input_message_ph->len);
 
+  // Instantiate struct to store the message digest.
+  uint32_t msg_digest_data[kCurve25519HashWords];
+  otcrypto_hash_digest_t msg_digest = {
+      .data = msg_digest_data,
+      .len = ARRAYSIZE(msg_digest_data),
+  };
+
   otcrypto_const_byte_buf_t msg_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, msg_bytes, msg_byte_len);
-  HARDENED_TRY(otcrypto_sha2_512(&msg_buf, msg_digest));
+  HARDENED_TRY(otcrypto_sha2_512(&msg_buf, &msg_digest));
+
+  // Arithmetically mask r before passing it to the OTBN app.
+  HARDENED_TRY(ed25519_mask_scalar(msg_digest.data, kCurve25519HashWords,
+                                   r0->data, r1->data,
+                                   kCurve25519MaskedScalarRWords));
+
+  curve25519_masked_scalar_r_t r;
+  HARDENED_TRY(
+      hardened_memcpy(r.share0, r0->data, kCurve25519MaskedScalarRWords));
+  HARDENED_TRY(
+      hardened_memcpy(r.share1, r1->data, kCurve25519MaskedScalarRWords));
 
   // Start the OTBN sign stage 1 app.
-  HARDENED_TRY_WIPE_DMEM(
-      curve25519_sign_stage1_start(msg_digest->data, key_digest->data));
+  HARDENED_TRY(curve25519_sign_stage1_start(&r, &s));
 
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
@@ -368,7 +465,8 @@ otcrypto_status_t otcrypto_ed25519_sign_part2_async_start(
     const otcrypto_unblinded_key_t *private_key,
     otcrypto_const_byte_buf_t *input_message_ph,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t *signature,
-    otcrypto_hash_digest_t *key_digest, otcrypto_hash_digest_t *msg_digest) {
+    otcrypto_word32_buf_t *s0, otcrypto_word32_buf_t *s1,
+    otcrypto_word32_buf_t *r0, otcrypto_word32_buf_t *r1) {
   // Check the signature.
   HARDENED_TRY(ed25519_signature_check(signature));
 
@@ -412,9 +510,20 @@ otcrypto_status_t otcrypto_ed25519_sign_part2_async_start(
   };
   HARDENED_TRY(otcrypto_sha2_512(&challenge_buf, &challenge_digest));
 
+  curve25519_masked_scalar_s_t s;
+  HARDENED_TRY(
+      hardened_memcpy(s.share0, s0->data, kCurve25519MaskedScalarSWords));
+  HARDENED_TRY(
+      hardened_memcpy(s.share1, s1->data, kCurve25519MaskedScalarSWords));
+
+  curve25519_masked_scalar_r_t r;
+  HARDENED_TRY(
+      hardened_memcpy(r.share0, r0->data, kCurve25519MaskedScalarRWords));
+  HARDENED_TRY(
+      hardened_memcpy(r.share1, r1->data, kCurve25519MaskedScalarRWords));
+
   // Start the OTBN sign stage 2 app.
-  HARDENED_TRY_WIPE_DMEM(curve25519_sign_stage2_start(
-      challenge_digest.data, msg_digest->data, key_digest->data));
+  HARDENED_TRY(curve25519_sign_stage2_start(challenge_digest.data, &r, &s));
 
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }

--- a/sw/device/lib/crypto/impl/ecc_curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc_curve25519.c
@@ -163,6 +163,24 @@ static status_t ed25519_message_prehash(
   return OTCRYPTO_OK;
 }
 
+/**
+ * Clamp the lower half of the h digest, to create the scalar s.
+ *
+ * This function is in accordance with RFC 8032, see Section 5.1.5 Step 2.
+ *
+ * @param h_hash_low The lower 256 bits of the h digest.
+ * @param[out] s, the clamped scalar s.
+ * @return OK.
+ */
+OT_WARN_UNUSED_RESULT
+static status_t ed25519_clamp(uint32_t hash_h_low[kCurve25519HalfHashWords]) {
+  // Set the lower 3 bits and the MSB to 0, set the MSB-1 to 1.
+  hash_h_low[0] &= 0xfffffff8;
+  hash_h_low[kCurve25519HalfHashWords - 1] &= 0x7fffffff;
+  hash_h_low[kCurve25519HalfHashWords - 1] |= 0x40000000;
+  return OTCRYPTO_OK;
+}
+
 otcrypto_status_t otcrypto_ed25519_keygen(
     const otcrypto_unblinded_key_t *private_key,
     otcrypto_unblinded_key_t *public_key) {
@@ -281,6 +299,8 @@ otcrypto_status_t otcrypto_ed25519_keygen_async_start(
       private_key->key_length);
   HARDENED_TRY(otcrypto_sha2_512(&key_buf, &key_digest));
 
+  HARDENED_TRY(ed25519_clamp(key_digest.data));
+
   // Start the OTBN keygen app.
   HARDENED_TRY_WIPE_DMEM(curve25519_keygen_start(key_digest.data));
 
@@ -310,6 +330,8 @@ otcrypto_status_t otcrypto_ed25519_sign_part1_async_start(
       otcrypto_const_byte_buf_t, (const uint8_t *const)private_key->key,
       private_key->key_length);
   HARDENED_TRY(otcrypto_sha2_512(&key_buf, key_digest));
+
+  HARDENED_TRY(ed25519_clamp(key_digest->data));
 
   // Prepend the dom2 prefix
   size_t dom2_len =

--- a/sw/device/lib/crypto/include/ecc_curve25519.h
+++ b/sw/device/lib/crypto/include/ecc_curve25519.h
@@ -137,7 +137,10 @@ otcrypto_status_t otcrypto_ed25519_keygen_async_finalize(
  * @param private_key Pointer to the unblinded private key struct.
  * @param input_message_ph Pre-hashed input message to be signed.
  * @param sign_mode EdDSA signature hashing mode.
- * @param key_digest[out] Pointer to the key digest.
+ * @param[out] s0 Pointer to the first arithmetic share of s.
+ * @param[out] s1 Pointer to the second arithmetic share of s.
+ * @param[out] r0 Pointer to the first arithmetic share of r.
+ * @param[out] r1 Pointer to the second arithmetic share of r.
  * @param msg_digest[out] Pointer to the msg digest.
  * @return Result of async Ed25519 start operation.
  */
@@ -145,8 +148,9 @@ OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ed25519_sign_part1_async_start(
     const otcrypto_unblinded_key_t *private_key,
     otcrypto_const_byte_buf_t *input_message_ph,
-    otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_hash_digest_t *key_digest,
-    otcrypto_hash_digest_t *msg_digest);
+    otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t *s0,
+    otcrypto_word32_buf_t *s1, otcrypto_word32_buf_t *r0,
+    otcrypto_word32_buf_t *r1);
 
 /**
  * Starts asynchronous signature generation for Ed25519.
@@ -157,8 +161,10 @@ otcrypto_status_t otcrypto_ed25519_sign_part1_async_start(
  * @param input_message_ph Pre-hashed input message to be signed.
  * @param sign_mode EdDSA signature hashing mode.
  * @param signature[out] Pointer to the EdDSA signature to get (R) value.
- * @param key_digest Pointer to the key digest.
- * @param msg_digest Pointer to the msg digest.
+ * @param s0 Pointer to the first arithmetic share of s.
+ * @param s1 Pointer to the second arithmetic share of s.
+ * @param r0 Pointer to the first arithmetic share of r.
+ * @param r1 Pointer to the second arithmetic share of r.
  * @return Result of async Ed25519 start operation.
  */
 OT_WARN_UNUSED_RESULT
@@ -166,7 +172,8 @@ otcrypto_status_t otcrypto_ed25519_sign_part2_async_start(
     const otcrypto_unblinded_key_t *private_key,
     otcrypto_const_byte_buf_t *input_message_ph,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t *signature,
-    otcrypto_hash_digest_t *key_digest, otcrypto_hash_digest_t *msg_digest);
+    otcrypto_word32_buf_t *s0, otcrypto_word32_buf_t *s1,
+    otcrypto_word32_buf_t *r0, otcrypto_word32_buf_t *r1);
 
 /**
  * Finalizes asynchronous signature generation for Ed25519.

--- a/sw/device/tests/crypto/otcrypto_interface.h
+++ b/sw/device/tests/crypto/otcrypto_interface.h
@@ -189,12 +189,14 @@ typedef struct otcrypto_interface_t {
                                                 otcrypto_word32_buf_t *);
   otcrypto_status_t (*ed25519_sign_part1_async_start)(
       const otcrypto_unblinded_key_t *, otcrypto_const_byte_buf_t *,
-      otcrypto_eddsa_sign_mode_t, otcrypto_hash_digest_t *,
-      otcrypto_hash_digest_t *);
+      otcrypto_eddsa_sign_mode_t, otcrypto_word32_buf_t *,
+      otcrypto_word32_buf_t *, otcrypto_word32_buf_t *,
+      otcrypto_word32_buf_t *);
   otcrypto_status_t (*ed25519_sign_part2_async_start)(
       const otcrypto_unblinded_key_t *, otcrypto_const_byte_buf_t *,
       otcrypto_eddsa_sign_mode_t, otcrypto_word32_buf_t *,
-      otcrypto_hash_digest_t *, otcrypto_hash_digest_t *);
+      otcrypto_word32_buf_t *, otcrypto_word32_buf_t *, otcrypto_word32_buf_t *,
+      otcrypto_word32_buf_t *);
   otcrypto_status_t (*ed25519_sign_async_finalize)(otcrypto_word32_buf_t *);
   otcrypto_status_t (*ed25519_verify_async_start)(
       const otcrypto_unblinded_key_t *, otcrypto_const_byte_buf_t *,

--- a/sw/otbn/crypto/ed25519.s
+++ b/sw/otbn/crypto/ed25519.s
@@ -654,7 +654,7 @@ ed25519_sign_stage2:
   jal x1, sc_reduce
   bn.mov w8, w18
 
-  /* Compute the signature scalar S = (r0 + (k * s0)) - (r1 + (k * s0)) mod L. */
+  /* Compute the signature scalar S = (r0 + (k * s0)) - (r1 + (k * s1)) mod L. */
 
   /* w7 <= w4 * [w22:w21] mod L = k * s0 mod L. */
   bn.mov w21, w4
@@ -676,7 +676,7 @@ ed25519_sign_stage2:
   /* w6 <= w6 + w8 mod L = (r1 + (k * s1)) mod L. */
   bn.addm w6, w6, w8
 
-  /* w4 <= w5 - w6 mod L = S = (r0 + (k * s0)) - (r1 + (k * s0)) mod L. */
+  /* w4 <= w5 - w6 mod L = S = (r0 + (k * s0)) - (r1 + (k * s1)) mod L. */
   bn.subm w4, w5, w6
 
   /* Write S to dmem.

--- a/sw/otbn/crypto/ed25519.s
+++ b/sw/otbn/crypto/ed25519.s
@@ -101,28 +101,34 @@
  */
 ed25519_gen_public_key:
 
-  /* Load the 256-bit lower half of the precomputed hash h.
-       w16 <= h[255:0] */
+  /* Load the arithmetic shares (s0, s1) of the precomputed and clamped secret
+     s and reduce them modulo L. */
+
+  /* [w17:w16] <= s0. */
   li       x2, 16
-  la       x3, ed25519_hash_h_low
-  bn.lid   x2, 0(x3)
+  la       x3, ed25519_s0
+  bn.lid   x2++, 0(x3)
+  bn.lid   x2++, 32(x3)
 
-  /* Recover the secret scalar s from h.
-       w16 <= s */
-  jal      x1, sc_clamp
+  /* w28 <= [w17:w16] mod L = s0 mod L. */
+  jal x1, sc_reduce
+  bn.mov w28, w18
 
-  /* Reduce s modulo L. Note: s is only 255 bits, so this full 512-bit
-     reduction could be much faster (in fact, since clamping guarantees 3L < s
-     < 4L, we can simply subtract 3L instead). However, this routine is not
-     performance-critical, so we use the generalized routine and set the high
-     bits to zero.
-       w18 <= [w31,w16] mod L = s mod L */
-  bn.mov   w17, w31
-  jal      x1, sc_reduce
+  /* Clear w16 and w17 with randomness before loading the second share s1. */
+  bn.wsrr w16, URND
+  bn.wsrr w17, URND
 
-  /* Save s for later.
-       w28 <= s mod L */
-  bn.mov   w28, w18
+  /* [w17:w16] <= s1. */
+  li       x2, 16
+  la       x3, ed25519_s1
+  bn.lid   x2++, 0(x3)
+  bn.lid   x2++, 32(x3)
+
+  /* w18 <= [w17:w16] mod L = s1 mod L. */
+  jal x1, sc_reduce
+
+  /* TODO: Remove once everything is in place. */
+  bn.subm w28, w28, w18
 
   /* Set up for field arithmetic in preparation for scalar multiplication.
        MOD <= p
@@ -476,21 +482,37 @@ ed25519_sign_stage1:
        MOD <= L */
   jal      x1, sc_init
 
-  /* Load the 512-bit precomputed hash r.
-       [w17:w16] <= r */
-  li       x2, 16
-  la       x3, ed25519_hash_r
-  bn.lid   x2, 0(x3++)
-  addi     x2, x2, 1
-  bn.lid   x2, 0(x3)
+  /* Load the 640-bit shares (r0, r1) of the precomputed hash r and reduce
+     them. */
 
-  /* Reduce r modulo L.
-       w18 <= [w17:w16] mod L = r mod L */
-  jal      x1, sc_reduce
+  /* [w22:w20] <= r0. */
+  li       x2, 20
+  la       x3, ed25519_r0
+  bn.lid   x2++, 0(x3)
+  bn.lid   x2++, 32(x3)
+  bn.lid   x2++, 64(x3)
 
-  /* Save r for later.
-       w5 <= w18 = r mod L */
-  bn.mov   w5, w18
+  /* w5 <= [w22:w20] mod L = r0 mod L. */
+  jal x1, sc_reduce_768
+  bn.mov w5, w18
+
+  /* Overwrite w20-w22 with randomness before loading the second share r1. */
+  bn.wsrr w20, URND
+  bn.wsrr w21, URND
+  bn.wsrr w22, URND
+
+  /* [w22:w20] <= r1. */
+  li       x2, 20
+  la       x3, ed25519_r1
+  bn.lid   x2++, 0(x3)
+  bn.lid   x2++, 32(x3)
+  bn.lid   x2++, 64(x3)
+
+  /* w18 <= [w22:w20] mod L = r1 mod L. */
+  jal x1, sc_reduce_768
+
+  /* TODO remove this once everything is in place. */
+  bn.subm   w5, w5, w18
 
   /* Calculate and write encoded public key A (A_) to DMEM.
        dmem[ed25519_public_key] <= A_
@@ -559,21 +581,35 @@ ed25519_sign_stage2:
        MOD <= L */
   jal      x1, sc_init
 
-  /* Load the 512-bit precomputed hash r.
-       [w17:w16] <= r */
-  li       x2, 16
-  la       x3, ed25519_hash_r
-  bn.lid   x2, 0(x3++)
-  addi     x2, x2, 1
-  bn.lid   x2, 0(x3)
+  /* Load the 640-bit shares (r0, r1) of the precomputed hash r and reduce
+     them. */
 
-  /* Reduce r modulo L.
-       w18 <= [w17:w16] mod L = r mod L */
-  jal      x1, sc_reduce
+  /* [w22:w20] <= r0. */
+  li       x2, 20
+  la       x3, ed25519_r0
+  bn.lid   x2++, 0(x3)
+  bn.lid   x2++, 32(x3)
+  bn.lid   x2++, 64(x3)
 
-  /* Save r for later.
-       w5 <= r mod L */
-  bn.mov   w5, w18
+  /* w5 <= [w22:w20] mod L = r0 mod L. */
+  jal x1, sc_reduce_768
+  bn.mov w5, w18
+
+  /* Overwrite w20-w22 with randomness before loading the second share r1. */
+  bn.wsrr w20, URND
+  bn.wsrr w21, URND
+  bn.wsrr w22, URND
+
+  /* [w22:w20] <= r1. */
+  li       x2, 20
+  la       x3, ed25519_r1
+  bn.lid   x2++, 0(x3)
+  bn.lid   x2++, 32(x3)
+  bn.lid   x2++, 64(x3)
+
+  /* w6 <= [w22:w20] mod L = r1 mod L. */
+  jal x1, sc_reduce_768
+  bn.mov w6, w18
 
   /* Load the 512-bit precomputed hash k.
        [w17:w16] <= k */
@@ -591,28 +627,57 @@ ed25519_sign_stage2:
        w4 <= k mod L */
   bn.mov   w4, w18
 
-  /* Load the 256-bit lower half of the precomputed hash h.
-       w16 <= h[255:0] */
+  /* Load the arithmetic shares (s0, s1) of the precomputed and clamped secret
+     s and reduce them modulo L. */
+
+  /* [w17:w16] <= s0. */
   li       x2, 16
-  la       x3, ed25519_hash_h_low
-  bn.lid   x2, 0(x3)
+  la       x3, ed25519_s0
+  bn.lid   x2++, 0(x3)
+  bn.lid   x2++, 32(x3)
 
-  /* Recover the secret scalar s from h.
-       w16 <= s */
-  jal      x1, sc_clamp
+  /* w7 <= [w17:w16] mod L = s0 mod L. */
+  jal x1, sc_reduce
+  bn.mov w7, w18
 
-  /* Compute the signature scalar S = (r + (k * s)) mod L. Note: s is not fully
-     reduced modulo L here, but that is permitted according to the
-     specification of sc_mul, which only requires that its inputs fit in 256
-     bits. */
+  /* Clear w16 and w17 with randomness before loading the second share s1. */
+  bn.wsrr w16, URND
+  bn.wsrr w17, URND
 
-  /* w18 <= (w4 * w16) mod L = (k * s) mod L */
-  bn.mov   w21, w4
-  bn.mov   w22, w16
-  jal      x1, sc_mul
+  /* [w17:w16] <= s1. */
+  li       x2, 16
+  la       x3, ed25519_s1
+  bn.lid   x2++, 0(x3)
+  bn.lid   x2++, 32(x3)
 
-  /* w4 <= (w5 + w18) mod L = (r + k * s) mod L = S */
-  bn.addm  w4, w5, w18
+  /* w8 <= [w17:w16] mod L = s1 mod L. */
+  jal x1, sc_reduce
+  bn.mov w8, w18
+
+  /* Compute the signature scalar S = (r0 + (k * s0)) - (r1 + (k * s0)) mod L. */
+
+  /* w7 <= w4 * [w22:w21] mod L = k * s0 mod L. */
+  bn.mov w21, w4
+  bn.mov w22, w7
+  jal x1, sc_mul
+  bn.mov w7, w18
+
+  /* w8 <= w4 * [w22:w21] mod L = k * s1 mod L. */
+  bn.mov w21, w4
+  bn.mov w22, w8
+  jal x1, sc_mul
+  bn.mov w8, w18
+
+  /* w5 <= w5 + w7 mod L = (r0 + (k * s0)) mod L. */
+  bn.addm w5, w5, w7
+
+  bn.xor w31, w31, w31 /* dummy */
+
+  /* w6 <= w6 + w8 mod L = (r1 + (k * s1)) mod L. */
+  bn.addm w6, w6, w8
+
+  /* w4 <= w5 - w6 mod L = S = (r0 + (k * s0)) - (r1 + (k * s0)) mod L. */
+  bn.subm w4, w5, w6
 
   /* Write S to dmem.
        dmem[ed25519_sig_S] <= w4 = S */
@@ -1545,20 +1610,6 @@ ed25519_public_key:
 ed25519_hash_k:
   .zero 64
 
-/* Lower half of precomputed hash h (256 bits). See RFC 8032, section
-   5.1.6, step 1 or the docstring of ed25519_sign. Input for sign. */
-.balign 32
-.weak ed25519_hash_h_low
-ed25519_hash_h_low:
-  .zero 32
-
-/* Precomputed hash r (512 bits). See RFC 8032, section 5.1.6, step 2 or the
-   docstring of ed25519_sign. Input for sign. */
-.balign 32
-.weak ed25519_hash_r
-ed25519_hash_r:
-  .zero 64
-
 /* Encoded LHS for verification (256 bits). */
 .balign 32
 .globl ed25519_verify_lhs
@@ -1570,6 +1621,32 @@ ed25519_verify_lhs:
 .globl ed25519_verify_rhs
 ed25519_verify_rhs:
   .zero 32
+
+/* Precomputed arithmetic shares of the clamped integer s (256 bits embedded in
+   384 bits). See RFC 8032, section 5.1.6, step 1 or the docstring of
+   ed25519_sign. Input for sign. */
+.balign 32
+.weak ed25519_s0
+ed25519_s0:
+  .zero 64
+
+.balign 32
+.weak ed25519_s1
+ed25519_s1:
+  .zero 64
+
+/* Precomputed arithmetic shares of r (512 bits embedded in 640 bits). See
+   RFC 8032, section 5.1.6, step 2 or the docstring of ed25519_sign. Input for
+   sign. */
+.balign 32
+.weak ed25519_r0
+ed25519_r0:
+  .zero 96
+
+.balign 32
+.weak ed25519_r1
+ed25519_r1:
+  .zero 96
 
 .data
 

--- a/sw/otbn/crypto/ed25519_scalar.s
+++ b/sw/otbn/crypto/ed25519_scalar.s
@@ -4,6 +4,7 @@
 .text
 .globl sc_init
 .globl sc_reduce
+.globl sc_reduce_768
 .globl sc_mul
 
 /**
@@ -233,6 +234,46 @@ sc_reduce:
   /* Second conditional subtraction can simply use add-modulo.
        w18 <= w18 < L ? w18 : w18 - L = x mod L */
   bn.addm w18, w18, w31
+
+  ret
+
+/**
+ * Fully reduce a 768-bit number modulo L.
+ *
+ * Returns c = a mod L.
+ *
+ * Using Horner's method we can reduce the 768-bit integer a with two 512-bit
+ * Barrett reductions (`see sc_reduce`):
+ *
+ *   a mod L = a2 * 2^512 + a1 * 2^256 + a0 mod L
+ *           = (a2 * 2^256 + a1) * 2^256 + a0
+ *           = b * 2^256 + a0
+ *           = ((b mod L) * 2^256 + a0) mod L
+ *
+ * In other words, we first reduce the 512-bit number b (the upper two 256-bit
+ * words of a) by L, followed by reduction of a0 + (b mod L) * 2^256.
+ *
+ * This routine runs in constant time.
+ *
+ * Flags: Flags have no meaning beyond the scope of this subroutine.
+ *
+ * @param[in]  [w22:w20]: a, number to be reduced (a < 2^768)
+ * @param[in]  [w15:w14]: mu = floor(2^512 / L) (precomputed constant)
+ * @param[in]  MOD: L, modulus
+ * @param[in]  w31: all-zero
+ * @param[out] w18: c, result = a mod L
+ *
+ * clobbered registers: w10 to w13, w16 to w17, w18
+ * clobbered flag groups: FG0
+ */
+sc_reduce_768:
+  bn.mov w16, w21
+  bn.mov w17, w22
+  jal x1, sc_reduce
+
+  bn.mov w16, w20
+  bn.mov w17, w18
+  jal x1, sc_reduce
 
   ret
 

--- a/sw/otbn/crypto/run_curve25519.s
+++ b/sw/otbn/crypto/run_curve25519.s
@@ -195,16 +195,28 @@ ed25519_public_key:
 ed25519_hash_k:
   .zero 64
 
-/* Lower half of precomputed hash h (256 bits). See RFC 8032, section
-   5.1.6, step 1 or the docstring of ed25519_sign. Input for sign. */
+/* Precomputed arithmetic shares of the clamped integer s (256 bits embedded in
+   384 bits). See RFC 8032, section 5.1.6, step 1 or the docstring of
+   ed25519_sign. Input for sign. */
 .balign 32
-.globl ed25519_hash_h_low
-ed25519_hash_h_low:
-  .zero 32
-
-/* Precomputed hash r (512 bits). See RFC 8032, section 5.1.6, step 2 or the
-   docstring of ed25519_sign. Input for sign. */
-.balign 32
-.globl ed25519_hash_r
-ed25519_hash_r:
+.globl ed25519_s0
+ed25519_s0:
   .zero 64
+
+.balign 32
+.globl ed25519_s1
+ed25519_s1:
+  .zero 64
+
+/* Precomputed arithmetic shares of r (512 bits embedded in 640 bits). See
+   RFC 8032, section 5.1.6, step 2 or the docstring of ed25519_sign.
+   Input for sign. */
+.balign 32
+.globl ed25519_r0
+ed25519_r0:
+  .zero 96
+
+.balign 32
+.globl ed25519_r1
+ed25519_r1:
+  .zero 96

--- a/sw/otbn/crypto/tests/BUILD
+++ b/sw/otbn/crypto/tests/BUILD
@@ -95,6 +95,17 @@ otbn_sim_test(
 )
 
 otbn_sim_test(
+    name = "ed25519_sc_reduce_test",
+    srcs = [
+        "ed25519_sc_reduce_test.s",
+    ],
+    testcase = "ed25519_sc_reduce_test.hjson",
+    deps = [
+        "//sw/otbn/crypto:ed25519_scalar",
+    ],
+)
+
+otbn_sim_test(
     name = "ed25519_sign_test",
     srcs = [
         "ed25519_sign_test.s",

--- a/sw/otbn/crypto/tests/ed25519_sc_reduce_test.hjson
+++ b/sw/otbn/crypto/tests/ed25519_sc_reduce_test.hjson
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+{
+  "entrypoint": "main",
+  "input": {
+    "dmem": {
+      "_sc_reduce_512_x": "0x90f9b857a61c7d890c0ddff5a8e5c4b838eb03eca2b19d6d9e7bd97ae5e21c18a61421b06a574c8837c3cfa4d717d11469b4715c67d3b522531672187c6c29bc",
+      "_sc_reduce_768_x": "0x532ab78966d88a121010c480b01130b161b1149c1aac61f9e2ceb1efd5c4d06c8a88ecdfcde4c94f568f054cd07f2095990575db2ba76c5e35fb8422f099b71463908b51c68c570f3aea447ce7a9b8ce8d359d09f8a18c2e7f1104c89ba6c23c",
+    }
+  },
+  "output": {
+    "dmem": {
+      "_sc_reduce_512_y": "0x19f357daf8255b6ef6fce29b6c3b3ad30697fa83d4f0c17d2955092dfdf6106",
+      "_sc_reduce_768_y": "0x135eaf3329c5c12b59ecba02ba86889eb41bd2b9d3792c48ac63b8e2c5a2fc1",
+    }
+  }
+}

--- a/sw/otbn/crypto/tests/ed25519_sc_reduce_test.s
+++ b/sw/otbn/crypto/tests/ed25519_sc_reduce_test.s
@@ -1,0 +1,65 @@
+/* Copyright lowRISC contributors (OpenTitan project). */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* Test we can correctly modular reduce 512-bit and 768-bit numbers. */
+
+.section .text.start
+
+main:
+  bn.xor w31, w31, w31
+
+  /* [w15:w14] <= mu, MOD <= L. */
+  jal x1, sc_init
+
+  /*
+   * Test 1: 512-bit modular reduction.
+   */
+
+  /* [w17:w16] <= dmem[_sc_reduce_512_x] = x. */
+  li x2, 16
+  la x3, _sc_reduce_512_x
+  bn.lid x2++, 0(x3)
+  bn.lid x2++, 32(x3)
+
+  /* w18 <= x mod L. */
+  jal x1, sc_reduce
+
+  /* dmem[_sc_reduce_512_y] <= w18 = x mod L. */
+  la x2, _sc_reduce_512_y
+  li x3, 18
+  bn.sid x3, 0(x2)
+
+  /*
+   * Test 2: 768-bit modular reduction.
+   */
+
+  /* [w22:w20] <= dmem[_sc_reduce_768_x] = x. */
+  li x2, 20
+  la x3, _sc_reduce_768_x
+  bn.lid x2++, 0(x3)
+  bn.lid x2++, 32(x3)
+  bn.lid x2++, 64(x3)
+
+  /* w18 <= x mod L. */
+  jal x1, sc_reduce_768
+
+  /* dmem[_sc_reduce_768_y] <= w18 = x mod L. */
+  la x2, _sc_reduce_768_y
+  li x3, 18
+  bn.sid x3, 0(x2)
+
+  ecall
+
+.data
+.balign 32
+
+_sc_reduce_512_x:
+.zero 64
+_sc_reduce_512_y:
+.zero 32
+
+_sc_reduce_768_x:
+.zero 96
+_sc_reduce_768_y:
+.zero 32

--- a/sw/otbn/crypto/tests/ed25519_sign_test.s
+++ b/sw/otbn/crypto/tests/ed25519_sign_test.s
@@ -190,45 +190,89 @@ ed25519_hash_k:
   .word 0x7bee6837
   .word 0x9f0e3ca0
 
-.globl ed25519_hash_r
+.globl ed25519_r0
 .balign 32
-ed25519_hash_r:
-  .word 0xd89cb1b6
-  .word 0x596f42e0
-  .word 0x2d11fa83
-  .word 0xaa43a189
-  .word 0xbcb8da97
-  .word 0x5b8deb5d
-  .word 0x28c95362
-  .word 0xf47252b6
-  .word 0xc2984004
-  .word 0x9c0390a9
-  .word 0x486a5bde
-  .word 0xfb0bdf18
-  .word 0x5ddc406e
-  .word 0x802454ee
-  .word 0x23239632
-  .word 0x2d3501e7
+ed25519_r0:
+  .word 0xc116c7c9
+  .word 0x915b1fba
+  .word 0xae4522f9
+  .word 0xcdeb12a3
+  .word 0x04df610a
+  .word 0x7f544c8d
+  .word 0xea45b5db
+  .word 0x0cb926da
+  .word 0x60e5ae41
+  .word 0x68a9364b
+  .word 0x888b8ad6
+  .word 0xf7c8e3db
+  .word 0x46c161d9
+  .word 0x087a6c01
+  .word 0x1ebb6a68
+  .word 0xe1bb2d09
+  .word 0xcf6a659e
+  .word 0x9a164106
+  .word 0xe6f4590b
+  .word 0x259f4329
+  .zero 16
 
-.globl ed25519_hash_h_low
+.globl ed25519_r1
 .balign 32
-ed25519_hash_h_low:
-  .word 0x86837c35
-  .word 0xcb33284f
-  .word 0xf12e7a42
-  .word 0x3c010ac0
-  .word 0x6827fffd
-  .word 0xa3c080d9
-  .word 0x06f020a5
-  .word 0x0fe94d90
-  .word 0x86837c35
-  .word 0xcb33284f
-  .word 0xf12e7a42
-  .word 0x3c010ac0
-  .word 0x6827fffd
-  .word 0xa3c080d9
-  .word 0x06f020a5
-  .word 0x0fe94d90
+ed25519_r1:
+  .word 0xe87a1613
+  .word 0x37ebdcd9
+  .word 0x81332876
+  .word 0x23a7711a
+  .word 0x48268673
+  .word 0x23c6612f
+  .word 0xc17c6279
+  .word 0x1846d424
+  .word 0x9e4d6e3c
+  .word 0xcca5a5a1
+  .word 0x40212ef7
+  .word 0xfcbd04c3
+  .word 0xe8e5216a
+  .word 0x88561712
+  .word 0xfb97d435
+  .word 0xb4862b21
+  .word 0xcf6a659e
+  .word 0x9a164106
+  .word 0xe6f4590b
+  .word 0x259f4329
+  .zero 16
+
+.globl ed25519_s0
+.balign 32
+ed25519_s0:
+  .word 0x4f2a8269
+  .word 0x9fa465b0
+  .word 0x3ed4614c
+  .word 0x33c2c848
+  .word 0xe22a4202
+  .word 0xff69a088
+  .word 0x9c48a724
+  .word 0x342d2d08
+  .word 0xe87a1614
+  .word 0x37ebdcd9
+  .word 0x81332876
+  .word 0x23a7711a
+  .zero 16
+
+.globl ed25519_s1
+.balign 32
+ed25519_s1:
+  .word 0xc8a70639
+  .word 0xd4713d60
+  .word 0x4da5e709
+  .word 0xf7c1bd87
+  .word 0x7a024204
+  .word 0x5ba91faf
+  .word 0x9558867f
+  .word 0xe443df78
+  .word 0xe87a1613
+  .word 0x37ebdcd9
+  .word 0x81332876
+  .word 0x23a7711a
+  .zero 16
 
 .globl test1_expected_sig_R
 .balign 32


### PR DESCRIPTION
Create an arithmetic sharing of the secret scalars `s = s0 - s1` and `r = r0 - r1` and compute the second
sign stage in a fully masked fashion. The sharing is created on Ibex.