### PR TITLE
[crypto] Remove variable length arrays

### DIFF
--- a/sw/device/lib/crypto/impl/aes_gcm/aes_gcm.c
+++ b/sw/device/lib/crypto/impl/aes_gcm/aes_gcm.c
@@ -678,7 +678,7 @@ status_t aes_gcm_decrypt_final(aes_gcm_context_t *ctx, size_t tag_len,
                                const uint32_t *tag, size_t *output_len,
                                uint8_t *output, hardened_bool_t *success) {
   // Get the expected authentication tag.
-  uint32_t expected_tag[tag_len];
+  uint32_t expected_tag[kAesBlockNumWords];
   size_t bytes_written;
   HARDENED_TRY(
       aes_gcm_final(ctx, tag_len, expected_tag, &bytes_written, output));

--- a/sw/device/lib/crypto/impl/aes_kwp/aes_kwp.c
+++ b/sw/device/lib/crypto/impl/aes_kwp/aes_kwp.c
@@ -168,8 +168,8 @@ status_t aes_kwp_unwrap(const aes_key_t kek, const uint32_t *ciphertext,
   // the prefix check. Otherwise it could expose a padding oracle, because
   // memcmp is not constant-time.
   if (pad_len != 0) {
-    uint8_t exp_pad[pad_len];
-    memset(exp_pad, 0, pad_len);
+    uint8_t exp_pad[kSemiblockBytes];
+    memset(exp_pad, 0, kSemiblockBytes);
     unsigned char *pad_start = ((unsigned char *)r) + plaintext_len;
     if (memcmp(pad_start, exp_pad, pad_len) != 0) {
       *success = kHardenedBoolFalse;

--- a/sw/device/lib/crypto/impl/drbg.c
+++ b/sw/device/lib/crypto/impl/drbg.c
@@ -89,8 +89,8 @@ static otcrypto_status_t seed_material_xor(
   // Copy into a word-aligned buffer. This allows us to use a XOR that is more
   // resilient against SCA leakage.
   size_t nwords = ceil_div(value->len, sizeof(uint32_t));
-  uint32_t value_words[nwords];
-  value_words[nwords - 1] = 0;
+  uint32_t value_words[kEntropySeedWords];
+  memset(value_words, 0, sizeof(value_words));
   HARDENED_TRY(randomized_bytecopy(value_words, value->data, value->len));
   // Check whether a FI tampered copying the bytes.
   HARDENED_CHECK_EQ(consttime_memeq_byte(value->data, value_words, value->len),


### PR DESCRIPTION
There are some buffers with user chosen length created in the cryptolib. Remove those and check for lengths.