### PR TITLE
[I2C, DV, RTL] Remove a non-existent assertion from DV / RTL

### DIFF
--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_error_intr_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_error_intr_vseq.sv
@@ -28,7 +28,6 @@ class i2c_host_error_intr_vseq extends i2c_rx_tx_vseq;
 
   virtual task body();
     `uvm_info(`gfn, "\n--> start of i2c_host_error_intr_vseq", UVM_DEBUG)
-    $assertoff(0, "tb.dut.i2c_core.u_i2c_fsm.SclInputGlitch_A");
     initialization();
     for (int i = 1; i <= num_runs; i++) begin
       `uvm_info(`gfn, $sformatf("\n  run simulation %0d/%0d", i, num_runs), UVM_DEBUG)

--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -885,11 +885,6 @@ module i2c_core import i2c_pkg::*;
   // ASSERTIONS //
   ////////////////
 
-  // TODO: Decide whether to keep this assertion. It is primarily checking the
-  // testbench, not the IP, due to the CDC cycle deletion.
-  // Check to make sure scl_i is never a single cycle glitch
-  //  `ASSERT(SclInputGlitch_A, $rose(scl_sync) |-> ##1 scl_sync)
-
   `ASSERT_INIT(FifoDepthValid_A, FifoDepth > 0 && FifoDepthW <= MaxFifoDepthW)
   `ASSERT_INIT(AcqFifoDepthValid_A, AcqFifoDepth > 0 && AcqFifoDepthW <= MaxFifoDepthW)
 


### PR DESCRIPTION
Everything started with a failing `i2c_host_smoke` test in Xcelium as: "Hierarchical name component lookup failed for
`tb.dut.i2c_core.u_i2c_fsm.SclInputGlitch_A`". This was added by PR #16889 in `i2c_host_error_intr_vseq` as part of $assertoff() switching the assertion off for SCL/SDA interference tests ( that's the justification given by the author in #16889). First, problem is that `i2c_fsm` module was renamed to `i2c_target_fsm` in PR #22345 which will break the path in $asseroff() hierarchy cause it to fail. Second, PR #22345 also removes `SclInputGlitch_A` from `i2c_target_fsm` but adds a different version of `SclInputGlitch_A` in `i2c_core`. That version said "the 2 flop synchronized output of scl_i can't be glitchy" along with a comment saying "To decide whether to keep this assertion as it is only required for the TB".

The author of #16889 switching the version of `SclInputGlitch_A` which was checking if the SCL input is glitchy (and not the 2FF synchronized one). I think it is never checked by DV and if the previous version of `SclInputGlitch_A` worked then assuming that the synchronized version could possibly work as well.

I think the best way to define assertion that will support TB / DV should go inside an SVA interface binded with the RTL and shouldn't exist in the RTL itself.

Given that. the solution is to remove the assertion from both RTL and DV.

Full marks to the switch added in PR [28366](https://github.com/lowRISC/opentitan/pull/28366) that spits an errors if the hierarchical paths are broken.