### PR TITLE
[Perso BlobV1 #4] Integrate V1 blob support into firmware

### DIFF
--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -36,9 +36,9 @@ enum {
  * Version of the personalization blob format.
  */
 // clang-format off
-#define ENUM_PERSO_BLOB_VERSION(_, value) \
-    value(_, V0, 0) \
-    value(_, V1, 1)
+#define ENUM_PERSO_BLOB_VERSION(field, value) \
+    value(field, V0, 0) \
+    value(field, V1, 1)
 UJSON_SERDE_ENUM(PersoBlobVersion, perso_blob_version_t, ENUM_PERSO_BLOB_VERSION);
 // clang-format on
 

--- a/sw/device/silicon_creator/lib/cert/dice_chain.c
+++ b/sw/device/silicon_creator/lib/cert/dice_chain.c
@@ -237,7 +237,7 @@ static rom_error_t dice_chain_load_flash(
   RETURN_IF_ERROR(perso_tlv_get_blob_version(
       dice_chain.page.data, sizeof(dice_chain.page.data),
       &dice_chain.blob_version, &offset));
-  dice_chain.tail_offset = offset;
+  dice_chain.tail_offset = util_round_up_to(offset, 3);
 
   return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/cert/dice_chain.c
+++ b/sw/device/silicon_creator/lib/cert/dice_chain.c
@@ -87,6 +87,11 @@ typedef struct dice_chain {
   perso_tlv_cert_obj_t cert_obj;
 
   /**
+   * The version of the perso blob.
+   */
+  perso_blob_version_t blob_version;
+
+  /**
    * Indicate whether the `cert_obj` is valid for the current `subject_pubkey`.
    */
   hardened_bool_t cert_valid;
@@ -159,8 +164,7 @@ static rom_error_t dice_chain_load_cert_obj(const char *name,
                                             size_t name_size) {
   rom_error_t err = perso_tlv_get_cert_obj(
       dice_chain_get_tail_buffer(), dice_chain_get_tail_size(),
-      kPersoBlobVersionV0, &dice_chain.cert_obj);
-
+      dice_chain.blob_version, &dice_chain.cert_obj);
   if (err != kErrorOk) {
     // Cleanup the stale value if error.
     dice_chain_reset_cert_obj();
@@ -228,6 +232,13 @@ static rom_error_t dice_chain_load_flash(
   dice_chain.info_page = info_page;
   dice_chain_reset_cert_obj();
 
+  // Detect the version of the blob stored in flash.
+  size_t offset = 0;
+  RETURN_IF_ERROR(perso_tlv_get_blob_version(
+      dice_chain.page.data, sizeof(dice_chain.page.data),
+      &dice_chain.blob_version, &offset));
+  dice_chain.tail_offset = offset;
+
   return kErrorOk;
 }
 
@@ -259,13 +270,13 @@ static rom_error_t dice_chain_push_cert(const char *name, const uint8_t *cert,
       kDiceCertFormat == kDiceCertFormatX509TcbInfo ? kPersoObjectTypeX509Cert
                                                     : kPersoObjectTypeCwtCert;
   RETURN_IF_ERROR(perso_tlv_cert_obj_build(
-      name, cert_type, cert, cert_size, kPersoBlobVersionV0,
+      name, cert_type, cert, cert_size, dice_chain.blob_version,
       dice_chain_get_tail_buffer(), &cert_page_left));
 
   // Move the offset to the new tail.
   RETURN_IF_ERROR(perso_tlv_get_cert_obj(
       dice_chain_get_tail_buffer(), dice_chain_get_tail_size(),
-      kPersoBlobVersionV0, &dice_chain.cert_obj));
+      dice_chain.blob_version, &dice_chain.cert_obj));
   dice_chain_next_cert_obj();
   return kErrorOk;
 }

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -455,15 +455,13 @@ static void compute_keymgr_owner_binding(void) {
  * If the caller passed a pointer, save there the certificate size.
  */
 static status_t hash_certificate(const flash_ctrl_info_page_t *page,
-                                 size_t offset, size_t *size) {
+                                 size_t offset, perso_blob_version_t version,
+                                 size_t *size) {
   memset(cert_buffer, 0, sizeof(cert_buffer));
 
   // Read first word of the certificate perso LTV object (contains the size).
-  perso_tlv_object_header_t objh;
-  uint16_t obj_size;
   TRY(flash_ctrl_info_read(page, offset, 1, cert_buffer));
-  memcpy(&objh, cert_buffer, sizeof(perso_tlv_object_header_t));
-  PERSO_TLV_GET_FIELD(Objh, Size, objh, &obj_size);
+  uint32_t obj_size = perso_tlv_object_size(cert_buffer, version);
 
   // Validate the perso LTV object size.
   if (obj_size == 0) {
@@ -488,8 +486,7 @@ static status_t hash_certificate(const flash_ctrl_info_page_t *page,
   perso_tlv_cert_obj_t cert_obj;
   TRY(flash_ctrl_info_read(page, offset, util_size_to_words(obj_size),
                            cert_buffer));
-  TRY(perso_tlv_get_cert_obj(cert_buffer, kBufferSize, kPersoBlobVersionV0,
-                             &cert_obj));
+  TRY(perso_tlv_get_cert_obj(cert_buffer, kBufferSize, version, &cert_obj));
   hmac_sha256_update(cert_obj.cert_body_p, cert_obj.cert_body_size);
 
   if (size) {
@@ -505,14 +502,29 @@ static status_t hash_all_certs(void) {
 
   // Push all certificates into the hash.
   for (size_t i = 0; i < ARRAYSIZE(cert_flash_layout); i++) {
-    uint32_t page_offset = 0;
     const cert_flash_info_layout_t curr_layout = cert_flash_layout[i];
     // Skip the page if it is not in use.
     if (!curr_layout.used) {
       continue;
     }
+
+    uint32_t page_offset = 0;
+    perso_blob_version_t page_version = kPersoBlobVersionV0;
+
+    // Read the first 16 bytes of the page to check for version block.
+    alignas(uint32_t) uint8_t head[16];
+    TRY(flash_ctrl_info_read(curr_layout.info_page, 0,
+                             util_size_to_words(sizeof(head)), head));
+
+    size_t version_offset = 0;
+    TRY(perso_tlv_get_blob_version(head, sizeof(head), &page_version,
+                                   &version_offset));
+
+    page_offset = util_round_up_to(version_offset, 3);
+
     for (size_t j = 0; j < curr_layout.num_certs; j++) {
-      TRY(hash_certificate(curr_layout.info_page, page_offset, &cert_obj_size));
+      TRY(hash_certificate(curr_layout.info_page, page_offset, page_version,
+                           &cert_obj_size));
       page_offset += util_size_to_words(cert_obj_size) * sizeof(uint32_t);
       page_offset = util_round_up_to(page_offset, 3);
     }
@@ -543,7 +555,9 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   TRY(ujson_deserialize_manuf_certgen_inputs_t(uj, &certgen_inputs));
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, false));
 
-  switch ((perso_blob_version_t)certgen_inputs.blob_version) {
+  perso_blob_version_t blob_version =
+      (perso_blob_version_t)certgen_inputs.blob_version;
+  switch (blob_version) {
     case kPersoBlobVersionV1:
       TRY(perso_tlv_init_v1_blob(&perso_blob_to_host));
       break;
@@ -614,7 +628,7 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   TRY(perso_tlv_push_cert_to_perso_blob(
       "UDS",
       /*needs_endorsement=*/kDiceCertFormat == kDiceCertFormatX509TcbInfo,
-      kDiceCertFormat, all_certs, curr_cert_size, kPersoBlobVersionV0,
+      kDiceCertFormat, all_certs, curr_cert_size, blob_version,
       &perso_blob_to_host));
 
   // After we have cranked the keymgr to the CreatorRootKey (UDS) stage, we now
@@ -639,7 +653,7 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
   TRY(perso_tlv_push_cert_to_perso_blob(
       "CDI_0", /*needs_endorsement=*/false, kDiceCertFormat, all_certs,
-      curr_cert_size, kPersoBlobVersionV0, &perso_blob_to_host));
+      curr_cert_size, blob_version, &perso_blob_to_host));
 
   // Generate CDI_1 keys and cert.
   curr_cert_size = kCdi1MaxCertSizeBytes;
@@ -657,7 +671,7 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
   TRY(perso_tlv_push_cert_to_perso_blob(
       "CDI_1", /*needs_endorsement=*/false, kDiceCertFormat, all_certs,
-      curr_cert_size, kPersoBlobVersionV0, &perso_blob_to_host));
+      curr_cert_size, blob_version, &perso_blob_to_host));
 
   return OK_STATUS();
 }
@@ -677,22 +691,30 @@ static status_t compute_tbs_was_hmac(perso_blob_t *perso_blob_to_host) {
       &flash_ctrl_state, kFlashInfoFieldWaferAuthSecret, was.key,
       kFlashInfoFieldWaferAuthSecretSizeIn32BitWords));
 
+  // Detect the version of the blob.
+  perso_blob_version_t version = kPersoBlobVersionV0;
+  size_t offset = 0;
+  TRY(perso_tlv_get_blob_version(perso_blob_to_host->body,
+                                 sizeof(perso_blob_to_host->body), &version,
+                                 &offset));
+
   // Compute HMAC of TBS certs with WAS as the key.
   // HSMs and host tooling will compute an HMAC in big endian format, so we do
   // the same to make the comparison easier.
   sc_hmac_hmac_sha256_init(was, /*big_endian_digest=*/true);
-  uint8_t *tlv_buf = perso_blob_to_host->body;
-  uint16_t obj_size;
+  uint8_t *tlv_buf = perso_blob_to_host->body + offset;
+  size_t num_objs = perso_blob_to_host->num_objs;
+  if (offset > 0) {
+    num_objs--;
+  }
+  uint32_t obj_size;
   perso_tlv_object_type_t obj_type;
   perso_tlv_cert_obj_t cert_obj;
-  for (size_t i = 0; i < perso_blob_to_host->num_objs; ++i) {
-    // Parse the TLV object header.
-    perso_tlv_object_header_t obj_header = *(uint16_t *)tlv_buf;
-    PERSO_TLV_GET_FIELD(Objh, Type, obj_header, &obj_type);
-    PERSO_TLV_GET_FIELD(Objh, Size, obj_header, &obj_size);
+  for (size_t i = 0; i < num_objs; ++i) {
+    obj_type = perso_tlv_object_type(tlv_buf, version);
+    obj_size = perso_tlv_object_size(tlv_buf, version);
     if (obj_type == kPersoObjectTypeX509Tbs) {
-      TRY(perso_tlv_get_cert_obj(tlv_buf, obj_size, kPersoBlobVersionV0,
-                                 &cert_obj));
+      TRY(perso_tlv_get_cert_obj(tlv_buf, obj_size, version, &cert_obj));
       hmac_sha256_update(cert_obj.cert_body_p, cert_obj.cert_body_size);
     }
     tlv_buf += obj_size;
@@ -702,9 +724,9 @@ static status_t compute_tbs_was_hmac(perso_blob_t *perso_blob_to_host) {
   hmac_sha256_final(&digest);
 
   // Push hash into perso blob.
-  TRY(perso_tlv_push_object_to_perso_blob(
-      kPersoObjectTypeWasTbsHmac, digest.digest, kHmacDigestNumBytes,
-      kPersoBlobVersionV0, perso_blob_to_host));
+  TRY(perso_tlv_push_object_to_perso_blob(kPersoObjectTypeWasTbsHmac,
+                                          digest.digest, kHmacDigestNumBytes,
+                                          version, perso_blob_to_host));
 
   // Read complete device ID and push into perso blob. The host will need the
   // device ID to reconstruct the WAS.
@@ -712,9 +734,9 @@ static status_t compute_tbs_was_hmac(perso_blob_t *perso_blob_to_host) {
   TRY(otp_ctrl_testutils_dai_read32_array(&otp_ctrl, kDifOtpCtrlPartitionHwCfg0,
                                           kHwCfgDeviceIdOffset, device_id,
                                           ARRAYSIZE(device_id)));
-  TRY(perso_tlv_push_object_to_perso_blob(
-      kPersoObjectTypeDeviceId, device_id, kHwCfgDeviceIdSizeInBytes,
-      kPersoBlobVersionV0, perso_blob_to_host));
+  TRY(perso_tlv_push_object_to_perso_blob(kPersoObjectTypeDeviceId, device_id,
+                                          kHwCfgDeviceIdSizeInBytes, version,
+                                          perso_blob_to_host));
 
   return OK_STATUS();
 }
@@ -825,7 +847,7 @@ static status_t extract_next_cert(uint8_t **dest, size_t *free_room) {
     // Extract the next perso LTV object, aborting if it is not a certificate.
     rom_error_t err = perso_tlv_get_cert_obj(
         perso_blob_from_host.body + perso_blob_from_host.next_free,
-        max_available(), kPersoBlobVersionV0, &block);
+        max_available(), perso_blob_from_host_version, &block);
     switch (err) {
       case kErrorOk:
         break;
@@ -926,6 +948,12 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
     }
   }
 
+  perso_blob_version_t blob_version =
+      (perso_blob_version_t)certgen_inputs.blob_version;
+  if (perso_blob_from_host_version != blob_version) {
+    return INVALID_ARGUMENT();
+  }
+
   /*****************************************************************************
    * Rearrange certificates to prepare for writing to flash.
    *
@@ -936,10 +964,10 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
    * 3. CDI_1 cert
    * 4. Provision Extension certs
    ****************************************************************************/
-  // We start scanning the perso LTV buffer we received from the host from the
-  // beginnging. We assume that the endorsed UDS cert is the first certificate
+  // We start scanning the received perso LTV buffer we received from the host.
+  // We assume that the endorsed UDS cert is the first certificate
   // in the buffer (even if preceeded by other types of perso LTV objects).
-  perso_blob_from_host.next_free = 0;
+  //
   // Location where the next cert perso LTV object will be copied to in the
   // `all_certs` buffer.
   uint8_t *next_cert = all_certs;
@@ -969,7 +997,7 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
     size_t offset = cert_offsets[i];
     TRY(perso_tlv_get_cert_obj(perso_blob_to_host.body + offset,
                                sizeof(perso_blob_to_host.body) - offset,
-                               kPersoBlobVersionV0, &block));
+                               blob_version, &block));
     if (block.obj_size > free_room)
       return RESOURCE_EXHAUSTED();
     memcpy(next_cert, block.obj_p, block.obj_size);
@@ -1000,13 +1028,30 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
 
     memset(&dice_page, 0, sizeof(dice_page));
 
+    if (blob_version == kPersoBlobVersionV1) {
+      // Write version block to start of the page.
+      uint16_t header = 0;
+      PERSO_TLV_SET_FIELD(Objh, Type, header, kPersoObjectTypeBlobVersion);
+      PERSO_TLV_SET_FIELD(Objh, Size, header,
+                          sizeof(perso_tlv_object_header_t) +
+                              sizeof(perso_tlv_blob_version_payload_t));
+      memcpy(dice_page.data + page_offset, &header, sizeof(uint16_t));
+      page_offset += sizeof(uint16_t);
+
+      uint16_t version_val = __builtin_bswap16(kPersoBlobVersionV1);
+      memcpy(dice_page.data + page_offset, &version_val, sizeof(uint16_t));
+      page_offset += sizeof(uint16_t);
+
+      // Pad to 8 bytes alignment.
+      page_offset = util_round_up_to(page_offset, 3);
+    }
+
     // This is a bit brittle, but we expect the sum of {layout}.num_certs values
     // in the following flash layout sections to be equal to the number of
     // endorsed extension certificates received from the host.
     for (size_t j = 0; j < curr_layout.num_certs; j++) {
       // Extract the cert block from the `all_certs` buffer.
-      TRY(perso_tlv_get_cert_obj(next_cert, free_room, kPersoBlobVersionV0,
-                                 &block));
+      TRY(perso_tlv_get_cert_obj(next_cert, free_room, blob_version, &block));
       // Round up the size to the nearest word boundary.
       uint32_t cert_size_words = util_size_to_words(block.obj_size);
       uint32_t cert_size_bytes_ru = cert_size_words * sizeof(uint32_t);

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -490,7 +490,6 @@ static status_t hash_certificate(const flash_ctrl_info_page_t *page,
                            cert_buffer));
   TRY(perso_tlv_get_cert_obj(cert_buffer, kBufferSize, kPersoBlobVersionV0,
                              &cert_obj));
-
   hmac_sha256_update(cert_obj.cert_body_p, cert_obj.cert_body_size);
 
   if (size) {
@@ -543,6 +542,16 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, true));
   TRY(ujson_deserialize_manuf_certgen_inputs_t(uj, &certgen_inputs));
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, false));
+
+  switch ((perso_blob_version_t)certgen_inputs.blob_version) {
+    case kPersoBlobVersionV1:
+      TRY(perso_tlv_init_v1_blob(&perso_blob_to_host));
+      break;
+    case kPersoBlobVersionV0:
+      break;
+    default:
+      return INVALID_ARGUMENT();
+  }
   // We copy over the UDS endorsement key ID to an SHA256 digest type, since
   // this is the format of key IDs generated on-dice.
   memcpy(uds_endorsement_key_id.digest, certgen_inputs.dice_auth_key_key_id,
@@ -801,6 +810,7 @@ static size_t max_available(void) {
  *                  reduces the size of the buffer by the size of the copied
  *                  certificate perso LTV object.
  */
+static perso_blob_version_t perso_blob_from_host_version;
 static status_t extract_next_cert(uint8_t **dest, size_t *free_room) {
   // A just in case sanity check that the next free location in the perso blob
   // data buffer is at the end of the buffer.
@@ -900,6 +910,21 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, true));
   TRY(ujson_deserialize_perso_blob_t(uj, &perso_blob_from_host));
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, false));
+
+  // Detect the version of the blob received from the host.
+  perso_blob_from_host.next_free = 0;
+  perso_blob_from_host_version = kPersoBlobVersionV0;
+  if (perso_blob_from_host.num_objs > 0) {
+    size_t offset = 0;
+    TRY(perso_tlv_get_blob_version(perso_blob_from_host.body,
+                                   sizeof(perso_blob_from_host.body),
+                                   &perso_blob_from_host_version, &offset));
+
+    if (offset > 0) {
+      perso_blob_from_host.next_free = offset;
+      perso_blob_from_host.num_objs--;
+    }
+  }
 
   /*****************************************************************************
    * Rearrange certificates to prepare for writing to flash.

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
@@ -289,6 +289,9 @@ rom_error_t perso_tlv_get_blob_version(const uint8_t *data, size_t size,
 
   perso_tlv_object_header_t header;
   memcpy(&header, data, sizeof(perso_tlv_object_header_t));
+  if (header == 0xFFFF) {
+    return kErrorOk;
+  }
   perso_tlv_object_type_t type;
   uint16_t obj_size;
   PERSO_TLV_GET_FIELD(Objh, Type, header, &type);

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -69,21 +69,51 @@ typedef enum perso_tlv_object_type {
   kPersoObjectTypePersoSha256Hash = 7,
 } perso_tlv_object_type_t;
 
+typedef uint16_t perso_tlv_object_header_v0_t;
+typedef uint16_t perso_tlv_cert_header_v0_t;
+typedef uint32_t perso_tlv_object_header_v1_t;
+typedef uint32_t perso_tlv_cert_header_v1_t;
+
 typedef uint16_t perso_tlv_object_header_t;
 typedef uint16_t perso_tlv_cert_header_t;
 typedef uint16_t perso_tlv_dev_seed_header_t;
 
-typedef enum perso_tlv_obj_header_fields {
+typedef enum perso_tlv_obj_header_fields_v0 {
   // Object size, total size, this header included.
-  kObjhSizeFieldShift = 0,
-  kObjhSizeFieldWidth = 12,
-  kObjhSizeFieldMask = (1 << kObjhSizeFieldWidth) - 1,
+  kObjhSizeFieldShiftV0 = 0,
+  kObjhSizeFieldWidthV0 = 12,
+  kObjhSizeFieldMaskV0 = (1 << kObjhSizeFieldWidthV0) - 1,
 
   // Object type, one of perso_tlv_object_type_t.
-  kObjhTypeFieldShift = kObjhSizeFieldWidth,
-  kObjhTypeFieldWidth =
-      sizeof(perso_tlv_object_header_t) * 8 - kObjhSizeFieldWidth,
-  kObjhTypeFieldMask = (1 << kObjhTypeFieldWidth) - 1,
+  kObjhTypeFieldShiftV0 = kObjhSizeFieldWidthV0,
+  kObjhTypeFieldWidthV0 =
+      sizeof(perso_tlv_object_header_v0_t) * 8 - kObjhSizeFieldWidthV0,
+  kObjhTypeFieldMaskV0 = (1 << kObjhTypeFieldWidthV0) - 1,
+} perso_tlv_obj_header_fields_v0_t;
+
+typedef enum perso_tlv_obj_header_fields_v1 {
+  // Object size, total size, this header included.
+  kObjhV1SizeFieldShift = 0,
+  kObjhV1SizeFieldWidth = 24,
+  kObjhV1SizeFieldMask = (1 << kObjhV1SizeFieldWidth) - 1,
+
+  // Object type, one of perso_tlv_object_type_t.
+  kObjhV1TypeFieldShift = kObjhV1SizeFieldWidth,
+  kObjhV1TypeFieldWidth =
+      sizeof(perso_tlv_object_header_v1_t) * 8 - kObjhV1SizeFieldWidth,
+  kObjhV1TypeFieldMask = (1 << kObjhV1TypeFieldWidth) - 1,
+} perso_tlv_obj_header_fields_v1_t;
+
+typedef enum perso_tlv_obj_header_fields {
+  // Object size, total size, this header included.
+  kObjhSizeFieldShift = kObjhSizeFieldShiftV0,
+  kObjhSizeFieldWidth = kObjhSizeFieldWidthV0,
+  kObjhSizeFieldMask = kObjhSizeFieldMaskV0,
+
+  // Object type, one of perso_tlv_object_type_t.
+  kObjhTypeFieldShift = kObjhTypeFieldShiftV0,
+  kObjhTypeFieldWidth = kObjhTypeFieldWidthV0,
+  kObjhTypeFieldMask = kObjhTypeFieldMaskV0,
 } perso_tlv_obj_header_fields_t;
 
 typedef struct perso_tlv_dev_seed_element {
@@ -112,17 +142,42 @@ typedef struct perso_tlv_dev_seed_set {
  *  | 4 bit length|       12 bits total size       |
  *  +-------------+--------------------------------+
  */
-typedef enum perso_tlv_cert_header_fields {
+typedef enum perso_tlv_cert_header_fields_v0 {
   // Certificate size, total size, this header and name length included.
-  kCrthSizeFieldShift = 0,
-  kCrthSizeFieldWidth = 12,
-  kCrthSizeFieldMask = (1 << kCrthSizeFieldWidth) - 1,
+  kCrthSizeFieldShiftV0 = 0,
+  kCrthSizeFieldWidthV0 = 12,
+  kCrthSizeFieldMaskV0 = (1 << kCrthSizeFieldWidthV0) - 1,
 
   // Length of the certificate name immediately following the header.
-  kCrthNameSizeFieldShift = kCrthSizeFieldWidth,
-  kCrthNameSizeFieldWidth =
-      sizeof(perso_tlv_cert_header_t) * 8 - kCrthSizeFieldWidth,
-  kCrthNameSizeFieldMask = (1 << kCrthNameSizeFieldWidth) - 1,
+  kCrthNameSizeFieldShiftV0 = kCrthSizeFieldWidthV0,
+  kCrthNameSizeFieldWidthV0 =
+      sizeof(perso_tlv_cert_header_v0_t) * 8 - kCrthSizeFieldWidthV0,
+  kCrthNameSizeFieldMaskV0 = (1 << kCrthNameSizeFieldWidthV0) - 1,
+} perso_tlv_cert_header_fields_v0_t;
+
+typedef enum perso_tlv_cert_header_fields_v1 {
+  // Certificate size, total size, this header and name length included.
+  kCrthV1SizeFieldShift = 0,
+  kCrthV1SizeFieldWidth = 24,
+  kCrthV1SizeFieldMask = (1 << kCrthV1SizeFieldWidth) - 1,
+
+  // Length of the certificate name immediately following the header.
+  kCrthV1NameSizeFieldShift = kCrthV1SizeFieldWidth,
+  kCrthV1NameSizeFieldWidth =
+      sizeof(perso_tlv_cert_header_v1_t) * 8 - kCrthV1SizeFieldWidth,
+  kCrthV1NameSizeFieldMask = (1 << kCrthV1NameSizeFieldWidth) - 1,
+} perso_tlv_cert_header_fields_v1_t;
+
+typedef enum perso_tlv_cert_header_fields {
+  // Certificate size, total size, this header and name length included.
+  kCrthSizeFieldShift = kCrthSizeFieldShiftV0,
+  kCrthSizeFieldWidth = kCrthSizeFieldWidthV0,
+  kCrthSizeFieldMask = kCrthSizeFieldMaskV0,
+
+  // Length of the certificate name immediately following the header.
+  kCrthNameSizeFieldShift = kCrthNameSizeFieldShiftV0,
+  kCrthNameSizeFieldWidth = kCrthNameSizeFieldWidthV0,
+  kCrthNameSizeFieldMask = kCrthNameSizeFieldMaskV0,
 } perso_tlv_cert_header_fields_t;
 
 // Helper macros allowing set or get various object and certificate header
@@ -144,6 +199,24 @@ typedef enum perso_tlv_cert_header_fields {
     uint16_t mask = k##type_name##field_name##FieldMask;                    \
     uint16_t shift = k##type_name##field_name##FieldShift;                  \
     *(field_value) = (__builtin_bswap16(full_value) >> shift) & mask;       \
+  }
+
+#define PERSO_TLV_SET_FIELD_V1(type_name, field_name, full_value, field_value) \
+  {                                                                            \
+    uint32_t mask = k##type_name##field_name##FieldMask;                       \
+    uint32_t shift = k##type_name##field_name##FieldShift;                     \
+    uint32_t fieldv = (uint32_t)(field_value)&mask;                            \
+    uint32_t fullv = __builtin_bswap32((uint32_t)(full_value));                \
+    mask = (uint32_t)(mask << shift);                                          \
+    (full_value) = __builtin_bswap32(                                          \
+        (uint32_t)((fullv & ~mask) | (((uint32_t)fieldv) << shift)));          \
+  }
+
+#define PERSO_TLV_GET_FIELD_V1(type_name, field_name, full_value, field_value) \
+  {                                                                            \
+    uint32_t mask = k##type_name##field_name##FieldMask;                       \
+    uint32_t shift = k##type_name##field_name##FieldShift;                     \
+    *(field_value) = (__builtin_bswap32(full_value) >> shift) & mask;          \
   }
 
 /**


### PR DESCRIPTION
Refactors ft_personalize and dice_chain to use the new version-agnostic perso_tlv library. This simplifies the firmware logic while adding support for the V1 blob format.

Chained on https://github.com/lowRISC/opentitan/pull/29792