### PR TITLE
[flash_ctrl,dv] Scopes in flash_ctrl_otf_base_vseq::read_flash

### DIFF
--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -572,21 +572,14 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
   // @arg: wd  : number of 4byte (TL bus unit) : default : 16
   // @arg: overrd : invoke oversize read
   // @arg: in_err : inject fatal error causes flash access disable
-  virtual task read_flash(ref flash_op_t flash_op, input int bank, int num, int wd = 16,
-                  int overrd = 0, bit in_err = 0);
-    data_q_t flash_read_data;
-    flash_otf_item exp_item;
-    bit poll_fifo_status = ~in_err;
+  virtual task read_flash(ref flash_op_t flash_op,
+                          input int      bank,
+                          input int      num,
+                          input int      wd = 16,
+                          input int      overrd = 0,
+                          input bit      in_err = 0);
     bit [flash_ctrl_top_specific_pkg::BusAddrByteW-1:0] start_addr, end_addr;
-    int page;
     bit overflow = 0;
-    uvm_reg_data_t reg_data;
-    bit derr_is_set;
-    bit drop;
-    int size, is_odd, tail;
-    addr_t tmp_addr;
-    flash_mp_region_cfg_t my_region;
-    rd_cache_t rd_entry;
 
     // Exclude secret partition from non scrambled / ecc mode
     if (cfg.ecc_mode == FlashEccDisabled &&
@@ -627,7 +620,18 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
               UVM_MEDIUM)
 
     for (int i = 0; i < num; i++) begin
-      drop = 0;
+      data_q_t              flash_read_data;
+      flash_otf_item        exp_item;
+      bit                   derr_is_set;
+      bit                   drop;
+      int unsigned          page;
+      int unsigned          size;
+      bit                   is_odd;
+      bit                   tail;
+      addr_t                tmp_addr;
+      flash_mp_region_cfg_t my_region;
+      rd_cache_t            rd_entry;
+
       flash_op.addr = flash_op.otf_addr;
       flash_op.addr[TL_AW-1:OTFBankId] = bank;
       rd_entry.bank = bank;
@@ -738,7 +742,9 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
         if (in_err) begin
            cfg.tlul_core_exp_cnt += flash_op.num_words;
         end
-        flash_ctrl_read(flash_op.num_words, flash_read_data, poll_fifo_status);
+        flash_ctrl_read(flash_op.num_words,
+                        flash_read_data,
+                        .poll_fifo_status(!in_err));
 
         if (overrd > 0) begin
           overread(flash_op, bank, num, overrd);
@@ -747,6 +753,8 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       end
 
       if (derr_is_set | cfg.ierr_created[ReadTaskCtrl]) begin
+        uvm_reg_data_t reg_data;
+
         `uvm_info("read_flash", $sformatf(
                   "bank:%0d addr: %x(otf:%x) derr_is_set:%0d ierr_created[ReadTaskCtrl]:%0d",
                   bank, flash_op.addr, flash_op.otf_addr, derr_is_set,
@@ -807,16 +815,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
   // @arg: in_err : inject fatal error causes flash access disable
   virtual task otf_direct_read(bit [OTFHostId-2:0] addr, int bank, int num, bit in_err);
     bit[TL_AW-1:0] tl_addr, st_addr, end_addr;
-    data_4s_t rdata;
-    flash_otf_item exp_item;
-    int page;
-    flash_op_t flash_op;
-    bit completed;
-    bit derr_is_set;
-    bit ierr_is_set;
-    bit derr, drop;
     bit overflow = 0;
-    flash_mp_region_cfg_t my_region;
     rd_cache_t rd_entry;
 
     end_addr = addr + num * 4 - 1;
@@ -841,8 +840,16 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     // Capture for the print in sb.
     st_addr = tl_addr;
     for (int i = 0; i < num ; i++) begin
-      drop = 0;
-      derr = 0;
+      data_4s_t             rdata;
+      flash_otf_item        exp_item;
+      int unsigned          page;
+      flash_op_t            flash_op;
+      bit                   completed;
+      bit                   derr_is_set;
+      bit                   ierr_is_set;
+      bit                   derr, drop;
+      flash_mp_region_cfg_t my_region;
+
       // force address wrap around
       if (cfg.ecc_mode > FlashEccEnabled) tl_addr[18:17] = cfg.tgt_pre[FlashPartData][TgtDr];
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -572,21 +572,14 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
   // @arg: wd  : number of 4byte (TL bus unit) : default : 16
   // @arg: overrd : invoke oversize read
   // @arg: in_err : inject fatal error causes flash access disable
-  virtual task read_flash(ref flash_op_t flash_op, input int bank, int num, int wd = 16,
-                  int overrd = 0, bit in_err = 0);
-    data_q_t flash_read_data;
-    flash_otf_item exp_item;
-    bit poll_fifo_status = ~in_err;
+  virtual task read_flash(ref flash_op_t flash_op,
+                          input int      bank,
+                          input int      num,
+                          input int      wd = 16,
+                          input int      overrd = 0,
+                          input bit      in_err = 0);
     bit [flash_ctrl_top_specific_pkg::BusAddrByteW-1:0] start_addr, end_addr;
-    int page;
     bit overflow = 0;
-    uvm_reg_data_t reg_data;
-    bit derr_is_set;
-    bit drop;
-    int size, is_odd, tail;
-    addr_t tmp_addr;
-    flash_mp_region_cfg_t my_region;
-    rd_cache_t rd_entry;
 
     // Exclude secret partition from non scrambled / ecc mode
     if (cfg.ecc_mode == FlashEccDisabled &&
@@ -627,7 +620,18 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
               UVM_MEDIUM)
 
     for (int i = 0; i < num; i++) begin
-      drop = 0;
+      data_q_t              flash_read_data;
+      flash_otf_item        exp_item;
+      bit                   derr_is_set;
+      bit                   drop;
+      int unsigned          page;
+      int unsigned          size;
+      bit                   is_odd;
+      bit                   tail;
+      addr_t                tmp_addr;
+      flash_mp_region_cfg_t my_region;
+      rd_cache_t            rd_entry;
+
       flash_op.addr = flash_op.otf_addr;
       flash_op.addr[TL_AW-1:OTFBankId] = bank;
       rd_entry.bank = bank;
@@ -738,7 +742,9 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
         if (in_err) begin
            cfg.tlul_core_exp_cnt += flash_op.num_words;
         end
-        flash_ctrl_read(flash_op.num_words, flash_read_data, poll_fifo_status);
+        flash_ctrl_read(flash_op.num_words,
+                        flash_read_data,
+                        .poll_fifo_status(!in_err));
 
         if (overrd > 0) begin
           overread(flash_op, bank, num, overrd);
@@ -747,6 +753,8 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       end
 
       if (derr_is_set | cfg.ierr_created[ReadTaskCtrl]) begin
+        uvm_reg_data_t reg_data;
+
         `uvm_info("read_flash", $sformatf(
                   "bank:%0d addr: %x(otf:%x) derr_is_set:%0d ierr_created[ReadTaskCtrl]:%0d",
                   bank, flash_op.addr, flash_op.otf_addr, derr_is_set,
@@ -807,16 +815,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
   // @arg: in_err : inject fatal error causes flash access disable
   virtual task otf_direct_read(bit [OTFHostId-2:0] addr, int bank, int num, bit in_err);
     bit[TL_AW-1:0] tl_addr, st_addr, end_addr;
-    data_4s_t rdata;
-    flash_otf_item exp_item;
-    int page;
-    flash_op_t flash_op;
-    bit completed;
-    bit derr_is_set;
-    bit ierr_is_set;
-    bit derr, drop;
     bit overflow = 0;
-    flash_mp_region_cfg_t my_region;
     rd_cache_t rd_entry;
 
     end_addr = addr + num * 4 - 1;
@@ -841,8 +840,16 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     // Capture for the print in sb.
     st_addr = tl_addr;
     for (int i = 0; i < num ; i++) begin
-      drop = 0;
-      derr = 0;
+      data_4s_t             rdata;
+      flash_otf_item        exp_item;
+      int unsigned          page;
+      flash_op_t            flash_op;
+      bit                   completed;
+      bit                   derr_is_set;
+      bit                   ierr_is_set;
+      bit                   derr, drop;
+      flash_mp_region_cfg_t my_region;
+
       // force address wrap around
       if (cfg.ecc_mode > FlashEccEnabled) tl_addr[18:17] = cfg.tgt_pre[FlashPartData][TgtDr];
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -572,21 +572,14 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
   // @arg: wd  : number of 4byte (TL bus unit) : default : 16
   // @arg: overrd : invoke oversize read
   // @arg: in_err : inject fatal error causes flash access disable
-  virtual task read_flash(ref flash_op_t flash_op, input int bank, int num, int wd = 16,
-                  int overrd = 0, bit in_err = 0);
-    data_q_t flash_read_data;
-    flash_otf_item exp_item;
-    bit poll_fifo_status = ~in_err;
+  virtual task read_flash(ref flash_op_t flash_op,
+                          input int      bank,
+                          input int      num,
+                          input int      wd = 16,
+                          input int      overrd = 0,
+                          input bit      in_err = 0);
     bit [flash_ctrl_top_specific_pkg::BusAddrByteW-1:0] start_addr, end_addr;
-    int page;
     bit overflow = 0;
-    uvm_reg_data_t reg_data;
-    bit derr_is_set;
-    bit drop;
-    int size, is_odd, tail;
-    addr_t tmp_addr;
-    flash_mp_region_cfg_t my_region;
-    rd_cache_t rd_entry;
 
     // Exclude secret partition from non scrambled / ecc mode
     if (cfg.ecc_mode == FlashEccDisabled &&
@@ -627,7 +620,18 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
               UVM_MEDIUM)
 
     for (int i = 0; i < num; i++) begin
-      drop = 0;
+      data_q_t              flash_read_data;
+      flash_otf_item        exp_item;
+      bit                   derr_is_set;
+      bit                   drop;
+      int unsigned          page;
+      int unsigned          size;
+      bit                   is_odd;
+      bit                   tail;
+      addr_t                tmp_addr;
+      flash_mp_region_cfg_t my_region;
+      rd_cache_t            rd_entry;
+
       flash_op.addr = flash_op.otf_addr;
       flash_op.addr[TL_AW-1:OTFBankId] = bank;
       rd_entry.bank = bank;
@@ -738,7 +742,9 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
         if (in_err) begin
            cfg.tlul_core_exp_cnt += flash_op.num_words;
         end
-        flash_ctrl_read(flash_op.num_words, flash_read_data, poll_fifo_status);
+        flash_ctrl_read(flash_op.num_words,
+                        flash_read_data,
+                        .poll_fifo_status(!in_err));
 
         if (overrd > 0) begin
           overread(flash_op, bank, num, overrd);
@@ -747,6 +753,8 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       end
 
       if (derr_is_set | cfg.ierr_created[ReadTaskCtrl]) begin
+        uvm_reg_data_t reg_data;
+
         `uvm_info("read_flash", $sformatf(
                   "bank:%0d addr: %x(otf:%x) derr_is_set:%0d ierr_created[ReadTaskCtrl]:%0d",
                   bank, flash_op.addr, flash_op.otf_addr, derr_is_set,
@@ -807,16 +815,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
   // @arg: in_err : inject fatal error causes flash access disable
   virtual task otf_direct_read(bit [OTFHostId-2:0] addr, int bank, int num, bit in_err);
     bit[TL_AW-1:0] tl_addr, st_addr, end_addr;
-    data_4s_t rdata;
-    flash_otf_item exp_item;
-    int page;
-    flash_op_t flash_op;
-    bit completed;
-    bit derr_is_set;
-    bit ierr_is_set;
-    bit derr, drop;
     bit overflow = 0;
-    flash_mp_region_cfg_t my_region;
     rd_cache_t rd_entry;
 
     end_addr = addr + num * 4 - 1;
@@ -841,8 +840,16 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     // Capture for the print in sb.
     st_addr = tl_addr;
     for (int i = 0; i < num ; i++) begin
-      drop = 0;
-      derr = 0;
+      data_4s_t             rdata;
+      flash_otf_item        exp_item;
+      int unsigned          page;
+      flash_op_t            flash_op;
+      bit                   completed;
+      bit                   derr_is_set;
+      bit                   ierr_is_set;
+      bit                   derr, drop;
+      flash_mp_region_cfg_t my_region;
+
       // force address wrap around
       if (cfg.ecc_mode > FlashEccEnabled) tl_addr[18:17] = cfg.tgt_pre[FlashPartData][TgtDr];
 


### PR DESCRIPTION
These changes were prompted by a bug fix that @gautschimi made when reviewing PR #28581. He noticed that one has to clear the derr_is_set flag on each iteration of the relevant loop.

The bug was in read_flash, but otf_direct_read has some very similar code with the same bug, so I've fixed it there too.

When looking at the change, I realised that lots of similar variables were actually local to one iteration of the loop body. This PR moves them to live more locally.

While moving the variables, I also tightened up the types slightly: all the integers are unsigned or are single bits.