### PR TITLE
[rv_timer, dv] Add FPV assertions for timer_core and prim_intr_hw

### DIFF
--- a/hw/ip/rv_timer/fpv/vip/rv_timer_core_assert_fpv.sv
+++ b/hw/ip/rv_timer/fpv/vip/rv_timer_core_assert_fpv.sv
@@ -23,6 +23,72 @@ module rv_timer_core_assert_fpv # (
   input logic [N-1:0] intr
 );
 
-  // TODO: populate me with FPV
+  // Default statements:
+  default disable iff (!rst_ni || !active);
+  default clocking @(posedge clk_i); endclocking
 
+  // Glue logic for the prescaler counter:
+  logic [11:0] prescaler_count;
+  logic        limit_reached;
+  always_ff @(posedge clk_i or negedge rst_ni) begin: prescaler_counter
+    if (!rst_ni || !active || prescaler_count == prescaler)
+      prescaler_count <= 0;
+    else
+      prescaler_count <= prescaler_count + 1'b1;
+  end
+  assign limit_reached = prescaler_count == prescaler;
+  // Don't allow prescaler/step/mtimecmp to change on the fly while active is set
+  ActiveImpliesConfigStable_A : assume property ($stable({prescaler, step}) && $stable(mtimecmp));
+
+  // Verify tick_count counter timer increases
+  TickCountIncreases_A : assert property (prescaler_count < prescaler |=>
+                                          prescaler_count == $past(prescaler_count) + 1);
+
+  // Tick set means prescaler equals the count.
+  // TickSet_A checks that if the RTL has tick set, then our internal logic must be equal to the
+  // prescaler max and vice-versa
+  TickSet_A: assert property (limit_reached iff tick);
+  // Helper property to help tool converge in above property more quickly by checking the internal
+  // count is equal to RTL count
+  TickSetHelper_A:
+    assert property (disable iff (!rst_ni) prescaler_count == gen_harts[0].u_core.tick_count);
+  // Note: Jasper doesn't autogenerate a cover property when using `iff` operator
+  TickSet_C: cover property (tick);
+
+  // Tick count reset:
+  TickCountActiveReset_A: assert property ($rose(active) |-> prescaler_count == 0);
+  // If we were active before, and the count equals the prescaler then the count should be
+  // reset to zero
+  property PrescalerMaxReset_p;
+    (prescaler_count == prescaler) |=> prescaler_count == 0;
+  endproperty
+  TickCountPrescalerMaxReset_A: assert property (PrescalerMaxReset_p);
+
+  // Free variable to avoid having to declare a generate block and hence proving faster
+  int unsigned fpv_timer_idx;
+  // Free variable constraints:
+  // - Lower than N
+  // - Can't change every time active is set
+  FreeIndexVariableMaxValue_A: assume property (fpv_timer_idx < N);
+  FreeIndexVariableStable_A: assume property ($stable(fpv_timer_idx));
+
+  // Force Mtime to be $past(mtime) + step when inrementing
+  MtimeChangesInStepIncrements_A:
+    assume property ($changed(mtime) |-> $past(tick) && ($past(mtime) + $past(step)) == mtime);
+
+  // Checks whether an interrupt raises during active being set. This means that the internal
+  // prescaler has saturated and mtime has increased causing it to be greater than or equal
+  // to mtimecmp
+  property InterruptRaiseWhilstActive_p;
+    $past(active) && $rose(intr[fpv_timer_idx]) |->
+      $past(tick) && ($past(mtime) + $past(step)) >= mtimecmp[fpv_timer_idx];
+  endproperty
+  InterruptRaiseWhilstActive_A: assert property (InterruptRaiseWhilstActive_p);
+
+  // Checks whether mtime is greater than or equal to mtimecmp as soon as active and interrupt
+  // raise
+  property InterruptRaiseAndActiveRaise_p;
+    $rose(active) && $rose(intr[fpv_timer_idx]) |-> mtime >= mtimecmp[fpv_timer_idx];
+  endproperty
+  InterruptRaiseAndActiveRaise_A: assert property (InterruptRaiseAndActiveRaise_p);
 endmodule

--- a/hw/ip/rv_timer/fpv/vip/rv_timer_core_assert_fpv.sv
+++ b/hw/ip/rv_timer/fpv/vip/rv_timer_core_assert_fpv.sv
@@ -44,6 +44,9 @@ module rv_timer_core_assert_fpv # (
   TickCountIncreases_A : assert property (prescaler_count < prescaler |=>
                                           prescaler_count == $past(prescaler_count) + 1);
 
+  // Tick should not assert when inactive
+  TickLowWhenInactive_A : assert property (disable iff (!rst_ni) !active |-> !tick);
+
   // Tick set means prescaler equals the count.
   // TickSet_A checks that if the RTL has tick set, then our internal logic must be equal to the
   // prescaler max and vice-versa
@@ -91,4 +94,11 @@ module rv_timer_core_assert_fpv # (
     $rose(active) && $rose(intr[fpv_timer_idx]) |-> mtime >= mtimecmp[fpv_timer_idx];
   endproperty
   InterruptRaiseAndActiveRaise_A: assert property (InterruptRaiseAndActiveRaise_p);
+
+  // Check interrupt is low when inactive or interrupt condition is not met
+  property InterruptLowWhenNotExpired_p;
+    !active || mtime < mtimecmp[fpv_timer_idx] |-> intr[fpv_timer_idx] == '0;
+  endproperty
+  InterruptLowWhenNotExpired_A: assert property (InterruptLowWhenNotExpired_p);
+  
 endmodule

--- a/hw/ip/rv_timer/fpv/vip/rv_timer_core_assert_fpv.sv
+++ b/hw/ip/rv_timer/fpv/vip/rv_timer_core_assert_fpv.sv
@@ -67,6 +67,9 @@ module rv_timer_core_assert_fpv # (
   endproperty
   TickCountPrescalerMaxReset_A: assert property (PrescalerMaxReset_p);
 
+  // Make sure prescaler_count never exceeds prescaler
+  PrescalerCountBounded_A: assert property (prescaler_count <= prescaler);
+
   // Free variable to avoid having to declare a generate block and hence proving faster
   int unsigned fpv_timer_idx;
   // Free variable constraints:
@@ -101,7 +104,14 @@ module rv_timer_core_assert_fpv # (
     !active || mtime < mtimecmp[fpv_timer_idx] |-> intr[fpv_timer_idx] == '0; 
   endproperty
   InterruptLowWhenNotExpired_A: assert property (InterruptLowWhenNotExpired_p);
-  
+
+  // Check interrupt is raised when active and mtime >= mtimecmp for selected index 
+  property InterruptHighWhenExpired_p;
+    disable iff (!rst_ni)
+    active && mtime >= mtimecmp[fpv_timer_idx] |-> intr[fpv_timer_idx];
+  endproperty
+  InterruptHighWhenExpired_A: assert property (InterruptHighWhenExpired_p);
+
   // Check mtime_d is always mtime + step, regardless of reset or active
   MtimeDAlwaysMtimePlusStep_A: assert property (disable iff ('0)  mtime_d == mtime + 64'(step));
 

--- a/hw/ip/rv_timer/fpv/vip/rv_timer_core_assert_fpv.sv
+++ b/hw/ip/rv_timer/fpv/vip/rv_timer_core_assert_fpv.sv
@@ -97,8 +97,12 @@ module rv_timer_core_assert_fpv # (
 
   // Check interrupt is low when inactive or interrupt condition is not met
   property InterruptLowWhenNotExpired_p;
-    !active || mtime < mtimecmp[fpv_timer_idx] |-> intr[fpv_timer_idx] == '0;
+    disable iff (!rst_ni) 
+    !active || mtime < mtimecmp[fpv_timer_idx] |-> intr[fpv_timer_idx] == '0; 
   endproperty
   InterruptLowWhenNotExpired_A: assert property (InterruptLowWhenNotExpired_p);
   
+  // Check mtime_d is always mtime + step, regardless of reset or active
+  MtimeDAlwaysMtimePlusStep_A: assert property (disable iff ('0)  mtime_d == mtime + 64'(step));
+
 endmodule

--- a/hw/ip/rv_timer/fpv/vip/rv_timer_interrupts_assert_fpv.sv
+++ b/hw/ip/rv_timer/fpv/vip/rv_timer_interrupts_assert_fpv.sv
@@ -20,14 +20,46 @@ module rv_timer_interrupts_assert_fpv # (
   input  [Width-1:0]  reg2hw_intr_test_q_i,
   input               reg2hw_intr_test_qe_i,
   input  [Width-1:0]  reg2hw_intr_state_q_i,
-  output              hw2reg_intr_state_de_o,
-  output [Width-1:0]  hw2reg_intr_state_d_o,
+  input               hw2reg_intr_state_de_o,
+  input  [Width-1:0]  hw2reg_intr_state_d_o,
 
   // outgoing interrupt
-  output logic [Width-1:0]  intr_o
+  input logic [Width-1:0]  intr_o
 );
+  // internal signals from inputs to mirror DUT signals
+  logic [Width-1:0] new_event;
+  assign new_event = (({Width{reg2hw_intr_test_qe_i}} & reg2hw_intr_test_q_i) | event_intr_i);
 
+  logic [Width-1:0] test_q;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) test_q <= '0;
+    else if (reg2hw_intr_test_qe_i) test_q <= reg2hw_intr_test_q_i;
+  end
 
-  // TODO: populate me with FPV
+  logic [Width-1:0] status;
+  assign status = (IntrT == "Event") ? reg2hw_intr_state_q_i : (event_intr_i | test_q);
+
+  // When state is event, make sure hw2reg_intr_state_de_o is only active when |new_event is high
+  `ASSERT(IntrStateWriteEnableOnEvent_A, IntrT == "Event" |-> 
+  (hw2reg_intr_state_de_o iff |new_event ))
+
+  // Checks hw2reg_intr_state_d_o equals new_event OR'd with current interrupt state in Event mode
+  `ASSERT(IntrStateOrUpdateOnEvent_A, IntrT == "Event" |-> 
+  (hw2reg_intr_state_d_o == (new_event | reg2hw_intr_state_q_i)))
+
+  // Check that in Status mode, hw2reg_intr_state_de_o is always driven high
+  `ASSERT(IntrStateDeAlwaysOnStatus_A, IntrT == "Status" |-> hw2reg_intr_state_de_o)
+  
+  // Check hw2reg_intr_state_d_o reflects event | test_q in Status mode
+  `ASSERT(IntrStateDataNewEventOrTestQ_A, IntrT == "Status" |-> 
+  (hw2reg_intr_state_d_o == (event_intr_i | test_q)))
+
+  // When FlopOutput == 1, intr_o is flopped status & reg2hw_intr_enable_q_i 
+  `ASSERT(IntrOutgoingFlopped_A, FlopOutput == 1 |->
+  (intr_o == $past(status & reg2hw_intr_enable_q_i)))
+
+  // When FlopOutput == 0, intr_o is combinational reg2hw_intr_state_q_i & reg2hw_intr_enable_q_i 
+  `ASSERT(IntrOutgoingNotFlopped_A, FlopOutput == 0 |->
+  (intr_o == (reg2hw_intr_state_q_i & reg2hw_intr_enable_q_i)))
 
 endmodule


### PR DESCRIPTION

Extends PR #27334 with FPV assertions for rv_timer_core and prim_intr_hw.

Fixes issue #29381