### PR TITLE
[crypto] Consequently check for null pointer before dereferencing

### DIFF
--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -303,8 +303,10 @@ static otcrypto_status_t otcrypto_aes_impl(
     const otcrypto_const_byte_buf_t *cipher_input,
     otcrypto_aes_padding_t aes_padding, otcrypto_byte_buf_t *cipher_output) {
   // Check for NULL pointers in input pointers and data buffers.
-  if (key == NULL || (aes_mode != kOtcryptoAesModeEcb && iv->data == NULL) ||
-      cipher_input->data == NULL || cipher_output->data == NULL) {
+  if (key == NULL ||
+      (aes_mode != kOtcryptoAesModeEcb && (iv == NULL || iv->data == NULL)) ||
+      cipher_input == NULL || cipher_input->data == NULL ||
+      cipher_output == NULL || cipher_output->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 

--- a/sw/device/lib/crypto/impl/aes_gcm.c
+++ b/sw/device/lib/crypto/impl/aes_gcm.c
@@ -286,7 +286,8 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt(
     otcrypto_word32_buf_t *auth_tag) {
   // Check for NULL pointers in input pointers and required-nonzero-length data
   // buffers.
-  if (key == NULL || iv->data == NULL || auth_tag->data == NULL) {
+  if (key == NULL || iv == NULL || iv->data == NULL || auth_tag == NULL ||
+      auth_tag->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -295,7 +296,8 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt(
 
   // Conditionally check for null pointers in data buffers that may be
   // 0-length.
-  if ((aad->len != 0 && aad->data == NULL) ||
+  if (aad == NULL || ciphertext == NULL || plaintext == NULL ||
+      (aad->len != 0 && aad->data == NULL) ||
       (ciphertext->len != 0 && ciphertext->data == NULL) ||
       (plaintext->len != 0 && plaintext->data == NULL)) {
     return OTCRYPTO_BAD_ARGS;
@@ -341,13 +343,15 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt(
     hardened_bool_t *success) {
   // Check for NULL pointers in input pointers and required-nonzero-length data
   // buffers.
-  if (key == NULL || iv->data == NULL || auth_tag->data == NULL) {
+  if (key == NULL || iv == NULL || iv->data == NULL || auth_tag == NULL ||
+      auth_tag->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 
   // Conditionally check for null pointers in data buffers that may be
   // 0-length.
-  if ((aad->len != 0 && aad->data == NULL) ||
+  if (aad == NULL || ciphertext == NULL || plaintext == NULL ||
+      (aad->len != 0 && aad->data == NULL) ||
       (ciphertext->len != 0 && ciphertext->data == NULL) ||
       (plaintext->len != 0 && plaintext->data == NULL)) {
     return OTCRYPTO_BAD_ARGS;
@@ -388,7 +392,8 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt(
 otcrypto_status_t otcrypto_aes_gcm_encrypt_init(
     otcrypto_blinded_key_t *key, const otcrypto_const_word32_buf_t *iv,
     otcrypto_aes_gcm_context_t *ctx) {
-  if (key == NULL || key->keyblob == NULL || iv->data == NULL || ctx == NULL) {
+  if (key == NULL || key->keyblob == NULL || iv == NULL || iv->data == NULL ||
+      ctx == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -415,7 +420,8 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_init(
 otcrypto_status_t otcrypto_aes_gcm_decrypt_init(
     otcrypto_blinded_key_t *key, const otcrypto_const_word32_buf_t *iv,
     otcrypto_aes_gcm_context_t *ctx) {
-  if (key == NULL || key->keyblob == NULL || iv->data == NULL || ctx == NULL) {
+  if (key == NULL || key->keyblob == NULL || iv == NULL || iv->data == NULL ||
+      ctx == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -441,7 +447,7 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt_init(
 
 otcrypto_status_t otcrypto_aes_gcm_update_aad(
     otcrypto_aes_gcm_context_t *ctx, const otcrypto_const_byte_buf_t *aad) {
-  if (ctx == NULL || aad->data == NULL) {
+  if (ctx == NULL || aad == NULL || aad->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -471,8 +477,8 @@ otcrypto_status_t otcrypto_aes_gcm_update_aad(
 otcrypto_status_t otcrypto_aes_gcm_update_encrypted_data(
     otcrypto_aes_gcm_context_t *ctx, const otcrypto_const_byte_buf_t *input,
     otcrypto_byte_buf_t *output, size_t *output_bytes_written) {
-  if (ctx == NULL || input->data == NULL || output->data == NULL ||
-      output_bytes_written == NULL) {
+  if (ctx == NULL || input == NULL || input->data == NULL || output == NULL ||
+      output->data == NULL || output_bytes_written == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
   *output_bytes_written = 0;
@@ -522,11 +528,12 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_final(
     otcrypto_aes_gcm_context_t *ctx, otcrypto_aes_gcm_tag_len_t tag_len,
     otcrypto_byte_buf_t *ciphertext, size_t *ciphertext_bytes_written,
     otcrypto_word32_buf_t *auth_tag) {
-  if (ctx == NULL || ciphertext_bytes_written == NULL ||
+  if (ctx == NULL || ciphertext_bytes_written == NULL || auth_tag == NULL ||
       auth_tag->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
-  if (ciphertext->len != 0 && ciphertext->data == NULL) {
+  if (ciphertext == NULL ||
+      (ciphertext->len != 0 && ciphertext->data == NULL)) {
     return OTCRYPTO_BAD_ARGS;
   }
   *ciphertext_bytes_written = 0;
@@ -572,11 +579,11 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt_final(
     const otcrypto_const_word32_buf_t *auth_tag,
     otcrypto_aes_gcm_tag_len_t tag_len, otcrypto_byte_buf_t *plaintext,
     size_t *plaintext_bytes_written, hardened_bool_t *success) {
-  if (ctx == NULL || plaintext_bytes_written == NULL ||
+  if (ctx == NULL || plaintext_bytes_written == NULL || auth_tag == NULL ||
       auth_tag->data == NULL || success == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
-  if (plaintext->len != 0 && plaintext->data == NULL) {
+  if (plaintext == NULL || (plaintext->len != 0 && plaintext->data == NULL)) {
     return OTCRYPTO_BAD_ARGS;
   }
   *plaintext_bytes_written = 0;

--- a/sw/device/lib/crypto/impl/hkdf.c
+++ b/sw/device/lib/crypto/impl/hkdf.c
@@ -129,10 +129,11 @@ otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t *ikm,
                                         const otcrypto_const_byte_buf_t *salt,
                                         otcrypto_blinded_key_t *prk) {
   // Check for null pointers.
-  if (ikm->keyblob == NULL || prk == NULL || prk->keyblob == NULL) {
+  if (ikm == NULL || ikm->keyblob == NULL || prk == NULL ||
+      prk->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
-  if (salt->data == NULL && salt->len != 0) {
+  if (salt == NULL || (salt->data == NULL && salt->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -228,10 +229,11 @@ otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t *ikm,
 otcrypto_status_t otcrypto_hkdf_expand(const otcrypto_blinded_key_t *prk,
                                        const otcrypto_const_byte_buf_t *info,
                                        otcrypto_blinded_key_t *okm) {
-  if (okm == NULL || okm->keyblob == NULL || prk->keyblob == NULL) {
+  if (okm == NULL || okm->keyblob == NULL || prk == NULL ||
+      prk->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
-  if (info->data == NULL && info->len != 0) {
+  if (info == NULL || (info->data == NULL && info->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
 

--- a/sw/device/lib/crypto/impl/hmac.c
+++ b/sw/device/lib/crypto/impl/hmac.c
@@ -216,7 +216,7 @@ otcrypto_status_t otcrypto_hmac(const otcrypto_blinded_key_t *key,
                                 const otcrypto_const_byte_buf_t *input_message,
                                 otcrypto_word32_buf_t *tag) {
   // Check for null pointers.
-  if (tag->data == NULL ||
+  if (tag == NULL || tag->data == NULL || input_message == NULL ||
       (input_message->data == NULL && input_message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -456,7 +456,7 @@ otcrypto_status_t otcrypto_hmac_init(otcrypto_hmac_context_t *ctx,
 otcrypto_status_t otcrypto_hmac_update(
     otcrypto_hmac_context_t *const ctx,
     const otcrypto_const_byte_buf_t *input_message) {
-  if (ctx == NULL) {
+  if (ctx == NULL || input_message == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -479,7 +479,7 @@ otcrypto_status_t otcrypto_hmac_update(
 
 otcrypto_status_t otcrypto_hmac_final(otcrypto_hmac_context_t *const ctx,
                                       otcrypto_word32_buf_t *tag) {
-  if (ctx == NULL || tag->data == NULL) {
+  if (ctx == NULL || tag == NULL || tag->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 

--- a/sw/device/lib/crypto/impl/kdf_ctr.c
+++ b/sw/device/lib/crypto/impl/kdf_ctr.c
@@ -72,7 +72,7 @@ otcrypto_status_t otcrypto_kdf_ctr_hmac(
     otcrypto_blinded_key_t *output_key_material) {
   // Check NULL pointers.
   if (output_key_material == NULL || output_key_material->keyblob == NULL ||
-      key_derivation_key->keyblob == NULL) {
+      key_derivation_key == NULL || key_derivation_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -85,12 +85,12 @@ otcrypto_status_t otcrypto_kdf_ctr_hmac(
   }
 
   // Check for null label with nonzero length.
-  if (label->data == NULL && label->len != 0) {
+  if (label == NULL || (label->data == NULL && label->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
 
   // Check for null context with nonzero length.
-  if (context->data == NULL && context->len != 0) {
+  if (context == NULL || (context->data == NULL && context->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
 

--- a/sw/device/lib/crypto/impl/sha2.c
+++ b/sw/device/lib/crypto/impl/sha2.c
@@ -22,11 +22,11 @@ static_assert(
 
 otcrypto_status_t otcrypto_sha2_256(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest) {
-  if (message->data == NULL && message->len != 0) {
+  if (message == NULL || (message->data == NULL && message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
 
-  if (digest->data == NULL ||
+  if (digest == NULL || digest->data == NULL ||
       launder32(digest->len) != kHmacSha256DigestWords) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -38,11 +38,11 @@ otcrypto_status_t otcrypto_sha2_256(const otcrypto_const_byte_buf_t *message,
 
 otcrypto_status_t otcrypto_sha2_384(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest) {
-  if (message->data == NULL && message->len != 0) {
+  if (message == NULL || (message->data == NULL && message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
 
-  if (digest->data == NULL ||
+  if (digest == NULL || digest->data == NULL ||
       launder32(digest->len) != kHmacSha384DigestWords) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -54,11 +54,11 @@ otcrypto_status_t otcrypto_sha2_384(const otcrypto_const_byte_buf_t *message,
 
 otcrypto_status_t otcrypto_sha2_512(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest) {
-  if (message->data == NULL && message->len != 0) {
+  if (message == NULL || (message->data == NULL && message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
 
-  if (digest->data == NULL ||
+  if (digest == NULL || digest->data == NULL ||
       launder32(digest->len) != kHmacSha512DigestWords) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -130,12 +130,16 @@ static status_t check_lengths(hmac_ctx_t *hmac_ctx) {
 
 otcrypto_status_t otcrypto_sha2_update(
     otcrypto_sha2_context_t *ctx, const otcrypto_const_byte_buf_t *message) {
+  if (ctx == NULL || message == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
   // Return early if the update size is 0.
   if (message->len == 0) {
     return otcrypto_eval_exit(OTCRYPTO_OK);
   }
 
-  if (ctx == NULL || message->data == NULL) {
+  if (message->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -146,7 +150,7 @@ otcrypto_status_t otcrypto_sha2_update(
 
 otcrypto_status_t otcrypto_sha2_final(otcrypto_sha2_context_t *ctx,
                                       otcrypto_hash_digest_t *digest) {
-  if (ctx == NULL || digest->data == NULL) {
+  if (ctx == NULL || digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 

--- a/sw/device/lib/crypto/impl/sha3.c
+++ b/sw/device/lib/crypto/impl/sha3.c
@@ -19,7 +19,7 @@ otcrypto_status_t otcrypto_sha3_224(const otcrypto_const_byte_buf_t *message,
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
-  if (message->data == NULL && message->len != 0) {
+  if (message == NULL || (message->data == NULL && message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
   if (launder32(digest->len) != kKmacSha3224DigestWords) {
@@ -35,7 +35,7 @@ otcrypto_status_t otcrypto_sha3_256(const otcrypto_const_byte_buf_t *message,
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
-  if (message->data == NULL && message->len != 0) {
+  if (message == NULL || (message->data == NULL && message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
   if (launder32(digest->len) != kKmacSha3256DigestWords) {
@@ -51,7 +51,7 @@ otcrypto_status_t otcrypto_sha3_384(const otcrypto_const_byte_buf_t *message,
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
-  if (message->data == NULL && message->len != 0) {
+  if (message == NULL || (message->data == NULL && message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
   if (launder32(digest->len) != kKmacSha3384DigestWords) {
@@ -67,7 +67,7 @@ otcrypto_status_t otcrypto_sha3_512(const otcrypto_const_byte_buf_t *message,
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
-  if (message->data == NULL && message->len != 0) {
+  if (message == NULL || (message->data == NULL && message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
   if (launder32(digest->len) != kKmacSha3512DigestWords) {
@@ -83,7 +83,7 @@ otcrypto_status_t otcrypto_shake128(const otcrypto_const_byte_buf_t *message,
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
-  if (message->data == NULL && message->len != 0) {
+  if (message == NULL || (message->data == NULL && message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
   digest->mode = kOtcryptoHashXofModeShake128;
@@ -95,7 +95,7 @@ otcrypto_status_t otcrypto_shake256(const otcrypto_const_byte_buf_t *message,
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
-  if (message->data == NULL && message->len != 0) {
+  if (message == NULL || (message->data == NULL && message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
   digest->mode = kOtcryptoHashXofModeShake256;
@@ -110,13 +110,15 @@ otcrypto_status_t otcrypto_cshake128(
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
-  if (message->data == NULL && message->len != 0) {
+  if (message == NULL || (message->data == NULL && message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
-  if (function_name_string->data == NULL && function_name_string->len != 0) {
+  if (function_name_string == NULL ||
+      (function_name_string->data == NULL && function_name_string->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
-  if (customization_string->data == NULL && customization_string->len != 0) {
+  if (customization_string == NULL ||
+      (customization_string->data == NULL && customization_string->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
   digest->mode = kOtcryptoHashXofModeCshake128;
@@ -134,13 +136,15 @@ otcrypto_status_t otcrypto_cshake256(
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
-  if (message->data == NULL && message->len != 0) {
+  if (message == NULL || (message->data == NULL && message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
-  if (function_name_string->data == NULL && function_name_string->len != 0) {
+  if (function_name_string == NULL ||
+      (function_name_string->data == NULL && function_name_string->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
-  if (customization_string->data == NULL && customization_string->len != 0) {
+  if (customization_string == NULL ||
+      (customization_string->data == NULL && customization_string->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
   digest->mode = kOtcryptoHashXofModeCshake256;


### PR DESCRIPTION
We already check some pointers for NULL before dereferencing them. This commit applies the same technique to the remaining ones where we did not do this consequently.