### PR TITLE
[test,sw] Unified test label based on hardware availability

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -280,6 +280,10 @@ nonhermetic_repo = use_repo_rule("//rules:nonhermetic.bzl", "nonhermetic_repo")
 
 nonhermetic_repo(name = "nonhermetic")
 
+devices_repo = use_repo_rule("//rules:devices.bzl", "devices_repo")
+
+devices_repo(name = "devices")
+
 # Source repositories (not Bazel-aware):
 github_tools = use_extension("//third_party/github:extensions.bzl", "github_tools")
 use_repo(github_tools, "com_github_gh")

--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -43,6 +43,7 @@ python3-wheel
 python-is-python3
 srecord
 tree
+usbutils
 xmlstarlet
 xsltproc
 xxd

--- a/rules/devices.bzl
+++ b/rules/devices.bzl
@@ -1,0 +1,58 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Variables that describe non-hermetic devices of the environment.
+
+This repository provides 1 variable:
+    - `CW_DEVICES`
+        - The presence of ChipWhisperer devices (CW305, CW310, CW340).
+"""
+
+LIST_FPGA_SCRIPT = """
+function _list_writable_usb() {(
+    set -euo pipefail
+    while read path; do
+      bus=$(echo $path | cut -d/ -f5)
+      dev=$(echo $path | cut -d/ -f6)
+      lsusb -d 2b3e: -s $bus:$dev || true
+    done <<< "$(find /dev/bus/usb -writable -type c)"
+)}
+
+function list_fpga() {(
+    set -euo pipefail
+
+    # Try lsusb with writable checks.
+    if _list_writable_usb 2>/dev/null | grep -oE "CW3(05|10|40)" | sort -u; then
+      return
+    fi
+    # Try udev symlinks.
+    if ls /dev/serial/by-id/ 2>/dev/null | grep -oE "CW3(05|10|40)" | sort -u; then
+      return
+    fi
+    # Fallback to lsusb
+    lsusb -d 2b3e: | grep -oE "CW3(05|10|40)" | sort -u || true
+)}
+"""
+
+def _devices_repo_impl(rctx):
+    # List available USB devices with lsusb and filter for 'ChipWhisperer' (VID 2b3e)
+    res = rctx.execute(["bash", "-c", """
+      set -euo pipefail
+      {LIST_FPGA_SCRIPT}
+      list_fpga
+    """.format(LIST_FPGA_SCRIPT = LIST_FPGA_SCRIPT)])
+    cw_devices = res.stdout.strip()
+    if cw_devices:
+        print("Found ChipWhisperer:", cw_devices.split("\n"))
+    else:
+        print("No ChipWhisperer devices found.")
+
+    rctx.file("devices.bzl", "CW_DEVICES = \"\"\"{}\"\"\"\n".format(cw_devices))
+    rctx.file("BUILD.bazel", "exports_files(glob([\"**\"]))\n")
+
+devices_repo = repository_rule(
+    implementation = _devices_repo_impl,
+    attrs = {},
+    local = True,
+)

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -61,6 +61,10 @@ load(
     _sim_qemu = "sim_qemu",
 )
 load(
+    "@lowrisc_opentitan//rules/opentitan:select.bzl",
+    "opentitan_select_test",
+)
+load(
     "@lowrisc_opentitan//hw/top:defs.bzl",
     "ALL_TOPS",
     "opentitan_select_top",
@@ -487,6 +491,18 @@ def opentitan_test(
             test_suite = str(Label(":{}".format(name))),
             **test_kwargs
         )
+
+    opentitan_select_test(
+        name = name + "_any",
+        tests = all_tests,
+        tags = ["manual"],
+    )
+
+    native.test_suite(
+        name = name + "_all",
+        tests = all_tests,
+        tags = ["manual"],
+    )
 
     native.test_suite(
         name = name,

--- a/rules/opentitan/select.bzl
+++ b/rules/opentitan/select.bzl
@@ -1,0 +1,157 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load("@lowrisc_opentitan//rules/opentitan:providers.bzl", "OpenTitanTestInfo")
+load("@lowrisc_opentitan//rules:devices.bzl", "LIST_FPGA_SCRIPT")
+load("@devices//:devices.bzl", "CW_DEVICES")
+
+_TEST_SCRIPT = """
+set -euo pipefail
+
+expected='{CW_DEVICES}'
+
+{LIST_FPGA_SCRIPT}
+
+# Confirm ChipWhisperer devices are the same as when Bazel was invoked.
+actual="$(list_fpga)"
+
+if [[ "$actual" != "$expected" ]]; then
+  echo "ERROR: Expected ChipWhisperer devices '$expected', but found '$actual'." >&2
+  echo "This indicates the devices available on the host have changed since Bazel was invoked." >&2
+  echo 'Please re-run `./bazelisk.sh fetch --repo=@devices --force`.' >&2
+  echo "" >&2
+  exit 1
+fi
+
+echo 'Test selected: {TEST_LABEL}'
+
+{TEST}
+"""
+
+def check_fpga_availability(label):
+    """Check if a specific FPGA is available for a test.
+
+    Args:
+      label: The label of the execution environment.
+    Returns:
+      bool: Whether the FPGA is available.
+    """
+    if "cw310" in label and "CW310" not in CW_DEVICES:
+        return False
+    if "hyper310" in label and "CW310" not in CW_DEVICES:
+        return False
+    if "cw340" in label and "CW340" not in CW_DEVICES:
+        return False
+    if "cw305" in label and "CW305" not in CW_DEVICES:
+        return False
+    return True
+
+def test_pattern(label, pattern):
+    """Checks if a label matches a preference pattern.
+
+    Args:
+      label: The execution environment label.
+      pattern: The pattern to match (substring or suffix ending in $).
+    Returns:
+      bool: Whether the label matches the pattern.
+    """
+    if pattern.endswith("$"):
+        return label.endswith(pattern[:-1])
+    return pattern in label
+
+def find_best_test_variant(tests, preference):
+    """Finds the best test variant based on execution environment preference.
+
+    Args:
+        tests: A list of targets with OpenTitanTestInfo providers.
+        preference: A list of patterns for exec_env labels, either a substring or a suffix ending with $.
+    Returns:
+        The target that matches the highest priority preference.
+    """
+
+    # Ensure the pattern only uses supported regex characters ($).
+    for pattern in preference:
+        for char in pattern.elems():
+            if char in "[]{}()|.*?\\^":
+                fail("Pattern {} has unsupported regex characters.".format(pattern))
+
+    first_match = None
+    tests = list(tests)
+    for pattern in preference:
+        for test in tests:
+            info = test[OpenTitanTestInfo]
+            label = str(info.exec_env.exec_env)
+            if test_pattern(label, pattern):
+                first_match = test
+                if check_fpga_availability(label):
+                    return test
+
+    # If no available exec_env is found, return the first match to ensure the
+    # Bazel build graph remains valid.
+    return first_match
+
+def _opentitan_select_test_impl(ctx):
+    """Finds the best test variant based on execution environment preference.
+
+    Args:
+        ctx: The rule context.
+    Returns:
+        The target that matches the highest priority preference.
+    """
+    out = ctx.actions.declare_file(ctx.label.name)
+
+    if len(ctx.attr.tests) == 0:
+        ctx.actions.write(
+            output = out,
+            content = """
+              echo "ERROR: No test targets found." >&2
+              exit 1
+            """,
+            is_executable = True,
+        )
+        return [DefaultInfo(executable = out)]
+
+    preference = ctx.attr._preference[BuildSettingInfo].value
+    test = find_best_test_variant(ctx.attr.tests, preference)
+    if not test:
+        fail("No test in group matches the execution environment preference.")
+
+    info = test[DefaultInfo]
+
+    # Test wrapper that also checks for outdated device info.
+    ctx.actions.write(
+        output = out,
+        content = _TEST_SCRIPT.format(
+            CW_DEVICES = CW_DEVICES,
+            LIST_FPGA_SCRIPT = LIST_FPGA_SCRIPT,
+            TEST_LABEL = str(test.label),
+            TEST = test[DefaultInfo].files_to_run.executable.short_path,
+        ),
+        is_executable = True,
+    )
+
+    return [
+        DefaultInfo(
+            executable = out,
+            runfiles = info.default_runfiles,
+            files = info.files,
+        ),
+    ]
+
+opentitan_select_test = rule(
+    implementation = _opentitan_select_test_impl,
+    attrs = {
+        "tests": attr.label_list(
+            doc = "The list of test variants in the group.",
+            providers = [OpenTitanTestInfo],
+        ),
+        "_preference": attr.label(
+            default = "@lowrisc_opentitan//sw:exec_env",
+            doc = "The preference list of execution environments.",
+            providers = [BuildSettingInfo],
+        ),
+    },
+    test = True,
+)

--- a/sw/BUILD
+++ b/sw/BUILD
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@bazel_skylib//rules:common_settings.bzl", "string_list_flag")
+
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
@@ -9,5 +11,36 @@ filegroup(
     srcs = glob(["**/*.md"]) + [
         "//sw/device:doc_files",
         "//sw/host:doc_files",
+    ],
+)
+
+# A build flag for specifying preferred execution environments as a list of strings.
+# Priority from highest to lowest.
+string_list_flag(
+    name = "exec_env",
+    build_setting_default = [
+        "fpga_cw340$",
+        "fpga_cw340_test_rom$",
+        "fpga_cw340_rom_with_fake_keys$",
+        "fpga_cw340_rom_ext$",
+        "fpga_cw340_sival$",
+        "fpga_cw340_sival_rom_ext$",
+        "fpga_cw310$",
+        "fpga_cw310_test_rom$",
+        "fpga_cw310_rom_with_fake_keys$",
+        "fpga_cw310_rom_ext$",
+        "fpga_cw310_sival$",
+        "fpga_cw310_sival_rom_ext$",
+        "sim_qemu_base$",
+        "sim_qemu_rom_with_fake_keys$",
+        "sim_verilator_base$",
+        "sim_verilator$",
+        "sim_verilator_rom_with_fake_keys$",
+        "sim_dv_base$",
+        "sim_dv$",
+        "fpga_cw305$",
+        "silicon_creator$",
+        "silicon_owner_sival_rom_ext$",
+        "",  # wildcard
     ],
 )


### PR DESCRIPTION
This change add a `*_any` label which automatically selects the most appropriate execution environment based on both user preference and the hardware availability, improving the quality of life.

* Running on ANY exec env
  * `//sw/device/tests:uart_smoketest_any`
  * (one of `//sw/device/tests:uart_smoketest_fpga_cw340_rom_with_fake_keys` etc)
* Running on ALL exec env
  * `//sw/device/tests:uart_smoketest_all`
  * (was `//sw/device/tests:uart_smoketest`)
* Run on a specific exec env
  * Same as before: `//sw/device/tests:uart_smoketest_fpga_cw340_rom_with_fake_keys` 
* Specify selection preference:
  * `--//sw:exec_env=cw340_test_rom,cw340_rom_ext` in test commandline or `~/.bazelrc`
  * (try with cw340 test rom first, then with rom_ext)

The preference pattern is tested against the execution environment name. It supports either a substring match or a suffix match when the pattern ends with a `$`. For example, `fpga_cw310$` will match `//hw/top_earlgrey:fpga_cw310` but not `//hw/top_earlgrey:fpga_cw310_test_rom`.

---

Previously, the `opentitan_test` macro created a `test_suite` for the primary label name. This forced users to either manually specify a execution environment using a long target suffix, or run the entire suite which often caused failures when the required hardware was not connected to the host.

This change adds an additional `opentitan_select_test` target. This new rule dynamically selects the most suitable test variant by cross-referencing a preference list, defined by the `--//sw:exec_env` flag, against the actual ChipWhisperer devices (CW305, CW310, CW340) detected on the host during the repository fetching phase.