### PR TITLE
[tl,dv] Improvements in host driver timing

### DIFF
--- a/hw/dv/sv/tl_agent/tl_device_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_device_driver.sv
@@ -35,9 +35,9 @@ class tl_device_driver extends tl_base_driver;
     forever begin
       ready_delay = $urandom_range(cfg.a_ready_delay_min, cfg.a_ready_delay_max);
       repeat(ready_delay) @(cfg.vif.device_cb);
-      cfg.vif.device_cb.d2h_int.a_ready <= 1'b1;
+      cfg.vif.device_cb.d2h.a_ready <= 1'b1;
       @(cfg.vif.device_cb);
-      cfg.vif.device_cb.d2h_int.a_ready <= 1'b0;
+      cfg.vif.device_cb.d2h.a_ready <= 1'b0;
     end
   endtask
 

--- a/hw/dv/sv/tl_agent/tl_host_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_host_driver.sv
@@ -202,15 +202,15 @@ task tl_host_driver::send_a_channel_request(tl_seq_item req);
 
     if (!cfg.in_reset) begin
       pending_a_req.push_back(req);
-      cfg.vif.host_cb.h2d_int.a_address <= req.a_addr;
-      cfg.vif.host_cb.h2d_int.a_opcode  <= tl_a_op_e'(req.a_opcode);
-      cfg.vif.host_cb.h2d_int.a_size    <= req.a_size;
-      cfg.vif.host_cb.h2d_int.a_param   <= req.a_param;
-      cfg.vif.host_cb.h2d_int.a_data    <= req.a_data;
-      cfg.vif.host_cb.h2d_int.a_mask    <= req.a_mask;
-      cfg.vif.host_cb.h2d_int.a_user    <= req.a_user;
-      cfg.vif.host_cb.h2d_int.a_source  <= req.a_source;
-      cfg.vif.host_cb.h2d_int.a_valid   <= 1'b1;
+      cfg.vif.host_cb.h2d.a_address <= req.a_addr;
+      cfg.vif.host_cb.h2d.a_opcode  <= tl_a_op_e'(req.a_opcode);
+      cfg.vif.host_cb.h2d.a_size    <= req.a_size;
+      cfg.vif.host_cb.h2d.a_param   <= req.a_param;
+      cfg.vif.host_cb.h2d.a_data    <= req.a_data;
+      cfg.vif.host_cb.h2d.a_mask    <= req.a_mask;
+      cfg.vif.host_cb.h2d.a_user    <= req.a_user;
+      cfg.vif.host_cb.h2d.a_source  <= req.a_source;
+      cfg.vif.host_cb.h2d.a_valid   <= 1'b1;
     end else begin
       req_abort = 1;
     end
@@ -218,9 +218,9 @@ task tl_host_driver::send_a_channel_request(tl_seq_item req);
     `DV_SPINWAIT_EXIT(send_a_request_body(req, a_valid_len, req_done, req_abort);,
                       wait(cfg.in_reset);)
 
-    // when reset and host_cb.h2d_int.a_valid <= 1 occur at the same time, if clock is off,
-    // there is a race condition and invalidate_a_channel can't clear a_valid.
-    if (cfg.in_reset) cfg.vif.host_cb.h2d_int.a_valid <= 1'b0;
+    // when reset and host_cb.h2d.a_valid <= 1 occur at the same time, if clock is off, there is a
+    // race condition and invalidate_a_channel can't clear a_valid.
+    if (cfg.in_reset) cfg.vif.host_cb.h2d.a_valid <= 1'b0;
     invalidate_a_channel();
   end
   seq_item_port.item_done();
@@ -251,7 +251,7 @@ task tl_host_driver::send_a_request_body(tl_seq_item req, int a_valid_len,
     end else if ((req.req_abort_after_a_valid_len || cfg.allow_a_valid_drop_wo_a_ready) &&
                  a_valid_cnt >= a_valid_len) begin
       if (req.req_abort_after_a_valid_len) req_abort = 1;
-      cfg.vif.host_cb.h2d_int.a_valid <= 1'b0;
+      cfg.vif.host_cb.h2d.a_valid <= 1'b0;
       // remove unaccepted item
       void'(pending_a_req.pop_back());
       invalidate_a_channel();
@@ -270,13 +270,13 @@ task tl_host_driver::d_ready_rsp();
     d_ready_delay = $urandom_range(cfg.d_ready_delay_min, cfg.d_ready_delay_max);
     // if a_valid high then d_ready must be high, exit the delay when a_valid is set
     repeat (d_ready_delay) begin
-      if (!cfg.host_can_stall_rsp_when_a_valid_high && cfg.vif.h2d_int.a_valid) break;
+      if (!cfg.host_can_stall_rsp_when_a_valid_high && cfg.vif.h2d.a_valid) break;
       @(cfg.vif.host_cb);
     end
 
-    cfg.vif.host_cb.h2d_int.d_ready <= 1'b1;
+    cfg.vif.host_cb.h2d.d_ready <= 1'b1;
     @(cfg.vif.host_cb);
-    cfg.vif.host_cb.h2d_int.d_ready <= 1'b0;
+    cfg.vif.host_cb.h2d.d_ready <= 1'b0;
   end
 endtask
 
@@ -285,7 +285,7 @@ task tl_host_driver::d_channel_thread();
   tl_seq_item rsp;
 
   forever begin
-    if ((cfg.vif.host_cb.d2h.d_valid && cfg.vif.h2d_int.d_ready && !cfg.in_reset) ||
+    if ((cfg.vif.host_cb.d2h.d_valid && cfg.vif.h2d.d_ready && !cfg.in_reset) ||
         ((pending_a_req.size() != 0) & cfg.in_reset)) begin
       // Use the source ID to find the matching request
       foreach (pending_a_req[i]) begin

--- a/hw/dv/sv/tl_agent/tl_host_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_host_driver.sv
@@ -38,7 +38,16 @@ class tl_host_driver extends tl_base_driver;
 
   // Send the body of a request on the A channel.
   //
+  // To do so, this writes a_valid and the other A signals and then waits for a clock edge where we
+  // see a_ready true, at which point the A channel transaction has been made.
+  //
+  // If a_ready doesn't go high, it's possible that there will be a timeout after a_valid_len
+  // cycles. If this is enabled and the timeout happens then remove the item from pendng_a_req,
+  // and invalidate the channel.
+  //
   // req:            The request whose body should be sent.
+  //
+  // a_valid_delay:  The number of host clock cycles to wait before asserting a_valid.
   //
   // a_valid_len:    The number of host clock cycles a_valid is held high waiting for a_ready to go
   //                 high and accept the request. If req has req_abort_after_a_valid_len set, or if
@@ -49,8 +58,11 @@ class tl_host_driver extends tl_base_driver;
   //
   // req_abort [out] This is set to 1'b1 if the host decides to drop a_valid because the receiver
   //                 hasn't responded with a_ready.
-  extern protected task send_a_request_body(tl_seq_item req, int a_valid_len,
-                                            output bit req_done, output bit req_abort);
+  extern local task send_a_request_body(tl_seq_item  req,
+                                        int unsigned a_valid_delay,
+                                        int unsigned a_valid_len,
+                                        output bit   req_done,
+                                        output bit   req_abort);
 
   // Drive the d_ready pin (as the host) forever to allow a device to send responses back
   //
@@ -77,11 +89,14 @@ class tl_host_driver extends tl_base_driver;
   // Return true if the given source is the a_source value of some pending request.
   extern protected function bit is_source_in_pending_req(bit [SourceWidth-1:0] source);
 
-  // Write rubbish to the A channel to invalidate it and set a_valid to zero
+  // Set a_valid to zero and write rubbish to the A channel to invalidate it.
+  //
+  // If direct is true, this directly drives the vif.h2d_int signal as well as setting signals in
+  // host_cb (meaning that this will have immediate effect, even if the clock is not running).
   //
   // If cfg.invalidate_a_x is true then all fields other than a_valid will be set to 'x. If it is
   // false then all the fields will be randomised.
-  extern protected function void invalidate_a_channel();
+  extern local task invalidate_a_channel(bit direct);
 endclass : tl_host_driver
 
 function tl_host_driver::new (string name, uvm_component parent);
@@ -101,9 +116,10 @@ endtask
 
 task tl_host_driver::on_enter_reset();
   // Since we've just started a period of reset, invalidate all signals and mark ourselves as not
-  // ready on the D channel.
-  invalidate_a_channel();
-  cfg.vif.h2d_int.d_ready <= 1'b0;
+  // ready on the D channel (both directly and through the clocking block)
+  invalidate_a_channel(1'b1);
+  cfg.vif.h2d_int.d_ready     <= 1'b0;
+  cfg.vif.host_cb.h2d.d_ready <= 1'b0;
 endtask
 
 function void tl_host_driver::on_leave_reset();
@@ -196,32 +212,16 @@ task tl_host_driver::send_a_channel_request(tl_seq_item req);
       end
     end
 
-    // break delay loop if reset asserted to release blocking
-    `DV_SPINWAIT_EXIT(repeat (a_valid_delay) @(cfg.vif.host_cb);,
-                      wait(cfg.in_reset);)
-
-    if (!cfg.in_reset) begin
-      pending_a_req.push_back(req);
-      cfg.vif.host_cb.h2d.a_address <= req.a_addr;
-      cfg.vif.host_cb.h2d.a_opcode  <= tl_a_op_e'(req.a_opcode);
-      cfg.vif.host_cb.h2d.a_size    <= req.a_size;
-      cfg.vif.host_cb.h2d.a_param   <= req.a_param;
-      cfg.vif.host_cb.h2d.a_data    <= req.a_data;
-      cfg.vif.host_cb.h2d.a_mask    <= req.a_mask;
-      cfg.vif.host_cb.h2d.a_user    <= req.a_user;
-      cfg.vif.host_cb.h2d.a_source  <= req.a_source;
-      cfg.vif.host_cb.h2d.a_valid   <= 1'b1;
-    end else begin
-      req_abort = 1;
-    end
-    // drop valid if it lasts for a_valid_len, even there is no a_ready
-    `DV_SPINWAIT_EXIT(send_a_request_body(req, a_valid_len, req_done, req_abort);,
-                      wait(cfg.in_reset);)
-
-    // when reset and host_cb.h2d.a_valid <= 1 occur at the same time, if clock is off, there is a
-    // race condition and invalidate_a_channel can't clear a_valid.
-    if (cfg.in_reset) cfg.vif.host_cb.h2d.a_valid <= 1'b0;
-    invalidate_a_channel();
+    fork : isolation_fork begin
+      fork
+        begin
+          wait(cfg.in_reset);
+          req_abort = 1;
+        end
+        send_a_request_body(req, a_valid_delay, a_valid_len, req_done, req_abort);
+      join_any
+      disable fork;
+    end join
   end
   seq_item_port.item_done();
   if (req_abort || cfg.in_reset) begin
@@ -236,13 +236,32 @@ task tl_host_driver::send_a_channel_request(tl_seq_item req);
                                        req.convert2string()), UVM_HIGH)
 endtask
 
-task tl_host_driver::send_a_request_body(tl_seq_item req, int a_valid_len,
-                                         output bit req_done, output bit req_abort);
+task tl_host_driver::send_a_request_body(tl_seq_item  req,
+                                         int unsigned a_valid_delay,
+                                         int unsigned a_valid_len,
+                                         output bit   req_done,
+                                         output bit   req_abort);
   int unsigned a_valid_cnt = 0;
   req_done = 1'b0;
   req_abort = 1'b0;
 
-  while (1) begin
+  // If there is a delay before sending the item, wait that number of cycles
+  repeat (a_valid_delay) @(cfg.vif.host_cb);
+
+  // Set signals on the A channel and add the request to pending_a_req, then wait for one clock
+  // edge, which causes the signals to actually be presented as signals on the interface.
+  pending_a_req.push_back(req);
+  cfg.vif.host_cb.h2d.a_address <= req.a_addr;
+  cfg.vif.host_cb.h2d.a_opcode  <= tl_a_op_e'(req.a_opcode);
+  cfg.vif.host_cb.h2d.a_size    <= req.a_size;
+  cfg.vif.host_cb.h2d.a_param   <= req.a_param;
+  cfg.vif.host_cb.h2d.a_data    <= req.a_data;
+  cfg.vif.host_cb.h2d.a_mask    <= req.a_mask;
+  cfg.vif.host_cb.h2d.a_user    <= req.a_user;
+  cfg.vif.host_cb.h2d.a_source  <= req.a_source;
+  cfg.vif.host_cb.h2d.a_valid   <= 1'b1;
+
+  forever begin
     @(cfg.vif.host_cb);
     a_valid_cnt++;
     if (cfg.vif.host_cb.d2h.a_ready) begin
@@ -251,14 +270,15 @@ task tl_host_driver::send_a_request_body(tl_seq_item req, int a_valid_len,
     end else if ((req.req_abort_after_a_valid_len || cfg.allow_a_valid_drop_wo_a_ready) &&
                  a_valid_cnt >= a_valid_len) begin
       if (req.req_abort_after_a_valid_len) req_abort = 1;
-      cfg.vif.host_cb.h2d.a_valid <= 1'b0;
       // remove unaccepted item
       void'(pending_a_req.pop_back());
-      invalidate_a_channel();
-      @(cfg.vif.host_cb);
       break;
     end
   end
+
+  // Finally, clear up the A channel signals (because the transaction has either happened or been
+  // aborted). The cleared signals will be visible on the interface on the next clock edge.
+  invalidate_a_channel(1'b0);
 endtask
 
 task tl_host_driver::d_ready_rsp();
@@ -336,23 +356,36 @@ function bit tl_host_driver::is_source_in_pending_req(bit [SourceWidth-1:0] sour
   return 0;
 endfunction
 
-function void tl_host_driver::invalidate_a_channel();
+task tl_host_driver::invalidate_a_channel(bit direct);
+  // To invalidate the A channel, we will drive a_valid to zero and drive all the other A channel
+  // signals to either 'x or to a random value. Since there's just one signal on the D channel, the
+  // easiest way to do this is to drive all the signals, but make sure to set the d_ready signal to
+  // the value it had before.
+  //
+  // If either current d_ready value is not known, consider it to be 0.
+  bit cb_d_ready  = cfg.vif.mon_cb.h2d.d_ready;
+  bit raw_d_ready = cfg.vif.mon_cb.h2d.d_ready;
+
   if (cfg.invalidate_a_x) begin
-    cfg.vif.h2d_int.a_opcode <= tlul_pkg::tl_a_op_e'('x);
-    cfg.vif.h2d_int.a_param <= '{default:'x};
-    cfg.vif.h2d_int.a_size <= '{default:'x};
-    cfg.vif.h2d_int.a_source <= '{default:'x};
-    cfg.vif.h2d_int.a_address <= '{default:'x};
-    cfg.vif.h2d_int.a_mask <= '{default:'x};
-    cfg.vif.h2d_int.a_data <= '{default:'x};
-    // The assignment to instr_type must have a cast since the LRM doesn't allow enum assignment of
-    // values not belonging to the enumeration set.
-    cfg.vif.h2d_int.a_user <= '{instr_type:prim_mubi_pkg::mubi4_t'('x), default:'x};
-    cfg.vif.h2d_int.a_valid <= 1'b0;
+    cfg.vif.host_cb.h2d         <= tl_h2d_t'('x);
+    cfg.vif.host_cb.h2d.a_valid <= 1'b0;
+    cfg.vif.host_cb.h2d.d_ready <= cb_d_ready;
+
+    if (direct) begin
+      cfg.vif.h2d_int         <= tl_h2d_t'('x);
+      cfg.vif.h2d_int.a_valid <= 1'b0;
+      cfg.vif.h2d_int.d_ready <= raw_d_ready;
+    end
   end else begin
     tlul_pkg::tl_h2d_t h2d;
-    `DV_CHECK_STD_RANDOMIZE_FATAL(h2d)
-    h2d.a_valid = 1'b0;
-    cfg.vif.h2d_int <= h2d;
+    if (!std::randomize(h2d) with { h2d.a_valid == 1'b0; h2d.d_ready == cb_d_ready; }) begin
+      `uvm_fatal(get_full_name(), "Failed to randomize h2d.")
+    end
+
+    cfg.vif.host_cb.h2d <= h2d;
+    if (direct) begin
+      h2d.d_ready = raw_d_ready;
+      cfg.vif.h2d_int <= h2d;
+    end
   end
-endfunction
+endtask

--- a/hw/dv/sv/tl_agent/tl_if.sv
+++ b/hw/dv/sv/tl_agent/tl_if.sv
@@ -20,7 +20,7 @@ interface tl_if(input clk, input rst_n);
 
   clocking host_cb @(posedge clk);
     input  rst_n;
-    output h2d_int;
+    output h2d = h2d_int;
     input  d2h;
   endclocking
   modport host_mp(clocking host_cb);
@@ -28,7 +28,7 @@ interface tl_if(input clk, input rst_n);
   clocking device_cb @(posedge clk);
     input  rst_n;
     input  h2d;
-    output d2h_int;
+    output d2h = d2h_int;
   endclocking
   modport device_mp(clocking device_cb);
 


### PR DESCRIPTION
The motivation for this PR is the final commit (which fixed a rather mysterious test failure when running rv_dm_smoke with Xcelium). That commit's message is:

> **[tl,dv] Minor timing fixes in tl_host_driver**
> 
> With the existing driver, an A channel transaction could get swallowed
> completely if a_ready was true and an item was presented to
> seq_item_port at an unexpected time.
> 
> This commit solves that problem, and also writes some careful notes
> about how the timing works with clocking blocks (because it's
> surprisingly confusing and not all that easy to figure out from
> waveforms).
