### PR TITLE
[pentest] Move sca_ibex_python_test to flaky

### DIFF
--- a/sw/device/tests/penetrationtests/BUILD
+++ b/sw/device/tests/penetrationtests/BUILD
@@ -369,7 +369,7 @@ pentest_cryptolib_sca_asym(
 
 pentest_sca(
     name = "sca_ibex_python_test",
-    tags = [],
+    tags = ["flaky"],
     test_args = "",
     test_harness = "//sw/host/penetrationtests/python/sca:sca_ibex_python_test",
     test_vectors = [],


### PR DESCRIPTION
The sca ibex test has a chance to fail due to some UART timeout. Move it to flaky, retesting it in CI will make sure it will succeed with higher success rate ensuring it will not block PRs.
Investigate the flakiness later to then remove the label.