### PR TITLE
[otbn,dv] Fix DV build with VCS

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_loop_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_loop_if.sv
@@ -101,18 +101,18 @@ interface otbn_loop_if #(
 
     // As the otbn_loop_if is bound to u_otbn_controller (see tb.sv) we can use an up-reference and
     // directly access current_loop instead of specifying its absolute name (tb.dut.u_otbn_core.x).
-    force current_loop.loop_addr_info.loop_addrs_intg = loop_addrs_padded_intg[38:32];
-    force current_loop.loop_addr_info.loop_start = loop_start;
-    force current_loop.loop_addr_info.loop_end = loop_end;
+    force u_otbn_loop_controller.current_loop.loop_addr_info = '{
+      loop_start:      loop_start,
+      loop_end:        loop_end,
+      loop_addrs_intg: loop_addrs_padded_intg[38:32]
+    };
   endfunction
 
   // Release the forcing of the loop_addr_info.
   function automatic void release_loop_addrs_info();
     // As the otbn_loop_if is bound to u_otbn_controller (see tb.sv) we can use an up-reference and
     // directly access current_loop instead of specifying its absolute name (tb.dut.u_otbn_core.x).
-    release current_loop.loop_addr_info.loop_addrs_intg;
-    release current_loop.loop_addr_info.loop_start;
-    release current_loop.loop_addr_info.loop_end;
+    release u_otbn_loop_controller.current_loop.loop_addr_info;
   endfunction
 
   // Track completing some loop. This is implied by the next item, but much easier to hit so maybe


### PR DESCRIPTION
The existing force/release code caused an elaboration failure with VCS. This was a bit confusing to me at first because the interface gets bound into the loop controller, where the requested path (e.g. current_loop.loop_addr_info.loop_start) is indeed valid.

However, an upwards name reference needs the first part (the identifier before the first ".") to be a module identifier and current_loop is just the name of a variable that happens to be a structure. (See section 23.8 of IEEE 1800-2017)

Fortunately, there is only one loop controller in the design and it has a known name, so we can go one step further upwards in the reference.

The longer name caused the lines to get a bit enormous, so I've changed the force/release to act on the whole structure at once.