### PR TITLE
[ci] Optimize remote cache bandwidth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -752,6 +752,7 @@ jobs:
         run: |
           # Build everything we selected, excluding some tags.
           ./bazelisk.sh build                                \
+            --remote_download_outputs=minimal                \
             --build_tests_only=false                         \
             --define DISABLE_VERILATOR_BUILD=true            \
             --test_tag_filters=-broken,-cw310,-verilator,-dv \
@@ -796,6 +797,7 @@ jobs:
         run: |
           # Compile some selected targets
           ./bazelisk.sh build                                \
+            --remote_download_outputs=minimal                \
             --build_tests_only=false                         \
             --//hw/top=darjeeling                            \
             //sw/device/tests/...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -760,7 +760,7 @@ jobs:
       - name: Run software unit tests
         run: |
           ./bazelisk.sh test                                          \
-            --build_tests_only=false                                  \
+            --build_tests_only=true                                   \
             --test_output=errors                                      \
             --define DISABLE_VERILATOR_BUILD=true                     \
             --test_tag_filters=-broken,-cw310,-verilator,-dv,-silicon \


### PR DESCRIPTION
This PR tunes several Bazel flags to reduce execution time and network bandwidth consumption.

1.  **Minimal Remote Downloads:**
    Added `--remote_download_outputs=minimal` to the software build steps in `ci.yml`. This prevents the environment from downloading unnecessary outputs from the remote cache that are not required for subsequent steps.

2.  **Optimize Test Execution:**
    Set `--build_tests_only=true` for the software unit test step. Since non-test dependencies are already built in the preceding "Build" step, this avoids redundant work and speeds up the test phase.

These changes collectively reduce some infrastructure bandwidth.
