### PR TITLE
[tl] Move assertions in tlul_assert to the posedge

### DIFF
--- a/hw/ip/tlul/rtl/tlul_assert.sv
+++ b/hw/ip/tlul/rtl/tlul_assert.sv
@@ -34,7 +34,7 @@ module tlul_assert #(
   bit disable_sva;
 
   default disable iff disable_sva || !rst_ni;
-  default clocking @(negedge clk_i); endclocking
+  default clocking @(posedge clk_i); endclocking
 
   //////////////////////////////////
   // check requests and responses //
@@ -86,23 +86,23 @@ module tlul_assert #(
   // keep track of pending requests //
   ////////////////////////////////////
 
-  // use negedge clk to avoid possible race conditions
-  always_ff @(negedge clk_i or negedge rst_ni) begin
+  always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       pend_req <= '0;
     end else begin
-      // store each request in pend_req array, ignoring requests that receive a combinational
-      // response.
-      if (curr_req.pend & (!d2h.d_valid || d2h.d_source != h2d.a_source)) begin
+      // Update pend_req if there is an A channel transaction on this cycle.
+      //
+      // Note that we can safely do this if there was a combinatorial response. In that case, it
+      // will be removed again just below.
+      if (curr_req.pend) begin
         pend_req[h2d.a_source] <= curr_req;
       end
 
-      if (d2h.d_valid) begin
-        // update pend_req array
-        if (h2d.d_ready) begin
-          pend_req[d2h.d_source].pend <= 0;
-        end
-      end //d2h.d_valid
+      // If there is a D channel transaction on this cycle, clear any pending request for the
+      // associated d_source.
+      if (d2h.d_valid && h2d.d_ready) begin
+        pend_req[d2h.d_source] <= '0;
+      end
     end
   end
 

--- a/hw/ip/tlul/rtl/tlul_assert.sv
+++ b/hw/ip/tlul/rtl/tlul_assert.sv
@@ -55,13 +55,6 @@ module tlul_assert #(
 
   pend_req_t [2**TL_AIW-1:0] pend_req;
 
-  logic [7:0]  a_mask, d_mask;
-  logic [63:0] a_data, d_data;
-  assign a_mask = 8'(h2d.a_mask);
-  assign a_data = 64'(h2d.a_data);
-  assign d_mask = 8'(pend_req[d2h.d_source].mask);
-  assign d_data = 64'(d2h.d_data);
-
   ////////////////////////////////////
   // Current request                //
   ////////////////////////////////////
@@ -81,6 +74,13 @@ module tlul_assert #(
   // assertion of `d_valid`.
   logic curr_fwd;
   assign curr_fwd = curr_req.pend & (d2h.d_source == h2d.a_source);
+
+  logic [7:0]  a_mask, d_mask;
+  logic [63:0] a_data, d_data;
+  assign a_mask = 8'(h2d.a_mask);
+  assign a_data = 64'(h2d.a_data);
+  assign d_mask = 8'(curr_fwd ? curr_req.mask : pend_req[d2h.d_source].mask);
+  assign d_data = 64'(d2h.d_data);
 
   ////////////////////////////////////
   // keep track of pending requests //


### PR DESCRIPTION
Since all the action in the protocol happens on the positive edge of the clock, move the assertions so that they match.