### PR TITLE
[hw,prim] Add new prim_inv

### DIFF
--- a/hw/ip/prim/README.md
+++ b/hw/ip/prim/README.md
@@ -348,9 +348,9 @@ After synthesizing the top module `prim_sdc_example` the following checks should
 
 1. In the synthesized netlist, the following number of size_only instances must be present:
 
-| cell names |  buf  | and2 |  xor  |  xnor  | flop | tie | clock_mux2 | clock_gating |
-| -----------|  ---- |------|-----  |------  |------|-----|------------|--------------|
-| #instances |  328  |  56  |  120  |  56    |  252 |  64 |  2         |  2           |
+| cell names |  buf  |  inv  | and2 |  xor  |  xnor  | flop | tie | clock_mux2 | clock_gating |
+| -----------|  ---- |  ---- |------|-----  |------  |------|-----|------------|--------------|
+| #instances |  328  |  56   |  56  |  120  |  56    |  252 |  64 |  2         |  2           |
 
 2. None of the test_*_o signals can be driven by a constant 0 or 1.
 The instantiated `size_only` instances must prevent logic optimizations and keep the output comparators.
@@ -364,7 +364,7 @@ This can be checked by the synthesis tool, e.g. `check_design -unloaded_comb/-un
 5. `lc_en_i`, `mubi_i` signals can only be connected to variables, or legal values (`MuBi4True`, `MuBi4False`, `On`, `Off`)
 
 If all checks are successful, the same constraints can be applied to the full design.
-The script `utils/design/check-netlist.py` [check-netlist] can be used to report a summary of size_only cells in a netlist.
+The script `util/design/check-netlist.py` [check-netlist] can be used to report a summary of size_only cells in a netlist.
 It can also automate an initial version of checks (4) and (5) but it does **not** replace a final manual inspection of the netlist.
 
 [check-netlist]: https://github.com/lowRISC/opentitan/tree/master/util/design#netlist-checker-script

--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -32,6 +32,7 @@ filesets:
       - lowrisc:prim:xor2
       - lowrisc:prim:xnor2
       - lowrisc:prim:and2
+      - lowrisc:prim:inv
       - lowrisc:prim:reg_we_check
       - lowrisc:prim:sha2
     files:

--- a/hw/ip/prim/rtl/prim_sdc_example.sv
+++ b/hw/ip/prim/rtl/prim_sdc_example.sv
@@ -9,21 +9,21 @@
 //
 // 1. In the synthesized netlist, the following number of size_only instances must be present:
 // e.g. grep -c -R u_size_only_x netlist.v (make sure the design is uniquified)
-// |-------------------------------------------------------------------------|
-// | Test | buf | and2 | xor | xnor | flop | tie | clock_mux2 | clock_gating |
-// | -----| ----|------|-----|------|------|-----|------------|--------------|
-// | 1    | 192 | -    |  -  | -    | -    | 64  | -          | -            |
-// | 2    | -   | -    |  64 | -    | -    | -   | -          | -            |
-// | 3    |  48 | 48   |  48 | 48   | 144  | -   | -          | -            |
-// | 4    |   8 |  8   |   8 |  8   |  24  | -   | -          | -            |
-// | 5    |  36 | -    |  -  | -    |  24  | -   | -          | -            |
-// | 6    |  16 | -    |  -  | -    |   8  | -   | -          | -            |
-// | 7    | -   | -    |  -  | -    |  32  | -   | 2          | 2            |
-// | 8    |  16 | -    |  -  | -    |   8  | -   | -          | -            |
-// | 9    |  12 | -    |  -  | -    |  12  | -   | -          | -            |
-// | -----| ----|------|-----|------|------|-----|------------|--------------|
-// |total | 328 | 56   | 120 | 56   | 252  | 64  | 2          | 2            |
-// |-------------------------------------------------------------------------|
+// |-------------------------------------------------------------------------------|
+// | Test | buf | inv | and2 | xor | xnor | flop | tie | clock_mux2 | clock_gating |
+// | -----|-----|-----|------|-----|------|------|-----|------------|--------------|
+// | 1    | 192 |  -  |  -   |  -  |  -   |  -   | 64  | -          | -            |
+// | 2    |  -  |  -  |  -   | 64  |  -   |  -   |  -  | -          | -            |
+// | 3    |  48 | 48  | 48   | 48  | 48   | 144  |  -  | -          | -            |
+// | 4    |   8 |  8  |  8   |  8  |  8   |  24  |  -  | -          | -            |
+// | 5    |  36 |  -  |  -   |  -  |  -   |  24  |  -  | -          | -            |
+// | 6    |  16 |  -  |  -   |  -  |  -   |   8  |  -  | -          | -            |
+// | 7    |  -  |  -  |  -   |  -  |  -   |  32  |  -  | 2          | 2            |
+// | 8    |  16 |  -  |  -   |  -  |  -   |   8  |  -  | -          | -            |
+// | 9    |  12 |  -  |  -   |  -  |  -   |  12  |  -  | -          | -            |
+// | -----|-----|-----|------|-----|------|------|-----|------------|--------------|
+// |total | 328 | 56  | 56   | 120 | 56   | 252  | 64  | 2          | 2            |
+// |-------------------------------------------------------------------------------|
 //
 // 2. None of the test_*_o signals can be driven by a constant 0 or 1.
 // The instantiated size_only instances must prevent logic optimizations and keep
@@ -198,13 +198,14 @@ module prim_sdc_example #(
   // These gates cannot be removed
   // The following size_only cells are expected:
   // 6*8 size_only_buf
+  // 6*8 size_only_inv
   // 6*8 size_only_and2
   // 6*8 size_only_xor
   // 6*8 size_only_xnor
   // 6*8*3 size_only_flop
 
   localparam int unsigned NumConst = 6;
-  localparam int unsigned NumGates = 7;
+  localparam int unsigned NumGates = 8;
 
   localparam logic [Width-1:0] ConstIn0 [NumConst] = {8'hAB,
                                                       8'hBA,
@@ -280,6 +281,13 @@ module prim_sdc_example #(
       .d_i  (ConstIn0[idx]),
       .q_o  (const_out_not_removed[idx][6])
     );
+
+    prim_inv #(
+      .Width(Width)
+    ) u_prim_inv (
+      .in_i (ConstIn0[idx]),
+      .out_o(const_out_not_removed[idx][7])
+    );
   end
 
   assign test_const_o = ^const_out_not_removed;
@@ -289,6 +297,7 @@ module prim_sdc_example #(
   ///////////////////////////////////////////////////
   // The following size_only cells are expected:
   // 8 size_only_buf
+  // 8 size_only_inv
   // 8 size_only_and2
   // 8 size_only_xor
   // 8 size_only_xnor
@@ -346,6 +355,12 @@ module prim_sdc_example #(
       .clk_i(clk_i),
       .d_i  (data_a[Width-1:0]),
       .q_o  (var_out_not_removed[6])
+  );
+  prim_inv #(
+      .Width(Width)
+  ) u_prim_inv (
+      .in_i (data_a[Width-1:0]),
+      .out_o(var_out_not_removed[7])
   );
 
   assign test_var_o = ^var_out_not_removed;

--- a/hw/ip/prim_asap7/prim_asap7.core
+++ b/hw/ip/prim_asap7/prim_asap7.core
@@ -35,6 +35,7 @@ filesets:
       - lowrisc:prim_asap7:xnor2
       - lowrisc:prim_asap7:xor2
       - lowrisc:prim_asap7:flop_no_rst
+      - lowrisc:prim_asap7:inv
 # Note that flash is a macro that depends on IPs, so they are not
 # included here. They must be brought in explicitly.
 #      - lowrisc:prim_generic:flash
@@ -64,6 +65,7 @@ mapping:
   "lowrisc:prim:xnor2"        : "lowrisc:prim_asap7:xnor2"
   "lowrisc:prim:xor2"         : "lowrisc:prim_asap7:xor2"
   "lowrisc:prim:flop_no_rst"  : "lowrisc:prim_asap7:flop_no_rst"
+  "lowrisc:prim:inv"          : "lowrisc:prim_asap7:inv"
   # Flash is a good canditate to be removed from the prims and become a macro like OTP.
   # TODO(#27042): When this is done, it should be removed from this mapping.
   "lowrisc:prim:flash": "lowrisc:prim_generic:flash"

--- a/hw/ip/prim_asap7/prim_asap7_inv.core
+++ b/hw/ip/prim_asap7/prim_asap7_inv.core
@@ -1,0 +1,38 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_asap7:inv"
+description: "asap7 instance of a inverter cell"
+virtual:
+  - lowrisc:prim:inv
+
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_inv.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim_asap7/rtl/prim_inv.sv
+++ b/hw/ip/prim_asap7/rtl/prim_inv.sv
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module prim_inv #(
+  parameter int Width = 1
+) (
+  input  logic [Width-1:0] in_i,
+  output logic [Width-1:0] out_o
+);
+
+  for (genvar idx = 0; idx < Width; idx++) begin : gen_bits
+    INVx2_ASAP7_75t_R u_size_only_inv (
+      .A(in_i[idx]),
+      .Y(out_o[idx])
+    );
+  end
+
+endmodule

--- a/hw/ip/prim_generic/prim_generic.core
+++ b/hw/ip/prim_generic/prim_generic.core
@@ -33,6 +33,7 @@ filesets:
       - lowrisc:prim_generic:xnor2
       - lowrisc:prim_generic:xor2
       - lowrisc:prim_generic:flop_no_rst
+      - lowrisc:prim_generic:inv
 # Note that flash is a macro that depends on IPs, so they are not
 # included here. They must be brought in explicitly.
 #      - lowrisc:prim_generic:flash
@@ -62,6 +63,7 @@ mapping:
   "lowrisc:prim:xnor2"        : "lowrisc:prim_generic:xnor2"
   "lowrisc:prim:xor2"         : "lowrisc:prim_generic:xor2"
   "lowrisc:prim:flop_no_rst"  : "lowrisc:prim_generic:flop_no_rst"
+  "lowrisc:prim:inv"          : "lowrisc:prim_generic:inv"
   # Flash is a good canditate to be removed from the prims and become a macro like OTP.
   # TODO(#27042): When this is done, it should be removed from this mapping.
   "lowrisc:prim:flash": "lowrisc:prim_generic:flash"

--- a/hw/ip/prim_generic/prim_generic_inv.core
+++ b/hw/ip/prim_generic/prim_generic_inv.core
@@ -1,0 +1,38 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_generic:inv"
+description: "inverter"
+virtual:
+  - lowrisc:prim:inv
+
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_inv.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim_generic/rtl/prim_inv.sv
+++ b/hw/ip/prim_generic/rtl/prim_inv.sv
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+module prim_inv #(
+  parameter int Width = 1
+) (
+  input  logic [Width-1:0] in_i,
+  output logic [Width-1:0] out_o
+);
+
+  assign out_o = ~in_i;
+
+endmodule

--- a/hw/ip/prim_xilinx/prim_xilinx.core
+++ b/hw/ip/prim_xilinx/prim_xilinx.core
@@ -32,6 +32,7 @@ filesets:
       - lowrisc:prim_generic:usb_diff_rx
       - lowrisc:prim_xilinx:xnor2
       - lowrisc:prim_xilinx:xor2
+      - lowrisc:prim_xilinx:inv
 # Note that flash is a macro that depends on IPs, so they are not
 # included here. They must be brought in explicitly.
 #      - lowrisc:prim_generic:flash
@@ -60,6 +61,7 @@ mapping:
   "lowrisc:prim:usb_diff_rx"  : lowrisc:prim_generic:usb_diff_rx
   "lowrisc:prim:xnor2"        : lowrisc:prim_xilinx:xnor2
   "lowrisc:prim:xor2"         : lowrisc:prim_xilinx:xor2
+  "lowrisc:prim:inv"          : lowrisc:prim_xilinx:inv
   # Flash is a good canditate to be removed from the prims and become a macro like OTP.
   # When this is done, it should be removed from this mapping.
   "lowrisc:prim:flash": "lowrisc:prim_generic:flash"

--- a/hw/ip/prim_xilinx/prim_xilinx_inv.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_inv.core
@@ -1,0 +1,40 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_xilinx:inv"
+description: "Xilinx inverter"
+virtual:
+  - lowrisc:prim:inv
+
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_inv.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim_xilinx/rtl/prim_inv.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_inv.sv
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Prevent Vivado from performing optimizations on/across this module.
+(* DONT_TOUCH = "yes" *)
+module prim_inv #(
+  parameter int Width = 1
+) (
+  input  logic [Width-1:0] in_i,
+  output logic [Width-1:0] out_o
+);
+
+  assign out_o = ~in_i;
+
+endmodule

--- a/hw/ip/prim_xilinx_ultrascale/prim_xilinx_ultrascale.core
+++ b/hw/ip/prim_xilinx_ultrascale/prim_xilinx_ultrascale.core
@@ -32,6 +32,7 @@ filesets:
       - lowrisc:prim_generic:usb_diff_rx
       - lowrisc:prim_xilinx:xnor2
       - lowrisc:prim_xilinx:xor2
+      - lowrisc:prim_xilinx:inv
 # Note that flash is a macro that depends on IPs, so they are not
 # included here. They must be brought in explicitly.
 #      - lowrisc:prim_generic:flash
@@ -60,6 +61,7 @@ mapping:
   "lowrisc:prim:usb_diff_rx"  : lowrisc:prim_generic:usb_diff_rx
   "lowrisc:prim:xnor2"        : lowrisc:prim_xilinx:xnor2
   "lowrisc:prim:xor2"         : lowrisc:prim_xilinx:xor2
+  "lowrisc:prim:inv"          : lowrisc:prim_xilinx:inv
   # Flash is a good canditate to be removed from the prims and become a macro like OTP.
   # When this is done, it should be removed from this mapping.
   "lowrisc:prim:flash": "lowrisc:prim_generic:flash"

--- a/hw/ip/prim_xilinx_ultrascale/prim_xilinx_ultrascale_inv.core
+++ b/hw/ip/prim_xilinx_ultrascale/prim_xilinx_ultrascale_inv.core
@@ -1,0 +1,40 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_xilinx_ultrascale:inv"
+description: "Xilinx inverter"
+virtual:
+  - lowrisc:prim:inv
+
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_inv.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim_xilinx_ultrascale/rtl/prim_inv.sv
+++ b/hw/ip/prim_xilinx_ultrascale/rtl/prim_inv.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+// Prevent Vivado from performing optimizations on/across this module.
+(* DONT_TOUCH = "yes" *)
+module prim_inv #(
+  parameter int Width = 1
+) (
+  input  logic [Width-1:0] in_i,
+  output logic [Width-1:0] out_o
+);
+
+  assign out_o = ~in_i;
+
+endmodule

--- a/util/design/check-netlist.py
+++ b/util/design/check-netlist.py
@@ -21,7 +21,7 @@ def hr(char: str) -> None:
 class Parser:
     # List of patterns we want to use for finding size_only constraints.
     size_only_patterns = [
-        "u_size_only",
+        "u_size_only", "u_size_only_inv",
         "u_size_only_xor", "u_size_only_xnor", "u_size_only_and",
         "u_size_only_mux", "u_size_only_flop", "u_size_only_buf",
         "u_size_only_tie", "u_size_only_clock_gate"


### PR DESCRIPTION
This PR adds a new inverter prim which can be used to instantiate an inverter with a directive that tells synthesis to not touch this primitive.