### PR TITLE
[silicon_creator] Fix warning about missing default label in `rom_ext_upgrade_interrupt.c`

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/rom_ext_upgrade_interrupt/rom_ext_upgrade_interrupt.c
+++ b/sw/device/silicon_creator/rom/e2e/rom_ext_upgrade_interrupt/rom_ext_upgrade_interrupt.c
@@ -134,6 +134,7 @@ bool test_main(void) {
 
       return status_ok(result);
     }
+    default:
+      return false;
   }
-  return false;
 }


### PR DESCRIPTION
One more fix for `-Wswitch-default` that newer Clang versions complain about.