### PR TITLE
[jtag,dv] Make jtag_dtm_reg_adapter a bit more local

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_agent.sv
+++ b/hw/dv/sv/jtag_agent/jtag_agent.sv
@@ -30,8 +30,17 @@ class jtag_agent extends dv_base_agent #(
     end
 
     if (cfg.is_active) begin
+      uvm_reg_map maps[$];
+      cfg.jtag_dtm_ral.get_maps(maps);
+      if (maps.size() != 1) begin
+        `uvm_fatal(get_full_name(),
+                   $sformatf("Cannot create JTAG DTM reg adapter: there are %0d reg maps.",
+                             maps.size()))
+      end
+
       m_jtag_dtm_reg_adapter = jtag_dtm_reg_adapter::type_id::create("m_jtag_dtm_reg_adapter");
-      m_jtag_dtm_reg_adapter.cfg = cfg;
+      m_jtag_dtm_reg_adapter.set_ir_len(cfg.ir_len);
+      m_jtag_dtm_reg_adapter.set_reg_map(maps[0]);
     end
   endfunction
 

--- a/hw/dv/sv/jtag_agent/jtag_dtm_reg_adapter.sv
+++ b/hw/dv/sv/jtag_agent/jtag_dtm_reg_adapter.sv
@@ -6,9 +6,11 @@
 class jtag_dtm_reg_adapter extends uvm_reg_adapter;
   `uvm_object_utils(jtag_dtm_reg_adapter)
 
-  // Ensure that when an instance of this adapter is created, the cfg handle below is initialized
-  // to the `jtag_agent_cfg` instance associated with this adapter instance.
-  jtag_agent_cfg cfg;
+  // Used when producing bus items for reads. See notes above set_reg_block() for details.
+  local uvm_reg_map m_reg_map;
+
+  // IR length to use in transactions. Set this with set_ir_len.
+  local int unsigned m_ir_len;
 
   function new(string name = "");
     super.new(name);
@@ -19,37 +21,76 @@ class jtag_dtm_reg_adapter extends uvm_reg_adapter;
     `DV_CHECK_GE_FATAL(`UVM_REG_DATA_WIDTH, JTAG_DRW)
   endfunction
 
+  // Pass a handle to a uvm_reg_map that represents the DTM registers. This will be used by the
+  // register adapter to generate bus items that represent register reads (in reg2bus). The tricky
+  // thing is that the only way to read a register over JTAG is to write something to it and then
+  // see the DR that comes out. In order for the stimulus to have as little impact as possible, this
+  // model allows a sequence to write the value that we currently believe is in the register.
+  //
+  // If there is no such map available, reg2bus will send a DR of zero to read a register.
+  function void set_reg_map(uvm_reg_map reg_map);
+    m_reg_map = reg_map;
+  endfunction
+
+  // Set the IR length to use for transactions
+  function void set_ir_len(int unsigned ir_len);
+    if (!ir_len) `uvm_fatal(get_name(), "ir_len must be greater than zero.")
+    m_ir_len = ir_len;
+  endfunction
+
   function uvm_sequence_item reg2bus(const ref uvm_reg_bus_op rw);
     jtag_item req;
     logic [JTAG_DRW-1:0] data;
-    // Per JTAG protocol, the DR is simultaneously written and read at the same time. That means, if
-    // we want to read a register, we need to write its DR with the same value we wrote before, to
-    // read it back. Otherwise, we will end up inadvertently writing 0s to it when reading it. To do
-    // so, we find the mirrored value of the register and set that to DR. Unfortunately, we do not
-    // know which map is associated with this adapter, so this does not support a multi-map system
-    // at this point.
-    if (rw.kind == UVM_READ) begin
-      jtag_dtm_base_reg rg;
-      uvm_reg_map maps[$];
-      cfg.jtag_dtm_ral.get_maps(maps);
-      `DV_CHECK_EQ_FATAL(maps.size(), 1, $sformatf("Multiple maps in RAL %0s is not supported",
-                                                   cfg.jtag_dtm_ral.get_full_name()))
-      `downcast(rg, maps[0].get_reg_by_offset(rw.addr))
-      data = rg.get_wdata_for_read();
-    end else begin
-      data = rw.data[JTAG_DRW-1:0];
-    end
+
+    data = (rw.kind == UVM_READ) ? get_wdata_for_read(rw.addr) : rw.data[JTAG_DRW-1:0];
 
     req = jtag_item::type_id::create("req");
-    `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
-        ir_len == cfg.ir_len;
-        ir     == rw.addr[JTAG_IRW-1:0];
-        dr_len == rw.n_bits;
-        dr     == local::data;
-        bus_op == (rw.kind == UVM_WRITE) ? dv_utils_pkg::BusOpWrite : dv_utils_pkg::BusOpRead;
-        skip_reselected_ir == 1;)
+    if (!req.randomize() with {
+          ir_len == m_ir_len;
+          ir     == rw.addr[JTAG_IRW-1:0];
+          dr_len == rw.n_bits;
+          dr     == local::data;
+          bus_op == (rw.kind == UVM_WRITE) ? dv_utils_pkg::BusOpWrite : dv_utils_pkg::BusOpRead;
+          skip_reselected_ir == 1;
+        }) begin
+      `uvm_fatal(get_name(), "Failed to randomize JTAG item.")
+    end
     `uvm_info(`gfn, $sformatf("reg2bus: %0s", req.sprint(uvm_default_line_printer)), UVM_HIGH)
     return req;
+  endfunction
+
+  // Get the value to send in DR that we believe is least likely to alter the current value of a
+  // register at addr. See notes above set_reg_map for more information.
+  local function uvm_reg_data_t get_wdata_for_read(uvm_reg_addr_t addr);
+    uvm_reg           base_reg;
+    jtag_dtm_base_reg dtm_reg;
+
+    if (m_reg_map == null) begin
+      // We don't seem to have a register map, so have no way to know whether there is a register at
+      // addr. This is a user error: the adapter should have been given a reg map before being used.
+      `uvm_error(get_name(), "A JTAG register adapter needs a reg_map to predict wdata for reads.")
+      return 0;
+    end
+
+    base_reg = m_reg_map.get_reg_by_offset(addr);
+    if (base_reg == null) begin
+      // If we don't believe there is a register at addr, that's fine: we don't expect the access to
+      // work, but it doesn't really matter what to send in DR.
+      `uvm_info(get_name(), "Picking wdata of zero for read with no known register.", UVM_HIGH)
+      return 0;
+    end
+
+    if (!$cast(dtm_reg, base_reg)) begin
+      // jtag_agent assumes that it will only access registers that are the special class
+      // jtag_dtm_base_reg (and therefore have a get_wdata_for_read function). We don't support
+      // arbitrary uvm_reg objects.
+      `uvm_error(get_name(),
+                 $sformatf("Cannot predict wdata for read of %0s: it is not a jtag_dtm_base_reg.",
+                           base_reg.get_name()))
+      return 0;
+    end
+
+    return dtm_reg.get_wdata_for_read();
   endfunction
 
   function void bus2reg(uvm_sequence_item bus_item, ref uvm_reg_bus_op rw);


### PR DESCRIPTION
The object doesn't really need a complete jtag_agent_cfg object: it just needs ir_len and the reg_map.

These now get passed explicitly in jtag_agent::build_phase.

The motivation for this is that I'd like to move the register model out of jtag_agent, but that will be a follow-up commit.