### PR TITLE
[crypto/test] Fix the gcm timing test

### DIFF
--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -217,20 +217,16 @@ opentitan_test(
     name = "aes_gcm_timing_functest",
     srcs = ["aes_gcm_timing_functest.c"],
     exec_env = CRYPTOTEST_EXEC_ENVS,
-    fpga = fpga_params(
-        timeout = "long",
-        tags = ["broken"],
-    ),
     verilator = verilator_params(
         timeout = "long",
         tags = ["broken"],
     ),
     deps = [
-        ":aes_gcm_testutils",
         ":aes_gcm_testvectors",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl/aes_gcm",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:profile",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
@@ -1352,6 +1348,7 @@ test_suite(
     tests = [
         ":aes_functest",
         ":aes_gcm_functest",
+        ":aes_gcm_timing_functest",
         ":aes_kwp_functest",
         ":aes_kwp_kat_functest",
         ":aes_kwp_sideload_functest",

--- a/sw/device/tests/crypto/aes_gcm_timing_functest.c
+++ b/sw/device/tests/crypto/aes_gcm_timing_functest.c
@@ -9,9 +9,9 @@
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/profile.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
-#include "sw/device/tests/crypto/aes_gcm_testutils.h"
 #include "sw/device/tests/crypto/aes_gcm_testvectors.h"
 
 // Global pointer to the current test vector.
@@ -36,48 +36,64 @@ static status_t test_decrypt_timing(void) {
             "Tag length %d is not a multiple of the word size (%d).",
             current_test->tag_len, sizeof(uint32_t));
 
-  // Call AES-GCM decrypt with an incorrect tag (first word wrong).
-  current_test->tag[0]++;
-  uint32_t cycles_invalid1;
+  // Construct the internal AES key representation.
+  uint32_t dummy_share[8] = {0};
+  aes_key_t aes_key = {
+      .mode = kAesCipherModeCtr,
+      .key_len = current_test->key_len,
+      .key_shares = {(uint32_t *)current_test->key, dummy_share},
+      .sideload = kHardenedBoolFalse,
+  };
+  aes_key.checksum = aes_key_integrity_checksum(&aes_key);
+
+  // Initialize the internal base context.
+  aes_gcm_context_t base_ctx;
+  size_t iv_num_words = current_test->iv_len / sizeof(uint32_t);
+
+  TRY(aes_gcm_decrypt_init(aes_key, iv_num_words, (uint32_t *)current_test->iv,
+                           &base_ctx));
+
+  aes_gcm_context_t test_ctx;
+  size_t output_len;
+  uint8_t dummy_output[16];
   hardened_bool_t valid;
-  TRY(aes_gcm_testutils_decrypt(current_test, &valid, /*streaming=*/false,
-                                &cycles_invalid1));
-  TRY_CHECK(valid == kHardenedBoolFalse);
-  current_test->tag[0]--;
-  LOG_INFO("First invalid tag: %d cycles", cycles_invalid1);
+  uint32_t cycles[3];
 
-  // Call AES-GCM decrypt with an incorrect tag (middle word wrong).
-  current_test->tag[tag_num_words / 2]++;
-  uint32_t cycles_invalid2;
-  TRY(aes_gcm_testutils_decrypt(current_test, &valid, /*streaming=*/false,
-                                &cycles_invalid2));
-  TRY_CHECK(valid == kHardenedBoolFalse);
-  current_test->tag[tag_num_words / 2]--;
-  LOG_INFO("Second invalid tag: %d cycles", cycles_invalid2);
+  // We test the first word, the middle word, and the last word.
+  size_t wrong_word_indices[3] = {0, tag_num_words / 2, tag_num_words - 1};
 
-  // Call AES-GCM decrypt with an incorrect tag (last word wrong).
-  current_test->tag[tag_num_words - 1]++;
-  uint32_t cycles_invalid3;
-  TRY(aes_gcm_testutils_decrypt(current_test, &valid, /*streaming=*/false,
-                                &cycles_invalid3));
-  TRY_CHECK(valid == kHardenedBoolFalse);
-  current_test->tag[tag_num_words - 1]--;
-  LOG_INFO("Third invalid tag: %d cycles", cycles_invalid3);
+  // Run in a loop to guarantee the same behaviour each time.
+  for (size_t i = 0; i < 3; i++) {
+    size_t idx = wrong_word_indices[i];
+    memcpy(&test_ctx, &base_ctx, sizeof(aes_gcm_context_t));
 
-  // Check that the cycle counts for the invalid tags match.
+    current_test->tag[idx]++;
+
+    uint64_t t_start = profile_start();
+    aes_gcm_decrypt_final(&test_ctx, tag_num_words,
+                          (uint32_t *)current_test->tag, &output_len,
+                          dummy_output, &valid);
+    cycles[i] = profile_end(t_start);
+
+    TRY_CHECK(valid == kHardenedBoolFalse);
+    current_test->tag[idx]--;
+    LOG_INFO("Invalid tag at word %d: %d cycles", idx, cycles[i]);
+  }
+
+  // Check that the cycle counts for the invalid tags match exactly.
   TRY_CHECK(
-      cycles_invalid1 == cycles_invalid2,
+      cycles[0] == cycles[1],
       "AES-GCM decryption was not constant-time for different invalid tags");
   TRY_CHECK(
-      cycles_invalid2 == cycles_invalid3,
+      cycles[1] == cycles[2],
       "AES-GCM decryption was not constant-time for different invalid tags");
   return OK_STATUS();
 }
 
 OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
-  status_t result;
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelHigh));
+  status_t result = OK_STATUS();
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
   hardened_bool_t icache_enabled;
   CHECK_STATUS_OK(otcrypto_disable_icache(&icache_enabled));
   for (size_t i = 0; i < ARRAYSIZE(kAesGcmTestvectors); i++) {


### PR DESCRIPTION
Call into the internal functions of the gcm to test whether they are constant time depending on invalid tags.
Essentially this test just verifies that memeq is constant time.