### PR TITLE
[crypto] Add const modifier to const buffers

### DIFF
--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -234,7 +234,7 @@ static status_t num_padded_blocks_get(size_t plaintext_len,
  * @param padding Padding mode.
  * @returns Number of AES blocks required.
  */
-static status_t get_block(otcrypto_const_byte_buf_t *input,
+static status_t get_block(const otcrypto_const_byte_buf_t *input,
                           otcrypto_aes_padding_t padding, size_t index,
                           aes_block_t *block) {
   size_t num_full_blocks = input->len / kAesBlockNumBytes;
@@ -300,8 +300,8 @@ otcrypto_status_t otcrypto_aes_padded_plaintext_length(
 static otcrypto_status_t otcrypto_aes_impl(
     otcrypto_blinded_key_t *key, otcrypto_word32_buf_t *iv,
     otcrypto_aes_mode_t aes_mode, otcrypto_aes_operation_t aes_operation,
-    otcrypto_const_byte_buf_t *cipher_input, otcrypto_aes_padding_t aes_padding,
-    otcrypto_byte_buf_t *cipher_output) {
+    const otcrypto_const_byte_buf_t *cipher_input,
+    otcrypto_aes_padding_t aes_padding, otcrypto_byte_buf_t *cipher_output) {
   // Check for NULL pointers in input pointers and data buffers.
   if (key == NULL || (aes_mode != kOtcryptoAesModeEcb && iv->data == NULL) ||
       cipher_input->data == NULL || cipher_output->data == NULL) {
@@ -550,7 +550,7 @@ otcrypto_status_t otcrypto_aes(otcrypto_blinded_key_t *key,
                                otcrypto_word32_buf_t *iv,
                                otcrypto_aes_mode_t aes_mode,
                                otcrypto_aes_operation_t aes_operation,
-                               otcrypto_const_byte_buf_t *cipher_input,
+                               const otcrypto_const_byte_buf_t *cipher_input,
                                otcrypto_aes_padding_t aes_padding,
                                otcrypto_byte_buf_t *cipher_output) {
   // Check for NULL pointers in input pointers and data buffers.

--- a/sw/device/lib/crypto/impl/aes_gcm.c
+++ b/sw/device/lib/crypto/impl/aes_gcm.c
@@ -279,13 +279,11 @@ static status_t clear_key_if_sideloaded(const aes_key_t key) {
   return keymgr_sideload_clear_aes();
 }
 
-otcrypto_status_t otcrypto_aes_gcm_encrypt(otcrypto_blinded_key_t *key,
-                                           otcrypto_const_byte_buf_t *plaintext,
-                                           otcrypto_const_word32_buf_t *iv,
-                                           otcrypto_const_byte_buf_t *aad,
-                                           otcrypto_aes_gcm_tag_len_t tag_len,
-                                           otcrypto_byte_buf_t *ciphertext,
-                                           otcrypto_word32_buf_t *auth_tag) {
+otcrypto_status_t otcrypto_aes_gcm_encrypt(
+    otcrypto_blinded_key_t *key, const otcrypto_const_byte_buf_t *plaintext,
+    const otcrypto_const_word32_buf_t *iv, const otcrypto_const_byte_buf_t *aad,
+    otcrypto_aes_gcm_tag_len_t tag_len, otcrypto_byte_buf_t *ciphertext,
+    otcrypto_word32_buf_t *auth_tag) {
   // Check for NULL pointers in input pointers and required-nonzero-length data
   // buffers.
   if (key == NULL || iv->data == NULL || auth_tag->data == NULL) {
@@ -336,10 +334,11 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt(otcrypto_blinded_key_t *key,
 }
 
 otcrypto_status_t otcrypto_aes_gcm_decrypt(
-    otcrypto_blinded_key_t *key, otcrypto_const_byte_buf_t *ciphertext,
-    otcrypto_const_word32_buf_t *iv, otcrypto_const_byte_buf_t *aad,
-    otcrypto_aes_gcm_tag_len_t tag_len, otcrypto_const_word32_buf_t *auth_tag,
-    otcrypto_byte_buf_t *plaintext, hardened_bool_t *success) {
+    otcrypto_blinded_key_t *key, const otcrypto_const_byte_buf_t *ciphertext,
+    const otcrypto_const_word32_buf_t *iv, const otcrypto_const_byte_buf_t *aad,
+    otcrypto_aes_gcm_tag_len_t tag_len,
+    const otcrypto_const_word32_buf_t *auth_tag, otcrypto_byte_buf_t *plaintext,
+    hardened_bool_t *success) {
   // Check for NULL pointers in input pointers and required-nonzero-length data
   // buffers.
   if (key == NULL || iv->data == NULL || auth_tag->data == NULL) {
@@ -387,7 +386,7 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt(
 }
 
 otcrypto_status_t otcrypto_aes_gcm_encrypt_init(
-    otcrypto_blinded_key_t *key, otcrypto_const_word32_buf_t *iv,
+    otcrypto_blinded_key_t *key, const otcrypto_const_word32_buf_t *iv,
     otcrypto_aes_gcm_context_t *ctx) {
   if (key == NULL || key->keyblob == NULL || iv->data == NULL || ctx == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -414,7 +413,7 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_init(
 }
 
 otcrypto_status_t otcrypto_aes_gcm_decrypt_init(
-    otcrypto_blinded_key_t *key, otcrypto_const_word32_buf_t *iv,
+    otcrypto_blinded_key_t *key, const otcrypto_const_word32_buf_t *iv,
     otcrypto_aes_gcm_context_t *ctx) {
   if (key == NULL || key->keyblob == NULL || iv->data == NULL || ctx == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -440,8 +439,8 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt_init(
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
-otcrypto_status_t otcrypto_aes_gcm_update_aad(otcrypto_aes_gcm_context_t *ctx,
-                                              otcrypto_const_byte_buf_t *aad) {
+otcrypto_status_t otcrypto_aes_gcm_update_aad(
+    otcrypto_aes_gcm_context_t *ctx, const otcrypto_const_byte_buf_t *aad) {
   if (ctx == NULL || aad->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -470,7 +469,7 @@ otcrypto_status_t otcrypto_aes_gcm_update_aad(otcrypto_aes_gcm_context_t *ctx,
 }
 
 otcrypto_status_t otcrypto_aes_gcm_update_encrypted_data(
-    otcrypto_aes_gcm_context_t *ctx, otcrypto_const_byte_buf_t *input,
+    otcrypto_aes_gcm_context_t *ctx, const otcrypto_const_byte_buf_t *input,
     otcrypto_byte_buf_t *output, size_t *output_bytes_written) {
   if (ctx == NULL || input->data == NULL || output->data == NULL ||
       output_bytes_written == NULL) {
@@ -569,7 +568,8 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_final(
 }
 
 otcrypto_status_t otcrypto_aes_gcm_decrypt_final(
-    otcrypto_aes_gcm_context_t *ctx, otcrypto_const_word32_buf_t *auth_tag,
+    otcrypto_aes_gcm_context_t *ctx,
+    const otcrypto_const_word32_buf_t *auth_tag,
     otcrypto_aes_gcm_tag_len_t tag_len, otcrypto_byte_buf_t *plaintext,
     size_t *plaintext_bytes_written, hardened_bool_t *success) {
   if (ctx == NULL || plaintext_bytes_written == NULL ||

--- a/sw/device/lib/crypto/impl/drbg.c
+++ b/sw/device/lib/crypto/impl/drbg.c
@@ -29,7 +29,8 @@
  * @return OK or error.
  */
 static status_t seed_material_construct(
-    otcrypto_const_byte_buf_t *value, entropy_seed_material_t *seed_material) {
+    const otcrypto_const_byte_buf_t *value,
+    entropy_seed_material_t *seed_material) {
   if (value->len > kEntropySeedBytes) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -78,7 +79,8 @@ static status_t seed_material_construct(
  * @return OK or error.
  */
 static otcrypto_status_t seed_material_xor(
-    otcrypto_const_byte_buf_t *value, entropy_seed_material_t *seed_material) {
+    const otcrypto_const_byte_buf_t *value,
+    entropy_seed_material_t *seed_material) {
   if (value->len > kEntropySeedBytes) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -105,7 +107,7 @@ static otcrypto_status_t seed_material_xor(
 }
 
 otcrypto_status_t otcrypto_drbg_instantiate(
-    otcrypto_const_byte_buf_t *perso_string) {
+    const otcrypto_const_byte_buf_t *perso_string) {
   // Check for NULL pointers or bad length.
   if (perso_string->len != 0 && perso_string->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -122,7 +124,7 @@ otcrypto_status_t otcrypto_drbg_instantiate(
 }
 
 otcrypto_status_t otcrypto_drbg_reseed(
-    otcrypto_const_byte_buf_t *additional_input) {
+    const otcrypto_const_byte_buf_t *additional_input) {
   // Check for NULL pointers or bad length.
   if (additional_input->len != 0 && additional_input->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -138,8 +140,8 @@ otcrypto_status_t otcrypto_drbg_reseed(
 }
 
 otcrypto_status_t otcrypto_drbg_manual_instantiate(
-    otcrypto_const_byte_buf_t *entropy,
-    otcrypto_const_byte_buf_t *perso_string) {
+    const otcrypto_const_byte_buf_t *entropy,
+    const otcrypto_const_byte_buf_t *perso_string) {
   // Check for NULL pointers or bad length.
   if (perso_string->len != 0 && perso_string->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -159,8 +161,8 @@ otcrypto_status_t otcrypto_drbg_manual_instantiate(
 }
 
 otcrypto_status_t otcrypto_drbg_manual_reseed(
-    otcrypto_const_byte_buf_t *entropy,
-    otcrypto_const_byte_buf_t *additional_input) {
+    const otcrypto_const_byte_buf_t *entropy,
+    const otcrypto_const_byte_buf_t *additional_input) {
   // Check for NULL pointers or bad length.
   if (additional_input->len != 0 && additional_input->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -191,9 +193,10 @@ otcrypto_status_t otcrypto_drbg_manual_reseed(
  * @param[out] drbg_output Buffer for output
  * @return Result status; OK or error
  */
-static otcrypto_status_t generate(hardened_bool_t fips_check,
-                                  otcrypto_const_byte_buf_t *additional_input,
-                                  otcrypto_word32_buf_t *drbg_output) {
+static otcrypto_status_t generate(
+    hardened_bool_t fips_check,
+    const otcrypto_const_byte_buf_t *additional_input,
+    otcrypto_word32_buf_t *drbg_output) {
   entropy_seed_material_t seed_material;
   HARDENED_TRY(seed_material_construct(additional_input, &seed_material));
   HARDENED_TRY(entropy_csrng_generate(&seed_material, drbg_output->data,
@@ -203,7 +206,7 @@ static otcrypto_status_t generate(hardened_bool_t fips_check,
 }
 
 otcrypto_status_t otcrypto_drbg_generate(
-    otcrypto_const_byte_buf_t *additional_input,
+    const otcrypto_const_byte_buf_t *additional_input,
     otcrypto_word32_buf_t *drbg_output) {
   if (drbg_output->len == 0) {
     // Nothing to do.
@@ -222,7 +225,7 @@ otcrypto_status_t otcrypto_drbg_generate(
 }
 
 otcrypto_status_t otcrypto_drbg_manual_generate(
-    otcrypto_const_byte_buf_t *additional_input,
+    const otcrypto_const_byte_buf_t *additional_input,
     otcrypto_word32_buf_t *drbg_output) {
   if (drbg_output->len == 0) {
     // Nothing to do.

--- a/sw/device/lib/crypto/impl/ecc/p256.c
+++ b/sw/device/lib/crypto/impl/ecc/p256.c
@@ -203,7 +203,7 @@ status_t p256_sideload_keygen_start(void) {
 }
 
 status_t p256_sideload_attestation_keygen_start(
-    otcrypto_const_word32_buf_t *attestation_seed) {
+    const otcrypto_const_word32_buf_t *attestation_seed) {
   if (launder32(attestation_seed->len) > kDiceAttestationMaxSeedLength) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -354,7 +354,7 @@ status_t p256_ecdsa_sideload_sign_start(
 
 status_t p256_sideload_attestation_sign_start(
     const uint32_t digest[kP256ScalarWords],
-    otcrypto_const_word32_buf_t *attestation_seed) {
+    const otcrypto_const_word32_buf_t *attestation_seed) {
   if (launder32(attestation_seed->len) > kDiceAttestationMaxSeedLength) {
     return OTCRYPTO_BAD_ARGS;
   }

--- a/sw/device/lib/crypto/impl/ecc/p256.h
+++ b/sw/device/lib/crypto/impl/ecc/p256.h
@@ -234,7 +234,7 @@ status_t p256_sideload_keygen_start(void);
  */
 OT_WARN_UNUSED_RESULT
 status_t p256_sideload_attestation_keygen_start(
-    otcrypto_const_word32_buf_t *attestation_seed);
+    const otcrypto_const_word32_buf_t *attestation_seed);
 
 /**
  * Finish an async P-256 sideloaded keypair generation operation on OTBN.
@@ -314,7 +314,7 @@ status_t p256_ecdsa_sideload_sign_start(
 OT_WARN_UNUSED_RESULT
 status_t p256_sideload_attestation_sign_start(
     const uint32_t digest[kP256ScalarWords],
-    otcrypto_const_word32_buf_t *attestation_seed);
+    const otcrypto_const_word32_buf_t *attestation_seed);
 
 /**
  * Finish an async ECDSA/P-256 signature generation operation on OTBN.

--- a/sw/device/lib/crypto/impl/ecc_curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc_curve25519.c
@@ -116,8 +116,8 @@ static status_t reverse_bytecpy(uint8_t *dst, const uint8_t *src, size_t len) {
  */
 static status_t ed25519_message_prehash(
     otcrypto_eddsa_sign_mode_t sign_mode,
-    otcrypto_const_byte_buf_t *input_message, otcrypto_byte_buf_t *message_ph,
-    uint32_t *prehash_buffer) {
+    const otcrypto_const_byte_buf_t *input_message,
+    otcrypto_byte_buf_t *message_ph, uint32_t *prehash_buffer) {
   // Only a message of length zero can have NULL as data.
   if (input_message->data == NULL && input_message->len != 0) {
     return OTCRYPTO_BAD_ARGS;
@@ -245,7 +245,7 @@ otcrypto_status_t otcrypto_ed25519_keygen(
 
 otcrypto_status_t otcrypto_ed25519_sign(
     const otcrypto_unblinded_key_t *private_key,
-    otcrypto_const_byte_buf_t *input_message,
+    const otcrypto_const_byte_buf_t *input_message,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t *signature) {
   // Validate signature buffer
   HARDENED_TRY(ed25519_signature_check(signature));
@@ -290,9 +290,9 @@ otcrypto_status_t otcrypto_ed25519_sign(
 
 otcrypto_status_t otcrypto_ed25519_verify(
     const otcrypto_unblinded_key_t *public_key,
-    otcrypto_const_byte_buf_t *input_message,
+    const otcrypto_const_byte_buf_t *input_message,
     otcrypto_eddsa_sign_mode_t sign_mode,
-    otcrypto_const_word32_buf_t *signature,
+    const otcrypto_const_word32_buf_t *signature,
     hardened_bool_t *verification_result) {
   if (verification_result == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -316,7 +316,7 @@ otcrypto_status_t otcrypto_ed25519_verify(
 otcrypto_status_t otcrypto_ed25519_sign_verify(
     const otcrypto_unblinded_key_t *private_key,
     const otcrypto_unblinded_key_t *public_key,
-    otcrypto_const_byte_buf_t *input_message,
+    const otcrypto_const_byte_buf_t *input_message,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t *signature) {
   // Signature generation.
   HARDENED_TRY(
@@ -378,7 +378,7 @@ otcrypto_status_t otcrypto_ed25519_keygen_async_finalize(
 
 otcrypto_status_t otcrypto_ed25519_sign_part1_async_start(
     const otcrypto_unblinded_key_t *private_key,
-    otcrypto_const_byte_buf_t *input_message_ph,
+    const otcrypto_const_byte_buf_t *input_message_ph,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t *s0,
     otcrypto_word32_buf_t *s1, otcrypto_word32_buf_t *r0,
     otcrypto_word32_buf_t *r1) {
@@ -463,7 +463,7 @@ otcrypto_status_t otcrypto_ed25519_sign_part1_async_start(
 
 otcrypto_status_t otcrypto_ed25519_sign_part2_async_start(
     const otcrypto_unblinded_key_t *private_key,
-    otcrypto_const_byte_buf_t *input_message_ph,
+    const otcrypto_const_byte_buf_t *input_message_ph,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t *signature,
     otcrypto_word32_buf_t *s0, otcrypto_word32_buf_t *s1,
     otcrypto_word32_buf_t *r0, otcrypto_word32_buf_t *r1) {
@@ -544,9 +544,9 @@ otcrypto_status_t otcrypto_ed25519_sign_async_finalize(
 
 otcrypto_status_t otcrypto_ed25519_verify_async_start(
     const otcrypto_unblinded_key_t *public_key,
-    otcrypto_const_byte_buf_t *input_message_ph,
+    const otcrypto_const_byte_buf_t *input_message_ph,
     otcrypto_eddsa_sign_mode_t sign_mode,
-    otcrypto_const_word32_buf_t *signature) {
+    const otcrypto_const_word32_buf_t *signature) {
   // Check the public key.
   HARDENED_TRY(ed25519_key_check(public_key));
 

--- a/sw/device/lib/crypto/impl/ecc_p256.c
+++ b/sw/device/lib/crypto/impl/ecc_p256.c
@@ -192,7 +192,7 @@ otcrypto_status_t otcrypto_ecdsa_p256_keygen(
 
 otcrypto_status_t otcrypto_ecdsa_p256_dice_keygen(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key,
-    otcrypto_const_word32_buf_t *attestation_seed) {
+    const otcrypto_const_word32_buf_t *attestation_seed) {
   HARDENED_TRY(otcrypto_ecdsa_p256_dice_keygen_async_start(private_key,
                                                            attestation_seed));
   return otcrypto_ecdsa_p256_dice_keygen_async_finalize(private_key,
@@ -237,7 +237,7 @@ otcrypto_status_t otcrypto_ecdsa_p256_sign(
 otcrypto_status_t otcrypto_ecdsa_p256_verify(
     const otcrypto_unblinded_key_t *public_key,
     const otcrypto_hash_digest_t message_digest,
-    otcrypto_const_word32_buf_t *signature,
+    const otcrypto_const_word32_buf_t *signature,
     hardened_bool_t *verification_result) {
   if (verification_result == NULL || signature->data == NULL ||
       public_key == NULL || public_key->key == NULL) {
@@ -419,7 +419,7 @@ otcrypto_status_t otcrypto_ecdsa_p256_keygen_async_finalize(
 
 otcrypto_status_t otcrypto_ecdsa_p256_dice_keygen_async_start(
     const otcrypto_blinded_key_t *private_key,
-    otcrypto_const_word32_buf_t *attestation_seed) {
+    const otcrypto_const_word32_buf_t *attestation_seed) {
   if (private_key == NULL || private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -583,7 +583,7 @@ otcrypto_status_t otcrypto_ecdsa_p256_sign_async_finalize(
 otcrypto_status_t otcrypto_ecdsa_p256_dice_sign_async_start(
     const otcrypto_blinded_key_t *private_key,
     const otcrypto_hash_digest_t message_digest,
-    otcrypto_const_word32_buf_t *attestation_seed) {
+    const otcrypto_const_word32_buf_t *attestation_seed) {
   if (private_key == NULL || private_key->keyblob == NULL ||
       message_digest.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -621,7 +621,7 @@ otcrypto_status_t otcrypto_ecdsa_p256_dice_sign_async_finalize(
 otcrypto_status_t otcrypto_ecdsa_p256_verify_async_start(
     const otcrypto_unblinded_key_t *public_key,
     const otcrypto_hash_digest_t message_digest,
-    otcrypto_const_word32_buf_t *signature) {
+    const otcrypto_const_word32_buf_t *signature) {
   if (public_key == NULL || signature->data == NULL ||
       message_digest.data == NULL || public_key->key == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -667,7 +667,7 @@ otcrypto_status_t otcrypto_ecdsa_p256_verify_async_start(
 }
 
 otcrypto_status_t otcrypto_ecdsa_p256_verify_async_finalize(
-    otcrypto_const_word32_buf_t *signature,
+    const otcrypto_const_word32_buf_t *signature,
     hardened_bool_t *verification_result) {
   if (verification_result == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -1021,8 +1021,8 @@ otcrypto_status_t otcrypto_ecc_p256_private_key_export(
 }
 
 otcrypto_status_t otcrypto_ecc_p256_arith_share_private_key(
-    otcrypto_const_word32_buf_t *bool_private_key_share0,
-    otcrypto_const_word32_buf_t *bool_private_key_share1,
+    const otcrypto_const_word32_buf_t *bool_private_key_share0,
+    const otcrypto_const_word32_buf_t *bool_private_key_share1,
     otcrypto_blinded_key_t *arith_private_key) {
   if (bool_private_key_share0 == NULL || bool_private_key_share1 == NULL ||
       arith_private_key == NULL || arith_private_key->keyblob == NULL) {

--- a/sw/device/lib/crypto/impl/ecc_p384.c
+++ b/sw/device/lib/crypto/impl/ecc_p384.c
@@ -273,7 +273,7 @@ otcrypto_status_t otcrypto_ecdsa_p384_sign(
 otcrypto_status_t otcrypto_ecdsa_p384_verify(
     const otcrypto_unblinded_key_t *public_key,
     const otcrypto_hash_digest_t message_digest,
-    otcrypto_const_word32_buf_t *signature,
+    const otcrypto_const_word32_buf_t *signature,
     hardened_bool_t *verification_result) {
   if (verification_result == NULL || signature->data == NULL ||
       public_key == NULL || public_key->key == NULL) {
@@ -544,7 +544,7 @@ otcrypto_status_t otcrypto_ecdsa_p384_sign_async_finalize(
 otcrypto_status_t otcrypto_ecdsa_p384_verify_async_start(
     const otcrypto_unblinded_key_t *public_key,
     const otcrypto_hash_digest_t message_digest,
-    otcrypto_const_word32_buf_t *signature) {
+    const otcrypto_const_word32_buf_t *signature) {
   if (public_key == NULL || signature->data == NULL ||
       message_digest.data == NULL || public_key->key == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -590,7 +590,7 @@ otcrypto_status_t otcrypto_ecdsa_p384_verify_async_start(
 }
 
 otcrypto_status_t otcrypto_ecdsa_p384_verify_async_finalize(
-    otcrypto_const_word32_buf_t *signature,
+    const otcrypto_const_word32_buf_t *signature,
     hardened_bool_t *verification_result) {
   if (verification_result == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -945,8 +945,8 @@ otcrypto_status_t otcrypto_ecc_p384_private_key_export(
 }
 
 otcrypto_status_t otcrypto_ecc_p384_arith_share_private_key(
-    otcrypto_const_word32_buf_t *bool_private_key_share0,
-    otcrypto_const_word32_buf_t *bool_private_key_share1,
+    const otcrypto_const_word32_buf_t *bool_private_key_share0,
+    const otcrypto_const_word32_buf_t *bool_private_key_share1,
     otcrypto_blinded_key_t *arith_private_key) {
   if (bool_private_key_share0 == NULL || bool_private_key_share1 == NULL ||
       arith_private_key == NULL || arith_private_key->keyblob == NULL) {

--- a/sw/device/lib/crypto/impl/hkdf.c
+++ b/sw/device/lib/crypto/impl/hkdf.c
@@ -54,8 +54,8 @@ static status_t digest_num_words_from_key_mode(otcrypto_key_mode_t key_mode,
 }
 
 otcrypto_status_t otcrypto_hkdf(const otcrypto_blinded_key_t *ikm,
-                                otcrypto_const_byte_buf_t *salt,
-                                otcrypto_const_byte_buf_t *info,
+                                const otcrypto_const_byte_buf_t *salt,
+                                const otcrypto_const_byte_buf_t *info,
                                 otcrypto_blinded_key_t *okm) {
   // Infer the digest length.
   size_t digest_wordlen;
@@ -126,7 +126,7 @@ static status_t hkdf_check_prk(size_t digest_words,
 }
 
 otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t *ikm,
-                                        otcrypto_const_byte_buf_t *salt,
+                                        const otcrypto_const_byte_buf_t *salt,
                                         otcrypto_blinded_key_t *prk) {
   // Check for null pointers.
   if (ikm->keyblob == NULL || prk == NULL || prk->keyblob == NULL) {
@@ -226,7 +226,7 @@ otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t *ikm,
 }
 
 otcrypto_status_t otcrypto_hkdf_expand(const otcrypto_blinded_key_t *prk,
-                                       otcrypto_const_byte_buf_t *info,
+                                       const otcrypto_const_byte_buf_t *info,
                                        otcrypto_blinded_key_t *okm) {
   if (okm == NULL || okm->keyblob == NULL || prk->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;

--- a/sw/device/lib/crypto/impl/hmac.c
+++ b/sw/device/lib/crypto/impl/hmac.c
@@ -213,7 +213,7 @@ static status_t check_key(const otcrypto_blinded_key_t *key) {
 
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_hmac(const otcrypto_blinded_key_t *key,
-                                otcrypto_const_byte_buf_t *input_message,
+                                const otcrypto_const_byte_buf_t *input_message,
                                 otcrypto_word32_buf_t *tag) {
   // Check for null pointers.
   if (tag->data == NULL ||

--- a/sw/device/lib/crypto/impl/key_transport.c
+++ b/sw/device/lib/crypto/impl/key_transport.c
@@ -18,7 +18,8 @@
 #define MODULE_ID MAKE_MODULE_ID('k', 't', 'r')
 
 otcrypto_status_t otcrypto_symmetric_keygen(
-    otcrypto_const_byte_buf_t *perso_string, otcrypto_blinded_key_t *key) {
+    const otcrypto_const_byte_buf_t *perso_string,
+    otcrypto_blinded_key_t *key) {
   if (key == NULL || key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -243,10 +244,10 @@ otcrypto_status_t otcrypto_key_wrap(const otcrypto_blinded_key_t *key_to_wrap,
       aes_kwp_wrap(kek, plaintext, sizeof(plaintext), wrapped_key->data));
 }
 
-otcrypto_status_t otcrypto_key_unwrap(otcrypto_const_word32_buf_t *wrapped_key,
-                                      const otcrypto_blinded_key_t *key_kek,
-                                      hardened_bool_t *success,
-                                      otcrypto_blinded_key_t *unwrapped_key) {
+otcrypto_status_t otcrypto_key_unwrap(
+    const otcrypto_const_word32_buf_t *wrapped_key,
+    const otcrypto_blinded_key_t *key_kek, hardened_bool_t *success,
+    otcrypto_blinded_key_t *unwrapped_key) {
   *success = kHardenedBoolFalse;
 
   if (wrapped_key->data == NULL || key_kek == NULL ||

--- a/sw/device/lib/crypto/impl/kmac.c
+++ b/sw/device/lib/crypto/impl/kmac.c
@@ -14,11 +14,10 @@
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('k', 'm', 'c')
 
-otcrypto_status_t otcrypto_kmac(otcrypto_blinded_key_t *key,
-                                otcrypto_const_byte_buf_t *input_message,
-                                otcrypto_const_byte_buf_t *customization_string,
-                                size_t required_output_len,
-                                otcrypto_word32_buf_t *tag) {
+otcrypto_status_t otcrypto_kmac(
+    otcrypto_blinded_key_t *key, const otcrypto_const_byte_buf_t *input_message,
+    const otcrypto_const_byte_buf_t *customization_string,
+    size_t required_output_len, otcrypto_word32_buf_t *tag) {
   // TODO (#16410) Revisit/complete error checks
 
   // Check for null pointers.

--- a/sw/device/lib/crypto/impl/rsa.c
+++ b/sw/device/lib/crypto/impl/rsa.c
@@ -94,7 +94,7 @@ static hardened_bool_t bignum_lt(const uint32_t *a, const uint32_t *b,
 }
 
 otcrypto_status_t otcrypto_rsa_public_key_construct(
-    otcrypto_rsa_size_t size, otcrypto_const_word32_buf_t *modulus,
+    otcrypto_rsa_size_t size, const otcrypto_const_word32_buf_t *modulus,
     otcrypto_unblinded_key_t *public_key) {
   if (modulus->data == NULL || public_key == NULL || public_key->key == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -318,9 +318,9 @@ otcrypto_status_t otcrypto_rsa_keygen(otcrypto_rsa_size_t size,
 }
 
 otcrypto_status_t otcrypto_rsa_private_key_from_exponents(
-    otcrypto_rsa_size_t size, otcrypto_const_word32_buf_t *modulus,
-    otcrypto_const_word32_buf_t *d_share0,
-    otcrypto_const_word32_buf_t *d_share1,
+    otcrypto_rsa_size_t size, const otcrypto_const_word32_buf_t *modulus,
+    const otcrypto_const_word32_buf_t *d_share0,
+    const otcrypto_const_word32_buf_t *d_share1,
     otcrypto_blinded_key_t *private_key) {
   if (modulus->data == NULL || d_share0->data == NULL ||
       d_share1->data == NULL || private_key == NULL ||
@@ -393,9 +393,9 @@ otcrypto_status_t otcrypto_rsa_private_key_from_exponents(
 }
 
 otcrypto_status_t otcrypto_rsa_keypair_from_cofactor(
-    otcrypto_rsa_size_t size, otcrypto_const_word32_buf_t *modulus,
-    otcrypto_const_word32_buf_t *cofactor_share0,
-    otcrypto_const_word32_buf_t *cofactor_share1,
+    otcrypto_rsa_size_t size, const otcrypto_const_word32_buf_t *modulus,
+    const otcrypto_const_word32_buf_t *cofactor_share0,
+    const otcrypto_const_word32_buf_t *cofactor_share1,
     otcrypto_unblinded_key_t *public_key, otcrypto_blinded_key_t *private_key) {
   if (public_key == NULL || public_key->key == NULL || private_key == NULL ||
       private_key->keyblob == NULL) {
@@ -460,7 +460,8 @@ otcrypto_status_t otcrypto_rsa_sign(const otcrypto_blinded_key_t *private_key,
 otcrypto_status_t otcrypto_rsa_verify(
     const otcrypto_unblinded_key_t *public_key,
     const otcrypto_hash_digest_t message_digest,
-    otcrypto_rsa_padding_t padding_mode, otcrypto_const_word32_buf_t *signature,
+    otcrypto_rsa_padding_t padding_mode,
+    const otcrypto_const_word32_buf_t *signature,
     hardened_bool_t *verification_result) {
   if (verification_result == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -477,8 +478,9 @@ otcrypto_status_t otcrypto_rsa_verify(
 
 otcrypto_status_t otcrypto_rsa_encrypt(
     const otcrypto_unblinded_key_t *public_key,
-    const otcrypto_hash_mode_t hash_mode, otcrypto_const_byte_buf_t *message,
-    otcrypto_const_byte_buf_t *label, otcrypto_word32_buf_t *ciphertext) {
+    const otcrypto_hash_mode_t hash_mode,
+    const otcrypto_const_byte_buf_t *message,
+    const otcrypto_const_byte_buf_t *label, otcrypto_word32_buf_t *ciphertext) {
   if (ciphertext->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -490,8 +492,9 @@ otcrypto_status_t otcrypto_rsa_encrypt(
 otcrypto_status_t otcrypto_rsa_decrypt(
     const otcrypto_blinded_key_t *private_key,
     const otcrypto_hash_mode_t hash_mode,
-    otcrypto_const_word32_buf_t *ciphertext, otcrypto_const_byte_buf_t *label,
-    otcrypto_byte_buf_t *plaintext, size_t *plaintext_bytelen) {
+    const otcrypto_const_word32_buf_t *ciphertext,
+    const otcrypto_const_byte_buf_t *label, otcrypto_byte_buf_t *plaintext,
+    size_t *plaintext_bytelen) {
   if (plaintext->data == NULL || plaintext_bytelen == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -581,9 +584,9 @@ otcrypto_status_t otcrypto_rsa_keygen_async_finalize(
 }
 
 otcrypto_status_t otcrypto_rsa_keypair_from_cofactor_async_start(
-    otcrypto_rsa_size_t size, otcrypto_const_word32_buf_t *modulus,
-    otcrypto_const_word32_buf_t *cofactor_share0,
-    otcrypto_const_word32_buf_t *cofactor_share1) {
+    otcrypto_rsa_size_t size, const otcrypto_const_word32_buf_t *modulus,
+    const otcrypto_const_word32_buf_t *cofactor_share0,
+    const otcrypto_const_word32_buf_t *cofactor_share1) {
   if (modulus->data == NULL || cofactor_share0->data == NULL ||
       cofactor_share1->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -821,7 +824,7 @@ otcrypto_status_t otcrypto_rsa_sign_async_finalize(
 
 otcrypto_status_t otcrypto_rsa_verify_async_start(
     const otcrypto_unblinded_key_t *public_key,
-    otcrypto_const_word32_buf_t *signature) {
+    const otcrypto_const_word32_buf_t *signature) {
   // Check for NULL pointers.
   if (public_key == NULL || public_key->key == NULL ||
       signature->data == NULL) {
@@ -924,8 +927,9 @@ otcrypto_status_t otcrypto_rsa_verify_async_finalize(
 
 otcrypto_status_t otcrypto_rsa_encrypt_async_start(
     const otcrypto_unblinded_key_t *public_key,
-    const otcrypto_hash_mode_t hash_mode, otcrypto_const_byte_buf_t *message,
-    otcrypto_const_byte_buf_t *label) {
+    const otcrypto_hash_mode_t hash_mode,
+    const otcrypto_const_byte_buf_t *message,
+    const otcrypto_const_byte_buf_t *label) {
   // Check for NULL pointers.
   if (public_key == NULL || public_key->key == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -1034,7 +1038,7 @@ otcrypto_status_t otcrypto_rsa_encrypt_async_finalize(
 
 otcrypto_status_t otcrypto_rsa_decrypt_async_start(
     const otcrypto_blinded_key_t *private_key,
-    otcrypto_const_word32_buf_t *ciphertext) {
+    const otcrypto_const_word32_buf_t *ciphertext) {
   // Check for NULL pointers.
   if (private_key == NULL || private_key->keyblob == NULL ||
       ciphertext->data == NULL) {
@@ -1135,8 +1139,9 @@ otcrypto_status_t otcrypto_rsa_decrypt_async_start(
 }
 
 otcrypto_status_t otcrypto_rsa_decrypt_async_finalize(
-    const otcrypto_hash_mode_t hash_mode, otcrypto_const_byte_buf_t *label,
-    otcrypto_byte_buf_t *plaintext, size_t *plaintext_bytelen) {
+    const otcrypto_hash_mode_t hash_mode,
+    const otcrypto_const_byte_buf_t *label, otcrypto_byte_buf_t *plaintext,
+    size_t *plaintext_bytelen) {
   if (plaintext->data == NULL || label->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }

--- a/sw/device/lib/crypto/impl/sha2.c
+++ b/sw/device/lib/crypto/impl/sha2.c
@@ -20,7 +20,7 @@ static_assert(
     sizeof(otcrypto_sha2_context_t) == sizeof(hmac_ctx_t),
     "`otcrypto_sha2_context_t` must be the same size as `hmac_ctx_t`.");
 
-otcrypto_status_t otcrypto_sha2_256(otcrypto_const_byte_buf_t *message,
+otcrypto_status_t otcrypto_sha2_256(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest) {
   if (message->data == NULL && message->len != 0) {
     return OTCRYPTO_BAD_ARGS;
@@ -36,7 +36,7 @@ otcrypto_status_t otcrypto_sha2_256(otcrypto_const_byte_buf_t *message,
   return otcrypto_eval_exit(hmac_hash_sha256(message, digest->data));
 }
 
-otcrypto_status_t otcrypto_sha2_384(otcrypto_const_byte_buf_t *message,
+otcrypto_status_t otcrypto_sha2_384(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest) {
   if (message->data == NULL && message->len != 0) {
     return OTCRYPTO_BAD_ARGS;
@@ -52,7 +52,7 @@ otcrypto_status_t otcrypto_sha2_384(otcrypto_const_byte_buf_t *message,
   return otcrypto_eval_exit(hmac_hash_sha384(message, digest->data));
 }
 
-otcrypto_status_t otcrypto_sha2_512(otcrypto_const_byte_buf_t *message,
+otcrypto_status_t otcrypto_sha2_512(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest) {
   if (message->data == NULL && message->len != 0) {
     return OTCRYPTO_BAD_ARGS;
@@ -128,8 +128,8 @@ static status_t check_lengths(hmac_ctx_t *hmac_ctx) {
   return OTCRYPTO_OK;
 }
 
-otcrypto_status_t otcrypto_sha2_update(otcrypto_sha2_context_t *ctx,
-                                       otcrypto_const_byte_buf_t *message) {
+otcrypto_status_t otcrypto_sha2_update(
+    otcrypto_sha2_context_t *ctx, const otcrypto_const_byte_buf_t *message) {
   // Return early if the update size is 0.
   if (message->len == 0) {
     return otcrypto_eval_exit(OTCRYPTO_OK);

--- a/sw/device/lib/crypto/impl/sha3.c
+++ b/sw/device/lib/crypto/impl/sha3.c
@@ -14,7 +14,7 @@
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('s', 'h', '3')
 
-otcrypto_status_t otcrypto_sha3_224(otcrypto_const_byte_buf_t *message,
+otcrypto_status_t otcrypto_sha3_224(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest) {
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -30,7 +30,7 @@ otcrypto_status_t otcrypto_sha3_224(otcrypto_const_byte_buf_t *message,
   return otcrypto_eval_exit(kmac_sha3_224(message, digest->data));
 }
 
-otcrypto_status_t otcrypto_sha3_256(otcrypto_const_byte_buf_t *message,
+otcrypto_status_t otcrypto_sha3_256(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest) {
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -46,7 +46,7 @@ otcrypto_status_t otcrypto_sha3_256(otcrypto_const_byte_buf_t *message,
   return otcrypto_eval_exit(kmac_sha3_256(message, digest->data));
 }
 
-otcrypto_status_t otcrypto_sha3_384(otcrypto_const_byte_buf_t *message,
+otcrypto_status_t otcrypto_sha3_384(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest) {
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -62,7 +62,7 @@ otcrypto_status_t otcrypto_sha3_384(otcrypto_const_byte_buf_t *message,
   return otcrypto_eval_exit(kmac_sha3_384(message, digest->data));
 }
 
-otcrypto_status_t otcrypto_sha3_512(otcrypto_const_byte_buf_t *message,
+otcrypto_status_t otcrypto_sha3_512(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest) {
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -78,7 +78,7 @@ otcrypto_status_t otcrypto_sha3_512(otcrypto_const_byte_buf_t *message,
   return otcrypto_eval_exit(kmac_sha3_512(message, digest->data));
 }
 
-otcrypto_status_t otcrypto_shake128(otcrypto_const_byte_buf_t *message,
+otcrypto_status_t otcrypto_shake128(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest) {
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -90,7 +90,7 @@ otcrypto_status_t otcrypto_shake128(otcrypto_const_byte_buf_t *message,
   return otcrypto_eval_exit(kmac_shake_128(message, digest->data, digest->len));
 }
 
-otcrypto_status_t otcrypto_shake256(otcrypto_const_byte_buf_t *message,
+otcrypto_status_t otcrypto_shake256(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest) {
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -103,9 +103,9 @@ otcrypto_status_t otcrypto_shake256(otcrypto_const_byte_buf_t *message,
 }
 
 otcrypto_status_t otcrypto_cshake128(
-    otcrypto_const_byte_buf_t *message,
-    otcrypto_const_byte_buf_t *function_name_string,
-    otcrypto_const_byte_buf_t *customization_string,
+    const otcrypto_const_byte_buf_t *message,
+    const otcrypto_const_byte_buf_t *function_name_string,
+    const otcrypto_const_byte_buf_t *customization_string,
     otcrypto_hash_digest_t *digest) {
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -127,9 +127,9 @@ otcrypto_status_t otcrypto_cshake128(
 }
 
 otcrypto_status_t otcrypto_cshake256(
-    otcrypto_const_byte_buf_t *message,
-    otcrypto_const_byte_buf_t *function_name_string,
-    otcrypto_const_byte_buf_t *customization_string,
+    const otcrypto_const_byte_buf_t *message,
+    const otcrypto_const_byte_buf_t *function_name_string,
+    const otcrypto_const_byte_buf_t *customization_string,
     otcrypto_hash_digest_t *digest) {
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;

--- a/sw/device/lib/crypto/include/aes.h
+++ b/sw/device/lib/crypto/include/aes.h
@@ -129,7 +129,7 @@ otcrypto_status_t otcrypto_aes(otcrypto_blinded_key_t *key,
                                otcrypto_word32_buf_t *iv,
                                otcrypto_aes_mode_t aes_mode,
                                otcrypto_aes_operation_t aes_operation,
-                               otcrypto_const_byte_buf_t *cipher_input,
+                               const otcrypto_const_byte_buf_t *cipher_input,
                                otcrypto_aes_padding_t aes_padding,
                                otcrypto_byte_buf_t *cipher_output);
 

--- a/sw/device/lib/crypto/include/aes_gcm.h
+++ b/sw/device/lib/crypto/include/aes_gcm.h
@@ -67,13 +67,11 @@ typedef struct otcrypto_aes_gcm_context {
  * @return Result of the authenticated encryption.
  * operation
  */
-otcrypto_status_t otcrypto_aes_gcm_encrypt(otcrypto_blinded_key_t *key,
-                                           otcrypto_const_byte_buf_t *plaintext,
-                                           otcrypto_const_word32_buf_t *iv,
-                                           otcrypto_const_byte_buf_t *aad,
-                                           otcrypto_aes_gcm_tag_len_t tag_len,
-                                           otcrypto_byte_buf_t *ciphertext,
-                                           otcrypto_word32_buf_t *auth_tag);
+otcrypto_status_t otcrypto_aes_gcm_encrypt(
+    otcrypto_blinded_key_t *key, const otcrypto_const_byte_buf_t *plaintext,
+    const otcrypto_const_word32_buf_t *iv, const otcrypto_const_byte_buf_t *aad,
+    otcrypto_aes_gcm_tag_len_t tag_len, otcrypto_byte_buf_t *ciphertext,
+    otcrypto_word32_buf_t *auth_tag);
 
 /**
  * Performs the AES-GCM authenticated decryption operation.
@@ -103,10 +101,11 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt(otcrypto_blinded_key_t *key,
  * operation
  */
 otcrypto_status_t otcrypto_aes_gcm_decrypt(
-    otcrypto_blinded_key_t *key, otcrypto_const_byte_buf_t *ciphertext,
-    otcrypto_const_word32_buf_t *iv, otcrypto_const_byte_buf_t *aad,
-    otcrypto_aes_gcm_tag_len_t tag_len, otcrypto_const_word32_buf_t *auth_tag,
-    otcrypto_byte_buf_t *plaintext, hardened_bool_t *success);
+    otcrypto_blinded_key_t *key, const otcrypto_const_byte_buf_t *ciphertext,
+    const otcrypto_const_word32_buf_t *iv, const otcrypto_const_byte_buf_t *aad,
+    otcrypto_aes_gcm_tag_len_t tag_len,
+    const otcrypto_const_word32_buf_t *auth_tag, otcrypto_byte_buf_t *plaintext,
+    hardened_bool_t *success);
 
 /**
  * Initializes the AES-GCM authenticated encryption operation.
@@ -131,7 +130,7 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt(
  * @return Result of the initialization operation.
  */
 otcrypto_status_t otcrypto_aes_gcm_encrypt_init(
-    otcrypto_blinded_key_t *key, otcrypto_const_word32_buf_t *iv,
+    otcrypto_blinded_key_t *key, const otcrypto_const_word32_buf_t *iv,
     otcrypto_aes_gcm_context_t *ctx);
 
 /**
@@ -161,7 +160,7 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_init(
  * @return Result of the initialization operation.
  */
 otcrypto_status_t otcrypto_aes_gcm_decrypt_init(
-    otcrypto_blinded_key_t *key, otcrypto_const_word32_buf_t *iv,
+    otcrypto_blinded_key_t *key, const otcrypto_const_word32_buf_t *iv,
     otcrypto_aes_gcm_context_t *ctx);
 /**
  * Updates additional authenticated data for an AES-GCM operation.
@@ -173,8 +172,8 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt_init(
  * @param aad Additional authenticated data.
  * @return Result of the update operation.
  */
-otcrypto_status_t otcrypto_aes_gcm_update_aad(otcrypto_aes_gcm_context_t *ctx,
-                                              otcrypto_const_byte_buf_t *aad);
+otcrypto_status_t otcrypto_aes_gcm_update_aad(
+    otcrypto_aes_gcm_context_t *ctx, const otcrypto_const_byte_buf_t *aad);
 
 /**
  * Updates authenticated-and-encrypted data for an AES-GCM operation.
@@ -201,7 +200,7 @@ otcrypto_status_t otcrypto_aes_gcm_update_aad(otcrypto_aes_gcm_context_t *ctx,
  * @return Result of the update operation.
  */
 otcrypto_status_t otcrypto_aes_gcm_update_encrypted_data(
-    otcrypto_aes_gcm_context_t *ctx, otcrypto_const_byte_buf_t *input,
+    otcrypto_aes_gcm_context_t *ctx, const otcrypto_const_byte_buf_t *input,
     otcrypto_byte_buf_t *output, size_t *output_bytes_written);
 
 /**
@@ -252,7 +251,8 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_final(
  * @return Result of the final operation.
  */
 otcrypto_status_t otcrypto_aes_gcm_decrypt_final(
-    otcrypto_aes_gcm_context_t *ctx, otcrypto_const_word32_buf_t *auth_tag,
+    otcrypto_aes_gcm_context_t *ctx,
+    const otcrypto_const_word32_buf_t *auth_tag,
     otcrypto_aes_gcm_tag_len_t tag_len, otcrypto_byte_buf_t *plaintext,
     size_t *plaintext_bytes_written, hardened_bool_t *success);
 

--- a/sw/device/lib/crypto/include/drbg.h
+++ b/sw/device/lib/crypto/include/drbg.h
@@ -31,7 +31,7 @@ extern "C" {
  * @return Result of the DRBG instantiate operation.
  */
 otcrypto_status_t otcrypto_drbg_instantiate(
-    otcrypto_const_byte_buf_t *perso_string);
+    const otcrypto_const_byte_buf_t *perso_string);
 
 /**
  * Reseeds the DRBG with fresh entropy.
@@ -43,7 +43,7 @@ otcrypto_status_t otcrypto_drbg_instantiate(
  * @return Result of the DRBG reseed operation.
  */
 otcrypto_status_t otcrypto_drbg_reseed(
-    otcrypto_const_byte_buf_t *additional_input);
+    const otcrypto_const_byte_buf_t *additional_input);
 
 /**
  * Instantiates the DRBG system.
@@ -63,8 +63,8 @@ otcrypto_status_t otcrypto_drbg_reseed(
  * @return Result of the DRBG manual instantiation.
  */
 otcrypto_status_t otcrypto_drbg_manual_instantiate(
-    otcrypto_const_byte_buf_t *entropy,
-    otcrypto_const_byte_buf_t *perso_string);
+    const otcrypto_const_byte_buf_t *entropy,
+    const otcrypto_const_byte_buf_t *perso_string);
 
 /**
  * Reseeds the DRBG with fresh entropy.
@@ -78,8 +78,8 @@ otcrypto_status_t otcrypto_drbg_manual_instantiate(
  * @return Result of the manual DRBG reseed operation.
  */
 otcrypto_status_t otcrypto_drbg_manual_reseed(
-    otcrypto_const_byte_buf_t *entropy,
-    otcrypto_const_byte_buf_t *additional_input);
+    const otcrypto_const_byte_buf_t *entropy,
+    const otcrypto_const_byte_buf_t *additional_input);
 
 /**
  * DRBG function for generating random bits.
@@ -100,7 +100,7 @@ otcrypto_status_t otcrypto_drbg_manual_reseed(
  * @return Result of the DRBG generate operation.
  */
 otcrypto_status_t otcrypto_drbg_generate(
-    otcrypto_const_byte_buf_t *additional_input,
+    const otcrypto_const_byte_buf_t *additional_input,
     otcrypto_word32_buf_t *drbg_output);
 
 /**
@@ -122,7 +122,7 @@ otcrypto_status_t otcrypto_drbg_generate(
  * @return Result of the DRBG generate operation.
  */
 otcrypto_status_t otcrypto_drbg_manual_generate(
-    otcrypto_const_byte_buf_t *additional_input,
+    const otcrypto_const_byte_buf_t *additional_input,
     otcrypto_word32_buf_t *drbg_output);
 
 /**

--- a/sw/device/lib/crypto/include/ecc_curve25519.h
+++ b/sw/device/lib/crypto/include/ecc_curve25519.h
@@ -59,7 +59,7 @@ otcrypto_status_t otcrypto_ed25519_keygen(
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ed25519_sign(
     const otcrypto_unblinded_key_t *private_key,
-    otcrypto_const_byte_buf_t *input_message,
+    const otcrypto_const_byte_buf_t *input_message,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t *signature);
 
 /**
@@ -80,9 +80,9 @@ otcrypto_status_t otcrypto_ed25519_sign(
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ed25519_verify(
     const otcrypto_unblinded_key_t *public_key,
-    otcrypto_const_byte_buf_t *input_message,
+    const otcrypto_const_byte_buf_t *input_message,
     otcrypto_eddsa_sign_mode_t sign_mode,
-    otcrypto_const_word32_buf_t *signature,
+    const otcrypto_const_word32_buf_t *signature,
     hardened_bool_t *verification_result);
 
 /**
@@ -100,7 +100,7 @@ OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ed25519_sign_verify(
     const otcrypto_unblinded_key_t *private_key,
     const otcrypto_unblinded_key_t *public_key,
-    otcrypto_const_byte_buf_t *input_message,
+    const otcrypto_const_byte_buf_t *input_message,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t *signature);
 
 /**
@@ -147,7 +147,7 @@ otcrypto_status_t otcrypto_ed25519_keygen_async_finalize(
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ed25519_sign_part1_async_start(
     const otcrypto_unblinded_key_t *private_key,
-    otcrypto_const_byte_buf_t *input_message_ph,
+    const otcrypto_const_byte_buf_t *input_message_ph,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t *s0,
     otcrypto_word32_buf_t *s1, otcrypto_word32_buf_t *r0,
     otcrypto_word32_buf_t *r1);
@@ -170,7 +170,7 @@ otcrypto_status_t otcrypto_ed25519_sign_part1_async_start(
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ed25519_sign_part2_async_start(
     const otcrypto_unblinded_key_t *private_key,
-    otcrypto_const_byte_buf_t *input_message_ph,
+    const otcrypto_const_byte_buf_t *input_message_ph,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t *signature,
     otcrypto_word32_buf_t *s0, otcrypto_word32_buf_t *s1,
     otcrypto_word32_buf_t *r0, otcrypto_word32_buf_t *r1);
@@ -205,9 +205,9 @@ otcrypto_status_t otcrypto_ed25519_sign_async_finalize(
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ed25519_verify_async_start(
     const otcrypto_unblinded_key_t *public_key,
-    otcrypto_const_byte_buf_t *input_message_ph,
+    const otcrypto_const_byte_buf_t *input_message_ph,
     otcrypto_eddsa_sign_mode_t sign_mode,
-    otcrypto_const_word32_buf_t *signature);
+    const otcrypto_const_word32_buf_t *signature);
 
 /**
  * Finalizes asynchronous signature verification for Ed25519.

--- a/sw/device/lib/crypto/include/ecc_p256.h
+++ b/sw/device/lib/crypto/include/ecc_p256.h
@@ -51,7 +51,7 @@ otcrypto_status_t otcrypto_ecdsa_p256_keygen(
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ecdsa_p256_dice_keygen(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key,
-    otcrypto_const_word32_buf_t *attestation_seed);
+    const otcrypto_const_word32_buf_t *attestation_seed);
 
 /**
  * Generates an ECDSA signature with curve P-256.
@@ -144,7 +144,7 @@ OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ecdsa_p256_verify(
     const otcrypto_unblinded_key_t *public_key,
     const otcrypto_hash_digest_t message_digest,
-    otcrypto_const_word32_buf_t *signature,
+    const otcrypto_const_word32_buf_t *signature,
     hardened_bool_t *verification_result);
 
 /**
@@ -221,7 +221,7 @@ otcrypto_status_t otcrypto_ecdsa_p256_keygen_async_finalize(
  */
 otcrypto_status_t otcrypto_ecdsa_p256_dice_keygen_async_start(
     const otcrypto_blinded_key_t *private_key,
-    otcrypto_const_word32_buf_t *attestation_seed);
+    const otcrypto_const_word32_buf_t *attestation_seed);
 
 /**
  * Finalizes asynchronous key generation for P-256 with the CDI key.
@@ -308,7 +308,7 @@ OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ecdsa_p256_dice_sign_async_start(
     const otcrypto_blinded_key_t *private_key,
     const otcrypto_hash_digest_t message_digest,
-    otcrypto_const_word32_buf_t *attestation_seed);
+    const otcrypto_const_word32_buf_t *attestation_seed);
 
 /**
  * Finalizes asynchronous signature generation for ECDSA/P-256 with the CDI key.
@@ -340,7 +340,7 @@ OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ecdsa_p256_verify_async_start(
     const otcrypto_unblinded_key_t *public_key,
     const otcrypto_hash_digest_t message_digest,
-    otcrypto_const_word32_buf_t *signature);
+    const otcrypto_const_word32_buf_t *signature);
 
 /**
  * Finalizes asynchronous signature verification for ECDSA/P-256.
@@ -359,7 +359,7 @@ otcrypto_status_t otcrypto_ecdsa_p256_verify_async_start(
  */
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ecdsa_p256_verify_async_finalize(
-    otcrypto_const_word32_buf_t *signature,
+    const otcrypto_const_word32_buf_t *signature,
     hardened_bool_t *verification_result);
 
 /**
@@ -590,8 +590,8 @@ status_t otcrypto_p256_base_point_mult(
  * @return Result of the sharing operation.
  */
 otcrypto_status_t otcrypto_ecc_p256_arith_share_private_key(
-    otcrypto_const_word32_buf_t *bool_private_key_share0,
-    otcrypto_const_word32_buf_t *bool_private_key_share1,
+    const otcrypto_const_word32_buf_t *bool_private_key_share0,
+    const otcrypto_const_word32_buf_t *bool_private_key_share1,
     otcrypto_blinded_key_t *arith_private_key);
 
 #ifdef __cplusplus

--- a/sw/device/lib/crypto/include/ecc_p384.h
+++ b/sw/device/lib/crypto/include/ecc_p384.h
@@ -128,7 +128,7 @@ OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ecdsa_p384_verify(
     const otcrypto_unblinded_key_t *public_key,
     const otcrypto_hash_digest_t message_digest,
-    otcrypto_const_word32_buf_t *signature,
+    const otcrypto_const_word32_buf_t *signature,
     hardened_bool_t *verification_result);
 
 /**
@@ -252,7 +252,7 @@ OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ecdsa_p384_verify_async_start(
     const otcrypto_unblinded_key_t *public_key,
     const otcrypto_hash_digest_t message_digest,
-    otcrypto_const_word32_buf_t *signature);
+    const otcrypto_const_word32_buf_t *signature);
 
 /**
  * Finalizes asynchronous signature verification for ECDSA/P-384.
@@ -271,7 +271,7 @@ otcrypto_status_t otcrypto_ecdsa_p384_verify_async_start(
  */
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ecdsa_p384_verify_async_finalize(
-    otcrypto_const_word32_buf_t *signature,
+    const otcrypto_const_word32_buf_t *signature,
     hardened_bool_t *verification_result);
 
 /**
@@ -502,8 +502,8 @@ status_t otcrypto_p384_base_point_mult(
  * @return Result of the sharing operation.
  */
 otcrypto_status_t otcrypto_ecc_p384_arith_share_private_key(
-    otcrypto_const_word32_buf_t *bool_private_key_share0,
-    otcrypto_const_word32_buf_t *bool_private_key_share1,
+    const otcrypto_const_word32_buf_t *bool_private_key_share0,
+    const otcrypto_const_word32_buf_t *bool_private_key_share1,
     otcrypto_blinded_key_t *arith_private_key);
 
 #ifdef __cplusplus

--- a/sw/device/lib/crypto/include/hkdf.h
+++ b/sw/device/lib/crypto/include/hkdf.h
@@ -43,8 +43,8 @@ extern "C" {
  * @return Result of the key derivation operation.
  */
 otcrypto_status_t otcrypto_hkdf(const otcrypto_blinded_key_t *ikm,
-                                otcrypto_const_byte_buf_t *salt,
-                                otcrypto_const_byte_buf_t *info,
+                                const otcrypto_const_byte_buf_t *salt,
+                                const otcrypto_const_byte_buf_t *info,
                                 otcrypto_blinded_key_t *okm);
 
 /**
@@ -67,7 +67,7 @@ otcrypto_status_t otcrypto_hkdf(const otcrypto_blinded_key_t *ikm,
  * @return Result of the key derivation operation.
  */
 otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t *ikm,
-                                        otcrypto_const_byte_buf_t *salt,
+                                        const otcrypto_const_byte_buf_t *salt,
                                         otcrypto_blinded_key_t *prk);
 
 /**
@@ -85,7 +85,7 @@ otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t *ikm,
  * @return Result of the key derivation operation.
  */
 otcrypto_status_t otcrypto_hkdf_expand(const otcrypto_blinded_key_t *prk,
-                                       otcrypto_const_byte_buf_t *info,
+                                       const otcrypto_const_byte_buf_t *info,
                                        otcrypto_blinded_key_t *okm);
 
 #ifdef __cplusplus

--- a/sw/device/lib/crypto/include/hmac.h
+++ b/sw/device/lib/crypto/include/hmac.h
@@ -55,7 +55,7 @@ typedef struct otcrypto_hmac_context {
  */
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_hmac(const otcrypto_blinded_key_t *key,
-                                otcrypto_const_byte_buf_t *input_message,
+                                const otcrypto_const_byte_buf_t *input_message,
                                 otcrypto_word32_buf_t *tag);
 
 /**

--- a/sw/device/lib/crypto/include/key_transport.h
+++ b/sw/device/lib/crypto/include/key_transport.h
@@ -48,7 +48,7 @@ extern "C" {
  */
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_symmetric_keygen(
-    otcrypto_const_byte_buf_t *perso_string, otcrypto_blinded_key_t *key);
+    const otcrypto_const_byte_buf_t *perso_string, otcrypto_blinded_key_t *key);
 
 /**
  * Creates a handle for a hardware-backed key.
@@ -157,10 +157,10 @@ otcrypto_status_t otcrypto_key_wrap(const otcrypto_blinded_key_t *key_to_wrap,
  * @return Result of the aes-kwp unwrap operation.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_key_unwrap(otcrypto_const_word32_buf_t *wrapped_key,
-                                      const otcrypto_blinded_key_t *key_kek,
-                                      hardened_bool_t *success,
-                                      otcrypto_blinded_key_t *unwrapped_key);
+otcrypto_status_t otcrypto_key_unwrap(
+    const otcrypto_const_word32_buf_t *wrapped_key,
+    const otcrypto_blinded_key_t *key_kek, hardened_bool_t *success,
+    otcrypto_blinded_key_t *unwrapped_key);
 
 /**
  * Creates a blinded key struct from masked key material.

--- a/sw/device/lib/crypto/include/kmac.h
+++ b/sw/device/lib/crypto/include/kmac.h
@@ -47,11 +47,10 @@ extern "C" {
  * @return The result of the KMAC operation.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_kmac(otcrypto_blinded_key_t *key,
-                                otcrypto_const_byte_buf_t *input_message,
-                                otcrypto_const_byte_buf_t *customization_string,
-                                size_t required_output_len,
-                                otcrypto_word32_buf_t *tag);
+otcrypto_status_t otcrypto_kmac(
+    otcrypto_blinded_key_t *key, const otcrypto_const_byte_buf_t *input_message,
+    const otcrypto_const_byte_buf_t *customization_string,
+    size_t required_output_len, otcrypto_word32_buf_t *tag);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/include/rsa.h
+++ b/sw/device/lib/crypto/include/rsa.h
@@ -115,7 +115,7 @@ otcrypto_status_t otcrypto_rsa_keygen(otcrypto_rsa_size_t size,
  * @return Result of the RSA key construction.
  */
 otcrypto_status_t otcrypto_rsa_public_key_construct(
-    otcrypto_rsa_size_t size, otcrypto_const_word32_buf_t *modulus,
+    otcrypto_rsa_size_t size, const otcrypto_const_word32_buf_t *modulus,
     otcrypto_unblinded_key_t *public_key);
 
 /**
@@ -132,9 +132,10 @@ otcrypto_status_t otcrypto_rsa_public_key_construct(
  * @return Result of the RSA key construction.
  */
 otcrypto_status_t otcrypto_rsa_private_key_from_exponents(
-    otcrypto_rsa_size_t size, otcrypto_const_word32_buf_t *modulus,
-    otcrypto_const_word32_buf_t *d_share0,
-    otcrypto_const_word32_buf_t *d_share1, otcrypto_blinded_key_t *private_key);
+    otcrypto_rsa_size_t size, const otcrypto_const_word32_buf_t *modulus,
+    const otcrypto_const_word32_buf_t *d_share0,
+    const otcrypto_const_word32_buf_t *d_share1,
+    otcrypto_blinded_key_t *private_key);
 
 /**
  * Constructs an RSA keypair from the public key and one prime cofactor.
@@ -153,9 +154,9 @@ otcrypto_status_t otcrypto_rsa_private_key_from_exponents(
  * @return Result of the RSA key construction.
  */
 otcrypto_status_t otcrypto_rsa_keypair_from_cofactor(
-    otcrypto_rsa_size_t size, otcrypto_const_word32_buf_t *modulus,
-    otcrypto_const_word32_buf_t *cofactor_share0,
-    otcrypto_const_word32_buf_t *cofactor_share1,
+    otcrypto_rsa_size_t size, const otcrypto_const_word32_buf_t *modulus,
+    const otcrypto_const_word32_buf_t *cofactor_share0,
+    const otcrypto_const_word32_buf_t *cofactor_share1,
     otcrypto_unblinded_key_t *public_key, otcrypto_blinded_key_t *private_key);
 
 /**
@@ -194,7 +195,8 @@ otcrypto_status_t otcrypto_rsa_sign(const otcrypto_blinded_key_t *private_key,
 otcrypto_status_t otcrypto_rsa_verify(
     const otcrypto_unblinded_key_t *public_key,
     const otcrypto_hash_digest_t message_digest,
-    otcrypto_rsa_padding_t padding_mode, otcrypto_const_word32_buf_t *signature,
+    otcrypto_rsa_padding_t padding_mode,
+    const otcrypto_const_word32_buf_t *signature,
     hardened_bool_t *verification_result);
 
 /**
@@ -230,8 +232,9 @@ otcrypto_status_t otcrypto_rsa_verify(
  */
 otcrypto_status_t otcrypto_rsa_encrypt(
     const otcrypto_unblinded_key_t *public_key,
-    const otcrypto_hash_mode_t hash_mode, otcrypto_const_byte_buf_t *message,
-    otcrypto_const_byte_buf_t *label, otcrypto_word32_buf_t *ciphertext);
+    const otcrypto_hash_mode_t hash_mode,
+    const otcrypto_const_byte_buf_t *message,
+    const otcrypto_const_byte_buf_t *label, otcrypto_word32_buf_t *ciphertext);
 
 /**
  * Decrypts a message with RSA.
@@ -266,8 +269,9 @@ otcrypto_status_t otcrypto_rsa_encrypt(
 otcrypto_status_t otcrypto_rsa_decrypt(
     const otcrypto_blinded_key_t *private_key,
     const otcrypto_hash_mode_t hash_mode,
-    otcrypto_const_word32_buf_t *ciphertext, otcrypto_const_byte_buf_t *label,
-    otcrypto_byte_buf_t *plaintext, size_t *plaintext_bytelen);
+    const otcrypto_const_word32_buf_t *ciphertext,
+    const otcrypto_const_byte_buf_t *label, otcrypto_byte_buf_t *plaintext,
+    size_t *plaintext_bytelen);
 /**
  * Starts the asynchronous RSA key generation function.
  *
@@ -305,9 +309,9 @@ otcrypto_status_t otcrypto_rsa_keygen_async_finalize(
  * @return Result of the RSA key construction.
  */
 otcrypto_status_t otcrypto_rsa_keypair_from_cofactor_async_start(
-    otcrypto_rsa_size_t size, otcrypto_const_word32_buf_t *modulus,
-    otcrypto_const_word32_buf_t *cofactor_share0,
-    otcrypto_const_word32_buf_t *cofactor_share1);
+    otcrypto_rsa_size_t size, const otcrypto_const_word32_buf_t *modulus,
+    const otcrypto_const_word32_buf_t *cofactor_share0,
+    const otcrypto_const_word32_buf_t *cofactor_share1);
 
 /**
  * Finalizes constructing an RSA private key using a cofactor.
@@ -367,7 +371,7 @@ otcrypto_status_t otcrypto_rsa_sign_async_finalize(
  */
 otcrypto_status_t otcrypto_rsa_verify_async_start(
     const otcrypto_unblinded_key_t *public_key,
-    otcrypto_const_word32_buf_t *signature);
+    const otcrypto_const_word32_buf_t *signature);
 
 /**
  * Finalizes the asynchronous signature verification function.
@@ -399,8 +403,9 @@ otcrypto_status_t otcrypto_rsa_verify_async_finalize(
  */
 otcrypto_status_t otcrypto_rsa_encrypt_async_start(
     const otcrypto_unblinded_key_t *public_key,
-    const otcrypto_hash_mode_t hash_mode, otcrypto_const_byte_buf_t *message,
-    otcrypto_const_byte_buf_t *label);
+    const otcrypto_hash_mode_t hash_mode,
+    const otcrypto_const_byte_buf_t *message,
+    const otcrypto_const_byte_buf_t *label);
 
 /**
  * Finalizes the asynchronous encryption function.
@@ -428,7 +433,7 @@ otcrypto_status_t otcrypto_rsa_encrypt_async_finalize(
  */
 otcrypto_status_t otcrypto_rsa_decrypt_async_start(
     const otcrypto_blinded_key_t *private_key,
-    otcrypto_const_word32_buf_t *ciphertext);
+    const otcrypto_const_word32_buf_t *ciphertext);
 
 /**
  * Finalizes the asynchronous decryption function.
@@ -443,8 +448,9 @@ otcrypto_status_t otcrypto_rsa_decrypt_async_start(
  * @return Result of the RSA decryption finalize operation.
  */
 otcrypto_status_t otcrypto_rsa_decrypt_async_finalize(
-    const otcrypto_hash_mode_t hash_mode, otcrypto_const_byte_buf_t *label,
-    otcrypto_byte_buf_t *plaintext, size_t *plaintext_bytelen);
+    const otcrypto_hash_mode_t hash_mode,
+    const otcrypto_const_byte_buf_t *label, otcrypto_byte_buf_t *plaintext,
+    size_t *plaintext_bytelen);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/include/sha2.h
+++ b/sw/device/lib/crypto/include/sha2.h
@@ -47,7 +47,7 @@ typedef struct otcrypto_sha2_context {
  * @return OK or error.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_sha2_256(otcrypto_const_byte_buf_t *message,
+otcrypto_status_t otcrypto_sha2_256(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest);
 
 /**
@@ -62,7 +62,7 @@ otcrypto_status_t otcrypto_sha2_256(otcrypto_const_byte_buf_t *message,
  * @return OK or error.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_sha2_384(otcrypto_const_byte_buf_t *message,
+otcrypto_status_t otcrypto_sha2_384(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest);
 
 /**
@@ -77,7 +77,7 @@ otcrypto_status_t otcrypto_sha2_384(otcrypto_const_byte_buf_t *message,
  * @return OK or error.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_sha2_512(otcrypto_const_byte_buf_t *message,
+otcrypto_status_t otcrypto_sha2_512(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest);
 
 /**
@@ -99,8 +99,8 @@ otcrypto_status_t otcrypto_sha2_init(otcrypto_hash_mode_t hash_mode,
  * @return OK or error.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_sha2_update(otcrypto_sha2_context_t *ctx,
-                                       otcrypto_const_byte_buf_t *message);
+otcrypto_status_t otcrypto_sha2_update(
+    otcrypto_sha2_context_t *ctx, const otcrypto_const_byte_buf_t *message);
 
 /**
  * Finish a streaming SHA2 operation.

--- a/sw/device/lib/crypto/include/sha3.h
+++ b/sw/device/lib/crypto/include/sha3.h
@@ -31,7 +31,7 @@ extern "C" {
  * @return OK or error.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_sha3_224(otcrypto_const_byte_buf_t *message,
+otcrypto_status_t otcrypto_sha3_224(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest);
 
 /**
@@ -47,7 +47,7 @@ otcrypto_status_t otcrypto_sha3_224(otcrypto_const_byte_buf_t *message,
  * @return OK or error.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_sha3_256(otcrypto_const_byte_buf_t *message,
+otcrypto_status_t otcrypto_sha3_256(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest);
 
 /**
@@ -63,7 +63,7 @@ otcrypto_status_t otcrypto_sha3_256(otcrypto_const_byte_buf_t *message,
  * @return OK or error.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_sha3_384(otcrypto_const_byte_buf_t *message,
+otcrypto_status_t otcrypto_sha3_384(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest);
 
 /**
@@ -79,7 +79,7 @@ otcrypto_status_t otcrypto_sha3_384(otcrypto_const_byte_buf_t *message,
  * @return OK or error.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_sha3_512(otcrypto_const_byte_buf_t *message,
+otcrypto_status_t otcrypto_sha3_512(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest);
 
 /**
@@ -94,7 +94,7 @@ otcrypto_status_t otcrypto_sha3_512(otcrypto_const_byte_buf_t *message,
  * @return OK or error.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_shake128(otcrypto_const_byte_buf_t *message,
+otcrypto_status_t otcrypto_shake128(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest);
 
 /**
@@ -109,7 +109,7 @@ otcrypto_status_t otcrypto_shake128(otcrypto_const_byte_buf_t *message,
  * @return OK or error.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_shake256(otcrypto_const_byte_buf_t *message,
+otcrypto_status_t otcrypto_shake256(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest);
 
 /**
@@ -130,9 +130,9 @@ otcrypto_status_t otcrypto_shake256(otcrypto_const_byte_buf_t *message,
  */
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_cshake128(
-    otcrypto_const_byte_buf_t *message,
-    otcrypto_const_byte_buf_t *function_name_string,
-    otcrypto_const_byte_buf_t *customization_string,
+    const otcrypto_const_byte_buf_t *message,
+    const otcrypto_const_byte_buf_t *function_name_string,
+    const otcrypto_const_byte_buf_t *customization_string,
     otcrypto_hash_digest_t *digest);
 
 /**
@@ -153,9 +153,9 @@ otcrypto_status_t otcrypto_cshake128(
  */
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_cshake256(
-    otcrypto_const_byte_buf_t *message,
-    otcrypto_const_byte_buf_t *function_name_string,
-    otcrypto_const_byte_buf_t *customization_string,
+    const otcrypto_const_byte_buf_t *message,
+    const otcrypto_const_byte_buf_t *function_name_string,
+    const otcrypto_const_byte_buf_t *customization_string,
     otcrypto_hash_digest_t *digest);
 
 #ifdef __cplusplus

--- a/sw/device/tests/crypto/cryptotest/firmware/hash.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/hash.c
@@ -41,7 +41,7 @@ status_t handle_hash(ujson_t *uj) {
       OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, NULL, 0);
 
   // Handle to correct oneshot hash API for the provided algorithm
-  otcrypto_status_t (*hash_oneshot)(otcrypto_const_byte_buf_t *,
+  otcrypto_status_t (*hash_oneshot)(const otcrypto_const_byte_buf_t *,
                                     otcrypto_hash_digest_t *);
 
   // Digest length in 32-bit words

--- a/sw/device/tests/crypto/otcrypto_interface.h
+++ b/sw/device/tests/crypto/otcrypto_interface.h
@@ -44,7 +44,7 @@ typedef struct otcrypto_interface_t {
       const otcrypto_const_word32_buf_t *);
 
   // Key utilities
-  otcrypto_status_t (*symmetric_keygen)(otcrypto_const_byte_buf_t *,
+  otcrypto_status_t (*symmetric_keygen)(const otcrypto_const_byte_buf_t *,
                                         otcrypto_blinded_key_t *);
   otcrypto_status_t (*hw_backed_key)(uint32_t, const uint32_t salt[7],
                                      otcrypto_blinded_key_t *);
@@ -55,7 +55,7 @@ typedef struct otcrypto_interface_t {
   otcrypto_status_t (*key_wrap)(const otcrypto_blinded_key_t *,
                                 const otcrypto_blinded_key_t *,
                                 otcrypto_word32_buf_t *);
-  otcrypto_status_t (*key_unwrap)(otcrypto_const_word32_buf_t *,
+  otcrypto_status_t (*key_unwrap)(const otcrypto_const_word32_buf_t *,
                                   const otcrypto_blinded_key_t *,
                                   hardened_bool_t *, otcrypto_blinded_key_t *);
   otcrypto_status_t (*import_blinded_key)(
@@ -68,74 +68,73 @@ typedef struct otcrypto_interface_t {
   // AES
   otcrypto_status_t (*aes)(otcrypto_blinded_key_t *, otcrypto_word32_buf_t *,
                            otcrypto_aes_mode_t, otcrypto_aes_operation_t,
-                           otcrypto_const_byte_buf_t *, otcrypto_aes_padding_t,
-                           otcrypto_byte_buf_t *);
+                           const otcrypto_const_byte_buf_t *,
+                           otcrypto_aes_padding_t, otcrypto_byte_buf_t *);
   otcrypto_status_t (*aes_padded_plaintext_length)(size_t,
                                                    otcrypto_aes_padding_t,
                                                    size_t *);
 
   // AES-GCM
   otcrypto_status_t (*aes_gcm_encrypt)(otcrypto_blinded_key_t *,
-                                       otcrypto_const_byte_buf_t *,
-                                       otcrypto_const_word32_buf_t *,
-                                       otcrypto_const_byte_buf_t *,
+                                       const otcrypto_const_byte_buf_t *,
+                                       const otcrypto_const_word32_buf_t *,
+                                       const otcrypto_const_byte_buf_t *,
                                        otcrypto_aes_gcm_tag_len_t,
                                        otcrypto_byte_buf_t *,
                                        otcrypto_word32_buf_t *);
   otcrypto_status_t (*aes_gcm_decrypt)(
-      otcrypto_blinded_key_t *, otcrypto_const_byte_buf_t *,
-      otcrypto_const_word32_buf_t *, otcrypto_const_byte_buf_t *,
-      otcrypto_aes_gcm_tag_len_t, otcrypto_const_word32_buf_t *,
+      otcrypto_blinded_key_t *, const otcrypto_const_byte_buf_t *,
+      const otcrypto_const_word32_buf_t *, const otcrypto_const_byte_buf_t *,
+      otcrypto_aes_gcm_tag_len_t, const otcrypto_const_word32_buf_t *,
       otcrypto_byte_buf_t *, hardened_bool_t *);
   otcrypto_status_t (*aes_gcm_encrypt_init)(otcrypto_blinded_key_t *,
-                                            otcrypto_const_word32_buf_t *,
+                                            const otcrypto_const_word32_buf_t *,
                                             otcrypto_aes_gcm_context_t *);
   otcrypto_status_t (*aes_gcm_decrypt_init)(otcrypto_blinded_key_t *,
-                                            otcrypto_const_word32_buf_t *,
+                                            const otcrypto_const_word32_buf_t *,
                                             otcrypto_aes_gcm_context_t *);
   otcrypto_status_t (*aes_gcm_update_aad)(otcrypto_aes_gcm_context_t *,
-                                          otcrypto_const_byte_buf_t *);
+                                          const otcrypto_const_byte_buf_t *);
   otcrypto_status_t (*aes_gcm_update_encrypted_data)(
-      otcrypto_aes_gcm_context_t *, otcrypto_const_byte_buf_t *,
+      otcrypto_aes_gcm_context_t *, const otcrypto_const_byte_buf_t *,
       otcrypto_byte_buf_t *, size_t *);
   otcrypto_status_t (*aes_gcm_encrypt_final)(otcrypto_aes_gcm_context_t *,
                                              otcrypto_aes_gcm_tag_len_t,
                                              otcrypto_byte_buf_t *, size_t *,
                                              otcrypto_word32_buf_t *);
-  otcrypto_status_t (*aes_gcm_decrypt_final)(otcrypto_aes_gcm_context_t *,
-                                             otcrypto_const_word32_buf_t *,
-                                             otcrypto_aes_gcm_tag_len_t,
-                                             otcrypto_byte_buf_t *, size_t *,
-                                             hardened_bool_t *);
+  otcrypto_status_t (*aes_gcm_decrypt_final)(
+      otcrypto_aes_gcm_context_t *, const otcrypto_const_word32_buf_t *,
+      otcrypto_aes_gcm_tag_len_t, otcrypto_byte_buf_t *, size_t *,
+      hardened_bool_t *);
 
   // DRBG
-  otcrypto_status_t (*drbg_instantiate)(otcrypto_const_byte_buf_t *);
-  otcrypto_status_t (*drbg_reseed)(otcrypto_const_byte_buf_t *);
-  otcrypto_status_t (*drbg_manual_instantiate)(otcrypto_const_byte_buf_t *,
-                                               otcrypto_const_byte_buf_t *);
-  otcrypto_status_t (*drbg_manual_reseed)(otcrypto_const_byte_buf_t *,
-                                          otcrypto_const_byte_buf_t *);
-  otcrypto_status_t (*drbg_generate)(otcrypto_const_byte_buf_t *,
+  otcrypto_status_t (*drbg_instantiate)(const otcrypto_const_byte_buf_t *);
+  otcrypto_status_t (*drbg_reseed)(const otcrypto_const_byte_buf_t *);
+  otcrypto_status_t (*drbg_manual_instantiate)(
+      const otcrypto_const_byte_buf_t *, const otcrypto_const_byte_buf_t *);
+  otcrypto_status_t (*drbg_manual_reseed)(const otcrypto_const_byte_buf_t *,
+                                          const otcrypto_const_byte_buf_t *);
+  otcrypto_status_t (*drbg_generate)(const otcrypto_const_byte_buf_t *,
                                      otcrypto_word32_buf_t *);
-  otcrypto_status_t (*drbg_manual_generate)(otcrypto_const_byte_buf_t *,
+  otcrypto_status_t (*drbg_manual_generate)(const otcrypto_const_byte_buf_t *,
                                             otcrypto_word32_buf_t *);
   otcrypto_status_t (*drbg_uninstantiate)(void);
 
   // HKDF
   otcrypto_status_t (*hkdf)(const otcrypto_blinded_key_t *,
-                            otcrypto_const_byte_buf_t *,
-                            otcrypto_const_byte_buf_t *,
+                            const otcrypto_const_byte_buf_t *,
+                            const otcrypto_const_byte_buf_t *,
                             otcrypto_blinded_key_t *);
   otcrypto_status_t (*hkdf_extract)(const otcrypto_blinded_key_t *,
-                                    otcrypto_const_byte_buf_t *,
+                                    const otcrypto_const_byte_buf_t *,
                                     otcrypto_blinded_key_t *);
   otcrypto_status_t (*hkdf_expand)(const otcrypto_blinded_key_t *,
-                                   otcrypto_const_byte_buf_t *,
+                                   const otcrypto_const_byte_buf_t *,
                                    otcrypto_blinded_key_t *);
 
   // HMAC
   otcrypto_status_t (*hmac)(const otcrypto_blinded_key_t *,
-                            otcrypto_const_byte_buf_t *,
+                            const otcrypto_const_byte_buf_t *,
                             otcrypto_word32_buf_t *);
   otcrypto_status_t (*hmac_init)(otcrypto_hmac_context_t *,
                                  const otcrypto_blinded_key_t *);
@@ -152,8 +151,8 @@ typedef struct otcrypto_interface_t {
 
   // KMAC
   otcrypto_status_t (*kmac)(otcrypto_blinded_key_t *,
-                            otcrypto_const_byte_buf_t *,
-                            otcrypto_const_byte_buf_t *, size_t,
+                            const otcrypto_const_byte_buf_t *,
+                            const otcrypto_const_byte_buf_t *, size_t,
                             otcrypto_word32_buf_t *);
 
   // KMAC-KDF
@@ -163,80 +162,79 @@ typedef struct otcrypto_interface_t {
                                 otcrypto_blinded_key_t *);
 
   // SHA-2
-  otcrypto_status_t (*sha2_256)(otcrypto_const_byte_buf_t *,
+  otcrypto_status_t (*sha2_256)(const otcrypto_const_byte_buf_t *,
                                 otcrypto_hash_digest_t *);
-  otcrypto_status_t (*sha2_384)(otcrypto_const_byte_buf_t *,
+  otcrypto_status_t (*sha2_384)(const otcrypto_const_byte_buf_t *,
                                 otcrypto_hash_digest_t *);
-  otcrypto_status_t (*sha2_512)(otcrypto_const_byte_buf_t *,
+  otcrypto_status_t (*sha2_512)(const otcrypto_const_byte_buf_t *,
                                 otcrypto_hash_digest_t *);
   otcrypto_status_t (*sha2_init)(otcrypto_hash_mode_t,
                                  otcrypto_sha2_context_t *);
   otcrypto_status_t (*sha2_update)(otcrypto_sha2_context_t *,
-                                   otcrypto_const_byte_buf_t *);
+                                   const otcrypto_const_byte_buf_t *);
   otcrypto_status_t (*sha2_final)(otcrypto_sha2_context_t *,
                                   otcrypto_hash_digest_t *);
 
   // SHA-3
-  otcrypto_status_t (*sha3_224)(otcrypto_const_byte_buf_t *,
+  otcrypto_status_t (*sha3_224)(const otcrypto_const_byte_buf_t *,
                                 otcrypto_hash_digest_t *);
-  otcrypto_status_t (*sha3_256)(otcrypto_const_byte_buf_t *,
+  otcrypto_status_t (*sha3_256)(const otcrypto_const_byte_buf_t *,
                                 otcrypto_hash_digest_t *);
-  otcrypto_status_t (*sha3_384)(otcrypto_const_byte_buf_t *,
+  otcrypto_status_t (*sha3_384)(const otcrypto_const_byte_buf_t *,
                                 otcrypto_hash_digest_t *);
-  otcrypto_status_t (*sha3_512)(otcrypto_const_byte_buf_t *,
+  otcrypto_status_t (*sha3_512)(const otcrypto_const_byte_buf_t *,
                                 otcrypto_hash_digest_t *);
-  otcrypto_status_t (*shake128)(otcrypto_const_byte_buf_t *,
+  otcrypto_status_t (*shake128)(const otcrypto_const_byte_buf_t *,
                                 otcrypto_hash_digest_t *);
-  otcrypto_status_t (*shake256)(otcrypto_const_byte_buf_t *,
+  otcrypto_status_t (*shake256)(const otcrypto_const_byte_buf_t *,
                                 otcrypto_hash_digest_t *);
-  otcrypto_status_t (*cshake128)(otcrypto_const_byte_buf_t *,
-                                 otcrypto_const_byte_buf_t *,
-                                 otcrypto_const_byte_buf_t *,
+  otcrypto_status_t (*cshake128)(const otcrypto_const_byte_buf_t *,
+                                 const otcrypto_const_byte_buf_t *,
+                                 const otcrypto_const_byte_buf_t *,
                                  otcrypto_hash_digest_t *);
-  otcrypto_status_t (*cshake256)(otcrypto_const_byte_buf_t *,
-                                 otcrypto_const_byte_buf_t *,
-                                 otcrypto_const_byte_buf_t *,
+  otcrypto_status_t (*cshake256)(const otcrypto_const_byte_buf_t *,
+                                 const otcrypto_const_byte_buf_t *,
+                                 const otcrypto_const_byte_buf_t *,
                                  otcrypto_hash_digest_t *);
 
   // ED25519
   otcrypto_status_t (*ed25519_keygen)(const otcrypto_unblinded_key_t *,
                                       otcrypto_unblinded_key_t *);
   otcrypto_status_t (*ed25519_sign)(const otcrypto_unblinded_key_t *,
-                                    otcrypto_const_byte_buf_t *,
+                                    const otcrypto_const_byte_buf_t *,
                                     otcrypto_eddsa_sign_mode_t,
                                     otcrypto_word32_buf_t *);
   otcrypto_status_t (*ed25519_sign_verify)(const otcrypto_unblinded_key_t *,
                                            const otcrypto_unblinded_key_t *,
-                                           otcrypto_const_byte_buf_t *,
+                                           const otcrypto_const_byte_buf_t *,
                                            otcrypto_eddsa_sign_mode_t,
                                            otcrypto_word32_buf_t *);
   otcrypto_status_t (*ed25519_verify)(const otcrypto_unblinded_key_t *,
-                                      otcrypto_const_byte_buf_t *,
+                                      const otcrypto_const_byte_buf_t *,
                                       otcrypto_eddsa_sign_mode_t,
-                                      otcrypto_const_word32_buf_t *,
+                                      const otcrypto_const_word32_buf_t *,
                                       hardened_bool_t *);
   otcrypto_status_t (*ed25519_keygen_async_start)(
       const otcrypto_unblinded_key_t *);
   otcrypto_status_t (*ed25519_keygen_async_finalize)(
       otcrypto_unblinded_key_t *);
-  otcrypto_status_t (*ed25519_sign_async_start)(const otcrypto_blinded_key_t *,
-                                                otcrypto_const_byte_buf_t *,
-                                                otcrypto_eddsa_sign_mode_t,
-                                                otcrypto_word32_buf_t *);
+  otcrypto_status_t (*ed25519_sign_async_start)(
+      const otcrypto_blinded_key_t *, const otcrypto_const_byte_buf_t *,
+      otcrypto_eddsa_sign_mode_t, otcrypto_word32_buf_t *);
   otcrypto_status_t (*ed25519_sign_part1_async_start)(
-      const otcrypto_unblinded_key_t *, otcrypto_const_byte_buf_t *,
+      const otcrypto_unblinded_key_t *, const otcrypto_const_byte_buf_t *,
       otcrypto_eddsa_sign_mode_t, otcrypto_word32_buf_t *,
       otcrypto_word32_buf_t *, otcrypto_word32_buf_t *,
       otcrypto_word32_buf_t *);
   otcrypto_status_t (*ed25519_sign_part2_async_start)(
-      const otcrypto_unblinded_key_t *, otcrypto_const_byte_buf_t *,
+      const otcrypto_unblinded_key_t *, const otcrypto_const_byte_buf_t *,
       otcrypto_eddsa_sign_mode_t, otcrypto_word32_buf_t *,
       otcrypto_word32_buf_t *, otcrypto_word32_buf_t *, otcrypto_word32_buf_t *,
       otcrypto_word32_buf_t *);
   otcrypto_status_t (*ed25519_sign_async_finalize)(otcrypto_word32_buf_t *);
   otcrypto_status_t (*ed25519_verify_async_start)(
-      const otcrypto_unblinded_key_t *, otcrypto_const_byte_buf_t *,
-      otcrypto_eddsa_sign_mode_t, otcrypto_const_word32_buf_t *);
+      const otcrypto_unblinded_key_t *, const otcrypto_const_byte_buf_t *,
+      otcrypto_eddsa_sign_mode_t, const otcrypto_const_word32_buf_t *);
   otcrypto_status_t (*ed25519_verify_async_finalize)(hardened_bool_t *);
 
   // X25519
@@ -257,19 +255,17 @@ typedef struct otcrypto_interface_t {
   otcrypto_status_t (*rsa_keygen)(otcrypto_rsa_size_t,
                                   otcrypto_unblinded_key_t *,
                                   otcrypto_blinded_key_t *);
-  otcrypto_status_t (*rsa_public_key_construct)(otcrypto_rsa_size_t,
-                                                otcrypto_const_word32_buf_t *,
-                                                otcrypto_unblinded_key_t *);
+  otcrypto_status_t (*rsa_public_key_construct)(
+      otcrypto_rsa_size_t, const otcrypto_const_word32_buf_t *,
+      otcrypto_unblinded_key_t *);
   otcrypto_status_t (*rsa_private_key_from_exponents)(
-      otcrypto_rsa_size_t, otcrypto_const_word32_buf_t *,
-      otcrypto_const_word32_buf_t *, otcrypto_const_word32_buf_t *,
+      otcrypto_rsa_size_t, const otcrypto_const_word32_buf_t *,
+      const otcrypto_const_word32_buf_t *, const otcrypto_const_word32_buf_t *,
       otcrypto_blinded_key_t *);
-  otcrypto_status_t (*rsa_keypair_from_cofactor)(otcrypto_rsa_size_t,
-                                                 otcrypto_const_word32_buf_t *,
-                                                 otcrypto_const_word32_buf_t *,
-                                                 otcrypto_const_word32_buf_t *,
-                                                 otcrypto_unblinded_key_t *,
-                                                 otcrypto_blinded_key_t *);
+  otcrypto_status_t (*rsa_keypair_from_cofactor)(
+      otcrypto_rsa_size_t, const otcrypto_const_word32_buf_t *,
+      const otcrypto_const_word32_buf_t *, const otcrypto_const_word32_buf_t *,
+      otcrypto_unblinded_key_t *, otcrypto_blinded_key_t *);
   otcrypto_status_t (*rsa_sign)(const otcrypto_blinded_key_t *,
                                 const otcrypto_hash_digest_t,
                                 otcrypto_rsa_padding_t,
@@ -277,53 +273,51 @@ typedef struct otcrypto_interface_t {
   otcrypto_status_t (*rsa_verify)(const otcrypto_unblinded_key_t *,
                                   const otcrypto_hash_digest_t,
                                   otcrypto_rsa_padding_t,
-                                  otcrypto_const_word32_buf_t *,
+                                  const otcrypto_const_word32_buf_t *,
                                   hardened_bool_t *);
   otcrypto_status_t (*rsa_encrypt)(const otcrypto_unblinded_key_t *,
                                    const otcrypto_hash_mode_t,
-                                   otcrypto_const_byte_buf_t *,
-                                   otcrypto_const_byte_buf_t *,
+                                   const otcrypto_const_byte_buf_t *,
+                                   const otcrypto_const_byte_buf_t *,
                                    otcrypto_word32_buf_t *);
   otcrypto_status_t (*rsa_decrypt)(const otcrypto_blinded_key_t *,
                                    const otcrypto_hash_mode_t,
-                                   otcrypto_const_word32_buf_t *,
-                                   otcrypto_const_byte_buf_t *,
+                                   const otcrypto_const_word32_buf_t *,
+                                   const otcrypto_const_byte_buf_t *,
                                    otcrypto_byte_buf_t *, size_t *);
   otcrypto_status_t (*rsa_keygen_async_start)(otcrypto_rsa_size_t);
   otcrypto_status_t (*rsa_keygen_async_finalize)(otcrypto_unblinded_key_t *,
                                                  otcrypto_blinded_key_t *);
   otcrypto_status_t (*rsa_keypair_from_cofactor_async_start)(
-      otcrypto_rsa_size_t, otcrypto_const_word32_buf_t *,
-      otcrypto_const_word32_buf_t *cofactor_share0,
-      otcrypto_const_word32_buf_t *cofactor_share1);
+      otcrypto_rsa_size_t, const otcrypto_const_word32_buf_t *,
+      const otcrypto_const_word32_buf_t *cofactor_share0,
+      const otcrypto_const_word32_buf_t *cofactor_share1);
   otcrypto_status_t (*rsa_keypair_from_cofactor_async_finalize)(
       otcrypto_unblinded_key_t *, otcrypto_blinded_key_t *);
   otcrypto_status_t (*rsa_sign_async_start)(const otcrypto_blinded_key_t *,
                                             const otcrypto_hash_digest_t,
                                             otcrypto_rsa_padding_t);
   otcrypto_status_t (*rsa_sign_async_finalize)(otcrypto_word32_buf_t *);
-  otcrypto_status_t (*rsa_verify_async_start)(const otcrypto_unblinded_key_t *,
-                                              otcrypto_const_word32_buf_t *);
+  otcrypto_status_t (*rsa_verify_async_start)(
+      const otcrypto_unblinded_key_t *, const otcrypto_const_word32_buf_t *);
   otcrypto_status_t (*rsa_verify_async_finalize)(const otcrypto_hash_digest_t,
                                                  otcrypto_rsa_padding_t,
                                                  hardened_bool_t *);
-  otcrypto_status_t (*rsa_encrypt_async_start)(const otcrypto_unblinded_key_t *,
-                                               const otcrypto_hash_mode_t,
-                                               otcrypto_const_byte_buf_t *,
-                                               otcrypto_const_byte_buf_t *);
+  otcrypto_status_t (*rsa_encrypt_async_start)(
+      const otcrypto_unblinded_key_t *, const otcrypto_hash_mode_t,
+      const otcrypto_const_byte_buf_t *, const otcrypto_const_byte_buf_t *);
   otcrypto_status_t (*rsa_encrypt_async_finalize)(otcrypto_word32_buf_t *);
-  otcrypto_status_t (*rsa_decrypt_async_start)(const otcrypto_blinded_key_t *,
-                                               otcrypto_const_word32_buf_t *);
-  otcrypto_status_t (*rsa_decrypt_async_finalize)(const otcrypto_hash_mode_t,
-                                                  otcrypto_const_byte_buf_t *,
-                                                  otcrypto_byte_buf_t *,
-                                                  size_t *);
+  otcrypto_status_t (*rsa_decrypt_async_start)(
+      const otcrypto_blinded_key_t *, const otcrypto_const_word32_buf_t *);
+  otcrypto_status_t (*rsa_decrypt_async_finalize)(
+      const otcrypto_hash_mode_t, const otcrypto_const_byte_buf_t *,
+      otcrypto_byte_buf_t *, size_t *);
   // P-256
   otcrypto_status_t (*ecdsa_p256_keygen)(otcrypto_blinded_key_t *,
                                          otcrypto_unblinded_key_t *);
-  otcrypto_status_t (*ecdsa_p256_dice_keygen)(otcrypto_blinded_key_t *,
-                                              otcrypto_unblinded_key_t *,
-                                              otcrypto_const_word32_buf_t *);
+  otcrypto_status_t (*ecdsa_p256_dice_keygen)(
+      otcrypto_blinded_key_t *, otcrypto_unblinded_key_t *,
+      const otcrypto_const_word32_buf_t *);
   otcrypto_status_t (*ecdsa_p256_sign_config_k)(const otcrypto_blinded_key_t *,
                                                 const otcrypto_blinded_key_t *,
                                                 const otcrypto_hash_digest_t,
@@ -337,7 +331,7 @@ typedef struct otcrypto_interface_t {
                                               otcrypto_word32_buf_t *);
   otcrypto_status_t (*ecdsa_p256_verify)(const otcrypto_unblinded_key_t *,
                                          const otcrypto_hash_digest_t,
-                                         otcrypto_const_word32_buf_t *,
+                                         const otcrypto_const_word32_buf_t *,
                                          hardened_bool_t *);
   otcrypto_status_t (*ecdh_p256_keygen)(otcrypto_blinded_key_t *,
                                         otcrypto_unblinded_key_t *);
@@ -349,7 +343,7 @@ typedef struct otcrypto_interface_t {
   otcrypto_status_t (*ecdsa_p256_keygen_async_finalize)(
       otcrypto_blinded_key_t *, otcrypto_unblinded_key_t *);
   otcrypto_status_t (*ecdsa_p256_dice_keygen_async_start)(
-      const otcrypto_blinded_key_t *, otcrypto_const_word32_buf_t *);
+      const otcrypto_blinded_key_t *, const otcrypto_const_word32_buf_t *);
   otcrypto_status_t (*ecdsa_p256_dice_keygen_async_finalize)(
       otcrypto_blinded_key_t *, otcrypto_unblinded_key_t *);
   otcrypto_status_t (*ecdsa_p256_sign_config_k_async_start)(
@@ -360,14 +354,14 @@ typedef struct otcrypto_interface_t {
   otcrypto_status_t (*ecdsa_p256_sign_async_finalize)(otcrypto_word32_buf_t *);
   otcrypto_status_t (*ecdsa_p256_dice_sign_async_start)(
       const otcrypto_blinded_key_t *, const otcrypto_hash_digest_t,
-      otcrypto_const_word32_buf_t *);
+      const otcrypto_const_word32_buf_t *);
   otcrypto_status_t (*ecdsa_p256_dice_sign_async_finalize)(
       otcrypto_word32_buf_t *);
   otcrypto_status_t (*ecdsa_p256_verify_async_start)(
       const otcrypto_unblinded_key_t *, const otcrypto_hash_digest_t,
-      otcrypto_const_word32_buf_t *);
+      const otcrypto_const_word32_buf_t *);
   otcrypto_status_t (*ecdsa_p256_verify_async_finalize)(
-      otcrypto_const_word32_buf_t *, hardened_bool_t *);
+      const otcrypto_const_word32_buf_t *, hardened_bool_t *);
   otcrypto_status_t (*ecdh_p256_keygen_async_start)(
       const otcrypto_blinded_key_t *);
   otcrypto_status_t (*ecdh_p256_keygen_async_finalize)(
@@ -375,9 +369,9 @@ typedef struct otcrypto_interface_t {
   otcrypto_status_t (*ecdh_p256_async_start)(const otcrypto_blinded_key_t *,
                                              const otcrypto_unblinded_key_t *);
   otcrypto_status_t (*ecdh_p256_async_finalize)(otcrypto_blinded_key_t *);
-  otcrypto_status_t (*ecc_p256_private_key_import)(otcrypto_const_word32_buf_t,
-                                                   otcrypto_const_word32_buf_t,
-                                                   otcrypto_blinded_key_t *);
+  otcrypto_status_t (*ecc_p256_private_key_import)(
+      const otcrypto_const_word32_buf_t, const otcrypto_const_word32_buf_t,
+      otcrypto_blinded_key_t *);
   otcrypto_status_t (*ecc_p256_private_key_export)(
       const otcrypto_blinded_key_t *, otcrypto_word32_buf_t *,
       otcrypto_word32_buf_t *);
@@ -392,7 +386,7 @@ typedef struct otcrypto_interface_t {
   status_t (*p256_base_point_mult)(const otcrypto_blinded_key_t *,
                                    otcrypto_unblinded_key_t *);
   otcrypto_status_t (*ecc_p256_arith_share_private_key)(
-      otcrypto_const_word32_buf_t *, otcrypto_const_word32_buf_t *,
+      const otcrypto_const_word32_buf_t *, const otcrypto_const_word32_buf_t *,
       otcrypto_blinded_key_t *);
 
   // P-384
@@ -411,7 +405,7 @@ typedef struct otcrypto_interface_t {
                                               otcrypto_word32_buf_t *);
   otcrypto_status_t (*ecdsa_p384_verify)(const otcrypto_unblinded_key_t *,
                                          const otcrypto_hash_digest_t,
-                                         otcrypto_const_word32_buf_t *,
+                                         const otcrypto_const_word32_buf_t *,
                                          hardened_bool_t *);
   otcrypto_status_t (*ecdh_p384_keygen)(otcrypto_blinded_key_t *,
                                         otcrypto_unblinded_key_t *);
@@ -430,9 +424,9 @@ typedef struct otcrypto_interface_t {
   otcrypto_status_t (*ecdsa_p384_sign_async_finalize)(otcrypto_word32_buf_t *);
   otcrypto_status_t (*ecdsa_p384_verify_async_start)(
       const otcrypto_unblinded_key_t *, const otcrypto_hash_digest_t,
-      otcrypto_const_word32_buf_t *);
+      const otcrypto_const_word32_buf_t *);
   otcrypto_status_t (*ecdsa_p384_verify_async_finalize)(
-      otcrypto_const_word32_buf_t *, hardened_bool_t *);
+      const otcrypto_const_word32_buf_t *, hardened_bool_t *);
   otcrypto_status_t (*ecdh_p384_keygen_async_start)(
       const otcrypto_blinded_key_t *);
   otcrypto_status_t (*ecdh_p384_keygen_async_finalize)(
@@ -440,9 +434,9 @@ typedef struct otcrypto_interface_t {
   otcrypto_status_t (*ecdh_p384_async_start)(const otcrypto_blinded_key_t *,
                                              const otcrypto_unblinded_key_t *);
   otcrypto_status_t (*ecdh_p384_async_finalize)(otcrypto_blinded_key_t *);
-  otcrypto_status_t (*ecc_p384_private_key_import)(otcrypto_const_word32_buf_t,
-                                                   otcrypto_const_word32_buf_t,
-                                                   otcrypto_blinded_key_t *);
+  otcrypto_status_t (*ecc_p384_private_key_import)(
+      const otcrypto_const_word32_buf_t, const otcrypto_const_word32_buf_t,
+      otcrypto_blinded_key_t *);
   otcrypto_status_t (*ecc_p384_private_key_export)(
       const otcrypto_blinded_key_t *, otcrypto_word32_buf_t *,
       otcrypto_word32_buf_t *);
@@ -457,7 +451,7 @@ typedef struct otcrypto_interface_t {
   status_t (*p384_base_point_mult)(const otcrypto_blinded_key_t *,
                                    otcrypto_unblinded_key_t *);
   otcrypto_status_t (*ecc_p384_arith_share_private_key)(
-      otcrypto_const_word32_buf_t *, otcrypto_const_word32_buf_t *,
+      const otcrypto_const_word32_buf_t *, const otcrypto_const_word32_buf_t *,
       otcrypto_blinded_key_t *);
 
 } otcrypto_interface_t;


### PR DESCRIPTION
Add the const modifier to otcrypto_const_byte_buf_t and otcrypto_const_word32_buf_t.
Make this consistent in the crypto functions.