### PR TITLE
[pwrmgr,dv] Remove do-nothing $assertoff

### DIFF
--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_reset_invalid_vseq.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_reset_invalid_vseq.sv
@@ -42,7 +42,6 @@ class pwrmgr_reset_invalid_vseq extends pwrmgr_base_vseq;
 
     wait_for_rom_and_active();
     check_reset_status('0);
-    $assertoff(0, "tb.dut.u_cdc.u_clr_reqack.SyncReqAckHoldReq");
 
     for (int i = 0; i < num_of_target_states; ++i) begin
       `uvm_info(`gfn, $sformatf("Starting new round %0d", i), UVM_MEDIUM)

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_reset_invalid_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_reset_invalid_vseq.sv
@@ -42,7 +42,6 @@ class pwrmgr_reset_invalid_vseq extends pwrmgr_base_vseq;
 
     wait_for_rom_and_active();
     check_reset_status('0);
-    $assertoff(0, "tb.dut.u_cdc.u_clr_reqack.SyncReqAckHoldReq");
 
     for (int i = 0; i < num_of_target_states; ++i) begin
       `uvm_info(`gfn, $sformatf("Starting new round %0d", i), UVM_MEDIUM)

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_reset_invalid_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_reset_invalid_vseq.sv
@@ -42,7 +42,6 @@ class pwrmgr_reset_invalid_vseq extends pwrmgr_base_vseq;
 
     wait_for_rom_and_active();
     check_reset_status('0);
-    $assertoff(0, "tb.dut.u_cdc.u_clr_reqack.SyncReqAckHoldReq");
 
     for (int i = 0; i < num_of_target_states; ++i) begin
       `uvm_info(`gfn, $sformatf("Starting new round %0d", i), UVM_MEDIUM)

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_reset_invalid_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_reset_invalid_vseq.sv
@@ -42,7 +42,6 @@ class pwrmgr_reset_invalid_vseq extends pwrmgr_base_vseq;
 
     wait_for_rom_and_active();
     check_reset_status('0);
-    $assertoff(0, "tb.dut.u_cdc.u_clr_reqack.SyncReqAckHoldReq");
 
     for (int i = 0; i < num_of_target_states; ++i) begin
       `uvm_info(`gfn, $sformatf("Starting new round %0d", i), UVM_MEDIUM)


### PR DESCRIPTION
Because the named assertion doesn't exist, this caused elaboration to fail with Xcelium (which is pickier than VCS about such things). The target assertion hasn't existed since the prim_sync_reqack instance replaced with a prim_flop_2sync in commit e5c9974 (in 2022).