### PR TITLE
[dv] Simplify use of the DV_GET_ENUM_PLUSARG macro

### DIFF
--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -479,18 +479,18 @@
 //
 // ENUM_: The enum type.
 // VAR_: The enum variable to which the plusarg value will be set (must be declared already).
-// PLUSARG_: the name of the plusarg (as raw text). This is typically the same as the enum variable.
+// PLUSARG_: the name of the plusarg (as a string). This is typically the same as the enum variable.
 // CHECK_EXISTS_: Throws a fatal error if the plusarg is not set.
 `ifndef DV_GET_ENUM_PLUSARG
 `define DV_GET_ENUM_PLUSARG(ENUM_, VAR_, PLUSARG_, CHECK_EXISTS_ = 0, ID_ = `gfn) \
   begin \
     string str; \
-    if ($value$plusargs(`"``PLUSARG_``=%0s`", str)) begin \
+    if ($value$plusargs({PLUSARG_, "=%0s"}, str)) begin \
       if (!uvm_enum_wrapper#(ENUM_)::from_name(str, VAR_)) begin \
         `uvm_fatal(ID_, $sformatf(`"Cannot find %s from enum ``ENUM_```", VAR_.name())) \
       end \
     end else if (CHECK_EXISTS_) begin \
-      `uvm_fatal(ID_, `"Please pass the plusarg +``PLUSARG_``=<``ENUM_``-literal>`") \
+      `uvm_fatal(ID_, $sformatf(`"Please pass the plusarg +%0s=<``ENUM_``-literal>`", PLUSARG_)) \
     end \
   end
 `endif

--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -480,17 +480,14 @@
 // ENUM_: The enum type.
 // VAR_: The enum variable to which the plusarg value will be set (must be declared already).
 // PLUSARG_: the name of the plusarg (as a string). This is typically the same as the enum variable.
-// CHECK_EXISTS_: Throws a fatal error if the plusarg is not set.
 `ifndef DV_GET_ENUM_PLUSARG
-`define DV_GET_ENUM_PLUSARG(ENUM_, VAR_, PLUSARG_, CHECK_EXISTS_ = 0, ID_ = `gfn) \
+`define DV_GET_ENUM_PLUSARG(ENUM_, VAR_, PLUSARG_, ID_ = `gfn) \
   begin \
     string str; \
     if ($value$plusargs({PLUSARG_, "=%0s"}, str)) begin \
       if (!uvm_enum_wrapper#(ENUM_)::from_name(str, VAR_)) begin \
         `uvm_fatal(ID_, $sformatf(`"Cannot find %s from enum ``ENUM_```", VAR_.name())) \
       end \
-    end else if (CHECK_EXISTS_) begin \
-      `uvm_fatal(ID_, $sformatf(`"Please pass the plusarg +%0s=<``ENUM_``-literal>`", PLUSARG_)) \
     end \
   end
 `endif

--- a/hw/ip/i2c/dv/tests/i2c_base_test.sv
+++ b/hw/ip/i2c/dv/tests/i2c_base_test.sv
@@ -18,7 +18,7 @@ class i2c_base_test extends cip_base_test #(.ENV_T(i2c_env),
     if_mode_e mode = Device;
     test_timeout_ns = 600_000_000; // 600ms
     super.build_phase(phase);
-    `DV_GET_ENUM_PLUSARG(if_mode_e, mode, i2c_agent_mode)
+    `DV_GET_ENUM_PLUSARG(if_mode_e, mode, "i2c_agent_mode")
     `uvm_info(`gfn, $sformatf("set i2c agent mode to %s", mode.name), UVM_MEDIUM)
     cfg.m_i2c_agent_cfg.if_mode = mode;
     void'($value$plusargs("use_intr_handler=%0b", cfg.use_intr_handler));

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_sideload_one_intf_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_sideload_one_intf_vseq.sv
@@ -22,7 +22,7 @@ class keymgr_sideload_one_intf_vseq extends keymgr_sideload_vseq;
   }
 
   function void pre_randomize();
-    `DV_GET_ENUM_PLUSARG(keymgr_pkg::keymgr_key_dest_e, sideload_dest, sideload_dest, 1)
+    `DV_GET_ENUM_PLUSARG(keymgr_pkg::keymgr_key_dest_e, sideload_dest, "sideload_dest", 1)
     super.pre_randomize();
   endfunction
 endclass : keymgr_sideload_one_intf_vseq

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_sideload_one_intf_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_sideload_one_intf_vseq.sv
@@ -22,7 +22,15 @@ class keymgr_sideload_one_intf_vseq extends keymgr_sideload_vseq;
   }
 
   function void pre_randomize();
-    `DV_GET_ENUM_PLUSARG(keymgr_pkg::keymgr_key_dest_e, sideload_dest, "sideload_dest", 1)
+    // Use $value$plusargs and save the result in a string, in order to check that the plusarg has
+    // actually been supplied. To cast it to an appropriate enum value, load again with
+    // DV_GET_ENUM_PLUSARG.
+    string _ignored_str;
+    if (!$value$plusargs("sideload_dest=%0s", _ignored_str)) begin
+      `uvm_fatal(get_name(), "Missing +sideload_dest=<keymgr_dest_e-literal> plusarg.")
+    end
+    `DV_GET_ENUM_PLUSARG(keymgr_pkg::keymgr_key_dest_e, sideload_dest, "sideload_dest")
+
     super.pre_randomize();
   endfunction
 endclass : keymgr_sideload_one_intf_vseq

--- a/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv.tpl
@@ -122,7 +122,7 @@ ${spc}ral.${src}_meas_ctrl_shadowed.hi,
 ${spc}ral.${src}_meas_ctrl_shadowed.lo};
 % endfor
     mubi_mode = ClkmgrMubiNone;
-    `DV_GET_ENUM_PLUSARG(clkmgr_mubi_e, mubi_mode, clkmgr_mubi_mode)
+    `DV_GET_ENUM_PLUSARG(clkmgr_mubi_e, mubi_mode, "clkmgr_mubi_mode")
     `uvm_info(`gfn, $sformatf("mubi_mode = %s", mubi_mode.name), UVM_MEDIUM)
   % if ext_clk_bypass:
     cfg.clkmgr_vif.init(.idle({NUM_TRANS{MuBi4True}}), .scanmode(scanmode), .lc_debug_en(Off));

--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv.tpl
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv.tpl
@@ -121,7 +121,7 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
     cfg.pwrmgr_vif.lc_hw_debug_en = lc_ctrl_pkg::Off;
     cfg.pwrmgr_vif.lc_dft_en = lc_ctrl_pkg::Off;
     mubi_mode = PwrmgrMubiNone;
-    `DV_GET_ENUM_PLUSARG(pwrmgr_mubi_e, mubi_mode, pwrmgr_mubi_mode)
+    `DV_GET_ENUM_PLUSARG(pwrmgr_mubi_e, mubi_mode, "pwrmgr_mubi_mode")
     `uvm_info(`gfn, $sformatf("pwrmgr mubi mode : %s", mubi_mode.name()), UVM_MEDIUM)
 
     if (do_pwrmgr_init) pwrmgr_init();

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_lc_base_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_lc_base_vseq.sv
@@ -14,7 +14,7 @@ class chip_sw_lc_base_vseq extends chip_sw_base_vseq;
   lc_ctrl_state_pkg::dec_lc_state_e init_lc_state = DecLcStInvalid;
 
   virtual task pre_start();
-    `DV_GET_ENUM_PLUSARG(lc_ctrl_state_pkg::dec_lc_state_e, init_lc_state, src_dec_state)
+    `DV_GET_ENUM_PLUSARG(lc_ctrl_state_pkg::dec_lc_state_e, init_lc_state, "src_dec_state")
     `uvm_info(`gfn, $sformatf("Init lc state is %0s", init_lc_state.name), UVM_MEDIUM)
     super.pre_start();
   endtask

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_lc_ctrl_scrap_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_lc_ctrl_scrap_vseq.sv
@@ -37,7 +37,7 @@ class chip_sw_lc_ctrl_scrap_vseq extends chip_sw_lc_base_vseq;
 
       // source state is randomized by default,
       // but if a plusarg is supplied, assign the given value
-      `DV_GET_ENUM_PLUSARG(lc_ctrl_state_pkg::dec_lc_state_e, src_state, src_dec_state)
+      `DV_GET_ENUM_PLUSARG(lc_ctrl_state_pkg::dec_lc_state_e, src_state, "src_dec_state")
       `uvm_info(`gfn, $sformatf("Source state is %0s", src_state.name), UVM_MEDIUM)
     end
   endfunction : pre_randomize

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_lc_walkthrough_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_lc_walkthrough_vseq.sv
@@ -21,7 +21,7 @@ class chip_sw_lc_walkthrough_vseq extends chip_sw_base_vseq;
   lc_ctrl_state_pkg::dec_lc_state_e dest_dec_state = lc_ctrl_state_pkg::DecLcStProdEnd;
 
   virtual task pre_start();
-    `DV_GET_ENUM_PLUSARG(lc_ctrl_state_pkg::dec_lc_state_e, dest_dec_state, dest_dec_state)
+    `DV_GET_ENUM_PLUSARG(lc_ctrl_state_pkg::dec_lc_state_e, dest_dec_state, "dest_dec_state")
     `uvm_info(`gfn, $sformatf("Destination state is %0s", dest_dec_state.name), UVM_MEDIUM)
     super.pre_start();
   endtask

--- a/hw/top_darjeeling/dv/tests/chip_base_test.sv
+++ b/hw/top_darjeeling/dv/tests/chip_base_test.sv
@@ -24,7 +24,7 @@ class chip_base_test extends cip_base_test #(
     super.build_phase(phase);
 
     // Knob to select the chip clock source.
-    `DV_GET_ENUM_PLUSARG(chip_clock_source_e, cfg.chip_clock_source, chip_clock_source)
+    `DV_GET_ENUM_PLUSARG(chip_clock_source_e, cfg.chip_clock_source, "chip_clock_source")
     if (cfg.chip_clock_source != ChipClockSourceInternal) begin
       cfg.clk_freq_mhz = cfg.chip_clock_source;
     end
@@ -66,7 +66,7 @@ class chip_base_test extends cip_base_test #(
     end
 
     // Knob to select the OTP image based on LC state.
-    `DV_GET_ENUM_PLUSARG(otp_type_e, cfg.use_otp_image, use_otp_image)
+    `DV_GET_ENUM_PLUSARG(otp_type_e, cfg.use_otp_image, "use_otp_image")
     `DV_CHECK_FATAL(cfg.otp_images.exists(cfg.use_otp_image),
                     $sformatf({"Unsupported plusarg value: +use_otp_image=%0s. An image associated",
                                "with this LC state needs to be created first."}, cfg.use_otp_image))

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -101,7 +101,7 @@ class clkmgr_base_vseq extends cip_base_vseq #(
                                      ral.main_meas_ctrl_shadowed.hi,
                                      ral.main_meas_ctrl_shadowed.lo};
     mubi_mode = ClkmgrMubiNone;
-    `DV_GET_ENUM_PLUSARG(clkmgr_mubi_e, mubi_mode, clkmgr_mubi_mode)
+    `DV_GET_ENUM_PLUSARG(clkmgr_mubi_e, mubi_mode, "clkmgr_mubi_mode")
     `uvm_info(`gfn, $sformatf("mubi_mode = %s", mubi_mode.name), UVM_MEDIUM)
     cfg.clkmgr_vif.init(.idle({NUM_TRANS{MuBi4True}}), .scanmode(scanmode));
     cfg.clkmgr_vif.update_io_ip_clk_en(1'b1);

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -117,7 +117,7 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
     cfg.pwrmgr_vif.lc_hw_debug_en = lc_ctrl_pkg::Off;
     cfg.pwrmgr_vif.lc_dft_en = lc_ctrl_pkg::Off;
     mubi_mode = PwrmgrMubiNone;
-    `DV_GET_ENUM_PLUSARG(pwrmgr_mubi_e, mubi_mode, pwrmgr_mubi_mode)
+    `DV_GET_ENUM_PLUSARG(pwrmgr_mubi_e, mubi_mode, "pwrmgr_mubi_mode")
     `uvm_info(`gfn, $sformatf("pwrmgr mubi mode : %s", mubi_mode.name()), UVM_MEDIUM)
 
     if (do_pwrmgr_init) pwrmgr_init();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
@@ -33,7 +33,7 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
       // overridden by the DV_GET_ENUM_PLUSARG macro below if the +select_jtag plusarg was provided.
       chip_jtag_tap_e from_plusarg = select_jtag;
 
-      `DV_GET_ENUM_PLUSARG(chip_common_pkg::chip_jtag_tap_e, from_plusarg, select_jtag)
+      `DV_GET_ENUM_PLUSARG(chip_common_pkg::chip_jtag_tap_e, from_plusarg, "select_jtag")
 
       if (select_jtag != JtagTapNone) begin
         // The select_jtag variable must have been set by the subclass. Check that there hasn't been

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_base_vseq.sv
@@ -15,7 +15,7 @@ class chip_sw_lc_base_vseq extends chip_sw_base_vseq;
 
   virtual task pre_start();
     cfg.chip_vif.tap_straps_if.drive(JtagTapLc);
-    `DV_GET_ENUM_PLUSARG(lc_ctrl_state_pkg::dec_lc_state_e, init_lc_state, src_dec_state)
+    `DV_GET_ENUM_PLUSARG(lc_ctrl_state_pkg::dec_lc_state_e, init_lc_state, "src_dec_state")
     `uvm_info(`gfn, $sformatf("Init lc state is %0s", init_lc_state.name), UVM_MEDIUM)
     super.pre_start();
   endtask

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_scrap_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_scrap_vseq.sv
@@ -37,7 +37,7 @@ class chip_sw_lc_ctrl_scrap_vseq extends chip_sw_lc_base_vseq;
 
       // source state is randomized by default,
       // but if a plusarg is supplied, assign the given value
-      `DV_GET_ENUM_PLUSARG(lc_ctrl_state_pkg::dec_lc_state_e, src_state, src_dec_state)
+      `DV_GET_ENUM_PLUSARG(lc_ctrl_state_pkg::dec_lc_state_e, src_state, "src_dec_state")
       `uvm_info(`gfn, $sformatf("Source state is %0s", src_state.name), UVM_MEDIUM)
     end
   endfunction : pre_randomize

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_vseq.sv
@@ -21,7 +21,7 @@ class chip_sw_lc_walkthrough_vseq extends chip_sw_base_vseq;
   lc_ctrl_state_pkg::dec_lc_state_e dest_dec_state = lc_ctrl_state_pkg::DecLcStProdEnd;
 
   virtual task pre_start();
-    `DV_GET_ENUM_PLUSARG(lc_ctrl_state_pkg::dec_lc_state_e, dest_dec_state, dest_dec_state)
+    `DV_GET_ENUM_PLUSARG(lc_ctrl_state_pkg::dec_lc_state_e, dest_dec_state, "dest_dec_state")
     `uvm_info(`gfn, $sformatf("Destination state is %0s", dest_dec_state.name), UVM_MEDIUM)
     cfg.chip_vif.tap_straps_if.drive(JtagTapLc);
     super.pre_start();

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -24,7 +24,7 @@ class chip_base_test extends cip_base_test #(
     super.build_phase(phase);
 
     // Knob to select the chip clock source.
-    `DV_GET_ENUM_PLUSARG(chip_clock_source_e, cfg.chip_clock_source, chip_clock_source)
+    `DV_GET_ENUM_PLUSARG(chip_clock_source_e, cfg.chip_clock_source, "chip_clock_source")
     if (cfg.chip_clock_source != ChipClockSourceInternal) begin
       cfg.clk_freq_mhz = cfg.chip_clock_source;
     end
@@ -66,7 +66,7 @@ class chip_base_test extends cip_base_test #(
     end
 
     // Knob to select the OTP image based on LC state.
-    `DV_GET_ENUM_PLUSARG(otp_type_e, cfg.use_otp_image, use_otp_image)
+    `DV_GET_ENUM_PLUSARG(otp_type_e, cfg.use_otp_image, "use_otp_image")
     `DV_CHECK_FATAL(cfg.otp_images.exists(cfg.use_otp_image),
                     $sformatf({"Unsupported plusarg value: +use_otp_image=%0s. An image associated",
                                "with this LC state needs to be created first."}, cfg.use_otp_image))

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -112,7 +112,7 @@ class clkmgr_base_vseq extends cip_base_vseq #(
                                     ral.usb_meas_ctrl_shadowed.hi,
                                     ral.usb_meas_ctrl_shadowed.lo};
     mubi_mode = ClkmgrMubiNone;
-    `DV_GET_ENUM_PLUSARG(clkmgr_mubi_e, mubi_mode, clkmgr_mubi_mode)
+    `DV_GET_ENUM_PLUSARG(clkmgr_mubi_e, mubi_mode, "clkmgr_mubi_mode")
     `uvm_info(`gfn, $sformatf("mubi_mode = %s", mubi_mode.name), UVM_MEDIUM)
     cfg.clkmgr_vif.init(.idle({NUM_TRANS{MuBi4True}}), .scanmode(scanmode), .lc_debug_en(Off));
     cfg.clkmgr_vif.update_io_ip_clk_en(1'b1);

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -124,7 +124,7 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
     cfg.pwrmgr_vif.lc_hw_debug_en = lc_ctrl_pkg::Off;
     cfg.pwrmgr_vif.lc_dft_en = lc_ctrl_pkg::Off;
     mubi_mode = PwrmgrMubiNone;
-    `DV_GET_ENUM_PLUSARG(pwrmgr_mubi_e, mubi_mode, pwrmgr_mubi_mode)
+    `DV_GET_ENUM_PLUSARG(pwrmgr_mubi_e, mubi_mode, "pwrmgr_mubi_mode")
     `uvm_info(`gfn, $sformatf("pwrmgr mubi mode : %s", mubi_mode.name()), UVM_MEDIUM)
 
     if (do_pwrmgr_init) pwrmgr_init();

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -109,7 +109,7 @@ class clkmgr_base_vseq extends cip_base_vseq #(
                                     ral.usb_meas_ctrl_shadowed.hi,
                                     ral.usb_meas_ctrl_shadowed.lo};
     mubi_mode = ClkmgrMubiNone;
-    `DV_GET_ENUM_PLUSARG(clkmgr_mubi_e, mubi_mode, clkmgr_mubi_mode)
+    `DV_GET_ENUM_PLUSARG(clkmgr_mubi_e, mubi_mode, "clkmgr_mubi_mode")
     `uvm_info(`gfn, $sformatf("mubi_mode = %s", mubi_mode.name), UVM_MEDIUM)
     cfg.clkmgr_vif.init(.idle({NUM_TRANS{MuBi4True}}), .scanmode(scanmode), .lc_debug_en(Off));
     cfg.clkmgr_vif.update_io_ip_clk_en(1'b1);

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -124,7 +124,7 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
     cfg.pwrmgr_vif.lc_hw_debug_en = lc_ctrl_pkg::Off;
     cfg.pwrmgr_vif.lc_dft_en = lc_ctrl_pkg::Off;
     mubi_mode = PwrmgrMubiNone;
-    `DV_GET_ENUM_PLUSARG(pwrmgr_mubi_e, mubi_mode, pwrmgr_mubi_mode)
+    `DV_GET_ENUM_PLUSARG(pwrmgr_mubi_e, mubi_mode, "pwrmgr_mubi_mode")
     `uvm_info(`gfn, $sformatf("pwrmgr mubi mode : %s", mubi_mode.name()), UVM_MEDIUM)
 
     if (do_pwrmgr_init) pwrmgr_init();


### PR DESCRIPTION
The first commit to be merged from this PR was inspired by a review of #29723, where it was noticeable how confusing the "stringification" in this macro can be. Both commits make the macro a bit simpler / easier to use.