### PR TITLE
[crypto/entropy] Add health_test_config_check testing

### DIFF
--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -1059,9 +1059,11 @@ status_t entropy_complex_health_test_config_check(hardened_bool_t fips) {
   // Check health test window
   reg = abs_mmio_read32(kBaseEntropySrc +
                         ENTROPY_SRC_HEALTH_TEST_WINDOWS_REG_OFFSET);
-  HARDENED_CHECK_EQ(bitfield_field32_read(
-                        reg, ENTROPY_SRC_HEALTH_TEST_WINDOWS_FIPS_WINDOW_FIELD),
-                    entropy_src_config->fips_test_window_size);
+  if (bitfield_field32_read(
+          reg, ENTROPY_SRC_HEALTH_TEST_WINDOWS_FIPS_WINDOW_FIELD) !=
+      entropy_src_config->fips_test_window_size) {
+    return OTCRYPTO_RECOV_ERR;
+  }
 
   // Check recoverable alerts
   if (abs_mmio_read32(kBaseEntropySrc +

--- a/sw/device/lib/crypto/drivers/entropy_test.c
+++ b/sw/device/lib/crypto/drivers/entropy_test.c
@@ -77,11 +77,39 @@ static status_t run_negative_test(void) {
   return OTCRYPTO_OK;
 }
 
+static status_t health_test_config_check_test(void) {
+  LOG_INFO("Running health test config check tests.");
+
+  // Test with FIPS set to False
+  TRY(entropy_complex_health_test_config_check(kHardenedBoolFalse));
+  CHECK(entropy_complex_health_test_config_check(kHardenedBoolTrue).value ==
+        OTCRYPTO_RECOV_ERR.value);
+
+  return OK_STATUS();
+}
+
+static status_t upgrade_fips_test(void) {
+  LOG_INFO("Running test to check it is possible to upgrade to fips.");
+
+  // Test with FIPS set to True
+  TRY(entropy_complex_init(kHardenedBoolTrue));
+  TRY(entropy_complex_health_test_config_check(kHardenedBoolTrue));
+  CHECK(entropy_complex_health_test_config_check(kHardenedBoolFalse).value ==
+        OTCRYPTO_RECOV_ERR.value);
+
+  return OK_STATUS();
+}
+
 bool test_main(void) {
   status_t result = OK_STATUS();
 
   EXECUTE_TEST(result, entropy_complex_init_test);
+  EXECUTE_TEST(result, health_test_config_check_test);
   EXECUTE_TEST(result, entropy_csrng_kat);
   EXECUTE_TEST(result, run_negative_test);
+
+  // Needs to be the last test as it upgrades to fips as we can not downgrade.
+  EXECUTE_TEST(result, upgrade_fips_test);
+
   return status_ok(result);
 }


### PR DESCRIPTION
Add a positive and negative test for health_test_config_check as well as an upgrade to fips test.
This test found out that we are too harsh to handle a bad configuration crashing the chip instead of providing a bad status. Change the function to provide the bad status instead.