### PR TITLE
[crypto/test] Add cSHAKE examples in functest

### DIFF
--- a/sw/device/tests/crypto/testvectors/kmac_hardcoded.hjson
+++ b/sw/device/tests/crypto/testvectors/kmac_hardcoded.hjson
@@ -41,4 +41,26 @@
     cust_str: 0x7bd5d47e446fcec2a3d811736110e5781bcccea696762e6116c6e9c92d99bf35
     digest: 0x108bcfadf89ed67c806f5b73216755c38b578488
   }
+  {
+    vector_identifier: "NIST SP 800-185, cSHAKE_samples.pdf, Sample #1"
+    operation: CSHAKE
+    security_str: 128
+    // Key is not used here, but we need a value.
+    key: 0x00000000
+    input_msg: 0x00010203
+    // Hex encoding for the ASCII string "Email Signature"
+    cust_str: 0x456d61696c205369676e6174757265
+    digest: 0xc1c36925b6409a04f1b504fcbca9d82b4017277cb5ed2b2065fc1d3814d5aaf5
+  }
+  {
+    vector_identifier: "NIST SP 800-185, cSHAKE_samples.pdf, Sample #3"
+    operation: CSHAKE
+    security_str: 256
+    // Key is not used here, but we need a value.
+    key: 0x00000000
+    input_msg: 0x00010203
+    // Hex encoding for the ASCII string "Email Signature"
+    cust_str: 0x456d61696c205369676e6174757265
+    digest: 0xd008828e2b80ac9d2218ffee1d070c48b8e4c87bff32c9699d5b6896eee0edd164020e2be0560858d9c00c037e34a96937c561a74c412bb4c746469527281c8c
+  }
 ]


### PR DESCRIPTION
Expand the kmac_hardcoded hjson to include some NIST cSHAKE examples.