### PR TITLE
[tl,dv] Clear the stop flag at the end, not the start, of body()

### DIFF
--- a/hw/dv/sv/tl_agent/seq_lib/tl_device_seq.sv
+++ b/hw/dv/sv/tl_agent/seq_lib/tl_device_seq.sv
@@ -42,9 +42,6 @@ class tl_device_seq #(type REQ = tl_seq_item, int unsigned AddrWidth = 32) exten
   }
 
   virtual task body();
-    // Clear the stop flag (which may have been set by seq_stop on the previous run of the sequence)
-    stop = 0;
-
     fork
       begin: isolation_thread
         fork
@@ -56,6 +53,11 @@ class tl_device_seq #(type REQ = tl_seq_item, int unsigned AddrWidth = 32) exten
         disable fork;
       end
     join
+
+    // Clear the stop flag. It must be set (because collect_request_thread and send_response_thread
+    // don't stop otherwise). Clear it to allow a virtual sequence to start the same sequence object
+    // again if it wishes.
+    stop = 0;
   endtask
 
   // A blocking task that retrieves a request from the TLM fifo, unless the seq is stopped.


### PR DESCRIPTION
Before this change, there was a race condition in the rv_dm testbench.

That block's base virtual sequence creates a device sequence (m_tl_sba_device_seq) in a task called
sba_tl_device_seq_start and then uses fork/join_none to start it in the background. One sequence that derives from rv_dm_base_vseq is rv_dm_sba_tl_access_vseq, which calls sba_tl_device_seq_stop at the start of its body. The result is that you can end up with this course of events:

  - rv_dm_base_vseq::dut_init calls sba_tl_device_seq_start, which starts an instance of tl_device_seq (whose body will run shortly).

  - The start of rv_dm_sba_tl_access_vseq::body calls sba_tl_device_seq_stop, which sets the stop flag in the device sequence and then waits for that sequence to run to completion.

  - The device sequence finally starts! At the start of tl_device_seq::body, it clears the stop flag.

  - The device sequence now runs until it sees the stop flag being set.

  - Hang.

The change in this commit moves the flag clearing to the end of the sequence. Honestly, I don't think we ever run an instance of this sequence multiple times, so we can probably just drop it. But this is clearly safe too.

Initial debugging made me wonder whether this was caused by commit c3b9a23, but I think the race is there either way.

This change fixes rv_dm_sba_tl_access, which is currently broken.