### PR TITLE
[rv_timer,dv] Fix broken TL handling in scoreboard

### DIFF
--- a/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
@@ -50,6 +50,8 @@ class rv_timer_scoreboard extends cip_base_scoreboard #(.CFG_T (rv_timer_env_cfg
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 
+    csr_name = csr.get_name();
+
     if (!write && channel == AddrChannel) begin
       if (!uvm_re_match("intr_state*", csr_name)) begin
         for (int i = 0; i < NUM_HARTS; i++) begin


### PR DESCRIPTION
This was my fault, caused by commit 6f9c36f: I accidentally removed the code that put the name of the CSR in a local variable.