### PR TITLE
[hw] gpiodpi: fix backwards log message

### DIFF
--- a/hw/dv/dpi/gpiodpi/gpiodpi.c
+++ b/hw/dv/dpi/gpiodpi/gpiodpi.c
@@ -240,9 +240,9 @@ uint32_t gpiodpi_host_to_device_tick(void *ctx_void, svBitVecVal *gpio_oe,
             ++gpio_text;
             int idx = parse_dec(&gpio_text);
             if (idx < NUM_GPIO) {
-              if (!GET_BIT(gpio_oe[0], idx)) {
+              if (GET_BIT(gpio_oe[0], idx)) {
                 fprintf(stderr,
-                        "GPIO: Host tried to pull disabled pin low: pin %2d\n",
+                        "GPIO: Host tried to pull output pin low: pin %2d\n",
                         idx);
               }
               CLR_BIT(ctx->driven_pin_values, idx);
@@ -260,9 +260,9 @@ uint32_t gpiodpi_host_to_device_tick(void *ctx_void, svBitVecVal *gpio_oe,
             ++gpio_text;
             int idx = parse_dec(&gpio_text);
             if (idx < NUM_GPIO) {
-              if (!GET_BIT(gpio_oe[0], idx)) {
+              if (GET_BIT(gpio_oe[0], idx)) {
                 fprintf(stderr,
-                        "GPIO: Host tried to pull disabled pin high: pin %2d\n",
+                        "GPIO: Host tried to pull output pin high: pin %2d\n",
                         idx);
               }
               SET_BIT(ctx->driven_pin_values, idx);


### PR DESCRIPTION
In the host -> device direction, the GPIODPI checks whether a written pin's output enable is *not* set, and if so issues a log message saying that the host tried to pull a disabled pin.

This check is backwards - if output enable is not set, then it *is* an input pin and can be effected by the write.

This flips the condition for the log message and changes 'disabled pin' to 'output pin' to make it more clear that the write was ineffective because the pin is in output mode.