### PR TITLE
[crypto] Update CL API doc

### DIFF
--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -37,6 +37,11 @@ For more details, see later sections (links in the "category" column).
 | [**Deterministic random bit generation**](#deterministic-random-bit-generation) | AES-CTR-DRBG |
 | [**Key derivation**](#key-derivation) | HMAC-KDF-CTR<br>KMAC-KDF-CTR |
 
+## Cryptolib Usage Examples
+
+Examples of how to use the cryptolib API are provided in the [cryptolib test directory][crypto-tests].
+These examples cover a range of algorithms and demonstrate the typical call sequence for symmetric and asymmetric cryptographic operations including key generation.
+
 ## Data structures
 
 These are the basic data structures used by the crypto library to communicate with the caller.
@@ -818,3 +823,4 @@ The table below is a recommendation from [NIST SP800-57 Part 1][nist-sp800-57] a
 [sha2-spec]: https://csrc.nist.gov/publications/detail/fips/180/4/final
 [sha3-spec]: https://csrc.nist.gov/publications/detail/fips/202/final
 [sha3-derived-spec]: https://csrc.nist.gov/publications/detail/sp/800-185/final
+[crypto-tests]: https://github.com/lowRISC/opentitan/tree/earlgrey_1.0.0/sw/device/tests/crypto

--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -171,6 +171,82 @@ A one-shot API initializes the required block cipher mode of operation (ECB, CBC
 {{#header-snippet sw/device/lib/crypto/include/aes.h otcrypto_aes_padding_strip }}
 {{#header-snippet sw/device/lib/crypto/include/aes.h otcrypto_aes }}
 
+#### Usage
+
+The following example shows how a message can be encrypted and decrypted using the cryptolib AES API.
+
+```c
+enum {
+  // Plaintext is 20 bytes: not a multiple of the 16-byte AES block size.
+  kPlaintextLen = 20,
+};
+
+// Two key shares that XOR to the actual 128-bit key.
+static const uint32_t kKeyShare0[4] = {0xdeadbeef, 0x01234567, 0x89abcdef, 0xfedcba98};
+static const uint32_t kKeyShare1[4] = {0x00000000, 0x00000000, 0x00000000, 0x00000000};
+
+bool aes_encrypt_decrypt_example(void) {
+  // --- Build the blinded AES-ECB key ---
+  otcrypto_key_config_t key_config = {
+    .version        = kOtcryptoLibVersion1,
+    .key_mode       = kOtcryptoKeyModeAesEcb,
+    .key_length     = 16,
+    .hw_backed      = kHardenedBoolFalse,
+    .exportable     = kHardenedBoolFalse,
+    .security_level = kOtcryptoKeySecurityLevelLow,
+  };
+  // Keyblob must be twice the key length (holds two shares).
+  uint32_t keyblob[8];
+  otcrypto_blinded_key_t key = {
+    .config         = key_config,
+    .keyblob_length = sizeof(keyblob),
+    .keyblob        = keyblob,
+  };
+  otcrypto_const_word32_buf_t share0 =
+    OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, kKeyShare0, 4);
+  otcrypto_const_word32_buf_t share1 =
+    OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, kKeyShare1, 4);
+  TRY(otcrypto_import_blinded_key(&share0, &share1, &key));
+
+  // --- Plaintext: 20 bytes, not a multiple of the block size ---
+  static const uint8_t kPlaintext[kPlaintextLen] = "Hello, OpenTitan!!!";
+
+  // --- Query padded length, then allocate output buffers ---
+  size_t padded_len;
+  TRY(otcrypto_aes_padded_plaintext_length(
+    kPlaintextLen, kOtcryptoAesPaddingPkcs7, &padded_len));
+
+  uint8_t ciphertext[padded_len];
+  uint8_t decrypted[padded_len];
+
+  // --- Encrypt ---
+  otcrypto_const_byte_buf_t plaintext_buf =
+    OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, kPlaintext, kPlaintextLen);
+  otcrypto_byte_buf_t ciphertext_buf =
+    OTCRYPTO_MAKE_BUF(otcrypto_byte_buf_t, ciphertext, padded_len);
+  TRY(otcrypto_aes(&key, /*iv=*/NULL, kOtcryptoAesModeEcb,
+                   kOtcryptoAesOperationEncrypt, &plaintext_buf,
+                   kOtcryptoAesPaddingPkcs7, &ciphertext_buf));
+
+  // --- Decrypt ---
+  otcrypto_const_byte_buf_t ciphertext_in =
+    OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, ciphertext, padded_len);
+  otcrypto_byte_buf_t decrypted_buf =
+    OTCRYPTO_MAKE_BUF(otcrypto_byte_buf_t, decrypted, padded_len);
+  TRY(otcrypto_aes(&key, /*iv=*/NULL, kOtcryptoAesModeEcb,
+                   kOtcryptoAesOperationDecrypt, &ciphertext_in,
+                   kOtcryptoAesPaddingPkcs7, &decrypted_buf));
+
+  // --- Strip padding ---
+  size_t recovered_len;
+  TRY(otcrypto_aes_padding_strip(
+    &decrypted_buf, kOtcryptoAesPaddingPkcs7, &recovered_len));
+
+  // --- Compare ---
+  return memcmp(kPlaintext, decrypted, recovered_len) == 0;
+}
+```
+
 ### AES-GCM
 
 AES-GCM (Galois/Counter Mode) is an authenticated encryption with associated data (AEAD) scheme.

--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -168,6 +168,7 @@ Because the crypto library uses the hardware AES block, it does not expose an in
 A one-shot API initializes the required block cipher mode of operation (ECB, CBC, CFB, OFB or CTR) and performs the required encryption/decryption.
 
 {{#header-snippet sw/device/lib/crypto/include/aes.h otcrypto_aes_padded_plaintext_length }}
+{{#header-snippet sw/device/lib/crypto/include/aes.h otcrypto_aes_padding_strip }}
 {{#header-snippet sw/device/lib/crypto/include/aes.h otcrypto_aes }}
 
 ### AES-GCM
@@ -390,6 +391,7 @@ For Ed25519 (a curve-specialized version of EdDSA, the Edwards curve digital sig
 {{#header-snippet sw/device/lib/crypto/include/ecc_curve25519.h otcrypto_ed25519_keygen }}
 {{#header-snippet sw/device/lib/crypto/include/ecc_curve25519.h otcrypto_ed25519_sign }}
 {{#header-snippet sw/device/lib/crypto/include/ecc_curve25519.h otcrypto_ed25519_verify }}
+{{#header-snippet sw/device/lib/crypto/include/ecc_curve25519.h otcrypto_ed25519_sign_verify }}
 
 #### X25519
 
@@ -454,6 +456,32 @@ Each party should generate a key pair, exchange public keys, and then generate t
 
 {{#header-snippet sw/device/lib/crypto/include/x25519.h otcrypto_x25519_async_start }}
 {{#header-snippet sw/device/lib/crypto/include/x25519.h otcrypto_x25519_async_finalize }}
+
+### Generic ECC Functions
+
+In addition to the specific ECC functions, the cryptolib also offers more generic functions.
+
+The following key import, export, and sharing functions are available.
+
+{{#header-snippet sw/device/lib/crypto/include/ecc_p256.h otcrypto_ecc_p256_private_key_import }}
+{{#header-snippet sw/device/lib/crypto/include/ecc_p256.h otcrypto_ecc_p256_private_key_export }}
+{{#header-snippet sw/device/lib/crypto/include/ecc_p256.h otcrypto_ecc_p256_public_key_import }}
+{{#header-snippet sw/device/lib/crypto/include/ecc_p256.h otcrypto_ecc_p256_public_key_export }}
+{{#header-snippet sw/device/lib/crypto/include/ecc_p256.h otcrypto_ecc_p256_arith_share_private_key }}
+
+{{#header-snippet sw/device/lib/crypto/include/ecc_p384.h otcrypto_ecc_p384_private_key_import }}
+{{#header-snippet sw/device/lib/crypto/include/ecc_p384.h otcrypto_ecc_p384_private_key_export }}
+{{#header-snippet sw/device/lib/crypto/include/ecc_p384.h otcrypto_ecc_p384_public_key_import }}
+{{#header-snippet sw/device/lib/crypto/include/ecc_p384.h otcrypto_ecc_p384_public_key_export }}
+{{#header-snippet sw/device/lib/crypto/include/ecc_p384.h otcrypto_ecc_p384_arith_share_private_key }}
+
+Cryptolib also offers helper functions to check a given point as well as perform a base point multiplication.
+
+{{#header-snippet sw/device/lib/crypto/include/ecc_p256.h otcrypto_ecc_p256_point_on_curve }}
+{{#header-snippet sw/device/lib/crypto/include/ecc_p256.h otcrypto_ecc_p256_base_point_mult }}
+
+{{#header-snippet sw/device/lib/crypto/include/ecc_p384.h otcrypto_ecc_p384_point_on_curve }}
+{{#header-snippet sw/device/lib/crypto/include/ecc_p384.h otcrypto_ecc_p384_base_point_mult }}
 
 ## Deterministic random bit generation
 

--- a/sw/device/lib/crypto/impl/ecc_p256.c
+++ b/sw/device/lib/crypto/impl/ecc_p256.c
@@ -311,7 +311,7 @@ otcrypto_status_t otcrypto_ecdh_p256(const otcrypto_blinded_key_t *private_key,
   return otcrypto_ecdh_p256_async_finalize(shared_secret);
 }
 
-otcrypto_status_t otcrypto_p256_point_on_curve(
+otcrypto_status_t otcrypto_ecc_p256_point_on_curve(
     const otcrypto_unblinded_key_t *point, hardened_bool_t *check_result) {
   if (point == NULL || point->key == NULL || check_result == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -323,7 +323,7 @@ otcrypto_status_t otcrypto_p256_point_on_curve(
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
-status_t otcrypto_p256_base_point_mult(
+status_t otcrypto_ecc_p256_base_point_mult(
     const otcrypto_blinded_key_t *private_key,
     otcrypto_unblinded_key_t *public_key) {
   if (private_key == NULL || public_key == NULL) {

--- a/sw/device/lib/crypto/impl/ecc_p384.c
+++ b/sw/device/lib/crypto/impl/ecc_p384.c
@@ -347,7 +347,7 @@ otcrypto_status_t otcrypto_ecdh_p384(const otcrypto_blinded_key_t *private_key,
   return otcrypto_ecdh_p384_async_finalize(shared_secret);
 }
 
-otcrypto_status_t otcrypto_p384_point_on_curve(
+otcrypto_status_t otcrypto_ecc_p384_point_on_curve(
     const otcrypto_unblinded_key_t *point, hardened_bool_t *check_result) {
   if (point == NULL || point->key == NULL || check_result == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -359,7 +359,7 @@ otcrypto_status_t otcrypto_p384_point_on_curve(
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
-status_t otcrypto_p384_base_point_mult(
+status_t otcrypto_ecc_p384_base_point_mult(
     const otcrypto_blinded_key_t *private_key,
     otcrypto_unblinded_key_t *public_key) {
   if (private_key == NULL || public_key == NULL) {

--- a/sw/device/lib/crypto/impl/kats.c
+++ b/sw/device/lib/crypto/impl/kats.c
@@ -685,7 +685,7 @@ static status_t kat_p256_base_point_mul(void) {
       .key = pk_act,
   };
 
-  HARDENED_TRY(otcrypto_p256_base_point_mult(&private_key, &public_key));
+  HARDENED_TRY(otcrypto_ecc_p256_base_point_mult(&private_key, &public_key));
 
   if (memcmp(pk_act, p256_Q, 64)) {
     return OTCRYPTO_BAD_ARGS;
@@ -732,7 +732,7 @@ static status_t kat_p256_point_on_curve(void) {
                                     .key_length = sizeof(p256_Q)};
   point.checksum = integrity_unblinded_checksum(&point);
 
-  HARDENED_TRY(otcrypto_p256_point_on_curve(&point, &result));
+  HARDENED_TRY(otcrypto_ecc_p256_point_on_curve(&point, &result));
   HARDENED_CHECK_EQ(result, kHardenedBoolTrue);
 
   uint32_t bad_point_data[16] = {0};
@@ -744,7 +744,7 @@ static status_t kat_p256_point_on_curve(void) {
                                         .key_length = sizeof(bad_point_data)};
   bad_point.checksum = integrity_unblinded_checksum(&bad_point);
 
-  HARDENED_TRY(otcrypto_p256_point_on_curve(&bad_point, &result));
+  HARDENED_TRY(otcrypto_ecc_p256_point_on_curve(&bad_point, &result));
   HARDENED_CHECK_EQ(result, kHardenedBoolFalse);
 
   return OTCRYPTO_OK;
@@ -806,7 +806,7 @@ static status_t kat_p384_base_point_mul(void) {
       .key = pk_act,
   };
 
-  HARDENED_TRY(otcrypto_p384_base_point_mult(&private_key, &public_key));
+  HARDENED_TRY(otcrypto_ecc_p384_base_point_mult(&private_key, &public_key));
 
   if (memcmp(pk_act, p384_Q, 96)) {
     return OTCRYPTO_BAD_ARGS;
@@ -853,7 +853,7 @@ static status_t kat_p384_point_on_curve(void) {
                                     .key_length = sizeof(p384_Q)};
   point.checksum = integrity_unblinded_checksum(&point);
 
-  HARDENED_TRY(otcrypto_p384_point_on_curve(&point, &result));
+  HARDENED_TRY(otcrypto_ecc_p384_point_on_curve(&point, &result));
   HARDENED_CHECK_EQ(result, kHardenedBoolTrue);
 
   uint32_t bad_point_data[24] = {0};
@@ -865,7 +865,7 @@ static status_t kat_p384_point_on_curve(void) {
                                         .key_length = sizeof(bad_point_data)};
   bad_point.checksum = integrity_unblinded_checksum(&bad_point);
 
-  HARDENED_TRY(otcrypto_p384_point_on_curve(&bad_point, &result));
+  HARDENED_TRY(otcrypto_ecc_p384_point_on_curve(&bad_point, &result));
   HARDENED_CHECK_EQ(result, kHardenedBoolFalse);
 
   return OTCRYPTO_OK;

--- a/sw/device/lib/crypto/include/ecc_p256.h
+++ b/sw/device/lib/crypto/include/ecc_p256.h
@@ -550,7 +550,7 @@ otcrypto_status_t otcrypto_ecc_p256_public_key_export(
  * checked.
  * @return Result of the point valid check operation.
  */
-otcrypto_status_t otcrypto_p256_point_on_curve(
+otcrypto_status_t otcrypto_ecc_p256_point_on_curve(
     const otcrypto_unblinded_key_t *point, hardened_bool_t *check_result);
 
 /**
@@ -563,7 +563,7 @@ otcrypto_status_t otcrypto_p256_point_on_curve(
  * @param public_key The resulting public key of the base point multiplication.
  * @return Result of the base point multiplication.
  */
-status_t otcrypto_p256_base_point_mult(
+status_t otcrypto_ecc_p256_base_point_mult(
     const otcrypto_blinded_key_t *private_key,
     otcrypto_unblinded_key_t *public_key);
 

--- a/sw/device/lib/crypto/include/ecc_p384.h
+++ b/sw/device/lib/crypto/include/ecc_p384.h
@@ -462,7 +462,7 @@ otcrypto_status_t otcrypto_ecc_p384_public_key_export(
  * checked.
  * @return Result of the point valid check operation.
  */
-otcrypto_status_t otcrypto_p384_point_on_curve(
+otcrypto_status_t otcrypto_ecc_p384_point_on_curve(
     const otcrypto_unblinded_key_t *point, hardened_bool_t *check_result);
 
 /**
@@ -475,7 +475,7 @@ otcrypto_status_t otcrypto_p384_point_on_curve(
  * @param public_key The resulting public key of the base point multiplication.
  * @return Result of the base point multiplication.
  */
-status_t otcrypto_p384_base_point_mult(
+status_t otcrypto_ecc_p384_base_point_mult(
     const otcrypto_blinded_key_t *private_key,
     otcrypto_unblinded_key_t *public_key);
 

--- a/sw/device/tests/crypto/ecc_p256_arith_share_private_key_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_arith_share_private_key_functest.c
@@ -111,7 +111,7 @@ status_t arith_share_private_key_test(void) {
 
   LOG_INFO("Calculating the public key...");
   CHECK_STATUS_OK(
-      otcrypto_p256_base_point_mult(&arith_shared_private_key, &ppp));
+      otcrypto_ecc_p256_base_point_mult(&arith_shared_private_key, &ppp));
 
   // Part 3: Sign a message with the arithmetically shared key.
 

--- a/sw/device/tests/crypto/ecc_p256_base_point_mult_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_base_point_mult_functest.c
@@ -60,7 +60,8 @@ status_t base_point_mult_test(void) {
   };
 
   LOG_INFO("Calculating base point multiplication...");
-  CHECK_STATUS_OK(otcrypto_p256_base_point_mult(&private_key, &public_key_ver));
+  CHECK_STATUS_OK(
+      otcrypto_ecc_p256_base_point_mult(&private_key, &public_key_ver));
 
   // The intial generated public key and the public key from the base point
   // multipliation must match.

--- a/sw/device/tests/crypto/ecc_p256_point_on_curve_check_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_point_on_curve_check_functest.c
@@ -47,7 +47,7 @@ status_t point_valid_test(void) {
 
   // Verify the valid point.
   hardened_bool_t result;
-  TRY(otcrypto_p256_point_on_curve(&point_valid, &result));
+  TRY(otcrypto_ecc_p256_point_on_curve(&point_valid, &result));
 
   if (result != kHardenedBoolTrue) {
     LOG_ERROR("Valid point failed point check.");
@@ -62,7 +62,7 @@ status_t point_valid_test(void) {
   };
 
   // Verify the invalid point.
-  TRY(otcrypto_p256_point_on_curve(&point_invalid, &result));
+  TRY(otcrypto_ecc_p256_point_on_curve(&point_invalid, &result));
 
   if (result != kHardenedBoolFalse) {
     LOG_ERROR("Invalid point passed point check.");

--- a/sw/device/tests/crypto/ecc_p384_arith_share_private_key_functest.c
+++ b/sw/device/tests/crypto/ecc_p384_arith_share_private_key_functest.c
@@ -113,8 +113,8 @@ status_t arith_share_private_key_test(void) {
   };
 
   LOG_INFO("Calculating the public key...");
-  CHECK_STATUS_OK(
-      otcrypto_p384_base_point_mult(&arith_shared_private_key, &public_key));
+  CHECK_STATUS_OK(otcrypto_ecc_p384_base_point_mult(&arith_shared_private_key,
+                                                    &public_key));
 
   // Part 3: Sign a message with the arithmetically shared key.
 

--- a/sw/device/tests/crypto/ecc_p384_base_point_mult_functest.c
+++ b/sw/device/tests/crypto/ecc_p384_base_point_mult_functest.c
@@ -60,7 +60,8 @@ status_t base_point_mult_test(void) {
   };
 
   LOG_INFO("Calculating base point multiplication...");
-  CHECK_STATUS_OK(otcrypto_p384_base_point_mult(&private_key, &public_key_ver));
+  CHECK_STATUS_OK(
+      otcrypto_ecc_p384_base_point_mult(&private_key, &public_key_ver));
 
   // The intial generated public key and the public key from the base point
   // multipliation must match.

--- a/sw/device/tests/crypto/ecc_p384_point_on_curve_check_functest.c
+++ b/sw/device/tests/crypto/ecc_p384_point_on_curve_check_functest.c
@@ -55,7 +55,7 @@ status_t point_valid_test(void) {
 
   // Verify the valid point.
   hardened_bool_t result;
-  TRY(otcrypto_p384_point_on_curve(&point_valid, &result));
+  TRY(otcrypto_ecc_p384_point_on_curve(&point_valid, &result));
 
   if (result != kHardenedBoolTrue) {
     LOG_ERROR("Valid point failed point check.");
@@ -70,7 +70,7 @@ status_t point_valid_test(void) {
   };
 
   // Verify the invalid point.
-  TRY(otcrypto_p384_point_on_curve(&point_invalid, &result));
+  TRY(otcrypto_ecc_p384_point_on_curve(&point_invalid, &result));
 
   if (result != kHardenedBoolFalse) {
     LOG_ERROR("Invalid point passed point check.");

--- a/sw/device/tests/crypto/otcrypto_interface.c
+++ b/sw/device/tests/crypto/otcrypto_interface.c
@@ -223,8 +223,8 @@ volatile otcrypto_interface_t otcrypto = {
     .ecc_p256_private_key_export = &otcrypto_ecc_p256_private_key_export,
     .ecc_p256_public_key_import = &otcrypto_ecc_p256_public_key_import,
     .ecc_p256_public_key_export = &otcrypto_ecc_p256_public_key_export,
-    .p256_point_on_curve = &otcrypto_p256_point_on_curve,
-    .p256_base_point_mult = &otcrypto_p256_base_point_mult,
+    .ecc_p256_point_on_curve = &otcrypto_ecc_p256_point_on_curve,
+    .ecc_p256_base_point_mult = &otcrypto_ecc_p256_base_point_mult,
     .ecc_p256_arith_share_private_key =
         &otcrypto_ecc_p256_arith_share_private_key,
 
@@ -263,8 +263,8 @@ volatile otcrypto_interface_t otcrypto = {
     .ecc_p384_private_key_export = &otcrypto_ecc_p384_private_key_export,
     .ecc_p384_public_key_import = &otcrypto_ecc_p384_public_key_import,
     .ecc_p384_public_key_export = &otcrypto_ecc_p384_public_key_export,
-    .p384_point_on_curve = &otcrypto_p384_point_on_curve,
-    .p384_base_point_mult = &otcrypto_p384_base_point_mult,
+    .ecc_p384_point_on_curve = &otcrypto_ecc_p384_point_on_curve,
+    .ecc_p384_base_point_mult = &otcrypto_ecc_p384_base_point_mult,
     .ecc_p384_arith_share_private_key =
         &otcrypto_ecc_p384_arith_share_private_key,
 

--- a/sw/device/tests/crypto/otcrypto_interface.h
+++ b/sw/device/tests/crypto/otcrypto_interface.h
@@ -381,10 +381,10 @@ typedef struct otcrypto_interface_t {
   otcrypto_status_t (*ecc_p256_public_key_export)(
       const otcrypto_unblinded_key_t *, otcrypto_word32_buf_t *,
       otcrypto_word32_buf_t *);
-  otcrypto_status_t (*p256_point_on_curve)(const otcrypto_unblinded_key_t *,
-                                           hardened_bool_t *);
-  status_t (*p256_base_point_mult)(const otcrypto_blinded_key_t *,
-                                   otcrypto_unblinded_key_t *);
+  otcrypto_status_t (*ecc_p256_point_on_curve)(const otcrypto_unblinded_key_t *,
+                                               hardened_bool_t *);
+  status_t (*ecc_p256_base_point_mult)(const otcrypto_blinded_key_t *,
+                                       otcrypto_unblinded_key_t *);
   otcrypto_status_t (*ecc_p256_arith_share_private_key)(
       const otcrypto_const_word32_buf_t *, const otcrypto_const_word32_buf_t *,
       otcrypto_blinded_key_t *);
@@ -446,10 +446,10 @@ typedef struct otcrypto_interface_t {
   otcrypto_status_t (*ecc_p384_public_key_export)(
       const otcrypto_unblinded_key_t *, otcrypto_word32_buf_t *,
       otcrypto_word32_buf_t *);
-  otcrypto_status_t (*p384_point_on_curve)(const otcrypto_unblinded_key_t *,
-                                           hardened_bool_t *);
-  status_t (*p384_base_point_mult)(const otcrypto_blinded_key_t *,
-                                   otcrypto_unblinded_key_t *);
+  otcrypto_status_t (*ecc_p384_point_on_curve)(const otcrypto_unblinded_key_t *,
+                                               hardened_bool_t *);
+  status_t (*ecc_p384_base_point_mult)(const otcrypto_blinded_key_t *,
+                                       otcrypto_unblinded_key_t *);
   otcrypto_status_t (*ecc_p384_arith_share_private_key)(
       const otcrypto_const_word32_buf_t *, const otcrypto_const_word32_buf_t *,
       otcrypto_blinded_key_t *);


### PR DESCRIPTION
- Add missing `ecc_` prefix to ECC functions
- Add missing API functions
- Add AES API usage example