### PR TITLE
[ci] Action version bumps to resolve warnings about upcoming Node.js 20 EOL in CI

### DIFF
--- a/.github/actions/download-partial-build-bin/action.yml
+++ b/.github/actions/download-partial-build-bin/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Download partial build bins
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         pattern: partial-build-bin-${{ inputs.job-patterns }}
         path: downloads

--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -46,7 +46,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 
-    - uses: astral-sh/setup-uv@v6
+    - uses: astral-sh/setup-uv@v8.0.0
       with:
         version: '0.7.14'
         enable-cache: true

--- a/.github/actions/publish-bazel-test-results/action.yml
+++ b/.github/actions/publish-bazel-test-results/action.yml
@@ -59,7 +59,7 @@ runs:
         gcloud storage cp "${{ inputs.merged-results }}" "gs://${BUCKET_PATH}"
 
     - name: Publish job summary
-      uses: mikepenz/action-junit-report@ec3a351c13e080dc4fa94c49ab7ad5bf778a9668 # v5
+      uses: mikepenz/action-junit-report@5b7ee5a21e8674b695313d769f3cbdfd5d4d53a4 # v6.0.0
       with:
         report_paths: ${{ inputs.merged-results }}
         annotate_only: true

--- a/.github/actions/publish-bazel-test-results/action.yml
+++ b/.github/actions/publish-bazel-test-results/action.yml
@@ -43,7 +43,7 @@ runs:
 
     - name: Upload report as artifact
       if: ${{ success() && inputs.artifact-name != '' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ inputs.merged-results }}

--- a/.github/workflows/bitstream.yml
+++ b/.github/workflows/bitstream.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-22.04-bitstream
     timeout-minutes: 240
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Required by get-bitstream-strategy.sh
       - name: Prepare environment

--- a/.github/workflows/bitstream.yml
+++ b/.github/workflows/bitstream.yml
@@ -99,14 +99,14 @@ jobs:
           cat $OBJ_DIR/hw/top_${{ inputs.top_name }}/${design_name}/${vlnv_path}.runs/impl_1/${design_name}_timing_summary_routed.rpt || true
 
       - name: Upload step outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: partial-build-bin-chip_${{ inputs.top_name }}_${{ inputs.design_suffix }}
           path: build-bin.tar
 
       - name: Upload artifacts if build failed
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: chip_${{ inputs.top_name }}_${{ inputs.design_suffix }}-build-out
           path: build-out

--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -31,7 +31,7 @@ jobs:
     if: github.event.pull_request.merged == true && (github.event_name != 'labeled' || startsWith('CherryPick:', github.event.label.name))
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -646,7 +646,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Download target pattern files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: execute_*-targets
           path: verify_fpga_jobs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -694,7 +694,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Build Developer Utility Container
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7.0.0
         env:
           DOCKER_BUILD_SUMMARY: false
           DOCKER_BUILD_RECORD_UPLOAD: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     name: Lint (quick)
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Required so we can lint commit messages.
       - name: Prepare environment
@@ -87,7 +87,7 @@ jobs:
     needs: quick_lint
     if: ${{ github.event_name != 'merge_group' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Bitstream cache requires all commits.
       - name: Prepare environment
@@ -146,7 +146,7 @@ jobs:
     env:
       BUCKET: gold-hybrid-255313-prod
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Bitstream cache requires all commits.
       - name: Prepare environment
@@ -193,7 +193,7 @@ jobs:
     needs: quick_lint
     if: ${{ github.event_name != 'merge_group' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Bitstream cache requires all commits.
       - name: Prepare environment
@@ -223,7 +223,7 @@ jobs:
       verible_config: hw/lint/tools/veriblelint/lowrisc-styleguide.rules.verible_lint
       verible_version: v0.0-3430-g060bde0f
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Prepare Verible config
         run: |
           echo "Concatenating Verible waivers"
@@ -253,7 +253,7 @@ jobs:
     if: ${{ github.event_name != 'merge_group' }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Bitstream cache requires all commits.
       - name: Prepare environment
@@ -287,7 +287,7 @@ jobs:
     if: ${{ github.event_name != 'merge_group' }}
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Bitstream cache requires all commits.
       - name: Prepare environment
@@ -303,7 +303,7 @@ jobs:
     needs: quick_lint
     if: ${{ github.event_name != 'merge_group' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
         with:
@@ -335,7 +335,7 @@ jobs:
     if: ${{ github.event_name != 'merge_group' }}
     timeout-minutes: 240
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
         with:
@@ -355,7 +355,7 @@ jobs:
     needs: quick_lint
     if: ${{ github.event_name != 'merge_group' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
         with:
@@ -435,7 +435,7 @@ jobs:
         run: |
           echo ":information_source: Bitstream caching is skipped for this pull request job" \
             >> "$GITHUB_STEP_SUMMARY"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: ${{ github.event_name != 'pull_request' }}
       - name: Prepare environment
         if: ${{ github.event_name != 'pull_request' }}
@@ -644,7 +644,7 @@ jobs:
       - execute_manuf_fpga_tests_cw340
     if: success() || failure()
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download target pattern files
         uses: actions/download-artifact@v4
         with:
@@ -692,7 +692,7 @@ jobs:
     needs: quick_lint
     if: ${{ github.event_name != 'merge_group' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build Developer Utility Container
         uses: docker/build-push-action@v6
         env:
@@ -709,7 +709,7 @@ jobs:
     needs: quick_lint
     if: ${{ github.event_name != 'merge_group' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Required for bitstream cache to work.
       - name: Prepare environment
@@ -781,7 +781,7 @@ jobs:
     needs: quick_lint
     if: ${{ github.event_name != 'merge_group' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Required for bitstream cache to work.
       - name: Prepare environment
@@ -808,7 +808,7 @@ jobs:
     needs: quick_lint
     if: ${{ github.event_name != 'merge_group' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Prepare environment
@@ -825,7 +825,7 @@ jobs:
     needs: quick_lint
     if: ${{ github.event_name != 'merge_group' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           path: opentitan
@@ -834,7 +834,7 @@ jobs:
         with:
           service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
           working-directory: opentitan
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: lowRISC/qemu
           ref: v9.2.0-2025-02-11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Build documentation
         run: util/site/build-docs.sh build
       - name: Upload files as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docs
           path: build-site/
@@ -315,7 +315,7 @@ jobs:
           mkdir -p build-bin/hw/top_englishbreakfast
           cp ${sim_binary_path} build-bin/hw/top_englishbreakfast/
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: verilated_englishbreakfast
           path: build-bin/hw/top_englishbreakfast/Vchip_englishbreakfast_verilator
@@ -399,7 +399,7 @@ jobs:
           cp "$vmem" "build-bin/${rom_path}"
 
       - name: Upload bitstream
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: chip_englishbreakfast_cw305
           path: build-bin.tar
@@ -681,7 +681,7 @@ jobs:
             false
           fi
       - name: Upload complete target list
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: all_fpga_targets
           path: all_fpga.txt
@@ -851,7 +851,7 @@ jobs:
           opentitan/bazelisk.sh build --override_repository="+qemu+qemu_opentitan_src=$PWD/qemu/" //third_party/qemu/...
       - name: Upload error logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: qemu-override-build-logs
           path: qemu/build/*.log

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: [ubuntu-22.04-fpga, "${{ inputs.board }}"]
     timeout-minutes: ${{ inputs.timeout }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
           fetch-depth: 0
@@ -112,7 +112,7 @@ jobs:
             echo "No tests to run after filtering"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: ${{ !cancelled() }}
         with:
           ref: ${{ github.ref }}

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -129,7 +129,7 @@ jobs:
           branch: ${{ inputs.branch }}
 
       - name: Upload target pattern file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: ${{ inputs.job_name }}-targets

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -241,7 +241,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Required for the bitstream cache to work.
       - name: Prepare environment

--- a/.github/workflows/pr_change_check.yml
+++ b/.github/workflows/pr_change_check.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout the default branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout the target branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           path: "target-branch"


### PR DESCRIPTION
Bump all actions that were still using node20 to newer major versions that use node24. For each action I've checked the breaking changes and migration guidance in the release notes, and it appears that no breaking changes impact our use cases.

For actions that support [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases), I've pinned the specific immutable release. For those without, I've pinned the specific revision of the newest major release. This would also mean pinning a specific SHA for the commonplace `checkout`, `upload-artifact` and `download-artifact` supported by GitHub, so for now these remain pinned only to major versions whilst no immutable releases exist. There are issues open on these actions upstream to support moving to immutable releases.