### PR TITLE
[rv_dm,dv] Correct fake driver in rv_dm_scanmode_vseq

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_scanmode_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_scanmode_vseq.sv
@@ -41,7 +41,7 @@ class rv_dm_scanmode_vseq extends rv_dm_base_vseq;
     dout = '0;
 
     for (int i = 0; i < len; i++) begin
-      dout[i] = cfg.m_jtag_agent_cfg.vif._tdo_internal;
+      dout[i] = cfg.m_jtag_agent_cfg.vif.tdo;
       tms_tdi(i == len - 1, value[i]);
     end
 


### PR DESCRIPTION
Because jtag_agent expects to control TCK, the scanmode test (where TCK is tied to the system clock) can't use it. As a quick hack, I knocked together a pretend driver inside the virtual sequence itself. Of course, that didn't work well when I changed the signal names in 99c37ef.

Change the names to match (and be a bit less internal, which is nice).