### PR TITLE
Make sure that the ROM does not contain the __udivdiv3 symbol

### DIFF
--- a/rules/actions.bzl
+++ b/rules/actions.bzl
@@ -4,3 +4,4 @@
 
 OT_ACTION_OBJDUMP = "objdump"
 OT_ACTION_LLVM_PROFDATA = "llvm-profdata"
+OT_ACTION_NM = "nm"

--- a/rules/opentitan/transform.bzl
+++ b/rules/opentitan/transform.bzl
@@ -7,7 +7,7 @@ load("@rules_cc//cc:action_names.bzl", "OBJ_COPY_ACTION_NAME")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@lowrisc_opentitan//rules/opentitan:util.bzl", "get_override")
-load("//rules:actions.bzl", "OT_ACTION_OBJDUMP")
+load("//rules:actions.bzl", "OT_ACTION_NM", "OT_ACTION_OBJDUMP")
 
 def obj_transform(ctx, strip_llvm_prf_cnts = False, **kwargs):
     """Transform an object file via objcopy.
@@ -133,6 +133,50 @@ def obj_disassemble(ctx, **kwargs):
             output.path,
         ],
         command = "$1 -wx --disassemble --line-numbers --disassemble-zeroes --source --visualize-jumps $2 | expand > $3",
+    )
+    return output
+
+def obj_list_symbols(ctx, **kwargs):
+    """Use nm to list all symbols.
+
+    Args:
+      ctx: The context object for this rule.
+      kwargs: Overrides of values normally retrived from the context object.
+        output: The name of the output file.  Constructed from `name` if not
+                specified.
+        src: The src File object.
+    Returns:
+      The output File.
+    """
+    cc_toolchain = find_cc_toolchain(ctx)
+    feature_config = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+    nm = cc_common.get_tool_for_action(
+        feature_configuration = feature_config,
+        action_name = OT_ACTION_NM,
+    )
+
+    output = kwargs.get("output")
+    if not output:
+        name = get_override(ctx, "attr.name", kwargs)
+        output = "{}.nm".format(name)
+
+    output = ctx.actions.declare_file(output)
+    src = get_override(ctx, "attr.src", kwargs)
+
+    ctx.actions.run_shell(
+        outputs = [output],
+        inputs = [src] + cc_toolchain.all_files.to_list(),
+        arguments = [
+            nm,
+            src.path,
+            output.path,
+        ],
+        command = "$1 $2 > $3",
     )
     return output
 

--- a/rules/symbols.bzl
+++ b/rules/symbols.bzl
@@ -1,0 +1,80 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rules for inspecting symbols in ELF files"""
+
+load("//rules:rv.bzl", "rv_rule")
+load("//rules/opentitan:providers.bzl", "OpenTitanBinaryInfo")
+load("//rules/opentitan:transform.bzl", "obj_list_symbols")
+
+CHECK_SYMBOLS_SCRIPT = """#!/bin/bash
+set -e
+
+function check_file() {{
+    # $1: elf file
+    # $2: sym file
+    if cat "$2" | awk '{{ print($3) }}' | grep -E "^({forbidden_syms})$"
+    then
+        echo "$1 contains some forbidden symbols"
+        exit 1
+    fi
+}}
+
+{checks}
+"""
+
+def _check_elf_symbols(ctx):
+    if OpenTitanBinaryInfo in ctx.attr.target:
+        ot_info = ctx.attr.target[OpenTitanBinaryInfo]
+
+        # For each execution environment, look at the corresponding provider and
+        # extract the elf.
+        elfs = [
+            getattr(ctx.attr.target[prov], "elf")
+            for prov in ot_info.exec_env
+        ]
+    else:
+        elfs = ctx.attr.target[DefaultInfo].files.to_list()
+
+    # For each elf file, we use nm to list the symbols.
+    syms = {}
+    for elf in elfs:
+        syms[elf] = obj_list_symbols(
+            ctx,
+            src = elf,
+            output = "{}_{}.nm".format(ctx.attr.name, elf.basename),
+        )
+
+    executable = ctx.actions.declare_file(ctx.attr.name + ".sh")
+    ctx.actions.write(
+        executable,
+        CHECK_SYMBOLS_SCRIPT.format(
+            checks = "\n".join([
+                "check_file \"{}\" \"{}\"".format(elf.short_path, sym.short_path)
+                for (elf, sym) in syms.items()
+            ]),
+            forbidden_syms = "|".join(ctx.attr.forbidden),
+        ),
+    )
+
+    return [
+        DefaultInfo(executable = executable, runfiles = ctx.runfiles(syms.values())),
+    ]
+
+check_elf_symbols_test = rv_rule(
+    implementation = _check_elf_symbols,
+    test = True,
+    attrs = {
+        "target": attr.label(
+            mandatory = True,
+            doc = "Target on which to check the symbols. If the target has an OpenTitanBinaryInfo provider, the elf file of every execution environent will be checked. Otherwise every file in the DefaultInfo provider will be checked",
+        ),
+        "forbidden": attr.string_list(
+            doc = "List of symbols which must not appear in the ELF file(s)",
+        ),
+        "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
+    },
+    fragments = ["cpp"],
+    toolchains = ["@rules_cc//cc:toolchain_type"],
+)

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -16,6 +16,7 @@ load(
     "opentitan_test",
 )
 load("//rules/opentitan:legacy.bzl", "legacy_rom_targets")
+load("//rules:symbols.bzl", "check_elf_symbols_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -237,6 +238,15 @@ opentitan_binary(
         # by tests such as `rom_epmp_test`.
         ":rom_isrs",
     ],
+)
+
+check_elf_symbols_test(
+    name = "mask_rom_symbol_check",
+    forbidden = [
+        "__udivdi3",
+        "__divdi3",
+    ],
+    target = ":mask_rom",
 )
 
 # Create the legacy ROM target names so that existing splicing rules can find

--- a/third_party/lowrisc/BUILD.lowrisc_rv32imcb_toolchain.bazel
+++ b/third_party/lowrisc/BUILD.lowrisc_rv32imcb_toolchain.bazel
@@ -23,6 +23,7 @@ exports_files(glob(["**"]))
         "clang",
         "clang++",
         "ar",
+        "nm",
         "objcopy",
         "objdump",
         "strip",

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -10,7 +10,12 @@ load("@rules_cc//cc/toolchains:feature_constraint.bzl", "cc_feature_constraint")
 load("@rules_cc//cc/toolchains:feature_set.bzl", "cc_feature_set")
 load("@rules_cc//cc/toolchains:toolchain.bzl", "cc_toolchain")
 load("@rules_cc//cc/toolchains:tool_map.bzl", "cc_tool_map")
-load("//rules:actions.bzl", "OT_ACTION_LLVM_PROFDATA", "OT_ACTION_OBJDUMP")
+load(
+    "//rules:actions.bzl",
+    "OT_ACTION_LLVM_PROFDATA",
+    "OT_ACTION_NM",
+    "OT_ACTION_OBJDUMP",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -104,12 +109,18 @@ cc_tool_map(
         "@rules_cc//cc/toolchains/actions:strip": "@lowrisc_rv32imcb_toolchain//:strip",
         ":action_llvm_profdata": "@lowrisc_rv32imcb_toolchain//:llvm_profdata",
         ":action_objdump": "@lowrisc_rv32imcb_toolchain//:objdump",
+        ":action_nm": "@lowrisc_rv32imcb_toolchain//:nm",
     },
 )
 
 cc_action_type(
     name = "action_llvm_profdata",
     action_name = OT_ACTION_LLVM_PROFDATA,
+)
+
+cc_action_type(
+    name = "action_nm",
+    action_name = OT_ACTION_NM,
 )
 
 cc_action_type(


### PR DESCRIPTION
This PR provides a way to check that a given ELF file (from a bazel target) does not contain certain symbols. We then use it to ensure that the ROM does not have the long division symbols. Those should in theory be impossible to use because with `-nostdlib` passed to the linker, it would result in a linking error. This therefore is more of a sanity/double check.