### PR TITLE
[manuf] Fix orchestrator subprocess stdout/stderr flakiness

### DIFF
--- a/sw/host/provisioning/orchestrator/src/util.py
+++ b/sw/host/provisioning/orchestrator/src/util.py
@@ -66,6 +66,11 @@ def run(cmd, stdout_logfile, stderr_logfile):
                          stderr=err_tee.stdin)
     out_tee.stdin.close()
     err_tee.stdin.close()
+
+    # Wait for any final buffered output to be written by tees
+    out_tee.wait()
+    err_tee.wait()
+
     return res
 
 


### PR DESCRIPTION
We need to wait for the tee outputs to finish, otherwise there may be some final contents buffered in stdout/stderr that are not yet written. In some unlucky cases, we can try and look for the data on this line and thus encounter flakiness, which often does not surface as a particularly comprehensible error (e.g. missing `CHIP_PROBE_DATA`). This becomes much more likely under heavy processing load, when many tests are running in parallel.

Note: this does not appear to be the only source of flakiness (also see: https://github.com/lowRISC/opentitan/issues/29555), but is at least a partial contributor.