### PR TITLE
[crypto/ecc] Cleanup NULL checks

### DIFF
--- a/sw/device/lib/crypto/impl/ecc_p256.c
+++ b/sw/device/lib/crypto/impl/ecc_p256.c
@@ -31,10 +31,6 @@
 OT_WARN_UNUSED_RESULT
 static status_t p256_private_key_length_check(
     const otcrypto_blinded_key_t *private_key) {
-  if (private_key->keyblob == NULL) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-
   if (private_key->config.hw_backed == kHardenedBoolTrue) {
     // Skip the length check in this case; if the salt is the wrong length, the
     // keyblob library will catch it before we sideload the key.
@@ -173,19 +169,6 @@ static status_t p256_signature_length_check(size_t len) {
 
 otcrypto_status_t otcrypto_ecdsa_p256_keygen(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
-  if (private_key == NULL || private_key->keyblob == NULL ||
-      public_key == NULL || public_key->key == NULL) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP256 ||
-      public_key->key_mode != kOtcryptoKeyModeEcdsaP256) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  if (!status_ok(p256_private_key_length_check(private_key)) ||
-      !status_ok(p256_public_key_length_check(public_key))) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-
   HARDENED_TRY(otcrypto_ecdsa_p256_keygen_async_start(private_key));
   return otcrypto_ecdsa_p256_keygen_async_finalize(private_key, public_key);
 }
@@ -239,14 +222,6 @@ otcrypto_status_t otcrypto_ecdsa_p256_verify(
     const otcrypto_hash_digest_t message_digest,
     otcrypto_const_word32_buf_t *signature,
     hardened_bool_t *verification_result) {
-  if (verification_result == NULL || signature->data == NULL ||
-      public_key == NULL || public_key->key == NULL) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  if (!status_ok(p256_signature_length_check(signature->len)) ||
-      !status_ok(p256_public_key_length_check(public_key))) {
-    return OTCRYPTO_BAD_ARGS;
-  }
   HARDENED_TRY(otcrypto_ecdsa_p256_verify_async_start(
       public_key, message_digest, signature));
   return otcrypto_ecdsa_p256_verify_async_finalize(signature,
@@ -276,18 +251,6 @@ otcrypto_status_t otcrypto_ecdsa_p256_sign_verify(
 
 otcrypto_status_t otcrypto_ecdh_p256_keygen(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
-  if (private_key == NULL || private_key->keyblob == NULL ||
-      public_key == NULL || public_key->key == NULL) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  if (private_key->config.key_mode != kOtcryptoKeyModeEcdhP256 ||
-      public_key->key_mode != kOtcryptoKeyModeEcdhP256) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  if (!status_ok(p256_private_key_length_check(private_key)) ||
-      !status_ok(p256_public_key_length_check(public_key))) {
-    return OTCRYPTO_BAD_ARGS;
-  }
   HARDENED_TRY(otcrypto_ecdh_p256_keygen_async_start(private_key));
   return otcrypto_ecdh_p256_keygen_async_finalize(private_key, public_key);
 }
@@ -295,18 +258,6 @@ otcrypto_status_t otcrypto_ecdh_p256_keygen(
 otcrypto_status_t otcrypto_ecdh_p256(const otcrypto_blinded_key_t *private_key,
                                      const otcrypto_unblinded_key_t *public_key,
                                      otcrypto_blinded_key_t *shared_secret) {
-  if (shared_secret == NULL || shared_secret->keyblob == NULL ||
-      private_key == NULL || private_key->keyblob == NULL ||
-      public_key == NULL || public_key->key == NULL) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  if (shared_secret->config.key_length != kP256CoordBytes) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  if (!status_ok(p256_private_key_length_check(private_key)) ||
-      !status_ok(p256_public_key_length_check(public_key))) {
-    return OTCRYPTO_BAD_ARGS;
-  }
   HARDENED_TRY(otcrypto_ecdh_p256_async_start(private_key, public_key));
   return otcrypto_ecdh_p256_async_finalize(shared_secret);
 }

--- a/sw/device/lib/crypto/impl/ecc_p384.c
+++ b/sw/device/lib/crypto/impl/ecc_p384.c
@@ -218,19 +218,6 @@ static status_t p384_signature_length_check(size_t len) {
 
 otcrypto_status_t otcrypto_ecdsa_p384_keygen(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
-  if (private_key == NULL || private_key->keyblob == NULL ||
-      public_key == NULL || public_key->key == NULL) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP384 ||
-      public_key->key_mode != kOtcryptoKeyModeEcdsaP384) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  if (!status_ok(p384_private_key_length_check(private_key)) ||
-      !status_ok(p384_public_key_length_check(public_key))) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-
   HARDENED_TRY(otcrypto_ecdsa_p384_keygen_async_start(private_key));
   return otcrypto_ecdsa_p384_keygen_async_finalize(private_key, public_key);
 }
@@ -240,14 +227,6 @@ otcrypto_status_t otcrypto_ecdsa_p384_sign_config_k(
     const otcrypto_blinded_key_t *secret_scalar,
     const otcrypto_hash_digest_t message_digest,
     otcrypto_word32_buf_t *signature) {
-  if (signature->data == NULL || private_key == NULL ||
-      private_key->keyblob == NULL) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  if (!status_ok(p384_signature_length_check(signature->len)) ||
-      !status_ok(p384_private_key_length_check(private_key))) {
-    return OTCRYPTO_BAD_ARGS;
-  }
   HARDENED_TRY(otcrypto_ecdsa_p384_sign_config_k_async_start(
       private_key, secret_scalar, message_digest));
   return otcrypto_ecdsa_p384_sign_async_finalize(signature);
@@ -257,14 +236,6 @@ otcrypto_status_t otcrypto_ecdsa_p384_sign(
     const otcrypto_blinded_key_t *private_key,
     const otcrypto_hash_digest_t message_digest,
     otcrypto_word32_buf_t *signature) {
-  if (signature->data == NULL || private_key == NULL ||
-      private_key->keyblob == NULL) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  if (!status_ok(p384_signature_length_check(signature->len)) ||
-      !status_ok(p384_private_key_length_check(private_key))) {
-    return OTCRYPTO_BAD_ARGS;
-  }
   HARDENED_TRY(
       otcrypto_ecdsa_p384_sign_async_start(private_key, message_digest));
   return otcrypto_ecdsa_p384_sign_async_finalize(signature);
@@ -275,14 +246,6 @@ otcrypto_status_t otcrypto_ecdsa_p384_verify(
     const otcrypto_hash_digest_t message_digest,
     otcrypto_const_word32_buf_t *signature,
     hardened_bool_t *verification_result) {
-  if (verification_result == NULL || signature->data == NULL ||
-      public_key == NULL || public_key->key == NULL) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  if (!status_ok(p384_signature_length_check(signature->len)) ||
-      !status_ok(p384_public_key_length_check(public_key))) {
-    return OTCRYPTO_BAD_ARGS;
-  }
   HARDENED_TRY(otcrypto_ecdsa_p384_verify_async_start(
       public_key, message_digest, signature));
   return otcrypto_ecdsa_p384_verify_async_finalize(signature,
@@ -312,18 +275,6 @@ otcrypto_status_t otcrypto_ecdsa_p384_sign_verify(
 
 otcrypto_status_t otcrypto_ecdh_p384_keygen(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
-  if (private_key == NULL || private_key->keyblob == NULL ||
-      public_key == NULL || public_key->key == NULL) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  if (private_key->config.key_mode != kOtcryptoKeyModeEcdhP384 ||
-      public_key->key_mode != kOtcryptoKeyModeEcdhP384) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  if (!status_ok(p384_private_key_length_check(private_key)) ||
-      !status_ok(p384_public_key_length_check(public_key))) {
-    return OTCRYPTO_BAD_ARGS;
-  }
   HARDENED_TRY(otcrypto_ecdh_p384_keygen_async_start(private_key));
   return otcrypto_ecdh_p384_keygen_async_finalize(private_key, public_key);
 }
@@ -331,18 +282,6 @@ otcrypto_status_t otcrypto_ecdh_p384_keygen(
 otcrypto_status_t otcrypto_ecdh_p384(const otcrypto_blinded_key_t *private_key,
                                      const otcrypto_unblinded_key_t *public_key,
                                      otcrypto_blinded_key_t *shared_secret) {
-  if (shared_secret == NULL || shared_secret->keyblob == NULL ||
-      private_key == NULL || private_key->keyblob == NULL ||
-      public_key == NULL || public_key->key == NULL) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  if (shared_secret->config.key_length != kP384CoordBytes) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  if (!status_ok(p384_private_key_length_check(private_key)) ||
-      !status_ok(p384_public_key_length_check(public_key))) {
-    return OTCRYPTO_BAD_ARGS;
-  }
   HARDENED_TRY(otcrypto_ecdh_p384_async_start(private_key, public_key));
   return otcrypto_ecdh_p384_async_finalize(shared_secret);
 }

--- a/sw/device/tests/crypto/ecdh_p256_functest.c
+++ b/sw/device/tests/crypto/ecdh_p256_functest.c
@@ -167,10 +167,17 @@ static status_t run_ecdh_negative_tests(void) {
   valid_shared.checksum = integrity_blinded_checksum(&valid_shared);
 
   // ECDH keygen negative tests
-  CHECK(otcrypto_ecdh_p256_keygen(NULL, &valid_pub).value ==
-        OTCRYPTO_BAD_ARGS.value);
-  CHECK(otcrypto_ecdh_p256_keygen(&valid_priv, NULL).value ==
-        OTCRYPTO_BAD_ARGS.value);
+
+  // Null pointers
+  CHECK(otcrypto_ecdh_p256_keygen(NULL, &valid_pub).value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p256_keygen_async_start(NULL).value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p256_keygen_async_finalize(NULL, &valid_pub).value !=
+        OTCRYPTO_OK.value);
+
+  CHECK(otcrypto_ecdh_p256_keygen(&valid_priv, NULL).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p256_keygen_async_finalize(&valid_priv, NULL).value !=
+        OTCRYPTO_OK.value);
 
   // Null keyblob
   otcrypto_blinded_key_t bad_priv_null = {
@@ -178,8 +185,12 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob_length = 80,
       .keyblob = NULL,
   };
-  CHECK(otcrypto_ecdh_p256_keygen(&bad_priv_null, &valid_pub).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdh_p256_keygen(&bad_priv_null, &valid_pub).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p256_keygen_async_start(&bad_priv_null).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p256_keygen_async_finalize(&bad_priv_null, &valid_pub)
+            .value != OTCRYPTO_OK.value);
 
   // Bad mode
   otcrypto_key_config_t bad_mode_cfg = kEcdhPrivateKeyConfig;
@@ -190,8 +201,12 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob = priv_keyblob,
   };
   bad_priv_mode.checksum = integrity_blinded_checksum(&bad_priv_mode);
-  CHECK(otcrypto_ecdh_p256_keygen(&bad_priv_mode, &valid_pub).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdh_p256_keygen(&bad_priv_mode, &valid_pub).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p256_keygen_async_start(&bad_priv_mode).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p256_keygen_async_finalize(&bad_priv_mode, &valid_pub)
+            .value != OTCRYPTO_OK.value);
 
   // Bad length
   otcrypto_key_config_t bad_len_cfg = kEcdhPrivateKeyConfig;
@@ -202,16 +217,59 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob = priv_keyblob,
   };
   bad_priv_len.checksum = integrity_blinded_checksum(&bad_priv_len);
-  CHECK(otcrypto_ecdh_p256_keygen(&bad_priv_len, &valid_pub).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdh_p256_keygen(&bad_priv_len, &valid_pub).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p256_keygen_async_start(&bad_priv_len).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p256_keygen_async_finalize(&bad_priv_len, &valid_pub)
+            .value != OTCRYPTO_OK.value);
+
+  // Bad keyblob length
+  otcrypto_blinded_key_t bad_priv_blob_len = {
+      .config = kEcdhPrivateKeyConfig,
+      .keyblob_length = 79,  // Should be 80
+      .keyblob = priv_keyblob,
+  };
+  bad_priv_blob_len.checksum = integrity_blinded_checksum(&bad_priv_blob_len);
+  CHECK(otcrypto_ecdh_p256_keygen(&bad_priv_blob_len, &valid_pub).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p256_keygen_async_start(&bad_priv_blob_len).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p256_keygen_async_finalize(&bad_priv_blob_len, &valid_pub)
+            .value != OTCRYPTO_OK.value);
+
+  // Bad hardware backed configuration
+  otcrypto_key_config_t bad_hw_cfg = kEcdhPrivateKeyConfig;
+  bad_hw_cfg.hw_backed = (hardened_bool_t)0x12345678;  // Invalid boolean
+  otcrypto_blinded_key_t bad_priv_hw = {
+      .config = bad_hw_cfg,
+      .keyblob_length = 80,
+      .keyblob = priv_keyblob,
+  };
+  bad_priv_hw.checksum = integrity_blinded_checksum(&bad_priv_hw);
+  CHECK(otcrypto_ecdh_p256_keygen(&bad_priv_hw, &valid_pub).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p256_keygen_async_start(&bad_priv_hw).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p256_keygen_async_finalize(&bad_priv_hw, &valid_pub)
+            .value != OTCRYPTO_OK.value);
 
   // ECDH shared secret negative tests
-  CHECK(otcrypto_ecdh_p256(NULL, &valid_pub, &valid_shared).value ==
-        OTCRYPTO_BAD_ARGS.value);
-  CHECK(otcrypto_ecdh_p256(&valid_priv, NULL, &valid_shared).value ==
-        OTCRYPTO_BAD_ARGS.value);
-  CHECK(otcrypto_ecdh_p256(&valid_priv, &valid_pub, NULL).value ==
-        OTCRYPTO_BAD_ARGS.value);
+
+  // Null pointers
+  CHECK(otcrypto_ecdh_p256(NULL, &valid_pub, &valid_shared).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p256_async_start(NULL, &valid_pub).value !=
+        OTCRYPTO_OK.value);
+
+  CHECK(otcrypto_ecdh_p256(&valid_priv, NULL, &valid_shared).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p256_async_start(&valid_priv, NULL).value !=
+        OTCRYPTO_OK.value);
+
+  CHECK(otcrypto_ecdh_p256(&valid_priv, &valid_pub, NULL).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p256_async_finalize(NULL).value != OTCRYPTO_OK.value);
 
   // Bad private key checksum
   otcrypto_blinded_key_t bad_priv_chk = {
@@ -220,8 +278,10 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob = priv_keyblob,
   };
   bad_priv_chk.checksum = valid_priv.checksum ^ 0xFFFFFFFF;
-  CHECK(otcrypto_ecdh_p256(&bad_priv_chk, &valid_pub, &valid_shared).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdh_p256(&bad_priv_chk, &valid_pub, &valid_shared).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p256_async_start(&bad_priv_chk, &valid_pub).value !=
+        OTCRYPTO_OK.value);
 
   // Bad public key checksum
   otcrypto_unblinded_key_t bad_pub_chk = {
@@ -230,20 +290,24 @@ static status_t run_ecdh_negative_tests(void) {
       .key = pub_key_data,
   };
   bad_pub_chk.checksum = valid_pub.checksum ^ 0xFFFFFFFF;
-  CHECK(otcrypto_ecdh_p256(&valid_priv, &bad_pub_chk, &valid_shared).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdh_p256(&valid_priv, &bad_pub_chk, &valid_shared).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p256_async_start(&valid_priv, &bad_pub_chk).value !=
+        OTCRYPTO_OK.value);
 
   // Bad shared secret HW backed
-  otcrypto_key_config_t bad_hw_cfg = kEcdhSharedKeyConfig;
-  bad_hw_cfg.hw_backed = kHardenedBoolTrue;
+  otcrypto_key_config_t bad_shared_hw_cfg = kEcdhSharedKeyConfig;
+  bad_shared_hw_cfg.hw_backed = kHardenedBoolTrue;
   otcrypto_blinded_key_t bad_shared_hw = {
-      .config = bad_hw_cfg,
+      .config = bad_shared_hw_cfg,
       .keyblob_length = sizeof(shared_keyblob),
       .keyblob = shared_keyblob,
   };
   bad_shared_hw.checksum = integrity_blinded_checksum(&bad_shared_hw);
-  CHECK(otcrypto_ecdh_p256(&valid_priv, &valid_pub, &bad_shared_hw).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdh_p256(&valid_priv, &valid_pub, &bad_shared_hw).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p256_async_finalize(&bad_shared_hw).value !=
+        OTCRYPTO_OK.value);
 
   // Bad shared secret length
   otcrypto_key_config_t bad_sym_len_cfg = kEcdhSharedKeyConfig;
@@ -254,8 +318,10 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob = shared_keyblob,
   };
   bad_shared_len.checksum = integrity_blinded_checksum(&bad_shared_len);
-  CHECK(otcrypto_ecdh_p256(&valid_priv, &valid_pub, &bad_shared_len).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdh_p256(&valid_priv, &valid_pub, &bad_shared_len).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p256_async_finalize(&bad_shared_len).value !=
+        OTCRYPTO_OK.value);
 
   return OTCRYPTO_OK;
 }

--- a/sw/device/tests/crypto/ecdh_p384_functest.c
+++ b/sw/device/tests/crypto/ecdh_p384_functest.c
@@ -143,6 +143,7 @@ status_t key_exchange_test(void) {
 
   return OTCRYPTO_OK;
 }
+
 static status_t run_ecdh_negative_tests(void) {
   LOG_INFO("Running ECDH negative tests.");
 
@@ -171,19 +172,32 @@ static status_t run_ecdh_negative_tests(void) {
   valid_shared.checksum = integrity_blinded_checksum(&valid_shared);
 
   // ECDH keygen negative tests
-  CHECK(otcrypto_ecdh_p384_keygen(NULL, &valid_pub).value ==
-        OTCRYPTO_BAD_ARGS.value);
-  CHECK(otcrypto_ecdh_p384_keygen(&valid_priv, NULL).value ==
-        OTCRYPTO_BAD_ARGS.value);
 
+  // Null pointers
+  CHECK(otcrypto_ecdh_p384_keygen(NULL, &valid_pub).value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p384_keygen_async_start(NULL).value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p384_keygen_async_finalize(NULL, &valid_pub).value !=
+        OTCRYPTO_OK.value);
+
+  CHECK(otcrypto_ecdh_p384_keygen(&valid_priv, NULL).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p384_keygen_async_finalize(&valid_priv, NULL).value !=
+        OTCRYPTO_OK.value);
+
+  // Null keyblob
   otcrypto_blinded_key_t bad_priv_null = {
       .config = kEcdhPrivateKeyConfig,
       .keyblob_length = 112,
       .keyblob = NULL,
   };
-  CHECK(otcrypto_ecdh_p384_keygen(&bad_priv_null, &valid_pub).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdh_p384_keygen(&bad_priv_null, &valid_pub).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p384_keygen_async_start(&bad_priv_null).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p384_keygen_async_finalize(&bad_priv_null, &valid_pub)
+            .value != OTCRYPTO_OK.value);
 
+  // Bad mode
   otcrypto_key_config_t bad_mode_cfg = kEcdhPrivateKeyConfig;
   bad_mode_cfg.key_mode = kOtcryptoKeyModeEcdsaP384;
   otcrypto_blinded_key_t bad_priv_mode = {
@@ -192,9 +206,14 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob = priv_keyblob,
   };
   bad_priv_mode.checksum = integrity_blinded_checksum(&bad_priv_mode);
-  CHECK(otcrypto_ecdh_p384_keygen(&bad_priv_mode, &valid_pub).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdh_p384_keygen(&bad_priv_mode, &valid_pub).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p384_keygen_async_start(&bad_priv_mode).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p384_keygen_async_finalize(&bad_priv_mode, &valid_pub)
+            .value != OTCRYPTO_OK.value);
 
+  // Bad length
   otcrypto_key_config_t bad_len_cfg = kEcdhPrivateKeyConfig;
   bad_len_cfg.key_length = 47;
   otcrypto_blinded_key_t bad_priv_len = {
@@ -203,46 +222,99 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob = priv_keyblob,
   };
   bad_priv_len.checksum = integrity_blinded_checksum(&bad_priv_len);
-  CHECK(otcrypto_ecdh_p384_keygen(&bad_priv_len, &valid_pub).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdh_p384_keygen(&bad_priv_len, &valid_pub).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p384_keygen_async_start(&bad_priv_len).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p384_keygen_async_finalize(&bad_priv_len, &valid_pub)
+            .value != OTCRYPTO_OK.value);
+
+  // Bad keyblob length
+  otcrypto_blinded_key_t bad_priv_blob_len = {
+      .config = kEcdhPrivateKeyConfig,
+      .keyblob_length = 111,  // Should be 112
+      .keyblob = priv_keyblob,
+  };
+  bad_priv_blob_len.checksum = integrity_blinded_checksum(&bad_priv_blob_len);
+  CHECK(otcrypto_ecdh_p384_keygen(&bad_priv_blob_len, &valid_pub).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p384_keygen_async_start(&bad_priv_blob_len).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p384_keygen_async_finalize(&bad_priv_blob_len, &valid_pub)
+            .value != OTCRYPTO_OK.value);
+
+  // Bad hardware backed configuration
+  otcrypto_key_config_t bad_hw_cfg = kEcdhPrivateKeyConfig;
+  bad_hw_cfg.hw_backed = (hardened_bool_t)0x12345678;  // Invalid boolean
+  otcrypto_blinded_key_t bad_priv_hw = {
+      .config = bad_hw_cfg,
+      .keyblob_length = 112,
+      .keyblob = priv_keyblob,
+  };
+  bad_priv_hw.checksum = integrity_blinded_checksum(&bad_priv_hw);
+  CHECK(otcrypto_ecdh_p384_keygen(&bad_priv_hw, &valid_pub).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p384_keygen_async_start(&bad_priv_hw).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p384_keygen_async_finalize(&bad_priv_hw, &valid_pub)
+            .value != OTCRYPTO_OK.value);
 
   // ECDH shared secret negative tests
-  CHECK(otcrypto_ecdh_p384(NULL, &valid_pub, &valid_shared).value ==
-        OTCRYPTO_BAD_ARGS.value);
-  CHECK(otcrypto_ecdh_p384(&valid_priv, NULL, &valid_shared).value ==
-        OTCRYPTO_BAD_ARGS.value);
-  CHECK(otcrypto_ecdh_p384(&valid_priv, &valid_pub, NULL).value ==
-        OTCRYPTO_BAD_ARGS.value);
 
+  // Null pointers
+  CHECK(otcrypto_ecdh_p384(NULL, &valid_pub, &valid_shared).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p384_async_start(NULL, &valid_pub).value !=
+        OTCRYPTO_OK.value);
+
+  CHECK(otcrypto_ecdh_p384(&valid_priv, NULL, &valid_shared).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p384_async_start(&valid_priv, NULL).value !=
+        OTCRYPTO_OK.value);
+
+  CHECK(otcrypto_ecdh_p384(&valid_priv, &valid_pub, NULL).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p384_async_finalize(NULL).value != OTCRYPTO_OK.value);
+
+  // Bad private key checksum
   otcrypto_blinded_key_t bad_priv_chk = {
       .config = kEcdhPrivateKeyConfig,
       .keyblob_length = 112,
       .keyblob = priv_keyblob,
   };
   bad_priv_chk.checksum = valid_priv.checksum ^ 0xFFFFFFFF;
-  CHECK(otcrypto_ecdh_p384(&bad_priv_chk, &valid_pub, &valid_shared).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdh_p384(&bad_priv_chk, &valid_pub, &valid_shared).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p384_async_start(&bad_priv_chk, &valid_pub).value !=
+        OTCRYPTO_OK.value);
 
+  // Bad public key checksum
   otcrypto_unblinded_key_t bad_pub_chk = {
       .key_mode = kOtcryptoKeyModeEcdhP384,
       .key_length = 96,
       .key = pub_key_data,
   };
   bad_pub_chk.checksum = valid_pub.checksum ^ 0xFFFFFFFF;
-  CHECK(otcrypto_ecdh_p384(&valid_priv, &bad_pub_chk, &valid_shared).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdh_p384(&valid_priv, &bad_pub_chk, &valid_shared).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p384_async_start(&valid_priv, &bad_pub_chk).value !=
+        OTCRYPTO_OK.value);
 
-  otcrypto_key_config_t bad_hw_cfg = kEcdhSharedKeyConfig;
-  bad_hw_cfg.hw_backed = kHardenedBoolTrue;
+  // Bad shared secret HW backed
+  otcrypto_key_config_t bad_shared_hw_cfg = kEcdhSharedKeyConfig;
+  bad_shared_hw_cfg.hw_backed = kHardenedBoolTrue;
   otcrypto_blinded_key_t bad_shared_hw = {
-      .config = bad_hw_cfg,
+      .config = bad_shared_hw_cfg,
       .keyblob_length = sizeof(shared_keyblob),
       .keyblob = shared_keyblob,
   };
   bad_shared_hw.checksum = integrity_blinded_checksum(&bad_shared_hw);
-  CHECK(otcrypto_ecdh_p384(&valid_priv, &valid_pub, &bad_shared_hw).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdh_p384(&valid_priv, &valid_pub, &bad_shared_hw).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p384_async_finalize(&bad_shared_hw).value !=
+        OTCRYPTO_OK.value);
 
+  // Bad shared secret length
   otcrypto_key_config_t bad_sym_len_cfg = kEcdhSharedKeyConfig;
   bad_sym_len_cfg.key_length = 47;
   otcrypto_blinded_key_t bad_shared_len = {
@@ -251,8 +323,10 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob = shared_keyblob,
   };
   bad_shared_len.checksum = integrity_blinded_checksum(&bad_shared_len);
-  CHECK(otcrypto_ecdh_p384(&valid_priv, &valid_pub, &bad_shared_len).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdh_p384(&valid_priv, &valid_pub, &bad_shared_len).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdh_p384_async_finalize(&bad_shared_len).value !=
+        OTCRYPTO_OK.value);
 
   return OTCRYPTO_OK;
 }

--- a/sw/device/tests/crypto/ecdsa_p256_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_functest.c
@@ -209,9 +209,18 @@ static status_t run_ecdsa_negative_tests(void) {
   hardened_bool_t verify_res;
 
   // ECDSA keygen negative tests
+
+  // Null pointers
   CHECK(otcrypto_ecdsa_p256_keygen(NULL, &valid_pub).value ==
         OTCRYPTO_BAD_ARGS.value);
-  CHECK(otcrypto_ecdsa_p256_keygen(&valid_priv, NULL).value ==
+  CHECK(otcrypto_ecdsa_p256_keygen_async_start(NULL).value ==
+        OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdsa_p256_keygen_async_finalize(NULL, &valid_pub).value ==
+        OTCRYPTO_BAD_ARGS.value);
+
+  CHECK(otcrypto_ecdsa_p256_keygen(&valid_priv, NULL).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p256_keygen_async_finalize(&valid_priv, NULL).value ==
         OTCRYPTO_BAD_ARGS.value);
 
   // Null pointer keyblob
@@ -222,6 +231,10 @@ static status_t run_ecdsa_negative_tests(void) {
   };
   CHECK(otcrypto_ecdsa_p256_keygen(&bad_priv_null, &valid_pub).value ==
         OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdsa_p256_keygen_async_start(&bad_priv_null).value ==
+        OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdsa_p256_keygen_async_finalize(&bad_priv_null, &valid_pub)
+            .value == OTCRYPTO_BAD_ARGS.value);
 
   // Bad mode
   otcrypto_key_config_t bad_mode_cfg = kPrivateKeyConfig;
@@ -234,6 +247,10 @@ static status_t run_ecdsa_negative_tests(void) {
   bad_priv_mode.checksum = integrity_blinded_checksum(&bad_priv_mode);
   CHECK(otcrypto_ecdsa_p256_keygen(&bad_priv_mode, &valid_pub).value ==
         OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdsa_p256_keygen_async_start(&bad_priv_mode).value ==
+        OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdsa_p256_keygen_async_finalize(&bad_priv_mode, &valid_pub)
+            .value == OTCRYPTO_BAD_ARGS.value);
 
   // Bad public key length
   otcrypto_unblinded_key_t bad_pub_len = {
@@ -242,12 +259,49 @@ static status_t run_ecdsa_negative_tests(void) {
       .key = pub_key_data,
   };
   bad_pub_len.checksum = integrity_unblinded_checksum(&bad_pub_len);
-  CHECK(otcrypto_ecdsa_p256_keygen(&valid_priv, &bad_pub_len).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdsa_p256_keygen(&valid_priv, &bad_pub_len).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p256_keygen_async_finalize(&valid_priv, &bad_pub_len)
+            .value != OTCRYPTO_OK.value);
+
+  // Bad keyblob length
+  otcrypto_blinded_key_t bad_priv_blob_len = {
+      .config = kPrivateKeyConfig,
+      .keyblob_length = 79,  // Should be 80
+      .keyblob = priv_keyblob,
+  };
+  bad_priv_blob_len.checksum = integrity_blinded_checksum(&bad_priv_blob_len);
+  CHECK(otcrypto_ecdsa_p256_keygen(&bad_priv_blob_len, &valid_pub).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p256_keygen_async_start(&bad_priv_blob_len).value !=
+        OTCRYPTO_OK.value);
+  CHECK(
+      otcrypto_ecdsa_p256_keygen_async_finalize(&bad_priv_blob_len, &valid_pub)
+          .value != OTCRYPTO_OK.value);
+
+  // Bad hardware backed configuration
+  otcrypto_key_config_t bad_hw_cfg = kPrivateKeyConfig;
+  bad_hw_cfg.hw_backed = (hardened_bool_t)0x12345678;  // Invalid boolean
+  otcrypto_blinded_key_t bad_priv_hw = {
+      .config = bad_hw_cfg,
+      .keyblob_length = 80,
+      .keyblob = priv_keyblob,
+  };
+  bad_priv_hw.checksum = integrity_blinded_checksum(&bad_priv_hw);
+  CHECK(otcrypto_ecdsa_p256_keygen(&bad_priv_hw, &valid_pub).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p256_keygen_async_start(&bad_priv_hw).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p256_keygen_async_finalize(&bad_priv_hw, &valid_pub)
+            .value != OTCRYPTO_OK.value);
 
   // ECDSA sign negative tests
-  CHECK(otcrypto_ecdsa_p256_sign(NULL, valid_digest, &valid_sig).value ==
-        OTCRYPTO_BAD_ARGS.value);
+
+  // Null pointers
+  CHECK(otcrypto_ecdsa_p256_sign(NULL, valid_digest, &valid_sig).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p256_sign_async_start(NULL, valid_digest).value !=
+        OTCRYPTO_OK.value);
 
   // Null digest data
   otcrypto_hash_digest_t bad_digest_null = {
@@ -255,7 +309,9 @@ static status_t run_ecdsa_negative_tests(void) {
       .len = 8,
   };
   CHECK(otcrypto_ecdsa_p256_sign(&valid_priv, bad_digest_null, &valid_sig)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p256_sign_async_start(&valid_priv, bad_digest_null)
+            .value != OTCRYPTO_OK.value);
 
   // Bad digest length
   otcrypto_hash_digest_t bad_digest_len = {
@@ -263,14 +319,19 @@ static status_t run_ecdsa_negative_tests(void) {
       .len = 7,
   };
   CHECK(
-      otcrypto_ecdsa_p256_sign(&valid_priv, bad_digest_len, &valid_sig).value ==
-      OTCRYPTO_BAD_ARGS.value);
+      otcrypto_ecdsa_p256_sign(&valid_priv, bad_digest_len, &valid_sig).value !=
+      OTCRYPTO_OK.value);
+  CHECK(
+      otcrypto_ecdsa_p256_sign_async_start(&valid_priv, bad_digest_len).value !=
+      OTCRYPTO_OK.value);
 
   // Null signature data
   otcrypto_word32_buf_t bad_sig_null =
       OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, NULL, 16);
   CHECK(otcrypto_ecdsa_p256_sign(&valid_priv, valid_digest, &bad_sig_null)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p256_sign_async_finalize(&bad_sig_null).value !=
+        OTCRYPTO_OK.value);
 
   // Corrupt private key checksum
   otcrypto_blinded_key_t bad_priv_chk = {
@@ -280,16 +341,51 @@ static status_t run_ecdsa_negative_tests(void) {
   };
   bad_priv_chk.checksum = valid_priv.checksum ^ 0xFFFFFFFF;
   CHECK(
-      otcrypto_ecdsa_p256_sign(&bad_priv_chk, valid_digest, &valid_sig).value ==
-      OTCRYPTO_BAD_ARGS.value);
+      otcrypto_ecdsa_p256_sign(&bad_priv_chk, valid_digest, &valid_sig).value !=
+      OTCRYPTO_OK.value);
+  CHECK(
+      otcrypto_ecdsa_p256_sign_async_start(&bad_priv_chk, valid_digest).value !=
+      OTCRYPTO_OK.value);
+
+  // Bad signature buffer length
+  otcrypto_word32_buf_t bad_sig_len =
+      OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, sig_data, 15);  // Should be 16
+  CHECK(
+      otcrypto_ecdsa_p256_sign(&valid_priv, valid_digest, &bad_sig_len).value !=
+      OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p256_sign_async_finalize(&bad_sig_len).value !=
+        OTCRYPTO_OK.value);
+
+  // ECDSA sign config k negative tests
+
+  CHECK(otcrypto_ecdsa_p256_sign_config_k(NULL, &valid_priv, valid_digest,
+                                          &valid_sig)
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p256_sign_config_k_async_start(NULL, &valid_priv,
+                                                      valid_digest)
+            .value != OTCRYPTO_OK.value);
+
+  // Passing a bad signature buffer length
+  CHECK(otcrypto_ecdsa_p256_sign_config_k(&valid_priv, &valid_priv,
+                                          valid_digest, &bad_sig_len)
+            .value != OTCRYPTO_OK.value);
 
   // ECDSA verify negative tests
+
+  // Null pointers
   CHECK(otcrypto_ecdsa_p256_verify(NULL, valid_digest, &valid_const_sig,
                                    &verify_res)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p256_verify_async_start(NULL, valid_digest,
+                                               &valid_const_sig)
+            .value != OTCRYPTO_OK.value);
+
   CHECK(otcrypto_ecdsa_p256_verify(&valid_pub, valid_digest, &valid_const_sig,
                                    NULL)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(
+      otcrypto_ecdsa_p256_verify_async_finalize(&valid_const_sig, NULL).value !=
+      OTCRYPTO_OK.value);
 
   // Corrupt public key checksum
   otcrypto_unblinded_key_t bad_pub_chk = {
@@ -300,15 +396,23 @@ static status_t run_ecdsa_negative_tests(void) {
   bad_pub_chk.checksum = valid_pub.checksum ^ 0xFFFFFFFF;
   CHECK(otcrypto_ecdsa_p256_verify(&bad_pub_chk, valid_digest, &valid_const_sig,
                                    &verify_res)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p256_verify_async_start(&bad_pub_chk, valid_digest,
+                                               &valid_const_sig)
+            .value != OTCRYPTO_OK.value);
 
   // Bad signature length
   otcrypto_const_word32_buf_t bad_const_sig_len =
       OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, sig_data, 15);
-
   CHECK(otcrypto_ecdsa_p256_verify(&valid_pub, valid_digest, &bad_const_sig_len,
                                    &verify_res)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p256_verify_async_start(&valid_pub, valid_digest,
+                                               &bad_const_sig_len)
+            .value != OTCRYPTO_OK.value);
+  CHECK(
+      otcrypto_ecdsa_p256_verify_async_finalize(&bad_const_sig_len, &verify_res)
+          .value != OTCRYPTO_OK.value);
 
   return OTCRYPTO_OK;
 }

--- a/sw/device/tests/crypto/ecdsa_p384_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p384_functest.c
@@ -214,19 +214,34 @@ static status_t run_ecdsa_negative_tests(void) {
   hardened_bool_t verify_res;
 
   // ECDSA keygen negative tests
-  CHECK(otcrypto_ecdsa_p384_keygen(NULL, &valid_pub).value ==
-        OTCRYPTO_BAD_ARGS.value);
-  CHECK(otcrypto_ecdsa_p384_keygen(&valid_priv, NULL).value ==
-        OTCRYPTO_BAD_ARGS.value);
 
+  // Null pointers
+  CHECK(otcrypto_ecdsa_p384_keygen(NULL, &valid_pub).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p384_keygen_async_start(NULL).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p384_keygen_async_finalize(NULL, &valid_pub).value !=
+        OTCRYPTO_OK.value);
+
+  CHECK(otcrypto_ecdsa_p384_keygen(&valid_priv, NULL).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p384_keygen_async_finalize(&valid_priv, NULL).value !=
+        OTCRYPTO_OK.value);
+
+  // Null pointer keyblob
   otcrypto_blinded_key_t bad_priv_null = {
       .config = kPrivateKeyConfig,
       .keyblob_length = 112,
       .keyblob = NULL,
   };
-  CHECK(otcrypto_ecdsa_p384_keygen(&bad_priv_null, &valid_pub).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdsa_p384_keygen(&bad_priv_null, &valid_pub).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p384_keygen_async_start(&bad_priv_null).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p384_keygen_async_finalize(&bad_priv_null, &valid_pub)
+            .value != OTCRYPTO_OK.value);
 
+  // Bad mode
   otcrypto_key_config_t bad_mode_cfg = kPrivateKeyConfig;
   bad_mode_cfg.key_mode = kOtcryptoKeyModeEcdhP384;
   otcrypto_blinded_key_t bad_priv_mode = {
@@ -235,42 +250,95 @@ static status_t run_ecdsa_negative_tests(void) {
       .keyblob = priv_keyblob,
   };
   bad_priv_mode.checksum = integrity_blinded_checksum(&bad_priv_mode);
-  CHECK(otcrypto_ecdsa_p384_keygen(&bad_priv_mode, &valid_pub).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdsa_p384_keygen(&bad_priv_mode, &valid_pub).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p384_keygen_async_start(&bad_priv_mode).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p384_keygen_async_finalize(&bad_priv_mode, &valid_pub)
+            .value != OTCRYPTO_OK.value);
 
+  // Bad public key length
   otcrypto_unblinded_key_t bad_pub_len = {
       .key_mode = kOtcryptoKeyModeEcdsaP384,
       .key_length = 95,
       .key = pub_key_data,
   };
   bad_pub_len.checksum = integrity_unblinded_checksum(&bad_pub_len);
-  CHECK(otcrypto_ecdsa_p384_keygen(&valid_priv, &bad_pub_len).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_ecdsa_p384_keygen(&valid_priv, &bad_pub_len).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p384_keygen_async_finalize(&valid_priv, &bad_pub_len)
+            .value != OTCRYPTO_OK.value);
+
+  // Bad keyblob length
+  otcrypto_blinded_key_t bad_priv_blob_len = {
+      .config = kPrivateKeyConfig,
+      .keyblob_length = 111,  // Should be 112
+      .keyblob = priv_keyblob,
+  };
+  bad_priv_blob_len.checksum = integrity_blinded_checksum(&bad_priv_blob_len);
+  CHECK(otcrypto_ecdsa_p384_keygen(&bad_priv_blob_len, &valid_pub).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p384_keygen_async_start(&bad_priv_blob_len).value !=
+        OTCRYPTO_OK.value);
+  CHECK(
+      otcrypto_ecdsa_p384_keygen_async_finalize(&bad_priv_blob_len, &valid_pub)
+          .value != OTCRYPTO_OK.value);
+
+  // Bad hardware backed configuration
+  otcrypto_key_config_t bad_hw_cfg = kPrivateKeyConfig;
+  bad_hw_cfg.hw_backed = (hardened_bool_t)0x12345678;  // Invalid boolean
+  otcrypto_blinded_key_t bad_priv_hw = {
+      .config = bad_hw_cfg,
+      .keyblob_length = 112,
+      .keyblob = priv_keyblob,
+  };
+  bad_priv_hw.checksum = integrity_blinded_checksum(&bad_priv_hw);
+  CHECK(otcrypto_ecdsa_p384_keygen(&bad_priv_hw, &valid_pub).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p384_keygen_async_start(&bad_priv_hw).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p384_keygen_async_finalize(&bad_priv_hw, &valid_pub)
+            .value != OTCRYPTO_OK.value);
 
   // ECDSA sign negative tests
-  CHECK(otcrypto_ecdsa_p384_sign(NULL, valid_digest, &valid_sig).value ==
-        OTCRYPTO_BAD_ARGS.value);
 
+  // Null pointers
+  CHECK(otcrypto_ecdsa_p384_sign(NULL, valid_digest, &valid_sig).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p384_sign_async_start(NULL, valid_digest).value !=
+        OTCRYPTO_OK.value);
+
+  // Null digest data
   otcrypto_hash_digest_t bad_digest_null = {
       .data = NULL,
       .len = 12,
   };
   CHECK(otcrypto_ecdsa_p384_sign(&valid_priv, bad_digest_null, &valid_sig)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p384_sign_async_start(&valid_priv, bad_digest_null)
+            .value != OTCRYPTO_OK.value);
 
+  // Bad digest length
   otcrypto_hash_digest_t bad_digest_len = {
       .data = digest_data,
       .len = 11,
   };
   CHECK(
-      otcrypto_ecdsa_p384_sign(&valid_priv, bad_digest_len, &valid_sig).value ==
-      OTCRYPTO_BAD_ARGS.value);
+      otcrypto_ecdsa_p384_sign(&valid_priv, bad_digest_len, &valid_sig).value !=
+      OTCRYPTO_OK.value);
+  CHECK(
+      otcrypto_ecdsa_p384_sign_async_start(&valid_priv, bad_digest_len).value !=
+      OTCRYPTO_OK.value);
 
+  // Null signature data
   otcrypto_word32_buf_t bad_sig_null =
       OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, NULL, 24);
   CHECK(otcrypto_ecdsa_p384_sign(&valid_priv, valid_digest, &bad_sig_null)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p384_sign_async_finalize(&bad_sig_null).value !=
+        OTCRYPTO_OK.value);
 
+  // Corrupt private key checksum
   otcrypto_blinded_key_t bad_priv_chk = {
       .config = kPrivateKeyConfig,
       .keyblob_length = 112,
@@ -278,17 +346,53 @@ static status_t run_ecdsa_negative_tests(void) {
   };
   bad_priv_chk.checksum = valid_priv.checksum ^ 0xFFFFFFFF;
   CHECK(
-      otcrypto_ecdsa_p384_sign(&bad_priv_chk, valid_digest, &valid_sig).value ==
-      OTCRYPTO_BAD_ARGS.value);
+      otcrypto_ecdsa_p384_sign(&bad_priv_chk, valid_digest, &valid_sig).value !=
+      OTCRYPTO_OK.value);
+  CHECK(
+      otcrypto_ecdsa_p384_sign_async_start(&bad_priv_chk, valid_digest).value !=
+      OTCRYPTO_OK.value);
+
+  // Bad signature buffer length
+  otcrypto_word32_buf_t bad_sig_len =
+      OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, sig_data, 23);  // Should be 24
+  CHECK(
+      otcrypto_ecdsa_p384_sign(&valid_priv, valid_digest, &bad_sig_len).value !=
+      OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p384_sign_async_finalize(&bad_sig_len).value !=
+        OTCRYPTO_OK.value);
+
+  // ECDSA sign config k negative tests
+
+  CHECK(otcrypto_ecdsa_p384_sign_config_k(NULL, &valid_priv, valid_digest,
+                                          &valid_sig)
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p384_sign_config_k_async_start(NULL, &valid_priv,
+                                                      valid_digest)
+            .value != OTCRYPTO_OK.value);
+
+  // Passing a bad signature buffer length
+  CHECK(otcrypto_ecdsa_p384_sign_config_k(&valid_priv, &valid_priv,
+                                          valid_digest, &bad_sig_len)
+            .value != OTCRYPTO_OK.value);
 
   // ECDSA verify negative tests
+
+  // Null pointers
   CHECK(otcrypto_ecdsa_p384_verify(NULL, valid_digest, &valid_const_sig,
                                    &verify_res)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p384_verify_async_start(NULL, valid_digest,
+                                               &valid_const_sig)
+            .value != OTCRYPTO_OK.value);
+
   CHECK(otcrypto_ecdsa_p384_verify(&valid_pub, valid_digest, &valid_const_sig,
                                    NULL)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(
+      otcrypto_ecdsa_p384_verify_async_finalize(&valid_const_sig, NULL).value !=
+      OTCRYPTO_OK.value);
 
+  // Corrupt public key checksum
   otcrypto_unblinded_key_t bad_pub_chk = {
       .key_mode = kOtcryptoKeyModeEcdsaP384,
       .key_length = 96,
@@ -297,14 +401,23 @@ static status_t run_ecdsa_negative_tests(void) {
   bad_pub_chk.checksum = valid_pub.checksum ^ 0xFFFFFFFF;
   CHECK(otcrypto_ecdsa_p384_verify(&bad_pub_chk, valid_digest, &valid_const_sig,
                                    &verify_res)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p384_verify_async_start(&bad_pub_chk, valid_digest,
+                                               &valid_const_sig)
+            .value != OTCRYPTO_OK.value);
 
-  otcrypto_const_word32_buf_t bad_const_sig_len =
-      OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, sig_data, 23);
-
+  // Bad signature length
+  otcrypto_const_word32_buf_t bad_const_sig_len = OTCRYPTO_MAKE_BUF(
+      otcrypto_const_word32_buf_t, sig_data, 23);  // Should be 24
   CHECK(otcrypto_ecdsa_p384_verify(&valid_pub, valid_digest, &bad_const_sig_len,
                                    &verify_res)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_ecdsa_p384_verify_async_start(&valid_pub, valid_digest,
+                                               &bad_const_sig_len)
+            .value != OTCRYPTO_OK.value);
+  CHECK(
+      otcrypto_ecdsa_p384_verify_async_finalize(&bad_const_sig_len, &verify_res)
+          .value != OTCRYPTO_OK.value);
 
   return OTCRYPTO_OK;
 }


### PR DESCRIPTION
Cleanup the checks for the input for the synchronous wrappers. Improve the negative testing to improve coverage.