### PR TITLE
Backport 28497 ([bazel] Use absolute path in EARLGREY_SLOTS definition)

### DIFF
--- a/hw/top_earlgrey/defs.bzl
+++ b/hw/top_earlgrey/defs.bzl
@@ -42,6 +42,6 @@ EARLGREY_SLOTS_COVERAGE = {
 }
 
 EARLGREY_SLOTS = select({
-    "//rules/coverage:enabled": EARLGREY_SLOTS_COVERAGE,
+    "@lowrisc_opentitan//rules/coverage:enabled": EARLGREY_SLOTS_COVERAGE,
     "//conditions:default": EARLGREY_SLOTS_NORMAL,
 })


### PR DESCRIPTION
Backport #28497