### PR TITLE
[crypto/rsa] Cleanup NULL checks

### DIFF
--- a/sw/device/lib/crypto/impl/rsa.c
+++ b/sw/device/lib/crypto/impl/rsa.c
@@ -96,7 +96,8 @@ static hardened_bool_t bignum_lt(const uint32_t *a, const uint32_t *b,
 otcrypto_status_t otcrypto_rsa_public_key_construct(
     otcrypto_rsa_size_t size, const otcrypto_const_word32_buf_t *modulus,
     otcrypto_unblinded_key_t *public_key) {
-  if (modulus->data == NULL || public_key == NULL || public_key->key == NULL) {
+  if (modulus == NULL || modulus->data == NULL || public_key == NULL ||
+      public_key->key == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_TRY(rsa_mode_check(public_key->key_mode));
@@ -301,15 +302,13 @@ otcrypto_status_t otcrypto_rsa_keygen_async_start(otcrypto_rsa_size_t size) {
 otcrypto_status_t otcrypto_rsa_keygen(otcrypto_rsa_size_t size,
                                       otcrypto_unblinded_key_t *public_key,
                                       otcrypto_blinded_key_t *private_key) {
-  if (public_key == NULL || public_key->key == NULL || private_key == NULL ||
-      private_key->keyblob == NULL) {
+  if (public_key == NULL || private_key == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+  // Check the size against the public key.
   otcrypto_rsa_size_t inferred_size;
   if (!status_ok(rsa_size_from_public_key(public_key, &inferred_size)) ||
-      inferred_size != size ||
-      !status_ok(public_key_structural_check(public_key)) ||
-      !status_ok(private_key_structural_check(size, private_key))) {
+      inferred_size != size) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -322,9 +321,9 @@ otcrypto_status_t otcrypto_rsa_private_key_from_exponents(
     const otcrypto_const_word32_buf_t *d_share0,
     const otcrypto_const_word32_buf_t *d_share1,
     otcrypto_blinded_key_t *private_key) {
-  if (modulus->data == NULL || d_share0->data == NULL ||
-      d_share1->data == NULL || private_key == NULL ||
-      private_key->keyblob == NULL) {
+  if (modulus == NULL || modulus->data == NULL || d_share0 == NULL ||
+      d_share0->data == NULL || d_share1 == NULL || d_share1->data == NULL ||
+      private_key == NULL || private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_TRY(rsa_mode_check(private_key->config.key_mode));
@@ -397,61 +396,26 @@ otcrypto_status_t otcrypto_rsa_keypair_from_cofactor(
     const otcrypto_const_word32_buf_t *cofactor_share0,
     const otcrypto_const_word32_buf_t *cofactor_share1,
     otcrypto_unblinded_key_t *public_key, otcrypto_blinded_key_t *private_key) {
-  if (public_key == NULL || public_key->key == NULL || private_key == NULL ||
-      private_key->keyblob == NULL) {
+  if (public_key == NULL || private_key == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+  // Check the size against the public key.
   otcrypto_rsa_size_t inferred_size;
   if (!status_ok(rsa_size_from_public_key(public_key, &inferred_size)) ||
-      inferred_size != size ||
-      !status_ok(public_key_structural_check(public_key)) ||
-      !status_ok(private_key_structural_check(size, private_key))) {
+      inferred_size != size) {
     return OTCRYPTO_BAD_ARGS;
   }
 
   HARDENED_TRY(otcrypto_rsa_keypair_from_cofactor_async_start(
       size, modulus, cofactor_share0, cofactor_share1));
-  HARDENED_TRY(otcrypto_rsa_keypair_from_cofactor_async_finalize(public_key,
-                                                                 private_key));
-
-  // Interpret the recomputed public key. Double-check the lengths to be safe,
-  // but they should have been checked above already.
-  hardened_bool_t modulus_eq = kHardenedBoolFalse;
-  switch (size) {
-    case kOtcryptoRsaSize2048: {
-      if (public_key->key_length != sizeof(rsa_2048_public_key_t) ||
-          modulus->len != kRsa2048NumWords) {
-        return OTCRYPTO_RECOV_ERR;
-      }
-      rsa_2048_public_key_t *pk = (rsa_2048_public_key_t *)public_key->key;
-      modulus_eq = hardened_memeq(modulus->data, pk->n.data, modulus->len);
-      return otcrypto_eval_exit(OTCRYPTO_OK);
-    }
-    case kOtcryptoRsaSize3072:
-      return OTCRYPTO_NOT_IMPLEMENTED;
-    case kOtcryptoRsaSize4096:
-      return OTCRYPTO_NOT_IMPLEMENTED;
-    default:
-      return OTCRYPTO_BAD_ARGS;
-  }
-
-  if (launder32(modulus_eq) != kHardenedBoolTrue) {
-    // This likely means that the cofactor/modulus combination was invalid,
-    // for example the modulus was not divisible by the cofactor, or the
-    // cofactor was too small.
-    return OTCRYPTO_BAD_ARGS;
-  }
-  HARDENED_CHECK_EQ(modulus_eq, kHardenedBoolTrue);
-  return otcrypto_eval_exit(OTCRYPTO_OK);
+  return otcrypto_rsa_keypair_from_cofactor_async_finalize(public_key,
+                                                           private_key);
 }
 
 otcrypto_status_t otcrypto_rsa_sign(const otcrypto_blinded_key_t *private_key,
                                     const otcrypto_hash_digest_t message_digest,
                                     otcrypto_rsa_padding_t padding_mode,
                                     otcrypto_word32_buf_t *signature) {
-  if (signature->data == NULL) {
-    return OTCRYPTO_BAD_ARGS;
-  }
   HARDENED_TRY(
       otcrypto_rsa_sign_async_start(private_key, message_digest, padding_mode));
   return otcrypto_rsa_sign_async_finalize(signature);
@@ -463,15 +427,7 @@ otcrypto_status_t otcrypto_rsa_verify(
     otcrypto_rsa_padding_t padding_mode,
     const otcrypto_const_word32_buf_t *signature,
     hardened_bool_t *verification_result) {
-  if (verification_result == NULL) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  otcrypto_status_t status =
-      otcrypto_rsa_verify_async_start(public_key, signature);
-  if (status.value != kOtcryptoStatusValueOk) {
-    return otcrypto_eval_exit(status);
-  }
-  HARDENED_CHECK_EQ(launder32(status.value), kOtcryptoStatusValueOk);
+  HARDENED_TRY(otcrypto_rsa_verify_async_start(public_key, signature));
   return otcrypto_rsa_verify_async_finalize(message_digest, padding_mode,
                                             verification_result);
 }
@@ -481,9 +437,6 @@ otcrypto_status_t otcrypto_rsa_encrypt(
     const otcrypto_hash_mode_t hash_mode,
     const otcrypto_const_byte_buf_t *message,
     const otcrypto_const_byte_buf_t *label, otcrypto_word32_buf_t *ciphertext) {
-  if (ciphertext->data == NULL) {
-    return OTCRYPTO_BAD_ARGS;
-  }
   HARDENED_TRY(
       otcrypto_rsa_encrypt_async_start(public_key, hash_mode, message, label));
   return otcrypto_rsa_encrypt_async_finalize(ciphertext);
@@ -495,21 +448,8 @@ otcrypto_status_t otcrypto_rsa_decrypt(
     const otcrypto_const_word32_buf_t *ciphertext,
     const otcrypto_const_byte_buf_t *label, otcrypto_byte_buf_t *plaintext,
     size_t *plaintext_bytelen) {
-  if (plaintext->data == NULL || plaintext_bytelen == NULL) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  uint8_t dummy_label_data[1] = {0};
-  otcrypto_const_byte_buf_t local_label = OTCRYPTO_MAKE_BUF(
-      otcrypto_const_byte_buf_t,
-      (label->data == NULL && label->len == 0) ? dummy_label_data : label->data,
-      label->len);
-  otcrypto_status_t status =
-      otcrypto_rsa_decrypt_async_start(private_key, ciphertext);
-  if (status.value != kOtcryptoStatusValueOk) {
-    return otcrypto_eval_exit(status);
-  }
-  HARDENED_CHECK_EQ(launder32(status.value), kOtcryptoStatusValueOk);
-  return otcrypto_rsa_decrypt_async_finalize(hash_mode, &local_label, plaintext,
+  HARDENED_TRY(otcrypto_rsa_decrypt_async_start(private_key, ciphertext));
+  return otcrypto_rsa_decrypt_async_finalize(hash_mode, label, plaintext,
                                              plaintext_bytelen);
 }
 
@@ -587,7 +527,8 @@ otcrypto_status_t otcrypto_rsa_keypair_from_cofactor_async_start(
     otcrypto_rsa_size_t size, const otcrypto_const_word32_buf_t *modulus,
     const otcrypto_const_word32_buf_t *cofactor_share0,
     const otcrypto_const_word32_buf_t *cofactor_share1) {
-  if (modulus->data == NULL || cofactor_share0->data == NULL ||
+  if (modulus == NULL || modulus->data == NULL || cofactor_share0 == NULL ||
+      cofactor_share0->data == NULL || cofactor_share1 == NULL ||
       cofactor_share1->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -788,9 +729,12 @@ otcrypto_status_t otcrypto_rsa_sign_async_start(
 otcrypto_status_t otcrypto_rsa_sign_async_finalize(
     otcrypto_word32_buf_t *signature) {
   // Check for NULL pointers.
-  if (signature->data == NULL) {
+  if (signature == NULL || signature->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+
+  // Verify the input buffer
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(signature));
 
   // Determine the size based on the signature buffer length.
   switch (launder32(signature->len)) {
@@ -814,9 +758,6 @@ otcrypto_status_t otcrypto_rsa_sign_async_finalize(
       return OTCRYPTO_BAD_ARGS;
   }
 
-  // Verify the input buffer
-  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(signature));
-
   // Should be unreachable.
   HARDENED_TRAP();
   return OTCRYPTO_FATAL_ERR;
@@ -826,7 +767,7 @@ otcrypto_status_t otcrypto_rsa_verify_async_start(
     const otcrypto_unblinded_key_t *public_key,
     const otcrypto_const_word32_buf_t *signature) {
   // Check for NULL pointers.
-  if (public_key == NULL || public_key->key == NULL ||
+  if (public_key == NULL || public_key->key == NULL || signature == NULL ||
       signature->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -935,11 +876,11 @@ otcrypto_status_t otcrypto_rsa_encrypt_async_start(
     return OTCRYPTO_BAD_ARGS;
   }
 
-  if (message->data == NULL && (message->len != 0)) {
+  if (message == NULL || ((message->data == NULL) && (message->len != 0))) {
     return OTCRYPTO_BAD_ARGS;
   }
 
-  if (label->data == NULL && (label->len != 0)) {
+  if (label == NULL || ((label->data == NULL) && (label->len != 0))) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -1001,7 +942,7 @@ otcrypto_status_t otcrypto_rsa_encrypt_async_start(
 otcrypto_status_t otcrypto_rsa_encrypt_async_finalize(
     otcrypto_word32_buf_t *ciphertext) {
   // Check for NULL pointers.
-  if (ciphertext->data == NULL) {
+  if (ciphertext == NULL || ciphertext->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -1142,7 +1083,8 @@ otcrypto_status_t otcrypto_rsa_decrypt_async_finalize(
     const otcrypto_hash_mode_t hash_mode,
     const otcrypto_const_byte_buf_t *label, otcrypto_byte_buf_t *plaintext,
     size_t *plaintext_bytelen) {
-  if (plaintext->data == NULL || label->data == NULL) {
+  if (plaintext == NULL || plaintext->data == NULL || label == NULL ||
+      label->data == NULL || plaintext_bytelen == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 

--- a/sw/device/lib/crypto/impl/rsa/run_rsa.c
+++ b/sw/device/lib/crypto/impl/rsa/run_rsa.c
@@ -101,8 +101,6 @@ status_t rsa_modexp_wait(size_t *num_words) {
   } else if (mode == kMode4096Modexp || mode == kMode4096ModexpF4) {
     *num_words = kRsa4096NumWords;
   } else {
-    // Wipe DMEM.
-    HARDENED_TRY(otbn_dmem_sec_wipe());
     // Unrecognized mode.
     return OTCRYPTO_FATAL_ERR;
   }
@@ -127,8 +125,6 @@ static status_t rsa_modexp_finalize(const size_t num_words, uint32_t *result) {
 
   // Check that the inferred result size matches expectations.
   if (num_words != num_words_inferred) {
-    // Wipe DMEM.
-    HARDENED_TRY(otbn_dmem_sec_wipe());
     return OTCRYPTO_FATAL_ERR;
   }
   HARDENED_CHECK_EQ(launder32(num_words), num_words_inferred);
@@ -306,7 +302,6 @@ static status_t keygen_finalize(uint32_t exp_mode, size_t num_words,
   uint32_t act_mode = 0;
   HARDENED_TRY(otbn_dmem_read(1, kOtbnVarRsaMode, &act_mode));
   if (act_mode != exp_mode) {
-    HARDENED_TRY(otbn_dmem_sec_wipe());
     return OTCRYPTO_FATAL_ERR;
   }
   HARDENED_CHECK_EQ(launder32(act_mode), exp_mode);
@@ -318,7 +313,6 @@ static status_t keygen_finalize(uint32_t exp_mode, size_t num_words,
   // Prime p.
   HARDENED_TRY(otbn_dmem_read(1, kOtbnVarRsaMrIterP, &mr_iters));
   if (mr_iters != kMrIters) {
-    HARDENED_TRY(otbn_dmem_sec_wipe());
     return OTCRYPTO_FATAL_ERR;
   }
   HARDENED_CHECK_EQ(launder32(mr_iters), kMrIters);
@@ -327,7 +321,6 @@ static status_t keygen_finalize(uint32_t exp_mode, size_t num_words,
   mr_iters = 0;
   HARDENED_TRY(otbn_dmem_read(1, kOtbnVarRsaMrIterQ, &mr_iters));
   if (mr_iters != kMrIters) {
-    HARDENED_TRY(otbn_dmem_sec_wipe());
     return OTCRYPTO_FATAL_ERR;
   }
   HARDENED_CHECK_EQ(launder32(mr_iters), kMrIters);

--- a/sw/device/lib/crypto/impl/rsa/run_rsa_key_from_cofactor.c
+++ b/sw/device/lib/crypto/impl/rsa/run_rsa_key_from_cofactor.c
@@ -76,7 +76,6 @@ status_t rsa_keygen_from_cofactor_2048_finalize(
   HARDENED_TRY_WIPE_DMEM(
       otbn_dmem_read(kOtbnRsaModeWords, kOtbnVarRsaMode, &act_mode));
   if (act_mode != kOtbnRsaModeCofactor2048) {
-    HARDENED_TRY(otbn_dmem_sec_wipe());
     return OTCRYPTO_FATAL_ERR;
   }
   HARDENED_CHECK_EQ(launder32(act_mode), kOtbnRsaModeCofactor2048);

--- a/sw/device/tests/crypto/rsa_2048_encryption_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_encryption_functest.c
@@ -275,19 +275,36 @@ static status_t run_encrypt_negative_tests(void) {
   size_t pt_len = 0;
 
   // Encrypt negative tests
+
+  // Null pointers
   CHECK(otcrypto_rsa_encrypt(NULL, kTestHashMode, &valid_msg, &valid_msg,
                              &valid_ct)
             .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_encrypt_async_start(NULL, kTestHashMode, &valid_msg,
+                                         &valid_msg)
+            .value != OTCRYPTO_OK.value);
+
   CHECK(otcrypto_rsa_encrypt(&valid_pub, kTestHashMode, &bad_msg_null,
                              &valid_msg, &valid_ct)
             .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_encrypt_async_start(&valid_pub, kTestHashMode,
+                                         &bad_msg_null, &valid_msg)
+            .value != OTCRYPTO_OK.value);
+
   CHECK(otcrypto_rsa_encrypt(&valid_pub, kTestHashMode, &valid_msg,
                              &bad_msg_null, &valid_ct)
             .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_encrypt_async_start(&valid_pub, kTestHashMode, &valid_msg,
+                                         &bad_msg_null)
+            .value != OTCRYPTO_OK.value);
+
   CHECK(otcrypto_rsa_encrypt(&valid_pub, kTestHashMode, &valid_msg, &valid_msg,
                              &bad_ct_null)
             .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_encrypt_async_finalize(&bad_ct_null).value !=
+        OTCRYPTO_OK.value);
 
+  // Corrupt checksum
   otcrypto_unblinded_key_t bad_pub_chk = {
       .key_mode = valid_pub.key_mode,
       .key_length = valid_pub.key_length,
@@ -297,7 +314,11 @@ static status_t run_encrypt_negative_tests(void) {
   CHECK(otcrypto_rsa_encrypt(&bad_pub_chk, kTestHashMode, &valid_msg,
                              &valid_msg, &valid_ct)
             .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_encrypt_async_start(&bad_pub_chk, kTestHashMode,
+                                         &valid_msg, &valid_msg)
+            .value != OTCRYPTO_OK.value);
 
+  // Bad mode
   otcrypto_unblinded_key_t bad_pub_mode = {
       .key_mode = kOtcryptoKeyModeRsaSignPkcs,
       .key_length = valid_pub.key_length,
@@ -307,27 +328,45 @@ static status_t run_encrypt_negative_tests(void) {
   CHECK(otcrypto_rsa_encrypt(&bad_pub_mode, kTestHashMode, &valid_msg,
                              &valid_msg, &valid_ct)
             .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_encrypt_async_start(&bad_pub_mode, kTestHashMode,
+                                         &valid_msg, &valid_msg)
+            .value != OTCRYPTO_OK.value);
 
   // Decrypt negative tests
+
+  // Null pointers
   CHECK(otcrypto_rsa_decrypt(NULL, kTestHashMode, &valid_const_ct, &valid_msg,
                              &valid_pt, &pt_len)
             .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_decrypt_async_start(NULL, &valid_const_ct).value !=
+        OTCRYPTO_OK.value);
 
   otcrypto_const_word32_buf_t bad_const_ct_null =
       OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, NULL, kRsa2048NumWords);
   CHECK(otcrypto_rsa_decrypt(&valid_priv, kTestHashMode, &bad_const_ct_null,
                              &valid_msg, &valid_pt, &pt_len)
             .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(
+      otcrypto_rsa_decrypt_async_start(&valid_priv, &bad_const_ct_null).value !=
+      OTCRYPTO_OK.value);
 
   otcrypto_byte_buf_t bad_pt_null =
       OTCRYPTO_MAKE_BUF(otcrypto_byte_buf_t, NULL, 256);
   CHECK(otcrypto_rsa_decrypt(&valid_priv, kTestHashMode, &valid_const_ct,
                              &valid_msg, &bad_pt_null, &pt_len)
             .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_decrypt_async_finalize(kTestHashMode, &valid_msg,
+                                            &bad_pt_null, &pt_len)
+            .value != OTCRYPTO_OK.value);
+
   CHECK(otcrypto_rsa_decrypt(&valid_priv, kTestHashMode, &valid_const_ct,
                              &valid_msg, &valid_pt, NULL)
             .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_decrypt_async_finalize(kTestHashMode, &valid_msg,
+                                            &valid_pt, NULL)
+            .value != OTCRYPTO_OK.value);
 
+  // Corrupt checksum
   otcrypto_blinded_key_t bad_priv_chk = {
       .config = priv_cfg,
       .keyblob_length = kOtcryptoRsa2048PrivateKeyblobBytes,
@@ -337,7 +376,11 @@ static status_t run_encrypt_negative_tests(void) {
   CHECK(otcrypto_rsa_decrypt(&bad_priv_chk, kTestHashMode, &valid_const_ct,
                              &valid_msg, &valid_pt, &pt_len)
             .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(
+      otcrypto_rsa_decrypt_async_start(&bad_priv_chk, &valid_const_ct).value !=
+      OTCRYPTO_OK.value);
 
+  // Bad mode
   otcrypto_key_config_t bad_priv_mode_cfg = priv_cfg;
   bad_priv_mode_cfg.key_mode = kOtcryptoKeyModeRsaSignPkcs;
   otcrypto_blinded_key_t bad_priv_mode = {
@@ -348,6 +391,219 @@ static status_t run_encrypt_negative_tests(void) {
   bad_priv_mode.checksum = integrity_blinded_checksum(&bad_priv_mode);
   CHECK(otcrypto_rsa_decrypt(&bad_priv_mode, kTestHashMode, &valid_const_ct,
                              &valid_msg, &valid_pt, &pt_len)
+            .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(
+      otcrypto_rsa_decrypt_async_start(&bad_priv_mode, &valid_const_ct).value !=
+      OTCRYPTO_OK.value);
+
+  return OTCRYPTO_OK;
+}
+
+static status_t run_public_key_construct_negative_tests(void) {
+  LOG_INFO("Running RSA public key construct negative tests");
+
+  uint32_t mod_data[kRsa2048NumWords] = {0};
+  otcrypto_const_word32_buf_t valid_mod = OTCRYPTO_MAKE_BUF(
+      otcrypto_const_word32_buf_t, mod_data, kRsa2048NumWords);
+  otcrypto_const_word32_buf_t bad_mod_null =
+      OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, NULL, kRsa2048NumWords);
+  otcrypto_const_word32_buf_t bad_mod_len = OTCRYPTO_MAKE_BUF(
+      otcrypto_const_word32_buf_t, mod_data, kRsa2048NumWords - 1);
+
+  uint32_t pub_data[kOtcryptoRsa2048PublicKeyBytes / 4] = {0};
+  otcrypto_unblinded_key_t valid_pub = {
+      .key_mode = kOtcryptoKeyModeRsaEncryptOaep,
+      .key_length = kOtcryptoRsa2048PublicKeyBytes,
+      .key = pub_data,
+  };
+
+  otcrypto_unblinded_key_t bad_pub_null_key = {
+      .key_mode = kOtcryptoKeyModeRsaEncryptOaep,
+      .key_length = kOtcryptoRsa2048PublicKeyBytes,
+      .key = NULL,
+  };
+
+  otcrypto_unblinded_key_t bad_pub_mode = {
+      .key_mode = kOtcryptoKeyModeEcdsaP256,
+      .key_length = kOtcryptoRsa2048PublicKeyBytes,
+      .key = pub_data,
+  };
+
+  otcrypto_unblinded_key_t bad_pub_len = {
+      .key_mode = kOtcryptoKeyModeRsaEncryptOaep,
+      .key_length = kOtcryptoRsa2048PublicKeyBytes - 1,
+      .key = pub_data,
+  };
+
+  // Null pointers
+  CHECK(
+      otcrypto_rsa_public_key_construct(kOtcryptoRsaSize2048, NULL, &valid_pub)
+          .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_public_key_construct(kOtcryptoRsaSize2048, &bad_mod_null,
+                                          &valid_pub)
+            .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(
+      otcrypto_rsa_public_key_construct(kOtcryptoRsaSize2048, &valid_mod, NULL)
+          .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_public_key_construct(kOtcryptoRsaSize2048, &valid_mod,
+                                          &bad_pub_null_key)
+            .value == OTCRYPTO_BAD_ARGS.value);
+
+  // Bad mode
+  CHECK(otcrypto_rsa_public_key_construct(kOtcryptoRsaSize2048, &valid_mod,
+                                          &bad_pub_mode)
+            .value == OTCRYPTO_BAD_ARGS.value);
+
+  // Mismatched lengths for 2048
+  CHECK(otcrypto_rsa_public_key_construct(kOtcryptoRsaSize2048, &bad_mod_len,
+                                          &valid_pub)
+            .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_public_key_construct(kOtcryptoRsaSize2048, &valid_mod,
+                                          &bad_pub_len)
+            .value == OTCRYPTO_BAD_ARGS.value);
+
+  // Mismatched size enum
+  CHECK(otcrypto_rsa_public_key_construct(kOtcryptoRsaSize3072, &valid_mod,
+                                          &valid_pub)
+            .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_public_key_construct(kOtcryptoRsaSize4096, &valid_mod,
+                                          &valid_pub)
+            .value == OTCRYPTO_BAD_ARGS.value);
+
+  // Invalid size enum
+  CHECK(otcrypto_rsa_public_key_construct((otcrypto_rsa_size_t)999, &valid_mod,
+                                          &valid_pub)
+            .value == OTCRYPTO_BAD_ARGS.value);
+
+  return OTCRYPTO_OK;
+}
+
+static status_t run_private_key_from_exponents_negative_tests(void) {
+  LOG_INFO("Running RSA private key from exponents negative tests");
+
+  // Allocate valid base buffers
+  uint32_t mod_data[kRsa2048NumWords] = {0};
+  uint32_t d0_data[kRsa2048NumWords] = {0};
+  uint32_t d1_data[kRsa2048NumWords] = {0};
+
+  otcrypto_const_word32_buf_t valid_mod = OTCRYPTO_MAKE_BUF(
+      otcrypto_const_word32_buf_t, mod_data, kRsa2048NumWords);
+  otcrypto_const_word32_buf_t valid_d0 =
+      OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, d0_data, kRsa2048NumWords);
+  otcrypto_const_word32_buf_t valid_d1 =
+      OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, d1_data, kRsa2048NumWords);
+
+  // Allocate invalid base buffers
+  otcrypto_const_word32_buf_t bad_buf_null =
+      OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, NULL, kRsa2048NumWords);
+  otcrypto_const_word32_buf_t bad_buf_len = OTCRYPTO_MAKE_BUF(
+      otcrypto_const_word32_buf_t, d0_data, kRsa2048NumWords - 1);
+
+  // Setup valid private key config
+  uint32_t priv_blob[kOtcryptoRsa2048PrivateKeyblobBytes / 4] = {0};
+  otcrypto_key_config_t valid_priv_cfg = {
+      .version = kOtcryptoLibVersion1,
+      .key_mode = kOtcryptoKeyModeRsaSignPkcs,  // valid RSA mode
+      .key_length = kOtcryptoRsa2048PrivateKeyBytes,
+      .hw_backed = kHardenedBoolFalse,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
+  otcrypto_blinded_key_t valid_priv = {
+      .config = valid_priv_cfg,
+      .keyblob_length = kOtcryptoRsa2048PrivateKeyblobBytes,
+      .keyblob = priv_blob,
+  };
+
+  // Setup invalid private key configs using initializer lists
+  otcrypto_blinded_key_t bad_priv_null_blob = {
+      .config = valid_priv_cfg,
+      .keyblob_length = kOtcryptoRsa2048PrivateKeyblobBytes,
+      .keyblob = NULL,
+  };
+
+  otcrypto_key_config_t bad_mode_cfg = valid_priv_cfg;
+  bad_mode_cfg.key_mode = kOtcryptoKeyModeEcdsaP256;
+  otcrypto_blinded_key_t bad_priv_mode = {
+      .config = bad_mode_cfg,
+      .keyblob_length = kOtcryptoRsa2048PrivateKeyblobBytes,
+      .keyblob = priv_blob,
+  };
+
+  otcrypto_key_config_t bad_hw_cfg = valid_priv_cfg;
+  bad_hw_cfg.hw_backed = kHardenedBoolTrue;
+  otcrypto_blinded_key_t bad_priv_hw = {
+      .config = bad_hw_cfg,
+      .keyblob_length = kOtcryptoRsa2048PrivateKeyblobBytes,
+      .keyblob = priv_blob,
+  };
+
+  otcrypto_blinded_key_t bad_priv_blob_len = {
+      .config = valid_priv_cfg,
+      .keyblob_length = 99,
+      .keyblob = priv_blob,
+  };
+
+  // Null pointers
+  CHECK(otcrypto_rsa_private_key_from_exponents(
+            kOtcryptoRsaSize2048, NULL, &valid_d0, &valid_d1, &valid_priv)
+            .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_private_key_from_exponents(kOtcryptoRsaSize2048,
+                                                &bad_buf_null, &valid_d0,
+                                                &valid_d1, &valid_priv)
+            .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_private_key_from_exponents(kOtcryptoRsaSize2048,
+                                                &valid_mod, &bad_buf_null,
+                                                &valid_d1, &valid_priv)
+            .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_private_key_from_exponents(kOtcryptoRsaSize2048,
+                                                &valid_mod, &valid_d0,
+                                                &bad_buf_null, &valid_priv)
+            .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_private_key_from_exponents(
+            kOtcryptoRsaSize2048, &valid_mod, &valid_d0, &valid_d1, NULL)
+            .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_private_key_from_exponents(kOtcryptoRsaSize2048,
+                                                &valid_mod, &valid_d0,
+                                                &valid_d1, &bad_priv_null_blob)
+            .value == OTCRYPTO_BAD_ARGS.value);
+
+  // Mismatched share lengths vs modulus length
+  CHECK(otcrypto_rsa_private_key_from_exponents(kOtcryptoRsaSize2048,
+                                                &valid_mod, &bad_buf_len,
+                                                &valid_d1, &valid_priv)
+            .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_private_key_from_exponents(kOtcryptoRsaSize2048,
+                                                &valid_mod, &valid_d0,
+                                                &bad_buf_len, &valid_priv)
+            .value == OTCRYPTO_BAD_ARGS.value);
+
+  // Bad Mode
+  CHECK(otcrypto_rsa_private_key_from_exponents(kOtcryptoRsaSize2048,
+                                                &valid_mod, &valid_d0,
+                                                &valid_d1, &bad_priv_mode)
+            .value == OTCRYPTO_BAD_ARGS.value);
+
+  // Bad HW backed config
+  CHECK(otcrypto_rsa_private_key_from_exponents(kOtcryptoRsaSize2048,
+                                                &valid_mod, &valid_d0,
+                                                &valid_d1, &bad_priv_hw)
+            .value == OTCRYPTO_BAD_ARGS.value);
+
+  // Bad Blob length vs Config Length
+  CHECK(otcrypto_rsa_private_key_from_exponents(kOtcryptoRsaSize2048,
+                                                &valid_mod, &valid_d0,
+                                                &valid_d1, &bad_priv_blob_len)
+            .value == OTCRYPTO_BAD_ARGS.value);
+
+  // Mismatched size enum vs actual buffer sizes
+  CHECK(otcrypto_rsa_private_key_from_exponents(
+            kOtcryptoRsaSize3072, &valid_mod, &valid_d0, &valid_d1, &valid_priv)
+            .value == OTCRYPTO_BAD_ARGS.value);
+
+  // Invalid size enum
+  CHECK(otcrypto_rsa_private_key_from_exponents((otcrypto_rsa_size_t)999,
+                                                &valid_mod, &valid_d0,
+                                                &valid_d1, &valid_priv)
             .value == OTCRYPTO_BAD_ARGS.value);
 
   return OTCRYPTO_OK;
@@ -361,5 +617,7 @@ bool test_main(void) {
   EXECUTE_TEST(test_result, oaep_decrypt_valid_test);
   EXECUTE_TEST(test_result, oaep_encrypt_decrypt_test);
   EXECUTE_TEST(test_result, run_encrypt_negative_tests);
+  EXECUTE_TEST(test_result, run_public_key_construct_negative_tests);
+  EXECUTE_TEST(test_result, run_private_key_from_exponents_negative_tests);
   return status_ok(test_result);
 }

--- a/sw/device/tests/crypto/rsa_2048_key_from_cofactor_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_key_from_cofactor_functest.c
@@ -200,31 +200,50 @@ static status_t run_cofactor_negative_tests(void) {
   CHECK(otcrypto_rsa_keypair_from_cofactor(kOtcryptoRsaSize2048, &bad_mod_null,
                                            &valid_cof, &valid_cof, &valid_pub,
                                            &valid_priv)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_rsa_keypair_from_cofactor_async_start(
+            kOtcryptoRsaSize2048, &bad_mod_null, &valid_cof, &valid_cof)
+            .value != OTCRYPTO_OK.value);
+
   CHECK(otcrypto_rsa_keypair_from_cofactor(kOtcryptoRsaSize2048, &valid_mod,
                                            &bad_cof_null, &valid_cof,
                                            &valid_pub, &valid_priv)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_rsa_keypair_from_cofactor_async_start(
+            kOtcryptoRsaSize2048, &valid_mod, &bad_cof_null, &valid_cof)
+            .value != OTCRYPTO_OK.value);
+
   CHECK(otcrypto_rsa_keypair_from_cofactor(kOtcryptoRsaSize2048, &valid_mod,
                                            &valid_cof, &valid_cof, NULL,
                                            &valid_priv)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_rsa_keypair_from_cofactor_async_finalize(NULL, &valid_priv)
+            .value != OTCRYPTO_OK.value);
+
   CHECK(otcrypto_rsa_keypair_from_cofactor(kOtcryptoRsaSize2048, &valid_mod,
                                            &valid_cof, &valid_cof, &valid_pub,
                                            NULL)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_rsa_keypair_from_cofactor_async_finalize(&valid_pub, NULL)
+            .value != OTCRYPTO_OK.value);
 
   // Cofactor length test
   CHECK(otcrypto_rsa_keypair_from_cofactor(kOtcryptoRsaSize2048, &valid_mod,
                                            &bad_cof_len, &valid_cof, &valid_pub,
                                            &valid_priv)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_rsa_keypair_from_cofactor_async_start(
+            kOtcryptoRsaSize2048, &valid_mod, &bad_cof_len, &valid_cof)
+            .value != OTCRYPTO_OK.value);
 
   // Bad enum size
   CHECK(otcrypto_rsa_keypair_from_cofactor((otcrypto_rsa_size_t)999, &valid_mod,
                                            &valid_cof, &valid_cof, &valid_pub,
                                            &valid_priv)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_rsa_keypair_from_cofactor_async_start(
+            (otcrypto_rsa_size_t)999, &valid_mod, &valid_cof, &valid_cof)
+            .value != OTCRYPTO_OK.value);
 
   // Bad public key struct
   otcrypto_unblinded_key_t bad_pub_len = {
@@ -235,7 +254,10 @@ static status_t run_cofactor_negative_tests(void) {
   CHECK(otcrypto_rsa_keypair_from_cofactor(kOtcryptoRsaSize2048, &valid_mod,
                                            &valid_cof, &valid_cof, &bad_pub_len,
                                            &valid_priv)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_rsa_keypair_from_cofactor_async_finalize(&bad_pub_len,
+                                                          &valid_priv)
+            .value != OTCRYPTO_OK.value);
 
   // Bad private key struct
   otcrypto_key_config_t bad_mode_cfg = priv_cfg;
@@ -248,7 +270,10 @@ static status_t run_cofactor_negative_tests(void) {
   CHECK(otcrypto_rsa_keypair_from_cofactor(kOtcryptoRsaSize2048, &valid_mod,
                                            &valid_cof, &valid_cof, &valid_pub,
                                            &bad_priv_mode)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_rsa_keypair_from_cofactor_async_finalize(&valid_pub,
+                                                          &bad_priv_mode)
+            .value != OTCRYPTO_OK.value);
 
   return OTCRYPTO_OK;
 }

--- a/sw/device/tests/crypto/rsa_2048_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_keygen_functest.c
@@ -145,10 +145,15 @@ static status_t run_keygen_negative_tests(void) {
   };
 
   // Null checks
-  CHECK(otcrypto_rsa_keygen(kOtcryptoRsaSize2048, NULL, &valid_priv).value ==
-        OTCRYPTO_BAD_ARGS.value);
-  CHECK(otcrypto_rsa_keygen(kOtcryptoRsaSize2048, &valid_pub, NULL).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_keygen(kOtcryptoRsaSize2048, NULL, &valid_priv).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_rsa_keygen_async_finalize(NULL, &valid_priv).value !=
+        OTCRYPTO_OK.value);
+
+  CHECK(otcrypto_rsa_keygen(kOtcryptoRsaSize2048, &valid_pub, NULL).value !=
+        OTCRYPTO_OK.value);
+  CHECK(otcrypto_rsa_keygen_async_finalize(&valid_pub, NULL).value !=
+        OTCRYPTO_OK.value);
 
   // Bad modes
   otcrypto_key_config_t bad_mode_cfg = valid_priv_cfg;
@@ -159,7 +164,9 @@ static status_t run_keygen_negative_tests(void) {
       .keyblob = priv_blob,
   };
   CHECK(otcrypto_rsa_keygen(kOtcryptoRsaSize2048, &valid_pub, &bad_priv_mode)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_rsa_keygen_async_finalize(&valid_pub, &bad_priv_mode).value !=
+        OTCRYPTO_OK.value);
 
   // HW backed restriction
   otcrypto_key_config_t bad_hw_cfg = valid_priv_cfg;
@@ -170,11 +177,25 @@ static status_t run_keygen_negative_tests(void) {
       .keyblob = priv_blob,
   };
   CHECK(otcrypto_rsa_keygen(kOtcryptoRsaSize2048, &valid_pub, &bad_priv_hw)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_rsa_keygen_async_finalize(&valid_pub, &bad_priv_hw).value !=
+        OTCRYPTO_OK.value);
 
   // Bad size enum
   CHECK(otcrypto_rsa_keygen((otcrypto_rsa_size_t)999, &valid_pub, &valid_priv)
-            .value == OTCRYPTO_BAD_ARGS.value);
+            .value != OTCRYPTO_OK.value);
+  CHECK(otcrypto_rsa_keygen_async_start((otcrypto_rsa_size_t)999).value !=
+        OTCRYPTO_OK.value);
+
+  // Bad length
+  otcrypto_blinded_key_t bad_priv_blob_len = {
+      .config = valid_priv_cfg,
+      .keyblob_length = 999,  // Should be kOtcryptoRsa2048PrivateKeyblobBytes
+      .keyblob = priv_blob,
+  };
+  CHECK(
+      otcrypto_rsa_keygen(kOtcryptoRsaSize2048, &valid_pub, &bad_priv_blob_len)
+          .value != OTCRYPTO_OK.value);
 
   return OTCRYPTO_OK;
 }

--- a/sw/device/tests/crypto/rsa_2048_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_signature_functest.c
@@ -342,16 +342,24 @@ static status_t run_signature_negative_tests(void) {
   hardened_bool_t verify_res;
 
   // Sign negative tests
+
+  // Null pointers
   CHECK(
       otcrypto_rsa_sign(NULL, valid_digest, kOtcryptoRsaPaddingPkcs, &valid_sig)
           .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(
+      otcrypto_rsa_sign_async_start(NULL, valid_digest, kOtcryptoRsaPaddingPkcs)
+          .value != OTCRYPTO_OK.value);
 
   otcrypto_word32_buf_t bad_sig_null =
       OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, NULL, kRsa2048NumWords);
   CHECK(otcrypto_rsa_sign(&valid_priv, valid_digest, kOtcryptoRsaPaddingPkcs,
                           &bad_sig_null)
             .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_sign_async_finalize(&bad_sig_null).value !=
+        OTCRYPTO_OK.value);
 
+  // Corrupt checksum
   otcrypto_blinded_key_t bad_priv_chk = {
       .config = valid_priv.config,
       .keyblob_length = valid_priv.keyblob_length,
@@ -361,20 +369,35 @@ static status_t run_signature_negative_tests(void) {
   CHECK(otcrypto_rsa_sign(&bad_priv_chk, valid_digest, kOtcryptoRsaPaddingPkcs,
                           &valid_sig)
             .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_sign_async_start(&bad_priv_chk, valid_digest,
+                                      kOtcryptoRsaPaddingPkcs)
+            .value != OTCRYPTO_OK.value);
 
   // Mismatched padding mode
   CHECK(otcrypto_rsa_sign(&valid_priv, valid_digest, kOtcryptoRsaPaddingPss,
                           &valid_sig)
             .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_sign_async_start(&valid_priv, valid_digest,
+                                      kOtcryptoRsaPaddingPss)
+            .value != OTCRYPTO_OK.value);
 
   // Verify negative tests
+
+  // Null pointers
   CHECK(otcrypto_rsa_verify(NULL, valid_digest, kOtcryptoRsaPaddingPkcs,
                             &valid_const_sig, &verify_res)
             .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_verify_async_start(NULL, &valid_const_sig).value !=
+        OTCRYPTO_OK.value);
+
   CHECK(otcrypto_rsa_verify(&valid_pub, valid_digest, kOtcryptoRsaPaddingPkcs,
                             &valid_const_sig, NULL)
             .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_verify_async_finalize(valid_digest,
+                                           kOtcryptoRsaPaddingPkcs, NULL)
+            .value != OTCRYPTO_OK.value);
 
+  // Corrupt checksum
   otcrypto_unblinded_key_t bad_pub_chk = {
       .key_mode = valid_pub.key_mode,
       .key_length = valid_pub.key_length,
@@ -384,12 +407,17 @@ static status_t run_signature_negative_tests(void) {
   CHECK(otcrypto_rsa_verify(&bad_pub_chk, valid_digest, kOtcryptoRsaPaddingPkcs,
                             &valid_const_sig, &verify_res)
             .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_verify_async_start(&bad_pub_chk, &valid_const_sig).value !=
+        OTCRYPTO_OK.value);
 
+  // Bad signature length
   otcrypto_const_word32_buf_t bad_const_sig_len =
       OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, sig_data, 99);
   CHECK(otcrypto_rsa_verify(&valid_pub, valid_digest, kOtcryptoRsaPaddingPkcs,
                             &bad_const_sig_len, &verify_res)
             .value == OTCRYPTO_BAD_ARGS.value);
+  CHECK(otcrypto_rsa_verify_async_start(&valid_pub, &bad_const_sig_len).value !=
+        OTCRYPTO_OK.value);
 
   return OTCRYPTO_OK;
 }


### PR DESCRIPTION
Improve RSA's negative tests, and refactor the input checks. The synchronized calls will leave the checks to the asynchronous ones (_start and _finalize), except for keygen and key_from_cofactor which relate the given size to the key.

This improves the coverage for RSA.