### PR TITLE
[ci] Stop englishbreakfast CI jobs for `earlgrey_1.0.0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,40 +312,6 @@ jobs:
         with:
           artifact-name: verilator_earlgrey-test-results
 
-  # Build CW305 variant of the English Breakfast toplevel design using Vivado
-  chip_englishbreakfast_cw305:
-    name: CW305's Bitstream
-    runs-on: ubuntu-22.04-bitstream
-    needs: quick_lint
-    steps:
-      - uses: actions/checkout@v4
-      - name: Prepare environment
-        uses: ./.github/actions/prepare-env
-        with:
-          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
-      - name: Build bitstream
-        run: |
-          # Build CW305 test rom required by `build-bitstream-vivado.sh`
-          rom_path="sw/device/lib/testing/test_rom"
-          ./bazelisk.sh build "//${rom_path}:test_rom_fpga_cw305" \
-            --features=-rv32_bitmanip \
-            --copt=-DOT_IS_ENGLISH_BREAKFAST_REDUCED_SUPPORT_FOR_INTERNAL_USE_ONLY_
-          vmem="$(./bazelisk.sh cquery --output=files "//${rom_path}:test_rom_fpga_cw305" \
-            --features=-rv32_bitmanip \
-            --copt=-DOT_IS_ENGLISH_BREAKFAST_REDUCED_SUPPORT_FOR_INTERNAL_USE_ONLY_
-          )"
-          mkdir -p "build-bin/${rom_path}"
-          cp "$vmem" "build-bin/${rom_path}"
-
-          module load "xilinx/vivado/${VIVADO_VERSION}"
-          ci/scripts/build-bitstream-vivado.sh top_englishbreakfast cw305
-      - name: Upload bitstream
-        uses: actions/upload-artifact@v4
-        with:
-          name: chip_englishbreakfast_cw305
-          path: build-bin/hw/top_englishbreakfast/lowrisc_systems_chip_englishbreakfast_cw305_0.1.bit
-          overwrite: true
-
   chip_earlgrey_cw310:
     name: Earl Grey for CW310
     needs: quick_lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,27 +272,6 @@ jobs:
       - name: Execute tests
         run: ./bazelisk.sh test --test_tag_filters=-nightly //sw/otbn/crypto/...
 
-  verilator_englishbreakfast:
-    name: Verilated English Breakfast
-    runs-on: ubuntu-22.04
-    needs: quick_lint
-    steps:
-      - uses: actions/checkout@v4
-      - name: Prepare environment
-        uses: ./.github/actions/prepare-env
-        with:
-          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
-      - name: Build simulator with Verilator
-        run: ./ci/scripts/build-chip-verilator.sh englishbreakfast
-      - name: Upload binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: verilated_englishbreakfast
-          path: build-bin/hw/top_englishbreakfast/Vchip_englishbreakfast_verilator
-          overwrite: true
-      - name: Test
-        run: ./ci/scripts/run-english-breakfast-verilator-tests.sh
-
   verilator_earlgrey:
     name: Verilated Earl Grey
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This top-level is no longer an active target for SCA experiments on the `earlgrey_1.0.0` branch, and so there is no value in building the English Breakfast bitstream for the CW305, nor running the Verilator smoketests. This PR drops these CI jobs on the `earlgrey_1.0.0` branch to reduce the total CI load.

The CW305 bitstream build can increase queueing for the `ubuntu-22.04-vivado` runners (not the `ubuntu-22.04-bitstream` runners, but still a custom runner with limited availability). 