### PR TITLE
[bazel,ci] Exclude `tlul/generic_dv` from the RTL file lists and CI bitstream cache check

### DIFF
--- a/.github/workflows/bitstream.yml
+++ b/.github/workflows/bitstream.yml
@@ -43,6 +43,7 @@ jobs:
             ':!/*.md' \
             ':!/.github/' \
             ':!/hw/**/dv/*' \
+            ':!/hw/**/generic_dv/*' \
             ':!/hw/dv/'
 
       - name: Extract cached bitstream

--- a/hw/BUILD
+++ b/hw/BUILD
@@ -170,6 +170,7 @@ filegroup(
         exclude = [
             "foundry/**",
             "**/dv/**",
+            "**/generic_dv/**",
             "doc/**",
         ],
     ) + [

--- a/hw/ip/BUILD
+++ b/hw/ip/BUILD
@@ -10,6 +10,7 @@ filegroup(
         ["**"],
         exclude = [
             "*/dv/**",
+            "*/generic_dv/**",
             "*/doc/**",
             "*/README.md",
         ],


### PR DESCRIPTION
This will allow DV changes touching the TL-UL "generic_dv" setup to hit the CI and Bazel caches for bitstream/simulator builds etc. So that for example https://github.com/lowRISC/opentitan/pull/29728 would have been [properly cached](https://github.com/lowRISC/opentitan/actions/runs/24832142462).