### PR TITLE
[ci] Move the CW305 English Breakfast bitstream build to a new monthly job & tweak nightly schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,63 +348,6 @@ jobs:
         with:
           artifact-name: verilator_earlgrey-test-results
 
-  # Build CW305 variant of the English Breakfast toplevel design using Vivado
-  chip_englishbreakfast_cw305:
-    name: CW305's Bitstream
-    runs-on: ubuntu-22.04-vivado
-    needs: quick_lint
-    if: ${{ github.event_name != 'merge_group' }}
-    steps:
-      - uses: actions/checkout@v6
-      - name: Prepare environment
-        uses: ./.github/actions/prepare-env
-        with:
-          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
-      - name: Build bitstream
-        run: |
-          . util/build_consts.sh
-
-          bitstream_target=//hw/top_englishbreakfast/bitstream:fpga_cw305
-          archive_target=//hw/top_englishbreakfast/bitstream:englishbreakfast_cw305_archive
-          bitstream_archive=$(./bazelisk.sh outquery ${archive_target})
-
-          trap 'get_logs' EXIT
-          get_logs() {
-            design_name=chip_englishbreakfast_cw305
-            SUB_PATH="hw/top_englishbreakfast/${design_name}"
-            mkdir -p "$OBJ_DIR/$SUB_PATH" "$BIN_DIR/$SUB_PATH"
-            # This can fail if the build result is from Bazel cache
-            cp -rLvt "$OBJ_DIR/$SUB_PATH/" \
-              $(./bazelisk.sh outquery-all ${bitstream_target}) || true
-
-            # TODO: Splice ROM into the bitstream?
-            cp -Lv ${bitstream_archive} build-bin.tar
-          }
-
-          # Build the bitstream first. It has an empty ROM (all zeroes).
-          module load "xilinx/vivado/${VIVADO_VERSION}"
-          ./bazelisk.sh build //hw/top_englishbreakfast/bitstream:englishbreakfast_cw305_archive
-          tar xvf ${bitstream_archive}
-
-          # Build CW305 test rom required by `build-bitstream-vivado.sh`
-          rom_path="sw/device/lib/testing/test_rom"
-          ./bazelisk.sh build "//${rom_path}:test_rom_fpga_cw305" \
-            --features=-rv32_bitmanip \
-            --copt=-DOT_IS_ENGLISH_BREAKFAST_REDUCED_SUPPORT_FOR_INTERNAL_USE_ONLY_
-          vmem="$(./bazelisk.sh cquery --output=files "//${rom_path}:test_rom_fpga_cw305" \
-            --features=-rv32_bitmanip \
-            --copt=-DOT_IS_ENGLISH_BREAKFAST_REDUCED_SUPPORT_FOR_INTERNAL_USE_ONLY_
-          )"
-          mkdir -p "build-bin/${rom_path}"
-          cp "$vmem" "build-bin/${rom_path}"
-
-      - name: Upload bitstream
-        uses: actions/upload-artifact@v7
-        with:
-          name: chip_englishbreakfast_cw305
-          path: build-bin.tar
-          overwrite: true
-
   chip_earlgrey_cw310_hyperdebug:
     name: Earl Grey for CW310 Hyperdebug
     needs: quick_lint

--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -1,0 +1,78 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Monthly
+on:
+  schedule:
+    - cron: "00 00 01 * *"
+      timezone: "Europe/London"
+
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to run the monthly on"
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  VIVADO_VERSION: "2021.1"
+
+jobs:
+  chip_englishbreakfast_cw305:
+    name: Build English Breakfast Bitstream for CW305
+    runs-on: ubuntu-22.04-vivado
+    steps:
+      - uses: actions/checkout@v6
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
+        with:
+          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
+      - name: Build bitstream
+        run: |
+          . util/build_consts.sh
+
+          bitstream_target=//hw/top_englishbreakfast/bitstream:fpga_cw305
+          archive_target=//hw/top_englishbreakfast/bitstream:englishbreakfast_cw305_archive
+          bitstream_archive=$(./bazelisk.sh outquery ${archive_target})
+
+          trap 'get_logs' EXIT
+          get_logs() {
+            design_name=chip_englishbreakfast_cw305
+            SUB_PATH="hw/top_englishbreakfast/${design_name}"
+            mkdir -p "$OBJ_DIR/$SUB_PATH" "$BIN_DIR/$SUB_PATH"
+            # This can fail if the build result is from Bazel cache
+            cp -rLvt "$OBJ_DIR/$SUB_PATH/" \
+              $(./bazelisk.sh outquery-all ${bitstream_target}) || true
+
+            # TODO: Splice ROM into the bitstream?
+            cp -Lv ${bitstream_archive} build-bin.tar
+          }
+
+          # Build the bitstream first. It has an empty ROM (all zeroes).
+          module load "xilinx/vivado/${VIVADO_VERSION}"
+          ./bazelisk.sh build //hw/top_englishbreakfast/bitstream:englishbreakfast_cw305_archive
+          tar xvf ${bitstream_archive}
+
+          # Build CW305 test rom required by `build-bitstream-vivado.sh`
+          rom_path="sw/device/lib/testing/test_rom"
+          ./bazelisk.sh build "//${rom_path}:test_rom_fpga_cw305" \
+            --features=-rv32_bitmanip \
+            --copt=-DOT_IS_ENGLISH_BREAKFAST_REDUCED_SUPPORT_FOR_INTERNAL_USE_ONLY_
+          vmem="$(./bazelisk.sh cquery --output=files "//${rom_path}:test_rom_fpga_cw305" \
+            --features=-rv32_bitmanip \
+            --copt=-DOT_IS_ENGLISH_BREAKFAST_REDUCED_SUPPORT_FOR_INTERNAL_USE_ONLY_
+          )"
+          mkdir -p "build-bin/${rom_path}"
+          cp "$vmem" "build-bin/${rom_path}"
+
+      - name: Upload bitstream
+        uses: actions/upload-artifact@v7
+        with:
+          name: chip_englishbreakfast_cw305
+          path: build-bin.tar
+          overwrite: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,7 +5,8 @@
 name: Nightly
 on:
   schedule:
-    - cron: "00 04 * * *"
+    - cron: "00 01 * * *"
+      timezone: "Europe/London"
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
We currently have no need to build the English Breakfast CW305 bitstreams for every PR, and it's increasing queueing for the `ubuntu-22.0.4-vivado` runners which have limited capacity. To allow these bitstreams to be made available at some regular cadence and help catch regressions in functionality, move this to a monthly job for now rather than removing it entirely.

This monthly job is scheduled to run at 12:00 AM on the 1st day of every month. If this is deemed insufficient, this bitstream build can be moved to a weekly/nightly later on instead. This PR also makes a small tweak to the nightly job to match the current load that we're seeing in CI.

*Note*: this cannot be tested before merging because the `workflow_dispatch` [requires that the workflow exist on the default branch](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#defining-inputs-for-manually-triggered-workflows) (`master`) to allow manual dispatching:

> This trigger only receives events when the workflow file is on the default branch. The triggered workflow receives the inputs in the inputs context. For more information, see [Contexts](https://docs.github.com/en/actions/learn-github-actions/contexts#inputs-context).

This is not expected to fail, but the intention is that after this PR is merged, a manual run of the monthly job can catch any errors which can then be tested on a separate branch, and any issues can be fixed in a follow-up PR (hopefully not needed). The job is basically moved verbatim, with the only differences being a small name change, and removal of the `needs` and `if` gates.