### PR TITLE
[crypto] Config bugfix and test + alert optimization

### DIFF
--- a/sw/device/lib/crypto/drivers/alert.c
+++ b/sw/device/lib/crypto/drivers/alert.c
@@ -24,13 +24,15 @@ uint32_t read_alert_registers(void) {
                       SENSOR_CTRL_FATAL_ALERT_REG_OFFSET);
   uint32_t combined_alerts = sensors_recov_alerts | sensors_fatal_alerts;
 
-  // Read out the alerts
-  for (uint32_t alert = 0; alert < ALERT_HANDLER_PARAM_N_ALERTS; alert++) {
-    uint32_t cause = abs_mmio_read32(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR +
-                                     (alert * sizeof(uint32_t)) +
-                                     ALERT_HANDLER_ALERT_CAUSE_0_REG_OFFSET);
-    combined_alerts |= cause;
-  }
+  // Read out the alerts accumulation of the classes
+  combined_alerts |= abs_mmio_read32(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR +
+                                     ALERT_HANDLER_CLASSA_ACCUM_CNT_REG_OFFSET);
+  combined_alerts |= abs_mmio_read32(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR +
+                                     ALERT_HANDLER_CLASSB_ACCUM_CNT_REG_OFFSET);
+  combined_alerts |= abs_mmio_read32(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR +
+                                     ALERT_HANDLER_CLASSC_ACCUM_CNT_REG_OFFSET);
+  combined_alerts |= abs_mmio_read32(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR +
+                                     ALERT_HANDLER_CLASSD_ACCUM_CNT_REG_OFFSET);
   // Read out the local alerts
   for (uint32_t local_alert = 0; local_alert < ALERT_HANDLER_PARAM_N_LOC_ALERT;
        local_alert++) {
@@ -41,6 +43,36 @@ uint32_t read_alert_registers(void) {
     combined_alerts |= local_cause;
   }
   return combined_alerts;
+}
+
+status_t clear_alert_class_accum(void) {
+  // Check whether we can write to the class accumulators
+  uint32_t regwen = abs_mmio_read32(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR +
+                                    ALERT_HANDLER_CLASSA_CLR_REGWEN_REG_OFFSET);
+  regwen |= abs_mmio_read32(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR +
+                            ALERT_HANDLER_CLASSB_CLR_REGWEN_REG_OFFSET);
+  regwen |= abs_mmio_read32(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR +
+                            ALERT_HANDLER_CLASSC_CLR_REGWEN_REG_OFFSET);
+  regwen |= abs_mmio_read32(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR +
+                            ALERT_HANDLER_CLASSD_CLR_REGWEN_REG_OFFSET);
+  if ((regwen & 0x1) != 1) {
+    return OTCRYPTO_FATAL_ERR;
+  }
+
+  abs_mmio_write32_shadowed(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR +
+                                ALERT_HANDLER_CLASSA_CLR_SHADOWED_REG_OFFSET,
+                            1);
+  abs_mmio_write32_shadowed(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR +
+                                ALERT_HANDLER_CLASSB_CLR_SHADOWED_REG_OFFSET,
+                            1);
+  abs_mmio_write32_shadowed(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR +
+                                ALERT_HANDLER_CLASSC_CLR_SHADOWED_REG_OFFSET,
+                            1);
+  abs_mmio_write32_shadowed(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR +
+                                ALERT_HANDLER_CLASSD_CLR_SHADOWED_REG_OFFSET,
+                            1);
+
+  return OTCRYPTO_OK;
 }
 
 status_t init_alert_registers(void) {
@@ -78,8 +110,11 @@ status_t init_alert_registers(void) {
                      0x1);
   }
 
+  // Clear the interupt states.
   abs_mmio_write32(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR +
                        ALERT_HANDLER_INTR_STATE_REG_OFFSET,
                    0xffffffff);
-  return OTCRYPTO_OK;
+
+  // Clear the class accumulators.
+  return clear_alert_class_accum();
 }

--- a/sw/device/lib/crypto/drivers/alert.h
+++ b/sw/device/lib/crypto/drivers/alert.h
@@ -19,6 +19,14 @@ OT_WARN_UNUSED_RESULT
 uint32_t read_alert_registers(void);
 
 /**
+ * Clear the class alerts accumulators.
+ *
+ * @return OK when the alert accumulators are cleared.
+ */
+OT_WARN_UNUSED_RESULT
+status_t clear_alert_class_accum(void);
+
+/**
  * Clear the alert, the sensors, and the local alert registers.
  *
  * @return OK when the alerts are cleared.

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -300,10 +300,10 @@ cc_library(
         ":status",
         "//hw/top_earlgrey/ip_autogen/clkmgr:clkmgr_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/crypto/drivers:alert",
         "//sw/device/lib/crypto/drivers:rv_core_ibex",
-        "//sw/device/lib/base:abs_mmio",
     ],
 )
 

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -303,6 +303,7 @@ cc_library(
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/crypto/drivers:alert",
         "//sw/device/lib/crypto/drivers:rv_core_ibex",
+        "//sw/device/lib/base:abs_mmio",
     ],
 )
 

--- a/sw/device/lib/crypto/impl/config.c
+++ b/sw/device/lib/crypto/impl/config.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/crypto/include/config.h"
 
+#include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/crypto/drivers/alert.h"
 #include "sw/device/lib/crypto/drivers/rv_core_ibex.h"
@@ -14,9 +15,8 @@
 
 otcrypto_status_t otcrypto_security_config_check(
     otcrypto_key_security_level_t security_level) {
-#if defined(OPENTITAN_IS_EARLGREY)
   if (launder32(security_level) != kOtcryptoKeySecurityLevelLow) {
-    // Check if the jittery clock is enabled on OpenTitan EarlGrey.
+    // Check if the jittery clock is enabled.
     uint32_t jittery_clk_en = abs_mmio_read32(
         TOP_EARLGREY_CLKMGR_AON_BASE_ADDR + CLKMGR_JITTER_ENABLE_REG_OFFSET);
     if (launder32(jittery_clk_en) != kMultiBitBool4True) {
@@ -35,15 +35,13 @@ otcrypto_status_t otcrypto_security_config_check(
     // Do not check the device config when security level is low.
     HARDENED_CHECK_EQ(security_level, kOtcryptoKeySecurityLevelLow);
   }
-#endif
   return OTCRYPTO_OK;
 }
 
 otcrypto_status_t otcrypto_set_security_config(
     otcrypto_key_security_level_t security_level) {
-#if defined(OPENTITAN_IS_EARLGREY)
   if (launder32(security_level) != kOtcryptoKeySecurityLevelLow) {
-    // Enable the jittery clock in OpenTitan Earlgrey.
+    // Enable the jittery clock.
     abs_mmio_write32(
         TOP_EARLGREY_CLKMGR_AON_BASE_ADDR + CLKMGR_JITTER_ENABLE_REG_OFFSET,
         kMultiBitBool4True);
@@ -54,7 +52,6 @@ otcrypto_status_t otcrypto_set_security_config(
     // Do not check the device config when security level is low.
     HARDENED_CHECK_EQ(security_level, kOtcryptoKeySecurityLevelLow);
   }
-#endif
   return OTCRYPTO_OK;
 }
 

--- a/sw/device/lib/crypto/impl/config.c
+++ b/sw/device/lib/crypto/impl/config.c
@@ -65,6 +65,11 @@ otcrypto_status_t otcrypto_restore_icache(hardened_bool_t icache_enabled) {
   return OTCRYPTO_OK;
 }
 
+otcrypto_status_t otcrypto_clear_alerts(void) {
+  HARDENED_TRY(init_alert_registers());
+  return OTCRYPTO_OK;
+}
+
 otcrypto_status_t otcrypto_init(otcrypto_key_security_level_t security_level) {
   HARDENED_TRY(otcrypto_set_security_config(security_level));
 
@@ -80,7 +85,6 @@ otcrypto_status_t otcrypto_eval_exit(otcrypto_status_t status) {
   if (read_alert_registers()) {
     return OTCRYPTO_FATAL_ERR;
   }
-  HARDENED_CHECK_EQ(launder32(read_alert_registers()), 0);
 
   // Verify the entropy source before leaving.
   HARDENED_TRY(otcrypto_entropy_health_test_config_check());

--- a/sw/device/lib/crypto/include/config.h
+++ b/sw/device/lib/crypto/include/config.h
@@ -71,6 +71,20 @@ OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_restore_icache(hardened_bool_t icache_enabled);
 
 /**
+ * Clear the alerts including local alerts and sensors.
+ *
+ * The cryptolib locks itself when there is a class (A,B,C,D) acumulation count
+ * higher than zero or when a local alert or sensor is triggered. This function
+ * reset these registers to continue crypto operations. Note that it writes to
+ * the registers in the alert manager.
+ *
+ * @param icache_enabled kHardenedBoolTrue to enable the iCache.
+ * @return Error status.
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_clear_alerts(void);
+
+/**
  * Initializes the crypto library for use.
  *
  * Check the security configuration
@@ -91,7 +105,7 @@ otcrypto_status_t otcrypto_init(otcrypto_key_security_level_t security_level);
  * Function used to return to the user, the last function call of every crypto
  * API. Only to be used when OTCRYPTO_OK can be returned.
  *
- * This function checks whether any alert was fired.
+ * This function checks whether any alert or sensor was fired.
  *
  * @param security_level Security level of the used key.
  * @returns OK when the security check passed.

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -270,13 +270,18 @@ opentitan_test(
         timeout = "eternal",
     ),
     deps = [
+        "//hw/ip/aes/data:aes_c_regs",
         "//hw/ip/rv_core_ibex/data:rv_core_ibex_c_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:csr",
         "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:status",
         "//sw/device/lib/crypto/include:datatypes",
+        "//sw/device/lib/runtime:irq",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:randomness_quality",
+        "//sw/device/lib/testing/test_framework:ottf_alerts",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -259,11 +259,19 @@ opentitan_test(
 opentitan_test(
     name = "config_functest",
     srcs = ["config_functest.c"],
-    exec_env = CRYPTOTEST_EXEC_ENVS,
+    # This test does not work on cw310 since it does not connect the jittery clock
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
+        },
+    ),
     verilator = verilator_params(
         timeout = "eternal",
     ),
     deps = [
+        "//hw/ip/rv_core_ibex/data:rv_core_ibex_c_regs",
+        "//sw/device/lib/base:csr",
         "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:status",
         "//sw/device/lib/crypto/include:datatypes",
@@ -1353,6 +1361,7 @@ test_suite(
         ":aes_kwp_kat_functest",
         ":aes_kwp_sideload_functest",
         ":aes_sideload_functest",
+        ":config_functest",
         ":drbg_functest",
         ":ecc_p256_arith_share_private_key_functest",
         ":ecc_p256_base_point_mult_functest",

--- a/sw/device/tests/crypto/config_functest.c
+++ b/sw/device/tests/crypto/config_functest.c
@@ -2,16 +2,22 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/csr.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/runtime/irq.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_alerts.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
+#include "aes_regs.h"
+#include "alert_handler_regs.h"  // Generated
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "rv_core_ibex_regs.h"
 
 #define MODULE_ID MAKE_MODULE_ID('t', 's', 't')
@@ -77,6 +83,122 @@ static status_t test_icache_disable_restore(void) {
   return OK_STATUS();
 }
 
+static status_t test_alert_caught_by_eval_exit(void) {
+  LOG_INFO("Testing otcrypto_eval_exit with forced AES alert");
+
+  // Initialize crypto (this also clears alert accumulators)
+  TRY(otcrypto_init(kOtcryptoKeySecurityLevelHigh));
+
+  // OTTF has its own alert management system, we have to bypass it.
+  // Disable interrupts globally.
+  // This prevents the OTTF ISR from preempting us and clearing the accumulator.
+  irq_global_ctrl(false);
+
+  // Force a recoverable alert of the AES
+  uint32_t alert_test_reg =
+      bitfield_bit32_write(0, AES_ALERT_TEST_RECOV_CTRL_UPDATE_ERR_BIT, true);
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR),
+                      (ptrdiff_t)AES_ALERT_TEST_REG_OFFSET, alert_test_reg);
+
+  // Verify eval_exit catches the alert.
+  // Because interrupts are off, the accumulator is preserved for this check.
+  otcrypto_status_t exit_status = otcrypto_eval_exit(OTCRYPTO_OK);
+  CHECK(exit_status.value == OTCRYPTO_FATAL_ERR.value,
+        "otcrypto_eval_exit failed to catch the AES alert. Expected 0x%08x, "
+        "got 0x%08x",
+        OTCRYPTO_FATAL_ERR.value, exit_status.value);
+
+  // Use the cryptolib's helper call to clear the alerts.
+  TRY(otcrypto_clear_alerts());
+
+  // Verify that the eval_exit passes again.
+  TRY(otcrypto_eval_exit(OTCRYPTO_OK));
+
+  // - Cleanup
+  // The PLIC still has a pending interrupt latched from the alert. If we turn
+  // IRQs back on right now, the ISR will run, find no cause, and abort(). To
+  // exit safely, we tell the OTTF to expect an alert, and trigger a fresh one.
+
+  // Feed the OTTF ISR.
+  TRY(ottf_alerts_expect_alert_start(kTopEarlgreyAlertIdAesRecovCtrlUpdateErr));
+
+  // Provide a new alert.
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR),
+                      (ptrdiff_t)AES_ALERT_TEST_REG_OFFSET, alert_test_reg);
+
+  // The CPU jumps to the ISR immediately. The ISR sees the second alert, marks
+  // it as caught, clears the PLIC state, and returns.
+  irq_global_ctrl(true);
+
+  // Finish the OTTF's expectation.
+  TRY(ottf_alerts_expect_alert_finish(
+      kTopEarlgreyAlertIdAesRecovCtrlUpdateErr));
+
+  return OK_STATUS();
+}
+
+static status_t test_lock(void) {
+  LOG_INFO("Testing locking the regwen provides a bad status");
+  // Locking the accumulators causes the alert to no longer be clearable.
+  // The test is similar to test_alert_caught_by_eval_exit
+
+  TRY(otcrypto_init(kOtcryptoKeySecurityLevelHigh));
+  irq_global_ctrl(false);
+
+  // Lock the accumulators
+  abs_mmio_write32_shadowed(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR +
+                                ALERT_HANDLER_CLASSA_CLR_REGWEN_REG_OFFSET,
+                            0);
+  abs_mmio_write32_shadowed(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR +
+                                ALERT_HANDLER_CLASSB_CLR_REGWEN_REG_OFFSET,
+                            0);
+  abs_mmio_write32_shadowed(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR +
+                                ALERT_HANDLER_CLASSC_CLR_REGWEN_REG_OFFSET,
+                            0);
+  abs_mmio_write32_shadowed(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR +
+                                ALERT_HANDLER_CLASSD_CLR_REGWEN_REG_OFFSET,
+                            0);
+
+  // Recoverable alert
+  uint32_t alert_test_reg =
+      bitfield_bit32_write(0, AES_ALERT_TEST_RECOV_CTRL_UPDATE_ERR_BIT, true);
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR),
+                      (ptrdiff_t)AES_ALERT_TEST_REG_OFFSET, alert_test_reg);
+
+  // eval_exit catches the alert.
+  otcrypto_status_t exit_status = otcrypto_eval_exit(OTCRYPTO_OK);
+  CHECK(exit_status.value == OTCRYPTO_FATAL_ERR.value,
+        "otcrypto_eval_exit failed to catch the AES alert. Expected 0x%08x, "
+        "got 0x%08x",
+        OTCRYPTO_FATAL_ERR.value, exit_status.value);
+
+  // Use the cryptolib's helper call to clear the alerts.
+  // However, the function will return OTCRYPTO_FATAL_ERR as these accumulators
+  // are locked.
+  exit_status = otcrypto_clear_alerts();
+  CHECK(exit_status.value == OTCRYPTO_FATAL_ERR.value,
+        "otcrypto_clear_alerts failed to lock. Expected 0x%08x, "
+        "got 0x%08x",
+        OTCRYPTO_FATAL_ERR.value, exit_status.value);
+
+  // Since the accumulators are locked, the cryptolib remains locked.
+  exit_status = otcrypto_eval_exit(OTCRYPTO_OK);
+  CHECK(exit_status.value == OTCRYPTO_FATAL_ERR.value,
+        "otcrypto_eval_exit failed to lock. Expected 0x%08x, "
+        "got 0x%08x",
+        OTCRYPTO_FATAL_ERR.value, exit_status.value);
+
+  // Cleanup
+  TRY(ottf_alerts_expect_alert_start(kTopEarlgreyAlertIdAesRecovCtrlUpdateErr));
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR),
+                      (ptrdiff_t)AES_ALERT_TEST_REG_OFFSET, alert_test_reg);
+  irq_global_ctrl(true);
+  TRY(ottf_alerts_expect_alert_finish(
+      kTopEarlgreyAlertIdAesRecovCtrlUpdateErr));
+
+  return OK_STATUS();
+}
+
 bool test_main(void) {
   status_t result = OK_STATUS();
 
@@ -87,6 +209,10 @@ bool test_main(void) {
   EXECUTE_TEST(result, test_init_and_exit);
   EXECUTE_TEST(result, test_multiple_inits);
   EXECUTE_TEST(result, test_icache_disable_restore);
+  EXECUTE_TEST(result, test_alert_caught_by_eval_exit);
+  // Locks the accumulators making the cryptolib alerts no longer clearable
+  // Hence this test should be the last
+  EXECUTE_TEST(result, test_lock);
 
   return status_ok(result);
 }

--- a/sw/device/tests/crypto/config_functest.c
+++ b/sw/device/tests/crypto/config_functest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/base/csr.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/crypto/impl/status.h"
@@ -10,6 +11,8 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "rv_core_ibex_regs.h"
 
 #define MODULE_ID MAKE_MODULE_ID('t', 's', 't')
 
@@ -49,12 +52,41 @@ static status_t test_multiple_inits(void) {
   return OK_STATUS();
 }
 
+static status_t test_security_config_check_negative(void) {
+  LOG_INFO("Testing negative security config check on boot state");
+  otcrypto_key_security_level_t sec_level = kOtcryptoKeySecurityLevelHigh;
+
+  otcrypto_status_t tamper_status = otcrypto_security_config_check(sec_level);
+  CHECK(tamper_status.value != OTCRYPTO_OK.value);
+
+  TRY(otcrypto_set_security_config(sec_level));
+
+  TRY(otcrypto_security_config_check(sec_level));
+
+  return OK_STATUS();
+}
+
+static status_t test_icache_disable_restore(void) {
+  LOG_INFO("Testing icache disable and restore");
+  hardened_bool_t icache_state;
+
+  TRY(otcrypto_disable_icache(&icache_state));
+
+  TRY(otcrypto_restore_icache(icache_state));
+
+  return OK_STATUS();
+}
+
 bool test_main(void) {
   status_t result = OK_STATUS();
 
+  // We run the config check first as the chip comes out of boot, so the config
+  // is not set yet.
+  EXECUTE_TEST(result, test_security_config_check_negative);
   EXECUTE_TEST(result, test_set_and_check_config);
   EXECUTE_TEST(result, test_init_and_exit);
   EXECUTE_TEST(result, test_multiple_inits);
+  EXECUTE_TEST(result, test_icache_disable_restore);
 
   return status_ok(result);
 }

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym.c
@@ -1169,8 +1169,6 @@ status_t handle_cryptolib_fi_asym_init(ujson_t *uj) {
                 released ? "true" : "false", build_hash_high, build_hash_low);
   RESP_OK(ujson_serialize_string, uj, cryptolib_version);
 
-  // Check the security config of the device.
-  TRY(otcrypto_security_config_check(kOtcryptoKeySecurityLevelHigh));
   /////////////// STUB END ///////////////
 
   return OK_STATUS();

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym.c
@@ -454,8 +454,6 @@ status_t handle_cryptolib_fi_sym_init(ujson_t *uj) {
                 released ? "true" : "false", build_hash_high, build_hash_low);
   RESP_OK(ujson_serialize_string, uj, cryptolib_version);
 
-  // Check the security config of the device.
-  TRY(otcrypto_security_config_check(kOtcryptoKeySecurityLevelHigh));
   /////////////// STUB END ///////////////
 
   return OK_STATUS();

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym.c
@@ -856,8 +856,6 @@ status_t handle_cryptolib_sca_asym_init(ujson_t *uj) {
                 released ? "true" : "false", build_hash_high, build_hash_low);
   RESP_OK(ujson_serialize_string, uj, cryptolib_version);
 
-  // Check the security config of the device.
-  TRY(otcrypto_security_config_check(kOtcryptoKeySecurityLevelHigh));
   /////////////// STUB END ///////////////
 
   return OK_STATUS();

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_sym.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_sym.c
@@ -908,8 +908,6 @@ status_t handle_cryptolib_sca_sym_init(ujson_t *uj) {
                 released ? "true" : "false", build_hash_high, build_hash_low);
   RESP_OK(ujson_serialize_string, uj, cryptolib_version);
 
-  // Check the security config of the device.
-  TRY(otcrypto_security_config_check(kOtcryptoKeySecurityLevelHigh));
   /////////////// STUB END ///////////////
 
   return OK_STATUS();


### PR DESCRIPTION
The ifdef OPENTITAN_IS_EARLGREY does not work on earlgrey. We need to remove it.
    
Add more tests for config including a negative test on otcrypto_security_config_check. But the test does not work on cw310 due to the jittery clock missing, hence, remove that exec env for that test.

The last commit is on alert management where we switch to reading class accumulators instead of the cause registers. This is to make our alert handling faster.