### PR TITLE
[crypto] kmac and hmac key checksums

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -175,6 +175,7 @@ cc_library(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:crc32",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:macros",

--- a/sw/device/lib/crypto/drivers/hmac.c
+++ b/sw/device/lib/crypto/drivers/hmac.c
@@ -760,7 +760,8 @@ uint32_t hmac_key_integrity_checksum(const hmac_key_t *key) {
   uint32_t ctx;
   crc32_init(&ctx);
   crc32_add32(&ctx, key->key_len);
-  crc32_add(&ctx, (unsigned char *)key->key_block, key->key_len);
+  crc32_add(&ctx, (unsigned char *)key->key_block,
+            key->key_len * sizeof(uint32_t));
   return crc32_finish(&ctx);
 }
 

--- a/sw/device/lib/crypto/drivers/kmac.c
+++ b/sw/device/lib/crypto/drivers/kmac.c
@@ -6,6 +6,7 @@
 
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/crc32.h"
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/drivers/rv_core_ibex.h"
@@ -866,4 +867,26 @@ status_t kmac_kmac_256(kmac_blinded_key_t *key, hardened_bool_t masked_digest,
 
   return kmac_process_msg_blocks(kKmacOperationKmac, message, digest,
                                  digest_len, masked_digest);
+}
+
+uint32_t kmac_key_integrity_checksum(const kmac_blinded_key_t *key) {
+  uint32_t ctx;
+  crc32_init(&ctx);
+  crc32_add32(&ctx, key->len);
+  // Compute the checksum only over a single share to avoid side-channel
+  // leakage. From a FI perspective only covering one key share is fine as
+  // (a) manipulating the second share with FI has only limited use to an
+  // adversary and (b) when manipulating the entire pointer to the key structure
+  // the checksum check fails.
+  crc32_add(&ctx, (unsigned char *)key->share0, key->len);
+  crc32_add32(&ctx, key->hw_backed);
+  return crc32_finish(&ctx);
+}
+
+hardened_bool_t kmac_key_integrity_checksum_check(
+    const kmac_blinded_key_t *key) {
+  if (key->checksum == launder32(kmac_key_integrity_checksum(key))) {
+    return kHardenedBoolTrue;
+  }
+  return kHardenedBoolFalse;
 }

--- a/sw/device/lib/crypto/drivers/kmac.c
+++ b/sw/device/lib/crypto/drivers/kmac.c
@@ -545,6 +545,7 @@ static status_t kmac_init(kmac_operation_t operation,
 OT_WARN_UNUSED_RESULT
 static status_t kmac_write_key_block(kmac_blinded_key_t *key) {
   if (launder32(key->hw_backed) == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(key->hw_backed, kHardenedBoolTrue);
     // Nothing to do.
     return OTCRYPTO_OK;
   } else if (launder32(key->hw_backed) != kHardenedBoolFalse) {
@@ -572,6 +573,9 @@ static status_t kmac_write_key_block(kmac_blinded_key_t *key) {
   HARDENED_TRY(hardened_memshred((uint32_t *)share1_addr, key_len_words));
   HARDENED_TRY(
       hardened_memcpy((uint32_t *)share1_addr, key->share1, key_len_words));
+
+  // Verify the checksum of the given key.
+  HARDENED_CHECK_EQ(kmac_key_integrity_checksum_check(key), kHardenedBoolTrue);
 
   return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/drivers/kmac.h
+++ b/sw/device/lib/crypto/drivers/kmac.h
@@ -55,6 +55,10 @@ typedef struct kmac_blinded_key {
   // Whether the key should be provided by keymgr through sideload port.
   // If `hw_backed` is true, `share0/1` pointers and `len` are ignored.
   hardened_bool_t hw_backed;
+  /**
+   * Checksum of this KMAC key structure.
+   */
+  uint32_t checksum;
 } kmac_blinded_key_t;
 
 /**
@@ -282,6 +286,28 @@ status_t kmac_kmac_256(kmac_blinded_key_t *key, hardened_bool_t masked_digest,
                        const otcrypto_const_byte_buf_t *message,
                        const unsigned char *cust_str, size_t cust_str_len,
                        uint32_t *digest, size_t digest_len);
+
+/**
+ * Compute the checksum of an KMAC key.
+ *
+ * Call this routine after creating or modifying the KMAC key structure.
+ *
+ * @param key KMAC key.
+ * @returns Checksum value.
+ */
+uint32_t kmac_key_integrity_checksum(const kmac_blinded_key_t *key);
+
+/**
+ * Perform an integrity check on the KMAC key.
+ *
+ * Returns `kHardenedBoolTrue` if the check passed and `kHardenedBoolFalse`
+ * otherwise.
+ *
+ * @param key KMAC key.
+ * @returns Whether the integrity check passed.
+ */
+hardened_bool_t kmac_key_integrity_checksum_check(
+    const kmac_blinded_key_t *key);
 
 #ifdef __cplusplus
 }

--- a/sw/device/lib/crypto/drivers/kmac_test.c
+++ b/sw/device/lib/crypto/drivers/kmac_test.c
@@ -81,6 +81,20 @@ static status_t run_negative_test(void) {
   CHECK_STATUS_OK(ottf_alerts_expect_alert_finish(
       kTopEarlgreyAlertIdKmacRecovOperationErr));
 
+  // Negative test kmac_key_integrity_checksum_check()
+  uint32_t share0[16] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF,
+                         0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF};
+  uint32_t share1[16] = {0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01,
+                         0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01};
+  kmac_blinded_key_t bad_key = {
+      .len = 16 * sizeof(uint32_t),
+      .share0 = &share0[0],
+      .share1 = &share1[0],
+      .hw_backed = kHardenedBoolFalse,
+  };
+  bad_key.checksum = kmac_key_integrity_checksum(&bad_key) ^ 0xFFFFFFFF;
+  CHECK(kmac_key_integrity_checksum_check(&bad_key) == kHardenedBoolFalse);
+
   return OTCRYPTO_OK;
 }
 

--- a/sw/device/lib/crypto/impl/kmac.c
+++ b/sw/device/lib/crypto/impl/kmac.c
@@ -81,6 +81,8 @@ otcrypto_status_t otcrypto_kmac(
       return OTCRYPTO_BAD_ARGS;
     }
     HARDENED_TRY(keyblob_to_shares(key, &kmac_key.share0, &kmac_key.share1));
+    // Set the checksum of the key.
+    kmac_key.checksum = kmac_key_integrity_checksum(&kmac_key);
   } else {
     return OTCRYPTO_BAD_ARGS;
   }

--- a/sw/device/lib/crypto/impl/kmac_kdf.c
+++ b/sw/device/lib/crypto/impl/kmac_kdf.c
@@ -88,6 +88,8 @@ otcrypto_status_t otcrypto_kmac_kdf(
     }
     HARDENED_TRY(keyblob_to_shares(key_derivation_key, &kmac_key.share0,
                                    &kmac_key.share1));
+    // Set the checksum of the key.
+    kmac_key.checksum = kmac_key_integrity_checksum(&kmac_key);
   } else {
     return OTCRYPTO_BAD_ARGS;
   }


### PR DESCRIPTION
Bugfix the hmac key integrity check.
Add a checksum in the kmac_blinded_key_t and use it.