### PR TITLE
[crypto/ecc] Move 25519 to blinded private keys

### DIFF
--- a/sw/device/lib/base/hardened_memory.h
+++ b/sw/device/lib/base/hardened_memory.h
@@ -227,6 +227,10 @@ status_t hardened_sub(const uint32_t *OT_RESTRICT x,
  * guaranteed. The function is hardened against fault injections and is
  * constant time in the value being reduced.
  *
+ * In order to have this function constant time, it conditionally adds n only
+ * once.
+ * This function mimics OTBN's subm.
+ *
  * @param x Pointer to the first operand.
  * @param y Pointer to the second operand.
  * @param n Pointer to the multi-word modulus.
@@ -248,6 +252,10 @@ status_t hardened_sub_mod(const uint32_t *OT_RESTRICT x,
  * Warning: the side-channel protection of this function call can not be
  * guaranteed. The function is hardened against fault injections and is
  * constant time in the value being reduced.
+ *
+ * In order to have this function constant time, it conditionally subtracts n
+ * only once.
+ * This function mimics OTBN's addm.
  *
  * @param x Pointer to the first operand.
  * @param y Pointer to the second operand.

--- a/sw/device/lib/crypto/impl/ecc/curve25519.h
+++ b/sw/device/lib/crypto/impl/ecc/curve25519.h
@@ -80,6 +80,56 @@ enum {
    * Magic value for verify success response.
    */
   kCurve25519VerifySuccess = 0xf77fe650,
+  /**
+   * Length of a Curve25519 curve point coordinate in bits.
+   */
+  kCurve25519CoordBits = 256,
+  /**
+   * Length of a Curve25519 curve point coordinate in bytes.
+   */
+  kCurve25519CoordBytes = kCurve25519CoordBits / 8,
+  /**
+   * Length of a Curve25519 curve point coordinate in words.
+   */
+  kCurve25519CoordWords = kCurve25519CoordBytes / sizeof(uint32_t),
+  /**
+   * Length of an element in the Curve25519 scalar field in bits.
+   */
+  kCurve25519ScalarBits = 256,
+  /**
+   * Length of a masked secret scalar share.
+   *
+   * Ed25519 uses no extra redundant bits for the initial seed sharing.
+   */
+  kCurve25519MaskedScalarShareBits = kCurve25519ScalarBits,
+  /**
+   * Length of a masked secret scalar share in bytes.
+   */
+  kCurve25519MaskedScalarShareBytes = kCurve25519MaskedScalarShareBits / 8,
+  /**
+   * Length of masked secret scalar share in words.
+   */
+  kCurve25519MaskedScalarShareWords =
+      kCurve25519MaskedScalarShareBytes / sizeof(uint32_t),
+  /**
+   * Number of shares for the scalar.
+   */
+  kCurve25519MaskedScalarNumShares = 2,
+  /**
+   * Length of the full masked secret scalar share in bits.
+   */
+  kCurve25519MaskedScalarTotalShareBits =
+      kCurve25519MaskedScalarNumShares * kCurve25519MaskedScalarShareBits,
+  /**
+   * Length of the full masked secret scalar share in bytes.
+   */
+  kCurve25519MaskedScalarTotalShareBytes =
+      kCurve25519MaskedScalarNumShares * kCurve25519MaskedScalarShareBytes,
+  /**
+   * Length of the full masked secret scalar share in words.
+   */
+  kCurve25519MaskedScalarTotalShareWords =
+      kCurve25519MaskedScalarNumShares * kCurve25519MaskedScalarShareWords,
 };
 
 /**

--- a/sw/device/lib/crypto/impl/ecc_curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc_curve25519.c
@@ -26,18 +26,66 @@ static const uint8_t kDom2Prefix[34] = {
 };
 
 /**
- * Check the lengths of public/private keys for curve 25519.
+ * Check the lengths of private keys for curve 25519.
+ *
+ * Checks the length of caller-allocated buffers for a 25519 private key.
+ *
+ * @param private_key Private key struct to check.
+ * @return OK if the lengths are correct or BAD_ARGS otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+static status_t ed25519_private_key_length_check(
+    const otcrypto_blinded_key_t *private_key) {
+  if (private_key == NULL || private_key->keyblob == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  if (private_key->config.hw_backed == kHardenedBoolTrue) {
+    // Skip the length check in this case; if the salt is the wrong length, the
+    // keyblob library will catch it before we sideload the key.
+    return OTCRYPTO_OK;
+  }
+  HARDENED_CHECK_NE(launder32(private_key->config.hw_backed),
+                    kHardenedBoolTrue);
+
+  // Check the unmasked length.
+  if (private_key->config.key_length != kCurve25519KeyBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(launder32(private_key->config.key_length),
+                    kCurve25519KeyBytes);
+
+  // Check the key mode.
+  if (private_key->config.key_mode != kOtcryptoKeyModeEd25519) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
+                    kOtcryptoKeyModeEd25519);
+
+  // Check the integrity of the key.
+  if (integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(launder32(integrity_blinded_key_check(private_key)),
+                    kHardenedBoolTrue);
+
+  return OTCRYPTO_OK;
+}
+
+/**
+ * Check the lengths of public keys for curve 25519.
  *
  * This function also does some basic checks on the key struct.
  *
  * Checks the length of caller-allocated buffers for a 25519 unblinded
  * key.
  *
- * @param key Public/private key struct to check.
+ * @param key Public key struct to check.
  * @return OK if the lengths are correct or BAD_ARGS otherwise.
  */
 OT_WARN_UNUSED_RESULT
-static status_t ed25519_key_check(const otcrypto_unblinded_key_t *key) {
+static status_t ed25519_public_key_length_check(
+    const otcrypto_unblinded_key_t *key) {
   // Check the key struct and key length.
   if (key == NULL || key->key_length != kCurve25519KeyBytes ||
       key->key == NULL || key->key_mode != kOtcryptoKeyModeEd25519) {
@@ -213,7 +261,7 @@ static status_t ed25519_mask_scalar(uint32_t *scalar, size_t scalar_len,
   // can be of different sizes, we resort here to a VLA.
   uint32_t buf[share_len];
   memset(buf, 0, share_len << 2);
-  HARDENED_TRY(hardened_memshred(buf, scalar_len));
+  hardened_memshred(buf, scalar_len);
   HARDENED_TRY(hardened_memcpy(buf, scalar, scalar_len));
 
   // Set share1 to a random value and unset its MSB.
@@ -221,8 +269,7 @@ static status_t ed25519_mask_scalar(uint32_t *scalar, size_t scalar_len,
       OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, share1, share_len);
   otcrypto_const_byte_buf_t kEmptyBuffer =
       OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, NULL, 0);
-  HARDENED_TRY(otcrypto_drbg_instantiate(&kEmptyBuffer));
-  HARDENED_TRY(otcrypto_drbg_generate(&kEmptyBuffer, &share1_buf));
+  hardened_memshred(share1, share_len);
   share1[share_len - 1] &= 0x7fffffff;
 
   // Compute share0 = share + share1.
@@ -231,8 +278,58 @@ static status_t ed25519_mask_scalar(uint32_t *scalar, size_t scalar_len,
   return OTCRYPTO_OK;
 }
 
+/**
+ * Unmasks the private key, computes the SHA-512 digest, clamps the lower half,
+ * and returns the arithmetically masked scalar 's'.
+ *
+ * The full key digest is also returned because the upper half is needed as a
+ * prefix during the first stage of signature generation.
+ *
+ * @param private_key The blinded private key.
+ * @param[out] key_digest The 512-bit SHA-512 hash of the unmasked key.
+ * @param[out] masked_s The clamped and masked scalar 's'.
+ * @return OK or error status.
+ */
+OT_WARN_UNUSED_RESULT
+static otcrypto_status_t ed25519_compute_scalar_and_prefix(
+    const otcrypto_blinded_key_t *private_key,
+    otcrypto_hash_digest_t *key_digest,
+    curve25519_masked_scalar_s_t *masked_s) {
+  // Compute hash_h.
+  if (private_key->config.hw_backed == kHardenedBoolFalse) {
+    uint32_t seed_data[kCurve25519KeyBytes / sizeof(uint32_t)];
+    uint32_t *share0 = private_key->keyblob;
+    uint32_t *share1 =
+        private_key->keyblob + keyblob_share_num_words(private_key->config);
+
+    // Unmask the seed using addition modulo 2^256.
+    HARDENED_TRY(hardened_add(share0, share1, ARRAYSIZE(seed_data), seed_data));
+
+    otcrypto_const_byte_buf_t key_buf =
+        OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t,
+                          (const uint8_t *const)seed_data, kCurve25519KeyBytes);
+    HARDENED_TRY(otcrypto_sha2_512(&key_buf, key_digest));
+
+    // Memshred the unmasked seed.
+    HARDENED_TRY(hardened_memshred(seed_data, ARRAYSIZE(seed_data)));
+  } else {
+    // Hardware-backed keys are not supported at the moment.
+    return OTCRYPTO_NOT_IMPLEMENTED;
+  }
+
+  // Immediately clamp the lower half of hash_h to create the secret scalar s.
+  HARDENED_TRY(ed25519_clamp(key_digest->data));
+
+  // Arithmetically mask s before passing it to the OTBN app.
+  HARDENED_TRY(ed25519_mask_scalar(key_digest->data, kCurve25519ScalarWords,
+                                   masked_s->share0, masked_s->share1,
+                                   kCurve25519MaskedScalarSWords));
+
+  return OTCRYPTO_OK;
+}
+
 otcrypto_status_t otcrypto_ed25519_public_key_from_private(
-    const otcrypto_unblinded_key_t *private_key,
+    const otcrypto_blinded_key_t *private_key,
     otcrypto_unblinded_key_t *public_key) {
   if (public_key == NULL || public_key->key == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -245,7 +342,7 @@ otcrypto_status_t otcrypto_ed25519_public_key_from_private(
 }
 
 otcrypto_status_t otcrypto_ed25519_sign(
-    const otcrypto_unblinded_key_t *private_key,
+    const otcrypto_blinded_key_t *private_key,
     const otcrypto_const_byte_buf_t *input_message,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t *signature) {
   // Validate signature buffer
@@ -315,7 +412,7 @@ otcrypto_status_t otcrypto_ed25519_verify(
 }
 
 otcrypto_status_t otcrypto_ed25519_sign_verify(
-    const otcrypto_unblinded_key_t *private_key,
+    const otcrypto_blinded_key_t *private_key,
     const otcrypto_unblinded_key_t *public_key,
     const otcrypto_const_byte_buf_t *input_message,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t *signature) {
@@ -336,9 +433,9 @@ otcrypto_status_t otcrypto_ed25519_sign_verify(
 }
 
 otcrypto_status_t otcrypto_ed25519_public_key_from_private_async_start(
-    const otcrypto_unblinded_key_t *private_key) {
+    const otcrypto_blinded_key_t *private_key) {
   // Check the private key.
-  HARDENED_TRY(ed25519_key_check(private_key));
+  HARDENED_TRY(ed25519_private_key_length_check(private_key));
 
   // Instantiate struct to store the secret key digest.
   uint32_t key_digest_data[kCurve25519HashWords];
@@ -347,20 +444,10 @@ otcrypto_status_t otcrypto_ed25519_public_key_from_private_async_start(
       .len = ARRAYSIZE(key_digest_data),
   };
 
-  // Compute hash_h.
-  otcrypto_const_byte_buf_t key_buf = OTCRYPTO_MAKE_BUF(
-      otcrypto_const_byte_buf_t, (const uint8_t *const)private_key->key,
-      private_key->key_length);
-  HARDENED_TRY(otcrypto_sha2_512(&key_buf, &key_digest));
-
-  // Immediately clamp the lower half of hash_h to create the secret scalar s.
-  HARDENED_TRY(ed25519_clamp(key_digest.data));
-
-  // Arithmetically mask s before passing it to the OTBN app.
   curve25519_masked_scalar_s_t s;
-  HARDENED_TRY(ed25519_mask_scalar(key_digest.data, kCurve25519ScalarWords,
-                                   s.share0, s.share1,
-                                   kCurve25519MaskedScalarSWords));
+
+  // Compute the digest and scalar
+  HARDENED_TRY(ed25519_compute_scalar_and_prefix(private_key, &key_digest, &s));
 
   // Start the OTBN keygen app.
   HARDENED_TRY(curve25519_keygen_start(&s));
@@ -378,13 +465,13 @@ otcrypto_status_t otcrypto_ed25519_public_key_from_private_async_finalize(
 }
 
 otcrypto_status_t otcrypto_ed25519_sign_part1_async_start(
-    const otcrypto_unblinded_key_t *private_key,
+    const otcrypto_blinded_key_t *private_key,
     const otcrypto_const_byte_buf_t *input_message_ph,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t *s0,
     otcrypto_word32_buf_t *s1, otcrypto_word32_buf_t *r0,
     otcrypto_word32_buf_t *r1) {
   // Check the private key.
-  HARDENED_TRY(ed25519_key_check(private_key));
+  HARDENED_TRY(ed25519_private_key_length_check(private_key));
 
   // Instantiate struct to store the secret key digest.
   uint32_t key_digest_data[kCurve25519HashWords];
@@ -392,27 +479,15 @@ otcrypto_status_t otcrypto_ed25519_sign_part1_async_start(
       .data = key_digest_data,
       .len = ARRAYSIZE(key_digest_data),
   };
-
-  // Compute hash_h.
-  // TODO(#28964) Check SCA hardening of the key digest.
-  otcrypto_const_byte_buf_t key_buf = OTCRYPTO_MAKE_BUF(
-      otcrypto_const_byte_buf_t, (const uint8_t *const)private_key->key,
-      private_key->key_length);
-  HARDENED_TRY(otcrypto_sha2_512(&key_buf, &key_digest));
-
-  // Immediately clamp the lower half of hash_h to create the secret scalar s.
-  HARDENED_TRY(ed25519_clamp(key_digest.data));
-
-  // Arithmetically mask s before passing it to the OTBN app.
-  HARDENED_TRY(ed25519_mask_scalar(key_digest.data, kCurve25519ScalarWords,
-                                   s0->data, s1->data,
-                                   kCurve25519MaskedScalarSWords));
-
   curve25519_masked_scalar_s_t s;
+
+  // Compute the digest and scalar
+  HARDENED_TRY(ed25519_compute_scalar_and_prefix(private_key, &key_digest, &s));
+
   HARDENED_TRY(
-      hardened_memcpy(s.share0, s0->data, kCurve25519MaskedScalarSWords));
+      hardened_memcpy(s0->data, s.share0, kCurve25519MaskedScalarSWords));
   HARDENED_TRY(
-      hardened_memcpy(s.share1, s1->data, kCurve25519MaskedScalarSWords));
+      hardened_memcpy(s1->data, s.share1, kCurve25519MaskedScalarSWords));
 
   // Prepend the dom2 prefix
   size_t dom2_len =
@@ -463,7 +538,7 @@ otcrypto_status_t otcrypto_ed25519_sign_part1_async_start(
 }
 
 otcrypto_status_t otcrypto_ed25519_sign_part2_async_start(
-    const otcrypto_unblinded_key_t *private_key,
+    const otcrypto_blinded_key_t *private_key,
     const otcrypto_const_byte_buf_t *input_message_ph,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t *signature,
     otcrypto_word32_buf_t *s0, otcrypto_word32_buf_t *s1,
@@ -472,7 +547,7 @@ otcrypto_status_t otcrypto_ed25519_sign_part2_async_start(
   HARDENED_TRY(ed25519_signature_check(signature));
 
   // Check the private key.
-  HARDENED_TRY(ed25519_key_check(private_key));
+  HARDENED_TRY(ed25519_private_key_length_check(private_key));
 
   // Finalize the signature stage 1 and retrieve the signature commitment R and
   // public key A.
@@ -549,7 +624,7 @@ otcrypto_status_t otcrypto_ed25519_verify_async_start(
     otcrypto_eddsa_sign_mode_t sign_mode,
     const otcrypto_const_word32_buf_t *signature) {
   // Check the public key.
-  HARDENED_TRY(ed25519_key_check(public_key));
+  HARDENED_TRY(ed25519_public_key_length_check(public_key));
 
   // Do some signature struct validity checks.
   HARDENED_TRY(ed25519_signature_check((otcrypto_word32_buf_t *)signature));

--- a/sw/device/lib/crypto/include/ecc_curve25519.h
+++ b/sw/device/lib/crypto/include/ecc_curve25519.h
@@ -39,20 +39,21 @@ typedef enum otcrypto_eddsa_sign_mode {
  * The caller must allocate the public key struct and its `key` buffer
  * (32 bytes) before calling this function. The `checksum` field will be
  * populated on success.
- *
- * @param[in]  private_key Pointer to the private key seed struct.
- * @param[out] public_key  Pointer to the public key struct to populate.
- * @return Result of the Ed25519 public key derivation.
+ * @param private_key Pointer to the blinded private key struct which is
+ * shared into d0, d1 such that d = d0 + d1 mod 2^256.
+ * @param[out] public_key Pointer to the unblinded public key struct.
+ * @return Result of the Ed25519 key generation.
  */
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ed25519_public_key_from_private(
-    const otcrypto_unblinded_key_t *private_key,
+    const otcrypto_blinded_key_t *private_key,
     otcrypto_unblinded_key_t *public_key);
 
 /**
  * Generates an Ed25519 digital signature.
  *
- * @param private_key Pointer to the unblinded private key struct.
+ * @param private_key Pointer to the blinded private key struct which is shared
+ * into d0, d1 such that d = d0 + d1 mod 2^256.
  * @param input_message Input message to be signed.
  * @param sign_mode EdDSA signature hashing mode.
  * @param[out] signature Pointer to the EdDSA signature with (r,s) values.
@@ -60,7 +61,7 @@ otcrypto_status_t otcrypto_ed25519_public_key_from_private(
  */
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ed25519_sign(
-    const otcrypto_unblinded_key_t *private_key,
+    const otcrypto_blinded_key_t *private_key,
     const otcrypto_const_byte_buf_t *input_message,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t *signature);
 
@@ -91,7 +92,8 @@ otcrypto_status_t otcrypto_ed25519_verify(
  * Generates an Ed25519 signature and verifies the signature
  * before releasing it to mitigate fault injection attacks.
  *
- * @param private_key Pointer to the unblinded private key struct.
+ * @param private_key Pointer to the blinded private key struct which is shared
+ * into d0, d1 such that d = d0 + d1 mod 2^256.
  * @param public_key Pointer to the unblinded public key struct.
  * @param input_message Message digest to be signed.
  * @param sign_mode EdDSA signature hashing mode.
@@ -100,7 +102,7 @@ otcrypto_status_t otcrypto_ed25519_verify(
  */
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ed25519_sign_verify(
-    const otcrypto_unblinded_key_t *private_key,
+    const otcrypto_blinded_key_t *private_key,
     const otcrypto_unblinded_key_t *public_key,
     const otcrypto_const_byte_buf_t *input_message,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t *signature);
@@ -111,12 +113,13 @@ otcrypto_status_t otcrypto_ed25519_sign_verify(
  * See `otcrypto_ed25519_public_key_from_private` for requirements on input
  * values.
  *
- * @param private_key Source structure for private key, or key handle.
+ * @param private_key Pointer to the blinded private key struct which is shared
+ * into d0, d1 such that d = d0 + d1 mod 2^256.
  * @return Result of asynchronous Ed25519 keygen start operation.
  */
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ed25519_public_key_from_private_async_start(
-    const otcrypto_unblinded_key_t *private_key);
+    const otcrypto_blinded_key_t *private_key);
 
 /**
  * Finalizes asynchronous key generation for Ed25519.
@@ -138,7 +141,8 @@ otcrypto_status_t otcrypto_ed25519_public_key_from_private_async_finalize(
  *
  * See `otcrypto_ed25519_sign` for requirements on input values.
  *
- * @param private_key Pointer to the unblinded private key struct.
+ * @param private_key Pointer to the blinded private key struct which is shared
+ * into d0, d1 such that d = d0 + d1 mod 2^256.
  * @param input_message_ph Pre-hashed input message to be signed.
  * @param sign_mode EdDSA signature hashing mode.
  * @param[out] s0 Pointer to the first arithmetic share of s.
@@ -150,7 +154,7 @@ otcrypto_status_t otcrypto_ed25519_public_key_from_private_async_finalize(
  */
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ed25519_sign_part1_async_start(
-    const otcrypto_unblinded_key_t *private_key,
+    const otcrypto_blinded_key_t *private_key,
     const otcrypto_const_byte_buf_t *input_message_ph,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t *s0,
     otcrypto_word32_buf_t *s1, otcrypto_word32_buf_t *r0,
@@ -161,7 +165,8 @@ otcrypto_status_t otcrypto_ed25519_sign_part1_async_start(
  *
  * See `otcrypto_ed25519_sign` for requirements on input values.
  *
- * @param private_key Pointer to the unblinded private key struct.
+ * @param private_key Pointer to the blinded private key struct which is shared
+ * into d0, d1 such that d = d0 + d1 mod 2^256.
  * @param input_message_ph Pre-hashed input message to be signed.
  * @param sign_mode EdDSA signature hashing mode.
  * @param signature[out] Pointer to the EdDSA signature to get (R) value.
@@ -173,7 +178,7 @@ otcrypto_status_t otcrypto_ed25519_sign_part1_async_start(
  */
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ed25519_sign_part2_async_start(
-    const otcrypto_unblinded_key_t *private_key,
+    const otcrypto_blinded_key_t *private_key,
     const otcrypto_const_byte_buf_t *input_message_ph,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t *signature,
     otcrypto_word32_buf_t *s0, otcrypto_word32_buf_t *s1,

--- a/sw/device/lib/crypto/include/ecc_p256.h
+++ b/sw/device/lib/crypto/include/ecc_p256.h
@@ -43,7 +43,7 @@ otcrypto_status_t otcrypto_ecdsa_p256_keygen(
  * including populating the key configuration and use the private key handle
  * returned by `otcrypto_hw_backed_attestation_key`.
  *
- * @param[out] private_key Pointer to the blinded private key (d) struct.
+ * @param private_key Pointer to the blinded private key (d) struct.
  * @param[out] public_key Pointer to the unblinded public key (Q) struct.
  * @param attestation_seed The additional per-chip fixed entropy.
  * @return Result of the ECDSA key generation.

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -542,6 +542,7 @@ opentitan_test(
         timeout = "long",
     ),
     deps = [
+        "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/crypto/drivers:otbn",
         "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:ecc_p256",
@@ -565,6 +566,7 @@ opentitan_test(
         tags = ["manual"],
     ),
     deps = [
+        "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/crypto/drivers:otbn",
         "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:ecc_p384",

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -647,11 +647,13 @@ opentitan_test(
         tags = ["manual"],
     ),
     deps = [
+        "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/crypto/drivers:otbn",
         "//sw/device/lib/crypto/impl:config",
         "//sw/device/lib/crypto/impl:ecc_curve25519",
         "//sw/device/lib/crypto/impl:entropy_src",
         "//sw/device/lib/crypto/impl:integrity",
+        "//sw/device/lib/crypto/impl:keyblob",
         "//sw/device/lib/crypto/impl:sha2",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/tests/crypto/ecdsa_p256_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_functest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
@@ -124,8 +125,36 @@ static status_t sign_then_verify_test(void) {
   return OK_STATUS();
 }
 
+/**
+ * A test where a known input is signed and is compared to the expected output.
+ * In addition, it draws randomness to share the known input using
+ * hardened_memshred. The input is shared using the hardened_sub_mod function
+ * using the P-256 curve order n.
+ */
 static status_t sign_kat(void) {
   uint32_t keyblob_len = 2 * kP256SecretScalarWords;
+
+  // P-256 curve order n, padded to 320 bits (10 words) for our math operations.
+  static const uint32_t kP256Order[kP256SecretScalarWords] = {
+      0xFC632551, 0xF3B9CAC2, 0xA7179E84, 0xBCE6FAAD, 0xFFFFFFFF,
+      0xFFFFFFFF, 0x00000000, 0xFFFFFFFF, 0x00000000, 0x00000000};
+
+  uint32_t unmasked_val[kP256SecretScalarWords];
+  uint32_t share1_rand[kP256SecretScalarWords];
+  uint32_t share0[kP256SecretScalarWords];
+  uint32_t share1[kP256SecretScalarWords];
+
+  memset(unmasked_val, 0, kP256SecretScalarBytes);
+  memcpy(unmasked_val, kKATSecretScalar, kP256TestVectorScalarInpBytes);
+
+  // Generate a random value and reduce it modulo n to get a valid share1
+  TRY(hardened_memshred(share1_rand, kP256SecretScalarWords));
+  TRY(hardened_mod_reduce(share1_rand, kP256Order, kP256SecretScalarWords,
+                          share1));
+
+  // Calculate share0 = (unmasked_val - share1) mod n
+  TRY(hardened_sub_mod(unmasked_val, share1, kP256Order, kP256SecretScalarWords,
+                       share0));
 
   // Allocate space for a masked secret scalar.
   uint32_t keyblob_scalar[keyblob_len];
@@ -134,9 +163,23 @@ static status_t sign_kat(void) {
       .keyblob_length = sizeof(keyblob_scalar),
       .keyblob = keyblob_scalar,
   };
-  memset(keyblob_scalar, 0, 2 * kP256SecretScalarBytes);
-  memcpy(keyblob_scalar, kKATSecretScalar, kP256TestVectorScalarInpBytes);
+  memcpy(keyblob_scalar, share0, kP256SecretScalarBytes);
+  // We copy over the full 320 random bits
+  memcpy(keyblob_scalar + kP256SecretScalarWords, share1_rand,
+         kP256SecretScalarBytes);
   secret_scalar.checksum = integrity_blinded_checksum(&secret_scalar);
+
+  memset(unmasked_val, 0, kP256SecretScalarBytes);
+  memcpy(unmasked_val, kKATKey, kP256TestVectorScalarInpBytes);
+
+  // Generate a random svalue and reduce it modulo n
+  TRY(hardened_memshred(share1_rand, kP256SecretScalarWords));
+  TRY(hardened_mod_reduce(share1_rand, kP256Order, kP256SecretScalarWords,
+                          share1));
+
+  // Calculate share0 = (unmasked_val - share1) mod n
+  TRY(hardened_sub_mod(unmasked_val, share1, kP256Order, kP256SecretScalarWords,
+                       share0));
 
   // Allocate space for a masked private key.
   uint32_t keyblob_sk[keyblob_len];
@@ -145,8 +188,8 @@ static status_t sign_kat(void) {
       .keyblob_length = sizeof(keyblob_sk),
       .keyblob = keyblob_sk,
   };
-  memset(keyblob_sk, 0, 2 * kP256SecretScalarBytes);
-  memcpy(keyblob_sk, kKATKey, kP256TestVectorScalarInpBytes);
+  memcpy(keyblob_sk, share0, kP256SecretScalarBytes);
+  memcpy(keyblob_sk + kP256SecretScalarWords, share1, kP256SecretScalarBytes);
   private_key.checksum = integrity_blinded_checksum(&private_key);
 
   // Hash the message.

--- a/sw/device/tests/crypto/ecdsa_p384_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p384_functest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
@@ -128,8 +129,37 @@ static status_t sign_then_verify_test(void) {
 
 OTTF_DEFINE_TEST_CONFIG();
 
+/**
+ * A test where a known input is signed and is compared to the expected output.
+ * In addition, it draws randomness to share the known input using
+ * hardened_memshred. The input is shared using the hardened_sub_mod function
+ * using the P-384 curve order n.
+ */
 static status_t sign_kat(void) {
   uint32_t keyblob_len = 2 * kP384SecretScalarWords;
+
+  // P-384 curve order n, padded to 448 bits (14 words) for our math operations.
+  static const uint32_t kP384Order[kP384SecretScalarWords] = {
+      0xCCC52973, 0xECEC196A, 0x48B0A77A, 0x581A0DB2, 0xF4372DDF,
+      0xC7634D81, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
+      0xFFFFFFFF, 0xFFFFFFFF, 0x00000000, 0x00000000};
+
+  uint32_t unmasked_val[kP384SecretScalarWords];
+  uint32_t share1_rand[kP384SecretScalarWords];
+  uint32_t share0[kP384SecretScalarWords];
+  uint32_t share1[kP384SecretScalarWords];
+
+  memset(unmasked_val, 0, kP384SecretScalarBytes);
+  memcpy(unmasked_val, kKATSecretScalar, kP384TestVectorScalarInpBytes);
+
+  // Generate a random value and reduce it modulo n to get a valid share1
+  TRY(hardened_memshred(share1_rand, kP384SecretScalarWords));
+  TRY(hardened_mod_reduce(share1_rand, kP384Order, kP384SecretScalarWords,
+                          share1));
+
+  // Calculate share0 = (unmasked_val - share1) mod n
+  TRY(hardened_sub_mod(unmasked_val, share1, kP384Order, kP384SecretScalarWords,
+                       share0));
 
   // Allocate space for a masked secret scalar.
   uint32_t keyblob_scalar[keyblob_len];
@@ -138,9 +168,23 @@ static status_t sign_kat(void) {
       .keyblob_length = sizeof(keyblob_scalar),
       .keyblob = keyblob_scalar,
   };
-  memset(keyblob_scalar, 0, 2 * kP384SecretScalarBytes);
-  memcpy(keyblob_scalar, kKATSecretScalar, kP384TestVectorScalarInpBytes);
+  memcpy(keyblob_scalar, share0, kP384SecretScalarBytes);
+  // We copy over the full random bits
+  memcpy(keyblob_scalar + kP384SecretScalarWords, share1,
+         kP384SecretScalarBytes);
   secret_scalar.checksum = integrity_blinded_checksum(&secret_scalar);
+
+  memset(unmasked_val, 0, kP384SecretScalarBytes);
+  memcpy(unmasked_val, kKATKey, kP384TestVectorScalarInpBytes);
+
+  // Generate new random noise and reduce it modulo n
+  TRY(hardened_memshred(share1_rand, kP384SecretScalarWords));
+  TRY(hardened_mod_reduce(share1_rand, kP384Order, kP384SecretScalarWords,
+                          share1));
+
+  // Calculate share0 = (unmasked_val - share1) mod n
+  TRY(hardened_sub_mod(unmasked_val, share1, kP384Order, kP384SecretScalarWords,
+                       share0));
 
   // Allocate space for a masked private key.
   uint32_t keyblob_sk[keyblob_len];
@@ -149,8 +193,8 @@ static status_t sign_kat(void) {
       .keyblob_length = sizeof(keyblob_sk),
       .keyblob = keyblob_sk,
   };
-  memset(keyblob_sk, 0, 2 * kP384SecretScalarBytes);
-  memcpy(keyblob_sk, kKATKey, kP384TestVectorScalarInpBytes);
+  memcpy(keyblob_sk, share0, kP384SecretScalarBytes);
+  memcpy(keyblob_sk + kP384SecretScalarWords, share1, kP384SecretScalarBytes);
   private_key.checksum = integrity_blinded_checksum(&private_key);
 
   // Hash the message.

--- a/sw/device/tests/crypto/ed25519_functest.c
+++ b/sw/device/tests/crypto/ed25519_functest.c
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_curve25519.h"
@@ -92,15 +94,47 @@ static const char kMessage[] = {
     0x72,
 };
 
+static const otcrypto_key_config_t kPrivateKeyConfig = {
+    .version = kOtcryptoLibVersion1,
+    .key_mode = kOtcryptoKeyModeEd25519,
+    .key_length = kEd25519PrivateKeyBytes,
+    .hw_backed = kHardenedBoolFalse,
+    .security_level = kOtcryptoKeySecurityLevelLow,
+};
+
+/**
+ * Helper function to securely populate the keyblob array with two shares.
+ */
+static status_t create_blinded_kat_keyblob(uint32_t *keyblob) {
+  // Zero out the entire blob to avoid checksumming uninitialized padding
+  memset(keyblob, 0, keyblob_num_words(kPrivateKeyConfig) * sizeof(uint32_t));
+
+  uint32_t *share0 = keyblob;
+  uint32_t *share1 = keyblob + keyblob_share_num_words(kPrivateKeyConfig);
+
+  // Generate a random mask for share1 (only need 8 words for the seed)
+  HARDENED_TRY(hardened_memshred(share1, kEd25519PrivateKeyWords));
+
+  // Calculate share0 = kSecretKey - share1 (implicitly modulo 2^256)
+  HARDENED_TRY(
+      hardened_sub(kSecretKey, share1, kEd25519PrivateKeyWords, share0));
+
+  return OTCRYPTO_OK;
+}
+
 status_t ed25519_kat_test(void) {
   LOG_INFO("Running Ed25519 KAT Test");
-  // Set up private_key struct.
-  otcrypto_unblinded_key_t private_key = {
-      .key_mode = kOtcryptoKeyModeEd25519,
-      .key_length = kEd25519PrivateKeyBytes,
-      .key = kSecretKey,
+
+  uint32_t keyblob[keyblob_num_words(kPrivateKeyConfig)];
+  CHECK_STATUS_OK(create_blinded_kat_keyblob(keyblob));
+
+  otcrypto_blinded_key_t private_key = {
+      .config = kPrivateKeyConfig,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
   };
-  private_key.checksum = integrity_unblinded_checksum(&private_key);
+  private_key.checksum = integrity_blinded_checksum(&private_key);
+
   // Set up public_key struct.
   uint32_t public_key_buf[kEd25519PublicKeyWords];
   otcrypto_unblinded_key_t public_key = {
@@ -155,12 +189,15 @@ status_t ed25519_kat_test(void) {
 static status_t hasheddsa_test(void) {
   LOG_INFO("Running HashEdDSA test");
 
-  otcrypto_unblinded_key_t private_key = {
-      .key_mode = kOtcryptoKeyModeEd25519,
-      .key_length = kEd25519PrivateKeyBytes,
-      .key = kSecretKey,
+  uint32_t keyblob[keyblob_num_words(kPrivateKeyConfig)];
+  CHECK_STATUS_OK(create_blinded_kat_keyblob(keyblob));
+
+  otcrypto_blinded_key_t private_key = {
+      .config = kPrivateKeyConfig,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
   };
-  private_key.checksum = integrity_unblinded_checksum(&private_key);
+  private_key.checksum = integrity_blinded_checksum(&private_key);
 
   uint32_t public_key_buf[kEd25519PublicKeyWords];
   otcrypto_unblinded_key_t public_key = {
@@ -206,13 +243,15 @@ static status_t hasheddsa_test(void) {
 static status_t sign_verify_test(void) {
   LOG_INFO("Running sign_verify test");
 
-  // Set up private_key struct.
-  otcrypto_unblinded_key_t private_key = {
-      .key_mode = kOtcryptoKeyModeEd25519,
-      .key_length = kEd25519PrivateKeyBytes,
-      .key = kSecretKey,
+  uint32_t keyblob[keyblob_num_words(kPrivateKeyConfig)];
+  CHECK_STATUS_OK(create_blinded_kat_keyblob(keyblob));
+
+  otcrypto_blinded_key_t private_key = {
+      .config = kPrivateKeyConfig,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
   };
-  private_key.checksum = integrity_unblinded_checksum(&private_key);
+  private_key.checksum = integrity_blinded_checksum(&private_key);
 
   // Set up public_key struct.
   uint32_t public_key_buf[kEd25519PublicKeyWords];
@@ -251,12 +290,15 @@ static status_t sign_verify_test(void) {
 static status_t run_negative_tests(void) {
   LOG_INFO("Running negative tests");
 
-  otcrypto_unblinded_key_t valid_priv = {
-      .key_mode = kOtcryptoKeyModeEd25519,
-      .key_length = kEd25519PrivateKeyBytes,
-      .key = kSecretKey,
+  uint32_t priv_keyblob[keyblob_num_words(kPrivateKeyConfig)];
+  CHECK_STATUS_OK(create_blinded_kat_keyblob(priv_keyblob));
+
+  otcrypto_blinded_key_t valid_priv = {
+      .config = kPrivateKeyConfig,
+      .keyblob_length = sizeof(priv_keyblob),
+      .keyblob = priv_keyblob,
   };
-  valid_priv.checksum = integrity_unblinded_checksum(&valid_priv);
+  valid_priv.checksum = integrity_blinded_checksum(&valid_priv);
 
   uint32_t public_key_buf[kEd25519PublicKeyWords];
   otcrypto_unblinded_key_t valid_pub = {
@@ -277,29 +319,50 @@ static status_t run_negative_tests(void) {
   otcrypto_word32_buf_t sig =
       OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, sig_buf, kEd25519SignatureWords);
 
-  // Test ed25519_key_check with invalid key length, mode, data, or checksum
-  otcrypto_unblinded_key_t bad_key = valid_priv;
-  bad_key.key_length = 31;
-  bad_key.checksum = integrity_unblinded_checksum(&bad_key);
-  CHECK(otcrypto_ed25519_public_key_from_private(&bad_key, &valid_pub).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  // Test ed25519_key_check with invalid key length
+  otcrypto_key_config_t bad_len_cfg = kPrivateKeyConfig;
+  bad_len_cfg.key_length = 31;
+  otcrypto_blinded_key_t bad_key_len = {
+      .config = bad_len_cfg,
+      .keyblob_length = sizeof(priv_keyblob),
+      .keyblob = priv_keyblob,
+  };
+  bad_key_len.checksum = integrity_blinded_checksum(&bad_key_len);
+  CHECK(otcrypto_ed25519_public_key_from_private(&bad_key_len, &valid_pub)
+            .value == OTCRYPTO_BAD_ARGS.value);
 
-  bad_key = valid_priv;
-  bad_key.key_mode = kOtcryptoKeyModeEcdsaP256;
-  bad_key.checksum = integrity_unblinded_checksum(&bad_key);
-  CHECK(otcrypto_ed25519_public_key_from_private(&bad_key, &valid_pub).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  // Test ed25519_key_check with invalid key mode
+  otcrypto_key_config_t bad_mode_cfg = kPrivateKeyConfig;
+  bad_mode_cfg.key_mode = kOtcryptoKeyModeEcdsaP256;
+  otcrypto_blinded_key_t bad_key_mode = {
+      .config = bad_mode_cfg,
+      .keyblob_length = sizeof(priv_keyblob),
+      .keyblob = priv_keyblob,
+  };
+  bad_key_mode.checksum = integrity_blinded_checksum(&bad_key_mode);
+  CHECK(otcrypto_ed25519_public_key_from_private(&bad_key_mode, &valid_pub)
+            .value == OTCRYPTO_BAD_ARGS.value);
 
-  bad_key = valid_priv;
-  bad_key.key = NULL;
-  CHECK(otcrypto_ed25519_public_key_from_private(&bad_key, &valid_pub).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  // Test ed25519_key_check with NULL data
+  otcrypto_blinded_key_t bad_key_null = {
+      .config = kPrivateKeyConfig,
+      .keyblob_length = sizeof(priv_keyblob),
+      .keyblob = NULL,
+  };
+  CHECK(otcrypto_ed25519_public_key_from_private(&bad_key_null, &valid_pub)
+            .value == OTCRYPTO_BAD_ARGS.value);
 
-  bad_key = valid_priv;
-  bad_key.checksum ^= 0xFFFFFFFF;
-  CHECK(otcrypto_ed25519_public_key_from_private(&bad_key, &valid_pub).value ==
-        OTCRYPTO_BAD_ARGS.value);
+  // Test ed25519_key_check with bad checksum
+  otcrypto_blinded_key_t bad_key_chk = {
+      .config = kPrivateKeyConfig,
+      .keyblob_length = sizeof(priv_keyblob),
+      .keyblob = priv_keyblob,
+  };
+  bad_key_chk.checksum = valid_priv.checksum ^ 0xFFFFFFFF;
+  CHECK(otcrypto_ed25519_public_key_from_private(&bad_key_chk, &valid_pub)
+            .value == OTCRYPTO_BAD_ARGS.value);
 
+  // Null pointer tests
   CHECK(otcrypto_ed25519_public_key_from_private(NULL, &valid_pub).value ==
         OTCRYPTO_BAD_ARGS.value);
 

--- a/sw/device/tests/crypto/otcrypto_interface.h
+++ b/sw/device/tests/crypto/otcrypto_interface.h
@@ -199,12 +199,12 @@ typedef struct otcrypto_interface_t {
 
   // ED25519
   otcrypto_status_t (*ed25519_public_key_from_private)(
-      const otcrypto_unblinded_key_t *, otcrypto_unblinded_key_t *);
-  otcrypto_status_t (*ed25519_sign)(const otcrypto_unblinded_key_t *,
+      const otcrypto_blinded_key_t *, otcrypto_unblinded_key_t *);
+  otcrypto_status_t (*ed25519_sign)(const otcrypto_blinded_key_t *,
                                     const otcrypto_const_byte_buf_t *,
                                     otcrypto_eddsa_sign_mode_t,
                                     otcrypto_word32_buf_t *);
-  otcrypto_status_t (*ed25519_sign_verify)(const otcrypto_unblinded_key_t *,
+  otcrypto_status_t (*ed25519_sign_verify)(const otcrypto_blinded_key_t *,
                                            const otcrypto_unblinded_key_t *,
                                            const otcrypto_const_byte_buf_t *,
                                            otcrypto_eddsa_sign_mode_t,
@@ -215,19 +215,19 @@ typedef struct otcrypto_interface_t {
                                       const otcrypto_const_word32_buf_t *,
                                       hardened_bool_t *);
   otcrypto_status_t (*ed25519_public_key_from_private_async_start)(
-      const otcrypto_unblinded_key_t *);
+      const otcrypto_blinded_key_t *);
   otcrypto_status_t (*ed25519_public_key_from_private_async_finalize)(
       otcrypto_unblinded_key_t *);
   otcrypto_status_t (*ed25519_sign_async_start)(
       const otcrypto_blinded_key_t *, const otcrypto_const_byte_buf_t *,
       otcrypto_eddsa_sign_mode_t, otcrypto_word32_buf_t *);
   otcrypto_status_t (*ed25519_sign_part1_async_start)(
-      const otcrypto_unblinded_key_t *, const otcrypto_const_byte_buf_t *,
+      const otcrypto_blinded_key_t *, const otcrypto_const_byte_buf_t *,
       otcrypto_eddsa_sign_mode_t, otcrypto_word32_buf_t *,
       otcrypto_word32_buf_t *, otcrypto_word32_buf_t *,
       otcrypto_word32_buf_t *);
   otcrypto_status_t (*ed25519_sign_part2_async_start)(
-      const otcrypto_unblinded_key_t *, const otcrypto_const_byte_buf_t *,
+      const otcrypto_blinded_key_t *, const otcrypto_const_byte_buf_t *,
       otcrypto_eddsa_sign_mode_t, otcrypto_word32_buf_t *,
       otcrypto_word32_buf_t *, otcrypto_word32_buf_t *, otcrypto_word32_buf_t *,
       otcrypto_word32_buf_t *);


### PR DESCRIPTION
We first use randomness in the functests of p256 and p384 for their sharings in order to make it clear how the sharing is made at API level.
We then move 25519 to use blinded private keys. The 25519 does not use secrets over the modulus of the curve order but modulo 2^256. We thus make an arithmetic sharing over the same order. As opposed to p256/p384 we do not further extend the sharing by, e.g., an additional 64b