### PR TITLE
[ip,kmac] Key manager EDN dependency removed

### DIFF
--- a/hw/ip/keymgr/keymgr_pkg.core
+++ b/hw/ip/keymgr/keymgr_pkg.core
@@ -3,13 +3,13 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:ip:keymgr_pkg:0.1"
-description: "Flash Package"
+description: "Key manager package"
 
 filesets:
   files_rtl:
     depend:
+      - lowrisc:prim:util
       - lowrisc:virtual_constants:top_pkg
-      - lowrisc:ip:edn_pkg
     files:
       - rtl/keymgr_reg_pkg.sv
       - rtl/keymgr_pkg.sv

--- a/hw/ip/keymgr/rtl/keymgr_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_pkg.sv
@@ -17,7 +17,6 @@ package keymgr_pkg;
   parameter int SwBindingWidth = 32 * keymgr_reg_pkg::NumSwBindingReg;
   parameter int SaltWidth = 32 * keymgr_reg_pkg::NumSaltReg;
   parameter int Shares = 2; // number of key shares
-  parameter int EdnWidth = edn_pkg::ENDPOINT_BUS_WIDTH;
   parameter int KeyVersionWidth = 32;  // Key version length for individual DICE stage
 
   // These should be defined in another module's package


### PR DESCRIPTION
Remove EDN package as dependency from keymrg_pkg since it is only used to define EdnWidth which is not used in the rest of the code base.