### PR TITLE
[I2C, dv] Simplified i2c_device_response seq's drive_read_byte()

### DIFF
--- a/hw/dv/sv/i2c_agent/seq_lib/i2c_base_seq.sv
+++ b/hw/dv/sv/i2c_agent/seq_lib/i2c_base_seq.sv
@@ -120,7 +120,7 @@ class i2c_base_seq extends dv_base_seq #(
         StDataByte: begin
           if (inp_xfer.dir == i2c_pkg::READ) begin
             // The agent drives the read bytes as target-transmitter.
-            fork drive_read_byte(); join_none
+            fork drive_read_byte($urandom); join_none
           end
         end
         StDataByteRcvd: begin
@@ -147,11 +147,11 @@ class i2c_base_seq extends dv_base_seq #(
   endtask : drive_addr_byte_ack
 
 
-  virtual task drive_read_byte();
+  virtual task drive_read_byte(bit [7:0] rdata);
     `uvm_create_obj(REQ, req);
     start_item(req);
     req.drv_type = RdData;
-    req.rdata = $urandom;
+    req.rdata = rdata;
     finish_item(req);
     `uvm_info(`gfn, "drive_read_byte()::finish_item()", UVM_DEBUG)
   endtask : drive_read_byte

--- a/hw/dv/sv/i2c_agent/seq_lib/i2c_device_response_seq.sv
+++ b/hw/dv/sv/i2c_agent/seq_lib/i2c_device_response_seq.sv
@@ -77,9 +77,8 @@ class i2c_device_response_seq extends i2c_base_seq;
 
   // This method hooks the start of every data byte in an inprogress READ transfer.
   // Fetch any read data from the local memory, and drive the data byte with this value.
-  virtual task drive_read_byte();
+  virtual task drive_read_byte(bit [7:0] rdata);
     bit[Addr7BitMode-1:0] xfer_addr = inp_xfer.addr[Addr7BitMode-1:0];
-    bit [7:0]             rdata;
 
     if (response_mem[xfer_addr].size() == 0) begin
       // We haven't previously seen a write transfer at this address. There is no data to return.
@@ -94,12 +93,7 @@ class i2c_device_response_seq extends i2c_base_seq;
       xfer_addr, rdata), UVM_DEBUG)
 
     // Drive the data byte
-    `uvm_create_obj(REQ, req);
-    start_item(req);
-    req.drv_type = RdData;
-    req.rdata = rdata;
-    finish_item(req);
+    super.drive_read_byte(rdata);
   endtask : drive_read_byte
-
 
 endclass : i2c_device_response_seq


### PR DESCRIPTION
This was actually replicating the definition of `drive_read_byte` from `i2c_base_seq`.