### PR TITLE
[aes,dv] Simplify how we sideload keys

### DIFF
--- a/hw/dv/sv/key_sideload_agent/key_sideload_driver.sv
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_driver.sv
@@ -11,7 +11,9 @@ class key_sideload_driver#(
   // the base class provides the following handles for use:
   // key_sideload_agent_cfg: cfg
 
-  `uvm_component_new
+  function new (string name, uvm_component parent);
+    super.new(name, parent);
+  endfunction
 
   // reset signals
   virtual task reset_signals();
@@ -27,22 +29,14 @@ class key_sideload_driver#(
       $cast(rsp, req.clone());
       rsp.set_id_info(req);
       `uvm_info(`gfn, $sformatf("rcvd item:\n%0s", req.sprint()), UVM_HIGH)
+
       cfg.vif.sideload_key.valid = req.valid;
-      if (req.valid) begin
-        cfg.vif.sideload_key.key[0] = req.key0;
-        cfg.vif.sideload_key.key[1] = req.key1;
-      end
-      else begin
-        cfg.vif.sideload_key.key[0] = 'x;
-        cfg.vif.sideload_key.key[1] = 'x;
-      end
-      // Always wait for one clock cycle. Otherwise, this task may consume zero time while the
-      // reset is active. This would be problematic as it would cause the key sideload interface
-      // to be updated endlessly and the DV environment to hang.
-      cfg.vif.wait_clks(1);
-      // send rsp back to seq
+      cfg.vif.sideload_key.key[0] = req.valid ? req.key0 : 'x;
+      cfg.vif.sideload_key.key[1] = req.valid ? req.key1 : 'x;
       `uvm_info(`gfn, "item sent", UVM_HIGH)
-      cfg.vif.wait_clks_or_rst(req.rsp_delay);
+
+      cfg.vif.wait_clks_or_rst(1 + req.rsp_delay);
+
       seq_item_port.item_done(req);
     end
   endtask

--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -17,8 +17,8 @@ class aes_base_vseq extends cip_base_vseq #(
   aes_seq_item       aes_item_queue[$];
   aes_message_item   aes_message;
   aes_message_item   message_queue[$];
-  key_sideload_set_seq sideload_seq, req_key_seq;
 
+  key_sideload_set_seq req_key_seq;
 
   // various knobs to enable certain routines
   bit                do_aes_init   = 1'b1;
@@ -637,18 +637,21 @@ class aes_base_vseq extends cip_base_vseq #(
   endtask // write_data_key_iv
 
 
-
-  // enable sideload sequence
-  // and get it to generate a key a random times
+  // Repeatedly run a sideload sequences. These generate new keys at random times, presenting them
+  // through the key sideload interface.
+  //
+  // Return if reset is asserted
   task start_sideload_seq();
-    sideload_seq = key_sideload_set_seq#(keymgr_pkg::hw_key_req_t)::type_id::create("sideload_seq");
-    `DV_CHECK_RANDOMIZE_FATAL(sideload_seq)
-    sideload_seq.start(p_sequencer.key_sideload_sequencer_h);
-    forever begin
-      `DV_CHECK_RANDOMIZE_FATAL(sideload_seq)
-      // send to sequencer with low priority so we can overwrite
-      `uvm_send_pri(sideload_seq, 100)
+    typedef key_sideload_set_seq#(keymgr_pkg::hw_key_req_t) sideload_seq_t;
 
+    while (!cfg.under_reset) begin
+      sideload_seq_t sideload_seq = sideload_seq_t::type_id::create("sideload_seq");
+
+      if (!sideload_seq.randomize()) begin
+        `uvm_fatal(get_name(), "Failed to randomize sideload_seq.")
+      end
+
+      sideload_seq.start(p_sequencer.key_sideload_sequencer_h);
     end
   endtask
 


### PR DESCRIPTION
The existing code was overly confusing because the sideload part of `aes_base_seq` that sends sideload sequences didn't know to stop after reset had been asserted. Switch things to work more conventionally.