### PR TITLE
[aes,dv] Allow key_sideload_set_seq to be aborted, not killed

### DIFF
--- a/hw/dv/sv/key_sideload_agent/key_sideload_driver.sv
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_driver.sv
@@ -34,7 +34,13 @@ class key_sideload_driver#(
       cfg.vif.sideload_key.key[1] = req.valid ? req.key1 : 'x;
       `uvm_info(`gfn, "item sent", UVM_HIGH)
 
-      cfg.vif.wait_clks_or_rst(1 + req.rsp_delay);
+      fork : isolation_fork begin
+        fork
+          cfg.vif.wait_clks_or_rst(1 + req.rsp_delay);
+          req.wait_stop_requested();
+        join_any
+        disable fork;
+      end join
 
       seq_item_port.item_done(req);
     end

--- a/hw/dv/sv/key_sideload_agent/key_sideload_item.sv
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_item.sv
@@ -13,6 +13,10 @@ class key_sideload_item #(
   rand bit [KeyWidth-1:0] key1;
   rand int unsigned       rsp_delay = 0;
 
+  // A flag that can be set from outside by calling request_stop(). When this is true, the
+  // wait_stop_requested() task will exit.
+  local bit               m_stop_requested;
+
   constraint rsp_delay_constraint_c {rsp_delay inside {[0:9]};}
 
   `uvm_object_utils_begin(key_sideload_item#(KEY_T))
@@ -22,6 +26,20 @@ class key_sideload_item #(
     `uvm_field_int(rsp_delay,  UVM_DEFAULT)
   `uvm_object_utils_end
 
-  `uvm_object_new
+  function new (string name="");
+    super.new(name);
+  endfunction
+
+  // Set a flag that will cause wait_stop_requested to exit
+  function void request_stop();
+    m_stop_requested = 1;
+  endfunction
+
+  // A task that runs until request_stop is called.
+  //
+  // This task is safe to kill.
+  task wait_stop_requested();
+    wait(m_stop_requested);
+  endtask
 
 endclass

--- a/hw/dv/sv/key_sideload_agent/seq_lib/key_sideload_set_seq.sv
+++ b/hw/dv/sv/key_sideload_agent/seq_lib/key_sideload_set_seq.sv
@@ -8,19 +8,53 @@ class key_sideload_set_seq #(
 
   `uvm_object_utils(key_sideload_set_seq#(KEY_T))
 
-  `uvm_object_new
   rand KEY_T sideload_key;
 
+  // The (single) item that is created and run
+  local key_sideload_item#(KEY_T) m_item;
+
+  // A flag that shows request_stop has run, and no item should be created or run.
+  local bit m_stop_requested;
+
+  function new (string name="");
+    super.new(name);
+  endfunction
+
   virtual task body();
-    key_sideload_item#(KEY_T) item;
-    item = key_sideload_item#(KEY_T)::type_id::create("item");
-    `DV_CHECK_RANDOMIZE_WITH_FATAL(item,
-                                   item.valid == sideload_key.valid;
-                                   item.key0 == sideload_key.key[0];
-                                   item.key1 == sideload_key.key[1];)
-    start_item(item);
-    finish_item(item);
-    get_response(item);
+    m_item = key_sideload_item#(KEY_T)::type_id::create("m_item");
+    if (m_stop_requested) return;
+
+    start_item(m_item);
+
+    if (!m_item.randomize() with {
+          m_item.valid == sideload_key.valid;
+          m_item.key0 == sideload_key.key[0];
+          m_item.key1 == sideload_key.key[1];
+        }) begin
+      `uvm_fatal(get_name(), "Failed to randomize m_item.")
+    end
+
+    if (m_stop_requested) begin
+      // m_stop_requested must have been set when we were waiting to start the item. Since it has
+      // started, we have to call finish (to avoid the sequencer locking up). Since we don't
+      // actually want the item to do anything, we just call request_stop on it now.
+      m_item.request_stop();
+    end
+
+    finish_item(m_item);
+    if (m_stop_requested) return;
+
+    get_response(m_item);
   endtask
+
+  // If the sequence is running an item, send a message to the driver running that item to ask that
+  // driver to abort the item, which will complete the sequence.
+  function void request_stop();
+    m_stop_requested = 1;
+
+    if (m_item != null) begin
+      m_item.request_stop();
+    end
+  endfunction
 
 endclass

--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -10,7 +10,6 @@ class aes_base_vseq extends cip_base_vseq #(
   );
 
   `uvm_object_utils(aes_base_vseq)
-  `uvm_object_new
 
   aes_reg2hw_t       aes_reg;
   aes_seq_item       aes_item;
@@ -29,6 +28,20 @@ class aes_base_vseq extends cip_base_vseq #(
   bit                key_used      = 0;
   bit                key_rdy       = 0;
   bit                new_key       = 0;
+
+  // A flag used by start_sideload_seq / stop_sideload_seq to track whether a sideload sequence is
+  // currently running. If true, there is currently a process running the sideload_sequences task.
+  local bit          m_sideload_seq_running;
+
+  // An event to control a sideload_sequences task if one is running. When the event is triggered,
+  // the task will tell the currently running sequence to stop, then will clear
+  // m_sideload_seq_running and exit.
+  local uvm_event    m_stop_sideload_seqs_event;
+
+  function new (string name="");
+    super.new(name);
+    m_stop_sideload_seqs_event = new();
+  endfunction
 
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init();
@@ -637,23 +650,49 @@ class aes_base_vseq extends cip_base_vseq #(
                         txt, data), UVM_MEDIUM)
   endtask // write_data_key_iv
 
-
-  // Repeatedly run a sideload sequences. These generate new keys at random times, presenting them
-  // through the key sideload interface.
+  // Repeatedly run the sideload sequence, which generates new keys at random times.
   //
-  // Return if reset is asserted
+  // This task runs until there is a reset or stop_sideload_seq() is called. The sequences that pass
+  // the new keys are run with priority 100: to pass a different key, send a sequence with a higher
+  // priority.
   task start_sideload_seq();
     typedef key_sideload_set_seq#(keymgr_pkg::hw_key_req_t) sideload_seq_t;
 
-    while (!cfg.under_reset) begin
+    bit end_loop = 0;
+
+    if (m_sideload_seq_running) begin
+      `uvm_fatal(get_name(), "Cannot start multiple sideload sequences.")
+    end
+    m_sideload_seq_running = 1;
+
+    while (!cfg.under_reset && !end_loop) begin
       sideload_seq_t sideload_seq = sideload_seq_t::type_id::create("sideload_seq");
 
       if (!sideload_seq.randomize()) begin
         `uvm_fatal(get_name(), "Failed to randomize sideload_seq.")
       end
 
-      sideload_seq.start(p_sequencer.key_sideload_sequencer_h);
+      fork : isolation_fork begin
+        fork
+          sideload_seq.start(p_sequencer.key_sideload_sequencer_h, this, 100);
+          begin
+            m_stop_sideload_seqs_event.wait_ptrigger();
+            end_loop = 1;
+            sideload_seq.request_stop();
+            wait(0);
+          end
+        join_any
+        disable fork;
+      end join
     end
+
+    m_sideload_seq_running = 0;
+  endtask
+
+  // Stop a sideload sequence if there is one running. Returns when the sequence has finished.
+  task stop_sideload_seq();
+    m_stop_sideload_seqs_event.trigger();
+    wait (!m_sideload_seq_running);
   endtask
 
   task req_sideload_key();

--- a/hw/ip/aes/dv/env/seq_lib/aes_reseed_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_reseed_vseq.sv
@@ -157,18 +157,12 @@ class aes_reseed_vseq extends aes_base_vseq;
     `uvm_info(`gfn, $sformatf("\n\n\t ----| STARTING AES MAIN SEQUENCE |----\n %s",
                               cfg.convert2string()), UVM_LOW)
 
-    // Create one thread such that we can kill all its children without unwanted side effects on the
-    // caller.
+    // generate list of messages
+    generate_message_queue();
+
     fork
-      begin
-
-        fork
-          // generate list of messages //
-          generate_message_queue();
-          // start sideload (even if not used)
-          start_sideload_seq();
-        join_any
-
+      start_sideload_seq();
+      fork : isolation_fork begin
         // Trigger reseed by manually setting the PRNG_RESEED bit in the TRIGGER register.
         `uvm_info(`gfn, "Triggering PRNG reseed via trigger register", UVM_LOW)
         fork
@@ -262,10 +256,10 @@ class aes_reseed_vseq extends aes_base_vseq;
           // Check that the reseeds happens when the counter expires.
           check_reseed_rate();
         join_any
+        disable fork;
 
-      end
-    // Kill all children.
-    disable fork;
+        stop_sideload_seq();
+      end join
     join
 
   endtask : body


### PR DESCRIPTION
This commit allows a virtual sequence to ask an instance of
key_sideload_set_seq to come to a stop, which we connect up in
aes_base_vseq as an example.

key_sideload_item has been extended with a flag to say a stop has been
requested. This can be set by calling key_sideload_item::request_stop.
When the flag is set, key_sideload_driver will immediately stop
driving the item.

This mechanism allows key_sideload_set_seq to have a request_stop
function, which will cause the sequence to complete immediately.

The change is prompted by a use in the AES block. There, aes_base_vseq
has always run random instances of key_sideload_set_seq in a loop with
the start_sideload_seq task.

This commit adds a stop_sideload_seq function that causes the
start_sideload_seq task to stop if it is running. It then tidies up
the fork/join structure in aes_reseed_vseq (which was kind of wrong
before) in a way that no longer requires us to kill start_sideload_seq
with disable fork.
