### PR TITLE
[aes,dv] Make check_{clearing/masking}_prng_reseed exit on reset

### DIFF
--- a/hw/ip/aes/dv/env/seq_lib/aes_reseed_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_reseed_vseq.sv
@@ -16,45 +16,73 @@ class aes_reseed_vseq extends aes_base_vseq;
   // Max wait time to accommodate long entropy delays and DUT stalls.
   int wait_timeout_cycles_max = 100000;
 
-  task check_clearing_prng_reseed();
-    // Wait for entropy_clearing_req to verify the reseeding is triggered.
-    bit request_seen = 0;
-    `uvm_info(`gfn, $sformatf("Checking that entropy_clearing_req goes high, currently %d",
-        cfg.aes_reseed_vif.entropy_clearing_req), UVM_MEDIUM)
-    `DV_SPINWAIT_EXIT(
-        wait (cfg.aes_reseed_vif.entropy_clearing_req) request_seen = 1;,
-        cfg.clk_rst_vif.wait_clks(wait_timeout_cycles_max);,
-        "Timeout waiting for entropy_clearing_req")
-    `DV_CHECK_EQ_FATAL(request_seen, 1'b1)
+  // Wait until the entropy_clearing_req signal goes high, verifying reseeding is triggered. This
+  // runs with a timeout: if the timeout is hit, it will generate an error.
+  //
+  // Exit immediately on reset.
+  local task check_clearing_prng_reseed();
+    `uvm_info(get_full_name(),
+              $sformatf("Waiting for entropy_clearing_req to go high (currently %d)",
+                        cfg.aes_reseed_vif.entropy_clearing_req),
+              UVM_MEDIUM)
+
+    fork : isolation_fork begin
+      fork
+        cfg.aes_reseed_vif.wait_entropy_clearing_req();
+        begin
+          cfg.clk_rst_vif.wait_clks(wait_timeout_cycles_max);
+          `uvm_error(get_full_name(), "Timeout waiting for entropy_clearing_req")
+        end
+      join_any
+      disable fork;
+    end join
   endtask
 
-  task check_masking_prng_reseed();
-    // Wait for entropy_masking_req to go high to verify the reseeding is triggered.
-    bit request_seen = 0;
-    `uvm_info(`gfn, $sformatf("Checking that entropy_masking_req goes high, currently %d",
-        cfg.aes_reseed_vif.entropy_masking_req), UVM_MEDIUM)
-    `DV_SPINWAIT_EXIT(
-        wait (cfg.aes_reseed_vif.entropy_masking_req) request_seen = 1;,
-        cfg.clk_rst_vif.wait_clks(wait_timeout_cycles);,
-        "Timeout waiting for entropy_masking_req")
-    `DV_CHECK_EQ_FATAL(request_seen | finished_all_msgs, 1'b1)
-    // Wait for entropy_masking_req to go low again to verify the reseeding finishes.
-    request_seen = 0;
-    `uvm_info(`gfn, $sformatf("Checking that entropy_masking_req goes low, currently %d",
-        cfg.aes_reseed_vif.entropy_masking_req), UVM_MEDIUM)
-    `DV_SPINWAIT_EXIT(
-        wait (!cfg.aes_reseed_vif.entropy_masking_req) request_seen = 1;,
-        cfg.clk_rst_vif.wait_clks(wait_timeout_cycles_max);,
-        "Timeout waiting for entropy_masking_req")
-    `DV_CHECK_EQ_FATAL(request_seen | finished_all_msgs, 1'b1)
+  // Wait for entropy_masking_req to go high and then low again.
+  //
+  // Exit immediately on reset or if finished_all_msgs becomes true.
+  local task check_masking_prng_reseed();
+    `uvm_info(get_full_name(),
+              $sformatf("Waiting for entropy_masking_req to go high (currently %d)",
+                        cfg.aes_reseed_vif.entropy_masking_req),
+              UVM_MEDIUM)
+    fork : isolation_fork_rise begin
+      fork
+        cfg.aes_reseed_vif.wait_entropy_masking_req(1);
+        wait(finished_all_msgs);
+        begin
+          cfg.clk_rst_vif.wait_clks(wait_timeout_cycles);
+          `uvm_error(get_full_name(), "Timeout waiting for entropy_masking_req to go high")
+        end
+      join_any
+      disable fork;
+    end join
+    if (cfg.under_reset || finished_all_msgs) return;
+
+    `uvm_info(get_full_name(), "Waiting for entropy_masking_req to go low again", UVM_MEDIUM)
+    fork : isolation_fork_fall begin
+      fork
+        cfg.aes_reseed_vif.wait_entropy_masking_req(0);
+        wait(finished_all_msgs);
+        begin
+          cfg.clk_rst_vif.wait_clks(wait_timeout_cycles_max);
+          `uvm_error(get_full_name(), "Timeout waiting for entropy_masking_req to go low again")
+        end
+      join_any
+      disable fork;
+    end join
   endtask
 
+  // Wait for the PRNG to reseed (with a reseeding that should have already been requested)
   task check_prng_reseed();
-    // Check entropy_clearing_req to verify the reseeding is actually triggered.
     check_clearing_prng_reseed();
+    if (cfg.under_reset) return;
+
     if (`EN_MASKING) begin
       check_masking_prng_reseed();
     end
+    if (cfg.under_reset) return;
+
     // Wait for the DUT to become idle again. This happens once the reseed operation finishes.
     csr_spinwait(.ptr(ral.status.idle), .exp_data(1'b1));
   endtask
@@ -165,6 +193,7 @@ class aes_reseed_vseq extends aes_base_vseq;
       prng_reseed();
       check_prng_reseed();
     join
+    if (cfg.under_reset) return;
 
     // Trigger reseed by writing a new key to the initial key registers. In case
     // KEY_TOUCH_FORCES_RESEED is not set, no reseed operation is supposed to be triggered. The

--- a/hw/ip/aes/dv/env/seq_lib/aes_reseed_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_reseed_vseq.sv
@@ -149,11 +149,113 @@ class aes_reseed_vseq extends aes_base_vseq;
     end
   endtask
 
-  task body();
+  // The core of the body() task, which is split out from body so that it can return more easily
+  // (even though other processes are in a fork).
+  //
+  // This task is run in an isolation fork.
+  task body_main_thread();
+    bit sideload_setup_done;
     bit sideload_valid;
     string sideload_valid_path = "tb.dut.keymgr_key_i.valid";
     bit sideload_enabled;
-    bit sideload_setup_done;
+
+    // Trigger reseed by manually setting the PRNG_RESEED bit in the TRIGGER register.
+    `uvm_info(`gfn, "Triggering PRNG reseed via trigger register", UVM_LOW)
+    fork
+      prng_reseed();
+      check_prng_reseed();
+    join
+
+    // Trigger reseed by writing a new key to the initial key registers. In case
+    // KEY_TOUCH_FORCES_RESEED is not set, no reseed operation is supposed to be triggered. The
+    // default configuration written after reset is not using the sideload interface for the
+    // key.
+    `uvm_info(`gfn, "Potentially triggering PRNG reseed by writing a new key", UVM_LOW)
+    `DV_CHECK_STD_RANDOMIZE_FATAL(init_key)
+    // Wait for the DUT to be idle before writing the key.
+    csr_spinwait(.ptr(ral.status.idle), .exp_data(1'b1));
+    if (cfg.do_reseed) begin
+      fork
+        write_key(init_key, 1'b0);
+        check_prng_reseed();
+      join
+    end else begin
+      write_key(init_key, 1'b0);
+      check_no_prng_reseed();
+    end
+
+    // Trigger reseed by loading a new key via sideload interface. In case
+    // KEY_TOUCH_FORCES_RESEED is not set, no reseed operation is supposed to be triggered.
+    // Wait for the DUT to be idle before enabling sideload.
+    `uvm_info(`gfn, "Potentially triggering PRNG reseed by providing a new sideload key",
+        UVM_LOW)
+    if (!uvm_hdl_check_path(sideload_valid_path)) begin
+      `uvm_fatal(`gfn, $sformatf("\n\t ----| PATH NOT FOUND"))
+    end
+    sideload_setup_done = 0;
+    while (!sideload_setup_done) begin
+      csr_spinwait(.ptr(ral.status.idle), .exp_data(1'b1));
+      // Make sure sideload is disabled.
+      set_sideload(1'b0);
+      sideload_enabled = 1'b0;
+      // Wait for sideload key to be valid before enabling sideload.
+      sideload_valid = 0;
+      `DV_SPINWAIT_EXIT(
+        while (!sideload_valid) begin
+          cfg.clk_rst_vif.wait_n_clks(1);
+          `DV_CHECK_FATAL(uvm_hdl_read(sideload_valid_path, sideload_valid))
+        end,
+        cfg.clk_rst_vif.wait_n_clks(wait_timeout_cycles);,
+        "Timeout waiting for valid sideload key")
+      fork
+        // Enable sideload.
+        begin
+          set_sideload(1'b1);
+          sideload_enabled = 1'b1;
+        end
+        // Detect if the sideload valid bit gets de-asserted while trying to enable sideload.
+        begin
+          while (sideload_valid && !sideload_enabled) begin
+            cfg.clk_rst_vif.wait_n_clks(1);
+            `DV_CHECK_FATAL(uvm_hdl_read(sideload_valid_path, sideload_valid))
+          end
+        end
+      join
+
+      // If the sideload valid bit got de-asserted again before fully enabling sideload, the key
+      // did not get loaded and we have to repeat the setup procedure. Otherwise, sideload was
+      // enabled successfully.
+      if (sideload_valid) begin
+        sideload_setup_done = 1;
+      end
+    end
+
+    // Sideload got enabled with a valid sideload key present. This must trigger a reseed in
+    // case KEY_TOUCH_FORCES_RESEED is set.
+    if (cfg.do_reseed) begin
+      check_prng_reseed();
+    end else begin
+      check_no_prng_reseed();
+    end
+
+    // Test that the PRNGs are reseeded at the proper rate during message processing.
+    `uvm_info(`gfn, "Testing automatic / block counter based reseeding of the masking PRNG",
+        UVM_LOW)
+    fork
+      basic: begin
+        // Kick off the message processing.
+        send_msg_queue(cfg.unbalanced, cfg.read_prob, cfg.write_prob);
+        finished_all_msgs = 1;
+        `uvm_info(`gfn, "Done with sending messages", UVM_LOW)
+      end
+
+      // Check that the reseeds happens when the counter expires.
+      check_reseed_rate();
+    join_any
+    disable fork;
+  endtask
+
+  task body();
     `uvm_info(`gfn, $sformatf("\n\n\t ----| STARTING AES MAIN SEQUENCE |----\n %s",
                               cfg.convert2string()), UVM_LOW)
 
@@ -163,101 +265,7 @@ class aes_reseed_vseq extends aes_base_vseq;
     fork
       start_sideload_seq();
       fork : isolation_fork begin
-        // Trigger reseed by manually setting the PRNG_RESEED bit in the TRIGGER register.
-        `uvm_info(`gfn, "Triggering PRNG reseed via trigger register", UVM_LOW)
-        fork
-          prng_reseed();
-          check_prng_reseed();
-        join
-
-        // Trigger reseed by writing a new key to the initial key registers. In case
-        // KEY_TOUCH_FORCES_RESEED is not set, no reseed operation is supposed to be triggered. The
-        // default configuration written after reset is not using the sideload interface for the
-        // key.
-        `uvm_info(`gfn, "Potentially triggering PRNG reseed by writing a new key", UVM_LOW)
-        `DV_CHECK_STD_RANDOMIZE_FATAL(init_key)
-        // Wait for the DUT to be idle before writing the key.
-        csr_spinwait(.ptr(ral.status.idle), .exp_data(1'b1));
-        if (cfg.do_reseed) begin
-          fork
-            write_key(init_key, 1'b0);
-            check_prng_reseed();
-          join
-        end else begin
-          write_key(init_key, 1'b0);
-          check_no_prng_reseed();
-        end
-
-        // Trigger reseed by loading a new key via sideload interface. In case
-        // KEY_TOUCH_FORCES_RESEED is not set, no reseed operation is supposed to be triggered.
-        // Wait for the DUT to be idle before enabling sideload.
-        `uvm_info(`gfn, "Potentially triggering PRNG reseed by providing a new sideload key",
-            UVM_LOW)
-        if (!uvm_hdl_check_path(sideload_valid_path)) begin
-          `uvm_fatal(`gfn, $sformatf("\n\t ----| PATH NOT FOUND"))
-        end
-        sideload_setup_done = 0;
-        while (!sideload_setup_done) begin
-          csr_spinwait(.ptr(ral.status.idle), .exp_data(1'b1));
-          // Make sure sideload is disabled.
-          set_sideload(1'b0);
-          sideload_enabled = 1'b0;
-          // Wait for sideload key to be valid before enabling sideload.
-          sideload_valid = 0;
-          `DV_SPINWAIT_EXIT(
-            while (!sideload_valid) begin
-              cfg.clk_rst_vif.wait_n_clks(1);
-              `DV_CHECK_FATAL(uvm_hdl_read(sideload_valid_path, sideload_valid))
-            end,
-            cfg.clk_rst_vif.wait_n_clks(wait_timeout_cycles);,
-            "Timeout waiting for valid sideload key")
-          fork
-            // Enable sideload.
-            begin
-              set_sideload(1'b1);
-              sideload_enabled = 1'b1;
-            end
-            // Detect if the sideload valid bit gets de-asserted while trying to enable sideload.
-            begin
-              while (sideload_valid && !sideload_enabled) begin
-                cfg.clk_rst_vif.wait_n_clks(1);
-                `DV_CHECK_FATAL(uvm_hdl_read(sideload_valid_path, sideload_valid))
-              end
-            end
-          join
-
-          // If the sideload valid bit got de-asserted again before fully enabling sideload, the key
-          // did not get loaded and we have to repeat the setup procedure. Otherwise, sideload was
-          // enabled successfully.
-          if (sideload_valid) begin
-            sideload_setup_done = 1;
-          end
-        end
-
-        // Sideload got enabled with a valid sideload key present. This must trigger a reseed in
-        // case KEY_TOUCH_FORCES_RESEED is set.
-        if (cfg.do_reseed) begin
-          check_prng_reseed();
-        end else begin
-          check_no_prng_reseed();
-        end
-
-        // Test that the PRNGs are reseeded at the proper rate during message processing.
-        `uvm_info(`gfn, "Testing automatic / block counter based reseeding of the masking PRNG",
-            UVM_LOW)
-        fork
-          basic: begin
-            // Kick off the message processing.
-            send_msg_queue(cfg.unbalanced, cfg.read_prob, cfg.write_prob);
-            finished_all_msgs = 1;
-            `uvm_info(`gfn, "Done with sending messages", UVM_LOW)
-          end
-
-          // Check that the reseeds happens when the counter expires.
-          check_reseed_rate();
-        join_any
-        disable fork;
-
+        body_main_thread();
         stop_sideload_seq();
       end join
     join

--- a/hw/ip/aes/dv/sva/aes_reseed_if.sv
+++ b/hw/ip/aes/dv/sva/aes_reseed_if.sv
@@ -47,4 +47,30 @@ interface aes_reseed_if
   `ASSERT(KeyTouchForcesReseed_A, key_touch_forces_reseed && key_init_new_pulse |->
     ##[1:20] entropy_clearing_req && (`EN_MASKING == entropy_masking_req) || alert_fatal)
 
+  // Wait until entropy_clearing_req becomes high, exiting immediately on reset
+  //
+  // This task is safe to kill.
+  task automatic wait_entropy_clearing_req();
+    fork : isolation_fork begin
+      fork
+        wait(entropy_clearing_req);
+        wait(!rst_ni);
+      join_any
+      disable fork;
+    end join
+  endtask
+
+  // Wait until entropy_masking_req has the requested value, exiting immediately on reset
+  //
+  // This task is safe to kill.
+  task automatic wait_entropy_masking_req(bit expected);
+    fork : isolation_fork begin
+      fork
+        wait(entropy_masking_req == expected);
+        wait(!rst_ni);
+      join_any
+      disable fork;
+    end join
+  endtask
+
 endinterface // aes_reseed_if


### PR DESCRIPTION
Of the two commits, the first is just a code re-ordering and won't have any effect. The second is the more interesting change, and has the following commit message:

> These two tasks worked by waiting for a signal on the reseed
> interface. Move that wait into tasks in the interface itself, and make
> those tasks exit on reset.
> 
> Since I was touching the code anyway, I also tidied up the way the
> sequence checks that it saw the reset. The resulting errors should be
> clearer and the code is dramatically easier to understand.
