### PR TITLE
[aes,dv] Enable resets in AES tests (without waiting for gaps)

### DIFF
--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -251,9 +251,13 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block_extended));
     keymgr_sideload_agent_cfg.start_default_seq = 0;
     num_edn = 1;
     super.initialize();
+
+    can_reset_with_csr_accesses = 1;
+
     tl_intg_alert_fields[ral.status.alert_fatal_fault] = 1;
     shadow_update_err_status_fields[ral.status.alert_recov_ctrl_update_err] = 1;
     shadow_storage_err_status_fields[ral.status.alert_fatal_fault] = 1;
+
     // get aes reseed check interface handle
     if (!uvm_config_db#(virtual aes_reseed_if)::get(null, "*.env" , "aes_reseed_vif",
                                                     aes_reseed_vif)) begin

--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -217,6 +217,7 @@ class aes_base_vseq extends cip_base_vseq #(
 
     if (wait_idle) begin
       csr_spinwait(.ptr(ral.status.idle), .exp_data(1'b1));
+      if (cfg.under_reset) return;
     end
 
     // In case configuration error injection is enabled, we inject an error with a probability of
@@ -292,6 +293,8 @@ class aes_base_vseq extends cip_base_vseq #(
         phase_prev.name(), phase_wr.name(), phase.name()), UVM_MEDIUM)
     `uvm_info(`gfn, $sformatf("Writing num_bytes_valid %0d", num_bytes_wr), UVM_MEDIUM)
     csr_update(.csr(ral.ctrl_gcm_shadowed), .en_shadow_wr(1'b1), .blocking(1));
+    if (cfg.under_reset) return;
+
     if (phase != phase_wr) begin
       // Reflect the resolution of invalid values in the abstraction class.
       ral.ctrl_gcm_shadowed.phase.set(phase_prev);
@@ -302,6 +305,7 @@ class aes_base_vseq extends cip_base_vseq #(
       // Perform a readback to check that the DUT resolved potentially illegal phase value changes
       // correctly.
       csr_rd(.ptr(ral.ctrl_gcm_shadowed), .value(ctrl_gcm), .blocking(1));
+      if (cfg.under_reset) return;
       if (ctrl_gcm.phase != phase_prev) begin
         `uvm_fatal(`gfn, $sformatf("Expected GCM phase %s, got %s",
             phase_prev.name(), ctrl_gcm.phase.name()))


### PR DESCRIPTION
The aes_stress_all_with_rand_reset test fails every time with this change! But it was failing every time before, and this refactor makes it possible to fix things incrementally.