### PR TITLE
[aes,dv] Don't add more resets inside aes_stress_all_with_rand_reset

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -360,9 +360,9 @@ class cip_base_vseq #(
   //   reset_delay_bound  Each time the sequence runs, this task will wait a random amount of time
   //                      before it starts waiting for an opportune time to inject the reset. This
   //                      is the upper bound on that wait.
-  extern protected task run_seq_with_rand_reset_vseq(uvm_sequence seq,
-                                                     int          num_times,
-                                                     uint         reset_delay_bound);
+  extern protected virtual task run_seq_with_rand_reset_vseq(uvm_sequence seq,
+                                                             int          num_times,
+                                                             uint         reset_delay_bound);
 
   // If cfg.can_reset_with_csr_accesses is false, wait_to_issue_reset() will try to wait for a time
   // with no CSR accesses before it injects the reset. The value returned by this function is an

--- a/hw/ip/aes/dv/env/seq_lib/aes_common_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_common_vseq.sv
@@ -165,6 +165,19 @@ class aes_common_vseq extends aes_base_vseq;
     end
   endfunction
 
+  // This task is extended from the one in cip_base_vseq. If seq is actually an aes_stress_all_vseq,
+  // tell that virtual sequence that it might be reset (so shouldn't run any sequences that
+  // themselves involve resets)
+  virtual protected task run_seq_with_rand_reset_vseq(uvm_sequence seq,
+                                                      int          num_times,
+                                                      uint         reset_delay_bound);
+    aes_stress_all_vseq stress_all_vseq;
+    if ($cast(stress_all_vseq, seq)) begin
+      stress_all_vseq.require_resettable();
+    end
+    super.run_seq_with_rand_reset_vseq(seq, num_times, reset_delay_bound);
+  endtask
+
   virtual task body();
     run_common_vseq_wrapper(num_trans);
   endtask : body

--- a/hw/ip/aes/dv/env/seq_lib/aes_stress_all_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_stress_all_vseq.sv
@@ -7,32 +7,74 @@
 
 class aes_stress_all_vseq extends aes_base_vseq;
   `uvm_object_utils(aes_stress_all_vseq)
-  `uvm_object_new
+
+  typedef struct {
+    string name;
+    bit    can_be_reset;
+  } seq_desc_t;
 
   // The sequences that we'll run back-to-back.
-  string vseq_names[$] = {
-    "aes_stress_vseq",
-    "aes_alert_reset_vseq",
-    "aes_reseed_vseq"
-  };
+  local seq_desc_t m_vseq_descs[$] = '{ '{"aes_stress_vseq",      1},
+                                        '{"aes_alert_reset_vseq", 0},
+                                        '{"aes_reseed_vseq",      1} };
+
+  // Set this flag by calling require_resettable. If it is set, the stress test will only schedule
+  // virtual sequences that can be reset.
+  bit m_must_be_resettable = 0;
+
+  function new (string name="");
+    super.new(name);
+  endfunction
+
+  virtual function void do_copy(uvm_object rhs);
+    aes_stress_all_vseq vseq_rhs;
+    super.do_copy(rhs);
+    if (!$cast(vseq_rhs, rhs)) `uvm_fatal(get_name(), "Cannot copy from RHS of wrong type.")
+    m_must_be_resettable = vseq_rhs.m_must_be_resettable;
+  endfunction
+
+  function void require_resettable();
+    m_must_be_resettable = 1;
+  endfunction
+
+  // Run a single virtual sequence (called in a loop by body)
+  local
+  task run_one(int unsigned idx, string name);
+    uvm_sequence base_seq = create_seq_by_name(name);
+    aes_base_vseq vseq;
+
+    if (!$cast(vseq, base_seq)) begin
+      `uvm_fatal(get_name(), "Cannot downcast sequence to a dv_base_vseq.")
+    end
+
+    vseq.do_apply_reset = (do_apply_reset && !m_must_be_resettable) ? $urandom_range(0, 1) : 0;
+    vseq.set_sequencer(p_sequencer);
+
+    `uvm_info(get_name(),
+              $sformatf("iteration[%0d]: starting %0s, resetting %0d",
+                        idx, name, vseq.do_apply_reset),
+              UVM_LOW)
+
+    vseq.start(p_sequencer);
+
+    `uvm_info(get_name(),
+              $sformatf("iteration[%0d]: ending %0s", idx, name),
+              UVM_LOW)
+  endtask
 
   task body();
     `uvm_info(`gfn, $sformatf("Running %0d sub-sequences", num_trans), UVM_LOW)
     for (int i = 0; i < num_trans; i++) begin
-      uvm_sequence   seq;
-      aes_base_vseq  aes_vseq;
-      uint           seq_idx = $urandom_range(0, vseq_names.size() - 1);
-      string         cur_vseq_name = vseq_names[seq_idx];
+      int unsigned idx;
+      if (!std::randomize(idx) with {
+            idx < m_vseq_descs.size();
+            m_must_be_resettable -> m_vseq_descs[idx].can_be_reset;
+          }) begin
+        `uvm_fatal(get_name(), "Failed to choose virtual sequence.")
+      end
+      run_one(i, m_vseq_descs[idx].name);
 
-      seq = create_seq_by_name(cur_vseq_name);
-      `downcast(aes_vseq, seq)
-
-      aes_vseq.do_apply_reset = (do_apply_reset) ? $urandom_range(0, 1) : 0;
-      aes_vseq.set_sequencer(p_sequencer);
-      `uvm_info(`gfn, $sformatf("iteration[%0d]: starting %0s, resetting %0d",
-          i, cur_vseq_name, aes_vseq.do_apply_reset), UVM_LOW)
-      aes_vseq.start(p_sequencer);
-      `uvm_info(`gfn, $sformatf("iteration[%0d]: ending %0s", i, cur_vseq_name), UVM_LOW)
+      if (cfg.under_reset) return;
     end
   endtask
 

--- a/hw/ip/aes/dv/env/seq_lib/aes_vseq_list.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_vseq_list.sv
@@ -6,7 +6,6 @@
 `include "aes_wake_up_vseq.sv"
 `include "aes_nist_vectors_vseq.sv"
 `include "aes_nist_vectors_gcm_vseq.sv"
-`include "aes_common_vseq.sv"
 `include "aes_stress_vseq.sv"
 `include "aes_alert_reset_vseq.sv"
 `include "aes_deinit_vseq.sv"
@@ -21,3 +20,4 @@
 `include "aes_readability_vseq.sv"
 `include "aes_stress_all_vseq.sv"
 `include "aes_gcm_save_restore_vseq.sv"
+`include "aes_common_vseq.sv"


### PR DESCRIPTION
The outer loop in stress_all_with_rand_reset runs the stress all sequence (aes_stress_all_vseq), together with some other do-nothing error sequences and then wants to inject a reset in the middle.

This won't work very well if the internal stress all sequence injects resets as well. To stop that happening:

  - Give aes_stress_all_vseq a flag that allows it to be told it should only run sequences that are resettable.

  - Extend cip_base_vseq::run_seq_with_rand_reset_vseq so that it sets that flag.

  - Teach aes_stress_all_vseq that aes_alert_reset_vseq is not resettable (it wants to inject resets itself).

  - Make the random vseq selection in aes_stress_all_vseq obey the flag that might tell it to only run sequences that are resettable.

The commit is marginally longer than you might hope because:

 - Annoyingly, I had to touch cip_base_vseq (because I stupidly hadn't made a task virtual).

 - We need to implement aes_stress_all_with_rand_reset::do_copy because cip_base_vseq::run_seq_with_rand_reset_vseq clones the sequence each time and we need to make sure the configuration gets passed across.