### PR TITLE
[dv] Allow a cfg to be passed directly to dv_base_agent

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_agent.sv
+++ b/hw/dv/sv/dv_lib/dv_base_agent.sv
@@ -52,7 +52,7 @@ endfunction
 function void dv_base_agent::build_phase(uvm_phase phase);
   super.build_phase(phase);
 
-  if (!uvm_config_db#(CFG_T)::get(this, "", "cfg", cfg)) begin
+  if (cfg == null && !uvm_config_db#(CFG_T)::get(this, "", "cfg", cfg)) begin
     `uvm_fatal(`gfn, $sformatf("failed to get %s from uvm_config_db", cfg.get_type_name()))
   end
   `uvm_info(`gfn, $sformatf("\n%0s", cfg.sprint()), UVM_HIGH)


### PR DESCRIPTION
Honestly, I'm not completely sure whether this is a better way to do it, but the motivation is that an testbench can set up e.g. 10 agents without needing to set 10 items in the config db and then retrieve them all.

The downside seems pretty trivial, so maybe it's worth trying out.