### PR TITLE
[rv_dm,dv] Give rv_dm_if a passive mode

### DIFF
--- a/hw/ip/rv_dm/dv/env/rv_dm_env.core
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.core
@@ -13,6 +13,7 @@ filesets:
       - lowrisc:dv:dv_base_reg
       - lowrisc:dv:jtag_agent
       - lowrisc:dv:jtag_dmi_agent
+      - lowrisc:dv:rv_dm_mode_agent
       - lowrisc:opentitan:bus_params_pkg
     files:
       - rv_dm_env_pkg.sv

--- a/hw/ip/rv_dm/dv/env/rv_dm_env.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.sv
@@ -10,8 +10,10 @@ class rv_dm_env extends cip_base_env #(
   );
   `uvm_component_utils(rv_dm_env)
 
-  tl_agent         m_tl_sba_agent;
-  jtag_agent       m_jtag_agent;
+  tl_agent           m_tl_sba_agent;
+  jtag_agent         m_jtag_agent;
+  rv_dm_mode_agent   m_mode_agent;
+
   jtag_dmi_monitor   m_jtag_dmi_monitor;
   sba_access_monitor m_sba_access_monitor;
 
@@ -51,6 +53,9 @@ class rv_dm_env extends cip_base_env #(
     m_jtag_agent = jtag_agent::type_id::create("m_jtag_agent", this);
     uvm_config_db#(jtag_agent_cfg)::set(this, "m_jtag_agent*", "cfg", cfg.m_jtag_agent_cfg);
     cfg.m_jtag_agent_cfg.en_cov = cfg.en_cov;
+
+    m_mode_agent = rv_dm_mode_agent::type_id::create("m_mode_agent", this);
+    m_mode_agent.cfg = cfg.m_mode_agent_cfg;
 
     m_jtag_dmi_monitor = jtag_dmi_monitor#()::type_id::create("m_jtag_dmi_monitor", this);
     m_jtag_dmi_monitor.cfg = cfg.m_jtag_agent_cfg;

--- a/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
@@ -5,9 +5,11 @@
 class rv_dm_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_dm_regs_reg_block));
 
   // ext component cfgs
-  virtual rv_dm_if    rv_dm_vif;
-  rand jtag_agent_cfg m_jtag_agent_cfg;
-  rand tl_agent_cfg   m_tl_sba_agent_cfg;
+  virtual rv_dm_if          rv_dm_vif;
+
+  rand jtag_agent_cfg       m_jtag_agent_cfg;
+  rand tl_agent_cfg         m_tl_sba_agent_cfg;
+  rand rv_dm_mode_agent_cfg m_mode_agent_cfg;
 
   // This controls whether the scoreboard (if enabled) should check correctness of TL error
   // responses. It defaults to being true but a vseq that is forcing internal signals might need to
@@ -42,6 +44,7 @@ class rv_dm_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_dm_regs_reg_block));
   function new (string name="");
     super.new(name);
     can_reset_with_csr_accesses = 1'b1;
+    m_mode_agent_cfg = rv_dm_mode_agent_cfg::type_id::create("m_mode_agent_cfg");
   endfunction
 
   virtual function void initialize();

--- a/hw/ip/rv_dm/dv/env/rv_dm_env_pkg.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env_pkg.sv
@@ -16,6 +16,7 @@ package rv_dm_env_pkg;
   import cip_base_pkg::*;
   import dv_base_reg_pkg::*;
   import csr_utils_pkg::*;
+  import rv_dm_mode_agent_pkg::*;
   import rv_dm_regs_ral_pkg::*;
   import rv_dm_mem_ral_pkg::*;
   import rv_dm_reg_pkg::NrHarts;

--- a/hw/ip/rv_dm/dv/env/rv_dm_if.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_if.sv
@@ -6,24 +6,53 @@ interface rv_dm_if(input logic clk, input logic rst_n);
 
   import rv_dm_env_pkg::*;
 
-  // DUT inputs.
-  logic                 scan_rst_n;
-  logic [NUM_HARTS-1:0] unavailable;
+  // Most of the signals in the interface are designed to be connected to ports of rv_dm. If
+  // is_active is true, the signals that will be connected to its input ports are driven by cb. If
+  // is_active is false, they are driven with 'z here, which allows the interface to monitor a
+  // larger design that drives rv_dm itself.
+  //
+  // The flag is defined as a wire with a weak pull-up. This ensures that a testbench that doesn't
+  // customise is_active will see the interface be driven actively, but allows a testbench that
+  // *does* want to customise the signal to pull it low.
+  wire is_active;
+  assign (weak0, weak1) is_active = 1'b1;
 
-  // DUT outputs.
-  wire ndmreset_req;
-  wire dmactive;
-  wire [NUM_HARTS-1:0] debug_req;
+  // The signals connected to ports of rv_dm, other than the TL, alert, RACL and JTAG interfaces.
+  // These have the same name as the port, but without an _i or _o suffix.
+  wire                  scan_rst_n;
+  wire                  ndmreset_req;
+  wire                  dmactive;
+  wire [NUM_HARTS-1:0]  debug_req;
+  wire  [NUM_HARTS-1:0] unavailable;
 
-  // Disable TLUL host SBA assertions when injecting intg errors on the response channel.
-  bit disable_tlul_assert_host_sba_resp_svas;
+  // "Internal" versions of the per-port signals above for rv_dm's input ports
+  logic                 scan_rst_n_internal;
+  logic [NUM_HARTS-1:0] unavailable_internal;
 
+  // Drive the wire signals for rv_dm's input ports if is_active is true
+  assign scan_rst_n  = is_active ? scan_rst_n_internal  : 'z;
+  assign unavailable = is_active ? unavailable_internal : 'z;
+
+  // A clocking block for driving the various _internal signals that are all synchronous to clk. If
+  // is_active is true, these can be used to drive input ports of rv_dm. The signals from output
+  // ports of rv_dm can also be sampled through this clocking block.
   clocking cb @(posedge clk);
-    output scan_rst_n;
-    output unavailable;
+    input  ndmreset_req;
+    input  dmactive;
+    input  debug_req;
+    output scan_rst_n = scan_rst_n_internal;
+    output unavailable = unavailable_internal;
+  endclocking
+
+  // A clocking block for a monitor
+  clocking mon_cb @(posedge clk);
     input ndmreset_req;
     input dmactive;
     input debug_req;
+    input unavailable;
   endclocking
+
+  // Disable TLUL host SBA assertions when injecting intg errors on the response channel.
+  bit disable_tlul_assert_host_sba_resp_svas;
 
 endinterface

--- a/hw/ip/rv_dm/dv/env/rv_dm_if.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_if.sv
@@ -6,22 +6,9 @@ interface rv_dm_if(input logic clk, input logic rst_n);
 
   import rv_dm_env_pkg::*;
 
-  // "Enable" inputs
-  lc_ctrl_pkg::lc_tx_t    lc_init_done;
-  lc_ctrl_pkg::lc_tx_t    lc_hw_debug_clr;
-  lc_ctrl_pkg::lc_tx_t    lc_hw_debug_en;
-  lc_ctrl_pkg::lc_tx_t    lc_check_byp_en;
-  lc_ctrl_pkg::lc_tx_t    lc_escalate_en;
-  lc_ctrl_pkg::lc_tx_t    pinmux_hw_debug_en;
-  lc_ctrl_pkg::lc_tx_t    lc_dft_en;
-  prim_mubi_pkg::mubi8_t  otp_dis_rv_dm_late_debug;
-  logic                   strap_en;
-  logic                   strap_en_override;
-
-  // Other DUT inputs.
-  prim_mubi_pkg::mubi4_t  scanmode;
-  logic                   scan_rst_n;
-  logic [NUM_HARTS-1:0]   unavailable;
+  // DUT inputs.
+  logic                 scan_rst_n;
+  logic [NUM_HARTS-1:0] unavailable;
 
   // DUT outputs.
   wire ndmreset_req;
@@ -32,13 +19,6 @@ interface rv_dm_if(input logic clk, input logic rst_n);
   bit disable_tlul_assert_host_sba_resp_svas;
 
   clocking cb @(posedge clk);
-    output lc_init_done;
-    output lc_hw_debug_clr;
-    output lc_hw_debug_en;
-    output pinmux_hw_debug_en;
-    output lc_dft_en;
-    output otp_dis_rv_dm_late_debug;
-    output scanmode;
     output scan_rst_n;
     output unavailable;
     input ndmreset_req;

--- a/hw/ip/rv_dm/dv/env/rv_dm_if.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_if.sv
@@ -6,24 +6,53 @@ interface rv_dm_if(input logic clk, input logic rst_n);
 
   import rv_dm_env_pkg::*;
 
-  // DUT inputs.
-  logic                 scan_rst_n;
-  logic [NUM_HARTS-1:0] unavailable;
+  // Most of the signals in the interface are designed to be connected to ports of rv_dm. If
+  // is_active is true, the signals that will be connected to its input ports are driven by cb. If
+  // is_active is false, they are driven with 'z here, which allows the interface to monitor a
+  // larger design that drives rv_dm itself.
+  //
+  // The flag is defined as a wire with a weak pull-up. This ensures that a testbench that doesn't
+  // customise is_active will see the interface be driven actively, but allows a testbench that
+  // *does* want to customise the signal to pull it low.
+  wire is_active;
+  assign (weak0, weak1) is_active = 1'b1;
 
-  // DUT outputs.
-  wire ndmreset_req;
-  wire dmactive;
+  // The signals connected to ports of rv_dm, other than the TL, alert, RACL and JTAG interfaces.
+  // These have the same name as the port, but without an _i or _o suffix.
+  wire                 scan_rst_n;
+  wire                 ndmreset_req;
+  wire                 dmactive;
   wire [NUM_HARTS-1:0] debug_req;
+  wire [NUM_HARTS-1:0] unavailable;
 
-  // Disable TLUL host SBA assertions when injecting intg errors on the response channel.
-  bit disable_tlul_assert_host_sba_resp_svas;
+  // "Internal" versions of the per-port signals above for rv_dm's input ports
+  logic                 scan_rst_n_internal;
+  logic [NUM_HARTS-1:0] unavailable_internal;
 
+  // Drive the wire signals for rv_dm's input ports if is_active is true
+  assign scan_rst_n  = is_active ? scan_rst_n_internal  : 'z;
+  assign unavailable = is_active ? unavailable_internal : 'z;
+
+  // A clocking block for driving the various _internal signals that are all synchronous to clk. If
+  // is_active is true, these can be used to drive input ports of rv_dm. The signals from output
+  // ports of rv_dm can also be sampled through this clocking block.
   clocking cb @(posedge clk);
-    output scan_rst_n;
-    output unavailable;
+    input  ndmreset_req;
+    input  dmactive;
+    input  debug_req;
+    output scan_rst_n = scan_rst_n_internal;
+    output unavailable = unavailable_internal;
+  endclocking
+
+  // A clocking block for a monitor
+  clocking mon_cb @(posedge clk);
     input ndmreset_req;
     input dmactive;
     input debug_req;
+    input unavailable;
   endclocking
+
+  // Disable TLUL host SBA assertions when injecting intg errors on the response channel.
+  bit disable_tlul_assert_host_sba_resp_svas;
 
 endinterface

--- a/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
@@ -177,6 +177,12 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
     end
   endtask
 
+  // Return true if the top-level lc_hw_debug_en_i signal (monitored through
+  // cfg.m_mode_agent_cfg.vif) is On
+  local function bit is_lc_hw_debug_en();
+    return cfg.m_mode_agent_cfg.vif.mon_cb.lc_hw_debug_en === lc_ctrl_pkg::On;
+  endfunction
+
   // Receive and process incoming predicted complete SBA accesses.
   virtual task process_sba_access_fifo();
     sba_access_item item;
@@ -195,7 +201,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
 
       // If the debugger is not enabled and cfg.sba_tl_tx_requires_debug=1 then we should not have
       // seen the SBA item translate into a TL access.
-      if (cfg.sba_tl_tx_requires_debug && cfg.rv_dm_vif.lc_hw_debug_en != lc_ctrl_pkg::On) begin
+      if (cfg.sba_tl_tx_requires_debug && !is_lc_hw_debug_en()) begin
         `DV_CHECK(sba_tl_access_q.size() == 0)
       end
 
@@ -213,7 +219,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
       `uvm_info(`gfn, $sformatf("Received SBA TL a_chan item:\n%0s",
                                 item.sprint(uvm_default_line_printer)), UVM_HIGH)
       if (cfg.sba_tl_tx_requires_debug) begin
-        `DV_CHECK(cfg.rv_dm_vif.lc_hw_debug_en == lc_ctrl_pkg::On,
+        `DV_CHECK(is_lc_hw_debug_en(),
                   "Received an SBA TL item when SBA should have been disabled.")
       end
 
@@ -228,7 +234,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
       `uvm_info(`gfn, $sformatf("Received SBA TL d_chan item:\n%0s",
                                 item.sprint(uvm_default_line_printer)), UVM_HIGH)
       if (cfg.sba_tl_tx_requires_debug) begin
-        `DV_CHECK(cfg.rv_dm_vif.lc_hw_debug_en == lc_ctrl_pkg::On,
+        `DV_CHECK(is_lc_hw_debug_en(),
                   "Received an SBA TL item when SBA should have been disabled.")
       end
       sba_tl_access_q.push_back(item);
@@ -416,7 +422,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
 
   // Return true if we're using late debug enable, based on top-level inputs and register state.
   function logic using_late_debug_enable();
-    prim_mubi_pkg::mubi8_t  pin_val = cfg.rv_dm_vif.otp_dis_rv_dm_late_debug;
+    prim_mubi_pkg::mubi8_t  pin_val = cfg.m_mode_agent_cfg.vif.otp_dis_rv_dm_late_debug;
     prim_mubi_pkg::mubi32_t reg_val = prim_mubi_pkg::mubi32_t'(`gmv(ral.late_debug_enable));
     return (prim_mubi_pkg::mubi8_test_true_strict(pin_val) ||
             prim_mubi_pkg::mubi32_test_true_strict(reg_val));
@@ -425,9 +431,9 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
   // Return whether debug is supposed to be enabled, based on whether we're using late debug enable
   // and on top-level inputs.
   function logic is_debug_enabled();
-    return lc_ctrl_pkg::lc_tx_test_true_strict(using_late_debug_enable ?
-                                               cfg.rv_dm_vif.lc_hw_debug_en :
-                                               cfg.rv_dm_vif.lc_dft_en);
+    return lc_ctrl_pkg::lc_tx_test_true_strict(using_late_debug_enable() ?
+                                               cfg.m_mode_agent_cfg.vif.mon_cb.lc_hw_debug_en :
+                                               cfg.m_mode_agent_cfg.vif.mon_cb.lc_dft_en);
   endfunction
 
   // This overrides a function in cip_base_scoreboard. The problem is that when debug is not

--- a/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
@@ -177,6 +177,12 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
     end
   endtask
 
+  // Return true if the top-level lc_hw_debug_en_i signal (monitored through
+  // cfg.m_mode_agent_cfg.vif) is On
+  local function bit is_lc_hw_debug_en();
+    return cfg.m_mode_agent_cfg.vif.mon_cb.lc_hw_debug_en === lc_ctrl_pkg::On;
+  endfunction
+
   // Receive and process incoming predicted complete SBA accesses.
   virtual task process_sba_access_fifo();
     sba_access_item item;
@@ -195,7 +201,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
 
       // If the debugger is not enabled and cfg.sba_tl_tx_requires_debug=1 then we should not have
       // seen the SBA item translate into a TL access.
-      if (cfg.sba_tl_tx_requires_debug && cfg.rv_dm_vif.lc_hw_debug_en != lc_ctrl_pkg::On) begin
+      if (cfg.sba_tl_tx_requires_debug && !is_lc_hw_debug_en()) begin
         `DV_CHECK(sba_tl_access_q.size() == 0)
       end
 
@@ -213,7 +219,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
       `uvm_info(`gfn, $sformatf("Received SBA TL a_chan item:\n%0s",
                                 item.sprint(uvm_default_line_printer)), UVM_HIGH)
       if (cfg.sba_tl_tx_requires_debug) begin
-        `DV_CHECK(cfg.rv_dm_vif.lc_hw_debug_en == lc_ctrl_pkg::On,
+        `DV_CHECK(is_lc_hw_debug_en(),
                   "Received an SBA TL item when SBA should have been disabled.")
       end
 
@@ -228,7 +234,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
       `uvm_info(`gfn, $sformatf("Received SBA TL d_chan item:\n%0s",
                                 item.sprint(uvm_default_line_printer)), UVM_HIGH)
       if (cfg.sba_tl_tx_requires_debug) begin
-        `DV_CHECK(cfg.rv_dm_vif.lc_hw_debug_en == lc_ctrl_pkg::On,
+        `DV_CHECK(is_lc_hw_debug_en(),
                   "Received an SBA TL item when SBA should have been disabled.")
       end
       sba_tl_access_q.push_back(item);
@@ -482,7 +488,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
 
   // Return true if we're using late debug enable, based on top-level inputs and register state.
   function logic using_late_debug_enable();
-    prim_mubi_pkg::mubi8_t  pin_val = cfg.rv_dm_vif.otp_dis_rv_dm_late_debug;
+    prim_mubi_pkg::mubi8_t  pin_val = cfg.m_mode_agent_cfg.vif.otp_dis_rv_dm_late_debug;
     prim_mubi_pkg::mubi32_t reg_val = prim_mubi_pkg::mubi32_t'(`gmv(ral.late_debug_enable));
     return (prim_mubi_pkg::mubi8_test_true_strict(pin_val) ||
             prim_mubi_pkg::mubi32_test_true_strict(reg_val));
@@ -491,9 +497,9 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
   // Return whether debug is supposed to be enabled, based on whether we're using late debug enable
   // and on top-level inputs.
   function logic is_debug_enabled();
-    return lc_ctrl_pkg::lc_tx_test_true_strict(using_late_debug_enable ?
-                                               cfg.rv_dm_vif.lc_hw_debug_en :
-                                               cfg.rv_dm_vif.lc_dft_en);
+    return lc_ctrl_pkg::lc_tx_test_true_strict(using_late_debug_enable() ?
+                                               cfg.m_mode_agent_cfg.vif.mon_cb.lc_hw_debug_en :
+                                               cfg.m_mode_agent_cfg.vif.mon_cb.lc_dft_en);
   endfunction
 
   // This overrides a function in cip_base_scoreboard. The problem is that when debug is not

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -271,21 +271,21 @@ class rv_dm_base_vseq extends cip_base_vseq #(
     uint delay;
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(delay, delay inside {[0:1000]};) // ns
     #(delay * 1ns);
-    cfg.rv_dm_vif.cb.scan_rst_n <= 1'b0;
+    cfg.rv_dm_vif.scan_rst_n_internal <= 1'b0;
     // Wait for core clock cycles.
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(delay, delay inside {[2:50]};) // cycles
     cfg.clk_rst_vif.wait_clks(delay);
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(delay, delay inside {[0:1000]};) // ns
-    cfg.rv_dm_vif.cb.scan_rst_n <= 1'b1;
+    cfg.rv_dm_vif.scan_rst_n_internal <= 1'b1;
   endtask
 
   virtual task apply_resets_concurrently(int reset_duration_ps = 0);
     int trst_n_duration_ps = cfg.m_jtag_agent_cfg.vif.get_tck_period_ps() * $urandom_range(5, 20);
-    cfg.rv_dm_vif.cb.scan_rst_n <= 1'b0;
+    cfg.rv_dm_vif.scan_rst_n_internal <= 1'b0;
     cfg.m_jtag_agent_cfg.vif.assert_test_reset();
     super.apply_resets_concurrently(dv_utils_pkg::max2(reset_duration_ps, trst_n_duration_ps));
     cfg.m_jtag_agent_cfg.vif.clear_test_reset();
-    cfg.rv_dm_vif.cb.scan_rst_n <= 1'b1;
+    cfg.rv_dm_vif.scan_rst_n_internal <= 1'b1;
   endtask
 
   virtual task dut_shutdown();
@@ -358,7 +358,7 @@ class rv_dm_base_vseq extends cip_base_vseq #(
 
     csr_wr(.ptr(jtag_dmi_ral.dmcontrol.haltreq), .value(1));
     if (!cfg.clk_rst_vif.rst_n) return;
-    `DV_CHECK_EQ(cfg.rv_dm_vif.cb.debug_req, 1)
+    `DV_CHECK_EQ(cfg.rv_dm_vif.mon_cb.debug_req, 1)
 
     // Wait a short time (up to 10 cycles, but stopping early if there's a reset)
     fork begin : isolation_fork

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -11,6 +11,9 @@ class rv_dm_base_vseq extends cip_base_vseq #(
   `uvm_object_utils(rv_dm_base_vseq)
   `uvm_object_new
 
+  // Configuration for running sequences
+  rv_dm_mode_sequencer m_mode_sequencer;
+
   // These flags control "late debug enable". The mode (late_debug_enable) gets randomized in
   // pre_start and it takes effect either through a top-level pin (pin_late_debug_enable) or a
   // register (reg_late_debug_enable).
@@ -18,7 +21,7 @@ class rv_dm_base_vseq extends cip_base_vseq #(
   // When one of this inputs is mubi true, the "debug enable" check is made on lc_hw_debug_en_i
   // instead of lc_dft_en_i.
   rand bit late_debug_enable;
-  rand bit pin_late_debug_enable;
+  rand bit pin_disable_late_debug;
   rand bit reg_late_debug_enable;
 
   // This flag controls whether the pinmux_hw_debug_en_i signal is set to On. This determines
@@ -101,10 +104,10 @@ class rv_dm_base_vseq extends cip_base_vseq #(
     cfg.en_scb == 1'b0 -> reg_late_debug_enable == 1'b0;
   }
 
-  // A constraint to make sure that pin_late_debug_enable and reg_late_debug_enable correctly
+  // A constraint to make sure that pin_disable_late_debug and reg_late_debug_enable correctly
   // implement the intent in the late_debug_enable bit.
   constraint late_debug_enable_split_c {
-    late_debug_enable == pin_late_debug_enable || reg_late_debug_enable;
+    late_debug_enable == (!pin_disable_late_debug) || reg_late_debug_enable;
   }
 
   // SBA TL device sequence. Class member for more controllability.
@@ -125,37 +128,73 @@ class rv_dm_base_vseq extends cip_base_vseq #(
   endfunction
 
   task pre_start();
-    cfg.rv_dm_vif.scanmode <= bool_to_mubi4_t(scanmode);
+    rv_dm_mode_seq mode_seq;
+    bit strap_en = 1'b0;
 
-    cfg.rv_dm_vif.unavailable <= unavailable;
+    // Before starting, check that the virtual sequence has been configured
+    if (m_mode_sequencer == null) `uvm_fatal(get_name(), "m_mode_sequencer not configured.")
 
-    cfg.rv_dm_vif.lc_dft_en <= bool_to_lc_tx_t(lc_dft_en);
-
-    cfg.rv_dm_vif.lc_check_byp_en <= lc_ctrl_pkg::Off;
-    cfg.rv_dm_vif.lc_escalate_en <= lc_ctrl_pkg::Off;
-    cfg.rv_dm_vif.strap_en_override <= 1'b0;
 `ifdef USE_DMI_INTERFACE
     // TODO: revisit this. In order to operate in DMI mode we need to assert `strap_en`.
-    cfg.rv_dm_vif.strap_en <= 1'b1;
-`else
-    cfg.rv_dm_vif.strap_en <= 1'b0;
+    strap_en = 1'b1;
 `endif
 
-    // Drive the otp_dis_rv_dm_late_debug_i pin to match pin_late_debug_enable (to avoid assertions
-    // that get triggered in prim_lc_sync/prim_mubi8_sync if the input is 'x). We will configure the
-    // register a little later, in dut_init.
-    set_late_debug_enable_with_pin(pin_late_debug_enable);
+    mode_seq = rv_dm_mode_seq::type_id::create("mode_seq");
+    mode_seq.m_has_lc_ctrl_signals = 1'b1;
+    mode_seq.m_has_pinmux_signals = 1'b1;
+    mode_seq.m_has_pwrmgr_signals = 1'b1;
+    mode_seq.m_has_otp_ctrl_signals = 1'b1;
+    mode_seq.m_has_scanmode = 1'b1;
 
-    // Drive the pinmux_hw_debug_en_i pin to match the pinmux_hw_debug_en bit, avoiding assertions
-    // that get triggered in prim_lc_sync if the input is 'x.
-    upd_pinmux_hw_debug_en();
+    if (!mode_seq.randomize() with {
+          // Signals from lc_ctrl //////////////////////////////////////////////////////////////////
+          //
+          // The lc_hw_debug_clr signal in the item is always given a valid lc_tx_t encoding that
+          // match the bit value in the vseq.
+          m_lc_hw_debug_clr == local::lc_hw_debug_clr;
+          m_lc_hw_debug_clr_valid == 1;
 
-    // Drive the lc_hw_debug_en_i pin to match the lc_hw_debug_en bit, avoiding assertions that get
-    // triggered in prim_lc_sync if the input is 'x.
-    upd_lc_hw_debug_en();
+          // We don't need to specify validity of the encoding for lc_hw_debug_en, lc_dft_en or
+          // lc_init_done. The sequence will choose On if the signal is true and an arbitrary value
+          // other than On otherwise.
+           m_lc_hw_debug_en == local::lc_hw_debug_en;
+           m_lc_dft_en      == local::lc_dft_en;
+           m_lc_init_done   == local::lc_init_done;
 
-    // Drive the lc_init_done_i pin to match the lc_init_done bit
-    upd_lc_init_done();
+           // Set lc_escalate_en and lc_check_byp_en to Off. (Don't escalate; Don't claim a
+           // life-cycle transition in rv_dm_dmi_gate)
+           m_lc_escalate_en  == 1'b0;
+           m_lc_check_byp_en == 1'b0;
+
+           m_strap_en_override == 1'b0;
+
+          // Signals from pinmux ///////////////////////////////////////////////////////////////////
+          //
+          // The sequence will choose On for pinmux_hw_debug_en if the signal is true and an
+          // arbitrary value other than On otherwise.
+           m_pinmux_hw_debug_en == local::pinmux_hw_debug_en;
+
+          // Signals from pwrmgr ///////////////////////////////////////////////////////////////////
+           m_strap_en == local::strap_en;
+
+          // Signals from otp_ctrl /////////////////////////////////////////////////////////////////
+          //
+          // The sequence will choose MuBi8False for m_otp_dis_rv_dm_late_debug if the signal is
+          // false and an arbitrary value other than MuBi8False otherwise.
+           m_otp_dis_rv_dm_late_debug == local::pin_disable_late_debug;
+
+           // Scanmode signal
+           //
+           // The sequence will choose MuBi4True for m_scanmode if the signal is true and an
+           // arbitrary value other than MuBi4True otherwise.
+           m_scanmode == local::scanmode;
+         }) begin
+      `uvm_fatal(get_name(), "Failed to randomize mode sequence.")
+    end
+
+    mode_seq.start(m_mode_sequencer);
+
+    cfg.rv_dm_vif.cb.unavailable <= unavailable;
 
     super.pre_start();
   endtask
@@ -369,52 +408,14 @@ class rv_dm_base_vseq extends cip_base_vseq #(
     return val;
   endfunction
 
-  function lc_ctrl_pkg::lc_tx_t bool_to_lc_tx_t(bit bool_val);
-    return lc_ctrl_pkg::lc_tx_t'(bool_to_something(bool_val, 4, lc_ctrl_pkg::On));
-  endfunction
-
-  function prim_mubi_pkg::mubi4_t bool_to_mubi4_t(bit bool_val);
-    return prim_mubi_pkg::mubi4_t'(bool_to_something(bool_val, 4, prim_mubi_pkg::MuBi4True));
-  endfunction
-
-  function prim_mubi_pkg::mubi8_t bool_to_mubi8_t(bit bool_val);
-    return prim_mubi_pkg::mubi8_t'(bool_to_something(bool_val, 8, prim_mubi_pkg::MuBi8True));
-  endfunction
-
   function prim_mubi_pkg::mubi32_t bool_to_mubi32_t(bit bool_val);
     return prim_mubi_pkg::mubi32_t'(bool_to_something(bool_val, 32, prim_mubi_pkg::MuBi32True));
-  endfunction
-
-  // Set the otp_dis_rv_dm_late_debug_i pin to a t/f value matching bool_val.
-  function void set_late_debug_enable_with_pin(bit bool_val);
-    cfg.rv_dm_vif.otp_dis_rv_dm_late_debug <= bool_to_mubi8_t(bool_val);
   endfunction
 
   // Write to the late_debug_enable register with a t/f value matching bool_val.
   virtual task set_late_debug_enable_with_reg(bit bool_val);
     csr_wr(.ptr(ral.late_debug_enable), .value(bool_to_mubi32_t(bool_val)));
   endtask
-
-  // Update the pinmux_hw_debug_en_i pin to match the bit in pinmux_hw_debug_en
-  function void upd_pinmux_hw_debug_en();
-    cfg.rv_dm_vif.pinmux_hw_debug_en <= bool_to_lc_tx_t(pinmux_hw_debug_en);
-  endfunction
-
-  // Update the lc_init_done_i pin to match the bit in lc_init_done
-  function void upd_lc_init_done();
-    cfg.rv_dm_vif.lc_init_done <= bool_to_lc_tx_t(lc_init_done);
-  endfunction
-
-  // Update the lc_hw_debug_clr_i and lc_hw_debug_en_i pins to match the bit in lc_hw_debug_clr and
-  // lc_hw_debug_en, respectively.
-  function void upd_lc_hw_debug_en();
-    // The `bool_to_lc_tx_t` function converts a bit type to a lc_tx_t type by mapping `1` to `On`
-    // and `0` to a random non-`On` value. For `lc_hw_debug_clr`, this is not what we want, though,
-    // because the DUT will interpret a non-`Off` value as `On`. Hence the ternary statement below
-    // instead maps `0` to `Off`.
-    cfg.rv_dm_vif.lc_hw_debug_clr <= lc_hw_debug_clr ? lc_ctrl_pkg::On : lc_ctrl_pkg::Off;
-    cfg.rv_dm_vif.lc_hw_debug_en <= bool_to_lc_tx_t(lc_hw_debug_en);
-  endfunction
 
   // Read the dtmcs register and check the dmistat field has the expected value, skipping the check
   // if the system is in reset.
@@ -517,4 +518,38 @@ class rv_dm_base_vseq extends cip_base_vseq #(
     // This should now have cleared the pending reset flag. Make sure it is clear.
     check_ndmreset_pending(1'b0);
   endtask
+
+  protected task upd_lc_hw_debug_en();
+    rv_dm_mode_seq mode_seq = rv_dm_mode_seq::type_id::create("mode_seq");
+    mode_seq.m_has_lc_ctrl_signals = 1'b1;
+
+    if (!mode_seq.randomize() with {
+          m_lc_hw_debug_clr == local::lc_hw_debug_clr;
+          m_lc_hw_debug_clr_valid == 1;
+          m_lc_hw_debug_en == local::lc_hw_debug_en;
+          m_lc_dft_en == local::lc_dft_en;
+          m_lc_init_done == local::lc_init_done;
+          m_lc_check_byp_en == 1'b0;
+          m_lc_escalate_en == 1'b0;
+          m_strap_en_override == 1'b0;
+        }) begin
+      `uvm_fatal(get_name(), "Failed to randomize mode sequence.")
+    end
+
+    mode_seq.start(m_mode_sequencer);
+  endtask
+
+  protected task upd_pinmux_hw_debug_en();
+    rv_dm_mode_seq mode_seq = rv_dm_mode_seq::type_id::create("mode_seq");
+    mode_seq.m_has_pinmux_signals = 1'b1;
+
+    if (!mode_seq.randomize() with {
+           m_pinmux_hw_debug_en == local::pinmux_hw_debug_en;
+         }) begin
+      `uvm_fatal(get_name(), "Failed to randomize mode sequence.")
+    end
+
+    mode_seq.start(m_mode_sequencer);
+  endtask
+
 endclass : rv_dm_base_vseq

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_debug_disabled_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_debug_disabled_vseq.sv
@@ -53,7 +53,8 @@ class rv_dm_debug_disabled_vseq extends rv_dm_base_vseq;
       // make sure it has had an effect.
       upd_lc_hw_debug_en();
       `uvm_info(`gfn,
-                $sformatf("Setting lc_hw_debug_en to %0x", cfg.rv_dm_vif.lc_hw_debug_en),
+                $sformatf("Setting lc_hw_debug_en to %0x",
+                          cfg.m_mode_agent_cfg.vif.mon_cb.lc_hw_debug_en),
                 UVM_LOW)
       cfg.clk_rst_vif.wait_clks(10);
 

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_mem_tl_access_halted_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_mem_tl_access_halted_vseq.sv
@@ -11,7 +11,7 @@ class rv_dm_mem_tl_access_halted_vseq extends rv_dm_base_vseq;
     uvm_reg_data_t r_data;
     // Disable unavailable signal to make sure that hart should be in known state. if hart
     // is unavailable then it could not halted.
-    cfg.rv_dm_vif.unavailable <= 0;
+    cfg.rv_dm_vif.cb.unavailable <= 0;
 
     // Make sure that the ndmreset signal is not currently asserted. If it is asserted then DMI
     // operations work but the TLUL connection is blocked by u_tlul_lc_gate_rom, which is held in

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_mem_tl_access_resuming_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_mem_tl_access_resuming_vseq.sv
@@ -44,7 +44,7 @@ class rv_dm_mem_tl_access_resuming_vseq extends rv_dm_base_vseq;
 
     // Disable unavailable signal to make sure that hart should be in known
     // state. If hart is unavailable then it could not halted.
-    cfg.rv_dm_vif.unavailable <= 0;
+    cfg.rv_dm_vif.cb.unavailable <= 0;
 
     // Request a halt as the debugger and then acknowledge it as the hart.
     request_halt();

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_smoke_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_smoke_vseq.sv
@@ -59,9 +59,9 @@ class rv_dm_smoke_vseq extends rv_dm_base_vseq;
     cfg.rv_dm_vif.cb.unavailable <= data;
     csr_rd(.ptr(jtag_dmi_ral.dmstatus), .value(data));
     if (cfg.clk_rst_vif.rst_n) begin
-      `DV_CHECK_EQ(cfg.rv_dm_vif.unavailable,
+      `DV_CHECK_EQ(cfg.rv_dm_vif.mon_cb.unavailable,
                    get_field_val(jtag_dmi_ral.dmstatus.anyunavail, data))
-      `DV_CHECK_EQ(cfg.rv_dm_vif.unavailable,
+      `DV_CHECK_EQ(cfg.rv_dm_vif.mon_cb.unavailable,
                    get_field_val(jtag_dmi_ral.dmstatus.allunavail, data))
     end
   endtask

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_stress_all_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_stress_all_vseq.sv
@@ -45,7 +45,7 @@ class rv_dm_stress_all_vseq extends rv_dm_base_vseq;
       if (do_apply_reset) rv_dm_vseq.do_apply_reset = $urandom_range(0, 1);
       else                rv_dm_vseq.do_apply_reset = 0;
 
-      rv_dm_vseq.set_sequencer(p_sequencer);
+      configure_child_vseq(rv_dm_vseq);
       `DV_CHECK_RANDOMIZE_FATAL(rv_dm_vseq)
       rv_dm_vseq.start(p_sequencer);
 
@@ -56,5 +56,11 @@ class rv_dm_stress_all_vseq extends rv_dm_base_vseq;
       if (!cfg.clk_rst_vif.rst_n) return;
      end
    endtask
+
+  // Set sequencers in the child vseq to match the ones used in this virtual sequence
+  function void configure_child_vseq(rv_dm_base_vseq child_vseq);
+    child_vseq.set_sequencer(p_sequencer);
+    child_vseq.m_mode_sequencer = m_mode_sequencer;
+  endfunction
 
 endclass : rv_dm_stress_all_vseq

--- a/hw/ip/rv_dm/dv/rv_dm_mode_agent/rv_dm_mode_agent.core
+++ b/hw/ip/rv_dm/dv/rv_dm_mode_agent/rv_dm_mode_agent.core
@@ -1,0 +1,29 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:rv_dm_mode_agent"
+description: "Agent that drives 'mode' signals (dft, LC etc.) for rv_dm"
+
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:prim:all:0.1
+      - lowrisc:dv:dv_lib
+      - lowrisc:prim:mubi_pkg
+      - lowrisc:ip:lc_ctrl_pkg
+    files:
+      - rv_dm_mode_if.sv
+      - rv_dm_mode_agent_pkg.sv
+      - rv_dm_mode_agent_cfg.svh: {is_include_file: true}
+      - rv_dm_mode_driver.svh: {is_include_file: true}
+      - rv_dm_mode_monitor.svh: {is_include_file: true}
+      - rv_dm_mode_agent.svh: {is_include_file: true}
+      - rv_dm_mode_seq_item.svh: {is_include_file: true}
+      - seq/rv_dm_mode_seq.svh: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/ip/rv_dm/dv/rv_dm_mode_agent/rv_dm_mode_agent.svh
+++ b/hw/ip/rv_dm/dv/rv_dm_mode_agent/rv_dm_mode_agent.svh
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class rv_dm_mode_agent extends dv_base_agent #(.CFG_T      (rv_dm_mode_agent_cfg),
+                                               .DRIVER_T   (rv_dm_mode_driver),
+                                               .SEQUENCER_T(rv_dm_mode_sequencer),
+                                               .MONITOR_T  (rv_dm_mode_monitor));
+  `uvm_component_utils(rv_dm_mode_agent)
+
+  extern function new (string name, uvm_component parent);
+  extern function void build_phase(uvm_phase phase);
+endclass
+
+function rv_dm_mode_agent::new (string name, uvm_component parent);
+  super.new(name, parent);
+endfunction
+
+function void rv_dm_mode_agent::build_phase(uvm_phase phase);
+  super.build_phase(phase);
+
+  // If cfg.vif isn't already supplied, look up a vif interface handle in the config db.
+  if (cfg.vif == null &&
+      !uvm_config_db#(virtual rv_dm_mode_if)::get(this, "", "vif", cfg.vif)) begin
+    `uvm_fatal(get_full_name(), "Failed to get vif from from uvm_config_db")
+  end
+
+  // If the agent is configured to be active, make sure that the is_active flag in the interface is
+  // also set: if it isn't our updates to the *_internal signals will have no effect.
+  if (cfg.is_active && !cfg.vif.is_active) begin
+    `uvm_error(get_full_name(), "Agent is active but the interface's is_active signal is false.")
+  end
+endfunction

--- a/hw/ip/rv_dm/dv/rv_dm_mode_agent/rv_dm_mode_agent_cfg.svh
+++ b/hw/ip/rv_dm/dv/rv_dm_mode_agent/rv_dm_mode_agent_cfg.svh
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Configuration class for rv_dm_mode_agent
+
+class rv_dm_mode_agent_cfg extends dv_base_agent_cfg;
+  `uvm_object_utils(rv_dm_mode_agent_cfg)
+
+  virtual rv_dm_mode_if vif;
+
+  extern function new (string name="");
+endclass
+
+function rv_dm_mode_agent_cfg::new (string name="");
+  super.new(name);
+endfunction

--- a/hw/ip/rv_dm/dv/rv_dm_mode_agent/rv_dm_mode_agent_pkg.sv
+++ b/hw/ip/rv_dm/dv/rv_dm_mode_agent/rv_dm_mode_agent_pkg.sv
@@ -1,0 +1,29 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package rv_dm_mode_agent_pkg;
+  import uvm_pkg::*;
+  `include "uvm_macros.svh"
+
+  import dv_base_agent_pkg::dv_base_agent_cfg;
+  import dv_base_agent_pkg::dv_base_agent;
+  import dv_base_agent_pkg::dv_base_driver;
+  import dv_base_agent_pkg::dv_base_monitor;
+  import dv_base_agent_pkg::dv_base_sequencer;
+  import dv_base_agent_pkg::dv_base_seq;
+
+  import lc_ctrl_pkg::lc_tx_t;
+  import prim_mubi_pkg::mubi4_t, prim_mubi_pkg::mubi8_t;
+
+  `include "rv_dm_mode_agent_cfg.svh"
+  `include "rv_dm_mode_seq_item.svh"
+  `include "rv_dm_mode_driver.svh"
+  `include "rv_dm_mode_monitor.svh"
+
+  typedef dv_base_sequencer #(.ITEM_T(rv_dm_mode_seq_item)) rv_dm_mode_sequencer;
+
+  `include "rv_dm_mode_agent.svh"
+
+  `include "seq/rv_dm_mode_seq.svh"
+endpackage

--- a/hw/ip/rv_dm/dv/rv_dm_mode_agent/rv_dm_mode_driver.svh
+++ b/hw/ip/rv_dm/dv/rv_dm_mode_agent/rv_dm_mode_driver.svh
@@ -1,0 +1,63 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Driver that sends rv_dm mode updates
+
+class rv_dm_mode_driver extends dv_base_driver #(rv_dm_mode_seq_item, rv_dm_mode_agent_cfg);
+  `uvm_component_utils(rv_dm_mode_driver)
+
+  extern function new (string name, uvm_component parent);
+  extern virtual task get_and_drive();
+  extern virtual task on_enter_reset();
+endclass
+
+function rv_dm_mode_driver::new (string name, uvm_component parent);
+  super.new(name, parent);
+endfunction
+
+task rv_dm_mode_driver::get_and_drive();
+  forever begin
+    rv_dm_mode_seq_item item;
+    seq_item_port.get_next_item(item);
+
+    `uvm_info("rjs", $sformatf("Setting rv_dm mode:\n%0s", item.sprint()), UVM_HIGH)
+
+    // If we aren't in reset, drive the signals from the item (possibly through a clocking block)
+    if (item.m_has_next_dm_addr) begin
+      cfg.vif.next_dm_addr_internal <= item.m_next_dm_addr;
+    end
+
+    if (item.m_has_lc_ctrl_signals) begin
+      cfg.vif.cb.lc_hw_debug_clr <= lc_tx_t'(item.m_lc_hw_debug_clr);
+      cfg.vif.cb.lc_hw_debug_en <= lc_tx_t'(item.m_lc_hw_debug_en);
+      cfg.vif.cb.lc_dft_en <= lc_tx_t'(item.m_lc_dft_en);
+      cfg.vif.cb.lc_check_byp_en <= lc_tx_t'(item.m_lc_check_byp_en);
+      cfg.vif.cb.lc_escalate_en <= lc_tx_t'(item.m_lc_escalate_en);
+      cfg.vif.cb.lc_init_done <= lc_tx_t'(item.m_lc_init_done);
+      cfg.vif.cb.strap_en_override <= item.m_strap_en_override;
+    end
+
+    if (item.m_has_pinmux_signals) begin
+      cfg.vif.cb.pinmux_hw_debug_en <= lc_tx_t'(item.m_pinmux_hw_debug_en);
+    end
+
+    if (item.m_has_pwrmgr_signals) begin
+      cfg.vif.strap_en_internal <= item.m_strap_en;
+    end
+
+    if (item.m_has_otp_ctrl_signals) begin
+      cfg.vif.otp_dis_rv_dm_late_debug_internal <= mubi8_t'(item.m_otp_dis_rv_dm_late_debug);
+    end
+
+    if (item.m_has_scanmode) begin
+      cfg.vif.scanmode_internal <= mubi4_t'(item.m_scanmode);
+    end
+
+    seq_item_port.item_done(item);
+  end
+endtask
+
+task rv_dm_mode_driver::on_enter_reset();
+  // Nothing to do for this driver: there isn't actually a reset on the interface.
+endtask

--- a/hw/ip/rv_dm/dv/rv_dm_mode_agent/rv_dm_mode_driver.svh
+++ b/hw/ip/rv_dm/dv/rv_dm_mode_agent/rv_dm_mode_driver.svh
@@ -1,0 +1,66 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Driver that sends rv_dm mode updates
+
+class rv_dm_mode_driver extends dv_base_driver #(rv_dm_mode_seq_item, rv_dm_mode_agent_cfg);
+  `uvm_component_utils(rv_dm_mode_driver)
+
+  extern function new (string name, uvm_component parent);
+  extern virtual task get_and_drive();
+  extern virtual task on_enter_reset();
+endclass
+
+function rv_dm_mode_driver::new (string name, uvm_component parent);
+  super.new(name, parent);
+endfunction
+
+task rv_dm_mode_driver::get_and_drive();
+  forever begin
+    rv_dm_mode_seq_item item;
+    seq_item_port.get_next_item(item);
+
+    `uvm_info("rjs", "Sending mode item", UVM_LOW)
+
+    // If we aren't in reset, drive the signals from the item (possibly through a clocking block)
+    if (item.m_has_next_dm_addr) begin
+      cfg.vif.next_dm_addr_internal <= item.m_next_dm_addr;
+    end
+
+    if (item.m_has_lc_ctrl_signals) begin
+      `uvm_info("rjs",
+                $sformatf("Sending lc_ctrl signals (debug clr = %0d)", item.m_lc_hw_debug_clr),
+                UVM_LOW)
+      cfg.vif.cb.lc_hw_debug_clr <= lc_tx_t'(item.m_lc_hw_debug_clr);
+      cfg.vif.cb.lc_hw_debug_en <= lc_tx_t'(item.m_lc_hw_debug_en);
+      cfg.vif.cb.lc_dft_en <= lc_tx_t'(item.m_lc_dft_en);
+      cfg.vif.cb.lc_check_byp_en <= lc_tx_t'(item.m_lc_check_byp_en);
+      cfg.vif.cb.lc_escalate_en <= lc_tx_t'(item.m_lc_escalate_en);
+      cfg.vif.cb.lc_init_done <= lc_tx_t'(item.m_lc_init_done);
+      cfg.vif.cb.strap_en_override <= item.m_strap_en_override;
+    end
+
+    if (item.m_has_pinmux_signals) begin
+      cfg.vif.cb.pinmux_hw_debug_en <= lc_tx_t'(item.m_pinmux_hw_debug_en);
+    end
+
+    if (item.m_has_pwrmgr_signals) begin
+      cfg.vif.strap_en_internal <= item.m_strap_en;
+    end
+
+    if (item.m_has_otp_ctrl_signals) begin
+      cfg.vif.otp_dis_rv_dm_late_debug_internal <= mubi8_t'(item.m_otp_dis_rv_dm_late_debug);
+    end
+
+    if (item.m_has_scanmode) begin
+      cfg.vif.scanmode_internal <= mubi4_t'(item.m_scanmode);
+    end
+
+    seq_item_port.item_done(item);
+  end
+endtask
+
+task rv_dm_mode_driver::on_enter_reset();
+  // Nothing to do for this driver: there isn't actually a reset on the interface.
+endtask

--- a/hw/ip/rv_dm/dv/rv_dm_mode_agent/rv_dm_mode_if.sv
+++ b/hw/ip/rv_dm/dv/rv_dm_mode_agent/rv_dm_mode_if.sv
@@ -1,0 +1,84 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Mode signals for rv_dm
+
+interface rv_dm_mode_if(input clk);
+  import lc_ctrl_pkg::lc_tx_t;
+  import prim_mubi_pkg::mubi8_t, prim_mubi_pkg::mubi4_t;
+
+  // If is_active is true, the signals that will be connected to its input ports are driven by cb.
+  // If is_active is false, they are driven with 'z here, which allows the interface to monitor a
+  // larger design that drives rv_dm itself.
+  //
+  // The flag is defined as a wire with a weak pull-up. This ensures that a testbench that doesn't
+  // customise is_active will see the interface be driven actively, but allows a testbench that
+  // *does* want to customise the signal to pull it low.
+  wire is_active;
+  assign (weak0, weak1) is_active = 1'b1;
+
+  wire [31:0]  next_dm_addr;
+  wire lc_tx_t lc_hw_debug_clr;
+  wire lc_tx_t lc_hw_debug_en;
+  wire lc_tx_t lc_dft_en;
+  wire lc_tx_t pinmux_hw_debug_en;
+  wire lc_tx_t lc_check_byp_en;
+  wire lc_tx_t lc_escalate_en;
+  wire lc_tx_t lc_init_done;
+  wire         strap_en;
+  wire         strap_en_override;
+  wire mubi8_t otp_dis_rv_dm_late_debug;
+  wire mubi4_t scanmode;
+
+  logic [31:0] next_dm_addr_internal;
+  lc_tx_t      lc_hw_debug_clr_internal;
+  lc_tx_t      lc_hw_debug_en_internal;
+  lc_tx_t      lc_dft_en_internal;
+  lc_tx_t      pinmux_hw_debug_en_internal;
+  lc_tx_t      lc_check_byp_en_internal;
+  lc_tx_t      lc_escalate_en_internal;
+  lc_tx_t      lc_init_done_internal;
+  logic        strap_en_internal;
+  logic        strap_en_override_internal;
+  mubi8_t      otp_dis_rv_dm_late_debug_internal;
+  mubi4_t      scanmode_internal;
+
+  assign next_dm_addr             = is_active ? next_dm_addr_internal             : 'z;
+  assign lc_hw_debug_clr          = is_active ? lc_hw_debug_clr_internal          : lc_tx_t'('z);
+  assign lc_hw_debug_en           = is_active ? lc_hw_debug_en_internal           : lc_tx_t'('z);
+  assign lc_dft_en                = is_active ? lc_dft_en_internal                : lc_tx_t'('z);
+  assign pinmux_hw_debug_en       = is_active ? pinmux_hw_debug_en_internal       : lc_tx_t'('z);
+  assign lc_check_byp_en          = is_active ? lc_check_byp_en_internal          : lc_tx_t'('z);
+  assign lc_escalate_en           = is_active ? lc_escalate_en_internal           : lc_tx_t'('z);
+  assign lc_init_done             = is_active ? lc_init_done_internal             : lc_tx_t'('z);
+  assign strap_en                 = is_active ? strap_en_internal                 : 'z;
+  assign strap_en_override        = is_active ? strap_en_override_internal        : 'z;
+  assign otp_dis_rv_dm_late_debug = is_active ? otp_dis_rv_dm_late_debug_internal : mubi8_t'('z);
+  assign scanmode                 = is_active ? scanmode_internal                 : mubi4_t'('z);
+
+  // An active clocking block for all signals that are not expected to be constant and are thus
+  // driven/sampled on the clock.
+  clocking cb @(posedge clk);
+    output lc_hw_debug_clr    = lc_hw_debug_clr_internal;
+    output lc_hw_debug_en     = lc_hw_debug_en_internal;
+    output lc_dft_en          = lc_dft_en_internal;
+    output pinmux_hw_debug_en = pinmux_hw_debug_en_internal;
+    output lc_check_byp_en    = lc_check_byp_en_internal;
+    output lc_escalate_en     = lc_escalate_en_internal;
+    output lc_init_done       = lc_init_done_internal;
+    output strap_en_override  = strap_en_override_internal;
+  endclocking
+
+  // A monitor clocking block for signals that are not expected to be constant.
+  clocking mon_cb @(posedge clk);
+    input lc_hw_debug_clr    = lc_hw_debug_clr;
+    input lc_hw_debug_en     = lc_hw_debug_en;
+    input lc_dft_en          = lc_dft_en;
+    input pinmux_hw_debug_en = pinmux_hw_debug_en;
+    input lc_check_byp_en    = lc_check_byp_en;
+    input lc_escalate_en     = lc_escalate_en;
+    input lc_init_done       = lc_init_done;
+    input strap_en_override  = strap_en_override;
+  endclocking
+endinterface

--- a/hw/ip/rv_dm/dv/rv_dm_mode_agent/rv_dm_mode_monitor.svh
+++ b/hw/ip/rv_dm/dv/rv_dm_mode_agent/rv_dm_mode_monitor.svh
@@ -1,0 +1,60 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Monitor that spots updates to the rv_dm mode pins
+
+class rv_dm_mode_monitor extends dv_base_monitor #(.ITEM_T (rv_dm_mode_seq_item),
+                                                   .CFG_T (rv_dm_mode_agent_cfg));
+  `uvm_component_utils(rv_dm_mode_monitor)
+
+  extern function new (string name, uvm_component parent);
+  extern virtual task run_phase(uvm_phase phase);
+
+  extern local function void take_snapshot();
+endclass
+
+function rv_dm_mode_monitor::new (string name, uvm_component parent);
+  super.new(name, parent);
+endfunction
+
+task rv_dm_mode_monitor::run_phase(uvm_phase phase);
+  fork
+    super.run_phase(phase);
+    forever begin
+      @({cfg.vif.next_dm_addr, cfg.vif.lc_hw_debug_clr, cfg.vif.lc_hw_debug_en, cfg.vif.lc_dft_en,
+         cfg.vif.pinmux_hw_debug_en, cfg.vif.lc_check_byp_en, cfg.vif.lc_escalate_en,
+         cfg.vif.lc_init_done, cfg.vif.strap_en, cfg.vif.strap_en_override,
+         cfg.vif.otp_dis_rv_dm_late_debug, cfg.vif.scanmode});
+      take_snapshot();
+    end
+  join
+endtask
+
+function void rv_dm_mode_monitor::take_snapshot();
+/// HACK  rv_dm_mode_seq_item item = rv_dm_mode_seq_item::type_id::create("item");
+  rv_dm_mode_seq_item item = new;
+
+  // As the monitor, we are filling out all the sections of the item.
+  item.m_has_next_dm_addr     = 1'b1;
+  item.m_has_lc_ctrl_signals  = 1'b1;
+  item.m_has_pinmux_signals   = 1'b1;
+  item.m_has_pwrmgr_signals   = 1'b1;
+  item.m_has_otp_ctrl_signals = 1'b1;
+  item.m_has_scanmode         = 1'b1;
+
+  item.m_next_dm_addr             = cfg.vif.next_dm_addr;
+  item.m_lc_hw_debug_clr          = cfg.vif.lc_hw_debug_clr;
+  item.m_lc_hw_debug_en           = cfg.vif.lc_hw_debug_en;
+  item.m_lc_dft_en                = cfg.vif.lc_dft_en;
+  item.m_pinmux_hw_debug_en       = cfg.vif.pinmux_hw_debug_en;
+  item.m_lc_check_byp_en          = cfg.vif.lc_check_byp_en;
+  item.m_lc_escalate_en           = cfg.vif.lc_escalate_en;
+  item.m_lc_init_done             = cfg.vif.lc_init_done;
+  item.m_strap_en                 = cfg.vif.strap_en;
+  item.m_strap_en_override        = cfg.vif.strap_en_override;
+  item.m_otp_dis_rv_dm_late_debug = cfg.vif.otp_dis_rv_dm_late_debug;
+  item.m_scanmode                 = cfg.vif.scanmode;
+
+  analysis_port.write(item);
+endfunction

--- a/hw/ip/rv_dm/dv/rv_dm_mode_agent/rv_dm_mode_seq_item.svh
+++ b/hw/ip/rv_dm/dv/rv_dm_mode_agent/rv_dm_mode_seq_item.svh
@@ -1,0 +1,167 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Sequence item for mode updates
+//
+// The signals come from various places in the toplevel, and each group has an associated validity
+// flag.
+
+class rv_dm_mode_seq_item extends uvm_sequence_item;
+  `uvm_object_utils(rv_dm_mode_seq_item)
+
+  bit             m_has_next_dm_addr;
+  rand bit [31:0] m_next_dm_addr;
+
+  // Note: The 4-bit values in this section represent values of type lc_tx_t, but we use the raw bit
+  //       vector to allow invalid encodings.
+  bit             m_has_lc_ctrl_signals;
+  rand bit [3:0]  m_lc_hw_debug_clr;
+  rand bit [3:0]  m_lc_hw_debug_en;
+  rand bit [3:0]  m_lc_dft_en;
+  rand bit [3:0]  m_lc_check_byp_en;
+  rand bit [3:0]  m_lc_escalate_en;
+  rand bit [3:0]  m_lc_init_done;
+  rand bit        m_strap_en_override;
+
+  // Note: The 4-bit value represents a value of type lc_tx_t, but we use the raw bit vector to
+  //       allow invalid encodings.
+  bit             m_has_pinmux_signals;
+  rand bit [3:0]  m_pinmux_hw_debug_en;
+
+  bit             m_has_pwrmgr_signals;
+  rand bit        m_strap_en;
+
+  // Note: The 8-bit value represents a value of type mubi8_t, but we use the raw bit vector to
+  //       allow invalid encodings.
+  bit             m_has_otp_ctrl_signals;
+  rand bit [7:0]  m_otp_dis_rv_dm_late_debug;
+
+  // Note: The 4-bit value represents a value of type mubi4_t, but we use the raw bit vector to
+  //       allow invalid encodings.
+  bit             m_has_scanmode;
+  rand bit [3:0]  m_scanmode;
+
+  extern function new (string name="");
+  extern virtual function void do_print(uvm_printer printer);
+
+  // Print an lc_tx_t field to the supplied printer
+  extern static function void print_lc_tx_t_field(uvm_printer printer,
+                                                  string      name,
+                                                  bit [3:0]   value);
+
+  // Print an mubi4_t field to the supplied printer
+  extern static function void print_mubi4_t_field(uvm_printer printer,
+                                                  string      name,
+                                                  bit [3:0]   value);
+
+  // Print an mubi8_t field to the supplied printer
+  extern static function void print_mubi8_t_field(uvm_printer printer,
+                                                  string      name,
+                                                  bit [7:0]   value);
+
+  // A slightly silly constraint that ensures signals that don't claim to be provided are dead zero.
+  // This shouldn't have any effect on the behaviour through the driver, but makes waves and logs a
+  // bit easier to read.
+  extern constraint zero_when_not_provided_c;
+endclass
+
+function rv_dm_mode_seq_item::new (string name="");
+  super.new(name);
+endfunction
+
+function void rv_dm_mode_seq_item::do_print(uvm_printer printer);
+  super.do_print(printer);
+
+  if (m_has_next_dm_addr) begin
+    printer.print_field_int("m_next_dm_addr", m_next_dm_addr, 32);
+  end else begin
+    printer.print_field_int("m_has_next_dm_addr", m_has_next_dm_addr, 1, UVM_BIN);
+  end
+
+  if (m_has_lc_ctrl_signals) begin
+    print_lc_tx_t_field(printer, "m_lc_hw_debug_clr", m_lc_hw_debug_clr);
+    print_lc_tx_t_field(printer, "m_lc_hw_debug_en", m_lc_hw_debug_en);
+    print_lc_tx_t_field(printer, "m_lc_dft_en", m_lc_dft_en);
+    print_lc_tx_t_field(printer, "m_lc_check_byp_en", m_lc_check_byp_en);
+    print_lc_tx_t_field(printer, "m_lc_escalate_en", m_lc_escalate_en);
+    print_lc_tx_t_field(printer, "m_lc_init_done", m_lc_init_done);
+    printer.print_field_int("m_strap_en_override", m_strap_en_override, 1, UVM_BIN);
+  end else begin
+    printer.print_field_int("m_has_lc_ctrl_signals", m_has_lc_ctrl_signals, 1, UVM_BIN);
+  end
+
+  if (m_has_pinmux_signals) begin
+    print_lc_tx_t_field(printer, "m_pinmux_hw_debug_en", m_pinmux_hw_debug_en);
+  end else begin
+    printer.print_field_int("m_has_pinmux_signals", m_has_pinmux_signals, 1, UVM_BIN);
+  end
+
+  if (m_has_pwrmgr_signals) begin
+    printer.print_field_int("m_strap_en", m_strap_en, 1, UVM_BIN);
+  end else begin
+    printer.print_field_int("m_has_pwrmgr_signals", m_has_pwrmgr_signals, 1, UVM_BIN);
+  end
+
+  if (m_has_otp_ctrl_signals) begin
+    print_mubi8_t_field(printer, "m_otp_dis_rv_dm_late_debug", m_otp_dis_rv_dm_late_debug);
+  end else begin
+    printer.print_field_int("m_has_otp_ctrl_signals", m_has_otp_ctrl_signals, 1, UVM_BIN);
+  end
+
+  if (m_has_scanmode) begin
+    print_mubi4_t_field(printer, "m_scanmode", m_scanmode);
+  end else begin
+    printer.print_field_int("m_has_scanmode", m_has_scanmode, 1, UVM_BIN);
+  end
+endfunction
+
+function void rv_dm_mode_seq_item::print_lc_tx_t_field(uvm_printer printer,
+                                                       string      name,
+                                                       bit [3:0]   value);
+  lc_tx_t as_enum = lc_tx_t'(value);
+  string  str = as_enum.name();
+
+  if (str == "") begin
+    str = "(?)";
+  end
+
+  printer.print_generic(name, "lc_tx_t", 4, $sformatf("%-3s = 4'b%04b", str, value));
+endfunction
+
+function void rv_dm_mode_seq_item::print_mubi4_t_field(uvm_printer printer,
+                                                       string      name,
+                                                       bit [3:0]   value);
+  mubi4_t as_enum = mubi4_t'(value);
+  string  str = as_enum.name();
+
+  if (str == "") begin
+    str = "(?)";
+  end
+
+  printer.print_generic(name, "mubi4_t", 4, $sformatf("%-10s = 4'b%04b", str, value));
+endfunction
+
+function void rv_dm_mode_seq_item::print_mubi8_t_field(uvm_printer printer,
+                                                       string      name,
+                                                       bit [7:0]   value);
+  mubi8_t as_enum = mubi8_t'(value);
+  string  str = as_enum.name();
+
+  if (str == "") begin
+    str = "(?)";
+  end
+
+  printer.print_generic(name, "mubi8_t", 8, $sformatf("%-10s = 8'h%02x", str, value));
+endfunction
+
+constraint rv_dm_mode_seq_item::zero_when_not_provided_c {
+  !m_has_next_dm_addr -> ~|m_next_dm_addr;
+  !m_has_lc_ctrl_signals -> ~|{m_lc_hw_debug_clr, m_lc_hw_debug_en, m_lc_dft_en,
+                               m_lc_check_byp_en, m_lc_escalate_en, m_lc_init_done,
+                               m_strap_en_override};
+  !m_has_pinmux_signals -> ~|m_pinmux_hw_debug_en;
+  !m_has_pwrmgr_signals -> ~|m_strap_en;
+  !m_has_otp_ctrl_signals -> ~|m_otp_dis_rv_dm_late_debug;
+  !m_has_scanmode -> ~|m_scanmode;
+}

--- a/hw/ip/rv_dm/dv/rv_dm_mode_agent/rv_dm_mode_seq_item.svh
+++ b/hw/ip/rv_dm/dv/rv_dm_mode_agent/rv_dm_mode_seq_item.svh
@@ -1,0 +1,66 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Sequence item for mode updates
+//
+// The signals come from various places in the toplevel, and each group has an associated validity
+// flag.
+
+class rv_dm_mode_seq_item extends uvm_sequence_item;
+  `uvm_object_utils(rv_dm_mode_seq_item)
+
+  bit             m_has_next_dm_addr;
+  rand bit [31:0] m_next_dm_addr;
+
+  // Note: The 4-bit values in this section represent values of type lc_tx_t, but we use the raw bit
+  //       vector to allow invalid encodings.
+  bit             m_has_lc_ctrl_signals;
+  rand bit [3:0]  m_lc_hw_debug_clr;
+  rand bit [3:0]  m_lc_hw_debug_en;
+  rand bit [3:0]  m_lc_dft_en;
+  rand bit [3:0]  m_lc_check_byp_en;
+  rand bit [3:0]  m_lc_escalate_en;
+  rand bit [3:0]  m_lc_init_done;
+  rand bit        m_strap_en_override;
+
+  // Note: The 4-bit value represents a value of type lc_tx_t, but we use the raw bit vector to
+  //       allow invalid encodings.
+  bit             m_has_pinmux_signals;
+  rand bit [3:0]  m_pinmux_hw_debug_en;
+
+  bit             m_has_pwrmgr_signals;
+  rand bit        m_strap_en;
+
+  // Note: The 8-bit value represents a value of type mubi8_t, but we use the raw bit vector to
+  //       allow invalid encodings.
+  bit             m_has_otp_ctrl_signals;
+  rand bit [7:0]  m_otp_dis_rv_dm_late_debug;
+
+  // Note: The 4-bit value represents a value of type mubi4_t, but we use the raw bit vector to
+  //       allow invalid encodings.
+  bit             m_has_scanmode;
+  rand bit [3:0]  m_scanmode;
+
+  extern function new (string name="");
+
+  // A slightly silly constraint that ensures signals that don't claim to be provided are dead zero.
+  // This shouldn't have any effect on the behaviour through the driver, but makes waves and logs a
+  // bit easier to read.
+  extern constraint zero_when_not_provided_c;
+endclass
+
+function rv_dm_mode_seq_item::new (string name="");
+  super.new(name);
+endfunction
+
+constraint rv_dm_mode_seq_item::zero_when_not_provided_c {
+  !m_has_next_dm_addr -> ~|m_next_dm_addr;
+  !m_has_lc_ctrl_signals -> ~|{m_lc_hw_debug_clr, m_lc_hw_debug_en, m_lc_dft_en,
+                               m_lc_check_byp_en, m_lc_escalate_en, m_lc_init_done,
+                               m_strap_en_override};
+  !m_has_pinmux_signals -> ~|m_pinmux_hw_debug_en;
+  !m_has_pwrmgr_signals -> ~|m_strap_en;
+  !m_has_otp_ctrl_signals -> ~|m_otp_dis_rv_dm_late_debug;
+  !m_has_scanmode -> ~|m_scanmode;
+}

--- a/hw/ip/rv_dm/dv/rv_dm_mode_agent/seq/rv_dm_mode_seq.svh
+++ b/hw/ip/rv_dm/dv/rv_dm_mode_agent/seq/rv_dm_mode_seq.svh
@@ -1,0 +1,276 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Very simple sequence that sends a single item with the given mode values (which can all be
+// randomised)
+//
+// Most of the mode values in the item are multi-bit. The corresponding values in the sequence have
+// documentation comments that explain how the single bit value in the sequence controls
+// randomisation of the multi-bit value in the item.
+
+class rv_dm_mode_seq extends dv_base_seq #(.REQ (rv_dm_mode_seq_item),
+                                           .SEQUENCER_T (rv_dm_mode_sequencer));
+  `uvm_object_utils(rv_dm_mode_seq)
+
+  bit m_has_next_dm_addr;
+  rand bit [31:0] m_next_dm_addr;
+
+  // Signals from lc_ctrl //////////////////////////////////////////////////////////////////////////
+  bit      m_has_lc_ctrl_signals;
+
+  // If m_lc_hw_debug_clr_valid is true then the item's m_lc_hw_debug_clr signal will be an lc_tx_t
+  // encoding of the boolean value in m_lc_hw_debug_clr. If not, the signal will be have arbitrary
+  // invalid encoding.
+  rand bit m_lc_hw_debug_clr_valid;
+  rand bit m_lc_hw_debug_clr;
+
+  // If m_lc_hw_debug_en is true, the item's m_lc_hw_debug_en signal will be On. If not, it will be
+  // an arbitrary value other than On.
+  rand bit m_lc_hw_debug_en;
+
+  // If m_lc_dft_en is true, the item's m_lc_dft_en signal will be On. If not, it will be an
+  // arbitrary value other than On.
+  rand bit m_lc_dft_en;
+
+  // If m_lc_check_byp_en is false, the item's m_lc_check_byp_en signal will be Off. If not, it will
+  // be an arbitrary value other than Off.
+  //
+  // Note: This signal is only used in DMI mode
+  rand bit m_lc_check_byp_en;
+
+  // If m_lc_escalate_en is false, the item's m_lc_escalate_en signal will be Off. If not, it will
+  // be an arbitrary value other than Off.
+  rand bit m_lc_escalate_en;
+
+  // If m_lc_init_done is true, the item's m_lc_init_done signal will be On. If not, it will be an
+  // arbitrary value other than On.
+  rand bit m_lc_init_done;
+
+  rand bit m_strap_en_override;
+
+  // Signals from pinmux ///////////////////////////////////////////////////////////////////////////
+  bit      m_has_pinmux_signals;
+
+  // If m_pinmux_hw_debug_en is true, the item's m_pinmux_hw_debug_en signal will be MuBi4True. If
+  // not, it will be an arbitrary value other than MuBi4True.
+  rand bit m_pinmux_hw_debug_en;
+
+  // Signals from pwrmgr ///////////////////////////////////////////////////////////////////////////
+  bit      m_has_pwrmgr_signals;
+  rand bit m_strap_en;
+
+  // Signals from otp_ctrl /////////////////////////////////////////////////////////////////////////
+  bit      m_has_otp_ctrl_signals;
+
+  // If m_otp_dis_rv_dm_late_debug is false, the item's m_otp_dis_rv_dm_late_debug signal will be
+  // MuBi8False. If not, it will be an arbitrary value other than MuBi8False.
+  rand bit m_otp_dis_rv_dm_late_debug;
+
+  // Scanmode signal ///////////////////////////////////////////////////////////////////////////////
+  bit      m_has_scanmode;
+
+  // If m_scanmode is true, the item's m_scanmode signal will be MuBi4True. If not, it will be an
+  // arbitrary value other than MuBi4True.
+  rand bit m_scanmode;
+
+  extern function new (string name="");
+  extern virtual function void do_print(uvm_printer printer);
+  extern virtual task body();
+
+  // A bool to multi-bit bool converter. If bool_val matches strict_bool, return strict_encoding. If
+  // not, return an arbitrary value with width bits that doesn't equal strict_encoding.
+  extern function bit [31:0] gen_something_for_bool(int unsigned width,
+                                                    bit          strict_bool,
+                                                    bit [31:0]   strict_encoding,
+                                                    bit          bool_val);
+
+  // Generate an lc_tx_t / mubi4_t / mubi8_t from the given boolean value. Use a valid encoding if
+  // bool_val = strict_val.
+  extern function bit [3:0] gen_lc_tx_t_from_bool(bit strict_val, bit bool_val);
+  extern function bit [3:0] gen_mubi4_t_from_bool(bit strict_val, bit bool_val);
+  extern function bit [7:0] gen_mubi8_t_from_bool(bit strict_val, bit bool_val);
+
+  // Generate a random lc_tx_t value that is neither On nor Off
+  extern function bit [3:0] gen_bad_lc_tx_t();
+
+  // Return bool_val as an lc_tx_t
+  extern static function bit [3:0] bool_to_lc_tx_t(bit bool_val);
+endclass
+
+function rv_dm_mode_seq::new (string name="");
+  super.new(name);
+endfunction
+
+function void rv_dm_mode_seq::do_print(uvm_printer printer);
+  super.do_print(printer);
+
+  if (m_has_next_dm_addr) begin
+    printer.print_field_int("m_next_dm_addr", m_next_dm_addr, 32);
+  end else begin
+    printer.print_field_int("m_has_next_dm_addr", m_has_next_dm_addr, 1);
+  end
+
+
+  if (m_has_lc_ctrl_signals) begin
+    printer.print_field_int("m_lc_hw_debug_clr_valid", m_lc_hw_debug_clr_valid, 1);
+    if (m_lc_hw_debug_clr_valid) begin
+      printer.print_field_int("m_lc_hw_debug_clr", m_lc_hw_debug_clr, 1);
+    end
+    printer.print_field_int("m_lc_hw_debug_en", m_lc_hw_debug_en, 1);
+    printer.print_field_int("m_lc_dft_en", m_lc_dft_en, 1);
+    printer.print_field_int("m_lc_check_byp_en", m_lc_check_byp_en, 1);
+    printer.print_field_int("m_lc_escalate_en", m_lc_escalate_en, 1);
+    printer.print_field_int("m_lc_init_done", m_lc_init_done, 1);
+    printer.print_field_int("m_strap_en_override", m_strap_en_override, 1);
+  end else begin
+    printer.print_field_int("m_has_lc_ctrl_signals", m_has_lc_ctrl_signals, 1);
+  end
+
+
+  if (m_has_pinmux_signals) begin
+    printer.print_field_int("m_pinmux_hw_debug_en", m_pinmux_hw_debug_en, 1);
+  end else begin
+    printer.print_field_int("m_has_pinmux_signals", m_has_pinmux_signals, 1);
+  end
+
+
+  if (m_has_pwrmgr_signals) begin
+    printer.print_field_int("m_strap_en", m_strap_en, 1);
+  end else begin
+    printer.print_field_int("m_has_pwrmgr_signals", m_has_pwrmgr_signals, 1);
+  end
+
+
+  if (m_has_otp_ctrl_signals) begin
+    printer.print_field_int("m_otp_dis_rv_dm_late_debug", m_otp_dis_rv_dm_late_debug, 1);
+  end else begin
+    printer.print_field_int("m_has_otp_ctrl_signals", m_has_otp_ctrl_signals, 1);
+  end
+
+
+  if (m_has_scanmode) begin
+    printer.print_field_int("m_scanmode", m_scanmode, 1);
+  end else begin
+    printer.print_field_int("m_has_scanmode", m_has_scanmode, 1);
+  end
+endfunction
+
+task rv_dm_mode_seq::body();
+  rv_dm_mode_seq_item item;
+
+  bit [3:0] enc_lc_hw_debug_clr, enc_lc_hw_debug_en, enc_lc_dft_en,
+            enc_lc_check_byp_en, enc_lc_escalate_en, enc_lc_init_done;
+  bit [3:0] enc_pinmux_hw_debug_en;
+  bit [7:0] enc_otp_dis_rv_dm_late_debug;
+  bit [3:0] enc_scanmode;
+
+  item = rv_dm_mode_seq_item::type_id::create("item");
+  item.m_has_next_dm_addr = m_has_next_dm_addr;
+  item.m_has_lc_ctrl_signals = m_has_lc_ctrl_signals;
+  item.m_has_pinmux_signals = m_has_pinmux_signals;
+  item.m_has_pwrmgr_signals = m_has_pwrmgr_signals;
+  item.m_has_otp_ctrl_signals = m_has_otp_ctrl_signals;
+  item.m_has_scanmode = m_has_scanmode;
+
+  start_item(item);
+
+  // Randomise encodings for various fields of the item (if they are enabled) before randomising the
+  // item itself. This avoids having to call complicated functions (which can call `uvm_error) from
+  // inside the item randomisation.
+  if (m_has_lc_ctrl_signals) begin
+    enc_lc_hw_debug_clr = m_lc_hw_debug_clr_valid ?
+                          bool_to_lc_tx_t(m_lc_hw_debug_clr) :
+                          gen_bad_lc_tx_t();
+    enc_lc_hw_debug_en = gen_lc_tx_t_from_bool(1, m_lc_hw_debug_en);
+    enc_lc_dft_en = gen_lc_tx_t_from_bool(1, m_lc_dft_en);
+    enc_lc_check_byp_en = gen_lc_tx_t_from_bool(0, m_lc_check_byp_en);
+    enc_lc_escalate_en = gen_lc_tx_t_from_bool(0, m_lc_escalate_en);
+    enc_lc_init_done = gen_lc_tx_t_from_bool(1, m_lc_init_done);
+  end
+  if (m_has_pinmux_signals) begin
+    enc_pinmux_hw_debug_en = gen_lc_tx_t_from_bool(1, m_pinmux_hw_debug_en);
+  end
+  if (m_has_otp_ctrl_signals) begin
+    enc_otp_dis_rv_dm_late_debug = gen_mubi8_t_from_bool(0, m_otp_dis_rv_dm_late_debug);
+  end
+  if (m_has_scanmode) begin
+    enc_scanmode = gen_mubi4_t_from_bool(1, m_scanmode);
+  end
+
+  if (!item.randomize() with {
+          if (m_has_next_dm_addr) {
+            item.m_next_dm_addr == local::m_next_dm_addr;
+          }
+          if (m_has_lc_ctrl_signals) {
+            item.m_lc_hw_debug_clr == local::enc_lc_hw_debug_clr;
+            item.m_lc_hw_debug_en == local::enc_lc_hw_debug_en;
+            item.m_lc_dft_en == local::enc_lc_dft_en;
+            item.m_lc_check_byp_en == local::enc_lc_check_byp_en;
+            item.m_lc_escalate_en == local::enc_lc_escalate_en;
+            item.m_lc_init_done == local::enc_lc_init_done;
+            item.m_strap_en_override == local::m_strap_en_override;
+          }
+          if (m_has_pinmux_signals) {
+            item.m_pinmux_hw_debug_en == local::enc_pinmux_hw_debug_en;
+          }
+          if (m_has_pwrmgr_signals) {
+            item.m_strap_en == local::m_strap_en;
+          }
+          if (m_has_otp_ctrl_signals) {
+            item.m_otp_dis_rv_dm_late_debug == local::enc_otp_dis_rv_dm_late_debug;
+          }
+          if (m_has_scanmode) {
+            item.m_scanmode == local::enc_scanmode;
+          }
+       }) begin
+    `uvm_fatal(get_name(), "Failed to randomize item")
+  end
+  finish_item(item);
+endtask
+
+function bit [31:0] rv_dm_mode_seq::gen_something_for_bool(int unsigned width,
+                                                           bit          strict_bool,
+                                                           bit [31:0]   strict_encoding,
+                                                           bit          bool_val);
+  if (bool_val == strict_bool) begin
+    return strict_encoding;
+  end else begin
+    bit [31:0] ret;
+    if (!std::randomize(ret) with { (ret >> width) == 0; ret != strict_encoding; }) begin
+      `uvm_error(get_full_name(),
+                 $sformatf("Couldn't pick a random non-strict value (width = %0d)", width))
+    end
+    return ret;
+  end
+endfunction
+
+function bit [3:0] rv_dm_mode_seq::gen_lc_tx_t_from_bool(bit strict_val, bit bool_val);
+  return gen_something_for_bool(4, strict_val,
+                                strict_val ? lc_ctrl_pkg::On : lc_ctrl_pkg::Off,
+                                bool_val);
+endfunction
+
+function bit [3:0] rv_dm_mode_seq::gen_mubi4_t_from_bool(bit strict_val, bit bool_val);
+  return gen_something_for_bool(4, strict_val,
+                                strict_val ? prim_mubi_pkg::MuBi4True : prim_mubi_pkg::MuBi4False,
+                                bool_val);
+endfunction
+
+function bit [7:0] rv_dm_mode_seq::gen_mubi8_t_from_bool(bit strict_val, bit bool_val);
+  return gen_something_for_bool(8, strict_val,
+                                strict_val ? prim_mubi_pkg::MuBi8True : prim_mubi_pkg::MuBi8False,
+                                bool_val);
+endfunction
+
+function bit [3:0] rv_dm_mode_seq::gen_bad_lc_tx_t();
+  bit [3:0] ret;
+  if (!std::randomize(ret) with { ret != lc_ctrl_pkg::On; ret != lc_ctrl_pkg::Off; }) begin
+    `uvm_error(get_full_name(), "Couldn't pick a random bad lc_tx_t")
+  end
+  return ret;
+endfunction
+
+function bit [3:0] rv_dm_mode_seq::bool_to_lc_tx_t(bit bool_val);
+  return bool_val ? lc_ctrl_pkg::On : lc_ctrl_pkg::Off;
+endfunction

--- a/hw/ip/rv_dm/dv/rv_dm_mode_agent/seq/rv_dm_mode_seq.svh
+++ b/hw/ip/rv_dm/dv/rv_dm_mode_agent/seq/rv_dm_mode_seq.svh
@@ -1,0 +1,221 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Very simple sequence that sends a single item with the given mode values (which can all be
+// randomised)
+//
+// Most of the mode values in the item are multi-bit. The corresponding values in the sequence have
+// documentation comments that explain how the single bit value gets controls randomisation of the
+// item value.
+
+class rv_dm_mode_seq extends dv_base_seq #(.REQ (rv_dm_mode_seq_item),
+                                           .SEQUENCER_T (rv_dm_mode_sequencer));
+  `uvm_object_utils(rv_dm_mode_seq)
+
+  bit m_has_next_dm_addr;
+  rand bit [31:0] m_next_dm_addr;
+
+  // Signals from lc_ctrl //////////////////////////////////////////////////////////////////////////
+  bit      m_has_lc_ctrl_signals;
+
+  // If m_lc_hw_debug_clr_valid is true then the item's m_lc_hw_debug_clr signal will be an lc_tx_t
+  // encoding of the boolean value in m_lc_hw_debug_clr. If not, the signal will be have arbitrary
+  // invalid encoding.
+  rand bit m_lc_hw_debug_clr_valid;
+  rand bit m_lc_hw_debug_clr;
+
+  // If m_lc_hw_debug_en is true, the item's m_lc_hw_debug_en signal will be On. If not, it will be
+  // an arbitrary value other than On.
+  rand bit m_lc_hw_debug_en;
+
+  // If m_lc_dft_en is true, the item's m_lc_dft_en signal will be On. If not, it will be an
+  // arbitrary value other than On.
+  rand bit m_lc_dft_en;
+
+  // If m_lc_check_byp_en is false, the item's m_lc_check_byp_en signal will be Off. If not, it will
+  // be an arbitrary value other than Off.
+  //
+  // Note: This signal is only used in DMI mode
+  rand bit m_lc_check_byp_en;
+
+  // If m_lc_escalate_en is false, the item's m_lc_escalate_en signal will be Off. If not, it will
+  // be an arbitrary value other than Off.
+  rand bit m_lc_escalate_en;
+
+  // If m_lc_init_done is true, the item's m_lc_init_done signal will be On. If not, it will be an
+  // arbitrary value other than On.
+  rand bit m_lc_init_done;
+
+  rand bit m_strap_en_override;
+
+  // Signals from pinmux ///////////////////////////////////////////////////////////////////////////
+  bit      m_has_pinmux_signals;
+
+  // If m_pinmux_hw_debug_en is true, the item's m_pinmux_hw_debug_en signal will be MuBi4True. If
+  // not, it will be an arbitrary value other than MuBi4True.
+  rand bit m_pinmux_hw_debug_en;
+
+  // Signals from pwrmgr ///////////////////////////////////////////////////////////////////////////
+  bit      m_has_pwrmgr_signals;
+  rand bit m_strap_en;
+
+  // Signals from otp_ctrl /////////////////////////////////////////////////////////////////////////
+  bit      m_has_otp_ctrl_signals;
+
+  // If m_otp_dis_rv_dm_late_debug is false, the item's m_otp_dis_rv_dm_late_debug signal will be
+  // MuBi8False. If not, it will be an arbitrary value other than MuBi8False.
+  rand bit m_otp_dis_rv_dm_late_debug;
+
+  // Scanmode signal ///////////////////////////////////////////////////////////////////////////////
+  bit      m_has_scanmode;
+
+  // If m_scanmode is true, the item's m_scanmode signal will be MuBi4True. If not, it will be an
+  // arbitrary value other than MuBi4True.
+  rand bit m_scanmode;
+
+  extern function new (string name="");
+  extern virtual task body();
+
+  // A bool to multi-bit bool converter. If bool_val matches strict_bool, return strict_encoding. If
+  // not, return an arbitrary value with width bits that doesn't equal strict_encoding.
+  extern function bit [31:0] gen_something_for_bool(int unsigned width,
+                                                    bit          strict_bool,
+                                                    bit [31:0]   strict_encoding,
+                                                    bit          bool_val);
+
+  // Generate an lc_tx_t / mubi4_t / mubi8_t from the given boolean value. Use a valid encoding if
+  // bool_val = strict_val.
+  extern function bit [3:0] gen_lc_tx_t_from_bool(bit strict_val, bit bool_val);
+  extern function bit [3:0] gen_mubi4_t_from_bool(bit strict_val, bit bool_val);
+  extern function bit [7:0] gen_mubi8_t_from_bool(bit strict_val, bit bool_val);
+
+  // Generate a random lc_tx_t value that is neither On nor Off
+  extern function bit [3:0] gen_bad_lc_tx_t();
+
+  // Return bool_val as an lc_tx_t
+  extern static function bit [3:0] bool_to_lc_tx_t(bit bool_val);
+endclass
+
+function rv_dm_mode_seq::new (string name="");
+  super.new(name);
+endfunction
+
+task rv_dm_mode_seq::body();
+  rv_dm_mode_seq_item item;
+
+  bit [3:0] enc_lc_hw_debug_clr, enc_lc_hw_debug_en, enc_lc_dft_en,
+            enc_lc_check_byp_en, enc_lc_escalate_en, enc_lc_init_done;
+  bit [3:0] enc_pinmux_hw_debug_en;
+  bit [7:0] enc_otp_dis_rv_dm_late_debug;
+  bit [3:0] enc_scanmode;
+
+  item = rv_dm_mode_seq_item::type_id::create("item");
+  item.m_has_next_dm_addr = m_has_next_dm_addr;
+  item.m_has_lc_ctrl_signals = m_has_lc_ctrl_signals;
+  item.m_has_pinmux_signals = m_has_pinmux_signals;
+  item.m_has_pwrmgr_signals = m_has_pwrmgr_signals;
+  item.m_has_otp_ctrl_signals = m_has_otp_ctrl_signals;
+  item.m_has_scanmode = m_has_scanmode;
+
+  start_item(item);
+
+  // Randomise encodings for various fields of the item (if they are enabled) before randomising the
+  // item itself. This avoids having to call complicated functions (which can call `uvm_error) from
+  // inside the item randomisation.
+  if (m_has_lc_ctrl_signals) begin
+    enc_lc_hw_debug_clr = m_lc_hw_debug_clr_valid ?
+                          bool_to_lc_tx_t(m_lc_hw_debug_clr) :
+                          gen_bad_lc_tx_t();
+    enc_lc_hw_debug_en = gen_lc_tx_t_from_bool(m_lc_hw_debug_en, 1);
+    enc_lc_dft_en = gen_lc_tx_t_from_bool(m_lc_dft_en, 1);
+    enc_lc_check_byp_en = gen_lc_tx_t_from_bool(m_lc_check_byp_en, 0);
+    enc_lc_escalate_en = gen_lc_tx_t_from_bool(m_lc_escalate_en, 0);
+    enc_lc_init_done = gen_lc_tx_t_from_bool(m_lc_init_done, 1);
+  end
+  if (m_has_pinmux_signals) begin
+    enc_pinmux_hw_debug_en = gen_mubi4_t_from_bool(m_pinmux_hw_debug_en, 1);
+  end
+  if (m_has_otp_ctrl_signals) begin
+    enc_otp_dis_rv_dm_late_debug = gen_mubi8_t_from_bool(m_otp_dis_rv_dm_late_debug, 0);
+  end
+  if (m_has_scanmode) begin
+    enc_scanmode = gen_mubi4_t_from_bool(m_scanmode, 1);
+  end
+
+  if (!item.randomize() with {
+          if (m_has_next_dm_addr) {
+            item.m_next_dm_addr == local::m_next_dm_addr;
+          }
+          if (m_has_lc_ctrl_signals) {
+            item.m_lc_hw_debug_clr == local::enc_lc_hw_debug_clr;
+            item.m_lc_hw_debug_en == local::enc_lc_hw_debug_en;
+            item.m_lc_dft_en == local::enc_lc_dft_en;
+            item.m_lc_check_byp_en == local::enc_lc_check_byp_en;
+            item.m_lc_escalate_en == local::enc_lc_escalate_en;
+            item.m_lc_init_done == local::enc_lc_init_done;
+            item.m_strap_en_override == local::m_strap_en_override;
+          }
+          if (m_has_pinmux_signals) {
+            item.m_pinmux_hw_debug_en == local::enc_pinmux_hw_debug_en;
+          }
+          if (m_has_pwrmgr_signals) {
+            item.m_strap_en == local::m_strap_en;
+          }
+          if (m_has_otp_ctrl_signals) {
+            item.m_otp_dis_rv_dm_late_debug == local::enc_otp_dis_rv_dm_late_debug;
+          }
+          if (m_has_scanmode) {
+            item.m_scanmode == local::enc_scanmode;
+          }
+       }) begin
+    `uvm_fatal(get_name(), "Failed to randomize item")
+  end
+  finish_item(item);
+endtask
+
+function bit [31:0] rv_dm_mode_seq::gen_something_for_bool(int unsigned width,
+                                                           bit          strict_bool,
+                                                           bit [31:0]   strict_encoding,
+                                                           bit          bool_val);
+  if (bool_val == strict_bool) begin
+    return strict_encoding;
+  end else begin
+    bit [31:0] ret;
+    if (!std::randomize(ret) with { (ret >> width) == 0; ret != strict_encoding; }) begin
+      `uvm_error(get_full_name(),
+                 $sformatf("Couldn't pick a random non-strict value (width = %0d)", width))
+    end
+    return ret;
+  end
+endfunction
+
+function bit [3:0] rv_dm_mode_seq::gen_lc_tx_t_from_bool(bit strict_val, bit bool_val);
+  return gen_something_for_bool(4, strict_val,
+                                strict_val ? lc_ctrl_pkg::On : lc_ctrl_pkg::Off,
+                                bool_val);
+endfunction
+
+function bit [3:0] rv_dm_mode_seq::gen_mubi4_t_from_bool(bit strict_val, bit bool_val);
+  return gen_something_for_bool(4, strict_val,
+                                strict_val ? prim_mubi_pkg::MuBi4True : prim_mubi_pkg::MuBi4False,
+                                bool_val);
+endfunction
+
+function bit [7:0] rv_dm_mode_seq::gen_mubi8_t_from_bool(bit strict_val, bit bool_val);
+  return gen_something_for_bool(8, strict_val,
+                                strict_val ? prim_mubi_pkg::MuBi8True : prim_mubi_pkg::MuBi8False,
+                                bool_val);
+endfunction
+
+function bit [3:0] rv_dm_mode_seq::gen_bad_lc_tx_t();
+  bit [3:0] ret;
+  if (!std::randomize(ret) with { ret != lc_ctrl_pkg::On; ret != lc_ctrl_pkg::Off; }) begin
+    `uvm_error(get_full_name(), "Couldn't pick a random bad lc_tx_t")
+  end
+  return ret;
+endfunction
+
+function bit [3:0] rv_dm_mode_seq::bool_to_lc_tx_t(bit bool_val);
+  return bool_val ? lc_ctrl_pkg::On : lc_ctrl_pkg::Off;
+endfunction

--- a/hw/ip/rv_dm/dv/tb.sv
+++ b/hw/ip/rv_dm/dv/tb.sv
@@ -27,6 +27,7 @@ module tb;
   tl_if sba_tl_if(.clk(clk), .rst_n(rst_n));
   jtag_if jtag_if();
   rv_dm_if rv_dm_if(.clk(clk), .rst_n(rst_n));
+  rv_dm_mode_if mode_if(.clk(clk));
 
   // Used for JTAG DTM connections via TL-UL.
   tlul_pkg::tl_h2d_t dbg_tl_h2d;
@@ -45,7 +46,7 @@ module tb;
     .jtag_i      ({jtag_if.tck, jtag_if.tms, jtag_if.trst_n, jtag_if.tdi}),
     .jtag_o      ({jtag_if.tdo, jtag_tdo_oe}),
     .scan_rst_ni (rv_dm_if.scan_rst_n),
-    .scanmode_i  (rv_dm_if.scanmode),
+    .scanmode_i  (mode_if.scanmode),
     .tl_h2d_o    (dbg_tl_h2d),
     .tl_d2h_i    (dbg_tl_d2h)
   );
@@ -66,26 +67,22 @@ module tb;
     .rst_ni                    (rst_n),
     .clk_lc_i                  (clk_lc  ),
     .rst_lc_ni                 (rst_lc_n),
+
     .racl_policies_i           (racl_policies),
     .racl_error_o              (),
-    // We don't currently model systems with multiple debug modules. Tie this port off with the same
-    // value as given as a default for next_dm_addr in rv_dm.hjson.
-    .next_dm_addr_i            ('0),
 
-    // the strapping behavior of lc_hw_debug_en_i will be tested at the top-level.
-    .lc_init_done_i            (rv_dm_if.lc_init_done             ),
-    .lc_hw_debug_clr_i         (rv_dm_if.lc_hw_debug_clr          ),
-    .lc_hw_debug_en_i          (rv_dm_if.lc_hw_debug_en           ),
-    .pinmux_hw_debug_en_i      (rv_dm_if.pinmux_hw_debug_en       ),
-    .lc_dft_en_i               (rv_dm_if.lc_dft_en                ),
-    .lc_check_byp_en_i         (rv_dm_if.lc_check_byp_en          ),
-    .lc_escalate_en_i          (rv_dm_if.lc_escalate_en           ),
-    .strap_en_i                (rv_dm_if.strap_en                 ),
-    .strap_en_override_i       (rv_dm_if.strap_en_override        ),
-
-    .otp_dis_rv_dm_late_debug_i(rv_dm_if.otp_dis_rv_dm_late_debug ),
-
-    .scanmode_i                (rv_dm_if.scanmode      ),
+    .next_dm_addr_i            (mode_if.next_dm_addr            ),
+    .lc_hw_debug_clr_i         (mode_if.lc_hw_debug_clr         ),
+    .lc_hw_debug_en_i          (mode_if.lc_hw_debug_en          ),
+    .lc_dft_en_i               (mode_if.lc_dft_en               ),
+    .pinmux_hw_debug_en_i      (mode_if.pinmux_hw_debug_en      ),
+    .lc_check_byp_en_i         (mode_if.lc_check_byp_en         ),
+    .lc_escalate_en_i          (mode_if.lc_escalate_en          ),
+    .lc_init_done_i            (mode_if.lc_init_done            ),
+    .strap_en_i                (mode_if.strap_en                ),
+    .strap_en_override_i       (mode_if.strap_en_override       ),
+    .otp_dis_rv_dm_late_debug_i(mode_if.otp_dis_rv_dm_late_debug),
+    .scanmode_i                (mode_if.scanmode                ),
     .scan_rst_ni               (rv_dm_if.scan_rst_n    ),
     .ndmreset_req_o            (rv_dm_if.ndmreset_req  ),
     .dmactive_o                (rv_dm_if.dmactive      ),
@@ -148,6 +145,8 @@ module tb;
     cfg.clk_rst_vifs["rv_dm_regs_reg_block"] = clk_rst_if;
     cfg.clk_rst_vifs["rv_dm_mem_reg_block"]  = clk_rst_if;
     cfg.clk_lc_rst_vif = clk_lc_rst_if;
+
+    cfg.m_mode_agent_cfg.vif = mode_if;
 
     cfg.initialize();
 

--- a/hw/ip/rv_dm/dv/tests/rv_dm_base_test.sv
+++ b/hw/ip/rv_dm/dv/tests/rv_dm_base_test.sv
@@ -31,4 +31,16 @@ class rv_dm_base_test extends cip_base_test #(
     test_timeout_ns = 300_000_000;  // 300ms.
   endfunction : build_phase
 
+  virtual function void configure_sequence(uvm_sequence seq);
+    rv_dm_base_vseq vseq;
+
+    super.configure_sequence(seq);
+
+    if (!$cast(vseq, seq)) begin
+      `uvm_fatal(get_full_name(), "Cannot configure sequence: it is not an rv_dm_base_vseq.")
+    end
+
+    vseq.m_mode_sequencer = env.m_mode_agent.sequencer;
+  endfunction
+
 endclass : rv_dm_base_test


### PR DESCRIPTION
**This PR is in draft because it depends on the following commits:**
- #29916 
- #29917 
- #29918 

Once those are merged, only the final commit remains. It has the following commit message:

> **[rv_dm,dv] Give rv_dm_if a passive mode**
> 
> Doing this properly involves tidying up the clocking block a little
> bit and defining a "mon_cb" version. Detailed changes:
> 
>   - The signals in the interface and the testbench are now listed in
>     the same order as the ports of rv_dm. No functional change, but it
>     should make the code slightly easier to read quickly.
> 
>   - The interface now has an is_active flag and the various signals
>     that the testbench *might* drive (inputs to rv_dm) are now wires
>     and driven with 'z in passive mode.
> 
>   - All the clocked signals are now in the clocking block. The commit
>     removes scanmode and scan_rst_n from the block (because they are
>     not synchronous to clk_i).
> 
>   - There is now a modport that groups together all the signals from
>     the "point of view" of an active testbench.
> 
>   - The code in the rv_dm environment now consistently accesses
>     signals through the modport.
> 
>   - For passive mode, the clocking block and modport are
>     duplicated (as mon_cb and mon_mp) with all the signals as inputs.
> 