### PR TITLE
[i2c/rtl] Change VAL register input to synced SCL/SDA

### DIFF
--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -280,8 +280,8 @@ module i2c_core import i2c_pkg::*;
        scl_rx_val <= 16'h0;
        sda_rx_val <= 16'h0;
     end else begin
-       scl_rx_val <= {scl_rx_val[14:0], scl_i};
-       sda_rx_val <= {sda_rx_val[14:0], sda_i};
+       scl_rx_val <= {scl_rx_val[14:0], scl_sync};
+       sda_rx_val <= {sda_rx_val[14:0], sda_sync};
     end
   end
 


### PR DESCRIPTION
Prior to this commit, the VAL register took new values directly from the SCL and SDA inputs.  As SCL and SDA are in a different clock domain than the VAL register, this is not ideal.  Instead, the signals should go through a CDC synchronizer before they get registered in the I2C IP.

This commit thus changes the VAL register input to `scl_sync` and `sda_sync`, which are output from `prim_flop_2sync` instances.

As the VAL register oversamples the SCL and SDA wires without any timing guarantees, it is intended for debug purposes only and needs to be post-processed.  Thus the previous implementation is not expected to have caused any real problem.  Nonetheless, this change improves this clock-domain crossing according to best practices.