### PR TITLE
Backport 27851 ([rom_ext] bump immutable section version to 0.4)

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -298,8 +298,8 @@ manifest(d = {
     "manuf_state_creator": hex(CONST.MANUF_STATE.PERSO_INITIAL),
     "visibility": ["//visibility:private"],
     "version_major": "0",
-    # Release: 2025-09-16-RC00
-    "version_minor": "2025091600",
+    # Release: 2025-10-29-RC00
+    "version_minor": "2025102900",
     "security_version": "0xFFFFFFFF",
 })
 

--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -14,7 +14,7 @@ def secver_write_selection():
 # because of how the bazel rule accepts attributes.
 ROM_EXT_VERSION = struct(
     MAJOR = "0",
-    MINOR = "115",
+    MINOR = "116",
     SECURITY = "0",
 )
 

--- a/sw/device/silicon_creator/rom_ext/imm_section/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/imm_section/defs.bzl
@@ -4,7 +4,7 @@
 
 # The version struct will be appened to the end of imm_section.
 IMM_SECTION_MAJOR_VERSION = 0
-IMM_SECTION_MINOR_VERSION = 3
+IMM_SECTION_MINOR_VERSION = 4
 
 IMM_SECTION_VERSION = "{}.{}".format(IMM_SECTION_MAJOR_VERSION, IMM_SECTION_MINOR_VERSION)
 


### PR DESCRIPTION
Backport #27851 and https://github.com/lowRISC/opentitan/pull/28589