### PR TITLE
Backport 28717: [manuf] Use the silicon_creator driver to compute hashes

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -111,6 +111,7 @@ cc_library(
         "//sw/device/lib/crypto/include:datatypes",
         "//sw/device/lib/dif:otp_ctrl",
         "//sw/device/lib/testing:otp_ctrl_testutils",
+        "//sw/device/silicon_creator/lib/drivers:hmac",
     ],
 )
 

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
@@ -12,6 +12,7 @@
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
 #include "sw/device/lib/testing/flash_ctrl_testutils.h"
 #include "sw/device/lib/testing/otp_ctrl_testutils.h"
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/manuf/lib/flash_info_fields.h"
 #include "sw/device/silicon_creator/manuf/lib/otp_img_types.h"
 #include "sw/device/silicon_creator/manuf/lib/util.h"
@@ -162,18 +163,17 @@ OT_WARN_UNUSED_RESULT
 static status_t lock_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
                                    dif_otp_ctrl_partition_t partition) {
   // Compute SHA256 of the OTP partition.
-  uint32_t digest[kSha256DigestWords];
-  otcrypto_word32_buf_t otp_partition_digest =
-      OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, digest, ARRAYSIZE(digest));
-  TRY(manuf_util_hash_otp_partition(otp_ctrl, partition, otp_partition_digest));
+  hmac_digest_t digest;
+  TRY(manuf_util_hash_otp_partition(otp_ctrl, partition, &digest));
 
   // Get the least significant 64 bits of the digest. We will use this as the
   // digest to lock the OTP partition. The complete digest will be used in the
-  // attestation key / certificate generation. Note: cryptolib generates the
-  // digest in big-endian format so we must rearrange the bytes.
-  uint64_t partition_digest_lowest_64bits = __builtin_bswap32(digest[6]);
+  // attestation key / certificate generation. Note: the silicon_creator hmac
+  // driver generates the digest in reversed (little-endian) format, so no
+  // byte swaps are needed.
+  uint64_t partition_digest_lowest_64bits = digest.digest[1];
   partition_digest_lowest_64bits =
-      (partition_digest_lowest_64bits << 32) | __builtin_bswap32(digest[7]);
+      (partition_digest_lowest_64bits << 32) | digest.digest[0];
 
   TRY(otp_ctrl_testutils_lock_partition(
       otp_ctrl, partition, /*digest=*/partition_digest_lowest_64bits));

--- a/sw/device/silicon_creator/manuf/lib/util.c
+++ b/sw/device/silicon_creator/manuf/lib/util.c
@@ -9,10 +9,10 @@
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/integrity.h"
-#include "sw/device/lib/crypto/include/sha2.h"
 #include "sw/device/lib/crypto/include/sha3.h"
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
 #include "sw/device/lib/testing/otp_ctrl_testutils.h"
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
 
 #include "hw/top/otp_ctrl_regs.h"  // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -65,15 +65,10 @@ status_t manuf_util_hash_lc_transition_token(const uint32_t *raw_token,
 
 status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
                                        dif_otp_ctrl_partition_t partition,
-                                       otcrypto_word32_buf_t output) {
-  if (otp_ctrl == NULL || output.len != kSha256DigestWords) {
+                                       hmac_digest_t *digest) {
+  if (otp_ctrl == NULL) {
     return INVALID_ARGUMENT();
   }
-  otcrypto_hash_digest_t digest = {
-      .data = output.data,
-      .len = output.len,
-  };
-
   switch (partition) {
     case kDifOtpCtrlPartitionVendorTest: {
       uint32_t
@@ -85,11 +80,11 @@ status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
           (OTP_CTRL_PARAM_VENDOR_TEST_SIZE -
            OTP_CTRL_PARAM_VENDOR_TEST_DIGEST_SIZE) /
               sizeof(uint32_t)));
-      otcrypto_const_byte_buf_t input = OTCRYPTO_MAKE_BUF(
-          otcrypto_const_byte_buf_t, (unsigned char *)vendor_test_32bit_array,
-          OTP_CTRL_PARAM_VENDOR_TEST_SIZE -
-              OTP_CTRL_PARAM_VENDOR_TEST_DIGEST_SIZE);
-      TRY(otcrypto_sha2_256(&input, &digest));
+      hmac_sha256(vendor_test_32bit_array,
+                  OTP_CTRL_PARAM_VENDOR_TEST_SIZE -
+                      OTP_CTRL_PARAM_VENDOR_TEST_DIGEST_SIZE,
+                  digest);
+
     } break;
     case kDifOtpCtrlPartitionCreatorSwCfg: {
       // Note: we purposely exclude the AST configuration data field of this
@@ -102,25 +97,22 @@ status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
       // same CreatorRootKey keymgr attestation binding value computed in the
       // field by the ROM is the same as the one used during perso when all the
       // CreatorSwCfg fields have not yet been set.
-      otcrypto_const_byte_buf_t input = OTCRYPTO_MAKE_BUF(
-          otcrypto_const_byte_buf_t,
-          (unsigned char *)(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR +
-                            OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET +
-                            OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_INIT_EN_OFFSET),
+      hmac_sha256(
+          (const void *)(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR +
+                         OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET +
+                         OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_INIT_EN_OFFSET),
           OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE -
               OTP_CTRL_PARAM_CREATOR_SW_CFG_DIGEST_SIZE -
-              OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_CFG_SIZE);
-      TRY(otcrypto_sha2_256(&input, &digest));
+              OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_CFG_SIZE,
+          digest);
     } break;
     case kDifOtpCtrlPartitionOwnerSwCfg: {
-      otcrypto_const_byte_buf_t input = OTCRYPTO_MAKE_BUF(
-          otcrypto_const_byte_buf_t,
-          (unsigned char *)(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR +
-                            OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET +
-                            OTP_CTRL_PARAM_OWNER_SW_CFG_OFFSET),
-          OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE -
-              OTP_CTRL_PARAM_OWNER_SW_CFG_DIGEST_SIZE);
-      TRY(otcrypto_sha2_256(&input, &digest));
+      hmac_sha256((const void *)(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR +
+                                 OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET +
+                                 OTP_CTRL_PARAM_OWNER_SW_CFG_OFFSET),
+                  OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE -
+                      OTP_CTRL_PARAM_OWNER_SW_CFG_DIGEST_SIZE,
+                  digest);
     } break;
     case kDifOtpCtrlPartitionRotCreatorAuthCodesign: {
       uint32_t rot_creator_auth_codesign_32bit_array
@@ -133,12 +125,11 @@ status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
           (OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_SIZE -
            OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_DIGEST_SIZE) /
               sizeof(uint32_t)));
-      otcrypto_const_byte_buf_t input = OTCRYPTO_MAKE_BUF(
-          otcrypto_const_byte_buf_t,
-          (unsigned char *)rot_creator_auth_codesign_32bit_array,
-          OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_SIZE -
-              OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_DIGEST_SIZE);
-      TRY(otcrypto_sha2_256(&input, &digest));
+      hmac_sha256(rot_creator_auth_codesign_32bit_array,
+                  OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_SIZE -
+                      OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_DIGEST_SIZE,
+                  digest);
+
     } break;
     case kDifOtpCtrlPartitionRotCreatorAuthState: {
       uint32_t rot_creator_auth_state_32bit_array
@@ -151,12 +142,10 @@ status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
           (OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_SIZE -
            OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_DIGEST_SIZE) /
               sizeof(uint32_t)));
-      otcrypto_const_byte_buf_t input = OTCRYPTO_MAKE_BUF(
-          otcrypto_const_byte_buf_t,
-          (unsigned char *)rot_creator_auth_state_32bit_array,
-          OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_SIZE -
-              OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_DIGEST_SIZE);
-      TRY(otcrypto_sha2_256(&input, &digest));
+      hmac_sha256(rot_creator_auth_state_32bit_array,
+                  OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_SIZE -
+                      OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_DIGEST_SIZE,
+                  digest);
     } break;
     default:
       return INVALID_ARGUMENT();

--- a/sw/device/silicon_creator/manuf/lib/util.h
+++ b/sw/device/silicon_creator/manuf/lib/util.h
@@ -8,8 +8,8 @@
 #include <stdint.h>
 
 #include "sw/device/lib/base/status.h"
-#include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
 
 /**
  * Hashes a lifecycle transition token to prepare it to be written to OTP.
@@ -52,6 +52,6 @@ status_t manuf_util_hash_lc_transition_token(const uint32_t *raw_token,
 OT_WARN_UNUSED_RESULT
 status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
                                        dif_otp_ctrl_partition_t partition,
-                                       otcrypto_word32_buf_t hash);
+                                       hmac_digest_t *digest);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_UTIL_H_


### PR DESCRIPTION
Use the silicon creator driver to compute the OTP partition truncated hashes.


(cherry picked from commit 5d5df2f5494b466707c3e9b8da4ff525bc85212b)

Manual backport of #28717