### PR TITLE
[clkmgr,dv] Fix invalid type in clkmgr_regwen_vseq

### DIFF
--- a/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_regwen_vseq.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_regwen_vseq.sv.tpl
@@ -11,16 +11,16 @@ class clkmgr_regwen_vseq extends clkmgr_base_vseq;
 
   task check_jitter_regwen();
     bit enable;
-    mubi4_t prev_value;
-    mubi4_t new_value;
+    logic [3:0] prev_value_bits;
+    mubi4_t     new_value;
 
     `DV_CHECK_STD_RANDOMIZE_FATAL(enable)
     new_value = get_rand_mubi4_val(.t_weight(1), .f_weight(1), .other_weight(2));
     `uvm_info(`gfn, $sformatf("Check jitter_regwen = %b", enable), UVM_MEDIUM)
     csr_wr(.ptr(ral.jitter_regwen), .value(enable));
-    csr_rd(.ptr(ral.jitter_enable), .value(prev_value));
+    csr_rd(.ptr(ral.jitter_enable), .value(prev_value_bits));
     csr_wr(.ptr(ral.jitter_enable), .value(new_value));
-    csr_rd_check(.ptr(ral. jitter_enable), .compare_value(enable ? new_value : prev_value));
+    csr_rd_check(.ptr(ral.jitter_enable), .compare_value(enable ? new_value : prev_value_bits));
     `uvm_info(`gfn, "Check jitter_regwen done", UVM_MEDIUM)
   endtask : check_jitter_regwen
 

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_regwen_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_regwen_vseq.sv
@@ -11,16 +11,16 @@ class clkmgr_regwen_vseq extends clkmgr_base_vseq;
 
   task check_jitter_regwen();
     bit enable;
-    mubi4_t prev_value;
-    mubi4_t new_value;
+    logic [3:0] prev_value_bits;
+    mubi4_t     new_value;
 
     `DV_CHECK_STD_RANDOMIZE_FATAL(enable)
     new_value = get_rand_mubi4_val(.t_weight(1), .f_weight(1), .other_weight(2));
     `uvm_info(`gfn, $sformatf("Check jitter_regwen = %b", enable), UVM_MEDIUM)
     csr_wr(.ptr(ral.jitter_regwen), .value(enable));
-    csr_rd(.ptr(ral.jitter_enable), .value(prev_value));
+    csr_rd(.ptr(ral.jitter_enable), .value(prev_value_bits));
     csr_wr(.ptr(ral.jitter_enable), .value(new_value));
-    csr_rd_check(.ptr(ral. jitter_enable), .compare_value(enable ? new_value : prev_value));
+    csr_rd_check(.ptr(ral.jitter_enable), .compare_value(enable ? new_value : prev_value_bits));
     `uvm_info(`gfn, "Check jitter_regwen done", UVM_MEDIUM)
   endtask : check_jitter_regwen
 

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_regwen_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_regwen_vseq.sv
@@ -11,16 +11,16 @@ class clkmgr_regwen_vseq extends clkmgr_base_vseq;
 
   task check_jitter_regwen();
     bit enable;
-    mubi4_t prev_value;
-    mubi4_t new_value;
+    logic [3:0] prev_value_bits;
+    mubi4_t     new_value;
 
     `DV_CHECK_STD_RANDOMIZE_FATAL(enable)
     new_value = get_rand_mubi4_val(.t_weight(1), .f_weight(1), .other_weight(2));
     `uvm_info(`gfn, $sformatf("Check jitter_regwen = %b", enable), UVM_MEDIUM)
     csr_wr(.ptr(ral.jitter_regwen), .value(enable));
-    csr_rd(.ptr(ral.jitter_enable), .value(prev_value));
+    csr_rd(.ptr(ral.jitter_enable), .value(prev_value_bits));
     csr_wr(.ptr(ral.jitter_enable), .value(new_value));
-    csr_rd_check(.ptr(ral. jitter_enable), .compare_value(enable ? new_value : prev_value));
+    csr_rd_check(.ptr(ral.jitter_enable), .compare_value(enable ? new_value : prev_value_bits));
     `uvm_info(`gfn, "Check jitter_regwen done", UVM_MEDIUM)
   endtask : check_jitter_regwen
 

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_regwen_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_regwen_vseq.sv
@@ -11,16 +11,16 @@ class clkmgr_regwen_vseq extends clkmgr_base_vseq;
 
   task check_jitter_regwen();
     bit enable;
-    mubi4_t prev_value;
-    mubi4_t new_value;
+    logic [3:0] prev_value_bits;
+    mubi4_t     new_value;
 
     `DV_CHECK_STD_RANDOMIZE_FATAL(enable)
     new_value = get_rand_mubi4_val(.t_weight(1), .f_weight(1), .other_weight(2));
     `uvm_info(`gfn, $sformatf("Check jitter_regwen = %b", enable), UVM_MEDIUM)
     csr_wr(.ptr(ral.jitter_regwen), .value(enable));
-    csr_rd(.ptr(ral.jitter_enable), .value(prev_value));
+    csr_rd(.ptr(ral.jitter_enable), .value(prev_value_bits));
     csr_wr(.ptr(ral.jitter_enable), .value(new_value));
-    csr_rd_check(.ptr(ral. jitter_enable), .compare_value(enable ? new_value : prev_value));
+    csr_rd_check(.ptr(ral.jitter_enable), .compare_value(enable ? new_value : prev_value_bits));
     `uvm_info(`gfn, "Check jitter_regwen done", UVM_MEDIUM)
   endtask : check_jitter_regwen
 


### PR DESCRIPTION
Xcelium isn't happy when writing to a variable of type mubi4_t with a 4-bit logic type. Since we don't care about the enum here, convert values to the underlying logic type.