### PR TITLE
[dv] Fix address mask computation in get_normalized_addr

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -447,7 +447,7 @@ class dv_base_reg_block extends uvm_reg_block;
   // Normalize these ignored bits to enable locating which CSR/mem is at the returned address.
   function uvm_reg_addr_t get_normalized_addr(uvm_reg_addr_t byte_addr, uvm_reg_map map = null);
     if (map == null) map = get_default_map();
-    return get_addr_from_offset(.byte_offset(byte_addr & addr_mask[map]),
+    return get_addr_from_offset(.byte_offset(byte_addr & get_addr_mask(map)),
                                 .word_aligned(1),
                                 .map(map));
   endfunction


### PR DESCRIPTION
The mask in addr_mask[map] is memoized, so only works if we have called get_addr_mask(map) already: that function computes the mask the first time it is called.