### PR TITLE
[crypto/test] Test mismatching finalize to start RSA functions

### DIFF
--- a/sw/device/lib/crypto/impl/rsa/run_rsa.c
+++ b/sw/device/lib/crypto/impl/rsa/run_rsa.c
@@ -305,8 +305,6 @@ static status_t keygen_finalize(uint32_t exp_mode, size_t num_words,
   uint32_t act_mode = 0;
   HARDENED_TRY(otbn_dmem_read(1, kOtbnVarRsaMode, &act_mode));
   if (act_mode != exp_mode) {
-    // COVERAGE (MISSING) We do not cover calling different finalize functions
-    // from their start functions.
     return OTCRYPTO_FATAL_ERR;
   }
   HARDENED_CHECK_EQ(launder32(act_mode), exp_mode);

--- a/sw/device/lib/crypto/impl/rsa/run_rsa_key_from_cofactor.c
+++ b/sw/device/lib/crypto/impl/rsa/run_rsa_key_from_cofactor.c
@@ -76,8 +76,6 @@ status_t rsa_keygen_from_cofactor_2048_finalize(
   HARDENED_TRY_WIPE_DMEM(
       otbn_dmem_read(kOtbnRsaModeWords, kOtbnVarRsaMode, &act_mode));
   if (act_mode != kOtbnRsaModeCofactor2048) {
-    // COVERAGE (MISSING) We do not cover calling different finalize functions
-    // from their start functions.
     return OTCRYPTO_FATAL_ERR;
   }
   HARDENED_CHECK_EQ(launder32(act_mode), kOtbnRsaModeCofactor2048);

--- a/sw/device/tests/crypto/rsa_2048_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_keygen_functest.c
@@ -200,6 +200,68 @@ static status_t run_keygen_negative_tests(void) {
   return OTCRYPTO_OK;
 }
 
+static status_t run_async_wrong_finalize_tests(void) {
+  LOG_INFO("Running RSA async wrong-finalize negative tests.");
+
+  uint32_t pub_data_2048[kOtcryptoRsa2048PublicKeyBytes / 4] = {0};
+  otcrypto_unblinded_key_t valid_pub_2048 = {
+      .key_mode = kOtcryptoKeyModeRsaSignPkcs,
+      .key_length = kOtcryptoRsa2048PublicKeyBytes,
+      .key = pub_data_2048,
+  };
+
+  uint32_t priv_blob_2048[kOtcryptoRsa2048PrivateKeyblobBytes / 4] = {0};
+  otcrypto_blinded_key_t valid_priv_2048 = {
+      .config =
+          {
+              .version = kOtcryptoLibVersion1,
+              .key_mode = kOtcryptoKeyModeRsaSignPkcs,
+              .key_length = kOtcryptoRsa2048PrivateKeyBytes,
+              .hw_backed = kHardenedBoolFalse,
+              .security_level = kOtcryptoKeySecurityLevelLow,
+          },
+      .keyblob_length = kOtcryptoRsa2048PrivateKeyblobBytes,
+      .keyblob = priv_blob_2048,
+  };
+
+  uint32_t pub_data_3072[kOtcryptoRsa3072PublicKeyBytes / 4] = {0};
+  otcrypto_unblinded_key_t valid_pub_3072 = {
+      .key_mode = kOtcryptoKeyModeRsaSignPkcs,
+      .key_length = kOtcryptoRsa3072PublicKeyBytes,
+      .key = pub_data_3072,
+  };
+
+  uint32_t priv_blob_3072[kOtcryptoRsa3072PrivateKeyblobBytes / 4] = {0};
+  otcrypto_blinded_key_t valid_priv_3072 = {
+      .config =
+          {
+              .version = kOtcryptoLibVersion1,
+              .key_mode = kOtcryptoKeyModeRsaSignPkcs,
+              .key_length = kOtcryptoRsa3072PrivateKeyBytes,
+              .hw_backed = kHardenedBoolFalse,
+              .security_level = kOtcryptoKeySecurityLevelLow,
+          },
+      .keyblob_length = kOtcryptoRsa3072PrivateKeyblobBytes,
+      .keyblob = priv_blob_3072,
+  };
+
+  LOG_INFO("Starting 2048 standard keygen, attempting cofactor finalize...");
+  CHECK_STATUS_OK(otcrypto_rsa_keygen_async_start(kOtcryptoRsaSize2048));
+
+  CHECK(otcrypto_rsa_keypair_from_cofactor_async_finalize(&valid_pub_2048,
+                                                          &valid_priv_2048)
+            .value == OTCRYPTO_FATAL_ERR.value);
+
+  LOG_INFO(
+      "Starting 2048 standard keygen, attempting 3072 standard finalize...");
+  CHECK_STATUS_OK(otcrypto_rsa_keygen_async_start(kOtcryptoRsaSize2048));
+
+  CHECK(otcrypto_rsa_keygen_async_finalize(&valid_pub_3072, &valid_priv_3072)
+            .value == OTCRYPTO_FATAL_ERR.value);
+
+  return OK_STATUS();
+}
+
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
@@ -207,6 +269,8 @@ bool test_main(void) {
 
   status_t test_result = OK_STATUS();
   EXECUTE_TEST(test_result, keygen_then_sign_test);
+  EXECUTE_TEST(test_result, run_async_wrong_finalize_tests);
+  // This test leaves the OTBN running, best call it at the end.
   EXECUTE_TEST(test_result, run_keygen_negative_tests);
   return status_ok(test_result);
 }


### PR DESCRIPTION
Verify that calling a wrong finalize from a different start function gives a bad status output for keygen. Context is that keygen is non deterministic hence we have no cycle count. Calling a wrong finalize function normally crashes the chip due to the instruction count. For keygen this a check by the mode of the OTBN. This test covers this.