### PR TITLE
[cryptotest] Test RSA Keygen

### DIFF
--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -268,12 +268,32 @@ RSA_TESTVECTOR_TARGETS = [
         "pkcs1_1.5",
         "pss",
     ]
+] + [
+    "//sw/host/cryptotest/testvectors/data:wycheproof_rsa_{}_{}_{}_sign.json".format(
+        padding_mode,
+        security_level,
+        hash_suffix,
+    )
+    for security_level in [
+        2048,
+        3072,
+        4096,
+    ]
+    for hash_suffix in [
+        "sha3_256",
+        "sha3_384",
+        "sha3_512",
+    ]
+    for padding_mode in [
+        "pkcs1_1.5",
+        "pss",
+    ]
 ]
 
 RSA_TESTVECTOR_ARGS = " ".join([
     "--rsa-json=\"$(rootpath {})\"".format(target)
     for target in RSA_TESTVECTOR_TARGETS
-])
+] + ["--run_keygen"])
 
 cryptotest(
     name = "rsa_kat",

--- a/sw/device/tests/crypto/cryptotest/firmware/rsa.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/rsa.c
@@ -74,6 +74,28 @@ static const uint32_t key_mask[kCryptotestRsa4096NumWords] = {
     0xe6cae515, 0x063cb76b, 0xff9428aa, 0x5c69fc6a, 0xbb15f685, 0xeb951a27,
     0xcadc73ec, 0xd3770767};
 
+static status_t hash_message(otcrypto_const_byte_buf_t *msg_buf,
+                             otcrypto_hash_mode_t hash_mode,
+                             otcrypto_hash_digest_t *msg_digest) {
+  switch (hash_mode) {
+    case kOtcryptoHashModeSha256:
+      return otcrypto_sha2_256(msg_buf, msg_digest);
+    case kOtcryptoHashModeSha384:
+      return otcrypto_sha2_384(msg_buf, msg_digest);
+    case kOtcryptoHashModeSha512:
+      return otcrypto_sha2_512(msg_buf, msg_digest);
+    case kOtcryptoHashModeSha3_256:
+      return otcrypto_sha3_256(msg_buf, msg_digest);
+    case kOtcryptoHashModeSha3_384:
+      return otcrypto_sha3_384(msg_buf, msg_digest);
+    case kOtcryptoHashModeSha3_512:
+      return otcrypto_sha3_512(msg_buf, msg_digest);
+    default:
+      LOG_ERROR("Unsupported RSA hash mode: %d", hash_mode);
+      return INVALID_ARGUMENT();
+  }
+}
+
 status_t handle_rsa_encrypt(ujson_t *uj) {
   cryptotest_rsa_encrypt_t uj_input;
   TRY(ujson_deserialize_cryptotest_rsa_encrypt_t(uj, &uj_input));
@@ -501,36 +523,7 @@ status_t handle_rsa_sign(ujson_t *uj) {
       .mode = hash_mode,
   };
 
-  // Hash the message.
-  switch (hash_mode) {
-    case kOtcryptoHashModeSha256:
-      TRY(otcrypto_sha2_256(&msg_buf, &msg_digest));
-      break;
-    case kOtcryptoHashModeSha384:
-      TRY(otcrypto_sha2_384(&msg_buf, &msg_digest));
-      break;
-    case kOtcryptoHashModeSha512:
-      TRY(otcrypto_sha2_512(&msg_buf, &msg_digest));
-      break;
-    case kOtcryptoHashModeSha3_256:
-      TRY(otcrypto_sha3_256(&msg_buf, &msg_digest));
-      break;
-    case kOtcryptoHashModeSha3_384:
-      TRY(otcrypto_sha3_384(&msg_buf, &msg_digest));
-      break;
-    case kOtcryptoHashModeSha3_512:
-      TRY(otcrypto_sha3_512(&msg_buf, &msg_digest));
-      break;
-    case kOtcryptoHashXofModeShake128:
-      TRY(otcrypto_shake128(&msg_buf, &msg_digest));
-      break;
-    case kOtcryptoHashXofModeShake256:
-      TRY(otcrypto_shake256(&msg_buf, &msg_digest));
-      break;
-    default:
-      LOG_ERROR("Unsupported RSA hash mode: %d", uj_input.hashing);
-      return INVALID_ARGUMENT();
-  }
+  TRY(hash_message(&msg_buf, hash_mode, &msg_digest));
 
   uint32_t sig_buf[rsa_num_words];
   otcrypto_word32_buf_t sig =
@@ -666,30 +659,7 @@ status_t handle_rsa_verify(ujson_t *uj) {
       .mode = hash_mode,
   };
 
-  // Hash the message.
-  switch (hash_mode) {
-    case kOtcryptoHashModeSha256:
-      TRY(otcrypto_sha2_256(&msg_buf, &msg_digest));
-      break;
-    case kOtcryptoHashModeSha384:
-      TRY(otcrypto_sha2_384(&msg_buf, &msg_digest));
-      break;
-    case kOtcryptoHashModeSha512:
-      TRY(otcrypto_sha2_512(&msg_buf, &msg_digest));
-      break;
-    case kOtcryptoHashModeSha3_256:
-      TRY(otcrypto_sha3_256(&msg_buf, &msg_digest));
-      break;
-    case kOtcryptoHashModeSha3_384:
-      TRY(otcrypto_sha3_384(&msg_buf, &msg_digest));
-      break;
-    case kOtcryptoHashModeSha3_512:
-      TRY(otcrypto_sha3_512(&msg_buf, &msg_digest));
-      break;
-    default:
-      LOG_ERROR("Unsupported RSA hash mode: %d", uj_input.hashing);
-      return INVALID_ARGUMENT();
-  }
+  TRY(hash_message(&msg_buf, hash_mode, &msg_digest));
 
   hardened_bool_t verification_result;
   otcrypto_status_t status = otcrypto_rsa_verify(
@@ -708,6 +678,193 @@ status_t handle_rsa_verify(ujson_t *uj) {
   return OK_STATUS();
 }
 
+status_t handle_rsa_keygen(ujson_t *uj) {
+  cryptotest_rsa_keygen_t uj_input;
+  TRY(ujson_deserialize_cryptotest_rsa_keygen_t(uj, &uj_input));
+
+  size_t rsa_num_words;
+  size_t public_key_bytes;
+  size_t private_key_bytes;
+  size_t private_key_blob_bytes;
+  otcrypto_rsa_size_t rsa_size;
+  size_t n_bytes = uj_input.security_level / 8;
+  switch (n_bytes) {
+    case kOtcryptoRsa2048PublicKeyBytes:
+      rsa_size = kOtcryptoRsaSize2048;
+      rsa_num_words = kCryptotestRsa2048NumWords;
+      public_key_bytes = kOtcryptoRsa2048PublicKeyBytes;
+      private_key_bytes = kOtcryptoRsa2048PrivateKeyBytes;
+      private_key_blob_bytes = kOtcryptoRsa2048PrivateKeyblobBytes;
+      break;
+    case kOtcryptoRsa3072PublicKeyBytes:
+      rsa_size = kOtcryptoRsaSize3072;
+      rsa_num_words = kCryptotestRsa3072NumWords;
+      public_key_bytes = kOtcryptoRsa3072PublicKeyBytes;
+      private_key_bytes = kOtcryptoRsa3072PrivateKeyBytes;
+      private_key_blob_bytes = kOtcryptoRsa3072PrivateKeyblobBytes;
+      break;
+    case kOtcryptoRsa4096PublicKeyBytes:
+      rsa_size = kOtcryptoRsaSize4096;
+      rsa_num_words = kCryptotestRsa4096NumWords;
+      public_key_bytes = kOtcryptoRsa4096PublicKeyBytes;
+      private_key_bytes = kOtcryptoRsa4096PrivateKeyBytes;
+      private_key_blob_bytes = kOtcryptoRsa4096PrivateKeyblobBytes;
+      break;
+    default:
+      LOG_ERROR("Unsupported RSA security_level: %d", uj_input.security_level);
+      return INVALID_ARGUMENT();
+  }
+
+  otcrypto_hash_mode_t hash_mode;
+  size_t hash_digest_words;
+  switch (uj_input.hashing) {
+    case kCryptotestRsaSha256:
+      hash_mode = kOtcryptoHashModeSha256;
+      hash_digest_words = 256 / 32;
+      break;
+    case kCryptotestRsaSha384:
+      hash_mode = kOtcryptoHashModeSha384;
+      hash_digest_words = 384 / 32;
+      break;
+    case kCryptotestRsaSha512:
+      hash_mode = kOtcryptoHashModeSha512;
+      hash_digest_words = 512 / 32;
+      break;
+    case kCryptotestRsaSha3_256:
+      hash_mode = kOtcryptoHashModeSha3_256;
+      hash_digest_words = 256 / 32;
+      break;
+    case kCryptotestRsaSha3_384:
+      hash_mode = kOtcryptoHashModeSha3_384;
+      hash_digest_words = 384 / 32;
+      break;
+    case kCryptotestRsaSha3_512:
+      hash_mode = kOtcryptoHashModeSha3_512;
+      hash_digest_words = 512 / 32;
+      break;
+    default:
+      LOG_ERROR("Unsupported RSA hash mode: %d", uj_input.hashing);
+      return INVALID_ARGUMENT();
+  }
+
+  otcrypto_key_mode_t key_mode;
+  otcrypto_rsa_padding_t padding_mode;
+  switch (uj_input.padding) {
+    case kCryptotestRsaPaddingPkcs:
+      padding_mode = kOtcryptoRsaPaddingPkcs;
+      key_mode = kOtcryptoKeyModeRsaSignPkcs;
+      break;
+    case kCryptotestRsaPaddingPss:
+      padding_mode = kOtcryptoRsaPaddingPss;
+      key_mode = kOtcryptoKeyModeRsaSignPss;
+      break;
+    case kCryptotestRsaPaddingOaep:
+      key_mode = kOtcryptoKeyModeRsaEncryptOaep;
+      break;
+    default:
+      LOG_ERROR("Unsupported RSA padding mode: %d", uj_input.padding);
+      return INVALID_ARGUMENT();
+  }
+
+  // Allocate and configure the public key.
+  uint32_t public_key_data[ceil_div(public_key_bytes, sizeof(uint32_t))];
+  otcrypto_unblinded_key_t public_key = {
+      .key_mode = key_mode,
+      .key_length = public_key_bytes,
+      .key = public_key_data,
+  };
+
+  // Allocate and configure the private key.
+  size_t keyblob_words = ceil_div(private_key_blob_bytes, sizeof(uint32_t));
+  uint32_t keyblob[keyblob_words];
+  otcrypto_blinded_key_t private_key = {
+      .config =
+          {
+              .version = kOtcryptoLibVersion1,
+              .key_mode = key_mode,
+              .key_length = private_key_bytes,
+              .hw_backed = kHardenedBoolFalse,
+              .security_level = kOtcryptoKeySecurityLevelLow,
+          },
+      .keyblob = keyblob,
+      .keyblob_length = private_key_blob_bytes,
+  };
+
+  TRY(otcrypto_rsa_keygen(rsa_size, &public_key, &private_key));
+
+  // Copy the message for the round-trip.
+  uint8_t msg[uj_input.msg_len];
+  memcpy(msg, uj_input.msg, uj_input.msg_len);
+  otcrypto_const_byte_buf_t msg_buf =
+      OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, msg, uj_input.msg_len);
+
+  bool result = true;
+
+  if (uj_input.padding == kCryptotestRsaPaddingOaep) {
+    // OAEP round-trip: encrypt then decrypt and compare.
+    uint8_t label_data[1] = {0};
+    otcrypto_const_byte_buf_t label =
+        OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, label_data, 0);
+
+    uint32_t ciphertext_buf[rsa_num_words];
+    otcrypto_word32_buf_t ciphertext =
+        OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, ciphertext_buf, rsa_num_words);
+
+    TRY(otcrypto_rsa_encrypt(&public_key, hash_mode, &msg_buf, &label,
+                             &ciphertext));
+
+    size_t hash_digest_bytes = hash_digest_words * sizeof(uint32_t);
+    size_t max_plaintext_bytes = n_bytes - 2 * hash_digest_bytes - 2;
+    uint8_t plaintext_buf[max_plaintext_bytes];
+    otcrypto_byte_buf_t plaintext = OTCRYPTO_MAKE_BUF(
+        otcrypto_byte_buf_t, plaintext_buf, max_plaintext_bytes);
+
+    otcrypto_const_word32_buf_t ciphertext_const = OTCRYPTO_MAKE_BUF(
+        otcrypto_const_word32_buf_t, ciphertext_buf, rsa_num_words);
+
+    size_t recovered_len = 0;
+    otcrypto_status_t status =
+        otcrypto_rsa_decrypt(&private_key, hash_mode, &ciphertext_const, &label,
+                             &plaintext, &recovered_len);
+    if (status.value != kOtcryptoStatusValueOk ||
+        recovered_len != uj_input.msg_len ||
+        memcmp(plaintext_buf, msg, uj_input.msg_len) != 0) {
+      result = false;
+    }
+  } else {
+    // Sign-then-verify round-trip.
+    uint32_t digest_data[hash_digest_words];
+    otcrypto_hash_digest_t msg_digest = {
+        .data = digest_data,
+        .len = ARRAYSIZE(digest_data),
+        .mode = hash_mode,
+    };
+
+    TRY(hash_message(&msg_buf, hash_mode, &msg_digest));
+
+    uint32_t sig_buf[rsa_num_words];
+    otcrypto_word32_buf_t sig =
+        OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, sig_buf, rsa_num_words);
+    TRY(otcrypto_rsa_sign(&private_key, msg_digest, padding_mode, &sig));
+
+    otcrypto_const_word32_buf_t sig_const =
+        OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, sig_buf, rsa_num_words);
+    hardened_bool_t verification_result;
+    otcrypto_status_t status =
+        otcrypto_rsa_verify(&public_key, msg_digest, padding_mode, &sig_const,
+                            &verification_result);
+    if (status.value != kOtcryptoStatusValueOk ||
+        verification_result != kHardenedBoolTrue) {
+      result = false;
+    }
+  }
+
+  cryptotest_rsa_keygen_resp_t uj_output;
+  uj_output.result = result;
+  RESP_OK(ujson_serialize_cryptotest_rsa_keygen_resp_t, uj, &uj_output);
+  return OK_STATUS();
+}
+
 status_t handle_rsa(ujson_t *uj) {
   rsa_subcommand_t cmd;
   TRY(ujson_deserialize_rsa_subcommand_t(uj, &cmd));
@@ -720,6 +877,8 @@ status_t handle_rsa(ujson_t *uj) {
       return handle_rsa_sign(uj);
     case kRsaSubcommandRsaVerify:
       return handle_rsa_verify(uj);
+    case kRsaSubcommandRsaKeygen:
+      return handle_rsa_keygen(uj);
     default:
       LOG_ERROR("Unrecognized RSA subcommand: %d", cmd);
       return INVALID_ARGUMENT();

--- a/sw/device/tests/crypto/cryptotest/json/rsa_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/rsa_commands.h
@@ -24,7 +24,8 @@ extern "C" {
     value(_, RsaEncrypt) \
     value(_, RsaDecrypt) \
     value(_, RsaSign) \
-    value(_, RsaVerify)
+    value(_, RsaVerify) \
+    value(_, RsaKeygen)
 UJSON_SERDE_ENUM(RsaSubcommand, rsa_subcommand_t, RSA_SUBCOMMAND);
 
 #define RSA_SIGN(field, string) \
@@ -97,6 +98,18 @@ UJSON_SERDE_STRUCT(CryptotestRsaEncryptResp, cryptotest_rsa_encrypt_resp_t, RSA_
     field(signature, uint8_t, RSA_CMD_MAX_MESSAGE_BYTES) \
     field(signature_len, size_t)
 UJSON_SERDE_STRUCT(CryptotestRsaSignResp, cryptotest_rsa_sign_resp_t, RSA_SIGN_RESP);
+
+#define RSA_KEYGEN(field, string) \
+    field(security_level, size_t) \
+    field(hashing, size_t) \
+    field(padding, size_t) \
+    field(msg, uint8_t, RSA_CMD_MAX_MESSAGE_BYTES) \
+    field(msg_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestRsaKeygen, cryptotest_rsa_keygen_t, RSA_KEYGEN);
+
+#define RSA_KEYGEN_RESP(field, string) \
+    field(result, bool)
+UJSON_SERDE_STRUCT(CryptotestRsaKeygenResp, cryptotest_rsa_keygen_resp_t, RSA_KEYGEN_RESP);
 
 #undef MODULE_ID
 

--- a/sw/host/tests/crypto/rsa_kat/src/main.rs
+++ b/sw/host/tests/crypto/rsa_kat/src/main.rs
@@ -14,8 +14,8 @@ use serde::Deserialize;
 use cryptotest_commands::commands::CryptotestCommand;
 use cryptotest_commands::rsa_commands::{
     CryptotestRsaDecrypt, CryptotestRsaDecryptResp, CryptotestRsaEncrypt, CryptotestRsaEncryptResp,
-    CryptotestRsaSign, CryptotestRsaSignResp, CryptotestRsaVerify, CryptotestRsaVerifyResp,
-    RsaSubcommand,
+    CryptotestRsaKeygen, CryptotestRsaKeygenResp, CryptotestRsaSign, CryptotestRsaSignResp,
+    CryptotestRsaVerify, CryptotestRsaVerifyResp, RsaSubcommand,
 };
 
 use opentitanlib::app::TransportWrapper;
@@ -50,6 +50,11 @@ struct Opts {
 
     #[arg(long, num_args = 1..)]
     rsa_json: Vec<String>,
+
+    // Run RSA keygen functional tests (sign-then-verify and encrypt-then-decrypt
+    // round-trips with freshly generated keys).
+    #[arg(long, default_value_t = false)]
+    run_keygen: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -302,6 +307,67 @@ fn run_rsa_testcase(
     Ok(())
 }
 
+// (security_level_bits, padding, hash_alg) parameter sets for keygen testing.
+// All three padding modes are covered for each security level. The message is
+// kept short to satisfy the OAEP plaintext bound at the largest hash size.
+const KEYGEN_CASES: &[(usize, &str, &str)] = &[
+    (2048, "pkcs1_1.5", "sha-256"),
+    (2048, "pss", "sha-256"),
+    (2048, "oaep", "sha-256"),
+    (3072, "pkcs1_1.5", "sha-384"),
+    (3072, "pss", "sha-384"),
+    (3072, "oaep", "sha-384"),
+    (4096, "pkcs1_1.5", "sha-512"),
+    (4096, "pss", "sha-512"),
+    (4096, "oaep", "sha-512"),
+];
+
+const KEYGEN_TEST_MESSAGE: &[u8] = &[
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+];
+
+fn run_rsa_keygen_testcase(
+    security_level: usize,
+    padding: &str,
+    hash_alg: &str,
+    spi_console: &SpiConsoleDevice,
+    timeout: Duration,
+) -> Result<()> {
+    let hashing = match hash_alg {
+        "sha-256" => 0,
+        "sha-384" => 1,
+        "sha-512" => 2,
+        "sha3-256" => 3,
+        "sha3-384" => 4,
+        "sha3-512" => 5,
+        _ => panic!("Invalid hashing mode"),
+    };
+    let padding_code = match padding {
+        "pkcs1_1.5" => 0,
+        "pss" => 1,
+        "oaep" => 2,
+        _ => panic!("Invalid padding mode"),
+    };
+
+    CryptotestCommand::Rsa.send(spi_console)?;
+    RsaSubcommand::RsaKeygen.send(spi_console)?;
+    CryptotestRsaKeygen {
+        security_level,
+        hashing,
+        padding: padding_code,
+        msg: ArrayVec::try_from(KEYGEN_TEST_MESSAGE).unwrap(),
+        msg_len: KEYGEN_TEST_MESSAGE.len(),
+    }
+    .send(spi_console)?;
+
+    let resp = CryptotestRsaKeygenResp::recv(spi_console, timeout, false, false)?;
+    assert!(
+        resp.result,
+        "RSA keygen round-trip failed for {security_level}-bit {padding} {hash_alg}"
+    );
+    Ok(())
+}
+
 fn test_rsa(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
     let spi_console_device = SpiConsoleDevice::new(&*spi, None, /*ignore_frame_num=*/ false)?;
@@ -337,6 +403,24 @@ fn test_rsa(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
 
             log::info!("Test counter: {}", rsa_test.test_case_id);
             run_rsa_testcase(rsa_test, opts, &spi_console_device)?;
+        }
+    }
+
+    if opts.run_keygen {
+        for &(security_level, padding, hash_alg) in KEYGEN_CASES {
+            log::info!(
+                "RSA keygen: {}-bit {} {}",
+                security_level,
+                padding,
+                hash_alg
+            );
+            run_rsa_keygen_testcase(
+                security_level,
+                padding,
+                hash_alg,
+                &spi_console_device,
+                opts.timeout,
+            )?;
         }
     }
     Ok(())


### PR DESCRIPTION
Add a test suite for the RSA key generation. As this test runs quite long, use `--skip-stride X` to reduce the number of test vectors to X vectors and avoid that we run into a timeout by setting `--timeout=Y` where Y is a bigger timeout value.