### PR TITLE
[sw,coremark] Fix missing switch default label warning in CoreMark

### DIFF
--- a/third_party/coremark/top_earlgrey/ee_printf.c
+++ b/third_party/coremark/top_earlgrey/ee_printf.c
@@ -503,6 +503,8 @@ ee_vsprintf(char *buf, const char *fmt, va_list args)
             case '0':
                 flags |= ZEROPAD;
                 goto repeat;
+            default:
+                break;
         }
 
         // Get field width


### PR DESCRIPTION
One more warning, not fixed in #29530