### PR TITLE
[script] Get more detailed coverage reports

### DIFF
--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -189,11 +189,15 @@
                      "+urg+lic+wait",
                      // Lists all the tests that covered a given object.
                      "-show tests",
+                     // Show covered/total object counts alongside each score.
+                     "-show ratios",
+                     // Show full hierarchy, including zero-coverage instances.
+                     "-show fullhier",
                      // Enable test grading using the "index" scheme, and the
                      // generation of the list of contributing tests with
                      // "testfile".
                      "-grade index testfile",
-                     // Use simple ratio of total covered bins over total bins across cps & crs,
+                     // Use simple ratio of total covered bins over total bins across cps & crs.
                      "-group ratio",
                      // Follow LRM naming conventions for array bins.
                      "-group lrm_bin_name",
@@ -202,6 +206,12 @@
                      "-group instcov_for_score",
                      "-dir {cov_merge_db_dir}",
                      "-line nocasedef",
+                     // Report all code coverage metric types explicitly.
+                     "-metric line+branch+cond+tgl+fsm+assert+group",
+                     // Expand toggle MDA (multi-dimensional array) reports instead of
+                     // compressing them into a single entry.
+                     "-nomdacmp",
+                     // Generate both HTML and text summary reports.
                      "-format both",
                      // Prepend each el file with `-elfile`.
                      "{eval_cmd} echo {vcs_cov_excl_files} | sed -E 's/(\\S+)/-elfile \\1/g'",

--- a/hw/dv/tools/xcelium/cov_report.tcl
+++ b/hw/dv/tools/xcelium/cov_report.tcl
@@ -24,15 +24,16 @@ set cov_merge_db_dir [string trim $::env(cov_merge_db_dir) " \"'"]
 set dut [string trim $::env(DUT_TOP)]
 set dut_uc [string toupper $dut]
 
-# Generate the text report (summary is sufficient).
-report -summary \
-  -inst uvm_pkg $dut \
+# Generate the text report.
+report -detail \
+  -inst uvm_pkg "$dut..." \
   -metrics all \
   -all \
   -cumulative on \
   -local off \
-  -grading covered \
-  -out $cov_report_dir/cov_report.txt
+  -grading both \
+  -source on \
+  -out $cov_report_dir/cov_report_detailed.txt
 
 # Generate the functional coverage report for tracking.
 report -summary \


### PR DESCRIPTION
- VCS:
  - Show covered/total object counts alongside each score.
  - Show full hierarchy, including zero-coverage instances.
  - Report all code coverage metric types explicitly.
  - Expand toggle MDA (multi-dimensional array) reports instead of compressing them into a single entry.

- Xcelium:
  - Detailed report with the full hierarchy.