### PR TITLE
[dv] Make dv_base_env_cfg::ral_model_names a set

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -144,9 +144,7 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
                    bus_params_pkg::BUS_DBW);
 
     // Create downstream agent cfg objects.
-    foreach (ral_model_names[i]) begin
-      string ral_name = ral_model_names[i];
-
+    foreach (ral_model_names[ral_name]) begin
       m_tl_agent_cfgs[ral_name] = tl_agent_cfg::type_id::create({"m_tl_agent_cfg_", ral_name});
       m_tl_agent_cfgs[ral_name].is_active = is_active;
       m_tl_agent_cfgs[ral_name].if_mode = (is_active ? dv_utils_pkg::Host : dv_utils_pkg::Monitor);

--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -48,25 +48,31 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
   // accessed through RAL_T::type_name, because this allows subclasses of dv_base_env_cfg to
   // override the base RAL type without messing up the parameterized class type.
   //
-  // This string will be prepended to ral_model_names at the start of the initialize function (which
-  // is after a derived class can have overridden it).
+  // This string will be added to ral_model_names at the start of the initialize function (which is
+  // after a derived class can have overridden it).
   protected string ral_type_name = RAL_T::type_name;
 
-  // A queue of the names of RAL models that should be created in the `initialize_ral` function.
+  // The set of the names of RAL models that should be created in the `initialize_ral` function.
   // Related agents and adapters will be created in the environment as well as connecting them with
   // the scoreboard.
   //
-  // To add another RAL model, a subclass of dv_base_env_cfg must make sure that the model's name is
-  // added to this queue before running dv_base_env_cfg::initialize_ral. One way to do this is to
-  // implement the function itself and update the queue before calling super.initialize_ral.
+  // The set is implemented as an associative array whose keys are elements of the set (and whose
+  // values contain no information).
   //
-  // An index into the collection of RAL model names is used as an index in ral_models, clk_rst_vifs
-  // and clk_freqs_mhz.
+  // The model names (keys of ral_model_names) are used as indices into associative arrays for
+  // ral_models, clk_rst_vifs and clk_freqs_mhz.
+  //
+  // To add another RAL model, a subclass of dv_base_env_cfg must make sure that the model's name is
+  // added to this set before running dv_base_env_cfg::initialize_ral. One way to do this is to
+  // implement the function itself and update the set before calling super.initialize_ral().
+  protected bit ral_model_names[string];
+
   typedef string string_queue_t[$];
-  protected string_queue_t ral_model_names;
 
   function string_queue_t get_ral_model_names();
-    return ral_model_names;
+    string_queue_t ret;
+    foreach (ral_model_names[name]) ret.push_back(name);
+    return ret;
   endfunction
 
   // A RAL model for each name in ral_model_names.
@@ -76,7 +82,7 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
   // that should be used for the associated TL interface.
   virtual clk_rst_if clk_rst_vifs[string];
 
-  // Clock frequencies for the TL interfaces indexed by ral_model_names.
+  // Clock frequencies for the TL interfaces indexed by the keys of ral_model_names.
   rand uint clk_freqs_mhz[string];
 
   // The "default" RAL's register model. This corresponds to RAL_T::type_name as a model name, and
@@ -103,7 +109,7 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
     `uvm_field_int              (en_dv_cdc,       UVM_DEFAULT)
     `uvm_field_int              (smoke_test,      UVM_DEFAULT)
     `uvm_field_int              (zero_delays,     UVM_DEFAULT)
-    `uvm_field_queue_string     (ral_model_names, UVM_DEFAULT)
+    `uvm_field_aa_int_string    (ral_model_names, UVM_DEFAULT)
     `uvm_field_aa_object_string (ral_models,      UVM_DEFAULT)
     `uvm_field_aa_int_string    (clk_freqs_mhz,   UVM_DEFAULT)
   `uvm_object_utils_end
@@ -196,8 +202,9 @@ function void dv_base_env_cfg::initialize_ral(int unsigned addr_width,
                                               int unsigned be_width);
   if (is_initialized) `uvm_fatal(`gfn, "Cannot call initialize_ral when already initialized")
 
-  // Prepend ral_type_name to ral_model_names (so the "default RAL" for the class gets index 0)
-  ral_model_names.push_front(ral_type_name);
+  // Add ral_type_name to ral_model_names (we just need the key in the array; the value has no
+  // meaning)
+  ral_model_names[ral_type_name] = 1'b0;
 
   is_initialized = 1'b1;
 
@@ -205,8 +212,8 @@ function void dv_base_env_cfg::initialize_ral(int unsigned addr_width,
   make_ral_models(addr_width, data_width, be_width);
 
   // add items to clk_freqs_mhz before randomizing it
-  foreach (ral_model_names[i]) begin
-    clk_freqs_mhz[ral_model_names[i]] = 0;
+  foreach (ral_model_names[name]) begin
+    clk_freqs_mhz[name] = 0;
   end
 endfunction
 
@@ -231,8 +238,8 @@ endfunction
 function void dv_base_env_cfg::make_ral_models(int unsigned addr_width,
                                                int unsigned data_width,
                                                int unsigned be_width);
-  foreach (ral_model_names[i]) begin
-    make_ral_model(ral_model_names[i], addr_width, data_width, be_width);
+  foreach (ral_model_names[name]) begin
+    make_ral_model(name, addr_width, data_width, be_width);
   end
 
   if (!ral_models.exists(ral_type_name)) begin

--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -211,6 +211,15 @@ function void dv_base_env_cfg::initialize_ral(int unsigned addr_width,
   // build the ral model
   make_ral_models(addr_width, data_width, be_width);
 
+  // At this point, each RAL model will exist in the ral_models associative array. As a convenience,
+  // set the "ral" class variable to the ral model defined for this type. This should have been
+  // created with some subtype of RAL_T.
+  if (!$cast(ral, ral_models[ral_type_name])) begin
+    `uvm_fatal(get_name(),
+               $sformatf("The register model stored under %0s cannot be cast to type RAL_T.",
+                         ral_type_name))
+  end
+
   // add items to clk_freqs_mhz before randomizing it
   foreach (ral_model_names[name]) begin
     clk_freqs_mhz[name] = 0;
@@ -273,7 +282,6 @@ function void dv_base_env_cfg::make_ral_model(string       ral_model_name,
     reg_blk.lock_model();
 
     ral_models[ral_model_name] = reg_blk;
-    if (reg_blk.get_name() == ral_type_name) `downcast(ral, reg_blk)
   end
 
   // At this point, either the model existed already or we've just created and locked it. In

--- a/hw/dv/sv/tl_agent/dv/env/tl_agent_env_cfg.sv
+++ b/hw/dv/sv/tl_agent/dv/env/tl_agent_env_cfg.sv
@@ -22,7 +22,7 @@ class tl_agent_env_cfg extends dv_base_env_cfg;
     // super.initialize
     is_initialized = 1'b1;
 
-    ral_model_names = {}; // no csr in tl_agent
+    ral_model_names.delete(); // no csr in tl_agent
     host_agent_cfg = tl_agent_cfg::type_id::create("host_agent_cfg");
     host_agent_cfg.max_outstanding_req = 1 << SourceWidth;
     host_agent_cfg.if_mode = dv_utils_pkg::Host;

--- a/hw/ip/aon_timer/dv/env/aon_timer_env_cfg.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_env_cfg.sv
@@ -73,9 +73,9 @@ task aon_timer_env_cfg::wait_for_we_pulse(input string path);
 endtask
 
 function void aon_timer_env_cfg::set_intr_state_has_prediction();
-  foreach (ral_model_names[i]) begin
+  foreach (ral_model_names[ral_name]) begin
     dv_base_reg regs_q[$];
-    ral_models[ral_model_names[i]].get_dv_base_regs(regs_q);
+    ral_models[ral_name].get_dv_base_regs(regs_q);
     foreach (regs_q[j]) begin
       if (!uvm_re_match("intr_state*", regs_q[j].get_name())) begin
         dv_base_reg_field fields_q[$];

--- a/hw/ip/mbx/dv/env/mbx_env_cfg.sv
+++ b/hw/ip/mbx/dv/env/mbx_env_cfg.sv
@@ -24,8 +24,9 @@ class mbx_env_cfg extends cip_base_env_cfg #(
   virtual function void initialize();
     list_of_alerts = mbx_env_pkg::LIST_OF_ALERTS;
 
-    // RAL for the SoC-side register interface.
-    ral_model_names.push_back(mbx_soc_ral_name);
+    // RAL for the SoC-side register interface: add mbx_soc_ral_name to the set of known model
+    // names. The associated value has no meaning.
+    ral_model_names[mbx_soc_ral_name] = 1'b0;
 
     super.initialize();
 

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
@@ -51,7 +51,10 @@ function rom_ctrl_env_cfg::new (string name="");
 
   list_of_alerts = rom_ctrl_env_pkg::LIST_OF_ALERTS;
   tl_intg_alert_name = "fatal";
-  ral_model_names.push_back("rom_ctrl_prim_reg_block");
+
+  // Add rom_ctrl_prim_reg_block to the set of known model names. The associated value has no
+  // meaning.
+  ral_model_names["rom_ctrl_prim_reg_block"] = 1'b0;
 
   num_interrupts = 0;
 

--- a/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
@@ -48,8 +48,9 @@ class rv_dm_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_dm_regs_reg_block));
     list_of_alerts = rv_dm_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_fault";
 
-    // Set up second RAL model for debug memory and associated collateral
-    ral_model_names.push_back(mem_ral_name);
+    // Request a second RAL model for debug memory and associated collateral, by adding mem_ral_name
+    // to the set of known model names. The associated value has no meaning.
+    ral_model_names[mem_ral_name] = 1'b1;
 
     // both RAL models use same clock frequency
     clk_freqs_mhz["rv_dm_mem_reg_block"] = clk_freq_mhz;

--- a/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_env_cfg.sv
+++ b/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_env_cfg.sv
@@ -25,8 +25,9 @@ endfunction : new
 function void soc_dbg_ctrl_env_cfg::initialize();
   list_of_alerts = soc_dbg_ctrl_env_pkg::LIST_OF_ALERTS;
 
-  // Set up second RAL model for JTAG registers
-  ral_model_names.push_back(jtag_ral_name);
+  // Request a second RAL model for JTAG registers by adding jtag_ral_name to the set of known model
+  // names. The associated value has no meaning.
+  ral_model_names[jtag_ral_name] = 1'b0;
   clk_freqs_mhz[jtag_ral_name] = clk_freq_mhz;
 
   super.initialize();

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
@@ -47,8 +47,9 @@ class sram_ctrl_env_cfg #(parameter int AddrWidth = 10)
     tl_intg_alert_name = "fatal_error";
     sec_cm_alert_name  = tl_intg_alert_name;
 
-    // Set up second RAL model for SRAM memory and associated collateral
-    ral_model_names.push_back(sram_ral_name);
+    // Request a second RAL model for SRAM memory and associated collateral, by adding mem_ral_name
+    // to the set of known model names. The associated value has no meaning.
+    ral_model_names[sram_ral_name] = 1'b0;
 
     super.initialize();
     tl_intg_alert_fields[ral.status.bus_integ_error] = 1;

--- a/hw/ip/tlul/generic_dv/env/xbar_env_cfg.sv
+++ b/hw/ip/tlul/generic_dv/env/xbar_env_cfg.sv
@@ -44,7 +44,7 @@ class xbar_env_cfg extends dv_base_env_cfg;
 
   virtual function void initialize();
     is_initialized = 1'b1;
-    ral_model_names = {}; // no csr in xbar
+    ral_model_names.delete(); // no csr in xbar
     // Host TL agent cfg
     num_hosts             = xbar_hosts.size();
     num_enabled_hosts     = xbar_hosts.size();

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -289,9 +289,11 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
     list_of_alerts = flash_ctrl_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_std_err";
     sec_cm_alert_name = tl_intg_alert_name;
-    // Set up second RAL model for Flash memory
-    ral_model_names.push_back(flash_ral_name);
-    ral_model_names.push_back(prim_ral_name);
+
+    // Request two extra RAL models (one for the flash and one for the prim registers) by adding the
+    // names to the set of RAL models. The associated values have no meaning.
+    ral_model_names[flash_ral_name] = 1'b0;
+    ral_model_names[prim_ral_name] = 1'b0;
 
     // both RAL models use same clock frequency
     clk_freqs_mhz[flash_ral_name] = clk_freq_mhz;

--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv.tpl
@@ -59,7 +59,11 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
 
   virtual function void initialize();
     string prim_ral_name = "otp_macro_prim_reg_block";
-    ral_model_names.push_back(prim_ral_name);
+
+    // Request an extra RAL models for the prim registers by adding its name to the set of RAL
+    // models. The associated value has no meaning.
+    ral_model_names[prim_ral_name] = 1'b0;
+
     clk_freqs_mhz[prim_ral_name] = clk_freq_mhz;
 
     list_of_alerts = otp_ctrl_env_pkg::LIST_OF_ALERTS;

--- a/hw/top_darjeeling/dv/env/chip_env_cfg.sv
+++ b/hw/top_darjeeling/dv/env/chip_env_cfg.sv
@@ -143,8 +143,10 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     // User can read `loc_alert_cause` to check ping timeout.
     en_scb_ping_chk = 0;
 
-    ral_model_names.push_back("chip_soc_dbg_reg_block");
-    ral_model_names.push_back("chip_soc_mbx_reg_block");
+    // Add the debug and mailbox register blocks to ral_model_names (we just need the keys in the
+    // array; the values have no meaning)
+    ral_model_names["chip_soc_dbg_reg_block"] = 1'b0;
+    ral_model_names["chip_soc_mbx_reg_block"] = 1'b0;
     super.initialize();
     `uvm_info(`gfn, $sformatf("ral_model_names: %0p", ral_model_names), UVM_LOW);
     soc_dbg_base_reg_block = ral_models["chip_soc_dbg_reg_block"];

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -55,7 +55,11 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
 
   virtual function void initialize();
     string prim_ral_name = "otp_macro_prim_reg_block";
-    ral_model_names.push_back(prim_ral_name);
+
+    // Request an extra RAL models for the prim registers by adding its name to the set of RAL
+    // models. The associated value has no meaning.
+    ral_model_names[prim_ral_name] = 1'b0;
+
     clk_freqs_mhz[prim_ral_name] = clk_freq_mhz;
 
     list_of_alerts = otp_ctrl_env_pkg::LIST_OF_ALERTS;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -289,9 +289,11 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
     list_of_alerts = flash_ctrl_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_std_err";
     sec_cm_alert_name = tl_intg_alert_name;
-    // Set up second RAL model for Flash memory
-    ral_model_names.push_back(flash_ral_name);
-    ral_model_names.push_back(prim_ral_name);
+
+    // Request two extra RAL models (one for the flash and one for the prim registers) by adding the
+    // names to the set of RAL models. The associated values have no meaning.
+    ral_model_names[flash_ral_name] = 1'b0;
+    ral_model_names[prim_ral_name] = 1'b0;
 
     // both RAL models use same clock frequency
     clk_freqs_mhz[flash_ral_name] = clk_freq_mhz;

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -57,7 +57,11 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
 
   virtual function void initialize();
     string prim_ral_name = "otp_macro_prim_reg_block";
-    ral_model_names.push_back(prim_ral_name);
+
+    // Request an extra RAL models for the prim registers by adding its name to the set of RAL
+    // models. The associated value has no meaning.
+    ral_model_names[prim_ral_name] = 1'b0;
+
     clk_freqs_mhz[prim_ral_name] = clk_freq_mhz;
 
     list_of_alerts = otp_ctrl_env_pkg::LIST_OF_ALERTS;

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -289,9 +289,11 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
     list_of_alerts = flash_ctrl_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_std_err";
     sec_cm_alert_name = tl_intg_alert_name;
-    // Set up second RAL model for Flash memory
-    ral_model_names.push_back(flash_ral_name);
-    ral_model_names.push_back(prim_ral_name);
+
+    // Request two extra RAL models (one for the flash and one for the prim registers) by adding the
+    // names to the set of RAL models. The associated values have no meaning.
+    ral_model_names[flash_ral_name] = 1'b0;
+    ral_model_names[prim_ral_name] = 1'b0;
 
     // both RAL models use same clock frequency
     clk_freqs_mhz[flash_ral_name] = clk_freq_mhz;


### PR DESCRIPTION
This PR contains two DV tidy-ups in `dv_base_env_cfg`.

The first one:
> **[dv] Make dv_base_env_cfg::ral_model_names a set**
> 
> There's no need for an ordering on the set of model names (and it ends
> up worryingly like "model zero is special"). Represent the set as an
> associative array (with meaningless values).

and the second:
> **[dv] Move the code that sets dv_base_env_cfg::ral**
> 
> Before this change, the ral class variable got set in make_ral_model
> if the name of the created uvm_reg_block matched ral_type_name.