### PR TITLE
[dv,chip] Add inherit_ral_models flag

### DIFF
--- a/hw/dv/sv/cip_lib/README.md
+++ b/hw/dv/sv/cip_lib/README.md
@@ -76,10 +76,10 @@ The following is a list of common features and settings:
   objection handle of the corresponding CSR field and valued with the expected
   value. This is the list of CSR fields that are modified when an alert triggers
   due to TL integrity violation event. The DV user is required to build this list
-  in the `initialize()` method after `super.initialize();`
+  in the `initialize` method after calling `super.initialize`
 ```systemverilog
-virtual function void initialize();
-  super.initialize(); // ral model is created in `super.initialize`
+virtual function void initialize(bit inherit_ral_models = 1'b0);
+  super.initialize(inherit_ral_models); // ral model is created in `super.initialize`
   tl_intg_alert_fields[ral.a_status_reg.a_field] = value;
 ```
 
@@ -384,9 +384,9 @@ from this CIP library class, please follow the steps below:
   so that creating alert host agents will take the updated `list_of_alerts` variable.
   For example in `otp_ctrl_env_cfg.sv`:
   ```systemverilog
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = otp_ctrl_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
   ```
 * **tb.sv**: Add `DV_ALERT_IF_CONNECT` macro that declares alert interfaces,
   connect alert interface wirings with DUT, and set alert_if to uvm_config_db.
@@ -424,8 +424,8 @@ Refer to section [cip_base_env_cfg](#cip_base_env_cfg) for more information on t
 The user may update these 2 variables as follows.
 ```systemverilog
 class ip_env_cfg extends cip_base_env_cfg #(.RAL_T(ip_reg_block));
-  virtual function void initialize();
-    super.initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
+    super.initialize(inherit_ral_models);
     tl_intg_alert_name = "fatal_fault_err";
     // csr / field name may vary in different IPs
     tl_intg_alert_fields[ral.fault_status.intg_err] = 1;
@@ -464,8 +464,8 @@ The countermeasure of shadow CSRs can be fully verified via importing [shadow_re
 The details of the test sequences are described in the testplan. Users need to assign the status CSR fields to `cfg.shadow_update_err_status_fields` and `cfg.shadow_storage_err_status_fields` for update error and storage error respectively.
 ```systemverilog
 class ip_env_cfg extends cip_base_env_cfg #(.RAL_T(ip_reg_block));
-  virtual function void initialize();
-    super.initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
+    super.initialize(inherit_ral_models);
     // csr / field name may vary in different IPs
     shadow_update_err_status_fields[ral.err_code.invalid_shadow_update] = 1;
     shadow_storage_err_status_fields[ral.fault_status.shadow] = 1;
@@ -550,8 +550,8 @@ package ip_env_pkg;
 4. Set alert name for countermeasure if the alert name is different from the default name - “fatal_fault”.
 ```systemverilog
 class ip_env_cfg extends cip_base_env_cfg #(.RAL_T(ip_reg_block));
-  virtual function void initialize();
-    super.initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
+    super.initialize(inherit_ral_models);
     sec_cm_alert_name = "fatal_check_error";
 ```
 

--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -136,12 +136,13 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
   // been initialised. To add a new RAL model, a subclass should extend cip_base_env_cfg::initialize
   // with a function that adds the model's name to ral_model_names before calling
   // super.initialize().
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     // Initialize the register models themselves. This uses initialize_ral, which is implemented in
     // dv_base_env_cfg.
     initialize_ral(bus_params_pkg::BUS_AW,
                    bus_params_pkg::BUS_DW,
-                   bus_params_pkg::BUS_DBW);
+                   bus_params_pkg::BUS_DBW,
+                   inherit_ral_models);
 
     // Create downstream agent cfg objects.
     foreach (ral_model_names[ral_name]) begin

--- a/hw/dv/sv/dv_lib/dv_base_env.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env.sv
@@ -19,9 +19,15 @@ class dv_base_env #(type CFG_T               = dv_base_env_cfg,
     string ral_models[$];
 
     super.build_phase(phase);
-    // get dv_base_env_cfg object from uvm_config_db
-    if (!uvm_config_db#(CFG_T)::get(this, "", "cfg", cfg)) begin
-      `uvm_fatal(`gfn, $sformatf("failed to get %s from uvm_config_db", cfg.get_type_name()))
+
+    // Get an env_cfg. This may have actually already been supplied before this environment's
+    // build_phase. That might be done by the test or by higher-level environment (if this
+    // environment represents a block that is being used in a larger subsystem- or chip-level
+    // environment). If the cfg has not been supplied, look it up uvm_config_db.
+    if (cfg == null) begin
+      if (!uvm_config_db#(CFG_T)::get(this, "", "cfg", cfg)) begin
+        `uvm_fatal(`gfn, $sformatf("failed to get %s from uvm_config_db", cfg.get_type_name()))
+      end
     end
 
     // Make sure the map in cfg from RAL name to clk_rst_if is populated. Copy the clock frequencies

--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -52,7 +52,7 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
   // after a derived class can have overridden it).
   protected string ral_type_name = RAL_T::type_name;
 
-  // The set of the names of RAL models that should be created in the `initialize_ral` function.
+  // The set of the names of RAL models that should exist by the end of `initialize_ral`.
   // Related agents and adapters will be created in the environment as well as connecting them with
   // the scoreboard.
   //
@@ -124,10 +124,15 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
   // The addr_width, data_width and be_width arguments are used to configure the analogous fields of
   // the dv_base_reg_block instances that are created.
   //
+  // If inherit_ral_models is true, the object is already expected to have the RAL models (possibly
+  // from a higher level of the testbench). If so, csr_base_addr should be ignored, but the other
+  // initialisation for the object is still done.
+  //
   // This function is virtual, allowing subclasses to set up list_of_alerts and num_interrupts.
   extern virtual function void initialize_ral(int unsigned addr_width,
                                               int unsigned data_width,
-                                              int unsigned be_width);
+                                              int unsigned be_width,
+                                              bit          inherit_ral_models);
 
   // Set pre-build RAL knobs.
   //
@@ -199,7 +204,8 @@ endfunction
 
 function void dv_base_env_cfg::initialize_ral(int unsigned addr_width,
                                               int unsigned data_width,
-                                              int unsigned be_width);
+                                              int unsigned be_width,
+                                              bit          inherit_ral_models);
   if (is_initialized) `uvm_fatal(`gfn, "Cannot call initialize_ral when already initialized")
 
   // Add ral_type_name to ral_model_names (we just need the key in the array; the value has no
@@ -208,8 +214,20 @@ function void dv_base_env_cfg::initialize_ral(int unsigned addr_width,
 
   is_initialized = 1'b1;
 
-  // build the ral model
-  make_ral_models(addr_width, data_width, be_width);
+  if (inherit_ral_models) begin
+    // If inherit_ral_models is true then there should already be a RAL model associated with each
+    // name (including ral_type_name). Check that there is.
+    foreach (ral_model_names[ral_name]) begin
+      if (!ral_models.exists(ral_name)) begin
+        `uvm_fatal(get_name(),
+                   $sformatf("inherit_ral_models is true but there is no RAL model at %0s.",
+                             ral_name))
+      end
+    end
+  end else begin
+    // As inherit_ral_models is false, we need to build them here.
+    make_ral_models(addr_width, data_width, be_width);
+  end
 
   // At this point, each RAL model will exist in the ral_models associative array. As a convenience,
   // set the "ral" class variable to the ral model defined for this type. This should have been
@@ -265,33 +283,29 @@ function void dv_base_env_cfg::make_ral_model(string       ral_model_name,
   dv_base_reg_block reg_blk;
 
   if (ral_models.exists(ral_model_name)) begin
-    // If a model for this name already exists, set reg_blk to point at it.
-    reg_blk = ral_models[ral_model_name];
-  end else begin
-    // If a model for this name doesn't already exist, we should make one.
-    reg_blk = create_ral_by_name(ral_model_name);
-
-    // Build the register block with an arbitrary base address (we choose 0). We'll change it
-    // later.
-    pre_build_ral_settings(reg_blk);
-    reg_blk.build(.base_addr(0), .csr_excl(null));
-    reg_blk.addr_width = addr_width;
-    reg_blk.data_width = data_width;
-    reg_blk.be_width   = be_width;
-    post_build_ral_settings(reg_blk);
-    reg_blk.lock_model();
-
-    ral_models[ral_model_name] = reg_blk;
+    // If there is already a model for this name, there's nothing to do (probably because the
+    // env_cfg has already been initialised)
+    return;
   end
 
-  // At this point, either the model existed already or we've just created and locked it. In
-  // either case, it should now be locked.
-  if (!reg_blk.is_locked()) begin
-    `uvm_fatal(`gfn, $sformatf("ral_models[%s] is not locked.", ral_model_name))
-  end
+  // If a model for this name doesn't already exist, we should make one.
+  reg_blk = create_ral_by_name(ral_model_name);
 
-  // Since the model is locked, we know its layout. Pick a base address for the register block.
+  // Build the register block with an arbitrary base address (we choose 0). We'll change it
+  // later.
+  pre_build_ral_settings(reg_blk);
+  reg_blk.build(.base_addr(0), .csr_excl(null));
+  reg_blk.addr_width = addr_width;
+  reg_blk.data_width = data_width;
+  reg_blk.be_width = be_width;
+  post_build_ral_settings(reg_blk);
+  reg_blk.lock_model();
+
+  // Set the base address for the register block that we have just created
   reg_blk.set_base_addr(.base_addr(0), .randomize_base_addr(1));
+
+  if (reg_blk.get_name() == ral_type_name) `downcast(ral, reg_blk)
+
   ral_models[ral_model_name] = reg_blk;
 endfunction
 

--- a/hw/dv/sv/tl_agent/dv/env/tl_agent_env_cfg.sv
+++ b/hw/dv/sv/tl_agent/dv/env/tl_agent_env_cfg.sv
@@ -17,7 +17,7 @@ class tl_agent_env_cfg extends dv_base_env_cfg;
 
   `uvm_object_new
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     // no need to call super.initialize, set is_initialized to bypass the check of calling
     // super.initialize
     is_initialized = 1'b1;

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cfg.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cfg.sv
@@ -59,9 +59,9 @@ class adc_ctrl_env_cfg extends cip_base_env_cfg #(
     end
   endfunction
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = adc_ctrl_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
     // Create ADC push pull agent configs
     for (int idx = 0; idx < ADC_CTRL_CHANNELS; idx++) begin
       string name = $sformatf("m_adc_push_pull_cfg_%0d", idx);

--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -244,13 +244,13 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block_extended));
     return str;
   endfunction
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = aes_env_pkg::LIST_OF_ALERTS;
     keymgr_sideload_agent_cfg = key_sideload_agent_cfg#(keymgr_pkg::hw_key_req_t)::type_id
                                 ::create("keymgr_sideload_agent_cfg");
     keymgr_sideload_agent_cfg.start_default_seq = 0;
     num_edn = 1;
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     can_reset_with_csr_accesses = 1;
 

--- a/hw/ip/aon_timer/dv/env/aon_timer_env_cfg.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_env_cfg.sv
@@ -16,7 +16,7 @@ class aon_timer_env_cfg extends cip_base_env_cfg #(.RAL_T(aon_timer_reg_block));
   `uvm_object_utils_end
 
   extern function new (string name="");
-  extern virtual function void initialize();
+  extern virtual function void initialize(bit inherit_ral_models = 1'b0);
   // Set the 'has_prediction' field flag for all the intr_state fields so the comparison
   // on reads can be carried out in cip_base_scoreboard
   extern function void set_intr_state_has_prediction();
@@ -38,9 +38,9 @@ function aon_timer_env_cfg::new (string name="");
   super.new(name);
 endfunction : new
 
-function void aon_timer_env_cfg::initialize();
+function void aon_timer_env_cfg::initialize(bit inherit_ral_models = 1'b0);
   list_of_alerts = aon_timer_env_pkg::LIST_OF_ALERTS;
-  super.initialize();
+  super.initialize(inherit_ral_models);
 
   m_tl_agent_cfg.max_outstanding_req = 1;
 

--- a/hw/ip/csrng/dv/env/csrng_env_cfg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_cfg.sv
@@ -263,7 +263,7 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
     end
   endfunction // post_randomize
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     if (!m_num_hw_apps) begin
       `uvm_fatal(get_name(),
                  "Cannot initialize cfg without any HW apps. Call set_num_hw_apps first.")
@@ -272,7 +272,7 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
     list_of_alerts = csrng_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_alert";
 
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     // create agent configs
     m_entropy_src_agent_cfg = push_pull_agent_cfg#(.HostDataWidth(entropy_src_pkg::

--- a/hw/ip/dma/dv/env/dma_env_cfg.sv
+++ b/hw/ip/dma/dv/env/dma_env_cfg.sv
@@ -67,7 +67,7 @@ class dma_env_cfg extends cip_base_env_cfg #(.RAL_T(dma_reg_block));
   `uvm_object_new
 
   // Function for Initialization
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = dma_env_pkg::LIST_OF_ALERTS;
     // Populate FIFO names
     fifo_names = '{"host", "ctn", "sys"};
@@ -82,7 +82,7 @@ class dma_env_cfg extends cip_base_env_cfg #(.RAL_T(dma_reg_block));
     asid_names[SocSystemAddr]  = "sys";
 
     // Initialize cip_base_env_cfg
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     // Interrupt count
     num_interrupts = ral.intr_state.get_n_used_bits();

--- a/hw/ip/edn/dv/env/edn_env_cfg.sv
+++ b/hw/ip/edn/dv/env/edn_env_cfg.sv
@@ -110,11 +110,11 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
     end
   endfunction // post_randomize
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = edn_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_alert";
     sec_cm_alert_name = "fatal_alert";
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     // create config objects
     m_csrng_agent_cfg = csrng_agent_cfg::type_id::create("m_csrng_genbits_agent_cfg");

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -251,10 +251,10 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   // Functions //
   ///////////////
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = entropy_src_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_alert";
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     dut_cfg = entropy_src_dut_cfg::type_id::create("dut_cfg");
 

--- a/hw/ip/hmac/dv/env/hmac_env_cfg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_cfg.sv
@@ -31,7 +31,7 @@ class hmac_env_cfg extends cip_base_env_cfg #(.RAL_T(hmac_reg_block));
   extern function new(string name="");
 
   // Class specific methods
-  extern function void initialize();
+  extern virtual function void initialize(bit inherit_ral_models = 1'b0);
 endclass : hmac_env_cfg
 
 
@@ -39,9 +39,9 @@ function hmac_env_cfg::new(string name="");
   super.new(name);
 endfunction : new
 
-function void hmac_env_cfg::initialize();
+function void hmac_env_cfg::initialize(bit inherit_ral_models = 1'b0);
   list_of_alerts = hmac_env_pkg::LIST_OF_ALERTS;
-  super.initialize();
+  super.initialize(inherit_ral_models);
   // set num_interrupts & num_alerts which will be used to create coverage and more
   num_interrupts = ral.intr_state.get_n_used_bits();
 

--- a/hw/ip/i2c/dv/env/i2c_env_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cfg.sv
@@ -88,9 +88,9 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
 
   `uvm_object_new
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = i2c_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     m_i2c_agent_cfg = i2c_agent_cfg::type_id::create("m_i2c_agent_cfg");
     m_i2c_agent_cfg.if_mode = Device;

--- a/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
@@ -15,12 +15,12 @@ class keymgr_env_cfg extends cip_base_env_cfg #(.RAL_T(keymgr_reg_block));
 
   `uvm_object_new
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = keymgr_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_fault_err";
     sec_cm_alert_name  = tl_intg_alert_name;
     num_edn = 1;
-    super.initialize();
+    super.initialize(inherit_ral_models);
     tl_intg_alert_fields[ral.fault_status.regfile_intg] = 1;
     shadow_update_err_status_fields[ral.err_code.invalid_shadow_update] = 1;
     shadow_storage_err_status_fields[ral.fault_status.shadow] = 1;

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env_cfg.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env_cfg.sv
@@ -18,12 +18,12 @@ class keymgr_dpe_env_cfg extends cip_base_env_cfg #(.RAL_T(keymgr_dpe_reg_block)
   // Interface that is bound into the keymgr_dpe_ctrl instance
   virtual keymgr_dpe_ctrl_if keymgr_dpe_ctrl_vif;
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = keymgr_dpe_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_fault_err";
     sec_cm_alert_name  = tl_intg_alert_name;
     num_edn = 1;
-    super.initialize();
+    super.initialize(inherit_ral_models);
     tl_intg_alert_fields[ral.fault_status.regfile_intg] = 1;
     shadow_update_err_status_fields[ral.err_code.invalid_shadow_update] = 1;
     shadow_storage_err_status_fields[ral.fault_status.shadow] = 1;

--- a/hw/ip/kmac/dv/env/kmac_env_cfg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cfg.sv
@@ -45,12 +45,12 @@ class kmac_env_cfg extends cip_base_env_cfg #(.RAL_T(kmac_reg_block));
 
   `uvm_object_new
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     num_edn = 1;
     list_of_alerts = kmac_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_fault_err";
     sec_cm_alert_name  = "fatal_fault_err";
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     tl_intg_alert_fields[ral.status.alert_fatal_fault] = 1;
     tl_intg_alert_fields[ral.cfg_regwen.en] = 0;

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
@@ -61,11 +61,11 @@ class lc_ctrl_env_cfg extends cip_base_env_cfg #(
 
   `uvm_object_new
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = lc_ctrl_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_bus_integ_error";
     sec_cm_alert_name = "fatal_state_error";
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     // Find parameters on config db
     if (!uvm_config_db#(lc_ctrl_parameters_cfg)::get(

--- a/hw/ip/mbx/dv/env/mbx_env_cfg.sv
+++ b/hw/ip/mbx/dv/env/mbx_env_cfg.sv
@@ -21,14 +21,14 @@ class mbx_env_cfg extends cip_base_env_cfg #(
   `uvm_object_utils_end
   `uvm_object_new
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = mbx_env_pkg::LIST_OF_ALERTS;
 
     // RAL for the SoC-side register interface: add mbx_soc_ral_name to the set of known model
     // names. The associated value has no meaning.
     ral_model_names[mbx_soc_ral_name] = 1'b0;
 
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     // Interrupt count
     num_interrupts = ral.intr_state.get_n_used_bits();

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
@@ -79,7 +79,7 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
     `DV_COMMON_CLK_CONSTRAINT(otp_freq_mhz)
   }
 
-  function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     num_edn = 2;
 
     // Set the list of alerts, needed by the CIP base code. This needs to match the names assigned
@@ -101,7 +101,7 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
     // Build OTP Key cfg object
     key_cfg = otp_key_agent_cfg::type_id::create("key_cfg");
 
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     // We can only have one outstanding TL item
     m_tl_agent_cfg.max_outstanding_req = 1;

--- a/hw/ip/pattgen/dv/env/pattgen_env_cfg.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_env_cfg.sv
@@ -16,7 +16,7 @@ class pattgen_env_cfg extends cip_base_env_cfg #(.RAL_T(pattgen_reg_block));
 
   // Implements a function from dv_base_env_cfg. The base class version creates RAL models. This
   // extension uses the type of the RAL model to set num_interrupts.
-  extern virtual function void initialize();
+  extern virtual function void initialize(bit inherit_ral_models = 1'b0);
 
   `uvm_object_utils_begin(pattgen_env_cfg)
     `uvm_field_object(m_pattgen_agent_cfg, UVM_DEFAULT)
@@ -34,8 +34,8 @@ function pattgen_env_cfg::new (string name="");
   seq_cfg = pattgen_seq_cfg::type_id::create("seq_cfg");
 endfunction
 
-function void pattgen_env_cfg::initialize();
-  super.initialize();
+function void pattgen_env_cfg::initialize(bit inherit_ral_models = 1'b0);
+  super.initialize(inherit_ral_models);
 
   num_interrupts = ral.intr_state.get_n_used_bits();
 endfunction

--- a/hw/ip/racl_ctrl/dv/env/racl_ctrl_base_env_cfg.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_ctrl_base_env_cfg.sv
@@ -17,7 +17,7 @@ class racl_ctrl_base_env_cfg extends cip_base_env_cfg;
   rand racl_error_log_agent_cfg external_error_agent_cfg;
 
   extern function new (string name="");
-  extern virtual function void initialize();
+  extern virtual function void initialize(bit inherit_ral_models = 1'b0);
 endclass
 
 function racl_ctrl_base_env_cfg::new (string name="");
@@ -27,13 +27,13 @@ function racl_ctrl_base_env_cfg::new (string name="");
     `uvm_fatal(`gfn, "Could not create reg window of correct type")
 endfunction
 
-function void racl_ctrl_base_env_cfg::initialize();
+function void racl_ctrl_base_env_cfg::initialize(bit inherit_ral_models = 1'b0);
   list_of_alerts = racl_ctrl_base_env_pkg::LIST_OF_ALERTS;
 
   // Tell the CIP base code how many interrupts we have (defaults to zero)
   num_interrupts = 1;
 
-  super.initialize();
+  super.initialize(inherit_ral_models);
 
   // Tell regs about ral, which contains the actual register model.
   regs.set_reg_block(ral);

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
@@ -43,7 +43,7 @@ class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block
   extern function new (string name="");
   extern function void post_randomize();
 
-  extern virtual function void initialize();
+  extern virtual function void initialize(bit inherit_ral_models = 1'b0);
   extern virtual protected function dv_base_reg_block create_ral_by_name(string name);
 
   // Retrieve the flag that says whether we should skip reading the middle of ROM. If true, this was
@@ -98,8 +98,8 @@ function void rom_ctrl_env_cfg::post_randomize();
   m_kmac_agent_cfg.rsp_delay_max = m_kmac_rsp_delay_max;
 endfunction
 
-function void rom_ctrl_env_cfg::initialize();
-  super.initialize();
+function void rom_ctrl_env_cfg::initialize(bit inherit_ral_models = 1'b0);
+  super.initialize(inherit_ral_models);
 
   // default TLUL supports 1 outstanding item, the rom TLUL supports 2 outstanding items.
   m_tl_agent_cfgs[RAL_T::type_name].max_outstanding_req = 1;

--- a/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
@@ -44,7 +44,7 @@ class rv_dm_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_dm_regs_reg_block));
     can_reset_with_csr_accesses = 1'b1;
   endfunction
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = rv_dm_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_fault";
 
@@ -55,7 +55,7 @@ class rv_dm_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_dm_regs_reg_block));
     // both RAL models use same clock frequency
     clk_freqs_mhz["rv_dm_mem_reg_block"] = clk_freq_mhz;
 
-    super.initialize();
+    super.initialize(inherit_ral_models);
     `uvm_info(`gfn, $sformatf("ral_model_names: %0p", ral_model_names), UVM_LOW)
 
     // Configure the RAL model for the mem register block (rv_dm_mem_reg_block) so that it doesn't

--- a/hw/ip/rv_timer/dv/env/rv_timer_env_cfg.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_env_cfg.sv
@@ -6,9 +6,9 @@ class rv_timer_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_timer_reg_block));
   `uvm_object_utils(rv_timer_env_cfg)
   `uvm_object_new
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = rv_timer_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
     // set num_interrupts
     num_interrupts = NUM_HARTS * NUM_TIMERS;
 

--- a/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_env_cfg.sv
+++ b/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_env_cfg.sv
@@ -14,7 +14,7 @@ class soc_dbg_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(soc_dbg_ctrl_core_r
   extern function new(string name="");
 
   // Class specific methods
-  extern function void initialize();
+  extern virtual function void initialize(bit inherit_ral_models = 1'b0);
 endclass : soc_dbg_ctrl_env_cfg
 
 
@@ -22,7 +22,7 @@ function soc_dbg_ctrl_env_cfg::new(string name="");
   super.new(name);
 endfunction : new
 
-function void soc_dbg_ctrl_env_cfg::initialize();
+function void soc_dbg_ctrl_env_cfg::initialize(bit inherit_ral_models = 1'b0);
   list_of_alerts = soc_dbg_ctrl_env_pkg::LIST_OF_ALERTS;
 
   // Request a second RAL model for JTAG registers by adding jtag_ral_name to the set of known model
@@ -30,5 +30,5 @@ function void soc_dbg_ctrl_env_cfg::initialize();
   ral_model_names[jtag_ral_name] = 1'b0;
   clk_freqs_mhz[jtag_ral_name] = clk_freq_mhz;
 
-  super.initialize();
+  super.initialize(inherit_ral_models);
 endfunction : initialize

--- a/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
@@ -56,9 +56,9 @@ class spi_device_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_device_reg_block)
     scb_clear_mems = 1;
   endfunction
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = spi_device_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
     // create spi agent config obj
     spi_host_agent_cfg = spi_agent_cfg::type_id::create("spi_host_agent_cfg");
     spi_device_agent_cfg = spi_agent_cfg::type_id::create("spi_device_agent_cfg");

--- a/hw/ip/spi_host/dv/env/spi_host_env_cfg.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_env_cfg.sv
@@ -52,9 +52,9 @@ class spi_host_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_host_reg_block));
   `uvm_object_new
 
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = spi_host_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     // create spi_host agent config obj
     m_spi_agent_cfg = spi_agent_cfg::type_id::create("m_spi_agent_cfg");

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
@@ -42,7 +42,8 @@ class sram_ctrl_env_cfg #(parameter int AddrWidth = 10)
   constraint otp_freq_mhz_c {
     `DV_COMMON_CLK_CONSTRAINT(otp_freq_mhz)
   }
-  virtual function void initialize();
+
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = sram_ctrl_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_error";
     sec_cm_alert_name  = tl_intg_alert_name;
@@ -51,7 +52,7 @@ class sram_ctrl_env_cfg #(parameter int AddrWidth = 10)
     // to the set of known model names. The associated value has no meaning.
     ral_model_names[sram_ral_name] = 1'b0;
 
-    super.initialize();
+    super.initialize(inherit_ral_models);
     tl_intg_alert_fields[ral.status.bus_integ_error] = 1;
 
     // Build KDI cfg object and configure

--- a/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_env_cfg.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_env_cfg.sv
@@ -13,9 +13,9 @@ class sysrst_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(sysrst_ctrl_reg_bloc
 
   `uvm_object_new
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = sysrst_ctrl_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     // set num_interrupts
     num_interrupts = ral.intr_state.get_n_used_bits();

--- a/hw/ip/tlul/generic_dv/env/xbar_env_cfg.sv
+++ b/hw/ip/tlul/generic_dv/env/xbar_env_cfg.sv
@@ -42,7 +42,7 @@ class xbar_env_cfg extends dv_base_env_cfg;
 
   `uvm_object_new
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     is_initialized = 1'b1;
     ral_model_names.delete(); // no csr in xbar
     // Host TL agent cfg

--- a/hw/ip/uart/dv/env/uart_env_cfg.sv
+++ b/hw/ip/uart/dv/env/uart_env_cfg.sv
@@ -17,9 +17,9 @@ class uart_env_cfg extends cip_base_env_cfg #(.RAL_T(uart_reg_block));
 
   `uvm_object_new
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = uart_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
     // create uart agent config obj
     m_uart_agent_cfg = uart_agent_cfg::type_id::create("m_uart_agent_cfg");
     // set num_interrupts & num_alerts which will be used to create coverage and more

--- a/hw/ip/usbdev/dv/env/usbdev_env_cfg.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_env_cfg.sv
@@ -73,9 +73,9 @@ class usbdev_env_cfg extends cip_base_env_cfg #(.RAL_T(usbdev_reg_block));
 
   `uvm_object_new
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = usbdev_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     // The DUT supports only a single outstanding request.
     m_tl_agent_cfgs[RAL_T::type_name].max_outstanding_req = 1;

--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env_cfg.sv.tpl
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env_cfg.sv.tpl
@@ -25,7 +25,7 @@ class ${module_instance_name}_env_cfg extends cip_base_env_cfg #(.RAL_T(${module
   extern function new(string name="");
 
   // Class specific methods
-  extern function void initialize();
+  extern virtual function void initialize(bit inherit_ral_models = 1'b0);
 endclass : ${module_instance_name}_env_cfg
 
 
@@ -33,9 +33,9 @@ function ${module_instance_name}_env_cfg::new(string name="");
   super.new(name);
 endfunction : new
 
-function void ${module_instance_name}_env_cfg::initialize();
+function void ${module_instance_name}_env_cfg::initialize(bit inherit_ral_models = 1'b0);
   list_of_alerts = ${module_instance_name}_env_pkg::LIST_OF_ALERTS;
-  super.initialize();
+  super.initialize(inherit_ral_models);
 
   // Set shadow register error status
   tl_intg_alert_fields[ral.alert_status.reg_intg_err] = 1;

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_env_cfg.sv.tpl
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_env_cfg.sv.tpl
@@ -18,9 +18,9 @@ class ${module_instance_name}_env_cfg extends cip_base_env_cfg #(.RAL_T(${module
 
   `uvm_object_new
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     num_edn = 1;
-    super.initialize();
+    super.initialize(inherit_ral_models);
     shadow_update_err_status_fields[ral.loc_alert_cause[LocalShadowRegUpdateErr].la] = 1;
     shadow_storage_err_status_fields[ral.loc_alert_cause[LocalShadowRegStorageErr].la] = 1;
 

--- a/hw/ip_templates/clkmgr/dv/env/clkmgr_env_cfg.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/clkmgr_env_cfg.sv.tpl
@@ -36,9 +36,9 @@ class clkmgr_env_cfg extends cip_base_env_cfg #(
 
   `uvm_object_new
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = clkmgr_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     // This is for the integrity error test.
     tl_intg_alert_name = "fatal_fault";

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -282,7 +282,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
     return region;
   endfunction // get_region_from_info
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     string prim_ral_name = "flash_ctrl_prim_reg_block";
     string fast_rcvr_name = "";
 
@@ -298,7 +298,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
     // both RAL models use same clock frequency
     clk_freqs_mhz[flash_ral_name] = clk_freq_mhz;
     clk_freqs_mhz[prim_ral_name] = clk_freq_mhz;
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     void'($value$plusargs("fast_rcvr_%s", fast_rcvr_name));
     if (fast_rcvr_name != "") begin

--- a/hw/ip_templates/gpio/dv/env/gpio_env_cfg.sv.tpl
+++ b/hw/ip_templates/gpio/dv/env/gpio_env_cfg.sv.tpl
@@ -24,9 +24,9 @@ class ${module_instance_name}_env_cfg extends cip_base_env_cfg #(
     super.new(name);
   endfunction
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = ${module_instance_name}_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
     // set num_interrupts & num_alerts which will be used to create coverage and more
     num_interrupts = ral.intr_state.get_n_used_bits();
 

--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv.tpl
@@ -57,7 +57,7 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
     }
   }
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     string prim_ral_name = "otp_macro_prim_reg_block";
 
     // Request an extra RAL models for the prim registers by adding its name to the set of RAL
@@ -71,7 +71,7 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
     tl_intg_alert_name = "fatal_bus_integ_error";
     sec_cm_alert_name  = "fatal_check_error";
 
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     // create push_pull agent config obj
     for (int i = 0; i < NumSramKeyReqSlots; i++) begin

--- a/hw/ip_templates/pwm/dv/env/pwm_env_cfg.sv.tpl
+++ b/hw/ip_templates/pwm/dv/env/pwm_env_cfg.sv.tpl
@@ -22,15 +22,15 @@ class ${module_instance_name}_env_cfg extends cip_base_env_cfg #(.RAL_T(${module
   constraint clk_scale_c { clk_scale inside {[256:1024]}; }
 
   // Method from dv_base_env_cfg. Construct RAL models and fill in monitor configs.
-  extern virtual function void initialize();
+  extern virtual function void initialize(bit inherit_ral_models = 1'b0);
 
   // Return the scaled core clock frequency in MHz.
   extern virtual function int get_clk_core_freq();
 endclass : ${module_instance_name}_env_cfg
 
-function void ${module_instance_name}_env_cfg::initialize();
+function void ${module_instance_name}_env_cfg::initialize(bit inherit_ral_models = 1'b0);
   list_of_alerts = ${module_instance_name}_env_pkg::LIST_OF_ALERTS;
-  super.initialize();
+  super.initialize(inherit_ral_models);
 
   // Set up the configuration for each of the monitors.
   foreach (m_pwm_monitor_cfg[i]) begin

--- a/hw/ip_templates/pwrmgr/dv/env/pwrmgr_env_cfg.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/pwrmgr_env_cfg.sv
@@ -31,9 +31,9 @@ class pwrmgr_env_cfg extends cip_base_env_cfg #(
   // The run_phase object, to deal with objections.
   uvm_phase run_phase;
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = pwrmgr_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
     num_interrupts = ral.intr_state.get_n_used_bits();
     `ASSERT_I(NumInstrMatch_A, num_interrupts == NUM_INTERRUPTS)
     `uvm_info(`gfn, $sformatf("num_interrupts = %0d", num_interrupts), UVM_MEDIUM)

--- a/hw/ip_templates/rstmgr/dv/env/rstmgr_env_cfg.sv.tpl
+++ b/hw/ip_templates/rstmgr/dv/env/rstmgr_env_cfg.sv.tpl
@@ -23,9 +23,9 @@ class rstmgr_env_cfg extends cip_base_env_cfg #(
   virtual rstmgr_cascading_sva_if rstmgr_cascading_sva_vif;
   virtual rstmgr_if rstmgr_vif;
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = rstmgr_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     tl_intg_alert_fields[ral.err_code.reg_intg_err] = 1;
     m_tl_agent_cfg.max_outstanding_req = 1;

--- a/hw/top_darjeeling/dv/env/chip_env_cfg.sv
+++ b/hw/top_darjeeling/dv/env/chip_env_cfg.sv
@@ -130,7 +130,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   `uvm_object_utils_end
 
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     dv_base_reg_block soc_dbg_base_reg_block;
     dv_base_reg_block soc_mbx_base_reg_block;
     list_of_alerts = chip_common_pkg::LIST_OF_ALERTS;
@@ -147,7 +147,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     // array; the values have no meaning)
     ral_model_names["chip_soc_dbg_reg_block"] = 1'b0;
     ral_model_names["chip_soc_mbx_reg_block"] = 1'b0;
-    super.initialize();
+    super.initialize(inherit_ral_models);
     `uvm_info(`gfn, $sformatf("ral_model_names: %0p", ral_model_names), UVM_LOW);
     soc_dbg_base_reg_block = ral_models["chip_soc_dbg_reg_block"];
     `downcast(chip_soc_dbg_ral, soc_dbg_base_reg_block);

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env_cfg.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env_cfg.sv
@@ -25,7 +25,7 @@ class ac_range_check_env_cfg extends cip_base_env_cfg #(.RAL_T(ac_range_check_re
   extern function new(string name="");
 
   // Class specific methods
-  extern function void initialize();
+  extern virtual function void initialize(bit inherit_ral_models = 1'b0);
 endclass : ac_range_check_env_cfg
 
 
@@ -33,9 +33,9 @@ function ac_range_check_env_cfg::new(string name="");
   super.new(name);
 endfunction : new
 
-function void ac_range_check_env_cfg::initialize();
+function void ac_range_check_env_cfg::initialize(bit inherit_ral_models = 1'b0);
   list_of_alerts = ac_range_check_env_pkg::LIST_OF_ALERTS;
-  super.initialize();
+  super.initialize(inherit_ral_models);
 
   // Set shadow register error status
   tl_intg_alert_fields[ral.alert_status.reg_intg_err] = 1;

--- a/hw/top_darjeeling/ip_autogen/alert_handler/dv/env/alert_handler_env_cfg.sv
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/dv/env/alert_handler_env_cfg.sv
@@ -18,9 +18,9 @@ class alert_handler_env_cfg extends cip_base_env_cfg #(.RAL_T(alert_handler_reg_
 
   `uvm_object_new
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     num_edn = 1;
-    super.initialize();
+    super.initialize(inherit_ral_models);
     shadow_update_err_status_fields[ral.loc_alert_cause[LocalShadowRegUpdateErr].la] = 1;
     shadow_storage_err_status_fields[ral.loc_alert_cause[LocalShadowRegStorageErr].la] = 1;
 

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/clkmgr_env_cfg.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/clkmgr_env_cfg.sv
@@ -26,9 +26,9 @@ class clkmgr_env_cfg extends cip_base_env_cfg #(
 
   `uvm_object_new
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = clkmgr_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     // This is for the integrity error test.
     tl_intg_alert_name = "fatal_fault";

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_env_cfg.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_env_cfg.sv
@@ -24,9 +24,9 @@ class gpio_env_cfg extends cip_base_env_cfg #(
     super.new(name);
   endfunction
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = gpio_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
     // set num_interrupts & num_alerts which will be used to create coverage and more
     num_interrupts = ral.intr_state.get_n_used_bits();
 

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -53,7 +53,7 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
     }
   }
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     string prim_ral_name = "otp_macro_prim_reg_block";
 
     // Request an extra RAL models for the prim registers by adding its name to the set of RAL
@@ -67,7 +67,7 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
     tl_intg_alert_name = "fatal_bus_integ_error";
     sec_cm_alert_name  = "fatal_check_error";
 
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     // create push_pull agent config obj
     for (int i = 0; i < NumSramKeyReqSlots; i++) begin

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_env_cfg.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_env_cfg.sv
@@ -31,9 +31,9 @@ class pwrmgr_env_cfg extends cip_base_env_cfg #(
   // The run_phase object, to deal with objections.
   uvm_phase run_phase;
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = pwrmgr_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
     num_interrupts = ral.intr_state.get_n_used_bits();
     `ASSERT_I(NumInstrMatch_A, num_interrupts == NUM_INTERRUPTS)
     `uvm_info(`gfn, $sformatf("num_interrupts = %0d", num_interrupts), UVM_MEDIUM)

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/rstmgr_env_cfg.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/rstmgr_env_cfg.sv
@@ -23,9 +23,9 @@ class rstmgr_env_cfg extends cip_base_env_cfg #(
   virtual rstmgr_cascading_sva_if rstmgr_cascading_sva_vif;
   virtual rstmgr_if rstmgr_vif;
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = rstmgr_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     tl_intg_alert_fields[ral.err_code.reg_intg_err] = 1;
     m_tl_agent_cfg.max_outstanding_req = 1;

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -135,7 +135,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   `uvm_object_utils_end
 
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = chip_common_pkg::LIST_OF_ALERTS;
     is_chip = 1;
 
@@ -146,7 +146,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     // User can read `loc_alert_cause` to check ping timeout.
     en_scb_ping_chk = 0;
 
-    super.initialize();
+    super.initialize(inherit_ral_models);
     `uvm_info(`gfn, $sformatf("ral_model_names: %0p", ral_model_names), UVM_LOW)
 
     // Set the a_source width limitation for the TL agent hooked up to the CPU cored port.

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_cfg.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_cfg.sv
@@ -18,9 +18,9 @@ class alert_handler_env_cfg extends cip_base_env_cfg #(.RAL_T(alert_handler_reg_
 
   `uvm_object_new
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     num_edn = 1;
-    super.initialize();
+    super.initialize(inherit_ral_models);
     shadow_update_err_status_fields[ral.loc_alert_cause[LocalShadowRegUpdateErr].la] = 1;
     shadow_storage_err_status_fields[ral.loc_alert_cause[LocalShadowRegStorageErr].la] = 1;
 

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/clkmgr_env_cfg.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/clkmgr_env_cfg.sv
@@ -32,9 +32,9 @@ class clkmgr_env_cfg extends cip_base_env_cfg #(
 
   `uvm_object_new
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = clkmgr_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     // This is for the integrity error test.
     tl_intg_alert_name = "fatal_fault";

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -282,7 +282,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
     return region;
   endfunction // get_region_from_info
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     string prim_ral_name = "flash_ctrl_prim_reg_block";
     string fast_rcvr_name = "";
 
@@ -298,7 +298,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
     // both RAL models use same clock frequency
     clk_freqs_mhz[flash_ral_name] = clk_freq_mhz;
     clk_freqs_mhz[prim_ral_name] = clk_freq_mhz;
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     void'($value$plusargs("fast_rcvr_%s", fast_rcvr_name));
     if (fast_rcvr_name != "") begin

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_env_cfg.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_env_cfg.sv
@@ -24,9 +24,9 @@ class gpio_env_cfg extends cip_base_env_cfg #(
     super.new(name);
   endfunction
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = gpio_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
     // set num_interrupts & num_alerts which will be used to create coverage and more
     num_interrupts = ral.intr_state.get_n_used_bits();
 

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -55,7 +55,7 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
     }
   }
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     string prim_ral_name = "otp_macro_prim_reg_block";
 
     // Request an extra RAL models for the prim registers by adding its name to the set of RAL
@@ -69,7 +69,7 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
     tl_intg_alert_name = "fatal_bus_integ_error";
     sec_cm_alert_name  = "fatal_check_error";
 
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     // create push_pull agent config obj
     for (int i = 0; i < NumSramKeyReqSlots; i++) begin

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_env_cfg.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_env_cfg.sv
@@ -31,9 +31,9 @@ class pwrmgr_env_cfg extends cip_base_env_cfg #(
   // The run_phase object, to deal with objections.
   uvm_phase run_phase;
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = pwrmgr_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
     num_interrupts = ral.intr_state.get_n_used_bits();
     `ASSERT_I(NumInstrMatch_A, num_interrupts == NUM_INTERRUPTS)
     `uvm_info(`gfn, $sformatf("num_interrupts = %0d", num_interrupts), UVM_MEDIUM)

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/rstmgr_env_cfg.sv
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/rstmgr_env_cfg.sv
@@ -26,9 +26,9 @@ class rstmgr_env_cfg extends cip_base_env_cfg #(
   virtual rstmgr_cascading_sva_if rstmgr_cascading_sva_vif;
   virtual rstmgr_if rstmgr_vif;
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = rstmgr_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     tl_intg_alert_fields[ral.err_code.reg_intg_err] = 1;
     m_tl_agent_cfg.max_outstanding_req = 1;

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/clkmgr_env_cfg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/clkmgr_env_cfg.sv
@@ -32,9 +32,9 @@ class clkmgr_env_cfg extends cip_base_env_cfg #(
 
   `uvm_object_new
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = clkmgr_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     // This is for the integrity error test.
     tl_intg_alert_name = "fatal_fault";

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -282,7 +282,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
     return region;
   endfunction // get_region_from_info
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     string prim_ral_name = "flash_ctrl_prim_reg_block";
     string fast_rcvr_name = "";
 
@@ -298,7 +298,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
     // both RAL models use same clock frequency
     clk_freqs_mhz[flash_ral_name] = clk_freq_mhz;
     clk_freqs_mhz[prim_ral_name] = clk_freq_mhz;
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     void'($value$plusargs("fast_rcvr_%s", fast_rcvr_name));
     if (fast_rcvr_name != "") begin

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_env_cfg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_env_cfg.sv
@@ -24,9 +24,9 @@ class gpio_env_cfg extends cip_base_env_cfg #(
     super.new(name);
   endfunction
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = gpio_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
     // set num_interrupts & num_alerts which will be used to create coverage and more
     num_interrupts = ral.intr_state.get_n_used_bits();
 

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/pwrmgr_env_cfg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/pwrmgr_env_cfg.sv
@@ -31,9 +31,9 @@ class pwrmgr_env_cfg extends cip_base_env_cfg #(
   // The run_phase object, to deal with objections.
   uvm_phase run_phase;
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = pwrmgr_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
     num_interrupts = ral.intr_state.get_n_used_bits();
     `ASSERT_I(NumInstrMatch_A, num_interrupts == NUM_INTERRUPTS)
     `uvm_info(`gfn, $sformatf("num_interrupts = %0d", num_interrupts), UVM_MEDIUM)

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_env_cfg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_env_cfg.sv
@@ -26,9 +26,9 @@ class rstmgr_env_cfg extends cip_base_env_cfg #(
   virtual rstmgr_cascading_sva_if rstmgr_cascading_sva_vif;
   virtual rstmgr_if rstmgr_vif;
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
     list_of_alerts = rstmgr_env_pkg::LIST_OF_ALERTS;
-    super.initialize();
+    super.initialize(inherit_ral_models);
 
     tl_intg_alert_fields[ral.err_code.reg_intg_err] = 1;
     m_tl_agent_cfg.max_outstanding_req = 1;

--- a/util/uvmdvgen/env_cfg.sv.tpl
+++ b/util/uvmdvgen/env_cfg.sv.tpl
@@ -23,12 +23,12 @@ class ${name}_env_cfg extends dv_base_env_cfg;
 
   `uvm_object_new
 
-  virtual function void initialize();
+  virtual function void initialize(bit inherit_ral_models = 1'b0);
 % if has_alerts:
     list_of_alerts = ${name}_env_pkg::LIST_OF_ALERTS;
 % endif
 % if has_ral:
-    super.initialize();
+    super.initialize(inherit_ral_models);
 % endif
 % for agent in env_agents:
     // create ${agent} agent config obj


### PR DESCRIPTION
If set, this flag tells (the config object of) an environment not to build its own uvm_reg_blocks in the initialize() function but instead to expect them to have been supplied already.

This allows the next level up to fill in the config object in that level's build_phase.
