### PR TITLE
[dv] Remove dv_base_reg_block::csr_addrs and its uses

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -83,7 +83,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
 
     foreach (cfg.ral_models[ral_name]) begin
       bit has_unmapped  = (cfg.ral_models[ral_name].unmapped_addr_ranges.size > 0);
-      bit has_csr       = (cfg.ral_models[ral_name].csr_addrs.size > 0);
+      bit has_csr       = cfg.ral_models[ral_name].has_csrs();
       bit has_mem       = (cfg.ral_models[ral_name].get_num_memories() > 0);
       bit has_mem_byte_access_err;
       bit has_wo_mem;
@@ -653,6 +653,24 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
             write_w_instr_type_err | instr_type_err | cfg.tl_mem_access_gated | csr_read_err);
   endfunction
 
+  // Return true if accessing size_bytes bytes starting at addr will address at least one register
+  // in block when using the default map.
+  local function bit touches_register(uvm_reg_addr_t    addr,
+                                      int unsigned      size_bytes,
+                                      dv_base_reg_block block);
+    uvm_reg_addr_t hi_addr = addr + size_bytes - 1;
+    uvm_reg_addr_t aligned_lo = block.get_word_aligned_addr(addr);
+    uvm_reg_addr_t aligned_hi = block.get_word_aligned_addr(hi_addr);
+
+    for (uvm_reg_addr_t a = aligned_lo; a <= aligned_hi; a++) begin
+      // We pass read=0 here because the implementation of uvm_reg_map means that this will also
+      // find write-only registers.
+      if (block.get_default_map().get_reg_by_offset(a, 1'b0) != null) return 1'b1;
+    end
+
+    return 1'b0;
+  endfunction
+
   protected function void check_tl_read_value_after_error(tl_seq_item item,
                                                           dv_base_reg_block block);
     bit [DataWidth-1:0] exp_data;
@@ -663,8 +681,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
     // When the access target was the memory, tlul_adapter_sram either returns
     // DataWhenInstrError ('1) or DataWhenError ('0) depending whether it was a
     // instruction type access or not.
-    uvm_reg_addr_t csr_addr = block.get_word_aligned_addr(item.a_addr);
-    if (csr_addr inside {block.csr_addrs}) begin
+    if (touches_register(item.a_addr, 1 << item.a_size, block)) begin
       exp_data = '1;
     end else begin
       // if error occurs when it's an instruction, return all 0 since it's an illegal instruction
@@ -675,11 +692,15 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
     `DV_CHECK_EQ(item.d_data, exp_data, "d_data mismatch when d_error = 1")
   endfunction
 
-  // Return true if the given address is mapped in the register block
+  // Return true if addr points at a register or inside a memory with the default reg_map for this
+  // block.
   local function bit is_tl_access_mapped_addr(bit [AddrWidth-1:0] addr, dv_base_reg_block block);
+    uvm_reg_map map = block.get_default_map();
     uvm_reg_addr_t norm_addr = block.get_normalized_addr(addr);
-    // check if it's mem addr or reg addr
-    return is_mem_addr(addr, block) || norm_addr inside {block.csr_addrs};
+
+    // Check if it's a memory or register adddress. Passning read=0 to get_reg_by_offset means that
+    // the code in uvm_reg_map will report write-only registers too.
+    return is_mem_addr(norm_addr, block) || (map.get_reg_by_offset(norm_addr, 1'b0) != null);
   endfunction
 
   // check if tl mem access will trigger error or not

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -242,9 +242,19 @@ task tl_write_ro_mem_err(string            ral_name,
 endtask
 
 // Return the address of the csr at a random index
-virtual function bit[BUS_AW-1:0] pick_rand_csr_addr (string ral_name, dv_base_reg_block block);
-  int index = $urandom_range(0, block.csr_addrs.size() - 1);
-  return block.csr_addrs[index];
+virtual function bit[BUS_AW-1:0] pick_rand_csr_addr (dv_base_reg_block block);
+  uvm_reg regs[$];
+  uvm_reg chosen_reg;
+  block.get_registers(regs, UVM_HIER);
+
+  if (regs.size() == 0) begin
+    `uvm_fatal(get_name(),
+               $sformatf("Cannot pick a random address: block %0s has no CSRs.", block.get_name()))
+  end
+
+  chosen_reg = regs[$urandom_range(0, regs.size() - 1)];
+
+  return chosen_reg.get_address();
 endfunction
 
 // Generate a stream of transactions that trigger errors connected with instr_type. This is either
@@ -255,8 +265,7 @@ endfunction
 // reset), stop generating transactions and return.
 virtual task tl_instr_type_err(string ral_name);
   dv_base_reg_block ral_model = cfg.ral_models[ral_name];
-  bit has_nofetch_csrs = ((ral_model.csr_addrs.size() > 0) &&
-                          !ral_model.get_allows_csr_fetch());
+  bit has_nofetch_csrs = ral_model.has_csrs() && !ral_model.get_allows_csr_fetch();
 
   repeat ($urandom_range(10, 100)) begin
     bit [BUS_AW-1:0] addr;
@@ -285,7 +294,7 @@ virtual task tl_instr_type_err(string ral_name);
       has_nofetch_csrs: begin
         write = 1'b0;
         instr_type = MuBi4True;
-        addr = pick_rand_csr_addr(ral_name, ral_model);
+        addr = pick_rand_csr_addr(ral_model);
       end
     endcase
 
@@ -310,8 +319,7 @@ virtual task run_tl_errors_vseq_sub(bit do_wait_clk = 0, string ral_name);
   dv_base_reg_block ral_model = cfg.ral_models[ral_name];
   bit [BUS_AW-1:0]  csr_base_addr = ral_model.default_map.get_base_addr();
   bit               has_mem_byte_access_err, has_wo_mem, has_ro_mem;
-
-  bit has_csr_addrs = (ral_model.csr_addrs.size() > 0);
+  bit               has_csrs = ral_model.has_csrs();
 
   // get_addr_mask returns address map size - 1 and get_max_offset return the offset of high byte
   // in address map. The difference btw them is unmapped address
@@ -344,7 +352,7 @@ virtual task run_tl_errors_vseq_sub(bit do_wait_clk = 0, string ral_name);
               1: tl_protocol_err(ral_name);
 
               // If there are CSRs, send writes with invalid byte enable masks to all of them
-              has_csr_addrs: tl_write_less_than_csr_width(ral_name, ral_model);
+              has_csrs: tl_write_less_than_csr_width(ral_name, ral_model);
 
               // If there are some unmapped addresses, generate transactions that access them.
               ral_model.has_unmapped_addrs: tl_access_unmapped_addr(ral_name, ral_model);

--- a/hw/dv/sv/csr_utils/README.md
+++ b/hw/dv/sv/csr_utils/README.md
@@ -77,7 +77,6 @@ This reset information is tracked by `dv_base_scoreboard` (using its
 ##### Global methods for CSR and MEM attributes
 This package provides methods to access CSR or Memory attributes, such as address,
 value, etc. Examples are:
- * `get_csr_addrs`
  * `get_mem_addr_ranges`
  * `decode_csr_or_field`
 

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -37,12 +37,6 @@ class dv_base_reg_block extends uvm_reg_block;
   // This is set by compute_addr_mask(), which must run after locking the model.
   protected uvm_reg_addr_t addr_mask[uvm_reg_map];
 
-  // A list of all CSR addresses
-  //
-  // This is populated by compute_csr_addrs, which iterates over the registers in the block and adds
-  // each register's address in turn.
-  uvm_reg_addr_t csr_addrs[$];
-
   // A list of all ranges associated with memories, ordered by increasing start address.
   //
   // To get the list of memory ranges, use get_mem_ranges (which is memoized).
@@ -245,20 +239,7 @@ class dv_base_reg_block extends uvm_reg_block;
     `DV_CHECK_FATAL(addr_mask[map])
   endfunction
 
-  // Internal function, used to get a list of all valid CSR addresses.
-  //
-  // This is idempotent and will re-calculate the same list if called a second time.
-  local function void compute_csr_addrs();
-    uvm_reg csrs[$];
-    get_registers(csrs);
-    csr_addrs.delete();
-    foreach (csrs[i]) begin
-      csr_addrs.push_back(csrs[i].get_address());
-    end
-    `uvm_info(`gfn, $sformatf("csr_addrs: %0p", csr_addrs), UVM_HIGH)
-  endfunction
-
-  // Ensure that m_mem_ranges has a list of all the memory ranges associated with memory.
+  // Internal function, used to get a list of all valid memory ranges
   //
   // Note that the block might not have any memories, in which case m_mem_ranges will be empty after
   // this function.
@@ -332,8 +313,7 @@ class dv_base_reg_block extends uvm_reg_block;
 
     get_registers(csrs);
 
-    // Compute all CSR addresses and mem ranges known to this reg block
-    compute_csr_addrs();
+    // Compute all mem ranges known to this reg block
     get_mem_ranges(mem_ranges);
 
     // Convert each CSR into an address range
@@ -448,8 +428,8 @@ class dv_base_reg_block extends uvm_reg_block;
   // randomize_base_addr arg is set, then the base_addr arg is ignored - the function randomizes and
   // sets the base_addr itself.
   //
-  // After setting the base address, this function updates csr_addrs, m_mem_ranges,
-  // mapped_addr_ranges and unmapped_addr_ranges.
+  // After setting the base address, this function updates m_mem_ranges, mapped_addr_ranges and
+  // unmapped_addr_ranges.
   function void set_base_addr(uvm_reg_addr_t base_addr, uvm_reg_map map = null,
                               bit randomize_base_addr = 0);
     uvm_reg_addr_t mask;
@@ -551,6 +531,17 @@ class dv_base_reg_block extends uvm_reg_block;
 
   function bit get_en_dv_reg_cov();
     return en_dv_reg_cov;
+  endfunction
+
+  // Return true if there is at least one register in this reg block or a child block
+  //
+  // This is equivalent to calling get_registers with hier=UVM_HIER (so that it recurses). It is no
+  // more efficient, but is slightly more convenient because the call-site doesn't need to create a
+  // queue to be passed as a reference.
+  function bit has_csrs();
+    uvm_reg regs[$];
+    get_registers(regs, UVM_HIER);
+    return regs.size() > 0;
   endfunction
 
 endclass

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_scoreboard.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_scoreboard.sv
@@ -208,11 +208,8 @@ class adc_ctrl_scoreboard extends cip_base_scoreboard #(
     bit            data_phase_write = (write && channel == DataChannel);
     uvm_reg_data_t write_data;
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -340,11 +340,8 @@ class aes_scoreboard extends cip_base_scoreboard #(
     bit            write         = item.is_write();
     uvm_reg_addr_t csr_addr      = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/ip/aon_timer/dv/env/aon_timer_scoreboard.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_scoreboard.sv
@@ -486,7 +486,6 @@ task aon_timer_scoreboard::predict_intr_state(bit [1:0] pred_intr_state, bit fie
         begin: iso_fork
           fork
             begin : intr_state_timely
-              bit exit_loop;
               // The update can occur at the same time as a read access. This could occur in the A
               // or D channels.
               // If we predicted an update during the A or D-phase, we need to hold the prediction
@@ -496,29 +495,16 @@ task aon_timer_scoreboard::predict_intr_state(bit [1:0] pred_intr_state, bit fie
               // D-phase handshake doesn't give information related to the TL-access and address.
               while (cfg.m_tl_agent_cfg.vif.h2d.a_valid && cfg.m_tl_agent_cfg.vif.d2h.a_ready) begin
                 if (cfg.m_tl_agent_cfg.vif.h2d.a_opcode == tlul_pkg::Get) begin
-                  bit [AddrWidth - 1   : 0] a_addr = cfg.m_tl_agent_cfg.vif.h2d.a_address;
-                  string                    ral_name = "aon_timer_reg_block";
-                  uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(a_addr);
-                  if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-                    uvm_reg csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-
-                    if(csr != null) begin
-                      if(csr.get_name() == "intr_state")
-                        cfg.clk_rst_vif.wait_n_clks(1);
-                      else
-                        exit_loop = 1;
-                    end
-                    else
-                      exit_loop = 1;
+                  bit [AddrWidth-1: 0] a_addr = cfg.m_tl_agent_cfg.vif.h2d.a_address;
+                  uvm_reg csr = cfg.ral.get_default_map().get_reg_by_offset(a_addr);
+                  if (csr == cfg.ral.intr_state) begin
+                    cfg.clk_rst_vif.wait_n_clks(1);
+                  end else begin
+                    break;
                   end
-                  else
-                    exit_loop = 1;
-                end
-                else
-                  exit_loop = 1;
-
-                if (exit_loop)
+                end else begin
                   break;
+                end
               end
               // If the update occurs during the D-phase, we wait until the D-phase ends
               if (ongoing_intr_state_read > 0) begin
@@ -677,12 +663,8 @@ task aon_timer_scoreboard::process_tl_access(tl_seq_item item, tl_channels_e cha
   bit data_phase_read   = (!write && channel == DataChannel);
   bit data_phase_write  = (write && channel == DataChannel);
 
-  // if access was to a valid csr, get the csr handle
-  if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-    csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-    `DV_CHECK_NE_FATAL(csr, null)
-  end
-  else begin
+  csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+  if (csr == null) begin
     `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
   end
 

--- a/hw/ip/csrng/dv/env/csrng_scoreboard.sv
+++ b/hw/ip/csrng/dv/env/csrng_scoreboard.sv
@@ -148,12 +148,8 @@ class csrng_scoreboard extends cip_base_scoreboard #(
     bit data_phase_read   = (!write && channel == DataChannel);
     bit data_phase_write  = (write && channel == DataChannel);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end
-    else begin
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/ip/dma/dv/env/dma_scoreboard.sv
+++ b/hw/ip/dma/dv/env/dma_scoreboard.sv
@@ -1412,17 +1412,12 @@ class dma_scoreboard extends cip_base_scoreboard #(
 
   // Main method to process transactions on register configuration interface
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
-    uvm_reg csr;
-
     bit write = item.is_write();
 
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
-      `uvm_fatal(`gfn, $sformatf("\naccess unexpected addr 0x%0h", csr_addr))
+    uvm_reg csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
+      `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 
     // The access is to a valid CSR, now process it.

--- a/hw/ip/edn/dv/env/edn_scoreboard.sv
+++ b/hw/ip/edn/dv/env/edn_scoreboard.sv
@@ -136,11 +136,8 @@ class edn_scoreboard extends cip_base_scoreboard #(
     bit main_sm_done;
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end
-    else begin
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -1472,10 +1472,8 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
     dut_reg_locked = ~`gmv(ral.regwen.regwen);
 
     // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -122,16 +122,19 @@ task hmac_scoreboard::process_tl_access(tl_seq_item item, tl_channels_e channel,
   bit     write                   = item.is_write();
   bit [TL_AW-1:0] addr_mask       = ral.get_addr_mask();
   uvm_reg_addr_t  csr_addr        = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
+  uvm_reg_addr_t  masked_addr     = item.a_addr & addr_mask;
 
-  // if access was to a valid csr, get the csr handle
-  if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-    csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-    `DV_CHECK_NE_FATAL(csr, null)
+  // If this is an access to a CSR, get the handle. If not, it should lie in the range
+  // [HMAC_MSG_FIFO_BASE:HMAC_MSG_FIFO_LAST_ADDR].
+
+  csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+  if (csr != null) begin
     csr_name = csr.get_name();
-  // if addr inside msg fifo, no ral model
-  end else if (!((item.a_addr & addr_mask) inside {[HMAC_MSG_FIFO_BASE :
-                                                    HMAC_MSG_FIFO_LAST_ADDR]})) begin
-    `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
+  end else if (!(masked_addr inside {[HMAC_MSG_FIFO_BASE:HMAC_MSG_FIFO_LAST_ADDR]})) begin
+    `uvm_fatal(get_full_name(),
+               $sformatf({"Address 0x%0h (from address 0x%0h) is not a register ",
+                          "and does not lie in the msg fifo range (0x%0h..0x%0h)."},
+                         csr_addr, item.a_addr, HMAC_MSG_FIFO_BASE, HMAC_MSG_FIFO_LAST_ADDR))
   end
 
   // if incoming access is a write to a valid csr or mem, then update right away on addr channel

--- a/hw/ip/i2c/dv/env/i2c_scoreboard.sv
+++ b/hw/ip/i2c/dv/env/i2c_scoreboard.sv
@@ -237,14 +237,12 @@ class i2c_scoreboard extends cip_base_scoreboard #(
     bit tl_accessackdata = (!write && channel == DataChannel); // read
     bit tl_accessack     =  (write && channel == DataChannel);
 
-    // If access was not addressed to a valid csr, raise a fatal error
-    if (!(csr_addr inside {i2c_ral.csr_addrs})) begin
+    // The access was to a valid csr, so get the corresponding RAL csr handle. If access was not
+    // addressed to a valid csr, raise a fatal error.
+    csr = i2c_ral.get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("An unexpected addr 0x%8h was accessed.", csr_addr))
     end
-
-    // The access was to a valid csr, so get the corresponding RAL csr handle
-    csr = i2c_ral.default_map.get_reg_by_offset(csr_addr);
-    `DV_CHECK_NE_FATAL(csr, null)
 
     // Update the reference model based on the TL-UL access
     // - This also updates the RAL

--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -416,14 +416,14 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
     bit data_phase_read   = (!write && channel == DataChannel);
     bit data_phase_write  = (write && channel == DataChannel);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-      `downcast(dv_reg, csr)
-    end
-    else begin
+    // Get a handle to the CSR being accessed.
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
+    end
+    if (!$cast(dv_reg, csr)) begin
+      `uvm_fatal(get_full_name(),
+                 $sformatf("Cannot cast register %0s to a dv_base_reg.", csr.get_name()))
     end
 
     // if incoming access is a write to a valid csr, then make updates right away

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
@@ -534,14 +534,14 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     bit data_phase_read   = (!write && channel == DataChannel);
     bit data_phase_write  = (write && channel == DataChannel);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-      `downcast(dv_reg, csr)
-    end
-    else begin
+    // Get a handle to the CSR being accessed.
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
+    end
+    if (!$cast(dv_reg, csr)) begin
+      `uvm_fatal(get_full_name(),
+                 $sformatf("Cannot cast register %0s to a dv_base_reg.", csr.get_name()))
     end
 
     // if incoming access is a write to a valid csr, then make updates right away

--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -655,10 +655,8 @@ class kmac_scoreboard extends cip_base_scoreboard #(.CFG_T(kmac_env_cfg),
     // time.
     msgfifo_access = 0;
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr != null) begin
       `downcast(dv_base_csr, csr)
 
       csr_name = csr.get_name();

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
@@ -272,11 +272,8 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
     bit             data_phase_read = (!write && channel == DataChannel);
     bit             data_phase_write = (write && channel == DataChannel);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/ip/pattgen/dv/env/pattgen_scoreboard.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_scoreboard.sv
@@ -100,12 +100,9 @@ task pattgen_scoreboard::process_tl_access(tl_seq_item   item,
   bit data_phase_read  = (!write && channel == DataChannel);
 
   uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
-  // if access was to a valid csr, get the csr handle
-  if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-    csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-    `DV_CHECK_NE_FATAL(csr, null)
-  end else begin
-    `uvm_fatal(`gfn, $sformatf("\naccess unexpected addr 0x%0h", csr_addr))
+  csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+  if (csr == null) begin
+    `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
   end
 
   // address write phase

--- a/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
@@ -35,20 +35,16 @@ class rv_timer_scoreboard extends cip_base_scoreboard #(.CFG_T (rv_timer_env_cfg
   endtask
 
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
-    uvm_reg csr;
     string  csr_name;
     bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
-
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-      csr_name = csr.get_name();
-    end else begin
+    uvm_reg csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
+
+    csr_name = csr.get_name();
 
     if (!write && channel == AddrChannel) begin
       if (!uvm_re_match("intr_state*", csr_name)) begin

--- a/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_scoreboard.sv
+++ b/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_scoreboard.sv
@@ -95,13 +95,8 @@ task soc_dbg_ctrl_scoreboard::process_tl_core_access(
   tl_seq_item item, uvm_reg_addr_t csr_addr, tl_phase_e tl_phase);
   string  ral_name      = ral.get_name();
   bit     do_read_check = 1;
-  uvm_reg csr;
-
-  // If access was to a valid CSR, get the CSR handle
-  if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-    csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-    `DV_CHECK_NE_FATAL(csr, null)
-  end else begin
+  uvm_reg csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+  if (csr == null) begin
     `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
   end
 

--- a/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
@@ -2111,30 +2111,31 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
   // process_tl_access:this task processes incoming access into the IP over tl interface
   // this is already called in cip_base_scoreboard::process_tl_a/d_chan_fifo tasks
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
-    uvm_reg csr;
     bit     do_read_check   = 1'b0; // TODO: fixme
     bit     write           = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
+    uvm_reg csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end
-    else if (csr_addr inside {[cfg.sram_egress_start_addr:cfg.sram_egress_end_addr]}) begin
-      // TODO: Anything to do here?
-      return;
-    end
-    else if (csr_addr inside {[cfg.sram_ingress_start_addr:cfg.sram_ingress_end_addr]}) begin
-      if (!write) begin
-        // cip_base_scoreboard compares the mem read only when the address exists
-        // just need to ensure address exists here and mem check is done at process_mem_read
-        `DV_CHECK(spi_mem.addr_exists(csr_addr))
+    if (csr == null) begin
+      if (csr_addr inside {[cfg.sram_egress_start_addr:cfg.sram_egress_end_addr]}) begin
+        // TODO: Anything to do here?
+        return;
       end
-      return;
-    end
-    else begin
-      `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
+      else if (csr_addr inside {[cfg.sram_ingress_start_addr:cfg.sram_ingress_end_addr]}) begin
+        if (!write) begin
+          // cip_base_scoreboard compares the mem read only when the address exists
+          // just need to ensure address exists here and mem check is done at process_mem_read
+          `DV_CHECK(spi_mem.addr_exists(csr_addr))
+        end
+        return;
+      end
+
+      `uvm_fatal(`gfn,
+                 $sformatf({"Address 0x%0h is neither a CSR, nor in the SRAM egress range ",
+                            "(0x%0h..0x%0h) or ingress range (0x%0h..0x%0h)."},
+                           csr_addr,
+                           cfg.sram_ingress_start_addr, cfg.sram_ingress_end_addr,
+                           cfg.sram_egress_start_addr, cfg.sram_egress_end_addr))
     end
 
     `uvm_info(`gfn,$sformatf(

--- a/hw/ip/spi_host/dv/env/spi_host_scoreboard.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_scoreboard.sv
@@ -568,17 +568,24 @@ class spi_host_scoreboard extends cip_base_scoreboard #(
     // Process the csr req
     // For writes, update local variables and fifo at address phase
     // For reads, update prediction at address phase and compare at data phase
-    end else if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      // If access was to a valid csr, get the csr handle
+    end else begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
+      if (csr == null) begin
+        `uvm_fatal(get_full_name(),
+                   $sformatf({"Access to unexpected address 0x%0h (neither a CSR nor in the ",
+                              "RX FIFO (range 0x%0h..0x%0h) or the TX FIFO (range 0x%0h..0x%0h)"},
+                             csr_addr,
+                             SPI_HOST_RX_FIFO_START, SPI_HOST_RX_FIFO_END,
+                             SPI_HOST_TX_FIFO_START, SPI_HOST_TX_FIFO_END))
+      end
+
+      csr_name = csr.get_name();
+
       // If incoming access is a write to a valid csr, then make updates right away
       if (cmd_phase_write) begin
         void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
       end
-      csr_name = csr.get_name();
-
-    end else `uvm_fatal(`gfn, $sformatf("\n  scb: access unexpected addr 0x%0h", csr_addr))
+    end
 
     `uvm_info(`gfn, $sformatf("%m - csr_name = %s, write = %0d, channel = %s",
                               csr_name, write, channel.name), UVM_DEBUG)

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -546,12 +546,8 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
       return;
     end
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end
-    else begin
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_scoreboard.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_scoreboard.sv
@@ -71,11 +71,8 @@ class sysrst_ctrl_scoreboard extends cip_base_scoreboard #(
     bit            data_phase_read = (!write && channel == DataChannel);
     bit            data_phase_write = (write && channel == DataChannel);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/ip/uart/dv/env/uart_scoreboard.sv
+++ b/hw/ip/uart/dv/env/uart_scoreboard.sv
@@ -163,11 +163,8 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
     bit     write           = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
@@ -634,11 +634,9 @@ class usbdev_scoreboard extends cip_base_scoreboard #(
                                  output uvm_reg csr, output int unsigned index);
     // Attempt to locate a CSR at this address.
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      string csr_name;
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-      csr_name = csr.get_name();
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr != null) begin
+      string csr_name = csr.get_name();
       index = get_index_from_reg_name(csr_name);
       return csr_name;
     end else if (is_mem_addr(item.a_addr, cfg.ral_models[ral_name])) begin

--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_scoreboard.sv.tpl
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_scoreboard.sv.tpl
@@ -238,26 +238,25 @@ task ${module_instance_name}_scoreboard::process_tl_access(tl_seq_item item,
   if ( write && channel == DataChannel) tl_phase = DChanWrite;
 
   // If access was to a valid csr, get the csr handle
-  if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-    csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-    `DV_CHECK_NE_FATAL(csr, null)
-    // When the CSR is defined as an array, simplify the name to make it generic. This will be
-    // useful if the template parameter "num_ranges" is changed.
-    if (csr.get_type_name() == "${module_instance_name}_reg_range_regwen") begin
-      csr_name = "range_regwen";
-    end else if (csr.get_type_name() == "${module_instance_name}_reg_range_base") begin
-      csr_name = "range_base";
-    end else if (csr.get_type_name() == "${module_instance_name}_reg_range_limit") begin
-      csr_name = "range_limit";
-    end else if (csr.get_type_name() == "${module_instance_name}_reg_range_attr") begin
-      csr_name = "range_attr";
-    end else if (csr.get_type_name() == "${module_instance_name}_reg_range_racl_policy_shadowed") begin
-      csr_name = "range_racl_policy_shadowed";
-    end else begin
-      csr_name = csr.get_name();
-    end
-  end else begin
+  csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+  if (csr == null) begin
     `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
+  end
+
+  // When the CSR is defined as an array, simplify the name to make it generic. This will be
+  // useful if the template parameter "num_ranges" is changed.
+  if (csr.get_type_name() == "${module_instance_name}_reg_range_regwen") begin
+    csr_name = "range_regwen";
+  end else if (csr.get_type_name() == "${module_instance_name}_reg_range_base") begin
+    csr_name = "range_base";
+  end else if (csr.get_type_name() == "${module_instance_name}_reg_range_limit") begin
+    csr_name = "range_limit";
+  end else if (csr.get_type_name() == "${module_instance_name}_reg_range_attr") begin
+    csr_name = "range_attr";
+  end else if (csr.get_type_name() == "${module_instance_name}_reg_range_racl_policy_shadowed") begin
+    csr_name = "range_racl_policy_shadowed";
+  end else begin
+    csr_name = csr.get_name();
   end
 
   csr_idx = get_csr_idx(csr.get_name(), csr_name);

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_scoreboard.sv.tpl
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_scoreboard.sv.tpl
@@ -348,23 +348,19 @@ class ${module_instance_name}_scoreboard extends cip_base_scoreboard #(
   endfunction
 
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
-    uvm_reg        csr;
     dv_base_reg    dv_base_csr;
     bit            do_read_check   = 1'b1;
     bit            write           = item.is_write();
     uvm_reg_addr_t csr_addr = {item.a_addr[TL_AW-1:2], 2'b00};
+    uvm_reg        csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = ral.default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-      `downcast(dv_base_csr, csr)
-    end
     if (csr == null) begin
       // we hit an oob addr - expect error response and return
       `DV_CHECK_EQ(item.d_error, 1'b1)
       return;
     end
+
+    `downcast(dv_base_csr, csr)
 
     if (channel == AddrChannel) begin
       // if incoming access is a write to a valid csr, then make updates right away

--- a/hw/ip_templates/clkmgr/dv/env/clkmgr_scoreboard.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/clkmgr_scoreboard.sv.tpl
@@ -252,11 +252,8 @@ ${spc}cfg.clkmgr_vif.scanmode_i == MuBi4True);
     string         access_str = write ? "write" : "read";
     string         channel_str = channel == AddrChannel ? "address" : "data";
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -203,27 +203,27 @@ class flash_ctrl_scoreboard #(
   endfunction
 
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
-    uvm_reg        csr;
     string         csr_wr_name = "";
     bit            do_read_check = 1'b1;
     bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
+    uvm_reg        csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    bit            mem_addr;
 
     bit            addr_phase_read = (!write && channel == AddrChannel);
     bit            addr_phase_write = (write && channel == AddrChannel);
     bit            data_phase_read = (!write && channel == DataChannel);
     bit            data_phase_write = (write && channel == DataChannel);
     bit            erase_req;
-    if (skip_read_check) do_read_check = 0;
-    // if access was to a valid csr, get the csr handle
-    if ((is_mem_addr(
-            item.a_addr, cfg.ral_models[ral_name]
-        ) || (csr_addr inside {cfg.ral_models[ral_name].csr_addrs})) &&
-            !cfg.dir_rd_in_progress) begin
 
+    if (skip_read_check) do_read_check = 0;
+
+    mem_addr = is_mem_addr(item.a_addr, cfg.ral_models[ral_name]);
+
+    if (mem_addr || (csr != null && !cfg.dir_rd_in_progress)) begin
       // if incoming access is a write to a valid csr, then make updates right away.
       if (addr_phase_write) begin
-        if (is_mem_addr(item.a_addr, cfg.ral_models[ral_name]) && cfg.scb_check) begin  // prog fifo
+        if (mem_addr && cfg.scb_check) begin  // prog fifo
           if (idx_wr == 0) begin
             csr_rd(.ptr(ral.addr), .value(data), .backdoor(1'b1));
             wr_addr = word_align_addr(get_field_val(ral.addr.start, data));
@@ -247,9 +247,7 @@ class flash_ctrl_scoreboard #(
           end else begin
             idx_wr += 1;
           end
-        end else if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-          csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-          `DV_CHECK_NE_FATAL(csr, null)
+        end else if (csr != null) begin
           csr_wr_name = csr.get_name();
           void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
           `uvm_info(`gfn, $sformatf("SCB EXP FLASH REG: 0x%0h", csr_addr), UVM_HIGH)
@@ -332,9 +330,7 @@ class flash_ctrl_scoreboard #(
       end
 
       if (data_phase_read) begin
-        if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-          csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-          `DV_CHECK_NE_FATAL(csr, null)
+        if (csr != null) begin
           // process the csr req
           // for write, update local variable and fifo at address phase
           // for read, update prediction at address phase and compare at data phase
@@ -382,7 +378,7 @@ class flash_ctrl_scoreboard #(
                          "reg name: %0s", csr.get_full_name()))
           end
           void'(csr.predict(.value(item.d_data), .kind(UVM_PREDICT_READ)));
-        end else if (is_mem_addr(item.a_addr, cfg.ral_models[ral_name]) && cfg.scb_check) begin
+        end else if (mem_addr && cfg.scb_check) begin
           // rd fifo
           if (idx_rd == 0) begin
             csr_rd(.ptr(ral.addr), .value(data), .backdoor(1'b1));

--- a/hw/ip_templates/gpio/dv/env/gpio_scoreboard.sv.tpl
+++ b/hw/ip_templates/gpio/dv/env/gpio_scoreboard.sv.tpl
@@ -65,16 +65,11 @@ class ${module_instance_name}_scoreboard extends cip_base_scoreboard #(.CFG_T ($
   // Task : process_tl_access
   // process monitored tl transaction
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
-    uvm_reg csr;
     bit do_read_check       = 1'b1;
     bit write               = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
-
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
+    uvm_reg csr             = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv.tpl
@@ -612,17 +612,14 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       bit data_phase_read, bit data_phase_write);
 
     bit         do_read_check = 1;
-    uvm_reg     csr;
+    uvm_reg     csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
     dv_base_reg dv_reg;
     string      csr_name;
 
     `uvm_info(`gfn, $sformatf("sw state %d, reg state %d", direct_access_regwen_state,
                              `gmv(ral.direct_access_regwen)), UVM_LOW);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
+    if (csr != null) begin
       `downcast(dv_reg, csr)
     // SW CFG window
     end else if ((csr_addr & addr_mask) inside

--- a/hw/ip_templates/pwm/dv/env/pwm_scoreboard.sv.tpl
+++ b/hw/ip_templates/pwm/dv/env/pwm_scoreboard.sv.tpl
@@ -133,15 +133,13 @@ task ${module_instance_name}_scoreboard::process_tl_access(tl_seq_item   item,
   bit             addr_phase_write = (write && channel  == AddrChannel);
   bit             data_phase_read  = (!write && channel == DataChannel);
 
-  // if access was to a valid csr, get the csr handle
-  if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-    csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-    `DV_CHECK_NE_FATAL(csr, null)
-    // Extract register index indicating the channel number.
-    idx = get_multireg_idx(csr.get_name());
-  end else begin
+  csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+  if (csr == null) begin
     `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
   end
+
+  // Extract register index indicating the channel number.
+  idx = get_multireg_idx(csr.get_name());
 
   // The REGWEN register controls write access to all of the DUT registers, including itself.
   if (addr_phase_write && `gmv(ral.regwen.regwen)) begin

--- a/hw/ip_templates/pwrmgr/dv/env/pwrmgr_scoreboard.sv.tpl
+++ b/hw/ip_templates/pwrmgr/dv/env/pwrmgr_scoreboard.sv.tpl
@@ -230,11 +230,8 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
     bit            data_phase_read = (!write && channel == DataChannel);
     bit            data_phase_write = (write && channel == DataChannel);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/ip_templates/rstmgr/dv/env/rstmgr_scoreboard.sv
+++ b/hw/ip_templates/rstmgr/dv/env/rstmgr_scoreboard.sv
@@ -141,11 +141,8 @@ class rstmgr_scoreboard extends cip_base_scoreboard #(
     bit            data_phase_read = (!write && channel == DataChannel);
     bit            data_phase_write = (write && channel == DataChannel);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_scoreboard.sv
@@ -238,26 +238,25 @@ task ac_range_check_scoreboard::process_tl_access(tl_seq_item item,
   if ( write && channel == DataChannel) tl_phase = DChanWrite;
 
   // If access was to a valid csr, get the csr handle
-  if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-    csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-    `DV_CHECK_NE_FATAL(csr, null)
-    // When the CSR is defined as an array, simplify the name to make it generic. This will be
-    // useful if the template parameter "num_ranges" is changed.
-    if (csr.get_type_name() == "ac_range_check_reg_range_regwen") begin
-      csr_name = "range_regwen";
-    end else if (csr.get_type_name() == "ac_range_check_reg_range_base") begin
-      csr_name = "range_base";
-    end else if (csr.get_type_name() == "ac_range_check_reg_range_limit") begin
-      csr_name = "range_limit";
-    end else if (csr.get_type_name() == "ac_range_check_reg_range_attr") begin
-      csr_name = "range_attr";
-    end else if (csr.get_type_name() == "ac_range_check_reg_range_racl_policy_shadowed") begin
-      csr_name = "range_racl_policy_shadowed";
-    end else begin
-      csr_name = csr.get_name();
-    end
-  end else begin
+  csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+  if (csr == null) begin
     `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
+  end
+
+  // When the CSR is defined as an array, simplify the name to make it generic. This will be
+  // useful if the template parameter "num_ranges" is changed.
+  if (csr.get_type_name() == "ac_range_check_reg_range_regwen") begin
+    csr_name = "range_regwen";
+  end else if (csr.get_type_name() == "ac_range_check_reg_range_base") begin
+    csr_name = "range_base";
+  end else if (csr.get_type_name() == "ac_range_check_reg_range_limit") begin
+    csr_name = "range_limit";
+  end else if (csr.get_type_name() == "ac_range_check_reg_range_attr") begin
+    csr_name = "range_attr";
+  end else if (csr.get_type_name() == "ac_range_check_reg_range_racl_policy_shadowed") begin
+    csr_name = "range_racl_policy_shadowed";
+  end else begin
+    csr_name = csr.get_name();
   end
 
   csr_idx = get_csr_idx(csr.get_name(), csr_name);

--- a/hw/top_darjeeling/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -348,23 +348,19 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
   endfunction
 
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
-    uvm_reg        csr;
     dv_base_reg    dv_base_csr;
     bit            do_read_check   = 1'b1;
     bit            write           = item.is_write();
     uvm_reg_addr_t csr_addr = {item.a_addr[TL_AW-1:2], 2'b00};
+    uvm_reg        csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = ral.default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-      `downcast(dv_base_csr, csr)
-    end
     if (csr == null) begin
       // we hit an oob addr - expect error response and return
       `DV_CHECK_EQ(item.d_error, 1'b1)
       return;
     end
+
+    `downcast(dv_base_csr, csr)
 
     if (channel == AddrChannel) begin
       // if incoming access is a write to a valid csr, then make updates right away

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -183,11 +183,8 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
     string         access_str = write ? "write" : "read";
     string         channel_str = channel == AddrChannel ? "address" : "data";
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
@@ -65,16 +65,11 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
   // Task : process_tl_access
   // process monitored tl transaction
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
-    uvm_reg csr;
     bit do_read_check       = 1'b1;
     bit write               = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
-
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
+    uvm_reg csr             = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -565,17 +565,14 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       bit data_phase_read, bit data_phase_write);
 
     bit         do_read_check = 1;
-    uvm_reg     csr;
+    uvm_reg     csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
     dv_base_reg dv_reg;
     string      csr_name;
 
     `uvm_info(`gfn, $sformatf("sw state %d, reg state %d", direct_access_regwen_state,
                              `gmv(ral.direct_access_regwen)), UVM_LOW);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
+    if (csr != null) begin
       `downcast(dv_reg, csr)
     // SW CFG window
     end else if ((csr_addr & addr_mask) inside

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -232,11 +232,8 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
     bit            data_phase_read = (!write && channel == DataChannel);
     bit            data_phase_write = (write && channel == DataChannel);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/rstmgr_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/rstmgr_scoreboard.sv
@@ -141,11 +141,8 @@ class rstmgr_scoreboard extends cip_base_scoreboard #(
     bit            data_phase_read = (!write && channel == DataChannel);
     bit            data_phase_write = (write && channel == DataChannel);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -348,23 +348,19 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
   endfunction
 
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
-    uvm_reg        csr;
     dv_base_reg    dv_base_csr;
     bit            do_read_check   = 1'b1;
     bit            write           = item.is_write();
     uvm_reg_addr_t csr_addr = {item.a_addr[TL_AW-1:2], 2'b00};
+    uvm_reg        csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = ral.default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-      `downcast(dv_base_csr, csr)
-    end
     if (csr == null) begin
       // we hit an oob addr - expect error response and return
       `DV_CHECK_EQ(item.d_error, 1'b1)
       return;
     end
+
+    `downcast(dv_base_csr, csr)
 
     if (channel == AddrChannel) begin
       // if incoming access is a write to a valid csr, then make updates right away

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -282,11 +282,8 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
     string         access_str = write ? "write" : "read";
     string         channel_str = channel == AddrChannel ? "address" : "data";
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -203,27 +203,27 @@ class flash_ctrl_scoreboard #(
   endfunction
 
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
-    uvm_reg        csr;
     string         csr_wr_name = "";
     bit            do_read_check = 1'b1;
     bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
+    uvm_reg        csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    bit            mem_addr;
 
     bit            addr_phase_read = (!write && channel == AddrChannel);
     bit            addr_phase_write = (write && channel == AddrChannel);
     bit            data_phase_read = (!write && channel == DataChannel);
     bit            data_phase_write = (write && channel == DataChannel);
     bit            erase_req;
-    if (skip_read_check) do_read_check = 0;
-    // if access was to a valid csr, get the csr handle
-    if ((is_mem_addr(
-            item.a_addr, cfg.ral_models[ral_name]
-        ) || (csr_addr inside {cfg.ral_models[ral_name].csr_addrs})) &&
-            !cfg.dir_rd_in_progress) begin
 
+    if (skip_read_check) do_read_check = 0;
+
+    mem_addr = is_mem_addr(item.a_addr, cfg.ral_models[ral_name]);
+
+    if (mem_addr || (csr != null && !cfg.dir_rd_in_progress)) begin
       // if incoming access is a write to a valid csr, then make updates right away.
       if (addr_phase_write) begin
-        if (is_mem_addr(item.a_addr, cfg.ral_models[ral_name]) && cfg.scb_check) begin  // prog fifo
+        if (mem_addr && cfg.scb_check) begin  // prog fifo
           if (idx_wr == 0) begin
             csr_rd(.ptr(ral.addr), .value(data), .backdoor(1'b1));
             wr_addr = word_align_addr(get_field_val(ral.addr.start, data));
@@ -247,9 +247,7 @@ class flash_ctrl_scoreboard #(
           end else begin
             idx_wr += 1;
           end
-        end else if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-          csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-          `DV_CHECK_NE_FATAL(csr, null)
+        end else if (csr != null) begin
           csr_wr_name = csr.get_name();
           void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
           `uvm_info(`gfn, $sformatf("SCB EXP FLASH REG: 0x%0h", csr_addr), UVM_HIGH)
@@ -332,9 +330,7 @@ class flash_ctrl_scoreboard #(
       end
 
       if (data_phase_read) begin
-        if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-          csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-          `DV_CHECK_NE_FATAL(csr, null)
+        if (csr != null) begin
           // process the csr req
           // for write, update local variable and fifo at address phase
           // for read, update prediction at address phase and compare at data phase
@@ -382,7 +378,7 @@ class flash_ctrl_scoreboard #(
                          "reg name: %0s", csr.get_full_name()))
           end
           void'(csr.predict(.value(item.d_data), .kind(UVM_PREDICT_READ)));
-        end else if (is_mem_addr(item.a_addr, cfg.ral_models[ral_name]) && cfg.scb_check) begin
+        end else if (mem_addr && cfg.scb_check) begin
           // rd fifo
           if (idx_rd == 0) begin
             csr_rd(.ptr(ral.addr), .value(data), .backdoor(1'b1));

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
@@ -65,16 +65,11 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
   // Task : process_tl_access
   // process monitored tl transaction
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
-    uvm_reg csr;
     bit do_read_check       = 1'b1;
     bit write               = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
-
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
+    uvm_reg csr             = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -585,17 +585,14 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       bit data_phase_read, bit data_phase_write);
 
     bit         do_read_check = 1;
-    uvm_reg     csr;
+    uvm_reg     csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
     dv_base_reg dv_reg;
     string      csr_name;
 
     `uvm_info(`gfn, $sformatf("sw state %d, reg state %d", direct_access_regwen_state,
                              `gmv(ral.direct_access_regwen)), UVM_LOW);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
+    if (csr != null) begin
       `downcast(dv_reg, csr)
     // SW CFG window
     end else if ((csr_addr & addr_mask) inside

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -226,11 +226,8 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
     bit            data_phase_read = (!write && channel == DataChannel);
     bit            data_phase_write = (write && channel == DataChannel);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/rstmgr_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/rstmgr_scoreboard.sv
@@ -141,11 +141,8 @@ class rstmgr_scoreboard extends cip_base_scoreboard #(
     bit            data_phase_read = (!write && channel == DataChannel);
     bit            data_phase_write = (write && channel == DataChannel);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -273,11 +273,8 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
     string         access_str = write ? "write" : "read";
     string         channel_str = channel == AddrChannel ? "address" : "data";
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -203,27 +203,27 @@ class flash_ctrl_scoreboard #(
   endfunction
 
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
-    uvm_reg        csr;
     string         csr_wr_name = "";
     bit            do_read_check = 1'b1;
     bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
+    uvm_reg        csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    bit            mem_addr;
 
     bit            addr_phase_read = (!write && channel == AddrChannel);
     bit            addr_phase_write = (write && channel == AddrChannel);
     bit            data_phase_read = (!write && channel == DataChannel);
     bit            data_phase_write = (write && channel == DataChannel);
     bit            erase_req;
-    if (skip_read_check) do_read_check = 0;
-    // if access was to a valid csr, get the csr handle
-    if ((is_mem_addr(
-            item.a_addr, cfg.ral_models[ral_name]
-        ) || (csr_addr inside {cfg.ral_models[ral_name].csr_addrs})) &&
-            !cfg.dir_rd_in_progress) begin
 
+    if (skip_read_check) do_read_check = 0;
+
+    mem_addr = is_mem_addr(item.a_addr, cfg.ral_models[ral_name]);
+
+    if (mem_addr || (csr != null && !cfg.dir_rd_in_progress)) begin
       // if incoming access is a write to a valid csr, then make updates right away.
       if (addr_phase_write) begin
-        if (is_mem_addr(item.a_addr, cfg.ral_models[ral_name]) && cfg.scb_check) begin  // prog fifo
+        if (mem_addr && cfg.scb_check) begin  // prog fifo
           if (idx_wr == 0) begin
             csr_rd(.ptr(ral.addr), .value(data), .backdoor(1'b1));
             wr_addr = word_align_addr(get_field_val(ral.addr.start, data));
@@ -247,9 +247,7 @@ class flash_ctrl_scoreboard #(
           end else begin
             idx_wr += 1;
           end
-        end else if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-          csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-          `DV_CHECK_NE_FATAL(csr, null)
+        end else if (csr != null) begin
           csr_wr_name = csr.get_name();
           void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
           `uvm_info(`gfn, $sformatf("SCB EXP FLASH REG: 0x%0h", csr_addr), UVM_HIGH)
@@ -332,9 +330,7 @@ class flash_ctrl_scoreboard #(
       end
 
       if (data_phase_read) begin
-        if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-          csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-          `DV_CHECK_NE_FATAL(csr, null)
+        if (csr != null) begin
           // process the csr req
           // for write, update local variable and fifo at address phase
           // for read, update prediction at address phase and compare at data phase
@@ -382,7 +378,7 @@ class flash_ctrl_scoreboard #(
                          "reg name: %0s", csr.get_full_name()))
           end
           void'(csr.predict(.value(item.d_data), .kind(UVM_PREDICT_READ)));
-        end else if (is_mem_addr(item.a_addr, cfg.ral_models[ral_name]) && cfg.scb_check) begin
+        end else if (mem_addr && cfg.scb_check) begin
           // rd fifo
           if (idx_rd == 0) begin
             csr_rd(.ptr(ral.addr), .value(data), .backdoor(1'b1));

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
@@ -65,16 +65,11 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
   // Task : process_tl_access
   // process monitored tl transaction
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
-    uvm_reg csr;
     bit do_read_check       = 1'b1;
     bit write               = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
-
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
+    uvm_reg csr             = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -226,11 +226,8 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
     bit            data_phase_read = (!write && channel == DataChannel);
     bit            data_phase_write = (write && channel == DataChannel);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_scoreboard.sv
@@ -141,11 +141,8 @@ class rstmgr_scoreboard extends cip_base_scoreboard #(
     bit            data_phase_read = (!write && channel == DataChannel);
     bit            data_phase_write = (write && channel == DataChannel);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end else begin
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 

--- a/util/uvmdvgen/scoreboard.sv.tpl
+++ b/util/uvmdvgen/scoreboard.sv.tpl
@@ -75,12 +75,8 @@ class ${name}_scoreboard extends dv_base_scoreboard #(
     bit data_phase_read   = (!write && channel == DataChannel);
     bit data_phase_write  = (write && channel == DataChannel);
 
-    // if access was to a valid csr, get the csr handle
-    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
-      `DV_CHECK_NE_FATAL(csr, null)
-    end
-    else begin
+    csr = cfg.ral_models[ral_name].get_default_map().get_reg_by_offset(csr_addr);
+    if (csr == null) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 


### PR DESCRIPTION
This was a rather strange item and (as far as I can tell) just shows that the original author didn't really understand how uvm_reg_map works.

Simplify things dramatically by using the machinery that already exists in UVM.