### PR TITLE
[rv_dm,dv] Improve scb's error message on a d_error mismatch

### DIFF
--- a/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
@@ -443,7 +443,14 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
         (channel == DataChannel) &&
         !is_debug_enabled()) begin
 
-      `DV_CHECK(item.d_error)
+      if (!item.d_error) begin
+        `uvm_error(get_full_name(),
+                   $sformatf({"Unexpected TL response. The transaction accesses ",
+                              "rv_dm_mem_reg_block when debug is disabled, so ",
+                              "the d_error response should be asserted. Item: %0s"},
+                             item.sprint(uvm_default_line_printer)))
+      end
+
       return 1'b1;
     end
 


### PR DESCRIPTION
This is a minor change, but it helped me when debugging a test where the scoreboard thought that debug was disabled, but the RTL saw things differently.

(This was in the context of a chip-level test: the underlying problem was that I hadn't taught the block-level environment that debug *was* enabled)