### PR TITLE
[clkmgr/rtl] Deglitch on shadow register error alerts

### DIFF
--- a/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -782,6 +782,18 @@ module clkmgr_reg_top (
   //   F[hi]: 8:0
   logic async_io_meas_ctrl_shadowed_hi_err_update;
   logic async_io_meas_ctrl_shadowed_hi_err_storage;
+  logic deglitched_io_meas_ctrl_shadowed_hi_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_io_meas_ctrl_shadowed_hi_err_storage_deglitch (
+    .clk_i (clk_io_i),
+    .rst_ni(rst_io_ni),
+    .d_i   (async_io_meas_ctrl_shadowed_hi_err_storage),
+    .q_o   (deglitched_io_meas_ctrl_shadowed_hi_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -790,7 +802,7 @@ module clkmgr_reg_top (
   ) u_io_meas_ctrl_shadowed_hi_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_io_meas_ctrl_shadowed_hi_err_storage),
+    .d_i(deglitched_io_meas_ctrl_shadowed_hi_err_storage),
     .q_o(io_meas_ctrl_shadowed_hi_storage_err)
   );
 
@@ -841,6 +853,18 @@ module clkmgr_reg_top (
   //   F[lo]: 17:9
   logic async_io_meas_ctrl_shadowed_lo_err_update;
   logic async_io_meas_ctrl_shadowed_lo_err_storage;
+  logic deglitched_io_meas_ctrl_shadowed_lo_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_io_meas_ctrl_shadowed_lo_err_storage_deglitch (
+    .clk_i (clk_io_i),
+    .rst_ni(rst_io_ni),
+    .d_i   (async_io_meas_ctrl_shadowed_lo_err_storage),
+    .q_o   (deglitched_io_meas_ctrl_shadowed_lo_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -849,7 +873,7 @@ module clkmgr_reg_top (
   ) u_io_meas_ctrl_shadowed_lo_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_io_meas_ctrl_shadowed_lo_err_storage),
+    .d_i(deglitched_io_meas_ctrl_shadowed_lo_err_storage),
     .q_o(io_meas_ctrl_shadowed_lo_storage_err)
   );
 
@@ -940,6 +964,18 @@ module clkmgr_reg_top (
   //   F[hi]: 8:0
   logic async_main_meas_ctrl_shadowed_hi_err_update;
   logic async_main_meas_ctrl_shadowed_hi_err_storage;
+  logic deglitched_main_meas_ctrl_shadowed_hi_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_main_meas_ctrl_shadowed_hi_err_storage_deglitch (
+    .clk_i (clk_main_i),
+    .rst_ni(rst_main_ni),
+    .d_i   (async_main_meas_ctrl_shadowed_hi_err_storage),
+    .q_o   (deglitched_main_meas_ctrl_shadowed_hi_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -948,7 +984,7 @@ module clkmgr_reg_top (
   ) u_main_meas_ctrl_shadowed_hi_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_main_meas_ctrl_shadowed_hi_err_storage),
+    .d_i(deglitched_main_meas_ctrl_shadowed_hi_err_storage),
     .q_o(main_meas_ctrl_shadowed_hi_storage_err)
   );
 
@@ -999,6 +1035,18 @@ module clkmgr_reg_top (
   //   F[lo]: 17:9
   logic async_main_meas_ctrl_shadowed_lo_err_update;
   logic async_main_meas_ctrl_shadowed_lo_err_storage;
+  logic deglitched_main_meas_ctrl_shadowed_lo_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_main_meas_ctrl_shadowed_lo_err_storage_deglitch (
+    .clk_i (clk_main_i),
+    .rst_ni(rst_main_ni),
+    .d_i   (async_main_meas_ctrl_shadowed_lo_err_storage),
+    .q_o   (deglitched_main_meas_ctrl_shadowed_lo_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -1007,7 +1055,7 @@ module clkmgr_reg_top (
   ) u_main_meas_ctrl_shadowed_lo_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_main_meas_ctrl_shadowed_lo_err_storage),
+    .d_i(deglitched_main_meas_ctrl_shadowed_lo_err_storage),
     .q_o(main_meas_ctrl_shadowed_lo_storage_err)
   );
 

--- a/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -1292,6 +1292,18 @@ module clkmgr_reg_top (
   //   F[hi]: 9:0
   logic async_io_meas_ctrl_shadowed_hi_err_update;
   logic async_io_meas_ctrl_shadowed_hi_err_storage;
+  logic deglitched_io_meas_ctrl_shadowed_hi_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_io_meas_ctrl_shadowed_hi_err_storage_deglitch (
+    .clk_i (clk_io_i),
+    .rst_ni(rst_io_ni),
+    .d_i   (async_io_meas_ctrl_shadowed_hi_err_storage),
+    .q_o   (deglitched_io_meas_ctrl_shadowed_hi_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -1300,7 +1312,7 @@ module clkmgr_reg_top (
   ) u_io_meas_ctrl_shadowed_hi_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_io_meas_ctrl_shadowed_hi_err_storage),
+    .d_i(deglitched_io_meas_ctrl_shadowed_hi_err_storage),
     .q_o(io_meas_ctrl_shadowed_hi_storage_err)
   );
 
@@ -1351,6 +1363,18 @@ module clkmgr_reg_top (
   //   F[lo]: 19:10
   logic async_io_meas_ctrl_shadowed_lo_err_update;
   logic async_io_meas_ctrl_shadowed_lo_err_storage;
+  logic deglitched_io_meas_ctrl_shadowed_lo_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_io_meas_ctrl_shadowed_lo_err_storage_deglitch (
+    .clk_i (clk_io_i),
+    .rst_ni(rst_io_ni),
+    .d_i   (async_io_meas_ctrl_shadowed_lo_err_storage),
+    .q_o   (deglitched_io_meas_ctrl_shadowed_lo_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -1359,7 +1383,7 @@ module clkmgr_reg_top (
   ) u_io_meas_ctrl_shadowed_lo_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_io_meas_ctrl_shadowed_lo_err_storage),
+    .d_i(deglitched_io_meas_ctrl_shadowed_lo_err_storage),
     .q_o(io_meas_ctrl_shadowed_lo_storage_err)
   );
 
@@ -1450,6 +1474,18 @@ module clkmgr_reg_top (
   //   F[hi]: 8:0
   logic async_io_div2_meas_ctrl_shadowed_hi_err_update;
   logic async_io_div2_meas_ctrl_shadowed_hi_err_storage;
+  logic deglitched_io_div2_meas_ctrl_shadowed_hi_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_io_div2_meas_ctrl_shadowed_hi_err_storage_deglitch (
+    .clk_i (clk_io_div2_i),
+    .rst_ni(rst_io_div2_ni),
+    .d_i   (async_io_div2_meas_ctrl_shadowed_hi_err_storage),
+    .q_o   (deglitched_io_div2_meas_ctrl_shadowed_hi_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -1458,7 +1494,7 @@ module clkmgr_reg_top (
   ) u_io_div2_meas_ctrl_shadowed_hi_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_io_div2_meas_ctrl_shadowed_hi_err_storage),
+    .d_i(deglitched_io_div2_meas_ctrl_shadowed_hi_err_storage),
     .q_o(io_div2_meas_ctrl_shadowed_hi_storage_err)
   );
 
@@ -1509,6 +1545,18 @@ module clkmgr_reg_top (
   //   F[lo]: 17:9
   logic async_io_div2_meas_ctrl_shadowed_lo_err_update;
   logic async_io_div2_meas_ctrl_shadowed_lo_err_storage;
+  logic deglitched_io_div2_meas_ctrl_shadowed_lo_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_io_div2_meas_ctrl_shadowed_lo_err_storage_deglitch (
+    .clk_i (clk_io_div2_i),
+    .rst_ni(rst_io_div2_ni),
+    .d_i   (async_io_div2_meas_ctrl_shadowed_lo_err_storage),
+    .q_o   (deglitched_io_div2_meas_ctrl_shadowed_lo_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -1517,7 +1565,7 @@ module clkmgr_reg_top (
   ) u_io_div2_meas_ctrl_shadowed_lo_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_io_div2_meas_ctrl_shadowed_lo_err_storage),
+    .d_i(deglitched_io_div2_meas_ctrl_shadowed_lo_err_storage),
     .q_o(io_div2_meas_ctrl_shadowed_lo_storage_err)
   );
 
@@ -1608,6 +1656,18 @@ module clkmgr_reg_top (
   //   F[hi]: 7:0
   logic async_io_div4_meas_ctrl_shadowed_hi_err_update;
   logic async_io_div4_meas_ctrl_shadowed_hi_err_storage;
+  logic deglitched_io_div4_meas_ctrl_shadowed_hi_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_io_div4_meas_ctrl_shadowed_hi_err_storage_deglitch (
+    .clk_i (clk_io_div4_i),
+    .rst_ni(rst_io_div4_ni),
+    .d_i   (async_io_div4_meas_ctrl_shadowed_hi_err_storage),
+    .q_o   (deglitched_io_div4_meas_ctrl_shadowed_hi_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -1616,7 +1676,7 @@ module clkmgr_reg_top (
   ) u_io_div4_meas_ctrl_shadowed_hi_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_io_div4_meas_ctrl_shadowed_hi_err_storage),
+    .d_i(deglitched_io_div4_meas_ctrl_shadowed_hi_err_storage),
     .q_o(io_div4_meas_ctrl_shadowed_hi_storage_err)
   );
 
@@ -1667,6 +1727,18 @@ module clkmgr_reg_top (
   //   F[lo]: 15:8
   logic async_io_div4_meas_ctrl_shadowed_lo_err_update;
   logic async_io_div4_meas_ctrl_shadowed_lo_err_storage;
+  logic deglitched_io_div4_meas_ctrl_shadowed_lo_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_io_div4_meas_ctrl_shadowed_lo_err_storage_deglitch (
+    .clk_i (clk_io_div4_i),
+    .rst_ni(rst_io_div4_ni),
+    .d_i   (async_io_div4_meas_ctrl_shadowed_lo_err_storage),
+    .q_o   (deglitched_io_div4_meas_ctrl_shadowed_lo_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -1675,7 +1747,7 @@ module clkmgr_reg_top (
   ) u_io_div4_meas_ctrl_shadowed_lo_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_io_div4_meas_ctrl_shadowed_lo_err_storage),
+    .d_i(deglitched_io_div4_meas_ctrl_shadowed_lo_err_storage),
     .q_o(io_div4_meas_ctrl_shadowed_lo_storage_err)
   );
 
@@ -1766,6 +1838,18 @@ module clkmgr_reg_top (
   //   F[hi]: 9:0
   logic async_main_meas_ctrl_shadowed_hi_err_update;
   logic async_main_meas_ctrl_shadowed_hi_err_storage;
+  logic deglitched_main_meas_ctrl_shadowed_hi_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_main_meas_ctrl_shadowed_hi_err_storage_deglitch (
+    .clk_i (clk_main_i),
+    .rst_ni(rst_main_ni),
+    .d_i   (async_main_meas_ctrl_shadowed_hi_err_storage),
+    .q_o   (deglitched_main_meas_ctrl_shadowed_hi_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -1774,7 +1858,7 @@ module clkmgr_reg_top (
   ) u_main_meas_ctrl_shadowed_hi_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_main_meas_ctrl_shadowed_hi_err_storage),
+    .d_i(deglitched_main_meas_ctrl_shadowed_hi_err_storage),
     .q_o(main_meas_ctrl_shadowed_hi_storage_err)
   );
 
@@ -1825,6 +1909,18 @@ module clkmgr_reg_top (
   //   F[lo]: 19:10
   logic async_main_meas_ctrl_shadowed_lo_err_update;
   logic async_main_meas_ctrl_shadowed_lo_err_storage;
+  logic deglitched_main_meas_ctrl_shadowed_lo_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_main_meas_ctrl_shadowed_lo_err_storage_deglitch (
+    .clk_i (clk_main_i),
+    .rst_ni(rst_main_ni),
+    .d_i   (async_main_meas_ctrl_shadowed_lo_err_storage),
+    .q_o   (deglitched_main_meas_ctrl_shadowed_lo_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -1833,7 +1929,7 @@ module clkmgr_reg_top (
   ) u_main_meas_ctrl_shadowed_lo_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_main_meas_ctrl_shadowed_lo_err_storage),
+    .d_i(deglitched_main_meas_ctrl_shadowed_lo_err_storage),
     .q_o(main_meas_ctrl_shadowed_lo_storage_err)
   );
 
@@ -1923,6 +2019,18 @@ module clkmgr_reg_top (
   //   F[hi]: 8:0
   logic async_usb_meas_ctrl_shadowed_hi_err_update;
   logic async_usb_meas_ctrl_shadowed_hi_err_storage;
+  logic deglitched_usb_meas_ctrl_shadowed_hi_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_usb_meas_ctrl_shadowed_hi_err_storage_deglitch (
+    .clk_i (clk_usb_i),
+    .rst_ni(rst_usb_ni),
+    .d_i   (async_usb_meas_ctrl_shadowed_hi_err_storage),
+    .q_o   (deglitched_usb_meas_ctrl_shadowed_hi_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -1931,7 +2039,7 @@ module clkmgr_reg_top (
   ) u_usb_meas_ctrl_shadowed_hi_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_usb_meas_ctrl_shadowed_hi_err_storage),
+    .d_i(deglitched_usb_meas_ctrl_shadowed_hi_err_storage),
     .q_o(usb_meas_ctrl_shadowed_hi_storage_err)
   );
 
@@ -1982,6 +2090,18 @@ module clkmgr_reg_top (
   //   F[lo]: 17:9
   logic async_usb_meas_ctrl_shadowed_lo_err_update;
   logic async_usb_meas_ctrl_shadowed_lo_err_storage;
+  logic deglitched_usb_meas_ctrl_shadowed_lo_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_usb_meas_ctrl_shadowed_lo_err_storage_deglitch (
+    .clk_i (clk_usb_i),
+    .rst_ni(rst_usb_ni),
+    .d_i   (async_usb_meas_ctrl_shadowed_lo_err_storage),
+    .q_o   (deglitched_usb_meas_ctrl_shadowed_lo_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -1990,7 +2110,7 @@ module clkmgr_reg_top (
   ) u_usb_meas_ctrl_shadowed_lo_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_usb_meas_ctrl_shadowed_lo_err_storage),
+    .d_i(deglitched_usb_meas_ctrl_shadowed_lo_err_storage),
     .q_o(usb_meas_ctrl_shadowed_lo_storage_err)
   );
 

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -1016,6 +1016,18 @@ module clkmgr_reg_top (
   //   F[hi]: 9:0
   logic async_io_meas_ctrl_shadowed_hi_err_update;
   logic async_io_meas_ctrl_shadowed_hi_err_storage;
+  logic deglitched_io_meas_ctrl_shadowed_hi_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_io_meas_ctrl_shadowed_hi_err_storage_deglitch (
+    .clk_i (clk_io_i),
+    .rst_ni(rst_io_ni),
+    .d_i   (async_io_meas_ctrl_shadowed_hi_err_storage),
+    .q_o   (deglitched_io_meas_ctrl_shadowed_hi_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -1024,7 +1036,7 @@ module clkmgr_reg_top (
   ) u_io_meas_ctrl_shadowed_hi_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_io_meas_ctrl_shadowed_hi_err_storage),
+    .d_i(deglitched_io_meas_ctrl_shadowed_hi_err_storage),
     .q_o(io_meas_ctrl_shadowed_hi_storage_err)
   );
 
@@ -1075,6 +1087,18 @@ module clkmgr_reg_top (
   //   F[lo]: 19:10
   logic async_io_meas_ctrl_shadowed_lo_err_update;
   logic async_io_meas_ctrl_shadowed_lo_err_storage;
+  logic deglitched_io_meas_ctrl_shadowed_lo_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_io_meas_ctrl_shadowed_lo_err_storage_deglitch (
+    .clk_i (clk_io_i),
+    .rst_ni(rst_io_ni),
+    .d_i   (async_io_meas_ctrl_shadowed_lo_err_storage),
+    .q_o   (deglitched_io_meas_ctrl_shadowed_lo_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -1083,7 +1107,7 @@ module clkmgr_reg_top (
   ) u_io_meas_ctrl_shadowed_lo_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_io_meas_ctrl_shadowed_lo_err_storage),
+    .d_i(deglitched_io_meas_ctrl_shadowed_lo_err_storage),
     .q_o(io_meas_ctrl_shadowed_lo_storage_err)
   );
 
@@ -1174,6 +1198,18 @@ module clkmgr_reg_top (
   //   F[hi]: 7:0
   logic async_io_div4_meas_ctrl_shadowed_hi_err_update;
   logic async_io_div4_meas_ctrl_shadowed_hi_err_storage;
+  logic deglitched_io_div4_meas_ctrl_shadowed_hi_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_io_div4_meas_ctrl_shadowed_hi_err_storage_deglitch (
+    .clk_i (clk_io_div4_i),
+    .rst_ni(rst_io_div4_ni),
+    .d_i   (async_io_div4_meas_ctrl_shadowed_hi_err_storage),
+    .q_o   (deglitched_io_div4_meas_ctrl_shadowed_hi_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -1182,7 +1218,7 @@ module clkmgr_reg_top (
   ) u_io_div4_meas_ctrl_shadowed_hi_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_io_div4_meas_ctrl_shadowed_hi_err_storage),
+    .d_i(deglitched_io_div4_meas_ctrl_shadowed_hi_err_storage),
     .q_o(io_div4_meas_ctrl_shadowed_hi_storage_err)
   );
 
@@ -1233,6 +1269,18 @@ module clkmgr_reg_top (
   //   F[lo]: 15:8
   logic async_io_div4_meas_ctrl_shadowed_lo_err_update;
   logic async_io_div4_meas_ctrl_shadowed_lo_err_storage;
+  logic deglitched_io_div4_meas_ctrl_shadowed_lo_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_io_div4_meas_ctrl_shadowed_lo_err_storage_deglitch (
+    .clk_i (clk_io_div4_i),
+    .rst_ni(rst_io_div4_ni),
+    .d_i   (async_io_div4_meas_ctrl_shadowed_lo_err_storage),
+    .q_o   (deglitched_io_div4_meas_ctrl_shadowed_lo_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -1241,7 +1289,7 @@ module clkmgr_reg_top (
   ) u_io_div4_meas_ctrl_shadowed_lo_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_io_div4_meas_ctrl_shadowed_lo_err_storage),
+    .d_i(deglitched_io_div4_meas_ctrl_shadowed_lo_err_storage),
     .q_o(io_div4_meas_ctrl_shadowed_lo_storage_err)
   );
 
@@ -1332,6 +1380,18 @@ module clkmgr_reg_top (
   //   F[hi]: 9:0
   logic async_main_meas_ctrl_shadowed_hi_err_update;
   logic async_main_meas_ctrl_shadowed_hi_err_storage;
+  logic deglitched_main_meas_ctrl_shadowed_hi_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_main_meas_ctrl_shadowed_hi_err_storage_deglitch (
+    .clk_i (clk_main_i),
+    .rst_ni(rst_main_ni),
+    .d_i   (async_main_meas_ctrl_shadowed_hi_err_storage),
+    .q_o   (deglitched_main_meas_ctrl_shadowed_hi_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -1340,7 +1400,7 @@ module clkmgr_reg_top (
   ) u_main_meas_ctrl_shadowed_hi_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_main_meas_ctrl_shadowed_hi_err_storage),
+    .d_i(deglitched_main_meas_ctrl_shadowed_hi_err_storage),
     .q_o(main_meas_ctrl_shadowed_hi_storage_err)
   );
 
@@ -1391,6 +1451,18 @@ module clkmgr_reg_top (
   //   F[lo]: 19:10
   logic async_main_meas_ctrl_shadowed_lo_err_update;
   logic async_main_meas_ctrl_shadowed_lo_err_storage;
+  logic deglitched_main_meas_ctrl_shadowed_lo_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_main_meas_ctrl_shadowed_lo_err_storage_deglitch (
+    .clk_i (clk_main_i),
+    .rst_ni(rst_main_ni),
+    .d_i   (async_main_meas_ctrl_shadowed_lo_err_storage),
+    .q_o   (deglitched_main_meas_ctrl_shadowed_lo_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -1399,7 +1471,7 @@ module clkmgr_reg_top (
   ) u_main_meas_ctrl_shadowed_lo_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_main_meas_ctrl_shadowed_lo_err_storage),
+    .d_i(deglitched_main_meas_ctrl_shadowed_lo_err_storage),
     .q_o(main_meas_ctrl_shadowed_lo_storage_err)
   );
 
@@ -1489,6 +1561,18 @@ module clkmgr_reg_top (
   //   F[hi]: 8:0
   logic async_usb_meas_ctrl_shadowed_hi_err_update;
   logic async_usb_meas_ctrl_shadowed_hi_err_storage;
+  logic deglitched_usb_meas_ctrl_shadowed_hi_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_usb_meas_ctrl_shadowed_hi_err_storage_deglitch (
+    .clk_i (clk_usb_i),
+    .rst_ni(rst_usb_ni),
+    .d_i   (async_usb_meas_ctrl_shadowed_hi_err_storage),
+    .q_o   (deglitched_usb_meas_ctrl_shadowed_hi_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -1497,7 +1581,7 @@ module clkmgr_reg_top (
   ) u_usb_meas_ctrl_shadowed_hi_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_usb_meas_ctrl_shadowed_hi_err_storage),
+    .d_i(deglitched_usb_meas_ctrl_shadowed_hi_err_storage),
     .q_o(usb_meas_ctrl_shadowed_hi_storage_err)
   );
 
@@ -1548,6 +1632,18 @@ module clkmgr_reg_top (
   //   F[lo]: 17:9
   logic async_usb_meas_ctrl_shadowed_lo_err_update;
   logic async_usb_meas_ctrl_shadowed_lo_err_storage;
+  logic deglitched_usb_meas_ctrl_shadowed_lo_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_usb_meas_ctrl_shadowed_lo_err_storage_deglitch (
+    .clk_i (clk_usb_i),
+    .rst_ni(rst_usb_ni),
+    .d_i   (async_usb_meas_ctrl_shadowed_lo_err_storage),
+    .q_o   (deglitched_usb_meas_ctrl_shadowed_lo_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -1556,7 +1652,7 @@ module clkmgr_reg_top (
   ) u_usb_meas_ctrl_shadowed_lo_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_usb_meas_ctrl_shadowed_lo_err_storage),
+    .d_i(deglitched_usb_meas_ctrl_shadowed_lo_err_storage),
     .q_o(usb_meas_ctrl_shadowed_lo_storage_err)
   );
 

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -1097,6 +1097,18 @@ ${bits.msb}\
       % if reg.async_clk and reg.shadowed:
   logic async_${finst_name}_err_update;
   logic async_${finst_name}_err_storage;
+  logic deglitched_${finst_name}_err_storage;
+
+  // flop storage error to filter combinational glitches before sending it across CDC
+  prim_flop #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_${finst_name}_err_storage_deglitch (
+    .clk_i (${reg.async_clk[1].clock}),
+    .rst_ni(${reg.async_clk[1].reset}),
+    .d_i   (async_${finst_name}_err_storage),
+    .q_o   (deglitched_${finst_name}_err_storage)
+  );
 
   // storage error is persistent and can be sampled at any time
   prim_flop_2sync #(
@@ -1105,7 +1117,7 @@ ${bits.msb}\
   ) u_${finst_name}_err_storage_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_${finst_name}_err_storage),
+    .d_i(deglitched_${finst_name}_err_storage),
     .q_o(${finst_name}_storage_err)
   );
 


### PR DESCRIPTION
In prior commits the `err_storage` signal from the `prim_subreg_shadow` module  was fed directly to a synchroniser. As the generation logic for this error is combinatorial it can generate glitches as it settles. There are several instances of these shadow registers in the Clock Manager the majority of which are in a different clock domain to the alert logic, therefore requiring synchronisation. The register interface is generated from the template file reg_top.sv.tpl in the util/reggen directory.

To prevent the glitches propagating, this commit adds an additional flop has been added to the error signal path before the synchroniser for each shadow register instance with a clock domain crossing. These additional flops were placed in the template, clkmgr_reg_top.sv was then regenerated with util/regtool.py

This commit resolves issue lowRISC/opentitan#24592