### PR TITLE
[crypto] RSA: Fix the primality OTBN tests

### DIFF
--- a/sw/otbn/crypto/tests/rsa_primality_negative_test.hjson
+++ b/sw/otbn/crypto/tests/rsa_primality_negative_test.hjson
@@ -2,28 +2,18 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// An 1024-bit value that passes other checks but isn't prime.
-//
-// Python script for generating the test data (using PyCryptoDome's
-// Crypto.Util.number package for the primality check):
-// while True:
-//   not_prime = random.randrange(lower_bound, (1 << 1024))
-//   not_prime |= 3
-//   if math.gcd(not_prime, 65537) != 1:
-//     continue
-//  if not number.isPrime(not_prime):
-//    break
-
 {
   "entrypoint": "main",
   "input": {
     "dmem": {
-      "rsa_n": "0xecbbd72477e406de8ff72a93afbe19ed4258d3dd8cfa5b2a8b5c76d22053504710a8460c30c5141fc581df484e58a2bd019c03a1acab6c7fd70f9865ac6dcdcce4cca95266e4d2dea9a408b8ded6591daa4416bb7ca78357cad5c7d527d46a06807337d6845484589c8010eb6b674194608e1b9732db4e8cee053d2572158cf7"
+      // Random 512-bit odd composite number.
+      "rsa_n": "0xb8f5ae78e3fbba684ccc0887980070787a9ee5561feefaba6b2dda76d8d036a835dbce05c5827ce612a84da4572f0a2c9a8f38ef373ad0fd805fbc8537129f03"
     }
-  }
+  },
   "output": {
-    "regs": {
-      "x2": "0x0000000"
+    "dmem": {
+      "mr_iter_p_tmp": "0x00000001",
+      "mr_iter_q_tmp": "0x00000001",
     }
   }
 }

--- a/sw/otbn/crypto/tests/rsa_primality_negative_test.s
+++ b/sw/otbn/crypto/tests/rsa_primality_negative_test.s
@@ -2,29 +2,27 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-/**
- * Ensure that a good value for p passes RSA keygen checks.
- *
- * Uses the test data from `rsa_keygen_checkp_good_test.hjson`, which is sized
- * for RSA-2048.
- */
+/* Verify that a composite number fails the primality tests. */
 
 .section .text.start
 
 main:
-  /* Init all-zero register. */
   bn.xor    w31, w31, w31
 
-  /* Load the number of limbs for this test. */
-  li        x30, 4
+  /* The number of limbs in this test. */
+  li x30, 2
 
+  /* Execute the Fermat test and store the result in an unused DMEM location. */
   jal x1, fermat_test
-  bne x2, x0, _end_test
+  la x3, mr_iter_p_tmp
+  xori x2, x2, 1
+  sw x2, 0(x3)
 
-  addi x3, x2, 0
-
+  /* Execute the Miller-Rabin test and store the result in an unused DMEM
+     location. */
   jal x1, miller_rabin_test
-  or x2, x2, x3
+  la x3, mr_iter_q_tmp
+  xori x2, x2, 1
+  sw x2, 0(x3)
 
-_end_test:
   ecall

--- a/sw/otbn/crypto/tests/rsa_primality_test.hjson
+++ b/sw/otbn/crypto/tests/rsa_primality_test.hjson
@@ -2,38 +2,18 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// An acceptable value for p.
-//
-// To make sure the checks on q are being tested, this value is specifically
-// chosen to be far enough away from the "bad" values of q that they wouldn't
-// be rejected on that basis.
-//
-// Python script for generating p (using PyCryptoDome's Crypto.Util.number
-// package for the primality check):
-// while True:
-//   p = random.randrange(lower_bound, 1 << 1024)
-//   p |= 3
-//   if abs(p - too_small) < (1 << 924):
-//     continue
-//   if abs(p - not_relprime) < (1 << 924):
-//     continue
-//   if abs(p - not_prime) < (1 << 924):
-//     continue
-//   if math.gcd(p-1, 65537) != 1:
-//     continue
-//   if number.isPrime(p):
-//     break
-
 {
   "entrypoint": "main",
   "input": {
     "dmem": {
-      "rsa_n": "0xd10b3338d7d2cca85be7b76c5497f2fe89a9f9b73e613262565636dbc5901c386b1df3c7b8eb3ac8548a9062a5958b33c84dfe0fa9e2c61250d75683be1585008f926d5cfc4d3a3f003746a3beefcc71d287133768fc0268e1f84cb791be8e6dfc48b706ee0515089ff618c0a648854d6a93e9a0452552e93720ffa2021fd53b"
+      // Random 512-bit prime number.
+      "rsa_n": "0xff0ccaca8fcab8cd26cce1ceecf31b544640115f191e24b5d938ee3db9f5e540b53e0e91dc50e3bb41307413693a1bc03d49fc0e077f0445a635f5732b3e0a4b"
     }
-  }
+  },
   "output": {
-    "regs": {
-      "x2": "0x00000001"
+    "dmem": {
+      "mr_iter_p_tmp": "0x00000001",
+      "mr_iter_q_tmp": "0x00000001",
     }
   }
 }

--- a/sw/otbn/crypto/tests/rsa_primality_test.s
+++ b/sw/otbn/crypto/tests/rsa_primality_test.s
@@ -2,29 +2,25 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-/**
- * Ensure that a good value for p passes RSA keygen checks.
- *
- * Uses the test data from `rsa_keygen_checkp_good_test.hjson`, which is sized
- * for RSA-2048.
- */
+/* Verify that a prime number passes the primality tests. */
 
 .section .text.start
 
 main:
-  /* Init all-zero register. */
   bn.xor    w31, w31, w31
 
-  /* Load the number of limbs for this test. */
-  li        x30, 4
+  /* The number of limbs in this test. */
+  li x30, 2
 
+  /* Execute the Fermat test and store the result in an unused DMEM location. */
   jal x1, fermat_test
-  beq x2, x0, _end_test
+  la x3, mr_iter_p_tmp
+  sw x2, 0(x3)
 
-  addi x3, x2, 0
-
+  /* Execute the Miller-Rabin test and store the result in an unused DMEM
+     location. */
   jal x1, miller_rabin_test
-  and x2, x2, x3
+  la x3, mr_iter_q_tmp
+  sw x2, 0(x3)
 
-_end_test:
   ecall


### PR DESCRIPTION
Bit rot caused those tests to not keep up with recent changes in the cryptolib, this commit overhauls them completely.