### PR TITLE
[dv,chip] Tidy up load methods for flash images in chip_sw_base_vseq

### DIFF
--- a/hw/top_earlgrey/dv/chip_manuf_ate_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_manuf_ate_tests.hjson
@@ -15,8 +15,6 @@
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: [
         "+sw_test_timeout_ns=160_000_000"
-        "+skip_flash_bkdr_load=1",
-        "+use_spi_load_bootstrap=1",
       ]
       run_timeout_mins: 180
     }
@@ -27,7 +25,6 @@
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: [
         "+sw_test_timeout_ns=160_000_000"
-        "+skip_flash_bkdr_load=1",
         "+use_spi_load_bootstrap=1",
       ]
       run_timeout_mins: 180

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -12,7 +12,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // Write logs from sw test to separate log file as well, in addition to the simulator log file.
   bit                 write_sw_logs_to_file = 1'b1;
 
-  // use spi or backdoor to load bootstrap on the next boot
+  // If true, load bootstrap using SPI on the next boot. If false, load it using a backdoor.
   bit                 use_spi_load_bootstrap = 0;
 
   // skip ROM backdoor loading (when using ROM macro block)

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -112,20 +112,25 @@ class chip_sw_base_vseq extends chip_base_vseq;
 `endif
     end
 
-    if (cfg.sw_images.exists(SwTypeTestSlotA)) begin
-      if (cfg.use_spi_load_bootstrap) begin
-        `uvm_info(`gfn, "Initializing SPI flash bootstrap", UVM_MEDIUM)
-        spi_device_load_bootstrap({cfg.sw_images[SwTypeTestSlotA], ".64.vmem"});
-        cfg.use_spi_load_bootstrap = 1'b0;
-      end else begin
-        cfg.mem_bkdr_util_h[FlashBank0Data].load_mem_from_file(
-            {cfg.sw_images[SwTypeTestSlotA], ".64.scr.vmem"});
+    if (cfg.use_spi_load_bootstrap) begin
+      // If use_spi_load_bootstrap is defined, load the image for slot A
+      if (!cfg.sw_images.exists(SwTypeTestSlotA)) begin
+        `uvm_error(get_name(), "Cannot load slot A over SPI: no SW image defined.")
       end
-    end
-    if (cfg.sw_images.exists(SwTypeTestSlotB)) begin
+      spi_device_load_bootstrap({cfg.sw_images[SwTypeTestSlotA], ".64.vmem"});
+      cfg.use_spi_load_bootstrap = 1'b0;
+
       // TODO: support bootstrapping entire flash address space, not just slot A.
-      cfg.mem_bkdr_util_h[FlashBank1Data].load_mem_from_file(
-          {cfg.sw_images[SwTypeTestSlotB], ".64.scr.vmem"});
+
+    end else begin
+      if (cfg.sw_images.exists(SwTypeTestSlotA)) begin
+        string image_path = {cfg.sw_images[SwTypeTestSlotA], ".64.scr.vmem"};
+        cfg.mem_bkdr_util_h[FlashBank0Data].load_mem_from_file(image_path);
+      end
+      if (cfg.sw_images.exists(SwTypeTestSlotB)) begin
+        string image_path = {cfg.sw_images[SwTypeTestSlotB], ".64.scr.vmem"};
+        cfg.mem_bkdr_util_h[FlashBank1Data].load_mem_from_file(image_path);
+      end
     end
 
     config_jitter();


### PR DESCRIPTION
The code in chip_sw_base_vseq::cpu_init expects to load up the contents of flash. Historically, it did so through a backdoor.

Near the release of Earlgrey 1.0.0, there several virtual sequences were added that load flash over SPI instead. You might expect this to be controlled through chip_env_cfg::use_spi_load_bootstrap, but the new sequences skip the code in the base class that does the loading and re-implement this separately.

I hadn't properly understood how this worked when I ported ate_bootstrap_disjoint in commit 4a305de, so set the plusarg before porting the code that would look it it. Even more confusingly, the ported version of ate_bootstrap_flash_erase (commit 46cc365) asks that any supplied images should be loaded over SPI... then supplies no images.

In both cases, the code does the right thing. But it's very confusing!

After the tidy-up in this commit, we just have two behaviours:

  - use_spi_load_bootstrap = 0

    This is the default behaviour. Load up any slot A or slot B image that exists, using mem_bkdr_util.

  - use_spi_load_bootstrap = 1

    Load the slot A image (which might well contain slot B as well) and write it into flash over SPI.

I'm hopeful that the other similar tests can be ported from the earlgrey_1.0.0 branch without needing to change this further.