### PR TITLE
[dv,ate] add test to bootstrap a single flash data page (merge-back)

### DIFF
--- a/hw/top_earlgrey/dv/chip_manuf_ate_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_manuf_ate_tests.hjson
@@ -19,6 +19,17 @@
       run_timeout_mins: 180
     }
     {
+      name: ate_bootstrap_one_frame
+      uvm_test_seq: chip_sw_ate_bootstrap_one_frame_vseq
+      sw_images: ["//sw/device/silicon_creator/manuf/tests:manuf_scrap_functest_prod:1:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=160_000_000"
+        "+use_spi_load_bootstrap=1",
+      ]
+      run_timeout_mins: 180
+    }
+    {
       name: ate_bootstrap_disjoint
       uvm_test_seq: chip_sw_ate_bootstrap_disjoint_vseq
       sw_images: ["//sw/device/silicon_creator/manuf/tests:multislot_empty_test:1:new_rules"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -142,6 +142,7 @@ filesets:
       - seq_lib/chip_sw_flash_host_gnt_err_inj_vseq.sv: {is_include_file: true}
       - seq_lib/chip_padctrl_attributes_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_ate_bootstrap_flash_erase_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_ate_bootstrap_one_frame_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_ate_bootstrap_disjoint_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_e2e_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_e2e_shutdown_exception_c_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_ate_bootstrap_one_frame_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_ate_bootstrap_one_frame_vseq.sv
@@ -1,0 +1,85 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This test performs the first two steps of a ROM bootstrap operation, i.e., flash erase followed
+// by a single page program operation. It then reads the first data page through a backdoor to check
+// this has been programmed.
+
+class chip_sw_ate_bootstrap_one_frame_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_ate_bootstrap_one_frame_vseq)
+  `uvm_object_new
+
+  local function automatic void _check_flash_data_page(input integer address,
+                                                       input integer expected);
+    logic [TL_DW-1:0] actual;
+    actual = cfg.mem_bkdr_util_h[FlashBank0Data].read32(address);
+    `DV_CHECK_EQ(actual, expected)
+  endfunction
+
+  virtual task body();
+    int unsigned num_errors;
+    string       sw_image;
+    byte         sw_byte_q[$];
+    int unsigned SPI_FLASH_PAGE_SIZE = 256;
+
+    // Do the standard setup, including loading up the flash image with spi_device_load_bootstrap.
+    //
+    // This sequence won't actually load the whole image (see the way we've overridden
+    // spi_write_flash_stream)
+    super.body();
+
+    // Read the SW frames again into a local queue. This feels a little silly (because we did it in
+    // the base class as well), but it's reasonably quick.
+    sw_image = {cfg.sw_images[SwTypeTestSlotA], ".64.vmem"};
+    read_sw_frames(sw_image, sw_byte_q);
+
+    // Do a backdoor read to check that the first page of flash (which should have been loaded in
+    // super.body) has indeed been loaded.
+    `uvm_info(`gfn, $sformatf("Checking page program succeeded\n"), UVM_LOW);
+    for (int a = 0; a < SPI_FLASH_PAGE_SIZE; a += 4) begin
+      bit [31:0] expected = {sw_byte_q[a+3], sw_byte_q[a+2], sw_byte_q[a+1], sw_byte_q[a+0]};
+      if (!check_flash_word_32(a, expected)) num_errors++;
+    end
+    if (num_errors > 0) begin
+      `uvm_error(get_name(),
+                 $sformatf("Found %0d errors in first page of programmed flash", num_errors))
+    end
+
+    // Set test passed.
+    assert_por_reset();
+    if (!num_errors) override_test_status_and_finish(.passed(1'b1));
+  endtask
+
+  // An override of chip_sw_base_vseq::spi_write_flash_stream.
+  //
+  // We only actually want to write a single page (the first one), so we do this by discarding
+  // everything after the first page_size bytes in the queue.
+  protected virtual task spi_write_flash_stream(const ref byte byte_q[$],
+                                                int unsigned page_size);
+    // Discard the later items in the queue
+    byte page_bytes[$];
+    int unsigned new_size = (byte_q.size() > page_size) ? page_size : byte_q.size();
+    page_bytes = byte_q[0 : new_size - 1];
+
+    super.spi_write_flash_stream(page_bytes, page_size);
+  endtask
+
+  // Do a backdoor read of a 32-bit word from the first bank of flash. On a match, return true. On a
+  // mismatch, generate a uvm_error describing the mismatch and return false.
+  //
+  local function bit check_flash_word_32(int unsigned address, bit [31:0] expected);
+    logic [31:0]     actual = cfg.mem_bkdr_util_h[FlashBank0Data].read32(address);
+
+    if (actual === expected) begin
+      return 1'b1;
+    end else begin
+      `uvm_error(get_name(),
+                 $sformatf({"Flash data mismatch at 0x%0h (in FlashBank0Data). ",
+                            "We expected 0x%0h but saw 0x%0h."},
+                           address, expected, actual))
+      return 1'b0;
+    end
+  endfunction
+
+endclass : chip_sw_ate_bootstrap_one_frame_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -573,12 +573,18 @@ class chip_sw_base_vseq extends chip_base_vseq;
 
     erase_flash_over_spi();
 
-    for (int unsigned idx = 0; idx < sw_byte_q.size(); idx += SPI_FLASH_PAGE_SIZE) begin
-      spi_write_flash_page(sw_byte_q, idx, SPI_FLASH_PAGE_SIZE);
-    end
+    spi_write_flash_stream(sw_byte_q, SPI_FLASH_PAGE_SIZE);
 
     cfg.chip_vif.sw_straps_if.drive(3'h0);
     assert_por_reset();
+  endtask
+
+  // Stream a byte queue into SPI flash, using sequential page-write operations of size page_size.
+  protected virtual task spi_write_flash_stream(const ref byte byte_q[$],
+                                                int unsigned page_size);
+    for (int unsigned idx = 0; idx < byte_q.size(); idx += page_size) begin
+      spi_write_flash_page(byte_q, idx, page_size);
+    end
   endtask
 
   // Write a single page to flash, starting with item at index start_idx. Send up to page_size bytes

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -106,6 +106,7 @@
 `include "chip_sw_rom_e2e_self_hash_gls_vseq.sv"
 `include "chip_sw_ate_bootstrap_flash_erase_vseq.sv"
 `include "chip_sw_ate_bootstrap_disjoint_vseq.sv"
+`include "chip_sw_ate_bootstrap_one_frame_vseq.sv"
 `include "chip_sw_power_idle_load_vseq.sv"
 `include "chip_sw_power_sleep_load_vseq.sv"
 `include "chip_sw_ast_clk_rst_inputs_vseq.sv"

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -78,6 +78,7 @@ _MANUF_TEST_LOCKED_KEY = None
         srcs = ["empty_functest.c"],
         ecdsa_key = _MANUF_TEST_LOCKED_KEY if (lc_state, lc_val) in _TEST_LOCKED_LC_ITEMS else ecdsa_key_for_lc_state(ECDSA_SPX_KEY_STRUCTS, lc_val),
         exec_env = {
+            "//hw/top_earlgrey:sim_dv": None,
             "//hw/top_earlgrey:fpga_cw340_sival": None,
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
         },


### PR DESCRIPTION
This adds a DV test that performs two basic bootstrap operations:
1. SPI flash erase, and
2. a single page program.

This is to facilitate bootstrap operation bringup in ATE environments.

This is a cherry-pick of ba9a09dfd5, which was added to the
earlgrey_1.0.0 branch in May 2025.

As part of cherry-picking the result, I have ported it to use the
infrastructure that's now available in chip_sw_base_vseq. Much of that
infrastructure got set up in commit 4a305de: in hindsight, I should
have ported this test first! It would have been rather easier.

**This is a port of #27188**