### PR TITLE
[dv,chip] Make bootstrap sequence more chatty

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -539,9 +539,11 @@ class chip_sw_base_vseq extends chip_base_vseq;
 
     erase_seq = spi_host_flash_seq::type_id::create("erase_seq");
     erase_seq.opcode = SpiFlashChipErase;
+    `uvm_info(get_name(), "Erasing flash over SPI", UVM_MEDIUM)
     spi_host_flash_issue_write_cmd(.write_command(erase_seq),
                                    .busy_timeout_ns(200_000_000),
                                    .busy_poll_interval_ns(1_000_000));
+    `uvm_info(get_name(), "Flash erased", UVM_MEDIUM)
   endtask
 
   // Load the flash binary specified by the `sw_image` path by sending a chip erase, then
@@ -564,15 +566,20 @@ class chip_sw_base_vseq extends chip_base_vseq;
     cfg.m_spi_host_agent_cfg.max_idle_ns_after_csb_drop = 200;
 
     // Configure the spi_agent for flash mode and add command info.
+    `uvm_info(`gfn, "Configuring SPI flash commands.", UVM_LOW)
     spi_agent_configure_flash_cmds(cfg.m_spi_host_agent_cfg);
 
     // Wait for the commands to be ready
+    `uvm_info(`gfn, "Waiting for SPI flash commands to be ready.", UVM_LOW)
     wait_for_flash_command_load();
 
+    `uvm_info(`gfn, $sformatf("Reading SW image frames from %0s ...", sw_image), UVM_LOW)
     read_sw_frames(sw_image, sw_byte_q);
 
+    `uvm_info(`gfn, "Sending SPI flash erase command ...", UVM_LOW)
     erase_flash_over_spi();
 
+    `uvm_info(`gfn, "Sending page program commands ...", UVM_LOW)
     spi_write_flash_stream(sw_byte_q, SPI_FLASH_PAGE_SIZE);
 
     cfg.chip_vif.sw_straps_if.drive(3'h0);
@@ -601,6 +608,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
       page_seq.payload_q.push_back(byte_q[i]);
     end
 
+    `uvm_info(get_name(), $sformatf("Writing flash page to 0x%0h over SPI.", start_idx), UVM_MEDIUM)
     spi_host_flash_issue_write_cmd(page_seq);
   endtask
 


### PR DESCRIPTION
This now prints out a message before each section of the spi_device_load_bootstrap (so that the log file gives a hint about where the bootstrap has got to).

It also prints out a message on either side of the flash erase. That operation takes a long time because the SW reads the whole of flash to check that it was erased.

Finally, it adds a print for each page that gets written.

I was concerned that the last item would generate too much output, but (for 2MiB of flash, split into 256 byte pages): this will generate 4096 lines: a bit chatty, but not ridiculous. And it's a lot nicer than watching a seemingly dead simulation.