### PR TITLE
Backport 28976 ([ft] increase individualization run timeout)

### DIFF
--- a/sw/host/provisioning/ft/src/main.rs
+++ b/sw/host/provisioning/ft/src/main.rs
@@ -92,7 +92,7 @@ struct Opts {
     second_bootstrap: PathBuf,
 
     /// Console receive timeout.
-    #[arg(long, value_parser = humantime::parse_duration, default_value = "20s")]
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "30s")]
     timeout: Duration,
 
     /// Name of the SPI interface to connect to the OTTF console.


### PR DESCRIPTION
Backport #28976