### PR TITLE
DRAFT [DO NOT MERGE]: [manifests] add project/top/ip manifests

### DIFF
--- a/hw/ip/adc_ctrl/ip_manifest.hjson
+++ b/hw/ip/adc_ctrl/ip_manifest.hjson
@@ -1,0 +1,10 @@
+{
+  "name": "adc_ctrl",
+  "sim": [
+    {
+      "cfg": "dv/adc_ctrl_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/aes/ip_manifest.hjson
+++ b/hw/ip/aes/ip_manifest.hjson
@@ -1,0 +1,19 @@
+{
+  "name": "aes",
+  "sim": [
+    {
+      "variant": "base",
+      "cfg": "dv/aes_base_sim_cfg.hjson"
+    },
+    {
+      "variant": "masked",
+      "cfg": "dv/aes_masked_sim_cfg.hjson"
+    },
+    {
+      "variant": "unmasked",
+      "cfg": "dv/aes_unmasked_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/aon_timer/ip_manifest.hjson
+++ b/hw/ip/aon_timer/ip_manifest.hjson
@@ -1,0 +1,10 @@
+{
+  "name": "aon_timer",
+  "sim": [
+    {
+      "cfg": "dv/aon_timer_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/ascon/ip_manifest.hjson
+++ b/hw/ip/ascon/ip_manifest.hjson
@@ -1,0 +1,6 @@
+{
+  "name": "ascon",
+  "sim": [],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/csrng/ip_manifest.hjson
+++ b/hw/ip/csrng/ip_manifest.hjson
@@ -1,0 +1,10 @@
+{
+  "name": "csrng",
+  "sim": [
+    {
+      "cfg": "dv/csrng_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/dma/ip_manifest.hjson
+++ b/hw/ip/dma/ip_manifest.hjson
@@ -1,0 +1,10 @@
+{
+  "name": "dma",
+  "sim": [
+    {
+      "cfg": "dv/dma_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/edn/ip_manifest.hjson
+++ b/hw/ip/edn/ip_manifest.hjson
@@ -1,0 +1,19 @@
+{
+  "name": "edn",
+  "sim": [
+    {
+      "variant": "base",
+      "cfg": "dv/edn_base_sim_cfg.hjson"
+    },
+    {
+      "variant": "edn0",
+      "cfg": "dv/edn_edn0_sim_cfg.hjson"
+    },
+    {
+      "variant": "edn1",
+      "cfg": "dv/edn_edn1_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/entropy_src/ip_manifest.hjson
+++ b/hw/ip/entropy_src/ip_manifest.hjson
@@ -1,0 +1,19 @@
+{
+  "name": "entropy_src",
+  "sim": [
+    {
+      "variant": "base",
+      "cfg": "dv/entropy_src_base_sim_cfg.hjson"
+    },
+    {
+      "variant": "rng16bits",
+      "cfg": "dv/entropy_src_rng16bits_sim_cfg.hjson"
+    },
+    {
+      "variant": "rng4bits",
+      "cfg": "dv/entropy_src_rng4bits_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/flash_ctrl/ip_manifest.hjson
+++ b/hw/ip/flash_ctrl/ip_manifest.hjson
@@ -1,0 +1,6 @@
+{
+  "name": "flash_ctrl",
+  "sim": [],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/hmac/ip_manifest.hjson
+++ b/hw/ip/hmac/ip_manifest.hjson
@@ -1,0 +1,10 @@
+{
+  "name": "hmac",
+  "sim": [
+    {
+      "cfg": "dv/hmac_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/i2c/ip_manifest.hjson
+++ b/hw/ip/i2c/ip_manifest.hjson
@@ -1,0 +1,10 @@
+{
+  "name": "i2c",
+  "sim": [
+    {
+      "cfg": "dv/i2c_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/keymgr/ip_manifest.hjson
+++ b/hw/ip/keymgr/ip_manifest.hjson
@@ -1,0 +1,10 @@
+{
+  "name": "keymgr",
+  "sim": [
+    {
+      "cfg": "dv/keymgr_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/keymgr_dpe/ip_manifest.hjson
+++ b/hw/ip/keymgr_dpe/ip_manifest.hjson
@@ -1,0 +1,10 @@
+{
+  "name": "keymgr_dpe",
+  "sim": [
+    {
+      "cfg": "dv/keymgr_dpe_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/kmac/ip_manifest.hjson
+++ b/hw/ip/kmac/ip_manifest.hjson
@@ -1,0 +1,19 @@
+{
+  "name": "kmac",
+  "sim": [
+    {
+      "variant": "base",
+      "cfg": "dv/kmac_base_sim_cfg.hjson"
+    },
+    {
+      "variant": "masked",
+      "cfg": "dv/kmac_masked_sim_cfg.hjson"
+    },
+    {
+      "variant": "unmasked",
+      "cfg": "dv/kmac_unmasked_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/lc_ctrl/ip_manifest.hjson
+++ b/hw/ip/lc_ctrl/ip_manifest.hjson
@@ -1,0 +1,27 @@
+{
+  "name": "lc_ctrl",
+  "sim": [
+    {
+      "variant": "base",
+      "cfg": "dv/lc_ctrl_base_sim_cfg.hjson"
+    },
+    {
+      "variant": "dmi_volatile_unlock_disabled",
+      "cfg": "dv/lc_ctrl_dmi_volatile_unlock_disabled_sim_cfg.hjson"
+    },
+    {
+      "variant": "dmi_volatile_unlock_enabled",
+      "cfg": "dv/lc_ctrl_dmi_volatile_unlock_enabled_sim_cfg.hjson"
+    },
+    {
+      "variant": "volatile_unlock_disabled",
+      "cfg": "dv/lc_ctrl_volatile_unlock_disabled_sim_cfg.hjson"
+    },
+    {
+      "variant": "volatile_unlock_enabled",
+      "cfg": "dv/lc_ctrl_volatile_unlock_enabled_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/mbx/ip_manifest.hjson
+++ b/hw/ip/mbx/ip_manifest.hjson
@@ -1,0 +1,10 @@
+{
+  "name": "mbx",
+  "sim": [
+    {
+      "cfg": "dv/mbx_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/otbn/ip_manifest.hjson
+++ b/hw/ip/otbn/ip_manifest.hjson
@@ -1,0 +1,6 @@
+{
+  "name": "otbn",
+  "sim": [],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/otp_ctrl/ip_manifest.hjson
+++ b/hw/ip/otp_ctrl/ip_manifest.hjson
@@ -1,0 +1,6 @@
+{
+  "name": "otp_ctrl",
+  "sim": [],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/otp_macro/ip_manifest.hjson
+++ b/hw/ip/otp_macro/ip_manifest.hjson
@@ -1,0 +1,6 @@
+{
+  "name": "otp_macro",
+  "sim": [],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/pattgen/ip_manifest.hjson
+++ b/hw/ip/pattgen/ip_manifest.hjson
@@ -1,0 +1,10 @@
+{
+  "name": "pattgen",
+  "sim": [
+    {
+      "cfg": "dv/pattgen_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/prim/ip_manifest.hjson
+++ b/hw/ip/prim/ip_manifest.hjson
@@ -1,0 +1,6 @@
+{
+  "name": "prim",
+  "sim": [],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/prim_asap7/ip_manifest.hjson
+++ b/hw/ip/prim_asap7/ip_manifest.hjson
@@ -1,0 +1,6 @@
+{
+  "name": "prim_asap7",
+  "sim": [],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/prim_generic/ip_manifest.hjson
+++ b/hw/ip/prim_generic/ip_manifest.hjson
@@ -1,0 +1,6 @@
+{
+  "name": "prim_generic",
+  "sim": [],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/prim_xilinx/ip_manifest.hjson
+++ b/hw/ip/prim_xilinx/ip_manifest.hjson
@@ -1,0 +1,6 @@
+{
+  "name": "prim_xilinx",
+  "sim": [],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/prim_xilinx_ultrascale/ip_manifest.hjson
+++ b/hw/ip/prim_xilinx_ultrascale/ip_manifest.hjson
@@ -1,0 +1,6 @@
+{
+  "name": "prim_xilinx_ultrascale",
+  "sim": [],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/racl_ctrl/ip_manifest.hjson
+++ b/hw/ip/racl_ctrl/ip_manifest.hjson
@@ -1,0 +1,6 @@
+{
+  "name": "racl_ctrl",
+  "sim": [],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/rom_ctrl/ip_manifest.hjson
+++ b/hw/ip/rom_ctrl/ip_manifest.hjson
@@ -1,0 +1,19 @@
+{
+  "name": "rom_ctrl",
+  "sim": [
+    {
+      "variant": "32kB",
+      "cfg": "dv/rom_ctrl_32kB_sim_cfg.hjson"
+    },
+    {
+      "variant": "64kB",
+      "cfg": "dv/rom_ctrl_64kB_sim_cfg.hjson"
+    },
+    {
+      "variant": "base",
+      "cfg": "dv/rom_ctrl_base_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/rv_core_ibex/ip_manifest.hjson
+++ b/hw/ip/rv_core_ibex/ip_manifest.hjson
@@ -1,0 +1,6 @@
+{
+  "name": "rv_core_ibex",
+  "sim": [],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/rv_dm/ip_manifest.hjson
+++ b/hw/ip/rv_dm/ip_manifest.hjson
@@ -1,0 +1,19 @@
+{
+  "name": "rv_dm",
+  "sim": [
+    {
+      "variant": "base",
+      "cfg": "dv/rv_dm_base_sim_cfg.hjson"
+    },
+    {
+      "variant": "use_dmi_interface",
+      "cfg": "dv/rv_dm_use_dmi_interface_sim_cfg.hjson"
+    },
+    {
+      "variant": "use_jtag_interface",
+      "cfg": "dv/rv_dm_use_jtag_interface_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/rv_timer/ip_manifest.hjson
+++ b/hw/ip/rv_timer/ip_manifest.hjson
@@ -1,0 +1,10 @@
+{
+  "name": "rv_timer",
+  "sim": [
+    {
+      "cfg": "dv/rv_timer_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/soc_dbg_ctrl/ip_manifest.hjson
+++ b/hw/ip/soc_dbg_ctrl/ip_manifest.hjson
@@ -1,0 +1,10 @@
+{
+  "name": "soc_dbg_ctrl",
+  "sim": [
+    {
+      "cfg": "dv/soc_dbg_ctrl_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/spi_device/ip_manifest.hjson
+++ b/hw/ip/spi_device/ip_manifest.hjson
@@ -1,0 +1,19 @@
+{
+  "name": "spi_device",
+  "sim": [
+    {
+      "variant": "base",
+      "cfg": "dv/base_sim_cfg.hjson"
+    },
+    {
+      "variant": "1r1w",
+      "cfg": "dv/spi_device_1r1w_sim_cfg.hjson"
+    },
+    {
+      "variant": "2p",
+      "cfg": "dv/spi_device_2p_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/spi_host/ip_manifest.hjson
+++ b/hw/ip/spi_host/ip_manifest.hjson
@@ -1,0 +1,10 @@
+{
+  "name": "spi_host",
+  "sim": [
+    {
+      "cfg": "dv/spi_host_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/sram_ctrl/ip_manifest.hjson
+++ b/hw/ip/sram_ctrl/ip_manifest.hjson
@@ -1,0 +1,31 @@
+{
+  "name": "sram_ctrl",
+  "sim": [
+    {
+      "variant": "base_fi",
+      "cfg": "dv/sram_ctrl_base_fi_sim_cfg.hjson"
+    },
+    {
+      "variant": "base",
+      "cfg": "dv/sram_ctrl_base_sim_cfg.hjson"
+    },
+    {
+      "variant": "exec_64kB",
+      "cfg": "dv/sram_ctrl_exec_64kB_sim_cfg.hjson"
+    },
+    {
+      "variant": "main_fi",
+      "cfg": "dv/sram_ctrl_main_fi_sim_cfg.hjson"
+    },
+    {
+      "variant": "main",
+      "cfg": "dv/sram_ctrl_main_sim_cfg.hjson"
+    },
+    {
+      "variant": "ret",
+      "cfg": "dv/sram_ctrl_ret_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/sysrst_ctrl/ip_manifest.hjson
+++ b/hw/ip/sysrst_ctrl/ip_manifest.hjson
@@ -1,0 +1,10 @@
+{
+  "name": "sysrst_ctrl",
+  "sim": [
+    {
+      "cfg": "dv/sysrst_ctrl_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/tlul/ip_manifest.hjson
+++ b/hw/ip/tlul/ip_manifest.hjson
@@ -1,0 +1,6 @@
+{
+  "name": "tlul",
+  "sim": [],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/uart/ip_manifest.hjson
+++ b/hw/ip/uart/ip_manifest.hjson
@@ -1,0 +1,10 @@
+{
+  "name": "uart",
+  "sim": [
+    {
+      "cfg": "dv/uart_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/ip/usbdev/ip_manifest.hjson
+++ b/hw/ip/usbdev/ip_manifest.hjson
@@ -1,0 +1,10 @@
+{
+  "name": "usbdev",
+  "sim": [
+    {
+      "cfg": "dv/usbdev_sim_cfg.hjson"
+    }
+  ],
+  "lint": [],
+  "formal": []
+}

--- a/hw/top_darjeeling/top_manifest.hjson
+++ b/hw/top_darjeeling/top_manifest.hjson
@@ -1,0 +1,139 @@
+{
+  "name": "darjeeling",
+  "ips": [
+    {
+      "name": "aes",
+      "variant": "masked"
+    },
+    {
+      "name": "aes",
+      "variant": "unmasked"
+    },
+    {
+      "name": "aon_timer"
+    },
+    {
+      "name": "csrng"
+    },
+    {
+      "name": "dma"
+    },
+    {
+      "name": "edn",
+      "variant": "edn0"
+    },
+    {
+      "name": "edn",
+      "variant": "edn1"
+    },
+    {
+      "name": "entropy_src",
+      "variant": "rng16bits"
+    },
+    {
+      "name": "hmac"
+    },
+    {
+      "name": "i2c"
+    },
+    {
+      "name": "keymgr_dpe"
+    },
+    {
+      "name": "kmac",
+      "variant": "masked"
+    },
+    {
+      "name": "kmac",
+      "variant": "unmasked"
+    },
+    {
+      "name": "lc_ctrl",
+      "variant": "dmi_volatile_unlock_disabled"
+    },
+    {
+      "name": "lc_ctrl",
+      "variant": "dmi_volatile_unlock_enabled"
+    },
+    {
+      "name": "mbx"
+    },
+    {
+      "name": "otbn"
+    },
+    {
+      "name": "prim",
+      "variant": "alert"
+    },
+    {
+      "name": "prim",
+      "variant": "esc"
+    },
+    {
+      "name": "prim",
+      "variant": "lfsr"
+    },
+    {
+      "name": "prim",
+      "variant": "present"
+    },
+    {
+      "name": "prim",
+      "variant": "prince"
+    },
+    {
+      "name": "rom_ctrl",
+      "variant": "32kB"
+    },
+    {
+      "name": "rom_ctrl",
+      "variant": "64kB"
+    },
+    {
+      "name": "rv_dm",
+      "variant": "use_dmi_interface"
+    },
+    {
+      "name": "rv_timer"
+    },
+    {
+      "name": "spi_device",
+      "variant": "1r1w"
+    },
+    {
+      "name": "spi_host"
+    },
+    {
+      "name": "sram_ctrl",
+      "variant": "main"
+    },
+    {
+      "name": "sram_ctrl",
+      "variant": "ret"
+    },
+    {
+      "name": "uart"
+    }
+  ],
+  "sim": [
+    {
+      "variant": "chip",
+      "cfg": "dv/chip_sim_cfg.hjson"
+    },
+    {
+      "cfg": "dv/top_darjeeling_sim_cfgs.hjson"
+    }
+  ],
+  "lint": [
+    "lint/top_darjeeling_dv_lint_cfgs.hjson",
+    "lint/top_darjeeling_fpga_lint_cfgs.hjson",
+    "lint/top_darjeeling_fpv_lint_cfgs.hjson",
+    "lint/top_darjeeling_lint_cfgs.hjson"
+  ],
+  "formal": [
+    "formal/chip_conn_cfg.hjson",
+    "formal/top_darjeeling_fpv_ip_cfgs.hjson",
+    "formal/top_darjeeling_fpv_prim_cfgs.hjson",
+    "formal/top_darjeeling_fpv_sec_cm_cfgs.hjson"
+  ]
+}

--- a/hw/top_earlgrey/top_manifest.hjson
+++ b/hw/top_earlgrey/top_manifest.hjson
@@ -1,0 +1,149 @@
+{
+  "name": "earlgrey",
+  "ips": [
+    {
+      "name": "adc_ctrl"
+    },
+    {
+      "name": "aes",
+      "variant": "masked"
+    },
+    {
+      "name": "aes",
+      "variant": "unmasked"
+    },
+    {
+      "name": "aon_timer"
+    },
+    {
+      "name": "csrng"
+    },
+    {
+      "name": "edn",
+      "variant": "edn0"
+    },
+    {
+      "name": "edn",
+      "variant": "edn1"
+    },
+    {
+      "name": "entropy_src",
+      "variant": "rng4bits"
+    },
+    {
+      "name": "hmac"
+    },
+    {
+      "name": "i2c"
+    },
+    {
+      "name": "keymgr"
+    },
+    {
+      "name": "kmac",
+      "variant": "masked"
+    },
+    {
+      "name": "kmac",
+      "variant": "unmasked"
+    },
+    {
+      "name": "lc_ctrl",
+      "variant": "volatile_unlock_disabled"
+    },
+    {
+      "name": "lc_ctrl",
+      "variant": "volatile_unlock_enabled"
+    },
+    {
+      "name": "otbn"
+    },
+    {
+      "name": "pattgen"
+    },
+    {
+      "name": "prim",
+      "variant": "alert"
+    },
+    {
+      "name": "prim",
+      "variant": "esc"
+    },
+    {
+      "name": "prim",
+      "variant": "lfsr"
+    },
+    {
+      "name": "prim",
+      "variant": "present"
+    },
+    {
+      "name": "prim",
+      "variant": "prince"
+    },
+    {
+      "name": "rom_ctrl",
+      "variant": "32kB"
+    },
+    {
+      "name": "rom_ctrl",
+      "variant": "64kB"
+    },
+    {
+      "name": "rv_dm",
+      "variant": "use_jtag_interface"
+    },
+    {
+      "name": "rv_timer"
+    },
+    {
+      "name": "spi_device",
+      "variant": "1r1w"
+    },
+    {
+      "name": "spi_device",
+      "variant": "2p"
+    },
+    {
+      "name": "spi_host"
+    },
+    {
+      "name": "sram_ctrl",
+      "variant": "main"
+    },
+    {
+      "name": "sram_ctrl",
+      "variant": "ret"
+    },
+    {
+      "name": "sysrst_ctrl"
+    },
+    {
+      "name": "uart"
+    },
+    {
+      "name": "usbdev"
+    }
+  ],
+  "sim": [
+    {
+      "variant": "chip",
+      "cfg": "dv/chip_sim_cfg.hjson"
+    },
+    {
+      "cfg": "dv/top_earlgrey_sim_cfgs.hjson"
+    }
+  ],
+  "lint": [
+    "lint/top_earlgrey_dv_lint_cfgs.hjson",
+    "lint/top_earlgrey_fpga_lint_cfgs.hjson",
+    "lint/top_earlgrey_fpv_lint_cfgs.hjson",
+    "lint/top_earlgrey_lint_cfgs.hjson"
+  ],
+  "formal": [
+    "formal/chip_conn_cfg.hjson",
+    "formal/top_earlgrey_fpv_ip_cfgs.hjson",
+    "formal/top_earlgrey_fpv_prim_cfgs.hjson",
+    "formal/top_earlgrey_fpv_sec_cm_cfgs.hjson"
+  ]
+}

--- a/hw/top_englishbreakfast/top_manifest.hjson
+++ b/hw/top_englishbreakfast/top_manifest.hjson
@@ -1,0 +1,9 @@
+{
+  "name": "englishbreakfast",
+  "ips": [],
+  "sim": [],
+  "lint": [
+    "lint/top_englishbreakfast_lint_cfgs.hjson"
+  ],
+  "formal": []
+}

--- a/project.hjson
+++ b/project.hjson
@@ -1,0 +1,171 @@
+{
+  "project": "opentitan",
+  "tops": [
+    {
+      "name": "darjeeling",
+      "path": "hw/top_darjeeling"
+    },
+    {
+      "name": "earlgrey",
+      "path": "hw/top_earlgrey"
+    },
+    {
+      "name": "englishbreakfast",
+      "path": "hw/top_englishbreakfast"
+    }
+  ],
+  "ips": [
+    {
+      "name": "adc_ctrl",
+      "path": "hw/ip/adc_ctrl"
+    },
+    {
+      "name": "aes",
+      "path": "hw/ip/aes"
+    },
+    {
+      "name": "aon_timer",
+      "path": "hw/ip/aon_timer"
+    },
+    {
+      "name": "ascon",
+      "path": "hw/ip/ascon"
+    },
+    {
+      "name": "csrng",
+      "path": "hw/ip/csrng"
+    },
+    {
+      "name": "dma",
+      "path": "hw/ip/dma"
+    },
+    {
+      "name": "edn",
+      "path": "hw/ip/edn"
+    },
+    {
+      "name": "entropy_src",
+      "path": "hw/ip/entropy_src"
+    },
+    {
+      "name": "flash_ctrl",
+      "path": "hw/ip/flash_ctrl"
+    },
+    {
+      "name": "hmac",
+      "path": "hw/ip/hmac"
+    },
+    {
+      "name": "i2c",
+      "path": "hw/ip/i2c"
+    },
+    {
+      "name": "keymgr",
+      "path": "hw/ip/keymgr"
+    },
+    {
+      "name": "keymgr_dpe",
+      "path": "hw/ip/keymgr_dpe"
+    },
+    {
+      "name": "kmac",
+      "path": "hw/ip/kmac"
+    },
+    {
+      "name": "lc_ctrl",
+      "path": "hw/ip/lc_ctrl"
+    },
+    {
+      "name": "mbx",
+      "path": "hw/ip/mbx"
+    },
+    {
+      "name": "otbn",
+      "path": "hw/ip/otbn"
+    },
+    {
+      "name": "otp_ctrl",
+      "path": "hw/ip/otp_ctrl"
+    },
+    {
+      "name": "otp_macro",
+      "path": "hw/ip/otp_macro"
+    },
+    {
+      "name": "pattgen",
+      "path": "hw/ip/pattgen"
+    },
+    {
+      "name": "prim",
+      "path": "hw/ip/prim"
+    },
+    {
+      "name": "prim_asap7",
+      "path": "hw/ip/prim_asap7"
+    },
+    {
+      "name": "prim_generic",
+      "path": "hw/ip/prim_generic"
+    },
+    {
+      "name": "prim_xilinx",
+      "path": "hw/ip/prim_xilinx"
+    },
+    {
+      "name": "prim_xilinx_ultrascale",
+      "path": "hw/ip/prim_xilinx_ultrascale"
+    },
+    {
+      "name": "racl_ctrl",
+      "path": "hw/ip/racl_ctrl"
+    },
+    {
+      "name": "rom_ctrl",
+      "path": "hw/ip/rom_ctrl"
+    },
+    {
+      "name": "rv_core_ibex",
+      "path": "hw/ip/rv_core_ibex"
+    },
+    {
+      "name": "rv_dm",
+      "path": "hw/ip/rv_dm"
+    },
+    {
+      "name": "rv_timer",
+      "path": "hw/ip/rv_timer"
+    },
+    {
+      "name": "soc_dbg_ctrl",
+      "path": "hw/ip/soc_dbg_ctrl"
+    },
+    {
+      "name": "spi_device",
+      "path": "hw/ip/spi_device"
+    },
+    {
+      "name": "spi_host",
+      "path": "hw/ip/spi_host"
+    },
+    {
+      "name": "sram_ctrl",
+      "path": "hw/ip/sram_ctrl"
+    },
+    {
+      "name": "sysrst_ctrl",
+      "path": "hw/ip/sysrst_ctrl"
+    },
+    {
+      "name": "tlul",
+      "path": "hw/ip/tlul"
+    },
+    {
+      "name": "uart",
+      "path": "hw/ip/uart"
+    },
+    {
+      "name": "usbdev",
+      "path": "hw/ip/usbdev"
+    }
+  ]
+}


### PR DESCRIPTION
Example manifest files for review. The idea here is to add some machine readable manifest files that add higher level structure to the repo. The manifests could be read by DVSim for example to provide a more intuitive interface, it could also be used by regression running infrastructure or reporting tools (website generation scripts).

Right now DVSim requires a full path to a sim config file, however we could simplify this to `dvsim run sim earlgrey`, `dvsim run lint darjeeling`, or `dvsim run formal earlgrey`. The exact interface is a separate issue, if we can get the manifest files in place this opens up a lot of potential tooling UX improvements.