### PR TITLE
[dv] Make CSR aliasing tests much quicker

### DIFF
--- a/hw/dv/sv/csr_utils/csr_aliasing_seq.sv
+++ b/hw/dv/sv/csr_utils/csr_aliasing_seq.sv
@@ -10,53 +10,130 @@
 class csr_aliasing_seq extends csr_base_seq;
   `uvm_object_utils(csr_aliasing_seq)
 
-  `uvm_object_new
+  // A queue of uvm_reg objects
+  typedef uvm_reg reg_queue_t[$];
+
+  // The size of "register chunk" to use in the test.
+  //
+  // The list of CSRs to test (test_csrs) is checked in chunks of this size (writing a random value
+  // to each register in a chunk, then reading back every register in the design to check that there
+  // was no aliasing).
+  int unsigned m_chunk_size = 10;
+
+  function new (string name="");
+      super.new(name);
+  endfunction
+
+  // Write a random value to csr, after applying any write exclusion that has been defined for the
+  // register.
+  local task randomize_register(uvm_reg csr);
+    uvm_reg_data_t wdata;
+
+    if (!std::randomize(wdata)) begin
+      `uvm_fatal(get_full_name(), "Failed to randomize wdata.")
+    end
+
+    wdata = get_csr_wdata_with_write_excl(csr, wdata, CsrAliasingTest);
+    csr_wr(.ptr(csr), .value(wdata), .predict(!external_checker));
+  endtask
+
+  // Write random values to each register in the list, running the sequences in parallel for maximum
+  // throughput.
+  local task randomize_registers(const ref uvm_reg registers[$]);
+    fork : isolation_fork begin
+      foreach (registers[i]) begin
+        automatic uvm_reg _reg = registers[i];
+        fork
+          randomize_register(_reg);
+        join_none
+      end
+      wait fork;
+    end join
+  endtask
+
+  // Read back csr using csr_rd_check and checking against the register model. Mask the comparison
+  // using get_mask_excl_fields (to avoid checking the values of fields that are not modelled).
+  local task read_back_register(uvm_reg csr);
+    csr_rd_check(.ptr           (csr),
+                 .compare       (!external_checker),
+                 .compare_vs_ral(1'b1),
+                 .compare_mask  (get_mask_excl_fields(csr, CsrExclWriteCheck, CsrAliasingTest)));
+  endtask
+
+  // Read back every register in the list, using csr_rd_check and checking against the register
+  // model.
+  //
+  // Comparisons are masked using get_mask_excl_fields (to avoid checking the values of fields that
+  // are not modelled).
+  local task read_back_registers(uvm_reg registers[$]);
+    fork : isolation_fork begin
+      foreach (registers[i]) begin
+        automatic uvm_reg _reg = registers[i];
+        fork
+          read_back_register(_reg);
+        join_none
+      end
+      wait fork;
+    end join
+  endtask
+
+  // Write random values to each register in write_list, then read all the registers in read_list
+  local task test_chunk(uvm_reg write_list[$], uvm_reg read_list[$]);
+    randomize_registers(write_list);
+    read_back_registers(read_list);
+  endtask
+
+  // Return a random sample from reg_queue with length sample_size (or the entire list if there
+  // aren't that many items)
+  local function reg_queue_t sample_reg_list(int unsigned      sample_size,
+                                             const ref uvm_reg reg_queue[$]);
+    uvm_reg ret[$] = reg_queue;
+    ret.shuffle();
+    return (reg_queue.size() < sample_size) ? ret[0:sample_size - 1] : ret;
+  endfunction
 
   virtual task body();
+    uvm_reg      total_list[$];
+    int unsigned num_chunks;
+
     foreach(test_csrs[i]) begin
-      uvm_reg_data_t wdata;
+      if (!is_excl(test_csrs[i], CsrExclWrite, CsrAliasingTest)) begin
+        total_list.push_back(test_csrs[i]);
+      end else begin
+        `uvm_info(get_full_name(),
+                  $sformatf("Skipping register %0s because of CsrExclWrite exclusion",
+                            test_csrs[i].get_full_name()),
+                  UVM_MEDIUM)
+      end
+    end
 
-      // check if parent block or register is excluded
-      if (is_excl(test_csrs[i], CsrExclWrite, CsrAliasingTest)) begin
-        `uvm_info(`gtn, $sformatf("Skipping register %0s due to CsrExclWrite exclusion",
-                                  test_csrs[i].get_full_name()), UVM_MEDIUM)
-        continue;
+    `uvm_info(get_full_name(),
+              $sformatf("Aliasing test with list of %0d registers (with a total of %0d visible)",
+                        test_csrs.size(),
+                        all_csrs.size()),
+              UVM_LOW)
+
+    num_chunks = (test_csrs.size() + m_chunk_size - 1) / m_chunk_size;
+
+    for (int unsigned i = 0; i < num_chunks; i++) begin
+      int unsigned start_idx = i * m_chunk_size;
+      int unsigned end_idx = start_idx + m_chunk_size;
+      uvm_reg write_regs[$];
+
+      if (end_idx >= test_csrs.size()) begin
+        end_idx = test_csrs.size() - 1;
       end
 
-      `uvm_info(`gtn,
-                $sformatf("Verifying register aliasing for %0s (register %0d / %0d)",
-                          test_csrs[i].get_full_name(), i + 1, test_csrs.size()),
-                UVM_MEDIUM)
+      write_regs = test_csrs[start_idx:end_idx];
 
-      `DV_CHECK_STD_RANDOMIZE_FATAL(wdata)
-      wdata = get_csr_wdata_with_write_excl(test_csrs[i], wdata, CsrAliasingTest);
-      csr_wr(.ptr(test_csrs[i]), .value(wdata), .blocking(0), .predict(!external_checker));
-
-      all_csrs.shuffle();
-
-      // If all_csrs queue size is larger than 100, randomly pick 100 CSRs to avoid chip level test
-      // runtime too long.
-      if (all_csrs.size() > 100) all_csrs = all_csrs[0 : 99];
-
-      foreach (all_csrs[j]) begin
-        uvm_reg_data_t compare_mask;
-
-        // check if parent block or register is excluded
-        if (is_excl(all_csrs[j], CsrExclInitCheck, CsrAliasingTest) ||
-            is_excl(all_csrs[j], CsrExclWriteCheck, CsrAliasingTest)) begin
-          `uvm_info(`gtn, $sformatf("Skipping register %0s due to CsrExclInit/WriteCheck exclusion",
-                                    all_csrs[j].get_full_name()), UVM_HIGH)
-          continue;
-        end
-
-        compare_mask = get_mask_excl_fields(all_csrs[j], CsrExclWriteCheck, CsrAliasingTest);
-        csr_rd_check(.ptr           (all_csrs[j]),
-                     .blocking      (0),
-                     .compare       (!external_checker),
-                     .compare_vs_ral(1'b1),
-                     .compare_mask  (compare_mask));
+      `uvm_info(get_full_name(),
+                $sformatf("Testing aliasing with chunk %0d/%0d", i + 1, num_chunks),
+                UVM_LOW)
+      foreach (write_regs[j]) begin
+        `uvm_info(get_full_name(), $sformatf("  - %0s", write_regs[j].get_name()), UVM_MEDIUM)
       end
-      wait_no_outstanding_access();
+
+      test_chunk(write_regs, sample_reg_list(100, all_csrs));
     end
   endtask
 

--- a/hw/dv/sv/csr_utils/csr_aliasing_seq.sv
+++ b/hw/dv/sv/csr_utils/csr_aliasing_seq.sv
@@ -1,0 +1,63 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// For each CSR, this sequence writes a random value to it and reads ALL CSRs back. The read value
+// of the CSR that was written is checked for correctness while adhering to its access policies. The
+// read value of all other CSRs are compared against their previous values. This verifies that there
+// is no aliasing across the address bits within the valid CSR space.
+
+class csr_aliasing_seq extends csr_base_seq;
+  `uvm_object_utils(csr_aliasing_seq)
+
+  `uvm_object_new
+
+  virtual task body();
+    foreach(test_csrs[i]) begin
+      uvm_reg_data_t wdata;
+
+      // check if parent block or register is excluded
+      if (is_excl(test_csrs[i], CsrExclWrite, CsrAliasingTest)) begin
+        `uvm_info(`gtn, $sformatf("Skipping register %0s due to CsrExclWrite exclusion",
+                                  test_csrs[i].get_full_name()), UVM_MEDIUM)
+        continue;
+      end
+
+      `uvm_info(`gtn,
+                $sformatf("Verifying register aliasing for %0s (register %0d / %0d)",
+                          test_csrs[i].get_full_name(), i + 1, test_csrs.size()),
+                UVM_MEDIUM)
+
+      `DV_CHECK_STD_RANDOMIZE_FATAL(wdata)
+      wdata = get_csr_wdata_with_write_excl(test_csrs[i], wdata, CsrAliasingTest);
+      csr_wr(.ptr(test_csrs[i]), .value(wdata), .blocking(0), .predict(!external_checker));
+
+      all_csrs.shuffle();
+
+      // If all_csrs queue size is larger than 100, randomly pick 100 CSRs to avoid chip level test
+      // runtime too long.
+      if (all_csrs.size() > 100) all_csrs = all_csrs[0 : 99];
+
+      foreach (all_csrs[j]) begin
+        uvm_reg_data_t compare_mask;
+
+        // check if parent block or register is excluded
+        if (is_excl(all_csrs[j], CsrExclInitCheck, CsrAliasingTest) ||
+            is_excl(all_csrs[j], CsrExclWriteCheck, CsrAliasingTest)) begin
+          `uvm_info(`gtn, $sformatf("Skipping register %0s due to CsrExclInit/WriteCheck exclusion",
+                                    all_csrs[j].get_full_name()), UVM_HIGH)
+          continue;
+        end
+
+        compare_mask = get_mask_excl_fields(all_csrs[j], CsrExclWriteCheck, CsrAliasingTest);
+        csr_rd_check(.ptr           (all_csrs[j]),
+                     .blocking      (0),
+                     .compare       (!external_checker),
+                     .compare_vs_ral(1'b1),
+                     .compare_mask  (compare_mask));
+      end
+      wait_no_outstanding_access();
+    end
+  endtask
+
+endclass

--- a/hw/dv/sv/csr_utils/csr_aliasing_seq.sv
+++ b/hw/dv/sv/csr_utils/csr_aliasing_seq.sv
@@ -148,8 +148,9 @@ task csr_aliasing_seq::test_chunk(uvm_reg write_list[$], uvm_reg read_list[$]);
   read_back_registers(read_list);
 endtask
 
-function reg_queue_t csr_aliasing_seq::sample_reg_list(int unsigned      sample_size,
-                                                       const ref uvm_reg reg_queue[$]);
+function csr_aliasing_seq::reg_queue_t
+  csr_aliasing_seq::sample_reg_list(int unsigned      sample_size,
+                                    const ref uvm_reg reg_queue[$]);
   uvm_reg ret[$] = reg_queue;
   ret.shuffle();
   return (reg_queue.size() < sample_size) ? ret[0:sample_size - 1] : ret;

--- a/hw/dv/sv/csr_utils/csr_aliasing_seq.sv
+++ b/hw/dv/sv/csr_utils/csr_aliasing_seq.sv
@@ -20,121 +20,137 @@ class csr_aliasing_seq extends csr_base_seq;
   // was no aliasing).
   int unsigned m_chunk_size = 10;
 
-  function new (string name="");
-      super.new(name);
-  endfunction
+  extern function new (string name="");
+
+  extern virtual task body();
 
   // Write a random value to csr, after applying any write exclusion that has been defined for the
   // register.
-  local task randomize_register(uvm_reg csr);
-    uvm_reg_data_t wdata;
-
-    if (!std::randomize(wdata)) begin
-      `uvm_fatal(get_full_name(), "Failed to randomize wdata.")
-    end
-
-    wdata = get_csr_wdata_with_write_excl(csr, wdata, CsrAliasingTest);
-    csr_wr(.ptr(csr), .value(wdata), .predict(!external_checker));
-  endtask
+  extern local task randomize_register(uvm_reg csr);
 
   // Write random values to each register in the list, running the sequences in parallel for maximum
   // throughput.
-  local task randomize_registers(const ref uvm_reg registers[$]);
-    fork : isolation_fork begin
-      foreach (registers[i]) begin
-        automatic uvm_reg _reg = registers[i];
-        fork
-          randomize_register(_reg);
-        join_none
-      end
-      wait fork;
-    end join
-  endtask
+  extern local task randomize_registers(const ref uvm_reg registers[$]);
 
   // Read back csr using csr_rd_check and checking against the register model. Mask the comparison
   // using get_mask_excl_fields (to avoid checking the values of fields that are not modelled).
-  local task read_back_register(uvm_reg csr);
-    csr_rd_check(.ptr           (csr),
-                 .compare       (!external_checker),
-                 .compare_vs_ral(1'b1),
-                 .compare_mask  (get_mask_excl_fields(csr, CsrExclWriteCheck, CsrAliasingTest)));
-  endtask
+  extern local task read_back_register(uvm_reg csr);
 
   // Read back every register in the list, using csr_rd_check and checking against the register
   // model.
   //
   // Comparisons are masked using get_mask_excl_fields (to avoid checking the values of fields that
   // are not modelled).
-  local task read_back_registers(uvm_reg registers[$]);
-    fork : isolation_fork begin
-      foreach (registers[i]) begin
-        automatic uvm_reg _reg = registers[i];
-        fork
-          read_back_register(_reg);
-        join_none
-      end
-      wait fork;
-    end join
-  endtask
+  extern local task read_back_registers(uvm_reg registers[$]);
 
   // Write random values to each register in write_list, then read all the registers in read_list
-  local task test_chunk(uvm_reg write_list[$], uvm_reg read_list[$]);
-    randomize_registers(write_list);
-    read_back_registers(read_list);
-  endtask
+  extern local task test_chunk(uvm_reg write_list[$], uvm_reg read_list[$]);
 
   // Return a random sample from reg_queue with length sample_size (or the entire list if there
   // aren't that many items)
-  local function reg_queue_t sample_reg_list(int unsigned      sample_size,
-                                             const ref uvm_reg reg_queue[$]);
-    uvm_reg ret[$] = reg_queue;
-    ret.shuffle();
-    return (reg_queue.size() < sample_size) ? ret[0:sample_size - 1] : ret;
-  endfunction
+  extern local function reg_queue_t sample_reg_list(int unsigned      sample_size,
+                                                    const ref uvm_reg reg_queue[$]);
+endclass
 
-  virtual task body();
-    uvm_reg      total_list[$];
-    int unsigned num_chunks;
+function csr_aliasing_seq::new (string name="");
+    super.new(name);
+endfunction
 
-    foreach(test_csrs[i]) begin
-      if (!is_excl(test_csrs[i], CsrExclWrite, CsrAliasingTest)) begin
-        total_list.push_back(test_csrs[i]);
-      end else begin
-        `uvm_info(get_full_name(),
-                  $sformatf("Skipping register %0s because of CsrExclWrite exclusion",
-                            test_csrs[i].get_full_name()),
-                  UVM_MEDIUM)
-      end
+task csr_aliasing_seq::body();
+  uvm_reg      total_list[$];
+  int unsigned num_chunks;
+
+  foreach(test_csrs[i]) begin
+    if (!is_excl(test_csrs[i], CsrExclWrite, CsrAliasingTest)) begin
+      total_list.push_back(test_csrs[i]);
+    end else begin
+      `uvm_info(get_full_name(),
+                $sformatf("Skipping register %0s because of CsrExclWrite exclusion",
+                          test_csrs[i].get_full_name()),
+                UVM_MEDIUM)
     end
+  end
+
+  `uvm_info(get_full_name(),
+            $sformatf("Aliasing test with list of %0d registers (with a total of %0d visible)",
+                      test_csrs.size(),
+                      all_csrs.size()),
+            UVM_LOW)
+
+  num_chunks = (test_csrs.size() + m_chunk_size - 1) / m_chunk_size;
+
+  for (int unsigned i = 0; i < num_chunks; i++) begin
+    int unsigned start_idx = i * m_chunk_size;
+    int unsigned end_idx = start_idx + m_chunk_size;
+    uvm_reg write_regs[$];
+
+    if (end_idx >= test_csrs.size()) begin
+      end_idx = test_csrs.size() - 1;
+    end
+
+    write_regs = test_csrs[start_idx:end_idx];
 
     `uvm_info(get_full_name(),
-              $sformatf("Aliasing test with list of %0d registers (with a total of %0d visible)",
-                        test_csrs.size(),
-                        all_csrs.size()),
+              $sformatf("Testing aliasing with chunk %0d/%0d", i + 1, num_chunks),
               UVM_LOW)
-
-    num_chunks = (test_csrs.size() + m_chunk_size - 1) / m_chunk_size;
-
-    for (int unsigned i = 0; i < num_chunks; i++) begin
-      int unsigned start_idx = i * m_chunk_size;
-      int unsigned end_idx = start_idx + m_chunk_size;
-      uvm_reg write_regs[$];
-
-      if (end_idx >= test_csrs.size()) begin
-        end_idx = test_csrs.size() - 1;
-      end
-
-      write_regs = test_csrs[start_idx:end_idx];
-
-      `uvm_info(get_full_name(),
-                $sformatf("Testing aliasing with chunk %0d/%0d", i + 1, num_chunks),
-                UVM_LOW)
-      foreach (write_regs[j]) begin
-        `uvm_info(get_full_name(), $sformatf("  - %0s", write_regs[j].get_name()), UVM_MEDIUM)
-      end
-
-      test_chunk(write_regs, sample_reg_list(100, all_csrs));
+    foreach (write_regs[j]) begin
+      `uvm_info(get_full_name(), $sformatf("  - %0s", write_regs[j].get_name()), UVM_MEDIUM)
     end
-  endtask
 
-endclass
+    test_chunk(write_regs, sample_reg_list(100, all_csrs));
+  end
+endtask
+
+task csr_aliasing_seq::randomize_register(uvm_reg csr);
+  uvm_reg_data_t wdata;
+
+  if (!std::randomize(wdata)) begin
+    `uvm_fatal(get_full_name(), "Failed to randomize wdata.")
+  end
+
+  wdata = get_csr_wdata_with_write_excl(csr, wdata, CsrAliasingTest);
+  csr_wr(.ptr(csr), .value(wdata), .predict(!external_checker));
+endtask
+
+task csr_aliasing_seq::randomize_registers(const ref uvm_reg registers[$]);
+  fork : isolation_fork begin
+    foreach (registers[i]) begin
+      automatic uvm_reg _reg = registers[i];
+      fork
+        randomize_register(_reg);
+      join_none
+    end
+    wait fork;
+  end join
+endtask
+
+task csr_aliasing_seq::read_back_register(uvm_reg csr);
+  csr_rd_check(.ptr           (csr),
+               .compare       (!external_checker),
+               .compare_vs_ral(1'b1),
+               .compare_mask  (get_mask_excl_fields(csr, CsrExclWriteCheck, CsrAliasingTest)));
+endtask
+
+task csr_aliasing_seq::read_back_registers(uvm_reg registers[$]);
+  fork : isolation_fork begin
+    foreach (registers[i]) begin
+      automatic uvm_reg _reg = registers[i];
+      fork
+        read_back_register(_reg);
+      join_none
+    end
+    wait fork;
+  end join
+endtask
+
+task csr_aliasing_seq::test_chunk(uvm_reg write_list[$], uvm_reg read_list[$]);
+  randomize_registers(write_list);
+  read_back_registers(read_list);
+endtask
+
+function reg_queue_t csr_aliasing_seq::sample_reg_list(int unsigned      sample_size,
+                                                       const ref uvm_reg reg_queue[$]);
+  uvm_reg ret[$] = reg_queue;
+  ret.shuffle();
+  return (reg_queue.size() < sample_size) ? ret[0:sample_size - 1] : ret;
+endfunction

--- a/hw/dv/sv/csr_utils/csr_aliasing_seq.sv
+++ b/hw/dv/sv/csr_utils/csr_aliasing_seq.sv
@@ -24,133 +24,149 @@ class csr_aliasing_seq extends csr_base_seq;
   // have changed unexpectedly.
   int unsigned m_reads_per_chunk = 100;
 
-  function new (string name="");
-      super.new(name);
-  endfunction
+  extern function new(string name="");
+  extern task body();
 
   // Write a random value to csr, after applying any write exclusion that has been defined for the
   // register.
-  local task randomize_register(uvm_reg csr);
-    uvm_reg_data_t wdata;
-
-    if (!std::randomize(wdata)) begin
-      `uvm_fatal(get_full_name(), "Failed to randomize wdata.")
-    end
-
-    wdata = get_csr_wdata_with_write_excl(csr, wdata, CsrAliasingTest);
-    csr_wr(.ptr(csr), .value(wdata), .predict(!external_checker));
-  endtask
+  extern local task randomize_register(uvm_reg csr);
 
   // Write random values to each register in the list, running the sequences in parallel for maximum
   // throughput.
-  local task randomize_chunk(const ref uvm_reg registers[$]);
-    fork : isolation_fork begin
-      foreach (registers[i]) begin
-        automatic uvm_reg _reg = registers[i];
-        fork
-          randomize_register(_reg);
-        join_none
-      end
-      wait fork;
-    end join
-  endtask
+  extern local task randomize_chunk(const ref uvm_reg registers[$]);
 
   // Read back csr using csr_rd_check and checking against the register model. Mask the comparison
   // using get_mask_excl_fields (to avoid checking the values of fields that are not modelled).
-  local task read_back_register(uvm_reg csr);
-    csr_rd_check(.ptr           (csr),
-                 .compare       (!external_checker),
-                 .compare_vs_ral(1'b1),
-                 .compare_mask  (get_mask_excl_fields(csr, CsrExclWriteCheck, CsrAliasingTest)));
-  endtask
+  extern local task read_back_register(uvm_reg csr);
 
   // Read back every register in the list, using csr_rd_check and checking against the register
   // model.
   //
   // Comparisons are masked using get_mask_excl_fields (to avoid checking the values of fields that
   // are not modelled).
-  local task read_back_chunk(uvm_reg registers[$]);
-    fork : isolation_fork begin
-      foreach (registers[i]) begin
-        automatic uvm_reg _reg = registers[i];
-        fork
-          read_back_register(_reg);
-        join_none
-      end
-      wait fork;
-    end join
-  endtask
+  extern local task read_back_chunk(uvm_reg registers[$]);
 
   // Write random values to each register in write_list, then read all the registers in read_list
-  local task test_chunk(uvm_reg write_list[$], uvm_reg read_list[$]);
-    randomize_chunk(write_list);
-    read_back_chunk(read_list);
-  endtask
+  extern local task test_chunk(uvm_reg write_list[$], uvm_reg read_list[$]);
 
   // Return a random subset of reg_queue with m_reads_per_chunk registers (or the entire list if
   // there aren't that many)
-  local function reg_queue_t sample_reg_list(const ref uvm_reg reg_queue[$]);
-    uvm_reg ret[$] = reg_queue;
-    ret.shuffle();
-    return (reg_queue.size() < m_reads_per_chunk) ? ret[0:m_reads_per_chunk - 1] : ret;
-  endfunction
+  extern local function reg_queue_t sample_reg_list(const ref uvm_reg reg_queue[$]);
+endclass
 
-  virtual task body();
-    uvm_reg      total_list[$];
-    int unsigned num_chunks;
+function csr_aliasing_seq::new(string name="");
+    super.new(name);
+endfunction
 
-    // The subset of test_csrs consisting of registers that do not have the CsrExclWrite exclusion.
-    // This will be split into chunks of size m_chunk_size.
-    uvm_reg regs_to_write[$];
+task csr_aliasing_seq::body();
+  uvm_reg      total_list[$];
+  int unsigned num_chunks;
 
-    // The subset of test_csrs consisting of registers that do not have the CsrExclInitCheck or
-    // CsrExclWriteCheck exclusion. Since test_csrs is just a section of all_csrs, this list is
-    // probably much larger than regs_to_write.
-    //
-    // A random sample of m_reads_per_chunk of these registers will be read back for each chunk.
-    uvm_reg regs_to_read[$];
+  // The subset of test_csrs consisting of registers that do not have the CsrExclWrite exclusion.
+  // This will be split into chunks of size m_chunk_size.
+  uvm_reg regs_to_write[$];
 
-    foreach(test_csrs[i]) begin
-      if (!is_excl(test_csrs[i], CsrExclWrite, CsrAliasingTest)) begin
-        regs_to_write.push_back(test_csrs[i]);
-      end
+  // The subset of test_csrs consisting of registers that do not have the CsrExclInitCheck or
+  // CsrExclWriteCheck exclusion. Since test_csrs is just a section of all_csrs, this list is
+  // probably much larger than regs_to_write.
+  //
+  // A random sample of m_reads_per_chunk of these registers will be read back for each chunk.
+  uvm_reg regs_to_read[$];
+
+  foreach(test_csrs[i]) begin
+    if (!is_excl(test_csrs[i], CsrExclWrite, CsrAliasingTest)) begin
+      regs_to_write.push_back(test_csrs[i]);
     end
-    foreach (all_csrs[i]) begin
-      if (!(is_excl(test_csrs[i], CsrExclInitCheck, CsrAliasingTest) ||
-            is_excl(test_csrs[i], CsrExclWriteCheck, CsrAliasingTest))) begin
-        regs_to_read.push_back(test_csrs[i]);
-      end
+  end
+  foreach (all_csrs[i]) begin
+    if (!(is_excl(test_csrs[i], CsrExclInitCheck, CsrAliasingTest) ||
+          is_excl(test_csrs[i], CsrExclWriteCheck, CsrAliasingTest))) begin
+      regs_to_read.push_back(test_csrs[i]);
+    end
+  end
+
+  `uvm_info(get_full_name(),
+            $sformatf({"Aliasing test with list of %0d writable and %0d readable registers ",
+                       "(from a group of %0d registers selected from the %0d that are visible)"},
+                      regs_to_write.size(), regs_to_read.size(),
+                      test_csrs.size(), all_csrs.size()),
+            UVM_LOW)
+
+  // The test will break the registers that get written into chunks, of size m_chunk_size.
+  num_chunks = (regs_to_write.size() + m_chunk_size - 1) / m_chunk_size;
+
+  for (int unsigned i = 0; i < num_chunks; i++) begin
+    // The [start_idx:end_idx] range is [i*m_chunk_size, (i+1)*m_chunk_size - 1], intersected with
+    // the set of valid indices for regs_to_write.
+    int unsigned start_idx = i * m_chunk_size;
+    int unsigned end_idx = start_idx + m_chunk_size - 1;
+
+    if (end_idx >= regs_to_write.size()) begin
+      end_idx = regs_to_write.size() - 1;
     end
 
     `uvm_info(get_full_name(),
-              $sformatf({"Aliasing test with list of %0d writable and %0d readable registers ",
-                         "(from a group of %0d registers selected from the %0d that are visible)"},
-                        regs_to_write.size(), regs_to_read.size(),
-                        test_csrs.size(), all_csrs.size()),
+              $sformatf("Testing aliasing with chunk %0d/%0d", i + 1, num_chunks),
               UVM_LOW)
-
-    // The test will break the registers that get written into chunks, of size m_chunk_size.
-    num_chunks = (regs_to_write.size() + m_chunk_size - 1) / m_chunk_size;
-
-    for (int unsigned i = 0; i < num_chunks; i++) begin
-      // The [start_idx:end_idx] range is [i*m_chunk_size, (i+1)*m_chunk_size - 1], intersected with
-      // the set of valid indices for regs_to_write.
-      int unsigned start_idx = i * m_chunk_size;
-      int unsigned end_idx = start_idx + m_chunk_size - 1;
-
-      if (end_idx >= regs_to_write.size()) begin
-        end_idx = regs_to_write.size() - 1;
-      end
-
-      `uvm_info(get_full_name(),
-                $sformatf("Testing aliasing with chunk %0d/%0d", i + 1, num_chunks),
-                UVM_LOW)
-      for (int unsigned j = start_idx; j <= end_idx; j++) begin
-        `uvm_info(get_full_name(), $sformatf("  - %0s", regs_to_write[j].get_name()), UVM_MEDIUM)
-      end
-
-      test_chunk(regs_to_write[start_idx:end_idx], sample_reg_list(regs_to_read));
+    for (int unsigned j = start_idx; j <= end_idx; j++) begin
+      `uvm_info(get_full_name(), $sformatf("  - %0s", regs_to_write[j].get_name()), UVM_MEDIUM)
     end
-  endtask
 
-endclass
+    test_chunk(regs_to_write[start_idx:end_idx], sample_reg_list(regs_to_read));
+  end
+endtask
+
+task csr_aliasing_seq::randomize_register(uvm_reg csr);
+  uvm_reg_data_t wdata;
+
+  if (!std::randomize(wdata)) begin
+    `uvm_fatal(get_full_name(), "Failed to randomize wdata.")
+  end
+
+  wdata = get_csr_wdata_with_write_excl(csr, wdata, CsrAliasingTest);
+  csr_wr(.ptr(csr), .value(wdata), .predict(!external_checker));
+endtask
+
+task csr_aliasing_seq::randomize_chunk(const ref uvm_reg registers[$]);
+  fork : isolation_fork begin
+    foreach (registers[i]) begin
+      automatic uvm_reg _reg = registers[i];
+      fork
+        randomize_register(_reg);
+      join_none
+    end
+    wait fork;
+  end join
+endtask
+
+task csr_aliasing_seq::read_back_register(uvm_reg csr);
+  csr_rd_check(.ptr           (csr),
+               .compare       (!external_checker),
+               .compare_vs_ral(1'b1),
+               .compare_mask  (get_mask_excl_fields(csr, CsrExclWriteCheck, CsrAliasingTest)));
+endtask
+
+task csr_aliasing_seq::read_back_chunk(uvm_reg registers[$]);
+  fork : isolation_fork begin
+    foreach (registers[i]) begin
+      automatic uvm_reg _reg = registers[i];
+      fork
+        read_back_register(_reg);
+      join_none
+    end
+    wait fork;
+  end join
+endtask
+
+task csr_aliasing_seq::test_chunk(uvm_reg write_list[$], uvm_reg read_list[$]);
+  randomize_chunk(write_list);
+  read_back_chunk(read_list);
+endtask
+
+function csr_aliasing_seq::reg_queue_t
+  csr_aliasing_seq::sample_reg_list(const ref uvm_reg reg_queue[$]);
+
+  uvm_reg ret[$] = reg_queue;
+  ret.shuffle();
+  return (reg_queue.size() < m_reads_per_chunk) ? ret[0:m_reads_per_chunk - 1] : ret;
+endfunction

--- a/hw/dv/sv/csr_utils/csr_aliasing_seq.sv
+++ b/hw/dv/sv/csr_utils/csr_aliasing_seq.sv
@@ -10,53 +10,146 @@
 class csr_aliasing_seq extends csr_base_seq;
   `uvm_object_utils(csr_aliasing_seq)
 
-  `uvm_object_new
+  // A queue of uvm_reg objects
+  typedef uvm_reg reg_queue_t[$];
+
+  // The size of "register chunk" to use in the test.
+  //
+  // The list of CSRs to test (test_csrs) is checked in chunks of this size (writing a random value
+  // to each register in a chunk, then reading back every register in the design to check that there
+  // was no aliasing).
+  int unsigned m_chunk_size = 10;
+
+  // The number of registers to read after writing a chunk of registers, looking for values that
+  // have changed unexpectedly.
+  int unsigned m_reads_per_chunk = 100;
+
+  function new (string name="");
+      super.new(name);
+  endfunction
+
+  // Write a random value to csr, after applying any write exclusion that has been defined for the
+  // register.
+  local task randomize_register(uvm_reg csr);
+    uvm_reg_data_t wdata;
+
+    if (!std::randomize(wdata)) begin
+      `uvm_fatal(get_full_name(), "Failed to randomize wdata.")
+    end
+
+    wdata = get_csr_wdata_with_write_excl(csr, wdata, CsrAliasingTest);
+    csr_wr(.ptr(csr), .value(wdata), .predict(!external_checker));
+  endtask
+
+  // Write random values to each register in the list, running the sequences in parallel for maximum
+  // throughput.
+  local task randomize_chunk(const ref uvm_reg registers[$]);
+    fork : isolation_fork begin
+      foreach (registers[i]) begin
+        automatic uvm_reg _reg = registers[i];
+        fork
+          randomize_register(_reg);
+        join_none
+      end
+      wait fork;
+    end join
+  endtask
+
+  // Read back csr using csr_rd_check and checking against the register model. Mask the comparison
+  // using get_mask_excl_fields (to avoid checking the values of fields that are not modelled).
+  local task read_back_register(uvm_reg csr);
+    csr_rd_check(.ptr           (csr),
+                 .compare       (!external_checker),
+                 .compare_vs_ral(1'b1),
+                 .compare_mask  (get_mask_excl_fields(csr, CsrExclWriteCheck, CsrAliasingTest)));
+  endtask
+
+  // Read back every register in the list, using csr_rd_check and checking against the register
+  // model.
+  //
+  // Comparisons are masked using get_mask_excl_fields (to avoid checking the values of fields that
+  // are not modelled).
+  local task read_back_chunk(uvm_reg registers[$]);
+    fork : isolation_fork begin
+      foreach (registers[i]) begin
+        automatic uvm_reg _reg = registers[i];
+        fork
+          read_back_register(_reg);
+        join_none
+      end
+      wait fork;
+    end join
+  endtask
+
+  // Write random values to each register in write_list, then read all the registers in read_list
+  local task test_chunk(uvm_reg write_list[$], uvm_reg read_list[$]);
+    randomize_chunk(write_list);
+    read_back_chunk(read_list);
+  endtask
+
+  // Return a random subset of reg_queue with m_reads_per_chunk registers (or the entire list if
+  // there aren't that many)
+  local function reg_queue_t sample_reg_list(const ref uvm_reg reg_queue[$]);
+    uvm_reg ret[$] = reg_queue;
+    ret.shuffle();
+    return (reg_queue.size() < m_reads_per_chunk) ? ret[0:m_reads_per_chunk - 1] : ret;
+  endfunction
 
   virtual task body();
+    uvm_reg      total_list[$];
+    int unsigned num_chunks;
+
+    // The subset of test_csrs consisting of registers that do not have the CsrExclWrite exclusion.
+    // This will be split into chunks of size m_chunk_size.
+    uvm_reg regs_to_write[$];
+
+    // The subset of test_csrs consisting of registers that do not have the CsrExclInitCheck or
+    // CsrExclWriteCheck exclusion. Since test_csrs is just a section of all_csrs, this list is
+    // probably much larger than regs_to_write.
+    //
+    // A random sample of m_reads_per_chunk of these registers will be read back for each chunk.
+    uvm_reg regs_to_read[$];
+
     foreach(test_csrs[i]) begin
-      uvm_reg_data_t wdata;
+      if (!is_excl(test_csrs[i], CsrExclWrite, CsrAliasingTest)) begin
+        regs_to_write.push_back(test_csrs[i]);
+      end
+    end
+    foreach (all_csrs[i]) begin
+      if (!(is_excl(test_csrs[i], CsrExclInitCheck, CsrAliasingTest) ||
+            is_excl(test_csrs[i], CsrExclWriteCheck, CsrAliasingTest))) begin
+        regs_to_read.push_back(test_csrs[i]);
+      end
+    end
 
-      // check if parent block or register is excluded
-      if (is_excl(test_csrs[i], CsrExclWrite, CsrAliasingTest)) begin
-        `uvm_info(`gtn, $sformatf("Skipping register %0s due to CsrExclWrite exclusion",
-                                  test_csrs[i].get_full_name()), UVM_MEDIUM)
-        continue;
+    `uvm_info(get_full_name(),
+              $sformatf({"Aliasing test with list of %0d writable and %0d readable registers ",
+                         "(from a group of %0d registers selected from the %0d that are visible)"},
+                        regs_to_write.size(), regs_to_read.size(),
+                        test_csrs.size(), all_csrs.size()),
+              UVM_LOW)
+
+    // The test will break the registers that get written into chunks, of size m_chunk_size.
+    num_chunks = (regs_to_write.size() + m_chunk_size - 1) / m_chunk_size;
+
+    for (int unsigned i = 0; i < num_chunks; i++) begin
+      // The [start_idx:end_idx] range is [i*m_chunk_size, (i+1)*m_chunk_size - 1], intersected with
+      // the set of valid indices for regs_to_write.
+      int unsigned start_idx = i * m_chunk_size;
+      int unsigned end_idx = start_idx + m_chunk_size - 1;
+
+      if (end_idx >= regs_to_write.size()) begin
+        end_idx = regs_to_write.size() - 1;
       end
 
-      `uvm_info(`gtn,
-                $sformatf("Verifying register aliasing for %0s (register %0d / %0d)",
-                          test_csrs[i].get_full_name(), i + 1, test_csrs.size()),
-                UVM_MEDIUM)
-
-      `DV_CHECK_STD_RANDOMIZE_FATAL(wdata)
-      wdata = get_csr_wdata_with_write_excl(test_csrs[i], wdata, CsrAliasingTest);
-      csr_wr(.ptr(test_csrs[i]), .value(wdata), .blocking(0), .predict(!external_checker));
-
-      all_csrs.shuffle();
-
-      // If all_csrs queue size is larger than 100, randomly pick 100 CSRs to avoid chip level test
-      // runtime too long.
-      if (all_csrs.size() > 100) all_csrs = all_csrs[0 : 99];
-
-      foreach (all_csrs[j]) begin
-        uvm_reg_data_t compare_mask;
-
-        // check if parent block or register is excluded
-        if (is_excl(all_csrs[j], CsrExclInitCheck, CsrAliasingTest) ||
-            is_excl(all_csrs[j], CsrExclWriteCheck, CsrAliasingTest)) begin
-          `uvm_info(`gtn, $sformatf("Skipping register %0s due to CsrExclInit/WriteCheck exclusion",
-                                    all_csrs[j].get_full_name()), UVM_HIGH)
-          continue;
-        end
-
-        compare_mask = get_mask_excl_fields(all_csrs[j], CsrExclWriteCheck, CsrAliasingTest);
-        csr_rd_check(.ptr           (all_csrs[j]),
-                     .blocking      (0),
-                     .compare       (!external_checker),
-                     .compare_vs_ral(1'b1),
-                     .compare_mask  (compare_mask));
+      `uvm_info(get_full_name(),
+                $sformatf("Testing aliasing with chunk %0d/%0d", i + 1, num_chunks),
+                UVM_LOW)
+      for (int unsigned j = start_idx; j <= end_idx; j++) begin
+        `uvm_info(get_full_name(), $sformatf("  - %0s", regs_to_write[j].get_name()), UVM_MEDIUM)
       end
-      wait_no_outstanding_access();
+
+      test_chunk(regs_to_write[start_idx:end_idx], sample_reg_list(regs_to_read));
     end
   endtask
 

--- a/hw/dv/sv/csr_utils/csr_base_seq.sv
+++ b/hw/dv/sv/csr_utils/csr_base_seq.sv
@@ -11,7 +11,7 @@
 // complete list of available registers is computed just before the sequence body (in the pre_start
 // task), but a test may wish to check a smaller subset of these registers.
 //
-// To make that possible, there are two plusarg-based mechanisms:
+// To make that possible there is a plusarg-based mechanism:
 //
 //  +num_test_csrs=
 //
@@ -21,15 +21,6 @@
 //
 //     If max_num_test_csrs has been set to a positive number after creating the sequence, it is
 //     used as another upper bound on the number of CSRs in a chunk for the sequence.
-//
-//  +num_csr_chunks=, +test_csr_chunk=
-//
-//     If num_test_csrs is not provided, the list of CSRs in all_csrs can instead be divided into a
-//     requested number of contiguous chunks by setting num_csr_chunks. The index of the chunk to
-//     test is then provided with test_csr_chunk.
-//
-//     It is an error to use these flags if max_num_test_csrs is set to a positive number (because
-//     there's not a nice description of the length of chunks in that situation).
 
 class csr_base_seq extends uvm_reg_sequence #(uvm_sequence #(uvm_reg_item));
   `uvm_object_utils(csr_base_seq)
@@ -62,8 +53,7 @@ class csr_base_seq extends uvm_reg_sequence #(uvm_sequence #(uvm_reg_item));
 
   // A queue of the CSR registers that have been selected for this test. These are contained in
   // all_csrs, but may be a proper subset if set_csr_test_range has picked only some of them (as
-  // instructed by the max_num_test_csrs or the num_test_csrs or num_csr_chunks plusargs). They will
-  // also be shuffled into a random order.
+  // instructed by max_num_test_csrs). They will also be shuffled into a random order.
   //
   // The queue gets populated by set_csr_test_range, which is called by the pre_start task. It is
   // then cleared by post_start, to ensure that it will be re-populated if the sequence is run
@@ -126,10 +116,10 @@ task csr_base_seq::post_start();
 endtask
 
 function void csr_base_seq::set_csr_test_range();
-  bit has_ntc, has_ncc, has_tcc;
+  bit has_ntc, has_tcc;
 
   int unsigned num_csrs;
-  int          num_test_csrs, num_csr_chunks, test_csr_chunk;
+  int          num_test_csrs;
 
   int unsigned start_idx, end_idx;
 
@@ -170,64 +160,7 @@ function void csr_base_seq::set_csr_test_range();
     end
   end
 
-  // Has the num_csr_chunks plusarg been supplied?
-  if ($value$plusargs("num_csr_chunks=%0d", num_csr_chunks)) begin
-    // Check that we want a positive number of CSR chunks (since "splitting the list into -3 chunks"
-    // wouldn't make much sense!). If not, generate a UVM error and ignore the plusarg.
-    if (num_csr_chunks < 1) begin
-      `uvm_error(`gtn, $sformatf("+num_csr_chunks=%0d, which is not positive.", num_csr_chunks))
-    end else begin
-      has_ncc = 1;
-    end
-  end
-
-  // Has the test_csr_chunk plusarg been supplied?
-  if ($value$plusargs("test_csr_chunk=%0d", test_csr_chunk)) begin
-    if (!has_ncc) begin
-      // This argument only makes sense if we *have* specified a number of CSR chunks.
-      `uvm_error(`gtn, "Cannot supply test_csr_chunk without num_csr_chunks")
-    end else if (test_csr_chunk < 0 || test_csr_chunk >= num_csr_chunks) begin
-      // Similarly, it only makes sense if it's a valid index into the list of chunks.
-      `uvm_error(`gtn,
-                 $sformatf("+test_csr_chunk=%0d is invalid when num_csr_chunks=%0d",
-                           test_csr_chunk, num_csr_chunks));
-    end
-    has_tcc = 1;
-  end
-
-  // Check that num_test_csrs and num_csr_chunks haven't both been supplied (because then there
-  // isn't any good chunk size)
-  if (has_ntc && has_ncc) begin
-    `uvm_error(`gtn, "Cannot set both +num_csr_chunks and +num_test_csrs. Using the latter.")
-    has_ncc = 0;
-  end
-
-  // At this point, at most one of has_ntc and has_ncc is true.
-  if (has_ncc) begin
-    int unsigned chunk_idx;
-
-    // If num_csr_chunks has been supplied we can use it to derive a chunk size in the same way as
-    // the has_ntc case.
-    int unsigned chunk_size = (num_csrs + num_csr_chunks - 1) / num_csr_chunks;
-
-    // At this point, we might find that the requested number of chunks is incompatible with
-    // max_num_test_csrs. If so, generate an error and then clip chunk_size (to ensure the test
-    // doesn't run for a silly time)
-    if (max_num_test_csrs > 0 && chunk_size > max_num_test_csrs) begin
-      `uvm_error(`gtn,
-                 $sformatf("chunk_size %0d is too large for max_num_test_csrs %0d",
-                           chunk_size, max_num_test_csrs))
-      chunk_size = max_num_test_csrs;
-    end
-
-    // We might already have a chunk index in test_csr_chunk. If not, we pick one at random in the
-    // allowed range.
-    chunk_idx = has_tcc ? test_csr_chunk : $urandom_range(num_csr_chunks - 1);
-
-    // Again, convert these two into a pair of CSR indices (where end_idx is strictly past the end)
-    start_idx = chunk_idx * chunk_size;
-    end_idx = start_idx + chunk_size - 1;
-  end else if (has_ntc || max_num_test_csrs > 0) begin
+  if (has_ntc || max_num_test_csrs > 0) begin
     int unsigned num_chunks, chunk_size, chunk_idx;
 
     // Take the smaller supplied value of num_test_csrs and max_num_test_csrs to give an upper bound

--- a/hw/dv/sv/csr_utils/csr_seq_lib.sv
+++ b/hw/dv/sv/csr_utils/csr_seq_lib.sv
@@ -317,68 +317,6 @@ class csr_bit_bash_seq extends csr_base_seq;
 endclass
 
 //--------------------------------------------------------------------------------------------------
-// Class: csr_aliasing_seq
-// Brief Description: For each CSR, this sequence writes a random value to it and reads ALL CSRs
-// back. The read value of the CSR that was written is checked for correctness while adhering to its
-// access policies. The read value of all other CSRs are compared against their previous values.
-// This verifies that there is no aliasing across the address bits within the valid CSR space.
-//--------------------------------------------------------------------------------------------------
-class csr_aliasing_seq extends csr_base_seq;
-  `uvm_object_utils(csr_aliasing_seq)
-
-  `uvm_object_new
-
-  virtual task body();
-    foreach(test_csrs[i]) begin
-      uvm_reg_data_t wdata;
-
-      // check if parent block or register is excluded
-      if (is_excl(test_csrs[i], CsrExclWrite, CsrAliasingTest)) begin
-        `uvm_info(`gtn, $sformatf("Skipping register %0s due to CsrExclWrite exclusion",
-                                  test_csrs[i].get_full_name()), UVM_MEDIUM)
-        continue;
-      end
-
-      `uvm_info(`gtn,
-                $sformatf("Verifying register aliasing for %0s (register %0d / %0d)",
-                          test_csrs[i].get_full_name(), i + 1, test_csrs.size()),
-                UVM_MEDIUM)
-
-      `DV_CHECK_STD_RANDOMIZE_FATAL(wdata)
-      wdata = get_csr_wdata_with_write_excl(test_csrs[i], wdata, CsrAliasingTest);
-      csr_wr(.ptr(test_csrs[i]), .value(wdata), .blocking(0), .predict(!external_checker));
-
-      all_csrs.shuffle();
-
-      // If all_csrs queue size is larger than 100, randomly pick 100 CSRs to avoid chip level test
-      // runtime too long.
-      if (all_csrs.size() > 100) all_csrs = all_csrs[0 : 99];
-
-      foreach (all_csrs[j]) begin
-        uvm_reg_data_t compare_mask;
-
-        // check if parent block or register is excluded
-        if (is_excl(all_csrs[j], CsrExclInitCheck, CsrAliasingTest) ||
-            is_excl(all_csrs[j], CsrExclWriteCheck, CsrAliasingTest)) begin
-          `uvm_info(`gtn, $sformatf("Skipping register %0s due to CsrExclInit/WriteCheck exclusion",
-                                    all_csrs[j].get_full_name()), UVM_HIGH)
-          continue;
-        end
-
-        compare_mask = get_mask_excl_fields(all_csrs[j], CsrExclWriteCheck, CsrAliasingTest);
-        csr_rd_check(.ptr           (all_csrs[j]),
-                     .blocking      (0),
-                     .compare       (!external_checker),
-                     .compare_vs_ral(1'b1),
-                     .compare_mask  (compare_mask));
-      end
-      wait_no_outstanding_access();
-    end
-  endtask
-
-endclass
-
-//--------------------------------------------------------------------------------------------------
 // Class: csr_mem_walk_seq
 // Brief Description: This seq walks through each address of the memory by running the default
 // UVM mem walk sequence.

--- a/hw/dv/sv/csr_utils/csr_utils.core
+++ b/hw/dv/sv/csr_utils/csr_utils.core
@@ -14,6 +14,7 @@ filesets:
       - csr_utils_pkg.sv
       - csr_base_seq.sv: {is_include_file: true}
       - csr_hw_reset_seq.sv: {is_include_file: true}
+      - csr_aliasing_seq.sv: {is_include_file: true}
       - csr_seq_lib.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -857,6 +857,7 @@ package csr_utils_pkg;
   // sources
   `include "csr_base_seq.sv"
   `include "csr_hw_reset_seq.sv"
+  `include "csr_aliasing_seq.sv"
   `include "csr_seq_lib.sv"
 
 endpackage

--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -862,6 +862,7 @@ package csr_utils_pkg;
   // sources
   `include "csr_base_seq.sv"
   `include "csr_hw_reset_seq.sv"
+  `include "csr_aliasing_seq.sv"
   `include "csr_seq_lib.sv"
 
 endpackage


### PR DESCRIPTION
The motivation for this work was me noticing how incredibly long the CSR aliasing test takes in the chip-level sequences. This change should make it a factor of 10 faster with essentially no risk. So it's probably worth doing!