### PR TITLE
[crypto/25519] Add rejection on non-canonical encoding

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/curve25519.h
+++ b/sw/device/lib/crypto/impl/ecc/curve25519.h
@@ -77,10 +77,6 @@ enum {
    */
   kCurve25519MaskedScalarPaddingWords = 4,
   /**
-   * Magic value for verify success response.
-   */
-  kCurve25519VerifySuccess = 0xf77fe650,
-  /**
    * Length of a Curve25519 curve point coordinate in bits.
    */
   kCurve25519CoordBits = 256,

--- a/sw/device/tests/crypto/ed25519_functest.c
+++ b/sw/device/tests/crypto/ed25519_functest.c
@@ -285,6 +285,62 @@ static status_t sign_verify_test(void) {
 }
 
 /**
+ * Wycheproof Test Case 61: "invalid R"
+ *
+ */
+static status_t run_wycheproof_invalid_r_test(void) {
+  LOG_INFO("Running Wycheproof invalid signature R");
+
+  uint32_t pubkey_data[kEd25519PublicKeyWords] = {
+      0x7f0e4d7d, 0x9ba65361, 0x22b54262, 0x85e6beab,
+      0x0f42a4fd, 0x08b13488, 0x36aebdc3, 0xfa49f59e,
+  };
+  otcrypto_unblinded_key_t valid_pub = {
+      .key_mode = kOtcryptoKeyModeEd25519,
+      .key_length = kEd25519PublicKeyBytes,
+      .key = pubkey_data,
+  };
+  valid_pub.checksum = integrity_unblinded_checksum(&valid_pub);
+
+  const uint8_t wycheproof_msg_bytes[] = {0x31, 0x32, 0x33, 0x34, 0x30, 0x30};
+  otcrypto_const_byte_buf_t msg =
+      OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, wycheproof_msg_bytes,
+                        sizeof(wycheproof_msg_bytes));
+
+  uint32_t wycheproof_sig_data[kEd25519SignatureWords] = {
+      // R (Non-canonical, y >= p)
+      0xffffffff,
+      0xffffffff,
+      0xffffffff,
+      0xffffffff,
+      0xffffffff,
+      0xffffffff,
+      0xffffffff,
+      0xffffffff,
+      // S
+      0x08193a46,
+      0xb77e2e38,
+      0xf9ce3a69,
+      0xf97c4f88,
+      0xe015a231,
+      0xbe761879,
+      0xa531c622,
+      0x0efd8198,
+  };
+  otcrypto_const_word32_buf_t signature_verif =
+      OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, wycheproof_sig_data,
+                        ARRAYSIZE(wycheproof_sig_data));
+
+  hardened_bool_t verify_res;
+
+  CHECK(otcrypto_ed25519_verify(&valid_pub, &msg, kOtcryptoEddsaSignModeEddsa,
+                                &signature_verif, &verify_res)
+            .value == OTCRYPTO_BAD_ARGS.value);
+
+  return OTCRYPTO_OK;
+}
+
+/**
  * Execute negative testing.
  */
 static status_t run_negative_tests(void) {
@@ -413,6 +469,7 @@ bool test_main(void) {
   EXECUTE_TEST(result, ed25519_kat_test);
   EXECUTE_TEST(result, hasheddsa_test);
   EXECUTE_TEST(result, sign_verify_test);
+  EXECUTE_TEST(result, run_wycheproof_invalid_r_test);
   EXECUTE_TEST(result, run_negative_tests);
 
   return status_ok(result);

--- a/sw/otbn/crypto/ed25519.s
+++ b/sw/otbn/crypto/ed25519.s
@@ -904,11 +904,7 @@ affine_decode_var:
   bn.rshi  w11, w11, w31 >> 255
   bn.rshi  w11, w31, w11 >> 1
 
-  /* Defensively reduce y modulo p in case y is non-canonical.
-       w11 <= (w11 + 0) mod p = w11 mod p */
-  bn.addm  w11, w11, w31
-
-  /* Solve the curve equation to get a candidate root. From RFC 8032,
+   /* Solve the curve equation to get a candidate root. From RFC 8032,
      section 5.1.3, step 2:
 
        To recover the x-coordinate, the curve equation implies
@@ -939,6 +935,28 @@ affine_decode_var:
        - If the provided point is valid, then (u/v) = x^2 and (u/v) must be
          square modulo p.
    */
+
+  /* Check that y is strictly less than p.
+     w27 <= MOD = p */
+  bn.wsrr  w27, MOD
+
+  /* FG0.C <= w11 < w27 = y < p */
+  bn.cmp   w11, w27
+
+  /* x2 <= FG0[0] = FG0.C */
+  csrrs    x2, FG0, x0
+  andi     x2, x2, 1
+
+  /* Fail if y >= p */
+  bne      x2, x0, .L_y_is_canonical
+
+  /* Return FAILURE if not canonical */
+  li       x20, 0x1d4
+  bn.mov   w10, w31
+  bn.mov   w11, w31
+  ret
+
+.L_y_is_canonical:
 
    /* Store the constant 1, which will be used to compute u and v.
         w25 <= 1 */
@@ -1109,9 +1127,6 @@ affine_decode_var:
        w10 <= FG0.L ? w10 : w27
                 = if (lsb(x) != lsb(r)) then (-r) mod p else r */
   bn.sel   w10, w10, w27, FG0.L
-
-  /* TODO: add an extra check that the curve equation is satisfied to protect
-     against glitching? */
 
   /* Exit point decoding with SUCCESS. */
   li       x20, 0x739

--- a/sw/otbn/crypto/run_curve25519.s
+++ b/sw/otbn/crypto/run_curve25519.s
@@ -164,7 +164,7 @@ mode:
   .zero 4
 
 /* Verification result code (32 bits). Output for verify.
-   If verification is successful, this will be SUCCESS = 0xf77fe650.
+   If verification is successful, this will be SUCCESS = 0x739.
    Otherwise, this will be FAILURE = 0xeda2bfaf. */
 .balign 32
 .globl ed25519_verify_result


### PR DESCRIPTION
Reject R and A when they are larger than the curve order p (instead of modular reducing them).
Create a wycheproof test in the functest to capture this new branch.