### PR TITLE
[dv] Two tidy-ups in fpv_csr.sv.tpl

### DIFF
--- a/util/reggen/fpv_csr.sv.tpl
+++ b/util/reggen/fpv_csr.sv.tpl
@@ -18,8 +18,6 @@
   assert rb.flat_regs
 
 %>\
-<%def name="construct_classes(block)">\
-
 `include "prim_assert.sv"
 `ifdef UVM
   `include "uvm_macros.svh"
@@ -321,5 +319,3 @@ module ${mod_base}_csr_assert_fpv import tlul_pkg::*;
 endmodule
 
 `undef REGWEN_PATH
-</%def>\
-${construct_classes(block)}

--- a/util/reggen/fpv_csr.sv.tpl
+++ b/util/reggen/fpv_csr.sv.tpl
@@ -25,11 +25,10 @@
   `include "uvm_macros.svh"
 `endif
 
-`ifndef FPV_ON
-  `define REGWEN_PATH tb.dut.${reg_block_path}
-`else
-  `define REGWEN_PATH ${lblock}.${reg_block_path}
-`endif
+ // An upwards hierarchical reference that starts at the type of the IP block. This will correctly
+ // find the block, as long as the assertion module is bound into the block (rather than sitting
+ // outside of it) in the testbench.
+`define REGWEN_PATH ${lblock}.${reg_block_path}
 
 // Block: ${lblock}
 module ${mod_base}_csr_assert_fpv import tlul_pkg::*;


### PR DESCRIPTION
This block is confusingly named: the FPV tests are a bit pontless, because they will never complete. However, it's also used in functional simulations.

The first commit in this PR fixes up a hierarchical path that only works for block-level tests with a particular name for the dut. That path *didn't* allow the assertions to be bound in to a chip-level test. Fortunately, the fix is extremely easy.

The second commit is even more trivial and just involves evaluating a template.