### PR TITLE
[crypto/kmac_kdf] Enable non-word sized digests

### DIFF
--- a/sw/device/lib/crypto/drivers/kmac.c
+++ b/sw/device/lib/crypto/drivers/kmac.c
@@ -613,16 +613,19 @@ static status_t kmac_write_key_block(kmac_blinded_key_t *key) {
  * @param message Input message string.
  * @param message_len Message length in bytes.
  * @param digest The struct to which the result will be written.
- * @param digest_len_words Requested digest length in 32-bit words.
+ * @param digest_len_bytes Requested digest length in bytes.
  * @param masked_digest Whether to return the digest in two shares.
  * @return Error code.
  */
 OT_WARN_UNUSED_RESULT
 static status_t kmac_process_msg_blocks(
     kmac_operation_t operation, const otcrypto_const_byte_buf_t *message,
-    uint32_t *digest, size_t digest_len_words, hardened_bool_t masked_digest) {
+    uint32_t *digest, size_t digest_len_bytes, hardened_bool_t masked_digest) {
   // Block until KMAC is idle.
   HARDENED_TRY(wait_status_bit(KMAC_STATUS_SHA3_IDLE_BIT, 1));
+
+  size_t digest_len_words =
+      (digest_len_bytes + sizeof(uint32_t) - 1) / sizeof(uint32_t);
 
   // Issue the start command, so that messages written to MSG_FIFO are forwarded
   // to Keccak
@@ -660,10 +663,11 @@ static status_t kmac_process_msg_blocks(
 
   // If operation=KMAC, then we need to write `right_encode(digest->len)`
   if (operation == kKmacOperationKmac) {
-    uint32_t digest_len_bits = 8 * sizeof(uint32_t) * digest_len_words;
-    if (digest_len_bits / (8 * sizeof(uint32_t)) != digest_len_words) {
-      // COVERAGE (SW ERR) This is an internal function, we only provide it
-      // valid inputs.
+    uint32_t digest_len_bits = 8 * digest_len_bytes;
+    // Check for overflow, i.e., when the input buffer is too large.
+    if (digest_len_bits / 8 != digest_len_bytes) {
+      // COVERAGE (SW ERR) This is only triggered if the input length exceeds
+      // the uint32_t range.
       return OTCRYPTO_BAD_ARGS;
     }
 
@@ -761,6 +765,16 @@ static status_t kmac_process_msg_blocks(
                                    KMAC_CMD_CMD_VALUE_DONE);
   abs_mmio_write32(kKmacBaseAddr + KMAC_CMD_REG_OFFSET, cmd_reg);
 
+  // Zero out the trailing bytes in the final word.
+  size_t remainder_bytes = digest_len_bytes % sizeof(uint32_t);
+  if (remainder_bytes > 0) {
+    uint32_t mask = (1U << (remainder_bytes * 8)) - 1;
+    digest[digest_len_words - 1] &= mask;
+    if (launder32(masked_digest) == kHardenedBoolTrue) {
+      digest[2 * digest_len_words - 1] &= mask;
+    }
+  }
+
   // Verify the input buffer
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(message));
 
@@ -793,7 +807,8 @@ static status_t hash(kmac_operation_t operation, kmac_security_str_t strength,
   HARDENED_TRY(kmac_init(operation, strength,
                          /*hw_backed=*/kHardenedBoolFalse));
 
-  return kmac_process_msg_blocks(operation, message, digest, digest_wordlen,
+  return kmac_process_msg_blocks(operation, message, digest,
+                                 digest_wordlen * sizeof(uint32_t),
                                  /*masked_digest=*/kHardenedBoolFalse);
 }
 

--- a/sw/device/lib/crypto/drivers/kmac.h
+++ b/sw/device/lib/crypto/drivers/kmac.h
@@ -235,10 +235,10 @@ status_t kmac_cshake_256(const otcrypto_const_byte_buf_t *message,
  * With SW-provided keys, `key->hw_backed` must be `kHardenedBoolFalse`, `share`
  * pointers must be correctly configured and `len` must match the key length.
  *
- * The caller must ensure that `digest_len` words are allocated at the location
+ * The caller must ensure that `digest_len` bytes are allocated at the location
  * pointed to by `digest`. `cust_str_len` must not exceed
  * `kKmacCustStrMaxSize`. If `masked_digest` is true, the `digest` buffer must
- * have enough space for 2x `digest_len` words.
+ * have enough space for 2x `digest_len` bytes.
  *
  * @param key The KMAC key.
  * @param masked_digest Whether to return the digest in concatenated shares.
@@ -246,7 +246,7 @@ status_t kmac_cshake_256(const otcrypto_const_byte_buf_t *message,
  * @param cust_str The customization string.
  * @param cust_str_len The customization string length in bytes.
  * @param[out] digest Output buffer for the result.
- * @param digest_len Requested digest length in 32-bit words.
+ * @param digest_len Requested digest length in bytes.
  * @return Error status.
  */
 OT_WARN_UNUSED_RESULT
@@ -267,10 +267,10 @@ status_t kmac_kmac_128(kmac_blinded_key_t *key, hardened_bool_t masked_digest,
  * With SW-provided keys, `key->hw_backed` must be `kHardenedBoolFalse`, `share`
  * pointers must be correctly configured and `len` must match the key length.
  *
- * The caller must ensure that `digest_len` words are allocated at the location
+ * The caller must ensure that `digest_len` bytes are allocated at the location
  * pointed to by `digest`. `cust_str_len` must not exceed
  * `kKmacCustStrMaxSize`. If `masked_digest` is true, the `digest` buffer must
- * have enough space for 2x `digest_len` words.
+ * have enough space for 2x `digest_len` bytes.
  *
  * @param key The KMAC key.
  * @param masked_digest Whether to return the digest in concatenated shares.
@@ -278,7 +278,7 @@ status_t kmac_kmac_128(kmac_blinded_key_t *key, hardened_bool_t masked_digest,
  * @param cust_str The customization string.
  * @param cust_str_len The customization string length in bytes.
  * @param[out] digest Output buffer for the result.
- * @param digest_len Requested digest length in 32-bit words.
+ * @param digest_len Requested digest length in bytes.
  * @return Error status.
  */
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/crypto/impl/kmac.c
+++ b/sw/device/lib/crypto/impl/kmac.c
@@ -38,8 +38,10 @@ otcrypto_status_t otcrypto_kmac(
   }
 
   // Ensure that tag buffer length and `required_output_len` match each other.
-  if (required_output_len != tag->len * sizeof(uint32_t) ||
-      required_output_len == 0) {
+  size_t required_output_words =
+      (required_output_len + sizeof(uint32_t) - 1) / sizeof(uint32_t);
+
+  if (tag->len != required_output_words || required_output_len == 0) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -95,7 +97,7 @@ otcrypto_status_t otcrypto_kmac(
                                  /*masked_digest=*/kHardenedBoolFalse,
                                  input_message, customization_string->data,
                                  customization_string->len, tag->data,
-                                 tag->len));
+                                 required_output_len));
       key_mode_used = launder32(key_mode_used) | kOtcryptoKeyModeKmac128;
       break;
     case kOtcryptoKeyModeKmac256:
@@ -103,7 +105,7 @@ otcrypto_status_t otcrypto_kmac(
                                  /*masked_digest=*/kHardenedBoolFalse,
                                  input_message, customization_string->data,
                                  customization_string->len, tag->data,
-                                 tag->len));
+                                 required_output_len));
       key_mode_used = launder32(key_mode_used) | kOtcryptoKeyModeKmac256;
       break;
     default:

--- a/sw/device/lib/crypto/impl/kmac_kdf.c
+++ b/sw/device/lib/crypto/impl/kmac_kdf.c
@@ -94,11 +94,6 @@ otcrypto_status_t otcrypto_kmac_kdf(
     return OTCRYPTO_BAD_ARGS;
   }
 
-  // At the moment, `kmac_kmac_128/256` only supports word-sized digest lengths.
-  if (output_key_material->config.key_length % sizeof(uint32_t) != 0) {
-    return OTCRYPTO_NOT_IMPLEMENTED;
-  }
-
   // Output key cannot be hardware-backed.
   if (output_key_material->config.hw_backed != kHardenedBoolFalse) {
     return OTCRYPTO_BAD_ARGS;
@@ -122,10 +117,10 @@ otcrypto_status_t otcrypto_kmac_kdf(
       key_mode_used = launder32(key_mode_used) | kOtcryptoKeyModeKdfKmac128;
       // No need to further check key size against security level because
       // `kmac_key_length_check` ensures that the key is at least 128-bit.
-      HARDENED_TRY(kmac_kmac_128(
-          &kmac_key, /*masked_digest=*/kHardenedBoolTrue, context, label->data,
-          label->len, output_key_material->keyblob,
-          output_key_material->config.key_length / sizeof(uint32_t)));
+      HARDENED_TRY(kmac_kmac_128(&kmac_key, /*masked_digest=*/kHardenedBoolTrue,
+                                 context, label->data, label->len,
+                                 output_key_material->keyblob,
+                                 output_key_material->config.key_length));
       break;
     }
     case kOtcryptoKeyModeKdfKmac256: {
@@ -135,10 +130,10 @@ otcrypto_status_t otcrypto_kmac_kdf(
       if (key_derivation_key->config.key_length < 256 / 8) {
         return OTCRYPTO_BAD_ARGS;
       }
-      HARDENED_TRY(kmac_kmac_256(
-          &kmac_key, /*masked_digest=*/kHardenedBoolTrue, context, label->data,
-          label->len, output_key_material->keyblob,
-          output_key_material->config.key_length / sizeof(uint32_t)));
+      HARDENED_TRY(kmac_kmac_256(&kmac_key, /*masked_digest=*/kHardenedBoolTrue,
+                                 context, label->data, label->len,
+                                 output_key_material->keyblob,
+                                 output_key_material->config.key_length));
       break;
     }
     default:

--- a/sw/device/tests/crypto/kdf_kmac_functest.c
+++ b/sw/device/tests/crypto/kdf_kmac_functest.c
@@ -183,6 +183,52 @@ static status_t run_kmac_kdf_negative_tests(void) {
   return OTCRYPTO_OK;
 }
 
+/**
+ * Verify functionality of generating non-word-aligned output keys.
+ */
+static status_t run_kmac_kdf_non_word_aligned_test(void) {
+  LOG_INFO("Running KMAC KDF non-word-aligned length test");
+
+  kdf_kmac_test_vector_t *vec = &kKdfTestVectors[0];
+
+  // Request an odd byte length (e.g. 1 byte less than standard word alignment)
+  size_t exact_byte_len = (vec->expected_output.len * sizeof(uint32_t)) - 1;
+
+  otcrypto_key_config_t okm_config = {
+      .version = kOtcryptoLibVersion1,
+      .key_mode = kOtcryptoKeyModeKdfKmac128,
+      .key_length = exact_byte_len,
+      .hw_backed = kHardenedBoolFalse,
+      .exportable = kHardenedBoolTrue,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
+
+  size_t keyblob_words = keyblob_num_words(okm_config);
+  uint32_t km_buffer[keyblob_words];
+
+  otcrypto_blinded_key_t output_key = {
+      .config = okm_config,
+      .keyblob = km_buffer,
+      .keyblob_length = sizeof(km_buffer),
+  };
+
+  vec->key_derivation_key.checksum =
+      integrity_blinded_checksum(&vec->key_derivation_key);
+
+  otcrypto_const_byte_buf_t label_buf = OTCRYPTO_MAKE_BUF(
+      otcrypto_const_byte_buf_t, vec->label.data, vec->label.len);
+  otcrypto_const_byte_buf_t context_buf = OTCRYPTO_MAKE_BUF(
+      otcrypto_const_byte_buf_t, vec->context.data, vec->context.len);
+
+  TRY(otcrypto_kmac_kdf(&vec->key_derivation_key, &label_buf, &context_buf,
+                        &output_key));
+
+  HARDENED_CHECK_EQ(integrity_blinded_key_check(&output_key),
+                    kHardenedBoolTrue);
+
+  return OTCRYPTO_OK;
+}
+
 OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   LOG_INFO("Testing cryptolib KMAC-KDF driver.");
@@ -199,6 +245,10 @@ bool test_main(void) {
              current_test_vector->vector_identifier);
     EXECUTE_TEST(test_result, run_test_vector);
   }
+
+  EXECUTE_TEST(test_result, run_kmac_kdf_non_word_aligned_test);
+
   EXECUTE_TEST(test_result, run_kmac_kdf_negative_tests);
+
   return status_ok(test_result);
 }

--- a/sw/device/tests/crypto/kmac_functest.c
+++ b/sw/device/tests/crypto/kmac_functest.c
@@ -315,8 +315,6 @@ static status_t run_negative_tests(void) {
             .value == OTCRYPTO_BAD_ARGS.value);
 
   // Tag and output length checks
-  CHECK(otcrypto_kmac(&valid_key, &valid_msg, &valid_cust, 31, &valid_tag)
-            .value == OTCRYPTO_BAD_ARGS.value);
   CHECK(
       otcrypto_kmac(&valid_key, &valid_msg, &valid_cust, 0, &valid_tag).value ==
       OTCRYPTO_BAD_ARGS.value);


### PR DESCRIPTION
Move the kmac driver to accept non-word buffers. Then, remove the "NOT_IMPLEMENTED" from the kmac_kdf and create a test for this case.