### PR TITLE
[sw/dv] Protect DPI scope and sim control for multithreading

### DIFF
--- a/hw/dv/verilator/cpp/sv_scoped.cc
+++ b/hw/dv/verilator/cpp/sv_scoped.cc
@@ -7,6 +7,8 @@
 #include <cassert>
 #include <sstream>
 
+std::mutex SVScoped::global_scope_mutex_;
+
 // Set scope by name, returning the old scope. If the name doesn't describe a
 // valid scope, throw an SVScoped::Error.
 static svScope SetAbsScope(const std::string &name) {
@@ -85,7 +87,10 @@ static svScope SetRelScope(const std::string &name) {
   return SetAbsScope(scope_name);
 }
 
-SVScoped::SVScoped(const std::string &name) : prev_scope_(SetRelScope(name)) {}
+SVScoped::SVScoped(const std::string &name) {
+  global_scope_mutex_.lock();
+  prev_scope_ = SetRelScope(name);
+}
 
 SVScoped::Error::Error(const std::string &scope_name)
     : scope_name_(scope_name) {

--- a/hw/dv/verilator/cpp/sv_scoped.h
+++ b/hw/dv/verilator/cpp/sv_scoped.h
@@ -6,6 +6,7 @@
 #define OPENTITAN_HW_DV_VERILATOR_CPP_SV_SCOPED_H_
 
 #include <cassert>
+#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <svdpi.h>
@@ -32,7 +33,10 @@
 class SVScoped {
  public:
   SVScoped(const std::string &name);
-  ~SVScoped() { svSetScope(prev_scope_); }
+  ~SVScoped() {
+    svSetScope(prev_scope_);
+    global_scope_mutex_.unlock();
+  }
 
   class Error : public std::exception {
    public:
@@ -49,6 +53,7 @@ class SVScoped {
   static std::string join_sv_scopes(const std::string &a, const std::string &b);
 
  private:
+  static std::mutex global_scope_mutex_;
   svScope prev_scope_;
 };
 

--- a/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
+++ b/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
@@ -218,8 +218,10 @@ void VerilatorSimCtrl::SetTimeout(unsigned int cycles) {
 }
 
 void VerilatorSimCtrl::RequestStop(bool simulation_success) {
-  request_stop_ = true;
-  simulation_success_ &= simulation_success;
+  request_stop_.store(1, std::memory_order_seq_cst);
+  if (!simulation_success) {
+    simulation_success_.store(false, std::memory_order_relaxed);
+  }
 }
 
 void VerilatorSimCtrl::RegisterExtension(SimCtrlExtension *ext) {
@@ -378,7 +380,7 @@ void VerilatorSimCtrl::Run() {
 
     Trace();
 
-    if (request_stop_) {
+    if (request_stop_.load(std::memory_order_seq_cst)) {
       std::cout << "Received stop request, shutting down simulation."
                 << std::endl;
       break;

--- a/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.h
+++ b/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_HW_DV_VERILATOR_SIMUTIL_VERILATOR_CPP_VERILATOR_SIM_CTRL_H_
 #define OPENTITAN_HW_DV_VERILATOR_SIMUTIL_VERILATOR_CPP_VERILATOR_SIM_CTRL_H_
 
+#include <atomic>
 #include <chrono>
 #include <string>
 #include <vector>
@@ -84,7 +85,7 @@ class VerilatorSimCtrl {
   /**
    * Get the simulation result
    */
-  bool WasSimulationSuccessful() const { return simulation_success_; }
+  bool WasSimulationSuccessful() const { return simulation_success_.load(std::memory_order_relaxed); }
 
   /**
    * Set the number of clock cycles (periods) before the reset signal is
@@ -134,8 +135,8 @@ class VerilatorSimCtrl {
   bool tracing_possible_;
   unsigned int initial_reset_delay_cycles_;
   unsigned int reset_duration_cycles_;
-  volatile unsigned int request_stop_;
-  volatile bool simulation_success_;
+  std::atomic<unsigned int> request_stop_;
+  std::atomic<bool> simulation_success_;
   std::chrono::steady_clock::time_point time_begin_;
   std::chrono::steady_clock::time_point time_end_;
   VerilatedTracer tracer_;


### PR DESCRIPTION
This commit refactors the C++ DPI layer to be thread-safe, addressing critical race conditions that block Verilator multithreading.

1. **Atomic Simulation Control**: Replaced `volatile` simulation flags (`request_stop_` and `simulation_success_`) in `VerilatorSimCtrl` with `std::atomic` using appropriate memory orders. This prevents non-atomic read-modify-write race conditions that could lead to dropped stop requests or corrupted test success states during concurrent execution.
2. **DPI Scope Serialization**: Introduced a static `std::mutex` to `SVScoped` to serialize DPI scope context switching via `svSetScope`. Without this, concurrent DPI memory writes would overwrite the global SV scope, resulting in cross-thread memory corruption.