### PR TITLE
Backport 28476 ([sw,cov] Report coverage in hardware reset shared libraries)

### DIFF
--- a/sw/device/lib/coverage/BUILD
+++ b/sw/device/lib/coverage/BUILD
@@ -12,6 +12,7 @@ cc_library(
     name = "api",
     hdrs = ["api.h"],
     deps = [
+        ":empty_runtime",
         "//sw/device/lib/base:macros",
     ],
 )
@@ -34,6 +35,23 @@ cc_library(
         "//sw/device/lib/base:macros",
     ],
     alwayslink = True,  # replacing weak symbol
+)
+
+cc_library(
+    name = "empty_runtime_real",
+    srcs = ["empty_runtime.c"],
+    features = ["-coverage"],
+    deps = [
+        "//sw/device/lib/base:macros",
+    ],
+)
+
+alias(
+    name = "empty_runtime",
+    actual = select({
+        "//rules/coverage:enabled": ":empty_runtime_real",
+        "//conditions:default": "//sw/device:nothing",
+    }),
 )
 
 cc_library(

--- a/sw/device/lib/coverage/empty_runtime.c
+++ b/sw/device/lib/coverage/empty_runtime.c
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/macros.h"
+
+OT_WEAK void coverage_transport_init(void) {}
+OT_WEAK void coverage_init(void) {}
+OT_WEAK void coverage_report(void) {}
+OT_WEAK void coverage_invalidate(void) {}

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -408,6 +408,7 @@ dual_cc_library(
             "//hw/top/dt",
             "//sw/device/lib/base:hardened",
             "//sw/device/lib/base:macros",
+            "//sw/device/lib/coverage:api",
             "//sw/device/silicon_creator/lib/drivers:lifecycle",
             "//hw/top:lc_ctrl_c_regs",
             "//hw/top:otp_ctrl_c_regs",

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -738,6 +738,7 @@ dual_cc_library(
             "//sw/device/lib/base:macros",
             "//sw/device/lib/base:multibits",
             "//sw/device/lib/runtime:hart",
+            "//sw/device/lib/coverage:api",
             "//sw/device/silicon_creator/lib:error",
             "//sw/device/silicon_creator/lib/base:sec_mmio",
             "//sw/device/silicon_creator/lib/drivers:otp",

--- a/sw/device/silicon_creator/lib/drivers/rstmgr.c
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr.c
@@ -14,6 +14,7 @@
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/multibits.h"
+#include "sw/device/lib/coverage/api.h"
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
 
 #ifdef OT_PLATFORM_RV32
@@ -137,6 +138,7 @@ rom_error_t rstmgr_info_en_check(uint32_t reset_reasons) {
 }
 
 void rstmgr_reset(void) {
+  coverage_report();
   abs_mmio_write32(rstmgr_base() + RSTMGR_RESET_REQ_REG_OFFSET,
                    kMultiBitBool4True);
 #ifdef OT_PLATFORM_RV32

--- a/sw/device/silicon_creator/lib/shutdown.c
+++ b/sw/device/silicon_creator/lib/shutdown.c
@@ -21,6 +21,7 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/multibits.h"
 #include "sw/device/lib/base/stdasm.h"
+#include "sw/device/lib/coverage/api.h"
 #include "sw/device/silicon_creator/lib/build_info.h"
 #include "sw/device/silicon_creator/lib/drivers/alert.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
@@ -529,11 +530,15 @@ SHUTDOWN_FUNC(noreturn, shutdown_hang(void)) {
 __attribute__((section(".shutdown")))
 #endif
 void shutdown_finalize(rom_error_t reason) {
+  // Report coverage before error reporting for tests expecting BFV.
+  coverage_report();
   shutdown_report_error(reason);
   // In a normal build, this function inlines to nothing.
   stack_utilization_print();
   shutdown_software_escalate();
   shutdown_keymgr_kill();
+  // Report coverage again to ensure the calls above are reported.
+  coverage_report();
   // Reset before killing the flash to be able to use this also in flash.
   shutdown_reset();
   shutdown_flash_kill();


### PR DESCRIPTION
Backport #28476