### PR TITLE
[sw/runtime] Add NIST SP 800-90B software entropy health monitor

### DIFF
--- a/sw/device/lib/runtime/BUILD
+++ b/sw/device/lib/runtime/BUILD
@@ -14,6 +14,15 @@ cc_library(
     target_compatible_with = [OPENTITAN_CPU],
 )
 
+cc_library(
+    name = "entropy_health",
+    srcs = ["entropy_health.c"],
+    hdrs = ["entropy_health.h"],
+    deps = [
+        "//sw/device/lib/base:macros",
+    ],
+)
+
 dual_cc_library(
     name = "hart",
     srcs = dual_inputs(
@@ -112,6 +121,15 @@ cc_test(
     deps = [
         ":print",
         "@abseil-cpp//absl/strings:str_format",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "entropy_health_unittest",
+    srcs = ["entropy_health_unittest.cc"],
+    deps = [
+        ":entropy_health",
         "@googletest//:gtest_main",
     ],
 )

--- a/sw/device/lib/runtime/entropy_health.c
+++ b/sw/device/lib/runtime/entropy_health.c
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/runtime/entropy_health.h"
+
+void entropy_health_rct_init(entropy_health_rct_state_t *state,
+                             uint32_t first_symbol) {
+  if (state == NULL) {
+    return;
+  }
+  state->current_symbol = first_symbol;
+  state->rep_count = 1;
+  state->fail_flag = 0;
+}
+
+void entropy_health_rct_update(entropy_health_rct_state_t *state,
+                               uint32_t new_symbol) {
+  if (state == NULL) {
+    return;
+  }
+
+  // Constant-time match evaluation (1 if match, 0 if different)
+  uint32_t diff = state->current_symbol ^ new_symbol;
+
+  // Convert diff to a boolean-like 0 or 1 without branching
+  // `!!diff` is 1 if diff != 0, so `1 - !!diff` is 1 if matched.
+  uint32_t match = 1 - (!!diff);
+
+  // If match == 1: rep_count = rep_count + 1
+  // If match == 0: rep_count = 0 + 1 = 1
+  state->rep_count = (state->rep_count * match) + 1;
+  state->current_symbol = new_symbol;
+
+  // Latch the failure flag if the threshold is reached.
+  // Using bitwise OR prevents the flag from clearing once set.
+  state->fail_flag |= (state->rep_count >= ENTROPY_HEALTH_RCT_THRESHOLD);
+}
+
+bool entropy_health_rct_has_failed(const entropy_health_rct_state_t *state) {
+  if (state == NULL) {
+    return true; // fail-safe
+  }
+  return state->fail_flag != 0;
+}

--- a/sw/device/lib/runtime/entropy_health.h
+++ b/sw/device/lib/runtime/entropy_health.h
@@ -1,0 +1,75 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_RUNTIME_ENTROPY_HEALTH_H_
+#define OPENTITAN_SW_DEVICE_LIB_RUNTIME_ENTROPY_HEALTH_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * @file
+ * @brief Software-Side Entropy Health Monitor
+ *
+ * This module provides defense-in-depth entropy health monitoring to satisfy
+ * NIST SP 800-90B requirements (e.g., Repetition Count Test) against silent
+ * hardware logic failures or bus faults.
+ */
+
+/**
+ * The threshold for the Repetition Count Test (RCT).
+ * If a symbol repeats this many times consecutively, the test fails.
+ */
+#define ENTROPY_HEALTH_RCT_THRESHOLD 31
+
+/**
+ * State for the Repetition Count Test (RCT).
+ */
+typedef struct entropy_health_rct_state {
+  uint32_t current_symbol;
+  uint32_t rep_count;
+  uint32_t fail_flag; // 0 = OK, non-zero = Failed
+} entropy_health_rct_state_t;
+
+/**
+ * Initializes the Repetition Count Test state.
+ *
+ * @param state A pointer to the RCT state to initialize.
+ * @param first_symbol The very first symbol drawn from the entropy source.
+ */
+void entropy_health_rct_init(entropy_health_rct_state_t *state,
+                             uint32_t first_symbol);
+
+/**
+ * Updates the RCT state with a new symbol using branchless logic.
+ *
+ * @param state A pointer to the RCT state.
+ * @param new_symbol The newly drawn symbol from the entropy source.
+ */
+void entropy_health_rct_update(entropy_health_rct_state_t *state,
+                               uint32_t new_symbol);
+
+/**
+ * Checks if the RCT has failed.
+ *
+ * Once this function returns true, it will continue to return true for the
+ * lifetime of the state object (until re-initialized).
+ *
+ * @param state A pointer to the RCT state.
+ * @return True if a failure has occurred, false otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+bool entropy_health_rct_has_failed(const entropy_health_rct_state_t *state);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_RUNTIME_ENTROPY_HEALTH_H_

--- a/sw/device/lib/runtime/entropy_health_unittest.cc
+++ b/sw/device/lib/runtime/entropy_health_unittest.cc
@@ -1,0 +1,61 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/runtime/entropy_health.h"
+
+#include "gtest/gtest.h"
+
+namespace entropy_health_test {
+namespace {
+
+TEST(EntropyHealthTest, HappyPath) {
+  entropy_health_rct_state_t state;
+  entropy_health_rct_init(&state, 0x12345678);
+
+  // Provide an alternating sequence.
+  for (int i = 0; i < ENTROPY_HEALTH_RCT_THRESHOLD * 2; ++i) {
+    uint32_t symbol = (i % 2 == 0) ? 0xAAAAAAAA : 0x55555555;
+    entropy_health_rct_update(&state, symbol);
+    EXPECT_FALSE(entropy_health_rct_has_failed(&state));
+  }
+}
+
+TEST(EntropyHealthTest, StuckAtFault) {
+  entropy_health_rct_state_t state;
+  uint32_t stuck_symbol = 0x00000000;
+  entropy_health_rct_init(&state, stuck_symbol);
+
+  // Inject THRESHOLD - 1 identical symbols.
+  // Note: the initialization counts as 1. So we inject THRESHOLD - 2 more.
+  for (int i = 0; i < ENTROPY_HEALTH_RCT_THRESHOLD - 2; ++i) {
+    entropy_health_rct_update(&state, stuck_symbol);
+    EXPECT_FALSE(entropy_health_rct_has_failed(&state));
+  }
+
+  // Inject exactly 1 more identical symbol to hit the threshold.
+  entropy_health_rct_update(&state, stuck_symbol);
+  EXPECT_TRUE(entropy_health_rct_has_failed(&state));
+}
+
+TEST(EntropyHealthTest, RecoveryResistance) {
+  entropy_health_rct_state_t state;
+  uint32_t stuck_symbol = 0xFFFFFFFF;
+  entropy_health_rct_init(&state, stuck_symbol);
+
+  // Trigger the fail flag.
+  for (int i = 0; i < ENTROPY_HEALTH_RCT_THRESHOLD - 1; ++i) {
+    entropy_health_rct_update(&state, stuck_symbol);
+  }
+  EXPECT_TRUE(entropy_health_rct_has_failed(&state));
+
+  // Inject 100 perfectly random, healthy symbols.
+  for (int i = 0; i < 100; ++i) {
+    entropy_health_rct_update(&state, i); // Changing symbols
+    // Assert that the fail flag remains set.
+    EXPECT_TRUE(entropy_health_rct_has_failed(&state));
+  }
+}
+
+}  // namespace
+}  // namespace entropy_health_test


### PR DESCRIPTION

### Summary
This PR introduces a standalone runtime service for software-side entropy health monitoring. It implements the **Repetition Count Test (RCT)** as specified in **NIST SP 800-90B (Section 4.4.1)**, providing an independent validation layer for entropy consumed by firmware.

### Technical Details
*   **Branchless Logic**: The RCT state machine is implemented using branchless bitwise operations to ensure **constant-time execution**. This mitigates timing-based side-channel attacks that could otherwise leak information about the entropy source's state.
*   **Defense-in-Depth**: While hardware health tests exist, this software monitor detects "stuck-at" faults or bus-level data corruption that may occur between the Entropy Source IP and the CPU boundary.
*   **Latching Mechanism**: The monitor includes a persistent failure latch, ensuring that once a health violation is detected, the system remains in a secure error state until an explicit reset.

### Testing Strategy
*   **Unit Tests**: Created `sw/device/lib/runtime/entropy_health_unittest.cc` covering:
    *   **Happy Path**: Verification with high-entropy sequences.
    *   **Failure Trigger**: Precise transition to error state at the `ENTROPY_RCT_THRESHOLD`.
    *   **Recovery Resistance**: Ensuring the error state persists even if subsequent entropy is valid.
*   **Build Verification**: Verified clean compilation via Bazel for the `rv32imc` freestanding target.

### Impact
Satisfies a core requirement for **FIPS 140-3** high-assurance security and improves the overall resilience of the OpenTitan Root of Trust.

---

### Verification Checklist
- [x] **Signed-off-by** added to commit message.
- [x] Unit tests passing (`bazel test //sw/device/lib/runtime:entropy_health_unittest`).
- [x] Documentation updated within code comments.
- [x] Code follows OpenTitan C/C++ style guidelines.