### PR TITLE
[crypto/25519] Draw shares via memshred

### DIFF
--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -99,7 +99,6 @@ cc_library(
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         ":config",
-        ":drbg",
         ":hmac",
         ":integrity",
         ":keyblob",

--- a/sw/device/lib/crypto/impl/ecc_curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc_curve25519.c
@@ -11,7 +11,6 @@
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
-#include "sw/device/lib/crypto/include/drbg.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/sha2.h"
 
@@ -269,8 +268,7 @@ static status_t ed25519_mask_scalar(uint32_t *scalar, size_t scalar_len,
       OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, share1, share_len);
   otcrypto_const_byte_buf_t kEmptyBuffer =
       OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, NULL, 0);
-  HARDENED_TRY(otcrypto_drbg_instantiate(&kEmptyBuffer));
-  HARDENED_TRY(otcrypto_drbg_generate(&kEmptyBuffer, &share1_buf));
+  HARDENED_TRY(hardened_memshred(share1, share_len));
   share1[share_len - 1] &= 0x7fffffff;
 
   // Compute share0 = share + share1.


### PR DESCRIPTION
Shares in 25519 can be generated via hardened_memshred since these can be non-crypto random.