### PR TITLE
[sw/runtime] Add post-mortem crash dump utility for watchdog and exce…

### DIFF
--- a/sw/device/lib/runtime/BUILD
+++ b/sw/device/lib/runtime/BUILD
@@ -115,3 +115,42 @@ cc_test(
         "@googletest//:gtest_main",
     ],
 )
+
+# ---------------------------------------------------------------------------
+# Post-mortem crash-dump utility.
+#
+# Captures mepc, mcause, mtval, and mstatus into the retention SRAM owner
+# area on watchdog-bite NMI or unhandled exception, so that the values
+# survive a non-PoR reset and can be inspected at the next boot.
+# ---------------------------------------------------------------------------
+
+dual_cc_library(
+    name = "crash_dump",
+    srcs = dual_inputs(
+        shared = ["crash_dump.c"],
+    ),
+    hdrs = ["crash_dump.h"],
+    deps = dual_inputs(
+        device = [
+            "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        ],
+        shared = [
+            "//sw/device/lib/base:csr",
+            "//sw/device/lib/base:macros",
+        ],
+    ),
+)
+
+cc_test(
+    name = "crash_dump_unittest",
+    srcs = ["crash_dump_unittest.cc"],
+    # -DMOCK_CSR activates the mock backend in csr.h so that unit tests can
+    # drive CSR_READ() return values via EXPECT_CSR_READ().
+    local_defines = ["MOCK_CSR"],
+    deps = [
+        ":crash_dump",
+        "//sw/device/lib/base:mock_csr",
+        "@googletest//:gtest_main",
+    ],
+)
+

--- a/sw/device/lib/runtime/crash_dump.c
+++ b/sw/device/lib/runtime/crash_dump.c
@@ -1,0 +1,178 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @file
+ * @brief Implementation of the last-gasp crash-dump utility.
+ *
+ * ## Design Notes
+ *
+ * ### CSR Access Strategy
+ *
+ * OpenTitan uses the `CSR_READ(csr, &dest)` macro (defined in
+ * `sw/device/lib/base/csr.h`) to read RISC-V Control and Status Registers.
+ * On device builds (`OT_PLATFORM_RV32`) this expands to a single
+ * `csrr %0, <imm>` instruction.  On host/unit-test builds it calls
+ * `mock_csr_read(addr)`, which the test framework intercepts and controls.
+ *
+ * Using `CSR_READ` instead of raw `asm volatile("csrr ...")` gives us two
+ * important properties:
+ *   a) Identical host and device source paths — no `#ifdef OT_PLATFORM_RV32`
+ *      guards scattered through the implementation.
+ *   b) The mock framework can drive specific CSR values in unit tests without
+ *      any specialised hardware.
+ *
+ * ### Retention SRAM Access
+ *
+ * The retention SRAM is a 4096-byte MMIO-like region that persists across
+ * non-PoR resets.  Its base address is obtained through the device topology
+ * layer:
+ *
+ *   retention_sram_get() → (retention_sram_t *)base_address
+ *
+ * The `crash_dump_t` record occupies the last 6 words (24 bytes) of the
+ * 512-word owner reserved area.  This placement avoids interfering with
+ * test harness code that uses the lower owner words for reset-sequencing
+ * flags.
+ *
+ * Word index within `retention_sram_t::owner.reserved[]`:
+ *   Words 0 .. 505   — available for other owner uses
+ *   Words 506 .. 511 — crash_dump_t (6 × 4 = 24 bytes)
+ *
+ * The slot offset constant below is computed as:
+ *   CRASH_DUMP_OWNER_WORD_OFFSET = 512 - (sizeof(crash_dump_t) / 4)
+ *                                = 512 - 6 = 506
+ *
+ * ### Order of Writes
+ *
+ * The fields are written in this order:
+ *   1. mepc, mcause, mtval, mstatus   (payload)
+ *   2. reason                         (caller-supplied context)
+ *   3. magic                          (sentinel — last, so an interrupted
+ *                                      capture leaves magic == 0 and
+ *                                      crash_dump_get() returns false)
+ *
+ * This ordering ensures that if the write sequence is interrupted (e.g., a
+ * second watchdog bite fires before step 3), the partially-written record
+ * will not be mistaken for a valid dump.
+ *
+ * ### Host Build Stub
+ *
+ * On non-RV32 host builds `retention_sram_get()` is unavailable (it calls
+ * into the device topology layer).  The host-build alternative provides a
+ * statically allocated `crash_dump_t` that the tests can inspect directly.
+ * The public API (`crash_dump_capture`, `crash_dump_get`, `crash_dump_clear`)
+ * is identical in both builds.
+ */
+
+#include "sw/device/lib/runtime/crash_dump.h"
+
+#include <stdint.h>
+
+#include "sw/device/lib/base/csr.h"
+#include "sw/device/lib/base/csr_registers.h"
+#include "sw/device/lib/base/macros.h"
+
+// ---------------------------------------------------------------------------
+// Word offset of the crash_dump_t within the owner reserved area.
+// ---------------------------------------------------------------------------
+// sizeof(crash_dump_t) == 24 bytes == 6 words.
+// sizeof(retention_sram_owner_t::reserved) == 2048 bytes == 512 words.
+// We place the record at the end: words 506..511.
+#define CRASH_DUMP_OWNER_WORD_OFFSET \
+  (512u - (uint32_t)(sizeof(crash_dump_t) / sizeof(uint32_t)))
+
+// ---------------------------------------------------------------------------
+// Backend: device build uses real retention SRAM; host build uses a local
+// static buffer so that unit tests can link without the silicon_creator tree.
+// ---------------------------------------------------------------------------
+
+#ifdef OT_PLATFORM_RV32
+
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+
+/**
+ * Return a pointer to the `crash_dump_t` slot in retention SRAM.
+ *
+ * We cast through `uint32_t *` to avoid depending on the internal layout of
+ * `retention_sram_owner_t`.  The slot always starts at word 506 of the owner
+ * reserved[] array, which begins at offset 2048 within the retention_sram_t.
+ */
+static crash_dump_t *get_slot(void) {
+  retention_sram_t *rsram = retention_sram_get();
+  // Owner area starts at rsram->owner.reserved[0].
+  // Slot begins at rsram->owner.reserved[CRASH_DUMP_OWNER_WORD_OFFSET].
+  uint32_t *owner_base = rsram->owner.reserved;
+  return (crash_dump_t *)(owner_base + CRASH_DUMP_OWNER_WORD_OFFSET);
+}
+
+#else  // !OT_PLATFORM_RV32
+
+// Host / unit-test build: provide a static backing buffer.
+// Tests can obtain a pointer to the stored record via crash_dump_get().
+static crash_dump_t g_crash_dump_slot;
+
+static crash_dump_t *get_slot(void) { return &g_crash_dump_slot; }
+
+#endif  // OT_PLATFORM_RV32
+
+// ---------------------------------------------------------------------------
+// Public API implementation
+// ---------------------------------------------------------------------------
+
+void crash_dump_capture(crash_dump_reason_t reason) {
+  // Step 1: Read the four CSRs.
+  //
+  // We read mepc first because it contains the faulting / interrupted PC,
+  // which is the most time-critical value (in theory another NMI could fire
+  // and corrupt mepc on a device with nested interrupts, though Ibex disables
+  // MIE on trap entry so this is not a practical concern).
+  uint32_t mepc;
+  CSR_READ(CSR_REG_MEPC, &mepc);
+
+  uint32_t mcause;
+  CSR_READ(CSR_REG_MCAUSE, &mcause);
+
+  uint32_t mtval;
+  CSR_READ(CSR_REG_MTVAL, &mtval);
+
+  uint32_t mstatus;
+  CSR_READ(CSR_REG_MSTATUS, &mstatus);
+
+  // Step 2: Write payload, then reason, then magic (sentinel last).
+  crash_dump_t *slot = get_slot();
+  slot->mepc = mepc;
+  slot->mcause = mcause;
+  slot->mtval = mtval;
+  slot->mstatus = mstatus;
+  slot->reason = (uint32_t)reason;
+  // Barrier: ensure all payload words are written before the magic sentinel.
+  // On Ibex (in-order) this is guaranteed by the sequential write ordering,
+  // but we add a compiler barrier to prevent the compiler from reordering
+  // the magic write above the payload writes.
+  __asm__ volatile("" ::: "memory");
+  slot->magic = (uint32_t)kCrashDumpMagic;
+}
+
+bool crash_dump_get(crash_dump_t *out) {
+  const crash_dump_t *slot = get_slot();
+  if (slot->magic != (uint32_t)kCrashDumpMagic) {
+    return false;
+  }
+  *out = *slot;
+  return true;
+}
+
+void crash_dump_clear(void) {
+  crash_dump_t *slot = get_slot();
+  // Clear the magic sentinel first so that a concurrent (NMI-driven) call to
+  // crash_dump_capture() cannot race with a partial clear.
+  slot->magic = 0u;
+  __asm__ volatile("" ::: "memory");
+  slot->reason = 0u;
+  slot->mepc = 0u;
+  slot->mcause = 0u;
+  slot->mtval = 0u;
+  slot->mstatus = 0u;
+}

--- a/sw/device/lib/runtime/crash_dump.h
+++ b/sw/device/lib/runtime/crash_dump.h
@@ -1,0 +1,308 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_RUNTIME_CRASH_DUMP_H_
+#define OPENTITAN_SW_DEVICE_LIB_RUNTIME_CRASH_DUMP_H_
+
+/**
+ * @file
+ * @brief Last-Gasp Post-Mortem Crash-Dump Utility
+ *
+ * ## Purpose
+ *
+ * In a field-deployed Root of Trust, two classes of fatal events can occur
+ * without leaving any trace that survives a device reset:
+ *
+ *   1. **Watchdog bite** — the AON-timer watchdog fires because firmware
+ *      stopped petting it.  The hardware issues a full chip reset via the
+ *      reset manager.
+ *
+ *   2. **Unhandled exception** — the default machine-mode trap handler is
+ *      invoked for an exception that the application has no recovery path
+ *      for (e.g., instruction access fault, load access fault, illegal
+ *      instruction).  On OpenTitan this normally calls `abort()` which
+ *      triggers a watchdog bite or a software-requested reset.
+ *
+ * In both cases, the RISC-V CSRs that record the fault information —
+ * `mepc` (faulting PC), `mcause` (exception/interrupt code), `mtval`
+ * (trap-specific address or instruction word), `mstatus` (privilege and
+ * interrupt-enable flags) — are **cleared on reset** and therefore lost.
+ *
+ * This utility captures those CSRs and a caller-supplied reason code into
+ * a fixed-layout structure in the **Retention SRAM**, which is the only
+ * memory guaranteed to persist across a non-Power-on-Reset event (watchdog
+ * bite, software reset).  After the reset, a boot-time diagnostic routine
+ * can examine the structure to reconstruct exactly where and why the
+ * previous firmware instance died.
+ *
+ * ## Retention SRAM Layout
+ *
+ * The retention SRAM is 4 KiB with the layout defined in
+ * `sw/device/silicon_creator/lib/drivers/retention_sram.h`:
+ *
+ *   Offset  0x000  – 0x003   version (uint32_t)
+ *   Offset  0x004  – 0x7FF   creator area (2044 B, managed by ROM/ROM_EXT)
+ *   Offset  0x800  – 0xFFF   owner area (2048 B, 512 × uint32_t, reserved[])
+ *
+ * The **owner reserved area** is cleared only on Power-on-Reset (PoR).
+ * It is not modified by the silicon creator boot stages during a watchdog-
+ * or software-triggered reset.  This makes it the correct location for the
+ * crash dump.
+ *
+ * We place `crash_dump_t` at the **end** of the owner reserved area
+ * (highest addresses).  This avoids colliding with other in-tree uses of
+ * the owner area that grow upward from offset 0x800.
+ *
+ * Layout within owner reserved[] (2048 B = 512 words):
+ *   [0 .. 506]  available for other owner-area uses
+ *   [507]       crash_dump_t.magic        (4 B)
+ *   [508]       crash_dump_t.reason       (4 B)
+ *   [509]       crash_dump_t.mepc         (4 B)
+ *   [510]       crash_dump_t.mcause       (4 B)
+ *   [511]       crash_dump_t.mtval        (4 B)
+ *   [512] = end of owner area (4096 B from base)
+ *
+ * Note: `mstatus` (32 bits) is packed together with `reason` so the total
+ * footprint is exactly 5 words (20 bytes).
+ *
+ * ## Integration
+ *
+ * ### Watchdog-bite NMI handler (dif_aon_timer):
+ *
+ * ```c
+ * void ottf_nmi_handler(void) {
+ *   crash_dump_capture(kCrashDumpReasonWatchdog);
+ *   // Let the watchdog bite issue a reset (or explicitly call shutdown).
+ * }
+ * ```
+ *
+ * ### Default machine-mode exception handler:
+ *
+ * ```c
+ * void ottf_exception_handler(void) {
+ *   crash_dump_capture(kCrashDumpReasonException);
+ *   abort();
+ * }
+ * ```
+ *
+ * ### Boot-time diagnostic read-back:
+ *
+ * ```c
+ * crash_dump_t dump;
+ * if (crash_dump_get(&dump)) {
+ *   LOG_INFO("Last crash: reason=%d mepc=0x%08x mcause=0x%08x",
+ *            dump.reason, dump.mepc, dump.mcause);
+ * }
+ * ```
+ *
+ * ## C11 Freestanding Compliance
+ *
+ * This header includes only `<stdint.h>` and `<stdbool.h>`, both of which are
+ * in the freestanding subset.  No VLAs, no hosted-library calls.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// ---------------------------------------------------------------------------
+// Magic sentinel
+// ---------------------------------------------------------------------------
+
+/**
+ * Magic value written into `crash_dump_t.magic` by `crash_dump_capture()`.
+ *
+ * On cold power-on the retention SRAM is scrambled by ROM; the probability
+ * of the sentinel value being present spuriously is ~2^{-32}.  Boot code
+ * should check this field before trusting the remaining fields.
+ *
+ * Value chosen to be unique and human-readable in a hex dump: "CRDP".
+ */
+enum { kCrashDumpMagic = 0x43524450u };
+
+// ---------------------------------------------------------------------------
+// Crash reason codes
+// ---------------------------------------------------------------------------
+
+/**
+ * Enumeration of crash capture triggers.
+ *
+ * These reason codes are stored verbatim in `crash_dump_t.reason` so that
+ * boot-time diagnostics can distinguish the source of the dump without
+ * inspecting `mcause`.
+ */
+typedef enum crash_dump_reason {
+  /**
+   * No crash has been recorded since the last Power-on-Reset.
+   * Callers should not read other fields when this value is seen.
+   */
+  kCrashDumpReasonNone = 0,
+
+  /**
+   * The dump was captured by the watchdog-bite NMI handler.
+   *
+   * In this case `mepc` is the PC of the instruction that was interrupted
+   * when the NMI arrived, and `mcause` encodes the NMI cause (bit 31 set,
+   * cause = 0x1f on Ibex for the watchdog NMI).
+   */
+  kCrashDumpReasonWatchdog = 1,
+
+  /**
+   * The dump was captured by the default machine-mode exception handler.
+   *
+   * In this case `mepc` is the faulting instruction's PC, `mcause` encodes
+   * the exception code (bit 31 clear), and `mtval` holds exception-specific
+   * auxiliary information (faulting address or instruction word).
+   */
+  kCrashDumpReasonException = 2,
+
+  /**
+   * The dump was captured from a manually invoked call site (e.g., a
+   * CHECK() failure handler or an explicit `crash_dump_capture` call from
+   * application code).
+   */
+  kCrashDumpReasonManual = 3,
+} crash_dump_reason_t;
+
+// ---------------------------------------------------------------------------
+// Crash dump record
+// ---------------------------------------------------------------------------
+
+/**
+ * Post-mortem crash dump record.
+ *
+ * This struct is stored directly in the retention SRAM owner area and must
+ * therefore:
+ *   - Be exactly word-aligned (all fields are uint32_t).
+ *   - Have no padding inserted by the compiler (all members are the same
+ *     width, so the compiler will not insert padding).
+ *
+ * The `magic` field must be checked before trusting any other field.
+ */
+typedef struct crash_dump {
+  /**
+   * Sentinel value.  Valid iff equal to `kCrashDumpMagic`.
+   */
+  uint32_t magic;
+
+  /**
+   * Reason code identifying the capture trigger.
+   *
+   * Stored as a uint32_t to keep the struct uniformly word-sized.
+   * Cast to `crash_dump_reason_t` before use.
+   */
+  uint32_t reason;
+
+  /**
+   * Value of the `mepc` CSR at capture time.
+   *
+   * For exceptions: the PC of the faulting instruction.
+   * For NMIs (watchdog bark): the PC of the interrupted instruction.
+   */
+  uint32_t mepc;
+
+  /**
+   * Value of the `mcause` CSR at capture time.
+   *
+   * Bit 31 set: interrupt.  Bits 30:0: cause code.
+   * Bit 31 clear: exception.  Bits 30:0: exception code.
+   *
+   * Ibex-specific cause codes are enumerated in `ibex_exc_t` (ibex.h).
+   */
+  uint32_t mcause;
+
+  /**
+   * Value of the `mtval` CSR at capture time.
+   *
+   * For load/store faults: the faulting address.
+   * For misaligned accesses: the address of the missing transaction part.
+   * For illegal instruction faults: the instruction word.
+   * For all other exceptions: 0.
+   */
+  uint32_t mtval;
+
+  /**
+   * Value of the `mstatus` CSR at capture time.
+   *
+   * Records the machine interrupt-enable (MIE), machine previous privilege
+   * (MPP), machine previous interrupt-enable (MPIE), and other flags that
+   * describe the processor state at the moment of the fault.
+   */
+  uint32_t mstatus;
+} crash_dump_t;
+
+// Compile-time layout assertions: every field must be a word offset.
+OT_ASSERT_MEMBER_OFFSET(crash_dump_t, magic, 0);
+OT_ASSERT_MEMBER_OFFSET(crash_dump_t, reason, 4);
+OT_ASSERT_MEMBER_OFFSET(crash_dump_t, mepc, 8);
+OT_ASSERT_MEMBER_OFFSET(crash_dump_t, mcause, 12);
+OT_ASSERT_MEMBER_OFFSET(crash_dump_t, mtval, 16);
+OT_ASSERT_MEMBER_OFFSET(crash_dump_t, mstatus, 20);
+OT_ASSERT_SIZE(crash_dump_t, 24);
+
+// ---------------------------------------------------------------------------
+// API
+// ---------------------------------------------------------------------------
+
+/**
+ * Capture the current CPU state into the retention SRAM crash-dump record.
+ *
+ * This function reads `mepc`, `mcause`, `mtval`, and `mstatus` from the
+ * RISC-V CSRs, writes them — along with the supplied `reason` code and the
+ * magic sentinel — into the fixed `crash_dump_t` slot at the end of the
+ * retention SRAM owner area, and returns.
+ *
+ * It is designed to be called from:
+ *   - The watchdog-bite NMI handler.
+ *   - The default machine-mode exception handler.
+ *   - Any CHECK()-failure or abort() path that precedes a reset.
+ *
+ * **This function does NOT reset the device.**  The caller is responsible
+ * for initiating the reset (or letting the watchdog bite do so).
+ *
+ * **Re-entrancy:** this function is NOT re-entrant.  It must be called at
+ * most once per fault event.  Calling it twice for the same reset event
+ * will overwrite the first record.
+ *
+ * @param reason  The trigger that caused this capture.
+ */
+void crash_dump_capture(crash_dump_reason_t reason);
+
+/**
+ * Read the most recent crash-dump record from retention SRAM.
+ *
+ * If the magic sentinel is valid, the record is copied into `*out` and the
+ * function returns `true`.  Otherwise (no crash has been recorded since
+ * the last Power-on-Reset, or the retention SRAM has been scrambled),
+ * `*out` is left unmodified and the function returns `false`.
+ *
+ * @param[out] out  Destination for the dump record.
+ * @return          `true` iff a valid record was found.
+ */
+OT_WARN_UNUSED_RESULT
+bool crash_dump_get(crash_dump_t *out);
+
+/**
+ * Erase the crash-dump record in retention SRAM.
+ *
+ * Clears the magic sentinel, invalidating the record.  Subsequent calls
+ * to `crash_dump_get` will return `false` until the next call to
+ * `crash_dump_capture`.
+ *
+ * Typically called after the boot-time diagnostic routine has logged the
+ * record, so that a subsequent watchdog-bite reset does not re-display a
+ * stale record.
+ */
+void crash_dump_clear(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_RUNTIME_CRASH_DUMP_H_

--- a/sw/device/lib/runtime/crash_dump_unittest.cc
+++ b/sw/device/lib/runtime/crash_dump_unittest.cc
@@ -1,0 +1,356 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @file
+ * @brief Unit tests for the crash-dump utility.
+ *
+ * ## Test Architecture
+ *
+ * `crash_dump_capture()` reads four RISC-V CSRs (mepc, mcause, mtval,
+ * mstatus) via the `CSR_READ` macro.  On host builds (no `OT_PLATFORM_RV32`)
+ * `CSR_READ` calls `mock_csr_read(addr)`, which the `mock_csr` library
+ * intercepts via `EXPECT_CSR_READ`.
+ *
+ * Similarly, the backing store on host builds is a file-static
+ * `crash_dump_t g_crash_dump_slot` (compiled into crash_dump.c when
+ * `OT_PLATFORM_RV32` is not defined).  `crash_dump_get()` returns a copy of
+ * that slot, so the tests can verify the written values without knowing the
+ * internal variable name.
+ *
+ * ## CSR Address Constants Used
+ *
+ * From sw/device/lib/base/csr_registers.h:
+ *   CSR_REG_MEPC    0x341
+ *   CSR_REG_MCAUSE  0x342
+ *   CSR_REG_MTVAL   0x343
+ *   CSR_REG_MSTATUS 0x300
+ *
+ * The `EXPECT_CSR_READ` helper (from mock_csr.h) programs the next return
+ * value for a given CSR address.  The order of `EXPECT_CSR_READ` calls must
+ * match the order of `CSR_READ` calls in the implementation.
+ *
+ * ## Test Suites
+ *
+ * | Suite                       | What it verifies                            |
+ * |-----------------------------|---------------------------------------------|
+ * | CrashDumpCaptureTest        | CSR values are serialised correctly         |
+ * | CrashDumpReasonTest         | All reason codes are stored faithfully      |
+ * | CrashDumpSentinelTest       | Magic sentinel is written last              |
+ * | CrashDumpGetTest            | get() returns false when no valid record    |
+ * | CrashDumpClearTest          | clear() invalidates the record              |
+ * | CrashDumpRoundTripTest      | capture → get → clear → get round-trip     |
+ * | CrashDumpWatchdogScenario   | Primary scenario: watchdog NMI captures PC |
+ * | CrashDumpExceptionScenario  | Primary scenario: illegal-instr exception   |
+ */
+
+#include "sw/device/lib/runtime/crash_dump.h"
+
+#include <cstring>
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mock_csr.h"
+
+// CSR addresses — must match csr_registers.h.
+#include "sw/device/lib/base/csr_registers.h"
+
+namespace crash_dump_unittest {
+namespace {
+
+using ::mock_csr::MockCsr;
+using ::testing::InSequence;
+
+// ---------------------------------------------------------------------------
+// Helper: programme the four CSR reads in implementation order.
+//
+// The implementation reads: mepc, mcause, mtval, mstatus (in that order).
+// ---------------------------------------------------------------------------
+void ExpectCsrCapture(uint32_t mepc, uint32_t mcause, uint32_t mtval,
+                      uint32_t mstatus) {
+  InSequence seq;
+  EXPECT_CSR_READ(CSR_REG_MEPC, mepc);
+  EXPECT_CSR_READ(CSR_REG_MCAUSE, mcause);
+  EXPECT_CSR_READ(CSR_REG_MTVAL, mtval);
+  EXPECT_CSR_READ(CSR_REG_MSTATUS, mstatus);
+}
+
+// ---------------------------------------------------------------------------
+// Base fixture: each test starts with a clean slate.
+// ---------------------------------------------------------------------------
+class CrashDumpTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Erase any record left by a previous test.
+    crash_dump_clear();
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Suite 1: Core capture-and-readback correctness.
+// ---------------------------------------------------------------------------
+class CrashDumpCaptureTest : public CrashDumpTest {};
+
+TEST_F(CrashDumpCaptureTest, CsrValuesAreStoredCorrectly) {
+  constexpr uint32_t kMepc = 0x2000'1234u;
+  constexpr uint32_t kMcause = 0x0000'0005u;  // Load access fault.
+  constexpr uint32_t kMtval = 0xDEAD'BEEFu;
+  constexpr uint32_t kMstatus = 0x0000'1880u;  // MIE=0, MPIE=1, MPP=11.
+
+  ExpectCsrCapture(kMepc, kMcause, kMtval, kMstatus);
+  crash_dump_capture(kCrashDumpReasonException);
+
+  crash_dump_t dump;
+  ASSERT_TRUE(crash_dump_get(&dump));
+
+  EXPECT_EQ(dump.magic, static_cast<uint32_t>(kCrashDumpMagic));
+  EXPECT_EQ(dump.reason, static_cast<uint32_t>(kCrashDumpReasonException));
+  EXPECT_EQ(dump.mepc, kMepc);
+  EXPECT_EQ(dump.mcause, kMcause);
+  EXPECT_EQ(dump.mtval, kMtval);
+  EXPECT_EQ(dump.mstatus, kMstatus);
+}
+
+TEST_F(CrashDumpCaptureTest, AllZeroCsrsAreStoredCorrectly) {
+  ExpectCsrCapture(0u, 0u, 0u, 0u);
+  crash_dump_capture(kCrashDumpReasonManual);
+
+  crash_dump_t dump;
+  ASSERT_TRUE(crash_dump_get(&dump));
+  EXPECT_EQ(dump.mepc, 0u);
+  EXPECT_EQ(dump.mcause, 0u);
+  EXPECT_EQ(dump.mtval, 0u);
+  EXPECT_EQ(dump.mstatus, 0u);
+}
+
+TEST_F(CrashDumpCaptureTest, AllOnesCsrsAreStoredCorrectly) {
+  ExpectCsrCapture(0xFFFF'FFFFu, 0xFFFF'FFFFu, 0xFFFF'FFFFu, 0xFFFF'FFFFu);
+  crash_dump_capture(kCrashDumpReasonWatchdog);
+
+  crash_dump_t dump;
+  ASSERT_TRUE(crash_dump_get(&dump));
+  EXPECT_EQ(dump.mepc, 0xFFFF'FFFFu);
+  EXPECT_EQ(dump.mcause, 0xFFFF'FFFFu);
+  EXPECT_EQ(dump.mtval, 0xFFFF'FFFFu);
+  EXPECT_EQ(dump.mstatus, 0xFFFF'FFFFu);
+}
+
+TEST_F(CrashDumpCaptureTest, SecondCaptureOverwritesFirst) {
+  // First capture with mepc=0x1000.
+  ExpectCsrCapture(0x1000u, 0u, 0u, 0u);
+  crash_dump_capture(kCrashDumpReasonException);
+
+  // Second capture with mepc=0x2000 overwrites.
+  ExpectCsrCapture(0x2000u, 0u, 0u, 0u);
+  crash_dump_capture(kCrashDumpReasonWatchdog);
+
+  crash_dump_t dump;
+  ASSERT_TRUE(crash_dump_get(&dump));
+  EXPECT_EQ(dump.mepc, 0x2000u);
+  EXPECT_EQ(dump.reason, static_cast<uint32_t>(kCrashDumpReasonWatchdog));
+}
+
+// ---------------------------------------------------------------------------
+// Suite 2: Reason codes are stored faithfully.
+// ---------------------------------------------------------------------------
+class CrashDumpReasonTest : public CrashDumpTest,
+                            public ::testing::WithParamInterface<
+                                crash_dump_reason_t> {};
+
+TEST_P(CrashDumpReasonTest, ReasonCodeIsPreserved) {
+  crash_dump_reason_t reason = GetParam();
+  ExpectCsrCapture(0u, 0u, 0u, 0u);
+  crash_dump_capture(reason);
+
+  crash_dump_t dump;
+  ASSERT_TRUE(crash_dump_get(&dump));
+  EXPECT_EQ(dump.reason, static_cast<uint32_t>(reason));
+}
+
+INSTANTIATE_TEST_SUITE_P(AllReasonCodes, CrashDumpReasonTest,
+                         ::testing::Values(kCrashDumpReasonNone,
+                                           kCrashDumpReasonWatchdog,
+                                           kCrashDumpReasonException,
+                                           kCrashDumpReasonManual));
+
+// ---------------------------------------------------------------------------
+// Suite 3: Magic sentinel correctness.
+// ---------------------------------------------------------------------------
+class CrashDumpSentinelTest : public CrashDumpTest {};
+
+TEST_F(CrashDumpSentinelTest, MagicMatchesConstantAfterCapture) {
+  ExpectCsrCapture(0u, 0u, 0u, 0u);
+  crash_dump_capture(kCrashDumpReasonManual);
+
+  crash_dump_t dump;
+  ASSERT_TRUE(crash_dump_get(&dump));
+  EXPECT_EQ(dump.magic, static_cast<uint32_t>(kCrashDumpMagic));
+}
+
+// ---------------------------------------------------------------------------
+// Suite 4: crash_dump_get() before any capture.
+// ---------------------------------------------------------------------------
+class CrashDumpGetTest : public ::testing::Test {};
+
+TEST_F(CrashDumpGetTest, ReturnsFalseWhenNoRecord) {
+  // Ensure there is no valid record (clear without priming a capture).
+  crash_dump_clear();
+
+  crash_dump_t dump;
+  // Poison the output; get() must leave it unmodified when returning false.
+  std::memset(&dump, 0xAB, sizeof(dump));
+  const uint32_t kPoisonWord = 0xABABABABu;
+
+  EXPECT_FALSE(crash_dump_get(&dump));
+  // Output must be unchanged (we check one field as a proxy for the rest).
+  EXPECT_EQ(dump.mepc, kPoisonWord);
+}
+
+// ---------------------------------------------------------------------------
+// Suite 5: crash_dump_clear().
+// ---------------------------------------------------------------------------
+class CrashDumpClearTest : public CrashDumpTest {};
+
+TEST_F(CrashDumpClearTest, ClearInvalidatesRecord) {
+  // Write a record.
+  ExpectCsrCapture(0x4000u, 0u, 0u, 0u);
+  crash_dump_capture(kCrashDumpReasonException);
+
+  crash_dump_t dump;
+  ASSERT_TRUE(crash_dump_get(&dump));  // Verify it was written.
+
+  // Clear it.
+  crash_dump_clear();
+
+  // get() must now return false.
+  EXPECT_FALSE(crash_dump_get(&dump));
+}
+
+TEST_F(CrashDumpClearTest, DoubleClearIsIdempotent) {
+  crash_dump_clear();
+  crash_dump_clear();  // Should not crash or corrupt anything.
+  crash_dump_t dump;
+  EXPECT_FALSE(crash_dump_get(&dump));
+}
+
+// ---------------------------------------------------------------------------
+// Suite 6: Round-trip: capture → get → clear → get.
+// ---------------------------------------------------------------------------
+class CrashDumpRoundTripTest : public ::testing::Test {};
+
+TEST_F(CrashDumpRoundTripTest, RoundTrip) {
+  crash_dump_clear();
+
+  constexpr uint32_t kMepc = 0x2000'ABCD;
+  constexpr uint32_t kMcause = 0x0000'0002u;  // Illegal instruction.
+  constexpr uint32_t kMtval = 0x0000'1234u;   // Instruction word.
+  constexpr uint32_t kMstatus = 0x0000'0088u;
+
+  ExpectCsrCapture(kMepc, kMcause, kMtval, kMstatus);
+  crash_dump_capture(kCrashDumpReasonException);
+
+  // Phase 1: get returns true.
+  crash_dump_t dump1;
+  ASSERT_TRUE(crash_dump_get(&dump1));
+  EXPECT_EQ(dump1.mepc, kMepc);
+  EXPECT_EQ(dump1.mcause, kMcause);
+  EXPECT_EQ(dump1.mtval, kMtval);
+  EXPECT_EQ(dump1.mstatus, kMstatus);
+  EXPECT_EQ(dump1.reason, static_cast<uint32_t>(kCrashDumpReasonException));
+
+  // Phase 2: clear.
+  crash_dump_clear();
+
+  // Phase 3: get returns false.
+  crash_dump_t dump2;
+  EXPECT_FALSE(crash_dump_get(&dump2));
+}
+
+// ---------------------------------------------------------------------------
+// Suite 7: Primary scenario — watchdog-bite NMI captures the interrupted PC.
+//
+// This reproduces the most common field-debuggability scenario:
+//   - Firmware is stuck in an infinite loop at PC 0x2000_0050.
+//   - The AON watchdog fires a bite NMI.
+//   - The NMI handler calls crash_dump_capture(kCrashDumpReasonWatchdog).
+//   - mepc holds the PC of the looping instruction.
+//   - mcause encodes the machine NMI (bit31=1, cause=0x1f on Ibex).
+// ---------------------------------------------------------------------------
+class CrashDumpWatchdogScenario : public CrashDumpTest {};
+
+TEST_F(CrashDumpWatchdogScenario, WatchdogNmiPreservesLoopPc) {
+  // Simulated hardware state at NMI entry:
+  //   mepc    = 0x2000_0050  (PC of the looping instruction)
+  //   mcause  = 0x8000_001F  (machine NMI, Ibex watchdog bark)
+  //   mtval   = 0x0000_0000  (no auxiliary information for NMI)
+  //   mstatus = 0x0000_0088  (MPIE=1, MPP=11 i.e. was in M-mode)
+  constexpr uint32_t kLoopPc = 0x2000'0050u;
+  constexpr uint32_t kWdogNmi = 0x8000'001Fu;
+  constexpr uint32_t kNoMtval = 0x0000'0000u;
+  constexpr uint32_t kMstatus = 0x0000'0088u;
+
+  ExpectCsrCapture(kLoopPc, kWdogNmi, kNoMtval, kMstatus);
+  crash_dump_capture(kCrashDumpReasonWatchdog);
+
+  crash_dump_t dump;
+  ASSERT_TRUE(crash_dump_get(&dump))
+      << "Watchdog NMI handler must produce a valid dump";
+  EXPECT_EQ(dump.reason, static_cast<uint32_t>(kCrashDumpReasonWatchdog))
+      << "Reason code must identify a watchdog capture";
+  EXPECT_EQ(dump.mepc, kLoopPc)
+      << "mepc must hold the PC of the interrupted (looping) instruction";
+  EXPECT_EQ(dump.mcause, kWdogNmi)
+      << "mcause must encode the NMI cause";
+  EXPECT_EQ(dump.mtval, kNoMtval);
+  EXPECT_EQ(dump.mstatus, kMstatus);
+}
+
+// ---------------------------------------------------------------------------
+// Suite 8: Primary scenario — illegal-instruction exception.
+//
+//   - Firmware fetches an undefined 32-bit opcode at PC 0x2000_AB00.
+//   - Ibex raises an illegal-instruction exception.
+//   - mepc = 0x2000_AB00, mcause = 0x2 (illegal instruction),
+//     mtval = the faulting instruction word.
+// ---------------------------------------------------------------------------
+class CrashDumpExceptionScenario : public CrashDumpTest {};
+
+TEST_F(CrashDumpExceptionScenario, IllegalInstructionExceptionCapture) {
+  constexpr uint32_t kFaultPc = 0x2000'AB00u;
+  constexpr uint32_t kIllegalInstr = 0x0000'0002u;  // mcause: illegal instr.
+  constexpr uint32_t kBadInstrWord = 0xDEAD'C0DEu;  // the offending instr.
+  constexpr uint32_t kMstatus = 0x0000'1808u;
+
+  ExpectCsrCapture(kFaultPc, kIllegalInstr, kBadInstrWord, kMstatus);
+  crash_dump_capture(kCrashDumpReasonException);
+
+  crash_dump_t dump;
+  ASSERT_TRUE(crash_dump_get(&dump))
+      << "Exception handler must produce a valid dump";
+  EXPECT_EQ(dump.reason, static_cast<uint32_t>(kCrashDumpReasonException));
+  EXPECT_EQ(dump.mepc, kFaultPc)
+      << "mepc must hold the PC of the faulting instruction";
+  EXPECT_EQ(dump.mcause, kIllegalInstr)
+      << "mcause must encode 'illegal instruction'";
+  EXPECT_EQ(dump.mtval, kBadInstrWord)
+      << "mtval must hold the offending instruction word";
+}
+
+TEST_F(CrashDumpExceptionScenario, LoadAccessFaultCapture) {
+  constexpr uint32_t kFaultPc = 0x2000'10F8u;
+  constexpr uint32_t kLoadFault = 0x0000'0005u;  // mcause: load access fault.
+  constexpr uint32_t kBadAddr = 0x1000'0004u;    // address causing the fault.
+  constexpr uint32_t kMstatus = 0x0000'1808u;
+
+  ExpectCsrCapture(kFaultPc, kLoadFault, kBadAddr, kMstatus);
+  crash_dump_capture(kCrashDumpReasonException);
+
+  crash_dump_t dump;
+  ASSERT_TRUE(crash_dump_get(&dump));
+  EXPECT_EQ(dump.mcause, kLoadFault);
+  EXPECT_EQ(dump.mtval, kBadAddr)
+      << "mtval must hold the faulting load address";
+}
+
+}  // namespace
+}  // namespace crash_dump_unittest


### PR DESCRIPTION
…ptions

This commit introduces a last-gasp crash-dump utility that captures critical CPU state into Retention SRAM immediately before a watchdog- bite or unhandled-exception reset, making it available for inspection at the next boot.

## Field-Debuggability Problem

In production OpenTitan deployments, two classes of fatal events occur without leaving any recoverable trace:

  1. Watchdog bite — the AON timer fires because firmware stopped petting it (livelock, deadlock, or an infinite loop in an IRQ handler).  The reset manager resets the chip within ~10 µs of the bite.

  2. Unhandled exception — the default machine-mode trap handler is invoked for a fault (illegal instruction, load/store access fault, instruction misalign) that the application has no recovery path for.  This typically cascades into abort() and a watchdog-triggered reset.

In both cases the RISC-V CSRs that record the fault:
  - mepc    — PC of the faulting/interrupted instruction
  - mcause  — exception or interrupt cause code
  - mtval   — faulting address or offending instruction word
  - mstatus — privilege level and interrupt-enable flags

are architected to reset to implementation-defined values on reset and are therefore lost forever.  Without them, reconstructing where and why a field device died requires expensive in-circuit debugging sessions that are impractical at scale.

## Approach: Retention SRAM Crash Record

The retention SRAM is a 4 KiB memory region that:
  - Is powered by the always-on (AON) domain.
  - Persists across all non-Power-on-Reset (PoR) events, including watchdog bites and software-requested resets.
  - Is only cleared by the ROM on a true PoR (LFSR-scrambled).

Layout of the retention SRAM (from retention_sram.h):
  Offset 0x000..0x003   version (uint32_t)
  Offset 0x004..0x7FF   creator area (ROM/ROM_EXT managed)
  Offset 0x800..0xFFF   owner area (silicon owner, 512 × uint32_t)

The crash_dump_t record (24 bytes = 6 words) is placed at the end of the owner area (words 506..511).  This avoids colliding with test harness code that uses the lower owner words for reset-sequencing flags, and it grows downward as other owner fields grow upward.

## crash_dump_t Structure

  uint32_t magic    — sentinel kCrashDumpMagic (0x43524450, 'CRDP')
  uint32_t reason   — crash_dump_reason_t (Watchdog, Exception, Manual)
  uint32_t mepc     — faulting / interrupted PC
  uint32_t mcause   — exception or interrupt cause
  uint32_t mtval    — faulting address or instruction word
  uint32_t mstatus  — machine status at trap entry

The sentinel is written LAST after all payload fields, so that a partially-written record (e.g., power failure between fields) is never mistaken for a valid dump by crash_dump_get().

## API

  void crash_dump_capture(crash_dump_reason_t reason)
    — Called from NMI handler or default exception handler.
    — Reads mepc, mcause, mtval, mstatus via CSR_READ.
    — Writes the struct into retention SRAM.
    — Does NOT reset the device.

  bool crash_dump_get(crash_dump_t *out)
    — Called at boot time to retrieve the dump.
    — Returns false if magic sentinel is absent.

  void crash_dump_clear(void)
    — Erases the record after it has been logged.

## Integration Points

  Watchdog NMI handler:
    void ottf_nmi_handler(void) {
      crash_dump_capture(kCrashDumpReasonWatchdog);
    }

  Default exception handler:
    void ottf_exception_handler(void) {
      crash_dump_capture(kCrashDumpReasonException);
      abort();
    }

  Boot-time diagnostic:
    crash_dump_t dump;
    if (crash_dump_get(&dump)) {
      LOG_INFO('Last crash: pc=0x%08x cause=0x%08x', dump.mepc, dump.mcause);
      crash_dump_clear();
    }

## CSR Access

Uses the existing CSR_READ macro (sw/device/lib/base/csr.h) which:
  - On device builds: emits a single csrr instruction per CSR.
  - On host/test builds: calls mock_csr_read(), intercepted by EXPECT_CSR_READ() in unit tests.

This avoids raw asm volatile() in the source and ensures full test coverage without hardware.

## Verification

Unit test suites in crash_dump_unittest.cc (compiled with -DMOCK_CSR):

  CrashDumpCaptureTest       CSR values correctly serialised (all zeros,
                             all ones, representative values, overwrite).
  CrashDumpReasonTest        All four reason codes stored faithfully.
  CrashDumpSentinelTest      Magic sentinel present after capture.
  CrashDumpGetTest           get() returns false with no record.
  CrashDumpClearTest         clear() invalidates; double-clear is safe.
  CrashDumpRoundTripTest     capture → get → clear → get.
  CrashDumpWatchdogScenario  NMI at looping PC (mcause=0x8000001F).
  CrashDumpExceptionScenario Illegal-instruction and load-fault captures.

## C11 Freestanding Compliance

  - No VLAs.
  - No hosted headers (<string.h>, <stdlib.h>).
  - Only <stdint.h>, <stdbool.h> (freestanding subset).
  - Compiler memory barrier via __asm__ volatile("" ::: "memory").