### PR TITLE
[rom_ext] Disable and lockdown flash bank erase in rom_ext

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -627,6 +627,12 @@ void flash_ctrl_bank_erase_perms_set(hardened_bool_t enable) {
                             reg);
 }
 
+void flash_ctrl_bank_erase_disable(void) {
+  abs_mmio_write32_shadowed(kBase + FLASH_CTRL_MP_BANK_CFG_SHADOWED_REG_OFFSET,
+                            0);
+  abs_mmio_write32(kBase + FLASH_CTRL_BANK_CFG_REGWEN_REG_OFFSET, 0);
+}
+
 /**
  * Information pages that should be locked by ROM_EXT before handing over
  * execution to the first owner boot stage. See

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -608,6 +608,15 @@ void flash_ctrl_info_cfg_lock(const flash_ctrl_info_page_t *info_page);
 void flash_ctrl_bank_erase_perms_set(hardened_bool_t enable);
 
 /**
+ * Disable and lock bank erase permissions for both flash banks.
+ *
+ * This function disables bank erase and locks the configuration register.
+ * Once locked, the bank erase permissions cannot be changed until the next
+ * reset.
+ */
+void flash_ctrl_bank_erase_disable(void);
+
+/**
  * Enable execution from flash.
  *
  * Note: a ePMP region must also be configured in order to execute code in

--- a/sw/device/silicon_creator/rom_ext/e2e/lockdown/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/lockdown/BUILD
@@ -95,3 +95,20 @@ opentitan_test(
         "//sw/device/silicon_creator/lib:dbg_print",
     ],
 )
+
+opentitan_test(
+    name = "bank_erase_lockdown",
+    srcs = ["bank_erase_lockdown.c"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+    },
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:flash_ctrl",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        "//sw/device/silicon_creator/lib/drivers:rstmgr",
+    ],
+)

--- a/sw/device/silicon_creator/rom_ext/e2e/lockdown/bank_erase_lockdown.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/lockdown/bank_erase_lockdown.c
@@ -1,0 +1,70 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_alerts.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  retention_sram_t *retram = retention_sram_get();
+
+  if (bitfield_bit32_read(retram->creator.reset_reasons,
+                          kRstmgrReasonPowerOn)) {
+    LOG_INFO("Primary boot: attempting bank erase");
+
+    dif_flash_ctrl_state_t flash_ctrl;
+    CHECK_DIF_OK(dif_flash_ctrl_init_state(
+        &flash_ctrl,
+        mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
+
+    dif_flash_ctrl_transaction_t transaction = {
+        .byte_address = 0,  // Bank 0
+        .op = kDifFlashCtrlOpBankErase,
+        .partition_type = kDifFlashCtrlPartitionTypeData,
+    };
+
+    // Ignore Alert 35 (flash_ctrl_recov_err) which is expected in lockdown
+    // case.
+    CHECK_STATUS_OK(
+        ottf_alerts_ignore_alert(kTopEarlgreyAlertIdFlashCtrlRecovErr));
+
+    // Attempt to enable bank erase for Bank 0.
+    OT_DISCARD(dif_flash_ctrl_set_bank_erase_enablement(&flash_ctrl, 0,
+                                                        kDifToggleEnabled));
+
+    // Attempt to start bank erase.
+    CHECK_DIF_OK(dif_flash_ctrl_start(&flash_ctrl, transaction));
+    LOG_INFO("dif_flash_ctrl_start succeeded, waiting for operation status.");
+
+    dif_flash_ctrl_output_t out;
+    dif_result_t end_result;
+    do {
+      end_result = dif_flash_ctrl_end(&flash_ctrl, &out);
+    } while (end_result == kDifUnavailable);
+
+    if (end_result == kDifOk) {
+      LOG_INFO("Operation completed. Error status: %d.", out.operation_error);
+      CHECK(out.operation_error, "Expected operation error but it succeeded!");
+    } else {
+      LOG_INFO("dif_flash_ctrl_end failed: %d", end_result);
+      return false;
+    }
+
+    LOG_INFO("Rebooting");
+    rstmgr_reset();
+    return false;
+  }
+
+  LOG_INFO("Rebooted successfully.");
+  return true;
+}

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -545,6 +545,9 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   // Maybe advance the security version.
   HARDENED_RETURN_IF_ERROR(rom_ext_advance_secver(boot_data, self));
 
+  // Disable and lock bank erase.
+  flash_ctrl_bank_erase_disable();
+
   rom_ext_sku_init();
 
   // Fix the boot data if needed

--- a/sw/device/tests/flash_ctrl_ops_test.c
+++ b/sw/device/tests/flash_ctrl_ops_test.c
@@ -299,9 +299,6 @@ static void do_bank0_data_partition_test(void) {
  * Tests the interrupts for erase, write and read of
  * the lowest and highest (usable) page of bank 1 data partition.
  * Confirms that the written data is read back correctly.
- * The whole bank is then erased and the interrupt is checked
- * followed by confirmation that the previously written data
- * has been wiped.
  */
 static void do_bank1_data_partition_test(void) {
   uint32_t address = 0;
@@ -376,7 +373,16 @@ static void do_bank1_data_partition_test(void) {
     read_and_check_host_if(kPageSize * page_index, test_data);
     CHECK_ARRAYS_EQ(readback_data, test_data, kDataSize);
   }
+}
 
+/**
+ * Tests the bank erase operation for bank 1.
+ * Erases the entire bank and verifies that the data is cleared
+ * (all bits set to 1) by reading back from the lowest and
+ * highest usable pages.
+ */
+static void do_bank1_erase_test(void) {
+  uint32_t address = 0;
   // Erasing the whole of bank 1.
   CHECK_DIF_OK(dif_flash_ctrl_set_bank_erase_enablement(&flash_state, 1,
                                                         kDifToggleEnabled));
@@ -457,6 +463,7 @@ bool test_main(void) {
     do_info_partition_test(kFlashInfoPageIdOwnerSecret, kRandomData2);
     do_info_partition_test(kFlashInfoPageIdIsoPart, kRandomData3);
     do_bank0_data_partition_test();
+    do_bank1_erase_test();
   }
   do_bank1_data_partition_test();
 

--- a/sw/device/tests/flash_ctrl_test.c
+++ b/sw/device/tests/flash_ctrl_test.c
@@ -304,16 +304,20 @@ bool test_main(void) {
 
   LOG_INFO("flash test!");
 
-  CHECK_DIF_OK(dif_flash_ctrl_set_bank_erase_enablement(&flash, /*bank=*/0,
-                                                        kDifToggleEnabled));
-  CHECK_DIF_OK(dif_flash_ctrl_set_bank_erase_enablement(&flash, /*bank=*/1,
-                                                        kDifToggleEnabled));
   test_basic_io();
   test_memory_protection();
 
-  CHECK_DIF_OK(dif_flash_ctrl_set_bank_erase_enablement(&flash, /*bank=*/0,
-                                                        kDifToggleDisabled));
-  CHECK_DIF_OK(dif_flash_ctrl_set_bank_erase_enablement(&flash, /*bank=*/1,
-                                                        kDifToggleDisabled));
+  // ROM_EXT disables bank erase to protect active slots. Skip these bank erase
+  // tests in owner stage.
+  if (kBootStage != kBootStageOwner) {
+    CHECK_DIF_OK(dif_flash_ctrl_set_bank_erase_enablement(&flash, /*bank=*/0,
+                                                          kDifToggleEnabled));
+    CHECK_DIF_OK(dif_flash_ctrl_set_bank_erase_enablement(&flash, /*bank=*/1,
+                                                          kDifToggleEnabled));
+    CHECK_DIF_OK(dif_flash_ctrl_set_bank_erase_enablement(&flash, /*bank=*/0,
+                                                          kDifToggleDisabled));
+    CHECK_DIF_OK(dif_flash_ctrl_set_bank_erase_enablement(&flash, /*bank=*/1,
+                                                          kDifToggleDisabled));
+  }
   return true;
 }


### PR DESCRIPTION
This PR lockdown flash bank erase in the `rom_ext` to prevent erasing active firmware slots, and provides an end-to-end test to verify the implementation.