### PR TITLE
[cryptotest] Test Ed25519 Sign with Wycheproof

### DIFF
--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -176,6 +176,7 @@ cryptotest(
 
 ED25519_TESTVECTOR_TARGETS = [
     "//sw/host/cryptotest/testvectors/data:wycheproof_ed25519_json",
+    "//sw/host/cryptotest/testvectors/data:wycheproof_ed25519_sign_json",
 ]
 
 ED25519_TESTVECTOR_ARGS = " ".join([

--- a/sw/device/tests/crypto/cryptotest/firmware/ed25519.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/ed25519.c
@@ -116,16 +116,25 @@ status_t handle_ed25519(ujson_t *uj) {
 
       otcrypto_status_t status = otcrypto_ed25519_sign_verify(
           &private_key, &public_key, &message, sign_mode, &signature);
-      if (status.value != kOtcryptoStatusValueOk) {
-        return INTERNAL(status.value);
-      }
 
-      memset(uj_signature.signature, 0, ED25519_CMD_SIGNATURE_BYTES);
-      memcpy(uj_signature.signature, signature_data,
-             ED25519_CMD_SIGNATURE_BYTES);
-      uj_signature.signature_len = ED25519_CMD_SIGNATURE_BYTES;
-      RESP_OK(ujson_serialize_cryptotest_ed25519_signature_t, uj,
-              &uj_signature);
+      cryptotest_ed25519_verify_output_t uj_output;
+      switch (status.value) {
+        case kOtcryptoStatusValueOk:
+          uj_output = kCryptotestEd25519VerifyOutputSuccess;
+          break;
+        case kOtcryptoStatusValueBadArgs:
+          uj_output = kCryptotestEd25519VerifyOutputFailure;
+          break;
+        default:
+          LOG_ERROR(
+              "Unexpected status value returned from "
+              "otcrypto_ed25519_sign_verify: "
+              "0x%x",
+              status.value);
+          return INTERNAL();
+      }
+      RESP_OK(ujson_serialize_cryptotest_ed25519_verify_output_t, uj,
+              &uj_output);
       return OK_STATUS();
     }
     case kCryptotestEd25519OperationVerify: {

--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -137,6 +137,24 @@ run_binary(
     tool = "//sw/host/cryptotest/testvectors/parsers:wycheproof_ed25519_parser",
 )
 
+run_binary(
+    name = "wycheproof_ed25519_sign_json",
+    srcs = [
+        "//sw/host/cryptotest/testvectors/data/schemas:ed25519_schema.json",
+        "@wycheproof//testvectors:eddsa_test.json",
+    ],
+    outs = [":wycheproof_ed25519_sign.json"],
+    args = [
+        "--src",
+        "$(location @wycheproof//testvectors:eddsa_test.json)",
+        "--dst",
+        "$(location :wycheproof_ed25519_sign.json)",
+        "--schema",
+        "$(location //sw/host/cryptotest/testvectors/data/schemas:ed25519_schema.json)",
+    ],
+    tool = "//sw/host/cryptotest/testvectors/parsers:wycheproof_ed25519_parser",
+)
+
 # Number of tests per configuration (e.g. Verify P-256 SHA-256)
 ECDSA_RANDOM_COUNT = 128
 

--- a/sw/host/cryptotest/testvectors/data/schemas/ed25519_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/ed25519_schema.json
@@ -27,7 +27,7 @@
       "operation": {
         "description": "Ed25519 operation",
         "type": "string",
-        "enum": ["verify"]
+        "enum": ["verify", "sign"]
       },
       "message": {
         "description": "Message to be verified",
@@ -41,8 +41,12 @@
         "description": "Signature to verify",
         "$ref": "#/$defs/byte_array"
       },
+      "private_key": {
+        "description": "Private key seed for sign operation",
+        "$ref": "#/$defs/byte_array"
+      },
       "result": {
-        "description": "Verification result",
+        "description": "Expected operation result",
         "type": "boolean"
       }
     }

--- a/sw/host/cryptotest/testvectors/parsers/wycheproof_ed25519_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/wycheproof_ed25519_parser.py
@@ -14,35 +14,51 @@ def parse_test_vectors(raw_data):
     test_groups = raw_data["testGroups"]
     test_vectors = list()
     for group in test_groups:
-        # Parse the key for the group
-        key = group["publicKey"]
+        # Support both v1 format (publicKey) and v0 format (key).
+        key = group.get("publicKey") or group.get("key")
         if key["curve"] != "edwards25519":
             logging.info(f"Skipped test group: Unsupported curve type '{key['curve']}'")
             continue
 
+        private_key = list(bytes.fromhex(key["sk"])) if "sk" in key else None
+
         # Parse tests within the group
         for test in group["tests"]:
             logging.debug(f"Parsing tcId {test['tcId']}")
+
+            # Parse the expected result
+            if test["result"] == "valid":
+                result = True
+            elif test["result"] == "invalid":
+                result = False
+            elif test["result"] == "acceptable":
+                # Err on the side of caution and reject "acceptable" signatures
+                result = False
+            else:
+                raise RuntimeError(f"Unexpected result type {test['result']}")
+
             test_vec = {
                 "algorithm": "ed25519",
                 "operation": "verify",
                 "message": list(bytes.fromhex(test["msg"])),
                 "public_key": list(bytes.fromhex(key["pk"])),
                 "signature": list(bytes.fromhex(test["sig"])),
+                "result": result,
             }
-
-            # Parse the expected result
-            if test["result"] == "valid":
-                test_vec["result"] = True
-            elif test["result"] == "invalid":
-                test_vec["result"] = False
-            elif test["result"] == "acceptable":
-                # Err on the side of caution and reject "acceptable" signatures
-                test_vec["result"] = False
-            else:
-                raise RuntimeError(f"Unexpected result type {test['result']}")
-
             test_vectors.append(test_vec)
+
+            # Emit a sign test vector for every valid test that has a private key.
+            if result and private_key is not None:
+                sign_vec = {
+                    "algorithm": "ed25519",
+                    "operation": "sign",
+                    "message": list(bytes.fromhex(test["msg"])),
+                    "public_key": list(bytes.fromhex(key["pk"])),
+                    "private_key": private_key,
+                    "signature": [],
+                    "result": True,
+                }
+                test_vectors.append(sign_vec)
 
     return test_vectors
 

--- a/sw/host/tests/crypto/ed25519_kat/src/main.rs
+++ b/sw/host/tests/crypto/ed25519_kat/src/main.rs
@@ -57,13 +57,23 @@ struct Ed25519TestCase {
     operation: String,
     message: Vec<u8>,
     public_key: Vec<u8>,
+    #[serde(default)]
+    private_key: Vec<u8>,
     signature: Vec<u8>,
     result: bool,
 }
 
 // Fixed sizes defined by the Ed25519 algorithm.
 const ED25519_PUBLIC_KEY_BYTES: usize = 32;
+const ED25519_PRIVATE_KEY_SEED_BYTES: usize = 32;
 const ED25519_SIGNATURE_BYTES: usize = 64;
+
+// Fixed mask for additive sharing of the Ed25519 private key seed.
+// seed = d0 + d1 (mod 2^256). Generated randomly for testing purposes.
+const RANDOM_MASK_ED25519: [u8; ED25519_PRIVATE_KEY_SEED_BYTES] = [
+    0x7e, 0x3f, 0x8a, 0x5c, 0x12, 0xd6, 0xb4, 0x90, 0xaf, 0x7e, 0x3d, 0x81, 0xc4, 0xb2, 0x5f, 0x98,
+    0xe0, 0xa1, 0xd7, 0x3c, 0x5b, 0x2e, 0x8f, 0x4a, 0x96, 0xd0, 0xc7, 0x1b, 0x38, 0xe4, 0xf2, 0x5a,
+];
 
 fn run_ed25519_testcase(
     test_case: &Ed25519TestCase,
@@ -77,6 +87,7 @@ fn run_ed25519_testcase(
 
     let operation = match test_case.operation.as_str() {
         "verify" => CryptotestEd25519Operation::Verify,
+        "sign" => CryptotestEd25519Operation::Sign,
         _ => panic!("Unsupported Ed25519 operation: {}", test_case.operation),
     };
 
@@ -102,10 +113,12 @@ fn run_ed25519_testcase(
     }
     .send(spi_console)?;
 
-    // For verify: send the actual signature. For sign: send zeros (unused).
+    // For verify: send the actual signature (R component reversed for device byte
+    // ordering). For sign: the firmware ignores this field; send an empty buffer.
     let mut signature_bytes = test_case.signature.clone();
-    // Reverse the R component (first half of signature) for device byte ordering.
-    if signature_bytes.len() >= ED25519_SIGNATURE_BYTES / 2 {
+    if matches!(operation, CryptotestEd25519Operation::Verify)
+        && signature_bytes.len() >= ED25519_SIGNATURE_BYTES / 2
+    {
         signature_bytes[..ED25519_SIGNATURE_BYTES / 2].reverse();
     }
     CryptotestEd25519Signature {
@@ -115,7 +128,7 @@ fn run_ed25519_testcase(
     }
     .send(spi_console)?;
 
-    // For verify: send the actual public key. For sign: send zeros (unused).
+    // Public key is used by verify; firmware derives it from the private key for sign.
     CryptotestEd25519PublicKey {
         public_key: ArrayVec::try_from(test_case.public_key.as_slice())
             .expect("Ed25519 public key had unexpected length."),
@@ -123,29 +136,49 @@ fn run_ed25519_testcase(
     }
     .send(spi_console)?;
 
-    // For verify: private key is unused by the device; send empty shares.
+    // For sign: additively mask the private key seed (seed = d0 + d1 mod 2^256).
+    // For verify: the firmware ignores the private key; send empty shares.
+    let (d0_bytes, d1_bytes): (Vec<u8>, Vec<u8>) =
+        if matches!(operation, CryptotestEd25519Operation::Sign) {
+            assert_eq!(
+                test_case.private_key.len(),
+                ED25519_PRIVATE_KEY_SEED_BYTES,
+                "Ed25519 private key must be exactly {} bytes (got {})",
+                ED25519_PRIVATE_KEY_SEED_BYTES,
+                test_case.private_key.len(),
+            );
+            let seed = &test_case.private_key;
+            let d0 = RANDOM_MASK_ED25519;
+            let mut d1 = [0u8; ED25519_PRIVATE_KEY_SEED_BYTES];
+            let mut borrow: i16 = 0;
+            for i in 0..ED25519_PRIVATE_KEY_SEED_BYTES {
+                let diff = seed[i] as i16 - d0[i] as i16 - borrow;
+                d1[i] = diff as u8;
+                borrow = if diff < 0 { 1 } else { 0 };
+            }
+            (d0.to_vec(), d1.to_vec())
+        } else {
+            (vec![], vec![])
+        };
     CryptotestEd25519PrivateKey {
-        d0: ArrayVec::try_from(vec![].as_slice()).unwrap(),
-        d0_len: 0,
-        d1: ArrayVec::try_from(vec![].as_slice()).unwrap(),
-        d1_len: 0,
+        d0: ArrayVec::try_from(d0_bytes.as_slice()).unwrap(),
+        d0_len: d0_bytes.len(),
+        d1: ArrayVec::try_from(d1_bytes.as_slice()).unwrap(),
+        d1_len: d1_bytes.len(),
     }
     .send(spi_console)?;
 
     let success = match operation {
-        CryptotestEd25519Operation::Verify => {
+        CryptotestEd25519Operation::Verify | CryptotestEd25519Operation::Sign => {
             let output =
                 CryptotestEd25519VerifyOutput::recv(spi_console, opts.timeout, false, false)?;
             match output {
                 CryptotestEd25519VerifyOutput::Success => true,
                 CryptotestEd25519VerifyOutput::Failure => false,
                 CryptotestEd25519VerifyOutput::IntValue(i) => {
-                    panic!("Invalid Ed25519 verify result: {}", i)
+                    panic!("Invalid Ed25519 result: {}", i)
                 }
             }
-        }
-        CryptotestEd25519Operation::Sign => {
-            unreachable!("Sign operation not yet implemented")
         }
         CryptotestEd25519Operation::IntValue(_) => {
             unreachable!("Should be caught above")


### PR DESCRIPTION
Test the Ed25519 signature generation by:

- Reusing valid Ed25519 verify wycheproof test vectors
- The cryptolib uses the `otcrypto_ed25519_sign_verify` function to first create the signature based on the test vector data and then tries to verify it.
- The result of the verify after sign is returned to the host - we expect a success as we only feed valid test vectors into the cl