### PR TITLE
[aes/dv] Set up separate config for variants with GCM support

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -187,7 +187,7 @@ class dv_base_reg_block extends uvm_reg_block;
     end
   endfunction
 
-  function void get_shadowed_regs(ref dv_base_reg shadowed_regs[$]);
+  virtual function void get_shadowed_regs(ref dv_base_reg shadowed_regs[$]);
     dv_base_reg all_regs[$];
     this.get_dv_base_regs(all_regs);
     foreach (all_regs[i]) begin

--- a/hw/ip/aes/dv/aes_base_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_base_sim_cfg.hjson
@@ -66,13 +66,25 @@
       name: aes_unmasked
       build_opts: ["+define+EN_MASKING=0",
                    "+define+SBOX_IMPL=aes_pkg::SBoxImplCanright",
-                   "+define+EN_GCM=1"]
+                   "+define+EN_GCM=0"]
     }
     {
       name: aes_masked
-        build_opts: ["+define+EN_MASKING=1",
-                     "+define+SBOX_IMPL=aes_pkg::SBoxImplDom",
-                     "+define+EN_GCM=1"]
+      build_opts: ["+define+EN_MASKING=1",
+                   "+define+SBOX_IMPL=aes_pkg::SBoxImplDom",
+                   "+define+EN_GCM=0"]
+    }
+    {
+      name: aes_gcm_unmasked
+      build_opts: ["+define+EN_MASKING=0",
+                   "+define+SBOX_IMPL=aes_pkg::SBoxImplCanright",
+                   "+define+EN_GCM=1"]
+    }
+    {
+      name: aes_gcm_masked
+      build_opts: ["+define+EN_MASKING=1",
+                   "+define+SBOX_IMPL=aes_pkg::SBoxImplDom",
+                   "+define+EN_GCM=1"]
     }
   ]
 
@@ -115,12 +127,6 @@
       reseed: 1
     }
     {
-      name: aes_nist_vectors_gcm
-      uvm_test: aes_wake_up_test
-      uvm_test_seq: aes_nist_vectors_gcm_vseq
-      reseed: 1
-    }
-    {
       name: aes_deinit
       uvm_test: aes_deinit_test
       uvm_test_seq: aes_deinit_vseq
@@ -134,12 +140,6 @@
       name: aes_readability
       uvm_test: aes_fi_test
       uvm_test_seq: aes_readability_vseq
-    }
-    {
-      name: aes_gcm_save_restore
-      uvm_test: aes_gcm_save_restore_test
-      uvm_test_seq: aes_gcm_save_restore_vseq
-      reseed: 100
     }
     // Regular tests for which the scoreboard is active.
     {
@@ -213,12 +213,6 @@
       uvm_test: aes_fi_test
       uvm_test_seq: aes_core_fi_vseq
       reseed: 70 // Test must cover 35 bins. Overseed by 2x to get reasonable coverage.
-    }
-    {
-      name: aes_ghash_fi
-      uvm_test: aes_ghash_fi_test
-      uvm_test_seq: aes_ghash_fi_vseq
-      reseed: 90 // Test must cover 42 bins. Overseed by 2x to get reasonable coverage.
     }
     // This test runs several sequences back-to-back with random resets between the individual
     // sequences. We shouldn't need many seeds here because aes_stress is the real stress test.

--- a/hw/ip/aes/dv/aes_gcm_masked_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_gcm_masked_sim_cfg.hjson
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// sim cfg file for AES with GCM support and with masking
+{
+  // Name of the sim cfg variant
+  variant: gcm_masked
+
+  // Import the base sram_ctrl sim_cfg file
+  import_cfgs: ["{proj_root}/hw/ip/aes/dv/aes_base_sim_cfg.hjson",
+                "{proj_root}/hw/ip/aes/dv/aes_gcm_tests.hjson"]
+
+  // Coverage exclusion
+  xcelium_cov_refine_files: ["{proj_root}/hw/ip/aes/dv/cov/refines/aes_UNR.vRefine"]
+
+  // Enable the appropriate build mode for all tests
+  en_build_modes: ["aes_gcm_masked"]
+}

--- a/hw/ip/aes/dv/aes_gcm_tests.hjson
+++ b/hw/ip/aes/dv/aes_gcm_tests.hjson
@@ -1,0 +1,27 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  tests: [
+    // Directed tests for which the scoreboard is disabled.
+    {
+      name: aes_nist_vectors_gcm
+      uvm_test: aes_wake_up_test
+      uvm_test_seq: aes_nist_vectors_gcm_vseq
+      reseed: 1
+    }
+    {
+      name: aes_gcm_save_restore
+      uvm_test: aes_gcm_save_restore_test
+      uvm_test_seq: aes_gcm_save_restore_vseq
+      reseed: 100
+    }
+    // FI tests for which the scoreboard is disabled.
+    {
+      name: aes_ghash_fi
+      uvm_test: aes_ghash_fi_test
+      uvm_test_seq: aes_ghash_fi_vseq
+      reseed: 90 // Test must cover 42 bins. Overseed by 2x to get reasonable coverage.
+    }
+  ]
+}

--- a/hw/ip/aes/dv/aes_gcm_unmasked_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_gcm_unmasked_sim_cfg.hjson
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// sim cfg file for AES with GCM support but without masking
+{
+  // Name of the sim cfg variant
+  variant: gcm_unmasked
+
+  // Import the base sram_ctrl sim_cfg file
+  import_cfgs: ["{proj_root}/hw/ip/aes/dv/aes_base_sim_cfg.hjson"]
+
+  // Coverage exclusions
+  xcelium_cov_refine_files: ["{proj_root}/hw/ip/aes/dv/cov/refines/aes_UNR.vRefine",
+                             "{proj_root}/hw/ip/aes/dv/cov/refines/aes_unmasked_UNR.vRefine"]
+
+  // Enable the appropriate build mode for all tests
+  en_build_modes: ["aes_gcm_unmasked"]
+}

--- a/hw/ip/aes/dv/cov/aes_cov_if.sv
+++ b/hw/ip/aes/dv/cov/aes_cov_if.sv
@@ -384,8 +384,8 @@ interface aes_cov_if
  `DV_FCOV_INSTANTIATE_CG(aes_iv_interleave_cg, en_full_cov)
  `DV_FCOV_INSTANTIATE_CG(aes_key_interleave_cg, en_full_cov)
  `DV_FCOV_INSTANTIATE_CG(aes_reg_interleave_cg, en_full_cov)
- `DV_FCOV_INSTANTIATE_CG(aes_gcm_len_cg, en_full_cov)
- `DV_FCOV_INSTANTIATE_CG(aes_ctrl_gcm_reg_cg, en_full_cov)
+ `DV_FCOV_INSTANTIATE_CG(aes_gcm_len_cg, en_full_cov && `EN_GCM)
+ `DV_FCOV_INSTANTIATE_CG(aes_ctrl_gcm_reg_cg, en_full_cov && `EN_GCM)
 
   ///////////////////////////////////
   // Sample functions              //

--- a/hw/ip/aes/dv/cov/aes_cov_if.sv
+++ b/hw/ip/aes/dv/cov/aes_cov_if.sv
@@ -58,7 +58,7 @@ interface aes_cov_if
        bins ctr     = { AES_CTR };
        bins gcm     = { AES_GCM };
        bins none    = { AES_NONE };
-       bins illegal = { [0:$] } with ($countones(item) != 1);
+       bins illegal = { [0:$] } with (($countones(item) != 1) && (item != AES_NONE));
       }
 
     cp_key_len: coverpoint aes_keylen

--- a/hw/ip/aes/dv/env/aes_env.core
+++ b/hw/ip/aes/dv/env/aes_env.core
@@ -20,6 +20,7 @@ filesets:
       - lowrisc:dv:aes_test_vectors
     files:
       - aes_env_pkg.sv
+      - aes_ral_extension.svh: {is_include_file: true}
       - aes_seq_item.sv: {is_include_file: true}
       - aes_message_item.sv: {is_include_file: true}
       - aes_env_cfg.sv: {is_include_file: true}

--- a/hw/ip/aes/dv/env/aes_env.sv
+++ b/hw/ip/aes/dv/env/aes_env.sv
@@ -15,6 +15,7 @@ class aes_env extends cip_base_env #(
   key_sideload_agent keymgr_sideload_agent;
 
   function void build_phase(uvm_phase phase);
+    aes_reg_block::type_id::set_type_override(aes_reg_block_extended::get_type());
     super.build_phase(phase);
 
     keymgr_sideload_agent = key_sideload_agent#(keymgr_pkg::hw_key_req_t)::type_id::create(

--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -310,9 +310,11 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
         `uvm_fatal(`gfn, $sformatf("FAILED TO GET HANDLE TO ROUND COUNTER INJECT INTERFACE %d",nn))
       end
     end
-    if (!uvm_config_db#(virtual fi_ghash_if)::get(null, "*.env", "aes_ghash_fi_vif",
-                         aes_ghash_fi_vif)) begin
-      `uvm_fatal(`gfn, "FAILED TO GET HANDLE TO GHASH FAULT INJECTION INTERFACE")
+    if (`EN_GCM) begin
+      if (!uvm_config_db#(virtual fi_ghash_if)::get(null, "*.env", "aes_ghash_fi_vif",
+                           aes_ghash_fi_vif)) begin
+        `uvm_fatal(`gfn, "FAILED TO GET HANDLE TO GHASH FAULT INJECTION INTERFACE")
+      end
     end
     if (!uvm_config_db#(virtual fi_core_if)::get(null, "*.env", "aes_core_fi_vif",
                          aes_core_fi_vif)) begin

--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
+class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block_extended));
 
   `uvm_object_utils_begin(aes_env_cfg)
   `uvm_object_utils_end

--- a/hw/ip/aes/dv/env/aes_env_pkg.sv
+++ b/hw/ip/aes/dv/env/aes_env_pkg.sv
@@ -18,6 +18,8 @@ package aes_env_pkg;
   import aes_pkg::*;
   import key_sideload_agent_pkg::*;
 
+  // AES-specific RAL extension
+  `include "aes_ral_extension.svh"
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/ip/aes/dv/env/aes_ral_extension.svh
+++ b/hw/ip/aes/dv/env/aes_ral_extension.svh
@@ -1,0 +1,27 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This class inherits from the auto-generated RAL, which in turn inherits from dv_base_reg_block.
+class aes_reg_block_extended extends aes_reg_block;
+  `uvm_object_utils(aes_reg_block_extended)
+
+  function new(string name = "aes_reg_block_extended", int has_coverage = UVM_NO_COVERAGE);
+    super.new(name, has_coverage);
+  endfunction
+
+  virtual function void get_shadowed_regs(ref dv_base_reg shadowed_regs[$]);
+    // Start with the default behavior.
+    super.get_shadowed_regs(shadowed_regs);
+
+    // Remove the GCM control register from the list of shadow registers if hardware support for
+    // GCM is not enabled. In this case, the writes to the register are ignored anyway.
+    if (`EN_GCM == 0) begin
+      foreach (shadowed_regs[i]) begin
+        if (shadowed_regs[i].get_name() == "ctrl_gcm_shadowed") begin
+          shadowed_regs.delete(i);
+        end
+      end
+    end
+  endfunction
+endclass

--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -229,6 +229,10 @@ class aes_scoreboard extends cip_base_scoreboard #(
     if (get_field_val(ral.trigger.start, wdata)) begin
       if (input_item.mode != AES_GCM) begin
         ok_to_fwd = input_item.mode != AES_NONE;
+      end else if (`EN_GCM == 0) begin
+        // We have an AES-GCM item but the hardware doesn't support GCM. This item is treated like
+        // an item with mode AES_NONE.
+        ok_to_fwd = 0;
       end else begin
         // In the AES-GCM mode, when we trigger the block, GCM is in the INIT
         // phase. In this phase, the hash subkey and the encrypted initial counter
@@ -392,27 +396,32 @@ class aes_scoreboard extends cip_base_scoreboard #(
           AES_OFB,
           AES_CTR,
           AES_GCM: begin
-            `uvm_info(`gfn, $sformatf("\n\t ----| AES Mode: %0s", input_item.mode.name()),
-                UVM_MEDIUM)
-            if (input_item.start_item) begin
-              // Verify that all 4 data_in, all 8 initial key, and all 4 IV registers have been
-              // updated.
-              if (input_item.data_in_valid() && input_item.key_clean(0, 0)
-                   && input_item.iv_clean(0, 0)) begin
-                // Clone and add to ref and rec data FIFO.
-                ok_to_fwd = 1;
-                input_item.start_item = 0;
+            if (input_item.mode != AES_GCM || `EN_GCM) begin
+              `uvm_info(`gfn, $sformatf("\n\t ----| AES Mode: %0s", input_item.mode.name()),
+                  UVM_MEDIUM)
+              if (input_item.start_item) begin
+                // Verify that all 4 data_in, all 8 initial key, and all 4 IV registers have been
+                // updated.
+                if (input_item.data_in_valid() && input_item.key_clean(0, 0)
+                     && input_item.iv_clean(0, 0)) begin
+                  // Clone and add to ref and rec data FIFO.
+                  ok_to_fwd = 1;
+                  input_item.start_item = 0;
+                end
+              end else begin
+                // Verify that all 4 data_in, all 8 initial key, and all 4 IV registers are clean.
+                `uvm_info(`gfn, $sformatf("\n\t ----| data_in_vld? %b, key clean? %b, IV clean? %b",
+                    input_item.data_in_valid(), input_item.key_clean(1, 0),
+                    input_item.iv_clean(1, 0)), UVM_MEDIUM)
+                if (input_item.data_in_valid() && input_item.key_clean(1, 0)
+                     && input_item.iv_clean(1, 0)) begin
+                  // Clone and add to ref and rec data FIFO.
+                  ok_to_fwd = 1;
+                end
               end
             end else begin
-              // Verify that all 4 data_in, all 8 initial key, and all 4 IV registers are clean.
-              `uvm_info(`gfn, $sformatf("\n\t ----| data_in_vld? %b, key clean? %b, IV clean? %b",
-                  input_item.data_in_valid(), input_item.key_clean(1, 0),
-                  input_item.iv_clean(1, 0)), UVM_MEDIUM)
-              if (input_item.data_in_valid() && input_item.key_clean(1, 0)
-                   && input_item.iv_clean(1, 0)) begin
-                // Clone and add to ref and rec data FIFO.
-                ok_to_fwd = 1;
-              end
+              `uvm_info(`gfn, "\n\t ----| Received illegal AES_GCM setting, reverting to AES_NONE",
+                  UVM_MEDIUM)
             end
           end
 
@@ -713,7 +722,8 @@ class aes_scoreboard extends cip_base_scoreboard #(
       bit [3:0][31:0] out_tag;
       msg_fifo.get(msg);
 
-      if (msg.aes_mode != AES_NONE && !msg.skip_msg) begin
+      if (msg.aes_mode != AES_NONE && !msg.skip_msg &&
+          (`EN_GCM || msg.aes_mode != AES_GCM)) begin
         msg.alloc_predicted_msg();
 
         operation = msg.aes_operation == AES_ENC ? 1'b0 :
@@ -801,7 +811,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
                 cfg.good_cnt, msg.aes_mode.name()), UVM_MEDIUM)
         cfg.good_cnt++;
 
-        if (input_item.mode == AES_GCM) begin
+        if (msg.aes_mode == AES_GCM) begin
           // As the message and tag matched the predicted output, sample AAD &
           // message length as well as the mode of operation.
           int msg_blocks = msg.message_length / 16;
@@ -827,6 +837,12 @@ class aes_scoreboard extends cip_base_scoreboard #(
               $sformatf("\n\t ----| MESSAGE #%0d was skipped due to start triggered prematurely",
                   cfg.good_cnt), UVM_MEDIUM)
           cfg.skipped_cnt++;
+        end
+        if ((`EN_GCM == 0) && (msg.aes_mode == AES_GCM)) begin
+          `uvm_info(`gfn,
+              $sformatf("\n\t ----| MESSAGE #%0d HAS ILLEGAL MODE MESSAGE IGNORED     |-----",
+                  cfg.good_cnt), UVM_MEDIUM)
+          cfg.corrupt_cnt++;
         end
       end
     end

--- a/hw/ip/aes/dv/env/aes_seq_item.sv
+++ b/hw/ip/aes/dv/env/aes_seq_item.sv
@@ -84,8 +84,10 @@ class aes_seq_item extends uvm_sequence_item;
   // bit to select if we clear 1 or more regs
   rand int                          clr_reg_dist_select;
 
-  // this is only used to program dut in illegal mode
+  // AES mode setting used to test illegal mode settings. This is used e.g. in the aes_config_error
+  // test.
   rand bit [$bits(aes_mode_e) -1:0] aes_mode;
+  rand bit                          aes_illegal_mode_gcm;
 
   // clear reg vector
   // [3] output data
@@ -94,10 +96,30 @@ class aes_seq_item extends uvm_sequence_item;
   // [0] key
   rand clear_t                      clear_reg;
 
+  constraint aes_illegal_mode_gcm_c {
+    if (`EN_GCM) {
+      // If the hardware supports GCM, AES_GCM is not an illegal mode setting and we should not use
+      // this to test the DUT's behavior in case of illegal mode settings.
+      aes_illegal_mode_gcm == 0;
+    } else {
+      // If the hardware does NOT support GCM, we should randomly select AES_GCM or any of the
+      // non-one-hot settings.
+      aes_illegal_mode_gcm dist { 0 := 4,
+                                  1 := 1};
+    }
+  }
+
   constraint aes_mode_c {
-   // force to be !onehot
+    solve aes_illegal_mode_gcm before aes_mode;
     if (mode == AES_NONE) {
-      !($countones(aes_mode) == 1);
+      // Enforce an illegal value. This includes values with multiple or no bits set as well as the
+      // value AES_GCM if support for GCM is not enabled. All these should be resolved to AES_NONE
+      // by the hardware.
+      if (aes_illegal_mode_gcm) {
+         aes_mode == AES_GCM;
+      } else {
+        $countones(aes_mode) != 1;
+      }
     } else {
       aes_mode == mode;
     }

--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -66,6 +66,7 @@ class aes_base_vseq extends cip_base_vseq #(
     aes_ctrl[7:2]  = aes_pkg::AES_ECB;   // 6'b00_0001
     aes_ctrl[10:8] = aes_pkg::AES_128;   // 3'b001
     csr_wr(.ptr(ral.ctrl_shadowed), .value(aes_ctrl), .en_shadow_wr(1'b1), .blocking(1));
+    csr_spinwait(.ptr(ral.status.idle), .exp_data(1'b1));
     csr_rd(.ptr(ral.ctrl_shadowed), .value(aes_ctrl), .blocking(1));
     // Write auxiliary control register and make sure the update went through, i.e., the register
     // isn't locked already.

--- a/hw/ip/aes/dv/env/seq_lib/aes_fi_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_fi_vseq.sv
@@ -17,14 +17,23 @@ class aes_fi_vseq extends aes_base_vseq;
   bit  wait_for_alert_clear = 0;
   bit  alert = 0;
 
-  typedef enum int { main_fsm = 0, cipher_fsm = 1, ctr_fsm = 2, ghash_fsm = 3} fi_t;
+  typedef enum int {
+    main_fsm   = 0,
+    cipher_fsm = 1,
+    ctr_fsm    = 2,
+    ghash_fsm  = 3
+  } fi_t;
 
   localparam bit FORCE   = 0;
   localparam bit RELEASE = 1;
 
   rand bit [StateWidth-1:0] force_state;
   rand int                  if_num;
-  rand fi_t fi_target;
+  rand fi_t                 fi_target;
+  constraint fi_target_c {fi_target dist { main_fsm   := 1,
+                                           cipher_fsm := 1,
+                                           ctr_fsm    := 1,
+                                           ghash_fsm  := `EN_GCM ? 1 : 0};}
 
   task body();
     `uvm_info(`gfn, $sformatf("\n\n\t ----| STARTING AES MAIN SEQUENCE |----\n %s",

--- a/hw/ip/aes/dv/tests/aes_alert_reset_test.sv
+++ b/hw/ip/aes/dv/tests/aes_alert_reset_test.sv
@@ -25,7 +25,7 @@ class aes_alert_reset_test extends aes_base_test;
     cfg.ctr_weight               = 10;
     cfg.ofb_weight               = 10;
     cfg.cfb_weight               = 10;
-    cfg.gcm_weight               = 10;
+    cfg.gcm_weight               = `EN_GCM ? 10 : 0;
 
     cfg.message_len_min          = 7;    // one block (16bytes=128bits)
     cfg.message_len_max          = 300;

--- a/hw/ip/aes/dv/tests/aes_b2b_test.sv
+++ b/hw/ip/aes/dv/tests/aes_b2b_test.sv
@@ -26,7 +26,7 @@ class aes_b2b_test extends aes_base_test;
     cfg.ctr_weight               = 10;
     cfg.ofb_weight               = 10;
     cfg.cfb_weight               = 10;
-    cfg.gcm_weight               = 10;
+    cfg.gcm_weight               = `EN_GCM ? 10 : 0;
 
     cfg.message_len_min          = 7;    // bytes
     cfg.message_len_max          = 1023; // bytes

--- a/hw/ip/aes/dv/tests/aes_base_test.sv
+++ b/hw/ip/aes/dv/tests/aes_base_test.sv
@@ -54,7 +54,7 @@ class aes_base_test extends cip_base_test #(
     cfg.ofb_weight                 = 10;
     cfg.cfb_weight                 = 10;
     cfg.ctr_weight                 = 10;
-    cfg.gcm_weight                 = 10;
+    cfg.gcm_weight                 = `EN_GCM ? 10 : 0;
 
   // KEYLEN weights
   // change of selecting 128b key

--- a/hw/ip/aes/dv/tests/aes_clear_test.sv
+++ b/hw/ip/aes/dv/tests/aes_clear_test.sv
@@ -25,7 +25,7 @@ class aes_clear_test extends aes_base_test;
     cfg.ctr_weight               = 10;
     cfg.ofb_weight               = 10;
     cfg.cfb_weight               = 10;
-    cfg.gcm_weight               = 10;
+    cfg.gcm_weight               = `EN_GCM ? 10 : 0;
 
     cfg.message_len_min          = 17;
     cfg.message_len_max          = 128;

--- a/hw/ip/aes/dv/tests/aes_config_error_test.sv
+++ b/hw/ip/aes/dv/tests/aes_config_error_test.sv
@@ -31,7 +31,7 @@ class aes_config_error_test extends aes_base_test;
     cfg.ctr_weight               = 10;
     cfg.ofb_weight               = 10;
     cfg.cfb_weight               = 10;
-    cfg.gcm_weight               = 10;
+    cfg.gcm_weight               = `EN_GCM ? 10 : 0;
 
     cfg.message_len_min          = 16;    // one block (16bytes=128bits)
     cfg.message_len_max          = 32;    //

--- a/hw/ip/aes/dv/tests/aes_deinit_test.sv
+++ b/hw/ip/aes/dv/tests/aes_deinit_test.sv
@@ -26,7 +26,7 @@ class aes_deinit_test extends aes_base_test;
     cfg.ctr_weight               = 10;
     cfg.ofb_weight               = 10;
     cfg.cfb_weight               = 10;
-    cfg.gcm_weight               = 10;
+    cfg.gcm_weight               = `EN_GCM ? 10 : 0;
 
     cfg.message_len_min          = 16;   // one block (16bytes=128bits)
     cfg.message_len_max          = 128;  //

--- a/hw/ip/aes/dv/tests/aes_fi_test.sv
+++ b/hw/ip/aes/dv/tests/aes_fi_test.sv
@@ -26,7 +26,7 @@ class aes_fi_test extends aes_base_test;
     cfg.ofb_weight               = 5;
     cfg.cfb_weight               = 5;
     cfg.ctr_weight               = 75;
-    cfg.gcm_weight               = 5;
+    cfg.gcm_weight               = `EN_GCM ? 5 : 0;
 
     cfg.message_len_min          = 1;    // one block (16bytes=128bits)
     cfg.message_len_max          = 65;

--- a/hw/ip/aes/dv/tests/aes_manual_config_err_test.sv
+++ b/hw/ip/aes/dv/tests/aes_manual_config_err_test.sv
@@ -34,7 +34,7 @@ class aes_manual_config_err_test extends aes_base_test;
     cfg.ctr_weight               = 10;
     cfg.ofb_weight               = 10;
     cfg.cfb_weight               = 10;
-    cfg.gcm_weight               = 10;
+    cfg.gcm_weight               = `EN_GCM ? 10 : 0;
 
     cfg.message_len_min          = 16;
     cfg.message_len_max          = 128;

--- a/hw/ip/aes/dv/tests/aes_reseed_test.sv
+++ b/hw/ip/aes/dv/tests/aes_reseed_test.sv
@@ -25,7 +25,7 @@ class aes_reseed_test extends aes_base_test;
     cfg.ctr_weight               = 10;
     cfg.ofb_weight               = 10;
     cfg.cfb_weight               = 10;
-    cfg.gcm_weight               = 10;
+    cfg.gcm_weight               = `EN_GCM ? 10 : 0;
 
     cfg.message_len_min          = 7;    // bytes
     cfg.message_len_max          = 1023; // bytes

--- a/hw/ip/aes/dv/tests/aes_sideload_test.sv
+++ b/hw/ip/aes/dv/tests/aes_sideload_test.sv
@@ -24,7 +24,7 @@ class aes_sideload_test extends aes_base_test;
     cfg.ctr_weight               = 10;
     cfg.ofb_weight               = 10;
     cfg.cfb_weight               = 10;
-    cfg.gcm_weight               = 10;
+    cfg.gcm_weight               = `EN_GCM ? 10 : 0;
 
     cfg.message_len_min          = 16;    // one block (16bytes=128bits)
     cfg.message_len_max          = 128;   //

--- a/hw/ip/aes/dv/tests/aes_smoke_test.sv
+++ b/hw/ip/aes/dv/tests/aes_smoke_test.sv
@@ -24,7 +24,7 @@ class aes_smoke_test extends aes_base_test;
     cfg.ctr_weight               = 10;
     cfg.ofb_weight               = 10;
     cfg.cfb_weight               = 10;
-    cfg.gcm_weight               = 10;
+    cfg.gcm_weight               = `EN_GCM ? 10 : 0;
 
     cfg.message_len_min          = 16;    // one block (16bytes=128bits)
     cfg.message_len_max          = 32;    //

--- a/hw/ip/aes/dv/tests/aes_stress_test.sv
+++ b/hw/ip/aes/dv/tests/aes_stress_test.sv
@@ -29,7 +29,7 @@ class aes_stress_test extends aes_base_test;
     cfg.ctr_weight               = 10;
     cfg.ofb_weight               = 10;
     cfg.cfb_weight               = 10;
-    cfg.gcm_weight               = 10;
+    cfg.gcm_weight               = `EN_GCM ? 10 : 0;
 
     cfg.message_len_min          = 7;    // bytes
     cfg.message_len_max          = 1023; // bytes

--- a/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
+++ b/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
@@ -19,8 +19,8 @@
              // Unit tests for UVCs.
              "{proj_root}/hw/dv/sv/tl_agent/dv/tl_agent_sim_cfg.hjson",
              // IPs.
-             "{proj_root}/hw/ip/aes/dv/aes_unmasked_sim_cfg.hjson",
-             "{proj_root}/hw/ip/aes/dv/aes_masked_sim_cfg.hjson",
+             "{proj_root}/hw/ip/aes/dv/aes_gcm_unmasked_sim_cfg.hjson",
+             "{proj_root}/hw/ip/aes/dv/aes_gcm_masked_sim_cfg.hjson",
              "{proj_root}/hw/ip/aon_timer/dv/aon_timer_sim_cfg.hjson",
              "{proj_root}/hw/ip/csrng/dv/csrng_sim_cfg.hjson",
              "{proj_root}/hw/ip/dma/dv/dma_sim_cfg.hjson",


### PR DESCRIPTION
This PR contains a couple of commits to enable running the block level DV for the AES configuration with GCM hardware support (currently used in Darjeeling) and the one without GCM hardware support (currently used in Earl Grey).

This is required to sign-off the AES block back at D2S/V2S following the upstreaming of the GCM feature. I am doing this now to unblock other DV work and simplify the sign-off work.

I am currently running coverage regressions with this PR and will post the results in a separate message.

