### PR TITLE
[csrng,dv] Fix instantiation of test in tb

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_test.sv
+++ b/hw/dv/sv/dv_lib/dv_base_test.sv
@@ -69,7 +69,7 @@ class dv_base_test #(type CFG_T = dv_base_env_cfg,
                    $sformatf("Failed to cast object of type %p to expected CFG_T class.", cfg_type))
       end
 
-      cfg.initialize();
+      initialize_env_cfg();
     end
 
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
@@ -98,6 +98,17 @@ class dv_base_test #(type CFG_T = dv_base_env_cfg,
     uvm_config_db#(CFG_T)::set(this, "*", "cfg", cfg);
 
   endfunction : build_phase
+
+  // Initialize an env_cfg that has been created in build_phase
+  //
+  // This virtual function allows classes that extend dv_base_test to configure the env_cfg before
+  // or after calling dv_base_test::initialize_env_cfg (which calls initialize on the cfg object).
+  //
+  // The function is not called for cfg objects that are supplied through uvm_config_db (since they
+  // are assumed to have been initialized in the testbench already).
+  virtual function void initialize_env_cfg();
+    cfg.initialize();
+  endfunction
 
   virtual function void end_of_elaboration_phase(uvm_phase phase);
     super.end_of_elaboration_phase(phase);

--- a/hw/ip/csrng/dv/README.md
+++ b/hw/ip/csrng/dv/README.md
@@ -36,13 +36,6 @@ The following utilities provide generic helper tasks and functions to perform ac
 * [dv_utils_pkg](../../../dv/sv/dv_utils/README.md)
 * [csr_utils_pkg](../../../dv/sv/csr_utils/README.md)
 
-### Global types & methods
-All common types and methods defined at the package level can be found in
-`csrng_env_pkg`. Some of them in use are:
-```systemverilog
-parameter uint NUM_HW_APPS = 2;
-```
-
 ### TL_agent
 CSRNG testbench instantiates (already handled in CIP base env) [tl_agent](../../../dv/sv/tl_agent/README.md)
 which provides the ability to drive and independently monitor random traffic via

--- a/hw/ip/csrng/dv/cov/csrng_cov_if.sv
+++ b/hw/ip/csrng/dv/cov/csrng_cov_if.sv
@@ -7,7 +7,6 @@
 interface csrng_cov_if (
   input logic clk_i
 );
-
   import uvm_pkg::*;
   import dv_utils_pkg::*;
   import csrng_pkg::*;
@@ -15,6 +14,15 @@ interface csrng_cov_if (
   import csrng_env_pkg::*;
   import prim_mubi_pkg::*;
   `include "dv_fcov_macros.svh"
+
+  // The maximum number of HW apps that the types in this interface can support.
+  localparam int unsigned MaxNumHwApps = 4;
+
+  // A bitmask of HW apps (of width governed by the MaxNumHwApps localparam)
+  typedef bit [MaxNumHwApps-1:0] app_mask_t;
+
+  // A queue of app_mask_t items (given a named type so that it can be returned by a function)
+  typedef app_mask_t app_mask_queue_t[$];
 
   bit en_full_cov = 1'b1;
   bit en_intg_cov = 1'b1;
@@ -195,15 +203,26 @@ interface csrng_cov_if (
     sw_app_read_sw_app_enable_cross: cross cp_sw_app_read, cp_sw_app_enable;
   endgroup : csrng_cfg_cg
 
-  covergroup csrng_sts_cg with function sample();
+  // Return a queue of masks that gives all the masks with just a single bit set, with num_hw_apps
+  // apps.
+  function automatic app_mask_queue_t single_masks(int unsigned num_hw_apps);
+    app_mask_queue_t ret;
+    for (int i = 0; i < num_hw_apps; i++) begin
+      ret.push_back(1 << i);
+    end
+    return ret;
+  endfunction
+
+  covergroup csrng_sts_cg (int unsigned num_hw_apps) with function sample();
     option.name         = "csrng_sts_cg";
     option.per_instance = 1;
 
-    cp_hw_inst_exc: coverpoint u_reg.hw_exc_sts_qs[NUM_HW_APPS-1:0] {
-      bins no_exc  = { 0 };
-      bins hw0_exc = { 1 };
-      bins hw1_exc = { 2 };
-      bins sim_exc = { 3 }; // simultaneous exception on both HW app interfaces
+    cp_hw_inst_exc: coverpoint u_reg.hw_exc_sts_qs[MaxNumHwApps-1:0] {
+      bins no_exc       = { '0 };
+      // A bin for an exception on each HW app interface
+      bins single_exc[] = single_masks(num_hw_apps);
+      // Simultaneous exception on all HW app interfaces
+      bins all_exc      = { (1 << num_hw_apps) - 1 };
     }
 
     cp_sw_cmd_sts_cmd_rdy: coverpoint u_reg.sw_cmd_sts_cmd_rdy_qs {
@@ -278,13 +297,12 @@ interface csrng_cov_if (
     cp_recov_alert_sts: coverpoint recov_alert;
   endgroup : csrng_recov_alert_sts_cg
 
-  covergroup csrng_cmds_cg with function sample(bit [NUM_HW_APPS-1:0] app,
-                                                acmd_e                acmd,
-                                                bit [3:0]             clen,
-                                                bit [3:0]             flags,
-                                                bit [11:0]            glen,
-                                                bit [1:0]             flags_transition
-                                               );
+  covergroup csrng_cmds_cg with function sample(bit [MaxNumHwApps-1:0] app,
+                                                acmd_e                 acmd,
+                                                bit [3:0]              clen,
+                                                bit [3:0]              flags,
+                                                bit [11:0]             glen,
+                                                bit [1:0]              flags_transition);
     option.name         = "csrng_cmds_cg";
     option.per_instance = 1;
 
@@ -566,7 +584,6 @@ interface csrng_cov_if (
   `DV_FCOV_INSTANTIATE_CG(csrng_sfifo_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(csrng_cfg_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(csrng_cmds_cg, en_full_cov)
-  `DV_FCOV_INSTANTIATE_CG(csrng_sts_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(csrng_err_code_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(csrng_err_code_test_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(csrng_recov_alert_sts_cg, en_full_cov)
@@ -574,6 +591,22 @@ interface csrng_cov_if (
   `DV_FCOV_INSTANTIATE_CG(csrng_genbits_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(csrng_state_db_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(csrng_es_sample_cg, en_full_cov)
+  csrng_sts_cg csrng_sts_cg_inst;
+
+  initial begin
+    // Use an upwards hierarcical reference to the csrng module into which we are bound and pick up
+    // its NumHwApps localparam
+    automatic int unsigned num_hw_apps = csrng.NumHwApps;
+
+    if (num_hw_apps > MaxNumHwApps) begin
+      `uvm_error($sformatf("%m"),
+                 $sformatf({"Interface bound into a csrng instance with NumHwApps = %0d, ",
+                            "but the interface only supports up to %0d HW apps."},
+                           num_hw_apps, MaxNumHwApps))
+    end
+
+    csrng_sts_cg_inst = new(num_hw_apps);
+  end
 
   // Sample functions needed for xcelium
   function automatic void cg_cfg_sample(csrng_env_cfg cfg);
@@ -586,9 +619,9 @@ interface csrng_cov_if (
                             );
   endfunction
 
-  function automatic void cg_cmds_sample(bit [NUM_HW_APPS-1:0] hwapp,
-                                         csrng_item cs_item,
-                                         mubi4_t flags_previous);
+  function automatic void cg_cmds_sample(bit [MaxNumHwApps-1:0] hwapp,
+                                         csrng_item             cs_item,
+                                         mubi4_t                flags_previous);
     bit flags_previous_bit = (flags_previous == MuBi4True) ? 1'b1 : 1'b0;
     bit flags_current_bit = (cs_item.flags == MuBi4True) ? 1'b1 : 1'b0;
     csrng_cmds_cg_inst.sample(hwapp,

--- a/hw/ip/csrng/dv/env/csrng_env.sv
+++ b/hw/ip/csrng/dv/env/csrng_env.sv
@@ -12,13 +12,19 @@ class csrng_env extends cip_base_env #(
 
   push_pull_agent#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))
       m_entropy_src_agent;
-  csrng_agent
-      m_edn_agent[NUM_HW_APPS];
+
+  // A CSRNG agent for each HW app
+  csrng_agent m_edn_agent[$];
 
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
+
+    // Construct an array of null sequencers inside the virtual sequencer (which was created in
+    // dv_base_env::build_phase). If active, these will be connected to real sequencers in
+    // connect_phase.
+    virtual_sequencer.edn_sequencer_h = new[cfg.m_num_hw_apps]('{default: null});
 
     // create components
     m_entropy_src_agent = push_pull_agent#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))
@@ -29,13 +35,17 @@ class csrng_env extends cip_base_env #(
     cfg.m_entropy_src_agent_cfg.if_mode    = dv_utils_pkg::Device;
     cfg.m_entropy_src_agent_cfg.en_cov     = cfg.en_cov;
 
-    for (int i = 0; i < NUM_HW_APPS; i++) begin
+    for (int i = 0; i < cfg.m_num_hw_apps; i++) begin
       string edn_agent_name = $sformatf("m_edn_agent[%0d]", i);
-      m_edn_agent[i] = csrng_agent::type_id::create(edn_agent_name, this);
-      uvm_config_db#(csrng_agent_cfg)::set(this, $sformatf("%0s*", edn_agent_name), "cfg",
-          cfg.m_edn_agent_cfg[i]);
+      csrng_agent edn_agent = csrng_agent::type_id::create(edn_agent_name, this);
+      m_edn_agent.push_back(edn_agent);
+
       cfg.m_edn_agent_cfg[i].if_mode = dv_utils_pkg::Host;
       cfg.m_edn_agent_cfg[i].en_cov  = cfg.en_cov;
+      uvm_config_db#(csrng_agent_cfg)::set(this,
+                                           $sformatf("%0s*", edn_agent_name),
+                                           "cfg",
+                                           cfg.m_edn_agent_cfg[i]);
     end
 
     if (!uvm_config_db#(virtual pins_if#(MuBi8Width))::get(this, "", "otp_en_cs_sw_app_read_vif",
@@ -65,16 +75,17 @@ class csrng_env extends cip_base_env #(
     if (cfg.en_scb) begin
       m_entropy_src_agent.monitor.analysis_port.connect(
         scoreboard.entropy_src_fifo.analysis_export);
-      for (int i = 0; i < NUM_HW_APPS; i++) begin
+      for (int i = 0; i < cfg.m_num_hw_apps; i++) begin
         m_edn_agent[i].monitor.analysis_port.connect(scoreboard.csrng_cmd_fifo[i].analysis_export);
       end
     end
     if (cfg.is_active) begin
       if (cfg.m_entropy_src_agent_cfg.is_active)
         virtual_sequencer.entropy_src_sequencer_h = m_entropy_src_agent.sequencer;
-      for (int i = 0; i < NUM_HW_APPS; i++) begin
-        if (cfg.m_edn_agent_cfg[i].is_active)
-          virtual_sequencer.edn_sequencer_h[i] = m_edn_agent[i].sequencer;
+      for (int i = 0; i < cfg.m_num_hw_apps; i++) begin
+        virtual_sequencer.edn_sequencer_h[i] = cfg.m_edn_agent_cfg[i].is_active ?
+                                               m_edn_agent[i].sequencer :
+                                               null;
       end
     end
   endfunction

--- a/hw/ip/csrng/dv/env/csrng_env_cfg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_cfg.sv
@@ -7,12 +7,25 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   `uvm_object_utils_begin(csrng_env_cfg)
   `uvm_object_utils_end
 
-  `uvm_object_new
+  typedef push_pull_agent_cfg#(.HostDataWidth(FIPS_CSRNG_BUS_WIDTH)) entropy_src_agent_cfg_t;
 
-  // ext component cfgs
-  rand push_pull_agent_cfg#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))
-                                                 m_entropy_src_agent_cfg;
-  rand csrng_agent_cfg                           m_edn_agent_cfg[NUM_HW_APPS];
+  // The number of HW apps.
+  //
+  // This is set by the test in its build_phase calling set_num_hw_apps(), which should be done
+  // before randomising this object.
+  int unsigned m_num_hw_apps;
+
+  // The total number of apps.
+  //
+  // This is set by the test in its build_phase calling set_num_hw_apps(), which should be done
+  // before randomising this object.
+  int unsigned m_num_apps;
+
+  rand entropy_src_agent_cfg_t m_entropy_src_agent_cfg;
+
+  // A CSRNG agent config for each HW application. These are created by the test calling
+  // set_num_hw_apps.
+  rand csrng_agent_cfg m_edn_agent_cfg[$];
 
   virtual pins_if#(MuBi8Width)   otp_en_cs_sw_app_read_vif;
   virtual pins_if#(MuBi4Width)   lc_hw_debug_en_vif;
@@ -38,7 +51,10 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
 
   bit    use_invalid_mubi;
 
-  rand bit       check_int_state, regwen, hw_app[NUM_HW_APPS], sw_app;
+  rand bit                    check_int_state, regwen;
+  rand bit [MaxNumHwApps-1:0] hw_app;
+  rand bit                    sw_app;
+
   rand mubi4_t   enable, sw_app_enable, read_int_state, fips_force_enable;
   rand bit [2:0] fips_force;
   rand bit [3:0] lc_hw_debug_en;
@@ -55,13 +71,11 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   rand which_cnt_e      which_cnt;
   rand which_aes_cm_e   which_aes_cm;
 
-  bit                                    compliance[NUM_HW_APPS + 1], status[NUM_HW_APPS + 1];
-  bit [csrng_env_pkg::KEY_LEN-1:0]       key[NUM_HW_APPS + 1];
-  bit [csrng_env_pkg::BLOCK_LEN-1:0]     v[NUM_HW_APPS + 1];
-  bit [csrng_env_pkg::RSD_CTR_LEN-1:0]   reseed_counter[NUM_HW_APPS + 1];
+  bit                                    compliance[MaxNumHwApps + 1], status[MaxNumHwApps + 1];
+  bit [csrng_env_pkg::KEY_LEN-1:0]       key[MaxNumHwApps + 1];
+  bit [csrng_env_pkg::BLOCK_LEN-1:0]     v[MaxNumHwApps + 1];
+  bit [csrng_env_pkg::RSD_CTR_LEN-1:0]   reseed_counter[MaxNumHwApps + 1];
 
-  int NHwApps = NUM_HW_APPS;
-  int NApps = NHwApps + 1;
   int Sp2VWidth = 3;
 
   rand csrng_pkg::acmd_e which_cmd_inv_seq;
@@ -74,7 +88,7 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   constraint  reseed_interval_c { reseed_interval inside {[1:10]};}
 
   rand uint   which_app_err_alert;
-  constraint  which_app_err_alert_c { which_app_err_alert inside {[0:NApps-1]};}
+  constraint  which_app_err_alert_c { which_app_err_alert inside {[0:m_num_apps-1]};}
 
   rand acmd_e which_cmd_alert;
   constraint  which_cmd_alert_c { which_cmd_alert inside {INS, GEN, RES};}
@@ -83,7 +97,7 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   constraint  max_reseed_count_c { max_reseed_count inside {[0:100]};}
 
   rand uint   which_hw_inst_exc;
-  constraint  which_hw_inst_exc_c { which_hw_inst_exc inside {[0:NHwApps-1]};}
+  constraint  which_hw_inst_exc_c { which_hw_inst_exc inside {[0:m_num_hw_apps-1]};}
 
   rand uint   which_sp2v;
   constraint  which_sp2v_c { which_sp2v inside {[0:Sp2VWidth-1]};}
@@ -130,6 +144,9 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
                                            int_state_read_enable[i] dist {
                                            1'b1 :/ int_state_read_enable_pct,
                                            1'b0 :/ (100 - int_state_read_enable_pct) };}
+
+  // The bits in hw_app should only be set if they correspond to an actual HW app
+  constraint hw_app_c { (hw_app >> m_num_hw_apps) == 0; }
 
   // Behind the aes_cipher_sm_err error code, there are which_aes_cm.num() countermeasures each of
   // which can be stimulated by forcing the Sp2VWidth independent logic rails. We bias error
@@ -202,6 +219,22 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
     enable_csrng_before_edn_clks <= max_enable_csrng_before_edn_clks;
   }
 
+  function new (string name="");
+    super.new(name);
+  endfunction
+
+  // Set the number of HW apps (stored in m_num_hw_apps) and create associated objects
+  function void set_num_hw_apps(int unsigned num_hw_apps);
+    if (num_hw_apps > MaxNumHwApps) begin
+      `uvm_fatal(get_name(),
+                 $sformatf("Cannot set num_hw_apps = %0d because MaxNumHwApps is %0d.",
+                           num_hw_apps, MaxNumHwApps))
+    end
+
+    m_num_hw_apps = num_hw_apps;
+    m_num_apps    = num_hw_apps + 1;
+  endfunction
+
   // Re-randomize enable and disable delays.  This is intended to be called between iterations in
   // tests that disable and re-enable CSRNG (and the agents).
   function automatic void randomize_disable_enable_clks();
@@ -231,15 +264,22 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   endfunction // post_randomize
 
   virtual function void initialize();
+    if (!m_num_hw_apps) begin
+      `uvm_fatal(get_name(),
+                 "Cannot initialize cfg without any HW apps. Call set_num_hw_apps first.")
+    end
+
     list_of_alerts = csrng_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_alert";
+
     super.initialize();
 
     // create agent configs
     m_entropy_src_agent_cfg = push_pull_agent_cfg#(.HostDataWidth(entropy_src_pkg::
                               FIPS_CSRNG_BUS_WIDTH))::type_id::create("m_entropy_src_agent_cfg");
-    for (int i = 0; i < NUM_HW_APPS; i++) begin
-      m_edn_agent_cfg[i] = csrng_agent_cfg::type_id::create($sformatf("m_edn_agent_cfg[%0d]", i));
+    for (int i = 0; i < m_num_hw_apps; i++) begin
+      string cfg_name = $sformatf("m_edn_agent_cfg[%0d]", i);
+      m_edn_agent_cfg.push_back(csrng_agent_cfg::type_id::create(cfg_name));
     end
 
     // set num_interrupts & num_alerts

--- a/hw/ip/csrng/dv/env/csrng_env_pkg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_pkg.sv
@@ -24,6 +24,9 @@ package csrng_env_pkg;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
+  // The maximum number of HW apps supported by the environment
+  parameter int unsigned MaxNumHwApps = 4;
+
   // parameters
   parameter uint     NUM_HW_APPS                = 2;
   parameter uint     HW_APP0                    = 0;

--- a/hw/ip/csrng/dv/env/csrng_env_pkg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_pkg.sv
@@ -28,7 +28,6 @@ package csrng_env_pkg;
   parameter int unsigned MaxNumHwApps = 4;
 
   // parameters
-  parameter uint     NUM_HW_APPS                = 2;
   parameter uint     HW_APP0                    = 0;
   parameter uint     HW_APP1                    = 1;
   parameter uint     SW_APP                     = 2;

--- a/hw/ip/csrng/dv/env/csrng_scoreboard.sv
+++ b/hw/ip/csrng/dv/env/csrng_scoreboard.sv
@@ -9,40 +9,51 @@ class csrng_scoreboard extends cip_base_scoreboard #(
   );
   `uvm_component_utils(csrng_scoreboard)
 
-  csrng_item                                              cs_item[NUM_HW_APPS + 1];
-  push_pull_item#(.HostDataWidth(FIPS_CSRNG_BUS_WIDTH))   es_item[NUM_HW_APPS + 1],
-                                                          es_item_q[NUM_HW_APPS + 1][$];
+  csrng_item                                              cs_item[];
+  push_pull_item#(.HostDataWidth(FIPS_CSRNG_BUS_WIDTH))   es_item[],
+                                                          es_item_q[][$];
   uint                                                    more_cmd_data;
   bit [TL_DW-1:0]                                         hw_genbits_reg_q[$];
   bit [GENBITS_BUS_WIDTH-1:0]                             hw_genbits,
-                                                          prd_genbits_q[NUM_HW_APPS + 1][$];
-  bit [CSRNG_BUS_WIDTH-1:0]                               cs_data[NUM_HW_APPS + 1],
-                                                          es_data[NUM_HW_APPS + 1];
-  bit                                                     fips[NUM_HW_APPS + 1];
+                                                          prd_genbits_q[][$];
+  bit [CSRNG_BUS_WIDTH-1:0]                               cs_data[],
+                                                          es_data[];
+  bit                                                     fips[];
+
   // Sample interrupt pins at read data phase. This is used to compare with intr_state read value.
   bit [3:0] intr_pins;
   bit [SW_APP:0] genbits_fips_previous;
   bit [SW_APP:0] genbits_fips_received = '0;
   mubi4_t [SW_APP:0] cmd_flag0_previous;
-  csrng_pkg::csrng_cmd_sts_e cmd_sts[NUM_HW_APPS + 1] = '{default: CMD_STS_SUCCESS};
+  csrng_pkg::csrng_cmd_sts_e cmd_sts[];
 
   bit [3:0] int_state_num;
-  bit [NUM_HW_APPS:0] int_state_read_enable;
+  bit [MaxNumHwApps:0] int_state_read_enable;
 
   virtual csrng_cov_if                                    cov_vif;
 
   // TLM agent fifos
   uvm_tlm_analysis_fifo#(push_pull_item#(.HostDataWidth(FIPS_CSRNG_BUS_WIDTH)))   entropy_src_fifo;
-  uvm_tlm_analysis_fifo#(csrng_item)   csrng_cmd_fifo[NUM_HW_APPS];
+  uvm_tlm_analysis_fifo#(csrng_item)   csrng_cmd_fifo[];
 
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
 
+    cs_item       = new[cfg.m_num_apps];
+    es_item       = new[cfg.m_num_apps];
+    es_item_q     = new[cfg.m_num_apps];
+    prd_genbits_q = new[cfg.m_num_apps];
+    cs_data       = new[cfg.m_num_apps];
+    es_data       = new[cfg.m_num_apps];
+    fips          = new[cfg.m_num_apps];
+    cmd_sts       = new[cfg.m_num_apps]('{default: CMD_STS_SUCCESS});
+
+    csrng_cmd_fifo   = new[cfg.m_num_hw_apps];
     entropy_src_fifo = new("entropy_src_fifo", this);
 
-    for (int i = 0; i < NUM_HW_APPS; i++) begin
+    for (int i = 0; i < cfg.m_num_hw_apps; i++) begin
       csrng_cmd_fifo[i] = new($sformatf("csrng_cmd_fifo[%0d]", i), this);
     end
 
@@ -63,7 +74,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
       handle_disable();
     join_none;
 
-    for (int i = 0; i < NUM_HW_APPS; i++) begin
+    for (int i = 0; i < cfg.m_num_hw_apps; i++) begin
       automatic int j = i;
       fork
         begin
@@ -84,7 +95,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
       entropy_src_fifo.flush();
       hw_genbits = '0;
       more_cmd_data = 0;
-      for (int i = 0; i < NUM_HW_APPS + 1; i++) begin
+      for (int i = 0; i < cfg.m_num_apps; i++) begin
         if (i != SW_APP) csrng_cmd_fifo[i].flush();
         es_item_q[i].delete();
         hw_genbits_reg_q.delete();
@@ -618,7 +629,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
      end
   endtask
 
-  task process_csrng_cmd_fifo(bit[NUM_HW_APPS-1:0] app);
+  task process_csrng_cmd_fifo(bit[MaxNumHwApps:0] app);
     forever begin
       csrng_cmd_fifo[app].get(cs_item[app]);
       cs_data[app] = '0;

--- a/hw/ip/csrng/dv/env/csrng_virtual_sequencer.sv
+++ b/hw/ip/csrng/dv/env/csrng_virtual_sequencer.sv
@@ -10,7 +10,8 @@ class csrng_virtual_sequencer extends cip_base_virtual_sequencer #(
 
   push_pull_sequencer#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))
       entropy_src_sequencer_h;
-  csrng_sequencer                           edn_sequencer_h[NUM_HW_APPS];
+
+  csrng_sequencer edn_sequencer_h[];
 
   `uvm_component_new
 

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_alert_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_alert_vseq.sv
@@ -360,7 +360,8 @@ class csrng_alert_vseq extends csrng_base_vseq;
     super.body();
 
     // Create EDN host sequences.
-    for (int i = 0; i < NUM_HW_APPS; i++) begin
+    m_edn_push_seq = new[cfg.m_num_hw_apps];
+    for (int i = 0; i < cfg.m_num_hw_apps; i++) begin
       m_edn_push_seq[i] = push_pull_host_seq#(csrng_pkg::CmdBusWidth)::type_id::create
                                               ($sformatf("m_edn_push_seq[%0d]", i));
     end

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
@@ -18,8 +18,7 @@ class csrng_base_vseq extends cip_base_vseq #(
 
   push_pull_device_seq#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))
       m_entropy_src_pull_seq;
-  push_pull_host_seq#(.HostDataWidth(csrng_pkg::CmdBusWidth))
-      m_edn_push_seq[NUM_HW_APPS];
+  push_pull_host_seq#(.HostDataWidth(csrng_pkg::CmdBusWidth)) m_edn_push_seq[];
 
   virtual task body();
     if (!uvm_config_db#(virtual csrng_cov_if)::get(null, "*.env" , "csrng_cov_if", cov_vif)) begin

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_cmds_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_cmds_vseq.sv
@@ -6,9 +6,9 @@ class csrng_cmds_vseq extends csrng_base_vseq;
   `uvm_object_utils(csrng_cmds_vseq)
   `uvm_object_new
 
-  csrng_item   cs_item, cs_item_q[NUM_HW_APPS + 1][$];
+  csrng_item   cs_item, cs_item_q[][$];
   uint         num_cmds, cmds_gen, cmds_sent;
-  bit          uninstantiate[NUM_HW_APPS + 1];
+  bit          uninstantiate[];
 
   function void gen_seed(uint app);
     bit [entropy_src_pkg::FIPS_BUS_WIDTH - 1:0]    fips;
@@ -68,7 +68,7 @@ class csrng_cmds_vseq extends csrng_base_vseq;
     cmds_gen = 0;
     cmds_sent = 0;
     // Generate queues of csrng commands
-    for (int i = 0; i < NUM_HW_APPS + 1; i++) begin
+    for (int i = 0; i < cfg.m_num_apps; i++) begin
       create_cmds(i);
     end
   endfunction
@@ -98,11 +98,15 @@ class csrng_cmds_vseq extends csrng_base_vseq;
   task body();
     super.body();
 
+    cs_item_q     = new[cfg.m_num_apps];
+    uninstantiate = new[cfg.m_num_apps];
+
     // Create entropy_src sequence
     m_entropy_src_pull_seq = push_pull_device_seq#(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH)::
         type_id::create("m_entropy_src_pull_seq");
     // Create edn host sequences
-    for (int i = 0; i < NUM_HW_APPS; i++) begin
+    m_edn_push_seq = new[cfg.m_num_hw_apps];
+    for (int i = 0; i < cfg.m_num_hw_apps; i++) begin
       m_edn_push_seq[i] = push_pull_host_seq#(csrng_pkg::CmdBusWidth)::type_id::create
                                               ($sformatf("m_edn_push_seq[%0d]", i));
     end
@@ -120,7 +124,7 @@ class csrng_cmds_vseq extends csrng_base_vseq;
       fork
         // Generate one thread for each hardware application interface. These will end once all the
         // commands have been sent.
-        for (int i = 0; i < NUM_HW_APPS + 1; i++) begin
+        for (int i = 0; i < cfg.m_num_apps; i++) begin
           automatic int j = i;
           fork
             forever begin
@@ -153,7 +157,7 @@ class csrng_cmds_vseq extends csrng_base_vseq;
           cfg.csrng_agents_vif.drive_edn_disable(1);
 
           // Clear any items that may remain in the command queues.
-          for (int i = 0; i < NUM_HW_APPS + 1; i++) begin
+          for (int i = 0; i < cfg.m_num_apps; i++) begin
             cs_item_q[i].delete();
           end
 
@@ -197,7 +201,7 @@ class csrng_cmds_vseq extends csrng_base_vseq;
 
     // Check internal state, then uninstantiate if not already
     if (cfg.check_int_state) begin
-      for (int i = 0; i < NUM_HW_APPS + 1; i++) begin
+      for (int i = 0; i < cfg.m_num_apps; i++) begin
         cfg.check_internal_state(.app(i), .compare(1));
         if (!uninstantiate[i]) begin
           cs_item = new();

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_err_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_err_vseq.sv
@@ -40,7 +40,8 @@ class csrng_err_vseq extends csrng_base_vseq;
     fifo_err_value[1] = '{"write": 1'b0, "read": 1'b0, "state": 1'b0};
 
     // Create edn host sequences
-    for (int i = 0; i < NUM_HW_APPS; i++) begin
+    m_edn_push_seq = new[cfg.m_num_hw_apps];
+    for (int i = 0; i < cfg.m_num_hw_apps; i++) begin
       m_edn_push_seq[i] = push_pull_host_seq#(csrng_pkg::CmdBusWidth)::type_id::create
                                               ($sformatf("m_edn_push_seq[%0d]", i));
     end

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_intr_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_intr_vseq.sv
@@ -313,7 +313,8 @@ class csrng_intr_vseq extends csrng_base_vseq;
   task body();
     super.body();
     // Create EDN host sequences.
-    for (int i = 0; i < NUM_HW_APPS; i++) begin
+    m_edn_push_seq = new[cfg.m_num_hw_apps];
+    for (int i = 0; i < cfg.m_num_hw_apps; i++) begin
       m_edn_push_seq[i] = push_pull_host_seq#(csrng_pkg::CmdBusWidth)::type_id::create
                                               ($sformatf("m_edn_push_seq[%0d]", i));
     end

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_intr_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_intr_vseq.sv
@@ -224,14 +224,15 @@ class csrng_intr_vseq extends csrng_base_vseq;
         fifo_base_path = fld_name.substr(0, last_index-1);
 
         foreach (path_exts[i]) begin
-          fifo_forced_paths[i] = cfg.csrng_path_vif.fifo_err_path(cfg.NHwApps, fifo_base_path,
+          fifo_forced_paths[i] = cfg.csrng_path_vif.fifo_err_path(cfg.m_num_hw_apps,
+                                                                  fifo_base_path,
                                                                   path_exts[i]);
         end
         force_all_fifo_errs(fifo_forced_paths, fifo_forced_values, path_exts,
                             ral.intr_state.cs_fatal_err, 1'b1, cfg.which_fifo_err);
       end
       cmd_stage_sm_error, main_sm_error, ctr_drbg_sm_error: begin
-        path = cfg.csrng_path_vif.sm_err_path(fld_name.substr(0, last_index-1), cfg.NHwApps);
+        path = cfg.csrng_path_vif.sm_err_path(fld_name.substr(0, last_index-1), cfg.m_num_hw_apps);
         force_path_err(path, 8'b0, ral.intr_state.cs_fatal_err, 1'b1);
       end
       aes_cipher_sm_error: begin
@@ -284,16 +285,16 @@ class csrng_intr_vseq extends csrng_base_vseq;
         `DV_CHECK_EQ(aes_fsm_state, aes_pkg::CIPHER_CTRL_ERROR)
       end
       ctr_error: begin
-        path = cfg.csrng_path_vif.cmd_gen_cnt_err_path(cfg.NHwApps);
+        path = cfg.csrng_path_vif.cmd_gen_cnt_err_path(cfg.m_num_hw_apps);
         force_path_err(path, 8'h01, ral.intr_state.cs_fatal_err, 1'b1);
       end
       fifo_write_error, fifo_read_error, fifo_state_error: begin
         fifo_name = cfg.which_fifo.name();
         path_key = fld_name.substr(first_index+1, last_index-1);
 
-        path1 = cfg.csrng_path_vif.fifo_err_path(cfg.NHwApps, fifo_name,
+        path1 = cfg.csrng_path_vif.fifo_err_path(cfg.m_num_hw_apps, fifo_name,
                                                  fifo_err_path[0][path_key]);
-        path2 = cfg.csrng_path_vif.fifo_err_path(cfg.NHwApps, fifo_name,
+        path2 = cfg.csrng_path_vif.fifo_err_path(cfg.m_num_hw_apps, fifo_name,
                                                  fifo_err_path[1][path_key]);
         value1 = fifo_err_value[0][path_key];
         value2 = fifo_err_value[1][path_key];

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_regwen_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_regwen_vseq.sv
@@ -14,8 +14,8 @@ class csrng_regwen_vseq extends csrng_base_vseq;
   int ctrl_int        = 0;
   int chk_int         = 0;
 
-  rand bit [NUM_HW_APPS:0] int_state_read_enable;
-  bit [NUM_HW_APPS:0] chk_int_state_read_enable;
+  rand bit [MaxNumHwApps:0] int_state_read_enable;
+  bit      [MaxNumHwApps:0] chk_int_state_read_enable;
 
   task body();
 

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_smoke_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_smoke_vseq.sv
@@ -32,7 +32,7 @@ class csrng_smoke_vseq extends csrng_base_vseq;
 
     // Check internal state
     if (cfg.check_int_state) begin
-      for (int i = 0; i < NUM_HW_APPS + 1; i++)
+      for (int i = 0; i < cfg.m_num_hw_apps + 1; i++)
         cfg.check_internal_state(.app(i), .compare(1));
     end
 

--- a/hw/ip/csrng/dv/tb.sv
+++ b/hw/ip/csrng/dv/tb.sv
@@ -15,17 +15,38 @@ module tb;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
+  // CSRNG has a "software app" for random numbers that are read over TLUL, then zero or more
+  // "hardware apps" which each have a connection through csrng_cmd_i / csrng_cmd_o.
+  //
+  // This number of apps isn't passed as a parameter to the design because each app has associated
+  // registers, which need auto-generating by reggen. However, the design exposes the number of apps
+  // (both HW and SW) as csrng_reg_pkg::NumApps.
+  //
+  // This value should be positive. Define NumHwApps locally because several things depend on that
+  // (such as the width of the csrng_cmd_i/o ports).
+  localparam int unsigned NumHwApps = (NumApps > 0) ? NumApps - 1 : 0;
+
+  // Check that NumApps really was positive. Also, check that NumHwApps matches the corresponding
+  // parameter in the dut.
+  initial begin
+    if (NumApps <= 0)
+      `uvm_error("tb", "NumApps should be strictly positive.")
+
+    if (NumHwApps != dut.NumHwApps)
+      `uvm_error("tb", "NumHwApps from dut doesn't match the value inferred from csrng_reg_pkg.")
+  end
+
   wire   clk, rst_n;
   wire   edn_disable, entropy_src_disable;
   wire   intr_cmd_req_done;
   wire   intr_entropy_req;
   wire   intr_hw_inst_exc;
   wire   intr_cs_fatal_err;
-  wire[NUM_MAX_INTERRUPTS-1:0]        interrupts;
-  wire[MuBi8Width - 1:0]              otp_en_cs_sw_app_read;
-  wire[MuBi4Width - 1:0]              lc_hw_debug_en;
-  csrng_pkg::csrng_req_t[NumApps-2:0] csrng_cmd_req;
-  csrng_pkg::csrng_rsp_t[NumApps-2:0] csrng_cmd_rsp;
+  wire[NUM_MAX_INTERRUPTS-1:0]          interrupts;
+  wire[MuBi8Width - 1:0]                otp_en_cs_sw_app_read;
+  wire[MuBi4Width - 1:0]                lc_hw_debug_en;
+  csrng_pkg::csrng_req_t[NumHwApps-1:0] csrng_cmd_req;
+  csrng_pkg::csrng_rsp_t[NumHwApps-1:0] csrng_cmd_rsp;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
@@ -33,7 +54,7 @@ module tb;
   pins_if#(MuBi8Width) otp_en_cs_sw_app_read_if(otp_en_cs_sw_app_read);
   pins_if#(MuBi4Width) lc_hw_debug_en_if(lc_hw_debug_en);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
-  csrng_if  csrng_if[NumApps-1](.clk(clk), .rst_n(edn_disable === 1'b1 ? 1'b0 : rst_n));
+  csrng_if  csrng_if[NumHwApps](.clk(clk), .rst_n(edn_disable === 1'b1 ? 1'b0 : rst_n));
   csrng_agents_if csrng_agents_if();
   push_pull_if#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))
       entropy_src_if(.clk(clk), .rst_n(entropy_src_disable === 1'b1 ? 1'b0 : rst_n));
@@ -78,7 +99,7 @@ module tb;
     .intr_cs_fatal_err_o        (intr_cs_fatal_err)
   );
 
-  for (genvar i = 0; i < NumApps - 1; i++) begin : gen_csrng_if
+  for (genvar i = 0; i < NumHwApps; i++) begin : gen_csrng_if
     assign csrng_cmd_req[i]    = csrng_if[i].cmd_req;
     assign csrng_if[i].cmd_rsp = csrng_cmd_rsp[i];
     initial begin

--- a/hw/ip/csrng/dv/tb.sv
+++ b/hw/ip/csrng/dv/tb.sv
@@ -9,6 +9,7 @@ module tb;
   import csrng_env_pkg::*;
   import csrng_test_pkg::*;
   import prim_mubi_pkg::*;
+  import csrng_reg_pkg::NumApps;
 
   // macro includes
   `include "uvm_macros.svh"
@@ -20,11 +21,11 @@ module tb;
   wire   intr_entropy_req;
   wire   intr_hw_inst_exc;
   wire   intr_cs_fatal_err;
-  wire[NUM_MAX_INTERRUPTS-1:0]              interrupts;
-  wire[MuBi8Width - 1:0]                    otp_en_cs_sw_app_read;
-  wire[MuBi4Width - 1:0]                    lc_hw_debug_en;
-  csrng_pkg::csrng_req_t[NUM_HW_APPS-1:0]   csrng_cmd_req;
-  csrng_pkg::csrng_rsp_t[NUM_HW_APPS-1:0]   csrng_cmd_rsp;
+  wire[NUM_MAX_INTERRUPTS-1:0]        interrupts;
+  wire[MuBi8Width - 1:0]              otp_en_cs_sw_app_read;
+  wire[MuBi4Width - 1:0]              lc_hw_debug_en;
+  csrng_pkg::csrng_req_t[NumApps-2:0] csrng_cmd_req;
+  csrng_pkg::csrng_rsp_t[NumApps-2:0] csrng_cmd_rsp;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
@@ -32,7 +33,7 @@ module tb;
   pins_if#(MuBi8Width) otp_en_cs_sw_app_read_if(otp_en_cs_sw_app_read);
   pins_if#(MuBi4Width) lc_hw_debug_en_if(lc_hw_debug_en);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
-  csrng_if  csrng_if[NUM_HW_APPS](.clk(clk), .rst_n(edn_disable === 1'b1 ? 1'b0 : rst_n));
+  csrng_if  csrng_if[NumApps-1](.clk(clk), .rst_n(edn_disable === 1'b1 ? 1'b0 : rst_n));
   csrng_agents_if csrng_agents_if();
   push_pull_if#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))
       entropy_src_if(.clk(clk), .rst_n(entropy_src_disable === 1'b1 ? 1'b0 : rst_n));
@@ -47,8 +48,7 @@ module tb;
   `DV_ALERT_IF_CONNECT()
 
   // dut
-  csrng#(.NHwApps(NUM_HW_APPS),
-         .RndCnstCsKeymgrDivNonProduction(LC_HW_DEBUG_EN_ON_DATA),
+  csrng#(.RndCnstCsKeymgrDivNonProduction(LC_HW_DEBUG_EN_ON_DATA),
          .RndCnstCsKeymgrDivProduction(LC_HW_DEBUG_EN_OFF_DATA))
   dut (
     .clk_i                      (clk      ),
@@ -78,7 +78,7 @@ module tb;
     .intr_cs_fatal_err_o        (intr_cs_fatal_err)
   );
 
-  for (genvar i = 0; i < NUM_HW_APPS; i++) begin : gen_csrng_if
+  for (genvar i = 0; i < NumApps - 1; i++) begin : gen_csrng_if
     assign csrng_cmd_req[i]    = csrng_if[i].cmd_req;
     assign csrng_if[i].cmd_rsp = csrng_cmd_rsp[i];
     initial begin
@@ -117,7 +117,7 @@ module tb;
   end
 
   // Assertions
-  for (genvar i = 0; i < NUM_HW_APPS + 1; i++) begin : gen_cmd_stage_asserts
+  for (genvar i = 0; i < NumApps; i++) begin : gen_cmd_stage_asserts
     `ASSERT(CmdStageFifoNotFullReady,
       $past(rst_n) &&
       (tb.dut.u_csrng_core.gen_cmd_stage[i].u_csrng_cmd_stage.sfifo_cmd_depth != 2'h2) |->

--- a/hw/ip/csrng/dv/tb.sv
+++ b/hw/ip/csrng/dv/tb.sv
@@ -93,6 +93,8 @@ module tb;
   assign interrupts[FifoErr]    = intr_cs_fatal_err;
 
   initial begin
+    uvm_config_db#(int unsigned)::set(null, "uvm_test_top", "num_hw_apps", dut.NumHwApps);
+
     // Drive clk and rst_n from clk_if
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);

--- a/hw/ip/csrng/dv/tests/csrng_alert_test.sv
+++ b/hw/ip/csrng/dv/tests/csrng_alert_test.sv
@@ -15,9 +15,5 @@ class csrng_alert_test extends csrng_base_test;
     cfg.otp_en_cs_sw_app_read_inval_pct = 0;
     cfg.sw_app_enable_pct               = 100;
     cfg.use_invalid_mubi                = 1;
-
-    `DV_CHECK_RANDOMIZE_FATAL(cfg)
-
-    `uvm_info("csrng_intr_dbg", $sformatf("%s", cfg.convert2string()), UVM_LOW)
   endfunction
 endclass : csrng_alert_test

--- a/hw/ip/csrng/dv/tests/csrng_base_test.sv
+++ b/hw/ip/csrng/dv/tests/csrng_base_test.sv
@@ -8,20 +8,27 @@ class csrng_base_test extends cip_base_test #(
   );
 
   `uvm_component_utils(csrng_base_test)
-  `uvm_component_new
 
-   virtual function void build_phase(uvm_phase phase);
-     super.build_phase(phase);
+  function new (string name, uvm_component parent);
+    super.new(name, parent);
+  endfunction
 
-     configure_env();
-   endfunction
+  // A function defined in dv_base_test
+  //
+  // In this extended class, we set the shape of the environment (by calling set_num_hw_apps) before
+  // the base class calls cfg.initialize(), and then follow-up by calling configure_env.
+  virtual function void initialize_env_cfg();
+    int unsigned num_hw_apps;
 
-  // the base class dv_base_test creates the following instances:
-  // csrng_env_cfg: cfg
-  // csrng_env:     env
+    if (!uvm_config_db#(int unsigned)::get(this, "", "num_hw_apps", num_hw_apps)) begin
+      `uvm_fatal(get_full_name(), "Failed to get num_hw_apps from uvm_config_db.")
+    end
+    cfg.set_num_hw_apps(num_hw_apps);
 
-  // the base class also looks up UVM_TEST_SEQ plusarg to create and run that seq in
-  // the run_phase; as such, nothing more needs to be done
+    super.initialize_env_cfg();
+
+    configure_env();
+  endfunction
 
   virtual function void configure_env();
     cfg.otp_en_cs_sw_app_read_pct        = 80;

--- a/hw/ip/csrng/dv/tests/csrng_base_test.sv
+++ b/hw/ip/csrng/dv/tests/csrng_base_test.sv
@@ -13,6 +13,10 @@ class csrng_base_test extends cip_base_test #(
     super.new(name, parent);
   endfunction
 
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+  endfunction
+
   // A function defined in dv_base_test
   //
   // In this extended class, we set the shape of the environment (by calling set_num_hw_apps) before

--- a/hw/ip/csrng/dv/tests/csrng_cmds_test.sv
+++ b/hw/ip/csrng/dv/tests/csrng_cmds_test.sv
@@ -38,8 +38,5 @@ class csrng_cmds_test extends csrng_base_test;
       cfg.m_edn_agent_cfg[i].min_genbits_rdy_dly = 0;
       cfg.m_edn_agent_cfg[i].max_genbits_rdy_dly = 70;
     end
-
-    `DV_CHECK_RANDOMIZE_FATAL(cfg)
-    `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)
   endfunction
 endclass : csrng_cmds_test

--- a/hw/ip/csrng/dv/tests/csrng_cmds_test.sv
+++ b/hw/ip/csrng/dv/tests/csrng_cmds_test.sv
@@ -28,7 +28,7 @@ class csrng_cmds_test extends csrng_base_test;
     cfg.min_enable_csrng_before_edn_clks = 10;
     cfg.max_enable_csrng_before_edn_clks = 200;
 
-    for (int i = 0; i < NUM_HW_APPS; i++) begin
+    for (int i = 0; i < cfg.m_num_hw_apps; i++) begin
       // CSRNG has a single AES primitive shared among the three application interfaces. To hit the
       // different genbits_depth_cross coverpoints, the maximum delay for asserting genbits_ready
       // and reading the previously requested bits from the genbits FIFO must be chosen

--- a/hw/ip/csrng/dv/tests/csrng_intr_test.sv
+++ b/hw/ip/csrng/dv/tests/csrng_intr_test.sv
@@ -15,9 +15,5 @@ class csrng_intr_test extends csrng_base_test;
     cfg.otp_en_cs_sw_app_read_inval_pct = 0;
     cfg.sw_app_enable_pct               = 100;
     cfg.use_invalid_mubi                = 0;
-
-    `DV_CHECK_RANDOMIZE_FATAL(cfg)
-
-    `uvm_info("csrng_intr_dbg", $sformatf("%s", cfg.convert2string()), UVM_LOW)
   endfunction
 endclass : csrng_intr_test

--- a/hw/ip/csrng/dv/tests/csrng_smoke_test.sv
+++ b/hw/ip/csrng/dv/tests/csrng_smoke_test.sv
@@ -12,9 +12,5 @@ class csrng_smoke_test extends csrng_base_test;
 
     cfg.use_invalid_mubi = 0;
     cfg.force_state_pct  = 100;
-
-    `DV_CHECK_RANDOMIZE_FATAL(cfg)
-
-    `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)
   endfunction
 endclass : csrng_smoke_test

--- a/hw/ip/csrng/dv/tests/csrng_stress_all_test.sv
+++ b/hw/ip/csrng/dv/tests/csrng_stress_all_test.sv
@@ -12,8 +12,5 @@ class csrng_stress_all_test extends csrng_base_test;
 
     cfg.num_cmds_min = 0;
     cfg.num_cmds_max = 20;
-
-    `DV_CHECK_RANDOMIZE_FATAL(cfg)
-    `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)
   endfunction
 endclass : csrng_stress_all_test


### PR DESCRIPTION
This fixes #30034, and also teaches the environment to be more agnostic about the number of HW apps supported by CSRNG.