### PR TITLE
[crypto] Remove the temporary status code for unimplemented functions

### DIFF
--- a/sw/device/lib/crypto/drivers/mock_entropy.cc
+++ b/sw/device/lib/crypto/drivers/mock_entropy.cc
@@ -50,14 +50,14 @@ status_t entropy_csrng_generate_start(
 status_t entropy_csrng_generate_data_get(uint32_t *buf, size_t len,
                                          hardened_bool_t fips_check) {
   // This mock does not support actually generating random values.
-  return OTCRYPTO_NOT_IMPLEMENTED;
+  return OTCRYPTO_FATAL_ERR;
 }
 
 status_t entropy_csrng_generate(const entropy_seed_material_t *seed_material,
                                 uint32_t *buf, size_t len,
                                 hardened_bool_t fips_check) {
   // This mock does not support actually generating random values.
-  return OTCRYPTO_NOT_IMPLEMENTED;
+  return OTCRYPTO_FATAL_ERR;
 }
 
 status_t entropy_csrng_uninstantiate(void) { return OTCRYPTO_OK; }

--- a/sw/device/lib/crypto/impl/status.h
+++ b/sw/device/lib/crypto/impl/status.h
@@ -42,9 +42,6 @@ extern "C" {
 #define OTCRYPTO_ASYNC_INCOMPLETE                         \
   ((status_t){.value = (int32_t)(0x80000000 | MODULE_ID | \
                                  ((__LINE__ & 0x7ff) << 5) | kUnavailable)})
-#define OTCRYPTO_NOT_IMPLEMENTED                          \
-  ((status_t){.value = (int32_t)(0x80000000 | MODULE_ID | \
-                                 ((__LINE__ & 0x7ff) << 5) | kUnimplemented)})
 #else
 
 #define OTCRYPTO_RECOV_ERR \
@@ -53,8 +50,6 @@ extern "C" {
 #define OTCRYPTO_BAD_ARGS ((status_t){.value = kOtcryptoStatusValueBadArgs})
 #define OTCRYPTO_ASYNC_INCOMPLETE \
   ((status_t){.value = kOtcryptoStatusValueAsyncIncomplete})
-#define OTCRYPTO_NOT_IMPLEMENTED \
-  ((status_t){.value = kOtcryptoStatusValueNotImplemented})
 
 #endif
 

--- a/sw/device/lib/crypto/impl/status_debug_unittest.cc
+++ b/sw/device/lib/crypto/impl/status_debug_unittest.cc
@@ -38,7 +38,6 @@ TEST(Status, ErrorMacrosHaveExpectedValues) {
   EXPECT_EQ(status_err(OTCRYPTO_RECOV_ERR), kAborted);
   EXPECT_EQ(status_err(OTCRYPTO_FATAL_ERR), kFailedPrecondition);
   EXPECT_EQ(status_err(OTCRYPTO_ASYNC_INCOMPLETE), kUnavailable);
-  EXPECT_EQ(status_err(OTCRYPTO_NOT_IMPLEMENTED), kUnimplemented);
 }
 
 __attribute__((noinline)) otcrypto_status_t try_interpret(status_t status) {

--- a/sw/device/lib/crypto/impl/status_unittest.cc
+++ b/sw/device/lib/crypto/impl/status_unittest.cc
@@ -27,9 +27,9 @@ int HammingDistance(int32_t a, int32_t b) {
 // Check the Hamming distances of the top-level error codes.
 constexpr int kMinimumHammingDistance = 5;
 TEST(Status, TopLevelStatusHammingDistance) {
-  std::array<otcrypto_status_t, 5> error_codes = {
+  std::array<otcrypto_status_t, 4> error_codes = {
       OTCRYPTO_BAD_ARGS, OTCRYPTO_RECOV_ERR, OTCRYPTO_FATAL_ERR,
-      OTCRYPTO_ASYNC_INCOMPLETE, OTCRYPTO_NOT_IMPLEMENTED};
+      OTCRYPTO_ASYNC_INCOMPLETE};
 
   // Expect the "OK" code to have a significant Hamming distance from 0.
   EXPECT_GE(HammingDistance(kOtcryptoStatusValueOk, 0), kMinimumHammingDistance)
@@ -66,7 +66,6 @@ TEST(Status, ErrorMacrosNotOk) {
   EXPECT_EQ(status_ok(OTCRYPTO_RECOV_ERR), false);
   EXPECT_EQ(status_ok(OTCRYPTO_FATAL_ERR), false);
   EXPECT_EQ(status_ok(OTCRYPTO_ASYNC_INCOMPLETE), false);
-  EXPECT_EQ(status_ok(OTCRYPTO_NOT_IMPLEMENTED), false);
 }
 
 TEST(Status, ErrorMacrosHaveExpectedValues) {
@@ -75,7 +74,6 @@ TEST(Status, ErrorMacrosHaveExpectedValues) {
   EXPECT_EQ(status_err(OTCRYPTO_RECOV_ERR), kAborted);
   EXPECT_EQ(status_err(OTCRYPTO_FATAL_ERR), kFailedPrecondition);
   EXPECT_EQ(status_err(OTCRYPTO_ASYNC_INCOMPLETE), kUnavailable);
-  EXPECT_EQ(status_err(OTCRYPTO_NOT_IMPLEMENTED), kUnimplemented);
 }
 
 __attribute__((noinline)) status_t do_hardened_try(status_t status) {

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -77,9 +77,6 @@ typedef enum otcrypto_status_value {
   kOtcryptoStatusValueFatalError = (int32_t)0x80006d80 | kFailedPrecondition,
   // An asynchronous operation is still in progress.
   kOtcryptoStatusValueAsyncIncomplete = (int32_t)0x8000ea40 | kUnavailable,
-  // TODO: remove all instances of this error before release; it is to track
-  // implementations that are not yet complete.
-  kOtcryptoStatusValueNotImplemented = (int32_t)0x80008d20 | kUnimplemented,
 } otcrypto_status_value_t;
 
 /**

--- a/sw/device/tests/crypto/status_functest.c
+++ b/sw/device/tests/crypto/status_functest.c
@@ -53,10 +53,6 @@ otcrypto_status_t async_incomplete_test(void) {
   otcrypto_status_t result = bad_test(OTCRYPTO_ASYNC_INCOMPLETE);
   return reverse_status(result);
 }
-otcrypto_status_t not_implemented_test(void) {
-  otcrypto_status_t result = bad_test(OTCRYPTO_NOT_IMPLEMENTED);
-  return reverse_status(result);
-}
 
 bool test_main(void) {
   status_t result = OTCRYPTO_OK;
@@ -68,7 +64,6 @@ bool test_main(void) {
   EXECUTE_TEST(result, recov_err_test);
   EXECUTE_TEST(result, fatal_err_test);
   EXECUTE_TEST(result, async_incomplete_test);
-  EXECUTE_TEST(result, not_implemented_test);
 
   return status_ok(result);
 }


### PR DESCRIPTION
The OTCRYPTO_NOT_IMPLEMENTED status code was created to track parts of the cryptolib that were not yet finished. These status codes are currently resolved, hence the status code can be removed.