### PR TITLE
[otbn,rtl] Refactor carry selection logic in otbn_vec_adder

### DIFF
--- a/hw/ip/otbn/rtl/otbn_vec_adder.sv
+++ b/hw/ip/otbn/rtl/otbn_vec_adder.sv
@@ -84,7 +84,11 @@ module otbn_vec_adder
 
     // Select the carry in depending on the ELEN. Take previous stage or external carry.
     // Adder 0 always takes the external carry.
-    assign prev_carry_out = i_adder == 0 ? carries_in_i[0] : adders_carry_out[i_adder - 1];
+    if (i_adder == 0) begin : g_carry_adder0
+      assign prev_carry_out = carries_in_i[0];
+    end else begin : g_carry_other_adders
+      assign prev_carry_out = adders_carry_out[i_adder - 1];
+    end
     assign carry_in = use_ext_carry_i[i_adder] ? carries_in_i[i_adder] : prev_carry_out;
 
     // Extract and preprocess the operands


### PR DESCRIPTION
Refactor carry selection logic in otbn_vec_adder to avoid out of index warning

The old "previous carry" selection indexed adders_carry_out with -1 in the adder 0 case. This works fine in hardware but VCS did warn about this. This change refactors the "previous carry" selection so always a valid index is used.

Thanks @rswarbrick for spotting this.