### PR TITLE
[entropy_src,dv] Avoid encoding "tb.dut" directly in the environment

### DIFF
--- a/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
+++ b/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Implements functional coverage for entropy_src.
+// Implements functional coverage for entropy_src and is bound into the dut
 interface entropy_src_cov_if
   import entropy_src_pkg::*;
   import prim_mubi_pkg::*;
@@ -1185,8 +1185,10 @@ interface entropy_src_cov_if
           es_type_csr, entropy_data_reg_enable_csr, fw_ov_mode_csr, entropy_insert_csr;
   mubi8_t otp_en_es_fw_read_val;
 
-  assign csrng_if_req = tb.dut.entropy_src_hw_if_i.es_req;
-  assign csrng_if_ack = tb.dut.entropy_src_hw_if_o.es_ack;
+  // Assign req/ack signals to track those in the entropy_src_hw_if_i/o ports of the entropy_src
+  // instance into which this interface has been bound.
+  assign csrng_if_req = entropy_src.entropy_src_hw_if_i.es_req;
+  assign csrng_if_ack = entropy_src.entropy_src_hw_if_o.es_ack;
 
   logic enable_q, enable_qq;
 
@@ -1195,37 +1197,43 @@ interface entropy_src_cov_if
       enable_q  <= 1'b0;
       enable_qq <= 1'b0;
     end else begin
+      // Register the enable_i input to u_enable_delay in the entropy_src_core for the entropy_src
+      // instance into which this interface has been bound.
+      enable_q  <= entropy_src.u_entropy_src_core.u_enable_delay.enable_i;
       enable_qq <= enable_q;
-      enable_q  <= tb.dut.u_entropy_src_core.u_enable_delay.enable_i;
 
       if(csrng_if_req && csrng_if_ack) begin
-        cg_csrng_hw_sample(tb.dut.reg2hw.conf.fips_enable.q,
-                           tb.dut.reg2hw.conf.fips_flag.q,
-                           tb.dut.reg2hw.conf.rng_fips.q,
-                           tb.dut.reg2hw.conf.threshold_scope.q,
-                           tb.dut.reg2hw.conf.rng_bit_enable.q,
-                           tb.dut.reg2hw.conf.rng_bit_sel.q,
-                           tb.dut.reg2hw.entropy_control.es_route.q,
-                           tb.dut.reg2hw.entropy_control.es_type.q,
-                           tb.dut.reg2hw.conf.entropy_data_reg_enable.q,
+        // Sample relevant register configuration (based on a hierarchical reference to the dut
+        // containing this interface)
+        cg_csrng_hw_sample(entropy_src.reg2hw.conf.fips_enable.q,
+                           entropy_src.reg2hw.conf.fips_flag.q,
+                           entropy_src.reg2hw.conf.rng_fips.q,
+                           entropy_src.reg2hw.conf.threshold_scope.q,
+                           entropy_src.reg2hw.conf.rng_bit_enable.q,
+                           entropy_src.reg2hw.conf.rng_bit_sel.q,
+                           entropy_src.reg2hw.entropy_control.es_route.q,
+                           entropy_src.reg2hw.entropy_control.es_type.q,
+                           entropy_src.reg2hw.conf.entropy_data_reg_enable.q,
                            otp_en_entropy_src_fw_read_i,
-                           tb.dut.reg2hw.fw_ov_control.fw_ov_mode.q,
+                           entropy_src.reg2hw.fw_ov_control.fw_ov_mode.q,
                            otp_en_entropy_src_fw_over_i,
-                           tb.dut.reg2hw.fw_ov_control.fw_ov_entropy_insert.q);
+                           entropy_src.reg2hw.fw_ov_control.fw_ov_entropy_insert.q);
       end
 
       if (enable_qq != enable_q) begin
         // Only sample this CG when the enable signal changes.
+        //
+        // Samples are based on a hierarchical reference to the dut containing this interface.
         enable_delay_cg_inst.sample(
             enable_q,
-            tb.dut.u_entropy_src_core.u_enable_delay.esrng_fifo_not_empty_i,
-            tb.dut.u_entropy_src_core.u_enable_delay.esbit_fifo_not_empty_i,
-            tb.dut.u_entropy_src_core.u_enable_delay.postht_fifo_not_empty_i,
-            tb.dut.u_entropy_src_core.u_enable_delay.distr_fifo_not_empty_i,
-            tb.dut.u_entropy_src_core.u_enable_delay.sha3_block_busy_i,
-            tb.dut.u_entropy_src_core.u_enable_delay.sha3_block_processed_i,
-            tb.dut.u_entropy_src_core.u_enable_delay.bypass_mode_i,
-            tb.dut.u_entropy_src_core.u_enable_delay.enable_o);
+            entropy_src.u_entropy_src_core.u_enable_delay.esrng_fifo_not_empty_i,
+            entropy_src.u_entropy_src_core.u_enable_delay.esbit_fifo_not_empty_i,
+            entropy_src.u_entropy_src_core.u_enable_delay.postht_fifo_not_empty_i,
+            entropy_src.u_entropy_src_core.u_enable_delay.distr_fifo_not_empty_i,
+            entropy_src.u_entropy_src_core.u_enable_delay.sha3_block_busy_i,
+            entropy_src.u_entropy_src_core.u_enable_delay.sha3_block_processed_i,
+            entropy_src.u_entropy_src_core.u_enable_delay.bypass_mode_i,
+            entropy_src.u_entropy_src_core.u_enable_delay.enable_o);
       end
     end
   end

--- a/hw/ip/entropy_src/dv/env/entropy_src_env.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env.sv
@@ -118,6 +118,17 @@ class entropy_src_env extends cip_base_env #(
          cfg.interrupt_vif)) begin
       `uvm_fatal(`gfn, "failed to get entropy_src_path_vif from uvm_config_db")
     end
+
+    // Disable random CDC delays in alert sender because the scoreboard otherwise could not
+    // accurately predict whether an alert request gets merged with an outstanding request or not
+    // (#18796).
+    cfg.disabled_prim_cdc_rand_delays = new[2];
+    for (int unsigned i = 0; i < 2; i++) begin
+      cfg.disabled_prim_cdc_rand_delays[i] = {cfg.entropy_src_path_vif.dut_path,
+                                              ".gen_alert_tx[0].u_prim_alert_sender.u_decode_ack",
+                                              $sformatf(".gen_async.i_sync_%0s", i ? "p" : "n"),
+                                              ".u_prim_cdc_rand_delay"};
+    end
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -270,19 +270,6 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
 
     // only support 1 outstanding TL item
     m_tl_agent_cfg.max_outstanding_req = 1;
-
-    // Disable random CDC delays in alert sender because the scoreboard otherwise could not
-    // accurately predict whether an alert request gets merged with an outstanding request or not
-    // (#18796).
-    disabled_prim_cdc_rand_delays = new[2];
-    foreach (disabled_prim_cdc_rand_delays[i]) begin
-     string path = "tb.dut.gen_alert_tx[0].u_prim_alert_sender.u_decode_ack.gen_async";
-     unique case (i)
-       0: path = {path, ".i_sync_n"};
-       1: path = {path, ".i_sync_p"};
-     endcase
-     disabled_prim_cdc_rand_delays[i] = {path, ".u_prim_cdc_rand_delay"};
-    end
   endfunction
 
   virtual function string convert2string();

--- a/hw/ip/entropy_src/dv/env/entropy_src_path_if.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_path_if.sv
@@ -2,17 +2,20 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// This interface deals with the force paths in ENTROPY_SRC interrupt and error tests
-
-`define CORE \
-    tb.dut.u_entropy_src_core
-`define REPCNT \
-    u_entropy_src_repcnt_ht.u_prim_max_tree_rep_cntr_max
+// This interface deals with the force paths in ENTROPY_SRC interrupt and error tests.
+//
+// It is bound into an instance of entropy_src, so can address signals inside the dut with upwards
+// hierarchical references.
 
 interface entropy_src_path_if ();
   import uvm_pkg::*;
 
-  string core_path = "tb.dut.u_entropy_src_core";
+  // The hierarchical path to the entropy_src instance into which the interface is bound.
+  string dut_path  = dv_utils_pkg::get_parent_hier($sformatf("%m"));
+
+  // The hierarchical path to the entropy_src_core instance in the entropy_src instance into which
+  // the interface is bound.
+  string core_path = {dut_path, ".u_entropy_src_core"};
 
   function automatic string fifo_err_path(string fifo_name, string path_name);
     return {core_path, ".", fifo_name, "_", path_name};
@@ -45,20 +48,27 @@ interface entropy_src_path_if ();
       end
     endcase // case (cntr_name)
   endfunction // cntr_err_path
-   // Disable assertions that we expect to trigger when injecting errors
+
+// The relative hierarchical path to the entropy_src core from the entropy_src instance into which
+// the interface is bound. This matches the string in the core_path variable.
+`define CORE   entropy_src.u_entropy_src_core
+
+  // Disable assertions that we expect to trigger when injecting errors
+  //
+  // This uses upwards hierarchical references, pointing at the instance into which we are bound.
   task automatic assert_off_err();
-    $assertoff(0, tb.dut.AlertTxKnownO_A);
-    $assertoff(0, tb.dut.IntrEsFifoErrKnownO_A);
-    $assertoff(0, tb.dut.EsHwIfEsAckKnownO_A);
-    $assertoff(0, tb.dut.EsHwIfEsBitsKnownO_A);
-    $assertoff(0, tb.dut.EsHwIfEsFipsKnownO_A);
-    $assertoff(0, tb.dut.EsXhtEntropyBitKnownO_A);
-    $assertoff(0, tb.dut.IntrEsEntropyValidKnownO_A);
-    $assertoff(0, tb.dut.IntrEsHealthTestFailedKnownO_A);
-    $assertoff(0, tb.dut.tlul_assert_device.dKnown_A);
-    $assertoff(0, tb.dut.tlul_assert_device.gen_device.gen_d2h.dDataKnown_A);
-    $assertoff(0, tb.dut.gen_alert_tx[0].u_prim_alert_sender.AlertPKnownO_A);
-    $assertoff(0, tb.dut.gen_alert_tx[0].u_prim_alert_sender.gen_async_assert.DiffEncoding_A);
+    $assertoff(0, entropy_src.AlertTxKnownO_A);
+    $assertoff(0, entropy_src.IntrEsFifoErrKnownO_A);
+    $assertoff(0, entropy_src.EsHwIfEsAckKnownO_A);
+    $assertoff(0, entropy_src.EsHwIfEsBitsKnownO_A);
+    $assertoff(0, entropy_src.EsHwIfEsFipsKnownO_A);
+    $assertoff(0, entropy_src.EsXhtEntropyBitKnownO_A);
+    $assertoff(0, entropy_src.IntrEsEntropyValidKnownO_A);
+    $assertoff(0, entropy_src.IntrEsHealthTestFailedKnownO_A);
+    $assertoff(0, entropy_src.tlul_assert_device.dKnown_A);
+    $assertoff(0, entropy_src.tlul_assert_device.gen_device.gen_d2h.dDataKnown_A);
+    $assertoff(0, entropy_src.gen_alert_tx[0].u_prim_alert_sender.AlertPKnownO_A);
+    $assertoff(0, entropy_src.gen_alert_tx[0].u_prim_alert_sender.gen_async_assert.DiffEncoding_A);
     $assertoff(0, `CORE.AtReset_ValidRngBitsPushedIntoEsrngFifo_A);
     $assertoff(0, `CORE.Final_ValidRngBitsPushedIntoEsrngFifo_A);
     $assertoff(0, `CORE.AtReset_EsrngFifoPushedIntoEsbitOrPosthtFifos_A);
@@ -92,8 +102,10 @@ interface entropy_src_path_if ();
     $assertoff(0, `CORE.u_entropy_src_markov_ht.u_min.ValidInImpliesValidOut_A);
     $assertoff(0, `CORE.u_entropy_src_markov_ht.u_max.ValidInImpliesValidOut_A);
     $assertoff(0, `CORE.u_sha3.u_keccak.gen_unmask_st_chk.UnmaskValidStates_A);
-    $assertoff(0, `CORE.`REPCNT.ValidInImpliesValidOut_A);
+    $assertoff(0,
+               `CORE.u_entropy_src_repcnt_ht.u_prim_max_tree_rep_cntr_max.ValidInImpliesValidOut_A);
   endtask
+
   function automatic void disable_entroy_drop_assertions();
     // Disable assertions which expect that no entropy is dropped between the esrng,
     // esbit and postht FIFOs.
@@ -107,4 +119,3 @@ interface entropy_src_path_if ();
 endinterface // entropy_src_path_if
 
 `undef CORE
-`undef REPCNT

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -32,7 +32,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
   bit observe_fifo_overflow = 0;
   int overflow_read_cnt     = 0;
 
-  string es_delayed_enable_path = "tb.dut.u_entropy_src_core.es_delayed_enable";
+  string es_delayed_enable_path;
   bit dut_pipeline_enabled = 0;
   bit regwen_pending = 0;
   bit ht_fips_mode = 0;
@@ -161,8 +161,8 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
   int precon_fifo_cnt = 0;
   bit sha3_msg_ready = 0;
   bit predict_fw_ov_wr_fifo_full = 0;
-  string pad_st_path = "tb.dut.u_entropy_src_core.u_sha3.u_pad.st[6:0]";
-  string pad_st_d_path = "tb.dut.u_entropy_src_core.u_sha3.u_pad.st_d[6:0]";
+  string pad_st_path;
+  string pad_st_d_path;
 
   // Variables used to model entropy propagating through the pipeline.
   int                       post_ht_drops = 0;
@@ -225,6 +225,10 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
 
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
+
+    es_delayed_enable_path = {cfg.entropy_src_path_vif.core_path, ".es_delayed_enable"};
+    pad_st_path = {cfg.entropy_src_path_vif.core_path, ".u_sha3.u_pad.st[6:0]"};
+    pad_st_d_path = {cfg.entropy_src_path_vif.core_path, ".u_sha3.u_pad.st_d[6:0]"};
   endfunction
 
   task run_phase(uvm_phase phase);

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
@@ -679,7 +679,7 @@ class entropy_src_base_vseq extends cip_base_vseq #(
 
   task force_fifo_err_exception(string paths [4], bit values [4],
                                 uvm_reg_field reg_field, bit exp_data);
-    string data_path = "tb.dut.u_entropy_src_core.sfifo_esrng_rdata";
+    string data_path = {cfg.entropy_src_path_vif.core_path, ".sfifo_esrng_rdata"};
     foreach (paths[i]) begin
       if (!uvm_hdl_check_path(paths[i])) begin
         `uvm_fatal(`gfn, $sformatf("\n\t ----| PATH NOT FOUND"))

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_err_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_err_vseq.sv
@@ -4,33 +4,6 @@
 
 // Test all ERR_CODE fields are asserted as expected, as well as the ERR_CODE_TEST register
 
-`define PATH1 \
-    tb.dut.u_entropy_src_core.u_prim_mubi4_sync_entropy_fips_en
-`define PATH2 \
-    tb.dut.u_entropy_src_core.u_prim_mubi4_sync_entropy_data_reg_en
-`define PATH3 \
-    tb.dut.u_entropy_src_core.u_prim_mubi4_sync_entropy_module_en
-`define PATH4 \
-    tb.dut.u_entropy_src_core.u_prim_mubi4_sync_rng_bit_en
-`define PATH5 \
-    tb.dut.u_entropy_src_core.u_prim_mubi4_sync_fw_ov_mode
-`define PATH6 \
-    tb.dut.u_entropy_src_core.u_prim_mubi4_sync_fw_ov_entropy_insert
-`define PATH7 \
-    tb.dut.u_entropy_src_core.u_prim_mubi4_sync_es_route
-`define PATH8 \
-    tb.dut.u_entropy_src_core.u_prim_mubi4_sync_es_type
-`define PATH9 \
-    tb.dut.u_entropy_src_core.u_prim_mubi4_sync_es_enable
-`define PATH10 \
-    tb.dut.u_entropy_src_core.u_prim_mubi4_sync_es_enable_pulse
-`define CORE \
-    tb.dut.u_entropy_src_core
-`define SHA3 \
-    u_sha3.u_keccak.u_round_count
-`define REPCNT \
-    u_entropy_src_repcnt_ht.u_prim_max_tree_rep_cntr_max
-
 class entropy_src_err_vseq extends entropy_src_base_vseq;
   `uvm_object_utils(entropy_src_err_vseq)
 

--- a/hw/ip/entropy_src/dv/tb/tb.sv
+++ b/hw/ip/entropy_src/dv/tb/tb.sv
@@ -39,7 +39,6 @@ module tb;
   push_pull_if#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))
       csrng_if(.clk(clk), .rst_n(csrng_rst_n));
   entropy_src_xht_if xht_if(.clk(clk), .rst_n(rst_n));
-  entropy_src_path_if entropy_src_path_if ();
 
   `DV_ALERT_IF_CONNECT()
 
@@ -89,6 +88,8 @@ module tb;
   assign interrupts[HealthTestFailed] = intr_health_test_failed;
   assign interrupts[ObserveFifoReady] = intr_observe_fifo_ready;
   assign interrupts[FatalErr]         = intr_fatal_err;
+
+  bind dut entropy_src_path_if entropy_src_path_if ();
 
   bind prim_packer_fifo : dut.u_entropy_src_core.u_prim_packer_fifo_precon
     entropy_subsys_fifo_exception_if #(
@@ -150,7 +151,7 @@ module tb;
         set(null, "*.env.m_csrng_agent*", "vif", csrng_if);
     uvm_config_db#(virtual entropy_src_xht_if)::set(null, "*.env.m_xht_agent*", "vif", xht_if);
     uvm_config_db#(virtual entropy_src_path_if)::set(null, "*.env", "entropy_src_path_vif",
-        entropy_src_path_if);
+                                                     dut.entropy_src_path_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end


### PR DESCRIPTION
We can simplify how some of these paths get calculated, and avoid polluting the code in the environment with information that shouldn't concern it.

