### PR TITLE
[test] Mark `manuf_sram_program_crc` test as broken

### DIFF
--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -258,7 +258,11 @@ cc_library(
         fpga = fpga_params(
             needs_jtag = True,
             otp = ":otp_img_sram_exec_en_{}".format(lc_state.lower()),
-            tags = ["manuf"],
+            tags = [
+                "manuf",
+                # Flaky in CI and locally, see #29555.
+                "broken",
+            ],
             test_cmd = "--elf={firmware}",
             test_harness = "//sw/host/tests/manuf/manuf_sram_program_crc_check",
         ),


### PR DESCRIPTION
This is failing ~20% of the time and causing problems in CI. Disabling until it can be investigated further.