### PR TITLE
[ownership] Fix persistence of min_security_version_bl0 during same-owner updates

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/ownership.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership.c
@@ -70,6 +70,7 @@ static rom_error_t locked_owner_init(boot_data_t *bootdata,
                                      owner_config_t *config,
                                      owner_application_keyring_t *keyring) {
   HARDENED_CHECK_EQ(bootdata->ownership_state, kOwnershipStateLockedOwner);
+  hardened_bool_t bootdata_dirty = kHardenedBoolFalse;
   if (owner_page_valid[0] == kOwnerPageStatusSealed &&
       launder32(owner_page_valid[1]) == kOwnerPageStatusSigned &&
       owner_block_newversion_mode() == kHardenedBoolTrue &&
@@ -86,6 +87,7 @@ static rom_error_t locked_owner_init(boot_data_t *bootdata,
       // redundant backup of the new configuration.
       owner_page_valid[0] = kOwnerPageStatusInvalid;
       owner_page_valid[1] = kOwnerPageStatusSealed;
+      bootdata_dirty = kHardenedBoolTrue;
     } else {
       // If the new page wasn't good, we'll do nothing here and let the next set
       // of validity checks copy page 0 over to page 1 and re-establish a
@@ -129,6 +131,33 @@ static rom_error_t locked_owner_init(boot_data_t *bootdata,
       return kErrorOwnershipBadInfoPage;
     }
   }
+
+  // Self-healing: If the enforced floor in bootdata is less than the
+  // requested floor in the active owner configuration, update bootdata
+  // and trigger a write-and-reboot. This handles the case where a power
+  // cut occurred after the owner page was updated but before bootdata
+  // was persisted.
+  // We only perform this check once both pages are fully validated and sealed.
+  if (launder32(owner_page_valid[0]) == kOwnerPageStatusSealed &&
+      launder32(owner_page_valid[1]) == kOwnerPageStatusSealed) {
+    HARDENED_CHECK_EQ(owner_page_valid[0], kOwnerPageStatusSealed);
+    HARDENED_CHECK_EQ(owner_page_valid[1], kOwnerPageStatusSealed);
+    if (launder32(owner_page[0].min_security_version_bl0) != UINT32_MAX &&
+        launder32(bootdata->min_security_version_bl0) <
+            launder32(owner_page[0].min_security_version_bl0)) {
+      HARDENED_CHECK_NE(owner_page[0].min_security_version_bl0, UINT32_MAX);
+      HARDENED_CHECK_LT(bootdata->min_security_version_bl0,
+                        owner_page[0].min_security_version_bl0);
+      bootdata->min_security_version_bl0 =
+          owner_page[0].min_security_version_bl0;
+      bootdata_dirty = kHardenedBoolTrue;
+    }
+  }
+
+  if (launder32(bootdata_dirty) == kHardenedBoolTrue) {
+    return kErrorWriteBootdataThenReboot;
+  }
+
   HARDENED_RETURN_IF_ERROR(owner_block_parse(
       &owner_page[0], /*check_only=*/kHardenedBoolFalse, config, keyring));
   uint32_t mp_index = 0;

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -1042,3 +1042,28 @@ ownership_transfer_test(
         "test_harness": "//sw/host/tests/ownership:newversion_test",
     },
 )
+
+manifest({
+    "name": "manifest_secver5",
+    "identifier": hex(CONST.OWNER),
+    "security_version": "5",
+    "visibility": ["//visibility:public"],
+})
+
+ownership_transfer_test(
+    name = "bl0_secver_persistence_test",
+    ecdsa_key = {
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
+    },
+    manifest = ":manifest_secver5",
+    shared_params = {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
+        "test_cmd": """
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
+            --next-application-key=sw/device/silicon_creator/lib/ownership/keys/fake/app_prod_ecdsa_p256.pub.der
+        """,
+        "test_harness": "//sw/host/tests/ownership:bl0_secver_persistence_test",
+    },
+)

--- a/sw/host/opentitanlib/src/ownership/mod.rs
+++ b/sw/host/opentitanlib/src/ownership/mod.rs
@@ -20,7 +20,7 @@ pub use isfb::OwnerIsfbConfig;
 pub use misc::{
     DetachedSignatureCommand, HybridRawPublicKey, KeyMaterial, OwnershipKeyAlg, TlvHeader, TlvTag,
 };
-pub use owner::{OwnerBlock, OwnerConfigItem, SramExecMode};
+pub use owner::{OwnerBlock, OwnerConfigItem, SramExecMode, MinSecurityVersion, OwnershipUpdateMode};
 pub use rescue::{CommandTag, OwnerRescueConfig, RescueProtocol};
 pub use signature::DetachedSignature;
 

--- a/sw/host/tests/ownership/BUILD
+++ b/sw/host/tests/ownership/BUILD
@@ -88,3 +88,16 @@ rust_binary(
         "@crate_index//:regex",
     ],
 )
+
+rust_binary(
+    name = "bl0_secver_persistence_test",
+    srcs = ["bl0_secver_persistence_test.rs"],
+    deps = [
+        ":transfer_lib",
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+    ],
+)

--- a/sw/host/tests/ownership/bl0_secver_persistence_test.rs
+++ b/sw/host/tests/ownership/bl0_secver_persistence_test.rs
@@ -3,16 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![allow(clippy::bool_assert_comparison)]
-use anyhow::{Result, anyhow, ensure};
+use anyhow::{Result, ensure};
 use clap::Parser;
-use regex::Regex;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::time::Duration;
 
 use opentitanlib::app::{TransportWrapper, UartRx};
+use opentitanlib::io::uart::Uart;
 use opentitanlib::chip::rom_error::RomError;
-use opentitanlib::ownership::OwnershipKeyAlg;
+use opentitanlib::ownership::{OwnershipKeyAlg, MinSecurityVersion, OwnershipUpdateMode};
 use opentitanlib::rescue::serial::RescueSerial;
 use opentitanlib::rescue::{EntryMode, Rescue};
 use opentitanlib::test_utils::init::InitializeTest;
@@ -31,8 +31,6 @@ struct Opts {
     next_key_alg: OwnershipKeyAlg,
     #[arg(long, help = "Next Owner private key (ECDSA P256)")]
     next_owner_key: Option<PathBuf>,
-    #[arg(long, help = "Next Owner public key (ECDSA P256)")]
-    next_owner_key_pub: Option<PathBuf>,
     #[arg(long, help = "Next Owner activate private key (ECDSA P256)")]
     next_activate_key: Option<PathBuf>,
     #[arg(long, help = "Next Owner unlock private key (ECDSA P256)")]
@@ -42,8 +40,6 @@ struct Opts {
 
     #[arg(long, help = "Next Owner private key (SPX)")]
     next_owner_key_spx: Option<PathBuf>,
-    #[arg(long, help = "Next Owner public key (SPX)")]
-    next_owner_key_spx_pub: Option<PathBuf>,
     #[arg(long, help = "Next Owner activate private key (SPX)")]
     next_activate_key_spx: Option<PathBuf>,
     #[arg(long, help = "Next Owner unlock private key (SPX)")]
@@ -54,41 +50,53 @@ struct Opts {
 
     #[arg(
         long,
-        default_value_t = transfer_lib::TEST_OWNER_CONFIG_VERSION,
-        help = "Configuration version to put in the owner config"
-    )]
-    config_version: u32,
-
-    #[arg(
-        long,
-        help = "Lock the owner config to the device identification number"
-    )]
-    locked_to_din: Option<u64>,
-
-    #[arg(
-        long,
         value_enum,
         default_value = "basic",
         help = "Style of Owner Config for this test"
     )]
     config_kind: transfer_lib::OwnerConfigKind,
-
-    #[arg(long, help = "Expected success conditions")]
-    expect: Vec<String>,
-
-    #[arg(long, help = "Expected error condition")]
-    expected_error: Option<String>,
 }
 
-fn newversion_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+fn wait_for_boot(uart: &dyn Uart, timeout: Duration, expected_ver: u32, expected_min: u32) -> Result<()> {
+    let capture = UartConsole::wait_for(
+        uart,
+        r"(?msR)Running.*PASS!$|BFV:([0-9A-Fa-f]{8})$",
+        timeout,
+    )?;
+    if capture[0].starts_with("BFV") {
+        let err = u32::from_str_radix(&capture[1], 16)?;
+        if err == 0 {
+            log::info!("Detected expected write-and-reboot (BFV:00000000). Waiting for next boot...");
+            // Wait again for the actual boot to PASS!
+            let capture2 = UartConsole::wait_for(
+                uart,
+                r"(?msR)Running.*PASS!$|BFV:([0-9A-Fa-f]{8})$",
+                timeout,
+            )?;
+            if capture2[0].starts_with("BFV") {
+                return RomError(u32::from_str_radix(&capture2[1], 16)?).into();
+            }
+            ensure!(capture2[0].contains(&format!("config_version = {expected_ver}")), "Expected config_version = {expected_ver}");
+            ensure!(capture2[0].contains(&format!("bl0_min_sec_ver = {expected_min}")), "Expected bl0_min_sec_ver = {expected_min}");
+        } else {
+            return RomError(err).into();
+        }
+    } else {
+        ensure!(capture[0].contains(&format!("config_version = {expected_ver}")), "Expected config_version = {expected_ver}");
+        ensure!(capture[0].contains(&format!("bl0_min_sec_ver = {expected_min}")), "Expected bl0_min_sec_ver = {expected_min}");
+    }
+    Ok(())
+}
+
+fn bl0_secver_persistence_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
     let rescue = RescueSerial::new(Rc::clone(&uart), opts.rescue_enter_delay);
 
-    log::info!("###### Get Device Info ######");
+    log::info!("###### Get Device Info (1) ######");
     rescue.enter(transport, EntryMode::Reset)?;
-    let (data, devid) = transfer_lib::get_device_info(transport, &rescue)?;
+    let (data, _devid) = transfer_lib::get_device_info(transport, &rescue)?;
 
-    log::info!("###### Upload Owner Block ######");
+    log::info!("###### Upload Owner Block V2 (min_sec_ver = 5) ######");
     transfer_lib::create_owner(
         transport,
         &rescue,
@@ -108,54 +116,30 @@ fn newversion_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         )?,
         &opts.next_application_key,
         opts.config_kind,
-        /*customize=*/
         |owner| {
-            owner.config_version = opts.config_version;
-            if let Some(din) = opts.locked_to_din {
-                let din = match din {
-                    0 => devid.din,
-                    x => x,
-                };
-                owner.lock_constraint = 0x6;
-                owner.device_id[1] = din as u32;
-                owner.device_id[2] = (din >> 32) as u32;
-            }
+            owner.config_version = 2;
+            owner.min_security_version_bl0 = MinSecurityVersion(5);
+            owner.update_mode = OwnershipUpdateMode::NewVersion;
         },
     )?;
 
-    log::info!("###### Boot After Update Complete ######");
+    log::info!("###### Boot After V2 Update (should trigger reboot and persist) ######");
     transport.reset_with_delay(UartRx::Clear, Duration::from_millis(50))?;
-    let mut capture = UartConsole::wait_for(
+    wait_for_boot(&*uart, opts.timeout, 2, 5)?;
+
+    log::info!("###### Reboot again to verify persistence ######");
+    transport.reset_with_delay(UartRx::Clear, Duration::from_millis(50))?;
+
+    let capture = UartConsole::wait_for(
         &*uart,
         r"(?msR)Running.*PASS!$|BFV:([0-9A-Fa-f]{8})$",
         opts.timeout,
     )?;
-    if capture[0].starts_with("BFV") {
-        let err = u32::from_str_radix(&capture[1], 16)?;
-        if err == 0 {
-            log::info!("Detected expected write-and-reboot (BFV:00000000). Waiting for next boot...");
-            // Wait again for the actual boot to PASS!
-            capture = UartConsole::wait_for(
-                &*uart,
-                r"(?msR)Running.*PASS!$|BFV:([0-9A-Fa-f]{8})$",
-                opts.timeout,
-            )?;
-            if capture[0].starts_with("BFV") {
-                return RomError(u32::from_str_radix(&capture[1], 16)?).into();
-            }
-        } else {
-            return RomError(err).into();
-        }
-    }
+    ensure!(!capture[0].starts_with("BFV"), "Boot failed or triggered unexpected reboot");
+    ensure!(capture[0].contains("config_version = 2"), "Expected config_version = 2");
+    ensure!(capture[0].contains("bl0_min_sec_ver = 5"), "Expected bl0_min_sec_ver = 5");
 
-    for exp in opts.expect.iter() {
-        let erx = Regex::new(exp)?;
-        ensure!(
-            erx.is_match(&capture[0]),
-            "Did not find expected output {exp:?}"
-        );
-    }
-
+    log::info!("###### BL0 SecVer Persistence test passed! ######");
     Ok(())
 }
 
@@ -163,22 +147,5 @@ fn main() -> Result<()> {
     let opts = Opts::parse();
     opts.init.init_logging();
     let transport = opts.init.init_target()?;
-
-    let result = newversion_test(&opts, &transport);
-    if let Some(error) = &opts.expected_error {
-        match result {
-            Ok(_) => Err(anyhow!("Ok when expecting {error:?}")),
-            Err(e) => {
-                let re = Regex::new(error).expect("regex");
-                if re.is_match(&e.to_string()) {
-                    log::info!("Got expected error code: {e}");
-                    Ok(())
-                } else {
-                    Err(anyhow!("Expected {error:?} but got {e}"))
-                }
-            }
-        }
-    } else {
-        result
-    }
+    bl0_secver_persistence_test(&opts, &transport)
 }


### PR DESCRIPTION
This fixes a bug in the ownership initialization flow where the minimum security version for BL0 (`min_security_version_bl0`) was not persisted to flash during automatic same-owner updates (NewVersion / SelfVersion modes).

Previously, `locked_owner_init` would successfully call `ownership_activate` which updated the floor in the RAM copy of `bootdata`, but it returned `kErrorOk` and continued booting. Because it did not return `kErrorWriteBootdataThenReboot`, the updated `bootdata` was never written to flash, causing the new floor to be lost upon the next reset.

This change resolves the issue by:
1. Modifying the ownership initialization flow to trigger the standard write-and-reboot sequence when a same-owner update is successfully activated, ensuring `bootdata` is persisted to flash.
2. Implementing a self-healing check during boot to automatically recover and persist the floor if a power loss occurs mid-update (i.e., after the owner configuration is updated but before `bootdata` is written).

Added a new E2E test `bl0_secver_persistence_test` to verify that the floor is successfully written to flash and survives multiple hard resets.