### PR TITLE
[crypto/itegrity] Cleanup public header

### DIFF
--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -46,7 +46,7 @@ static status_t aes_key_construct(otcrypto_blinded_key_t *blinded_key,
                                   const otcrypto_aes_mode_t aes_mode,
                                   aes_key_t *aes_key) {
   // Key integrity check.
-  if (integrity_blinded_key_check(blinded_key) != kHardenedBoolTrue) {
+  if (otcrypto_integrity_blinded_key_check(blinded_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -126,8 +126,9 @@ static status_t aes_key_construct(otcrypto_blinded_key_t *blinded_key,
   // Second integrity check of the key we got passed into the cryptolib.
   // This check is placed here to catch any corruptions that might have
   // happen after the first check when assembling the `aes_key`.
-  HARDENED_CHECK_EQ(launder32(integrity_blinded_key_check(blinded_key)),
-                    kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(
+      launder32(otcrypto_integrity_blinded_key_check(blinded_key)),
+      kHardenedBoolTrue);
 
   return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/impl/aes_gcm.c
+++ b/sw/device/lib/crypto/impl/aes_gcm.c
@@ -113,7 +113,7 @@ status_t gcm_remask_key(aes_gcm_context_t *internal_ctx) {
 static status_t aes_gcm_key_construct(otcrypto_blinded_key_t *blinded_key,
                                       aes_key_t *aes_key) {
   // Key integrity check.
-  if (launder32(integrity_blinded_key_check(blinded_key)) !=
+  if (launder32(otcrypto_integrity_blinded_key_check(blinded_key)) !=
       kHardenedBoolTrue) {
     // COVERAGE (MISSING) The bad integrity input key is not covered.
     return OTCRYPTO_BAD_ARGS;
@@ -168,7 +168,7 @@ static status_t aes_gcm_key_construct(otcrypto_blinded_key_t *blinded_key,
   // Second integrity check of the key we got passed into the cryptolib.
   // This check is placed here to catch any corruptions that might have
   // happen after the first check when assembling the `aes_key`.
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(blinded_key),
+  HARDENED_CHECK_EQ(otcrypto_integrity_blinded_key_check(blinded_key),
                     kHardenedBoolTrue);
 
   return OTCRYPTO_OK;

--- a/sw/device/lib/crypto/impl/ecc_curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc_curve25519.c
@@ -62,11 +62,12 @@ static status_t curve25519_private_key_length_check(
   HARDENED_CHECK_EQ(launder32(private_key->config.key_mode), expected_mode);
 
   // Check the integrity of the key.
-  if (integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
+  if (otcrypto_integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(integrity_blinded_key_check(private_key)),
-                    kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(
+      launder32(otcrypto_integrity_blinded_key_check(private_key)),
+      kHardenedBoolTrue);
 
   return OTCRYPTO_OK;
 }
@@ -93,10 +94,10 @@ static status_t curve25519_public_key_length_check(
   HARDENED_CHECK_EQ(launder32(key->key_mode), expected_mode);
 
   // Check the integrity of the key.
-  if (integrity_unblinded_key_check(key) != kHardenedBoolTrue) {
+  if (otcrypto_integrity_unblinded_key_check(key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(integrity_unblinded_key_check(key)),
+  HARDENED_CHECK_EQ(launder32(otcrypto_integrity_unblinded_key_check(key)),
                     kHardenedBoolTrue);
 
   return OTCRYPTO_OK;
@@ -458,7 +459,7 @@ otcrypto_status_t otcrypto_ed25519_public_key_from_private_async_finalize(
   // Finalize the keygen operation and retrieve the public key.
   HARDENED_TRY_WIPE_DMEM(curve25519_keygen_finalize(public_key->key));
   // Calculate the public key checksum.
-  public_key->checksum = integrity_unblinded_checksum(public_key);
+  public_key->checksum = otcrypto_integrity_unblinded_checksum(public_key);
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
@@ -722,7 +723,7 @@ otcrypto_status_t otcrypto_x25519_keygen_async_start(
 otcrypto_status_t otcrypto_x25519_keygen_async_finalize(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
   HARDENED_TRY_WIPE_DMEM(curve25519_x25519_keygen_finalize(public_key->key));
-  public_key->checksum = integrity_unblinded_checksum(public_key);
+  public_key->checksum = otcrypto_integrity_unblinded_checksum(public_key);
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
@@ -769,6 +770,6 @@ otcrypto_status_t otcrypto_x25519_async_finalize(
   HARDENED_TRY(
       hardened_sub(unmasked_secret, share1, kCurve25519PointWords, share0));
 
-  shared_secret->checksum = integrity_blinded_checksum(shared_secret);
+  shared_secret->checksum = otcrypto_integrity_blinded_checksum(shared_secret);
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }

--- a/sw/device/lib/crypto/impl/ecc_p256.c
+++ b/sw/device/lib/crypto/impl/ecc_p256.c
@@ -131,8 +131,8 @@ static status_t internal_p256_keygen_finalize(
   }
 
   // Set the key checksums.
-  private_key->checksum = integrity_blinded_checksum(private_key);
-  public_key->checksum = integrity_unblinded_checksum(public_key);
+  private_key->checksum = otcrypto_integrity_blinded_checksum(private_key);
+  public_key->checksum = otcrypto_integrity_unblinded_checksum(public_key);
 
   // Clear the OTBN sideload slot (in case the seed was sideloaded).
   return keymgr_sideload_clear_otbn();
@@ -273,7 +273,7 @@ status_t otcrypto_ecc_p256_base_point_mult(
     return OTCRYPTO_BAD_ARGS;
   }
 
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(private_key),
+  HARDENED_CHECK_EQ(otcrypto_integrity_blinded_key_check(private_key),
                     kHardenedBoolTrue);
 
   p256_masked_scalar_t private_scalar;
@@ -287,7 +287,7 @@ status_t otcrypto_ecc_p256_base_point_mult(
   p256_point_t *pk = (p256_point_t *)public_key->key;
   HARDENED_TRY_WIPE_DMEM(p256_base_point_mult(&private_scalar, pk));
 
-  public_key->checksum = integrity_unblinded_checksum(public_key);
+  public_key->checksum = otcrypto_integrity_unblinded_checksum(public_key);
 
   return OTCRYPTO_OK;
 }
@@ -397,11 +397,12 @@ static otcrypto_status_t otcrypto_ecdsa_p256_sign_async_start_setup(
   }
 
   // Check the integrity of the private key.
-  if (integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
+  if (otcrypto_integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(integrity_blinded_key_check(private_key)),
-                    kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(
+      launder32(otcrypto_integrity_blinded_key_check(private_key)),
+      kHardenedBoolTrue);
 
   if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP256) {
     return OTCRYPTO_BAD_ARGS;
@@ -452,7 +453,7 @@ otcrypto_status_t otcrypto_ecdsa_p256_sign_config_k_async_start(
   // to the ECC implementation, check again its integrity. If the pointer would
   // have been tampered with between the first integrity check we did when
   // entering the CryptoLib and here, we would detect this now.
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(private_key),
+  HARDENED_CHECK_EQ(otcrypto_integrity_blinded_key_check(private_key),
                     kHardenedBoolTrue);
 
   return otcrypto_eval_exit(OTCRYPTO_OK);
@@ -495,7 +496,7 @@ otcrypto_status_t otcrypto_ecdsa_p256_sign_async_start(
   // to the ECC implementation, check again its integrity. If the pointer would
   // have been tampered with between the first integrity check we did when
   // entering the CryptoLib and here, we would detect this now.
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(private_key),
+  HARDENED_CHECK_EQ(otcrypto_integrity_blinded_key_check(private_key),
                     kHardenedBoolTrue);
 
   return otcrypto_eval_exit(OTCRYPTO_OK);
@@ -569,11 +570,12 @@ otcrypto_status_t otcrypto_ecdsa_p256_verify_async_start(
   }
 
   // Check the integrity of the public key.
-  if (integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
+  if (otcrypto_integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(integrity_unblinded_key_check(public_key)),
-                    kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(
+      launder32(otcrypto_integrity_unblinded_key_check(public_key)),
+      kHardenedBoolTrue);
 
   // Check the public key mode.
   if (public_key->key_mode != kOtcryptoKeyModeEcdsaP256) {
@@ -602,7 +604,7 @@ otcrypto_status_t otcrypto_ecdsa_p256_verify_async_start(
   // to the ECC implementation, check again its integrity. If the pointer would
   // have been tampered with between the first integrity check we did when
   // entering the CryptoLib and here, we would detect this now.
-  HARDENED_CHECK_EQ(integrity_unblinded_key_check(public_key),
+  HARDENED_CHECK_EQ(otcrypto_integrity_unblinded_key_check(public_key),
                     kHardenedBoolTrue);
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
@@ -669,14 +671,16 @@ otcrypto_status_t otcrypto_ecdh_p256_async_start(
   }
 
   // Check the integrity of the keys.
-  if (integrity_blinded_key_check(private_key) != kHardenedBoolTrue ||
-      integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
+  if (otcrypto_integrity_blinded_key_check(private_key) != kHardenedBoolTrue ||
+      otcrypto_integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(integrity_blinded_key_check(private_key)),
-                    kHardenedBoolTrue);
-  HARDENED_CHECK_EQ(launder32(integrity_unblinded_key_check(public_key)),
-                    kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(
+      launder32(otcrypto_integrity_blinded_key_check(private_key)),
+      kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(
+      launder32(otcrypto_integrity_unblinded_key_check(public_key)),
+      kHardenedBoolTrue);
 
   // Check the key modes.
   if (private_key->config.key_mode != kOtcryptoKeyModeEcdhP256 ||
@@ -718,9 +722,9 @@ otcrypto_status_t otcrypto_ecdh_p256_async_start(
   // to the ECC implementation, check again its integrity. If the pointer would
   // have been tampered with between the first integrity check we did when
   // entering the CryptoLib and here, we would detect this now.
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(private_key),
+  HARDENED_CHECK_EQ(otcrypto_integrity_blinded_key_check(private_key),
                     kHardenedBoolTrue);
-  HARDENED_CHECK_EQ(integrity_unblinded_key_check(public_key),
+  HARDENED_CHECK_EQ(otcrypto_integrity_unblinded_key_check(public_key),
                     kHardenedBoolTrue);
 
   return otcrypto_eval_exit(OTCRYPTO_OK);
@@ -769,7 +773,7 @@ otcrypto_status_t otcrypto_ecdh_p256_async_finalize(
                                    shared_secret->keyblob));
 
   // Set the checksum.
-  shared_secret->checksum = integrity_blinded_checksum(shared_secret);
+  shared_secret->checksum = otcrypto_integrity_blinded_checksum(shared_secret);
 
   // Clear the OTBN sideload slot (in case the seed was sideloaded).
   return otcrypto_eval_exit(keymgr_sideload_clear_otbn());
@@ -806,7 +810,7 @@ otcrypto_status_t otcrypto_ecc_p256_public_key_import(
   HARDENED_TRY(hardened_memcpy(pt->y, y.data, kP256CoordWords));
 
   // Calculate the public key checksum.
-  public_key->checksum = integrity_unblinded_checksum(public_key);
+  public_key->checksum = otcrypto_integrity_unblinded_checksum(public_key);
 
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
@@ -837,7 +841,7 @@ otcrypto_status_t otcrypto_ecc_p256_public_key_export(
   HARDENED_TRY(p256_public_key_length_check(public_key));
 
   // Check the integrity of the public key.
-  if (integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
+  if (otcrypto_integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -896,7 +900,7 @@ otcrypto_status_t otcrypto_ecc_p256_private_key_import(
                       share1.data, kP256MaskedScalarShareWords));
 
   // Set the blinded key checksum.
-  private_key->checksum = integrity_blinded_checksum(private_key);
+  private_key->checksum = otcrypto_integrity_blinded_checksum(private_key);
 
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
@@ -943,7 +947,7 @@ otcrypto_status_t otcrypto_ecc_p256_private_key_export(
   HARDENED_TRY(p256_private_key_length_check(private_key));
 
   // Check the integrity of the provided private key.
-  if (integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
+  if (otcrypto_integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -1022,7 +1026,8 @@ otcrypto_status_t otcrypto_ecc_p256_arith_share_private_key(
                                kP256MaskedScalarTotalShareWords));
 
   // Set the shared key checksum.
-  arith_private_key->checksum = integrity_blinded_checksum(arith_private_key);
+  arith_private_key->checksum =
+      otcrypto_integrity_blinded_checksum(arith_private_key);
 
   HARDENED_CHECK_EQ(OTCRYPTO_CHECK_BUF(bool_private_key_share0),
                     kHardenedBoolTrue);

--- a/sw/device/lib/crypto/impl/ecc_p384.c
+++ b/sw/device/lib/crypto/impl/ecc_p384.c
@@ -182,8 +182,8 @@ static status_t internal_p384_keygen_finalize(
     return OTCRYPTO_BAD_ARGS;
   }
 
-  private_key->checksum = integrity_blinded_checksum(private_key);
-  public_key->checksum = integrity_unblinded_checksum(public_key);
+  private_key->checksum = otcrypto_integrity_blinded_checksum(private_key);
+  public_key->checksum = otcrypto_integrity_unblinded_checksum(public_key);
   return OTCRYPTO_OK;
 }
 
@@ -297,7 +297,7 @@ status_t otcrypto_ecc_p384_base_point_mult(
     return OTCRYPTO_BAD_ARGS;
   }
 
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(private_key),
+  HARDENED_CHECK_EQ(otcrypto_integrity_blinded_key_check(private_key),
                     kHardenedBoolTrue);
 
   p384_masked_scalar_t private_scalar;
@@ -311,7 +311,7 @@ status_t otcrypto_ecc_p384_base_point_mult(
   p384_point_t *pk = (p384_point_t *)public_key->key;
   HARDENED_TRY_WIPE_DMEM(p384_base_point_mult(&private_scalar, pk));
 
-  public_key->checksum = integrity_unblinded_checksum(public_key);
+  public_key->checksum = otcrypto_integrity_unblinded_checksum(public_key);
 
   return OTCRYPTO_OK;
 }
@@ -349,11 +349,12 @@ static otcrypto_status_t otcrypto_ecdsa_p384_sign_async_start_setup(
   }
 
   // Check the integrity of the private key.
-  if (integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
+  if (otcrypto_integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(integrity_blinded_key_check(private_key)),
-                    kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(
+      launder32(otcrypto_integrity_blinded_key_check(private_key)),
+      kHardenedBoolTrue);
 
   if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP384) {
     return OTCRYPTO_BAD_ARGS;
@@ -404,7 +405,7 @@ otcrypto_status_t otcrypto_ecdsa_p384_sign_config_k_async_start(
   // to the ECC implementation, check again its integrity. If the pointer would
   // have been tampered with between the first integrity check we did when
   // entering the CryptoLib and here, we would detect this now.
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(private_key),
+  HARDENED_CHECK_EQ(otcrypto_integrity_blinded_key_check(private_key),
                     kHardenedBoolTrue);
 
   return otcrypto_eval_exit(OTCRYPTO_OK);
@@ -447,7 +448,7 @@ otcrypto_status_t otcrypto_ecdsa_p384_sign_async_start(
   // to the ECC implementation, check again its integrity. If the pointer would
   // have been tampered with between the first integrity check we did when
   // entering the CryptoLib and here, we would detect this now.
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(private_key),
+  HARDENED_CHECK_EQ(otcrypto_integrity_blinded_key_check(private_key),
                     kHardenedBoolTrue);
 
   return otcrypto_eval_exit(OTCRYPTO_OK);
@@ -482,11 +483,12 @@ otcrypto_status_t otcrypto_ecdsa_p384_verify_async_start(
   }
 
   // Check the integrity of the public key.
-  if (integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
+  if (otcrypto_integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(integrity_unblinded_key_check(public_key)),
-                    kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(
+      launder32(otcrypto_integrity_unblinded_key_check(public_key)),
+      kHardenedBoolTrue);
 
   // Check the public key mode.
   if (public_key->key_mode != kOtcryptoKeyModeEcdsaP384) {
@@ -515,7 +517,7 @@ otcrypto_status_t otcrypto_ecdsa_p384_verify_async_start(
   // to the ECC implementation, check again its integrity. If the pointer would
   // have been tampered with between the first integrity check we did when
   // entering the CryptoLib and here, we would detect this now.
-  HARDENED_CHECK_EQ(integrity_unblinded_key_check(public_key),
+  HARDENED_CHECK_EQ(otcrypto_integrity_unblinded_key_check(public_key),
                     kHardenedBoolTrue);
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
@@ -583,14 +585,16 @@ otcrypto_status_t otcrypto_ecdh_p384_async_start(
   }
 
   // Check the integrity of the keys.
-  if (integrity_blinded_key_check(private_key) != kHardenedBoolTrue ||
-      integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
+  if (otcrypto_integrity_blinded_key_check(private_key) != kHardenedBoolTrue ||
+      otcrypto_integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(integrity_blinded_key_check(private_key)),
-                    kHardenedBoolTrue);
-  HARDENED_CHECK_EQ(launder32(integrity_unblinded_key_check(public_key)),
-                    kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(
+      launder32(otcrypto_integrity_blinded_key_check(private_key)),
+      kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(
+      launder32(otcrypto_integrity_unblinded_key_check(public_key)),
+      kHardenedBoolTrue);
 
   // Check the key modes.
   if (private_key->config.key_mode != kOtcryptoKeyModeEcdhP384 ||
@@ -632,9 +636,9 @@ otcrypto_status_t otcrypto_ecdh_p384_async_start(
   // have passed to the ECC implementation, check again their integrity. If the
   // pointers would have been tampered with between the first integrity check we
   // did when entering the CryptoLib and here, we would detect this now.
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(private_key),
+  HARDENED_CHECK_EQ(otcrypto_integrity_blinded_key_check(private_key),
                     kHardenedBoolTrue);
-  HARDENED_CHECK_EQ(integrity_unblinded_key_check(public_key),
+  HARDENED_CHECK_EQ(otcrypto_integrity_unblinded_key_check(public_key),
                     kHardenedBoolTrue);
 
   return otcrypto_eval_exit(OTCRYPTO_OK);
@@ -683,7 +687,7 @@ otcrypto_status_t otcrypto_ecdh_p384_async_finalize(
                                    shared_secret->keyblob));
 
   // Set the checksum.
-  shared_secret->checksum = integrity_blinded_checksum(shared_secret);
+  shared_secret->checksum = otcrypto_integrity_blinded_checksum(shared_secret);
 
   // Clear the OTBN sideload slot (in case the seed was sideloaded).
   return otcrypto_eval_exit(keymgr_sideload_clear_otbn());
@@ -720,7 +724,7 @@ otcrypto_status_t otcrypto_ecc_p384_public_key_import(
   HARDENED_TRY(hardened_memcpy(pt->y, y.data, kP384CoordWords));
 
   // Calculate the public key checksum.
-  public_key->checksum = integrity_unblinded_checksum(public_key);
+  public_key->checksum = otcrypto_integrity_unblinded_checksum(public_key);
 
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
@@ -751,7 +755,7 @@ otcrypto_status_t otcrypto_ecc_p384_public_key_export(
   HARDENED_TRY(p384_public_key_length_check(public_key));
 
   // Check the integrity of the public key.
-  if (integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
+  if (otcrypto_integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -810,7 +814,7 @@ otcrypto_status_t otcrypto_ecc_p384_private_key_import(
                       share1.data, kP384MaskedScalarShareWords));
 
   // Set the blinded key checksum.
-  private_key->checksum = integrity_blinded_checksum(private_key);
+  private_key->checksum = otcrypto_integrity_blinded_checksum(private_key);
 
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
@@ -857,7 +861,7 @@ otcrypto_status_t otcrypto_ecc_p384_private_key_export(
   HARDENED_TRY(p384_private_key_length_check(private_key));
 
   // Check the integrity of the provided private key.
-  if (integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
+  if (otcrypto_integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -936,7 +940,8 @@ otcrypto_status_t otcrypto_ecc_p384_arith_share_private_key(
                                kP384MaskedScalarTotalShareWords));
 
   // Set the shared key checksum.
-  arith_private_key->checksum = integrity_blinded_checksum(arith_private_key);
+  arith_private_key->checksum =
+      otcrypto_integrity_blinded_checksum(arith_private_key);
 
   HARDENED_CHECK_EQ(OTCRYPTO_CHECK_BUF(bool_private_key_share0),
                     kHardenedBoolTrue);

--- a/sw/device/lib/crypto/impl/hkdf.c
+++ b/sw/device/lib/crypto/impl/hkdf.c
@@ -138,7 +138,8 @@ otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t *ikm,
   }
 
   // Check the private key checksum.
-  if (launder32(integrity_blinded_key_check(ikm)) != kHardenedBoolTrue) {
+  if (launder32(otcrypto_integrity_blinded_key_check(ikm)) !=
+      kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -200,7 +201,7 @@ otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t *ikm,
       .keyblob = salt_keyblob,
       .keyblob_length = sizeof(salt_keyblob),
   };
-  salt_key.checksum = integrity_blinded_checksum(&salt_key);
+  salt_key.checksum = otcrypto_integrity_blinded_checksum(&salt_key);
 
   // Call HMAC(salt, IKM).
   uint32_t tag_data[digest_words];
@@ -214,7 +215,7 @@ otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t *ikm,
   memset(prk_mask, 0, sizeof(prk_mask));
   HARDENED_TRY(
       keyblob_from_key_and_mask(tag_data, prk_mask, prk->config, prk->keyblob));
-  prk->checksum = integrity_blinded_checksum(prk);
+  prk->checksum = otcrypto_integrity_blinded_checksum(prk);
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
@@ -294,6 +295,6 @@ otcrypto_status_t otcrypto_hkdf_expand(const otcrypto_blinded_key_t *prk,
   // Construct a blinded key.
   HARDENED_TRY(
       keyblob_from_key_and_mask(okm_data, mask, okm->config, okm->keyblob));
-  okm->checksum = integrity_blinded_checksum(okm);
+  okm->checksum = otcrypto_integrity_blinded_checksum(okm);
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }

--- a/sw/device/lib/crypto/impl/hmac.c
+++ b/sw/device/lib/crypto/impl/hmac.c
@@ -221,10 +221,12 @@ static status_t check_key(const otcrypto_blinded_key_t *key) {
   }
 
   // Check the integrity of the key.
-  if (launder32(integrity_blinded_key_check(key)) != kHardenedBoolTrue) {
+  if (launder32(otcrypto_integrity_blinded_key_check(key)) !=
+      kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(key), kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(otcrypto_integrity_blinded_key_check(key),
+                    kHardenedBoolTrue);
 
   return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/impl/integrity.c
+++ b/sw/device/lib/crypto/impl/integrity.c
@@ -8,7 +8,8 @@
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/macros.h"
 
-uint32_t integrity_unblinded_checksum(const otcrypto_unblinded_key_t *key) {
+uint32_t otcrypto_integrity_unblinded_checksum(
+    const otcrypto_unblinded_key_t *key) {
   uint32_t ctx;
   crc32_init(&ctx);
   crc32_add32(&ctx, key->key_mode);
@@ -17,7 +18,8 @@ uint32_t integrity_unblinded_checksum(const otcrypto_unblinded_key_t *key) {
   return crc32_finish(&ctx);
 }
 
-uint32_t integrity_blinded_checksum(const otcrypto_blinded_key_t *key) {
+uint32_t otcrypto_integrity_blinded_checksum(
+    const otcrypto_blinded_key_t *key) {
   uint32_t ctx;
   crc32_init(&ctx);
   crc32_add32(&ctx, key->config.version);
@@ -31,16 +33,18 @@ uint32_t integrity_blinded_checksum(const otcrypto_blinded_key_t *key) {
   return crc32_finish(&ctx);
 }
 
-hardened_bool_t integrity_unblinded_key_check(
+hardened_bool_t otcrypto_integrity_unblinded_key_check(
     const otcrypto_unblinded_key_t *key) {
-  if (key->checksum == launder32(integrity_unblinded_checksum(key))) {
-    HARDENED_CHECK_EQ(key->checksum, integrity_unblinded_checksum(key));
+  if (key->checksum == launder32(otcrypto_integrity_unblinded_checksum(key))) {
+    HARDENED_CHECK_EQ(key->checksum,
+                      otcrypto_integrity_unblinded_checksum(key));
     return kHardenedBoolTrue;
   }
   return kHardenedBoolFalse;
 }
 
-hardened_bool_t integrity_blinded_key_check(const otcrypto_blinded_key_t *key) {
+hardened_bool_t otcrypto_integrity_blinded_key_check(
+    const otcrypto_blinded_key_t *key) {
   // Reject keys that come from a newer version of the library (downgrade
   // protection).
   if (launder32(key->config.version) != kOtcryptoLibVersion1) {
@@ -48,17 +52,19 @@ hardened_bool_t integrity_blinded_key_check(const otcrypto_blinded_key_t *key) {
   }
   HARDENED_CHECK_EQ(key->config.version, kOtcryptoLibVersion1);
 
-  if (key->checksum == launder32(integrity_blinded_checksum(key))) {
-    HARDENED_CHECK_EQ(key->checksum, integrity_blinded_checksum(key));
+  if (key->checksum == launder32(otcrypto_integrity_blinded_checksum(key))) {
+    HARDENED_CHECK_EQ(key->checksum, otcrypto_integrity_blinded_checksum(key));
     return kHardenedBoolTrue;
   }
   return kHardenedBoolFalse;
 }
 
 #ifndef OTCRYPTO_DISABLE_BUF_INTEGRITY_CHECKS
+
 OT_NOINLINE
 hardened_bool_t verify_buf_integrity(const otcrypto_generic_buf_t *buf) {
-  uint32_t expected = calculate_buf_checksum(buf->data, buf->len);
+  uint32_t expected = kOtcryptoInitIntegrityChecksum +
+                      (uint32_t)(uintptr_t)buf->data + (uint32_t)buf->len;
 
   if (buf->ptr_checksum == launder32(expected)) {
     HARDENED_CHECK_EQ(buf->ptr_checksum, expected);

--- a/sw/device/lib/crypto/impl/integrity_unittest.cc
+++ b/sw/device/lib/crypto/impl/integrity_unittest.cc
@@ -30,9 +30,9 @@ TEST(IntegrityTest, UnblindedKeyValid) {
       .key_length = static_cast<uint32_t>(key_data.size() * sizeof(uint32_t)),
       .key = key_data.data(),
   };
-  key.checksum = integrity_unblinded_checksum(&key);
+  key.checksum = otcrypto_integrity_unblinded_checksum(&key);
 
-  EXPECT_EQ(integrity_unblinded_key_check(&key), kHardenedBoolTrue);
+  EXPECT_EQ(otcrypto_integrity_unblinded_key_check(&key), kHardenedBoolTrue);
 }
 
 TEST(IntegrityTest, UnblindedKeyCorruptedData) {
@@ -43,10 +43,10 @@ TEST(IntegrityTest, UnblindedKeyCorruptedData) {
       .key_length = static_cast<uint32_t>(key_data.size() * sizeof(uint32_t)),
       .key = key_data.data(),
   };
-  key.checksum = integrity_unblinded_checksum(&key);
+  key.checksum = otcrypto_integrity_unblinded_checksum(&key);
 
   key_data[0] ^= 0xFFFFFFFF;
-  EXPECT_EQ(integrity_unblinded_key_check(&key), kHardenedBoolFalse);
+  EXPECT_EQ(otcrypto_integrity_unblinded_key_check(&key), kHardenedBoolFalse);
 }
 
 TEST(IntegrityTest, BlindedKeyValid) {
@@ -59,9 +59,9 @@ TEST(IntegrityTest, BlindedKeyValid) {
       .keyblob = keyblob.data(),
   };
 
-  key.checksum = integrity_blinded_checksum(&key);
+  key.checksum = otcrypto_integrity_blinded_checksum(&key);
 
-  EXPECT_EQ(integrity_blinded_key_check(&key), kHardenedBoolTrue);
+  EXPECT_EQ(otcrypto_integrity_blinded_key_check(&key), kHardenedBoolTrue);
 }
 
 TEST(IntegrityTest, BlindedKeyCorruptedConfig) {
@@ -74,7 +74,7 @@ TEST(IntegrityTest, BlindedKeyCorruptedConfig) {
           static_cast<uint32_t>(keyblob.size() * sizeof(uint32_t)),
       .keyblob = keyblob.data(),
   };
-  uint32_t original_checksum = integrity_blinded_checksum(&valid_key);
+  uint32_t original_checksum = otcrypto_integrity_blinded_checksum(&valid_key);
 
   otcrypto_key_config_t bad_config = kValidConfig;
   bad_config.security_level = kOtcryptoKeySecurityLevelHigh;
@@ -86,7 +86,7 @@ TEST(IntegrityTest, BlindedKeyCorruptedConfig) {
   };
   bad_key.checksum = original_checksum;
 
-  EXPECT_EQ(integrity_blinded_key_check(&bad_key), kHardenedBoolFalse);
+  EXPECT_EQ(otcrypto_integrity_blinded_key_check(&bad_key), kHardenedBoolFalse);
 }
 
 TEST(IntegrityTest, BlindedKeyDowngradeProtection) {
@@ -103,9 +103,9 @@ TEST(IntegrityTest, BlindedKeyDowngradeProtection) {
       .keyblob = keyblob.data(),
   };
 
-  key.checksum = integrity_blinded_checksum(&key);
+  key.checksum = otcrypto_integrity_blinded_checksum(&key);
 
-  EXPECT_EQ(integrity_blinded_key_check(&key), kHardenedBoolFalse);
+  EXPECT_EQ(otcrypto_integrity_blinded_key_check(&key), kHardenedBoolFalse);
 }
 
 TEST(IntegrityTest, BufferCreationAndCheck) {

--- a/sw/device/lib/crypto/impl/kats.c
+++ b/sw/device/lib/crypto/impl/kats.c
@@ -582,7 +582,7 @@ static status_t kat_sha256_hmac(void) {
       .keyblob_length = sizeof(keyblob),
       .checksum = 0,
   };
-  blinded_key.checksum = integrity_blinded_checksum(&blinded_key);
+  blinded_key.checksum = otcrypto_integrity_blinded_checksum(&blinded_key);
 
   uint32_t act_tag[128 / 32];
   otcrypto_word32_buf_t tag_buf =
@@ -610,7 +610,7 @@ static status_t kat_sha512_hmac(void) {
       .keyblob_length = sizeof(keyblob),
       .checksum = 0,
   };
-  blinded_key.checksum = integrity_blinded_checksum(&blinded_key);
+  blinded_key.checksum = otcrypto_integrity_blinded_checksum(&blinded_key);
 
   uint32_t act_tag[32 / 4];
   otcrypto_word32_buf_t tag_buf =
@@ -640,7 +640,7 @@ static status_t kat_p256_sign(void) {
       .checksum = 0,
   };
   memcpy(keyblob_sk, p256_d, 32);
-  private_key.checksum = integrity_blinded_checksum(&private_key);
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
 
   uint32_t keyblob_scalar[20] = {0};
   otcrypto_blinded_key_t secret_scalar = {
@@ -650,7 +650,7 @@ static status_t kat_p256_sign(void) {
       .checksum = 0,
   };
   memcpy(keyblob_scalar, p256_k, 32);
-  secret_scalar.checksum = integrity_blinded_checksum(&secret_scalar);
+  secret_scalar.checksum = otcrypto_integrity_blinded_checksum(&secret_scalar);
 
   otcrypto_hash_digest_t digest = {.data = (uint32_t *)p256_msg_digest,
                                    .len = 8};
@@ -676,7 +676,7 @@ static status_t kat_p256_base_point_mul(void) {
       .keyblob = keyblob_sk,
   };
   memcpy(keyblob_sk, p256_d, 32);
-  private_key.checksum = integrity_blinded_checksum(&private_key);
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
 
   uint32_t pk_act[16] = {0};
   otcrypto_unblinded_key_t public_key = {
@@ -702,7 +702,7 @@ static status_t kat_p256_verify(void) {
       .key_length = sizeof(p256_Q),
       .key = (uint32_t *)p256_Q,
   };
-  public_key.checksum = integrity_unblinded_checksum(&public_key);
+  public_key.checksum = otcrypto_integrity_unblinded_checksum(&public_key);
 
   otcrypto_hash_digest_t digest = {.data = (uint32_t *)p256_msg_digest,
                                    .len = 8};
@@ -730,7 +730,7 @@ static status_t kat_p256_point_on_curve(void) {
   otcrypto_unblinded_key_t point = {.key_mode = kOtcryptoKeyModeEcdsaP256,
                                     .key = (uint32_t *)p256_Q,
                                     .key_length = sizeof(p256_Q)};
-  point.checksum = integrity_unblinded_checksum(&point);
+  point.checksum = otcrypto_integrity_unblinded_checksum(&point);
 
   HARDENED_TRY(otcrypto_ecc_p256_point_on_curve(&point, &result));
   HARDENED_CHECK_EQ(result, kHardenedBoolTrue);
@@ -742,7 +742,7 @@ static status_t kat_p256_point_on_curve(void) {
   otcrypto_unblinded_key_t bad_point = {.key_mode = kOtcryptoKeyModeEcdsaP256,
                                         .key = bad_point_data,
                                         .key_length = sizeof(bad_point_data)};
-  bad_point.checksum = integrity_unblinded_checksum(&bad_point);
+  bad_point.checksum = otcrypto_integrity_unblinded_checksum(&bad_point);
 
   HARDENED_TRY(otcrypto_ecc_p256_point_on_curve(&bad_point, &result));
   HARDENED_CHECK_EQ(result, kHardenedBoolFalse);
@@ -760,7 +760,7 @@ static status_t kat_p384_sign(void) {
   };
 
   memcpy(keyblob_sk, p384_d, 48);
-  private_key.checksum = integrity_blinded_checksum(&private_key);
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
 
   uint32_t keyblob_scalar[28] = {0};
   otcrypto_blinded_key_t secret_scalar = {
@@ -770,7 +770,7 @@ static status_t kat_p384_sign(void) {
       .checksum = 0,
   };
   memcpy(keyblob_scalar, p384_k, 48);
-  secret_scalar.checksum = integrity_blinded_checksum(&secret_scalar);
+  secret_scalar.checksum = otcrypto_integrity_blinded_checksum(&secret_scalar);
 
   otcrypto_hash_digest_t digest = {.data = (uint32_t *)p384_msg_digest,
                                    .len = 12};
@@ -797,7 +797,7 @@ static status_t kat_p384_base_point_mul(void) {
       .checksum = 0,
   };
   memcpy(keyblob_sk, p384_d, 48);
-  private_key.checksum = integrity_blinded_checksum(&private_key);
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
 
   uint32_t pk_act[24] = {0};
   otcrypto_unblinded_key_t public_key = {
@@ -823,7 +823,7 @@ static status_t kat_p384_verify(void) {
       .key_length = sizeof(p384_Q),
       .key = (uint32_t *)p384_Q,
   };
-  public_key.checksum = integrity_unblinded_checksum(&public_key);
+  public_key.checksum = otcrypto_integrity_unblinded_checksum(&public_key);
 
   otcrypto_hash_digest_t digest = {.data = (uint32_t *)p384_msg_digest,
                                    .len = 12};
@@ -851,7 +851,7 @@ static status_t kat_p384_point_on_curve(void) {
   otcrypto_unblinded_key_t point = {.key_mode = kOtcryptoKeyModeEcdsaP384,
                                     .key = (uint32_t *)p384_Q,
                                     .key_length = sizeof(p384_Q)};
-  point.checksum = integrity_unblinded_checksum(&point);
+  point.checksum = otcrypto_integrity_unblinded_checksum(&point);
 
   HARDENED_TRY(otcrypto_ecc_p384_point_on_curve(&point, &result));
   HARDENED_CHECK_EQ(result, kHardenedBoolTrue);
@@ -863,7 +863,7 @@ static status_t kat_p384_point_on_curve(void) {
   otcrypto_unblinded_key_t bad_point = {.key_mode = kOtcryptoKeyModeEcdsaP384,
                                         .key = bad_point_data,
                                         .key_length = sizeof(bad_point_data)};
-  bad_point.checksum = integrity_unblinded_checksum(&bad_point);
+  bad_point.checksum = otcrypto_integrity_unblinded_checksum(&bad_point);
 
   HARDENED_TRY(otcrypto_ecc_p384_point_on_curve(&bad_point, &result));
   HARDENED_CHECK_EQ(result, kHardenedBoolFalse);
@@ -972,7 +972,7 @@ static status_t kat_aes_gcm_256_encrypt(void) {
       .keyblob_length = sizeof(keyblob),
       .checksum = 0,
   };
-  key.checksum = integrity_blinded_checksum(&key);
+  key.checksum = otcrypto_integrity_blinded_checksum(&key);
 
   otcrypto_const_byte_buf_t pt_buf = OTCRYPTO_MAKE_BUF(
       otcrypto_const_byte_buf_t, aes_gcm_256_pt, sizeof(aes_gcm_256_pt));
@@ -1013,7 +1013,7 @@ static status_t kat_aes_ecb_256_decrypt(void) {
       .keyblob_length = sizeof(keyblob),
       .checksum = 0,
   };
-  key.checksum = integrity_blinded_checksum(&key);
+  key.checksum = otcrypto_integrity_blinded_checksum(&key);
 
   otcrypto_const_byte_buf_t ct_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, (uint8_t *)aes_256_ct, 16);
@@ -1062,7 +1062,7 @@ static status_t kat_kmac_256(void) {
       .keyblob_length = sizeof(keyblob),
       .checksum = 0,
   };
-  blinded_key.checksum = integrity_blinded_checksum(&blinded_key);
+  blinded_key.checksum = otcrypto_integrity_blinded_checksum(&blinded_key);
 
   otcrypto_const_byte_buf_t msg_buf = OTCRYPTO_MAKE_BUF(
       otcrypto_const_byte_buf_t, kmac_256_in, sizeof(kmac_256_in));

--- a/sw/device/lib/crypto/impl/kdf_ctr.c
+++ b/sw/device/lib/crypto/impl/kdf_ctr.c
@@ -87,7 +87,8 @@ otcrypto_status_t otcrypto_kdf_ctr_hmac(
   }
 
   // Check the private key checksum.
-  if (integrity_blinded_key_check(key_derivation_key) != kHardenedBoolTrue) {
+  if (otcrypto_integrity_blinded_key_check(key_derivation_key) !=
+      kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -187,7 +188,7 @@ otcrypto_status_t otcrypto_kdf_ctr_hmac(
                                          output_key_material->keyblob));
 
   output_key_material->checksum =
-      integrity_blinded_checksum(output_key_material);
+      otcrypto_integrity_blinded_checksum(output_key_material);
 
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }

--- a/sw/device/lib/crypto/impl/key_transport.c
+++ b/sw/device/lib/crypto/impl/key_transport.c
@@ -56,7 +56,7 @@ otcrypto_status_t otcrypto_symmetric_keygen(
   HARDENED_TRY(otcrypto_drbg_generate(&empty, &share1_buf));
 
   // Populate the checksum and return.
-  key->checksum = integrity_blinded_checksum(key);
+  key->checksum = otcrypto_integrity_blinded_checksum(key);
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
@@ -86,7 +86,7 @@ otcrypto_status_t otcrypto_hw_backed_key(uint32_t version,
   memcpy(&key->keyblob[1], salt, 7 * sizeof(uint32_t));
 
   // Set the checksum.
-  key->checksum = integrity_blinded_checksum(key);
+  key->checksum = otcrypto_integrity_blinded_checksum(key);
 
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
@@ -108,7 +108,7 @@ otcrypto_status_t otcrypto_hw_backed_attestation_key(
   memcpy(&key->keyblob[1], salt, 8 * sizeof(uint32_t));
 
   // Set the checksum.
-  key->checksum = integrity_blinded_checksum(key);
+  key->checksum = otcrypto_integrity_blinded_checksum(key);
 
   return OTCRYPTO_OK;
 }
@@ -163,7 +163,7 @@ otcrypto_status_t ot_crypto_hw_backed_keygen(hardened_bool_t attestation,
   // Wipe the sensitive key material.
   HARDENED_TRY(hardened_memshred(output.share0, share_words));
 
-  key->checksum = integrity_blinded_checksum(key);
+  key->checksum = otcrypto_integrity_blinded_checksum(key);
 
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
@@ -206,10 +206,12 @@ otcrypto_status_t otcrypto_wrapped_key_len(const otcrypto_key_config_t config,
 static status_t aes_kwp_key_construct(const otcrypto_blinded_key_t *key_kek,
                                       aes_key_t *aes_key) {
   // Key integrity check.
-  if (launder32(integrity_blinded_key_check(key_kek)) != kHardenedBoolTrue) {
+  if (launder32(otcrypto_integrity_blinded_key_check(key_kek)) !=
+      kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(key_kek), kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(otcrypto_integrity_blinded_key_check(key_kek),
+                    kHardenedBoolTrue);
 
   // Check the key mode.
   if (launder32((uint32_t)key_kek->config.key_mode) != kOtcryptoKeyModeAesKwp) {
@@ -257,11 +259,11 @@ otcrypto_status_t otcrypto_key_wrap(const otcrypto_blinded_key_t *key_to_wrap,
   }
 
   // Check the integrity of the key material we are wrapping.
-  if (launder32(integrity_blinded_key_check(key_to_wrap)) !=
+  if (launder32(otcrypto_integrity_blinded_key_check(key_to_wrap)) !=
       kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(key_to_wrap),
+  HARDENED_CHECK_EQ(otcrypto_integrity_blinded_key_check(key_to_wrap),
                     kHardenedBoolTrue);
 
   // Check the length of the output buffer.
@@ -363,7 +365,7 @@ otcrypto_status_t otcrypto_key_unwrap(
                                plaintext + config_words + 2, keyblob_words));
 
   // Finally, check the integrity of the key material we unwrapped.
-  *success = integrity_blinded_key_check(unwrapped_key);
+  *success = otcrypto_integrity_blinded_key_check(unwrapped_key);
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
@@ -403,7 +405,7 @@ otcrypto_status_t otcrypto_import_blinded_key(
   // Construct the blinded key.
   HARDENED_TRY(keyblob_from_shares(key_share0->data, key_share1->data,
                                    blinded_key->config, blinded_key->keyblob));
-  blinded_key->checksum = integrity_blinded_checksum(blinded_key);
+  blinded_key->checksum = otcrypto_integrity_blinded_checksum(blinded_key);
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
@@ -417,11 +419,11 @@ otcrypto_status_t otcrypto_export_blinded_key(
   }
 
   // Check key integrity.
-  if (launder32(integrity_blinded_key_check(blinded_key)) !=
+  if (launder32(otcrypto_integrity_blinded_key_check(blinded_key)) !=
       kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(blinded_key),
+  HARDENED_CHECK_EQ(otcrypto_integrity_blinded_key_check(blinded_key),
                     kHardenedBoolTrue);
 
   // Ensure the key is symmetric and not hardware-backed.

--- a/sw/device/lib/crypto/impl/key_transport_unittest.cc
+++ b/sw/device/lib/crypto/impl/key_transport_unittest.cc
@@ -302,7 +302,7 @@ TEST(KeyTransport, KeyWrapUnwrapNegative) {
       .keyblob = target_keyblob,
       .checksum = 0,
   };
-  target_key.checksum = integrity_blinded_checksum(&target_key);
+  target_key.checksum = otcrypto_integrity_blinded_checksum(&target_key);
 
   uint32_t kek_keyblob[16] = {0};
   otcrypto_blinded_key_t kek_key = {
@@ -311,7 +311,7 @@ TEST(KeyTransport, KeyWrapUnwrapNegative) {
       .keyblob = kek_keyblob,
       .checksum = 0,
   };
-  kek_key.checksum = integrity_blinded_checksum(&kek_key);
+  kek_key.checksum = otcrypto_integrity_blinded_checksum(&kek_key);
 
   uint32_t wrapped_data[64] = {0};
   otcrypto_word32_buf_t wrapped_buf = {
@@ -339,7 +339,7 @@ TEST(KeyTransport, KeyWrapUnwrapNegative) {
       .keyblob = kek_keyblob,
       .checksum = 0,
   };
-  bad_kek_mode.checksum = integrity_blinded_checksum(&bad_kek_mode);
+  bad_kek_mode.checksum = otcrypto_integrity_blinded_checksum(&bad_kek_mode);
   EXPECT_NOT_OK(otcrypto_key_wrap(&target_key, &bad_kek_mode, &wrapped_buf));
 
   // Target key checksum error

--- a/sw/device/lib/crypto/impl/keyblob.c
+++ b/sw/device/lib/crypto/impl/keyblob.c
@@ -252,7 +252,7 @@ status_t keyblob_remask(otcrypto_blinded_key_t *key) {
   HARDENED_TRY(hardened_xor_in_place(share1, mask, key_share_words));
 
   // Update the key checksum.
-  key->checksum = integrity_blinded_checksum(key);
+  key->checksum = otcrypto_integrity_blinded_checksum(key);
   return OTCRYPTO_OK;
 }
 

--- a/sw/device/lib/crypto/impl/keyblob_unittest.cc
+++ b/sw/device/lib/crypto/impl/keyblob_unittest.cc
@@ -406,7 +406,7 @@ TEST(Keyblob, RemaskPassesIntegrity) {
   EXPECT_OK(keyblob_remask(&key));
 
   // Check that the integrity checksum was updated.
-  EXPECT_EQ(integrity_blinded_key_check(&key), kHardenedBoolTrue);
+  EXPECT_EQ(otcrypto_integrity_blinded_key_check(&key), kHardenedBoolTrue);
 }
 
 TEST(Keyblob, ShareNumWordsRsa) {

--- a/sw/device/lib/crypto/impl/kmac.c
+++ b/sw/device/lib/crypto/impl/kmac.c
@@ -51,10 +51,12 @@ otcrypto_status_t otcrypto_kmac(
   HARDENED_TRY(kmac_key_length_check(key_len));
 
   // Check the integrity of the blinded key.
-  if (launder32(integrity_blinded_key_check(key)) != kHardenedBoolTrue) {
+  if (launder32(otcrypto_integrity_blinded_key_check(key)) !=
+      kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(key), kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(otcrypto_integrity_blinded_key_check(key),
+                    kHardenedBoolTrue);
 
   kmac_blinded_key_t kmac_key = {
       .share0 = NULL,

--- a/sw/device/lib/crypto/impl/kmac_kdf.c
+++ b/sw/device/lib/crypto/impl/kmac_kdf.c
@@ -43,11 +43,11 @@ otcrypto_status_t otcrypto_kmac_kdf(
   }
 
   // Check the private key checksum.
-  if (launder32(integrity_blinded_key_check(key_derivation_key)) !=
+  if (launder32(otcrypto_integrity_blinded_key_check(key_derivation_key)) !=
       kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(key_derivation_key),
+  HARDENED_CHECK_EQ(otcrypto_integrity_blinded_key_check(key_derivation_key),
                     kHardenedBoolTrue);
 
   // Check `key_len` is supported by KMAC HWIP.
@@ -145,7 +145,7 @@ otcrypto_status_t otcrypto_kmac_kdf(
                     key_derivation_key->config.key_mode);
 
   output_key_material->checksum =
-      integrity_blinded_checksum(output_key_material);
+      otcrypto_integrity_blinded_checksum(output_key_material);
 
   // Clear the KMAC sideload slot in case the key was sideloaded.
   return otcrypto_eval_exit(keymgr_sideload_clear_kmac());

--- a/sw/device/lib/crypto/impl/rsa.c
+++ b/sw/device/lib/crypto/impl/rsa.c
@@ -138,7 +138,7 @@ otcrypto_status_t otcrypto_rsa_public_key_construct(
   // Verify the input buffer
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(modulus));
 
-  public_key->checksum = integrity_unblinded_checksum(public_key);
+  public_key->checksum = otcrypto_integrity_unblinded_checksum(public_key);
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
@@ -395,7 +395,7 @@ otcrypto_status_t otcrypto_rsa_private_key_from_exponents(
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(modulus));
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(d_share0));
 
-  private_key->checksum = integrity_blinded_checksum(private_key);
+  private_key->checksum = otcrypto_integrity_blinded_checksum(private_key);
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
@@ -526,8 +526,8 @@ otcrypto_status_t otcrypto_rsa_keygen_async_finalize(
   HARDENED_CHECK_EQ(launder32(size_used), size);
 
   // Construct checksums for the new keys.
-  public_key->checksum = integrity_unblinded_checksum(public_key);
-  private_key->checksum = integrity_blinded_checksum(private_key);
+  public_key->checksum = otcrypto_integrity_unblinded_checksum(public_key);
+  private_key->checksum = otcrypto_integrity_blinded_checksum(private_key);
 
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
@@ -667,8 +667,8 @@ otcrypto_status_t otcrypto_rsa_keypair_from_cofactor_async_finalize(
   }
 
   // Construct checksums for the new keys.
-  public_key->checksum = integrity_unblinded_checksum(public_key);
-  private_key->checksum = integrity_blinded_checksum(private_key);
+  public_key->checksum = otcrypto_integrity_unblinded_checksum(public_key);
+  private_key->checksum = otcrypto_integrity_blinded_checksum(private_key);
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
@@ -732,7 +732,7 @@ otcrypto_status_t otcrypto_rsa_sign_async_start(
       key_mode_padding_check(private_key->config.key_mode, padding_mode));
 
   // Verify the checksum.
-  if (integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
+  if (otcrypto_integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -829,7 +829,7 @@ otcrypto_status_t otcrypto_rsa_verify_async_start(
   HARDENED_TRY(public_key_structural_check(public_key));
 
   // Verify the checksum.
-  if (integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
+  if (otcrypto_integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -940,7 +940,7 @@ otcrypto_status_t otcrypto_rsa_encrypt_async_start(
   HARDENED_TRY(public_key_structural_check(public_key));
 
   // Verify the checksum.
-  if (integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
+  if (otcrypto_integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -1049,7 +1049,7 @@ otcrypto_status_t otcrypto_rsa_decrypt_async_start(
   HARDENED_TRY(private_key_structural_check(size, private_key));
 
   // Verify the checksum.
-  if (integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
+  if (otcrypto_integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
 

--- a/sw/device/lib/crypto/include/integrity.h
+++ b/sw/device/lib/crypto/include/integrity.h
@@ -31,7 +31,8 @@ extern "C" {
  * @param key Unblinded key.
  * @returns Checksum value.
  */
-uint32_t integrity_unblinded_checksum(const otcrypto_unblinded_key_t *key);
+uint32_t otcrypto_integrity_unblinded_checksum(
+    const otcrypto_unblinded_key_t *key);
 
 /**
  * Compute the checksum of a blinded key.
@@ -42,7 +43,7 @@ uint32_t integrity_unblinded_checksum(const otcrypto_unblinded_key_t *key);
  * @param key Blinded key.
  * @returns Checksum value.
  */
-uint32_t integrity_blinded_checksum(const otcrypto_blinded_key_t *key);
+uint32_t otcrypto_integrity_blinded_checksum(const otcrypto_blinded_key_t *key);
 
 /**
  * Perform an integrity check on the unblinded key.
@@ -54,7 +55,7 @@ uint32_t integrity_blinded_checksum(const otcrypto_blinded_key_t *key);
  * @returns Whether the integrity check passed.
  */
 OT_WARN_UNUSED_RESULT
-hardened_bool_t integrity_unblinded_key_check(
+hardened_bool_t otcrypto_integrity_unblinded_key_check(
     const otcrypto_unblinded_key_t *key);
 
 /**
@@ -67,26 +68,14 @@ hardened_bool_t integrity_unblinded_key_check(
  * @returns Whether the integrity check passed.
  */
 OT_WARN_UNUSED_RESULT
-hardened_bool_t integrity_blinded_key_check(const otcrypto_blinded_key_t *key);
-
-/**
- * Helper function to calculate the checksum for a buffer.
- *
- * The integrity is calculated only on the buffer address and length, but not
- * the content. This allows the creation of a secure buffer before the content
- * is available, and the content can be filled later.
- */
-OT_WARN_UNUSED_RESULT
-static inline uint32_t calculate_buf_checksum(const void *data, size_t len) {
-  return kOtcryptoInitIntegrityChecksum + (uint32_t)(uintptr_t)data +
-         (uint32_t)len;
-}
+hardened_bool_t otcrypto_integrity_blinded_key_check(
+    const otcrypto_blinded_key_t *key);
 
 #ifndef OTCRYPTO_DISABLE_BUF_INTEGRITY_CHECKS
 
 /**
  * Macro to create a buffer such otcrypto_const_word32_buf, otcrypto_word32_buf,
- * otcrypto_const_byte_buf, otcrypto_byte_buf.
+ * otcrypto_const_byte_buf, otcrypto_byte_buf.verify_buf_integrity
  *
  * A secure manner of creating a buffer is to create a buffer with its length,
  * then set its checksum using the macro. After the checksum is set, the buffer
@@ -96,10 +85,11 @@ static inline uint32_t calculate_buf_checksum(const void *data, size_t len) {
  * called after the buffer is consumed.
  *
  */
-#define OTCRYPTO_MAKE_BUF(type, data_ptr, length)                \
-  (type) {                                                       \
-    .data = (data_ptr), .len = (length),                         \
-    .ptr_checksum = calculate_buf_checksum((data_ptr), (length)) \
+#define OTCRYPTO_MAKE_BUF(type, data_ptr, length)                        \
+  (type) {                                                               \
+    .data = (data_ptr), .len = (length),                                 \
+    .ptr_checksum = kOtcryptoInitIntegrityChecksum +                     \
+                    (uint32_t)(uintptr_t)(data_ptr) + (uint32_t)(length) \
   }
 
 /**

--- a/sw/device/tests/crypto/aes_functest.c
+++ b/sw/device/tests/crypto/aes_functest.c
@@ -88,7 +88,7 @@ static status_t run_encrypt(const aes_test_t *test, bool streaming) {
       .keyblob_length = sizeof(keyblob),
       .keyblob = keyblob,
   };
-  key.checksum = integrity_blinded_checksum(&key);
+  key.checksum = otcrypto_integrity_blinded_checksum(&key);
 
   // Construct a buffer to hold the IV.
   uint32_t iv_data[kAesBlockWords];
@@ -160,7 +160,7 @@ static status_t run_decrypt(const aes_test_t *test, bool streaming) {
       .keyblob_length = sizeof(keyblob),
       .keyblob = keyblob,
   };
-  key.checksum = integrity_blinded_checksum(&key);
+  key.checksum = otcrypto_integrity_blinded_checksum(&key);
 
   // Construct a buffer to hold the IV.
   uint32_t iv_data[kAesBlockWords];
@@ -276,7 +276,7 @@ static status_t run_negative_tests(void) {
       .keyblob_length = sizeof(keyblob),
       .keyblob = keyblob,
   };
-  key.checksum = integrity_blinded_checksum(&key);
+  key.checksum = otcrypto_integrity_blinded_checksum(&key);
 
   uint32_t iv_data[kAesBlockWords] = {0};
   otcrypto_word32_buf_t iv =

--- a/sw/device/tests/crypto/aes_gcm_functest.c
+++ b/sw/device/tests/crypto/aes_gcm_functest.c
@@ -79,7 +79,7 @@ static status_t run_bad_args_test(void) {
       .keyblob_length = sizeof(keyblob),
       .keyblob = keyblob,
   };
-  key.checksum = integrity_blinded_checksum(&key);
+  key.checksum = otcrypto_integrity_blinded_checksum(&key);
 
   uint32_t iv_data[3] = {0};
   otcrypto_const_word32_buf_t iv =
@@ -157,7 +157,7 @@ static status_t run_bad_args_test(void) {
       .keyblob_length = sizeof(keyblob),
       .keyblob = keyblob,
   };
-  bad_mode_key.checksum = integrity_blinded_checksum(&bad_mode_key);
+  bad_mode_key.checksum = otcrypto_integrity_blinded_checksum(&bad_mode_key);
   CHECK(otcrypto_aes_gcm_encrypt(&bad_mode_key, &pt, &iv, &aad,
                                  kOtcryptoAesGcmTagLen128, &ct, &tag)
             .value == OTCRYPTO_BAD_ARGS.value);
@@ -169,7 +169,7 @@ static status_t run_bad_args_test(void) {
       .keyblob_length = 16,  // Wrong size
       .keyblob = keyblob,
   };
-  bad_hw_key.checksum = integrity_blinded_checksum(&bad_hw_key);
+  bad_hw_key.checksum = otcrypto_integrity_blinded_checksum(&bad_hw_key);
   CHECK(otcrypto_aes_gcm_encrypt(&bad_hw_key, &pt, &iv, &aad,
                                  kOtcryptoAesGcmTagLen128, &ct, &tag)
             .value == OTCRYPTO_BAD_ARGS.value);
@@ -235,7 +235,7 @@ static status_t run_bad_args_test(void) {
             .value == OTCRYPTO_BAD_ARGS.value);
 
   // Update the key checksum because we remasked before
-  key.checksum = integrity_blinded_checksum(&key);
+  key.checksum = otcrypto_integrity_blinded_checksum(&key);
 
   // Test operation ordering
   otcrypto_aes_gcm_context_t ctx_aad_after_data;
@@ -286,7 +286,7 @@ static status_t run_bad_args_test(void) {
             .value == OTCRYPTO_BAD_ARGS.value);
 
   // Update the key checksum because we remasked before
-  key.checksum = integrity_blinded_checksum(&key);
+  key.checksum = otcrypto_integrity_blinded_checksum(&key);
 
   // Re-init context for decrypt to reset input_len for the partial block test
   TRY(otcrypto_aes_gcm_decrypt_init(&key, &iv, &ctx));
@@ -300,7 +300,7 @@ static status_t run_bad_args_test(void) {
   // Edge Case & Fault Injection Coverage
 
   // Failed Decryption Tag Check
-  key.checksum = integrity_blinded_checksum(&key);
+  key.checksum = otcrypto_integrity_blinded_checksum(&key);
   TRY(otcrypto_aes_gcm_encrypt(&key, &pt, &iv, &aad, kOtcryptoAesGcmTagLen128,
                                &ct, &tag));
   ct.data[0] ^= 0x01;  // Corrupt ciphertext bit
@@ -328,7 +328,7 @@ static status_t run_bad_args_test(void) {
             .value != OTCRYPTO_OK.value);
 
   // Inner Driver Bounds & Overflows
-  key.checksum = integrity_blinded_checksum(&key);
+  key.checksum = otcrypto_integrity_blinded_checksum(&key);
   TRY(otcrypto_aes_gcm_encrypt_init(&key, &iv, &ctx));
 
   otcrypto_const_byte_buf_t buf_16 =
@@ -355,13 +355,13 @@ static status_t run_bad_args_test(void) {
             .value != OTCRYPTO_OK.value);
 
   // Final API NULL Checks
-  key.checksum = integrity_blinded_checksum(&key);
+  key.checksum = otcrypto_integrity_blinded_checksum(&key);
   TRY(otcrypto_aes_gcm_encrypt_init(&key, &iv, &ctx));
   CHECK(otcrypto_aes_gcm_encrypt_final(&ctx, kOtcryptoAesGcmTagLen128,
                                        &null_out_16, &written, &tag)
             .value != OTCRYPTO_OK.value);
 
-  key.checksum = integrity_blinded_checksum(&key);
+  key.checksum = otcrypto_integrity_blinded_checksum(&key);
   TRY(otcrypto_aes_gcm_decrypt_init(&key, &iv, &ctx));
   CHECK(otcrypto_aes_gcm_decrypt_final(&ctx, &tag_const,
                                        kOtcryptoAesGcmTagLen128, &null_out_16,
@@ -369,13 +369,13 @@ static status_t run_bad_args_test(void) {
             .value != OTCRYPTO_OK.value);
 
   // Fault Injection
-  key.checksum = integrity_blinded_checksum(&key);
+  key.checksum = otcrypto_integrity_blinded_checksum(&key);
   TRY(otcrypto_aes_gcm_encrypt_init(&key, &iv, &ctx));
   ctx.data[0] = 0xBADBAD;  // Corrupt is_encrypt boolean
   CHECK(otcrypto_aes_gcm_update_encrypted_data(&ctx, &buf_16, &out_16, &written)
             .value != OTCRYPTO_OK.value);
 
-  key.checksum = integrity_blinded_checksum(&key);
+  key.checksum = otcrypto_integrity_blinded_checksum(&key);
   TRY(otcrypto_aes_gcm_encrypt_init(&key, &iv, &ctx));
   ctx.data[1] = 0xBADBAD;  // Corrupt aes_key.mode enum
   CHECK(otcrypto_aes_gcm_update_encrypted_data(&ctx, &buf_16, &out_16, &written)
@@ -409,7 +409,7 @@ static status_t run_sideload_test(void) {
       .keyblob_length = kKeyblobHwBackedBytes,
       .keyblob = div_data,
   };
-  sideload_key.checksum = integrity_blinded_checksum(&sideload_key);
+  sideload_key.checksum = otcrypto_integrity_blinded_checksum(&sideload_key);
 
   uint32_t iv_data[3] = {0x01020304, 0x05060708, 0x090a0b0c};
   otcrypto_const_word32_buf_t iv =

--- a/sw/device/tests/crypto/aes_gcm_testutils.c
+++ b/sw/device/tests/crypto/aes_gcm_testutils.c
@@ -145,7 +145,7 @@ status_t aes_gcm_testutils_encrypt(const aes_gcm_test_t *test, bool streaming,
   };
 
   // Set the checksum.
-  key.checksum = integrity_blinded_checksum(&key);
+  key.checksum = otcrypto_integrity_blinded_checksum(&key);
 
   size_t iv_num_words =
       (test->iv_len + sizeof(uint32_t) - 1) / sizeof(uint32_t);
@@ -235,7 +235,7 @@ status_t aes_gcm_testutils_decrypt(const aes_gcm_test_t *test,
   };
 
   // Set the checksum.
-  key.checksum = integrity_blinded_checksum(&key);
+  key.checksum = otcrypto_integrity_blinded_checksum(&key);
 
   size_t iv_num_words =
       (test->iv_len + sizeof(uint32_t) - 1) / sizeof(uint32_t);

--- a/sw/device/tests/crypto/cryptotest/firmware/ed25519.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/ed25519.c
@@ -95,7 +95,7 @@ status_t handle_ed25519(ujson_t *uj) {
           .keyblob_length = sizeof(keyblob),
           .keyblob = keyblob,
       };
-      private_key.checksum = integrity_blinded_checksum(&private_key);
+      private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
 
       // Derive the public key from the private key.
       uint32_t public_key_buf[kEd25519PublicKeyWords];
@@ -153,7 +153,7 @@ status_t handle_ed25519(ujson_t *uj) {
           .key_length = ED25519_CMD_PUBLIC_KEY_BYTES,
           .key = public_key_buf,
       };
-      public_key.checksum = integrity_unblinded_checksum(&public_key);
+      public_key.checksum = otcrypto_integrity_unblinded_checksum(&public_key);
 
       uint32_t signature_data[kEd25519MaxSignatureWords];
       memset(signature_data, 0xff, sizeof(signature_data));

--- a/sw/device/tests/crypto/ecc_p256_arith_share_private_key_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_arith_share_private_key_functest.c
@@ -187,7 +187,7 @@ static status_t run_arith_share_negative_tests(void) {
       .keyblob_length = sizeof(keyblob),
       .keyblob = keyblob,
   };
-  priv_key.checksum = integrity_blinded_checksum(&priv_key);
+  priv_key.checksum = otcrypto_integrity_blinded_checksum(&priv_key);
 
   // Null inputs
   CHECK(otcrypto_ecc_p256_arith_share_private_key(NULL, &share1, &priv_key)
@@ -210,7 +210,7 @@ static status_t run_arith_share_negative_tests(void) {
       .keyblob_length = sizeof(keyblob),
       .keyblob = keyblob,
   };
-  bad_mode_key.checksum = integrity_blinded_checksum(&bad_mode_key);
+  bad_mode_key.checksum = otcrypto_integrity_blinded_checksum(&bad_mode_key);
   CHECK(
       otcrypto_ecc_p256_arith_share_private_key(&share0, &share1, &bad_mode_key)
           .value != OTCRYPTO_OK.value);
@@ -223,7 +223,7 @@ static status_t run_arith_share_negative_tests(void) {
       .keyblob_length = sizeof(keyblob),
       .keyblob = keyblob,
   };
-  bad_hw_key.checksum = integrity_blinded_checksum(&bad_hw_key);
+  bad_hw_key.checksum = otcrypto_integrity_blinded_checksum(&bad_hw_key);
   CHECK(otcrypto_ecc_p256_arith_share_private_key(&share0, &share1, &bad_hw_key)
             .value != OTCRYPTO_OK.value);
 

--- a/sw/device/tests/crypto/ecc_p256_dice_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_dice_functest.c
@@ -264,7 +264,7 @@ static status_t run_dice_negative_tests(void) {
       .keyblob_length = sizeof(priv_keyblob),
       .keyblob = priv_keyblob,
   };
-  valid_priv.checksum = integrity_blinded_checksum(&valid_priv);
+  valid_priv.checksum = otcrypto_integrity_blinded_checksum(&valid_priv);
 
   uint32_t digest_data[8] = {0};
   otcrypto_hash_digest_t valid_digest = {
@@ -294,7 +294,7 @@ static status_t run_dice_negative_tests(void) {
       .keyblob_length = sizeof(priv_keyblob),
       .keyblob = priv_keyblob,
   };
-  bad_mode_priv.checksum = integrity_blinded_checksum(&bad_mode_priv);
+  bad_mode_priv.checksum = otcrypto_integrity_blinded_checksum(&bad_mode_priv);
   CHECK(otcrypto_ecdsa_p256_dice_sign_async_start(&bad_mode_priv, valid_digest,
                                                   &attestation_seed)
             .value != OTCRYPTO_OK.value);

--- a/sw/device/tests/crypto/ecc_p256_key_import_export_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_key_import_export_functest.c
@@ -238,7 +238,7 @@ static status_t run_import_export_negative_tests(void) {
       .key_length = sizeof(pk_buf),
       .key = pk_buf,
   };
-  pub_key.checksum = integrity_unblinded_checksum(&pub_key);
+  pub_key.checksum = otcrypto_integrity_unblinded_checksum(&pub_key);
 
   uint32_t share0_data[10] = {0};
   uint32_t share1_data[10] = {0};
@@ -270,7 +270,7 @@ static status_t run_import_export_negative_tests(void) {
       .keyblob_length = sizeof(keyblob),
       .keyblob = keyblob,
   };
-  priv_key.checksum = integrity_blinded_checksum(&priv_key);
+  priv_key.checksum = otcrypto_integrity_blinded_checksum(&priv_key);
 
   otcrypto_const_word32_buf_t null_in_buf = {0};
   otcrypto_word32_buf_t null_out_buf = {0};
@@ -326,7 +326,7 @@ static status_t run_import_export_negative_tests(void) {
       OTCRYPTO_OK.value);
 
   // Bad mode & integrity
-  pub_bad_mode.checksum = integrity_unblinded_checksum(&pub_bad_mode);
+  pub_bad_mode.checksum = otcrypto_integrity_unblinded_checksum(&pub_bad_mode);
   CHECK(otcrypto_ecc_p256_public_key_export(&pub_bad_mode, &x_out, &y_out)
             .value != OTCRYPTO_OK.value);
 
@@ -406,12 +406,12 @@ static status_t run_import_export_negative_tests(void) {
             .value != OTCRYPTO_OK.value);
 
   // Bad mode & hw_backed
-  priv_bad_mode.checksum = integrity_blinded_checksum(&priv_bad_mode);
+  priv_bad_mode.checksum = otcrypto_integrity_blinded_checksum(&priv_bad_mode);
   CHECK(otcrypto_ecc_p256_private_key_export(&priv_bad_mode, &share0_out,
                                              &share1_out)
             .value != OTCRYPTO_OK.value);
 
-  priv_bad_hw.checksum = integrity_blinded_checksum(&priv_bad_hw);
+  priv_bad_hw.checksum = otcrypto_integrity_blinded_checksum(&priv_bad_hw);
   CHECK(otcrypto_ecc_p256_private_key_export(&priv_bad_hw, &share0_out,
                                              &share1_out)
             .value != OTCRYPTO_OK.value);
@@ -424,7 +424,8 @@ static status_t run_import_export_negative_tests(void) {
       .keyblob_length = sizeof(keyblob),
       .keyblob = keyblob,
   };
-  priv_no_export.checksum = integrity_blinded_checksum(&priv_no_export);
+  priv_no_export.checksum =
+      otcrypto_integrity_blinded_checksum(&priv_no_export);
   CHECK(otcrypto_ecc_p256_private_key_export(&priv_no_export, &share0_out,
                                              &share1_out)
             .value != OTCRYPTO_OK.value);

--- a/sw/device/tests/crypto/ecc_p384_arith_share_private_key_functest.c
+++ b/sw/device/tests/crypto/ecc_p384_arith_share_private_key_functest.c
@@ -187,7 +187,7 @@ static status_t run_arith_share_negative_tests(void) {
       .keyblob_length = sizeof(keyblob),
       .keyblob = keyblob,
   };
-  priv_key.checksum = integrity_blinded_checksum(&priv_key);
+  priv_key.checksum = otcrypto_integrity_blinded_checksum(&priv_key);
 
   // Null inputs
   CHECK(otcrypto_ecc_p384_arith_share_private_key(NULL, &share1, &priv_key)
@@ -210,7 +210,7 @@ static status_t run_arith_share_negative_tests(void) {
       .keyblob_length = sizeof(keyblob),
       .keyblob = keyblob,
   };
-  bad_mode_key.checksum = integrity_blinded_checksum(&bad_mode_key);
+  bad_mode_key.checksum = otcrypto_integrity_blinded_checksum(&bad_mode_key);
   CHECK(
       otcrypto_ecc_p384_arith_share_private_key(&share0, &share1, &bad_mode_key)
           .value != OTCRYPTO_OK.value);
@@ -223,7 +223,7 @@ static status_t run_arith_share_negative_tests(void) {
       .keyblob_length = sizeof(keyblob),
       .keyblob = keyblob,
   };
-  bad_hw_key.checksum = integrity_blinded_checksum(&bad_hw_key);
+  bad_hw_key.checksum = otcrypto_integrity_blinded_checksum(&bad_hw_key);
   CHECK(otcrypto_ecc_p384_arith_share_private_key(&share0, &share1, &bad_hw_key)
             .value != OTCRYPTO_OK.value);
 

--- a/sw/device/tests/crypto/ecc_p384_key_import_export_functest.c
+++ b/sw/device/tests/crypto/ecc_p384_key_import_export_functest.c
@@ -236,7 +236,7 @@ static status_t run_import_export_negative_tests(void) {
       .key_length = sizeof(pk_buf),
       .key = pk_buf,
   };
-  pub_key.checksum = integrity_unblinded_checksum(&pub_key);
+  pub_key.checksum = otcrypto_integrity_unblinded_checksum(&pub_key);
 
   uint32_t share0_data[14] = {0};
   uint32_t share1_data[14] = {0};
@@ -268,7 +268,7 @@ static status_t run_import_export_negative_tests(void) {
       .keyblob_length = sizeof(keyblob),
       .keyblob = keyblob,
   };
-  priv_key.checksum = integrity_blinded_checksum(&priv_key);
+  priv_key.checksum = otcrypto_integrity_blinded_checksum(&priv_key);
 
   otcrypto_const_word32_buf_t null_in_buf = {0};
   otcrypto_word32_buf_t null_out_buf = {0};
@@ -324,7 +324,7 @@ static status_t run_import_export_negative_tests(void) {
       OTCRYPTO_OK.value);
 
   // Bad mode & integrity
-  pub_bad_mode.checksum = integrity_unblinded_checksum(&pub_bad_mode);
+  pub_bad_mode.checksum = otcrypto_integrity_unblinded_checksum(&pub_bad_mode);
   CHECK(otcrypto_ecc_p384_public_key_export(&pub_bad_mode, &x_out, &y_out)
             .value != OTCRYPTO_OK.value);
 
@@ -404,12 +404,12 @@ static status_t run_import_export_negative_tests(void) {
             .value != OTCRYPTO_OK.value);
 
   // Bad mode & hw_backed
-  priv_bad_mode.checksum = integrity_blinded_checksum(&priv_bad_mode);
+  priv_bad_mode.checksum = otcrypto_integrity_blinded_checksum(&priv_bad_mode);
   CHECK(otcrypto_ecc_p384_private_key_export(&priv_bad_mode, &share0_out,
                                              &share1_out)
             .value != OTCRYPTO_OK.value);
 
-  priv_bad_hw.checksum = integrity_blinded_checksum(&priv_bad_hw);
+  priv_bad_hw.checksum = otcrypto_integrity_blinded_checksum(&priv_bad_hw);
   CHECK(otcrypto_ecc_p384_private_key_export(&priv_bad_hw, &share0_out,
                                              &share1_out)
             .value != OTCRYPTO_OK.value);
@@ -422,7 +422,8 @@ static status_t run_import_export_negative_tests(void) {
       .keyblob_length = sizeof(keyblob),
       .keyblob = keyblob,
   };
-  priv_no_export.checksum = integrity_blinded_checksum(&priv_no_export);
+  priv_no_export.checksum =
+      otcrypto_integrity_blinded_checksum(&priv_no_export);
   CHECK(otcrypto_ecc_p384_private_key_export(&priv_no_export, &share0_out,
                                              &share1_out)
             .value != OTCRYPTO_OK.value);

--- a/sw/device/tests/crypto/ecdh_p256_functest.c
+++ b/sw/device/tests/crypto/ecdh_p256_functest.c
@@ -148,7 +148,7 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob_length = 80,
       .keyblob = priv_keyblob,
   };
-  valid_priv.checksum = integrity_blinded_checksum(&valid_priv);
+  valid_priv.checksum = otcrypto_integrity_blinded_checksum(&valid_priv);
 
   uint32_t pub_key_data[64 / 4] = {0};
   otcrypto_unblinded_key_t valid_pub = {
@@ -156,7 +156,7 @@ static status_t run_ecdh_negative_tests(void) {
       .key_length = 64,
       .key = pub_key_data,
   };
-  valid_pub.checksum = integrity_unblinded_checksum(&valid_pub);
+  valid_pub.checksum = otcrypto_integrity_unblinded_checksum(&valid_pub);
 
   uint32_t shared_keyblob[keyblob_num_words(kEcdhSharedKeyConfig)];
   otcrypto_blinded_key_t valid_shared = {
@@ -164,7 +164,7 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob_length = sizeof(shared_keyblob),
       .keyblob = shared_keyblob,
   };
-  valid_shared.checksum = integrity_blinded_checksum(&valid_shared);
+  valid_shared.checksum = otcrypto_integrity_blinded_checksum(&valid_shared);
 
   // ECDH keygen negative tests
 
@@ -200,7 +200,7 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob_length = 80,
       .keyblob = priv_keyblob,
   };
-  bad_priv_mode.checksum = integrity_blinded_checksum(&bad_priv_mode);
+  bad_priv_mode.checksum = otcrypto_integrity_blinded_checksum(&bad_priv_mode);
   CHECK(otcrypto_ecdh_p256_keygen(&bad_priv_mode, &valid_pub).value !=
         OTCRYPTO_OK.value);
   CHECK(otcrypto_ecdh_p256_keygen_async_start(&bad_priv_mode).value !=
@@ -216,7 +216,7 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob_length = 80,
       .keyblob = priv_keyblob,
   };
-  bad_priv_len.checksum = integrity_blinded_checksum(&bad_priv_len);
+  bad_priv_len.checksum = otcrypto_integrity_blinded_checksum(&bad_priv_len);
   CHECK(otcrypto_ecdh_p256_keygen(&bad_priv_len, &valid_pub).value !=
         OTCRYPTO_OK.value);
   CHECK(otcrypto_ecdh_p256_keygen_async_start(&bad_priv_len).value !=
@@ -230,7 +230,8 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob_length = 79,  // Should be 80
       .keyblob = priv_keyblob,
   };
-  bad_priv_blob_len.checksum = integrity_blinded_checksum(&bad_priv_blob_len);
+  bad_priv_blob_len.checksum =
+      otcrypto_integrity_blinded_checksum(&bad_priv_blob_len);
   CHECK(otcrypto_ecdh_p256_keygen(&bad_priv_blob_len, &valid_pub).value !=
         OTCRYPTO_OK.value);
   CHECK(otcrypto_ecdh_p256_keygen_async_start(&bad_priv_blob_len).value !=
@@ -246,7 +247,7 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob_length = 80,
       .keyblob = priv_keyblob,
   };
-  bad_priv_hw.checksum = integrity_blinded_checksum(&bad_priv_hw);
+  bad_priv_hw.checksum = otcrypto_integrity_blinded_checksum(&bad_priv_hw);
   CHECK(otcrypto_ecdh_p256_keygen(&bad_priv_hw, &valid_pub).value !=
         OTCRYPTO_OK.value);
   CHECK(otcrypto_ecdh_p256_keygen_async_start(&bad_priv_hw).value !=
@@ -303,7 +304,7 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob_length = sizeof(shared_keyblob),
       .keyblob = shared_keyblob,
   };
-  bad_shared_hw.checksum = integrity_blinded_checksum(&bad_shared_hw);
+  bad_shared_hw.checksum = otcrypto_integrity_blinded_checksum(&bad_shared_hw);
   CHECK(otcrypto_ecdh_p256(&valid_priv, &valid_pub, &bad_shared_hw).value !=
         OTCRYPTO_OK.value);
   CHECK(otcrypto_ecdh_p256_async_finalize(&bad_shared_hw).value !=
@@ -317,7 +318,8 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob_length = sizeof(shared_keyblob),
       .keyblob = shared_keyblob,
   };
-  bad_shared_len.checksum = integrity_blinded_checksum(&bad_shared_len);
+  bad_shared_len.checksum =
+      otcrypto_integrity_blinded_checksum(&bad_shared_len);
   CHECK(otcrypto_ecdh_p256(&valid_priv, &valid_pub, &bad_shared_len).value !=
         OTCRYPTO_OK.value);
   CHECK(otcrypto_ecdh_p256_async_finalize(&bad_shared_len).value !=
@@ -330,7 +332,7 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob_length = 80,
       .keyblob = priv_keyblob,
   };
-  bad_ecdh_mode.checksum = integrity_blinded_checksum(&bad_ecdh_mode);
+  bad_ecdh_mode.checksum = otcrypto_integrity_blinded_checksum(&bad_ecdh_mode);
   CHECK(otcrypto_ecdh_p256_async_start(&bad_ecdh_mode, &valid_pub).value !=
         OTCRYPTO_OK.value);
 
@@ -341,7 +343,7 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob_length = 80,
       .keyblob = priv_keyblob,
   };
-  bad_ecdh_hw.checksum = integrity_blinded_checksum(&bad_ecdh_hw);
+  bad_ecdh_hw.checksum = otcrypto_integrity_blinded_checksum(&bad_ecdh_hw);
   CHECK(otcrypto_ecdh_p256_async_start(&bad_ecdh_hw, &valid_pub).value !=
         OTCRYPTO_OK.value);
 
@@ -351,7 +353,7 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob = valid_shared.keyblob,
   };
   bad_shared_blob_len.checksum =
-      integrity_blinded_checksum(&bad_shared_blob_len);
+      otcrypto_integrity_blinded_checksum(&bad_shared_blob_len);
   CHECK(otcrypto_ecdh_p256_async_finalize(&bad_shared_blob_len).value !=
         OTCRYPTO_OK.value);
 

--- a/sw/device/tests/crypto/ecdh_p384_functest.c
+++ b/sw/device/tests/crypto/ecdh_p384_functest.c
@@ -153,7 +153,7 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob_length = 112,
       .keyblob = priv_keyblob,
   };
-  valid_priv.checksum = integrity_blinded_checksum(&valid_priv);
+  valid_priv.checksum = otcrypto_integrity_blinded_checksum(&valid_priv);
 
   uint32_t pub_key_data[96 / 4] = {0};
   otcrypto_unblinded_key_t valid_pub = {
@@ -161,7 +161,7 @@ static status_t run_ecdh_negative_tests(void) {
       .key_length = 96,
       .key = pub_key_data,
   };
-  valid_pub.checksum = integrity_unblinded_checksum(&valid_pub);
+  valid_pub.checksum = otcrypto_integrity_unblinded_checksum(&valid_pub);
 
   uint32_t shared_keyblob[keyblob_num_words(kEcdhSharedKeyConfig)];
   otcrypto_blinded_key_t valid_shared = {
@@ -169,7 +169,7 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob_length = sizeof(shared_keyblob),
       .keyblob = shared_keyblob,
   };
-  valid_shared.checksum = integrity_blinded_checksum(&valid_shared);
+  valid_shared.checksum = otcrypto_integrity_blinded_checksum(&valid_shared);
 
   // ECDH keygen negative tests
 
@@ -205,7 +205,7 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob_length = 112,
       .keyblob = priv_keyblob,
   };
-  bad_priv_mode.checksum = integrity_blinded_checksum(&bad_priv_mode);
+  bad_priv_mode.checksum = otcrypto_integrity_blinded_checksum(&bad_priv_mode);
   CHECK(otcrypto_ecdh_p384_keygen(&bad_priv_mode, &valid_pub).value !=
         OTCRYPTO_OK.value);
   CHECK(otcrypto_ecdh_p384_keygen_async_start(&bad_priv_mode).value !=
@@ -221,7 +221,7 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob_length = 112,
       .keyblob = priv_keyblob,
   };
-  bad_priv_len.checksum = integrity_blinded_checksum(&bad_priv_len);
+  bad_priv_len.checksum = otcrypto_integrity_blinded_checksum(&bad_priv_len);
   CHECK(otcrypto_ecdh_p384_keygen(&bad_priv_len, &valid_pub).value !=
         OTCRYPTO_OK.value);
   CHECK(otcrypto_ecdh_p384_keygen_async_start(&bad_priv_len).value !=
@@ -235,7 +235,8 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob_length = 111,  // Should be 112
       .keyblob = priv_keyblob,
   };
-  bad_priv_blob_len.checksum = integrity_blinded_checksum(&bad_priv_blob_len);
+  bad_priv_blob_len.checksum =
+      otcrypto_integrity_blinded_checksum(&bad_priv_blob_len);
   CHECK(otcrypto_ecdh_p384_keygen(&bad_priv_blob_len, &valid_pub).value !=
         OTCRYPTO_OK.value);
   CHECK(otcrypto_ecdh_p384_keygen_async_start(&bad_priv_blob_len).value !=
@@ -251,7 +252,7 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob_length = 112,
       .keyblob = priv_keyblob,
   };
-  bad_priv_hw.checksum = integrity_blinded_checksum(&bad_priv_hw);
+  bad_priv_hw.checksum = otcrypto_integrity_blinded_checksum(&bad_priv_hw);
   CHECK(otcrypto_ecdh_p384_keygen(&bad_priv_hw, &valid_pub).value !=
         OTCRYPTO_OK.value);
   CHECK(otcrypto_ecdh_p384_keygen_async_start(&bad_priv_hw).value !=
@@ -308,7 +309,7 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob_length = sizeof(shared_keyblob),
       .keyblob = shared_keyblob,
   };
-  bad_shared_hw.checksum = integrity_blinded_checksum(&bad_shared_hw);
+  bad_shared_hw.checksum = otcrypto_integrity_blinded_checksum(&bad_shared_hw);
   CHECK(otcrypto_ecdh_p384(&valid_priv, &valid_pub, &bad_shared_hw).value !=
         OTCRYPTO_OK.value);
   CHECK(otcrypto_ecdh_p384_async_finalize(&bad_shared_hw).value !=
@@ -322,7 +323,8 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob_length = sizeof(shared_keyblob),
       .keyblob = shared_keyblob,
   };
-  bad_shared_len.checksum = integrity_blinded_checksum(&bad_shared_len);
+  bad_shared_len.checksum =
+      otcrypto_integrity_blinded_checksum(&bad_shared_len);
   CHECK(otcrypto_ecdh_p384(&valid_priv, &valid_pub, &bad_shared_len).value !=
         OTCRYPTO_OK.value);
   CHECK(otcrypto_ecdh_p384_async_finalize(&bad_shared_len).value !=
@@ -335,7 +337,7 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob_length = 112,
       .keyblob = priv_keyblob,
   };
-  bad_ecdh_mode.checksum = integrity_blinded_checksum(&bad_ecdh_mode);
+  bad_ecdh_mode.checksum = otcrypto_integrity_blinded_checksum(&bad_ecdh_mode);
   CHECK(otcrypto_ecdh_p384_async_start(&bad_ecdh_mode, &valid_pub).value !=
         OTCRYPTO_OK.value);
 
@@ -346,7 +348,7 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob_length = 112,
       .keyblob = priv_keyblob,
   };
-  bad_ecdh_hw.checksum = integrity_blinded_checksum(&bad_ecdh_hw);
+  bad_ecdh_hw.checksum = otcrypto_integrity_blinded_checksum(&bad_ecdh_hw);
   CHECK(otcrypto_ecdh_p384_async_start(&bad_ecdh_hw, &valid_pub).value !=
         OTCRYPTO_OK.value);
 
@@ -356,7 +358,7 @@ static status_t run_ecdh_negative_tests(void) {
       .keyblob = valid_shared.keyblob,
   };
   bad_shared_blob_len.checksum =
-      integrity_blinded_checksum(&bad_shared_blob_len);
+      otcrypto_integrity_blinded_checksum(&bad_shared_blob_len);
   CHECK(otcrypto_ecdh_p384_async_finalize(&bad_shared_blob_len).value !=
         OTCRYPTO_OK.value);
 

--- a/sw/device/tests/crypto/ecdsa_p256_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_functest.c
@@ -167,7 +167,7 @@ static status_t sign_kat(void) {
   // We copy over the full 320 random bits
   memcpy(keyblob_scalar + kP256SecretScalarWords, share1_rand,
          kP256SecretScalarBytes);
-  secret_scalar.checksum = integrity_blinded_checksum(&secret_scalar);
+  secret_scalar.checksum = otcrypto_integrity_blinded_checksum(&secret_scalar);
 
   memset(unmasked_val, 0, kP256SecretScalarBytes);
   memcpy(unmasked_val, kKATKey, kP256TestVectorScalarInpBytes);
@@ -190,7 +190,7 @@ static status_t sign_kat(void) {
   };
   memcpy(keyblob_sk, share0, kP256SecretScalarBytes);
   memcpy(keyblob_sk + kP256SecretScalarWords, share1, kP256SecretScalarBytes);
-  private_key.checksum = integrity_blinded_checksum(&private_key);
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
 
   // Hash the message.
   otcrypto_const_byte_buf_t msg =
@@ -228,7 +228,7 @@ static status_t run_ecdsa_negative_tests(void) {
       .keyblob_length = 80,
       .keyblob = priv_keyblob,
   };
-  valid_priv.checksum = integrity_blinded_checksum(&valid_priv);
+  valid_priv.checksum = otcrypto_integrity_blinded_checksum(&valid_priv);
 
   uint32_t pub_key_data[64 / 4] = {0};
   otcrypto_unblinded_key_t valid_pub = {
@@ -236,7 +236,7 @@ static status_t run_ecdsa_negative_tests(void) {
       .key_length = 64,
       .key = pub_key_data,
   };
-  valid_pub.checksum = integrity_unblinded_checksum(&valid_pub);
+  valid_pub.checksum = otcrypto_integrity_unblinded_checksum(&valid_pub);
 
   uint32_t digest_data[32 / 4] = {0};
   otcrypto_hash_digest_t valid_digest = {
@@ -287,7 +287,7 @@ static status_t run_ecdsa_negative_tests(void) {
       .keyblob_length = 80,
       .keyblob = priv_keyblob,
   };
-  bad_priv_mode.checksum = integrity_blinded_checksum(&bad_priv_mode);
+  bad_priv_mode.checksum = otcrypto_integrity_blinded_checksum(&bad_priv_mode);
   CHECK(otcrypto_ecdsa_p256_keygen(&bad_priv_mode, &valid_pub).value ==
         OTCRYPTO_BAD_ARGS.value);
   CHECK(otcrypto_ecdsa_p256_keygen_async_start(&bad_priv_mode).value ==
@@ -301,7 +301,7 @@ static status_t run_ecdsa_negative_tests(void) {
       .key_length = 63,
       .key = pub_key_data,
   };
-  bad_pub_len.checksum = integrity_unblinded_checksum(&bad_pub_len);
+  bad_pub_len.checksum = otcrypto_integrity_unblinded_checksum(&bad_pub_len);
   CHECK(otcrypto_ecdsa_p256_keygen(&valid_priv, &bad_pub_len).value !=
         OTCRYPTO_OK.value);
   CHECK(otcrypto_ecdsa_p256_keygen_async_finalize(&valid_priv, &bad_pub_len)
@@ -313,7 +313,8 @@ static status_t run_ecdsa_negative_tests(void) {
       .keyblob_length = 79,  // Should be 80
       .keyblob = priv_keyblob,
   };
-  bad_priv_blob_len.checksum = integrity_blinded_checksum(&bad_priv_blob_len);
+  bad_priv_blob_len.checksum =
+      otcrypto_integrity_blinded_checksum(&bad_priv_blob_len);
   CHECK(otcrypto_ecdsa_p256_keygen(&bad_priv_blob_len, &valid_pub).value !=
         OTCRYPTO_OK.value);
   CHECK(otcrypto_ecdsa_p256_keygen_async_start(&bad_priv_blob_len).value !=
@@ -330,7 +331,7 @@ static status_t run_ecdsa_negative_tests(void) {
       .keyblob_length = 80,
       .keyblob = priv_keyblob,
   };
-  bad_priv_hw.checksum = integrity_blinded_checksum(&bad_priv_hw);
+  bad_priv_hw.checksum = otcrypto_integrity_blinded_checksum(&bad_priv_hw);
   CHECK(otcrypto_ecdsa_p256_keygen(&bad_priv_hw, &valid_pub).value !=
         OTCRYPTO_OK.value);
   CHECK(otcrypto_ecdsa_p256_keygen_async_start(&bad_priv_hw).value !=
@@ -469,7 +470,7 @@ static status_t run_ecdsa_negative_tests(void) {
       .key_length = valid_pub.key_length,
       .key = valid_pub.key,
   };
-  bad_pub_mode.checksum = integrity_unblinded_checksum(&bad_pub_mode);
+  bad_pub_mode.checksum = otcrypto_integrity_unblinded_checksum(&bad_pub_mode);
   CHECK(otcrypto_ecdsa_p256_keygen_async_finalize(&valid_priv, &bad_pub_mode)
             .value != OTCRYPTO_OK.value);
 
@@ -481,7 +482,7 @@ static status_t run_ecdsa_negative_tests(void) {
       .keyblob_length = 80,
       .keyblob = priv_keyblob,
   };
-  bad_sign_hw.checksum = integrity_blinded_checksum(&bad_sign_hw);
+  bad_sign_hw.checksum = otcrypto_integrity_blinded_checksum(&bad_sign_hw);
   CHECK(
       otcrypto_ecdsa_p256_sign_async_start(&bad_sign_hw, valid_digest).value !=
       OTCRYPTO_OK.value);

--- a/sw/device/tests/crypto/ecdsa_p384_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p384_functest.c
@@ -172,7 +172,7 @@ static status_t sign_kat(void) {
   // We copy over the full random bits
   memcpy(keyblob_scalar + kP384SecretScalarWords, share1,
          kP384SecretScalarBytes);
-  secret_scalar.checksum = integrity_blinded_checksum(&secret_scalar);
+  secret_scalar.checksum = otcrypto_integrity_blinded_checksum(&secret_scalar);
 
   memset(unmasked_val, 0, kP384SecretScalarBytes);
   memcpy(unmasked_val, kKATKey, kP384TestVectorScalarInpBytes);
@@ -195,7 +195,7 @@ static status_t sign_kat(void) {
   };
   memcpy(keyblob_sk, share0, kP384SecretScalarBytes);
   memcpy(keyblob_sk + kP384SecretScalarWords, share1, kP384SecretScalarBytes);
-  private_key.checksum = integrity_blinded_checksum(&private_key);
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
 
   // Hash the message.
   otcrypto_const_byte_buf_t msg =
@@ -233,7 +233,7 @@ static status_t run_ecdsa_negative_tests(void) {
       .keyblob_length = 112,
       .keyblob = priv_keyblob,
   };
-  valid_priv.checksum = integrity_blinded_checksum(&valid_priv);
+  valid_priv.checksum = otcrypto_integrity_blinded_checksum(&valid_priv);
 
   uint32_t pub_key_data[96 / 4] = {0};
   otcrypto_unblinded_key_t valid_pub = {
@@ -241,7 +241,7 @@ static status_t run_ecdsa_negative_tests(void) {
       .key_length = 96,
       .key = pub_key_data,
   };
-  valid_pub.checksum = integrity_unblinded_checksum(&valid_pub);
+  valid_pub.checksum = otcrypto_integrity_unblinded_checksum(&valid_pub);
 
   uint32_t digest_data[48 / 4] = {0};
   otcrypto_hash_digest_t valid_digest = {
@@ -293,7 +293,7 @@ static status_t run_ecdsa_negative_tests(void) {
       .keyblob_length = 112,
       .keyblob = priv_keyblob,
   };
-  bad_priv_mode.checksum = integrity_blinded_checksum(&bad_priv_mode);
+  bad_priv_mode.checksum = otcrypto_integrity_blinded_checksum(&bad_priv_mode);
   CHECK(otcrypto_ecdsa_p384_keygen(&bad_priv_mode, &valid_pub).value !=
         OTCRYPTO_OK.value);
   CHECK(otcrypto_ecdsa_p384_keygen_async_start(&bad_priv_mode).value !=
@@ -307,7 +307,7 @@ static status_t run_ecdsa_negative_tests(void) {
       .key_length = 95,
       .key = pub_key_data,
   };
-  bad_pub_len.checksum = integrity_unblinded_checksum(&bad_pub_len);
+  bad_pub_len.checksum = otcrypto_integrity_unblinded_checksum(&bad_pub_len);
   CHECK(otcrypto_ecdsa_p384_keygen(&valid_priv, &bad_pub_len).value !=
         OTCRYPTO_OK.value);
   CHECK(otcrypto_ecdsa_p384_keygen_async_finalize(&valid_priv, &bad_pub_len)
@@ -319,7 +319,8 @@ static status_t run_ecdsa_negative_tests(void) {
       .keyblob_length = 111,  // Should be 112
       .keyblob = priv_keyblob,
   };
-  bad_priv_blob_len.checksum = integrity_blinded_checksum(&bad_priv_blob_len);
+  bad_priv_blob_len.checksum =
+      otcrypto_integrity_blinded_checksum(&bad_priv_blob_len);
   CHECK(otcrypto_ecdsa_p384_keygen(&bad_priv_blob_len, &valid_pub).value !=
         OTCRYPTO_OK.value);
   CHECK(otcrypto_ecdsa_p384_keygen_async_start(&bad_priv_blob_len).value !=
@@ -336,7 +337,7 @@ static status_t run_ecdsa_negative_tests(void) {
       .keyblob_length = 112,
       .keyblob = priv_keyblob,
   };
-  bad_priv_hw.checksum = integrity_blinded_checksum(&bad_priv_hw);
+  bad_priv_hw.checksum = otcrypto_integrity_blinded_checksum(&bad_priv_hw);
   CHECK(otcrypto_ecdsa_p384_keygen(&bad_priv_hw, &valid_pub).value !=
         OTCRYPTO_OK.value);
   CHECK(otcrypto_ecdsa_p384_keygen_async_start(&bad_priv_hw).value !=
@@ -480,7 +481,7 @@ static status_t run_ecdsa_negative_tests(void) {
       .key_length = valid_pub.key_length,
       .key = valid_pub.key,
   };
-  bad_pub_mode.checksum = integrity_unblinded_checksum(&bad_pub_mode);
+  bad_pub_mode.checksum = otcrypto_integrity_unblinded_checksum(&bad_pub_mode);
   CHECK(otcrypto_ecdsa_p384_keygen_async_finalize(&valid_priv, &bad_pub_mode)
             .value != OTCRYPTO_OK.value);
 
@@ -492,7 +493,7 @@ static status_t run_ecdsa_negative_tests(void) {
       .keyblob_length = 112,
       .keyblob = priv_keyblob,
   };
-  bad_sign_hw.checksum = integrity_blinded_checksum(&bad_sign_hw);
+  bad_sign_hw.checksum = otcrypto_integrity_blinded_checksum(&bad_sign_hw);
   CHECK(
       otcrypto_ecdsa_p384_sign_async_start(&bad_sign_hw, valid_digest).value !=
       OTCRYPTO_OK.value);

--- a/sw/device/tests/crypto/ed25519_functest.c
+++ b/sw/device/tests/crypto/ed25519_functest.c
@@ -133,7 +133,7 @@ status_t ed25519_kat_test(void) {
       .keyblob_length = sizeof(keyblob),
       .keyblob = keyblob,
   };
-  private_key.checksum = integrity_blinded_checksum(&private_key);
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
 
   // Set up public_key struct.
   uint32_t public_key_buf[kEd25519PublicKeyWords];
@@ -197,7 +197,7 @@ static status_t hasheddsa_test(void) {
       .keyblob_length = sizeof(keyblob),
       .keyblob = keyblob,
   };
-  private_key.checksum = integrity_blinded_checksum(&private_key);
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
 
   uint32_t public_key_buf[kEd25519PublicKeyWords];
   otcrypto_unblinded_key_t public_key = {
@@ -251,7 +251,7 @@ static status_t sign_verify_test(void) {
       .keyblob_length = sizeof(keyblob),
       .keyblob = keyblob,
   };
-  private_key.checksum = integrity_blinded_checksum(&private_key);
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
 
   // Set up public_key struct.
   uint32_t public_key_buf[kEd25519PublicKeyWords];
@@ -261,7 +261,7 @@ static status_t sign_verify_test(void) {
       .key_length = kEd25519PublicKeyBytes,
       .key = public_key_buf,
   };
-  public_key.checksum = integrity_unblinded_checksum(&public_key);
+  public_key.checksum = otcrypto_integrity_unblinded_checksum(&public_key);
 
   // Set up input_message struct.
   otcrypto_const_byte_buf_t input_message =
@@ -300,7 +300,7 @@ static status_t run_wycheproof_invalid_r_test(void) {
       .key_length = kEd25519PublicKeyBytes,
       .key = pubkey_data,
   };
-  valid_pub.checksum = integrity_unblinded_checksum(&valid_pub);
+  valid_pub.checksum = otcrypto_integrity_unblinded_checksum(&valid_pub);
 
   const uint8_t wycheproof_msg_bytes[] = {0x31, 0x32, 0x33, 0x34, 0x30, 0x30};
   otcrypto_const_byte_buf_t msg =
@@ -354,7 +354,7 @@ static status_t run_negative_tests(void) {
       .keyblob_length = sizeof(priv_keyblob),
       .keyblob = priv_keyblob,
   };
-  valid_priv.checksum = integrity_blinded_checksum(&valid_priv);
+  valid_priv.checksum = otcrypto_integrity_blinded_checksum(&valid_priv);
 
   uint32_t public_key_buf[kEd25519PublicKeyWords];
   otcrypto_unblinded_key_t valid_pub = {
@@ -362,7 +362,7 @@ static status_t run_negative_tests(void) {
       .key_length = kEd25519PublicKeyBytes,
       .key = public_key_buf,
   };
-  valid_pub.checksum = integrity_unblinded_checksum(&valid_pub);
+  valid_pub.checksum = otcrypto_integrity_unblinded_checksum(&valid_pub);
 
   otcrypto_const_byte_buf_t msg =
       OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, (const uint8_t *)kMessage,
@@ -383,7 +383,7 @@ static status_t run_negative_tests(void) {
       .keyblob_length = sizeof(priv_keyblob),
       .keyblob = priv_keyblob,
   };
-  bad_key_len.checksum = integrity_blinded_checksum(&bad_key_len);
+  bad_key_len.checksum = otcrypto_integrity_blinded_checksum(&bad_key_len);
   CHECK(otcrypto_ed25519_public_key_from_private(&bad_key_len, &valid_pub)
             .value == OTCRYPTO_BAD_ARGS.value);
 
@@ -395,7 +395,7 @@ static status_t run_negative_tests(void) {
       .keyblob_length = sizeof(priv_keyblob),
       .keyblob = priv_keyblob,
   };
-  bad_key_mode.checksum = integrity_blinded_checksum(&bad_key_mode);
+  bad_key_mode.checksum = otcrypto_integrity_blinded_checksum(&bad_key_mode);
   CHECK(otcrypto_ed25519_public_key_from_private(&bad_key_mode, &valid_pub)
             .value == OTCRYPTO_BAD_ARGS.value);
 

--- a/sw/device/tests/crypto/hkdf_functest.c
+++ b/sw/device/tests/crypto/hkdf_functest.c
@@ -110,7 +110,7 @@ static status_t run_test(hkdf_test_vector_t *test) {
       .keyblob = ikm_keyblob,
       .keyblob_length = sizeof(ikm_keyblob),
   };
-  ikm.checksum = integrity_blinded_checksum(&ikm);
+  ikm.checksum = otcrypto_integrity_blinded_checksum(&ikm);
 
   // Construct a blinded key struct for the intermediate key (PRK).
   otcrypto_key_config_t prk_config = {
@@ -408,7 +408,7 @@ static status_t test_otcrypto_hkdf(void) {
       .keyblob = ikm_keyblob,
       .keyblob_length = sizeof(ikm_keyblob),
   };
-  ikm.checksum = integrity_blinded_checksum(&ikm);
+  ikm.checksum = otcrypto_integrity_blinded_checksum(&ikm);
 
   // Setup OKM
   otcrypto_key_config_t okm_config = {
@@ -481,19 +481,19 @@ static status_t run_negative_tests(void) {
   otcrypto_blinded_key_t valid_ikm = {.config = valid_ikm_cfg,
                                       .keyblob_length = sizeof(ikm_blob),
                                       .keyblob = ikm_blob};
-  valid_ikm.checksum = integrity_blinded_checksum(&valid_ikm);
+  valid_ikm.checksum = otcrypto_integrity_blinded_checksum(&valid_ikm);
 
   uint32_t prk_blob[keyblob_num_words(valid_prk_cfg)];
   otcrypto_blinded_key_t valid_prk = {.config = valid_prk_cfg,
                                       .keyblob_length = sizeof(prk_blob),
                                       .keyblob = prk_blob};
-  valid_prk.checksum = integrity_blinded_checksum(&valid_prk);
+  valid_prk.checksum = otcrypto_integrity_blinded_checksum(&valid_prk);
 
   uint32_t okm_blob[keyblob_num_words(valid_okm_cfg)];
   otcrypto_blinded_key_t valid_okm = {.config = valid_okm_cfg,
                                       .keyblob_length = sizeof(okm_blob),
                                       .keyblob = okm_blob};
-  valid_okm.checksum = integrity_blinded_checksum(&valid_okm);
+  valid_okm.checksum = otcrypto_integrity_blinded_checksum(&valid_okm);
 
   uint8_t dummy_data[] = {0x01};
   otcrypto_const_byte_buf_t valid_buf =
@@ -532,7 +532,7 @@ static status_t run_negative_tests(void) {
   otcrypto_blinded_key_t bad_ikm_mode = {.config = bad_mode_cfg,
                                          .keyblob_length = sizeof(ikm_blob),
                                          .keyblob = ikm_blob};
-  bad_ikm_mode.checksum = integrity_blinded_checksum(&bad_ikm_mode);
+  bad_ikm_mode.checksum = otcrypto_integrity_blinded_checksum(&bad_ikm_mode);
   CHECK(otcrypto_hkdf_extract(&bad_ikm_mode, &valid_buf, &valid_prk).value ==
         OTCRYPTO_BAD_ARGS.value);
 
@@ -541,7 +541,7 @@ static status_t run_negative_tests(void) {
   otcrypto_blinded_key_t bad_prk_mode = {.config = bad_prk_mode_cfg,
                                          .keyblob_length = sizeof(prk_blob),
                                          .keyblob = prk_blob};
-  bad_prk_mode.checksum = integrity_blinded_checksum(&bad_prk_mode);
+  bad_prk_mode.checksum = otcrypto_integrity_blinded_checksum(&bad_prk_mode);
   CHECK(otcrypto_hkdf_extract(&valid_ikm, &valid_buf, &bad_prk_mode).value ==
         OTCRYPTO_BAD_ARGS.value);
 
@@ -551,13 +551,14 @@ static status_t run_negative_tests(void) {
   otcrypto_blinded_key_t bad_prk_len = {.config = bad_prk_len_cfg,
                                         .keyblob_length = sizeof(prk_blob),
                                         .keyblob = prk_blob};
-  bad_prk_len.checksum = integrity_blinded_checksum(&bad_prk_len);
+  bad_prk_len.checksum = otcrypto_integrity_blinded_checksum(&bad_prk_len);
   CHECK(otcrypto_hkdf_extract(&valid_ikm, &valid_buf, &bad_prk_len).value ==
         OTCRYPTO_BAD_ARGS.value);
 
   otcrypto_blinded_key_t bad_prk_blob_len = {
       .config = valid_prk_cfg, .keyblob_length = 99, .keyblob = prk_blob};
-  bad_prk_blob_len.checksum = integrity_blinded_checksum(&bad_prk_blob_len);
+  bad_prk_blob_len.checksum =
+      otcrypto_integrity_blinded_checksum(&bad_prk_blob_len);
   CHECK(
       otcrypto_hkdf_extract(&valid_ikm, &valid_buf, &bad_prk_blob_len).value ==
       OTCRYPTO_BAD_ARGS.value);
@@ -579,7 +580,8 @@ static status_t run_negative_tests(void) {
   // HKDF expand config tests
   otcrypto_blinded_key_t bad_okm_blob_len = {
       .config = valid_okm_cfg, .keyblob_length = 99, .keyblob = okm_blob};
-  bad_okm_blob_len.checksum = integrity_blinded_checksum(&bad_okm_blob_len);
+  bad_okm_blob_len.checksum =
+      otcrypto_integrity_blinded_checksum(&bad_okm_blob_len);
   CHECK(otcrypto_hkdf_expand(&valid_prk, &valid_buf, &bad_okm_blob_len).value ==
         OTCRYPTO_BAD_ARGS.value);
 
@@ -590,7 +592,7 @@ static status_t run_negative_tests(void) {
   otcrypto_blinded_key_t huge_okm = {.config = huge_okm_cfg,
                                      .keyblob_length = sizeof(huge_blob),
                                      .keyblob = huge_blob};
-  huge_okm.checksum = integrity_blinded_checksum(&huge_okm);
+  huge_okm.checksum = otcrypto_integrity_blinded_checksum(&huge_okm);
   CHECK(otcrypto_hkdf_expand(&valid_prk, &valid_buf, &huge_okm).value ==
         OTCRYPTO_BAD_ARGS.value);
 

--- a/sw/device/tests/crypto/hmac_functest.c
+++ b/sw/device/tests/crypto/hmac_functest.c
@@ -33,7 +33,7 @@ static hmac_test_vector_t *current_test_vector = NULL;
 static status_t run_test_vector(void) {
   // Populate `checksum` and `config.security_level` fields.
   current_test_vector->key.checksum =
-      integrity_blinded_checksum(&current_test_vector->key);
+      otcrypto_integrity_blinded_checksum(&current_test_vector->key);
 
   // The test vectors already have the correct digest sizes hardcoded.
   size_t digest_len = current_test_vector->digest.len;
@@ -96,7 +96,7 @@ static status_t run_negative_tests(void) {
       .keyblob_length = sizeof(keyblob),
       .keyblob = keyblob,
   };
-  valid_key.checksum = integrity_blinded_checksum(&valid_key);
+  valid_key.checksum = otcrypto_integrity_blinded_checksum(&valid_key);
 
   // Base valid buffers
   uint8_t msg_data[] = "test";
@@ -142,7 +142,7 @@ static status_t run_negative_tests(void) {
       .keyblob_length = sizeof(keyblob),
       .keyblob = keyblob,
   };
-  bad_key_mode.checksum = integrity_blinded_checksum(&bad_key_mode);
+  bad_key_mode.checksum = otcrypto_integrity_blinded_checksum(&bad_key_mode);
   CHECK(otcrypto_hmac(&bad_key_mode, &msg, &tag).value ==
         OTCRYPTO_BAD_ARGS.value);
 

--- a/sw/device/tests/crypto/hmac_multistream_functest.c
+++ b/sw/device/tests/crypto/hmac_multistream_functest.c
@@ -193,7 +193,7 @@ static status_t ctx_init(otcrypto_hmac_context_t *ctx,
       .keyblob_length = current_test_vector->key.keyblob_length,
       .checksum = 0,
   };
-  key.checksum = integrity_blinded_checksum(&key);
+  key.checksum = otcrypto_integrity_blinded_checksum(&key);
 
   otcrypto_hash_mode_t hash_mode;
 
@@ -235,7 +235,7 @@ static status_t hmac_oneshot(hmac_test_vector_t *current_test_vector) {
       .keyblob_length = current_test_vector->key.keyblob_length,
       .checksum = 0,
   };
-  key.checksum = integrity_blinded_checksum(&key);
+  key.checksum = otcrypto_integrity_blinded_checksum(&key);
 
   // The test vectors already have the correct digest sizes hardcoded.
   size_t digest_len = current_test_vector->digest.len;

--- a/sw/device/tests/crypto/hmac_sha256_functest.c
+++ b/sw/device/tests/crypto/hmac_sha256_functest.c
@@ -77,7 +77,7 @@ static status_t run_test(const uint32_t *key, size_t key_len,
       .keyblob_length = sizeof(keyblob),
       .checksum = 0,
   };
-  blinded_key.checksum = integrity_blinded_checksum(&blinded_key);
+  blinded_key.checksum = otcrypto_integrity_blinded_checksum(&blinded_key);
 
   uint32_t act_tag[kTagLenWords];
   otcrypto_word32_buf_t tag_buf =
@@ -174,7 +174,7 @@ static status_t streaming_test(void) {
       .keyblob_length = sizeof(keyblob),
       .checksum = 0,
   };
-  blinded_key.checksum = integrity_blinded_checksum(&blinded_key);
+  blinded_key.checksum = otcrypto_integrity_blinded_checksum(&blinded_key);
 
   uint32_t act_tag[kTagLenWords];
   otcrypto_word32_buf_t tag_buf =

--- a/sw/device/tests/crypto/hmac_sha384_functest.c
+++ b/sw/device/tests/crypto/hmac_sha384_functest.c
@@ -82,7 +82,7 @@ static status_t run_test(const uint32_t *key, size_t key_len,
       .keyblob_length = sizeof(keyblob),
       .checksum = 0,
   };
-  blinded_key.checksum = integrity_blinded_checksum(&blinded_key);
+  blinded_key.checksum = otcrypto_integrity_blinded_checksum(&blinded_key);
 
   uint32_t act_tag[kTagLenWords];
   otcrypto_word32_buf_t tag_buf =
@@ -183,7 +183,7 @@ static status_t streaming_test(void) {
       .keyblob_length = sizeof(keyblob),
       .checksum = 0,
   };
-  blinded_key.checksum = integrity_blinded_checksum(&blinded_key);
+  blinded_key.checksum = otcrypto_integrity_blinded_checksum(&blinded_key);
 
   uint32_t act_tag[kTagLenWords];
   otcrypto_word32_buf_t tag_buf =

--- a/sw/device/tests/crypto/hmac_sha512_functest.c
+++ b/sw/device/tests/crypto/hmac_sha512_functest.c
@@ -85,7 +85,7 @@ static status_t run_test(const uint32_t *key, size_t key_len,
       .keyblob_length = sizeof(keyblob),
       .checksum = 0,
   };
-  blinded_key.checksum = integrity_blinded_checksum(&blinded_key);
+  blinded_key.checksum = otcrypto_integrity_blinded_checksum(&blinded_key);
 
   uint32_t act_tag[kTagLenWords];
   otcrypto_word32_buf_t tag_buf =
@@ -193,7 +193,7 @@ static status_t streaming_test(void) {
       .keyblob_length = sizeof(keyblob),
       .checksum = 0,
   };
-  blinded_key.checksum = integrity_blinded_checksum(&blinded_key);
+  blinded_key.checksum = otcrypto_integrity_blinded_checksum(&blinded_key);
 
   uint32_t act_tag[kTagLenWords];
   otcrypto_word32_buf_t tag_buf =

--- a/sw/device/tests/crypto/kdf_hmac_ctr_functest.c
+++ b/sw/device/tests/crypto/kdf_hmac_ctr_functest.c
@@ -98,7 +98,7 @@ static status_t run_test(kdf_test_vector_t *test) {
       .keyblob = kdk_keyblob,
       .keyblob_length = sizeof(kdk_keyblob),
   };
-  kdk.checksum = integrity_blinded_checksum(&kdk);
+  kdk.checksum = otcrypto_integrity_blinded_checksum(&kdk);
 
   // Construct a blinded key struct for the output keying material. The key mode
   // here doesn't really matter, it just needs to be some symmetric key.
@@ -1108,13 +1108,13 @@ static status_t run_hmac_kdf_negative_tests(void) {
   otcrypto_blinded_key_t valid_kdk = {.config = kdk_cfg,
                                       .keyblob_length = sizeof(kdk_blob),
                                       .keyblob = kdk_blob};
-  valid_kdk.checksum = integrity_blinded_checksum(&valid_kdk);
+  valid_kdk.checksum = otcrypto_integrity_blinded_checksum(&valid_kdk);
 
   uint32_t km_blob[keyblob_num_words(km_cfg)];
   memset(km_blob, 0, sizeof(km_blob));
   otcrypto_blinded_key_t valid_km = {
       .config = km_cfg, .keyblob_length = sizeof(km_blob), .keyblob = km_blob};
-  valid_km.checksum = integrity_blinded_checksum(&valid_km);
+  valid_km.checksum = otcrypto_integrity_blinded_checksum(&valid_km);
 
   uint8_t dummy_data[] = "test";
   otcrypto_const_byte_buf_t valid_buf =
@@ -1154,7 +1154,7 @@ static status_t run_hmac_kdf_negative_tests(void) {
   otcrypto_blinded_key_t bad_kdk_mode = {.config = bad_kdk_mode_cfg,
                                          .keyblob_length = sizeof(kdk_blob),
                                          .keyblob = kdk_blob};
-  bad_kdk_mode.checksum = integrity_blinded_checksum(&bad_kdk_mode);
+  bad_kdk_mode.checksum = otcrypto_integrity_blinded_checksum(&bad_kdk_mode);
   CHECK(otcrypto_kdf_ctr_hmac(&bad_kdk_mode, &valid_buf, &valid_buf, &valid_km)
             .value == OTCRYPTO_BAD_ARGS.value);
 
@@ -1164,7 +1164,7 @@ static status_t run_hmac_kdf_negative_tests(void) {
   otcrypto_blinded_key_t bad_km_len0 = {.config = bad_km_len0_cfg,
                                         .keyblob_length = sizeof(km_blob),
                                         .keyblob = km_blob};
-  bad_km_len0.checksum = integrity_blinded_checksum(&bad_km_len0);
+  bad_km_len0.checksum = otcrypto_integrity_blinded_checksum(&bad_km_len0);
   CHECK(otcrypto_kdf_ctr_hmac(&valid_kdk, &valid_buf, &valid_buf, &bad_km_len0)
             .value == OTCRYPTO_BAD_ARGS.value);
 
@@ -1173,7 +1173,7 @@ static status_t run_hmac_kdf_negative_tests(void) {
   otcrypto_blinded_key_t bad_km_hw = {.config = bad_km_hw_cfg,
                                       .keyblob_length = sizeof(km_blob),
                                       .keyblob = km_blob};
-  bad_km_hw.checksum = integrity_blinded_checksum(&bad_km_hw);
+  bad_km_hw.checksum = otcrypto_integrity_blinded_checksum(&bad_km_hw);
   CHECK(otcrypto_kdf_ctr_hmac(&valid_kdk, &valid_buf, &valid_buf, &bad_km_hw)
             .value == OTCRYPTO_BAD_ARGS.value);
 
@@ -1182,14 +1182,16 @@ static status_t run_hmac_kdf_negative_tests(void) {
   otcrypto_blinded_key_t bad_km_hw_invalid = {.config = bad_km_hw_inv_cfg,
                                               .keyblob_length = sizeof(km_blob),
                                               .keyblob = km_blob};
-  bad_km_hw_invalid.checksum = integrity_blinded_checksum(&bad_km_hw_invalid);
+  bad_km_hw_invalid.checksum =
+      otcrypto_integrity_blinded_checksum(&bad_km_hw_invalid);
   CHECK(otcrypto_kdf_ctr_hmac(&valid_kdk, &valid_buf, &valid_buf,
                               &bad_km_hw_invalid)
             .value == OTCRYPTO_BAD_ARGS.value);
 
   otcrypto_blinded_key_t bad_km_bloblen = {
       .config = km_cfg, .keyblob_length = 99, .keyblob = km_blob};
-  bad_km_bloblen.checksum = integrity_blinded_checksum(&bad_km_bloblen);
+  bad_km_bloblen.checksum =
+      otcrypto_integrity_blinded_checksum(&bad_km_bloblen);
   CHECK(
       otcrypto_kdf_ctr_hmac(&valid_kdk, &valid_buf, &valid_buf, &bad_km_bloblen)
           .value == OTCRYPTO_BAD_ARGS.value);
@@ -1199,7 +1201,7 @@ static status_t run_hmac_kdf_negative_tests(void) {
   otcrypto_blinded_key_t bad_km_huge = {.config = bad_km_huge_cfg,
                                         .keyblob_length = sizeof(km_blob),
                                         .keyblob = km_blob};
-  bad_km_huge.checksum = integrity_blinded_checksum(&bad_km_huge);
+  bad_km_huge.checksum = otcrypto_integrity_blinded_checksum(&bad_km_huge);
   CHECK(otcrypto_kdf_ctr_hmac(&valid_kdk, &valid_buf, &valid_buf, &bad_km_huge)
             .value == OTCRYPTO_BAD_ARGS.value);
 

--- a/sw/device/tests/crypto/kdf_kmac_functest.c
+++ b/sw/device/tests/crypto/kdf_kmac_functest.c
@@ -50,7 +50,8 @@ static status_t run_test_vector(void) {
 
   // Populate `checksum` and `config.security_level` fields.
   current_test_vector->key_derivation_key.checksum =
-      integrity_blinded_checksum(&current_test_vector->key_derivation_key);
+      otcrypto_integrity_blinded_checksum(
+          &current_test_vector->key_derivation_key);
 
   otcrypto_const_byte_buf_t label_buf = OTCRYPTO_MAKE_BUF(
       otcrypto_const_byte_buf_t, current_test_vector->label.data,
@@ -62,7 +63,7 @@ static status_t run_test_vector(void) {
   TRY(otcrypto_kmac_kdf(&current_test_vector->key_derivation_key, &label_buf,
                         &context_buf, &output_key_material));
 
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(&output_key_material),
+  HARDENED_CHECK_EQ(otcrypto_integrity_blinded_key_check(&output_key_material),
                     kHardenedBoolTrue);
 
   // Export the derived blinded key.
@@ -113,13 +114,13 @@ static status_t run_kmac_kdf_negative_tests(void) {
   otcrypto_blinded_key_t valid_kdk = {.config = kdk_cfg,
                                       .keyblob_length = sizeof(kdk_blob),
                                       .keyblob = kdk_blob};
-  valid_kdk.checksum = integrity_blinded_checksum(&valid_kdk);
+  valid_kdk.checksum = otcrypto_integrity_blinded_checksum(&valid_kdk);
 
   uint32_t km_blob[keyblob_num_words(km_cfg)];
   memset(km_blob, 0, sizeof(km_blob));
   otcrypto_blinded_key_t valid_km = {
       .config = km_cfg, .keyblob_length = sizeof(km_blob), .keyblob = km_blob};
-  valid_km.checksum = integrity_blinded_checksum(&valid_km);
+  valid_km.checksum = otcrypto_integrity_blinded_checksum(&valid_km);
 
   uint8_t dummy_data[] = "test";
   otcrypto_const_byte_buf_t valid_buf =
@@ -159,7 +160,7 @@ static status_t run_kmac_kdf_negative_tests(void) {
   otcrypto_blinded_key_t bad_kdk_mode = {.config = bad_kdk_mode_cfg,
                                          .keyblob_length = sizeof(kdk_blob),
                                          .keyblob = kdk_blob};
-  bad_kdk_mode.checksum = integrity_blinded_checksum(&bad_kdk_mode);
+  bad_kdk_mode.checksum = otcrypto_integrity_blinded_checksum(&bad_kdk_mode);
   CHECK(otcrypto_kmac_kdf(&bad_kdk_mode, &valid_buf, &valid_buf, &valid_km)
             .value == OTCRYPTO_BAD_ARGS.value);
 
@@ -169,14 +170,15 @@ static status_t run_kmac_kdf_negative_tests(void) {
   otcrypto_blinded_key_t bad_km_hw = {.config = bad_km_hw_cfg,
                                       .keyblob_length = sizeof(km_blob),
                                       .keyblob = km_blob};
-  bad_km_hw.checksum = integrity_blinded_checksum(&bad_km_hw);
+  bad_km_hw.checksum = otcrypto_integrity_blinded_checksum(&bad_km_hw);
   CHECK(
       otcrypto_kmac_kdf(&valid_kdk, &valid_buf, &valid_buf, &bad_km_hw).value ==
       OTCRYPTO_BAD_ARGS.value);
 
   otcrypto_blinded_key_t bad_km_bloblen = {
       .config = km_cfg, .keyblob_length = 99, .keyblob = km_blob};
-  bad_km_bloblen.checksum = integrity_blinded_checksum(&bad_km_bloblen);
+  bad_km_bloblen.checksum =
+      otcrypto_integrity_blinded_checksum(&bad_km_bloblen);
   CHECK(otcrypto_kmac_kdf(&valid_kdk, &valid_buf, &valid_buf, &bad_km_bloblen)
             .value == OTCRYPTO_BAD_ARGS.value);
 
@@ -213,7 +215,7 @@ static status_t run_kmac_kdf_non_word_aligned_test(void) {
   };
 
   vec->key_derivation_key.checksum =
-      integrity_blinded_checksum(&vec->key_derivation_key);
+      otcrypto_integrity_blinded_checksum(&vec->key_derivation_key);
 
   otcrypto_const_byte_buf_t label_buf = OTCRYPTO_MAKE_BUF(
       otcrypto_const_byte_buf_t, vec->label.data, vec->label.len);
@@ -223,7 +225,7 @@ static status_t run_kmac_kdf_non_word_aligned_test(void) {
   TRY(otcrypto_kmac_kdf(&vec->key_derivation_key, &label_buf, &context_buf,
                         &output_key));
 
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(&output_key),
+  HARDENED_CHECK_EQ(otcrypto_integrity_blinded_key_check(&output_key),
                     kHardenedBoolTrue);
 
   return OTCRYPTO_OK;

--- a/sw/device/tests/crypto/kdf_kmac_sideload_functest.c
+++ b/sw/device/tests/crypto/kdf_kmac_sideload_functest.c
@@ -320,7 +320,8 @@ static status_t run_test_vector(void) {
   uint32_t km_buffer2[km_keyblob_len];
 
   current_test_vector->key_derivation_key.checksum =
-      integrity_blinded_checksum(&current_test_vector->key_derivation_key);
+      otcrypto_integrity_blinded_checksum(
+          &current_test_vector->key_derivation_key);
 
   otcrypto_key_config_t km_config = {
       // The following key_mode is a dummy placeholder. It does not

--- a/sw/device/tests/crypto/kmac_functest.c
+++ b/sw/device/tests/crypto/kmac_functest.c
@@ -190,7 +190,7 @@ static status_t run_cshake(otcrypto_hash_digest_t *digest) {
  */
 static status_t run_kmac(otcrypto_word32_buf_t tag) {
   current_test_vector->key.checksum =
-      integrity_blinded_checksum(&current_test_vector->key);
+      otcrypto_integrity_blinded_checksum(&current_test_vector->key);
   otcrypto_const_byte_buf_t input_msg = OTCRYPTO_MAKE_BUF(
       otcrypto_const_byte_buf_t, current_test_vector->input_msg.data,
       current_test_vector->input_msg.len);
@@ -270,7 +270,7 @@ static status_t run_negative_tests(void) {
       .keyblob_length = sizeof(valid_keyblob),
       .keyblob = valid_keyblob,
   };
-  valid_key.checksum = integrity_blinded_checksum(&valid_key);
+  valid_key.checksum = otcrypto_integrity_blinded_checksum(&valid_key);
 
   // Base valid buffers
   uint8_t dummy_data[] = "test";
@@ -337,7 +337,7 @@ static status_t run_negative_tests(void) {
       .keyblob_length = sizeof(valid_keyblob),
       .keyblob = valid_keyblob,
   };
-  bad_key_mode.checksum = integrity_blinded_checksum(&bad_key_mode);
+  bad_key_mode.checksum = otcrypto_integrity_blinded_checksum(&bad_key_mode);
   CHECK(otcrypto_kmac(&bad_key_mode, &valid_msg, &valid_cust, valid_req_len,
                       &valid_tag)
             .value == OTCRYPTO_BAD_ARGS.value);
@@ -348,7 +348,7 @@ static status_t run_negative_tests(void) {
       .keyblob_length = 32,
       .keyblob = valid_keyblob,
   };
-  bad_sw_len.checksum = integrity_blinded_checksum(&bad_sw_len);
+  bad_sw_len.checksum = otcrypto_integrity_blinded_checksum(&bad_sw_len);
   CHECK(otcrypto_kmac(&bad_sw_len, &valid_msg, &valid_cust, valid_req_len,
                       &valid_tag)
             .value == OTCRYPTO_BAD_ARGS.value);
@@ -361,7 +361,7 @@ static status_t run_negative_tests(void) {
       .keyblob_length = sizeof(valid_keyblob),
       .keyblob = valid_keyblob,
   };
-  bad_hw_enum.checksum = integrity_blinded_checksum(&bad_hw_enum);
+  bad_hw_enum.checksum = otcrypto_integrity_blinded_checksum(&bad_hw_enum);
   CHECK(otcrypto_kmac(&bad_hw_enum, &valid_msg, &valid_cust, valid_req_len,
                       &valid_tag)
             .value == OTCRYPTO_BAD_ARGS.value);
@@ -374,7 +374,7 @@ static status_t run_negative_tests(void) {
       .keyblob_length = 32,
       .keyblob = valid_keyblob,
   };
-  bad_hw_len.checksum = integrity_blinded_checksum(&bad_hw_len);
+  bad_hw_len.checksum = otcrypto_integrity_blinded_checksum(&bad_hw_len);
   CHECK(otcrypto_kmac(&bad_hw_len, &valid_msg, &valid_cust, valid_req_len,
                       &valid_tag)
             .value == OTCRYPTO_BAD_ARGS.value);

--- a/sw/device/tests/crypto/kmac_sideload_functest.c
+++ b/sw/device/tests/crypto/kmac_sideload_functest.c
@@ -281,7 +281,7 @@ static status_t run_test_vector(void) {
   uint32_t digest2[digest_num_words];
 
   current_test_vector->key.checksum =
-      integrity_blinded_checksum(&current_test_vector->key);
+      otcrypto_integrity_blinded_checksum(&current_test_vector->key);
 
   otcrypto_word32_buf_t tag_buf1 =
       OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, digest1, ARRAYSIZE(digest1));

--- a/sw/device/tests/crypto/otcrypto_interface.c
+++ b/sw/device/tests/crypto/otcrypto_interface.c
@@ -31,6 +31,10 @@ volatile otcrypto_interface_t otcrypto = {
     .check_const_byte_buf = &otcrypto_check_const_byte_buf,
     .check_word32_buf = &otcrypto_check_word32_buf,
     .check_const_word32_buf = &otcrypto_check_const_word32_buf,
+    .integrity_unblinded_checksum = &otcrypto_integrity_unblinded_checksum,
+    .integrity_blinded_checksum = &otcrypto_integrity_blinded_checksum,
+    .integrity_unblinded_key_check = &otcrypto_integrity_unblinded_key_check,
+    .integrity_blinded_key_check = &otcrypto_integrity_blinded_key_check,
 
     // Symmetric key generation.
     .symmetric_keygen = &otcrypto_symmetric_keygen,

--- a/sw/device/tests/crypto/otcrypto_interface.h
+++ b/sw/device/tests/crypto/otcrypto_interface.h
@@ -42,6 +42,12 @@ typedef struct otcrypto_interface_t {
   hardened_bool_t (*check_word32_buf)(const otcrypto_word32_buf_t *);
   hardened_bool_t (*check_const_word32_buf)(
       const otcrypto_const_word32_buf_t *);
+  uint32_t (*integrity_unblinded_checksum)(const otcrypto_unblinded_key_t *);
+  uint32_t (*integrity_blinded_checksum)(const otcrypto_blinded_key_t *);
+  hardened_bool_t (*integrity_unblinded_key_check)(
+      const otcrypto_unblinded_key_t *);
+  hardened_bool_t (*integrity_blinded_key_check)(
+      const otcrypto_blinded_key_t *);
 
   // Key utilities
   otcrypto_status_t (*symmetric_keygen)(const otcrypto_const_byte_buf_t *,

--- a/sw/device/tests/crypto/rsa_2048_encryption_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_encryption_functest.c
@@ -237,7 +237,7 @@ static status_t run_encrypt_negative_tests(void) {
       .key_length = kOtcryptoRsa2048PublicKeyBytes,
       .key = pub_data,
   };
-  valid_pub.checksum = integrity_unblinded_checksum(&valid_pub);
+  valid_pub.checksum = otcrypto_integrity_unblinded_checksum(&valid_pub);
 
   otcrypto_key_config_t priv_cfg = {
       .version = kOtcryptoLibVersion1,
@@ -252,7 +252,7 @@ static status_t run_encrypt_negative_tests(void) {
       .keyblob_length = kOtcryptoRsa2048PrivateKeyblobBytes,
       .keyblob = priv_blob,
   };
-  valid_priv.checksum = integrity_blinded_checksum(&valid_priv);
+  valid_priv.checksum = otcrypto_integrity_blinded_checksum(&valid_priv);
 
   // Base valid/invalid buffers
   uint8_t msg_data[] = "test";
@@ -324,7 +324,7 @@ static status_t run_encrypt_negative_tests(void) {
       .key_length = valid_pub.key_length,
       .key = pub_data,
   };
-  bad_pub_mode.checksum = integrity_unblinded_checksum(&bad_pub_mode);
+  bad_pub_mode.checksum = otcrypto_integrity_unblinded_checksum(&bad_pub_mode);
   CHECK(otcrypto_rsa_encrypt(&bad_pub_mode, kTestHashMode, &valid_msg,
                              &valid_msg, &valid_ct)
             .value == OTCRYPTO_BAD_ARGS.value);
@@ -388,7 +388,7 @@ static status_t run_encrypt_negative_tests(void) {
       .keyblob_length = kOtcryptoRsa2048PrivateKeyblobBytes,
       .keyblob = priv_blob,
   };
-  bad_priv_mode.checksum = integrity_blinded_checksum(&bad_priv_mode);
+  bad_priv_mode.checksum = otcrypto_integrity_blinded_checksum(&bad_priv_mode);
   CHECK(otcrypto_rsa_decrypt(&bad_priv_mode, kTestHashMode, &valid_const_ct,
                              &valid_msg, &valid_pt, &pt_len)
             .value == OTCRYPTO_BAD_ARGS.value);
@@ -432,7 +432,7 @@ static status_t run_encrypt_negative_tests(void) {
       .key_length = 257,  // Unrecognized length
       .key = pub_data,
   };
-  pub_bad_size.checksum = integrity_unblinded_checksum(&pub_bad_size);
+  pub_bad_size.checksum = otcrypto_integrity_unblinded_checksum(&pub_bad_size);
   CHECK(otcrypto_rsa_encrypt(&pub_bad_size, kTestHashMode, &valid_msg,
                              &valid_msg, &valid_ct)
             .value == OTCRYPTO_BAD_ARGS.value);

--- a/sw/device/tests/crypto/rsa_2048_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_signature_functest.c
@@ -323,7 +323,7 @@ static status_t run_signature_negative_tests(void) {
       .key_length = kOtcryptoRsa2048PublicKeyBytes,
       .key = pub_data,
   };
-  valid_pub.checksum = integrity_unblinded_checksum(&valid_pub);
+  valid_pub.checksum = otcrypto_integrity_unblinded_checksum(&valid_pub);
 
   uint32_t priv_blob[kOtcryptoRsa2048PrivateKeyblobBytes / 4] = {0};
   otcrypto_blinded_key_t valid_priv = {
@@ -338,7 +338,7 @@ static status_t run_signature_negative_tests(void) {
       .keyblob_length = kOtcryptoRsa2048PrivateKeyblobBytes,
       .keyblob = priv_blob,
   };
-  valid_priv.checksum = integrity_blinded_checksum(&valid_priv);
+  valid_priv.checksum = otcrypto_integrity_blinded_checksum(&valid_priv);
 
   uint32_t digest_data[256 / 32] = {0};
   otcrypto_hash_digest_t valid_digest = {.data = digest_data,

--- a/sw/device/tests/crypto/symmetric_keygen_functest.c
+++ b/sw/device/tests/crypto/symmetric_keygen_functest.c
@@ -93,7 +93,7 @@ static status_t basic_keygen_test(otcrypto_key_config_t config) {
     TRY(otcrypto_symmetric_keygen(&kPersonalization, &key));
 
     // Ensure the checksum passes.
-    TRY_CHECK(integrity_blinded_key_check(&key) == kHardenedBoolTrue);
+    TRY_CHECK(otcrypto_integrity_blinded_key_check(&key) == kHardenedBoolTrue);
 
     // Try the statistical test.
     status_t stat_status = randomness_quality_monobit_test(
@@ -216,7 +216,7 @@ static status_t hw_backed_keygen_test(void) {
 
   // Initialize the hardware-backed keyblob preset.
   TRY(otcrypto_hw_backed_key(version, salt, &key));
-  TRY_CHECK(key.checksum == integrity_blinded_checksum(&key));
+  TRY_CHECK(key.checksum == otcrypto_integrity_blinded_checksum(&key));
 
   // Generate the SW-visible key from the hardware-backed preset.
   TRY(ot_crypto_hw_backed_keygen(kHardenedBoolFalse, &key));
@@ -224,7 +224,7 @@ static status_t hw_backed_keygen_test(void) {
   // Verify the key struct was morphed correctly.
   TRY_CHECK(key.config.hw_backed == kHardenedBoolFalse);
   TRY_CHECK(key.keyblob_length == 16 * sizeof(uint32_t));
-  TRY_CHECK(integrity_blinded_key_check(&key) == kHardenedBoolTrue);
+  TRY_CHECK(otcrypto_integrity_blinded_key_check(&key) == kHardenedBoolTrue);
 
   // We provide a test with CDI set to one, i.e., using the attestation key.
   uint32_t attestation_keyblob[9];
@@ -242,7 +242,7 @@ static status_t hw_backed_keygen_test(void) {
   TRY(otcrypto_hw_backed_attestation_key(attestation_version, attestation_salt,
                                          &attestation_key));
   TRY_CHECK(attestation_key.checksum ==
-            integrity_blinded_checksum(&attestation_key));
+            otcrypto_integrity_blinded_checksum(&attestation_key));
 
   // Generate the SW-visible key from the hardware-backed preset.
   TRY(ot_crypto_hw_backed_keygen(kHardenedBoolTrue, &attestation_key));
@@ -250,7 +250,7 @@ static status_t hw_backed_keygen_test(void) {
   // Verify the key struct was morphed correctly.
   TRY_CHECK(key.config.hw_backed == kHardenedBoolFalse);
   TRY_CHECK(key.keyblob_length == 16 * sizeof(uint32_t));
-  TRY_CHECK(integrity_blinded_key_check(&key) == kHardenedBoolTrue);
+  TRY_CHECK(otcrypto_integrity_blinded_key_check(&key) == kHardenedBoolTrue);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/crypto/x25519_functest.c
+++ b/sw/device/tests/crypto/x25519_functest.c
@@ -103,7 +103,8 @@ status_t x25519_kat_test(void) {
       .keyblob_length = sizeof(keyblob_alice),
       .keyblob = keyblob_alice,
   };
-  private_key_alice.checksum = integrity_blinded_checksum(&private_key_alice);
+  private_key_alice.checksum =
+      otcrypto_integrity_blinded_checksum(&private_key_alice);
 
   // Set up public_key struct for bob.
   uint32_t public_key_buf_bob[kX25519PublicKeyWords];
@@ -113,7 +114,8 @@ status_t x25519_kat_test(void) {
       .key_length = kX25519PublicKeyBytes,
       .key = public_key_buf_bob,
   };
-  public_key_bob.checksum = integrity_unblinded_checksum(&public_key_bob);
+  public_key_bob.checksum =
+      otcrypto_integrity_unblinded_checksum(&public_key_bob);
 
   // Set up shared secret struct.
   uint32_t shared_secret_keyblob[keyblob_num_words(kPrivateKeyConfig)];
@@ -153,7 +155,8 @@ status_t x25519_keygen_test(void) {
       .keyblob_length = sizeof(keyblob_alice),
       .keyblob = keyblob_alice,
   };
-  private_key_alice.checksum = integrity_blinded_checksum(&private_key_alice);
+  private_key_alice.checksum =
+      otcrypto_integrity_blinded_checksum(&private_key_alice);
 
   // Set up public_key struct for alice.
   uint32_t public_key_buf_alice[kX25519PublicKeyWords];
@@ -162,7 +165,8 @@ status_t x25519_keygen_test(void) {
       .key_length = kX25519PublicKeyBytes,
       .key = public_key_buf_alice,
   };
-  public_key_alice.checksum = integrity_unblinded_checksum(&public_key_alice);
+  public_key_alice.checksum =
+      otcrypto_integrity_unblinded_checksum(&public_key_alice);
 
   // Run x25519 key generation.
   CHECK_STATUS_OK(

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
@@ -1109,7 +1109,7 @@ status_t cryptolib_fi_ed25519_sign_impl(
       .keyblob_length = sizeof(private_keyblob),
       .keyblob = private_keyblob,
   };
-  private_key.checksum = integrity_blinded_checksum(&private_key);
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
 
   // Derive the public key (required by sign_verify).
   uint32_t public_key_data[ED25519_CMD_SCALAR_BYTES / sizeof(uint32_t)];
@@ -1177,7 +1177,7 @@ status_t cryptolib_fi_ed25519_verify_impl(
       .key_length = ED25519_CMD_SCALAR_BYTES,
       .key = public_key_data,
   };
-  public_key.checksum = integrity_unblinded_checksum(&public_key);
+  public_key.checksum = otcrypto_integrity_unblinded_checksum(&public_key);
 
   // Reconstruct the 64-byte signature from r[0..31] and s[0..31].
   uint32_t signature_data[ED25519_CMD_SIG_BYTES / sizeof(uint32_t)];
@@ -1233,7 +1233,7 @@ status_t cryptolib_fi_x25519_base_mul_impl(
       .keyblob_length = sizeof(private_keyblob),
       .keyblob = private_keyblob,
   };
-  private_key.checksum = integrity_blinded_checksum(&private_key);
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
 
   // Construct public key
   uint32_t public_key_buf[X25519_CMD_BYTES / sizeof(uint32_t)];
@@ -1282,7 +1282,7 @@ status_t cryptolib_fi_x25519_ecdh_impl(
       .keyblob_length = sizeof(private_keyblob),
       .keyblob = private_keyblob,
   };
-  private_key.checksum = integrity_blinded_checksum(&private_key);
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
 
   uint32_t public_key_buf[X25519_CMD_BYTES / sizeof(uint32_t)];
   memset(public_key_buf, 0, sizeof(public_key_buf));
@@ -1292,7 +1292,7 @@ status_t cryptolib_fi_x25519_ecdh_impl(
       .key_length = X25519_CMD_BYTES,
       .key = public_key_buf,
   };
-  public_key.checksum = integrity_unblinded_checksum(&public_key);
+  public_key.checksum = otcrypto_integrity_unblinded_checksum(&public_key);
 
   uint32_t shared_secretblob[16];
   memset(shared_secretblob, 0, sizeof(shared_secretblob));

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym_impl.c
@@ -787,7 +787,7 @@ status_t cryptolib_sca_ed25519_sign_impl(
       .keyblob_length = sizeof(private_keyblob),
       .keyblob = private_keyblob,
   };
-  private_key.checksum = integrity_blinded_checksum(&private_key);
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
 
   // Derive the public key (required by sign_verify).
   uint32_t public_key_data[ED25519_CMD_SCALAR_BYTES / sizeof(uint32_t)];
@@ -864,7 +864,7 @@ status_t cryptolib_sca_x25519_base_mul_impl(uint8_t scalar[X25519_CMD_BYTES],
       .keyblob_length = sizeof(private_keyblob),
       .keyblob = private_keyblob,
   };
-  private_key.checksum = integrity_blinded_checksum(&private_key);
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
 
   uint32_t public_key_buf[X25519_CMD_BYTES / sizeof(uint32_t)];
   memset(public_key_buf, 0, sizeof(public_key_buf));
@@ -906,7 +906,7 @@ status_t cryptolib_sca_x25519_ecdh_impl(
       .keyblob_length = sizeof(private_keyblob),
       .keyblob = private_keyblob,
   };
-  private_key.checksum = integrity_blinded_checksum(&private_key);
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
 
   uint32_t public_key_buf[X25519_CMD_BYTES / sizeof(uint32_t)];
   memcpy(public_key_buf, uj_input.public_x, X25519_CMD_BYTES);
@@ -915,7 +915,7 @@ status_t cryptolib_sca_x25519_ecdh_impl(
       .key_length = sizeof(public_key_buf),
       .key = public_key_buf,
   };
-  public_key.checksum = integrity_unblinded_checksum(&public_key);
+  public_key.checksum = otcrypto_integrity_unblinded_checksum(&public_key);
 
   uint32_t shared_secretblob[16];
   memset(shared_secretblob, 0, sizeof(shared_secretblob));


### PR DESCRIPTION
Change the public functions for the user to have the otcrypto_ prefix in the name. Change the OTCRYPTO_MAKE_BUF macro to ingest the inline function. Include the new public functions to otcrypto_interface.