### PR TITLE
[cryptotest] Enable ACVP testing for RSA sign

### DIFF
--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -69,6 +69,20 @@ cryptotest(
     ],
 )
 
+cryptotest(
+    name = "rsa_acvp_siggen",
+    slow_test = True,
+    test_args = " ".join([
+        "--input=\"$(rootpath //sw/host/cryptotest/testvectors/acvp:rsa_vectors.json)\"",
+        "--run-siggen",
+        "--timeout=250s",
+    ]),
+    test_harness = "//sw/host/tests/crypto/acvp:harness",
+    test_vectors = [
+        "//sw/host/cryptotest/testvectors/acvp:rsa_vectors.json",
+    ],
+)
+
 AES_TESTVECTOR_TARGETS = [
     "//sw/host/cryptotest/testvectors/data:nist_cavp_aes_kat_{}_{}_{}_json".format(alg, kat_type, key_len)
     for alg in ("cbc", "cfb128", "ecb", "ofb")
@@ -704,6 +718,7 @@ test_suite(
         ":hmac_sha512_kat",
         ":kmac_kat",
         ":rsa_acvp",
+        ":rsa_acvp_siggen",
         ":rsa_kat",
         ":sha256_kat",
         ":sha384_kat",

--- a/sw/device/tests/crypto/cryptotest/firmware/rsa.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/rsa.c
@@ -676,9 +676,9 @@ status_t handle_rsa_verify(ujson_t *uj) {
   return OK_STATUS();
 }
 
-status_t handle_rsa_keygen(ujson_t *uj) {
-  cryptotest_rsa_keygen_t uj_input;
-  TRY(ujson_deserialize_cryptotest_rsa_keygen_t(uj, &uj_input));
+status_t handle_rsa_keygen_check(ujson_t *uj) {
+  cryptotest_rsa_keygen_check_t uj_input;
+  TRY(ujson_deserialize_cryptotest_rsa_keygen_check_t(uj, &uj_input));
 
   size_t rsa_num_words;
   size_t public_key_bytes;
@@ -857,9 +857,9 @@ status_t handle_rsa_keygen(ujson_t *uj) {
     }
   }
 
-  cryptotest_rsa_keygen_resp_t uj_output;
+  cryptotest_rsa_keygen_check_resp_t uj_output;
   uj_output.result = result;
-  RESP_OK(ujson_serialize_cryptotest_rsa_keygen_resp_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_cryptotest_rsa_keygen_check_resp_t, uj, &uj_output);
   return OK_STATUS();
 }
 
@@ -875,8 +875,8 @@ status_t handle_rsa(ujson_t *uj) {
       return handle_rsa_sign(uj);
     case kRsaSubcommandRsaVerify:
       return handle_rsa_verify(uj);
-    case kRsaSubcommandRsaKeygen:
-      return handle_rsa_keygen(uj);
+    case kRsaSubcommandRsaKeygenCheck:
+      return handle_rsa_keygen_check(uj);
     default:
       LOG_ERROR("Unrecognized RSA subcommand: %d", cmd);
       return INVALID_ARGUMENT();

--- a/sw/device/tests/crypto/cryptotest/firmware/rsa.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/rsa.c
@@ -72,6 +72,108 @@ static const uint32_t key_mask[kCryptotestRsa4096NumWords] = {
     0xe6cae515, 0x063cb76b, 0xff9428aa, 0x5c69fc6a, 0xbb15f685, 0xeb951a27,
     0xcadc73ec, 0xd3770767};
 
+static status_t rsa_size_params(size_t security_level,
+                                otcrypto_rsa_size_t *rsa_size,
+                                size_t *rsa_num_words, size_t *public_key_bytes,
+                                size_t *private_key_bytes,
+                                size_t *private_key_blob_bytes) {
+  size_t n_bytes = security_level / 8;
+  switch (n_bytes) {
+    case kOtcryptoRsa2048PublicKeyBytes:
+      *rsa_size = kOtcryptoRsaSize2048;
+      *rsa_num_words = kCryptotestRsa2048NumWords;
+      if (public_key_bytes)
+        *public_key_bytes = kOtcryptoRsa2048PublicKeyBytes;
+      if (private_key_bytes)
+        *private_key_bytes = kOtcryptoRsa2048PrivateKeyBytes;
+      if (private_key_blob_bytes)
+        *private_key_blob_bytes = kOtcryptoRsa2048PrivateKeyblobBytes;
+      break;
+    case kOtcryptoRsa3072PublicKeyBytes:
+      *rsa_size = kOtcryptoRsaSize3072;
+      *rsa_num_words = kCryptotestRsa3072NumWords;
+      if (public_key_bytes)
+        *public_key_bytes = kOtcryptoRsa3072PublicKeyBytes;
+      if (private_key_bytes)
+        *private_key_bytes = kOtcryptoRsa3072PrivateKeyBytes;
+      if (private_key_blob_bytes)
+        *private_key_blob_bytes = kOtcryptoRsa3072PrivateKeyblobBytes;
+      break;
+    case kOtcryptoRsa4096PublicKeyBytes:
+      *rsa_size = kOtcryptoRsaSize4096;
+      *rsa_num_words = kCryptotestRsa4096NumWords;
+      if (public_key_bytes)
+        *public_key_bytes = kOtcryptoRsa4096PublicKeyBytes;
+      if (private_key_bytes)
+        *private_key_bytes = kOtcryptoRsa4096PrivateKeyBytes;
+      if (private_key_blob_bytes)
+        *private_key_blob_bytes = kOtcryptoRsa4096PrivateKeyblobBytes;
+      break;
+    default:
+      LOG_ERROR("Unsupported RSA security_level: %d", (uint32_t)security_level);
+      return INVALID_ARGUMENT();
+  }
+  return OK_STATUS();
+}
+
+static status_t rsa_hash_mode(size_t hashing, otcrypto_hash_mode_t *hash_mode,
+                              size_t *hash_digest_words) {
+  switch (hashing) {
+    case kCryptotestRsaSha256:
+      *hash_mode = kOtcryptoHashModeSha256;
+      if (hash_digest_words)
+        *hash_digest_words = 256 / 32;
+      break;
+    case kCryptotestRsaSha384:
+      *hash_mode = kOtcryptoHashModeSha384;
+      if (hash_digest_words)
+        *hash_digest_words = 384 / 32;
+      break;
+    case kCryptotestRsaSha512:
+      *hash_mode = kOtcryptoHashModeSha512;
+      if (hash_digest_words)
+        *hash_digest_words = 512 / 32;
+      break;
+    case kCryptotestRsaSha3_256:
+      *hash_mode = kOtcryptoHashModeSha3_256;
+      if (hash_digest_words)
+        *hash_digest_words = 256 / 32;
+      break;
+    case kCryptotestRsaSha3_384:
+      *hash_mode = kOtcryptoHashModeSha3_384;
+      if (hash_digest_words)
+        *hash_digest_words = 384 / 32;
+      break;
+    case kCryptotestRsaSha3_512:
+      *hash_mode = kOtcryptoHashModeSha3_512;
+      if (hash_digest_words)
+        *hash_digest_words = 512 / 32;
+      break;
+    default:
+      LOG_ERROR("Unsupported RSA hash mode: %d", (uint32_t)hashing);
+      return INVALID_ARGUMENT();
+  }
+  return OK_STATUS();
+}
+
+static status_t rsa_sign_padding(size_t padding, otcrypto_key_mode_t *key_mode,
+                                 otcrypto_rsa_padding_t *padding_mode) {
+  switch (padding) {
+    case kCryptotestRsaPaddingPkcs:
+      *key_mode = kOtcryptoKeyModeRsaSignPkcs;
+      *padding_mode = kOtcryptoRsaPaddingPkcs;
+      break;
+    case kCryptotestRsaPaddingPss:
+      *key_mode = kOtcryptoKeyModeRsaSignPss;
+      *padding_mode = kOtcryptoRsaPaddingPss;
+      break;
+    default:
+      LOG_ERROR("Unsupported RSA padding mode: %d", (uint32_t)padding);
+      return INVALID_ARGUMENT();
+  }
+  return OK_STATUS();
+}
+
 static status_t hash_message(otcrypto_const_byte_buf_t *msg_buf,
                              otcrypto_hash_mode_t hash_mode,
                              otcrypto_hash_digest_t *msg_digest) {
@@ -108,55 +210,14 @@ status_t handle_rsa_encrypt(ujson_t *uj) {
     return INVALID_ARGUMENT();
   }
 
-  size_t rsa_num_words;
-  size_t public_key_bytes;
   otcrypto_rsa_size_t rsa_size;
+  size_t rsa_num_words, public_key_bytes;
   size_t n_bytes = uj_input.security_level / 8;
-  switch (n_bytes) {
-    case kOtcryptoRsa2048PublicKeyBytes:
-      rsa_size = kOtcryptoRsaSize2048;
-      rsa_num_words = kCryptotestRsa2048NumWords;
-      public_key_bytes = kOtcryptoRsa2048PublicKeyBytes;
-      break;
-    case kOtcryptoRsa3072PublicKeyBytes:
-      rsa_size = kOtcryptoRsaSize3072;
-      rsa_num_words = kCryptotestRsa3072NumWords;
-      public_key_bytes = kOtcryptoRsa3072PublicKeyBytes;
-      break;
-    case kOtcryptoRsa4096PublicKeyBytes:
-      rsa_size = kOtcryptoRsaSize4096;
-      rsa_num_words = kCryptotestRsa4096NumWords;
-      public_key_bytes = kOtcryptoRsa4096PublicKeyBytes;
-      break;
-    default:
-      LOG_ERROR("Unsupported RSA security_level: %d", uj_input.security_level);
-      return INVALID_ARGUMENT();
-  }
+  TRY(rsa_size_params(uj_input.security_level, &rsa_size, &rsa_num_words,
+                      &public_key_bytes, NULL, NULL));
 
   otcrypto_hash_mode_t hash_mode;
-  switch (uj_input.hashing) {
-    case kCryptotestRsaSha256:
-      hash_mode = kOtcryptoHashModeSha256;
-      break;
-    case kCryptotestRsaSha384:
-      hash_mode = kOtcryptoHashModeSha384;
-      break;
-    case kCryptotestRsaSha512:
-      hash_mode = kOtcryptoHashModeSha512;
-      break;
-    case kCryptotestRsaSha3_256:
-      hash_mode = kOtcryptoHashModeSha3_256;
-      break;
-    case kCryptotestRsaSha3_384:
-      hash_mode = kOtcryptoHashModeSha3_384;
-      break;
-    case kCryptotestRsaSha3_512:
-      hash_mode = kOtcryptoHashModeSha3_512;
-      break;
-    default:
-      LOG_ERROR("Unsupported RSA hash mode: %d", uj_input.hashing);
-      return INVALID_ARGUMENT();
-  }
+  TRY(rsa_hash_mode(uj_input.hashing, &hash_mode, NULL));
 
   // Create the modulus N buffer.
   uint32_t n_buf[rsa_num_words];
@@ -228,66 +289,16 @@ status_t handle_rsa_decrypt(ujson_t *uj) {
     return INVALID_ARGUMENT();
   }
 
-  size_t rsa_num_words;
-  size_t private_key_bytes;
-  size_t private_key_blob_bytes;
   otcrypto_rsa_size_t rsa_size;
+  size_t rsa_num_words, private_key_bytes, private_key_blob_bytes;
   size_t n_bytes = uj_input.security_level / 8;
-  switch (n_bytes) {
-    case kOtcryptoRsa2048PublicKeyBytes:
-      rsa_size = kOtcryptoRsaSize2048;
-      rsa_num_words = kCryptotestRsa2048NumWords;
-      private_key_bytes = kOtcryptoRsa2048PrivateKeyBytes;
-      private_key_blob_bytes = kOtcryptoRsa2048PrivateKeyblobBytes;
-      break;
-    case kOtcryptoRsa3072PublicKeyBytes:
-      rsa_size = kOtcryptoRsaSize3072;
-      rsa_num_words = kCryptotestRsa3072NumWords;
-      private_key_bytes = kOtcryptoRsa3072PrivateKeyBytes;
-      private_key_blob_bytes = kOtcryptoRsa3072PrivateKeyblobBytes;
-      break;
-    case kOtcryptoRsa4096PublicKeyBytes:
-      rsa_size = kOtcryptoRsaSize4096;
-      rsa_num_words = kCryptotestRsa4096NumWords;
-      private_key_bytes = kOtcryptoRsa4096PrivateKeyBytes;
-      private_key_blob_bytes = kOtcryptoRsa4096PrivateKeyblobBytes;
-      break;
-    default:
-      LOG_ERROR("Unsupported RSA security_level: %d", uj_input.security_level);
-      return INVALID_ARGUMENT();
-  }
+  TRY(rsa_size_params(uj_input.security_level, &rsa_size, &rsa_num_words, NULL,
+                      &private_key_bytes, &private_key_blob_bytes));
 
   otcrypto_hash_mode_t hash_mode;
-  size_t hash_digest_bytes;
-  switch (uj_input.hashing) {
-    case kCryptotestRsaSha256:
-      hash_mode = kOtcryptoHashModeSha256;
-      hash_digest_bytes = 256 / 8;
-      break;
-    case kCryptotestRsaSha384:
-      hash_mode = kOtcryptoHashModeSha384;
-      hash_digest_bytes = 384 / 8;
-      break;
-    case kCryptotestRsaSha512:
-      hash_mode = kOtcryptoHashModeSha512;
-      hash_digest_bytes = 512 / 8;
-      break;
-    case kCryptotestRsaSha3_256:
-      hash_mode = kOtcryptoHashModeSha3_256;
-      hash_digest_bytes = 256 / 8;
-      break;
-    case kCryptotestRsaSha3_384:
-      hash_mode = kOtcryptoHashModeSha3_384;
-      hash_digest_bytes = 384 / 8;
-      break;
-    case kCryptotestRsaSha3_512:
-      hash_mode = kOtcryptoHashModeSha3_512;
-      hash_digest_bytes = 512 / 8;
-      break;
-    default:
-      LOG_ERROR("Unsupported RSA hash mode: %d", uj_input.hashing);
-      return INVALID_ARGUMENT();
-  }
+  size_t hash_digest_words;
+  TRY(rsa_hash_mode(uj_input.hashing, &hash_mode, &hash_digest_words));
+  size_t hash_digest_bytes = hash_digest_words * sizeof(uint32_t);
 
   // Create the modulus N buffer.
   uint32_t n_buf[rsa_num_words];
@@ -385,82 +396,19 @@ status_t handle_rsa_sign(ujson_t *uj) {
     return INVALID_ARGUMENT();
   }
 
-  size_t rsa_num_words;
-  size_t private_key_bytes;
-  size_t private_key_blob_bytes;
   otcrypto_rsa_size_t rsa_size;
+  size_t rsa_num_words, private_key_bytes, private_key_blob_bytes;
   size_t n_bytes = uj_input.security_level / 8;
-  switch (n_bytes) {
-    case kOtcryptoRsa2048PublicKeyBytes:
-      rsa_size = kOtcryptoRsaSize2048;
-      rsa_num_words = kCryptotestRsa2048NumWords;
-      private_key_bytes = kOtcryptoRsa2048PrivateKeyBytes;
-      private_key_blob_bytes = kOtcryptoRsa2048PrivateKeyblobBytes;
-      break;
-    case kOtcryptoRsa3072PublicKeyBytes:
-      rsa_size = kOtcryptoRsaSize3072;
-      rsa_num_words = kCryptotestRsa3072NumWords;
-      private_key_bytes = kOtcryptoRsa3072PrivateKeyBytes;
-      private_key_blob_bytes = kOtcryptoRsa3072PrivateKeyblobBytes;
-      break;
-    case kOtcryptoRsa4096PublicKeyBytes:
-      rsa_size = kOtcryptoRsaSize4096;
-      rsa_num_words = kCryptotestRsa4096NumWords;
-      private_key_bytes = kOtcryptoRsa4096PrivateKeyBytes;
-      private_key_blob_bytes = kOtcryptoRsa4096PrivateKeyblobBytes;
-      break;
-    default:
-      LOG_ERROR("Unsupported RSA security_level: %d", uj_input.security_level);
-      return INVALID_ARGUMENT();
-  }
+  TRY(rsa_size_params(uj_input.security_level, &rsa_size, &rsa_num_words, NULL,
+                      &private_key_bytes, &private_key_blob_bytes));
 
   otcrypto_hash_mode_t hash_mode;
   size_t hash_digest_words;
-  switch (uj_input.hashing) {
-    case kCryptotestRsaSha256:
-      hash_mode = kOtcryptoHashModeSha256;
-      hash_digest_words = 256 / 32;
-      break;
-    case kCryptotestRsaSha384:
-      hash_mode = kOtcryptoHashModeSha384;
-      hash_digest_words = 384 / 32;
-      break;
-    case kCryptotestRsaSha512:
-      hash_mode = kOtcryptoHashModeSha512;
-      hash_digest_words = 512 / 32;
-      break;
-    case kCryptotestRsaSha3_256:
-      hash_mode = kOtcryptoHashModeSha3_256;
-      hash_digest_words = 256 / 32;
-      break;
-    case kCryptotestRsaSha3_384:
-      hash_mode = kOtcryptoHashModeSha3_384;
-      hash_digest_words = 384 / 32;
-      break;
-    case kCryptotestRsaSha3_512:
-      hash_mode = kOtcryptoHashModeSha3_512;
-      hash_digest_words = 512 / 32;
-      break;
-    default:
-      LOG_ERROR("Unsupported RSA hash mode: %d", uj_input.hashing);
-      return INVALID_ARGUMENT();
-  }
+  TRY(rsa_hash_mode(uj_input.hashing, &hash_mode, &hash_digest_words));
 
   otcrypto_key_mode_t key_mode;
   otcrypto_rsa_padding_t padding_mode;
-  switch (uj_input.padding) {
-    case kCryptotestRsaPaddingPkcs:
-      padding_mode = kOtcryptoRsaPaddingPkcs;
-      key_mode = kOtcryptoKeyModeRsaSignPkcs;
-      break;
-    case kCryptotestRsaPaddingPss:
-      padding_mode = kOtcryptoRsaPaddingPss;
-      key_mode = kOtcryptoKeyModeRsaSignPss;
-      break;
-    default:
-      LOG_ERROR("Unsupported RSA padding mode: %d", uj_input.padding);
-      return INVALID_ARGUMENT();
-  };
+  TRY(rsa_sign_padding(uj_input.padding, &key_mode, &padding_mode));
 
   // Create the modulus N buffer.
   uint32_t n_buf[rsa_num_words];
@@ -548,74 +496,19 @@ status_t handle_rsa_verify(ujson_t *uj) {
     return INVALID_ARGUMENT();
   }
 
+  otcrypto_rsa_size_t rsa_size;
   size_t rsa_num_words;
   size_t n_bytes = uj_input.security_level / 8;
-  otcrypto_rsa_size_t rsa_size;
-  switch (n_bytes) {
-    case kOtcryptoRsa2048PublicKeyBytes:
-      rsa_size = kOtcryptoRsaSize2048;
-      rsa_num_words = kCryptotestRsa2048NumWords;
-      break;
-    case kOtcryptoRsa3072PublicKeyBytes:
-      rsa_size = kOtcryptoRsaSize3072;
-      rsa_num_words = kCryptotestRsa3072NumWords;
-      break;
-    case kOtcryptoRsa4096PublicKeyBytes:
-      rsa_size = kOtcryptoRsaSize4096;
-      rsa_num_words = kCryptotestRsa4096NumWords;
-      break;
-    default:
-      LOG_ERROR("Unsupported RSA security_level: %d", uj_input.security_level);
-      return INVALID_ARGUMENT();
-  }
+  TRY(rsa_size_params(uj_input.security_level, &rsa_size, &rsa_num_words, NULL,
+                      NULL, NULL));
 
   otcrypto_hash_mode_t hash_mode;
   size_t hash_digest_words;
-  switch (uj_input.hashing) {
-    case kCryptotestRsaSha256:
-      hash_mode = kOtcryptoHashModeSha256;
-      hash_digest_words = 256 / 32;
-      break;
-    case kCryptotestRsaSha384:
-      hash_mode = kOtcryptoHashModeSha384;
-      hash_digest_words = 384 / 32;
-      break;
-    case kCryptotestRsaSha512:
-      hash_mode = kOtcryptoHashModeSha512;
-      hash_digest_words = 512 / 32;
-      break;
-    case kCryptotestRsaSha3_256:
-      hash_mode = kOtcryptoHashModeSha3_256;
-      hash_digest_words = 256 / 32;
-      break;
-    case kCryptotestRsaSha3_384:
-      hash_mode = kOtcryptoHashModeSha3_384;
-      hash_digest_words = 384 / 32;
-      break;
-    case kCryptotestRsaSha3_512:
-      hash_mode = kOtcryptoHashModeSha3_512;
-      hash_digest_words = 512 / 32;
-      break;
-    default:
-      LOG_ERROR("Unsupported RSA hash mode: %d", uj_input.hashing);
-      return INVALID_ARGUMENT();
-  }
+  TRY(rsa_hash_mode(uj_input.hashing, &hash_mode, &hash_digest_words));
 
   otcrypto_key_mode_t key_mode;
   otcrypto_rsa_padding_t padding_mode;
-  switch (uj_input.padding) {
-    case kCryptotestRsaPaddingPkcs:
-      padding_mode = kOtcryptoRsaPaddingPkcs;
-      key_mode = kOtcryptoKeyModeRsaSignPkcs;
-      break;
-    case kCryptotestRsaPaddingPss:
-      padding_mode = kOtcryptoRsaPaddingPss;
-      key_mode = kOtcryptoKeyModeRsaSignPss;
-      break;
-    default:
-      LOG_ERROR("Unsupported RSA padding mode: %d", uj_input.padding);
-      return INVALID_ARGUMENT();
-  };
+  TRY(rsa_sign_padding(uj_input.padding, &key_mode, &padding_mode));
 
   // Create the modulus N buffer.
   uint32_t n_buf[rsa_num_words];
@@ -680,88 +573,26 @@ status_t handle_rsa_keygen_check(ujson_t *uj) {
   cryptotest_rsa_keygen_check_t uj_input;
   TRY(ujson_deserialize_cryptotest_rsa_keygen_check_t(uj, &uj_input));
 
-  size_t rsa_num_words;
-  size_t public_key_bytes;
-  size_t private_key_bytes;
-  size_t private_key_blob_bytes;
   otcrypto_rsa_size_t rsa_size;
+  size_t rsa_num_words, public_key_bytes, private_key_bytes,
+      private_key_blob_bytes;
   size_t n_bytes = uj_input.security_level / 8;
-  switch (n_bytes) {
-    case kOtcryptoRsa2048PublicKeyBytes:
-      rsa_size = kOtcryptoRsaSize2048;
-      rsa_num_words = kCryptotestRsa2048NumWords;
-      public_key_bytes = kOtcryptoRsa2048PublicKeyBytes;
-      private_key_bytes = kOtcryptoRsa2048PrivateKeyBytes;
-      private_key_blob_bytes = kOtcryptoRsa2048PrivateKeyblobBytes;
-      break;
-    case kOtcryptoRsa3072PublicKeyBytes:
-      rsa_size = kOtcryptoRsaSize3072;
-      rsa_num_words = kCryptotestRsa3072NumWords;
-      public_key_bytes = kOtcryptoRsa3072PublicKeyBytes;
-      private_key_bytes = kOtcryptoRsa3072PrivateKeyBytes;
-      private_key_blob_bytes = kOtcryptoRsa3072PrivateKeyblobBytes;
-      break;
-    case kOtcryptoRsa4096PublicKeyBytes:
-      rsa_size = kOtcryptoRsaSize4096;
-      rsa_num_words = kCryptotestRsa4096NumWords;
-      public_key_bytes = kOtcryptoRsa4096PublicKeyBytes;
-      private_key_bytes = kOtcryptoRsa4096PrivateKeyBytes;
-      private_key_blob_bytes = kOtcryptoRsa4096PrivateKeyblobBytes;
-      break;
-    default:
-      LOG_ERROR("Unsupported RSA security_level: %d", uj_input.security_level);
-      return INVALID_ARGUMENT();
-  }
+  TRY(rsa_size_params(uj_input.security_level, &rsa_size, &rsa_num_words,
+                      &public_key_bytes, &private_key_bytes,
+                      &private_key_blob_bytes));
 
   otcrypto_hash_mode_t hash_mode;
   size_t hash_digest_words;
-  switch (uj_input.hashing) {
-    case kCryptotestRsaSha256:
-      hash_mode = kOtcryptoHashModeSha256;
-      hash_digest_words = 256 / 32;
-      break;
-    case kCryptotestRsaSha384:
-      hash_mode = kOtcryptoHashModeSha384;
-      hash_digest_words = 384 / 32;
-      break;
-    case kCryptotestRsaSha512:
-      hash_mode = kOtcryptoHashModeSha512;
-      hash_digest_words = 512 / 32;
-      break;
-    case kCryptotestRsaSha3_256:
-      hash_mode = kOtcryptoHashModeSha3_256;
-      hash_digest_words = 256 / 32;
-      break;
-    case kCryptotestRsaSha3_384:
-      hash_mode = kOtcryptoHashModeSha3_384;
-      hash_digest_words = 384 / 32;
-      break;
-    case kCryptotestRsaSha3_512:
-      hash_mode = kOtcryptoHashModeSha3_512;
-      hash_digest_words = 512 / 32;
-      break;
-    default:
-      LOG_ERROR("Unsupported RSA hash mode: %d", uj_input.hashing);
-      return INVALID_ARGUMENT();
-  }
+  TRY(rsa_hash_mode(uj_input.hashing, &hash_mode, &hash_digest_words));
 
+  // OAEP uses a distinct key mode and code path; sign/verify use
+  // rsa_sign_padding.
   otcrypto_key_mode_t key_mode;
   otcrypto_rsa_padding_t padding_mode;
-  switch (uj_input.padding) {
-    case kCryptotestRsaPaddingPkcs:
-      padding_mode = kOtcryptoRsaPaddingPkcs;
-      key_mode = kOtcryptoKeyModeRsaSignPkcs;
-      break;
-    case kCryptotestRsaPaddingPss:
-      padding_mode = kOtcryptoRsaPaddingPss;
-      key_mode = kOtcryptoKeyModeRsaSignPss;
-      break;
-    case kCryptotestRsaPaddingOaep:
-      key_mode = kOtcryptoKeyModeRsaEncryptOaep;
-      break;
-    default:
-      LOG_ERROR("Unsupported RSA padding mode: %d", uj_input.padding);
-      return INVALID_ARGUMENT();
+  if (uj_input.padding == kCryptotestRsaPaddingOaep) {
+    key_mode = kOtcryptoKeyModeRsaEncryptOaep;
+  } else {
+    TRY(rsa_sign_padding(uj_input.padding, &key_mode, &padding_mode));
   }
 
   // Allocate and configure the public key.
@@ -863,6 +694,69 @@ status_t handle_rsa_keygen_check(ujson_t *uj) {
   return OK_STATUS();
 }
 
+status_t handle_rsa_keygen(ujson_t *uj) {
+  cryptotest_rsa_keygen_t uj_input;
+  TRY(ujson_deserialize_cryptotest_rsa_keygen_t(uj, &uj_input));
+
+  otcrypto_rsa_size_t rsa_size;
+  size_t rsa_num_words, public_key_bytes, private_key_bytes,
+      private_key_blob_bytes;
+  size_t n_bytes = uj_input.security_level / 8;
+  TRY(rsa_size_params(uj_input.security_level, &rsa_size, &rsa_num_words,
+                      &public_key_bytes, &private_key_bytes,
+                      &private_key_blob_bytes));
+
+  otcrypto_key_mode_t key_mode;
+  otcrypto_rsa_padding_t padding_mode;
+  TRY(rsa_sign_padding(uj_input.padding, &key_mode, &padding_mode));
+
+  // Allocate and configure the public key.
+  uint32_t public_key_data[ceil_div(public_key_bytes, sizeof(uint32_t))];
+  otcrypto_unblinded_key_t public_key = {
+      .key_mode = key_mode,
+      .key_length = public_key_bytes,
+      .key = public_key_data,
+  };
+
+  // Allocate and configure the private key.
+  size_t keyblob_words = ceil_div(private_key_blob_bytes, sizeof(uint32_t));
+  uint32_t keyblob[keyblob_words];
+  otcrypto_blinded_key_t private_key = {
+      .config =
+          {
+              .version = kOtcryptoLibVersion1,
+              .key_mode = key_mode,
+              .key_length = private_key_bytes,
+              .hw_backed = kHardenedBoolFalse,
+              .security_level = kOtcryptoKeySecurityLevelLow,
+          },
+      .keyblob = keyblob,
+      .keyblob_length = private_key_blob_bytes,
+  };
+
+  TRY(otcrypto_rsa_keygen(rsa_size, &public_key, &private_key));
+
+  // Extract the raw private exponent d from the two-share keyblob:
+  // keyblob = [share0 | share1], where share0 = d ^ share1.
+  uint32_t d_buf[rsa_num_words];
+  for (size_t i = 0; i < rsa_num_words; i++) {
+    d_buf[i] = keyblob[i] ^ keyblob[rsa_num_words + i];
+  }
+
+  // Return n, d, and e to the host.
+  cryptotest_rsa_keygen_resp_t uj_output;
+  memset(uj_output.n, 0, RSA_CMD_MAX_N_BYTES);
+  memcpy(uj_output.n, public_key_data, n_bytes);
+  uj_output.n_len = n_bytes;
+  memset(uj_output.d, 0, RSA_CMD_MAX_N_BYTES);
+  memcpy(uj_output.d, d_buf, n_bytes);
+  uj_output.d_len = n_bytes;
+  uj_output.e = kCryptotestRsaSupportedE;
+
+  RESP_OK(ujson_serialize_cryptotest_rsa_keygen_resp_t, uj, &uj_output);
+  return OK_STATUS();
+}
+
 status_t handle_rsa(ujson_t *uj) {
   rsa_subcommand_t cmd;
   TRY(ujson_deserialize_rsa_subcommand_t(uj, &cmd));
@@ -877,6 +771,8 @@ status_t handle_rsa(ujson_t *uj) {
       return handle_rsa_verify(uj);
     case kRsaSubcommandRsaKeygenCheck:
       return handle_rsa_keygen_check(uj);
+    case kRsaSubcommandRsaKeygen:
+      return handle_rsa_keygen(uj);
     default:
       LOG_ERROR("Unrecognized RSA subcommand: %d", cmd);
       return INVALID_ARGUMENT();

--- a/sw/device/tests/crypto/cryptotest/json/rsa_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/rsa_commands.h
@@ -25,7 +25,7 @@ extern "C" {
     value(_, RsaDecrypt) \
     value(_, RsaSign) \
     value(_, RsaVerify) \
-    value(_, RsaKeygen)
+    value(_, RsaKeygenCheck)
 UJSON_SERDE_ENUM(RsaSubcommand, rsa_subcommand_t, RSA_SUBCOMMAND);
 
 #define RSA_SIGN(field, string) \
@@ -99,17 +99,17 @@ UJSON_SERDE_STRUCT(CryptotestRsaEncryptResp, cryptotest_rsa_encrypt_resp_t, RSA_
     field(signature_len, size_t)
 UJSON_SERDE_STRUCT(CryptotestRsaSignResp, cryptotest_rsa_sign_resp_t, RSA_SIGN_RESP);
 
-#define RSA_KEYGEN(field, string) \
+#define RSA_KEYGEN_CHECK(field, string) \
     field(security_level, size_t) \
     field(hashing, size_t) \
     field(padding, size_t) \
     field(msg, uint8_t, RSA_CMD_MAX_MESSAGE_BYTES) \
     field(msg_len, size_t)
-UJSON_SERDE_STRUCT(CryptotestRsaKeygen, cryptotest_rsa_keygen_t, RSA_KEYGEN);
+UJSON_SERDE_STRUCT(CryptotestRsaKeygenCheck, cryptotest_rsa_keygen_check_t, RSA_KEYGEN_CHECK);
 
-#define RSA_KEYGEN_RESP(field, string) \
+#define RSA_KEYGEN_CHECK_RESP(field, string) \
     field(result, bool)
-UJSON_SERDE_STRUCT(CryptotestRsaKeygenResp, cryptotest_rsa_keygen_resp_t, RSA_KEYGEN_RESP);
+UJSON_SERDE_STRUCT(CryptotestRsaKeygenCheckResp, cryptotest_rsa_keygen_check_resp_t, RSA_KEYGEN_CHECK_RESP);
 
 #undef MODULE_ID
 

--- a/sw/device/tests/crypto/cryptotest/json/rsa_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/rsa_commands.h
@@ -25,7 +25,8 @@ extern "C" {
     value(_, RsaDecrypt) \
     value(_, RsaSign) \
     value(_, RsaVerify) \
-    value(_, RsaKeygenCheck)
+    value(_, RsaKeygenCheck) \
+    value(_, RsaKeygen)
 UJSON_SERDE_ENUM(RsaSubcommand, rsa_subcommand_t, RSA_SUBCOMMAND);
 
 #define RSA_SIGN(field, string) \
@@ -110,6 +111,19 @@ UJSON_SERDE_STRUCT(CryptotestRsaKeygenCheck, cryptotest_rsa_keygen_check_t, RSA_
 #define RSA_KEYGEN_CHECK_RESP(field, string) \
     field(result, bool)
 UJSON_SERDE_STRUCT(CryptotestRsaKeygenCheckResp, cryptotest_rsa_keygen_check_resp_t, RSA_KEYGEN_CHECK_RESP);
+
+#define RSA_KEYGEN(field, string) \
+    field(security_level, size_t) \
+    field(padding, size_t)
+UJSON_SERDE_STRUCT(CryptotestRsaKeygen, cryptotest_rsa_keygen_t, RSA_KEYGEN);
+
+#define RSA_KEYGEN_RESP(field, string) \
+    field(n, uint8_t, RSA_CMD_MAX_N_BYTES) \
+    field(n_len, size_t) \
+    field(d, uint8_t, RSA_CMD_MAX_N_BYTES) \
+    field(d_len, size_t) \
+    field(e, uint32_t)
+UJSON_SERDE_STRUCT(CryptotestRsaKeygenResp, cryptotest_rsa_keygen_resp_t, RSA_KEYGEN_RESP);
 
 #undef MODULE_ID
 

--- a/sw/host/cryptotest/testvectors/acvp/rsa_vectors.json
+++ b/sw/host/cryptotest/testvectors/acvp/rsa_vectors.json
@@ -6630,5 +6630,51 @@
         ]
       }
     ]
+  },
+  {
+    "vsId": 1,
+    "algorithm": "RSA-sigGen",
+    "revision": "1.0",
+    "isSample": true,
+    "testGroups": [
+      {
+        "tgId": 1,
+        "sigType": "pkcs1v1.5",
+        "modulo": 2048,
+        "hashAlg": "SHA-256",
+        "testType": "GDT",
+        "tests": [
+          {
+            "tcId": 1,
+            "deferred": false,
+            "message": "3e"
+          },
+          {
+            "tcId": 2,
+            "deferred": false,
+            "message": "8f"
+          }
+        ]
+      },
+      {
+        "tgId": 2,
+        "sigType": "pss",
+        "modulo": 2048,
+        "hashAlg": "SHA-256",
+        "testType": "GDT",
+        "tests": [
+          {
+            "tcId": 3,
+            "deferred": false,
+            "message": "3e"
+          },
+          {
+            "tcId": 4,
+            "deferred": false,
+            "message": "8f"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/sw/host/tests/crypto/acvp/src/main.rs
+++ b/sw/host/tests/crypto/acvp/src/main.rs
@@ -50,6 +50,15 @@ struct Opts {
     // ACVP JSON result file containing expected outputs.
     #[arg(long)]
     expected: Option<std::path::PathBuf>,
+
+    // Run RSA sigGen test vectors from the input file.
+    // sigGen results are non-deterministic and are never compared against --expected.
+    #[arg(long, default_value_t = false)]
+    run_siggen: bool,
+
+    // Output ACVP JSON result file for RSA sigGen (implies --run-siggen).
+    #[arg(long)]
+    output_siggen: Option<std::path::PathBuf>,
 }
 
 #[derive(Deserialize, PartialEq, Serialize)]
@@ -63,6 +72,9 @@ enum AcvpVectors {
     },
     Hmac(hmac::HmacTestVectorSet),
     Cshake(cshake::CshakeTestVectorSet),
+    // RsaSigGen must precede Rsa: sigGen test cases have a required `message`
+    // field that sigVer test cases lack, so sigVer vectors will fall through to Rsa.
+    RsaSigGen(rsa::RsaSignGenTestVectorSet),
     Rsa(rsa::RsaTestVectorSet),
 }
 
@@ -77,6 +89,7 @@ enum AcvpResults {
     },
     Hmac(hmac::HmacResultVectorSet),
     Cshake(cshake::CshakeResultVectorSet),
+    RsaSigGen(rsa::RsaSignGenResultVectorSet),
     Rsa(rsa::RsaResultVectorSet),
 }
 
@@ -154,6 +167,7 @@ fn run<R: std::io::Read, W: std::io::Write>(
     input: R,
     expected: Option<R>,
     output: Option<W>,
+    output_siggen: Option<W>,
 ) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
     let spi_console_device = SpiConsoleDevice::new(
@@ -166,6 +180,7 @@ fn run<R: std::io::Read, W: std::io::Write>(
 
     let acvp_vectors: Vec<AcvpVectors> = serde_json::from_reader(input)?;
     let mut acvp_results: Vec<AcvpResults> = Vec::with_capacity(acvp_vectors.len());
+    let mut siggen_results: Vec<rsa::RsaSignGenResultVectorSet> = Vec::new();
 
     for v in acvp_vectors {
         match v {
@@ -196,17 +211,35 @@ fn run<R: std::io::Read, W: std::io::Write>(
                     opts.seed,
                 )?))
             }
-            AcvpVectors::Rsa(vs) => acvp_results.push(AcvpResults::Rsa(rsa::run_rsa_vector_set(
-                opts.timeout,
-                &spi_console_device,
-                &vs,
-                opts.skip_stride,
-                opts.seed,
-            )?)),
+            AcvpVectors::RsaSigGen(vs) => {
+                if opts.run_siggen || opts.output_siggen.is_some() {
+                    siggen_results.push(rsa::run_rsa_siggen_vector_set(
+                        opts.timeout,
+                        &spi_console_device,
+                        &vs,
+                        opts.skip_stride,
+                        opts.seed,
+                    )?);
+                }
+            }
+            AcvpVectors::Rsa(vs) => {
+                if opts.expected.is_some() || opts.output.is_some() {
+                    acvp_results.push(AcvpResults::Rsa(rsa::run_rsa_vector_set(
+                        opts.timeout,
+                        &spi_console_device,
+                        &vs,
+                        opts.skip_stride,
+                        opts.seed,
+                    )?));
+                }
+            }
         }
     }
     if let Some(w) = output {
         serde_json::to_writer_pretty(w, &acvp_results)?;
+    }
+    if let Some(w) = output_siggen {
+        serde_json::to_writer_pretty(w, &siggen_results)?;
     }
     if let Some(r) = expected {
         let expected_results_json: serde_json::Value = serde_json::from_reader(r)?;
@@ -241,7 +274,11 @@ fn main() -> Result<()> {
         log::warn!("Missing input ACVP JSON file");
         return Ok(());
     };
-    if opts.expected.is_none() && opts.output.is_none() {
+    if opts.expected.is_none()
+        && opts.output.is_none()
+        && !opts.run_siggen
+        && opts.output_siggen.is_none()
+    {
         log::warn!("Missing expected/output ACVP JSON files");
         return Ok(());
     }
@@ -265,6 +302,14 @@ fn main() -> Result<()> {
         }
         None => None,
     };
+    let output_siggen = match &opts.output_siggen {
+        Some(path) => {
+            let f = std::fs::File::create(path)
+                .inspect_err(|e| log::error!("open siggen output file: {e}"))?;
+            Some(std::io::BufWriter::new(f))
+        }
+        None => None,
+    };
 
-    run(&opts, &transport, input, expected, output)
+    run(&opts, &transport, input, expected, output, output_siggen)
 }

--- a/sw/host/tests/crypto/acvp/src/rsa.rs
+++ b/sw/host/tests/crypto/acvp/src/rsa.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 
 use cryptotest_commands::commands::CryptotestCommand;
 use cryptotest_commands::rsa_commands::{
+    CryptotestRsaKeygen, CryptotestRsaKeygenResp, CryptotestRsaSign, CryptotestRsaSignResp,
     CryptotestRsaVerify, CryptotestRsaVerifyResp, RsaSubcommand,
 };
 
@@ -23,7 +24,7 @@ use rand_chacha::ChaCha8Rng;
 const RSA_MAX_BYTES: usize = 512;
 const RSA_MAX_MSG_BYTES: usize = 514;
 
-// Hashing algorithm IDs matching your C firmware (as usize)
+// Hashing algorithm IDs matching the C firmware
 const HASH_SHA256: usize = 0;
 const HASH_SHA384: usize = 1;
 const HASH_SHA512: usize = 2;
@@ -31,10 +32,12 @@ const HASH_SHA3_256: usize = 3;
 const HASH_SHA3_384: usize = 4;
 const HASH_SHA3_512: usize = 5;
 
-// Padding mode IDs matching your C firmware (as usize)
+// Padding mode IDs matching the C firmware
 const PADDING_PKCS: usize = 0;
 const PADDING_PSS: usize = 1;
 const PADDING_OAEP: usize = 2;
+
+// Signature verification input structs
 
 #[derive(Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -63,7 +66,7 @@ struct RsaTestCase {
 struct RsaTestGroup {
     tg_id: usize,
     test_type: String,
-    modulo: usize, // e.g., 2048, 3072, 4096
+    modulo: usize,
     hash_alg: String,
     #[serde(default)]
     sig_type: Option<String>,
@@ -80,6 +83,8 @@ pub struct RsaTestVectorSet {
     is_sample: bool,
     test_groups: Vec<RsaTestGroup>,
 }
+
+// Signature verification result structs
 
 #[derive(Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -111,6 +116,71 @@ pub struct RsaResultVectorSet {
     pub test_groups: Vec<RsaResultGroup>,
 }
 
+// Signature generation input structs
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RsaSignGenTestCase {
+    tc_id: usize,
+    message: String,
+    #[serde(default)]
+    deferred: bool,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RsaSignGenTestGroup {
+    tg_id: usize,
+    test_type: String,
+    modulo: usize,
+    hash_alg: String,
+    #[serde(default)]
+    sig_type: Option<String>,
+    tests: Vec<RsaSignGenTestCase>,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RsaSignGenTestVectorSet {
+    vs_id: usize,
+    algorithm: String,
+    revision: String,
+    #[serde(default)]
+    is_sample: bool,
+    test_groups: Vec<RsaSignGenTestGroup>,
+}
+
+// Signature generation result structs
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RsaSignGenResultCase {
+    pub tc_id: usize,
+    pub signature: String,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RsaSignGenResultGroup {
+    pub tg_id: usize,
+    pub n: String,
+    pub e: String,
+    pub tests: Vec<RsaSignGenResultCase>,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RsaSignGenResultVectorSet {
+    pub vs_id: usize,
+    pub algorithm: String,
+    pub revision: String,
+    #[serde(default)]
+    pub is_sample: bool,
+    pub test_groups: Vec<RsaSignGenResultGroup>,
+}
+
+// Helper functions
+
 fn map_hash_alg(alg: &str) -> Result<usize> {
     match alg.to_uppercase().as_str() {
         "SHA-256" | "SHA2-256" => Ok(HASH_SHA256),
@@ -123,6 +193,29 @@ fn map_hash_alg(alg: &str) -> Result<usize> {
     }
 }
 
+fn map_padding(sig_type: Option<&str>) -> usize {
+    match sig_type.unwrap_or("pkcs1v1.5").to_lowercase().as_str() {
+        "pss" => PADDING_PSS,
+        "oaep" => PADDING_OAEP,
+        _ => PADDING_PKCS,
+    }
+}
+
+fn u32_to_be_hex(v: u32) -> String {
+    let bytes = v.to_be_bytes();
+    let significant = bytes.iter().skip_while(|&&b| b == 0);
+    let vec: Vec<u8> = significant.copied().collect();
+    let hex = hex::encode_upper(&vec);
+    // ensure even length
+    if hex.len() % 2 == 1 {
+        format!("0{}", hex)
+    } else {
+        hex
+    }
+}
+
+// Signature Verification
+
 fn run_rsa_verify_case(
     timeout: Duration,
     spi_console: &SpiConsoleDevice,
@@ -131,17 +224,15 @@ fn run_rsa_verify_case(
     padding: usize,
     hashing: usize,
 ) -> Result<RsaResultCase> {
-    // OpenTitan expects little-endian integers for math, so we reverse `n` and `sig`
+    // OpenTitan uses little-endian integers; reverse `n` and `sig`.
     let mut n = Vec::<u8>::from_hex(tc.n.as_ref().unwrap())?;
     n.reverse();
 
     let mut sig = Vec::<u8>::from_hex(tc.sig.as_ref().unwrap())?;
     sig.reverse();
 
-    // The message is just a byte string, so we do NOT reverse it.
     let msg = Vec::<u8>::from_hex(tc.msg.as_ref().unwrap())?;
 
-    // Convert hex exponent (e.g. "010001") to u32
     let e_bytes = Vec::<u8>::from_hex(tc.e.as_ref().unwrap())?;
     let mut e: u32 = 0;
     for &b in &e_bytes {
@@ -162,7 +253,7 @@ fn run_rsa_verify_case(
 
     CryptotestRsaVerify {
         padding,
-        security_level: tg.modulo, // Now properly typed as usize
+        security_level: tg.modulo,
         hashing,
         e,
         n: n_array,
@@ -195,29 +286,14 @@ fn run_rsa_group(
     let mut result_cases = Vec::new();
 
     let hashing = map_hash_alg(&tg.hash_alg)?;
+    let padding = map_padding(tg.sig_type.as_deref());
 
-    let padding = match tg
-        .sig_type
-        .as_deref()
-        .unwrap_or("pkcs1v15")
-        .to_lowercase()
-        .as_str()
-    {
-        "pss" => PADDING_PSS,
-        "oaep" => PADDING_OAEP,
-        _ => PADDING_PKCS,
-    };
-
-    // Ensure that at least one test per group is run
     let stride = min(skip_stride, tg.tests.len());
-
-    // Prevent division by zero if a test group happens to be entirely empty
     let offset = if stride > 0 { start_offset % stride } else { 0 };
     log::info!("Tests options: skip_stride: {}, offset: {}", stride, offset);
 
     for tc in &tg.tests {
         if stride > 0 && (tc.tc_id % stride) != offset {
-            // Skip test
             continue;
         }
 
@@ -258,12 +334,10 @@ pub fn run_rsa_vector_set(
     let seed = seed_arg.unwrap_or_else(rand::random::<u64>);
     log::info!("Using seed {}", seed);
 
-    // Create a deterministic RNG from the seed for skipping
     let mut drng = ChaCha8Rng::seed_from_u64(seed);
     let (skip_stride, start_offset) = match (drng.next_u32() as usize).checked_rem(skip_stride_arg)
     {
         Some(offset) => (skip_stride_arg, offset),
-        // if skip_stride_arg is 0, skip_stride is set to 1 to execute all the tests
         None => (1usize, 0usize),
     };
 
@@ -281,6 +355,215 @@ pub fn run_rsa_vector_set(
     }
 
     Ok(RsaResultVectorSet {
+        vs_id: vs.vs_id,
+        algorithm: vs.algorithm.clone(),
+        revision: vs.revision.clone(),
+        is_sample: vs.is_sample,
+        test_groups: result_groups,
+    })
+}
+
+// Signature Generation
+
+// Runs key generation on the device
+fn run_rsa_keygen(
+    timeout: Duration,
+    spi_console: &SpiConsoleDevice,
+    security_level: usize,
+    padding: usize,
+) -> Result<(Vec<u8>, Vec<u8>, u32)> {
+    CryptotestCommand::Rsa.send(spi_console)?;
+    RsaSubcommand::RsaKeygen.send(spi_console)?;
+
+    CryptotestRsaKeygen {
+        security_level,
+        padding,
+    }
+    .send(spi_console)?;
+
+    let resp = CryptotestRsaKeygenResp::recv(spi_console, timeout, false, false)?;
+
+    // Convert to little-endian.
+    let n_le = resp.n.as_slice()[..resp.n_len].to_vec();
+    let d_le = resp.d.as_slice()[..resp.d_len].to_vec();
+
+    Ok((n_le, d_le, resp.e))
+}
+
+// Signs `tc.message` with the provided key, verifies the resulting signature,
+// and returns the test result case with the signature.
+#[allow(clippy::too_many_arguments)]
+fn run_rsa_sign_case(
+    timeout: Duration,
+    spi_console: &SpiConsoleDevice,
+    security_level: usize,
+    padding: usize,
+    hashing: usize,
+    n_le: &[u8],
+    d_le: &[u8],
+    e: u32,
+    tc: &RsaSignGenTestCase,
+) -> Result<RsaSignGenResultCase> {
+    let msg = Vec::<u8>::from_hex(&tc.message)?;
+
+    let mut n_array = arrayvec::ArrayVec::<u8, RSA_MAX_BYTES>::new();
+    n_array.try_extend_from_slice(n_le)?;
+
+    let mut d_array = arrayvec::ArrayVec::<u8, RSA_MAX_BYTES>::new();
+    d_array.try_extend_from_slice(d_le)?;
+
+    let mut msg_array = arrayvec::ArrayVec::<u8, RSA_MAX_MSG_BYTES>::new();
+    msg_array.try_extend_from_slice(&msg)?;
+
+    let label_array = arrayvec::ArrayVec::<u8, RSA_MAX_MSG_BYTES>::new();
+
+    CryptotestCommand::Rsa.send(spi_console)?;
+    RsaSubcommand::RsaSign.send(spi_console)?;
+
+    CryptotestRsaSign {
+        msg: msg_array.clone(),
+        msg_len: msg.len(),
+        e,
+        d: d_array,
+        n: n_array.clone(),
+        security_level,
+        label: label_array,
+        label_len: 0,
+        hashing,
+        padding,
+    }
+    .send(spi_console)?;
+
+    let sign_resp = CryptotestRsaSignResp::recv(spi_console, timeout, false, false)?;
+
+    let sig_len = sign_resp.signature_len;
+    let sig_le = sign_resp.signature.as_slice()[..sig_len].to_vec();
+
+    // Verify the signature we just produced.
+    let mut sig_array = arrayvec::ArrayVec::<u8, RSA_MAX_MSG_BYTES>::new();
+    sig_array.try_extend_from_slice(&sig_le)?;
+
+    CryptotestCommand::Rsa.send(spi_console)?;
+    RsaSubcommand::RsaVerify.send(spi_console)?;
+
+    CryptotestRsaVerify {
+        msg: msg_array,
+        msg_len: msg.len(),
+        e,
+        n: n_array,
+        security_level,
+        sig: sig_array,
+        sig_len,
+        hashing,
+        padding,
+    }
+    .send(spi_console)?;
+
+    let verify_resp = CryptotestRsaVerifyResp::recv(spi_console, timeout, false, false)?;
+
+    if !verify_resp.result {
+        return Err(std::io::Error::other(format!(
+            "Sign-then-verify failed for tc_id {}",
+            tc.tc_id
+        ))
+        .into());
+    }
+
+    // ACVP output uses big-endian hex for the signature.
+    let mut sig_be = sig_le;
+    sig_be.reverse();
+
+    Ok(RsaSignGenResultCase {
+        tc_id: tc.tc_id,
+        signature: hex::encode_upper(&sig_be),
+    })
+}
+
+fn run_rsa_siggen_group(
+    timeout: Duration,
+    spi_console: &SpiConsoleDevice,
+    tg: &RsaSignGenTestGroup,
+    skip_stride: usize,
+    start_offset: usize,
+) -> Result<RsaSignGenResultGroup> {
+    log::info!("tg_id: {}", tg.tg_id);
+
+    let hashing = map_hash_alg(&tg.hash_alg)?;
+    let padding = map_padding(tg.sig_type.as_deref());
+
+    // One key generation per group; all test cases in the group reuse the key.
+    let (n_le, d_le, e) = run_rsa_keygen(timeout, spi_console, tg.modulo, padding)?;
+
+    // Convert n and e to big-endian hex for the ACVP result.
+    let mut n_be = n_le.clone();
+    n_be.reverse();
+    let n_hex = hex::encode_upper(&n_be);
+    let e_hex = u32_to_be_hex(e);
+
+    let stride = min(skip_stride, tg.tests.len());
+    let offset = if stride > 0 { start_offset % stride } else { 0 };
+    log::info!("Tests options: skip_stride: {}, offset: {}", stride, offset);
+
+    let mut result_cases = Vec::new();
+    for tc in &tg.tests {
+        if stride > 0 && (tc.tc_id % stride) != offset {
+            continue;
+        }
+
+        log::info!("tc_id: {}", tc.tc_id);
+
+        result_cases.push(run_rsa_sign_case(
+            timeout,
+            spi_console,
+            tg.modulo,
+            padding,
+            hashing,
+            &n_le,
+            &d_le,
+            e,
+            tc,
+        )?);
+    }
+
+    Ok(RsaSignGenResultGroup {
+        tg_id: tg.tg_id,
+        n: n_hex,
+        e: e_hex,
+        tests: result_cases,
+    })
+}
+
+pub fn run_rsa_siggen_vector_set(
+    timeout: Duration,
+    spi_console: &SpiConsoleDevice,
+    vs: &RsaSignGenTestVectorSet,
+    skip_stride_arg: usize,
+    seed_arg: Option<u64>,
+) -> Result<RsaSignGenResultVectorSet> {
+    log::info!("vs_id: {}", vs.vs_id);
+
+    let seed = seed_arg.unwrap_or_else(rand::random::<u64>);
+    log::info!("Using seed {}", seed);
+
+    let mut drng = ChaCha8Rng::seed_from_u64(seed);
+    let (skip_stride, start_offset) = match (drng.next_u32() as usize).checked_rem(skip_stride_arg)
+    {
+        Some(offset) => (skip_stride_arg, offset),
+        None => (1usize, 0usize),
+    };
+
+    let mut result_groups = Vec::with_capacity(vs.test_groups.len());
+    for tg in &vs.test_groups {
+        result_groups.push(run_rsa_siggen_group(
+            timeout,
+            spi_console,
+            tg,
+            skip_stride,
+            start_offset,
+        )?);
+    }
+
+    Ok(RsaSignGenResultVectorSet {
         vs_id: vs.vs_id,
         algorithm: vs.algorithm.clone(),
         revision: vs.revision.clone(),

--- a/sw/host/tests/crypto/rsa_kat/src/main.rs
+++ b/sw/host/tests/crypto/rsa_kat/src/main.rs
@@ -14,8 +14,8 @@ use serde::Deserialize;
 use cryptotest_commands::commands::CryptotestCommand;
 use cryptotest_commands::rsa_commands::{
     CryptotestRsaDecrypt, CryptotestRsaDecryptResp, CryptotestRsaEncrypt, CryptotestRsaEncryptResp,
-    CryptotestRsaKeygen, CryptotestRsaKeygenResp, CryptotestRsaSign, CryptotestRsaSignResp,
-    CryptotestRsaVerify, CryptotestRsaVerifyResp, RsaSubcommand,
+    CryptotestRsaKeygenCheck, CryptotestRsaKeygenCheckResp, CryptotestRsaSign,
+    CryptotestRsaSignResp, CryptotestRsaVerify, CryptotestRsaVerifyResp, RsaSubcommand,
 };
 
 use opentitanlib::app::TransportWrapper;
@@ -350,8 +350,8 @@ fn run_rsa_keygen_testcase(
     };
 
     CryptotestCommand::Rsa.send(spi_console)?;
-    RsaSubcommand::RsaKeygen.send(spi_console)?;
-    CryptotestRsaKeygen {
+    RsaSubcommand::RsaKeygenCheck.send(spi_console)?;
+    CryptotestRsaKeygenCheck {
         security_level,
         hashing,
         padding: padding_code,
@@ -360,7 +360,7 @@ fn run_rsa_keygen_testcase(
     }
     .send(spi_console)?;
 
-    let resp = CryptotestRsaKeygenResp::recv(spi_console, timeout, false, false)?;
+    let resp = CryptotestRsaKeygenCheckResp::recv(spi_console, timeout, false, false)?;
     assert!(
         resp.result,
         "RSA keygen round-trip failed for {security_level}-bit {padding} {hash_alg}"


### PR DESCRIPTION
This pull requests enables us to conduct [ACVP](https://pages.nist.gov/ACVP/) testing for RSA sign. ACVP requests (test vectors) from the server can be placed in `sw/host/cryptotest/testvectors/acvp/rsa_vectors.json`. The test framework passes these test vectors as following:

- For each test group, a key generation is conducted on the device. The key is returned to the host harness.
- For each test case in a group:
  - The key is used to sign the message from the test vector.
  - We conduct a verify after the sign to check if the verification was successful
- At the end of the test, a JSON file is generated, which can be returned to the ACVP server for validation.

The ACVP request looks as following (please note that is a dummy vector that was generated by myself and following the [publicly](https://github.com/usnistgov/ACVP-Server/tree/master/gen-val/json-files) available format):
```json
[
  {
    "vsId": 1,
    "algorithm": "RSA-sigGen",
    "revision": "1.0",
    "isSample": true,
    "testGroups": [
      {
        "tgId": 1,
        "sigType": "pkcs1v1.5",
        "modulo": 2048,
        "hashAlg": "SHA-256",
        "testType": "GDT",
        "tests": [
          {
            "tcId": 1,
            "deferred": false,
            "message": "3e"
          },
          {
            "tcId": 2,
            "deferred": false,
            "message": "8f"
          }
        ]
      },
      {
        "tgId": 2,
        "sigType": "pss",
        "modulo": 2048,
        "hashAlg": "SHA-256",
        "testType": "GDT",
        "tests": [
          {
            "tcId": 3,
            "deferred": false,
            "message": "3e"
          },
          {
            "tcId": 4,
            "deferred": false,
            "message": "8f"
          }
        ]
      }
    ]
  }
]
```

The response that was generated with:
```
./bazelisk.sh run //sw/device/tests/crypto/cryptotest:rsa_acvp_siggen_fpga_cw340_sival_rom_ext -- --output-siggen=rsa_siggen_output.json
```
and can be provided to the ACVP server:
```json
[
  {
    "vsId": 1,
    "algorithm": "RSA-sigGen",
    "revision": "1.0",
    "isSample": true,
    "testGroups": [
      {
        "tgId": 1,
        "n": "D6BEEA9E465C2FAB7F8E5DF0B72B0289437781CEE9F69E0CDB4C2910E56C72346E52624653DFD029F1D06E453DC68A4E47EB93F520B852DEFA69C024D6C8FE55446E1D366A3151581AD7F535609B75816ECE1C7B2B3645455CCC950CC7A9D5C799B314A3E94F9A9280FF211D0DA725C8CBC712E4452198710365B826E773B9765C8BD39879ED9D4CEEB79560B43A5701059FEB6E894DFDFA3371C2DEAEE637C16E984774679E145D2281656D35C72386899D11D9937EF9BF895A8AA519E678BA6F6960BA757591CFEC4C8B483650C24143F694575886D29B92D418863FE138092FEAC0E137F534E705C713B58C66A6C42A83B9EAA44CB9F5FFFABEB449DA4CA1",
        "e": "010001",
        "tests": [
          {
            "tcId": 1,
            "signature": "B461A0BAC65D301FC9A918C8EFCCF600E17AC7DFDEDE36AC5D9882ABBEF133890F2952233D651554F57B4250BEFA33A5386C972EFF3E430B318C4BC368EED70F21311A99FB23AECFE23DFB0DF1C872999495FCDE5589167E00F6ED12701786D563AB5E6E81C47BFB333307F85106673DB676A3A984A74AAA8A025EEAAE57C8102A8065CA7AA25BE48540995C047F07EEAAAA832122277BF9185AB112348242E2F0817371E54784E7BF1EE64B523CF74770688B3642408706A2D088E4D865B0F0F9858304708912BDF45B06F6CAE2DBC667001113EAAA27FEB45C25DF3A3392B0BF1F6E427D0BF2119A325355F968E02C13B6F0482E17E0719A0AC00CAD42D183"
          },
          {
            "tcId": 2,
            "signature": "70BFAACC2F55F8AB7B65D0F6CABE0FEEB72F7971008B7AD4B2B71BD1F37F90B7F28006E13A470EC91E34B799A9D6B5313525E85B5D7CD32B7CC15E3EC3DC871972702172D85472A61373E0602B93C52DE1E2498A0801F4F620824CE6E46A936F3848DB9176195D8C4E46B4C7BB944B0E2F1AC6B31605C33C81AAC1D254CFB935890AB682EB5CF07D1219F64E822D5DFD5527CD456C39593810DA6101C202A6FD50C0AE5453E74B477DC57F56144487D0FC60A2365830BAD0AB7DCB332DBDDBF82C31D821A592A55EFD2A4F36F845D9924661C26A9204BD37502BD90D99E48B88ECB5775D8EE361B17353383EF0CAFD717BAA08BEB8668F0A595F7097AC7BC939"
          }
        ]
      },
      {
        "tgId": 2,
        "n": "A996BE8F4A476A5CC7E8D6E4B6991F79B78A913CF048DF965CE03AFB43DCF052ED7EE724DAAF1FC790FB3F1FB6FC21BAE4E6ED20A93439EBBE38413F454E814DD2D1258970170A04E8E0D8805EC5548096DDDF372F084991290E8F828DA9B220471AB4630BD7A47682ED1130A4D509EA3162A0651CF6963BE0E812C7CAC482FCAAA7477D5DB60EEFB7353DCF168B7C60A1F6675C99C0AD19EF6D44B081BF63BD6D14992C9B09EF1B420CE5BC36A1805ECE1E1633BFDE5720616F22CDF2DAB1C7135B9FBEA4B251606A25C286C57A11C80B52410D8088365A138B1D2E0F33F9CDC54566410C88F5DF004CE9F16D6D4BA7E0DCD2A5C82E261013DDFC55CA6989E1",
        "e": "010001",
        "tests": [
          {
            "tcId": 3,
            "signature": "A722CA11D24FFAB1EEB80B3B7756F51F2F8D8B4733866AF74935B089163DC2711593205318A0B0909DC6398D19E140F35EB16E407AA0E0EC99AC6EE838731AA91B5029820037D56BF40E749EF7D81F9B2CABD7B4C0286A96FFDBB0E0C1B7E36B1FEEE5CD10F24BBDF57A99D1CB0DF66C0E2F5FF1E530E208FFCA8DDE0B5D3DC64FD93FB3A67D872656D2264264BADED239FFE3DA58414F899B77499C8D7C5886A6AC0BAC42DB9E11CBD475D0369016D27F0263B88001CB30A49FF2A140DC08860FCB415EBEE9507A3B8745F0411B07BA5FC25034C622374352D5A9BC7A459A429633348A33903DBCBA45C3FACD081281BB6B019DC670176A6B721D217A4C76BD"
          },
          {
            "tcId": 4,
            "signature": "07F98F1AF3BE80A27112E33061180FD06F91AECBB6CE8ABF0B78672D563F3ED7DCE52C84032BF9A551A15EF2696CEFE2A7CC25A6F37C17A9D3238D065F4AD11D0F5459B27CC2A05850F3221A17015A1337B3DDA13A4B4F99A1AC6C52F642529DF8AE2D471A00E8228119E2B7637B3A6D76D9F1E65B32C650CCE319260500D95DAEF0170F437F0A0CAE42B75B6C736E8BFE268AD0F58EF481CD22CEA40479F9A78A84E94CB91DCA960494D36FD6858CA896DCFFFB909AF015BB9FC63C00C31E5E07B15BD3B5E3875074FF32B11057566AA06328F972CB2A98C1FC8B207E25DF5786B2AEEB921100F1F6826D2448CD49BF1534C27233C235731594E3C26D0FE490"
          }
        ]
      }
    ]
  }
]
```