### PR TITLE
[I2C, DV] Refactoring / Simplifying functions in sequences

### DIFF
--- a/hw/dv/sv/i2c_agent/seq_lib/i2c_base_seq.sv
+++ b/hw/dv/sv/i2c_agent/seq_lib/i2c_base_seq.sv
@@ -137,15 +137,24 @@ class i2c_base_seq extends dv_base_seq #(
     `uvm_info(`gfn, "Got to end of Agent-Target transfer. Now awaiting new transfer.", UVM_DEBUG)
   endtask : send_device_mode_txn
 
+  // Return DevAck by default unless an extended class overrides it.
+  protected virtual function drv_type_e get_ack_nack();
+    return DevAck;
+  endfunction
 
-  virtual task drive_addr_byte_ack();
+  local task drive_ack();
     `uvm_create_obj(REQ, req);
     start_item(req);
-    req.drv_type = DevAck;
+    req.drv_type = get_ack_nack();
+    if (req.drv_type == DevNack)
+      `uvm_info(`gfn, "Nacking the byte!", UVM_HIGH)
     finish_item(req);
+  endtask : drive_ack
+
+  virtual task drive_addr_byte_ack();
+    drive_ack();
     `uvm_info(`gfn, "drive_addr_byte_ack()::finish_item()", UVM_DEBUG)
   endtask : drive_addr_byte_ack
-
 
   virtual task drive_read_byte(bit [7:0] rdata);
     `uvm_create_obj(REQ, req);
@@ -156,12 +165,8 @@ class i2c_base_seq extends dv_base_seq #(
     `uvm_info(`gfn, "drive_read_byte()::finish_item()", UVM_DEBUG)
   endtask : drive_read_byte
 
-
   virtual task drive_write_byte_ack();
-    `uvm_create_obj(REQ, req);
-    start_item(req);
-    req.drv_type = DevAck;
-    finish_item(req);
+    drive_ack();
     `uvm_info(`gfn, "drive_write_byte_ack()::finish_item()", UVM_DEBUG)
   endtask : drive_write_byte_ack
 

--- a/hw/dv/sv/i2c_agent/seq_lib/i2c_target_may_nack_seq.sv
+++ b/hw/dv/sv/i2c_agent/seq_lib/i2c_target_may_nack_seq.sv
@@ -23,24 +23,17 @@ class i2c_target_may_nack_seq extends i2c_base_seq;
   // METHODS //
   /////////////
 
-
-  virtual function void randomize_ack();
-    `DV_CHECK_STD_RANDOMIZE_FATAL(acknack);
-    case (acknack)
-      i2c_pkg::ACK:  req.drv_type = DevAck;
-      i2c_pkg::NACK: req.drv_type = DevNack;
-      default: `uvm_fatal(`gfn, "Shouldn't get here!")
-    endcase
-  endfunction : randomize_ack
-
+  // Return DevAck or DevNack with equal probability
+  local function drv_type_e get_ack_nack();
+    return ($urandom_range(0,1) ? DevAck : DevNack);
+  endfunction
 
   virtual task drive_addr_byte_ack();
     `uvm_create_obj(REQ, req);
     start_item(req);
 
-    // The base class / default behaviour is to ACK all address bytes.
-    // Here, choose randomly between ACK and NACK.
-    randomize_ack();
+    req.drv_type = get_ack_nack();
+
     if (req.drv_type == DevNack) `uvm_info(`gfn, "NACKing the address byte!", UVM_LOW)
 
     finish_item(req);
@@ -51,7 +44,8 @@ class i2c_target_may_nack_seq extends i2c_base_seq;
     `uvm_create_obj(REQ, req);
     start_item(req);
 
-    randomize_ack();
+    req.drv_type = get_ack_nack();
+
     if (req.drv_type == DevNack) `uvm_info(`gfn, "NACKing a data byte!", UVM_LOW)
 
     finish_item(req);

--- a/hw/dv/sv/i2c_agent/seq_lib/i2c_target_may_nack_seq.sv
+++ b/hw/dv/sv/i2c_agent/seq_lib/i2c_target_may_nack_seq.sv
@@ -24,32 +24,8 @@ class i2c_target_may_nack_seq extends i2c_base_seq;
   /////////////
 
   // Return DevAck or DevNack with equal probability
-  local function drv_type_e get_ack_nack();
+  protected virtual function drv_type_e get_ack_nack();
     return ($urandom_range(0,1) ? DevAck : DevNack);
   endfunction
-
-  virtual task drive_addr_byte_ack();
-    `uvm_create_obj(REQ, req);
-    start_item(req);
-
-    req.drv_type = get_ack_nack();
-
-    if (req.drv_type == DevNack) `uvm_info(`gfn, "NACKing the address byte!", UVM_LOW)
-
-    finish_item(req);
-  endtask : drive_addr_byte_ack
-
-
-  virtual task drive_write_byte_ack();
-    `uvm_create_obj(REQ, req);
-    start_item(req);
-
-    req.drv_type = get_ack_nack();
-
-    if (req.drv_type == DevNack) `uvm_info(`gfn, "NACKing a data byte!", UVM_LOW)
-
-    finish_item(req);
-  endtask : drive_write_byte_ack
-
 
 endclass : i2c_target_may_nack_seq


### PR DESCRIPTION
Refactoring in the sequences to avoid duplication and simplifies the way `i2c_target_may_nack_seq` randomizes `ack` and `nack`