### PR TITLE
[cryptolib] Remove `montmul` dependency from `run_rsa_key_from_cofactor`

### DIFF
--- a/sw/otbn/crypto/BUILD
+++ b/sw/otbn/crypto/BUILD
@@ -332,7 +332,6 @@ otbn_binary(
         ":div",
         ":gcd",
         ":lcm",
-        ":montmul",
         ":mul",
         ":rsa_key_from_cofactor",
         ":rsa_modinv_f4",


### PR DESCRIPTION
As this code is not used, lets remove it to save some bytes.