### PR TITLE
[prim_subreg] Define SwAccessNONE

### DIFF
--- a/hw/ip/prim/rtl/prim_subreg_pkg.sv
+++ b/hw/ip/prim/rtl/prim_subreg_pkg.sv
@@ -6,12 +6,13 @@ package prim_subreg_pkg;
 
   // Register access specifier
   typedef enum logic [2:0] {
-    SwAccessRW  = 3'd0, // Read-write
-    SwAccessRO  = 3'd1, // Read-only
-    SwAccessWO  = 3'd2, // Write-only
-    SwAccessW1C = 3'd3, // Write 1 to clear
-    SwAccessW1S = 3'd4, // Write 1 to set
-    SwAccessW0C = 3'd5, // Write 0 to clear
-    SwAccessRC  = 3'd6  // Read to clear. Do not use, only exists for compatibility.
+    SwAccessRW   = 3'd0, // Read-write
+    SwAccessRO   = 3'd1, // Read-only
+    SwAccessWO   = 3'd2, // Write-only
+    SwAccessW1C  = 3'd3, // Write 1 to clear
+    SwAccessW1S  = 3'd4, // Write 1 to set
+    SwAccessW0C  = 3'd5, // Write 0 to clear
+    SwAccessRC   = 3'd6, // Read to clear. Do not use, only exists for compatibility.
+    SwAccessNONE = 3'd7  // No access from software.
   } sw_access_e;
 endpackage


### PR DESCRIPTION
Although this software access mode may appear useless, presenting a register in the IP block that is accessible only from the IP hardware itself, it can nonetheless be emitted by the reggen code and thus fail to elaborate.

A register that is inaccessible to software may be thought of as a word address that does not fault accesses, always swallowing write data and returning zero when read.

Alternatively, if this is considered useless behavior, we could reject the hjson configuration that includes sw-inaccessible register(s).