### PR TITLE
[crypto/ecc] Refactor p256 and p384

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/p256.c
+++ b/sw/device/lib/crypto/impl/ecc/p256.c
@@ -116,9 +116,68 @@ enum {
   kModeArithShareSecretKeyInsCnt = 147,
 };
 
-static status_t p256_masked_scalar_write(p256_masked_scalar_t *src,
-                                         const otbn_addr_t share0_addr,
-                                         const otbn_addr_t share1_addr) {
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p256_init_otbn(
+    uint32_t mode) {
+  // Load the P-256 app. Fails if OTBN is non-idle.
+  HARDENED_TRY(otbn_load_app(kOtbnAppP256));
+  // Set mode so start() will jump into the requested routine.
+  return otbn_dmem_write(kOtbnP256ModeWords, &mode, kOtbnVarMode);
+}
+
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p256_write_point(
+    const p256_point_t *point) {
+  // Set the point x coordinate.
+  HARDENED_TRY(otbn_dmem_write(kP256CoordWords, point->x, kOtbnVarX));
+  // Set the point y coordinate.
+  return otbn_dmem_write(kP256CoordWords, point->y, kOtbnVarY);
+}
+
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p256_read_point(
+    p256_point_t *point) {
+  // Read the public key from OTBN dmem.
+  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarX, point->x));
+  return otbn_dmem_read(kP256CoordWords, kOtbnVarY, point->y);
+}
+
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p256_write_attestation_seed(
+    const otcrypto_const_word32_buf_t *attestation_seed) {
+  if (attestation_seed == NULL) {
+    // No attestation seed is used.
+    return otbn_dmem_set(kDiceAttestationMaxSeedLength, 0,
+                         kOtbnVarBootAttestationAdditionalSeed);
+  }
+
+  if (launder32(attestation_seed->len) > kDiceAttestationMaxSeedLength) {
+    // COVERAGE (MISSING) We do not cover too long attestation seed inputs.
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(attestation_seed));
+
+  // Write the attestation seed to the extra variables area.
+  HARDENED_TRY(otbn_dmem_write(attestation_seed->len, attestation_seed->data,
+                               kOtbnVarBootAttestationAdditionalSeed));
+  // Pad the remainder by zeros.
+  return otbn_dmem_set(kDiceAttestationMaxSeedLength - attestation_seed->len, 0,
+                       kOtbnVarBootAttestationAdditionalSeed +
+                           attestation_seed->len * sizeof(uint32_t));
+}
+
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p256_check_otbn_status(void) {
+  // Read the status code out of DMEM (false if basic checks on the validity of
+  // the signature and public key failed).
+  uint32_t ok;
+  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarOk, &ok));
+  if (launder32(ok) != kHardenedBoolTrue) {
+    HARDENED_TRY(otbn_dmem_sec_wipe());
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(ok, kHardenedBoolTrue);
+  return OTCRYPTO_OK;
+}
+
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p256_masked_scalar_write(
+    p256_masked_scalar_t *src, const otbn_addr_t share0_addr,
+    const otbn_addr_t share1_addr) {
   HARDENED_TRY(
       otbn_dmem_write(kP256MaskedScalarShareWords, src->share0, share0_addr));
   HARDENED_TRY(
@@ -133,6 +192,31 @@ static status_t p256_masked_scalar_write(p256_masked_scalar_t *src,
                              share1_addr + kP256MaskedScalarShareBytes));
 
   return OTCRYPTO_OK;
+}
+
+/**
+ * Set the message digest for signature generation or verification.
+ *
+ * OTBN requires the digest in little-endian form, so this routine flips the
+ * bytes.
+ *
+ * @param digest Digest to set (big-endian).
+ * @return OK or error.
+ */
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t set_message_digest(
+    const uint32_t digest[kP256ScalarWords]) {
+  // Set the message digest. We swap all the bytes so that OTBN can interpret
+  // the digest as a little-endian integer, which is a more natural fit for the
+  // architecture than the big-endian form requested by the specification (FIPS
+  // 186-5, section B.2.1).
+  uint32_t digest_little_endian[kP256ScalarWords];
+  size_t i = 0;
+  for (; launder32(i) < kP256ScalarWords; i++) {
+    digest_little_endian[i] =
+        __builtin_bswap32(digest[kP256ScalarWords - 1 - i]);
+  }
+  HARDENED_CHECK_EQ(i, kP256ScalarWords);
+  return otbn_dmem_write(kP256ScalarWords, digest_little_endian, kOtbnVarMsg);
 }
 
 uint32_t p256_masked_scalar_checksum(const p256_masked_scalar_t *scalar) {
@@ -180,27 +264,15 @@ hardened_bool_t p256_ecdh_shared_key_checksum_check(
 }
 
 status_t p256_keygen_start(void) {
-  // Load the P-256 app. Fails if OTBN is non-idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppP256));
-
-  // Set mode so start() will jump into keygen.
-  uint32_t mode = kOtbnP256ModeKeygen;
-  HARDENED_TRY(otbn_dmem_write(kOtbnP256ModeWords, &mode, kOtbnVarMode));
+  HARDENED_TRY(p256_init_otbn(kOtbnP256ModeKeygen));
 
   // Start the OTBN routine.
   return otbn_execute();
 }
 
 status_t p256_sideload_keygen_start(void) {
-  // Load the P-256 app. Fails if OTBN is non-idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppP256));
-
-  // Set mode so start() will jump into sideload-keygen.
-  uint32_t mode = kOtbnP256ModeSideloadKeygen;
-  HARDENED_TRY(otbn_dmem_write(kOtbnP256ModeWords, &mode, kOtbnVarMode));
-  // No attestation seed is used.
-  HARDENED_TRY(otbn_dmem_set(kDiceAttestationMaxSeedLength, 0,
-                             kOtbnVarBootAttestationAdditionalSeed));
+  HARDENED_TRY(p256_init_otbn(kOtbnP256ModeSideloadKeygen));
+  HARDENED_TRY(p256_write_attestation_seed(NULL));
 
   // Start the OTBN routine.
   return otbn_execute();
@@ -208,27 +280,8 @@ status_t p256_sideload_keygen_start(void) {
 
 status_t p256_sideload_attestation_keygen_start(
     const otcrypto_const_word32_buf_t *attestation_seed) {
-  if (launder32(attestation_seed->len) > kDiceAttestationMaxSeedLength) {
-    // COVERAGE (MISSING) We do not cover too long attestation seed inputs.
-    return OTCRYPTO_BAD_ARGS;
-  }
-
-  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(attestation_seed));
-
-  // Load the P-256 app. Fails if OTBN is non-idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppP256));
-
-  // Set mode so start() will jump into sideload-keygen.
-  uint32_t mode = kOtbnP256ModeSideloadKeygen;
-  HARDENED_TRY(otbn_dmem_write(kOtbnP256ModeWords, &mode, kOtbnVarMode));
-
-  HARDENED_TRY(otbn_dmem_write(attestation_seed->len, attestation_seed->data,
-                               kOtbnVarBootAttestationAdditionalSeed));
-  // Pad the remainder by zeros.
-  HARDENED_TRY(
-      otbn_dmem_set(kDiceAttestationMaxSeedLength - attestation_seed->len, 0,
-                    kOtbnVarBootAttestationAdditionalSeed +
-                        attestation_seed->len * sizeof(uint32_t)));
+  HARDENED_TRY(p256_init_otbn(kOtbnP256ModeSideloadKeygen));
+  HARDENED_TRY(p256_write_attestation_seed(attestation_seed));
 
   // Start the OTBN routine.
   return otbn_execute();
@@ -248,8 +301,7 @@ status_t p256_keygen_finalize(p256_masked_scalar_t *private_key,
   private_key->checksum = p256_masked_scalar_checksum(private_key);
 
   // Read the public key from OTBN dmem.
-  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarX, public_key->x));
-  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarY, public_key->y));
+  HARDENED_TRY(p256_read_point(public_key));
 
   // Wipe DMEM.
   HARDENED_TRY(otbn_dmem_sec_wipe());
@@ -263,8 +315,7 @@ status_t p256_sideload_keygen_finalize(p256_point_t *public_key) {
   HARDENED_CHECK_EQ(otbn_instruction_count_get(), kModeKeygenSideloadInsCnt);
 
   // Read the public key from OTBN dmem.
-  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarX, public_key->x));
-  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarY, public_key->y));
+  HARDENED_TRY(p256_read_point(public_key));
 
   // Wipe DMEM.
   HARDENED_TRY(otbn_dmem_sec_wipe());
@@ -272,38 +323,9 @@ status_t p256_sideload_keygen_finalize(p256_point_t *public_key) {
   return OTCRYPTO_OK;
 }
 
-/**
- * Set the message digest for signature generation or verification.
- *
- * OTBN requires the digest in little-endian form, so this routine flips the
- * bytes.
- *
- * @param digest Digest to set (big-endian).
- * @return OK or error.
- */
-static status_t set_message_digest(const uint32_t digest[kP256ScalarWords]) {
-  // Set the message digest. We swap all the bytes so that OTBN can interpret
-  // the digest as a little-endian integer, which is a more natural fit for the
-  // architecture than the big-endian form requested by the specification (FIPS
-  // 186-5, section B.2.1).
-  uint32_t digest_little_endian[kP256ScalarWords];
-  size_t i = 0;
-  for (; launder32(i) < kP256ScalarWords; i++) {
-    digest_little_endian[i] =
-        __builtin_bswap32(digest[kP256ScalarWords - 1 - i]);
-  }
-  HARDENED_CHECK_EQ(i, kP256ScalarWords);
-  return otbn_dmem_write(kP256ScalarWords, digest_little_endian, kOtbnVarMsg);
-}
-
 status_t p256_ecdsa_sign_start(const uint32_t digest[kP256ScalarWords],
                                p256_masked_scalar_t *private_key) {
-  // Load the P-256 app. Fails if OTBN is non-idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppP256));
-
-  // Set mode so start() will jump into signing.
-  uint32_t mode = kOtbnP256ModeSign;
-  HARDENED_TRY(otbn_dmem_write(kOtbnP256ModeWords, &mode, kOtbnVarMode));
+  HARDENED_TRY(p256_init_otbn(kOtbnP256ModeSign));
 
   // Set the message digest.
   HARDENED_TRY(set_message_digest(digest));
@@ -318,12 +340,7 @@ status_t p256_ecdsa_sign_start(const uint32_t digest[kP256ScalarWords],
 status_t p256_ecdsa_sign_config_k_start(const uint32_t digest[kP256ScalarWords],
                                         p256_masked_scalar_t *private_key,
                                         p256_masked_scalar_t *secret_scalar) {
-  // Load the P-256 app. Fails if OTBN is non-idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppP256));
-
-  // Set mode so start() will jump into signing.
-  uint32_t mode = kOtbnP256ModeSignConfigK;
-  HARDENED_TRY(otbn_dmem_write(kOtbnP256ModeWords, &mode, kOtbnVarMode));
+  HARDENED_TRY(p256_init_otbn(kOtbnP256ModeSignConfigK));
 
   // Set the message digest.
   HARDENED_TRY(set_message_digest(digest));
@@ -340,15 +357,8 @@ status_t p256_ecdsa_sign_config_k_start(const uint32_t digest[kP256ScalarWords],
 
 status_t p256_ecdsa_sideload_sign_start(
     const uint32_t digest[kP256ScalarWords]) {
-  // Load the P-256 app. Fails if OTBN is non-idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppP256));
-
-  // Set mode so start() will jump into sideloaded signing.
-  uint32_t mode = kOtbnP256ModeSideloadSign;
-  HARDENED_TRY(otbn_dmem_write(kOtbnP256ModeWords, &mode, kOtbnVarMode));
-  // No attestation seed is used.
-  HARDENED_TRY(otbn_dmem_set(kDiceAttestationMaxSeedLength, 0,
-                             kOtbnVarBootAttestationAdditionalSeed));
+  HARDENED_TRY(p256_init_otbn(kOtbnP256ModeSideloadSign));
+  HARDENED_TRY(p256_write_attestation_seed(NULL));
 
   // Set the message digest.
   HARDENED_TRY(set_message_digest(digest));
@@ -360,30 +370,12 @@ status_t p256_ecdsa_sideload_sign_start(
 status_t p256_sideload_attestation_sign_start(
     const uint32_t digest[kP256ScalarWords],
     const otcrypto_const_word32_buf_t *attestation_seed) {
-  if (launder32(attestation_seed->len) > kDiceAttestationMaxSeedLength) {
-    // COVERAGE (MISSING) We do not cover too long attestation seed inputs.
-    return OTCRYPTO_BAD_ARGS;
-  }
-  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(attestation_seed));
-
-  // Load the P-256 app. Fails if OTBN is non-idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppP256));
-
-  // Set mode so start() will jump into sideloaded signing.
-  uint32_t mode = kOtbnP256ModeSideloadSign;
-  HARDENED_TRY(otbn_dmem_write(kOtbnP256ModeWords, &mode, kOtbnVarMode));
+  HARDENED_TRY(p256_init_otbn(kOtbnP256ModeSideloadSign));
 
   // Set the message digest.
   HARDENED_TRY(set_message_digest(digest));
 
-  // Write the attestation seed to the extra variables area.
-  HARDENED_TRY(otbn_dmem_write(attestation_seed->len, attestation_seed->data,
-                               kOtbnVarBootAttestationAdditionalSeed));
-  // Pad the remainder by zeros.
-  HARDENED_TRY(
-      otbn_dmem_set(kDiceAttestationMaxSeedLength - attestation_seed->len, 0,
-                    kOtbnVarBootAttestationAdditionalSeed +
-                        attestation_seed->len * sizeof(uint32_t)));
+  HARDENED_TRY(p256_write_attestation_seed(attestation_seed));
 
   // Start the OTBN routine.
   return otbn_execute();
@@ -417,12 +409,7 @@ status_t p256_ecdsa_sign_finalize(p256_ecdsa_signature_t *result) {
 status_t p256_ecdsa_verify_start(const p256_ecdsa_signature_t *signature,
                                  const uint32_t digest[kP256ScalarWords],
                                  const p256_point_t *public_key) {
-  // Load the P-256 app and set up data pointers
-  HARDENED_TRY(otbn_load_app(kOtbnAppP256));
-
-  // Set mode so start() will jump into verifying.
-  uint32_t mode = kOtbnP256ModeVerify;
-  HARDENED_TRY(otbn_dmem_write(kOtbnP256ModeWords, &mode, kOtbnVarMode));
+  HARDENED_TRY(p256_init_otbn(kOtbnP256ModeVerify));
 
   // Set the message digest.
   HARDENED_TRY(set_message_digest(digest));
@@ -433,11 +420,7 @@ status_t p256_ecdsa_verify_start(const p256_ecdsa_signature_t *signature,
   // Set the signature S.
   HARDENED_TRY(otbn_dmem_write(kP256ScalarWords, signature->s, kOtbnVarS));
 
-  // Set the public key x coordinate.
-  HARDENED_TRY(otbn_dmem_write(kP256CoordWords, public_key->x, kOtbnVarX));
-
-  // Set the public key y coordinate.
-  HARDENED_TRY(otbn_dmem_write(kP256CoordWords, public_key->y, kOtbnVarY));
+  HARDENED_TRY(p256_write_point(public_key));
 
   // Start the OTBN routine.
   return otbn_execute();
@@ -448,15 +431,7 @@ status_t p256_ecdsa_verify_finalize(const p256_ecdsa_signature_t *signature,
   // Spin here waiting for OTBN to complete.
   HARDENED_TRY(otbn_busy_wait_for_done());
 
-  // Read the status code out of DMEM (false if basic checks on the validity of
-  // the signature and public key failed).
-  uint32_t ok;
-  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarOk, &ok));
-  if (launder32(ok) != kHardenedBoolTrue) {
-    HARDENED_TRY(otbn_dmem_sec_wipe());
-    return OTCRYPTO_BAD_ARGS;
-  }
-  HARDENED_CHECK_EQ(ok, kHardenedBoolTrue);
+  HARDENED_TRY(p256_check_otbn_status());
 
   // Read x_r (recovered R) out of OTBN dmem.
   uint32_t x_r[kP256ScalarWords];
@@ -472,21 +447,12 @@ status_t p256_ecdsa_verify_finalize(const p256_ecdsa_signature_t *signature,
 
 status_t p256_ecdh_start(p256_masked_scalar_t *private_key,
                          const p256_point_t *public_key) {
-  // Load the P-256 app. Fails if OTBN is non-idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppP256));
-
-  // Set mode so start() will jump into shared-key generation.
-  uint32_t mode = kOtbnP256ModeEcdh;
-  HARDENED_TRY(otbn_dmem_write(kOtbnP256ModeWords, &mode, kOtbnVarMode));
+  HARDENED_TRY(p256_init_otbn(kOtbnP256ModeEcdh));
 
   // Set the private key shares.
   HARDENED_TRY(p256_masked_scalar_write(private_key, kOtbnVarD0, kOtbnVarD1));
 
-  // Set the public key x coordinate.
-  HARDENED_TRY(otbn_dmem_write(kP256CoordWords, public_key->x, kOtbnVarX));
-
-  // Set the public key y coordinate.
-  HARDENED_TRY(otbn_dmem_write(kP256CoordWords, public_key->y, kOtbnVarY));
+  HARDENED_TRY(p256_write_point(public_key));
 
   // Start the OTBN routine.
   return otbn_execute();
@@ -496,14 +462,7 @@ status_t p256_ecdh_finalize(p256_ecdh_shared_key_t *shared_key) {
   // Spin here waiting for OTBN to complete.
   HARDENED_TRY(otbn_busy_wait_for_done());
 
-  // Read the code indicating if the public key is valid.
-  uint32_t ok;
-  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarOk, &ok));
-  if (launder32(ok) != kHardenedBoolTrue) {
-    HARDENED_TRY(otbn_dmem_sec_wipe());
-    return OTCRYPTO_BAD_ARGS;
-  }
-  HARDENED_CHECK_EQ(ok, kHardenedBoolTrue);
+  HARDENED_TRY(p256_check_otbn_status());
 
   // OTBN returned the status code OK, so check for the expected instr. count.
   uint32_t ins_cnt;
@@ -527,22 +486,9 @@ status_t p256_ecdh_finalize(p256_ecdh_shared_key_t *shared_key) {
 }
 
 status_t p256_sideload_ecdh_start(const p256_point_t *public_key) {
-  // Load the P-256 app. Fails if OTBN is non-idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppP256));
-
-  // Set mode so start() will jump into shared-key generation.
-  uint32_t mode = kOtbnP256ModeSideloadEcdh;
-  HARDENED_TRY(otbn_dmem_write(kOtbnP256ModeWords, &mode, kOtbnVarMode));
-
-  // Set the public key x coordinate.
-  HARDENED_TRY(otbn_dmem_write(kP256CoordWords, public_key->x, kOtbnVarX));
-
-  // Set the public key y coordinate.
-  HARDENED_TRY(otbn_dmem_write(kP256CoordWords, public_key->y, kOtbnVarY));
-
-  // No attestation seed is used.
-  HARDENED_TRY(otbn_dmem_set(kDiceAttestationMaxSeedLength, 0,
-                             kOtbnVarBootAttestationAdditionalSeed));
+  HARDENED_TRY(p256_init_otbn(kOtbnP256ModeSideloadEcdh));
+  HARDENED_TRY(p256_write_point(public_key));
+  HARDENED_TRY(p256_write_attestation_seed(NULL));
 
   // Start the OTBN routine.
   return otbn_execute();
@@ -550,18 +496,8 @@ status_t p256_sideload_ecdh_start(const p256_point_t *public_key) {
 
 status_t p256_point_on_curve_check(const p256_point_t *point,
                                    hardened_bool_t *result) {
-  // Load the P-256 app. Fails if OTBN is non-idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppP256));
-
-  // Set mode so start() will jump into the is on point check routine.
-  uint32_t mode = kOtbnP256ModePointOnCurveCheck;
-  HARDENED_TRY(otbn_dmem_write(kOtbnP256ModeWords, &mode, kOtbnVarMode));
-
-  // Set the point x coordinate.
-  HARDENED_TRY(otbn_dmem_write(kP256CoordWords, point->x, kOtbnVarX));
-
-  // Set the point y coordinate.
-  HARDENED_TRY(otbn_dmem_write(kP256CoordWords, point->y, kOtbnVarY));
+  HARDENED_TRY(p256_init_otbn(kOtbnP256ModePointOnCurveCheck));
+  HARDENED_TRY(p256_write_point(point));
 
   // Start the OTBN routine.
   HARDENED_TRY(otbn_execute());
@@ -581,12 +517,7 @@ status_t p256_point_on_curve_check(const p256_point_t *point,
 
 status_t p256_base_point_mult(p256_masked_scalar_t *private_key,
                               p256_point_t *public_key) {
-  // Load the P-256 app. Fails if OTBN is non-idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppP256));
-
-  // Set mode so start() will jump into the is on point check routine.
-  uint32_t mode = kOtbnP256ModeBasePointMult;
-  HARDENED_TRY(otbn_dmem_write(kOtbnP256ModeWords, &mode, kOtbnVarMode));
+  HARDENED_TRY(p256_init_otbn(kOtbnP256ModeBasePointMult));
 
   // Set the private key shares.
   HARDENED_TRY(p256_masked_scalar_write(private_key, kOtbnVarD0, kOtbnVarD1));
@@ -600,9 +531,7 @@ status_t p256_base_point_mult(p256_masked_scalar_t *private_key,
   // Check if we executed the expected number of OTBN instructions.
   HARDENED_CHECK_EQ(otbn_instruction_count_get(), kModeBasePointMultInsCnt);
 
-  // Read the public key from OTBN dmem.
-  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarX, public_key->x));
-  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarY, public_key->y));
+  HARDENED_TRY(p256_read_point(public_key));
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();
@@ -611,12 +540,7 @@ status_t p256_base_point_mult(p256_masked_scalar_t *private_key,
 OT_WARN_UNUSED_RESULT
 status_t p256_arith_share_private_key(p256_masked_scalar_t *boolean_private_key,
                                       p256_masked_scalar_t *arith_private_key) {
-  // Load the P-256 app. Fails if OTBN is non-idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppP256));
-
-  // Set mode so start() will jump into the share secret key routine.
-  uint32_t mode = kOtbnP256ModeArithShareSecretKey;
-  HARDENED_TRY(otbn_dmem_write(kOtbnP256ModeWords, &mode, kOtbnVarMode));
+  HARDENED_TRY(p256_init_otbn(kOtbnP256ModeArithShareSecretKey));
 
   // Write the Boolean-shared key to DMEM.
   HARDENED_TRY(

--- a/sw/device/lib/crypto/impl/ecc/p384.c
+++ b/sw/device/lib/crypto/impl/ecc/p384.c
@@ -126,9 +126,34 @@ enum {
   kModeArithShareSecretKeyInsCnt = 308,
 };
 
-static status_t p384_masked_scalar_write(p384_masked_scalar_t *src,
-                                         const otbn_addr_t share0_addr,
-                                         const otbn_addr_t share1_addr) {
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p384_init_otbn(
+    uint32_t mode) {
+  HARDENED_TRY(otbn_load_app(kOtbnAppP384));
+  return otbn_dmem_write(kP384ModeWords, &mode, kOtbnVarMode);
+}
+
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p384_read_point(
+    p384_point_t *point) {
+  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarX, point->x));
+  return otbn_dmem_read(kP384CoordWords, kOtbnVarY, point->y);
+}
+
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p384_check_otbn_status(void) {
+  uint32_t ok;
+  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarOk, &ok));
+  if (launder32(ok) != kHardenedBoolTrue) {
+    HARDENED_TRY(otbn_dmem_sec_wipe());
+    // COVERAGE (MISSING) We do not cover a negative ECDH check where a bad
+    // public key is given.
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(ok, kHardenedBoolTrue);
+  return OTCRYPTO_OK;
+}
+
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p384_masked_scalar_write(
+    p384_masked_scalar_t *src, const otbn_addr_t share0_addr,
+    const otbn_addr_t share1_addr) {
   HARDENED_TRY(
       otbn_dmem_write(kP384MaskedScalarShareWords, src->share0, share0_addr));
   HARDENED_TRY(
@@ -143,6 +168,50 @@ static status_t p384_masked_scalar_write(p384_masked_scalar_t *src,
                              share1_addr + kP384MaskedScalarShareBytes));
 
   return OTCRYPTO_OK;
+}
+
+/**
+ * Write a scalar-sized value into DMEM, with padding as needed.
+ *
+ * @param src Source value.
+ * @param addr DMEM address to write.
+ */
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p384_scalar_write(
+    const uint32_t src[kP384ScalarWords], const otbn_addr_t addr) {
+  HARDENED_TRY(otbn_dmem_write(kP384ScalarWords, src, addr));
+
+  return otbn_dmem_set(kScalarPaddingWords, 0, addr + kP384ScalarBytes);
+}
+
+/**
+ * Write a point into the x and y buffers, with padding as needed.
+ *
+ * @param p Point to write.
+ */
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t set_public_key(
+    const p384_point_t *p) {
+  HARDENED_TRY(otbn_dmem_write(kP384CoordWords, p->x, kOtbnVarX));
+  HARDENED_TRY(otbn_dmem_write(kP384CoordWords, p->y, kOtbnVarY));
+
+  HARDENED_TRY(
+      otbn_dmem_set(kCoordPaddingWords, 0, kOtbnVarX + kP384CoordBytes));
+  return otbn_dmem_set(kCoordPaddingWords, 0, kOtbnVarY + kP384CoordBytes);
+}
+
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t set_message_digest(
+    const uint32_t digest[kP384ScalarWords], const otbn_addr_t dst) {
+  // Set the message digest. We swap all the bytes so that OTBN can interpret
+  // the digest as a little-endian integer, which is a more natural fit for the
+  // architecture than the big-endian form requested by the specification (FIPS
+  // 186-5, section B.2.1).
+  uint32_t digest_little_endian[kP384ScalarWords];
+  size_t i = 0;
+  for (; launder32(i) < kP384ScalarWords; i++) {
+    digest_little_endian[i] =
+        __builtin_bswap32(digest[kP384ScalarWords - 1 - i]);
+  }
+  HARDENED_CHECK_EQ(i, kP384ScalarWords);
+  return p384_scalar_write(digest_little_endian, dst);
 }
 
 uint32_t p384_masked_scalar_checksum(const p384_masked_scalar_t *scalar) {
@@ -165,49 +234,6 @@ hardened_bool_t p384_masked_scalar_checksum_check(
   // COVERAGE (FI CM) We only provide correct encoded scalars, this is to check
   // for faults.
   return kHardenedBoolFalse;
-}
-
-/**
- * Write a scalar-sized value into DMEM, with padding as needed.
- *
- * @param src Source value.
- * @param addr DMEM address to write.
- */
-static status_t p384_scalar_write(const uint32_t src[kP384ScalarWords],
-                                  const otbn_addr_t addr) {
-  HARDENED_TRY(otbn_dmem_write(kP384ScalarWords, src, addr));
-
-  return otbn_dmem_set(kScalarPaddingWords, 0, addr + kP384ScalarBytes);
-}
-
-/**
- * Write a point into the x and y buffers, with padding as needed.
- *
- * @param p Point to write.
- */
-static status_t set_public_key(const p384_point_t *p) {
-  HARDENED_TRY(otbn_dmem_write(kP384CoordWords, p->x, kOtbnVarX));
-  HARDENED_TRY(otbn_dmem_write(kP384CoordWords, p->y, kOtbnVarY));
-
-  HARDENED_TRY(
-      otbn_dmem_set(kCoordPaddingWords, 0, kOtbnVarX + kP384CoordBytes));
-  return otbn_dmem_set(kCoordPaddingWords, 0, kOtbnVarY + kP384CoordBytes);
-}
-
-static status_t set_message_digest(const uint32_t digest[kP384ScalarWords],
-                                   const otbn_addr_t dst) {
-  // Set the message digest. We swap all the bytes so that OTBN can interpret
-  // the digest as a little-endian integer, which is a more natural fit for the
-  // architecture than the big-endian form requested by the specification (FIPS
-  // 186-5, section B.2.1).
-  uint32_t digest_little_endian[kP384ScalarWords];
-  size_t i = 0;
-  for (; launder32(i) < kP384ScalarWords; i++) {
-    digest_little_endian[i] =
-        __builtin_bswap32(digest[kP384ScalarWords - 1 - i]);
-  }
-  HARDENED_CHECK_EQ(i, kP384ScalarWords);
-  return p384_scalar_write(digest_little_endian, dst);
 }
 
 uint32_t p384_ecdh_shared_key_checksum(const p384_ecdh_shared_key_t *key) {
@@ -233,12 +259,7 @@ hardened_bool_t p384_ecdh_shared_key_checksum_check(
 }
 
 status_t p384_keygen_start(void) {
-  // Load the ECDH/P-384 app. Fails if OTBN is non-idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppP384));
-
-  // Set mode so start() will jump into keygen.
-  uint32_t mode = kP384ModeKeygen;
-  HARDENED_TRY(otbn_dmem_write(kP384ModeWords, &mode, kOtbnVarMode));
+  HARDENED_TRY(p384_init_otbn(kP384ModeKeygen));
 
   // Start the OTBN routine.
   return otbn_execute();
@@ -258,8 +279,7 @@ status_t p384_keygen_finalize(p384_masked_scalar_t *private_key,
   private_key->checksum = p384_masked_scalar_checksum(private_key);
 
   // Read the public key from OTBN dmem.
-  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarX, public_key->x));
-  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarY, public_key->y));
+  HARDENED_TRY(p384_read_point(public_key));
 
   // Wipe DMEM.
   HARDENED_TRY(otbn_dmem_sec_wipe());
@@ -268,12 +288,7 @@ status_t p384_keygen_finalize(p384_masked_scalar_t *private_key,
 }
 
 status_t p384_sideload_keygen_start(void) {
-  // Load the ECDH/P-384 app. Fails if OTBN is non-idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppP384));
-
-  // Set mode so start() will jump into keygen.
-  uint32_t mode = kP384ModeSideloadKeygen;
-  HARDENED_TRY(otbn_dmem_write(kP384ModeWords, &mode, kOtbnVarMode));
+  HARDENED_TRY(p384_init_otbn(kP384ModeSideloadKeygen));
 
   // Start the OTBN routine.
   return otbn_execute();
@@ -285,8 +300,7 @@ status_t p384_sideload_keygen_finalize(p384_point_t *public_key) {
   HARDENED_CHECK_EQ(otbn_instruction_count_get(), kModeKeygenSideloadInsCnt);
 
   // Read the public key from OTBN dmem.
-  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarX, public_key->x));
-  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarY, public_key->y));
+  HARDENED_TRY(p384_read_point(public_key));
 
   // Wipe DMEM.
   HARDENED_TRY(otbn_dmem_sec_wipe());
@@ -296,12 +310,7 @@ status_t p384_sideload_keygen_finalize(p384_point_t *public_key) {
 
 status_t p384_ecdsa_sign_start(const uint32_t digest[kP384ScalarWords],
                                p384_masked_scalar_t *private_key) {
-  // Load the ECDSA/P-384 app. Fails if OTBN is non-idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppP384));
-
-  // Set mode so start() will jump into sideloaded signing.
-  uint32_t mode = kP384ModeSign;
-  HARDENED_TRY(otbn_dmem_write(kP384ModeWords, &mode, kOtbnVarMode));
+  HARDENED_TRY(p384_init_otbn(kP384ModeSign));
 
   // Set the message digest.
   HARDENED_TRY(set_message_digest(digest, kOtbnVarMsg));
@@ -316,12 +325,7 @@ status_t p384_ecdsa_sign_start(const uint32_t digest[kP384ScalarWords],
 status_t p384_ecdsa_sign_config_k_start(const uint32_t digest[kP384ScalarWords],
                                         p384_masked_scalar_t *private_key,
                                         p384_masked_scalar_t *secret_scalar) {
-  // Load the ECDSA/P-384 app. Fails if OTBN is non-idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppP384));
-
-  // Set mode so start() will jump into sideloaded signing.
-  uint32_t mode = kP384ModeSignConfigK;
-  HARDENED_TRY(otbn_dmem_write(kP384ModeWords, &mode, kOtbnVarMode));
+  HARDENED_TRY(p384_init_otbn(kP384ModeSignConfigK));
 
   // Set the message digest.
   HARDENED_TRY(set_message_digest(digest, kOtbnVarMsg));
@@ -338,12 +342,7 @@ status_t p384_ecdsa_sign_config_k_start(const uint32_t digest[kP384ScalarWords],
 
 status_t p384_ecdsa_sideload_sign_start(
     const uint32_t digest[kP384ScalarWords]) {
-  // Load the ECDSA/P-384 app. Fails if OTBN is non-idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppP384));
-
-  // Set mode so start() will jump into sideloaded signing.
-  uint32_t mode = kP384ModeSideloadSign;
-  HARDENED_TRY(otbn_dmem_write(kP384ModeWords, &mode, kOtbnVarMode));
+  HARDENED_TRY(p384_init_otbn(kP384ModeSideloadSign));
 
   // Set the message digest.
   HARDENED_TRY(set_message_digest(digest, kOtbnVarMsg));
@@ -380,12 +379,7 @@ status_t p384_ecdsa_sign_finalize(p384_ecdsa_signature_t *result) {
 status_t p384_ecdsa_verify_start(const p384_ecdsa_signature_t *signature,
                                  const uint32_t digest[kP384ScalarWords],
                                  const p384_point_t *public_key) {
-  // Load the ECDSA/P-384 app
-  HARDENED_TRY(otbn_load_app(kOtbnAppP384));
-
-  // Set mode so start() will jump into ECDSA verify.
-  uint32_t mode = kP384ModeVerify;
-  HARDENED_TRY(otbn_dmem_write(kP384ModeWords, &mode, kOtbnVarMode));
+  HARDENED_TRY(p384_init_otbn(kP384ModeVerify));
 
   // Set the message digest.
   HARDENED_TRY(set_message_digest(digest, kOtbnVarMsg));
@@ -408,15 +402,7 @@ status_t p384_ecdsa_verify_finalize(const p384_ecdsa_signature_t *signature,
   // Spin here waiting for OTBN to complete.
   HARDENED_TRY(otbn_busy_wait_for_done());
 
-  // Read the status code out of DMEM (false if basic checks on the validity of
-  // the signature and public key failed).
-  uint32_t ok;
-  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarOk, &ok));
-  if (launder32(ok) != kHardenedBoolTrue) {
-    HARDENED_TRY(otbn_dmem_sec_wipe());
-    return OTCRYPTO_BAD_ARGS;
-  }
-  HARDENED_CHECK_EQ(ok, kHardenedBoolTrue);
+  HARDENED_TRY(p384_check_otbn_status());
 
   // Read x_r (recovered R) out of OTBN dmem.
   uint32_t x_r[kP384ScalarWords];
@@ -432,12 +418,7 @@ status_t p384_ecdsa_verify_finalize(const p384_ecdsa_signature_t *signature,
 
 status_t p384_ecdh_start(p384_masked_scalar_t *private_key,
                          const p384_point_t *public_key) {
-  // Load the ECDH/P-384 app. Fails if OTBN is non-idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppP384));
-
-  // Set mode so start() will jump into shared-key generation.
-  uint32_t mode = kP384ModeEcdh;
-  HARDENED_TRY(otbn_dmem_write(kP384ModeWords, &mode, kOtbnVarMode));
+  HARDENED_TRY(p384_init_otbn(kP384ModeEcdh));
 
   // Set the private key shares.
   HARDENED_TRY(p384_masked_scalar_write(private_key, kOtbnVarD0, kOtbnVarD1));
@@ -453,17 +434,7 @@ status_t p384_ecdh_finalize(p384_ecdh_shared_key_t *shared_key) {
   // Spin here waiting for OTBN to complete.
   HARDENED_TRY(otbn_busy_wait_for_done());
 
-  // Read the status code out of DMEM (false if basic checks on the validity of
-  // the signature and public key failed).
-  uint32_t ok;
-  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarOk, &ok));
-  if (launder32(ok) != kHardenedBoolTrue) {
-    HARDENED_TRY(otbn_dmem_sec_wipe());
-    // COVERAGE (MISSING) We do not cover a negative ECDH check where a bad
-    // public key is given.
-    return OTCRYPTO_BAD_ARGS;
-  }
-  HARDENED_CHECK_EQ(ok, kHardenedBoolTrue);
+  HARDENED_TRY(p384_check_otbn_status());
 
   // OTBN returned the status code OK, so check for the expected instr. count.
   uint32_t ins_cnt;
@@ -487,12 +458,7 @@ status_t p384_ecdh_finalize(p384_ecdh_shared_key_t *shared_key) {
 }
 
 status_t p384_sideload_ecdh_start(const p384_point_t *public_key) {
-  // Load the ECDH/P-384 app. Fails if OTBN is non-idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppP384));
-
-  // Set mode so start() will jump into shared-key generation.
-  uint32_t mode = kP384ModeSideloadEcdh;
-  HARDENED_TRY(otbn_dmem_write(kP384ModeWords, &mode, kOtbnVarMode));
+  HARDENED_TRY(p384_init_otbn(kP384ModeSideloadEcdh));
 
   // Set the public key.
   HARDENED_TRY(set_public_key(public_key));
@@ -503,23 +469,10 @@ status_t p384_sideload_ecdh_start(const p384_point_t *public_key) {
 
 status_t p384_point_on_curve_check(const p384_point_t *point,
                                    hardened_bool_t *result) {
-  // Load the P-384 app. Fails if OTBN is non-idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppP384));
+  HARDENED_TRY(p384_init_otbn(kOtbnP384ModePointOnCurveCheck));
 
-  // Set mode so start() will jump into the is on point check routine.
-  uint32_t mode = kOtbnP384ModePointOnCurveCheck;
-  HARDENED_TRY(otbn_dmem_write(kP384ModeWords, &mode, kOtbnVarMode));
-
-  // Set the point x coordinate.
-  HARDENED_TRY(otbn_dmem_write(kP384CoordWords, point->x, kOtbnVarX));
-
-  // Set the point y coordinate.
-  HARDENED_TRY(otbn_dmem_write(kP384CoordWords, point->y, kOtbnVarY));
-
-  HARDENED_TRY(
-      otbn_dmem_set(kCoordPaddingWords, 0, kOtbnVarX + kP384CoordBytes));
-  HARDENED_TRY(
-      otbn_dmem_set(kCoordPaddingWords, 0, kOtbnVarY + kP384CoordBytes));
+  // Set the point.
+  HARDENED_TRY(set_public_key(point));
 
   // Start the OTBN routine.
   HARDENED_TRY(otbn_execute());
@@ -551,12 +504,7 @@ status_t p384_point_on_curve_check(const p384_point_t *point,
 
 status_t p384_base_point_mult(p384_masked_scalar_t *private_key,
                               p384_point_t *public_key) {
-  // Load the P-384 app. Fails if OTBN is non-idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppP384));
-
-  // Set mode so start() will jump into the is on point check routine.
-  uint32_t mode = kOtbnP384ModeBasePointMult;
-  HARDENED_TRY(otbn_dmem_write(kP384ModeWords, &mode, kOtbnVarMode));
+  HARDENED_TRY(p384_init_otbn(kOtbnP384ModeBasePointMult));
 
   // Set the private key shares.
   HARDENED_TRY(p384_masked_scalar_write(private_key, kOtbnVarD0, kOtbnVarD1));
@@ -571,8 +519,7 @@ status_t p384_base_point_mult(p384_masked_scalar_t *private_key,
   HARDENED_CHECK_EQ(otbn_instruction_count_get(), kModeBasePointMultInsCnt);
 
   // Read the public key from OTBN dmem.
-  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarX, public_key->x));
-  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarY, public_key->y));
+  HARDENED_TRY(p384_read_point(public_key));
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();
@@ -581,12 +528,7 @@ status_t p384_base_point_mult(p384_masked_scalar_t *private_key,
 OT_WARN_UNUSED_RESULT
 status_t p384_arith_share_private_key(p384_masked_scalar_t *boolean_private_key,
                                       p384_masked_scalar_t *arith_private_key) {
-  // Load the P-384 app. Fails if OTBN is non-idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppP384));
-
-  // Set mode so start() will jump into the is on point check routine.
-  uint32_t mode = kOtbnP384ModeArithShareSecretKey;
-  HARDENED_TRY(otbn_dmem_write(kP384ModeWords, &mode, kOtbnVarMode));
+  HARDENED_TRY(p384_init_otbn(kOtbnP384ModeArithShareSecretKey));
 
   // Write the Boolean-shared key to DMEM.
   HARDENED_TRY(

--- a/sw/device/lib/crypto/impl/ecc_p256.c
+++ b/sw/device/lib/crypto/impl/ecc_p256.c
@@ -16,6 +16,46 @@
 #define MODULE_ID MAKE_MODULE_ID('p', '2', '5')
 
 /**
+ * Extracts and verifies a P-256 masked scalar from a blinded key struct.
+ *
+ * This safely copies the blinded key material (two shares) from the opaque
+ * keyblob into the internal `p256_masked_scalar_t` representation.
+ *
+ * @param key The blinded key containing the raw 320-bit masked scalar shares.
+ * @param[out] scalar Destination struct for the extracted shares and checksum.
+ * @return OK on success, or an error code if a fault is detected.
+ */
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t load_private_scalar(
+    const otcrypto_blinded_key_t *key, p256_masked_scalar_t *scalar) {
+  HARDENED_TRY(hardened_memcpy(scalar->share0, key->keyblob,
+                               kP256MaskedScalarTotalShareWords));
+  HARDENED_CHECK_EQ(hardened_memeq(key->keyblob, scalar->share0,
+                                   kP256MaskedScalarTotalShareWords),
+                    kHardenedBoolTrue);
+  scalar->checksum = p256_masked_scalar_checksum(scalar);
+  return OTCRYPTO_OK;
+}
+
+/**
+ * Derives and loads a hardware-backed attestation key into OTBN.
+ *
+ * This extracts the diversification parameters (salt, version) embedded within
+ * the blinded key's configuration and commands the hardware Key Manager to
+ * derive the corresponding key and sideload it directly into the OTBN
+ * coprocessor, keeping the key material completely hidden from software.
+ *
+ * @param private_key The blinded key containing the diversification config.
+ * @return OK if the key manager successfully sideloads the key, or an error.
+ */
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t
+load_attestation_diversification(const otcrypto_blinded_key_t *private_key) {
+  keymgr_diversification_t diversification;
+  HARDENED_TRY(keyblob_to_keymgr_attestation_diversification(private_key,
+                                                             &diversification));
+  return keymgr_generate_key_otbn(diversification, kHardenedBoolTrue);
+}
+
+/**
  * Check the lengths of private keys for curve P-256.
  *
  * Checks the length of caller-allocated buffers for a P-256 private key. This
@@ -28,8 +68,7 @@
  * @param private_key Private key struct to check.
  * @return OK if the lengths are correct or BAD_ARGS otherwise.
  */
-OT_WARN_UNUSED_RESULT
-static status_t p256_private_key_length_check(
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p256_private_key_length_check(
     const otcrypto_blinded_key_t *private_key) {
   if (private_key->config.hw_backed == kHardenedBoolTrue) {
     // Skip the length check in this case; if the salt is the wrong length, the
@@ -69,8 +108,7 @@ static status_t p256_private_key_length_check(
  * @param public_key Public key struct to check.
  * @return OK if the lengths are correct or BAD_ARGS otherwise.
  */
-OT_WARN_UNUSED_RESULT
-static status_t p256_public_key_length_check(
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p256_public_key_length_check(
     const otcrypto_unblinded_key_t *public_key) {
   if (public_key->key_length != sizeof(p256_point_t)) {
     return OTCRYPTO_BAD_ARGS;
@@ -91,8 +129,7 @@ static status_t p256_public_key_length_check(
  * @param[out] public_key Public key to populate.
  * @return OK or error.
  */
-OT_WARN_UNUSED_RESULT
-static status_t internal_p256_keygen_finalize(
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t internal_p256_keygen_finalize(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
   // Check the lengths of caller-allocated buffers.
   HARDENED_TRY(p256_private_key_length_check(private_key));
@@ -147,14 +184,86 @@ static status_t internal_p256_keygen_finalize(
  * @param len Length to check.
  * @return OK if the lengths are correct or BAD_ARGS otherwise.
  */
-OT_WARN_UNUSED_RESULT
-static status_t p256_signature_length_check(size_t len) {
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p256_signature_length_check(
+    size_t len) {
   if (len > UINT32_MAX / sizeof(uint32_t) ||
       len * sizeof(uint32_t) != sizeof(p256_ecdsa_signature_t)) {
     return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_CHECK_EQ(launder32(len) * sizeof(uint32_t),
                     sizeof(p256_ecdsa_signature_t));
+
+  return OTCRYPTO_OK;
+}
+
+/**
+ * Calls P-256 key generation.
+ *
+ * Can be used for both ECDSA and ECDH. If the key is hardware-backed, loads
+ * the data from key manager and calls the sideloaded key generation routine.
+ *
+ * @param private_key Sideloaded key handle.
+ * @return OK or error.
+ */
+OT_NOINLINE
+OT_WARN_UNUSED_RESULT
+static status_t internal_p256_keygen_start(
+    const otcrypto_blinded_key_t *private_key) {
+  if (private_key->config.hw_backed == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
+                      kHardenedBoolTrue);
+    HARDENED_TRY(keyblob_sideload_key_otbn(private_key));
+    return otcrypto_eval_exit(p256_sideload_keygen_start());
+  } else if (private_key->config.hw_backed == kHardenedBoolFalse) {
+    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
+                      kHardenedBoolFalse);
+    return otcrypto_eval_exit(p256_keygen_start());
+  }
+  return OTCRYPTO_BAD_ARGS;
+}
+
+/**
+ * Performs input validation and setup for ECDSA P-256 signature generation.
+ *
+ * This routine centralizes the parameter validation required before
+ * starting an asynchronous signature generation.
+ *
+ * @param private_key The blinded private key intended for signing.
+ * @param message_digest The pre-computed hash digest to be signed.
+ * @return OK if all security and parameter checks pass, or BAD_ARGS if
+ *         inputs are invalid, mismatched, or if a fault is detected.
+ */
+OT_NOINLINE
+OT_WARN_UNUSED_RESULT
+static otcrypto_status_t otcrypto_ecdsa_p256_sign_async_start_setup(
+    const otcrypto_blinded_key_t *private_key,
+    const otcrypto_hash_digest_t message_digest) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
+  if (private_key == NULL || private_key->keyblob == NULL ||
+      message_digest.data == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+#endif
+
+  if (otcrypto_integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(
+      launder32(otcrypto_integrity_blinded_key_check(private_key)),
+      kHardenedBoolTrue);
+
+  if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP256) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
+                    kOtcryptoKeyModeEcdsaP256);
+
+  if (message_digest.len != kP256ScalarWords) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(launder32(message_digest.len), kP256ScalarWords);
+
+  HARDENED_TRY(p256_private_key_length_check(private_key));
 
   return OTCRYPTO_OK;
 }
@@ -285,12 +394,7 @@ status_t otcrypto_ecc_p256_base_point_mult(
                     kHardenedBoolTrue);
 
   p256_masked_scalar_t private_scalar;
-  HARDENED_TRY(hardened_memcpy(private_scalar.share0, private_key->keyblob,
-                               kP256MaskedScalarTotalShareWords));
-  HARDENED_CHECK_EQ(hardened_memeq(private_key->keyblob, private_scalar.share0,
-                                   kP256MaskedScalarTotalShareWords),
-                    kHardenedBoolTrue);
-  private_scalar.checksum = p256_masked_scalar_checksum(&private_scalar);
+  HARDENED_TRY(load_private_scalar(private_key, &private_scalar));
 
   p256_point_t *pk = (p256_point_t *)public_key->key;
   HARDENED_TRY_WIPE_DMEM(p256_base_point_mult(&private_scalar, pk));
@@ -298,31 +402,6 @@ status_t otcrypto_ecc_p256_base_point_mult(
   public_key->checksum = otcrypto_integrity_unblinded_checksum(public_key);
 
   return OTCRYPTO_OK;
-}
-
-/**
- * Calls P-256 key generation.
- *
- * Can be used for both ECDSA and ECDH. If the key is hardware-backed, loads
- * the data from key manager and calls the sideloaded key generation routine.
- *
- * @param private_key Sideloaded key handle.
- * @return OK or error.
- */
-OT_WARN_UNUSED_RESULT
-static status_t internal_p256_keygen_start(
-    const otcrypto_blinded_key_t *private_key) {
-  if (private_key->config.hw_backed == kHardenedBoolTrue) {
-    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                      kHardenedBoolTrue);
-    HARDENED_TRY(keyblob_sideload_key_otbn(private_key));
-    return otcrypto_eval_exit(p256_sideload_keygen_start());
-  } else if (private_key->config.hw_backed == kHardenedBoolFalse) {
-    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                      kHardenedBoolFalse);
-    return otcrypto_eval_exit(p256_keygen_start());
-  }
-  return OTCRYPTO_BAD_ARGS;
 }
 
 otcrypto_status_t otcrypto_ecdsa_p256_keygen_async_start(
@@ -386,11 +465,7 @@ otcrypto_status_t otcrypto_ecdsa_p256_dice_keygen_async_start(
   HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
                     kOtcryptoKeyModeEcdsaP256);
 
-  keymgr_diversification_t diversification;
-  HARDENED_TRY(keyblob_to_keymgr_attestation_diversification(private_key,
-                                                             &diversification));
-  HARDENED_TRY(keymgr_generate_key_otbn(diversification, kHardenedBoolTrue));
-
+  HARDENED_TRY(load_attestation_diversification(private_key));
   HARDENED_TRY_WIPE_DMEM(
       p256_sideload_attestation_keygen_start(attestation_seed));
 
@@ -400,42 +475,6 @@ otcrypto_status_t otcrypto_ecdsa_p256_dice_keygen_async_start(
 otcrypto_status_t otcrypto_ecdsa_p256_dice_keygen_async_finalize(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
   return otcrypto_ecdsa_p256_keygen_async_finalize(private_key, public_key);
-}
-
-static otcrypto_status_t otcrypto_ecdsa_p256_sign_async_start_setup(
-    const otcrypto_blinded_key_t *private_key,
-    const otcrypto_hash_digest_t message_digest) {
-#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
-  if (private_key == NULL || private_key->keyblob == NULL ||
-      message_digest.data == NULL) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-#endif
-
-  // Check the integrity of the private key.
-  if (otcrypto_integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  HARDENED_CHECK_EQ(
-      launder32(otcrypto_integrity_blinded_key_check(private_key)),
-      kHardenedBoolTrue);
-
-  if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP256) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
-                    kOtcryptoKeyModeEcdsaP256);
-
-  // Check the digest length.
-  if (message_digest.len != kP256ScalarWords) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  HARDENED_CHECK_EQ(launder32(message_digest.len), kP256ScalarWords);
-
-  // Check the key length and load the private key.
-  HARDENED_TRY(p256_private_key_length_check(private_key));
-
-  return OTCRYPTO_OK;
 }
 
 otcrypto_status_t otcrypto_ecdsa_p256_sign_config_k_async_start(
@@ -450,18 +489,15 @@ otcrypto_status_t otcrypto_ecdsa_p256_sign_config_k_async_start(
   HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
                     kHardenedBoolFalse);
   p256_masked_scalar_t private_scalar;
-  HARDENED_TRY(hardened_memcpy(private_scalar.share0, private_key->keyblob,
-                               kP256MaskedScalarTotalShareWords));
-  private_scalar.checksum = p256_masked_scalar_checksum(&private_scalar);
+  HARDENED_TRY(load_private_scalar(private_key, &private_scalar));
 
   // Load the secret scalar k.
   // The use of fixed scalars should be limited to KATs.
   HARDENED_CHECK_EQ(launder32(secret_scalar->config.hw_backed),
                     kHardenedBoolFalse);
   p256_masked_scalar_t config_k_scalar;
-  HARDENED_TRY(hardened_memcpy(config_k_scalar.share0, secret_scalar->keyblob,
-                               kP256MaskedScalarTotalShareWords));
-  config_k_scalar.checksum = p256_masked_scalar_checksum(&config_k_scalar);
+  HARDENED_TRY(load_private_scalar(secret_scalar, &config_k_scalar));
+
   HARDENED_TRY_WIPE_DMEM(p256_ecdsa_sign_config_k_start(
       message_digest.data, &private_scalar, &config_k_scalar));
 
@@ -488,13 +524,7 @@ otcrypto_status_t otcrypto_ecdsa_p256_sign_async_start(
     HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
                       kHardenedBoolFalse);
     p256_masked_scalar_t private_scalar;
-    HARDENED_TRY(hardened_memcpy(private_scalar.share0, private_key->keyblob,
-                                 kP256MaskedScalarTotalShareWords));
-    HARDENED_CHECK_EQ(
-        hardened_memeq(private_key->keyblob, private_scalar.share0,
-                       kP256MaskedScalarTotalShareWords),
-        kHardenedBoolTrue);
-    private_scalar.checksum = p256_masked_scalar_checksum(&private_scalar);
+    HARDENED_TRY(load_private_scalar(private_key, &private_scalar));
     HARDENED_TRY_WIPE_DMEM(
         p256_ecdsa_sign_start(message_digest.data, &private_scalar));
   } else if (private_key->config.hw_backed == kHardenedBoolTrue) {
@@ -735,13 +765,7 @@ otcrypto_status_t otcrypto_ecdh_p256_async_start(
     HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
                       kHardenedBoolFalse);
     p256_masked_scalar_t private_scalar;
-    HARDENED_TRY(hardened_memcpy(private_scalar.share0, private_key->keyblob,
-                                 kP256MaskedScalarTotalShareWords));
-    HARDENED_CHECK_EQ(
-        hardened_memeq(private_key->keyblob, private_scalar.share0,
-                       kP256MaskedScalarTotalShareWords),
-        kHardenedBoolTrue);
-    private_scalar.checksum = p256_masked_scalar_checksum(&private_scalar);
+    HARDENED_TRY(load_private_scalar(private_key, &private_scalar));
     HARDENED_TRY_WIPE_DMEM(p256_ecdh_start(&private_scalar, pk));
   } else {
     // Invalid value for `hw_backed`.

--- a/sw/device/lib/crypto/impl/ecc_p384.c
+++ b/sw/device/lib/crypto/impl/ecc_p384.c
@@ -24,8 +24,7 @@
  * @param private_key Sideloaded key handle.
  * @return OK or error.
  */
-OT_WARN_UNUSED_RESULT
-static status_t internal_p384_keygen_start(
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t internal_p384_keygen_start(
     const otcrypto_blinded_key_t *private_key) {
   if (private_key->config.hw_backed == kHardenedBoolTrue) {
     HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
@@ -39,6 +38,17 @@ static status_t internal_p384_keygen_start(
   } else {
     return OTCRYPTO_BAD_ARGS;
   }
+  return OTCRYPTO_OK;
+}
+
+OT_NOINLINE static status_t load_private_scalar(
+    const otcrypto_blinded_key_t *key, p384_masked_scalar_t *scalar) {
+  HARDENED_TRY(hardened_memcpy(scalar->share0, key->keyblob,
+                               kP384MaskedScalarTotalShareWords));
+  HARDENED_CHECK_EQ(hardened_memeq(key->keyblob, scalar->share0,
+                                   kP384MaskedScalarTotalShareWords),
+                    kHardenedBoolTrue);
+  scalar->checksum = p384_masked_scalar_checksum(scalar);
   return OTCRYPTO_OK;
 }
 
@@ -74,8 +84,7 @@ otcrypto_status_t otcrypto_ecdsa_p384_keygen_async_start(
  * @param private_key Private key struct to check.
  * @return OK if the lengths are correct or BAD_ARGS otherwise.
  */
-OT_WARN_UNUSED_RESULT
-static status_t p384_private_key_length_check(
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p384_private_key_length_check(
     const otcrypto_blinded_key_t *private_key) {
 #ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (private_key->keyblob == NULL) {
@@ -121,8 +130,7 @@ static status_t p384_private_key_length_check(
  * @param public_key Public key struct to check.
  * @return OK if the lengths are correct or BAD_ARGS otherwise.
  */
-OT_WARN_UNUSED_RESULT
-static status_t p384_public_key_length_check(
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p384_public_key_length_check(
     const otcrypto_unblinded_key_t *public_key) {
   if (public_key->key_length != sizeof(p384_point_t)) {
     return OTCRYPTO_BAD_ARGS;
@@ -143,8 +151,7 @@ static status_t p384_public_key_length_check(
  * @param[out] public_key Public key to populate.
  * @return OK or error.
  */
-OT_WARN_UNUSED_RESULT
-static status_t internal_p384_keygen_finalize(
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t internal_p384_keygen_finalize(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
   // Check the lengths of caller-allocated buffers.
   HARDENED_TRY(p384_private_key_length_check(private_key));
@@ -201,8 +208,8 @@ static status_t internal_p384_keygen_finalize(
  * @param len Length to check.
  * @return OK if the lengths are correct or BAD_ARGS otherwise.
  */
-OT_WARN_UNUSED_RESULT
-static status_t p384_signature_length_check(size_t len) {
+OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p384_signature_length_check(
+    size_t len) {
   if (len > UINT32_MAX / sizeof(uint32_t) ||
       len * sizeof(uint32_t) != sizeof(p384_ecdsa_signature_t)) {
     return OTCRYPTO_BAD_ARGS;
@@ -310,12 +317,7 @@ status_t otcrypto_ecc_p384_base_point_mult(
                     kHardenedBoolTrue);
 
   p384_masked_scalar_t private_scalar;
-  HARDENED_TRY(hardened_memcpy(private_scalar.share0, private_key->keyblob,
-                               kP384MaskedScalarTotalShareWords));
-  HARDENED_CHECK_EQ(hardened_memeq(private_key->keyblob, private_scalar.share0,
-                                   kP384MaskedScalarTotalShareWords),
-                    kHardenedBoolTrue);
-  private_scalar.checksum = p384_masked_scalar_checksum(&private_scalar);
+  HARDENED_TRY(load_private_scalar(private_key, &private_scalar));
 
   p384_point_t *pk = (p384_point_t *)public_key->key;
   HARDENED_TRY_WIPE_DMEM(p384_base_point_mult(&private_scalar, pk));
@@ -351,7 +353,7 @@ otcrypto_status_t otcrypto_ecdsa_p384_keygen_async_finalize(
   return otcrypto_eval_exit(keymgr_sideload_clear_otbn());
 }
 
-static otcrypto_status_t otcrypto_ecdsa_p384_sign_async_start_setup(
+OT_NOINLINE static otcrypto_status_t otcrypto_ecdsa_p384_sign_async_start_setup(
     const otcrypto_blinded_key_t *private_key,
     const otcrypto_hash_digest_t message_digest) {
 #ifndef OTCRYPTO_DISABLE_NULL_CHECKS
@@ -399,18 +401,15 @@ otcrypto_status_t otcrypto_ecdsa_p384_sign_config_k_async_start(
   HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
                     kHardenedBoolFalse);
   p384_masked_scalar_t private_scalar;
-  HARDENED_TRY(hardened_memcpy(private_scalar.share0, private_key->keyblob,
-                               kP384MaskedScalarTotalShareWords));
-  private_scalar.checksum = p384_masked_scalar_checksum(&private_scalar);
+  HARDENED_TRY(load_private_scalar(private_key, &private_scalar));
 
   // Load the secret scalar k.
   // The use of fixed scalars should be limited to KATs.
   HARDENED_CHECK_EQ(launder32(secret_scalar->config.hw_backed),
                     kHardenedBoolFalse);
   p384_masked_scalar_t config_k_scalar;
-  HARDENED_TRY(hardened_memcpy(config_k_scalar.share0, secret_scalar->keyblob,
-                               kP384MaskedScalarTotalShareWords));
-  config_k_scalar.checksum = p384_masked_scalar_checksum(&config_k_scalar);
+  HARDENED_TRY(load_private_scalar(secret_scalar, &config_k_scalar));
+
   HARDENED_TRY_WIPE_DMEM(p384_ecdsa_sign_config_k_start(
       message_digest.data, &private_scalar, &config_k_scalar));
 
@@ -437,13 +436,7 @@ otcrypto_status_t otcrypto_ecdsa_p384_sign_async_start(
     HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
                       kHardenedBoolFalse);
     p384_masked_scalar_t private_scalar;
-    HARDENED_TRY(hardened_memcpy(private_scalar.share0, private_key->keyblob,
-                                 kP384MaskedScalarTotalShareWords));
-    HARDENED_CHECK_EQ(
-        hardened_memeq(private_key->keyblob, private_scalar.share0,
-                       kP384MaskedScalarTotalShareWords),
-        kHardenedBoolTrue);
-    private_scalar.checksum = p384_masked_scalar_checksum(&private_scalar);
+    HARDENED_TRY(load_private_scalar(private_key, &private_scalar));
     HARDENED_TRY_WIPE_DMEM(
         p384_ecdsa_sign_start(message_digest.data, &private_scalar));
   } else if (private_key->config.hw_backed == kHardenedBoolTrue) {
@@ -645,13 +638,7 @@ otcrypto_status_t otcrypto_ecdh_p384_async_start(
     HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
                       kHardenedBoolFalse);
     p384_masked_scalar_t private_scalar;
-    HARDENED_TRY(hardened_memcpy(private_scalar.share0, private_key->keyblob,
-                                 kP384MaskedScalarTotalShareWords));
-    HARDENED_CHECK_EQ(
-        hardened_memeq(private_key->keyblob, private_scalar.share0,
-                       kP384MaskedScalarTotalShareWords),
-        kHardenedBoolTrue);
-    private_scalar.checksum = p384_masked_scalar_checksum(&private_scalar);
+    HARDENED_TRY(load_private_scalar(private_key, &private_scalar));
     HARDENED_TRY_WIPE_DMEM(p384_ecdh_start(&private_scalar, pk));
   } else {
     // Invalid value for `hw_backed`.


### PR DESCRIPTION
Refactor p256 and p384 to save on code size by making subroutines which are used accross multiple functions.