### PR TITLE
[crypto] Create a compile time option for NULL checks

### DIFF
--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -53,6 +53,19 @@ Moreover, the function also checks the entropy complex health test and alert con
 
 {{#header-snippet sw/device/lib/crypto/include/config.h otcrypto_eval_exit }}
 
+## Build Configurations
+
+The OpenTitan cryptography library provides several compile-time configuration settings via Bazel. These flags allow you to optimize code size, enable deep debugging, or mark the library for release.
+
+You can activate these settings during the build process by passing `--define=<setting>=true` to Bazel.
+
+| Configuration Setting | Internal Define | Description |
+|---|---|---|
+| `crypto_status_debug` | `OTCRYPTO_STATUS_DEBUG` | Embeds the module ID and line number directly into `otcrypto_status_t` error codes. This significantly aids debugging but increases the footprint and alters standard error structures. |
+| `release_build` | `CRYPTOLIB_IS_RELEASED` | Marks the build as a frozen release version. This directly updates the `released` boolean flag retrieved when calling `otcrypto_build_info()`. |
+| `disable_null_checks` | `OTCRYPTO_DISABLE_NULL_CHECKS` | Removes `NULL` pointer checks on API inputs throughout the library (e.g., AES-GCM operations). This saves code size, but strictly requires the caller to guarantee no `NULL` pointers are passed. |
+| `disable_buf_integrity_checks` | `OTCRYPTO_DISABLE_BUF_INTEGRITY_CHECKS` | Disables runtime integrity verification for data buffers. This bypasses `verify_buf_integrity`, removing the check that compares `ptr_checksum` against the data's calculated checksum. |
+
 ## Cryptolib Usage Examples
 
 Examples of how to use the cryptolib API are provided in the [cryptolib test directory][crypto-tests].

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -28,6 +28,13 @@ config_setting(
     },
 )
 
+config_setting(
+    name = "disable_null_checks",
+    define_values = {
+        "disable_null_checks": "true",
+    },
+)
+
 cc_library(
     name = "aes",
     srcs = ["aes.c"],
@@ -377,10 +384,16 @@ cc_library(
     hdrs = [
         "status.h",
     ],
-    # Turn debugging on only if the `crypto_status_debug` command-line option
-    # is set.
     defines = select({
+        # Turn debugging on only if the `crypto_status_debug` command-line option
+        # is set.
         ":crypto_status_debug": ["OTCRYPTO_STATUS_DEBUG"],
+        "//conditions:default": [],
+    }) + select({
+        # This disables NULL checks on API input to save code size
+        # Activate it by building the library with `--define=disable_null_checks=true`
+        # The status header is used in all API functions to pass a bad status hence it propagates to where the flag is needed
+        ":disable_null_checks": ["OTCRYPTO_DISABLE_NULL_CHECKS"],
         "//conditions:default": [],
     }),
     deps = [

--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -457,10 +457,12 @@ static otcrypto_status_t otcrypto_aes_impl(
 otcrypto_status_t otcrypto_aes_padding_strip(
     otcrypto_byte_buf_t *padded_plaintext, otcrypto_aes_padding_t aes_padding,
     size_t *plaintext_len) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (padded_plaintext == NULL || padded_plaintext->data == NULL ||
       plaintext_len == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Input must be a non-zero multiple of the AES block size.
   if (padded_plaintext->len == 0 ||
@@ -543,6 +545,7 @@ otcrypto_status_t otcrypto_aes(otcrypto_blinded_key_t *key,
                                const otcrypto_const_byte_buf_t *cipher_input,
                                otcrypto_aes_padding_t aes_padding,
                                otcrypto_byte_buf_t *cipher_output) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for NULL pointers in input pointers and data buffers.
   if (key == NULL || key->keyblob == NULL ||
       (aes_mode != kOtcryptoAesModeEcb && (iv == NULL || iv->data == NULL)) ||
@@ -550,6 +553,7 @@ otcrypto_status_t otcrypto_aes(otcrypto_blinded_key_t *key,
       (cipher_output == NULL || cipher_output->data == NULL)) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   if (launder32(key->config.security_level) == kOtcryptoKeySecurityLevelLow) {
     HARDENED_CHECK_EQ(key->config.security_level, kOtcryptoKeySecurityLevelLow);

--- a/sw/device/lib/crypto/impl/aes_gcm.c
+++ b/sw/device/lib/crypto/impl/aes_gcm.c
@@ -285,6 +285,7 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt(
     const otcrypto_const_word32_buf_t *iv, const otcrypto_const_byte_buf_t *aad,
     otcrypto_aes_gcm_tag_len_t tag_len, otcrypto_byte_buf_t *ciphertext,
     otcrypto_word32_buf_t *auth_tag) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for NULL pointers in input pointers and required-nonzero-length data
   // buffers.
   if (key == NULL || iv == NULL || iv->data == NULL || auth_tag == NULL ||
@@ -301,6 +302,7 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt(
       (plaintext->len != 0 && plaintext->data == NULL)) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Ensure the plaintext and ciphertext lengths match.
   if (launder32(ciphertext->len) != plaintext->len) {
@@ -343,6 +345,7 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt(
     otcrypto_aes_gcm_tag_len_t tag_len,
     const otcrypto_const_word32_buf_t *auth_tag, otcrypto_byte_buf_t *plaintext,
     hardened_bool_t *success) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for NULL pointers in input pointers and required-nonzero-length data
   // buffers.
   if (key == NULL || key->keyblob == NULL || iv == NULL || iv->data == NULL ||
@@ -358,6 +361,7 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt(
       (plaintext->len != 0 && plaintext->data == NULL)) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Construct the AES key.
   aes_key_t aes_key;
@@ -394,10 +398,12 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt(
 otcrypto_status_t otcrypto_aes_gcm_encrypt_init(
     otcrypto_blinded_key_t *key, const otcrypto_const_word32_buf_t *iv,
     otcrypto_aes_gcm_context_t *ctx) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (key == NULL || key->keyblob == NULL || iv == NULL || iv->data == NULL ||
       ctx == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Construct the AES key.
   aes_key_t aes_key;
@@ -422,10 +428,12 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_init(
 otcrypto_status_t otcrypto_aes_gcm_decrypt_init(
     otcrypto_blinded_key_t *key, const otcrypto_const_word32_buf_t *iv,
     otcrypto_aes_gcm_context_t *ctx) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (key == NULL || key->keyblob == NULL || iv == NULL || iv->data == NULL ||
       ctx == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Construct the AES key.
   aes_key_t aes_key;
@@ -449,9 +457,11 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt_init(
 
 otcrypto_status_t otcrypto_aes_gcm_update_aad(
     otcrypto_aes_gcm_context_t *ctx, const otcrypto_const_byte_buf_t *aad) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (ctx == NULL || aad == NULL || aad->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   if (aad->len == 0) {
     // Nothing to do.
@@ -480,10 +490,12 @@ otcrypto_status_t otcrypto_aes_gcm_update_aad(
 otcrypto_status_t otcrypto_aes_gcm_update_encrypted_data(
     otcrypto_aes_gcm_context_t *ctx, const otcrypto_const_byte_buf_t *input,
     otcrypto_byte_buf_t *output, size_t *output_bytes_written) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (ctx == NULL || input == NULL || input->data == NULL || output == NULL ||
       output->data == NULL || output_bytes_written == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   *output_bytes_written = 0;
 
   if (input->len == 0) {
@@ -533,6 +545,7 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_final(
     otcrypto_aes_gcm_context_t *ctx, otcrypto_aes_gcm_tag_len_t tag_len,
     otcrypto_byte_buf_t *ciphertext, size_t *ciphertext_bytes_written,
     otcrypto_word32_buf_t *auth_tag) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (ctx == NULL || ciphertext_bytes_written == NULL || auth_tag == NULL ||
       auth_tag->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -541,6 +554,7 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_final(
       (ciphertext->len != 0 && ciphertext->data == NULL)) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   *ciphertext_bytes_written = 0;
 
   // Check the tag length.
@@ -584,6 +598,7 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt_final(
     const otcrypto_const_word32_buf_t *auth_tag,
     otcrypto_aes_gcm_tag_len_t tag_len, otcrypto_byte_buf_t *plaintext,
     size_t *plaintext_bytes_written, hardened_bool_t *success) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (ctx == NULL || plaintext_bytes_written == NULL || auth_tag == NULL ||
       auth_tag->data == NULL || success == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -591,6 +606,7 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt_final(
   if (plaintext == NULL || (plaintext->len != 0 && plaintext->data == NULL)) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   *plaintext_bytes_written = 0;
   *success = kHardenedBoolFalse;
 

--- a/sw/device/lib/crypto/impl/cmac.c
+++ b/sw/device/lib/crypto/impl/cmac.c
@@ -63,9 +63,11 @@ enum {
  * Checks for NULL pointers or invalid settings in the blinded key.
  */
 static status_t check_key(const otcrypto_blinded_key_t *key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (key == NULL || key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   // Check the integrity of the key.
   if (launder32(otcrypto_integrity_blinded_key_check(key)) !=
       kHardenedBoolTrue) {
@@ -321,10 +323,12 @@ OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_cmac(const otcrypto_blinded_key_t *key,
                                 const otcrypto_const_byte_buf_t *input_message,
                                 otcrypto_word32_buf_t *tag) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (tag == NULL || tag->data == NULL || input_message == NULL ||
       (input_message->data == NULL && input_message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   HARDENED_TRY(hardened_memshred(tag->data, tag->len));
   HARDENED_TRY(check_key(key));
 
@@ -401,9 +405,11 @@ otcrypto_status_t otcrypto_cmac(const otcrypto_blinded_key_t *key,
 
 otcrypto_status_t otcrypto_cmac_init(otcrypto_cmac_context_t *ctx,
                                      const otcrypto_blinded_key_t *key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (ctx == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   HARDENED_TRY(check_key(key));
 
   if (launder32(key->config.hw_backed) == kHardenedBoolTrue) {
@@ -459,12 +465,14 @@ otcrypto_status_t otcrypto_cmac_init(otcrypto_cmac_context_t *ctx,
 otcrypto_status_t otcrypto_cmac_update(
     otcrypto_cmac_context_t *const ctx,
     const otcrypto_const_byte_buf_t *input_message) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (ctx == NULL || input_message == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
   if (input_message->data == NULL && input_message->len != 0) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   otcrypto_key_security_level_t security_level =
       (otcrypto_key_security_level_t)ctx->data[kCtxSecurityLevelOffset];
@@ -507,9 +515,11 @@ otcrypto_status_t otcrypto_cmac_update(
 
 otcrypto_status_t otcrypto_cmac_final(otcrypto_cmac_context_t *const ctx,
                                       otcrypto_word32_buf_t *tag) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (ctx == NULL || tag == NULL || tag->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   otcrypto_key_security_level_t security_level =
       (otcrypto_key_security_level_t)ctx->data[kCtxSecurityLevelOffset];

--- a/sw/device/lib/crypto/impl/drbg.c
+++ b/sw/device/lib/crypto/impl/drbg.c
@@ -108,10 +108,12 @@ static otcrypto_status_t seed_material_xor(
 
 otcrypto_status_t otcrypto_drbg_instantiate(
     const otcrypto_const_byte_buf_t *perso_string) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for NULL pointers or bad length.
   if (perso_string->len != 0 && perso_string->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   entropy_seed_material_t seed_material;
   HARDENED_TRY(
@@ -125,11 +127,13 @@ otcrypto_status_t otcrypto_drbg_instantiate(
 
 otcrypto_status_t otcrypto_drbg_reseed(
     const otcrypto_const_byte_buf_t *additional_input) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for NULL pointers or bad length.
   if (additional_input == NULL ||
       (additional_input->len != 0 && additional_input->data == NULL)) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   entropy_seed_material_t seed_material;
   HARDENED_TRY(
@@ -143,11 +147,16 @@ otcrypto_status_t otcrypto_drbg_reseed(
 otcrypto_status_t otcrypto_drbg_manual_instantiate(
     const otcrypto_const_byte_buf_t *entropy,
     const otcrypto_const_byte_buf_t *perso_string) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for NULL pointers or bad length.
   if (perso_string->len != 0 && perso_string->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
-  if (entropy->data == NULL || entropy->len != kEntropySeedBytes) {
+  if (entropy->data == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+#endif
+  if (entropy->len != kEntropySeedBytes) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -164,13 +173,17 @@ otcrypto_status_t otcrypto_drbg_manual_instantiate(
 otcrypto_status_t otcrypto_drbg_manual_reseed(
     const otcrypto_const_byte_buf_t *entropy,
     const otcrypto_const_byte_buf_t *additional_input) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for NULL pointers or bad length.
   if (additional_input == NULL ||
       (additional_input->len != 0 && additional_input->data == NULL)) {
     return OTCRYPTO_BAD_ARGS;
   }
-  if (entropy == NULL || entropy->data == NULL ||
-      entropy->len != kEntropySeedBytes) {
+  if (entropy == NULL || entropy->data == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+#endif
+  if (entropy->len != kEntropySeedBytes) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -215,11 +228,13 @@ otcrypto_status_t otcrypto_drbg_generate(
     // Nothing to do.
     return OTCRYPTO_OK;
   }
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (additional_input == NULL ||
       (additional_input->len != 0 && additional_input->data == NULL) ||
       drbg_output == NULL || drbg_output->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Randomize destination buffer.
   HARDENED_TRY(hardened_memshred(drbg_output->data, drbg_output->len));
@@ -235,11 +250,13 @@ otcrypto_status_t otcrypto_drbg_manual_generate(
     // Nothing to do.
     return OTCRYPTO_OK;
   }
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (additional_input == NULL ||
       (additional_input->len != 0 && additional_input->data == NULL) ||
       drbg_output == NULL || drbg_output->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   return otcrypto_eval_exit(generate(/*fips_check=*/kHardenedBoolFalse,
                                      additional_input, drbg_output));

--- a/sw/device/lib/crypto/impl/ecc_curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc_curve25519.c
@@ -36,9 +36,11 @@ OT_WARN_UNUSED_RESULT
 static status_t curve25519_private_key_length_check(
     const otcrypto_blinded_key_t *private_key,
     otcrypto_key_mode_t expected_mode) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (private_key == NULL || private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   if (private_key->config.hw_backed == kHardenedBoolTrue) {
     // Skip the length check in this case; if the salt is the wrong length, the
@@ -86,9 +88,14 @@ static status_t curve25519_private_key_length_check(
 OT_WARN_UNUSED_RESULT
 static status_t curve25519_public_key_length_check(
     const otcrypto_unblinded_key_t *key, otcrypto_key_mode_t expected_mode) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
+  if (key == NULL || key->key == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+#endif
   // Check the key struct and key length.
-  if (key == NULL || key->key_length != kCurve25519KeyBytes ||
-      key->key == NULL || key->key_mode != expected_mode) {
+  if (key->key_length != kCurve25519KeyBytes ||
+      key->key_mode != expected_mode) {
     return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_CHECK_EQ(launder32(key->key_mode), expected_mode);
@@ -116,10 +123,14 @@ static status_t curve25519_public_key_length_check(
  */
 OT_WARN_UNUSED_RESULT
 static status_t ed25519_signature_check(otcrypto_word32_buf_t *signature) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
+  if (signature == NULL || signature->data == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+#endif
   // Check the signature struct and signature length.
-  if (signature == NULL || signature->len > UINT32_MAX / sizeof(uint32_t) ||
-      signature->len * sizeof(uint32_t) != sizeof(curve25519_signature_t) ||
-      signature->data == NULL) {
+  if (signature->len > UINT32_MAX / sizeof(uint32_t) ||
+      signature->len * sizeof(uint32_t) != sizeof(curve25519_signature_t)) {
     return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_CHECK_EQ(launder32(signature->len) * sizeof(uint32_t),
@@ -166,10 +177,12 @@ static status_t ed25519_message_prehash(
     otcrypto_eddsa_sign_mode_t sign_mode,
     const otcrypto_const_byte_buf_t *input_message,
     otcrypto_byte_buf_t *message_ph, uint32_t *prehash_buffer) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Only a message of length zero can have NULL as data.
   if (input_message->data == NULL && input_message->len != 0) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Instantiate variable for an FI check on the sign mode used.
   otcrypto_eddsa_sign_mode_t sign_mode_used = launder32(0);
@@ -329,9 +342,11 @@ static otcrypto_status_t ed25519_compute_scalar_and_prefix(
 otcrypto_status_t otcrypto_ed25519_public_key_from_private(
     const otcrypto_blinded_key_t *private_key,
     otcrypto_unblinded_key_t *public_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (public_key == NULL || public_key->key == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   // Start the execution of the key generation.
   HARDENED_TRY(
       otcrypto_ed25519_public_key_from_private_async_start(private_key));
@@ -390,9 +405,11 @@ otcrypto_status_t otcrypto_ed25519_verify(
     otcrypto_eddsa_sign_mode_t sign_mode,
     const otcrypto_const_word32_buf_t *signature,
     hardened_bool_t *verification_result) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (verification_result == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   uint32_t prehash_buffer[kCurve25519HashWords];
   otcrypto_byte_buf_t message_ph;
@@ -630,9 +647,11 @@ otcrypto_status_t otcrypto_ed25519_verify_async_start(
 
   // Do some signature struct validity checks.
   HARDENED_TRY(ed25519_signature_check((otcrypto_word32_buf_t *)signature));
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (signature->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Compute SHA512(R || A || PH(M)).
   curve25519_signature_t sig_curve25519;

--- a/sw/device/lib/crypto/impl/ecc_p256.c
+++ b/sw/device/lib/crypto/impl/ecc_p256.c
@@ -179,10 +179,12 @@ otcrypto_status_t otcrypto_ecdsa_p256_sign_config_k(
     const otcrypto_blinded_key_t *secret_scalar,
     const otcrypto_hash_digest_t message_digest,
     otcrypto_word32_buf_t *signature) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (signature->data == NULL || private_key == NULL ||
       private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   if (!status_ok(p256_signature_length_check(signature->len)) ||
       !status_ok(p256_private_key_length_check(private_key))) {
     return OTCRYPTO_BAD_ARGS;
@@ -196,10 +198,12 @@ otcrypto_status_t otcrypto_ecdsa_p256_sign(
     const otcrypto_blinded_key_t *private_key,
     const otcrypto_hash_digest_t message_digest,
     otcrypto_word32_buf_t *signature) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (signature->data == NULL || private_key == NULL ||
       private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   if (!status_ok(p256_signature_length_check(signature->len)) ||
       !status_ok(p256_private_key_length_check(private_key))) {
     return OTCRYPTO_BAD_ARGS;
@@ -256,9 +260,11 @@ otcrypto_status_t otcrypto_ecdh_p256(const otcrypto_blinded_key_t *private_key,
 
 otcrypto_status_t otcrypto_ecc_p256_point_on_curve(
     const otcrypto_unblinded_key_t *point, hardened_bool_t *check_result) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (point == NULL || point->key == NULL || check_result == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   p256_point_t *pt = (p256_point_t *)point->key;
   HARDENED_TRY(p256_point_on_curve_check(pt, check_result));
@@ -269,9 +275,11 @@ otcrypto_status_t otcrypto_ecc_p256_point_on_curve(
 status_t otcrypto_ecc_p256_base_point_mult(
     const otcrypto_blinded_key_t *private_key,
     otcrypto_unblinded_key_t *public_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (private_key == NULL || public_key == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   HARDENED_CHECK_EQ(otcrypto_integrity_blinded_key_check(private_key),
                     kHardenedBoolTrue);
@@ -319,9 +327,11 @@ static status_t internal_p256_keygen_start(
 
 otcrypto_status_t otcrypto_ecdsa_p256_keygen_async_start(
     const otcrypto_blinded_key_t *private_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (private_key == NULL || private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the key mode.
   if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP256) {
@@ -337,11 +347,13 @@ otcrypto_status_t otcrypto_ecdsa_p256_keygen_async_start(
 
 otcrypto_status_t otcrypto_ecdsa_p256_keygen_async_finalize(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for any NULL pointers.
   if (private_key == NULL || public_key == NULL ||
       private_key->keyblob == NULL || public_key->key == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the key modes.
   if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP256 ||
@@ -361,9 +373,11 @@ otcrypto_status_t otcrypto_ecdsa_p256_keygen_async_finalize(
 otcrypto_status_t otcrypto_ecdsa_p256_dice_keygen_async_start(
     const otcrypto_blinded_key_t *private_key,
     const otcrypto_const_word32_buf_t *attestation_seed) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (private_key == NULL || private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the key mode.
   if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP256) {
@@ -391,10 +405,12 @@ otcrypto_status_t otcrypto_ecdsa_p256_dice_keygen_async_finalize(
 static otcrypto_status_t otcrypto_ecdsa_p256_sign_async_start_setup(
     const otcrypto_blinded_key_t *private_key,
     const otcrypto_hash_digest_t message_digest) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (private_key == NULL || private_key->keyblob == NULL ||
       message_digest.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the integrity of the private key.
   if (otcrypto_integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
@@ -504,9 +520,11 @@ otcrypto_status_t otcrypto_ecdsa_p256_sign_async_start(
 
 otcrypto_status_t otcrypto_ecdsa_p256_sign_async_finalize(
     otcrypto_word32_buf_t *signature) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (signature->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Verify the input buffer
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(signature));
@@ -526,10 +544,12 @@ otcrypto_status_t otcrypto_ecdsa_p256_dice_sign_async_start(
     const otcrypto_blinded_key_t *private_key,
     const otcrypto_hash_digest_t message_digest,
     const otcrypto_const_word32_buf_t *attestation_seed) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (private_key == NULL || private_key->keyblob == NULL ||
       message_digest.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the key mode.
   if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP256) {
@@ -564,10 +584,12 @@ otcrypto_status_t otcrypto_ecdsa_p256_verify_async_start(
     const otcrypto_unblinded_key_t *public_key,
     const otcrypto_hash_digest_t message_digest,
     const otcrypto_const_word32_buf_t *signature) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (public_key == NULL || signature->data == NULL ||
       message_digest.data == NULL || public_key->key == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the integrity of the public key.
   if (otcrypto_integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
@@ -612,9 +634,11 @@ otcrypto_status_t otcrypto_ecdsa_p256_verify_async_start(
 otcrypto_status_t otcrypto_ecdsa_p256_verify_async_finalize(
     const otcrypto_const_word32_buf_t *signature,
     hardened_bool_t *verification_result) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (verification_result == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Verify the input buffer
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(signature));
@@ -627,9 +651,11 @@ otcrypto_status_t otcrypto_ecdsa_p256_verify_async_finalize(
 
 otcrypto_status_t otcrypto_ecdh_p256_keygen_async_start(
     const otcrypto_blinded_key_t *private_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (private_key == NULL || private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   if (private_key->config.key_mode != kOtcryptoKeyModeEcdhP256) {
     return OTCRYPTO_BAD_ARGS;
@@ -644,11 +670,13 @@ otcrypto_status_t otcrypto_ecdh_p256_keygen_async_start(
 
 otcrypto_status_t otcrypto_ecdh_p256_keygen_async_finalize(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for any NULL pointers.
   if (private_key == NULL || public_key == NULL ||
       private_key->keyblob == NULL || public_key->key == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   if (public_key->key_mode != kOtcryptoKeyModeEcdhP256 ||
       private_key->config.key_mode != kOtcryptoKeyModeEcdhP256) {
@@ -665,10 +693,12 @@ otcrypto_status_t otcrypto_ecdh_p256_keygen_async_finalize(
 otcrypto_status_t otcrypto_ecdh_p256_async_start(
     const otcrypto_blinded_key_t *private_key,
     const otcrypto_unblinded_key_t *public_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (private_key == NULL || public_key == NULL || public_key->key == NULL ||
       private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the integrity of the keys.
   if (otcrypto_integrity_blinded_key_check(private_key) != kHardenedBoolTrue ||
@@ -732,9 +762,11 @@ otcrypto_status_t otcrypto_ecdh_p256_async_start(
 
 otcrypto_status_t otcrypto_ecdh_p256_async_finalize(
     otcrypto_blinded_key_t *shared_secret) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (shared_secret == NULL || shared_secret->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Randomize the output before computing it.
   HARDENED_TRY(hardened_memshred(shared_secret->keyblob, kP256CoordWords));
@@ -782,10 +814,12 @@ otcrypto_status_t otcrypto_ecdh_p256_async_finalize(
 otcrypto_status_t otcrypto_ecc_p256_public_key_import(
     const otcrypto_const_word32_buf_t x, const otcrypto_const_word32_buf_t y,
     otcrypto_unblinded_key_t *public_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (x.data == NULL || y.data == NULL || public_key == NULL ||
       public_key->key == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the lengths of the input coordinate buffers.
   if (x.len != kP256CoordWords || y.len != kP256CoordWords) {
@@ -818,10 +852,12 @@ otcrypto_status_t otcrypto_ecc_p256_public_key_import(
 otcrypto_status_t otcrypto_ecc_p256_public_key_export(
     const otcrypto_unblinded_key_t *public_key, otcrypto_word32_buf_t *x,
     otcrypto_word32_buf_t *y) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (x == NULL || x->data == NULL || y == NULL || y->data == NULL ||
       public_key == NULL || public_key->key == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the lengths of the output coordinate buffers.
   if (x->len != kP256CoordWords || y->len != kP256CoordWords) {
@@ -856,10 +892,12 @@ otcrypto_status_t otcrypto_ecc_p256_public_key_export(
 otcrypto_status_t otcrypto_ecc_p256_private_key_import(
     otcrypto_const_word32_buf_t share0, otcrypto_const_word32_buf_t share1,
     otcrypto_blinded_key_t *private_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (share0.data == NULL || share1.data == NULL || private_key == NULL ||
       private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Each share must be 320 bits (256-bit scalar + 64 redundant bits for
   // side-channel protection).
@@ -908,11 +946,13 @@ otcrypto_status_t otcrypto_ecc_p256_private_key_import(
 otcrypto_status_t otcrypto_ecc_p256_private_key_export(
     const otcrypto_blinded_key_t *private_key, otcrypto_word32_buf_t *share0,
     otcrypto_word32_buf_t *share1) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (share0 == NULL || share0->data == NULL || share1 == NULL ||
       share1->data == NULL || private_key == NULL ||
       private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the output buffer lengths: each must be exactly 320 bits (256-bit
   // scalar + 64 redundant bits for side-channel protection).
@@ -969,10 +1009,12 @@ otcrypto_status_t otcrypto_ecc_p256_arith_share_private_key(
     const otcrypto_const_word32_buf_t *bool_private_key_share0,
     const otcrypto_const_word32_buf_t *bool_private_key_share1,
     otcrypto_blinded_key_t *arith_private_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (bool_private_key_share0 == NULL || bool_private_key_share1 == NULL ||
       arith_private_key == NULL || arith_private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // The key shares must resided in 320-bit buffers.
   if (bool_private_key_share0->len != kP256MaskedScalarShareWords ||

--- a/sw/device/lib/crypto/impl/ecc_p384.c
+++ b/sw/device/lib/crypto/impl/ecc_p384.c
@@ -44,9 +44,11 @@ static status_t internal_p384_keygen_start(
 
 otcrypto_status_t otcrypto_ecdsa_p384_keygen_async_start(
     const otcrypto_blinded_key_t *private_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (private_key == NULL || private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the key mode.
   if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP384) {
@@ -75,9 +77,11 @@ otcrypto_status_t otcrypto_ecdsa_p384_keygen_async_start(
 OT_WARN_UNUSED_RESULT
 static status_t p384_private_key_length_check(
     const otcrypto_blinded_key_t *private_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   if (private_key->config.hw_backed == kHardenedBoolTrue) {
     // Skip the length check in this case; if the salt is the wrong length, the
@@ -126,6 +130,7 @@ static status_t p384_public_key_length_check(
   HARDENED_CHECK_EQ(launder32(public_key->key_length), sizeof(p384_point_t));
   return OTCRYPTO_OK;
 }
+
 /**
  * Finalize a keypair generation operation for curve P-384.
  *
@@ -280,9 +285,11 @@ otcrypto_status_t otcrypto_ecdh_p384(const otcrypto_blinded_key_t *private_key,
 
 otcrypto_status_t otcrypto_ecc_p384_point_on_curve(
     const otcrypto_unblinded_key_t *point, hardened_bool_t *check_result) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (point == NULL || point->key == NULL || check_result == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   p384_point_t *pt = (p384_point_t *)point->key;
   HARDENED_TRY(p384_point_on_curve_check(pt, check_result));
@@ -293,9 +300,11 @@ otcrypto_status_t otcrypto_ecc_p384_point_on_curve(
 status_t otcrypto_ecc_p384_base_point_mult(
     const otcrypto_blinded_key_t *private_key,
     otcrypto_unblinded_key_t *public_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (private_key == NULL || public_key == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   HARDENED_CHECK_EQ(otcrypto_integrity_blinded_key_check(private_key),
                     kHardenedBoolTrue);
@@ -318,11 +327,13 @@ status_t otcrypto_ecc_p384_base_point_mult(
 
 otcrypto_status_t otcrypto_ecdsa_p384_keygen_async_finalize(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for any NULL pointers.
   if (private_key == NULL || public_key == NULL ||
       private_key->keyblob == NULL || public_key->key == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the key modes.
   if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP384 ||
@@ -343,10 +354,12 @@ otcrypto_status_t otcrypto_ecdsa_p384_keygen_async_finalize(
 static otcrypto_status_t otcrypto_ecdsa_p384_sign_async_start_setup(
     const otcrypto_blinded_key_t *private_key,
     const otcrypto_hash_digest_t message_digest) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (private_key == NULL || private_key->keyblob == NULL ||
       message_digest.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the integrity of the private key.
   if (otcrypto_integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
@@ -456,9 +469,11 @@ otcrypto_status_t otcrypto_ecdsa_p384_sign_async_start(
 
 otcrypto_status_t otcrypto_ecdsa_p384_sign_async_finalize(
     otcrypto_word32_buf_t *signature) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (signature->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Verify the input buffer
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(signature));
@@ -473,14 +488,17 @@ otcrypto_status_t otcrypto_ecdsa_p384_sign_async_finalize(
   // Clear the OTBN sideload slot (in case the key was sideloaded).
   return otcrypto_eval_exit(keymgr_sideload_clear_otbn());
 }
+
 otcrypto_status_t otcrypto_ecdsa_p384_verify_async_start(
     const otcrypto_unblinded_key_t *public_key,
     const otcrypto_hash_digest_t message_digest,
     const otcrypto_const_word32_buf_t *signature) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (public_key == NULL || signature->data == NULL ||
       message_digest.data == NULL || public_key->key == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the integrity of the public key.
   if (otcrypto_integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
@@ -525,9 +543,11 @@ otcrypto_status_t otcrypto_ecdsa_p384_verify_async_start(
 otcrypto_status_t otcrypto_ecdsa_p384_verify_async_finalize(
     const otcrypto_const_word32_buf_t *signature,
     hardened_bool_t *verification_result) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (verification_result == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Verify the input buffer
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(signature));
@@ -543,9 +563,11 @@ otcrypto_status_t otcrypto_ecdsa_p384_verify_async_finalize(
 
 otcrypto_status_t otcrypto_ecdh_p384_keygen_async_start(
     const otcrypto_blinded_key_t *private_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (private_key == NULL || private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   if (private_key->config.key_mode != kOtcryptoKeyModeEcdhP384) {
     return OTCRYPTO_BAD_ARGS;
@@ -558,11 +580,13 @@ otcrypto_status_t otcrypto_ecdh_p384_keygen_async_start(
 
 otcrypto_status_t otcrypto_ecdh_p384_keygen_async_finalize(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for any NULL pointers.
   if (private_key == NULL || public_key == NULL ||
       private_key->keyblob == NULL || public_key->key == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   if (public_key->key_mode != kOtcryptoKeyModeEcdhP384 ||
       private_key->config.key_mode != kOtcryptoKeyModeEcdhP384) {
@@ -579,10 +603,12 @@ otcrypto_status_t otcrypto_ecdh_p384_keygen_async_finalize(
 otcrypto_status_t otcrypto_ecdh_p384_async_start(
     const otcrypto_blinded_key_t *private_key,
     const otcrypto_unblinded_key_t *public_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (private_key == NULL || public_key == NULL || public_key->key == NULL ||
       private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the integrity of the keys.
   if (otcrypto_integrity_blinded_key_check(private_key) != kHardenedBoolTrue ||
@@ -646,9 +672,11 @@ otcrypto_status_t otcrypto_ecdh_p384_async_start(
 
 otcrypto_status_t otcrypto_ecdh_p384_async_finalize(
     otcrypto_blinded_key_t *shared_secret) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (shared_secret == NULL || shared_secret->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Randomize the output before computing it.
   HARDENED_TRY(hardened_memshred(shared_secret->keyblob, kP384CoordWords));
@@ -696,10 +724,12 @@ otcrypto_status_t otcrypto_ecdh_p384_async_finalize(
 otcrypto_status_t otcrypto_ecc_p384_public_key_import(
     const otcrypto_const_word32_buf_t x, const otcrypto_const_word32_buf_t y,
     otcrypto_unblinded_key_t *public_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (x.data == NULL || y.data == NULL || public_key == NULL ||
       public_key->key == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the lengths of the input coordinate buffers.
   if (x.len != kP384CoordWords || y.len != kP384CoordWords) {
@@ -732,10 +762,12 @@ otcrypto_status_t otcrypto_ecc_p384_public_key_import(
 otcrypto_status_t otcrypto_ecc_p384_public_key_export(
     const otcrypto_unblinded_key_t *public_key, otcrypto_word32_buf_t *x,
     otcrypto_word32_buf_t *y) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (x == NULL || x->data == NULL || y == NULL || y->data == NULL ||
       public_key == NULL || public_key->key == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the lengths of the output coordinate buffers.
   if (x->len != kP384CoordWords || y->len != kP384CoordWords) {
@@ -770,10 +802,12 @@ otcrypto_status_t otcrypto_ecc_p384_public_key_export(
 otcrypto_status_t otcrypto_ecc_p384_private_key_import(
     otcrypto_const_word32_buf_t share0, otcrypto_const_word32_buf_t share1,
     otcrypto_blinded_key_t *private_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (share0.data == NULL || share1.data == NULL || private_key == NULL ||
       private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Each share must be 448 bits (384-bit scalar + 64 redundant bits for
   // side-channel protection).
@@ -822,11 +856,13 @@ otcrypto_status_t otcrypto_ecc_p384_private_key_import(
 otcrypto_status_t otcrypto_ecc_p384_private_key_export(
     const otcrypto_blinded_key_t *private_key, otcrypto_word32_buf_t *share0,
     otcrypto_word32_buf_t *share1) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (share0 == NULL || share0->data == NULL || share1 == NULL ||
       share1->data == NULL || private_key == NULL ||
       private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the output buffer lengths: each must be exactly 448 bits (384-bit
   // scalar + 64 redundant bits for side-channel protection).
@@ -883,10 +919,12 @@ otcrypto_status_t otcrypto_ecc_p384_arith_share_private_key(
     const otcrypto_const_word32_buf_t *bool_private_key_share0,
     const otcrypto_const_word32_buf_t *bool_private_key_share1,
     otcrypto_blinded_key_t *arith_private_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (bool_private_key_share0 == NULL || bool_private_key_share1 == NULL ||
       arith_private_key == NULL || arith_private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // The key shares must resided in 448-bit buffers.
   if (bool_private_key_share0->len != kP384MaskedScalarShareWords ||

--- a/sw/device/lib/crypto/impl/hkdf.c
+++ b/sw/device/lib/crypto/impl/hkdf.c
@@ -138,6 +138,7 @@ static status_t hkdf_check_prk(size_t digest_words,
 otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t *ikm,
                                         const otcrypto_const_byte_buf_t *salt,
                                         otcrypto_blinded_key_t *prk) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for null pointers.
   if (ikm == NULL || ikm->keyblob == NULL || prk == NULL ||
       prk->keyblob == NULL) {
@@ -146,6 +147,7 @@ otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t *ikm,
   if (salt == NULL || (salt->data == NULL && salt->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the private key checksum.
   if (launder32(otcrypto_integrity_blinded_key_check(ikm)) !=
@@ -245,6 +247,7 @@ otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t *ikm,
 otcrypto_status_t otcrypto_hkdf_expand(const otcrypto_blinded_key_t *prk,
                                        const otcrypto_const_byte_buf_t *info,
                                        otcrypto_blinded_key_t *okm) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (okm == NULL || okm->keyblob == NULL || prk == NULL ||
       prk->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -252,6 +255,7 @@ otcrypto_status_t otcrypto_hkdf_expand(const otcrypto_blinded_key_t *prk,
   if (info == NULL || (info->data == NULL && info->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Infer the digest size.
   size_t digest_words = 0;

--- a/sw/device/lib/crypto/impl/hmac.c
+++ b/sw/device/lib/crypto/impl/hmac.c
@@ -210,9 +210,11 @@ static status_t hmac_key_construct(const otcrypto_blinded_key_t *key,
  * @return OK or error.
  */
 static status_t check_key(const otcrypto_blinded_key_t *key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (key == NULL || key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // The underlying HMAC hardware does not have sideload support.
   if (key->config.hw_backed != kHardenedBoolFalse) {
@@ -235,11 +237,13 @@ OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_hmac(const otcrypto_blinded_key_t *key,
                                 const otcrypto_const_byte_buf_t *input_message,
                                 otcrypto_word32_buf_t *tag) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for null pointers.
   if (tag == NULL || tag->data == NULL || input_message == NULL ||
       (input_message->data == NULL && input_message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   // Preload the tag with randomness.
   HARDENED_TRY(hardened_memshred(tag->data, tag->len));
 
@@ -426,9 +430,11 @@ otcrypto_status_t otcrypto_hmac(const otcrypto_blinded_key_t *key,
 
 otcrypto_status_t otcrypto_hmac_init(otcrypto_hmac_context_t *ctx,
                                      const otcrypto_blinded_key_t *key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (ctx == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the key for null pointers or invalid configurations.
   HARDENED_TRY(check_key(key));
@@ -530,6 +536,7 @@ otcrypto_status_t otcrypto_hmac_init(otcrypto_hmac_context_t *ctx,
 otcrypto_status_t otcrypto_hmac_update(
     otcrypto_hmac_context_t *const ctx,
     const otcrypto_const_byte_buf_t *input_message) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (ctx == NULL || input_message == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -538,6 +545,7 @@ otcrypto_status_t otcrypto_hmac_update(
   if (input_message->data == NULL && input_message->len != 0) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   otcrypto_key_security_level_t security_level =
       (otcrypto_key_security_level_t)ctx->data[kCtxSecurityLevelOffset];
@@ -576,9 +584,11 @@ otcrypto_status_t otcrypto_hmac_update(
 
 otcrypto_status_t otcrypto_hmac_final(otcrypto_hmac_context_t *const ctx,
                                       otcrypto_word32_buf_t *tag) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (ctx == NULL || tag == NULL || tag->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   otcrypto_key_security_level_t security_level =
       (otcrypto_key_security_level_t)ctx->data[kCtxSecurityLevelOffset];

--- a/sw/device/lib/crypto/impl/kdf_ctr.c
+++ b/sw/device/lib/crypto/impl/kdf_ctr.c
@@ -72,6 +72,7 @@ otcrypto_status_t otcrypto_kdf_ctr_hmac(
     const otcrypto_const_byte_buf_t *label,
     const otcrypto_const_byte_buf_t *context,
     otcrypto_blinded_key_t *output_key_material) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check NULL pointers.
   if (output_key_material == NULL || output_key_material->keyblob == NULL ||
       key_derivation_key == NULL || key_derivation_key->keyblob == NULL) {
@@ -87,6 +88,7 @@ otcrypto_status_t otcrypto_kdf_ctr_hmac(
   if (context == NULL || (context->data == NULL && context->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the private key checksum.
   if (otcrypto_integrity_blinded_key_check(key_derivation_key) !=

--- a/sw/device/lib/crypto/impl/keyblob.c
+++ b/sw/device/lib/crypto/impl/keyblob.c
@@ -129,8 +129,12 @@ status_t keyblob_buffer_to_keymgr_diversification(
 status_t keyblob_to_keymgr_diversification(
     const otcrypto_blinded_key_t *key,
     keymgr_diversification_t *diversification) {
-  if (launder32(key->config.hw_backed) != kHardenedBoolTrue ||
-      key->keyblob == NULL) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
+  if (key->keyblob == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+#endif
+  if (launder32(key->config.hw_backed) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_CHECK_EQ(key->config.hw_backed, kHardenedBoolTrue);
@@ -146,8 +150,12 @@ status_t keyblob_to_keymgr_diversification(
 status_t keyblob_to_keymgr_attestation_diversification(
     const otcrypto_blinded_key_t *key,
     keymgr_diversification_t *diversification) {
-  if (launder32(key->config.hw_backed) != kHardenedBoolTrue ||
-      key->keyblob == NULL) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
+  if (key->keyblob == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+#endif
+  if (launder32(key->config.hw_backed) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_CHECK_EQ(key->config.hw_backed, kHardenedBoolTrue);
@@ -258,9 +266,11 @@ status_t keyblob_remask(otcrypto_blinded_key_t *key) {
 
 status_t keyblob_key_unmask(const otcrypto_blinded_key_t *key,
                             size_t unmasked_key_len, uint32_t *unmasked_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (key == NULL || unmasked_key == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   if (keyblob_share_num_words(key->config) != unmasked_key_len) {
     return OTCRYPTO_BAD_ARGS;
   }

--- a/sw/device/lib/crypto/impl/kmac.c
+++ b/sw/device/lib/crypto/impl/kmac.c
@@ -20,6 +20,7 @@ otcrypto_status_t otcrypto_kmac(
     size_t required_output_len, otcrypto_word32_buf_t *tag) {
   // TODO (#16410) Revisit/complete error checks
 
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for null pointers.
   if (key == NULL || key->keyblob == NULL || tag == NULL || tag->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -36,6 +37,7 @@ otcrypto_status_t otcrypto_kmac(
       (customization_string->data == NULL && customization_string->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Ensure that tag buffer length and `required_output_len` match each other.
   size_t required_output_words =

--- a/sw/device/lib/crypto/impl/kmac_kdf.c
+++ b/sw/device/lib/crypto/impl/kmac_kdf.c
@@ -21,9 +21,11 @@ otcrypto_status_t otcrypto_kmac_kdf(
     const otcrypto_const_byte_buf_t *label,
     const otcrypto_const_byte_buf_t *context,
     otcrypto_blinded_key_t *output_key_material) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check NULL pointers.
-  if (key_derivation_key->keyblob == NULL || output_key_material == NULL ||
-      output_key_material->keyblob == NULL) {
+  if (key_derivation_key == NULL || key_derivation_key->keyblob == NULL ||
+      output_key_material == NULL || output_key_material->keyblob == NULL ||
+      label == NULL || context == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -31,16 +33,19 @@ otcrypto_status_t otcrypto_kmac_kdf(
   if (label->data == NULL && label->len != 0) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   // Because of KMAC HWIPs prefix limitation, `label` should not exceed
   // `kKmacCustStrMaxSize` bytes.
   if (label->len > kKmacCustStrMaxSize) {
     return OTCRYPTO_BAD_ARGS;
   }
 
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for null context with nonzero length.
   if (context->data == NULL && context->len != 0) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the private key checksum.
   if (launder32(otcrypto_integrity_blinded_key_check(key_derivation_key)) !=

--- a/sw/device/lib/crypto/impl/rsa.c
+++ b/sw/device/lib/crypto/impl/rsa.c
@@ -97,10 +97,12 @@ static hardened_bool_t bignum_lt(const uint32_t *a, const uint32_t *b,
 otcrypto_status_t otcrypto_rsa_public_key_construct(
     otcrypto_rsa_size_t size, const otcrypto_const_word32_buf_t *modulus,
     otcrypto_unblinded_key_t *public_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (modulus == NULL || modulus->data == NULL || public_key == NULL ||
       public_key->key == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   HARDENED_TRY(rsa_mode_check(public_key->key_mode));
 
   switch (size) {
@@ -309,9 +311,11 @@ otcrypto_status_t otcrypto_rsa_keygen_async_start(otcrypto_rsa_size_t size) {
 otcrypto_status_t otcrypto_rsa_keygen(otcrypto_rsa_size_t size,
                                       otcrypto_unblinded_key_t *public_key,
                                       otcrypto_blinded_key_t *private_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (public_key == NULL || private_key == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   // Check the size against the public key.
   otcrypto_rsa_size_t inferred_size;
   if (!status_ok(rsa_size_from_public_key(public_key, &inferred_size)) ||
@@ -328,11 +332,13 @@ otcrypto_status_t otcrypto_rsa_private_key_from_exponents(
     const otcrypto_const_word32_buf_t *d_share0,
     const otcrypto_const_word32_buf_t *d_share1,
     otcrypto_blinded_key_t *private_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (modulus == NULL || modulus->data == NULL || d_share0 == NULL ||
       d_share0->data == NULL || d_share1 == NULL || d_share1->data == NULL ||
       private_key == NULL || private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   HARDENED_TRY(rsa_mode_check(private_key->config.key_mode));
 
   // Ensure that the length of the private exponent shares matches the length
@@ -407,9 +413,11 @@ otcrypto_status_t otcrypto_rsa_keypair_from_cofactor(
     const otcrypto_const_word32_buf_t *cofactor_share0,
     const otcrypto_const_word32_buf_t *cofactor_share1,
     otcrypto_unblinded_key_t *public_key, otcrypto_blinded_key_t *private_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (public_key == NULL || private_key == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   // Check the size against the public key.
   otcrypto_rsa_size_t inferred_size;
   if (!status_ok(rsa_size_from_public_key(public_key, &inferred_size)) ||
@@ -466,11 +474,13 @@ otcrypto_status_t otcrypto_rsa_decrypt(
 
 otcrypto_status_t otcrypto_rsa_keygen_async_finalize(
     otcrypto_unblinded_key_t *public_key, otcrypto_blinded_key_t *private_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for NULL pointers.
   if (public_key == NULL || public_key->key == NULL || private_key == NULL ||
       private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Infer the RSA size from the public key modulus.
   otcrypto_rsa_size_t size;
@@ -545,11 +555,13 @@ otcrypto_status_t otcrypto_rsa_keypair_from_cofactor_async_start(
     otcrypto_rsa_size_t size, const otcrypto_const_word32_buf_t *modulus,
     const otcrypto_const_word32_buf_t *cofactor_share0,
     const otcrypto_const_word32_buf_t *cofactor_share1) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (modulus == NULL || modulus->data == NULL || cofactor_share0 == NULL ||
       cofactor_share0->data == NULL || cofactor_share1 == NULL ||
       cofactor_share1->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Verify the input buffers
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(modulus));
@@ -611,11 +623,13 @@ otcrypto_status_t otcrypto_rsa_keypair_from_cofactor_async_start(
 
 otcrypto_status_t otcrypto_rsa_keypair_from_cofactor_async_finalize(
     otcrypto_unblinded_key_t *public_key, otcrypto_blinded_key_t *private_key) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for NULL pointers.
   if (public_key == NULL || public_key->key == NULL || private_key == NULL ||
       private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Infer the RSA size from the public key modulus.
   otcrypto_rsa_size_t size;
@@ -715,11 +729,13 @@ otcrypto_status_t otcrypto_rsa_sign_async_start(
     const otcrypto_blinded_key_t *private_key,
     const otcrypto_hash_digest_t message_digest,
     otcrypto_rsa_padding_t padding_mode) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for NULL pointers.
   if (message_digest.data == NULL || private_key == NULL ||
       private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Infer the RSA size from the private key.
   otcrypto_rsa_size_t size;
@@ -781,10 +797,12 @@ otcrypto_status_t otcrypto_rsa_sign_async_start(
 
 otcrypto_status_t otcrypto_rsa_sign_async_finalize(
     otcrypto_word32_buf_t *signature) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for NULL pointers.
   if (signature == NULL || signature->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Verify the input buffer
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(signature));
@@ -819,11 +837,13 @@ otcrypto_status_t otcrypto_rsa_sign_async_finalize(
 otcrypto_status_t otcrypto_rsa_verify_async_start(
     const otcrypto_unblinded_key_t *public_key,
     const otcrypto_const_word32_buf_t *signature) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for NULL pointers.
   if (public_key == NULL || public_key->key == NULL || signature == NULL ||
       signature->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Verify the input buffer
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(signature));
@@ -902,10 +922,12 @@ otcrypto_status_t otcrypto_rsa_verify_async_start(
 otcrypto_status_t otcrypto_rsa_verify_async_finalize(
     const otcrypto_hash_digest_t message_digest,
     otcrypto_rsa_padding_t padding_mode, hardened_bool_t *verification_result) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for NULL pointers.
   if (message_digest.data == NULL || verification_result == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Initialize verification result to false by default.
   *verification_result = kHardenedBoolFalse;
@@ -923,6 +945,7 @@ otcrypto_status_t otcrypto_rsa_encrypt_async_start(
     const otcrypto_hash_mode_t hash_mode,
     const otcrypto_const_byte_buf_t *message,
     const otcrypto_const_byte_buf_t *label) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for NULL pointers.
   if (public_key == NULL || public_key->key == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -935,6 +958,7 @@ otcrypto_status_t otcrypto_rsa_encrypt_async_start(
   if (label == NULL || ((label->data == NULL) && (label->len != 0))) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Check the caller-provided public key buffer.
   HARDENED_TRY(public_key_structural_check(public_key));
@@ -997,10 +1021,12 @@ otcrypto_status_t otcrypto_rsa_encrypt_async_start(
 
 otcrypto_status_t otcrypto_rsa_encrypt_async_finalize(
     otcrypto_word32_buf_t *ciphertext) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for NULL pointers.
   if (ciphertext == NULL || ciphertext->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   switch (launder32(ciphertext->len)) {
     case kRsa2048NumWords: {
@@ -1037,11 +1063,13 @@ otcrypto_status_t otcrypto_rsa_encrypt_async_finalize(
 otcrypto_status_t otcrypto_rsa_decrypt_async_start(
     const otcrypto_blinded_key_t *private_key,
     const otcrypto_const_word32_buf_t *ciphertext) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for NULL pointers.
   if (private_key == NULL || private_key->keyblob == NULL ||
       ciphertext->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Infer the RSA size from the private key.
   otcrypto_rsa_size_t size;
@@ -1147,10 +1175,12 @@ otcrypto_status_t otcrypto_rsa_decrypt_async_finalize(
     const otcrypto_hash_mode_t hash_mode,
     const otcrypto_const_byte_buf_t *label, otcrypto_byte_buf_t *plaintext,
     size_t *plaintext_bytelen) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (plaintext == NULL || plaintext->data == NULL || label == NULL ||
       label->data == NULL || plaintext_bytelen == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Call the unified `finalize()` operation, which will infer the RSA size
   // from OTBN.

--- a/sw/device/lib/crypto/impl/sha2.c
+++ b/sw/device/lib/crypto/impl/sha2.c
@@ -22,12 +22,16 @@ static_assert(
 
 otcrypto_status_t otcrypto_sha2_256(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (message == NULL || (message->data == NULL && message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
 
-  if (digest == NULL || digest->data == NULL ||
-      launder32(digest->len) != kHmacSha256DigestWords) {
+  if (digest == NULL || digest->data == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+#endif
+  if (launder32(digest->len) != kHmacSha256DigestWords) {
     return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_CHECK_EQ(digest->len, kHmacSha256DigestWords);
@@ -38,12 +42,16 @@ otcrypto_status_t otcrypto_sha2_256(const otcrypto_const_byte_buf_t *message,
 
 otcrypto_status_t otcrypto_sha2_384(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (message == NULL || (message->data == NULL && message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
 
-  if (digest == NULL || digest->data == NULL ||
-      launder32(digest->len) != kHmacSha384DigestWords) {
+  if (digest == NULL || digest->data == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+#endif
+  if (launder32(digest->len) != kHmacSha384DigestWords) {
     return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_CHECK_EQ(digest->len, kHmacSha384DigestWords);
@@ -54,12 +62,16 @@ otcrypto_status_t otcrypto_sha2_384(const otcrypto_const_byte_buf_t *message,
 
 otcrypto_status_t otcrypto_sha2_512(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (message == NULL || (message->data == NULL && message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
 
-  if (digest == NULL || digest->data == NULL ||
-      launder32(digest->len) != kHmacSha512DigestWords) {
+  if (digest == NULL || digest->data == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+#endif
+  if (launder32(digest->len) != kHmacSha512DigestWords) {
     return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_CHECK_EQ(digest->len, kHmacSha512DigestWords);
@@ -70,9 +82,11 @@ otcrypto_status_t otcrypto_sha2_512(const otcrypto_const_byte_buf_t *message,
 
 otcrypto_status_t otcrypto_sha2_init(otcrypto_hash_mode_t hash_mode,
                                      otcrypto_sha2_context_t *ctx) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (ctx == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   hmac_ctx_t hmac_ctx;
   otcrypto_hash_mode_t hash_mode_used = launder32(0);
@@ -131,18 +145,22 @@ static status_t check_lengths(hmac_ctx_t *hmac_ctx) {
 
 otcrypto_status_t otcrypto_sha2_update(
     otcrypto_sha2_context_t *ctx, const otcrypto_const_byte_buf_t *message) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (ctx == NULL || message == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   // Return early if the update size is 0.
   if (message->len == 0) {
     return otcrypto_eval_exit(OTCRYPTO_OK);
   }
 
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (message->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   hmac_ctx_t *hmac_ctx = (hmac_ctx_t *)ctx->data;
   HARDENED_TRY(check_lengths(hmac_ctx));
@@ -151,9 +169,11 @@ otcrypto_status_t otcrypto_sha2_update(
 
 otcrypto_status_t otcrypto_sha2_final(otcrypto_sha2_context_t *ctx,
                                       otcrypto_hash_digest_t *digest) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (ctx == NULL || digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
 
   hmac_ctx_t *hmac_ctx = (hmac_ctx_t *)ctx->data;
   HARDENED_TRY(check_lengths(hmac_ctx));

--- a/sw/device/lib/crypto/impl/sha3.c
+++ b/sw/device/lib/crypto/impl/sha3.c
@@ -16,12 +16,14 @@
 
 otcrypto_status_t otcrypto_sha3_224(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
   if (message == NULL || (message->data == NULL && message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   if (launder32(digest->len) != kKmacSha3224DigestWords) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -32,12 +34,14 @@ otcrypto_status_t otcrypto_sha3_224(const otcrypto_const_byte_buf_t *message,
 
 otcrypto_status_t otcrypto_sha3_256(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
   if (message == NULL || (message->data == NULL && message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   if (launder32(digest->len) != kKmacSha3256DigestWords) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -48,12 +52,14 @@ otcrypto_status_t otcrypto_sha3_256(const otcrypto_const_byte_buf_t *message,
 
 otcrypto_status_t otcrypto_sha3_384(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
   if (message == NULL || (message->data == NULL && message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   if (launder32(digest->len) != kKmacSha3384DigestWords) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -64,12 +70,14 @@ otcrypto_status_t otcrypto_sha3_384(const otcrypto_const_byte_buf_t *message,
 
 otcrypto_status_t otcrypto_sha3_512(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
   if (message == NULL || (message->data == NULL && message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   if (launder32(digest->len) != kKmacSha3512DigestWords) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -80,24 +88,28 @@ otcrypto_status_t otcrypto_sha3_512(const otcrypto_const_byte_buf_t *message,
 
 otcrypto_status_t otcrypto_shake128(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
   if (message == NULL || (message->data == NULL && message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   digest->mode = kOtcryptoHashXofModeShake128;
   return otcrypto_eval_exit(kmac_shake_128(message, digest->data, digest->len));
 }
 
 otcrypto_status_t otcrypto_shake256(const otcrypto_const_byte_buf_t *message,
                                     otcrypto_hash_digest_t *digest) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
   if (message == NULL || (message->data == NULL && message->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   digest->mode = kOtcryptoHashXofModeShake256;
   return otcrypto_eval_exit(kmac_shake_256(message, digest->data, digest->len));
 }
@@ -107,6 +119,7 @@ otcrypto_status_t otcrypto_cshake128(
     const otcrypto_const_byte_buf_t *function_name_string,
     const otcrypto_const_byte_buf_t *customization_string,
     otcrypto_hash_digest_t *digest) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -121,6 +134,7 @@ otcrypto_status_t otcrypto_cshake128(
       (customization_string->data == NULL && customization_string->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   digest->mode = kOtcryptoHashXofModeCshake128;
   return otcrypto_eval_exit(
       kmac_cshake_128(message, function_name_string->data,
@@ -133,6 +147,7 @@ otcrypto_status_t otcrypto_cshake256(
     const otcrypto_const_byte_buf_t *function_name_string,
     const otcrypto_const_byte_buf_t *customization_string,
     otcrypto_hash_digest_t *digest) {
+#ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   if (digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -147,6 +162,7 @@ otcrypto_status_t otcrypto_cshake256(
       (customization_string->data == NULL && customization_string->len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
+#endif
   digest->mode = kOtcryptoHashXofModeCshake256;
   return otcrypto_eval_exit(
       kmac_cshake_256(message, function_name_string->data,


### PR DESCRIPTION
When running the cryptolib with `--define=disable_null_checks=true`, one can disable all the API's NULL checks on the input allowing to save code size.

At the time of writing this option saves 3.4k bytes.