### PR TITLE
[rom_ext] Bump ROM_EXT version to 0.121

### DIFF
--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -14,7 +14,7 @@ def secver_write_selection():
 # because of how the bazel rule accepts attributes.
 ROM_EXT_VERSION = struct(
     MAJOR = "0",
-    MINOR = "120",
+    MINOR = "121",
     SECURITY = "0",
 )
 


### PR DESCRIPTION
This patch updates the MINOR version of ROM_EXT from 120 to 121 in `sw/device/silicon_creator/rom_ext/defs.bzl`.