### PR TITLE
[dv] Reseed optimization

### DIFF
--- a/hw/dv/sv/tl_agent/dv/tl_agent_sim_cfg.hjson
+++ b/hw/dv/sv/tl_agent/dv/tl_agent_sim_cfg.hjson
@@ -22,7 +22,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Default UVM test and seq class name.
   uvm_test: tl_agent_base_test

--- a/hw/dv/tools/dvsim/tests/alert_test.hjson
+++ b/hw/dv/tools/dvsim/tests/alert_test.hjson
@@ -13,7 +13,7 @@
       name: "{name}_alert_test"
       uvm_test_seq: "{name}_common_vseq"
       run_opts: ["+run_alert_test", "+en_scb=0"]
-      reseed: 50
+      reseed: 10
     }
   ]
 }

--- a/hw/dv/tools/dvsim/tests/csr_tests.hjson
+++ b/hw/dv/tools/dvsim/tests/csr_tests.hjson
@@ -22,7 +22,7 @@
       build_mode: "cover_reg_top"
       run_opts: ["+csr_hw_reset"]
       en_run_modes: ["csr_tests_mode"]
-      reseed: 5
+      reseed: 1
     }
 
     {
@@ -30,7 +30,7 @@
       build_mode: "cover_reg_top"
       run_opts: ["+csr_rw"]
       en_run_modes: ["csr_tests_mode"]
-      reseed: 20
+      reseed: 5
     }
 
     {
@@ -38,7 +38,7 @@
       build_mode: "cover_reg_top"
       run_opts: ["+csr_bit_bash"]
       en_run_modes: ["csr_tests_mode"]
-      reseed: 5
+      reseed: 1
     }
 
     {
@@ -46,7 +46,7 @@
       build_mode: "cover_reg_top"
       run_opts: ["+csr_aliasing"]
       en_run_modes: ["csr_tests_mode"]
-      reseed: 5
+      reseed: 1
     }
 
     {
@@ -54,7 +54,7 @@
       build_mode: "cover_reg_top"
       run_opts: ["+run_same_csr_outstanding"]
       en_run_modes: ["csr_tests_mode"]
-      reseed: 20
+      reseed: 5
     }
 
     {
@@ -62,7 +62,7 @@
       build_mode: "cover_reg_top"
       run_opts: ["+run_csr_mem_rw_with_rand_reset", "+test_timeout_ns=10000000000"]
       en_run_modes: ["csr_tests_mode"]
-      reseed: 20
+      reseed: 5
     }
   ]
 

--- a/hw/dv/tools/dvsim/tests/intr_test.hjson
+++ b/hw/dv/tools/dvsim/tests/intr_test.hjson
@@ -14,7 +14,7 @@
       build_mode: "cover_reg_top"
       uvm_test_seq: "{name}_common_vseq"
       run_opts: ["+run_intr_test"]
-      reseed: 50
+      reseed: 10
     }
   ]
 }

--- a/hw/dv/tools/dvsim/tests/mem_tests.hjson
+++ b/hw/dv/tools/dvsim/tests/mem_tests.hjson
@@ -13,7 +13,7 @@
       name: mem_tests_mode
       uvm_test_seq: "{name}_common_vseq"
       run_opts: ["+en_scb=0"]
-      reseed: 5
+      reseed: 1
     }
   ]
 

--- a/hw/dv/tools/dvsim/tests/passthru_mem_intg_tests.hjson
+++ b/hw/dv/tools/dvsim/tests/passthru_mem_intg_tests.hjson
@@ -14,7 +14,7 @@
       build_mode: "cover_reg_top"
       uvm_test_seq: "{name}_common_vseq"
       run_opts: ["+run_passthru_mem_tl_intg_err"]
-      reseed: 20
+      reseed: 5
     }
   ]
 }

--- a/hw/dv/tools/dvsim/tests/stress_tests.hjson
+++ b/hw/dv/tools/dvsim/tests/stress_tests.hjson
@@ -13,7 +13,7 @@
                  // 10s
                  "+test_timeout_ns=10000000000",
                  "+stress_seq={name}_stress_all_vseq"]
-      run_timeout_mins: 180
+      run_timeout_mins: 60
     }
   ]
 }

--- a/hw/dv/tools/dvsim/tests/tl_access_tests.hjson
+++ b/hw/dv/tools/dvsim/tests/tl_access_tests.hjson
@@ -14,14 +14,14 @@
       build_mode: "cover_reg_top"
       uvm_test_seq: "{name}_common_vseq"
       run_opts: ["+run_tl_errors"]
-      reseed: 20
+      reseed: 25
     }
     {
       name: "{name}_tl_intg_err"
       build_mode: "cover_reg_top"
       uvm_test_seq: "{name}_common_vseq"
       run_opts: ["+run_tl_intg_err", "+en_scb=0"]
-      reseed: 20
+      reseed: 25
     }
   ]
 }

--- a/hw/ip/adc_ctrl/dv/adc_ctrl_sim_cfg.hjson
+++ b/hw/ip/adc_ctrl/dv/adc_ctrl_sim_cfg.hjson
@@ -38,7 +38,7 @@
   sim_tops: ["adc_ctrl_bind", "adc_ctrl_cov_bind", "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Add ADC_CTRL specific exclusion files.
   vcs_cov_excl_files: ["{proj_root}/hw/ip/adc_ctrl/dv/cov/adc_ctrl_cov_unr_excl.el"]

--- a/hw/ip/aes/dv/aes_base_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_base_sim_cfg.hjson
@@ -47,7 +47,7 @@
   xcelium_cov_refine_files: []
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Need to override the default output directory
   overrides: [
@@ -151,6 +151,7 @@
       name: aes_config_error
       uvm_test: aes_config_error_test
       uvm_test_seq: aes_stress_vseq
+      reseed: 50
     }
     {
       name: aes_stress
@@ -161,6 +162,7 @@
       name: aes_b2b
       uvm_test: aes_b2b_test
       uvm_test_seq: aes_stress_vseq
+      reseed: 25
     }
     {
       name: aes_clear
@@ -171,6 +173,7 @@
       name: aes_alert_reset
       uvm_test: aes_alert_reset_test
       uvm_test_seq: aes_alert_reset_vseq
+      reseed: 25
     }
     {
       name: aes_sideload
@@ -207,12 +210,13 @@
       uvm_test: aes_fi_test
       uvm_test_seq: aes_ctr_fi_vseq
       run_timeout_mins: 1 // Short test; if not done within 1 min, something's wrong.
+      reseed: 25
     }
     {
       name: aes_core_fi
       uvm_test: aes_fi_test
       uvm_test_seq: aes_core_fi_vseq
-      reseed: 70 // Test must cover 35 bins. Overseed by 2x to get reasonable coverage.
+      reseed: 100 // Test must cover 35 bins. Overseed by 2x to get reasonable coverage.
     }
     // This test runs several sequences back-to-back with random resets between the individual
     // sequences. We shouldn't need many seeds here because aes_stress is the real stress test.

--- a/hw/ip/csrng/dv/csrng_sim_cfg.hjson
+++ b/hw/ip/csrng/dv/csrng_sim_cfg.hjson
@@ -40,7 +40,7 @@
   sim_tops: ["csrng_bind", "csrng_cov_bind", "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 25
 
   // Update all builds to add options specific to AES C model compilation.
   en_build_modes: ["{tool}_aes_model_build_opts"]

--- a/hw/ip/edn/dv/edn_base_sim_cfg.hjson
+++ b/hw/ip/edn/dv/edn_base_sim_cfg.hjson
@@ -43,7 +43,7 @@
   vcs_cov_excl_files: ["{proj_root}/hw/ip/edn/dv/cov/edn_fsm_excl.el"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   overrides: [
     // Override the default scratch directory and rel_path to take variant into account
@@ -76,31 +76,34 @@
       name: edn_regwen
       uvm_test: edn_regwen_test
       uvm_test_seq: edn_smoke_vseq
-      reseed: 10
+      reseed: 5
     }
 
     {
       name: edn_genbits
       uvm_test: edn_genbits_test
       uvm_test_seq: edn_genbits_vseq
-      reseed: 300
+      reseed: 100
     }
 
     {
       name: edn_stress_all
       uvm_test: edn_stress_all_test
       uvm_test_seq: edn_stress_all_vseq
+      reseed: 30
     }
 
     {
       name: edn_stress_all_with_rand_reset
       uvm_test: edn_stress_all_test
+      reseed: 30
     }
 
     {
       name: edn_intr
       uvm_test: edn_intr_test
       uvm_test_seq: edn_intr_vseq
+      reseed: 20
     }
 
     {
@@ -123,6 +126,7 @@
       uvm_test_seq: edn_disable_vseq
       // For debug purpose, this test is very short.
       run_opts: ["+test_timeout_ns=500_000"]
+      reseed: 50
     }
 
     {
@@ -131,6 +135,7 @@
       uvm_test_seq: edn_disable_auto_req_mode_vseq
       // For debug purpose, this test is very short.
       run_opts: ["+test_timeout_ns=500_000"]
+      reseed: 50
     }
   ]
 

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -40,7 +40,7 @@
   vcs_cov_excl_files: ["{proj_root}/hw/ip/i2c/dv/cov/i2c_cov_excl.el"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Default UVM test and seq class name.
   uvm_test: i2c_base_test
@@ -62,11 +62,13 @@
     {
       name: i2c_host_smoke
       uvm_test_seq: i2c_host_smoke_vseq
+      reseed: 5
     }
 
     {
       name: i2c_host_override
       uvm_test_seq: i2c_host_override_vseq
+      reseed: 50
     }
 
     // TODO(#21887) Removed pending DV fixes after removal
@@ -80,59 +82,70 @@
     {
       name: i2c_host_fifo_watermark
       uvm_test_seq: i2c_host_fifo_watermark_vseq
+      reseed: 5
     }
 
     {
       name: i2c_host_fifo_overflow
       uvm_test_seq: i2c_host_fifo_overflow_vseq
+      reseed: 5
     }
 
     {
       name: i2c_host_fifo_reset_fmt
       uvm_test_seq: i2c_host_fifo_reset_fmt_vseq
       run_opts: ["+test_timeout_ns=10_000_000"]
+      reseed: 25
     }
 
     {
       name: i2c_host_fifo_fmt_empty
       uvm_test_seq: i2c_host_fifo_fmt_empty_vseq
       run_opts: ["+test_timeout_ns=10_000_000"]
+      reseed: 5
     }
 
     {
       name: i2c_host_fifo_reset_rx
       uvm_test_seq: i2c_host_fifo_reset_rx_vseq
       run_opts: ["+test_timeout_ns=10_000_000"]
+      reseed: 5
     }
 
     {
       name: i2c_host_fifo_full
       uvm_test_seq: i2c_host_fifo_full_vseq
+      reseed: 5
     }
 
     {
       name: i2c_host_perf
       uvm_test_seq: i2c_host_perf_vseq
+      reseed: 5
     }
 
     {
       name: i2c_host_perf_precise
       uvm_test_seq: i2c_host_perf_precise_vseq
+      reseed: 5
     }
 
     {
       name: i2c_host_stretch_timeout
       uvm_test_seq: i2c_host_stretch_timeout_vseq
+      reseed: 5
     }
 
     {
       name: i2c_host_error_intr
       uvm_test_seq: i2c_host_error_intr_vseq
+      reseed: 50
     }
 
     {
       name: i2c_host_stress_all
       uvm_test_seq: i2c_host_stress_all_vseq
+      reseed: 30
     }
     {
       name: i2c_target_glitch
@@ -144,39 +157,46 @@
       name: i2c_target_smoke
       uvm_test_seq: i2c_target_smoke_vseq
       run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=100_000_000"]
+      reseed: 5
     }
     {
       name: i2c_target_stress_wr
       uvm_test_seq: i2c_target_stress_wr_vseq
       run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=600_000_000"]
+      reseed: 5
     }
     {
       name: i2c_target_stress_rd
       uvm_test_seq: i2c_target_stress_rd_vseq
       run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=100_000_000"]
+      reseed: 5
     }
     {
       name: i2c_target_stretch
       uvm_test_seq: i2c_target_stretch_vseq
       run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=400_000_000"]
+      reseed: 5
     }
     {
       name: i2c_target_intr_smoke
       uvm_test_seq: i2c_target_smoke_vseq
       run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=200_000_000",
                  "+use_intr_handler=1"]
+      reseed: 5
     }
     {
       name: i2c_target_intr_stress_wr
       uvm_test_seq: i2c_target_stress_wr_vseq
       run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=600_000_000",
                  "+use_intr_handler=1", "+slow_acq=1"]
+      reseed: 5
     }
     {
       name: i2c_target_timeout
       uvm_test_seq: i2c_target_timeout_vseq
       run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=50_000_000",
                  "+use_intr_handler=1"]
+      reseed: 5
     }
     {
       name: i2c_target_unexp_stop
@@ -189,36 +209,42 @@
       uvm_test_seq: i2c_target_fifo_reset_acq_vseq
       run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=20_000_000",
                  "+use_intr_handler=1"]
+      reseed: 5
     }
     {
       name: i2c_target_fifo_reset_tx
       uvm_test_seq: i2c_target_fifo_reset_tx_vseq
       run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=20_000_000",
                  "+use_intr_handler=1"]
+      reseed: 50
     }
     {
       name: i2c_target_perf
       uvm_test_seq: i2c_target_perf_vseq
       run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=20_000_000",
                  "+use_intr_handler=1"]
+      reseed: 5
     }
     {
       name: i2c_target_stress_all
       uvm_test_seq: i2c_target_stress_all_vseq
       run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=300_000_000",
                  "+use_intr_handler=1"]
+      reseed: 30
     }
     {
       name: i2c_target_bad_addr
       uvm_test_seq: i2c_target_smoke_vseq
       run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=20_000_000",
                  "+use_intr_handler=1", "+i2c_bad_addr_pct=50"]
+      reseed: 5
     }
     {
       name: i2c_target_hrst
       uvm_test_seq: i2c_target_hrst_vseq
       run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=20_000_000",
                  "+use_intr_handler=1"]
+      reseed: 50
     }
     {
       name: "i2c_host_stress_all_with_rand_reset"
@@ -241,10 +267,12 @@
       name: "i2c_host_mode_toggle"
       uvm_test_seq: "i2c_host_mode_toggle_vseq"
       run_timeout_mins: 10
+      reseed: 50
     }
     {
       name: "i2c_host_may_nack"
       uvm_test_seq: "i2c_host_may_nack_vseq"
+      reseed: 50
     }
     {
       name: i2c_target_fifo_watermarks_acq
@@ -252,6 +280,7 @@
       run_opts: ["+i2c_agent_mode=Host",
                  "+test_timeout_ns=20_000_000",
                  "+use_intr_handler=1"]
+      reseed: 5
     }
     {
       name: i2c_target_fifo_watermarks_tx
@@ -259,6 +288,7 @@
       run_opts: ["+i2c_agent_mode=Host",
                  "+test_timeout_ns=20_000_000",
                  "+use_intr_handler=1"]
+      reseed: 5
     }
     {
       name: i2c_target_tx_stretch_ctrl
@@ -266,6 +296,7 @@
       run_opts: ["+i2c_agent_mode=Host",
                  "+test_timeout_ns=20_000_000",
                  "+use_intr_handler=1"]
+      reseed: 5
     }
     {
       name: i2c_target_smbus_maxlen
@@ -273,6 +304,7 @@
       run_opts: ["+i2c_agent_mode=Host",
                  "+test_timeout_ns=20_000_000",
                  "+use_intr_handler=1"]
+      reseed: 5
     }
     {
       name: i2c_target_nack_acqfull
@@ -280,6 +312,7 @@
       run_opts: ["+i2c_agent_mode=Host",
                  "+test_timeout_ns=20_000_000",
                  "+use_intr_handler=1"]
+      reseed: 50
     }
     {
       name: i2c_target_nack_acqfull_addr
@@ -287,6 +320,7 @@
       run_opts: ["+i2c_agent_mode=Host",
                  "+test_timeout_ns=20_000_000",
                  "+use_intr_handler=1"]
+      reseed: 50
     }
     {
       name: i2c_target_nack_txstretch
@@ -294,6 +328,7 @@
       run_opts: ["+i2c_agent_mode=Host",
                  "+test_timeout_ns=20_000_000",
                  "+use_intr_handler=1"]
+      reseed: 30
     }
   ]
 

--- a/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
+++ b/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
@@ -41,7 +41,7 @@
              "sec_cm_prim_sparse_fsm_flop_bind", "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 20
 
   // Add keymgr specific exclusion files.
   vcs_cov_excl_files: ["{proj_root}/hw/ip/keymgr/dv/cov/keymgr_cov_excl.el"]
@@ -66,6 +66,7 @@
     {
       name: keymgr_smoke
       uvm_test_seq: keymgr_smoke_vseq
+      reseed: 30
     }
 
     {
@@ -94,6 +95,7 @@
     {
       name: keymgr_random
       uvm_test_seq: keymgr_random_vseq
+      reseed: 30
     }
 
     {
@@ -101,16 +103,19 @@
       uvm_test_seq: keymgr_cfg_regwen_vseq
       // This test is to check reg programming is gated when cfg_regwen=0, it's timing sensitive
       run_opts: ["+zero_delays=1"]
+      reseed: 50
     }
 
     {
       name: keymgr_direct_to_disabled
       uvm_test_seq: keymgr_direct_to_disabled_vseq
+      reseed: 30
     }
 
     {
       name: keymgr_lc_disable
       uvm_test_seq: keymgr_lc_disable_vseq
+      reseed: 50
     }
 
     {
@@ -121,6 +126,7 @@
     {
       name: keymgr_hwsw_invalid_input
       uvm_test_seq: keymgr_hwsw_invalid_input_vseq
+      reseed: 50
     }
 
     {
@@ -131,6 +137,7 @@
     {
       name: keymgr_custom_cm
       uvm_test_seq: keymgr_custom_cm_vseq
+      reseed: 50
     }
 
     {
@@ -146,6 +153,7 @@
     {
       name: keymgr_stress_all
       uvm_test_seq: keymgr_stress_all_vseq
+      reseed: 50
     }
   ]
 

--- a/hw/ip/keymgr_dpe/dv/keymgr_dpe_sim_cfg.hjson
+++ b/hw/ip/keymgr_dpe/dv/keymgr_dpe_sim_cfg.hjson
@@ -43,7 +43,7 @@
              "sec_cm_prim_sparse_fsm_flop_bind", "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Add keymgr_dpe specific exclusion files.
   vcs_cov_excl_files: ["{proj_root}/hw/ip/keymgr_dpe/dv/cov/keymgr_dpe_cov_excl.el"]

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -44,7 +44,7 @@
              "sec_cm_prim_count_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 20
 
   run_opts: ["+test_timeout_ns=4_000_000_000"]
 
@@ -106,6 +106,7 @@
       name: "{name}_sideload_invalid"
       uvm_test_seq: kmac_sideload_invalid_vseq
       run_opts: ["+test_timeout_ns=1_000_000_000"]
+      reseed: 50
     }
     {
       name: "{name}_burst_write"
@@ -180,6 +181,7 @@
       name: "{name}_app"
       uvm_test_seq: kmac_app_vseq
       run_opts: ["+test_timeout_ns=500_000_000"]
+      reseed: 25
     }
     {
       name: "{name}_app_with_partial_data"
@@ -225,6 +227,7 @@
     {
       name: "{name}_lc_escalation"
       uvm_test_seq: kmac_lc_escalation_vseq
+      reseed: 50
     }
     {
       name: kmac_stress_all

--- a/hw/ip/lc_ctrl/dv/lc_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_base_sim_cfg.hjson
@@ -38,7 +38,7 @@
              "sec_cm_prim_sparse_fsm_flop_bind", "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   overrides: [
     //
@@ -79,6 +79,7 @@
     {
       name: lc_ctrl_smoke
       uvm_test_seq: lc_ctrl_smoke_vseq
+      reseed: 20
     }
 
     {
@@ -90,26 +91,31 @@
     {
       name: lc_ctrl_state_failure
       uvm_test_seq: lc_ctrl_state_failure_vseq
+      reseed: 20
     }
 
     {
       name: lc_ctrl_state_post_trans
       uvm_test_seq: lc_ctrl_state_post_trans_vseq
+      reseed: 20
     }
 
     {
       name: lc_ctrl_prog_failure
       uvm_test_seq: lc_ctrl_prog_failure_vseq
+      reseed: 20
     }
 
     {
       name: lc_ctrl_errors
       uvm_test_seq: lc_ctrl_lc_errors_vseq
+      reseed: 20
     }
 
     {
       name: lc_ctrl_security_escalation
       uvm_test_seq: lc_ctrl_security_escalation_vseq
+      reseed: 20
     }
 
     {

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -57,7 +57,7 @@ name:
              "sec_cm_prim_count_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Default UVM test and seq class name.
   uvm_test: otbn_base_test

--- a/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson
@@ -24,7 +24,7 @@
   import_cfgs: ["{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 20
+  reseed: 10
 
   // Enable cdc instrumentation
   run_opts: ["+cdc_instrumentation_enabled=1"]
@@ -52,6 +52,7 @@
   tests: [
     {
       name: prim_async_alert
+      reseed: 20
     }
     {
       name: prim_async_fatal_alert

--- a/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson
@@ -21,7 +21,7 @@
   import_cfgs: ["{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 1
 
   // Enable cdc instrumentation
   run_opts: ["+cdc_instrumentation_enabled=1"]

--- a/hw/ip/prim/dv/prim_present/prim_present_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_present/prim_present_sim_cfg.hjson
@@ -21,7 +21,7 @@
   import_cfgs: ["{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 1
 
   // Enable cdc instrumentation
   run_opts: ["+cdc_instrumentation_enabled=1"]

--- a/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson
@@ -25,7 +25,7 @@
   en_build_modes: ["{tool}_crypto_dpi_prince_build_opts"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Enable cdc instrumentation
   run_opts: ["+cdc_instrumentation_enabled=1"]
@@ -49,13 +49,6 @@
     {
       name: smoke
       tests: ["prim_prince_test"]
-    }
-    {
-      name: nightly
-      // Run the same test as the "smoke" regression, just with a higher reseed value.
-      // This higher reseed value is due to the rather large state space created by
-      // the 128-bit key and 64-bit data values.
-      reseed: 500
     }
   ]
 }

--- a/hw/ip/racl_ctrl/dv/racl_ctrl_tests.hjson
+++ b/hw/ip/racl_ctrl/dv/racl_ctrl_tests.hjson
@@ -25,7 +25,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Default UVM test and seq class name.
   uvm_test: racl_ctrl_base_test

--- a/hw/ip/rv_dm/dv/rv_dm_base_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_base_sim_cfg.hjson
@@ -38,7 +38,7 @@
   sim_tops: ["rv_dm_bind", "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Enable cdc instrumentation.
   run_opts: ["+cdc_instrumentation_enabled=1"]
@@ -83,7 +83,6 @@
       build_mode: "cover_reg_top"
       run_opts: ["+csr_aliasing"]
       en_run_modes: ["csr_tests_mode"]
-      reseed: 5
       run_opts: ["+test_timeout_ns=100_000_000"]
     }
     {
@@ -312,10 +311,11 @@
     {
       name: rv_dm_stress_all
       uvm_test_seq: rv_dm_stress_all_vseq
+      reseed: 20
     }
     {
       name: rv_dm_stress_all_with_rand_reset
-      reseed: 10
+      reseed: 20
     }
   ]
 

--- a/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson
+++ b/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson
@@ -20,6 +20,11 @@
   // Testplan hjson file.
   testplan: "{proj_root}/hw/ip/rv_timer/data/rv_timer_testplan.hjson"
 
+  // Verification Plan related data.
+  vplan: "{self_dir}/../data/rv_timer_vplan.hjson"
+  cov_vplan_prepare_opts: ["--bypass-trace"]
+  cov_vplan_process_opts: [""]
+
   // RAL spec - used to generate the RAL model.
   ral_spec: "{proj_root}/hw/ip/rv_timer/data/rv_timer.hjson"
 

--- a/hw/ip/soc_dbg_ctrl/dv/soc_dbg_ctrl_sim_cfg.hjson
+++ b/hw/ip/soc_dbg_ctrl/dv/soc_dbg_ctrl_sim_cfg.hjson
@@ -36,7 +36,7 @@
   sim_tops: ["soc_dbg_ctrl_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Default UVM test and seq class name.
   uvm_test: soc_dbg_ctrl_base_test

--- a/hw/ip/spi_device/dv/base_sim_cfg.hjson
+++ b/hw/ip/spi_device/dv/base_sim_cfg.hjson
@@ -42,7 +42,7 @@
   sim_tops: ["spi_device_bind", "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 15
 
   // Enable cdc instrumentation.
   run_opts: ["+cdc_instrumentation_enabled=1"]
@@ -154,16 +154,19 @@
     {
       name: spi_device_flash_all
       uvm_test_seq: spi_device_flash_all_vseq
+      reseed: 25
     }
 
     {
       name: spi_device_flash_and_tpm
       uvm_test_seq: spi_device_flash_and_tpm_vseq
+      reseed: 25
     }
 
     {
       name: spi_device_flash_and_tpm_min_idle
       uvm_test_seq: spi_device_flash_and_tpm_min_idle_vseq
+      reseed: 25
     }
   ]
 

--- a/hw/ip/spi_host/dv/spi_host_sim_cfg.hjson
+++ b/hw/ip/spi_host/dv/spi_host_sim_cfg.hjson
@@ -43,7 +43,7 @@
   xcelium_cov_refine_files: ["{proj_root}/hw/ip/spi_host/dv/cov/spi_host_unr_excl.vRefine"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Default UVM test and seq class name.
   uvm_test: spi_host_base_test
@@ -65,7 +65,7 @@
     {
       name: spi_host_upper_range_clkdiv
       uvm_test_seq: spi_host_upper_range_clkdiv_vseq
-      reseed: 10 // Reduced reseed since this test may take ages
+      reseed: 5
     }
     {
       name: spi_host_performance

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -48,7 +48,7 @@
              "sec_cm_prim_onehot_check_bind", "sec_cm_prim_count_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 5
+  reseed: 8
 
   // Need to override the default output directory
   overrides: [

--- a/hw/ip/sysrst_ctrl/dv/sysrst_ctrl_sim_cfg.hjson
+++ b/hw/ip/sysrst_ctrl/dv/sysrst_ctrl_sim_cfg.hjson
@@ -38,7 +38,7 @@
   sim_tops: ["sysrst_ctrl_bind", "sysrst_ctrl_cov_bind", "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Enable cdc instrumentation.
   run_opts: ["+cdc_instrumentation_enabled=1"]
@@ -92,21 +92,25 @@
     {
       name: sysrst_ctrl_auto_blk_key_output
       uvm_test_seq: sysrst_ctrl_auto_blk_key_output_vseq
+      reseed: 25
     }
     {
       name: sysrst_ctrl_ultra_low_pwr
       uvm_test_seq: sysrst_ctrl_ultra_low_pwr_vseq
       run_opts: ["+test_timeout_ns=10_000_000_000"]
+      reseed: 25
     }
     {
       name: sysrst_ctrl_combo_detect
       uvm_test_seq: sysrst_ctrl_combo_detect_vseq
       run_opts: ["+test_timeout_ns=10_000_000_000"]
+      reseed: 25
     }
     {
       name: sysrst_ctrl_edge_detect
       uvm_test_seq: sysrst_ctrl_edge_detect_vseq
       run_opts: ["+test_timeout_ns=10_000_000_000"]
+      reseed: 50
     }
     {
       name: sysrst_ctrl_combo_detect_with_pre_cond

--- a/hw/ip/tlul/generic_dv/xbar_sim_cfg.hjson
+++ b/hw/ip/tlul/generic_dv/xbar_sim_cfg.hjson
@@ -42,7 +42,7 @@
   sim_tops: ["{dut}_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 20
 
   // Enable cdc instrumentation.
   run_opts: ["+cdc_instrumentation_enabled=1"]

--- a/hw/ip/tlul/generic_dv/xbar_tests.hjson
+++ b/hw/ip/tlul/generic_dv/xbar_tests.hjson
@@ -148,6 +148,7 @@
                  // `dv_base_vseq`) to prevent timeouts.
                  "+max_num_trans=10",
                 ]
+      reseed: 50
     }
 
     {
@@ -204,6 +205,7 @@
       en_run_modes: ["xbar_run_mode"]
       uvm_test: xbar_error_test
       uvm_test_seq: xbar_stress_all_vseq
+      reseed: 50
     }
 
     {
@@ -212,6 +214,7 @@
       en_run_modes: ["xbar_run_mode"]
       uvm_test: xbar_error_test
       uvm_test_seq: xbar_stress_all_with_rand_reset_vseq
+      reseed: 50
     }
   ]
 

--- a/hw/ip/uart/dv/uart_sim_cfg.hjson
+++ b/hw/ip/uart/dv/uart_sim_cfg.hjson
@@ -38,7 +38,7 @@
   sim_tops: ["uart_bind", "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Enable cdc instrumentation.
   run_opts: ["+cdc_instrumentation_enabled=1"]
@@ -75,7 +75,7 @@
     {
       name: uart_fifo_reset
       // need more seeds to cover uart_env_cov::rx_fifo_level_cg and uart_env_cov::tx_fifo_level_cg
-      reseed: 300
+      reseed: 200
       uvm_test_seq: uart_fifo_reset_vseq
     }
 
@@ -132,7 +132,7 @@
     {
       name: uart_stress_all_with_rand_reset
       // need more seeds to cover uart_agent_cov::uart_reset_cg
-      reseed: 100
+      reseed: 20
     }
   ]
 

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -39,7 +39,7 @@
   sim_tops: ["usbdev_bind", "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // USBDEV coverage exclusion files.
   vcs_cov_excl_files: ["{proj_root}/hw/ip/usbdev/dv/cov/usbdev_manual_excl.el",
@@ -119,6 +119,7 @@
     {
       name: usbdev_device_address
       uvm_test_seq: usbdev_device_address_vseq
+      reseed: 25
     }
     {
       name: usbdev_device_timeout
@@ -155,6 +156,7 @@
     {
       name: usbdev_endpoint_access
       uvm_test_seq: usbdev_endpoint_access_vseq
+      reseed: 25
     }
     {
       name: usbdev_endpoint_types
@@ -296,6 +298,7 @@
     {
       name: usbdev_link_suspend
       uvm_test_seq: usbdev_link_suspend_vseq
+      reseed: 25
     }
     {
       name: usbdev_low_speed_traffic
@@ -416,14 +419,17 @@
     {
       name: usbdev_pkt_buffer
       uvm_test_seq: usbdev_pkt_buffer_vseq
+      reseed: 25
     }
     {
       name: usbdev_pkt_received
       uvm_test_seq: usbdev_pkt_received_vseq
+      reseed: 25
     }
     {
       name: usbdev_pkt_sent
       uvm_test_seq: usbdev_pkt_sent_vseq
+      reseed: 25
     }
     {
       name: usbdev_random_length_in_transaction
@@ -473,6 +479,7 @@
     {
       name: usbdev_rx_crc_err
       uvm_test_seq: usbdev_rx_crc_err_vseq
+      reseed: 25
     }
     {
       name: usbdev_rx_full

--- a/hw/ip_templates/ac_range_check/dv/ac_range_check_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/ac_range_check/dv/ac_range_check_sim_cfg.hjson.tpl
@@ -36,7 +36,7 @@
   sim_tops: ["${module_instance_name}_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Default UVM test and seq class name.
   uvm_test: ${module_instance_name}_base_test

--- a/hw/ip_templates/alert_handler/dv/alert_handler_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/alert_handler/dv/alert_handler_sim_cfg.hjson.tpl
@@ -40,7 +40,7 @@
              "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   overrides: [
     {
@@ -72,45 +72,53 @@
     {
       name: ${module_instance_name}_random_classes
       uvm_test_seq: alert_handler_random_classes_vseq
+      reseed: 50
     }
 
     {
       name: ${module_instance_name}_esc_intr_timeout
       uvm_test_seq: alert_handler_esc_intr_timeout_vseq
+      reseed: 50
     }
 
     {
       name: ${module_instance_name}_esc_alert_accum
       uvm_test_seq: alert_handler_esc_alert_accum_vseq
+      reseed: 25
     }
 
     {
       name: ${module_instance_name}_sig_int_fail
       uvm_test_seq: alert_handler_sig_int_fail_vseq
+      reseed: 50
     }
 
     {
       name: ${module_instance_name}_entropy
       uvm_test_seq: alert_handler_entropy_vseq
       run_opts: ["+test_timeout_ns=1_000_000_000"]
+      reseed: 25
     }
 
     {
       name: ${module_instance_name}_ping_timeout
       uvm_test_seq: alert_handler_ping_timeout_vseq
       run_opts: ["+test_timeout_ns=1_000_000_000"]
+      reseed: 50
     }
 
     {
       name: ${module_instance_name}_lpg
       uvm_test_seq: alert_handler_lpg_vseq
       run_opts: ["+test_timeout_ns=1_000_000_000"]
+      reseed: 50
     }
 
     {
       name: ${module_instance_name}_lpg_stub_clk
       uvm_test_seq: alert_handler_lpg_stub_clk_vseq
       run_opts: ["+test_timeout_ns=1_000_000_000"]
+      reseed: 50
     }
 
     {
@@ -125,6 +133,7 @@
     {
       name: ${module_instance_name}_stress_all
       run_opts: ["+test_timeout_ns=15_000_000_000"]
+      reseed: 50
     }
 
     {

--- a/hw/ip_templates/clkmgr/dv/clkmgr_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/clkmgr/dv/clkmgr_sim_cfg.hjson.tpl
@@ -42,7 +42,7 @@
              "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // CLKMGR exclusion files.
   vcs_cov_excl_files: ["{self_dir}/cov/clkmgr_cov_manual_excl.el",

--- a/hw/ip_templates/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson.tpl
@@ -46,7 +46,7 @@
              "sec_cm_prim_count_bind", "sec_cm_prim_sparse_fsm_flop_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
 
   run_modes: [
@@ -351,7 +351,7 @@
       name: flash_ctrl_re_evict
       uvm_test_seq: flash_ctrl_re_evict_vseq
       run_opts: ["+scb_otf_en=1", "+ecc_mode=1", "+en_always_read=1"]
-      reseed: 20
+      reseed: 25
     }
     {
       name: flash_ctrl_disable

--- a/hw/ip_templates/gpio/dv/gpio_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/gpio/dv/gpio_sim_cfg.hjson.tpl
@@ -39,7 +39,7 @@
   sim_tops: ["${module_instance_name}_bind", "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Default UVM test and seq class name.
   uvm_test: ${module_instance_name}_base_test

--- a/hw/ip_templates/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson.tpl
@@ -57,7 +57,7 @@
              "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Add OTP_CTRL specific exclusion files.
   vcs_cov_excl_files: ["{self_dir}/cov/otp_ctrl_cov_unr_excl.el",
@@ -128,6 +128,7 @@
     {
       name: otp_ctrl_dai_lock
       uvm_test_seq: otp_ctrl_dai_lock_vseq
+      reseed: 30
     }
 
     {
@@ -138,6 +139,7 @@
     {
       name: otp_ctrl_check_fail
       uvm_test_seq: otp_ctrl_check_fail_vseq
+      reseed: 50
     }
 
     {
@@ -156,6 +158,7 @@
       // This test is to check reg programming is gated when direct_access_regwen=0
       // Thus this test is timing sensitive
       run_opts: ["+zero_delays=1"]
+      reseed: 30
     }
 
     {

--- a/hw/ip_templates/pwrmgr/dv/pwrmgr_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/pwrmgr/dv/pwrmgr_sim_cfg.hjson.tpl
@@ -51,7 +51,7 @@
              "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Default UVM test and seq class name.
   uvm_test: pwrmgr_base_test

--- a/hw/ip_templates/rstmgr/dv/rstmgr_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/rstmgr/dv/rstmgr_sim_cfg.hjson.tpl
@@ -54,7 +54,7 @@
 	     "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 5
 
   // Default UVM test and seq class name.
   uvm_test: rstmgr_base_test
@@ -92,6 +92,7 @@
     {
       name: rstmgr_leaf_rst_cnsty
       uvm_test_seq: rstmgr_leaf_rst_cnsty_vseq
+      reseed: 25
     }
     {
       name: rstmgr_leaf_rst_shadow_attack

--- a/hw/top_darjeeling/dv/chip_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_sim_cfg.hjson
@@ -391,7 +391,7 @@
       name: xbar_run_mode
       en_run_modes: ["gen_otp_images_mode"]
       run_opts: ["+xbar_mode=1"]
-      reseed: 100
+      reseed: 50
     }
   ]
 

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/ac_range_check_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/ac_range_check_sim_cfg.hjson
@@ -36,7 +36,7 @@
   sim_tops: ["ac_range_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Default UVM test and seq class name.
   uvm_test: ac_range_check_base_test

--- a/hw/top_darjeeling/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -40,7 +40,7 @@
              "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   overrides: [
     {
@@ -72,45 +72,53 @@
     {
       name: alert_handler_random_classes
       uvm_test_seq: alert_handler_random_classes_vseq
+      reseed: 50
     }
 
     {
       name: alert_handler_esc_intr_timeout
       uvm_test_seq: alert_handler_esc_intr_timeout_vseq
+      reseed: 50
     }
 
     {
       name: alert_handler_esc_alert_accum
       uvm_test_seq: alert_handler_esc_alert_accum_vseq
+      reseed: 25
     }
 
     {
       name: alert_handler_sig_int_fail
       uvm_test_seq: alert_handler_sig_int_fail_vseq
+      reseed: 50
     }
 
     {
       name: alert_handler_entropy
       uvm_test_seq: alert_handler_entropy_vseq
       run_opts: ["+test_timeout_ns=1_000_000_000"]
+      reseed: 25
     }
 
     {
       name: alert_handler_ping_timeout
       uvm_test_seq: alert_handler_ping_timeout_vseq
       run_opts: ["+test_timeout_ns=1_000_000_000"]
+      reseed: 50
     }
 
     {
       name: alert_handler_lpg
       uvm_test_seq: alert_handler_lpg_vseq
       run_opts: ["+test_timeout_ns=1_000_000_000"]
+      reseed: 50
     }
 
     {
       name: alert_handler_lpg_stub_clk
       uvm_test_seq: alert_handler_lpg_stub_clk_vseq
       run_opts: ["+test_timeout_ns=1_000_000_000"]
+      reseed: 50
     }
 
     {
@@ -125,6 +133,7 @@
     {
       name: alert_handler_stress_all
       run_opts: ["+test_timeout_ns=15_000_000_000"]
+      reseed: 50
     }
 
     {

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson
@@ -42,7 +42,7 @@
              "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // CLKMGR exclusion files.
   vcs_cov_excl_files: ["{self_dir}/cov/clkmgr_cov_manual_excl.el",

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/gpio_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/gpio_sim_cfg.hjson
@@ -39,7 +39,7 @@
   sim_tops: ["gpio_bind", "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Default UVM test and seq class name.
   uvm_test: gpio_base_test

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -57,7 +57,7 @@
              "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Add OTP_CTRL specific exclusion files.
   vcs_cov_excl_files: ["{self_dir}/cov/otp_ctrl_cov_unr_excl.el",
@@ -128,6 +128,7 @@
     {
       name: otp_ctrl_dai_lock
       uvm_test_seq: otp_ctrl_dai_lock_vseq
+      reseed: 30
     }
 
     {
@@ -138,6 +139,7 @@
     {
       name: otp_ctrl_check_fail
       uvm_test_seq: otp_ctrl_check_fail_vseq
+      reseed: 50
     }
 
     {
@@ -156,6 +158,7 @@
       // This test is to check reg programming is gated when direct_access_regwen=0
       // Thus this test is timing sensitive
       run_opts: ["+zero_delays=1"]
+      reseed: 30
     }
 
     {

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -51,7 +51,7 @@
              "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Default UVM test and seq class name.
   uvm_test: pwrmgr_base_test

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
@@ -54,7 +54,7 @@
 	     "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 5
 
   // Default UVM test and seq class name.
   uvm_test: rstmgr_base_test
@@ -92,6 +92,7 @@
     {
       name: rstmgr_leaf_rst_cnsty
       uvm_test_seq: rstmgr_leaf_rst_cnsty_vseq
+      reseed: 25
     }
     {
       name: rstmgr_leaf_rst_shadow_attack

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -405,7 +405,7 @@
       name: xbar_run_mode
       en_run_modes: ["gen_otp_images_mode"]
       run_opts: ["+xbar_mode=1"]
-      reseed: 100
+      reseed: 50
     }
   ]
 

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -40,7 +40,7 @@
              "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   overrides: [
     {
@@ -72,45 +72,53 @@
     {
       name: alert_handler_random_classes
       uvm_test_seq: alert_handler_random_classes_vseq
+      reseed: 50
     }
 
     {
       name: alert_handler_esc_intr_timeout
       uvm_test_seq: alert_handler_esc_intr_timeout_vseq
+      reseed: 50
     }
 
     {
       name: alert_handler_esc_alert_accum
       uvm_test_seq: alert_handler_esc_alert_accum_vseq
+      reseed: 25
     }
 
     {
       name: alert_handler_sig_int_fail
       uvm_test_seq: alert_handler_sig_int_fail_vseq
+      reseed: 50
     }
 
     {
       name: alert_handler_entropy
       uvm_test_seq: alert_handler_entropy_vseq
       run_opts: ["+test_timeout_ns=1_000_000_000"]
+      reseed: 25
     }
 
     {
       name: alert_handler_ping_timeout
       uvm_test_seq: alert_handler_ping_timeout_vseq
       run_opts: ["+test_timeout_ns=1_000_000_000"]
+      reseed: 50
     }
 
     {
       name: alert_handler_lpg
       uvm_test_seq: alert_handler_lpg_vseq
       run_opts: ["+test_timeout_ns=1_000_000_000"]
+      reseed: 50
     }
 
     {
       name: alert_handler_lpg_stub_clk
       uvm_test_seq: alert_handler_lpg_stub_clk_vseq
       run_opts: ["+test_timeout_ns=1_000_000_000"]
+      reseed: 50
     }
 
     {
@@ -125,6 +133,7 @@
     {
       name: alert_handler_stress_all
       run_opts: ["+test_timeout_ns=15_000_000_000"]
+      reseed: 50
     }
 
     {

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson
@@ -42,7 +42,7 @@
              "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // CLKMGR exclusion files.
   vcs_cov_excl_files: ["{self_dir}/cov/clkmgr_cov_manual_excl.el",

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -46,7 +46,7 @@
              "sec_cm_prim_count_bind", "sec_cm_prim_sparse_fsm_flop_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
 
   run_modes: [
@@ -351,7 +351,7 @@
       name: flash_ctrl_re_evict
       uvm_test_seq: flash_ctrl_re_evict_vseq
       run_opts: ["+scb_otf_en=1", "+ecc_mode=1", "+en_always_read=1"]
-      reseed: 20
+      reseed: 25
     }
     {
       name: flash_ctrl_disable

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/gpio_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/gpio_sim_cfg.hjson
@@ -39,7 +39,7 @@
   sim_tops: ["gpio_bind", "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Default UVM test and seq class name.
   uvm_test: gpio_base_test

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -57,7 +57,7 @@
              "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Add OTP_CTRL specific exclusion files.
   vcs_cov_excl_files: ["{self_dir}/cov/otp_ctrl_cov_unr_excl.el",
@@ -128,6 +128,7 @@
     {
       name: otp_ctrl_dai_lock
       uvm_test_seq: otp_ctrl_dai_lock_vseq
+      reseed: 30
     }
 
     {
@@ -138,6 +139,7 @@
     {
       name: otp_ctrl_check_fail
       uvm_test_seq: otp_ctrl_check_fail_vseq
+      reseed: 50
     }
 
     {
@@ -156,6 +158,7 @@
       // This test is to check reg programming is gated when direct_access_regwen=0
       // Thus this test is timing sensitive
       run_opts: ["+zero_delays=1"]
+      reseed: 30
     }
 
     {

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -51,7 +51,7 @@
              "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Default UVM test and seq class name.
   uvm_test: pwrmgr_base_test

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
@@ -54,7 +54,7 @@
 	     "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 5
 
   // Default UVM test and seq class name.
   uvm_test: rstmgr_base_test
@@ -92,6 +92,7 @@
     {
       name: rstmgr_leaf_rst_cnsty
       uvm_test_seq: rstmgr_leaf_rst_cnsty_vseq
+      reseed: 25
     }
     {
       name: rstmgr_leaf_rst_shadow_attack

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson
@@ -42,7 +42,7 @@
              "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // CLKMGR exclusion files.
   vcs_cov_excl_files: ["{self_dir}/cov/clkmgr_cov_manual_excl.el",

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -46,7 +46,7 @@
              "sec_cm_prim_count_bind", "sec_cm_prim_sparse_fsm_flop_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
 
   run_modes: [
@@ -351,7 +351,7 @@
       name: flash_ctrl_re_evict
       uvm_test_seq: flash_ctrl_re_evict_vseq
       run_opts: ["+scb_otf_en=1", "+ecc_mode=1", "+en_always_read=1"]
-      reseed: 20
+      reseed: 25
     }
     {
       name: flash_ctrl_disable

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/gpio_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/gpio_sim_cfg.hjson
@@ -39,7 +39,7 @@
   sim_tops: ["gpio_bind", "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Default UVM test and seq class name.
   uvm_test: gpio_base_test

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -51,7 +51,7 @@
              "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Default UVM test and seq class name.
   uvm_test: pwrmgr_base_test

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
@@ -54,7 +54,7 @@
 	     "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 5
 
   // Default UVM test and seq class name.
   uvm_test: rstmgr_base_test
@@ -92,6 +92,7 @@
     {
       name: rstmgr_leaf_rst_cnsty
       uvm_test_seq: rstmgr_leaf_rst_cnsty_vseq
+      reseed: 25
     }
     {
       name: rstmgr_leaf_rst_shadow_attack

--- a/util/uvmdvgen/sim_cfg.hjson.tpl
+++ b/util/uvmdvgen/sim_cfg.hjson.tpl
@@ -57,7 +57,7 @@
   sim_tops: ["${name}_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 1
 
   // Default UVM test and seq class name.
   uvm_test: ${name}_base_test


### PR DESCRIPTION
The goal is to reduce the overall runtime of the DV regression by  optimizing the reseed values for all blocks/tops. The new values are based on the analysis of the test results from the last 10 regressions for which I took the minimum values. Then I have reduced reseeding from 50 to 10 for all IPs and analyzed whether it had an impact on the coverage results. Some values have slightly decreased, but overall the coverage is not impacted and the runtime is significantly reduced.