### PR TITLE
[crypto/rsa] Refactor RSA for code size

### DIFF
--- a/sw/device/lib/crypto/impl/rsa.c
+++ b/sw/device/lib/crypto/impl/rsa.c
@@ -286,13 +286,16 @@ otcrypto_status_t otcrypto_rsa_keygen_async_start(otcrypto_rsa_size_t size) {
   switch (launder32(size)) {
     case kOtcryptoRsaSize2048:
       HARDENED_CHECK_EQ(size, kOtcryptoRsaSize2048);
-      return rsa_keygen_2048_start();
+      HARDENED_TRY(rsa_keygen_start(kRsaSize2048));
+      return otcrypto_eval_exit(OTCRYPTO_OK);
     case kOtcryptoRsaSize3072:
       HARDENED_CHECK_EQ(size, kOtcryptoRsaSize3072);
-      return rsa_keygen_3072_start();
+      HARDENED_TRY(rsa_keygen_start(kRsaSize3072));
+      return otcrypto_eval_exit(OTCRYPTO_OK);
     case kOtcryptoRsaSize4096:
       HARDENED_CHECK_EQ(size, kOtcryptoRsaSize4096);
-      return rsa_keygen_4096_start();
+      HARDENED_TRY(rsa_keygen_start(kRsaSize4096));
+      return otcrypto_eval_exit(OTCRYPTO_OK);
     default:
       return OTCRYPTO_BAD_ARGS;
   }
@@ -492,7 +495,9 @@ otcrypto_status_t otcrypto_rsa_keygen_async_finalize(
       rsa_2048_public_key_t *pk = (rsa_2048_public_key_t *)public_key->key;
       rsa_2048_private_key_t *sk =
           (rsa_2048_private_key_t *)private_key->keyblob;
-      HARDENED_TRY_WIPE_DMEM(rsa_keygen_2048_finalize(pk, sk));
+      HARDENED_TRY_WIPE_DMEM(rsa_keygen_finalize_size(
+          kRsaSize2048, sk->n.data, sk->d0.data, sk->d1.data));
+      HARDENED_TRY(hardened_memcpy(pk->n.data, sk->n.data, kRsa2048NumWords));
       size_used = launder32(size_used) | kOtcryptoRsaSize2048;
       break;
     }
@@ -501,7 +506,9 @@ otcrypto_status_t otcrypto_rsa_keygen_async_finalize(
       rsa_3072_public_key_t *pk = (rsa_3072_public_key_t *)public_key->key;
       rsa_3072_private_key_t *sk =
           (rsa_3072_private_key_t *)private_key->keyblob;
-      HARDENED_TRY_WIPE_DMEM(rsa_keygen_3072_finalize(pk, sk));
+      HARDENED_TRY_WIPE_DMEM(rsa_keygen_finalize_size(
+          kRsaSize3072, sk->n.data, sk->d0.data, sk->d1.data));
+      HARDENED_TRY(hardened_memcpy(pk->n.data, sk->n.data, kRsa3072NumWords));
       size_used = launder32(size_used) | kOtcryptoRsaSize3072;
       break;
     }
@@ -510,7 +517,9 @@ otcrypto_status_t otcrypto_rsa_keygen_async_finalize(
       rsa_4096_public_key_t *pk = (rsa_4096_public_key_t *)public_key->key;
       rsa_4096_private_key_t *sk =
           (rsa_4096_private_key_t *)private_key->keyblob;
-      HARDENED_TRY_WIPE_DMEM(rsa_keygen_4096_finalize(pk, sk));
+      HARDENED_TRY_WIPE_DMEM(rsa_keygen_finalize_size(
+          kRsaSize4096, sk->n.data, sk->d0.data, sk->d1.data));
+      HARDENED_TRY(hardened_memcpy(pk->n.data, sk->n.data, kRsa4096NumWords));
       size_used = launder32(size_used) | kOtcryptoRsaSize4096;
       break;
     }
@@ -553,7 +562,12 @@ otcrypto_status_t otcrypto_rsa_keypair_from_cofactor_async_start(
     return OTCRYPTO_BAD_ARGS;
   }
 
-  switch (size) {
+  // TODO: RSA keys are currently unblinded, so combine the shares.
+  for (size_t i = 0; i < cofactor_share1->len; i++) {
+    ((uint32_t *)cofactor_share0->data)[i] ^= cofactor_share1->data[i];
+  }
+
+  switch (launder32(size)) {
     case kOtcryptoRsaSize2048: {
       if (cofactor_share0->len !=
               sizeof(rsa_2048_cofactor_t) / sizeof(uint32_t) ||
@@ -561,14 +575,8 @@ otcrypto_status_t otcrypto_rsa_keypair_from_cofactor_async_start(
         // COVERAGE (MISSING) We do not cover bad size.
         return OTCRYPTO_BAD_ARGS;
       }
-      rsa_2048_cofactor_t *cf = (rsa_2048_cofactor_t *)cofactor_share0->data;
-      // TODO: RSA keys are currently unblinded, so combine the shares.
-      for (size_t i = 0; i < cofactor_share1->len; i++) {
-        cf->data[i] ^= cofactor_share1->data[i];
-      }
-      rsa_2048_public_key_t pk;
-      HARDENED_TRY(hardened_memcpy(pk.n.data, modulus->data, modulus->len));
-      HARDENED_TRY_WIPE_DMEM(rsa_keygen_from_cofactor_2048_start(&pk, cf));
+      HARDENED_TRY_WIPE_DMEM(rsa_keygen_from_cofactor_start(
+          kRsaSize2048, modulus->data, cofactor_share0->data));
       return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kOtcryptoRsaSize3072: {
@@ -577,13 +585,8 @@ otcrypto_status_t otcrypto_rsa_keypair_from_cofactor_async_start(
           modulus->len != kRsa3072NumWords) {
         return OTCRYPTO_BAD_ARGS;
       }
-      rsa_3072_cofactor_t *cf = (rsa_3072_cofactor_t *)cofactor_share0->data;
-      for (size_t i = 0; i < cofactor_share1->len; i++) {
-        cf->data[i] ^= cofactor_share1->data[i];
-      }
-      rsa_3072_public_key_t pk;
-      HARDENED_TRY(hardened_memcpy(pk.n.data, modulus->data, modulus->len));
-      HARDENED_TRY_WIPE_DMEM(rsa_keygen_from_cofactor_3072_start(&pk, cf));
+      HARDENED_TRY_WIPE_DMEM(rsa_keygen_from_cofactor_start(
+          kRsaSize3072, modulus->data, cofactor_share0->data));
       return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kOtcryptoRsaSize4096: {
@@ -592,13 +595,8 @@ otcrypto_status_t otcrypto_rsa_keypair_from_cofactor_async_start(
           modulus->len != kRsa4096NumWords) {
         return OTCRYPTO_BAD_ARGS;
       }
-      rsa_4096_cofactor_t *cf = (rsa_4096_cofactor_t *)cofactor_share0->data;
-      for (size_t i = 0; i < cofactor_share1->len; i++) {
-        cf->data[i] ^= cofactor_share1->data[i];
-      }
-      rsa_4096_public_key_t pk;
-      HARDENED_TRY(hardened_memcpy(pk.n.data, modulus->data, modulus->len));
-      HARDENED_TRY_WIPE_DMEM(rsa_keygen_from_cofactor_4096_start(&pk, cf));
+      HARDENED_TRY_WIPE_DMEM(rsa_keygen_from_cofactor_start(
+          kRsaSize4096, modulus->data, cofactor_share0->data));
       return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     default:
@@ -641,7 +639,8 @@ otcrypto_status_t otcrypto_rsa_keypair_from_cofactor_async_finalize(
       rsa_2048_public_key_t *pk = (rsa_2048_public_key_t *)public_key->key;
       rsa_2048_private_key_t *sk =
           (rsa_2048_private_key_t *)private_key->keyblob;
-      HARDENED_TRY_WIPE_DMEM(rsa_keygen_from_cofactor_2048_finalize(pk, sk));
+      HARDENED_TRY_WIPE_DMEM(rsa_keygen_from_cofactor_finalize(
+          kRsaSize2048, pk->n.data, sk->n.data, sk->d0.data, sk->d1.data));
       break;
     }
     case kOtcryptoRsaSize3072: {
@@ -649,7 +648,8 @@ otcrypto_status_t otcrypto_rsa_keypair_from_cofactor_async_finalize(
       rsa_3072_public_key_t *pk = (rsa_3072_public_key_t *)public_key->key;
       rsa_3072_private_key_t *sk =
           (rsa_3072_private_key_t *)private_key->keyblob;
-      HARDENED_TRY_WIPE_DMEM(rsa_keygen_from_cofactor_3072_finalize(pk, sk));
+      HARDENED_TRY_WIPE_DMEM(rsa_keygen_from_cofactor_finalize(
+          kRsaSize3072, pk->n.data, sk->n.data, sk->d0.data, sk->d1.data));
       break;
     }
     case kOtcryptoRsaSize4096: {
@@ -657,7 +657,8 @@ otcrypto_status_t otcrypto_rsa_keypair_from_cofactor_async_finalize(
       rsa_4096_public_key_t *pk = (rsa_4096_public_key_t *)public_key->key;
       rsa_4096_private_key_t *sk =
           (rsa_4096_private_key_t *)private_key->keyblob;
-      HARDENED_TRY_WIPE_DMEM(rsa_keygen_from_cofactor_4096_finalize(pk, sk));
+      HARDENED_TRY_WIPE_DMEM(rsa_keygen_from_cofactor_finalize(
+          kRsaSize4096, pk->n.data, sk->n.data, sk->d0.data, sk->d1.data));
       break;
     }
     default:
@@ -742,24 +743,27 @@ otcrypto_status_t otcrypto_rsa_sign_async_start(
       HARDENED_CHECK_EQ(size, kOtcryptoRsaSize2048);
       rsa_2048_private_key_t *sk =
           (rsa_2048_private_key_t *)private_key->keyblob;
-      HARDENED_TRY_WIPE_DMEM(rsa_signature_generate_2048_start(
-          sk, message_digest, (rsa_signature_padding_t)padding_mode));
+      HARDENED_TRY_WIPE_DMEM(rsa_signature_generate_start(
+          kRsaSize2048, sk->d0.data, sk->d1.data, sk->n.data, message_digest,
+          (rsa_signature_padding_t)padding_mode));
       return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kOtcryptoRsaSize3072: {
       HARDENED_CHECK_EQ(size, kOtcryptoRsaSize3072);
       rsa_3072_private_key_t *sk =
           (rsa_3072_private_key_t *)private_key->keyblob;
-      HARDENED_TRY_WIPE_DMEM(rsa_signature_generate_3072_start(
-          sk, message_digest, (rsa_signature_padding_t)padding_mode));
+      HARDENED_TRY_WIPE_DMEM(rsa_signature_generate_start(
+          kRsaSize3072, sk->d0.data, sk->d1.data, sk->n.data, message_digest,
+          (rsa_signature_padding_t)padding_mode));
       return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kOtcryptoRsaSize4096: {
       HARDENED_CHECK_EQ(size, kOtcryptoRsaSize4096);
       rsa_4096_private_key_t *sk =
           (rsa_4096_private_key_t *)private_key->keyblob;
-      HARDENED_TRY_WIPE_DMEM(rsa_signature_generate_4096_start(
-          sk, message_digest, (rsa_signature_padding_t)padding_mode));
+      HARDENED_TRY_WIPE_DMEM(rsa_signature_generate_start(
+          kRsaSize4096, sk->d0.data, sk->d1.data, sk->n.data, message_digest,
+          (rsa_signature_padding_t)padding_mode));
       return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     default:
@@ -789,19 +793,18 @@ otcrypto_status_t otcrypto_rsa_sign_async_finalize(
   switch (launder32(signature->len)) {
     case kRsa2048NumWords:
       HARDENED_CHECK_EQ(signature->len, kRsa2048NumWords);
-      HARDENED_TRY_WIPE_DMEM(rsa_signature_generate_2048_finalize(
-          (rsa_2048_int_t *)signature->data));
+      HARDENED_TRY_WIPE_DMEM(
+          rsa_signature_generate_finalize(kRsaSize2048, signature->data));
       return otcrypto_eval_exit(OTCRYPTO_OK);
     case kRsa3072NumWords:
       HARDENED_CHECK_EQ(signature->len, kRsa3072NumWords);
-      HARDENED_TRY_WIPE_DMEM(rsa_signature_generate_3072_finalize(
-          (rsa_3072_int_t *)signature->data));
+      HARDENED_TRY_WIPE_DMEM(
+          rsa_signature_generate_finalize(kRsaSize3072, signature->data));
       return otcrypto_eval_exit(OTCRYPTO_OK);
     case kRsa4096NumWords:
       HARDENED_CHECK_EQ(signature->len, kRsa4096NumWords);
       HARDENED_TRY_WIPE_DMEM(
-          otcrypto_eval_exit(rsa_signature_generate_4096_finalize(
-              (rsa_4096_int_t *)signature->data)));
+          rsa_signature_generate_finalize(kRsaSize4096, signature->data));
       return otcrypto_eval_exit(OTCRYPTO_OK);
     default:
       return OTCRYPTO_BAD_ARGS;
@@ -837,53 +840,50 @@ otcrypto_status_t otcrypto_rsa_verify_async_start(
   otcrypto_rsa_size_t size;
   HARDENED_TRY(rsa_size_from_public_key(public_key, &size));
 
-  switch (size) {
+  switch (launder32(size)) {
     case kOtcryptoRsaSize2048: {
+      HARDENED_CHECK_EQ(size, kOtcryptoRsaSize2048);
       if (signature->len != kRsa2048NumWords) {
         return OTCRYPTO_BAD_ARGS;
       }
       rsa_2048_public_key_t *pk = (rsa_2048_public_key_t *)public_key->key;
-      rsa_2048_int_t *sig = (rsa_2048_int_t *)signature->data;
-
       // Check that signature is < n.
-      if (bignum_lt(sig->data, pk->n.data, kRsa2048NumWords) ==
+      if (bignum_lt(signature->data, pk->n.data, kRsa2048NumWords) ==
           kHardenedBoolFalse) {
         return OTCRYPTO_BAD_ARGS;
       }
-
-      HARDENED_TRY_WIPE_DMEM(rsa_signature_verify_2048_start(pk, sig));
+      HARDENED_TRY_WIPE_DMEM(rsa_signature_verify_start(
+          kRsaSize2048, pk->n.data, signature->data));
       return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kOtcryptoRsaSize3072: {
+      HARDENED_CHECK_EQ(size, kOtcryptoRsaSize3072);
       if (signature->len != kRsa3072NumWords) {
         return OTCRYPTO_BAD_ARGS;
       }
       rsa_3072_public_key_t *pk = (rsa_3072_public_key_t *)public_key->key;
-      rsa_3072_int_t *sig = (rsa_3072_int_t *)signature->data;
-
       // Check that signature is < n.
-      if (bignum_lt(sig->data, pk->n.data, kRsa3072NumWords) ==
+      if (bignum_lt(signature->data, pk->n.data, kRsa3072NumWords) ==
           kHardenedBoolFalse) {
         return OTCRYPTO_BAD_ARGS;
       }
-
-      HARDENED_TRY_WIPE_DMEM(rsa_signature_verify_3072_start(pk, sig));
+      HARDENED_TRY_WIPE_DMEM(rsa_signature_verify_start(
+          kRsaSize3072, pk->n.data, signature->data));
       return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kOtcryptoRsaSize4096: {
+      HARDENED_CHECK_EQ(size, kOtcryptoRsaSize4096);
       if (signature->len != kRsa4096NumWords) {
         return OTCRYPTO_BAD_ARGS;
       }
       rsa_4096_public_key_t *pk = (rsa_4096_public_key_t *)public_key->key;
-      rsa_4096_int_t *sig = (rsa_4096_int_t *)signature->data;
-
       // Check that signature is < n.
-      if (bignum_lt(sig->data, pk->n.data, kRsa4096NumWords) ==
+      if (bignum_lt(signature->data, pk->n.data, kRsa4096NumWords) ==
           kHardenedBoolFalse) {
         return OTCRYPTO_BAD_ARGS;
       }
-
-      HARDENED_TRY_WIPE_DMEM(rsa_signature_verify_4096_start(pk, sig));
+      HARDENED_TRY_WIPE_DMEM(rsa_signature_verify_start(
+          kRsaSize4096, pk->n.data, signature->data));
       return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     default:
@@ -959,25 +959,27 @@ otcrypto_status_t otcrypto_rsa_encrypt_async_start(
       HARDENED_CHECK_EQ(size, kOtcryptoRsaSize2048);
       HARDENED_CHECK_EQ(public_key->key_length, sizeof(rsa_2048_public_key_t));
       rsa_2048_public_key_t *pk = (rsa_2048_public_key_t *)public_key->key;
-      HARDENED_TRY_WIPE_DMEM(rsa_encrypt_2048_start(
-          pk, hash_mode, message->data, message->len, label->data, label->len));
+      HARDENED_TRY_WIPE_DMEM(
+          rsa_encrypt_start(kRsaSize2048, pk->n.data, hash_mode, message->data,
+                            message->len, label->data, label->len));
       return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kOtcryptoRsaSize3072: {
       HARDENED_CHECK_EQ(size, kOtcryptoRsaSize3072);
       HARDENED_CHECK_EQ(public_key->key_length, sizeof(rsa_3072_public_key_t));
       rsa_3072_public_key_t *pk = (rsa_3072_public_key_t *)public_key->key;
-      HARDENED_TRY_WIPE_DMEM(otcrypto_eval_exit(
-          rsa_encrypt_3072_start(pk, hash_mode, message->data, message->len,
-                                 label->data, label->len)));
+      HARDENED_TRY_WIPE_DMEM(
+          rsa_encrypt_start(kRsaSize3072, pk->n.data, hash_mode, message->data,
+                            message->len, label->data, label->len));
       return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kOtcryptoRsaSize4096: {
       HARDENED_CHECK_EQ(size, kOtcryptoRsaSize4096);
       HARDENED_CHECK_EQ(public_key->key_length, sizeof(rsa_4096_public_key_t));
       rsa_4096_public_key_t *pk = (rsa_4096_public_key_t *)public_key->key;
-      HARDENED_TRY_WIPE_DMEM(rsa_encrypt_4096_start(
-          pk, hash_mode, message->data, message->len, label->data, label->len));
+      HARDENED_TRY_WIPE_DMEM(
+          rsa_encrypt_start(kRsaSize4096, pk->n.data, hash_mode, message->data,
+                            message->len, label->data, label->len));
       return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     default:
@@ -1004,22 +1006,22 @@ otcrypto_status_t otcrypto_rsa_encrypt_async_finalize(
     case kRsa2048NumWords: {
       HARDENED_CHECK_EQ(ciphertext->len * sizeof(uint32_t),
                         sizeof(rsa_2048_int_t));
-      rsa_2048_int_t *ctext = (rsa_2048_int_t *)ciphertext->data;
-      HARDENED_TRY_WIPE_DMEM(rsa_encrypt_2048_finalize(ctext));
+      HARDENED_TRY_WIPE_DMEM(
+          rsa_encrypt_finalize(kRsaSize2048, ciphertext->data));
       return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kRsa3072NumWords: {
       HARDENED_CHECK_EQ(ciphertext->len * sizeof(uint32_t),
                         sizeof(rsa_3072_int_t));
-      rsa_3072_int_t *ctext = (rsa_3072_int_t *)ciphertext->data;
-      HARDENED_TRY_WIPE_DMEM(rsa_encrypt_3072_finalize(ctext));
+      HARDENED_TRY_WIPE_DMEM(
+          rsa_encrypt_finalize(kRsaSize3072, ciphertext->data));
       return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kRsa4096NumWords: {
       HARDENED_CHECK_EQ(ciphertext->len * sizeof(uint32_t),
                         sizeof(rsa_4096_int_t));
-      rsa_4096_int_t *ctext = (rsa_4096_int_t *)ciphertext->data;
-      HARDENED_TRY_WIPE_DMEM(rsa_encrypt_4096_finalize(ctext));
+      HARDENED_TRY_WIPE_DMEM(
+          rsa_encrypt_finalize(kRsaSize4096, ciphertext->data));
       return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     default:
@@ -1072,15 +1074,16 @@ otcrypto_status_t otcrypto_rsa_decrypt_async_start(
       }
       rsa_2048_private_key_t *sk =
           (rsa_2048_private_key_t *)private_key->keyblob;
-      rsa_2048_int_t *ctext = (rsa_2048_int_t *)ciphertext->data;
 
       // Check that ciphertext is < n.
-      if (bignum_lt(ctext->data, sk->n.data, kRsa2048NumWords) ==
+      if (bignum_lt(ciphertext->data, sk->n.data, kRsa2048NumWords) ==
           kHardenedBoolFalse) {
         return OTCRYPTO_BAD_ARGS;
       }
 
-      HARDENED_TRY_WIPE_DMEM(rsa_decrypt_2048_start(sk, ctext));
+      HARDENED_TRY_WIPE_DMEM(rsa_decrypt_start(kRsaSize2048, sk->d0.data,
+                                               sk->d1.data, sk->n.data,
+                                               ciphertext->data));
       return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kOtcryptoRsaSize3072: {
@@ -1092,16 +1095,17 @@ otcrypto_status_t otcrypto_rsa_decrypt_async_start(
       }
       rsa_3072_private_key_t *sk =
           (rsa_3072_private_key_t *)private_key->keyblob;
-      rsa_3072_int_t *ctext = (rsa_3072_int_t *)ciphertext->data;
 
       // Check that ciphertext is < n.
-      if (bignum_lt(ctext->data, sk->n.data, kRsa3072NumWords) ==
+      if (bignum_lt(ciphertext->data, sk->n.data, kRsa3072NumWords) ==
           kHardenedBoolFalse) {
         // COVERAGE (MISSING) We do not cover ciphertexts larger than n
         return OTCRYPTO_BAD_ARGS;
       }
 
-      HARDENED_TRY_WIPE_DMEM(rsa_decrypt_3072_start(sk, ctext));
+      HARDENED_TRY_WIPE_DMEM(rsa_decrypt_start(kRsaSize3072, sk->d0.data,
+                                               sk->d1.data, sk->n.data,
+                                               ciphertext->data));
       return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     case kOtcryptoRsaSize4096: {
@@ -1113,16 +1117,17 @@ otcrypto_status_t otcrypto_rsa_decrypt_async_start(
       }
       rsa_4096_private_key_t *sk =
           (rsa_4096_private_key_t *)private_key->keyblob;
-      rsa_4096_int_t *ctext = (rsa_4096_int_t *)ciphertext->data;
 
       // Check that ciphertext is < n.
-      if (bignum_lt(ctext->data, sk->n.data, kRsa4096NumWords) ==
+      if (bignum_lt(ciphertext->data, sk->n.data, kRsa4096NumWords) ==
           kHardenedBoolFalse) {
         // COVERAGE (MISSING) We do not cover ciphertexts larger than n
         return OTCRYPTO_BAD_ARGS;
       }
 
-      HARDENED_TRY_WIPE_DMEM(rsa_decrypt_4096_start(sk, ctext));
+      HARDENED_TRY_WIPE_DMEM(rsa_decrypt_start(kRsaSize4096, sk->d0.data,
+                                               sk->d1.data, sk->n.data,
+                                               ciphertext->data));
       return otcrypto_eval_exit(OTCRYPTO_OK);
     }
     default:

--- a/sw/device/lib/crypto/impl/rsa/rsa_datatypes.h
+++ b/sw/device/lib/crypto/impl/rsa/rsa_datatypes.h
@@ -37,6 +37,15 @@ enum {
 };
 
 /**
+ * Internal RSA sizes.
+ */
+typedef enum rsa_size {
+  kRsaSize2048 = 0x1e3a,
+  kRsaSize3072 = 0x2b5c,
+  kRsaSize4096 = 0x34d9,
+} rsa_size_t;
+
+/**
  * A type that holds a 2048-bit number.
  *
  * This type can be used for RSA-2048 signatures, moduli, private exponents,

--- a/sw/device/lib/crypto/impl/rsa/rsa_encryption.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_encryption.c
@@ -14,32 +14,54 @@
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('r', 'e', 'n')
 
-status_t rsa_encrypt_2048_start(const rsa_2048_public_key_t *public_key,
-                                const otcrypto_hash_mode_t hash_mode,
-                                const uint8_t *message, size_t message_bytelen,
-                                const uint8_t *label, size_t label_bytelen) {
+status_t rsa_encrypt_start(rsa_size_t size, const uint32_t *n,
+                           const otcrypto_hash_mode_t hash_mode,
+                           const uint8_t *message, size_t message_bytelen,
+                           const uint8_t *label, size_t label_bytelen) {
+  size_t num_words = 0;
+  switch (launder32(size)) {
+    case kRsaSize2048:
+      HARDENED_CHECK_EQ(size, kRsaSize2048);
+      num_words = kRsa2048NumWords;
+      break;
+    case kRsaSize3072:
+      HARDENED_CHECK_EQ(size, kRsaSize3072);
+      num_words = kRsa3072NumWords;
+      break;
+    case kRsaSize4096:
+      HARDENED_CHECK_EQ(size, kRsaSize4096);
+      num_words = kRsa4096NumWords;
+      break;
+    default:
+      HARDENED_TRAP();
+      // COVERAGE (FI CM) Unreachable code, checked against fault injections.
+      return OTCRYPTO_FATAL_ERR;
+  }
+
+  // Allocate maximum possible size to avoid VLAs. We allocate enough for
+  // 4096, but will only utilize `num_words`.
+  uint32_t encoded_message[kRsa4096NumWords];
+
   // Encode the message.
-  rsa_2048_int_t encoded_message;
-  HARDENED_TRY(
-      hardened_memshred(encoded_message.data, ARRAYSIZE(encoded_message.data)));
-  HARDENED_TRY(rsa_padding_oaep_encode(
-      hash_mode, message, message_bytelen, label, label_bytelen,
-      ARRAYSIZE(encoded_message.data), encoded_message.data));
+  HARDENED_TRY(hardened_memshred(encoded_message, ARRAYSIZE(encoded_message)));
+  HARDENED_TRY(rsa_padding_oaep_encode(hash_mode, message, message_bytelen,
+                                       label, label_bytelen, num_words,
+                                       encoded_message));
 
   // Start computing (encoded_message ^ e) mod n with a variable-time
   // exponentiation.
-  return rsa_modexp_vartime_2048_start(&encoded_message, &public_key->n);
+  return rsa_modexp_vartime_start(size, encoded_message, n);
 }
 
-status_t rsa_encrypt_2048_finalize(rsa_2048_int_t *ciphertext) {
-  return rsa_modexp_2048_finalize(ciphertext);
+status_t rsa_encrypt_finalize(rsa_size_t size, uint32_t *ciphertext) {
+  return rsa_modexp_finalize_size(size, ciphertext);
 }
 
-status_t rsa_decrypt_2048_start(const rsa_2048_private_key_t *private_key,
-                                const rsa_2048_int_t *ciphertext) {
+status_t rsa_decrypt_start(rsa_size_t size, const uint32_t *d0,
+                           const uint32_t *d1, const uint32_t *n,
+                           const uint32_t *ciphertext) {
   // Start computing (ciphertext ^ d) mod n.
-  return rsa_modexp_consttime_2048_start(ciphertext, &private_key->d0,
-                                         &private_key->d1, &private_key->n);
+  return rsa_modexp_consttime_start(size, ciphertext, d0, d1, n);
 }
 
 status_t rsa_decrypt_finalize(const otcrypto_hash_mode_t hash_mode,
@@ -79,7 +101,8 @@ status_t rsa_decrypt_finalize(const otcrypto_hash_mode_t hash_mode,
     case kRsa2048NumWords: {
       HARDENED_CHECK_EQ(num_words, kRsa2048NumWords);
       rsa_2048_int_t recovered_message;
-      HARDENED_TRY(rsa_modexp_2048_finalize(&recovered_message));
+      HARDENED_TRY(
+          rsa_modexp_finalize_size(kRsaSize2048, recovered_message.data));
       return rsa_padding_oaep_decode(
           hash_mode, label, label_bytelen, recovered_message.data,
           ARRAYSIZE(recovered_message.data), plaintext, plaintext_len);
@@ -87,7 +110,8 @@ status_t rsa_decrypt_finalize(const otcrypto_hash_mode_t hash_mode,
     case kRsa3072NumWords: {
       HARDENED_CHECK_EQ(num_words, kRsa3072NumWords);
       rsa_3072_int_t recovered_message;
-      HARDENED_TRY(rsa_modexp_3072_finalize(&recovered_message));
+      HARDENED_TRY(
+          rsa_modexp_finalize_size(kRsaSize3072, recovered_message.data));
       return rsa_padding_oaep_decode(
           hash_mode, label, label_bytelen, recovered_message.data,
           ARRAYSIZE(recovered_message.data), plaintext, plaintext_len);
@@ -95,7 +119,8 @@ status_t rsa_decrypt_finalize(const otcrypto_hash_mode_t hash_mode,
     case kRsa4096NumWords: {
       HARDENED_CHECK_EQ(num_words, kRsa4096NumWords);
       rsa_4096_int_t recovered_message;
-      HARDENED_TRY(rsa_modexp_4096_finalize(&recovered_message));
+      HARDENED_TRY(
+          rsa_modexp_finalize_size(kRsaSize4096, recovered_message.data));
       return rsa_padding_oaep_decode(
           hash_mode, label, label_bytelen, recovered_message.data,
           ARRAYSIZE(recovered_message.data), plaintext, plaintext_len);
@@ -110,60 +135,4 @@ status_t rsa_decrypt_finalize(const otcrypto_hash_mode_t hash_mode,
   HARDENED_TRAP();
   // COVERAGE (FI CM) Unreachable code, checked against fault injections.
   return OTCRYPTO_FATAL_ERR;
-}
-
-status_t rsa_encrypt_3072_start(const rsa_3072_public_key_t *public_key,
-                                const otcrypto_hash_mode_t hash_mode,
-                                const uint8_t *message, size_t message_bytelen,
-                                const uint8_t *label, size_t label_bytelen) {
-  // Encode the message.
-  rsa_3072_int_t encoded_message;
-  HARDENED_TRY(
-      hardened_memshred(encoded_message.data, ARRAYSIZE(encoded_message.data)));
-  HARDENED_TRY(rsa_padding_oaep_encode(
-      hash_mode, message, message_bytelen, label, label_bytelen,
-      ARRAYSIZE(encoded_message.data), encoded_message.data));
-
-  // Start computing (encoded_message ^ e) mod n with a variable-time
-  // exponentiation.
-  return rsa_modexp_vartime_3072_start(&encoded_message, &public_key->n);
-}
-
-status_t rsa_encrypt_3072_finalize(rsa_3072_int_t *ciphertext) {
-  return rsa_modexp_3072_finalize(ciphertext);
-}
-
-status_t rsa_decrypt_3072_start(const rsa_3072_private_key_t *private_key,
-                                const rsa_3072_int_t *ciphertext) {
-  // Start computing (ciphertext ^ d) mod n.
-  return rsa_modexp_consttime_3072_start(ciphertext, &private_key->d0,
-                                         &private_key->d1, &private_key->n);
-}
-
-status_t rsa_encrypt_4096_start(const rsa_4096_public_key_t *public_key,
-                                const otcrypto_hash_mode_t hash_mode,
-                                const uint8_t *message, size_t message_bytelen,
-                                const uint8_t *label, size_t label_bytelen) {
-  // Encode the message.
-  rsa_4096_int_t encoded_message;
-  HARDENED_TRY(
-      hardened_memshred(encoded_message.data, ARRAYSIZE(encoded_message.data)));
-  HARDENED_TRY(rsa_padding_oaep_encode(
-      hash_mode, message, message_bytelen, label, label_bytelen,
-      ARRAYSIZE(encoded_message.data), encoded_message.data));
-
-  // Start computing (encoded_message ^ e) mod n with a variable-time
-  // exponentiation.
-  return rsa_modexp_vartime_4096_start(&encoded_message, &public_key->n);
-}
-
-status_t rsa_encrypt_4096_finalize(rsa_4096_int_t *ciphertext) {
-  return rsa_modexp_4096_finalize(ciphertext);
-}
-
-status_t rsa_decrypt_4096_start(const rsa_4096_private_key_t *private_key,
-                                const rsa_4096_int_t *ciphertext) {
-  // Start computing (ciphertext ^ d) mod n.
-  return rsa_modexp_consttime_4096_start(ciphertext, &private_key->d0,
-                                         &private_key->d1, &private_key->n);
 }

--- a/sw/device/lib/crypto/impl/rsa/rsa_encryption.h
+++ b/sw/device/lib/crypto/impl/rsa/rsa_encryption.h
@@ -18,7 +18,7 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
- * Starts encrypting a message with RSA-2048; returns immediately.
+ * Starts encrypting a message with RSA; returns immediately.
  *
  * The key exponent must be F4=65537; no other exponents are supported.  The
  * padding scheme is OAEP, and the mask generation function (MGF) is MGF1 with
@@ -27,7 +27,8 @@ extern "C" {
  *
  * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
  *
- * @param public_key RSA public key.
+ * @param size RSA size parameter (e.g. 2048, 3072, 4096).
+ * @param n RSA public modulus.
  * @param hash_mode Hash function to use for message encoding.
  * @param message Message to encrypt.
  * @param message_bytelen Message length in bytes.
@@ -36,40 +37,45 @@ extern "C" {
  * @return Result of the operation (OK or error).
  */
 OT_WARN_UNUSED_RESULT
-status_t rsa_encrypt_2048_start(const rsa_2048_public_key_t *public_key,
-                                const otcrypto_hash_mode_t hash_mode,
-                                const uint8_t *message, size_t message_bytelen,
-                                const uint8_t *label, size_t label_bytelen);
+status_t rsa_encrypt_start(rsa_size_t size, const uint32_t *n,
+                           const otcrypto_hash_mode_t hash_mode,
+                           const uint8_t *message, size_t message_bytelen,
+                           const uint8_t *label, size_t label_bytelen);
 
 /**
- * Waits for an RSA-2048 encryption to complete.
+ * Waits for an RSA encryption to complete.
  *
- * Should be invoked only after a `rsa_encrypt_2048_start` call. Blocks until
+ * Should be invoked only after a `rsa_encrypt_start` call. Blocks until
  * OTBN is done processing.
  *
+ * @param size RSA size parameter (e.g. 2048, 3072, 4096).
  * @param[out] ciphertext Encrypted message.
  * @return Result of the operation (OK or error).
  */
 OT_WARN_UNUSED_RESULT
-status_t rsa_encrypt_2048_finalize(rsa_2048_int_t *ciphertext);
+status_t rsa_encrypt_finalize(rsa_size_t size, uint32_t *ciphertext);
 
 /**
- * Start decrypting a message with RSA-2048; returns immediately.
+ * Start decrypting a message with RSA; returns immediately.
  *
  * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
  *
- * @param private_key RSA private key.
+ * @param size RSA size parameter (e.g. 2048, 3072, 4096).
+ * @param d0 RSA private exponent share 0.
+ * @param d1 RSA private exponent share 1.
+ * @param n RSA public modulus.
  * @param ciphertext Encrypted message.
  * @return Result of the operation (OK or error).
  */
 OT_WARN_UNUSED_RESULT
-status_t rsa_decrypt_2048_start(const rsa_2048_private_key_t *private_key,
-                                const rsa_2048_int_t *ciphertext);
+status_t rsa_decrypt_start(rsa_size_t size, const uint32_t *d0,
+                           const uint32_t *d1, const uint32_t *n,
+                           const uint32_t *ciphertext);
 
 /**
  * Waits for an RSA decryption to complete.
  *
- * Should be invoked only after an `rsa_decrypt_{size}_start`, but works for
+ * Should be invoked only after an `rsa_decrypt_start`, but works for
  * any RSA size. Blocks until OTBN is done processing, and then infers the size
  * from the OTBN application mode.
  *
@@ -103,104 +109,6 @@ status_t rsa_decrypt_finalize(const otcrypto_hash_mode_t hash_mode,
                               const uint8_t *label, size_t label_bytelen,
                               size_t plaintext_max_bytelen, uint8_t *plaintext,
                               size_t *plaintext_bytelen);
-
-/**
- * Starts encrypting a message with RSA-3072; returns immediately.
- *
- * The key exponent must be F4=65537; no other exponents are supported.  The
- * padding scheme is OAEP, and the mask generation function (MGF) is MGF1 with
- * the hash function indicated by `hash_mode` and a salt the same length as the
- * hash function output.
- *
- * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
- *
- * @param public_key RSA public key.
- * @param hash_mode Hash function to use for message encoding.
- * @param message Message to encrypt.
- * @param message_bytelen Message length in bytes.
- * @param label Label for OAEP padding.
- * @param label_bytelen Length of label in bytes.
- * @return Result of the operation (OK or error).
- */
-OT_WARN_UNUSED_RESULT
-status_t rsa_encrypt_3072_start(const rsa_3072_public_key_t *public_key,
-                                const otcrypto_hash_mode_t hash_mode,
-                                const uint8_t *message, size_t message_bytelen,
-                                const uint8_t *label, size_t label_bytelen);
-
-/**
- * Waits for an RSA-3072 encryption to complete.
- *
- * Should be invoked only after a `rsa_encrypt_3072_start` call. Blocks until
- * OTBN is done processing.
- *
- * @param[out] ciphertext Encrypted message.
- * @return Result of the operation (OK or error).
- */
-OT_WARN_UNUSED_RESULT
-status_t rsa_encrypt_3072_finalize(rsa_3072_int_t *ciphertext);
-
-/**
- * Start decrypting a message with RSA-3072; returns immediately.
- *
- * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
- *
- * @param private_key RSA private key.
- * @param ciphertext Encrypted message.
- * @return Result of the operation (OK or error).
- */
-OT_WARN_UNUSED_RESULT
-status_t rsa_decrypt_3072_start(const rsa_3072_private_key_t *private_key,
-                                const rsa_3072_int_t *ciphertext);
-
-/**
- * Starts encrypting a message with RSA-4096; returns immediately.
- *
- * The key exponent must be F4=65537; no other exponents are supported.  The
- * padding scheme is OAEP, and the mask generation function (MGF) is MGF1 with
- * the hash function indicated by `hash_mode` and a salt the same length as the
- * hash function output.
- *
- * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
- *
- * @param public_key RSA public key.
- * @param hash_mode Hash function to use for message encoding.
- * @param message Message to encrypt.
- * @param message_bytelen Message length in bytes.
- * @param label Label for OAEP padding.
- * @param label_bytelen Length of label in bytes.
- * @return Result of the operation (OK or error).
- */
-OT_WARN_UNUSED_RESULT
-status_t rsa_encrypt_4096_start(const rsa_4096_public_key_t *public_key,
-                                const otcrypto_hash_mode_t hash_mode,
-                                const uint8_t *message, size_t message_bytelen,
-                                const uint8_t *label, size_t label_bytelen);
-
-/**
- * Waits for an RSA-4096 encryption to complete.
- *
- * Should be invoked only after a `rsa_encrypt_4096_start` call. Blocks until
- * OTBN is done processing.
- *
- * @param[out] ciphertext Encrypted message.
- * @return Result of the operation (OK or error).
- */
-OT_WARN_UNUSED_RESULT
-status_t rsa_encrypt_4096_finalize(rsa_4096_int_t *ciphertext);
-
-/**
- * Start decrypting a message with RSA-4096; returns immediately.
- *
- * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
- *
- * @param private_key RSA private key.
- * @param ciphertext Encrypted message.
- * @return Result of the operation (OK or error).
- */
-OT_WARN_UNUSED_RESULT
-status_t rsa_decrypt_4096_start(const rsa_4096_private_key_t *private_key,
-                                const rsa_4096_int_t *ciphertext);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/impl/rsa/rsa_signature.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_signature.c
@@ -162,29 +162,51 @@ static status_t encoded_message_verify(
   return OTCRYPTO_FATAL_ERR;
 }
 
-status_t rsa_signature_generate_2048_start(
-    const rsa_2048_private_key_t *private_key,
+status_t rsa_signature_generate_start(
+    rsa_size_t size, const uint32_t *d0, const uint32_t *d1, const uint32_t *n,
     const otcrypto_hash_digest_t message_digest,
     const rsa_signature_padding_t padding_mode) {
+  size_t num_words = 0;
+  switch (launder32(size)) {
+    case kRsaSize2048:
+      HARDENED_CHECK_EQ(size, kRsaSize2048);
+      num_words = kRsa2048NumWords;
+      break;
+    case kRsaSize3072:
+      HARDENED_CHECK_EQ(size, kRsaSize3072);
+      num_words = kRsa3072NumWords;
+      break;
+    case kRsaSize4096:
+      HARDENED_CHECK_EQ(size, kRsaSize4096);
+      num_words = kRsa4096NumWords;
+      break;
+    default:
+      HARDENED_TRAP();
+      // COVERAGE (FI CM) Unreachable code, checked against fault injections.
+      return OTCRYPTO_FATAL_ERR;
+  }
+
+  // Allocate maximum possible size to avoid VLAs. We allocate enough for
+  // 4096, but will only utilize `num_words`.
+  uint32_t encoded_message[kRsa4096NumWords];
+  HARDENED_TRY(hardened_memshred(encoded_message, ARRAYSIZE(encoded_message)));
+
   // Encode the message.
-  rsa_2048_int_t encoded_message;
-  HARDENED_TRY(message_encode(message_digest, padding_mode,
-                              ARRAYSIZE(encoded_message.data),
-                              encoded_message.data));
+  HARDENED_TRY(
+      message_encode(message_digest, padding_mode, num_words, encoded_message));
 
   // Start computing (encoded_message ^ d) mod n.
-  return rsa_modexp_consttime_2048_start(&encoded_message, &private_key->d0,
-                                         &private_key->d1, &private_key->n);
+  return rsa_modexp_consttime_start(size, encoded_message, d0, d1, n);
 }
 
-status_t rsa_signature_generate_2048_finalize(rsa_2048_int_t *signature) {
-  return rsa_modexp_2048_finalize(signature);
+status_t rsa_signature_generate_finalize(rsa_size_t size, uint32_t *signature) {
+  return rsa_modexp_finalize_size(size, signature);
 }
 
-status_t rsa_signature_verify_2048_start(
-    const rsa_2048_public_key_t *public_key, const rsa_2048_int_t *signature) {
+status_t rsa_signature_verify_start(rsa_size_t size, const uint32_t *n,
+                                    const uint32_t *signature) {
   // Start computing (sig ^ e) mod n with a variable-time exponentiation.
-  return rsa_modexp_vartime_2048_start(signature, &public_key->n);
+  return rsa_modexp_vartime_start(size, signature, n);
 }
 
 status_t rsa_signature_verify_finalize(
@@ -201,7 +223,8 @@ status_t rsa_signature_verify_finalize(
     case kRsa2048NumWords: {
       HARDENED_CHECK_EQ(num_words, kRsa2048NumWords);
       rsa_2048_int_t recovered_message;
-      HARDENED_TRY(rsa_modexp_2048_finalize(&recovered_message));
+      HARDENED_TRY(
+          rsa_modexp_finalize_size(kRsaSize2048, recovered_message.data));
       return encoded_message_verify(
           message_digest, padding_mode, recovered_message.data,
           ARRAYSIZE(recovered_message.data), verification_result);
@@ -209,7 +232,8 @@ status_t rsa_signature_verify_finalize(
     case kRsa3072NumWords: {
       HARDENED_CHECK_EQ(num_words, kRsa3072NumWords);
       rsa_3072_int_t recovered_message;
-      HARDENED_TRY(rsa_modexp_3072_finalize(&recovered_message));
+      HARDENED_TRY(
+          rsa_modexp_finalize_size(kRsaSize3072, recovered_message.data));
       return encoded_message_verify(
           message_digest, padding_mode, recovered_message.data,
           ARRAYSIZE(recovered_message.data), verification_result);
@@ -217,7 +241,8 @@ status_t rsa_signature_verify_finalize(
     case kRsa4096NumWords: {
       HARDENED_CHECK_EQ(num_words, kRsa4096NumWords);
       rsa_4096_int_t recovered_message;
-      HARDENED_TRY(rsa_modexp_4096_finalize(&recovered_message));
+      HARDENED_TRY(
+          rsa_modexp_finalize_size(kRsaSize4096, recovered_message.data));
       return encoded_message_verify(
           message_digest, padding_mode, recovered_message.data,
           ARRAYSIZE(recovered_message.data), verification_result);
@@ -233,54 +258,4 @@ status_t rsa_signature_verify_finalize(
   HARDENED_TRAP();
   // COVERAGE (FI CM) Unreachable code, checked against fault injections.
   return OTCRYPTO_FATAL_ERR;
-}
-
-status_t rsa_signature_generate_3072_start(
-    const rsa_3072_private_key_t *private_key,
-    const otcrypto_hash_digest_t message_digest,
-    const rsa_signature_padding_t padding_mode) {
-  // Encode the message.
-  rsa_3072_int_t encoded_message;
-  HARDENED_TRY(message_encode(message_digest, padding_mode,
-                              ARRAYSIZE(encoded_message.data),
-                              encoded_message.data));
-
-  // Start computing (encoded_message ^ d) mod n.
-  return rsa_modexp_consttime_3072_start(&encoded_message, &private_key->d0,
-                                         &private_key->d1, &private_key->n);
-}
-
-status_t rsa_signature_generate_3072_finalize(rsa_3072_int_t *signature) {
-  return rsa_modexp_3072_finalize(signature);
-}
-
-status_t rsa_signature_verify_3072_start(
-    const rsa_3072_public_key_t *public_key, const rsa_3072_int_t *signature) {
-  // Start computing (sig ^ e) mod n with a variable-time exponentiation.
-  return rsa_modexp_vartime_3072_start(signature, &public_key->n);
-}
-
-status_t rsa_signature_generate_4096_start(
-    const rsa_4096_private_key_t *private_key,
-    const otcrypto_hash_digest_t message_digest,
-    const rsa_signature_padding_t padding_mode) {
-  // Encode the message.
-  rsa_4096_int_t encoded_message;
-  HARDENED_TRY(message_encode(message_digest, padding_mode,
-                              ARRAYSIZE(encoded_message.data),
-                              encoded_message.data));
-
-  // Start computing (encoded_message ^ d) mod n.
-  return rsa_modexp_consttime_4096_start(&encoded_message, &private_key->d0,
-                                         &private_key->d1, &private_key->n);
-}
-
-status_t rsa_signature_generate_4096_finalize(rsa_4096_int_t *signature) {
-  return rsa_modexp_4096_finalize(signature);
-}
-
-status_t rsa_signature_verify_4096_start(
-    const rsa_4096_public_key_t *public_key, const rsa_4096_int_t *signature) {
-  // Start computing (sig ^ e) mod n with a variable-time exponentiation.
-  return rsa_modexp_vartime_4096_start(signature, &public_key->n);
 }

--- a/sw/device/lib/crypto/impl/rsa/rsa_signature.h
+++ b/sw/device/lib/crypto/impl/rsa/rsa_signature.h
@@ -41,52 +41,57 @@ typedef enum rsa_signature_padding {
 } rsa_signature_padding_t;
 
 /**
- * Starts generating an RSA-2048 signature; returns immediately.
+ * Starts generating an RSA signature; returns immediately.
  *
  * The key exponent must be F4=65537; no other exponents are supported.
  *
  * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
  *
- * @param private_key RSA private key.
+ * @param size RSA size parameter (e.g. 2048, 3072, 4096).
+ * @param d0 RSA private exponent share 0.
+ * @param d1 RSA private exponent share 1.
+ * @param n RSA public modulus.
  * @param message_digest Message digest to sign.
  * @param padding_mode Signature padding mode.
  * @return Result of the operation (OK or error).
  */
 OT_WARN_UNUSED_RESULT
-status_t rsa_signature_generate_2048_start(
-    const rsa_2048_private_key_t *private_key,
+status_t rsa_signature_generate_start(
+    rsa_size_t size, const uint32_t *d0, const uint32_t *d1, const uint32_t *n,
     const otcrypto_hash_digest_t message_digest,
     const rsa_signature_padding_t padding_mode);
 
 /**
- * Waits for an RSA-2048 signature generation to complete.
+ * Waits for an RSA signature generation to complete.
  *
- * Should be invoked only after `rsa_2048_sign_start`. Blocks until OTBN is
- * done processing.
+ * Should be invoked only after `rsa_signature_generate_start`. Blocks until
+ * OTBN is done processing.
  *
+ * @param size RSA size parameter (e.g. 2048, 3072, 4096).
  * @param[out] signature Generated signature.
  * @return Result of the operation (OK or error).
  */
 OT_WARN_UNUSED_RESULT
-status_t rsa_signature_generate_2048_finalize(rsa_2048_int_t *signature);
+status_t rsa_signature_generate_finalize(rsa_size_t size, uint32_t *signature);
 
 /**
- * Starts verifying an RSA-2048 signature; returns immediately.
+ * Starts verifying an RSA signature; returns immediately.
  *
  * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
  *
- * @param public_key RSA public key.
+ * @param size RSA size parameter (e.g. 2048, 3072, 4096).
+ * @param n RSA public modulus.
  * @param signature Signature to verify.
  * @return Result of the operation (OK or error).
  */
 OT_WARN_UNUSED_RESULT
-status_t rsa_signature_verify_2048_start(
-    const rsa_2048_public_key_t *public_key, const rsa_2048_int_t *signature);
+status_t rsa_signature_verify_start(rsa_size_t size, const uint32_t *n,
+                                    const uint32_t *signature);
 
 /**
  * Waits for any RSA signature verification to complete.
  *
- * Should be invoked only after a `rsa_signature_verify_{size}_start` call, but
+ * Should be invoked only after a `rsa_signature_verify_start` call, but
  * can be invoked for any size. Blocks until OTBN is done processing, and then
  * infers the size from the OTBN application mode.
  *
@@ -105,92 +110,6 @@ status_t rsa_signature_verify_finalize(
     const otcrypto_hash_digest_t message_digest,
     const rsa_signature_padding_t padding_mode,
     hardened_bool_t *verification_result);
-
-/**
- * Starts generating an RSA-3072 signature; returns immediately.
- *
- * The key exponent must be F4=65537; no other exponents are supported.
- *
- * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
- *
- * @param private_key RSA private key.
- * @param message_digest Message digest to sign.
- * @param padding_mode Signature padding mode.
- * @return Result of the operation (OK or error).
- */
-OT_WARN_UNUSED_RESULT
-status_t rsa_signature_generate_3072_start(
-    const rsa_3072_private_key_t *private_key,
-    const otcrypto_hash_digest_t message_digest,
-    const rsa_signature_padding_t padding_mode);
-
-/**
- * Waits for an RSA-3072 signature generation to complete.
- *
- * Should be invoked only after `rsa_3072_sign_start`. Blocks until OTBN is
- * done processing.
- *
- * @param[out] signature Generated signature.
- * @return Result of the operation (OK or error).
- */
-OT_WARN_UNUSED_RESULT
-status_t rsa_signature_generate_3072_finalize(rsa_3072_int_t *signature);
-
-/**
- * Starts verifying an RSA-3072 signature; returns immediately.
- *
- * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
- *
- * @param public_key RSA public key.
- * @param signature Signature to verify.
- * @return Result of the operation (OK or error).
- */
-OT_WARN_UNUSED_RESULT
-status_t rsa_signature_verify_3072_start(
-    const rsa_3072_public_key_t *public_key, const rsa_3072_int_t *signature);
-
-/**
- * Starts generating an RSA-4096 signature; returns immediately.
- *
- * The key exponent must be F4=65537; no other exponents are supported.
- *
- * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
- *
- * @param private_key RSA private key.
- * @param message_digest Message digest to sign.
- * @param padding_mode Signature padding mode.
- * @return Result of the operation (OK or error).
- */
-OT_WARN_UNUSED_RESULT
-status_t rsa_signature_generate_4096_start(
-    const rsa_4096_private_key_t *private_key,
-    const otcrypto_hash_digest_t message_digest,
-    const rsa_signature_padding_t padding_mode);
-
-/**
- * Waits for an RSA-4096 signature generation to complete.
- *
- * Should be invoked only after `rsa_4096_sign_start`. Blocks until OTBN is
- * done processing.
- *
- * @param[out] signature Generated signature.
- * @return Result of the operation (OK or error).
- */
-OT_WARN_UNUSED_RESULT
-status_t rsa_signature_generate_4096_finalize(rsa_4096_int_t *signature);
-
-/**
- * Starts verifying an RSA-4096 signature; returns immediately.
- *
- * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
- *
- * @param public_key RSA public key.
- * @param signature Signature to verify.
- * @return Result of the operation (OK or error).
- */
-OT_WARN_UNUSED_RESULT
-status_t rsa_signature_verify_4096_start(
-    const rsa_4096_public_key_t *public_key, const rsa_4096_int_t *signature);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/impl/rsa/run_rsa.c
+++ b/sw/device/lib/crypto/impl/rsa/run_rsa.c
@@ -139,132 +139,6 @@ static status_t rsa_modexp_finalize(const size_t num_words, uint32_t *result) {
   return otbn_dmem_sec_wipe();
 }
 
-status_t rsa_modexp_consttime_2048_start(const rsa_2048_int_t *base,
-                                         const rsa_2048_int_t *exp0,
-                                         const rsa_2048_int_t *exp1,
-                                         const rsa_2048_int_t *modulus) {
-  // Load the OTBN app. Fails if OTBN is not idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppRsa));
-
-  // Set mode.
-  uint32_t mode = kMode2048Modexp;
-  HARDENED_TRY(otbn_dmem_write(1, &mode, kOtbnVarRsaMode));
-
-  // Set the base, the modulus n and private exponent d.
-  HARDENED_TRY(otbn_dmem_write(kRsa2048NumWords, base->data, kOtbnVarRsaInOut));
-  HARDENED_TRY(otbn_dmem_write(kRsa2048NumWords, modulus->data, kOtbnVarRsaN));
-  HARDENED_TRY(otbn_dmem_write(kRsa2048NumWords, exp0->data, kOtbnVarRsaD0));
-  HARDENED_TRY(otbn_dmem_write(kRsa2048NumWords, exp1->data, kOtbnVarRsaD1));
-
-  // Start OTBN.
-  return otbn_execute();
-}
-
-status_t rsa_modexp_vartime_2048_start(const rsa_2048_int_t *base,
-                                       const rsa_2048_int_t *modulus) {
-  // Load the OTBN app. Fails if OTBN is not idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppRsa));
-
-  // Set mode.
-  uint32_t mode = kMode2048ModexpF4;
-  HARDENED_TRY(otbn_dmem_write(1, &mode, kOtbnVarRsaMode));
-
-  // Set the base and the modulus n.
-  HARDENED_TRY(otbn_dmem_write(kRsa2048NumWords, base->data, kOtbnVarRsaInOut));
-  HARDENED_TRY(otbn_dmem_write(kRsa2048NumWords, modulus->data, kOtbnVarRsaN));
-
-  // Start OTBN.
-  return otbn_execute();
-}
-
-status_t rsa_modexp_2048_finalize(rsa_2048_int_t *result) {
-  return rsa_modexp_finalize(kRsa2048NumWords, result->data);
-}
-
-status_t rsa_modexp_consttime_3072_start(const rsa_3072_int_t *base,
-                                         const rsa_3072_int_t *exp0,
-                                         const rsa_3072_int_t *exp1,
-                                         const rsa_3072_int_t *modulus) {
-  // Load the OTBN app. Fails if OTBN is not idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppRsa));
-
-  // Set mode.
-  uint32_t mode = kMode3072Modexp;
-  HARDENED_TRY(otbn_dmem_write(1, &mode, kOtbnVarRsaMode));
-
-  // Set the base, the modulus n and private exponent d.
-  HARDENED_TRY(otbn_dmem_write(kRsa3072NumWords, base->data, kOtbnVarRsaInOut));
-  HARDENED_TRY(otbn_dmem_write(kRsa3072NumWords, modulus->data, kOtbnVarRsaN));
-  HARDENED_TRY(otbn_dmem_write(kRsa3072NumWords, exp0->data, kOtbnVarRsaD0));
-  HARDENED_TRY(otbn_dmem_write(kRsa3072NumWords, exp1->data, kOtbnVarRsaD1));
-
-  // Start OTBN.
-  return otbn_execute();
-}
-
-status_t rsa_modexp_vartime_3072_start(const rsa_3072_int_t *base,
-                                       const rsa_3072_int_t *modulus) {
-  // Load the OTBN app. Fails if OTBN is not idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppRsa));
-
-  // Set mode.
-  uint32_t mode = kMode3072ModexpF4;
-  HARDENED_TRY(otbn_dmem_write(1, &mode, kOtbnVarRsaMode));
-
-  // Set the base and the modulus n.
-  HARDENED_TRY(otbn_dmem_write(kRsa3072NumWords, base->data, kOtbnVarRsaInOut));
-  HARDENED_TRY(otbn_dmem_write(kRsa3072NumWords, modulus->data, kOtbnVarRsaN));
-
-  // Start OTBN.
-  return otbn_execute();
-}
-
-status_t rsa_modexp_3072_finalize(rsa_3072_int_t *result) {
-  return rsa_modexp_finalize(kRsa3072NumWords, result->data);
-}
-
-status_t rsa_modexp_consttime_4096_start(const rsa_4096_int_t *base,
-                                         const rsa_4096_int_t *exp0,
-                                         const rsa_4096_int_t *exp1,
-                                         const rsa_4096_int_t *modulus) {
-  // Load the OTBN app. Fails if OTBN is not idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppRsa));
-
-  // Set mode.
-  uint32_t mode = kMode4096Modexp;
-  HARDENED_TRY(otbn_dmem_write(1, &mode, kOtbnVarRsaMode));
-
-  // Set the base, the modulus n and private exponent d.
-  HARDENED_TRY(otbn_dmem_write(kRsa4096NumWords, base->data, kOtbnVarRsaInOut));
-  HARDENED_TRY(otbn_dmem_write(kRsa4096NumWords, modulus->data, kOtbnVarRsaN));
-  HARDENED_TRY(otbn_dmem_write(kRsa4096NumWords, exp0->data, kOtbnVarRsaD0));
-  HARDENED_TRY(otbn_dmem_write(kRsa4096NumWords, exp1->data, kOtbnVarRsaD1));
-
-  // Start OTBN.
-  return otbn_execute();
-}
-
-status_t rsa_modexp_vartime_4096_start(const rsa_4096_int_t *base,
-                                       const rsa_4096_int_t *modulus) {
-  // Load the OTBN app. Fails if OTBN is not idle.
-  HARDENED_TRY(otbn_load_app(kOtbnAppRsa));
-
-  // Set mode.
-  uint32_t mode = kMode4096ModexpF4;
-  HARDENED_TRY(otbn_dmem_write(1, &mode, kOtbnVarRsaMode));
-
-  // Set the base and the modulus n.
-  HARDENED_TRY(otbn_dmem_write(kRsa4096NumWords, base->data, kOtbnVarRsaInOut));
-  HARDENED_TRY(otbn_dmem_write(kRsa4096NumWords, modulus->data, kOtbnVarRsaN));
-
-  // Start OTBN.
-  return otbn_execute();
-}
-
-status_t rsa_modexp_4096_finalize(rsa_4096_int_t *result) {
-  return rsa_modexp_finalize(kRsa4096NumWords, result->data);
-}
-
 /**
  * Start the OTBN key generation program in random-key mode.
  *
@@ -293,7 +167,8 @@ static status_t keygen_start(uint32_t mode) {
  * @param exp_mode Application mode to expect.
  * @param num_words Number of words for modulus and private exponent.
  * @param[out] n Buffer for the modulus.
- * @param[out] d Buffer for the private exponent.
+ * @param[out] d0 Buffer for the private exponent share 0.
+ * @param[out] d1 Buffer for the private exponent share 1.
  * @return OK or error.
  */
 static status_t keygen_finalize(uint32_t exp_mode, size_t num_words,
@@ -345,47 +220,163 @@ static status_t keygen_finalize(uint32_t exp_mode, size_t num_words,
   return otbn_dmem_sec_wipe();
 }
 
-status_t rsa_keygen_2048_start(void) { return keygen_start(kMode2048Keygen); }
+status_t rsa_modexp_consttime_start(rsa_size_t size, const uint32_t *base,
+                                    const uint32_t *exp0, const uint32_t *exp1,
+                                    const uint32_t *modulus) {
+  // Load the OTBN app. Fails if OTBN is not idle.
+  HARDENED_TRY(otbn_load_app(kOtbnAppRsa));
 
-status_t rsa_keygen_2048_finalize(rsa_2048_public_key_t *public_key,
-                                  rsa_2048_private_key_t *private_key) {
-  HARDENED_TRY(keygen_finalize(kMode2048Keygen, kRsa2048NumWords,
-                               private_key->n.data, private_key->d0.data,
-                               private_key->d1.data));
+  size_t num_words = 0;
+  uint32_t mode = 0;
 
-  // Copy the modulus to the public key.
-  HARDENED_TRY(hardened_memcpy(public_key->n.data, private_key->n.data,
-                               ARRAYSIZE(private_key->n.data)));
+  switch (launder32(size)) {
+    case kRsaSize2048:
+      HARDENED_CHECK_EQ(size, kRsaSize2048);
+      num_words = kRsa2048NumWords;
+      mode = kMode2048Modexp;
+      break;
+    case kRsaSize3072:
+      HARDENED_CHECK_EQ(size, kRsaSize3072);
+      num_words = kRsa3072NumWords;
+      mode = kMode3072Modexp;
+      break;
+    case kRsaSize4096:
+      HARDENED_CHECK_EQ(size, kRsaSize4096);
+      num_words = kRsa4096NumWords;
+      mode = kMode4096Modexp;
+      break;
+    default:
+      HARDENED_TRAP();
+      // COVERAGE (FI CM) Unreachable code, checked against fault injections.
+      return OTCRYPTO_FATAL_ERR;
+  }
 
-  return OTCRYPTO_OK;
+  // Set mode.
+  HARDENED_TRY(otbn_dmem_write(1, &mode, kOtbnVarRsaMode));
+
+  // Set the base, the modulus n and private exponent d.
+  HARDENED_TRY(otbn_dmem_write(num_words, base, kOtbnVarRsaInOut));
+  HARDENED_TRY(otbn_dmem_write(num_words, modulus, kOtbnVarRsaN));
+  HARDENED_TRY(otbn_dmem_write(num_words, exp0, kOtbnVarRsaD0));
+  HARDENED_TRY(otbn_dmem_write(num_words, exp1, kOtbnVarRsaD1));
+
+  // Start OTBN.
+  return otbn_execute();
 }
 
-status_t rsa_keygen_3072_start(void) { return keygen_start(kMode3072Keygen); }
+status_t rsa_modexp_vartime_start(rsa_size_t size, const uint32_t *base,
+                                  const uint32_t *modulus) {
+  // Load the OTBN app. Fails if OTBN is not idle.
+  HARDENED_TRY(otbn_load_app(kOtbnAppRsa));
 
-status_t rsa_keygen_3072_finalize(rsa_3072_public_key_t *public_key,
-                                  rsa_3072_private_key_t *private_key) {
-  HARDENED_TRY(keygen_finalize(kMode3072Keygen, kRsa3072NumWords,
-                               private_key->n.data, private_key->d0.data,
-                               private_key->d1.data));
+  size_t num_words = 0;
+  uint32_t mode = 0;
 
-  // Copy the modulus to the public key.
-  HARDENED_TRY(hardened_memcpy(public_key->n.data, private_key->n.data,
-                               ARRAYSIZE(private_key->n.data)));
+  switch (launder32(size)) {
+    case kRsaSize2048:
+      HARDENED_CHECK_EQ(size, kRsaSize2048);
+      num_words = kRsa2048NumWords;
+      mode = kMode2048ModexpF4;
+      break;
+    case kRsaSize3072:
+      HARDENED_CHECK_EQ(size, kRsaSize3072);
+      num_words = kRsa3072NumWords;
+      mode = kMode3072ModexpF4;
+      break;
+    case kRsaSize4096:
+      HARDENED_CHECK_EQ(size, kRsaSize4096);
+      num_words = kRsa4096NumWords;
+      mode = kMode4096ModexpF4;
+      break;
+    default:
+      HARDENED_TRAP();
+      // COVERAGE (FI CM) Unreachable code, checked against fault injections.
+      return OTCRYPTO_FATAL_ERR;
+  }
 
-  return OTCRYPTO_OK;
+  // Set mode.
+  HARDENED_TRY(otbn_dmem_write(1, &mode, kOtbnVarRsaMode));
+
+  // Set the base and the modulus n.
+  HARDENED_TRY(otbn_dmem_write(num_words, base, kOtbnVarRsaInOut));
+  HARDENED_TRY(otbn_dmem_write(num_words, modulus, kOtbnVarRsaN));
+
+  // Start OTBN.
+  return otbn_execute();
 }
 
-status_t rsa_keygen_4096_start(void) { return keygen_start(kMode4096Keygen); }
+status_t rsa_modexp_finalize_size(rsa_size_t size, uint32_t *result) {
+  size_t expected_words = 0;
+  switch (launder32(size)) {
+    case kRsaSize2048:
+      HARDENED_CHECK_EQ(size, kRsaSize2048);
+      expected_words = kRsa2048NumWords;
+      break;
+    case kRsaSize3072:
+      HARDENED_CHECK_EQ(size, kRsaSize3072);
+      expected_words = kRsa3072NumWords;
+      break;
+    case kRsaSize4096:
+      HARDENED_CHECK_EQ(size, kRsaSize4096);
+      expected_words = kRsa4096NumWords;
+      break;
+    default:
+      HARDENED_TRAP();
+      // COVERAGE (FI CM) Unreachable code, checked against fault injections.
+      return OTCRYPTO_FATAL_ERR;
+  }
+  return rsa_modexp_finalize(expected_words, result);
+}
 
-status_t rsa_keygen_4096_finalize(rsa_4096_public_key_t *public_key,
-                                  rsa_4096_private_key_t *private_key) {
-  HARDENED_TRY(keygen_finalize(kMode4096Keygen, kRsa4096NumWords,
-                               private_key->n.data, private_key->d0.data,
-                               private_key->d1.data));
+status_t rsa_keygen_start(rsa_size_t size) {
+  uint32_t mode = 0;
+  switch (launder32(size)) {
+    case kRsaSize2048:
+      HARDENED_CHECK_EQ(size, kRsaSize2048);
+      mode = kMode2048Keygen;
+      break;
+    case kRsaSize3072:
+      HARDENED_CHECK_EQ(size, kRsaSize3072);
+      mode = kMode3072Keygen;
+      break;
+    case kRsaSize4096:
+      HARDENED_CHECK_EQ(size, kRsaSize4096);
+      mode = kMode4096Keygen;
+      break;
+    default:
+      HARDENED_TRAP();
+      // COVERAGE (FI CM) Unreachable code, checked against fault injections.
+      return OTCRYPTO_FATAL_ERR;
+  }
+  return keygen_start(mode);
+}
 
-  // Copy the modulus to the public key.
-  HARDENED_TRY(hardened_memcpy(public_key->n.data, private_key->n.data,
-                               ARRAYSIZE(private_key->n.data)));
+status_t rsa_keygen_finalize_size(rsa_size_t size, uint32_t *n, uint32_t *d0,
+                                  uint32_t *d1) {
+  uint32_t mode = 0;
+  size_t expected_words = 0;
 
-  return OTCRYPTO_OK;
+  switch (launder32(size)) {
+    case kRsaSize2048:
+      HARDENED_CHECK_EQ(size, kRsaSize2048);
+      mode = kMode2048Keygen;
+      expected_words = kRsa2048NumWords;
+      break;
+    case kRsaSize3072:
+      HARDENED_CHECK_EQ(size, kRsaSize3072);
+      mode = kMode3072Keygen;
+      expected_words = kRsa3072NumWords;
+      break;
+    case kRsaSize4096:
+      HARDENED_CHECK_EQ(size, kRsaSize4096);
+      mode = kMode4096Keygen;
+      expected_words = kRsa4096NumWords;
+      break;
+    default:
+      HARDENED_TRAP();
+      // COVERAGE (FI CM) Unreachable code, checked against fault injections.
+      return OTCRYPTO_FATAL_ERR;
+  }
+
+  return keygen_finalize(mode, expected_words, n, d0, d1);
 }

--- a/sw/device/lib/crypto/impl/rsa/run_rsa.h
+++ b/sw/device/lib/crypto/impl/rsa/run_rsa.h
@@ -31,214 +31,79 @@ extern "C" {
 status_t rsa_modexp_wait(size_t *num_words);
 
 /**
- * Start a constant-time RSA-2048 modular exponentiation.
+ * Start a constant-time RSA modular exponentiation.
  *
  * This construct is for secret exponents, and is much slower than the
  * variable-time version.
  *
  * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
  *
+ * @param size RSA size parameter (e.g. 2048, 3072, 4096).
  * @param base Exponentiation base.
- * @param exp Exponent to raise the base to.
+ * @param exp0 Exponent to raise the base to (share 0).
+ * @param exp1 Exponent to raise the base to (share 1).
  * @param modulus Modulus for exponentiation.
  * @return Status of the operation (OK or error).
  */
-status_t rsa_modexp_consttime_2048_start(const rsa_2048_int_t *base,
-                                         const rsa_2048_int_t *exp0,
-                                         const rsa_2048_int_t *exp1,
-                                         const rsa_2048_int_t *modulus);
+status_t rsa_modexp_consttime_start(rsa_size_t size, const uint32_t *base,
+                                    const uint32_t *exp0, const uint32_t *exp1,
+                                    const uint32_t *modulus);
 
 /**
- * Start a variable-time RSA-2048 modular exponentiation.
+ * Start a variable-time RSA modular exponentiation.
  *
  * Do not use this construct with secret exponents; its timing depends on the
  * exponent.
  *
  * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
  *
+ * @param size RSA size parameter (e.g. 2048, 3072, 4096).
  * @param base Exponentiation base.
- * @param exp Exponent to raise the base to.
  * @param modulus Modulus for exponentiation.
  * @return Status of the operation (OK or error).
  */
-status_t rsa_modexp_vartime_2048_start(const rsa_2048_int_t *base,
-                                       const rsa_2048_int_t *modulus);
+status_t rsa_modexp_vartime_start(rsa_size_t size, const uint32_t *base,
+                                  const uint32_t *modulus);
 
 /**
- * Waits for an RSA-2048 modular exponentiation to complete.
+ * Waits for an RSA modular exponentiation to complete.
  *
  * Can be used after either:
- * - `rsa_modexp_consttime_2048_start()`
- * - `rsa_modexp_vartime_2048_start()`
+ * - `rsa_modexp_consttime_start()`
+ * - `rsa_modexp_vartime_start()`
  *
+ * @param size RSA size parameter (e.g. 2048, 3072, 4096).
  * @param[out] result Exponentiation result = (base ^ exp) mod modulus.
  * @return Status of the operation (OK or error).
  */
-status_t rsa_modexp_2048_finalize(rsa_2048_int_t *result);
+status_t rsa_modexp_finalize_size(rsa_size_t size, uint32_t *result);
 
 /**
- * Start a constant-time RSA-3072 modular exponentiation.
- *
- * This construct is for secret exponents, and is much slower than the
- * variable-time version.
- *
- * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
- *
- * @param base Exponentiation base.
- * @param exp Exponent to raise the base to.
- * @param modulus Modulus for exponentiation.
- * @return Status of the operation (OK or error).
- */
-status_t rsa_modexp_consttime_3072_start(const rsa_3072_int_t *base,
-                                         const rsa_3072_int_t *exp0,
-                                         const rsa_3072_int_t *exp1,
-                                         const rsa_3072_int_t *modulus);
-
-/**
- * Start a variable-time RSA-3072 modular exponentiation.
- *
- * Do not use this construct with secret exponents; its timing depends on the
- * exponent.
- *
- * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
- *
- * @param base Exponentiation base.
- * @param exp Exponent to raise the base to.
- * @param modulus Modulus for exponentiation.
- * @return Status of the operation (OK or error).
- */
-status_t rsa_modexp_vartime_3072_start(const rsa_3072_int_t *base,
-                                       const rsa_3072_int_t *modulus);
-
-/**
- * Waits for an RSA-3072 modular exponentiation to complete.
- *
- * Can be used after either:
- * - `rsa_modexp_consttime_3072_start()`
- * - `rsa_modexp_vartime_3072_start()`
- *
- * @param[out] result Exponentiation result = (base ^ exp) mod modulus.
- * @return Status of the operation (OK or error).
- */
-status_t rsa_modexp_3072_finalize(rsa_3072_int_t *result);
-
-/**
- * Start a constant-time RSA-4096 modular exponentiation.
- *
- * This construct is for secret exponents, and is much slower than the
- * variable-time version.
- *
- * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
- *
- * @param base Exponentiation base.
- * @param exp Exponent to raise the base to.
- * @param modulus Modulus for exponentiation.
- * @return Status of the operation (OK or error).
- */
-status_t rsa_modexp_consttime_4096_start(const rsa_4096_int_t *base,
-                                         const rsa_4096_int_t *exp0,
-                                         const rsa_4096_int_t *exp1,
-                                         const rsa_4096_int_t *modulus);
-
-/**
- * Start a variable-time RSA-4096 modular exponentiation.
- *
- * Do not use this construct with secret exponents; its timing depends on the
- * exponent.
- *
- * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
- *
- * @param base Exponentiation base.
- * @param exp Exponent to raise the base to.
- * @param modulus Modulus for exponentiation.
- * @return Status of the operation (OK or error).
- */
-status_t rsa_modexp_vartime_4096_start(const rsa_4096_int_t *base,
-                                       const rsa_4096_int_t *modulus);
-
-/**
- * Waits for an RSA-4096 modular exponentiation to complete.
- *
- * Can be used after either:
- * - `rsa_modexp_consttime_4096_start()`
- * - `rsa_modexp_vartime_4096_start()`
- *
- * @param[out] result Exponentiation result = (base ^ exp) mod modulus.
- * @return Status of the operation (OK or error).
- */
-status_t rsa_modexp_4096_finalize(rsa_4096_int_t *result);
-
-/**
- * Starts an RSA-2048 key generation operation; returns immediately.
+ * Starts an RSA key generation operation; returns immediately.
  *
  * The key exponent is always F4=65537; no other exponents are supported.
  *
  * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
  *
+ * @param size RSA size parameter (e.g. 2048, 3072, 4096).
  * @return Result of the operation (OK or error).
  */
-status_t rsa_keygen_2048_start(void);
+status_t rsa_keygen_start(rsa_size_t size);
 
 /**
- * Waits for an RSA-2048 key generation to complete.
+ * Waits for an RSA key generation to complete.
  *
- * Should be invoked only after `rsa_keygen_2048_start`. Blocks until OTBN is
+ * Should be invoked only after `rsa_keygen_start`. Blocks until OTBN is
  * done processing.
  *
- * @param[out] public_key Generated public key (n, e).
- * @param[out] private_key Generated private key (d, e).
+ * @param size RSA size parameter (e.g. 2048, 3072, 4096).
+ * @param[out] n Generated public key modulus (n).
+ * @param[out] d0 Generated private key exponent share 0 (d0).
+ * @param[out] d1 Generated private key exponent share 1 (d1).
  * @return Result of the operation (OK or error).
  */
-status_t rsa_keygen_2048_finalize(rsa_2048_public_key_t *public_key,
-                                  rsa_2048_private_key_t *private_key);
-
-/**
- * Starts an RSA-3072 key generation operation; returns immediately.
- *
- * The key exponent is always F4=65537; no other exponents are supported.
- *
- * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
- *
- * @return Result of the operation (OK or error).
- */
-status_t rsa_keygen_3072_start(void);
-
-/**
- * Waits for an RSA-3072 key generation to complete.
- *
- * Should be invoked only after `rsa_keygen_3072_start`. Blocks until OTBN is
- * done processing.
- *
- * @param[out] public_key Generated public key (n, e).
- * @param[out] private_key Generated private key (d, e).
- * @return Result of the operation (OK or error).
- */
-status_t rsa_keygen_3072_finalize(rsa_3072_public_key_t *public_key,
-                                  rsa_3072_private_key_t *private_key);
-
-/**
- * Starts an RSA-4096 key generation operation; returns immediately.
- *
- * The key exponent is always F4=65537; no other exponents are supported.
- *
- * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
- *
- * @return Result of the operation (OK or error).
- */
-status_t rsa_keygen_4096_start(void);
-
-/**
- * Waits for an RSA-4096 key generation to complete.
- *
- * Should be invoked only after `rsa_keygen_4096_start`. Blocks until OTBN is
- * done processing.
- *
- * @param[out] public_key Generated public key (n, e).
- * @param[out] private_key Generated private key (d, e).
- * @return Result of the operation (OK or error).
- */
-status_t rsa_keygen_4096_finalize(rsa_4096_public_key_t *public_key,
-                                  rsa_4096_private_key_t *private_key);
+status_t rsa_keygen_finalize_size(rsa_size_t size, uint32_t *n, uint32_t *d0,
+                                  uint32_t *d1);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/impl/rsa/run_rsa_key_from_cofactor.c
+++ b/sw/device/lib/crypto/impl/rsa/run_rsa_key_from_cofactor.c
@@ -56,134 +56,104 @@ enum {
   kOtbnRsaModeWords = 1,
 };
 
-status_t rsa_keygen_from_cofactor_2048_start(
-    const rsa_2048_public_key_t *public_key,
-    const rsa_2048_cofactor_t *cofactor) {
+status_t rsa_keygen_from_cofactor_start(rsa_size_t size,
+                                        const uint32_t *public_key_n,
+                                        const uint32_t *cofactor) {
   // Load the RSA key generation app. Fails if OTBN is non-idle.
   HARDENED_TRY(otbn_load_app(kOtbnAppRsaKeygen));
 
-  // Write the modulus and cofactor into DMEM.
-  HARDENED_TRY(otbn_dmem_write(ARRAYSIZE(public_key->n.data),
-                               public_key->n.data, kOtbnVarRsaN));
-  HARDENED_TRY(otbn_dmem_write(ARRAYSIZE(cofactor->data), cofactor->data,
-                               kOtbnVarRsaCofactor));
+  size_t num_words = 0;
+  uint32_t mode = 0;
+
+  switch (launder32(size)) {
+    case kRsaSize2048:
+      HARDENED_CHECK_EQ(size, kRsaSize2048);
+      num_words = kRsa2048NumWords;
+      mode = kOtbnRsaModeCofactor2048;
+      break;
+    case kRsaSize3072:
+      HARDENED_CHECK_EQ(size, kRsaSize3072);
+      num_words = kRsa3072NumWords;
+      mode = kOtbnRsaModeCofactor3072;
+      break;
+    case kRsaSize4096:
+      HARDENED_CHECK_EQ(size, kRsaSize4096);
+      num_words = kRsa4096NumWords;
+      mode = kOtbnRsaModeCofactor4096;
+      break;
+    default:
+      HARDENED_TRAP();
+      // COVERAGE (FI CM) Unreachable code, checked against fault injections.
+      return OTCRYPTO_FATAL_ERR;
+  }
+
+  // Write the modulus and cofactor into DMEM. Note: The cofactor is half the
+  // size of the modulus.
+  HARDENED_TRY(otbn_dmem_write(num_words, public_key_n, kOtbnVarRsaN));
+  HARDENED_TRY(otbn_dmem_write(num_words / 2, cofactor, kOtbnVarRsaCofactor));
 
   // Set mode and start OTBN.
-  uint32_t mode = kOtbnRsaModeCofactor2048;
   HARDENED_TRY(otbn_dmem_write(kOtbnRsaModeWords, &mode, kOtbnVarRsaMode));
   return otbn_execute();
 }
 
-status_t rsa_keygen_from_cofactor_2048_finalize(
-    rsa_2048_public_key_t *public_key, rsa_2048_private_key_t *private_key) {
+status_t rsa_keygen_from_cofactor_finalize(rsa_size_t size,
+                                           uint32_t *public_key_n,
+                                           uint32_t *private_key_n,
+                                           uint32_t *private_key_d0,
+                                           uint32_t *private_key_d1) {
   // Spin here waiting for OTBN to complete.
   HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
+
+  size_t num_words = 0;
+  uint32_t exp_mode = 0;
+
+  switch (launder32(size)) {
+    case kRsaSize2048:
+      HARDENED_CHECK_EQ(size, kRsaSize2048);
+      num_words = kRsa2048NumWords;
+      exp_mode = kOtbnRsaModeCofactor2048;
+      break;
+    case kRsaSize3072:
+      HARDENED_CHECK_EQ(size, kRsaSize3072);
+      num_words = kRsa3072NumWords;
+      exp_mode = kOtbnRsaModeCofactor3072;
+      break;
+    case kRsaSize4096:
+      HARDENED_CHECK_EQ(size, kRsaSize4096);
+      num_words = kRsa4096NumWords;
+      exp_mode = kOtbnRsaModeCofactor4096;
+      break;
+    default:
+      HARDENED_TRAP();
+      // COVERAGE (FI CM) Unreachable code, checked against fault injections.
+      return OTCRYPTO_FATAL_ERR;
+  }
 
   // Read the mode from OTBN dmem and panic if it's not as expected.
   uint32_t act_mode = 0;
   HARDENED_TRY_WIPE_DMEM(
       otbn_dmem_read(kOtbnRsaModeWords, kOtbnVarRsaMode, &act_mode));
-  if (act_mode != kOtbnRsaModeCofactor2048) {
+  if (act_mode != exp_mode) {
     return OTCRYPTO_FATAL_ERR;
   }
-  HARDENED_CHECK_EQ(launder32(act_mode), kOtbnRsaModeCofactor2048);
+  HARDENED_CHECK_EQ(launder32(act_mode), exp_mode);
 
   // Read the public modulus (n) from OTBN dmem.
   HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kRsa2048NumWords, kOtbnVarRsaN, private_key->n.data));
+      otbn_dmem_read(num_words, kOtbnVarRsaN, private_key_n));
 
   // Read the first share of the private exponent (d) from OTBN dmem.
   HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kRsa2048NumWords, kOtbnVarRsaD0, private_key->d0.data));
+      otbn_dmem_read(num_words, kOtbnVarRsaD0, private_key_d0));
 
   // Read the second share of the private exponent (d) from OTBN dmem.
   HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kRsa2048NumWords, kOtbnVarRsaD1, private_key->d1.data));
+      otbn_dmem_read(num_words, kOtbnVarRsaD1, private_key_d1));
 
   // Copy the modulus to the public key.
-  HARDENED_TRY(hardened_memcpy(public_key->n.data, private_key->n.data,
-                               ARRAYSIZE(private_key->n.data)));
+  HARDENED_TRY(hardened_memcpy(public_key_n, private_key_n, num_words));
 
   // Wipe DMEM.
-  return otbn_dmem_sec_wipe();
-}
-
-status_t rsa_keygen_from_cofactor_3072_start(
-    const rsa_3072_public_key_t *public_key,
-    const rsa_3072_cofactor_t *cofactor) {
-  HARDENED_TRY(otbn_load_app(kOtbnAppRsaKeygen));
-
-  HARDENED_TRY(otbn_dmem_write(ARRAYSIZE(public_key->n.data),
-                               public_key->n.data, kOtbnVarRsaN));
-  HARDENED_TRY(otbn_dmem_write(ARRAYSIZE(cofactor->data), cofactor->data,
-                               kOtbnVarRsaCofactor));
-
-  uint32_t mode = kOtbnRsaModeCofactor3072;
-  HARDENED_TRY(otbn_dmem_write(kOtbnRsaModeWords, &mode, kOtbnVarRsaMode));
-  return otbn_execute();
-}
-
-status_t rsa_keygen_from_cofactor_3072_finalize(
-    rsa_3072_public_key_t *public_key, rsa_3072_private_key_t *private_key) {
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
-
-  uint32_t act_mode = 0;
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kOtbnRsaModeWords, kOtbnVarRsaMode, &act_mode));
-  if (act_mode != kOtbnRsaModeCofactor3072) {
-    return OTCRYPTO_FATAL_ERR;
-  }
-  HARDENED_CHECK_EQ(launder32(act_mode), kOtbnRsaModeCofactor3072);
-
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kRsa3072NumWords, kOtbnVarRsaN, private_key->n.data));
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kRsa3072NumWords, kOtbnVarRsaD0, private_key->d0.data));
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kRsa3072NumWords, kOtbnVarRsaD1, private_key->d1.data));
-
-  HARDENED_TRY(hardened_memcpy(public_key->n.data, private_key->n.data,
-                               ARRAYSIZE(private_key->n.data)));
-
-  return otbn_dmem_sec_wipe();
-}
-
-status_t rsa_keygen_from_cofactor_4096_start(
-    const rsa_4096_public_key_t *public_key,
-    const rsa_4096_cofactor_t *cofactor) {
-  HARDENED_TRY(otbn_load_app(kOtbnAppRsaKeygen));
-
-  HARDENED_TRY(otbn_dmem_write(ARRAYSIZE(public_key->n.data),
-                               public_key->n.data, kOtbnVarRsaN));
-  HARDENED_TRY(otbn_dmem_write(ARRAYSIZE(cofactor->data), cofactor->data,
-                               kOtbnVarRsaCofactor));
-
-  uint32_t mode = kOtbnRsaModeCofactor4096;
-  HARDENED_TRY(otbn_dmem_write(kOtbnRsaModeWords, &mode, kOtbnVarRsaMode));
-  return otbn_execute();
-}
-
-status_t rsa_keygen_from_cofactor_4096_finalize(
-    rsa_4096_public_key_t *public_key, rsa_4096_private_key_t *private_key) {
-  HARDENED_TRY_WIPE_DMEM(otbn_busy_wait_for_done());
-
-  uint32_t act_mode = 0;
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kOtbnRsaModeWords, kOtbnVarRsaMode, &act_mode));
-  if (act_mode != kOtbnRsaModeCofactor4096) {
-    return OTCRYPTO_FATAL_ERR;
-  }
-  HARDENED_CHECK_EQ(launder32(act_mode), kOtbnRsaModeCofactor4096);
-
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kRsa4096NumWords, kOtbnVarRsaN, private_key->n.data));
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kRsa4096NumWords, kOtbnVarRsaD0, private_key->d0.data));
-  HARDENED_TRY_WIPE_DMEM(
-      otbn_dmem_read(kRsa4096NumWords, kOtbnVarRsaD1, private_key->d1.data));
-
-  HARDENED_TRY(hardened_memcpy(public_key->n.data, private_key->n.data,
-                               ARRAYSIZE(private_key->n.data)));
-
   return otbn_dmem_sec_wipe();
 }

--- a/sw/device/lib/crypto/impl/rsa/run_rsa_key_from_cofactor.h
+++ b/sw/device/lib/crypto/impl/rsa/run_rsa_key_from_cofactor.h
@@ -11,13 +11,14 @@
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/crypto/impl/rsa/rsa_datatypes.h"
 #include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
 
 /**
- * Starts an RSA-2048 key-from-cofactor operation; returns immediately.
+ * Starts an RSA key-from-cofactor operation; returns immediately.
  *
  * The key exponent must be F4=65537; no other exponents are supported. This
  * routine does not perform any checks on the generated keypair (e.g. primality
@@ -25,98 +26,37 @@ extern "C" {
  *
  * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
  *
- * @param public_key Public key (n, e).
+ * @param size RSA size parameter (e.g., 2048, 3072, 4096).
+ * @param public_key_n Public key modulus (n).
  * @param cofactor One of the prime cofactors (p or q).
  * @return Result of the operation (OK or error).
  */
-status_t rsa_keygen_from_cofactor_2048_start(
-    const rsa_2048_public_key_t *public_key,
-    const rsa_2048_cofactor_t *cofactor);
+status_t rsa_keygen_from_cofactor_start(rsa_size_t size,
+                                        const uint32_t *public_key_n,
+                                        const uint32_t *cofactor);
 
 /**
- * Waits for an RSA-2048 key-from-cofactor operation to complete.
+ * Waits for an RSA key-from-cofactor operation to complete.
  *
- * Should be invoked only after `rsa_keygen_from_cofactor_2048_start`. Blocks
+ * Should be invoked only after `rsa_keygen_from_cofactor_start`. Blocks
  * until OTBN is done processing.
  *
  * The public key returned by this function is recomputed by OTBN; callers may
  * find it helpful to compare the public key modulus returned to the one that
  * was passed to OTBN originally in order to check for errors.
  *
- * @param[out] public_key Generated public key (n, e).
- * @param[out] private_key Generated private key (d, e).
+ * @param size RSA size parameter (e.g., 2048, 3072, 4096).
+ * @param[out] public_key_n Generated public key modulus (n).
+ * @param[out] private_key_n Generated private key modulus (n).
+ * @param[out] private_key_d0 Generated private key exponent share 0 (d0).
+ * @param[out] private_key_d1 Generated private key exponent share 1 (d1).
  * @return Result of the operation (OK or error).
  */
-status_t rsa_keygen_from_cofactor_2048_finalize(
-    rsa_2048_public_key_t *public_key, rsa_2048_private_key_t *private_key);
-
-/**
- * Starts an RSA-3072 key-from-cofactor operation; returns immediately.
- *
- * The key exponent must be F4=65537; no other exponents are supported. This
- * routine does not perform any checks on the generated keypair (e.g. primality
- * checks or even range checks).
- *
- * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
- *
- * @param public_key Public key (n, e).
- * @param cofactor One of the prime cofactors (p or q).
- * @return Result of the operation (OK or error).
- */
-status_t rsa_keygen_from_cofactor_3072_start(
-    const rsa_3072_public_key_t *public_key,
-    const rsa_3072_cofactor_t *cofactor);
-
-/**
- * Waits for an RSA-3072 key-from-cofactor operation to complete.
- *
- * Should be invoked only after `rsa_keygen_from_cofactor_3072_start`. Blocks
- * until OTBN is done processing.
- *
- * The public key returned by this function is recomputed by OTBN; callers may
- * find it helpful to compare the public key modulus returned to the one that
- * was passed to OTBN originally in order to check for errors.
- *
- * @param[out] public_key Generated public key (n, e).
- * @param[out] private_key Generated private key (d, e).
- * @return Result of the operation (OK or error).
- */
-status_t rsa_keygen_from_cofactor_3072_finalize(
-    rsa_3072_public_key_t *public_key, rsa_3072_private_key_t *private_key);
-
-/**
- * Starts an RSA-4096 key-from-cofactor operation; returns immediately.
- *
- * The key exponent must be F4=65537; no other exponents are supported. This
- * routine does not perform any checks on the generated keypair (e.g. primality
- * checks or even range checks).
- *
- * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
- *
- * @param public_key Public key (n, e).
- * @param cofactor One of the prime cofactors (p or q).
- * @return Result of the operation (OK or error).
- */
-status_t rsa_keygen_from_cofactor_4096_start(
-    const rsa_4096_public_key_t *public_key,
-    const rsa_4096_cofactor_t *cofactor);
-
-/**
- * Waits for an RSA-4096 key-from-cofactor operation to complete.
- *
- * Should be invoked only after `rsa_keygen_from_cofactor_4096_start`. Blocks
- * until OTBN is done processing.
- *
- * The public key returned by this function is recomputed by OTBN; callers may
- * find it helpful to compare the public key modulus returned to the one that
- * was passed to OTBN originally in order to check for errors.
- *
- * @param[out] public_key Generated public key (n, e).
- * @param[out] private_key Generated private key (d, e).
- * @return Result of the operation (OK or error).
- */
-status_t rsa_keygen_from_cofactor_4096_finalize(
-    rsa_4096_public_key_t *public_key, rsa_4096_private_key_t *private_key);
+status_t rsa_keygen_from_cofactor_finalize(rsa_size_t size,
+                                           uint32_t *public_key_n,
+                                           uint32_t *private_key_n,
+                                           uint32_t *private_key_d0,
+                                           uint32_t *private_key_d1);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
Bundle the 2k, 3k, and 4k calls in RSA with a size input (though leave the API unchanged). In order to save code size.

At the time of writing, this saves 1.3k bytes.