### PR TITLE
[crypto] Replace memset in GCM wih volatile loop

### DIFF
--- a/sw/device/lib/crypto/impl/aes_gcm/aes_gcm.c
+++ b/sw/device/lib/crypto/impl/aes_gcm/aes_gcm.c
@@ -662,7 +662,12 @@ status_t aes_gcm_decrypt(const aes_key_t key, const size_t iv_len,
     // If authentication fails, zero the plaintext so that the caller does not
     // use the unauthenticated decrypted data. We still use `OTCRYPTO_OK`
     // because there was no internal error during the authentication check.
-    memset(plaintext_base, 0, ciphertext_len);
+    volatile uint8_t *p = plaintext_base;
+    // Use a volatile loop instead of a memset to ensure that the code persists
+    // even when compiler optimizations are enabled.
+    for (size_t i = 0; i < ciphertext_len; i++) {
+      p[i] = 0;
+    }
   }
   return result;
 }


### PR DESCRIPTION
The compiler could get rid of the memset when aggressive compiler optimizations are enabled. Although this wouldn't be a big problem (the API documentation states that the result only should be used when the CL reports back a success), switch to a volatile loop to guarantee that we always return a zero buffer independent of the compiler optimiziations we use or don't use.