### PR TITLE
[hw,otbn] Add sec_add

### DIFF
--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -42,6 +42,7 @@ filesets:
       - rtl/otbn_loop_controller.sv
       - rtl/otbn_stack.sv
       - rtl/otbn_rnd.sv
+      - rtl/otbn_sec_add.sv
       - rtl/otbn_start_stop_control.sv
       - rtl/otbn_core.sv
       - rtl/otbn_vec_adder.sv

--- a/hw/ip/otbn/pre_dv/README.md
+++ b/hw/ip/otbn/pre_dv/README.md
@@ -1,0 +1,99 @@
+# `otbn_sec_add` Verilator Testbench
+
+This directory contains a C++ Verilator testbench for `otbn_sec_add`, the first-order masked parallel prefix adder used in the OTBN mask accelerator.
+The testbench drives random two-share Boolean inputs and fresh randomness for 1 000 000 stimulus/check pairs, unmasking both input shares and the output shares to verify that the adder computes the correct (Width+1)-bit sum.
+
+
+## Prerequisites
+
+Follow the [Verilator setup guide](../../../../doc/getting_started/setup_verilator.md).
+
+
+## Building and running
+
+All commands below are run from the OpenTitan repository root.
+
+1. Elaborate the RTL and compile the Verilated model.
+   ```sh
+   verilator --cc --exe --build --trace --assert -Wno-WIDTH \
+     --top-module otbn_sec_add \
+     -GWidth=32 \
+     -CFLAGS "-DWIDTH=32" \
+     +define+INC_ASSERT -UVERILATOR \
+     -Ihw/ip/prim/rtl \
+     -Ihw/ip/prim_generic/rtl \
+     hw/ip/prim/rtl/prim_secded_pkg.sv \
+     hw/ip/prim/rtl/prim_trivium_pkg.sv \
+     hw/ip/prim/rtl/prim_util_pkg.sv \
+     hw/ip/prim/rtl/prim_mubi_pkg.sv \
+     hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv \
+     hw/ip/lc_ctrl/rtl/lc_ctrl_state_pkg.sv \
+     hw/ip/lc_ctrl/rtl/lc_ctrl_pkg.sv \
+     hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv \
+     hw/ip/otbn/rtl/otbn_pkg.sv \
+     hw/ip/otbn/rtl/otbn_sec_add.sv \
+     hw/ip/otbn/pre_dv/otbn_sec_add_tb.cpp \
+     -o otbn_sec_add_tb
+   ```
+
+
+1. Run the testbench.
+   ```sh
+   obj_dir/otbn_sec_add_tb
+   ```
+
+   A passing run produces:
+   ```
+   Test ***PASSED*** 1000000 checks
+   ```
+
+   A failing run prints one line per mismatch and then:
+   ```
+   Test ***FAILED*** <n> / 1000000
+   ```
+
+The simulation also writes a VCD waveform to `dump.vcd` in the working directory.
+
+
+## Configuring the adder width
+
+The testbench supports Width values of 4, 8, 16, and 32 bits.
+Two flags must always be kept in sync:
+
+| Flag                  | Purpose                                              |
+|-----------------------|------------------------------------------------------|
+| `-GWidth=N`           | Sets the `Width` parameter of the elaborated RTL     |
+| `-CFLAGS "-DWIDTH=N"` | Sets the matching `WIDTH` macro in the C++ testbench |
+
+Mismatching the two values produces silent wrong results because the testbench and the DUT would disagree on the randomness bus width and the result layout.
+
+Before switching to a different width, remove the stale build artefacts to avoid linker errors from a previous elaboration.
+
+```sh
+rm -rf obj_dir
+```
+
+Example for Width=16:
+
+```sh
+verilator --cc --exe --build --trace --assert -Wno-WIDTH \
+  --top-module otbn_sec_add \
+  -GWidth=16 \
+  -CFLAGS "-DWIDTH=16" \
+  +define+INC_ASSERT -UVERILATOR \
+  -Ihw/ip/prim/rtl \
+  -Ihw/ip/prim_generic/rtl \
+  hw/ip/prim/rtl/prim_secded_pkg.sv \
+  hw/ip/prim/rtl/prim_trivium_pkg.sv \
+  hw/ip/prim/rtl/prim_util_pkg.sv \
+  hw/ip/prim/rtl/prim_mubi_pkg.sv \
+  hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv \
+  hw/ip/lc_ctrl/rtl/lc_ctrl_state_pkg.sv \
+  hw/ip/lc_ctrl/rtl/lc_ctrl_pkg.sv \
+  hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv \
+  hw/ip/otbn/rtl/otbn_pkg.sv \
+  hw/ip/otbn/rtl/otbn_sec_add.sv \
+  hw/ip/otbn/pre_dv/otbn_sec_add_tb.cpp \
+  -o otbn_sec_add_tb
+obj_dir/otbn_sec_add_tb
+```

--- a/hw/ip/otbn/pre_dv/otbn_sec_add_tb.cpp
+++ b/hw/ip/otbn/pre_dv/otbn_sec_add_tb.cpp
@@ -1,0 +1,175 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <cstdio>
+#include <queue>
+#include <random>
+#include <type_traits>
+
+#include "Votbn_sec_add.h"
+#include "verilated.h"
+#include "verilated_vcd_c.h"
+
+// Width of each adder input in bits.
+// This tesbench has only been run with Width as 4, 8, 16 or 32.
+// Override at compile time with -DWIDTH=<n> (e.g. -DWIDTH=16).
+#ifndef WIDTH
+#define WIDTH 32
+#endif
+
+static constexpr int kWidth = WIDTH;
+static_assert(kWidth >= 4 && kWidth <= 32,
+              "Testbench only supports 4 <= Width <= 32.");
+
+// constexpr floor-log2, which equals $clog2 for power-of-2 values.
+constexpr int clog2(int n) { return n <= 1 ? 0 : 1 + clog2(n >> 1); }
+
+static constexpr int kStages = clog2(kWidth);
+static constexpr int kRandWidth = 2 * (kStages * kWidth + 1);
+static constexpr int kRandWords = (kRandWidth + 31) / 32;
+
+// Mask for a single (kWidth+1)-bit result share.
+static constexpr uint64_t kResultMask = (2ULL << kWidth) - 1;
+
+// Mask to restrict random stimulus values to kWidth bits.
+static constexpr uint32_t kShareMask =
+    (kWidth == 32) ? ~0u : ((1u << kWidth) - 1);
+
+static constexpr int TOT_STIMS = 1'000'000;
+static constexpr int RST_HALF_CLK = 20;  // 10 full clock cycles
+
+// Extract one (kWidth+1)-bit share from result_o[1:0][kWidth:0] viewed as
+// uint32_t[].
+static uint64_t result_share(const uint32_t *r, int share) {
+  const int lo_word = (share * (kWidth + 1)) / 32;
+  const int lo_shift = (share * (kWidth + 1)) % 32;
+  uint64_t bits = (uint64_t)r[lo_word];
+  // Only read the next word if the share spans a 32-bit boundary.
+  if (lo_shift + kWidth + 1 > 32)
+    bits |= (uint64_t)r[lo_word + 1] << 32;
+  return (bits >> lo_shift) & kResultMask;
+}
+
+int main(int argc, char **argv) {
+  VerilatedContext *const contextp = new VerilatedContext;
+  contextp->commandArgs(argc, argv);
+  contextp->traceEverOn(true);
+
+  Votbn_sec_add *const dut = new Votbn_sec_add(contextp, "TOP");
+  // rand_i is IData/QData/WData depending on kRandWidth; access it as
+  // uint32_t[] regardless of Verilator type, safe on little-endian hosts for
+  // kWidth >= 4.
+  uint32_t *const rand_raw = reinterpret_cast<uint32_t *>(&dut->rand_i);
+  // VCD waveform writer; receives signal snapshots on each vcd->dump() call.
+  VerilatedVcdC *const vcd = new VerilatedVcdC;
+
+  dut->trace(vcd, 99);
+  vcd->open("dump.vcd");
+
+  // Mersenne Twister RNG with a fixed seed for deterministic, reproducible
+  // stimulus.
+  std::mt19937 rng(42);
+  // Produces uniformly distributed random uint32_t values (full 32-bit range).
+  std::uniform_int_distribution<uint32_t> dist;
+
+  // FIFO of expected (kWidth+1)-bit results. Each entry is pushed when a
+  // stimulus is driven and popped when the corresponding valid_o fires,
+  // absorbing the pipeline latency.
+  std::queue<uint64_t> exp_queue;
+  int n_stims = 0, n_checks = 0, n_errs = 0;
+
+  // Initialise all inputs to a known state before the first eval().
+  dut->clk_i = 0;
+  dut->rst_ni = 0;
+  dut->valid_i = 0;
+  dut->stall_i = 0;
+  dut->inp1_i = 0;
+  dut->inp2_i = 0;
+  for (int i = 0; i < kRandWords; i++)
+    rand_raw[i] = 0;
+
+  // Propagate initial input values through all combinational logic.
+  dut->eval();
+
+  while (n_checks < TOT_STIMS) {
+    dut->clk_i = !dut->clk_i;
+
+    // Release reset after 10 cycles.
+    if (contextp->time() == RST_HALF_CLK)
+      dut->rst_ni = 1;
+
+    if (dut->clk_i && dut->rst_ni) {
+      // Drive stimulus and push golden value for what the DUT will capture this
+      // edge.
+      if (n_stims < TOT_STIMS) {
+        // a0/a1: shares 0 and 1 of inp1_i.
+        const uint32_t a0 = dist(rng) & kShareMask;
+        const uint32_t a1 = dist(rng) & kShareMask;
+        // b0/b1: shares 0 and 1 of inp2_i.
+        const uint32_t b0 = dist(rng) & kShareMask;
+        const uint32_t b1 = dist(rng) & kShareMask;
+        // Verilator packs [1:0][kWidth-1:0] as a flat 2*kWidth-bit integer:
+        // share1 in the upper half, share0 in the lower half. Cast to the
+        // port's exact Verilator type to suppress narrowing warnings (QData for
+        // kWidth=32, IData for 16, SData for 8).
+        dut->inp1_i =
+            static_cast<std::remove_reference_t<decltype(dut->inp1_i)>>(
+                ((uint64_t)a1 << kWidth) | a0);
+        dut->inp2_i =
+            static_cast<std::remove_reference_t<decltype(dut->inp2_i)>>(
+                ((uint64_t)b1 << kWidth) | b0);
+        dut->valid_i = 1;
+        for (int i = 0; i < kRandWords; i++)
+          rand_raw[i] = dist(rng);
+
+        // Push the golden model computation of the result into exp_queue.
+        exp_queue.push(((uint64_t)(a0 ^ a1) + (uint64_t)(b0 ^ b1)) &
+                       kResultMask);
+
+        n_stims++;
+      } else {
+        dut->valid_i = 0;
+      }
+    }
+
+    // Propagate the clock edge and any driven inputs through the DUT.
+    dut->eval();
+
+    // Compare the DUT output to the golden model.
+    if (dut->clk_i && dut->rst_ni && dut->valid_o && !exp_queue.empty()) {
+      const uint32_t *res = reinterpret_cast<const uint32_t *>(&dut->result_o);
+      const uint64_t s0 = result_share(res, 0);
+      const uint64_t s1 = result_share(res, 1);
+      const uint64_t got = (s0 ^ s1) & kResultMask;
+      const uint64_t exp = exp_queue.front();
+      exp_queue.pop();
+      n_checks++;
+      if (got != exp) {
+        n_errs++;
+        printf(
+            "[FAIL] t=%-8llu | exp=%09llx got=%09llx (s0=%09llx s1=%09llx)\n",
+            (unsigned long long)contextp->time(), (unsigned long long)exp,
+            (unsigned long long)got, (unsigned long long)s0,
+            (unsigned long long)s1);
+      }
+    }
+
+    // Record all signal values at the current time step into the VCD file.
+    vcd->dump(contextp->time());
+    contextp->timeInc(1);
+  }
+
+  if (n_errs)
+    printf("Test ***FAILED*** %d / %d\n", n_errs, n_checks);
+  else
+    printf("Test ***PASSED*** %d checks\n", n_checks);
+
+  dut->final();
+  vcd->close();
+  delete vcd;
+  delete dut;
+  delete contextp;
+  return n_errs ? 1 : 0;
+}

--- a/hw/ip/otbn/pre_sca/alma/README.md
+++ b/hw/ip/otbn/pre_sca/alma/README.md
@@ -214,7 +214,7 @@ Run the following command to see the circuit diagramm if there is a leakage:
    xdot tmp/dbg-circuit-0.dot
    ```
 
-## Formally verifying the HPC Gadgets used in the OTBN core
+## Formally verifying the mask accelerator interface modules
 
 After completing the prerequisites above, source the build constants, activate the Alma virtual
 environment and run `verify_sec_add.sh` with the desired gadget:
@@ -227,7 +227,7 @@ source dev/bin/activate
 ${REPO_TOP}/hw/ip/otbn/pre_sca/alma/verify_sec_add.sh <gadget>
 ```
 
-where `<gadget>` is one of `hpc2`, `hpc2o`, `hpc3`, or `hpc3o`.
+where `<gadget>` is one of `hpc2`, `hpc2o`, `hpc3`, `hpc3o`, or `sec_add`.
 The script runs all steps (parse, label, trace, verify) automatically, using the synthesized
 netlist from `syn_out/latest/generated/`.
 

--- a/hw/ip/otbn/pre_sca/alma/cpp/verilator_tb_otbn_sec_add_sca_wrapper.cpp
+++ b/hw/ip/otbn/pre_sca/alma/cpp/verilator_tb_otbn_sec_add_sca_wrapper.cpp
@@ -1,0 +1,63 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Copyright IAIK.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <random>
+#include <stdio.h>
+
+#include "Vcircuit.h"
+#include "testbench.h"
+
+int main(int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Testbench<Vcircuit> tb;
+  tb.opentrace("tmp.vcd");
+
+  // RNG Setup for high-quality entropy
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<uint32_t> dis(0, 0xFFFFFFFF);
+
+  tb.reset();
+
+  // 322 bits requires 11 words of 32-bits (11 * 32 = 352)
+  const int NUM_WORDS = 11;
+  // Mask for the 11th word (Word 10) to only use 2 bits: (1 << 2) - 1
+  const uint32_t LAST_WORD_MASK = 0x3;
+
+  // Initialize the first cycle of randomness
+  for (int word = 0; word < NUM_WORDS; word++) {
+    if (word == (NUM_WORDS - 1)) {
+      tb.m_core.rand_i[word] = dis(gen) & LAST_WORD_MASK;
+    } else {
+      tb.m_core.rand_i[word] = dis(gen);
+    }
+  }
+
+  // Drive Combined Shares (A and B)
+  // [63:32] = B, [31:0] = A
+  tb.m_core.share0_i = 0xDEADBEEFF0F0F0F0ULL;
+  tb.m_core.share1_i = 0x0002C001F0F0F0F0ULL;
+  tb.m_core.en_i = 0;
+
+  tb.tick();
+
+  tb.m_core.en_i = 0x1;
+
+  // Simulation Run
+  for (int i = 0; i < 6; i++) {
+    tb.tick();
+    tb.m_core.en_i = 0x0;
+    for (int word = 0; word < NUM_WORDS; word++) {
+      if (word == (NUM_WORDS - 1)) {
+        tb.m_core.rand_i[word] = dis(gen) & LAST_WORD_MASK;
+      } else {
+        tb.m_core.rand_i[word] = dis(gen);
+      }
+    }
+  }
+
+  tb.closetrace();
+  return 0;
+}

--- a/hw/ip/otbn/pre_sca/alma/verify_sec_add.sh
+++ b/hw/ip/otbn/pre_sca/alma/verify_sec_add.sh
@@ -14,7 +14,7 @@ case "$TARGET_TYPE" in
   hpc2o)   export TOP_MODULE=prim_hpc2o_sca_wrapper ;;
   hpc3)    export TOP_MODULE=prim_hpc3_sca_wrapper ;;
   hpc3o)   export TOP_MODULE=prim_hpc3o_sca_wrapper ;;
-  *)       export TOP_MODULE=prim_hpc3o_sca_wrapper ;;
+  *)       export TOP_MODULE=otbn_sec_add_sca_wrapper ;;
 esac
 
 TESTBENCH=${TOP_MODULE}
@@ -36,6 +36,7 @@ sed -i 's/\(rand_i\(\s\[[0-9]\+:0\]\)\?\s=\s\)unimportant/\1random/g' tmp/labels
   --netlist tmp/circuit.v --c-compiler gcc -o tmp/circuit
 
 # Verify
+# --cycles should be larger than the number of cycles, in the simulation, to be evaluated.
 ./verify.py --json tmp/circuit.json \
   --label tmp/labels.txt \
   --top-module ${TOP_MODULE} \

--- a/hw/ip/otbn/pre_sca/prolead/README.md
+++ b/hw/ip/otbn/pre_sca/prolead/README.md
@@ -35,7 +35,7 @@ This directory contains support files to perform leakage analysis on OTBN gadget
    ```sh
    ./syn_yosys_sec_add.sh <gadget>
    ```
-   Supported gadgets are: `hpc2`, `hpc2o`, `hpc3`, `hpc3o`.
+   Supported gadgets are: `hpc2`, `hpc2o`, `hpc3`, `hpc3o`, `sec_add`.
 
 
 ## Running the leakage analysis
@@ -56,7 +56,7 @@ After building PROLEAD and synthesizing the target gadget:
    ```sh
    ./evaluate.sh <gadget>
    ```
-   The default (no argument) runs the full `mask_accelerator` wrapper.
+   The default (no argument) runs the `sec_add` wrapper.
 
    Results are written to `out/<gadget>_<timestamp>/` and a symlink `out/latest` points to the most recent run.
 

--- a/hw/ip/otbn/pre_sca/prolead/evaluate.sh
+++ b/hw/ip/otbn/pre_sca/prolead/evaluate.sh
@@ -22,7 +22,7 @@ case "$1" in
     ;;
   *)
     # Default case.
-    TOP_MODULE=prim_hpc3o_sca_wrapper
+    TOP_MODULE=otbn_sec_add_sca_wrapper
     ;;
 esac
 if [[ "$#" -gt 1 ]]; then
@@ -45,7 +45,7 @@ echo ${CONFIG_SRC}
 
 # Strip the _comment key (PROLEAD validates all JSON keys strictly).
 CONFIG_TMP=$(mktemp --suffix=.json)
-jq 'del(._comment)' "${CONFIG_SRC}" > "${CONFIG_TMP}"
+grep -v '"_comment"' "${CONFIG_SRC}" > "${CONFIG_TMP}"
 
 # Launch the tool.
 PROLEAD -l ${REPO_TOP}/hw/ip/otbn/pre_sca/prolead/nang45.json \

--- a/hw/ip/otbn/pre_sca/prolead/server_config_otbn_sec_add_sca_wrapper.json
+++ b/hw/ip/otbn/pre_sca/prolead/server_config_otbn_sec_add_sca_wrapper.json
@@ -1,0 +1,111 @@
+{
+  "_comment": "Copyright lowRISC contributors (OpenTitan project). Licensed under the Apache License, Version 2.0, see LICENSE for details. SPDX-License-Identifier: Apache-2.0",
+  "performance": {
+    "max_number_of_threads": "half",
+    "minimize_probing_sets": "aggressive"
+  },
+  "simulation": {
+    "groups": [
+      "64'h$$$$$$$$$$$$$$$$",
+      "64'h0000000000000000"
+    ],
+    "number_of_clock_cycles": 9,
+    "always_random_inputs": [
+      "rand_i[321:0]"
+    ],
+    "input_sequence": [
+      {
+        "signals": [
+          {
+            "name": "share0_i[63:0]",
+            "value": "64'h0000000000000000"
+          },
+          {
+            "name": "share1_i[63:0]",
+            "value": "64'h0000000000000000"
+          },
+          {
+            "name": "en_i",
+            "value": "1'b0"
+          },
+          {
+            "name": "rst_ni",
+            "value": "1'b1"
+          }
+        ]
+      },
+      {
+        "signals": [
+          {
+            "name": "share0_i[63:0]",
+            "value": "64'h0000000000000000"
+          },
+          {
+            "name": "share1_i[63:0]",
+            "value": "64'h0000000000000000"
+          },
+          {
+            "name": "en_i",
+            "value": "1'b0"
+          },
+          {
+            "name": "rst_ni",
+            "value": "1'b0"
+          }
+        ]
+      },
+      {
+        "signals": [
+          {
+            "name": "share0_i[63:0]",
+            "value": "group_in0[63:0]"
+          },
+          {
+            "name": "share1_i[63:0]",
+            "value": "group_in1[63:0]"
+          },
+          {
+            "name": "en_i",
+            "value": "1'b1"
+          },
+          {
+            "name": "rst_ni",
+            "value": "1'b1"
+          }
+        ]
+      },
+      {
+        "signals": [
+          {
+            "name": "share0_i[63:0]",
+            "value": "64'h0000000000000000"
+          },
+          {
+            "name": "share1_i[63:0]",
+            "value": "64'h0000000000000000"
+          },
+          {
+            "name": "en_i",
+            "value": "1'b0"
+          },
+          {
+            "name": "rst_ni",
+            "value": "1'b1"
+          }
+        ]
+      }
+    ],
+    "number_of_simulations": 1536000,
+    "number_of_simulations_per_step": 128000
+  },
+  "hardware": {
+    "clock_signal_name": "clk_i"
+  },
+  "side_channel_analysis": {
+    "order": 1,
+    "transitional_leakage": true,
+    "clock_cycles": [
+        "4-9"
+    ]
+  }
+}

--- a/hw/ip/otbn/pre_sca/rtl/otbn_sec_add_sca_wrapper.sv
+++ b/hw/ip/otbn/pre_sca/rtl/otbn_sec_add_sca_wrapper.sv
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module otbn_sec_add_sca_wrapper #(
+  parameter  int Width       = 32,
+  localparam int NumShares   = 2,
+  localparam int Stages      = $clog2(Width),
+  localparam int RandWidth   = 2*(Stages*Width + 1),
+  localparam int DoubleWidth = 2*Width
+) (
+  input clk_i,
+  input rst_ni,
+
+  input  logic                          en_i,
+  input  logic [RandWidth-1:0]          rand_i,
+  // share0_i = {b_share0, a_share0}, share1_i = {b_share1, a_share1}
+  input  logic [DoubleWidth-1:0]        share0_i,
+  input  logic [DoubleWidth-1:0]        share1_i,
+
+  output logic [NumShares-1:0][Width:0] result_o,
+  output logic                          valid_o
+);
+
+  logic [NumShares-1:0][Width-1:0] inp1_shares;
+  logic [NumShares-1:0][Width-1:0] inp2_shares;
+
+  assign inp1_shares[0] = share0_i[Width-1:0];
+  assign inp1_shares[1] = share1_i[Width-1:0];
+  assign inp2_shares[0] = share0_i[DoubleWidth-1:Width];
+  assign inp2_shares[1] = share1_i[DoubleWidth-1:Width];
+
+  otbn_sec_add u_otbn_sec_add (
+    .clk_i,
+    .rst_ni,
+    .valid_i  (en_i),
+    .stall_i  (1'b0),
+    .rand_i   (rand_i),
+    .inp1_i   (inp1_shares),
+    .inp2_i   (inp2_shares),
+    .result_o (result_o),
+    .valid_o  (valid_o)
+  );
+
+endmodule : otbn_sec_add_sca_wrapper

--- a/hw/ip/otbn/pre_syn/syn_setup_sec_add.example.sh
+++ b/hw/ip/otbn/pre_syn/syn_setup_sec_add.example.sh
@@ -14,7 +14,8 @@ case "$TARGET_TYPE" in
   hpc2o)       export LR_SYNTH_TOP_MODULE=prim_hpc2o_sca_wrapper ;;
   hpc3)        export LR_SYNTH_TOP_MODULE=prim_hpc3_sca_wrapper ;;
   hpc3o)       export LR_SYNTH_TOP_MODULE=prim_hpc3o_sca_wrapper ;;
-  *)           export LR_SYNTH_TOP_MODULE=prim_hpc3o_sca_wrapper ;;
+  sec_add)     export LR_SYNTH_TOP_MODULE=otbn_sec_add_sca_wrapper ;;
+  *)           export LR_SYNTH_TOP_MODULE=otbn_sec_add_sca_wrapper ;;
 esac
 
 # Setup cell library path.

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -41,6 +41,9 @@ package otbn_pkg;
   // Number of Wide Data Registers (WDRs)
   parameter int NWdr = 2 ** WdrAw;
 
+  // Number of shares used inside the mask accelerator
+  parameter int NumShares = 2;
+
   // Width of entropy input
   parameter int EdnDataWidth = 256;
 

--- a/hw/ip/otbn/rtl/otbn_sec_add.sv
+++ b/hw/ip/otbn/rtl/otbn_sec_add.sv
@@ -1,0 +1,312 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+// Description: First-order masked parallel prefix adder based on HPC3 gadgets.
+//
+// Implements a masked Sklansky adder operating on two Width-bit Boolean sharings (inp1_i, inp2_i)
+// and producing a (Width+1)-bit Boolean sharing (result_o), where the extra bit is the carry out.
+// The masking uses 2 shares throughout and is secure against first-order probing attacks. All AND
+// gates are implemented with HPC3 or HPC3o gadgets providing glitch-robust PINI security.
+//
+// Pipeline structure (latency = log2(Width) + 1 cycles, 6 cycles for Width=32):
+//   Cycle 0:    Pre-processing: compute generate (g = inp1 & inp2) and propagate (p = inp1 ^ inp2)
+//   Cycles 1-5: Prefix tree:    log2(Width) stages of masked generate and propagate operations
+//   Cycle 5:    Combinatorial sum generation: result[i] = p_initial[i] ^ g_final[i]
+//
+// rand_i (RandWidth = 2*(log2(Width)*Width + 1) bits = 322 bits for Width=32) is the random input
+// and must be fresh every cycle while data is being processed. Each HPC3 gadget has a dedicated
+// 2-bit randomness register loaded from rand_i one cycle before the gadget fires (enabled by
+// update_en[level-1]).
+//
+// valid_i qualifies the inputs. It is registered through the pipeline alongside the data.
+// stall_i freezes the entire pipeline (all pipeline registers hold their values).
+// valid_o is asserted when a valid result is present at result_o and stall_i is low.
+//
+// Security verification: verified for first order power SCA using Coco Alma and PROLEAD. Setups
+// are under {REPO_TOP}/hw/ip/otbn/pre_sca.
+
+module otbn_sec_add
+  import otbn_pkg::*;
+#(
+  parameter  int Width     = 32,
+  localparam int Stages    = $clog2(Width),            // derived parameter
+  localparam int RandWidth = 2 * (Stages * Width + 1)  // derived parameter
+) (
+  input  logic clk_i,
+  input  logic rst_ni,
+
+  input  logic                            valid_i,
+  input  logic                            stall_i,
+  input  logic [RandWidth-1:0]            rand_i,
+  input  logic [NumShares-1:0][Width-1:0] inp1_i,
+  input  logic [NumShares-1:0][Width-1:0] inp2_i,
+  output logic [NumShares-1:0][Width:0]   result_o,
+  output logic                            valid_o
+);
+
+  // Width needs to be a power of 2.
+  `ASSERT_INIT(OtbnSecAddWidthPow2_A, (Width & (Width - 1)) == 0)
+
+  // g[l][s][i]: prefix generate for share s, bit i, after l prefix stages.
+  // p[l][s][i]: prefix propagate for share s, bit i, after l prefix stages.
+  // pre_p[l][s][i]: initial propagate (inp1^inp2) delayed l pipeline cycles.
+  logic [Stages:0][NumShares-1:0][Width-1:0] g;
+  logic [Stages:0][NumShares-1:0][Width-1:0] p;
+  logic [Stages+1:0][NumShares-1:0][Width-1:0] pre_p;
+
+`ifdef INC_ASSERT
+  // Tracks which rand_i bits are consumed by the generate loops below.
+  // ASSERT_FINAL at the end of the module verifies full coverage.
+  logic [RandWidth-1:0] rand_coverage;
+`endif
+
+  // en[l]: valid flag at pipeline stage l.
+  // update_en[l]: enable for stage l registers, deasserted during stall.
+  logic [Stages+1:0] en;
+  logic [Stages:0] update_en;
+
+  assign en[0] = valid_i;
+
+  always_comb begin
+    for (int i = 0; i <= Stages; i++) begin
+      update_en[i] = en[i] & ~stall_i;
+    end
+  end
+
+  // Pre-computation stage.
+  // pre_p[0] = inp1 ^ inp2
+  for (genvar s = 0; s < NumShares; s++) begin : gen_pre_p
+    prim_xor2 #(
+      .Width(Width)
+    ) u_prim_xor2 (
+      .in0_i(inp1_i[s]),
+      .in1_i(inp2_i[s]),
+      .out_o(pre_p[0][s])
+    );
+  end
+
+  // Align p[0] with g[0], which is delayed by one cycle.
+  assign p[0] = pre_p[1];
+
+  // g[0] = inp1 & inp2
+  for (genvar i = 0; i < Width; i++) begin : gen_pre_g
+    prim_hpc3 #(
+      .EnW(1'b0)
+    ) u_prim_hpc3_and_g (
+      .clk_i,
+      .rst_ni,
+      .en_i(update_en[0]),
+      .x_i ({inp1_i[1][i], inp1_i[0][i]}),
+      .y_i ({inp2_i[1][i], inp2_i[0][i]}),
+      .w_i ('0),
+      .r_i (rand_i[2*i]),
+      .rp_i(rand_i[2*i+1]),
+      .z_o ({g[0][1][i], g[0][0][i]})
+    );
+
+`ifdef INC_ASSERT
+    assign rand_coverage[2*i]   = 1'b1;
+    assign rand_coverage[2*i+1] = 1'b1;
+`endif
+  end
+
+  // Prefix Tree Logic.
+  //
+  // Each level l (1..Stages) is split into Width/(2*Step) groups where Step = 2^(l-1).
+  // Each group spans 2*Step bits and is structured into Step feedthrough nodes and Step active
+  // nodes [gs, gs+2*Step).
+  //  - Feedthrough nodes [gs,      gs+Step):   carry G and P forward unchanged via registers.
+  //  - Active nodes      [gs+Step, gs+2*Step): compute updated G and optionally P.
+  //    Remote is gs+Step-1, the MSB of the feedthrough half.
+  //
+  // Exception: active nodes in group 0 (gs==0) compute only G; their P output is never
+  // consumed since group 0 bits are never referenced as Remote by any other group.
+  //
+  // Each G or P computation is realised by one HPC3 gadget and consumes 2 fresh random bits.
+  for (genvar level = 1; level <= Stages; level++) begin : gen_prefix_stage
+    // Step: half-group size in bits (feedthrough half = lower Step, active half = upper Step).
+    localparam int Step = 1 << (level - 1);
+    // Absolute rand_i bit offset for this level's gadgets.
+    localparam int StageRandOffset = 2 * (level * Width - (Step - 1));
+
+    for (genvar gs = 0; gs < Width; gs = gs + 2*Step) begin : gen_group_logic
+      // Remote is the MSB of this group's feedthrough half.
+      localparam int Remote = gs + Step - 1;
+      // Absolute rand_i bit offset for this group's gadgets.
+      // Group 0: G nodes only, 2 bits/node.
+      // Others groups: G+P nodes, 4 bits/node.
+      localparam int BitsPerNode     = (gs == 0) ? 2 : 4;
+      localparam int GroupRandOffset = StageRandOffset + (gs == 0 ? 0 : 2*(gs - Step));
+
+      // Feedthrough nodes: register G and P unchanged into the next level.
+      for (genvar i = gs; i < gs + Step; i++) begin : gen_feedthrough
+        prim_flop_en #(
+          .Width(NumShares),
+          .ResetValue('0)
+        ) u_prim_flop_en_g (
+          .clk_i (clk_i),
+          .rst_ni(rst_ni),
+          .en_i  (update_en[level]),
+          .d_i   ({g[level-1][1][i], g[level-1][0][i]}),
+          .q_o   ({g[level][1][i],   g[level][0][i]})
+        );
+
+        // For group 0, P is never consumed as a Remote reference, so tie it to zero.
+        if (gs > 0) begin : gen_reg_p
+          prim_flop_en #(
+            .Width(NumShares),
+            .ResetValue('0)
+          ) u_prim_flop_en_p (
+            .clk_i (clk_i),
+            .rst_ni(rst_ni),
+            .en_i  (update_en[level]),
+            .d_i   ({p[level-1][1][i], p[level-1][0][i]}),
+            .q_o   ({p[level][1][i],   p[level][0][i]})
+          );
+        end else begin : gen_no_reg_p
+          logic unused_p;
+          assign p[level][0][i] = '0;
+          assign p[level][1][i] = '0;
+          assign unused_p = p[level][0][i] ^ p[level][1][i];
+        end
+      end
+
+      // Active nodes: compute updated G and optionally P.
+      for (genvar i = gs + Step; i < gs + 2 * Step; i++) begin : gen_gadgets
+        // Absolute rand_i bit offset for this node's gadgets.
+        localparam int NodeRandOffset = GroupRandOffset + BitsPerNode * (i - gs - Step);
+
+        // 2-bit randomness register for the G gadget.
+        // Loaded one cycle before the gadget fires.
+        logic [1:0] rand_g_q;
+        prim_flop_en #(
+          .Width(2),
+          .ResetValue('0)
+        ) u_prim_flop_en_rand_g (
+          .clk_i,
+          .rst_ni,
+          .en_i(update_en[level-1]),
+          .d_i (rand_i[NodeRandOffset +: 2]),
+          .q_o (rand_g_q)
+        );
+
+        // Compute the prefix generate: G[level][i] = G[level-1][i] ^ (P[level-1][i] & G[level-1][Remote])
+        prim_hpc3 #(
+          .EnW(1'b1)
+        ) u_prim_hpc3o_g (
+          .clk_i,
+          .rst_ni,
+          .en_i(update_en[level]),
+          .x_i ({g[level-1][1][Remote], g[level-1][0][Remote]}),
+          .y_i ({p[level-1][1][i],      p[level-1][0][i]}),
+          .w_i ({g[level-1][1][i],      g[level-1][0][i]}),
+          .r_i (rand_g_q[0]),
+          .rp_i(rand_g_q[1]),
+          .z_o ({g[level][1][i], g[level][0][i]})
+        );
+
+`ifdef INC_ASSERT
+        assign rand_coverage[NodeRandOffset]   = 1'b1;
+        assign rand_coverage[NodeRandOffset+1] = 1'b1;
+`endif
+
+        // For group 0, P is never consumed as a Remote reference, so tie it to zero.
+        if (gs == 0) begin : gen_no_gadget_p
+          logic unused_p;
+          assign p[level][0][i] = '0;
+          assign p[level][1][i] = '0;
+          assign unused_p = p[level][0][i] ^ p[level][1][i];
+
+        end else begin : gen_gadget_p
+          // 2-bit randomness register for the P gadget.
+          logic [1:0] rand_p_q;
+          prim_flop_en #(
+            .Width(2),
+            .ResetValue('0)
+          ) u_prim_flop_en_rand_p (
+            .clk_i,
+            .rst_ni,
+            .en_i(update_en[level-1]),
+            .d_i (rand_i[NodeRandOffset + 2 +: 2]),
+            .q_o (rand_p_q)
+          );
+
+          // Compute the prefix propagate: P[level][i] = P[level-1][Remote] & P[level-1][i]
+          prim_hpc3 #(
+            .EnW(1'b0)
+          ) u_prim_hpc3_and_p (
+            .clk_i,
+            .rst_ni,
+            .en_i(update_en[level]),
+            .x_i ({p[level-1][1][Remote], p[level-1][0][Remote]}),
+            .y_i ({p[level-1][1][i],      p[level-1][0][i]}),
+            .w_i ('0),
+            .r_i (rand_p_q[0]),
+            .rp_i(rand_p_q[1]),
+            .z_o ({p[level][1][i], p[level][0][i]})
+          );
+
+`ifdef INC_ASSERT
+          assign rand_coverage[NodeRandOffset+2] = 1'b1;
+          assign rand_coverage[NodeRandOffset+3] = 1'b1;
+`endif
+        end
+      end
+    end
+  end
+
+  for (genvar level = 1; level <= Stages + 1; level++) begin : gen_feedthrough_stage
+    // Feed through pre_p from the pre processing stage for the final sum computation.
+    prim_flop_en #(
+      .Width(NumShares * Width),
+      .ResetValue('0)
+    ) u_prim_flop_en_pre_p (
+      .clk_i (clk_i),
+      .rst_ni(rst_ni),
+      .en_i  (update_en[level-1]),
+      .d_i   ({pre_p[level-1][1], pre_p[level-1][0]}),
+      .q_o   ({pre_p[level][1],   pre_p[level][0]})
+    );
+
+    // Feed through the valid flag signal, which will be used for the stage enable signal.
+    prim_flop_en #(
+      .Width(1),
+      .ResetValue('0)
+    ) u_prim_flop_en_enable (
+      .clk_i (clk_i),
+      .rst_ni(rst_ni),
+      .en_i  (~stall_i),
+      .d_i   (en[level-1]),
+      .q_o   (en[level])
+    );
+  end
+
+  // Final Sum Generation: result[i] = p_initial[i] ^ carry_in[i]
+  // carry_in[i] = g[Stages][i-1] (prefix generate for bits [0..i-1])
+  // carry_in[0] = 0
+  for (genvar s = 0; s < NumShares; s++) begin : gen_sum_share
+    assign result_o[s][0] = pre_p[Stages+1][s][0];
+    for (genvar i = 1; i < Width; i++) begin : gen_sum_bit
+      prim_xor2 #(
+        .Width(1)
+      ) u_prim_xor2 (
+        .in0_i(pre_p[Stages+1][s][i]),
+        .in1_i(g[Stages][s][i-1]),
+        .out_o(result_o[s][i])
+      );
+    end
+    assign result_o[s][Width] = g[Stages][s][Width-1];
+  end
+
+  // Output valid signal only when there's no stall.
+  assign valid_o = en[Stages+1] && !stall_i;
+
+`ifdef INC_ASSERT
+  // Assert that all rand_i bits are assigned.
+  `ASSERT_FINAL(OtbnSecAddRandCoverageComplete_A, rand_coverage == {RandWidth{1'b1}})
+`endif
+
+endmodule

--- a/quality/BUILD.bazel
+++ b/quality/BUILD.bazel
@@ -80,6 +80,7 @@ licence_test(
         "hw/ip/kmac/pre_sca/alma/cpp/verilator_tb_keccak_2share.cpp",
         "hw/ip/otbn/pre_sca/alma/cpp/testbench.h",
         "hw/ip/otbn/pre_sca/alma/cpp/verilator_tb_hpc_gadget_impl.h",
+        "hw/ip/otbn/pre_sca/alma/cpp/verilator_tb_otbn_sec_add_sca_wrapper.cpp",
     ],
     licence = """
     Copyright lowRISC contributors (OpenTitan project).


### PR DESCRIPTION
## Overview
This PR introduces the secure adder, which will serve as the core arithmetic component of the mask accelerator. The adder instantiates Hardware Private Circuits (HPC) gadgets specifically for secure AND and Toffoli operations.

## Architecture & Pipelining

<img width="1082" height="241" alt="sec_add" src="https://github.com/user-attachments/assets/df395fec-5271-43f2-a238-4da32dcdd7e5" />


The graph above illustrates the layout of the 32-bit instantiation. The design is based on a Sklansky adder (a type of parallel prefix adder) and is fully pipelined. Each shape in the diagram (square, circle) represents one clock cycle of latency.

The data path is broken down into three main phases:

1. **Pre-computation Stage:** Computes the initial propagate and generate bits from the two input sharings.

2. **Prefix Adder Tree (5 Stages):** Combines the pre-computed values across the prefix tree logic.

3. **Final Sum Stage:** Combines the resulting propagate and generate bits to compute the final masked sum.

The graph illustrates how the bits are combined, which was very helpful when designing the circuit.

## Synthesis & Verification
For the evaluation of this module, this PR also includes tooling setups:

- **Verilator Testbench:** Verifies instantiations with different widths.
- **Synthesis Setup:** Extended scripts for synthesis.
- **PROLEAD Setup:** Added configuration and testbenches.
- **Coco Alma Setup:** Added configuration and testbenches.