### PR TITLE
[alert,dv] Randomize correct object in alert_receiver_alert_rsp_seq

### DIFF
--- a/hw/dv/sv/alert_esc_agent/seq_lib/alert_receiver_alert_rsp_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/alert_receiver_alert_rsp_seq.sv
@@ -48,7 +48,7 @@ task alert_receiver_alert_rsp_seq::default_rsp_thread();
       wait (req_q.size());
       rsp = req_q.pop_front();
       start_item(rsp);
-      `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
+      `DV_CHECK_RANDOMIZE_WITH_FATAL(rsp,
                                      r_alert_ping_send == 0;
                                      r_alert_rsp       == 1;
                                      int_err           == 0;


### PR DESCRIPTION
This sequence cloned a sequence item, before randomising the item we'd started with, then driving the clone.

I'm not really convinced we need the cloning at all, but we should definitely be running the object that we randomised.