### PR TITLE
[chip, i2c, dv] Make Hold bit in the agent always be at least 1

### DIFF
--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_i2c_host_tx_rx_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_i2c_host_tx_rx_vseq.sv
@@ -84,8 +84,8 @@ class chip_sw_i2c_host_tx_rx_vseq extends chip_sw_i2c_tx_rx_vseq;
     // Hold SDA a cycle longer to account for CDC delays, if CDC is enabled.
     if (cfg.en_dv_cdc) begin
       tSetupBit++;
-      cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tHoldBit = 1;
     end
+    cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tHoldBit = 1;
     cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tSetupBit = tSetupBit;
     cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tClockLow = half_period_cycles - tSetupBit;
     cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tClockPulse = half_period_cycles;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_i2c_host_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_i2c_host_tx_rx_vseq.sv
@@ -84,8 +84,8 @@ class chip_sw_i2c_host_tx_rx_vseq extends chip_sw_i2c_tx_rx_vseq;
     // Hold SDA a cycle longer to account for CDC delays, if CDC is enabled.
     if (cfg.en_dv_cdc) begin
       tSetupBit++;
-      cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tHoldBit = 1;
     end
+    cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tHoldBit = 1;
     cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tSetupBit = tSetupBit;
     cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tClockLow = half_period_cycles - tSetupBit;
     cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tClockPulse = half_period_cycles;


### PR DESCRIPTION
Hold cycles are assigned with 1, for all the supported speeds by OT's I2C block. Check "default_timing_for_speed" function in dif_i2c.c. 

Agent only declare Hold bit = 1 when CDC instrumentation is on. Change it to align with SW parameter independent of CDC instrumentation switch.