### PR TITLE
[chip,dv] Simplify code in chip_sw_all_escalation_resets_vseq

### DIFF
--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_all_escalation_resets_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_all_escalation_resets_vseq.sv
@@ -5,78 +5,107 @@
 class chip_sw_all_escalation_resets_vseq extends chip_sw_base_vseq;
   `uvm_object_utils(chip_sw_all_escalation_resets_vseq)
 
-  `uvm_object_new
-
-  // This associates a regex used to match the instance path and an alert number.
   typedef struct {
-    string ip_inst_regex;
-    byte alert_num;
+    // A shell glob that represents the instance path. This is matched with a * at each end (so
+    // "bar" will match "foobarqux")
+    string ip_inst_glob;
+
+    // The countermeasure by which we will trigger an alert. If this is the empty string, it
+    // defaults to default_cm_name (to avoid having to write a string lots of times in the file)
+    string countermeasure;
+
+    // The index of the alert that the countermeasure will generate
+    int unsigned alert_num;
   } ip_fatal_alert_t;
 
+  // The default countermeasure name for an ip_fatal_alert_t: if its countermeasure field is empty,
+  // this is the countermeasure selected.
+  string default_cm_name = "prim_reg_we_check";
+
   ip_fatal_alert_t ip_alerts[] = '{
-    '{"*aes*prim_reg_we_check*", TopDarjeelingAlertIdAesFatalFault},
-    '{"*aon_timer*prim_reg_we_check*", TopDarjeelingAlertIdAonTimerAonFatalFault},
-    '{"*clkmgr*prim_reg_we_check*", TopDarjeelingAlertIdClkmgrAonFatalFault},
-    '{"*csrng*prim_reg_we_check*", TopDarjeelingAlertIdCsrngFatalAlert},
-    '{"*edn0*prim_reg_we_check*", TopDarjeelingAlertIdEdn0FatalAlert},
-    '{"*edn1*prim_reg_we_check*", TopDarjeelingAlertIdEdn1FatalAlert},
-    '{"*gpio*prim_reg_we_check*", TopDarjeelingAlertIdGpioFatalFault},
-    '{"*hmac*prim_reg_we_check*", TopDarjeelingAlertIdHmacFatalFault},
-    '{"*i2c0*prim_reg_we_check*", TopDarjeelingAlertIdI2c0FatalFault},
-    '{"*keymgr_dpe*prim_reg_we_check*", TopDarjeelingAlertIdKeymgrDpeFatalFaultErr},
-    '{"*kmac*prim_reg_we_check*", TopDarjeelingAlertIdKmacFatalFaultErr},
-    // TODO TopDarjeelingAlertIdLcCtrlFatalProgError: done in sw/device/tests/sim_dv/lc_ctrl_program_error.c?
-    '{"*lc_ctrl*state_regs*", TopDarjeelingAlertIdLcCtrlFatalStateError},
-    '{"*lc_ctrl*prim_reg_we_check*", TopDarjeelingAlertIdLcCtrlFatalBusIntegError},
-    '{"*otbn*prim_reg_we_check*", TopDarjeelingAlertIdOtbnFatal},
+    '{"aes", "", TopDarjeelingAlertIdAesFatalFault},
+    '{"aon_timer", "", TopDarjeelingAlertIdAonTimerAonFatalFault},
+    '{"clkmgr", "", TopDarjeelingAlertIdClkmgrAonFatalFault},
+    '{"csrng", "", TopDarjeelingAlertIdCsrngFatalAlert},
+    '{"edn0", "", TopDarjeelingAlertIdEdn0FatalAlert},
+    '{"edn1", "", TopDarjeelingAlertIdEdn1FatalAlert},
+    '{"gpio", "", TopDarjeelingAlertIdGpioFatalFault},
+    '{"hmac", "", TopDarjeelingAlertIdHmacFatalFault},
+    '{"i2c0", "", TopDarjeelingAlertIdI2c0FatalFault},
+    '{"keymgr_dpe", "", TopDarjeelingAlertIdKeymgrDpeFatalFaultErr},
+    '{"kmac", "", TopDarjeelingAlertIdKmacFatalFaultErr},
+    // TODO TopDarjeelingAlertIdLcCtrlFatalProgError: done in .../sim_dv/lc_ctrl_program_error.c?
+    '{"lc_ctrl", "state_regs", TopDarjeelingAlertIdLcCtrlFatalStateError},
+    '{"lc_ctrl", "", TopDarjeelingAlertIdLcCtrlFatalBusIntegError},
+    '{"otbn", "", TopDarjeelingAlertIdOtbnFatal},
     // TopDarjeelingAlertIdOtpCtrlFatalMacroError: done in chip_sw_otp_ctrl_escalation_vseq
-    '{"*otp_ctrl.u_otp.*u_state_regs", TopDarjeelingAlertIdOtpCtrlFatalPrimOtpAlert},
-    '{"*otp_ctrl*u_otp_ctrl_dai*", TopDarjeelingAlertIdOtpCtrlFatalCheckError},
-    '{"*otp_ctrl*prim_reg_we_check*", TopDarjeelingAlertIdOtpCtrlFatalBusIntegError},
-    '{"*pinmux*prim_reg_we_check*", TopDarjeelingAlertIdPinmuxAonFatalFault},
-    '{"*pwrmgr*prim_reg_we_check*", TopDarjeelingAlertIdPwrmgrAonFatalFault},
-    '{"*rom_ctrl0*prim_reg_we_check*", TopDarjeelingAlertIdRomCtrl0Fatal},
-    '{"*rom_ctrl1*prim_reg_we_check*", TopDarjeelingAlertIdRomCtrl1Fatal},
-    '{"*rstmgr*prim_reg_we_check*", TopDarjeelingAlertIdRstmgrAonFatalFault},
+    '{"otp_ctrl.u_otp", "u_state_regs", TopDarjeelingAlertIdOtpCtrlFatalPrimOtpAlert},
+    '{"otp_ctrl", "u_otp_ctrl_dai", TopDarjeelingAlertIdOtpCtrlFatalCheckError},
+    '{"otp_ctrl", "", TopDarjeelingAlertIdOtpCtrlFatalBusIntegError},
+    '{"pinmux", "", TopDarjeelingAlertIdPinmuxAonFatalFault},
+    '{"pwrmgr", "", TopDarjeelingAlertIdPwrmgrAonFatalFault},
+    '{"rom_ctrl0", "", TopDarjeelingAlertIdRomCtrl0Fatal},
+    '{"rom_ctrl1", "", TopDarjeelingAlertIdRomCtrl1Fatal},
+    '{"rstmgr", "", TopDarjeelingAlertIdRstmgrAonFatalFault},
     // TopDarjeelingAlertIdRstmgrAonFatalCnstyFault cannot use this test.
     //
-    '{"*rv_core_ibex*sw_fatal_err*", TopDarjeelingAlertIdRvCoreIbexFatalSwErr},
-    '{"*rv_core_ibex*prim_reg_we_check*", TopDarjeelingAlertIdRvCoreIbexFatalHwErr},
-    '{"*rv_dm*prim_reg_we_check*", TopDarjeelingAlertIdRvDmFatalFault},
-    '{"*rv_plic*prim_reg_we_check*", TopDarjeelingAlertIdRvPlicFatalFault},
-    '{"*rv_timer*prim_reg_we_check*", TopDarjeelingAlertIdRvTimerFatalFault},
-    '{"*spi_device*prim_reg_we_check*", TopDarjeelingAlertIdSpiDeviceFatalFault},
-    '{"*spi_host0*prim_reg_we_check*", TopDarjeelingAlertIdSpiHost0FatalFault},
-    '{"*sram_ctrl_main*prim_reg_we_check*", TopDarjeelingAlertIdSramCtrlMainFatalError},
-    '{"*sram_ctrl_ret*prim_reg_we_check*", TopDarjeelingAlertIdSramCtrlRetAonFatalError},
-    '{"*uart0*prim_reg_we_check*", TopDarjeelingAlertIdUart0FatalFault}
+    '{"rv_core_ibex", "sw_fatal_err", TopDarjeelingAlertIdRvCoreIbexFatalSwErr},
+    '{"rv_core_ibex", "", TopDarjeelingAlertIdRvCoreIbexFatalHwErr},
+    '{"rv_dm", "", TopDarjeelingAlertIdRvDmFatalFault},
+    '{"rv_plic", "", TopDarjeelingAlertIdRvPlicFatalFault},
+    '{"rv_timer", "", TopDarjeelingAlertIdRvTimerFatalFault},
+    '{"spi_device", "", TopDarjeelingAlertIdSpiDeviceFatalFault},
+    '{"spi_host0", "", TopDarjeelingAlertIdSpiHost0FatalFault},
+    '{"sram_ctrl_main", "", TopDarjeelingAlertIdSramCtrlMainFatalError},
+    '{"sram_ctrl_ret", "", TopDarjeelingAlertIdSramCtrlRetAonFatalError},
+    '{"uart0", "", TopDarjeelingAlertIdUart0FatalFault}
   };
 
-  rand int ip_index;
-  constraint ip_index_c {ip_index inside {[0 : ip_alerts.size() - 1]};}
-
-  // Finds an entry in ip_alerts matching an ip and a security counter-measure by name.
-  // It returns the index of the matching entry. It is fatal if no entry is found.
-  function int get_ip_index_from_name(string ip_name, string sec_cm);
-    string regex = {"*", ip_name, "*", sec_cm, "*"};
-    foreach (ip_alerts[i]) begin
-      if (ip_alerts[i].ip_inst_regex == regex) return i;
-    end
-    `uvm_error(`gfn, $sformatf("%0s does not have a matched ip_index", ip_name))
+  function new (string name="");
+    super.new(name);
   endfunction
 
-  // Returns the first character index in the string argument that represents
-  // the separator (an asterisk, *) between an IP and an associated
-  // counter-measure. If no asterisk is found, returns a negative number.
-  function int find_separator(string str);
-    string sep_char = "*";
-    byte sep = sep_char.getc(0);
-    for (int i = 0; i < str.len(); i = i + 1) begin
-      if (str.getc(i) == sep) begin
+  // Return the index of an entry in ip_alerts for the requested ip and security counter-measure,
+  // searching by name.
+  //
+  // Fail with an error if there is no matching entry.
+  function int unsigned get_ip_index_from_name(string ip_name, string sec_cm);
+    bit allow_empty = (sec_cm == default_cm_name);
+
+    foreach (ip_alerts[i]) begin
+      if (ip_alerts[i].ip_inst_glob == ip_name &&
+          (ip_alerts[i].countermeasure == sec_cm ||
+           (allow_empty && ip_alerts[i].countermeasure == ""))) begin
         return i;
       end
     end
-    return -1;
+    `uvm_error(get_full_name(), $sformatf("Unknown ip/sec_cm pair: %0s/%0s.", ip_name, sec_cm))
+    return 0;
+  endfunction
+
+  // Split str into an ip_name shell glob and countermeasure, splitting on the last '*'. If there is
+  // no '*' in the string, treat the whole thing as an ip_name shell glob and output
+  // default_cm_name for sec_cm.
+  function void tokenize_ip_and_countermeasure(string        str,
+                                               output string ip_name,
+                                               output string sec_cm);
+    bit          found_star;
+    int unsigned last_star_idx;
+
+    for (int unsigned i = 0; i < str.len(); i++) begin
+      if (str.getc(i) == "*") begin
+        last_star_idx = i;
+        found_star = 1;
+      end
+    end
+
+    if (found_star) begin
+      ip_name = str.substr(0, last_star_idx - 1);
+      sec_cm = str.substr(last_star_idx + 1, str.len() - 1);
+    end else begin
+      ip_name = str;
+      sec_cm = default_cm_name;
+    end
   endfunction
 
   // Consume the plusarg called plusarg_name, whose value should be a comma-separated list of
@@ -92,42 +121,59 @@ class chip_sw_all_escalation_resets_vseq extends chip_sw_base_vseq;
     end
   endfunction
 
-  virtual task body();
-    sec_cm_pkg::sec_cm_base_if_proxy if_proxy;
-    ip_fatal_alert_t ip_alert;
-    bit [7:0] sw_alert_num[];
-    string actual_ip;
+  // Look at the entries in the +avoid_inject_fatal_error_for_ips plusarg and add the associated
+  // indices in ip_alerts to excluded_indices.
+  function void get_excluded_indices(ref int unsigned excluded_indices[$]);
     string excluded_ips[$];
-    int excluded_ip_idxs[$];
-
     append_queue_plusarg("avoid_inject_fatal_error_for_ips", excluded_ips);
 
     foreach (excluded_ips[i]) begin
-      string sec_cm;
-      int sep_idx = find_separator(excluded_ips[i]);
-
-      if (sep_idx >= 0) begin
-        int str_len = excluded_ips[i].len();
-        actual_ip = excluded_ips[i].substr(0, sep_idx-1);
-        sec_cm = excluded_ips[i].substr(sep_idx + 1, str_len - 1);
-      end else begin
-        actual_ip = excluded_ips[i];
-        sec_cm = "prim_reg_we_check";
-      end
-      excluded_ip_idxs.push_back(get_ip_index_from_name(actual_ip, sec_cm));
+      string ip_name, sec_cm;
+      tokenize_ip_and_countermeasure(excluded_ips[i], ip_name, sec_cm);
+      excluded_indices.push_back(get_ip_index_from_name(ip_name, sec_cm));
     end
-    `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(ip_index, !(ip_index inside {excluded_ip_idxs});)
+  endfunction
 
-    ip_alert = ip_alerts[ip_index];
+  // Return the countermeasure field for an ip_fatal_alert_t (expanding "" to default_cm_name)
+  function string cm_for_alert(const ref ip_fatal_alert_t alert);
+    return (alert.countermeasure == "") ? default_cm_name : alert.countermeasure;
+  endfunction
 
-    // This sequence will trigger a fatal sec_cm failure.
+  // Return a shell glob for the sec_cm_base_if_proxy for the requested item
+  function string glob_for_alert(const ref ip_fatal_alert_t alert);
+    return {"*", alert.ip_inst_glob, "*", cm_for_alert(alert), "*"};
+  endfunction
+
+  // Search the registered sec_cm proxies and return one that matches the requested item
+  //
+  // If non match, fail with an error.
+  function sec_cm_pkg::sec_cm_base_if_proxy find_proxy_for_alert(const ref ip_fatal_alert_t alert);
+    return sec_cm_pkg::find_sec_cm_if_proxy(.path(glob_for_alert(alert)), .is_regex(1));
+  endfunction
+
+  virtual task body();
+    int unsigned         ip_idx;
+    int unsigned         excluded_ip_idxs[$];
+    ip_fatal_alert_t     ip_alert;
+    bit [7:0]            sw_alert_num[];
+
+    get_excluded_indices(excluded_ip_idxs);
+
+    if (!std::randomize(ip_idx) with {
+          ip_idx < ip_alerts.size();
+          !(ip_idx inside {excluded_ip_idxs});
+        }) begin
+      `uvm_fatal(get_full_name(), "Failed to randomize ip_idx")
+    end
+    ip_alert = ip_alerts[ip_idx];
+
+    // Run chip_sw_base_vseq::body, which will start the SW on the CPU
     super.body();
 
-    `uvm_info(`gfn, $sformatf(
-              "Will inject fault for %s, expecting alert %0d",
-              ip_alert.ip_inst_regex,
-              ip_alert.alert_num
-              ), UVM_MEDIUM)
+    `uvm_info(get_full_name(),
+              $sformatf("Will trigger countermeasure %0s in IP block at %0s, expecting alert %0d",
+                        cm_for_alert(ip_alert), ip_alert.ip_inst_glob, ip_alert.alert_num),
+              UVM_LOW)
 
     // Disable scoreboard tl error checks since we will trigger faults which cannot be predicted.
     cfg.en_scb_tl_err_chk = 0;
@@ -136,22 +182,18 @@ class chip_sw_all_escalation_resets_vseq extends chip_sw_base_vseq;
     sw_alert_num = {ip_alert.alert_num};
     sw_symbol_backdoor_overwrite("kExpectedAlertNumber", sw_alert_num);
 
-    ip_alert = ip_alerts[ip_index];
-
     if (ip_alert.alert_num == TopDarjeelingAlertIdRvCoreIbexFatalSwErr) begin
       `uvm_info(`gfn, "Testing Software fatal alert, no fault to inject", UVM_MEDIUM)
       return;
     end
 
-    if_proxy = sec_cm_pkg::find_sec_cm_if_proxy(.path(ip_alert.ip_inst_regex), .is_regex(1));
     `DV_WAIT(cfg.sw_logger_vif.printed_log == "Ready for fault injection",
              "Timeout waiting for fault injection request.")
 
-    `uvm_info(`gfn, $sformatf(
-              "Injecting fault for IP %s, with alert %0d",
-              ip_alert.ip_inst_regex,
-              ip_alert.alert_num
-              ), UVM_MEDIUM);
-    if_proxy.inject_fault();
+    `uvm_info(get_full_name(),
+              $sformatf("Injecting fault for IP block at %0s, with alert %0d",
+                        ip_alert.ip_inst_glob, ip_alert.alert_num),
+              UVM_LOW);
+    find_proxy_for_alert(ip_alert).inject_fault();
   endtask
 endclass

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_all_escalation_resets_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_all_escalation_resets_vseq.sv
@@ -5,78 +5,107 @@
 class chip_sw_all_escalation_resets_vseq extends chip_sw_base_vseq;
   `uvm_object_utils(chip_sw_all_escalation_resets_vseq)
 
-  `uvm_object_new
-
-  // This associates a regex used to match the instance path and an alert number.
   typedef struct {
-    string ip_inst_regex;
-    byte alert_num;
+    // A shell glob that represents the instance path. This is matched with a * at each end (so
+    // "bar" will match "foobarqux")
+    string ip_inst_glob;
+
+    // The countermeasure by which we will trigger an alert. If this is the empty string, it
+    // defaults to default_cm_name (to avoid having to write a string lots of times in the file)
+    string countermeasure;
+
+    // The index of the alert that the countermeasure will generate
+    int unsigned alert_num;
   } ip_fatal_alert_t;
 
+  // The default countermeasure name for an ip_fatal_alert_t: if its countermeasure field is empty,
+  // this is the countermeasure selected.
+  string default_cm_name = "prim_reg_we_check";
+
   ip_fatal_alert_t ip_alerts[] = '{
-    '{"*aes*prim_reg_we_check*", TopDarjeelingAlertIdAesFatalFault},
-    '{"*aon_timer*prim_reg_we_check*", TopDarjeelingAlertIdAonTimerFatalFault},
-    '{"*clkmgr*prim_reg_we_check*", TopDarjeelingAlertIdClkmgrFatalFault},
-    '{"*csrng*prim_reg_we_check*", TopDarjeelingAlertIdCsrngFatalAlert},
-    '{"*edn0*prim_reg_we_check*", TopDarjeelingAlertIdEdn0FatalAlert},
-    '{"*edn1*prim_reg_we_check*", TopDarjeelingAlertIdEdn1FatalAlert},
-    '{"*gpio*prim_reg_we_check*", TopDarjeelingAlertIdGpioFatalFault},
-    '{"*hmac*prim_reg_we_check*", TopDarjeelingAlertIdHmacFatalFault},
-    '{"*i2c0*prim_reg_we_check*", TopDarjeelingAlertIdI2c0FatalFault},
-    '{"*keymgr_dpe*prim_reg_we_check*", TopDarjeelingAlertIdKeymgrDpeFatalFaultErr},
-    '{"*kmac*prim_reg_we_check*", TopDarjeelingAlertIdKmacFatalFaultErr},
-    // TODO TopDarjeelingAlertIdLcCtrlFatalProgError: done in sw/device/tests/sim_dv/lc_ctrl_program_error.c?
-    '{"*lc_ctrl*state_regs*", TopDarjeelingAlertIdLcCtrlFatalStateError},
-    '{"*lc_ctrl*prim_reg_we_check*", TopDarjeelingAlertIdLcCtrlFatalBusIntegError},
-    '{"*otbn*prim_reg_we_check*", TopDarjeelingAlertIdOtbnFatal},
+    '{"aes", "", TopDarjeelingAlertIdAesFatalFault},
+    '{"aon_timer", "", TopDarjeelingAlertIdAonTimerFatalFault},
+    '{"clkmgr", "", TopDarjeelingAlertIdClkmgrFatalFault},
+    '{"csrng", "", TopDarjeelingAlertIdCsrngFatalAlert},
+    '{"edn0", "", TopDarjeelingAlertIdEdn0FatalAlert},
+    '{"edn1", "", TopDarjeelingAlertIdEdn1FatalAlert},
+    '{"gpio", "", TopDarjeelingAlertIdGpioFatalFault},
+    '{"hmac", "", TopDarjeelingAlertIdHmacFatalFault},
+    '{"i2c0", "", TopDarjeelingAlertIdI2c0FatalFault},
+    '{"keymgr_dpe", "", TopDarjeelingAlertIdKeymgrDpeFatalFaultErr},
+    '{"kmac", "", TopDarjeelingAlertIdKmacFatalFaultErr},
+    // TODO TopDarjeelingAlertIdLcCtrlFatalProgError: done in .../sim_dv/lc_ctrl_program_error.c?
+    '{"lc_ctrl", "state_regs", TopDarjeelingAlertIdLcCtrlFatalStateError},
+    '{"lc_ctrl", "", TopDarjeelingAlertIdLcCtrlFatalBusIntegError},
+    '{"otbn", "", TopDarjeelingAlertIdOtbnFatal},
     // TopDarjeelingAlertIdOtpCtrlFatalMacroError: done in chip_sw_otp_ctrl_escalation_vseq
-    '{"*otp_ctrl.u_otp.*u_state_regs", TopDarjeelingAlertIdOtpCtrlFatalPrimOtpAlert},
-    '{"*otp_ctrl*u_otp_ctrl_dai*", TopDarjeelingAlertIdOtpCtrlFatalCheckError},
-    '{"*otp_ctrl*prim_reg_we_check*", TopDarjeelingAlertIdOtpCtrlFatalBusIntegError},
-    '{"*pinmux*prim_reg_we_check*", TopDarjeelingAlertIdPinmuxFatalFault},
-    '{"*pwrmgr*prim_reg_we_check*", TopDarjeelingAlertIdPwrmgrFatalFault},
-    '{"*rom_ctrl0*prim_reg_we_check*", TopDarjeelingAlertIdRomCtrl0Fatal},
-    '{"*rom_ctrl1*prim_reg_we_check*", TopDarjeelingAlertIdRomCtrl1Fatal},
-    '{"*rstmgr*prim_reg_we_check*", TopDarjeelingAlertIdRstmgrFatalFault},
+    '{"otp_ctrl.u_otp", "u_state_regs", TopDarjeelingAlertIdOtpCtrlFatalPrimOtpAlert},
+    '{"otp_ctrl", "u_otp_ctrl_dai", TopDarjeelingAlertIdOtpCtrlFatalCheckError},
+    '{"otp_ctrl", "", TopDarjeelingAlertIdOtpCtrlFatalBusIntegError},
+    '{"pinmux", "", TopDarjeelingAlertIdPinmuxFatalFault},
+    '{"pwrmgr", "", TopDarjeelingAlertIdPwrmgrFatalFault},
+    '{"rom_ctrl0", "", TopDarjeelingAlertIdRomCtrl0Fatal},
+    '{"rom_ctrl1", "", TopDarjeelingAlertIdRomCtrl1Fatal},
+    '{"rstmgr", "", TopDarjeelingAlertIdRstmgrFatalFault},
     // TopDarjeelingAlertIdRstmgrFatalCnstyFault cannot use this test.
     //
-    '{"*rv_core_ibex*sw_fatal_err*", TopDarjeelingAlertIdRvCoreIbexFatalSwErr},
-    '{"*rv_core_ibex*prim_reg_we_check*", TopDarjeelingAlertIdRvCoreIbexFatalHwErr},
-    '{"*rv_dm*prim_reg_we_check*", TopDarjeelingAlertIdRvDmFatalFault},
-    '{"*rv_plic*prim_reg_we_check*", TopDarjeelingAlertIdRvPlicFatalFault},
-    '{"*rv_timer*prim_reg_we_check*", TopDarjeelingAlertIdRvTimerFatalFault},
-    '{"*spi_device*prim_reg_we_check*", TopDarjeelingAlertIdSpiDeviceFatalFault},
-    '{"*spi_host0*prim_reg_we_check*", TopDarjeelingAlertIdSpiHost0FatalFault},
-    '{"*sram_ctrl_main*prim_reg_we_check*", TopDarjeelingAlertIdSramCtrlMainFatalError},
-    '{"*sram_ctrl_ret*prim_reg_we_check*", TopDarjeelingAlertIdSramCtrlRetFatalError},
-    '{"*uart0*prim_reg_we_check*", TopDarjeelingAlertIdUart0FatalFault}
+    '{"rv_core_ibex", "sw_fatal_err", TopDarjeelingAlertIdRvCoreIbexFatalSwErr},
+    '{"rv_core_ibex", "", TopDarjeelingAlertIdRvCoreIbexFatalHwErr},
+    '{"rv_dm", "", TopDarjeelingAlertIdRvDmFatalFault},
+    '{"rv_plic", "", TopDarjeelingAlertIdRvPlicFatalFault},
+    '{"rv_timer", "", TopDarjeelingAlertIdRvTimerFatalFault},
+    '{"spi_device", "", TopDarjeelingAlertIdSpiDeviceFatalFault},
+    '{"spi_host0", "", TopDarjeelingAlertIdSpiHost0FatalFault},
+    '{"sram_ctrl_main", "", TopDarjeelingAlertIdSramCtrlMainFatalError},
+    '{"sram_ctrl_ret", "", TopDarjeelingAlertIdSramCtrlRetFatalError},
+    '{"uart0", "", TopDarjeelingAlertIdUart0FatalFault}
   };
 
-  rand int ip_index;
-  constraint ip_index_c {ip_index inside {[0 : ip_alerts.size() - 1]};}
-
-  // Finds an entry in ip_alerts matching an ip and a security counter-measure by name.
-  // It returns the index of the matching entry. It is fatal if no entry is found.
-  function int get_ip_index_from_name(string ip_name, string sec_cm);
-    string regex = {"*", ip_name, "*", sec_cm, "*"};
-    foreach (ip_alerts[i]) begin
-      if (ip_alerts[i].ip_inst_regex == regex) return i;
-    end
-    `uvm_error(`gfn, $sformatf("%0s does not have a matched ip_index", ip_name))
+  function new (string name="");
+    super.new(name);
   endfunction
 
-  // Returns the first character index in the string argument that represents
-  // the separator (an asterisk, *) between an IP and an associated
-  // counter-measure. If no asterisk is found, returns a negative number.
-  function int find_separator(string str);
-    string sep_char = "*";
-    byte sep = sep_char.getc(0);
-    for (int i = 0; i < str.len(); i = i + 1) begin
-      if (str.getc(i) == sep) begin
+  // Return the index of an entry in ip_alerts for the requested ip and security counter-measure,
+  // searching by name.
+  //
+  // Fail with an error if there is no matching entry.
+  function int unsigned get_ip_index_from_name(string ip_name, string sec_cm);
+    bit allow_empty = (sec_cm == default_cm_name);
+
+    foreach (ip_alerts[i]) begin
+      if (ip_alerts[i].ip_inst_glob == ip_name &&
+          (ip_alerts[i].countermeasure == sec_cm ||
+           (allow_empty && ip_alerts[i].countermeasure == ""))) begin
         return i;
       end
     end
-    return -1;
+    `uvm_error(get_full_name(), $sformatf("Unknown ip/sec_cm pair: %0s/%0s.", ip_name, sec_cm))
+    return 0;
+  endfunction
+
+  // Split str into an ip_name shell glob and countermeasure, splitting on the last '*'. If there is
+  // no '*' in the string, treat the whole thing as an ip_name shell glob and output
+  // default_cm_name for sec_cm.
+  function void tokenize_ip_and_countermeasure(string        str,
+                                               output string ip_name,
+                                               output string sec_cm);
+    bit          found_star;
+    int unsigned last_star_idx;
+
+    for (int unsigned i = 0; i < str.len(); i++) begin
+      if (str.getc(i) == "*") begin
+        last_star_idx = i;
+        found_star = 1;
+      end
+    end
+
+    if (found_star) begin
+      ip_name = str.substr(0, last_star_idx - 1);
+      sec_cm = str.substr(last_star_idx + 1, str.len() - 1);
+    end else begin
+      ip_name = str;
+      sec_cm = default_cm_name;
+    end
   endfunction
 
   // Consume the plusarg called plusarg_name, whose value should be a comma-separated list of
@@ -92,42 +121,59 @@ class chip_sw_all_escalation_resets_vseq extends chip_sw_base_vseq;
     end
   endfunction
 
-  virtual task body();
-    sec_cm_pkg::sec_cm_base_if_proxy if_proxy;
-    ip_fatal_alert_t ip_alert;
-    bit [7:0] sw_alert_num[];
-    string actual_ip;
+  // Look at the entries in the +avoid_inject_fatal_error_for_ips plusarg and add the associated
+  // indices in ip_alerts to excluded_indices.
+  function void get_excluded_indices(ref int unsigned excluded_indices[$]);
     string excluded_ips[$];
-    int excluded_ip_idxs[$];
-
     append_queue_plusarg("avoid_inject_fatal_error_for_ips", excluded_ips);
 
     foreach (excluded_ips[i]) begin
-      string sec_cm;
-      int sep_idx = find_separator(excluded_ips[i]);
-
-      if (sep_idx >= 0) begin
-        int str_len = excluded_ips[i].len();
-        actual_ip = excluded_ips[i].substr(0, sep_idx-1);
-        sec_cm = excluded_ips[i].substr(sep_idx + 1, str_len - 1);
-      end else begin
-        actual_ip = excluded_ips[i];
-        sec_cm = "prim_reg_we_check";
-      end
-      excluded_ip_idxs.push_back(get_ip_index_from_name(actual_ip, sec_cm));
+      string ip_name, sec_cm;
+      tokenize_ip_and_countermeasure(excluded_ips[i], ip_name, sec_cm);
+      excluded_indices.push_back(get_ip_index_from_name(ip_name, sec_cm));
     end
-    `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(ip_index, !(ip_index inside {excluded_ip_idxs});)
+  endfunction
 
-    ip_alert = ip_alerts[ip_index];
+  // Return the countermeasure field for an ip_fatal_alert_t (expanding "" to default_cm_name)
+  function string cm_for_alert(const ref ip_fatal_alert_t alert);
+    return (alert.countermeasure == "") ? default_cm_name : alert.countermeasure;
+  endfunction
 
-    // This sequence will trigger a fatal sec_cm failure.
+  // Return a shell glob for the sec_cm_base_if_proxy for the requested item
+  function string glob_for_alert(const ref ip_fatal_alert_t alert);
+    return {"*", alert.ip_inst_glob, "*", cm_for_alert(alert), "*"};
+  endfunction
+
+  // Search the registered sec_cm proxies and return one that matches the requested item
+  //
+  // If non match, fail with an error.
+  function sec_cm_pkg::sec_cm_base_if_proxy find_proxy_for_alert(const ref ip_fatal_alert_t alert);
+    return sec_cm_pkg::find_sec_cm_if_proxy(.path(glob_for_alert(alert)), .is_regex(1));
+  endfunction
+
+  virtual task body();
+    int unsigned         ip_idx;
+    int unsigned         excluded_ip_idxs[$];
+    ip_fatal_alert_t     ip_alert;
+    bit [7:0]            sw_alert_num[];
+
+    get_excluded_indices(excluded_ip_idxs);
+
+    if (!std::randomize(ip_idx) with {
+          ip_idx < ip_alerts.size();
+          !(ip_idx inside {excluded_ip_idxs});
+        }) begin
+      `uvm_fatal(get_full_name(), "Failed to randomize ip_idx")
+    end
+    ip_alert = ip_alerts[ip_idx];
+
+    // Run chip_sw_base_vseq::body, which will start the SW on the CPU
     super.body();
 
-    `uvm_info(`gfn, $sformatf(
-              "Will inject fault for %s, expecting alert %0d",
-              ip_alert.ip_inst_regex,
-              ip_alert.alert_num
-              ), UVM_MEDIUM)
+    `uvm_info(get_full_name(),
+              $sformatf("Will trigger countermeasure %0s in IP block at %0s, expecting alert %0d",
+                        cm_for_alert(ip_alert), ip_alert.ip_inst_glob, ip_alert.alert_num),
+              UVM_LOW)
 
     // Disable scoreboard tl error checks since we will trigger faults which cannot be predicted.
     cfg.en_scb_tl_err_chk = 0;
@@ -136,22 +182,18 @@ class chip_sw_all_escalation_resets_vseq extends chip_sw_base_vseq;
     sw_alert_num = {ip_alert.alert_num};
     sw_symbol_backdoor_overwrite("kExpectedAlertNumber", sw_alert_num);
 
-    ip_alert = ip_alerts[ip_index];
-
     if (ip_alert.alert_num == TopDarjeelingAlertIdRvCoreIbexFatalSwErr) begin
       `uvm_info(`gfn, "Testing Software fatal alert, no fault to inject", UVM_MEDIUM)
       return;
     end
 
-    if_proxy = sec_cm_pkg::find_sec_cm_if_proxy(.path(ip_alert.ip_inst_regex), .is_regex(1));
     `DV_WAIT(cfg.sw_logger_vif.printed_log == "Ready for fault injection",
              "Timeout waiting for fault injection request.")
 
-    `uvm_info(`gfn, $sformatf(
-              "Injecting fault for IP %s, with alert %0d",
-              ip_alert.ip_inst_regex,
-              ip_alert.alert_num
-              ), UVM_MEDIUM);
-    if_proxy.inject_fault();
+    `uvm_info(get_full_name(),
+              $sformatf("Injecting fault for IP block at %0s, with alert %0d",
+                        ip_alert.ip_inst_glob, ip_alert.alert_num),
+              UVM_LOW);
+    find_proxy_for_alert(ip_alert).inject_fault();
   endtask
 endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_all_escalation_resets_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_all_escalation_resets_vseq.sv
@@ -5,93 +5,122 @@
 class chip_sw_all_escalation_resets_vseq extends chip_sw_base_vseq;
   `uvm_object_utils(chip_sw_all_escalation_resets_vseq)
 
-  `uvm_object_new
-
-  // This associates a regex used to match the instance path and an alert number.
   typedef struct {
-    string ip_inst_regex;
-    byte alert_num;
+    // A shell glob that represents the instance path. This is matched with a * at each end (so
+    // "bar" will match "foobarqux")
+    string ip_inst_glob;
+
+    // The countermeasure by which we will trigger an alert. If this is the empty string, it
+    // defaults to default_cm_name (to avoid having to write a string lots of times in the file)
+    string countermeasure;
+
+    // The index of the alert that the countermeasure will generate
+    int unsigned alert_num;
   } ip_fatal_alert_t;
 
+  // The default countermeasure name for an ip_fatal_alert_t: if its countermeasure field is empty,
+  // this is the countermeasure selected.
+  string default_cm_name = "prim_reg_we_check";
+
   ip_fatal_alert_t ip_alerts[] = '{
-    '{"*adc_ctrl*prim_reg_we_check*", TopEarlgreyAlertIdAdcCtrlAonFatalFault},
-    '{"*aes*prim_reg_we_check*", TopEarlgreyAlertIdAesFatalFault},
-    '{"*aon_timer*prim_reg_we_check*", TopEarlgreyAlertIdAonTimerAonFatalFault},
-    '{"*clkmgr*prim_reg_we_check*", TopEarlgreyAlertIdClkmgrAonFatalFault},
-    '{"*csrng*prim_reg_we_check*", TopEarlgreyAlertIdCsrngFatalAlert},
-    '{"*edn0*prim_reg_we_check*", TopEarlgreyAlertIdEdn0FatalAlert},
-    '{"*edn1*prim_reg_we_check*", TopEarlgreyAlertIdEdn1FatalAlert},
-    '{"*entropy_src*prim_reg_we_check*", TopEarlgreyAlertIdEntropySrcFatalAlert},
-    '{"*flash_ctrl*prim_reg_we_check*", TopEarlgreyAlertIdFlashCtrlFatalStdErr},
+    '{"adc_ctrl", "", TopEarlgreyAlertIdAdcCtrlAonFatalFault},
+    '{"aes", "", TopEarlgreyAlertIdAesFatalFault},
+    '{"aon_timer", "", TopEarlgreyAlertIdAonTimerAonFatalFault},
+    '{"clkmgr", "", TopEarlgreyAlertIdClkmgrAonFatalFault},
+    '{"csrng", "", TopEarlgreyAlertIdCsrngFatalAlert},
+    '{"edn0", "", TopEarlgreyAlertIdEdn0FatalAlert},
+    '{"edn1", "", TopEarlgreyAlertIdEdn1FatalAlert},
+    '{"entropy_src", "", TopEarlgreyAlertIdEntropySrcFatalAlert},
+    '{"flash_ctrl", "", TopEarlgreyAlertIdFlashCtrlFatalStdErr},
     // test u_eflash.u_flash alert TopEarlgreyAlertIdFlashCtrlFatalErr is implemented in the
     // `chip_sw_flash_host_gnt_err_inj_vseq` sequence.
-    '{"*flash_ctrl*.u_flash.*prim_reg_we_check*", TopEarlgreyAlertIdFlashCtrlFatalPrimFlashAlert},
-    '{"*gpio*prim_reg_we_check*", TopEarlgreyAlertIdGpioFatalFault},
-    '{"*hmac*prim_reg_we_check*", TopEarlgreyAlertIdHmacFatalFault},
-    '{"*i2c0*prim_reg_we_check*", TopEarlgreyAlertIdI2c0FatalFault},
-    '{"*i2c1*prim_reg_we_check*", TopEarlgreyAlertIdI2c1FatalFault},
-    '{"*i2c2*prim_reg_we_check*", TopEarlgreyAlertIdI2c2FatalFault},
-    '{"*keymgr*prim_reg_we_check*", TopEarlgreyAlertIdKeymgrFatalFaultErr},
-    '{"*kmac*prim_reg_we_check*", TopEarlgreyAlertIdKmacFatalFaultErr},
-    // TODO TopEarlgreyAlertIdLcCtrlFatalProgError: done in sw/device/tests/sim_dv/lc_ctrl_program_error.c?
-    '{"*lc_ctrl*state_regs*", TopEarlgreyAlertIdLcCtrlFatalStateError},
-    '{"*lc_ctrl*prim_reg_we_check*", TopEarlgreyAlertIdLcCtrlFatalBusIntegError},
-    '{"*otbn*prim_reg_we_check*", TopEarlgreyAlertIdOtbnFatal},
+    '{"flash_ctrl*.u_flash", "", TopEarlgreyAlertIdFlashCtrlFatalPrimFlashAlert},
+    '{"gpio", "", TopEarlgreyAlertIdGpioFatalFault},
+    '{"hmac", "", TopEarlgreyAlertIdHmacFatalFault},
+    '{"i2c0", "", TopEarlgreyAlertIdI2c0FatalFault},
+    '{"i2c1", "", TopEarlgreyAlertIdI2c1FatalFault},
+    '{"i2c2", "", TopEarlgreyAlertIdI2c2FatalFault},
+    '{"keymgr", "", TopEarlgreyAlertIdKeymgrFatalFaultErr},
+    '{"kmac", "", TopEarlgreyAlertIdKmacFatalFaultErr},
+    // TODO TopEarlgreyAlertIdLcCtrlFatalProgError: done in .../sim_dv/lc_ctrl_program_error.c?
+    '{"lc_ctrl", "state_regs", TopEarlgreyAlertIdLcCtrlFatalStateError},
+    '{"lc_ctrl", "", TopEarlgreyAlertIdLcCtrlFatalBusIntegError},
+    '{"otbn", "", TopEarlgreyAlertIdOtbnFatal},
     // TopEarlgreyAlertIdOtpCtrlFatalMacroError: done in chip_sw_otp_ctrl_escalation_vseq
-    '{"*otp_ctrl*u_otp_ctrl_dai*", TopEarlgreyAlertIdOtpCtrlFatalCheckError},
-    '{"*otp_ctrl*prim_reg_we_check*", TopEarlgreyAlertIdOtpCtrlFatalBusIntegError},
-    '{"*pattgen*prim_reg_we_check*", TopEarlgreyAlertIdPattgenFatalFault},
-    '{"*pinmux*prim_reg_we_check*", TopEarlgreyAlertIdPinmuxAonFatalFault},
-    '{"*pwm*prim_reg_we_check*", TopEarlgreyAlertIdPwmAonFatalFault},
-    '{"*pwrmgr*prim_reg_we_check*", TopEarlgreyAlertIdPwrmgrAonFatalFault},
-    '{"*rom_ctrl*prim_reg_we_check*", TopEarlgreyAlertIdRomCtrlFatal},
-    '{"*rstmgr*prim_reg_we_check*", TopEarlgreyAlertIdRstmgrAonFatalFault},
+    '{"otp_ctrl", "u_otp_ctrl_dai", TopEarlgreyAlertIdOtpCtrlFatalCheckError},
+    '{"otp_ctrl", "", TopEarlgreyAlertIdOtpCtrlFatalBusIntegError},
+    '{"pattgen", "", TopEarlgreyAlertIdPattgenFatalFault},
+    '{"pinmux", "", TopEarlgreyAlertIdPinmuxAonFatalFault},
+    '{"pwm", "", TopEarlgreyAlertIdPwmAonFatalFault},
+    '{"pwrmgr", "", TopEarlgreyAlertIdPwrmgrAonFatalFault},
+    '{"rom_ctrl", "", TopEarlgreyAlertIdRomCtrlFatal},
+    '{"rstmgr", "", TopEarlgreyAlertIdRstmgrAonFatalFault},
     // TopEarlgreyAlertIdRstmgrAonFatalCnstyFault cannot use this test.
     //
-    '{"*rv_core_ibex*sw_fatal_err*", TopEarlgreyAlertIdRvCoreIbexFatalSwErr},
-    '{"*rv_core_ibex*prim_reg_we_check*", TopEarlgreyAlertIdRvCoreIbexFatalHwErr},
-    '{"*rv_dm*prim_reg_we_check*", TopEarlgreyAlertIdRvDmFatalFault},
-    '{"*rv_plic*prim_reg_we_check*", TopEarlgreyAlertIdRvPlicFatalFault},
-    '{"*rv_timer*prim_reg_we_check*", TopEarlgreyAlertIdRvTimerFatalFault},
-    '{"*sensor_ctrl*prim_reg_we_check*", TopEarlgreyAlertIdSensorCtrlAonFatalAlert},
-    '{"*spi_device*prim_reg_we_check*", TopEarlgreyAlertIdSpiDeviceFatalFault},
-    '{"*spi_host0*prim_reg_we_check*", TopEarlgreyAlertIdSpiHost0FatalFault},
-    '{"*spi_host1*prim_reg_we_check*", TopEarlgreyAlertIdSpiHost1FatalFault},
-    '{"*sram_ctrl_main*prim_reg_we_check*", TopEarlgreyAlertIdSramCtrlMainFatalError},
-    '{"*sram_ctrl_ret*prim_reg_we_check*", TopEarlgreyAlertIdSramCtrlRetAonFatalError},
-    '{"*sysrst_ctrl*prim_reg_we_check*", TopEarlgreyAlertIdSysrstCtrlAonFatalFault},
-    '{"*uart0*prim_reg_we_check*", TopEarlgreyAlertIdUart0FatalFault},
-    '{"*uart1*prim_reg_we_check*", TopEarlgreyAlertIdUart1FatalFault},
-    '{"*uart2*prim_reg_we_check*", TopEarlgreyAlertIdUart2FatalFault},
-    '{"*uart3*prim_reg_we_check*", TopEarlgreyAlertIdUart3FatalFault},
-    '{"*usbdev*prim_reg_we_check*", TopEarlgreyAlertIdUsbdevFatalFault}
+    '{"rv_core_ibex", "sw_fatal_err", TopEarlgreyAlertIdRvCoreIbexFatalSwErr},
+    '{"rv_core_ibex", "", TopEarlgreyAlertIdRvCoreIbexFatalHwErr},
+    '{"rv_dm", "", TopEarlgreyAlertIdRvDmFatalFault},
+    '{"rv_plic", "", TopEarlgreyAlertIdRvPlicFatalFault},
+    '{"rv_timer", "", TopEarlgreyAlertIdRvTimerFatalFault},
+    '{"sensor_ctrl", "", TopEarlgreyAlertIdSensorCtrlAonFatalAlert},
+    '{"spi_device", "", TopEarlgreyAlertIdSpiDeviceFatalFault},
+    '{"spi_host0", "", TopEarlgreyAlertIdSpiHost0FatalFault},
+    '{"spi_host1", "", TopEarlgreyAlertIdSpiHost1FatalFault},
+    '{"sram_ctrl_main", "", TopEarlgreyAlertIdSramCtrlMainFatalError},
+    '{"sram_ctrl_ret", "", TopEarlgreyAlertIdSramCtrlRetAonFatalError},
+    '{"sysrst_ctrl", "", TopEarlgreyAlertIdSysrstCtrlAonFatalFault},
+    '{"uart0", "", TopEarlgreyAlertIdUart0FatalFault},
+    '{"uart1", "", TopEarlgreyAlertIdUart1FatalFault},
+    '{"uart2", "", TopEarlgreyAlertIdUart2FatalFault},
+    '{"uart3", "", TopEarlgreyAlertIdUart3FatalFault},
+    '{"usbdev", "", TopEarlgreyAlertIdUsbdevFatalFault}
   };
 
-  rand int ip_index;
-  constraint ip_index_c {ip_index inside {[0 : ip_alerts.size() - 1]};}
-
-  // Finds an entry in ip_alerts matching an ip and a security counter-measure by name.
-  // It returns the index of the matching entry. It is fatal if no entry is found.
-  function int get_ip_index_from_name(string ip_name, string sec_cm);
-    string regex = {"*", ip_name, "*", sec_cm, "*"};
-    foreach (ip_alerts[i]) begin
-      if (ip_alerts[i].ip_inst_regex == regex) return i;
-    end
-    `uvm_error(`gfn, $sformatf("%0s does not have a matched ip_index", ip_name))
+  function new (string name="");
+    super.new(name);
   endfunction
 
-  // Returns the first character index in the string argument that represents
-  // the separator (an asterisk, *) between an IP and an associated
-  // counter-measure. If no asterisk is found, returns a negative number.
-  function int find_separator(string str);
-    string sep_char = "*";
-    byte sep = sep_char.getc(0);
-    for (int i = 0; i < str.len(); i = i + 1) begin
-      if (str.getc(i) == sep) begin
+  // Return the index of an entry in ip_alerts for the requested ip and security counter-measure,
+  // searching by name.
+  //
+  // Fail with an error if there is no matching entry.
+  function int unsigned get_ip_index_from_name(string ip_name, string sec_cm);
+    bit allow_empty = (sec_cm == default_cm_name);
+
+    foreach (ip_alerts[i]) begin
+      if (ip_alerts[i].ip_inst_glob == ip_name &&
+          (ip_alerts[i].countermeasure == sec_cm ||
+           (allow_empty && ip_alerts[i].countermeasure == ""))) begin
         return i;
       end
     end
-    return -1;
+    `uvm_error(get_full_name(), $sformatf("Unknown ip/sec_cm pair: %0s/%0s.", ip_name, sec_cm))
+    return 0;
+  endfunction
+
+  // Split str into an ip_name shell glob and countermeasure, splitting on the last '*'. If there is
+  // no '*' in the string, treat the whole thing as an ip_name shell glob and output
+  // default_cm_name for sec_cm.
+  function void tokenize_ip_and_countermeasure(string        str,
+                                               output string ip_name,
+                                               output string sec_cm);
+    bit          found_star;
+    int unsigned last_star_idx;
+
+    for (int unsigned i = 0; i < str.len(); i++) begin
+      if (str.getc(i) == "*") begin
+        last_star_idx = i;
+        found_star = 1;
+      end
+    end
+
+    if (found_star) begin
+      ip_name = str.substr(0, last_star_idx - 1);
+      sec_cm = str.substr(last_star_idx + 1, str.len() - 1);
+    end else begin
+      ip_name = str;
+      sec_cm = default_cm_name;
+    end
   endfunction
 
   // Consume the plusarg called plusarg_name, whose value should be a comma-separated list of
@@ -107,42 +136,59 @@ class chip_sw_all_escalation_resets_vseq extends chip_sw_base_vseq;
     end
   endfunction
 
-  virtual task body();
-    sec_cm_pkg::sec_cm_base_if_proxy if_proxy;
-    ip_fatal_alert_t ip_alert;
-    bit [7:0] sw_alert_num[];
-    string actual_ip;
+  // Look at the entries in the +avoid_inject_fatal_error_for_ips plusarg and add the associated
+  // indices in ip_alerts to excluded_indices.
+  function void get_excluded_indices(ref int unsigned excluded_indices[$]);
     string excluded_ips[$];
-    int excluded_ip_idxs[$];
-
     append_queue_plusarg("avoid_inject_fatal_error_for_ips", excluded_ips);
 
     foreach (excluded_ips[i]) begin
-      string sec_cm;
-      int sep_idx = find_separator(excluded_ips[i]);
-
-      if (sep_idx >= 0) begin
-        int str_len = excluded_ips[i].len();
-        actual_ip = excluded_ips[i].substr(0, sep_idx-1);
-        sec_cm = excluded_ips[i].substr(sep_idx + 1, str_len - 1);
-      end else begin
-        actual_ip = excluded_ips[i];
-        sec_cm = "prim_reg_we_check";
-      end
-      excluded_ip_idxs.push_back(get_ip_index_from_name(actual_ip, sec_cm));
+      string ip_name, sec_cm;
+      tokenize_ip_and_countermeasure(excluded_ips[i], ip_name, sec_cm);
+      excluded_indices.push_back(get_ip_index_from_name(ip_name, sec_cm));
     end
-    `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(ip_index, !(ip_index inside {excluded_ip_idxs});)
+  endfunction
 
-    ip_alert = ip_alerts[ip_index];
+  // Return the countermeasure field for an ip_fatal_alert_t (expanding "" to default_cm_name)
+  function string cm_for_alert(const ref ip_fatal_alert_t alert);
+    return (alert.countermeasure == "") ? default_cm_name : alert.countermeasure;
+  endfunction
 
-    // This sequence will trigger a fatal sec_cm failure.
+  // Return a shell glob for the sec_cm_base_if_proxy for the requested item
+  function string glob_for_alert(const ref ip_fatal_alert_t alert);
+    return {"*", alert.ip_inst_glob, "*", cm_for_alert(alert), "*"};
+  endfunction
+
+  // Search the registered sec_cm proxies and return one that matches the requested item
+  //
+  // If non match, fail with an error.
+  function sec_cm_pkg::sec_cm_base_if_proxy find_proxy_for_alert(const ref ip_fatal_alert_t alert);
+    return sec_cm_pkg::find_sec_cm_if_proxy(.path(glob_for_alert(alert)), .is_regex(1));
+  endfunction
+
+  virtual task body();
+    int unsigned         ip_idx;
+    int unsigned         excluded_ip_idxs[$];
+    ip_fatal_alert_t     ip_alert;
+    bit [7:0]            sw_alert_num[];
+
+    get_excluded_indices(excluded_ip_idxs);
+
+    if (!std::randomize(ip_idx) with {
+          ip_idx < ip_alerts.size();
+          !(ip_idx inside {excluded_ip_idxs});
+        }) begin
+      `uvm_fatal(get_full_name(), "Failed to randomize ip_idx")
+    end
+    ip_alert = ip_alerts[ip_idx];
+
+    // Run chip_sw_base_vseq::body, which will start the SW on the CPU
     super.body();
 
-    `uvm_info(`gfn, $sformatf(
-              "Will inject fault for %s, expecting alert %0d",
-              ip_alert.ip_inst_regex,
-              ip_alert.alert_num
-              ), UVM_MEDIUM)
+    `uvm_info(get_full_name(),
+              $sformatf("Will trigger countermeasure %0s in IP block at %0s, expecting alert %0d",
+                        cm_for_alert(ip_alert), ip_alert.ip_inst_glob, ip_alert.alert_num),
+              UVM_LOW)
 
     // Disable scoreboard tl error checks since we will trigger faults which cannot be predicted.
     cfg.en_scb_tl_err_chk = 0;
@@ -151,22 +197,18 @@ class chip_sw_all_escalation_resets_vseq extends chip_sw_base_vseq;
     sw_alert_num = {ip_alert.alert_num};
     sw_symbol_backdoor_overwrite("kExpectedAlertNumber", sw_alert_num);
 
-    ip_alert = ip_alerts[ip_index];
-
     if (ip_alert.alert_num == TopEarlgreyAlertIdRvCoreIbexFatalSwErr) begin
       `uvm_info(`gfn, "Testing Software fatal alert, no fault to inject", UVM_MEDIUM)
       return;
     end
 
-    if_proxy = sec_cm_pkg::find_sec_cm_if_proxy(.path(ip_alert.ip_inst_regex), .is_regex(1));
     `DV_WAIT(cfg.sw_logger_vif.printed_log == "Ready for fault injection",
              "Timeout waiting for fault injection request.")
 
-    `uvm_info(`gfn, $sformatf(
-              "Injecting fault for IP %s, with alert %0d",
-              ip_alert.ip_inst_regex,
-              ip_alert.alert_num
-              ), UVM_MEDIUM);
-    if_proxy.inject_fault();
+    `uvm_info(get_full_name(),
+              $sformatf("Injecting fault for IP block at %0s, with alert %0d",
+                        ip_alert.ip_inst_glob, ip_alert.alert_num),
+              UVM_LOW);
+    find_proxy_for_alert(ip_alert).inject_fault();
   endtask
 endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_all_escalation_resets_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_all_escalation_resets_vseq.sv
@@ -5,94 +5,123 @@
 class chip_sw_all_escalation_resets_vseq extends chip_sw_base_vseq;
   `uvm_object_utils(chip_sw_all_escalation_resets_vseq)
 
-  `uvm_object_new
-
-  // This associates a regex used to match the instance path and an alert number.
   typedef struct {
-    string ip_inst_regex;
-    byte alert_num;
+    // A shell glob that represents the instance path. This is matched with a * at each end (so
+    // "bar" will match "foobarqux")
+    string ip_inst_glob;
+
+    // The countermeasure by which we will trigger an alert. If this is the empty string, it
+    // defaults to default_cm_name (to avoid having to write a string lots of times in the file)
+    string countermeasure;
+
+    // The index of the alert that the countermeasure will generate
+    int unsigned alert_num;
   } ip_fatal_alert_t;
 
+  // The default countermeasure name for an ip_fatal_alert_t: if its countermeasure field is empty,
+  // this is the countermeasure selected.
+  string default_cm_name = "prim_reg_we_check";
+
   ip_fatal_alert_t ip_alerts[] = '{
-    '{"*adc_ctrl*prim_reg_we_check*", TopEarlgreyAlertIdAdcCtrlFatalFault},
-    '{"*aes*prim_reg_we_check*", TopEarlgreyAlertIdAesFatalFault},
-    '{"*aon_timer*prim_reg_we_check*", TopEarlgreyAlertIdAonTimerFatalFault},
-    '{"*clkmgr*prim_reg_we_check*", TopEarlgreyAlertIdClkmgrFatalFault},
-    '{"*csrng*prim_reg_we_check*", TopEarlgreyAlertIdCsrngFatalAlert},
-    '{"*edn0*prim_reg_we_check*", TopEarlgreyAlertIdEdn0FatalAlert},
-    '{"*edn1*prim_reg_we_check*", TopEarlgreyAlertIdEdn1FatalAlert},
-    '{"*entropy_src*prim_reg_we_check*", TopEarlgreyAlertIdEntropySrcFatalAlert},
-    '{"*flash_ctrl*prim_reg_we_check*", TopEarlgreyAlertIdFlashCtrlFatalStdErr},
-    '{"*rram_ctrl*prim_reg_we_check*", TopEarlgreyAlertIdRramCtrlFatalStdErr},
+    '{"adc_ctrl", "", TopEarlgreyAlertIdAdcCtrlFatalFault},
+    '{"aes", "", TopEarlgreyAlertIdAesFatalFault},
+    '{"aon_timer", "", TopEarlgreyAlertIdAonTimerFatalFault},
+    '{"clkmgr", "", TopEarlgreyAlertIdClkmgrFatalFault},
+    '{"csrng", "", TopEarlgreyAlertIdCsrngFatalAlert},
+    '{"edn0", "", TopEarlgreyAlertIdEdn0FatalAlert},
+    '{"edn1", "", TopEarlgreyAlertIdEdn1FatalAlert},
+    '{"entropy_src", "", TopEarlgreyAlertIdEntropySrcFatalAlert},
+    '{"flash_ctrl", "", TopEarlgreyAlertIdFlashCtrlFatalStdErr},
+    '{"rram_ctrl", "", TopEarlgreyAlertIdRramCtrlFatalStdErr},
     // test u_eflash.u_flash alert TopEarlgreyAlertIdFlashCtrlFatalErr is implemented in the
     // `chip_sw_flash_host_gnt_err_inj_vseq` sequence.
-    '{"*flash_ctrl*.u_flash.*prim_reg_we_check*", TopEarlgreyAlertIdFlashCtrlFatalPrimFlashAlert},
-    '{"*rram_macro*prim_reg_we_check*", TopEarlgreyAlertIdRramCtrlFatalMacroErr},
-    '{"*gpio*prim_reg_we_check*", TopEarlgreyAlertIdGpioFatalFault},
-    '{"*hmac*prim_reg_we_check*", TopEarlgreyAlertIdHmacFatalFault},
-    '{"*i2c0*prim_reg_we_check*", TopEarlgreyAlertIdI2c0FatalFault},
-    '{"*i2c1*prim_reg_we_check*", TopEarlgreyAlertIdI2c1FatalFault},
-    '{"*i2c2*prim_reg_we_check*", TopEarlgreyAlertIdI2c2FatalFault},
-    '{"*keymgr*prim_reg_we_check*", TopEarlgreyAlertIdKeymgrFatalFaultErr},
-    '{"*kmac*prim_reg_we_check*", TopEarlgreyAlertIdKmacFatalFaultErr},
-    // TODO TopEarlgreyAlertIdLcCtrlFatalProgError: done in sw/device/tests/sim_dv/lc_ctrl_program_error.c?
-    '{"*lc_ctrl*state_regs*", TopEarlgreyAlertIdLcCtrlFatalStateError},
-    '{"*lc_ctrl*prim_reg_we_check*", TopEarlgreyAlertIdLcCtrlFatalBusIntegError},
-    '{"*otbn*prim_reg_we_check*", TopEarlgreyAlertIdOtbnFatal},
+    '{"flash_ctrl*.u_flash", "", TopEarlgreyAlertIdFlashCtrlFatalPrimFlashAlert},
+    '{"rram_macro", "", TopEarlgreyAlertIdRramCtrlFatalMacroErr},
+    '{"gpio", "", TopEarlgreyAlertIdGpioFatalFault},
+    '{"hmac", "", TopEarlgreyAlertIdHmacFatalFault},
+    '{"i2c0", "", TopEarlgreyAlertIdI2c0FatalFault},
+    '{"i2c1", "", TopEarlgreyAlertIdI2c1FatalFault},
+    '{"i2c2", "", TopEarlgreyAlertIdI2c2FatalFault},
+    '{"keymgr", "", TopEarlgreyAlertIdKeymgrFatalFaultErr},
+    '{"kmac", "", TopEarlgreyAlertIdKmacFatalFaultErr},
+    // TODO TopEarlgreyAlertIdLcCtrlFatalProgError: done in .../sim_dv/lc_ctrl_program_error.c?
+    '{"lc_ctrl", "state_regs", TopEarlgreyAlertIdLcCtrlFatalStateError},
+    '{"lc_ctrl", "", TopEarlgreyAlertIdLcCtrlFatalBusIntegError},
+    '{"otbn", "", TopEarlgreyAlertIdOtbnFatal},
     // TopEarlgreyAlertIdOtpCtrlFatalMacroError: done in chip_sw_otp_ctrl_escalation_vseq
-    '{"*otp_ctrl*u_otp_ctrl_dai*", TopEarlgreyAlertIdOtpCtrlFatalCheckError},
-    '{"*otp_ctrl*prim_reg_we_check*", TopEarlgreyAlertIdOtpCtrlFatalBusIntegError},
-    '{"*pinmux*prim_reg_we_check*", TopEarlgreyAlertIdPinmuxFatalFault},
-    '{"*pwrmgr*prim_reg_we_check*", TopEarlgreyAlertIdPwrmgrFatalFault},
-    '{"*rom_ctrl*prim_reg_we_check*", TopEarlgreyAlertIdRomCtrlFatal},
-    '{"*rstmgr*prim_reg_we_check*", TopEarlgreyAlertIdRstmgrFatalFault},
+    '{"otp_ctrl", "u_otp_ctrl_dai", TopEarlgreyAlertIdOtpCtrlFatalCheckError},
+    '{"otp_ctrl", "", TopEarlgreyAlertIdOtpCtrlFatalBusIntegError},
+    '{"pinmux", "", TopEarlgreyAlertIdPinmuxFatalFault},
+    '{"pwrmgr", "", TopEarlgreyAlertIdPwrmgrFatalFault},
+    '{"rom_ctrl", "", TopEarlgreyAlertIdRomCtrlFatal},
+    '{"rstmgr", "", TopEarlgreyAlertIdRstmgrFatalFault},
     // TopEarlgreyAlertIdRstmgrFatalCnstyFault cannot use this test.
     //
-    '{"*rv_core_ibex*sw_fatal_err*", TopEarlgreyAlertIdRvCoreIbexFatalSwErr},
-    '{"*rv_core_ibex*prim_reg_we_check*", TopEarlgreyAlertIdRvCoreIbexFatalHwErr},
-    '{"*rv_dm*prim_reg_we_check*", TopEarlgreyAlertIdRvDmFatalFault},
-    '{"*rv_plic*prim_reg_we_check*", TopEarlgreyAlertIdRvPlicFatalFault},
-    '{"*rv_timer*prim_reg_we_check*", TopEarlgreyAlertIdRvTimerFatalFault},
-    '{"*sensor_ctrl*prim_reg_we_check*", TopEarlgreyAlertIdSensorCtrlFatalAlert},
-    '{"*spi_device*prim_reg_we_check*", TopEarlgreyAlertIdSpiDeviceFatalFault},
-    '{"*spi_host0*prim_reg_we_check*", TopEarlgreyAlertIdSpiHost0FatalFault},
-    '{"*spi_host1*prim_reg_we_check*", TopEarlgreyAlertIdSpiHost1FatalFault},
-    '{"*sram_ctrl_main*prim_reg_we_check*", TopEarlgreyAlertIdSramCtrlMainFatalError},
-    '{"*sram_ctrl_sec*prim_reg_we_check*", TopEarlgreyAlertIdSramCtrlSecFatalError},
-    '{"*sram_ctrl_ret*prim_reg_we_check*", TopEarlgreyAlertIdSramCtrlRetFatalError},
-    '{"*sysrst_ctrl*prim_reg_we_check*", TopEarlgreyAlertIdSysrstCtrlFatalFault},
-    '{"*uart0*prim_reg_we_check*", TopEarlgreyAlertIdUart0FatalFault},
-    '{"*uart1*prim_reg_we_check*", TopEarlgreyAlertIdUart1FatalFault},
-    '{"*uart2*prim_reg_we_check*", TopEarlgreyAlertIdUart2FatalFault},
-    '{"*uart3*prim_reg_we_check*", TopEarlgreyAlertIdUart3FatalFault},
-    '{"*usbdev*prim_reg_we_check*", TopEarlgreyAlertIdUsbdevFatalFault}
+    '{"rv_core_ibex", "sw_fatal_err", TopEarlgreyAlertIdRvCoreIbexFatalSwErr},
+    '{"rv_core_ibex", "", TopEarlgreyAlertIdRvCoreIbexFatalHwErr},
+    '{"rv_dm", "", TopEarlgreyAlertIdRvDmFatalFault},
+    '{"rv_plic", "", TopEarlgreyAlertIdRvPlicFatalFault},
+    '{"rv_timer", "", TopEarlgreyAlertIdRvTimerFatalFault},
+    '{"sensor_ctrl", "", TopEarlgreyAlertIdSensorCtrlFatalAlert},
+    '{"spi_device", "", TopEarlgreyAlertIdSpiDeviceFatalFault},
+    '{"spi_host0", "", TopEarlgreyAlertIdSpiHost0FatalFault},
+    '{"spi_host1", "", TopEarlgreyAlertIdSpiHost1FatalFault},
+    '{"sram_ctrl_main", "", TopEarlgreyAlertIdSramCtrlMainFatalError},
+    '{"sram_ctrl_sec", "", TopEarlgreyAlertIdSramCtrlSecFatalError},
+    '{"sram_ctrl_ret", "", TopEarlgreyAlertIdSramCtrlRetFatalError},
+    '{"sysrst_ctrl", "", TopEarlgreyAlertIdSysrstCtrlFatalFault},
+    '{"uart0", "", TopEarlgreyAlertIdUart0FatalFault},
+    '{"uart1", "", TopEarlgreyAlertIdUart1FatalFault},
+    '{"uart2", "", TopEarlgreyAlertIdUart2FatalFault},
+    '{"uart3", "", TopEarlgreyAlertIdUart3FatalFault},
+    '{"usbdev", "", TopEarlgreyAlertIdUsbdevFatalFault}
   };
 
-  rand int ip_index;
-  constraint ip_index_c {ip_index inside {[0 : ip_alerts.size() - 1]};}
-
-  // Finds an entry in ip_alerts matching an ip and a security counter-measure by name.
-  // It returns the index of the matching entry. It is fatal if no entry is found.
-  function int get_ip_index_from_name(string ip_name, string sec_cm);
-    string regex = {"*", ip_name, "*", sec_cm, "*"};
-    foreach (ip_alerts[i]) begin
-      if (ip_alerts[i].ip_inst_regex == regex) return i;
-    end
-    `uvm_error(`gfn, $sformatf("%0s does not have a matched ip_index", ip_name))
+  function new (string name="");
+    super.new(name);
   endfunction
 
-  // Returns the first character index in the string argument that represents
-  // the separator (an asterisk, *) between an IP and an associated
-  // counter-measure. If no asterisk is found, returns a negative number.
-  function int find_separator(string str);
-    string sep_char = "*";
-    byte sep = sep_char.getc(0);
-    for (int i = 0; i < str.len(); i = i + 1) begin
-      if (str.getc(i) == sep) begin
+  // Return the index of an entry in ip_alerts for the requested ip and security counter-measure,
+  // searching by name.
+  //
+  // Fail with an error if there is no matching entry.
+  function int unsigned get_ip_index_from_name(string ip_name, string sec_cm);
+    bit allow_empty = (sec_cm == default_cm_name);
+
+    foreach (ip_alerts[i]) begin
+      if (ip_alerts[i].ip_inst_glob == ip_name &&
+          (ip_alerts[i].countermeasure == sec_cm ||
+           (allow_empty && ip_alerts[i].countermeasure == ""))) begin
         return i;
       end
     end
-    return -1;
+    `uvm_error(get_full_name(), $sformatf("Unknown ip/sec_cm pair: %0s/%0s.", ip_name, sec_cm))
+    return 0;
+  endfunction
+
+  // Split str into an ip_name shell glob and countermeasure, splitting on the last '*'. If there is
+  // no '*' in the string, treat the whole thing as an ip_name shell glob and output
+  // default_cm_name for sec_cm.
+  function void tokenize_ip_and_countermeasure(string        str,
+                                               output string ip_name,
+                                               output string sec_cm);
+    bit          found_star;
+    int unsigned last_star_idx;
+
+    for (int unsigned i = 0; i < str.len(); i++) begin
+      if (str.getc(i) == "*") begin
+        last_star_idx = i;
+        found_star = 1;
+      end
+    end
+
+    if (found_star) begin
+      ip_name = str.substr(0, last_star_idx - 1);
+      sec_cm = str.substr(last_star_idx + 1, str.len() - 1);
+    end else begin
+      ip_name = str;
+      sec_cm = default_cm_name;
+    end
   endfunction
 
   // Consume the plusarg called plusarg_name, whose value should be a comma-separated list of
@@ -108,42 +137,59 @@ class chip_sw_all_escalation_resets_vseq extends chip_sw_base_vseq;
     end
   endfunction
 
-  virtual task body();
-    sec_cm_pkg::sec_cm_base_if_proxy if_proxy;
-    ip_fatal_alert_t ip_alert;
-    bit [7:0] sw_alert_num[];
-    string actual_ip;
+  // Look at the entries in the +avoid_inject_fatal_error_for_ips plusarg and add the associated
+  // indices in ip_alerts to excluded_indices.
+  function void get_excluded_indices(ref int unsigned excluded_indices[$]);
     string excluded_ips[$];
-    int excluded_ip_idxs[$];
-
     append_queue_plusarg("avoid_inject_fatal_error_for_ips", excluded_ips);
 
     foreach (excluded_ips[i]) begin
-      string sec_cm;
-      int sep_idx = find_separator(excluded_ips[i]);
-
-      if (sep_idx >= 0) begin
-        int str_len = excluded_ips[i].len();
-        actual_ip = excluded_ips[i].substr(0, sep_idx-1);
-        sec_cm = excluded_ips[i].substr(sep_idx + 1, str_len - 1);
-      end else begin
-        actual_ip = excluded_ips[i];
-        sec_cm = "prim_reg_we_check";
-      end
-      excluded_ip_idxs.push_back(get_ip_index_from_name(actual_ip, sec_cm));
+      string ip_name, sec_cm;
+      tokenize_ip_and_countermeasure(excluded_ips[i], ip_name, sec_cm);
+      excluded_indices.push_back(get_ip_index_from_name(ip_name, sec_cm));
     end
-    `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(ip_index, !(ip_index inside {excluded_ip_idxs});)
+  endfunction
 
-    ip_alert = ip_alerts[ip_index];
+  // Return the countermeasure field for an ip_fatal_alert_t (expanding "" to default_cm_name)
+  function string cm_for_alert(const ref ip_fatal_alert_t alert);
+    return (alert.countermeasure == "") ? default_cm_name : alert.countermeasure;
+  endfunction
 
-    // This sequence will trigger a fatal sec_cm failure.
+  // Return a shell glob for the sec_cm_base_if_proxy for the requested item
+  function string glob_for_alert(const ref ip_fatal_alert_t alert);
+    return {"*", alert.ip_inst_glob, "*", cm_for_alert(alert), "*"};
+  endfunction
+
+  // Search the registered sec_cm proxies and return one that matches the requested item
+  //
+  // If non match, fail with an error.
+  function sec_cm_pkg::sec_cm_base_if_proxy find_proxy_for_alert(const ref ip_fatal_alert_t alert);
+    return sec_cm_pkg::find_sec_cm_if_proxy(.path(glob_for_alert(alert)), .is_regex(1));
+  endfunction
+
+  virtual task body();
+    int unsigned         ip_idx;
+    int unsigned         excluded_ip_idxs[$];
+    ip_fatal_alert_t     ip_alert;
+    bit [7:0]            sw_alert_num[];
+
+    get_excluded_indices(excluded_ip_idxs);
+
+    if (!std::randomize(ip_idx) with {
+          ip_idx < ip_alerts.size();
+          !(ip_idx inside {excluded_ip_idxs});
+        }) begin
+      `uvm_fatal(get_full_name(), "Failed to randomize ip_idx")
+    end
+    ip_alert = ip_alerts[ip_idx];
+
+    // Run chip_sw_base_vseq::body, which will start the SW on the CPU
     super.body();
 
-    `uvm_info(`gfn, $sformatf(
-              "Will inject fault for %s, expecting alert %0d",
-              ip_alert.ip_inst_regex,
-              ip_alert.alert_num
-              ), UVM_MEDIUM)
+    `uvm_info(get_full_name(),
+              $sformatf("Will trigger countermeasure %0s in IP block at %0s, expecting alert %0d",
+                        cm_for_alert(ip_alert), ip_alert.ip_inst_glob, ip_alert.alert_num),
+              UVM_LOW)
 
     // Disable scoreboard tl error checks since we will trigger faults which cannot be predicted.
     cfg.en_scb_tl_err_chk = 0;
@@ -152,22 +198,18 @@ class chip_sw_all_escalation_resets_vseq extends chip_sw_base_vseq;
     sw_alert_num = {ip_alert.alert_num};
     sw_symbol_backdoor_overwrite("kExpectedAlertNumber", sw_alert_num);
 
-    ip_alert = ip_alerts[ip_index];
-
     if (ip_alert.alert_num == TopEarlgreyAlertIdRvCoreIbexFatalSwErr) begin
       `uvm_info(`gfn, "Testing Software fatal alert, no fault to inject", UVM_MEDIUM)
       return;
     end
 
-    if_proxy = sec_cm_pkg::find_sec_cm_if_proxy(.path(ip_alert.ip_inst_regex), .is_regex(1));
     `DV_WAIT(cfg.sw_logger_vif.printed_log == "Ready for fault injection",
              "Timeout waiting for fault injection request.")
 
-    `uvm_info(`gfn, $sformatf(
-              "Injecting fault for IP %s, with alert %0d",
-              ip_alert.ip_inst_regex,
-              ip_alert.alert_num
-              ), UVM_MEDIUM);
-    if_proxy.inject_fault();
+    `uvm_info(get_full_name(),
+              $sformatf("Injecting fault for IP block at %0s, with alert %0d",
+                        ip_alert.ip_inst_glob, ip_alert.alert_num),
+              UVM_LOW);
+    find_proxy_for_alert(ip_alert).inject_fault();
   endtask
 endclass


### PR DESCRIPTION
Now that the PR on which this one depended has been merged, just the following commit remains:

> This patch adds lots of comment lines explaining what the code does
> and also makes the following changes:
> 
>   - Split ip_fatal_alert_t so that it supplies the countermeasure
>     separately.
> 
>   - Pass a default countermeasure (prim_reg_we_check) to avoid having
>     to write that string lots of times.
> 
>   - Avoid setting the ip_alert variable with the same value twice
