### PR TITLE
[rom] Fix sram readback base address

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/sram/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sram/BUILD
@@ -42,7 +42,7 @@ otp_image(
     overlays = STD_OTP_OVERLAYS + [":otp_json_readback_enable"],
 )
 
-_TESTS = {
+_READBACK_TESTS = {
     "default": {
         "otp": None,
     },
@@ -70,7 +70,7 @@ _TESTS = {
             "//sw/device/silicon_creator/lib/drivers:otp",
         ],
     )
-    for name, param in _TESTS.items()
+    for name, param in _READBACK_TESTS.items()
 ]
 
 test_suite(
@@ -78,6 +78,64 @@ test_suite(
     tags = ["manual"],
     tests = [
         "sram_readback_{}_test".format(name)
-        for name in _TESTS.keys()
+        for name in _READBACK_TESTS.keys()
+    ],
+)
+
+otp_json(
+    name = "otp_json_renew_disabled",
+    partitions = [
+        otp_partition(
+            name = "CREATOR_SW_CFG",
+            items = {
+                "CREATOR_SW_CFG_SRAM_KEY_RENEW_AND_INIT_EN": otp_hex(CONST.HARDENED_FALSE),
+            },
+        ),
+    ],
+)
+
+otp_image(
+    name = "otp_img_renew_disabled",
+    src = "//hw/top_earlgrey/data/otp:otp_json_rma",
+    overlays = STD_OTP_OVERLAYS + [":otp_json_renew_disabled"],
+)
+
+_RENEW_TESTS = {
+    "default": {
+        "otp": None,
+    },
+    "disabled": {
+        "otp": ":otp_img_renew_disabled",
+    },
+}
+
+[
+    opentitan_test(
+        name = "sram_key_renew_{}_test".format(name),
+        srcs = ["sram_renew_test.c"],
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        },
+        fpga = fpga_params(
+            otp = param["otp"],
+        ),
+        deps = [
+            "//hw/top:otp_ctrl_c_regs",
+            "//hw/top:sram_ctrl_c_regs",
+            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//sw/device/lib/base:abs_mmio",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib/drivers:otp",
+        ],
+    )
+    for name, param in _RENEW_TESTS.items()
+]
+
+test_suite(
+    name = "sram_key_renew_test",
+    tags = ["manual"],
+    tests = [
+        "sram_key_renew_{}_test".format(name)
+        for name in _RENEW_TESTS.keys()
     ],
 )

--- a/sw/device/silicon_creator/rom/e2e/sram/sram_renew_test.c
+++ b/sw/device/silicon_creator/rom/e2e/sram/sram_renew_test.c
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/drivers/otp.h"
+
+#include "hw/top/otp_ctrl_regs.h"
+#include "hw/top/sram_ctrl_regs.h"
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+enum {
+  kSramCtrlBase = TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR,
+};
+
+bool test_main(void) {
+  uint32_t otp = otp_read32(
+      OTP_CTRL_PARAM_CREATOR_SW_CFG_SRAM_KEY_RENEW_AND_INIT_EN_OFFSET);
+  uint32_t status =
+      abs_mmio_read32(kSramCtrlBase + SRAM_CTRL_STATUS_REG_OFFSET);
+  bool key_valid = (status & (1 << SRAM_CTRL_STATUS_SCR_KEY_VALID_BIT)) != 0;
+
+  LOG_INFO("sram_renew: otp=%x status=%x key_valid=%d", otp, status, key_valid);
+
+  if (otp == kHardenedBoolFalse) {
+    return !key_valid;
+  } else {
+    return key_valid;
+  }
+}

--- a/sw/device/silicon_creator/rom/rom_start.S
+++ b/sw/device/silicon_creator/rom/rom_start.S
@@ -419,8 +419,8 @@ LABEL_FOR_TEST(kRomStartWatchdogEnabled)
   lw   t2, OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_SRAM_READBACK_EN_OFFSET(a0)
   lw   t0, OTP_CTRL_PARAM_CREATOR_SW_CFG_SRAM_KEY_RENEW_AND_INIT_EN_OFFSET(a0)
   li   t1, HARDENED_BOOL_FALSE
-  beq t0, t1, .L_sram_key_renew_skip
   li a0, TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR
+  beq t0, t1, .L_sram_key_renew_skip
   li a1, (1 << SRAM_CTRL_CTRL_RENEW_SCR_KEY_BIT) | (1 << SRAM_CTRL_CTRL_INIT_BIT)
   sw a1, SRAM_CTRL_CTRL_REG_OFFSET(a0)
 .L_sram_key_renew_skip:


### PR DESCRIPTION
This PR fixes a ROM bug about an untested OTP feature for disabling SRAM scramble key renew.
Renew is enabled in OTP by default in current earlgrey SKUs, so they are unaffected.

The fix moves the initialization of `a0` with the `TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR` before the
`.L_sram_key_renew_skip` check.

Previously, if `SRAM_KEY_RENEW_EN` was disabled, the subsequent `SRAM_CTRL_READBACK_REG_OFFSET` store would use an incorrect base register (`a0` pointing to the OTP controller), potentially causing misconfiguration.

https://github.com/lowRISC/opentitan/blob/b76d9ada848d1d78db878892d051b1c44f7ffcfe/sw/device/silicon_creator/rom/rom_start.S#L417-L428