### PR TITLE
[rom_ext/otbn_boot_services] Add instruction counts

### DIFF
--- a/sw/device/silicon_creator/lib/otbn_boot_services.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.c
@@ -141,7 +141,13 @@ rom_error_t otbn_boot_attestation_keygen(
   HARDENED_RETURN_IF_ERROR(sc_otbn_execute());
   SEC_MMIO_WRITE_INCREMENT(kScOtbnSecMmioExecute);
 
-  // TODO(#20023): Check the instruction count register (see `mod_exp_otbn`).
+  // Verify the OTBN instruction count to mitigate FI.
+  uint32_t insn_cnt = sc_otbn_instruction_count_get();
+  if (launder32(insn_cnt) != kOtbnInsnCountKeygenROM) {
+    HARDENED_CHECK_EQ(insn_cnt, kOtbnInsnCountKeygen);
+  } else {
+    HARDENED_CHECK_EQ(insn_cnt, kOtbnInsnCountKeygenROM);
+  }
 
   // Retrieve the public key.
   HARDENED_RETURN_IF_ERROR(sc_otbn_dmem_read(kEcdsaP256PublicKeyCoordWords,
@@ -218,7 +224,13 @@ rom_error_t otbn_boot_attestation_key_save(
   HARDENED_RETURN_IF_ERROR(sc_otbn_execute());
   SEC_MMIO_WRITE_INCREMENT(kScOtbnSecMmioExecute);
 
-  // TODO(#20023): Check the instruction count register (see `mod_exp_otbn`).
+  // Verify the OTBN instruction count to mitigate FI.
+  uint32_t insn_cnt = sc_otbn_instruction_count_get();
+  if (launder32(insn_cnt) != kOtbnInsnCountKeySaveROM) {
+    HARDENED_CHECK_EQ(insn_cnt, kOtbnInsnCountKeySave);
+  } else {
+    HARDENED_CHECK_EQ(insn_cnt, kOtbnInsnCountKeySaveROM);
+  }
 
   return kErrorOk;
 }
@@ -259,7 +271,13 @@ rom_error_t otbn_boot_attestation_endorse(const hmac_digest_t *digest,
   HARDENED_RETURN_IF_ERROR(sc_otbn_execute());
   SEC_MMIO_WRITE_INCREMENT(kScOtbnSecMmioExecute);
 
-  // TODO(#20023): Check the instruction count register (see `mod_exp_otbn`).
+  // Verify the OTBN instruction count to mitigate FI.
+  uint32_t insn_cnt = sc_otbn_instruction_count_get();
+  if (launder32(insn_cnt) != kOtbnInsnCountEndorseROM) {
+    HARDENED_CHECK_EQ(insn_cnt, kOtbnInsnCountEndorse);
+  } else {
+    HARDENED_CHECK_EQ(insn_cnt, kOtbnInsnCountEndorseROM);
+  }
 
   // Retrieve the signature (in two parts, r and s).
   HARDENED_RETURN_IF_ERROR(sc_otbn_dmem_read(kEcdsaP256SignatureComponentWords,
@@ -311,8 +329,6 @@ rom_error_t otbn_boot_sigverify_finish(uint32_t *recovered_r) {
   // Read the status value again as an extra hardening measure.
   HARDENED_RETURN_IF_ERROR(sc_otbn_dmem_read(1, kOtbnVarBootOk, &ok));
   HARDENED_CHECK_EQ(ok, kHardenedBoolTrue);
-
-  // TODO(#20023): Check the instruction count register (see `mod_exp_otbn`).
 
   // Read the recovered `r` value from DMEM.
   return sc_otbn_dmem_read(kEcdsaP256SignatureComponentWords, kOtbnVarBootXr,

--- a/sw/device/silicon_creator/lib/otbn_boot_services.h
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.h
@@ -19,6 +19,28 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
+ * Expected OTBN instruction counts for various boot service modes.
+ *
+ * Two targets are provided per mode to account for underlying profile
+ * differences between the OTBN service from silicon ROM
+ * (Earlgrey-PROD-A2-M6-ROM-RC1) or at HEAD.
+ */
+
+// DO NOT EDIT: ROM instruction counts are fixed for the silicon version.
+enum {
+  kOtbnInsnCountKeygenROM = 0x9ceb1,
+  kOtbnInsnCountKeySaveROM = 0x66,
+  kOtbnInsnCountEndorseROM = 0xa4a07,
+};
+
+// Instruction counts for current version.
+enum {
+  kOtbnInsnCountKeygen = 0x8c110,
+  kOtbnInsnCountKeySave = 0x69,
+  kOtbnInsnCountEndorse = 0x9435e,
+};
+
+/**
  * Loads the OTBN boot-services application.
  *
  * Loads the OTBN program that runs attestation and code-signature


### PR DESCRIPTION
Add instruction count checking for the p256 OTBN operations. Remove the TODO for verification since that is not constant time. Distinguish between ROM instruction counts and HEAD instruction counts by testing the OTBN instruction count against two constants. When updating the p256 sign, verify, or keygen operations at HEAD please only change the regular constants but leave the ROM constants the same for earlgrey silicon.