### PR TITLE
[ci] Fix job IDs for FPGA TestROM tests

### DIFF
--- a/ci/scripts/schedule_fpga_jobs.py
+++ b/ci/scripts/schedule_fpga_jobs.py
@@ -13,6 +13,7 @@ do not take too long, splitting them into several jobs if necessary.
 """
 
 import argparse
+from collections import defaultdict
 import json
 from pathlib import Path
 import subprocess
@@ -257,6 +258,19 @@ def main():
     sched("ROM", "cw310", "cw310_rom", ["cw310_rom_with_fake_keys"])
     sched("TestROM", "cw340", "cw340_test_rom", ["cw340_test_rom"])
     sched("TestROM", "cw310", "cw310_test_rom", ["cw310_test_rom"])
+
+    # Check for ID collisions in the scheduled jobs.
+    jobs_by_id = defaultdict(list)
+    for job in jobs:
+        jobs_by_id[job["id"]].append(job)
+
+    duplicates = {id: jobs for id, jobs in jobs_by_id.items() if len(jobs) > 1}
+    if duplicates:
+        for id, jobs in duplicates.items():
+            print(f"Error: jobs have the same id {id}:", file=sys.stderr)
+            for job in jobs:
+                print(f"  {job['name']}", file=sys.stderr)
+        sys.exit(1)
 
     for job in jobs:
         tests = job.pop("tests")

--- a/ci/scripts/schedule_fpga_jobs.py
+++ b/ci/scripts/schedule_fpga_jobs.py
@@ -255,8 +255,8 @@ def main():
 
     sched("ROM", "cw340", "cw340_rom", ["cw340_rom_with_fake_keys"])
     sched("ROM", "cw310", "cw310_rom", ["cw310_rom_with_fake_keys"])
-    sched("TestROM", "cw340", "cw340_rom", ["cw340_test_rom"])
-    sched("TestROM", "cw310", "cw310_rom", ["cw310_test_rom"])
+    sched("TestROM", "cw340", "cw340_test_rom", ["cw340_test_rom"])
+    sched("TestROM", "cw310", "cw310_test_rom", ["cw310_test_rom"])
 
     for job in jobs:
         tests = job.pop("tests")

--- a/ci/scripts/schedule_fpga_jobs.py
+++ b/ci/scripts/schedule_fpga_jobs.py
@@ -272,6 +272,9 @@ def main():
                 print(f"  {job['name']}", file=sys.stderr)
         sys.exit(1)
 
+    # Clean up the jobs list to remove empty jobs.
+    jobs = [j for j in jobs if j["tests"]]
+
     for job in jobs:
         tests = job.pop("tests")
         target_file = "{}.txt".format(job["id"])


### PR DESCRIPTION
Related to 
* #29811

We update the job IDs for TestROM tests to use `cw340_test_rom` and `cw310_test_rom` respectively, preventing overwriting over the standard ROM test (`cw340_rom` and `cw310_rom`). A check is also added to prevent collision.

Also, this PR includes a change that filters out empty job.

Without this fix, the "CW310 ROM Tests" jobs runs the "CW310 TestROM Tests" incorrectly. ([Example](https://github.com/lowRISC/opentitan/actions/runs/25793273182/job/75764767169))