### PR TITLE
[crypto/hmac] Refactor HMAC

### DIFF
--- a/sw/device/lib/crypto/drivers/hmac.c
+++ b/sw/device/lib/crypto/drivers/hmac.c
@@ -114,6 +114,8 @@ typedef enum hmac_key_length {
   kKeyLengthNone = HMAC_CFG_KEY_LENGTH_VALUE_KEY_NONE,
 } hmac_key_length_t;
 
+static void sha2_init(hmac_digest_length_t digest_len, hmac_ctx_t *ctx);
+
 /**
  * Wait until HMAC becomes idle.
  *
@@ -478,6 +480,138 @@ static status_t oneshot(const uint32_t cfg, const hmac_key_t *key,
   return OTCRYPTO_OK;
 }
 
+/**
+ * Universal redundant core engine for one-shot HMAC evaluations.
+ *
+ * Computes an HMAC digest natively in software using the provided inner and
+ * outer padding masks. This function serves as a Fault Injection (FI)
+ * countermeasure for High security level configurations by providing an
+ * implementation path that executes independently of the primary HMAC core.
+ *
+ * @param key The initialized HMAC key structure containing the unmasked block.
+ * @param msg The input message buffer to be authenticated.
+ * @param[out] tag Destination buffer for the final HMAC authentication tag.
+ * @param block_words The internal block size of the underlying hash in words.
+ * @param digest_words The digest output size of the underlying hash in words.
+ * @param opad_mask Byte mask repeated to construct the outer padding (e.g.,
+ * 0x5c).
+ * @param init_fn Pointer to the mode-specific initialization function.
+ * @return Result of the operation (OK or error status).
+ */
+static status_t hmac_redundant_core(const hmac_key_t *key,
+                                    const otcrypto_const_byte_buf_t *msg,
+                                    otcrypto_word32_buf_t *tag,
+                                    size_t block_words, size_t digest_words,
+                                    uint32_t opad_mask,
+                                    void (*init_fn)(hmac_ctx_t *)) {
+  size_t block_bytes = block_words * sizeof(uint32_t);
+  uint32_t o_key_pad[kHmacMaxBlockWords];
+  uint32_t i_key_pad[kHmacMaxBlockWords];
+  memset(o_key_pad, 0, block_bytes);
+  memset(i_key_pad, 0, block_bytes);
+
+  // XOR the key K with the outer (opad) and inner (ipad) padding.
+  uint32_t opad[kHmacMaxBlockWords];
+  uint32_t ipad[kHmacMaxBlockWords];
+  memset(opad, opad_mask & 0xFF, block_bytes);
+  memset(ipad, 0x36, block_bytes);
+  HARDENED_TRY(hardened_xor(key->key_block, opad, block_words, o_key_pad));
+  HARDENED_TRY(hardened_xor(key->key_block, ipad, block_words, i_key_pad));
+
+  // h_i_key_pad_msg = H(i_key_pad || m).
+  hmac_ctx_t ctx;
+  init_fn(&ctx);
+
+  otcrypto_const_byte_buf_t i_key_pad_buf = OTCRYPTO_MAKE_BUF(
+      otcrypto_const_byte_buf_t, (const uint8_t *)i_key_pad, block_bytes);
+  HARDENED_TRY(hmac_update(&ctx, &i_key_pad_buf));
+  HARDENED_TRY(hmac_update(&ctx, msg));
+
+  uint32_t h_i_key_pad_msg[kHmacMaxDigestWords];
+  memset(h_i_key_pad_msg, 0, sizeof(h_i_key_pad_msg));
+  otcrypto_word32_buf_t inner_digest =
+      OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, h_i_key_pad_msg, digest_words);
+  HARDENED_TRY(hmac_final(&ctx, &inner_digest));
+
+  // hmac = H(o_key_pad || h_i_key_pad_msg).
+  init_fn(&ctx);
+
+  otcrypto_const_byte_buf_t o_key_pad_buf = OTCRYPTO_MAKE_BUF(
+      otcrypto_const_byte_buf_t, (const uint8_t *)o_key_pad, block_bytes);
+  HARDENED_TRY(hmac_update(&ctx, &o_key_pad_buf));
+
+  otcrypto_const_byte_buf_t h_i_key_pad_msg_buf = OTCRYPTO_MAKE_BUF(
+      otcrypto_const_byte_buf_t, (const uint8_t *)h_i_key_pad_msg,
+      digest_words * sizeof(uint32_t));
+  HARDENED_TRY(hmac_update(&ctx, &h_i_key_pad_msg_buf));
+
+  return hmac_final(&ctx, tag);
+}
+
+static status_t hmac_init_redundant_core(hmac_key_t key, hmac_ctx_t *ctx,
+                                         size_t block_words,
+                                         size_t digest_words,
+                                         hmac_digest_length_t digest_len) {
+  ctx->msg_block_wordlen = block_words;
+  ctx->digest_wordlen = digest_words;
+  sha2_init(digest_len, ctx);
+  // Store key so hmac_hmac_sha256_final_redundant can derive o_key_pad.
+  ctx->key.key_len = key.key_len;
+  ctx->key.checksum = key.checksum;
+  hardened_memcpy(ctx->key.key_block, key.key_block, key.key_len);
+  HARDENED_CHECK_EQ(
+      hardened_memeq(key.key_block, ctx->key.key_block, key.key_len),
+      kHardenedBoolTrue);
+  // Compute i_key_pad = key XOR ipad and absorb it so subsequent hmac_update
+  // calls receive only message bytes.
+  uint32_t i_key_pad[kHmacMaxBlockWords];
+  uint32_t ipad[kHmacMaxBlockWords];
+  memset(i_key_pad, 0, block_words * sizeof(uint32_t));
+  memset(ipad, 0x36, block_words * sizeof(uint32_t));
+  HARDENED_TRY(hardened_xor(key.key_block, ipad, block_words, i_key_pad));
+  otcrypto_const_byte_buf_t i_key_pad_buf =
+      OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, (const uint8_t *)i_key_pad,
+                        block_words * sizeof(uint32_t));
+  return hmac_update(ctx, &i_key_pad_buf);
+}
+
+static status_t hmac_final_redundant_core(
+    hmac_ctx_t *ctx, otcrypto_word32_buf_t *tag, size_t block_words,
+    size_t digest_words, uint32_t opad_mask, void (*init_fn)(hmac_ctx_t *)) {
+  size_t block_bytes = block_words * sizeof(uint32_t);
+  // Save key before hmac_final wipes the context.
+  hmac_key_t saved_key;
+  saved_key.key_len = ctx->key.key_len;
+  saved_key.checksum = ctx->key.checksum;
+  hardened_memcpy(saved_key.key_block, ctx->key.key_block, ctx->key.key_len);
+  HARDENED_CHECK_EQ(
+      hardened_memeq(saved_key.key_block, ctx->key.key_block, ctx->key.key_len),
+      kHardenedBoolTrue);
+  // Finalize inner hash: H(i_key_pad || msg).
+  uint32_t inner_digest_data[kHmacMaxDigestWords];
+  memset(inner_digest_data, 0, sizeof(inner_digest_data));
+  otcrypto_word32_buf_t inner_digest =
+      OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, inner_digest_data, digest_words);
+  HARDENED_TRY(hmac_final(ctx, &inner_digest));
+  // Compute o_key_pad = key XOR opad and run the outer hash.
+  uint32_t o_key_pad[kHmacMaxBlockWords];
+  uint32_t opad[kHmacMaxBlockWords];
+  memset(o_key_pad, 0, block_bytes);
+  memset(opad, opad_mask & 0xFF, block_bytes);
+  HARDENED_TRY(hardened_xor(saved_key.key_block, opad, block_words, o_key_pad));
+  init_fn(ctx);
+  otcrypto_const_byte_buf_t o_key_pad_buf = OTCRYPTO_MAKE_BUF(
+      otcrypto_const_byte_buf_t, (const uint8_t *)o_key_pad, block_bytes);
+  HARDENED_TRY(hmac_update(ctx, &o_key_pad_buf));
+  otcrypto_const_byte_buf_t inner_buf = OTCRYPTO_MAKE_BUF(
+      otcrypto_const_byte_buf_t, (const uint8_t *)inner_digest_data,
+      digest_words * sizeof(uint32_t));
+  HARDENED_TRY(hmac_update(ctx, &inner_buf));
+  return hmac_final(ctx, tag);
+}
+
+// --- Specific Drivers mapping to common helper targets ---
+
 status_t hmac_hash_sha256(const otcrypto_const_byte_buf_t *msg,
                           uint32_t *digest) {
   uint32_t cfg =
@@ -510,51 +644,9 @@ status_t hmac_hmac_sha256_cl(const hmac_key_t *key,
 status_t hmac_hmac_sha256_redundant(const hmac_key_t *key,
                                     const otcrypto_const_byte_buf_t *msg,
                                     otcrypto_word32_buf_t *tag) {
-  uint32_t o_key_pad[kHmacSha256BlockWords];
-  uint32_t i_key_pad[kHmacSha256BlockWords];
-  memset(o_key_pad, 0, kHmacSha256BlockBytes);
-  memset(i_key_pad, 0, kHmacSha256BlockBytes);
-
-  // XOR the key K with the outer (opad) and inner (ipad) padding.
-  uint32_t opad[kHmacSha256BlockWords];
-  uint32_t ipad[kHmacSha256BlockWords];
-  memset(opad, 0x5c5c5c5c, kHmacSha256BlockBytes);
-  memset(ipad, 0x36363636, kHmacSha256BlockBytes);
-  HARDENED_TRY(
-      hardened_xor(key->key_block, opad, kHmacSha256BlockWords, o_key_pad));
-  HARDENED_TRY(
-      hardened_xor(key->key_block, ipad, kHmacSha256BlockWords, i_key_pad));
-
-  // h_i_key_pad_msg = H(i_key_pad || m).
-  hmac_ctx_t ctx;
-  hmac_hash_sha256_init(&ctx);
-
-  otcrypto_const_byte_buf_t i_key_pad_buf =
-      OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, (const uint8_t *)i_key_pad,
-                        kHmacSha256BlockBytes);
-  HARDENED_TRY(hmac_update(&ctx, &i_key_pad_buf));
-  HARDENED_TRY(hmac_update(&ctx, msg));
-
-  uint32_t h_i_key_pad_msg[kHmacSha256DigestWords];
-  memset(h_i_key_pad_msg, 0, sizeof(h_i_key_pad_msg));
-  otcrypto_word32_buf_t inner_digest = OTCRYPTO_MAKE_BUF(
-      otcrypto_word32_buf_t, h_i_key_pad_msg, kHmacSha256DigestWords);
-  HARDENED_TRY(hmac_final(&ctx, &inner_digest));
-
-  // hmac = H(o_key_pad || h_i_key_pad_msg).
-  hmac_hash_sha256_init(&ctx);
-
-  otcrypto_const_byte_buf_t o_key_pad_buf =
-      OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, (const uint8_t *)o_key_pad,
-                        kHmacSha256BlockBytes);
-  HARDENED_TRY(hmac_update(&ctx, &o_key_pad_buf));
-
-  otcrypto_const_byte_buf_t h_i_key_pad_msg_buf = OTCRYPTO_MAKE_BUF(
-      otcrypto_const_byte_buf_t, (const uint8_t *)h_i_key_pad_msg,
-      kHmacSha256DigestBytes);
-  HARDENED_TRY(hmac_update(&ctx, &h_i_key_pad_msg_buf));
-
-  return hmac_final(&ctx, tag);
+  return hmac_redundant_core(key, msg, tag, kHmacSha256BlockWords,
+                             kHmacSha256DigestWords, 0x5c5c5c5c,
+                             hmac_hash_sha256_init);
 }
 
 status_t hmac_hmac_sha384(const hmac_key_t *key,
@@ -568,47 +660,9 @@ status_t hmac_hmac_sha384(const hmac_key_t *key,
 status_t hmac_hmac_sha384_redundant(const hmac_key_t *key,
                                     const otcrypto_const_byte_buf_t *msg,
                                     otcrypto_word32_buf_t *tag) {
-  uint32_t o_key_pad[kHmacSha384BlockWords];
-  uint32_t i_key_pad[kHmacSha384BlockWords];
-  memset(o_key_pad, 0, kHmacSha384BlockBytes);
-  memset(i_key_pad, 0, kHmacSha384BlockBytes);
-
-  // XOR the key K with the outer (opad) and inner (ipad) padding.
-  for (size_t it = 0; it < kHmacSha384BlockWords; it++) {
-    o_key_pad[it] = key->key_block[it] ^ 0x5c5c5c5c;
-    i_key_pad[it] = key->key_block[it] ^ 0x36363636;
-  }
-
-  // h_i_key_pad_msg = H(i_key_pad || m).
-  hmac_ctx_t ctx;
-  hmac_hash_sha384_init(&ctx);
-
-  otcrypto_const_byte_buf_t i_key_pad_buf =
-      OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, (const uint8_t *)i_key_pad,
-                        kHmacSha384BlockBytes);
-  HARDENED_TRY(hmac_update(&ctx, &i_key_pad_buf));
-  HARDENED_TRY(hmac_update(&ctx, msg));
-
-  uint32_t h_i_key_pad_msg[kHmacSha384DigestWords];
-  memset(h_i_key_pad_msg, 0, sizeof(h_i_key_pad_msg));
-  otcrypto_word32_buf_t inner_digest = OTCRYPTO_MAKE_BUF(
-      otcrypto_word32_buf_t, h_i_key_pad_msg, kHmacSha384DigestWords);
-  HARDENED_TRY(hmac_final(&ctx, &inner_digest));
-
-  // hmac = H(o_key_pad || h_i_key_pad_msg).
-  hmac_hash_sha384_init(&ctx);
-
-  otcrypto_const_byte_buf_t o_key_pad_buf =
-      OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, (const uint8_t *)o_key_pad,
-                        kHmacSha384BlockBytes);
-  HARDENED_TRY(hmac_update(&ctx, &o_key_pad_buf));
-
-  otcrypto_const_byte_buf_t h_i_key_pad_msg_buf = OTCRYPTO_MAKE_BUF(
-      otcrypto_const_byte_buf_t, (const uint8_t *)h_i_key_pad_msg,
-      kHmacSha384DigestBytes);
-  HARDENED_TRY(hmac_update(&ctx, &h_i_key_pad_msg_buf));
-
-  return hmac_final(&ctx, tag);
+  return hmac_redundant_core(key, msg, tag, kHmacSha384BlockWords,
+                             kHmacSha384DigestWords, 0x5c5c5c5c,
+                             hmac_hash_sha384_init);
 }
 
 status_t hmac_hmac_sha512(const hmac_key_t *key,
@@ -622,47 +676,9 @@ status_t hmac_hmac_sha512(const hmac_key_t *key,
 status_t hmac_hmac_sha512_redundant(const hmac_key_t *key,
                                     const otcrypto_const_byte_buf_t *msg,
                                     otcrypto_word32_buf_t *tag) {
-  uint32_t o_key_pad[kHmacSha512BlockWords];
-  uint32_t i_key_pad[kHmacSha512BlockWords];
-  memset(o_key_pad, 0, kHmacSha512BlockBytes);
-  memset(i_key_pad, 0, kHmacSha512BlockBytes);
-
-  // XOR the key K with the outer (opad) and inner (ipad) padding.
-  for (size_t it = 0; it < kHmacSha512BlockWords; it++) {
-    o_key_pad[it] = key->key_block[it] ^ 0x5c5c5c5c;
-    i_key_pad[it] = key->key_block[it] ^ 0x36363636;
-  }
-
-  // h_i_key_pad_msg = H(i_key_pad || m).
-  hmac_ctx_t ctx;
-  hmac_hash_sha512_init(&ctx);
-
-  otcrypto_const_byte_buf_t i_key_pad_buf =
-      OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, (const uint8_t *)i_key_pad,
-                        kHmacSha512BlockBytes);
-  HARDENED_TRY(hmac_update(&ctx, &i_key_pad_buf));
-  HARDENED_TRY(hmac_update(&ctx, msg));
-
-  uint32_t h_i_key_pad_msg[kHmacSha512DigestWords];
-  memset(h_i_key_pad_msg, 0, sizeof(h_i_key_pad_msg));
-  otcrypto_word32_buf_t inner_digest = OTCRYPTO_MAKE_BUF(
-      otcrypto_word32_buf_t, h_i_key_pad_msg, kHmacSha512DigestWords);
-  HARDENED_TRY(hmac_final(&ctx, &inner_digest));
-
-  // hmac = H(o_key_pad || h_i_key_pad_msg).
-  hmac_hash_sha512_init(&ctx);
-
-  otcrypto_const_byte_buf_t o_key_pad_buf =
-      OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, (const uint8_t *)o_key_pad,
-                        kHmacSha512BlockBytes);
-  HARDENED_TRY(hmac_update(&ctx, &o_key_pad_buf));
-
-  otcrypto_const_byte_buf_t h_i_key_pad_msg_buf = OTCRYPTO_MAKE_BUF(
-      otcrypto_const_byte_buf_t, (const uint8_t *)h_i_key_pad_msg,
-      kHmacSha512DigestBytes);
-  HARDENED_TRY(hmac_update(&ctx, &h_i_key_pad_msg_buf));
-
-  return hmac_final(&ctx, tag);
+  return hmac_redundant_core(key, msg, tag, kHmacSha512BlockWords,
+                             kHmacSha512DigestWords, 0x5c5c5c5c,
+                             hmac_hash_sha512_init);
 }
 
 /**
@@ -758,177 +774,39 @@ void hmac_hmac_sha512_init(const hmac_key_t key, hmac_ctx_t *ctx) {
 }
 
 status_t hmac_hmac_sha256_init_redundant(hmac_key_t key, hmac_ctx_t *ctx) {
-  ctx->msg_block_wordlen = kHmacSha256BlockWords;
-  ctx->digest_wordlen = kHmacSha256DigestWords;
-  sha2_init(kDigestLengthSha256, ctx);
-  // Store key so hmac_hmac_sha256_final_redundant can derive o_key_pad.
-  ctx->key.key_len = key.key_len;
-  ctx->key.checksum = key.checksum;
-  hardened_memcpy(ctx->key.key_block, key.key_block, key.key_len);
-  HARDENED_CHECK_EQ(
-      hardened_memeq(key.key_block, ctx->key.key_block, key.key_len),
-      kHardenedBoolTrue);
-  // Compute i_key_pad = key XOR ipad and absorb it so subsequent hmac_update
-  // calls receive only message bytes.
-  uint32_t i_key_pad[kHmacSha256BlockWords];
-  uint32_t ipad[kHmacSha256BlockWords];
-  memset(i_key_pad, 0, kHmacSha256BlockBytes);
-  memset(ipad, 0x36, kHmacSha256BlockBytes);
-  HARDENED_TRY(
-      hardened_xor(key.key_block, ipad, kHmacSha256BlockWords, i_key_pad));
-  otcrypto_const_byte_buf_t i_key_pad_buf =
-      OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, (const uint8_t *)i_key_pad,
-                        kHmacSha256BlockBytes);
-  return hmac_update(ctx, &i_key_pad_buf);
+  return hmac_init_redundant_core(key, ctx, kHmacSha256BlockWords,
+                                  kHmacSha256DigestWords, kDigestLengthSha256);
 }
 
 status_t hmac_hmac_sha384_init_redundant(hmac_key_t key, hmac_ctx_t *ctx) {
-  ctx->msg_block_wordlen = kHmacSha384BlockWords;
-  ctx->digest_wordlen = kHmacSha384DigestWords;
-  sha2_init(kDigestLengthSha384, ctx);
-  ctx->key.key_len = key.key_len;
-  ctx->key.checksum = key.checksum;
-  hardened_memcpy(ctx->key.key_block, key.key_block, key.key_len);
-  HARDENED_CHECK_EQ(
-      hardened_memeq(key.key_block, ctx->key.key_block, key.key_len),
-      kHardenedBoolTrue);
-  // Compute i_key_pad = key XOR ipad and absorb it so subsequent hmac_update
-  // calls receive only message bytes.
-  uint32_t i_key_pad[kHmacSha384BlockWords];
-  uint32_t ipad[kHmacSha384BlockWords];
-  memset(i_key_pad, 0, kHmacSha384BlockBytes);
-  memset(ipad, 0x36, kHmacSha384BlockBytes);
-  HARDENED_TRY(
-      hardened_xor(key.key_block, ipad, kHmacSha384BlockWords, i_key_pad));
-  otcrypto_const_byte_buf_t i_key_pad_buf =
-      OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, (const uint8_t *)i_key_pad,
-                        kHmacSha384BlockBytes);
-  return hmac_update(ctx, &i_key_pad_buf);
+  return hmac_init_redundant_core(key, ctx, kHmacSha384BlockWords,
+                                  kHmacSha384DigestWords, kDigestLengthSha384);
 }
 
 status_t hmac_hmac_sha512_init_redundant(hmac_key_t key, hmac_ctx_t *ctx) {
-  ctx->msg_block_wordlen = kHmacSha512BlockWords;
-  ctx->digest_wordlen = kHmacSha512DigestWords;
-  sha2_init(kDigestLengthSha512, ctx);
-  ctx->key.key_len = key.key_len;
-  ctx->key.checksum = key.checksum;
-  hardened_memcpy(ctx->key.key_block, key.key_block, key.key_len);
-  HARDENED_CHECK_EQ(
-      hardened_memeq(key.key_block, ctx->key.key_block, key.key_len),
-      kHardenedBoolTrue);
-  // Compute i_key_pad = key XOR ipad and absorb it so subsequent hmac_update
-  // calls receive only message bytes.
-  uint32_t i_key_pad[kHmacSha512BlockWords];
-  uint32_t ipad[kHmacSha512BlockWords];
-  memset(i_key_pad, 0, kHmacSha512BlockBytes);
-  memset(ipad, 0x36, kHmacSha512BlockBytes);
-  HARDENED_TRY(
-      hardened_xor(key.key_block, ipad, kHmacSha512BlockWords, i_key_pad));
-  otcrypto_const_byte_buf_t i_key_pad_buf =
-      OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, (const uint8_t *)i_key_pad,
-                        kHmacSha512BlockBytes);
-  return hmac_update(ctx, &i_key_pad_buf);
+  return hmac_init_redundant_core(key, ctx, kHmacSha512BlockWords,
+                                  kHmacSha512DigestWords, kDigestLengthSha512);
 }
 
 status_t hmac_hmac_sha256_final_redundant(hmac_ctx_t *ctx,
                                           otcrypto_word32_buf_t *tag) {
-  // Save key before hmac_final wipes the context.
-  hmac_key_t saved_key;
-  saved_key.key_len = ctx->key.key_len;
-  saved_key.checksum = ctx->key.checksum;
-  hardened_memcpy(saved_key.key_block, ctx->key.key_block, ctx->key.key_len);
-  HARDENED_CHECK_EQ(
-      hardened_memeq(saved_key.key_block, ctx->key.key_block, ctx->key.key_len),
-      kHardenedBoolTrue);
-  // Finalize inner hash: H(i_key_pad || msg).
-  uint32_t inner_digest_data[kHmacSha256DigestWords];
-  memset(inner_digest_data, 0, sizeof(inner_digest_data));
-  otcrypto_word32_buf_t inner_digest = OTCRYPTO_MAKE_BUF(
-      otcrypto_word32_buf_t, inner_digest_data, kHmacSha256DigestWords);
-  HARDENED_TRY(hmac_final(ctx, &inner_digest));
-  // Compute o_key_pad = key XOR opad and run the outer hash.
-  uint32_t o_key_pad[kHmacSha256BlockWords];
-  uint32_t opad[kHmacSha256BlockWords];
-  memset(o_key_pad, 0, kHmacSha256BlockBytes);
-  memset(opad, 0x5c5c5c5c, kHmacSha256BlockBytes);
-  HARDENED_TRY(hardened_xor(saved_key.key_block, opad, kHmacSha256BlockWords,
-                            o_key_pad));
-  hmac_hash_sha256_init(ctx);
-  otcrypto_const_byte_buf_t o_key_pad_buf =
-      OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, (const uint8_t *)o_key_pad,
-                        kHmacSha256BlockBytes);
-  HARDENED_TRY(hmac_update(ctx, &o_key_pad_buf));
-  otcrypto_const_byte_buf_t inner_buf = OTCRYPTO_MAKE_BUF(
-      otcrypto_const_byte_buf_t, (const uint8_t *)inner_digest_data,
-      kHmacSha256DigestBytes);
-  HARDENED_TRY(hmac_update(ctx, &inner_buf));
-  return hmac_final(ctx, tag);
+  return hmac_final_redundant_core(ctx, tag, kHmacSha256BlockWords,
+                                   kHmacSha256DigestWords, 0x5c5c5c5c,
+                                   hmac_hash_sha256_init);
 }
 
 status_t hmac_hmac_sha384_final_redundant(hmac_ctx_t *ctx,
                                           otcrypto_word32_buf_t *tag) {
-  // Save key before hmac_final wipes the context.
-  hmac_key_t saved_key;
-  saved_key.key_len = ctx->key.key_len;
-  saved_key.checksum = ctx->key.checksum;
-  hardened_memcpy(saved_key.key_block, ctx->key.key_block, ctx->key.key_len);
-  HARDENED_CHECK_EQ(
-      hardened_memeq(saved_key.key_block, ctx->key.key_block, ctx->key.key_len),
-      kHardenedBoolTrue);
-  uint32_t inner_digest_data[kHmacSha384DigestWords];
-  memset(inner_digest_data, 0, sizeof(inner_digest_data));
-  otcrypto_word32_buf_t inner_digest = OTCRYPTO_MAKE_BUF(
-      otcrypto_word32_buf_t, inner_digest_data, kHmacSha384DigestWords);
-  HARDENED_TRY(hmac_final(ctx, &inner_digest));
-  uint32_t o_key_pad[kHmacSha384BlockWords];
-  uint32_t opad[kHmacSha384BlockWords];
-  memset(o_key_pad, 0, kHmacSha384BlockBytes);
-  memset(opad, 0x5c, kHmacSha384BlockBytes);
-  HARDENED_TRY(hardened_xor(saved_key.key_block, opad, kHmacSha384BlockWords,
-                            o_key_pad));
-  hmac_hash_sha384_init(ctx);
-  otcrypto_const_byte_buf_t o_key_pad_buf =
-      OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, (const uint8_t *)o_key_pad,
-                        kHmacSha384BlockBytes);
-  HARDENED_TRY(hmac_update(ctx, &o_key_pad_buf));
-  otcrypto_const_byte_buf_t inner_buf = OTCRYPTO_MAKE_BUF(
-      otcrypto_const_byte_buf_t, (const uint8_t *)inner_digest_data,
-      kHmacSha384DigestBytes);
-  HARDENED_TRY(hmac_update(ctx, &inner_buf));
-  return hmac_final(ctx, tag);
+  return hmac_final_redundant_core(ctx, tag, kHmacSha384BlockWords,
+                                   kHmacSha384DigestWords, 0x5c5c5c5c,
+                                   hmac_hash_sha384_init);
 }
 
 status_t hmac_hmac_sha512_final_redundant(hmac_ctx_t *ctx,
                                           otcrypto_word32_buf_t *tag) {
-  // Save key before hmac_final wipes the context.
-  hmac_key_t saved_key;
-  saved_key.key_len = ctx->key.key_len;
-  saved_key.checksum = ctx->key.checksum;
-  hardened_memcpy(saved_key.key_block, ctx->key.key_block, ctx->key.key_len);
-  HARDENED_CHECK_EQ(
-      hardened_memeq(saved_key.key_block, ctx->key.key_block, ctx->key.key_len),
-      kHardenedBoolTrue);
-  uint32_t inner_digest_data[kHmacSha512DigestWords];
-  memset(inner_digest_data, 0, sizeof(inner_digest_data));
-  otcrypto_word32_buf_t inner_digest = OTCRYPTO_MAKE_BUF(
-      otcrypto_word32_buf_t, inner_digest_data, kHmacSha512DigestWords);
-  HARDENED_TRY(hmac_final(ctx, &inner_digest));
-  uint32_t o_key_pad[kHmacSha512BlockWords];
-  uint32_t opad[kHmacSha512BlockWords];
-  memset(o_key_pad, 0, kHmacSha512BlockBytes);
-  memset(opad, 0x5c, kHmacSha512BlockBytes);
-  HARDENED_TRY(hardened_xor(saved_key.key_block, opad, kHmacSha512BlockWords,
-                            o_key_pad));
-  hmac_hash_sha512_init(ctx);
-  otcrypto_const_byte_buf_t o_key_pad_buf =
-      OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, (const uint8_t *)o_key_pad,
-                        kHmacSha512BlockBytes);
-  HARDENED_TRY(hmac_update(ctx, &o_key_pad_buf));
-  otcrypto_const_byte_buf_t inner_buf = OTCRYPTO_MAKE_BUF(
-      otcrypto_const_byte_buf_t, (const uint8_t *)inner_digest_data,
-      kHmacSha512DigestBytes);
-  HARDENED_TRY(hmac_update(ctx, &inner_buf));
-  return hmac_final(ctx, tag);
+  return hmac_final_redundant_core(ctx, tag, kHmacSha512BlockWords,
+                                   kHmacSha512DigestWords, 0x5c5c5c5c,
+                                   hmac_hash_sha512_init);
 }
 
 uint32_t hmac_key_integrity_checksum(const hmac_key_t *key) {

--- a/sw/device/lib/crypto/impl/hmac.c
+++ b/sw/device/lib/crypto/impl/hmac.c
@@ -84,89 +84,18 @@ static status_t hmac_key_construct(const otcrypto_blinded_key_t *key,
   if (launder32(key->config.key_length) >
       key_block_wordlen * sizeof(uint32_t)) {
     otcrypto_hmac_key_mode_t used_key_mode = launder32(0);
+    status_t (*hash_fn)(const otcrypto_const_byte_buf_t *, uint32_t *) = NULL;
     switch (key->config.key_mode) {
       case kOtcryptoKeyModeHmacSha256:
-        if (key->config.security_level == kOtcryptoKeySecurityLevelHigh) {
-          // Create an inverted copy of the input key and run the real sha and
-          // inverted one in a random order.
-          uint32_t key_copy[key_block_wordlen];
-          uint32_t random_unmasked_key[unmasked_key_len];
-          otcrypto_const_byte_buf_t random_unmasked_key_buf = OTCRYPTO_MAKE_BUF(
-              otcrypto_const_byte_buf_t, (unsigned char *)random_unmasked_key,
-              key->config.key_length);
-          HARDENED_TRY(
-              hardened_memshred(random_unmasked_key, unmasked_key_len));
-
-          bool swap = ibex_rnd32_read() & 0x1;
-          if (swap) {
-            HARDENED_TRY(hmac_hash_sha256(&random_unmasked_key_buf, key_copy));
-            HARDENED_TRY(
-                hmac_hash_sha256(&unmasked_key_buf, hmac_key->key_block));
-          } else {
-            HARDENED_TRY(
-                hmac_hash_sha256(&unmasked_key_buf, hmac_key->key_block));
-            HARDENED_TRY(hmac_hash_sha256(&random_unmasked_key_buf, key_copy));
-          }
-        } else {
-          HARDENED_TRY(
-              hmac_hash_sha256(&unmasked_key_buf, hmac_key->key_block));
-        }
+        hash_fn = hmac_hash_sha256;
         used_key_mode = launder32(used_key_mode) | kOtcryptoKeyModeHmacSha256;
         break;
       case kOtcryptoKeyModeHmacSha384:
-        if (key->config.security_level == kOtcryptoKeySecurityLevelHigh) {
-          // Create an inverted copy of the input key and run the real sha and
-          // inverted one in a random order.
-          uint32_t key_copy[key_block_wordlen];
-          uint32_t random_unmasked_key[unmasked_key_len];
-          otcrypto_const_byte_buf_t random_unmasked_key_buf = OTCRYPTO_MAKE_BUF(
-              otcrypto_const_byte_buf_t, (unsigned char *)random_unmasked_key,
-              key->config.key_length);
-          HARDENED_TRY(
-              hardened_memshred(random_unmasked_key, unmasked_key_len));
-
-          bool swap = ibex_rnd32_read() & 0x1;
-          if (swap) {
-            HARDENED_TRY(hmac_hash_sha384(&random_unmasked_key_buf, key_copy));
-            HARDENED_TRY(
-                hmac_hash_sha384(&unmasked_key_buf, hmac_key->key_block));
-          } else {
-            HARDENED_TRY(
-                hmac_hash_sha384(&unmasked_key_buf, hmac_key->key_block));
-            HARDENED_TRY(hmac_hash_sha384(&random_unmasked_key_buf, key_copy));
-          }
-        } else {
-          HARDENED_TRY(
-              hmac_hash_sha384(&unmasked_key_buf, hmac_key->key_block));
-        }
+        hash_fn = hmac_hash_sha384;
         used_key_mode = launder32(used_key_mode) | kOtcryptoKeyModeHmacSha384;
         break;
       case kOtcryptoKeyModeHmacSha512:
-        if (key->config.security_level == kOtcryptoKeySecurityLevelHigh) {
-          // Create an inverted copy of the input key and run the real sha and
-          // inverted one in a random order.
-          uint32_t key_copy[key_block_wordlen];
-          uint32_t random_unmasked_key[unmasked_key_len];
-          otcrypto_const_byte_buf_t random_unmasked_key_buf = OTCRYPTO_MAKE_BUF(
-              otcrypto_const_byte_buf_t, (unsigned char *)random_unmasked_key,
-              key->config.key_length);
-          HARDENED_TRY(
-              hardened_memshred(random_unmasked_key, unmasked_key_len));
-
-          bool swap = ibex_rnd32_read() & 0x1;
-          if (swap) {
-            HARDENED_TRY(hmac_hash_sha512(&random_unmasked_key_buf, key_copy));
-            HARDENED_TRY(
-                hmac_hash_sha512(&unmasked_key_buf, hmac_key->key_block));
-          } else {
-            HARDENED_TRY(
-                hmac_hash_sha512(&unmasked_key_buf, hmac_key->key_block));
-            HARDENED_TRY(hmac_hash_sha512(&random_unmasked_key_buf, key_copy));
-          }
-        } else {
-          HARDENED_TRY(
-              hmac_hash_sha512(&unmasked_key_buf, hmac_key->key_block));
-        }
+        hash_fn = hmac_hash_sha512;
         used_key_mode = launder32(used_key_mode) | kOtcryptoKeyModeHmacSha512;
         break;
       default:
@@ -175,6 +104,28 @@ static status_t hmac_key_construct(const otcrypto_blinded_key_t *key,
         return OTCRYPTO_BAD_ARGS;
     }
     HARDENED_CHECK_EQ(used_key_mode, key->config.key_mode);
+
+    if (key->config.security_level != kOtcryptoKeySecurityLevelHigh) {
+      HARDENED_TRY(hash_fn(&unmasked_key_buf, hmac_key->key_block));
+    } else {
+      // Create an inverted copy of the input key and run the real sha and
+      // inverted one in a random order.
+      uint32_t key_copy[key_block_wordlen];
+      uint32_t random_unmasked_key[unmasked_key_len];
+      otcrypto_const_byte_buf_t random_unmasked_key_buf = OTCRYPTO_MAKE_BUF(
+          otcrypto_const_byte_buf_t, (unsigned char *)random_unmasked_key,
+          key->config.key_length);
+      HARDENED_TRY(hardened_memshred(random_unmasked_key, unmasked_key_len));
+
+      bool swap = ibex_rnd32_read() & 0x1;
+      if (swap) {
+        HARDENED_TRY(hash_fn(&random_unmasked_key_buf, key_copy));
+        HARDENED_TRY(hash_fn(&unmasked_key_buf, hmac_key->key_block));
+      } else {
+        HARDENED_TRY(hash_fn(&unmasked_key_buf, hmac_key->key_block));
+        HARDENED_TRY(hash_fn(&random_unmasked_key_buf, key_copy));
+      }
+    }
   } else {
     HARDENED_CHECK_LE(key->config.key_length,
                       key_block_wordlen * sizeof(uint32_t));
@@ -251,174 +202,86 @@ otcrypto_status_t otcrypto_hmac(const otcrypto_blinded_key_t *key,
   HARDENED_TRY(check_key(key));
 
   // Call the appropriate function from the HMAC driver.
-  hmac_key_t hmac_key;
+  status_t (*cl_fn)(const hmac_key_t *, const otcrypto_const_byte_buf_t *,
+                    otcrypto_word32_buf_t *) = NULL;
+  status_t (*redundant_fn)(const hmac_key_t *,
+                           const otcrypto_const_byte_buf_t *,
+                           otcrypto_word32_buf_t *) = NULL;
+  size_t block_words = 0;
+  otcrypto_hmac_key_mode_t key_mode_used = launder32(0);
+
   switch (key->config.key_mode) {
-    case kOtcryptoKeyModeHmacSha256: {
-      HARDENED_CHECK_EQ(launder32(key->config.key_mode),
-                        kOtcryptoKeyModeHmacSha256);
-      HARDENED_TRY(hmac_key_construct(key, kHmacSha256BlockWords, &hmac_key));
-      if (key->config.security_level == kOtcryptoKeySecurityLevelLow) {
-        // No protection against FI.
-        HARDENED_CHECK_EQ(launder32(key->config.security_level),
-                          kOtcryptoKeySecurityLevelLow);
-        return otcrypto_eval_exit(
-            hmac_hmac_sha256_cl(&hmac_key, input_message, tag));
-      } else if (key->config.security_level ==
-                 kOtcryptoKeySecurityLevelMedium) {
-        // Call the HMAC core twice and compare both tags. This serves as a FI
-        // countermeasure.
-        // First HMAC computation using the HMAC core.
-        HARDENED_CHECK_EQ(launder32(key->config.security_level),
-                          kOtcryptoKeySecurityLevelMedium);
-        HARDENED_TRY(hmac_hmac_sha256_cl(&hmac_key, input_message, tag));
-        // Second HMAC computation using the HMAC core.
-        uint32_t tag_redundant_data[kHmacSha256DigestWords];
-        otcrypto_word32_buf_t tag_redundant = OTCRYPTO_MAKE_BUF(
-            otcrypto_word32_buf_t, tag_redundant_data, tag->len);
-        hmac_key_t hmac_key_redundant;
-        HARDENED_TRY(hmac_key_construct(key, kHmacSha256BlockWords,
-                                        &hmac_key_redundant));
-        HARDENED_TRY(hmac_hmac_sha256_cl(&hmac_key_redundant, input_message,
-                                         &tag_redundant));
-        // Comparison of both tags.
-        HARDENED_CHECK_EQ(
-            hardened_memeq(&tag->data[0], &tag_redundant.data[0], tag->len),
-            kHardenedBoolTrue);
-        return otcrypto_eval_exit(OTCRYPTO_OK);
-      } else {
-        // Perform two HMAC operations. The first call uses the HMAC core. The
-        // second use uses a HMAC implementation that does not use the HMAC
-        // core. This serves as a FI countermeasure.
-        HARDENED_CHECK_EQ(launder32(key->config.security_level),
-                          kOtcryptoKeySecurityLevelHigh);
-        // First HMAC computation using the HMAC core.
-        HARDENED_TRY(hmac_hmac_sha256_cl(&hmac_key, input_message, tag));
-        // Second HMAC computation without using the HMAC core.
-        uint32_t tag_redundant_data[kHmacSha256DigestWords];
-        otcrypto_word32_buf_t tag_redundant = OTCRYPTO_MAKE_BUF(
-            otcrypto_word32_buf_t, tag_redundant_data, tag->len);
-        hmac_key_t hmac_key_redundant;
-        HARDENED_TRY(hmac_key_construct(key, kHmacSha256BlockWords,
-                                        &hmac_key_redundant));
-        HARDENED_TRY(hmac_hmac_sha256_redundant(&hmac_key_redundant,
-                                                input_message, &tag_redundant));
-        // Comparison of both tags.
-        HARDENED_CHECK_EQ(
-            hardened_memeq(&tag->data[0], &tag_redundant.data[0], tag->len),
-            kHardenedBoolTrue);
-        return otcrypto_eval_exit(OTCRYPTO_OK);
-      }
-    }
-    case kOtcryptoKeyModeHmacSha384: {
-      HARDENED_CHECK_EQ(key->config.key_mode, kOtcryptoKeyModeHmacSha384);
-      HARDENED_TRY(hmac_key_construct(key, kHmacSha384BlockWords, &hmac_key));
-      if (key->config.security_level == kOtcryptoKeySecurityLevelLow) {
-        HARDENED_CHECK_EQ(launder32(key->config.security_level),
-                          kOtcryptoKeySecurityLevelLow);
-        return otcrypto_eval_exit(
-            hmac_hmac_sha384(&hmac_key, input_message, tag));
-      } else if (key->config.security_level ==
-                 kOtcryptoKeySecurityLevelMedium) {
-        // Call the HMAC core twice and compare both tags. This serves as a FI
-        // countermeasure.
-        // First HMAC computation using the HMAC core.
-        HARDENED_CHECK_EQ(launder32(key->config.security_level),
-                          kOtcryptoKeySecurityLevelMedium);
-        HARDENED_TRY(hmac_hmac_sha384(&hmac_key, input_message, tag));
-        // Second HMAC computation using the HMAC core.
-        uint32_t tag_redundant_data[kHmacSha384DigestWords];
-        otcrypto_word32_buf_t tag_redundant = OTCRYPTO_MAKE_BUF(
-            otcrypto_word32_buf_t, tag_redundant_data, tag->len);
-        hmac_key_t hmac_key_redundant;
-        HARDENED_TRY(hmac_key_construct(key, kHmacSha384BlockWords,
-                                        &hmac_key_redundant));
-        HARDENED_TRY(hmac_hmac_sha384(&hmac_key_redundant, input_message,
-                                      &tag_redundant));
-        // Comparison of both tags.
-        HARDENED_CHECK_EQ(
-            hardened_memeq(&tag->data[0], &tag_redundant.data[0], tag->len),
-            kHardenedBoolTrue);
-        return otcrypto_eval_exit(OTCRYPTO_OK);
-      } else {
-        // Perform two HMAC operations. The first call uses the HMAC core. The
-        // second use uses a HMAC implementation that does not use the HMAC
-        // core. This serves as a FI countermeasure.
-        HARDENED_CHECK_EQ(launder32(key->config.security_level),
-                          kOtcryptoKeySecurityLevelHigh);
-        // First HMAC computation using the HMAC core.
-        HARDENED_TRY(hmac_hmac_sha384(&hmac_key, input_message, tag));
-        // Second HMAC computation without using the HMAC core.
-        uint32_t tag_redundant_data[kHmacSha384DigestWords];
-        otcrypto_word32_buf_t tag_redundant = OTCRYPTO_MAKE_BUF(
-            otcrypto_word32_buf_t, tag_redundant_data, tag->len);
-        hmac_key_t hmac_key_redundant;
-        HARDENED_TRY(hmac_key_construct(key, kHmacSha384BlockWords,
-                                        &hmac_key_redundant));
-        HARDENED_TRY(hmac_hmac_sha384_redundant(&hmac_key_redundant,
-                                                input_message, &tag_redundant));
-        // Comparison of both tags.
-        HARDENED_CHECK_EQ(
-            hardened_memeq(&tag->data[0], &tag_redundant.data[0], tag->len),
-            kHardenedBoolTrue);
-        return otcrypto_eval_exit(OTCRYPTO_OK);
-      }
-    }
-    case kOtcryptoKeyModeHmacSha512: {
-      HARDENED_CHECK_EQ(key->config.key_mode, kOtcryptoKeyModeHmacSha512);
-      HARDENED_TRY(hmac_key_construct(key, kHmacSha512BlockWords, &hmac_key));
-      if (key->config.security_level == kOtcryptoKeySecurityLevelLow) {
-        HARDENED_CHECK_EQ(launder32(key->config.security_level),
-                          kOtcryptoKeySecurityLevelLow);
-        return otcrypto_eval_exit(
-            hmac_hmac_sha512(&hmac_key, input_message, tag));
-      } else if (key->config.security_level ==
-                 kOtcryptoKeySecurityLevelMedium) {
-        // Call the HMAC core twice and compare both tags. This serves as a FI
-        // countermeasure.
-        // First HMAC computation using the HMAC core.
-        HARDENED_CHECK_EQ(launder32(key->config.security_level),
-                          kOtcryptoKeySecurityLevelMedium);
-        HARDENED_TRY(hmac_hmac_sha512(&hmac_key, input_message, tag));
-        // Second HMAC computation using the HMAC core.
-        uint32_t tag_redundant_data[kHmacSha512DigestWords];
-        otcrypto_word32_buf_t tag_redundant = OTCRYPTO_MAKE_BUF(
-            otcrypto_word32_buf_t, tag_redundant_data, tag->len);
-        hmac_key_t hmac_key_redundant;
-        HARDENED_TRY(hmac_key_construct(key, kHmacSha512BlockWords,
-                                        &hmac_key_redundant));
-        HARDENED_TRY(hmac_hmac_sha512(&hmac_key_redundant, input_message,
-                                      &tag_redundant));
-        // Comparison of both tags.
-        HARDENED_CHECK_EQ(
-            hardened_memeq(&tag->data[0], &tag_redundant.data[0], tag->len),
-            kHardenedBoolTrue);
-        return otcrypto_eval_exit(OTCRYPTO_OK);
-      } else {
-        // Perform two HMAC operations. The first call uses the HMAC core. The
-        // second use uses a HMAC implementation that does not use the HMAC
-        // core. This serves as a FI countermeasure.
-        HARDENED_CHECK_EQ(launder32(key->config.security_level),
-                          kOtcryptoKeySecurityLevelHigh);
-        // First HMAC computation using the HMAC core.
-        HARDENED_TRY(hmac_hmac_sha512(&hmac_key, input_message, tag));
-        // Second HMAC computation without using the HMAC core.
-        uint32_t tag_redundant_data[kHmacSha512DigestWords];
-        otcrypto_word32_buf_t tag_redundant = OTCRYPTO_MAKE_BUF(
-            otcrypto_word32_buf_t, tag_redundant_data, tag->len);
-        hmac_key_t hmac_key_redundant;
-        HARDENED_TRY(hmac_key_construct(key, kHmacSha512BlockWords,
-                                        &hmac_key_redundant));
-        HARDENED_TRY(hmac_hmac_sha512_redundant(&hmac_key_redundant,
-                                                input_message, &tag_redundant));
-        // Comparison of both tags.
-        HARDENED_CHECK_EQ(
-            hardened_memeq(&tag->data[0], &tag_redundant.data[0], tag->len),
-            kHardenedBoolTrue);
-        return otcrypto_eval_exit(OTCRYPTO_OK);
-      }
-    }
+    case kOtcryptoKeyModeHmacSha256:
+      key_mode_used = launder32(key_mode_used) | kOtcryptoKeyModeHmacSha256;
+      block_words = kHmacSha256BlockWords;
+      cl_fn = hmac_hmac_sha256_cl;
+      redundant_fn = hmac_hmac_sha256_redundant;
+      break;
+    case kOtcryptoKeyModeHmacSha384:
+      key_mode_used = launder32(key_mode_used) | kOtcryptoKeyModeHmacSha384;
+      block_words = kHmacSha384BlockWords;
+      cl_fn = hmac_hmac_sha384;
+      redundant_fn = hmac_hmac_sha384_redundant;
+      break;
+    case kOtcryptoKeyModeHmacSha512:
+      key_mode_used = launder32(key_mode_used) | kOtcryptoKeyModeHmacSha512;
+      block_words = kHmacSha512BlockWords;
+      cl_fn = hmac_hmac_sha512;
+      redundant_fn = hmac_hmac_sha512_redundant;
+      break;
     default:
       return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(launder32(key_mode_used), key->config.key_mode);
+
+  hmac_key_t hmac_key;
+  HARDENED_TRY(hmac_key_construct(key, block_words, &hmac_key));
+
+  if (key->config.security_level == kOtcryptoKeySecurityLevelLow) {
+    // No protection against FI.
+    HARDENED_CHECK_EQ(launder32(key->config.security_level),
+                      kOtcryptoKeySecurityLevelLow);
+    return otcrypto_eval_exit(cl_fn(&hmac_key, input_message, tag));
+  } else if (key->config.security_level == kOtcryptoKeySecurityLevelMedium) {
+    // Call the HMAC core twice and compare both tags. This serves as a FI
+    // countermeasure.
+    // First HMAC computation using the HMAC core.
+    HARDENED_CHECK_EQ(launder32(key->config.security_level),
+                      kOtcryptoKeySecurityLevelMedium);
+    HARDENED_TRY(cl_fn(&hmac_key, input_message, tag));
+    // Second HMAC computation using the HMAC core.
+    uint32_t tag_redundant_data[kHmacMaxDigestWords];
+    otcrypto_word32_buf_t tag_redundant =
+        OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, tag_redundant_data, tag->len);
+    hmac_key_t hmac_key_redundant;
+    HARDENED_TRY(hmac_key_construct(key, block_words, &hmac_key_redundant));
+    HARDENED_TRY(cl_fn(&hmac_key_redundant, input_message, &tag_redundant));
+    // Comparison of both tags.
+    HARDENED_CHECK_EQ(
+        hardened_memeq(&tag->data[0], &tag_redundant.data[0], tag->len),
+        kHardenedBoolTrue);
+    return otcrypto_eval_exit(OTCRYPTO_OK);
+  } else {
+    // Perform two HMAC operations. The first call uses the HMAC core. The
+    // second use uses a HMAC implementation that does not use the HMAC
+    // core. This serves as a FI countermeasure.
+    HARDENED_CHECK_EQ(launder32(key->config.security_level),
+                      kOtcryptoKeySecurityLevelHigh);
+    // First HMAC computation using the HMAC core.
+    HARDENED_TRY(cl_fn(&hmac_key, input_message, tag));
+    // Second HMAC computation without using the HMAC core.
+    uint32_t tag_redundant_data[kHmacMaxDigestWords];
+    otcrypto_word32_buf_t tag_redundant =
+        OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, tag_redundant_data, tag->len);
+    hmac_key_t hmac_key_redundant;
+    HARDENED_TRY(hmac_key_construct(key, block_words, &hmac_key_redundant));
+    HARDENED_TRY(
+        redundant_fn(&hmac_key_redundant, input_message, &tag_redundant));
+    // Comparison of both tags.
+    HARDENED_CHECK_EQ(
+        hardened_memeq(&tag->data[0], &tag_redundant.data[0], tag->len),
+        kHardenedBoolTrue);
+    return otcrypto_eval_exit(OTCRYPTO_OK);
   }
 
   // Should be unreachable.
@@ -443,69 +306,29 @@ otcrypto_status_t otcrypto_hmac_init(otcrypto_hmac_context_t *ctx,
   hmac_ctx_t redundant_ctx;
   hmac_key_t hmac_key;
   otcrypto_hmac_key_mode_t key_mode_used = launder32(0);
+
+  void (*init_fn)(const hmac_key_t, hmac_ctx_t *) = NULL;
+  status_t (*init_redundant_fn)(hmac_key_t, hmac_ctx_t *) = NULL;
+  size_t block_words = 0;
+
   switch (launder32(key->config.key_mode)) {
     case kOtcryptoKeyModeHmacSha256:
       key_mode_used = launder32(key_mode_used) | kOtcryptoKeyModeHmacSha256;
-      HARDENED_CHECK_EQ(key->config.key_mode, kOtcryptoKeyModeHmacSha256);
-      HARDENED_TRY(hmac_key_construct(key, kHmacSha256BlockWords, &hmac_key));
-      hmac_hmac_sha256_init_cl(hmac_key, &primary_ctx);
-      if (launder32(key->config.security_level) ==
-          kOtcryptoKeySecurityLevelLow) {
-        HARDENED_CHECK_EQ(launder32(key->config.security_level),
-                          kOtcryptoKeySecurityLevelLow);
-      } else if (launder32(key->config.security_level) ==
-                 kOtcryptoKeySecurityLevelMedium) {
-        // For a medium security level, call the init function a second time.
-        HARDENED_CHECK_EQ(launder32(key->config.security_level),
-                          kOtcryptoKeySecurityLevelMedium);
-        hmac_hmac_sha256_init_cl(hmac_key, &redundant_ctx);
-      } else {
-        // For a high security level, the redundant init is done using a
-        // different implementation approach.
-        HARDENED_TRY(hmac_hmac_sha256_init_redundant(hmac_key, &redundant_ctx));
-      }
+      block_words = kHmacSha256BlockWords;
+      init_fn = hmac_hmac_sha256_init_cl;
+      init_redundant_fn = hmac_hmac_sha256_init_redundant;
       break;
     case kOtcryptoKeyModeHmacSha384:
       key_mode_used = launder32(key_mode_used) | kOtcryptoKeyModeHmacSha384;
-      HARDENED_CHECK_EQ(key->config.key_mode, kOtcryptoKeyModeHmacSha384);
-      HARDENED_TRY(hmac_key_construct(key, kHmacSha384BlockWords, &hmac_key));
-      hmac_hmac_sha384_init(hmac_key, &primary_ctx);
-      if (launder32(key->config.security_level) ==
-          kOtcryptoKeySecurityLevelLow) {
-        HARDENED_CHECK_EQ(launder32(key->config.security_level),
-                          kOtcryptoKeySecurityLevelLow);
-      } else if (launder32(key->config.security_level) ==
-                 kOtcryptoKeySecurityLevelMedium) {
-        // For a medium security level, call the init function a second time.
-        HARDENED_CHECK_EQ(launder32(key->config.security_level),
-                          kOtcryptoKeySecurityLevelMedium);
-        hmac_hmac_sha384_init(hmac_key, &redundant_ctx);
-      } else {
-        // For a high security level, the redundant init is done using a
-        // different implementation approach.
-        HARDENED_TRY(hmac_hmac_sha384_init_redundant(hmac_key, &redundant_ctx));
-      }
+      block_words = kHmacSha384BlockWords;
+      init_fn = hmac_hmac_sha384_init;
+      init_redundant_fn = hmac_hmac_sha384_init_redundant;
       break;
     case kOtcryptoKeyModeHmacSha512:
       key_mode_used = launder32(key_mode_used) | kOtcryptoKeyModeHmacSha512;
-      HARDENED_CHECK_EQ(key->config.key_mode, kOtcryptoKeyModeHmacSha512);
-      HARDENED_TRY(hmac_key_construct(key, kHmacSha512BlockWords, &hmac_key));
-      hmac_hmac_sha512_init(hmac_key, &primary_ctx);
-      if (launder32(key->config.security_level) ==
-          kOtcryptoKeySecurityLevelLow) {
-        HARDENED_CHECK_EQ(launder32(key->config.security_level),
-                          kOtcryptoKeySecurityLevelLow);
-      } else if (launder32(key->config.security_level) ==
-                 kOtcryptoKeySecurityLevelMedium) {
-        // For a medium security level, call the init function a second time.
-        HARDENED_CHECK_EQ(launder32(key->config.security_level),
-                          kOtcryptoKeySecurityLevelMedium);
-        hmac_hmac_sha512_init(hmac_key, &redundant_ctx);
-      } else {
-        // For a high security level, the redundant init is done using a
-        // different implementation approach.
-        HARDENED_TRY(hmac_hmac_sha512_init_redundant(hmac_key, &redundant_ctx));
-      }
+      block_words = kHmacSha512BlockWords;
+      init_fn = hmac_hmac_sha512_init;
+      init_redundant_fn = hmac_hmac_sha512_init_redundant;
       break;
     default:
       return OTCRYPTO_BAD_ARGS;
@@ -513,6 +336,24 @@ otcrypto_status_t otcrypto_hmac_init(otcrypto_hmac_context_t *ctx,
   // Check if we landed in the correct case statement. Use ORs for this to
   // avoid that multiple cases were executed.
   HARDENED_CHECK_EQ(launder32(key_mode_used), key->config.key_mode);
+
+  HARDENED_TRY(hmac_key_construct(key, block_words, &hmac_key));
+  init_fn(hmac_key, &primary_ctx);
+
+  if (launder32(key->config.security_level) == kOtcryptoKeySecurityLevelLow) {
+    HARDENED_CHECK_EQ(launder32(key->config.security_level),
+                      kOtcryptoKeySecurityLevelLow);
+  } else if (launder32(key->config.security_level) ==
+             kOtcryptoKeySecurityLevelMedium) {
+    // For a medium security level, call the init function a second time.
+    HARDENED_CHECK_EQ(launder32(key->config.security_level),
+                      kOtcryptoKeySecurityLevelMedium);
+    init_fn(hmac_key, &redundant_ctx);
+  } else {
+    // For a high security level, the redundant init is done using a
+    // different implementation approach.
+    HARDENED_TRY(init_redundant_fn(hmac_key, &redundant_ctx));
+  }
 
   ctx->data[kCtxSecurityLevelOffset] = (uint32_t)key->config.security_level;
   randomized_bytecopy(&ctx->data[kCtxPrimaryOffset], &primary_ctx,


### PR DESCRIPTION
Make a hmac_redundant_core function in the hmac driver with a size input such that the code can be re-used over all SHA sizes. Create dispatch functions in the hmac API to squash code size for different SHA sizes.