### PR TITLE
[kmac,rtl] Rewrite an expression in keccak_2share for lint warning

### DIFF
--- a/hw/ip/kmac/rtl/keccak_2share.sv
+++ b/hw/ip/kmac/rtl/keccak_2share.sv
@@ -411,8 +411,10 @@ module keccak_2share
     end
     for (int x = 0 ; x < 5 ; x++) begin
       for (int z = 0 ; z < W ; z++) begin
+        // index_z is z-1 modulo W, which will be W-1 if z=0. Computing modulus "expr % W" with
+        // "expr & (W-1)" works because W is a power of two.
         int index_z;
-        index_z = (z == 0) ? W-1 : z-1; // (z+1)%W
+        index_z = (z - 1) & (W - 1);
         d[x][z] = c[ThetaIndexX1[x]][z] ^ c[ThetaIndexX2[x]][index_z];
       end
     end


### PR DESCRIPTION
A local run of AscentLint just complained about the next line, warning that the array access at index index_z might be reading off the start of the array.

This is not a very precise analysis! I suspect it means that the symbolic execution in this analysis pass of AscentLint didn't propagate as many constraints as it could have done. As a result, it inferred that z >= 0 so (at the worst) index_z >= -1, but didn't notice that the z-1 branch of the ternary is only taken when z > 0.

Instead of doing this, notice that W is a power of two, so we can reduce modulo W by doing a bitwise AND with W-1. The only interesting situation is when z = 0. In that case, z-1 = -1 (a signed integer). Since negative numbers are expressed in twos-complement (required by the SystemVerilog spec), the bottom bits of -1 will indeed equal W-1.
