### PR TITLE
[crypto] Check length of wrapped key

### DIFF
--- a/sw/device/lib/crypto/impl/key_transport.c
+++ b/sw/device/lib/crypto/impl/key_transport.c
@@ -329,6 +329,12 @@ otcrypto_status_t otcrypto_key_unwrap(
     return OTCRYPTO_BAD_ARGS;
   }
 
+  // Sanitize the length of the key. Maximum bound is currently the size of a
+  // RSA 4096 private key.
+  if (wrapped_key->len > kOtcryptoWrappedKeyMaxWords) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
   // Unwrap the key.
   uint32_t plaintext[wrapped_key->len];
   HARDENED_TRY(hardened_memshred(plaintext, ARRAYSIZE(plaintext)));

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -444,6 +444,24 @@ typedef struct otcrypto_key_config {
 } otcrypto_key_config_t;
 
 /**
+ * Maximum number of 32-bit words in a wrapped key.
+ *
+ * Sized for the largest supported key (RSA-4096 private key). Callers can use
+ * this to bound input buffers passed to `otcrypto_key_unwrap`.
+ */
+enum {
+  kOtcryptoWrappedKeyMaxWords =
+      /* key configuration struct */
+  sizeof(otcrypto_key_config_t) / sizeof(uint32_t) +
+  /* checksum and keyblob_length fields */
+  2 +
+  /* RSA-4096 keyblob: 2 shares of 512 bytes each */
+  2 * (4096 / 8 / sizeof(uint32_t)) +
+  /* AES-KWP 64-bit integrity prefix */
+  2,
+};
+
+/**
  * Struct to handle unmasked key type.
  */
 typedef struct otcrypto_unblinded_key {


### PR DESCRIPTION
Previously, an attacker would have been able to provide an arbitrary length for the wrapped key length. As this is dangerous, limit the size to the max key length we currently have (RSA 4096).