### PR TITLE
[aes/doc] Update documentation prior to D2S/V2S signoffs

### DIFF
--- a/hw/ip/aes/dv/README.md
+++ b/hw/ip/aes/dv/README.md
@@ -10,8 +10,8 @@
 ## Current status
 * [Design & verification stage](../../../README.md)
   * [HW development stages](../../../../doc/project_governance/development_stages.md)
-* [Simulation results for Masked AES](https://reports.opentitan.org/hw/ip/aes_masked/dv/latest/report.html)
-* [Simulation results for Unmasked AES](https://reports.opentitan.org/hw/ip/aes_unmasked/dv/latest/report.html)
+* [Simulation results for Masked/Unmasked AES](https://dashboard.reports.lowrisc.org/opentitan/earlgrey/dashboard.html)
+* [Simulation results for Masked/Unmasked AES with GCM Support](https://dashboard.reports.lowrisc.org/opentitan/darjeeling/dashboard.html)
 
 ## Design features
 For detailed information on AES design features, please see the [AES HWIP Technical Specification](../README.md).
@@ -57,6 +57,9 @@ which provides the ability to drive and monitor edn traffic via the edn interfac
 The AES RAL model is created with the [`ralgen`](../../../dv/tools/ralgen/README.md) FuseSoC generator script automatically when the simulation is at the build stage.
 
 It can be created manually by invoking [`regtool`](../../../../util/reggen/doc/setup_and_use.md):
+```console
+$ $REPO_TOP/util/regtool.py $REPO_TOP/hw/ip/aes/data/aes.hjson -s --outdir <path_to_directory>
+```
 
 ### Stimulus strategy
 #### Test sequences
@@ -137,14 +140,17 @@ This setting is only available when using the C-model as reference and is contro
 ## Building and running tests
 The [dvsim](https://github.com/lowRISC/dvsim) tool is used for building and running our tests and regressions.
 Please take a look at the link for detailed information on the usage, capabilities, features and known issues.
-Here's how to run a smoke test:
+
+In the examples below, the VARIANT variable should contain one of `masked`, `unmasked`, `gcm_masked` and `gcm_unmasked`.
+
+To run a smoke test, use:
 ```console
-$ dvsim $REPO_TOP/hw/ip/aes/dv/aes_sim_cfg.hjson -i aes_smoke
+$ dvsim $REPO_TOP/hw/ip/aes/dv/aes_${VARIANT}_sim_cfg.hjson -i aes_smoke
 ```
-Here's how to run a basic test without DPI calls:
+To run a basic test without DPI calls, run:
 ```console
 $ dvsim $REPO_TOP/hw/ip/aes/dv/aes_${VARIANT}_sim_cfg.hjson -i aes_wakeup
 ```
-In this run command, $VARIANT can be `masked` or `unmasked`.
+
 ## Testplan
 [Testplan](../data/aes_testplan.hjson)


### PR DESCRIPTION
This PR contains two documentation commits to update the document prior to the D2S/V2S signoffs (see #30127 and #30128).