### PR TITLE
[dv] Add chip_ast_ral_pkg when skip_ral_gen is used

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -38,6 +38,7 @@ filesets:
       - lowrisc:dv:lc_ctrl_dv_utils
       - "!fileset_partner ? (lowrisc:systems:top_earlgrey_ast_pkg)"
       - "fileset_partner ? (partner:systems:top_earlgrey_ast_pkg)"
+      - "skip_ral_gen ? (partner:dv:chip_ast_ral_pkg)"
     files:
       - chip_common_pkg.sv
       - chip_if.sv


### PR DESCRIPTION
If skip_ral_gen is set use a pre-built/partner-provided RAL package for AST instead of using the open-source AST  RAL.