### PR TITLE
[chip,dv] Define a virtual "chip_ral" core

### DIFF
--- a/hw/top_darjeeling/dv/env/chip_ral.core
+++ b/hw/top_darjeeling/dv/env/chip_ral.core
@@ -5,6 +5,9 @@ CAPI=2:
 name: "lowrisc:dv:top_darjeeling_chip_ral:0.1"
 description: "UVM register model for the chip"
 
+virtual:
+    - lowrisc:dv:chip_ral
+
 filesets:
   ral_dep:
     depend:

--- a/hw/top_earlgrey/dv/env/chip_ral.core
+++ b/hw/top_earlgrey/dv/env/chip_ral.core
@@ -5,6 +5,9 @@ CAPI=2:
 name: "lowrisc:dv:top_earlgrey_chip_ral:0.1"
 description: "UVM register model for the chip"
 
+virtual:
+    - lowrisc:dv:chip_ral
+
 filesets:
   ral_dep:
     depend:


### PR DESCRIPTION
Now that PRs on which this depends have been merged, only the following commit remains:

> **[chip,dv] Define a virtual "chip_ral" core**
> 
> This is supplied by a top-level chip-level register model. Defining it
> like this means that a block-level environment can depend on
> lowrisc:dv:chip_ral if the chip_level config parameter is set, which
> will ensure it appears in the EDA file list *after* the register model
> upon which it depends.
> 