### PR TITLE
[cryptotest] X25519 Wycheproof testing

### DIFF
--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -246,6 +246,23 @@ cryptotest(
     test_vectors = ED25519_TESTVECTOR_TARGETS,
 )
 
+X25519_TESTVECTOR_TARGETS = [
+    "//sw/host/cryptotest/testvectors/data:wycheproof_x25519_json",
+]
+
+X25519_TESTVECTOR_ARGS = " ".join([
+    "--x25519-json=\"$(rootpath {})\"".format(target)
+    for target in X25519_TESTVECTOR_TARGETS
+])
+
+cryptotest(
+    name = "x25519_kat",
+    slow_test = True,
+    test_args = X25519_TESTVECTOR_ARGS,
+    test_harness = "//sw/host/tests/crypto/x25519_kat:harness",
+    test_vectors = X25519_TESTVECTOR_TARGETS,
+)
+
 RSA_TESTVECTOR_TARGETS = [
     "//sw/host/cryptotest/testvectors/data:wycheproof_rsa_pkcs1_1.5_2048_{}.json".format(hash)
     for hash in [
@@ -773,5 +790,6 @@ test_suite(
         ":shake128_kat",
         ":shake256_kat",
         ":sphincsplus_kat",
+        ":x25519_kat",
     ],
 )

--- a/sw/device/tests/crypto/cryptotest/cryptotest.bzl
+++ b/sw/device/tests/crypto/cryptotest/cryptotest.bzl
@@ -37,6 +37,7 @@ FIRMWARE_DEPS = [
     "//sw/device/tests/crypto/cryptotest/firmware:kmac",
     "//sw/device/tests/crypto/cryptotest/firmware:rsa",
     "//sw/device/tests/crypto/cryptotest/firmware:sphincsplus",
+    "//sw/device/tests/crypto/cryptotest/firmware:x25519",
     "//sw/device/lib/base:csr",
     "//sw/device/lib/base:status",
     "//sw/device/lib/testing/test_framework:check",

--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -90,6 +90,22 @@ cc_library(
 )
 
 cc_library(
+    name = "x25519",
+    srcs = ["x25519.c"],
+    hdrs = ["x25519.h"],
+    deps = [
+        "//sw/device/lib/base:hardened_memory",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/crypto",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/tests/crypto/cryptotest/json:x25519_commands",
+    ],
+)
+
+cc_library(
     name = "drbg",
     srcs = ["drbg.c"],
     hdrs = ["drbg.h"],
@@ -195,6 +211,7 @@ FIRMWARE_DEPS = [
     ":kmac",
     ":rsa",
     ":sphincsplus",
+    ":x25519",
     "//sw/device/lib/base:csr",
     "//sw/device/lib/crypto",
     "//sw/device/lib/testing/test_framework:check",

--- a/sw/device/tests/crypto/cryptotest/firmware/firmware.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/firmware.c
@@ -25,6 +25,7 @@
 #include "sw/device/tests/crypto/cryptotest/json/kmac_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/rsa_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/sphincsplus_commands.h"
+#include "sw/device/tests/crypto/cryptotest/json/x25519_commands.h"
 
 // Include handlers
 #include "aes.h"
@@ -38,6 +39,7 @@
 #include "kmac.h"
 #include "rsa.h"
 #include "sphincsplus.h"
+#include "x25519.h"
 
 OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
                         .console.base_addr = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR,
@@ -82,6 +84,9 @@ status_t process_cmd(ujson_t *uj) {
         break;
       case kCryptotestCommandSphincsPlus:
         RESP_ERR(uj, handle_sphincsplus(uj));
+        break;
+      case kCryptotestCommandX25519:
+        RESP_ERR(uj, handle_x25519(uj));
         break;
       default:
         LOG_ERROR("Unrecognized command: %d", cmd);

--- a/sw/device/tests/crypto/cryptotest/firmware/x25519.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/x25519.c
@@ -1,0 +1,144 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/ecc_curve25519.h"
+#include "sw/device/lib/crypto/include/integrity.h"
+#include "sw/device/lib/crypto/include/key_transport.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/tests/crypto/cryptotest/json/x25519_commands.h"
+
+// Copied from internal headers to remove dependencies.
+// kOtcryptoKeyModeX25519 is typed as kOtcryptoKeyTypeEcc, so the keyblob
+// library appends 64 redundant bits per share (see keyblob.c). These extra
+// bytes are zero-padded and unused by the X25519 algorithm itself.
+enum {
+  kX25519PrivateKeyWords = X25519_CMD_PRIVATE_KEY_BYTES / sizeof(uint32_t),
+  kX25519MaskedScalarShareBytes = X25519_CMD_PRIVATE_KEY_BYTES + (64 / 8),
+  kX25519MaskedScalarShareWords =
+      kX25519MaskedScalarShareBytes / sizeof(uint32_t),
+  kX25519MaskedScalarTotalWords = 2 * kX25519MaskedScalarShareWords,
+  kX25519PublicKeyWords = X25519_CMD_PUBLIC_KEY_BYTES / sizeof(uint32_t),
+  kX25519SharedSecretWords = X25519_CMD_SHARED_SECRET_BYTES / sizeof(uint32_t),
+};
+
+static const otcrypto_key_config_t kX25519PrivateKeyConfig = {
+    .version = kOtcryptoLibVersion1,
+    .key_mode = kOtcryptoKeyModeX25519,
+    .key_length = X25519_CMD_PRIVATE_KEY_BYTES,
+    .hw_backed = kHardenedBoolFalse,
+    .exportable = kHardenedBoolFalse,
+    .security_level = kOtcryptoKeySecurityLevelLow,
+};
+
+status_t handle_x25519(ujson_t *uj) {
+  cryptotest_x25519_private_key_t uj_private_key;
+  cryptotest_x25519_public_key_t uj_public_key;
+
+  TRY(ujson_deserialize_cryptotest_x25519_private_key_t(uj, &uj_private_key));
+  TRY(ujson_deserialize_cryptotest_x25519_public_key_t(uj, &uj_public_key));
+
+  if (uj_private_key.private_key_len != X25519_CMD_PRIVATE_KEY_BYTES) {
+    LOG_ERROR("Invalid X25519 private key length (have = %d, want = %d bytes)",
+              (uint32_t)uj_private_key.private_key_len,
+              X25519_CMD_PRIVATE_KEY_BYTES);
+    return INVALID_ARGUMENT();
+  }
+  if (uj_public_key.public_key_len != X25519_CMD_PUBLIC_KEY_BYTES) {
+    LOG_ERROR("Invalid X25519 public key length (have = %d, want = %d bytes)",
+              (uint32_t)uj_public_key.public_key_len,
+              X25519_CMD_PUBLIC_KEY_BYTES);
+    return INVALID_ARGUMENT();
+  }
+
+  // Copy the raw private key into a word-aligned buffer.
+  uint32_t raw_key[kX25519PrivateKeyWords] = {0};
+  memcpy(raw_key, uj_private_key.private_key, X25519_CMD_PRIVATE_KEY_BYTES);
+
+  // Apply blinding on the device: generate a random share1, then compute
+  // share0 = raw_key - share1 (mod 2^256). The extra padding words per share
+  // (beyond kX25519PrivateKeyWords) remain zero-initialized.
+  uint32_t keyblob[kX25519MaskedScalarTotalWords] = {0};
+  uint32_t *share0 = keyblob;
+  uint32_t *share1 = keyblob + kX25519MaskedScalarShareWords;
+  HARDENED_TRY(hardened_memshred(share1, kX25519PrivateKeyWords));
+  HARDENED_TRY(hardened_sub(raw_key, share1, kX25519PrivateKeyWords, share0));
+
+  otcrypto_blinded_key_t private_key = {
+      .config = kX25519PrivateKeyConfig,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+  };
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
+
+  // Build the peer's unblinded public key from the raw u-coordinate bytes.
+  uint32_t public_key_buf[kX25519PublicKeyWords] = {0};
+  memcpy(public_key_buf, uj_public_key.public_key, X25519_CMD_PUBLIC_KEY_BYTES);
+  otcrypto_unblinded_key_t public_key = {
+      .key_mode = kOtcryptoKeyModeX25519,
+      .key_length = X25519_CMD_PUBLIC_KEY_BYTES,
+      .key = public_key_buf,
+  };
+  public_key.checksum = otcrypto_integrity_unblinded_checksum(&public_key);
+
+  // Allocate the blinded shared secret output (symmetric key, two XOR shares).
+  uint32_t shared_secretblob[kX25519SharedSecretWords * 2];
+  memset(shared_secretblob, 0, sizeof(shared_secretblob));
+  otcrypto_blinded_key_t shared_secret = {
+      .config =
+          {
+              .version = kOtcryptoLibVersion1,
+              .key_mode = kOtcryptoKeyModeAesCtr,
+              .key_length = X25519_CMD_SHARED_SECRET_BYTES,
+              .hw_backed = kHardenedBoolFalse,
+              .exportable = kHardenedBoolTrue,
+              .security_level = kOtcryptoKeySecurityLevelLow,
+          },
+      .keyblob_length = sizeof(shared_secretblob),
+      .keyblob = shared_secretblob,
+  };
+
+  cryptotest_x25519_derive_output_t uj_output;
+  memset(&uj_output, 0, sizeof(uj_output));
+  uj_output.shared_secret_len = X25519_CMD_SHARED_SECRET_BYTES;
+
+  otcrypto_status_t status =
+      otcrypto_x25519(&private_key, &public_key, &shared_secret);
+  switch (status.value) {
+    case kOtcryptoStatusValueOk:
+      uj_output.result = true;
+      break;
+    case kOtcryptoStatusValueBadArgs:
+      uj_output.result = false;
+      RESP_OK(ujson_serialize_cryptotest_x25519_derive_output_t, uj,
+              &uj_output);
+      return OK_STATUS();
+    default:
+      TRY(status);
+      break;
+  }
+
+  // Unmask the shared secret by XOR-ing the two output shares.
+  uint32_t dest_share0[kX25519SharedSecretWords];
+  uint32_t dest_share1[kX25519SharedSecretWords];
+  otcrypto_word32_buf_t share0_buf = OTCRYPTO_MAKE_BUF(
+      otcrypto_word32_buf_t, dest_share0, ARRAYSIZE(dest_share0));
+  otcrypto_word32_buf_t share1_buf = OTCRYPTO_MAKE_BUF(
+      otcrypto_word32_buf_t, dest_share1, ARRAYSIZE(dest_share1));
+  TRY(otcrypto_export_blinded_key(&shared_secret, &share0_buf, &share1_buf));
+
+  uint32_t unblinded_secret[kX25519SharedSecretWords];
+  TRY(hardened_add(dest_share0, dest_share1, kX25519SharedSecretWords,
+                   unblinded_secret));
+
+  memcpy(uj_output.shared_secret, unblinded_secret,
+         X25519_CMD_SHARED_SECRET_BYTES);
+
+  RESP_OK(ujson_serialize_cryptotest_x25519_derive_output_t, uj, &uj_output);
+  return OK_STATUS();
+}

--- a/sw/device/tests/crypto/cryptotest/firmware/x25519.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/x25519.h
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_X25519_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_X25519_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+status_t handle_x25519(ujson_t *uj);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_X25519_H_

--- a/sw/device/tests/crypto/cryptotest/json/BUILD
+++ b/sw/device/tests/crypto/cryptotest/json/BUILD
@@ -20,6 +20,7 @@ cc_library(
         ":hmac_commands",
         ":kmac_commands",
         ":rsa_commands",
+        ":x25519_commands",
         "//sw/device/lib/ujson",
     ],
 )
@@ -108,6 +109,14 @@ cc_library(
     name = "sphincsplus_commands",
     srcs = ["sphincsplus_commands.c"],
     hdrs = ["sphincsplus_commands.h"],
+    features = ["-coverage"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
+    name = "x25519_commands",
+    srcs = ["x25519_commands.c"],
+    hdrs = ["x25519_commands.h"],
     features = ["-coverage"],
     deps = ["//sw/device/lib/ujson"],
 )

--- a/sw/device/tests/crypto/cryptotest/json/commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/commands.h
@@ -23,7 +23,8 @@ extern "C" {
     value(_, Kmac) \
     value(_, Quit) \
     value(_, Rsa) \
-    value(_, SphincsPlus)
+    value(_, SphincsPlus) \
+    value(_, X25519)
 UJSON_SERDE_ENUM(CryptotestCommand, cryptotest_cmd_t, COMMAND);
 
 // clang-format on

--- a/sw/device/tests/crypto/cryptotest/json/x25519_commands.c
+++ b/sw/device/tests/crypto/cryptotest/json/x25519_commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "x25519_commands.h"

--- a/sw/device/tests/crypto/cryptotest/json/x25519_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/x25519_commands.h
@@ -1,0 +1,47 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_X25519_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_X25519_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// X25519 key and shared secret sizes (fixed by the algorithm).
+#define X25519_CMD_PRIVATE_KEY_BYTES 32
+#define X25519_CMD_PUBLIC_KEY_BYTES 32
+#define X25519_CMD_SHARED_SECRET_BYTES 32
+
+// clang-format off
+
+// Derive operation:
+// The host sends, in order:
+// - private_key (X25519_PRIVATE_KEY)  [raw scalar; blinding is applied on the device]
+// - public_key (X25519_PUBLIC_KEY)    [peer's u-coordinate]
+// The device responds with:
+// - output (X25519_DERIVE_OUTPUT)     [unblinded shared secret and result]
+
+#define X25519_PRIVATE_KEY(field, string) \
+    field(private_key, uint8_t, X25519_CMD_PRIVATE_KEY_BYTES) \
+    field(private_key_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestX25519PrivateKey, cryptotest_x25519_private_key_t, X25519_PRIVATE_KEY);
+
+#define X25519_PUBLIC_KEY(field, string) \
+    field(public_key, uint8_t, X25519_CMD_PUBLIC_KEY_BYTES) \
+    field(public_key_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestX25519PublicKey, cryptotest_x25519_public_key_t, X25519_PUBLIC_KEY);
+
+#define X25519_DERIVE_OUTPUT(field, string) \
+    field(result, bool) \
+    field(shared_secret, uint8_t, X25519_CMD_SHARED_SECRET_BYTES) \
+    field(shared_secret_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestX25519DeriveOutput, cryptotest_x25519_derive_output_t, X25519_DERIVE_OUTPUT);
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_X25519_COMMANDS_H_

--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -155,6 +155,24 @@ run_binary(
     tool = "//sw/host/cryptotest/testvectors/parsers:wycheproof_ed25519_parser",
 )
 
+run_binary(
+    name = "wycheproof_x25519_json",
+    srcs = [
+        "//sw/host/cryptotest/testvectors/data/schemas:x25519_schema.json",
+        "@wycheproof//testvectors_v1:x25519_test.json",
+    ],
+    outs = [":wycheproof_x25519.json"],
+    args = [
+        "--src",
+        "$(location @wycheproof//testvectors_v1:x25519_test.json)",
+        "--dst",
+        "$(location :wycheproof_x25519.json)",
+        "--schema",
+        "$(location //sw/host/cryptotest/testvectors/data/schemas:x25519_schema.json)",
+    ],
+    tool = "//sw/host/cryptotest/testvectors/parsers:wycheproof_x25519_parser",
+)
+
 # Number of tests per configuration (e.g. Verify P-256 SHA-256)
 ECDSA_RANDOM_COUNT = 128
 

--- a/sw/host/cryptotest/testvectors/data/schemas/BUILD
+++ b/sw/host/cryptotest/testvectors/data/schemas/BUILD
@@ -25,4 +25,5 @@ exports_files([
     "kmac_schema.json",
     "rsa_schema.json",
     "sphincsplus_schema.json",
+    "x25519_schema.json",
 ])

--- a/sw/host/cryptotest/testvectors/data/schemas/x25519_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/x25519_schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/lowRISC/opentitan/master/sw/host/cryptotest/testvectors/data/schemas/x25519_schema.json",
+  "title": "Cryptotest X25519 Key Derivation Test Vector",
+  "description": "A list of testvectors for X25519 Key Derivation testing",
+  "$defs": {
+    "byte_array": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    }
+  },
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "vendor": {
+        "description": "Test vector vendor name",
+        "type": "string"
+      },
+      "test_case_id": {
+        "description": "Test case ID from test vector source -- used for debugging",
+        "type": "integer"
+      },
+      "algorithm": {
+        "description": "Should be x25519",
+        "type": "string",
+        "enum": ["x25519"]
+      },
+      "operation": {
+        "description": "X25519 operation",
+        "type": "string",
+        "enum": ["derive"]
+      },
+      "private_key": {
+        "description": "Local private key scalar (32 bytes, little-endian), from Wycheproof 'private' field",
+        "$ref": "#/$defs/byte_array"
+      },
+      "public_key": {
+        "description": "Peer's public key u-coordinate (32 bytes, little-endian), from Wycheproof 'public' field",
+        "$ref": "#/$defs/byte_array"
+      },
+      "shared_secret": {
+        "description": "Expected shared secret u-coordinate (32 bytes, little-endian), from Wycheproof 'shared' field",
+        "$ref": "#/$defs/byte_array"
+      },
+      "result": {
+        "description": "Expected derivation result",
+        "type": "string",
+        "enum": ["valid"]
+      }
+    }
+  }
+}

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -216,3 +216,12 @@ py_binary(
         requirement("jsonschema"),
     ],
 )
+
+py_binary(
+    name = "wycheproof_x25519_parser",
+    srcs = ["wycheproof_x25519_parser.py"],
+    deps = [
+        ":cryptotest_util",
+        requirement("jsonschema"),
+    ],
+)

--- a/sw/host/cryptotest/testvectors/parsers/wycheproof_x25519_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/wycheproof_x25519_parser.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+import jsonschema
+import logging
+import sys
+
+
+def parse_test_vectors(raw_data):
+    test_groups = raw_data["testGroups"]
+    test_vectors = list()
+    for group in test_groups:
+        if group["curve"] != "curve25519":
+            logging.info(
+                f"Skipped test group: Unsupported curve type '{group['curve']}'"
+            )
+            continue
+
+        for test in group["tests"]:
+            logging.debug(f"Parsing tcId {test['tcId']}")
+
+            if test["result"] != "valid":
+                logging.info(
+                    f"Skipped tcId {test['tcId']}: result is '{test['result']}'"
+                )
+                continue
+
+            test_vec = {
+                "vendor": "wycheproof",
+                "test_case_id": test["tcId"],
+                "algorithm": "x25519",
+                "operation": "derive",
+                "private_key": list(bytes.fromhex(test["private"])),
+                "public_key": list(bytes.fromhex(test["public"])),
+                "shared_secret": list(bytes.fromhex(test["shared"])),
+                "result": "valid",
+            }
+            test_vectors.append(test_vec)
+
+    return test_vectors
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--src",
+        metavar="FILE",
+        type=argparse.FileType("r"),
+        help="Test vector input file to parse"
+    )
+    parser.add_argument(
+        "--dst",
+        metavar="FILE",
+        type=argparse.FileType("w"),
+        help="File to write parsed JSON test cases"
+    )
+    parser.add_argument(
+        "--schema",
+        type=str,
+        help="Test vector schema file"
+    )
+    args = parser.parse_args()
+
+    testvecs = parse_test_vectors(json.load(args.src))
+    args.src.close()
+
+    # Validate generated JSON
+    with open(args.schema) as schema_file:
+        schema = json.load(schema_file)
+    jsonschema.validate(testvecs, schema)
+
+    logging.info(f"Created {len(testvecs)} tests")
+    json.dump(testvecs, args.dst)
+    args.dst.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sw/host/cryptotest/ujson_lib/BUILD
+++ b/sw/host/cryptotest/ujson_lib/BUILD
@@ -67,6 +67,11 @@ ujson_rust(
     srcs = ["//sw/device/tests/crypto/cryptotest/json:sphincsplus_commands"],
 )
 
+ujson_rust(
+    name = "x25519_commands_rust",
+    srcs = ["//sw/device/tests/crypto/cryptotest/json:x25519_commands"],
+)
+
 rust_library(
     name = "cryptotest_commands",
     srcs = [
@@ -83,6 +88,7 @@ rust_library(
         "src/lib.rs",
         "src/rsa_commands.rs",
         "src/sphincsplus_commands.rs",
+        "src/x25519_commands.rs",
     ],
     compile_data = [
         ":commands_rust",
@@ -97,6 +103,7 @@ rust_library(
         ":kmac_commands_rust",
         ":rsa_commands_rust",
         ":sphincsplus_commands_rust",
+        ":x25519_commands_rust",
     ],
     rustc_env = {
         "commands_loc": "$(execpath :commands_rust)",
@@ -111,6 +118,7 @@ rust_library(
         "kmac_commands_loc": "$(execpath :kmac_commands_rust)",
         "rsa_commands_loc": "$(execpath :rsa_commands_rust)",
         "sphincsplus_commands_loc": "$(execpath :sphincsplus_commands_rust)",
+        "x25519_commands_loc": "$(execpath :x25519_commands_rust)",
     },
     deps = [
         "//sw/host/opentitanlib",

--- a/sw/host/cryptotest/ujson_lib/src/lib.rs
+++ b/sw/host/cryptotest/ujson_lib/src/lib.rs
@@ -13,3 +13,4 @@ pub mod hmac_commands;
 pub mod kmac_commands;
 pub mod rsa_commands;
 pub mod sphincsplus_commands;
+pub mod x25519_commands;

--- a/sw/host/cryptotest/ujson_lib/src/x25519_commands.rs
+++ b/sw/host/cryptotest/ujson_lib/src/x25519_commands.rs
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+include!(env!("x25519_commands_loc"));

--- a/sw/host/tests/crypto/x25519_kat/BUILD
+++ b/sw/host/tests/crypto/x25519_kat/BUILD
@@ -1,0 +1,25 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "harness",
+    srcs = ["src/main.rs"],
+    deps = [
+        "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/crypto/x25519_kat/src/main.rs
+++ b/sw/host/tests/crypto/x25519_kat/src/main.rs
@@ -1,0 +1,209 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use arrayvec::ArrayVec;
+use clap::Parser;
+use serde::Deserialize;
+use std::cmp::min;
+use std::fs;
+use std::time::Duration;
+
+use cryptotest_commands::commands::CryptotestCommand;
+use cryptotest_commands::x25519_commands::{
+    CryptotestX25519DeriveOutput, CryptotestX25519PrivateKey, CryptotestX25519PublicKey,
+};
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::console::spi::SpiConsoleDevice;
+use opentitanlib::execute_test;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
+use opentitanlib::uart::console::UartConsole;
+use rand::RngCore;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    // Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+
+    // Reduce number of tests that are run by this factor.
+    // 1 out of skip_stride tests are run. The ID of the first test to run is
+    // (pseudo-)randomly chosen between 0 and skip_stride.
+    // If skip_stride is set to 0, all tests are run.
+    #[arg(long, default_value_t = 0usize)]
+    skip_stride: usize,
+
+    // Seed value for random number generator.
+    #[arg(long)]
+    seed: Option<u64>,
+
+    #[arg(long, num_args = 1..)]
+    x25519_json: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct X25519TestCase {
+    vendor: String,
+    test_case_id: usize,
+    algorithm: String,
+    private_key: Vec<u8>,
+    public_key: Vec<u8>,
+    shared_secret: Vec<u8>,
+}
+
+// Fixed sizes defined by the X25519 algorithm (RFC 7748).
+const X25519_PRIVATE_KEY_BYTES: usize = 32;
+const X25519_PUBLIC_KEY_BYTES: usize = 32;
+const X25519_SHARED_SECRET_BYTES: usize = 32;
+
+fn run_x25519_testcase(
+    test_case: &X25519TestCase,
+    opts: &Opts,
+    spi_console: &SpiConsoleDevice,
+    failures: &mut Vec<String>,
+    test_counter: usize,
+) -> Result<()> {
+    log::info!(
+        "vendor: {}, test case: {}",
+        test_case.vendor,
+        test_case.test_case_id
+    );
+    assert_eq!(test_case.algorithm.as_str(), "x25519");
+    assert_eq!(
+        test_case.private_key.len(),
+        X25519_PRIVATE_KEY_BYTES,
+        "X25519 private key must be exactly {} bytes (got {})",
+        X25519_PRIVATE_KEY_BYTES,
+        test_case.private_key.len(),
+    );
+    assert_eq!(
+        test_case.public_key.len(),
+        X25519_PUBLIC_KEY_BYTES,
+        "X25519 public key must be exactly {} bytes (got {})",
+        X25519_PUBLIC_KEY_BYTES,
+        test_case.public_key.len(),
+    );
+
+    // X25519 keys and shared secrets are in RFC 7748 little-endian byte order;
+    // the test vectors are already in this format so no reversal is needed.
+    CryptotestCommand::X25519.send(spi_console)?;
+
+    CryptotestX25519PrivateKey {
+        private_key: ArrayVec::try_from(test_case.private_key.as_slice())
+            .expect("X25519 private key had unexpected length."),
+        private_key_len: test_case.private_key.len(),
+    }
+    .send(spi_console)?;
+
+    CryptotestX25519PublicKey {
+        public_key: ArrayVec::try_from(test_case.public_key.as_slice())
+            .expect("X25519 public key had unexpected length."),
+        public_key_len: test_case.public_key.len(),
+    }
+    .send(spi_console)?;
+
+    let output = CryptotestX25519DeriveOutput::recv(spi_console, opts.timeout, false, false)?;
+
+    if output.shared_secret_len > X25519_SHARED_SECRET_BYTES {
+        panic!(
+            "X25519 returned shared secret length {} exceeds maximum {}.",
+            output.shared_secret_len, X25519_SHARED_SECRET_BYTES
+        );
+    }
+
+    let device_secret = &output.shared_secret[..output.shared_secret_len];
+
+    let success = output.result && device_secret == test_case.shared_secret.as_slice();
+
+    if !success {
+        log::info!(
+            "FAILED test #{}: device result = {}, device secret = {:02x?}",
+            test_case.test_case_id,
+            output.result,
+            device_secret,
+        );
+        failures.push(format!("x25519 #{}", test_counter));
+    }
+    Ok(())
+}
+
+fn test_x25519(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let spi = transport.spi("BOOTSTRAP")?;
+    let spi_console_device = SpiConsoleDevice::new(
+        &*spi,
+        None,
+        /*ignore_frame_num=*/ false,
+        Some(opts.init.backend_opts.interface.as_str()),
+    )?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
+
+    let seed = opts.seed.unwrap_or_else(rand::random::<u64>);
+    log::info!("Using seed {}", seed);
+
+    let mut drng = ChaCha8Rng::seed_from_u64(seed);
+    let (skip_stride, start_offset) = match (drng.next_u32() as usize).checked_rem(opts.skip_stride)
+    {
+        Some(offset) => (opts.skip_stride, offset),
+        // If skip_stride is 0, run all tests.
+        None => (1usize, 0usize),
+    };
+
+    let mut test_counter = 0usize;
+    let mut failures = vec![];
+    let test_vector_files = &opts.x25519_json;
+    for file in test_vector_files {
+        let raw_json = fs::read_to_string(file)?;
+        let x25519_tests: Vec<X25519TestCase> = serde_json::from_str(&raw_json)?;
+
+        // Ensure that at least one test per JSON file is run.
+        let stride = min(skip_stride, x25519_tests.len());
+        let offset = start_offset % stride;
+        log::info!("Tests options: skip_stride: {}, offset: {}", stride, offset);
+
+        for (i, x25519_test) in x25519_tests.iter().enumerate() {
+            test_counter += 1;
+
+            if (i % stride) != offset {
+                // Skip test.
+                continue;
+            }
+
+            log::info!("Test counter: {}", test_counter);
+            run_x25519_testcase(
+                x25519_test,
+                opts,
+                &spi_console_device,
+                &mut failures,
+                test_counter,
+            )?;
+        }
+    }
+    CryptotestCommand::Quit.send(&spi_console_device)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"PASS!|FAIL!", opts.timeout * 10)?;
+    assert_eq!(
+        0,
+        failures.len(),
+        "Failed {} out of {} tests. Failures: {:?}",
+        failures.len(),
+        test_counter,
+        failures
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    let transport = opts.init.init_target()?;
+    execute_test!(test_x25519, &opts, &transport);
+    Ok(())
+}


### PR DESCRIPTION
This PR enables us to test our X25519 implementiation using the Wycheproof test vectors. Please note that those test vectors are either marked as `valid` or `acceptable`. Currently, we only test `valid` test vectors.