### PR TITLE
[cov,ci] Ensure all generated sources are available for coverage

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -51,6 +51,9 @@ build:ot_coverage --experimental_use_llvm_covmap
 build:ot_coverage --experimental_generate_llvm_lcov
 build:ot_coverage --combined_report=lcov
 
+# Aspect to collect all source files into the coverage_sources output group.
+build:ot_coverage --aspects=rules/coverage/info.bzl%coverage_sources_aspect
+
 # Set coverage mode indicators
 build:ot_coverage --define='ot_coverage_enabled=true'
 build:ot_coverage --@rules_rust//:extra_rustc_flag='--cfg=feature="ot_coverage_enabled"'

--- a/.github/workflows/coverage-quick.yml
+++ b/.github/workflows/coverage-quick.yml
@@ -76,14 +76,18 @@ jobs:
             >> "$target_pattern_file"
       - name: Run software unit tests coverage
         run: |
-          ./bazelisk.sh coverage                             \
-            --build_tests_only                               \
-            --keep_going                                     \
-            --config=ot_coverage                             \
-            --test_output=errors                             \
-            --define DISABLE_VERILATOR_BUILD=true            \
-            --target_pattern_file="$target_pattern_file"     \
+          ARGS=(
+            --build_tests_only
+            --keep_going
+            --config=ot_coverage
+            --test_output=errors
+            --define DISABLE_VERILATOR_BUILD=true
+            --target_pattern_file="$target_pattern_file"
             --test_tag_filters=-broken,-coverage_broken,-cw310,-verilator,-dv,-silicon,-qemu
+          )
+          ./bazelisk.sh coverage "${ARGS[@]}"
+          # Ensure all generated sources are available.
+          ./bazelisk.sh build "${ARGS[@]}" --output_groups=coverage_sources
       - name: Publish Bazel test results
         uses: ./.github/actions/publish-bazel-test-results
         if: ${{ !cancelled() }}

--- a/ci/scripts/run-fpga-tests.sh
+++ b/ci/scripts/run-fpga-tests.sh
@@ -87,3 +87,8 @@ if [[ "${mode}" == "coverage" ]]; then
 fi
 
 ./bazelisk.sh "${mode}" "${TEST_ARGS[@]}"
+
+# Ensure all generated sources are available.
+if [[ "${mode}" == "coverage" ]]; then
+  ./bazelisk.sh build "${ARGS[@]}" --output_groups=coverage_sources
+fi

--- a/rules/coverage/info.bzl
+++ b/rules/coverage/info.bzl
@@ -23,3 +23,43 @@ def create_cc_instrumented_files_info(ctx, metadata_files):
         metadata_files = metadata_files,
     )
     return info
+
+def _coverage_sources_aspect_impl(target, ctx):
+    """Collects source files for coverage analysis.
+
+    This aspect traverses the dependency graph to gather all files necessary for
+    coverage reporting. This specific output group can be explicitly requested
+    to ensure that the generated source files are available for analysis.
+
+    ```
+    bazel build \
+      --output_groups=coverage_sources \
+      --aspects=rules/coverage/info.bzl%coverage_sources_aspect \
+      <targets...>
+    ```
+
+    Returns:
+        An OutputGroupInfo provider containing the `coverage_sources` group.
+    """
+
+    sources = []
+
+    if InstrumentedFilesInfo in target:
+        info = target[InstrumentedFilesInfo]
+        sources.append(info.metadata_files)
+        sources.append(info.instrumented_files)
+
+    if OutputGroupInfo in target:
+        info = target[OutputGroupInfo]
+        if "coverage_sources" in info:
+            sources.append(info.coverage_sources)
+
+    return [
+        OutputGroupInfo(
+            coverage_sources = depset(transitive = sources),
+        ),
+    ]
+
+coverage_sources_aspect = aspect(
+    implementation = _coverage_sources_aspect_impl,
+)


### PR DESCRIPTION
This PR fixes missing generated files for coverage report generation due to remote-cache.

By default, bazel only downloads the artifacts of top-level targets (i.e. targets specified in cmdline) from the remote cache, including test result / compiled libs... These artifacts does not include generated sources used to during compilation in the dependencies.

However, coverage report generation is executed outside of bazel environment, which requires the source code to be present locally.

This PR solves this issue by collecting all sources into the `coverage_sources` output group, and request those files explicitly in CI before generating reports.

---

Note: `bazel coverage` also accepts `--output-groups` flag, but it won't download the files. We need to use `bazel build` to fetch from remote cache.

TEST: The tests in "CI / Coverage (quick) / Unit Tests (pull_request)" job are all cached, while its artifact contains generated sources correctly.