### PR TITLE
[ci] Migrate airgapped build to GCP runners using unshare

### DIFF
--- a/ci/scripts/test-airgapped-build.sh
+++ b/ci/scripts/test-airgapped-build.sh
@@ -14,19 +14,14 @@ fi
 # Clean out bazel cache so no remnants exist for test.
 "${PWD}/bazel-airgapped/bazel" clean --expunge
 
-# Remove the airgapped network namespace.
-remove_airgapped_netns() {
-  sudo ip netns delete airgapped
-}
-trap remove_airgapped_netns EXIT
+# Use unshare to create an ephemeral, unprivileged user and network namespace.
+# --map-root-user allows us to bring up the loopback interface without host CAP_NET_ADMIN capabilities.
+unshare --user --net --map-root-user bash -c '
+  # Set up access to loopback.
+  ip addr add 127.0.0.1/8 dev lo
+  ip link set dev lo up
 
-# Set up a network namespace named "airgapped" with access to loopback.
-sudo ip netns add airgapped
-sudo ip netns exec airgapped ip addr add 127.0.0.1/8 dev lo
-sudo ip netns exec airgapped ip link set dev lo up
-
-# Enter the network namespace and perform several builds.
-sudo ip netns exec airgapped sudo -u "$USER" \
+  # Perform the airgapped builds.
   env \
     BAZEL_BITSTREAMS_CACHE="${PWD}/bazel-airgapped/bitstreams-cache" \
     OT_AIRGAPPED="true"                                              \
@@ -36,5 +31,6 @@ sudo ip netns exec airgapped sudo -u "$USER" \
     --vendor_dir="${PWD}/bazel-airgapped/bazel-vendor"               \
     --define DISABLE_VERILATOR_BUILD=true                            \
     //sw/device/silicon_creator/rom:mask_rom
+'
 
 exit 0


### PR DESCRIPTION
## Summary
This PR addresses the disk space and network namespace issues described in #19512 by migrating the `airgapped_build` job from Azure to GCP runners.

## Technical Details
GCP containerized runners drop `CAP_NET_ADMIN`, causing `sudo ip netns` commands to fail. Instead of relying on Docker, this fix uses `unshare --user --net --map-root-user` to create an unprivileged user and network namespace. This allows the script to bring up the loopback interface (`lo`) and execute the Bazel build with network isolation intact, without requiring root capabilities on the host runner.

Local testing confirms the `unshare` namespace successfully blocks network access (yielding the expected 'Unknown Host' errors when the offline cache is missing dependencies).

Fixes #19512