### PR TITLE
[crypto] Throw error for X25519 points on quadratic twist

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc/curve25519.c
@@ -45,6 +45,8 @@ OTBN_DECLARE_SYMBOL_ADDR(run_curve25519,
                          x25519_public_key);  // X25519 public key.
 OTBN_DECLARE_SYMBOL_ADDR(run_curve25519,
                          x25519_shared_key);  // X25519 shared key.
+OTBN_DECLARE_SYMBOL_ADDR(run_curve25519,
+                         x25519_ok);  // X25519 result status.
 
 // Declare mode constants.
 OTBN_DECLARE_SYMBOL_ADDR(run_curve25519, MODE_KEYGEN);
@@ -361,6 +363,17 @@ status_t curve25519_x25519_finalize(
     uint32_t shared_secret[kCurve25519PointWords]) {
   // Spin here waiting for OTBN to complete.
   HARDENED_TRY(otbn_busy_wait_for_done());
+
+  // Check whether OTBN accepted the public key (rejects twist points).
+  uint32_t ok;
+  const otbn_addr_t kOtbnVarX25519Ok =
+      OTBN_ADDR_T_INIT(run_curve25519, x25519_ok);
+  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarX25519Ok, &ok));
+  if (launder32(ok) != kHardenedBoolTrue) {
+    HARDENED_TRY(otbn_dmem_sec_wipe());
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(ok, kHardenedBoolTrue);
 
   // Read the shared secret from OTBN dmem.
   const otbn_addr_t kOtbnVarX25519SharedKey =

--- a/sw/device/lib/crypto/impl/ecc_curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc_curve25519.c
@@ -803,7 +803,7 @@ otcrypto_status_t otcrypto_x25519_async_finalize(
     otcrypto_blinded_key_t *shared_secret) {
   uint32_t unmasked_secret[kCurve25519PointWords];
   memset(unmasked_secret, 0, sizeof(unmasked_secret));
-  HARDENED_TRY_WIPE_DMEM(curve25519_x25519_finalize(unmasked_secret));
+  HARDENED_TRY(curve25519_x25519_finalize(unmasked_secret));
 
   uint32_t *share0 = shared_secret->keyblob;
   uint32_t *share1 =

--- a/sw/device/lib/crypto/impl/ecc_curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc_curve25519.c
@@ -802,6 +802,7 @@ otcrypto_status_t otcrypto_x25519_async_start(
 otcrypto_status_t otcrypto_x25519_async_finalize(
     otcrypto_blinded_key_t *shared_secret) {
   uint32_t unmasked_secret[kCurve25519PointWords];
+  memset(unmasked_secret, 0, sizeof(unmasked_secret));
   HARDENED_TRY_WIPE_DMEM(curve25519_x25519_finalize(unmasked_secret));
 
   uint32_t *share0 = shared_secret->keyblob;

--- a/sw/host/cryptotest/testvectors/data/schemas/x25519_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/x25519_schema.json
@@ -52,7 +52,7 @@
       "result": {
         "description": "Expected derivation result",
         "type": "string",
-        "enum": ["valid"]
+        "enum": ["valid", "invalid"]
       }
     }
   }

--- a/sw/host/cryptotest/testvectors/parsers/wycheproof_x25519_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/wycheproof_x25519_parser.py
@@ -9,6 +9,26 @@ import jsonschema
 import logging
 import sys
 
+# Curve25519 field prime and Montgomery curve constant A.
+_P = 2**255 - 19
+_A = 486662
+
+
+def _is_twist_point(public_key_hex):
+    """Returns True if the u-coordinate is on the quadratic twist of Curve25519.
+
+    A u-coordinate is on the twist when u^3 + A*u^2 + u is a non-residue mod p,
+    i.e. its Legendre symbol equals -1.  OpenTitan's X25519 implementation
+    rejects such points, so they must be treated as invalid test vectors.
+    """
+    u = int.from_bytes(bytes.fromhex(public_key_hex), 'little')
+    u = u & ((1 << 255) - 1)  # clear bit 255, matching OTBN's bn.and mask step
+    u = u % _P                 # reduce mod p, matching OTBN's bn.addm step
+    rhs = (pow(u, 3, _P) + _A * pow(u, 2, _P) + u) % _P
+    if rhs == 0:
+        return False
+    return pow(rhs, (_P - 1) // 2, _P) == _P - 1
+
 
 def parse_test_vectors(raw_data):
     test_groups = raw_data["testGroups"]
@@ -29,6 +49,14 @@ def parse_test_vectors(raw_data):
                 )
                 continue
 
+            result = "valid"
+            if _is_twist_point(test["public"]):
+                logging.info(
+                    f"tcId {test['tcId']}: overriding result to invalid "
+                    f"(public key is on the quadratic twist, rejected by OpenTitan)"
+                )
+                result = "invalid"
+
             test_vec = {
                 "vendor": "wycheproof",
                 "test_case_id": test["tcId"],
@@ -37,7 +65,7 @@ def parse_test_vectors(raw_data):
                 "private_key": list(bytes.fromhex(test["private"])),
                 "public_key": list(bytes.fromhex(test["public"])),
                 "shared_secret": list(bytes.fromhex(test["shared"])),
-                "result": "valid",
+                "result": result,
             }
             test_vectors.append(test_vec)
 

--- a/sw/host/cryptotest/testvectors/parsers/wycheproof_x25519_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/wycheproof_x25519_parser.py
@@ -43,12 +43,6 @@ def parse_test_vectors(raw_data):
         for test in group["tests"]:
             logging.debug(f"Parsing tcId {test['tcId']}")
 
-            if test["result"] != "valid":
-                logging.info(
-                    f"Skipped tcId {test['tcId']}: result is '{test['result']}'"
-                )
-                continue
-
             result = "valid"
             if _is_twist_point(test["public"]):
                 logging.info(

--- a/sw/host/tests/crypto/x25519_kat/src/main.rs
+++ b/sw/host/tests/crypto/x25519_kat/src/main.rs
@@ -49,6 +49,13 @@ struct Opts {
     x25519_json: Vec<String>,
 }
 
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+enum X25519Result {
+    Valid,
+    Invalid,
+}
+
 #[derive(Debug, Deserialize)]
 struct X25519TestCase {
     vendor: String,
@@ -57,6 +64,7 @@ struct X25519TestCase {
     private_key: Vec<u8>,
     public_key: Vec<u8>,
     shared_secret: Vec<u8>,
+    result: X25519Result,
 }
 
 // Fixed sizes defined by the X25519 algorithm (RFC 7748).
@@ -121,12 +129,16 @@ fn run_x25519_testcase(
 
     let device_secret = &output.shared_secret[..output.shared_secret_len];
 
-    let success = output.result && device_secret == test_case.shared_secret.as_slice();
+    let success = match test_case.result {
+        X25519Result::Valid => output.result && device_secret == test_case.shared_secret.as_slice(),
+        X25519Result::Invalid => !output.result,
+    };
 
     if !success {
         log::info!(
-            "FAILED test #{}: device result = {}, device secret = {:02x?}",
+            "FAILED test #{}: expected = {:?}, device result = {}, device secret = {:02x?}",
             test_case.test_case_id,
+            test_case.result,
             output.result,
             device_secret,
         );

--- a/sw/otbn/crypto/25519.s
+++ b/sw/otbn/crypto/25519.s
@@ -1939,6 +1939,28 @@ trigger_fault_if_fg0_not_z:
   ret
 
 /**
+ * Check that the X25519 public key u is valid for the Montgomery-to-Edwards map.
+ *
+ * The Montgomery-to-Edwards conversion y = (u-1)/(u+1) has a zero denominator
+ * at u = p-1. fe_inv(0) = 0, so the conversion silently produces y = 0,
+ * which decodes as a valid Edwards point and bypasses the twist check.
+ *
+ * @param[in]  w9:  Montgomery u-coordinate (reduced mod p, MSB cleared)
+ * @param[in]  w31: all-zero
+ * @param[out] x2:  0 if u is acceptable, non-zero if u = p-1
+ *
+ * clobbered registers: x2, w10
+ * clobbered flag groups: FG0
+ */
+x25519_check_denominator:
+  bn.addi  w10, w31, 1
+  bn.addm  w10, w9, w10
+  bn.cmp   w10, w31
+  csrrs    x2, FG0, x0
+  andi     x2, x2, 8
+  ret
+
+/**
  * Convert Montgomery u-coordinate to Twisted Edwards y-coordinate.
  * Formula: y = (u - 1) * (u + 1)^-1 mod p
  *
@@ -2024,6 +2046,10 @@ X25519:
   bn.rshi  w7, w31, w7 >> 1
   bn.and   w9, w9, w7
   bn.addm  w9, w9, w31
+
+  /* Reject u = p-1 before the Montgomery-to-Edwards conversion. */
+  jal      x1, x25519_check_denominator
+  bne      x2, x0, .L_x25519_fail
 
   /* Convert Montgomery u to Edwards y */
   jal      x1, x25519_mont_u_to_ed_y

--- a/sw/otbn/crypto/25519.s
+++ b/sw/otbn/crypto/25519.s
@@ -2004,8 +2004,10 @@ x25519_ed_y_to_mont_u:
  * @param[in]  w8: scalar (private key, already clamped by host CPU)
  * @param[in]  w9: Montgomery u-coordinate (public key or base point 9)
  * @param[out] w22: result, X25519(k, u) as an encoded u-coordinate
+ * @param[out] x20: SUCCESS if the public key decoding passed,
+ *                  FAILURE if the public key decoding failed
  *
- * clobbered registers: x2, x3, x20, x21, w2, w6 to w30
+ * clobbered registers: x2, x3, x21, w2, w6 to w30
  * clobbered flag groups: FG0
  */
 X25519:
@@ -2058,11 +2060,14 @@ X25519:
   /* Convert Edwards y back to Montgomery u */
   jal      x1, x25519_ed_y_to_mont_u
 
+  /* Signal success to caller via x20. */
+  li       x20, 0x739
   ret
 
 .L_x25519_fail:
-  /* If point decoding fails, return 0 in w22 */
+  /* If point decoding fails, return 0 in w22 and signal failure via x20. */
   bn.xor   w22, w22, w22
+  li       x20, 0x1d4
   ret
 
 .bss

--- a/sw/otbn/crypto/25519.s
+++ b/sw/otbn/crypto/25519.s
@@ -2059,10 +2059,12 @@ X25519:
   la       x3, ed25519_d
   bn.lid   x2, 0(x3)
 
-  /* Decode x coordinate using the curve equation. */
+  /* Decode x coordinate and verify the point lies on the Ed25519 curve.
+     Points on the quadratic twist of Curve25519 do not map to valid Ed25519
+     points, so affine_decode_var will fail for them. */
   jal      x1, affine_decode_var
 
-  /* Check for failure (e.g., if the point is on the quadratic twist). */
+  /* Fail if the point was not on the Ed25519 curve (e.g. twist point). */
   li       x21, 0x739
   bne      x20, x21, .L_x25519_fail
 

--- a/sw/otbn/crypto/run_curve25519.s
+++ b/sw/otbn/crypto/run_curve25519.s
@@ -191,6 +191,10 @@ x25519:
   /* Call Edwards-mapped X25519 */
   jal      x1, X25519
 
+  /* Store result status (SUCCESS or FAILURE) from x20. */
+  la       x3, x25519_ok
+  sw       x20, 0(x3)
+
   /* Store shared key from w22 */
   li       x2, 22
   la       x3, x25519_shared_key
@@ -239,6 +243,10 @@ x25519_sideload:
   bn.lid x2, 0(x3)
 
   jal x1, X25519
+
+  /* Store result status (SUCCESS or FAILURE) from x20. */
+  la       x3, x25519_ok
+  sw       x20, 0(x3)
 
   /* Store shared key from w22 */
   li x2, 22
@@ -338,6 +346,12 @@ ed25519_r0:
 .globl ed25519_r1
 ed25519_r1:
   .zero 96
+
+/* X25519 result status (SUCCESS=0x739 or FAILURE=0x1d4). Output for x25519. */
+.balign 4
+.globl x25519_ok
+x25519_ok:
+  .zero 4
 
 /* X25519 public key */
 .balign 32


### PR DESCRIPTION
Previously, we detected if a point is on the quadratic twist and simply put the output to all 0. Instead, we should flag this to the cryptolib C code and handle it there.