### PR TITLE
[pentest] FI hardening

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/fi/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/fi/BUILD
@@ -104,6 +104,8 @@ cc_library(
         "//sw/device/lib/testing/test_framework:ujson_ottf",
         "//sw/device/tests/penetrationtests/firmware/lib:pentest_lib",
         "//sw/device/tests/penetrationtests/json:cryptolib_fi_asym_commands",
+        # Specifically load the HARDENED_TRY
+        "//sw/device/lib/crypto/impl:status",
     ] + select({
         # This is the target for the cryptolib given as a prebuilt drop
         "//sw/device/tests/penetrationtests/cryptolib_drop:use_prebuilt_cryptolib": [
@@ -131,6 +133,8 @@ cc_library(
         "//sw/device/lib/testing/test_framework:ujson_ottf",
         "//sw/device/tests/penetrationtests/firmware/lib:pentest_lib",
         "//sw/device/tests/penetrationtests/json:cryptolib_fi_sym_commands",
+        # Specifically load the HARDENED_TRY
+        "//sw/device/lib/crypto/impl:status",
     ] + select({
         # This is the target for the cryptolib given as a prebuilt drop
         "//sw/device/tests/penetrationtests/cryptolib_drop:use_prebuilt_cryptolib": [

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym.c
@@ -45,8 +45,15 @@ status_t handle_cryptolib_fi_asym_rsa_enc(ujson_t *uj) {
 
   cryptolib_fi_asym_rsa_enc_out_t uj_output;
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status =
       (size_t)cryptolib_fi_rsa_enc_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
   // Get registered local alerts from alert handler.
@@ -90,8 +97,15 @@ status_t handle_cryptolib_fi_asym_rsa_sign(ujson_t *uj) {
 
   cryptolib_fi_asym_rsa_sign_out_t uj_output;
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status =
       (size_t)cryptolib_fi_rsa_sign_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
   // Get registered local alerts from alert handler.
@@ -134,8 +148,15 @@ status_t handle_cryptolib_fi_asym_rsa_verify(ujson_t *uj) {
 
   cryptolib_fi_asym_rsa_verify_out_t uj_output;
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status =
       (size_t)cryptolib_fi_rsa_verify_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
   // Get registered local alerts from alert handler.
@@ -180,8 +201,15 @@ status_t handle_cryptolib_fi_asym_p256_base_mul(ujson_t *uj) {
   memset(&uj_output, 0, sizeof(uj_output));
 
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status =
       (size_t)cryptolib_fi_p256_base_mul_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -271,8 +299,15 @@ status_t handle_cryptolib_fi_asym_p256_ecdh(ujson_t *uj) {
 
   cryptolib_fi_asym_p256_ecdh_out_t uj_output;
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status =
       (size_t)cryptolib_fi_p256_ecdh_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -316,8 +351,15 @@ status_t handle_cryptolib_fi_asym_p256_sign(ujson_t *uj) {
 
   cryptolib_fi_asym_p256_sign_out_t uj_output;
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status =
       (size_t)cryptolib_fi_p256_sign_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -361,8 +403,15 @@ status_t handle_cryptolib_fi_asym_p256_verify(ujson_t *uj) {
 
   cryptolib_fi_asym_p256_verify_out_t uj_output;
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status =
       (size_t)cryptolib_fi_p256_verify_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -408,8 +457,15 @@ status_t handle_cryptolib_fi_asym_p384_base_mul(ujson_t *uj) {
   memset(&uj_output, 0, sizeof(uj_output));
 
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status =
       (size_t)cryptolib_fi_p384_base_mul_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -499,8 +555,15 @@ status_t handle_cryptolib_fi_asym_p384_ecdh(ujson_t *uj) {
 
   cryptolib_fi_asym_p384_ecdh_out_t uj_output;
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status =
       (size_t)cryptolib_fi_p384_ecdh_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -544,8 +607,15 @@ status_t handle_cryptolib_fi_asym_p384_sign(ujson_t *uj) {
 
   cryptolib_fi_asym_p384_sign_out_t uj_output;
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status =
       (size_t)cryptolib_fi_p384_sign_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -589,8 +659,15 @@ status_t handle_cryptolib_fi_asym_p384_verify(ujson_t *uj) {
 
   cryptolib_fi_asym_p384_verify_out_t uj_output;
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status =
       (size_t)cryptolib_fi_p384_verify_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -859,8 +936,15 @@ status_t handle_cryptolib_fi_asym_x25519_base_mul(ujson_t *uj) {
   cryptolib_fi_asym_x25519_base_mul_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status =
       (size_t)cryptolib_fi_x25519_base_mul_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -907,8 +991,15 @@ status_t handle_cryptolib_fi_asym_x25519_point_mul(ujson_t *uj) {
   cryptolib_fi_asym_x25519_point_mul_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status =
       (size_t)cryptolib_fi_x25519_point_mul_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -954,8 +1045,15 @@ status_t handle_cryptolib_fi_asym_x25519_ecdh(ujson_t *uj) {
   cryptolib_fi_asym_x25519_ecdh_out_t uj_output;
   memset(&uj_output, 0, sizeof(uj_output));
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status =
       (size_t)cryptolib_fi_x25519_ecdh_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -1043,8 +1141,15 @@ status_t handle_cryptolib_fi_asym_ed25519_sign(ujson_t *uj) {
 
   cryptolib_fi_asym_ed25519_sign_out_t uj_output;
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status =
       (size_t)cryptolib_fi_ed25519_sign_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -1088,8 +1193,15 @@ status_t handle_cryptolib_fi_asym_ed25519_verify(ujson_t *uj) {
 
   cryptolib_fi_asym_ed25519_verify_out_t uj_output;
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status =
       (size_t)cryptolib_fi_ed25519_verify_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
@@ -1506,21 +1506,83 @@ status_t cryptolib_fi_x25519_ecdh_impl(
 status_t cryptolib_fi_x25519_point_mul_impl(
     cryptolib_fi_asym_x25519_point_mul_in_t uj_input,
     cryptolib_fi_asym_x25519_point_mul_out_t *uj_output) {
-  // Point multiplication in X25519 is equivalent to ECDH
-  // where Bob's scalar is used as the base point.
-  cryptolib_fi_asym_x25519_ecdh_in_t ecdh_in;
-  memcpy(ecdh_in.private_key, uj_input.scalar_alice, X25519_CMD_BYTES);
-  memcpy(ecdh_in.public_x, uj_input.scalar_bob, X25519_CMD_BYTES);
-  memset(ecdh_in.public_y, 0, X25519_CMD_BYTES);  // Ignored
-  ecdh_in.cfg = uj_input.cfg;
-  ecdh_in.trigger = uj_input.trigger;
+  // Use the Ed25519 masked size since both use the exact same 256-bit curve
+  uint32_t private_keyblob[kPentestEd25519MaskedPrivateKeyWords * 2];
+  memset(private_keyblob, 0, sizeof(private_keyblob));
+  // Alice's scalar acts as the private key
+  memcpy(private_keyblob, uj_input.scalar_alice, X25519_CMD_BYTES);
 
-  cryptolib_fi_asym_x25519_ecdh_out_t ecdh_out;
-  HARDENED_TRY(cryptolib_fi_x25519_ecdh_impl(ecdh_in, &ecdh_out));
+  otcrypto_blinded_key_t private_key = {
+      .config =
+          {
+              .version = kOtcryptoLibVersion1,
+              .key_mode = kOtcryptoKeyModeX25519,
+              .key_length = X25519_CMD_BYTES,
+              .hw_backed = kHardenedBoolFalse,
+              .exportable = kHardenedBoolTrue,
+              .security_level = kOtcryptoKeySecurityLevelLow,
+          },
+      .keyblob_length = sizeof(private_keyblob),
+      .keyblob = private_keyblob,
+  };
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
 
-  memcpy(uj_output->x, ecdh_out.shared_key, X25519_CMD_BYTES);
-  memset(uj_output->y, 0, X25519_CMD_BYTES);
-  uj_output->cfg = ecdh_out.cfg;
+  uint32_t public_key_buf[X25519_CMD_BYTES / sizeof(uint32_t)];
+  memset(public_key_buf, 0, sizeof(public_key_buf));
+  // Bob's scalar acts as the base point (public key X coordinate)
+  memcpy(public_key_buf, uj_input.scalar_bob, X25519_CMD_BYTES);
+
+  otcrypto_unblinded_key_t public_key = {
+      .key_mode = kOtcryptoKeyModeX25519,
+      .key_length = X25519_CMD_BYTES,
+      .key = public_key_buf,
+  };
+  public_key.checksum = otcrypto_integrity_unblinded_checksum(&public_key);
+
+  uint32_t shared_secretblob[16];
+  memset(shared_secretblob, 0, sizeof(shared_secretblob));
+  otcrypto_blinded_key_t shared_secret = {
+      .config =
+          {
+              .version = kOtcryptoLibVersion1,
+              .key_mode = kOtcryptoKeyModeAesCtr,
+              .key_length = X25519_CMD_BYTES,
+              .hw_backed = kHardenedBoolFalse,
+              .exportable = kHardenedBoolTrue,
+              .security_level = kOtcryptoKeySecurityLevelLow,
+          },
+      .keyblob_length = sizeof(shared_secretblob),
+      .keyblob = shared_secretblob,
+  };
+
+  // FI Trigger window
+  if (uj_input.trigger) {
+    pentest_set_trigger_high();
+  }
+  HARDENED_TRY(otcrypto_x25519(&private_key, &public_key, &shared_secret));
+  if (uj_input.trigger) {
+    pentest_set_trigger_low();
+  }
+
+  uint32_t ss_share0[8];
+  uint32_t ss_share1[8];
+  otcrypto_word32_buf_t ss_share0_buf =
+      OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, ss_share0, 8);
+  otcrypto_word32_buf_t ss_share1_buf =
+      OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, ss_share1, 8);
+
+  HARDENED_TRY(otcrypto_export_blinded_key(&shared_secret, &ss_share0_buf,
+                                           &ss_share1_buf));
+
+  uint32_t ss_unmasked[8];
+  HARDENED_TRY(hardened_add(ss_share0, ss_share1, 8, ss_unmasked));
+
+  // Map the unmasked secret back to the point multiplication output
+  uj_output->cfg = 0;
+  memset(uj_output->x, 0, X25519_CMD_BYTES);
+  memcpy(uj_output->x, ss_unmasked, X25519_CMD_BYTES);
+  memset(uj_output->y, 0,
+         X25519_CMD_BYTES);  // Y coordinate is ignored in X25519
   uj_output->magic = kOutputComplete;
 
   return OK_STATUS();

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
@@ -156,6 +156,7 @@ status_t cryptolib_fi_rsa_enc_impl(cryptolib_fi_asym_rsa_enc_in_t uj_input,
     memcpy(uj_output->n, uj_input.n, uj_input.n_len);
     memset(uj_output->d, 0, RSA_CMD_MAX_N_BYTES);
     memcpy(uj_output->d, uj_input.d, uj_input.n_len);
+    uj_output->magic = kOutputComplete;
   } else {
     // Decryption.
 
@@ -233,6 +234,7 @@ status_t cryptolib_fi_rsa_enc_impl(cryptolib_fi_asym_rsa_enc_in_t uj_input,
     memcpy(uj_output->n, uj_input.n, uj_input.n_len);
     memset(uj_output->d, 0, RSA_CMD_MAX_N_BYTES);
     memcpy(uj_output->d, uj_input.d, uj_input.n_len);
+    uj_output->magic = kOutputComplete;
   }
 
   return OK_STATUS();
@@ -406,6 +408,7 @@ status_t cryptolib_fi_rsa_sign_impl(
   memcpy(uj_output->n, uj_input.n, uj_input.n_len);
   memset(uj_output->d, 0, RSA_CMD_MAX_N_BYTES);
   memcpy(uj_output->d, uj_input.d, uj_input.n_len);
+  uj_output->magic = kOutputComplete;
 
   return OK_STATUS();
 }
@@ -554,6 +557,7 @@ status_t cryptolib_fi_rsa_verify_impl(
     uj_output->result = false;
   }
   uj_output->cfg = 0;
+  uj_output->magic = kOutputComplete;
 
   return OK_STATUS();
 }
@@ -647,6 +651,7 @@ status_t cryptolib_fi_p256_ecdh_impl(
   uj_output->cfg = 0;
   memset(uj_output->shared_key, 0, P256_CMD_BYTES);
   memcpy(uj_output->shared_key, ss, P256_CMD_BYTES);
+  uj_output->magic = kOutputComplete;
 
   return OK_STATUS();
 }
@@ -767,6 +772,7 @@ status_t cryptolib_fi_p256_sign_impl(
 
   memcpy(uj_output->pubx, out_pub_x, P256_CMD_BYTES);
   memcpy(uj_output->puby, out_pub_y, P256_CMD_BYTES);
+  uj_output->magic = kOutputComplete;
 
   return OK_STATUS();
 }
@@ -827,6 +833,7 @@ status_t cryptolib_fi_p256_verify_impl(
     uj_output->result = false;
   }
   uj_output->cfg = 0;
+  uj_output->magic = kOutputComplete;
 
   return OK_STATUS();
 }
@@ -891,6 +898,7 @@ status_t cryptolib_fi_p256_base_mul_impl(
   memset(uj_output->y, 0, P256_CMD_BYTES);
   memcpy(uj_output->x, out_pub_x, P256_CMD_BYTES);
   memcpy(uj_output->y, out_pub_y, P256_CMD_BYTES);
+  uj_output->magic = kOutputComplete;
 
   return OK_STATUS();
 }
@@ -984,6 +992,7 @@ status_t cryptolib_fi_p384_ecdh_impl(
   uj_output->cfg = 0;
   memset(uj_output->shared_key, 0, P384_CMD_BYTES);
   memcpy(uj_output->shared_key, ss, P384_CMD_BYTES);
+  uj_output->magic = kOutputComplete;
 
   return OK_STATUS();
 }
@@ -1103,6 +1112,7 @@ status_t cryptolib_fi_p384_sign_impl(
 
   memcpy(uj_output->pubx, out_pub_x, P384_CMD_BYTES);
   memcpy(uj_output->puby, out_pub_y, P384_CMD_BYTES);
+  uj_output->magic = kOutputComplete;
 
   return OK_STATUS();
 }
@@ -1163,6 +1173,7 @@ status_t cryptolib_fi_p384_verify_impl(
     uj_output->result = false;
   }
   uj_output->cfg = 0;
+  uj_output->magic = kOutputComplete;
 
   return OK_STATUS();
 }
@@ -1227,6 +1238,7 @@ status_t cryptolib_fi_p384_base_mul_impl(
   memset(uj_output->y, 0, P384_CMD_BYTES);
   memcpy(uj_output->x, out_pub_x, P384_CMD_BYTES);
   memcpy(uj_output->y, out_pub_y, P384_CMD_BYTES);
+  uj_output->magic = kOutputComplete;
 
   return OK_STATUS();
 }
@@ -1308,6 +1320,7 @@ status_t cryptolib_fi_ed25519_sign_impl(
   memset(uj_output->pubx, 0, ED25519_CMD_SCALAR_BYTES);
   memset(uj_output->puby, 0, ED25519_CMD_SCALAR_BYTES);
   memcpy(uj_output->pubx, public_key_data, ED25519_CMD_SCALAR_BYTES);
+  uj_output->magic = kOutputComplete;
 
   return OK_STATUS();
 }
@@ -1356,6 +1369,7 @@ status_t cryptolib_fi_ed25519_verify_impl(
     uj_output->result = false;
   }
   uj_output->cfg = 0;
+  uj_output->magic = kOutputComplete;
 
   return OK_STATUS();
 }
@@ -1405,6 +1419,7 @@ status_t cryptolib_fi_x25519_base_mul_impl(
   memset(uj_output->x, 0, X25519_CMD_BYTES);
   memset(uj_output->y, 0, X25519_CMD_BYTES);  // X25519 has no Y coordinate
   memcpy(uj_output->x, public_key.key, X25519_CMD_BYTES);
+  uj_output->magic = kOutputComplete;
 
   return OK_STATUS();
 }
@@ -1483,6 +1498,7 @@ status_t cryptolib_fi_x25519_ecdh_impl(
   uj_output->cfg = 0;
   memset(uj_output->shared_key, 0, X25519_CMD_BYTES);
   memcpy(uj_output->shared_key, ss_unmasked, X25519_CMD_BYTES);
+  uj_output->magic = kOutputComplete;
 
   return OK_STATUS();
 }
@@ -1505,6 +1521,7 @@ status_t cryptolib_fi_x25519_point_mul_impl(
   memcpy(uj_output->x, ecdh_out.shared_key, X25519_CMD_BYTES);
   memset(uj_output->y, 0, X25519_CMD_BYTES);
   uj_output->cfg = ecdh_out.cfg;
+  uj_output->magic = kOutputComplete;
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
@@ -8,6 +8,7 @@
 #include "sw/device/lib/base/math.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_curve25519.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
@@ -117,7 +118,8 @@ status_t cryptolib_fi_rsa_enc_impl(cryptolib_fi_asym_rsa_enc_in_t uj_input,
         .key_length = public_key_bytes,
         .key = public_key_data,
     };
-    TRY(otcrypto_rsa_public_key_construct(rsa_size, &modulus, &public_key));
+    HARDENED_TRY(
+        otcrypto_rsa_public_key_construct(rsa_size, &modulus, &public_key));
 
     // Create input message.
     uint8_t msg_buf[num_words];
@@ -188,8 +190,8 @@ status_t cryptolib_fi_rsa_enc_impl(cryptolib_fi_asym_rsa_enc_in_t uj_input,
     if (uj_input.trigger & kPentestTrigger1) {
       pentest_set_trigger_high();
     }
-    TRY(otcrypto_rsa_private_key_from_exponents(rsa_size, &modulus, &d_share0,
-                                                &d_share1, &private_key));
+    HARDENED_TRY(otcrypto_rsa_private_key_from_exponents(
+        rsa_size, &modulus, &d_share0, &d_share1, &private_key));
     if (uj_input.trigger & kPentestTrigger1) {
       pentest_set_trigger_low();
     }
@@ -212,8 +214,8 @@ status_t cryptolib_fi_rsa_enc_impl(cryptolib_fi_asym_rsa_enc_in_t uj_input,
     if (uj_input.trigger & kPentestTrigger2) {
       pentest_set_trigger_high();
     }
-    TRY(otcrypto_rsa_decrypt(&private_key, hash_mode, &ciphertext, &label_buf,
-                             &plaintext, &msg_len));
+    HARDENED_TRY(otcrypto_rsa_decrypt(&private_key, hash_mode, &ciphertext,
+                                      &label_buf, &plaintext, &msg_len));
     if (uj_input.trigger & kPentestTrigger2) {
       pentest_set_trigger_low();
     }
@@ -341,8 +343,8 @@ status_t cryptolib_fi_rsa_sign_impl(
   if (uj_input.trigger & kPentestTrigger1) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_rsa_private_key_from_exponents(rsa_size, &modulus, &d_share0,
-                                              &d_share1, &private_key));
+  HARDENED_TRY(otcrypto_rsa_private_key_from_exponents(
+      rsa_size, &modulus, &d_share0, &d_share1, &private_key));
   if (uj_input.trigger & kPentestTrigger1) {
     pentest_set_trigger_low();
   }
@@ -366,11 +368,11 @@ status_t cryptolib_fi_rsa_sign_impl(
   }
   // Hash the message.
   if (hash_mode == kOtcryptoHashModeSha256) {
-    TRY(otcrypto_sha2_256(&msg_buf, &msg_digest));
+    HARDENED_TRY(otcrypto_sha2_256(&msg_buf, &msg_digest));
   } else if (hash_mode == kOtcryptoHashModeSha384) {
-    TRY(otcrypto_sha2_384(&msg_buf, &msg_digest));
+    HARDENED_TRY(otcrypto_sha2_384(&msg_buf, &msg_digest));
   } else {
-    TRY(otcrypto_sha2_512(&msg_buf, &msg_digest));
+    HARDENED_TRY(otcrypto_sha2_512(&msg_buf, &msg_digest));
   }
   if (uj_input.trigger & kPentestTrigger2) {
     pentest_set_trigger_low();
@@ -384,7 +386,8 @@ status_t cryptolib_fi_rsa_sign_impl(
   if (uj_input.trigger & kPentestTrigger3) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_rsa_sign(&private_key, msg_digest, padding_mode, &sig_buf));
+  HARDENED_TRY(
+      otcrypto_rsa_sign(&private_key, msg_digest, padding_mode, &sig_buf));
   // Trigger window.
   if (uj_input.trigger & kPentestTrigger3) {
     pentest_set_trigger_low();
@@ -489,7 +492,8 @@ status_t cryptolib_fi_rsa_verify_impl(
   if (uj_input.trigger & kPentestTrigger1) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_rsa_public_key_construct(rsa_size, &modulus, &public_key));
+  HARDENED_TRY(
+      otcrypto_rsa_public_key_construct(rsa_size, &modulus, &public_key));
   // Trigger window.
   if (uj_input.trigger & kPentestTrigger1) {
     pentest_set_trigger_low();
@@ -523,11 +527,11 @@ status_t cryptolib_fi_rsa_verify_impl(
   }
   // Hash the message.
   if (hash_mode == kOtcryptoHashModeSha256) {
-    TRY(otcrypto_sha2_256(&msg_buf, &msg_digest));
+    HARDENED_TRY(otcrypto_sha2_256(&msg_buf, &msg_digest));
   } else if (hash_mode == kOtcryptoHashModeSha384) {
-    TRY(otcrypto_sha2_384(&msg_buf, &msg_digest));
+    HARDENED_TRY(otcrypto_sha2_384(&msg_buf, &msg_digest));
   } else {
-    TRY(otcrypto_sha2_512(&msg_buf, &msg_digest));
+    HARDENED_TRY(otcrypto_sha2_512(&msg_buf, &msg_digest));
   }
   if (uj_input.trigger & kPentestTrigger2) {
     pentest_set_trigger_low();
@@ -538,8 +542,8 @@ status_t cryptolib_fi_rsa_verify_impl(
   if (uj_input.trigger & kPentestTrigger3) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_rsa_verify(&public_key, msg_digest, padding_mode, &sig,
-                          &verification_result));
+  HARDENED_TRY(otcrypto_rsa_verify(&public_key, msg_digest, padding_mode, &sig,
+                                   &verification_result));
   if (uj_input.trigger & kPentestTrigger3) {
     pentest_set_trigger_low();
   }
@@ -582,8 +586,8 @@ status_t cryptolib_fi_p256_ecdh_impl(
   otcrypto_const_word32_buf_t share1_buf = OTCRYPTO_MAKE_BUF(
       otcrypto_const_word32_buf_t, share1, kPentestP256MaskedPrivateKeyWords);
 
-  TRY(otcrypto_ecc_p256_private_key_import(share0_buf, share1_buf,
-                                           &private_key));
+  HARDENED_TRY(otcrypto_ecc_p256_private_key_import(share0_buf, share1_buf,
+                                                    &private_key));
 
   // Construct the public key object.
   uint32_t public_key_buf[kPentestP256Words * 2];
@@ -603,7 +607,7 @@ status_t cryptolib_fi_p256_ecdh_impl(
   otcrypto_const_word32_buf_t y_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, pub_y, kPentestP256Words);
 
-  TRY(otcrypto_ecc_p256_public_key_import(x_buf, y_buf, &public_key));
+  HARDENED_TRY(otcrypto_ecc_p256_public_key_import(x_buf, y_buf, &public_key));
 
   // Create a destination for the shared secret.
   uint32_t shared_secretblob[kPentestP256Words * 2];
@@ -623,7 +627,7 @@ status_t cryptolib_fi_p256_ecdh_impl(
   };
 
   pentest_set_trigger_high();
-  TRY(otcrypto_ecdh_p256(&private_key, &public_key, &shared_secret));
+  HARDENED_TRY(otcrypto_ecdh_p256(&private_key, &public_key, &shared_secret));
   pentest_set_trigger_low();
 
   uint32_t ss_share0[kPentestP256Words];
@@ -633,8 +637,8 @@ status_t cryptolib_fi_p256_ecdh_impl(
   otcrypto_word32_buf_t ss_share1_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, ss_share1, ARRAYSIZE(ss_share1));
   uint32_t ss[kPentestP256Words];
-  TRY(otcrypto_export_blinded_key(&shared_secret, &ss_share0_buf,
-                                  &ss_share1_buf));
+  HARDENED_TRY(otcrypto_export_blinded_key(&shared_secret, &ss_share0_buf,
+                                           &ss_share1_buf));
   for (size_t i = 0; i < kPentestP256Words; i++) {
     ss[i] = ss_share0[i] ^ ss_share1[i];
   }
@@ -675,8 +679,8 @@ status_t cryptolib_fi_p256_sign_impl(
   otcrypto_const_word32_buf_t share1_buf = OTCRYPTO_MAKE_BUF(
       otcrypto_const_word32_buf_t, share1, kPentestP256MaskedPrivateKeyWords);
 
-  TRY(otcrypto_ecc_p256_private_key_import(share0_buf, share1_buf,
-                                           &private_key));
+  HARDENED_TRY(otcrypto_ecc_p256_private_key_import(share0_buf, share1_buf,
+                                                    &private_key));
 
   // Create the public key.
   uint32_t public_key_buf[kPentestP256Words * 2];
@@ -696,7 +700,7 @@ status_t cryptolib_fi_p256_sign_impl(
   otcrypto_const_word32_buf_t y_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, pub_y, kPentestP256Words);
 
-  TRY(otcrypto_ecc_p256_public_key_import(x_buf, y_buf, &public_key));
+  HARDENED_TRY(otcrypto_ecc_p256_public_key_import(x_buf, y_buf, &public_key));
 
   // Create a key pair if requested.
   // This will overwrite the private and public key above.
@@ -705,7 +709,7 @@ status_t cryptolib_fi_p256_sign_impl(
     if (uj_input.trigger == 0) {
       pentest_set_trigger_high();
     }
-    TRY(otcrypto_ecdsa_p256_keygen(&private_key, &public_key));
+    HARDENED_TRY(otcrypto_ecdsa_p256_keygen(&private_key, &public_key));
     pentest_set_trigger_low();
     if (uj_input.trigger == 0) {
       pentest_set_trigger_low();
@@ -733,8 +737,8 @@ status_t cryptolib_fi_p256_sign_impl(
     pentest_set_trigger_high();
   }
   // Sign the message.
-  TRY(otcrypto_ecdsa_p256_sign_verify(&private_key, &public_key, message_digest,
-                                      &signature_mut));
+  HARDENED_TRY(otcrypto_ecdsa_p256_sign_verify(&private_key, &public_key,
+                                               message_digest, &signature_mut));
   if (uj_input.trigger == 1) {
     pentest_set_trigger_low();
   }
@@ -758,7 +762,8 @@ status_t cryptolib_fi_p256_sign_impl(
   otcrypto_word32_buf_t out_y_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, out_pub_y, kPentestP256Words);
 
-  TRY(otcrypto_ecc_p256_public_key_export(&public_key, &out_x_buf, &out_y_buf));
+  HARDENED_TRY(
+      otcrypto_ecc_p256_public_key_export(&public_key, &out_x_buf, &out_y_buf));
 
   memcpy(uj_output->pubx, out_pub_x, P256_CMD_BYTES);
   memcpy(uj_output->puby, out_pub_y, P256_CMD_BYTES);
@@ -798,7 +803,7 @@ status_t cryptolib_fi_p256_verify_impl(
   otcrypto_const_word32_buf_t y_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, pub_y, kPentestP256Words);
 
-  TRY(otcrypto_ecc_p256_public_key_import(x_buf, y_buf, &public_key));
+  HARDENED_TRY(otcrypto_ecc_p256_public_key_import(x_buf, y_buf, &public_key));
 
   // Setup the signature buffer.
   uint32_t signature_data[kPentestP256Words * 2] = {0};
@@ -812,8 +817,8 @@ status_t cryptolib_fi_p256_verify_impl(
   hardened_bool_t verification_result = kHardenedBoolFalse;
 
   pentest_set_trigger_high();
-  TRY(otcrypto_ecdsa_p256_verify(&public_key, message_digest, &signature,
-                                 &verification_result));
+  HARDENED_TRY(otcrypto_ecdsa_p256_verify(&public_key, message_digest,
+                                          &signature, &verification_result));
   pentest_set_trigger_low();
 
   // Return data back to host.
@@ -853,8 +858,8 @@ status_t cryptolib_fi_p256_base_mul_impl(
   otcrypto_const_word32_buf_t share1_buf = OTCRYPTO_MAKE_BUF(
       otcrypto_const_word32_buf_t, share1, kPentestP256MaskedPrivateKeyWords);
 
-  TRY(otcrypto_ecc_p256_private_key_import(share0_buf, share1_buf,
-                                           &private_key));
+  HARDENED_TRY(otcrypto_ecc_p256_private_key_import(share0_buf, share1_buf,
+                                                    &private_key));
 
   uint32_t public_key_buf[kPentestP256Words * 2];
   otcrypto_unblinded_key_t public_key = {
@@ -866,7 +871,7 @@ status_t cryptolib_fi_p256_base_mul_impl(
   if (uj_input.trigger) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_ecc_p256_base_point_mult(&private_key, &public_key));
+  HARDENED_TRY(otcrypto_ecc_p256_base_point_mult(&private_key, &public_key));
   if (uj_input.trigger) {
     pentest_set_trigger_low();
   }
@@ -878,7 +883,8 @@ status_t cryptolib_fi_p256_base_mul_impl(
   otcrypto_word32_buf_t out_y_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, out_pub_y, kPentestP256Words);
 
-  TRY(otcrypto_ecc_p256_public_key_export(&public_key, &out_x_buf, &out_y_buf));
+  HARDENED_TRY(
+      otcrypto_ecc_p256_public_key_export(&public_key, &out_x_buf, &out_y_buf));
 
   uj_output->cfg = 0;
   memset(uj_output->x, 0, P256_CMD_BYTES);
@@ -917,8 +923,8 @@ status_t cryptolib_fi_p384_ecdh_impl(
   otcrypto_const_word32_buf_t share1_buf = OTCRYPTO_MAKE_BUF(
       otcrypto_const_word32_buf_t, share1, kPentestP384MaskedPrivateKeyWords);
 
-  TRY(otcrypto_ecc_p384_private_key_import(share0_buf, share1_buf,
-                                           &private_key));
+  HARDENED_TRY(otcrypto_ecc_p384_private_key_import(share0_buf, share1_buf,
+                                                    &private_key));
 
   // Construct the public key object.
   uint32_t public_key_buf[kPentestP384Words * 2];
@@ -938,7 +944,7 @@ status_t cryptolib_fi_p384_ecdh_impl(
   otcrypto_const_word32_buf_t y_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, pub_y, kPentestP384Words);
 
-  TRY(otcrypto_ecc_p384_public_key_import(x_buf, y_buf, &public_key));
+  HARDENED_TRY(otcrypto_ecc_p384_public_key_import(x_buf, y_buf, &public_key));
 
   // Create a destination for the shared secret.
   uint32_t shared_secretblob[kPentestP384Words * 2];
@@ -958,7 +964,7 @@ status_t cryptolib_fi_p384_ecdh_impl(
   };
 
   pentest_set_trigger_high();
-  TRY(otcrypto_ecdh_p384(&private_key, &public_key, &shared_secret));
+  HARDENED_TRY(otcrypto_ecdh_p384(&private_key, &public_key, &shared_secret));
   pentest_set_trigger_low();
 
   uint32_t ss_share0[kPentestP384Words];
@@ -968,8 +974,8 @@ status_t cryptolib_fi_p384_ecdh_impl(
   otcrypto_word32_buf_t ss_share1_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, ss_share1, ARRAYSIZE(ss_share1));
   uint32_t ss[kPentestP384Words];
-  TRY(otcrypto_export_blinded_key(&shared_secret, &ss_share0_buf,
-                                  &ss_share1_buf));
+  HARDENED_TRY(otcrypto_export_blinded_key(&shared_secret, &ss_share0_buf,
+                                           &ss_share1_buf));
   for (size_t i = 0; i < kPentestP384Words; i++) {
     ss[i] = ss_share0[i] ^ ss_share1[i];
   }
@@ -1010,8 +1016,8 @@ status_t cryptolib_fi_p384_sign_impl(
   otcrypto_const_word32_buf_t share1_buf = OTCRYPTO_MAKE_BUF(
       otcrypto_const_word32_buf_t, share1, kPentestP384MaskedPrivateKeyWords);
 
-  TRY(otcrypto_ecc_p384_private_key_import(share0_buf, share1_buf,
-                                           &private_key));
+  HARDENED_TRY(otcrypto_ecc_p384_private_key_import(share0_buf, share1_buf,
+                                                    &private_key));
 
   // Create the public key.
   uint32_t public_key_buf[kPentestP384Words * 2];
@@ -1031,7 +1037,7 @@ status_t cryptolib_fi_p384_sign_impl(
   otcrypto_const_word32_buf_t y_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, pub_y, kPentestP384Words);
 
-  TRY(otcrypto_ecc_p384_public_key_import(x_buf, y_buf, &public_key));
+  HARDENED_TRY(otcrypto_ecc_p384_public_key_import(x_buf, y_buf, &public_key));
 
   // Create a key pair if requested.
   // This will overwrite the private and public key above.
@@ -1040,7 +1046,7 @@ status_t cryptolib_fi_p384_sign_impl(
     if (uj_input.trigger == 0) {
       pentest_set_trigger_high();
     }
-    TRY(otcrypto_ecdsa_p384_keygen(&private_key, &public_key));
+    HARDENED_TRY(otcrypto_ecdsa_p384_keygen(&private_key, &public_key));
     pentest_set_trigger_low();
     if (uj_input.trigger == 0) {
       pentest_set_trigger_low();
@@ -1067,8 +1073,8 @@ status_t cryptolib_fi_p384_sign_impl(
   if (uj_input.trigger == 1) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_ecdsa_p384_sign_verify(&private_key, &public_key, message_digest,
-                                      &signature_mut));
+  HARDENED_TRY(otcrypto_ecdsa_p384_sign_verify(&private_key, &public_key,
+                                               message_digest, &signature_mut));
   if (uj_input.trigger == 1) {
     pentest_set_trigger_low();
   }
@@ -1092,7 +1098,8 @@ status_t cryptolib_fi_p384_sign_impl(
   otcrypto_word32_buf_t out_y_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, out_pub_y, kPentestP384Words);
 
-  TRY(otcrypto_ecc_p384_public_key_export(&public_key, &out_x_buf, &out_y_buf));
+  HARDENED_TRY(
+      otcrypto_ecc_p384_public_key_export(&public_key, &out_x_buf, &out_y_buf));
 
   memcpy(uj_output->pubx, out_pub_x, P384_CMD_BYTES);
   memcpy(uj_output->puby, out_pub_y, P384_CMD_BYTES);
@@ -1132,7 +1139,7 @@ status_t cryptolib_fi_p384_verify_impl(
   otcrypto_const_word32_buf_t y_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, pub_y, kPentestP384Words);
 
-  TRY(otcrypto_ecc_p384_public_key_import(x_buf, y_buf, &public_key));
+  HARDENED_TRY(otcrypto_ecc_p384_public_key_import(x_buf, y_buf, &public_key));
 
   // Setup the signature buffer.
   uint32_t signature_data[kPentestP384Words * 2] = {0};
@@ -1146,8 +1153,8 @@ status_t cryptolib_fi_p384_verify_impl(
   hardened_bool_t verification_result = kHardenedBoolFalse;
 
   pentest_set_trigger_high();
-  TRY(otcrypto_ecdsa_p384_verify(&public_key, message_digest, &signature,
-                                 &verification_result));
+  HARDENED_TRY(otcrypto_ecdsa_p384_verify(&public_key, message_digest,
+                                          &signature, &verification_result));
   pentest_set_trigger_low();
 
   // Return data back to host.
@@ -1187,8 +1194,8 @@ status_t cryptolib_fi_p384_base_mul_impl(
   otcrypto_const_word32_buf_t share1_buf = OTCRYPTO_MAKE_BUF(
       otcrypto_const_word32_buf_t, share1, kPentestP384MaskedPrivateKeyWords);
 
-  TRY(otcrypto_ecc_p384_private_key_import(share0_buf, share1_buf,
-                                           &private_key));
+  HARDENED_TRY(otcrypto_ecc_p384_private_key_import(share0_buf, share1_buf,
+                                                    &private_key));
 
   uint32_t public_key_buf[kPentestP384Words * 2];
   otcrypto_unblinded_key_t public_key = {
@@ -1200,7 +1207,7 @@ status_t cryptolib_fi_p384_base_mul_impl(
   if (uj_input.trigger) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_ecc_p384_base_point_mult(&private_key, &public_key));
+  HARDENED_TRY(otcrypto_ecc_p384_base_point_mult(&private_key, &public_key));
   if (uj_input.trigger) {
     pentest_set_trigger_low();
   }
@@ -1212,7 +1219,8 @@ status_t cryptolib_fi_p384_base_mul_impl(
   otcrypto_word32_buf_t out_y_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, out_pub_y, kPentestP384Words);
 
-  TRY(otcrypto_ecc_p384_public_key_export(&public_key, &out_x_buf, &out_y_buf));
+  HARDENED_TRY(
+      otcrypto_ecc_p384_public_key_export(&public_key, &out_x_buf, &out_y_buf));
 
   uj_output->cfg = 0;
   memset(uj_output->x, 0, P384_CMD_BYTES);
@@ -1259,7 +1267,8 @@ status_t cryptolib_fi_ed25519_sign_impl(
   if (uj_input.trigger == 0) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_ed25519_public_key_from_private(&private_key, &public_key));
+  HARDENED_TRY(
+      otcrypto_ed25519_public_key_from_private(&private_key, &public_key));
   if (uj_input.trigger == 0) {
     pentest_set_trigger_low();
   }
@@ -1278,7 +1287,8 @@ status_t cryptolib_fi_ed25519_sign_impl(
   if (uj_input.trigger == 1) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_ed25519_sign_verify(&private_key, &public_key, &input_message,
+  HARDENED_TRY(
+      otcrypto_ed25519_sign_verify(&private_key, &public_key, &input_message,
                                    kOtcryptoEddsaSignModeEddsa, &signature));
   if (uj_input.trigger == 1) {
     pentest_set_trigger_low();
@@ -1335,9 +1345,9 @@ status_t cryptolib_fi_ed25519_verify_impl(
   hardened_bool_t verification_result = kHardenedBoolFalse;
 
   pentest_set_trigger_high();
-  TRY(otcrypto_ed25519_verify(&public_key, &input_message,
-                              kOtcryptoEddsaSignModeEddsa, &signature,
-                              &verification_result));
+  HARDENED_TRY(otcrypto_ed25519_verify(&public_key, &input_message,
+                                       kOtcryptoEddsaSignModeEddsa, &signature,
+                                       &verification_result));
   pentest_set_trigger_low();
 
   // Return data back to host.
@@ -1386,7 +1396,7 @@ status_t cryptolib_fi_x25519_base_mul_impl(
   if (uj_input.trigger) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_x25519_keygen(&private_key, &public_key));
+  HARDENED_TRY(otcrypto_x25519_keygen(&private_key, &public_key));
   if (uj_input.trigger) {
     pentest_set_trigger_low();
   }
@@ -1452,7 +1462,7 @@ status_t cryptolib_fi_x25519_ecdh_impl(
   if (uj_input.trigger) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_x25519(&private_key, &public_key, &shared_secret));
+  HARDENED_TRY(otcrypto_x25519(&private_key, &public_key, &shared_secret));
   if (uj_input.trigger) {
     pentest_set_trigger_low();
   }
@@ -1464,11 +1474,11 @@ status_t cryptolib_fi_x25519_ecdh_impl(
   otcrypto_word32_buf_t ss_share1_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, ss_share1, 8);
 
-  TRY(otcrypto_export_blinded_key(&shared_secret, &ss_share0_buf,
-                                  &ss_share1_buf));
+  HARDENED_TRY(otcrypto_export_blinded_key(&shared_secret, &ss_share0_buf,
+                                           &ss_share1_buf));
 
   uint32_t ss_unmasked[8];
-  TRY(hardened_add(ss_share0, ss_share1, 8, ss_unmasked));
+  HARDENED_TRY(hardened_add(ss_share0, ss_share1, 8, ss_unmasked));
 
   uj_output->cfg = 0;
   memset(uj_output->shared_key, 0, X25519_CMD_BYTES);
@@ -1490,7 +1500,7 @@ status_t cryptolib_fi_x25519_point_mul_impl(
   ecdh_in.trigger = uj_input.trigger;
 
   cryptolib_fi_asym_x25519_ecdh_out_t ecdh_out;
-  TRY(cryptolib_fi_x25519_ecdh_impl(ecdh_in, &ecdh_out));
+  HARDENED_TRY(cryptolib_fi_x25519_ecdh_impl(ecdh_in, &ecdh_out));
 
   memcpy(uj_output->x, ecdh_out.shared_key, X25519_CMD_BYTES);
   memset(uj_output->y, 0, X25519_CMD_BYTES);

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
@@ -140,6 +140,8 @@ status_t cryptolib_fi_rsa_enc_impl(cryptolib_fi_asym_rsa_enc_in_t uj_input,
       pentest_set_trigger_low();
     }
 
+    HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&ciphertext));
+
     // Return data back to host.
     uj_output->data_len = num_bytes;
     uj_output->cfg = 0;
@@ -215,6 +217,8 @@ status_t cryptolib_fi_rsa_enc_impl(cryptolib_fi_asym_rsa_enc_in_t uj_input,
     if (uj_input.trigger & kPentestTrigger2) {
       pentest_set_trigger_low();
     }
+
+    HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&plaintext));
 
     // Return data back to host.
     uj_output->data_len = msg_len;
@@ -385,6 +389,8 @@ status_t cryptolib_fi_rsa_sign_impl(
   if (uj_input.trigger & kPentestTrigger3) {
     pentest_set_trigger_low();
   }
+
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&sig_buf));
 
   // Return data back to host.
   uj_output->sig_len = uj_input.n_len;
@@ -733,6 +739,8 @@ status_t cryptolib_fi_p256_sign_impl(
     pentest_set_trigger_low();
   }
 
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&signature_mut));
+
   // Return data back to host.
   uj_output->cfg = 0;
   memset(uj_output->r, 0, P256_CMD_BYTES);
@@ -1065,6 +1073,8 @@ status_t cryptolib_fi_p384_sign_impl(
     pentest_set_trigger_low();
   }
 
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&signature_mut));
+
   // Return data back to host.
   uj_output->cfg = 0;
   memset(uj_output->r, 0, P384_CMD_BYTES);
@@ -1273,6 +1283,8 @@ status_t cryptolib_fi_ed25519_sign_impl(
   if (uj_input.trigger == 1) {
     pentest_set_trigger_low();
   }
+
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&signature));
 
   // Return signature: R component (first 32 bytes) in r, S (next 32) in s.
   uj_output->cfg = 0;

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym.c
@@ -46,7 +46,14 @@ status_t handle_cryptolib_fi_sym_aes(ujson_t *uj) {
 
   cryptolib_fi_sym_aes_out_t uj_output;
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status = (size_t)cryptolib_fi_aes_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -94,7 +101,14 @@ status_t handle_cryptolib_fi_sym_cmac(ujson_t *uj) {
   memset(&uj_output, 0, sizeof(uj_output));
 
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status = (size_t)cryptolib_fi_cmac_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -139,7 +153,14 @@ status_t handle_cryptolib_fi_sym_gcm(ujson_t *uj) {
 
   cryptolib_fi_sym_gcm_out_t uj_output;
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status = (size_t)cryptolib_fi_gcm_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -227,7 +248,14 @@ status_t handle_cryptolib_fi_sym_hmac(ujson_t *uj) {
 
   cryptolib_fi_sym_hmac_out_t uj_output;
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status = (size_t)cryptolib_fi_hmac_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -271,8 +299,15 @@ status_t handle_cryptolib_fi_sym_drbg_generate(ujson_t *uj) {
 
   cryptolib_fi_sym_drbg_generate_out_t uj_output;
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status =
       (size_t)cryptolib_fi_drbg_generate_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -316,8 +351,15 @@ status_t handle_cryptolib_fi_sym_drbg_reseed(ujson_t *uj) {
 
   cryptolib_fi_sym_drbg_reseed_out_t uj_output;
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status =
       (size_t)cryptolib_fi_drbg_reseed_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -404,8 +446,15 @@ status_t handle_cryptolib_fi_sym_trng_init(ujson_t *uj) {
 
   cryptolib_fi_sym_trng_init_out_t uj_output;
   uj_output.status = kUnknown;
+  uj_output.magic = kOutputPending;
   uj_output.status =
       (size_t)cryptolib_fi_trng_init_impl(uj_input, &uj_output).value;
+
+  if (uj_output.status == OK_STATUS().value) {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputComplete);
+  } else {
+    HARDENED_CHECK_EQ(uj_output.magic, kOutputPending);
+  }
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym_impl.c
@@ -6,6 +6,7 @@
 
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/aes.h"
 #include "sw/device/lib/crypto/include/aes_gcm.h"
 #include "sw/device/lib/crypto/include/cmac.h"
@@ -150,7 +151,7 @@ status_t cryptolib_fi_aes_impl(cryptolib_fi_sym_aes_in_t uj_input,
 
   // Trigger window.
   pentest_set_trigger_high();
-  TRY(otcrypto_aes(&key, &iv, mode, op, &input, padding, &output));
+  HARDENED_TRY(otcrypto_aes(&key, &iv, mode, op, &input, padding, &output));
   pentest_set_trigger_low();
 
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&output));
@@ -183,7 +184,7 @@ status_t cryptolib_fi_drbg_generate_impl(
   if (uj_input.trigger & kPentestTrigger2) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_drbg_generate(&nonce, &output));
+  HARDENED_TRY(otcrypto_drbg_generate(&nonce, &output));
   if (uj_input.trigger & kPentestTrigger2) {
     pentest_set_trigger_low();
   }
@@ -212,7 +213,7 @@ status_t cryptolib_fi_drbg_reseed_impl(
   if (uj_input.trigger & kPentestTrigger1) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_drbg_instantiate(&entropy));
+  HARDENED_TRY(otcrypto_drbg_instantiate(&entropy));
   if (uj_input.trigger & kPentestTrigger1) {
     pentest_set_trigger_low();
   }
@@ -230,7 +231,7 @@ status_t cryptolib_fi_trng_init_impl(
   if (uj_input.trigger & kPentestTrigger1) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_entropy_init());
+  HARDENED_TRY(otcrypto_entropy_init());
   if (uj_input.trigger & kPentestTrigger1) {
     pentest_set_trigger_low();
   }
@@ -329,8 +330,8 @@ status_t cryptolib_fi_gcm_impl(cryptolib_fi_sym_gcm_in_t uj_input,
 
   // Trigger window.
   pentest_set_trigger_high();
-  TRY(otcrypto_aes_gcm_encrypt(&key, &plaintext, &iv, &aad, tag_len,
-                               &actual_ciphertext, &actual_tag));
+  HARDENED_TRY(otcrypto_aes_gcm_encrypt(&key, &plaintext, &iv, &aad, tag_len,
+                                        &actual_ciphertext, &actual_tag));
   pentest_set_trigger_low();
 
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&actual_ciphertext));
@@ -430,7 +431,7 @@ status_t cryptolib_fi_hmac_impl(cryptolib_fi_sym_hmac_in_t uj_input,
 
   // Trigger window.
   pentest_set_trigger_high();
-  TRY(otcrypto_hmac(&key, &input_message, &tag));
+  HARDENED_TRY(otcrypto_hmac(&key, &input_message, &tag));
   pentest_set_trigger_low();
 
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&tag));
@@ -504,7 +505,7 @@ status_t cryptolib_fi_cmac_impl(cryptolib_fi_sym_cmac_in_t uj_input,
 
   // Trigger window.
   pentest_set_trigger_high();
-  TRY(otcrypto_cmac(&key, &input_message, &tag));
+  HARDENED_TRY(otcrypto_cmac(&key, &input_message, &tag));
   pentest_set_trigger_low();
 
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&tag));

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym_impl.c
@@ -161,6 +161,7 @@ status_t cryptolib_fi_aes_impl(cryptolib_fi_sym_aes_in_t uj_input,
   uj_output->cfg = 0;
   memset(uj_output->data, 0, AES_CMD_MAX_MSG_BYTES);
   memcpy(uj_output->data, output_buf, uj_output->data_len);
+  uj_output->magic = kOutputComplete;
 
   return OK_STATUS();
 }
@@ -195,6 +196,7 @@ status_t cryptolib_fi_drbg_generate_impl(
   uj_output->cfg = 0;
   memset(uj_output->data, 0, DRBG_CMD_MAX_OUTPUT_BYTES);
   memcpy(uj_output->data, output_data, uj_input.data_len);
+  uj_output->magic = kOutputComplete;
 
   return OK_STATUS();
 }
@@ -220,6 +222,7 @@ status_t cryptolib_fi_drbg_reseed_impl(
 
   // Return data back to host.
   uj_output->cfg = 0;
+  uj_output->magic = kOutputComplete;
 
   return OK_STATUS();
 }
@@ -238,6 +241,7 @@ status_t cryptolib_fi_trng_init_impl(
 
   // Return data back to host.
   uj_output->cfg = 0;
+  uj_output->magic = kOutputComplete;
 
   return OK_STATUS();
 }
@@ -347,6 +351,7 @@ status_t cryptolib_fi_gcm_impl(cryptolib_fi_sym_gcm_in_t uj_input,
   uj_output->tag_len = uj_input.tag_len;
   memset(uj_output->tag, 0, AES_CMD_MAX_MSG_BYTES);
   memcpy(uj_output->tag, actual_tag_data, uj_output->tag_len);
+  uj_output->magic = kOutputComplete;
 
   return OK_STATUS();
 }
@@ -441,6 +446,7 @@ status_t cryptolib_fi_hmac_impl(cryptolib_fi_sym_hmac_in_t uj_input,
   uj_output->cfg = 0;
   memset(uj_output->data, 0, HMAC_CMD_MAX_TAG_BYTES);
   memcpy(uj_output->data, tag_buf, uj_output->data_len);
+  uj_output->magic = kOutputComplete;
 
   return OK_STATUS();
 }
@@ -515,6 +521,7 @@ status_t cryptolib_fi_cmac_impl(cryptolib_fi_sym_cmac_in_t uj_input,
   uj_output->cfg = uj_input.cfg;
   memset(uj_output->data, 0, AES_CMD_MAX_MSG_BYTES);
   memcpy(uj_output->data, tag_buf, uj_output->data_len);
+  uj_output->magic = kOutputComplete;
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym_impl.c
@@ -153,6 +153,8 @@ status_t cryptolib_fi_aes_impl(cryptolib_fi_sym_aes_in_t uj_input,
   TRY(otcrypto_aes(&key, &iv, mode, op, &input, padding, &output));
   pentest_set_trigger_low();
 
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&output));
+
   // Return data back to host.
   uj_output->data_len = padded_len_bytes;
   uj_output->cfg = 0;
@@ -185,6 +187,8 @@ status_t cryptolib_fi_drbg_generate_impl(
   if (uj_input.trigger & kPentestTrigger2) {
     pentest_set_trigger_low();
   }
+
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&output));
 
   // Return data back to host.
   uj_output->cfg = 0;
@@ -329,6 +333,9 @@ status_t cryptolib_fi_gcm_impl(cryptolib_fi_sym_gcm_in_t uj_input,
                                &actual_ciphertext, &actual_tag));
   pentest_set_trigger_low();
 
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&actual_ciphertext));
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&actual_tag));
+
   // Return data back to host.
   uj_output->cfg = 0;
   // Ciphertext.
@@ -426,6 +433,8 @@ status_t cryptolib_fi_hmac_impl(cryptolib_fi_sym_hmac_in_t uj_input,
   TRY(otcrypto_hmac(&key, &input_message, &tag));
   pentest_set_trigger_low();
 
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&tag));
+
   // Return data back to host.
   uj_output->data_len = tag_bytes;
   uj_output->cfg = 0;
@@ -497,6 +506,8 @@ status_t cryptolib_fi_cmac_impl(cryptolib_fi_sym_cmac_in_t uj_input,
   pentest_set_trigger_high();
   TRY(otcrypto_cmac(&key, &input_message, &tag));
   pentest_set_trigger_low();
+
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&tag));
 
   // Return data back to host.
   uj_output->data_len = tag_bytes;

--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h
@@ -15,6 +15,10 @@
 
 static const char PENTEST_VERSION[16] = "PENTEST: v1.0.3";
 
+// Magic values to indicate whether the call is complete or not.
+#define kOutputPending 0x1d4a9f23
+#define kOutputComplete 0x6b8c1a7e
+
 // NOP macros used in different FI tests.
 #define NOP1 "nop\n"
 #define NOP10 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1

--- a/sw/device/tests/penetrationtests/firmware/sca/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/sca/BUILD
@@ -100,6 +100,8 @@ cc_library(
         "//sw/device/lib/testing/test_framework:ujson_ottf",
         "//sw/device/tests/penetrationtests/firmware/lib:pentest_lib",
         "//sw/device/tests/penetrationtests/json:cryptolib_sca_asym_commands",
+        # Specifically load the HARDENED_TRY
+        "//sw/device/lib/crypto/impl:status",
     ] + select({
         # This is the target for the cryptolib given as a prebuilt drop
         "//sw/device/tests/penetrationtests/cryptolib_drop:use_prebuilt_cryptolib": [
@@ -125,6 +127,8 @@ cc_library(
         "//sw/device/lib/testing/test_framework:ujson_ottf",
         "//sw/device/tests/penetrationtests/firmware/lib:pentest_lib",
         "//sw/device/tests/penetrationtests/json:cryptolib_sca_sym_commands",
+        # Specifically load the HARDENED_TRY
+        "//sw/device/lib/crypto/impl:status",
     ] + select({
         # This is the target for the cryptolib given as a prebuilt drop
         "//sw/device/tests/penetrationtests/cryptolib_drop:use_prebuilt_cryptolib": [

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym_impl.c
@@ -168,6 +168,8 @@ status_t cryptolib_sca_rsa_dec_impl(
     pentest_set_trigger_low();
   }
 
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&plaintext));
+
   // Return data back to host.
   *data_out_len = msg_len;
   *cfg_out = 0;
@@ -429,6 +431,8 @@ status_t cryptolib_sca_rsa_sign_impl(
     pentest_set_trigger_low();
   }
 
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&rsa_sig));
+
   // Return data back to host.
   *sig_len = *n_len;
   *cfg_out = 0;
@@ -528,6 +532,8 @@ status_t cryptolib_sca_p256_sign_impl(
   if (uj_input.trigger == 1) {
     pentest_set_trigger_low();
   }
+
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&signature_mut));
 
   // Return data back to host.
   uj_output->cfg = 0;
@@ -740,6 +746,8 @@ status_t cryptolib_sca_p384_sign_impl(
     pentest_set_trigger_low();
   }
 
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&signature_mut));
+
   // Return data back to host.
   uj_output->cfg = 0;
   memset(uj_output->r, 0, P384_CMD_BYTES);
@@ -825,6 +833,8 @@ status_t cryptolib_sca_ed25519_sign_impl(
   if (uj_input.trigger == 1) {
     pentest_set_trigger_low();
   }
+
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&signature));
 
   // Return signature: R component (first 32 bytes) in r, S (next 32) in s.
   uj_output->cfg = 0;

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym_impl.c
@@ -8,6 +8,7 @@
 #include "sw/device/lib/base/math.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_curve25519.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
@@ -134,8 +135,8 @@ status_t cryptolib_sca_rsa_dec_impl(
   if (trigger & kPentestTrigger1) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_rsa_private_key_from_exponents(rsa_size, &modulus, &d_share0,
-                                              &d_share1, &private_key));
+  HARDENED_TRY(otcrypto_rsa_private_key_from_exponents(
+      rsa_size, &modulus, &d_share0, &d_share1, &private_key));
   if (trigger & kPentestTrigger1) {
     pentest_set_trigger_low();
   }
@@ -162,8 +163,8 @@ status_t cryptolib_sca_rsa_dec_impl(
   if (trigger & kPentestTrigger2) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_rsa_decrypt(&private_key, hash_mode, &ciphertext, &label_buf,
-                           &plaintext, &msg_len));
+  HARDENED_TRY(otcrypto_rsa_decrypt(&private_key, hash_mode, &ciphertext,
+                                    &label_buf, &plaintext, &msg_len));
   if (trigger & kPentestTrigger2) {
     pentest_set_trigger_low();
   }
@@ -207,8 +208,8 @@ status_t cryptolib_sca_p256_ecdh_impl(
   otcrypto_const_word32_buf_t share1_buf = OTCRYPTO_MAKE_BUF(
       otcrypto_const_word32_buf_t, share1, kPentestP256MaskedPrivateKeyWords);
 
-  TRY(otcrypto_ecc_p256_private_key_import(share0_buf, share1_buf,
-                                           &private_key));
+  HARDENED_TRY(otcrypto_ecc_p256_private_key_import(share0_buf, share1_buf,
+                                                    &private_key));
 
   // Construct the public key object.
   uint32_t public_key_buf[kPentestP256Words * 2];
@@ -228,7 +229,7 @@ status_t cryptolib_sca_p256_ecdh_impl(
   otcrypto_const_word32_buf_t y_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, pub_y, kPentestP256Words);
 
-  TRY(otcrypto_ecc_p256_public_key_import(x_buf, y_buf, &public_key));
+  HARDENED_TRY(otcrypto_ecc_p256_public_key_import(x_buf, y_buf, &public_key));
 
   // Create a destination for the shared secret.
   uint32_t shared_secretblob[kPentestP256Words * 2];
@@ -259,8 +260,8 @@ status_t cryptolib_sca_p256_ecdh_impl(
   otcrypto_word32_buf_t ss_share1_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, ss_share1, ARRAYSIZE(ss_share1));
   uint32_t ss[kPentestP256Words];
-  TRY(otcrypto_export_blinded_key(&shared_secret, &ss_share0_buf,
-                                  &ss_share1_buf));
+  HARDENED_TRY(otcrypto_export_blinded_key(&shared_secret, &ss_share0_buf,
+                                           &ss_share1_buf));
   for (size_t i = 0; i < kPentestP256Words; i++) {
     ss[i] = ss_share0[i] ^ ss_share1[i];
   }
@@ -382,8 +383,8 @@ status_t cryptolib_sca_rsa_sign_impl(
   if (trigger & kPentestTrigger1) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_rsa_private_key_from_exponents(rsa_size, &modulus, &d_share0,
-                                              &d_share1, &private_key));
+  HARDENED_TRY(otcrypto_rsa_private_key_from_exponents(
+      rsa_size, &modulus, &d_share0, &d_share1, &private_key));
   if (trigger & kPentestTrigger1) {
     pentest_set_trigger_low();
   }
@@ -407,11 +408,11 @@ status_t cryptolib_sca_rsa_sign_impl(
   }
   // Hash the message.
   if (hash_mode == kOtcryptoHashModeSha256) {
-    TRY(otcrypto_sha2_256(&msg_buf, &msg_digest));
+    HARDENED_TRY(otcrypto_sha2_256(&msg_buf, &msg_digest));
   } else if (hash_mode == kOtcryptoHashModeSha384) {
-    TRY(otcrypto_sha2_384(&msg_buf, &msg_digest));
+    HARDENED_TRY(otcrypto_sha2_384(&msg_buf, &msg_digest));
   } else {
-    TRY(otcrypto_sha2_512(&msg_buf, &msg_digest));
+    HARDENED_TRY(otcrypto_sha2_512(&msg_buf, &msg_digest));
   }
   if (trigger & kPentestTrigger2) {
     pentest_set_trigger_low();
@@ -425,7 +426,8 @@ status_t cryptolib_sca_rsa_sign_impl(
   if (trigger & kPentestTrigger3) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_rsa_sign(&private_key, msg_digest, padding_mode, &rsa_sig));
+  HARDENED_TRY(
+      otcrypto_rsa_sign(&private_key, msg_digest, padding_mode, &rsa_sig));
   // Trigger window.
   if (trigger & kPentestTrigger3) {
     pentest_set_trigger_low();
@@ -470,8 +472,8 @@ status_t cryptolib_sca_p256_sign_impl(
   otcrypto_const_word32_buf_t share1_buf = OTCRYPTO_MAKE_BUF(
       otcrypto_const_word32_buf_t, share1, kPentestP256MaskedPrivateKeyWords);
 
-  TRY(otcrypto_ecc_p256_private_key_import(share0_buf, share1_buf,
-                                           &private_key));
+  HARDENED_TRY(otcrypto_ecc_p256_private_key_import(share0_buf, share1_buf,
+                                                    &private_key));
 
   // Create the public key.
   uint32_t public_key_buf[kPentestP256Words * 2];
@@ -491,7 +493,7 @@ status_t cryptolib_sca_p256_sign_impl(
   otcrypto_const_word32_buf_t y_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, pub_y, kPentestP256Words);
 
-  TRY(otcrypto_ecc_p256_public_key_import(x_buf, y_buf, &public_key));
+  HARDENED_TRY(otcrypto_ecc_p256_public_key_import(x_buf, y_buf, &public_key));
 
   // Create a key pair if requested.
   // This will overwrite the private and public key above.
@@ -500,7 +502,7 @@ status_t cryptolib_sca_p256_sign_impl(
     if (uj_input.trigger == 0) {
       pentest_set_trigger_high();
     }
-    TRY(otcrypto_ecdsa_p256_keygen(&private_key, &public_key));
+    HARDENED_TRY(otcrypto_ecdsa_p256_keygen(&private_key, &public_key));
     pentest_set_trigger_low();
     if (uj_input.trigger == 0) {
       pentest_set_trigger_low();
@@ -527,8 +529,8 @@ status_t cryptolib_sca_p256_sign_impl(
   if (uj_input.trigger == 1) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_ecdsa_p256_sign_verify(&private_key, &public_key, message_digest,
-                                      &signature_mut));
+  HARDENED_TRY(otcrypto_ecdsa_p256_sign_verify(&private_key, &public_key,
+                                               message_digest, &signature_mut));
   if (uj_input.trigger == 1) {
     pentest_set_trigger_low();
   }
@@ -552,7 +554,8 @@ status_t cryptolib_sca_p256_sign_impl(
   otcrypto_word32_buf_t out_y_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, out_pub_y, kPentestP256Words);
 
-  TRY(otcrypto_ecc_p256_public_key_export(&public_key, &out_x_buf, &out_y_buf));
+  HARDENED_TRY(
+      otcrypto_ecc_p256_public_key_export(&public_key, &out_x_buf, &out_y_buf));
 
   memcpy(uj_output->pubx, out_pub_x, P256_CMD_BYTES);
   memcpy(uj_output->puby, out_pub_y, P256_CMD_BYTES);
@@ -588,8 +591,8 @@ status_t cryptolib_sca_p384_ecdh_impl(
   otcrypto_const_word32_buf_t share1_buf = OTCRYPTO_MAKE_BUF(
       otcrypto_const_word32_buf_t, share1, kPentestP384MaskedPrivateKeyWords);
 
-  TRY(otcrypto_ecc_p384_private_key_import(share0_buf, share1_buf,
-                                           &private_key));
+  HARDENED_TRY(otcrypto_ecc_p384_private_key_import(share0_buf, share1_buf,
+                                                    &private_key));
 
   // Construct the public key object.
   uint32_t public_key_buf[kPentestP384Words * 2];
@@ -609,7 +612,7 @@ status_t cryptolib_sca_p384_ecdh_impl(
   otcrypto_const_word32_buf_t y_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, pub_y, kPentestP384Words);
 
-  TRY(otcrypto_ecc_p384_public_key_import(x_buf, y_buf, &public_key));
+  HARDENED_TRY(otcrypto_ecc_p384_public_key_import(x_buf, y_buf, &public_key));
 
   // Create a destination for the shared secret.
   uint32_t shared_secretblob[kPentestP384Words * 2];
@@ -640,8 +643,8 @@ status_t cryptolib_sca_p384_ecdh_impl(
   otcrypto_word32_buf_t ss_share1_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, ss_share1, ARRAYSIZE(ss_share1));
   uint32_t ss[kPentestP384Words];
-  TRY(otcrypto_export_blinded_key(&shared_secret, &ss_share0_buf,
-                                  &ss_share1_buf));
+  HARDENED_TRY(otcrypto_export_blinded_key(&shared_secret, &ss_share0_buf,
+                                           &ss_share1_buf));
   for (size_t i = 0; i < kPentestP384Words; i++) {
     ss[i] = ss_share0[i] ^ ss_share1[i];
   }
@@ -683,8 +686,8 @@ status_t cryptolib_sca_p384_sign_impl(
   otcrypto_const_word32_buf_t share1_buf = OTCRYPTO_MAKE_BUF(
       otcrypto_const_word32_buf_t, share1, kPentestP384MaskedPrivateKeyWords);
 
-  TRY(otcrypto_ecc_p384_private_key_import(share0_buf, share1_buf,
-                                           &private_key));
+  HARDENED_TRY(otcrypto_ecc_p384_private_key_import(share0_buf, share1_buf,
+                                                    &private_key));
 
   // Create the public key.
   uint32_t public_key_buf[kPentestP384Words * 2];
@@ -704,7 +707,7 @@ status_t cryptolib_sca_p384_sign_impl(
   otcrypto_const_word32_buf_t y_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, pub_y, kPentestP384Words);
 
-  TRY(otcrypto_ecc_p384_public_key_import(x_buf, y_buf, &public_key));
+  HARDENED_TRY(otcrypto_ecc_p384_public_key_import(x_buf, y_buf, &public_key));
 
   // Create a key pair if requested.
   // This will overwrite the private and public key above.
@@ -713,7 +716,7 @@ status_t cryptolib_sca_p384_sign_impl(
     if (uj_input.trigger == 0) {
       pentest_set_trigger_high();
     }
-    TRY(otcrypto_ecdsa_p384_keygen(&private_key, &public_key));
+    HARDENED_TRY(otcrypto_ecdsa_p384_keygen(&private_key, &public_key));
     pentest_set_trigger_low();
     if (uj_input.trigger == 0) {
       pentest_set_trigger_low();
@@ -740,8 +743,8 @@ status_t cryptolib_sca_p384_sign_impl(
   if (uj_input.trigger == 1) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_ecdsa_p384_sign_verify(&private_key, &public_key, message_digest,
-                                      &signature_mut));
+  HARDENED_TRY(otcrypto_ecdsa_p384_sign_verify(&private_key, &public_key,
+                                               message_digest, &signature_mut));
   if (uj_input.trigger == 1) {
     pentest_set_trigger_low();
   }
@@ -765,7 +768,8 @@ status_t cryptolib_sca_p384_sign_impl(
   otcrypto_word32_buf_t out_y_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, out_pub_y, kPentestP384Words);
 
-  TRY(otcrypto_ecc_p384_public_key_export(&public_key, &out_x_buf, &out_y_buf));
+  HARDENED_TRY(
+      otcrypto_ecc_p384_public_key_export(&public_key, &out_x_buf, &out_y_buf));
 
   memcpy(uj_output->pubx, out_pub_x, P384_CMD_BYTES);
   memcpy(uj_output->puby, out_pub_y, P384_CMD_BYTES);
@@ -809,7 +813,8 @@ status_t cryptolib_sca_ed25519_sign_impl(
   if (uj_input.trigger == 0) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_ed25519_public_key_from_private(&private_key, &public_key));
+  HARDENED_TRY(
+      otcrypto_ed25519_public_key_from_private(&private_key, &public_key));
   if (uj_input.trigger == 0) {
     pentest_set_trigger_low();
   }
@@ -828,7 +833,8 @@ status_t cryptolib_sca_ed25519_sign_impl(
   if (uj_input.trigger == 1) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_ed25519_sign_verify(&private_key, &public_key, &input_message,
+  HARDENED_TRY(
+      otcrypto_ed25519_sign_verify(&private_key, &public_key, &input_message,
                                    kOtcryptoEddsaSignModeEddsa, &signature));
   if (uj_input.trigger == 1) {
     pentest_set_trigger_low();
@@ -885,7 +891,7 @@ status_t cryptolib_sca_x25519_base_mul_impl(uint8_t scalar[X25519_CMD_BYTES],
   };
 
   pentest_set_trigger_high();
-  TRY(otcrypto_x25519_keygen(&private_key, &public_key));
+  HARDENED_TRY(otcrypto_x25519_keygen(&private_key, &public_key));
   pentest_set_trigger_low();
 
   *cfg_out = 0;
@@ -944,7 +950,7 @@ status_t cryptolib_sca_x25519_ecdh_impl(
   };
 
   pentest_set_trigger_high();
-  TRY(otcrypto_x25519(&private_key, &public_key, &shared_secret));
+  HARDENED_TRY(otcrypto_x25519(&private_key, &public_key, &shared_secret));
   pentest_set_trigger_low();
 
   uint32_t ss_share0[8];
@@ -954,11 +960,11 @@ status_t cryptolib_sca_x25519_ecdh_impl(
   otcrypto_word32_buf_t ss_share1_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, ss_share1, 8);
 
-  TRY(otcrypto_export_blinded_key(&shared_secret, &ss_share0_buf,
-                                  &ss_share1_buf));
+  HARDENED_TRY(otcrypto_export_blinded_key(&shared_secret, &ss_share0_buf,
+                                           &ss_share1_buf));
 
   uint32_t ss_unmasked[8];
-  TRY(hardened_add(ss_share0, ss_share1, 8, ss_unmasked));
+  HARDENED_TRY(hardened_add(ss_share0, ss_share1, 8, ss_unmasked));
 
   uj_output->cfg = 0;
   memset(uj_output->shared_key, 0, X25519_CMD_BYTES);
@@ -978,7 +984,7 @@ status_t cryptolib_sca_x25519_point_mul_impl(
   ecdh_in.trigger = uj_input.trigger;
 
   cryptolib_sca_asym_x25519_ecdh_out_t ecdh_out;
-  TRY(cryptolib_sca_x25519_ecdh_impl(ecdh_in, &ecdh_out));
+  HARDENED_TRY(cryptolib_sca_x25519_ecdh_impl(ecdh_in, &ecdh_out));
 
   memcpy(uj_output->x, ecdh_out.shared_key, X25519_CMD_BYTES);
   memset(uj_output->y, 0, X25519_CMD_BYTES);
@@ -1016,8 +1022,8 @@ status_t cryptolib_sca_p256_base_mul_impl(uint8_t scalar[P256_CMD_BYTES],
   otcrypto_const_word32_buf_t share1_buf = OTCRYPTO_MAKE_BUF(
       otcrypto_const_word32_buf_t, share1, kPentestP256MaskedPrivateKeyWords);
 
-  TRY(otcrypto_ecc_p256_private_key_import(share0_buf, share1_buf,
-                                           &private_key));
+  HARDENED_TRY(otcrypto_ecc_p256_private_key_import(share0_buf, share1_buf,
+                                                    &private_key));
 
   uint32_t public_key_buf[kPentestP256Words * 2];
   otcrypto_unblinded_key_t public_key = {
@@ -1029,7 +1035,7 @@ status_t cryptolib_sca_p256_base_mul_impl(uint8_t scalar[P256_CMD_BYTES],
   if (trigger) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_ecc_p256_base_point_mult(&private_key, &public_key));
+  HARDENED_TRY(otcrypto_ecc_p256_base_point_mult(&private_key, &public_key));
   if (trigger) {
     pentest_set_trigger_low();
   }
@@ -1041,7 +1047,8 @@ status_t cryptolib_sca_p256_base_mul_impl(uint8_t scalar[P256_CMD_BYTES],
   otcrypto_word32_buf_t out_y_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, out_pub_y, kPentestP256Words);
 
-  TRY(otcrypto_ecc_p256_public_key_export(&public_key, &out_x_buf, &out_y_buf));
+  HARDENED_TRY(
+      otcrypto_ecc_p256_public_key_export(&public_key, &out_x_buf, &out_y_buf));
 
   *cfg_out = 0;
   memset(x, 0, P256_CMD_BYTES);
@@ -1081,8 +1088,8 @@ status_t cryptolib_sca_p384_base_mul_impl(uint8_t scalar[P384_CMD_BYTES],
   otcrypto_const_word32_buf_t share1_buf = OTCRYPTO_MAKE_BUF(
       otcrypto_const_word32_buf_t, share1, kPentestP384MaskedPrivateKeyWords);
 
-  TRY(otcrypto_ecc_p384_private_key_import(share0_buf, share1_buf,
-                                           &private_key));
+  HARDENED_TRY(otcrypto_ecc_p384_private_key_import(share0_buf, share1_buf,
+                                                    &private_key));
 
   uint32_t public_key_buf[kPentestP384Words * 2];
   otcrypto_unblinded_key_t public_key = {
@@ -1094,7 +1101,7 @@ status_t cryptolib_sca_p384_base_mul_impl(uint8_t scalar[P384_CMD_BYTES],
   if (trigger) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_ecc_p384_base_point_mult(&private_key, &public_key));
+  HARDENED_TRY(otcrypto_ecc_p384_base_point_mult(&private_key, &public_key));
   if (trigger) {
     pentest_set_trigger_low();
   }
@@ -1106,7 +1113,8 @@ status_t cryptolib_sca_p384_base_mul_impl(uint8_t scalar[P384_CMD_BYTES],
   otcrypto_word32_buf_t out_y_buf =
       OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, out_pub_y, kPentestP384Words);
 
-  TRY(otcrypto_ecc_p384_public_key_export(&public_key, &out_x_buf, &out_y_buf));
+  HARDENED_TRY(
+      otcrypto_ecc_p384_public_key_export(&public_key, &out_x_buf, &out_y_buf));
 
   *cfg_out = 0;
   memset(x, 0, P384_CMD_BYTES);
@@ -1149,7 +1157,8 @@ status_t cryptolib_sca_ed25519_base_mul_impl(
   if (trigger) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_ed25519_public_key_from_private(&private_key, &public_key));
+  HARDENED_TRY(
+      otcrypto_ed25519_public_key_from_private(&private_key, &public_key));
   if (trigger) {
     pentest_set_trigger_low();
   }

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym_impl.c
@@ -976,19 +976,73 @@ status_t cryptolib_sca_x25519_ecdh_impl(
 status_t cryptolib_sca_x25519_point_mul_impl(
     cryptolib_sca_asym_x25519_point_mul_in_t uj_input,
     cryptolib_sca_asym_x25519_point_mul_out_t *uj_output) {
-  cryptolib_sca_asym_x25519_ecdh_in_t ecdh_in;
-  memcpy(ecdh_in.private_key, uj_input.scalar_alice, X25519_CMD_BYTES);
-  memcpy(ecdh_in.public_x, uj_input.scalar_bob, X25519_CMD_BYTES);
-  memset(ecdh_in.public_y, 0, X25519_CMD_BYTES);
-  ecdh_in.cfg = uj_input.cfg;
-  ecdh_in.trigger = uj_input.trigger;
+  uint32_t private_keyblob[kPentestEd25519MaskedPrivateKeyWords * 2];
+  memset(private_keyblob, 0, sizeof(private_keyblob));
+  // Alice's scalar acts as the private key
+  memcpy(private_keyblob, uj_input.scalar_alice, X25519_CMD_BYTES);
 
-  cryptolib_sca_asym_x25519_ecdh_out_t ecdh_out;
-  HARDENED_TRY(cryptolib_sca_x25519_ecdh_impl(ecdh_in, &ecdh_out));
+  otcrypto_blinded_key_t private_key = {
+      .config =
+          {
+              .version = kOtcryptoLibVersion1,
+              .key_mode = kOtcryptoKeyModeX25519,
+              .key_length = X25519_CMD_BYTES,
+              .hw_backed = kHardenedBoolFalse,
+              .exportable = kHardenedBoolTrue,
+              .security_level = kOtcryptoKeySecurityLevelHigh,
+          },
+      .keyblob_length = sizeof(private_keyblob),
+      .keyblob = private_keyblob,
+  };
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
 
-  memcpy(uj_output->x, ecdh_out.shared_key, X25519_CMD_BYTES);
+  uint32_t public_key_buf[X25519_CMD_BYTES / sizeof(uint32_t)];
+  // Bob's scalar acts as the base point (public key X coordinate)
+  memcpy(public_key_buf, uj_input.scalar_bob, X25519_CMD_BYTES);
+
+  otcrypto_unblinded_key_t public_key = {
+      .key_mode = kOtcryptoKeyModeX25519,
+      .key_length = sizeof(public_key_buf),
+      .key = public_key_buf,
+  };
+  public_key.checksum = otcrypto_integrity_unblinded_checksum(&public_key);
+
+  uint32_t shared_secretblob[16];
+  memset(shared_secretblob, 0, sizeof(shared_secretblob));
+  otcrypto_blinded_key_t shared_secret = {
+      .config =
+          {
+              .version = kOtcryptoLibVersion1,
+              .key_mode = kOtcryptoKeyModeAesCtr,
+              .key_length = X25519_CMD_BYTES,
+              .hw_backed = kHardenedBoolFalse,
+              .exportable = kHardenedBoolTrue,
+              .security_level = kOtcryptoKeySecurityLevelHigh,
+          },
+      .keyblob_length = sizeof(shared_secretblob),
+      .keyblob = shared_secretblob,
+  };
+
+  pentest_set_trigger_high();
+  HARDENED_TRY(otcrypto_x25519(&private_key, &public_key, &shared_secret));
+  pentest_set_trigger_low();
+
+  uint32_t ss_share0[8];
+  uint32_t ss_share1[8];
+  otcrypto_word32_buf_t ss_share0_buf =
+      OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, ss_share0, 8);
+  otcrypto_word32_buf_t ss_share1_buf =
+      OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, ss_share1, 8);
+
+  HARDENED_TRY(otcrypto_export_blinded_key(&shared_secret, &ss_share0_buf,
+                                           &ss_share1_buf));
+
+  uint32_t ss_unmasked[8];
+  HARDENED_TRY(hardened_add(ss_share0, ss_share1, 8, ss_unmasked));
+
+  uj_output->cfg = 0;
+  memcpy(uj_output->x, ss_unmasked, X25519_CMD_BYTES);
   memset(uj_output->y, 0, X25519_CMD_BYTES);
-  uj_output->cfg = ecdh_out.cfg;
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_sym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_sym_impl.c
@@ -154,6 +154,8 @@ status_t cryptolib_sca_aes_impl(uint8_t data_in[AES_CMD_MAX_MSG_BYTES],
                    &output));
   pentest_set_trigger_low();
 
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&output));
+
   // Return data back to host.
   *data_out_len = padded_len_bytes;
   *cfg_out = 0;
@@ -187,6 +189,8 @@ status_t cryptolib_sca_drbg_generate_impl(
   if (trigger & kPentestTrigger2) {
     pentest_set_trigger_low();
   }
+
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&output));
 
   // Return data back to host.
   *cfg_out = 0;
@@ -319,6 +323,9 @@ status_t cryptolib_sca_gcm_impl(
                                gcm_tag_len, &actual_ciphertext, &actual_tag));
   pentest_set_trigger_low();
 
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&actual_ciphertext));
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&actual_tag));
+
   // Return data back to host.
   *cfg_out = 0;
   // Ciphertext.
@@ -420,6 +427,8 @@ status_t cryptolib_sca_hmac_impl(uint8_t data_in[HMAC_CMD_MAX_MSG_BYTES],
   TRY(otcrypto_hmac(&hmac_key, &input_message, &tag));
   pentest_set_trigger_low();
 
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&tag));
+
   // Return data back to host.
   *data_out_len = tag_bytes;
   *cfg_out = 0;
@@ -496,6 +505,8 @@ status_t cryptolib_sca_cmac_impl(uint8_t data_in[AES_CMD_MAX_MSG_BYTES],
   pentest_set_trigger_high();
   TRY(otcrypto_cmac(&cmac_key, &input_message, &tag));
   pentest_set_trigger_low();
+
+  HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&tag));
 
   // Return data back to host.
   *data_out_len = tag_bytes;

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_sym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_sym_impl.c
@@ -6,6 +6,7 @@
 
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/aes.h"
 #include "sw/device/lib/crypto/include/aes_gcm.h"
 #include "sw/device/lib/crypto/include/cmac.h"
@@ -150,8 +151,8 @@ status_t cryptolib_sca_aes_impl(uint8_t data_in[AES_CMD_MAX_MSG_BYTES],
 
   // Trigger window.
   pentest_set_trigger_high();
-  TRY(otcrypto_aes(&aes_key, &aes_iv, aes_mode, op, &input, aes_padding,
-                   &output));
+  HARDENED_TRY(otcrypto_aes(&aes_key, &aes_iv, aes_mode, op, &input,
+                            aes_padding, &output));
   pentest_set_trigger_low();
 
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&output));
@@ -185,7 +186,7 @@ status_t cryptolib_sca_drbg_generate_impl(
   if (trigger & kPentestTrigger2) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_drbg_generate(&nonce_in, &output));
+  HARDENED_TRY(otcrypto_drbg_generate(&nonce_in, &output));
   if (trigger & kPentestTrigger2) {
     pentest_set_trigger_low();
   }
@@ -216,7 +217,7 @@ status_t cryptolib_sca_drbg_reseed_impl(
   if (trigger & kPentestTrigger1) {
     pentest_set_trigger_high();
   }
-  TRY(otcrypto_drbg_instantiate(&entropy_in));
+  HARDENED_TRY(otcrypto_drbg_instantiate(&entropy_in));
   if (trigger & kPentestTrigger1) {
     pentest_set_trigger_low();
   }
@@ -319,8 +320,9 @@ status_t cryptolib_sca_gcm_impl(
 
   // Trigger window.
   pentest_set_trigger_high();
-  TRY(otcrypto_aes_gcm_encrypt(&gcm_key, &plaintext, &gcm_iv, &gcm_aad,
-                               gcm_tag_len, &actual_ciphertext, &actual_tag));
+  HARDENED_TRY(otcrypto_aes_gcm_encrypt(&gcm_key, &plaintext, &gcm_iv, &gcm_aad,
+                                        gcm_tag_len, &actual_ciphertext,
+                                        &actual_tag));
   pentest_set_trigger_low();
 
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&actual_ciphertext));
@@ -424,7 +426,7 @@ status_t cryptolib_sca_hmac_impl(uint8_t data_in[HMAC_CMD_MAX_MSG_BYTES],
 
   // Trigger window.
   pentest_set_trigger_high();
-  TRY(otcrypto_hmac(&hmac_key, &input_message, &tag));
+  HARDENED_TRY(otcrypto_hmac(&hmac_key, &input_message, &tag));
   pentest_set_trigger_low();
 
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&tag));
@@ -503,7 +505,7 @@ status_t cryptolib_sca_cmac_impl(uint8_t data_in[AES_CMD_MAX_MSG_BYTES],
 
   // Trigger window.
   pentest_set_trigger_high();
-  TRY(otcrypto_cmac(&cmac_key, &input_message, &tag));
+  HARDENED_TRY(otcrypto_cmac(&cmac_key, &input_message, &tag));
   pentest_set_trigger_low();
 
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(&tag));

--- a/sw/device/tests/penetrationtests/json/cryptolib_fi_asym_commands.h
+++ b/sw/device/tests/penetrationtests/json/cryptolib_fi_asym_commands.h
@@ -69,6 +69,7 @@ RUST_ONLY(UJSON_SERDE_ENUM(CryptoLibFiAsymSubcommand, cryptolib_fi_asym_subcomma
 UJSON_SERDE_STRUCT(CryptoLibFiAsymRsaEncIn, cryptolib_fi_asym_rsa_enc_in_t, CRYPTOLIBFIASYM_RSA_ENC_IN);
 
 #define CRYPTOLIBFIASYM_RSA_ENC_OUT(field, string) \
+    field(magic, uint32_t) \
     field(n, uint8_t, RSA_CMD_MAX_N_BYTES) \
     field(d, uint8_t, RSA_CMD_MAX_N_BYTES) \
     field(n_len, size_t) \
@@ -96,6 +97,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymRsaEncOut, cryptolib_fi_asym_rsa_enc_out_t, CR
 UJSON_SERDE_STRUCT(CryptoLibFiAsymRsaSignIn, cryptolib_fi_asym_rsa_sign_in_t, CRYPTOLIBFIASYM_RSA_SIGN_IN);
 
 #define CRYPTOLIBFIASYM_RSA_SIGN_OUT(field, string) \
+    field(magic, uint32_t) \
     field(n, uint8_t, RSA_CMD_MAX_N_BYTES) \
     field(d, uint8_t, RSA_CMD_MAX_N_BYTES) \
     field(n_len, size_t) \
@@ -124,6 +126,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymRsaSignOut, cryptolib_fi_asym_rsa_sign_out_t, 
 UJSON_SERDE_STRUCT(CryptoLibFiAsymRsaVerifyIn, cryptolib_fi_asym_rsa_verify_in_t, CRYPTOLIBFIASYM_RSA_VERIFY_IN);
 
 #define CRYPTOLIBFIASYM_RSA_VERIFY_OUT(field, string) \
+    field(magic, uint32_t) \
     field(result, bool) \
     field(status, size_t) \
     field(alerts, uint32_t, 3) \
@@ -140,6 +143,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymRsaVerifyOut, cryptolib_fi_asym_rsa_verify_out
 UJSON_SERDE_STRUCT(CryptoLibFiAsymPrimeIn, cryptolib_fi_asym_prime_in_t, CRYPTOLIBFIASYM_PRIME_IN);
 
 #define CRYPTOLIBFIASYM_PRIME_OUT(field, string) \
+    field(magic, uint32_t) \
     field(prime, uint8_t, RSA_CMD_MAX_N_BYTES) \
     field(prime_len, size_t) \
     field(status, size_t) \
@@ -157,6 +161,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymPrimeOut, cryptolib_fi_asym_prime_out_t, CRYPT
 UJSON_SERDE_STRUCT(CryptoLibFiAsymP256BaseMulIn, cryptolib_fi_asym_p256_base_mul_in_t, CRYPTOLIBFIASYM_P256_BASE_MUL_IN);
 
 #define CRYPTOLIBFIASYM_P256_BASE_MUL_OUT(field, string) \
+    field(magic, uint32_t) \
     field(x, uint8_t, P256_CMD_BYTES) \
     field(y, uint8_t, P256_CMD_BYTES) \
     field(status, size_t) \
@@ -175,6 +180,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymP256BaseMulOut, cryptolib_fi_asym_p256_base_mu
 UJSON_SERDE_STRUCT(CryptoLibFiAsymP256PointMulIn, cryptolib_fi_asym_p256_point_mul_in_t, CRYPTOLIBFIASYM_P256_POINT_MUL_IN);
 
 #define CRYPTOLIBFIASYM_P256_POINT_MUL_OUT(field, string) \
+    field(magic, uint32_t) \
     field(x, uint8_t, P256_CMD_BYTES) \
     field(y, uint8_t, P256_CMD_BYTES) \
     field(status, size_t) \
@@ -194,6 +200,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymP256PointMulOut, cryptolib_fi_asym_p256_point_
 UJSON_SERDE_STRUCT(CryptoLibFiAsymP256EcdhIn, cryptolib_fi_asym_p256_ecdh_in_t, CRYPTOLIBFIASYM_P256_ECDH_IN);
 
 #define CRYPTOLIBFIASYM_P256_ECDH_OUT(field, string) \
+    field(magic, uint32_t) \
     field(shared_key, uint8_t, P256_CMD_BYTES) \
     field(status, size_t) \
     field(alerts, uint32_t, 3) \
@@ -213,6 +220,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymP256EcdhOut, cryptolib_fi_asym_p256_ecdh_out_t
 UJSON_SERDE_STRUCT(CryptoLibFiAsymP256SignIn, cryptolib_fi_asym_p256_sign_in_t, CRYPTOLIBFIASYM_P256_SIGN_IN);
 
 #define CRYPTOLIBFIASYM_P256_SIGN_OUT(field, string) \
+    field(magic, uint32_t) \
     field(r, uint8_t, P256_CMD_BYTES) \
     field(s, uint8_t, P256_CMD_BYTES) \
     field(pubx, uint8_t, P256_CMD_BYTES) \
@@ -236,6 +244,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymP256SignOut, cryptolib_fi_asym_p256_sign_out_t
 UJSON_SERDE_STRUCT(CryptoLibFiAsymP256VerifyIn, cryptolib_fi_asym_p256_verify_in_t, CRYPTOLIBFIASYM_P256_VERIFY_IN);
 
 #define CRYPTOLIBFIASYM_P256_VERIFY_OUT(field, string) \
+    field(magic, uint32_t) \
     field(result, bool) \
     field(status, size_t) \
     field(alerts, uint32_t, 3) \
@@ -252,6 +261,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymP256VerifyOut, cryptolib_fi_asym_p256_verify_o
 UJSON_SERDE_STRUCT(CryptoLibFiAsymP384BaseMulIn, cryptolib_fi_asym_p384_base_mul_in_t, CRYPTOLIBFIASYM_P384_BASE_MUL_IN);
 
 #define CRYPTOLIBFIASYM_P384_BASE_MUL_OUT(field, string) \
+    field(magic, uint32_t) \
     field(x, uint8_t, P384_CMD_BYTES) \
     field(y, uint8_t, P384_CMD_BYTES) \
     field(status, size_t) \
@@ -270,6 +280,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymP384BaseMulOut, cryptolib_fi_asym_p384_base_mu
 UJSON_SERDE_STRUCT(CryptoLibFiAsymP384PointMulIn, cryptolib_fi_asym_p384_point_mul_in_t, CRYPTOLIBFIASYM_P384_POINT_MUL_IN);
 
 #define CRYPTOLIBFIASYM_P384_POINT_MUL_OUT(field, string) \
+    field(magic, uint32_t) \
     field(x, uint8_t, P384_CMD_BYTES) \
     field(y, uint8_t, P384_CMD_BYTES) \
     field(status, size_t) \
@@ -289,6 +300,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymP384PointMulOut, cryptolib_fi_asym_p384_point_
 UJSON_SERDE_STRUCT(CryptoLibFiAsymP384EcdhIn, cryptolib_fi_asym_p384_ecdh_in_t, CRYPTOLIBFIASYM_P384_ECDH_IN);
 
 #define CRYPTOLIBFIASYM_P384_ECDH_OUT(field, string) \
+    field(magic, uint32_t) \
     field(shared_key, uint8_t, P384_CMD_BYTES) \
     field(status, size_t) \
     field(alerts, uint32_t, 3) \
@@ -308,6 +320,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymP384EcdhOut, cryptolib_fi_asym_p384_ecdh_out_t
 UJSON_SERDE_STRUCT(CryptoLibFiAsymP384SignIn, cryptolib_fi_asym_p384_sign_in_t, CRYPTOLIBFIASYM_P384_SIGN_IN);
 
 #define CRYPTOLIBFIASYM_P384_SIGN_OUT(field, string) \
+    field(magic, uint32_t) \
     field(r, uint8_t, P384_CMD_BYTES) \
     field(s, uint8_t, P384_CMD_BYTES) \
     field(pubx, uint8_t, P384_CMD_BYTES) \
@@ -331,6 +344,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymP384SignOut, cryptolib_fi_asym_p384_sign_out_t
 UJSON_SERDE_STRUCT(CryptoLibFiAsymP384VerifyIn, cryptolib_fi_asym_p384_verify_in_t, CRYPTOLIBFIASYM_P384_VERIFY_IN);
 
 #define CRYPTOLIBFIASYM_P384_VERIFY_OUT(field, string) \
+    field(magic, uint32_t) \
     field(result, bool) \
     field(status, size_t) \
     field(alerts, uint32_t, 3) \
@@ -347,6 +361,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymP384VerifyOut, cryptolib_fi_asym_p384_verify_o
 UJSON_SERDE_STRUCT(CryptoLibFiAsymSECP256K1BaseMulIn, cryptolib_fi_asym_secp256k1_base_mul_in_t, CRYPTOLIBFIASYM_SECP256K1_BASE_MUL_IN);
 
 #define CRYPTOLIBFIASYM_SECP256K1_BASE_MUL_OUT(field, string) \
+    field(magic, uint32_t) \
     field(x, uint8_t, SECP256K1_CMD_BYTES) \
     field(y, uint8_t, SECP256K1_CMD_BYTES) \
     field(status, size_t) \
@@ -365,6 +380,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymSECP256K1BaseMulOut, cryptolib_fi_asym_secp256
 UJSON_SERDE_STRUCT(CryptoLibFiAsymSECP256K1PointMulIn, cryptolib_fi_asym_secp256k1_point_mul_in_t, CRYPTOLIBFIASYM_SECP256K1_POINT_MUL_IN);
 
 #define CRYPTOLIBFIASYM_SECP256K1_POINT_MUL_OUT(field, string) \
+    field(magic, uint32_t) \
     field(x, uint8_t, SECP256K1_CMD_BYTES) \
     field(y, uint8_t, SECP256K1_CMD_BYTES) \
     field(status, size_t) \
@@ -384,6 +400,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymSECP256K1PointMulOut, cryptolib_fi_asym_secp25
 UJSON_SERDE_STRUCT(CryptoLibFiAsymSECP256K1EcdhIn, cryptolib_fi_asym_secp256k1_ecdh_in_t, CRYPTOLIBFIASYM_SECP256K1_ECDH_IN);
 
 #define CRYPTOLIBFIASYM_SECP256K1_ECDH_OUT(field, string) \
+    field(magic, uint32_t) \
     field(shared_key, uint8_t, SECP256K1_CMD_BYTES) \
     field(status, size_t) \
     field(alerts, uint32_t, 3) \
@@ -401,6 +418,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymSECP256K1EcdhOut, cryptolib_fi_asym_secp256k1_
 UJSON_SERDE_STRUCT(CryptoLibFiAsymSECP256K1SignIn, cryptolib_fi_asym_secp256k1_sign_in_t, CRYPTOLIBFIASYM_SECP256K1_SIGN_IN);
 
 #define CRYPTOLIBFIASYM_SECP256K1_SIGN_OUT(field, string) \
+    field(magic, uint32_t) \
     field(r, uint8_t, SECP256K1_CMD_BYTES) \
     field(s, uint8_t, SECP256K1_CMD_BYTES) \
     field(pubx, uint8_t, SECP256K1_CMD_BYTES) \
@@ -424,6 +442,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymSECP256K1SignOut, cryptolib_fi_asym_secp256k1_
 UJSON_SERDE_STRUCT(CryptoLibFiAsymSECP256K1VerifyIn, cryptolib_fi_asym_secp256k1_verify_in_t, CRYPTOLIBFIASYM_SECP256K1_VERIFY_IN);
 
 #define CRYPTOLIBFIASYM_SECP256K1_VERIFY_OUT(field, string) \
+    field(magic, uint32_t) \
     field(result, bool) \
     field(status, size_t) \
     field(alerts, uint32_t, 3) \
@@ -440,6 +459,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymSECP256K1VerifyOut, cryptolib_fi_asym_secp256k
 UJSON_SERDE_STRUCT(CryptoLibFiAsymX25519BaseMulIn, cryptolib_fi_asym_x25519_base_mul_in_t, CRYPTOLIBFIASYM_X25519_BASE_MUL_IN);
 
 #define CRYPTOLIBFIASYM_X25519_BASE_MUL_OUT(field, string) \
+    field(magic, uint32_t) \
     field(x, uint8_t, X25519_CMD_BYTES) \
     field(y, uint8_t, X25519_CMD_BYTES) \
     field(status, size_t) \
@@ -458,6 +478,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymX25519BaseMulOut, cryptolib_fi_asym_x25519_bas
 UJSON_SERDE_STRUCT(CryptoLibFiAsymX25519PointMulIn, cryptolib_fi_asym_x25519_point_mul_in_t, CRYPTOLIBFIASYM_X25519_POINT_MUL_IN);
 
 #define CRYPTOLIBFIASYM_X25519_POINT_MUL_OUT(field, string) \
+    field(magic, uint32_t) \
     field(x, uint8_t, X25519_CMD_BYTES) \
     field(y, uint8_t, X25519_CMD_BYTES) \
     field(status, size_t) \
@@ -477,6 +498,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymX25519PointMulOut, cryptolib_fi_asym_x25519_po
 UJSON_SERDE_STRUCT(CryptoLibFiAsymX25519EcdhIn, cryptolib_fi_asym_x25519_ecdh_in_t, CRYPTOLIBFIASYM_X25519_ECDH_IN);
 
 #define CRYPTOLIBFIASYM_X25519_ECDH_OUT(field, string) \
+    field(magic, uint32_t) \
     field(shared_key, uint8_t, X25519_CMD_BYTES) \
     field(status, size_t) \
     field(alerts, uint32_t, 3) \
@@ -493,6 +515,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymX25519EcdhOut, cryptolib_fi_asym_x25519_ecdh_o
 UJSON_SERDE_STRUCT(CryptoLibFiAsymED25519BaseMulIn, cryptolib_fi_asym_ed25519_base_mul_in_t, CRYPTOLIBFIASYM_ED25519_BASE_MUL_IN);
 
 #define CRYPTOLIBFIASYM_ED25519_BASE_MUL_OUT(field, string) \
+    field(magic, uint32_t) \
     field(x, uint8_t, ED25519_CMD_SCALAR_BYTES) \
     field(y, uint8_t, ED25519_CMD_SCALAR_BYTES) \
     field(status, size_t) \
@@ -512,6 +535,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymED25519BaseMulOut, cryptolib_fi_asym_ed25519_b
 UJSON_SERDE_STRUCT(CryptoLibFiAsymED25519SignIn, cryptolib_fi_asym_ed25519_sign_in_t, CRYPTOLIBFIASYM_ED25519_SIGN_IN);
 
 #define CRYPTOLIBFIASYM_ED25519_SIGN_OUT(field, string) \
+    field(magic, uint32_t) \
     field(r, uint8_t, ED25519_CMD_SIG_BYTES) \
     field(s, uint8_t, ED25519_CMD_SIG_BYTES) \
     field(pubx, uint8_t, ED25519_CMD_SCALAR_BYTES) \
@@ -536,6 +560,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiAsymED25519SignOut, cryptolib_fi_asym_ed25519_sign
 UJSON_SERDE_STRUCT(CryptoLibFiAsymED25519VerifyIn, cryptolib_fi_asym_ed25519_verify_in_t, CRYPTOLIBFIASYM_ED25519_VERIFY_IN);
 
 #define CRYPTOLIBFIASYM_ED25519_VERIFY_OUT(field, string) \
+    field(magic, uint32_t) \
     field(result, bool) \
     field(status, size_t) \
     field(alerts, uint32_t, 3) \

--- a/sw/device/tests/penetrationtests/json/cryptolib_fi_sym_commands.h
+++ b/sw/device/tests/penetrationtests/json/cryptolib_fi_sym_commands.h
@@ -57,6 +57,7 @@ RUST_ONLY(UJSON_SERDE_ENUM(CryptoLibFiSymSubcommand, cryptolib_fi_sym_subcommand
 UJSON_SERDE_STRUCT(CryptoLibFiSymAesIn, cryptolib_fi_sym_aes_in_t, CRYPTOLIBFISYM_AES_IN);
 
 #define CRYPTOLIBFISYM_AES_OUT(field, string) \
+    field(magic, uint32_t) \
     field(data, uint8_t, AES_CMD_MAX_MSG_BYTES) \
     field(data_len, size_t) \
     field(status, size_t) \
@@ -78,6 +79,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiSymAesOut, cryptolib_fi_sym_aes_out_t, CRYPTOLIBFI
 UJSON_SERDE_STRUCT(CryptoLibFiSymCmacIn, cryptolib_fi_sym_cmac_in_t, CRYPTOLIBFISYM_CMAC_IN);
 
 #define CRYPTOLIBFISYM_CMAC_OUT(field, string) \
+    field(magic, uint32_t) \
     field(data, uint8_t, AES_CMD_MAX_MSG_BYTES) \
     field(data_len, size_t) \
     field(status, size_t) \
@@ -103,6 +105,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiSymCmacOut, cryptolib_fi_sym_cmac_out_t, CRYPTOLIB
 UJSON_SERDE_STRUCT(CryptoLibFiSymGcmIn, cryptolib_fi_sym_gcm_in_t, CRYPTOLIBFISYM_GCM_IN);
 
 #define CRYPTOLIBFISYM_GCM_OUT(field, string) \
+    field(magic, uint32_t) \
     field(data, uint8_t, AES_CMD_MAX_MSG_BYTES) \
     field(data_len, size_t) \
     field(tag, uint8_t, AES_CMD_MAX_MSG_BYTES) \
@@ -129,6 +132,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiSymGcmOut, cryptolib_fi_sym_gcm_out_t, CRYPTOLIBFI
 UJSON_SERDE_STRUCT(CryptoLibFiSymTdesIn, cryptolib_fi_sym_tdes_in_t, CRYPTOLIBFISYM_TDES_IN);
 
 #define CRYPTOLIBFISYM_TDES_OUT(field, string) \
+    field(magic, uint32_t) \
     field(data, uint8_t, TDES_CMD_MAX_MSG_BYTES) \
     field(data_len, size_t) \
     field(status, size_t) \
@@ -151,6 +155,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiSymTdesOut, cryptolib_fi_sym_tdes_out_t, CRYPTOLIB
 UJSON_SERDE_STRUCT(CryptoLibFiSymHmacIn, cryptolib_fi_sym_hmac_in_t, CRYPTOLIBFISYM_HMAC_IN);
 
 #define CRYPTOLIBFISYM_HMAC_OUT(field, string) \
+    field(magic, uint32_t) \
     field(data, uint8_t, HMAC_CMD_MAX_TAG_BYTES) \
     field(data_len, size_t) \
     field(status, size_t) \
@@ -182,6 +187,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiSymDrbgGenerateIn, cryptolib_fi_sym_drbg_generate_
 UJSON_SERDE_STRUCT(CryptoLibFiSymDrbgReseedIn, cryptolib_fi_sym_drbg_reseed_in_t, CRYPTOLIBFISYM_DRBG_RESEED_IN);
 
 #define CRYPTOLIBFISYM_DRBG_GENERATE_OUT(field, string) \
+    field(magic, uint32_t) \
     field(data, uint8_t, DRBG_CMD_MAX_OUTPUT_BYTES) \
     field(status, size_t) \
     field(alerts, uint32_t, 3) \
@@ -192,6 +198,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiSymDrbgReseedIn, cryptolib_fi_sym_drbg_reseed_in_t
 UJSON_SERDE_STRUCT(CryptoLibFiSymDrbgGenerateOut, cryptolib_fi_sym_drbg_generate_out_t, CRYPTOLIBFISYM_DRBG_GENERATE_OUT);
 
 #define CRYPTOLIBFISYM_DRBG_RESEED_OUT(field, string) \
+    field(magic, uint32_t) \
     field(status, size_t) \
     field(alerts, uint32_t, 3) \
     field(loc_alerts, uint32_t) \
@@ -212,6 +219,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiSymTrngGenerateIn, cryptolib_fi_sym_trng_generate_
 UJSON_SERDE_STRUCT(CryptoLibFiSymTrngInitIn, cryptolib_fi_sym_trng_init_in_t, CRYPTOLIBFISYM_TRNG_INIT_IN);
 
 #define CRYPTOLIBFISYM_TRNG_GENERATE_OUT(field, string) \
+    field(magic, uint32_t) \
     field(data, uint8_t, TRNG_CMD_MAX_OUTPUT_BYTES) \
     field(status, size_t) \
     field(alerts, uint32_t, 3) \
@@ -222,6 +230,7 @@ UJSON_SERDE_STRUCT(CryptoLibFiSymTrngInitIn, cryptolib_fi_sym_trng_init_in_t, CR
 UJSON_SERDE_STRUCT(CryptoLibFiSymTrngGenerateOut, cryptolib_fi_sym_trng_generate_out_t, CRYPTOLIBFISYM_TRNG_GENERATE_OUT);
 
 #define CRYPTOLIBFISYM_TRNG_INIT_OUT(field, string) \
+    field(magic, uint32_t) \
     field(status, size_t) \
     field(alerts, uint32_t, 3) \
     field(loc_alerts, uint32_t) \

--- a/sw/host/penetrationtests/python/fi/test_scripts/fi_asym_cryptolib_python_test.py
+++ b/sw/host/penetrationtests/python/fi/test_scripts/fi_asym_cryptolib_python_test.py
@@ -19,7 +19,7 @@ from Crypto.PublicKey import RSA, ECC
 from Crypto.Signature import pkcs1_15, DSS
 from Crypto.Hash import SHA256, SHA384
 
-ignored_keys_set = set([])
+ignored_keys_set = set(["magic"])
 opentitantool_path = ""
 iterations = 1
 repetitions = 3

--- a/sw/host/penetrationtests/python/fi/test_scripts/fi_sym_cryptolib_python_test.py
+++ b/sw/host/penetrationtests/python/fi/test_scripts/fi_sym_cryptolib_python_test.py
@@ -18,7 +18,7 @@ import random
 from Crypto.Hash import SHA256, HMAC, CMAC
 from Crypto.Cipher import AES
 
-ignored_keys_set = set([])
+ignored_keys_set = set(["magic"])
 opentitantool_path = ""
 iterations = 3
 repetitions = 3

--- a/sw/host/tests/penetrationtests/pentest_lib/src/lib.rs
+++ b/sw/host/tests/penetrationtests/pentest_lib/src/lib.rs
@@ -51,6 +51,8 @@ pub fn filter_response_common(
     map.remove("retention_ram_initialized");
     map.remove("bl0");
     map.remove("rom_ext");
+    // Contains a magic value to check if the command ran properly
+    map.remove("magic");
 
     map
 }


### PR DESCRIPTION
- Add a hardened TRY macro for pentest and use it
- Verify output buffers in pentest using OTCRYPTO_CHECK_BUF
- Add a magic value to the output structure to verify it
- In order to use that output structure's magic value, rewrite x25519 point mult to not call the pentest one