### PR TITLE
[crypto] Launder OK status for leaf nodes

### DIFF
--- a/sw/device/lib/crypto/drivers/aes.c
+++ b/sw/device/lib/crypto/drivers/aes.c
@@ -234,7 +234,7 @@ status_t aes_verify_ctrl_aux_reg(void) {
   HARDENED_CHECK_EQ(abs_mmio_read32(kBase + AES_CTRL_AUX_SHADOWED_REG_OFFSET),
                     launder32(ctrl_aux_reg));
 
-  return OTCRYPTO_OK;
+  return LAUNDERED_OTCRYPTO_OK;
 }
 
 /**

--- a/sw/device/lib/crypto/drivers/aes.c
+++ b/sw/device/lib/crypto/drivers/aes.c
@@ -57,11 +57,11 @@ static status_t spin_until(uint32_t bit) {
  */
 static status_t aes_write_key(aes_key_t key) {
   if (key.sideload != kHardenedBoolFalse) {
-    HARDENED_CHECK_EQ(key.sideload, kHardenedBoolTrue);
+    HARDENED_CHECK_EQ(key.sideload, launder32(kHardenedBoolTrue));
     // Nothing to be done; key must be separately loaded from keymgr.
     return OTCRYPTO_OK;
   }
-  HARDENED_CHECK_EQ(key.sideload, kHardenedBoolFalse);
+  HARDENED_CHECK_EQ(key.sideload, launder32(kHardenedBoolFalse));
 
   uint32_t share0 = kBase + AES_KEY_SHARE0_0_REG_OFFSET;
   uint32_t share1 = kBase + AES_KEY_SHARE1_0_REG_OFFSET;

--- a/sw/device/lib/crypto/drivers/hmac.c
+++ b/sw/device/lib/crypto/drivers/hmac.c
@@ -172,7 +172,7 @@ static status_t clear(void) {
   // Use a random value from EDN to wipe HMAC.
   abs_mmio_write32(kHmacBaseAddr + HMAC_WIPE_SECRET_REG_OFFSET,
                    (uint32_t)ibex_rnd32_read());
-  return OTCRYPTO_OK;
+  return LAUNDERED_OTCRYPTO_OK;
 }
 
 /**
@@ -347,7 +347,7 @@ static status_t msg_fifo_write(const uint8_t *message, size_t message_len) {
   // Check that the loops ran for the correct number of iterations.
   HARDENED_CHECK_EQ(i, message_len);
 
-  return OTCRYPTO_OK;
+  return LAUNDERED_OTCRYPTO_OK;
 }
 
 /**

--- a/sw/device/lib/crypto/drivers/keymgr.c
+++ b/sw/device/lib/crypto/drivers/keymgr.c
@@ -66,7 +66,7 @@ static status_t keymgr_start(keymgr_diversification_t diversification) {
   abs_mmio_write32(kBaseAddr + KEYMGR_START_REG_OFFSET,
                    1 << KEYMGR_START_EN_BIT);
 
-  return OTCRYPTO_OK;
+  return LAUNDERED_OTCRYPTO_OK;
 }
 
 /**

--- a/sw/device/lib/crypto/drivers/kmac.c
+++ b/sw/device/lib/crypto/drivers/kmac.c
@@ -417,7 +417,7 @@ static status_t little_endian_encode(size_t value, uint8_t *encoding_buf,
     encoding_buf[idx] = reverse_buf[len - 1 - idx];
   }
 
-  return OTCRYPTO_OK;
+  return LAUNDERED_OTCRYPTO_OK;
 }
 
 /**

--- a/sw/device/lib/crypto/drivers/rv_core_ibex.c
+++ b/sw/device/lib/crypto/drivers/rv_core_ibex.c
@@ -53,7 +53,7 @@ hardened_bool_t ibex_check_security_config(void) {
 
 status_t ibex_set_security_config(void) {
   CSR_SET_BITS(CSR_REG_CPUCTRL, kExpectedConfig << kIdx);
-  return OTCRYPTO_OK;
+  return LAUNDERED_OTCRYPTO_OK;
 }
 
 /**
@@ -87,7 +87,7 @@ status_t ibex_disable_icache(hardened_bool_t *icache_enabled) {
     HARDENED_CHECK_EQ(launder32(*icache_enabled), kHardenedBoolFalse);
   }
 
-  return OTCRYPTO_OK;
+  return LAUNDERED_OTCRYPTO_OK;
 }
 
 void ibex_restore_icache(hardened_bool_t icache_enabled) {

--- a/sw/device/lib/crypto/impl/aes_gcm.c
+++ b/sw/device/lib/crypto/impl/aes_gcm.c
@@ -244,12 +244,8 @@ status_t aes_gcm_check_tag_length(size_t word_len,
 static status_t load_key_if_sideloaded(const aes_key_t key) {
   if (launder32(key.sideload) == kHardenedBoolFalse) {
     return OTCRYPTO_OK;
-  } else if (key.sideload != kHardenedBoolTrue) {
-    // COVERAGE (SW ERR) This is an internal function, the aes key's sideload is
-    // set internal by good parameters.
-    return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(key.sideload, kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(key.sideload, launder32(kHardenedBoolTrue));
   keymgr_diversification_t diversification;
   HARDENED_TRY(keyblob_buffer_to_keymgr_diversification(
       key.key_shares[0], kOtcryptoKeyModeAesGcm, &diversification));
@@ -269,14 +265,14 @@ static status_t load_key_if_sideloaded(const aes_key_t key) {
  */
 static status_t clear_key_if_sideloaded(const aes_key_t key) {
   if (launder32(key.sideload) == kHardenedBoolFalse) {
-    HARDENED_CHECK_EQ(key.sideload, kHardenedBoolFalse);
+    HARDENED_CHECK_EQ(key.sideload, launder32(kHardenedBoolFalse));
     return OTCRYPTO_OK;
   } else if (launder32(key.sideload) != kHardenedBoolTrue) {
     // COVERAGE (SW ERR) This is an internal function, the aes key's sideload is
     // set internal by good parameters.
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(key.sideload, kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(key.sideload, launder32(kHardenedBoolTrue));
   return keymgr_sideload_clear_aes();
 }
 

--- a/sw/device/lib/crypto/impl/aes_gcm/aes_gcm.c
+++ b/sw/device/lib/crypto/impl/aes_gcm/aes_gcm.c
@@ -341,7 +341,8 @@ static status_t aes_gcm_get_tag(aes_gcm_context_t *ctx, size_t tag_len,
     HARDENED_TRY(ghash_update_redundant(&ctx->ghash_ctx, kAesBlockNumBytes,
                                         (unsigned char *)last_block));
   } else {
-    HARDENED_CHECK_EQ(ctx->security_level, kOtcryptoKeySecurityLevelLow);
+    HARDENED_CHECK_EQ(ctx->security_level,
+                      launder32(kOtcryptoKeySecurityLevelLow));
     ghash_update(&ctx->ghash_ctx, kAesBlockNumBytes,
                  (unsigned char *)last_block);
   }
@@ -513,7 +514,8 @@ status_t aes_gcm_update_encrypted_data(aes_gcm_context_t *ctx, size_t input_len,
           &ctx->ghash_ctx, partial_ghash_block_len,
           (unsigned char *)ctx->partial_ghash_block.data));
     } else {
-      HARDENED_CHECK_EQ(ctx->security_level, kOtcryptoKeySecurityLevelLow);
+      HARDENED_CHECK_EQ(ctx->security_level,
+                        launder32(kOtcryptoKeySecurityLevelLow));
       ghash_update(&ctx->ghash_ctx, partial_ghash_block_len,
                    (unsigned char *)ctx->partial_ghash_block.data);
     }
@@ -575,7 +577,8 @@ status_t aes_gcm_final(aes_gcm_context_t *ctx, size_t tag_len, uint32_t *tag,
           &ctx->ghash_ctx, partial_ghash_block_len,
           (unsigned char *)ctx->partial_ghash_block.data));
     } else {
-      HARDENED_CHECK_EQ(ctx->security_level, kOtcryptoKeySecurityLevelLow);
+      HARDENED_CHECK_EQ(ctx->security_level,
+                        launder32(kOtcryptoKeySecurityLevelLow));
       ghash_update(&ctx->ghash_ctx, partial_ghash_block_len,
                    (unsigned char *)ctx->partial_ghash_block.data);
     }
@@ -611,7 +614,8 @@ status_t aes_gcm_final(aes_gcm_context_t *ctx, size_t tag_len, uint32_t *tag,
         HARDENED_TRY(ghash_update_redundant(&ctx->ghash_ctx, *output_len,
                                             (unsigned char *)output));
       } else {
-        HARDENED_CHECK_EQ(ctx->security_level, kOtcryptoKeySecurityLevelLow);
+        HARDENED_CHECK_EQ(ctx->security_level,
+                          launder32(kOtcryptoKeySecurityLevelLow));
         ghash_update(&ctx->ghash_ctx, *output_len, (unsigned char *)output);
       }
     }
@@ -625,7 +629,8 @@ status_t aes_gcm_final(aes_gcm_context_t *ctx, size_t tag_len, uint32_t *tag,
           &ctx->ghash_ctx, partial_ghash_block_len,
           (unsigned char *)ctx->partial_ghash_block.data));
     } else {
-      HARDENED_CHECK_EQ(ctx->security_level, kOtcryptoKeySecurityLevelLow);
+      HARDENED_CHECK_EQ(ctx->security_level,
+                        launder32(kOtcryptoKeySecurityLevelLow));
       ghash_update(&ctx->ghash_ctx, partial_ghash_block_len,
                    (unsigned char *)ctx->partial_ghash_block.data);
     }

--- a/sw/device/lib/crypto/impl/aes_gcm/ghash.c
+++ b/sw/device/lib/crypto/impl/aes_gcm/ghash.c
@@ -207,7 +207,7 @@ status_t ghash_init(ghash_context_t *ctx) {
 
   ctx->checksum = ghash_context_integrity_checksum(ctx);
 
-  return OTCRYPTO_OK;
+  return LAUNDERED_OTCRYPTO_OK;
 }
 
 /**
@@ -353,7 +353,7 @@ static status_t ghash_process_block(ghash_context_t *ctx,
   // Increment the number of processed ghash block counter.
   ctx->ghash_block_cnt++;
 
-  return OTCRYPTO_OK;
+  return LAUNDERED_OTCRYPTO_OK;
 }
 
 status_t ghash_process_full_blocks(ghash_context_t *ctx, size_t partial_len,
@@ -454,7 +454,7 @@ status_t ghash_handle_enc_initial_counter_block(
   // Update the checksum.
   ctx->checksum = ghash_context_integrity_checksum(ctx);
 
-  return OTCRYPTO_OK;
+  return LAUNDERED_OTCRYPTO_OK;
 }
 
 status_t ghash_final(ghash_context_t *ctx, uint32_t *result) {

--- a/sw/device/lib/crypto/impl/config.c
+++ b/sw/device/lib/crypto/impl/config.c
@@ -62,7 +62,7 @@ otcrypto_status_t otcrypto_disable_icache(hardened_bool_t *icache_enabled) {
 
 otcrypto_status_t otcrypto_restore_icache(hardened_bool_t icache_enabled) {
   ibex_restore_icache(icache_enabled);
-  return OTCRYPTO_OK;
+  return LAUNDERED_OTCRYPTO_OK;
 }
 
 otcrypto_status_t otcrypto_clear_alerts(void) {

--- a/sw/device/lib/crypto/impl/cryptolib_build_info.c
+++ b/sw/device/lib/crypto/impl/cryptolib_build_info.c
@@ -19,5 +19,5 @@ otcrypto_status_t otcrypto_build_info(uint32_t *version, bool *released,
   *build_hash_low = kCryptoLibBuildInfo.scm_revision.scm_revision_low;
   *build_hash_high = kCryptoLibBuildInfo.scm_revision.scm_revision_high;
 
-  return OTCRYPTO_OK;
+  return LAUNDERED_OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/impl/ecc_curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc_curve25519.c
@@ -155,7 +155,7 @@ static status_t reverse_bytecpy(uint8_t *dst, const uint8_t *src, size_t len) {
     dst[i] = src[len - 1 - i];
   }
 
-  return OTCRYPTO_OK;
+  return LAUNDERED_OTCRYPTO_OK;
 }
 
 /**
@@ -240,7 +240,7 @@ static status_t ed25519_clamp(uint32_t hash_h_low[kCurve25519HalfHashWords]) {
   hash_h_low[0] &= 0xfffffff8;
   hash_h_low[kCurve25519HalfHashWords - 1] &= 0x7fffffff;
   hash_h_low[kCurve25519HalfHashWords - 1] |= 0x40000000;
-  return OTCRYPTO_OK;
+  return LAUNDERED_OTCRYPTO_OK;
 }
 
 /**

--- a/sw/device/lib/crypto/impl/status.h
+++ b/sw/device/lib/crypto/impl/status.h
@@ -26,6 +26,10 @@ extern "C" {
  * minimized.
  */
 #define OTCRYPTO_OK ((status_t){.value = kHardenedBoolTrue})
+
+#define LAUNDERED_OTCRYPTO_OK \
+  ((status_t){.value = (int)launder32(kHardenedBoolTrue)})
+
 #ifdef OTCRYPTO_STATUS_DEBUG
 
 #define OTCRYPTO_RECOV_ERR                                \


### PR DESCRIPTION
Specifically for functions that can only return OTCRYPTO_OK as a status_t (specifically, the function should not call a HARDENED_TRY to another function), the compiler will circumvent Control Flow Integrity (CFI) assuming the function will be returning OTCRYPTO_OK.
For those specific "leaf nodes" we should launder the status in order to enforse the correct CFI behaviour.