### PR TITLE
WIP: Add an `AnyVersion` update_mode

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/datatypes.h
+++ b/sw/device/silicon_creator/lib/ownership/datatypes.h
@@ -116,6 +116,11 @@ typedef enum ownership_update_mode {
    * self-same owner if the config_version is newer)
    */
   kOwnershipUpdateModeSelfVersion = 0x564c4553,
+  /**
+   * Update mode AnyVersion: `ANYV`
+   * Accept any valid and signed ownership block.
+   */
+  kOwnershipUpdateModeAnyVersion = 0x56594e41,
 } ownership_update_mode_t;
 
 typedef enum lock_constraint {

--- a/sw/device/silicon_creator/lib/ownership/owner_block.c
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.c
@@ -64,7 +64,8 @@ hardened_bool_t owner_block_owner_key_equal(void) {
 hardened_bool_t owner_block_newversion_mode(void) {
   if (owner_page_valid[0] == kOwnerPageStatusSealed &&
       (owner_page[0].update_mode == kOwnershipUpdateModeNewVersion ||
-       owner_page[0].update_mode == kOwnershipUpdateModeSelfVersion)) {
+       owner_page[0].update_mode == kOwnershipUpdateModeSelfVersion ||
+       owner_page[0].update_mode == kOwnershipUpdateModeAnyVersion)) {
     return kHardenedBoolTrue;
   }
   return kHardenedBoolFalse;

--- a/sw/device/silicon_creator/lib/ownership/ownership.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership.c
@@ -74,12 +74,19 @@ static rom_error_t locked_owner_init(boot_data_t *bootdata,
   if (owner_page_valid[0] == kOwnerPageStatusSealed &&
       launder32(owner_page_valid[1]) == kOwnerPageStatusSigned &&
       owner_block_newversion_mode() == kHardenedBoolTrue &&
-      owner_page[1].config_version > owner_page[0].config_version &&
-      launder32(owner_block_owner_key_equal()) == kHardenedBoolTrue) {
+      owner_page[1].config_version > owner_page[0].config_version) {
     HARDENED_CHECK_EQ(owner_page_valid[1], kOwnerPageStatusSigned);
-    HARDENED_CHECK_EQ(owner_block_owner_key_equal(), kHardenedBoolTrue);
-    rom_error_t error =
-        ownership_activate(bootdata, /*write_both_pages=*/kHardenedBoolFalse);
+
+    rom_error_t error = kHardenedBoolFalse;
+    if (launder32(owner_page[0].update_mode) == kOwnershipUpdateModeAnyVersion) {
+      HARDENED_CHECK_EQ(owner_page[0].update_mode, kOwnershipUpdateModeAnyVersion);
+      error = ownership_activate(bootdata, /*write_both_pages=*/kHardenedBoolFalse);
+    } else if (launder32(owner_block_owner_key_equal()) == kHardenedBoolTrue) {
+      HARDENED_CHECK_EQ(owner_block_owner_key_equal(), kHardenedBoolTrue);
+      error = ownership_activate(bootdata, /*write_both_pages=*/kHardenedBoolFalse);
+    } else {
+      // Do nothing and don't activate the new page.
+    }
     if (launder32(error) == kErrorOk) {
       HARDENED_CHECK_EQ(error, kErrorOk);
       // Thunk the status of page 0 to Invalid so the next set of validity

--- a/sw/device/silicon_creator/lib/ownership/ownership_key.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_key.c
@@ -33,6 +33,11 @@ const owner_detached_signature_t *ownership_signature_scan(
     uintptr_t start, size_t length, uint32_t command, const nonce_t *nonce) {
   if (length < sizeof(owner_detached_signature_t))
     return NULL;
+  // The nonce in the detached signature is not cryptographically bound.  It is
+  // merely a token to uniquely identify a detached signature block and not
+  // confuse it with any other block that may be left over in flash.  We'll
+  // allow a nonce of zero as a wildcard to match any detached signature block.
+  nonce_t zero = {0, 0};
   length -= sizeof(owner_detached_signature_t);
   uintptr_t end = start + length;
   while (start < end) {
@@ -41,7 +46,9 @@ const owner_detached_signature_t *ownership_signature_scan(
     if (sig->header.tag == kTlvTagDetachedSignature &&
         sig->header.length == sizeof(owner_detached_signature_t) &&
         sig->header.version.major == 0 && sig->command == command &&
-        nonce_equal(&sig->nonce, nonce)) {
+        (
+            nonce_equal(&sig->nonce, zero ) || nonce_equal(&sig->nonce, nonce)
+        )) {
       return sig;
     }
     start += FLASH_CTRL_PARAM_BYTES_PER_PAGE;

--- a/sw/device/silicon_creator/lib/ownership/ownership_unlock.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_unlock.c
@@ -74,7 +74,9 @@ static rom_error_t unlock(boot_svc_msg_t *msg, boot_data_t *bootdata) {
     uint32_t flash_exec = 0;
     switch (owner_page[0].update_mode) {
       case kOwnershipUpdateModeOpen:
+      case kOwnershipUpdateModeAnyVersion:
         // The Open mode allows unlock to any unlock state.
+        // The AnyVersion mode is very permissive and permits unlocks.
         break;
       case kOwnershipUpdateModeNewVersion:
         // The NewVersion mode forbids all unlocks.
@@ -82,7 +84,7 @@ static rom_error_t unlock(boot_svc_msg_t *msg, boot_data_t *bootdata) {
       case kOwnershipUpdateModeSelf:
       case kOwnershipUpdateModeSelfVersion:
       default:
-        // The `unlock` funciton services UnlockAny and UnlockEndorsed requests,
+        // The `unlock` function services UnlockAny and UnlockEndorsed requests,
         // neither of which are valid for the `Self` mode.
         return kErrorOwnershipInvalidMode;
     }
@@ -124,6 +126,7 @@ static rom_error_t unlock_update(boot_svc_msg_t *msg, boot_data_t *bootdata) {
         return kErrorOwnershipUnlockDenied;
       case kOwnershipUpdateModeSelf:
       case kOwnershipUpdateModeSelfVersion:
+      case kOwnershipUpdateModeAnyVersion:
       case kOwnershipUpdateModeOpen:
       default:
           // The `unlock_update` funciton services UnlockUpdate update requests,


### PR DESCRIPTION
The `AnyVersion` mode allows ownership transfer to a new owner without an unlock/activate sequence.  When in `AnyVersion` mode, the chip will accept any valid and correctly signed ownership block.