### PR TITLE
[cryptotest] Add X25519 ACVP testing

### DIFF
--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -263,6 +263,16 @@ cryptotest(
     test_vectors = X25519_TESTVECTOR_TARGETS,
 )
 
+cryptotest(
+    name = "x25519_acvp",
+    slow_test = True,
+    test_args = "--input=\"$(rootpath //sw/host/cryptotest/testvectors/acvp:x25519_vectors.hjson)\"",
+    test_harness = "//sw/host/tests/crypto/acvp:harness",
+    test_vectors = [
+        "//sw/host/cryptotest/testvectors/acvp:x25519_vectors.hjson",
+    ],
+)
+
 RSA_TESTVECTOR_TARGETS = [
     "//sw/host/cryptotest/testvectors/data:wycheproof_rsa_pkcs1_1.5_2048_{}.json".format(hash)
     for hash in [
@@ -790,6 +800,7 @@ test_suite(
         ":shake128_kat",
         ":shake256_kat",
         ":sphincsplus_kat",
+        ":x25519_acvp",
         ":x25519_kat",
     ],
 )

--- a/sw/device/tests/crypto/cryptotest/firmware/x25519.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/x25519.c
@@ -36,6 +36,101 @@ static const otcrypto_key_config_t kX25519PrivateKeyConfig = {
     .security_level = kOtcryptoKeySecurityLevelLow,
 };
 
+status_t handle_x25519_key_exchange(ujson_t *uj) {
+  // Receive the server's public key from the host.
+  cryptotest_x25519_public_key_t uj_server_public_key;
+  TRY(ujson_deserialize_cryptotest_x25519_public_key_t(uj,
+                                                       &uj_server_public_key));
+  if (uj_server_public_key.public_key_len != X25519_CMD_PUBLIC_KEY_BYTES) {
+    LOG_ERROR(
+        "Invalid X25519 server public key length (have = %d, want = %d bytes)",
+        (uint32_t)uj_server_public_key.public_key_len,
+        X25519_CMD_PUBLIC_KEY_BYTES);
+    return INVALID_ARGUMENT();
+  }
+
+  // Generate a random ephemeral private key and apply blinding.
+  uint32_t raw_key[kX25519PrivateKeyWords] = {0};
+  HARDENED_TRY(hardened_memshred(raw_key, kX25519PrivateKeyWords));
+
+  uint32_t keyblob[kX25519MaskedScalarTotalWords] = {0};
+  uint32_t *share0 = keyblob;
+  uint32_t *share1 = keyblob + kX25519MaskedScalarShareWords;
+  HARDENED_TRY(hardened_memshred(share1, kX25519PrivateKeyWords));
+  HARDENED_TRY(hardened_sub(raw_key, share1, kX25519PrivateKeyWords, share0));
+
+  otcrypto_blinded_key_t private_key = {
+      .config = kX25519PrivateKeyConfig,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+  };
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
+
+  // Derive the corresponding ephemeral public key.
+  uint32_t gen_public_key_buf[kX25519PublicKeyWords] = {0};
+  otcrypto_unblinded_key_t gen_public_key = {
+      .key_mode = kOtcryptoKeyModeX25519,
+      .key_length = X25519_CMD_PUBLIC_KEY_BYTES,
+      .key = gen_public_key_buf,
+  };
+  TRY(otcrypto_x25519_keygen(&private_key, &gen_public_key));
+
+  // Build the server's public key struct.
+  uint32_t server_public_key_buf[kX25519PublicKeyWords] = {0};
+  memcpy(server_public_key_buf, uj_server_public_key.public_key,
+         X25519_CMD_PUBLIC_KEY_BYTES);
+  otcrypto_unblinded_key_t server_public_key = {
+      .key_mode = kOtcryptoKeyModeX25519,
+      .key_length = X25519_CMD_PUBLIC_KEY_BYTES,
+      .key = server_public_key_buf,
+  };
+  server_public_key.checksum =
+      otcrypto_integrity_unblinded_checksum(&server_public_key);
+
+  // Allocate the blinded shared secret output.
+  uint32_t shared_secretblob[kX25519SharedSecretWords * 2];
+  memset(shared_secretblob, 0, sizeof(shared_secretblob));
+  otcrypto_blinded_key_t shared_secret = {
+      .config =
+          {
+              .version = kOtcryptoLibVersion1,
+              .key_mode = kOtcryptoKeyModeAesCtr,
+              .key_length = X25519_CMD_SHARED_SECRET_BYTES,
+              .hw_backed = kHardenedBoolFalse,
+              .exportable = kHardenedBoolTrue,
+              .security_level = kOtcryptoKeySecurityLevelLow,
+          },
+      .keyblob_length = sizeof(shared_secretblob),
+      .keyblob = shared_secretblob,
+  };
+
+  TRY(otcrypto_x25519(&private_key, &server_public_key, &shared_secret));
+
+  // Unmask the shared secret by adding its two shares.
+  uint32_t dest_share0[kX25519SharedSecretWords];
+  uint32_t dest_share1[kX25519SharedSecretWords];
+  otcrypto_word32_buf_t share0_buf = OTCRYPTO_MAKE_BUF(
+      otcrypto_word32_buf_t, dest_share0, ARRAYSIZE(dest_share0));
+  otcrypto_word32_buf_t share1_buf = OTCRYPTO_MAKE_BUF(
+      otcrypto_word32_buf_t, dest_share1, ARRAYSIZE(dest_share1));
+  TRY(otcrypto_export_blinded_key(&shared_secret, &share0_buf, &share1_buf));
+
+  uint32_t unblinded_secret[kX25519SharedSecretWords];
+  TRY(hardened_add(dest_share0, dest_share1, kX25519SharedSecretWords,
+                   unblinded_secret));
+
+  cryptotest_x25519_kex_output_t uj_output;
+  memset(&uj_output, 0, sizeof(uj_output));
+  memcpy(uj_output.public_key, gen_public_key_buf, X25519_CMD_PUBLIC_KEY_BYTES);
+  uj_output.public_key_len = X25519_CMD_PUBLIC_KEY_BYTES;
+  memcpy(uj_output.shared_secret, unblinded_secret,
+         X25519_CMD_SHARED_SECRET_BYTES);
+  uj_output.shared_secret_len = X25519_CMD_SHARED_SECRET_BYTES;
+
+  RESP_OK(ujson_serialize_cryptotest_x25519_kex_output_t, uj, &uj_output);
+  return OK_STATUS();
+}
+
 status_t handle_x25519_shared_secret_generation(ujson_t *uj) {
   cryptotest_x25519_private_key_t uj_private_key;
   cryptotest_x25519_public_key_t uj_public_key;
@@ -149,6 +244,8 @@ status_t handle_x25519(ujson_t *uj) {
   switch (cmd) {
     case kX25519SubcommandX25519SSG:
       return handle_x25519_shared_secret_generation(uj);
+    case kX25519SubcommandX25519KEX:
+      return handle_x25519_key_exchange(uj);
     default:
       LOG_ERROR("Unrecognized X25519 subcommand: %d", cmd);
       return INVALID_ARGUMENT();

--- a/sw/device/tests/crypto/cryptotest/firmware/x25519.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/x25519.c
@@ -36,7 +36,7 @@ static const otcrypto_key_config_t kX25519PrivateKeyConfig = {
     .security_level = kOtcryptoKeySecurityLevelLow,
 };
 
-status_t handle_x25519(ujson_t *uj) {
+status_t handle_x25519_shared_secret_generation(ujson_t *uj) {
   cryptotest_x25519_private_key_t uj_private_key;
   cryptotest_x25519_public_key_t uj_public_key;
 
@@ -140,5 +140,18 @@ status_t handle_x25519(ujson_t *uj) {
          X25519_CMD_SHARED_SECRET_BYTES);
 
   RESP_OK(ujson_serialize_cryptotest_x25519_derive_output_t, uj, &uj_output);
+  return OK_STATUS();
+}
+
+status_t handle_x25519(ujson_t *uj) {
+  x25519_subcommand_t cmd;
+  TRY(ujson_deserialize_x25519_subcommand_t(uj, &cmd));
+  switch (cmd) {
+    case kX25519SubcommandX25519SSG:
+      return handle_x25519_shared_secret_generation(uj);
+    default:
+      LOG_ERROR("Unrecognized X25519 subcommand: %d", cmd);
+      return INVALID_ARGUMENT();
+  }
   return OK_STATUS();
 }

--- a/sw/device/tests/crypto/cryptotest/firmware/x25519.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/x25519.h
@@ -8,6 +8,7 @@
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/ujson/ujson.h"
 
+status_t handle_x25519_key_exchange(ujson_t *uj);
 status_t handle_x25519_shared_secret_generation(ujson_t *uj);
 status_t handle_x25519(ujson_t *uj);
 

--- a/sw/device/tests/crypto/cryptotest/firmware/x25519.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/x25519.h
@@ -8,6 +8,7 @@
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/ujson/ujson.h"
 
+status_t handle_x25519_shared_secret_generation(ujson_t *uj);
 status_t handle_x25519(ujson_t *uj);
 
 #endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_X25519_H_

--- a/sw/device/tests/crypto/cryptotest/json/x25519_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/x25519_commands.h
@@ -16,12 +16,16 @@ extern "C" {
 
 // clang-format off
 
-// Derive operation:
+// Shared secret generation
 // The host sends, in order:
 // - private_key (X25519_PRIVATE_KEY)  [raw scalar; blinding is applied on the device]
 // - public_key (X25519_PUBLIC_KEY)    [peer's u-coordinate]
 // The device responds with:
 // - output (X25519_DERIVE_OUTPUT)     [unblinded shared secret and result]
+
+#define X25519_SUBCOMMAND(_, value) \
+    value(_, X25519SSG)
+UJSON_SERDE_ENUM(X25519Subcommand, x25519_subcommand_t, X25519_SUBCOMMAND);
 
 #define X25519_PRIVATE_KEY(field, string) \
     field(private_key, uint8_t, X25519_CMD_PRIVATE_KEY_BYTES) \

--- a/sw/device/tests/crypto/cryptotest/json/x25519_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/x25519_commands.h
@@ -24,7 +24,8 @@ extern "C" {
 // - output (X25519_DERIVE_OUTPUT)     [unblinded shared secret and result]
 
 #define X25519_SUBCOMMAND(_, value) \
-    value(_, X25519SSG)
+    value(_, X25519SSG) \
+    value(_, X25519KEX)
 UJSON_SERDE_ENUM(X25519Subcommand, x25519_subcommand_t, X25519_SUBCOMMAND);
 
 #define X25519_PRIVATE_KEY(field, string) \
@@ -42,6 +43,17 @@ UJSON_SERDE_STRUCT(CryptotestX25519PublicKey, cryptotest_x25519_public_key_t, X2
     field(shared_secret, uint8_t, X25519_CMD_SHARED_SECRET_BYTES) \
     field(shared_secret_len, size_t)
 UJSON_SERDE_STRUCT(CryptotestX25519DeriveOutput, cryptotest_x25519_derive_output_t, X25519_DERIVE_OUTPUT);
+
+// Key exchange output
+// The device responds with:
+// - public_key  [generated ephemeral public key (u-coordinate)]
+// - shared_secret [unblinded shared secret]
+#define X25519_KEX_OUTPUT(field, string) \
+    field(public_key, uint8_t, X25519_CMD_PUBLIC_KEY_BYTES) \
+    field(public_key_len, size_t) \
+    field(shared_secret, uint8_t, X25519_CMD_SHARED_SECRET_BYTES) \
+    field(shared_secret_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestX25519KexOutput, cryptotest_x25519_kex_output_t, X25519_KEX_OUTPUT);
 
 // clang-format on
 

--- a/sw/host/cryptotest/testvectors/acvp/BUILD
+++ b/sw/host/cryptotest/testvectors/acvp/BUILD
@@ -13,4 +13,5 @@ exports_files([
     "hmac_sha256_vectors.json",
     "rsa_expected.json",
     "rsa_vectors.json",
+    "x25519_vectors.hjson",
 ])

--- a/sw/host/cryptotest/testvectors/acvp/x25519_vectors.hjson
+++ b/sw/host/cryptotest/testvectors/acvp/x25519_vectors.hjson
@@ -1,0 +1,154 @@
+// Copyright lowRISC contributors (OpenTitan project).
+//
+// Source: NIST ACVP-Server (https://github.com/usnistgov/ACVP-Server)
+// NIST License:
+// NIST-developed software is provided by NIST as a public service. You may
+// use, copy, and distribute copies of the software in any medium, provided
+// that you keep intact this entire notice. You may improve, modify, and create
+// derivative works of the software or any portion of the software, and you may
+// copy and distribute such modifications or works. Modified works should carry
+// a notice stating that you changed the software and should note the date and
+// nature of any such change. Please explicitly acknowledge the National
+// Institute of Standards and Technology as the source of the software.
+//
+// NIST-developed software is expressly provided "AS IS." NIST MAKES NO
+// WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF
+// LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND DATA ACCURACY. NIST
+// NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE
+// UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST
+// DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE
+// SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE
+// CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+//
+// You are solely responsible for determining the appropriateness of using and
+// distributing the software and you assume all risks associated with its use,
+// including but not limited to the risks and costs of program errors,
+// compliance with applicable laws, damage to or loss of data, programs or
+// equipment, and the unavailability or interruption of operation. This
+// software is not intended to be used in any situation where a failure could
+// cause risk of injury or damage to property. The software developed by NIST
+// employees is not subject to copyright protection within the United States.
+//
+// Based on:
+// https://github.com/usnistgov/ACVP-Server/blob/master/gen-val/json-files/XECDH-SSC-RFC7748/prompt.json
+// Modifications:
+// This file was modified on 21.05.2026 as following:
+// - Removed test group 2.
+// - Wrapped in an array for compatibility with the ACVP harness.
+[{
+  "vsId": 0,
+  "algorithm": "XECDH",
+  "mode": "SSC",
+  "revision": "RFC7748",
+  "isSample": true,
+  "testGroups": [
+    {
+      "tgId": 1,
+      "testType": "AFT",
+      "curve": "Curve25519",
+      "tests": [
+        {
+          "tcId": 1,
+          "publicServer": "42C4060DF475A484E4236D10F17180AF3B99F6D684DDF870E845881B9071A54E"
+        },
+        {
+          "tcId": 2,
+          "publicServer": "6F816BF7D5F9A0A1D9455D41A02CFFF189809ADA9DDFB2715C34BBB5F0947603"
+        },
+        {
+          "tcId": 3,
+          "publicServer": "B11FADD796461DBB7B4744C8D120AB417BA0BCB4D07C19BAC5D35A5A63E1262E"
+        },
+        {
+          "tcId": 4,
+          "publicServer": "9E50A0F910DF7272063F56E6C1FA0985D67EEDB27A614F1B50F169E553BF6935"
+        },
+        {
+          "tcId": 5,
+          "publicServer": "E5CC81E9470D117B0A447F857479C1D62A1707CFBBB7C5982EC37E3B0D70445B"
+        },
+        {
+          "tcId": 6,
+          "publicServer": "1AF998D78E31E5F3E4B239069D59577103BB22BCD74A7F340F0CBEB2E0749656"
+        },
+        {
+          "tcId": 7,
+          "publicServer": "3E89E54DCBE9864564ED5D9E7AF8C81519296434974415AE911C1E6D979CE86C"
+        },
+        {
+          "tcId": 8,
+          "publicServer": "48953896FEC80D17357B5172F57267002CAF85F7B8AAD72ABB9A7C974BDC624A"
+        },
+        {
+          "tcId": 9,
+          "publicServer": "5B1F9736154161C3EDEB6B2CEB0E3EE53ACB8D5E911E93E753C4C000207EC50C"
+        },
+        {
+          "tcId": 10,
+          "publicServer": "1BC4C7B94927A81D9CA201B5A4C82C379BDF0ADDE6EA0BAECF923252CD5D6673"
+        },
+        {
+          "tcId": 11,
+          "publicServer": "C7103A622C399D5A6FFFA827E24F49F37398201FA35423BD04C72D025864AC1E"
+        },
+        {
+          "tcId": 12,
+          "publicServer": "FD9095C9EA7C3A5BD7A59556B81CB537AF1BBE6C6327A95C096090754C5C1120"
+        },
+        {
+          "tcId": 13,
+          "publicServer": "DDC2FDA36F630995AC295A2F8D743623C193F226C0B91CAA0F03DF3272B2F067"
+        },
+        {
+          "tcId": 14,
+          "publicServer": "6E0CDA7BB75AD207B30C01B9BF57F8F0143389442BBABCB037C8E1FA6CED1C7E"
+        },
+        {
+          "tcId": 15,
+          "publicServer": "81DC2EFBCF3054744CAFD5F659355298651DB7B44FA464178DC39318D3CE0E78"
+        },
+        {
+          "tcId": 16,
+          "publicServer": "0B20799C9FBCBC9E3254CB69422DC043F0315E72EA8A95664EF5C37223D27072"
+        },
+        {
+          "tcId": 17,
+          "publicServer": "07C3802DDD18F2CB01BB5EADA2F17FBDCC808C5E136D53E739198D5A71DEC61A"
+        },
+        {
+          "tcId": 18,
+          "publicServer": "50721754D50790BEB2B608EE6538BD33B30E984560186991C1534FAF7B150D12"
+        },
+        {
+          "tcId": 19,
+          "publicServer": "3D51C7B4479379FC253E2A2B333FE15A3489CEC3C78CB63CACAD2025CD276B07"
+        },
+        {
+          "tcId": 20,
+          "publicServer": "D5C7A1C50C77D83242F86C8E4E55669238A368898CDE9044AFF0C2EDAEAD2717"
+        },
+        {
+          "tcId": 21,
+          "publicServer": "75C3281BEB47BB8B757D88924FEA098DE0B14B8AE35904F0850854E2D9E29E0A"
+        },
+        {
+          "tcId": 22,
+          "publicServer": "5A8650D92D13FE430C0C26E41BBB12B97F7972C0B8D7A58A2942CF15EF505E32"
+        },
+        {
+          "tcId": 23,
+          "publicServer": "3114BC1DC454A98EBA47097E8F03E7AC1251BBC9EA26A74ABC1B87F6E7756943"
+        },
+        {
+          "tcId": 24,
+          "publicServer": "B943F23DFECAD4A954D67BD09B66AC34B65C23F844BC4058543A36576A0F361D"
+        },
+        {
+          "tcId": 25,
+          "publicServer": "18C78BD5BD90B5CAD9F141ACE03C0EDC6D3E76154BF2E7A1700CD9252111BA52"
+        }
+      ]
+    }
+  ]
+}]

--- a/sw/host/tests/crypto/acvp/BUILD
+++ b/sw/host/tests/crypto/acvp/BUILD
@@ -15,6 +15,7 @@ rust_binary(
         "src/hmac.rs",
         "src/main.rs",
         "src/rsa.rs",
+        "src/x25519.rs",
     ],
     deps = [
         "//sw/host/cryptotest/ujson_lib:cryptotest_commands",

--- a/sw/host/tests/crypto/acvp/src/main.rs
+++ b/sw/host/tests/crypto/acvp/src/main.rs
@@ -19,6 +19,7 @@ mod cshake;
 mod eddsa;
 mod hmac;
 mod rsa;
+mod x25519;
 
 #[derive(Debug, Parser)]
 struct Opts {
@@ -87,6 +88,10 @@ enum AcvpVectors {
     // vectors match Eddsa first and sigGen vectors fall through to EddsaSigGen.
     Eddsa(eddsa::EddsaTestVectorSet),
     EddsaSigGen(eddsa::EddsaSignGenTestVectorSet),
+    // X25519TestVectorSet must precede EddsaKeyGen: EddsaKeygenTestVectorSet test
+    // cases only require `tc_id`, so they would silently match x25519 test cases
+    // (which also have `tc_id` plus `publicServer`) if X25519 came later.
+    X25519(x25519::X25519TestVectorSet),
     // EddsaKeygenTestVectorSet has no `preHash` in groups, so sigGen vectors
     // (which require preHash) fall through to EddsaKeyGen.
     EddsaKeyGen(eddsa::EddsaKeygenTestVectorSet),
@@ -110,6 +115,7 @@ enum AcvpResults {
     Eddsa(eddsa::EddsaResultVectorSet),
     RsaSigGen(rsa::RsaSignGenResultVectorSet),
     Rsa(rsa::RsaResultVectorSet),
+    X25519(x25519::X25519ResultVectorSet),
 }
 
 fn validate_subset(actual: &[AcvpResults], expected_json: &serde_json::Value) -> Result<()> {
@@ -290,6 +296,13 @@ fn run<R: std::io::Read, W: std::io::Write>(
                     )?));
                 }
             }
+            AcvpVectors::X25519(vs) => {
+                acvp_results.push(AcvpResults::X25519(x25519::run_x25519_vector_set(
+                    opts.timeout,
+                    &spi_console_device,
+                    &vs,
+                )?));
+            }
         }
     }
     if let Some(w) = output {
@@ -380,7 +393,6 @@ fn main() -> Result<()> {
         }
         None => None,
     };
-
     run(
         &opts,
         &transport,

--- a/sw/host/tests/crypto/acvp/src/x25519.rs
+++ b/sw/host/tests/crypto/acvp/src/x25519.rs
@@ -1,0 +1,148 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use arrayvec::ArrayVec;
+use hex::FromHex;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+use cryptotest_commands::commands::CryptotestCommand;
+use cryptotest_commands::x25519_commands::{
+    CryptotestX25519KexOutput, CryptotestX25519PublicKey, X25519Subcommand,
+};
+
+use opentitanlib::console::spi::SpiConsoleDevice;
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
+
+// Input structs (from x25519_vectors.hjson)
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct X25519TestCase {
+    tc_id: usize,
+    public_server: String,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct X25519TestGroup {
+    tg_id: usize,
+    #[allow(dead_code)]
+    test_type: String,
+    #[allow(dead_code)]
+    curve: String,
+    tests: Vec<X25519TestCase>,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct X25519TestVectorSet {
+    vs_id: usize,
+    algorithm: String,
+    mode: String,
+    revision: String,
+    #[serde(default)]
+    is_sample: bool,
+    test_groups: Vec<X25519TestGroup>,
+}
+
+// Output structs (for the JSON result file)
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct X25519ResultCase {
+    tc_id: usize,
+    public_iut: String,
+    z: String,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct X25519ResultGroup {
+    tg_id: usize,
+    tests: Vec<X25519ResultCase>,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct X25519ResultVectorSet {
+    vs_id: usize,
+    algorithm: String,
+    mode: String,
+    revision: String,
+    #[serde(default)]
+    is_sample: bool,
+    test_groups: Vec<X25519ResultGroup>,
+}
+
+fn run_x25519_case(
+    timeout: Duration,
+    spi_console: &SpiConsoleDevice,
+    tc: &X25519TestCase,
+) -> Result<X25519ResultCase> {
+    let public_server = Vec::<u8>::from_hex(&tc.public_server)?;
+
+    CryptotestCommand::X25519.send(spi_console)?;
+    X25519Subcommand::X25519KEX.send(spi_console)?;
+
+    CryptotestX25519PublicKey {
+        public_key: ArrayVec::try_from(public_server.as_slice())
+            .map_err(|_| std::io::Error::other("X25519 server public key unexpected length"))?,
+        public_key_len: public_server.len(),
+    }
+    .send(spi_console)?;
+
+    let output = CryptotestX25519KexOutput::recv(spi_console, timeout, false, false)?;
+
+    let public_iut = &output.public_key[..output.public_key_len];
+    let z = &output.shared_secret[..output.shared_secret_len];
+
+    Ok(X25519ResultCase {
+        tc_id: tc.tc_id,
+        public_iut: hex::encode_upper(public_iut),
+        z: hex::encode_upper(z),
+    })
+}
+
+fn run_x25519_group(
+    timeout: Duration,
+    spi_console: &SpiConsoleDevice,
+    tg: &X25519TestGroup,
+) -> Result<X25519ResultGroup> {
+    log::info!("tg_id: {}", tg.tg_id);
+
+    let mut result_cases = Vec::new();
+    for tc in &tg.tests {
+        log::info!("tc_id: {}", tc.tc_id);
+        result_cases.push(run_x25519_case(timeout, spi_console, tc)?);
+    }
+
+    Ok(X25519ResultGroup {
+        tg_id: tg.tg_id,
+        tests: result_cases,
+    })
+}
+
+pub fn run_x25519_vector_set(
+    timeout: Duration,
+    spi_console: &SpiConsoleDevice,
+    vs: &X25519TestVectorSet,
+) -> Result<X25519ResultVectorSet> {
+    log::info!("vs_id: {}", vs.vs_id);
+
+    let mut result_groups = Vec::with_capacity(vs.test_groups.len());
+    for tg in &vs.test_groups {
+        result_groups.push(run_x25519_group(timeout, spi_console, tg)?);
+    }
+
+    Ok(X25519ResultVectorSet {
+        vs_id: vs.vs_id,
+        algorithm: vs.algorithm.clone(),
+        mode: vs.mode.clone(),
+        revision: vs.revision.clone(),
+        is_sample: vs.is_sample,
+        test_groups: result_groups,
+    })
+}

--- a/sw/host/tests/crypto/x25519_kat/src/main.rs
+++ b/sw/host/tests/crypto/x25519_kat/src/main.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 use cryptotest_commands::commands::CryptotestCommand;
 use cryptotest_commands::x25519_commands::{
     CryptotestX25519DeriveOutput, CryptotestX25519PrivateKey, CryptotestX25519PublicKey,
+    X25519Subcommand,
 };
 
 use opentitanlib::app::TransportWrapper;
@@ -91,11 +92,12 @@ fn run_x25519_testcase(
         X25519_PUBLIC_KEY_BYTES,
         test_case.public_key.len(),
     );
+    // Send X25519 Shared Secret Generation command.
+    CryptotestCommand::X25519.send(spi_console)?;
+    X25519Subcommand::X25519SSG.send(spi_console)?;
 
     // X25519 keys and shared secrets are in RFC 7748 little-endian byte order;
     // the test vectors are already in this format so no reversal is needed.
-    CryptotestCommand::X25519.send(spi_console)?;
-
     CryptotestX25519PrivateKey {
         private_key: ArrayVec::try_from(test_case.private_key.as_slice())
             .expect("X25519 private key had unexpected length."),


### PR DESCRIPTION
This PR enables us testing the X25519 implementation with the ACVP server.

The host harness reads in the test vector from `x25519_vectors.hjson` which is then transmitted to the device. The device first does a keygen to create a public and a private key. Afterwards, the private device key together with the host public key is used to generate the shared secret. The shared secret as well as the public device key is sent to the host. The user can write this output to a JSON file, which can be transmitted to the ACVP server for validation.

Usage:
```
./bazelisk.sh run //sw/device/tests/crypto/cryptotest:x25519_acvp_fpga_cw340_sival_rom_ext -- --output=x25519_output.json
```