### PR TITLE
Enable i2c tests on CW340

### DIFF
--- a/sw/device/lib/testing/i2c_testutils.c
+++ b/sw/device/lib/testing/i2c_testutils.c
@@ -73,6 +73,8 @@ static status_t get_i2c_pads_for_platform(dt_i2c_t i2c_dt,
 #elif defined(OPENTITAN_IS_EARLGREY) || defined(OPENTITAN_IS_ENGLISHBREAKFAST)
   // For Earlgrey and EnglishBreakfast platforms
   switch (platform) {
+    case I2cPinmuxPlatformIdSilicon:
+    case I2cPinmuxPlatformIdCw340:
     case I2cPinmuxPlatformIdHyper310:  // CW310 HyperDebug
       *sda_pad = kDtPadIoa7;
       *scl_pad = kDtPadIoa8;

--- a/sw/device/lib/testing/i2c_testutils.h
+++ b/sw/device/lib/testing/i2c_testutils.h
@@ -127,6 +127,8 @@ typedef enum i2c_pinmux_platform_id {
   I2cPinmuxPlatformIdHyper310 = 0,
   I2cPinmuxPlatformIdDvsim,
   I2cPinmuxPlatformIdCw310Pmod,
+  I2cPinmuxPlatformIdCw340,
+  I2cPinmuxPlatformIdSilicon,
   I2cPinmuxPlatformIdCount,
 } i2c_pinmux_platform_id_t;
 

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -6719,6 +6719,7 @@ opentitan_test(
     ],
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_sival": None,
+        "//hw/top_earlgrey:fpga_cw340_sival": None,
     },
     fpga = fpga_params(
         test_cmd = """

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -6750,6 +6750,7 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
         },
     ),
     fpga = fpga_params(

--- a/sw/device/tests/i2c_host_override_test.c
+++ b/sw/device/tests/i2c_host_override_test.c
@@ -98,8 +98,22 @@ static status_t i2c_configure_instance(uint8_t i2c_instance) {
       mmio_region_from_addr(kI2cBaseAddrTable[i2c_instance]);
   TRY(dif_i2c_init(base_addr, &i2c));
 
-  TRY(i2c_testutils_select_pinmux(&pinmux, i2c_instance,
-                                  I2cPinmuxPlatformIdHyper310));
+  i2c_pinmux_platform_id_t platform = I2cPinmuxPlatformIdHyper310;
+  switch (kDeviceType) {
+    case kDeviceFpgaCw310:
+      platform = I2cPinmuxPlatformIdHyper310;
+      break;
+    case kDeviceFpgaCw340:
+      platform = I2cPinmuxPlatformIdCw340;
+      break;
+    case kDeviceSilicon:
+      platform = I2cPinmuxPlatformIdSilicon;
+      break;
+    default:
+      TRY_CHECK(false, "Unsupported platform=%u", kDeviceType);
+  };
+
+  TRY(i2c_testutils_select_pinmux(&pinmux, i2c_instance, platform));
 
   TRY(dif_i2c_override_set_enabled(&i2c, kDifToggleEnabled));
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));

--- a/sw/device/tests/i2c_target_smbus_arp_test.c
+++ b/sw/device/tests/i2c_target_smbus_arp_test.c
@@ -296,7 +296,22 @@ static status_t test_init(void) {
   base_addr = mmio_region_from_addr(TOP_EARLGREY_I2C0_BASE_ADDR);
   TRY(dif_i2c_init(base_addr, &i2c));
 
-  TRY(i2c_testutils_select_pinmux(&pinmux, 0, I2cPinmuxPlatformIdHyper310));
+  i2c_pinmux_platform_id_t platform = I2cPinmuxPlatformIdHyper310;
+  switch (kDeviceType) {
+    case kDeviceFpgaCw310:
+      platform = I2cPinmuxPlatformIdHyper310;
+      break;
+    case kDeviceFpgaCw340:
+      platform = I2cPinmuxPlatformIdCw340;
+      break;
+    case kDeviceSilicon:
+      platform = I2cPinmuxPlatformIdSilicon;
+      break;
+    default:
+      TRY_CHECK(false, "Unsupported platform=%u", kDeviceType);
+  };
+
+  TRY(i2c_testutils_select_pinmux(&pinmux, /*instance=*/0, platform));
   TRY(i2c_testutils_set_speed(&i2c, kDifI2cSpeedStandard,
                               /*sda_rise_nanos=*/400, /*sda_fall_nanos=*/110));
 

--- a/sw/host/ot_transports/hyperdebug/config/hyperdebug_cw340.json5
+++ b/sw/host/ot_transports/hyperdebug/config/hyperdebug_cw340.json5
@@ -48,6 +48,12 @@
       "mode": "Alternate",
       "pull_mode": "PullUp",
       "alias_of": "IOA7"
+    },
+    {
+      "name": "I2C_SCL",
+      "mode": "Alternate",
+      "pull_mode": "PullUp",
+      "alias_of": "IOA8"
     }
   ],
   "strappings": [


### PR DESCRIPTION
The main issue was the lack of pull up resitors. Unlike the CW310 + Swizzle board, the CW340 does not have pull up resitors on the i2c bus.

Fix: https://github.com/lowRISC/opentitan/issues/30166

