### PR TITLE
[rescue] Avoid large rodata initializer for dfu_ctx_t

### DIFF
--- a/sw/device/silicon_creator/lib/rescue/rescue_spi.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue_spi.c
@@ -78,10 +78,10 @@ void dfu_transport_result(dfu_ctx_t *ctx, rom_error_t result) {
 
 rom_error_t rescue_protocol(boot_data_t *bootdata, boot_log_t *boot_log,
                             const owner_rescue_config_t *config) {
-  dfu_ctx_t ctx = {
-      .dfu_state = kDfuStateIdle,
-      .dfu_error = kDfuErrOk,
-  };
+  dfu_ctx_t ctx;
+  memset(&ctx, 0, sizeof(ctx));
+  ctx.dfu_state = kDfuStateIdle;
+  ctx.dfu_error = kDfuErrOk;
   dbg_printf("SPI-DFU rescue ready\r\n");
   rescue_state_init(&ctx.state, bootdata, boot_log, config);
   spi_device_init(

--- a/sw/device/silicon_creator/lib/rescue/rescue_usb.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue_usb.c
@@ -7,6 +7,7 @@
 
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/memory.h"
 #include "sw/device/silicon_creator/lib/boot_data.h"
 #include "sw/device/silicon_creator/lib/dbg_print.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
@@ -164,16 +165,14 @@ void dfu_transport_result(dfu_ctx_t *ctx, rom_error_t result) {
 rom_error_t rescue_protocol(boot_data_t *bootdata, boot_log_t *boot_log,
                             const owner_rescue_config_t *config) {
   set_serialnumber();
-  dfu_ctx_t ctx = {
-      .ep0 =
-          {
-              .device_desc = &device_desc,
-              .config_desc = config_desc,
-              .string_desc = string_desc,
-          },
-      .dfu_state = kDfuStateIdle,
-      .dfu_error = kDfuErrOk,
-  };
+  dfu_ctx_t ctx;
+  memset(&ctx, 0, sizeof(ctx));
+  ctx.ep0.device_desc = &device_desc;
+  ctx.ep0.config_desc = config_desc;
+  ctx.ep0.string_desc = string_desc;
+  ctx.dfu_state = kDfuStateIdle;
+  ctx.dfu_error = kDfuErrOk;
+
   dbg_printf("USB-DFU rescue ready\r\n");
   rescue_state_init(&ctx.state, bootdata, boot_log, config);
   pinmux_init_usb();


### PR DESCRIPTION
The `dfu_ctx_t` struct has a large buffer allocated for rescue transfers in `rescue_state_t`.

Using a designated initializer for this struct produces a large, mostly zero-filled initializer in `rodata`, consuming approximately **2.5KB of ROM_EXT flash space**.

https://github.com/lowRISC/opentitan/blob/81739c5bf28a58e8951ccd8d4fa3c5d453085aa0/sw/device/silicon_creator/lib/rescue/rescue.h#L108-L110

To reclaim this space, this change replaces the designated initializer with manual field-by-field initialization, eliminating the bloated `rodata` payload.