### PR TITLE
[spi_device/spi_host, dv] Add SPI unmapped tests

### DIFF
--- a/hw/ip/spi_device/data/spi_device_testplan.hjson
+++ b/hw/ip/spi_device/data/spi_device_testplan.hjson
@@ -337,6 +337,19 @@
       tests: ["spi_device_cfg_cmd"]
     }
     {
+      name: flash_mode_ignore_cmds
+      desc: '''
+            - Set the device busy bit.
+            - Constrain the issued opcode to commands the spec requires to be ignored while
+              busy: WREN, WRDI, EN4B, EX4B, and upload commands with the busy bit set in
+              their cmd_info slot.
+            - Issue commands immediately without waiting for busy to de-assert.
+            - Check that the DUT discards each command without modifying flash status,
+              address-mode state or the upload FIFO.'''
+      stage: V2
+      tests: ["spi_device_flash_mode_ignore_cmds"]
+    }
+    {
       name: TPM_with_flash_or_passthrough_mode
       desc: '''
             - Enable TPM mode.

--- a/hw/ip/spi_host/data/spi_host_testplan.hjson
+++ b/hw/ip/spi_host/data/spi_host_testplan.hjson
@@ -105,6 +105,23 @@
       tests: ["spi_host_speed"]
     }
     {
+      name: upper_range_clkdiv
+      desc: '''
+            Verify SPI host correctness with large clock divider values.
+
+            Stimulus:
+              - Constrain CLKDIV to the upper half of the valid range, with 30 % probability
+                of selecting the maximum value
+              - Enable FSM fast mode so the internal counter decrements by 16 units per step,
+                bounding simulation time for very slow SPI clocks
+
+            Checking:
+              - Ensure transactions are transmitted/received correctly under slow SPI clocks
+            '''
+      stage: V2
+      tests: ["spi_host_upper_range_clkdiv"]
+    }
+    {
       name: sw_reset
       desc: '''
             verify software reset behavior


### PR DESCRIPTION
  - Add testpoint for spi_device_flash_mode_ignore_cmds in the spi_device testplan (introduced in #23599: disallow certain flash commands while busy).
  - Add testpoint for spi_host_upper_range_clkdiv in the spi_host testplan (introduced in #23906: SPI host timeout fixes).