### PR TITLE
[crypto] Add transitive feature to binary blob

### DIFF
--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -626,6 +626,22 @@ common_binary_attrs = {
     ),
 }
 
+def _transitive_feature_transition_impl(settings, attr):
+    features = settings["//command_line_option:features"] + attr.transitive_features
+    return {
+        "//command_line_option:features": features,
+    }
+
+_transitive_feature_transition = transition(
+    implementation = _transitive_feature_transition_impl,
+    inputs = [
+        "//command_line_option:features",
+    ],
+    outputs = [
+        "//command_line_option:features",
+    ],
+)
+
 opentitan_binary_blob = rv_rule(
     implementation = _opentitan_binary_blob,
     attrs = dict(common_binary_attrs.items() + {
@@ -640,7 +656,12 @@ opentitan_binary_blob = rv_rule(
         ),
         "deps_blob": attr.label_list(
             providers = [CcInfo],
+            cfg = _transitive_feature_transition,
             doc = "The list of other libraries to be for the creation of the binary blob.",
+        ),
+        "transitive_features": attr.string_list(
+            default = [],
+            doc = "Features to apply transitively to all dependencies.",
         ),
         "_linker_script_template": attr.label(
             default = Label("//sw/device/lib/crypto/configs:otcrypto_blob.ld"),

--- a/sw/device/lib/crypto/BUILD
+++ b/sw/device/lib/crypto/BUILD
@@ -56,6 +56,8 @@ opentitan_binary_blob(
         "//sw/device/lib/base:memory",
         "//sw/device/lib/runtime:log",
     ],
+    # We add the compiler option -fno-jump-tables to prevent the compiler making the code position dependent.
+    transitive_features = ["no_jump_tables"],
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/crypto/include:crypto_hdrs",

--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -46,8 +46,6 @@ dual_cc_library(
     hdrs = [
         "alert.h",
     ],
-    # We add the compiler option -fno-jump-tables to prevent the compiler making the code position dependent.
-    features = ["no_jump_tables"],
     deps = dual_inputs(
         device = [
             "//hw/top_earlgrey:alert_handler_c_regs",
@@ -88,8 +86,6 @@ cc_library(
     name = "aes",
     srcs = ["aes.c"],
     hdrs = ["aes.h"],
-    # We add the compiler option -fno-jump-tables to prevent the compiler making the code position dependent.
-    features = ["no_jump_tables"],
     deps = [
         ":rv_core_ibex",
         "//hw/ip/aes/data:aes_c_regs",
@@ -132,8 +128,6 @@ cc_library(
     hdrs = [
         "keymgr.h",
     ],
-    # We add the compiler option -fno-jump-tables to prevent the compiler making the code position dependent.
-    features = ["no_jump_tables"],
     deps = [
         ":rv_core_ibex",
         "//hw/ip/keymgr/data:keymgr_c_regs",
@@ -175,8 +169,6 @@ cc_library(
         "kmac.h",
         "//sw/device/lib/crypto/include:datatypes.h",
     ],
-    # We add the compiler option -fno-jump-tables to prevent the compiler making the code position dependent.
-    features = ["no_jump_tables"],
     deps = [
         ":rv_core_ibex",
         "//hw/ip/kmac/data:kmac_c_regs",
@@ -221,8 +213,6 @@ dual_cc_library(
         host = ["mock_entropy.cc"],
     ),
     hdrs = ["entropy.h"],
-    # We add the compiler option -fno-jump-tables to prevent the compiler making the code position dependent.
-    features = ["no_jump_tables"],
     deps = dual_inputs(
         device = [
             "//hw/ip/csrng/data:csrng_c_regs",
@@ -288,8 +278,6 @@ cc_library(
     name = "hmac",
     srcs = ["hmac.c"],
     hdrs = ["hmac.h"],
-    # We add the compiler option -fno-jump-tables to prevent the compiler making the code position dependent.
-    features = ["no_jump_tables"],
     deps = [
         "//hw/ip/hmac/data:hmac_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -337,8 +325,6 @@ dual_cc_library(
     hdrs = dual_inputs(
         shared = ["rv_core_ibex.h"],
     ),
-    # We add the compiler option -fno-jump-tables to prevent the compiler making the code position dependent.
-    features = ["no_jump_tables"],
     deps = dual_inputs(
         device = [
             "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -378,8 +364,6 @@ cc_library(
     name = "otbn",
     srcs = ["otbn.c"],
     hdrs = ["otbn.h"],
-    # We add the compiler option -fno-jump-tables to prevent the compiler making the code position dependent.
-    features = ["no_jump_tables"],
     deps = [
         "//hw/ip/otbn/data:otbn_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -319,6 +319,7 @@ opentitan_binary_blob(
         "//sw/device/lib/runtime:log",
     ],
     rom_origin = "0x10000",
+    transitive_features = ["no_jump_tables"],
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/crypto/include:crypto_hdrs",


### PR DESCRIPTION
The the transitive_features option with opentitan_binary_blob to allow compiler flags to be applied to the dependencies from the target. Then move no-jump-tables to this feature.

With thanks to Yi-Hsuan Deng <yhdeng@google.com>