### PR TITLE
WIP: [rom_ext] Support flexible owner image placement

### DIFF
--- a/rules/manifest.bzl
+++ b/rules/manifest.bzl
@@ -167,7 +167,7 @@ def _manifest_impl(ctx):
             "secver_write",
             "isfb",
             "isfb_erase",
-            None,
+            "base_addr",
             None,
             None,
             None,
@@ -209,6 +209,16 @@ def _manifest_impl(ctx):
             },
         )
 
+    base_addr = ctx.attr.base_addr
+    if base_addr != "none":
+        mf["extension_params"].append(
+            {
+                "base_addr": {
+                    "base_addr": int(base_addr, 0),
+                },
+            },
+        )
+
     file = ctx.actions.declare_file("{}.json".format(ctx.attr.name))
     ctx.actions.write(file, json.encode_indent(mf))
     return DefaultInfo(
@@ -246,6 +256,7 @@ _manifest = rule(
         "integrator_specific_firmware_binding": attr.string(doc = "Create an Integrator Specific Firmware Block (ISFB) JSON object"),
         "isfb_erase_allowed_policy": attr.string(doc = "Create an ISFB Erase Allowed Policy JSON object"),
         "secver_write": attr.string(default = "none", values = ["none", "false", "true"], doc = "Add the secver_write extension with the specified value"),
+        "base_addr": attr.string(default = "none", doc = "Add the base_addr extension with the specified value"),
     },
 )
 

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -215,6 +215,7 @@ def opentitan_test(
         silicon = _silicon_params(),
         verilator = _verilator_params(),
         qemu = _qemu_params(),
+        slot_spec = {},
         run_in_ci = None,
         **kwargs):
     """Instantiate a test per execution environment.
@@ -329,6 +330,7 @@ def opentitan_test(
             rsa_key = rsa_key,
             spx_key = spx_key,
             manifest = manifest,
+            slot_spec = slot_spec,
             needs_jtag = getattr(tparam, "needs_jtag", False),
         )
 

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -147,6 +147,7 @@ enum module_ {
   X(kErrorBootPolicyBadIdentifier,    ERROR_(1, kModuleBootPolicy, kInternal)), \
   X(kErrorBootPolicyBadLength,        ERROR_(2, kModuleBootPolicy, kInternal)), \
   X(kErrorBootPolicyRollback,         ERROR_(3, kModuleBootPolicy, kInternal)), \
+  X(kErrorBootPolicyBadBaseAddr,      ERROR_(4, kModuleBootPolicy, kInternal)), \
   \
   X(kErrorBootstrapEraseAddress,      ERROR_(1, kModuleBootstrap, kInvalidArgument)), \
   X(kErrorBootstrapProgramAddress,    ERROR_(2, kModuleBootstrap, kInvalidArgument)), \

--- a/sw/device/silicon_creator/lib/manifest.c
+++ b/sw/device/silicon_creator/lib/manifest.c
@@ -40,3 +40,5 @@ extern rom_error_t manifest_ext_get_isfb(const manifest_t *manifest,
                                          const manifest_ext_isfb_t **isfb);
 extern rom_error_t manifest_ext_get_isfb_erase(
     const manifest_t *manifest, const manifest_ext_isfb_erase_t **isfb_erase);
+extern rom_error_t manifest_ext_get_base_addr(
+    const manifest_t *manifest, const manifest_ext_base_addr_t **base_addr);

--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -415,6 +415,10 @@ enum {
    */
   kManifestExtIdIsfbErase = 0x45465349,
   /**
+   * ASCII "BASE".
+   */
+  kManifestExtIdBaseAddr = 0x45534142,
+  /**
    * ASCII "EXT0.
    */
   kManifestExtNameSpxKey = 0x30545845,
@@ -422,6 +426,10 @@ enum {
    * ASCII "EXT1.
    */
   kManifestExtNameSpxSignature = 0x31545845,
+  /**
+   * ASCII "BADD".
+   */
+  kManifestExtNameBaseAddr = 0x44444142,
 };
 
 /**
@@ -550,6 +558,20 @@ typedef struct manifest_ext_isfb_erase {
 } manifest_ext_isfb_erase_t;
 
 /**
+ * Manifest extension: Base address the image is designed to be placed.
+ */
+typedef struct manifest_ext_base_addr {
+  /**
+   * Required manifest header.
+   */
+  manifest_ext_header_t header;
+  /**
+   * Base address offset (relative to bank start).
+   */
+  uint32_t base_addr;
+} manifest_ext_base_addr_t;
+
+/**
  * Table of manifest extensions.
  *
  * Columns: Table index, type name, extenstion name, identifier, signed or not.
@@ -560,7 +582,8 @@ typedef struct manifest_ext_isfb_erase {
   X(1, manifest_ext_spx_signature_t, spx_signature, kManifestExtIdSpxSignature, false) \
   X(2, manifest_ext_secver_write_t,  secver_write,  kManifestExtIdSecVerWrite,  true)  \
   X(3, manifest_ext_isfb_t,          isfb,          kManifestExtIdIsfb,         true)  \
-  X(4, manifest_ext_isfb_erase_t,    isfb_erase,    kManifestExtIdIsfbErase,    true)
+  X(4, manifest_ext_isfb_erase_t,    isfb_erase,    kManifestExtIdIsfbErase,    true)  \
+  X(5, manifest_ext_base_addr_t,     base_addr,     kManifestExtIdBaseAddr,     true)
 // clang-format on
 
 #if defined(OT_PLATFORM_RV32) || defined(MANIFEST_UNIT_TEST_)
@@ -722,6 +745,8 @@ rom_error_t manifest_ext_get_isfb(const manifest_t *manifest,
                                   const manifest_ext_isfb_t **isfb);
 rom_error_t manifest_ext_get_isfb_erase(
     const manifest_t *manifest, const manifest_ext_isfb_erase_t **isfb_erase);
+rom_error_t manifest_ext_get_base_addr(
+    const manifest_t *manifest, const manifest_ext_base_addr_t **base_addr);
 
 #endif  // defined(OT_PLATFORM_RV32) || defined(MANIFEST_UNIT_TEST_)
 

--- a/sw/device/silicon_creator/lib/mock_manifest.cc
+++ b/sw/device/silicon_creator/lib/mock_manifest.cc
@@ -39,5 +39,10 @@ rom_error_t manifest_ext_get_isfb(const manifest_t *manifest,
   return MockManifest::Instance().Isfb(manifest, isfb);
 }
 
+rom_error_t manifest_ext_get_base_addr(
+    const manifest_t *manifest, const manifest_ext_base_addr_t **base_addr) {
+  return MockManifest::Instance().BaseAddr(manifest, base_addr);
+}
+
 }  // extern "C"
 }  // namespace rom_test

--- a/sw/device/silicon_creator/lib/mock_manifest.h
+++ b/sw/device/silicon_creator/lib/mock_manifest.h
@@ -28,6 +28,8 @@ class MockManifest : public global_mock::GlobalMock<MockManifest> {
                const manifest_ext_spx_signature_t **spx_signature));
   MOCK_METHOD(rom_error_t, Isfb,
               (const manifest_t *, const manifest_ext_isfb_t **isfb));
+  MOCK_METHOD(rom_error_t, BaseAddr,
+              (const manifest_t *, const manifest_ext_base_addr_t **base_addr));
 };
 
 }  // namespace internal

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
@@ -82,6 +82,32 @@ _POSITIONS = {
         "success": "bl0_slot = __BB\r\n",
         "otp_img": None,
     },
+    "owner_slot_b_shifted_pass": {
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
+        "romext_offset": "{rom_ext_slot_a}",
+        "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_b",
+        "owner_offset": "{owner_slot_b}",
+        "success": "bl0_slot = __BB\r\n",
+        "otp_img": None,
+        "manifest": ":owner_slot_b_shifted_manifest",
+        "slot_spec": {
+            "rom_ext_size": "0x12000",
+            "owner_slot_b": "0x92000",
+        },
+    },
+    "owner_slot_b_shifted_fail": {
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
+        "romext_offset": "{rom_ext_slot_a}",
+        "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_b",
+        "owner_offset": "{owner_slot_b}",
+        "success": "BFV:0442500d",
+        "failure": "bl0_slot = __BB\r\n",
+        "otp_img": None,
+        "slot_spec": {
+            "rom_ext_size": "0x12000",
+            "owner_slot_b": "0x92000",
+        },
+    },
     "owner_virtual_a": {
         "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
         "romext_offset": "{rom_ext_slot_a}",
@@ -170,6 +196,7 @@ _POSITIONS = {
             romext_offset = position["romext_offset"],
         ),
         linker_script = position["linker_script"],
+        manifest = position.get("manifest"),
         qemu = qemu_params(
             assemble = "{romext}@{romext_offset} {firmware}@{owner_offset}",
             binaries = {
@@ -181,6 +208,7 @@ _POSITIONS = {
             owner_offset = position["owner_offset"],
             romext_offset = position["romext_offset"],
         ),
+        slot_spec = position.get("slot_spec", {}),
         deps = [
             "//sw/device/lib/base:status",
             "//sw/device/lib/testing/test_framework:ottf_main",
@@ -195,6 +223,14 @@ test_suite(
     name = "positions",
     tests = ["position_{}".format(name) for name in _POSITIONS],
 )
+
+manifest(d = {
+    "name": "owner_slot_b_shifted_manifest",
+    "address_translation": hex(CONST.HARDENED_FALSE),
+    "identifier": hex(CONST.OWNER),
+    "base_addr": "0x12000",
+    "visibility": ["//visibility:public"],
+})
 
 manifest(d = {
     "name": "bad_manifest",

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -213,17 +213,8 @@ void rom_ext_sram_exec(owner_sram_exec_mode_t mode) {
 extern char _owner_virtual_start_address[];
 extern char _owner_virtual_size[];
 
-/**
- * Compute the virtual address corresponding to the physical address `lma_addr`.
- *
- * @param manifest Pointer to the current manifest.
- * @param lma_addr Load address or physical address.
- * @return the computed virtual address.
- */
-OT_WARN_UNUSED_RESULT
-static uintptr_t owner_vma_get(const manifest_t *manifest, uintptr_t lma_addr) {
-  return (lma_addr - (uintptr_t)manifest +
-          (uintptr_t)_owner_virtual_start_address + CHIP_ROM_EXT_SIZE_MAX);
+static uintptr_t owner_vma_get(uintptr_t bank_base, uintptr_t lma_addr) {
+  return lma_addr - bank_base + (uintptr_t)_owner_virtual_start_address;
 }
 
 OT_WARN_UNUSED_RESULT
@@ -291,8 +282,9 @@ static rom_error_t rom_ext_boot(boot_data_t *boot_data, boot_log_t *boot_log,
   switch (launder32(manifest->address_translation)) {
     case kHardenedBoolTrue:
       HARDENED_CHECK_EQ(manifest->address_translation, kHardenedBoolTrue);
-      ibex_addr_remap_1_set((uintptr_t)_owner_virtual_start_address,
-                            (uintptr_t)manifest, (size_t)_owner_virtual_size);
+      uintptr_t bank_base = flash_bank_base_get((uintptr_t)manifest);
+      ibex_addr_remap_1_set((uintptr_t)_owner_virtual_start_address, bank_base,
+                            (size_t)_owner_virtual_size);
       SEC_MMIO_WRITE_INCREMENT(kAddressTranslationSecMmioConfigure);
 
       // Unlock read-only for the whole rom_ext virtual memory.
@@ -308,9 +300,9 @@ static rom_error_t rom_ext_boot(boot_data_t *boot_data, boot_log_t *boot_log,
       // Move the ROM_EXT execution section from the load address to the virtual
       // address.
       // TODO(#13513): Harden these calculations.
-      text_region.start = owner_vma_get(manifest, text_region.start);
-      text_region.end = owner_vma_get(manifest, text_region.end);
-      entry_point = owner_vma_get(manifest, entry_point);
+      text_region.start = owner_vma_get(bank_base, text_region.start);
+      text_region.end = owner_vma_get(bank_base, text_region.end);
+      entry_point = owner_vma_get(bank_base, entry_point);
       break;
     case kHardenedBoolFalse:
       HARDENED_CHECK_EQ(manifest->address_translation, kHardenedBoolFalse);
@@ -392,31 +384,24 @@ static rom_error_t rom_ext_try_next_stage(boot_data_t *boot_data,
   rom_error_t slot[2] = {0, 0};
   for (size_t i = 0; i < ARRAYSIZE(manifests.ordered); ++i) {
     uint32_t flash_exec = 0;
-    char slot_id =
-        (manifests.ordered[i] == rom_ext_boot_policy_manifest_a_get()) ? 'A'
-                                                                       : 'B';
+    boot_slot_t current_slot = manifests.ordered[i].slot;
+    const manifest_t *manifest = manifests.ordered[i].manifest;
+
     error =
-        rom_ext_verify(manifests.ordered[i], slot_id, boot_data, &flash_exec,
-                       &keyring, &verify_key, &owner_config, &isfb_check_count);
+        rom_ext_verify(manifest, current_slot, boot_data, &flash_exec, &keyring,
+                       &verify_key, &owner_config, &isfb_check_count);
     slot[i] = error;
     if (error != kErrorOk) {
-      dbg_printf("verifyfail: Slot%c;%x\r\n", slot_id, error);
+      dbg_printf("verifyfail: Slot:%C;%x\r\n", current_slot, error);
       continue;
     }
     HARDENED_CHECK_EQ(flash_exec, kSigverifyFlashExec);
 
-    if (manifests.ordered[i] == rom_ext_boot_policy_manifest_a_get()) {
-      boot_log->bl0_slot = kBootSlotA;
-    } else if (manifests.ordered[i] == rom_ext_boot_policy_manifest_b_get()) {
-      boot_log->bl0_slot = kBootSlotB;
-    } else {
-      return kErrorRomExtBootFailed;
-    }
+    boot_log->bl0_slot = current_slot;
     boot_log_digest_update(boot_log);
 
     // Boot fails if a verified ROM_EXT cannot be booted.
-    RETURN_IF_ERROR(
-        rom_ext_boot(boot_data, boot_log, manifests.ordered[i], &flash_exec));
+    RETURN_IF_ERROR(rom_ext_boot(boot_data, boot_log, manifest, &flash_exec));
     // `rom_ext_boot()` should never return `kErrorOk`, but if it does
     // we must shut down the chip instead of trying the next ROM_EXT.
     return kErrorRomExtBootFailed;
@@ -435,6 +420,10 @@ static rom_error_t rom_ext_try_next_stage(boot_data_t *boot_data,
 }
 
 static void rom_ext_flash_protect_self(uint32_t rom_ext_slot) {
+  const manifest_t *self = rom_ext_manifest();
+  uint32_t actual_size = self->length;
+  uint32_t pages = (actual_size + kFlashPageSize - 1) / kFlashPageSize;
+
   flash_ctrl_cfg_t cfg = flash_ctrl_data_default_cfg_get();
   flash_ctrl_perms_t read = {
       .read = kMultiBitBool4True,
@@ -446,10 +435,10 @@ static void rom_ext_flash_protect_self(uint32_t rom_ext_slot) {
       .write = kMultiBitBool4True,
       .erase = kMultiBitBool4True,
   };
-  flash_ctrl_data_region_protect(0, kRomExtAStart, kRomExtSizeInPages,
+  flash_ctrl_data_region_protect(0, kRomExtAStart, pages,
                                  rom_ext_slot == kBootSlotA ? read : write, cfg,
                                  kHardenedBoolTrue);
-  flash_ctrl_data_region_protect(1, kRomExtBStart, kRomExtSizeInPages,
+  flash_ctrl_data_region_protect(1, kRomExtBStart, pages,
                                  rom_ext_slot == kBootSlotB ? read : write, cfg,
                                  kHardenedBoolTrue);
 }
@@ -562,7 +551,7 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   boot_log_check_or_init(boot_log, rom_ext_current_slot(), rom_chip_info);
   boot_log->rom_ext_major = self->version_major;
   boot_log->rom_ext_minor = self->version_minor;
-  boot_log->rom_ext_size = CHIP_ROM_EXT_SIZE_MAX;
+  boot_log->rom_ext_size = self->length;
   // Even though `primary_bl0_slot` can be changed by boot svc, we initialize
   // it here so the "SetNextBl0" can do a one-time override of the RAM copy
   // of `boot_data`.

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.c
@@ -13,18 +13,23 @@ rom_ext_boot_policy_manifests_t rom_ext_boot_policy_manifests_get(
     const boot_data_t *boot_data) {
   const manifest_t *slot_a = rom_ext_boot_policy_manifest_a_get();
   const manifest_t *slot_b = rom_ext_boot_policy_manifest_b_get();
+
+  rom_ext_boot_policy_manifest_t manifest_a = {.manifest = slot_a,
+                                               .slot = kBootSlotA};
+  rom_ext_boot_policy_manifest_t manifest_b = {.manifest = slot_b,
+                                               .slot = kBootSlotB};
+
   uint32_t slot = boot_data->primary_bl0_slot;
   switch (launder32(slot)) {
     case kBootSlotB:
       HARDENED_CHECK_EQ(slot, kBootSlotB);
       return (rom_ext_boot_policy_manifests_t){
-          .ordered = {slot_b, slot_a},
+          .ordered = {manifest_b, manifest_a},
       };
     case kBootSlotA:
-      OT_FALLTHROUGH_INTENDED;
     default:
       return (rom_ext_boot_policy_manifests_t){
-          .ordered = {slot_a, slot_b},
+          .ordered = {manifest_a, manifest_b},
       };
   }
 }
@@ -63,6 +68,9 @@ static inline rom_error_t manifest_check_rom_ext(const manifest_t *manifest) {
 
 rom_error_t rom_ext_boot_policy_manifest_check(const manifest_t *manifest,
                                                const boot_data_t *boot_data) {
+  if (manifest == NULL) {
+    return kErrorBootPolicyBadIdentifier;
+  }
   if (manifest->identifier != CHIP_BL0_IDENTIFIER) {
     return kErrorBootPolicyBadIdentifier;
   }
@@ -82,6 +90,20 @@ rom_error_t rom_ext_boot_policy_manifest_check(const manifest_t *manifest,
                     boot_data->min_security_version_bl0);
 
   RETURN_IF_ERROR(manifest_check_rom_ext(manifest));
+
+  // Base address check
+  uintptr_t bank_base = flash_bank_base_get((uintptr_t)manifest);
+  uint32_t base_addr = (uintptr_t)manifest - bank_base;
+
+  uint32_t expected_base_addr = 0x10000;  // 64K default
+  const manifest_ext_base_addr_t *ext;
+  if (manifest_ext_get_base_addr(manifest, &ext) == kErrorOk) {
+    expected_base_addr = ext->base_addr;
+  }
+  if (base_addr != expected_base_addr) {
+    return kErrorBootPolicyBadBaseAddr;
+  }
+
   return kErrorOk;
 }
 

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.h
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.h
@@ -27,12 +27,17 @@ typedef void owner_stage_entry_point(void);
  *
  * These boot stages must be verified prior to handing over execution.
  */
+typedef struct rom_ext_boot_policy_manifest {
+  const manifest_t *manifest;
+  boot_slot_t slot;
+} rom_ext_boot_policy_manifest_t;
+
 typedef struct rom_ext_boot_policy_manifests {
   /**
    * First owner boot stage manifests in descending order according to
    * their security versions.
    */
-  const manifest_t *ordered[2];
+  rom_ext_boot_policy_manifest_t ordered[2];
 } rom_ext_boot_policy_manifests_t;
 
 /**

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h
@@ -18,7 +18,51 @@ extern "C" {
 static_assert((TOP_EARLGREY_EFLASH_SIZE_BYTES % 2) == 0,
               "Flash size is not divisible by 2");
 
+/**
+ * Returns the base address of the flash bank containing the given address.
+ *
+ * This function asserts that the calculated base address is indeed either Bank
+ * A or Bank B base address, and triggers a hardened trap on target if the
+ * assertion fails (e.g., if the input address is outside the valid flash
+ * boundaries).
+ *
+ * @param addr A physical address in flash.
+ * @return The base address of the flash bank (either Bank A or Bank B).
+ */
+static inline uintptr_t flash_bank_base_get(uintptr_t addr) {
+  uintptr_t bank_size = TOP_EARLGREY_EFLASH_SIZE_BYTES / 2;
+  uintptr_t bank_base = addr & ~(bank_size - 1);
+
+#if defined(OT_PLATFORM_RV32)
+  uintptr_t diff = launder32(bank_base) ^ TOP_EARLGREY_EFLASH_BASE_ADDR;
+  HARDENED_CHECK_EQ(diff & ~bank_size, 0);
+#endif
+
+  return bank_base;
+}
+
 #ifdef OT_PLATFORM_RV32
+/**
+ * Helper function to scan a flash bank for the first valid owner boot stage
+ * manifest.
+ *
+ * The scan starts at a 64K offset (0x10000) and ends at a 256K offset (0x40000)
+ * (excluded) in steps of 8K (0x2000).
+ *
+ * @param bank_base The base address of the flash bank.
+ * @return Pointer to the first found manifest, or NULL if none found.
+ */
+static inline const manifest_t *rom_ext_boot_policy_manifest_search(
+    uintptr_t bank_base) {
+  for (uintptr_t offset = 0x10000; offset < 0x40000; offset += 0x2000) {
+    const manifest_t *manifest = (const manifest_t *)(bank_base + offset);
+    if (manifest->identifier == CHIP_BL0_IDENTIFIER) {
+      return manifest;
+    }
+  }
+  return NULL;
+}
+
 /**
  * Returns a pointer to the manifest of the first owner boot stage image stored
  * in flash slot A.
@@ -27,9 +71,8 @@ static_assert((TOP_EARLGREY_EFLASH_SIZE_BYTES % 2) == 0,
  * A.
  */
 OT_WARN_UNUSED_RESULT
-inline const manifest_t *rom_ext_boot_policy_manifest_a_get(void) {
-  return (const manifest_t *)(TOP_EARLGREY_EFLASH_BASE_ADDR +
-                              CHIP_ROM_EXT_SIZE_MAX);
+static inline const manifest_t *rom_ext_boot_policy_manifest_a_get(void) {
+  return rom_ext_boot_policy_manifest_search(TOP_EARLGREY_EFLASH_BASE_ADDR);
 }
 
 /**
@@ -40,10 +83,9 @@ inline const manifest_t *rom_ext_boot_policy_manifest_a_get(void) {
  * B.
  */
 OT_WARN_UNUSED_RESULT
-inline const manifest_t *rom_ext_boot_policy_manifest_b_get(void) {
-  return (const manifest_t *)(TOP_EARLGREY_EFLASH_BASE_ADDR +
-                              (TOP_EARLGREY_EFLASH_SIZE_BYTES / 2) +
-                              CHIP_ROM_EXT_SIZE_MAX);
+static inline const manifest_t *rom_ext_boot_policy_manifest_b_get(void) {
+  return rom_ext_boot_policy_manifest_search(
+      TOP_EARLGREY_EFLASH_BASE_ADDR + (TOP_EARLGREY_EFLASH_SIZE_BYTES / 2));
 }
 #else
 /**

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_unittest.cc
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_unittest.cc
@@ -148,11 +148,15 @@ TEST_P(ManifestOrderTest, ManifestsGet) {
   rom_ext_boot_policy_manifests_t res =
       rom_ext_boot_policy_manifests_get(&boot_data);
   if (GetParam().primary == kBootSlotA) {
-    EXPECT_EQ(res.ordered[0], &manifest_a);
-    EXPECT_EQ(res.ordered[1], &manifest_b);
+    EXPECT_EQ(res.ordered[0].manifest, &manifest_a);
+    EXPECT_EQ(res.ordered[0].slot, kBootSlotA);
+    EXPECT_EQ(res.ordered[1].manifest, &manifest_b);
+    EXPECT_EQ(res.ordered[1].slot, kBootSlotB);
   } else {
-    EXPECT_EQ(res.ordered[0], &manifest_b);
-    EXPECT_EQ(res.ordered[1], &manifest_a);
+    EXPECT_EQ(res.ordered[0].manifest, &manifest_b);
+    EXPECT_EQ(res.ordered[0].slot, kBootSlotB);
+    EXPECT_EQ(res.ordered[1].manifest, &manifest_a);
+    EXPECT_EQ(res.ordered[1].slot, kBootSlotA);
   }
 }
 

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_services.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_services.c
@@ -95,14 +95,15 @@ static rom_error_t boot_svc_min_sec_ver_handler(
     const manifest_t *manifest = rom_ext_boot_policy_manifest_a_get();
     uint32_t flash_exec = 0;
     rom_error_t error =
-        rom_ext_verify(manifest, /*slot_id=*/0, boot_data, &flash_exec, keyring,
-                       verify_key, owner_config, isfb_check_count);
+        rom_ext_verify(manifest, kBootSlotUnspecified, boot_data, &flash_exec,
+                       keyring, verify_key, owner_config, isfb_check_count);
     if (error == kErrorOk) {
       slot_a_max_sec_ver = manifest->security_version;
     }
     manifest = rom_ext_boot_policy_manifest_b_get();
-    error = rom_ext_verify(manifest, /*slot_id=*/0, boot_data, &flash_exec,
-                           keyring, verify_key, owner_config, isfb_check_count);
+    error =
+        rom_ext_verify(manifest, kBootSlotUnspecified, boot_data, &flash_exec,
+                       keyring, verify_key, owner_config, isfb_check_count);
     if (error == kErrorOk) {
       slot_b_max_sec_ver = manifest->security_version;
     }

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_services_unittest.cc
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_services_unittest.cc
@@ -219,6 +219,16 @@ TEST_F(RomExtBootServicesTest, BootSvcMinBl0SecVerValid) {
   manifest_t manifest_a{};
   manifest_t manifest_b{};
 
+  uintptr_t addr_a = (uintptr_t)&manifest_a;
+  uintptr_t bank_base_a = addr_a & ~((TOP_EARLGREY_EFLASH_SIZE_BYTES / 2) - 1);
+  uint32_t offset_a = addr_a - bank_base_a;
+  manifest_ext_base_addr_t ext_base_addr_a{.base_addr = offset_a};
+
+  uintptr_t addr_b = (uintptr_t)&manifest_b;
+  uintptr_t bank_base_b = addr_b & ~((TOP_EARLGREY_EFLASH_SIZE_BYTES / 2) - 1);
+  uint32_t offset_b = addr_b - bank_base_b;
+  manifest_ext_base_addr_t ext_base_addr_b{.base_addr = offset_b};
+
   manifest_a.identifier = CHIP_BL0_IDENTIFIER;
   manifest_a.length = CHIP_BL0_SIZE_MIN;
   manifest_a.security_version = 2;
@@ -250,6 +260,8 @@ TEST_F(RomExtBootServicesTest, BootSvcMinBl0SecVerValid) {
       .WillOnce(Return(kErrorManifestBadExtension));
   EXPECT_CALL(mock_manifest_, SpxSignature)
       .WillOnce(Return(kErrorManifestBadExtension));
+  EXPECT_CALL(mock_manifest_, BaseAddr(&manifest_a, _))
+      .WillOnce(DoAll(SetArgPointee<1>(&ext_base_addr_a), Return(kErrorOk)));
 
   EXPECT_CALL(mock_rnd_, Uint32);
   EXPECT_CALL(mock_hmac_, sha256_init);
@@ -271,6 +283,8 @@ TEST_F(RomExtBootServicesTest, BootSvcMinBl0SecVerValid) {
       .WillOnce(Return(kErrorManifestBadExtension));
   EXPECT_CALL(mock_manifest_, SpxSignature)
       .WillOnce(Return(kErrorManifestBadExtension));
+  EXPECT_CALL(mock_manifest_, BaseAddr(&manifest_b, _))
+      .WillOnce(DoAll(SetArgPointee<1>(&ext_base_addr_b), Return(kErrorOk)));
 
   EXPECT_CALL(mock_rnd_, Uint32);
   EXPECT_CALL(mock_hmac_, sha256_init);
@@ -375,6 +389,16 @@ TEST_F(RomExtBootServicesTest, BootSvcMinBl0SecVerInvalidHigh) {
   manifest_t manifest_a{};
   manifest_t manifest_b{};
 
+  uintptr_t addr_a = (uintptr_t)&manifest_a;
+  uintptr_t bank_base_a = addr_a & ~((TOP_EARLGREY_EFLASH_SIZE_BYTES / 2) - 1);
+  uint32_t offset_a = addr_a - bank_base_a;
+  manifest_ext_base_addr_t ext_base_addr_a{.base_addr = offset_a};
+
+  uintptr_t addr_b = (uintptr_t)&manifest_b;
+  uintptr_t bank_base_b = addr_b & ~((TOP_EARLGREY_EFLASH_SIZE_BYTES / 2) - 1);
+  uint32_t offset_b = addr_b - bank_base_b;
+  manifest_ext_base_addr_t ext_base_addr_b{.base_addr = offset_b};
+
   manifest_a.identifier = CHIP_BL0_IDENTIFIER;
   manifest_a.length = CHIP_BL0_SIZE_MIN;
   manifest_a.security_version = 2;
@@ -406,6 +430,8 @@ TEST_F(RomExtBootServicesTest, BootSvcMinBl0SecVerInvalidHigh) {
       .WillOnce(Return(kErrorManifestBadExtension));
   EXPECT_CALL(mock_manifest_, SpxSignature)
       .WillOnce(Return(kErrorManifestBadExtension));
+  EXPECT_CALL(mock_manifest_, BaseAddr(&manifest_a, _))
+      .WillOnce(DoAll(SetArgPointee<1>(&ext_base_addr_a), Return(kErrorOk)));
 
   EXPECT_CALL(mock_rnd_, Uint32);
   EXPECT_CALL(mock_hmac_, sha256_init);
@@ -427,6 +453,8 @@ TEST_F(RomExtBootServicesTest, BootSvcMinBl0SecVerInvalidHigh) {
       .WillOnce(Return(kErrorManifestBadExtension));
   EXPECT_CALL(mock_manifest_, SpxSignature)
       .WillOnce(Return(kErrorManifestBadExtension));
+  EXPECT_CALL(mock_manifest_, BaseAddr(&manifest_b, _))
+      .WillOnce(DoAll(SetArgPointee<1>(&ext_base_addr_b), Return(kErrorOk)));
 
   EXPECT_CALL(mock_rnd_, Uint32);
   EXPECT_CALL(mock_hmac_, sha256_init);

--- a/sw/device/silicon_creator/rom_ext/rom_ext_verify.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_verify.c
@@ -20,7 +20,7 @@
 #include "sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.h"
 
 OT_WARN_UNUSED_RESULT
-rom_error_t rom_ext_verify(const manifest_t *manifest, char slot_id,
+rom_error_t rom_ext_verify(const manifest_t *manifest, boot_slot_t slot,
                            const boot_data_t *boot_data, uint32_t *flash_exec,
                            owner_application_keyring_t *keyring,
                            size_t *verify_key, owner_config_t *owner_config,
@@ -51,8 +51,8 @@ rom_error_t rom_ext_verify(const manifest_t *manifest, char slot_id,
   RETURN_IF_ERROR(owner_keyring_find_key(keyring, key_id, verify_key));
   uint32_t key_alg = keyring->key[*verify_key]->key_alg;
 
-  if (slot_id) {
-    dbg_printf("verify: Slot%c;key%u;%C;%C\r\n", slot_id, (uint32_t)*verify_key,
+  if (slot != kBootSlotUnspecified) {
+    dbg_printf("verify: Slot:%C;key%u;%C;%C\r\n", slot, (uint32_t)*verify_key,
                key_alg, keyring->key[*verify_key]->key_domain);
   }
 

--- a/sw/device/silicon_creator/rom_ext/rom_ext_verify.h
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_verify.h
@@ -18,9 +18,9 @@ extern "C" {
  * Verify the the next boot stage according to the owner configuration.
  *
  * @param manifest Pointer to the manifest being examined.
- * @param slot_id Name of the slot being examined ('A', 'B' or 0).  This
- *                parameter controls the "verify" debug print, but is not used
- *                for any verification purpose.
+ * @param slot Slot being examined (kBootSlotA, kBootSlotB or
+ * kBootSlotUnspecified). This parameter controls the "verify" debug print, but
+ * is not used for any verification purpose.
  * @param boot_data Pointer to the boot_data struct.
  * @param flash_exec[out] Redundant check word for image validity.
  * @param keyring A list of valid owner Application keys.
@@ -31,7 +31,7 @@ extern "C" {
  * @return kErrorOk or a validation error.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t rom_ext_verify(const manifest_t *manifest, char slot_id,
+rom_error_t rom_ext_verify(const manifest_t *manifest, boot_slot_t slot,
                            const boot_data_t *boot_data, uint32_t *flash_exec,
                            owner_application_keyring_t *keyring,
                            size_t *verify_key, owner_config_t *owner_config,

--- a/sw/host/opentitanlib/src/image/manifest.rs
+++ b/sw/host/opentitanlib/src/image/manifest.rs
@@ -46,12 +46,14 @@ pub const MANIFEST_EXT_ID_SECVER_WRITE: u32 = 0x3f086a41;
 pub const MANIFEST_EXT_ID_ISFB: u32 = 0x42465349;
 pub const MANIFEST_EXT_ID_ISFB_ERASE: u32 = 0x45465349;
 pub const MANIFEST_EXT_ID_IMAGE_TYPE: u32 = 0x494d4754;
+pub const MANIFEST_EXT_ID_BASE_ADDR: u32 = 0x45534142;
 pub const MANIFEST_EXT_NAME_SPX_KEY: u32 = 0x30545845;
 pub const MANIFEST_EXT_NAME_SPX_SIGNATURE: u32 = 0x31545845;
 pub const MANIFEST_EXT_NAME_SECVER_WRITE: u32 = 0x56434553;
 pub const MANIFEST_EXT_NAME_ISFB: u32 = 0x42465349;
 pub const MANIFEST_EXT_NAME_ISFB_ERASE: u32 = 0x45465349;
 pub const MANIFEST_EXT_NAME_IMAGE_TYPE: u32 = 0x494d4754;
+pub const MANIFEST_EXT_NAME_BASE_ADDR: u32 = 0x44444142;
 pub const CHIP_ROM_EXT_IDENTIFIER: u32 = 0x4552544f;
 pub const CHIP_BL0_IDENTIFIER: u32 = 0x3042544f;
 pub const CHIP_ROM_EXT_SIZE_MIN: u32 = 8788;
@@ -219,6 +221,13 @@ pub struct ManifestExtIsfbErasePolicy {
 pub struct ManifestExtImageType {
     pub header: ManifestExtHeader,
     pub image_type: u32,
+}
+
+#[repr(C)]
+#[derive(Immutable, IntoBytes, FromBytes, Debug, Default)]
+pub struct ManifestExtBaseAddr {
+    pub header: ManifestExtHeader,
+    pub base_addr: u32,
 }
 
 /// A type that holds the 256-bit device identifier.

--- a/sw/host/opentitanlib/src/image/manifest_ext.rs
+++ b/sw/host/opentitanlib/src/image/manifest_ext.rs
@@ -31,6 +31,7 @@ with_unknown! {
         isfb = MANIFEST_EXT_ID_ISFB,
         isfb_erase = MANIFEST_EXT_ID_ISFB_ERASE,
         image_type = MANIFEST_EXT_ID_IMAGE_TYPE,
+        base_addr = MANIFEST_EXT_ID_BASE_ADDR,
     }
 }
 
@@ -79,6 +80,9 @@ pub enum ManifestExtEntrySpec {
     #[serde(alias = "image_type")]
     ImageType { image_type: u32 },
 
+    #[serde(alias = "base_addr")]
+    BaseAddr { base_addr: u32 },
+
     #[serde(alias = "raw")]
     Raw {
         name: HexEncoded<u32>,
@@ -96,6 +100,7 @@ pub enum ManifestExtEntry {
     Isfb(ManifestExtIsfb),
     IsfbErasePolicy(ManifestExtIsfbErasePolicy),
     ImageType(ManifestExtImageType),
+    BaseAddr(ManifestExtBaseAddr),
     Raw {
         header: ManifestExtHeader,
         data: Vec<u8>,
@@ -130,6 +135,7 @@ impl ManifestExtEntrySpec {
             ManifestExtEntrySpec::Isfb { .. } => MANIFEST_EXT_ID_ISFB,
             ManifestExtEntrySpec::IsfbErasePolicy { .. } => MANIFEST_EXT_ID_ISFB_ERASE,
             ManifestExtEntrySpec::ImageType { image_type: _ } => MANIFEST_EXT_ID_IMAGE_TYPE,
+            ManifestExtEntrySpec::BaseAddr { .. } => MANIFEST_EXT_ID_BASE_ADDR,
             ManifestExtEntrySpec::Raw { identifier, .. } => **identifier,
         }
     }
@@ -140,7 +146,8 @@ impl ManifestExtEntrySpec {
             | ManifestExtEntrySpec::SecVerWrite { .. }
             | ManifestExtEntrySpec::Isfb { .. }
             | ManifestExtEntrySpec::IsfbErasePolicy { .. }
-            | ManifestExtEntrySpec::ImageType { .. } => true,
+            | ManifestExtEntrySpec::ImageType { .. }
+            | ManifestExtEntrySpec::BaseAddr { .. } => true,
             ManifestExtEntrySpec::SpxSignature { .. } => false,
             ManifestExtEntrySpec::Raw { signed, .. } => *signed,
         }
@@ -228,6 +235,16 @@ impl ManifestExtEntry {
         }))
     }
 
+    pub fn new_base_addr_entry(base_addr: u32) -> Result<Self> {
+        Ok(ManifestExtEntry::BaseAddr(ManifestExtBaseAddr {
+            header: ManifestExtHeader {
+                identifier: MANIFEST_EXT_ID_BASE_ADDR,
+                name: MANIFEST_EXT_NAME_BASE_ADDR,
+            },
+            base_addr,
+        }))
+    }
+
     /// Creates a new manifest extension from a given `spec`.
     pub fn from_spec(spec: &ManifestExtEntrySpec) -> Result<Self> {
         Ok(match spec {
@@ -264,6 +281,9 @@ impl ManifestExtEntry {
             ManifestExtEntrySpec::ImageType { image_type } => {
                 ManifestExtEntry::new_image_type_entry(*image_type)?
             }
+            ManifestExtEntrySpec::BaseAddr { base_addr } => {
+                ManifestExtEntry::new_base_addr_entry(*base_addr)?
+            }
             ManifestExtEntrySpec::Raw {
                 name,
                 identifier,
@@ -288,6 +308,7 @@ impl ManifestExtEntry {
             ManifestExtEntry::Isfb(isfb) => &isfb.header,
             ManifestExtEntry::IsfbErasePolicy(erase) => &erase.header,
             ManifestExtEntry::ImageType(image_type) => &image_type.header,
+            ManifestExtEntry::BaseAddr(base_addr) => &base_addr.header,
             ManifestExtEntry::Raw { header, data: _ } => header,
         }
     }
@@ -301,6 +322,7 @@ impl ManifestExtEntry {
             ManifestExtEntry::Isfb(isfb) => isfb.to_vec().unwrap(),
             ManifestExtEntry::IsfbErasePolicy(erase) => erase.as_bytes().to_vec(),
             ManifestExtEntry::ImageType(image_type) => image_type.as_bytes().to_vec(),
+            ManifestExtEntry::BaseAddr(base_addr) => base_addr.as_bytes().to_vec(),
             ManifestExtEntry::Raw { header, data } => {
                 header.as_bytes().iter().chain(data).copied().collect()
             }

--- a/sw/host/opentitantool/src/command/image.rs
+++ b/sw/host/opentitantool/src/command/image.rs
@@ -285,6 +285,7 @@ impl CommandDispatch for ManifestUpdateCommand {
                 ManifestExtId::isfb.into(),
                 ManifestExtId::isfb_erase.into(),
                 ManifestExtId::image_type.into(),
+                ManifestExtId::base_addr.into(),
             ])
             .collect::<HashSet<u32>>();
         image.update_signed_region(&signed_ids)?;


### PR DESCRIPTION
## WIP, commit chain will be cleaned up later.

Introduce support for a flexible owner-stage boot image (e.g., BL0) placement within a flash bank. Historically, the owner image has been placed at a fixed offset (CHIP_ROM_EXT_SIZE_MAX) right after the ROM_EXT stage.

This change enables scanning the flash bank for a valid owner stage manifest starting from a 64K offset (0x10000) up to a 256K offset (0x40000) with step size 8K (0x2000). A new `base_addr` manifest extension is added to specify and verify the expected load offset of the image relative to the bank base.