### PR TITLE
[crypto] Add stateful KAT

### DIFF
--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -66,6 +66,44 @@ You can activate these settings during the build process by passing `--define=<s
 | `disable_null_checks` | `OTCRYPTO_DISABLE_NULL_CHECKS` | Removes `NULL` pointer checks on API inputs throughout the library (e.g., AES-GCM operations). This saves code size, but strictly requires the caller to guarantee no `NULL` pointers are passed. |
 | `disable_buf_integrity_checks` | `OTCRYPTO_DISABLE_BUF_INTEGRITY_CHECKS` | Disables runtime integrity verification for data buffers. This bypasses `verify_buf_integrity`, removing the check that compares `ptr_checksum` against the data's calculated checksum. |
 
+## FIPS Build & Position-Independent Code (PIC)
+
+In addition to the default development build (`crypto_dev` which builds a standard static library), the cryptolib can be built as a **position-independent binary blob** for FIPS compliance.
+This specialized target hashes the library's contents and fuses the hash onto the binary boundary.
+
+You can trigger this build using the `--config=crypto_fips_all` Bazel flag.
+The exact functions included in this blob are strictly governed by an allowlist configuration file located in `//sw/device/lib/crypto/configs`.
+
+Because the FIPS blob is relocatable and contiguous, developers contributing to the cryptolib must adhere to strict memory and structural constraints:
+
+*   **No `.bss` or `.data` Sections:** The linker script enforces that the `.bss`, `.sbss`, `.data`, and `.sdata2` sections have a size of exactly 0. You **cannot** use static (non-const) variables or uninitialized global variables. All data must reside in `.text`, `.rodata`, or `.srodata`.
+*   **Strict Position Independence:** Code must be completely position-independent (PIC) and cannot rely on a Global Offset Table (GOT).
+*   **No Jump Tables:** The library is explicitly compiled with `-fno-jump-tables`. This forces the compiler to handle `switch` statements without generating position-dependent jump tables.
+
+### Stateful Logic & The Tethering Contract
+
+Because the FIPS blob is strictly stateless (`.bss` of 0), tracking run-once states—such as lazy Known-Answer Test (KAT) evaluations—requires a "tethering" trick.
+
+The cryptolib C code resolves a PC-relative offset to look exactly past the end of its own footprint (specifically, right after its 48-byte hash).
+It expects the host firmware to place a pointer at that exact physical location, which points back to mutable memory in the firmware's `.bss`.
+
+For the firmware developer consuming the FIPS blob, this creates a strict physical memory contract.
+
+**1. Allocate the State in Firmware C Code**
+The firmware must allocate the memory and define a pointer forced into a specific `.rodata` section:
+
+```c
+// 1. Allocate the actual memory the cryptolib will mutate.
+// This lives normally in the firmware's .bss section.
+uint32_t otcrypto_fips_kat_state = 0;
+
+// 2. Create a constant pointer to that memory.
+// The used attribute prevents the compiler from optimizing it out,
+// and the section attribute allows the linker to place it physically.
+__attribute__((used, section(".rodata.otcrypto_tether")))
+void * const otcrypto_tether_ptr = &otcrypto_fips_kat_state;
+```
+
 ## Cryptolib Usage Examples
 
 Examples of how to use the cryptolib API are provided in the [cryptolib test directory][crypto-tests].

--- a/sw/device/lib/crypto/BUILD
+++ b/sw/device/lib/crypto/BUILD
@@ -14,7 +14,10 @@ cc_library(
     name = "otcrypto_api",
     defines =
         select({
-            "//sw/device/lib/crypto/configs:hashed": ["HASH_SELF_CHECK_ENABLE"],
+            "//sw/device/lib/crypto/configs:hashed": [
+                "HASH_SELF_CHECK_ENABLE",
+                "KAT_CHECK_ENABLE",
+            ],
             "//conditions:default": [],
         }),
     deps = [

--- a/sw/device/lib/crypto/configs/otcrypto_blob.ld
+++ b/sw/device/lib/crypto/configs/otcrypto_blob.ld
@@ -19,6 +19,15 @@ SECTIONS {
         _libotcrypto_hash_ = .;
 
         . = . + 48;
+
+        /*
+         * Internal anchor: This symbol is used internally by the cryptolib C code
+         * to generate a PC-relative offset pointing to this exact address.
+         * The host firmware must use its global linker script to place a pointer
+         * to its state variable at this physical location.
+         * See cryptolib_api.md for info.
+         */
+        _libotcrypto_tether_ = .;
     } > ROM
 
     .sdata2 : {

--- a/sw/device/lib/crypto/configs/otcrypto_partial.ld
+++ b/sw/device/lib/crypto/configs/otcrypto_partial.ld
@@ -16,5 +16,14 @@ SECTIONS {
         _libotcrypto_hash_ = .;
 
         . = . + 48; /* Reserved for the hash */
+
+        /*
+         * Internal anchor: This symbol is used internally by the cryptolib C code
+         * to generate a PC-relative offset pointing to this exact address.
+         * The host firmware must use its global linker script to place a pointer
+         * to its state variable at this physical location.
+         * See cryptolib_api.md for info.
+         */
+        _libotcrypto_tether_ = .;
     }
 }

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -42,6 +42,7 @@ cc_library(
     deps = [
         ":config",
         ":integrity",
+        ":kats_api",
         ":keyblob",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:memory",
@@ -58,6 +59,7 @@ cc_library(
     deps = [
         ":config",
         ":integrity",
+        ":kats_api",
         ":keyblob",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:memory",
@@ -106,6 +108,7 @@ cc_library(
     deps = [
         ":config",
         ":integrity",
+        ":kats_api",
         ":keyblob",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:memory",
@@ -124,6 +127,7 @@ cc_library(
         ":config",
         ":hmac",
         ":integrity",
+        ":kats_api",
         ":keyblob",
         ":sha2",
         ":status",
@@ -140,6 +144,7 @@ cc_library(
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         ":config",
+        ":kats_api",
         ":keyblob",
         "//sw/device/lib/crypto/drivers:hmac",
         "//sw/device/lib/crypto/impl/ecc:p256",
@@ -154,6 +159,7 @@ cc_library(
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         ":config",
+        ":kats_api",
         ":keyblob",
         "//sw/device/lib/crypto/drivers:hmac",
         "//sw/device/lib/crypto/impl/ecc:p384",
@@ -217,7 +223,6 @@ cc_test(
 cc_library(
     name = "kats",
     srcs = ["kats.c"],
-    hdrs = ["kats.h"],
     deps = [
         ":aes",
         ":aes_gcm",
@@ -228,6 +233,7 @@ cc_library(
         ":entropy_src",
         ":hmac",
         ":integrity",
+        ":kats_api",
         ":keyblob",
         ":kmac",
         ":rsa",
@@ -236,6 +242,21 @@ cc_library(
         ":status",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/crypto/drivers:entropy_kat",
+        "//sw/device/lib/crypto/include:datatypes",
+    ],
+    alwayslink = True,
+)
+
+# We split the header to avoid circular dependencies.
+cc_library(
+    name = "kats_api",
+    hdrs = ["kats.h"],
+    defines = select({
+        "//sw/device/lib/crypto/configs:hashed": ["KAT_CHECK_ENABLE"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":status",
         "//sw/device/lib/crypto/include:datatypes",
     ],
 )
@@ -330,6 +351,7 @@ cc_library(
     deps = [
         ":config",
         ":integrity",
+        ":kats_api",
         ":status",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/crypto/drivers:entropy",
@@ -368,6 +390,7 @@ cc_library(
     deps = [
         ":config",
         ":integrity",
+        ":kats_api",
         ":status",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:hardened_memory",
@@ -386,6 +409,7 @@ cc_library(
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         ":config",
+        ":kats_api",
         ":status",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:hardened_memory",
@@ -447,6 +471,7 @@ cc_library(
     deps = [
         ":config",
         ":integrity",
+        ":kats_api",
         ":keyblob",
         ":sha2",
         "//sw/device/lib/base:hardened",
@@ -465,6 +490,7 @@ cc_library(
     deps = [
         ":config",
         ":integrity",
+        ":kats_api",
         ":keyblob",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:hardened_memory",

--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -10,6 +10,7 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/drivers/aes.h"
 #include "sw/device/lib/crypto/drivers/keymgr.h"
+#include "sw/device/lib/crypto/impl/kats.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/config.h"
@@ -554,6 +555,9 @@ otcrypto_status_t otcrypto_aes(otcrypto_blinded_key_t *key,
     return OTCRYPTO_BAD_ARGS;
   }
 #endif
+
+  // Run the AES ECB 256 KAT exactly once before utilizing the block
+  HARDENED_TRY(otcrypto_stateful_kat(kTestAesEcb256DecryptBit));
 
   if (launder32(key->config.security_level) == kOtcryptoKeySecurityLevelLow) {
     HARDENED_CHECK_EQ(key->config.security_level, kOtcryptoKeySecurityLevelLow);

--- a/sw/device/lib/crypto/impl/aes_gcm.c
+++ b/sw/device/lib/crypto/impl/aes_gcm.c
@@ -13,6 +13,7 @@
 #include "sw/device/lib/crypto/drivers/rv_core_ibex.h"
 #include "sw/device/lib/crypto/impl/aes_gcm/aes_gcm.h"
 #include "sw/device/lib/crypto/impl/aes_gcm/ghash.h"
+#include "sw/device/lib/crypto/impl/kats.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/config.h"

--- a/sw/device/lib/crypto/impl/cmac.c
+++ b/sw/device/lib/crypto/impl/cmac.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/crypto/drivers/aes.h"
 #include "sw/device/lib/crypto/drivers/keymgr.h"
+#include "sw/device/lib/crypto/impl/kats.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/config.h"

--- a/sw/device/lib/crypto/impl/ecc_curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc_curve25519.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/crypto/drivers/hmac.h"
 #include "sw/device/lib/crypto/impl/ecc/curve25519.h"
+#include "sw/device/lib/crypto/impl/kats.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/config.h"

--- a/sw/device/lib/crypto/impl/ecc_p256.c
+++ b/sw/device/lib/crypto/impl/ecc_p256.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/crypto/drivers/hmac.h"
 #include "sw/device/lib/crypto/impl/ecc/p256.h"
+#include "sw/device/lib/crypto/impl/kats.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"

--- a/sw/device/lib/crypto/impl/ecc_p384.c
+++ b/sw/device/lib/crypto/impl/ecc_p384.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/crypto/drivers/hmac.h"
 #include "sw/device/lib/crypto/impl/ecc/p384.h"
+#include "sw/device/lib/crypto/impl/kats.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"

--- a/sw/device/lib/crypto/impl/hmac.c
+++ b/sw/device/lib/crypto/impl/hmac.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/crypto/drivers/hmac.h"
 #include "sw/device/lib/crypto/drivers/rv_core_ibex.h"
+#include "sw/device/lib/crypto/impl/kats.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/config.h"

--- a/sw/device/lib/crypto/impl/kats.c
+++ b/sw/device/lib/crypto/impl/kats.c
@@ -273,20 +273,6 @@ static const uint32_t rsa2048_mod[64] = {
     0x105cc797, 0x924ec514, 0x146810df, 0xb1ab4a49,
 };
 
-static const uint32_t rsa2048_exp[64] = {
-    0x0b19915b, 0xa6a935e6, 0x426b2e10, 0xb4ff0629, 0x7322343b, 0x3f28c8d5,
-    0x190757ce, 0x87409d6b, 0xd88e282b, 0x01c13c2a, 0xebb79189, 0x74cbeab9,
-    0x93de5d54, 0xae1bc80a, 0x083a75f2, 0xd574d229, 0xeb46696e, 0x7648cfb6,
-    0xe7ad1b36, 0xbd0e81b2, 0x19c72703, 0xebea5085, 0xf8c7d152, 0x34dcf84d,
-    0xa437187f, 0x41e4f88e, 0xe4e35f9f, 0xcd8bc6f8, 0x7f98e2f2, 0xffdf75ca,
-    0x3698226e, 0x903f2a56, 0xbf21a6dc, 0x97cbf653, 0xe9d80cb3, 0x55dc1685,
-    0xe0ebae21, 0xc8171e18, 0x8e73d26d, 0xbbdbaac1, 0x886e8007, 0x673c9da4,
-    0xe2cb0698, 0xa9f1ba2d, 0xedab4f0a, 0x197e890c, 0x65e7e736, 0x1de28f24,
-    0x57cf5137, 0x631ff441, 0x22539942, 0xcee3fd41, 0xd22b5f8a, 0x995dd87a,
-    0xcaa6815c, 0x08ca0fd3, 0x8f996093, 0x30b7c446, 0xf69b11f7, 0xa298dd00,
-    0xfd4e8120, 0x059df602, 0x25feb268, 0x0f3f749e,
-};
-
 static const uint32_t rsa2048_sig[64] = {
     0xab66c6c7, 0x97effc0a, 0x9869cdba, 0x7b6c09fe, 0x2124d28f, 0x793084b3,
     0x4da24b72, 0x4f6c8659, 0x63e3a27b, 0xbbe8d120, 0x8789190f, 0x1722fe46,
@@ -304,14 +290,6 @@ static const uint32_t rsa2048_sig[64] = {
 static const uint32_t rsa2048_digest[8] = {
     0x7a99dab2, 0x7ce06e96, 0x83f0e143, 0x88e57c80,
     0xcaa4c04b, 0xca023bd1, 0x18a172dc, 0x1709b520,
-};
-
-static const otcrypto_key_config_t kRsa2048Config = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeRsaSignPkcs,
-    .key_length = kOtcryptoRsa2048PrivateKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
 };
 
 // Test vector comes from the rsa_4096_signature_functest
@@ -1118,7 +1096,45 @@ static const kat_dispatch_t kKatDispatch[] = {
     {OTCRYPTO_KAT_KMAC_256, &kat_kmac_256},
 };
 
-status_t run_kats(otcrypto_kat_id_t tests) {
+#ifdef KAT_CHECK_ENABLE
+
+// Link to the tether provided by the application.
+// This points to a stateful variable.
+extern void *_libotcrypto_tether_;
+
+static inline uint32_t *get_kat_state_ptr(void) {
+  uint32_t **host_tether_addr = (uint32_t **)&_libotcrypto_tether_;
+  return *host_tether_addr;
+}
+
+otcrypto_status_t otcrypto_stateful_kat(otcrypto_kat_bits_t kat_bit) {
+  uint32_t *state = get_kat_state_ptr();
+
+  if (state == NULL) {
+    return OTCRYPTO_FATAL_ERR;
+  }
+
+  uint32_t mask = (1UL << kat_bit);
+
+  if ((*state & mask) == 0) {
+    *state |= mask;  // Re-entrance lock
+
+    otcrypto_kat_id_t test_id = {.flags = mask};
+    status_t result = run_kats(test_id);
+
+    // When failing a KAT
+    if (result.value != kHardenedBoolTrue) {
+      *state &= ~mask;  // Unset the mask
+      return result;
+    }
+  }
+
+  return OTCRYPTO_OK;
+}
+
+#endif  // KAT_CHECK_ENABLE
+
+otcrypto_status_t run_kats(otcrypto_kat_id_t tests) {
   if (tests.flags == 0 || tests.flags >= (1 << kTestLastBit)) {
     return OTCRYPTO_BAD_ARGS;
   }

--- a/sw/device/lib/crypto/impl/kats.h
+++ b/sw/device/lib/crypto/impl/kats.h
@@ -77,7 +77,47 @@ typedef struct {
  * @param tests_to_run bit mask with tests to run
  * @return OK if the requested KATs passed.
  */
-status_t run_kats(otcrypto_kat_id_t tests_to_run);
+otcrypto_status_t run_kats(otcrypto_kat_id_t tests_to_run);
+
+/**
+ * @brief Ensures the specified Known-Answer Test (KAT) is executed exactly
+ * once.
+ *
+ * This function provides stateful, lazy evaluation of KATs depending on the
+ * build configuration:
+ *
+ * - **FIPS Build (`KAT_CHECK_ENABLE` defined):** It checks a tethered state
+ *   variable (provided by the host firmware) to verify if the KAT corresponding
+ *   to `kat_bit` has already run. If not, it executes the KAT and securely
+ *   updates the state. Subsequent calls for the same KAT will bypass execution.
+ * - **Standard Build (`KAT_CHECK_ENABLE` undefined):** The function evaluates
+ *   to a static inline no-op. It returns `OTCRYPTO_OK` immediately to avoid
+ *   unnecessary execution and linker dependencies.
+ *
+ * @param kat_bit The specific KAT to execute (e.g.,
+ * `kTestAesEcb256DecryptBit`).
+ * @return Result of the operation. Returns `OTCRYPTO_OK` on success, if the
+ *         KAT already passed, or if lazy evaluation is disabled. Returns
+ *         `OTCRYPTO_FATAL_ERR` if the KAT fails or the state pointer is
+ * missing.
+ */
+#ifndef KAT_CHECK_ENABLE
+
+// STANDARD BUILD: Lazy KAT evaluation is disabled.
+// Defined as static inline so the compiler embeds the OK status directly
+// into aes.c, avoiding any linker dependency on kats.o.
+static inline otcrypto_status_t otcrypto_stateful_kat(
+    otcrypto_kat_bits_t kat_bit) {
+  return OTCRYPTO_OK;
+}
+
+#else
+
+// FIPS BUILD: Evaluates lazily using host-tethered state.
+// Implementation lives in kats.c
+otcrypto_status_t otcrypto_stateful_kat(otcrypto_kat_bits_t kat_bit);
+
+#endif  // KAT_CHECK_ENABLE
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/impl/kmac.c
+++ b/sw/device/lib/crypto/impl/kmac.c
@@ -6,6 +6,7 @@
 
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/crypto/drivers/kmac.h"
+#include "sw/device/lib/crypto/impl/kats.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/config.h"

--- a/sw/device/lib/crypto/impl/rsa.c
+++ b/sw/device/lib/crypto/impl/rsa.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/base/math.h"
 #include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/kats.h"
 #include "sw/device/lib/crypto/impl/rsa/rsa_encryption.h"
 #include "sw/device/lib/crypto/impl/rsa/rsa_signature.h"
 #include "sw/device/lib/crypto/impl/rsa/run_rsa.h"

--- a/sw/device/lib/crypto/impl/sha2.c
+++ b/sw/device/lib/crypto/impl/sha2.c
@@ -8,6 +8,7 @@
 
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/crypto/drivers/hmac.h"
+#include "sw/device/lib/crypto/impl/kats.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/integrity.h"

--- a/sw/device/lib/crypto/impl/sha3.c
+++ b/sw/device/lib/crypto/impl/sha3.c
@@ -8,6 +8,7 @@
 
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/crypto/drivers/kmac.h"
+#include "sw/device/lib/crypto/impl/kats.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/config.h"
 

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -1011,12 +1011,21 @@ opentitan_test(
     name = "kats_functest",
     srcs = ["kats_functest.c"],
     exec_env = CRYPTOTEST_EXEC_ENVS,
+    local_defines = select({
+        "//sw/device/lib/crypto/configs:hashed": ["KAT_CHECK_ENABLE"],
+        "//conditions:default": [],
+    }),
     verilator = verilator_params(
         timeout = "long",
     ),
     deps = [
+        "//sw/device/lib/crypto/impl:aes",
         "//sw/device/lib/crypto/impl:config",
+        "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/crypto/impl:kats",
+        "//sw/device/lib/crypto/impl:keyblob",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],

--- a/sw/device/tests/crypto/kats_functest.c
+++ b/sw/device/tests/crypto/kats_functest.c
@@ -3,17 +3,111 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/crypto/impl/kats.h"
+#include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/aes.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/integrity.h"
+#include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 OTTF_DEFINE_TEST_CONFIG();
 
+#ifdef KAT_CHECK_ENABLE
+// The actual state tracked by the kat evaluation
+uint32_t otcrypto_fips_kat_state = 0;
+
+// The symbol that the cryptolib expects to find during the standard link.
+void *_libotcrypto_tether_ = &otcrypto_fips_kat_state;
+#endif
+
+/**
+ * @brief Tests that the lazy KAT evaluation runs once and skips thereafter.
+ */
+status_t test_lazy_kat_execution(void) {
+#ifdef KAT_CHECK_ENABLE
+  LOG_INFO("Testing lazy KAT execution for FIPS build using AES...");
+
+  TRY_CHECK(otcrypto_fips_kat_state == 0, "KAT state should be 0 initially.");
+
+  otcrypto_key_config_t config = {
+      .version = kOtcryptoLibVersion1,
+      .key_mode = kOtcryptoKeyModeAesEcb,
+      .key_length = 16,
+      .hw_backed = kHardenedBoolFalse,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
+
+  uint32_t keyblob[8] = {0};
+  otcrypto_blinded_key_t key = {
+      .config = config,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+  };
+  key.checksum = otcrypto_integrity_blinded_checksum(&key);
+
+  uint32_t iv_data[128 / 8 / sizeof(uint32_t)] = {0};
+  otcrypto_word32_buf_t iv =
+      OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, iv_data, 4);
+
+  uint8_t input_data[16] = {0};
+  otcrypto_const_byte_buf_t input =
+      OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, input_data, 16);
+
+  uint8_t output_data[16] = {0};
+  otcrypto_byte_buf_t output =
+      OTCRYPTO_MAKE_BUF(otcrypto_byte_buf_t, output_data, 16);
+
+  // First run (should run KAT, then fail mode check)
+  uint64_t t1_start = ibex_mcycle_read();
+  otcrypto_status_t status1 =
+      otcrypto_aes(&key, &iv, kOtcryptoAesModeCbc, kOtcryptoAesOperationEncrypt,
+                   &input, kOtcryptoAesPaddingNull, &output);
+  uint64_t t1_end = ibex_mcycle_read();
+  uint64_t first_run_cycles = t1_end - t1_start;
+
+  // Ensure it failed properly inside otcrypto_aes
+  TRY_CHECK(status1.value == OTCRYPTO_BAD_ARGS.value,
+            "Expected BAD_ARGS due to mode mismatch.");
+
+  // Verify the KAT bit for AES ECB 256 was successfully set.
+  TRY_CHECK((otcrypto_fips_kat_state & OTCRYPTO_KAT_AES_ECB_256_DECRYPT) != 0,
+            "AES KAT bit was not set by the cryptolib.");
+
+  // Verify NO OTHER bits were set.
+  TRY_CHECK(otcrypto_fips_kat_state == OTCRYPTO_KAT_AES_ECB_256_DECRYPT,
+            "Other KAT bits were erroneously set.");
+
+  // Second run (should skip KAT, then fail mode check)
+  uint64_t t2_start = ibex_mcycle_read();
+  otcrypto_status_t status2 =
+      otcrypto_aes(&key, &iv, kOtcryptoAesModeCbc, kOtcryptoAesOperationEncrypt,
+                   &input, kOtcryptoAesPaddingNull, &output);
+  uint64_t t2_end = ibex_mcycle_read();
+  uint64_t second_run_cycles = t2_end - t2_start;
+
+  TRY_CHECK(status2.value == OTCRYPTO_BAD_ARGS.value,
+            "Expected BAD_ARGS due to mode mismatch.");
+
+  LOG_INFO("First run (with KAT): %u cycles", (uint32_t)first_run_cycles);
+  LOG_INFO("Second run (skipped KAT): %u cycles", (uint32_t)second_run_cycles);
+
+  // Prove the second run was significantly faster
+  TRY_CHECK(second_run_cycles < (first_run_cycles / 2),
+            "Second run was not faster; KAT was not skipped.");
+
+  LOG_INFO("KAT FIPS behavior verified using AES.");
+#endif
+
+  return OK_STATUS();
+}
+
 bool test_main(void) {
   CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
-  CHECK_STATUS_OK(run_kats(OTCRYPTO_KAT_ALL_TESTS));
+  // Run the lazy execution proof
+  CHECK_STATUS_OK(test_lazy_kat_execution());
 
   return true;
 }


### PR DESCRIPTION
Add the logic to run a lazy version of the KAT. Namely to run a Known Answer Test only on the first execution of a function.

In order for this to work, the application has to set the tether that can be used by the cryptolib. This is done by setting
```
// The actual state tracked by the kat evaluation
uint32_t otcrypto_fips_kat_state = 0;

// The symbol that the cryptolib expects to find during the standard link.
void *_libotcrypto_tether_ = &otcrypto_fips_kat_state;
```
This is also explained in the documentation.

Create a KAT test that when run with the hashed_flag (such as with --config=crypto_fips_all) will test that the first execution of the AES will run at least twice the cycles versus the second and sets the KAT stateful mask.

This is currently only integrated for the AES.