### PR TITLE
[crypto] Cleanup on failures

### DIFF
--- a/sw/device/lib/crypto/drivers/aes.c
+++ b/sw/device/lib/crypto/drivers/aes.c
@@ -343,6 +343,10 @@ status_t aes_end(aes_block_t *iv) {
     HARDENED_CHECK_EQ(i, ARRAYSIZE(iv->data));
   }
 
+  return spin_until(AES_STATUS_IDLE_BIT);
+}
+
+status_t aes_clear(void) {
   uint32_t trigger_reg = 0;
   trigger_reg = bitfield_bit32_write(
       trigger_reg, AES_TRIGGER_KEY_IV_DATA_IN_CLEAR_BIT, true);

--- a/sw/device/lib/crypto/drivers/aes.h
+++ b/sw/device/lib/crypto/drivers/aes.h
@@ -174,6 +174,14 @@ OT_WARN_UNUSED_RESULT
 status_t aes_end(aes_block_t *iv);
 
 /**
+ * Clears the AES hardware data registers and triggers.
+ *
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t aes_clear(void);
+
+/**
  * Compute the checksum of an AES key.
  *
  * Call this routine after creating or modifying the aes key structure.

--- a/sw/device/lib/crypto/drivers/hmac.c
+++ b/sw/device/lib/crypto/drivers/hmac.c
@@ -176,6 +176,11 @@ static status_t clear(void) {
 }
 
 /**
+ * Hardware wipe guard.
+ */
+static void hmac_wipe_guard(uint32_t *dummy) { (void)clear(); }
+
+/**
  * Write given key to HMAC HWIP.
  *
  * This function does not return error, so it is the responsibility of the
@@ -438,6 +443,8 @@ static status_t ensure_idle(void) {
 static status_t oneshot(const uint32_t cfg, const hmac_key_t *key,
                         const otcrypto_const_byte_buf_t *msg,
                         size_t digest_wordlen, uint32_t *digest) {
+  uint32_t hw_cleanup_guard __attribute__((cleanup(hmac_wipe_guard))) = 1;
+
   // Check that the block is idle.
   HARDENED_TRY(ensure_idle());
 
@@ -476,7 +483,7 @@ static status_t oneshot(const uint32_t cfg, const hmac_key_t *key,
 
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(msg));
 
-  return clear();
+  return OTCRYPTO_OK;
 }
 
 /**
@@ -825,6 +832,8 @@ hardened_bool_t hmac_key_integrity_checksum_check(const hmac_key_t *key) {
 }
 
 status_t hmac_update(hmac_ctx_t *ctx, const otcrypto_const_byte_buf_t *data) {
+  uint32_t hw_cleanup_guard __attribute__((cleanup(hmac_wipe_guard))) = 1;
+
   // If we don't have enough new bytes to fill a block, just update the partial
   // block and return.
   size_t block_bytelen = ctx->msg_block_wordlen * sizeof(uint32_t);
@@ -877,11 +886,12 @@ status_t hmac_update(hmac_ctx_t *ctx, const otcrypto_const_byte_buf_t *data) {
 
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(data));
 
-  // Clean up.
-  return clear();
+  return OTCRYPTO_OK;
 }
 
 status_t hmac_final(hmac_ctx_t *ctx, otcrypto_word32_buf_t *digest) {
+  uint32_t hw_cleanup_guard __attribute__((cleanup(hmac_wipe_guard))) = 1;
+
   // Restore context will restore the context and also hit start or continue
   // button as necessary.
   HARDENED_TRY(context_restore(ctx));
@@ -908,6 +918,5 @@ status_t hmac_final(hmac_ctx_t *ctx, otcrypto_word32_buf_t *digest) {
 
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(digest));
 
-  // Clean up.
-  return clear();
+  return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/drivers/kmac.c
+++ b/sw/device/lib/crypto/drivers/kmac.c
@@ -153,6 +153,16 @@ OT_ASSERT_ENUM_VALUE(ARRAYSIZE(prefix_offsets), KMAC_PREFIX_MULTIREG_COUNT);
 OT_ASSERT_ENUM_VALUE(32, KMAC_PREFIX_PREFIX_FIELD_WIDTH);
 
 /**
+ * Hardware wipe guard.
+ */
+static void kmac_wipe_guard(uint32_t *dummy) {
+  uint32_t cmd_reg = KMAC_CMD_REG_RESVAL;
+  cmd_reg = bitfield_field32_write(cmd_reg, KMAC_CMD_CMD_FIELD,
+                                   KMAC_CMD_CMD_VALUE_DONE);
+  abs_mmio_write32(kKmacBaseAddr + KMAC_CMD_REG_OFFSET, cmd_reg);
+}
+
+/**
  * Return the rate (in bytes) for given security strength.
  *
  * The caller must ensure that `keccak_rate` is not a NULL pointer. This is not
@@ -618,6 +628,9 @@ OT_WARN_UNUSED_RESULT
 static status_t kmac_process_msg_blocks(
     kmac_operation_t operation, const otcrypto_const_byte_buf_t *message,
     uint32_t *digest, size_t digest_len_bytes, hardened_bool_t masked_digest) {
+  // This variable guarantees kmac_wipe_guard() is called on exit.
+  uint32_t hw_cleanup_guard __attribute__((cleanup(kmac_wipe_guard))) = 1;
+
   // Block until KMAC is idle.
   HARDENED_TRY(wait_status_bit(KMAC_STATUS_SHA3_IDLE_BIT, 1));
 
@@ -755,12 +768,6 @@ static status_t kmac_process_msg_blocks(
 
   // Poll the status register until in the 'squeeze' state.
   HARDENED_TRY(wait_status_bit(KMAC_STATUS_SHA3_SQUEEZE_BIT, 1));
-
-  // Release the KMAC core, so that it goes back to idle mode
-  cmd_reg = KMAC_CMD_REG_RESVAL;
-  cmd_reg = bitfield_field32_write(cmd_reg, KMAC_CMD_CMD_FIELD,
-                                   KMAC_CMD_CMD_VALUE_DONE);
-  abs_mmio_write32(kKmacBaseAddr + KMAC_CMD_REG_OFFSET, cmd_reg);
 
   // Zero out the trailing bytes in the final word.
   size_t remainder_bytes = digest_len_bytes % sizeof(uint32_t);

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -318,6 +318,7 @@ cc_library(
         ":status",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:math",
+        "//sw/device/lib/crypto/drivers:keymgr",
         "//sw/device/lib/crypto/drivers:kmac",
         "//sw/device/lib/crypto/drivers:rv_core_ibex",
         "//sw/device/lib/crypto/include:datatypes",

--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -280,6 +280,14 @@ otcrypto_status_t otcrypto_aes_padded_plaintext_length(
 }
 
 /**
+ * Hardware cleanup guard.
+ */
+static void hw_wipe_guard(uint32_t *dummy) {
+  (void)aes_clear();
+  (void)keymgr_sideload_clear_aes();
+}
+
+/**
  * Performs the AES operation.
  *
  * @param key Pointer to the blinded key struct with key shares.
@@ -297,6 +305,9 @@ static otcrypto_status_t otcrypto_aes_impl(
     otcrypto_aes_mode_t aes_mode, otcrypto_aes_operation_t aes_operation,
     const otcrypto_const_byte_buf_t *cipher_input,
     otcrypto_aes_padding_t aes_padding, otcrypto_byte_buf_t *cipher_output) {
+  // Guarantees hw_wipe_guard() is called on exit.
+  uint32_t hw_cleanup_guard __attribute__((cleanup(hw_wipe_guard))) = 1;
+
   // Calculate the number of blocks for the input, including the padding for
   // encryption.
   size_t input_nblocks;
@@ -450,8 +461,7 @@ static otcrypto_status_t otcrypto_aes_impl(
     HARDENED_TRY(hardened_memcpy(iv->data, aes_iv.data, kAesBlockNumWords));
   }
 
-  // In case the key was sideloaded, clear it.
-  return otcrypto_eval_exit(keymgr_sideload_clear_aes());
+  return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
 otcrypto_status_t otcrypto_aes_padding_strip(

--- a/sw/device/lib/crypto/impl/aes_gcm.c
+++ b/sw/device/lib/crypto/impl/aes_gcm.c
@@ -43,6 +43,20 @@ enum {
 };
 
 /**
+ * AES cleanup guard.
+ */
+static void aes_wipe_guard(uint32_t *dummy) { (void)aes_clear(); }
+
+/**
+ * Sideload cleanup guard.
+ */
+static void sideload_wipe_guard(hardened_bool_t *is_sideloaded) {
+  if (*is_sideloaded == kHardenedBoolTrue) {
+    (void)keymgr_sideload_clear_aes();
+  }
+}
+
+/**
  * Save an AES-GCM context.
  *
  * @param internal_ctx Internal context object to save.
@@ -252,30 +266,6 @@ static status_t load_key_if_sideloaded(const aes_key_t key) {
   return keymgr_generate_key_aes(diversification);
 }
 
-/**
- * Clear the sideload slot if the AES key was sideloaded.
- *
- * It is important to clear the sideload slot before returning to the caller so
- * that other applications can't access the key in between operations.
- *
- * If the key is not a sideloaded key, this function does nothing.
- *
- * @param key Key that was possibly loaded.
- * @return OK or errror.
- */
-static status_t clear_key_if_sideloaded(const aes_key_t key) {
-  if (launder32(key.sideload) == kHardenedBoolFalse) {
-    HARDENED_CHECK_EQ(key.sideload, launder32(kHardenedBoolFalse));
-    return OTCRYPTO_OK;
-  } else if (launder32(key.sideload) != kHardenedBoolTrue) {
-    // COVERAGE (SW ERR) This is an internal function, the aes key's sideload is
-    // set internal by good parameters.
-    return OTCRYPTO_BAD_ARGS;
-  }
-  HARDENED_CHECK_EQ(key.sideload, launder32(kHardenedBoolTrue));
-  return keymgr_sideload_clear_aes();
-}
-
 otcrypto_status_t otcrypto_aes_gcm_encrypt(
     otcrypto_blinded_key_t *key, const otcrypto_const_byte_buf_t *plaintext,
     const otcrypto_const_word32_buf_t *iv, const otcrypto_const_byte_buf_t *aad,
@@ -300,6 +290,10 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt(
   }
 #endif
 
+  hardened_bool_t is_sideloaded __attribute__((cleanup(sideload_wipe_guard))) =
+      kHardenedBoolFalse;
+  uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
+
   // Ensure the plaintext and ciphertext lengths match.
   if (launder32(ciphertext->len) != plaintext->len) {
     return OTCRYPTO_BAD_ARGS;
@@ -315,6 +309,9 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt(
   // Construct the AES key.
   aes_key_t aes_key;
   HARDENED_TRY(aes_gcm_key_construct(key, &aes_key));
+  if (launder32(aes_key.sideload) == kHardenedBoolTrue) {
+    is_sideloaded = kHardenedBoolTrue;
+  }
   HARDENED_TRY(load_key_if_sideloaded(aes_key));
 
   // Call the core encryption operation.
@@ -322,8 +319,6 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt(
                                plaintext->data, aad->len, aad->data,
                                auth_tag->len, key->config.security_level,
                                auth_tag->data, ciphertext->data));
-
-  HARDENED_TRY(clear_key_if_sideloaded(aes_key));
 
   // Verify the input buffers
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(plaintext));
@@ -359,9 +354,16 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt(
   }
 #endif
 
+  hardened_bool_t is_sideloaded __attribute__((cleanup(sideload_wipe_guard))) =
+      kHardenedBoolFalse;
+  uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
+
   // Construct the AES key.
   aes_key_t aes_key;
   HARDENED_TRY(aes_gcm_key_construct(key, &aes_key));
+  if (launder32(aes_key.sideload) == kHardenedBoolTrue) {
+    is_sideloaded = kHardenedBoolTrue;
+  }
   HARDENED_TRY(load_key_if_sideloaded(aes_key));
 
   // Ensure the plaintext and ciphertext lengths match.
@@ -378,8 +380,6 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt(
                                ciphertext->data, aad->len, aad->data,
                                auth_tag->len, auth_tag->data, plaintext->data,
                                key->config.security_level, success));
-
-  HARDENED_TRY(clear_key_if_sideloaded(aes_key));
 
   // Verify the input buffers
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(plaintext));
@@ -401,9 +401,16 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_init(
   }
 #endif
 
+  hardened_bool_t is_sideloaded __attribute__((cleanup(sideload_wipe_guard))) =
+      kHardenedBoolFalse;
+  uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
+
   // Construct the AES key.
   aes_key_t aes_key;
   HARDENED_TRY(aes_gcm_key_construct(key, &aes_key));
+  if (launder32(aes_key.sideload) == kHardenedBoolTrue) {
+    is_sideloaded = kHardenedBoolTrue;
+  }
   HARDENED_TRY(load_key_if_sideloaded(aes_key));
 
   // Call the internal init operation.
@@ -411,9 +418,8 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_init(
   internal_ctx.security_level = key->config.security_level;
   HARDENED_TRY(aes_gcm_encrypt_init(aes_key, iv->len, iv->data, &internal_ctx));
 
-  // Save the context and clear the key if needed.
+  // Save the context.
   HARDENED_TRY(gcm_context_save(&internal_ctx, ctx));
-  HARDENED_TRY(clear_key_if_sideloaded(internal_ctx.key));
 
   // Verify the input buffer
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(iv));
@@ -431,9 +437,16 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt_init(
   }
 #endif
 
+  hardened_bool_t is_sideloaded __attribute__((cleanup(sideload_wipe_guard))) =
+      kHardenedBoolFalse;
+  uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
+
   // Construct the AES key.
   aes_key_t aes_key;
   HARDENED_TRY(aes_gcm_key_construct(key, &aes_key));
+  if (launder32(aes_key.sideload) == kHardenedBoolTrue) {
+    is_sideloaded = kHardenedBoolTrue;
+  }
   HARDENED_TRY(load_key_if_sideloaded(aes_key));
 
   // Call the internal init operation.
@@ -441,9 +454,8 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt_init(
   internal_ctx.security_level = key->config.security_level;
   HARDENED_TRY(aes_gcm_decrypt_init(aes_key, iv->len, iv->data, &internal_ctx));
 
-  // Save the context and clear the key if needed.
+  // Save the context.
   HARDENED_TRY(gcm_context_save(&internal_ctx, ctx));
-  HARDENED_TRY(clear_key_if_sideloaded(internal_ctx.key));
 
   // Verify the input buffer
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(iv));
@@ -465,17 +477,23 @@ otcrypto_status_t otcrypto_aes_gcm_update_aad(
     return OTCRYPTO_OK;
   }
 
+  hardened_bool_t is_sideloaded __attribute__((cleanup(sideload_wipe_guard))) =
+      kHardenedBoolFalse;
+  uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
+
   // Restore the AES-GCM context object and load the key if needed.
   aes_gcm_context_t internal_ctx;
   HARDENED_TRY(gcm_context_restore(ctx, &internal_ctx));
+  if (launder32(internal_ctx.key.sideload) == kHardenedBoolTrue) {
+    is_sideloaded = kHardenedBoolTrue;
+  }
   HARDENED_TRY(load_key_if_sideloaded(internal_ctx.key));
 
   // Call the internal update operation.
   HARDENED_TRY(aes_gcm_update_aad(&internal_ctx, aad->len, aad->data));
 
-  // Save the context and clear the key if needed.
+  // Save the context.
   HARDENED_TRY(gcm_context_save(&internal_ctx, ctx));
-  HARDENED_TRY(clear_key_if_sideloaded(internal_ctx.key));
 
   // Verify the input buffer
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(aad));
@@ -500,9 +518,16 @@ otcrypto_status_t otcrypto_aes_gcm_update_encrypted_data(
     return OTCRYPTO_OK;
   }
 
+  hardened_bool_t is_sideloaded __attribute__((cleanup(sideload_wipe_guard))) =
+      kHardenedBoolFalse;
+  uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
+
   // Restore the AES-GCM context object and load the key if needed.
   aes_gcm_context_t internal_ctx;
   HARDENED_TRY(gcm_context_restore(ctx, &internal_ctx));
+  if (launder32(internal_ctx.key.sideload) == kHardenedBoolTrue) {
+    is_sideloaded = kHardenedBoolTrue;
+  }
   HARDENED_TRY(load_key_if_sideloaded(internal_ctx.key));
   // Remask the key if it is not sideloaded.
   HARDENED_TRY(gcm_remask_key(&internal_ctx));
@@ -526,9 +551,8 @@ otcrypto_status_t otcrypto_aes_gcm_update_encrypted_data(
                                              input->data, output_bytes_written,
                                              output->data));
 
-  // Save the context and clear the key if needed.
+  // Save the context.
   HARDENED_TRY(gcm_context_save(&internal_ctx, ctx));
-  HARDENED_TRY(clear_key_if_sideloaded(internal_ctx.key));
 
   // Verify the input buffers
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(input));
@@ -559,9 +583,16 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_final(
   // Randomize the tag before the operation.
   HARDENED_TRY(hardened_memshred(auth_tag->data, auth_tag->len));
 
+  hardened_bool_t is_sideloaded __attribute__((cleanup(sideload_wipe_guard))) =
+      kHardenedBoolFalse;
+  uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
+
   // Restore the AES-GCM context object and load the key if needed.
   aes_gcm_context_t internal_ctx;
   HARDENED_TRY(gcm_context_restore(ctx, &internal_ctx));
+  if (launder32(internal_ctx.key.sideload) == kHardenedBoolTrue) {
+    is_sideloaded = kHardenedBoolTrue;
+  }
   HARDENED_TRY(load_key_if_sideloaded(internal_ctx.key));
   // Remask the key if it is not sideloaded.
   HARDENED_TRY(gcm_remask_key(&internal_ctx));
@@ -578,9 +609,8 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_final(
                                      auth_tag->data, ciphertext_bytes_written,
                                      ciphertext->data));
 
-  // Clear the context and the key if needed.
+  // Clear the context.
   HARDENED_TRY(hardened_memshred(ctx->data, ARRAYSIZE(ctx->data)));
-  HARDENED_TRY(clear_key_if_sideloaded(internal_ctx.key));
 
   // Verify the input buffers
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(ciphertext));
@@ -609,9 +639,16 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt_final(
   // Check the tag length.
   HARDENED_TRY(aes_gcm_check_tag_length(auth_tag->len, tag_len));
 
+  hardened_bool_t is_sideloaded __attribute__((cleanup(sideload_wipe_guard))) =
+      kHardenedBoolFalse;
+  uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
+
   // Restore the AES-GCM context object and load the key if needed.
   aes_gcm_context_t internal_ctx;
   HARDENED_TRY(gcm_context_restore(ctx, &internal_ctx));
+  if (launder32(internal_ctx.key.sideload) == kHardenedBoolTrue) {
+    is_sideloaded = kHardenedBoolTrue;
+  }
   HARDENED_TRY(load_key_if_sideloaded(internal_ctx.key));
   // Remask the key if it is not sideloaded.
   HARDENED_TRY(gcm_remask_key(&internal_ctx));
@@ -628,9 +665,8 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt_final(
                                      auth_tag->data, plaintext_bytes_written,
                                      plaintext->data, success));
 
-  // Clear the context and the key if needed.
+  // Clear the context.
   HARDENED_TRY(hardened_memshred(ctx->data, ARRAYSIZE(ctx->data)));
-  HARDENED_TRY(clear_key_if_sideloaded(internal_ctx.key));
 
   // Verify the input buffers
   HARDENED_CHECK_EQ(kHardenedBoolTrue, OTCRYPTO_CHECK_BUF(auth_tag));

--- a/sw/device/lib/crypto/impl/cmac.c
+++ b/sw/device/lib/crypto/impl/cmac.c
@@ -60,6 +60,20 @@ enum {
 };
 
 /**
+ * AES cleanup guard.
+ */
+static void aes_wipe_guard(uint32_t *dummy) { (void)aes_clear(); }
+
+/**
+ * Sideload cleanup guard.
+ */
+static void sideload_wipe_guard(hardened_bool_t *is_sideloaded) {
+  if (*is_sideloaded == kHardenedBoolTrue) {
+    (void)keymgr_sideload_clear_aes();
+  }
+}
+
+/**
  * Checks for NULL pointers or invalid settings in the blinded key.
  */
 static status_t check_key(const otcrypto_blinded_key_t *key) {
@@ -329,11 +343,18 @@ otcrypto_status_t otcrypto_cmac(const otcrypto_blinded_key_t *key,
     return OTCRYPTO_BAD_ARGS;
   }
 #endif
+
+  // Clear AES unconditionally, and clear sideload if requested.
+  uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
+  hardened_bool_t is_sideloaded __attribute__((cleanup(sideload_wipe_guard))) =
+      kHardenedBoolFalse;
+
   HARDENED_TRY(hardened_memshred(tag->data, tag->len));
   HARDENED_TRY(check_key(key));
 
   if (launder32(key->config.hw_backed) == kHardenedBoolTrue) {
     HARDENED_CHECK_EQ(key->config.hw_backed, kHardenedBoolTrue);
+    is_sideloaded = kHardenedBoolTrue;
     keymgr_diversification_t diversification;
     HARDENED_TRY(keyblob_to_keymgr_diversification(key, &diversification));
     HARDENED_TRY(keymgr_generate_key_aes(diversification));
@@ -410,6 +431,9 @@ otcrypto_status_t otcrypto_cmac_init(otcrypto_cmac_context_t *ctx,
     return OTCRYPTO_BAD_ARGS;
   }
 #endif
+
+  uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
+
   HARDENED_TRY(check_key(key));
 
   if (launder32(key->config.hw_backed) == kHardenedBoolTrue) {
@@ -474,6 +498,8 @@ otcrypto_status_t otcrypto_cmac_update(
   }
 #endif
 
+  uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
+
   otcrypto_key_security_level_t security_level =
       (otcrypto_key_security_level_t)ctx->data[kCtxSecurityLevelOffset];
 
@@ -521,6 +547,10 @@ otcrypto_status_t otcrypto_cmac_final(otcrypto_cmac_context_t *const ctx,
   }
 #endif
 
+  uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
+  hardened_bool_t is_sideloaded __attribute__((cleanup(sideload_wipe_guard))) =
+      kHardenedBoolFalse;
+
   otcrypto_key_security_level_t security_level =
       (otcrypto_key_security_level_t)ctx->data[kCtxSecurityLevelOffset];
 
@@ -528,6 +558,10 @@ otcrypto_status_t otcrypto_cmac_final(otcrypto_cmac_context_t *const ctx,
   HARDENED_TRY(hardened_memcpy((uint32_t *)&primary_ctx,
                                (const uint32_t *)&ctx->data[kCtxPrimaryOffset],
                                kOtcryptoCmacCtxStructWords));
+
+  if (launder32(primary_ctx.sideload) == kHardenedBoolTrue) {
+    is_sideloaded = kHardenedBoolTrue;
+  }
 
   if (launder32(security_level) == kOtcryptoKeySecurityLevelLow) {
     HARDENED_CHECK_EQ(launder32(security_level), kOtcryptoKeySecurityLevelLow);

--- a/sw/device/lib/crypto/impl/kmac.c
+++ b/sw/device/lib/crypto/impl/kmac.c
@@ -14,6 +14,15 @@
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('k', 'm', 'c')
 
+/**
+ * Sideload cleanup guard.
+ */
+static void sideload_wipe_guard(hardened_bool_t *is_sideloaded) {
+  if (*is_sideloaded == kHardenedBoolTrue) {
+    (void)keymgr_sideload_clear_kmac();
+  }
+}
+
 otcrypto_status_t otcrypto_kmac(
     otcrypto_blinded_key_t *key, const otcrypto_const_byte_buf_t *input_message,
     const otcrypto_const_byte_buf_t *customization_string,
@@ -38,6 +47,9 @@ otcrypto_status_t otcrypto_kmac(
     return OTCRYPTO_BAD_ARGS;
   }
 #endif
+
+  hardened_bool_t is_sideloaded __attribute__((cleanup(sideload_wipe_guard))) =
+      kHardenedBoolFalse;
 
   // Ensure that tag buffer length and `required_output_len` match each other.
   size_t required_output_words =
@@ -71,6 +83,8 @@ otcrypto_status_t otcrypto_kmac(
     if (key_len != kKmacSideloadKeyLength / 8) {
       return OTCRYPTO_BAD_ARGS;
     }
+    is_sideloaded = kHardenedBoolTrue;
+
     // Configure keymgr with diversification input and then generate the
     // sideload key.
     keymgr_diversification_t diversification;
@@ -118,10 +132,6 @@ otcrypto_status_t otcrypto_kmac(
   // Check if we landed in the correct case statement. Use ORs for this to
   // avoid that multiple cases were executed.
   HARDENED_CHECK_EQ(launder32(key_mode_used), key->config.key_mode);
-
-  if (key->config.hw_backed == kHardenedBoolTrue) {
-    HARDENED_TRY(keymgr_sideload_clear_kmac());
-  }
 
   // Verify the input buffer
   HARDENED_CHECK_EQ(kHardenedBoolTrue,

--- a/sw/device/lib/crypto/impl/kmac_kdf.c
+++ b/sw/device/lib/crypto/impl/kmac_kdf.c
@@ -6,6 +6,7 @@
 
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/base/math.h"
+#include "sw/device/lib/crypto/drivers/keymgr.h"
 #include "sw/device/lib/crypto/drivers/kmac.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/impl/status.h"
@@ -15,6 +16,15 @@
 
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('k', 'k', 'd')
+
+/**
+ * Sideload cleanup guard.
+ */
+static void sideload_wipe_guard(hardened_bool_t *is_sideloaded) {
+  if (*is_sideloaded == kHardenedBoolTrue) {
+    (void)keymgr_sideload_clear_kmac();
+  }
+}
 
 otcrypto_status_t otcrypto_kmac_kdf(
     otcrypto_blinded_key_t *key_derivation_key,
@@ -34,6 +44,10 @@ otcrypto_status_t otcrypto_kmac_kdf(
     return OTCRYPTO_BAD_ARGS;
   }
 #endif
+
+  hardened_bool_t is_sideloaded __attribute__((cleanup(sideload_wipe_guard))) =
+      kHardenedBoolFalse;
+
   // Because of KMAC HWIPs prefix limitation, `label` should not exceed
   // `kKmacCustStrMaxSize` bytes.
   if (label->len > kKmacCustStrMaxSize) {
@@ -75,6 +89,9 @@ otcrypto_status_t otcrypto_kmac_kdf(
         kKmacSideloadKeyLength / 8) {
       return OTCRYPTO_BAD_ARGS;
     }
+
+    is_sideloaded = kHardenedBoolTrue;
+
     // Configure keymgr with diversification input and then generate the
     // sideload key.
     keymgr_diversification_t diversification;
@@ -152,6 +169,5 @@ otcrypto_status_t otcrypto_kmac_kdf(
   output_key_material->checksum =
       otcrypto_integrity_blinded_checksum(output_key_material);
 
-  // Clear the KMAC sideload slot in case the key was sideloaded.
-  return otcrypto_eval_exit(keymgr_sideload_clear_kmac());
+  return otcrypto_eval_exit(OTCRYPTO_OK);
 }


### PR DESCRIPTION
Use the cleanup attribute in order to attach cleanup functions to a guard to cleanup the hardware. These functions are called when the variables go out of scope. Hence, we clear the hardware on both the succesful execution (as it was before) and on bad status output (which is new).