### PR TITLE
[ci] More action version bumps to resolve warnings about upcoming Node.js 20 EOL in CI

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -123,7 +123,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 
-    - uses: google-github-actions/setup-gcloud@v2
+    - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db  # v3.0.1
       if: github.event_name != 'pull_request' && inputs.service_account_json != ''
 
     - name: Configure ~/.bazelrc

--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -102,7 +102,7 @@ runs:
     # Log into Google Cloud using service account JSON.
     # This can't be Workload Identity Federation because Bazel performance using WIF is terrible.
     # This needs access to secrets and thus doesn't work for pull request.
-    - uses: google-github-actions/auth@v2
+    - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
       id: google_auth
       if: github.event_name != 'pull_request' && inputs.service_account_json != ''
       with:

--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Create backport PRs
         id: backport
-        uses: korthout/backport-action@e8161d6a0dbfa2651b7daa76cbb75bc7c925bbf3 # v2.4.1
+        uses: korthout/backport-action@66065406958f46e82238fd59546f5a99e69e22aa # v4.5.2
         with:
           label_pattern: "^CherryPick:([^ ]+)$"
           pull_title: "Cherry-pick to ${target_branch}: ${pull_title}"

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -98,7 +98,7 @@ jobs:
       # and set up the target_pattern_file variable.
       - name: Download job target file
         if: inputs.artifact != ''
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.artifact }}
           path: job_schedule

--- a/.github/workflows/private-ci.yml
+++ b/.github/workflows/private-ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Private CI
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const payload = {

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Rerun failed GitHub actions
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             for await (const response of github.paginate.iterator(


### PR DESCRIPTION
A follow-up to #29859. Partially resolves #30152 (note this only fixes `master` - similar fixes need to be made independently for `earlgrey_1.0.0`).

Bump all actions that were still using Node20 to newer major versions that use Node24. For each action I've checked the breaking changes and migration guidance in the release notes, and it appears that no breaking changes impact our use cases.

Addresses a regression from #29811 which re-introduced an old action version with this problem, and also updates actions from a variety of workflows that were originally missed (I previously checked the CI workflow and did a basic grep). *Hopefully* I've caught everything now, but there's a lot of manual checking here.

For actions that support [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases), I've pinned the specific immutable release. For those without, I've pinned the specific revision of the newest major release. This would also mean pinning a specific SHA for the commonplace `checkout`, `upload-artifact` and `download-artifact` supported by GitHub, so for now these remain pinned only to major versions whilst no immutable releases exist. There are issues open on these actions upstream to support moving to immutable releases.