### PR TITLE
[i2c, rtl] Saturate timing counter to prevent underflow condition

### DIFF
--- a/hw/ip/i2c/rtl/i2c_controller_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_controller_fsm.sv
@@ -140,7 +140,7 @@ module i2c_controller_fsm import i2c_pkg::*;
       // If we disable Host-Mode mid-txn, keep counting until the end of
       // byte, at which point we create a STOP condition then return to Idle.
       (!host_idle_o && !host_enable_i)) begin
-      tcount_d = tcount_q - 1'b1;
+      tcount_d = (tcount_q == 16'h0) ? 16'h0 :  tcount_q - 1'b1;
     end
   end
 
@@ -976,6 +976,9 @@ module i2c_controller_fsm import i2c_pkg::*;
 
   // Make sure we never attempt to send a single cycle glitch
   `ASSERT(SclOutputGlitch_A, $rose(scl_o) |-> ##1 scl_o)
+
+  // Make sure we never underflow the internal timer
+  `ASSERT_NEVER(I2CTimerUnderflow_A, tcount_q == 16'h0000 && tcount_d == 16'hFFFF)
 
   // TODO: Handle the assertion below
 //  // I2C bus outputs


### PR DESCRIPTION
This PR adds preventive measures to the I2C controller FSM to ensure it handles misconfigured software timing inputs without underflowing the internal down-counter.

# Cause 
When passing `12'h0` for `thd_dat_i` (due to a misconfiguration) the internal timing down counter in the controller underflows. 

# Preventive Measures 
* Converted the decrement logic into a saturating subtractor (`tcount_d = (tcount_q == 16'h0) ? 16'h0 : tcount_q - 1'b1;`). This safely clamps the counter at 0, allowing the hardware to handle 0 software configurations without underflowing.

* Added the `I2CTimerUnderflow_A` assertion using the `ASSERT_NEVER` macro to trigger upon underflow condition. 
