### PR TITLE
[keymgr_dpe,dv] Fix some hierarchical paths in common_vseq

### DIFF
--- a/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_common_vseq.sv
+++ b/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_common_vseq.sv
@@ -123,16 +123,16 @@ class keymgr_dpe_common_vseq extends keymgr_dpe_base_vseq;
     case (if_proxy.sec_cm_type)
       SecCmPrimCount: begin
         if (enable) begin
-          $asserton(0, "tb.keymgr_kmac_intf");
-          $asserton(0, "tb.dut.tlul_assert_device.gen_device.dDataKnown_A");
+          $asserton(0, "tb.keymgr_dpe_kmac_intf");
+          $asserton(0, "tb.dut.tlul_assert_device.gen_device.gen_d2h.dDataKnown_A");
           $asserton(0, "tb.dut.u_ctrl.DataEn_A");
           $asserton(0, "tb.dut.u_ctrl.DataEnDis_A");
           $asserton(0, "tb.dut.u_ctrl.CntZero_A");
           $asserton(0, "tb.dut.u_kmac_if.LastStrb_A");
           $asserton(0, "tb.dut.KmacDataKnownO_A");
         end else begin
-          $assertoff(0, "tb.keymgr_kmac_intf");
-          $assertoff(0, "tb.dut.tlul_assert_device.gen_device.dDataKnown_A");
+          $assertoff(0, "tb.keymgr_dpe_kmac_intf");
+          $assertoff(0, "tb.dut.tlul_assert_device.gen_device.gen_d2h.dDataKnown_A");
           $assertoff(0, "tb.dut.u_ctrl.DataEn_A");
           $assertoff(0, "tb.dut.u_ctrl.DataEnDis_A");
           $assertoff(0, "tb.dut.u_ctrl.CntZero_A");


### PR DESCRIPTION
These cause elaboration errors if you try to build with Xcelium.