### PR TITLE
[crypto] Stateful KATs

### DIFF
--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -72,11 +72,22 @@ This specialized target hashes the library's contents and fuses the hash onto th
 You can trigger this build using the `--config=crypto_fips_all` Bazel flag.
 The exact functions included in this blob are strictly governed by an allowlist configuration file located in `//sw/device/lib/crypto/configs`.
 
-Because the FIPS blob is relocatable and contiguous, developers contributing to the cryptolib must adhere to strict memory and structural constraints:
+Because the FIPS blob is relocatable and contiguous, developers contributing to the cryptolib must adhere to strict memory and structural constraints.
+
+### Cryptolib Contributor Constraints
 
 *   **No `.bss` or `.data` Sections:** The linker script enforces that the `.bss`, `.sbss`, `.data`, and `.sdata2` sections have a size of exactly 0. You **cannot** use static (non-const) variables or uninitialized global variables. All data must reside in `.text`, `.rodata`, or `.srodata`.
 *   **Strict Position Independence:** Code must be completely position-independent (PIC) and cannot rely on a Global Offset Table (GOT).
 *   **No Jump Tables:** The library is explicitly compiled with `-fno-jump-tables`. This forces the compiler to handle `switch` statements without generating position-dependent jump tables.
+*   **No Function Pointer Arrays:** Do not use `static const` arrays of function pointers (such as execution dispatch tables). The compiler will bake absolute memory addresses into the `.rodata` section. Instead, use sequential `if` statements or `switch` blocks, which force the compiler to generate safe, PC-relative jump instructions (`jal` or `auipc`).
+*   **Dynamic Pointer Initialization:** When initializing structs that contain pointers (like `otcrypto_byte_buf_t` or `otcrypto_unblinded_key_t`) with global constant arrays, **do not** use static curly-brace initialization or macros like `OTCRYPTO_MAKE_BUF`. The GCC optimizer will trap this and embed absolute addresses into `.rodata`. Instead, construct these structs dynamically at runtime using the inline builder functions provided in `integrity.h` (e.g., `otcrypto_make_const_byte_buf()`). This forces the compiler to calculate the pointer offsets safely on the stack.
+
+### Stateful Known Answer Tests (KATs)
+
+In the FIPS build, cryptographic operations are gated by Power-On Self-Tests (POSTs) and Known Answer Tests (KATs).
+The cryptolib handles these seamlessly, but internal contributors must observe the following rule to prevent lockups:
+
+*   **Run-Once State Tracking:** To minimize latency, KATs execute lazily upon the first invocation of a module. The cryptolib records successful KAT executions in the hardware's Retention SRAM. `otcrypto_init()` clears this state at boot. Never clear or mutate this Retention SRAM state manually outside of `otcrypto_init()`, or you will corrupt the execution ledger.
 
 ### Testing PIC Compliance
 

--- a/sw/device/lib/crypto/BUILD
+++ b/sw/device/lib/crypto/BUILD
@@ -14,7 +14,10 @@ cc_library(
     name = "otcrypto_api",
     defines =
         select({
-            "//sw/device/lib/crypto/configs:hashed": ["HASH_SELF_CHECK_ENABLE"],
+            "//sw/device/lib/crypto/configs:hashed": [
+                "HASH_SELF_CHECK_ENABLE",
+                "KAT_CHECK_ENABLE",
+            ],
             "//conditions:default": [],
         }),
     deps = [
@@ -31,6 +34,7 @@ cc_library(
         "//sw/device/lib/crypto/impl:hkdf",
         "//sw/device/lib/crypto/impl:hmac",
         "//sw/device/lib/crypto/impl:integrity",
+        "//sw/device/lib/crypto/impl:kats",
         "//sw/device/lib/crypto/impl:kdf_ctr",
         "//sw/device/lib/crypto/impl:key_transport",
         "//sw/device/lib/crypto/impl:kmac",
@@ -56,6 +60,10 @@ opentitan_binary_blob(
         "//sw/device/lib/base:memory",
         "//sw/device/lib/runtime:log",
     ],
+    target_compatible_with = select({
+        "//sw/device/lib/crypto/configs:crypto_fips_all": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     # We add the compiler option -fno-jump-tables to prevent the compiler making the code position dependent.
     # Minsize is added to reduce code size.
     transitive_features = [
@@ -131,4 +139,5 @@ pkg_tar(
 filegroup(
     name = "otcrypto_binary_blob_inspection",
     srcs = [":otcrypto_binary_blob_api"],
+    tags = ["manual"],
 )

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -42,6 +42,7 @@ cc_library(
     deps = [
         ":config",
         ":integrity",
+        ":kats_api",
         ":keyblob",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:memory",
@@ -217,7 +218,6 @@ cc_test(
 cc_library(
     name = "kats",
     srcs = ["kats.c"],
-    hdrs = ["kats.h"],
     deps = [
         ":aes",
         ":aes_gcm",
@@ -229,14 +229,33 @@ cc_library(
         ":entropy_src",
         ":hmac",
         ":integrity",
+        ":kats_api",
         ":keyblob",
         ":kmac",
         ":rsa",
         ":sha2",
         ":sha3",
         ":status",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/crypto/drivers:entropy_kat",
+        "//sw/device/lib/crypto/include:datatypes",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
+    alwayslink = True,
+)
+
+# We split the header to avoid circular dependencies.
+cc_library(
+    name = "kats_api",
+    hdrs = ["kats.h"],
+    defines = select({
+        "//sw/device/lib/crypto/configs:hashed": ["KAT_CHECK_ENABLE"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":status",
         "//sw/device/lib/crypto/include:datatypes",
     ],
 )
@@ -347,6 +366,10 @@ cc_library(
     name = "config",
     srcs = ["config.c"],
     hdrs = ["//sw/device/lib/crypto/include:config.h"],
+    defines = select({
+        "//sw/device/lib/crypto/configs:hashed": ["KAT_CHECK_ENABLE"],
+        "//conditions:default": [],
+    }),
     deps = [
         ":entropy_src",
         ":integrity",
@@ -357,6 +380,7 @@ cc_library(
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/crypto/drivers:alert",
         "//sw/device/lib/crypto/drivers:rv_core_ibex",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
     ],
 )
 

--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -10,6 +10,7 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/drivers/aes.h"
 #include "sw/device/lib/crypto/drivers/keymgr.h"
+#include "sw/device/lib/crypto/impl/kats.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/config.h"
@@ -564,6 +565,9 @@ otcrypto_status_t otcrypto_aes(otcrypto_blinded_key_t *key,
     return OTCRYPTO_BAD_ARGS;
   }
 #endif
+
+  // Run the AES ECB 256 KAT exactly once before utilizing the block
+  HARDENED_TRY(otcrypto_stateful_kat(kTestAesEcb256DecryptBit));
 
   if (launder32(key->config.security_level) == kOtcryptoKeySecurityLevelLow) {
     HARDENED_CHECK_EQ(key->config.security_level, kOtcryptoKeySecurityLevelLow);

--- a/sw/device/lib/crypto/impl/config.c
+++ b/sw/device/lib/crypto/impl/config.c
@@ -13,6 +13,12 @@
 #include "clkmgr_regs.h"
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+#ifdef KAT_CHECK_ENABLE
+
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+
+#endif
+
 otcrypto_status_t otcrypto_security_config_check(
     otcrypto_key_security_level_t security_level) {
   if (launder32(security_level) != kOtcryptoKeySecurityLevelLow) {
@@ -74,6 +80,12 @@ otcrypto_status_t otcrypto_init(otcrypto_key_security_level_t security_level) {
   HARDENED_TRY(otcrypto_set_security_config(security_level));
 
   HARDENED_TRY(init_alert_registers());
+
+#ifdef KAT_CHECK_ENABLE
+  // Clear the KAT evaluation state.
+  retention_sram_t *ret_sram = (retention_sram_t *)kRetentionSramBase;
+  ret_sram->owner.cryptolib_state = 0;
+#endif
 
   // Instantiate the RNG.
   HARDENED_TRY(otcrypto_entropy_init());

--- a/sw/device/lib/crypto/impl/kats.c
+++ b/sw/device/lib/crypto/impl/kats.c
@@ -1171,6 +1171,42 @@ static status_t kat_ed25519_verify(void) {
   return OTCRYPTO_OK;
 }
 
+#ifdef KAT_CHECK_ENABLE
+
+static inline uint32_t *get_kat_state_ptr(void) {
+  // Cast the absolute hardware address directly to the struct pointer.
+  retention_sram_t *ret_sram = (retention_sram_t *)kRetentionSramBase;
+
+  return &ret_sram->owner.cryptolib_state;
+}
+
+otcrypto_status_t otcrypto_stateful_kat(otcrypto_kat_bits_t kat_bit) {
+  uint32_t *state = get_kat_state_ptr();
+
+  if (state == NULL) {
+    return OTCRYPTO_FATAL_ERR;
+  }
+
+  uint32_t mask = (1UL << kat_bit);
+
+  if ((*state & mask) == 0) {
+    *state |= mask;  // Re-entrance lock
+
+    otcrypto_kat_id_t test_id = {.flags = mask};
+    status_t result = run_kats(test_id);
+
+    // If the KAT failed, unset the mask so it can be retried or debugged
+    if (result.value != kHardenedBoolTrue) {
+      *state &= ~mask;
+      return result;
+    }
+  }
+
+  return OTCRYPTO_OK;
+}
+
+#endif  // KAT_CHECK_ENABLE
+
 otcrypto_status_t run_kats(otcrypto_kat_id_t tests) {
   if (tests.flags == 0 || tests.flags >= (1UL << kTestLastBit)) {
     return OTCRYPTO_BAD_ARGS;

--- a/sw/device/lib/crypto/impl/kats.h
+++ b/sw/device/lib/crypto/impl/kats.h
@@ -83,6 +83,42 @@ typedef struct {
  */
 otcrypto_status_t run_kats(otcrypto_kat_id_t tests_to_run);
 
+/**
+ * @brief Ensures the specified Known-Answer Test (KAT) is executed exactly
+ * once.
+ *
+ * This function provides stateful, lazy evaluation of KATs depending on the
+ * build configuration:
+ *
+ * - **FIPS Build (`KAT_CHECK_ENABLE` defined):** It checks a tethered state
+ *   variable (provided by the host firmware) to verify if the KAT corresponding
+ *   to `kat_bit` has already run. If not, it executes the KAT and securely
+ *   updates the state. Subsequent calls for the same KAT will bypass execution.
+ * - **Standard Build (`KAT_CHECK_ENABLE` undefined):** The function evaluates
+ *   to a static inline no-op. It returns `OTCRYPTO_OK` immediately to avoid
+ *   unnecessary execution and linker dependencies.
+ *
+ * @param kat_bit The specific KAT to execute (e.g.,
+ * `kTestAesEcb256DecryptBit`).
+ * @return Result of the operation. Returns `OTCRYPTO_OK` on success, if the KAT
+ * already passed, or if lazy evaluation is disabled. Returns
+ * `OTCRYPTO_FATAL_ERR` if the KAT fails or the state pointer is missing.
+ */
+#ifndef KAT_CHECK_ENABLE
+
+// Standard build: Stateful KAT evaluation is disabled (non FIPS).
+static inline otcrypto_status_t otcrypto_stateful_kat(
+    otcrypto_kat_bits_t kat_bit) {
+  return OTCRYPTO_OK;
+}
+
+#else
+
+// FIPS build: Evaluates kats in a stateful manner
+otcrypto_status_t otcrypto_stateful_kat(otcrypto_kat_bits_t kat_bit);
+
+#endif  // KAT_CHECK_ENABLE
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/silicon_creator/lib/drivers/retention_sram.h
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram.h
@@ -32,7 +32,6 @@ typedef struct retention_sram_creator {
    * communicate with each other.
    */
   boot_svc_msg_t boot_svc_msg;
-
   /**
    * Space reserved for future allocation by the silicon creator.
    *
@@ -82,6 +81,13 @@ OT_ASSERT_SIZE(retention_sram_creator_t, 2044);
  */
 typedef struct retention_sram_owner {
   /**
+   * The state of the cryptolib concerning FIPS.
+   *
+   * This includes whether the self-integrity check was run, and whether the
+   * Known-Answer-Tests have been run.
+   */
+  uint32_t cryptolib_state;
+  /**
    * Space reserved for allocation by the silicon owner.
    *
    * The silcon creator boot stages will not modify this field except for
@@ -90,8 +96,12 @@ typedef struct retention_sram_owner {
    * Tests that need to trigger (or detect) a device reset may use this field to
    * preserve state information across resets.
    */
-  uint32_t reserved[2048 / sizeof(uint32_t)];
+  uint32_t reserved[(2048 - (sizeof(uint32_t)  // cryptolib_state
+                             )) /
+                    sizeof(uint32_t)];
 } retention_sram_owner_t;
+OT_ASSERT_MEMBER_OFFSET(retention_sram_owner_t, cryptolib_state, 0);
+OT_ASSERT_MEMBER_OFFSET(retention_sram_owner_t, reserved, 4);
 OT_ASSERT_SIZE(retention_sram_owner_t, 2048);
 
 /**

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -335,6 +335,10 @@ opentitan_binary_blob(
         "//sw/device/lib/runtime:log",
     ],
     rom_origin = "0x10000",
+    target_compatible_with = select({
+        "//sw/device/lib/crypto/configs:crypto_fips_all": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     transitive_features = [
         "no_jump_tables",
         "minsize",
@@ -1042,15 +1046,29 @@ opentitan_test(
     name = "kats_functest",
     srcs = ["kats_functest.c"],
     exec_env = CRYPTOTEST_EXEC_ENVS,
+    local_defines = select({
+        "//sw/device/lib/crypto/configs:hashed": ["KAT_CHECK_ENABLE"],
+        "//conditions:default": [],
+    }),
     verilator = verilator_params(
         timeout = "long",
     ),
     deps = [
-        "//sw/device/lib/crypto/impl:config",
-        "//sw/device/lib/crypto/impl:kats",
+        "//sw/device/lib/crypto",
+        "//sw/device/lib/crypto/include:crypto_hdrs",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
     ],
+)
+
+# Call the kats test with --config=crypto_fips_all
+# Call for example kats_functest_fips_fpga_cw340_sival_rom_ext, i.e., append fips behind the name and before the exec_env
+fips_wrap_opentitan_test(
+    name = "kats_functest",
+    exec_env = CRYPTOTEST_FIPS_EXEC_ENVS,
 )
 
 opentitan_test(

--- a/sw/device/tests/crypto/kats_functest.c
+++ b/sw/device/tests/crypto/kats_functest.c
@@ -2,18 +2,113 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/lib/crypto/impl/kats.h"
+#include "sw/device/lib/crypto/include/aes.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/integrity.h"
+#include "sw/device/lib/crypto/include/key_transport.h"
+#include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
+#ifdef KAT_CHECK_ENABLE
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+#endif
+
 OTTF_DEFINE_TEST_CONFIG();
+
+/**
+ * @brief Tests that the KAT evaluation runs once and skips thereafter.
+ */
+status_t test_stateful_kat_execution(void) {
+#ifdef KAT_CHECK_ENABLE
+  LOG_INFO("Testing stateful KAT execution for FIPS build using AES...");
+
+  // Verify the hardware state is zeroed out (otcrypto_init handles this)
+  TRY_CHECK(retention_sram_get()->owner.cryptolib_state == 0,
+            "KAT state should be 0 initially.");
+
+  otcrypto_key_config_t config = {
+      .version = kOtcryptoLibVersion1,
+      .key_mode = kOtcryptoKeyModeAesEcb,
+      .key_length = 16,
+      .hw_backed = kHardenedBoolFalse,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
+
+  uint32_t share0_data[4] = {0x01234567, 0x89abcdef, 0x55aa55aa, 0xaa55aa55};
+  uint32_t share1_data[4] = {0};
+  otcrypto_const_word32_buf_t key_share0 =
+      OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, share0_data, 4);
+  otcrypto_const_word32_buf_t key_share1 =
+      OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, share1_data, 4);
+
+  uint32_t keyblob[8] = {0};
+  otcrypto_blinded_key_t key = {
+      .config = config,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+  };
+
+  otcrypto_status_t import_status =
+      otcrypto_import_blinded_key(&key_share0, &key_share1, &key);
+  TRY_CHECK(import_status.value == kHardenedBoolTrue, "Key import failed.");
+
+  uint32_t iv_data[4] = {0};
+  otcrypto_word32_buf_t iv =
+      OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, iv_data, 4);
+
+  uint8_t input_data[16] = {0};
+  otcrypto_const_byte_buf_t input =
+      OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, input_data, 16);
+
+  uint8_t output_data[16] = {0};
+  otcrypto_byte_buf_t output =
+      OTCRYPTO_MAKE_BUF(otcrypto_byte_buf_t, output_data, 16);
+
+  uint64_t t1_start = ibex_mcycle_read();
+  otcrypto_status_t status1 =
+      otcrypto_aes(&key, &iv, kOtcryptoAesModeCbc, kOtcryptoAesOperationEncrypt,
+                   &input, kOtcryptoAesPaddingNull, &output);
+  uint64_t t1_end = ibex_mcycle_read();
+  uint64_t first_run_cycles = t1_end - t1_start;
+
+  // Ensure it failed properly inside otcrypto_aes
+  TRY_CHECK(status1.value != kHardenedBoolTrue,
+            "Expected failure due to mode mismatch.");
+
+  // Verify that *some* KAT bit was successfully set in hardware.
+  TRY_CHECK(retention_sram_get()->owner.cryptolib_state != 0,
+            "KAT state was not mutated by the cryptolib.");
+
+  uint64_t t2_start = ibex_mcycle_read();
+  otcrypto_status_t status2 =
+      otcrypto_aes(&key, &iv, kOtcryptoAesModeCbc, kOtcryptoAesOperationEncrypt,
+                   &input, kOtcryptoAesPaddingNull, &output);
+  uint64_t t2_end = ibex_mcycle_read();
+  uint64_t second_run_cycles = t2_end - t2_start;
+
+  TRY_CHECK(status2.value != kHardenedBoolTrue,
+            "Expected failure due to mode mismatch.");
+
+  LOG_INFO("First run (with KAT): %u cycles", (uint32_t)first_run_cycles);
+  LOG_INFO("Second run (skipped KAT): %u cycles", (uint32_t)second_run_cycles);
+
+  // Prove the second run was significantly faster
+  TRY_CHECK(second_run_cycles < (first_run_cycles / 2),
+            "Second run was not faster; KAT was not skipped.");
+
+  LOG_INFO("KAT FIPS behavior verified using AES.");
+#endif
+
+  return OK_STATUS();
+}
 
 bool test_main(void) {
   CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
-  CHECK_STATUS_OK(run_kats(OTCRYPTO_KAT_ALL_TESTS));
+  CHECK_STATUS_OK(test_stateful_kat_execution());
 
   return true;
 }


### PR DESCRIPTION
- Take a word from silicon creator's reserved structure in retention SRAM and use it for stateful logic in the cryptolib (1 word)
- Use the word to allow for stateful execution of the KATs