### PR TITLE
[crypto] Create a fips Bazel wrapper

### DIFF
--- a/sw/device/lib/crypto/configs/fips_wrapper.bzl
+++ b/sw/device/lib/crypto/configs/fips_wrapper.bzl
@@ -1,0 +1,73 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules/opentitan:defs.bzl", "opentitan_test")
+
+def _fips_transition_impl(settings, attr):
+    return {
+        "//sw/device/lib/crypto/configs:cryptolib_config_flag": "crypto_fips_all",
+        "//sw/device/lib/crypto/configs:hashed_flag": True,
+        "//sw/device/lib/crypto/configs:type_flag": "binary_blob",
+    }
+
+fips_transition = transition(
+    implementation = _fips_transition_impl,
+    inputs = [],
+    outputs = [
+        "//sw/device/lib/crypto/configs:cryptolib_config_flag",
+        "//sw/device/lib/crypto/configs:hashed_flag",
+        "//sw/device/lib/crypto/configs:type_flag",
+    ],
+)
+
+def _fips_test_wrapper_impl(ctx):
+    actual_test = ctx.executable.actual_test
+
+    executable = ctx.actions.declare_file(ctx.label.name)
+
+    # Create a symlink to the transitioned test executable
+    ctx.actions.symlink(
+        output = executable,
+        target_file = actual_test,
+        is_executable = True,
+    )
+
+    # Gather runfiles
+    runfiles = ctx.runfiles(files = [actual_test])
+    runfiles = runfiles.merge(ctx.attr.actual_test[0].default_runfiles)
+
+    # Bundle the transitioned data files into the execution environment
+    if hasattr(ctx.attr, "data"):
+        for d in ctx.attr.data:
+            runfiles = runfiles.merge(d[DefaultInfo].default_runfiles)
+            runfiles = runfiles.merge(ctx.runfiles(files = d.files.to_list()))
+
+    return [DefaultInfo(
+        executable = executable,
+        runfiles = runfiles,
+    )]
+
+# Create a wrapper for a test to run with the --config=crypto_fips_all flag
+fips_transition_test = rule(
+    implementation = _fips_test_wrapper_impl,
+    test = True,
+    attrs = {
+        "actual_test": attr.label(executable = True, cfg = fips_transition),
+        "data": attr.label_list(allow_files = True, cfg = fips_transition),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+)
+
+# Generates a wrapper for an opentitan_test to run with the --config=crypto_fips_all flag
+def fips_wrap_opentitan_test(name, exec_env):
+    for env_label in exec_env.keys():
+        env_suffix = env_label.split(":")[-1]
+
+        # The new name of the test is {name}_fips_{exec_env}
+        fips_transition_test(
+            name = "{}_fips_{}".format(name, env_suffix),
+            actual_test = ":{}_{}".format(name, env_suffix),
+        )

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -18,14 +18,29 @@ load(
     "silicon_params",
     "verilator_params",
 )
+load(
+    "@provisioning_exts//:cfg.bzl",
+    "EXT_EXEC_ENV_SILICON_ROM_EXT",
+)
 load("@ot_python_deps//:requirements.bzl", "requirement")
 load("//rules/coverage:view.bzl", "coverage_view_test")
+load("//sw/device/lib/crypto/configs:fips_wrapper.bzl", "fips_transition_test", "fips_wrap_opentitan_test")
 
 package(default_visibility = ["//visibility:public"])
 
 CRYPTOTEST_EXEC_ENVS = dicts.add(
     EARLGREY_TEST_ENVS,
     EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    {
+        "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
+    },
+)
+
+# Specifying more restricted platforms for the FIPS tests
+# due to the transition environment not allowing to pass other flags
+# such as Verilator flags
+CRYPTOTEST_FIPS_EXEC_ENVS = dicts.add(
+    EXT_EXEC_ENV_SILICON_ROM_EXT,
     {
         "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
     },
@@ -350,12 +365,24 @@ filegroup(
     output_group = "dis_file",
 )
 
+# Internal target, to be used for otcrypto_pic_test
+py_test(
+    name = "internal_otcrypto_pic_test",
+    srcs = ["otcrypto_pic_test.py"],
+    main = "otcrypto_pic_test.py",
+    tags = ["manual"],
+    deps = [
+        "@rules_python//python/runfiles",
+    ],
+)
+
 # Verify whether the binary blob of the cryptolib API is position-independent
 # by checking that the symbol addresses are appropriately shifted when
 # shifting the library in memory.
-py_test(
+# Run the test with config=crypto_fips_all
+fips_transition_test(
     name = "otcrypto_pic_test",
-    srcs = ["otcrypto_pic_test.py"],
+    actual_test = ":internal_otcrypto_pic_test",
     args = [
         "--elf-base=$(location :otcrypto_elf_base)",
         "--elf-offset=$(location :otcrypto_elf_shifted)",
@@ -373,7 +400,6 @@ py_test(
         "@lowrisc_rv32imcb_toolchain//:bin/riscv32-unknown-elf-nm",
         "@lowrisc_rv32imcb_toolchain//:bin/riscv32-unknown-elf-objcopy",
         "@lowrisc_rv32imcb_toolchain//:bin/riscv32-unknown-elf-objdump",
-        "@rules_python//python/runfiles",
     ],
 )
 
@@ -1573,6 +1599,13 @@ opentitan_test(
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
+)
+
+# Call the hash test with --config=crypto_fips_all
+# Call for example otcrypto_hash_test_fips_fpga_cw340_sival_rom_ext, i.e., append fips behind the name and before the exec_env
+fips_wrap_opentitan_test(
+    name = "otcrypto_hash_test",
+    exec_env = CRYPTOTEST_FIPS_EXEC_ENVS,
 )
 
 opentitan_test(


### PR DESCRIPTION
Create a new Bazel target to run tests (including opentitan_tests) with the configs defined in //sw/device/lib/crypto/configs, i.e., to run a test with the --config=crypto_fips_all flag.
This puts the new binary blob and self-tests in CI.