### PR TITLE
[crypto/25519] X25519 FI hardening

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc/curve25519.c
@@ -63,6 +63,10 @@ enum {
   kModeKeygenInsCnt = 342098,
   kModeSignStage1InsCnt = 684257,
   kModeSignStage2InsCnt = 655,
+  kModeX25519InsCnt = 366561,
+  kModeX25519SideloadInsCnt = 362932,
+  kModeX25519KeygenInsCnt = 359288,
+  kModeX25519KeygenSideloadInsCnt = 355659,
 };
 
 /**
@@ -360,8 +364,15 @@ status_t curve25519_x25519_sideload_start(
 
 status_t curve25519_x25519_finalize(
     uint32_t shared_secret[kCurve25519MaskedPointWords]) {
+  uint32_t ins_cnt;
   // Spin here waiting for OTBN to complete.
   HARDENED_TRY(otbn_busy_wait_for_done());
+  ins_cnt = otbn_instruction_count_get();
+  if (launder32(ins_cnt) == kModeX25519InsCnt) {
+    HARDENED_CHECK_EQ(ins_cnt, kModeX25519InsCnt);
+  } else {
+    HARDENED_CHECK_EQ(ins_cnt, kModeX25519SideloadInsCnt);
+  }
 
   // Check whether OTBN accepted the public key (rejects twist points).
   uint32_t ok;
@@ -408,8 +419,15 @@ status_t curve25519_x25519_keygen_start(
 
 status_t curve25519_x25519_keygen_finalize(
     uint32_t public_key[kCurve25519PointWords]) {
+  uint32_t ins_cnt;
   // Spin here waiting for OTBN to complete.
   HARDENED_TRY(otbn_busy_wait_for_done());
+  ins_cnt = otbn_instruction_count_get();
+  if (launder32(ins_cnt) == kModeX25519KeygenInsCnt) {
+    HARDENED_CHECK_EQ(ins_cnt, kModeX25519KeygenInsCnt);
+  } else {
+    HARDENED_CHECK_EQ(ins_cnt, kModeX25519KeygenSideloadInsCnt);
+  }
 
   // Read the public key from OTBN dmem.
   const otbn_addr_t kOtbnVarX25519PublicKey =

--- a/sw/device/lib/crypto/impl/ecc/curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc/curve25519.c
@@ -60,8 +60,8 @@ enum {
   /*
    * The expected instruction counts for constant time functions.
    */
-  kModeKeygenInsCnt = 342108,
-  kModeSignStage1InsCnt = 684277,
+  kModeKeygenInsCnt = 342098,
+  kModeSignStage1InsCnt = 684257,
   kModeSignStage2InsCnt = 655,
 };
 

--- a/sw/device/lib/crypto/impl/ecc/curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc/curve25519.c
@@ -380,7 +380,6 @@ status_t curve25519_x25519_finalize(
       OTBN_ADDR_T_INIT(run_curve25519, x25519_ok);
   HARDENED_TRY(otbn_dmem_read(1, kOtbnVarX25519Ok, &ok));
   if (launder32(ok) != kHardenedBoolTrue) {
-    HARDENED_TRY(otbn_dmem_sec_wipe());
     return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_CHECK_EQ(ok, kHardenedBoolTrue);

--- a/sw/device/lib/crypto/impl/ecc_curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc_curve25519.c
@@ -782,7 +782,7 @@ otcrypto_status_t otcrypto_x25519_async_start(
 
 otcrypto_status_t otcrypto_x25519_async_finalize(
     otcrypto_blinded_key_t *shared_secret) {
-  HARDENED_TRY(curve25519_x25519_finalize(shared_secret->keyblob));
+  HARDENED_TRY_WIPE_DMEM(curve25519_x25519_finalize(shared_secret->keyblob));
   shared_secret->checksum = otcrypto_integrity_blinded_checksum(shared_secret);
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }

--- a/sw/device/tests/crypto/x25519_functest.c
+++ b/sw/device/tests/crypto/x25519_functest.c
@@ -128,6 +128,8 @@ status_t x25519_kat_test(void) {
   // Run X25519.
   CHECK_STATUS_OK(
       otcrypto_x25519(&private_key_alice, &public_key_bob, &shared_secret));
+  LOG_INFO("OTBN instruction count for x25519: 0x%08x",
+           otbn_instruction_count_get());
 
   // Unmask the shared secret.
   uint32_t shared_secret_unmasked[kX25519SharedSecretWords];
@@ -170,6 +172,8 @@ status_t x25519_keygen_test(void) {
   // Run x25519 key generation.
   CHECK_STATUS_OK(
       otcrypto_x25519_keygen(&private_key_alice, &public_key_alice));
+  LOG_INFO("OTBN instruction count for keygen: 0x%08x",
+           otbn_instruction_count_get());
 
   // Check the x25519 key generation result.
   TRY_CHECK_ARRAYS_EQ(kPublicKeyAlice, public_key_alice.key,

--- a/sw/device/tests/crypto/x25519_sideload_functest.c
+++ b/sw/device/tests/crypto/x25519_sideload_functest.c
@@ -138,6 +138,8 @@ status_t key_exchange_test(void) {
   // Generate a keypair.
   LOG_INFO("Generating X25519 keypair A");
   TRY(otcrypto_x25519_keygen(&private_keyA, &public_keyA));
+  LOG_INFO("OTBN instruction count for keygen: 0x%08x",
+           otbn_instruction_count_get());
 
   // Generate a second keypair.
   LOG_INFO("Generating X25519 keypair B");
@@ -164,6 +166,8 @@ status_t key_exchange_test(void) {
   // Compute the shared secret from A's side.
   LOG_INFO("Generating shared secret (A)");
   TRY(otcrypto_x25519(&private_keyA, &public_keyB, &shared_keyA));
+  LOG_INFO("OTBN instruction count for x25519: 0x%08x",
+           otbn_instruction_count_get());
 
   // Compute the shared secret from B's side.
   LOG_INFO("Generating shared secret (B)");

--- a/sw/otbn/crypto/25519.s
+++ b/sw/otbn/crypto/25519.s
@@ -16,7 +16,7 @@
 .globl ext_double
 .globl ext_add
 .globl ext_to_affine
-.globl ext_is_on_curve
+.globl ed25519_isoncurve_ext
 .globl x25519
 
 /**
@@ -175,13 +175,13 @@ ed25519_gen_public_key:
   li       x5, 0  /* Ed25519 mode: use rnd * L */
   jal      x1, ext_scmul_sca
 
+  /* Check that A is a curve point in projective space. */
+  jal      x1, ed25519_isoncurve_ext
+  jal      x1, trigger_fault_if_fg0_not_z
+
   /* Convert A to affine coordinates.
        w10 <= A.x, w11 <= A.y */
   jal      x1, ext_to_affine
-
-  /* Check that A is a curve point. */
-  jal      x1, ext_is_on_curve
-  jal      x1, trigger_fault_if_fg0_not_z
 
   /* Encode A.
        w11 <= encode(w10, w11) = A_ */
@@ -406,12 +406,12 @@ ed25519_verify_var:
        [w13:w10] <= w28 * [w9:w6] = [8][S]B */
   jal      x1, ext_scmul
 
+  /* Check that LHS is a curve point in projective space. */
+  jal      x1, ed25519_isoncurve_ext
+  jal      x1, trigger_fault_if_fg0_not_z
+
   /* Convert LHS [8][S]B to affine. */
   jal      x1, ext_to_affine
-
-  /* Check that LHS is a curve point. */
-  jal      x1, ext_is_on_curve
-  jal      x1, trigger_fault_if_fg0_not_z
 
   /* Encode LHS. */
   jal      x1, affine_encode
@@ -428,12 +428,12 @@ ed25519_verify_var:
   bn.mov   w12, w4
   bn.mov   w13, w5
 
+  /* Check that RHS is a curve point in projective space. */
+  jal      x1, ed25519_isoncurve_ext
+  jal      x1, trigger_fault_if_fg0_not_z
+
   /* Convert RHS to affine. */
   jal      x1, ext_to_affine
-
-  /* Check that RHS is a curve point. */
-  jal      x1, ext_is_on_curve
-  jal      x1, trigger_fault_if_fg0_not_z
 
   /* Encode RHS. */
   jal      x1, affine_encode
@@ -562,13 +562,13 @@ ed25519_sign_stage1:
   li       x5, 0  /* Ed25519 mode: use rnd * L */
   jal      x1, ext_scmul_sca
 
+  /* Check that R is a curve point in projective space. */
+  jal      x1, ed25519_isoncurve_ext
+  jal      x1, trigger_fault_if_fg0_not_z
+
   /* Convert R to affine coordinates.
        w10 <= R.x, w11 <= R.y */
   jal      x1, ext_to_affine
-
-  /* Check that R is a curve point. */
-  jal      x1, ext_is_on_curve
-  jal      x1, trigger_fault_if_fg0_not_z
 
   /* Encode R.
        w11 <= encode(w10, w11) = R_ */
@@ -1701,75 +1701,6 @@ ext_add:
   ret
 
 /**
- * Perform an is-on-curve check.
- *
- * Given affine (x, y)-coordinates verify whether they constitute a valid
- * Ed25519 curve point by comparing the lefthand and righthand side of the
- * curve equation to each other. In other words, this routine checks that
- *
- *  a * x^2 + y^2 = 1 + d * x^2 * y^2.
- *
- * This routine runs in constant time.
- *
- * @param[in] w10: x-coordinate.
- * @param[in] w11: y-coordinate.
- * @param[in] w19: constant, 19.
- * @param[in] w30: constant, 38.
- * @param[in] w31: all-zero.
- * @param[in] MOD: p, modulus = 2^255 - 19.
- * @param[out] FG0.Z: result, 1 if the point is on the curve, 0 otherwise.
- *
- * clobbered registers: w12 to w18, w20 to w22.
- * clobbered flag groups: FG0.
- */
-ext_is_on_curve:
-  /* Load the curve constants.
-       w12 <= a
-       w13 <= d. */
-  li x2, 12
-  la x3, ed25519_a
-  bn.lid x2++, 0(x3)
-  la x3, ed25519_d
-  bn.lid x2, 0(x3)
-
-  /* w14 <= w22 * w22 = x^2. */
-  bn.mov w22, w10
-  jal x1, fe_square
-  bn.mov w14, w22
-
-  /* w15 <= w22 * w22 = y^2. */
-  bn.mov w22, w11
-  jal x1, fe_square
-  bn.mov w15, w22
-
-  /* w2 <= w22 * w23 = a * x^2. */
-  bn.mov w22, w12
-  bn.mov w23, w14
-  jal x1, fe_mul
-
-  /* w16 <= w15 + w22 = a * x^2 + y^2. */
-  bn.addm w16, w15, w22
-
-  /* w22 <= w22 * w23 = d * x^2. */
-  bn.mov w22, w13
-  bn.mov w23, w14
-  jal x1, fe_mul
-
-  /* w22 <= w22 * w23 = d * x^2 * y^2. */
-  bn.mov w23, w15
-  jal x1, fe_mul
-
-  /* w17 <= w17 + w22 = 1 + d * x^2 * y^2. */
-  bn.addi w17, w31, 1
-  bn.addm w17, w17, w22
-
-  /* Return 2^256-1 if w16 = w17, i.e., a * x^2 + y^2 = 1 + d * x^2 * y^2. */
-  bn.not w12, w31
-  bn.cmp w16, w17, FG0
-
-  ret
-
-/**
  * Raise a coordinate field element (modulo p) to the power of ((p-5) / 8).
  *
  * Returns c = a^(2^252-3) mod p.
@@ -1994,30 +1925,133 @@ x25519_mont_u_to_ed_y:
   ret
 
 /**
- * Convert Twisted Edwards y-coordinate back to Montgomery u-coordinate.
- * Formula: u = (1 + y) * (1 - y)^-1 mod p
+ * Convert Twisted Edwards extended projective coordinates to a masked Montgomery u-coordinate.
  *
- * @param[in]  w11: Twisted Edwards y
+ * Maps the resulting Ed25519 point from extended projective coordinates
+ * to its affine Curve25519 (Montgomery) u-coordinate equivalent.
+ * To prevent unmasking the shared secret in registers, a random
+ * arithmetic mask 'r' is applied during the projective conversion:
+ * u_masked = u - r mod p
+ * = ((Z + Y) - r * (Z - Y)) / (Z - Y) mod p
+ * = (U - r * W) * W^-1 mod p
+ *
+ * @param[in]  w11: Y coordinate
+ * @param[in]  w12: Z coordinate
  * @param[in]  w31: all-zero
- * @param[out] w22: Montgomery u
+ * @param[out] w19: r, the random arithmetic mask applied to the output
+ * @param[out] w22: u_masked, the arithmetically masked X25519 result
+ * @param[out] x2:  0 if successful, 8 if U = Z + Y = 0 mod p (invalid point)
  *
- * clobbered registers: w6, w10, w16, w23
+ * clobbered registers: x2, x3, w16, w19, w22 to w25
+ * clobbered flag groups: FG0
  */
-x25519_ed_y_to_mont_u:
-  bn.addi  w6, w31, 1
-  /* w10 = 1 + y */
-  bn.addm  w10, w6, w11
-  /* w16 = 1 - y */
-  bn.subm  w16, w6, w11
+x25519_ed_ext_to_mont_u_masked:
+  /* W = (Z - Y) mod p */
+  bn.subm  w23, w12, w11
 
-  /* Invert (1 - y) */
-  jal      x1, fe_inv
+  /* U = (Z + Y) mod p  */
+  /* Note that this value is still masked by the coord rand. */
+  bn.addm  w24, w12, w11
 
-  /* u = (1 + y) * (1 - y)^-1 */
-  bn.mov   w23, w10
+  /* Check if U == 0 mod p */
+  bn.cmp   w24, w31
+  csrrs    x2, FG0, x0
+  andi     x2, x2, 8      /* Extract the Z flag (bit 3) from FG0 */
+  addi     x3, x0, 8
+
+  /* If the Z flag is set (U = 0). Jump to end and return failure flag. */
+  beq      x2, x3, .L_invalid_mapping
+
+  /* Fetch random mask r and reduce it modulo p. */
+  bn.wsrr  w25, URND
+  bn.addm  w25, w25, w31
+
+  /* Compute T1 = (r * W) mod p. */
+  bn.mov   w22, w25
   jal      x1, fe_mul
 
-  /* The resulting u-coordinate is now in w22. */
+  /* U_masked = U - (r * W) mod p */
+  bn.subm  w24, w24, w22
+
+  bn.mov   w16, w23
+
+  bn.cmp   w16, w31
+  csrrs    x2, FG0, x0
+  andi     x2, x2, 8
+  addi     x3, x0, 8
+  /* Reject if we have the identity point (W = 0). */
+  beq      x2, x3, .L_invalid_mapping
+
+  /* Compute W^-1 mod p. */
+  jal      x1, fe_inv
+
+  /* Compute u_masked = U_masked * W^-1 mod p. */
+  bn.mov   w23, w24
+  jal      x1, fe_mul
+
+  /* Output mask 'r' in w19. */
+  bn.mov   w19, w25
+
+.L_invalid_mapping:
+  ret
+
+/**
+ * Checks if a point in extended twisted Edwards coordinates is on the curve.
+ *
+ * Computes lhs = -X^2 + Y^2 mod p and rhs = Z^2 + d * T^2 mod p
+ * and sets the FG0.Z flag if they are equal.
+ *
+ * @param[in]  w10: X coordinate
+ * @param[in]  w11: Y coordinate
+ * @param[in]  w12: Z coordinate
+ * @param[in]  w13: T coordinate
+ * @param[in]  w31: all-zero
+ * @param[in]  MOD: p, modulus = 2^255 - 19
+ * @param[out] FG0.Z: 1 if point is on curve, 0 otherwise
+ *
+ * clobbered registers: x2, x3, w14 to w17, w22, w23
+ * clobbered flag groups: FG0
+ */
+ed25519_isoncurve_ext:
+  /* Compute X^2 mod p */
+  bn.mov   w22, w10
+  jal      x1, fe_square
+  bn.mov   w14, w22
+
+  /* Compute Y^2 mod p */
+  bn.mov   w22, w11
+  jal      x1, fe_square
+  bn.mov   w15, w22
+
+  /* Compute lhs = -X^2 + Y^2 mod p */
+  bn.subm  w14, w15, w14
+
+  /* Compute Z^2 mod p */
+  bn.mov   w22, w12
+  jal      x1, fe_square
+  bn.mov   w15, w22
+
+  /* Compute T^2 mod p */
+  bn.mov   w22, w13
+  jal      x1, fe_square
+  /* w22 is now T^2 */
+
+  /* Load curve constant d into w16 */
+  li       x2, 16
+  la       x3, ed25519_d
+  bn.lid   x2, 0(x3)
+
+  /* Compute d * T^2 mod p */
+  bn.mov   w23, w16
+  jal      x1, fe_mul
+  /* w22 is now d * T^2 */
+
+  /* Compute rhs = Z^2 + d * T^2 mod p */
+  bn.addm  w15, w15, w22
+
+  /* Compare lhs and rhs. Sets FG0.Z to 1 if equal. */
+  bn.cmp   w14, w15, FG0
+
   ret
 
 /**
@@ -2039,7 +2073,7 @@ x25519_ed_y_to_mont_u:
  * @param[out] x20: SUCCESS if the public key decoding passed,
  * FAILURE if the public key decoding failed or u=0
  *
- * clobbered registers: x2, x3, x21, w2, w6 to w30
+ * clobbered registers: x2, x3, x5, x21, x24, w2, w6 to w30
  * clobbered flag groups: FG0
  */
 x25519:
@@ -2071,7 +2105,7 @@ x25519:
      points, so affine_decode_var will fail for them. */
   jal      x1, affine_decode_var
 
-  /* Fail if the point was not on the Ed25519 curve (e.g. twist point). */
+  /* Fail if the point was not on the Ed25519 curve (i.e. points on twisted curve). */
   li       x21, 0x739
   bne      x20, x21, .L_x25519_fail
 
@@ -2087,62 +2121,19 @@ x25519:
   li       x5, 1  /* X25519 mode: use 8 * rnd * L */
   jal      x1, ext_scmul_sca
 
-  /* Map the resulting Ed25519 point from extended projective coordinates  */
-  /* to its affine Curve25519 (Montgomery) u-coordinate equivalent.        */
+  /* Verify the resulting projective point is a valid curve point */
+  jal      x1, ed25519_isoncurve_ext
+  jal      x1, trigger_fault_if_fg0_not_z
 
-  /* The standard mapping is u = (Z + Y) / (Z - Y) mod p.                  */
-  /* To prevent unmasking the shared secret in registers, we apply a       */
-  /* random arithmetic mask 'r' during the projective conversion:          */
-  /* u_masked = u - r mod p                                                */
-  /* = ((Z + Y) - r * (Z - Y)) / (Z - Y) mod p                             */
-  /* = (U - r * W) * W^-1 mod p                                            */
+  /* Map Ed25519 extended projective back to masked Curve25519 Montgomery u */
+  jal      x1, x25519_ed_ext_to_mont_u_masked
 
-  /* W = (Z - Y) mod p */
-  bn.subm  w23, w12, w11
-
-  /* U = (Z + Y) mod p  */
-  /* Note that this value is still masked by the coord rand. */
-  bn.addm  w24, w12, w11
-
-  /* Check if U == 0 mod p */
-  bn.cmp   w24, w31
-  csrrs    x2, FG0, x0
-  andi     x2, x2, 8      /* Extract the Z flag (bit 3) from FG0 */
-  addi     x3, x0, 8
-
-  /* If the Z flag is set (x2 == 8), U is 0. Jump to failure. */
-  beq      x2, x3, .L_x25519_fail
-
-  /* Fetch random mask r and reduce it modulo p. */
-  bn.wsrr  w25, URND
-  bn.addm  w25, w25, w31
-
-  /* Compute T1 = (r * W) mod p. */
-  bn.mov   w22, w25
-  jal      x1, fe_mul
-
-  /* U_masked = U - (r * W) mod p */
-  bn.subm  w24, w24, w22
-
-  /* Compute W^-1 mod p. */
-  bn.mov   w16, w23
-  jal      x1, fe_inv
-
-  /* u_masked = U_masked * W^-1 mod p */
-  bn.mov   w23, w24
-  jal      x1, fe_mul
-
-  /* Check if W == 0 mod p */
-  bn.cmp   w16, w31
-  csrrs    x2, FG0, x0
-  andi     x2, x2, 8      /* Extract the Z flag */
-  addi     x3, x0, 8
-  beq      x2, x3, .L_x25519_fail  /* Reject if we have the identity point */
-
-  bn.mov   w19, w25
+  /* If x2 is not 0 (it is 8), U was 0, meaning an invalid mapping. Jump to failure. */
+  bne      x2, x0, .L_x25519_fail
 
   /* Signal success to caller via x20. */
   li       x20, 0x739
+
   ret
 
 .L_x25519_fail:

--- a/sw/otbn/crypto/25519.s
+++ b/sw/otbn/crypto/25519.s
@@ -874,14 +874,12 @@ affine_encode:
  *   - Solving the curve equation to get two candidates for x.
  *   - Use lsb(x) to select the correct candidate.
  *
- * This implementation, in accordance with ZIP215 validation criteria, will
- * accept non-canonical values of y in the range [p,2^255). However, the output
- * y value will be fully reduced modulo p.
+ * In order to allow instruction count checking for fault injection protection,
+ * this runs in constant time.
  *
- * Since the inputs to this routine are all public values, there's no need to
- * make it constant-time.
- *
- * This routine runs in variable time.
+ * To achieve constant-time execution, this routine computes both possible
+ * roots and uses branchless hardware selection (bn.sel) and bitwise masking
+ * to apply the correct root and status code.
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
@@ -894,7 +892,7 @@ affine_encode:
  * @param[out] w10: output x (x < p) (only valid if x20=SUCCESS)
  * @param[out] w11: output y (y < p) (only valid if x20=SUCCESS)
  *
- * clobbered registers: w10, w11, w14 to w18, w20 to w28
+ * clobbered registers: x2, x5 to x7, w10, w11, w14 to w18, w20 to w28
  * clobbered flag groups: FG0
  */
 affine_decode_var:
@@ -946,66 +944,56 @@ affine_decode_var:
   /* FG0.C <= w11 < w27 = y < p */
   bn.cmp   w11, w27
 
-  /* x2 <= FG0[0] = FG0.C */
-  csrrs    x2, FG0, x0
-  andi     x2, x2, 1
+  /* x7 <= FG0[0] = FG0.C
+     x7 will be 1 if y is canonical, 0 if y >= p */
+  csrrs    x7, FG0, x0
+  andi     x7, x7, 1
 
-  /* Fail if y >= p */
-  bne      x2, x0, .L_y_is_canonical
+  /* Store the constant 1, which will be used to compute u and v.
+     w25 <= 1 */
+  bn.addi  w25, w31, 1
 
-  /* Return FAILURE if not canonical */
-  li       x20, 0x1d4
-  bn.mov   w10, w31
-  bn.mov   w11, w31
-  ret
+  /* Compute u and v. */
 
-.L_y_is_canonical:
+  /* w22 <= (w11^2) mod p = y^2 mod p */
+  bn.mov   w22, w11
+  jal      x1, fe_square
+  /* w26 <= (w22 - w25) mod p <= (y^2 - 1) mod p = u */
+  bn.subm  w26, w22, w25
+  /* w22 <= (w22 * w29) mod p = (y^2 * d) mod p */
+  bn.mov   w23, w29
+  jal      x1, fe_mul
+  /* w25 <= (w22 + w25) mod p = (y^2 * d + 1) mod p = v */
+  bn.addm  w25, w22, w25
 
-   /* Store the constant 1, which will be used to compute u and v.
-        w25 <= 1 */
-   bn.addi   w25, w31, 1
+  /* Compute the candidate root r = (u*(v^3))((u*(v^7))^((p-5)/8)) mod p. */
 
-   /* Compute u and v. */
-
-   /* w22 <= (w11^2) mod p = y^2 mod p */
-   bn.mov   w22, w11
-   jal      x1, fe_square
-   /* w26 <= (w22 - w25) mod p <= (y^2 - 1) mod p = u */
-   bn.subm  w26, w22, w25
-   /* w22 <= (w22 * w29) mod p = (y^2 * d) mod p */
-   bn.mov   w23, w29
-   jal      x1, fe_mul
-   /* w25 <= (w22 + w25) mod p = (y^2 * d + 1) mod p = v */
-   bn.addm  w25, w22, w25
-
-   /* Compute the candidate root r = (u*(v^3))((u*(v^7))^((p-5)/8)) mod p. */
-
-   /* w27 <= (w26 * w25) mod p = (u * v) mod p */
-   bn.mov   w22, w26
-   bn.mov   w23, w25
-   jal      x1, fe_mul
-   bn.mov   w27, w22
-   /* w28 <= (w25^2) mod p = (v^2) mod p */
-   bn.mov   w22, w25
-   jal      x1, fe_square
-   bn.mov   w28, w22
-   /* w27 <= (w27 * w28) mod p = (u * v^3) mod p */
-   bn.mov   w22, w27
-   bn.mov   w23, w28
-   jal      x1, fe_mul
-   bn.mov   w27, w22
-   /* w22 <= (w28^2) mod p = (v^4) mod p */
-   bn.mov   w22, w28
-   jal      x1, fe_square
-   /* w22 <= (w22 * w27) mod p = (u * v^7) mod p */
-   bn.mov   w23, w27
-   jal      x1, fe_mul
-   /* w22 <= (w22^((p-5)/8)) mod p = (u * v^7)^((p-5)/8) mod p */
-   bn.mov   w16, w22
-   jal      x1, fe_pow_2252m3
-   /* w22 <= (w22 * w27) mod p = r */
-   bn.mov   w23, w27
-   jal      x1, fe_mul
+  /* w27 <= (w26 * w25) mod p = (u * v) mod p */
+  bn.mov   w22, w26
+  bn.mov   w23, w25
+  jal      x1, fe_mul
+  bn.mov   w27, w22
+  /* w28 <= (w25^2) mod p = (v^2) mod p */
+  bn.mov   w22, w25
+  jal      x1, fe_square
+  bn.mov   w28, w22
+  /* w27 <= (w27 * w28) mod p = (u * v^3) mod p */
+  bn.mov   w22, w27
+  bn.mov   w23, w28
+  jal      x1, fe_mul
+  bn.mov   w27, w22
+  /* w22 <= (w28^2) mod p = (v^4) mod p */
+  bn.mov   w22, w28
+  jal      x1, fe_square
+  /* w22 <= (w22 * w27) mod p = (u * v^7) mod p */
+  bn.mov   w23, w27
+  jal      x1, fe_mul
+  /* w22 <= (w22^((p-5)/8)) mod p = (u * v^7)^((p-5)/8) mod p */
+  bn.mov   w16, w22
+  jal      x1, fe_pow_2252m3
+  /* w22 <= (w22 * w27) mod p = r */
+  bn.mov   w23, w27
+  jal      x1, fe_mul
 
   /* Use the candidate root to derive two possible square roots of x^2. From
      RFC 8032, section 5.1.3, step 3 (with the candidate root again shown as r
@@ -1020,6 +1008,8 @@ affine_decode_var:
 
        3.  Otherwise, no square root exists for modulo p, and decoding
            fails.
+           Note: In this constant-time implementation, case 3 (failure) is
+           handled branchlessly at the end by returning a FAILURE status code.
 
      Again the RFC doesn't really explain the mathematics here. Recall from the
      last step that:
@@ -1047,92 +1037,57 @@ affine_decode_var:
         w27 <= w22 = r */
   bn.mov   w27, w22
 
-  /* w22 <= (w22^2) mod p = (r^2) mod p */
-  jal      x1, fe_square
-  /* w22 <= (w22 * w25) mod p = (r^2 * v) mod p */
-  bn.mov   w23, w25
-  jal      x1, fe_mul
-
-  /* Check for case 1: (r^2 * v) mod p == u. */
-
-  /* x3 <= 8 */
-  addi     x3, x0, 8
-
-  /* FG0.Z <= (w22 - w26 == 0) = ((r^2 * v) mod p == u) */
-  bn.cmp   w22, w26
-  /* x2 <= FG0[3] = FG0.Z = ((r^2 * v) mod p == u) */
-  csrrs    x2, FG0, x0
-  and      x2, x2, x3
-
-  /* Go to step 3, case 1 if we are in case 1. */
-  beq      x2, x3, decode_step3_case1
-
-  /* Check for case 2: (r^2 * v) mod p == (- u) mod p */
-
-  /* w28 <= (w31 - w26) mod p = (0 - u) mod p */
-  bn.subm  w28, w31, w26
-
-  /* FG0.Z <= (w22 - w28 == 0) = ((r^2 * v) mod p == (-u) mod p) */
-  bn.cmp   w22, w28
-  /* x2 <= FG0[3] = FG0.Z = ((r^2 * v) mod p == (-u) mod p) */
-  csrrs    x2, FG0, x0
-  and      x2, x2, x3
-
-  /* Go to step 3, case 2 if we are in case 2. */
-  beq      x2, x3, decode_step3_case2
-
-  /* If we get here, then r^2 was not equal to either (u/v) or - (u/v), so we
-     are in case 3, (u/v) is nonsquare mod p, and point decoding fails. */
-  li       x20, 0x1d4
-  bn.mov   w10, w31
-  bn.mov   w11, w31
-  ret
-
-  decode_step3_case2:
-  /* Multiply r by sqrt(-1) = 2^((p-1)/4). */
-
-  /* w23 <= dmem[ed25519_sqrt_m1] = sqrt(-1) mod p */
+  /* Compute case 2 root: r_alt = r * sqrt(-1) mod p */
   la       x2, ed25519_sqrt_m1
   li       x3, 23
-  bn.lid   x3, 0(x2)
+  bn.lid   x3, 0(x2)           /* w23 <= sqrt(-1) */
+  jal      x1, fe_mul          /* w22 <= r * sqrt(-1) */
+  bn.mov   w14, w22            /* w14 <= r_alt */
 
-  /* w27 <= (w27 * w23) mod p = (r * sqrt(-1)) mod p */
+  /* Restore r to w22 to compute (r^2 * v) mod p */
   bn.mov   w22, w27
-  jal      x1, fe_mul
-  bn.mov   w27, w22
+  jal      x1, fe_square       /* w22 <= r^2 */
+  bn.mov   w23, w25            /* w23 <= v */
+  jal      x1, fe_mul          /* w22 <= (r^2 * v) mod p */
 
-  /* From here, r^2 = x^2 and we can proceed with the same steps as case 1. */
+  /* Pre-calculate -u */
+  bn.subm  w28, w31, w26       /* w28 <= (-u) mod p */
 
-  decode_step3_case1:
-  /* Once we're here, we know that r^2 = x^2, and therefore r is either x or
-     -x. Following RFC 8032, section 5.1.3, step 4, we set the resulting
-     point's x coordinate to r if lsb(x) from the encoded point matches lsb(r),
-     and set x to (-r) mod p otherwise.
+  /* Evaluate Case 1: (r^2 * v) mod p == u */
+  bn.cmp   w22, w26            /* FG0.Z is 1 if Case 1 is true */
+  csrrs    x5, FG0, x0
+  andi     x5, x5, 8           /* x5 = 8 if Case 1, else 0 */
 
-     Because we are following the ZIP15 validation criteria instead of the RFC,
-     we allow the case where x=0 but the encoded lsb(x)=1, so that check is
-     skipped here. In this case, we will decode x as (-0) mod p = 0.
+  /* Evaluate Case 2: (r^2 * v) mod p == -u */
+  bn.cmp   w22, w28            /* FG0.Z is 1 if Case 2 is true */
+  csrrs    x6, FG0, x0
+  andi     x6, x6, 8           /* x6 = 8 if Case 2, else 0 */
 
-     Code here expects:
-       w27: r such that r^2 = x^2 (mod p).
-       w31: all-zero
-  */
-
-  /* Compute (-r) mod p.
-       w10 <= (w31 - w27) mod p = (-r) mod p */
+  /* If the math failed, the calculations are bogus, nevertheless
+     we will return a FAILURE code. */
+  bn.sel   w27, w14, w27, FG0.Z
   bn.subm  w10, w31, w27
-
-  /* Set FG.L to be 1 iff the LSBs of r and x are mismatched.
-       FG0.L <= lsb(w24 ^ w27) = lsb(lsb(x) ^ r) = lsb(x) ^ lsb(r) = (lsb(x) != lsb(r)) */
   bn.xor   w24, w27, w24
-
-  /* If the LSBs are mismatched, select (-r) mod p; otherwise select r.
-       w10 <= FG0.L ? w10 : w27
-                = if (lsb(x) != lsb(r)) then (-r) mod p else r */
   bn.sel   w10, w10, w27, FG0.L
 
-  /* Exit point decoding with SUCCESS. */
-  li       x20, 0x739
+  /* Check math validity: x2 = 8 if math passed, 0 if math failed */
+  or       x2, x5, x6
+  srli     x2, x2, 3           /* x2 = 1 if math passed, 0 if failed */
+
+  /* Combine with the canonical check from the very beginning (x7) */
+  and      x2, x2, x7          /* x2 = 1 ONLY if both passed */
+
+  li       x20, 0x1d4          /* Base: FAILURE */
+  li       x5,  0x565          /* Difference between SUCCESS and FAILURE */
+
+  /* Create a bitmask (0xFFFFFFFF or 0x00000000) */
+  sub      x2, x0, x2
+
+  /* Apply the mask to the difference */
+  and      x5, x5, x2          /* x5 = 1381 if valid, 0 if invalid */
+
+  /* Add to the base failure code */
+  add      x20, x20, x5
 
   ret
 
@@ -1946,6 +1901,9 @@ x25519_mont_u_to_ed_y:
  * clobbered flag groups: FG0
  */
 x25519_ed_ext_to_mont_u_masked:
+  /* Initialize error accumulator in x4 */
+  add      x4, x0, x0
+
   /* W = (Z - Y) mod p */
   bn.subm  w23, w12, w11
 
@@ -1957,10 +1915,9 @@ x25519_ed_ext_to_mont_u_masked:
   bn.cmp   w24, w31
   csrrs    x2, FG0, x0
   andi     x2, x2, 8      /* Extract the Z flag (bit 3) from FG0 */
-  addi     x3, x0, 8
 
-  /* If the Z flag is set (U = 0). Jump to end and return failure flag. */
-  beq      x2, x3, .L_invalid_mapping
+  /* Accumulate U=0 error locally */
+  or       x4, x4, x2
 
   /* Fetch random mask r and reduce it modulo p. */
   bn.wsrr  w25, URND
@@ -1975,12 +1932,13 @@ x25519_ed_ext_to_mont_u_masked:
 
   bn.mov   w16, w23
 
+  /* Check if W == 0 mod p */
   bn.cmp   w16, w31
-  csrrs    x2, FG0, x0
-  andi     x2, x2, 8
-  addi     x3, x0, 8
-  /* Reject if we have the identity point (W = 0). */
-  beq      x2, x3, .L_invalid_mapping
+  csrrs    x3, FG0, x0
+  andi     x3, x3, 8      /* Extract the Z flag */
+
+  /* Accumulate W=0 error locally */
+  or       x4, x4, x3
 
   /* Compute W^-1 mod p. */
   jal      x1, fe_inv
@@ -1992,7 +1950,9 @@ x25519_ed_ext_to_mont_u_masked:
   /* Output mask 'r' in w19. */
   bn.mov   w19, w25
 
-.L_invalid_mapping:
+  /* Move the error accumulator into x2 */
+  add      x2, x4, x0
+
   ret
 
 /**
@@ -2082,6 +2042,9 @@ x25519:
   bn.xor   w31, w31, w31
   bn.addi  w30, w31, 38
 
+  /* Initialize global error accumulator */
+  add      x26, x0, x0
+
   /* Mask MSB of u and reduce modulo p */
   bn.not   w7, w31
   bn.rshi  w7, w31, w7 >> 1
@@ -2090,7 +2053,7 @@ x25519:
 
   /* Reject u = p-1 before the Montgomery-to-Edwards conversion. */
   jal      x1, x25519_check_denominator
-  bne      x2, x0, .L_x25519_fail
+  or       x26, x26, x2     /* Accumulate error */
 
   /* Convert Montgomery u to Edwards y */
   jal      x1, x25519_mont_u_to_ed_y
@@ -2105,9 +2068,10 @@ x25519:
      points, so affine_decode_var will fail for them. */
   jal      x1, affine_decode_var
 
-  /* Fail if the point was not on the Ed25519 curve (i.e. points on twisted curve). */
+  /* Check if the point was on the Ed25519 curve (i.e. points on twisted curve). */
   li       x21, 0x739
-  bne      x20, x21, .L_x25519_fail
+  sub      x5, x20, x21     /* x5 = 0 if success, != 0 if fail */
+  or       x26, x26, x5     /* Accumulate error */
 
   /* Convert affine (x, y) to extended (X, Y, Z, T) */
   bn.mov   w6, w10
@@ -2123,23 +2087,41 @@ x25519:
 
   /* Verify the resulting projective point is a valid curve point */
   jal      x1, ed25519_isoncurve_ext
-  jal      x1, trigger_fault_if_fg0_not_z
+
+  /* Accumulate curve check error (x2 = 0 on curve, 8 off curve) */
+  csrrs    x2, FG0, x0
+  andi     x2, x2, 8
+  xori     x2, x2, 8
+  or       x26, x26, x2
 
   /* Map Ed25519 extended projective back to masked Curve25519 Montgomery u */
   jal      x1, x25519_ed_ext_to_mont_u_masked
+  or       x26, x26, x2     /* Accumulate the returned error from x2 */
 
-  /* If x2 is not 0 (it is 8), U was 0, meaning an invalid mapping. Jump to failure. */
-  bne      x2, x0, .L_x25519_fail
+  /* Calculate return mask: 0xFFFFFFFF if SUCCESS, 0x00000000 if ERROR */
+  sub      x27, x0, x26     /* x27 = -x26 */
+  or       x27, x27, x26    /* x27 = -x26 | x26. MSB is 1 if x26 != 0 */
+  srai     x27, x27, 31     /* x27 = (x26 != 0) ? 0xFFFFFFFF : 0x00000000 */
+  xori     x27, x27, -1     /* x27 = (x26 != 0) ? 0x00000000 : 0xFFFFFFFF */
 
-  /* Signal success to caller via x20. */
-  li       x20, 0x739
+  /* Load DIFF and FAILURE */
+  li       x20, 0x1d4       /* FAILURE */
+  li       x28, 0x6ED       /* XOR difference */
 
-  ret
+  /* Apply the difference ONLY if the mask says success */
+  and      x28, x28, x27    /* x28 = DIFF if success, 0 if error */
+  xor      x20, x20, x28    /* x20 = SUCCESS if success, FAILURE if error */
 
-.L_x25519_fail:
-  /* If point decoding fails, return 0 in w22 and signal failure via x20. */
-  bn.xor   w22, w22, w22
-  li       x20, 0x1d4
+  /* Fetch 256 bits of true randomness into a scratch register (w28) */
+  bn.wsrr  w28, URND
+
+  /* Map the success mask into a flag. */
+  andi     x29, x27, 8
+  csrrw    x0, FG0, x29
+
+  /* Shred the output if there was an error. */
+  bn.sel   w22, w22, w28, FG0.Z
+
   ret
 
 .bss

--- a/sw/otbn/crypto/tests/BUILD
+++ b/sw/otbn/crypto/tests/BUILD
@@ -1123,6 +1123,10 @@ otbn_sim_test(
 
 otbn_consttime_test(
     name = "x25519_consttime",
+    ignore = [
+        "trigger_fault_if_fg0_z",
+        "trigger_fault_if_fg0_not_z",
+    ],
     secrets = [
         "w8",
     ],
@@ -1143,6 +1147,7 @@ test_suite(
         ":ed25519_sc_reduce_test",
         ":ed25519_sign_test",
         ":ed25519_verify_test",
+        ":ed25519_ext_is_on_curve_test",
 
         # X25519,
         ":x25519_test",

--- a/sw/otbn/crypto/tests/ed25519_ext_is_on_curve_test.hjson
+++ b/sw/otbn/crypto/tests/ed25519_ext_is_on_curve_test.hjson
@@ -6,18 +6,23 @@
   "entrypoint": "main",
   "input": {
     "dmem": {
-      // A random curve point.
-      "_ed25519_ext_is_on_curve_x_pos": "0x55d0e09a2b9d34292297e08d60d0f620c513d47253187c24b12786bd777645ce",
-      "_ed25519_ext_is_on_curve_y_pos": "0x1a5107f7681a02af2523a6daf372e10e3a0764c9d3fe4bd5b70ab18201985ad7",
-      // Random coordinates not on the curve.
+      // The Ed25519 Base Point in Extended Coordinates
+      "_ed25519_ext_is_on_curve_x_pos": "0x216936d3cd6e53fec0a4e231fdd6dc5c692cc7609525a7b2c9562d608f25d51a",
+      "_ed25519_ext_is_on_curve_y_pos": "0x6666666666666666666666666666666666666666666666666666666666666658",
+      "_ed25519_ext_is_on_curve_z_pos": "0x0000000000000000000000000000000000000000000000000000000000000001",
+      "_ed25519_ext_is_on_curve_t_pos": "0x67875f0fd78b766566ea4e8e64abe37d20f09f80775152f56dde8ab3a5b7dda3",
+
+      // Random coordinates not on the curve
       "_ed25519_ext_is_on_curve_x_neg": "0x17e68428af426ff150575ffda8f0e9358b4913e46b1b393bb0e45096a7fa2a18",
       "_ed25519_ext_is_on_curve_y_neg": "0x77b757982c0973c3dcba33b71f31dea4e5413b29a560b409767712cc0cb6399c",
+      "_ed25519_ext_is_on_curve_z_neg": "0x0000000000000000000000000000000000000000000000000000000000000001",
+      "_ed25519_ext_is_on_curve_t_neg": "0x0000000000000000000000000000000000000000000000000000000000000001"
     }
   },
   "output": {
     "dmem": {
       "_ed25519_ext_is_on_curve_res_pos": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "_ed25519_ext_is_on_curve_res_neg": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "_ed25519_ext_is_on_curve_res_neg": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     }
   }
 }

--- a/sw/otbn/crypto/tests/ed25519_ext_is_on_curve_test.s
+++ b/sw/otbn/crypto/tests/ed25519_ext_is_on_curve_test.s
@@ -22,10 +22,12 @@ main:
 
   li x2, 10
   la x3, _ed25519_ext_is_on_curve_x_pos
-  bn.lid x2++, 0(x3)
-  bn.lid x2++, 32(x3)
+  bn.lid x2++, 0(x3)   /* w10 = X */
+  bn.lid x2++, 32(x3)  /* w11 = Y */
+  bn.lid x2++, 64(x3)  /* w12 = Z */
+  bn.lid x2++, 96(x3)  /* w13 = T */
 
-  jal x1, ext_is_on_curve
+  jal x1, ed25519_isoncurve_ext
 
   bn.sel w0, w1, w31, FG0.Z
   la x3, _ed25519_ext_is_on_curve_res_pos
@@ -37,10 +39,12 @@ main:
 
   li x2, 10
   la x3, _ed25519_ext_is_on_curve_x_neg
-  bn.lid x2++, 0(x3)
-  bn.lid x2++, 32(x3)
+  bn.lid x2++, 0(x3)   /* w10 = X */
+  bn.lid x2++, 32(x3)  /* w11 = Y */
+  bn.lid x2++, 64(x3)  /* w12 = Z */
+  bn.lid x2++, 96(x3)  /* w13 = T */
 
-  jal x1, ext_is_on_curve
+  jal x1, ed25519_isoncurve_ext
 
   bn.sel w0, w31, w1, FG0.Z
   la x3, _ed25519_ext_is_on_curve_res_neg
@@ -55,10 +59,18 @@ _ed25519_ext_is_on_curve_x_pos:
 .zero 32
 _ed25519_ext_is_on_curve_y_pos:
 .zero 32
+_ed25519_ext_is_on_curve_z_pos:
+.zero 32
+_ed25519_ext_is_on_curve_t_pos:
+.zero 32
 
 _ed25519_ext_is_on_curve_x_neg:
 .zero 32
 _ed25519_ext_is_on_curve_y_neg:
+.zero 32
+_ed25519_ext_is_on_curve_z_neg:
+.zero 32
+_ed25519_ext_is_on_curve_t_neg:
 .zero 32
 
 _ed25519_ext_is_on_curve_res_pos:


### PR DESCRIPTION
- Change the on curve to projective coordinates and add it after the x25519 for FI protection
- Add instruction count checking (and make affine_encode constant time to make this possible)
- Wipe DMEM always after x25519 final