### PR TITLE
[crypto] Add self-integrity check to init

### DIFF
--- a/sw/device/lib/crypto/impl/config.c
+++ b/sw/device/lib/crypto/impl/config.c
@@ -78,6 +78,10 @@ otcrypto_status_t otcrypto_init(otcrypto_key_security_level_t security_level) {
   // Instantiate the RNG.
   HARDENED_TRY(otcrypto_entropy_init());
 
+#ifdef HASH_SELF_CHECK_ENABLE
+  HARDENED_TRY(otcrypto_integrity_check());
+#endif
+
   return OTCRYPTO_OK;
 }
 

--- a/sw/device/tests/crypto/otcrypto_hash_test.c
+++ b/sw/device/tests/crypto/otcrypto_hash_test.c
@@ -63,18 +63,6 @@ bool test_main(void) {
   status_t result = OK_STATUS();
   CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
 
-#ifdef HASH_SELF_CHECK_ENABLE
-  otcrypto_status_t check_status = otcrypto_integrity_check();
-
-  if (!status_ok(check_status)) {
-    LOG_ERROR("FIPS Library integrity check failed! Code: 0x%08x",
-              check_status.value);
-    return false;
-  }
-
-  LOG_INFO("Self-integrity check passed.");
-#endif
-
   result = hash_test();
   return status_ok(result);
 }


### PR DESCRIPTION
Add the FIPS self-integrity check of the cryptolib to the otcrypto_init when the library is compiled with HASH_SELF_CHECK_ENABLE (such as with --config=crypto_fips_all).
Remove the self-integrity test in the hash test since it is called in the init now.