### PR TITLE
[dv] Split reactive agents from dv_base_agent

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent.sv
@@ -5,9 +5,9 @@
 // ---------------------------------------------
 // Alert agent
 // ---------------------------------------------
-class alert_esc_agent extends dv_base_agent#(
+class alert_esc_agent extends dv_reactive_agent #(
     .CFG_T           (alert_esc_agent_cfg),
-    .DRIVER_T        (dv_base_driver#(alert_esc_seq_item, alert_esc_agent_cfg)),
+    .DRIVER_T        (dv_base_driver #(alert_esc_seq_item, alert_esc_agent_cfg)),
     .SEQUENCER_T     (alert_esc_sequencer),
     .MONITOR_T       (alert_esc_base_monitor),
     .COV_T           (alert_esc_agent_cov)

--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
@@ -6,7 +6,7 @@
 // ---------------------------------------------
 // Configuration class for Alert agent
 // ---------------------------------------------
-class alert_esc_agent_cfg extends dv_base_agent_cfg;
+class alert_esc_agent_cfg extends dv_reactive_agent_cfg;
   virtual alert_esc_if vif;
   virtual alert_esc_probe_if probe_vif;
   bit is_alert        = 1;

--- a/hw/dv/sv/alert_esc_agent/alert_esc_base_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_base_monitor.sv
@@ -5,7 +5,7 @@
 
 // A base class for monitors that track alert/escalation items and watch an alert_esc_if.
 
-class alert_esc_base_monitor extends dv_base_monitor #(
+class alert_esc_base_monitor extends dv_reactive_monitor #(
   .ITEM_T(alert_esc_seq_item),
   .CFG_T (alert_esc_agent_cfg),
   .COV_T (alert_esc_agent_cov)

--- a/hw/dv/sv/alert_esc_agent/alert_esc_sequencer.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_sequencer.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class alert_esc_sequencer extends dv_base_sequencer#(alert_esc_seq_item, alert_esc_agent_cfg);
+class alert_esc_sequencer extends dv_reactive_sequencer #(alert_esc_seq_item, alert_esc_agent_cfg);
   `uvm_component_utils(alert_esc_sequencer)
 
   extern function new (string name, uvm_component parent);

--- a/hw/dv/sv/csrng_agent/csrng_agent.sv
+++ b/hw/dv/sv/csrng_agent/csrng_agent.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class csrng_agent extends dv_base_agent #(
+class csrng_agent extends dv_reactive_agent #(
   .CFG_T          (csrng_agent_cfg),
   .DRIVER_T       (csrng_driver),
   .HOST_DRIVER_T  (csrng_host_driver),

--- a/hw/dv/sv/csrng_agent/csrng_agent_cfg.sv
+++ b/hw/dv/sv/csrng_agent/csrng_agent_cfg.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class csrng_agent_cfg extends dv_base_agent_cfg;
+class csrng_agent_cfg extends dv_reactive_agent_cfg;
 
   // interface handle used by driver, monitor & the sequencer, via cfg handle
   virtual csrng_if vif;

--- a/hw/dv/sv/csrng_agent/csrng_monitor.sv
+++ b/hw/dv/sv/csrng_agent/csrng_monitor.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class csrng_monitor extends dv_base_monitor #(
+class csrng_monitor extends dv_reactive_monitor #(
     .ITEM_T (csrng_item),
     .CFG_T  (csrng_agent_cfg),
     .COV_T  (csrng_agent_cov)

--- a/hw/dv/sv/csrng_agent/csrng_sequencer.sv
+++ b/hw/dv/sv/csrng_agent/csrng_sequencer.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class csrng_sequencer extends dv_base_sequencer #(
+class csrng_sequencer extends dv_reactive_sequencer #(
     .ITEM_T (csrng_item),
     .CFG_T  (csrng_agent_cfg)
 );

--- a/hw/dv/sv/dv_base_agent/dv_base_agent.core
+++ b/hw/dv/sv/dv_base_agent/dv_base_agent.core
@@ -19,6 +19,11 @@ filesets:
       - dv_base_driver.sv: {is_include_file: true}
       - dv_base_agent.sv: {is_include_file: true}
       - dv_base_seq.sv: {is_include_file: true}
+
+      - dv_reactive_agent_cfg.sv: {is_include_file: true}
+      - dv_reactive_monitor.sv: {is_include_file: true}
+      - dv_reactive_sequencer.sv: {is_include_file: true}
+      - dv_reactive_agent.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/dv/sv/dv_base_agent/dv_base_agent.sv
+++ b/hw/dv/sv/dv_base_agent/dv_base_agent.sv
@@ -83,10 +83,4 @@ function void dv_base_agent::connect_phase(uvm_phase phase);
   if (cfg.is_active && cfg.has_driver) begin
     driver.seq_item_port.connect(sequencer.seq_item_export);
   end
-  if (cfg.has_req_fifo) begin
-    monitor.req_analysis_port.connect(sequencer.req_analysis_fifo.analysis_export);
-  end
-  if (cfg.has_rsp_fifo) begin
-    monitor.rsp_analysis_port.connect(sequencer.rsp_analysis_fifo.analysis_export);
-  end
 endfunction

--- a/hw/dv/sv/dv_base_agent/dv_base_agent_cfg.sv
+++ b/hw/dv/sv/dv_base_agent/dv_base_agent_cfg.sv
@@ -26,14 +26,6 @@ class dv_base_agent_cfg extends uvm_object;
   // false, the agent can work by connecting to some lower-level agent to send multiple items.
   bit has_driver = 1'b1;
 
-  // True if agent's sequencer has a request fifo. If so, the agent will connect its monitor's
-  // req_analysis_port to the sequencer's request fifo.
-  bit has_req_fifo = 1'b0;
-
-  // True if agent's sequencer has a response fifo. If so, the agent will connect its monitor's
-  // req_analysis_port to the sequencer's response fifo.
-  bit has_rsp_fifo = 1'b0;
-
   // The minimum time in ns that the monitor expects to see ok_to_end be high before it drops an
   // objection that stopped the run_phase ending.
   int ok_to_end_delay_ns = 1000;
@@ -49,8 +41,6 @@ class dv_base_agent_cfg extends uvm_object;
     `uvm_field_int (en_cov,               UVM_DEFAULT)
     `uvm_field_enum(if_mode_e, if_mode,   UVM_DEFAULT)
     `uvm_field_int (has_driver,           UVM_DEFAULT)
-    `uvm_field_int (has_req_fifo,         UVM_DEFAULT)
-    `uvm_field_int (has_rsp_fifo,         UVM_DEFAULT)
     `uvm_field_int (ok_to_end_delay_ns,   UVM_DEFAULT)
     `uvm_field_int (in_reset,             UVM_DEFAULT)
   `uvm_object_utils_end

--- a/hw/dv/sv/dv_base_agent/dv_base_agent_pkg.sv
+++ b/hw/dv/sv/dv_base_agent/dv_base_agent_pkg.sv
@@ -22,6 +22,11 @@ package dv_base_agent_pkg;
   `include "dv_base_driver.sv"
   `include "dv_base_agent.sv"
 
+  `include "dv_reactive_agent_cfg.sv"
+  `include "dv_reactive_monitor.sv"
+  `include "dv_reactive_sequencer.sv"
+  `include "dv_reactive_agent.sv"
+
   // base seq
   `include "dv_base_seq.sv"
 

--- a/hw/dv/sv/dv_base_agent/dv_base_monitor.sv
+++ b/hw/dv/sv/dv_base_agent/dv_base_monitor.sv
@@ -3,11 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class dv_base_monitor #(type ITEM_T = uvm_sequence_item,
-                        type REQ_ITEM_T = ITEM_T,
-                        type RSP_ITEM_T = ITEM_T,
                         type CFG_T  = dv_base_agent_cfg,
                         type COV_T  = dv_base_agent_cov) extends uvm_monitor;
-  `uvm_component_param_utils(dv_base_monitor #(ITEM_T, REQ_ITEM_T, RSP_ITEM_T, CFG_T, COV_T))
+  `uvm_component_param_utils(dv_base_monitor #(ITEM_T, CFG_T, COV_T))
 
   CFG_T cfg;
   COV_T cov;
@@ -22,18 +20,11 @@ class dv_base_monitor #(type ITEM_T = uvm_sequence_item,
   // Analysis port for the collected transfer.
   uvm_analysis_port #(ITEM_T) analysis_port;
 
-  // item will be sent to this port for seq when req phase is done (last is set)
-  uvm_analysis_port #(REQ_ITEM_T) req_analysis_port;
-  // item will be sent to this port for seq when rsp phase is done (rsp_done is set)
-  uvm_analysis_port #(RSP_ITEM_T) rsp_analysis_port;
-
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     analysis_port = new("analysis_port", this);
-    req_analysis_port = new("req_analysis_port", this);
-    rsp_analysis_port = new("rsp_analysis_port", this);
   endfunction
 
   virtual task run_phase(uvm_phase phase);

--- a/hw/dv/sv/dv_base_agent/dv_base_sequencer.sv
+++ b/hw/dv/sv/dv_base_agent/dv_base_sequencer.sv
@@ -10,28 +10,9 @@ class dv_base_sequencer #(type ITEM_T     = uvm_sequence_item,
   `uvm_component_param_utils(dv_base_sequencer #(.ITEM_T     (ITEM_T),
                                                  .CFG_T      (CFG_T),
                                                  .RSP_ITEM_T (RSP_ITEM_T)))
-
-  // These FIFOs collect items when req/rsp is received, which are used to communicate between
-  // monitor and sequences. These FIFOs are optional
-  // When device is re-active, it gets items from req_analysis_fifo and send rsp to driver
-  // When this is a high-level agent, monitors put items to these 2 FIFOs for high-level seq
-  uvm_tlm_analysis_fifo #(ITEM_T)     req_analysis_fifo;
-  uvm_tlm_analysis_fifo #(RSP_ITEM_T) rsp_analysis_fifo;
-
   CFG_T cfg;
 
-  `uvm_component_new
-
-  function void build_phase(uvm_phase phase);
-    super.build_phase(phase);
-
-    // Avoid null pointer if the cfg is not defined.
-    if (cfg == null) begin
-      `uvm_fatal(`gfn, "cfg handle is null.")
-    end else begin
-      if (cfg.has_req_fifo) req_analysis_fifo = new("req_analysis_fifo", this);
-      if (cfg.has_rsp_fifo) rsp_analysis_fifo = new("rsp_analysis_fifo", this);
-    end
-  endfunction : build_phase
-
+  function new(string name, uvm_component parent);
+    super.new(name, parent);
+  endfunction
 endclass

--- a/hw/dv/sv/dv_base_agent/dv_reactive_agent.sv
+++ b/hw/dv/sv/dv_base_agent/dv_reactive_agent.sv
@@ -1,0 +1,59 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// An extension of the base agent class that connects the monitor to the sequencer in order to allow
+// the agent to run sequences that react to items collected by the monitor.
+//
+//   CFG_T:          The type of the configuration object. This should be a subclass of
+//                   dv_reactive_agent_cfg
+//
+//   DRIVER_T:       The type of the driver. This should be a subclass of dv_base_driver.
+//
+//   HOST_DRIVER_T   The type of the driver when the agent configured with if_mode set to Host. This
+//                   should be a subclass of DRIVER_T.
+//
+//   DEVICE_DRIVER_T The type of the driver when the agent configured with if_mode set to Device.
+//                   This should be a subclass of DRIVER_T.
+//
+//   SEQUENCER_T     The type of the sequencer. This should be a subclass of dv_reactive_sequencer.
+//
+//   MONITOR_T       The type of the monitor. This should be a subclass of dv_reactive_monitor.
+//
+//   COV_T           The type of the object that monitors coverage. This should be a subclass of
+//                   dv_base_agent_cov.
+
+class dv_reactive_agent #(type CFG_T            = dv_reactive_agent_cfg,
+                          type DRIVER_T         = dv_base_driver,
+                          type HOST_DRIVER_T    = DRIVER_T,
+                          type DEVICE_DRIVER_T  = DRIVER_T,
+                          type SEQUENCER_T      = dv_reactive_sequencer,
+                          type MONITOR_T        = dv_reactive_monitor,
+                          type COV_T            = dv_base_agent_cov)
+  extends dv_base_agent #(.CFG_T(CFG_T),
+                          .DRIVER_T(DRIVER_T),
+                          .HOST_DRIVER_T(HOST_DRIVER_T), .DEVICE_DRIVER_T(DEVICE_DRIVER_T),
+                          .SEQUENCER_T(SEQUENCER_T),
+                          .MONITOR_T(MONITOR_T),
+                          .COV_T(COV_T));
+
+  `uvm_component_param_utils(dv_reactive_agent #(CFG_T, DRIVER_T, HOST_DRIVER_T, DEVICE_DRIVER_T,
+                                                 SEQUENCER_T, MONITOR_T, COV_T))
+
+  extern function new (string name, uvm_component parent);
+  extern function void connect_phase(uvm_phase phase);
+endclass
+
+function dv_reactive_agent::new (string name, uvm_component parent);
+  super.new(name, parent);
+endfunction
+
+function void dv_reactive_agent::connect_phase(uvm_phase phase);
+  super.connect_phase(phase);
+  if (cfg.has_req_fifo) begin
+    monitor.req_analysis_port.connect(sequencer.req_analysis_fifo.analysis_export);
+  end
+  if (cfg.has_rsp_fifo) begin
+    monitor.rsp_analysis_port.connect(sequencer.rsp_analysis_fifo.analysis_export);
+  end
+endfunction

--- a/hw/dv/sv/dv_base_agent/dv_reactive_agent_cfg.sv
+++ b/hw/dv/sv/dv_base_agent/dv_reactive_agent_cfg.sv
@@ -1,0 +1,27 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// The base config object for a reactive agent
+
+class dv_reactive_agent_cfg extends dv_base_agent_cfg;
+
+  // True if agent's sequencer has a request fifo. If so, the agent will connect its monitor's
+  // req_analysis_port to the sequencer's request fifo.
+  bit has_req_fifo = 1'b0;
+
+  // True if agent's sequencer has a response fifo. If so, the agent will connect its monitor's
+  // req_analysis_port to the sequencer's response fifo.
+  bit has_rsp_fifo = 1'b0;
+
+  `uvm_object_utils_begin(dv_reactive_agent_cfg)
+    `uvm_field_int (has_req_fifo, UVM_DEFAULT)
+    `uvm_field_int (has_rsp_fifo, UVM_DEFAULT)
+  `uvm_object_utils_end
+
+  extern function new (string name="");
+endclass
+
+function dv_reactive_agent_cfg::new (string name="");
+  super.new(name);
+endfunction

--- a/hw/dv/sv/dv_base_agent/dv_reactive_monitor.sv
+++ b/hw/dv/sv/dv_base_agent/dv_reactive_monitor.sv
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class dv_reactive_monitor #(type ITEM_T = uvm_sequence_item,
+                            type REQ_ITEM_T = ITEM_T,
+                            type RSP_ITEM_T = ITEM_T,
+                            type CFG_T = dv_base_agent_cfg,
+                            type COV_T = dv_base_agent_cov)
+  extends dv_base_monitor #(.ITEM_T(ITEM_T), .CFG_T(CFG_T), .COV_T(COV_T));
+
+  `uvm_component_param_utils(dv_reactive_monitor #(ITEM_T, REQ_ITEM_T, RSP_ITEM_T, CFG_T, COV_T))
+
+  // item will be sent to this port for seq when req phase is done (last is set)
+  uvm_analysis_port #(REQ_ITEM_T) req_analysis_port;
+  // item will be sent to this port for seq when rsp phase is done (rsp_done is set)
+  uvm_analysis_port #(RSP_ITEM_T) rsp_analysis_port;
+
+  extern function new (string name, uvm_component parent);
+  extern function void build_phase(uvm_phase phase);
+endclass
+
+function dv_reactive_monitor::new (string name, uvm_component parent);
+  super.new(name, parent);
+endfunction
+
+function void dv_reactive_monitor::build_phase(uvm_phase phase);
+  super.build_phase(phase);
+  req_analysis_port = new("req_analysis_port", this);
+  rsp_analysis_port = new("rsp_analysis_port", this);
+endfunction

--- a/hw/dv/sv/dv_base_agent/dv_reactive_sequencer.sv
+++ b/hw/dv/sv/dv_base_agent/dv_reactive_sequencer.sv
@@ -1,0 +1,38 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class dv_reactive_sequencer #(type ITEM_T     = uvm_sequence_item,
+                              type CFG_T      = dv_reactive_agent_cfg,
+                              type RSP_ITEM_T = ITEM_T)
+  extends dv_base_sequencer #(.ITEM_T(ITEM_T), .CFG_T(CFG_T), .RSP_ITEM_T(RSP_ITEM_T));
+
+  `uvm_component_param_utils(dv_reactive_sequencer #(.ITEM_T     (ITEM_T),
+                                                     .CFG_T      (CFG_T),
+                                                     .RSP_ITEM_T (RSP_ITEM_T)))
+
+  // These FIFOs collect items when req/rsp is received, which are used to communicate between
+  // monitor and sequences. These FIFOs are only created if has_req_fifo / has_rsp_fifo is true in
+  // the agent config.
+  //
+  // When device is reactive, it gets items from req_analysis_fifo and send rsp to driver When this
+  // is a high-level agent, monitors put items to these 2 FIFOs for high-level seq
+  uvm_tlm_analysis_fifo #(ITEM_T)     req_analysis_fifo;
+  uvm_tlm_analysis_fifo #(RSP_ITEM_T) rsp_analysis_fifo;
+
+  extern function new(string name, uvm_component parent);
+  extern function void build_phase(uvm_phase phase);
+endclass
+
+function dv_reactive_sequencer::new(string name, uvm_component parent);
+  super.new(name, parent);
+endfunction
+
+function void dv_reactive_sequencer::build_phase(uvm_phase phase);
+  super.build_phase(phase);
+
+  if (cfg == null) `uvm_fatal(get_full_name(), "agent cfg not provided.")
+
+  if (cfg.has_req_fifo) req_analysis_fifo = new("req_analysis_fifo", this);
+  if (cfg.has_rsp_fifo) rsp_analysis_fifo = new("rsp_analysis_fifo", this);
+endfunction

--- a/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_agent.sv
+++ b/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_agent.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class entropy_src_xht_agent extends dv_base_agent #(
+class entropy_src_xht_agent extends dv_reactive_agent #(
   .CFG_T       (entropy_src_xht_agent_cfg),
   .DRIVER_T    (entropy_src_xht_device_driver),
   .SEQUENCER_T (entropy_src_xht_sequencer),

--- a/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_agent_cfg.sv
+++ b/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_agent_cfg.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class entropy_src_xht_agent_cfg extends dv_base_agent_cfg;
+class entropy_src_xht_agent_cfg extends dv_reactive_agent_cfg;
 
   virtual entropy_src_xht_if vif;
 

--- a/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_monitor.sv
+++ b/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_monitor.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class entropy_src_xht_monitor extends dv_base_monitor #(
+class entropy_src_xht_monitor extends dv_reactive_monitor #(
   .ITEM_T (entropy_src_xht_item),
   .CFG_T  (entropy_src_xht_agent_cfg),
   .COV_T  (dv_base_agent_cov#(entropy_src_xht_agent_cfg))

--- a/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_sequencer.sv
+++ b/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_sequencer.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class entropy_src_xht_sequencer extends dv_base_sequencer #(
+class entropy_src_xht_sequencer extends dv_reactive_sequencer #(
     .ITEM_T (entropy_src_xht_item),
     .CFG_T  (entropy_src_xht_agent_cfg)
 );

--- a/hw/dv/sv/jtag_dmi_agent/jtag_dmi_monitor.sv
+++ b/hw/dv/sv/jtag_dmi_agent/jtag_dmi_monitor.sv
@@ -7,7 +7,7 @@
 // Unlike the name suggests, this monitor does not actually monitor the DMI interface
 // directly, but indirectly by snooping the reads and writes to the DTM DMI register.
 // TODO: In future, it may be better to rename this to jtag_dmi_csr_monitor.
-class jtag_dmi_monitor #(type ITEM_T = jtag_dmi_item) extends dv_base_monitor#(
+class jtag_dmi_monitor #(type ITEM_T = jtag_dmi_item) extends dv_reactive_monitor #(
     .ITEM_T (ITEM_T),
     .CFG_T  (jtag_agent_cfg));
   `uvm_component_param_utils(jtag_dmi_monitor #(ITEM_T))

--- a/hw/dv/sv/jtag_dmi_agent/sba_access_monitor.sv
+++ b/hw/dv/sv/jtag_dmi_agent/sba_access_monitor.sv
@@ -13,7 +13,7 @@
 // higher level testbench components to process.
 //
 // Reads and writes made to non SBA registers are passed on through non_sba_jtag_dmi_analysis_port.
-class sba_access_monitor #(type ITEM_T = sba_access_item) extends dv_base_monitor#(
+class sba_access_monitor #(type ITEM_T = sba_access_item) extends dv_reactive_monitor #(
     .ITEM_T (ITEM_T),
     .CFG_T  (jtag_agent_cfg));
   `uvm_component_param_utils(sba_access_monitor #(ITEM_T))

--- a/hw/dv/sv/kmac_app_agent/kmac_app_agent.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_agent.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class kmac_app_agent extends dv_base_agent #(
+class kmac_app_agent extends dv_reactive_agent #(
   .CFG_T          (kmac_app_agent_cfg),
   .DRIVER_T       (kmac_app_driver),
   .HOST_DRIVER_T  (kmac_app_host_driver),

--- a/hw/dv/sv/kmac_app_agent/kmac_app_agent_cfg.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_agent_cfg.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class kmac_app_agent_cfg extends dv_base_agent_cfg;
+class kmac_app_agent_cfg extends dv_reactive_agent_cfg;
 
   // interface handle used by driver, monitor & the sequencer, via cfg handle
   virtual kmac_app_intf vif;

--- a/hw/dv/sv/kmac_app_agent/kmac_app_monitor.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_monitor.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class kmac_app_monitor extends dv_base_monitor #(
+class kmac_app_monitor extends dv_reactive_monitor #(
     .ITEM_T (kmac_app_item),
     .CFG_T  (kmac_app_agent_cfg),
     .COV_T  (kmac_app_agent_cov)

--- a/hw/dv/sv/kmac_app_agent/kmac_app_sequencer.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_sequencer.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class kmac_app_sequencer extends dv_base_sequencer #(
+class kmac_app_sequencer extends dv_reactive_sequencer #(
     .ITEM_T (kmac_app_item),
     .CFG_T  (kmac_app_agent_cfg)
 );

--- a/hw/dv/sv/push_pull_agent/push_pull_agent.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_agent.sv
@@ -5,7 +5,7 @@
 class push_pull_agent #(
     parameter int HostDataWidth   = 32,
     parameter int DeviceDataWidth = HostDataWidth
-) extends dv_base_agent #(
+) extends dv_reactive_agent #(
     .CFG_T      (push_pull_agent_cfg#(HostDataWidth, DeviceDataWidth)),
     .DRIVER_T   (push_pull_driver#(HostDataWidth, DeviceDataWidth)),
     .SEQUENCER_T(push_pull_sequencer#(HostDataWidth, DeviceDataWidth)),

--- a/hw/dv/sv/push_pull_agent/push_pull_agent_cfg.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_agent_cfg.sv
@@ -4,7 +4,7 @@
 
 class push_pull_agent_cfg #(parameter int HostDataWidth = 32,
                             parameter int DeviceDataWidth = HostDataWidth)
-  extends dv_base_agent_cfg;
+  extends dv_reactive_agent_cfg;
 
   // interface handle used by driver, monitor & the sequencer, via cfg handle
   virtual push_pull_if#(HostDataWidth, DeviceDataWidth) vif;

--- a/hw/dv/sv/push_pull_agent/push_pull_monitor.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_monitor.sv
@@ -4,7 +4,7 @@
 
 class push_pull_monitor #(parameter int HostDataWidth = 32,
                           parameter int DeviceDataWidth = HostDataWidth)
-  extends dv_base_monitor #(
+  extends dv_reactive_monitor #(
     .ITEM_T (push_pull_item#(HostDataWidth, DeviceDataWidth)),
     .CFG_T  (push_pull_agent_cfg#(HostDataWidth, DeviceDataWidth)),
     .COV_T  (push_pull_agent_cov#(HostDataWidth, DeviceDataWidth))

--- a/hw/dv/sv/push_pull_agent/push_pull_sequencer.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_sequencer.sv
@@ -4,7 +4,7 @@
 
 class push_pull_sequencer #(parameter int HostDataWidth = 32,
                             parameter int DeviceDataWidth = HostDataWidth)
-  extends dv_base_sequencer #(
+  extends dv_reactive_sequencer #(
     .ITEM_T (push_pull_item#(HostDataWidth, DeviceDataWidth)),
     .CFG_T  (push_pull_agent_cfg#(HostDataWidth, DeviceDataWidth))
 );

--- a/hw/dv/sv/spi_agent/spi_agent.sv
+++ b/hw/dv/sv/spi_agent/spi_agent.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class spi_agent extends dv_base_agent#(
+class spi_agent extends dv_reactive_agent #(
     .CFG_T          (spi_agent_cfg),
     .DRIVER_T       (spi_driver),
     .HOST_DRIVER_T  (spi_host_driver),

--- a/hw/dv/sv/spi_agent/spi_agent_cfg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_cfg.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class spi_agent_cfg extends dv_base_agent_cfg;
+class spi_agent_cfg extends dv_reactive_agent_cfg;
 
   // enable monitor collection and checker
   bit en_monitor = 1'b1;

--- a/hw/dv/sv/spi_agent/spi_monitor.sv
+++ b/hw/dv/sv/spi_agent/spi_monitor.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class spi_monitor extends dv_base_monitor#(
+class spi_monitor extends dv_reactive_monitor #(
     .ITEM_T (spi_item),
     .CFG_T  (spi_agent_cfg),
     .COV_T  (spi_agent_cov)

--- a/hw/dv/sv/spi_agent/spi_sequencer.sv
+++ b/hw/dv/sv/spi_agent/spi_sequencer.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class spi_sequencer extends dv_base_sequencer#(spi_item, spi_agent_cfg, spi_item);
+class spi_sequencer extends dv_reactive_sequencer #(spi_item, spi_agent_cfg, spi_item);
   `uvm_component_utils(spi_sequencer)
 
   // Analysis imp to receive items from host AP in monitor

--- a/hw/dv/sv/usb20_agent/usb20_agent.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class usb20_agent extends dv_base_agent #(
+class usb20_agent extends dv_reactive_agent #(
   .CFG_T          (usb20_agent_cfg),
   .DRIVER_T       (usb20_driver),
   .SEQUENCER_T    (usb20_sequencer),

--- a/hw/dv/sv/usb20_agent/usb20_agent_cfg.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent_cfg.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class usb20_agent_cfg extends dv_base_agent_cfg;
+class usb20_agent_cfg extends dv_reactive_agent_cfg;
 
   // interface handle used by driver, monitor & the sequencer, via cfg handle
   virtual usb20_block_if bif;

--- a/hw/dv/sv/usb20_agent/usb20_agent_pkg.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent_pkg.sv
@@ -76,8 +76,7 @@ package usb20_agent_pkg;
   typedef class usb20_agent_cfg;
 
   // reuse dv_base_sequencer as is with the right parameter set
-  typedef dv_base_sequencer #(.ITEM_T     (usb20_item),
-    .CFG_T      (usb20_agent_cfg)) usb20_sequencer;
+  typedef dv_reactive_sequencer #(.ITEM_T(usb20_item), .CFG_T (usb20_agent_cfg)) usb20_sequencer;
 
   // functions
 

--- a/hw/dv/sv/usb20_agent/usb20_monitor.sv
+++ b/hw/dv/sv/usb20_agent/usb20_monitor.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class usb20_monitor extends dv_base_monitor #(
+class usb20_monitor extends dv_reactive_monitor #(
   .ITEM_T (usb20_item),
   .REQ_ITEM_T (usb20_item),
   .RSP_ITEM_T (usb20_item),


### PR DESCRIPTION
Historically, dv_base_agent has had some extra wiring to allow reactive sequences, driven by the monitor:

  - The monitor has two ports: req_analysis_port and rsp_analysis_port
  - These are attached to corresponding exports in the sequencer.

The idea is that a reactive sequence can subscribe to the appropriate exports and respond accordingly.

This isn't really the current convention in the UVM world. The main problem is that you end up with the stimulus (the sequence) depending on behaviour of an analysis component. The more standard way to do this is to broadcast the requests from the driver instead, and pass them to the sequence that responds.

Even when unused, the existing structure can be problematic. If you want to make an agent that can be active in either direction ("Host" or "Device") on an interface, you probably want a different driver in each case, and it makes more sense for these drivers to have different sequence item types. This, in turn, means you need a different sequencer type in each direction. You then build two copies of the agent ("my_host_agent" and "my_device_agent"). Unfortunately, these can't share a monitor! The monitor type ends up needing to know the direction ("REQ_ITEM_T" and "RSP_ITEM_T").

This commit splits out the "agent with a sequencer that reacts to a monitor" into an intermediate class. The agents that used this structure can now inherit from that type, giving chains like

  alert_esc_agent < dv_reactive_agent < dv_base_agent