### PR TITLE
[keymgr,dv] Make assertion failures in keymgr_if more informative

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_if.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_if.sv
@@ -565,25 +565,61 @@ interface keymgr_if(input clk, input rst_n);
     end
   endfunction
 
-  // Create a macro to skip checking key values when LC is off or fault error occurs
-  `define ASSERT_IFF_KEYMGR_LEGAL(NAME, SEQ) \
-    `ASSERT(NAME, SEQ, clk, !rst_n || keymgr_en_sync2 != lc_ctrl_pkg::On || !en_chk)
+  // Assertions that check key values, skipping situations when when LC is off or fault error occurs
+  //
+  // These assertions all share the same disable and clocking settings, so are grouped into a
+  // gen_keymgr_legal_checks block, where they can share a "default disable" and "default clocking".
+  if (1) begin : gen_keymgr_legal_checks
+    default disable iff !rst_n || keymgr_en_sync2 != lc_ctrl_pkg::On || !en_chk;
+    default clocking @(posedge clk); endclocking
 
-  `ASSERT_IFF_KEYMGR_LEGAL(CheckKmacKey, is_kmac_key_good && kmac_key_exp.valid ->
-                           (kmac_key.key[0] ^ kmac_key.key[1]) ==
-                           (kmac_key_exp.key[0] ^ kmac_key_exp.key[1]))
-  `ASSERT_IFF_KEYMGR_LEGAL(CheckKmacKeyValid, is_kmac_key_good ->
-                           kmac_key_exp.valid == kmac_key.valid)
+    CheckKmacKeyValid:
+      assert property (is_kmac_key_good -> kmac_key_exp.valid == kmac_key.valid)
+      else `uvm_error("CheckKmacKeyValid",
+                      $sformatf("Mismatch for valid bit. Saw %0b but expected %0b.",
+                                kmac_key.valid, kmac_key_exp.valid))
 
-  `ASSERT_IFF_KEYMGR_LEGAL(CheckAesKey, aes_sideload_status == SideLoadAvail && aes_key_exp.valid ->
-                           aes_key == aes_key_exp)
-  `ASSERT_IFF_KEYMGR_LEGAL(CheckAesKeyValid, aes_sideload_status != SideLoadClear ->
-                           aes_key_exp.valid == aes_key.valid)
+    CheckKmacKey:
+      assert property (is_kmac_key_good && kmac_key.valid ->
+                       (kmac_key.key[0] ^ kmac_key.key[1]) ==
+                       (kmac_key_exp.key[0] ^ kmac_key_exp.key[1]))
+      else `uvm_error("CheckKmacKey",
+                      $sformatf({"Key mismatch. Saw 0x%0h ^ 0x%0h = 0x%0h ",
+                                 "but expected 0x%0h ^ 0x%0h = 0x%0h."},
+                                kmac_key.key[0], kmac_key.key[1],
+                                kmac_key.key[0] ^ kmac_key.key[1],
+                                kmac_key_exp.key[0], kmac_key_exp.key[1],
+                                kmac_key_exp.key[0] ^ kmac_key_exp.key[1]))
 
-  `ASSERT_IFF_KEYMGR_LEGAL(CheckOtbnKey, otbn_sideload_status == SideLoadAvail && otbn_key_exp.valid
-                           -> otbn_key == otbn_key_exp)
-  `ASSERT_IFF_KEYMGR_LEGAL(CheckOtbnKeyValid, otbn_sideload_status != SideLoadClear ->
-                           otbn_key_exp.valid == otbn_key.valid)
+
+    CheckAesKeyValid:
+      assert property (aes_sideload_status != SideLoadClear -> aes_key_exp.valid == aes_key.valid)
+      else `uvm_error("CheckAesKeyValid",
+                      $sformatf("Mismatch for valid bit. Saw %0b but expected %0b.",
+                                aes_key.valid, aes_key_exp.valid))
+
+    CheckAesKey:
+      assert property (aes_sideload_status == SideLoadAvail && aes_key.valid ->
+                       aes_key == aes_key_exp)
+      else `uvm_error("CheckAesKey",
+                      $sformatf("Key mismatch. Saw 0x%0h but expected 0x%0h",
+                                aes_key, aes_key_exp))
+
+
+    CheckOtbnKeyValid:
+      assert property (otbn_sideload_status != SideLoadClear ->
+                       otbn_key_exp.valid == otbn_key.valid)
+      else `uvm_error("CheckOtbnKeyValid",
+                      $sformatf("Mismatch for valid bit. Saw %0b but expected %0b.",
+                                otbn_key.valid, otbn_key_exp.valid))
+
+    CheckOtbnKey:
+      assert property (otbn_sideload_status == SideLoadAvail && otbn_key.valid ->
+                       otbn_key == otbn_key_exp)
+      else `uvm_error("CheckOtbnKey",
+                      $sformatf("Key mismatch. Saw 0x%0h but expected 0x%0h",
+                                otbn_key, otbn_key_exp))
+  end
 
   // for EDN assertion
   // sync req/ack to core clk domain
@@ -661,6 +697,4 @@ interface keymgr_if(input clk, input rst_n);
   `ASSERT(CheckEdn2ndReq, $rose(edn_req_sync) && edn_req_cnt == 1 |->
           edn_wait_cnt < edn_tolerance_upd,
           clk, !rst_n || !en_chk)
-
-  `undef ASSERT_IFF_KEYMGR_LEGAL
 endinterface


### PR DESCRIPTION
The assertions are checking the same behaviour, but we can make use of
the fact we're in a UVM context and print out a more helpful error
message.

The only change to the assertion properties themselves is that they
`CheckKmacKey`, `CheckAesKey` and `CheckOtbnKey` now use the observed valid
signal instead of the expected one. This is equivalent (because of
`CheckKmacKeyValid`, `CheckAesKeyValid` and `CheckOtbnKeyValid`), but
probably makes a bit more sense.

The expansion of text is because we now print out more information on
a failure (including both halves of masked values). The motivation for
this was that I'd messed up some wiring when integrating a modified
KMAC agent. Improving the error messages here made it rather easier to
see what was going on.
