### PR TITLE
[chip,dv] Back-port improvements to chip_sw_spi_passthrough_vseq

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_passthrough_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_passthrough_vseq.sv
@@ -156,11 +156,7 @@ class chip_sw_spi_passthrough_vseq extends chip_sw_base_vseq;
     super.cpu_init();
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(passthrough_filters);
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(read_pipeline_mode);
-`ifdef GATE_LEVEL
-    // Two stages full cycle is forced since GLS fails for freqs over 24MHz
-    // TODO: does GLS gets satisfied equally for "two stages half cycle" read pipeline value?
-    read_pipeline_mode = 2;
-`endif
+
     read_pipeline_mode_data[0] = {read_pipeline_mode};
     sw_symbol_backdoor_overwrite("kReadPipelineMode", read_pipeline_mode_data);
     sw_filter_config = {<<byte{passthrough_filters}};

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_passthrough_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_passthrough_vseq.sv
@@ -5,25 +5,29 @@
 class chip_sw_spi_passthrough_vseq extends chip_sw_base_vseq;
   `uvm_object_utils(chip_sw_spi_passthrough_vseq)
 
-  `uvm_object_new
-
   // The sequence of opcodes used for the test.
   spi_flash_cmd_e test_opcodes[$];
+
   // Whether to check for transactions appearing on the unused spi_host.
   bit en_unused_spi_host_monitoring = 1'b1;
+
   // Frequencies to use for testing the sequences.
   time sck_periods_ps[] = '{
     41_000, // 24 MHz
-`ifndef GATE_LEVEL
-    //TODO return 30MHz for GLS simulation when issue #24597 is fixed
-    // 30Mhz SCK is not supported when CMD_INFO.read_pipeline_mode is set to 0x0 or 0x1
     33_000, // 30 MHz
-`endif
     167_000 // 6 MHz
   };
+
   // A bit map of command slots that will have passthrough filters enabled.
   rand bit [spi_device_pkg::NumTotalCmdInfo-1:0] passthrough_filters;
 
+  // This test will run with a random SCK period, selected from sck_periods_ps
+  rand time sck_period_ps;
+
+  // Constrain the selected SCK period to be one of the frequencies in sck_periods_ps
+  constraint valid_sck_period_c {
+    sck_period_ps inside {sck_periods_ps};
+  }
 
   // Configures the read pipeline when set to non-zero
   rand bit [1:0] read_pipeline_mode;
@@ -31,6 +35,18 @@ class chip_sw_spi_passthrough_vseq extends chip_sw_base_vseq;
   constraint read_pipeline_mode_c {
     read_pipeline_mode <= 2;
   }
+
+  // Constrain read_pipeline_mode to be 2 when running at a high frequency (with period at most
+  // 33_000, so an SCK frequency of 30 MHz or more)
+  constraint high_speed_read_pipeline_c {
+    if (sck_period_ps <= 33_000) {
+      read_pipeline_mode == 2;
+    }
+  }
+
+  function new (string name="");
+    super.new(name);
+  endfunction
 
   // Generate a random permutation of the following opcodes, and place them in
   // the test_opcodes queue:
@@ -164,6 +180,16 @@ class chip_sw_spi_passthrough_vseq extends chip_sw_base_vseq;
   endtask
 
   virtual task body();
+    `uvm_info(get_full_name(),
+              $sformatf({"\nRunning SPI passthrough test with following config:\n",
+                         "    SCK period                  = %0d ps\n",
+                         "    Enabled passthrough filters = 0x%0h\n",
+                         "    Read pipeline mode          = %0d"},
+                        sck_period_ps,
+                        passthrough_filters,
+                        read_pipeline_mode),
+              UVM_LOW)
+
     // Turn off the FIFO data output assertion, as spi_device issues a read
     // before it knows whether it needs the data.
     $assertoff(0, "tb.dut.top_earlgrey.u_spi_device.u_readcmd.u_readsram.u_sram_fifo.DataKnown_A");
@@ -197,11 +223,11 @@ class chip_sw_spi_passthrough_vseq extends chip_sw_base_vseq;
         monitor_unused_spi_host();
       join_none
     end
-    foreach (sck_periods_ps[i]) begin
-      cfg.m_spi_host_agent_cfg.sck_period_ps = sck_periods_ps[i];
-      generate_spi_flash_sequence();
-      execute_spi_flash_sequence();
-    end
+
+    cfg.m_spi_host_agent_cfg.sck_period_ps = sck_period_ps;
+    generate_spi_flash_sequence();
+    execute_spi_flash_sequence();
+
     override_test_status_and_finish(1'b1);
   endtask
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_passthrough_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_passthrough_vseq.sv
@@ -153,13 +153,13 @@ class chip_sw_spi_passthrough_vseq extends chip_sw_base_vseq;
   virtual task cpu_init();
     bit [7:0] sw_filter_config[4];
     bit [7:0] read_pipeline_mode_data[1];
-    super.cpu_init();
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(passthrough_filters);
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(read_pipeline_mode);
 
     read_pipeline_mode_data[0] = {read_pipeline_mode};
-    sw_symbol_backdoor_overwrite("kReadPipelineMode", read_pipeline_mode_data);
     sw_filter_config = {<<byte{passthrough_filters}};
+
+    super.cpu_init();
+
+    sw_symbol_backdoor_overwrite("kReadPipelineMode", read_pipeline_mode_data);
     sw_symbol_backdoor_overwrite("kFilteredCommands", sw_filter_config);
   endtask
 

--- a/sw/device/tests/sim_dv/spi_passthrough_test.c
+++ b/sw/device/tests/sim_dv/spi_passthrough_test.c
@@ -406,6 +406,12 @@ bool test_main(void) {
   CHECK_DIF_OK(dif_spi_device_init_handle(spi_device_base_addr, &spi_device));
   bool upload_write_commands = (kUploadWriteCommands != 0);
 
+  // Print kFilteredCommands and kReadPipelineMode to the log, which
+  // allows us to check SW has seen the pipeline configuration
+  // expected by the DV code.
+  LOG_INFO("kFilteredCommands = %x", kFilteredCommands);
+  LOG_INFO("kReadPipelineMode = %d", kReadPipelineMode);
+
   CHECK_STATUS_OK(spi_device_testutils_configure_passthrough(
       &spi_device, kFilteredCommands, upload_write_commands));
   CHECK_STATUS_OK(spi_device_testutils_configure_read_pipeline(


### PR DESCRIPTION
This is a backport of #30129.

The first commit is a manual back-port of 5ec693e. It should be safe to apply as-is. Alternatively, we could merge #29679 first, which will supply that first commit.