### PR TITLE
[kmac,dv] Make set_tl_assert_en protected

### DIFF
--- a/hw/ip/kmac/dv/env/seq_lib/kmac_common_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_common_vseq.sv
@@ -111,7 +111,7 @@ class kmac_common_vseq extends kmac_base_vseq;
     super.shadow_reg_err_ctrl_svas(enable, path);
   endfunction
 
-  virtual function void set_tl_assert_en(bit enable, string path = "*");
+  virtual protected function void set_tl_assert_en(bit enable, string path = "*");
     set_kmac_csr_assert_en(enable);
     super.set_tl_assert_en(enable, path);
   endfunction


### PR DESCRIPTION
I made this function protected in the base class with 83d178b and it didn't occur to me that I should probably do the same thing in deriving classes (to stop EDA tools complaining quite reasonably!)

~~~

This change avoids warning messages polluting the build logs when you build/run KMAC tests. Sorry it was needed!