### PR TITLE
[Topgen] don’t reassign alias_from_raw

### DIFF
--- a/util/topgen.py
+++ b/util/topgen.py
@@ -1083,7 +1083,7 @@ def create_generic_ip_blocks(topcfg: ConfigT, alias_cfgs: Dict[str, ConfigT],
         else:
             ip_block = IpBlock.from_path(str(hjson_path), [])
             if ip_type in alias_cfgs:
-                ip_block = ip_block.alias_from_raw(
+                ip_block.alias_from_raw(
                     False, alias_cfgs[ip_type], f"alias file for {ip_type}")
             ip_attrs[ip_type] = IpAttrs(ip_block=ip_block,
                                         hjson_path=hjson_path,
@@ -1116,8 +1116,8 @@ def create_ipgen_ip_block(topname: str, template_name: str, module_name: str,
                           alias_cfgs: Dict[str, ConfigT]) -> IpBlock:
     ip_block = ipgen_hjson_render(template_name, topname, params)
     if module_name in alias_cfgs:
-        ip_block = ip_block.alias_from_raw(False, alias_cfgs[module_name],
-                                           f"alias file for {module_name}")
+        ip_block.alias_from_raw(False, alias_cfgs[module_name],
+                                f"alias file for {module_name}")
     return ip_block
 
 


### PR DESCRIPTION
When alias_hjson is used, ip_block in topgen.py  is set to None.
` ip_block = ip_block.alias_from_raw(...) `   -> returns None and then reassigns ip_block to None, so the valid IpBlock is lost.
This set name_to_block["flash_ctrl"] = None. Then amend_pinmux_io tries to call methods on None → crash.
The error:
  ```
 File "opentitan/rep/util/topgen/merge.py", line 1573, in amend_pinmux_io
                    sig_list = deepcopy(block.get_signals_as_list_of_dicts())
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                AttributeError: 'NoneType' object has no attribute 'get_signals_as_list_of_dicts'

```
