### PR TITLE
[cryptotest[ AES ACVP testing

### DIFF
--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -163,6 +163,27 @@ cryptotest(
     ],
 )
 
+# Runs AES-ECB and AES-GCM ACVP test vectors and compares against expected
+# results.  To also save the results to a file, append --output=<path> when
+# invoking with `bazelisk.sh run`:
+#
+#   ./bazelisk.sh run \
+#       //sw/device/tests/crypto/cryptotest:aes_acvp_fpga_cw340_sival_rom_ext -- \
+#           --output=/tmp/aes_acvp_results.json
+cryptotest(
+    name = "aes_acvp",
+    slow_test = True,
+    test_args = " ".join([
+        "--input=\"$(rootpath //sw/host/cryptotest/testvectors/acvp:aes_vectors.hjson)\"",
+        "--expected=\"$(rootpath //sw/host/cryptotest/testvectors/acvp:aes_expected.hjson)\"",
+    ]),
+    test_harness = "//sw/host/tests/crypto/acvp:harness",
+    test_vectors = [
+        "//sw/host/cryptotest/testvectors/acvp:aes_vectors.hjson",
+        "//sw/host/cryptotest/testvectors/acvp:aes_expected.hjson",
+    ],
+)
+
 AES_TESTVECTOR_TARGETS = [
     "//sw/host/cryptotest/testvectors/data:nist_cavp_aes_kat_{}_{}_{}_json".format(alg, kat_type, key_len)
     for alg in ("cbc", "cfb128", "ecb", "ofb")
@@ -811,6 +832,7 @@ cryptotest(
 test_suite(
     name = "crypto_kat_test_suite",
     tests = [
+        ":aes_acvp",
         ":aes_gcm_kat",
         ":aes_kat",
         ":cshake_acvp",

--- a/sw/host/cryptotest/testvectors/acvp/BUILD
+++ b/sw/host/cryptotest/testvectors/acvp/BUILD
@@ -5,6 +5,8 @@
 package(default_visibility = ["//visibility:public"])
 
 exports_files([
+    "aes_expected.hjson",
+    "aes_vectors.hjson",
     "cshake_expected.json",
     "cshake_vectors.json",
     "ecdsa_expected.hjson",

--- a/sw/host/cryptotest/testvectors/acvp/aes_expected.hjson
+++ b/sw/host/cryptotest/testvectors/acvp/aes_expected.hjson
@@ -1,0 +1,80 @@
+// Copyright lowRISC contributors (OpenTitan project).
+//
+// Source: NIST ACVP-Server (https://github.com/usnistgov/ACVP-Server)
+// NIST License:
+// NIST-developed software is provided by NIST as a public service. You may
+// use, copy, and distribute copies of the software in any medium, provided
+// that you keep intact this entire notice. You may improve, modify, and create
+// derivative works of the software or any portion of the software, and you may
+// copy and distribute such modifications or works. Modified works should carry
+// a notice stating that you changed the software and should note the date and
+// nature of any such change. Please explicitly acknowledge the National
+// Institute of Standards and Technology as the source of the software.
+//
+// NIST-developed software is expressly provided "AS IS." NIST MAKES NO
+// WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF
+// LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND DATA ACCURACY. NIST
+// NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE
+// UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST
+// DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE
+// SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE
+// CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+//
+// You are solely responsible for determining the appropriateness of using and
+// distributing the software and you assume all risks associated with its use,
+// including but not limited to the risks and costs of program errors,
+// compliance with applicable laws, damage to or loss of data, programs or
+// equipment, and the unavailability or interruption of operation. This
+// software is not intended to be used in any situation where a failure could
+// cause risk of injury or damage to property. The software developed by NIST
+// employees is not subject to copyright protection within the United States.
+//
+// Based on:
+// https://github.com/usnistgov/ACVP-Server/blob/master/gen-val/json-files/ACVP-AES-ECB-1.0/expectedResults.json
+// Modifications:
+// This file was modified on 13.05.2026 as following:
+// - For AES-ECB, removed all test groups except tgId 1.
+[
+  {
+    "vsId": 0,
+    "algorithm": "ACVP-AES-ECB",
+    "revision": "1.0",
+    "isSample": false,
+    "testGroups": [
+      {
+        "tgId": 1,
+        "tests": [
+          {
+            "tcId": 1,
+            "ct": "459264F4798F6A78BACB89C15ED3D601"
+          },
+          {
+            "tcId": 2,
+            "ct": "0336763E966D92595A567CC9CE537F5E"
+          },
+          {
+            "tcId": 3,
+            "ct": "A9A1631BF4996954EBC093957B234589"
+          },
+          {
+            "tcId": 4,
+            "ct": "FF4F8391A6A40CA5B25D23BEDD44A597"
+          },
+          {
+            "tcId": 5,
+            "ct": "92BEEDAB1895A94FAA69B632E5CC47CE"
+          },
+          {
+            "tcId": 6,
+            "ct": "08A4E2EFEC8A8E3312CA7460B9040BBF"
+          },
+          {
+            "tcId": 7,
+            "ct": "DC43BE40BE0E53712F7E2BF5CA707209"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/sw/host/cryptotest/testvectors/acvp/aes_expected.hjson
+++ b/sw/host/cryptotest/testvectors/acvp/aes_expected.hjson
@@ -32,9 +32,11 @@
 //
 // Based on:
 // https://github.com/usnistgov/ACVP-Server/blob/master/gen-val/json-files/ACVP-AES-ECB-1.0/expectedResults.json
+// https://github.com/usnistgov/ACVP-Server/blob/master/gen-val/json-files/ACVP-AES-GCM-1.0/expectedResults.json
 // Modifications:
-// This file was modified on 13.05.2026 as following:
-// - For AES-ECB, removed all test groups except tgId 1.
+// This file was modified on 26.05.2026 as following:
+// - Combined AES-ECB and AES-GCM test vectors.
+// - For AES-ECB and AES-GCM, removed all test groups except tgId 1.
 [
   {
     "vsId": 0,
@@ -72,6 +74,94 @@
           {
             "tcId": 7,
             "ct": "DC43BE40BE0E53712F7E2BF5CA707209"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "vsId": 0,
+    "algorithm": "ACVP-AES-GCM",
+    "revision": "1.0",
+    "isSample": false,
+    "testGroups": [
+      {
+        "tgId": 1,
+        "tests": [
+          {
+            "tcId": 1,
+            "ct": "",
+            "tag": "9E557D92647C1510D4101EBEED0C52DD"
+          },
+          {
+            "tcId": 2,
+            "ct": "",
+            "tag": "6A7BBCDB4834109B6AA067B5358D94F3"
+          },
+          {
+            "tcId": 3,
+            "ct": "",
+            "tag": "72445E31C5DF05DFA2CCBA54AE385DFD"
+          },
+          {
+            "tcId": 4,
+            "ct": "",
+            "tag": "4F8508CB9C385C72935DEFD397BEB317"
+          },
+          {
+            "tcId": 5,
+            "ct": "",
+            "tag": "374A8920101702D1CCDE488A3ED7BD74"
+          },
+          {
+            "tcId": 6,
+            "ct": "",
+            "tag": "350DB3900067E56F16C77C835DAC544C"
+          },
+          {
+            "tcId": 7,
+            "ct": "",
+            "tag": "F150351CD6C3D09ED6F65CCDD9016329"
+          },
+          {
+            "tcId": 8,
+            "ct": "",
+            "tag": "7F6917FC8C4437E897DED97F56BAF97E"
+          },
+          {
+            "tcId": 9,
+            "ct": "",
+            "tag": "7C0487B32951712B1C8B5A383D1D2C7D"
+          },
+          {
+            "tcId": 10,
+            "ct": "",
+            "tag": "3EB7851F7C2C22FE454487DC6F3DF568"
+          },
+          {
+            "tcId": 11,
+            "ct": "",
+            "tag": "D4FAB95E8D69AEA9FBD8F5828D3BD431"
+          },
+          {
+            "tcId": 12,
+            "ct": "",
+            "tag": "142EC77E700EA07AFEDCA19968237921"
+          },
+          {
+            "tcId": 13,
+            "ct": "",
+            "tag": "25A704866524EDF070813B81D076BC0A"
+          },
+          {
+            "tcId": 14,
+            "ct": "",
+            "tag": "17FFF7D09A61124C5D7B41EC93A030CF"
+          },
+          {
+            "tcId": 15,
+            "ct": "",
+            "tag": "935A4D11F33268110BB7EC6ED1DA7440"
           }
         ]
       }

--- a/sw/host/cryptotest/testvectors/acvp/aes_vectors.hjson
+++ b/sw/host/cryptotest/testvectors/acvp/aes_vectors.hjson
@@ -1,0 +1,90 @@
+// Copyright lowRISC contributors (OpenTitan project).
+//
+// Source: NIST ACVP-Server (https://github.com/usnistgov/ACVP-Server)
+// NIST License:
+// NIST-developed software is provided by NIST as a public service. You may
+// use, copy, and distribute copies of the software in any medium, provided
+// that you keep intact this entire notice. You may improve, modify, and create
+// derivative works of the software or any portion of the software, and you may
+// copy and distribute such modifications or works. Modified works should carry
+// a notice stating that you changed the software and should note the date and
+// nature of any such change. Please explicitly acknowledge the National
+// Institute of Standards and Technology as the source of the software.
+//
+// NIST-developed software is expressly provided "AS IS." NIST MAKES NO
+// WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF
+// LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND DATA ACCURACY. NIST
+// NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE
+// UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST
+// DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE
+// SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE
+// CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+//
+// You are solely responsible for determining the appropriateness of using and
+// distributing the software and you assume all risks associated with its use,
+// including but not limited to the risks and costs of program errors,
+// compliance with applicable laws, damage to or loss of data, programs or
+// equipment, and the unavailability or interruption of operation. This
+// software is not intended to be used in any situation where a failure could
+// cause risk of injury or damage to property. The software developed by NIST
+// employees is not subject to copyright protection within the United States.
+//
+// Based on:
+// https://github.com/usnistgov/ACVP-Server/blob/master/gen-val/json-files/ACVP-AES-ECB-1.0/prompt.json
+// Modifications:
+// This file was modified on 26.05.2026 as following:
+// - For AES-ECB, removed all test groups except tgId 1.
+[
+  {
+    "vsId": 0,
+    "algorithm": "ACVP-AES-ECB",
+    "revision": "1.0",
+    "isSample": false,
+    "testGroups": [
+      {
+        "tgId": 1,
+        "testType": "AFT",
+        "direction": "encrypt",
+        "keyLen": 128,
+        "tests": [
+          {
+            "tcId": 1,
+            "pt": "B26AEB1874E47CA8358FF22378F09144",
+            "key": "00000000000000000000000000000000"
+          },
+          {
+            "tcId": 2,
+            "pt": "F34481EC3CC627BACD5DC3FB08F273E6",
+            "key": "00000000000000000000000000000000"
+          },
+          {
+            "tcId": 3,
+            "pt": "9798C4640BAD75C7C3227DB910174E72",
+            "key": "00000000000000000000000000000000"
+          },
+          {
+            "tcId": 4,
+            "pt": "96AB5C2FF612D9DFAAE8C31F30C42168",
+            "key": "00000000000000000000000000000000"
+          },
+          {
+            "tcId": 5,
+            "pt": "CB9FCEEC81286CA3E989BD979B0CB284",
+            "key": "00000000000000000000000000000000"
+          },
+          {
+            "tcId": 6,
+            "pt": "58C8E00B2631686D54EAB84B91F0ACA1",
+            "key": "00000000000000000000000000000000"
+          },
+          {
+            "tcId": 7,
+            "pt": "6A118A874519E64E9963798A503F1D35",
+            "key": "00000000000000000000000000000000"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/sw/host/cryptotest/testvectors/acvp/aes_vectors.hjson
+++ b/sw/host/cryptotest/testvectors/acvp/aes_vectors.hjson
@@ -32,9 +32,11 @@
 //
 // Based on:
 // https://github.com/usnistgov/ACVP-Server/blob/master/gen-val/json-files/ACVP-AES-ECB-1.0/prompt.json
+// https://github.com/usnistgov/ACVP-Server/blob/master/gen-val/json-files/ACVP-AES-GCM-1.0/prompt.json
 // Modifications:
 // This file was modified on 26.05.2026 as following:
-// - For AES-ECB, removed all test groups except tgId 1.
+// - Combined AES-ECB and AES-GCM test vectors.
+// - For AES-ECB and AES-GCM, removed all test groups except tgId 1.
 [
   {
     "vsId": 0,
@@ -82,6 +84,133 @@
             "tcId": 7,
             "pt": "6A118A874519E64E9963798A503F1D35",
             "key": "00000000000000000000000000000000"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "vsId": 0,
+    "algorithm": "ACVP-AES-GCM",
+    "revision": "1.0",
+    "isSample": false,
+    "testGroups": [
+      {
+        "tgId": 1,
+        "testType": "AFT",
+        "direction": "encrypt",
+        "keyLen": 128,
+        "ivLen": 96,
+        "ivGen": "external",
+        "ivGenMode": "8.2.2",
+        "payloadLen": 0,
+        "aadLen": 120,
+        "tagLen": 128,
+        "tests": [
+          {
+            "tcId": 1,
+            "pt": "",
+            "key": "4B2CBE2158F5D6A28CC798DF4F99F777",
+            "aad": "4607F76F4FDA85DAFDC8CE085E0CE5",
+            "iv": "3851BAF79831605B75086E79"
+          },
+          {
+            "tcId": 2,
+            "pt": "",
+            "key": "32E106F67A99F89788D168BEB6596400",
+            "aad": "65FC70A3CC2E0F14B3C56216881F8C",
+            "iv": "491F4B2DF6D0288DB54716B6"
+          },
+          {
+            "tcId": 3,
+            "pt": "",
+            "key": "15BF034EE6DC3DA6296EE138B90FC0CE",
+            "aad": "EDDE20197C7DED0B293B061F349840",
+            "iv": "DE8CB48EE0F1CB57F4E9FFB5"
+          },
+          {
+            "tcId": 4,
+            "pt": "",
+            "key": "A1BAF46B4B1E8C169EA89892697C1CB4",
+            "aad": "6A4687585852AE3438D97CC703EE17",
+            "iv": "B857C80F75CC7336114DEF84"
+          },
+          {
+            "tcId": 5,
+            "pt": "",
+            "key": "0E5EB84C7E64825C7569712DFEB2F156",
+            "aad": "2BC528CEB661427363C3D7C41A474B",
+            "iv": "F88AD682C50FD2EFBF5DFFA2"
+          },
+          {
+            "tcId": 6,
+            "pt": "",
+            "key": "BF5C3A9C65D72512F752A09C9B5ABA59",
+            "aad": "9D43A96F28E0753DEF6E6E07FD8442",
+            "iv": "0B8AE56978B462A5C0F8486C"
+          },
+          {
+            "tcId": 7,
+            "pt": "",
+            "key": "28DCCD63B305BB169BB7E85FE55591DF",
+            "aad": "8F8EDFA6E95B755976955ED3483CD2",
+            "iv": "407F6C53CCF5DDA6F868B22C"
+          },
+          {
+            "tcId": 8,
+            "pt": "",
+            "key": "3AD410F60CF85C923F2D9CE336E6A185",
+            "aad": "900865D0DB20458368F9A191775A58",
+            "iv": "FE37880DC4531AD581C4E24D"
+          },
+          {
+            "tcId": 9,
+            "pt": "",
+            "key": "1D650E5AD0B45A2A519DE40203C271CF",
+            "aad": "BF4D54FB100225DB37D80AA5883B92",
+            "iv": "3FE45FF564B983251816574D"
+          },
+          {
+            "tcId": 10,
+            "pt": "",
+            "key": "7B7473CA6E44320019A0DD324B77B5AD",
+            "aad": "EE74A91456154EA7DF2702E8069099",
+            "iv": "0F25C4D8969D268C89CF89DC"
+          },
+          {
+            "tcId": 11,
+            "pt": "",
+            "key": "368EF87F3BA49549334D756F7127C264",
+            "aad": "0EE044D4503197D12D2773BAD595DD",
+            "iv": "BE20E127CBEEB126BA5705A8"
+          },
+          {
+            "tcId": 12,
+            "pt": "",
+            "key": "AC8B6AF21571F41B413DD940CC0CE10E",
+            "aad": "CAB5E1F3A6E9F334A1E3A0A480E430",
+            "iv": "F0EABB2B51EDA331A8F69401"
+          },
+          {
+            "tcId": 13,
+            "pt": "",
+            "key": "95F171B040EDEC74200716786A4C9883",
+            "aad": "81FEBC3A769A3EC54CC2B2AF464EB5",
+            "iv": "8A099FB344B8D82105CDE359"
+          },
+          {
+            "tcId": 14,
+            "pt": "",
+            "key": "D933FFCCCF7F179277F2B409F089F497",
+            "aad": "37E2149B37A2199F6DEF54B283A4C8",
+            "iv": "2B8E42BF97178EF7A6E4F745"
+          },
+          {
+            "tcId": 15,
+            "pt": "",
+            "key": "29214E6ABF1A50CBC3EA399138ED22FA",
+            "aad": "AB966DC5A64F1FA1588ACC1CF4062C",
+            "iv": "F451A8FD6B66E538E72E655B"
           }
         ]
       }

--- a/sw/host/tests/crypto/acvp/BUILD
+++ b/sw/host/tests/crypto/acvp/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = [
+        "src/aes.rs",
         "src/cshake.rs",
         "src/ecdsa.rs",
         "src/eddsa.rs",

--- a/sw/host/tests/crypto/acvp/src/aes.rs
+++ b/sw/host/tests/crypto/acvp/src/aes.rs
@@ -1,0 +1,365 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use arrayvec::ArrayVec;
+use hex::FromHex;
+use serde::{Deserialize, Serialize};
+use std::cmp::min;
+use std::time::Duration;
+
+use cryptotest_commands::aes_commands::{
+    AesSubcommand, CryptotestAesData, CryptotestAesMode, CryptotestAesOperation,
+    CryptotestAesOutput, CryptotestAesPadding,
+};
+use cryptotest_commands::aes_gcm_commands::{
+    AesGcmSubcommand, CryptotestAesGcmData, CryptotestAesGcmOperation, CryptotestAesGcmOutput,
+};
+use cryptotest_commands::commands::CryptotestCommand;
+
+use opentitanlib::console::spi::SpiConsoleDevice;
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
+use rand::RngCore;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+
+const AES_BLOCK_BYTES: usize = 16;
+const AES_CMD_MAX_KEY_BYTES: usize = 32;
+const AES_CMD_MAX_MSG_BYTES: usize = 64;
+const AES_GCM_CMD_MAX_MSG_BYTES: usize = 64;
+const AES_GCM_CMD_MAX_TAG_BYTES: usize = 16;
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AesTestCase {
+    tc_id: usize,
+    key: String,
+    #[serde(default)]
+    pt: String,
+    #[serde(default)]
+    ct: String,
+    #[serde(default)]
+    iv: String,
+    #[serde(default)]
+    aad: String,
+    #[serde(default)]
+    tag: String,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AesTestGroup {
+    tg_id: usize,
+    test_type: String,
+    direction: String,
+    key_len: usize,
+    #[serde(default)]
+    iv_len: usize,
+    #[serde(default)]
+    aad_len: usize,
+    #[serde(default)]
+    tag_len: usize,
+    tests: Vec<AesTestCase>,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AesTestVectorSet {
+    vs_id: usize,
+    algorithm: String,
+    revision: String,
+    #[serde(default)]
+    is_sample: bool,
+    test_groups: Vec<AesTestGroup>,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AesResultCase {
+    pub tc_id: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ct: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pt: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_passed: Option<bool>,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AesResultGroup {
+    pub tg_id: usize,
+    pub tests: Vec<AesResultCase>,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AesResultVectorSet {
+    pub vs_id: usize,
+    pub algorithm: String,
+    pub revision: String,
+    #[serde(default)]
+    pub is_sample: bool,
+    pub test_groups: Vec<AesResultGroup>,
+}
+
+fn run_aes_block_case(
+    timeout: Duration,
+    spi_console: &SpiConsoleDevice,
+    algorithm: &str,
+    direction: &str,
+    tc: &AesTestCase,
+) -> Result<AesResultCase> {
+    log::info!("tc_id: {}", tc.tc_id);
+
+    let key = Vec::<u8>::from_hex(tc.key.as_bytes())?;
+    let input_hex = if direction == "encrypt" {
+        &tc.pt
+    } else {
+        &tc.ct
+    };
+    let input_bytes = Vec::<u8>::from_hex(input_hex.as_bytes())?;
+
+    let mut iv = [0u8; AES_BLOCK_BYTES];
+    if !tc.iv.is_empty() {
+        let iv_bytes = Vec::<u8>::from_hex(tc.iv.as_bytes())?;
+        let copy_len = min(iv_bytes.len(), AES_BLOCK_BYTES);
+        iv[..copy_len].copy_from_slice(&iv_bytes[..copy_len]);
+    }
+
+    let mode = match algorithm {
+        "ACVP-AES-ECB" => CryptotestAesMode::Ecb,
+        "ACVP-AES-CBC" => CryptotestAesMode::Cbc,
+        "ACVP-AES-CFB128" => CryptotestAesMode::Cfb,
+        "ACVP-AES-OFB" => CryptotestAesMode::Ofb,
+        "ACVP-AES-CTR" => CryptotestAesMode::Ctr,
+        _ => anyhow::bail!("Unsupported AES algorithm: {}", algorithm),
+    };
+    let operation = if direction == "encrypt" {
+        CryptotestAesOperation::Encrypt
+    } else {
+        CryptotestAesOperation::Decrypt
+    };
+
+    CryptotestCommand::Aes.send(spi_console)?;
+    AesSubcommand::AesBlock.send(spi_console)?;
+    mode.send(spi_console)?;
+    operation.send(spi_console)?;
+    CryptotestAesPadding::Null.send(spi_console)?;
+
+    let mut key_arr: ArrayVec<u8, AES_CMD_MAX_KEY_BYTES> = ArrayVec::new();
+    key_arr.try_extend_from_slice(&key)?;
+    let mut input_arr: ArrayVec<u8, AES_CMD_MAX_MSG_BYTES> = ArrayVec::new();
+    input_arr.try_extend_from_slice(&input_bytes)?;
+
+    CryptotestAesData {
+        key: key_arr,
+        key_length: key.len(),
+        iv: ArrayVec::from(iv),
+        input: input_arr,
+        input_len: input_bytes.len(),
+    }
+    .send(spi_console)?;
+
+    let aes_output = CryptotestAesOutput::recv(spi_console, timeout, false, false)?;
+    let output_len = aes_output.output_len as usize;
+    let output_hex = hex::encode_upper(&aes_output.output[..output_len]);
+
+    if direction == "encrypt" {
+        Ok(AesResultCase {
+            tc_id: tc.tc_id,
+            ct: Some(output_hex),
+            pt: None,
+            tag: None,
+            test_passed: None,
+        })
+    } else {
+        Ok(AesResultCase {
+            tc_id: tc.tc_id,
+            ct: None,
+            pt: Some(output_hex),
+            tag: None,
+            test_passed: None,
+        })
+    }
+}
+
+fn run_aes_gcm_case(
+    timeout: Duration,
+    spi_console: &SpiConsoleDevice,
+    direction: &str,
+    tag_len_bits: usize,
+    tc: &AesTestCase,
+) -> Result<AesResultCase> {
+    log::info!("tc_id: {}", tc.tc_id);
+
+    let key = Vec::<u8>::from_hex(tc.key.as_bytes())?;
+    let iv_bytes = Vec::<u8>::from_hex(tc.iv.as_bytes())?;
+    let aad_bytes = if tc.aad.is_empty() {
+        vec![]
+    } else {
+        Vec::<u8>::from_hex(tc.aad.as_bytes())?
+    };
+    let tag_len_bytes = tag_len_bits / 8;
+
+    let (input_bytes, tag_bytes) = if direction == "encrypt" {
+        let pt = if tc.pt.is_empty() {
+            vec![]
+        } else {
+            Vec::<u8>::from_hex(tc.pt.as_bytes())?
+        };
+        // Send zeros of the right tag length; the firmware computes and returns the actual tag.
+        (pt, vec![0u8; tag_len_bytes])
+    } else {
+        let ct = if tc.ct.is_empty() {
+            vec![]
+        } else {
+            Vec::<u8>::from_hex(tc.ct.as_bytes())?
+        };
+        let tag = Vec::<u8>::from_hex(tc.tag.as_bytes())?;
+        (ct, tag)
+    };
+
+    CryptotestCommand::AesGcm.send(spi_console)?;
+    AesGcmSubcommand::AesGcmOp.send(spi_console)?;
+
+    let operation = if direction == "encrypt" {
+        CryptotestAesGcmOperation::Encrypt
+    } else {
+        CryptotestAesGcmOperation::Decrypt
+    };
+    operation.send(spi_console)?;
+
+    let mut key_arr: ArrayVec<u8, AES_CMD_MAX_KEY_BYTES> = ArrayVec::new();
+    key_arr.try_extend_from_slice(&key)?;
+    let mut iv_arr: ArrayVec<u8, AES_BLOCK_BYTES> = ArrayVec::new();
+    iv_arr.try_extend_from_slice(&iv_bytes)?;
+    let mut input_arr: ArrayVec<u8, AES_GCM_CMD_MAX_MSG_BYTES> = ArrayVec::new();
+    input_arr.try_extend_from_slice(&input_bytes)?;
+    let mut aad_arr: ArrayVec<u8, AES_GCM_CMD_MAX_MSG_BYTES> = ArrayVec::new();
+    aad_arr.try_extend_from_slice(&aad_bytes)?;
+    let mut tag_arr: ArrayVec<u8, AES_GCM_CMD_MAX_TAG_BYTES> = ArrayVec::new();
+    tag_arr.try_extend_from_slice(&tag_bytes)?;
+
+    CryptotestAesGcmData {
+        key: key_arr,
+        key_length: key.len(),
+        iv: iv_arr,
+        iv_length: iv_bytes.len(),
+        input: input_arr,
+        input_length: input_bytes.len(),
+        aad: aad_arr,
+        aad_length: aad_bytes.len(),
+        tag: tag_arr,
+        tag_length: tag_len_bytes,
+    }
+    .send(spi_console)?;
+
+    let gcm_output = CryptotestAesGcmOutput::recv(spi_console, timeout, false, false)?;
+
+    if direction == "encrypt" {
+        let ct_hex = hex::encode_upper(&gcm_output.output[..gcm_output.output_len]);
+        let tag_hex = hex::encode_upper(&gcm_output.tag[..gcm_output.tag_len]);
+        Ok(AesResultCase {
+            tc_id: tc.tc_id,
+            ct: Some(ct_hex),
+            pt: None,
+            tag: Some(tag_hex),
+            test_passed: None,
+        })
+    } else if gcm_output.tag_valid {
+        let pt_hex = hex::encode_upper(&gcm_output.output[..gcm_output.output_len]);
+        Ok(AesResultCase {
+            tc_id: tc.tc_id,
+            ct: None,
+            pt: Some(pt_hex),
+            tag: None,
+            test_passed: None,
+        })
+    } else {
+        Ok(AesResultCase {
+            tc_id: tc.tc_id,
+            ct: None,
+            pt: None,
+            tag: None,
+            test_passed: Some(false),
+        })
+    }
+}
+
+fn run_aes_group(
+    timeout: Duration,
+    spi_console: &SpiConsoleDevice,
+    algorithm: &str,
+    tg: &AesTestGroup,
+    skip_stride: usize,
+    start_offset: usize,
+) -> Result<AesResultGroup> {
+    log::info!("tg_id: {}", tg.tg_id);
+    let mut result_cases: Vec<AesResultCase> = Vec::new();
+
+    let stride = min(skip_stride, tg.tests.len());
+    let offset = if stride > 0 { start_offset % stride } else { 0 };
+    log::info!("Tests options: skip_stride: {}, offset: {}", stride, offset);
+
+    let is_gcm = algorithm == "ACVP-AES-GCM";
+    for tc in &tg.tests {
+        if stride > 0 && (tc.tc_id % stride) != offset {
+            continue;
+        }
+        let result = if is_gcm {
+            run_aes_gcm_case(timeout, spi_console, &tg.direction, tg.tag_len, tc)?
+        } else {
+            run_aes_block_case(timeout, spi_console, algorithm, &tg.direction, tc)?
+        };
+        result_cases.push(result);
+    }
+
+    Ok(AesResultGroup {
+        tg_id: tg.tg_id,
+        tests: result_cases,
+    })
+}
+
+pub fn run_aes_vector_set(
+    timeout: Duration,
+    spi_console: &SpiConsoleDevice,
+    vs: &AesTestVectorSet,
+    skip_stride_arg: usize,
+    seed_arg: Option<u64>,
+) -> Result<AesResultVectorSet> {
+    log::info!("vs_id: {}", vs.vs_id);
+
+    let seed = seed_arg.unwrap_or_else(rand::random::<u64>);
+    log::info!("Using seed {}", seed);
+
+    let mut drng = ChaCha8Rng::seed_from_u64(seed);
+    let (skip_stride, start_offset) = match (drng.next_u32() as usize).checked_rem(skip_stride_arg)
+    {
+        Some(offset) => (skip_stride_arg, offset),
+        None => (1usize, 0usize),
+    };
+
+    let mut result_groups: Vec<AesResultGroup> = Vec::with_capacity(vs.test_groups.len());
+    for tg in &vs.test_groups {
+        result_groups.push(run_aes_group(
+            timeout,
+            spi_console,
+            &vs.algorithm,
+            tg,
+            skip_stride,
+            start_offset,
+        )?);
+    }
+
+    Ok(AesResultVectorSet {
+        vs_id: vs.vs_id,
+        algorithm: vs.algorithm.clone(),
+        revision: vs.revision.clone(),
+        is_sample: vs.is_sample,
+        test_groups: result_groups,
+    })
+}

--- a/sw/host/tests/crypto/acvp/src/main.rs
+++ b/sw/host/tests/crypto/acvp/src/main.rs
@@ -15,6 +15,7 @@ use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::rpc::ConsoleSend;
 use opentitanlib::uart::console::UartConsole;
 
+mod aes;
 mod cshake;
 mod ecdsa;
 mod eddsa;
@@ -116,6 +117,9 @@ enum AcvpVectors {
     // field that sigVer test cases lack, so sigVer vectors will fall through to Rsa.
     RsaSigGen(rsa::RsaSignGenTestVectorSet),
     Rsa(rsa::RsaTestVectorSet),
+    // AesTestVectorSet groups require a `direction` field that no other
+    // algorithm's groups have, so AES vectors fall through all prior variants.
+    Aes(aes::AesTestVectorSet),
 }
 
 #[derive(Deserialize, PartialEq, Serialize)]
@@ -134,6 +138,7 @@ enum AcvpResults {
     RsaSigGen(rsa::RsaSignGenResultVectorSet),
     Rsa(rsa::RsaResultVectorSet),
     X25519(x25519::X25519ResultVectorSet),
+    Aes(aes::AesResultVectorSet),
 }
 
 fn validate_subset(actual: &[AcvpResults], expected_json: &serde_json::Value) -> Result<()> {
@@ -357,6 +362,17 @@ fn run<R: std::io::Read, W: std::io::Write>(
                     &spi_console_device,
                     &vs,
                 )?));
+            }
+            AcvpVectors::Aes(vs) => {
+                if opts.expected.is_some() || opts.output.is_some() {
+                    acvp_results.push(AcvpResults::Aes(aes::run_aes_vector_set(
+                        opts.timeout,
+                        &spi_console_device,
+                        &vs,
+                        opts.skip_stride,
+                        opts.seed,
+                    )?));
+                }
             }
         }
     }

--- a/sw/host/tests/crypto/acvp/src/main.rs
+++ b/sw/host/tests/crypto/acvp/src/main.rs
@@ -82,44 +82,24 @@ struct Opts {
     output_eddsa: Option<std::path::PathBuf>,
 }
 
-#[derive(Deserialize, PartialEq, Serialize)]
-#[serde(rename_all_fields = "camelCase")]
-#[serde(untagged)]
 enum AcvpVectors {
     Header {
         url: String,
         vector_set_urls: Vec<String>,
         time: String,
     },
-    Hmac(hmac::HmacTestVectorSet),
+    Aes(aes::AesTestVectorSet),
     Cshake(cshake::CshakeTestVectorSet),
-    // EcdsaTestVectorSet (sigVer) has required qx/qy/r/s in each test case;
-    // EcdsaSignGenTestVectorSet (sigGen) has only message, so sigVer vectors
-    // match Ecdsa first and sigGen vectors fall through to EcdsaSigGen.
-    // EcdsaKeyGenTestVectorSet (keyGen) groups have secretGenerationMode but
-    // no hashAlg, so they fall through both Ecdsa and EcdsaSigGen to EcdsaKeyGen.
     Ecdsa(ecdsa::EcdsaTestVectorSet),
     EcdsaSigGen(ecdsa::EcdsaSignGenTestVectorSet),
     EcdsaKeyGen(ecdsa::EcdsaKeyGenTestVectorSet),
-    // EddsaTestVectorSet (sigVer) requires `q` and `signature` in each test
-    // case; EddsaSignGenTestVectorSet (sigGen) has only `message`, so sigVer
-    // vectors match Eddsa first and sigGen vectors fall through to EddsaSigGen.
     Eddsa(eddsa::EddsaTestVectorSet),
     EddsaSigGen(eddsa::EddsaSignGenTestVectorSet),
-    // X25519TestVectorSet must precede EddsaKeyGen: EddsaKeygenTestVectorSet test
-    // cases only require `tc_id`, so they would silently match x25519 test cases
-    // (which also have `tc_id` plus `publicServer`) if X25519 came later.
-    X25519(x25519::X25519TestVectorSet),
-    // EddsaKeygenTestVectorSet has no `preHash` in groups, so sigGen vectors
-    // (which require preHash) fall through to EddsaKeyGen.
     EddsaKeyGen(eddsa::EddsaKeygenTestVectorSet),
-    // RsaSigGen must precede Rsa: sigGen test cases have a required `message`
-    // field that sigVer test cases lack, so sigVer vectors will fall through to Rsa.
+    Hmac(hmac::HmacTestVectorSet),
     RsaSigGen(rsa::RsaSignGenTestVectorSet),
     Rsa(rsa::RsaTestVectorSet),
-    // AesTestVectorSet groups require a `direction` field that no other
-    // algorithm's groups have, so AES vectors fall through all prior variants.
-    Aes(aes::AesTestVectorSet),
+    X25519(x25519::X25519TestVectorSet),
 }
 
 #[derive(Deserialize, PartialEq, Serialize)]
@@ -139,6 +119,51 @@ enum AcvpResults {
     Rsa(rsa::RsaResultVectorSet),
     X25519(x25519::X25519ResultVectorSet),
     Aes(aes::AesResultVectorSet),
+}
+
+fn parse_vector_set(raw: serde_json::Value) -> Result<AcvpVectors> {
+    if raw.get("url").is_some() {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Header {
+            url: String,
+            vector_set_urls: Vec<String>,
+            time: String,
+        }
+        let h: Header = serde_json::from_value(raw)?;
+        return Ok(AcvpVectors::Header {
+            url: h.url,
+            vector_set_urls: h.vector_set_urls,
+            time: h.time,
+        });
+    }
+
+    // Extract as owned Strings so `raw` can be moved into serde_json::from_value below.
+    let algorithm = raw["algorithm"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("vector set missing 'algorithm' field"))?
+        .to_owned();
+    let mode = raw
+        .get("mode")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_owned();
+
+    Ok(match (algorithm.as_str(), mode.as_str()) {
+        (a, _) if a.starts_with("HMAC") => AcvpVectors::Hmac(serde_json::from_value(raw)?),
+        (a, _) if a.starts_with("cSHAKE") => AcvpVectors::Cshake(serde_json::from_value(raw)?),
+        (a, _) if a.starts_with("ACVP-AES") => AcvpVectors::Aes(serde_json::from_value(raw)?),
+        ("ECDSA", "sigVer") => AcvpVectors::Ecdsa(serde_json::from_value(raw)?),
+        ("ECDSA", "sigGen") => AcvpVectors::EcdsaSigGen(serde_json::from_value(raw)?),
+        ("ECDSA", "keyGen") => AcvpVectors::EcdsaKeyGen(serde_json::from_value(raw)?),
+        ("EDDSA", "sigVer") => AcvpVectors::Eddsa(serde_json::from_value(raw)?),
+        ("EDDSA", "sigGen") => AcvpVectors::EddsaSigGen(serde_json::from_value(raw)?),
+        ("EDDSA", "keyGen") => AcvpVectors::EddsaKeyGen(serde_json::from_value(raw)?),
+        ("RSA-sigGen", _) => AcvpVectors::RsaSigGen(serde_json::from_value(raw)?),
+        ("RSA-sigVer", _) => AcvpVectors::Rsa(serde_json::from_value(raw)?),
+        ("XECDH", _) => AcvpVectors::X25519(serde_json::from_value(raw)?),
+        _ => anyhow::bail!("Unknown algorithm/mode: {:?}/{:?}", algorithm, mode),
+    })
 }
 
 fn validate_subset(actual: &[AcvpResults], expected_json: &serde_json::Value) -> Result<()> {
@@ -230,7 +255,11 @@ fn run<R: std::io::Read, W: std::io::Write>(
     )?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
-    let acvp_vectors: Vec<AcvpVectors> = deser_hjson::from_reader(input)?;
+    let raw_vectors: Vec<serde_json::Value> = deser_hjson::from_reader(input)?;
+    let acvp_vectors = raw_vectors
+        .into_iter()
+        .map(parse_vector_set)
+        .collect::<Result<Vec<_>>>()?;
     let mut acvp_results: Vec<AcvpResults> = Vec::with_capacity(acvp_vectors.len());
     // All EdDSA results (sigVer, sigGen, keyGen) are collected for --output-eddsa.
     let mut eddsa_results: Vec<serde_json::Value> = Vec::new();


### PR DESCRIPTION
Add ACVP testing for AES. Currently, ECB and GCM test vectors are checked in but testing other modes works as well. The user can provide a test vector input file and either an expected output file to which the output is compared or a path to a new json file where the output is written to.