### PR TITLE
[crypto] Add minsize for fips blob

### DIFF
--- a/sw/device/lib/crypto/BUILD
+++ b/sw/device/lib/crypto/BUILD
@@ -57,7 +57,11 @@ opentitan_binary_blob(
         "//sw/device/lib/runtime:log",
     ],
     # We add the compiler option -fno-jump-tables to prevent the compiler making the code position dependent.
-    transitive_features = ["no_jump_tables"],
+    # Minsize is added to reduce code size.
+    transitive_features = [
+        "no_jump_tables",
+        "minsize",
+    ],
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/crypto/include:crypto_hdrs",


### PR DESCRIPTION
Add the minsize feature (-Oz flag) for minimum code size. This saves 2k bytes.