### PR TITLE
[adc_ctrl,dv] Generalise paths in adc_ctrl SVA interfaces

### DIFF
--- a/hw/ip/adc_ctrl/dv/sva/adc_ctrl_fsm_sva_if.sv
+++ b/hw/ip/adc_ctrl/dv/sva/adc_ctrl_fsm_sva_if.sv
@@ -47,8 +47,11 @@ interface adc_ctrl_fsm_sva_if
       else `ASSERT_ERROR(LpSampleCntSwReset_A)
 
     // Check connectivity of the state output register (this is used for debug only).
+    //
+    // The hierarchical reference is an upwards hierarchical reference and works because this
+    // interface is bound into an instance of adc_ctrl.
     FsmDebugOut_A:
-      assert property (fsm_state_q === tb.dut.u_reg.hw2reg.adc_fsm_state.d)
+      assert property (fsm_state_q === adc_ctrl.u_reg.hw2reg.adc_fsm_state.d)
       else `ASSERT_ERROR(FsmDebugOut_A)
   end
 

--- a/hw/ip/adc_ctrl/dv/sva/adc_ctrl_sva_if.sv
+++ b/hw/ip/adc_ctrl/dv/sva/adc_ctrl_sva_if.sv
@@ -113,11 +113,15 @@ interface adc_ctrl_sva_if
           ~rst_aon_ni)
   `ASSERT(EnterLowPower_A, EnterLowPower_P, clk_aon_i, ~rst_aon_ni | ~testmode_low_power)
 
-  // Assertion controls
-
+  // Local assertion controls
   `DV_ASSERT_CTRL("PwrupTime_A_CTRL", PwrupTime_A)
   `DV_ASSERT_CTRL("WakeupTime_A_CTRL", WakeupTime_A)
   `DV_ASSERT_CTRL("EnterLowPower_A_CTRL", EnterLowPower_A)
-  `DV_ASSERT_CTRL("ADC_CTRL_FSM_A_CTRL", tb.dut.u_adc_ctrl_core.u_adc_ctrl_fsm)
+
+  // Control for an assertion in the dut
+  //
+  // The hierarchical reference is an upwards hierarchical reference and works because this
+  // interface is bound into an instance of adc_ctrl.
+  `DV_ASSERT_CTRL("ADC_CTRL_FSM_A_CTRL", adc_ctrl.u_adc_ctrl_core.u_adc_ctrl_fsm)
 
 endinterface : adc_ctrl_sva_if


### PR DESCRIPTION
These interfaces are bound into adc_ctrl, so an upwards hierarchical reference works. Doing it like this avoids needing to encode the structure of the testbench (which is a problem for vertical re-use).