### PR TITLE
[ownership] Add support for AnyVersion ownership transfer mode

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -237,6 +237,7 @@ cc_library(
         ":datatypes",
         ":owner_block",
         ":ownership_key",
+        "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:memory",
         "//sw/device/silicon_creator/lib:boot_data",
         "//sw/device/silicon_creator/lib:error",

--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -92,6 +92,7 @@ dual_cc_library(
     ),
     deps = dual_inputs(
         device = [
+            ":owner_block",
             ":owner_verify",
             "//sw/device/lib/arch:device",
             "//sw/device/lib/base:memory",
@@ -109,6 +110,7 @@ dual_cc_library(
         shared = [
             ":datatypes",
             "//sw/device/lib/base:hardened",
+            "//sw/device/silicon_creator/lib:boot_data",
             "//sw/device/silicon_creator/lib/drivers:hmac",
             "//sw/device/silicon_creator/lib:error",
         ],

--- a/sw/device/silicon_creator/lib/ownership/datatypes.h
+++ b/sw/device/silicon_creator/lib/ownership/datatypes.h
@@ -116,6 +116,12 @@ typedef enum ownership_update_mode {
    * self-same owner if the config_version is newer)
    */
   kOwnershipUpdateModeSelfVersion = 0x564c4553,
+  /**
+   * Update mode AnyVersion: `ANYV`
+   * (accept new owner configs as long as the config_version is newer,
+   * or any config_version if it is a new owner (transfer))
+   */
+  kOwnershipUpdateModeAnyVersion = 0x56594e41,
 } ownership_update_mode_t;
 
 typedef enum lock_constraint {

--- a/sw/device/silicon_creator/lib/ownership/mock_ownership_key.cc
+++ b/sw/device/silicon_creator/lib/ownership/mock_ownership_key.cc
@@ -34,5 +34,9 @@ rom_error_t ownership_secret_new(uint32_t prior_key_alg,
                                                  prior_owner_key);
 }
 
+rom_error_t ownership_secret_update(boot_data_t *bootdata) {
+  return MockOwnershipKey::Instance().secret_update(bootdata);
+}
+
 }  // extern "C"
 }  // namespace rom_test

--- a/sw/device/silicon_creator/lib/ownership/mock_ownership_key.h
+++ b/sw/device/silicon_creator/lib/ownership/mock_ownership_key.h
@@ -24,6 +24,7 @@ class MockOwnershipKey : public global_mock::GlobalMock<MockOwnershipKey> {
   MOCK_METHOD(rom_error_t, seal_page, (size_t));
   MOCK_METHOD(rom_error_t, seal_check, (size_t));
   MOCK_METHOD(rom_error_t, secret_new, (uint32_t, const owner_keydata_t *));
+  MOCK_METHOD(rom_error_t, secret_update, (boot_data_t *));
 };
 
 }  // namespace internal

--- a/sw/device/silicon_creator/lib/ownership/owner_block.c
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.c
@@ -64,7 +64,8 @@ hardened_bool_t owner_block_owner_key_equal(void) {
 hardened_bool_t owner_block_newversion_mode(void) {
   if (owner_page_valid[0] == kOwnerPageStatusSealed &&
       (owner_page[0].update_mode == kOwnershipUpdateModeNewVersion ||
-       owner_page[0].update_mode == kOwnershipUpdateModeSelfVersion)) {
+       owner_page[0].update_mode == kOwnershipUpdateModeSelfVersion ||
+       owner_page[0].update_mode == kOwnershipUpdateModeAnyVersion)) {
     return kHardenedBoolTrue;
   }
   return kHardenedBoolFalse;

--- a/sw/device/silicon_creator/lib/ownership/ownership.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership.c
@@ -73,28 +73,53 @@ static rom_error_t locked_owner_init(boot_data_t *bootdata,
   hardened_bool_t bootdata_dirty = kHardenedBoolFalse;
   if (owner_page_valid[0] == kOwnerPageStatusSealed &&
       launder32(owner_page_valid[1]) == kOwnerPageStatusSigned &&
-      owner_block_newversion_mode() == kHardenedBoolTrue &&
-      launder32(owner_page[1].config_version) >
-          launder32(owner_page[0].config_version) &&
-      launder32(owner_block_owner_key_equal()) == kHardenedBoolTrue) {
-    HARDENED_CHECK_EQ(owner_page_valid[1], kOwnerPageStatusSigned);
-    HARDENED_CHECK_EQ(owner_block_owner_key_equal(), kHardenedBoolTrue);
-    HARDENED_CHECK_GT(owner_page[1].config_version,
-                      owner_page[0].config_version);
-    rom_error_t error =
-        ownership_activate(bootdata, /*write_both_pages=*/kHardenedBoolFalse);
-    if (launder32(error) == kErrorOk) {
-      HARDENED_CHECK_EQ(error, kErrorOk);
-      // Thunk the status of page 0 to Invalid so the next set of validity
-      // checks will copy the new page 1 content over to page 0 and establish a
-      // redundant backup of the new configuration.
-      owner_page_valid[0] = kOwnerPageStatusInvalid;
-      owner_page_valid[1] = kOwnerPageStatusSealed;
-      bootdata_dirty = kHardenedBoolTrue;
-    } else {
-      // If the new page wasn't good, we'll do nothing here and let the next set
-      // of validity checks copy page 0 over to page 1 and re-establish a
-      // redundant backup of the current configuration.
+      launder32(owner_block_newversion_mode()) == kHardenedBoolTrue) {
+    hardened_bool_t update_valid = kHardenedBoolFalse;
+
+    if (launder32(owner_block_owner_key_equal()) == kHardenedBoolTrue) {
+      if (launder32(owner_page[1].config_version) >
+          launder32(owner_page[0].config_version)) {
+        update_valid = kHardenedBoolTrue;
+      }
+    } else if (owner_page[0].update_mode == kOwnershipUpdateModeAnyVersion) {
+      update_valid = kHardenedBoolTrue;
+    }
+
+    if (launder32(update_valid) == kHardenedBoolTrue) {
+      HARDENED_CHECK_EQ(update_valid, kHardenedBoolTrue);
+      HARDENED_CHECK_EQ(owner_page_valid[1], kOwnerPageStatusSigned);
+      if (launder32(owner_block_owner_key_equal()) == kHardenedBoolTrue) {
+        HARDENED_CHECK_EQ(owner_block_owner_key_equal(), kHardenedBoolTrue);
+        HARDENED_CHECK_GT(owner_page[1].config_version,
+                          owner_page[0].config_version);
+      } else {
+        HARDENED_CHECK_EQ(owner_page[0].update_mode,
+                          kOwnershipUpdateModeAnyVersion);
+      }
+
+      rom_error_t error =
+          ownership_activate(bootdata, /*write_both_pages=*/kHardenedBoolFalse);
+      if (launder32(error) == kErrorOk) {
+        HARDENED_CHECK_EQ(error, kErrorOk);
+
+        if (launder32(owner_block_owner_key_equal()) == kHardenedBoolFalse) {
+          HARDENED_CHECK_EQ(owner_block_owner_key_equal(), kHardenedBoolFalse);
+          HARDENED_RETURN_IF_ERROR(ownership_secret_update(bootdata));
+        } else {
+          HARDENED_CHECK_EQ(owner_block_owner_key_equal(), kHardenedBoolTrue);
+        }
+
+        // Thunk the status of page 0 to Invalid so the next set of validity
+        // checks will copy the new page 1 content over to page 0 and establish
+        // a redundant backup of the new configuration.
+        owner_page_valid[0] = kOwnerPageStatusInvalid;
+        owner_page_valid[1] = kOwnerPageStatusSealed;
+        bootdata_dirty = kHardenedBoolTrue;
+      } else {
+        // If the new page wasn't good, we'll do nothing here and let the next
+        // set of validity checks copy page 0 over to page 1 and re-establish a
+        // redundant backup of the current configuration.
+      }
     }
   }
 

--- a/sw/device/silicon_creator/lib/ownership/ownership.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership.c
@@ -141,20 +141,14 @@ static rom_error_t locked_owner_init(boot_data_t *bootdata,
   // cut occurred after the owner page was updated but before bootdata
   // was persisted.
   // We only perform this check once both pages are fully validated and sealed.
-  if (launder32(owner_page_valid[0]) == kOwnerPageStatusSealed &&
-      launder32(owner_page_valid[1]) == kOwnerPageStatusSealed) {
-    HARDENED_CHECK_EQ(owner_page_valid[0], kOwnerPageStatusSealed);
-    HARDENED_CHECK_EQ(owner_page_valid[1], kOwnerPageStatusSealed);
-    if (launder32(owner_page[0].min_security_version_bl0) != UINT32_MAX &&
-        launder32(bootdata->min_security_version_bl0) <
-            launder32(owner_page[0].min_security_version_bl0)) {
-      HARDENED_CHECK_NE(owner_page[0].min_security_version_bl0, UINT32_MAX);
-      HARDENED_CHECK_LT(bootdata->min_security_version_bl0,
-                        owner_page[0].min_security_version_bl0);
-      bootdata->min_security_version_bl0 =
-          owner_page[0].min_security_version_bl0;
-      bootdata_dirty = kHardenedBoolTrue;
-    }
+  if (launder32(owner_page[0].min_security_version_bl0) != UINT32_MAX &&
+      launder32(bootdata->min_security_version_bl0) <
+          launder32(owner_page[0].min_security_version_bl0)) {
+    HARDENED_CHECK_NE(owner_page[0].min_security_version_bl0, UINT32_MAX);
+    HARDENED_CHECK_LT(bootdata->min_security_version_bl0,
+                      owner_page[0].min_security_version_bl0);
+    bootdata->min_security_version_bl0 = owner_page[0].min_security_version_bl0;
+    bootdata_dirty = kHardenedBoolTrue;
   }
 
   if (launder32(bootdata_dirty) == kHardenedBoolTrue) {

--- a/sw/device/silicon_creator/lib/ownership/ownership_activate.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_activate.c
@@ -91,10 +91,6 @@ static rom_error_t activate_handler(boot_svc_msg_t *msg,
     return kErrorOwnershipInvalidDin;
   }
 
-  // Copy the prior owner's key so we can save it in the key history.
-  uint32_t prior_key_alg = owner_page[0].ownership_key_alg;
-  owner_keydata_t prior_owner_key = owner_page[0].owner_key;
-
   HARDENED_RETURN_IF_ERROR(
       ownership_activate(bootdata, /*write_both_pages=*/kHardenedBoolTrue));
 
@@ -113,9 +109,7 @@ static rom_error_t activate_handler(boot_svc_msg_t *msg,
   } else {
     // All other activations are transfers and need to regenerate entropy stored
     // in the OwnerSecret page.
-    HARDENED_RETURN_IF_ERROR(
-        ownership_secret_new(prior_key_alg, &prior_owner_key));
-    bootdata->ownership_transfers += 1;
+    HARDENED_RETURN_IF_ERROR(ownership_secret_update(bootdata));
   }
 
   // Set the ownership state to LockedOwner.

--- a/sw/device/silicon_creator/lib/ownership/ownership_activate.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_activate.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/silicon_creator/lib/ownership/ownership_activate.h"
 
+#include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/silicon_creator/lib/boot_data.h"
@@ -33,20 +34,19 @@ rom_error_t ownership_activate(boot_data_t *bootdata,
   // flash writes succeeded.
   //
   // Program the sealed page into slot 1.
-  HARDENED_RETURN_IF_ERROR(flash_ctrl_info_erase(&kFlashCtrlInfoPageOwnerSlot1,
-                                                 kFlashCtrlEraseTypePage));
-  HARDENED_RETURN_IF_ERROR(flash_ctrl_info_write(
-      &kFlashCtrlInfoPageOwnerSlot1, 0,
-      sizeof(owner_page[1]) / sizeof(uint32_t), &owner_page[1]));
-
-  if (write_both_pages == kHardenedBoolTrue) {
-    // Program the same data into slot 0.
-    HARDENED_RETURN_IF_ERROR(flash_ctrl_info_erase(
-        &kFlashCtrlInfoPageOwnerSlot0, kFlashCtrlEraseTypePage));
+  const flash_ctrl_info_page_t *slots[2] = {
+      &kFlashCtrlInfoPageOwnerSlot1,
+      &kFlashCtrlInfoPageOwnerSlot0,
+  };
+  const size_t num_pages = write_both_pages == kHardenedBoolTrue ? 2 : 1;
+  size_t i = 0;
+  for (; launder32(i) < num_pages; i = launder32(i) + 1) {
+    HARDENED_RETURN_IF_ERROR(
+        flash_ctrl_info_erase(slots[i], kFlashCtrlEraseTypePage));
     HARDENED_RETURN_IF_ERROR(flash_ctrl_info_write(
-        &kFlashCtrlInfoPageOwnerSlot0, 0,
-        sizeof(owner_page[1]) / sizeof(uint32_t), &owner_page[1]));
+        slots[i], 0, sizeof(owner_page[1]) / sizeof(uint32_t), &owner_page[1]));
   }
+  HARDENED_CHECK_EQ(i, num_pages);
 
   return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/ownership/ownership_activate_unittest.cc
+++ b/sw/device/silicon_creator/lib/ownership/ownership_activate_unittest.cc
@@ -283,7 +283,8 @@ TEST_P(OwnershipActivateValidStateTest, OwnerPageValid) {
       .WillOnce(Return(kErrorOk));
 
   if (state != kOwnershipStateUnlockedSelf) {
-    EXPECT_CALL(ownership_key_, secret_new(_, _)).WillOnce(Return(kErrorOk));
+    EXPECT_CALL(ownership_key_, secret_update(&bootdata_))
+        .WillOnce(Return(kErrorOk));
   }
 
   // The nonce will be regenerated.
@@ -353,7 +354,8 @@ TEST_P(OwnershipActivateValidStateTest, UpdateBootdataBl0MinSecVer) {
       .WillOnce(Return(kErrorOk));
 
   if (state != kOwnershipStateUnlockedSelf) {
-    EXPECT_CALL(ownership_key_, secret_new(_, _)).WillOnce(Return(kErrorOk));
+    EXPECT_CALL(ownership_key_, secret_update(&bootdata_))
+        .WillOnce(Return(kErrorOk));
   }
 
   // The nonce will be regenerated.
@@ -419,7 +421,8 @@ TEST_P(OwnershipActivateNextBl0Slot, UpdateBootdataPrimaryBl0Slot) {
       .WillOnce(Return(kErrorOk));
 
   // The transfer will regenerate the owner secret.
-  EXPECT_CALL(ownership_key_, secret_new(_, _)).WillOnce(Return(kErrorOk));
+  EXPECT_CALL(ownership_key_, secret_update(&bootdata_))
+      .WillOnce(Return(kErrorOk));
 
   // The nonce will be regenerated.
   EXPECT_CALL(rnd_, Uint32()).WillRepeatedly(Return(99));

--- a/sw/device/silicon_creator/lib/ownership/ownership_key.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_key.c
@@ -89,29 +89,22 @@ rom_error_t ownership_key_validate(size_t page, ownership_key_t key,
   hmac_digest_t digest;
   hmac_sha256(message, len, &digest);
 
-  if ((key & kOwnershipKeyUnlock) == kOwnershipKeyUnlock) {
-    if (owner_verify(key_alg, &owner_page[page].unlock_key, ecdsa, spx, NULL, 0,
-                     NULL, 0, message, len, &digest, flash_exec) == kErrorOk) {
-      return kErrorOk;
+  const struct {
+    ownership_key_t mask;
+    const owner_keydata_t *key;
+  } keys[] = {
+      {kOwnershipKeyUnlock, &owner_page[page].unlock_key},
+      {kOwnershipKeyActivate, &owner_page[page].activate_key},
+      {kOwnershipKeyRecovery, kNoOwnerRecoveryKey},
+      {0, &owner_page[page].owner_key},
+  };
+  for (size_t i = 0; i < ARRAYSIZE(keys); ++i) {
+    if (keys[i].key != NULL && (key & keys[i].mask) == keys[i].mask) {
+      if (owner_verify(key_alg, keys[i].key, ecdsa, spx, NULL, 0, NULL, 0,
+                       message, len, &digest, flash_exec) == kErrorOk) {
+        return kErrorOk;
+      }
     }
-  }
-  if ((key & kOwnershipKeyActivate) == kOwnershipKeyActivate) {
-    if (owner_verify(key_alg, &owner_page[page].activate_key, ecdsa, spx, NULL,
-                     0, NULL, 0, message, len, &digest,
-                     flash_exec) == kErrorOk) {
-      return kErrorOk;
-    }
-  }
-  if (kNoOwnerRecoveryKey &&
-      (key & kOwnershipKeyRecovery) == kOwnershipKeyRecovery) {
-    if (owner_verify(key_alg, kNoOwnerRecoveryKey, ecdsa, spx, NULL, 0, NULL, 0,
-                     message, len, &digest, flash_exec) == kErrorOk) {
-      return kErrorOk;
-    }
-  }
-  if (owner_verify(key_alg, &owner_page[page].owner_key, ecdsa, spx, NULL, 0,
-                   NULL, 0, message, len, &digest, flash_exec) == kErrorOk) {
-    return kErrorOk;
   }
   return kErrorOwnershipInvalidSignature;
 }

--- a/sw/device/silicon_creator/lib/ownership/ownership_key.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_key.c
@@ -33,13 +33,18 @@ const owner_detached_signature_t *ownership_signature_scan(
     return NULL;
   length -= sizeof(owner_detached_signature_t);
   uintptr_t end = start + length;
+  // The nonce in the detached signature is not cryptographically bound. It is
+  // merely a token to uniquely identify a detached signature block and not
+  // confuse it with any other block that may be left over in flash. We'll
+  // allow a nonce of zero as a wildcard to match any detached signature block.
+  const nonce_t zero = {0};
   while (start < end) {
     const owner_detached_signature_t *sig =
         (const owner_detached_signature_t *)start;
     if (sig->header.tag == kTlvTagDetachedSignature &&
         sig->header.length == sizeof(owner_detached_signature_t) &&
         sig->header.version.major == 0 && sig->command == command &&
-        nonce_equal(&sig->nonce, nonce)) {
+        (nonce_equal(&sig->nonce, &zero) || nonce_equal(&sig->nonce, nonce))) {
       return sig;
     }
     start += FLASH_CTRL_PARAM_BYTES_PER_PAGE;

--- a/sw/device/silicon_creator/lib/ownership/ownership_key.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_key.c
@@ -11,13 +11,11 @@
 #include "sw/device/silicon_creator/lib/drivers/keymgr.h"
 #include "sw/device/silicon_creator/lib/drivers/kmac.h"
 #include "sw/device/silicon_creator/lib/nonce.h"
+#include "sw/device/silicon_creator/lib/ownership/owner_block.h"
 #include "sw/device/silicon_creator/lib/ownership/owner_verify.h"
 
 #include "flash_ctrl_regs.h"
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-
-// RAM copy of the owner INFO pages from flash.
-extern owner_block_t owner_page[2];
 
 OT_WEAK const owner_keydata_t *const kNoOwnerRecoveryKey;
 
@@ -258,4 +256,14 @@ rom_error_t ownership_history_get(hmac_digest_t *history) {
   secret_page_enable(/*read=*/kMultiBitBool4False,
                      /*write=*/kMultiBitBool4False);
   return error;
+}
+
+rom_error_t ownership_secret_update(boot_data_t *bootdata) {
+  uint32_t prior_key_alg = owner_page[0].ownership_key_alg;
+  const owner_keydata_t *prior_owner_key = &owner_page[0].owner_key;
+  HARDENED_RETURN_IF_ERROR(
+      ownership_secret_new(prior_key_alg, prior_owner_key));
+  bootdata->ownership_transfers += 1;
+
+  return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/ownership/ownership_key.h
+++ b/sw/device/silicon_creator/lib/ownership/ownership_key.h
@@ -7,6 +7,7 @@
 
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/silicon_creator/lib/boot_data.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/ownership/datatypes.h"
@@ -111,5 +112,14 @@ rom_error_t ownership_secret_new(uint32_t prior_key_alg,
  * @return Success or error code.
  */
 rom_error_t ownership_history_get(hmac_digest_t *history);
+
+/**
+ * Update the owner secret and transfer counter in bootdata if a transfer has
+ * occurred.
+ *
+ * @param bootdata The current bootdata.
+ * @return Success or error code.
+ */
+rom_error_t ownership_secret_update(boot_data_t *bootdata);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_OWNERSHIP_KEY_H_

--- a/sw/device/silicon_creator/lib/ownership/ownership_unlock.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_unlock.c
@@ -74,7 +74,8 @@ static rom_error_t unlock(boot_svc_msg_t *msg, boot_data_t *bootdata) {
     uint32_t flash_exec = 0;
     switch (owner_page[0].update_mode) {
       case kOwnershipUpdateModeOpen:
-        // The Open mode allows unlock to any unlock state.
+      case kOwnershipUpdateModeAnyVersion:
+        // The Open and AnyVersion modes allow unlock to any unlock state.
         break;
       case kOwnershipUpdateModeNewVersion:
         // The NewVersion mode forbids all unlocks.
@@ -125,6 +126,7 @@ static rom_error_t unlock_update(boot_svc_msg_t *msg, boot_data_t *bootdata) {
       case kOwnershipUpdateModeSelf:
       case kOwnershipUpdateModeSelfVersion:
       case kOwnershipUpdateModeOpen:
+      case kOwnershipUpdateModeAnyVersion:
       default:
           // The `unlock_update` funciton services UnlockUpdate update requests,
           // which are valid for the `Open` and `Self` modes.

--- a/sw/device/silicon_creator/lib/ownership/test_owner.c
+++ b/sw/device/silicon_creator/lib/ownership/test_owner.c
@@ -353,6 +353,11 @@ rom_error_t sku_creator_owner_init(boot_data_t *bootdata) {
   // thunk the ownership state to LockedOwner.
   bootdata->ownership_state = TEST_OWNERSHIP_STATE;
 
+  // Set the nonce to something other than zero to test wildcard match for the
+  // detached signature.
+  bootdata->nonce.value[0] = 0xdeadbeef;
+  bootdata->nonce.value[1] = 0x12345678;
+
   // Write the configuration to both owner page 0.  The next boot of the ROM_EXT
   // will make a redundant copyh in page 1.
   OT_DISCARD(flash_ctrl_info_erase(&kFlashCtrlInfoPageOwnerSlot0,

--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -91,6 +91,11 @@ TEST_OWNER_CONFIGS = {
         "owner_defines": ["TEST_OWNER_UPDATE_MODE=kOwnershipUpdateModeNewVersion"],
         "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_xmodem"],
     },
+    "owner_update_anyversion": {
+        # Enable the AnyVersion update mode of ownership.
+        "owner_defines": ["TEST_OWNER_UPDATE_MODE=kOwnershipUpdateModeAnyVersion"],
+        "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_xmodem"],
+    },
     "owner_sram_exec_enabled": {
         "owner_defines": [
             "TEST_OWNER_SRAM_EXEC_MODE=kOwnerSramExecModeEnabled",

--- a/sw/device/silicon_creator/rom_ext/doc/ownership.md
+++ b/sw/device/silicon_creator/rom_ext/doc/ownership.md
@@ -85,7 +85,7 @@ These update modes are motivated by two scenarios:
 - The Unlock Key is a very powerful key and owners may want to attenuate the power of the unlock key to mitigate the risk of the key leaking.
 - An owner may want to provide a configuration update for devices in the field that does not require the unlock and activate procedure.
 
-The update mode provides for four types of owner configuration update procedures:
+The update mode provides for five types of owner configuration update procedures:
 
 - `Open` mode allows the unlock key to unlock the device into any of the unlocked states.
 - `Self` mode allows the unlock key to unlock the device into only the `UnlockedSelf` state.
@@ -93,6 +93,10 @@ The update mode provides for four types of owner configuration update procedures
   Instead, the device may accept an ownership configuration update at any time _if and only if_ the new configuration is signed by the self-same owner _and_ the configuration has a newer `config_version` number.
 - `SelfVersion` is a combination of the `Self` and `NewVersion` modes.
   Instead, the device may accept an ownership configuration update at any time _if and only if_ the new configuration is signed by the self-same owner _and_ the configuration has a newer `config_version` number.  The device will _also_ allow the unlock key to unlock the device into the `UnlockedSelf` state.  When in the `UnlockedSelf` state, the device can accept a configuration that would move the `config_version` backwards.
+- `AnyVersion` mode allows the device to accept an ownership configuration update or transfer directly in the `LockedOwner` state.
+  - If the new configuration is signed by the self-same owner, it must have a newer `config_version` (same as `NewVersion`).
+  - If the new configuration is signed by a different owner (i.e., a transfer), it is accepted unconditionally without needing to match the prior owner key or a newer `config_version`, performing a direct in-place transfer of ownership.
+  - The unlock key is still permitted to unlock the device to any unlocked state (same as `Open` mode).
 
 When the update mode is `Self`, `NewVersion` or `SelfVersion`, the power of the unlock key is reduced to only allow ownership operations that do not change the owner.
 
@@ -394,6 +398,63 @@ subgraph container["<font size=6>Flow: Endorsed Ownership Transfer</font>"]
 end
 ```
 
+### Direct Ownership Transfer
+
+A direct ownership transfer allows ownership of the chip to be transferred to a new owner directly in the `LockedOwner` state without utilizing the Boot Services unlock and activate procedure. This flow is only possible if the current owner has previously configured the update mode of the chip to `AnyVersion`.
+
+1. The current owner delivers the chip (device) to the next owner.
+2. The next owner prepares a new Owner Configuration signed with the next owner's key.
+3. The next owner writes this new Owner Configuration directly into Owner Page 1, then reboots the chip.
+4. Upon booting, the ROM_EXT detects that Owner Page 1 has a valid signed configuration and that the owner key has changed.
+5. Since the current update mode is `AnyVersion`, the ROM_EXT automatically accepts the new configuration:
+   - It validates and seals the new configuration in Owner Page 1.
+   - It regenerates the Owner Secret seed and increments the `ownership_transfers` counter in `boot_data`.
+   - It invalidates Owner Page 0 and schedules a reboot to finalize the transfer.
+6. Upon reboot, the ROM_EXT copies the newly sealed configuration from Owner Page 1 to Owner Page 0, establishing a redundant backup of the new configuration.
+7. The chip is now locked to the next owner and will boot application firmware signed with the new owner's keys.
+
+```mermaid
+flowchart LR
+subgraph container["<font size=6>Flow: Direct Ownership Transfer</font>"]
+    subgraph flow[" "]
+        direction TB
+        start((<b>Start</b>))
+        deliver((Deliver to next owner.))
+        write[<b>Write Owner Config</b>
+            Store new Owner Config in Owner Page 1.
+            Reboot.
+        ]
+        process[<b>ROM_EXT Processing</b>
+            Validate & seal Owner Page 1.
+            Update Owner Secret & transfers counter.
+            Invalidate Owner Page 0.
+            Reboot.
+        ]
+        restore[<b>ROM_EXT Redundancy Restore</b>
+            Copy sealed Owner Config from Page 1 to Page 0.
+        ]
+        done((<b>Done</b>))
+        start --> deliver
+        deliver --> write
+        write --> process
+        process --> restore
+        restore --> done((<b>Done</b>))
+    end
+
+    signing[
+        <span style="color:black"><b>Signing Service</b>
+        Next Owner
+        </span>
+    ]
+
+    write <-- "Sign Owner Config with Next Owner Key" --> signing
+
+    style flow fill:none,stroke:none
+    style signing fill:#aee,stroke:#6cc
+    style container fill:none,stroke:black
+end
+```
+
 ## Boot Services Commands
 
 All ownership operations are facilitated by boot services commands to the ROM\_EXT.
@@ -558,7 +619,7 @@ typedef struct owner_block {
   uint32_t sram_exec_mode;
   /** Ownership key algorithm (currently, only ECDSA is supported). */
   uint32_t ownership_key_alg;
-  /** Ownership update mode (one of OPEN, SELF, NEWV) */
+  /** Ownership update mode (one of OPEN, SELF, NEWV, SELV, ANYV) */
   uint32_t update_mode;
   /** Set the minimum security version to this value (UINT32_MAX: no change) */
   uint32_t min_security_version_bl0;

--- a/sw/device/silicon_creator/rom_ext/doc/ownership.md
+++ b/sw/device/silicon_creator/rom_ext/doc/ownership.md
@@ -108,6 +108,8 @@ All ownership-related boot services commands include the nonce and a signature b
 Each successful ownership-related boot services request (ie: `OwnershipUnlock` and `OwnershipActivate`) will cause a new nonce to be generated
 Any subsequent ownership-related request must use the new nonce value.
 
+To support offline or pre-calculated detached signatures, the nonce in the detached signature block may be set to zero (`0`). A nonce of zero acts as a wildcard, allowing the detached signature block to be verified against any current challenge nonce. Since the nonce in a detached signature block is not cryptographically bound (and the signature itself remains cryptographically bound to the original message or block), this does not impact the security posture. Instead, the nonce field in a detached signature is primarily used as a token to uniquely identify and locate a specific detached signature block when multiple signatures are stored in flash, avoiding confusion with older leftover signatures.
+
 The ownership nonce is stored in the `boot_data` record.
 
 ### Owner Key

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -812,6 +812,124 @@ ownership_transfer_test(
 )
 
 ownership_transfer_test(
+    name = "anyversion_update_test",
+    ecdsa_key = {
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
+    },
+    shared_params = {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_anyversion",
+        "test_cmd": """
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
+            --next-application-key=sw/device/silicon_creator/lib/ownership/keys/fake/app_prod_ecdsa_p256.pub.der
+            --config-version=2
+            # We expect to see the version updated, the owner key the same, and transfers = 0.
+            --expect "config_version = 2"
+            --expect "owner_key = 8e3dcb50"
+            --expect "ownership_transfers = 0"
+        """,
+        "test_harness": "//sw/host/tests/ownership:newversion_test",
+    },
+)
+
+ownership_transfer_test(
+    name = "anyversion_update_fails_test",
+    ecdsa_key = {
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
+    },
+    shared_params = {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_anyversion",
+        "test_cmd": """
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
+            --next-application-key=sw/device/silicon_creator/lib/ownership/keys/fake/app_prod_ecdsa_p256.pub.der
+            --config-version=0
+            # We expect the update to fail (since version 0 is not greater than current 1),
+            # so config_version must remain 1.
+            --expect "config_version = 1"
+            --expect "ownership_transfers = 0"
+        """,
+        "test_harness": "//sw/host/tests/ownership:newversion_test",
+    },
+)
+
+ownership_transfer_test(
+    name = "anyversion_transfer_test",
+    ecdsa_key = {
+        "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
+    },
+    shared_params = {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_anyversion",
+        "test_cmd": """
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
+            --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
+            --config-version=0
+            # We expect to see the version is 0 (transfer under AnyVersion doesn't require newer version),
+            # the owner key is the dummy key (665ff5e3), and transfers = 1.
+            --expect "config_version = 0"
+            --expect "owner_key = 665ff5e3"
+            --expect "ownership_transfers = 1"
+        """,
+        "test_harness": "//sw/host/tests/ownership:newversion_test",
+    },
+)
+
+ownership_transfer_test(
+    name = "anyversion_unlock_update_test",
+    ecdsa_key = {
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
+    },
+    shared_params = {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_anyversion",
+        "test_cmd": """
+            --unlock-mode=Update
+            --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
+            --next-application-key=sw/device/silicon_creator/lib/ownership/keys/fake/app_prod_ecdsa_p256.pub.der
+            --non-transfer-update=true
+        """,
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
+)
+
+ownership_transfer_test(
+    name = "anyversion_unlock_transfer_test",
+    ecdsa_key = {
+        "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
+    },
+    shared_params = {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_anyversion",
+        "test_cmd": """
+            --unlock-mode=Any
+            --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
+            --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
+        """,
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
+)
+
+ownership_transfer_test(
     name = "newversion_badlock_test",
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -930,6 +930,34 @@ ownership_transfer_test(
 )
 
 ownership_transfer_test(
+    name = "anyversion_wildcard_nonce_test",
+    ecdsa_key = {
+        "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
+    },
+    shared_params = {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_anyversion",
+        "test_cmd": """
+            --next-key-alg=HybridSpxPure
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
+            --next-owner-key-spx=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key_spx)
+            --next-unlock-key-spx=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:unlock_key_spx)
+            --next-activate-key-spx=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key_spx)
+            --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
+            --config-version=0
+            --use-zero-nonce
+            # We expect the transfer to successfully complete using the zero wildcard nonce,
+            # so the owner key is the dummy key (665ff5e3), and transfers = 1.
+            --expect "config_version = 0"
+            --expect "owner_key = 665ff5e3"
+            --expect "ownership_transfers = 1"
+        """,
+        "test_harness": "//sw/host/tests/ownership:newversion_test",
+    },
+)
+
+ownership_transfer_test(
     name = "newversion_badlock_test",
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_services_unittest.cc
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_services_unittest.cc
@@ -582,7 +582,7 @@ TEST_F(RomExtBootServicesTest, BootSvcOwnershipActivate) {
       .WillOnce(Return(kErrorOk));
 
   if (boot_data.ownership_state != kOwnershipStateUnlockedSelf) {
-    EXPECT_CALL(mock_ownership_key_, secret_new(_, _))
+    EXPECT_CALL(mock_ownership_key_, secret_update(&boot_data))
         .WillOnce(Return(kErrorOk));
   }
 

--- a/sw/host/tests/ownership/newversion_test.rs
+++ b/sw/host/tests/ownership/newversion_test.rs
@@ -59,6 +59,9 @@ struct Opts {
     )]
     config_version: u32,
 
+    #[arg(long, help = "Use zero nonce for detached signature")]
+    use_zero_nonce: bool,
+
     #[arg(
         long,
         help = "Lock the owner config to the device identification number"
@@ -88,11 +91,17 @@ fn newversion_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     rescue.enter(transport, EntryMode::Reset)?;
     let (data, devid) = transfer_lib::get_device_info(transport, &rescue)?;
 
+    let nonce = if opts.use_zero_nonce {
+        0
+    } else {
+        data.rom_ext_nonce
+    };
+
     log::info!("###### Upload Owner Block ######");
     transfer_lib::create_owner(
         transport,
         &rescue,
-        data.rom_ext_nonce,
+        nonce,
         opts.next_key_alg,
         HybridPair::load(
             opts.next_owner_key.as_deref(),


### PR DESCRIPTION
This change introduces the AnyVersion update mode.

In this mode:
- An owner block update is valid if the owner key matches and the new configuration version is strictly greater than the current version.
- An owner block update is also valid if the owner key does not match (representing a transfer), without requiring a greater configuration version.
- If a transfer is performed, replace the owner secret with new entropy, and the ownership transfers counter in boot data is incremented.
- Similar to Open mode, AnyVersion mode permits unlocking the device to any unlock state.

Additionally, this change:
-  Refactor key validation and slot activation for code size reduction
- Extracts the shared owner secret regeneration and transfer counter increment logic from `ownership.c` and `ownership_activate.c` into a unified helper `ownership_secret_update` in `ownership_key.c`.
- Adds end-to-end tests to verify direct update logic, invalid version updates, and successful direct transfers.
- Adds end-to-end tests to verify the `unlock -> update-> activate` flow for both configuration updates and transfers under `AnyVersion` mode.
- Documents the new `AnyVersion` mode and direct ownership transfer flow in the ROM_EXT ownership documentation.
- Updates `ownership_signature_scan` to accept a zero nonce when searching for detached signatures. 