### PR TITLE
[earlgrey,doc] Remove mention of generic mode in spi_device

### DIFF
--- a/hw/top_earlgrey/doc/datasheet.md
+++ b/hw/top_earlgrey/doc/datasheet.md
@@ -81,7 +81,7 @@ The OpenTitan Earl Grey chip provides the following features:
             <li>32x GPIO (using multiplexable IO)</li>
             <li>4x UART (using multiplexable IO)</li>
             <li>3x I2C with host and device modes (using multiplexable IO)</li>
-            <li>SPI device (using fixed IO) with TPM, generic, flash and passthrough modes</li>
+            <li>SPI device (using fixed IO) with TPM, flash and passthrough modes</li>
             <li>2x SPI host (using both fixed and multiplexable IO)</li>
             <li>USB device at full speed</li>
           </ul>


### PR DESCRIPTION
This has been removed from the block and commit f28b7134094 was supposed to remove the last mention of the mode. We left one!