### PR TITLE
[crypto/25519] Add comments

### DIFF
--- a/sw/otbn/crypto/25519.s
+++ b/sw/otbn/crypto/25519.s
@@ -17,7 +17,7 @@
 .globl ext_add
 .globl ext_to_affine
 .globl ext_is_on_curve
-.globl X25519
+.globl x25519
 
 /**
  * This library contains an implementation of the Ed25519 signature scheme
@@ -1941,7 +1941,7 @@ trigger_fault_if_fg0_not_z:
   ret
 
 /**
- * Check that the X25519 public key u is valid for the Montgomery-to-Edwards map.
+ * Check that the x25519 public key u is valid for the Montgomery-to-Edwards map.
  *
  * The Montgomery-to-Edwards conversion y = (u-1)/(u+1) has a zero denominator
  * at u = p-1. fe_inv(0) = 0, so the conversion silently produces y = 0,
@@ -2019,7 +2019,7 @@ x25519_ed_y_to_mont_u:
   ret
 
 /**
- * Top-level X25519 function using Twisted Edwards scalar multiplication.
+ * Top-level x25519 function using Twisted Edwards scalar multiplication.
  *
  * This routine saves instruction memory by reusing the Ed25519 point arithmetic.
  * It maps the Montgomery u-coordinate to a Twisted Edwards y-coordinate,
@@ -2027,14 +2027,14 @@ x25519_ed_y_to_mont_u:
  *
  * @param[in]  w8: scalar (private key, already clamped by host CPU)
  * @param[in]  w9: Montgomery u-coordinate (public key or base point 9)
- * @param[out] w22: result, X25519(k, u) as an encoded u-coordinate
+ * @param[out] w22: result, x25519(k, u) as an encoded u-coordinate
  * @param[out] x20: SUCCESS if the public key decoding passed,
  *                  FAILURE if the public key decoding failed
  *
  * clobbered registers: x2, x3, x21, w2, w6 to w30
  * clobbered flag groups: FG0
  */
-X25519:
+x25519:
   /* Initialize field arithmetic (MOD <= p, w19 <= 19) */
   jal      x1, fe_init
   bn.xor   w31, w31, w31

--- a/sw/otbn/crypto/25519_scalar.s
+++ b/sw/otbn/crypto/25519_scalar.s
@@ -328,19 +328,19 @@ sc_mul:
   ret
 
 /**
- * Blind a scalar with a multiple of the curve order L.
+ * Blind a scalar with a multiple of the point order 8 * L (considering points out of the main curve).
  *
- * Given a scalar s < L, this routine adds a random multiple of the group order
- * 8 * k * L to the scalar such that s + 8 * k * L. We left shift k * L (multiply by 8) in order to clamp the blinding factor.
+ * Given a scalar s < L, this routine adds a random multiple of the point order
+ * k * 8 * L to the scalar such that s + k * 8 * L.
  * In accordance, with Schindler's and Wiemers' recommendation [1] the blinding factor k is 128 bits. Since the
  * curve order L is 253 bits, by choosing a 128-bit factor k we can guarantee
- * that the blinded scalar s + 8 * k * L is at most 385 bits.
+ * that the blinded scalar s + k * 8 * L is at most 385 bits.
  *
  * [1] https://csrc.nist.gov/csrc/media/events/workshop-on-elliptic-curve-cryptography-standards/documents/papers/session6-schindler-werner.pdf
  *
- * @param[in] w20: s, the scalar to be blinded (s < L).
+ * @param[in] w20: s, the scalar to be blinded.
  * @param[in] w31: all-zero.
- * @param[out] [w17:w16]: The blinded scalar s + k * L.
+ * @param[out] [w17:w16]: The blinded scalar s + k * 8 * L.
  *
  * Clobbered registers: x2, x3, w21, w22, w23.
  * Clobbered flag groups: FG0.
@@ -368,15 +368,16 @@ sc_blind:
   bn.mulqacc.so  w16.U, w21.3, w22.0, 64
   bn.mulqacc.wo  w17,   w21.3, w22.1, 0
 
+  /* Left shift the result to calculate 8 * k * L */
   /* w17 = (w17 << 3) | (w16 >> 253) */
   bn.rshi w17, w17, w16 >> 253
 
   /* w16 = (w16 << 3) | (0 >> 253) */
   bn.rshi w16, w16, w31 >> 253
 
-  /* Add the 381-bit blinding value to the 253-bit scalar resulting in a
-     382-bit blinded scalar avoiding any overflow.
-       [w17:w16] <= [w17:w16] + w20 = k * L + s. */
+  /* Add the 384-bit blinding value to the 253-bit scalar resulting in a
+     385-bit blinded scalar avoiding any overflow.
+       [w17:w16] <= [w17:w16] + w20 = k * 8 * L + s. */
   bn.add w16, w16, w20
   bn.addc w17, w17, w31
 

--- a/sw/otbn/crypto/field25519.s
+++ b/sw/otbn/crypto/field25519.s
@@ -9,7 +9,7 @@
 
 /**
  * This library contains arithmetic for the finite field modulo the prime
- * p = 2^255-19, which is used for both the X25519 key exchange and the Ed25519
+ * p = 2^255-19, which is used for both the x25519 key exchange and the Ed25519
  * signature scheme.
  */
 

--- a/sw/otbn/crypto/run_curve25519.s
+++ b/sw/otbn/crypto/run_curve25519.s
@@ -3,7 +3,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /**
- * Entrypoint for 25519 ECDH (X25519) and EdDSA (ed25519) operations.
+ * Entrypoint for 25519 ECDH (x25519) and EdDSA (ed25519) operations.
  *
  * This binary has the following modes of operation:
  * 1. MODE_SIGN_PART1: generate a new keypair
@@ -52,28 +52,28 @@ start:
   lw    x2, 0(x2)
 
   addi  x3, x0, MODE_KEYGEN
-  beq   x2, x3, ed25519_keygen
+  beq   x2, x3, run_ed25519_keygen
 
   addi  x3, x0, MODE_SIGN_STAGE1
-  beq   x2, x3, ed25519_sign_compute_r
+  beq   x2, x3, run_ed25519_sign_compute_r
 
   addi  x3, x0, MODE_SIGN_STAGE2
-  beq   x2, x3, ed25519_sign_compute_s
+  beq   x2, x3, run_ed25519_sign_compute_s
 
   addi  x3, x0, MODE_VERIFY
-  beq   x2, x3, ed25519_verify
+  beq   x2, x3, run_ed25519_verify
 
   addi  x3, x0, MODE_X25519
-  beq   x2, x3, x25519
+  beq   x2, x3, run_x25519
 
   addi  x3, x0, MODE_X25519_KEYGEN
-  beq   x2, x3, x25519_keygen
+  beq   x2, x3, run_x25519_keygen
 
   addi  x3, x0, MODE_X25519_SIDELOAD
-  beq   x2, x3, x25519_sideload
+  beq   x2, x3, run_x25519_sideload
 
   addi  x3, x0, MODE_X25519_KEYGEN_SIDELOAD
-  beq   x2, x3, x25519_keygen_sideload
+  beq   x2, x3, run_x25519_keygen_sideload
 
   /* Invalid mode; fail. */
   unimp
@@ -91,7 +91,7 @@ start:
  * clobbered registers: x2 to x3, w2 to w31
  * clobbered flag groups: FG0
  */
-ed25519_keygen:
+run_ed25519_keygen:
   /* Zeroize w31 */
   bn.xor   w31, w31, w31
 
@@ -119,7 +119,7 @@ ed25519_keygen:
  * clobbered registers: x2 to x3, w2 to w31
  * clobbered flag groups: FG0
  */
-ed25519_sign_compute_r:
+run_ed25519_sign_compute_r:
   /* Zeroize w31 */
   bn.xor   w31, w31, w31
 
@@ -142,7 +142,7 @@ ed25519_sign_compute_r:
  * clobbered registers: x2 to x4, x20 to x23, w2 to w31
  * clobbered flag groups: FG0
  */
-ed25519_sign_compute_s:
+run_ed25519_sign_compute_s:
   /* Zeroize w31 */
   bn.xor   w31, w31, w31
 
@@ -165,7 +165,7 @@ ed25519_sign_compute_s:
  * clobbered registers: x2 to x4, x20 to x23, w2 to w31
  * clobbered flag groups: FG0
  */
-ed25519_verify:
+run_ed25519_verify:
   /* Zeroize w31 */
   bn.xor   w31, w31, w31
 
@@ -174,7 +174,22 @@ ed25519_verify:
 
   ecall
 
-x25519:
+/**
+ * X25519 shared secret generation operation.
+ * Generates the shared secret given a memory-provided private key and peer's public key.
+ *
+ * Returns SUCCESS or FAILURE in x20, and the encoded shared key point.
+ *
+ * @param[in]  dmem[ed25519_s0]: private key share 0, 256 bits
+ * @param[in]  dmem[ed25519_s1]: private key share 1, 256 bits
+ * @param[in]  dmem[x25519_public_key]: peer's public key (u-coordinate), 256 bits
+ * @param[out] dmem[x25519_shared_key]: computed shared secret, 256 bits
+ * @param[out] dmem[x25519_ok]: SUCCESS or FAILURE code
+ *
+ * clobbered registers: x2 to x3, x20, w2 to w31
+ * clobbered flag groups: FG0
+ */
+run_x25519:
   /* Zeroize w31 */
   bn.xor   w31, w31, w31
 
@@ -235,8 +250,8 @@ x25519:
   la       x3, x25519_public_key
   bn.lid   x2, 0(x3)
 
-  /* Call Edwards-mapped X25519 */
-  jal      x1, X25519
+  /* Call Edwards-mapped x25519 */
+  jal      x1, x25519
 
   /* Store result status (SUCCESS or FAILURE) from x20. */
   la       x3, x25519_ok
@@ -249,7 +264,20 @@ x25519:
 
   ecall
 
-x25519_keygen:
+/**
+ * X25519 key generation operation.
+ * Generates the public key given a memory-provided private key.
+ *
+ * Returns the encoded public key point.
+ *
+ * @param[in]  dmem[ed25519_s0]: private key share 0, 256 bits
+ * @param[in]  dmem[ed25519_s1]: private key share 1, 256 bits
+ * @param[out] dmem[x25519_public_key]: generated public key (u-coordinate), 256 bits
+ *
+ * clobbered registers: x2 to x3, x20, w2 to w31
+ * clobbered flag groups: FG0
+ */
+run_x25519_keygen:
   /* Zeroize w31 */
   bn.xor   w31, w31, w31
 
@@ -308,7 +336,7 @@ x25519_keygen:
   /* Set Curve25519 basepoint */
   bn.addi  w9, w31, 9
 
-  jal      x1, X25519
+  jal      x1, x25519
 
   /* Store public key from w22 */
   li       x2, 22
@@ -317,7 +345,22 @@ x25519_keygen:
 
   ecall
 
-x25519_sideload:
+/**
+ * X25519 shared secret generation operation (sideloaded key).
+ * Generates the shared secret using a sideloaded private key from the hardware key manager.
+ *
+ * Returns SUCCESS or FAILURE in x20, and the encoded shared key point.
+ *
+ * @param[in]  KEY_S0_L: hardware-sideloaded private key share 0, 256 bits
+ * @param[in]  KEY_S1_L: hardware-sideloaded private key share 1, 256 bits
+ * @param[in]  dmem[x25519_public_key]: peer's public key (u-coordinate), 256 bits
+ * @param[out] dmem[x25519_shared_key]: computed shared secret, 256 bits
+ * @param[out] dmem[x25519_ok]: SUCCESS or FAILURE code
+ *
+ * clobbered registers: x2 to x3, x20, w2 to w31
+ * clobbered flag groups: FG0
+ */
+run_x25519_sideload:
   /* Zeroize w31 */
   bn.xor   w31, w31, w31
 
@@ -358,7 +401,7 @@ x25519_sideload:
   la x3, x25519_public_key
   bn.lid x2, 0(x3)
 
-  jal x1, X25519
+  jal x1, x25519
 
   /* Store result status (SUCCESS or FAILURE) from x20. */
   la       x3, x25519_ok
@@ -371,7 +414,20 @@ x25519_sideload:
 
   ecall
 
-x25519_keygen_sideload:
+/**
+ * X25519 key generation operation (sideloaded key).
+ * Generates the public key using a sideloaded private key from the hardware key manager.
+ *
+ * Returns the encoded public key point.
+ *
+ * @param[in]  KEY_S0_L: hardware-sideloaded private key share 0, 256 bits
+ * @param[in]  KEY_S1_L: hardware-sideloaded private key share 1, 256 bits
+ * @param[out] dmem[x25519_public_key]: generated public key (u-coordinate), 256 bits
+ *
+ * clobbered registers: x2 to x3, x20, w2 to w31
+ * clobbered flag groups: FG0
+ */
+run_x25519_keygen_sideload:
   /* Zeroize w31 */
   bn.xor   w31, w31, w31
 
@@ -410,7 +466,7 @@ x25519_keygen_sideload:
   /* Set Curve25519 basepoint */
   bn.addi w9, w31, 9
 
-  jal x1, X25519
+  jal x1, x25519
 
   /* Store public key from w22 into DMEM */
   li x2, 22
@@ -485,13 +541,13 @@ ed25519_r0:
 ed25519_r1:
   .zero 96
 
-/* X25519 result status (SUCCESS=0x739 or FAILURE=0x1d4). Output for x25519. */
+/* x25519 result status (SUCCESS=0x739 or FAILURE=0x1d4). Output for x25519. */
 .balign 4
 .globl x25519_ok
 x25519_ok:
   .zero 4
 
-/* X25519 public key */
+/* x25519 public key */
 .balign 32
 .globl x25519_public_key
 x25519_public_key:

--- a/sw/otbn/crypto/tests/BUILD
+++ b/sw/otbn/crypto/tests/BUILD
@@ -1126,7 +1126,7 @@ otbn_consttime_test(
     secrets = [
         "w8",
     ],
-    subroutine = "X25519",
+    subroutine = "x25519",
     deps = [
         ":x25519_test",
     ],

--- a/sw/otbn/crypto/tests/x25519_test.s
+++ b/sw/otbn/crypto/tests/x25519_test.s
@@ -35,8 +35,8 @@ main:
   bn.mov  w2, w8
   bn.mov  w4, w31
 
-  /* w22 <= X25519(k, u) */
-  jal     x1, X25519
+  /* w22 <= x25519(k, u) */
+  jal     x1, x25519
 
   /* w20 <= expected result */
   li      x2, 20


### PR DESCRIPTION
Update the comments for x25519 in the OTBN code.
Rename the run_curve25519 symbols to make it clear which the symbols are for the wrapper and for the internal calls (previously we had x25519 and X25519).