### PR TITLE
[rv_timer,dv] Allow resets in rv_timer sequences

### DIFF
--- a/hw/ip/rv_timer/dv/env/rv_timer_env_cfg.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_env_cfg.sv
@@ -9,6 +9,9 @@ class rv_timer_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_timer_reg_block));
   virtual function void initialize();
     list_of_alerts = rv_timer_env_pkg::LIST_OF_ALERTS;
     super.initialize();
+
+    can_reset_with_csr_accesses = 1;
+
     // set num_interrupts
     num_interrupts = NUM_HARTS * NUM_TIMERS;
 


### PR DESCRIPTION
Honestly, I was expecting this not to work, but I just ran 64 seeds of rv_timer_stress_all_with_rand_reset and they all passed.

Looks like this takes less thought than I feared!