### PR TITLE
[doc] Move badge domain from dashboards to dashboard.reports

### DIFF
--- a/hw/ip/prim/README.md
+++ b/hw/ip/prim/README.md
@@ -1,30 +1,30 @@
 # lowRISC Hardware Primitives
 
 [`prim_alert`](https://reports.opentitan.org/hw/ip/prim/dv/prim_alert/latest/report.html):
-![](https://dashboards.lowrisc.org/badges/dv/prim_alert/test.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_alert/passing.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_alert/functional.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_alert/code.svg)<br>
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_alert/test.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_alert/passing.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_alert/functional.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_alert/code.svg)<br>
 [`prim_esc`](https://reports.opentitan.org/hw/ip/prim/dv/prim_esc/latest/report.html):
-![](https://dashboards.lowrisc.org/badges/dv/prim_esc/test.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_esc/passing.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_esc/functional.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_esc/code.svg)<br>
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_esc/test.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_esc/passing.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_esc/functional.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_esc/code.svg)<br>
 [`prim_lfsr`](https://reports.opentitan.org/hw/ip/prim/dv/prim_lfsr/latest/report.html):
-![](https://dashboards.lowrisc.org/badges/dv/prim_lfsr/test.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_lfsr/passing.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_lfsr/functional.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_lfsr/code.svg)<br>
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_lfsr/test.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_lfsr/passing.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_lfsr/functional.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_lfsr/code.svg)<br>
 [`prim_present`](https://reports.opentitan.org/hw/ip/prim/dv/prim_present/latest/report.html):
-![](https://dashboards.lowrisc.org/badges/dv/prim_present/test.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_present/passing.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_present/functional.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_present/code.svg)<br>
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_present/test.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_present/passing.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_present/functional.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_present/code.svg)<br>
 [`prim_prince`](https://reports.opentitan.org/hw/ip/prim/dv/prim_prince/latest/report.html):
-![](https://dashboards.lowrisc.org/badges/dv/prim_prince/test.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_prince/passing.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_prince/functional.svg)
-![](https://dashboards.lowrisc.org/badges/dv/prim_prince/code.svg)<br>
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_prince/test.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_prince/passing.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_prince/functional.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/prim_prince/code.svg)<br>
 
 ## Concepts
 

--- a/hw/ip_templates/rv_core_ibex/README.md
+++ b/hw/ip_templates/rv_core_ibex/README.md
@@ -1,10 +1,10 @@
 # Ibex RISC-V Core Wrapper Technical Specification
 
 [`rv_core_ibex`](https://ibex.reports.lowrisc.org/opentitan/latest/report.html):
-![](https://dashboards.lowrisc.org/badges/dv/ibex/opentitan/test.svg)
-![](https://dashboards.lowrisc.org/badges/dv/ibex/opentitan/passing.svg)
-![](https://dashboards.lowrisc.org/badges/dv/ibex/opentitan/functional.svg)
-![](https://dashboards.lowrisc.org/badges/dv/ibex/opentitan/code.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/ibex/opentitan/test.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/ibex/opentitan/passing.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/ibex/opentitan/functional.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/ibex/opentitan/code.svg)
 
 # Overview
 

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/README.md
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/README.md
@@ -1,10 +1,10 @@
 # Ibex RISC-V Core Wrapper Technical Specification
 
 [`rv_core_ibex`](https://ibex.reports.lowrisc.org/opentitan/latest/report.html):
-![](https://dashboards.lowrisc.org/badges/dv/ibex/opentitan/test.svg)
-![](https://dashboards.lowrisc.org/badges/dv/ibex/opentitan/passing.svg)
-![](https://dashboards.lowrisc.org/badges/dv/ibex/opentitan/functional.svg)
-![](https://dashboards.lowrisc.org/badges/dv/ibex/opentitan/code.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/ibex/opentitan/test.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/ibex/opentitan/passing.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/ibex/opentitan/functional.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/ibex/opentitan/code.svg)
 
 # Overview
 

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/README.md
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/README.md
@@ -1,10 +1,10 @@
 # Ibex RISC-V Core Wrapper Technical Specification
 
 [`rv_core_ibex`](https://ibex.reports.lowrisc.org/opentitan/latest/report.html):
-![](https://dashboards.lowrisc.org/badges/dv/ibex/opentitan/test.svg)
-![](https://dashboards.lowrisc.org/badges/dv/ibex/opentitan/passing.svg)
-![](https://dashboards.lowrisc.org/badges/dv/ibex/opentitan/functional.svg)
-![](https://dashboards.lowrisc.org/badges/dv/ibex/opentitan/code.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/ibex/opentitan/test.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/ibex/opentitan/passing.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/ibex/opentitan/functional.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/ibex/opentitan/code.svg)
 
 # Overview
 

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/README.md
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/README.md
@@ -1,10 +1,10 @@
 # Ibex RISC-V Core Wrapper Technical Specification
 
 [`rv_core_ibex`](https://ibex.reports.lowrisc.org/opentitan/latest/report.html):
-![](https://dashboards.lowrisc.org/badges/dv/ibex/opentitan/test.svg)
-![](https://dashboards.lowrisc.org/badges/dv/ibex/opentitan/passing.svg)
-![](https://dashboards.lowrisc.org/badges/dv/ibex/opentitan/functional.svg)
-![](https://dashboards.lowrisc.org/badges/dv/ibex/opentitan/code.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/ibex/opentitan/test.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/ibex/opentitan/passing.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/ibex/opentitan/functional.svg)
+![](https://dashboard.reports.lowrisc.org/badges/dv/ibex/opentitan/code.svg)
 
 # Overview
 


### PR DESCRIPTION
Soon badges will be migrating from the `dashboards.lowrisc.org` domain to the `dashboard.reports.lowrisc.org`. For now they exist in both but to get ahead of the migration it makes sense to change them.

The same path has been kept because there are no top-specific paths for the badges (`prim` & `rv_ibex_core`) used in either domain, so its a pretty basic change to keep everything as it is now.
