### PR TITLE
Partial Backport of 28552 (Refactor FPGA test_cmd setup/cleanup boilerplate)

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -9,6 +9,7 @@ load(
 )
 load(
     "//rules/opentitan:defs.bzl",
+    "CLEAR_TEST_CMD",
     "DEFAULT_TEST_FAILURE_MSG",
     "DEFAULT_TEST_SUCCESS_MSG",
     "fpga_cw305",
@@ -120,6 +121,7 @@ fpga_cw340(
         "--rcfile=",
         "--logging=info",
         "--interface={interface}",
+        "--drop-reset",
     ] + select({
         "//ci:lowrisc_fpga_cw340": [
             "--uarts=/dev/ttyACM_CW340_1,/dev/ttyACM_CW340_0",
@@ -156,14 +158,11 @@ fpga_cw340(
     exec_env = "fpga_cw340_test_rom",
     mmi = "//hw/bitstream/cw340:mmi",
     otp = "//hw/top_earlgrey/data/otp:img_rma",
+    param = {
+        "testopt_bootstrap": "True",
+    },
     rom = "//sw/device/lib/testing/test_rom:test_rom",
-    test_cmd = """
-        --exec="transport init"
-        --exec="fpga load-bitstream {bitstream}"
-        --exec="bootstrap --clear-uart=true {firmware}"
-        --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-        no-op
-    """,
+    test_cmd = CLEAR_TEST_CMD,
 )
 
 fpga_cw340(
@@ -176,14 +175,11 @@ fpga_cw340(
     manifest = "//sw/device/silicon_creator/rom_ext:manifest",
     mmi = "//hw/bitstream/cw340:mmi",
     otp = "//hw/top_earlgrey/data/otp:img_rma",
+    param = {
+        "testopt_bootstrap": "True",
+    },
     rom = "//sw/device/silicon_creator/rom:mask_rom",
-    test_cmd = """
-        --exec="transport init"
-        --exec="fpga load-bitstream {bitstream}"
-        --exec="bootstrap --clear-uart=true {firmware}"
-        --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-        no-op
-    """,
+    test_cmd = CLEAR_TEST_CMD,
 )
 
 fpga_cw340(
@@ -205,9 +201,6 @@ fpga_cw340(
     manifest = "//sw/device/silicon_owner:manifest",
     otp = "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_rma",
     param = {
-        "interface": "hyper340",
-        "exit_success": DEFAULT_TEST_SUCCESS_MSG,
-        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
         "assemble": "{rom_ext}@{rom_ext_slot_a} {firmware}@{owner_slot_a}",
     },
     rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",

--- a/rules/opentitan/fpga.bzl
+++ b/rules/opentitan/fpga.bzl
@@ -27,12 +27,23 @@ load(
 )
 load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
 
+_TEST_COMMANDS = """
+TEST_SETUP_CMD=({test_setup_cmd})
+TEST_CMD=({test_cmd})
+TEST_CLEANUP_CMD=({test_cleanup_cmd})
+POST_TEST_CMD=({post_test_cmd})
+"""
+
 _TEST_SCRIPT = """#!/bin/bash
 set -e
 
+{test_commands}
+
+export RUST_BACKTRACE=1
+
 function cleanup {{
-  echo "cleanup: {post_test_harness} {post_test_cmd}"
-  {post_test_harness} {post_test_cmd}
+  {post_test_harness} "${{POST_TEST_CMD[@]}}"
+  {opentitantool} {args} "${{TEST_CLEANUP_CMD[@]}}" no-op
 }}
 
 # Bazel will send a SIGTERM when the timeout expires and will
@@ -41,9 +52,10 @@ function cleanup {{
 # on timeout.
 trap cleanup EXIT
 
-TEST_CMD=({test_cmd})
-echo Invoking test: {test_harness} {args} "$@" "${{TEST_CMD[@]}}"
-RUST_BACKTRACE=1 {test_harness} {args} "$@" "${{TEST_CMD[@]}}"
+set -x
+
+{opentitantool} {args} "${{TEST_SETUP_CMD[@]}}" no-op
+{test_harness} {args} "$@" "${{TEST_CMD[@]}}"
 """
 
 def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfile):
@@ -105,6 +117,75 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
         "hashfile": hashfile,
     }
 
+def _get_bool(param, name, default = "False"):
+    value = param.get(name, default).lower()
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    fail("Invalid boolean value {} for field {}".format(name, value))
+
+def _get_test_commands(ctx, param, exec_env):
+    """Process the testopt flags to generate test commands.
+
+    Test Option Param Fields:
+      testopt_bootstrap: If True, bootstrap the firmware before test.
+      testopt_clear_before_test: If True, clear the bitstream before test.
+      testopt_clear_after_test: If True, clear the bitstream after test.
+      testopt_needs_jtag: If True, tests require JTAG access.
+
+    Common Param Fields:
+      exit_success: The console output for test success.
+      exit_failure: The console output for test failure.
+      jtag_test_cmd: The JTAG test command (if testopt_needs_jtag is True).
+      bitstream: The bitstream to load before test.
+      firmware: The firmware to load with bootstrap.
+
+    Args:
+      ctx: The rule context.
+      param: A dictionary of key-value test parameters.
+      exec_env: The ExecEnvInfo for this environment.
+
+    Returns:
+      (string, string) A tuple of (test_setup_cmd, test_cleanup_cmd), which are
+      opentitantool arguments.
+    """
+
+    test_cmd = get_fallback(ctx, "attr.test_cmd", exec_env)
+
+    # If no test_cmd or custom harness is specified, run the default console harness.
+    if not test_cmd.strip() and not ctx.attr.test_harness:
+        test_cmd = """
+          console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'
+        """
+
+    if _get_bool(param, "testopt_needs_jtag"):
+        test_cmd = " {jtag_test_cmd} " + test_cmd
+
+    # Construct the opentitantool test setup commands
+    test_setup_cmd = ['--exec="transport init"']
+    if _get_bool(param, "testopt_clear_before_test"):
+        test_setup_cmd.append('--exec="fpga clear-bitstream"')
+    if "bitstream" in param:
+        test_setup_cmd.append('--exec="fpga load-bitstream {bitstream}"')
+    if _get_bool(param, "testopt_bootstrap") and "firmware" in param:
+        test_setup_cmd.append('--exec="bootstrap --leave-in-reset --clear-uart=true {firmware}"')
+    test_setup_cmd = "\n".join(test_setup_cmd)
+
+    # Construct the opentitantool test cleanup commands
+    test_cleanup_cmd = []
+    if _get_bool(param, "testopt_clear_after_test"):
+        test_cleanup_cmd.append('--exec="fpga clear-bitstream"')
+
+    test_cleanup_cmd = "\n".join(test_cleanup_cmd)
+
+    return _TEST_COMMANDS.format(
+        test_setup_cmd = test_setup_cmd,
+        test_cmd = test_cmd,
+        test_cleanup_cmd = test_cleanup_cmd,
+        post_test_cmd = ctx.attr.post_test_cmd,
+    )
+
 def _test_dispatch(ctx, exec_env, firmware):
     """Dispatch a test for the fpga_cw3{05,10,40} environment.
 
@@ -140,36 +221,39 @@ def _test_dispatch(ctx, exec_env, firmware):
 
     # FIXME: maybe splice a bitstream here
 
-    # Perform all relevant substitutions on the test_cmd.
-    test_cmd = get_fallback(ctx, "attr.test_cmd", exec_env)
-    test_cmd = test_cmd.format(**param)
-    test_cmd = ctx.expand_location(test_cmd, data_labels)
-
     # Get the pre-test_cmd args.
     args = get_fallback(ctx, "attr.args", exec_env)
     args = " ".join(args).format(**param)
     args = ctx.expand_location(args, data_labels)
 
-    # Construct the test script
-    script = ctx.actions.declare_file(ctx.attr.name + ".bash")
+    # Perform all relevant substitutions on the test_cmd.
+    test_commands = _get_test_commands(ctx, param, exec_env)
+    test_commands = test_commands.format(**param)
+    test_commands = ctx.expand_location(test_commands, data_labels)
+
+    # Construct the post test commands
     post_test_harness_path = ctx.executable.post_test_harness
-    post_test_cmd = ctx.attr.post_test_cmd.format(**param)
     if post_test_harness_path != None:
         data_files.append(post_test_harness_path)
         post_test_harness_path = post_test_harness_path.short_path
     else:
         post_test_harness_path = ""
+
+    # Construct the test script
+    script = ctx.actions.declare_file(ctx.attr.name + ".bash")
     ctx.actions.write(
         script,
         _TEST_SCRIPT.format(
             test_harness = test_harness.executable.short_path,
             args = args,
-            test_cmd = test_cmd,
+            test_commands = test_commands,
             post_test_harness = post_test_harness_path,
-            post_test_cmd = post_test_cmd,
+            opentitantool = exec_env._opentitantool.executable.short_path,
         ),
         is_executable = True,
     )
+    data_files.append(exec_env._opentitantool.executable)
+
     return script, data_files
 
 def _fpga_cw305(ctx):
@@ -216,6 +300,8 @@ def fpga_params(
         test_cmd = "",
         data = [],
         defines = [],
+        post_test_cmd = "",
+        post_test_harness = None,
         **kwargs):
     """A macro to create CW3{05,10,40} parameters for OpenTitan tests.
 
@@ -242,8 +328,10 @@ def fpga_params(
         bitstream = "@//hw/bitstream/universal:splice"
 
     # Clear bitstream after the test if it changes the OTP.
-    post_test_harness = "//sw/host/opentitantool" if changes_otp else None
-    post_test_cmd = "--rcfile= --logging=info --interface={interface} fpga clear-bitstream" if changes_otp else ""
+    if changes_otp:
+        kwargs["testopt_clear_after_test"] = "True"
+    if needs_jtag:
+        kwargs["testopt_needs_jtag"] = "True"
     return struct(
         # We do not yet know what FPGA platform the test will target (as this is
         # defined in the execution environment), so we do not know that tag
@@ -258,11 +346,7 @@ def fpga_params(
         otp = otp,
         bitstream = bitstream,
         needs_jtag = needs_jtag,
-        test_cmd = ("""
-            --bitstream={bitstream}
-        """ if test_harness != None else "") + ("""
-            {jtag_test_cmd}
-        """ if needs_jtag else "") + test_cmd,
+        test_cmd = test_cmd,
         data = data,
         param = kwargs,
         post_test_cmd = post_test_cmd,

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -471,9 +471,6 @@ opentitan_test(
     fpga = fpga_params(
         flow_control_message = _FLOW_CONTROL_MESSAGE,
         test_cmd = """
-            --exec="transport init"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {firmware}"
             --exec="console --non-interactive --exit-success=WAIT --exit-failure=PASS|FAIL --flow-control"
             console
             --flow-control

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -87,12 +87,9 @@ _MANUF_TEST_LOCKED_KEY = None
             needs_jtag = True,
             otp = "//hw/top_earlgrey/data/otp:img_{}".format(lc_state.lower()),
             tags = ["manuf"],
-            test_cmd = (
-                "" if (
-                    (lc_state, lc_val) in _TEST_LOCKED_LC_ITEMS
-                ) else "--bootstrap={firmware}"
-            ) + " --initial-lc-state={lc_state}",
+            test_cmd = "--initial-lc-state={lc_state}",
             test_harness = "//sw/host/tests/manuf/manuf_scrap",
+            testopt_bootstrap = str((lc_state, lc_val) not in _TEST_LOCKED_LC_ITEMS),
         ),
         deps = [
             "//sw/device/lib/runtime:log",
@@ -127,6 +124,7 @@ opentitan_test(
         otp = "//hw/top_earlgrey/data/otp:img_raw",
         tags = ["manuf"],
         test_harness = "//sw/host/tests/manuf/manuf_cp_unlock_raw",
+        testopt_bootstrap = "False",
     ),
     deps = [
         "//hw/top:otp_ctrl_c_regs",
@@ -149,6 +147,7 @@ opentitan_test(
         otp = "//hw/top_earlgrey/data/otp:img_raw",
         tags = ["manuf"],
         test_harness = "//sw/host/tests/manuf/manuf_cp_volatile_unlock_raw",
+        testopt_bootstrap = "False",
     ),
     deps = [
         "//hw/top:otp_ctrl_c_regs",
@@ -188,6 +187,7 @@ opentitan_test(
             tags = ["manuf"],
             test_cmd = "--initial-lc-state={lc_state}",
             test_harness = "//sw/host/tests/manuf/manuf_cp_yield_test",
+            testopt_bootstrap = "False",
         ),
         deps = [
             "//hw/top:otp_ctrl_c_regs",
@@ -262,6 +262,7 @@ cc_library(
             ],
             test_cmd = "--elf={firmware}",
             test_harness = "//sw/host/tests/manuf/manuf_sram_program_crc_check",
+            testopt_bootstrap = "False",
         ),
         kind = "ram",
         linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
@@ -359,6 +360,7 @@ opentitan_binary(
                 --elf={sram_program}
             """,
             test_harness = "//sw/host/tests/manuf/manuf_cp_device_info_flash_wr",
+            testopt_bootstrap = "False",
         ),
         spx_key = spx_key_for_lc_state(
             ECDSA_SPX_KEY_STRUCTS,
@@ -439,6 +441,7 @@ opentitan_binary(
                 --elf={sram_program}
             """,
             test_harness = "//sw/host/tests/manuf/manuf_cp_ast_test_execution",
+            testopt_bootstrap = "False",
         ),
         deps = [
             "//sw/device/lib/runtime:log",
@@ -471,6 +474,7 @@ opentitan_test(
         otp = ":otp_img_otp_ctrl_functest",
         tags = ["manuf"],
         test_harness = "//sw/host/tests/manuf/manuf_cp_test_lock",
+        testopt_bootstrap = "False",
     ),
     deps = [
         "//hw/top:otp_ctrl_c_regs",
@@ -499,6 +503,7 @@ opentitan_test(
         otp = ":otp_img_otp_ctrl_functest",
         tags = ["manuf"],
         test_harness = "//sw/host/tests/manuf/otp_ctrl:otp_ctrl",
+        testopt_bootstrap = "False",
     ),
     deps = [
         "//hw/top:otp_ctrl_c_regs",
@@ -554,9 +559,6 @@ opentitan_test(
     },
     fpga = fpga_params(
         tags = ["manuf"],
-        test_cmd = """
-            --bootstrap={firmware}
-        """,
         test_harness = "//sw/host/tests/manuf/manuf_ujson_msg_size",
     ),
     deps = [
@@ -575,9 +577,6 @@ opentitan_test(
     },
     fpga = fpga_params(
         tags = ["manuf"],
-        test_cmd = """
-            --bootstrap={firmware}
-        """,
         test_harness = "//sw/host/tests/manuf/manuf_ujson_msg_padding",
     ),
     deps = [

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -591,8 +591,6 @@ STACK_UTILIZATION_FPGA_PARAMS = {
             # This is a manual test.  Run it with:
             #     --test_output=streamed --copt=-DSTACK_UTILIZATION_CHECK
             ###########################################################################'"
-            --exec="transport init"
-            --exec="fpga load-bitstream {bitstream}"
 
             --exec="no-op --info '### Measuring stack utilization for bootstrap slot A'"
             --exec="bootstrap --clear-uart=true --leave-in-bootstrap {good_a}"
@@ -635,6 +633,7 @@ STACK_UTILIZATION_FPGA_PARAMS = {
             --exec="console --non-interactive --exit-success='{stack_usage}' --exit-failure='PASS|FAIL'"
             no-op
         """,
+        testopt_bootstrap = "False",
     )
     for fpga in ["cw340"]
 }

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -452,14 +452,7 @@ opentitan_test(
         exit_success = "min_security_version_rom_ext:0(?s:.*)min_security_version_rom_ext:1(?s:.*)" + MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.BOOT_POLICY.ROLLBACK)),
         # We clear the bitstream to force any subsequent test to load a
         # fresh bitstream and clear all memories (ie: flash-based boot policy).
-        test_cmd = """
-            --exec="transport init"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {firmware}"
-            --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-            --exec="fpga clear-bitstream\"
-            no-op
-        """,
+        testopt_clear_after_test = "True",
     ),
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     deps = [

--- a/sw/device/silicon_creator/rom/e2e/bootstrap/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/bootstrap/BUILD
@@ -78,9 +78,6 @@ opentitan_test(
         changes_otp = True,
         needs_jtag = True,
         otp = "otp_img_bootstrap_rma",
-        test_cmd = """
-            --bootstrap="{firmware}"
-        """,
         test_harness = "//sw/host/tests/rom/e2e_bootstrap_rma",
     ),
     deps = [
@@ -106,6 +103,7 @@ opentitan_test(
         },
         otp = "//hw/top_earlgrey/data/otp:img_bootstrap_disabled",
         test_harness = "//sw/host/tests/rom/e2e_bootstrap_disabled",
+        testopt_bootstrap = "False",
     ),
     manifest = None,
 )

--- a/sw/device/silicon_creator/rom/e2e/jtag_inject/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/jtag_inject/BUILD
@@ -53,6 +53,7 @@ package(default_visibility = ["//visibility:public"])
                 --elf={sram_program}
             """,
             test_harness = "//sw/host/tests/chip/jtag:sram_load",
+            testopt_bootstrap = "False",
         ),
         deps = [
             "//sw/device/lib/runtime:log",
@@ -94,6 +95,7 @@ test_suite(
             otp = ":img_{}_exec_disabled".format(lc_state),
             test_cmd = " --elf={rom:elf}",
             test_harness = "//sw/host/tests/rom/e2e_openocd_debug_test:asm_interrupt_handler",
+            testopt_bootstrap = "False",
         ),
         deps = [
             "//sw/device/lib/runtime:log",
@@ -135,6 +137,7 @@ test_suite(
             otp = ":img_{}_exec_disabled".format(lc_state),
             test_cmd = " --elf={rom:elf}",
             test_harness = "//sw/host/tests/rom/e2e_openocd_debug_test:shutdown_execution_asm",
+            testopt_bootstrap = "False",
         ),
         deps = [
             "//sw/device/lib/runtime:log",
@@ -177,6 +180,7 @@ test_suite(
             tags = ["broken"],
             test_cmd = " --elf={rom:elf}",
             test_harness = "//sw/host/tests/rom/e2e_openocd_debug_test:asm_watchdog_bark",
+            testopt_bootstrap = "False",
         ),
         deps = [
             "//sw/device/lib/runtime:log",
@@ -219,6 +223,7 @@ test_suite(
             tags = ["broken"],
             test_cmd = " --elf={rom:elf}",
             test_harness = "//sw/host/tests/rom/e2e_openocd_debug_test:asm_watchdog_bite",
+            testopt_bootstrap = "False",
         ),
         deps = [
             "//sw/device/lib/runtime:log",
@@ -267,6 +272,7 @@ LC_STATES_DEBUG_DISALLOWED = [
             otp = ":img_{}_exec_disabled".format(lc_state),
             test_cmd = " --elf={rom:elf}" + (" --expect-fail" if lc_state_val in LC_STATES_DEBUG_DISALLOWED else " "),
             test_harness = "//sw/host/tests/rom/e2e_openocd_debug_test:debug_test",
+            testopt_bootstrap = "False",
         ),
         deps = [
             "//sw/device/lib/runtime:log",

--- a/sw/device/silicon_creator/rom/e2e/reset_reason/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/reset_reason/BUILD
@@ -67,14 +67,14 @@ RESET_CORRUPTION_SCENARIOS = [
         "otp": 0,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
-        "test_cmd": "",
+        "testopt_bootstrap": "True",
     },
     {
         "name": "check_disabled_no_fault",
         "otp": CONST.HARDENED_FALSE << 16 | CONST.HARDENED_FALSE,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
-        "test_cmd": "",
+        "testopt_bootstrap": "True",
     },
     {
         "name": "check_disabled_with_fault",
@@ -84,14 +84,14 @@ RESET_CORRUPTION_SCENARIOS = [
         "otp": CONST.HARDENED_FALSE << 16 | 0,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
-        "test_cmd": "",
+        "testopt_bootstrap": "True",
     },
     {
         "name": "check_enabled_no_fault",
         "otp": CONST.HARDENED_TRUE << 16 | CONST.HARDENED_TRUE,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
-        "test_cmd": "",
+        "testopt_bootstrap": "True",
     },
     {
         "name": "check_enabled_with_fault",
@@ -104,12 +104,7 @@ RESET_CORRUPTION_SCENARIOS = [
         "exit_failure": DEFAULT_TEST_SUCCESS_MSG,
         # This test will fault before bootstrap straps are read, so simply
         # start the console and look for the fault message.
-        "test_cmd": """
-            --exec="transport init"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-            no-op
-        """,
+        "testopt_bootstrap": "False",
     },
 ]
 
@@ -150,7 +145,7 @@ RESET_CORRUPTION_SCENARIOS = [
             exit_failure = t["exit_failure"],
             exit_success = t["exit_success"],
             otp = ":otp_img_reset_reason_{}".format(t["name"]),
-            test_cmd = t["test_cmd"],
+            testopt_bootstrap = t["testopt_bootstrap"],
         ),
         deps = [
             "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/silicon_creator/rom/e2e/rom_ext_upgrade_interrupt/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/rom_ext_upgrade_interrupt/BUILD
@@ -71,15 +71,8 @@ otp_json(
         fpga = fpga_params(
             otp = ":otp_img_rom_ext_upgrade_interrupt_{}".format(lc_state),
             tags = maybe_skip_in_ci(lc_state_val),
-            test_cmd = """
-                --exec="transport init"
-                --exec="fpga clear-bitstream"
-                --exec="fpga load-bitstream {bitstream}"
-                --exec="bootstrap --clear-uart=true {firmware}"
-                --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-                --exec="fpga clear-bitstream"
-                no-op
-            """,
+            testopt_clear_after_test = "True",
+            testopt_clear_before_test = "True",
         ),
         manifest = ":manifest_rom_ext_upgrade_interrupt",
         deps = [

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/BUILD
@@ -70,9 +70,6 @@ opentitan_test(
         exit_failure = "BFV|PASS|FAIL",
         exit_success = "mode: RESQ\r\n",
         test_cmd = """
-            --exec="transport init"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {firmware}"
             --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
             # Try the `REBO` mode and make sure it works.
             --exec="rescue no-op --reset-target=reboot"
@@ -132,16 +129,9 @@ opentitan_test(
     },
     fpga = fpga_params(
         assemble = "{rom_ext}@{rom_ext_slot_a} {firmware}@{owner_slot_a}",
-        changes_otp = True,
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_boot_svc_after_wakeup",
-        test_cmd = """
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {firmware}"
-            --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-            no-op
-        """,
+        testopt_clear_after_test = "True",
+        testopt_clear_before_test = "True",
     ),
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
     deps = [
@@ -176,9 +166,9 @@ NEXT_TEST_SEQUENCES = [
         },
         fpga = fpga_params(
             assemble = "{rom_ext}@{rom_ext_slot_a} {firmware}@{owner_slot_a} {firmware}@{owner_slot_b}",
-            changes_otp = True,  # Clear the primary slot settings
             exit_failure = "BFV:.*|PASS|FAIL",
             exit_success = "FinalBootLog: 3:{}\r\n".format(test_sequence),
+            testopt_clear_after_test = "True",  # Clear the primary slot settings
         ),
         linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
         deps = [
@@ -207,14 +197,7 @@ opentitan_test(
         assemble = "{rom_ext}@{rom_ext_slot_a} {firmware}@{owner_slot_a} {firmware}@{owner_slot_b}",
         exit_failure = "BFV:.*|PASS|FAIL",
         exit_success = "FinalBootLog: 5:ABBBA\r\n",
-        test_cmd = """
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {firmware}"
-            --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-            no-op
-        """,
+        testopt_clear_before_test = "True",
     ),
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
     deps = [
@@ -336,15 +319,8 @@ MIN_SEC_VER_SLOTS = [
             binaries = {
                 ":min_sec_ver_5": "min_sec_ver_5",
             },
-            test_cmd = """
-                --exec="transport init"
-                --exec="fpga clear-bitstream"
-                --exec="fpga load-bitstream {bitstream}"
-                --exec="bootstrap --clear-uart=true {firmware}"
-                --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-                --exec="fpga clear-bitstream"
-                no-op
-            """,
+            testopt_clear_after_test = "True",
+            testopt_clear_before_test = "True",
             v0_slot = "{{owner_slot_{}}}".format(slots[0]),
             v5_slot = "{{owner_slot_{}}}".format(slots[1]),
         ),

--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
@@ -114,11 +114,10 @@ _VARIATION_INTEROP_TEST_CASES = [
             },
             otp = "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_rma",
             test_cmd = """
-                --clear-bitstream
-                --bootstrap={firmware}
                 --second-bootstrap={second}
             """,
             test_harness = "//sw/host/tests/rom_ext/e2e_variation_interop",
+            testopt_clear_before_test = "True",
         ),
     )
     for tc in _VARIATION_INTEROP_TEST_CASES

--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
@@ -164,9 +164,6 @@ opentitan_test(
             ":modify_digest": "modify_digest",
         },
         test_cmd = """
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
             --exec="no-op --info='##### Prepare CDI cert page'"
             --exec="bootstrap --clear-uart=true {firmware}"
             --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}' --timeout=10s"
@@ -180,6 +177,8 @@ opentitan_test(
             --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}' --timeout=10s"
             no-op
         """,
+        testopt_bootstrap = "False",
+        testopt_clear_before_test = "True",
     ),
     deps = [
         "//sw/device/lib/base:status",

--- a/sw/device/silicon_creator/rom_ext/e2e/flash_ecc_error/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/flash_ecc_error/BUILD
@@ -182,8 +182,6 @@ opentitan_binary(
             slot_a = "0x10000",
             slot_b = "0x90000",
             test_cmd = """
-                --exec="transport init"
-                --exec="fpga load-bitstream {bitstream}"
                 # First run the setup program to make sure the keymgr secrets are configured.
                 # This is required to allow the ROM_EXT to run.
                 --exec="bootstrap --clear-uart=true {setup}"
@@ -198,6 +196,7 @@ opentitan_binary(
                 --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
                 no-op
             """,
+            testopt_bootstrap = "False",
         ),
     )
     for t in BOOT_POLICY_FLASH_ECC_ERROR_TESTS
@@ -227,8 +226,6 @@ opentitan_test(
         slot_a = "0x10000",
         slot_b = "0x90000",
         test_cmd = """
-            --exec="transport init"
-            --exec="fpga load-bitstream {bitstream}"
             # First run the setup program to make sure the keymgr secrets are configured.
             # This is required to allow the ROM_EXT to run.
             --exec="bootstrap --clear-uart=true {setup}"
@@ -243,6 +240,7 @@ opentitan_test(
             --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
             no-op
         """,
+        testopt_bootstrap = "False",
     ),
 )
 

--- a/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
@@ -166,14 +166,7 @@ SRAM_EXEC_TESTCASES = [
             changes_otp = True,
             exit_success = test["exit_success"],
             rom_ext = test["rom_ext"],
-            test_cmd = """
-                --exec="transport init"
-                --exec="fpga clear-bitstream"
-                --exec="fpga load-bitstream {bitstream}"
-                --exec="bootstrap --clear-uart=true {firmware}"
-                --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-                no-op
-            """,
+            testopt_clear_before_test = "True",
         ),
         linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
         deps = [
@@ -200,7 +193,6 @@ opentitan_test(
         rom_ext_sec_version = ROM_EXT_VERSION.SECURITY,
         rom_ext_version = ROM_EXT_VERSION.MINOR,
         test_cmd = """
-            --bootstrap={firmware}
             --wait-for="PASS!"
             --rom-ext-version="{rom_ext_version}"
             --rom-ext-sec-version="{rom_ext_sec_version}"

--- a/sw/device/silicon_creator/rom_ext/e2e/isfb/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/isfb/BUILD
@@ -74,10 +74,10 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        changes_otp = True,
         # Check that bank=0 page=5 is configured for RD/WR, but not ERase.
         exit_success = "info region bank=0 part=0 page=5 RD-WR-uu-uu-uu-uu LK",
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_isfb",
+        testopt_clear_after_test = "True",
     ),
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
     deps = [
@@ -98,13 +98,13 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        changes_otp = True,
         # Even though the isfb_erase extension is present and set to true,
         # the manifest doesn't node lock this image.  The erase condition
         # is not met and the ISFB page should not allow erase.
         # Check that bank=0 page=5 is configured for RD/WR, but not ERase.
         exit_success = "info region bank=0 part=0 page=5 RD-WR-uu-uu-uu-uu LK",
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_isfb",
+        testopt_clear_after_test = "True",
     ),
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
     manifest = ":manifest_bad_erase_contraint",
@@ -219,21 +219,20 @@ _ISFB_CONTRAINT_TESTS = {
             binaries = {
                 ":isfb_page_init": "isfb_page_init",
             },
-            changes_otp = True,
             exit_failure = param["failure"],
             exit_success = param["success"],
             rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_isfb",
             test_cmd = """
                 --exec="image assemble --output=init.bin --mirror=false --size=131072 {rom_ext}@0 {isfb_page_init}@0x10000"
-                --exec="transport init"
-                --exec="fpga clear-bitstream"
-                --exec="fpga load-bitstream {bitstream}"
                 --exec="bootstrap --clear-uart=true init.bin"
                 --exec="console --non-interactive --exit-success='PASS!' --timeout=10s"
                 --exec="bootstrap --clear-uart=true {firmware}"
                 --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}' --timeout=10s"
                 no-op
             """,
+            testopt_bootstrap = "False",
+            testopt_clear_after_test = "True",
+            testopt_clear_before_test = "True",
         ),
         linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
         manifest = param["manifest"],

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -15,11 +15,6 @@ load(
 
 package(default_visibility = ["//visibility:public"])
 
-# TODO(#24462): The tests in this file are marked `changes_otp = True`,
-# but they don't change OTP.  They modify the ownership INFO pages,
-# so we need to clear the bitstream after the test, which is what the
-# `changes_otp` parameter actually does.
-
 opentitan_binary(
     name = "boot_test",
     testonly = True,
@@ -82,9 +77,7 @@ ownership_transfer_test(
     name = "transfer_any_test",
     ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0"},
     fpga = {
-        "changes_otp": True,
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -109,9 +102,7 @@ ownership_transfer_test(
         "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
     },
     fpga = {
-        "changes_otp": True,
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -130,10 +121,8 @@ ownership_transfer_test(
         "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
     },
     fpga = {
-        "changes_otp": True,
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_default_ownership_state_unlock_any",
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Abort
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -153,10 +142,8 @@ ownership_transfer_test(
         "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
     },
     fpga = {
-        "changes_otp": True,
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_default_ownership_state_unlock_any",
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Abort
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -176,10 +163,8 @@ ownership_transfer_test(
         "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
     },
     fpga = {
-        "changes_otp": True,
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_invalid_key_alg",
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --skip-unlock=true
@@ -202,9 +187,7 @@ ownership_transfer_test(
         "binaries": {
             ":boot_test": "boot_test",
         },
-        "changes_otp": True,
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -222,9 +205,7 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "bad_unlock_signature_test",
     fpga = {
-        "changes_otp": True,
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -247,10 +228,8 @@ ownership_transfer_test(
         "binaries": {
             ":boot_test": "boot_test",
         },
-        "changes_otp": True,
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_corrupted_owner_key_alg",
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -272,10 +251,8 @@ ownership_transfer_test(
         "binaries": {
             ":boot_test": "boot_test",
         },
-        "changes_otp": True,
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_corrupted_owner_key_alg",
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --key-alg=HybridSpxPure
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -294,9 +271,7 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "bad_appkey_constraint_test",
     fpga = {
-        "changes_otp": True,
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -313,9 +288,7 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "good_appkey_constraint_test",
     fpga = {
-        "changes_otp": True,
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -333,9 +306,7 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "bad_unlock_test",
     fpga = {
-        "changes_otp": True,
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             # NOTE: We use the wrong unlock key to test that the unlock operation fails.
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
@@ -352,10 +323,8 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "unlock_when_recovery_state_test",
     fpga = {
-        "changes_otp": True,
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_default_ownership_state_recovery",
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             # NOTE: We use the owner recovery key to test that the unlock operation succeeds.
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:no_owner_recovery_key)
@@ -371,9 +340,7 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "unlock_with_owner_recovery_key_test",
     fpga = {
-        "changes_otp": True,
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             # NOTE: We use the owner recovery key to test that the unlock operation succeeds.
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:no_owner_recovery_key)
@@ -390,9 +357,7 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "bad_activate_test",
     fpga = {
-        "changes_otp": True,
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             # NOTE: We use the wrong activate key to test that the activate operation fails.
@@ -411,9 +376,7 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "bad_owner_block_test",
     fpga = {
-        "changes_otp": True,
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -432,9 +395,7 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "bad_app_key_test",
     fpga = {
-        "changes_otp": True,
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -453,9 +414,7 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "transfer_endorsed_test",
     fpga = {
-        "changes_otp": True,
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Endorsed
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -472,9 +431,7 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "bad_endorsee_test",
     fpga = {
-        "changes_otp": True,
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Endorsed
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -494,9 +451,7 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "locked_update_test",
     fpga = {
-        "changes_otp": True,
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Update
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
@@ -519,9 +474,7 @@ ownership_transfer_test(
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
     fpga = {
-        "changes_otp": True,
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Update
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             # NOTE: We use the wrong owner key to test that the activate operation fails.
@@ -541,9 +494,7 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "bad_locked_update_no_exec_test",
     fpga = {
-        "changes_otp": True,
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Update
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -568,10 +519,8 @@ ownership_transfer_test(
         "timeout": "long",
         # We boot on Side B since rescue will rewrite side A.
         "assemble": "{rom_ext}@{rom_ext_slot_a} {firmware}@{owner_slot_b}",
-        "changes_otp": True,
         "tags": ["slow_test"],
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -596,9 +545,7 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "rescue_permission_test",
     fpga = {
-        "changes_otp": True,
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -645,13 +592,11 @@ _FLASH_PERMISSION_TESTS = {
             "binaries": {
                 ":flash_regions": "flash_regions",
             },
-            "changes_otp": True,
             "owner_slot": param["owner_slot"],
             "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_virtual",
             "rom_ext_offset": param["rom_ext_offset"],
             "rom_ext_slot": param["rom_ext_slot"],
             "test_cmd": """
-                --bootstrap={firmware}
                 --unlock-mode=Any
                 --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
                 --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -683,9 +628,7 @@ _FLASH_PERMISSION_TESTS = {
 ownership_transfer_test(
     name = "flash_error_test",
     fpga = {
-        "changes_otp": True,
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -708,9 +651,7 @@ ownership_transfer_test(
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
     fpga = {
-        "changes_otp": True,
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Update
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
@@ -733,10 +674,8 @@ ownership_transfer_test(
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
     fpga = {
-        "changes_otp": True,
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
         "test_cmd": """
-            --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
@@ -756,10 +695,8 @@ ownership_transfer_test(
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
     fpga = {
-        "changes_otp": True,
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
         "test_cmd": """
-            --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
@@ -780,10 +717,8 @@ ownership_transfer_test(
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
     fpga = {
-        "changes_otp": True,
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
         "test_cmd": """
-            --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
@@ -803,10 +738,8 @@ ownership_transfer_test(
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
     fpga = {
-        "changes_otp": True,
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
         "test_cmd": """
-            --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
@@ -827,10 +760,8 @@ ownership_transfer_test(
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
     fpga = {
-        "changes_otp": True,
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
         "test_cmd": """
-            --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
@@ -886,9 +817,7 @@ ownership_transfer_test(
         "binaries": {
             ":keymgr_test": "keymgr_test",
         },
-        "changes_otp": True,
         "test_cmd": """
-            --bootstrap={firmware}
             --pre-transfer-boot-check=true
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -920,9 +849,7 @@ ownership_transfer_test(
         "binaries": {
             ":boot_test": "boot_test",
         },
-        "changes_otp": True,
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-key-alg=HybridSpxPure
@@ -954,10 +881,8 @@ ownership_transfer_test(
         "binaries": {
             ":boot_test": "boot_test",
         },
-        "changes_otp": True,
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_hybrid_owner_keys",
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --key-alg=HybridSpxPure
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -990,10 +915,8 @@ ownership_transfer_test(
         "binaries": {
             ":boot_test": "boot_test",
         },
-        "changes_otp": True,
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_spx_pure_owner_keys",
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --key-alg=SpxPure
             --unlock-key-spx=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key_spx)
@@ -1015,10 +938,8 @@ ownership_transfer_test(
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
     fpga = {
-        "changes_otp": True,
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_hybrid_owner_update_newversion",
         "test_cmd": """
-            --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
@@ -1042,10 +963,8 @@ ownership_transfer_test(
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
     fpga = {
-        "changes_otp": True,
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_hybrid_owner_update_newversion",
         "test_cmd": """
-            --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -6,7 +6,6 @@ load("//rules:const.bzl", "CONST", "hex")
 load("//rules:manifest.bzl", "manifest")
 load(
     "//rules/opentitan:defs.bzl",
-    "fpga_params",
     "opentitan_binary",
 )
 load(
@@ -82,10 +81,9 @@ manifest({
 ownership_transfer_test(
     name = "transfer_any_test",
     ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0"},
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -94,8 +92,8 @@ ownership_transfer_test(
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
             --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
     deps = [
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -110,10 +108,9 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -123,8 +120,8 @@ ownership_transfer_test(
             --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa_pub)
             --activate-bl0-slot=SlotB
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 ownership_transfer_test(
@@ -132,11 +129,10 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_default_ownership_state_unlock_any",
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_default_ownership_state_unlock_any",
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Abort
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -147,8 +143,8 @@ ownership_transfer_test(
             --invalid-device-id=true
             --expected-error=OwnershipInvalidDin
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 ownership_transfer_test(
@@ -156,11 +152,10 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_default_ownership_state_unlock_any",
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_default_ownership_state_unlock_any",
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Abort
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -171,8 +166,8 @@ ownership_transfer_test(
             --invalid-nonce=true
             --expected-error=OwnershipInvalidNonce
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 ownership_transfer_test(
@@ -180,11 +175,10 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_invalid_key_alg",
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_invalid_key_alg",
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -195,8 +189,8 @@ ownership_transfer_test(
             --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa_pub)
             --dual-owner-boot-check=false
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 ownership_transfer_test(
@@ -204,13 +198,12 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        binaries = {
+    fpga = {
+        "binaries": {
             ":boot_test": "boot_test",
         },
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+        "changes_otp": True,
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -222,16 +215,15 @@ ownership_transfer_test(
             --dual-owner-boot-check=false
             --rescue-after-activate={boot_test}
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 ownership_transfer_test(
     name = "bad_unlock_signature_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -242,8 +234,8 @@ ownership_transfer_test(
             --unlock-sig=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:all_zero_sig)
             --expected-error=OwnershipSignatureNotFound
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 ownership_transfer_test(
@@ -251,14 +243,13 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        binaries = {
+    fpga = {
+        "binaries": {
             ":boot_test": "boot_test",
         },
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_corrupted_owner_key_alg",
-        test_cmd = """
-            --clear-bitstream
+        "changes_otp": True,
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_corrupted_owner_key_alg",
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -268,8 +259,8 @@ ownership_transfer_test(
             --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa_pub)
             --expected-error=OwnershipInvalidAlgorithm
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 ownership_transfer_test(
@@ -277,14 +268,13 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        binaries = {
+    fpga = {
+        "binaries": {
             ":boot_test": "boot_test",
         },
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_corrupted_owner_key_alg",
-        test_cmd = """
-            --clear-bitstream
+        "changes_otp": True,
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_corrupted_owner_key_alg",
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --key-alg=HybridSpxPure
@@ -297,16 +287,15 @@ ownership_transfer_test(
             --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa_pub)
             --expected-error=OwnershipInvalidAlgorithm
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 ownership_transfer_test(
     name = "bad_appkey_constraint_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -317,16 +306,15 @@ ownership_transfer_test(
             --config-kind=with-app-constraint
             --expected-error=SigverifyBadEcdsaSignature
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 ownership_transfer_test(
     name = "good_appkey_constraint_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -336,18 +324,17 @@ ownership_transfer_test(
             --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
             --config-kind=with-app-constraint
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
     manifest = ":nodelocked_manifest",
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_unlock_test
 ownership_transfer_test(
     name = "bad_unlock_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             # NOTE: We use the wrong unlock key to test that the unlock operation fails.
@@ -358,17 +345,16 @@ ownership_transfer_test(
             --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
             --expected-error=OwnershipInvalidSignature
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 ownership_transfer_test(
     name = "unlock_when_recovery_state_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_default_ownership_state_recovery",
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_default_ownership_state_recovery",
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             # NOTE: We use the owner recovery key to test that the unlock operation succeeds.
@@ -378,16 +364,15 @@ ownership_transfer_test(
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
             --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa_pub)
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 ownership_transfer_test(
     name = "unlock_with_owner_recovery_key_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             # NOTE: We use the owner recovery key to test that the unlock operation succeeds.
@@ -397,17 +382,16 @@ ownership_transfer_test(
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
             --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa_pub)
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_activate_test
 ownership_transfer_test(
     name = "bad_activate_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -419,17 +403,16 @@ ownership_transfer_test(
             --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
             --expected-error=OwnershipInvalidSignature
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_owner_block_test
 ownership_transfer_test(
     name = "bad_owner_block_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -441,17 +424,16 @@ ownership_transfer_test(
             --dual-owner-boot-check=false
             --expected-error=OwnershipInvalidInfoPage
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_app_key_test
 ownership_transfer_test(
     name = "bad_app_key_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -463,17 +445,16 @@ ownership_transfer_test(
             --next-application-key=sw/device/silicon_creator/lib/ownership/keys/fake/app_prod_ecdsa_p256.pub.der
             --expected-error=OwnershipKeyNotFound
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_transfer_endorsed_test
 ownership_transfer_test(
     name = "transfer_endorsed_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Endorsed
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -483,17 +464,16 @@ ownership_transfer_test(
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
             --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_endorsee_test
 ownership_transfer_test(
     name = "bad_endorsee_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Endorsed
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -506,17 +486,16 @@ ownership_transfer_test(
             --dual-owner-boot-check=false
             --expected-error=OwnershipInvalidInfoPage
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_locked_update_test
 ownership_transfer_test(
     name = "locked_update_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Update
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -528,8 +507,8 @@ ownership_transfer_test(
             --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
             --non-transfer-update=true
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_locked_update_test
@@ -539,10 +518,9 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Update
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -554,18 +532,17 @@ ownership_transfer_test(
             --dual-owner-boot-check=false
             --expected-error=OwnershipInvalidInfoPage
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_locked_update_test
 # Part 2: Ensure the UnlockedSelf state denies execution to anything signed with new app keys.
 ownership_transfer_test(
     name = "bad_locked_update_no_exec_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Update
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -579,22 +556,21 @@ ownership_transfer_test(
             --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
             --expected-error=OwnershipKeyNotFound
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_rescue_limit_test
 ownership_transfer_test(
     name = "rescue_limit_test",
     srcs = ["flash_contents.c"],
-    fpga = fpga_params(
-        timeout = "long",
+    fpga = {
+        "timeout": "long",
         # We boot on Side B since rescue will rewrite side A.
-        assemble = "{rom_ext}@{rom_ext_slot_a} {firmware}@{owner_slot_b}",
-        changes_otp = True,
-        tags = ["slow_test"],
-        test_cmd = """
-            --clear-bitstream
+        "assemble": "{rom_ext}@{rom_ext_slot_a} {firmware}@{owner_slot_b}",
+        "changes_otp": True,
+        "tags": ["slow_test"],
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -603,8 +579,8 @@ ownership_transfer_test(
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
             --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
         """,
-        test_harness = "//sw/host/tests/ownership:rescue_limit_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:rescue_limit_test",
+    },
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_b",
     deps = [
         "//hw/top:flash_ctrl_c_regs",
@@ -619,10 +595,9 @@ ownership_transfer_test(
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_rescue_permission_test
 ownership_transfer_test(
     name = "rescue_permission_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -631,8 +606,8 @@ ownership_transfer_test(
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
             --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
         """,
-        test_harness = "//sw/host/tests/ownership:rescue_permission_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:rescue_permission_test",
+    },
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_flash_permission_test
@@ -665,18 +640,17 @@ _FLASH_PERMISSION_TESTS = {
     ownership_transfer_test(
         name = "flash_permission_test_slot_{}".format(name),
         srcs = ["flash_regions.c"],
-        fpga = fpga_params(
-            assemble = "{rom_ext}@{rom_ext_offset} {firmware}@0x10000",
-            binaries = {
+        fpga = {
+            "assemble": "{rom_ext}@{rom_ext_offset} {firmware}@0x10000",
+            "binaries": {
                 ":flash_regions": "flash_regions",
             },
-            changes_otp = True,
-            owner_slot = param["owner_slot"],
-            rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_virtual",
-            rom_ext_offset = param["rom_ext_offset"],
-            rom_ext_slot = param["rom_ext_slot"],
-            test_cmd = """
-                --clear-bitstream
+            "changes_otp": True,
+            "owner_slot": param["owner_slot"],
+            "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_virtual",
+            "rom_ext_offset": param["rom_ext_offset"],
+            "rom_ext_slot": param["rom_ext_slot"],
+            "test_cmd": """
                 --bootstrap={firmware}
                 --unlock-mode=Any
                 --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -689,8 +663,8 @@ _FLASH_PERMISSION_TESTS = {
                 --rescue-slot={owner_slot}
                 --expected-rom-ext-slot={rom_ext_slot}
             """,
-            test_harness = "//sw/host/tests/ownership:flash_permission_test",
-        ),
+            "test_harness": "//sw/host/tests/ownership:flash_permission_test",
+        },
         linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
         deps = [
             "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -708,10 +682,9 @@ _FLASH_PERMISSION_TESTS = {
 # Tests that a owner config with an improper flash configuration cannot be activated.
 ownership_transfer_test(
     name = "flash_error_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -723,8 +696,8 @@ ownership_transfer_test(
             --dual-owner-boot-check=false
             --expected-error=OwnershipFlashConfigRomExt
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 # Test that the `sku_creator_owner_init` function responsible for installing the test owner on
@@ -734,10 +707,9 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Update
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -751,8 +723,8 @@ ownership_transfer_test(
             --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
             --non-transfer-update=true
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 ownership_transfer_test(
@@ -760,11 +732,10 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
+        "test_cmd": """
             --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -775,8 +746,8 @@ ownership_transfer_test(
             --expect "config_version = 2"
             --expect "owner_key = 8e3dcb50"
         """,
-        test_harness = "//sw/host/tests/ownership:newversion_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:newversion_test",
+    },
 )
 
 ownership_transfer_test(
@@ -784,11 +755,10 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
+        "test_cmd": """
             --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -800,8 +770,8 @@ ownership_transfer_test(
             --expect "config_version = 1"
             --expect "owner_key = 8e3dcb50"
         """,
-        test_harness = "//sw/host/tests/ownership:newversion_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:newversion_test",
+    },
 )
 
 ownership_transfer_test(
@@ -809,11 +779,10 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
+        "test_cmd": """
             --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -824,8 +793,8 @@ ownership_transfer_test(
             --expect "config_version = 1"
             --expect "owner_key = 8e3dcb50"
         """,
-        test_harness = "//sw/host/tests/ownership:newversion_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:newversion_test",
+    },
 )
 
 ownership_transfer_test(
@@ -833,11 +802,10 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
+        "test_cmd": """
             --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -849,8 +817,8 @@ ownership_transfer_test(
             --expect "config_version = 2"
             --expect "owner_key = 8e3dcb50"
         """,
-        test_harness = "//sw/host/tests/ownership:newversion_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:newversion_test",
+    },
 )
 
 ownership_transfer_test(
@@ -858,11 +826,10 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
+        "test_cmd": """
             --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -874,8 +841,8 @@ ownership_transfer_test(
             --expect "config_version = 1"
             --expect "owner_key = 8e3dcb50"
         """,
-        test_harness = "//sw/host/tests/ownership:newversion_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:newversion_test",
+    },
 )
 
 opentitan_binary(
@@ -915,13 +882,12 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        binaries = {
+    fpga = {
+        "binaries": {
             ":keymgr_test": "keymgr_test",
         },
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+        "changes_otp": True,
+        "test_cmd": """
             --bootstrap={firmware}
             --pre-transfer-boot-check=true
             --unlock-mode=Any
@@ -933,8 +899,8 @@ ownership_transfer_test(
             --rescue-after-activate={keymgr_test}
             --keygen-check=true
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:status",
@@ -950,13 +916,12 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "transfer_ecdsa_to_pq_test",
     ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0"},
-    fpga = fpga_params(
-        binaries = {
+    fpga = {
+        "binaries": {
             ":boot_test": "boot_test",
         },
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+        "changes_otp": True,
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -971,8 +936,8 @@ ownership_transfer_test(
             --dual-owner-boot-check=false
             --rescue-after-activate={boot_test}
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
     deps = [
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -985,14 +950,13 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "transfer_pq_to_pq_test",
     ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0"},
-    fpga = fpga_params(
-        binaries = {
+    fpga = {
+        "binaries": {
             ":boot_test": "boot_test",
         },
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_hybrid_owner_keys",
-        test_cmd = """
-            --clear-bitstream
+        "changes_otp": True,
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_hybrid_owner_keys",
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --key-alg=HybridSpxPure
@@ -1006,8 +970,8 @@ ownership_transfer_test(
             --dual-owner-boot-check=false
             --rescue-after-activate={boot_test}
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
     deps = [
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -1022,14 +986,13 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        binaries = {
+    fpga = {
+        "binaries": {
             ":boot_test": "boot_test",
         },
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_spx_pure_owner_keys",
-        test_cmd = """
-            --clear-bitstream
+        "changes_otp": True,
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_spx_pure_owner_keys",
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --key-alg=SpxPure
@@ -1042,8 +1005,8 @@ ownership_transfer_test(
             --dual-owner-boot-check=false
             --rescue-after-activate={boot_test}
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 ownership_transfer_test(
@@ -1051,11 +1014,10 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_hybrid_owner_update_newversion",
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_hybrid_owner_update_newversion",
+        "test_cmd": """
             --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -1070,8 +1032,8 @@ ownership_transfer_test(
             --expect "config_version = 2"
             --expect "owner_key = 8e3dcb50"
         """,
-        test_harness = "//sw/host/tests/ownership:newversion_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:newversion_test",
+    },
 )
 
 ownership_transfer_test(
@@ -1079,11 +1041,10 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_hybrid_owner_update_newversion",
-        test_cmd = """
-            --clear-bitstream
+    fpga = {
+        "changes_otp": True,
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_hybrid_owner_update_newversion",
+        "test_cmd": """
             --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -1095,6 +1056,6 @@ ownership_transfer_test(
             --expect "config_version = 1"
             --expect "owner_key = 8e3dcb50"
         """,
-        test_harness = "//sw/host/tests/ownership:newversion_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:newversion_test",
+    },
 )

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/defs.bzl
@@ -4,6 +4,7 @@
 
 load(
     "//rules/opentitan:defs.bzl",
+    "fpga_params",
     "opentitan_test",
 )
 
@@ -16,6 +17,7 @@ def ownership_transfer_test(
         ecdsa_key = {
             "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
         },
+        fpga = None,
         manifest = None,
         data = [
             "//sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key",
@@ -49,6 +51,14 @@ def ownership_transfer_test(
             "//sw/device/silicon_creator/lib/ownership:datatypes",
         ],
         **kwargs):
+    # FPGA should always clear the bitstream & bootstrap first, so
+    # enable these on every FPGA test unless overridden
+    if "test_cmd" in fpga:
+        fpga["test_cmd"] = """
+            --clear-bitstream
+        """ + fpga["test_cmd"]
+    fpga = fpga_params(**fpga)
+
     opentitan_test(
         name = name,
         srcs = srcs,
@@ -58,5 +68,6 @@ def ownership_transfer_test(
         data = data,
         defines = defines,
         deps = deps,
+        fpga = fpga,
         **kwargs
     )

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/defs.bzl
@@ -53,10 +53,11 @@ def ownership_transfer_test(
         **kwargs):
     # FPGA should always clear the bitstream & bootstrap first, so
     # enable these on every FPGA test unless overridden
-    if "test_cmd" in fpga:
-        fpga["test_cmd"] = """
-            --clear-bitstream
-        """ + fpga["test_cmd"]
+    fpga = {
+        "testopt_clear_after_test": "True",
+        "testopt_clear_before_test": "True",
+        "testopt_bootstrap": "True",
+    } | (fpga or {})
     fpga = fpga_params(**fpga)
 
     opentitan_test(

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -117,16 +117,12 @@ _CONFIGS = {
             binaries = {
                 ":boot_test_{}".format(name): "payload",
             },
-            changes_otp = True,  # See important note at the top
             params = config["params"],
             rom_ext = config["rom_ext"],
             setup = config["setup"],
             slot = position["slot"],
             tags = config["tags"],
             test_cmd = """
-                --exec="transport init"
-                --exec="fpga clear-bitstream"
-                --exec="fpga load-bitstream {bitstream}"
                 {setup}
                 --exec="bootstrap --clear-uart=true {rom_ext}"
                 # First make sure the ROM_EXT is faulting because there is no firmware
@@ -137,6 +133,9 @@ _CONFIGS = {
                 --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
                 no-op
             """,
+            testopt_bootstrap = "False",
+            testopt_clear_after_test = "True",  # See important note at the top
+            testopt_clear_before_test = "True",
         ),
     )
     for name, position in _POSITIONS.items()
@@ -176,7 +175,6 @@ genrule(
                 ":boot_test_{}".format(name): "payload",
                 ":bad_rom_ext": "bad_rom_ext",
             },
-            changes_otp = True,  # See important note at the top
             exit_failure = _RESCUE_ROMEXT_RESULTS[name == rxslot]["failure"],
             exit_success = _RESCUE_ROMEXT_RESULTS[name == rxslot]["success"].format(slot = name),
             image_name = "/tmp/rescue_rom_ext_{}.img".format(name),
@@ -184,9 +182,6 @@ genrule(
             rom_ext_offset = _POSITIONS[rxslot]["rom_ext_offset"],
             slot = position["slot"],
             test_cmd = """
-                --exec="transport init"
-                --exec="fpga load-bitstream {bitstream}"
-                --exec="bootstrap --clear-uart=true {firmware}"
                 # First make sure the ROM_EXT is faulting because there is no firmware
                 --exec="console --non-interactive --exit-success='BFV:' --exit-failure='PASS|FAIL'"
                 # Construct a firmware image with the bad ROM_EXT
@@ -197,6 +192,7 @@ genrule(
                 --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
                 no-op
             """,
+            testopt_clear_after_test = "True",  # See important note at the top
         ),
     )
     for name, position in _POSITIONS.items()
@@ -215,16 +211,11 @@ genrule(
                 ":boot_test_slot_a": "slot_a",
                 ":boot_test_slot_b": "slot_b",
             },
-            changes_otp = True,  # See important note at the top
             params = config["params"],
             rom_ext = config["rom_ext"],
             setup = config["setup"],
             tags = config["tags"],
             test_cmd = """
-                --exec="transport init"
-                --exec="fpga clear-bitstream"
-                --exec="fpga load-bitstream {bitstream}"
-                --exec="bootstrap --clear-uart=true {firmware}"
                 --exec="console --non-interactive --timeout=100ms"
                 {setup}
                 --exec="no-op --info='##### Set next slot via the rescue protocol'"
@@ -237,6 +228,8 @@ genrule(
                 --exec="console --non-interactive --exit-success='bl0_slot = AA__\r\n' --exit-failure='{exit_failure}'"
                 no-op
             """,
+            testopt_clear_after_test = "True",  # See important note at the top
+            testopt_clear_before_test = "True",
         ),
     )
     for protocol, config in _CONFIGS.items()
@@ -254,16 +247,12 @@ genrule(
                 ":boot_test_slot_a": "slot_a",
                 ":boot_test_slot_b": "slot_b",
             },
-            changes_otp = True,  # See important note at the top
             params = config["params"],
             rom_ext = config["rom_ext"],
             setup = config["setup"],
             tags = config["tags"],
             test_cmd = """
-                --exec="transport init"
-                --exec="fpga clear-bitstream"
-                --exec="fpga load-bitstream {bitstream}"
-                --exec="bootstrap --clear-uart=true {firmware}"
+                --exec="console --non-interactive --timeout=100ms"
                 {setup}
                 --exec="no-op --info='##### Set primary slot via the rescue protocol'"
                 --exec="rescue {params} boot-svc set-next-bl0-slot --primary=SlotB"
@@ -279,6 +268,8 @@ genrule(
                 --exec="console --non-interactive --exit-success='bl0_slot = AA__\r\n' --exit-failure='{exit_failure}'"
                 no-op
             """,
+            testopt_clear_after_test = "True",  # See important note at the top
+            testopt_clear_before_test = "True",
         ),
     )
     for protocol, config in _CONFIGS.items()
@@ -295,11 +286,8 @@ genrule(
             binaries = {
                 ":boot_test_slot_a": "payload",
             },
-            changes_otp = True,  # See important note at the top
             rate = rate,
             test_cmd = """
-                --exec="transport init"
-                --exec="fpga load-bitstream {bitstream}"
                 --exec="bootstrap --clear-uart=true {rom_ext}"
                 # First make sure the ROM_EXT is faulting because there is no firmware
                 --exec="console --non-interactive --exit-success='BFV:' --exit-failure='PASS|FAIL'"
@@ -309,6 +297,8 @@ genrule(
                 --exec="console --baudrate=115200 --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
                 no-op
             """,
+            testopt_bootstrap = "False",
+            testopt_clear_after_test = "True",  # See important note at the top
         ),
     )
     # FPGA CW310 and CW340 only support the baudrate up to 230K.
@@ -329,11 +319,8 @@ genrule(
             binaries = {
                 ":boot_test_slot_a": "payload",
             },
-            changes_otp = True,  # See important note at the top
             rate = rate,
             test_cmd = """
-                --exec="transport init"
-                --exec="fpga load-bitstream {bitstream}"
                 --exec="bootstrap --clear-uart=true {rom_ext}"
                 # Trigger rescue.
                 --exec="rescue no-op"
@@ -342,6 +329,8 @@ genrule(
                 --exec="console --non-interactive --send='REBO\r' --exit-success='ROM:' --exit-failure='BFV:.*\r\n'"
                 no-op
             """,
+            testopt_bootstrap = "False",
+            testopt_clear_after_test = "True",  # See important note at the top
         ),
     )
     # FPGA CW310 and CW340 only support the baudrate up to 230K.
@@ -363,13 +352,8 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        changes_otp = True,  # See important note at the top
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_xmodem_timeout",
         test_cmd = """
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {firmware}"
             # Trigger rescue and do nothing.  We expect the inactivity timer to
             # cause rescue to exit and then boot the firmware.
             --exec="rescue no-op"
@@ -377,6 +361,8 @@ opentitan_test(
             --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
             no-op
         """,
+        testopt_clear_after_test = "True",  # See important note at the top
+        testopt_clear_before_test = "True",
     ),
     deps = [
         "//sw/device/lib/base:status",
@@ -404,7 +390,6 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        changes_otp = True,  # See important note at the top
         # We configure OTP to preserve the reset reason and set the watchdog timeout
         # to one second.
         otp = "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_preserve_reset_prod",
@@ -412,10 +397,6 @@ opentitan_test(
         # want to simulate the trigger being jammed.
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_spidfu",
         test_cmd = """
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {firmware}"
             # Set the trigger with gpio command to simulate the trigger being jammed.
             --exec="gpio set --mode PushPull --value true Ioa2"
             # Check for firmware execution.  We'll enter rescue, timeout,
@@ -423,6 +404,8 @@ opentitan_test(
             --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
             no-op
         """,
+        testopt_clear_after_test = "True",  # See important note at the top
+        testopt_clear_before_test = "True",
     ),
     deps = [
         "//sw/device/lib/base:status",
@@ -442,15 +425,10 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        changes_otp = True,  # See important note at the top
         exit_failure = "ok: ",
         exit_success = "error: mode not allowed",
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_xmodem_restricted_commands",
         test_cmd = """
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {firmware}"
             # Trigger rescue and make sure we can get the device ID.
             --exec="rescue get-device-id --reboot=false"
             # Try the `RESQ` mode and make sure we get an error message.
@@ -459,6 +437,8 @@ opentitan_test(
             --exec="console --non-interactive --send='REBO\r' --exit-success='ROM:' --exit-failure='BFV:.*\r\n'"
             no-op
         """,
+        testopt_clear_after_test = "True",  # See important note at the top
+        testopt_clear_before_test = "True",
     ),
     deps = [
         "//sw/device/lib/base:status",
@@ -479,20 +459,17 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        changes_otp = True,  # See important note at the top
         params = "-p spi-dfu -t gpio -v +Ioa2",
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_spidfu_restricted_commands",
         setup = "--exec=\"gpio set --mode OpenDrain Ioa2\"",
         test_cmd = """
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
             {setup}
-            --exec="bootstrap --clear-uart=true {firmware}"
             # Trigger rescue and make sure we can get the device ID.
             --exec="rescue {params} get-device-id --reboot=false"
             no-op
         """,
+        testopt_clear_after_test = "True",  # See important note at the top
+        testopt_clear_before_test = "True",
     ),
     deps = [
         "//sw/device/lib/base:status",
@@ -510,7 +487,6 @@ opentitan_test(
         },
         fpga = fpga_params(
             assemble = "",
-            changes_otp = True,  # See important note at the top
             exit_success = "BFV:05524304\r\n",
             # Wait for at least the rescue timeout + 5 seconds
             rescue_tmo = "{}s".format(config.get("rescue_timeout", 5) + 5),
@@ -521,9 +497,6 @@ opentitan_test(
             setup = config["setup"],
             tags = config["tags"],
             test_cmd = """
-                --exec="transport init"
-                --exec="fpga clear-bitstream"
-                --exec="fpga load-bitstream {bitstream}"
                 {setup}
                 # Load only the ROM_EXT so the boot will fail because of no firmware.
                 --exec="bootstrap --clear-uart=true {rom_ext}"
@@ -531,6 +504,9 @@ opentitan_test(
                 --exec="console --non-interactive --exit-success='{exit_success}' --timeout={rescue_tmo}"
                 no-op
             """,
+            testopt_bootstrap = "False",
+            testopt_clear_after_test = "True",  # See important note at the top
+            testopt_clear_before_test = "True",
         ),
     )
     for name, config in _CONFIGS.items()
@@ -544,15 +520,15 @@ opentitan_test(
         },
         fpga = fpga_params(
             assemble = "",
-            changes_otp = True,  # See important note at the top
             params = config["params"],
             rom_ext = config["rom_ext"],
             test_cmd = """
-            --clear-bitstream
             --bootstrap={rom_ext}
             rescue {params} --action=get-boot-log
             """,
             test_harness = "//sw/host/tests/rescue:rescue_test",
+            testopt_clear_after_test = "True",  # See important note at the top
+            testopt_clear_before_test = "True",
         ),
     )
     for protocol, config in _CONFIGS.items()
@@ -566,17 +542,17 @@ opentitan_test(
         },
         fpga = fpga_params(
             assemble = "",
-            changes_otp = True,  # See important note at the top
             device_id = DEVICE_ID,
             params = config["params"],
             rom_ext = config["rom_ext"],
             test_cmd = """
-            --clear-bitstream
             --bootstrap={rom_ext}
             --device-id={device_id}
             rescue {params} --action=get-device-id
             """,
             test_harness = "//sw/host/tests/rescue:rescue_test",
+            testopt_clear_after_test = "True",  # See important note at the top
+            testopt_clear_before_test = "True",
         ),
     )
     for protocol, config in _CONFIGS.items()
@@ -594,16 +570,15 @@ opentitan_test(
                 config["rom_ext"]: "romext",
                 "//sw/device/silicon_creator/rom_ext/e2e/attestation:print_certs": "firmware",
             },
-            changes_otp = True,  # See important note at the top
             owner_offset = "0x10000",
             params = config["params"],
             romext_offset = "0",
             test_cmd = """
-            --clear-bitstream
-            --bootstrap={firmware}
             rescue {params} --action=get-owner-page
             """,
             test_harness = "//sw/host/tests/rescue:rescue_test",
+            testopt_clear_after_test = "True",  # See important note at the top
+            testopt_clear_before_test = "True",
         ),
     )
     for protocol, config in _CONFIGS.items()
@@ -623,11 +598,11 @@ opentitan_test(
         owner_offset = "0x10000",
         romext_offset = "0",
         test_cmd = """
-        --clear-bitstream
-        --bootstrap={firmware}
         rescue --action=disability
         """,
         test_harness = "//sw/host/tests/rescue:rescue_test",
+        testopt_clear_after_test = "True",  # See important note at the top
+        testopt_clear_before_test = "True",
     ),
 )
 
@@ -642,16 +617,15 @@ opentitan_test(
             "//sw/device/silicon_creator/rom_ext:rom_ext_spidfu_rescue_disability": "romext",
             "//sw/device/silicon_creator/rom_ext/e2e/attestation:print_certs": "firmware",
         },
-        changes_otp = True,  # See important note at the top
         owner_offset = "0x10000",
         params = "-p spi-dfu -t gpio -v +Ioa2",
         romext_offset = "0",
         test_cmd = """
-        --clear-bitstream
-        --bootstrap={firmware}
         rescue {params} --action=disability
         """,
         test_harness = "//sw/host/tests/rescue:rescue_test",
+        testopt_clear_after_test = "True",  # See important note at the top
+        testopt_clear_before_test = "True",
     ),
 )
 
@@ -664,9 +638,6 @@ opentitan_test(
         assemble = "",
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
         test_cmd = """
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
             --exec="bootstrap --clear-uart=true {rom_ext}"
             # Trigger rescue and make sure we can get the device ID.
             --exec="rescue get-device-id --reboot=false"
@@ -676,6 +647,8 @@ opentitan_test(
             --exec="console --non-interactive --send='REBO\r' --exit-success='ROM:' --exit-failure='BFV:.*\r\n'"
             no-op
         """,
+        testopt_bootstrap = "False",
+        testopt_clear_before_test = "True",
     ),
 )
 
@@ -691,10 +664,6 @@ opentitan_test(
             ":boot_test_slot_a": "firmware",
         },
         test_cmd = """
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {firmware}"
             --exec="console --non-interactive --exit-success='warning: rescue' --exit-failure='{exit_failure}'"
             # Trigger rescue and make sure we can get the device ID even if the protocol specified in the rescue
             # config doesn't match the ROM_EXT implementation.
@@ -703,6 +672,7 @@ opentitan_test(
             --exec="console --non-interactive --send='REBO\r' --exit-success='Finished' --exit-failure='BFV:.*\r\n'"
             no-op
         """,
+        testopt_clear_before_test = "True",
     ),
 )
 
@@ -719,11 +689,10 @@ opentitan_test(
         },
         params = "-p spi-dfu -t gpio -v +Ioa2",
         test_cmd = """
-        --clear-bitstream
-        --bootstrap={firmware}
         rescue {params} --action=disability
         """,
         test_harness = "//sw/host/tests/rescue:rescue_test",
+        testopt_clear_before_test = "True",
     ),
 )
 
@@ -739,11 +708,8 @@ opentitan_test(
             "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a": "romext",
             ":boot_test_slot_a": "firmware",
         },
-        test_cmd = """
-        --clear-bitstream
-        --bootstrap={firmware}
-        """,
         test_harness = "//sw/host/tests/rescue:xmodem_rescue_error_handling",
+        testopt_clear_before_test = "True",
     ),
 )
 
@@ -760,11 +726,10 @@ opentitan_test(
         },
         params = "-p spi-dfu -t gpio -v +Ioa2",
         test_cmd = """
-        --clear-bitstream
-        --bootstrap={firmware}
         rescue {params} --action=spi-dfu-state-transitions
         """,
         test_harness = "//sw/host/tests/rescue:dfu_rescue_error_handling",
+        testopt_clear_before_test = "True",
     ),
 )
 
@@ -781,11 +746,10 @@ opentitan_test(
         },
         params = "-p spi-dfu -t gpio -v +Ioa2",
         test_cmd = """
-        --clear-bitstream
-        --bootstrap={firmware}
         rescue {params} --action=invalid-spi-dfu-requests
         """,
         test_harness = "//sw/host/tests/rescue:dfu_rescue_error_handling",
+        testopt_clear_before_test = "True",
     ),
 )
 
@@ -802,11 +766,10 @@ opentitan_test(
         },
         params = "-p spi-dfu -t gpio -v +Ioa2",
         test_cmd = """
-        --clear-bitstream
-        --bootstrap={firmware}
         rescue {params} --action=invalid-spi-flash-transaction
         """,
         test_harness = "//sw/host/tests/rescue:dfu_rescue_error_handling",
+        testopt_clear_before_test = "True",
     ),
 )
 
@@ -823,11 +786,10 @@ opentitan_test(
         },
         params = "-p usb-dfu -t strap -v 3",
         test_cmd = """
-        --clear-bitstream
-        --bootstrap={firmware}
         rescue {params} --action=usb-dfu-out-chunk-too-big
         """,
         test_harness = "//sw/host/tests/rescue:dfu_rescue_error_handling",
+        testopt_clear_before_test = "True",
     ),
 )
 
@@ -842,17 +804,10 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        changes_otp = True,  # See important note at the top
         exit_failure = "(FAIL|BFV:|mode: RESQ).*",
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
-        test_cmd = """
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {firmware}"
-            --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-            no-op
-        """,
+        testopt_clear_after_test = "True",  # See important note at the top
+        testopt_clear_before_test = "True",
     ),
     deps = [
         "//sw/device/lib/base:status",
@@ -874,17 +829,10 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        changes_otp = True,  # See important note at the top
         exit_success = "mode: RESQ",
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_xmodem_enter_on_watchdog",
-        test_cmd = """
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {firmware}"
-            --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-            no-op
-        """,
+        testopt_clear_after_test = "True",  # See important note at the top
+        testopt_clear_before_test = "True",
     ),
     deps = [
         "//sw/device/lib/base:status",

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/std_utils/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/std_utils/BUILD
@@ -22,11 +22,13 @@ opentitan_test(
         },
         changes_otp = True,
         test_cmd = """
-            --clear-bitstream
             --bootstrap={rom_ext}
             --firmware={boot_test}
         """,
         test_harness = "//sw/host/tests/rescue:xmodem_protocol",
+        testopt_bootstrap = "False",
+        testopt_clear_after_test = "True",
+        testopt_clear_before_test = "True",
     ),
 )
 
@@ -43,7 +45,6 @@ opentitan_test(
         changes_otp = True,
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_usbdfu",
         test_cmd = """
-            --clear-bitstream
             --bootstrap={rom_ext}
             --firmware={boot_test}
             rescue
@@ -51,5 +52,8 @@ opentitan_test(
             --value=3
         """,
         test_harness = "//sw/host/tests/rescue:usbdfu_protocol",
+        testopt_bootstrap = "False",
+        testopt_clear_after_test = "True",
+        testopt_clear_before_test = "True",
     ),
 )

--- a/sw/device/silicon_creator/rom_ext/e2e/secver/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/secver/BUILD
@@ -114,7 +114,6 @@ opentitan_test(
             ":rom_ext_2": "rom_ext2",
             ":rom_ext_3": "rom_ext3",
         },
-        changes_otp = True,
         exit_success = "BFV:{}".format(hex_digits(CONST.BFV.BOOT_POLICY.ROLLBACK)),
         rom_ext = ":rom_ext_0",
         test_cmd = """
@@ -122,12 +121,8 @@ opentitan_test(
             --exec="image assemble -s 131072 --mirror=false -o fw1.bin {rom_ext1}@0 {boot_test_b}@0x10000"
             --exec="image assemble -s 131072 --mirror=false -o fw2.bin {rom_ext2}@0 {boot_test_a}@0x10000"
             --exec="image assemble -s 131072 --mirror=false -o fw3.bin {rom_ext3}@0 {boot_test_b}@0x10000"
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
 
-            # Bootstrap the initial version 0 into SlotA
-            --exec="bootstrap --clear-uart=true {firmware}"
+            # Check the initial version 0 has been bootstrapped into SlotA
             --exec="console --non-interactive --exit-success='rom_ext_min_sec_ver = 0'"
 
             # Rescue and update to SlotB.  We expect to update the secver.
@@ -147,6 +142,8 @@ opentitan_test(
             --exec="console --non-interactive --exit-success='{exit_success}' --timeout=10s"
             no-op
         """,
+        testopt_clear_after_test = "True",
+        testopt_clear_before_test = "True",
     ),
 )
 

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4564,12 +4564,9 @@ opentitan_test(
         # is not run in CI which causes a CI error ("Verify FPGA Jobs" check
         # will fail).
         tags = ["manuf"],
-        test_cmd = """
-            --clear-bitstream
-            --bootstrap="{firmware}"
-            "{firmware:elf}"
-        """,
+        test_cmd = "{firmware:elf}",
         test_harness = "//sw/host/tests/chip/ottf_console_with_gpio_tx_indicator",
+        testopt_clear_before_test = "True",
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -6304,6 +6301,7 @@ test_suite(
             ],
             test_cmd = " --expect-fail" if lc_state_val in _LC_STATES_DEBUG_DISALLOWED else "",
             test_harness = "//sw/host/tests/chip/rv_dm:lc_disabled",
+            testopt_bootstrap = "False",
         ),
         silicon = silicon_params(
             needs_jtag = True,
@@ -7116,6 +7114,7 @@ opentitan_test(
         otp = "//sw/device/silicon_creator/manuf/tests:otp_img_rom_exec_disabled_test_unlocked0",
         test_cmd = "--elf={sram_program}",
         test_harness = "//sw/host/tests/chip/rv_core_ibex_isa",
+        testopt_bootstrap = "False",
     ),
     silicon = silicon_params(
         needs_jtag = True,
@@ -7221,6 +7220,7 @@ opentitan_test(
         tags = ["manual"],
         test_cmd = "--elf={sram_program}",
         test_harness = "//sw/host/tests/chip/rv_core_ibex_epmp",
+        testopt_bootstrap = "False",
     ),
     silicon = silicon_params(
         needs_jtag = True,
@@ -7349,6 +7349,7 @@ opentitan_test(
         otp = "//sw/device/silicon_creator/manuf/tests:otp_img_rom_exec_disabled_test_unlocked0",
         test_cmd = "--elf={sram_program}",
         test_harness = "//sw/host/tests/chip/rv_core_ibex_epmp",
+        testopt_bootstrap = "False",
     ),
     silicon = silicon_params(
         binaries = {

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4558,12 +4558,6 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
     },
     fpga = fpga_params(
-        # We run this as part of the manuf test suite as we want to run it in
-        # the hyper310 exec_env as this is most realistic of a provisioning
-        # scenario where this feature will be used. Without this tag, the test
-        # is not run in CI which causes a CI error ("Verify FPGA Jobs" check
-        # will fail).
-        tags = ["manuf"],
         test_cmd = "{firmware:elf}",
         test_harness = "//sw/host/tests/chip/ottf_console_with_gpio_tx_indicator",
         testopt_clear_before_test = "True",

--- a/sw/host/opentitanlib/src/test_utils/init.rs
+++ b/sw/host/opentitanlib/src/test_utils/init.rs
@@ -29,6 +29,10 @@ pub struct InitializeTest {
     #[arg(long, default_value = "off")]
     pub logging: LevelFilter,
 
+    /// De-assert reset signal before executing commands.
+    #[arg(short, long)]
+    drop_reset: bool,
+
     #[command(flatten)]
     pub backend_opts: backend::BackendOpts,
 
@@ -139,6 +143,10 @@ impl InitializeTest {
 
         // Set up the default pin configurations as specified in the transport's config file.
         transport.apply_default_configuration(None)?;
+
+        if self.drop_reset {
+            transport.pin_strapping("RESET")?.remove()?;
+        }
 
         // Create the UART first to initialize the desired parameters.
         let _uart = self.bootstrap.options.uart_params.create(&transport)?;

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -110,6 +110,10 @@ struct Opts {
     #[arg(long, num_args = 1)]
     exec: Vec<String>,
 
+    /// De-assert reset signal before executing commands.
+    #[arg(short, long)]
+    drop_reset: bool,
+
     #[command(flatten)]
     backend_opts: backend::BackendOpts,
 
@@ -231,6 +235,10 @@ fn main() -> Result<()> {
     let opts = parse_command_line(Opts::parse(), args_os())?;
 
     let transport = backend::create(&opts.backend_opts)?;
+
+    if opts.drop_reset {
+        transport.pin_strapping("RESET")?.remove()?;
+    }
 
     for command in &opts.exec {
         execute(


### PR DESCRIPTION
This PR backports the first 4 commits of #28552. The rationale is that we want to do more work on the build system in master so it's preferable to backport this to avoid conflict. I am *not* backporting the part of #28552 which switches tests to the new system because there are many conflicts and some PRs have not yet been backported which make it awkward to handle.