### PR TITLE
[kmac,dv] Fix type of DPI interface

### DIFF
--- a/hw/ip/kmac/dv/dpi/digestpp_dpi.cc
+++ b/hw/ip/kmac/dv/dpi/digestpp_dpi.cc
@@ -217,7 +217,7 @@ extern void c_dpi_cshake256(const svOpenArrayHandle msg,
 extern void c_dpi_kmac128(const svOpenArrayHandle msg, uint64_t msg_len,
                           const svOpenArrayHandle key, uint64_t key_len,
                           const char *customization_str, uint64_t output_len,
-                          svBitVecVal *digest) {
+                          svOpenArrayHandle digest) {
   uint64_t output_len_bits = output_len * 8;
 
   // Load message from SV memory
@@ -255,7 +255,7 @@ extern void c_dpi_kmac128(const svOpenArrayHandle msg, uint64_t msg_len,
 extern void c_dpi_kmac128_xof(const svOpenArrayHandle msg, uint64_t msg_len,
                               const svOpenArrayHandle key, uint64_t key_len,
                               const char *customization_str,
-                              uint64_t output_len, svBitVecVal *digest) {
+                              uint64_t output_len, svOpenArrayHandle digest) {
   // Load message from SV memory
   uint8_t *msg_arr = (uint8_t *)malloc(msg_len * sizeof(uint8_t));
   load_arr_from_simulator(msg, msg_arr, msg_len);
@@ -291,7 +291,7 @@ extern void c_dpi_kmac128_xof(const svOpenArrayHandle msg, uint64_t msg_len,
 extern void c_dpi_kmac256(const svOpenArrayHandle msg, uint64_t msg_len,
                           const svOpenArrayHandle key, uint64_t key_len,
                           const char *customization_str, uint64_t output_len,
-                          svBitVecVal *digest) {
+                          svOpenArrayHandle digest) {
   uint64_t output_len_bits = output_len * 8;
 
   // Load message from SV memory
@@ -329,7 +329,7 @@ extern void c_dpi_kmac256(const svOpenArrayHandle msg, uint64_t msg_len,
 extern void c_dpi_kmac256_xof(const svOpenArrayHandle msg, uint64_t msg_len,
                               const svOpenArrayHandle key, uint64_t key_len,
                               const char *customization_str,
-                              uint64_t output_len, svBitVecVal *digest) {
+                              uint64_t output_len, svOpenArrayHandle digest) {
   // Load message from SV memory
   uint8_t *msg_arr = (uint8_t *)malloc(msg_len * sizeof(uint8_t));
   load_arr_from_simulator(msg, msg_arr, msg_len);


### PR DESCRIPTION
This argument in the C functions is for what the DPI layer calls an "open array":
```
  import "DPI-C" context function void c_dpi_cshake128(
    input bit[7:0]          msg[],
    input string            function_name,
    input string            customization_str,
    input longint unsigned  msg_len,
    input longint unsigned  output_len,
    output bit[7:0]         digest[]
  );
```
(see section H.8.6 of IEEE 1800-2012) and, as such, should be given an svOpenArrayHandle on the C side.

The typedef is not very informative: it's actually void*! But it makes more sense to be consistent with the other equivalent arguments.

This PR is split out from #30143, where @etterli originally added it.