### PR TITLE
[crypto/25519] Fix the KAT for x25519

### DIFF
--- a/sw/device/tests/crypto/cryptotest/firmware/x25519.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/x25519.c
@@ -106,7 +106,7 @@ status_t handle_x25519_key_exchange(ujson_t *uj) {
 
   TRY(otcrypto_x25519(&private_key, &server_public_key, &shared_secret));
 
-  // Unmask the shared secret by adding its two shares.
+  // Unmask the shared secret by xoring its two shares.
   uint32_t dest_share0[kX25519SharedSecretWords];
   uint32_t dest_share1[kX25519SharedSecretWords];
   otcrypto_word32_buf_t share0_buf = OTCRYPTO_MAKE_BUF(
@@ -116,7 +116,7 @@ status_t handle_x25519_key_exchange(ujson_t *uj) {
   TRY(otcrypto_export_blinded_key(&shared_secret, &share0_buf, &share1_buf));
 
   uint32_t unblinded_secret[kX25519SharedSecretWords];
-  TRY(hardened_add(dest_share0, dest_share1, kX25519SharedSecretWords,
+  TRY(hardened_xor(dest_share0, dest_share1, kX25519SharedSecretWords,
                    unblinded_secret));
 
   cryptotest_x25519_kex_output_t uj_output;
@@ -228,7 +228,7 @@ status_t handle_x25519_shared_secret_generation(ujson_t *uj) {
   TRY(otcrypto_export_blinded_key(&shared_secret, &share0_buf, &share1_buf));
 
   uint32_t unblinded_secret[kX25519SharedSecretWords];
-  TRY(hardened_add(dest_share0, dest_share1, kX25519SharedSecretWords,
+  TRY(hardened_xor(dest_share0, dest_share1, kX25519SharedSecretWords,
                    unblinded_secret));
 
   memcpy(uj_output.shared_secret, unblinded_secret,

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
@@ -1649,7 +1649,7 @@ status_t cryptolib_fi_x25519_ecdh_impl(
                                            &ss_share1_buf));
 
   uint32_t ss_unmasked[8];
-  HARDENED_TRY(hardened_add(ss_share0, ss_share1, 8, ss_unmasked));
+  HARDENED_TRY(hardened_xor(ss_share0, ss_share1, 8, ss_unmasked));
 
   uj_output->cfg = 0;
   memset(uj_output->shared_key, 0, X25519_CMD_BYTES);
@@ -1738,7 +1738,7 @@ status_t cryptolib_fi_x25519_point_mul_impl(
                                            &ss_share1_buf));
 
   uint32_t ss_unmasked[8];
-  HARDENED_TRY(hardened_add(ss_share0, ss_share1, 8, ss_unmasked));
+  HARDENED_TRY(hardened_xor(ss_share0, ss_share1, 8, ss_unmasked));
 
   // Map the unmasked secret back to the point multiplication output
   uj_output->cfg = 0;

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym_impl.c
@@ -1061,7 +1061,7 @@ status_t cryptolib_sca_x25519_ecdh_impl(
                                            &ss_share1_buf));
 
   uint32_t ss_unmasked[8];
-  HARDENED_TRY(hardened_add(ss_share0, ss_share1, 8, ss_unmasked));
+  HARDENED_TRY(hardened_xor(ss_share0, ss_share1, 8, ss_unmasked));
 
   uj_output->cfg = 0;
   memset(uj_output->shared_key, 0, X25519_CMD_BYTES);
@@ -1140,7 +1140,7 @@ status_t cryptolib_sca_x25519_point_mul_impl(
                                            &ss_share1_buf));
 
   uint32_t ss_unmasked[8];
-  HARDENED_TRY(hardened_add(ss_share0, ss_share1, 8, ss_unmasked));
+  HARDENED_TRY(hardened_xor(ss_share0, ss_share1, 8, ss_unmasked));
 
   uj_output->cfg = 0;
   memcpy(uj_output->x, ss_unmasked, X25519_CMD_BYTES);

--- a/sw/host/tests/crypto/x25519_kat/src/main.rs
+++ b/sw/host/tests/crypto/x25519_kat/src/main.rs
@@ -131,7 +131,15 @@ fn run_x25519_testcase(
 
     let device_secret = &output.shared_secret[..output.shared_secret_len];
 
-    let success = match test_case.result {
+    let is_all_zeros = test_case.shared_secret.iter().all(|&b| b == 0);
+
+    // We expect the all zero secret outputs to be invalid
+    let mut expected_result = &test_case.result;
+    if is_all_zeros && *expected_result == X25519Result::Valid {
+        expected_result = &X25519Result::Invalid;
+    }
+
+    let success = match expected_result {
         X25519Result::Valid => output.result && device_secret == test_case.shared_secret.as_slice(),
         X25519Result::Invalid => !output.result,
     };

--- a/sw/otbn/crypto/25519.s
+++ b/sw/otbn/crypto/25519.s
@@ -2128,9 +2128,16 @@ x25519:
   bn.mov   w16, w23
   jal      x1, fe_inv
 
-  /* Compute u_masked = U_masked * W^-1 mod p. */
+  /* u_masked = U_masked * W^-1 mod p */
   bn.mov   w23, w24
   jal      x1, fe_mul
+
+  /* Check if W == 0 mod p */
+  bn.cmp   w16, w31
+  csrrs    x2, FG0, x0
+  andi     x2, x2, 8      /* Extract the Z flag */
+  addi     x3, x0, 8
+  beq      x2, x3, .L_x25519_fail  /* Reject if we have the identity point */
 
   bn.mov   w19, w25
 


### PR DESCRIPTION
With the output masking of X25519 we did not handle when W = 0. This was caught by the wycheproof vectors.
The test was also not adapted to perform the unmasking via an XOR. Also update the pentest tests.