### PR TITLE
[rv_timer,dv] Fix broken reset tracking in rv_timer_random_vseq

### DIFF
--- a/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_base_vseq.sv
+++ b/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_base_vseq.sv
@@ -141,33 +141,54 @@ class rv_timer_base_vseq extends cip_base_vseq #(
     csr_rd(.ptr(intr_state_rg), .value(status));
   endtask
 
-  // poll a intr_status continuously until it reads the expected value.
+  // Wait the given number of nanoseconds, exiting early on reset.
+  task wait_ns_or_reset(int unsigned delay_ns);
+    if (!delay_ns) return;
+    fork : isolation_fork begin
+      fork
+        #(delay_ns * 1ns);
+        wait(cfg.under_reset);
+      join_any
+      disable fork;
+    end join
+  endtask
+
+  // Poll the intr_state register for the given hart until it reads the expected value.
+  //
+  // There is a gap of spinwait_delay_ns between each read and a timeout of timeout_ns.
   virtual task intr_state_spinwait(input int  hart              = 0,
                                    input uint exp_data          = 0,
                                    input uint spinwait_delay_ns = 0,
                                    input uint timeout_ns        = 10_000_000); // 10ms
-    bit [TL_DW-1:0] read_data;
-    uvm_reg intr_state_rg;
-    intr_state_rg = ral.get_reg_by_name($sformatf("intr_state%0d", hart));
-    `DV_CHECK_NE_FATAL(intr_state_rg, null)
-    fork
-      begin : isolation_fork
-        fork
-          while (1) begin
-            csr_rd(.ptr(intr_state_rg), .value(read_data));
-            if (read_data == exp_data) break;
-            if (spinwait_delay_ns) #(spinwait_delay_ns * 1ns);
-          end
-          wait (cfg.under_reset);
-          begin
-            `DV_WAIT_TIMEOUT(timeout_ns, "intr_state_spinwait",
-                             $sformatf("timeout %0s (addr=0x%0h) == 0x%0h",
-                             intr_state_rg.get_full_name(), intr_state_rg.get_address(), exp_data))
-          end
-        join_any
-        disable fork;
-      end : isolation_fork
-    join
+    uvm_reg intr_state_rg = ral.get_reg_by_name($sformatf("intr_state%0d", hart));
+    bit     seen_exp_data = 0;
+
+    if (intr_state_rg == null)
+      `uvm_fatal(get_full_name(),
+                 $sformatf("Cannot find intr_state register for hart %0d", hart))
+
+    fork : isolation_fork begin
+      fork
+        while (!seen_exp_data && !cfg.under_reset) begin
+          bit [TL_DW-1:0] read_data;
+
+          csr_rd(.ptr(intr_state_rg), .value(read_data));
+          seen_exp_data = (read_data == exp_data);
+          if (!seen_exp_data) wait_ns_or_reset(spinwait_delay_ns);
+        end
+        `DV_WAIT_TIMEOUT(timeout_ns, "intr_state_spinwait",
+                         $sformatf("timeout %0s (addr=0x%0h) == 0x%0h",
+                                   intr_state_rg.get_full_name(),
+                                   intr_state_rg.get_address(),
+                                   exp_data))
+      join_any
+
+      // If we get here then the spinwait has seen a reset or the value it expected or we have timed
+      // out. In the former case, we should just disable the timeout thread. In the latter case, we
+      // can safely disable the spinwait thread. It doesn't really matter if we mess up a TL driver:
+      // we've reported an error already.
+      disable fork;
+    end join
   endtask
 
   // task to read interrupt status reg for given Hart

--- a/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_random_vseq.sv
+++ b/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_random_vseq.sv
@@ -100,6 +100,39 @@ class rv_timer_random_vseq extends rv_timer_base_vseq;
     num_trans.rand_mode(0);
   endtask
 
+  // Repeatedly read each hart's intr_state register until its bits exactly equal the set of enabled
+  // timers (en_timers), meaning that the right interrupts have been asserted.
+  //
+  // The spinwait calls have timeouts derived from timeout_ns. The task will exit immediately on
+  // reset.
+  task intr_state_spinwait_all_harts(int unsigned timeout_ns);
+    fork : isolation_fork begin
+      for (int i = 0; i < NUM_HARTS; i++) begin
+        automatic int a_i = i;
+        if (en_harts[a_i]) begin
+          fork begin
+            // Poll intr_status continuously until it reads the expected value. If the interrupt
+            // will happen in timeout_ns nanoseconds and we happen to read the state just
+            // beforehand, we'll see the high value on the next read (delay nanoseconds later). As
+            // such, we set the spinwait timeout to the sum of the two numbers plus an extra 100ns
+            // for a few extra clock ticks.
+            int unsigned actual_timeout_ns;
+
+            `DV_CHECK_MEMBER_RANDOMIZE_FATAL(delay)
+
+            actual_timeout_ns = 100 + delay + timeout_ns;
+            intr_state_spinwait(.hart(a_i), .exp_data(en_timers),
+                                .spinwait_delay_ns(delay), .timeout_ns(actual_timeout_ns));
+          end join_none
+        end
+      end
+
+      // Wait for all of the interrupt polling tasks to complete. If a reset is asserted, they will
+      // all complete immediately.
+      wait fork;
+    end join
+  endtask
+
   task body();
     // This task will run timers and wait until they raise an interrupt. This timeout gives an upper
     // bound on how long to wait.
@@ -123,41 +156,16 @@ class rv_timer_random_vseq extends rv_timer_base_vseq;
         end
       end
 
-      // assert reset while timer is running
-      if (assert_reset) begin
-        `DV_CHECK_MEMBER_RANDOMIZE_FATAL(delay)
-        cfg.clk_rst_vif.wait_clks_or_rst(delay);
-        dut_init("HARD");
-      end
+      fork
+        // Wait a randomised amount of time and then assert a reset (while the timer is running)
+        if (assert_reset) begin
+          `DV_CHECK_MEMBER_RANDOMIZE_FATAL(delay)
+          cfg.clk_rst_vif.wait_clks_or_rst(delay);
+          dut_init("HARD");
+        end
 
-      fork begin : isolation_fork
-        fork
-          wait (cfg.under_reset);
-          begin
-            for (int i = 0; i < NUM_HARTS; i++) begin
-              automatic int a_i = i;
-              fork
-                if (en_harts[a_i]) begin
-                  // Poll intr_status continuously until it reads the expected value. If the
-                  // interrupt will happen in intr_timeout nanoseconds and we happen to read the
-                  // state just beforehand, we'll see the high value on the next read (delay
-                  // nanoseconds later). As such, we set the spinwait timeout to the sum of the two
-                  // numbers plus an extra 100ns for a few extra clock ticks.
-                  int unsigned actual_timeout_ns;
-
-                  `DV_CHECK_MEMBER_RANDOMIZE_FATAL(delay)
-
-                  actual_timeout_ns = 100 + delay + intr_timeout_ns;
-                  intr_state_spinwait(.hart(a_i), .exp_data(en_timers),
-                                      .spinwait_delay_ns(delay), .timeout_ns(actual_timeout_ns));
-                end
-              join_none
-            end
-            wait fork;
-          end
-        join_any
-        disable fork;
-      end join
+        intr_state_spinwait_all_harts(intr_timeout_ns);
+      join
 
       // Disable timers.
       csr_wr(.ptr(ral.ctrl[0]), .value(ral.ctrl[0].get_reset()));
@@ -170,7 +178,6 @@ class rv_timer_random_vseq extends rv_timer_base_vseq;
           end
         end
       end
-
     end
   endtask : body
 


### PR DESCRIPTION
This got broken by an engineer trying to track resets properly. Among other things, the timeout in rv_timer_random_vseq got moved to occur *before* the thing it was waiting for...

Put it back in the right place and be less trigger happy with "disable fork" (to avoid killing a process that's being run by a driver).

This fixes the rv_timer_random_reset test which was broken.