### PR TITLE
[pwrmgr,dv] Add missing `pwrmgr_repeat_wakeup_reset` test

### DIFF
--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_repeat_wakeup_reset_vseq.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_repeat_wakeup_reset_vseq.sv
@@ -11,9 +11,6 @@ class pwrmgr_repeat_wakeup_reset_vseq extends pwrmgr_wakeup_reset_vseq;
 
   bit [lc_ctrl_pkg::TxWidth-1:0] bad_lc_tx;
 
-  int cycles_from_reset;
-  int micros_to_release;
-
   bit super_sequence_done;
 
   task body();
@@ -27,38 +24,58 @@ class pwrmgr_repeat_wakeup_reset_vseq extends pwrmgr_wakeup_reset_vseq;
         super.body();
         super_sequence_done = 1;
       end
-      drv_stim(mubi_mode);
+      drv_stim();
     join
   endtask : body
 
-  task drv_stim(pwrmgr_mubi_e mubi_mode);
-    if (mubi_mode == PwrmgrMubiLcCtrl) drv_lc_ctrl();
-  endtask : drv_stim
-
-  task drv_lc_ctrl();
-    int delay;
-
-    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(cycles_from_reset, cycles_from_reset inside {[2 : 8]};)
-    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(micros_to_release, micros_to_release inside {[2 : 4]};)
+  task drv_stim();
+    int unsigned cycles_from_reset = $urandom_range(2, 8);
+    int unsigned micros_to_release = $urandom_range(2, 4);
 
     repeat (50) begin : repeat_50
       wait(cfg.esc_clk_rst_vif.rst_n);
       cfg.clk_rst_vif.wait_clks(cycles_from_reset);
-      if (super_sequence_done) begin
-        `uvm_info(`gfn, "Break from drv_lc_ctrl", UVM_MEDIUM)
-        break;
-      end
-      `uvm_info(`gfn, "Injection to lc_hw_debug_en", UVM_MEDIUM)
-      cfg.pwrmgr_vif.lc_hw_debug_en = get_rand_lc_tx_val(
-          .t_weight(1), .f_weight(1), .other_weight(2)
-      );
-      #(micros_to_release * 1us);
-      `uvm_info(`gfn, "Injection to lc_dft_en", UVM_MEDIUM)
       if (super_sequence_done) break;
-      cfg.pwrmgr_vif.lc_dft_en = get_rand_lc_tx_val(.t_weight(1), .f_weight(1), .other_weight(2));
+
+      drive_inputs(1);
+      #(micros_to_release * 1us);
+      if (super_sequence_done) break;
+
+      drive_inputs(0);
       #(micros_to_release * 1us);
     end : repeat_50
-    `uvm_info(`gfn, "ended drv_lc_ctrl", UVM_MEDIUM)
-  endtask : drv_lc_ctrl
+    `uvm_info(`gfn, "ended drv_stim", UVM_MEDIUM)
+  endtask : drv_stim
+
+  task drive_inputs(bit phase0);
+    case (mubi_mode)
+      PwrmgrMubiLcCtrl:  drive_lc_ctrl_inputs(phase0);
+      PwrmgrMubiRomCtrl: drive_rom_ctrl_inputs(phase0);
+      default: `uvm_fatal(get_full_name(), $sformatf("Unknown mubi_mode: %s", mubi_mode.name()))
+    endcase
+  endtask : drive_inputs
+
+  task drive_rom_ctrl_inputs(bit phase0);
+    if (phase0) begin
+      for (int r = 0; r < NumRomInputs; r++) begin
+        mubi4_t rand_done = get_rand_mubi4_val(.t_weight(1), .f_weight(1), .other_weight(2));
+        mubi4_t rand_good = get_rand_mubi4_val(.t_weight(1), .f_weight(1), .other_weight(2));
+        `uvm_info(`gfn, $sformatf("Injection to rom_ctrl[%0d]", r), UVM_MEDIUM)
+        cfg.pwrmgr_vif.update_rom_ctrl('{done: rand_done, good: rand_good}, r);
+      end
+    end else begin
+      update_roms_response(.done(MuBi4True), .good(MuBi4True));
+    end
+  endtask : drive_rom_ctrl_inputs
+
+  task drive_lc_ctrl_inputs(bit phase0);
+    if (phase0) begin
+      cfg.pwrmgr_vif.lc_hw_debug_en = get_rand_lc_tx_val(.t_weight(1),
+                                                         .f_weight(1),
+                                                         .other_weight(2));
+    end else begin
+      cfg.pwrmgr_vif.lc_dft_en = get_rand_lc_tx_val(.t_weight(1), .f_weight(1), .other_weight(2));
+    end
+  endtask : drive_lc_ctrl_inputs
 
 endclass : pwrmgr_repeat_wakeup_reset_vseq

--- a/hw/ip_templates/pwrmgr/dv/pwrmgr_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/pwrmgr/dv/pwrmgr_sim_cfg.hjson.tpl
@@ -88,6 +88,11 @@
       run_opts: ["+test_timeout_ns=1000000"]
     }
     {
+      name: pwrmgr_repeat_wakeup_reset
+      uvm_test_seq: pwrmgr_repeat_wakeup_reset_vseq
+      run_opts: ["+test_timeout_ns=4000000", "+pwrmgr_mubi_mode=PwrmgrMubiRomCtrl"]
+    }
+    {
       name: pwrmgr_aborted_low_power
       uvm_test_seq: pwrmgr_aborted_low_power_vseq
     }

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_repeat_wakeup_reset_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_repeat_wakeup_reset_vseq.sv
@@ -11,9 +11,6 @@ class pwrmgr_repeat_wakeup_reset_vseq extends pwrmgr_wakeup_reset_vseq;
 
   bit [lc_ctrl_pkg::TxWidth-1:0] bad_lc_tx;
 
-  int cycles_from_reset;
-  int micros_to_release;
-
   bit super_sequence_done;
 
   task body();
@@ -27,38 +24,58 @@ class pwrmgr_repeat_wakeup_reset_vseq extends pwrmgr_wakeup_reset_vseq;
         super.body();
         super_sequence_done = 1;
       end
-      drv_stim(mubi_mode);
+      drv_stim();
     join
   endtask : body
 
-  task drv_stim(pwrmgr_mubi_e mubi_mode);
-    if (mubi_mode == PwrmgrMubiLcCtrl) drv_lc_ctrl();
-  endtask : drv_stim
-
-  task drv_lc_ctrl();
-    int delay;
-
-    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(cycles_from_reset, cycles_from_reset inside {[2 : 8]};)
-    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(micros_to_release, micros_to_release inside {[2 : 4]};)
+  task drv_stim();
+    int unsigned cycles_from_reset = $urandom_range(2, 8);
+    int unsigned micros_to_release = $urandom_range(2, 4);
 
     repeat (50) begin : repeat_50
       wait(cfg.esc_clk_rst_vif.rst_n);
       cfg.clk_rst_vif.wait_clks(cycles_from_reset);
-      if (super_sequence_done) begin
-        `uvm_info(`gfn, "Break from drv_lc_ctrl", UVM_MEDIUM)
-        break;
-      end
-      `uvm_info(`gfn, "Injection to lc_hw_debug_en", UVM_MEDIUM)
-      cfg.pwrmgr_vif.lc_hw_debug_en = get_rand_lc_tx_val(
-          .t_weight(1), .f_weight(1), .other_weight(2)
-      );
-      #(micros_to_release * 1us);
-      `uvm_info(`gfn, "Injection to lc_dft_en", UVM_MEDIUM)
       if (super_sequence_done) break;
-      cfg.pwrmgr_vif.lc_dft_en = get_rand_lc_tx_val(.t_weight(1), .f_weight(1), .other_weight(2));
+
+      drive_inputs(1);
+      #(micros_to_release * 1us);
+      if (super_sequence_done) break;
+
+      drive_inputs(0);
       #(micros_to_release * 1us);
     end : repeat_50
-    `uvm_info(`gfn, "ended drv_lc_ctrl", UVM_MEDIUM)
-  endtask : drv_lc_ctrl
+    `uvm_info(`gfn, "ended drv_stim", UVM_MEDIUM)
+  endtask : drv_stim
+
+  task drive_inputs(bit phase0);
+    case (mubi_mode)
+      PwrmgrMubiLcCtrl:  drive_lc_ctrl_inputs(phase0);
+      PwrmgrMubiRomCtrl: drive_rom_ctrl_inputs(phase0);
+      default: `uvm_fatal(get_full_name(), $sformatf("Unknown mubi_mode: %s", mubi_mode.name()))
+    endcase
+  endtask : drive_inputs
+
+  task drive_rom_ctrl_inputs(bit phase0);
+    if (phase0) begin
+      for (int r = 0; r < NumRomInputs; r++) begin
+        mubi4_t rand_done = get_rand_mubi4_val(.t_weight(1), .f_weight(1), .other_weight(2));
+        mubi4_t rand_good = get_rand_mubi4_val(.t_weight(1), .f_weight(1), .other_weight(2));
+        `uvm_info(`gfn, $sformatf("Injection to rom_ctrl[%0d]", r), UVM_MEDIUM)
+        cfg.pwrmgr_vif.update_rom_ctrl('{done: rand_done, good: rand_good}, r);
+      end
+    end else begin
+      update_roms_response(.done(MuBi4True), .good(MuBi4True));
+    end
+  endtask : drive_rom_ctrl_inputs
+
+  task drive_lc_ctrl_inputs(bit phase0);
+    if (phase0) begin
+      cfg.pwrmgr_vif.lc_hw_debug_en = get_rand_lc_tx_val(.t_weight(1),
+                                                         .f_weight(1),
+                                                         .other_weight(2));
+    end else begin
+      cfg.pwrmgr_vif.lc_dft_en = get_rand_lc_tx_val(.t_weight(1), .f_weight(1), .other_weight(2));
+    end
+  endtask : drive_lc_ctrl_inputs
 
 endclass : pwrmgr_repeat_wakeup_reset_vseq

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -88,6 +88,11 @@
       run_opts: ["+test_timeout_ns=1000000"]
     }
     {
+      name: pwrmgr_repeat_wakeup_reset
+      uvm_test_seq: pwrmgr_repeat_wakeup_reset_vseq
+      run_opts: ["+test_timeout_ns=4000000", "+pwrmgr_mubi_mode=PwrmgrMubiRomCtrl"]
+    }
+    {
       name: pwrmgr_aborted_low_power
       uvm_test_seq: pwrmgr_aborted_low_power_vseq
     }

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_repeat_wakeup_reset_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_repeat_wakeup_reset_vseq.sv
@@ -11,9 +11,6 @@ class pwrmgr_repeat_wakeup_reset_vseq extends pwrmgr_wakeup_reset_vseq;
 
   bit [lc_ctrl_pkg::TxWidth-1:0] bad_lc_tx;
 
-  int cycles_from_reset;
-  int micros_to_release;
-
   bit super_sequence_done;
 
   task body();
@@ -27,38 +24,58 @@ class pwrmgr_repeat_wakeup_reset_vseq extends pwrmgr_wakeup_reset_vseq;
         super.body();
         super_sequence_done = 1;
       end
-      drv_stim(mubi_mode);
+      drv_stim();
     join
   endtask : body
 
-  task drv_stim(pwrmgr_mubi_e mubi_mode);
-    if (mubi_mode == PwrmgrMubiLcCtrl) drv_lc_ctrl();
-  endtask : drv_stim
-
-  task drv_lc_ctrl();
-    int delay;
-
-    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(cycles_from_reset, cycles_from_reset inside {[2 : 8]};)
-    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(micros_to_release, micros_to_release inside {[2 : 4]};)
+  task drv_stim();
+    int unsigned cycles_from_reset = $urandom_range(2, 8);
+    int unsigned micros_to_release = $urandom_range(2, 4);
 
     repeat (50) begin : repeat_50
       wait(cfg.esc_clk_rst_vif.rst_n);
       cfg.clk_rst_vif.wait_clks(cycles_from_reset);
-      if (super_sequence_done) begin
-        `uvm_info(`gfn, "Break from drv_lc_ctrl", UVM_MEDIUM)
-        break;
-      end
-      `uvm_info(`gfn, "Injection to lc_hw_debug_en", UVM_MEDIUM)
-      cfg.pwrmgr_vif.lc_hw_debug_en = get_rand_lc_tx_val(
-          .t_weight(1), .f_weight(1), .other_weight(2)
-      );
-      #(micros_to_release * 1us);
-      `uvm_info(`gfn, "Injection to lc_dft_en", UVM_MEDIUM)
       if (super_sequence_done) break;
-      cfg.pwrmgr_vif.lc_dft_en = get_rand_lc_tx_val(.t_weight(1), .f_weight(1), .other_weight(2));
+
+      drive_inputs(1);
+      #(micros_to_release * 1us);
+      if (super_sequence_done) break;
+
+      drive_inputs(0);
       #(micros_to_release * 1us);
     end : repeat_50
-    `uvm_info(`gfn, "ended drv_lc_ctrl", UVM_MEDIUM)
-  endtask : drv_lc_ctrl
+    `uvm_info(`gfn, "ended drv_stim", UVM_MEDIUM)
+  endtask : drv_stim
+
+  task drive_inputs(bit phase0);
+    case (mubi_mode)
+      PwrmgrMubiLcCtrl:  drive_lc_ctrl_inputs(phase0);
+      PwrmgrMubiRomCtrl: drive_rom_ctrl_inputs(phase0);
+      default: `uvm_fatal(get_full_name(), $sformatf("Unknown mubi_mode: %s", mubi_mode.name()))
+    endcase
+  endtask : drive_inputs
+
+  task drive_rom_ctrl_inputs(bit phase0);
+    if (phase0) begin
+      for (int r = 0; r < NumRomInputs; r++) begin
+        mubi4_t rand_done = get_rand_mubi4_val(.t_weight(1), .f_weight(1), .other_weight(2));
+        mubi4_t rand_good = get_rand_mubi4_val(.t_weight(1), .f_weight(1), .other_weight(2));
+        `uvm_info(`gfn, $sformatf("Injection to rom_ctrl[%0d]", r), UVM_MEDIUM)
+        cfg.pwrmgr_vif.update_rom_ctrl('{done: rand_done, good: rand_good}, r);
+      end
+    end else begin
+      update_roms_response(.done(MuBi4True), .good(MuBi4True));
+    end
+  endtask : drive_rom_ctrl_inputs
+
+  task drive_lc_ctrl_inputs(bit phase0);
+    if (phase0) begin
+      cfg.pwrmgr_vif.lc_hw_debug_en = get_rand_lc_tx_val(.t_weight(1),
+                                                         .f_weight(1),
+                                                         .other_weight(2));
+    end else begin
+      cfg.pwrmgr_vif.lc_dft_en = get_rand_lc_tx_val(.t_weight(1), .f_weight(1), .other_weight(2));
+    end
+  endtask : drive_lc_ctrl_inputs
 
 endclass : pwrmgr_repeat_wakeup_reset_vseq

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -88,6 +88,11 @@
       run_opts: ["+test_timeout_ns=1000000"]
     }
     {
+      name: pwrmgr_repeat_wakeup_reset
+      uvm_test_seq: pwrmgr_repeat_wakeup_reset_vseq
+      run_opts: ["+test_timeout_ns=4000000", "+pwrmgr_mubi_mode=PwrmgrMubiRomCtrl"]
+    }
+    {
       name: pwrmgr_aborted_low_power
       uvm_test_seq: pwrmgr_aborted_low_power_vseq
     }

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_repeat_wakeup_reset_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_repeat_wakeup_reset_vseq.sv
@@ -11,9 +11,6 @@ class pwrmgr_repeat_wakeup_reset_vseq extends pwrmgr_wakeup_reset_vseq;
 
   bit [lc_ctrl_pkg::TxWidth-1:0] bad_lc_tx;
 
-  int cycles_from_reset;
-  int micros_to_release;
-
   bit super_sequence_done;
 
   task body();
@@ -27,38 +24,58 @@ class pwrmgr_repeat_wakeup_reset_vseq extends pwrmgr_wakeup_reset_vseq;
         super.body();
         super_sequence_done = 1;
       end
-      drv_stim(mubi_mode);
+      drv_stim();
     join
   endtask : body
 
-  task drv_stim(pwrmgr_mubi_e mubi_mode);
-    if (mubi_mode == PwrmgrMubiLcCtrl) drv_lc_ctrl();
-  endtask : drv_stim
-
-  task drv_lc_ctrl();
-    int delay;
-
-    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(cycles_from_reset, cycles_from_reset inside {[2 : 8]};)
-    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(micros_to_release, micros_to_release inside {[2 : 4]};)
+  task drv_stim();
+    int unsigned cycles_from_reset = $urandom_range(2, 8);
+    int unsigned micros_to_release = $urandom_range(2, 4);
 
     repeat (50) begin : repeat_50
       wait(cfg.esc_clk_rst_vif.rst_n);
       cfg.clk_rst_vif.wait_clks(cycles_from_reset);
-      if (super_sequence_done) begin
-        `uvm_info(`gfn, "Break from drv_lc_ctrl", UVM_MEDIUM)
-        break;
-      end
-      `uvm_info(`gfn, "Injection to lc_hw_debug_en", UVM_MEDIUM)
-      cfg.pwrmgr_vif.lc_hw_debug_en = get_rand_lc_tx_val(
-          .t_weight(1), .f_weight(1), .other_weight(2)
-      );
-      #(micros_to_release * 1us);
-      `uvm_info(`gfn, "Injection to lc_dft_en", UVM_MEDIUM)
       if (super_sequence_done) break;
-      cfg.pwrmgr_vif.lc_dft_en = get_rand_lc_tx_val(.t_weight(1), .f_weight(1), .other_weight(2));
+
+      drive_inputs(1);
+      #(micros_to_release * 1us);
+      if (super_sequence_done) break;
+
+      drive_inputs(0);
       #(micros_to_release * 1us);
     end : repeat_50
-    `uvm_info(`gfn, "ended drv_lc_ctrl", UVM_MEDIUM)
-  endtask : drv_lc_ctrl
+    `uvm_info(`gfn, "ended drv_stim", UVM_MEDIUM)
+  endtask : drv_stim
+
+  task drive_inputs(bit phase0);
+    case (mubi_mode)
+      PwrmgrMubiLcCtrl:  drive_lc_ctrl_inputs(phase0);
+      PwrmgrMubiRomCtrl: drive_rom_ctrl_inputs(phase0);
+      default: `uvm_fatal(get_full_name(), $sformatf("Unknown mubi_mode: %s", mubi_mode.name()))
+    endcase
+  endtask : drive_inputs
+
+  task drive_rom_ctrl_inputs(bit phase0);
+    if (phase0) begin
+      for (int r = 0; r < NumRomInputs; r++) begin
+        mubi4_t rand_done = get_rand_mubi4_val(.t_weight(1), .f_weight(1), .other_weight(2));
+        mubi4_t rand_good = get_rand_mubi4_val(.t_weight(1), .f_weight(1), .other_weight(2));
+        `uvm_info(`gfn, $sformatf("Injection to rom_ctrl[%0d]", r), UVM_MEDIUM)
+        cfg.pwrmgr_vif.update_rom_ctrl('{done: rand_done, good: rand_good}, r);
+      end
+    end else begin
+      update_roms_response(.done(MuBi4True), .good(MuBi4True));
+    end
+  endtask : drive_rom_ctrl_inputs
+
+  task drive_lc_ctrl_inputs(bit phase0);
+    if (phase0) begin
+      cfg.pwrmgr_vif.lc_hw_debug_en = get_rand_lc_tx_val(.t_weight(1),
+                                                         .f_weight(1),
+                                                         .other_weight(2));
+    end else begin
+      cfg.pwrmgr_vif.lc_dft_en = get_rand_lc_tx_val(.t_weight(1), .f_weight(1), .other_weight(2));
+    end
+  endtask : drive_lc_ctrl_inputs
 
 endclass : pwrmgr_repeat_wakeup_reset_vseq

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -88,6 +88,11 @@
       run_opts: ["+test_timeout_ns=1000000"]
     }
     {
+      name: pwrmgr_repeat_wakeup_reset
+      uvm_test_seq: pwrmgr_repeat_wakeup_reset_vseq
+      run_opts: ["+test_timeout_ns=4000000", "+pwrmgr_mubi_mode=PwrmgrMubiRomCtrl"]
+    }
+    {
       name: pwrmgr_aborted_low_power
       uvm_test_seq: pwrmgr_aborted_low_power_vseq
     }


### PR DESCRIPTION
- Add `pwrmgr_repeat_wakeup_reset` to `pwrmgr_sim_cfg.hjson.tpl` with `+pwrmgr_mubi_mode=PwrmgrMubiRomCtrl` and a 4 ms timeout (matching the original `pwrmgr_sec_cm_rom_ctrl_intersig_mubi`) entry).
- Refactor pwrmgr_repeat_wakeup_reset_vseq to unify the duplicated `drv_lc_ctrl`/`drv_rom_ctrl` loops into a single drv_stim loop, with a `drive_inputs(phase0)` task dispatching via case on `mubi_mode` to `drive_lc_ctrl_inputs` or `drive_rom_ctrl_inputs`. The `rom_ctrl` path injects random MuBi4 values (including invalid encodings) on all `NumRomInputs` channels of `rom_ctrl_i` as background stimulus during the wakeup/reset sequence.
- Add a `uvm_fatal` default in `drive_inputs` for unknown `mubi_mode` values.