### PR TITLE
[ot_certs] Add ML-DSA support to x509 certificate templates

### DIFF
--- a/sw/host/ot_certs/BUILD
+++ b/sw/host/ot_certs/BUILD
@@ -2,13 +2,28 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_rust//rust:defs.bzl", "rust_doc", "rust_library", "rust_test", "rust_test_suite")
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_doc",
+    "rust_library",
+    "rust_test",
+    "rust_test_suite",
+)
+load(
+    "//rules:certificates.bzl",
+    "certificate_template",
+)
 
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "generic_cert",
     srcs = ["tests/generic.hjson"],
+)
+
+filegroup(
+    name = "mldsa_cert",
+    srcs = ["tests/mldsa.hjson"],
 )
 
 filegroup(
@@ -87,6 +102,7 @@ rust_test_suite(
         ":generic_cert",
         ":example_cert",
         ":example_data",
+        ":mldsa_cert",
     ],
     deps = [
         ":ot_certs",
@@ -100,4 +116,9 @@ rust_test_suite(
 rust_doc(
     name = "ot_certs_doc",
     crate = ":ot_certs",
+)
+
+certificate_template(
+    name = "mldsa_test_template",
+    template = "tests/mldsa.hjson",
 )

--- a/sw/host/ot_certs/BUILD
+++ b/sw/host/ot_certs/BUILD
@@ -22,8 +22,12 @@ filegroup(
 )
 
 filegroup(
-    name = "mldsa_cert",
-    srcs = ["tests/mldsa.hjson"],
+    name = "mldsa_certs",
+    srcs = [
+        "tests/mldsa_44.hjson",
+        "tests/mldsa_65.hjson",
+        "tests/mldsa_87.hjson",
+    ],
 )
 
 filegroup(
@@ -102,7 +106,7 @@ rust_test_suite(
         ":generic_cert",
         ":example_cert",
         ":example_data",
-        ":mldsa_cert",
+        ":mldsa_certs",
     ],
     deps = [
         ":ot_certs",
@@ -119,6 +123,16 @@ rust_doc(
 )
 
 certificate_template(
-    name = "mldsa_test_template",
-    template = "tests/mldsa.hjson",
+    name = "mldsa_44_test_template",
+    template = "tests/mldsa_44.hjson",
+)
+
+certificate_template(
+    name = "mldsa_65_test_template",
+    template = "tests/mldsa_65.hjson",
+)
+
+certificate_template(
+    name = "mldsa_87_test_template",
+    template = "tests/mldsa_87.hjson",
 )

--- a/sw/host/ot_certs/src/asn1/mod.rs
+++ b/sw/host/ot_certs/src/asn1/mod.rs
@@ -49,6 +49,9 @@ pub enum Oid {
     State,
     // Signature algorithms.
     EcdsaWithSha256,
+    Mldsa44,
+    Mldsa65,
+    Mldsa87,
     // Public key type.
     EcPublicKey,
     // Elliptic curve names.
@@ -113,6 +116,11 @@ impl Oid {
             // ecdsa-with-SHA256 OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840)
             //      ansi-X9-62(10045) signatures(4) ecdsa-with-SHA2(3) 2 }
             Oid::EcdsaWithSha256 => "1.2.840.10045.4.3.2",
+
+            // From FIPS 204 / RFC 9881 (Pure ML-DSA)
+            Oid::Mldsa44 => "2.16.840.1.101.3.4.3.17",
+            Oid::Mldsa65 => "2.16.840.1.101.3.4.3.18",
+            Oid::Mldsa87 => "2.16.840.1.101.3.4.3.19",
 
             // From https://datatracker.ietf.org/doc/html/rfc3279
             // ansi-X9-62  OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840) 10045 }

--- a/sw/host/ot_certs/src/asn1/x509.rs
+++ b/sw/host/ot_certs/src/asn1/x509.rs
@@ -412,6 +412,9 @@ impl X509 {
                     builder.push_oid(&Oid::EcPublicKey)?;
                     Self::push_ec_public_key_params(builder, ec_pubkey)
                 }
+                SubjectPublicKeyInfo::Mldsa44(_) => builder.push_oid(&Oid::Mldsa44),
+                SubjectPublicKeyInfo::Mldsa65(_) => builder.push_oid(&Oid::Mldsa65),
+                SubjectPublicKeyInfo::Mldsa87(_) => builder.push_oid(&Oid::Mldsa87),
             },
         )
     }
@@ -423,6 +426,11 @@ impl X509 {
         match pubkey_info {
             SubjectPublicKeyInfo::EcPublicKey(ec_pubkey) => {
                 Self::push_ec_public_key(builder, ec_pubkey)
+            }
+            SubjectPublicKeyInfo::Mldsa44(mldsa_pubkey)
+            | SubjectPublicKeyInfo::Mldsa65(mldsa_pubkey)
+            | SubjectPublicKeyInfo::Mldsa87(mldsa_pubkey) => {
+                builder.push_byte_array(Some("pubkey_mldsa".into()), &mldsa_pubkey.public_key)
             }
         }
     }
@@ -510,6 +518,9 @@ impl X509 {
         // Per the X509 specification, the signature parameters must not contain any parameters
         builder.push_seq(Some("algorithm_identifier".into()), |builder| match sig {
             Signature::EcdsaWithSha256 { .. } => builder.push_oid(&Oid::EcdsaWithSha256),
+            Signature::Mldsa44 { .. } => builder.push_oid(&Oid::Mldsa44),
+            Signature::Mldsa65 { .. } => builder.push_oid(&Oid::Mldsa65),
+            Signature::Mldsa87 { .. } => builder.push_oid(&Oid::Mldsa87),
         })
     }
 
@@ -522,6 +533,15 @@ impl X509 {
                     s: Value::Literal(zero.clone()),
                 };
                 Self::push_ecdsa_sig(builder, value.as_ref().unwrap_or(&empty_ecdsa))
+            }
+            Signature::Mldsa44 { value }
+            | Signature::Mldsa65 { value }
+            | Signature::Mldsa87 { value } => {
+                let empty_sig = Value::Literal(Vec::new());
+                builder.push_byte_array(
+                    Some("sig_mldsa_value".into()),
+                    value.as_ref().unwrap_or(&empty_sig),
+                )
             }
         }
     }

--- a/sw/host/ot_certs/src/codegen.rs
+++ b/sw/host/ot_certs/src/codegen.rs
@@ -403,6 +403,14 @@ fn var_appears_in_sig(var_name: &str, sig: &Signature) -> bool {
             };
             r.refers_to(var_name) || s.refers_to(var_name)
         }
+        Signature::Mldsa44 { value }
+        | Signature::Mldsa65 { value }
+        | Signature::Mldsa87 { value } => {
+            let Some(val) = value else {
+                return false;
+            };
+            val.refers_to(var_name)
+        }
     }
 }
 

--- a/sw/host/ot_certs/src/template/mod.rs
+++ b/sw/host/ot_certs/src/template/mod.rs
@@ -31,7 +31,7 @@
 //! }
 //! ```
 
-use anyhow::Result;
+use anyhow::{Context, Result, bail, ensure};
 use indexmap::IndexMap;
 use num_bigint_dig::BigUint;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -296,7 +296,21 @@ pub enum Conversion {
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(tag = "algorithm", rename_all = "kebab-case")]
 pub enum Signature {
-    EcdsaWithSha256 { value: Option<EcdsaSignature> },
+    EcdsaWithSha256 {
+        value: Option<EcdsaSignature>,
+    },
+    #[serde(rename = "mldsa-44")]
+    Mldsa44 {
+        value: Option<Value<Vec<u8>>>,
+    },
+    #[serde(rename = "mldsa-65")]
+    Mldsa65 {
+        value: Option<Value<Vec<u8>>>,
+    },
+    #[serde(rename = "mldsa-87")]
+    Mldsa87 {
+        value: Option<Value<Vec<u8>>>,
+    },
 }
 
 /// Representation of an ECDSA signature.
@@ -315,6 +329,19 @@ pub struct EcdsaSignature {
 #[serde(tag = "algorithm", rename_all = "kebab-case")]
 pub enum SubjectPublicKeyInfo {
     EcPublicKey(EcPublicKeyInfo),
+    #[serde(rename = "mldsa-44")]
+    Mldsa44(MldsaPublicKeyInfo),
+    #[serde(rename = "mldsa-65")]
+    Mldsa65(MldsaPublicKeyInfo),
+    #[serde(rename = "mldsa-87")]
+    Mldsa87(MldsaPublicKeyInfo),
+}
+
+/// Representation of ML-DSA public key information.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MldsaPublicKeyInfo {
+    pub public_key: Value<Vec<u8>>,
 }
 
 /// Representation of an elliptic curve public key information.
@@ -485,7 +512,187 @@ impl VariableType {
 
 impl Template {
     pub fn from_hjson_str(content: &str) -> Result<Template> {
-        Ok(deser_hjson::from_str(content)?)
+        let tmpl: Template = deser_hjson::from_str(content)?;
+        tmpl.validate()?;
+        Ok(tmpl)
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        self.validate_public_key()?;
+        self.validate_signature()?;
+        Ok(())
+    }
+
+    fn validate_variable_size(
+        &self,
+        var_name: &str,
+        expected_size: usize,
+        field_name: &str,
+    ) -> Result<()> {
+        let var_type = self.variables.get(var_name).with_context(|| {
+            format!(
+                "variable '{}' used in {} is not declared",
+                var_name, field_name
+            )
+        })?;
+
+        match var_type {
+            VariableType::Boolean => bail!(
+                "variable '{}' used in {} is a Boolean, but must be a ByteArray or Integer",
+                var_name,
+                field_name
+            ),
+            _ => {
+                let (min_size, max_size) = var_type.array_size();
+                ensure!(
+                    min_size == expected_size && max_size == expected_size,
+                    "variable '{}' used in {} must have exact-size {}, but has range [{}, {}]",
+                    var_name,
+                    field_name,
+                    expected_size,
+                    min_size,
+                    max_size
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_public_key(&self) -> Result<()> {
+        match &self.certificate.subject_public_key_info {
+            SubjectPublicKeyInfo::EcPublicKey(ec) => {
+                let expected_size = match ec.curve {
+                    EcCurve::Prime256v1 => 32,
+                };
+                if let Value::Variable(var) = &ec.public_key.x {
+                    self.validate_variable_size(
+                        &var.name,
+                        expected_size,
+                        "public key X coordinate",
+                    )?;
+                }
+                if let Value::Variable(var) = &ec.public_key.y {
+                    self.validate_variable_size(
+                        &var.name,
+                        expected_size,
+                        "public key Y coordinate",
+                    )?;
+                }
+            }
+            SubjectPublicKeyInfo::Mldsa44(mldsa) => {
+                if let Value::Variable(var) = &mldsa.public_key {
+                    self.validate_variable_size(&var.name, 1312, "ML-DSA-44 public key")?;
+                } else if let Value::Literal(bytes) = &mldsa.public_key {
+                    ensure!(
+                        bytes.len() == 1312,
+                        "ML-DSA-44 literal public key must be 1312 bytes, got {}",
+                        bytes.len()
+                    );
+                }
+            }
+            SubjectPublicKeyInfo::Mldsa65(mldsa) => {
+                if let Value::Variable(var) = &mldsa.public_key {
+                    self.validate_variable_size(&var.name, 1952, "ML-DSA-65 public key")?;
+                } else if let Value::Literal(bytes) = &mldsa.public_key {
+                    ensure!(
+                        bytes.len() == 1952,
+                        "ML-DSA-65 literal public key must be 1952 bytes, got {}",
+                        bytes.len()
+                    );
+                }
+            }
+            SubjectPublicKeyInfo::Mldsa87(mldsa) => {
+                if let Value::Variable(var) = &mldsa.public_key {
+                    self.validate_variable_size(&var.name, 2592, "ML-DSA-87 public key")?;
+                } else if let Value::Literal(bytes) = &mldsa.public_key {
+                    ensure!(
+                        bytes.len() == 2592,
+                        "ML-DSA-87 literal public key must be 2592 bytes, got {}",
+                        bytes.len()
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_signature(&self) -> Result<()> {
+        match &self.certificate.signature {
+            Signature::EcdsaWithSha256 { value } => {
+                if let Some(sig) = value {
+                    if let Value::Variable(var) = &sig.r {
+                        let var_type = self.variables.get(&var.name).with_context(|| {
+                            format!(
+                                "variable '{}' used in signature R is not declared",
+                                var.name
+                            )
+                        })?;
+                        let (_, max_size) = var_type.array_size();
+                        ensure!(
+                            max_size <= 32,
+                            "variable '{}' used in signature R must have max size <= 32, got {}",
+                            var.name,
+                            max_size
+                        );
+                    }
+                    if let Value::Variable(var) = &sig.s {
+                        let var_type = self.variables.get(&var.name).with_context(|| {
+                            format!(
+                                "variable '{}' used in signature S is not declared",
+                                var.name
+                            )
+                        })?;
+                        let (_, max_size) = var_type.array_size();
+                        ensure!(
+                            max_size <= 32,
+                            "variable '{}' used in signature S must have max size <= 32, got {}",
+                            var.name,
+                            max_size
+                        );
+                    }
+                }
+            }
+            Signature::Mldsa44 { value } => {
+                if let Some(val) = value {
+                    if let Value::Variable(var) = val {
+                        self.validate_variable_size(&var.name, 2420, "ML-DSA-44 signature")?;
+                    } else if let Value::Literal(bytes) = val {
+                        ensure!(
+                            bytes.len() == 2420,
+                            "ML-DSA-44 literal signature must be 2420 bytes, got {}",
+                            bytes.len()
+                        );
+                    }
+                }
+            }
+            Signature::Mldsa65 { value } => {
+                if let Some(val) = value {
+                    if let Value::Variable(var) = val {
+                        self.validate_variable_size(&var.name, 3300, "ML-DSA-65 signature")?;
+                    } else if let Value::Literal(bytes) = val {
+                        ensure!(
+                            bytes.len() == 3300,
+                            "ML-DSA-65 literal signature must be 3300 bytes, got {}",
+                            bytes.len()
+                        );
+                    }
+                }
+            }
+            Signature::Mldsa87 { value } => {
+                if let Some(val) = value {
+                    if let Value::Variable(var) = val {
+                        self.validate_variable_size(&var.name, 4627, "ML-DSA-87 signature")?;
+                    } else if let Value::Literal(bytes) = val {
+                        ensure!(
+                            bytes.len() == 4627,
+                            "ML-DSA-87 literal signature must be 4627 bytes, got {}",
+                            bytes.len()
+                        );
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 }
 

--- a/sw/host/ot_certs/src/template/subst.rs
+++ b/sw/host/ot_certs/src/template/subst.rs
@@ -15,7 +15,8 @@ use serde::{Deserialize, Serialize};
 use crate::template::{
     BasicConstraints, Certificate, CertificateExtension, Conversion, DiceTcbInfoExtension,
     DiceTcbInfoFlags, EcPublicKey, EcPublicKeyInfo, EcdsaSignature, FirmwareId, KeyUsage,
-    Signature, SizeRange, SubjectPublicKeyInfo, Template, Value, Variable, VariableType,
+    MldsaPublicKeyInfo, Signature, SizeRange, SubjectPublicKeyInfo, Template, Value, Variable,
+    VariableType,
 };
 
 /// Substitution value: this is the raw value loaded from a hjson/json file
@@ -505,7 +506,24 @@ impl Subst for SubjectPublicKeyInfo {
             SubjectPublicKeyInfo::EcPublicKey(ec) => {
                 Ok(SubjectPublicKeyInfo::EcPublicKey(ec.subst(data)?))
             }
+            SubjectPublicKeyInfo::Mldsa44(mldsa) => {
+                Ok(SubjectPublicKeyInfo::Mldsa44(mldsa.subst(data)?))
+            }
+            SubjectPublicKeyInfo::Mldsa65(mldsa) => {
+                Ok(SubjectPublicKeyInfo::Mldsa65(mldsa.subst(data)?))
+            }
+            SubjectPublicKeyInfo::Mldsa87(mldsa) => {
+                Ok(SubjectPublicKeyInfo::Mldsa87(mldsa.subst(data)?))
+            }
         }
+    }
+}
+
+impl Subst for MldsaPublicKeyInfo {
+    fn subst(&self, data: &SubstData) -> Result<MldsaPublicKeyInfo> {
+        Ok(MldsaPublicKeyInfo {
+            public_key: self.public_key.subst(data)?,
+        })
     }
 }
 
@@ -531,6 +549,15 @@ impl Subst for Signature {
     fn subst(&self, data: &SubstData) -> Result<Signature> {
         match self {
             Signature::EcdsaWithSha256 { value } => Ok(Signature::EcdsaWithSha256 {
+                value: value.subst(data)?,
+            }),
+            Signature::Mldsa44 { value } => Ok(Signature::Mldsa44 {
+                value: value.subst(data)?,
+            }),
+            Signature::Mldsa65 { value } => Ok(Signature::Mldsa65 {
+                value: value.subst(data)?,
+            }),
+            Signature::Mldsa87 { value } => Ok(Signature::Mldsa87 {
                 value: value.subst(data)?,
             }),
         }

--- a/sw/host/ot_certs/src/template/testgen.rs
+++ b/sw/host/ot_certs/src/template/testgen.rs
@@ -14,7 +14,9 @@ use openssl::nid::Nid;
 use openssl::pkey::Private;
 
 use crate::template::subst::{SubstData, SubstValue};
-use crate::template::{EcCurve, EcPublicKeyInfo, SubjectPublicKeyInfo, Template, Value, Variable};
+use crate::template::{
+    EcCurve, EcPublicKeyInfo, MldsaPublicKeyInfo, SubjectPublicKeyInfo, Template, Value, Variable,
+};
 
 // Convert a template curve name to an openssl one.
 fn ecgroup_from_curve(curve: &EcCurve) -> EcGroup {
@@ -115,7 +117,30 @@ impl Template {
     fn random_public_key(&self) -> Result<SubstData> {
         match &self.certificate.subject_public_key_info {
             SubjectPublicKeyInfo::EcPublicKey(ec) => Self::random_ec_public_key(ec),
+            SubjectPublicKeyInfo::Mldsa44(mldsa) => Self::random_mldsa_public_key(mldsa, 1312),
+            SubjectPublicKeyInfo::Mldsa65(mldsa) => Self::random_mldsa_public_key(mldsa, 1952),
+            SubjectPublicKeyInfo::Mldsa87(mldsa) => Self::random_mldsa_public_key(mldsa, 2592),
         }
+    }
+
+    fn random_mldsa_public_key(
+        mldsa_pubkey: &MldsaPublicKeyInfo,
+        size: usize,
+    ) -> Result<SubstData> {
+        use rand::Rng;
+        let mut data = SubstData::new();
+        if let Value::Variable(Variable { name, convert }) = &mldsa_pubkey.public_key {
+            ensure!(
+                convert.is_none(),
+                "cannot generate a random public key if 'public_key' is a variable with conversion"
+            );
+            let mut rng = rand::thread_rng();
+            let mut bytes = vec![0u8; size];
+            rng.fill(&mut bytes[..]);
+            data.values
+                .insert(name.clone(), SubstValue::ByteArray(bytes));
+        }
+        Ok(data)
     }
 
     fn random_ec_public_key(ec_pubkey: &EcPublicKeyInfo) -> Result<SubstData> {

--- a/sw/host/ot_certs/tests/mldsa.hjson
+++ b/sw/host/ot_certs/tests/mldsa.hjson
@@ -1,0 +1,61 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+    name: "mldsa",
+
+    variables: {
+        serial_number: {
+            type: "integer",
+            range-size: [0, 32],
+        },
+        not_before: {
+            type: "string",
+            exact-size: 15,
+        }
+        not_after: {
+            type: "string",
+            exact-size: 15,
+        }
+        pub_key_id: {
+            type: "byte-array",
+            exact-size: 20,
+            tweak-msb: true,
+        },
+        auth_key_id: {
+            type: "byte-array",
+            exact-size: 20,
+            tweak-msb: true,
+        },
+        mldsa_pub_key: {
+            type: "byte-array",
+            exact-size: 1952,
+        },
+        mldsa_sig: {
+            type: "byte-array",
+            exact-size: 3300,
+        }
+    },
+
+    certificate: {
+        serial_number: { var: "serial_number" },
+        issuer: [
+            { common_name: "Test Issuer" },
+        ],
+        subject: [
+            { common_name: "Test Subject" },
+        ],
+        not_before: { var: "not_before" },
+        not_after: { var: "not_after" },
+        subject_public_key_info: {
+            algorithm: "mldsa-65",
+            public_key: { var: "mldsa_pub_key" },
+        },
+        authority_key_identifier: { var: "auth_key_id" },
+        subject_key_identifier: { var: "pub_key_id" },
+        signature: {
+            algorithm: "mldsa-65",
+            value: { var: "mldsa_sig" }
+        }
+    }
+}

--- a/sw/host/ot_certs/tests/mldsa_44.hjson
+++ b/sw/host/ot_certs/tests/mldsa_44.hjson
@@ -1,0 +1,61 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+    name: "mldsa_44",
+
+    variables: {
+        serial_number: {
+            type: "integer",
+            range-size: [0, 32],
+        },
+        not_before: {
+            type: "string",
+            exact-size: 15,
+        }
+        not_after: {
+            type: "string",
+            exact-size: 15,
+        }
+        pub_key_id: {
+            type: "byte-array",
+            exact-size: 20,
+            tweak-msb: true,
+        },
+        auth_key_id: {
+            type: "byte-array",
+            exact-size: 20,
+            tweak-msb: true,
+        },
+        mldsa_pub_key: {
+            type: "byte-array",
+            exact-size: 1312,
+        },
+        mldsa_sig: {
+            type: "byte-array",
+            exact-size: 2420,
+        }
+    },
+
+    certificate: {
+        serial_number: { var: "serial_number" },
+        issuer: [
+            { common_name: "Test Issuer" },
+        ],
+        subject: [
+            { common_name: "Test Subject" },
+        ],
+        not_before: { var: "not_before" },
+        not_after: { var: "not_after" },
+        subject_public_key_info: {
+            algorithm: "mldsa-44",
+            public_key: { var: "mldsa_pub_key" },
+        },
+        authority_key_identifier: { var: "auth_key_id" },
+        subject_key_identifier: { var: "pub_key_id" },
+        signature: {
+            algorithm: "mldsa-44",
+            value: { var: "mldsa_sig" }
+        }
+    }
+}

--- a/sw/host/ot_certs/tests/mldsa_65.hjson
+++ b/sw/host/ot_certs/tests/mldsa_65.hjson
@@ -1,0 +1,61 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+    name: "mldsa_65",
+
+    variables: {
+        serial_number: {
+            type: "integer",
+            range-size: [0, 32],
+        },
+        not_before: {
+            type: "string",
+            exact-size: 15,
+        }
+        not_after: {
+            type: "string",
+            exact-size: 15,
+        }
+        pub_key_id: {
+            type: "byte-array",
+            exact-size: 20,
+            tweak-msb: true,
+        },
+        auth_key_id: {
+            type: "byte-array",
+            exact-size: 20,
+            tweak-msb: true,
+        },
+        mldsa_pub_key: {
+            type: "byte-array",
+            exact-size: 1952,
+        },
+        mldsa_sig: {
+            type: "byte-array",
+            exact-size: 3300,
+        }
+    },
+
+    certificate: {
+        serial_number: { var: "serial_number" },
+        issuer: [
+            { common_name: "Test Issuer" },
+        ],
+        subject: [
+            { common_name: "Test Subject" },
+        ],
+        not_before: { var: "not_before" },
+        not_after: { var: "not_after" },
+        subject_public_key_info: {
+            algorithm: "mldsa-65",
+            public_key: { var: "mldsa_pub_key" },
+        },
+        authority_key_identifier: { var: "auth_key_id" },
+        subject_key_identifier: { var: "pub_key_id" },
+        signature: {
+            algorithm: "mldsa-65",
+            value: { var: "mldsa_sig" }
+        }
+    }
+}

--- a/sw/host/ot_certs/tests/mldsa_87.hjson
+++ b/sw/host/ot_certs/tests/mldsa_87.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-    name: "mldsa",
+    name: "mldsa_87",
 
     variables: {
         serial_number: {
@@ -29,11 +29,11 @@
         },
         mldsa_pub_key: {
             type: "byte-array",
-            exact-size: 1952,
+            exact-size: 2592,
         },
         mldsa_sig: {
             type: "byte-array",
-            exact-size: 3300,
+            exact-size: 4627,
         }
     },
 
@@ -48,13 +48,13 @@
         not_before: { var: "not_before" },
         not_after: { var: "not_after" },
         subject_public_key_info: {
-            algorithm: "mldsa-65",
+            algorithm: "mldsa-87",
             public_key: { var: "mldsa_pub_key" },
         },
         authority_key_identifier: { var: "auth_key_id" },
         subject_key_identifier: { var: "pub_key_id" },
         signature: {
-            algorithm: "mldsa-65",
+            algorithm: "mldsa-87",
             value: { var: "mldsa_sig" }
         }
     }

--- a/sw/host/ot_certs/tests/mldsa_test.rs
+++ b/sw/host/ot_certs/tests/mldsa_test.rs
@@ -1,0 +1,136 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use ot_certs::codegen::generate_cert;
+use ot_certs::template::Template;
+
+const MLDSA_CERT: &str = include_str!("mldsa.hjson");
+
+#[test]
+fn test_mldsa_codegen() -> Result<()> {
+    let tmpl = Template::from_hjson_str(MLDSA_CERT)?;
+    let codegen = generate_cert("tests/mldsa.hjson", &tmpl)?;
+
+    // Basic sanity checks on generated code.
+    assert!(codegen.source_h.contains("mldsa_tbs_values_t"));
+    assert!(codegen.source_h.contains("mldsa_sig_values_t"));
+    assert!(codegen.source_h.contains("mldsa_build_tbs"));
+    assert!(codegen.source_h.contains("mldsa_build_cert"));
+
+    // Check that variables are present in the struct.
+    assert!(codegen.source_h.contains("uint8_t *mldsa_pub_key;"));
+    assert!(codegen.source_h.contains("uint8_t *mldsa_sig;"));
+
+    Ok(())
+}
+
+#[test]
+fn test_mldsa_random_test() -> Result<()> {
+    let tmpl = Template::from_hjson_str(MLDSA_CERT)?;
+    let random_data = tmpl.random_test()?;
+
+    // Check that the generated random data has the correct variables.
+    assert!(random_data.values.contains_key("mldsa_pub_key"));
+    assert!(random_data.values.contains_key("mldsa_sig"));
+
+    // Check sizes.
+    if let Some(ot_certs::template::subst::SubstValue::ByteArray(bytes)) =
+        random_data.values.get("mldsa_pub_key")
+    {
+        assert_eq!(bytes.len(), 1952);
+    } else {
+        panic!("mldsa_pub_key is not a ByteArray");
+    }
+
+    if let Some(ot_certs::template::subst::SubstValue::ByteArray(bytes)) =
+        random_data.values.get("mldsa_sig")
+    {
+        assert_eq!(bytes.len(), 3300);
+    } else {
+        panic!("mldsa_sig is not a ByteArray");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_mldsa_invalid_pubkey_size() {
+    let invalid_tmpl = r#"
+    {
+        name: "mldsa_invalid_pubkey",
+        variables: {
+            mldsa_pub_key: {
+                type: "byte-array",
+                exact-size: 1000, // Invalid size for ML-DSA-65 (expects 1952)
+            },
+            mldsa_sig: {
+                type: "byte-array",
+                exact-size: 3300,
+            }
+        },
+        certificate: {
+            serial_number: 1,
+            issuer: [{ common_name: "Test" }],
+            subject: [{ common_name: "Test" }],
+            not_before: "20230101000000Z",
+            not_after: "99991231235959Z",
+            subject_public_key_info: {
+                algorithm: "mldsa-65",
+                public_key: { var: "mldsa_pub_key" },
+            },
+            signature: {
+                algorithm: "mldsa-65",
+                value: { var: "mldsa_sig" }
+            }
+        }
+    }
+    "#;
+    let result = Template::from_hjson_str(invalid_tmpl);
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains(
+        "variable 'mldsa_pub_key' used in ML-DSA-65 public key must have exact-size 1952"
+    ));
+}
+
+#[test]
+fn test_mldsa_invalid_sig_size() {
+    let invalid_tmpl = r#"
+    {
+        name: "mldsa_invalid_sig",
+        variables: {
+            mldsa_pub_key: {
+                type: "byte-array",
+                exact-size: 1952,
+            },
+            mldsa_sig: {
+                type: "byte-array",
+                exact-size: 3000, // Invalid size for ML-DSA-65 (expects 3300)
+            }
+        },
+        certificate: {
+            serial_number: 1,
+            issuer: [{ common_name: "Test" }],
+            subject: [{ common_name: "Test" }],
+            not_before: "20230101000000Z",
+            not_after: "99991231235959Z",
+            subject_public_key_info: {
+                algorithm: "mldsa-65",
+                public_key: { var: "mldsa_pub_key" },
+            },
+            signature: {
+                algorithm: "mldsa-65",
+                value: { var: "mldsa_sig" }
+            }
+        }
+    }
+    "#;
+    let result = Template::from_hjson_str(invalid_tmpl);
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("variable 'mldsa_sig' used in ML-DSA-65 signature must have exact-size 3300")
+    );
+}

--- a/sw/host/ot_certs/tests/mldsa_test.rs
+++ b/sw/host/ot_certs/tests/mldsa_test.rs
@@ -6,18 +6,19 @@ use anyhow::Result;
 use ot_certs::codegen::generate_cert;
 use ot_certs::template::Template;
 
-const MLDSA_CERT: &str = include_str!("mldsa.hjson");
+const MLDSA_44_CERT: &str = include_str!("mldsa_44.hjson");
+const MLDSA_65_CERT: &str = include_str!("mldsa_65.hjson");
+const MLDSA_87_CERT: &str = include_str!("mldsa_87.hjson");
 
-#[test]
-fn test_mldsa_codegen() -> Result<()> {
-    let tmpl = Template::from_hjson_str(MLDSA_CERT)?;
-    let codegen = generate_cert("tests/mldsa.hjson", &tmpl)?;
+fn run_codegen_test(tmpl_str: &str, tmpl_path: &str, name: &str) -> Result<()> {
+    let tmpl = Template::from_hjson_str(tmpl_str)?;
+    let codegen = generate_cert(tmpl_path, &tmpl)?;
 
     // Basic sanity checks on generated code.
-    assert!(codegen.source_h.contains("mldsa_tbs_values_t"));
-    assert!(codegen.source_h.contains("mldsa_sig_values_t"));
-    assert!(codegen.source_h.contains("mldsa_build_tbs"));
-    assert!(codegen.source_h.contains("mldsa_build_cert"));
+    assert!(codegen.source_h.contains(&format!("{}_tbs_values_t", name)));
+    assert!(codegen.source_h.contains(&format!("{}_sig_values_t", name)));
+    assert!(codegen.source_h.contains(&format!("{}_build_tbs", name)));
+    assert!(codegen.source_h.contains(&format!("{}_build_cert", name)));
 
     // Check that variables are present in the struct.
     assert!(codegen.source_h.contains("uint8_t *mldsa_pub_key;"));
@@ -27,8 +28,26 @@ fn test_mldsa_codegen() -> Result<()> {
 }
 
 #[test]
-fn test_mldsa_random_test() -> Result<()> {
-    let tmpl = Template::from_hjson_str(MLDSA_CERT)?;
+fn test_mldsa_44_codegen() -> Result<()> {
+    run_codegen_test(MLDSA_44_CERT, "tests/mldsa_44.hjson", "mldsa_44")
+}
+
+#[test]
+fn test_mldsa_65_codegen() -> Result<()> {
+    run_codegen_test(MLDSA_65_CERT, "tests/mldsa_65.hjson", "mldsa_65")
+}
+
+#[test]
+fn test_mldsa_87_codegen() -> Result<()> {
+    run_codegen_test(MLDSA_87_CERT, "tests/mldsa_87.hjson", "mldsa_87")
+}
+
+fn run_random_test(
+    tmpl_str: &str,
+    expected_pubkey_size: usize,
+    expected_sig_size: usize,
+) -> Result<()> {
+    let tmpl = Template::from_hjson_str(tmpl_str)?;
     let random_data = tmpl.random_test()?;
 
     // Check that the generated random data has the correct variables.
@@ -39,7 +58,7 @@ fn test_mldsa_random_test() -> Result<()> {
     if let Some(ot_certs::template::subst::SubstValue::ByteArray(bytes)) =
         random_data.values.get("mldsa_pub_key")
     {
-        assert_eq!(bytes.len(), 1952);
+        assert_eq!(bytes.len(), expected_pubkey_size);
     } else {
         panic!("mldsa_pub_key is not a ByteArray");
     }
@@ -47,7 +66,7 @@ fn test_mldsa_random_test() -> Result<()> {
     if let Some(ot_certs::template::subst::SubstValue::ByteArray(bytes)) =
         random_data.values.get("mldsa_sig")
     {
-        assert_eq!(bytes.len(), 3300);
+        assert_eq!(bytes.len(), expected_sig_size);
     } else {
         panic!("mldsa_sig is not a ByteArray");
     }
@@ -56,81 +75,142 @@ fn test_mldsa_random_test() -> Result<()> {
 }
 
 #[test]
-fn test_mldsa_invalid_pubkey_size() {
-    let invalid_tmpl = r#"
-    {
-        name: "mldsa_invalid_pubkey",
-        variables: {
-            mldsa_pub_key: {
-                type: "byte-array",
-                exact-size: 1000, // Invalid size for ML-DSA-65 (expects 1952)
-            },
-            mldsa_sig: {
-                type: "byte-array",
-                exact-size: 3300,
-            }
-        },
-        certificate: {
-            serial_number: 1,
-            issuer: [{ common_name: "Test" }],
-            subject: [{ common_name: "Test" }],
-            not_before: "20230101000000Z",
-            not_after: "99991231235959Z",
-            subject_public_key_info: {
-                algorithm: "mldsa-65",
-                public_key: { var: "mldsa_pub_key" },
-            },
-            signature: {
-                algorithm: "mldsa-65",
-                value: { var: "mldsa_sig" }
-            }
-        }
-    }
-    "#;
-    let result = Template::from_hjson_str(invalid_tmpl);
-    assert!(result.is_err());
-    let err = result.unwrap_err().to_string();
-    assert!(err.contains(
-        "variable 'mldsa_pub_key' used in ML-DSA-65 public key must have exact-size 1952"
-    ));
+fn test_mldsa_44_random_test() -> Result<()> {
+    run_random_test(MLDSA_44_CERT, 1312, 2420)
 }
 
 #[test]
-fn test_mldsa_invalid_sig_size() {
-    let invalid_tmpl = r#"
-    {
-        name: "mldsa_invalid_sig",
-        variables: {
-            mldsa_pub_key: {
+fn test_mldsa_65_random_test() -> Result<()> {
+    run_random_test(MLDSA_65_CERT, 1952, 3300)
+}
+
+#[test]
+fn test_mldsa_87_random_test() -> Result<()> {
+    run_random_test(MLDSA_87_CERT, 2592, 4627)
+}
+
+fn run_invalid_pubkey_size_test(
+    algorithm: &str,
+    correct_pubkey_size: usize,
+    incorrect_pubkey_size: usize,
+    correct_sig_size: usize,
+    algo_name_in_err: &str,
+) {
+    let invalid_tmpl = format!(
+        r#"
+    {{
+        name: "mldsa_invalid_pubkey",
+        variables: {{
+            mldsa_pub_key: {{
                 type: "byte-array",
-                exact-size: 1952,
-            },
-            mldsa_sig: {
+                exact-size: {incorrect_pubkey_size},
+            }},
+            mldsa_sig: {{
                 type: "byte-array",
-                exact-size: 3000, // Invalid size for ML-DSA-65 (expects 3300)
-            }
-        },
-        certificate: {
+                exact-size: {correct_sig_size},
+            }}
+        }},
+        certificate: {{
             serial_number: 1,
-            issuer: [{ common_name: "Test" }],
-            subject: [{ common_name: "Test" }],
+            issuer: [{{ common_name: "Test" }}],
+            subject: [{{ common_name: "Test" }}],
             not_before: "20230101000000Z",
             not_after: "99991231235959Z",
-            subject_public_key_info: {
-                algorithm: "mldsa-65",
-                public_key: { var: "mldsa_pub_key" },
-            },
-            signature: {
-                algorithm: "mldsa-65",
-                value: { var: "mldsa_sig" }
-            }
-        }
-    }
-    "#;
-    let result = Template::from_hjson_str(invalid_tmpl);
+            subject_public_key_info: {{
+                algorithm: "{algorithm}",
+                public_key: {{ var: "mldsa_pub_key" }},
+            }},
+            signature: {{
+                algorithm: "{algorithm}",
+                value: {{ var: "mldsa_sig" }}
+            }}
+        }}
+    }}
+    "#
+    );
+    let result = Template::from_hjson_str(&invalid_tmpl);
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
-    assert!(
-        err.contains("variable 'mldsa_sig' used in ML-DSA-65 signature must have exact-size 3300")
+    assert!(err.contains(&format!(
+        "variable 'mldsa_pub_key' used in {} public key must have exact-size {}",
+        algo_name_in_err, correct_pubkey_size
+    )));
+}
+
+#[test]
+fn test_mldsa_44_invalid_pubkey_size() {
+    run_invalid_pubkey_size_test("mldsa-44", 1312, 1000, 2420, "ML-DSA-44");
+}
+
+#[test]
+fn test_mldsa_65_invalid_pubkey_size() {
+    run_invalid_pubkey_size_test("mldsa-65", 1952, 1000, 3300, "ML-DSA-65");
+}
+
+#[test]
+fn test_mldsa_87_invalid_pubkey_size() {
+    run_invalid_pubkey_size_test("mldsa-87", 2592, 1000, 4627, "ML-DSA-87");
+}
+
+fn run_invalid_sig_size_test(
+    algorithm: &str,
+    correct_pubkey_size: usize,
+    correct_sig_size: usize,
+    incorrect_sig_size: usize,
+    algo_name_in_err: &str,
+) {
+    let invalid_tmpl = format!(
+        r#"
+    {{
+        name: "mldsa_invalid_sig",
+        variables: {{
+            mldsa_pub_key: {{
+                type: "byte-array",
+                exact-size: {correct_pubkey_size},
+            }},
+            mldsa_sig: {{
+                type: "byte-array",
+                exact-size: {incorrect_sig_size},
+            }}
+        }},
+        certificate: {{
+            serial_number: 1,
+            issuer: [{{ common_name: "Test" }}],
+            subject: [{{ common_name: "Test" }}],
+            not_before: "20230101000000Z",
+            not_after: "99991231235959Z",
+            subject_public_key_info: {{
+                algorithm: "{algorithm}",
+                public_key: {{ var: "mldsa_pub_key" }},
+            }},
+            signature: {{
+                algorithm: "{algorithm}",
+                value: {{ var: "mldsa_sig" }}
+            }}
+        }}
+    }}
+    "#
     );
+    let result = Template::from_hjson_str(&invalid_tmpl);
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains(&format!(
+        "variable 'mldsa_sig' used in {} signature must have exact-size {}",
+        algo_name_in_err, correct_sig_size
+    )));
+}
+
+#[test]
+fn test_mldsa_44_invalid_sig_size() {
+    run_invalid_sig_size_test("mldsa-44", 1312, 2420, 3000, "ML-DSA-44");
+}
+
+#[test]
+fn test_mldsa_65_invalid_sig_size() {
+    run_invalid_sig_size_test("mldsa-65", 1952, 3300, 3000, "ML-DSA-65");
+}
+
+#[test]
+fn test_mldsa_87_invalid_sig_size() {
+    run_invalid_sig_size_test("mldsa-87", 2592, 4627, 3000, "ML-DSA-87");
 }

--- a/sw/host/tests/attestation/attestation_test.rs
+++ b/sw/host/tests/attestation/attestation_test.rs
@@ -69,15 +69,22 @@ fn get_base64_blob(haystack: &str, rx: &str) -> Result<Vec<u8>> {
 }
 
 fn check_public_key(key: &SubjectPublicKeyInfo, id: &[u8], subject: &Name) -> Result<bool> {
-    let SubjectPublicKeyInfo::EcPublicKey(info) = key;
+    let material = match key {
+        SubjectPublicKeyInfo::EcPublicKey(info) => {
+            let mut material = Vec::new();
+            let x = &info.public_key.x.get_value().to_bytes_be();
+            let y = &info.public_key.y.get_value().to_bytes_be();
+            material.extend(vec![0; 32 - x.len()]);
+            material.extend(x);
+            material.extend(vec![0; 32 - y.len()]);
+            material.extend(y);
+            material
+        }
+        SubjectPublicKeyInfo::Mldsa44(info)
+        | SubjectPublicKeyInfo::Mldsa65(info)
+        | SubjectPublicKeyInfo::Mldsa87(info) => info.public_key.get_value().clone(),
+    };
 
-    let mut material = Vec::new();
-    let x = &info.public_key.x.get_value().to_bytes_be();
-    let y = &info.public_key.y.get_value().to_bytes_be();
-    material.extend(vec![0; 32 - x.len()]);
-    material.extend(x);
-    material.extend(vec![0; 32 - y.len()]);
-    material.extend(y);
     let hash = Sha256Digest::hash(&material).to_vec();
     let keyid = &hash[..20];
     log::info!("computed id = {:?}", hex::encode(keyid));


### PR DESCRIPTION
Add support for the post-quantum signature algorithm ML-DSA (FIPS 204) to the certificate template generation tool.

This includes:
- Adding OID representations for ML-DSA-44, ML-DSA-65, and ML-DSA-87.
- Supporting ML-DSA in X.509 public key and signature builders.
- Adding template validation, substition, and testgen for ML-DSA.
- Adding a test case for ML-DSA.