### PR TITLE
[rom_ext] Use dynamic ROM_EXT size from slot_spec

### DIFF
--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -215,6 +215,7 @@ def opentitan_test(
         silicon = _silicon_params(),
         verilator = _verilator_params(),
         qemu = _qemu_params(),
+        slot_spec = {},
         run_in_ci = None,
         **kwargs):
     """Instantiate a test per execution environment.
@@ -329,6 +330,7 @@ def opentitan_test(
             rsa_key = rsa_key,
             spx_key = spx_key,
             manifest = manifest,
+            slot_spec = slot_spec,
             needs_jtag = getattr(tparam, "needs_jtag", False),
         )
 

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -307,9 +307,9 @@ asm_library_with_coverage(
             "//sw/device/silicon_creator/lib/sigverify",
             "//sw/device/silicon_creator/rom_ext/imm_section:imm_section_version",
             "//sw/otbn/crypto:boot",
-        ] + variation_deps,
+        ] + variation.deps,
     )
-    for variation_name, variation_deps in ROM_EXT_VARIATIONS.items()
+    for variation_name, variation in ROM_EXT_VARIATIONS.items()
 ]
 
 manifest(d = {
@@ -341,6 +341,7 @@ manifest(d = {
         ],
         linker_script = ":ld_slot_{}".format(slot),
         manifest = ":manifest",
+        slot_spec = variation.slot_spec,
         spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:spx_keyset": "prod_key_0"},
         deps = [
             ":rom_ext_{}".format(variation_name),
@@ -352,13 +353,13 @@ manifest(d = {
             "//sw/device/silicon_creator/rom_ext/imm_section:main_section_{}_slot_{}".format(variation_name, slot),
         ],
     )
-    for variation_name, variation_deps in ROM_EXT_VARIATIONS.items()
+    for variation_name, variation in ROM_EXT_VARIATIONS.items()
     for slot in SLOTS
 ]
 
 ROM_EXT_LABELS.extend([
     "rom_ext_{}_slot_{}".format(variation_name, slot)
-    for variation_name, variation_deps in ROM_EXT_VARIATIONS.items()
+    for variation_name, variation in ROM_EXT_VARIATIONS.items()
     for slot in SLOTS
 ])
 

--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -19,12 +19,28 @@ ROM_EXT_VERSION = struct(
 )
 
 ROM_EXT_VARIATIONS = {
-    "dice_x509": [
-        "//sw/device/silicon_creator/lib/cert:dice",
-    ],
-    "dice_cwt": [
-        "//sw/device/silicon_creator/lib/cert:dice_cwt",
-    ],
+    "dice_x509": struct(
+        deps = [
+            "//sw/device/silicon_creator/lib/cert:dice",
+        ],
+        slot_spec = {},
+    ),
+    "dice_cwt": struct(
+        deps = [
+            "//sw/device/silicon_creator/lib/cert:dice_cwt",
+        ],
+        slot_spec = {},
+    ),
+    "dice_mldsa": struct(
+        deps = [
+            "//sw/device/silicon_creator/lib/cert:dice",
+        ],
+        slot_spec = {
+            "owner_slot_a": "0x20000",
+            "owner_slot_b": "0xa0000",
+            "rom_ext_size": "0x20000",
+        },
+    ),
 }
 
 SLOTS = [

--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
@@ -29,7 +29,7 @@ package(default_visibility = ["//visibility:public"])
 
 [
     opentitan_test(
-        name = "no_refresh_{}_test".format(variation),
+        name = "no_refresh_{}_test".format(variation_name),
         srcs = ["no_refresh_test.c"],
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
@@ -39,13 +39,14 @@ package(default_visibility = ["//visibility:public"])
         fpga = fpga_params(
             exit_failure = "Rebooting[\\s\\S]*CDI_1 certificate not valid[\\s\\S]*Rebooted",
             exit_success = "Rebooted\r\n",
-            rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_{}_slot_a".format(variation),
+            rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_{}_slot_a".format(variation_name),
         ),
         qemu = qemu_params(
             exit_failure = "Rebooting[\\s\\S]*CDI_1 certificate not valid[\\s\\S]*Rebooted",
             exit_success = "Rebooted\r\n",
-            rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_{}_slot_a".format(variation),
+            rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_{}_slot_a".format(variation_name),
         ),
+        slot_spec = variation.slot_spec,
         deps = [
             "//sw/device/lib/base:status",
             "//sw/device/lib/runtime:log",
@@ -55,7 +56,7 @@ package(default_visibility = ["//visibility:public"])
             "//sw/device/silicon_creator/lib/drivers:rstmgr",
         ],
     )
-    for variation in ROM_EXT_VARIATIONS.keys()
+    for variation_name, variation in ROM_EXT_VARIATIONS.items()
 ]
 
 manifest({
@@ -85,23 +86,6 @@ opentitan_binary(
     ],
 )
 
-[
-    opentitan_binary_assemble(
-        name = "{}_rom_ext_owner_bundle".format(variation),
-        testonly = True,
-        bins = {
-            "//sw/device/silicon_creator/rom_ext:rom_ext_{}_slot_a".format(variation): SLOTS["a"],
-            ":print_certs_for_assemble": OWNER_SLOTS["a"],
-        },
-        exec_env = [
-            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys",
-            "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys",
-            "//hw/top_earlgrey:sim_qemu_rom_with_fake_keys",
-        ],
-    )
-    for variation in ROM_EXT_VARIATIONS.keys()
-]
-
 _VARIATION_INTEROP_TEST_CASES = [
     {
         "first": "x509",
@@ -111,6 +95,23 @@ _VARIATION_INTEROP_TEST_CASES = [
         "first": "cwt",
         "second": "x509",
     },
+]
+
+[
+    opentitan_binary_assemble(
+        name = "dice_{}_rom_ext_owner_bundle".format(name),
+        testonly = True,
+        bins = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_dice_{}_slot_a".format(name): SLOTS["a"],
+            ":print_certs_for_assemble": OWNER_SLOTS["a"],
+        },
+        exec_env = [
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys",
+            "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys",
+            "//hw/top_earlgrey:sim_qemu_rom_with_fake_keys",
+        ],
+    )
+    for name in _VARIATION_INTEROP_TEST_CASES[0].values()
 ]
 
 [
@@ -243,7 +244,7 @@ DEBUG_MODE_TESTCASES = [
     opentitan_test(
         name = "debug_mode_{}_{}_test".format(
             testcase["name"],
-            variation,
+            variation_name,
         ),
         srcs = ["debug_mode_test.c"],
         defines = testcase["defines"],
@@ -254,11 +255,12 @@ DEBUG_MODE_TESTCASES = [
             "//hw/top_earlgrey:sim_qemu_rom_ext": None,
         },
         fpga = fpga_params(
-            rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_{}_slot_a".format(variation),
+            rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_{}_slot_a".format(variation_name),
         ),
         qemu = qemu_params(
-            rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_{}_slot_a".format(variation),
+            rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_{}_slot_a".format(variation_name),
         ),
+        slot_spec = variation.slot_spec,
         deps = [
             "//sw/device/lib/base:status",
             "//sw/device/lib/runtime:log",
@@ -269,5 +271,5 @@ DEBUG_MODE_TESTCASES = [
         ],
     )
     for testcase in DEBUG_MODE_TESTCASES
-    for variation in ROM_EXT_VARIATIONS.keys()
+    for variation_name, variation in ROM_EXT_VARIATIONS.items()
 ]

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
@@ -26,6 +26,10 @@ load(
     "qemu_params",
 )
 load(
+    "//sw/device/silicon_creator/rom_ext:defs.bzl",
+    "ROM_EXT_VARIATIONS",
+)
+load(
     "//sw/device/silicon_creator/rom_ext/imm_section:defs.bzl",
     "IMMUTABLE_HASH_UNENFORCED_MSG",
     "IMM_SECTION_MAJOR_VERSION",
@@ -82,6 +86,15 @@ _POSITIONS = {
         "success": "bl0_slot = __BB\r\n",
         "otp_img": None,
     },
+    "owner_slot_b_shifted": {
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_mldsa_slot_a",
+        "romext_offset": "{rom_ext_slot_a}",
+        "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_b",
+        "owner_offset": "{owner_slot_b}",
+        "success": "bl0_slot = __BB\r\n",
+        "otp_img": None,
+        "slot_spec": ROM_EXT_VARIATIONS["dice_mldsa"].slot_spec,
+    },
     "owner_virtual_a": {
         "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
         "romext_offset": "{rom_ext_slot_a}",
@@ -97,6 +110,15 @@ _POSITIONS = {
         "owner_offset": "{owner_slot_b}",
         "success": "bl0_slot = __BB\r\n",
         "otp_img": None,
+    },
+    "owner_virtual_b_shifted": {
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_mldsa_slot_a",
+        "romext_offset": "{rom_ext_slot_a}",
+        "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
+        "owner_offset": "{owner_slot_b}",
+        "success": "bl0_slot = __BB\r\n",
+        "otp_img": None,
+        "slot_spec": ROM_EXT_VARIATIONS["dice_mldsa"].slot_spec,
     },
     "romext_slot_a": {
         "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
@@ -181,6 +203,7 @@ _POSITIONS = {
             owner_offset = position["owner_offset"],
             romext_offset = position["romext_offset"],
         ),
+        slot_spec = position.get("slot_spec", {}),
         deps = [
             "//sw/device/lib/base:status",
             "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/silicon_creator/rom_ext/imm_section/BUILD
+++ b/sw/device/silicon_creator/rom_ext/imm_section/BUILD
@@ -143,12 +143,13 @@ ld_library(
         ],
         linker_script = ":ld_slot_{}".format(slot),
         manifest = "//hw/top_earlgrey:none_manifest",
+        slot_spec = variation.slot_spec,
         deps = [
             ":main_lib",
             "//sw/device/lib/crt",
-        ] + variation_deps,
+        ] + variation.deps,
     )
-    for variation_name, variation_deps in ROM_EXT_VARIATIONS.items()
+    for variation_name, variation in ROM_EXT_VARIATIONS.items()
     for slot in SLOTS
 ]
 
@@ -165,7 +166,7 @@ ld_library(
         name = "main_binaries_{}_slot_{}_hardened_comparison_test".format(variation_name, slot),
         srcs = [":main_binaries_{}_slot_{}".format(variation_name, slot)],
     )
-    for variation_name, variation_deps in ROM_EXT_VARIATIONS.items()
+    for variation_name, variation in ROM_EXT_VARIATIONS.items()
     for slot in SLOTS
 ]
 
@@ -174,7 +175,7 @@ ld_library(
         name = "main_section_{}_slot_{}".format(variation_name, slot),
         src = ":main_binaries_{}_slot_{}".format(variation_name, slot),
     )
-    for variation_name, variation_deps in ROM_EXT_VARIATIONS.items()
+    for variation_name, variation in ROM_EXT_VARIATIONS.items()
     for slot in SLOTS
 ]
 

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -71,11 +71,8 @@ enum {
   kFlashPageSize = FLASH_CTRL_PARAM_BYTES_PER_PAGE,
   kFlashTotalSize = 2 * kFlashBankSize,
 
-  kRomExtSizeInPages = CHIP_ROM_EXT_SIZE_MAX / kFlashPageSize,
   kRomExtAStart = 0 / kFlashPageSize,
-  kRomExtAEnd = kRomExtAStart + kRomExtSizeInPages,
   kRomExtBStart = kFlashBankSize + kRomExtAStart,
-  kRomExtBEnd = kRomExtBStart + kRomExtSizeInPages,
 };
 
 // Declaration for the ROM_EXT manifest start address, populated by the linker
@@ -223,7 +220,7 @@ extern char _owner_virtual_size[];
 OT_WARN_UNUSED_RESULT
 static uintptr_t owner_vma_get(const manifest_t *manifest, uintptr_t lma_addr) {
   return (lma_addr - (uintptr_t)manifest +
-          (uintptr_t)_owner_virtual_start_address + CHIP_ROM_EXT_SIZE_MAX);
+          (uintptr_t)_owner_virtual_start_address + (uint32_t)_rom_ext_size);
 }
 
 OT_WARN_UNUSED_RESULT
@@ -435,6 +432,9 @@ static rom_error_t rom_ext_try_next_stage(boot_data_t *boot_data,
 }
 
 static void rom_ext_flash_protect_self(uint32_t rom_ext_slot) {
+  uint32_t actual_size = (uint32_t)_rom_ext_size;
+  uint32_t pages = (actual_size + kFlashPageSize - 1) / kFlashPageSize;
+
   flash_ctrl_cfg_t cfg = flash_ctrl_data_default_cfg_get();
   flash_ctrl_perms_t read = {
       .read = kMultiBitBool4True,
@@ -446,10 +446,10 @@ static void rom_ext_flash_protect_self(uint32_t rom_ext_slot) {
       .write = kMultiBitBool4True,
       .erase = kMultiBitBool4True,
   };
-  flash_ctrl_data_region_protect(0, kRomExtAStart, kRomExtSizeInPages,
+  flash_ctrl_data_region_protect(0, kRomExtAStart, pages,
                                  rom_ext_slot == kBootSlotA ? read : write, cfg,
                                  kHardenedBoolTrue);
-  flash_ctrl_data_region_protect(1, kRomExtBStart, kRomExtSizeInPages,
+  flash_ctrl_data_region_protect(1, kRomExtBStart, pages,
                                  rom_ext_slot == kBootSlotB ? read : write, cfg,
                                  kHardenedBoolTrue);
 }
@@ -562,7 +562,7 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   boot_log_check_or_init(boot_log, rom_ext_current_slot(), rom_chip_info);
   boot_log->rom_ext_major = self->version_major;
   boot_log->rom_ext_minor = self->version_minor;
-  boot_log->rom_ext_size = CHIP_ROM_EXT_SIZE_MAX;
+  boot_log->rom_ext_size = (uint32_t)_rom_ext_size;
   // Even though `primary_bl0_slot` can be changed by boot svc, we initialize
   // it here so the "SetNextBl0" can do a one-time override of the RAM copy
   // of `boot_data`.

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h
@@ -19,6 +19,12 @@ static_assert((TOP_EARLGREY_EFLASH_SIZE_BYTES % 2) == 0,
               "Flash size is not divisible by 2");
 
 #ifdef OT_PLATFORM_RV32
+
+/**
+ * ROM_EXT size from Bazel's `slot_spec`.
+ */
+extern char _rom_ext_size[];
+
 /**
  * Returns a pointer to the manifest of the first owner boot stage image stored
  * in flash slot A.
@@ -27,9 +33,9 @@ static_assert((TOP_EARLGREY_EFLASH_SIZE_BYTES % 2) == 0,
  * A.
  */
 OT_WARN_UNUSED_RESULT
-inline const manifest_t *rom_ext_boot_policy_manifest_a_get(void) {
+static inline const manifest_t *rom_ext_boot_policy_manifest_a_get(void) {
   return (const manifest_t *)(TOP_EARLGREY_EFLASH_BASE_ADDR +
-                              CHIP_ROM_EXT_SIZE_MAX);
+                              (uint32_t)_rom_ext_size);
 }
 
 /**
@@ -40,10 +46,10 @@ inline const manifest_t *rom_ext_boot_policy_manifest_a_get(void) {
  * B.
  */
 OT_WARN_UNUSED_RESULT
-inline const manifest_t *rom_ext_boot_policy_manifest_b_get(void) {
+static inline const manifest_t *rom_ext_boot_policy_manifest_b_get(void) {
   return (const manifest_t *)(TOP_EARLGREY_EFLASH_BASE_ADDR +
                               (TOP_EARLGREY_EFLASH_SIZE_BYTES / 2) +
-                              CHIP_ROM_EXT_SIZE_MAX);
+                              (uint32_t)_rom_ext_size);
 }
 #else
 /**

--- a/sw/device/silicon_creator/rom_ext/rom_ext_slot_a.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_slot_a.ld
@@ -15,7 +15,6 @@
 INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
 
 /* Slot A starts at begining of the eFlash. */
-_rom_ext_size = LENGTH(eflash) / 2;
 _rom_ext_start_address = ORIGIN(eflash);
 
 REGION_ALIAS("rom_ext_flash", eflash);

--- a/sw/device/silicon_creator/rom_ext/rom_ext_slot_b.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_slot_b.ld
@@ -15,8 +15,8 @@
 INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
 
 /* Slot B starts at the half-size mark of the eFlash. */
-_rom_ext_size = LENGTH(eflash) / 2;
-_rom_ext_start_address = ORIGIN(eflash) + _rom_ext_size;
+_eflash_bank_size = LENGTH(eflash) / 2;
+_rom_ext_start_address = ORIGIN(eflash) + _eflash_bank_size;
 
 REGION_ALIAS("rom_ext_flash", eflash);
 

--- a/sw/device/silicon_creator/rom_ext/rom_ext_slot_virtual.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_slot_virtual.ld
@@ -20,8 +20,9 @@ INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
  * Symbols to be used in the setup of the address translation for ROM_EXT.
  */
 _rom_ext_start_address = ORIGIN(rom_ext_virtual);
-_rom_ext_size = LENGTH(rom_ext_virtual);
-ASSERT((_rom_ext_size <= (LENGTH(eflash) / 2)), "Error: rom ext flash is bigger than slot");
+ASSERT(
+  LENGTH(rom_ext_virtual) <= LENGTH(eflash) / 2,
+  "Error: rom ext virtual space is bigger than slot");
 
 REGION_ALIAS("rom_ext_flash", rom_ext_virtual);
 

--- a/sw/device/silicon_creator/rom_ext/sival/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/BUILD
@@ -37,7 +37,7 @@ manifest(d = {
 #   --//hw/bitstream/universal:otp=//hw/ip/otp_ctrl/data/earlgrey_skus/sival:otp_img_prod_manuf_personalized
 [
     opentitan_binary(
-        name = "rom_ext_{}_fake_slot_{}".format(variation, slot),
+        name = "rom_ext_{}_fake_slot_{}".format(variation_name, slot),
         ecdsa_key = select({
             "//signing:test_keys": {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:ecdsa_keyset": "prod_key_0"},
             "//conditions:default": {"//hw/ip/otp_ctrl/data/earlgrey_skus/sival/keys:keyset": "sv00-earlgrey-a1-root-ecdsa-test-0"},
@@ -55,10 +55,11 @@ manifest(d = {
         # In order to prevent the linker from prematurely discarding symbols, we
         # need to give the CRT library last.
         linkopts = [
-            "$(location //sw/device/silicon_creator/rom_ext:rom_ext_{})".format(variation),
+            "$(location //sw/device/silicon_creator/rom_ext:rom_ext_{})".format(variation_name),
             "$(location //sw/device/lib/crt)",
         ],
         manifest = ":manifest_sival",
+        slot_spec = variation.slot_spec,
         deps = [
             # The sival_owner C library is included only in the "fake" ROM_EXT,
             # as it is typically used to test FPGA flows and the FPGA doesn't
@@ -67,17 +68,17 @@ manifest(d = {
             "//sw/device/lib/crt",
             "//sw/device/silicon_creator/lib:manifest_def",
             "//sw/device/silicon_creator/lib/rescue:rescue_xmodem",
-            "//sw/device/silicon_creator/rom_ext:rom_ext_{}".format(variation),
-            "//sw/device/silicon_creator/rom_ext/imm_section:main_section_{}_slot_{}".format(variation, slot),
+            "//sw/device/silicon_creator/rom_ext:rom_ext_{}".format(variation_name),
+            "//sw/device/silicon_creator/rom_ext/imm_section:main_section_{}_slot_{}".format(variation_name, slot),
         ],
     )
-    for variation in ROM_EXT_VARIATIONS.keys()
+    for variation_name, variation in ROM_EXT_VARIATIONS.items()
     for slot in SLOTS
 ]
 
 [
     opentitan_binary(
-        name = "rom_ext_{}_prod_slot_{}".format(variation, slot),
+        name = "rom_ext_{}_prod_slot_{}".format(variation_name, slot),
         exec_env = [
             "//hw/top_earlgrey:silicon_creator",
             "//hw/top_earlgrey:fpga_cw310",
@@ -89,20 +90,21 @@ manifest(d = {
         ],
         linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_{}".format(slot),
         linkopts = [
-            "$(location //sw/device/silicon_creator/rom_ext:rom_ext_{})".format(variation),
+            "$(location //sw/device/silicon_creator/rom_ext:rom_ext_{})".format(variation_name),
             "$(location //sw/device/lib/crt)",
         ],
+        slot_spec = variation.slot_spec,
         deps = [
             # The sival_owner C library is excluded from the real ROM_EXT,
             # as chips maintain their ownership configuration in flash.
             "//sw/device/lib/crt",
             "//sw/device/silicon_creator/lib:manifest_def",
             "//sw/device/silicon_creator/lib/rescue:rescue_xmodem",
-            "//sw/device/silicon_creator/rom_ext:rom_ext_{}".format(variation),
-            "//sw/device/silicon_creator/rom_ext/imm_section:main_section_{}_slot_{}".format(variation, slot),
+            "//sw/device/silicon_creator/rom_ext:rom_ext_{}".format(variation_name),
+            "//sw/device/silicon_creator/rom_ext/imm_section:main_section_{}_slot_{}".format(variation_name, slot),
         ],
     )
-    for variation in ROM_EXT_VARIATIONS.keys()
+    for variation_name, variation in ROM_EXT_VARIATIONS.items()
     for slot in SLOTS
 ]
 
@@ -160,8 +162,8 @@ offline_presigning_artifacts(
     name = "presigning",
     testonly = True,
     srcs = [
-        ":rom_ext_{}_prod_slot_{}".format(variation, slot)
-        for variation in ROM_EXT_VARIATIONS.keys()
+        ":rom_ext_{}_prod_slot_{}".format(variation_name, slot)
+        for variation_name in ROM_EXT_VARIATIONS.keys()
         for slot in SLOTS
     ],
     ecdsa_key = {


### PR DESCRIPTION
This allows the ROM_EXT size to be configured dynamically via Bazel's `slot_spec`.

Note: To ensure different placements boot securely, we must also add the intended base address into the manifest. This allows the ROM_EXT to reject misplaced OwnerSW even if signed. This feature will be implemented in a future PR if we decide to adjust slot for production FW.