### PR TITLE
[crypto/config] Wipe OTBN and keymgr at init

### DIFF
--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -356,6 +356,7 @@ cc_library(
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/crypto/drivers:alert",
+        "//sw/device/lib/crypto/drivers:keymgr",
         "//sw/device/lib/crypto/drivers:otbn",
         "//sw/device/lib/crypto/drivers:rv_core_ibex",
     ],

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -356,6 +356,7 @@ cc_library(
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/crypto/drivers:alert",
+        "//sw/device/lib/crypto/drivers:otbn",
         "//sw/device/lib/crypto/drivers:rv_core_ibex",
     ],
 )

--- a/sw/device/lib/crypto/impl/config.c
+++ b/sw/device/lib/crypto/impl/config.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/crypto/drivers/alert.h"
+#include "sw/device/lib/crypto/drivers/keymgr.h"
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/drivers/rv_core_ibex.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
@@ -81,6 +82,9 @@ otcrypto_status_t otcrypto_init(otcrypto_key_security_level_t security_level) {
 
   // The OTBN is still left with DMEM from the boot.
   HARDENED_TRY(otbn_dmem_sec_wipe());
+  // Also clear the sideloaded keys for kmac and otbn.
+  HARDENED_TRY(keymgr_sideload_clear_otbn());
+  HARDENED_TRY(keymgr_sideload_clear_kmac());
 
 #ifdef HASH_SELF_CHECK_ENABLE
   HARDENED_TRY(otcrypto_integrity_check());

--- a/sw/device/lib/crypto/impl/config.c
+++ b/sw/device/lib/crypto/impl/config.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/crypto/drivers/alert.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/drivers/rv_core_ibex.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 
@@ -77,6 +78,9 @@ otcrypto_status_t otcrypto_init(otcrypto_key_security_level_t security_level) {
 
   // Instantiate the RNG.
   HARDENED_TRY(otcrypto_entropy_init());
+
+  // The OTBN is still left with DMEM from the boot.
+  HARDENED_TRY(otbn_dmem_sec_wipe());
 
 #ifdef HASH_SELF_CHECK_ENABLE
   HARDENED_TRY(otcrypto_integrity_check());


### PR DESCRIPTION
The OTBN's DMEM is unwiped after ROM_EXT (for example DICE keys are present), hence, at orcrypto_init wipe the DMEM.
Also clear the sideloaded keys for OTBN and KMAC.