### PR TITLE
[crypto/otbn] Remove dmem wipe at start

### DIFF
--- a/sw/device/lib/crypto/drivers/otbn.c
+++ b/sw/device/lib/crypto/drivers/otbn.c
@@ -322,7 +322,6 @@ status_t otbn_load_app(const otbn_app_t app) {
       (size_t)(app.dmem_data_end - app.dmem_data_start);
 
   HARDENED_TRY(otbn_imem_sec_wipe());
-  HARDENED_TRY(otbn_dmem_sec_wipe());
 
   // Reset the LOAD_CHECKSUM register.
   abs_mmio_write32(kBase + OTBN_LOAD_CHECKSUM_REG_OFFSET, 0);


### PR DESCRIPTION
We always clear the dmem at the end of an operation. We can remove the wipe at the start.