### PR TITLE
[i2c, rtl] saturate timing counter to prevent underflow (replaces #30184)

### DIFF
--- a/hw/ip/i2c/rtl/i2c_controller_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_controller_fsm.sv
@@ -140,7 +140,7 @@ module i2c_controller_fsm import i2c_pkg::*;
       // If we disable Host-Mode mid-txn, keep counting until the end of
       // byte, at which point we create a STOP condition then return to Idle.
       (!host_idle_o && !host_enable_i)) begin
-      tcount_d = tcount_q - 1'b1;
+      tcount_d = (tcount_q == 16'h0) ? 16'h0 :  tcount_q - 1'b1;
     end
   end
 
@@ -976,6 +976,9 @@ module i2c_controller_fsm import i2c_pkg::*;
 
   // Make sure we never attempt to send a single cycle glitch
   `ASSERT(SclOutputGlitch_A, $rose(scl_o) |-> ##1 scl_o)
+
+  // Make sure we never underflow the internal timer
+  `ASSERT_NEVER(I2CTimerUnderflow_A, tcount_q == 16'h0000 && tcount_d == 16'hFFFF)
 
   // TODO: Handle the assertion below
 //  // I2C bus outputs


### PR DESCRIPTION
(re-opening in a copy because I don't have the permission to re-open #30184.)

# Description
This PR re-opens the initiative started in #30184 with additional context. It adds a saturating subtractor to the I2C Controller FSM down-counter to prevent an immediate 16'hFFFF underflow (a ~5.9ms hardware stall) when timing registers (namely `TIMING3.THD_DAT` ) are configured with 0.

# How I found it
I am bringing up this IP on an FPGA. During bare-metal driver development, I accidentally configured `THD_DAT` to 0. Because the FSM down-counter is unsigned, this caused an underflow to `16'hFFFF`, locking up the I2C bus for 5.9ms in my case.

# The documentation contradiction
I completely agree that the OpenTitan spec explicitly mandates `THD_DAT >= 1` (see [note](https://github.com/lowRISC/opentitan/blob/master/hw/ip/i2c/doc/programmers_guide.md?plain=1#L54)), making this technically a software driver violation. However, in the [Timing parameter examples table](https://opentitan.org/book/hw/ip/i2c/doc/programmers_guide.html#timing-parameter-examples), the documentation explicitly calculates and lists a register value of 0 for `TIMING3.THD_DAT`. Because the official example (and the I2C spec) uses 0, I suspect other firmware developers might easily fall into the same misconfiguration trap that I did and end up with unexpected results.

# The intent of the PR
My goal wasn't to 'fix' broken RTL, but rather to add a saturating subtractor as a preventive hardware safeguard. This ensures the FSM handles the misconfiguration without incurring a massive hardware timeout.

# Next steps
If the project prefers to strictly trust software to adhere to the spec bounds in order to save RTL area, I completely understand and am happy to leave this closed! In that case, would you be open to me submitting a separate documentation PR to update the Fast-mode Plus example table so others don't hit this timeout?

(sorry for the lack of context upfront, it was my first PR in this project)