### PR TITLE
[crypto/test] Change to OTCRYPTO_RECOV_ERR

### DIFF
--- a/sw/device/lib/crypto/impl/rsa/run_rsa.c
+++ b/sw/device/lib/crypto/impl/rsa/run_rsa.c
@@ -69,7 +69,7 @@ static status_t rsa_check_otbn_status(void) {
   // Check if it matches the expected magic value
   if (launder32(ok) != kHardenedBoolTrue) {
     HARDENED_TRY(otbn_dmem_sec_wipe());
-    return OTCRYPTO_BAD_ARGS;
+    return OTCRYPTO_RECOV_ERR;
   }
   HARDENED_CHECK_EQ(ok, kHardenedBoolTrue);
 
@@ -193,7 +193,7 @@ static status_t keygen_finalize(uint32_t exp_mode, size_t num_words,
   const otbn_addr_t kOtbnVarRsaMode = OTBN_ADDR_T_INIT(run_rsa, mode);
   HARDENED_TRY(otbn_dmem_read(1, kOtbnVarRsaMode, &act_mode));
   if (act_mode != exp_mode) {
-    return OTCRYPTO_FATAL_ERR;
+    return OTCRYPTO_RECOV_ERR;
   }
   HARDENED_CHECK_EQ(launder32(act_mode), exp_mode);
 

--- a/sw/device/lib/crypto/impl/rsa/run_rsa_key_from_cofactor.c
+++ b/sw/device/lib/crypto/impl/rsa/run_rsa_key_from_cofactor.c
@@ -112,7 +112,7 @@ status_t rsa_keygen_from_cofactor_finalize(rsa_size_t size,
   // Check if it matches the expected magic value
   if (launder32(ok) != kHardenedBoolTrue) {
     HARDENED_TRY(otbn_dmem_sec_wipe());
-    return OTCRYPTO_BAD_ARGS;
+    return OTCRYPTO_RECOV_ERR;
   }
   HARDENED_CHECK_EQ(ok, kHardenedBoolTrue);
 
@@ -154,7 +154,7 @@ status_t rsa_keygen_from_cofactor_finalize(rsa_size_t size,
   HARDENED_TRY_WIPE_DMEM(
       otbn_dmem_read(kOtbnRsaModeWords, kOtbnVarRsaMode, &act_mode));
   if (act_mode != exp_mode) {
-    return OTCRYPTO_FATAL_ERR;
+    return OTCRYPTO_RECOV_ERR;
   }
   HARDENED_CHECK_EQ(launder32(act_mode), exp_mode);
 

--- a/sw/device/tests/crypto/rsa_2048_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_keygen_functest.c
@@ -250,14 +250,14 @@ static status_t run_async_wrong_finalize_tests(void) {
 
   CHECK(otcrypto_rsa_keypair_from_cofactor_async_finalize(&valid_pub_2048,
                                                           &valid_priv_2048)
-            .value == OTCRYPTO_FATAL_ERR.value);
+            .value == OTCRYPTO_RECOV_ERR.value);
 
   LOG_INFO(
       "Starting 2048 standard keygen, attempting 3072 standard finalize...");
   CHECK_STATUS_OK(otcrypto_rsa_keygen_async_start(kOtcryptoRsaSize2048));
 
   CHECK(otcrypto_rsa_keygen_async_finalize(&valid_pub_3072, &valid_priv_3072)
-            .value == OTCRYPTO_FATAL_ERR.value);
+            .value == OTCRYPTO_RECOV_ERR.value);
 
   return OK_STATUS();
 }


### PR DESCRIPTION
Due to checking the OK variable from the OTBN for RSA applications, the negative test on running finalize with a different operation is now caught due to this OK value.
Change the return status of these outputs to recoverable errors since the user could have mistaken the finalize.