### PR TITLE
[dv] Fix "protected" flag for read_and_check_all_csrs_after_reset

### DIFF
--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_common_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_common_vseq.sv
@@ -36,7 +36,7 @@ class keymgr_common_vseq extends keymgr_base_vseq;
     run_common_vseq_wrapper(num_trans);
   endtask : body
 
-  virtual task read_and_check_all_csrs_after_reset();
+  virtual protected task read_and_check_all_csrs_after_reset();
     // need to set keymgr_en to be On, before it can be read back with correct init values
     cfg.keymgr_vif.init(do_rand_otp_key, do_invalid_otp_key);
     delay_after_reset_before_access_csr();

--- a/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_common_vseq.sv
+++ b/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_common_vseq.sv
@@ -36,7 +36,7 @@ class keymgr_dpe_common_vseq extends keymgr_dpe_base_vseq;
     run_common_vseq_wrapper(num_trans);
   endtask : body
 
-  virtual task read_and_check_all_csrs_after_reset();
+  virtual protected task read_and_check_all_csrs_after_reset();
     // need to set keymgr_en to be On, before it can be read back with correct init values
     cfg.keymgr_dpe_vif.init(do_rand_otp_key, do_invalid_otp_key);
     delay_after_reset_before_access_csr();

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
@@ -96,7 +96,7 @@ class lc_ctrl_base_vseq extends cip_base_vseq #(
   endtask
 
   // some registers won't set to default value until otp_init is done
-  virtual task read_and_check_all_csrs_after_reset();
+  virtual protected task read_and_check_all_csrs_after_reset();
     lc_ctrl_init();
     super.read_and_check_all_csrs_after_reset();
   endtask

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -52,7 +52,7 @@ class spi_device_base_vseq extends cip_base_vseq #(
     cfg.spi_cfg_sema.put();
   endtask : dut_init
 
-  virtual task read_and_check_all_csrs_after_reset();
+  virtual protected task read_and_check_all_csrs_after_reset();
     delay_after_reset_before_access_csr();
     super.read_and_check_all_csrs_after_reset();
   endtask

--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_base_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_base_vseq.sv
@@ -102,7 +102,7 @@ class sysrst_ctrl_base_vseq extends cip_base_vseq #(
     cfg.clk_rst_vif.wait_clks(2);
   endtask
 
-  virtual task read_and_check_all_csrs_after_reset();
+  virtual protected task read_and_check_all_csrs_after_reset();
     add_delay_after_reset_before_csrs_access();
     super.read_and_check_all_csrs_after_reset();
   endtask


### PR DESCRIPTION
I made this task protected in commit 83d178b949d, which was kind of reasonable (although should probably have been a separate commit). But I didn't change all the classes that extend cip_base_vseq to match. This causes build warnings from Xcelium, at least.

Fix them.