### PR TITLE
[otbn] Specify the OTBN side of the KMAC interface

### DIFF
--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -29,6 +29,7 @@ See that document for integration overview within the broader top level system.
 * Full control-flow support with conditional branch and unconditional jump instructions, hardware loops, and hardware-managed call/return stacks.
 * Reduced, security-focused instruction set architecture for easier verification and the prevention of data leaks.
 * Built-in access to random numbers.
+* CSR / WSR based interface to KMAC HWIP to offload hashing operations.
 
 ## Description
 
@@ -378,10 +379,10 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
     <tr>
       <td>0x7D9</td>
       <td>RW</td>
-      <td>KMAC_IF_STATUS</td>
+      <td>KMAC_STATUS</td>
       <td>
-        Write a 1 to bits 1 or 2 to clear the error bits.
-        KMAC_IF_STATUS is a CSR that exposes status information for the OTBN-KMAC interface.
+        KMAC_STATUS exposes status information for the OTBN-KMAC interface.
+        All fields are read only except RSP_ERROR, CTRL_ERROR, and MSG_WRITE_ERROR which are W1C.
         <table>
           <thead>
             <tr><th>Bit</th><th>Description</th></tr>
@@ -390,29 +391,35 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
             <tr>
               <td>0</td>
               <td>
-                MSG_WRITE_RDY indicates whether the KMAC_DATA_S0/1 WSR is ready for the next word.
+                READY is 1 when the interface is ready to accept a command and/or new data in KMAC_DATA_S0/1.
               </td>
             </tr>
             <tr>
               <td>1</td>
               <td>
-                MSG_SEND_ERROR (W1C) indicates whether an error occurred after issuing a message send command.
+                RSP_VALID is 1 when the lowest 64 bit words in KMAC_DATA_S0/1 contain valid data (actual digest data is only valid if RSP_ERROR is not 1). This flag is cleared once both, KMAC_DATA_S0 and KMAC_DATA_S1, have been read or when a DONE command is issued.
               </td>
             </tr>
             <tr>
               <td>2</td>
               <td>
-                MSG_WRITE_ERROR (W1C) indicates whether an error occurred after writing to the KMAC_DATA_S0/1 WSR.
+                RSP_ERROR is set to 1 and held when a response is received that signals an error on the KMAC HWIP side. If 1, all received digest data (incl. previously received) must be considered as invalid. This flag is cleared (W1C) when SW writes a 1 to it.
               </td>
             </tr>
             <tr>
               <td>3</td>
               <td>
-                DIGEST_VALID indicates whether the 64 bit word in KMAC_DATA_S0/1 WSR is valid.
+                CTRL_ERROR is 1 when a command was issued while the interface was not ready for it or the command violated the expected command order (for example, a SEND command is issued before a START command). A command raising this error is ignored. This flag is cleared (W1C) when SW writes a 1 to it.
               </td>
             </tr>
             <tr>
-              <td>31:4</td>
+              <td>4</td>
+              <td>
+                MSG_WRITE_ERROR is 1 when a write to KMAC_DATA_S0/1, KMAC_STRB or KMAC_CFG occurred while the interface was not ready to accept new message data or a new configuration. It is also set when a write to KMAC_DATA_S0/1 collides with an incoming digest response. This flag is cleared (W1C) when SW writes a 1 to it.
+              </td>
+            </tr>
+            <tr>
+              <td>31:5</td>
               <td>
                 Reserved. Always reads as 0. Any write is ignored.
               </td>
@@ -424,9 +431,10 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
     <tr>
       <td>0x7DA</td>
       <td>RW</td>
-      <td>KMAC_INTR</td>
+      <td>KMAC_CTRL</td>
       <td>
-        KMAC_INTR is a CSR that exposes the KMAC_ERROR interrupt of the KMAC HWIP.
+        The KMAC control register is used to control the KMAC interface.
+        Always reads as 0.
         <table>
           <thead>
             <tr><th>Bit</th><th>Description</th></tr>
@@ -435,13 +443,37 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
             <tr>
               <td>0</td>
               <td>
-                KMAC_ERROR (W1C) indicates whether an error occurred in the KMAC HWIP.
+                START: Writing 1 to this bit issues a START command.
               </td>
             </tr>
             <tr>
-              <td>31:1</td>
+              <td>1</td>
               <td>
-                Reserved. Always reads as 0. Any write is ignored.
+                SEND: Writing 1 to this bit starts sending the current message in KMAC_DATA_S0/1.
+              </td>
+            </tr>
+            <tr>
+              <td>2</td>
+              <td>
+                PROCESS: Writing 1 to this bit issues a PROCESS command.
+              </td>
+            </tr>
+            <tr>
+              <td>3</td>
+              <td>
+                DONE: Writing 1 to this bit issues a DONE command.
+              </td>
+            </tr>
+            <tr>
+              <td>4</td>
+              <td>
+                CLOSE: Writing 1 to this bit issues a CLOSE command.
+              </td>
+            </tr>
+            <tr>
+              <td>31:5</td>
+              <td>
+                Reserved. Any write is ignored. Always reads as 0.
               </td>
             </tr>
           </tbody>
@@ -453,8 +485,9 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
       <td>RW</td>
       <td>KMAC_CFG</td>
       <td>
-        A configuration register for the KMAC interface.
-        The encodings for the fields are equivalent to the encodings for the CFG_SHADOWED register in the KMAC HWIP.
+        The KMAC configuration register is used to set the hashing session configuration.
+        The three fields EN_XOF, STRENGTH, and MODE are duplicated.
+        For a configuration to be valid, the upper fields must contain the bitwise inverted value of the lower fields.
         <table>
           <thead>
             <tr><th>Bit</th><th>Description</th></tr>
@@ -463,25 +496,49 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
             <tr>
               <td>0</td>
               <td>
-                KMAC_EN enables keyed operation in the KMAC HWIP (kmac_en = 0/1).
+                EN_XOF enables the eXtendable Output Function (XOF) operation. If 1, XOF operation is enabled and the KMAC HWIP will automatically trigger a RUN command once the full rate has been pushed. If 0, KMAC HWIP will only push the first rate, and no other digest will be produced. Usually enabled for SHAKE and cSHAKE and disabled for SHA3 and KMAC modes.
               </td>
             </tr>
             <tr>
               <td>3:1</td>
               <td>
-                STRENGTH allows OTBN to select the desired security strength (kstrength = L128 / L224 / L256 / L384 / L512).
+                STRENGTH defines the security strength of the operation. Valid values are L128, L224, L256, L384, and L512. See KMAC HWIP for encoding of values. The selected value must be compatible with chosen mode (see corresponding standards).  If STRENGTH = L224 and MODE = SHA3, the digest size is not a multiple of 64 bits. As such, only the lower 32 bits of the last digest response (4th beat of the digest response) contain valid data.
               </td>
             </tr>
             <tr>
               <td>5:4</td>
               <td>
-                MODE allows OTBN to set the KMAC hashing mode (mode = SHAKE / cSHAKE / SHA3).
+                MODE defines the hashing mode. This can be SHA3, SHAKE, cSHAKE, or KMAC. See KMAC HWIP for encoding of values. Note, cSHAKE uses prefix from KMAC HWIP CSRs (configured by SW), and KMAC always uses hard coded "KMAC" prefix.
               </td>
             </tr>
             <tr>
-              <td>31:6</td>
+              <td>15:6</td>
               <td>
-                Reserved. Always reads as 0. Any write is ignored.
+                Reserved. Any write is ignored. Always reads as 0.
+              </td>
+            </tr>
+            <tr>
+              <td>16</td>
+              <td>
+                EN_XOF_INV must be the bitwise inverted value of EN_XOF.
+              </td>
+            </tr>
+            <tr>
+              <td>19:17</td>
+              <td>
+                STRENGTH_INV must be the bitwise inverted value of STRENGTH.
+              </td>
+            </tr>
+            <tr>
+              <td>21:20</td>
+              <td>
+                MODE_INV must be the bitwise inverted value of MODE.
+              </td>
+            </tr>
+            <tr>
+              <td>31:22</td>
+              <td>
+                Reserved. Any write is ignored. Always reads as 0.
               </td>
             </tr>
           </tbody>
@@ -491,85 +548,19 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
     <tr>
       <td>0x7DC</td>
       <td>RW</td>
-      <td>KMAC_MSG_SEND</td>
+      <td>KMAC_STRB</td>
       <td>
-        A command register to send a message to KMAC.
-        Reads from this register always return a 0.
-        <table>
-          <thead>
-            <tr><th>Bit</th><th>Description</th></tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>0</td>
-              <td>
-                MSG_SEND can be set to send the contents of KMAC_DATA_S0 and KMAC_DATA_S1 to KMAC.
-              </td>
-            </tr>
-            <tr>
-              <td>31:1</td>
-              <td>
-                Reserved. Always reads as 0. Any write is ignored.
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </td>
-    </tr>
-    <tr>
-      <td>0x7DD</td>
-      <td>RW</td>
-      <td>KMAC_CMD</td>
-      <td>
-        The encodings for the commands are equivalent to the encodings for the CMD register in the KMAC HWIP.
-        Reads from this register always return a 0.
-        <table>
-          <thead>
-            <tr><th>Bit</th><th>Description</th></tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>5:0</td>
-              <td>
-                CMD is the KMAC command field used to issue START, PROCESS, RUN and DONE commands to KMAC.
-              </td>
-            </tr>
-            <tr>
-              <td>31:6</td>
-              <td>
-                Reserved. Always reads as 0. Any write is ignored.
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </td>
-    </tr>
-    <tr>
-      <td>0x7DE</td>
-      <td>RW</td>
-      <td>KMAC_BYTE_STROBE</td>
-      <td>
-        The input bytes of KMAC_DATA_S0/1 that are valid and should be consumed by KMAC.
+        Defines which of the bytes of KMAC_DATA_S0/1 are valid and should be sent towards the KMAC HWIP.
+        Each bit corresponds to one byte in KMAC_DATA_S0/1, with bit 0 corresponding to the least significant byte.
+        May only be written to when KMAC_STATUS.READY = 1.
         <br>
-        For all message chunks except the final one, BYTE_STROBE must be programmed to all ones, indicating that all bytes in KMAC_DATA are valid. For the final message chunk, selected bits may be cleared to indicate unused bytes.
-        Any cleared bits must correspond to the most-significant bytes only, that is, the mask must be contiguous, with no zero bit followed by a one at a higher significance.
-        This needs to be the case, because that's how SHA3 inside KMAC expects the data.
+        For all messages except the final one, KMAC_STRB must be programmed to all ones, indicating that all bytes in KMAC_DATA_S0/1 are valid.
+        The final message can be shorter.
+        It can be 1 to 32 bytes long which must be encoded in KMAC_STRB by setting the corresponding number of least significant bits to 1.
+        The strobe therefore must always be contiguous and LSB aligned.
         If a non contiguous strobe is defined the behaviour is undefined.
         <br>
-        Reads from this register return the current configuration of the KMAC_BYTE_STROBE CSR.
-        <table>
-          <thead>
-            <tr><th>Bit</th><th>Description</th></tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>31:0</td>
-              <td>
-                BYTE_STROBE is the KMAC byte strobe field.
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        Reads from this register return the current strobe.
       </td>
     </tr>
     <tr>
@@ -634,75 +625,6 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
         <br>
         The number is sourced from an local PRNG.
         Reads never stall.
-      </td>
-    </tr>
-    <tr>
-      <td>0xFC2</td>
-      <td>RO</td>
-      <td>KMAC_STATUS</td>
-      <td>
-        Writes to this CSR are always ignored.
-        This CSR exposes the internal state of the SHA3 FSM within KMAC.
-        <table>
-          <thead>
-            <tr><th>Bit</th><th>Description</th></tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>0</td>
-              <td>
-                SHA3_IDLE indicates whether the SHA3 core is in the idle state.
-              </td>
-            </tr>
-            <tr>
-              <td>1</td>
-              <td>
-                SHA3_ABSORB indicates whether the SHA3 core is in the absorb state.
-              </td>
-            </tr>
-            <tr>
-              <td>2</td>
-              <td>
-                SHA3_SQUEEZE indicates whether the SHA3 core is in the squeeze state.
-              </td>
-            </tr>
-            <tr>
-              <td>31:3</td>
-              <td>
-                Reserved. Always reads as 0. Any write is ignored.
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </td>
-    </tr>
-    <tr>
-      <td>0xFC3</td>
-      <td>RO</td>
-      <td>KMAC_ERROR</td>
-      <td>
-        Writes to this register are ignored.
-        This register exposes the error code from the KMAC HWIP ERR_CODE register.
-        No other information from the KMAC HWIP ERR_CODE register is exposed.
-        <table>
-          <thead>
-            <tr><th>Bit</th><th>Description</th></tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>7:0</td>
-              <td>
-                ERROR_CODE contains the error code coming directly from the KMAC HWIP.
-              </td>
-            </tr>
-            <tr>
-              <td>31:8</td>
-              <td>
-                Reserved. Always reads as 0. Any write is ignored.
-              </td>
-            </tr>
-          </tbody>
-        </table>
       </td>
     </tr>
     <tr>
@@ -870,16 +792,19 @@ All read-write (RW) WSRs are set to 0 when OTBN starts an operation (when 1 is w
       <td>RW</td>
       <td><a name="kmac-data-s0">KMAC_DATA_S0</a></td>
       <td>
-        KMAC_DATA_S0 is the first 256-bit share of the masked message or digest interface.
+        KMAC_DATA_S0 and KMAC_DATA_S1 are used to send message parts towards the KMAC HWIP as well as to receive the resulting digest.
         <br>
-        For masked operations, provide the first share here and the second share in KMAC_DATA_S1.
+        For sending message parts, i.e., when writing to the WSRs, the WSRs are 256-bit wide.
+        The message is sent towards the KMAC HWIP in 64-bit parts, starting with the least significant word.
+        To send a masked message, provide the first share in KMAC_DATA_S0 and the second share in KMAC_DATA_S1.
+        If no masking is required, set one share to the plaintext data and the other share to all-zeros.
         <br>
-        If masking is not required:
-        - Set this share to the plaintext data.
-        - Set the other share to all-zeros.
+        When reading from the WSRs, the digest data is only 64-bit wide and is placed in the least significant 64 bits.
+        The upper bits [255:64] are not updated by the digest response.
+        If a valid response is present (indicated by KMAC_STATUS.RSP_VALID), once both KMAC_DATA_S0 and KMAC_DATA_S1 are read, the KMAC interface starts accepting the next digest part.
         <br>
-        The digest data is provided in chunks of 64 bits at a time.
-        For plaintext retrieval of the digest, software must XOR the values from KMAC_DATA_S0 and KMAC_DATA_S1.
+        The provided digest is always in Boolean shared representation.
+        To retrieve the plaintext digest, software must XOR the values from KMAC_DATA_S0 and KMAC_DATA_S1.
         <table>
           <thead>
             <tr><th>Bit</th><th>Description</th></tr>
@@ -894,7 +819,7 @@ All read-write (RW) WSRs are set to 0 when OTBN starts an operation (when 1 is w
             <tr>
               <td>255:64</td>
               <td>
-                Write: Words 1-3 of the message share. Read: Returns `0`. Digest shares are read out via the least significant word only.
+                Write: Words 1-3 of the message share. Read: Digest shares are read out via the least significant word only, these bits are not affected by a digest response and keep the value written by SW.
               </td>
             </tr>
           </tbody>
@@ -906,35 +831,7 @@ All read-write (RW) WSRs are set to 0 when OTBN starts an operation (when 1 is w
       <td>RW</td>
       <td><a name="kmac-data-s1">KMAC_DATA_S1</a></td>
       <td>
-        KMAC_DATA_S1 is the second 256-bit share of the masked message or digest interface.
-        <br>
-        For masked operations, provide the second share here and the second share in KMAC_DATA_S0.
-        <br>
-        If masking is not required:
-        - Set this share to the plaintext data.
-        - Set the other share to all-zeros.
-        <br>
-        The digest data is provided in chunks of 64 bits at a time.
-        For plaintext retrieval of the digest, software must XOR the values from KMAC_DATA_S0 and KMAC_DATA_S1.
-        <table>
-          <thead>
-            <tr><th>Bit</th><th>Description</th></tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>63:0</td>
-              <td>
-                Write: Least significant word of the message share. Read: Current 64-bit word of the digest share.
-              </td>
-            </tr>
-            <tr>
-              <td>255:64</td>
-              <td>
-                Write: Words 1-3 of the message share. Read: Returns `0`. Digest shares are read out via the least significant word only.
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        KMAC_DATA_S1 is the counterpart of KMAC_DATA_S0: see its documentation for details.
       </td>
     </tr>
     <tr>

--- a/hw/ip/otbn/data/csr.yml
+++ b/hw/ip/otbn/data/csr.yml
@@ -99,68 +99,97 @@
     Write to this CSR to begin a request to fill the RND cache.
     Always reads as 0.
 
-- name: kmac_if_status
+- name: kmac_status
   address: 0x7d9
   doc: |
-    Write a 1 to bits 1 or 2 to clear the error bits.
-    KMAC_IF_STATUS is a CSR that exposes status information for the OTBN-KMAC interface.
+    KMAC_STATUS exposes status information for the OTBN-KMAC interface.
+    All fields are read only except RSP_ERROR, CTRL_ERROR, and MSG_WRITE_ERROR which are W1C.
   bits:
-    0: MSG_WRITE_RDY indicates whether the KMAC_DATA_S0/1 WSR is ready for the next word.
-    1: MSG_SEND_ERROR (W1C) indicates whether an error occurred after issuing a message send command.
-    2: MSG_WRITE_ERROR (W1C) indicates whether an error occurred after writing to the KMAC_DATA_S0/1 WSR.
-    3: DIGEST_VALID indicates whether the 64 bit word in KMAC_DATA_S0/1 WSR is valid.
-    31-4: Reserved. Always reads as 0. Any write is ignored.
+    0: |
+      READY is 1 when the interface is ready to accept a command and/or new data in KMAC_DATA_S0/1.
+    1: |
+      RSP_VALID is 1 when the lowest 64 bit words in KMAC_DATA_S0/1 contain valid data (actual digest data is only valid if RSP_ERROR is not 1).
+      This flag is cleared once both, KMAC_DATA_S0 and KMAC_DATA_S1, have been read or when a DONE command is issued.
+    2: |
+      RSP_ERROR is set to 1 and held when a response is received that signals an error on the KMAC HWIP side.
+      If 1, all received digest data (incl. previously received) must be considered as invalid.
+      This flag is cleared (W1C) when SW writes a 1 to it.
+    3: |
+      CTRL_ERROR is 1 when a command was issued while the interface was not ready for it or the command violated the expected command order (for example, a SEND command is issued before a START command).
+      A command raising this error is ignored.
+      This flag is cleared (W1C) when SW writes a 1 to it.
+    4: |
+      MSG_WRITE_ERROR is 1 when a write to KMAC_DATA_S0/1, KMAC_STRB or KMAC_CFG occurred while the interface was not ready to accept new message data or a new configuration.
+      It is also set when a write to KMAC_DATA_S0/1 collides with an incoming digest response.
+      This flag is cleared (W1C) when SW writes a 1 to it.
+    31-5: Reserved. Always reads as 0. Any write is ignored.
 
-- name: kmac_intr
+- name: kmac_ctrl
   address: 0x7da
   doc: |
-    KMAC_INTR is a CSR that exposes the KMAC_ERROR interrupt of the KMAC HWIP.
+    The KMAC control register is used to control the KMAC interface.
+    Always reads as 0.
   bits:
-    0: KMAC_ERROR (W1C) indicates whether an error occurred in the KMAC HWIP.
-    31-1: Reserved. Always reads as 0. Any write is ignored.
+    0: |
+      START: Writing 1 to this bit issues a START command.
+    1: |
+      SEND: Writing 1 to this bit starts sending the current message in KMAC_DATA_S0/1.
+    2: |
+      PROCESS: Writing 1 to this bit issues a PROCESS command.
+    3: |
+      DONE: Writing 1 to this bit issues a DONE command.
+    4: |
+      CLOSE: Writing 1 to this bit issues a CLOSE command.
+    31-5: Reserved. Any write is ignored. Always reads as 0.
 
 - name: kmac_cfg
   address: 0x7db
   doc: |
-    A configuration register for the KMAC interface.
-    The encodings for the fields are equivalent to the encodings for the CFG_SHADOWED register in the KMAC HWIP.
+    The KMAC configuration register is used to set the hashing session configuration.
+    The three fields EN_XOF, STRENGTH, and MODE are duplicated.
+    For a configuration to be valid, the upper fields must contain the bitwise inverted value of the lower fields.
   bits:
-    0: KMAC_EN enables keyed operation in the KMAC HWIP (kmac_en = 0/1).
-    3-1: STRENGTH allows OTBN to select the desired security strength (kstrength = L128 / L224 / L256 / L384 / L512).
-    5-4: MODE allows OTBN to set the KMAC hashing mode (mode = SHAKE / cSHAKE / SHA3).
-    31-6: Reserved. Always reads as 0. Any write is ignored.
+    0: |
+      EN_XOF enables the eXtendable Output Function (XOF) operation.
+      If 1, XOF operation is enabled and the KMAC HWIP will automatically trigger a RUN command once the full rate has been pushed.
+      If 0, KMAC HWIP will only push the first rate, and no other digest will be produced.
+      Usually enabled for SHAKE and cSHAKE and disabled for SHA3 and KMAC modes.
+    3-1: |
+      STRENGTH defines the security strength of the operation.
+      Valid values are L128, L224, L256, L384, and L512.
+      See KMAC HWIP for encoding of values.
+      The selected value must be compatible with chosen mode (see corresponding standards).
 
-- name: kmac_msg_send
+      If STRENGTH = L224 and MODE = SHA3, the digest size is not a multiple of 64 bits.
+      As such, only the lower 32 bits of the last digest response (4th beat of the digest response) contain valid data.
+    5-4: |
+      MODE defines the hashing mode.
+      This can be SHA3, SHAKE, cSHAKE, or KMAC.
+      See KMAC HWIP for encoding of values.
+      Note, cSHAKE uses prefix from KMAC HWIP CSRs (configured by SW), and KMAC always uses hard coded "KMAC" prefix.
+    15-6: Reserved. Any write is ignored. Always reads as 0.
+    16: |
+      EN_XOF_INV must be the bitwise inverted value of EN_XOF.
+    19-17: |
+      STRENGTH_INV must be the bitwise inverted value of STRENGTH.
+    21-20: |
+      MODE_INV must be the bitwise inverted value of MODE.
+    31-22: Reserved. Any write is ignored. Always reads as 0.
+
+- name: kmac_strb
   address: 0x7dc
   doc: |
-    A command register to send a message to KMAC.
-    Reads from this register always return a 0.
-  bits:
-    0: MSG_SEND can be set to send the contents of KMAC_DATA_S0 and KMAC_DATA_S1 to KMAC.
-    31-1: Reserved. Always reads as 0. Any write is ignored.
+    Defines which of the bytes of KMAC_DATA_S0/1 are valid and should be sent towards the KMAC HWIP.
+    Each bit corresponds to one byte in KMAC_DATA_S0/1, with bit 0 corresponding to the least significant byte.
+    May only be written to when KMAC_STATUS.READY = 1.
 
-- name: kmac_cmd
-  address: 0x7dd
-  doc: |
-    The encodings for the commands are equivalent to the encodings for the CMD register in the KMAC HWIP.
-    Reads from this register always return a 0.
-  bits:
-    5-0: CMD is the KMAC command field used to issue START, PROCESS, RUN and DONE commands to KMAC.
-    31-6: Reserved. Always reads as 0. Any write is ignored.
-
-- name: kmac_byte_strobe
-  address: 0x7de
-  doc: |
-    The input bytes of KMAC_DATA_S0/1 that are valid and should be consumed by KMAC.
-
-    For all message chunks except the final one, BYTE_STROBE must be programmed to all ones, indicating that all bytes in KMAC_DATA are valid. For the final message chunk, selected bits may be cleared to indicate unused bytes.
-    Any cleared bits must correspond to the most-significant bytes only, that is, the mask must be contiguous, with no zero bit followed by a one at a higher significance.
-    This needs to be the case, because that's how SHA3 inside KMAC expects the data.
+    For all messages except the final one, KMAC_STRB must be programmed to all ones, indicating that all bytes in KMAC_DATA_S0/1 are valid.
+    The final message can be shorter.
+    It can be 1 to 32 bytes long which must be encoded in KMAC_STRB by setting the corresponding number of least significant bits to 1.
+    The strobe therefore must always be contiguous and LSB aligned.
     If a non contiguous strobe is defined the behaviour is undefined.
 
-    Reads from this register return the current configuration of the KMAC_BYTE_STROBE CSR.
-  bits:
-    31-0: BYTE_STROBE is the KMAC byte strobe field.
+    Reads from this register return the current strobe.
 
 - name: mai_ctrl
   address: 0x7e0
@@ -201,29 +230,6 @@
 
     The number is sourced from an local PRNG.
     Reads never stall.
-
-- name: kmac_status
-  address: 0xfc2
-  read-only: true
-  doc: |
-    Writes to this CSR are always ignored.
-    This CSR exposes the internal state of the SHA3 FSM within KMAC.
-  bits:
-    0: SHA3_IDLE indicates whether the SHA3 core is in the idle state.
-    1: SHA3_ABSORB indicates whether the SHA3 core is in the absorb state.
-    2: SHA3_SQUEEZE indicates whether the SHA3 core is in the squeeze state.
-    31-3: Reserved. Always reads as 0. Any write is ignored.
-
-- name: kmac_error
-  address: 0xfc3
-  read-only: true
-  doc: |
-    Writes to this register are ignored.
-    This register exposes the error code from the KMAC HWIP ERR_CODE register.
-    No other information from the KMAC HWIP ERR_CODE register is exposed.
-  bits:
-    7-0: ERROR_CODE contains the error code coming directly from the KMAC HWIP.
-    31-8: Reserved. Always reads as 0. Any write is ignored.
 
 - name: mai_status
   address: 0xfca

--- a/hw/ip/otbn/data/wsr.yml
+++ b/hw/ip/otbn/data/wsr.yml
@@ -71,44 +71,31 @@
 - name: kmac_data_s0
   address: 8
   doc: |
-    KMAC_DATA_S0 is the first 256-bit share of the masked message or digest interface.
+    KMAC_DATA_S0 and KMAC_DATA_S1 are used to send message parts towards the KMAC HWIP as well as to receive the resulting digest.
 
-    For masked operations, provide the first share here and the second share in KMAC_DATA_S1.
+    For sending message parts, i.e., when writing to the WSRs, the WSRs are 256-bit wide.
+    The message is sent towards the KMAC HWIP in 64-bit parts, starting with the least significant word.
+    To send a masked message, provide the first share in KMAC_DATA_S0 and the second share in KMAC_DATA_S1.
+    If no masking is required, set one share to the plaintext data and the other share to all-zeros.
 
-    If masking is not required:
-    - Set this share to the plaintext data.
-    - Set the other share to all-zeros.
+    When reading from the WSRs, the digest data is only 64-bit wide and is placed in the least significant 64 bits.
+    The upper bits [255:64] are not updated by the digest response.
+    If a valid response is present (indicated by KMAC_STATUS.RSP_VALID), once both KMAC_DATA_S0 and KMAC_DATA_S1 are read, the KMAC interface starts accepting the next digest part.
 
-    The digest data is provided in chunks of 64 bits at a time.
-    For plaintext retrieval of the digest, software must XOR the values from KMAC_DATA_S0 and KMAC_DATA_S1.
+    The provided digest is always in Boolean shared representation.
+    To retrieve the plaintext digest, software must XOR the values from KMAC_DATA_S0 and KMAC_DATA_S1.
   bits:
     63-0: |
       Write: Least significant word of the message share.
       Read: Current 64-bit word of the digest share.
     255-64: |
       Write: Words 1-3 of the message share.
-      Read: Returns `0`. Digest shares are read out via the least significant word only.
+      Read: Digest shares are read out via the least significant word only, these bits are not affected by a digest response and keep the value written by SW.
 
 - name: kmac_data_s1
   address: 9
   doc: |
-    KMAC_DATA_S1 is the second 256-bit share of the masked message or digest interface.
-
-    For masked operations, provide the second share here and the second share in KMAC_DATA_S0.
-
-    If masking is not required:
-    - Set this share to the plaintext data.
-    - Set the other share to all-zeros.
-
-    The digest data is provided in chunks of 64 bits at a time.
-    For plaintext retrieval of the digest, software must XOR the values from KMAC_DATA_S0 and KMAC_DATA_S1.
-  bits:
-    63-0: |
-      Write: Least significant word of the message share.
-      Read: Current 64-bit word of the digest share.
-    255-64: |
-      Write: Words 1-3 of the message share.
-      Read: Returns `0`. Digest shares are read out via the least significant word only.
+    KMAC_DATA_S1 is the counterpart of KMAC_DATA_S0: see its documentation for details.
 
 - name: mai_res_s0
   address: 10

--- a/hw/ip/otbn/doc/theory_of_operation.md
+++ b/hw/ip/otbn/doc/theory_of_operation.md
@@ -518,6 +518,7 @@ The following state is wiped:
 * The accumulator register (also accessible through the ACC WSR) and the intermediate result registers for the Montgomery computation (hidden registers).
 * Flags (accessible through the FG0, FG1, and FLAGS CSRs)
 * The modulus (accessible through the MOD0 to MOD7 CSRs and the MOD WSR)
+* The WSRs and CSRs for the KMAC interface.
 
 The wiping procedure is a two-step process:
 * Overwrite the state with randomness from URND and request a reseed of URND.
@@ -528,7 +529,240 @@ In order to prevent mismatches between ISS and RTL, software needs to initialise
 
 Loop and call stack pointers are reset.
 
+A secure wipe terminates any ongoing KMAC interface session.
+See the secure wipe section of the interface description.
+
 Host software cannot explicitly trigger an internal secure wipe; it is performed automatically after reset and at the end of an `EXECUTE` operation.
+
+### KMAC interface
+The OTBN features an interface towards the KMAC HWIP which can be used to offload hashing operations.
+It consists of the following CSRs / WSRs:
+- `KMAC_STATUS`
+- `KMAC_CTRL`
+- `KMAC_CFG`
+- `KMAC_STRB`
+- `KMAC_DATA_S0` / `KMAC_DATA_S1`
+
+Behind these CSRs/WSRs, which are described in more detail [here](../README.md#Control-and-Status-Registers-(CSRs)), OTBN uses a [dynamic application interface](../../kmac/doc/theory_of_operation.md#application-interfaces) of the KMAC HWIP.
+
+Before OTBN can make use of this interface, system SW must setup the KMAC HWIP correctly.
+See the KMAC HWIP documentation what must be configured before OTBN can use the interface.
+
+OTBN software can control this interface by configuring it via `KMAC_CFG` and issuing commands via `KMAC_CTRL`.
+These commands are then translated to dynamic application interface requests.
+The responses from the interface are translated and exposed to OTBN SW via `KMAC_STATUS` and `KMAC_DATA_S0` / `KMAC_DATA_S1`.
+
+The interface supports multiple successive sessions where each session follows the following high-level steps:
+- Configure the desired hashing mode via `KMAC_CFG`.
+- Check if the interface is ready by checking for `KMAC_STATUS.READY = 1`.
+- Start a session by issuing the `KMAC_CTRL.START` command.
+- Send the message parts by issuing one or more `KMAC_CTRL.SEND` commands.
+- Issue the `KMAC_CTRL.PROCESS` command to process the full message.
+- Wait for the first response by polling until `KMAC_STATUS.RSP_VALID = 1`.
+- Check for errors by reading `KMAC_STATUS.RSP_ERROR`.
+  - If there is an error, the session must be terminated by issuing the `KMAC_CTRL.DONE` command.
+- Read the digest in 64-bit parts from `KMAC_DATA_S0` and `KMAC_DATA_S1`.
+- For more digest data, poll again until `KMAC_STATUS.RSP_VALID = 1` after reading both data WSRs.
+- Once the digest or the desired XOF output is read, end the digest reading phase by issuing a `KMAC_CTRL.DONE` command.
+- Wait until the `KMAC_CTRL.DONE` command has completed by polling until `KMAC_STATUS.RSP_VALID = 1`.
+- Check for errors by reading `KMAC_STATUS.RSP_ERROR`, `KMAC_STATUS.MSG_WRITE_ERROR`, and `KMAC_STATUS.CTRL_ERROR`.
+  - If there is an error, the digest data must be considered as invalid.
+- Issue the `KMAC_CTRL.CLOSE` command to end the session.
+
+Note that this high-level outline simplifies some steps, especially the error handling.
+If there is no error at the end, OTBN can start the next session with a new configuration and message.
+See the detailed explanations for the different steps in the next sections and the error handling section for more details.
+
+#### Session details
+This section elaborates on the previously presented high-level steps how to use the interface.
+The interface keeps track of the current session with the following state machine.
+Note, a command is issued by OTBN SW and a request/response refers to a KMAC HWIP application interface request/response which is generated/received by the OTBN-KMAC interface module.
+For simplicity, additional states to handle a secure wipe are not depicted.
+
+```mermaid
+stateDiagram-v2
+[*] --> Idle
+
+Idle --> Starting: START command
+
+Starting --> WaitForMsg: Start request sent
+
+WaitForMsg --> SendingMsg: SEND command
+WaitForMsg --> Processing: PROCESS command
+
+SendingMsg --> WaitForMsg: Message sent
+
+Processing --> Receiving: PROCESS request sent
+
+Receiving --> Terminating: DONE command
+
+Terminating --> WaitForFinish: Termination request sent
+
+WaitForFinish --> WaitForClose: Finish response received
+
+WaitForClose --> Idle: CLOSE command
+```
+
+##### Starting a session
+To start a session the OTBN SW has to:
+- Write the desired hashing configuration to `KMAC_CFG`.
+  - There is no validation when writing a configuration to `KMAC_CFG` but KMAC HWIP does check the configuration once the session is started.
+    See [error handling](#error-handling) section for more details.
+- Poll until `KMAC_STATUS.READY = 1`.
+  - This should be 1 in most cases when OTBN starts executing a program, however, the interface could still be terminating a previous session due to a secure wipe (see secure wipe behaviour).
+- Issue the `KMAC_CTRL.START` command by writing a 1 to it.
+- There may be no write to `KMAC_CFG` until `KMAC_STATUS.READY` is 1 again (polled for before sending message).
+  - Otherwise the configuration can be changed while the start request is being sent.
+    The behaviour of the interface in this case is undefined.
+  - Writing `KMAC_CFG` while `KMAC_STATUS.READY` is 0 sets `KMAC_STATUS.MSG_WRITE_ERROR`.
+
+There is no immediate response indicating whether the session was started successfully or not.
+This can be detected when sending the message or is reported along the first digest response: see [error handling](#error-handling).
+As such, after sending the `KMAC_CTRL.START` command OTBN SW must continue with sending the message.
+
+##### Sending the message
+Once the `KMAC_CTRL.START` command was issued, OTBN SW can send the message by following these steps:
+- Poll until `KMAC_STATUS.READY = 1`.
+  - This can time out in certain error cases, see [error handling](#error-handling).
+- Write a message into `KMAC_DATA_S0` and `KMAC_DATA_S1` (share 0 and 1, respectively) and set the corresponding strobe in `KMAC_STRB`.
+  - All messages, including the last one, must be contiguous and LSB aligned.
+  - Only the last message may be partial.
+  - For an unmasked message, write the plaintext into one of the input WSRs and write zeros into the other one.
+- Send the message by writing a 1 to `KMAC_CTRL.SEND`.
+- Repeat these steps until the full message has been sent.
+
+To end the message phase:
+  - Poll until `KMAC_STATUS.READY = 1`.
+  - Issue the `KMAC_CTRL.PROCESS` command by writing a 1 to it.
+
+##### Retrieving digest data
+Once the `PROCESS` command is issued, the KMAC HWIP starts hashing the message.
+As soon as the first digest part is ready, the app interface automatically pushes it towards OTBN without any additional requests from OTBN.
+After issuing the `PROCESS` command, OTBN software thus must do the following:
+- Wait for the first response by polling until `KMAC_STATUS.RSP_VALID = 1`.
+- Check `KMAC_STATUS.RSP_ERROR`.
+  - If 1, an error occurred and the app interface does not send any further responses.
+  - The session must be terminated as described in the error section.
+- If there is no error, OTBN can read the first digest data (64-bit) from `KMAC_DATA_S0` and `KMAC_DATA_S1`.
+  - The digest data always comes in a shared representation.
+    To recover the plaintext digest the values read from `KMAC_DATA_S0` and `KMAC_DATA_S1` must be XORed.
+- Once both WSRs, `KMAC_DATA_S0` and `KMAC_DATA_S1`, have been read the interface clears `KMAC_STATUS.RSP_VALID` and the interface will accept the next digest part from the app interface.
+  (i.e., the `KMAC_STATUS.RSP_VALID` bit serves as back-pressure.)
+- Repeat the steps until the full digest or the required XOF output is received.
+  - As the `KMAC_STATUS.RSP_ERROR` flag is sticky, subsequent checks can be postponed until the last element is read.
+  - The first check is however essential as in case of an error no more responses arrive and polling `KMAC_STATUS.RSP_VALID` would deadlock.
+
+The number of digest parts pushed by the app interface depends on the selected mode, strength and XOF setting.
+
+If `KMAC_CFG.EN_XOF = 0`, the KMAC HWIP pushes only the digest parts that make up the first rate (the actual digest only), i.e., it pushes `roundup(digest_width / 64)` responses.
+Once these are pushed, the interface waits for a `DONE` command as explained [below](#ending-a-session).
+
+If `KMAC_CFG.EN_XOF = 1`, the KMAC HWIP pushes infinite responses.
+For this it automatically squeezes more digest by issuing a KMAC HWIP internal `RUN` command each time it finishes pushing one full rate.
+As soon as the squeezing has finished, the app starts again to push the new rate towards OTBN.
+When the OTBN software has received enough XOF output, the session can be terminated as explained [below](#ending-a-session).
+
+###### Optimizing the digest retrieval
+The KMAC hashing operation is fully deterministic and thus the polling until `KMAC_STATUS.RSP_VALID = 1` can be optimized.
+The first polling after issuing the `PROCESS` command is required as it is unknown when exactly the first response arrives (error response arrives earlier than the first digest).
+However, once the first response has arrived, the arrival of the subsequent responses is fully deterministic.
+The KMAC HWIP pushes the full rate back to back and the squeezing is also a deterministic operation.
+On the OTBN interface side, each time both shares are read, the next digest is accepted by the interface in the same cycle (assuming the KMAC HWIP is currently pushing digest data).
+This allows OTBN SW to read the digest responses back to back, exploiting the full bandwidth the KMAC provides.
+
+##### Ending a session
+
+A session must always be ended with the `DONE` command followed by a `CLOSE` command, regardless of whether an error was detected during the message or digest phase.
+This is required to bring the KMAC HWIP back to idle so that the next session can begin or in case of an error to release the interface so that system SW then can handle the KMAC HWIP error (see KMAC HWIP documentation how errors must be handled).
+
+To end a session:
+- Issue the `KMAC_CTRL.DONE` command by writing a 1 it.
+  - `KMAC_STATUS.RSP_VALID` is cleared immediately upon issuing `DONE`, even if the current values in `KMAC_DATA_S0`/`KMAC_DATA_S1` have not been read yet.
+- Poll until `KMAC_STATUS.RSP_VALID = 1`.
+  - This final response acknowledges the end of the session.
+- Check the error flags (see [error handling](#error-handling) for more details):
+  - `KMAC_STATUS.RSP_ERROR`
+  - `KMAC_STATUS.MSG_WRITE_ERROR`
+  - `KMAC_STATUS.CTRL_ERROR`
+- Once the errors have been checked, issue the `KMAC_CTRL.CLOSE` command to end the session.
+
+If there has been no error detected, the digest from this session is valid and the interface is ready to start the next session.
+
+#### Error handling
+
+The possible errors during a session can be separated between KMAC related errors and OTBN SW errors.
+
+The OTBN SW related errors are:
+1. `KMAC_STATUS.MSG_WRITE_ERROR`
+    - OTBN SW wrote to `KMAC_DATA_S0` / `KMAC_DATA_S1`, `KMAC_STRB` or `KMAC_CFG` when the interface was not ready to accept new data or a new configuration, i.e, when `KMAC_STATUS.READY = 0`.
+    - OTBN SW wrote to `KMAC_DATA_S0` / `KMAC_DATA_S1` in the same cycle the interface wrote an incoming digest response into them during the receive phase (even though `KMAC_STATUS.READY = 1`).
+      The digest response has priority, so the SW write to the least significant word is ignored.
+    - In this case the configuration / message sent to KMAC HWIP could be corrupted and any digest must be considered invalid.
+1. `KMAC_STATUS.CTRL_ERROR`
+    - OTBN SW issued an unexpected command sometime during the session.
+    - As any unexpected commands are ignored the digest data is still valid.
+      However, it gives a hint for a programming error or that OTBN was attacked during the session.
+
+The KMAC related errors cases are:
+1. `KMAC_STATUS.READY` remains low after issuing the `KMAC_CTRL.START` or a `KMAC_CTRL.SEND` command:
+    - The KMAC HWIP does not accept the session request because:
+      - It is busy serving another request.
+        - Note, if the request channel is pipelined, the timeout can happen as soon as the pipeline is full, i.e., after sending the first few messages.
+      - It is in a terminal error state.
+1. A digest response has `KMAC_STATUS.RSP_ERROR = 1`.
+   This happens if either:
+    - The session request is rejected because:
+        - The requested hashing configuration is invalid.
+        - System SW did not set `CFG_SHADOWED.entropy_ready` of the KMAC HWIP before OTBN SW is started.
+      - This service rejected error is reported with the first response after the `KMAC_CTRL.PROCESS` command.
+    - A KMAC HWIP internal error occurred during the session.
+      - Can occur at any time when receiving digest data.
+      - See the KMAC HWIP documentation for error causes.
+
+In case the `KMAC_STATUS.READY` remains low, the KMAC must be assumed as locked up and OTBN SW must abort the execution.
+If OTBN aborts its execution, the system SW then must take the required steps to recover the KMAC HWIP.
+See also the section explaining the secure wipe behaviour.
+
+If a service rejected error or the KMAC HWIP internal error occurs, all digest data must be considered as invalid.
+OTBN SW then must end the session.
+For this OTBN SW should:
+- Clear the `KMAC_STATUS.RSP_ERROR` bit (W1C).
+- Issue the `KMAC_CTRL.DONE` command.
+- Poll until `KMAC_STATUS.RSP_VALID = 1`.
+- Check the `KMAC_STATUS.RSP_ERROR` bit
+  - If it is set again, this means the KMAC HWIP experienced an internal error and this cannot be handled from the OTBN side.
+  - If it is 0, a service rejected error occurred and OTBN can try again with a new session (e.g., with a valid configuration).
+- In any case, issue the `KMAC_CTRL.CLOSE` command to end the session.
+
+#### KMAC interface secure wipe behaviour
+
+When a secure wipe starts, the behaviour depends on whether a session is ongoing or not.
+
+If no session is ongoing, then:
+- `KMAC_DATA_S0` / `KMAC_DATA_S1` are overwritten with randomness twice like any other WSR (regular secure wipe behaviour).
+- `KMAC_CFG` and `KMAC_STRB` are reset to their default values.
+- All flags in `KMAC_STATUS` are cleared.
+
+If a session is ongoing, then:
+- `KMAC_DATA_S0` / `KMAC_DATA_S1` are overwritten with randomness twice like any other WSR (regular secure wipe behaviour).
+- The `KMAC_STATUS.READY` is immediately cleared to 0.
+- The interface starts immediately to end the session in a graceful way.
+  - A message beat that is already being sent is completed (its request `valid` stays asserted until the beat is accepted), but no further beats are sent.
+  - If the session is still in the message phase, a `PROCESS` request is sent.
+  - If required a termination request is sent, and any digest responses that still arrive are discarded until the finish response is received.
+- Once the session has been ended, `KMAC_CFG` and `KMAC_STRB` are reset to their default values and all flags in `KMAC_STATUS` are cleared.
+- Once no secure wipe is ongoing anymore, `KMAC_STATUS.READY` returns back to 1.
+
+Because the data WSRs are wiped immediately, a wipe that coincides with an in-flight message beat can change that beat's data while its request `valid` is asserted.
+This would violate the valid locked-in principle and leads to undefined digest data.
+However, this is a rare corner case and is deliberately accepted because in this case any produced digest data will get discarded.
+
+Terminating the session requires the KMAC HWIP to accept the requests.
+If the KMAC HWIP never does this, the termination could take arbitrarily long.
+A secure wipe can therefore finish before the session is terminated, after which OTBN returns to its idle state (or locks up in the error case).
+It would then be possible for system SW to start another OTBN program before the previous program's session has been terminated.
+Therefore, any OTBN program must check for `KMAC_STATUS.READY = 1` before starting a session.
+If a further secure wipe occurs before the termination completes, the `KMAC_DATA_S0` / `KMAC_DATA_S1` WSRs are wiped again while the termination process continues unaffected.
 
 ## References
 


### PR DESCRIPTION
The last commit of this PR specifies the CSR/WSR based KMAC interface which OTBN SW can make use of to offload hashing operations.

Only the last commit is relevant. All other commits are part of https://github.com/lowRISC/opentitan/pull/30141 (RTL of KMAC side of interface) or https://github.com/lowRISC/opentitan/pull/30143 (required DV changes and RTL changes of IPs already using the app interface). Changes are expected for these PRs.