### PR TITLE
[entropy_src,dv] Re-add random reset stress test

### DIFF
--- a/hw/ip/entropy_src/dv/entropy_src_base_sim_cfg.hjson
+++ b/hw/ip/entropy_src/dv/entropy_src_base_sim_cfg.hjson
@@ -32,8 +32,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
-                // TODO: import `stress_tests.hjson` once hanging issue is resolved.
-                "{proj_root}/hw/dv/tools/dvsim/tests/stress_all_test.hjson"]
+                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
   sim_tops: ["entropy_src_bind", "entropy_src_cov_bind", "sec_cm_prim_onehot_check_bind"]
@@ -100,6 +99,11 @@
       name: entropy_src_stress_all
       uvm_test: entropy_src_stress_all_test
       uvm_test_seq: entropy_src_stress_all_vseq
+    }
+
+    {
+      name: entropy_src_stress_all_with_rand_reset
+      reseed: 10
     }
 
     {


### PR DESCRIPTION
- This test was removed in #11323 because of a hanging issue. The test is now re-added as it doesn't seem to hang anymore. All seeds are failing but it's preferable to see the issues rather than hiding them.
- This PR will clear-out an error raised by DVSim:
`[E 260603 11:27:54 regression:152] Test "entropy_src_stress_all_with_rand_reset" added to regression "V3" not found!`