### PR TITLE
[otbn, dv] Extend otbn env with WDR addr fields

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_trace_item.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_trace_item.sv
@@ -15,6 +15,10 @@ class otbn_trace_item extends uvm_sequence_item;
   logic [255:0] wdr_operand_a;
   logic [255:0] wdr_operand_b;
 
+  // WDR operand addr
+  logic [4:0] wdr_addr_a;
+  logic [4:0] wdr_addr_b;
+
   // Flag read/write data
   otbn_pkg::flags_t flags_read_data [2];
   logic [1:0]       flags_write_valid;
@@ -23,6 +27,9 @@ class otbn_trace_item extends uvm_sequence_item;
   // GPR and WDR write data
   logic [31:0]  gpr_write_data;
   logic [255:0] wdr_write_data;
+
+  // WDR write addr
+  logic [4:0] wdr_write_addr;
 
   // Flags showing call stack pushes and pops
   call_stack_flags_t call_stack_flags;
@@ -55,11 +62,14 @@ class otbn_trace_item extends uvm_sequence_item;
     `uvm_field_int        (gpr_operand_b,            UVM_DEFAULT | UVM_HEX)
     `uvm_field_int        (wdr_operand_a,            UVM_DEFAULT | UVM_HEX)
     `uvm_field_int        (wdr_operand_b,            UVM_DEFAULT | UVM_HEX)
+    `uvm_field_int        (wdr_addr_a,               UVM_DEFAULT | UVM_HEX)
+    `uvm_field_int        (wdr_addr_b,               UVM_DEFAULT | UVM_HEX)
     `uvm_field_sarray_int (flags_read_data,          UVM_DEFAULT | UVM_HEX)
     `uvm_field_int        (flags_write_valid,        UVM_DEFAULT | UVM_BIN)
     `uvm_field_sarray_int (flags_write_data,         UVM_DEFAULT | UVM_HEX)
     `uvm_field_int        (gpr_write_data,           UVM_DEFAULT | UVM_HEX)
     `uvm_field_int        (wdr_write_data,           UVM_DEFAULT | UVM_HEX)
+    `uvm_field_int        (wdr_write_addr,           UVM_DEFAULT | UVM_HEX)
     `uvm_field_int        (call_stack_flags,         UVM_DEFAULT)
     `uvm_field_enum       (stack_fullness_e, loop_stack_fullness, UVM_DEFAULT)
     `uvm_field_enum       (stack_fullness_e, call_stack_fullness, UVM_DEFAULT)

--- a/hw/ip/otbn/dv/uvm/env/otbn_trace_monitor.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_trace_monitor.sv
@@ -44,11 +44,14 @@ class otbn_trace_monitor extends dv_base_monitor #(
             item.gpr_operand_b = cfg.trace_vif.rf_base_rd_data_b;
             item.wdr_operand_a = cfg.trace_vif.rf_bignum_rd_data_a;
             item.wdr_operand_b = cfg.trace_vif.rf_bignum_rd_data_b;
+            item.wdr_addr_a = cfg.trace_vif.rf_bignum_rd_addr_a;
+            item.wdr_addr_b = cfg.trace_vif.rf_bignum_rd_addr_b;
             item.flags_read_data = cfg.trace_vif.flags_read_data;
             item.flags_write_valid = cfg.trace_vif.flags_write;
             item.flags_write_data = cfg.trace_vif.flags_write_data;
             item.gpr_write_data = cfg.trace_vif.rf_base_wr_data;
             item.wdr_write_data = cfg.trace_vif.rf_bignum_wr_data;
+            item.wdr_write_addr = cfg.trace_vif.rf_bignum_wr_addr;
             item.call_stack_flags = cfg.rf_base_vif.get_call_stack_flags();
             item.loop_stack_fullness = cfg.loop_vif.get_fullness();
             item.call_stack_fullness = cfg.rf_base_vif.get_call_stack_fullness();


### PR DESCRIPTION
This PR is created from the commit made in [https://github.com/lowRISC/opentitan/pull/30263].

The WDR addr fields are added in otbn_trace_item and otbn_trace_monitor for use in functional coverage for the SIMD vectorized instructions