### PR TITLE
[spi_host, flash] Check for Quad Mode support in SFDP before Quad Mode tests

### DIFF
--- a/sw/device/lib/testing/spi_flash_testutils.h
+++ b/sw/device/lib/testing/spi_flash_testutils.h
@@ -65,7 +65,7 @@ typedef struct spi_flash_testutils_parameter_header {
 } spi_flash_testutils_parameter_header_t;
 
 // JESD216F, section 6.4.18:
-// The Quad Enable mechanism is bits 20:23 of the 15th dword.
+// The Quad Enable mechanism is bits 20:22 of the 15th dword.
 #define SPI_FLASH_QUAD_ENABLE ((bitfield_field32_t){.mask = 7, .index = 20})
 #define SPI_FLASH_ADDRESS_MODE ((bitfield_field32_t){.mask = 3, .index = 17})
 

--- a/sw/device/tests/spi_host_flash_test_impl.c
+++ b/sw/device/tests/spi_host_flash_test_impl.c
@@ -1,6 +1,8 @@
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
+#include "sw/device/tests/spi_host_flash_test_impl.h"
+
 #include <assert.h>
 
 #include "sw/device/lib/arch/device.h"

--- a/sw/device/tests/spi_host_flash_test_impl.c
+++ b/sw/device/tests/spi_host_flash_test_impl.c
@@ -93,8 +93,8 @@ status_t test_sector_erase(dif_spi_host_t *spi) {
 }
 
 status_t test_enable_quad_mode(dif_spi_host_t *spi) {
-  if (sfdp.param.length < 14) {
-    return INVALID_ARGUMENT();
+  if (!is_quad_mode_supported()) {
+    return UNAVAILABLE();
   }
   uint8_t mech =
       (uint8_t)bitfield_field32_read(sfdp.bfpt[14], SPI_FLASH_QUAD_ENABLE);
@@ -122,6 +122,9 @@ status_t test_page_program(dif_spi_host_t *spi) {
 status_t test_page_program_quad(
     dif_spi_host_t *spi, uint8_t opcode,
     spi_flash_testutils_transaction_width_mode_t page_program_mode) {
+  if (!is_quad_mode_supported()) {
+    return UNAVAILABLE();
+  }
   enum { kPageSize = 256, kAddress = kPageSize * 10 };
 
   TRY(spi_flash_testutils_erase_sector(spi, kAddress, false));
@@ -166,6 +169,9 @@ status_t test_dual_read(dif_spi_host_t *spi) {
 
 // Read the flash device using the "fast quad read" opcode.
 status_t test_quad_read(dif_spi_host_t *spi) {
+  if (!is_quad_mode_supported()) {
+    return UNAVAILABLE();
+  }
   uint8_t buf[256];
   TRY(spi_flash_testutils_read_op(spi, kSpiDeviceFlashOpReadQuad, buf,
                                   sizeof(buf), 0,
@@ -182,6 +188,18 @@ bool is_4_bytes_address_mode_supported(void) {
       bitfield_field32_read(sfdp.bfpt[0], SPI_FLASH_ADDRESS_MODE);
   return (address_mode == kSupport3and4Bytes ||
           address_mode == kSupportOnly4Bytes);
+}
+
+bool is_quad_mode_supported(void) {
+  if (sfdp.param.length < 14) {
+    return false;
+  }
+  uint8_t qe_mechanism =
+      (uint8_t)bitfield_field32_read(sfdp.bfpt[14], SPI_FLASH_QUAD_ENABLE);
+  if (qe_mechanism == 0 || qe_mechanism == 7) {
+    return false;
+  }
+  return true;
 }
 
 status_t test_4bytes_address(dif_spi_host_t *spi) {

--- a/sw/device/tests/spi_host_flash_test_impl.h
+++ b/sw/device/tests/spi_host_flash_test_impl.h
@@ -91,6 +91,13 @@ status_t test_quad_read(dif_spi_host_t *spi);
 bool is_4_bytes_address_mode_supported(void);
 
 /**
+ * Check if the flash supports quad mode.
+ *
+ * @return True if quad mode is supported.
+ */
+bool is_quad_mode_supported(void);
+
+/**
  * Enable 4-byte addressing mode, write and read to a page that needs 4 bytes to
  * be addressed and disables the 4-bytes addressing mode.
  *

--- a/sw/device/tests/spi_host_flash_test_impl.h
+++ b/sw/device/tests/spi_host_flash_test_impl.h
@@ -41,7 +41,7 @@ status_t test_sector_erase(dif_spi_host_t *spi);
  * @param manufacture_id The expected manufacture_id.
  * @return status_t containing either OK or an error.
  */
-status_t test_read_jedec(dif_spi_host_t *spi, uint16_t manufacture_id);
+status_t test_read_jedec(dif_spi_host_t *spi, uint8_t manufacture_id);
 
 /**
  * Send the enable quad mode command.
@@ -86,7 +86,6 @@ status_t test_quad_read(dif_spi_host_t *spi);
 /**
  * Check if the flash supports 4-byte addressing.
  *
- * @param spi A spi host handler.
  * @return True if 4-byte addressing mode is supported.
  */
 bool is_4_bytes_address_mode_supported(void);

--- a/sw/device/tests/spi_host_smoketest.c
+++ b/sw/device/tests/spi_host_smoketest.c
@@ -46,7 +46,11 @@ bool test_main(void) {
   EXECUTE_TEST(result, test_software_reset, &spi_host);
   EXECUTE_TEST(result, test_read_sfdp, &spi_host);
   EXECUTE_TEST(result, test_sector_erase, &spi_host);
-  EXECUTE_TEST(result, test_enable_quad_mode, &spi_host);
+  if (is_quad_mode_supported()) {
+    EXECUTE_TEST(result, test_enable_quad_mode, &spi_host);
+  } else {
+    LOG_WARNING("Quad Mode is not supported by this flash.");
+  }
   EXECUTE_TEST(result, test_page_program, &spi_host);
   return status_ok(result);
 }

--- a/sw/device/tests/spi_host_winbond_flash_test.c
+++ b/sw/device/tests/spi_host_winbond_flash_test.c
@@ -86,17 +86,25 @@ bool test_main(void) {
   EXECUTE_TEST(result, test_read_sfdp, &spi_host);
   EXECUTE_TEST(result, test_sector_erase, &spi_host);
   EXECUTE_TEST(result, test_read_jedec, &spi_host, kManufactureId);
-  EXECUTE_TEST(result, test_enable_quad_mode, &spi_host);
+  if (is_quad_mode_supported()) {
+    EXECUTE_TEST(result, test_enable_quad_mode, &spi_host);
+  } else {
+    LOG_WARNING("Quad Mode is not supported by this flash.");
+  }
   EXECUTE_TEST(result, test_page_program, &spi_host);
   if (is_4_bytes_address_mode_supported()) {
     EXECUTE_TEST(result, test_4bytes_address, &spi_host);
   }
   EXECUTE_TEST(result, test_fast_read, &spi_host);
   EXECUTE_TEST(result, test_dual_read, &spi_host);
-  EXECUTE_TEST(result, test_quad_read, &spi_host);
-  // The Winbond flash `4PP` opcode operates in 1-1-4 mode.
-  EXECUTE_TEST(result, test_page_program_quad, &spi_host,
-               kPageQuadProgramOpcode, kTransactionWidthMode114);
+  if (is_quad_mode_supported()) {
+    EXECUTE_TEST(result, test_quad_read, &spi_host);
+    // The Winbond flash `4PP` opcode operates in 1-1-4 mode.
+    EXECUTE_TEST(result, test_page_program_quad, &spi_host,
+                 kPageQuadProgramOpcode, kTransactionWidthMode114);
+  } else {
+    LOG_WARNING("Quad Mode is not supported by this flash.");
+  }
   EXECUTE_TEST(result, test_erase_32k_block, &spi_host);
   EXECUTE_TEST(result, test_erase_64k_block, &spi_host);
 


### PR DESCRIPTION
This is required for getting the `spi_host_smoketest` and `spi_host_winbond_flash_test` tests working in QEMU. In QEMU the W25Q256 does not support Quad Mode and the BFPT table in the SFDP is shorter to only include the mandatory data - see https://github.com/lowRISC/qemu/blob/ot-10.2.0/hw/block/m25p80_sfdp.c#L299-L333.