### PR TITLE
[otbn] otbn_fi_sim_test and otbn_tvla_sim_test

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/standalonesim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/standalonesim.py
@@ -38,9 +38,6 @@ class StandaloneSim(OTBNSim):
             if self.state.ext_regs.read('RND_REQ', True):
                 self.state.wsrs.RND.set_unsigned(next(_TEST_RND_DATA), False,
                                                  False)
-            # If there's a URND request, respond immediately.
-            if not self.state.wsrs.URND.running:
-                self.state.wsrs.URND.set_seed(_TEST_URND_DATA)
 
             # Similarly, if URND is not running, provide it with some arbitrary
             # seed.

--- a/hw/ip/otbn/util/BUILD
+++ b/hw/ip/otbn/util/BUILD
@@ -69,3 +69,26 @@ py_binary(
         requirement("pyelftools"),
     ],
 )
+
+py_binary(
+    name = "otbn_fi_campaign",
+    srcs = ["otbn_fi_campaign.py"],
+    imports = ["../dv/otbnsim"],
+    deps = [
+        "//hw/ip/otbn/dv/otbnsim/sim:load_elf",
+        "//hw/ip/otbn/dv/otbnsim/sim:standalonesim",
+        requirement("pyelftools"),
+    ],
+)
+
+py_binary(
+    name = "otbn_tvla_campaign",
+    srcs = ["otbn_tvla_campaign.py"],
+    data = ["//hw/ip/otbn/dv/otbnsim:standalone"],
+    imports = ["../dv/otbnsim"],
+    deps = [
+        "//hw/ip/otbn/dv/otbnsim/sim:load_elf",
+        "//hw/ip/otbn/dv/otbnsim/sim:standalonesim",
+        requirement("pyelftools"),
+    ],
+)

--- a/hw/ip/otbn/util/otbn_fi_campaign.py
+++ b/hw/ip/otbn/util/otbn_fi_campaign.py
@@ -1,0 +1,826 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import concurrent.futures
+import multiprocessing
+import argparse
+import sys
+import tempfile
+import os
+import json
+import random
+from collections import Counter
+from elftools.elf.elffile import ELFFile
+
+from sim.standalonesim import StandaloneSim
+from sim.load_elf import load_elf
+from sim.state import FsmState
+from typing import Any, Dict, Iterable, List, Optional, TextIO, Tuple
+
+
+class FISim(StandaloneSim):
+    def __init__(
+        self, fi_skip_pc: Optional[int] = None, fi_skip_occurrence: int = 0
+    ) -> None:
+        super().__init__()
+        self.fi_skip_pc = fi_skip_pc
+        self.fi_skip_occurrence = fi_skip_occurrence
+        self.pc_hit_counts: Dict[int, int] = {}
+
+    def run(
+        self,
+        verbose: bool,
+        dump_file: Optional[TextIO] = None,
+        trace_file: Optional[TextIO] = None,
+        max_insns: Optional[int] = None,
+    ) -> int:
+        insn_count = 0
+        self.state.complete_init_sec_wipe()
+        while True:
+            if max_insns is not None and insn_count >= max_insns:
+                raise TimeoutError("Maximum instruction limit reached")
+            if self.state.ext_regs.read("RND_REQ", True):
+                self.state.wsrs.RND.set_unsigned(random.getrandbits(256), False, False)
+            if not self.state.wsrs.URND.running:
+                seed = [random.getrandbits(64) for _ in range(4)]
+                self.state.wsrs.URND.set_seed(seed)
+
+            current_pc = self.state.pc
+
+            if trace_file is not None:
+                trace_file.write(f"0x{current_pc:08x}\n")
+
+            if current_pc == self.fi_skip_pc:
+                hits = self.pc_hit_counts.get(current_pc, 0)
+                if hits == self.fi_skip_occurrence:
+                    target_insn = self.program[current_pc // 4]
+                    orig_execute = target_insn.execute
+
+                    def nop_execute(*args: Any, **kwargs: Any) -> None:
+                        pass
+
+                    setattr(target_insn, "execute", nop_execute)
+                    self.step(verbose)
+                    setattr(target_insn, "execute", orig_execute)
+
+                    self.pc_hit_counts[current_pc] = hits + 1
+                    insn_count += 1
+                    continue
+
+                self.pc_hit_counts[current_pc] = hits + 1
+
+            self.step(verbose)
+            insn_count += 1
+
+            if self.state.get_fsm_state() in [FsmState.IDLE, FsmState.LOCKED]:
+                if dump_file is not None:
+                    self.dump_regs(dump_file)
+                break
+
+        return insn_count
+
+
+def parse_dmem_bytes(
+    dmem_data: bytes, offsets: Dict[str, int], sizes: Dict[str, int]
+) -> Dict[str, int]:
+    results = {}
+    for sym, addr in offsets.items():
+        size = sizes[sym]
+        num_words = size // 4
+        val_bytes = bytearray()
+        for i in range(num_words):
+            word_idx = (addr // 4) + i
+            off_5 = word_idx * 5
+            word_data = dmem_data[off_5 + 1: off_5 + 5]
+            val_bytes.extend(word_data)
+        results[sym] = int.from_bytes(val_bytes, byteorder="little")
+    return results
+
+
+# We go at most twice in a loop in order to shorten the test
+MAX_PC_DEPTH = 2
+
+
+def get_symbol_offsets(
+    elf_path: str, target_symbols: Iterable[str]
+) -> Dict[str, int]:
+    """Finds the byte offsets of the target variables in DMEM."""
+    offsets = {}
+    with open(elf_path, "rb") as f:
+        elffile = ELFFile(f)
+        symtab = elffile.get_section_by_name(".symtab")
+        for sym in symtab.iter_symbols():
+            if sym.name in target_symbols:
+                offsets[sym.name] = sym["st_value"]
+    return offsets
+
+
+def parse_dmem(
+    dmem_dump_path: str, offsets: Dict[str, int], sizes: Dict[str, int]
+) -> Dict[str, int]:
+    """Reads specific variables from the raw DMEM dump."""
+    results = {}
+
+    with open(dmem_dump_path, "rb") as f:
+        dmem_data = f.read()
+
+    for sym, addr in offsets.items():
+        size = sizes[sym]
+        num_words = size // 4
+
+        val_bytes = bytearray()
+
+        # Read the memory word-by-word
+        for i in range(num_words):
+            word_idx = (addr // 4) + i
+            off_5 = word_idx * 5
+
+            # Format: [ECC Byte] [Data0] [Data1] [Data2] [Data3]
+            # We skip index 0, and grab indices 1, 2, 3, and 4.
+            word_data = dmem_data[off_5 + 1: off_5 + 5]
+            val_bytes.extend(word_data)
+
+        # Convert the reassembled raw bytes to a Little-Endian integer
+        results[sym] = int.from_bytes(val_bytes, byteorder="little")
+
+    return results
+
+
+def run_test_and_get_dmem(
+    elf_path: str,
+    offsets: Dict[str, int],
+    sizes: Dict[str, int],
+    dmem_json: Optional[str] = None,
+    trace_file: Optional[str] = None,
+    skip_pc: Optional[int] = None,
+    skip_occurrence: int = 0,
+    max_insns: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Runs the simulator and returns the parsed DMEM values."""
+    sim = FISim(fi_skip_pc=skip_pc, fi_skip_occurrence=skip_occurrence)
+    exp_end_addr = load_elf(sim, elf_path)
+
+    key0 = int((str("deadbeef") * 12), 16)
+    key1 = int((str("baadf00d") * 12), 16)
+    sim.state.wsrs.set_sideload_keys(key0, key1)
+
+    if dmem_json:
+        with open(dmem_json, "r") as f:
+            dmem_batch_data = json.load(f)
+        if dmem_batch_data:
+            parsed_dmem = {k: bytes.fromhex(v) for k, v in dmem_batch_data[0].items()}
+            sim.load_dmem_vars(parsed_dmem)
+
+    sim.state.ext_regs.commit()
+    sim.start(collect_stats=False)
+
+    trace_f = None
+    if trace_file:
+        trace_f = open(trace_file, "w")
+
+    try:
+        insn_count = sim.run(verbose=False, trace_file=trace_f, max_insns=max_insns)
+    except TimeoutError:
+        return {"status": "TIMEOUT"}
+    except Exception:
+        import traceback
+        traceback.print_exc()
+        return {"status": "ERROR"}
+    finally:
+        if trace_f:
+            trace_f.close()
+
+    if exp_end_addr is not None and sim.state.pc != exp_end_addr:
+        return {"status": "ERROR"}
+
+    dmem_data = sim.dump_data()
+    regs = parse_dmem_bytes(dmem_data, offsets, sizes)
+    return {"status": "SUCCESS", "regs": regs, "insn_count": insn_count}
+
+
+def attack_worker(
+    task: Tuple[
+        int,
+        int,
+        str,
+        str,
+        bool,
+        Dict[str, int],
+        Dict[str, int],
+        str,
+        str,
+        int,
+    ]
+) -> Tuple[
+    int, int, Optional[Dict[str, Any]], Optional[Dict[str, Any]]
+]:
+    random.seed()
+    (
+        pc,
+        occ,
+        elf_path,
+        attack_mode,
+        fixed_instruction_count,
+        offsets,
+        sizes,
+        dmem_a_path,
+        dmem_b_path,
+        baseline_insn_count,
+    ) = task
+    res_a = None
+    res_b = None
+
+    max_insns = baseline_insn_count * 2 if baseline_insn_count else None
+
+    if attack_mode in ["collision", "corruption"]:
+        res_a = run_test_and_get_dmem(
+            elf_path=elf_path,
+            offsets=offsets,
+            sizes=sizes,
+            dmem_json=dmem_a_path,
+            skip_pc=pc,
+            skip_occurrence=occ,
+            max_insns=max_insns,
+        )
+
+        if res_a["status"] != "SUCCESS" and attack_mode == "collision":
+            return pc, occ, res_a, None
+
+    if attack_mode in ["collision", "bypass"]:
+        res_b = run_test_and_get_dmem(
+            elf_path=elf_path,
+            offsets=offsets,
+            sizes=sizes,
+            dmem_json=dmem_b_path,
+            skip_pc=pc,
+            skip_occurrence=occ,
+            max_insns=max_insns,
+        )
+
+    return pc, occ, res_a, res_b
+
+
+def build_pc_to_line_map(elf_path: str) -> Dict[int, Tuple[str, int]]:
+    """Extracts DWARF line info to map PCs to source code lines."""
+    pc_map = {}
+    with open(elf_path, "rb") as f:
+        elffile = ELFFile(f)
+        if not elffile.has_dwarf_info():
+            return pc_map
+        dwarfinfo = elffile.get_dwarf_info()
+        for cu in dwarfinfo.iter_CUs():
+            line_program = dwarfinfo.line_program_for_CU(cu)
+            if line_program is None:
+                continue
+            for entry in line_program.get_entries():
+                if entry.state is None or entry.state.file == 0:
+                    continue
+                file_entry = line_program["file_entry"][entry.state.file - 1]
+                pc_map[entry.state.address] = (
+                    file_entry.name.decode("utf-8"),
+                    entry.state.line,
+                )
+    return pc_map
+
+
+def parse_trace_for_pcs(trace_file: str) -> List[int]:
+    pc_list = []
+    with open(trace_file, "r") as f:
+        for line in f:
+            if line.strip().startswith("0x"):
+                try:
+                    pc_str = line.strip().split()[0]
+                    pc_str = pc_str.replace(":", "")
+                    pc_list.append(int(pc_str, 16))
+                except ValueError:
+                    pass
+    return pc_list
+
+
+def annotate_trace_file(
+    trace_path: str, dwarf_map: Dict[int, Tuple[str, int]]
+) -> None:
+    """Rewrites the trace file to include DWARF source code mapping."""
+    with open(trace_path, "r") as f:
+        lines = f.readlines()
+
+    with open(trace_path, "w") as f:
+        for line in lines:
+            if line.strip().startswith("0x"):
+                try:
+                    # Extract just the PC hex string
+                    pc_str = line.strip().split(":")[0].split()[0]
+                    pc = int(pc_str, 16)
+
+                    # If we have DWARF info, append it as a comment
+                    if pc in dwarf_map:
+                        filepath, lineno = dwarf_map[pc]
+                        filename = os.path.basename(filepath)
+                        line = line.rstrip() + f"    // [{filename}:{lineno}]\n"
+                except Exception:
+                    pass
+            f.write(line)
+
+
+def generate_boolean_shares(
+    secret: int, share_size: int, modulus: Optional[int] = None
+) -> Tuple[int, int]:
+    r = random.getrandbits(share_size * 8)
+    return secret ^ r, r
+
+
+def generate_additive_shares(
+    secret: int, share_size: int, modulus: Optional[int] = None
+) -> Tuple[int, int]:
+    if modulus is None:
+        raise ValueError("Modulus required for additive sharing")
+    r = random.randrange(0, modulus)
+    return (secret - r) % modulus, r
+
+
+def generate_scalar_blind_shares(
+    secret: int, share_size: int, modulus: Optional[int] = None
+) -> Tuple[int, int]:
+    if modulus is None:
+        raise ValueError("Modulus required for scalar blinding")
+    blind_bits = (share_size * 8) - modulus.bit_length()
+    if blind_bits <= 0:
+        raise ValueError("Error in blinding bits size")
+    r0 = random.getrandbits(blind_bits)
+    r1 = random.getrandbits(blind_bits)
+    return secret + (r0 * modulus), r1 * modulus
+
+
+SHARE_GENERATORS = {
+    "boolean": generate_boolean_shares,
+    "additive": generate_additive_shares,
+    "scalar_blind": generate_scalar_blind_shares,
+}
+
+
+def generate_shares(
+    mode: str, secret: int, share_size: int, modulus: Optional[int] = None
+) -> Tuple[int, int]:
+    local_generators = {
+        "boolean": generate_boolean_shares,
+        "additive": generate_additive_shares,
+        "scalar_blind": generate_scalar_blind_shares,
+    }
+
+    generator = None
+    for k, v in local_generators.items():
+        if k == mode:
+            generator = v
+            break
+    if generator is None:
+        raise ValueError(f"Unknown mode: {mode}")
+    return generator(secret, share_size, modulus)
+
+
+def create_dmem_override(
+    secrets_cfg: List[Dict[str, Any]], out_path: str
+) -> None:
+    trace_dict = {}
+    for sec in secrets_cfg:
+        if sec["mode"] == "unmasked" or len(sec["symbols"]) == 1:
+            trace_dict[sec["symbols"][0]] = (
+                sec["secret"].to_bytes(sec["size"], "little").hex()
+            )
+        else:
+            share0, share1 = generate_shares(
+                sec["mode"], sec["secret"], sec["size"], sec["modulus"]
+            )
+            trace_dict[sec["symbols"][0]] = share0.to_bytes(sec["size"], "little").hex()
+            trace_dict[sec["symbols"][1]] = share1.to_bytes(sec["size"], "little").hex()
+
+    with open(out_path, "w") as f:
+        json.dump([trace_dict], f)
+
+
+def unmask_value(
+    regs: Dict[str, int],
+    col_sym: str,
+    mode: str,
+    size: int,
+    modulus_str: Optional[str] = None,
+) -> int:
+    syms = col_sym.split(",")
+    modulus = int(modulus_str, 16) if modulus_str else None
+
+    if mode == "unmasked":
+        assert len(syms) == 1
+        return regs[syms[0]]
+
+    if mode == "boolean":
+        if len(syms) == 1:
+            val = regs[syms[0]]
+            share_size_bits = (size * 8) // 2
+            mask = (1 << share_size_bits) - 1
+            share0 = val & mask
+            share1 = val >> share_size_bits
+            return share0 ^ share1
+        elif len(syms) == 2:
+            return regs[syms[0]] ^ regs[syms[1]]
+        else:
+            raise ValueError("Boolean unmasking supports 1 or 2 symbols")
+
+    if mode == "additive":
+        if modulus is None:
+            raise ValueError("Modulus required for additive unmasking")
+        if len(syms) == 1:
+            val = regs[syms[0]]
+            share_size_bits = (size * 8) // 2
+            share0 = val & ((1 << share_size_bits) - 1)
+            share1 = val >> share_size_bits
+            return (share0 + share1) % modulus
+        elif len(syms) == 2:
+            return (regs[syms[0]] + regs[syms[1]]) % modulus
+        else:
+            raise ValueError("Additive unmasking supports 1 or 2 symbols")
+
+    raise ValueError(f"Unknown mode: {mode}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="OTBN FI Campaign")
+    parser.add_argument("simulator")
+    parser.add_argument("--elf", required=True)
+    parser.add_argument(
+        "--attack-mode",
+        choices=["collision", "corruption", "bypass"],
+        default="collision",
+    )
+    parser.add_argument("--ok-sym", required=True, help="Symbol name for OK flag")
+    parser.add_argument(
+        "--ok-size", type=int, required=True, help="Size in bytes of OK flag"
+    )
+    parser.add_argument(
+        "--ok-val", required=True, help="Expected OK value (e.g. 0x739)"
+    )
+    parser.add_argument("--col-sym", required=True, help="Symbol for collision check")
+    parser.add_argument(
+        "--col-size", type=int, required=True, help="Size in bytes of collision target"
+    )
+    parser.add_argument(
+        "--col-threshold",
+        type=float,
+        default=1.0,
+        help="Partial collision threshold (e.g., 0.75 for 75%)",
+    )
+    parser.add_argument(
+        "--col-mode",
+        choices=["unmasked", "boolean", "additive"],
+        default="unmasked",
+        help="Masking mode for collision target",
+    )
+    parser.add_argument(
+        "--col-modulus",
+        help="Modulus for additive unmasking (hex string)",
+    )
+    parser.add_argument(
+        "--fixed-instruction-count",
+        action="store_true",
+        help="Enforce strict cycle/instruction counting",
+    )
+    parser.add_argument(
+        "--target-a-secret",
+        action="append",
+        default=[],
+        help="Format: sym[s]:mode:size:hex[:mod]",
+    )
+    parser.add_argument(
+        "--target-b-secret",
+        action="append",
+        default=[],
+        help="Format: sym[s]:mode:size:hex[:mod]",
+    )
+    args = parser.parse_args()
+
+    def parse_secret_args(arg_list: List[str]) -> List[Dict[str, Any]]:
+        secrets = []
+        for item in arg_list:
+            parts = item.split(":")
+            modulus = int(parts[4], 16) if len(parts) > 4 and parts[4] else None
+            secrets.append(
+                {
+                    "symbols": parts[0].split(","),
+                    "mode": parts[1],
+                    "size": int(parts[2]),
+                    "secret": int(parts[3], 16),
+                    "modulus": modulus,
+                }
+            )
+        return secrets
+
+    target_a_secrets = parse_secret_args(args.target_a_secret)
+    target_b_secrets = parse_secret_args(args.target_b_secret)
+
+    ok_val_int = int(args.ok_val, 16)
+    sizes = {args.ok_sym: args.ok_size}
+    col_syms = args.col_sym.split(",")
+    for sym in col_syms:
+        sizes[sym] = args.col_size
+
+    col_mode = args.col_mode
+    if len(col_syms) == 1 and col_mode in ["boolean", "additive"]:
+        unmasked_size = args.col_size // 2
+    else:
+        unmasked_size = args.col_size
+
+    offsets = get_symbol_offsets(args.elf, sizes.keys())
+
+    print("Extracting DWARF info from ELF")
+    dwarf_map = build_pc_to_line_map(args.elf)
+
+    shm_dir = "/dev/shm" if os.path.exists("/dev/shm") else None
+    dmem_a_fd, dmem_a_path = tempfile.mkstemp(dir=shm_dir, suffix=".json")
+    os.close(dmem_a_fd)
+    dmem_b_fd, dmem_b_path = tempfile.mkstemp(dir=shm_dir, suffix=".json")
+    os.close(dmem_b_fd)
+
+    create_dmem_override(target_a_secrets, dmem_a_path)
+    create_dmem_override(target_b_secrets, dmem_b_path)
+
+    try:
+        baseline_collision_val = None
+
+        print("--- Generating Baseline (Target A) ---")
+        trace_file_a = "golden_trace_a.log"
+        absolute_trace_path = os.path.abspath(trace_file_a)
+        print(f"Trace file path: {absolute_trace_path}")
+
+        res_a = run_test_and_get_dmem(
+            args.elf,
+            offsets,
+            sizes,
+            dmem_json=dmem_a_path,
+            trace_file=trace_file_a,
+        )
+        if args.attack_mode in ["collision", "corruption"]:
+            if res_a["status"] != "SUCCESS" or res_a["regs"][args.ok_sym] != ok_val_int:
+                print(
+                    "ERROR: Target A did not return the expected OK value on a normal run."
+                )
+                return 1
+
+        annotate_trace_file(trace_file_a, dwarf_map)
+        baseline_collision_val = 0
+        if res_a["status"] == "SUCCESS":
+            baseline_collision_val = unmask_value(
+                res_a["regs"],
+                args.col_sym,
+                args.col_mode,
+                args.col_size,
+                args.col_modulus,
+            )
+        baseline_insn_count = len(parse_trace_for_pcs(trace_file_a))
+
+        print(
+            f"Baseline collision target ({args.col_sym}): {hex(baseline_collision_val)}"
+        )
+        print(f"Baseline instruction count: {baseline_insn_count}")
+
+        if args.attack_mode in ["collision", "bypass"]:
+            print("--- Generating Trace (Target B) ---")
+            trace_file = "golden_trace_b.log"
+            absolute_trace_path = os.path.abspath(trace_file)
+            print(f"Trace file path: {absolute_trace_path}")
+
+            res_b = run_test_and_get_dmem(
+                args.elf,
+                offsets,
+                sizes,
+                dmem_json=dmem_b_path,
+                trace_file=trace_file,
+            )
+
+            if args.attack_mode == "collision":
+                if (
+                    res_b["status"] != "SUCCESS" or
+                    res_b["regs"][args.ok_sym] != ok_val_int
+                ):
+                    print(
+                        "ERROR: Target B did not return the expected OK value on a normal run."
+                    )
+                    return 1
+            elif args.attack_mode == "bypass":
+                if (
+                    res_b["status"] == "SUCCESS" and
+                    res_b["regs"][args.ok_sym] == ok_val_int
+                ):
+                    print("ERROR: In bypass mode, target B must fail. It returned ok.")
+                    return 1
+
+            annotate_trace_file(trace_file, dwarf_map)
+
+        pc_counts = Counter(parse_trace_for_pcs(trace_file_a))
+        attack_queue = [
+            (
+                pc,
+                occ,
+                args.elf,
+                args.attack_mode,
+                args.fixed_instruction_count,
+                offsets,
+                sizes,
+                dmem_a_path,
+                dmem_b_path,
+                baseline_insn_count,
+            )
+            for pc, total in pc_counts.items()
+            for occ in range(min(MAX_PC_DEPTH, total))
+        ]
+        total_attacks = len(attack_queue)
+        completed_attacks = 0
+        successful_attacks = 0
+
+        max_workers = max(1, multiprocessing.cpu_count() - 2)
+        print(
+            f"--- Starting fault simulation ({total_attacks} attacks, {max_workers} processes) ---"
+        )
+
+        with concurrent.futures.ProcessPoolExecutor(
+            max_workers=max_workers
+        ) as executor:
+            future_to_task = {
+                executor.submit(attack_worker, task): task for task in attack_queue
+            }
+
+            for future in concurrent.futures.as_completed(future_to_task):
+                completed_attacks += 1
+                try:
+                    pc, occ, fault_res_a, fault_res_b = future.result()
+                except Exception as e:
+                    print(f"Thread crashed unexpectedly: {e}", flush=True)
+                    continue
+
+                dwarf_str = "unknown_src"
+                if pc in dwarf_map:
+                    filepath, lineno = dwarf_map[pc]
+                    filename = os.path.basename(filepath)
+                    dwarf_str = f"{filename}:{lineno}"
+
+                progress = (
+                    f"[{completed_attacks:4}/{total_attacks}] "
+                    f"PC {hex(pc):<6} [{dwarf_str:<30}] (occ {occ}):"
+                )
+
+                if args.attack_mode == "collision":
+                    if fault_res_a["status"] == "TIMEOUT" or (
+                        fault_res_b and fault_res_b["status"] == "TIMEOUT"
+                    ):
+                        print(f"{progress} Caught (timeout)", flush=True)
+                        continue
+
+                    if fault_res_a["status"] != "SUCCESS" or (
+                        fault_res_b and fault_res_b["status"] != "SUCCESS"
+                    ):
+                        print(f"{progress} Caught (crash)", flush=True)
+                        continue
+
+                    regs_a = fault_res_a["regs"]
+                    regs_b = fault_res_b["regs"]
+
+                    if args.fixed_instruction_count:
+                        if fault_res_a["insn_count"] not in [
+                            baseline_insn_count,
+                            baseline_insn_count - 1,
+                        ] or fault_res_b["insn_count"] not in [
+                            baseline_insn_count,
+                            baseline_insn_count - 1,
+                        ]:
+                            print(
+                                f"{progress} Caught (instr. count mismatch)", flush=True
+                            )
+                            continue
+
+                    if (
+                        regs_a[args.ok_sym] == ok_val_int and
+                        regs_b[args.ok_sym] == ok_val_int
+                    ):
+                        val_a = unmask_value(
+                            regs_a,
+                            args.col_sym,
+                            args.col_mode,
+                            args.col_size,
+                            args.col_modulus,
+                        )
+                        val_b = unmask_value(
+                            regs_b,
+                            args.col_sym,
+                            args.col_mode,
+                            args.col_size,
+                            args.col_modulus,
+                        )
+
+                        total_bits = unmasked_size * 8
+                        xor_val = val_a ^ val_b
+                        mismatched_bits = bin(xor_val).count("1")
+                        matched_bits = total_bits - mismatched_bits
+                        match_ratio = matched_bits / total_bits
+
+                        if match_ratio >= args.col_threshold:
+                            print(
+                                f"\n{progress} Collision found ({match_ratio * 100:.1f}% match)\n"
+                                f"    val_a: {hex(val_a)}\n"
+                                f"    val_b: {hex(val_b)}\n",
+                                flush=True,
+                            )
+                            successful_attacks += 1
+                        else:
+                            print(
+                                f"{progress} No collision ({match_ratio * 100:.1f}% match)",
+                                flush=True,
+                            )
+                    else:
+                        print(f"{progress} Not ok status", flush=True)
+
+                elif args.attack_mode == "corruption":
+                    if fault_res_a["status"] == "TIMEOUT":
+                        print(f"{progress} Caught (timeout)", flush=True)
+                        continue
+                    if fault_res_a["status"] != "SUCCESS":
+                        print(f"{progress} Caught (crash)", flush=True)
+                        continue
+
+                    regs_a = fault_res_a["regs"]
+                    if args.fixed_instruction_count:
+                        if fault_res_a["insn_count"] not in [
+                            baseline_insn_count,
+                            baseline_insn_count - 1,
+                        ]:
+                            print(
+                                f"{progress} Caught (instr. count mismatch)", flush=True
+                            )
+                            continue
+
+                    if regs_a[args.ok_sym] == ok_val_int:
+                        val_a = unmask_value(
+                            regs_a,
+                            args.col_sym,
+                            args.col_mode,
+                            args.col_size,
+                            args.col_modulus,
+                        )
+                        total_bits = unmasked_size * 8
+                        xor_val = val_a ^ baseline_collision_val
+                        match_ratio = (
+                            total_bits - bin(xor_val).count("1")
+                        ) / total_bits
+
+                        if match_ratio < args.col_threshold:
+                            print(
+                                f"\n{progress} Successful corruption \n"
+                                f"    golden:  {hex(baseline_collision_val)}\n"
+                                f"    faulted: {hex(val_a)}\n",
+                                flush=True,
+                            )
+                            successful_attacks += 1
+                        else:
+                            print(f"{progress} No corruption", flush=True)
+                    else:
+                        print(f"{progress} Not ok status", flush=True)
+
+                elif args.attack_mode == "bypass":
+                    if fault_res_b["status"] == "TIMEOUT":
+                        print(f"{progress} Caught (timeout)", flush=True)
+                        continue
+                    if fault_res_b["status"] != "SUCCESS":
+                        print(f"{progress} Caught (crash)", flush=True)
+                        continue
+
+                    regs_b = fault_res_b["regs"]
+                    if args.fixed_instruction_count:
+                        if fault_res_b["insn_count"] not in [
+                            baseline_insn_count,
+                            baseline_insn_count - 1,
+                        ]:
+                            print(
+                                f"{progress} Caught (instr. count mismatch)", flush=True
+                            )
+                            continue
+
+                    if regs_b[args.ok_sym] == ok_val_int:
+                        print(
+                            f"\n{progress} Successful bypass\n",
+                            flush=True,
+                        )
+                        successful_attacks += 1
+                    else:
+                        print(f"{progress} No bypass", flush=True)
+
+        print(
+            f"Campaign Complete. Successful Attacks: {successful_attacks}", flush=True
+        )
+        return 0 if successful_attacks == 0 else 1
+
+    finally:
+        if os.path.exists(dmem_a_path):
+            os.remove(dmem_a_path)
+        if os.path.exists(dmem_b_path):
+            os.remove(dmem_b_path)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hw/ip/otbn/util/otbn_tvla_campaign.py
+++ b/hw/ip/otbn/util/otbn_tvla_campaign.py
@@ -1,0 +1,752 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import sys
+import os
+import random
+import math
+import tempfile
+import concurrent.futures
+import multiprocessing
+from collections import defaultdict, Counter
+from elftools.elf.elffile import ELFFile
+
+from sim.standalonesim import StandaloneSim
+from sim.load_elf import load_elf
+from sim.state import FsmState
+from sim.isa import OTBNInsn
+from sim.trace import Trace
+from typing import Any, Dict, List, Optional, TextIO, Tuple
+
+
+class TVLASim(StandaloneSim):
+    def __init__(self, trace_hw_file: Optional[TextIO] = None) -> None:
+        super().__init__()
+        self.trace_hw_file = trace_hw_file
+        if self.trace_hw_file is not None:
+            self._tvla_init()
+
+    def _on_retire(self, verbose: bool, insn: OTBNInsn) -> List[Trace]:
+        if self.trace_hw_file is not None:
+            self._tvla_pending_wdrs = list(self.state.wdrs._pending_writes)
+        return super()._on_retire(verbose, insn)
+
+    def _on_stall(self, verbose: bool, fetch_next: bool) -> List[Trace]:
+        if self.trace_hw_file is not None:
+            self._tvla_pending_wdrs = list(self.state.wdrs._pending_writes)
+        return super()._on_stall(verbose, fetch_next)
+
+    def run_batch(
+        self,
+        verbose: bool,
+        batch_size: int,
+        dmem_batch_data: Optional[List[Dict[str, bytes]]] = None,
+    ) -> int:
+        insn_count = 0
+        initial_pc = self.state.pc
+        snapshot_dmem = self.state.dmem.dump_le_words() if batch_size > 1 else None
+
+        for trace_idx in range(batch_size):
+            if batch_size > 1:
+                assert snapshot_dmem is not None
+                if self.trace_hw_file:
+                    self.trace_hw_file.write("===\n")
+                self.state.dmem.load_le_words(
+                    snapshot_dmem, has_validity=True, word_offset=0
+                )
+                for i in range(32):
+                    self.state.gprs.get_reg(i).write_unsigned(0)
+                    self.state.wdrs.get_reg(i).write_unsigned(0)
+                self.state.wsrs.ACC.write_unsigned(0)
+                self.state.csrs.flags[0].write_unsigned(0)
+                self.state.csrs.flags[1].write_unsigned(0)
+                self.state.wsrs.URND.set_seed(
+                    [random.getrandbits(64) for _ in range(4)]
+                )
+                self.state.pc = initial_pc
+                self.state.commit(sim_stalled=True)
+                self._tvla_init()
+
+            if dmem_batch_data:
+                sim_dmem_vars = dmem_batch_data[trace_idx]
+                self.load_dmem_vars(sim_dmem_vars)
+
+            self.state.ext_regs.commit()
+            self.start(collect_stats=False)
+            self.state.complete_init_sec_wipe()
+
+            while True:
+                if self.state.ext_regs.read("RND_REQ", True):
+                    self.state.wsrs.RND.set_unsigned(
+                        random.getrandbits(256), False, False
+                    )
+                if not self.state.wsrs.URND.running:
+                    self.state.wsrs.URND.set_seed(
+                        [random.getrandbits(64) for _ in range(4)]
+                    )
+
+                current_pc = self.state.pc
+
+                tvla_hits = 0
+                if self.trace_hw_file is not None:
+                    tvla_hits = self._tvla_hits.get(current_pc, 0)
+                    self._tvla_pre_step(current_pc)
+
+                self.step(verbose)
+                insn_count += 1
+
+                if self.trace_hw_file is not None:
+                    self._tvla_post_step(current_pc, self.trace_hw_file)
+                    self._tvla_hits[current_pc] = tvla_hits + 1
+
+                if self.state.get_fsm_state() in [FsmState.IDLE, FsmState.LOCKED]:
+                    break
+
+        return insn_count
+
+    def _tvla_init(self) -> None:
+        self._tvla_hits: Dict[int, int] = {}
+        self._tvla_pending_wdrs: List[int] = []
+        self._tvla_latches: Dict[str, int] = {
+            "fg0": 0,
+            "fg1": 0,
+            "in_wide": 0,
+            "in_gp": 0,
+        }
+
+    def _tvla_pre_step(self, current_pc: int) -> None:
+        self._tvla_wdrs_before = self.state.wdrs.peek_unsigned_values()
+        self._tvla_gprs_before = self.state.gprs.peek_unsigned_values()
+        self._tvla_acc_before = self.state.wsrs.ACC.read_unsigned()
+
+        wrs1_idx, wrs2_idx = None, None
+        grs1_idx, grs2_idx = None, None
+        try:
+            insn_obj = self.program[current_pc // 4]
+            op_vals = insn_obj.op_vals
+            mnemonic = insn_obj.insn.mnemonic
+            if "wrs1" in op_vals:
+                wrs1_idx = op_vals["wrs1"]
+            elif "wrs" in op_vals:
+                wrs1_idx = op_vals["wrs"]
+            if "wrs2" in op_vals:
+                wrs2_idx = op_vals["wrs2"]
+
+            gpr_sources = []
+            if "grs1" in op_vals:
+                gpr_sources.append(op_vals["grs1"])
+            elif "grs" in op_vals:
+                gpr_sources.append(op_vals["grs"])
+            if "grs2" in op_vals:
+                gpr_sources.append(op_vals["grs2"])
+            if "grd" in op_vals and mnemonic == 'bn.lid':
+                gpr_sources.append(op_vals["grd"])
+
+            if len(gpr_sources) > 0:
+                grs1_idx = gpr_sources[0]
+            if len(gpr_sources) > 1:
+                grs2_idx = gpr_sources[1]
+        except Exception:
+            pass
+
+        self._tvla_in_hw, self._tvla_in_hd = (
+            0,
+            0,
+        )
+
+        if wrs1_idx is not None or wrs2_idx is not None:
+            val1 = self._tvla_wdrs_before[wrs1_idx] if wrs1_idx is not None else 0
+            val2 = self._tvla_wdrs_before[wrs2_idx] if wrs2_idx is not None else 0
+            val = (val1 << 256) | val2
+            self._tvla_in_hw = bin(val).count("1")
+            self._tvla_in_hd = bin(self._tvla_latches["in_wide"] ^ val).count("1")
+            self._tvla_latches["in_wide"] = val
+            self._tvla_latches["in_gp"] = 0
+        elif grs1_idx is not None or grs2_idx is not None:
+            val1 = self._tvla_gprs_before[grs1_idx] if grs1_idx is not None else 0
+            val2 = self._tvla_gprs_before[grs2_idx] if grs2_idx is not None else 0
+            val = (val1 << 32) | val2
+            self._tvla_in_hw = bin(val).count("1")
+            self._tvla_in_hd = bin(self._tvla_latches["in_gp"] ^ val).count("1")
+            self._tvla_latches["in_gp"] = val
+            self._tvla_latches["in_wide"] = 0
+        else:
+            self._tvla_latches["in_wide"] = 0
+            self._tvla_latches["in_gp"] = 0
+
+    def _tvla_post_step(self, current_pc: int, trace_hw_file: TextIO) -> None:
+        wdrs_after = self.state.wdrs.peek_unsigned_values()
+        acc_after = self.state.wsrs.ACC.read_unsigned()
+        fg0_after = self.state.csrs.flags[0].read_unsigned()
+        fg1_after = self.state.csrs.flags[1].read_unsigned()
+
+        curr_alu_out = None
+        out_hd = 0
+        if self._tvla_acc_before != acc_after:
+            curr_alu_out = acc_after
+            out_hd = bin(self._tvla_acc_before ^ acc_after).count("1")
+        else:
+            if self._tvla_pending_wdrs:
+                idx = sorted(self._tvla_pending_wdrs)[0]
+                curr_alu_out = wdrs_after[idx]
+                out_hd = bin(self._tvla_wdrs_before[idx] ^ curr_alu_out).count("1")
+
+        out_hw = bin(curr_alu_out).count("1") if curr_alu_out is not None else 0
+
+        fg0_hw = bin(fg0_after).count("1")
+        fg0_hd = bin(self._tvla_latches["fg0"] ^ fg0_after).count("1")
+        fg1_hw = bin(fg1_after).count("1")
+        fg1_hd = bin(self._tvla_latches["fg1"] ^ fg1_after).count("1")
+
+        trace_hw_file.write(
+            f"{current_pc:#x} {out_hw} {out_hd} {fg0_hw} {fg0_hd} "
+            f"{fg1_hw} {fg1_hd} {self._tvla_in_hw} {self._tvla_in_hd}\n"
+        )
+
+        self._tvla_latches["fg0"] = fg0_after
+        self._tvla_latches["fg1"] = fg1_after
+
+
+NUM_MODELS = 8
+
+MODEL_NAMES = {
+    0: "Out HW",
+    1: "Out HD",
+    2: "fg0 HW",
+    3: "fg0 HD",
+    4: "fg1 HW",
+    5: "fg1 HD",
+    6: "In HW",
+    7: "In HD",
+}
+
+
+class TVLAAccumulator:
+    def __init__(self) -> None:
+        self.counts = defaultdict(lambda: defaultdict(lambda: [0, 0]))
+        self.sums = defaultdict(
+            lambda: defaultdict(lambda: [[0.0] * NUM_MODELS, [0.0] * NUM_MODELS])
+        )
+        self.sum_sqs = defaultdict(
+            lambda: defaultdict(lambda: [[0.0] * NUM_MODELS, [0.0] * NUM_MODELS])
+        )
+
+    def add_trace_hws(
+        self, pc: int, occ: int, set_idx: int, hws: List[int]
+    ) -> None:
+        self.counts[pc][occ][set_idx] += 1
+        for i in range(NUM_MODELS):
+            hw = hws[i]
+            self.sums[pc][occ][set_idx][i] += hw
+            self.sum_sqs[pc][occ][set_idx][i] += hw**2
+
+    def compute_t_test(self, pc: int, occ: int, model_idx: int) -> float:
+        n0 = self.counts[pc][occ][0]
+        n1 = self.counts[pc][occ][1]
+
+        if n0 < 2 or n1 < 2:
+            return 0.0
+
+        sum0 = self.sums[pc][occ][0][model_idx]
+        sum1 = self.sums[pc][occ][1][model_idx]
+        sq0 = self.sum_sqs[pc][occ][0][model_idx]
+        sq1 = self.sum_sqs[pc][occ][1][model_idx]
+
+        mean0 = sum0 / n0
+        mean1 = sum1 / n1
+
+        var0 = (sq0 - (sum0**2) / n0) / (n0 - 1)
+        var1 = (sq1 - (sum1**2) / n1) / (n1 - 1)
+
+        if var0 == 0 and var1 == 0:
+            return 0.0
+
+        t_stat = (mean0 - mean1) / math.sqrt((var0 / n0) + (var1 / n1))
+        return t_stat
+
+
+def build_pc_to_line_map(elf_path: str) -> Dict[int, Tuple[str, int]]:
+    """Extracts DWARF line info to map PCs to source code lines."""
+    pc_map = {}
+    try:
+        with open(elf_path, "rb") as f:
+            elffile = ELFFile(f)
+            if not elffile.has_dwarf_info():
+                return pc_map
+            dwarfinfo = elffile.get_dwarf_info()
+            for cu in dwarfinfo.iter_CUs():
+                line_program = dwarfinfo.line_program_for_CU(cu)
+                if line_program is None:
+                    continue
+                for entry in line_program.get_entries():
+                    if entry.state is None or entry.state.file == 0:
+                        continue
+                    file_entry = line_program["file_entry"][entry.state.file - 1]
+                    pc_map[entry.state.address] = (
+                        file_entry.name.decode("utf-8"),
+                        entry.state.line,
+                    )
+    except Exception as e:
+        print(f"Failed to extract DWARF info: {e}")
+    return pc_map
+
+
+def annotate_trace_file(
+    trace_path: str, dwarf_map: Dict[int, Tuple[str, int]]
+) -> None:
+    """Rewrites the trace file to include headers, aligned columns, and source mapping."""
+    with open(trace_path, "r") as f:
+        lines = f.readlines()
+
+    header1 = (
+        "PC     | Out HW | Out HD | fg0 HW | fg0 HD | fg1 HW | fg1 HD | "
+        "In HW  | In HD  | Source\n"
+    )
+    header2 = (
+        "-------|--------|--------|--------|--------|--------|--------|"
+        "--------|--------|--------------------------\n"
+    )
+
+    with open(trace_path, "w") as f:
+        f.write(header1)
+        f.write(header2)
+
+        for line in lines:
+            if line.strip().startswith("0x"):
+                try:
+                    parts = line.strip().split()
+                    pc_str = parts[0]
+                    pc = int(pc_str, 16)
+                    m = [int(x) for x in parts[1:9]]
+
+                    dwarf_str = ""
+                    if pc in dwarf_map:
+                        filepath, lineno = dwarf_map[pc]
+                        filename = os.path.basename(filepath)
+                        dwarf_str = f"// [{filename}:{lineno}]"
+
+                    formatted = (
+                        f"{pc_str:<6} | {m[0]:>6} | {m[1]:>6} | {m[2]:>6} | {m[3]:>6} | "
+                        f"{m[4]:>6} | {m[5]:>6} | {m[6]:>6} | {m[7]:>6} | {dwarf_str}\n"
+                    )
+                    f.write(formatted)
+                except Exception:
+                    pass
+
+
+def generate_shares(
+    mode: str, secret: int, share_size: int, modulus: Optional[int] = None
+) -> Tuple[int, Optional[int]]:
+    """Generates shares based on the selected cryptographic masking mode."""
+    if mode == "boolean":
+        # share0 ^ share1 = secret
+        r = random.getrandbits(share_size * 8)
+        share0 = secret ^ r
+        share1 = r
+        return share0, share1
+
+    elif mode == "additive":
+        # (share0 + share1) mod n = secret
+        if modulus is None:
+            raise ValueError("Modulus required for additive sharing")
+        r = random.randrange(0, modulus)
+        share0 = (secret - r) % modulus
+        share1 = r
+        return share0, share1
+
+    elif mode == "subtractive":
+        # (share0 - share1) mod n = secret
+        if modulus is None:
+            raise ValueError("Modulus required for subtractive sharing")
+        r = random.randrange(0, modulus)
+        share0 = (secret + r) % modulus
+        share1 = r
+        return share0, share1
+
+    elif mode == "scalar_blind":
+        # ECC specific: share0 = secret + r0*n, share1 = r1*n
+        if modulus is None:
+            raise ValueError("Modulus required for scalar blinding")
+        blind_bits = (share_size * 8) - modulus.bit_length()
+        if blind_bits <= 0:
+            raise ValueError("Error in blinding bits size")
+        r0 = random.getrandbits(blind_bits)
+        r1 = random.getrandbits(blind_bits)
+        share0 = secret + (r0 * modulus)
+        share1 = r1 * modulus
+        return share0, share1
+
+    elif mode == "const":
+        return secret, None
+
+    raise ValueError(f"Unknown mode: {mode}")
+
+
+def run_experiment(
+    task: Tuple[str, str, int, int, int, Dict[str, Any]]
+) -> Tuple[int, int, Dict[Tuple[int, int], List[Any]]]:
+    """Runs a batched simulation."""
+    _, elf_path, set_idx, batch_num, batch_size, cfg = task
+    random.seed()
+
+    # Write to RAM
+    shm_dir = "/dev/shm" if os.path.exists("/dev/shm") else None
+
+    trace_hw = tempfile.NamedTemporaryFile(dir=shm_dir, mode="w+", delete=False)
+    trace_path = trace_hw.name
+
+    local_stats = {}
+
+    try:
+        batch_dmem = []
+        is_random_set = set_idx == 1
+
+        for _ in range(batch_size):
+            trace_dict = {}
+
+            # Target shares (fixed vs random)
+            for tvla in cfg["tvla_secrets"]:
+                if is_random_set:
+                    bit_len = tvla["size"] * 8
+                    current_secret = random.getrandbits(bit_len)
+                    if tvla["modulus"]:
+                        current_secret = current_secret % tvla["modulus"]
+                else:
+                    current_secret = tvla["secret"]
+
+                share0, share1 = generate_shares(
+                    tvla["mode"], current_secret, tvla["size"], tvla["modulus"]
+                )
+                trace_dict[tvla["symbols"][0]] = share0.to_bytes(
+                    tvla["size"], "little"
+                ).hex()
+                if share1 is not None and len(tvla["symbols"]) > 1:
+                    trace_dict[tvla["symbols"][1]] = share1.to_bytes(
+                        tvla["size"], "little"
+                    ).hex()
+
+            # Fixed background (value is always the same)
+            for bg in cfg["fixed_bg_secrets"]:
+                bg_share0, bg_share1 = generate_shares(
+                    bg["mode"], bg["secret"], bg["size"], bg["modulus"]
+                )
+                trace_dict[bg["symbols"][0]] = bg_share0.to_bytes(
+                    bg["size"], "little"
+                ).hex()
+                if bg_share1 is not None and len(bg["symbols"]) > 1:
+                    trace_dict[bg["symbols"][1]] = bg_share1.to_bytes(
+                        bg["size"], "little"
+                    ).hex()
+
+            # Random background (value is randomized on every trace)
+            for bg in cfg["random_bg_secrets"]:
+                bit_len = bg["size"] * 8
+                rnd_sec = random.getrandbits(bit_len)
+                if bg["modulus"]:
+                    rnd_sec = rnd_sec % bg["modulus"]
+
+                bg_share0, bg_share1 = generate_shares(
+                    bg["mode"], rnd_sec, bg["size"], bg["modulus"]
+                )
+                trace_dict[bg["symbols"][0]] = bg_share0.to_bytes(
+                    bg["size"], "little"
+                ).hex()
+                if bg_share1 is not None and len(bg["symbols"]) > 1:
+                    trace_dict[bg["symbols"][1]] = bg_share1.to_bytes(
+                        bg["size"], "little"
+                    ).hex()
+
+            batch_dmem.append(trace_dict)
+
+        parsed_batch_dmem = []
+        for dmem_dict in batch_dmem:
+            parsed_dict = {k: bytes.fromhex(v) for k, v in dmem_dict.items()}
+            parsed_batch_dmem.append(parsed_dict)
+
+        sim = TVLASim(trace_hw_file=trace_hw)
+        load_elf(sim, elf_path)
+
+        key0 = int((str("deadbeef") * 12), 16)
+        key1 = int((str("baadf00d") * 12), 16)
+        sim.state.wsrs.set_sideload_keys(key0, key1)
+
+        sim.run_batch(
+            verbose=False, batch_size=batch_size, dmem_batch_data=parsed_batch_dmem
+        )
+
+        trace_hw.flush()
+        trace_hw.seek(0)
+
+        pc_counts = Counter()
+        for line in trace_hw:
+            # Check if the state is cleared
+            if line.startswith("==="):
+                pc_counts.clear()
+                continue
+
+            parts = line.strip().split()
+            if not parts:
+                continue
+
+            pc = int(parts[0], 16)
+            hws = [int(x) for x in parts[1:]]
+
+            occ = pc_counts[pc]
+
+            if (pc, occ) not in local_stats:
+                # [count, sums_array, sum_sqs_array]
+                local_stats[(pc, occ)] = [0, [0.0] * NUM_MODELS, [0.0] * NUM_MODELS]
+
+            stats = local_stats[(pc, occ)]
+            stats[0] += 1
+            for i in range(NUM_MODELS):
+                stats[1][i] += hws[i]
+                stats[2][i] += hws[i] ** 2
+
+            pc_counts[pc] += 1
+
+        if not local_stats:
+            print(f"\nBatch {batch_num} produced an empty trace file.", flush=True)
+
+    except Exception as e:
+        print(f"\nBatch {batch_num} python exception: {e}", flush=True)
+    finally:
+        trace_hw.close()
+        if os.path.exists(trace_path):
+            os.remove(trace_path)
+
+    return batch_num, set_idx, local_stats
+
+
+def generate_reference_trace(
+    simulator_path: str,
+    elf_path: str,
+    dwarf_map: Dict[int, Tuple[str, int]],
+    cfg: Dict[str, Any],
+) -> None:
+    """Generates a single annotated trace file for manual inspection."""
+    # simulator_path is ignored
+    print("--- Generating Annotated Reference Trace ---", flush=True)
+    out_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR", ".")
+    ref_trace_path = os.path.join(out_dir, "tvla_reference_trace.log")
+
+    trace_dict = {}
+
+    # Generate target shares
+    for tvla in cfg["tvla_secrets"]:
+        share0, share1 = generate_shares(
+            tvla["mode"], tvla["secret"], tvla["size"], tvla["modulus"]
+        )
+        trace_dict[tvla["symbols"][0]] = share0.to_bytes(tvla["size"], "little").hex()
+        if share1 is not None and len(tvla["symbols"]) > 1:
+            trace_dict[tvla["symbols"][1]] = share1.to_bytes(tvla["size"], "little").hex()
+
+    # Generate fixed background shares
+    for bg in cfg["fixed_bg_secrets"]:
+        bg_share0, bg_share1 = generate_shares(
+            bg["mode"], bg["secret"], bg["size"], bg["modulus"]
+        )
+        trace_dict[bg["symbols"][0]] = bg_share0.to_bytes(bg["size"], "little").hex()
+        if bg_share1 is not None and len(bg["symbols"]) > 1:
+            trace_dict[bg["symbols"][1]] = bg_share1.to_bytes(bg["size"], "little").hex()
+
+    # Generate random background shares
+    for bg in cfg["random_bg_secrets"]:
+        bit_len = bg["size"] * 8
+        rnd_sec = random.getrandbits(bit_len)
+        if bg["modulus"]:
+            rnd_sec = rnd_sec % bg["modulus"]
+
+        bg_share0, bg_share1 = generate_shares(
+            bg["mode"], rnd_sec, bg["size"], bg["modulus"]
+        )
+        trace_dict[bg["symbols"][0]] = bg_share0.to_bytes(bg["size"], "little").hex()
+        if bg_share1 is not None and len(bg["symbols"]) > 1:
+            trace_dict[bg["symbols"][1]] = bg_share1.to_bytes(bg["size"], "little").hex()
+
+    parsed_dmem = {k: bytes.fromhex(v) for k, v in trace_dict.items()}
+
+    with open(ref_trace_path, "w") as ref_trace_file:
+        sim = TVLASim(trace_hw_file=ref_trace_file)
+        load_elf(sim, elf_path)
+
+        key0 = int((str("deadbeef") * 12), 16)
+        key1 = int((str("baadf00d") * 12), 16)
+        sim.state.wsrs.set_sideload_keys(key0, key1)
+
+        sim.run_batch(verbose=False, batch_size=1, dmem_batch_data=[parsed_dmem])
+
+    annotate_trace_file(ref_trace_path, dwarf_map)
+
+    abs_path = os.path.abspath(ref_trace_path)
+    if "/sandbox/" in abs_path and "/execroot/" in abs_path:
+        final_path = (
+            abs_path[: abs_path.find("/sandbox/")] +
+            abs_path[abs_path.find("/execroot/"):]
+        )
+    else:
+        final_path = abs_path
+
+    print(f"Reference trace file path: {final_path}\n", flush=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="OTBN TVLA Side-Channel Assessment")
+    parser.add_argument("simulator", help="Path to otbnsim executable")
+    parser.add_argument("--elf", required=True, help="Target ELF file")
+    parser.add_argument(
+        "--num-experiments", type=int, default=1000, help="Total runs (split 50/50)"
+    )
+    parser.add_argument(
+        "--t-threshold", type=float, default=6.0, help="T-Test leakage threshold"
+    )
+    parser.add_argument(
+        "--tvla-secret",
+        action="append",
+        required=True,
+        help="Format: sym0,sym1:mode:size:hex_secret[:hex_modulus]",
+    )
+    parser.add_argument(
+        "--fixed-bg-secret",
+        action="append",
+        default=[],
+        help="Format: sym0,sym1:mode:size:hex_secret[:hex_modulus]",
+    )
+    parser.add_argument(
+        "--random-bg-secret",
+        action="append",
+        default=[],
+        help="Format: sym0,sym1:mode:size:hex_secret[:hex_modulus]",
+    )
+
+    args = parser.parse_args()
+
+    def parse_secret_args(arg_list: List[str]) -> List[Dict[str, Any]]:
+        secrets = []
+        for item in arg_list:
+            parts = item.split(":")
+            modulus = int(parts[4], 16) if len(parts) > 4 and parts[4] else None
+            secrets.append(
+                {
+                    "symbols": parts[0].split(","),
+                    "mode": parts[1],
+                    "size": int(parts[2]),
+                    "secret": int(parts[3], 16),
+                    "modulus": modulus,
+                }
+            )
+        return secrets
+
+    gen_config = {
+        "tvla_secrets": parse_secret_args(args.tvla_secret),
+        "fixed_bg_secrets": parse_secret_args(args.fixed_bg_secret),
+        "random_bg_secrets": parse_secret_args(args.random_bg_secret),
+    }
+
+    # Extract DWARF map
+    dwarf_map = build_pc_to_line_map(args.elf)
+
+    # Generate the reference trace
+    generate_reference_trace(args.simulator, args.elf, dwarf_map, gen_config)
+
+    accumulator = TVLAAccumulator()
+    max_threads = max(1, multiprocessing.cpu_count() - 2)
+
+    BATCH_SIZE = 100
+    num_fixed_batches = (args.num_experiments // 2) // BATCH_SIZE
+    num_random_batches = (args.num_experiments // 2) // BATCH_SIZE
+
+    print(
+        f"--- Starting Batched TVLA ({args.num_experiments} traces on {max_threads} cores) ---",
+        flush=True,
+    )
+
+    batches = [0] * num_fixed_batches + [1] * num_random_batches
+    random.shuffle(batches)
+
+    tasks = [
+        (args.simulator, args.elf, set_idx, i, BATCH_SIZE, gen_config)
+        for i, set_idx in enumerate(batches)
+    ]
+
+    completed_traces = 0
+
+    with concurrent.futures.ProcessPoolExecutor(max_workers=max_threads) as executor:
+        future_to_task = {executor.submit(run_experiment, task): task for task in tasks}
+
+        for future in concurrent.futures.as_completed(future_to_task):
+            completed_traces += BATCH_SIZE
+            print(
+                f"Completed {completed_traces}/{args.num_experiments} traces",
+                flush=True,
+            )
+
+            try:
+                batch_num, set_idx, local_stats = future.result()
+
+                for (pc, occ), (count, sums, sqs) in local_stats.items():
+                    accumulator.counts[pc][occ][set_idx] += count
+                    for i in range(NUM_MODELS):
+                        accumulator.sums[pc][occ][set_idx][i] += sums[i]
+                        accumulator.sum_sqs[pc][occ][set_idx][i] += sqs[i]
+
+            except Exception as e:
+                print(f"Process crashed: {e}", flush=True)
+
+    print("\n--- Analyzing T-Test Statistics ---", flush=True)
+
+    n0, n1 = 0, 0
+
+    if accumulator.counts:
+        first_pc = sorted(accumulator.counts.keys())[0]
+        n0 = accumulator.counts[first_pc][0][0]
+        n1 = accumulator.counts[first_pc][0][1]
+        print(
+            f"Engine loaded {n0} fixed traces and {n1} random traces.",
+            flush=True,
+        )
+
+    leakages_found = 0
+    max_t_score = 0.0
+
+    for pc in sorted(accumulator.counts.keys()):
+        for occ in accumulator.counts[pc].keys():
+            for model_idx in range(NUM_MODELS):
+                t_val = accumulator.compute_t_test(pc, occ, model_idx)
+                abs_t = abs(t_val)
+
+                if abs_t > max_t_score:
+                    max_t_score = abs_t
+
+                if abs_t > args.t_threshold:
+                    model_name = MODEL_NAMES.get(model_idx, f"M{model_idx}")
+
+                    dwarf_str = "Unknown source"
+                    if pc in dwarf_map:
+                        filepath, lineno = dwarf_map[pc]
+                        dwarf_str = f"{os.path.basename(filepath)}:{lineno}"
+
+                    print(
+                        f"Leakage | PC: {hex(pc):<6} | Occ: {occ} | "
+                        f"Model: {model_name:<8} | t-value: {t_val:>7.2f} | "
+                        f"Source: {dwarf_str}",
+                        flush=True,
+                    )
+                    leakages_found += 1
+
+    print(
+        f"\nThe maximum absolute t-value across all PCs and models was: {max_t_score:.2f}",
+        flush=True,
+    )
+
+    print(
+        f"\nCampaign complete. Total leakages > {args.t_threshold}: {leakages_found}",
+        flush=True,
+    )
+    return 0 if leakages_found == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rules/otbn.bzl
+++ b/rules/otbn.bzl
@@ -579,3 +579,133 @@ otbn_insn_count_range = rule(
         ),
     },
 )
+
+def _otbn_fi_sim_test_impl(ctx):
+    elf = ctx.attr.target[OutputGroupInfo].elf.to_list()
+    if len(elf) != 1:
+        fail("target must provide exactly one .elf")
+    elf = elf[0]
+
+    campaign_tool = ctx.executable._fi_campaign
+    simulator = ctx.executable._simulator
+
+    test_runner = ctx.actions.declare_file(ctx.label.name + "_runner.sh")
+
+    script_content = "{} {} --elf {} --attack-mode {} --ok-sym {} --ok-size {} --ok-val {} --col-sym {} --col-size {} --col-threshold {} --col-mode {}".format(
+        campaign_tool.short_path,
+        simulator.short_path,
+        elf.short_path,
+        ctx.attr.attack_mode,
+        ctx.attr.ok_symbol,
+        ctx.attr.ok_size,
+        ctx.attr.ok_value,
+        ctx.attr.collision_symbol,
+        ctx.attr.collision_size,
+        ctx.attr.col_threshold,
+        ctx.attr.collision_mode,
+    )
+
+    if ctx.attr.collision_modulus:
+        script_content += " --col-modulus {}".format(ctx.attr.collision_modulus)
+
+    if ctx.attr.fixed_instruction_count:
+        script_content += " --fixed-instruction-count"
+
+    for syms, config in ctx.attr.target_a_secrets.items():
+        script_content += ' --target-a-secret "{}:{}"'.format(syms, config)
+
+    for syms, config in ctx.attr.target_b_secrets.items():
+        script_content += ' --target-b-secret "{}:{}"'.format(syms, config)
+
+    ctx.actions.write(
+        output = test_runner,
+        content = script_content,
+        is_executable = True,
+    )
+
+    runfiles = ctx.runfiles(files = [campaign_tool, simulator, elf])
+    runfiles = runfiles.merge(ctx.attr._fi_campaign[DefaultInfo].default_runfiles)
+    runfiles = runfiles.merge(ctx.attr._simulator[DefaultInfo].default_runfiles)
+
+    return [DefaultInfo(
+        executable = test_runner,
+        runfiles = runfiles,
+    )]
+
+otbn_fi_sim_test = rule(
+    implementation = _otbn_fi_sim_test_impl,
+    test = True,
+    attrs = {
+        "target": attr.label(providers = [OutputGroupInfo], mandatory = True),
+        "attack_mode": attr.string(default = "collision", values = ["collision", "corruption", "bypass"]),
+        "target_a_secrets": attr.string_dict(default = {}),
+        "target_b_secrets": attr.string_dict(default = {}),
+        "ok_symbol": attr.string(mandatory = True),
+        "ok_size": attr.int(mandatory = True),
+        "ok_value": attr.string(mandatory = True),
+        "col_threshold": attr.string(default = "1.0"),
+        "collision_symbol": attr.string(mandatory = True),
+        "collision_size": attr.int(mandatory = True),
+        "collision_mode": attr.string(default = "unmasked", values = ["unmasked", "boolean", "additive"]),
+        "collision_modulus": attr.string(default = ""),
+        "fixed_instruction_count": attr.bool(default = False),
+        "_fi_campaign": attr.label(default = "//hw/ip/otbn/util:otbn_fi_campaign", executable = True, cfg = "exec"),
+        "_simulator": attr.label(default = "//hw/ip/otbn/dv/otbnsim:standalone", executable = True, cfg = "exec"),
+    },
+)
+
+def _otbn_tvla_sim_test_impl(ctx):
+    elf = ctx.attr.target[OutputGroupInfo].elf.to_list()[0]
+
+    campaign_tool = ctx.executable._tvla_campaign
+    simulator = ctx.executable._simulator
+
+    test_runner = ctx.actions.declare_file(ctx.label.name + "_runner.sh")
+
+    script_content = "{} {} --elf {} --num-experiments {} --t-threshold {}".format(
+        campaign_tool.short_path,
+        simulator.short_path,
+        elf.short_path,
+        ctx.attr.num_experiments,
+        ctx.attr.t_threshold,
+    )
+
+    # Append TVLA targets
+    for syms, config in ctx.attr.tvla_secrets.items():
+        script_content += ' --tvla-secret "{}:{}"'.format(syms, config)
+
+    for syms, config in ctx.attr.fixed_background_secrets.items():
+        script_content += ' --fixed-bg-secret "{}:{}"'.format(syms, config)
+
+    for syms, config in ctx.attr.random_background_secrets.items():
+        script_content += ' --random-bg-secret "{}:{}"'.format(syms, config)
+
+    ctx.actions.write(
+        output = test_runner,
+        content = script_content,
+        is_executable = True,
+    )
+
+    runfiles = ctx.runfiles(files = [campaign_tool, elf])
+    runfiles = runfiles.merge(ctx.attr._tvla_campaign[DefaultInfo].default_runfiles)
+    runfiles = runfiles.merge(ctx.attr._simulator[DefaultInfo].default_runfiles)
+
+    return [DefaultInfo(
+        executable = test_runner,
+        runfiles = runfiles,
+    )]
+
+otbn_tvla_sim_test = rule(
+    implementation = _otbn_tvla_sim_test_impl,
+    test = True,
+    attrs = {
+        "target": attr.label(providers = [OutputGroupInfo], mandatory = True),
+        "num_experiments": attr.int(default = 1000),
+        "t_threshold": attr.string(default = "4.5"),
+        "tvla_secrets": attr.string_dict(mandatory = True),
+        "fixed_background_secrets": attr.string_dict(default = {}),
+        "random_background_secrets": attr.string_dict(default = {}),
+        "_tvla_campaign": attr.label(default = "//hw/ip/otbn/util:otbn_tvla_campaign", executable = True, cfg = "exec"),
+        "_simulator": attr.label(default = "//hw/ip/otbn/dv/otbnsim:standalone", executable = True, cfg = "exec"),
+    },
+)

--- a/sw/otbn/crypto/25519.s
+++ b/sw/otbn/crypto/25519.s
@@ -1290,7 +1290,7 @@ ext_scmul_sca:
 
 
   /* Iterate over all scalar bits starting at the MSB. */
-  loopi  385, 56
+  loopi  385, 56    /* SCA_TEST_REPLACE: loopi 3, 56 */
     /* Compute Q = 2 * Q.
          [w13:w10] <= [w13:w10] + [w13:w10] = 2 * Q  */
     jal x1, ext_double

--- a/sw/otbn/crypto/modexp.s
+++ b/sw/otbn/crypto/modexp.s
@@ -307,7 +307,7 @@ _message_blinding_prologue_end:
     addi   x2, x2, 1
 
   # Compute bit length of current bigint size.
-  slli  x21, x30, 8
+  slli  x21, x30, 8    /* SCA_TEST_REPLACE: addi x21, x0, 3 */
 
   # Main loop of the exponentiation, iterate over all exponent bits:
   loop x21, 68

--- a/sw/otbn/crypto/p256_base.s
+++ b/sw/otbn/crypto/p256_base.s
@@ -1351,7 +1351,8 @@ scalar_mult_int:
   bn.rshi   w2, w2, w20 >> 65
 
   /* double-and-add loop with decreasing index */
-  loopi     321, 63
+  /* if updating the loop, please change the test replacement as well */
+  loopi     321, 63    /* SCA_TEST_REPLACE: loopi 3, 63 */
 
     /* double point Q
        Q = (w8, w9, w10) <= 2*(w8, w9, w10) = 2*Q */

--- a/sw/otbn/crypto/p384_internal_mult.s
+++ b/sw/otbn/crypto/p384_internal_mult.s
@@ -161,12 +161,12 @@ scalar_mult_int_p384:
   bn.wsrr   w3, URND
 
   /* Set the loop iteration variable for the multiplication. */
-  addi      x16, x0, 448
+  addi      x16, x0, 448    /* SCA_TEST_REPLACE: addi      x16, x0, 3 */
 
   /* perform the scalar multiplication. */
   jal       x1, scalar_mult_int_p384_internal
 
-  addi      x2, x0, 448
+  addi      x2, x0, 448    /* SCA_TEST_REPLACE: addi      x2, x0, 3 */
   beq       x2, x16, scalar_mult_int_p384_ret
 
   /* The number of iterations has been faulted; fail. */
@@ -239,12 +239,12 @@ scalar_mult_int_p384_reblind:
   bn.rshi   w3, w3, w6 >> 66
 
   /* Set the loop iteration variable for the multiplication. */
-  addi      x16, x0, 578
+  addi      x16, x0, 578    /* SCA_TEST_REPLACE: addi      x16, x0, 3 */
 
   /* perform the scalar multiplication. */
   jal       x1, scalar_mult_int_p384_internal
 
-  addi      x2, x0, 578
+  addi      x2, x0, 578    /* SCA_TEST_REPLACE: addi      x2, x0, 3 */
   beq       x2, x16, scalar_mult_int_p384_reblind_ret
 
   /* The number of iterations has been faulted; fail. */

--- a/sw/otbn/crypto/tests/fi/BUILD
+++ b/sw/otbn/crypto/tests/fi/BUILD
@@ -1,0 +1,339 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:otbn.bzl", "otbn_fi_sim_test")
+
+package(default_visibility = ["//visibility:public"])
+
+# Look for collisions in 'r' with different nonces
+otbn_fi_sim_test(
+    name = "p256_ecdsa_sign_fi_nonce_test",
+    timeout = "eternal",
+    attack_mode = "collision",
+    col_threshold = "0.75",
+    collision_size = 32,
+    collision_symbol = "r",
+    fixed_instruction_count = True,
+    ok_size = 4,
+    ok_symbol = "ok",
+    ok_value = "0x739",
+    tags = ["manual"],
+    target = "//sw/otbn/crypto:run_p256",
+    target_a_secrets = {
+        "mode": "unmasked:4:0x563",
+        "msg": "unmasked:32:0x06d712076ce90fefb028ad8a90d4d90b17d015f1b54d7452400bdd7d4456fd21",
+        "d0_io,d1_io": "additive:64:0x112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00:0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+        "k0_io,k1_io": "scalar_blind:64:0x1111111111111111111111111111111111111111111111111111111111111111:0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+    },
+    target_b_secrets = {
+        "mode": "unmasked:4:0x563",
+        "msg": "unmasked:32:0x06d712076ce90fefb028ad8a90d4d90b17d015f1b54d7452400bdd7d4456fd21",
+        "d0_io,d1_io": "additive:64:0x112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00:0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+        "k0_io,k1_io": "scalar_blind:64:0x9999999999999999999999999999999999999999999999999999999999999999:0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+    },
+)
+
+# Look for collisions of the output x_r between two separate messages while needing the ok status
+otbn_fi_sim_test(
+    name = "p256_ecdsa_verify_msg_fi_test",
+    timeout = "eternal",
+    attack_mode = "collision",
+    col_threshold = "0.75",  # We call a collision of r if they match 75%
+    collision_size = 32,  # x_r is a 256-bit word
+    collision_symbol = "x_r",
+    fixed_instruction_count = False,  # Verify is a variable time algorithm
+    ok_size = 4,  # ok is a 32-bit word
+    ok_symbol = "ok",
+    ok_value = "0x739",
+    tags = ["manual"],
+    target = "//sw/otbn/crypto:run_p256",
+    # Correct signature
+    target_a_secrets = {
+        "mode": "unmasked:4:0x5D8",
+        "msg": "unmasked:32:0x06d712076ce90fefb028ad8a90d4d90b17d015f1b54d7452400bdd7d4456fd21",
+        "r": "unmasked:32:0x815215ad7dd27f336b35843cbe064de299504edd0c7d87dd1147ea5680a9674a",
+        "s": "unmasked:32:0xa3991e01c444042086e30cd999e589ad4dad9404e90a6d17d0b1051ec93fd605",
+        "x": "unmasked:32:0xb5511a6afacdc5461628ce58db6c8bf36ec0c0b2f36b06899773b7b3bfa8c334",
+        "y": "unmasked:32:0x42a1c6971f31c14343dd09eab53a17fa7f7a11d0ab9c6924a87070589e008c2e",
+    },
+    target_b_secrets = {
+        "mode": "unmasked:4:0x5D8",
+        "msg": "unmasked:32:0x16d712076ce90fefb028ad8a90d4d90b17d015f1b54d7452400bdd7d4456fd21",  # Changed byte
+        "r": "unmasked:32:0x815215ad7dd27f336b35843cbe064de299504edd0c7d87dd1147ea5680a9674a",
+        "s": "unmasked:32:0xa3991e01c444042086e30cd999e589ad4dad9404e90a6d17d0b1051ec93fd605",
+        "x": "unmasked:32:0xb5511a6afacdc5461628ce58db6c8bf36ec0c0b2f36b06899773b7b3bfa8c334",
+        "y": "unmasked:32:0x42a1c6971f31c14343dd09eab53a17fa7f7a11d0ab9c6924a87070589e008c2e",
+    },
+)
+
+# Look for collisions of the output x_r between two separate public keys while needing the ok status
+otbn_fi_sim_test(
+    name = "p256_ecdsa_verify_pubkey_fi_test",
+    timeout = "eternal",
+    attack_mode = "collision",
+    col_threshold = "0.75",
+    collision_size = 32,
+    collision_symbol = "x_r",
+    fixed_instruction_count = False,
+    ok_size = 4,
+    ok_symbol = "ok",
+    ok_value = "0x739",
+    tags = ["manual"],
+    target = "//sw/otbn/crypto:run_p256",
+    # Correct signature and public key
+    target_a_secrets = {
+        "mode": "unmasked:4:0x5D8",
+        "msg": "unmasked:32:0x06d712076ce90fefb028ad8a90d4d90b17d015f1b54d7452400bdd7d4456fd21",
+        "r": "unmasked:32:0x815215ad7dd27f336b35843cbe064de299504edd0c7d87dd1147ea5680a9674a",
+        "s": "unmasked:32:0xa3991e01c444042086e30cd999e589ad4dad9404e90a6d17d0b1051ec93fd605",
+        "x": "unmasked:32:0xb5511a6afacdc5461628ce58db6c8bf36ec0c0b2f36b06899773b7b3bfa8c334",
+        "y": "unmasked:32:0x42a1c6971f31c14343dd09eab53a17fa7f7a11d0ab9c6924a87070589e008c2e",
+    },
+    # Same msg, r, s, but different public key
+    target_b_secrets = {
+        "mode": "unmasked:4:0x5D8",
+        "msg": "unmasked:32:0x06d712076ce90fefb028ad8a90d4d90b17d015f1b54d7452400bdd7d4456fd21",
+        "r": "unmasked:32:0x815215ad7dd27f336b35843cbe064de299504edd0c7d87dd1147ea5680a9674a",
+        "s": "unmasked:32:0xa3991e01c444042086e30cd999e589ad4dad9404e90a6d17d0b1051ec93fd605",
+        "x": "unmasked:32:0x2927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838",
+        "y": "unmasked:32:0xc7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
+    },
+)
+
+# Look for collisions of the shared secret between two different secret keys
+otbn_fi_sim_test(
+    name = "p256_ecdh_fi_test",
+    timeout = "eternal",
+    attack_mode = "collision",
+    col_threshold = "0.75",
+    collision_mode = "boolean",
+    collision_size = 32,
+    collision_symbol = "x,y",
+    fixed_instruction_count = True,
+    ok_size = 4,
+    ok_symbol = "ok",
+    ok_value = "0x739",
+    tags = ["manual"],
+    target = "//sw/otbn/crypto:run_p256",
+    # Secret A
+    target_a_secrets = {
+        "mode": "unmasked:4:0x1AD",
+        "d0_io,d1_io": "additive:64:0x1420fc41742102631b76ebe83fdfa3799590ef5db0b2c78121d0a016fe6d1071:0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+        "x": "unmasked:32:0xb5511a6afacdc5461628ce58db6c8bf36ec0c0b2f36b06899773b7b3bfa8c334",
+        "y": "unmasked:32:0x42a1c6971f31c14343dd09eab53a17fa7f7a11d0ab9c6924a87070589e008c2e",
+    },
+    # Secret B (different private key, same public key)
+    target_b_secrets = {
+        "mode": "unmasked:4:0x1AD",
+        "d0_io,d1_io": "additive:64:0x112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00:0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+        "x": "unmasked:32:0xb5511a6afacdc5461628ce58db6c8bf36ec0c0b2f36b06899773b7b3bfa8c334",
+        "y": "unmasked:32:0x42a1c6971f31c14343dd09eab53a17fa7f7a11d0ab9c6924a87070589e008c2e",
+    },
+)
+
+# Look for collisions in 'r' with different nonces for P384
+otbn_fi_sim_test(
+    name = "p384_ecdsa_sign_fi_nonce_test",
+    timeout = "eternal",
+    attack_mode = "collision",
+    col_threshold = "0.75",
+    collision_size = 48,  # P384 r is 48 bytes
+    collision_symbol = "r",
+    fixed_instruction_count = True,
+    ok_size = 4,
+    ok_symbol = "ok",
+    ok_value = "0x0",
+    tags = ["manual"],
+    target = "//sw/otbn/crypto:run_p384",
+    target_a_secrets = {
+        "mode": "unmasked:4:0x655",
+        "msg": "unmasked:64:0x00000000000000000000000000000000555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555",
+        "d0_io,d1_io": "additive:64:0x32f9e2b08677a5f2adb9ce1be14cd8df800a4c9416f5c1ee1e9d19e796d2f9e05b7d3b0f4de8344e6e0012819a0c1b763eb17c275c832a51:0xffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
+        "k0_io,k1_io": "scalar_blind:64:0x111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111:0xffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
+    },
+    target_b_secrets = {
+        "mode": "unmasked:4:0x655",
+        "msg": "unmasked:64:0x00000000000000000000000000000000555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555",
+        "d0_io,d1_io": "additive:64:0x32f9e2b08677a5f2adb9ce1be14cd8df800a4c9416f5c1ee1e9d19e796d2f9e05b7d3b0f4de8344e6e0012819a0c1b763eb17c275c832a51:0xffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
+        "k0_io,k1_io": "scalar_blind:64:0x999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999:0xffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
+    },
+)
+
+# Look for collisions of the output x_r between two separate public keys while needing the ok status
+otbn_fi_sim_test(
+    name = "p384_ecdsa_verify_pubkey_fi_test",
+    timeout = "eternal",
+    attack_mode = "collision",
+    col_threshold = "0.75",
+    collision_size = 48,
+    collision_symbol = "x_r",
+    fixed_instruction_count = False,
+    ok_size = 4,
+    ok_symbol = "ok",
+    ok_value = "0x739",
+    tags = ["manual"],
+    target = "//sw/otbn/crypto:run_p384",
+    # Correct signature and public key A
+    target_a_secrets = {
+        "mode": "unmasked:4:0x0BD",
+        "msg": "unmasked:64:0x00000000000000000000000000000000555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555",
+        "r": "unmasked:64:0x00000000000000000000000000000000b2fcf95c7c0d8125b45990dbd3c4305349d29eef0235d77ec16c09de12d35b3856e186cf9a1a30fc2b23ce3ab68c28d8",
+        "s": "unmasked:64:0x000000000000000000000000000000001a72ebdde34d88c1fa9554e0f19a653d80eb391d3e7f68950016f9c3a78101eb77e415a198144c27752042f524bc1bf9",
+        "x": "unmasked:64:0x00000000000000000000000000000000ca230836b439d7011a9ea916cf60d89e394d8b7047e806616c30f2d8ee0e2beb5869de54b1cac6097b8294604877f3d1",
+        "y": "unmasked:64:0x00000000000000000000000000000000aaafcad203afe2c268eef2d1d65e905d82b63bf3928c3e92cea028a9ec18818cc7e55880bf3aff6ec31ef079c181f90f",
+    },
+    # Same msg, r, s, but public key B (base point G)
+    target_b_secrets = {
+        "mode": "unmasked:4:0x0BD",
+        "msg": "unmasked:64:0x00000000000000000000000000000000555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555",
+        "r": "unmasked:64:0x00000000000000000000000000000000b2fcf95c7c0d8125b45990dbd3c4305349d29eef0235d77ec16c09de12d35b3856e186cf9a1a30fc2b23ce3ab68c28d8",
+        "s": "unmasked:64:0x000000000000000000000000000000001a72ebdde34d88c1fa9554e0f19a653d80eb391d3e7f68950016f9c3a78101eb77e415a198144c27752042f524bc1bf9",
+        "x": "unmasked:64:0x00000000000000000000000000000000aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7",
+        "y": "unmasked:64:0x000000000000000000000000000000003617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f",
+    },
+)
+
+# Look for collisions of the shared secret between two different public keys
+otbn_fi_sim_test(
+    name = "curve25519_ecdh_fi_test",
+    timeout = "eternal",
+    attack_mode = "collision",
+    col_threshold = "0.75",
+    collision_mode = "boolean",
+    collision_size = 64,
+    collision_symbol = "x25519_shared_key",
+    fixed_instruction_count = True,
+    ok_size = 4,
+    ok_symbol = "x25519_ok",
+    ok_value = "0x739",
+    tags = ["manual"],
+    target = "//sw/otbn/crypto:run_curve25519",
+    # Secret A
+    target_a_secrets = {
+        "mode": "unmasked:4:0x695",
+        "ed25519_s0,ed25519_s1": "additive:32:0x112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00:0x10000000000000000000000000000000000000000000000000000000000000000",
+        "x25519_public_key": "unmasked:32:0x4c1cabd0a603a9103b35b326ec2466727c5fb124a4c19435db3030586768dbe6",
+    },
+    # Secret B (different private key, same public key)
+    target_b_secrets = {
+        "mode": "unmasked:4:0x695",
+        "ed25519_s0,ed25519_s1": "additive:32:0x012233445566778899aabbccddeeff00112233445566778899aabbccdd1eff00:0x10000000000000000000000000000000000000000000000000000000000000000",
+        "x25519_public_key": "unmasked:32:0x4c1cabd0a603a9103b35b326ec2466727c5fb124a4c19435db3030586768dbe6",
+    },
+)
+
+# # Look for collisions in RSA 512 decryption
+otbn_fi_sim_test(
+    name = "rsa_512_fi_test",
+    timeout = "eternal",
+    attack_mode = "collision",
+    col_threshold = "0.75",
+    collision_size = 64,
+    collision_symbol = "inout",
+    fixed_instruction_count = False,
+    ok_size = 4,
+    ok_symbol = "ok",
+    ok_value = "0x739",
+    tags = ["manual"],
+    target = "//sw/otbn/crypto:run_rsa",
+    target_a_secrets = {
+        "mode": "unmasked:4:0x3ad",  # MODE_RSA_512_MODEXP
+        "rsa_n": "unmasked:64:0x906ce5d361397c1ce1f5b75760a23b20786e52ca82f66ec7216e982b5945a19afe4aba4e1c59d1aa020b035ef4c08da0658e9702c9bb46392d3b81ce594dec21",
+        "rsa_d0": "unmasked:64:0x354d9c10865d447ebaac7fe326a9d65724726953c74d2e9098051a5b9148bcfed742487a13f0350dbb897a967fb872e83acd05430c8ba533fe8b2e91e902ef79",
+        "rsa_d1": "unmasked:64:0x07618e6fa119246ed63e813a12581081b1adacc6e532f9369fc5289555113fcbca4943b2e02fc6bb722402a4a2a0a685b86b12799e910ab9242e9d8e49d29004",
+        "inout": "unmasked:64:0xd487ce1eaf19922ad9b8a714e61a441c12e0c8b2bad640fb19488dec4f65d4d9259f4329e6f4590b9a164106cf6a659eb4862b21fb97d43588561712e8e5216a",
+    },
+    # Different ciphertext
+    target_b_secrets = {
+        "mode": "unmasked:4:0x3ad",
+        "rsa_n": "unmasked:64:0x906ce5d361397c1ce1f5b75760a23b20786e52ca82f66ec7216e982b5945a19afe4aba4e1c59d1aa020b035ef4c08da0658e9702c9bb46392d3b81ce594dec21",
+        "rsa_d0": "unmasked:64:0x354d9c10865d447ebaac7fe326a9d65724726953c74d2e9098051a5b9148bcfed742487a13f0350dbb897a967fb872e83acd05430c8ba533fe8b2e91e902ef79",
+        "rsa_d1": "unmasked:64:0x07618e6fa119246ed63e813a12581081b1adacc6e532f9369fc5289555113fcbca4943b2e02fc6bb722402a4a2a0a685b86b12799e910ab9242e9d8e49d29004",
+        "inout": "unmasked:64:0xd487ce1eaf19922ad9b8a714e61a441c12e0c8b2bad640fb19488dec4f65d4d9259f4329e6f4590b9a164106cf6a659eb4862b21fb97d43588561712e8e5216b",
+    },
+)
+
+# Look for collisions in 'R' with different nonces for Ed25519
+otbn_fi_sim_test(
+    name = "ed25519_sign_fi_nonce_test",
+    timeout = "eternal",
+    attack_mode = "collision",
+    col_threshold = "0.75",
+    collision_size = 32,
+    collision_symbol = "ed25519_sig_R",
+    fixed_instruction_count = True,
+    ok_size = 4,
+    ok_symbol = "x25519_ok",
+    ok_value = "0x0",
+    tags = ["manual"],
+    target = "//sw/otbn/crypto:run_curve25519",
+    target_a_secrets = {
+        "mode": "unmasked:4:0x669",
+        "ed25519_s0,ed25519_s1": "additive:64:0x512233445566778899aabbccddeeff00112233445566778899aabbccddeeff00:0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed",
+        "ed25519_r0,ed25519_r1": "additive:96:0x1111111111111111111111111111111111111111111111111111111111111111:0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed",
+    },
+    target_b_secrets = {
+        "mode": "unmasked:4:0x669",
+        "ed25519_s0,ed25519_s1": "additive:64:0x512233445566778899aabbccddeeff00112233445566778899aabbccddeeff00:0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed",
+        "ed25519_r0,ed25519_r1": "additive:96:0x2222222222222222222222222222222222222222222222222222222222222222:0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed",
+    },
+)
+
+# Ed25519 Verification FI test (message collision)
+otbn_fi_sim_test(
+    name = "ed25519_verify_fi_msg_collision_test",
+    timeout = "eternal",
+    attack_mode = "collision",
+    collision_size = 32,
+    collision_symbol = "ed25519_verify_rhs",
+    fixed_instruction_count = False,
+    ok_size = 4,
+    ok_symbol = "ed25519_verify_result",
+    ok_value = "0x739",
+    tags = ["manual"],
+    target = "//sw/otbn/crypto:run_curve25519",
+    target_a_secrets = {
+        "mode": "unmasked:4:0x54E",
+        "ed25519_hash_k": "unmasked:64:0x9f0e3ca07bee6837283462046ae8b109acf2337c37117420c7228a98dc5bf10ec2a4a7bc4df02282f0f34d280df15d037b82c32003dabdffe76f536b2b067127",
+        "ed25519_sig_R": "unmasked:32:0x5501492265e073d874d9e5b81e7f87848a826e80cce2869072ac60c3004356e5",
+        "ed25519_sig_S": "unmasked:32:0x0b107a8e4341516524be5b59f0f55bd26bb4f91c70391ec6ac3ba3901582b85f",
+        "ed25519_public_key": "unmasked:32:0x1a5107f7681a02af2523a6daf372e10e3a0764c9d3fe4bd5b70ab18201985ad7",
+    },
+    target_b_secrets = {
+        "mode": "unmasked:4:0x54E",
+        "ed25519_hash_k": "unmasked:64:0x9f0e3ca07bee6837283462046ae8b109acf2337c37117420c7228a98dc5bf10ec2a4a7bc4df02282f0f34d280df15d037b82c32003dabdffe76f536b2b067128",
+        "ed25519_sig_R": "unmasked:32:0x5501492265e073d874d9e5b81e7f87848a826e80cce2869072ac60c3004356e5",
+        "ed25519_sig_S": "unmasked:32:0x0b107a8e4341516524be5b59f0f55bd26bb4f91c70391ec6ac3ba3901582b85f",
+        "ed25519_public_key": "unmasked:32:0x1a5107f7681a02af2523a6daf372e10e3a0764c9d3fe4bd5b70ab18201985ad7",
+    },
+)
+
+# Ed25519 Verification FI test (public key collision)
+otbn_fi_sim_test(
+    name = "ed25519_verify_fi_pubkey_collision_test",
+    timeout = "eternal",
+    attack_mode = "collision",
+    collision_size = 32,
+    collision_symbol = "ed25519_verify_rhs",
+    fixed_instruction_count = False,
+    ok_size = 4,
+    ok_symbol = "ed25519_verify_result",
+    ok_value = "0x739",
+    tags = ["manual"],
+    target = "//sw/otbn/crypto:run_curve25519",
+    target_a_secrets = {
+        "mode": "unmasked:4:0x54E",
+        "ed25519_hash_k": "unmasked:64:0x9f0e3ca07bee6837283462046ae8b109acf2337c37117420c7228a98dc5bf10ec2a4a7bc4df02282f0f34d280df15d037b82c32003dabdffe76f536b2b067127",
+        "ed25519_sig_R": "unmasked:32:0x5501492265e073d874d9e5b81e7f87848a826e80cce2869072ac60c3004356e5",
+        "ed25519_sig_S": "unmasked:32:0x0b107a8e4341516524be5b59f0f55bd26bb4f91c70391ec6ac3ba3901582b85f",
+        "ed25519_public_key": "unmasked:32:0x1a5107f7681a02af2523a6daf372e10e3a0764c9d3fe4bd5b70ab18201985ad7",
+    },
+    target_b_secrets = {
+        "mode": "unmasked:4:0x54E",
+        "ed25519_hash_k": "unmasked:64:0x9f0e3ca07bee6837283462046ae8b109acf2337c37117420c7228a98dc5bf10ec2a4a7bc4df02282f0f34d280df15d037b82c32003dabdffe76f536b2b067128",
+        "ed25519_sig_R": "unmasked:32:0x5501492265e073d874d9e5b81e7f87848a826e80cce2869072ac60c3004356e5",
+        "ed25519_sig_S": "unmasked:32:0x0b107a8e4341516524be5b59f0f55bd26bb4f91c70391ec6ac3ba3901582b85f",
+        "ed25519_public_key": "unmasked:32:0x5501492265e073d874d9e5b81e7f87848a826e80cce2869072ac60c3004356e5",
+    },
+)

--- a/sw/otbn/crypto/tests/tvla/BUILD
+++ b/sw/otbn/crypto/tests/tvla/BUILD
@@ -1,0 +1,278 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:otbn.bzl", "otbn_library", "otbn_sim_test", "otbn_tvla_sim_test")
+
+package(default_visibility = ["//visibility:public"])
+
+# In order to reduce TVLA time, we manually adapt the scalar multiply loop to shorten the time it takes to run sign
+genrule(
+    name = "p256_base_short_s",
+    srcs = ["//sw/otbn/crypto:p256_base.s"],
+    outs = ["p256_base_short.s"],
+    cmd = "sed -E 's/^([[:space:]]*).*\\/\\*[[:space:]]*SCA_TEST_REPLACE:[[:space:]]*(.*)[[:space:]]*\\*\\//\\1\\2/' $< > $@",
+    tags = ["manual"],
+)
+
+otbn_library(
+    name = "p256_base_short",
+    srcs = [
+        ":p256_base_short_s",
+        "//sw/otbn/crypto:p256_b2a.s",
+    ],
+    tags = ["manual"],
+)
+
+otbn_sim_test(
+    name = "run_p256_short",
+    srcs = ["//sw/otbn/crypto:run_p256.s"],
+    tags = ["manual"],
+    deps = [
+        ":p256_base_short",
+        "//sw/otbn/crypto:p256_isoncurve",
+        "//sw/otbn/crypto:p256_isoncurve_check",
+        "//sw/otbn/crypto:p256_isoncurve_proj",
+        "//sw/otbn/crypto:p256_shared_key",
+        "//sw/otbn/crypto:p256_sign",
+        "//sw/otbn/crypto:p256_verify",
+    ],
+)
+
+otbn_tvla_sim_test(
+    name = "p256_ecdh_tvla_test",
+    timeout = "eternal",
+    fixed_background_secrets = {
+        "mode": "const:4:0x1AD",
+        "x": "const:32:0xb5511a6afacdc5461628ce58db6c8bf36ec0c0b2f36b06899773b7b3bfa8c334",
+        "y": "const:32:0x42a1c6971f31c14343dd09eab53a17fa7f7a11d0ab9c6924a87070589e008c2e",
+    },
+    num_experiments = 5000,
+    t_threshold = "7.0",
+    tags = ["manual"],
+    target = ":run_p256_short",
+    tvla_secrets = {
+        "d0_io,d1_io": "additive:64:0x112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00:0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+    },
+)
+
+# Run a fixed versus random key with message and nonce fixed
+otbn_tvla_sim_test(
+    name = "p256_ecdsa_sign_tvla_test",
+    timeout = "eternal",
+    # Fixed secrets: value stays the same, but allow for masking (unless const)
+    fixed_background_secrets = {
+        "mode": "const:4:0x563",
+        "msg": "const:32:0x112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00",
+    },
+    num_experiments = 5000,
+    # Random secrets: value is new every run and shares are re-masked
+    random_background_secrets = {
+        "k0_io,k1_io": "scalar_blind:64:0:0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+    },
+    # We do not have noise, so a high threshold is just to filter false positives
+    t_threshold = "7.0",
+    tags = ["manual"],
+    target = ":run_p256_short",
+    # TVLA targets: toggle between fixed and random
+    # Format: "sym0,sym1": "mode:size_in_bytes:secret_hex:modulus_hex(optional)"
+    tvla_secrets = {
+        "d0_io,d1_io": "additive:64:0x112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00:0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+    },
+)
+
+genrule(
+    name = "p384_internal_mult_short_s",
+    srcs = ["//sw/otbn/crypto:p384_internal_mult.s"],
+    outs = ["p384_internal_mult_short.s"],
+    cmd = "sed -E 's/^([[:space:]]*).*\\/\\*[[:space:]]*SCA_TEST_REPLACE:[[:space:]]*(.*)[[:space:]]*\\*\\//\\1\\2/' $< > $@",
+    tags = ["manual"],
+)
+
+otbn_library(
+    name = "p384_internal_mult_short",
+    srcs = [
+        ":p384_internal_mult_short_s",
+    ],
+    tags = ["manual"],
+)
+
+genrule(
+    name = "25519_short_s",
+    srcs = ["//sw/otbn/crypto:25519.s"],
+    outs = ["25519_short.s"],
+    cmd = "sed -E 's/^([[:space:]]*).*\\/\\*[[:space:]]*SCA_TEST_REPLACE:[[:space:]]*(.*)[[:space:]]*\\*\\//\\1\\2/' $< > $@",
+    tags = ["manual"],
+)
+
+otbn_library(
+    name = "25519_short",
+    srcs = [
+        ":25519_short_s",
+    ],
+    tags = ["manual"],
+)
+
+genrule(
+    name = "modexp_short_s",
+    srcs = ["//sw/otbn/crypto:modexp.s"],
+    outs = ["modexp_short.s"],
+    cmd = "sed -E 's/^([[:space:]]*).*\\/\\*[[:space:]]*SCA_TEST_REPLACE:[[:space:]]*(.*)[[:space:]]*\\*\\//\\1\\2/' $< > $@",
+    tags = ["manual"],
+)
+
+otbn_sim_test(
+    name = "run_p384_short",
+    srcs = ["//sw/otbn/crypto:run_p384.s"],
+    tags = ["manual"],
+    deps = [
+        ":p384_internal_mult_short",
+        "//sw/otbn/crypto:p384_a2b",
+        "//sw/otbn/crypto:p384_b2a",
+        "//sw/otbn/crypto:p384_base",
+        "//sw/otbn/crypto:p384_base_mult",
+        "//sw/otbn/crypto:p384_isoncurve",
+        "//sw/otbn/crypto:p384_isoncurve_proj",
+        "//sw/otbn/crypto:p384_keygen",
+        "//sw/otbn/crypto:p384_keygen_from_seed",
+        "//sw/otbn/crypto:p384_mem",
+        "//sw/otbn/crypto:p384_modinv",
+        "//sw/otbn/crypto:p384_scalar_mult",
+        "//sw/otbn/crypto:p384_sign",
+        "//sw/otbn/crypto:p384_verify",
+    ],
+)
+
+otbn_tvla_sim_test(
+    name = "p384_ecdh_tvla_test",
+    timeout = "eternal",
+    fixed_background_secrets = {
+        "mode": "const:4:0x578",
+        "x": "const:64:0x00000000000000000000000000000000ca230836b439d7011a9ea916cf60d89e394d8b7047e806616c30f2d8ee0e2beb5869de54b1cac6097b8294604877f3d1",
+        "y": "const:64:0x00000000000000000000000000000000aaafcad203afe2c268eef2d1d65e905d82b63bf3928c3e92cea028a9ec18818cc7e55880bf3aff6ec31ef079c181f90f",
+    },
+    num_experiments = 5000,
+    t_threshold = "7.0",
+    tags = ["manual"],
+    target = ":run_p384_short",
+    tvla_secrets = {
+        "d0_io,d1_io": "additive:64:0x32f9e2b08677a5f2adb9ce1be14cd8df800a4c9416f5c1ee1e9d19e796d2f9e05b7d3b0f4de8344e6e0012819a0c1b763eb17c275c832a51:0xffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
+    },
+)
+
+otbn_tvla_sim_test(
+    name = "p384_ecdsa_sign_tvla_test",
+    timeout = "eternal",
+    fixed_background_secrets = {
+        "mode": "const:4:0x655",
+        "msg": "const:64:0x112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00",
+    },
+    num_experiments = 5000,
+    random_background_secrets = {
+        "k0_io,k1_io": "scalar_blind:64:0:0xaa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7",
+    },
+    t_threshold = "7.0",
+    tags = ["manual"],
+    target = ":run_p384_short",
+    tvla_secrets = {
+        "d0_io,d1_io": "additive:64:0x112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00:0xaa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7",
+    },
+)
+
+otbn_sim_test(
+    name = "run_curve25519_short",
+    srcs = ["//sw/otbn/crypto:run_curve25519.s"],
+    tags = ["manual"],
+    deps = [
+        ":25519_short",
+        "//sw/otbn/crypto:25519_scalar",
+        "//sw/otbn/crypto:field25519",
+        "//sw/otbn/crypto:p256_a2b",
+        "//sw/otbn/crypto:p256_b2a",
+    ],
+)
+
+otbn_tvla_sim_test(
+    name = "curve25519_ecdh_tvla_test",
+    timeout = "eternal",
+    fixed_background_secrets = {
+        "mode": "const:4:0x695",
+        "x25519_public_key": "const:32:0x4c1cabd0a603a9103b35b326ec2466727c5fb124a4c19435db3030586768dbe6",
+    },
+    num_experiments = 5000,
+    t_threshold = "7.0",
+    tags = ["manual"],
+    target = ":run_curve25519_short",
+    tvla_secrets = {
+        "ed25519_s0,ed25519_s1": "additive:32:0x112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00:0x10000000000000000000000000000000000000000000000000000000000000000",
+    },
+)
+
+otbn_tvla_sim_test(
+    name = "ed25519_sign_tvla_test",
+    timeout = "eternal",
+    fixed_background_secrets = {
+        "mode": "const:4:0x669",
+    },
+    num_experiments = 5000,
+    random_background_secrets = {
+        "ed25519_r0,ed25519_r1": "subtractive:96:0:0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed",
+    },
+    t_threshold = "7.0",
+    tags = ["manual"],
+    target = ":run_curve25519_short",
+    tvla_secrets = {
+        "ed25519_s0,ed25519_s1": "subtractive:64:0x112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00:0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed",
+    },
+)
+
+otbn_sim_test(
+    name = "run_rsa_short",
+    srcs = [
+        ":modexp_short_s",
+        "//sw/otbn/crypto:div.s",
+        "//sw/otbn/crypto:gcd.s",
+        "//sw/otbn/crypto:montmul.s",
+        "//sw/otbn/crypto:mul.s",
+        "//sw/otbn/crypto:rsa_keygen.s",
+        "//sw/otbn/crypto:rsa_modinv_f4.s",
+        "//sw/otbn/crypto:rsa_primality.s",
+        "//sw/otbn/crypto:run_rsa.s",
+        "//sw/otbn/crypto:run_rsa_mem.s",
+    ],
+    tags = ["manual"],
+)
+
+otbn_tvla_sim_test(
+    name = "rsa_2048_tvla_test",
+    timeout = "eternal",
+    fixed_background_secrets = {
+        "mode": "const:4:0x582",
+        "rsa_n": "const:256:0xb5ed720fe7e1b4a65494e8e9421df94910811d23854cb07b08a34508b682b188b16fa70e4804b4c4f54a54ae2a10848abc9253ac7c6085e5b9abcbcd48515db1626b01df4e7f5f1c85b9ce1b4c8d0f77f3854c8bc4f350ad4d993a6815d0d62ac83b47a257adb40023e1acf003d27953f19c5cbede1af58e42ef12ad9907c20ca428f8b7dbb6f3434936b1108d17ee343d7127f8885ff2513eb834c17bf1c4ddec0d61cc26f5f683c10c0e48676608811e9341f2898f690bc9fafd3b7e46d375e2178a141faf0d637767da550de4c5b9939af133ceba7cd2734df4ad269c166180afd8c35060de8ac302ca911aa3f92d139ed1595523a7f6c201cfafed4c17b5",
+        "inout": "const:256:0x95fb986cd4aeee4b013effc1d183670380a9e2133ecc6a38dbbfff3f8ef20e1923a5e3741eac8772ee80f28994968fcabd6d454b7791263872bc68d97b6f4fbb76cee24f205d812ad36f2fcb6c11145943009a051c39c18c45b53ee19e51df0254b31eb991783718fb35c51dec249956bceb0276eaee88d8ecdeae2c08ac62a0018408af3923206e911a7ecf6ad786255fa69d63d333e6f44ebd3f5e6ebb7c82443c694d913e200492c89f046943f2dc7d8cf9951c6a33fa721558d1956fb552349ded082714be6a8bff775fd05162744d229fc9fac72509476bdc6434e5187bf3a1cc426cc13f0a10dcf0d15f28abcecfe5674782f232464b1a890d42b6fdd0",
+    },
+    num_experiments = 5000,
+    t_threshold = "7.0",
+    tags = ["manual"],
+    target = ":run_rsa_short",
+    tvla_secrets = {
+        "rsa_d0,rsa_d1": "boolean:256:0x51a84a52295a7da34ac3abe746edfd3e7651fdaa3be2b8340124878fe99bafe4130072934e700e537965ebac60e51918cc9b4143627050a95435703cac011974cd200aaf18a4c3242241cbe924eb0bce6357a98bf2d2e39b660128de1f2ca5747e7b5d23d906f68c398ec9f8d13e5f86f623a0dd6b03dec403f71b03207502fbb6c7d812f391e010cbed264655d11ab63c262a803196a128df72ecf1c65ed7f742371e4c4ee355f44cfae81ec0a256da9aa3eb1935fc509d366de08c7edb522411670cd7ee0053bb9395ac4cbe0af6f3cdd1c24e225ee47aa4f381764cfab389db993fed537f397fbff31362a85872993bc467dde42b66894f4cb3ce712b2ee1",
+    },
+)
+
+otbn_tvla_sim_test(
+    name = "rsa_512_tvla_test",
+    timeout = "eternal",
+    fixed_background_secrets = {
+        "mode": "const:4:0x3ad",
+        "rsa_n": "const:64:0x906ce5d361397c1ce1f5b75760a23b20786e52ca82f66ec7216e982b5945a19afe4aba4e1c59d1aa020b035ef4c08da0658e9702c9bb46392d3b81ce594dec21",
+        "inout": "const:64:0xd487ce1eaf19922ad9b8a714e61a441c12e0c8b2bad640fb19488dec4f65d4d9259f4329e6f4590b9a164106cf6a659eb4862b21fb97d43588561712e8e5216a",
+    },
+    num_experiments = 1800,
+    t_threshold = "7.0",
+    tags = ["manual"],
+    target = ":run_rsa_short",
+    tvla_secrets = {
+        "rsa_d0,rsa_d1": "boolean:64:0x322c127f274460106c92fed934f1c6d695dfc595227fd7a607c032cec45983351d0b0bc8f3dff3b6c9ad7832dd18d46d82a6173a921aaf8adaa5b31fa0d07f7d",
+    },
+)


### PR DESCRIPTION
Add a new otbn_fi_sim_test target which simulates an otbn application and performs a campaign of instruction skip tests. The test works as follows:
- It ingests two test cases. Namely, a test with two different inputs.
- It traces the first test in order to know the program counters of the performed test. It checks for an output status value, which is given in the Bazel target as the ok_symbol.
- For each program counter (with a max occurence of 2), skip the instruction and test with both inputs. The user picks a collision symbol, if the test gives back an ok status and the two cases provide the same output, the test gives back the program counter calling it an effective fault injection.

We perform instruction skipping as a form of fault injection testing since this model is easy to apply and provides a manner of testing the hardening of otbn applications.

Varia:
- We allow the checking of partial collisions (based on Hamming distance) where the user gives the percentage of overlap when it is called a partial collision.
- The user can set the fixed_instruction_count value to true in which case the user assumes the OTBN application will be checked for it's instruction count for a fault to be effective.

We apply the new rule to perform a p256 verify simulation. The message values are different, however, using an instruction skip, we call an effective fault as one that collides the output x_r value.
We also create a test for p256 sign.
Vary the input nonce but keep the message and key fixed and look for collisions in the output R. This catches whether we can fix the nonce with a skip.