### PR TITLE
[crypto/ecc] Harden verify

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/p256.c
+++ b/sw/device/lib/crypto/impl/ecc/p256.c
@@ -427,6 +427,20 @@ status_t p256_ecdsa_verify_finalize(const p256_ecdsa_signature_t *signature,
 
   HARDENED_TRY(p256_check_otbn_status());
 
+  *result = kHardenedBoolFalse;
+  // The input r should not be zero
+  size_t i = 0;
+  uint32_t r_bits_or = 0;
+  for (; launder32(i) < kP256ScalarWords; ++i) {
+    r_bits_or |= signature->r[i];
+  }
+  HARDENED_CHECK_EQ(i, kP256ScalarWords);
+  if (launder32(r_bits_or) == 0) {
+    HARDENED_TRY(otbn_dmem_sec_wipe());
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_NE(r_bits_or, 0);
+
   // Read x_r (recovered R) out of OTBN dmem.
   uint32_t x_r[kP256ScalarWords];
   const otbn_addr_t kOtbnVarXr = OTBN_ADDR_T_INIT(run_p256, x_r);

--- a/sw/device/lib/crypto/impl/ecc/p384.c
+++ b/sw/device/lib/crypto/impl/ecc/p384.c
@@ -401,6 +401,20 @@ status_t p384_ecdsa_verify_finalize(const p384_ecdsa_signature_t *signature,
 
   HARDENED_TRY(p384_check_otbn_status());
 
+  *result = kHardenedBoolFalse;
+  // The input r should not be zero
+  size_t i = 0;
+  uint32_t r_bits_or = 0;
+  for (; launder32(i) < kP384ScalarWords; ++i) {
+    r_bits_or |= signature->r[i];
+  }
+  HARDENED_CHECK_EQ(i, kP384ScalarWords);
+  if (launder32(r_bits_or) == 0) {
+    HARDENED_TRY(otbn_dmem_sec_wipe());
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_NE(r_bits_or, 0);
+
   // Read x_r (recovered R) out of OTBN dmem.
   uint32_t x_r[kP384ScalarWords];
   const otbn_addr_t kOtbnVarXr = OTBN_ADDR_T_INIT(run_p384, x_r);

--- a/sw/otbn/crypto/p256_verify.s
+++ b/sw/otbn/crypto/p256_verify.s
@@ -153,6 +153,33 @@ p256_verify:
   /* Abort if they do not match */
   jal       x1, trigger_fault_if_fg0_z
 
+  /* Reverse check: We verify that (u1 * s) mod n == msg mod n */
+
+  /* Put u1 into w24 for multiplication */
+  bn.mov    w24, w1
+
+  /* Load original s from dmem directly into w25 */
+  la        x20, s
+  li        x2, 25
+  bn.lid    x2, 0(x20)
+
+  /* Compute w19 = (u1 * s) mod n */
+  jal       x1, mod_mul_256x256
+
+  /* Load original msg from dmem into w20 */
+  la        x19, msg
+  li        x2, 20
+  bn.lid    x2, 0(x19)
+
+  /* w20 = (w20 + 0) mod n */
+  bn.addm   w20, w20, w31
+
+  /* Compare calculated msg (w19) with reduced msg (w20) */
+  bn.cmp    w19, w20
+
+  /* Abort if they do not match */
+  jal       x1, trigger_fault_if_fg0_z
+
   /* Set up for coordinate arithmetic.
        MOD <= p
        w28 <= r256


### PR DESCRIPTION
- For p256/p384 verify, the calculated r value can not be equal to zero.
    Hence, when the user provides a zero value in the signature to verify,
    provide a bad argument result.
- Add a redundant check on u1 in p256 verify.