### PR TITLE
[dv] Remove some unused interrupt interfaces from testbenches

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -705,6 +705,11 @@ task cip_base_vseq::check_interrupts(bit [BUS_DW-1:0]  interrupts,
   bit [BUS_DW-1:0] exp_pins;
   bit [BUS_DW-1:0] exp_intr_state;
 
+  if (cfg.intr_vif == null) begin
+    `uvm_error(get_full_name(), "Can't check interrupts: there is no intr_vif")
+    return;
+  end
+
   if (cfg.under_reset) return;
 
   act_pins = cfg.intr_vif.sample() & interrupts;
@@ -768,6 +773,11 @@ task cip_base_vseq::run_intr_test_vseq(int num_times = 1);
   import dv_utils_pkg::interrupt_t;
   dv_base_reg intr_csrs[$];
   dv_base_reg intr_test_csrs[$];
+
+  if (cfg.intr_vif == null) begin
+    `uvm_error(get_full_name(), "Can't run intr_test sequence: there is no intr_vif")
+    return;
+  end
 
   foreach (all_csrs[i]) begin
     string csr_name = all_csrs[i].get_name();

--- a/hw/ip/aes/dv/tb/tb.sv
+++ b/hw/ip/aes/dv/tb/tb.sv
@@ -14,7 +14,6 @@ module tb;
   `include "dv_macros.svh"
 
   wire                                    clk, rst_n, rst_shadowed_n;
-  wire [NUM_MAX_INTERRUPTS-1:0]           interrupts;
   wire [$bits(lc_ctrl_pkg::lc_tx_t) : 0]  lc_escalate;
   wire                                    idle;
   prim_mubi_pkg::mubi4_t                  idle_s;
@@ -25,7 +24,6 @@ module tb;
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   rst_shadowed_if rst_shadowed_if(.rst_n(rst_n), .rst_shadowed_n(rst_shadowed_n));
-  pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
 
   pins_if #($bits(lc_escalate)) lc_escalate_if (lc_escalate);
   pins_if #(1) idle_if (idle);
@@ -76,7 +74,6 @@ module tb;
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(virtual rst_shadowed_if)::set(null, "*.env", "rst_shadowed_vif",
                                                  rst_shadowed_if);
-    uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual aes_cov_if)::set(null, "*.env", "aes_cov_if", dut.u_aes_cov_if );
     uvm_config_db#(virtual key_sideload_if)

--- a/hw/ip/sram_ctrl/dv/tb.sv
+++ b/hw/ip/sram_ctrl/dv/tb.sv
@@ -20,7 +20,7 @@ module tb;
   wire rst_n;
   wire clk_otp;
   wire rst_otp_n;
-  wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
+
   // RACL:
   // Currently not used, but copying RTL's default value
   parameter int unsigned RaclPolicySelNumRangesRam = 1;
@@ -38,7 +38,6 @@ module tb;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
-  pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
   clk_rst_if otp_clk_rst_if(.clk(clk_otp), .rst_n(rst_otp_n));
 
   // TLUL interface to the CSR regfile
@@ -148,7 +147,6 @@ module tb;
     uvm_config_db#(virtual clk_rst_if)::set(
         null, "*.env", "clk_rst_vif_sram_ctrl_prim_reg_block", clk_rst_if);
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "otp_clk_rst_vif", otp_clk_rst_if);
-    uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(virtual push_pull_if#(.DeviceDataWidth(KDI_DATA_SIZE)))::set(null,
       "*.env.m_kdi_agent*", "vif", kdi_if);
     uvm_config_db#(virtual sram_ctrl_lc_if)::set(null, "*.env", "lc_vif", lc_if);


### PR DESCRIPTION
The first commit is to make sure it's ok not to pass an interrupt interface (based on grepping for "intr_vif" in the base classes). The other two remove the interfaces.