### PR TITLE
[aes,dv] Remove unconnected signal from tb

### DIFF
--- a/hw/ip/aes/dv/tb/tb.sv
+++ b/hw/ip/aes/dv/tb/tb.sv
@@ -15,7 +15,6 @@ module tb;
 
   wire                                    clk, rst_n, rst_shadowed_n;
   wire [NUM_MAX_INTERRUPTS-1:0]           interrupts;
-  wire                                    edn_req;
   wire [$bits(lc_ctrl_pkg::lc_tx_t) : 0]  lc_escalate;
   wire                                    idle;
   prim_mubi_pkg::mubi4_t                  idle_s;


### PR DESCRIPTION
This was orphaned ages ago, by 889184a159e.

(I noticed because I'm looking into wiring up the AES environment into chip-level simulations, so am working through the list of connections in the block-level tb)