### PR TITLE
[cryptotest] Add ACVP RSA Keygen testing

### DIFF
--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -177,6 +177,20 @@ cryptotest(
     ],
 )
 
+cryptotest(
+    name = "rsa_keygen_acvp",
+    slow_test = True,
+    test_args = " ".join([
+        "--input=\"$(rootpath //sw/host/cryptotest/testvectors/acvp:rsa_keygen_vectors.json)\"",
+        "--run-keygen",
+        "--timeout=250s",
+    ]),
+    test_harness = "//sw/host/tests/crypto/acvp:harness",
+    test_vectors = [
+        "//sw/host/cryptotest/testvectors/acvp:rsa_keygen_vectors.json",
+    ],
+)
+
 # Runs AES-ECB and AES-GCM ACVP test vectors and compares against expected
 # results.  To also save the results to a file, append --output=<path> when
 # invoking with `bazelisk.sh run`:
@@ -883,6 +897,7 @@ test_suite(
         ":rsa_acvp",
         ":rsa_acvp_siggen",
         ":rsa_kat",
+        ":rsa_keygen_acvp",
         ":sha256_kat",
         ":sha384_kat",
         ":sha3_224_kat",

--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -161,6 +161,8 @@ cc_library(
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",
         "//sw/device/lib/crypto",
+        "//sw/device/lib/crypto/impl/rsa:rsa_datatypes",
+        "//sw/device/lib/crypto/impl/rsa:run_rsa",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:rand_testutils",
         "//sw/device/lib/testing/test_framework:ujson_ottf",

--- a/sw/device/tests/crypto/cryptotest/firmware/rsa.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/rsa.c
@@ -6,6 +6,8 @@
 
 #include "sw/device/lib/base/math.h"
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/impl/rsa/rsa_datatypes.h"
+#include "sw/device/lib/crypto/impl/rsa/run_rsa.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/sha2.h"
@@ -757,6 +759,64 @@ status_t handle_rsa_keygen(ujson_t *uj) {
   return OK_STATUS();
 }
 
+status_t handle_rsa_keygen_acvp(ujson_t *uj) {
+  cryptotest_rsa_keygen_acvp_t uj_input;
+  TRY(ujson_deserialize_cryptotest_rsa_keygen_acvp_t(uj, &uj_input));
+
+  otcrypto_rsa_size_t otcrypto_size;
+  size_t rsa_num_words;
+  size_t n_bytes = uj_input.security_level / 8;
+  TRY(rsa_size_params(uj_input.security_level, &otcrypto_size, &rsa_num_words,
+                      NULL, NULL, NULL));
+
+  rsa_size_t rsa_size;
+  switch (otcrypto_size) {
+    case kOtcryptoRsaSize2048:
+      rsa_size = kRsaSize2048;
+      break;
+    case kOtcryptoRsaSize3072:
+      rsa_size = kRsaSize3072;
+      break;
+    case kOtcryptoRsaSize4096:
+      rsa_size = kRsaSize4096;
+      break;
+    default:
+      LOG_ERROR("Unsupported RSA size: %d", (uint32_t)uj_input.security_level);
+      return INVALID_ARGUMENT();
+  }
+
+  uint32_t n_buf[rsa_num_words];
+  uint32_t d0_buf[rsa_num_words];
+  uint32_t d1_buf[rsa_num_words];
+  size_t prime_words = rsa_num_words / 2;
+  size_t prime_bytes = n_bytes / 2;
+  uint32_t p_buf[prime_words];
+  uint32_t q_buf[prime_words];
+
+  TRY(rsa_keygen_start(rsa_size));
+  TRY(rsa_keygen_finalize_size(rsa_size, n_buf, d0_buf, d1_buf, p_buf, q_buf));
+
+  uint32_t d_buf[rsa_num_words];
+  for (size_t i = 0; i < rsa_num_words; i++) {
+    d_buf[i] = d0_buf[i] ^ d1_buf[i];
+  }
+
+  cryptotest_rsa_keygen_acvp_resp_t uj_output;
+  memset(&uj_output, 0, sizeof(uj_output));
+  memcpy(uj_output.n, n_buf, n_bytes);
+  uj_output.n_len = n_bytes;
+  memcpy(uj_output.d, d_buf, n_bytes);
+  uj_output.d_len = n_bytes;
+  memcpy(uj_output.p, p_buf, prime_bytes);
+  uj_output.p_len = prime_bytes;
+  memcpy(uj_output.q, q_buf, prime_bytes);
+  uj_output.q_len = prime_bytes;
+  uj_output.e = kCryptotestRsaSupportedE;
+
+  RESP_OK(ujson_serialize_cryptotest_rsa_keygen_acvp_resp_t, uj, &uj_output);
+  return OK_STATUS();
+}
+
 status_t handle_rsa(ujson_t *uj) {
   rsa_subcommand_t cmd;
   TRY(ujson_deserialize_rsa_subcommand_t(uj, &cmd));
@@ -773,6 +833,8 @@ status_t handle_rsa(ujson_t *uj) {
       return handle_rsa_keygen_check(uj);
     case kRsaSubcommandRsaKeygen:
       return handle_rsa_keygen(uj);
+    case kRsaSubcommandRsaKeygenAcvp:
+      return handle_rsa_keygen_acvp(uj);
     default:
       LOG_ERROR("Unrecognized RSA subcommand: %d", cmd);
       return INVALID_ARGUMENT();

--- a/sw/device/tests/crypto/cryptotest/json/rsa_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/rsa_commands.h
@@ -17,6 +17,9 @@ extern "C" {
 // Accomodate for these additional bytes.
 #define RSA_CMD_MAX_MESSAGE_BYTES 514
 #define RSA_CMD_MAX_SIGNATURE_BYTES 514
+// Prime factors p and q are half the size of the modulus n.
+// RSA-4096 has 256-byte primes, so this covers all supported key sizes.
+#define RSA_CMD_MAX_PRIME_BYTES 256
 
 // clang-format off
 
@@ -26,7 +29,8 @@ extern "C" {
     value(_, RsaSign) \
     value(_, RsaVerify) \
     value(_, RsaKeygenCheck) \
-    value(_, RsaKeygen)
+    value(_, RsaKeygen) \
+    value(_, RsaKeygenAcvp)
 UJSON_SERDE_ENUM(RsaSubcommand, rsa_subcommand_t, RSA_SUBCOMMAND);
 
 #define RSA_SIGN(field, string) \
@@ -124,6 +128,22 @@ UJSON_SERDE_STRUCT(CryptotestRsaKeygen, cryptotest_rsa_keygen_t, RSA_KEYGEN);
     field(d_len, size_t) \
     field(e, uint32_t)
 UJSON_SERDE_STRUCT(CryptotestRsaKeygenResp, cryptotest_rsa_keygen_resp_t, RSA_KEYGEN_RESP);
+
+#define RSA_KEYGEN_ACVP(field, string) \
+    field(security_level, size_t)
+UJSON_SERDE_STRUCT(CryptotestRsaKeygenAcvp, cryptotest_rsa_keygen_acvp_t, RSA_KEYGEN_ACVP);
+
+#define RSA_KEYGEN_ACVP_RESP(field, string) \
+    field(n, uint8_t, RSA_CMD_MAX_N_BYTES) \
+    field(n_len, size_t) \
+    field(d, uint8_t, RSA_CMD_MAX_N_BYTES) \
+    field(d_len, size_t) \
+    field(p, uint8_t, RSA_CMD_MAX_PRIME_BYTES) \
+    field(p_len, size_t) \
+    field(q, uint8_t, RSA_CMD_MAX_PRIME_BYTES) \
+    field(q_len, size_t) \
+    field(e, uint32_t)
+UJSON_SERDE_STRUCT(CryptotestRsaKeygenAcvpResp, cryptotest_rsa_keygen_acvp_resp_t, RSA_KEYGEN_ACVP_RESP);
 
 #undef MODULE_ID
 

--- a/sw/host/cryptotest/testvectors/acvp/BUILD
+++ b/sw/host/cryptotest/testvectors/acvp/BUILD
@@ -18,6 +18,7 @@ exports_files([
     "kmac_expected.hjson",
     "kmac_vectors.hjson",
     "rsa_expected.json",
+    "rsa_keygen_vectors.json",
     "rsa_vectors.json",
     "sha_expected.hjson",
     "sha_vectors.hjson",

--- a/sw/host/cryptotest/testvectors/acvp/rsa_keygen_vectors.json
+++ b/sw/host/cryptotest/testvectors/acvp/rsa_keygen_vectors.json
@@ -1,0 +1,33 @@
+[
+  {
+    "vsId": 0,
+    "algorithm": "RSA",
+    "mode": "keyGen",
+    "revision": "FIPS186-4",
+    "isSample": true,
+    "testGroups": [
+      {
+        "tgId": 1,
+        "infoGeneratedByServer": false,
+        "modulo": 2048,
+        "testType": "GDT",
+        "keyFormat": "standard",
+        "primeTest": "2powSecStr",
+        "randPQ": "probable",
+        "pubExp": "fixed",
+        "fixedPubExp": "010001",
+        "tests": [
+          {
+            "tcId": 1
+          },
+          {
+            "tcId": 2
+          },
+          {
+            "tcId": 3
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/sw/host/tests/crypto/acvp/src/main.rs
+++ b/sw/host/tests/crypto/acvp/src/main.rs
@@ -82,6 +82,10 @@ struct Opts {
     // Output ACVP JSON result file for all EdDSA results (sigVer, sigGen, keyGen).
     #[arg(long)]
     output_eddsa: Option<std::path::PathBuf>,
+
+    // Output ACVP JSON result file for RSA keyGen results.
+    #[arg(long)]
+    output_rsa_keygen: Option<std::path::PathBuf>,
 }
 
 enum AcvpVectors {
@@ -101,6 +105,7 @@ enum AcvpVectors {
     Hmac(hmac::HmacTestVectorSet),
     Kmac(kmac::KmacTestVectorSet),
     RsaSigGen(rsa::RsaSignGenTestVectorSet),
+    RsaKeyGen(rsa::RsaKeyGenTestVectorSet),
     Rsa(rsa::RsaTestVectorSet),
     Sha(sha::ShaTestVectorSet),
     X25519(x25519::X25519TestVectorSet),
@@ -168,6 +173,7 @@ fn parse_vector_set(raw: serde_json::Value) -> Result<AcvpVectors> {
         ("EDDSA", "sigGen") => AcvpVectors::EddsaSigGen(serde_json::from_value(raw)?),
         ("EDDSA", "keyGen") => AcvpVectors::EddsaKeyGen(serde_json::from_value(raw)?),
         ("RSA-sigGen", _) => AcvpVectors::RsaSigGen(serde_json::from_value(raw)?),
+        ("RSA", "keyGen") => AcvpVectors::RsaKeyGen(serde_json::from_value(raw)?),
         ("RSA-sigVer", _) => AcvpVectors::Rsa(serde_json::from_value(raw)?),
         ("XECDH", _) => AcvpVectors::X25519(serde_json::from_value(raw)?),
         _ => anyhow::bail!("Unknown algorithm/mode: {:?}/{:?}", algorithm, mode),
@@ -253,6 +259,7 @@ fn run<R: std::io::Read, W: std::io::Write>(
     output_eddsa: Option<W>,
     output_ecdsa_siggen: Option<W>,
     output_ecdsa_keygen: Option<W>,
+    output_rsa_keygen: Option<W>,
 ) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
     let spi_console_device = SpiConsoleDevice::new(
@@ -278,6 +285,8 @@ fn run<R: std::io::Read, W: std::io::Write>(
     let mut ecdsa_siggen_results: Vec<serde_json::Value> = Vec::new();
     // ECDSA keyGen results are serialised to --output-ecdsa-keygen.
     let mut ecdsa_keygen_results: Vec<serde_json::Value> = Vec::new();
+    // RSA keyGen results are serialised to --output-rsa-keygen.
+    let mut rsa_keygen_results: Vec<serde_json::Value> = Vec::new();
 
     for v in acvp_vectors {
         match v {
@@ -379,6 +388,16 @@ fn run<R: std::io::Read, W: std::io::Write>(
                     eddsa_results.push(serde_json::to_value(result)?);
                 }
             }
+            AcvpVectors::RsaKeyGen(vs) => {
+                if opts.run_keygen || opts.output_rsa_keygen.is_some() {
+                    let result = rsa::run_rsa_keygen_acvp_vector_set(
+                        opts.timeout,
+                        &spi_console_device,
+                        &vs,
+                    )?;
+                    rsa_keygen_results.push(serde_json::to_value(result)?);
+                }
+            }
             AcvpVectors::RsaSigGen(vs) => {
                 if opts.run_siggen || opts.output_siggen.is_some() {
                     let result = rsa::run_rsa_siggen_vector_set(
@@ -445,6 +464,9 @@ fn run<R: std::io::Read, W: std::io::Write>(
     if let Some(w) = output_ecdsa_keygen {
         serde_json::to_writer_pretty(w, &ecdsa_keygen_results)?;
     }
+    if let Some(w) = output_rsa_keygen {
+        serde_json::to_writer_pretty(w, &rsa_keygen_results)?;
+    }
     if let Some(w) = output_eddsa {
         serde_json::to_writer_pretty(w, &eddsa_results)?;
     }
@@ -489,6 +511,7 @@ fn main() -> Result<()> {
         && opts.output_ecdsa_siggen.is_none()
         && opts.output_ecdsa_keygen.is_none()
         && opts.output_eddsa.is_none()
+        && opts.output_rsa_keygen.is_none()
     {
         log::warn!("Missing expected/output ACVP JSON files");
         return Ok(());
@@ -545,6 +568,14 @@ fn main() -> Result<()> {
         }
         None => None,
     };
+    let output_rsa_keygen = match &opts.output_rsa_keygen {
+        Some(path) => {
+            let f = std::fs::File::create(path)
+                .inspect_err(|e| log::error!("open rsa keygen output file: {e}"))?;
+            Some(std::io::BufWriter::new(f))
+        }
+        None => None,
+    };
     run(
         &opts,
         &transport,
@@ -555,5 +586,6 @@ fn main() -> Result<()> {
         output_eddsa,
         output_ecdsa_siggen,
         output_ecdsa_keygen,
+        output_rsa_keygen,
     )
 }

--- a/sw/host/tests/crypto/acvp/src/rsa.rs
+++ b/sw/host/tests/crypto/acvp/src/rsa.rs
@@ -10,8 +10,9 @@ use std::time::Duration;
 
 use cryptotest_commands::commands::CryptotestCommand;
 use cryptotest_commands::rsa_commands::{
-    CryptotestRsaKeygen, CryptotestRsaKeygenResp, CryptotestRsaSign, CryptotestRsaSignResp,
-    CryptotestRsaVerify, CryptotestRsaVerifyResp, RsaSubcommand,
+    CryptotestRsaKeygen, CryptotestRsaKeygenAcvp, CryptotestRsaKeygenAcvpResp,
+    CryptotestRsaKeygenResp, CryptotestRsaSign, CryptotestRsaSignResp, CryptotestRsaVerify,
+    CryptotestRsaVerifyResp, RsaSubcommand,
 };
 
 use opentitanlib::console::spi::SpiConsoleDevice;
@@ -530,6 +531,144 @@ fn run_rsa_siggen_group(
         n: n_hex,
         e: e_hex,
         tests: result_cases,
+    })
+}
+
+// RSA Key Generation (ACVP keyGen mode)
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RsaKeyGenTestCase {
+    tc_id: usize,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RsaKeyGenTestGroup {
+    tg_id: usize,
+    modulo: usize,
+    tests: Vec<RsaKeyGenTestCase>,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RsaKeyGenTestVectorSet {
+    vs_id: usize,
+    algorithm: String,
+    mode: String,
+    revision: String,
+    #[serde(default)]
+    is_sample: bool,
+    test_groups: Vec<RsaKeyGenTestGroup>,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RsaKeyGenResultCase {
+    pub tc_id: usize,
+    pub e: String,
+    pub p: String,
+    pub q: String,
+    pub n: String,
+    pub d: String,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RsaKeyGenResultGroup {
+    pub tg_id: usize,
+    pub tests: Vec<RsaKeyGenResultCase>,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RsaKeyGenResultVectorSet {
+    pub vs_id: usize,
+    pub algorithm: String,
+    pub mode: String,
+    pub revision: String,
+    #[serde(default)]
+    pub is_sample: bool,
+    pub test_groups: Vec<RsaKeyGenResultGroup>,
+}
+
+fn run_rsa_keygen_acvp_case(
+    timeout: Duration,
+    spi_console: &SpiConsoleDevice,
+    security_level: usize,
+    tc: &RsaKeyGenTestCase,
+) -> Result<RsaKeyGenResultCase> {
+    CryptotestCommand::Rsa.send(spi_console)?;
+    RsaSubcommand::RsaKeygenAcvp.send(spi_console)?;
+
+    CryptotestRsaKeygenAcvp { security_level }.send(spi_console)?;
+
+    let resp = CryptotestRsaKeygenAcvpResp::recv(spi_console, timeout, false, false)?;
+
+    let n_le = resp.n.as_slice()[..resp.n_len].to_vec();
+    let d_le = resp.d.as_slice()[..resp.d_len].to_vec();
+    let p_le = resp.p.as_slice()[..resp.p_len].to_vec();
+    let q_le = resp.q.as_slice()[..resp.q_len].to_vec();
+
+    // Convert from little-endian to big-endian hex for ACVP output.
+    let mut n_be = n_le;
+    n_be.reverse();
+    let mut d_be = d_le;
+    d_be.reverse();
+    let mut p_be = p_le;
+    p_be.reverse();
+    let mut q_be = q_le;
+    q_be.reverse();
+
+    Ok(RsaKeyGenResultCase {
+        tc_id: tc.tc_id,
+        e: u32_to_be_hex(resp.e),
+        p: hex::encode_upper(&p_be),
+        q: hex::encode_upper(&q_be),
+        n: hex::encode_upper(&n_be),
+        d: hex::encode_upper(&d_be),
+    })
+}
+
+fn run_rsa_keygen_acvp_group(
+    timeout: Duration,
+    spi_console: &SpiConsoleDevice,
+    tg: &RsaKeyGenTestGroup,
+) -> Result<RsaKeyGenResultGroup> {
+    log::info!("tg_id: {}", tg.tg_id);
+    let mut result_cases = Vec::new();
+    for tc in &tg.tests {
+        log::info!("tc_id: {}", tc.tc_id);
+        result_cases.push(run_rsa_keygen_acvp_case(
+            timeout,
+            spi_console,
+            tg.modulo,
+            tc,
+        )?);
+    }
+    Ok(RsaKeyGenResultGroup {
+        tg_id: tg.tg_id,
+        tests: result_cases,
+    })
+}
+
+pub fn run_rsa_keygen_acvp_vector_set(
+    timeout: Duration,
+    spi_console: &SpiConsoleDevice,
+    vs: &RsaKeyGenTestVectorSet,
+) -> Result<RsaKeyGenResultVectorSet> {
+    log::info!("vs_id: {}", vs.vs_id);
+    let mut result_groups = Vec::new();
+    for tg in &vs.test_groups {
+        result_groups.push(run_rsa_keygen_acvp_group(timeout, spi_console, tg)?);
+    }
+    Ok(RsaKeyGenResultVectorSet {
+        vs_id: vs.vs_id,
+        algorithm: vs.algorithm.clone(),
+        mode: vs.mode.clone(),
+        revision: vs.revision.clone(),
+        is_sample: false,
+        test_groups: result_groups,
     })
 }
 


### PR DESCRIPTION
With 964706b1d27d78ca0b84015c5867c0b2591fec88, we now can read out all information that ACVP RSA keygen testing needs (n, q, p, q, e). This PR adds now ACVP testing for RSA keygen with a fixed e and the standard key format.

When running it with:
```
./bazelisk.sh run //sw/device/tests/crypto/cryptotest:rsa_keygen_acvp_fpga_cw340_sival_rom_ext -- --output-rsa-keygen=rsa_keygen_output.json
```
The following JSON file is generated:
```json
[
  {
    "algorithm": "RSA",
    "isSample": false,
    "mode": "keyGen",
    "revision": "FIPS186-4",
    "testGroups": [
      {
        "tests": [
          {
            "d": "180071F2790921969D91284236A7ADE76B30F9A28BF676BA5F2E486E358A2F0DC70D5E00C3544ACE76CEB145CE6C5D0734FBBD9EF2E906A66229A07115A2B734FDE69B4F9FC67E0572C676B87D27FFBC66B3A44274ABE8B1D483C8E55597E15DC7AEC23AA5CDB0F0A46C7A77C682787974AFE1BA7FF5B729010428B6EE058885B201041B95A96490CFCDCD95389EFC6C4DBD50ACB457B6295AD831BCB09CB36B409E8AD6C3CF3CCCEDE8F7310773AFDA2A0BF58666A8900ACBCC435F76727346183E1E076898A9A38D7020290431013995A8E8FFEAC6B5ADA391F913C662E3E8E9BB73E112534F4EEB224A5EB7FDCF36487378FAD1B2CB24DF918B7B423FFBF9",
            "e": "010001",
            "n": "C0305AAC1F4EAC5ACE0D67029290BAF8F72674C19925D8DDB769EFD590B44E1194E09BEA1AF94A370EDCA88A9D5569DA276B4816094C98B39A53729FF5469C4177DD97247BB7F331EC7AD2C7ECD4D7EA03CBE1145C1D5C53120BB8A343FEA207BF8032016093826B38D0A6F2F4D4BDF59C3E81A618E76DFEF681CB975DE939CE27AC2309BB62B2F9C5297689A522A20C213DB4BDBAA19313B53B9A37924CCC15EBFC3D98D2CC66F7A1F4D069374CFF29B606593AB38AF76E47EDC7869FD346CC8E8B9978C0801666351A2F68026B682C0BD89DC569167FD04CC70B8D2E59D5241C2E0104A9768A6E63A95E226C4DE5D72AA63A266EA17066E6727D0D99CC91D1",
            "p": "FC3496E73D4B0C7AE898F705CCEC1262E8C75B335AF62510A0C8A9450D40B09431A0C34996A0AE2998FA4922B5C1A8F044FC5F1F8547CFC06471A00D249E24A4C1091CC72C9D7D447E20787D5F1E972E98B5D0436D3187A592E374D461FEEFA0FA1E6FBCC34DD9BA118729F16915C7C411FF5437360B0CBF00C5590B9BE42EDF",
            "q": "C31499E62CC7DD0F0FFCB28CADF08C98DE14AFD8A97903C232DD84B7FA2BD286B5DC16C8A2CDE3C135B0481D684FD37CABEBD1499CC4C51C6E18C755A46F470BE5A652BBC13715471C43805FAB4E7B5FC7ECF138E244BFD05B30FDF27887B2BE67D74CD404A1F4C21715AA9EBECEE1A9D88F7FCAD026E35D2984022E7A40454F",
            "tcId": 1
          },
          {
            "d": "4A6ED51C3BE165DFBD377C5307054E25A1397CEF3DD017B9F55ADDFA0B38F7E77291D531EBAB40623ED312C4E335080F9FBFFA7766DC776EF5507A94B69DF2D0E50B9DAA54C801237DD84AEFB40A369D25134F6839FC9748E0D270C083CCA67A7AFA478F1B59AFAEEAE7BF8BCE57E486466E3D4EF56330079A26D22E0EAA63C3030EEFC893DCDDB5CF41817A7BA8BACE7B9B4998B95C06F9AB37582011A4B063C6B2B9BB209E35F1390CBAFC40B1E29F6CFB7A3A35B5822BFC71A6620BF6C81DE634DE5F1A7259A0E68D13D38FCF1D7DBB6883F23AF424B570B93DC62423DF00B7BACC357C9B36D0D3DB7416C50DAFB0F6E542D15CBA1F3972FFB57C542FAC35",
            "e": "010001",
            "n": "C45F96EA41555671BE4364BDF1ED1208B6467DD69454C4C64A30142AC27F240AF309DC279F97EA205F321208C7B3320F8F36481211A98F654D0733D6BFBB2C7A23CE8525A697B25F9AB7038E2CCEC1ACFEF6BD83A05F7BD0CD3CF937EF11D77D816F65ED0185E91B786811ED534160835D429A1F16B461D955E1655D33A54B87AEB3CDAD44BDC022D25C4BDCA2D06568BB513444428F955F8502A1245A60D7CF3695E02DEC181D4C260438AAE98C280B6CFE8ED7330452EC6FE3D6A89BEB27B84F6A12CC90E7DEDB675D66C065FC7C02CDDFE1AB15A3A7F4EBB57EA0D6A01512188F580039140E57F697693D256E35FC0BC6CA42C57CA94A7489B661A2016589",
            "p": "EA8C28EF825B414B1465B9586286FA550CC7764024278AAB71F844BC30560ABECED2019533833FC7AE08D3A7BDFF5B9C1365BFE35A8DDD8D1CE48766CF54161F808E559A07DA0AD4563231510C0C7CC142F50E96EA938081D45EF331019F6A449D90EE589B739606D60D1E57818744FCCEC124F30051DE73CD0F278F76E511EF",
            "q": "D65598FA31D5AA1149DE33D452E2D7A765AE23AB7B3338F290B221B66AA66F5C7D81302FE3B248279DA63566A47BEF7879766FF04A71E7980A216C37FEBA75072FF84A2D7240E43468DBDF6DBA0F84C6B63FE200FAF6998E8D0D1F739043B6ADCB2D091EAAD22DF8E79C0769FE2C89905ADFF8BD25C974FCC84CDE514A689807",
            "tcId": 2
          },
          {
            "d": "2C11A1A2E292F7B5195A9CEAADABAD1BAA8F12CA3E4801D39042FA115798C23DE80F3A1542702D770796661EEF2737084C5B985088EE482427D836861C4CE5D79D12742EFC54138CE79594DFE9D308C8284E1FDDC8A4431ABB92A744221D38A90A46E28414C17E2059AE368474198823A014898A3D60048E6E185A9E0E0776D3641E9380748CC8C25DCDA61CFAADDFBFC1A7DCFA7DA9F83851BDE461CCBBEFA3A401DDD5AADA8EFDCCC62A639A387A7C1299272616AC84E5FC2487720897F2F275E0F3B119FE5155D0FB01BE9534616558DC35CDE14D81A511D38E0B78F48C40721F344A753170680C1474E0823A4DFD4FFD7305803A741D029591E8690D48ED",
            "e": "010001",
            "n": "C8944EA9DD4AF18BFE378BE3F4856459D04B55FC24AA2EC04CA31C4AC5C6890D6DB2E9A911E4B9AB7F4E2B4C3DC456414F2B04F67072F14DF5F191EB09114415BE0168B9E80D82887DEB6B8948C033AFDF1D2491DE387F47A4C862672DA9ADCB640A8A0DAD48D21C0D45EDA9F5E6B8F536483F4583B197E4E17CC49B8AD3E7CEA12C6503E2B360D7A19F4B5D6987F374758D2CDE25805655F9DC62BAC3FD50BF30B4BB964BF47B760A2FA0A0A66A56F99CFCE09354CF4ABE907A2D12D5C7DF575B09522DF272705F02F08F8091ABDE16FC5DF9AFC47EAE6142B9D3A6C504D569B0A18B02ADE52BB4B37129DB1A016C6B60BA0C756F3CD0BCF23059AA18AD4249",
            "p": "CB47AFAA7D85B75047BE892709973377B5228A7E72C4049FDBEF73795DC8037C50BF9B6535145879DFA2D4AB55F3A4F5EB1730A6678536441BC220E01F0FB7EB7302F38507F4442A09F5FCD509AF73163E9F80318275737C3AB47141630B1435B25452A5FF9B6DC9D8D5CB50D1D951DBF64DD1772DBD7798433C8FE9A7A4064F",
            "q": "FC9950787449490A11F62A82BD43DBF5D411B13FA196A5C3F31C22BB2EF4AB1FC90C943E6035BECFCB414DDB18E290DD538A3C8910BADC20B0604C3A64C2276A0AEAF1C32E622A369A45ECDEC9FB7B987675443E529DF3D25AE0BE7DA6AC607327D2653978426C8D4F55BF58F6055C152AE710C04AA2FD3324A3989348981FE7",
            "tcId": 3
          }
        ],
        "tgId": 1
      }
    ],
    "vsId": 0
  }
]
```