### PR TITLE
[ot_certs] Implement DER length patching in ASN1 codegen

### DIFF
--- a/sw/device/silicon_creator/lib/cert/template.c
+++ b/sw/device/silicon_creator/lib/cert/template.c
@@ -49,7 +49,7 @@ void template_patch_size_be_impl(template_pos_t memo, uint8_t *out_end) {
                                         (uint16_t)(out_end - (uint8_t *)memo));
 }
 
-uint8_t* template_patch_size_der_impl(template_pos_t memo, uint8_t* out_end) {
+uint8_t *template_patch_size_der_impl(template_pos_t memo, uint8_t *out_end) {
   uint8_t *memo_ptr = (uint8_t *)memo;
   const size_t kReservedLen = 3;
 

--- a/sw/device/silicon_creator/lib/cert/template.c
+++ b/sw/device/silicon_creator/lib/cert/template.c
@@ -48,3 +48,36 @@ void template_patch_size_be_impl(template_pos_t memo, uint8_t *out_end) {
   *(uint16_t *)memo = __builtin_bswap16(__builtin_bswap16(*(uint16_t *)memo) +
                                         (uint16_t)(out_end - (uint8_t *)memo));
 }
+
+uint8_t* template_patch_size_der_impl(template_pos_t memo, uint8_t* out_end) {
+  uint8_t *memo_ptr = (uint8_t *)memo;
+  const size_t kReservedLen = 3;
+
+  size_t content_size = (size_t)(out_end - (memo_ptr + kReservedLen));
+
+  size_t der_len_bytes = 0;
+  if (content_size <= 0x7f) {
+    memo_ptr[0] = (uint8_t)content_size;
+    der_len_bytes = 1;
+  } else if (content_size <= 0xff) {
+    memo_ptr[0] = 0x81;
+    memo_ptr[1] = (uint8_t)content_size;
+    der_len_bytes = 2;
+  } else {
+    memo_ptr[0] = 0x82;
+    memo_ptr[1] = (uint8_t)(content_size >> 8);
+    memo_ptr[2] = (uint8_t)(content_size & 0xff);
+    der_len_bytes = 3;
+  }
+
+  if (der_len_bytes < kReservedLen) {
+    uint8_t *src = memo_ptr + kReservedLen;
+    uint8_t *dst = memo_ptr + der_len_bytes;
+    while (src < out_end) {
+      *dst++ = *src++;
+    }
+    out_end = dst;
+  }
+
+  return out_end;
+}

--- a/sw/device/silicon_creator/lib/cert/template.h
+++ b/sw/device/silicon_creator/lib/cert/template.h
@@ -221,7 +221,7 @@ void template_patch_size_be_impl(template_pos_t memo, uint8_t *out_end);
 /**
  * Private implementation of `template_patch_size_der`.
  */
-uint8_t* template_patch_size_der_impl(template_pos_t memo, uint8_t *out_end);
+uint8_t *template_patch_size_der_impl(template_pos_t memo, uint8_t *out_end);
 
 /**
  * Add the actual output size after the memo to the patch location.
@@ -237,7 +237,8 @@ static inline void template_patch_size_be(template_state_t *state,
 }
 
 /**
- * Patch the length field using DER encoding (reserving 3 bytes), and shift the content if needed.
+ * Patch the length field using DER encoding (reserving 3 bytes), and shift the
+ * content if needed.
  *
  * @param state Pointer to the template engine state.
  * @param memo The memorized location from `template_save_pos`.

--- a/sw/device/silicon_creator/lib/cert/template.h
+++ b/sw/device/silicon_creator/lib/cert/template.h
@@ -219,6 +219,11 @@ static inline template_pos_t template_save_pos(template_state_t *state,
 void template_patch_size_be_impl(template_pos_t memo, uint8_t *out_end);
 
 /**
+ * Private implementation of `template_patch_size_der`.
+ */
+uint8_t* template_patch_size_der_impl(template_pos_t memo, uint8_t *out_end);
+
+/**
  * Add the actual output size after the memo to the patch location.
  *
  * The function will perform addition as BE u16 (i.e. mod 65536).
@@ -229,6 +234,17 @@ void template_patch_size_be_impl(template_pos_t memo, uint8_t *out_end);
 static inline void template_patch_size_be(template_state_t *state,
                                           template_pos_t memo) {
   template_patch_size_be_impl(memo, state->out_end);
+}
+
+/**
+ * Patch the length field using DER encoding (reserving 3 bytes), and shift the content if needed.
+ *
+ * @param state Pointer to the template engine state.
+ * @param memo The memorized location from `template_save_pos`.
+ */
+static inline void template_patch_size_der(template_state_t *state,
+                                           template_pos_t memo) {
+  state->out_end = template_patch_size_der_impl(memo, state->out_end);
 }
 
 /**

--- a/sw/host/ot_certs/src/asn1/codegen.rs
+++ b/sw/host/ot_certs/src/asn1/codegen.rs
@@ -60,6 +60,8 @@ enum CodeChunk {
     ConstBytes(Vec<u8>),
     // Patch the last two bytes with length delta.
     SizePatchMemo(i16),
+    // Patch the length field using DER encoding (reserving 3 bytes).
+    DerSizePatchMemo,
     // Create a new nested block with left curly brace.
     OpenBlock,
     // Close a nested block. It should be paired with OpenBlock.
@@ -72,6 +74,7 @@ impl CodeChunk {
             CodeChunk::Code(_) => false,
             CodeChunk::ConstBytes(_) => true,
             CodeChunk::SizePatchMemo(_) => true,
+            CodeChunk::DerSizePatchMemo => true,
             CodeChunk::OpenBlock => true,
             CodeChunk::CloseBlock => true,
         }
@@ -158,6 +161,16 @@ impl Codegen<'_> {
                             output.push_str(&format!(
                                 "
                                     /* Size patch with delta {delta} */
+                                    template_pos_t memo = template_save_pos(&state, {patch_offset});
+                                "
+                            ));
+                        }
+                        CodeChunk::DerSizePatchMemo => {
+                            // Always 3 bytes reserved for DER patch.
+                            let patch_offset = nbytes - 3;
+                            output.push_str(&format!(
+                                "
+                                    /* DER Size patch memo */
                                     template_pos_t memo = template_save_pos(&state, {patch_offset});
                                 "
                             ));
@@ -279,26 +292,16 @@ impl Codegen<'_> {
     }
 
     /// Get the placeholder for length octet encoded with DER.
-    fn get_size_placeholder(min_size: usize, max_size: usize) -> Result<Vec<u8>> {
-        // DER requires the length octet encoded in minimum bytes.
-        let tag_size = Self::tag_size(max_size);
-        ensure!(
-            Self::tag_size(min_size) == tag_size,
-            "Var-sized length octet is not supported,\
-             max={max_size},\
-             min={min_size}"
-        );
-
+    fn get_size_placeholder(size: usize) -> Vec<u8> {
         let mut len_enc = Vec::<u8>::new();
-        if max_size <= 0x7f {
+        if size <= 0x7f {
             len_enc.push(0);
         } else {
-            let nbytes = Self::tag_size(max_size) - 2;
+            let nbytes = Self::tag_size(size) - 2;
             len_enc.push(0x80 | (nbytes as u8));
             len_enc.extend(std::iter::repeat(0).take(nbytes));
         }
-
-        Ok(len_enc)
+        len_enc
     }
 
     /// Return the maximum size of ASN1 tag, ie the tag itself, the length.
@@ -794,9 +797,15 @@ impl Builder for Codegen<'_> {
         let max_size: usize = self.max_out_size - old_max_size;
 
         // Generate size patching code.
-        let len_enc = Self::get_size_placeholder(min_size, max_size)?;
-        self.min_out_size += len_enc.len();
-        self.max_out_size += len_enc.len();
+        let len_enc_min = Self::get_size_placeholder(min_size);
+        let len_enc_max = Self::get_size_placeholder(max_size);
+
+        // Calculate size bounds updates.
+        let use_der_patch = min_size != max_size && len_enc_min.len() != len_enc_max.len();
+        let reserved_max_len = if use_der_patch { 3 } else { len_enc_max.len() };
+
+        self.min_out_size += len_enc_min.len();
+        self.max_out_size += reserved_max_len;
 
         if min_size == max_size {
             self.output[len_idx].comment = Some(format!("Length of fixed-sized {tag_name}"));
@@ -822,15 +831,30 @@ impl Builder for Codegen<'_> {
             let len_enc = Der::encode_size(max_size);
             self.output[len_idx].code = CodeChunk::ConstBytes(len_enc);
             // The memo placeholder is left empty / no-op in this branch.
+        } else if use_der_patch {
+            // Use DER patch. Always reserve 3 bytes.
+            let len_enc = vec![0x82, 0x00, 0x00];
+
+            self.output[len_idx].comment = Some(format!(
+                "Length of {tag_name} between {min_size} ~ {max_size} (DER patch)"
+            ));
+            self.output[len_idx].code = CodeChunk::ConstBytes(len_enc);
+
+            self.output[memo_idx] = CodeChunkWithComment {
+                code: CodeChunk::DerSizePatchMemo,
+                comment: Some(format!("Start of {tag_name}")),
+            };
+            self.push_chunk(
+                CodeChunk::Code("template_patch_size_der(&state, memo);\n".to_string()),
+                Some(format!("End of {tag_name}")),
+            );
         } else {
-            /* var-sized tag */
+            // Equal-size var-sized
             self.output[len_idx].comment = Some(format!(
                 "Length of {tag_name} between {min_size} ~ {max_size}"
             ));
+            self.output[len_idx].code = CodeChunk::ConstBytes(len_enc_max);
 
-            self.output[len_idx].code = CodeChunk::ConstBytes(len_enc);
-
-            // Add the memo statement.
             self.output[memo_idx] = CodeChunkWithComment {
                 code: CodeChunk::SizePatchMemo(-2),
                 comment: Some(format!("Start of {tag_name}")),

--- a/sw/host/ot_certs/tests/generic.hjson
+++ b/sw/host/ot_certs/tests/generic.hjson
@@ -97,7 +97,7 @@
         }
         tpm_vendor: {
             type: "string",
-            exact-size: 100,
+            range-size: [10, 150],
         }
         tpm_model: {
             type: "string",


### PR DESCRIPTION
This commit introduces support for patching variable-length fields using standard DER length encoding, enabling the encoding of variables with a wide range of size constraints. This is a prerequisite for unifying the ECDSA and MLDSA variants into a single template.

Previously, the code generator only supported cases where the inferred minimum and maximum sizes resulted in the 
same DER length encoding size. For example:
* Same: min = 0x10 (encoded as h'10), max = 0x20 (encoded as h'20)
* Differ: min = 0x10 (encoded as h'10), max = 0x200 (encoded as h'820200)


With this change, a `template_patch_size_der` instruction is generated when they differ.

At runtime, this instruction writes the appropriate DER length field (1, 2, or 3 bytes) and shifts subsequent encoded bytes backward in the buffer if fewer than 3 bytes are used.

This change does not impact existing certificate templates; the code generator will continue to emit the more efficient `template_patch_size_be` instruction where applicable. Emitting the DER size patch increases the binary footprint by approximately 100 bytes.