### PR TITLE
[ci] Disable CW310 in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,15 +352,6 @@ jobs:
         with:
           artifact-name: verilator_earlgrey-test-results
 
-  chip_earlgrey_cw310_hyperdebug:
-    name: Earl Grey for CW310 Hyperdebug
-    needs: quick_lint
-    uses: ./.github/workflows/bitstream.yml
-    secrets: inherit
-    with:
-      top_name: earlgrey
-      design_suffix: cw310_hyperdebug
-
   chip_earlgrey_cw340:
     name: Earl Grey for CW340
     needs: quick_lint
@@ -374,7 +365,6 @@ jobs:
     name: Cache bitstreams to GCP
     runs-on: ubuntu-22.04
     needs:
-      - chip_earlgrey_cw310_hyperdebug
       - chip_earlgrey_cw340
     steps:
       - name: Skipped message
@@ -393,7 +383,7 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         uses: ./.github/actions/download-partial-build-bin
         with:
-          job-patterns: chip_earlgrey_{cw310,cw310_hyperdebug,cw340}
+          job-patterns: chip_earlgrey_cw340
       - name: Create bitstream cache archive
         if: ${{ github.event_name != 'pull_request' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,7 +417,6 @@ jobs:
     name: Schedule FPGA jobs
     runs-on: ubuntu-22.04
     outputs:
-      jobs_cw310: ${{ steps.schedule.outputs.jobs_cw310 }}
       jobs_cw340: ${{ steps.schedule.outputs.jobs_cw340 }}
     steps:
       - uses: actions/checkout@v6
@@ -437,9 +436,6 @@ jobs:
             --test_tag_filters=-manual,-broken,-skip_in_ci,-slow_test,fpga \
             "tests(//sw/... union @manufacturer_test_hooks//...)")
           echo "$JOBS"
-          echo 'jobs_cw310<<EOF' >> "$GITHUB_OUTPUT"
-          echo "$JOBS" | jq '[.[] | select(.board == "cw310")]' >> "$GITHUB_OUTPUT"
-          echo EOF >> "$GITHUB_OUTPUT"
           echo 'jobs_cw340<<EOF' >> "$GITHUB_OUTPUT"
           echo "$JOBS" | jq '[.[] | select(.board == "cw340")]' >> "$GITHUB_OUTPUT"
           echo EOF >> "$GITHUB_OUTPUT"
@@ -448,27 +444,6 @@ jobs:
         with:
             name: fpga_jobs
             path: ${{ steps.schedule.outputs.jobs_dir }}
-
-  execute_fpga_cw310_jobs:
-    name: ${{ matrix.name }}
-    needs:
-      - schedule_fpga_jobs
-      - quick_lint
-      - chip_earlgrey_cw310_hyperdebug
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.schedule_fpga_jobs.outputs.jobs_cw310) }}
-    uses: ./.github/workflows/fpga.yml
-    if: ${{ github.event_name != 'merge_group' }}
-    secrets: inherit
-    with:
-      job_name: ${{ matrix.id }}
-      bitstream: chip_earlgrey_cw310_hyperdebug
-      board: ${{ matrix.board }}
-      interface: hyper310
-      artifact: fpga_jobs
-      target_file: ${{ matrix.target_file }}
 
   execute_fpga_cw340_jobs:
     name: ${{ matrix.name }}


### PR DESCRIPTION
This PR disables the CW310 tests in CI and stops building and caching its bitstreams. This is necessary for the move to only the CW340 due to resource constraints of the CW310.