### PR TITLE
[rtl,conn] Calculate ResetWidths differently in rstmgr_pkg.sv

### DIFF
--- a/hw/ip_templates/rstmgr/rtl/rstmgr_pkg.sv.tpl
+++ b/hw/ip_templates/rstmgr/rtl/rstmgr_pkg.sv.tpl
@@ -70,7 +70,8 @@ package rstmgr_pkg;
   };
 
   // Enumeration for pwrmgr hw reset inputs
-  localparam int ResetWidths = $clog2(rstmgr_reg_pkg::NumTotalResets);
+  import rstmgr_reg_pkg::NumTotalResets;
+  localparam int ResetWidths = $clog2(NumTotalResets);
   typedef enum logic [ResetWidths-1:0] {
     ReqPeriResetIdx[0:${len(peri_reqs)-1}],
     % for req in (int_reqs + debug_reqs):

--- a/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_pkg.sv
@@ -66,7 +66,8 @@ package rstmgr_pkg;
   };
 
   // Enumeration for pwrmgr hw reset inputs
-  localparam int ResetWidths = $clog2(rstmgr_reg_pkg::NumTotalResets);
+  import rstmgr_reg_pkg::NumTotalResets;
+  localparam int ResetWidths = $clog2(NumTotalResets);
   typedef enum logic [ResetWidths-1:0] {
     ReqPeriResetIdx[0:1],
     ReqMainPwrResetIdx,

--- a/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr_pkg.sv
@@ -95,7 +95,8 @@ package rstmgr_pkg;
   };
 
   // Enumeration for pwrmgr hw reset inputs
-  localparam int ResetWidths = $clog2(rstmgr_reg_pkg::NumTotalResets);
+  import rstmgr_reg_pkg::NumTotalResets;
+  localparam int ResetWidths = $clog2(NumTotalResets);
   typedef enum logic [ResetWidths-1:0] {
     ReqPeriResetIdx[0:1],
     ReqMainPwrResetIdx,

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr_pkg.sv
@@ -76,7 +76,8 @@ package rstmgr_pkg;
   };
 
   // Enumeration for pwrmgr hw reset inputs
-  localparam int ResetWidths = $clog2(rstmgr_reg_pkg::NumTotalResets);
+  import rstmgr_reg_pkg::NumTotalResets;
+  localparam int ResetWidths = $clog2(NumTotalResets);
   typedef enum logic [ResetWidths-1:0] {
     ReqPeriResetIdx[0:0],
     ReqMainPwrResetIdx,


### PR DESCRIPTION
The code is obviously equivalent, but the Jasper tool (v2024.06) throws an elaboration error with the old version.

My suspicion is that we're running into a weird corner case in the tool code, and it can't figure out that the value being assigned to the parameter is a constant. Evaluating the value in two steps seems to bypass the problem.

To reproduce the error, run:

  dvsim hw/top_earlgrey/formal/chip_conn_cfg.hjson