### PR TITLE
[sw] Port the `stack_utilization_test` to the CW340

### DIFF
--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -585,13 +585,12 @@ genrule(
     """,
 )
 
-opentitan_test(
-    name = "stack_utilization_test",
-    cw310 = fpga_params(
+STACK_UTILIZATION_FPGA_PARAMS = {
+    fpga: fpga_params(
         binaries = {
-            "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_prod_key_0_fpga_cw310_rom_with_fake_keys_signed_bin": "good_a",
-            "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_prod_key_0_fpga_cw310_rom_with_fake_keys_signed_bin": "good_b",
-            "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_prod_key_0_corrupted_fpga_cw310_rom_with_fake_keys_signed_bin": "bad_a",
+            "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_prod_key_0": "good_a",
+            "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_prod_key_0": "good_b",
+            "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_prod_key_0_corrupted_fpga_{}_rom_with_fake_keys_signed_bin".format(fpga): "bad_a",
             ":empty_flash": "empty",
         },
         stack_usage = "STK:[0-9A-Fa-f/]+\r\n",
@@ -646,8 +645,16 @@ opentitan_test(
             --exec="console --non-interactive --exit-success='{stack_usage}' --exit-failure='PASS|FAIL'"
             no-op
         """,
-    ),
+    )
+    for fpga in ("cw310", "cw340")
+}
+
+opentitan_test(
+    name = "stack_utilization_test",
+    cw310 = STACK_UTILIZATION_FPGA_PARAMS["cw310"],
+    cw340 = STACK_UTILIZATION_FPGA_PARAMS["cw340"],
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": "cw310",
+        "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": "cw340",
     },
 )

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -90,6 +90,7 @@ opentitan_test(
         srcs = [":empty_test"],
         exec_env = [
             "//hw/top_earlgrey:fpga_cw310",
+            "//hw/top_earlgrey:fpga_cw340",
             "//hw/top_earlgrey:sim_dv",
             "//hw/top_earlgrey:sim_verilator",
             "//hw/top_darjeeling:sim_dv",
@@ -129,6 +130,7 @@ opentitan_test(
         srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test"],
         exec_env = [
             "//hw/top_earlgrey:fpga_cw310",
+            "//hw/top_earlgrey:fpga_cw340",
             "//hw/top_earlgrey:sim_dv",
             "//hw/top_earlgrey:sim_verilator",
             "//hw/top_darjeeling:sim_dv",
@@ -154,6 +156,7 @@ opentitan_test(
         ecdsa_key = ecdsa_key_by_name(ECDSA_ONLY_KEY_STRUCTS, key),
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
             "//hw/top_earlgrey:sim_dv": None,
             "//hw/top_earlgrey:sim_verilator": None,
             "//hw/top_darjeeling:sim_dv": None,
@@ -201,6 +204,7 @@ opentitan_test(
     for key in SIGVERIFY_LC_KEYS
     for group in [
         "fpga_cw310_rom_with_fake_keys",
+        "fpga_cw340_rom_with_fake_keys",
         "sim_dv",
     ]
 ]
@@ -222,6 +226,7 @@ opentitan_test(
     for key in SIGVERIFY_LC_KEYS
     for group in [
         "fpga_cw310_rom_with_fake_keys",
+        "fpga_cw340_rom_with_fake_keys",
         "sim_dv",
     ]
 ]


### PR DESCRIPTION
See the commit messages for more info - the modularisation is unfortunately a bit more complicated than it needs to be because the corrupted binaries must be generated with a `genrule` and thus don't go through the regular OpenTitan execution environment providers. I don't think there's a cleaner way to handle this case, but please do let me know of any suggestions!

