### PR TITLE
[conn,earlgrey] Fix invalid names in connection assertions

### DIFF
--- a/hw/top_earlgrey/formal/conn_csvs/analog_sigs.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/analog_sigs.csv
@@ -7,7 +7,7 @@
 
 ,NAME,SRC BLOCK,SRC SIGNAL,DEST BLOCK,DEST SIGNAL,,,,,,
 
-CONNECTION, OTP_EXT_VOLT,     , OTP_EXT_VOLT,     top_earlgrey.u_otp_ctrl.u_otp             , ext_voltage_io,
+CONNECTION, OTP_EXT_VOLT,     , OTP_EXT_VOLT,     top_earlgrey.u_otp_macro                  , ext_voltage_h_io,
 CONNECTION, FLASH_TEST_MODE_O,, "{FLASH_TEST_MODE1, FLASH_TEST_MODE0}", top_earlgrey.u_flash_ctrl.u_eflash.u_flash, flash_test_mode_a_io,
 CONNECTION, FLASH_TEST_MODE_I,  top_earlgrey.u_flash_ctrl.u_eflash.u_flash, flash_test_mode_a_io, , "{FLASH_TEST_MODE1, FLASH_TEST_MODE0}",
 CONNECTION, FLASH_TEST_VOLT_O,, FLASH_TEST_VOLT,  top_earlgrey.u_flash_ctrl.u_eflash.u_flash, flash_test_voltage_h_io,

--- a/hw/top_earlgrey/formal/conn_csvs/ast_entropy_src_cfg.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/ast_entropy_src_cfg.csv
@@ -9,6 +9,6 @@
 
 # ast -> entropy_src connectivity
 CONNECTION, AST_ENTROPY_SRC_RNG_VAL, u_ast, rng_val_o, top_earlgrey.u_entropy_src, entropy_src_rng_valid_i
-CONNECTION, AST_ENTROPY_SRC_RNG_B, u_ast, rng_b_o, top_earlgrey.u_entropy_src, entropy_src_rng_bit_i
+CONNECTION, AST_ENTROPY_SRC_RNG_B, u_ast, rng_b_o, top_earlgrey.u_entropy_src, entropy_src_rng_bits_i
 CONNECTION, AST_ENTROPY_SRC_RNG_FIPS, top_earlgrey.u_entropy_src, rng_fips_o, u_ast, rng_fips_i,
 CONNECTION, AST_ENTROPY_SRC_RNG_EN, top_earlgrey.u_entropy_src, entropy_src_rng_enable_o, u_ast, rng_en_i

--- a/hw/top_earlgrey/formal/conn_csvs/ast_infra.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/ast_infra.csv
@@ -40,9 +40,9 @@ CONNECTION, AST_RST_POR_IN,           ,                      POR_N,             
 # Other power related signals
 #################################
 
-CONNECTION, AST_USB_REF_IN,      top_earlgrey.u_usbdev,      usb_ref_pulse_o,           u_ast,                   usb_ref_pulse_i
-CONNECTION, AST_USB_REF_VAL_IN,  top_earlgrey.u_usbdev,      usb_ref_val_o,             u_ast,                   usb_ref_val_i
-CONNECTION, AST_OTP_PWR_SEQ_IN,  top_earlgrey.u_otp_ctrl,    otp_ast_pwr_seq_o,         u_ast,                   otp_power_seq_i
-CONNECTION, AST_MAIN_PD_IN,      top_earlgrey.u_pwrmgr_aon,  pwr_ast_o.main_pd_n,       u_ast,                   main_pd_ni
-CONNECTION, AST_MAIN_ISO_EN_IN,  top_earlgrey.u_pwrmgr_aon,  pwr_ast_o.pwr_clamp_env,   u_ast,                   main_env_iso_en_i
-CONNECTION, AST_OTP_PWR_SEQ_OUT, u_ast,                      otp_power_seq_h_o,         top_earlgrey.u_otp_ctrl, otp_ast_pwr_seq_h_i
+CONNECTION, AST_USB_REF_IN,      top_earlgrey.u_usbdev,      usb_ref_pulse_o,           u_ast,                    usb_ref_pulse_i
+CONNECTION, AST_USB_REF_VAL_IN,  top_earlgrey.u_usbdev,      usb_ref_val_o,             u_ast,                    usb_ref_val_i
+CONNECTION, AST_OTP_PWR_SEQ_IN,  top_earlgrey.u_otp_macro,   pwr_seq_o,                 u_ast,                    otp_power_seq_i
+CONNECTION, AST_MAIN_PD_IN,      top_earlgrey.u_pwrmgr_aon,  pwr_ast_o.main_pd_n,       u_ast,                    main_pd_ni
+CONNECTION, AST_MAIN_ISO_EN_IN,  top_earlgrey.u_pwrmgr_aon,  pwr_ast_o.pwr_clamp_env,   u_ast,                    main_env_iso_en_i
+CONNECTION, AST_OTP_PWR_SEQ_OUT, u_ast,                      otp_power_seq_h_o,         top_earlgrey.u_otp_macro, pwr_seq_h_i

--- a/hw/top_earlgrey/formal/conn_csvs/ast_mem_cfg.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/ast_mem_cfg.csv
@@ -21,23 +21,23 @@ CONNECTION, AST_DFT_SPI_DEVICE_RAM_2P_CFG, u_ast.u_ast_dft, "{12'h0, dpram_rml_o
 
 # Single port RAMs.
 # To otbn.
-CONNECTION, AST_DFT_OTBN_IMEM_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_otbn.u_imem.u_prim_ram_1p_adv.u_mem, cfg_i
-CONNECTION, AST_DFT_OTBN_DMEM_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_otbn.u_dmem.u_prim_ram_1p_adv.u_mem, cfg_i
+CONNECTION, AST_DFT_OTBN_IMEM_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_otbn.u_imem.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i
+CONNECTION, AST_DFT_OTBN_DMEM_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_otbn.u_dmem.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i
 
 # To rv_core_ibex.
-CONNECTION, AST_DFT_RV_CORE_IBEX_TAG0_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[0].gen_scramble_rams.tag_bank.u_prim_ram_1p_adv.u_mem, cfg_i
-CONNECTION, AST_DFT_RV_CORE_IBEX_TAG1_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[1].gen_scramble_rams.tag_bank.u_prim_ram_1p_adv.u_mem, cfg_i
-CONNECTION, AST_DFT_RV_CORE_IBEX_DATA0_RAM_1P_CFG, u_ast.u_ast_dft,"{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[0].gen_scramble_rams.data_bank.u_prim_ram_1p_adv.u_mem, cfg_i
-CONNECTION, AST_DFT_RV_CORE_IBEX_DATA1_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[1].gen_scramble_rams.data_bank.u_prim_ram_1p_adv.u_mem, cfg_i
+CONNECTION, AST_DFT_RV_CORE_IBEX_TAG0_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[0].gen_scramble_rams.tag_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i
+CONNECTION, AST_DFT_RV_CORE_IBEX_TAG1_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[1].gen_scramble_rams.tag_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i
+CONNECTION, AST_DFT_RV_CORE_IBEX_DATA0_RAM_1P_CFG, u_ast.u_ast_dft,"{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[0].gen_scramble_rams.data_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i
+CONNECTION, AST_DFT_RV_CORE_IBEX_DATA1_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[1].gen_scramble_rams.data_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i
 
 # To sram_ctrl (main).
-CONNECTION, AST_DFT_SRAM_MAIN_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_sram_ctrl_main.u_prim_ram_1p_scr.u_prim_ram_1p_adv.u_mem, cfg_i
+CONNECTION, AST_DFT_SRAM_MAIN_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_sram_ctrl_main.u_prim_ram_1p_scr.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i
 
 # To sram_ctrl (ret).
-CONNECTION, AST_DFT_SRAM_RET_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_sram_ctrl_ret_aon.u_prim_ram_1p_scr.u_prim_ram_1p_adv.u_mem, cfg_i
+CONNECTION, AST_DFT_SRAM_RET_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_sram_ctrl_ret_aon.u_prim_ram_1p_scr.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i
 
 # To rom.
 CONNECTION, AST_DFT_ROM_CFG, u_ast.u_ast_dft, sprom_rm_o,top_earlgrey.u_rom_ctrl.gen_rom_scramble_enabled.u_rom.u_rom.u_prim_rom, cfg_i
 
 # To usbdev.
-CONNECTION, AST_DFT_USBDEV_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_usbdev.gen_no_stubbed_memory.u_memory_1p.u_mem, cfg_i
+CONNECTION, AST_DFT_USBDEV_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_usbdev.gen_no_stubbed_memory.u_memory_1p.gen_ram_inst[0].u_mem, cfg_i

--- a/hw/top_earlgrey/formal/conn_csvs/ast_otp.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/ast_otp.csv
@@ -7,7 +7,7 @@
 
 ,NAME,SRC BLOCK,SRC SIGNAL,DEST BLOCK,DEST SIGNAL,,,,,,
 
-CONNECTION, OTP_AST_OBS_CTRL, top_earlgrey.u_otp_ctrl.u_otp, otp_obs_o, u_ast, otp_obs_i
-CONNECTION, AST_OTP_OBS_CTRL, u_ast, obs_ctrl_o, top_earlgrey.u_otp_ctrl.u_otp, obs_ctrl_i
-CONNECTION, AST_OTP_PWR_SEQ_H, u_ast, otp_power_seq_h_o, top_earlgrey.u_otp_ctrl.u_otp, pwr_seq_h_i
-CONNECTION, OTP_AST_PWR_SEQ, top_earlgrey.u_otp_ctrl.u_otp, pwr_seq_o, u_ast, otp_power_seq_i
+CONNECTION, OTP_AST_OBS_CTRL,  top_earlgrey.u_otp_macro, otp_obs_o,         u_ast,                    otp_obs_i
+CONNECTION, AST_OTP_OBS_CTRL,  u_ast,                    obs_ctrl_o,        top_earlgrey.u_otp_macro, obs_ctrl_i
+CONNECTION, AST_OTP_PWR_SEQ_H, u_ast ,                   otp_power_seq_h_o, top_earlgrey.u_otp_macro, pwr_seq_h_i
+CONNECTION, OTP_AST_PWR_SEQ,   top_earlgrey.u_otp_macro, pwr_seq_o,         u_ast,                    otp_power_seq_i

--- a/hw/top_earlgrey/formal/conn_csvs/ast_scanmode.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/ast_scanmode.csv
@@ -12,7 +12,7 @@ CONNECTION, AST_SCANMODE_PADRING,      u_ast, dft_scan_md_o, u_padring,         
 CONNECTION, AST_SCANMODE_CLKMGR,       u_ast, dft_scan_md_o, top_earlgrey.u_clkmgr_aon,   scanmode_i
 CONNECTION, AST_SCANMODE_FLASH_CTRL,   u_ast, dft_scan_md_o, top_earlgrey.u_flash_ctrl,   scanmode_i
 CONNECTION, AST_SCANMODE_LC_CTRL,      u_ast, dft_scan_md_o, top_earlgrey.u_lc_ctrl,      scanmode_i
-CONNECTION, AST_SCANMODE_OTP_CTRL,     u_ast, dft_scan_md_o, top_earlgrey.u_otp_ctrl,     scanmode_i
+CONNECTION, AST_SCANMODE_OTP_CTRL,     u_ast, dft_scan_md_o, top_earlgrey.u_otp_macro,    scanmode_i
 CONNECTION, AST_SCANMODE_PINMUX,       u_ast, dft_scan_md_o, top_earlgrey.u_pinmux_aon,   scanmode_i
 CONNECTION, AST_SCANMODE_RSTMGR,       u_ast, dft_scan_md_o, top_earlgrey.u_rstmgr_aon,   scanmode_i
 CONNECTION, AST_SCANMODE_RV_CORE_IBEX, u_ast, dft_scan_md_o, top_earlgrey.u_rv_core_ibex, scanmode_i

--- a/hw/top_earlgrey/formal/conn_csvs/lc_ctrl_broadcast.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/lc_ctrl_broadcast.csv
@@ -36,7 +36,7 @@ CONNECTION, LC_HW_DEBUG_EN_RV_DM,          top_earlgrey.u_lc_ctrl, lc_hw_debug_e
 CONNECTION, LC_HW_DEBUG_EN_CSRNG,          top_earlgrey.u_lc_ctrl, lc_hw_debug_en_o, top_earlgrey.u_csrng,             lc_hw_debug_en_i
 
 # Verify that lc_ctrl's lc_dft_en_o signal is correctly connected to IPs.
-CONNECTION, LC_DFT_EN_OTP,    top_earlgrey.u_lc_ctrl, lc_dft_en_o, top_earlgrey.u_otp_ctrl,   lc_dft_en_i
+CONNECTION, LC_DFT_EN_OTP,    top_earlgrey.u_lc_ctrl, lc_dft_en_o, top_earlgrey.u_otp_macro,  lc_dft_en_i
 CONNECTION, LC_DFT_EN_PWRMGR, top_earlgrey.u_lc_ctrl, lc_dft_en_o, top_earlgrey.u_pwrmgr_aon, lc_dft_en_i
 CONNECTION, LC_DFT_EN_PINMUX, top_earlgrey.u_lc_ctrl, lc_dft_en_o, top_earlgrey.u_pinmux_aon, lc_dft_en_i
 CONNECTION, LC_DFT_EN_AST,    top_earlgrey.u_lc_ctrl, lc_dft_en_o, u_ast,                     lc_dft_en_i

--- a/hw/top_earlgrey/formal/conn_csvs/otp_lc_vendor_test.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/otp_lc_vendor_test.csv
@@ -8,5 +8,5 @@
 ,NAME,SRC BLOCK,SRC SIGNAL,DEST BLOCK,DEST SIGNAL,,,,,,
 
 # Verify the vendor_test connectivities.
-CONNECTION, LC_OTP_VENDOR_TEST_CTRL,   top_earlgrey.u_lc_ctrl,  lc_otp_vendor_test_o, top_earlgrey.u_otp_ctrl, lc_otp_vendor_test_i
-CONNECTION, LC_OTP_VENDOR_TEST_STATUS, top_earlgrey.u_otp_ctrl, lc_otp_vendor_test_o, top_earlgrey.u_lc_ctrl,  lc_otp_vendor_test_i
+CONNECTION, LC_OTP_VENDOR_TEST_CTRL,   top_earlgrey.u_lc_ctrl,   lc_otp_vendor_test_o, top_earlgrey.u_otp_macro, test_i
+CONNECTION, LC_OTP_VENDOR_TEST_STATUS, top_earlgrey.u_otp_macro, test_o,               top_earlgrey.u_lc_ctrl,   lc_otp_vendor_test_i


### PR DESCRIPTION
Fix various connectivity checks that have been broken by development since the last earlgrey tapeout.

These tests can be run with:

    dvsim hw/top_earlgrey/formal/chip_conn_cfg.hjson

Before this commit, they failed to elaborate because quite a lot of signal names had changed (from a change that moved the OTP macro and then two different port changes related to Darjeeling).

This commit gets things building again. The tests don't actually *pass* (two different counterexamples), but fixing that will be a separate commit.

The changes involved were:

+ Commit 2b9e4b3 moved the OTP macro out of otp_ctrl, which broke the following connections:

  - In analog_sigs.csv, there is a check for the connection of an external voltage signal (OTP_EXT_VOLT) to the macro.

  - In ast_infra.csv, there is a check on the path of a power sequencing signal from u_ast to the OTP macro.

  - In ast_scanmode.csv, there is a check for the connection of the scanmode DFT signal from u_ast to the OTP macro.

  - In ast_otp.csv, there are checks for four signals ebetween the AST and the OTP macro.

  - In lc_ctrl_broadcast.csv, there is a check that the DFT enable signal from lc_ctrl is passed properly to the OTP macro.

  - In otp_lc_vendor_test.csv, there is also a check for a separate connection from lc_ctrl to the OTP macro.

+ Commit 4befb49 changed the way entropy bits are connected from the TRNG in the u_ast to the entropy_src. It had a typo (s/bit/bits/). This connection was tracked in ast_entropy_src_cfg.csv.

+ Commit aea12b7 (adding memory tiling for Darjeeling) changed the path to the memories inside various blocks (OTBN, Ibex, usbdev). The cfg connections for these memories are tracked in ast_mem_cfg.csv.