### PR TITLE
[dv] Remove unused dv_utils_pkg::get_masked_data

### DIFF
--- a/hw/dv/sv/dv_utils/dv_utils_pkg.sv
+++ b/hw/dv/sv/dv_utils/dv_utils_pkg.sv
@@ -143,20 +143,6 @@ package dv_utils_pkg;
     return report_server.get_severity_count(UVM_FATAL) > 0;
   endfunction
 
-  // get masked data based on provided byte mask; if csr reg handle is provided (optional) then
-  // masked bytes from csr's mirrored value are returned, else masked bytes are 0's
-  function automatic bit [bus_params_pkg::BUS_DW-1:0]
-      get_masked_data(bit [bus_params_pkg::BUS_DW-1:0] data,
-                      bit [bus_params_pkg::BUS_DBW-1:0] mask,
-                      uvm_reg csr = null);
-    bit [bus_params_pkg::BUS_DW-1:0] csr_data;
-    csr_data = (csr != null) ? csr.get_mirrored_value() : '0;
-    get_masked_data = data;
-    foreach (mask[i]) begin
-      if (~mask[i]) get_masked_data[i * 8 +: 8] = csr_data[i * 8 +: 8];
-    end
-  endfunction
-
   // create a sequence by name and return the handle of uvm_sequence
   function automatic uvm_sequence create_seq_by_name(string seq_name);
     uvm_object      obj;


### PR DESCRIPTION
This function has not been used since the start of the repository's development history.