### PR TITLE
[dv] Make dv_base_reg depend on prim:mubi_pkg, not prim:mubi

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg.core
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg.core
@@ -9,7 +9,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:dv:dv_utils
-      - lowrisc:prim:mubi
+      - lowrisc:prim:mubi_pkg
     files:
       - dv_base_reg_pkg.sv
       - csr_excl_item.sv: {is_include_file: true}


### PR DESCRIPTION
The previous version meant that this DV code depended on the RTL implementation of some mubi functions, which isn't the right thing.