### PR TITLE
[crypto/kats] Add stateful execution

### DIFF
--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -3,6 +3,7 @@
 This page is intended for users of the OpenTitan cryptographic library.
 The library is written in C and uses OpenTitan's hardware blocks for accelerated cryptography.
 It generally attempts to minimize code size and protect against side-channel and fault-injection attacks, including by physically present attackers.
+For a secure setting, the cryptolib should be the only software in the firmware authorized to interact with the crypto blocks in OpenTitan.
 
 This page:
 - Lists a quick reference for [supported algorithms](#supported-algorithms)
@@ -39,6 +40,7 @@ For more details, see later sections (links in the "category" column).
 
 Before using the cryptolib, the user should initialize the system with the dedicated `otcrypto_init` function.
 Depending on the provided `security_level` (`kOtcryptoKeySecurityLevelLow`, `kOtcryptoKeySecurityLevelMedium`, `kOtcryptoKeySecurityLevelHigh`), the initialization function enables certain countermeasures (e.g., the Ibex dummy instruction [feature][dummy-instruction]).
+The function also takes a pointer to an `otcrypto_state_t` structure, which is used to track the library's internal state (such as KATs and integrity checks) across calls.
 Please note that this function only can be called from the machine (M) mode privilege level as it writes to system registers.
 
 {{#header-snippet sw/device/lib/crypto/include/config.h otcrypto_init }}
@@ -72,11 +74,42 @@ This specialized target hashes the library's contents and fuses the hash onto th
 You can trigger this build using the `--config=crypto_fips_all` Bazel flag.
 The exact functions included in this blob are strictly governed by an allowlist configuration file located in `//sw/device/lib/crypto/configs`.
 
-Because the FIPS blob is relocatable and contiguous, developers contributing to the cryptolib must adhere to strict memory and structural constraints:
+Because the FIPS blob is relocatable and contiguous, developers contributing to the cryptolib must adhere to strict memory and structural constraints.
 
-*   **No `.bss` or `.data` Sections:** The linker script enforces that the `.bss`, `.sbss`, `.data`, and `.sdata2` sections have a size of exactly 0. You **cannot** use static (non-const) variables or uninitialized global variables. All data must reside in `.text`, `.rodata`, or `.srodata`.
+### Cryptolib Contributor Constraints
+
+*   **No `.bss` or `.data` sections:** The linker script enforces that the `.bss`, `.sbss`, `.data`, and `.sdata2` sections have a size of exactly 0.
+You **cannot** use static (non-const) variables or uninitialized global variables.
+All data must reside in `.text`, `.rodata`, or `.srodata`.
 *   **Strict Position Independence:** Code must be completely position-independent (PIC) and cannot rely on a Global Offset Table (GOT).
-*   **No Jump Tables:** The library is explicitly compiled with `-fno-jump-tables`. This forces the compiler to handle `switch` statements without generating position-dependent jump tables.
+*   **No Jump Tables:** The library is explicitly compiled with `-fno-jump-tables`.
+This forces the compiler to handle `switch` statements without generating position-dependent jump tables.
+*   **No Function Pointer Arrays:** Do not use `static const` arrays of function pointers (such as execution dispatch tables).
+The compiler will bake absolute memory addresses into the `.rodata` section.
+Instead, use sequential `if` statements or `switch` blocks, which force the compiler to generate safe, PC-relative jump instructions (`jal` or `auipc`).
+*   **Dynamic Pointer Initialization:** When initializing structs that contain pointers (like `otcrypto_byte_buf_t` or `otcrypto_unblinded_key_t`) with global constant arrays, **do not** use static curly-brace initialization or macros like `OTCRYPTO_MAKE_BUF`.
+The GCC optimizer will trap this and embed absolute addresses into `.rodata`.
+Instead, construct these structs dynamically at runtime using the inline builder functions provided in `integrity.h` (e.g., `otcrypto_make_const_byte_buf()`).
+This forces the compiler to calculate the pointer offsets safely on the stack.
+
+### Stateful Known Answer Tests (KATs)
+
+In the FIPS build, cryptographic operations are gated by Power-On Self-Tests (POSTs), Known Answer Tests (KATs), and self-integrity checks.
+The cryptolib handles these seamlessly, but internal contributors and host applications must observe the following rules to prevent lockups and memory faults:
+
+*   **Run-Once State Tracking:** To minimize latency, KATs execute lazily upon the first invocation of a module.
+Because the cryptolib cannot maintain its own `.bss` section to track this execution state, the ledger relies on a host-provided state pointer passed during `otcrypto_init()`.
+*   **Hardware Pointer Stashing:** To avoid passing this pointer through every internal crypto function call, the cryptolib splits and stashes the 32-bit state address inside two unused 16-bit threshold registers within the hardware's `ENTROPY_SRC` block (`ENTROPY_SRC_EXTHT_HI_THRESHOLDS` and `ENTROPY_SRC_EXTHT_LO_THRESHOLDS`).
+These registers do not influence the entropy source's health tests.
+*   **Register Integrity:** Never manually configure or overwrite the `ENTROPY_SRC_EXTHT_HI_THRESHOLDS` or `ENTROPY_SRC_EXTHT_LO_THRESHOLDS` registers in the entropy source after initialization.
+Doing so will corrupt the stashed pointer.
+*   **Host Memory Stability:** The host firmware calling `otcrypto_init()` must ensure that the memory address backing the KAT state is globally stable.
+Do not pass a stack-allocated variable unless its scope is guaranteed to outlive all cryptographic operations.
+*   **Self-Integrity Check:** In FIPS mode, `otcrypto_init()` performs a self-integrity check by hashing the library's binary blob and comparing it to a pre-calculated hash.
+The result is stored in the tracking state.
+Subsequent operations verify that this check has passed, returning a recoverable error (`kOtcryptoStatusValueInternalError`) if it has not.
+*   **Locked State:** If the self-integrity check fails, or if any subsequent KAT fails, the library enters a locked state.
+Once locked, the library is disabled, and all subsequent cryptographic operations will immediately return a fatal error (`kOtcryptoStatusValueFatalError`), this is only reverted by resetting the chip.
 
 ### Testing PIC Compliance
 

--- a/sw/device/lib/crypto/BUILD
+++ b/sw/device/lib/crypto/BUILD
@@ -14,7 +14,9 @@ cc_library(
     name = "otcrypto_api",
     defines =
         select({
-            "//sw/device/lib/crypto/configs:hashed": ["HASH_SELF_CHECK_ENABLE"],
+            "//sw/device/lib/crypto/configs:hashed": [
+                "FIPS_MODE",
+            ],
             "//conditions:default": [],
         }),
     deps = [
@@ -31,6 +33,7 @@ cc_library(
         "//sw/device/lib/crypto/impl:hkdf",
         "//sw/device/lib/crypto/impl:hmac",
         "//sw/device/lib/crypto/impl:integrity",
+        "//sw/device/lib/crypto/impl:kats",
         "//sw/device/lib/crypto/impl:kdf_ctr",
         "//sw/device/lib/crypto/impl:key_transport",
         "//sw/device/lib/crypto/impl:kmac",
@@ -39,6 +42,7 @@ cc_library(
         "//sw/device/lib/crypto/impl:self_integrity",
         "//sw/device/lib/crypto/impl:sha2",
         "//sw/device/lib/crypto/impl:sha3",
+        "//sw/device/lib/crypto/impl:state",
         "//sw/device/lib/crypto/include:datatypes",
     ],
 )
@@ -56,6 +60,10 @@ opentitan_binary_blob(
         "//sw/device/lib/base:memory",
         "//sw/device/lib/runtime:log",
     ],
+    target_compatible_with = select({
+        "//sw/device/lib/crypto/configs:crypto_fips_all": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     # We add the compiler option -fno-jump-tables to prevent the compiler making the code position dependent.
     # Minsize is added to reduce code size.
     transitive_features = [
@@ -131,4 +139,5 @@ pkg_tar(
 filegroup(
     name = "otcrypto_binary_blob_inspection",
     srcs = [":otcrypto_binary_blob_api"],
+    tags = ["manual"],
 )

--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -747,7 +747,7 @@ static void entropy_src_stop(void) {
  *
  * See hw/ip/csrng/doc/_index.md#module-enable-and-disable for more details.
  */
-static void entropy_complex_stop_all(void) {
+void entropy_complex_stop_all(void) {
   edn_stop(kBaseEdn0);
   edn_stop(kBaseEdn1);
   abs_mmio_write32(kBaseCsrng + CSRNG_CTRL_REG_OFFSET, CSRNG_CTRL_REG_RESVAL);
@@ -838,8 +838,6 @@ static status_t entropy_src_configure(const entropy_src_config_t *config) {
   SET_FIPS_THRESH(BUCKET, config->bucket_threshold);
   SET_FIPS_THRESH(MARKOV_HI, config->markov_hi_threshold);
   SET_FIPS_THRESH(MARKOV_LO, config->markov_lo_threshold);
-  SET_FIPS_THRESH(EXTHT_HI, config->extht_hi_threshold);
-  SET_FIPS_THRESH(EXTHT_LO, config->extht_lo_threshold);
 
   HARDENED_CHECK_EQ(
       abs_mmio_read32(kBaseEntropySrc + ENTROPY_SRC_ENTROPY_CONTROL_REG_OFFSET),
@@ -977,8 +975,6 @@ static status_t entropy_src_check(const entropy_src_config_t *config) {
   VERIFY_FIPS_THRESH(BUCKET, config->bucket_threshold);
   VERIFY_FIPS_THRESH(MARKOV_HI, config->markov_hi_threshold);
   VERIFY_FIPS_THRESH(MARKOV_LO, config->markov_lo_threshold);
-  VERIFY_FIPS_THRESH(EXTHT_HI, config->extht_hi_threshold);
-  VERIFY_FIPS_THRESH(EXTHT_LO, config->extht_lo_threshold);
 
   return OTCRYPTO_OK;
 }
@@ -1022,9 +1018,7 @@ static status_t edn_check(const edn_config_t *config) {
   return OTCRYPTO_RECOV_ERR;
 }
 
-status_t entropy_complex_init(hardened_bool_t fips) {
-  entropy_complex_stop_all();
-
+status_t entropy_complex_start(hardened_bool_t fips) {
   const entropy_complex_config_t *config =
       &kEntropyComplexConfigs[kEntropyComplexConfigIdFipsContinuous];
 
@@ -1066,6 +1060,11 @@ status_t entropy_complex_check(hardened_bool_t fips) {
   HARDENED_TRY(csrng_check());
   HARDENED_TRY(edn_check(&config->edn0));
   return edn_check(&config->edn1);
+}
+
+status_t entropy_complex_init(hardened_bool_t fips) {
+  entropy_complex_stop_all();
+  return entropy_complex_start(fips);
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/crypto/drivers/entropy.h
+++ b/sw/device/lib/crypto/drivers/entropy.h
@@ -86,15 +86,48 @@ extern const entropy_seed_material_t kEntropyEmptySeed;
 /**
  * Configures the entropy complex in continuous mode.
  *
- * The complex is configured in continuous mode with FIPS mode enabled. This is
- * the default operational mode of the entropy_src, csrng, edn0 and edn1 blocks.
+ * This function configures the entropy_src, csrng, edn0, and edn1 blocks for
+ * default operation in continuous mode. If FIPS mode is enabled, it applies
+ * strict health test thresholds; otherwise, it defaults to boot-level settings.
  *
- * @param fips kHardenedTrue to enable FIPS health test threshold settings,
- * otherwise use the boot settings.
+ * Calls both entropy_complex_stop_all and entropy_complex_start.
+ *
+ * @param fips Set to `kHardenedBoolTrue` to enable FIPS health test thresholds,
+ *             or `kHardenedBoolFalse` to use boot settings.
  * @return Operation status in `status_t` format.
  */
 OT_WARN_UNUSED_RESULT
 status_t entropy_complex_init(hardened_bool_t fips);
+
+/**
+ * Disables the entropy complex.
+ *
+ * The order of operations is important to avoid synchronization issues across
+ * blocks. For Example, EDN has FIFOs used to send commands to the downstream
+ * CSRNG instances. Such FIFOs are not cleared when EDN is reconfigured, and an
+ * explicit clear FIFO command needs to be set by software (see #14506). There
+ * may be additional race conditions for downstream blocks that are
+ * processing requests from an upstream endpoint (e.g. entropy_src processing a
+ * request from CSRNG, or CSRNG processing a request from EDN). To avoid these
+ * issues, it is recommended to first disable EDN, then CSRNG and entropy_src
+ * last.
+ *
+ * See hw/ip/csrng/doc/_index.md#module-enable-and-disable for more details.
+ */
+void entropy_complex_stop_all(void);
+
+/**
+ * Configures the entropy complex in continuous mode.
+ *
+ * Similar to entropy_complex_init but does not stop the entropy source.
+ * Expects entropy_complex_stop_all to be called before.
+ *
+ * @param fips Set to `kHardenedBoolTrue` to enable FIPS health test thresholds,
+ *             or `kHardenedBoolFalse` to use boot settings.
+ * @return Operation status in `status_t` format.
+ */
+OT_WARN_UNUSED_RESULT
+status_t entropy_complex_start(hardened_bool_t fips);
 
 /**
  * Ensures that the entropy complex is ready for use.

--- a/sw/device/lib/crypto/drivers/mock_entropy.cc
+++ b/sw/device/lib/crypto/drivers/mock_entropy.cc
@@ -21,6 +21,10 @@ const entropy_seed_material_t kEntropyEmptySeed = {
 
 status_t entropy_complex_init(hardened_bool_t fips) { return OTCRYPTO_OK; }
 
+void entropy_complex_stop_all(void) {}
+
+status_t entropy_complex_start(hardened_bool_t fips) { return OTCRYPTO_OK; }
+
 status_t entropy_complex_check(hardened_bool_t fips) { return OTCRYPTO_OK; }
 
 status_t entropy_complex_health_test_config_check(hardened_bool_t fips) {

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -13,6 +13,7 @@ load(
     "opentitan_test",
     "verilator_params",
 )
+load("//rules:cross_platform.bzl", "dual_cc_library", "dual_inputs")
 
 config_setting(
     name = "crypto_status_debug",
@@ -43,6 +44,7 @@ cc_library(
         ":config",
         ":integrity",
         ":keyblob",
+        ":state",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/crypto/drivers:aes",
@@ -194,13 +196,14 @@ cc_library(
     srcs = ["self_integrity.c"],
     hdrs = ["//sw/device/lib/crypto/include:self_integrity.h"],
     local_defines = select({
-        "//sw/device/lib/crypto/configs:hashed": ["HASH_SELF_CHECK_ENABLE"],
+        "//sw/device/lib/crypto/configs:hashed": ["FIPS_MODE"],
         "//conditions:default": [],
     }),
     deps = [
-        ":sha2",
+        ":state",
         ":status",
         "//sw/device/lib/base:hardened",
+        "//sw/device/lib/crypto/drivers:hmac",
         "//sw/device/lib/crypto/include:datatypes",
     ],
 )
@@ -214,10 +217,19 @@ cc_test(
     ],
 )
 
+# Created to deal with the circular dependency (the KATs need the crypto dependencies, but crypto needs to call the KAT)
+cc_library(
+    name = "kats_hdrs",
+    hdrs = ["kats.h"],
+    deps = [
+        ":status",
+        "//sw/device/lib/crypto/include:datatypes",
+    ],
+)
+
 cc_library(
     name = "kats",
     srcs = ["kats.c"],
-    hdrs = ["kats.h"],
     deps = [
         ":aes",
         ":aes_gcm",
@@ -229,6 +241,7 @@ cc_library(
         ":entropy_src",
         ":hmac",
         ":integrity",
+        ":kats_hdrs",
         ":keyblob",
         ":kmac",
         ":rsa",
@@ -239,6 +252,7 @@ cc_library(
         "//sw/device/lib/crypto/drivers:entropy_kat",
         "//sw/device/lib/crypto/include:datatypes",
     ],
+    alwayslink = True,
 )
 
 cc_library(
@@ -347,19 +361,55 @@ cc_library(
     name = "config",
     srcs = ["config.c"],
     hdrs = ["//sw/device/lib/crypto/include:config.h"],
+    defines = select({
+        "//sw/device/lib/crypto/configs:hashed": ["FIPS_MODE"],
+        "//conditions:default": [],
+    }),
     deps = [
         ":entropy_src",
         ":integrity",
+        ":self_integrity",
+        ":state",
         ":status",
         "//hw/top_earlgrey/ip_autogen/clkmgr:clkmgr_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/crypto/drivers:alert",
+        "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/crypto/drivers:keymgr",
         "//sw/device/lib/crypto/drivers:otbn",
         "//sw/device/lib/crypto/drivers:rv_core_ibex",
     ],
+)
+
+dual_cc_library(
+    name = "state",
+    srcs = dual_inputs(
+        device = ["state.c"],
+        host = ["mock_state.cc"],
+    ),
+    hdrs = ["state.h"],
+    defines = select({
+        "//sw/device/lib/crypto/configs:hashed": ["FIPS_MODE"],
+        "//conditions:default": [],
+    }),
+    deps = dual_inputs(
+        device = [
+            "//hw/ip/entropy_src/data:entropy_src_c_regs",
+            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//sw/device/lib/base:abs_mmio",
+            "//sw/device/lib/crypto/drivers:entropy",
+        ],
+        host = [
+            "//sw/device/lib/base:hardened",
+            "//sw/device/lib/base:memory",
+        ],
+        shared = [
+            ":kats_hdrs",
+            "//sw/device/lib/base:hardened_memory",
+        ],
+    ),
 )
 
 cc_library(

--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -11,6 +11,7 @@
 #include "sw/device/lib/crypto/drivers/aes.h"
 #include "sw/device/lib/crypto/drivers/keymgr.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/impl/state.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
@@ -310,6 +311,9 @@ static otcrypto_status_t otcrypto_aes_impl(
     otcrypto_aes_padding_t aes_padding, otcrypto_byte_buf_t *cipher_output) {
   // Guarantees hw_wipe_guard() is called on exit.
   uint32_t hw_cleanup_guard __attribute__((cleanup(hw_wipe_guard))) = 1;
+
+  // Run the AES ECB 256 KAT exactly once before utilizing the block
+  HARDENED_TRY(stateful_health_check(kTestAesEcb256DecryptBit));
 
   // Calculate the number of blocks for the input, including the padding for
   // encryption.

--- a/sw/device/lib/crypto/impl/config.c
+++ b/sw/device/lib/crypto/impl/config.c
@@ -7,10 +7,13 @@
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/crypto/drivers/alert.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/drivers/keymgr.h"
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/drivers/rv_core_ibex.h"
+#include "sw/device/lib/crypto/impl/state.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
+#include "sw/device/lib/crypto/include/self_integrity.h"
 
 #include "clkmgr_regs.h"
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -72,13 +75,22 @@ otcrypto_status_t otcrypto_clear_alerts(void) {
   return OTCRYPTO_OK;
 }
 
-otcrypto_status_t otcrypto_init(otcrypto_key_security_level_t security_level) {
+otcrypto_status_t otcrypto_init(otcrypto_key_security_level_t security_level,
+                                otcrypto_state_t *state) {
   HARDENED_TRY(otcrypto_set_security_config(security_level));
 
   HARDENED_TRY(init_alert_registers());
 
-  // Instantiate the RNG.
-  HARDENED_TRY(otcrypto_entropy_init());
+  // Instantiate the state.
+  HARDENED_TRY(init_state(state, security_level));
+
+  // The state can only be written with a disabled entropy source.
+  entropy_complex_stop_all();
+
+  HARDENED_TRY(store_state(state));
+
+  // Instantiate the entropy source in FIPS mode.
+  HARDENED_TRY(entropy_complex_start(kHardenedBoolTrue));
 
   // The OTBN is still left with DMEM from the boot.
   HARDENED_TRY(otbn_dmem_sec_wipe());
@@ -86,7 +98,7 @@ otcrypto_status_t otcrypto_init(otcrypto_key_security_level_t security_level) {
   HARDENED_TRY(keymgr_sideload_clear_otbn());
   HARDENED_TRY(keymgr_sideload_clear_kmac());
 
-#ifdef HASH_SELF_CHECK_ENABLE
+#ifdef FIPS_MODE
   HARDENED_TRY(otcrypto_integrity_check());
 #endif
 
@@ -94,12 +106,18 @@ otcrypto_status_t otcrypto_init(otcrypto_key_security_level_t security_level) {
 }
 
 otcrypto_status_t otcrypto_eval_exit(otcrypto_status_t status) {
-  if (read_alert_registers()) {
-    return OTCRYPTO_FATAL_ERR;
-  }
+  crypto_state_t *state = NULL;
 
-  // Verify the entropy source before leaving.
-  HARDENED_TRY(otcrypto_entropy_health_test_config_check());
+  HARDENED_TRY(read_state_pointer(&state));
+
+  if (state->security_level != kOtcryptoKeySecurityLevelLow) {
+    if (read_alert_registers()) {
+      return OTCRYPTO_FATAL_ERR;
+    }
+
+    // Verify the entropy source before leaving.
+    HARDENED_TRY(otcrypto_entropy_health_test_config_check());
+  }
 
   return status;
 }

--- a/sw/device/lib/crypto/impl/kats.c
+++ b/sw/device/lib/crypto/impl/kats.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/crypto/impl/kats.h"
 
 #include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/drivers/entropy_kat.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/impl/status.h"
@@ -21,15 +22,6 @@
 #include "sw/device/lib/crypto/include/rsa.h"
 #include "sw/device/lib/crypto/include/sha2.h"
 #include "sw/device/lib/crypto/include/sha3.h"
-
-#ifdef KAT_CHECK_ENABLE
-
-#include "sw/device/lib/base/abs_mmio.h"
-#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
-
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-
-#endif
 
 // We first provide all configs and test vectors
 static const uint32_t kTestMask[] = {
@@ -1171,7 +1163,7 @@ static status_t kat_ed25519_verify(void) {
   return OTCRYPTO_OK;
 }
 
-otcrypto_status_t run_kats(otcrypto_kat_id_t tests) {
+otcrypto_status_t run_kats(kat_id_t tests) {
   if (tests.flags == 0 || tests.flags >= (1UL << kTestLastBit)) {
     return OTCRYPTO_BAD_ARGS;
   }

--- a/sw/device/lib/crypto/impl/kats.h
+++ b/sw/device/lib/crypto/impl/kats.h
@@ -37,7 +37,7 @@ typedef enum {
   kTestEd25519VerifyBit,
   // Last entry used for mask calculation
   kTestLastBit,
-} otcrypto_kat_bits_t;
+} kat_bits_t;
 
 #define _FLAG(flag) (1UL << kTest##flag##Bit)
 
@@ -69,9 +69,9 @@ typedef enum {
 
 typedef struct {
   uint64_t flags;
-} otcrypto_kat_id_t;
+} kat_id_t;
 
-#define OTCRYPTO_KAT_FLAGS(_flags) ((otcrypto_kat_id_t){.flags = _flags})
+#define OTCRYPTO_KAT_FLAGS(_flags) ((kat_id_t){.flags = _flags})
 
 #define OTCRYPTO_KAT_ALL_TESTS OTCRYPTO_KAT_FLAGS(((1UL << kTestLastBit) - 1))
 
@@ -81,7 +81,7 @@ typedef struct {
  * @param tests_to_run bit mask with tests to run
  * @return OK if the requested KATs passed.
  */
-otcrypto_status_t run_kats(otcrypto_kat_id_t tests_to_run);
+otcrypto_status_t run_kats(kat_id_t tests_to_run);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/impl/mock_state.cc
+++ b/sw/device/lib/crypto/impl/mock_state.cc
@@ -1,0 +1,55 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/impl/state.h"
+
+namespace test {
+extern "C" {
+
+static crypto_state_t *stored_state = nullptr;
+static crypto_state_t default_state = {
+    .imem_cache = 0,
+    .kat_state = 0,
+    .security_level = kOtcryptoKeySecurityLevelLow,
+    .self_check_state = kHardenedBoolFalse,
+    .locked_state = kHardenedBoolFalse,
+};
+
+otcrypto_status_t init_state(otcrypto_state_t *state,
+                             otcrypto_key_security_level_t security_level) {
+  crypto_state_t *internal_state = (crypto_state_t *)state;
+  memset(internal_state, 0, sizeof(*internal_state));
+  internal_state->locked_state = kHardenedBoolFalse;
+  internal_state->self_check_state = kHardenedBoolFalse;
+  internal_state->security_level = security_level;
+  return OTCRYPTO_OK;
+}
+
+otcrypto_status_t store_state(otcrypto_state_t *state) {
+  stored_state = (crypto_state_t *)state;
+  return OTCRYPTO_OK;
+}
+
+status_t read_state_pointer(crypto_state_t **state) {
+  if (state == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (stored_state == nullptr) {
+    *state = &default_state;
+  } else {
+    *state = stored_state;
+  }
+  return OTCRYPTO_OK;
+}
+
+#ifdef FIPS_MODE
+otcrypto_status_t stateful_health_check(kat_bits_t kat_bit) {
+  return OTCRYPTO_OK;
+}
+#endif
+
+}  // extern "C"
+}  // namespace test

--- a/sw/device/lib/crypto/impl/self_integrity.c
+++ b/sw/device/lib/crypto/impl/self_integrity.c
@@ -3,27 +3,34 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/crypto/drivers/hmac.h"
+#include "sw/device/lib/crypto/impl/state.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/integrity.h"
-#include "sw/device/lib/crypto/include/sha2.h"
 
-#ifdef HASH_SELF_CHECK_ENABLE
+#ifdef FIPS_MODE
 
 extern const uint8_t _libotcrypto_start_[];
 extern const uint8_t _libotcrypto_end_[];
 
 otcrypto_status_t otcrypto_integrity_check(void) {
+  crypto_state_t *state = NULL;
+
+  HARDENED_TRY(read_state_pointer(&state));
+
+  if (state->locked_state == kHardenedBoolTrue) {
+    return OTCRYPTO_FATAL_ERR;
+  }
+
   const size_t lib_len = (size_t)(_libotcrypto_end_ - _libotcrypto_start_);
 
   uint32_t digest_content[12] = {0};
-  otcrypto_sha2_context_t ctx;
-  otcrypto_hash_digest_t digest = {
-      .mode = kOtcryptoHashModeSha384,
-      .len = ARRAYSIZE(digest_content),
-      .data = digest_content,
-  };
+  hmac_ctx_t ctx;
+  otcrypto_word32_buf_t digest = OTCRYPTO_MAKE_BUF(
+      otcrypto_word32_buf_t, digest_content, ARRAYSIZE(digest_content));
 
-  HARDENED_TRY(otcrypto_sha2_init(kOtcryptoHashModeSha384, &ctx));
+  // Initialize the HMAC driver in SHA384 mode.
+  hmac_hash_sha384_init(&ctx);
 
   size_t acc_len = 0;
   const size_t kMaxChunkSize = 2048;
@@ -38,11 +45,11 @@ otcrypto_status_t otcrypto_integrity_check(void) {
         otcrypto_const_byte_buf_t,
         (const uint8_t *)(_libotcrypto_start_ + acc_len), len);
 
-    HARDENED_TRY(otcrypto_sha2_update(&ctx, &buf));
+    HARDENED_TRY(hmac_update(&ctx, &buf));
     acc_len += len;
   }
 
-  HARDENED_TRY(otcrypto_sha2_final(&ctx, &digest));
+  HARDENED_TRY(hmac_final(&ctx, &digest));
   extern const uint8_t _libotcrypto_hash_[];
   const uint8_t *hash_ptr = _libotcrypto_hash_;
 
@@ -52,9 +59,13 @@ otcrypto_status_t otcrypto_integrity_check(void) {
   }
 
   if (diff != 0) {
+    // Lock the cryptolib if the self-integrity check failed
+    state->locked_state = kHardenedBoolTrue;
     return OTCRYPTO_FATAL_ERR;
   }
 
+  // Set the stateful word that the self-integrity check is done
+  state->self_check_state = kHardenedBoolTrue;
   return OTCRYPTO_OK;
 }
 

--- a/sw/device/lib/crypto/impl/state.c
+++ b/sw/device/lib/crypto/impl/state.c
@@ -1,0 +1,106 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/impl/state.h"
+
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
+#include "sw/device/lib/crypto/drivers/rv_core_ibex.h"
+
+#include "entropy_src_regs.h"  // Generated
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+static const uint32_t kBaseEntropySrc = TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR;
+
+otcrypto_status_t init_state(otcrypto_state_t *state,
+                             otcrypto_key_security_level_t security_level) {
+  crypto_state_t *internal_state = (crypto_state_t *)state;
+  internal_state->imem_cache = 0;
+  internal_state->kat_state = 0;
+  internal_state->locked_state = kHardenedBoolFalse;
+  internal_state->self_check_state = kHardenedBoolFalse;
+  internal_state->security_level = security_level;
+  return OTCRYPTO_OK;
+}
+
+otcrypto_status_t store_state(otcrypto_state_t *state) {
+  if (state == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  uint32_t state_addr = (uint32_t)state;
+  uint16_t state_hi = (uint16_t)(state_addr >> 16);
+  uint16_t state_lo = (uint16_t)(state_addr & 0xFFFF);
+
+  abs_mmio_write32(
+      kBaseEntropySrc + ENTROPY_SRC_EXTHT_HI_THRESHOLDS_REG_OFFSET,
+      bitfield_field32_write(ENTROPY_SRC_EXTHT_HI_THRESHOLDS_REG_RESVAL,
+                             ENTROPY_SRC_EXTHT_HI_THRESHOLDS_FIPS_THRESH_FIELD,
+                             state_hi));
+  abs_mmio_write32(
+      kBaseEntropySrc + ENTROPY_SRC_EXTHT_LO_THRESHOLDS_REG_OFFSET,
+      bitfield_field32_write(ENTROPY_SRC_EXTHT_LO_THRESHOLDS_REG_RESVAL,
+                             ENTROPY_SRC_EXTHT_LO_THRESHOLDS_FIPS_THRESH_FIELD,
+                             state_lo));
+  return OTCRYPTO_OK;
+}
+
+status_t read_state_pointer(crypto_state_t **state) {
+  if (state == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  uint32_t reg_hi = abs_mmio_read32(kBaseEntropySrc +
+                                    ENTROPY_SRC_EXTHT_HI_THRESHOLDS_REG_OFFSET);
+  uint32_t reg_lo = abs_mmio_read32(kBaseEntropySrc +
+                                    ENTROPY_SRC_EXTHT_LO_THRESHOLDS_REG_OFFSET);
+
+  uint32_t val_hi = bitfield_field32_read(
+      reg_hi, ENTROPY_SRC_EXTHT_HI_THRESHOLDS_FIPS_THRESH_FIELD);
+  uint32_t val_lo = bitfield_field32_read(
+      reg_lo, ENTROPY_SRC_EXTHT_LO_THRESHOLDS_FIPS_THRESH_FIELD);
+
+  uint32_t state_addr = (val_hi << 16) | val_lo;
+  *state = (crypto_state_t *)state_addr;
+
+  return OTCRYPTO_OK;
+}
+
+#ifdef FIPS_MODE
+
+otcrypto_status_t stateful_health_check(kat_bits_t kat_bit) {
+  crypto_state_t *state = NULL;
+
+  HARDENED_TRY(read_state_pointer(&state));
+
+  // If we are in a locked state, the health check returns a fatal error
+  if (state->locked_state == kHardenedBoolTrue) {
+    return OTCRYPTO_FATAL_ERR;
+  }
+
+  // We consider the missing self-integrity case to be a user error, hence we
+  // return a recoverable error.
+  if (state->self_check_state == kHardenedBoolFalse) {
+    return OTCRYPTO_RECOV_ERR;
+  }
+
+  uint32_t mask = (1UL << kat_bit);
+
+  if ((state->kat_state & mask) == 0) {
+    state->kat_state |= mask;  // Re-entrance lock
+
+    kat_id_t test_id = {.flags = mask};
+    status_t result = run_kats(test_id);
+
+    // If the KAT failed, lock the cryptolib
+    if (result.value != kHardenedBoolTrue) {
+      state->locked_state = kHardenedBoolTrue;
+      return result;
+    }
+  }
+
+  return OTCRYPTO_OK;
+}
+
+#endif  // FIPS_MODE

--- a/sw/device/lib/crypto/impl/state.h
+++ b/sw/device/lib/crypto/impl/state.h
@@ -1,0 +1,99 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_STATE_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_STATE_H_
+
+#include "sw/device/lib/crypto/impl/kats.h"
+#include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+typedef struct crypto_state {
+  uint32_t imem_cache;
+  uint32_t kat_state;
+  otcrypto_key_security_level_t security_level;
+  hardened_bool_t self_check_state;
+  hardened_bool_t locked_state;
+} crypto_state_t;
+
+static_assert(sizeof(otcrypto_state_t) >= sizeof(crypto_state_t),
+              "Unmatching size of internal and external state definition");
+
+/**
+ * Initializes the state structure.
+ *
+ * @param state Pointer to the state to initialize.
+ * @param security_level The security level that is used for the cryptolib
+ * itself.
+ * @return error on failure.
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t init_state(otcrypto_state_t *state,
+                             otcrypto_key_security_level_t security_level);
+
+/**
+ * Stores the state pointer stashed in the EXTHT threshold registers of the
+ * entropy_src.
+ *
+ * @param state Pointer to the state to store.
+ * @return error on failure.
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t store_state(otcrypto_state_t *state);
+
+/**
+ * Retrieves the state pointer stashed in the EXTHT threshold registers of the
+ * entropy_src.
+ *
+ * @param[out] state Pointer to receive the reconstructed memory address.
+ * @return error on failure.
+ */
+OT_WARN_UNUSED_RESULT
+status_t read_state_pointer(crypto_state_t **state);
+
+/**
+ * @brief Ensures the specified Known Answer Test (KAT) is executed exactly
+ * once. Checks the state of the cryptolib whether it is locked or whether the
+ * self integrity passed.
+ *
+ * This function provides stateful, lazy evaluation of KATs depending on the
+ * build configuration:
+ *
+ * - **FIPS Build (`FIPS_MODE` defined):** It retrieves the KAT state
+ *   pointer previously stashed in the hardware entropy complex during
+ *   initialization. It checks this state to verify if the KAT corresponding
+ *   to `kat_bit` has already passed. If not, it executes the KAT and securely
+ *   updates the state bitmask.
+ * - **Standard Build (`FIPS_MODE` undefined):** The function simply returns
+ * OTCRYPTO_OK and performs no checks.
+ *
+ * @param kat_bit The specific KAT identifier to execute.
+ * @return Result of the operation. Returns `OTCRYPTO_OK` on success, if the
+ *         KAT already passed, or if lazy evaluation is disabled. Returns
+ *         `OTCRYPTO_FATAL_ERR` if the KAT fails or if the stashed state
+ *         pointer cannot be recovered from hardware.
+ */
+#ifndef FIPS_MODE
+
+// Standard build: Stateful KAT evaluation is disabled (non FIPS).
+static inline otcrypto_status_t stateful_health_check(kat_bits_t kat_bit) {
+  return OTCRYPTO_OK;
+}
+
+#else
+
+// FIPS build: Evaluates kats in a stateful manner
+otcrypto_status_t stateful_health_check(kat_bits_t kat_bit);
+
+#endif  // FIPS_MODE
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_STATE_H_

--- a/sw/device/lib/crypto/include/config.h
+++ b/sw/device/lib/crypto/include/config.h
@@ -85,21 +85,40 @@ OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_clear_alerts(void);
 
 /**
- * Initializes the crypto library for use.
+ * Initializes the cryptographic library for use.
  *
- * Check the security configuration
- * Set up alert management
- * Perform (some) KATs for FIPS
- * Set up the entropy source
+ * This function prepares the cryptolib for secure operation by performing the
+ * following initialization sequence:
+ * - Validates the system security configuration.
+ * - Configures alert management and Ibex registers.
+ * - Initializes the entropy complex for random number generation.
+ * - Executes baseline Power-On Self-Tests (POSTs) and initial Known Answer
+ *   Tests (KATs) required for FIPS compliance.
  *
- * This function writes to alert manager and Ibex registers.
- * It is only usable in M mode.
+ * To support lazy evaluation of subsequent KATs without violating memory
+ * constraints, this function stashes the provided `state` pointer into the
+ * hardware entropy complex.
  *
- * @param security_level Security level of the used key.
- * @returns OK when the security check passed.
+ * The given security level (abusin the key security structure) determines the
+ * security level the library will use. Non-low security level will set the ibex
+ * CSRs to enable a jittery clock and dummy instructions; manually verify alerts
+ * from the HW and sensors after every cryptographic operation; and verify
+ * whether the entropy source is not tampered with.
+ *
+ * @note Because this function writes directly to alert manager and Ibex
+ *       registers, it can only be executed in Machine mode (M mode).
+ *
+ * @param security_level Minimum security level targeted for the environment
+ * (this abuses the key security structure).
+ * @param state          Pointer to a stable 32-bit memory location (e.g., in
+ * `.bss` or Retention SRAM) used to continuously track KAT execution.
+ * @return Result of the initialization operation. Returns
+ * `kOtcryptoStatusValueOk` on success, or an appropriate error code if any
+ * check or test fails.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_init(otcrypto_key_security_level_t security_level);
+otcrypto_status_t otcrypto_init(otcrypto_key_security_level_t security_level,
+                                otcrypto_state_t *state);
 
 /**
  * Function used to return to the user, the last function call of every crypto

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -531,6 +531,13 @@ typedef struct otcrypto_hash_digest {
   size_t len;
 } otcrypto_hash_digest_t;
 
+/**
+ * State structure for the crypto library.
+ */
+typedef struct otcrypto_state {
+  uint32_t data[5];
+} otcrypto_state_t;
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/crypto/include/entropy_src.h
+++ b/sw/device/lib/crypto/include/entropy_src.h
@@ -19,9 +19,13 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
- * Configures the entropy source in continuous mode with FIPS thresholds.
+ * Configures the entropy complex in continuous mode with FIPS thresholds.
  *
- * @return Operation status in `otcrypto_status_t` format.
+ * This function initializes the hardware entropy source, CSRNG, and EDN blocks
+ * for FIPS-compliant continuous operation.
+ *
+ * @return Result of the initialization operation. Returns
+ * `kOtcryptoStatusValueOk` on success.
  */
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_entropy_init(void);

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -335,6 +335,10 @@ opentitan_binary_blob(
         "//sw/device/lib/runtime:log",
     ],
     rom_origin = "0x10000",
+    target_compatible_with = select({
+        "//sw/device/lib/crypto/configs:crypto_fips_all": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     transitive_features = [
         "no_jump_tables",
         "minsize",
@@ -1042,15 +1046,28 @@ opentitan_test(
     name = "kats_functest",
     srcs = ["kats_functest.c"],
     exec_env = CRYPTOTEST_EXEC_ENVS,
+    local_defines = select({
+        "//sw/device/lib/crypto/configs:hashed": ["FIPS_MODE"],
+        "//conditions:default": [],
+    }),
     verilator = verilator_params(
         timeout = "long",
     ),
     deps = [
-        "//sw/device/lib/crypto/impl:config",
-        "//sw/device/lib/crypto/impl:kats",
+        "//sw/device/lib/crypto",
+        "//sw/device/lib/crypto/include:crypto_hdrs",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
+)
+
+# Call the kats test with --config=crypto_fips_all
+# Call for example kats_functest_fips_fpga_cw340_sival_rom_ext, i.e., append fips behind the name and before the exec_env
+fips_wrap_opentitan_test(
+    name = "kats_functest",
+    exec_env = CRYPTOTEST_FIPS_EXEC_ENVS,
 )
 
 opentitan_test(
@@ -1592,7 +1609,7 @@ opentitan_test(
     srcs = ["otcrypto_hash_test.c"],
     exec_env = CRYPTOTEST_EXEC_ENVS,
     local_defines = select({
-        "//sw/device/lib/crypto/configs:hashed": ["HASH_SELF_CHECK_ENABLE"],
+        "//sw/device/lib/crypto/configs:hashed": ["FIPS_MODE"],
         "//conditions:default": [],
     }),
     deps = [

--- a/sw/device/tests/crypto/aes_functest.c
+++ b/sw/device/tests/crypto/aes_functest.c
@@ -354,8 +354,9 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t result = OK_STATUS();
+  otcrypto_state_t state = {0};
 
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   for (size_t i = 0; i < ARRAYSIZE(kAesTests); i++) {
     LOG_INFO("Starting AES test %d of %d...", i + 1, ARRAYSIZE(kAesTests));

--- a/sw/device/tests/crypto/aes_gcm_functest.c
+++ b/sw/device/tests/crypto/aes_gcm_functest.c
@@ -464,8 +464,9 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t result = OK_STATUS();
+  otcrypto_state_t state = {0};
 
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   for (size_t i = 0; i < ARRAYSIZE(kAesGcmTestvectors); i++) {
     LOG_INFO("Starting AES-GCM test %d of %d...", i + 1,

--- a/sw/device/tests/crypto/aes_gcm_timing_functest.c
+++ b/sw/device/tests/crypto/aes_gcm_timing_functest.c
@@ -102,7 +102,8 @@ static status_t test_decrypt_timing(void) {
 OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   status_t result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   hardened_bool_t icache_enabled;
   CHECK_STATUS_OK(otcrypto_disable_icache(&icache_enabled));
   for (size_t i = 0; i < ARRAYSIZE(kAesGcmTestvectors); i++) {

--- a/sw/device/tests/crypto/aes_kwp_functest.c
+++ b/sw/device/tests/crypto/aes_kwp_functest.c
@@ -107,7 +107,8 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   status_t result = OK_STATUS();
 
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   EXECUTE_TEST(result, wrap_unwrap_random_test);
 
   return status_ok(result);

--- a/sw/device/tests/crypto/aes_kwp_kat_functest.c
+++ b/sw/device/tests/crypto/aes_kwp_kat_functest.c
@@ -156,7 +156,8 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   status_t result = OK_STATUS();
 
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   EXECUTE_TEST(result, no_padding_test);
   EXECUTE_TEST(result, needs_padding_test);
 

--- a/sw/device/tests/crypto/aes_kwp_sideload_functest.c
+++ b/sw/device/tests/crypto/aes_kwp_sideload_functest.c
@@ -139,7 +139,8 @@ status_t test_setup(void) {
   // Initialize entropy complex for cryptolib, which the key manager uses to
   // clear sideloaded keys. The `keymgr_testutils_startup` function restarts
   // the device, so this should happen afterwards.
-  return otcrypto_init(kOtcryptoKeySecurityLevelLow);
+  otcrypto_state_t state = {0};
+  return otcrypto_init(kOtcryptoKeySecurityLevelLow, &state);
 }
 
 OTTF_DEFINE_TEST_CONFIG();

--- a/sw/device/tests/crypto/aes_sideload_functest.c
+++ b/sw/device/tests/crypto/aes_sideload_functest.c
@@ -153,7 +153,8 @@ status_t test_setup(void) {
   // Initialize entropy complex for cryptolib, which the key manager uses to
   // clear sideloaded keys. The `keymgr_testutils_startup` function restarts
   // the device, so this should happen afterwards.
-  return otcrypto_init(kOtcryptoKeySecurityLevelLow);
+  otcrypto_state_t state = {0};
+  return otcrypto_init(kOtcryptoKeySecurityLevelLow, &state);
 }
 
 /**

--- a/sw/device/tests/crypto/cmac_functest.c
+++ b/sw/device/tests/crypto/cmac_functest.c
@@ -236,7 +236,8 @@ bool test_main(void) {
 
   // Testing overall cryptolib low security, i.e., no jittery clock or dummy
   // instructions
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   for (size_t i = 0; i < ARRAYSIZE(available_security_levels); ++i) {
     current_sec_level = available_security_levels[i];

--- a/sw/device/tests/crypto/config_functest.c
+++ b/sw/device/tests/crypto/config_functest.c
@@ -39,7 +39,8 @@ static status_t test_set_and_check_config(void) {
 static status_t test_init_and_exit(void) {
   otcrypto_key_security_level_t sec_level = kOtcryptoKeySecurityLevelHigh;
 
-  TRY(otcrypto_init(sec_level));
+  otcrypto_state_t state = {0};
+  TRY(otcrypto_init(sec_level, &state));
   TRY(otcrypto_security_config_check(sec_level));
   TRY(otcrypto_eval_exit(OTCRYPTO_OK));
 
@@ -51,8 +52,9 @@ static status_t test_multiple_inits(void) {
 
   TRY(otcrypto_set_security_config(sec_level));
 
+  otcrypto_state_t state = {0};
   for (size_t i = 0; i < 50; i++) {
-    TRY(otcrypto_init(sec_level));
+    TRY(otcrypto_init(sec_level, &state));
   }
 
   return OK_STATUS();
@@ -87,7 +89,8 @@ static status_t test_alert_caught_by_eval_exit(void) {
   LOG_INFO("Testing otcrypto_eval_exit with forced AES alert");
 
   // Initialize crypto (this also clears alert accumulators)
-  TRY(otcrypto_init(kOtcryptoKeySecurityLevelHigh));
+  otcrypto_state_t state = {0};
+  TRY(otcrypto_init(kOtcryptoKeySecurityLevelHigh, &state));
 
   // OTTF has its own alert management system, we have to bypass it.
   // Disable interrupts globally.
@@ -142,7 +145,8 @@ static status_t test_lock(void) {
   // Locking the accumulators causes the alert to no longer be clearable.
   // The test is similar to test_alert_caught_by_eval_exit
 
-  TRY(otcrypto_init(kOtcryptoKeySecurityLevelHigh));
+  otcrypto_state_t state = {0};
+  TRY(otcrypto_init(kOtcryptoKeySecurityLevelHigh, &state));
   irq_global_ctrl(false);
 
   // Lock the accumulators

--- a/sw/device/tests/crypto/cryptotest/firmware/firmware.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/firmware.c
@@ -110,7 +110,8 @@ bool test_main(void) {
   // Coverage becomes flaky with the jittery clock and dummy operations.
   sec_level = kOtcryptoKeySecurityLevelLow;
 #endif
-  CHECK_STATUS_OK(otcrypto_init(sec_level));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(sec_level, &state));
   ujson_t uj = ujson_ottf_console();
   return status_ok(process_cmd(&uj));
 }

--- a/sw/device/tests/crypto/drbg_functest.c
+++ b/sw/device/tests/crypto/drbg_functest.c
@@ -191,7 +191,8 @@ static status_t run_negative_tests(void) {
 bool test_main(void) {
   status_t result = OK_STATUS();
 
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   EXECUTE_TEST(result, kat_test);
   EXECUTE_TEST(result, random_test);

--- a/sw/device/tests/crypto/ecc_p256_arith_share_private_key_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_arith_share_private_key_functest.c
@@ -233,7 +233,8 @@ static status_t run_arith_share_negative_tests(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   status_t err0 = arith_share_private_key_test(false);
   status_t err1 = arith_share_private_key_test(true);

--- a/sw/device/tests/crypto/ecc_p256_base_point_mult_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_base_point_mult_functest.c
@@ -79,7 +79,8 @@ status_t base_point_mult_test(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   status_t err = base_point_mult_test();
   if (!status_ok(err)) {

--- a/sw/device/tests/crypto/ecc_p256_dice_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_dice_functest.c
@@ -245,7 +245,8 @@ static status_t test_setup(void) {
   // Initialize entropy complex for cryptolib, which the key manager uses to
   // clear sideloaded keys. The `keymgr_testutils_startup` function restarts
   // the device, so this should happen afterwards.
-  return otcrypto_init(kOtcryptoKeySecurityLevelLow);
+  otcrypto_state_t state = {0};
+  return otcrypto_init(kOtcryptoKeySecurityLevelLow, &state);
 }
 
 static status_t run_dice_negative_tests(void) {

--- a/sw/device/tests/crypto/ecc_p256_key_import_export_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_key_import_export_functest.c
@@ -436,7 +436,8 @@ static status_t run_import_export_negative_tests(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   CHECK_STATUS_OK(ecdh_key_mode_test());
 

--- a/sw/device/tests/crypto/ecc_p256_point_on_curve_check_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_point_on_curve_check_functest.c
@@ -82,7 +82,8 @@ status_t point_valid_test(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   status_t err = point_valid_test();
   if (!status_ok(err)) {

--- a/sw/device/tests/crypto/ecc_p384_arith_share_private_key_functest.c
+++ b/sw/device/tests/crypto/ecc_p384_arith_share_private_key_functest.c
@@ -233,7 +233,8 @@ static status_t run_arith_share_negative_tests(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   status_t err0 = arith_share_private_key_test(false);
   status_t err1 = arith_share_private_key_test(true);

--- a/sw/device/tests/crypto/ecc_p384_base_point_mult_functest.c
+++ b/sw/device/tests/crypto/ecc_p384_base_point_mult_functest.c
@@ -79,7 +79,8 @@ status_t base_point_mult_test(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   status_t err = base_point_mult_test();
   if (!status_ok(err)) {

--- a/sw/device/tests/crypto/ecc_p384_key_import_export_functest.c
+++ b/sw/device/tests/crypto/ecc_p384_key_import_export_functest.c
@@ -434,7 +434,8 @@ static status_t run_import_export_negative_tests(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   CHECK_STATUS_OK(ecdh_key_mode_test());
 

--- a/sw/device/tests/crypto/ecc_p384_point_on_curve_check_functest.c
+++ b/sw/device/tests/crypto/ecc_p384_point_on_curve_check_functest.c
@@ -187,7 +187,8 @@ status_t point_partial_collision_test(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   status_t err = point_valid_test();
   if (!status_ok(err)) {

--- a/sw/device/tests/crypto/ecdh_p256_functest.c
+++ b/sw/device/tests/crypto/ecdh_p256_functest.c
@@ -363,7 +363,8 @@ static status_t run_ecdh_negative_tests(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   status_t err = key_exchange_test();
   if (!status_ok(err)) {

--- a/sw/device/tests/crypto/ecdh_p256_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdh_p256_sideload_functest.c
@@ -174,7 +174,8 @@ static status_t test_setup(void) {
   // Initialize entropy complex for cryptolib, which the key manager uses to
   // clear sideloaded keys. The `keymgr_testutils_startup` function restarts
   // the device, so this should happen afterwards.
-  return otcrypto_init(kOtcryptoKeySecurityLevelLow);
+  otcrypto_state_t state = {0};
+  return otcrypto_init(kOtcryptoKeySecurityLevelLow, &state);
 }
 
 OTTF_DEFINE_TEST_CONFIG();

--- a/sw/device/tests/crypto/ecdh_p384_functest.c
+++ b/sw/device/tests/crypto/ecdh_p384_functest.c
@@ -368,7 +368,8 @@ static status_t run_ecdh_negative_tests(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   status_t err = key_exchange_test();
   if (!status_ok(err)) {

--- a/sw/device/tests/crypto/ecdh_p384_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdh_p384_sideload_functest.c
@@ -171,7 +171,8 @@ static status_t test_setup(void) {
   // Initialize entropy complex for cryptolib, which the key manager uses to
   // clear sideloaded keys. The `keymgr_testutils_startup` function restarts
   // the device, so this should happen afterwards.
-  return otcrypto_init(kOtcryptoKeySecurityLevelLow);
+  otcrypto_state_t state = {0};
+  return otcrypto_init(kOtcryptoKeySecurityLevelLow, &state);
 }
 
 OTTF_DEFINE_TEST_CONFIG();

--- a/sw/device/tests/crypto/ecdsa_p256_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_functest.c
@@ -523,7 +523,8 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   status_t result = OK_STATUS();
 
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   EXECUTE_TEST(result, sign_then_verify_test);
   EXECUTE_TEST(result, sign_kat);
   EXECUTE_TEST(result, run_ecdsa_negative_tests);

--- a/sw/device/tests/crypto/ecdsa_p256_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_sideload_functest.c
@@ -127,7 +127,8 @@ static status_t test_setup(void) {
   // Initialize entropy complex for cryptolib, which the key manager uses to
   // clear sideloaded keys. The `keymgr_testutils_startup` function restarts
   // the device, so this should happen afterwards.
-  return otcrypto_init(kOtcryptoKeySecurityLevelLow);
+  otcrypto_state_t state = {0};
+  return otcrypto_init(kOtcryptoKeySecurityLevelLow, &state);
 }
 
 OTTF_DEFINE_TEST_CONFIG();

--- a/sw/device/tests/crypto/ecdsa_p256_verify_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_verify_functest.c
@@ -53,7 +53,8 @@ bool test_main(void) {
   // Stays true only if all tests pass.
   bool result = true;
 
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   // The definition of `RULE_NAME` comes from the autogen Bazel rule.
   LOG_INFO("Starting ecdsa_p256_verify_test:%s", RULE_NAME);

--- a/sw/device/tests/crypto/ecdsa_p384_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p384_functest.c
@@ -532,7 +532,8 @@ static status_t run_ecdsa_negative_tests(void) {
 bool test_main(void) {
   status_t result = OK_STATUS();
 
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   EXECUTE_TEST(result, sign_then_verify_test);
   EXECUTE_TEST(result, sign_kat);
   EXECUTE_TEST(result, run_ecdsa_negative_tests);

--- a/sw/device/tests/crypto/ecdsa_p384_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p384_sideload_functest.c
@@ -125,7 +125,8 @@ static status_t test_setup(void) {
   // Initialize entropy complex for cryptolib, which the key manager uses to
   // clear sideloaded keys. The `keymgr_testutils_startup` function restarts
   // the device, so this should happen afterwards.
-  return otcrypto_init(kOtcryptoKeySecurityLevelLow);
+  otcrypto_state_t state = {0};
+  return otcrypto_init(kOtcryptoKeySecurityLevelLow, &state);
 }
 
 OTTF_DEFINE_TEST_CONFIG();

--- a/sw/device/tests/crypto/ed25519_functest.c
+++ b/sw/device/tests/crypto/ed25519_functest.c
@@ -467,7 +467,8 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   status_t result = OK_STATUS();
 
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   EXECUTE_TEST(result, ed25519_kat_test);
   EXECUTE_TEST(result, hasheddsa_test);

--- a/sw/device/tests/crypto/hkdf_functest.c
+++ b/sw/device/tests/crypto/hkdf_functest.c
@@ -602,7 +602,8 @@ static status_t run_negative_tests(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   status_t test_result = OK_STATUS();
   EXECUTE_TEST(test_result, rfc_test1);

--- a/sw/device/tests/crypto/hmac_functest.c
+++ b/sw/device/tests/crypto/hmac_functest.c
@@ -180,7 +180,8 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   LOG_INFO("Testing cryptolib HMAC/SHA-2 streaming implementations.");
   status_t test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   for (size_t i = 0; i < ARRAYSIZE(kHmacTestVectors); i++) {
     current_test_vector = &kHmacTestVectors[i];
     LOG_INFO("Running test %d of %d, test vector identifier: %s", i + 1,

--- a/sw/device/tests/crypto/hmac_multistream_functest.c
+++ b/sw/device/tests/crypto/hmac_multistream_functest.c
@@ -471,7 +471,8 @@ bool test_main(void) {
 
   // Testing overall cryptolib low security, i.e., no jittery clock or dummy
   // instructions
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   for (size_t i = 0; i < ARRAYSIZE(available_security_levels); ++i) {
     current_sec_level = available_security_levels[i];

--- a/sw/device/tests/crypto/hmac_sha256_functest.c
+++ b/sw/device/tests/crypto/hmac_sha256_functest.c
@@ -221,7 +221,8 @@ bool test_main(void) {
 
   // Testing overall cryptolib low security, i.e., no jittery clock or dummy
   // instructions
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   for (size_t i = 0; i < ARRAYSIZE(available_security_levels); ++i) {
     current_sec_level = available_security_levels[i];

--- a/sw/device/tests/crypto/hmac_sha384_functest.c
+++ b/sw/device/tests/crypto/hmac_sha384_functest.c
@@ -235,7 +235,8 @@ bool test_main(void) {
 
   // Testing overall cryptolib low security, i.e., no jittery clock or dummy
   // instructions
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   for (size_t i = 0; i < ARRAYSIZE(available_security_levels); ++i) {
     current_sec_level = available_security_levels[i];

--- a/sw/device/tests/crypto/hmac_sha512_functest.c
+++ b/sw/device/tests/crypto/hmac_sha512_functest.c
@@ -245,7 +245,8 @@ bool test_main(void) {
 
   // Testing overall cryptolib low security, i.e., no jittery clock or dummy
   // instructions
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   for (size_t i = 0; i < ARRAYSIZE(available_security_levels); ++i) {
     current_sec_level = available_security_levels[i];

--- a/sw/device/tests/crypto/kats_functest.c
+++ b/sw/device/tests/crypto/kats_functest.c
@@ -2,18 +2,116 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/lib/crypto/impl/kats.h"
+#include <string.h>
+
+#include "sw/device/lib/crypto/include/aes.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/integrity.h"
+#include "sw/device/lib/crypto/include/key_transport.h"
+#include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 OTTF_DEFINE_TEST_CONFIG();
 
-bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+// Define the state as static (this is user's side)
+static otcrypto_state_t test_cryptolib_state = {0};
 
-  CHECK_STATUS_OK(run_kats(OTCRYPTO_KAT_ALL_TESTS));
+/**
+ * @brief Tests that the KAT evaluation runs once and skips thereafter.
+ */
+status_t test_stateful_kat_execution(void) {
+#ifdef FIPS_MODE
+  LOG_INFO("Testing stateful KAT execution for FIPS build using AES...");
+
+  // Verify the state is zeroed out initially
+  otcrypto_state_t initial_state = test_cryptolib_state;
+
+  otcrypto_key_config_t config = {
+      .version = kOtcryptoLibVersion1,
+      .key_mode = kOtcryptoKeyModeAesEcb,
+      .key_length = 16,
+      .hw_backed = kHardenedBoolFalse,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
+
+  uint32_t share0_data[4] = {0x01234567, 0x89abcdef, 0x55aa55aa, 0xaa55aa55};
+  uint32_t share1_data[4] = {0};
+  otcrypto_const_word32_buf_t key_share0 =
+      OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, share0_data, 4);
+  otcrypto_const_word32_buf_t key_share1 =
+      OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, share1_data, 4);
+
+  uint32_t keyblob[8] = {0};
+  otcrypto_blinded_key_t key = {
+      .config = config,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+  };
+
+  otcrypto_status_t import_status =
+      otcrypto_import_blinded_key(&key_share0, &key_share1, &key);
+  TRY_CHECK(import_status.value == kHardenedBoolTrue, "Key import failed.");
+
+  uint32_t iv_data[4] = {0};
+  otcrypto_word32_buf_t iv =
+      OTCRYPTO_MAKE_BUF(otcrypto_word32_buf_t, iv_data, 4);
+
+  uint8_t input_data[16] = {0};
+  otcrypto_const_byte_buf_t input =
+      OTCRYPTO_MAKE_BUF(otcrypto_const_byte_buf_t, input_data, 16);
+
+  uint8_t output_data[16] = {0};
+  otcrypto_byte_buf_t output =
+      OTCRYPTO_MAKE_BUF(otcrypto_byte_buf_t, output_data, 16);
+
+  uint64_t t1_start = ibex_mcycle_read();
+  otcrypto_status_t status1 =
+      otcrypto_aes(&key, &iv, kOtcryptoAesModeCbc, kOtcryptoAesOperationEncrypt,
+                   &input, kOtcryptoAesPaddingNull, &output);
+  uint64_t t1_end = ibex_mcycle_read();
+  uint64_t first_run_cycles = t1_end - t1_start;
+
+  // Ensure it failed properly inside otcrypto_aes
+  TRY_CHECK(status1.value != kHardenedBoolTrue,
+            "Expected failure due to mode mismatch.");
+
+  // Verify that some KAT bit was successfully set in our stashed state
+  TRY_CHECK(memcmp(&initial_state, &test_cryptolib_state,
+                   sizeof(otcrypto_state_t)) != 0,
+            "KAT state was not mutated by the cryptolib.");
+
+  uint64_t t2_start = ibex_mcycle_read();
+  otcrypto_status_t status2 =
+      otcrypto_aes(&key, &iv, kOtcryptoAesModeCbc, kOtcryptoAesOperationEncrypt,
+                   &input, kOtcryptoAesPaddingNull, &output);
+  uint64_t t2_end = ibex_mcycle_read();
+  uint64_t second_run_cycles = t2_end - t2_start;
+
+  TRY_CHECK(status2.value != kHardenedBoolTrue,
+            "Expected failure due to mode mismatch.");
+
+  LOG_INFO("First run (with KAT): %u cycles", (uint32_t)first_run_cycles);
+  LOG_INFO("Second run (skipped KAT): %u cycles", (uint32_t)second_run_cycles);
+
+  // Prove the second run was significantly faster
+  TRY_CHECK(second_run_cycles < (first_run_cycles / 2),
+            "Second run was not faster; KAT was not skipped.");
+
+  LOG_INFO("KAT FIPS behavior verified using AES.");
+#endif
+
+  return OK_STATUS();
+}
+
+bool test_main(void) {
+  // Pass the address of the static state variable
+  CHECK_STATUS_OK(
+      otcrypto_init(kOtcryptoKeySecurityLevelHigh, &test_cryptolib_state));
+
+  CHECK_STATUS_OK(test_stateful_kat_execution());
 
   return true;
 }

--- a/sw/device/tests/crypto/kdf_hmac_ctr_functest.c
+++ b/sw/device/tests/crypto/kdf_hmac_ctr_functest.c
@@ -1220,7 +1220,8 @@ static status_t run_hmac_kdf_negative_tests(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   status_t test_result = OK_STATUS();
 

--- a/sw/device/tests/crypto/kdf_kmac_functest.c
+++ b/sw/device/tests/crypto/kdf_kmac_functest.c
@@ -235,7 +235,8 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   LOG_INFO("Testing cryptolib KMAC-KDF driver.");
 
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   // Initialize the core with default parameters
   CHECK_STATUS_OK(kmac_hwip_default_configure());
 

--- a/sw/device/tests/crypto/kdf_kmac_sideload_functest.c
+++ b/sw/device/tests/crypto/kdf_kmac_sideload_functest.c
@@ -440,7 +440,8 @@ bool test_main(void) {
   LOG_INFO("Keymgr entered %s State", state_name);
   LOG_INFO("Testing cryptolib KDF-KMAC driver with sideloaded key.");
 
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   // Initialize the core with default parameters
   CHECK_STATUS_OK(kmac_hwip_default_configure());
 

--- a/sw/device/tests/crypto/kmac_functest.c
+++ b/sw/device/tests/crypto/kmac_functest.c
@@ -491,7 +491,8 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   LOG_INFO("Testing cryptolib KMAC driver.");
 
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   // Initialize the core with default parameters
   CHECK_STATUS_OK(kmac_hwip_default_configure());
 

--- a/sw/device/tests/crypto/kmac_sideload_functest.c
+++ b/sw/device/tests/crypto/kmac_sideload_functest.c
@@ -357,7 +357,8 @@ bool test_main(void) {
   LOG_INFO("Keymgr entered %s State", state_name);
   LOG_INFO("Testing cryptolib KMAC driver with sideloaded key.");
 
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   // Initialize the core with default parameters
   CHECK_STATUS_OK(kmac_hwip_default_configure());
 

--- a/sw/device/tests/crypto/otcrypto_export_test.c
+++ b/sw/device/tests/crypto/otcrypto_export_test.c
@@ -74,7 +74,8 @@ int32_t hash_test(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  RETURN_IF_ERROR(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  RETURN_IF_ERROR(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   int result = hash_test();
   return result == 0;
 }

--- a/sw/device/tests/crypto/otcrypto_hash_test.c
+++ b/sw/device/tests/crypto/otcrypto_hash_test.c
@@ -61,7 +61,8 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   result = hash_test();
   return status_ok(result);

--- a/sw/device/tests/crypto/otcrypto_interface.h
+++ b/sw/device/tests/crypto/otcrypto_interface.h
@@ -20,7 +20,7 @@ typedef struct otcrypto_interface_t {
   otcrypto_status_t (*set_security_config)(otcrypto_key_security_level_t);
   otcrypto_status_t (*disable_icache)(hardened_bool_t *);
   otcrypto_status_t (*restore_icache)(hardened_bool_t);
-  otcrypto_status_t (*init)(otcrypto_key_security_level_t);
+  otcrypto_status_t (*init)(otcrypto_key_security_level_t, otcrypto_state_t *);
   otcrypto_status_t (*eval_exit)(otcrypto_status_t);
 
   // Build info

--- a/sw/device/tests/crypto/rsa_2048_encryption_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_encryption_functest.c
@@ -671,7 +671,8 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   EXECUTE_TEST(test_result, oaep_decrypt_valid_test);
   EXECUTE_TEST(test_result, oaep_encrypt_decrypt_test);
   EXECUTE_TEST(test_result, run_encrypt_negative_tests);

--- a/sw/device/tests/crypto/rsa_2048_key_from_cofactor_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_key_from_cofactor_functest.c
@@ -282,7 +282,8 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   EXECUTE_TEST(test_result, keypair_from_p_test);
   EXECUTE_TEST(test_result, keypair_from_q_test);
   EXECUTE_TEST(test_result, run_cofactor_negative_tests);

--- a/sw/device/tests/crypto/rsa_2048_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_keygen_functest.c
@@ -265,7 +265,8 @@ static status_t run_async_wrong_finalize_tests(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   status_t test_result = OK_STATUS();
   EXECUTE_TEST(test_result, keygen_then_sign_test);

--- a/sw/device/tests/crypto/rsa_2048_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_signature_functest.c
@@ -524,7 +524,8 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   EXECUTE_TEST(test_result, pkcs1v15_sign_test);
   EXECUTE_TEST(test_result, pkcs1v15_verify_valid_test);
   EXECUTE_TEST(test_result, pkcs1v15_verify_invalid_test);

--- a/sw/device/tests/crypto/rsa_3072_encryption_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_encryption_functest.c
@@ -249,7 +249,8 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   EXECUTE_TEST(test_result, oaep_decrypt_valid_test);
   EXECUTE_TEST(test_result, oaep_encrypt_decrypt_test);
   return status_ok(test_result);

--- a/sw/device/tests/crypto/rsa_3072_key_from_cofactor_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_key_from_cofactor_functest.c
@@ -233,7 +233,8 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   EXECUTE_TEST(test_result, keypair_from_p_test);
   EXECUTE_TEST(test_result, keypair_from_q_test);
   EXECUTE_TEST(test_result, run_cofactor_negative_tests);

--- a/sw/device/tests/crypto/rsa_3072_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_keygen_functest.c
@@ -122,7 +122,8 @@ status_t keygen_then_sign_test(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   status_t test_result = OK_STATUS();
   EXECUTE_TEST(test_result, keygen_then_sign_test);

--- a/sw/device/tests/crypto/rsa_3072_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_signature_functest.c
@@ -389,7 +389,8 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   EXECUTE_TEST(test_result, pkcs1v15_sign_test);
   EXECUTE_TEST(test_result, pkcs1v15_verify_valid_test);
   EXECUTE_TEST(test_result, pkcs1v15_verify_invalid_test);

--- a/sw/device/tests/crypto/rsa_4096_encryption_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_encryption_functest.c
@@ -269,7 +269,8 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   EXECUTE_TEST(test_result, oaep_decrypt_valid_test);
   EXECUTE_TEST(test_result, oaep_encrypt_decrypt_test);
   return status_ok(test_result);

--- a/sw/device/tests/crypto/rsa_4096_key_from_cofactor_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_key_from_cofactor_functest.c
@@ -251,7 +251,8 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   EXECUTE_TEST(test_result, keypair_from_p_test);
   EXECUTE_TEST(test_result, keypair_from_q_test);
   EXECUTE_TEST(test_result, run_cofactor_negative_tests);

--- a/sw/device/tests/crypto/rsa_4096_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_keygen_functest.c
@@ -122,7 +122,8 @@ status_t keygen_then_sign_test(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   status_t test_result = OK_STATUS();
   EXECUTE_TEST(test_result, keygen_then_sign_test);

--- a/sw/device/tests/crypto/rsa_4096_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_signature_functest.c
@@ -364,7 +364,8 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   EXECUTE_TEST(test_result, pkcs1v15_sign_test);
   EXECUTE_TEST(test_result, pkcs1v15_verify_valid_test);
   EXECUTE_TEST(test_result, pkcs1v15_verify_invalid_test);

--- a/sw/device/tests/crypto/sha256_functest.c
+++ b/sw/device/tests/crypto/sha256_functest.c
@@ -231,7 +231,8 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   EXECUTE_TEST(test_result, simple_test);
   EXECUTE_TEST(test_result, empty_test);
   EXECUTE_TEST(test_result, two_block_test);

--- a/sw/device/tests/crypto/sha384_functest.c
+++ b/sw/device/tests/crypto/sha384_functest.c
@@ -162,7 +162,8 @@ static volatile status_t test_result;
 
 bool test_main(void) {
   test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   EXECUTE_TEST(test_result, empty_test);
   EXECUTE_TEST(test_result, one_block_test);
   EXECUTE_TEST(test_result, two_block_test);

--- a/sw/device/tests/crypto/sha512_functest.c
+++ b/sw/device/tests/crypto/sha512_functest.c
@@ -151,7 +151,8 @@ static volatile status_t test_result;
 
 bool test_main(void) {
   test_result = OK_STATUS();
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   EXECUTE_TEST(test_result, one_block_test);
   EXECUTE_TEST(test_result, two_block_test);
   EXECUTE_TEST(test_result, streaming_test);

--- a/sw/device/tests/crypto/symmetric_keygen_functest.c
+++ b/sw/device/tests/crypto/symmetric_keygen_functest.c
@@ -277,7 +277,8 @@ static status_t test_setup(void) {
   // Initialize entropy complex for cryptolib, which the key manager uses to
   // clear sideloaded keys. The `keymgr_testutils_startup` function restarts
   // the device, so this should happen afterwards.
-  return otcrypto_init(kOtcryptoKeySecurityLevelLow);
+  otcrypto_state_t state = {0};
+  return otcrypto_init(kOtcryptoKeySecurityLevelLow, &state);
 }
 
 bool test_main(void) {

--- a/sw/device/tests/crypto/x25519_functest.c
+++ b/sw/device/tests/crypto/x25519_functest.c
@@ -187,7 +187,8 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   status_t result = OK_STATUS();
 
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
 
   EXECUTE_TEST(result, x25519_kat_test);
   EXECUTE_TEST(result, x25519_keygen_test);

--- a/sw/device/tests/crypto/x25519_sideload_functest.c
+++ b/sw/device/tests/crypto/x25519_sideload_functest.c
@@ -209,7 +209,8 @@ static status_t test_setup(void) {
   TRY(keymgr_testutils_check_state(&keymgr, kDifKeymgrStateOwnerRootKey));
 
   // Initialize entropy complex for cryptolib.
-  return otcrypto_init(kOtcryptoKeySecurityLevelLow);
+  otcrypto_state_t state = {0};
+  return otcrypto_init(kOtcryptoKeySecurityLevelLow, &state);
 }
 
 OTTF_DEFINE_TEST_CONFIG();

--- a/sw/device/tests/penetrationtests/firmware/firmware_cryptolib_fi_asym.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware_cryptolib_fi_asym.c
@@ -39,7 +39,8 @@ status_t process_cmd(ujson_t *uj) {
 }
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   ujson_t uj = ujson_ottf_console();
   return status_ok(process_cmd(&uj));
 }

--- a/sw/device/tests/penetrationtests/firmware/firmware_cryptolib_fi_sym.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware_cryptolib_fi_sym.c
@@ -39,7 +39,8 @@ status_t process_cmd(ujson_t *uj) {
 }
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   ujson_t uj = ujson_ottf_console();
   return status_ok(process_cmd(&uj));
 }

--- a/sw/device/tests/penetrationtests/firmware/firmware_cryptolib_sca_asym.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware_cryptolib_sca_asym.c
@@ -45,7 +45,8 @@ status_t process_cmd(ujson_t *uj) {
 }
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   ujson_t uj = ujson_ottf_console();
   return status_ok(process_cmd(&uj));
 }

--- a/sw/device/tests/penetrationtests/firmware/firmware_cryptolib_sca_sym.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware_cryptolib_sca_sym.c
@@ -45,7 +45,8 @@ status_t process_cmd(ujson_t *uj) {
 }
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   ujson_t uj = ujson_ottf_console();
   return status_ok(process_cmd(&uj));
 }

--- a/sw/device/tests/penetrationtests/firmware/firmware_gdb.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware_gdb.c
@@ -277,7 +277,8 @@ status_t handle_gdb(ujson_t *uj) {
 }
 
 bool test_main(void) {
-  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow));
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
   ujson_t uj = ujson_ottf_console();
   return status_ok(handle_gdb(&uj));
 }


### PR DESCRIPTION
The ENTROPY_SRC_EXTHT_HI_THRESHOLDS and ENTROPY_SRC_EXTHT_LO_THRESHOLDS are not used in the earlgrey_1.0.0 chip. These registers hold a total of 32-bit of data that can be written to if the entropy source is disabled and can be read at any time.
We use these registers as scratch for the cryptolib to hold the address of a variable given by the user of the library when calling otcrypto_init. This address can then be used to store a 32-bit word which the cryptolib can freely adapt.
Use this to create a stateful variant of the Known-Answer-Tests, namely to make them a lazy execution, executing them only at the first instance of a crypto operation.