### PR TITLE
[aes,dv] Remove dependency on push_pull_agent from AES environment

### DIFF
--- a/hw/ip/aes/dv/env/aes_env.core
+++ b/hw/ip/aes/dv/env/aes_env.core
@@ -12,7 +12,6 @@ filesets:
     depend:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
-      - lowrisc:dv:push_pull_agent
       - lowrisc:dv:csr_utils
       - lowrisc:dv:aes_model_dpi
       - lowrisc:dv:key_sideload_agent

--- a/hw/ip/aes/dv/env/aes_env_pkg.sv
+++ b/hw/ip/aes/dv/env/aes_env_pkg.sv
@@ -12,7 +12,6 @@ package aes_env_pkg;
   import tl_agent_pkg::*;
   import dv_lib_pkg::*;
   import cip_base_pkg::*;
-  import push_pull_agent_pkg::*;
   import aes_reg_pkg::*;
   import aes_ral_pkg::*;
   import aes_pkg::*;


### PR DESCRIPTION
This was added with commit 889184a (which added an EDN connection but not an agent!). Since we're not actually using it, don't depend on the DV agent.