### PR TITLE
[ci] Revert "allocate airgap to self-hosted machine"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
 
   airgapped_build:
     name: Airgapped build
-    runs-on: ubuntu-22.04-vivado
+    runs-on: ubuntu-22.04
     needs: quick_lint
     if: ${{ github.event_name != 'merge_group' }}
     steps:
@@ -203,8 +203,8 @@ jobs:
         with:
           service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
           configure-bazel: false
-      # - name: Free disk space
-      #   uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
       - name: Check disk space
         run: |
           df -h


### PR DESCRIPTION
This reverts commit 76f732e9a81a177818c412c742a7e72b55df1216.

This commit was a test that was merged mistakenly. The job that it changes was disabled in CI so this was not caught.

See https://github.com/lowRISC/opentitan/pull/29154