### PR TITLE
[aes,dv] Add missing dependency to aes_cov.core

### DIFF
--- a/hw/ip/aes/dv/cov/aes_cov.core
+++ b/hw/ip/aes/dv/cov/aes_cov.core
@@ -9,6 +9,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:dv:dv_utils
+      - lowrisc:dv:cip_lib
       - lowrisc:ip:aes
     files:
       - aes_cov_if.sv


### PR DESCRIPTION
This core includes aes_cov_bind.sv, which binds a copy of cip_lc_tx_cov_if into any instance of aes. That interface is actually defined in lowrisc:dv:cip_lib, so we should depend on that.