### PR TITLE
[imm_section] Export symbols from immutable ROM_EXT section

### DIFF
--- a/rules/opentitan/transform.bzl
+++ b/rules/opentitan/transform.bzl
@@ -331,3 +331,84 @@ def convert_to_scrambled_rom_vmem(ctx, **kwargs):
         executable = tool,
     )
     return (output, hashfile)
+
+def obj_blob(ctx, src, output_section, exports = [], abs = True, prefix_exports = "", **kwargs):
+    """Transform an ELF to a binary blob and package it in an object file with symbols.
+
+    Args:
+      ctx: The rule context.
+      src: The src ELF or BIN File object.
+      output_section: The section name for the binary blob in the output object file.
+      exports: A list of exact symbol names to export from the ELF.
+      abs: Whether to export symbols as absolute symbols (default True).
+      prefix_exports: Prefix to add to the exported symbols.
+      kwargs: Overrides of values normally retrieved from the context object.
+        name: Name of the output object file (without extension).
+    Returns:
+      The output object File.
+    """
+    name = get_override(ctx, "attr.name", kwargs)
+
+    if src.extension == "bin":
+        if exports:
+            fail("Cannot export symbols from a raw binary file: {}".format(src.path))
+        binary = src
+    else:
+        # 1. Convert ELF to binary blob
+        binary = obj_transform(
+            ctx,
+            name = name + "_blob",
+            strip_llvm_prf_cnts = True,
+            suffix = "bin",
+            format = "binary",
+            src = src,
+        )
+
+    # 2. Convert binary blob to object file and add symbols
+    output_o = ctx.actions.declare_file("{}.o".format(name))
+    tool = get_override(ctx, "executable._add_shared_symbols_tool", kwargs)
+
+    cc_toolchain = find_cc_toolchain(ctx)
+    feature_config = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+    objcopy = cc_common.get_tool_for_action(
+        feature_configuration = feature_config,
+        action_name = OBJ_COPY_ACTION_NAME,
+    )
+    objdump = cc_common.get_tool_for_action(
+        feature_configuration = feature_config,
+        action_name = OT_ACTION_OBJDUMP,
+    )
+
+    args = ctx.actions.args()
+    args.add("--bin", binary)
+    args.add("--output", output_o)
+    args.add("--output-section", output_section)
+    if exports:
+        args.add("--elf", src)
+        args.add_all(exports, before_each = "--symbol")
+    if abs:
+        args.add("--abs")
+    args.add("--prefix", prefix_exports)
+    args.add("--objcopy", objcopy)
+    args.add("--objdump", objdump)
+
+    inputs = [binary]
+    if exports:
+        inputs.append(src)
+
+    ctx.actions.run(
+        outputs = [output_o],
+        inputs = depset(
+            inputs,
+            transitive = [cc_toolchain.all_files],
+        ),
+        arguments = [args],
+        executable = tool,
+    )
+
+    return output_o

--- a/sw/device/silicon_creator/rom_ext/imm_section/BUILD
+++ b/sw/device/silicon_creator/rom_ext/imm_section/BUILD
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_python//python:defs.bzl", "py_binary")
 load("@lowrisc_opentitan//rules/opentitan:transform.bzl", "obj_transform")
 load("//rules/coverage:view.bzl", "coverage_view_test")
 load("//rules/coverage:asm.bzl", "asm_library_with_coverage")
@@ -184,4 +185,12 @@ imm_section_bundle(
         variation_name: ":main_binaries_{}_slot_virtual".format(variation_name)
         for variation_name, _ in ROM_EXT_VARIATIONS.items()
     },
+)
+
+py_binary(
+    name = "exportability_test_tool",
+    testonly = True,
+    srcs = ["exportability_test_tool.py"],
+    main = "exportability_test_tool.py",
+    visibility = ["//sw/device/silicon_creator/rom_ext/imm_section:__subpackages__"],
 )

--- a/sw/device/silicon_creator/rom_ext/imm_section/e2e/export/BUILD
+++ b/sw/device/silicon_creator/rom_ext/imm_section/e2e/export/BUILD
@@ -1,0 +1,136 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//rules/opentitan:defs.bzl",
+    "fpga_params",
+    "opentitan_binary",
+    "opentitan_test",
+    "qemu_params",
+)
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load(
+    "//sw/device/silicon_creator/rom_ext/imm_section:utils.bzl",
+    "create_imm_section_targets",
+    "exportability_test",
+)
+load(
+    "//sw/device/silicon_creator/rom_ext/imm_section:defs.bzl",
+    "DEFAULT_EXEC_ENV",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+EXPORTS = [
+    "test_string",
+    "test_add",
+    "memcpy",
+]
+
+PLACEMENTS = {
+    "a": "{rom_ext_slot_a}",
+    "b": "{rom_ext_slot_b}",
+    "virtual": "{rom_ext_slot_a}",
+}
+
+VARIANTS = [
+    {
+        "name": "test_imm_lib",
+        "copts": [],
+        "expect_fail": False,
+    },
+    {
+        "name": "test_imm_lib_bss",
+        "copts": ["-DUSE_BSS"],
+        "expect_fail": True,
+    },
+    {
+        "name": "test_imm_lib_data",
+        "copts": ["-DUSE_DATA"],
+        "expect_fail": True,
+    },
+]
+
+[
+    cc_library(
+        name = var["name"],
+        testonly = True,
+        srcs = ["test_imm_blob.c"],
+        copts = var["copts"],
+        deps = [
+            "//sw/device/lib/base:memory",
+            "//sw/device/silicon_creator/lib/base:static_critical",
+            "//sw/device/silicon_creator/lib/base:static_dice",
+            "//sw/device/silicon_creator/rom_ext/imm_section:imm_section_version_def",
+        ],
+    )
+    for var in VARIANTS
+]
+
+[
+    # Test imm_section binary for slot.
+    opentitan_binary(
+        name = "test_imm_section_bin_slot_{}".format(slot),
+        testonly = True,
+        exec_env = DEFAULT_EXEC_ENV,
+        extra_bazel_features = [
+            "minsize",
+            "use_lld",
+        ],
+        linker_script = "//sw/device/silicon_creator/rom_ext/imm_section:ld_slot_{}".format(slot),
+        manifest = "//hw/top_earlgrey:none_manifest",
+        deps = [
+            ":test_imm_lib",
+        ],
+    )
+    for slot in PLACEMENTS.keys()
+]
+
+[
+    # Create custom imm_section target from the test binary for slot.
+    create_imm_section_targets(
+        name = "test_imm_section_slot_{}".format(slot),
+        testonly = True,
+        src = ":test_imm_section_bin_slot_{}".format(slot),
+        prefix_exports = "imm_shared_",
+        exports = EXPORTS,
+    )
+    for slot in PLACEMENTS.keys()
+]
+
+[
+    # Run the test at the rom_ext stage. The test program itself acts as the rom_ext
+    # and embeds our test_imm_section in the .rom_ext_immutable section.
+    opentitan_test(
+        name = "export_test_slot_{}".format(slot),
+        srcs = ["export_test.c"],
+        exec_env = {
+            "//hw/top_earlgrey:sim_qemu_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
+        },
+        fpga = fpga_params(
+            assemble = "{{firmware}}@{}".format(PLACEMENTS[slot]),
+        ),
+        linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_{}".format(slot),
+        qemu = qemu_params(
+            assemble = "{{firmware}}@{}".format(PLACEMENTS[slot]),
+        ),
+        deps = [
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            ":test_imm_section_slot_{}".format(slot),
+        ],
+    )
+    for slot in PLACEMENTS.keys()
+]
+
+[
+    exportability_test(
+        name = var["name"] + "_exportability_test",
+        expect_fail = var["expect_fail"],
+        exports = EXPORTS,
+        deps = [":" + var["name"]],
+    )
+    for var in VARIANTS
+]

--- a/sw/device/silicon_creator/rom_ext/imm_section/e2e/export/export_test.c
+++ b/sw/device/silicon_creator/rom_ext/imm_section/e2e/export/export_test.c
@@ -1,0 +1,50 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+// Declare the shared symbols
+extern const char imm_shared_test_string[];
+extern int imm_shared_test_add(int a, int b);
+extern void *imm_shared_memcpy(void *dest, const void *src, size_t n);
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  LOG_INFO("Running imm_section export test...");
+
+  // 1. Test test_add
+  int sum = imm_shared_test_add(2, 3);
+  LOG_INFO("test_add(2, 3) = %d", sum);
+  if (sum != 5) {
+    LOG_ERROR("Expected test_add(2, 3) to be 5, got %d", sum);
+    return false;
+  }
+
+  // 2. Test test_string
+  LOG_INFO("test_string = '%s'", imm_shared_test_string);
+  const char expected_string[] = "Hello from test imm_section!";
+  if (memcmp(imm_shared_test_string, expected_string,
+             sizeof(expected_string)) != 0) {
+    LOG_ERROR("Expected test_string '%s', got '%s'", expected_string,
+              imm_shared_test_string);
+    return false;
+  }
+
+  // 3. Test memcpy
+  char src[] = "Shared memcpy works!";
+  char dst[32];
+  memset(dst, 0, sizeof(dst));
+
+  imm_shared_memcpy(dst, src, sizeof(src));
+
+  if (memcmp(dst, src, sizeof(src)) != 0) {
+    LOG_ERROR("Expected memcpy destination '%s', got '%s'", src, dst);
+    return false;
+  }
+
+  return true;
+}

--- a/sw/device/silicon_creator/rom_ext/imm_section/e2e/export/test_imm_blob.c
+++ b/sw/device/silicon_creator/rom_ext/imm_section/e2e/export/test_imm_blob.c
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+
+const char test_string[] = "Hello from test imm_section!";
+
+int bss_var;
+int data_var = 42;
+
+int test_add(int a, int b) {
+#ifdef USE_BSS
+  bss_var++;
+#endif
+#ifdef USE_DATA
+  data_var++;
+#endif
+  return a + b;
+}
+
+// Global pointers used to reference the symbols from the entry point,
+// preventing the linker from garbage collecting them.
+const void *test_string_ref;
+const void *test_add_ref;
+const void *memcpy_ref;
+
+void _imm_section_start_boot(void) {
+  test_string_ref = test_string;
+  test_add_ref = (const void *)test_add;
+  memcpy_ref = (const void *)memcpy;
+}

--- a/sw/device/silicon_creator/rom_ext/imm_section/exportability_test_tool.py
+++ b/sw/device/silicon_creator/rom_ext/imm_section/exportability_test_tool.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import subprocess
+import sys
+import re
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Verify imm_section exportability.")
+    parser.add_argument("object", help="The object file to check.")
+    parser.add_argument("--objdump", default="llvm-objdump", help="Path to objdump tool.")
+    parser.add_argument(
+        "--expect-fail",
+        action="store_true",
+        help="Expect the verification to fail.",
+    )
+    args = parser.parse_args()
+
+    # Run objdump -h to get section headers
+    try:
+        res = subprocess.run(
+            [args.objdump, "-h", args.object],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Error running objdump: {e.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    print("Objdump output:")
+    print(res.stdout)
+
+    # Run objdump -t to get symbol table
+    try:
+        res_t = subprocess.run(
+            [args.objdump, "-t", args.object],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+        print("Symbol table:")
+        print(res_t.stdout)
+    except subprocess.CalledProcessError as e:
+        print(f"Error running objdump -t: {e.stderr}", file=sys.stderr)
+
+    # Parse sections and check sizes for .data and .bss
+    # Lines look like:
+    #  Idx Name          Size      VMA       LMA       File off  Algn
+    #    0 .text         000000a4  ...
+    # We look for .data and .bss and check if size is non-zero.
+    # Note that sections might not exist, which is fine (size is 0).
+
+    # Matches: index name size ...
+    # Section name is group 2, size is group 3.
+    pattern = re.compile(r"^\s*(\d+)\s+(\.\S+)\s+([0-9a-fA-F]+)")
+    section_pattern = re.compile(r"^\.(data|bss|sbss|sdata)(\..*)?$")
+
+    failed = False
+    for line in res.stdout.splitlines():
+        m = pattern.match(line)
+        if not m:
+            continue
+        idx, name, size_hex = m.groups()
+        if section_pattern.match(name):
+            size = int(size_hex, 16)
+            if size > 0:
+                print(
+                    f"ERROR: Section {name} has non-zero size: {size_hex} "
+                    f"({size} bytes)",
+                    file=sys.stderr,
+                )
+                failed = True
+
+    if failed:
+        if args.expect_fail:
+            print("PASS: Verification failed as expected.")
+            sys.exit(0)
+        else:
+            sys.exit(1)
+    else:
+        if args.expect_fail:
+            print("FAIL: Expected verification to fail, but it passed!", file=sys.stderr)
+            sys.exit(1)
+        else:
+            print("PASS: .data and .bss are empty or absent.")
+            sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/sw/device/silicon_creator/rom_ext/imm_section/utils.bzl
+++ b/sw/device/silicon_creator/rom_ext/imm_section/utils.bzl
@@ -12,7 +12,9 @@ load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load(
     "@rules_cc//cc:action_names.bzl",
     "CPP_LINK_STATIC_LIBRARY_ACTION_NAME",
+    "OBJ_COPY_ACTION_NAME",
 )
+load("//rules:actions.bzl", "OT_ACTION_OBJDUMP")
 load("@lowrisc_opentitan//rules:rv.bzl", "rv_rule")
 load("@lowrisc_opentitan//rules/opentitan:transform.bzl", "obj_blob")
 load(
@@ -210,3 +212,99 @@ def imm_section_bundle(name, variants, **kwargs):
         variants_values = variants.values(),
         **kwargs
     )
+
+def _exportability_test_impl(ctx):
+    cc_toolchain = find_cc_toolchain(ctx)
+    features = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+    )
+
+    # Partial link
+    linking_contexts = [dep[CcInfo].linking_context for dep in ctx.attr.deps]
+    linkopts = [
+        "-nostdlib",
+        "-Wl,-r",
+        "-Wl,--gc-sections",
+    ]
+    for sym in ctx.attr.exports:
+        linkopts.append("-Wl,-u,{}".format(sym))
+
+    name_relocatable_o = ctx.attr.name + "_relocatable.o"
+    linking_outputs = cc_common.link(
+        name = name_relocatable_o,
+        actions = ctx.actions,
+        output_type = "executable",
+        feature_configuration = features,
+        cc_toolchain = cc_toolchain,
+        linking_contexts = linking_contexts,
+        user_link_flags = linkopts,
+    )
+    relocatable_o = linking_outputs.executable
+
+    # Find objdump in toolchain
+    objdump_path = cc_common.get_tool_for_action(
+        feature_configuration = features,
+        action_name = OT_ACTION_OBJDUMP,
+    )
+
+    test_script = ctx.actions.declare_file(ctx.attr.name + "_test.sh")
+    script_content = """
+        exec "{test_tool}" "{object}" --objdump "{objdump}" {expect_fail_flag}
+    """.format(
+        test_tool = ctx.executable._test_tool.short_path,
+        object = relocatable_o.short_path,
+        objdump = objdump_path,
+        expect_fail_flag = "--expect-fail" if ctx.attr.expect_fail else "",
+    )
+
+    ctx.actions.write(
+        output = test_script,
+        content = script_content,
+        is_executable = True,
+    )
+
+    # Runfiles
+    runfiles = ctx.runfiles(
+        files = [
+            relocatable_o,
+            ctx.executable._test_tool,
+        ],
+        transitive_files = cc_toolchain.all_files,
+    ).merge(ctx.attr._test_tool[DefaultInfo].default_runfiles)
+
+    return [
+        DefaultInfo(
+            executable = test_script,
+            runfiles = runfiles,
+        ),
+    ]
+
+exportability_test = rv_rule(
+    implementation = _exportability_test_impl,
+    attrs = {
+        "deps": attr.label_list(
+            providers = [CcInfo],
+            doc = "The libraries to test for exportability. Usually contains the imm_section library under test.",
+        ),
+        "exports": attr.string_list(
+            default = [],
+            doc = "The list of symbols that are expected to be exported from the library. These will be used as GC roots during partial link.",
+        ),
+        "expect_fail": attr.bool(
+            default = False,
+            doc = "If True, the test is expected to fail (i.e. validation finds BSS/data). Used for negative testing.",
+        ),
+        "_test_tool": attr.label(
+            default = "//sw/device/silicon_creator/rom_ext/imm_section:exportability_test_tool",
+            executable = True,
+            cfg = "exec",
+        ),
+        "_cc_toolchain": attr.label(
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        ),
+    },
+    fragments = ["cpp"],
+    test = True,
+    toolchains = ["@rules_cc//cc:toolchain_type"],
+)

--- a/sw/device/silicon_creator/rom_ext/imm_section/utils.bzl
+++ b/sw/device/silicon_creator/rom_ext/imm_section/utils.bzl
@@ -12,9 +12,9 @@ load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load(
     "@rules_cc//cc:action_names.bzl",
     "CPP_LINK_STATIC_LIBRARY_ACTION_NAME",
-    "OBJ_COPY_ACTION_NAME",
 )
 load("@lowrisc_opentitan//rules:rv.bzl", "rv_rule")
+load("@lowrisc_opentitan//rules/opentitan:transform.bzl", "obj_blob")
 load(
     "//sw/device/silicon_creator/rom_ext/imm_section:defs.bzl",
     "IMM_SECTION_VERSION",
@@ -61,55 +61,32 @@ def _cc_import(ctx, cc_toolchain, object):
     return static_library, cc_info
 
 def _choose_one_build(src):
-    # Returns binary_file, [Runfiles]
-
     if type(src) == "File":
-        return src, []
+        return src
 
     # e2e/exec_env tests ensure the immutable rom_ext is the same across all
     # exec env.
-    bin = get_one_binary_file(src, field = "binary", providers = [SiliconBinaryInfo])
-    elf = get_one_binary_file(src, field = "elf", providers = [SiliconBinaryInfo])
-    return bin, [elf]
+    return get_one_binary_file(src, field = "elf", providers = [SiliconBinaryInfo])
 
 def _create_imm_section_targets_impl(ctx):
     cc_toolchain = find_cc_toolchain(ctx)
-    feature_config = cc_common.configure_features(
-        ctx = ctx,
-        cc_toolchain = cc_toolchain,
-        requested_features = ctx.features,
-        unsupported_features = ctx.disabled_features,
-    )
-    objcopy = cc_common.get_tool_for_action(
-        feature_configuration = feature_config,
-        action_name = OBJ_COPY_ACTION_NAME,
+    src_file = _choose_one_build(ctx.attr.src)
+    runfiles = [src_file]
+
+    if not src_file:
+        fail("create_imm_section_targets requires src file")
+
+    # Use the new generic obj_blob helper
+    final_object = obj_blob(
+        ctx,
+        output_section = ".rom_ext_immutable",
+        exports = ctx.attr.exports,
+        abs = True,
+        prefix_exports = ctx.attr.prefix_exports,
+        src = src_file,
     )
 
-    src, runfiles = _choose_one_build(ctx.attr.src)
-
-    object = ctx.actions.declare_file(
-        "{}.{}".format(
-            src.basename.replace("." + src.extension, ""),
-            "o",
-        ),
-    )
-    ctx.actions.run(
-        outputs = [object],
-        inputs = [src] + cc_toolchain.all_files.to_list(),
-        arguments = [
-            "-I",
-            "binary",
-            "-O",
-            "elf32-littleriscv",
-            "--rename-section",
-            ".data=.rom_ext_immutable,alloc,load,readonly,data,contents",
-            src.path,
-            object.path,
-        ],
-        executable = objcopy,
-    )
-
-    lib, cc_info = _cc_import(ctx, cc_toolchain, object)
+    lib, cc_info = _cc_import(ctx, cc_toolchain, final_object)
 
     return [
         DefaultInfo(
@@ -122,7 +99,28 @@ def _create_imm_section_targets_impl(ctx):
 create_imm_section_targets = rv_rule(
     implementation = _create_imm_section_targets_impl,
     attrs = {
-        "src": attr.label(allow_files = True),
+        "src": attr.label(
+            allow_files = True,
+            doc = "The source test binary (typically an ELF or a SiliconBinaryInfo target) from which to extract the immutable section.",
+        ),
+        "exports": attr.string_list(
+            default = [],
+            doc = "The list of exact symbol names to export from the binary blob. These symbols will be made public in the generated object file.",
+        ),
+        "prefix_exports": attr.string(
+            default = "imm_shared_",
+            doc = "A prefix to prepend to each exported symbol name to avoid naming collisions.",
+        ),
+        "_add_shared_symbols_tool": attr.label(
+            default = "//util:add_shared_symbols",
+            executable = True,
+            cfg = "exec",
+        ),
+        "_check_initial_coverage": attr.label(
+            default = "//util/coverage:check_initial_coverage",
+            executable = True,
+            cfg = "exec",
+        ),
         "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
     fragments = ["cpp"],

--- a/util/BUILD
+++ b/util/BUILD
@@ -98,3 +98,8 @@ py_binary(
     name = "gen_stamped_tarball",
     srcs = ["gen_stamped_tarball.py"],
 )
+
+py_binary(
+    name = "add_shared_symbols",
+    srcs = ["add_shared_symbols.py"],
+)

--- a/util/add_shared_symbols.py
+++ b/util/add_shared_symbols.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import re
+import subprocess
+import sys
+
+
+def get_symbol_table(elf, objdump_path):
+    """Runs objdump -t on the ELF and parses the output.
+
+    Returns a dict mapping symbol name to its address (int).
+    """
+    try:
+        objdump_res = subprocess.run(
+            [objdump_path, "-t", elf],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Error running objdump: {e.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    symbols = {}
+    # Matches: <address> <flags> <section> <size> <name>
+    # Address can be 8 or 16 hex chars, or spaces (for undefined symbols)
+    # Flags is 7 chars. Section is non-whitespace. Size is hex. Name is non-whitespace.
+    pattern = re.compile(
+        r"^([0-9a-fA-F]{8,16}| {8,16}) (.{7}) (\S+)\s+([0-9a-fA-F]{8,16})\s+(\S+)"
+    )
+    for line in objdump_res.stdout.splitlines():
+        m = pattern.match(line)
+        if not m:
+            continue
+        addr_str, flags, section, size_str, name = m.groups()
+
+        if section == "*UND*":
+            continue
+
+        try:
+            addr = int(addr_str, 16) if addr_str.strip() else 0
+            symbols[name] = addr
+        except ValueError:
+            continue
+    return symbols
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert binary to object file and add shared symbols."
+    )
+    parser.add_argument(
+        "-b", "--bin", required=True, help="Input binary file."
+    )
+    parser.add_argument("-e", "--elf", help="Input ELF file.")
+    parser.add_argument("-o", "--output", required=True, help="Output .o file.")
+    parser.add_argument(
+        "-s",
+        "--symbol",
+        action="append",
+        dest="symbols",
+        help="Symbol name to export. Can be specified multiple times.",
+    )
+    parser.add_argument(
+        "--output-section",
+        default=".rodata",
+        help="Section name for the binary blob.",
+    )
+    parser.add_argument(
+        "--abs", action="store_true", help="Export symbols as absolute symbols."
+    )
+    parser.add_argument(
+        "--prefix", default="", help="Prefix to add to exported symbols."
+    )
+    parser.add_argument(
+        "--objcopy", default="llvm-objcopy", help="Path to objcopy tool."
+    )
+    parser.add_argument(
+        "--objdump", default="llvm-objdump", help="Path to objdump tool."
+    )
+
+    args = parser.parse_args()
+
+    symbols_to_export = args.symbols if args.symbols else []
+
+    objcopy_args = [
+        args.objcopy,
+        "-I",
+        "binary",
+        "-O",
+        "elf32-littleriscv",
+        "--rename-section",
+        f".data={args.output_section}",
+    ]
+
+    if symbols_to_export:
+        if not args.elf:
+            print(
+                "Error: --elf is required when exporting symbols.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        symbol_table = get_symbol_table(args.elf, args.objdump)
+
+        # Match symbols
+        matched_symbols = {}
+        missing_symbols = []
+        for sym_name in symbols_to_export:
+            if sym_name in symbol_table:
+                matched_symbols[sym_name] = symbol_table[sym_name]
+            else:
+                missing_symbols.append(sym_name)
+
+        if missing_symbols:
+            for sym_name in missing_symbols:
+                print(
+                    f"Error: symbol '{sym_name}' not found in ELF.",
+                    file=sys.stderr,
+                )
+            sys.exit(1)
+
+        for sym_name, addr in matched_symbols.items():
+            export_name = f"{args.prefix}{sym_name}"
+            if args.abs:
+                # Absolute symbol
+                objcopy_args.append(f"--add-symbol={export_name}=0x{addr:x},global")
+            else:
+                # Relative symbol (offset is same as address if base is assumed to be 0)
+                objcopy_args.append(
+                    f"--add-symbol={export_name}={args.output_section}:0x{addr:x},global"
+                )
+
+    objcopy_args.extend([args.bin, args.output])
+
+    try:
+        subprocess.run(
+            objcopy_args,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Error running objcopy: {e.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This patch introduces a mechanism to export symbols from the immutable ROM_EXT section, enabling users to link against functions/objects defined inside the `.rom_ext_immutable` section to save firmware space.