### PR TITLE
[conn] Fix connectivity check for flash test modes

### DIFF
--- a/hw/top_earlgrey/formal/conn_csvs/analog_sigs.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/analog_sigs.csv
@@ -8,9 +8,8 @@
 ,NAME,SRC BLOCK,SRC SIGNAL,DEST BLOCK,DEST SIGNAL,,,,,,
 
 CONNECTION, OTP_EXT_VOLT,     , OTP_EXT_VOLT,     top_earlgrey.u_otp_macro                  , ext_voltage_h_io,
-CONNECTION, FLASH_TEST_MODE_O,, "{FLASH_TEST_MODE1, FLASH_TEST_MODE0}", top_earlgrey.u_flash_ctrl.u_eflash.u_flash, flash_test_mode_a_io,
-CONNECTION, FLASH_TEST_MODE_I,  top_earlgrey.u_flash_ctrl.u_eflash.u_flash, flash_test_mode_a_io, , "{FLASH_TEST_MODE1, FLASH_TEST_MODE0}",
-CONNECTION, FLASH_TEST_VOLT_O,, FLASH_TEST_VOLT,  top_earlgrey.u_flash_ctrl.u_eflash.u_flash, flash_test_voltage_h_io,
-CONNECTION, FLASH_TEST_VOLT_I,  top_earlgrey.u_flash_ctrl.u_eflash.u_flash, flash_test_voltage_h_io, , FLASH_TEST_VOLT,
+CONNECTION, FLASH_TEST_MODE0, , FLASH_TEST_MODE0, top_earlgrey.u_flash_ctrl.u_eflash.u_flash, flash_test_mode_a_io[0],
+CONNECTION, FLASH_TEST_MODE1, , FLASH_TEST_MODE1, top_earlgrey.u_flash_ctrl.u_eflash.u_flash, flash_test_mode_a_io[1],
+CONNECTION, FLASH_TEST_VOLT,  , FLASH_TEST_VOLT,  top_earlgrey.u_flash_ctrl.u_eflash.u_flash, flash_test_voltage_h_io,
 CONNECTION, AST_CC1,          , CC1,              u_ast,                                      adc_a0_ai,
 CONNECTION, AST_CC2,          , CC2,              u_ast,                                      adc_a1_ai,


### PR DESCRIPTION
These were changed in 945e4ed86de, which was definitely wrong: the syntax isn't even understood by the tool!

Generate one connectivity assertion per pad (getting rid of the syntactically incorrect bit vectors) but drop the unnecessary assertion in each direction.

*Note: There are quite a lot of other syntactically incorrect lines in the connectivity list. I suspect the author hadn't actually used the tool after adding them. As such, there will be other similar PRs.*