### PR TITLE
[rom_ext/ownership] Make ISFB feature configurable at build/link time

### DIFF
--- a/sw/device/silicon_creator/lib/boot_log.h
+++ b/sw/device/silicon_creator/lib/boot_log.h
@@ -94,6 +94,14 @@ enum {
 #define BOOT_LOG_EVENT_REDUNDANCY 0
 
 /**
+ * Boot log event (bit 1): ISFB configuration error.
+ *
+ * Set to 1 if the chip requires ISFB checks (owner config has isfb enabled),
+ * but the ROM_EXT is linked with the isfb_null stub.
+ */
+#define BOOT_LOG_EVENT_ISFB_ERROR 1
+
+/**
  * Updates the digest of the boot_log.
  *
  * This function computes the digest over all fields of the boot_log_t struct

--- a/sw/device/silicon_creator/lib/mock_manifest.cc
+++ b/sw/device/silicon_creator/lib/mock_manifest.cc
@@ -39,5 +39,10 @@ rom_error_t manifest_ext_get_isfb(const manifest_t *manifest,
   return MockManifest::Instance().Isfb(manifest, isfb);
 }
 
+rom_error_t manifest_ext_get_isfb_erase(
+    const manifest_t *manifest, const manifest_ext_isfb_erase_t **isfb_erase) {
+  return MockManifest::Instance().IsfbErase(manifest, isfb_erase);
+}
+
 }  // extern "C"
 }  // namespace rom_test

--- a/sw/device/silicon_creator/lib/mock_manifest.h
+++ b/sw/device/silicon_creator/lib/mock_manifest.h
@@ -28,6 +28,9 @@ class MockManifest : public global_mock::GlobalMock<MockManifest> {
                const manifest_ext_spx_signature_t **spx_signature));
   MOCK_METHOD(rom_error_t, Isfb,
               (const manifest_t *, const manifest_ext_isfb_t **isfb));
+  MOCK_METHOD(rom_error_t, IsfbErase,
+              (const manifest_t *,
+               const manifest_ext_isfb_erase_t **isfb_erase));
 };
 
 }  // namespace internal

--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -31,19 +31,35 @@ cc_library(
 )
 
 cc_library(
-    name = "isfb",
-    srcs = ["isfb.c"],
+    name = "isfb_headers",
     hdrs = ["isfb.h"],
     deps = [
         ":datatypes",
         ":owner_block",
         "//sw/device/lib/base:hardened",
+        "//sw/device/silicon_creator/lib:manifest",
+    ],
+)
+
+cc_library(
+    name = "isfb",
+    srcs = ["isfb.c"],
+    deps = [
+        ":isfb_headers",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/lib:error",
-        "//sw/device/silicon_creator/lib:manifest",
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/lib/drivers:rnd",
+    ],
+)
+
+cc_library(
+    name = "isfb_null",
+    srcs = ["isfb_null.c"],
+    deps = [
+        ":isfb_headers",
+        "//sw/device/silicon_creator/lib:error",
     ],
 )
 
@@ -164,6 +180,7 @@ cc_test(
     ],
     deps = [
         ":datatypes",
+        ":isfb",
         ":owner_block",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/testing:binary_blob",

--- a/sw/device/silicon_creator/lib/ownership/isfb.c
+++ b/sw/device/silicon_creator/lib/ownership/isfb.c
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "sw/device/silicon_creator/lib/ownership/isfb.h"
 
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/hardened.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/manifest.h"
@@ -126,7 +128,7 @@ rom_error_t isfb_boot_request_process(const manifest_ext_isfb_t *ext,
 }
 
 rom_error_t isfb_info_flash_erase_policy_get(
-    owner_config_t *owner_config, uint32_t key_domain,
+    const owner_config_t *owner_config, uint32_t key_domain,
     hardened_bool_t manifest_is_node_locked,
     const manifest_ext_isfb_erase_t *ext_isfb_erase,
     hardened_bool_t *erase_en) {
@@ -187,3 +189,100 @@ rom_error_t isfb_info_flash_erase_policy_get(
 }
 
 extern uint32_t isfb_expected_count_get(const manifest_ext_isfb_t *ext);
+
+rom_error_t owner_block_info_isfb_erase_enable(
+    boot_data_t *bootdata, const owner_config_t *owner_config) {
+  if (bootdata->ownership_state != kOwnershipStateLockedOwner)
+    return kErrorOk;
+  // Check whether the ISFB configuration exists.
+  if ((hardened_bool_t)owner_config->isfb == kHardenedBoolFalse)
+    return kErrorOk;
+  // Check whether the FLASH INFO configuration exists.
+  if ((hardened_bool_t)owner_config->info == kHardenedBoolFalse)
+    return kErrorOk;
+
+  const owner_flash_info_config_t *info = owner_config->info;
+  size_t len = (info->header.length - sizeof(owner_flash_info_config_t)) /
+               sizeof(owner_info_page_t);
+
+  const owner_info_page_t *config = info->config;
+  uint32_t crypt = 0;
+  for (size_t i = 0; i < len; ++i, ++config, crypt += 0x11111111) {
+    if (is_owner_page(config->bank, config->page) == kHardenedBoolTrue &&
+        config->bank == owner_config->isfb->bank &&
+        config->page == owner_config->isfb->page) {
+      flash_ctrl_info_page_t page;
+      HARDENED_RETURN_IF_ERROR(flash_ctrl_info_type0_params_build(
+          config->bank, config->page, &page));
+
+      uint32_t val = config->access ^ crypt;
+      flash_ctrl_perms_t perm = {
+          .read = bitfield_field32_read(val, FLASH_CONFIG_READ),
+          .write = bitfield_field32_read(val, FLASH_CONFIG_PROGRAM),
+          .erase = kMultiBitBool4True,
+      };
+      flash_ctrl_info_perms_set(&page, perm);
+    }
+  }
+  return kErrorOk;
+}
+
+rom_error_t isfb_check_and_verify(const manifest_t *manifest,
+                                  const owner_config_t *owner_config,
+                                  uint32_t *isfb_check_count) {
+  // Perform ISFB checks if the extension is present.
+  if ((hardened_bool_t)owner_config->isfb != kHardenedBoolFalse) {
+    const manifest_ext_isfb_t *ext_isfb;
+    rom_error_t error = manifest_ext_get_isfb(manifest, &ext_isfb);
+    if (error == kErrorOk) {
+      *isfb_check_count = kHardenedBoolFalse;
+      RETURN_IF_ERROR(
+          isfb_boot_request_process(ext_isfb, owner_config, isfb_check_count));
+      // The previous function returns `kErrorOwnershipISFBFailed` if the strike
+      // check or product expression check fails. The following check is to
+      // detect any faults.
+      HARDENED_CHECK_EQ(*isfb_check_count, isfb_expected_count_get(ext_isfb));
+    } else {
+      HARDENED_CHECK_NE(error, kErrorOk);
+    }
+  }
+  return kErrorOk;
+}
+
+rom_error_t isfb_boot_verify(const manifest_t *manifest,
+                             const owner_config_t *owner_config,
+                             const owner_application_keyring_t *keyring,
+                             size_t verify_key, boot_data_t *boot_data,
+                             uint32_t isfb_check_count) {
+  if (launder32((hardened_bool_t)owner_config->isfb) != kHardenedBoolFalse) {
+    hardened_bool_t node_locked = manifest->usage_constraints.selector_bits
+                                      ? kHardenedBoolTrue
+                                      : kHardenedBoolFalse;
+
+    const manifest_ext_isfb_erase_t *ext_isfb_erase;
+    rom_error_t ext_error =
+        manifest_ext_get_isfb_erase(manifest, &ext_isfb_erase);
+
+    hardened_bool_t erase_en = kHardenedBoolFalse;
+    HARDENED_RETURN_IF_ERROR(isfb_info_flash_erase_policy_get(
+        owner_config, keyring->key[verify_key]->key_domain, node_locked,
+        (ext_error == kErrorOk) ? ext_isfb_erase : NULL, &erase_en));
+
+    if (launder32(erase_en) == kHardenedBoolTrue) {
+      HARDENED_RETURN_IF_ERROR(
+          owner_block_info_isfb_erase_enable(boot_data, owner_config));
+      HARDENED_CHECK_EQ(erase_en, kHardenedBoolTrue);
+    }
+
+    // Redundant check to ensure that the ISFB check was performed earlier in
+    // the boot process.
+    const manifest_ext_isfb_t *ext_isfb;
+    rom_error_t error = manifest_ext_get_isfb(manifest, &ext_isfb);
+    if (error == kErrorOk) {
+      HARDENED_CHECK_EQ(isfb_check_count, isfb_expected_count_get(ext_isfb));
+    } else {
+      HARDENED_CHECK_NE(error, kErrorOk);
+    }
+  }
+  return kErrorOk;
+}

--- a/sw/device/silicon_creator/lib/ownership/isfb.c
+++ b/sw/device/silicon_creator/lib/ownership/isfb.c
@@ -286,3 +286,5 @@ rom_error_t isfb_boot_verify(const manifest_t *manifest,
   }
   return kErrorOk;
 }
+
+hardened_bool_t isfb_is_present(void) { return kHardenedBoolTrue; }

--- a/sw/device/silicon_creator/lib/ownership/isfb.h
+++ b/sw/device/silicon_creator/lib/ownership/isfb.h
@@ -104,6 +104,13 @@ rom_error_t isfb_boot_verify(const manifest_t *manifest,
                              size_t verify_key, boot_data_t *boot_data,
                              uint32_t isfb_check_count);
 
+/**
+ * Returns whether this is a real ISFB implementation or a null stub.
+ *
+ * @return kHardenedBoolTrue if this is the real implementation.
+ */
+hardened_bool_t isfb_is_present(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sw/device/silicon_creator/lib/ownership/isfb.h
+++ b/sw/device/silicon_creator/lib/ownership/isfb.h
@@ -71,9 +71,38 @@ rom_error_t isfb_boot_request_process(const manifest_ext_isfb_t *ext,
  * @return The result of the operation.
  */
 rom_error_t isfb_info_flash_erase_policy_get(
-    owner_config_t *owner_config, uint32_t key_domain,
+    const owner_config_t *owner_config, uint32_t key_domain,
     hardened_bool_t manifest_is_node_locked,
     const manifest_ext_isfb_erase_t *ext_isfb_erase, hardened_bool_t *erase_en);
+
+/**
+ * Perform checks for ISFB when verifying the owner image during rom_ext_verify.
+ *
+ * @param manifest The manifest of the image to verify.
+ * @param owner_config The owner configuration.
+ * @param[out] isfb_check_count The number of checks performed.
+ * @return The result of the operation.
+ */
+rom_error_t isfb_check_and_verify(const manifest_t *manifest,
+                                  const owner_config_t *owner_config,
+                                  uint32_t *isfb_check_count);
+
+/**
+ * Perform ISFB boot-time verification before jumping to the owner code.
+ *
+ * @param manifest The manifest of the image to boot.
+ * @param owner_config The owner configuration.
+ * @param keyring The keyring of owner keys.
+ * @param verify_key The index of the verified key.
+ * @param boot_data Boot data.
+ * @param isfb_check_count The number of checks performed during verification.
+ * @return The result of the operation.
+ */
+rom_error_t isfb_boot_verify(const manifest_t *manifest,
+                             const owner_config_t *owner_config,
+                             const owner_application_keyring_t *keyring,
+                             size_t verify_key, boot_data_t *boot_data,
+                             uint32_t isfb_check_count);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/ownership/isfb_null.c
+++ b/sw/device/silicon_creator/lib/ownership/isfb_null.c
@@ -56,3 +56,5 @@ rom_error_t isfb_boot_verify(const manifest_t *manifest,
   (void)isfb_check_count;
   return kErrorOk;
 }
+
+hardened_bool_t isfb_is_present(void) { return kHardenedBoolFalse; }

--- a/sw/device/silicon_creator/lib/ownership/isfb_null.c
+++ b/sw/device/silicon_creator/lib/ownership/isfb_null.c
@@ -1,0 +1,58 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/ownership/isfb.h"
+#include "sw/device/silicon_creator/lib/ownership/owner_block.h"
+
+rom_error_t isfb_boot_request_process(const manifest_ext_isfb_t *ext,
+                                      const owner_config_t *owner_config,
+                                      uint32_t *checks_performed_count) {
+  (void)ext;
+  (void)owner_config;
+  *checks_performed_count = UINT32_MAX;
+  return kErrorOwnershipISFBNotPresent;
+}
+
+rom_error_t isfb_info_flash_erase_policy_get(
+    const owner_config_t *owner_config, uint32_t key_domain,
+    hardened_bool_t manifest_is_node_locked,
+    const manifest_ext_isfb_erase_t *ext_isfb_erase,
+    hardened_bool_t *erase_en) {
+  (void)owner_config;
+  (void)key_domain;
+  (void)manifest_is_node_locked;
+  (void)ext_isfb_erase;
+  *erase_en = kHardenedBoolFalse;
+  return kErrorOk;
+}
+
+rom_error_t owner_block_info_isfb_erase_enable(
+    boot_data_t *bootdata, const owner_config_t *owner_config) {
+  (void)bootdata;
+  (void)owner_config;
+  return kErrorOk;
+}
+
+rom_error_t isfb_check_and_verify(const manifest_t *manifest,
+                                  const owner_config_t *owner_config,
+                                  uint32_t *isfb_check_count) {
+  (void)manifest;
+  (void)owner_config;
+  *isfb_check_count = kHardenedBoolFalse;
+  return kErrorOk;
+}
+
+rom_error_t isfb_boot_verify(const manifest_t *manifest,
+                             const owner_config_t *owner_config,
+                             const owner_application_keyring_t *keyring,
+                             size_t verify_key, boot_data_t *boot_data,
+                             uint32_t isfb_check_count) {
+  (void)manifest;
+  (void)owner_config;
+  (void)keyring;
+  (void)verify_key;
+  (void)boot_data;
+  (void)isfb_check_count;
+  return kErrorOk;
+}

--- a/sw/device/silicon_creator/lib/ownership/isfb_unittest.cc
+++ b/sw/device/silicon_creator/lib/ownership/isfb_unittest.cc
@@ -251,4 +251,6 @@ TEST_F(IsfbTest, ErasePolicyDisableExpectedCheck) {
   EXPECT_EQ(erase_en, kHardenedBoolTrue);
 }
 
+TEST_F(IsfbTest, IsPresent) { EXPECT_EQ(isfb_is_present(), kHardenedBoolTrue); }
+
 }  // namespace

--- a/sw/device/silicon_creator/lib/ownership/owner_block.c
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.c
@@ -110,16 +110,6 @@ hardened_bool_t owner_block_page1_valid_for_transfer(boot_data_t *bootdata) {
   return kHardenedBoolFalse;
 }
 
-static inline hardened_bool_t is_owner_page(const uint8_t bank,
-                                            const uint8_t page) {
-  // On earlgrey_a1, in banks 0 and 1, pages 5-8 (inclusive) are reserved
-  // for the owner.
-  if (page >= 5 && page <= 8) {
-    return kHardenedBoolTrue;
-  }
-  return kHardenedBoolFalse;
-}
-
 // These checking functions aren't defined in owner_block.h because they aren't
 // meant to be public APIs.  They aren't static so we can access the symbols in
 // the unit test program.
@@ -541,43 +531,6 @@ rom_error_t owner_block_info_lockdown(const owner_flash_info_config_t *info) {
         flash_ctrl_info_cfg_lock(&page);
         SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioInfoCfgLock);
       }
-    }
-  }
-  return kErrorOk;
-}
-
-rom_error_t owner_block_info_isfb_erase_enable(
-    boot_data_t *bootdata, const owner_config_t *owner_config) {
-  if (bootdata->ownership_state != kOwnershipStateLockedOwner)
-    return kErrorOk;
-  // Check whether the ISFB configuration exists.
-  if ((hardened_bool_t)owner_config->isfb == kHardenedBoolFalse)
-    return kErrorOk;
-  // Check whether the FLASH INFO configuration exists.
-  if ((hardened_bool_t)owner_config->info == kHardenedBoolFalse)
-    return kErrorOk;
-
-  const owner_flash_info_config_t *info = owner_config->info;
-  size_t len = (info->header.length - sizeof(owner_flash_info_config_t)) /
-               sizeof(owner_info_page_t);
-
-  const owner_info_page_t *config = info->config;
-  uint32_t crypt = 0;
-  for (size_t i = 0; i < len; ++i, ++config, crypt += 0x11111111) {
-    if (is_owner_page(config->bank, config->page) == kHardenedBoolTrue &&
-        config->bank == owner_config->isfb->bank &&
-        config->page == owner_config->isfb->page) {
-      flash_ctrl_info_page_t page;
-      HARDENED_RETURN_IF_ERROR(flash_ctrl_info_type0_params_build(
-          config->bank, config->page, &page));
-
-      uint32_t val = config->access ^ crypt;
-      flash_ctrl_perms_t perm = {
-          .read = bitfield_field32_read(val, FLASH_CONFIG_READ),
-          .write = bitfield_field32_read(val, FLASH_CONFIG_PROGRAM),
-          .erase = kMultiBitBool4True,
-      };
-      flash_ctrl_info_perms_set(&page, perm);
     }
   }
   return kErrorOk;

--- a/sw/device/silicon_creator/lib/ownership/owner_block.h
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.h
@@ -233,6 +233,18 @@ hardened_bool_t owner_rescue_command_allowed(
  * @param measurement The measurement value.
  */
 void owner_block_measurement(size_t page, hmac_digest_t *mesaurment);
+
+static inline hardened_bool_t is_owner_page(const uint8_t bank,
+                                            const uint8_t page) {
+  (void)bank;
+  // On earlgrey_a1, in banks 0 and 1, pages 5-8 (inclusive) are reserved
+  // for the owner.
+  if (page >= 5 && page <= 8) {
+    return kHardenedBoolTrue;
+  }
+  return kHardenedBoolFalse;
+}
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -143,6 +143,7 @@ cc_test(
     deps = [
         ":rom_ext_boot_services",
         dual_cc_device_library_of("//sw/device/silicon_creator/lib/boot_svc:boot_svc_header"),
+        "//sw/device/silicon_creator/lib/ownership:isfb",
         "//sw/device/silicon_creator/lib/rescue:rescue_null",
         "//sw/device/silicon_creator/testing:rom_test",
         "@googletest//:gtest_main",
@@ -190,7 +191,7 @@ cc_library(
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib:manifest",
         "//sw/device/silicon_creator/lib/base:boot_measurements",
-        "//sw/device/silicon_creator/lib/ownership:isfb",
+        "//sw/device/silicon_creator/lib/ownership:isfb_headers",
         "//sw/device/silicon_creator/lib/ownership:owner_block",
         "//sw/device/silicon_creator/lib/ownership:owner_verify",
         "//sw/device/silicon_creator/lib/sigverify:usage_constraints",
@@ -298,7 +299,7 @@ asm_library_with_coverage(
             "//sw/device/silicon_creator/lib/drivers:uart",
             "//sw/device/silicon_creator/lib/drivers:watchdog",
             "//sw/device/silicon_creator/lib/ownership",
-            "//sw/device/silicon_creator/lib/ownership:isfb",
+            "//sw/device/silicon_creator/lib/ownership:isfb_headers",
             "//sw/device/silicon_creator/lib/ownership:owner_block",
             "//sw/device/silicon_creator/lib/ownership:owner_verify",
             "//sw/device/silicon_creator/lib/ownership:ownership_activate",
@@ -346,6 +347,7 @@ manifest(d = {
             ":rom_ext_{}".format(variation_name),
             "//sw/device/lib/crt",
             "//sw/device/silicon_creator/lib:manifest_def",
+            "//sw/device/silicon_creator/lib/ownership:isfb_null",
             "//sw/device/silicon_creator/lib/ownership:test_owner",
             "//sw/device/silicon_creator/lib/ownership/keys/fake",
             "//sw/device/silicon_creator/lib/rescue:rescue_xmodem",
@@ -385,7 +387,10 @@ ROM_EXT_LABELS.extend([
             "//sw/device/silicon_creator/lib/ownership:test_owner_{}".format(name),
             "//sw/device/silicon_creator/lib/ownership/keys/fake",
             "//sw/device/silicon_creator/rom_ext/imm_section:main_section_dice_x509_slot_virtual",
-        ] + param["rescue_module"],
+        ] + param.get(
+            "isfb_module",
+            ["//sw/device/silicon_creator/lib/ownership:isfb_null"],
+        ) + param["rescue_module"],
     )
     for name, param in TEST_OWNER_CONFIGS.items()
 ]
@@ -422,6 +427,7 @@ opentitan_binary(
         ":rom_ext_dice_x509",
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",
+        "//sw/device/silicon_creator/lib/ownership:isfb_null",
         "//sw/device/silicon_creator/lib/ownership:test_owner",
         "//sw/device/silicon_creator/lib/ownership/keys/fake",
         "//sw/device/silicon_creator/lib/rescue:rescue_xmodem",

--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -281,6 +281,14 @@ TEST_OWNER_CONFIGS = {
         "isfb_module": ["//sw/device/silicon_creator/lib/ownership:isfb"],
         "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_xmodem"],
     },
+    "isfb_error": {
+        # Intended to use the default isfb_null for testing the case that the
+        # rom_ext is accidentally linked to isfb_null.
+        "owner_defines": [
+            "WITH_ISFB=1",
+        ],
+        "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_xmodem"],
+    },
     "custom_fallback_owner": {
         "owner_defines": [
             # Enable fallback default owner override.

--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -278,6 +278,7 @@ TEST_OWNER_CONFIGS = {
         "owner_defines": [
             "WITH_ISFB=1",
         ],
+        "isfb_module": ["//sw/device/silicon_creator/lib/ownership:isfb"],
         "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_xmodem"],
     },
     "custom_fallback_owner": {

--- a/sw/device/silicon_creator/rom_ext/e2e/isfb/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/isfb/BUILD
@@ -252,3 +252,28 @@ _ISFB_CONTRAINT_TESTS = {
     )
     for name, param in _ISFB_CONTRAINT_TESTS.items()
 ]
+
+opentitan_test(
+    name = "isfb_null_event_test",
+    srcs = ["isfb_null_event_test.c"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+    },
+    fpga = fpga_params(
+        timeout = "long",
+        exit_failure = DEFAULT_TEST_FAILURE_MSG,
+        exit_success = DEFAULT_TEST_SUCCESS_MSG,
+        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_isfb_error",
+        testopt_clear_after_test = "True",
+        testopt_clear_before_test = "True",
+    ),
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
+    manifest = ":manifest_isfb_product_expr",
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
+)

--- a/sw/device/silicon_creator/rom_ext/e2e/isfb/isfb_null_event_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/isfb/isfb_null_event_test.c
@@ -1,0 +1,26 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/boot_log.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  retention_sram_t *retram = retention_sram_get();
+
+  bool isfb_error = bitfield_bit32_read(retram->creator.boot_log.events,
+                                        BOOT_LOG_EVENT_ISFB_ERROR);
+  LOG_INFO("ISFB error event raised: %d", isfb_error);
+
+  CHECK(isfb_error,
+        "ISFB error event should be raised when linked to isfb_null on an "
+        "ISFB-enabled chip");
+  return true;
+}

--- a/sw/device/silicon_creator/rom_ext/e2e/secver/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/secver/BUILD
@@ -91,6 +91,7 @@ _TEST_ROM_EXTS = {
         deps = [
             "//sw/device/lib/crt",
             "//sw/device/silicon_creator/lib:manifest_def",
+            "//sw/device/silicon_creator/lib/ownership:isfb_null",
             "//sw/device/silicon_creator/lib/ownership:test_owner",
             "//sw/device/silicon_creator/lib/ownership/keys/fake",
             "//sw/device/silicon_creator/lib/rescue:rescue_xmodem",

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -327,36 +327,9 @@ static rom_error_t rom_ext_boot(boot_data_t *boot_data, boot_log_t *boot_log,
   ibex_addr_remap_lockdown(0);
   ibex_addr_remap_lockdown(1);
 
-  if (launder32((hardened_bool_t)owner_config.isfb) != kHardenedBoolFalse) {
-    hardened_bool_t node_locked = manifest->usage_constraints.selector_bits
-                                      ? kHardenedBoolTrue
-                                      : kHardenedBoolFalse;
-
-    const manifest_ext_isfb_erase_t *ext_isfb_erase;
-    rom_error_t ext_error =
-        manifest_ext_get_isfb_erase(manifest, &ext_isfb_erase);
-
-    hardened_bool_t erase_en = kHardenedBoolFalse;
-    HARDENED_RETURN_IF_ERROR(isfb_info_flash_erase_policy_get(
-        &owner_config, keyring.key[verify_key]->key_domain, node_locked,
-        (ext_error == kErrorOk) ? ext_isfb_erase : NULL, &erase_en));
-
-    if (launder32(erase_en) == kHardenedBoolTrue) {
-      HARDENED_RETURN_IF_ERROR(
-          owner_block_info_isfb_erase_enable(boot_data, &owner_config));
-      HARDENED_CHECK_EQ(erase_en, kHardenedBoolTrue);
-    }
-
-    // Redundant check to ensure that the ISFB check was performed earlier in
-    // the boot process.
-    const manifest_ext_isfb_t *ext_isfb;
-    rom_error_t error = manifest_ext_get_isfb(manifest, &ext_isfb);
-    if (error == kErrorOk) {
-      HARDENED_CHECK_EQ(isfb_check_count, isfb_expected_count_get(ext_isfb));
-    } else {
-      HARDENED_CHECK_NE(error, kErrorOk);
-    }
-  }
+  HARDENED_RETURN_IF_ERROR(isfb_boot_verify(manifest, &owner_config, &keyring,
+                                            verify_key, boot_data,
+                                            isfb_check_count));
 
   // Lock the flash according to the ownership configuration.
   HARDENED_RETURN_IF_ERROR(

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -597,6 +597,14 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
     }
   }
 
+  // Detect if ISFB is required by owner block but missing from the linked
+  // ROM_EXT.
+  if (isfb_is_present() == kHardenedBoolFalse &&
+      (hardened_bool_t)owner_config.isfb != kHardenedBoolFalse) {
+    boot_log->events =
+        bitfield_bit32_write(boot_log->events, BOOT_LOG_EVENT_ISFB_ERROR, true);
+  }
+
   // Synchronize the boot_log entries that could be changed by boot services.
   boot_log->rom_ext_nonce = boot_data->nonce;
   boot_log->ownership_state = boot_data->ownership_state;

--- a/sw/device/silicon_creator/rom_ext/rom_ext_verify.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_verify.c
@@ -88,21 +88,8 @@ rom_error_t rom_ext_verify(const manifest_t *manifest, char slot_id,
       digest_region.length, &act_digest, flash_exec));
 
   // Perform ISFB checks if the extension is present.
-  if ((hardened_bool_t)owner_config->isfb != kHardenedBoolFalse) {
-    const manifest_ext_isfb_t *ext_isfb;
-    rom_error_t error = manifest_ext_get_isfb(manifest, &ext_isfb);
-    if (error == kErrorOk) {
-      *isfb_check_count = kHardenedBoolFalse;
-      RETURN_IF_ERROR(
-          isfb_boot_request_process(ext_isfb, owner_config, isfb_check_count));
-      // The previous function returns `kErrorOwnershipISFBFailed` if the strike
-      // check or product expression check fails. The following check is to
-      // detect any faults.
-      HARDENED_CHECK_EQ(*isfb_check_count, isfb_expected_count_get(ext_isfb));
-    } else {
-      HARDENED_CHECK_NE(error, kErrorOk);
-    }
-  }
+  RETURN_IF_ERROR(
+      isfb_check_and_verify(manifest, owner_config, isfb_check_count));
 
   // This is given that we are expected to perform redundant checks on
   // `flash_exec` and `isfb_check_count`. This is also the reason why don't use

--- a/sw/device/silicon_creator/rom_ext/sival/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/BUILD
@@ -66,6 +66,7 @@ manifest(d = {
             ":sival_owner",
             "//sw/device/lib/crt",
             "//sw/device/silicon_creator/lib:manifest_def",
+            "//sw/device/silicon_creator/lib/ownership:isfb_null",
             "//sw/device/silicon_creator/lib/rescue:rescue_xmodem",
             "//sw/device/silicon_creator/rom_ext:rom_ext_{}".format(variation),
             "//sw/device/silicon_creator/rom_ext/imm_section:main_section_{}_slot_{}".format(variation, slot),
@@ -97,6 +98,7 @@ manifest(d = {
             # as chips maintain their ownership configuration in flash.
             "//sw/device/lib/crt",
             "//sw/device/silicon_creator/lib:manifest_def",
+            "//sw/device/silicon_creator/lib/ownership:isfb_null",
             "//sw/device/silicon_creator/lib/rescue:rescue_xmodem",
             "//sw/device/silicon_creator/rom_ext:rom_ext_{}".format(variation),
             "//sw/device/silicon_creator/rom_ext/imm_section:main_section_{}_slot_{}".format(variation, slot),
@@ -141,6 +143,7 @@ ROM_EXT_CONFIGS = {
             # as chips maintain their ownership configuration in flash.
             "//sw/device/lib/crt",
             "//sw/device/silicon_creator/lib:manifest_def",
+            "//sw/device/silicon_creator/lib/ownership:isfb_null",
             "//sw/device/silicon_creator/rom_ext:rom_ext_{}".format(config["dice"]),
             "//sw/device/silicon_creator/rom_ext/imm_section:main_section_{}_slot_virtual".format(config["dice"]),
         ] + config["deps"],


### PR DESCRIPTION
This introduces link-time modularity for the Integration Specific Firmware Binding (ISFB) feature, enabling a low-overhead configuration to strip out ISFB from ROM_EXT builds.
- Extracted conditional and manifest getter checks from `rom_ext.c` and `rom_ext_verify.c` into top-level wrapper helpers `isfb_check_and_verify` and `isfb_boot_verify`.
- Added header-only target `:isfb_headers` in `lib/ownership/BUILD` containing `isfb.h` to allow compiling core ROM_EXT modules without target-level dependencies on a concrete ISFB implementation.
- Implemented stub implementations for all ISFB interfaces in `isfb_null.c`, and configured it as the default linked variant.
- Added parameter `"isfb_module"` to the test owner configuration mapping in `rom_ext/defs.bzl` to link the active implementation `:isfb` exclusively for `rom_ext_isfb` targets.
- Updated `mock_manifest` to support `manifest_ext_get_isfb_erase` mock calls. For ROM_EXT variants using the `isfb_null` module, the code size is reduced by ~1,600 bytes