### PR TITLE
[ci] Exclude "Schedule FPGA jobs" from merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,6 +406,7 @@ jobs:
   schedule_fpga_jobs:
     name: Schedule FPGA jobs
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name != 'merge_group' }}
     outputs:
       jobs_cw340: ${{ steps.schedule.outputs.jobs_cw340 }}
     steps:


### PR DESCRIPTION
This wasn't excluded when it was first created, but isn't needed in the merge queue. Although this job is fast and resource-light, we shouldn't have the merge queue running more than necessary to ensure high throughput.