### PR TITLE
[conn] Rewrite the connectivity checks between ast and pads

### DIFF
--- a/hw/top_earlgrey/formal/conn_csvs/ast_infra.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/ast_infra.csv
@@ -10,15 +10,47 @@
 #################################
 # Pad connections to/from AST
 #################################
-CONNECTION, AST_PAD0,            u_ast,                      ast2pad_t0_ao,                                       , IOA2,
-CONNECTION, AST_PAD1,            u_ast,                      ast2pad_t1_ao,                                       , IOA3,
-CONNECTION, AST_PINMUX,          u_ast,                      ast2padmux_o,              top_earlgrey.u_sensor_ctrl_aon, ast2pinmux_i,
-CONNECTION, PAD_AST,                  ,                      "{IOC3, IOC2, IOC1, IOB2, IOB1, IOB0, IOA5, IOA4}", u_ast, padmux2ast_i,
-# The inputs of above pads can be disabled using the mio_attr[25:23, 11:9, 5:4] control signals driven by pinmux.
-# Whenever pinmux is in reset, the inputs of these pads must be enabled.
-# Below conditions evaluate to: (mio_attr[x] == 1'b1 && rst_ni == 1'b1) || (rst_ni == 1'b0)
-CONDITION,                            ,                      "{mio_attr[25], mio_attr[24], mio_attr[23], mio_attr[11], mio_attr[10], mio_attr[9], mio_attr[5], mio_attr[4]}",    1'b1
-CONDITION,   top_earlgrey.u_pinmux_aon,                      rst_ni,                    1'b1,                    1'b0
+CONNECTION, AST_PAD0,   u_ast, ast2pad_t0_ao, ,                               IOA2,
+CONNECTION, AST_PAD1,   u_ast, ast2pad_t1_ao, ,                               IOA3,
+CONNECTION, AST_PINMUX, u_ast, ast2padmux_o,  top_earlgrey.u_sensor_ctrl_aon, ast2pinmux_i,
+
+# There are fixed connections from MIO pads to the AST's padmux2ast_i. These are listed in a
+# definition called PAD2AST_WIRES (in ast_pkg.sv). Check that chip_earlgrey_asic.sv connects the
+# pads up as expected.
+#
+# These pad connections can be disabled and are controlled by bits in mio_attr, with indices
+# controlled by the sizes the blocks of named pads (IOA* starts at index 0; IOB* starts at index 9;
+# IOC* starts at index 23).
+#
+# A pad is enabled if its associated mio_attr field is true or if pinmux is in reset. The latter
+# condition isn't currently checked by this file because the connectivity app's auto-generated
+# properties are disabled by the reset that applies to pinmux.
+#
+# Note: This check contains a manual copy of that list of pads and also the mapping from pad names
+#       to MIO indices. If either changes, the list in this file will need updating.
+CONNECTION, PAD_AST_0, , IOA4,        u_ast, padmux2ast_i[0],
+, CONDITION, ,                          mio_attr[4], 1'b1
+
+CONNECTION, PAD_AST_1, , IOA5, u_ast, padmux2ast_i[1],
+, CONDITION, ,                          mio_attr[5], 1'b1
+
+CONNECTION, PAD_AST_2, , IOB0, u_ast, padmux2ast_i[2],
+, CONDITION, ,                          mio_attr[9], 1'b1
+
+CONNECTION, PAD_AST_3, , IOB1, u_ast, padmux2ast_i[3],
+, CONDITION, ,                          mio_attr[10], 1'b1
+
+CONNECTION, PAD_AST_4, , IOB2, u_ast, padmux2ast_i[4],
+, CONDITION, ,                          mio_attr[11], 1'b1
+
+CONNECTION, PAD_AST_5, , IOC1, u_ast, padmux2ast_i[5],
+, CONDITION, ,                          mio_attr[23], 1'b1
+
+CONNECTION, PAD_AST_6, , IOC2, u_ast, padmux2ast_i[6],
+, CONDITION, ,                          mio_attr[24], 1'b1
+
+CONNECTION, PAD_AST_7, , IOC3, u_ast, padmux2ast_i[7],
+, CONDITION, ,                          mio_attr[25], 1'b1
 
 #################################
 # Other clocks

--- a/hw/top_earlgrey/formal/conn_csvs/ast_infra.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/ast_infra.csv
@@ -10,26 +10,101 @@
 #################################
 # Pad connections to/from AST
 #################################
-CONNECTION, AST_PAD0,            u_ast,                      ast2pad_t0_ao,                                       , IOA2,
-CONNECTION, AST_PAD1,            u_ast,                      ast2pad_t1_ao,                                       , IOA3,
-CONNECTION, AST_PINMUX,          u_ast,                      ast2padmux_o,              top_earlgrey.earlgrey_pd_aon.u_sensor_ctrl, ast2pinmux_i,
-CONNECTION, PAD_AST,                  ,                      "{IOC3, IOC2, IOC1, IOB2, IOB1, IOB0, IOA5, IOA4}", u_ast, padmux2ast_i,
-# The inputs of above pads can be disabled using the mio_attr[25:23, 11:9, 5:4] control signals driven by pinmux.
-# Whenever pinmux is in reset, the inputs of these pads must be enabled.
-# Below conditions evaluate to: (mio_attr[x] == 1'b1 && rst_ni == 1'b1) || (rst_ni == 1'b0)
-CONDITION,                            ,                      "{mio_attr[25], mio_attr[24], mio_attr[23], mio_attr[11], mio_attr[10], mio_attr[9], mio_attr[5], mio_attr[4]}",    1'b1
-CONDITION,   top_earlgrey.earlgrey_pd_main.u_pinmux,                      rst_ni,                    1'b1,                    1'b0
+CONNECTION, AST_PAD0,   u_ast, ast2pad_t0_ao, ,                                           IOA2,
+CONNECTION, AST_PAD1,   u_ast, ast2pad_t1_ao, ,                                           IOA3,
+CONNECTION, AST_PINMUX, u_ast, ast2padmux_o,  top_earlgrey.earlgrey_pd_aon.u_sensor_ctrl, ast2pinmux_i,
+
+# There are fixed connections from MIO pads to the AST's padmux2ast_i. These are listed in a
+# definition called PAD2AST_WIRES (in ast_pkg.sv). Check that chip_earlgrey_asic.sv connects the
+# pads up as expected.
+#
+# These pad connections can be disabled and are controlled by bits in mio_attr, with indices
+# controlled by the sizes the blocks of named pads (IOA* starts at index 0; IOB* starts at index 9;
+# IOC* starts at index 22).
+#
+# A pad is enabled if the input_disable field in its associated mio_attr is false or if pinmux is in
+# reset. Both of these cases are covered by the CONDITION rows below. Since the syntax is hard to
+# parse, here's how to unpack the CSV syntax for the first example:
+#
+#  - We are defining a connectivity check called "PAD_AST_0"
+#
+#  - The "source block" is empty (which means we can refer to an external pin or a signal in
+#    chip_earlgrey_asic).
+#
+#  - The source signal (a pin name here) is IOA4
+#
+#  - The destination block is u_ast
+#
+#  - The signal in that destination block is padmux2ast_i[0]
+#
+#  - The two signals at the ends of the connection are only required to be equal if either the
+#    appropriate input is not disabled, or if pinmux is in reset. This gives a condition of the
+#    form:
+#
+#        !mio_attr[4].input_disable || !u_pinmux.rst_ni.
+#
+#  - To express this with the syntax that Jasper's connectivity app supports, the condition is
+#    actually written with the equivalent formulation:
+#
+#        !mio_attr[4].input_disable || (mio_attr[4].input_disable && !u_pinmux.rst_ni)
+#
+#  - That way, the first CONDITION line let's us say that the CONNECTION line applies if
+#    mio_attr[4].input_disable has value 1'b0 (regardless of the value of rst_ni in the pinmux).
+#
+#  - The second CONDITION line says that the CONNECTION line applies if mio_attr[4].input_disable
+#    has value 1'b1 (the other option) and the rst_ni line in the pinmux has value zero.
+#
+# In prose form, the full block says:
+#
+#   "If mio_attr[4].input_disable is false or if pinmux is in reset then the IOA4 pin is connected
+#   to bit zero of the padmux2ast_i input of u_ast."
+#
+#
+# Note: This PAD_AST_* checks below contain a manual copy of that list of pads and also the mapping
+#       from pad names to MIO indices. If either changes, the list in this file will need updating.
+#       This list is currently also set to match the behaviour of padring.sv when its mux_iob_sel_i
+#       signal is zero (which is the case in the open source repository).
+
+CONNECTION, PAD_AST_0, , IOA4, u_ast, padmux2ast_i[0],
+CONDITION, , mio_attr[4].input_disable, 1'b0
+CONDITION, top_earlgrey.earlgrey_pd_main.u_pinmux, rst_ni, 1'b1, 1'b0
+
+CONNECTION, PAD_AST_1, , IOA5, u_ast, padmux2ast_i[1],
+CONDITION, , mio_attr[5].input_disable, 1'b0
+CONDITION, top_earlgrey.earlgrey_pd_main.u_pinmux, rst_ni, 1'b1, 1'b0
+
+CONNECTION, PAD_AST_2, , IOB0, u_ast, padmux2ast_i[2],
+CONDITION, , mio_attr[9].input_disable, 1'b0
+CONDITION, top_earlgrey.earlgrey_pd_main.u_pinmux, rst_ni, 1'b1, 1'b0
+
+CONNECTION, PAD_AST_3, , IOB1, u_ast, padmux2ast_i[3],
+CONDITION, , mio_attr[10].input_disable, 1'b0
+CONDITION, top_earlgrey.earlgrey_pd_main.u_pinmux, rst_ni, 1'b1, 1'b0
+
+CONNECTION, PAD_AST_4, , IOB2, u_ast, padmux2ast_i[4],
+CONDITION, , mio_attr[11].input_disable, 1'b0
+CONDITION, top_earlgrey.earlgrey_pd_main.u_pinmux, rst_ni, 1'b1, 1'b0
+
+CONNECTION, PAD_AST_5, , IOC1, u_ast, padmux2ast_i[5],
+CONDITION, , mio_attr[23].input_disable, 1'b0
+CONDITION, top_earlgrey.earlgrey_pd_main.u_pinmux, rst_ni, 1'b1, 1'b0
+
+CONNECTION, PAD_AST_6, , IOC2, u_ast, padmux2ast_i[6],
+CONDITION, , mio_attr[24].input_disable, 1'b0
+CONDITION, top_earlgrey.earlgrey_pd_main.u_pinmux, rst_ni, 1'b1, 1'b0
+
+CONNECTION, PAD_AST_7, , IOC3, u_ast, padmux2ast_i[7],
+CONDITION, , mio_attr[25].input_disable, 1'b0
+CONDITION, top_earlgrey.earlgrey_pd_main.u_pinmux, rst_ni, 1'b1, 1'b0
 
 #################################
 # Other clocks
 #################################
 CONNECTION, AST_CLK_SPI_SNS_IN,       ,                      SPI_DEV_CLK,               u_ast,                   sns_spi_ext_clk_i
+
 CONNECTION, AST_CLK_EXT_IN,           ,                      IOC6,                      u_ast,                   clk_ast_ext_i
-# The input of the IOC6 pad can be disabled using the mio_attr[28] control bit driven by pinmux.
-# Whenever pinmux is in reset, the input of the IOC6 pad must be enabled.
-# Below conditions evaluate to: (mio_attr[28] == 1'b1 && rst_ni == 1'b1) || (rst_ni == 1'b0)
-CONDITION,                            ,                      mio_attr[28],              1'b1,
-CONDITION,   top_earlgrey.earlgrey_pd_main.u_pinmux,                      rst_ni,                    1'b1,                    1'b0
+CONDITION, , mio_attr[28].input_disable, 1'b0
+CONDITION, top_earlgrey.earlgrey_pd_main.u_pinmux, rst_ni, 1'b1, 1'b0
 
 #################################
 # Other resets
@@ -42,7 +117,5 @@ CONNECTION, AST_RST_POR_IN,           ,                      POR_N,             
 
 CONNECTION, AST_USB_REF_IN,      top_earlgrey.earlgrey_pd_main.u_usbdev,      usb_ref_pulse_o,           u_ast,                    usb_ref_pulse_i
 CONNECTION, AST_USB_REF_VAL_IN,  top_earlgrey.earlgrey_pd_main.u_usbdev,      usb_ref_val_o,             u_ast,                    usb_ref_val_i
-CONNECTION, AST_OTP_PWR_SEQ_IN,  top_earlgrey.earlgrey_pd_main.u_otp_macro,   pwr_seq_o,                 u_ast,                    otp_power_seq_i
 CONNECTION, AST_MAIN_PD_IN,      top_earlgrey.earlgrey_pd_aon.u_pwrmgr,  pwr_ast_o.main_pd_n,       u_ast,                    main_pd_ni
 CONNECTION, AST_MAIN_ISO_EN_IN,  top_earlgrey.earlgrey_pd_aon.u_pwrmgr,  pwr_ast_o.pwr_clamp_env,   u_ast,                    main_env_iso_en_i
-CONNECTION, AST_OTP_PWR_SEQ_OUT, u_ast,                      otp_power_seq_h_o,         top_earlgrey.earlgrey_pd_main.u_otp_macro, pwr_seq_h_i


### PR DESCRIPTION
These weren't quite right before because the "{a, b, c}" vector syntax isn't supported by the Jasper connectivity app (which spits out error messages).

The condition also wasn't quite right: it was saying that the constraint applied if the given 8-bit vector was equal to 1'b1: not what we want!