### PR TITLE
[conn] Fix syntax errors in ast_mem_cfg.sv

### DIFF
--- a/hw/top_earlgrey/formal/conn_csvs/ast_mem_cfg.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/ast_mem_cfg.csv
@@ -9,7 +9,7 @@
 
 # AST DFT module emits some configuration bits for single and dual port memories in the chip. These
 # cannot be covered functionally in the open source repo, since they are not used by the generic
-# memory models. TThese signals are excluded from coverage collection AFTER they have been added to
+# memory models. These signals are excluded from coverage collection AFTER they have been added to
 # this checker.
 #
 #  The source path (within AST) is inferred manually from the RTL. The destination paths are
@@ -17,7 +17,7 @@
 
 # Dual port RAMs.
 # To spi_device.
-CONNECTION, AST_DFT_SPI_DEVICE_RAM_2P_CFG, u_ast.u_ast_dft, "{12'h0, dpram_rml_o}", top_earlgrey.u_spi_device.u_spid_dpram.gen_ram2p.u_memory_2p.u_mem, cfg_i
+CONNECTION, AST_DFT_SPI_DEVICE_RAM_2P_CFG, u_ast.u_ast_dft, "dpram_rml_o", top_earlgrey.u_spi_device.u_spid_dpram.gen_ram2p.u_memory_2p.u_mem, cfg_i
 
 # Single port RAMs.
 # To otbn.

--- a/hw/top_earlgrey/formal/conn_csvs/ast_mem_cfg.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/ast_mem_cfg.csv
@@ -17,27 +17,36 @@
 
 # Dual port RAMs.
 # To spi_device.
-CONNECTION, AST_DFT_SPI_DEVICE_RAM_2P_CFG, u_ast.u_ast_dft, "dpram_rml_o", top_earlgrey.u_spi_device.u_spid_dpram.gen_ram2p.u_memory_2p.u_mem, cfg_i
+CONNECTION, AST_DFT_SPI_DEVICE_RAM_2P_CFG, u_ast.u_ast_dft, dpram_rml_o, top_earlgrey.u_spi_device.u_spid_dpram.gen_ram2p.u_memory_2p.u_mem, cfg_i
 
 # Single port RAMs.
 # To otbn.
-CONNECTION, AST_DFT_OTBN_IMEM_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_otbn.u_imem.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i
-CONNECTION, AST_DFT_OTBN_DMEM_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_otbn.u_dmem.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i
+CONNECTION, AST_DFT_OTBN_IMEM_RAM_1P_CFG0, u_ast.u_ast_dft, spram_rm_o, top_earlgrey.u_otbn.u_imem.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i.ram_cfg
+CONNECTION, AST_DFT_OTBN_IMEM_RAM_1P_CFG1, u_ast.u_ast_dft, sprgf_rm_o, top_earlgrey.u_otbn.u_imem.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i.rf_cfg
+CONNECTION, AST_DFT_OTBN_DMEM_RAM_1P_CFG0, u_ast.u_ast_dft, spram_rm_o, top_earlgrey.u_otbn.u_dmem.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i.ram_cfg
+CONNECTION, AST_DFT_OTBN_DMEM_RAM_1P_CFG1, u_ast.u_ast_dft, sprgf_rm_o, top_earlgrey.u_otbn.u_dmem.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i.rf_cfg
 
 # To rv_core_ibex.
-CONNECTION, AST_DFT_RV_CORE_IBEX_TAG0_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[0].gen_scramble_rams.tag_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i
-CONNECTION, AST_DFT_RV_CORE_IBEX_TAG1_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[1].gen_scramble_rams.tag_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i
-CONNECTION, AST_DFT_RV_CORE_IBEX_DATA0_RAM_1P_CFG, u_ast.u_ast_dft,"{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[0].gen_scramble_rams.data_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i
-CONNECTION, AST_DFT_RV_CORE_IBEX_DATA1_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[1].gen_scramble_rams.data_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i
+CONNECTION, AST_DFT_RV_CORE_IBEX_TAG0_RAM_1P_CFG0,  u_ast.u_ast_dft, spram_rm_o, top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[0].gen_scramble_rams.tag_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i.ram_cfg
+CONNECTION, AST_DFT_RV_CORE_IBEX_TAG0_RAM_1P_CFG1,  u_ast.u_ast_dft, sprgf_rm_o, top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[0].gen_scramble_rams.tag_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i.rf_cfg
+CONNECTION, AST_DFT_RV_CORE_IBEX_TAG1_RAM_1P_CFG0,  u_ast.u_ast_dft, spram_rm_o, top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[1].gen_scramble_rams.tag_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i.ram_cfg
+CONNECTION, AST_DFT_RV_CORE_IBEX_TAG1_RAM_1P_CFG1,  u_ast.u_ast_dft, sprgf_rm_o, top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[1].gen_scramble_rams.tag_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i.rf_cfg
+CONNECTION, AST_DFT_RV_CORE_IBEX_DATA0_RAM_1P_CFG0, u_ast.u_ast_dft, spram_rm_o, top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[0].gen_scramble_rams.data_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i.ram_cfg
+CONNECTION, AST_DFT_RV_CORE_IBEX_DATA0_RAM_1P_CFG1, u_ast.u_ast_dft, sprgf_rm_o, top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[0].gen_scramble_rams.data_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i.rf_cfg
+CONNECTION, AST_DFT_RV_CORE_IBEX_DATA1_RAM_1P_CFG0, u_ast.u_ast_dft, spram_rm_o, top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[1].gen_scramble_rams.data_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i.ram_cfg
+CONNECTION, AST_DFT_RV_CORE_IBEX_DATA1_RAM_1P_CFG1, u_ast.u_ast_dft, sprgf_rm_o, top_earlgrey.u_rv_core_ibex.u_core.gen_rams.gen_rams_inner[1].gen_scramble_rams.data_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i.rf_cfg
 
 # To sram_ctrl (main).
-CONNECTION, AST_DFT_SRAM_MAIN_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_sram_ctrl_main.u_prim_ram_1p_scr.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i
+CONNECTION, AST_DFT_SRAM_MAIN_RAM_1P_CFG0, u_ast.u_ast_dft, spram_rm_o, top_earlgrey.u_sram_ctrl_main.u_prim_ram_1p_scr.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i.ram_cfg
+CONNECTION, AST_DFT_SRAM_MAIN_RAM_1P_CFG1, u_ast.u_ast_dft, sprgf_rm_o, top_earlgrey.u_sram_ctrl_main.u_prim_ram_1p_scr.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i.rf_cfg
 
 # To sram_ctrl (ret).
-CONNECTION, AST_DFT_SRAM_RET_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_sram_ctrl_ret_aon.u_prim_ram_1p_scr.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i
+CONNECTION, AST_DFT_SRAM_RET_RAM_1P_CFG0, u_ast.u_ast_dft, spram_rm_o, top_earlgrey.u_sram_ctrl_ret_aon.u_prim_ram_1p_scr.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i.ram_cfg
+CONNECTION, AST_DFT_SRAM_RET_RAM_1P_CFG1, u_ast.u_ast_dft, sprgf_rm_o, top_earlgrey.u_sram_ctrl_ret_aon.u_prim_ram_1p_scr.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem, cfg_i.rf_cfg
 
 # To rom.
 CONNECTION, AST_DFT_ROM_CFG, u_ast.u_ast_dft, sprom_rm_o,top_earlgrey.u_rom_ctrl.gen_rom_scramble_enabled.u_rom.u_rom.u_prim_rom, cfg_i
 
 # To usbdev.
-CONNECTION, AST_DFT_USBDEV_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_usbdev.gen_no_stubbed_memory.u_memory_1p.gen_ram_inst[0].u_mem, cfg_i
+CONNECTION, AST_DFT_USBDEV_RAM_1P_CFG0, u_ast.u_ast_dft, spram_rm_o, top_earlgrey.u_usbdev.gen_no_stubbed_memory.u_memory_1p.gen_ram_inst[0].u_mem, cfg_i.ram_cfg
+CONNECTION, AST_DFT_USBDEV_RAM_1P_CFG1, u_ast.u_ast_dft, sprgf_rm_o, top_earlgrey.u_usbdev.gen_no_stubbed_memory.u_memory_1p.gen_ram_inst[0].u_mem, cfg_i.rf_cfg


### PR DESCRIPTION
The two commits are:

> **[conn] Fix some padding in ast_mem_cfg.csv**
> 
> The padding isn't needed for this sort of check and (conveniently) it
> really isn't needed for this connection: both ends are 4*6 bits
> anyway.

and

> **[conn] Split up pairs of connection checks in ast_mem_cfg.sv**
> 
> The existing syntax is not accepted by the version of Jasper that we're using.
> The original root of these lines is edc8093f707.
> 
> Since the CSV format doesn't allow any sort of macro, you end up
> having to double everything up to check the ram and the rf bits of the
> connection separately.
