### PR TITLE
[ci] Revert "Disable CW310 bitstream builds in CI workflow"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,6 +352,15 @@ jobs:
         with:
           artifact-name: verilator_earlgrey-test-results
 
+  chip_earlgrey_cw310_hyperdebug:
+    name: Earl Grey for CW310 Hyperdebug
+    needs: quick_lint
+    uses: ./.github/workflows/bitstream.yml
+    secrets: inherit
+    with:
+      top_name: earlgrey
+      design_suffix: cw310_hyperdebug
+
   chip_earlgrey_cw340:
     name: Earl Grey for CW340
     needs: quick_lint
@@ -365,6 +374,7 @@ jobs:
     name: Cache bitstreams to GCP
     runs-on: ubuntu-22.04
     needs:
+      - chip_earlgrey_cw310_hyperdebug
       - chip_earlgrey_cw340
     steps:
       - name: Skipped message
@@ -383,7 +393,7 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         uses: ./.github/actions/download-partial-build-bin
         with:
-          job-patterns: chip_earlgrey_cw340
+          job-patterns: chip_earlgrey_{cw310,cw310_hyperdebug,cw340}
       - name: Create bitstream cache archive
         if: ${{ github.event_name != 'pull_request' }}
         run: |


### PR DESCRIPTION
This reverts commit 0bc453e2931b15d3a3ca7f17cd5400e149b93ac4.

Parts of the Bazel build graph still depend on the CW310 bitstreams being present in the most recently cached entry, so we cannot remove the bitstream from the cache until the CW310 is removed from the Bazel tree entirely.