### PR TITLE
[i3c] Implementations of HCI DAT and DCT

### DIFF
--- a/hw/ip/i3c/rtl/i3c_dat.sv
+++ b/hw/ip/i3c/rtl/i3c_dat.sv
@@ -1,0 +1,175 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Device Address Table (HCI 8.1).
+//
+// - conveys information about each currently-addressable Target from the driver software to the
+//   hardware.
+// - hardware requires only read access and has highest priority.
+module i3c_dat
+  import i3c_pkg::*;
+  import prim_ram_1p_pkg::*;
+#(
+  parameter int unsigned DataWidth = 32,
+  parameter int unsigned NumDATEntries = i3c_pkg::NumDATEntries,
+
+  localparam int unsigned DATMemWidth = $bits(i3c_dat_mem_t),
+  // Derived parameters.
+  localparam int unsigned DATAddrW = $clog2(NumDATEntries)
+) (
+  input                   clk_i,
+  input                   rst_ni,
+
+  // Hardware interface.
+  input                   dat_re_i,
+  input    [DATAddrW-1:0] dat_idx_i,
+  output    i3c_dat_mem_t dat_rdata_o,
+
+  // HCI Device Address Table interface.
+  input                   sw_dat_req_i,
+  output                  sw_dat_gnt_o,
+  input                   sw_dat_we_i,
+  input      [DATAddrW:0] sw_dat_addr_i,
+  input   [DataWidth-1:0] sw_dat_wdata_i,
+  output                  sw_dat_rvalid_o,
+  output  [DataWidth-1:0] sw_dat_rdata_o,
+
+  // DFT-related signals.
+  input  ram_1p_cfg_t     dat_cfg_i,
+  output ram_1p_cfg_rsp_t dat_cfg_rsp_o
+);
+
+  // The CPU cannot access the full DAT Entry in a single access; its bus is narrower.
+  localparam int unsigned DATWidthWords = (DATMemWidth + DataWidth - 1) / DataWidth;
+
+  // We need to track which of the table entries has a dynamic address supplied by the driver
+  // software; the memory will start up with undefined contents and nothing in the HCI registers
+  // indicates which entries have been populated.
+  logic [NumDATEntries-1:0] addr_written;
+  logic rdata_valid_q;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      addr_written  <= '0;
+      rdata_valid_q <= 1'b0;
+    end else begin
+      // Since `rdata_valid_q` modifies the returned dynamic address, keep it stable after reading.
+      if (dat_re_i) rdata_valid_q <= addr_written[dat_idx_i];
+      if (&{sw_dat_req_i, sw_dat_gnt_o, sw_dat_we_i, !sw_dat_addr_i[0]}) begin
+        // Extract the DAT index from the address; each DAT entry occupies two words.
+        addr_written[sw_dat_addr_i >> 1] <= 1'b1;
+      end
+    end
+  end
+
+  // Remap the read/write data from/to the packed memory entries.
+  i3c_dat_mem_t sw_dat_wmask;
+  i3c_dat_mem_t sw_dat_wdata_packed;
+  i3c_dat_entry_t sw_dat_wdata_full;
+  assign sw_dat_wdata_full = i3c_dat_entry_t'({DATWidthWords{sw_dat_wdata_i}});
+
+  always_comb begin
+    // Write strobes for software access to the DAT
+    // - individual bit strobes because each DAT entry is presentd to the HCI as as 2 x 32-bit
+    //   words, containing 25 and 27 valid data bits; there are no common factors.
+    sw_dat_wmask = '0;
+    if (sw_dat_addr_i[0]) begin
+      sw_dat_wmask.autocmd_hdr_code   = '1;
+      sw_dat_wmask.autocmd_mode       = '1;
+      sw_dat_wmask.autocmd_value      = '1;
+      sw_dat_wmask.autocmd_mask       = '1;
+    end else begin
+      sw_dat_wmask.device             = '1;
+      sw_dat_wmask.dev_nack_retry_cnt = '1;
+      sw_dat_wmask.ring_id            = '1;
+      sw_dat_wmask.dynamic_address    = '1;
+      sw_dat_wmask.ts                 = '1;
+      sw_dat_wmask.crr_reject         = '1;
+      sw_dat_wmask.ibi_reject         = '1;
+      sw_dat_wmask.ibi_payload        = '1;
+      sw_dat_wmask.static_address     = '1;
+    end
+
+    sw_dat_wdata_packed.autocmd_hdr_code   = sw_dat_wdata_full.autocmd_hdr_code;
+    sw_dat_wdata_packed.autocmd_mode       = sw_dat_wdata_full.autocmd_mode;
+    sw_dat_wdata_packed.autocmd_value      = sw_dat_wdata_full.autocmd_value;
+    sw_dat_wdata_packed.autocmd_mask       = sw_dat_wdata_full.autocmd_mask;
+    sw_dat_wdata_packed.device             = sw_dat_wdata_full.device;
+    sw_dat_wdata_packed.dev_nack_retry_cnt = sw_dat_wdata_full.dev_nack_retry_cnt;
+    sw_dat_wdata_packed.ring_id            = sw_dat_wdata_full.ring_id;
+    sw_dat_wdata_packed.dynamic_address    = sw_dat_wdata_full.dynamic_address;
+    sw_dat_wdata_packed.ts                 = sw_dat_wdata_full.ts;
+    sw_dat_wdata_packed.crr_reject         = sw_dat_wdata_full.crr_reject;
+    sw_dat_wdata_packed.ibi_reject         = sw_dat_wdata_full.ibi_reject;
+    sw_dat_wdata_packed.ibi_payload        = sw_dat_wdata_full.ibi_payload;
+    sw_dat_wdata_packed.static_address     = sw_dat_wdata_full.static_address;
+  end
+
+  i3c_dat_entry_t sw_dat_rdata_full;
+  i3c_dat_mem_t sw_dat_rdata_packed;
+  logic [DATMemWidth-1:0] sw_dat_rdata_raw;
+  assign sw_dat_rdata_packed = i3c_dat_mem_t'(sw_dat_rdata_raw);
+
+  always_comb begin
+    sw_dat_rdata_full = '0;  // Zero-initialize the reserved fields.
+    sw_dat_rdata_full.autocmd_hdr_code   = sw_dat_rdata_packed.autocmd_hdr_code;
+    sw_dat_rdata_full.autocmd_mode       = sw_dat_rdata_packed.autocmd_mode;
+    sw_dat_rdata_full.autocmd_value      = sw_dat_rdata_packed.autocmd_value;
+    sw_dat_rdata_full.autocmd_mask       = sw_dat_rdata_packed.autocmd_mask;
+    sw_dat_rdata_full.device             = sw_dat_rdata_packed.device;
+    sw_dat_rdata_full.dev_nack_retry_cnt = sw_dat_rdata_packed.dev_nack_retry_cnt;
+    sw_dat_rdata_full.ring_id            = sw_dat_rdata_packed.ring_id;
+    sw_dat_rdata_full.dynamic_address    = sw_dat_rdata_packed.dynamic_address;
+    sw_dat_rdata_full.ts                 = sw_dat_rdata_packed.ts;
+    sw_dat_rdata_full.crr_reject         = sw_dat_rdata_packed.crr_reject;
+    sw_dat_rdata_full.ibi_reject         = sw_dat_rdata_packed.ibi_reject;
+    sw_dat_rdata_full.ibi_payload        = sw_dat_rdata_packed.ibi_payload;
+    sw_dat_rdata_full.static_address     = sw_dat_rdata_packed.static_address;
+  end
+
+  // Extract the appropriate CPU word from the DCT entry to return it.
+  logic sw_dat_rdata_sel;
+  assign sw_dat_rdata_o = sw_dat_rdata_sel ? sw_dat_rdata_full[63:32] : sw_dat_rdata_full[31:0];
+
+  i3c_dat_mem_t dat_wdata_packed;
+  logic [DATMemWidth-1:0] dat_rdata_raw;
+  always_comb begin
+    dat_rdata_o = i3c_dat_mem_t'(dat_rdata_raw);
+    if (!rdata_valid_q) dat_rdata_o.dynamic_address = '0;
+  end
+
+  // Device Address Table.
+  i3c_dxt #(
+    .EntryWidth (DATMemWidth),
+    .NumEntries (NumDATEntries),
+    .MaskWidth  (DATMemWidth),
+    .OOBWidth   (1)
+  ) u_dat(
+    .clk_i      (clk_i),
+    .rst_ni     (rst_ni),
+
+    // Port A (hardware; highest priority).
+    .a_re_i     (dat_re_i),
+    .a_we_i     (1'b0),
+    .a_idx_i    (dat_idx_i),
+    .a_wmask_i  ('0),
+    .a_wdata_i  ('0),
+    .a_rdata_o  (dat_rdata_raw),
+
+    // Port B (software; lowest priority).
+    .b_req_i    (sw_dat_req_i),
+    .b_gnt_o    (sw_dat_gnt_o),
+    .b_we_i     (sw_dat_we_i),
+    .b_idx_i    (sw_dat_addr_i[DATAddrW:1]),
+    .b_wmask_i  (sw_dat_wmask),
+    .b_wdata_i  (sw_dat_wdata_packed),
+    .b_oob_i    (sw_dat_addr_i[0]),
+    .b_rvalid_o (sw_dat_rvalid_o),
+    .b_rdata_o  (sw_dat_rdata_raw),
+    .b_oob_o    (sw_dat_rdata_sel),
+
+    .cfg_i      (dat_cfg_i),
+    .cfg_rsp_o  (dat_cfg_rsp_o)
+  );
+
+endmodule

--- a/hw/ip/i3c/rtl/i3c_dct.sv
+++ b/hw/ip/i3c/rtl/i3c_dct.sv
@@ -1,0 +1,124 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Device Characteristics Table (HCI 8.2).
+//
+// - conveys the properties of each assigned Target to the driver software.
+// - hardware requires only write access and has highest priority.
+module i3c_dct
+  import i3c_pkg::*;
+  import prim_ram_1p_pkg::*;
+#(
+  parameter int unsigned DataWidth = 32,
+  parameter int unsigned NumDCTEntries = i3c_pkg::NumDCTEntries,
+
+  localparam int unsigned DCTMemWidth = $bits(i3c_dct_mem_t),
+  // Derived parameters.
+  localparam int unsigned DCTMaskW = (DCTMemWidth + 7) / 8,
+  localparam int unsigned DCTAddrW = $clog2(NumDCTEntries)
+) (
+  input                   clk_i,
+  input                   rst_ni,
+
+  // Hardware interface.
+  input                   dct_we_i,
+  input    [DCTAddrW-1:0] dct_idx_i,
+  input    [DCTMaskW-1:0] dct_wmask_i,
+  input     i3c_dct_mem_t dct_wdata_i,
+
+  // HCI Device Characteristics Table interface.
+  input                   sw_dct_req_i,
+  output                  sw_dct_gnt_o,
+  input                   sw_dct_we_i,
+  input    [DCTAddrW+1:0] sw_dct_addr_i,
+  input   [DataWidth-1:0] sw_dct_wdata_i,
+  output                  sw_dct_rvalid_o,
+  output  [DataWidth-1:0] sw_dct_rdata_o,
+
+  // DFT-related signals.
+  input  ram_1p_cfg_t     dct_cfg_i,
+  output ram_1p_cfg_rsp_t dct_cfg_rsp_o
+);
+
+  // The CPU cannot access the full DCT Entry in a single access; its bus is narrower.
+  localparam int unsigned DCTEntryWidth = $bits(i3c_dct_entry_t);
+  localparam int unsigned DCTWidthWords = (DCTEntryWidth + DataWidth - 1) / DataWidth;
+  localparam int unsigned Log2DW = $clog2(DataWidth);
+
+  logic [DCTMaskW-1:0] sw_dct_wmask;
+  i3c_dct_mem_t sw_dct_wdata_packed;
+  i3c_dct_entry_t sw_dct_wdata_full;
+  assign sw_dct_wdata_full = i3c_dct_entry_t'({DCTWidthWords{sw_dct_wdata_i}});
+
+  always_comb begin
+    sw_dct_wmask = '0;
+    // The DCT entry is mapped into a number of CPU memory locations, but with
+    // holes (HCI Table 131).
+    case (sw_dct_addr_i[1:0])
+      2'b00: sw_dct_wmask[3:0] = 4'hF;
+      2'b01: sw_dct_wmask[5:4] = 2'b11;
+      2'b10: sw_dct_wmask[7:6] = 2'b11;
+      default: sw_dct_wmask[8] = 1'b1;
+    endcase
+
+    sw_dct_wdata_packed.dynamic_address = sw_dct_wdata_full.dynamic_address;
+    sw_dct_wdata_packed.bcr = sw_dct_wdata_full.bcr;
+    sw_dct_wdata_packed.dcr = sw_dct_wdata_full.dcr;
+    sw_dct_wdata_packed.pid_lo = sw_dct_wdata_full.pid_lo;
+    sw_dct_wdata_packed.pid_hi = sw_dct_wdata_full.pid_hi;
+  end
+
+  i3c_dct_entry_t sw_dct_rdata_full;
+  i3c_dct_mem_t sw_dct_rdata_packed;
+  logic [DCTMemWidth-1:0] sw_dct_rdata_raw;
+  assign sw_dct_rdata_packed = i3c_dct_mem_t'(sw_dct_rdata_raw);
+
+  always_comb begin
+    sw_dct_rdata_full = '0;  // Zero-initialize the reserved fields.
+    sw_dct_rdata_full.dynamic_address = sw_dct_rdata_packed.dynamic_address;
+    sw_dct_rdata_full.bcr             = sw_dct_rdata_packed.bcr;
+    sw_dct_rdata_full.dcr             = sw_dct_rdata_packed.dcr;
+    sw_dct_rdata_full.pid_lo          = sw_dct_rdata_packed.pid_lo;
+    sw_dct_rdata_full.pid_hi          = sw_dct_rdata_packed.pid_hi;
+  end
+
+  // Extract the appropriate CPU word from the DCT entry to return it.
+  logic [1:0] sw_dct_rdata_sel;
+  assign sw_dct_rdata_o = DataWidth'(sw_dct_rdata_full >> {sw_dct_rdata_sel, Log2DW'(0)});
+
+  // Device Characteristics Table.
+  i3c_dxt #(
+    .EntryWidth (DCTMemWidth),
+    .NumEntries (NumDCTEntries),
+    .MaskWidth  (DCTMaskW),
+    .OOBWidth   (2)
+  ) u_dct(
+    .clk_i      (clk_i),
+    .rst_ni     (rst_ni),
+
+    // Port A (hardware; highest priority).
+    .a_re_i     (1'b0),
+    .a_we_i     (dct_we_i),
+    .a_idx_i    (dct_idx_i),
+    .a_wmask_i  (dct_wmask_i),
+    .a_wdata_i  (dct_wdata_i),
+    .a_rdata_o  (),
+
+    // Port B (software; lowest priority).
+    .b_req_i    (sw_dct_req_i),
+    .b_gnt_o    (sw_dct_gnt_o),
+    .b_we_i     (sw_dct_we_i),
+    .b_idx_i    (sw_dct_addr_i[DCTAddrW+1:2]),
+    .b_wmask_i  (sw_dct_wmask),
+    .b_wdata_i  (sw_dct_wdata_packed),
+    .b_oob_i    (sw_dct_addr_i[1:0]),
+    .b_rvalid_o (sw_dct_rvalid_o),
+    .b_rdata_o  (sw_dct_rdata_raw),
+    .b_oob_o    (sw_dct_rdata_sel),
+
+    .cfg_i      (dct_cfg_i),
+    .cfg_rsp_o  (dct_cfg_rsp_o)
+  );
+
+endmodule

--- a/hw/ip/i3c/rtl/i3c_dxt.sv
+++ b/hw/ip/i3c/rtl/i3c_dxt.sv
@@ -1,0 +1,110 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Implementation of the following two HCI-specified tables:
+//
+// - Device Address Table (HCI 8.1).
+// - Device Characteristics Table (HCI 8.2).
+//
+// These two tables need to be accessed by both software and hardware, with the hardware
+// having higher priority and stalling the software access slightly when necessary.
+// Support for sub-word writing is included.
+
+module i3c_dxt
+  import prim_ram_1p_pkg::*;
+#(
+  // Width of each entry, in bits.
+  parameter int unsigned EntryWidth = 72,
+  parameter int unsigned NumEntries = 32,
+  // Number of write strobes across the width of an entry.
+  parameter int unsigned MaskWidth  = EntryWidth / 8,
+  // Additional `Out Of Band` bits for port B, since it has a variable response time.
+  parameter int unsigned OOBWidth   = 1,
+  // Derived parameters.
+  localparam int unsigned IdxW = $clog2(NumEntries)
+) (
+  input                   clk_i,
+  input                   rst_ni,
+
+  // Port A (highest priority).
+  // - hardware interface; reads/writes full entries.
+  input                   a_re_i,
+  input                   a_we_i,
+  input        [IdxW-1:0] a_idx_i,
+  input   [MaskWidth-1:0] a_wmask_i,
+  input  [EntryWidth-1:0] a_wdata_i,
+  output [EntryWidth-1:0] a_rdata_o,
+
+  // Port B (lowest priority).
+  // - software interface has bus width read/write access, which translate to memory sub-words
+  //   since the memory entries are wider.
+  input                   b_req_i,
+  output                  b_gnt_o,
+  input                   b_we_i,
+  input        [IdxW-1:0] b_idx_i,
+  input   [MaskWidth-1:0] b_wmask_i,
+  input  [EntryWidth-1:0] b_wdata_i,
+  input    [OOBWidth-1:0] b_oob_i,
+  output                  b_rvalid_o,
+  output [EntryWidth-1:0] b_rdata_o,
+  output   [OOBWidth-1:0] b_oob_o,
+
+  input  ram_1p_cfg_t     cfg_i,
+  output ram_1p_cfg_rsp_t cfg_rsp_o
+);
+
+  localparam int unsigned DataBitsPerMask = EntryWidth / MaskWidth;
+
+  logic [EntryWidth-1:0] wmask_full;
+  logic [EntryWidth-1:0] rdata_full;
+  logic a_req;
+
+  assign a_req = a_re_i | a_we_i;
+  assign b_gnt_o = ~a_req;
+
+  // The RAM model _demands_ a full width mask and then narrows it internally.
+  wire [MaskWidth-1:0] wmask = a_req ? a_wmask_i : b_wmask_i;
+  for (genvar b = 0; b < MaskWidth; b++) begin : gen_wmask_full
+    assign wmask_full[b * DataBitsPerMask +: DataBitsPerMask] = {DataBitsPerMask{wmask[b]}};
+  end
+
+  prim_ram_1p #(
+    .Width            (EntryWidth),
+    .Depth            (NumEntries),
+    .DataBitsPerMask  (DataBitsPerMask)
+  ) u_dxt (
+    .clk_i      (clk_i),
+    .rst_ni     (rst_ni),
+
+    .req_i      (a_req | b_req_i),
+    .write_i    (a_req ? a_we_i    : b_we_i),
+    .addr_i     (a_req ? a_idx_i   : b_idx_i),
+    .wdata_i    (a_req ? a_wdata_i : b_wdata_i),
+    .wmask_i    (wmask_full),
+    .rdata_o    (rdata_full),
+
+    .cfg_i      (cfg_i),
+    .cfg_rsp_o  (cfg_rsp_o)
+  );
+
+  logic [OOBWidth-1:0] b_oob;
+  logic b_rvalid;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      b_rvalid  <= 1'b0;
+      b_oob     <= '0;
+    end else begin
+      // Read data is returned a cycle after the read request.
+      b_rvalid  <= &{b_req_i, ~b_we_i, ~a_req};
+      // Ensure that the OOB data is propagated too.
+      if (b_req_i & ~a_req) begin
+        b_oob   <= b_oob_i;
+      end
+    end
+  end
+  assign b_rvalid_o = b_rvalid;
+  assign b_oob_o    = b_oob;
+  assign {a_rdata_o, b_rdata_o} = {2{rdata_full}};
+
+endmodule


### PR DESCRIPTION
The HCI specifies two data structures (DAT and DCT) to pass device information between the driver software and the Controller logic.

The Device Address Table (DAT) is used during regular I3C traffic and provides the Controller hardware with device properties and configuration.

The Device Characteristics Table collects properties of the Targets involved in the Dynamic Address Assignment (DAA) procedure and conveys them to the driver software.

Since the two tables have much in common, a submodule i3c_dxt implements them both.