### PR TITLE
[pentest/aes] Allow to disable masking

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/sca/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/sca/BUILD
@@ -20,6 +20,7 @@ cc_library(
         "//sw/device/lib/dif:aes",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:aes_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_alerts",
         "//sw/device/lib/testing/test_framework:ujson_ottf",
         "//sw/device/lib/ujson",
         "//sw/device/sca/lib:aes",

--- a/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
@@ -19,6 +19,7 @@
 
 #if !OT_IS_ENGLISH_BREAKFAST
 #include "sw/device/lib/testing/aes_testutils.h"
+#include "sw/device/lib/testing/test_framework/ottf_alerts.h"
 #endif
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -397,6 +398,9 @@ status_t handle_aes_pentest_seed_lfsr(ujson_t *uj) {
 #if !OT_IS_ENGLISH_BREAKFAST
   if (transaction.force_masks) {
     LOG_INFO("Disabling masks.");
+    // The EDN will throw an error with this command since it will output a
+    // block of zeros. Hence expect and catch the alert
+    TRY(ottf_alerts_ignore_alert(kTopEarlgreyAlertIdEdn0RecovAlert));
     status_t res = aes_testutils_masking_prng_zero_output_seed();
     if (res.value != 0) {
       return ABORTED();

--- a/sw/host/penetrationtests/python/sca/host_scripts/sca_aes_functions.py
+++ b/sw/host/penetrationtests/python/sca/host_scripts/sca_aes_functions.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+import time
 from sw.host.penetrationtests.python.sca.communication.sca_aes_commands import OTAES
 from sw.host.penetrationtests.python.sca.communication.sca_prng_commands import OTPRNG
 from sw.host.penetrationtests.python.sca.communication.sca_trigger_commands import OTTRIGGER
@@ -23,6 +24,8 @@ def char_aes_single_encrypt(target, iterations, fpga, masking, key, text, reset 
     else:
         lfsr_seed = 0
     aessca.seed_lfsr(lfsr_seed.to_bytes(4, "little"))
+    # Give time to warm up the EDN when masking is requested to be disabled
+    time.sleep(0.5)
 
     # Set the trigger
     triggersca = OTTRIGGER(target)
@@ -52,6 +55,8 @@ def char_aes_batch_daisy_chain(
     else:
         lfsr_seed = 0
     aessca.seed_lfsr(lfsr_seed.to_bytes(4, "little"))
+    # Give time to warm up the EDN when masking is requested to be disabled
+    time.sleep(0.5)
 
     # Set the trigger
     triggersca = OTTRIGGER(target)
@@ -84,6 +89,8 @@ def char_aes_batch_fvsr_data(
     else:
         lfsr_seed = 0
     aessca.seed_lfsr(lfsr_seed.to_bytes(4, "little"))
+    # Give time to warm up the EDN when masking is requested to be disabled
+    time.sleep(0.5)
 
     # Set the trigger
     triggersca = OTTRIGGER(target)
@@ -115,6 +122,8 @@ def char_aes_batch_fvsr_key(target, iterations, num_segments, fpga, masking, key
     else:
         lfsr_seed = 0
     aessca.seed_lfsr(lfsr_seed.to_bytes(4, "little"))
+    # Give time to warm up the EDN when masking is requested to be disabled
+    time.sleep(0.5)
 
     # Set the trigger
     triggersca = OTTRIGGER(target)
@@ -147,6 +156,8 @@ def char_aes_batch_random(target, iterations, num_segments, fpga, masking, key, 
     else:
         lfsr_seed = 0
     aessca.seed_lfsr(lfsr_seed.to_bytes(4, "little"))
+    # Give time to warm up the EDN when masking is requested to be disabled
+    time.sleep(0.5)
 
     # Set the trigger
     triggersca = OTTRIGGER(target)

--- a/sw/host/penetrationtests/python/sca/test_scripts/sca_aes_python_test.py
+++ b/sw/host/penetrationtests/python/sca/test_scripts/sca_aes_python_test.py
@@ -117,8 +117,9 @@ class AesScaTest(unittest.TestCase):
         self.assertIn("PENTEST", version)
 
     def test_char_aes_single_encrypt(self):
-        # Note that setting this to false gives errors for production chips
-        masking = True
+        # Note that setting this to false does not actually
+        # turn off masking in silicon, only on FPGA
+        masking = False
         key = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
         text = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
         actual_result = sca_aes_functions.char_aes_single_encrypt(
@@ -136,7 +137,6 @@ class AesScaTest(unittest.TestCase):
 
     def test_char_aes_batch_daisy_chain(self):
         for num_segments in num_segments_list:
-            # Note that setting this to false gives errors for production chips
             masking = True
             key = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
             text = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
@@ -161,7 +161,6 @@ class AesScaTest(unittest.TestCase):
 
     def test_char_aes_batch_fvsr_data(self):
         for num_segments in num_segments_list:
-            # Note that setting this to false gives errors for production chips
             masking = True
             key = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
             text = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]


### PR DESCRIPTION
Debug the pentest framework such that disabled masking for the AES is possible.