### PR TITLE
[silicon_creator] Add OTBN checksum verification

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -496,6 +496,7 @@ cc_library(
         "//hw/top/dt",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:crc32",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
         "//sw/device/silicon_creator/lib/drivers:rnd",

--- a/sw/device/silicon_creator/lib/drivers/otbn.c
+++ b/sw/device/silicon_creator/lib/drivers/otbn.c
@@ -7,10 +7,12 @@
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
 #include "hw/top/dt/otbn.h"
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/crc32.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/drivers/rnd.h"
 #include "sw/device/silicon_creator/lib/error.h"
@@ -72,24 +74,18 @@ rom_error_t sc_otbn_busy_wait_for_done(void) {
 /**
  * Helper function for writing to OTBN's DMEM or IMEM.
  *
- * @param dest_addr Destination address.
+ * @param reg_offset Register offset (IMEM or DMEM).
+ * @param otbn_addr OTBN address relative to memory start.
  * @param src Source buffer.
  * @param num_words Number of words to copy.
  */
-static void sc_otbn_write(uint32_t dest_addr, const uint32_t *src,
-                          size_t num_words) {
-  // Start from a random index less than `num_words`.
-  uint32_t i = ((uint64_t)rnd_uint32() * (uint64_t)num_words) >> 32;
-  enum { kStep = 1 };
+static void sc_otbn_write(uint32_t reg_offset, uint32_t otbn_addr,
+                          const uint32_t *src, size_t num_words) {
+  uint32_t dest_addr = otbn_base() + reg_offset + otbn_addr;
   uint32_t iter_cnt = 0, r_iter_cnt = num_words - 1;
   for (; launder32(iter_cnt) < num_words && launder32(r_iter_cnt) < num_words;
        ++iter_cnt, --r_iter_cnt) {
-    abs_mmio_write32(dest_addr + i * sizeof(uint32_t), src[i]);
-    i += kStep;
-    if (launder32(i) >= num_words) {
-      i -= num_words;
-    }
-    HARDENED_CHECK_LT(i, num_words);
+    abs_mmio_write32(dest_addr + iter_cnt * sizeof(uint32_t), src[iter_cnt]);
   }
   HARDENED_CHECK_EQ(iter_cnt, num_words);
   HARDENED_CHECK_EQ(r_iter_cnt, UINT32_MAX);
@@ -100,7 +96,7 @@ static rom_error_t sc_otbn_imem_write(size_t num_words, const uint32_t *src,
                                       sc_otbn_addr_t dest) {
   HARDENED_RETURN_IF_ERROR(
       check_offset_len(dest, num_words, OTBN_IMEM_SIZE_BYTES));
-  sc_otbn_write(otbn_base() + OTBN_IMEM_REG_OFFSET + dest, src, num_words);
+  sc_otbn_write(OTBN_IMEM_REG_OFFSET, dest, src, num_words);
   return kErrorOk;
 }
 
@@ -108,7 +104,31 @@ rom_error_t sc_otbn_dmem_write(size_t num_words, const uint32_t *src,
                                sc_otbn_addr_t dest) {
   HARDENED_RETURN_IF_ERROR(
       check_offset_len(dest, num_words, OTBN_DMEM_SIZE_BYTES));
-  sc_otbn_write(otbn_base() + OTBN_DMEM_REG_OFFSET + dest, src, num_words);
+
+  // Reset the LOAD_CHECKSUM register.
+  abs_mmio_write32(otbn_base() + OTBN_LOAD_CHECKSUM_REG_OFFSET, 0);
+
+  sc_otbn_write(OTBN_DMEM_REG_OFFSET, dest, src, num_words);
+
+  // Calculate expected checksum.
+  uint32_t crc_ctx;
+  crc32_init(&crc_ctx);
+  for (size_t i = 0; i < num_words; ++i) {
+    crc32_add32(&crc_ctx, src[i]);
+    uint16_t location = (uint16_t)(((dest >> 2) + i) & 0x7FFF);
+    crc32_add8(&crc_ctx, (uint8_t)location);
+    crc32_add8(&crc_ctx, (uint8_t)(location >> 8));
+  }
+
+  // Verify checksum.
+  uint32_t checksum_expected = crc32_finish(&crc_ctx);
+  uint32_t checksum =
+      abs_mmio_read32(otbn_base() + OTBN_LOAD_CHECKSUM_REG_OFFSET);
+  if (launder32(checksum) != checksum_expected) {
+    return kErrorOtbnBadChecksum;
+  }
+  HARDENED_CHECK_EQ(checksum, checksum_expected);
+
   return kErrorOk;
 }
 
@@ -249,6 +269,9 @@ rom_error_t sc_otbn_load_app(const sc_otbn_app_t app) {
   HARDENED_RETURN_IF_ERROR(sc_otbn_dmem_sec_wipe());
   HARDENED_RETURN_IF_ERROR(sc_otbn_imem_sec_wipe());
 
+  // Reset the LOAD_CHECKSUM register.
+  abs_mmio_write32(otbn_base() + OTBN_LOAD_CHECKSUM_REG_OFFSET, 0);
+
   const size_t imem_num_words = (size_t)(app.imem_end - app.imem_start);
   const size_t data_num_words =
       (size_t)(app.dmem_data_end - app.dmem_data_start);
@@ -259,8 +282,19 @@ rom_error_t sc_otbn_load_app(const sc_otbn_app_t app) {
       sc_otbn_imem_write(imem_num_words, app.imem_start, imem_start_addr));
 
   if (data_num_words > 0) {
-    HARDENED_RETURN_IF_ERROR(sc_otbn_dmem_write(
-        data_num_words, app.dmem_data_start, app.dmem_data_start_addr));
+    HARDENED_RETURN_IF_ERROR(check_offset_len(
+        app.dmem_data_start_addr, data_num_words, OTBN_DMEM_SIZE_BYTES));
+    sc_otbn_write(OTBN_DMEM_REG_OFFSET, app.dmem_data_start_addr,
+                  app.dmem_data_start, data_num_words);
   }
+
+  // Ensure that the checksum matches expectations.
+  uint32_t checksum =
+      abs_mmio_read32(otbn_base() + OTBN_LOAD_CHECKSUM_REG_OFFSET);
+  if (launder32(checksum) != app.checksum) {
+    return kErrorOtbnBadChecksum;
+  }
+  HARDENED_CHECK_EQ(checksum, app.checksum);
+
   return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/drivers/otbn.h
+++ b/sw/device/silicon_creator/lib/drivers/otbn.h
@@ -113,6 +113,13 @@ typedef struct sc_otbn_app {
    * time.
    */
   const sc_otbn_addr_t dmem_data_start_addr;
+  /**
+   * Application checksum.
+   *
+   * This value represents a CRC32 checksum over IMEM and the `.data` portion
+   * of DMEM.
+   */
+  const uint32_t checksum;
 } sc_otbn_app_t;
 
 /**
@@ -177,12 +184,13 @@ typedef struct sc_otbn_app {
  * @param app_name Name of the application to load, which is typically the
  *                 name of the main (assembly) source file.
  */
-#define OTBN_DECLARE_APP_SYMBOLS(app_name)             \
-  OTBN_DECLARE_SYMBOL_PTR(app_name, _imem_start);      \
-  OTBN_DECLARE_SYMBOL_PTR(app_name, _imem_end);        \
-  OTBN_DECLARE_SYMBOL_PTR(app_name, _dmem_data_start); \
-  OTBN_DECLARE_SYMBOL_PTR(app_name, _dmem_data_end);   \
-  OTBN_DECLARE_SYMBOL_ADDR(app_name, _dmem_data_start);
+#define OTBN_DECLARE_APP_SYMBOLS(app_name)              \
+  OTBN_DECLARE_SYMBOL_PTR(app_name, _imem_start);       \
+  OTBN_DECLARE_SYMBOL_PTR(app_name, _imem_end);         \
+  OTBN_DECLARE_SYMBOL_PTR(app_name, _dmem_data_start);  \
+  OTBN_DECLARE_SYMBOL_PTR(app_name, _dmem_data_end);    \
+  OTBN_DECLARE_SYMBOL_ADDR(app_name, _dmem_data_start); \
+  OTBN_DECLARE_SYMBOL_ADDR(app_name, _checksum)
 
 /**
  * Initializes the OTBN application information structure.
@@ -201,6 +209,7 @@ typedef struct sc_otbn_app {
       .dmem_data_start = OTBN_SYMBOL_PTR(app_name, _dmem_data_start),       \
       .dmem_data_end = OTBN_SYMBOL_PTR(app_name, _dmem_data_end),           \
       .dmem_data_start_addr = OTBN_ADDR_T_INIT(app_name, _dmem_data_start), \
+      .checksum = OTBN_ADDR_T_INIT(app_name, _checksum),                    \
   })
 
 /**

--- a/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
@@ -9,6 +9,7 @@
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mock_abs_mmio.h"
+#include "sw/device/lib/base/mock_crc32.h"
 #include "sw/device/silicon_creator/lib/base/mock_sec_mmio.h"
 #include "sw/device/silicon_creator/lib/drivers/mock_rnd.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
@@ -61,6 +62,7 @@ class OtbnTest : public rom_test::RomTest {
   rom_test::MockAbsMmio abs_mmio_;
   rom_test::MockRnd rnd_;
   rom_test::MockSecMmio sec_mmio_;
+  rom_test::MockCrc32 crc32_;
 };
 
 class ExecuteTest : public OtbnTest {};
@@ -180,11 +182,22 @@ TEST_F(DmemWriteTest, SuccessWithoutOffset) {
 
   std::array<uint32_t, 2> test_data = {0x12345678, 0xabcdef01};
   sc_otbn_addr_t dest_addr = 0;
+  uint32_t expected_checksum = 0x12345678;
 
-  EXPECT_CALL(rnd_, Uint32()).WillOnce(Return(0));
+  EXPECT_ABS_WRITE32(base_ + OTBN_LOAD_CHECKSUM_REG_OFFSET, 0);
+
   EXPECT_ABS_WRITE32(base_ + OTBN_DMEM_REG_OFFSET + dest_addr, test_data[0]);
   EXPECT_ABS_WRITE32(base_ + OTBN_DMEM_REG_OFFSET + dest_addr + 4,
                      test_data[1]);
+
+  EXPECT_CALL(crc32_, Init(testing::_));
+  EXPECT_CALL(crc32_, Add32(testing::_, test_data[0]));
+  EXPECT_CALL(crc32_, Add8(testing::_, testing::_)).Times(2);
+  EXPECT_CALL(crc32_, Add32(testing::_, test_data[1]));
+  EXPECT_CALL(crc32_, Add8(testing::_, testing::_)).Times(2);
+
+  EXPECT_CALL(crc32_, Finish(testing::_)).WillOnce(Return(expected_checksum));
+  EXPECT_ABS_READ32(base_ + OTBN_LOAD_CHECKSUM_REG_OFFSET, expected_checksum);
 
   EXPECT_EQ(sc_otbn_dmem_write(2, test_data.data(), dest_addr), kErrorOk);
 }
@@ -195,11 +208,22 @@ TEST_F(DmemWriteTest, SuccessWithOffset) {
 
   std::array<uint32_t, 2> test_data = {0x12345678, 0xabcdef01};
   sc_otbn_addr_t dest_addr = 4;
+  uint32_t expected_checksum = 0x12345678;
 
-  EXPECT_CALL(rnd_, Uint32()).WillOnce(Return(0));
+  EXPECT_ABS_WRITE32(base_ + OTBN_LOAD_CHECKSUM_REG_OFFSET, 0);
+
   EXPECT_ABS_WRITE32(base_ + OTBN_DMEM_REG_OFFSET + dest_addr, test_data[0]);
   EXPECT_ABS_WRITE32(base_ + OTBN_DMEM_REG_OFFSET + dest_addr + 4,
                      test_data[1]);
+
+  EXPECT_CALL(crc32_, Init(testing::_));
+  EXPECT_CALL(crc32_, Add32(testing::_, test_data[0]));
+  EXPECT_CALL(crc32_, Add8(testing::_, testing::_)).Times(2);
+  EXPECT_CALL(crc32_, Add32(testing::_, test_data[1]));
+  EXPECT_CALL(crc32_, Add8(testing::_, testing::_)).Times(2);
+
+  EXPECT_CALL(crc32_, Finish(testing::_)).WillOnce(Return(expected_checksum));
+  EXPECT_ABS_READ32(base_ + OTBN_LOAD_CHECKSUM_REG_OFFSET, expected_checksum);
 
   EXPECT_EQ(sc_otbn_dmem_write(2, test_data.data(), dest_addr), kErrorOk);
 }
@@ -229,6 +253,33 @@ TEST_F(DmemWriteTest, FailureOverflowOffset) {
 
   EXPECT_EQ(sc_otbn_dmem_write(test_data.size(), test_data.data(), dest_addr),
             kErrorOtbnBadOffsetLen);
+}
+
+TEST_F(DmemWriteTest, FailureChecksumMismatch) {
+  static_assert(OTBN_DMEM_SIZE_BYTES >= 8, "OTBN DMEM size too small.");
+
+  std::array<uint32_t, 2> test_data = {0x12345678, 0xabcdef01};
+  sc_otbn_addr_t dest_addr = 0;
+  uint32_t expected_checksum = 0x12345678;
+
+  EXPECT_ABS_WRITE32(base_ + OTBN_LOAD_CHECKSUM_REG_OFFSET, 0);
+
+  EXPECT_ABS_WRITE32(base_ + OTBN_DMEM_REG_OFFSET + dest_addr, test_data[0]);
+  EXPECT_ABS_WRITE32(base_ + OTBN_DMEM_REG_OFFSET + dest_addr + 4,
+                     test_data[1]);
+
+  EXPECT_CALL(crc32_, Init(testing::_));
+  EXPECT_CALL(crc32_, Add32(testing::_, test_data[0]));
+  EXPECT_CALL(crc32_, Add8(testing::_, testing::_)).Times(2);
+  EXPECT_CALL(crc32_, Add32(testing::_, test_data[1]));
+  EXPECT_CALL(crc32_, Add8(testing::_, testing::_)).Times(2);
+
+  EXPECT_CALL(crc32_, Finish(testing::_)).WillOnce(Return(expected_checksum));
+  EXPECT_ABS_READ32(base_ + OTBN_LOAD_CHECKSUM_REG_OFFSET,
+                    expected_checksum ^ 1);
+
+  EXPECT_EQ(sc_otbn_dmem_write(2, test_data.data(), dest_addr),
+            kErrorOtbnBadChecksum);
 }
 
 class DmemReadTest : public OtbnTest {};
@@ -268,12 +319,14 @@ TEST_F(OtbnAppTest, OtbnLoadAppSuccess) {
   std::array<uint32_t, 2> imem_data = {0x01234567, 0x89abcdef};
   std::array<uint32_t, 2> dmem_data = {0x456789ab, 0xcdef0123};
   sc_otbn_addr_t dmem_data_offset = 0x12;
+  uint32_t expected_checksum = 0x12345678;
   sc_otbn_app_t app = {
       .imem_start = imem_data.data(),
       .imem_end = imem_data.data() + imem_data.size(),
       .dmem_data_start = dmem_data.data(),
-      .dmem_data_end = dmem_data.data() + imem_data.size(),
+      .dmem_data_end = dmem_data.data() + dmem_data.size(),
       .dmem_data_start_addr = dmem_data_offset,
+      .checksum = expected_checksum,
   };
 
   // Test assumption.
@@ -294,18 +347,21 @@ TEST_F(OtbnAppTest, OtbnLoadAppSuccess) {
   ExpectCmdRun(kScOtbnCmdSecWipeDmem, err_bits_ok_, kScOtbnStatusIdle);
   // `sc_otbn_imem_sec_wipe`
   ExpectCmdRun(kScOtbnCmdSecWipeImem, err_bits_ok_, kScOtbnStatusIdle);
+
+  EXPECT_ABS_WRITE32(base_ + OTBN_LOAD_CHECKSUM_REG_OFFSET, 0);
+
   // `otbn_imem_write`
-  EXPECT_CALL(rnd_, Uint32()).WillOnce(Return(0));
   EXPECT_ABS_WRITE32(base_ + OTBN_IMEM_REG_OFFSET, imem_data[0]);
   EXPECT_ABS_WRITE32(base_ + OTBN_IMEM_REG_OFFSET + sizeof(uint32_t),
                      imem_data[1]);
   // `sc_otbn_dmem_write`
-  EXPECT_CALL(rnd_, Uint32()).WillOnce(Return(0));
   EXPECT_ABS_WRITE32(base_ + OTBN_DMEM_REG_OFFSET + dmem_data_offset,
                      dmem_data[0]);
   EXPECT_ABS_WRITE32(
       base_ + OTBN_DMEM_REG_OFFSET + dmem_data_offset + sizeof(uint32_t),
       dmem_data[1]);
+
+  EXPECT_ABS_READ32(base_ + OTBN_LOAD_CHECKSUM_REG_OFFSET, expected_checksum);
 
   EXPECT_EQ(sc_otbn_load_app(app), kErrorOk);
 }
@@ -321,6 +377,7 @@ TEST_F(OtbnAppTest, OtbnLoadInvalidAppEmptyImem) {
       .dmem_data_start = dmem_data.data(),
       .dmem_data_end = dmem_data.data() + dmem_data.size(),
       .dmem_data_start_addr = dmem_data_offset,
+      .checksum = 0,
   };
 
   // Test assumption.
@@ -344,6 +401,7 @@ TEST_F(OtbnAppTest, OtbnLoadInvalidAppImemOutOfRange) {
       .dmem_data_start = dmem_data.data(),
       .dmem_data_end = dmem_data.data() + dmem_data.size(),
       .dmem_data_start_addr = dmem_data_offset,
+      .checksum = 0,
   };
 
   // Read twice for hardening.
@@ -354,7 +412,51 @@ TEST_F(OtbnAppTest, OtbnLoadInvalidAppImemOutOfRange) {
   // `sc_otbn_imem_sec_wipe`
   ExpectCmdRun(kScOtbnCmdSecWipeImem, err_bits_ok_, kScOtbnStatusIdle);
 
+  EXPECT_ABS_WRITE32(base_ + OTBN_LOAD_CHECKSUM_REG_OFFSET, 0);
+
   EXPECT_EQ(sc_otbn_load_app(app), kErrorOtbnBadOffsetLen);
+}
+
+TEST_F(OtbnAppTest, OtbnLoadAppChecksumMismatch) {
+  std::array<uint32_t, 2> imem_data = {0x01234567, 0x89abcdef};
+  std::array<uint32_t, 2> dmem_data = {0x456789ab, 0xcdef0123};
+  sc_otbn_addr_t dmem_data_offset = 0x12;
+  uint32_t expected_checksum = 0x12345678;
+  sc_otbn_app_t app = {
+      .imem_start = imem_data.data(),
+      .imem_end = imem_data.data() + imem_data.size(),
+      .dmem_data_start = dmem_data.data(),
+      .dmem_data_end = dmem_data.data() + dmem_data.size(),
+      .dmem_data_start_addr = dmem_data_offset,
+      .checksum = expected_checksum,
+  };
+
+  // Read twice for hardening.
+  EXPECT_ABS_READ32(base_ + OTBN_STATUS_REG_OFFSET, kScOtbnStatusIdle);
+  EXPECT_ABS_READ32(base_ + OTBN_STATUS_REG_OFFSET, kScOtbnStatusIdle);
+  // `sc_otbn_dmem_sec_wipe`
+  ExpectCmdRun(kScOtbnCmdSecWipeDmem, err_bits_ok_, kScOtbnStatusIdle);
+  // `sc_otbn_imem_sec_wipe`
+  ExpectCmdRun(kScOtbnCmdSecWipeImem, err_bits_ok_, kScOtbnStatusIdle);
+
+  EXPECT_ABS_WRITE32(base_ + OTBN_LOAD_CHECKSUM_REG_OFFSET, 0);
+
+  // `otbn_imem_write`
+  EXPECT_ABS_WRITE32(base_ + OTBN_IMEM_REG_OFFSET, imem_data[0]);
+  EXPECT_ABS_WRITE32(base_ + OTBN_IMEM_REG_OFFSET + sizeof(uint32_t),
+                     imem_data[1]);
+  // `sc_otbn_dmem_write`
+  EXPECT_ABS_WRITE32(base_ + OTBN_DMEM_REG_OFFSET + dmem_data_offset,
+                     dmem_data[0]);
+  EXPECT_ABS_WRITE32(
+      base_ + OTBN_DMEM_REG_OFFSET + dmem_data_offset + sizeof(uint32_t),
+      dmem_data[1]);
+
+  // Expect checksum read returning WRONG checksum.
+  EXPECT_ABS_READ32(base_ + OTBN_LOAD_CHECKSUM_REG_OFFSET,
+                    expected_checksum ^ 1);
+
+  EXPECT_EQ(sc_otbn_load_app(app), kErrorOtbnBadChecksum);
 }
 
 class OtbnWriteTest : public OtbnTest {};
@@ -362,17 +464,28 @@ class OtbnWriteTest : public OtbnTest {};
 TEST_F(OtbnWriteTest, Success) {
   constexpr uint32_t kDestAddr = 6;
   std::array<uint32_t, 2> test_data = {0x12345678, 0xabcdef01};
+  uint32_t expected_checksum = 0x12345678;
 
   // Test assumption.
   static_assert(
       OTBN_DMEM_SIZE_BYTES >= sizeof(uint32_t) * test_data.size() + kDestAddr,
       "OTBN DMEM size too small.");
 
-  EXPECT_CALL(rnd_, Uint32()).WillOnce(Return(0));
+  EXPECT_ABS_WRITE32(base_ + OTBN_LOAD_CHECKSUM_REG_OFFSET, 0);
+
   EXPECT_ABS_WRITE32(base_ + OTBN_DMEM_REG_OFFSET + kDestAddr, test_data[0]);
   EXPECT_ABS_WRITE32(
       base_ + OTBN_DMEM_REG_OFFSET + kDestAddr + sizeof(uint32_t),
       test_data[1]);
+
+  EXPECT_CALL(crc32_, Init(testing::_));
+  EXPECT_CALL(crc32_, Add32(testing::_, test_data[0]));
+  EXPECT_CALL(crc32_, Add8(testing::_, testing::_)).Times(2);
+  EXPECT_CALL(crc32_, Add32(testing::_, test_data[1]));
+  EXPECT_CALL(crc32_, Add8(testing::_, testing::_)).Times(2);
+
+  EXPECT_CALL(crc32_, Finish(testing::_)).WillOnce(Return(expected_checksum));
+  EXPECT_ABS_READ32(base_ + OTBN_LOAD_CHECKSUM_REG_OFFSET, expected_checksum);
 
   EXPECT_EQ(sc_otbn_dmem_write(2, test_data.data(), kDestAddr), kErrorOk);
 }

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -137,6 +137,7 @@ enum module_ {
   X(kErrorOtbnSecWipeDmemFailed,      ERROR_(5, kModuleOtbn, kInternal)), \
   X(kErrorOtbnBadInsnCount,           ERROR_(6, kModuleOtbn, kInternal)), \
   X(kErrorOtbnUnavailable,            ERROR_(7, kModuleOtbn, kInternal)), \
+  X(kErrorOtbnBadChecksum,            ERROR_(8, kModuleOtbn, kInternal)), \
   \
   X(kErrorFlashCtrlDataRead,          ERROR_(1, kModuleFlashCtrl, kInternal)), \
   X(kErrorFlashCtrlInfoRead,          ERROR_(2, kModuleFlashCtrl, kInternal)), \


### PR DESCRIPTION
For the OTBN driver in silicon_creator, add verification of the checksum registers just like in the lib/crypto/drivers/otbn.c.