### PR TITLE
[silicon_creator] Wipe DMEM after use

### DIFF
--- a/sw/device/silicon_creator/lib/otbn_boot_services.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.c
@@ -241,6 +241,9 @@ rom_error_t otbn_boot_attestation_endorse(const hmac_digest_t *digest,
   HARDENED_RETURN_IF_ERROR(sc_otbn_dmem_read(kEcdsaP256SignatureComponentWords,
                                              kOtbnVarBootS, sig->s));
 
+  // Clear the key and the DMEM.
+  HARDENED_RETURN_IF_ERROR(otbn_boot_attestation_key_clear());
+
   // Verify the signature.
   uint32_t recovered_r[kEcdsaP256SignatureComponentWords];
   HARDENED_RETURN_IF_ERROR(otbn_boot_sigverify(key, sig, digest, recovered_r));
@@ -305,8 +308,12 @@ rom_error_t otbn_boot_sigverify_finish(uint32_t *recovered_r) {
   // TODO(#20023): Check the instruction count register (see `mod_exp_otbn`).
 
   // Read the recovered `r` value from DMEM.
-  return sc_otbn_dmem_read(kEcdsaP256SignatureComponentWords, kOtbnVarBootXr,
-                           recovered_r);
+  HARDENED_RETURN_IF_ERROR(sc_otbn_dmem_read(kEcdsaP256SignatureComponentWords,
+                                             kOtbnVarBootXr, recovered_r));
+
+  // We clear the DMEM of the OTBN in order to wipe variables like the ok
+  // status.
+  return otbn_boot_attestation_key_clear();
 }
 
 rom_error_t otbn_boot_sigverify(const ecdsa_p256_public_key_t *key,

--- a/sw/device/silicon_creator/lib/otbn_boot_services_functest.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services_functest.c
@@ -171,11 +171,6 @@ rom_error_t attestation_advance_and_endorse_test(void) {
   ecdsa_p256_signature_t sig;
   RETURN_IF_ERROR(otbn_boot_attestation_endorse(&digest, &sig, &pk));
 
-  // Run endorsement again (should not return an error, but should produce an
-  // invalid signature).
-  CHECK(otbn_boot_attestation_endorse(&digest, &sig, &pk) ==
-        kErrorSigverifyBadEcdsaSignature);
-
   // Check that generating a new key with the same diversification as before
   // now gets a different public key because keymgr has advanced.
   ecdsa_p256_public_key_t pk_adv;


### PR DESCRIPTION
In line with the cryptolib's style of using the OTBN, wipe the DMEM after the use of it for both ECC verify and sign. The verify wipe is there to remove variables such as the ok status.