### PR TITLE
[hw, rv_plic] Correct target Interrupt Enable stride

### DIFF
--- a/hw/ip_templates/rv_plic/data/rv_plic.hjson.tpl
+++ b/hw/ip_templates/rv_plic/data/rv_plic.hjson.tpl
@@ -179,7 +179,7 @@
       }
     },
 % for i in range(target):
-    { skipto: "${"0x{:x}".format(0x00002000 + i * 0x100)}" }
+    { skipto: "${"0x{:x}".format(0x00002000 + i * 0x80)}" }
     { multireg: {
         name: "IE${i}",
         desc: "Interrupt Enable for Target ${i}",


### PR DESCRIPTION
Per the [PLIC specification](https://github.com/riscv/riscv-plic-spec/releases/download/1.0.0/riscv-plic-1.0.0.pdf) memory map, the spacing between context/"target" interrupt enable registers should be `0x80` instead of `0x100`.

This has not been an issue because the Opentitan tops use a single Ibex core which does not support S-mode, therefore only one interrupt context/target is present ([Earl Grey](https://opentitan.org/book/hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic.html#ie0_0), [Darjeeling](https://opentitan.org/book/hw/top_darjeeling/ip_autogen/rv_plic/data/rv_plic.html#ie0_0)) so this stride mismatch has never come up. This is however relevant to [Mocha](https://github.com/lowRISC/mocha/), which uses this IP template and has 2 contexts as S-mode is supported in CVA-6, and at the moment workarounds are needed in Linux and OpenSBI.