### PR TITLE
[rom_ext] Add bl0 boot diagnostics to `boot_log`

### DIFF
--- a/sw/device/silicon_creator/lib/boot_log.h
+++ b/sw/device/silicon_creator/lib/boot_log.h
@@ -56,8 +56,12 @@ typedef struct boot_log {
   uint32_t retention_ram_initialized;
   /** Signals of events during boot. */
   uint32_t events;
+  /** The firmware domain of the application we booted. */
+  uint32_t bl0_firmware_domain;
+  /** If we didn't boot the preferred slot, the errorcode describing why. */
+  uint32_t bl0_failure_reason;
   /** Pad to 128 bytes. */
-  uint32_t reserved[7];
+  uint32_t reserved[5];
 } boot_log_t;
 
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, digest, 0);
@@ -76,7 +80,10 @@ OT_ASSERT_MEMBER_OFFSET(boot_log_t, bl0_min_sec_ver, 84);
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, primary_bl0_slot, 88);
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, retention_ram_initialized, 92);
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, events, 96);
-OT_ASSERT_MEMBER_OFFSET(boot_log_t, reserved, 100);
+OT_ASSERT_MEMBER_OFFSET(boot_log_t, bl0_firmware_domain, 100);
+OT_ASSERT_MEMBER_OFFSET(boot_log_t, bl0_failure_reason, 104);
+OT_ASSERT_MEMBER_OFFSET(boot_log_t, reserved, 108);
+OT_ASSERT_SIZE(boot_log_t, 128);
 
 enum {
   /**

--- a/sw/device/silicon_creator/lib/boot_log_unittest.cc
+++ b/sw/device/silicon_creator/lib/boot_log_unittest.cc
@@ -7,6 +7,7 @@
 #include <cstring>
 
 #include "gtest/gtest.h"
+#include "sw/device/lib/base/hardened.h"
 #include "sw/device/silicon_creator/lib/build_info.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/drivers/mock_hmac.h"
@@ -59,7 +60,21 @@ class BootLogTest : public rom_test::RomTest {
       .identifier = kBootLogIdentifier,
       .chip_version = expected_chip_version,
       .rom_ext_slot = expected_rom_ext_slot,
+      .rom_ext_major = 1,
+      .rom_ext_minor = 2,
+      .rom_ext_size = 0x1000,
+      .rom_ext_nonce = {{0x01234567, 0x89abcdef}},
       .bl0_slot = expected_bl0_slot,
+      .ownership_state = 0x55555555,
+      .ownership_transfers = 3,
+      .rom_ext_min_sec_ver = 1,
+      .bl0_min_sec_ver = 2,
+      .primary_bl0_slot = kBootSlotA,
+      .retention_ram_initialized = kHardenedBoolTrue,
+      .events = 0x12,
+      .bl0_firmware_domain = 0x34,
+      .bl0_failure_reason = 0x56,
+      .reserved = {1, 2, 3, 4, 5},
   };
 };
 
@@ -88,15 +103,15 @@ TEST_F(BootLogTest, DigestUpdate) {
                                    expected_digest_region_len, _))
       .WillOnce(testing::SetArgPointee<2>(new_digest));
 
+  boot_log_t boot_log_copy = boot_log;
   boot_log_digest_update(&boot_log);
 
   // Check that the digest field in boot_log has been updated correctly
   EXPECT_EQ(new_digest, boot_log.digest);
   // Ensure no other fields changed
-  EXPECT_EQ(kBootLogIdentifier, boot_log.identifier);
-  EXPECT_EQ(expected_rom_ext_slot, boot_log.rom_ext_slot);
-  EXPECT_EQ(expected_bl0_slot, boot_log.bl0_slot);
-  EXPECT_EQ(expected_chip_version, boot_log.chip_version);
+  EXPECT_EQ(0, std::memcmp((char *)&boot_log + sizeof(hmac_digest_t),
+                           (char *)&boot_log_copy + sizeof(hmac_digest_t),
+                           sizeof(boot_log_t) - sizeof(hmac_digest_t)));
 }
 
 TEST_F(BootLogTest, BootLogCheckSuccess) {
@@ -124,15 +139,12 @@ TEST_F(BootLogTest, BootLogCheckSuccess) {
                                    expected_digest_region_len, _))
       .WillOnce(testing::SetArgPointee<2>(new_digest));
 
+  boot_log_t boot_log_copy = boot_log;
   uint32_t error = boot_log_check(&boot_log);
   EXPECT_EQ(error, kErrorOk);
 
   // Ensure no fields have been changed
-  EXPECT_EQ(expected_digest, boot_log.digest);
-  EXPECT_EQ(kBootLogIdentifier, boot_log.identifier);
-  EXPECT_EQ(expected_rom_ext_slot, boot_log.rom_ext_slot);
-  EXPECT_EQ(expected_bl0_slot, boot_log.bl0_slot);
-  EXPECT_EQ(expected_chip_version, boot_log.chip_version);
+  EXPECT_EQ(0, std::memcmp(&boot_log, &boot_log_copy, sizeof(boot_log_t)));
 }
 
 TEST_F(BootLogTest, BootLogCheckFailure) {
@@ -160,15 +172,12 @@ TEST_F(BootLogTest, BootLogCheckFailure) {
                                    expected_digest_region_len, _))
       .WillOnce(testing::SetArgPointee<2>(new_digest));
 
+  boot_log_t boot_log_copy = boot_log;
   uint32_t error = boot_log_check(&boot_log);
   EXPECT_EQ(error, kErrorBootLogInvalid);
 
   // Ensure no fields have been changed
-  EXPECT_EQ(expected_digest, boot_log.digest);
-  EXPECT_EQ(kBootLogIdentifier, boot_log.identifier);
-  EXPECT_EQ(expected_rom_ext_slot, boot_log.rom_ext_slot);
-  EXPECT_EQ(expected_bl0_slot, boot_log.bl0_slot);
-  EXPECT_EQ(expected_chip_version, boot_log.chip_version);
+  EXPECT_EQ(0, std::memcmp(&boot_log, &boot_log_copy, sizeof(boot_log_t)));
 }
 
 }  // namespace

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
@@ -79,7 +79,7 @@ _POSITIONS = {
         "romext_offset": "{rom_ext_slot_a}",
         "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_b",
         "owner_offset": "{owner_slot_b}",
-        "success": "bl0_slot = __BB\r\n",
+        "success": r"bl0_slot = __BB[\s\S]*boot_log bl0_failure_reason = 0142500d",
         "otp_img": None,
     },
     "owner_virtual_a": {

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/boot_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/boot_test.c
@@ -136,6 +136,9 @@ status_t boot_log_print(boot_log_t *boot_log) {
   LOG_INFO("boot_log rom_ext_min_sec_ver = %u", boot_log->rom_ext_min_sec_ver);
   LOG_INFO("boot_log bl0_min_sec_ver = %u", boot_log->bl0_min_sec_ver);
   LOG_INFO("boot_log primary_bl0_slot = %C", boot_log->primary_bl0_slot);
+  LOG_INFO("boot_log bl0_firmware_domain = %08x",
+           boot_log->bl0_firmware_domain);
+  LOG_INFO("boot_log bl0_failure_reason = %08x", boot_log->bl0_failure_reason);
   TRY(manifest_print());
   TRY(ownership_print());
   TRY(keymgr_print());

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -229,10 +229,10 @@ static uintptr_t owner_vma_get(const manifest_t *manifest, uintptr_t lma_addr) {
 OT_WARN_UNUSED_RESULT
 static rom_error_t rom_ext_boot(boot_data_t *boot_data, boot_log_t *boot_log,
                                 const manifest_t *manifest,
+                                const owner_application_key_t *key,
                                 uint32_t *flash_exec) {
   // Determine which owner block the key came from and measure that block.
   hmac_digest_t owner_measurement;
-  const owner_application_key_t *key = keyring.key[verify_key];
   owner_block_measurement(owner_block_key_page(key), &owner_measurement);
 
   keymgr_binding_value_t sealing_binding;
@@ -363,6 +363,8 @@ static rom_error_t rom_ext_try_next_stage(boot_data_t *boot_data,
       rom_ext_boot_policy_manifests_get(boot_data);
   rom_error_t error = kErrorRomExtBootFailed;
   rom_error_t slot[2] = {0, 0};
+  boot_log->bl0_failure_reason = kErrorOk;
+  boot_log->bl0_firmware_domain = 0;
   for (size_t i = 0; i < ARRAYSIZE(manifests.ordered); ++i) {
     uint32_t flash_exec = 0;
     char slot_id =
@@ -374,6 +376,8 @@ static rom_error_t rom_ext_try_next_stage(boot_data_t *boot_data,
     slot[i] = error;
     if (error != kErrorOk) {
       dbg_printf("verifyfail: Slot%c;%x\r\n", slot_id, error);
+      boot_log->bl0_failure_reason = error;
+      boot_log_digest_update(boot_log);
       continue;
     }
     HARDENED_CHECK_EQ(flash_exec, kSigverifyFlashExec);
@@ -385,11 +389,13 @@ static rom_error_t rom_ext_try_next_stage(boot_data_t *boot_data,
     } else {
       return kErrorRomExtBootFailed;
     }
+    const owner_application_key_t *key = keyring.key[verify_key];
+    boot_log->bl0_firmware_domain = key->key_domain;
     boot_log_digest_update(boot_log);
 
     // Boot fails if a verified ROM_EXT cannot be booted.
-    RETURN_IF_ERROR(
-        rom_ext_boot(boot_data, boot_log, manifests.ordered[i], &flash_exec));
+    RETURN_IF_ERROR(rom_ext_boot(boot_data, boot_log, manifests.ordered[i], key,
+                                 &flash_exec));
     // `rom_ext_boot()` should never return `kErrorOk`, but if it does
     // we must shut down the chip instead of trying the next ROM_EXT.
     return kErrorRomExtBootFailed;

--- a/sw/host/opentitanlib/src/chip/boot_log.rs
+++ b/sw/host/opentitanlib/src/chip/boot_log.rs
@@ -11,6 +11,7 @@ use std::convert::TryFrom;
 
 use super::ChipDataError;
 use super::boot_svc::BootSlot;
+use super::rom_error::RomError;
 use crate::chip::boolean::HardenedBool;
 use crate::with_unknown;
 
@@ -64,9 +65,15 @@ pub struct BootLog {
     pub primary_bl0_slot: BootSlot,
     /// Whether the retention RAM was initialized on this boot.
     pub retention_ram_initialized: HardenedBool,
+    /// Signals of events during boot.
+    pub events: u32,
+    /// The firmware domain of the application we booted.
+    pub bl0_firmware_domain: u32,
+    /// If we didn't boot the preferred slot, the errorcode describing why.
+    pub bl0_failure_reason: RomError,
     /// Reserved for future use.
     #[annotate(format=hex)]
-    pub reserved: [u32; 8],
+    pub reserved: [u32; 5],
 }
 
 impl TryFrom<&[u8]> for BootLog {
@@ -95,6 +102,9 @@ impl TryFrom<&[u8]> for BootLog {
         val.bl0_min_sec_ver = reader.read_u32::<LittleEndian>()?;
         val.primary_bl0_slot = BootSlot(reader.read_u32::<LittleEndian>()?);
         val.retention_ram_initialized = HardenedBool(reader.read_u32::<LittleEndian>()?);
+        val.events = reader.read_u32::<LittleEndian>()?;
+        val.bl0_firmware_domain = reader.read_u32::<LittleEndian>()?;
+        val.bl0_failure_reason = RomError(reader.read_u32::<LittleEndian>()?);
         reader.read_u32_into::<LittleEndian>(&mut val.reserved)?;
         Ok(val)
     }


### PR DESCRIPTION
This commit:
- Adds bl0_firmware_domain and bl0_failure_reason fields.
- Updatese the static assertions in boot_log.h to match the new layout.
- Updates boot_log_unittest.cc to initialize and verify all fields of boot_log_t using memcmp.
- Updates the E2E test position_owner_slot_b to verify that bl0_failure_reason is correctly populated.