### PR TITLE
[sysrst_ctrl] `chip_sw_sysrst_ctrl_inputs`: fix reading of SV backdoor variable

### DIFF
--- a/sw/device/tests/sysrst_ctrl_inputs_test.c
+++ b/sw/device/tests/sysrst_ctrl_inputs_test.c
@@ -111,7 +111,7 @@ bool test_main(void) {
       kDeviceType == kDeviceSimDV ? &kTestExpectedDV : &kTestExpectedReal;
 
   for (int i = 0; i < kNumPhases; ++i) {
-    OTTF_WAIT_FOR(i == *kTestPhase, kTestPhaseTimeoutUsec);
+    OTTF_WAIT_FOR(i == OTTF_BACKDOOR_READ(*kTestPhase), kTestPhaseTimeoutUsec);
     uint8_t input_pins = read_input_pins();
     LOG_INFO("Expect pins: %x, got: %x", *kTestExpected, input_pins);
     CHECK(*kTestExpected == input_pins);


### PR DESCRIPTION
The `chip_sw_sysrst_ctrl_inputs` test was failing when switching compilers or making seemingly NFC changes. The root cause appears to be a missing `OTTF_BACKDOOR_READ`, which can cause stale values to be read from the flash cache instead of the data written by the testbench through the backdoor write.

A brief codebase search indicates that other tests are probably also lacking the same fix, but this PR focuses on the one place where the problem is actively manifesting. We can explore other strategies to fix this more robustely in the broader codebase (perhaps ensuring flushing when the backdoor writes happen?).