### PR TITLE
[sw] Ensure tlv cert size won't exceed outer tlv container.

### DIFF
--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
@@ -19,9 +19,10 @@ rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
   }
   obj->obj_p = buf;
   memcpy(&objh, buf, sizeof(perso_tlv_object_header_t));
+
   // Extract LTV object size.
   PERSO_TLV_GET_FIELD(Objh, Size, objh, &obj_size);
-  if (obj_size == 0)
+  if (obj_size <= sizeof(perso_tlv_object_header_t))
     return kErrorPersoTlvCertObjNotFound;  // Object is empty.
   if (obj_size > ltv_buf_size)
     return kErrorPersoTlvInternal;  // Object exceeds the size of host buffer.
@@ -35,7 +36,7 @@ rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
     return kErrorPersoTlvCertObjNotFound;
   }
   buf += sizeof(perso_tlv_object_header_t);
-  ltv_buf_size -= sizeof(perso_tlv_object_header_t);
+  ltv_buf_size = obj_size - sizeof(perso_tlv_object_header_t);
 
   // If we made it this far, we found a certificate LTV object, so we will parse
   // the object's header and metadata next.

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
@@ -70,7 +70,7 @@ rom_error_t perso_tlv_get_cert_obj_view(const uint8_t *buf, size_t ltv_buf_size,
       return kErrorPersoTlvInternal;
   }
 
-  if (obj_size == 0)
+  if (obj_size <= obj_header_size)
     return kErrorPersoTlvCertObjNotFound;  // Object is empty.
   if (obj_size > ltv_buf_size)
     return kErrorPersoTlvInternal;  // Object exceeds the size of host buffer.
@@ -82,7 +82,7 @@ rom_error_t perso_tlv_get_cert_obj_view(const uint8_t *buf, size_t ltv_buf_size,
     return kErrorPersoTlvCertObjNotFound;
   }
   buf += obj_header_size;
-  ltv_buf_size -= obj_header_size;
+  ltv_buf_size = obj_size - obj_header_size;
 
   // If we made it this far, we found a certificate LTV object, so we will parse
   // the object's header and metadata next.


### PR DESCRIPTION
In `perso_tlv_get_cert_obj`, we previously restrict the parsing of the  inner certificate to the size limits of the whole buffer, but not the one specified by the outer LTV object's header (`obj_size`).

This patch ensures that the size limit (`ltv_buf_size`) is truncated to the actual size of the TLV object payload
(`obj_size - sizeof(perso_tlv_object_header_t)`).

This prevents the inner certificate parsing from reading past the end of its outer TLV container.