### PR TITLE
[boot_services] Wipe ok status after ECC verify

### DIFF
--- a/sw/device/silicon_creator/lib/otbn_boot_services.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.c
@@ -347,6 +347,10 @@ rom_error_t otbn_boot_sigverify_finish(uint32_t *recovered_r) {
   HARDENED_RETURN_IF_ERROR(sc_otbn_dmem_read(1, kOtbnVarBootOk, &ok));
   HARDENED_CHECK_EQ(ok, kHardenedBoolTrue);
 
+  // Clear the status in OTBN.
+  uint32_t zero = 0;
+  HARDENED_RETURN_IF_ERROR(sc_otbn_dmem_write(1, &zero, kOtbnVarBootOk));
+
   // Read the recovered `r` value from DMEM.
   return sc_otbn_dmem_read(kEcdsaP256SignatureComponentWords, kOtbnVarBootXr,
                            recovered_r);


### PR DESCRIPTION
In order to clear the status in OTBN, clear it after using ECDSA verify.