### PR TITLE
[spi_dev, top] Define 1r1w variant as default, remove 2p variant from regressions

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_pkg.sv
@@ -408,7 +408,7 @@ package spi_device_pkg;
   } sram_type_e;
 
   // Sram parameters
-  parameter sram_type_e DefaultSramType = SramType2p;
+  parameter sram_type_e DefaultSramType = SramType1r1w;
   parameter int unsigned SramDw      = 32;
   parameter int unsigned SramStrbW   = SramDw/8;
   parameter int unsigned SramOffsetW = $clog2(SramStrbW);

--- a/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
+++ b/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
@@ -47,7 +47,6 @@
              "{proj_root}/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson",
              "{proj_root}/hw/ip/spi_host/dv/spi_host_sim_cfg.hjson",
              "{proj_root}/hw/ip/spi_device/dv/spi_device_1r1w_sim_cfg.hjson",
-             // "{proj_root}/hw/ip/spi_device/dv/spi_device_2p_sim_cfg.hjson",
              "{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_main_sim_cfg.hjson",
              "{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_ret_sim_cfg.hjson",
              "{proj_root}/hw/ip/uart/dv/uart_sim_cfg.hjson",

--- a/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
+++ b/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
@@ -47,7 +47,6 @@
              "{proj_root}/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson",
              "{proj_root}/hw/ip/spi_host/dv/spi_host_sim_cfg.hjson",
              "{proj_root}/hw/ip/spi_device/dv/spi_device_1r1w_sim_cfg.hjson",
-             "{proj_root}/hw/ip/spi_device/dv/spi_device_2p_sim_cfg.hjson",
              "{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_main_sim_cfg.hjson",
              "{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_ret_sim_cfg.hjson",
              "{proj_root}/hw/ip/sysrst_ctrl/dv/sysrst_ctrl_sim_cfg.hjson",


### PR DESCRIPTION
This is follow-up of https://github.com/lowRISC/opentitan/pull/30310.