### PR TITLE
[otbn] Integrate the KMAC interface into the OTBN

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -257,6 +257,14 @@
       act:     "rcv"
       package: "keymgr_pkg"
     },
+
+    // KMAC interface
+    { struct:  "app"
+      type:    "req_rsp"
+      name:    "kmac_data"
+      act:     "req"
+      package: "kmac_pkg"
+    },
   ],
   features: [
     {

--- a/hw/ip/otbn/doc/interfaces.md
+++ b/hw/ip/otbn/doc/interfaces.md
@@ -24,6 +24,7 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 | lc_rma_req       | lc_ctrl_pkg::lc_tx              | uni     | rcv   |       1 |               |
 | lc_rma_ack       | lc_ctrl_pkg::lc_tx              | uni     | req   |       1 |               |
 | keymgr_key       | keymgr_pkg::otbn_key_req        | uni     | rcv   |       1 |               |
+| kmac_data        | kmac_pkg::app                   | req_rsp | req   |       1 |               |
 | tl               | tlul_pkg::tl                    | req_rsp | rsp   |       1 |               |
 
 ## Interrupts

--- a/hw/ip/otbn/doc/otbn_intro.md
+++ b/hw/ip/otbn/doc/otbn_intro.md
@@ -191,7 +191,6 @@ otbn_consttime_test(
 ## Future Ideas
 
 For future versions of OTBN, we are considering:
-- A direct interface from OTBN to the [KMAC][kmac] hardware block, which would allow OTBN to directly run SHA-3 and SHAKE functions
 - Expose the [`INSN_CNT`](registers.md#insn_cnt) register to OTBN applications to make cycle count checks at runtime.
   Useful for algorithm which do not execute always in constant time.
 - More isolation from Ibex, including potentially giving OTBN its own ROM so that Ibex doesn't need to load secrets into it

--- a/hw/ip/otbn/doc/theory_of_operation.md
+++ b/hw/ip/otbn/doc/theory_of_operation.md
@@ -553,14 +553,14 @@ These commands are then translated to dynamic application interface requests.
 The responses from the interface are translated and exposed to OTBN SW via `KMAC_STATUS` and `KMAC_DATA_S0` / `KMAC_DATA_S1`.
 
 The interface supports multiple successive sessions where each session follows the following high-level steps:
-- Configure the desired hashing mode via `KMAC_CFG`.
 - Check if the interface is ready by checking for `KMAC_STATUS.READY = 1`.
+- Configure the desired hashing mode via `KMAC_CFG`.
 - Start a session by issuing the `KMAC_CTRL.START` command.
 - Send the message parts by issuing one or more `KMAC_CTRL.SEND` commands.
 - Issue the `KMAC_CTRL.PROCESS` command to process the full message.
 - Wait for the first response by polling until `KMAC_STATUS.RSP_VALID = 1`.
 - Check for errors by reading `KMAC_STATUS.RSP_ERROR`.
-  - If there is an error, the session must be terminated by issuing the `KMAC_CTRL.DONE` command.
+  - If there is an error, the session must be terminated, see error handling.
 - Read the digest in 64-bit parts from `KMAC_DATA_S0` and `KMAC_DATA_S1`.
 - For more digest data, poll again until `KMAC_STATUS.RSP_VALID = 1` after reading both data WSRs.
 - Once the digest or the desired XOF output is read, end the digest reading phase by issuing a `KMAC_CTRL.DONE` command.
@@ -605,11 +605,11 @@ WaitForClose --> Idle: CLOSE command
 
 ##### Starting a session
 To start a session the OTBN SW has to:
+- Poll until `KMAC_STATUS.READY = 1`.
+  - This should be 1 in most cases when OTBN starts executing a program, however, the interface could still be terminating a previous session due to a secure wipe (see secure wipe behaviour).
 - Write the desired hashing configuration to `KMAC_CFG`.
   - There is no validation when writing a configuration to `KMAC_CFG` but KMAC HWIP does check the configuration once the session is started.
     See [error handling](#error-handling) section for more details.
-- Poll until `KMAC_STATUS.READY = 1`.
-  - This should be 1 in most cases when OTBN starts executing a program, however, the interface could still be terminating a previous session due to a secure wipe (see secure wipe behaviour).
 - Issue the `KMAC_CTRL.START` command by writing a 1 to it.
 - There may be no write to `KMAC_CFG` until `KMAC_STATUS.READY` is 1 again (polled for before sending message).
   - Otherwise the configuration can be changed while the start request is being sent.
@@ -654,10 +654,10 @@ After issuing the `PROCESS` command, OTBN software thus must do the following:
 
 The number of digest parts pushed by the app interface depends on the selected mode, strength and XOF setting.
 
-For SHA3 and KMAC, `KMAC_CFG.EN_XOF` must 0 and the interface pushes only the SHA3 digest or the requested output length for KMAC.
+For SHA3 and KMAC, `KMAC_CFG.EN_XOF` must be `0` and the interface pushes only the SHA3 digest or the requested output length for KMAC.
 The requested output length of KMAC is fixed by the KMAC HWIP to 384 bits.
 For SHA3 it pushes `roundup(digest_width / 64)` responses.
-For KMAC it pushes `384 / 64 = 9` responses.
+For KMAC it pushes `384 / 64 = 6` responses.
 Once these are pushed, the interface waits for a `DONE` command as explained [below](#ending-a-session).
 
 If the mode is SHAKE or cSHAKE, `KMAC_CFG.EN_XOF` controls whether the KMAC HWIP automatically issues RUN commands.
@@ -665,7 +665,7 @@ If `KMAC_CFG.EN_XOF = 0`, the KMAC HWIP pushes only the digest parts that make u
 Once these are pushed, the interface waits for a `DONE` command as explained [below](#ending-a-session).
 
 If `KMAC_CFG.EN_XOF = 1`, the KMAC HWIP pushes infinite responses.
-For this it automatically squeezes more digest by issuing a KMAC HWIP internal `RUN` command each time it finishes pushing one full rate.
+For this it automatically squeezes more digest by issuing a KMAC HWIP internal squeeze command each time it finishes pushing one full rate.
 As soon as the squeezing has finished, the app starts again to push the new rate towards OTBN.
 When the OTBN software has received enough XOF output, the session can be terminated as explained [below](#ending-a-session).
 

--- a/hw/ip/otbn/doc/theory_of_operation.md
+++ b/hw/ip/otbn/doc/theory_of_operation.md
@@ -695,6 +695,7 @@ To end a session:
   - `KMAC_STATUS.MSG_WRITE_ERROR`
   - `KMAC_STATUS.CTRL_ERROR`
 - Once the errors have been checked, issue the `KMAC_CTRL.CLOSE` command to end the session.
+  - This will clear all error flags.
 
 If there has been no error detected, the digest from this session is valid and the interface is ready to start the next session.
 

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -381,6 +381,69 @@ interface otbn_trace_if
                                           gen_mai.u_otbn_mai.ispr_mai_ctrl_wdata_i};
   assign ispr_write_data[IsprMaiStatus] = '0;
 
+  assign ispr_read[IsprKmacDataS0] = any_ispr_read & (ispr_addr == IsprKmacDataS0);
+  assign ispr_read[IsprKmacDataS1] = any_ispr_read & (ispr_addr == IsprKmacDataS1);
+  assign ispr_read[IsprKmacStatus] = any_ispr_read & (ispr_addr == IsprKmacStatus);
+  assign ispr_read[IsprKmacCtrl]   = any_ispr_read & (ispr_addr == IsprKmacCtrl);
+  assign ispr_read[IsprKmacCfg]    = any_ispr_read & (ispr_addr == IsprKmacCfg);
+  assign ispr_read[IsprKmacStrb]   = any_ispr_read & (ispr_addr == IsprKmacStrb);
+
+  for (genvar i_word = 0; i_word < BaseWordsPerWLEN; i_word++) begin : gen_kmac_ispr_read_words
+    assign ispr_read_data[IsprKmacDataS0][i_word*32+:32] =
+          u_otbn_kmac_if.ispr_kmac_data_s0_rdata_o[i_word*39+:32];
+    assign ispr_read_data[IsprKmacDataS1][i_word*32+:32] =
+          u_otbn_kmac_if.ispr_kmac_data_s1_rdata_o[i_word*39+:32];
+  end
+
+  assign ispr_read_data[IsprKmacStatus] = {{(WLEN - 32'd32){1'b0}},
+                                           u_otbn_kmac_if.ispr_kmac_status_rdata_o};
+  assign ispr_read_data[IsprKmacCtrl]   = '0;
+  assign ispr_read_data[IsprKmacCfg]    = {{(WLEN - 32'd32){1'b0}},
+                                           u_otbn_kmac_if.ispr_kmac_cfg_rdata_o};
+  assign ispr_read_data[IsprKmacStrb]   = {{(WLEN - 32'd32){1'b0}},
+                                           u_otbn_kmac_if.ispr_kmac_strb_rdata_o};
+
+  // TODO: The response update is not considered. Do we need to model this?
+  for (genvar i_word = 0; i_word < BaseWordsPerWLEN; i_word++) begin : gen_kmac_ispr_write_words
+    assign ispr_write_data[IsprKmacDataS0][i_word*32+:32] =
+        u_otbn_kmac_if.ispr_kmac_data_s0_d[i_word].word;
+    assign ispr_write_data[IsprKmacDataS1][i_word*32+:32] =
+        u_otbn_kmac_if.ispr_kmac_data_s1_d[i_word].word;
+
+  end
+
+  // TODO: Enable tracing once simulator is updated. We disable any tracing of KMAC related ISPRs
+  //       until simulator is implemented. Otherwise there are trace mismatches during secure wipe.
+  //       Note, reads can already be traced because these are only emitted depending on SW.
+  assign ispr_write[IsprKmacDataS0] = 1'b0;
+                                      // u_otbn_kmac_if.ispr_kmac_data_s0_wr_i ||
+                                      // u_otbn_kmac_if.sec_wipe_ispr_kmac_data_s0_i;
+  assign ispr_write[IsprKmacDataS1] = 1'b0;
+                                      // u_otbn_kmac_if.ispr_kmac_data_s1_wr_i ||
+                                      // u_otbn_kmac_if.sec_wipe_ispr_kmac_data_s1_i;
+
+  // A write can clear certain bits.
+  // TODO: Enable tracing once simulator is updated.
+  assign ispr_write[IsprKmacStatus]      = 1'b0;
+  assign ispr_write_data[IsprKmacStatus] = '0;
+
+  // There is no direct secure wipe.
+  // TODO: Enable tracing once simulator is updated.
+  assign ispr_write[IsprKmacCtrl]      = 1'b0; // u_otbn_kmac_if.ispr_kmac_ctrl_wr_i;
+  assign ispr_write_data[IsprKmacCtrl] = {{(WLEN - 32'd32){1'b0}},
+                                          u_otbn_kmac_if.ispr_kmac_ctrl_wdata_i};
+
+  // There is no direct secure wipe.
+  // TODO: Enable tracing once simulator is updated.
+  assign ispr_write[IsprKmacCfg]       = 1'b0; // u_otbn_kmac_if.ispr_kmac_cfg_wr_i;
+  assign ispr_write_data[IsprKmacCfg]  = {{(WLEN - 32'd32){1'b0}},
+                                          u_otbn_kmac_if.ispr_kmac_cfg_wdata_i};
+
+  // There is no direct secure wipe.
+  // TODO: Enable tracing once simulator is updated.
+  assign ispr_write[IsprKmacStrb]      = 1'b0; // u_otbn_kmac_if.ispr_kmac_strb_wr_i;
+  assign ispr_write_data[IsprKmacStrb] = {{(WLEN - 32'd32){1'b0}},
+                                          u_otbn_kmac_if.ispr_kmac_strb_wdata_i};
 
   // Separate per flag group tracking using the flags_t struct so tracer can cleanly present flag
   // accesses.

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
@@ -111,6 +111,12 @@ module otbn_tracer (
       IsprMaiIn1S1: return "MAI_IN1_S1";
       IsprMaiCtrl: return "MAI_CTRL";
       IsprMaiStatus: return "MAI_STATUS";
+      IsprKmacDataS0: return "KMAC_DATA_S0";
+      IsprKmacDataS1: return "KMAC_DATA_S1";
+      IsprKmacStatus: return "KMAC_STATUS";
+      IsprKmacCtrl: return "KMAC_CTRL";
+      IsprKmacCfg: return "KMAC_CFG";
+      IsprKmacStrb: return "KMAC_STRB";
       default: return $sformatf("UNKNOWN_ISPR: (%d)", ispr);
     endcase
   endfunction
@@ -130,10 +136,15 @@ module otbn_tracer (
       IsprMaiIn0S0,
       IsprMaiIn0S1,
       IsprMaiIn1S0,
-      IsprMaiIn1S1: return WLEN;
+      IsprMaiIn1S1,
+      IsprKmacDataS0,
+      IsprKmacDataS1: return WLEN;
       IsprFlags,
       IsprMaiCtrl,
-      IsprMaiStatus: return 32;
+      IsprMaiStatus,
+      IsprKmacStatus,
+      IsprKmacCtrl,
+      IsprKmacStrb: return 32;
       default: return -1;
     endcase
   endfunction

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -125,7 +125,10 @@ module otbn_top_sim (
     .software_errs_fatal_i       ( 1'b0                       ),
 
     .sideload_key_shares_i       ( sideload_key_shares        ),
-    .sideload_key_shares_valid_i ( 2'b11                      )
+    .sideload_key_shares_valid_i ( 2'b11                      ),
+
+    .kmac_app_req_o(    ),
+    .kmac_app_rsp_i( '0 )
   );
 
   // The values returned by the mock EDN must match those set in `standalonesim.py`.

--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -22,6 +22,8 @@ filesets:
       - lowrisc:ip:edn_pkg
       - lowrisc:ip:otbn_pkg
       - lowrisc:prim:onehot_check
+      - lowrisc:ip:kmac_pkg
+      - lowrisc:ip:sha3
     files:
       - rtl/otbn_controller.sv
       - rtl/otbn_decoder.sv
@@ -40,6 +42,7 @@ filesets:
       - rtl/otbn_mac_bignum.sv
       - rtl/otbn_mai.sv
       - rtl/otbn_mask_accelerator.sv
+      - rtl/otbn_kmac_if.sv
       - rtl/otbn_mod_result_selector.sv
       - rtl/otbn_loop_controller.sv
       - rtl/otbn_stack.sv

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -82,7 +82,11 @@ module otbn
   output otp_ctrl_pkg::otbn_otp_key_req_t otbn_otp_key_o,
   input  otp_ctrl_pkg::otbn_otp_key_rsp_t otbn_otp_key_i,
 
-  input keymgr_pkg::otbn_key_req_t keymgr_key_i
+  input keymgr_pkg::otbn_key_req_t keymgr_key_i,
+
+  // KMAC application interface.
+  output kmac_pkg::app_req_t kmac_data_o,
+  input  kmac_pkg::app_rsp_t kmac_data_i
 );
 
   import prim_mubi_pkg::*;
@@ -1176,7 +1180,12 @@ module otbn
     .software_errs_fatal_i       (software_errs_fatal_q),
 
     .sideload_key_shares_i       (keymgr_key_i.key),
-    .sideload_key_shares_valid_i ({2{keymgr_key_i.valid}})
+    .sideload_key_shares_valid_i ({2{keymgr_key_i.valid}}),
+
+    // The naming kmac_data is just to be consistent with other IPs connecting to KMAC. From here
+    // on use more sensible name.
+    .kmac_app_req_o(kmac_data_o),
+    .kmac_app_rsp_i(kmac_data_i)
   );
 
   always_ff @(posedge clk_i or negedge rst_n) begin
@@ -1450,6 +1459,12 @@ module otbn
     gen_alert_tx[AlertFatalIdx].u_prim_alert_sender.alert_req_i
   )
 
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT_IN(
+    OtbnKmacFsmCheck_A,
+    u_otbn_core.u_otbn_kmac_if.u_state_regs,
+    gen_alert_tx[AlertFatalIdx].u_prim_alert_sender.alert_req_i
+  )
+
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT_IN(
     OtbnCallStackWrPtrAlertCheck_A,
     u_otbn_core.u_otbn_rf_base.u_call_stack.u_stack_wr_ptr,
@@ -1458,7 +1473,13 @@ module otbn
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT_IN(
     OtbnLoopInfoStackWrPtrAlertCheck_A,
     u_otbn_core.u_otbn_controller.u_otbn_loop_controller.loop_info_stack.u_stack_wr_ptr,
-    gen_alert_tx[AlertFatalIdx].u_prim_alert_sender.alert_req_i)
+    gen_alert_tx[AlertFatalIdx].u_prim_alert_sender.alert_req_i
+  )
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT_IN(
+    OtbnKmacMsgSelectorCntAlertCheck_A,
+    u_otbn_core.u_otbn_kmac_if.u_msg_selector_count,
+    gen_alert_tx[AlertFatalIdx].u_prim_alert_sender.alert_req_i
+  )
 
   `ASSERT_ERROR_TRIGGER_ALERT_IN(
     OtbnBnMacCycleCountAlertCheck_A,

--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -158,6 +158,26 @@ module otbn_alu_bignum
   input  logic [ExtWLEN-1:0]          ispr_mai_res_s0_rdata_i,
   input  logic [ExtWLEN-1:0]          ispr_mai_res_s1_rdata_i,
 
+  output logic                        ispr_kmac_status_wr_o,
+  output logic [31:0]                 ispr_kmac_status_wdata_o,
+  output logic                        ispr_kmac_ctrl_wr_o,
+  output logic [31:0]                 ispr_kmac_ctrl_wdata_o,
+  output logic                        ispr_kmac_cfg_wr_o,
+  output logic [31:0]                 ispr_kmac_cfg_wdata_o,
+  output logic                        ispr_kmac_strb_wr_o,
+  output logic [31:0]                 ispr_kmac_strb_wdata_o,
+  output logic                        ispr_kmac_data_s0_wr_o,
+  output logic [ExtWLEN-1:0]          ispr_kmac_data_s0_wdata_o,
+  output logic                        ispr_kmac_data_s1_wr_o,
+  output logic [ExtWLEN-1:0]          ispr_kmac_data_s1_wdata_o,
+  input  logic [31:0]                 ispr_kmac_status_rdata_i,
+  input  logic [31:0]                 ispr_kmac_cfg_rdata_i,
+  input  logic [31:0]                 ispr_kmac_strb_rdata_i,
+  input  logic [ExtWLEN-1:0]          ispr_kmac_data_s0_rdata_i,
+  input  logic [ExtWLEN-1:0]          ispr_kmac_data_s1_rdata_i,
+  output logic                        ispr_kmac_data_s0_rd_o,
+  output logic                        ispr_kmac_data_s1_rd_o,
+
   output logic                        reg_intg_violation_err_o,
 
   input  logic                        sec_wipe_mod_urnd_i,
@@ -575,6 +595,61 @@ module otbn_alu_bignum
     .out_o(ispr_mai_ctrl_wdata_o)
   );
 
+  ////////////////
+  // KMAC Write //
+  ////////////////
+
+  assign ispr_kmac_status_wr_o = ispr_bignum_predec_i.ispr_wr_en[IsprKmacStatus];
+  // SEC_CM: DATA_REG_SW.SCA
+  prim_blanker #(.Width(32'd32)) u_ispr_kmac_status_wdata_blanker (
+    .in_i (ispr_base_wdata_i),
+    .en_i (ispr_kmac_status_wr_o),
+    .out_o(ispr_kmac_status_wdata_o)
+  );
+
+  assign ispr_kmac_ctrl_wr_o = ispr_bignum_predec_i.ispr_wr_en[IsprKmacCtrl];
+  // SEC_CM: DATA_REG_SW.SCA
+  prim_blanker #(.Width(32'd32)) u_ispr_kmac_ctrl_wdata_blanker (
+    .in_i (ispr_base_wdata_i),
+    .en_i (ispr_kmac_ctrl_wr_o),
+    .out_o(ispr_kmac_ctrl_wdata_o)
+  );
+
+  assign ispr_kmac_cfg_wr_o = ispr_bignum_predec_i.ispr_wr_en[IsprKmacCfg];
+  // SEC_CM: DATA_REG_SW.SCA
+  prim_blanker #(.Width(32'd32)) u_ispr_kmac_cfg_wdata_blanker (
+    .in_i (ispr_base_wdata_i),
+    .en_i (ispr_kmac_cfg_wr_o),
+    .out_o(ispr_kmac_cfg_wdata_o)
+  );
+
+  assign ispr_kmac_strb_wr_o = ispr_bignum_predec_i.ispr_wr_en[IsprKmacStrb];
+  // SEC_CM: DATA_REG_SW.SCA
+  prim_blanker #(.Width(32'd32)) u_ispr_kmac_strb_wdata_blanker (
+    .in_i (ispr_base_wdata_i),
+    .en_i (ispr_kmac_strb_wr_o),
+    .out_o(ispr_kmac_strb_wdata_o)
+  );
+
+  assign ispr_kmac_data_s0_wr_o = ispr_bignum_predec_i.ispr_wr_en[IsprKmacDataS0];
+  // SEC_CM: DATA_REG_SW.SCA
+  prim_blanker #(.Width(ExtWLEN)) u_ispr_kmac_data_s0_wdata_blanker (
+    .in_i (ispr_bignum_wdata_intg_i),
+    .en_i (ispr_kmac_data_s0_wr_o),
+    .out_o(ispr_kmac_data_s0_wdata_o)
+  );
+
+  assign ispr_kmac_data_s1_wr_o = ispr_bignum_predec_i.ispr_wr_en[IsprKmacDataS1];
+  // SEC_CM: DATA_REG_SW.SCA
+  prim_blanker #(.Width(ExtWLEN)) u_ispr_kmac_data_s1_wdata_blanker (
+    .in_i (ispr_bignum_wdata_intg_i),
+    .en_i (ispr_kmac_data_s1_wr_o),
+    .out_o(ispr_kmac_data_s1_wdata_o)
+  );
+
+  assign ispr_kmac_data_s0_rd_o = ispr_bignum_predec_i.ispr_rd_en[IsprKmacDataS0];
+  assign ispr_kmac_data_s1_rd_o = ispr_bignum_predec_i.ispr_rd_en[IsprKmacDataS1];
+
   ///////////////
   // ISPR Read //
   ///////////////
@@ -585,8 +660,8 @@ module otbn_alu_bignum
   // 2. Select between the ISPRs that have integrity bits and the result of the first stage.
 
   // Number of ISPRs that have no integrity protection
-  localparam int NNoIntgIspr = 9;
-  // IDs for ISPRs with integrity
+  localparam int NNoIntgIspr = 12;
+  // IDs for ISPRs without integrity
   localparam int IsprRndNoIntg = 0;
   localparam int IsprUrndNoIntg = 1;
   localparam int IsprMaiCtrlNoIntg = 2;
@@ -596,11 +671,14 @@ module otbn_alu_bignum
   localparam int IsprKeyS0HNoIntg = 6;
   localparam int IsprKeyS1LNoIntg = 7;
   localparam int IsprKeyS1HNoIntg = 8;
+  localparam int IsprKmacStatusNoIntg = 9;
+  localparam int IsprKmacCfgNoIntg = 10;
+  localparam int IsprKmacStrbNoIntg = 11;
 
   logic [NNoIntgIspr-1:0] ispr_rdata_no_intg_mux_sel;
 
   // Number of ISPRs that have integrity protection
-  localparam int NIntgIspr = 8;
+  localparam int NIntgIspr = 10;
   // IDs for ISPRs with integrity
   localparam int IsprModIntg = 0;
   localparam int IsprAccIntg = 1;
@@ -610,8 +688,10 @@ module otbn_alu_bignum
   localparam int IsprMaiIn0S1Intg = 5;
   localparam int IsprMaiIn1S0Intg = 6;
   localparam int IsprMaiIn1S1Intg = 7;
+  localparam int IsprKmacDataS0Intg = 8;
+  localparam int IsprKmacDataS1Intg = 9;
   // ID representing all ISPRs with no integrity
-  localparam int IsprNoIntg = 8;
+  localparam int IsprNoIntg = 10;
 
   logic [NIntgIspr:0] ispr_rdata_intg_mux_sel;
   logic [ExtWLEN-1:0] ispr_rdata_intg_mux_in    [NIntgIspr+1];
@@ -635,24 +715,39 @@ module otbn_alu_bignum
   assign ispr_rdata_no_intg_mux_in[IsprKeyS1HNoIntg] =
       {{(WLEN - (SideloadKeyWidth - 256)){1'b0}}, sideload_key_shares_i[1][SideloadKeyWidth-1:256]};
 
-  assign ispr_rdata_no_intg_mux_sel[IsprRndNoIntg]       =
+  assign ispr_rdata_no_intg_mux_in[IsprKmacStatusNoIntg] =
+      {{(WLEN - 32){1'b0}}, ispr_kmac_status_rdata_i};
+  assign ispr_rdata_no_intg_mux_in[IsprKmacCfgNoIntg]    =
+      {{(WLEN - 32){1'b0}}, ispr_kmac_cfg_rdata_i};
+  assign ispr_rdata_no_intg_mux_in[IsprKmacStrbNoIntg]   =
+      {{(WLEN - 32){1'b0}}, ispr_kmac_strb_rdata_i};
+
+  assign ispr_rdata_no_intg_mux_sel[IsprRndNoIntg]        =
       ispr_bignum_predec_i.ispr_rd_en[IsprRnd];
-  assign ispr_rdata_no_intg_mux_sel[IsprUrndNoIntg]      =
+  assign ispr_rdata_no_intg_mux_sel[IsprUrndNoIntg]       =
       ispr_bignum_predec_i.ispr_rd_en[IsprUrnd];
-  assign ispr_rdata_no_intg_mux_sel[IsprMaiCtrlNoIntg]   =
+  assign ispr_rdata_no_intg_mux_sel[IsprMaiCtrlNoIntg]    =
       ispr_bignum_predec_i.ispr_rd_en[IsprMaiCtrl];
-  assign ispr_rdata_no_intg_mux_sel[IsprMaiStatusNoIntg] =
+  assign ispr_rdata_no_intg_mux_sel[IsprMaiStatusNoIntg]  =
       ispr_bignum_predec_i.ispr_rd_en[IsprMaiStatus];
-  assign ispr_rdata_no_intg_mux_sel[IsprFlagsNoIntg]     =
+  assign ispr_rdata_no_intg_mux_sel[IsprFlagsNoIntg]      =
       ispr_bignum_predec_i.ispr_rd_en[IsprFlags];
-  assign ispr_rdata_no_intg_mux_sel[IsprKeyS0LNoIntg]    =
+  assign ispr_rdata_no_intg_mux_sel[IsprKeyS0LNoIntg]     =
       ispr_bignum_predec_i.ispr_rd_en[IsprKeyS0L];
-  assign ispr_rdata_no_intg_mux_sel[IsprKeyS0HNoIntg]    =
+  assign ispr_rdata_no_intg_mux_sel[IsprKeyS0HNoIntg]     =
       ispr_bignum_predec_i.ispr_rd_en[IsprKeyS0H];
-  assign ispr_rdata_no_intg_mux_sel[IsprKeyS1LNoIntg]    =
+  assign ispr_rdata_no_intg_mux_sel[IsprKeyS1LNoIntg]     =
       ispr_bignum_predec_i.ispr_rd_en[IsprKeyS1L];
-  assign ispr_rdata_no_intg_mux_sel[IsprKeyS1HNoIntg]    =
+  assign ispr_rdata_no_intg_mux_sel[IsprKeyS1HNoIntg]     =
       ispr_bignum_predec_i.ispr_rd_en[IsprKeyS1H];
+  assign ispr_rdata_no_intg_mux_sel[IsprKmacStatusNoIntg] =
+      ispr_bignum_predec_i.ispr_rd_en[IsprKmacStatus];
+  assign ispr_rdata_no_intg_mux_sel[IsprKmacCfgNoIntg]    =
+      ispr_bignum_predec_i.ispr_rd_en[IsprKmacCfg];
+  assign ispr_rdata_no_intg_mux_sel[IsprKmacStrbNoIntg]   =
+      ispr_bignum_predec_i.ispr_rd_en[IsprKmacStrb];
+  // KMAC_CTRL always reads as '0. We use the onehot MUX to output '0 by not factoring in the
+  // KMAC_CTRL read enable signal into its select signal.
 
   logic [WLEN-1:0]    ispr_rdata_no_intg;
   logic [ExtWLEN-1:0] ispr_rdata_intg_calc;
@@ -677,27 +772,45 @@ module otbn_alu_bignum
   end
 
   // Second stage
-  assign ispr_rdata_intg_mux_in[IsprModIntg]      = mod_intg_q;
-  assign ispr_rdata_intg_mux_in[IsprAccIntg]      = ispr_acc_intg_i;
-  assign ispr_rdata_intg_mux_in[IsprMaiResS0Intg] = ispr_mai_res_s0_rdata_i;
-  assign ispr_rdata_intg_mux_in[IsprMaiResS1Intg] = ispr_mai_res_s1_rdata_i;
-  assign ispr_rdata_intg_mux_in[IsprMaiIn0S0Intg] = ispr_mai_in0_s0_rdata_i;
-  assign ispr_rdata_intg_mux_in[IsprMaiIn0S1Intg] = ispr_mai_in0_s1_rdata_i;
-  assign ispr_rdata_intg_mux_in[IsprMaiIn1S0Intg] = ispr_mai_in1_s0_rdata_i;
-  assign ispr_rdata_intg_mux_in[IsprMaiIn1S1Intg] = ispr_mai_in1_s1_rdata_i;
-  assign ispr_rdata_intg_mux_in[IsprNoIntg]       = ispr_rdata_intg_calc;
+  assign ispr_rdata_intg_mux_in[IsprModIntg]        = mod_intg_q;
+  assign ispr_rdata_intg_mux_in[IsprAccIntg]        = ispr_acc_intg_i;
+  assign ispr_rdata_intg_mux_in[IsprMaiResS0Intg]   = ispr_mai_res_s0_rdata_i;
+  assign ispr_rdata_intg_mux_in[IsprMaiResS1Intg]   = ispr_mai_res_s1_rdata_i;
+  assign ispr_rdata_intg_mux_in[IsprMaiIn0S0Intg]   = ispr_mai_in0_s0_rdata_i;
+  assign ispr_rdata_intg_mux_in[IsprMaiIn0S1Intg]   = ispr_mai_in0_s1_rdata_i;
+  assign ispr_rdata_intg_mux_in[IsprMaiIn1S0Intg]   = ispr_mai_in1_s0_rdata_i;
+  assign ispr_rdata_intg_mux_in[IsprMaiIn1S1Intg]   = ispr_mai_in1_s1_rdata_i;
+  assign ispr_rdata_intg_mux_in[IsprKmacDataS0Intg] = ispr_kmac_data_s0_rdata_i;
+  assign ispr_rdata_intg_mux_in[IsprKmacDataS1Intg] = ispr_kmac_data_s1_rdata_i;
+  assign ispr_rdata_intg_mux_in[IsprNoIntg]         = ispr_rdata_intg_calc;
 
-  assign ispr_rdata_intg_mux_sel[IsprModIntg]      = ispr_bignum_predec_i.ispr_rd_en[IsprMod];
-  assign ispr_rdata_intg_mux_sel[IsprAccIntg]      = ispr_bignum_predec_i.ispr_rd_en[IsprAcc];
-  assign ispr_rdata_intg_mux_sel[IsprMaiResS0Intg] = ispr_bignum_predec_i.ispr_rd_en[IsprMaiResS0];
-  assign ispr_rdata_intg_mux_sel[IsprMaiResS1Intg] = ispr_bignum_predec_i.ispr_rd_en[IsprMaiResS1];
-  assign ispr_rdata_intg_mux_sel[IsprMaiIn0S0Intg] = ispr_bignum_predec_i.ispr_rd_en[IsprMaiIn0S0];
-  assign ispr_rdata_intg_mux_sel[IsprMaiIn0S1Intg] = ispr_bignum_predec_i.ispr_rd_en[IsprMaiIn0S1];
-  assign ispr_rdata_intg_mux_sel[IsprMaiIn1S0Intg] = ispr_bignum_predec_i.ispr_rd_en[IsprMaiIn1S0];
-  assign ispr_rdata_intg_mux_sel[IsprMaiIn1S1Intg] = ispr_bignum_predec_i.ispr_rd_en[IsprMaiIn1S1];
+  assign ispr_rdata_intg_mux_sel[IsprModIntg]        =
+      ispr_bignum_predec_i.ispr_rd_en[IsprMod];
+  assign ispr_rdata_intg_mux_sel[IsprAccIntg]        =
+      ispr_bignum_predec_i.ispr_rd_en[IsprAcc];
+  assign ispr_rdata_intg_mux_sel[IsprMaiResS0Intg]   =
+      ispr_bignum_predec_i.ispr_rd_en[IsprMaiResS0];
+  assign ispr_rdata_intg_mux_sel[IsprMaiResS1Intg]   =
+      ispr_bignum_predec_i.ispr_rd_en[IsprMaiResS1];
+  assign ispr_rdata_intg_mux_sel[IsprMaiIn0S0Intg]   =
+      ispr_bignum_predec_i.ispr_rd_en[IsprMaiIn0S0];
+  assign ispr_rdata_intg_mux_sel[IsprMaiIn0S1Intg]   =
+      ispr_bignum_predec_i.ispr_rd_en[IsprMaiIn0S1];
+  assign ispr_rdata_intg_mux_sel[IsprMaiIn1S0Intg]   =
+      ispr_bignum_predec_i.ispr_rd_en[IsprMaiIn1S0];
+  assign ispr_rdata_intg_mux_sel[IsprMaiIn1S1Intg]   =
+      ispr_bignum_predec_i.ispr_rd_en[IsprMaiIn1S1];
+  assign ispr_rdata_intg_mux_sel[IsprKmacDataS0Intg] =
+      ispr_bignum_predec_i.ispr_rd_en[IsprKmacDataS0];
+  assign ispr_rdata_intg_mux_sel[IsprKmacDataS1Intg] =
+      ispr_bignum_predec_i.ispr_rd_en[IsprKmacDataS1];
 
   assign ispr_rdata_intg_mux_sel[IsprNoIntg] =
-    |{ispr_bignum_predec_i.ispr_rd_en[IsprMaiCtrl],
+    |{ispr_bignum_predec_i.ispr_rd_en[IsprKmacStrb],
+      ispr_bignum_predec_i.ispr_rd_en[IsprKmacCfg],
+      ispr_bignum_predec_i.ispr_rd_en[IsprKmacCtrl],
+      ispr_bignum_predec_i.ispr_rd_en[IsprKmacStatus],
+      ispr_bignum_predec_i.ispr_rd_en[IsprMaiCtrl],
       ispr_bignum_predec_i.ispr_rd_en[IsprMaiStatus],
       ispr_bignum_predec_i.ispr_rd_en[IsprKeyS1H:IsprKeyS0L],
       ispr_bignum_predec_i.ispr_rd_en[IsprUrnd],

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -1313,6 +1313,22 @@ module otbn_controller
         ispr_addr_base      = IsprUrnd;
         ispr_word_addr_base = '0;
       end
+      CsrKmacStatus: begin
+        ispr_addr_base      = IsprKmacStatus;
+        ispr_word_addr_base = '0;
+      end
+      CsrKmacCtrl: begin
+        ispr_addr_base      = IsprKmacCtrl;
+        ispr_word_addr_base = '0;
+      end
+      CsrKmacCfg: begin
+        ispr_addr_base      = IsprKmacCfg;
+        ispr_word_addr_base = '0;
+      end
+      CsrKmacStrb: begin
+        ispr_addr_base      = IsprKmacStrb;
+        ispr_word_addr_base = '0;
+      end
       CsrMaiCtrl: begin
         ispr_addr_base      = IsprMaiCtrl;
         ispr_word_addr_base = '0;
@@ -1466,12 +1482,14 @@ module otbn_controller
         ispr_addr_bignum = IsprKeyS1H;
         key_invalid = ~sideload_key_shares_valid_i[1];
       end
-      WsrMaiResS0: ispr_addr_bignum = IsprMaiResS0;
-      WsrMaiResS1: ispr_addr_bignum = IsprMaiResS1;
-      WsrMaiIn0S0: ispr_addr_bignum = IsprMaiIn0S0;
-      WsrMaiIn0S1: ispr_addr_bignum = IsprMaiIn0S1;
-      WsrMaiIn1S0: ispr_addr_bignum = IsprMaiIn1S0;
-      WsrMaiIn1S1: ispr_addr_bignum = IsprMaiIn1S1;
+      WsrMaiResS0:   ispr_addr_bignum = IsprMaiResS0;
+      WsrMaiResS1:   ispr_addr_bignum = IsprMaiResS1;
+      WsrMaiIn0S0:   ispr_addr_bignum = IsprMaiIn0S0;
+      WsrMaiIn0S1:   ispr_addr_bignum = IsprMaiIn0S1;
+      WsrMaiIn1S0:   ispr_addr_bignum = IsprMaiIn1S0;
+      WsrMaiIn1S1:   ispr_addr_bignum = IsprMaiIn1S1;
+      WsrKmacDataS0: ispr_addr_bignum = IsprKmacDataS0;
+      WsrKmacDataS1: ispr_addr_bignum = IsprKmacDataS1;
       default: wsr_illegal_addr = 1'b1;
     endcase
   end

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -102,7 +102,11 @@ module otbn_core
   input logic software_errs_fatal_i,
 
   input logic [1:0]                       sideload_key_shares_valid_i,
-  input logic [1:0][SideloadKeyWidth-1:0] sideload_key_shares_i
+  input logic [1:0][SideloadKeyWidth-1:0] sideload_key_shares_i,
+
+  // KMAC application interface
+  output kmac_pkg::app_req_t kmac_app_req_o,
+  input  kmac_pkg::app_rsp_t kmac_app_rsp_i
 );
   import prim_mubi_pkg::*;
 
@@ -261,6 +265,26 @@ module otbn_core
   logic [ExtWLEN-1:0] ispr_mai_res_s0_rdata;
   logic [ExtWLEN-1:0] ispr_mai_res_s1_rdata;
 
+  logic               ispr_kmac_status_wr;
+  logic [31:0]        ispr_kmac_status_wdata;
+  logic [31:0]        ispr_kmac_status_rdata;
+  logic               ispr_kmac_ctrl_wr;
+  logic [31:0]        ispr_kmac_ctrl_wdata;
+  logic               ispr_kmac_cfg_wr;
+  logic [31:0]        ispr_kmac_cfg_wdata;
+  logic [31:0]        ispr_kmac_cfg_rdata;
+  logic               ispr_kmac_strb_wr;
+  logic [31:0]        ispr_kmac_strb_wdata;
+  logic [31:0]        ispr_kmac_strb_rdata;
+  logic               ispr_kmac_data_s0_wr;
+  logic [ExtWLEN-1:0] ispr_kmac_data_s0_wdata;
+  logic               ispr_kmac_data_s1_wr;
+  logic [ExtWLEN-1:0] ispr_kmac_data_s1_wdata;
+  logic [ExtWLEN-1:0] ispr_kmac_data_s0_rdata;
+  logic               ispr_kmac_data_s0_rd;
+  logic [ExtWLEN-1:0] ispr_kmac_data_s1_rdata;
+  logic               ispr_kmac_data_s1_rd;
+
   logic            rnd_req;
   logic            rnd_prefetch_req;
   logic            rnd_valid;
@@ -302,6 +326,9 @@ module otbn_core
   logic sec_wipe_mai_res_s0_urnd;
   logic sec_wipe_mai_res_s1_urnd;
 
+  logic sec_wipe_kmac_data_s0_urnd;
+  logic sec_wipe_kmac_data_s1_urnd;
+
   logic zero_flags;
 
   logic                     prefetch_en;
@@ -327,6 +354,10 @@ module otbn_core
   logic mai_software_error;
   logic mai_reg_intg_violation_err;
   logic mai_state_err;
+
+  logic kmac_sec_wipe_err;
+  logic kmac_reg_intg_violation_err;
+  logic kmac_state_err_d, kmac_state_err;
 
   logic req_sec_wipe_urnd_keys_q;
 
@@ -372,6 +403,9 @@ module otbn_core
     .sec_wipe_mai_in1_s1_urnd_o(sec_wipe_mai_in1_s1_urnd),
     .sec_wipe_mai_res_s0_urnd_o(sec_wipe_mai_res_s0_urnd),
     .sec_wipe_mai_res_s1_urnd_o(sec_wipe_mai_res_s1_urnd),
+
+    .sec_wipe_kmac_data_s0_urnd_o(sec_wipe_kmac_data_s0_urnd),
+    .sec_wipe_kmac_data_s1_urnd_o(sec_wipe_kmac_data_s1_urnd),
 
     .ispr_init_o         (ispr_init),
     .state_reset_o       (state_reset),
@@ -479,7 +513,8 @@ module otbn_core
                           rf_base_sec_wipe_err,
                           rf_bignum_wr_sec_wipe_err,
                           alu_bignum_sec_wipe_err,
-                          mac_bignum_sec_wipe_err};
+                          mac_bignum_sec_wipe_err,
+                          kmac_sec_wipe_err};
 
   // Controller: coordinate between functional units, prepare their inputs (e.g. by muxing between
   // operand sources), and post-process their outputs as needed.
@@ -649,7 +684,7 @@ module otbn_core
   logic non_controller_reg_intg_violation_d, non_controller_reg_intg_violation;
   assign non_controller_reg_intg_violation_d =
       |{alu_bignum_reg_intg_violation_err, mac_bignum_reg_intg_violation_err, rf_base_intg_err_d,
-        mai_reg_intg_violation_err};
+        mai_reg_intg_violation_err, kmac_reg_intg_violation_err};
 
   ////////////////////////////////////////////////////////////////
   // Register local escalation signals for timinig optimization //
@@ -688,6 +723,7 @@ module otbn_core
       non_controller_reg_intg_violation <= '0;
       insn_addr_err                     <= '0;
       mac_bignum_state_error            <= '0;
+      kmac_state_err                    <= '0;
     end else begin
       urnd_all_zero                     <= urnd_all_zero_d;
       predec_error                      <= predec_error_d;
@@ -696,6 +732,7 @@ module otbn_core
       non_controller_reg_intg_violation <= non_controller_reg_intg_violation_d;
       insn_addr_err                     <= insn_addr_err_d;
       mac_bignum_state_error            <= mac_bignum_state_error_d;
+      kmac_state_err                    <= kmac_state_err_d;
     end
   end
 
@@ -710,7 +747,8 @@ module otbn_core
                            rf_base_spurious_we_err,
                            mac_bignum_state_error,
                            mubi_err,
-                           mai_state_err},
+                           mai_state_err,
+                           kmac_state_err},
     reg_intg_violation:  |{controller_err_bits.reg_intg_violation,
                            non_controller_reg_intg_violation},
     dmem_intg_violation: lsu_rdata_err,
@@ -748,7 +786,8 @@ module otbn_core
                   mubi4_bool_to_mubi(|{start_stop_fatal_error, urnd_all_zero, predec_error,
                                        rf_base_spurious_we_err, lsu_rdata_err,
                                        insn_fetch_err, non_controller_reg_intg_violation,
-                                       insn_addr_err, mac_bignum_state_error, mai_state_err}));
+                                       insn_addr_err, mac_bignum_state_error, mai_state_err,
+                                       kmac_state_err}));
 
   assign controller_recov_escalate_en =
       mubi4_bool_to_mubi(|{rnd_rep_err, rnd_fips_err});
@@ -759,7 +798,8 @@ module otbn_core
                   mubi4_bool_to_mubi(|{urnd_all_zero, rf_base_intg_err, rf_base_spurious_we_err,
                                        predec_error, lsu_rdata_err, insn_fetch_err,
                                        mac_bignum_state_error,
-                                       controller_fatal_err, insn_addr_err, mai_state_err}));
+                                       controller_fatal_err, insn_addr_err, mai_state_err,
+                                       kmac_state_err}));
 
   // Signal error if MuBi input signals take on invalid values as this means something bad is
   // happening. The explicit error detection is required as the mubi4_or_hi operations above
@@ -983,6 +1023,26 @@ module otbn_core
     .ispr_mai_res_s0_rdata_i(ispr_mai_res_s0_rdata),
     .ispr_mai_res_s1_rdata_i(ispr_mai_res_s1_rdata),
 
+    .ispr_kmac_status_wr_o    (ispr_kmac_status_wr),
+    .ispr_kmac_status_wdata_o (ispr_kmac_status_wdata),
+    .ispr_kmac_ctrl_wr_o      (ispr_kmac_ctrl_wr),
+    .ispr_kmac_ctrl_wdata_o   (ispr_kmac_ctrl_wdata),
+    .ispr_kmac_cfg_wr_o       (ispr_kmac_cfg_wr),
+    .ispr_kmac_cfg_wdata_o    (ispr_kmac_cfg_wdata),
+    .ispr_kmac_strb_wr_o      (ispr_kmac_strb_wr),
+    .ispr_kmac_strb_wdata_o   (ispr_kmac_strb_wdata),
+    .ispr_kmac_data_s0_wr_o   (ispr_kmac_data_s0_wr),
+    .ispr_kmac_data_s0_wdata_o(ispr_kmac_data_s0_wdata),
+    .ispr_kmac_data_s1_wr_o   (ispr_kmac_data_s1_wr),
+    .ispr_kmac_data_s1_wdata_o(ispr_kmac_data_s1_wdata),
+    .ispr_kmac_status_rdata_i (ispr_kmac_status_rdata),
+    .ispr_kmac_cfg_rdata_i    (ispr_kmac_cfg_rdata),
+    .ispr_kmac_strb_rdata_i   (ispr_kmac_strb_rdata),
+    .ispr_kmac_data_s0_rdata_i(ispr_kmac_data_s0_rdata),
+    .ispr_kmac_data_s1_rdata_i(ispr_kmac_data_s1_rdata),
+    .ispr_kmac_data_s0_rd_o   (ispr_kmac_data_s0_rd),
+    .ispr_kmac_data_s1_rd_o   (ispr_kmac_data_s1_rd),
+
     .reg_intg_violation_err_o(alu_bignum_reg_intg_violation_err),
 
     .sec_wipe_mod_urnd_i(sec_wipe_mod_urnd),
@@ -1109,6 +1169,46 @@ module otbn_core
       .urnd_data_i                 (urnd_data)
     );
   end
+
+  otbn_kmac_if u_otbn_kmac_if (
+    .clk_i,
+    .rst_ni,
+
+    .app_req_o(kmac_app_req_o),
+    .app_rsp_i(kmac_app_rsp_i),
+
+    .ispr_kmac_status_wr_i   (ispr_kmac_status_wr),
+    .ispr_kmac_status_wdata_i(ispr_kmac_status_wdata),
+    .ispr_kmac_ctrl_wr_i     (ispr_kmac_ctrl_wr),
+    .ispr_kmac_ctrl_wdata_i  (ispr_kmac_ctrl_wdata),
+    .ispr_kmac_cfg_wr_i      (ispr_kmac_cfg_wr),
+    .ispr_kmac_cfg_wdata_i   (ispr_kmac_cfg_wdata),
+    .ispr_kmac_strb_wr_i     (ispr_kmac_strb_wr),
+    .ispr_kmac_strb_wdata_i  (ispr_kmac_strb_wdata),
+
+    .ispr_kmac_status_rdata_o(ispr_kmac_status_rdata),
+    .ispr_kmac_cfg_rdata_o   (ispr_kmac_cfg_rdata),
+    .ispr_kmac_strb_rdata_o  (ispr_kmac_strb_rdata),
+
+    .ispr_kmac_data_s0_wr_i   (ispr_kmac_data_s0_wr),
+    .ispr_kmac_data_s0_wdata_i(ispr_kmac_data_s0_wdata),
+    .ispr_kmac_data_s1_wr_i   (ispr_kmac_data_s1_wr),
+    .ispr_kmac_data_s1_wdata_i(ispr_kmac_data_s1_wdata),
+
+    .ispr_kmac_data_s0_rd_i   (ispr_kmac_data_s0_rd),
+    .ispr_kmac_data_s0_rdata_o(ispr_kmac_data_s0_rdata),
+    .ispr_kmac_data_s1_rd_i   (ispr_kmac_data_s1_rd),
+    .ispr_kmac_data_s1_rdata_o(ispr_kmac_data_s1_rdata),
+
+    .sec_wipe_running_i          (secure_wipe_running_o),
+    .sec_wipe_ispr_kmac_data_s0_i(sec_wipe_kmac_data_s0_urnd),
+    .sec_wipe_ispr_kmac_data_s1_i(sec_wipe_kmac_data_s1_urnd),
+    .urnd_data_i                 (urnd_data),
+
+    .sec_wipe_err_o          (kmac_sec_wipe_err),
+    .reg_intg_violation_err_o(kmac_reg_intg_violation_err),
+    .state_err_o             (kmac_state_err_d)
+  );
 
   otbn_rnd #(
     .RndCnstUrndPrngSeed(RndCnstUrndPrngSeed)

--- a/hw/ip/otbn/rtl/otbn_kmac_if.sv
+++ b/hw/ip/otbn/rtl/otbn_kmac_if.sv
@@ -205,6 +205,7 @@ module otbn_kmac_if
 
   logic accept_data_rsp;
   logic clear_rsp_valid;
+  logic clear_error_flags;
   logic discard_rsp_ready;
   logic finish_rsp_hs;
 
@@ -230,6 +231,7 @@ module otbn_kmac_if
     // Control signals for the response handling.
     accept_data_rsp   = 1'b0;
     clear_rsp_valid   = 1'b0;
+    clear_error_flags = 1'b0;
     discard_rsp_ready = 1'b0;
 
     // Secure wipe recovery
@@ -360,8 +362,9 @@ module otbn_kmac_if
           state_d = OtbnKmacSecWipeClearing;
         end else if (current_cmd.close) begin
           // Clean up any state
-          state_d         = OtbnKmacIdle;
-          clear_rsp_valid = 1'b1;
+          state_d           = OtbnKmacIdle;
+          clear_rsp_valid   = 1'b1;
+          clear_error_flags = 1'b1;
         end
         unexpected_cmd_detected = |{current_cmd.start, current_cmd.send, current_cmd.proc,
                                     current_cmd.done};
@@ -645,10 +648,10 @@ module otbn_kmac_if
 
   // The RSP_ERROR is sticky and W1C where any response has priority over the SW clearing.
   // Discard any updates during the secure wipe except when FSM resets the flag.
-  assign rsp_error_d = wipe_configuration              ? 1'b0                          :
-                       sec_wipe_detected               ? rsp_error_q                   :
-                       data_rsp_hs || discarded_rsp_hs ? app_rsp_i.error | rsp_error_q :
-                       clear_rsp_error                 ? 1'b0                          :
+  assign rsp_error_d = wipe_configuration              ? 1'b0                           :
+                       sec_wipe_detected               ? rsp_error_q                    :
+                       data_rsp_hs || discarded_rsp_hs ? app_rsp_i.error || rsp_error_q :
+                       clear_rsp_error                 ? 1'b0                           :
                                                          rsp_error_q;
 
   // The MSG_WRITE_ERROR is sticky and W1C.
@@ -791,11 +794,14 @@ module otbn_kmac_if
 
   assign ispr_kmac_status_rdata_o = ispr_kmac_status_r;
 
-  assign clear_rsp_error = ispr_kmac_status_w.status.rsp_error & ispr_kmac_status_wr_i;
+  assign clear_rsp_error = (ispr_kmac_status_w.status.rsp_error && ispr_kmac_status_wr_i) ||
+                           clear_error_flags;
 
-  assign clear_msg_write_error = ispr_kmac_status_w.status.msg_write_error & ispr_kmac_status_wr_i;
+  assign clear_msg_write_error =
+      (ispr_kmac_status_w.status.msg_write_error && ispr_kmac_status_wr_i) || clear_error_flags;
 
-  assign clear_ctrl_error = ispr_kmac_status_w.status.ctrl_error & ispr_kmac_status_wr_i;
+  assign clear_ctrl_error = (ispr_kmac_status_w.status.ctrl_error && ispr_kmac_status_wr_i) ||
+                            clear_error_flags;
 
   ///////////////////////////
   // Secure wipe detection //
@@ -906,12 +912,12 @@ module otbn_kmac_if
   // Interface connection //
   //////////////////////////
   assign app_req_o = '{
-    req_valid: send_start_req | send_msg_beat | send_process_req | send_termination_req,
+    req_valid: send_start_req || send_msg_beat || send_process_req || send_termination_req,
     data_s0:   req_data_s0,
     data_s1:   req_data_s1,
     strb:      req_strb,
-    req_last:  send_process_req | send_termination_req,
-    rsp_ready: data_rsp_ready | discard_rsp_ready
+    req_last:  send_process_req || send_termination_req,
+    rsp_ready: data_rsp_ready || discard_rsp_ready
   };
 
   // Assert that only one request source  is active at the same time as otherwise requests are

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -414,31 +414,27 @@ package otbn_pkg;
   typedef enum logic [CsrNumWidth-1:0] {
     // Address ranges follow the RISC-V Privileged Specification v1.11
     // 0x7C0-0x7FF Custom read/write
-    CsrFg0            = 12'h7C0,
-    CsrFg1            = 12'h7C1,
-    CsrFlags          = 12'h7C8,
-    CsrMod0           = 12'h7D0,
-    CsrMod1           = 12'h7D1,
-    CsrMod2           = 12'h7D2,
-    CsrMod3           = 12'h7D3,
-    CsrMod4           = 12'h7D4,
-    CsrMod5           = 12'h7D5,
-    CsrMod6           = 12'h7D6,
-    CsrMod7           = 12'h7D7,
-    CsrRndPrefetch    = 12'h7D8,
-    // CsrKmacIfStatus   = 12'h7d9,
-    // CsrKmacIntr       = 12'h7da,
-    // CsrKmacCfg        = 12'h7db,
-    // CsrKmacMsgSend    = 12'h7dc,
-    // CsrKmacCmd        = 12'h7dd,
-    // CsrKmacByteStrobe = 12'h7de,
-    CsrMaiCtrl        = 12'h7e0,
+    CsrFg0         = 12'h7C0,
+    CsrFg1         = 12'h7C1,
+    CsrFlags       = 12'h7C8,
+    CsrMod0        = 12'h7D0,
+    CsrMod1        = 12'h7D1,
+    CsrMod2        = 12'h7D2,
+    CsrMod3        = 12'h7D3,
+    CsrMod4        = 12'h7D4,
+    CsrMod5        = 12'h7D5,
+    CsrMod6        = 12'h7D6,
+    CsrMod7        = 12'h7D7,
+    CsrRndPrefetch = 12'h7D8,
+    CsrKmacStatus  = 12'h7d9,
+    CsrKmacCtrl    = 12'h7da,
+    CsrKmacCfg     = 12'h7db,
+    CsrKmacStrb    = 12'h7dc,
+    CsrMaiCtrl     = 12'h7e0,
 
     // 0xFC0-0xFFF Custom read-only
     CsrRnd         = 12'hFC0,
     CsrUrnd        = 12'hFC1,
-    // CsrKmacStatus  = 12'hfc2,
-    // CsrKmacError   = 12'hfc3,
     CsrMaiStatus   = 12'hfca
   } csr_e;
 
@@ -454,8 +450,8 @@ package otbn_pkg;
     WsrKeyS0H     = 'd5,
     WsrKeyS1L     = 'd6,
     WsrKeyS1H     = 'd7,
-    // WsrKmacDataS0 = 'd8,
-    // WsrKmacDataS1 = 'd9,
+    WsrKmacDataS0 = 'd8,
+    WsrKmacDataS1 = 'd9,
     WsrMaiResS0   = 'd10,
     WsrMaiResS1   = 'd11,
     WsrMaiIn0S0   = 'd12,
@@ -467,26 +463,32 @@ package otbn_pkg;
   // Internal Special Purpose Registers (ISPRs)
   // CSRs and WSRs have some overlap into what they map into. ISPRs are the actual registers in the
   // design which CSRs and WSRs are mapped on to.
-  parameter int NIspr = 17;
+  parameter int NIspr = 23;
   parameter int IsprNumWidth = $clog2(NIspr);
   typedef enum logic [IsprNumWidth-1:0] {
-    IsprMod       = 'd0,
-    IsprRnd       = 'd1,
-    IsprAcc       = 'd2,
-    IsprFlags     = 'd3,
-    IsprUrnd      = 'd4,
-    IsprKeyS0L    = 'd5,
-    IsprKeyS0H    = 'd6,
-    IsprKeyS1L    = 'd7,
-    IsprKeyS1H    = 'd8,
-    IsprMaiResS0  = 'd9,
-    IsprMaiResS1  = 'd10,
-    IsprMaiIn0S0  = 'd11,
-    IsprMaiIn0S1  = 'd12,
-    IsprMaiIn1S0  = 'd13,
-    IsprMaiIn1S1  = 'd14,
-    IsprMaiCtrl   = 'd15,
-    IsprMaiStatus = 'd16
+    IsprMod        = 'd0,
+    IsprRnd        = 'd1,
+    IsprAcc        = 'd2,
+    IsprFlags      = 'd3,
+    IsprUrnd       = 'd4,
+    IsprKeyS0L     = 'd5,
+    IsprKeyS0H     = 'd6,
+    IsprKeyS1L     = 'd7,
+    IsprKeyS1H     = 'd8,
+    IsprMaiResS0   = 'd9,
+    IsprMaiResS1   = 'd10,
+    IsprMaiIn0S0   = 'd11,
+    IsprMaiIn0S1   = 'd12,
+    IsprMaiIn1S0   = 'd13,
+    IsprMaiIn1S1   = 'd14,
+    IsprMaiCtrl    = 'd15,
+    IsprMaiStatus  = 'd16,
+    IsprKmacDataS0 = 'd17,
+    IsprKmacDataS1 = 'd18,
+    IsprKmacStatus = 'd19,
+    IsprKmacCtrl   = 'd20,
+    IsprKmacCfg    = 'd21,
+    IsprKmacStrb   = 'd22
   } ispr_e;
 
   typedef logic [$clog2(NFlagGroups)-1:0] flag_group_t;

--- a/hw/ip/otbn/rtl/otbn_predecode.sv
+++ b/hw/ip/otbn/rtl/otbn_predecode.sv
@@ -761,26 +761,32 @@ module otbn_predecode
         CsrMod4, CsrMod5, CsrMod6, CsrMod7: ispr_addr = IsprMod;
         CsrRnd:                             ispr_addr = IsprRnd;
         CsrUrnd:                            ispr_addr = IsprUrnd;
+        CsrKmacStatus:                      ispr_addr = IsprKmacStatus;
+        CsrKmacCtrl:                        ispr_addr = IsprKmacCtrl;
+        CsrKmacCfg:                         ispr_addr = IsprKmacCfg;
+        CsrKmacStrb:                        ispr_addr = IsprKmacStrb;
         CsrMaiCtrl:                         ispr_addr = IsprMaiCtrl;
         CsrMaiStatus:                       ispr_addr = IsprMaiStatus;
         default: ;
       endcase
     end else begin
       unique case (wsr_addr)
-        WsrMod:      ispr_addr = IsprMod;
-        WsrRnd:      ispr_addr = IsprRnd;
-        WsrUrnd:     ispr_addr = IsprUrnd;
-        WsrAcc:      ispr_addr = IsprAcc;
-        WsrKeyS0L:   ispr_addr = IsprKeyS0L;
-        WsrKeyS0H:   ispr_addr = IsprKeyS0H;
-        WsrKeyS1L:   ispr_addr = IsprKeyS1L;
-        WsrKeyS1H:   ispr_addr = IsprKeyS1H;
-        WsrMaiResS0: ispr_addr = IsprMaiResS0;
-        WsrMaiResS1: ispr_addr = IsprMaiResS1;
-        WsrMaiIn0S0: ispr_addr = IsprMaiIn0S0;
-        WsrMaiIn0S1: ispr_addr = IsprMaiIn0S1;
-        WsrMaiIn1S0: ispr_addr = IsprMaiIn1S0;
-        WsrMaiIn1S1: ispr_addr = IsprMaiIn1S1;
+        WsrMod:        ispr_addr = IsprMod;
+        WsrRnd:        ispr_addr = IsprRnd;
+        WsrUrnd:       ispr_addr = IsprUrnd;
+        WsrAcc:        ispr_addr = IsprAcc;
+        WsrKeyS0L:     ispr_addr = IsprKeyS0L;
+        WsrKeyS0H:     ispr_addr = IsprKeyS0H;
+        WsrKeyS1L:     ispr_addr = IsprKeyS1L;
+        WsrKeyS1H:     ispr_addr = IsprKeyS1H;
+        WsrKmacDataS0: ispr_addr = IsprKmacDataS0;
+        WsrKmacDataS1: ispr_addr = IsprKmacDataS1;
+        WsrMaiResS0:   ispr_addr = IsprMaiResS0;
+        WsrMaiResS1:   ispr_addr = IsprMaiResS1;
+        WsrMaiIn0S0:   ispr_addr = IsprMaiIn0S0;
+        WsrMaiIn0S1:   ispr_addr = IsprMaiIn0S1;
+        WsrMaiIn1S0:   ispr_addr = IsprMaiIn1S0;
+        WsrMaiIn1S1:   ispr_addr = IsprMaiIn1S1;
         default: ;
       endcase
     end

--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -69,6 +69,9 @@ module otbn_start_stop_control
   output logic sec_wipe_mai_res_s0_urnd_o,
   output logic sec_wipe_mai_res_s1_urnd_o,
 
+  output logic sec_wipe_kmac_data_s0_urnd_o,
+  output logic sec_wipe_kmac_data_s1_urnd_o,
+
   output logic ispr_init_o,
   output logic state_reset_o,
   output logic insn_cnt_clear_int_o,
@@ -159,35 +162,37 @@ module otbn_start_stop_control
       otbn_start_stop_state_e, OtbnStartStopStateInitial)
 
   always_comb begin
-    urnd_reseed_req_o          = 1'b0;
-    urnd_advance_o             = 1'b0;
-    state_d                    = state_q;
-    ispr_init_o                = 1'b0;
-    state_reset_o              = 1'b0;
-    insn_cnt_clear_int_o       = 1'b0;
-    sec_wipe_wdr_o             = 1'b0;
-    sec_wipe_wdr_urnd_o        = 1'b0;
-    sec_wipe_base_o            = 1'b0;
-    sec_wipe_base_urnd_o       = 1'b0;
-    sec_wipe_mac_urnd_o        = 1'b0;
-    sec_wipe_mod_urnd_o        = 1'b0;
-    sec_wipe_zero_o            = 1'b0;
-    sec_wipe_mai_in0_s0_urnd_o = 1'b0;
-    sec_wipe_mai_in0_s1_urnd_o = 1'b0;
-    sec_wipe_mai_in1_s0_urnd_o = 1'b0;
-    sec_wipe_mai_in1_s1_urnd_o = 1'b0;
-    sec_wipe_mai_res_s0_urnd_o = 1'b0;
-    sec_wipe_mai_res_s1_urnd_o = 1'b0;
-    addr_cnt_inc               = 1'b0;
-    secure_wipe_ack_o          = 1'b0;
-    secure_wipe_running_d      = 1'b0;
-    state_error_d              = state_error_q;
-    allow_secure_wipe          = 1'b0;
-    expect_secure_wipe         = 1'b0;
-    spurious_urnd_ack_error    = 1'b0;
-    wipe_after_urnd_refresh_d  = wipe_after_urnd_refresh_q;
-    rma_ack_d                  = rma_ack_q;
-    mubi_err_d                 = mubi_err_q;
+    urnd_reseed_req_o            = 1'b0;
+    urnd_advance_o               = 1'b0;
+    state_d                      = state_q;
+    ispr_init_o                  = 1'b0;
+    state_reset_o                = 1'b0;
+    insn_cnt_clear_int_o         = 1'b0;
+    sec_wipe_wdr_o               = 1'b0;
+    sec_wipe_wdr_urnd_o          = 1'b0;
+    sec_wipe_base_o              = 1'b0;
+    sec_wipe_base_urnd_o         = 1'b0;
+    sec_wipe_mac_urnd_o          = 1'b0;
+    sec_wipe_mod_urnd_o          = 1'b0;
+    sec_wipe_zero_o              = 1'b0;
+    sec_wipe_kmac_data_s0_urnd_o = 1'b0;
+    sec_wipe_kmac_data_s1_urnd_o = 1'b0;
+    sec_wipe_mai_in0_s0_urnd_o   = 1'b0;
+    sec_wipe_mai_in0_s1_urnd_o   = 1'b0;
+    sec_wipe_mai_in1_s0_urnd_o   = 1'b0;
+    sec_wipe_mai_in1_s1_urnd_o   = 1'b0;
+    sec_wipe_mai_res_s0_urnd_o   = 1'b0;
+    sec_wipe_mai_res_s1_urnd_o   = 1'b0;
+    addr_cnt_inc                 = 1'b0;
+    secure_wipe_ack_o            = 1'b0;
+    secure_wipe_running_d        = 1'b0;
+    state_error_d                = state_error_q;
+    allow_secure_wipe            = 1'b0;
+    expect_secure_wipe           = 1'b0;
+    spurious_urnd_ack_error      = 1'b0;
+    wipe_after_urnd_refresh_d    = wipe_after_urnd_refresh_q;
+    rma_ack_d                    = rma_ack_q;
+    mubi_err_d                   = mubi_err_q;
 
     unique case (state_q)
       OtbnStartStopStateInitial: begin
@@ -330,12 +335,14 @@ module otbn_start_stop_control
         expect_secure_wipe    = 1'b1;
         secure_wipe_running_d = 1'b1;
         // reset registers in sequence
-        sec_wipe_mai_res_s0_urnd_o = (addr_cnt_q == 6'b000000);
-        sec_wipe_mai_res_s1_urnd_o = (addr_cnt_q == 6'b000001);
-        sec_wipe_mai_in0_s0_urnd_o = (addr_cnt_q == 6'b000010);
-        sec_wipe_mai_in0_s1_urnd_o = (addr_cnt_q == 6'b000011);
-        sec_wipe_mai_in1_s0_urnd_o = (addr_cnt_q == 6'b000100);
-        sec_wipe_mai_in1_s1_urnd_o = (addr_cnt_q == 6'b000101);
+        sec_wipe_kmac_data_s0_urnd_o = (addr_cnt_q == 6'b000000);
+        sec_wipe_kmac_data_s1_urnd_o = (addr_cnt_q == 6'b000001);
+        sec_wipe_mai_res_s0_urnd_o   = (addr_cnt_q == 6'b000010);
+        sec_wipe_mai_res_s1_urnd_o   = (addr_cnt_q == 6'b000011);
+        sec_wipe_mai_in0_s0_urnd_o   = (addr_cnt_q == 6'b000100);
+        sec_wipe_mai_in0_s1_urnd_o   = (addr_cnt_q == 6'b000101);
+        sec_wipe_mai_in1_s0_urnd_o   = (addr_cnt_q == 6'b000110);
+        sec_wipe_mai_in1_s1_urnd_o   = (addr_cnt_q == 6'b000111);
         // We let this phase run for 32 cycles to allow future accelerator registers
         // to be cleared in this stage without the need to adapt the DV model of OTBN.
         if (addr_cnt_q == 6'b011111) begin

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -5727,6 +5727,16 @@
           index: -1
         }
         {
+          name: kmac_data
+          struct: app
+          package: kmac_pkg
+          type: req_rsp
+          act: req
+          width: 1
+          inst_name: otbn
+          index: -1
+        }
+        {
           name: tl
           struct: tl
           package: tlul_pkg
@@ -25545,6 +25555,16 @@
         default: ""
         domain: Main
         top_signame: keymgr_dpe_otbn_key
+        index: -1
+      }
+      {
+        name: kmac_data
+        struct: app
+        package: kmac_pkg
+        type: req_rsp
+        act: req
+        width: 1
+        inst_name: otbn
         index: -1
       }
       {

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -1675,6 +1675,8 @@ module top_darjeeling #(
     .lc_rma_req_i(lc_ctrl_lc_nvm_rma_req),
     .lc_rma_ack_o(otbn_lc_rma_ack),
     .keymgr_key_i(keymgr_dpe_otbn_key),
+    .kmac_data_o(),
+    .kmac_data_i(kmac_pkg::APP_RSP_DEFAULT),
     .tl_i(otbn_tl_req),
     .tl_o(otbn_tl_rsp)
   );

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -7849,6 +7849,16 @@
           index: -1
         }
         {
+          name: kmac_data
+          struct: app
+          package: kmac_pkg
+          type: req_rsp
+          act: req
+          width: 1
+          inst_name: otbn
+          index: -1
+        }
+        {
           name: tl
           struct: tl
           package: tlul_pkg
@@ -25469,6 +25479,16 @@
         default: ""
         domain: Main
         top_signame: keymgr_otbn_key
+        index: -1
+      }
+      {
+        name: kmac_data
+        struct: app
+        package: kmac_pkg
+        type: req_rsp
+        act: req
+        width: 1
+        inst_name: otbn
         index: -1
       }
       {

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -7484,8 +7484,8 @@
           }
           default: kmac_pkg::APP_REQ_DEFAULT
           inst_name: kmac
-          end_idx: 3
-          top_type: partial-one-to-N
+          end_idx: -1
+          top_type: one-to-N
           top_signame: kmac_app
           index: -1
         }
@@ -7856,7 +7856,10 @@
           act: req
           width: 1
           inst_name: otbn
-          index: -1
+          default: ""
+          domain: Main
+          top_signame: kmac_app
+          index: 3
         }
         {
           name: tl
@@ -10326,6 +10329,7 @@
         keymgr.kmac_data
         lc_ctrl.kmac_data
         rom_ctrl.kmac_data
+        otbn.kmac_data
       ]
       kmac.en_masking:
       [
@@ -25255,8 +25259,8 @@
         }
         default: kmac_pkg::APP_REQ_DEFAULT
         inst_name: kmac
-        end_idx: 3
-        top_type: partial-one-to-N
+        end_idx: -1
+        top_type: one-to-N
         top_signame: kmac_app
         index: -1
       }
@@ -25489,7 +25493,10 @@
         act: req
         width: 1
         inst_name: otbn
-        index: -1
+        default: ""
+        domain: Main
+        top_signame: kmac_app
+        index: 3
       }
       {
         name: tl
@@ -32281,7 +32288,7 @@
           name_top: KmacNumAppIntf
         }
         type: req_rsp
-        end_idx: 3
+        end_idx: -1
         act: rsp
         suffix: req
         default: kmac_pkg::APP_REQ_DEFAULT
@@ -32303,7 +32310,7 @@
           name_top: KmacNumAppIntf
         }
         type: req_rsp
-        end_idx: 3
+        end_idx: -1
         act: rsp
         suffix: rsp
         default: ""

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -1213,9 +1213,10 @@
       'keymgr.otbn_key'         : ['otbn.keymgr_key'],
 
       // KMAC Application Interface
-      'kmac.app'                : ['keymgr.kmac_data',    // Keymgr needs to be at index 0
-                                   'lc_ctrl.kmac_data',   // LC needs to be at index 1
-                                   'rom_ctrl.kmac_data'], // ROM needs to be at index 2
+      'kmac.app'                : ['keymgr.kmac_data',   // Keymgr needs to be at index 0
+                                   'lc_ctrl.kmac_data',  // LC needs to be at index 1
+                                   'rom_ctrl.kmac_data', // ROM needs to be at index 2
+                                   'otbn.kmac_data'],    // OTBN needs to be at index 3
       'kmac.en_masking'         : ['keymgr.kmac_en_masking'],
 
       // The idle connection is automatically connected through topgen.

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -2189,6 +2189,8 @@ module top_earlgrey #(
     .lc_rma_req_i(lc_ctrl_lc_nvm_rma_req),
     .lc_rma_ack_o(lc_ctrl_lc_nvm_rma_ack[1]),
     .keymgr_key_i(keymgr_otbn_key),
+    .kmac_data_o(),
+    .kmac_data_i(kmac_pkg::APP_RSP_DEFAULT),
     .tl_i(otbn_tl_req),
     .tl_o(otbn_tl_rsp)
   );

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -790,15 +790,12 @@ module top_earlgrey #(
 
   // Dummy signal definitions for unused partial inter-module signals
   otp_ctrl_pkg::sram_otp_key_rsp_t unused_otp_ctrl_sram_otp_key_rsp3;
-  kmac_pkg::app_rsp_t unused_kmac_app_rsp3;
 
   // Assign unused partial inter-module signals
   assign unused_otp_ctrl_sram_otp_key_rsp3 = otp_ctrl_sram_otp_key_rsp[3];
-  assign unused_kmac_app_rsp3 = kmac_app_rsp[3];
 
   // Assign undriven partial inter-module signals
   assign otp_ctrl_sram_otp_key_req[3] = '0;
-  assign kmac_app_req[3] = kmac_pkg::APP_REQ_DEFAULT;
 
   // OTP HW_CFG* Broadcast signals.
   // TODO(#6713): The actual struct breakout and mapping currently needs to
@@ -2189,8 +2186,8 @@ module top_earlgrey #(
     .lc_rma_req_i(lc_ctrl_lc_nvm_rma_req),
     .lc_rma_ack_o(lc_ctrl_lc_nvm_rma_ack[1]),
     .keymgr_key_i(keymgr_otbn_key),
-    .kmac_data_o(),
-    .kmac_data_i(kmac_pkg::APP_RSP_DEFAULT),
+    .kmac_data_o(kmac_app_req[3]),
+    .kmac_data_i(kmac_app_rsp[3]),
     .tl_i(otbn_tl_req),
     .tl_o(otbn_tl_rsp)
   );


### PR DESCRIPTION
This PR integrates the OTBN side of the KMAC interface into the OTBN pipeline. It also connects the interface for the Earl Grey chip.

Only the last two commits are relevant. This PR depends on https://github.com/lowRISC/opentitan/pull/30283.