### PR TITLE
[kmac,dv] Make kmac_app_item::byte_data_q unsigned

### DIFF
--- a/hw/dv/sv/kmac_app_agent/kmac_app_item.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_item.sv
@@ -9,7 +9,7 @@ class kmac_app_item extends uvm_sequence_item;
   // request data/mask
   //
   // also used by the monitor to assemble the full request message
-  rand byte byte_data_q[$];
+  rand byte unsigned byte_data_q[$];
 
   // Static mode: single full-width digest.
   rand bit [kmac_pkg::AppDigestW-1:0] digest_s0;

--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -1039,7 +1039,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
 
   virtual function void compare_adv_creator_data(keymgr_cdi_type_e cdi_type,
                                                  bit exp_match,
-                                                 const ref byte byte_data_q[$]);
+                                                 const ref byte unsigned byte_data_q[$]);
     adv_creator_data_t exp, act;
     string str = $sformatf("cdi_type: %s\n", cdi_type.name);
 
@@ -1071,7 +1071,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
 
   virtual function void compare_adv_owner_int_data(keymgr_cdi_type_e cdi_type,
                                                    bit exp_match,
-                                                   const ref byte byte_data_q[$]);
+                                                   const ref byte unsigned byte_data_q[$]);
     adv_owner_int_data_t exp, act;
     string str = $sformatf("cdi_type: %s\n", cdi_type.name);
 
@@ -1098,7 +1098,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
 
   virtual function void compare_adv_owner_data(keymgr_cdi_type_e cdi_type,
                                                bit exp_match,
-                                               const ref byte byte_data_q[$]);
+                                               const ref byte unsigned byte_data_q[$]);
     adv_owner_data_t exp, act;
     string str = $sformatf("cdi_type: %s\n", cdi_type.name);
 
@@ -1125,7 +1125,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
 
   // for invalid OP, should not output any meaningful data to KMAC. Check the outputs aren't
   // matching to any of existing meaningful data
-  virtual function void compare_invalid_data(const ref byte byte_data_q[$]);
+  virtual function void compare_invalid_data(const ref byte unsigned byte_data_q[$]);
     adv_owner_data_t act;
 
     act = {<<8{byte_data_q}};
@@ -1148,7 +1148,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
     end
   endfunction
 
-  virtual function void compare_id_data(const ref byte byte_data_q[$]);
+  virtual function void compare_id_data(const ref byte unsigned byte_data_q[$]);
     bit [keymgr_pkg::IdDataWidth-1:0] act, exp;
 
     case (current_state)
@@ -1164,7 +1164,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
     id_data_a_array[current_state] = act;
   endfunction
 
-  virtual function void compare_gen_out_data(const ref byte byte_data_q[$]);
+  virtual function void compare_gen_out_data(const ref byte unsigned byte_data_q[$]);
     gen_out_data_t exp, act;
     keymgr_pkg::keymgr_ops_e op = get_operation();
     keymgr_pkg::keymgr_key_dest_e dest = keymgr_pkg::keymgr_key_dest_e'(

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
@@ -1267,7 +1267,7 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
 
   virtual function void compare_boot_stage_0_data(
       bit exp_match,
-      const ref byte byte_data_q[$]
+      const ref byte unsigned byte_data_q[$]
   );
     adv_creator_data_t exp, act;
     string str = $sformatf("src_slot: %0d\n", current_key_slot.src_slot);
@@ -1304,7 +1304,7 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
 
   virtual function void compare_boot_stage_1_data(
       bit exp_match,
-      const ref byte byte_data_q[$]
+      const ref byte unsigned byte_data_q[$]
     );
     adv_owner_int_data_t exp, act;
     string str = $sformatf("src_slot: %0d\n", current_key_slot.src_slot);
@@ -1332,7 +1332,7 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
   // being sent out to the kmac engine
   virtual function void compare_boot_stage_gte_2_data(
      bit exp_match,
-     const ref byte byte_data_q[$]
+     const ref byte unsigned byte_data_q[$]
    );
     adv_owner_data_t exp, act;
     string str = $sformatf("src_slot: %0d\n", current_key_slot.src_slot);
@@ -1360,7 +1360,7 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
 
   // for invalid OP, should not output any meaningful data to KMAC. Check the outputs aren't
   // matching to any of existing meaningful data
-  virtual function void compare_invalid_data(const ref byte byte_data_q[$]);
+  virtual function void compare_invalid_data(const ref byte unsigned byte_data_q[$]);
     adv_owner_data_t act;
 
     act = {<<8{byte_data_q}};
@@ -1383,7 +1383,7 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     end
   endfunction
 
-  virtual function void compare_gen_out_data(const ref byte byte_data_q[$]);
+  virtual function void compare_gen_out_data(const ref byte unsigned byte_data_q[$]);
     gen_out_data_t exp, act;
     keymgr_dpe_pkg::keymgr_dpe_ops_e op = get_operation();
     keymgr_pkg::keymgr_key_dest_e dest = keymgr_pkg::keymgr_key_dest_e'(

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
@@ -36,7 +36,7 @@ class rom_ctrl_scoreboard extends cip_base_scoreboard #(
   // Check the data in a KMAC request. This is what rom_ctrl sent to KMAC and it should be a copy of
   // the contents of ROM, which we can read through a memory backdoor. This checks that rom_ctrl has
   // successfully read the contents of ROM.
-  extern function void check_kmac_data(const ref byte byte_data_q[$]);
+  extern function void check_kmac_data(const ref byte unsigned byte_data_q[$]);
 
   // Follow responses sent from KMAC. There will be one after each reset and it will be a response
   // to a request that was seen in process_kmac_req_fifo.
@@ -108,7 +108,7 @@ task rom_ctrl_scoreboard::process_kmac_req_fifo();
 endtask
 
 // Read data sent to the kmac block and check it against memory data
-function void rom_ctrl_scoreboard::check_kmac_data(const ref byte byte_data_q[$]);
+function void rom_ctrl_scoreboard::check_kmac_data(const ref byte unsigned byte_data_q[$]);
   int word = 0;
   int addr = 0;
   // Check that we received the expected amount of data


### PR DESCRIPTION
This probably shouldn't be a signed value (we want bytes that contain 129, not -127!)