### PR TITLE
[keymgr,dv] Rename "keymgr.*_kmac_agent" to just "kmac_agent"

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_env.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env.sv
@@ -12,16 +12,16 @@ class keymgr_env extends cip_base_env #(
 
   `uvm_component_new
 
-  kmac_app_agent m_keymgr_kmac_agent;
+  kmac_app_agent m_kmac_agent;
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
 
-    // create m_keymgr_kmac_agent and set config object
-    m_keymgr_kmac_agent = kmac_app_agent::type_id::create("m_keymgr_kmac_agent", this);
-    uvm_config_db#(kmac_app_agent_cfg)::set(this, "m_keymgr_kmac_agent", "cfg",
-                                             cfg.m_keymgr_kmac_agent_cfg);
-    cfg.m_keymgr_kmac_agent_cfg.en_cov = cfg.en_cov;
+    // create m_kmac_agent and set config object
+    m_kmac_agent = kmac_app_agent::type_id::create("m_kmac_agent", this);
+    uvm_config_db#(kmac_app_agent_cfg)::set(this, "m_kmac_agent", "cfg",
+                                             cfg.m_kmac_agent_cfg);
+    cfg.m_kmac_agent_cfg.en_cov = cfg.en_cov;
     if (!uvm_config_db#(keymgr_vif)::get(this, "", "keymgr_vif", cfg.keymgr_vif)) begin
       `uvm_fatal(`gfn, "failed to get keymgr_vif from uvm_config_db")
     end
@@ -30,8 +30,8 @@ class keymgr_env extends cip_base_env #(
 
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
-    m_keymgr_kmac_agent.monitor.req_analysis_port.connect(scoreboard.req_fifo.analysis_export);
-    m_keymgr_kmac_agent.monitor.analysis_port.connect(scoreboard.rsp_fifo.analysis_export);
+    m_kmac_agent.monitor.req_analysis_port.connect(scoreboard.req_fifo.analysis_export);
+    m_kmac_agent.monitor.analysis_port.connect(scoreboard.rsp_fifo.analysis_export);
   endfunction
 
 endclass

--- a/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
@@ -4,7 +4,7 @@
 
 class keymgr_env_cfg extends cip_base_env_cfg #(.RAL_T(keymgr_reg_block));
 
-  rand kmac_app_agent_cfg m_keymgr_kmac_agent_cfg;
+  rand kmac_app_agent_cfg m_kmac_agent_cfg;
 
   keymgr_scoreboard scb;
   // interface for input data from LC, OTP and flash
@@ -25,8 +25,8 @@ class keymgr_env_cfg extends cip_base_env_cfg #(.RAL_T(keymgr_reg_block));
     shadow_update_err_status_fields[ral.err_code.invalid_shadow_update] = 1;
     shadow_storage_err_status_fields[ral.fault_status.shadow] = 1;
 
-    m_keymgr_kmac_agent_cfg = kmac_app_agent_cfg::type_id::create("m_keymgr_kmac_agent_cfg");
-    m_keymgr_kmac_agent_cfg.if_mode = dv_utils_pkg::Device;
+    m_kmac_agent_cfg = kmac_app_agent_cfg::type_id::create("m_kmac_agent_cfg");
+    m_kmac_agent_cfg.if_mode = dv_utils_pkg::Device;
 
     // keymgr requests entropy periodically, if seq is done, don't need to add any delay due to
     // activity from EDN interface

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_kmac_rsp_err_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_kmac_rsp_err_vseq.sv
@@ -22,7 +22,7 @@ class keymgr_kmac_rsp_err_vseq extends keymgr_hwsw_invalid_input_vseq;
   }
 
   task pre_start();
-    cfg.m_keymgr_kmac_agent_cfg.error_rsp_pct = 20;
+    cfg.m_kmac_agent_cfg.error_rsp_pct = 20;
 
     // fatal alert will be triggered, need reset to clear it
     expect_fatal_alerts = 1;

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_sync_async_fault_cross_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_sync_async_fault_cross_vseq.sv
@@ -47,7 +47,7 @@ class keymgr_sync_async_fault_cross_vseq extends keymgr_base_vseq;
     // Issue one operation, either advance or gen-out
     bit is_adv_op = $urandom_range(0, 1);
 
-    cfg.m_keymgr_kmac_agent_cfg.error_rsp_pct = 100;
+    cfg.m_kmac_agent_cfg.error_rsp_pct = 100;
     keymgr_operations(.advance_state(is_adv_op),
                       .num_gen_op(!is_adv_op),
                       .clr_output(0),

--- a/hw/ip/keymgr/dv/tb.sv
+++ b/hw/ip/keymgr/dv/tb.sv
@@ -80,8 +80,8 @@ module tb;
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual keymgr_if)::set(null, "*.env", "keymgr_vif", keymgr_if);
-    uvm_config_db#(virtual kmac_app_intf)::set(null,
-                   "*env.m_keymgr_kmac_agent*", "vif", keymgr_kmac_intf);
+    uvm_config_db#(virtual kmac_app_intf)::set(null, "*env.m_kmac_agent*", "vif", keymgr_kmac_intf);
+
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env.sv
@@ -12,16 +12,16 @@ class keymgr_dpe_env extends cip_base_env #(
 
   `uvm_component_new
 
-  kmac_app_agent m_keymgr_dpe_kmac_agent;
+  kmac_app_agent m_kmac_agent;
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
 
-    // create m_keymgr_dpe_kmac_agent and set config object
-    m_keymgr_dpe_kmac_agent = kmac_app_agent::type_id::create("m_keymgr_dpe_kmac_agent", this);
-    uvm_config_db#(kmac_app_agent_cfg)::set(this, "m_keymgr_dpe_kmac_agent", "cfg",
-                                             cfg.m_keymgr_dpe_kmac_agent_cfg);
-    cfg.m_keymgr_dpe_kmac_agent_cfg.en_cov = cfg.en_cov;
+    // create m_kmac_agent and set config object
+    m_kmac_agent = kmac_app_agent::type_id::create("m_kmac_agent", this);
+    uvm_config_db#(kmac_app_agent_cfg)::set(this, "m_kmac_agent", "cfg",
+                                             cfg.m_kmac_agent_cfg);
+    cfg.m_kmac_agent_cfg.en_cov = cfg.en_cov;
     if (!uvm_config_db#(keymgr_dpe_vif)::get(this, "", "keymgr_dpe_vif", cfg.keymgr_dpe_vif)) begin
       `uvm_fatal(`gfn, "failed to get keymgr_dpe_vif from uvm_config_db")
     end
@@ -30,8 +30,8 @@ class keymgr_dpe_env extends cip_base_env #(
 
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
-    m_keymgr_dpe_kmac_agent.monitor.req_analysis_port.connect(scoreboard.req_fifo.analysis_export);
-    m_keymgr_dpe_kmac_agent.monitor.analysis_port.connect(scoreboard.rsp_fifo.analysis_export);
+    m_kmac_agent.monitor.req_analysis_port.connect(scoreboard.req_fifo.analysis_export);
+    m_kmac_agent.monitor.analysis_port.connect(scoreboard.rsp_fifo.analysis_export);
   endfunction
 
 endclass

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env_cfg.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env_cfg.sv
@@ -4,7 +4,7 @@
 
 class keymgr_dpe_env_cfg extends cip_base_env_cfg #(.RAL_T(keymgr_dpe_reg_block));
 
-  rand kmac_app_agent_cfg m_keymgr_dpe_kmac_agent_cfg;
+  rand kmac_app_agent_cfg m_kmac_agent_cfg;
 
   keymgr_dpe_scoreboard scb;
   // interface for input data from LC or OTP
@@ -25,9 +25,9 @@ class keymgr_dpe_env_cfg extends cip_base_env_cfg #(.RAL_T(keymgr_dpe_reg_block)
     shadow_update_err_status_fields[ral.err_code.invalid_shadow_update] = 1;
     shadow_storage_err_status_fields[ral.fault_status.shadow] = 1;
 
-    m_keymgr_dpe_kmac_agent_cfg =
-      kmac_app_agent_cfg::type_id::create("m_keymgr_dpe_kmac_agent_cfg");
-    m_keymgr_dpe_kmac_agent_cfg.if_mode = dv_utils_pkg::Device;
+    m_kmac_agent_cfg =
+      kmac_app_agent_cfg::type_id::create("m_kmac_agent_cfg");
+    m_kmac_agent_cfg.if_mode = dv_utils_pkg::Device;
 
     // keymgr_dpe requests entropy periodically, if seq is done,
     // don't need to add any delay due to

--- a/hw/ip/keymgr_dpe/dv/tb.sv
+++ b/hw/ip/keymgr_dpe/dv/tb.sv
@@ -82,7 +82,7 @@ module tb;
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual keymgr_dpe_if)::set(null, "*.env", "keymgr_dpe_vif", keymgr_dpe_if);
     uvm_config_db#(virtual kmac_app_intf)::set(null,
-                   "*env.m_keymgr_dpe_kmac_agent*", "vif", keymgr_dpe_kmac_intf);
+                   "*env.m_kmac_agent*", "vif", keymgr_dpe_kmac_intf);
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end


### PR DESCRIPTION
There's no need to encode the name of the environment into agents that it instantiates.