### PR TITLE
[kmac,dv] Rename the "user digest share" items

### DIFF
--- a/hw/dv/sv/kmac_app_agent/kmac_app_agent_cfg.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_agent_cfg.sv
@@ -41,19 +41,21 @@ class kmac_app_agent_cfg extends dv_reactive_agent_cfg;
                        1 := 2 };
   }
 
-  // Setter method for the user digest share queues - must be called externally to place specific user-digest_share0
-  // to be sent by the driver.
-  function void add_user_digest_share(kmac_pkg::rsp_digest_t rsp_digest_h);
+  // Setter method, which adds the given digest to the queue.
+  function void add_user_digest(kmac_pkg::rsp_digest_t rsp_digest_h);
     rsp_digest_hs.push_back(rsp_digest_h);
   endfunction
-  // Getter method for the user digest share - returns the first data entry.
-  function kmac_pkg::rsp_digest_t get_user_digest_share();
-    `DV_CHECK_NE_FATAL(has_user_digest_share(), 0, "rsp_digest_share0 is empty!")
+
+  // Getter method for the user digest. Returns the first digest, or an error if there is none.
+  function kmac_pkg::rsp_digest_t pop_user_digest();
+    if (!has_user_digest()) begin
+      `uvm_fatal(get_name(), "Cannot get a user digest: the queue is empty.")
+    end
     return rsp_digest_hs.pop_front();
   endfunction
-  // Getter method for the user digest share - must be called externally to check whether there is
-  // any user data in the queues.
-  function bit has_user_digest_share();
+
+  // Getter method that returns true if there is at least one digest in the queue.
+  function bit has_user_digest();
     return (rsp_digest_hs.size() > 0);
   endfunction
 

--- a/hw/dv/sv/kmac_app_agent/seq_lib/kmac_app_device_seq.sv
+++ b/hw/dv/sv/kmac_app_agent/seq_lib/kmac_app_device_seq.sv
@@ -22,9 +22,9 @@ class kmac_app_device_seq extends kmac_app_base_seq;
     kmac_pkg::rsp_digest_t rsp_digest_h = '0;
     bit gen_error, set_share;
 
-    if (cfg.has_user_digest_share()) begin
+    if (cfg.has_user_digest()) begin
       set_share = 1;
-      rsp_digest_h = cfg.get_user_digest_share();
+      rsp_digest_h = cfg.pop_user_digest();
     end else begin
       set_share = 0;
     end

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
@@ -219,8 +219,8 @@ class lc_ctrl_base_vseq extends cip_base_vseq #(
 
   // Clear kmac agent digest data
   virtual function void clear_kmac_user_digest_share();
-    while (cfg.m_kmac_app_agent_cfg.has_user_digest_share()) begin
-      void'(cfg.m_kmac_app_agent_cfg.get_user_digest_share());
+    while (cfg.m_kmac_app_agent_cfg.has_user_digest()) begin
+      void'(cfg.m_kmac_app_agent_cfg.pop_user_digest());
     end
   endfunction
 

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_errors_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_errors_vseq.sv
@@ -550,7 +550,7 @@ class lc_ctrl_errors_vseq extends lc_ctrl_smoke_vseq;
       end
     end
     clear_kmac_user_digest_share();
-    cfg.m_kmac_app_agent_cfg.add_user_digest_share(kmac_digest);
+    cfg.m_kmac_app_agent_cfg.add_user_digest(kmac_digest);
     // Set error response
     cfg.m_kmac_app_agent_cfg.error_rsp_pct = (err_inj.token_response_err) ? 100 : 0;
   endfunction

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
@@ -136,7 +136,7 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
 
     kmac_digest = token_to_kmac_digest(tokens_a[token_idx], token_scramble);
     clear_kmac_user_digest_share();
-    cfg.m_kmac_app_agent_cfg.add_user_digest_share(kmac_digest);
+    cfg.m_kmac_app_agent_cfg.add_user_digest(kmac_digest);
   endfunction
 
 endclass : lc_ctrl_smoke_vseq

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
@@ -139,7 +139,7 @@ function void rom_ctrl_base_vseq::set_kmac_digest(bit [DIGEST_SIZE-1:0] value);
   `DV_CHECK_STD_RANDOMIZE_FATAL(share0)
   rsp_digest_h.digest_share0 = share0;
   rsp_digest_h.digest_share1 = rsp_digest_h.digest_share0 ^ value;
-  cfg.m_kmac_agent_cfg.add_user_digest_share(rsp_digest_h);
+  cfg.m_kmac_agent_cfg.add_user_digest(rsp_digest_h);
 endfunction
 
 // Configure the KMAC agent to respond with the ROM's expected digest if correct is as_expected


### PR DESCRIPTION
These queues contain digests, rather than shares. I suspect the original name was because it's a queue of digests which, in turn, have multiple shares, so it's a "share digest" queue. But the name looks a lot like it's a queue of shares, which is wrong.