### PR TITLE
[kmac,dv] Rename kmac_app_intf to kmac_app_if

### DIFF
--- a/hw/dv/sv/cip_lib/README.md
+++ b/hw/dv/sv/cip_lib/README.md
@@ -594,7 +594,7 @@ class keymgr_common_vseq extends keymgr_base_vseq;
     case (if_proxy.sec_cm_type)
       SecCmPrimCount: begin
         if (enable) begin
-          $asserton(0, "tb.keymgr_kmac_intf");
+          $asserton(0, "tb.kmac_if");
           $asserton(0, "tb.dut.tlul_assert_device.gen_device.dDataKnown_A");
           $asserton(0, "tb.dut.u_ctrl.DataEn_A");
           $asserton(0, "tb.dut.u_ctrl.DataEnDis_A");
@@ -602,7 +602,7 @@ class keymgr_common_vseq extends keymgr_base_vseq;
           $asserton(0, "tb.dut.u_kmac_if.LastStrb_A");
           $asserton(0, "tb.dut.KmacDataKnownO_A");
         end else begin
-          $assertoff(0, "tb.keymgr_kmac_intf");
+          $assertoff(0, "tb.kmac_if");
           $assertoff(0, "tb.dut.tlul_assert_device.gen_device.dDataKnown_A");
           $assertoff(0, "tb.dut.u_ctrl.DataEn_A");
           $assertoff(0, "tb.dut.u_ctrl.DataEnDis_A");

--- a/hw/dv/sv/kmac_app_agent/kmac_app_agent.core
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_agent.core
@@ -14,7 +14,7 @@ filesets:
       - lowrisc:ip:kmac_pkg
     files:
       - kmac_app_agent_pkg.sv
-      - kmac_app_intf.sv
+      - kmac_app_if.sv
       - kmac_app_item.sv: {is_include_file: true}
       - kmac_app_agent_cfg.sv: {is_include_file: true}
       - kmac_app_sequencer.sv: {is_include_file: true}

--- a/hw/dv/sv/kmac_app_agent/kmac_app_agent.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_agent.sv
@@ -23,9 +23,9 @@ class kmac_app_agent extends dv_reactive_agent #(
     // use for mon-seq connection
     cfg.has_req_fifo = 1;
 
-    // get kmac_app_intf handle
-    if (!uvm_config_db#(virtual kmac_app_intf)::get(this, "", "vif", cfg.vif)) begin
-      `uvm_fatal(`gfn, "failed to get kmac_app_intf handle from uvm_config_db")
+    // get kmac_app_if handle
+    if (!uvm_config_db#(virtual kmac_app_if)::get(this, "", "vif", cfg.vif)) begin
+      `uvm_fatal(`gfn, "failed to get kmac_app_if handle from uvm_config_db")
     end
 
     // create push_agent, agent_cfg

--- a/hw/dv/sv/kmac_app_agent/kmac_app_agent_cfg.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_agent_cfg.sv
@@ -5,7 +5,7 @@
 class kmac_app_agent_cfg extends dv_reactive_agent_cfg;
 
   // Interface handle used by driver, monitor and the sequencer
-  virtual kmac_app_intf vif;
+  virtual kmac_app_if vif;
 
   // Minimum and maximum delays between requests
   int unsigned req_delay_min = 0;

--- a/hw/dv/sv/kmac_app_agent/kmac_app_if.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_if.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // verilog_lint: waive interface-name-style
-interface kmac_app_intf (input clk, input rst_n);
+interface kmac_app_if (input clk, input rst_n);
 
   import keymgr_pkg::*;
 

--- a/hw/ip/keymgr/dv/env/keymgr_if.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_if.sv
@@ -387,9 +387,9 @@ interface keymgr_if(input clk, input rst_n);
         `DV_CHECK_STD_RANDOMIZE_FATAL(invalid_kmac_rsp, , msg_id)
         // set `done` to 1, force the other fields to a random value to avoid X propagation
         invalid_kmac_rsp.rsp_valid = 1;
-        force tb.keymgr_kmac_intf.kmac_data_rsp = invalid_kmac_rsp;
+        force tb.kmac_if.kmac_data_rsp = invalid_kmac_rsp;
         @(negedge clk);
-        release tb.keymgr_kmac_intf.kmac_data_rsp;
+        release tb.kmac_if.kmac_data_rsp;
       end
       FaultSideloadNotConsistent: begin
         pre_sideload_valids = tb.dut.u_sideload_ctrl.valids;
@@ -493,9 +493,9 @@ interface keymgr_if(input clk, input rst_n);
   // keymgr will sent constantly changed entropy data to KMAC for KDF operation.
   always_comb begin
     if (!is_kmac_data_good || keymgr_en_sync1 != lc_ctrl_pkg::On) begin
-      $assertoff(0, tb.keymgr_kmac_intf.req_data_if.H_DataStableWhenValidAndNotReady_A);
+      $assertoff(0, tb.kmac_if.req_data_if.H_DataStableWhenValidAndNotReady_A);
     end else begin
-      $asserton(0, tb.keymgr_kmac_intf.req_data_if.H_DataStableWhenValidAndNotReady_A);
+      $asserton(0, tb.kmac_if.req_data_if.H_DataStableWhenValidAndNotReady_A);
     end
   end
 

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_common_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_common_vseq.sv
@@ -123,7 +123,7 @@ class keymgr_common_vseq extends keymgr_base_vseq;
     case (if_proxy.sec_cm_type)
       SecCmPrimCount: begin
         if (enable) begin
-          $asserton(0, "tb.keymgr_kmac_intf");
+          $asserton(0, "tb.kmac_if");
           $asserton(0, "tb.dut.tlul_assert_device.gen_device.gen_d2h.dDataKnown_A");
           $asserton(0, "tb.dut.u_ctrl.DataEn_A");
           $asserton(0, "tb.dut.u_ctrl.DataEnDis_A");
@@ -131,7 +131,7 @@ class keymgr_common_vseq extends keymgr_base_vseq;
           $asserton(0, "tb.dut.u_kmac_if.LastStrb_A");
           $asserton(0, "tb.dut.KmacDataKnownO_A");
         end else begin
-          $assertoff(0, "tb.keymgr_kmac_intf");
+          $assertoff(0, "tb.kmac_if");
           $assertoff(0, "tb.dut.tlul_assert_device.gen_device.gen_d2h.dDataKnown_A");
           $assertoff(0, "tb.dut.u_ctrl.DataEn_A");
           $assertoff(0, "tb.dut.u_ctrl.DataEnDis_A");

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_custom_cm_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_custom_cm_vseq.sv
@@ -24,7 +24,7 @@ class keymgr_custom_cm_vseq extends keymgr_lc_disable_vseq;
     ral.default_map.set_auto_predict(1);
 
     // forcing internal design may cause uninitialized reg to be used, disable these checking
-    $assertoff(0, "tb.keymgr_kmac_intf");
+    $assertoff(0, "tb.kmac_if");
     $assertoff(0, "tb.dut.u_ctrl.DataEn_A");
     $assertoff(0, "tb.dut.u_ctrl.DataEnDis_A");
     $assertoff(0, "tb.dut.u_ctrl.CntZero_A");
@@ -94,7 +94,7 @@ class keymgr_custom_cm_vseq extends keymgr_lc_disable_vseq;
     // fatal alert will be triggered, need reset to clear it
     expect_fatal_alerts = 1;
     super.post_start();
-    $asserton(0, "tb.keymgr_kmac_intf");
+    $asserton(0, "tb.kmac_if");
     $asserton(0, "tb.dut.u_ctrl.DataEn_A");
     $asserton(0, "tb.dut.u_ctrl.DataEnDis_A");
     $asserton(0, "tb.dut.u_ctrl.CntZero_A");

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_hwsw_invalid_input_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_hwsw_invalid_input_vseq.sv
@@ -35,7 +35,7 @@ class keymgr_hwsw_invalid_input_vseq extends keymgr_sw_invalid_input_vseq;
 
   task body();
     // invalid HW input may cause unstable data on kmac interface
-    $assertoff(0, "tb.keymgr_kmac_intf.req_data_if.H_DataStableWhenValidAndNotReady_A");
+    $assertoff(0, "tb.kmac_if.req_data_if.H_DataStableWhenValidAndNotReady_A");
     super.body();
   endtask : body
 endclass : keymgr_hwsw_invalid_input_vseq

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_sync_async_fault_cross_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_sync_async_fault_cross_vseq.sv
@@ -22,7 +22,7 @@ class keymgr_sync_async_fault_cross_vseq extends keymgr_base_vseq;
 
     // disable push-pull interface assertion since faults may cause the kmac interface
     // to be filled with random, constantly changing data
-    $assertoff(0, "tb.keymgr_kmac_intf.req_data_if.H_DataStableWhenValidAndNotReady_A");
+    $assertoff(0, "tb.kmac_if.req_data_if.H_DataStableWhenValidAndNotReady_A");
 
     fork
       trigger_sync_fault();

--- a/hw/ip/keymgr/dv/tb.sv
+++ b/hw/ip/keymgr/dv/tb.sv
@@ -22,11 +22,11 @@ module tb;
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
   keymgr_if keymgr_if(.clk(clk), .rst_n(rst_n));
-  kmac_app_intf keymgr_kmac_intf(.clk(clk), .rst_n(rst_n));
+  kmac_app_if kmac_if(.clk(clk), .rst_n(rst_n));
 
   // connect KDF interface for assertion check
-  assign keymgr_if.kmac_data_req = keymgr_kmac_intf.kmac_data_req;
-  assign keymgr_if.kmac_data_rsp = keymgr_kmac_intf.kmac_data_rsp;
+  assign keymgr_if.kmac_data_req = kmac_if.kmac_data_req;
+  assign keymgr_if.kmac_data_rsp = kmac_if.kmac_data_rsp;
 
   `DV_ALERT_IF_CONNECT()
 
@@ -53,8 +53,8 @@ module tb;
     .aes_key_o            (keymgr_if.aes_key),
     .otbn_key_o           (keymgr_if.otbn_key),
     .kmac_key_o           (keymgr_if.kmac_key),
-    .kmac_data_o          (keymgr_kmac_intf.kmac_data_req),
-    .kmac_data_i          (keymgr_kmac_intf.kmac_data_rsp),
+    .kmac_data_o          (kmac_if.kmac_data_req),
+    .kmac_data_i          (kmac_if.kmac_data_rsp),
     .kmac_en_masking_i    (1'b1),
     .lc_keymgr_en_i       (keymgr_if.keymgr_en),
     .lc_keymgr_div_i      (keymgr_if.keymgr_div),
@@ -80,7 +80,7 @@ module tb;
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual keymgr_if)::set(null, "*.env", "keymgr_vif", keymgr_if);
-    uvm_config_db#(virtual kmac_app_intf)::set(null, "*env.m_kmac_agent*", "vif", keymgr_kmac_intf);
+    uvm_config_db#(virtual kmac_app_if)::set(null, "*env.m_kmac_agent*", "vif", kmac_if);
 
     $timeformat(-12, 0, " ps", 12);
     run_test();

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_if.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_if.sv
@@ -433,9 +433,9 @@ interface keymgr_dpe_if(input clk, input rst_n);
         `DV_CHECK_STD_RANDOMIZE_FATAL(invalid_kmac_rsp, , msg_id)
         // set `rsp_valid` to 1, force the other fields to a random value to avoid X propagation
         invalid_kmac_rsp.rsp_valid = 1;
-        force tb.keymgr_dpe_kmac_intf.kmac_data_rsp = invalid_kmac_rsp;
+        force tb.kmac_if.kmac_data_rsp = invalid_kmac_rsp;
         @(negedge clk);
-        release tb.keymgr_dpe_kmac_intf.kmac_data_rsp;
+        release tb.kmac_if.kmac_data_rsp;
       end
       FaultSideloadNotConsistent: begin
         pre_sideload_valids = tb.dut.u_sideload_ctrl.valids;
@@ -541,9 +541,9 @@ interface keymgr_dpe_if(input clk, input rst_n);
   // keymgr_dpe will sent constantly changed entropy data to KMAC for KDF operation.
   always_comb begin
     if (!is_kmac_data_good || keymgr_dpe_en_sync1 != lc_ctrl_pkg::On) begin
-      $assertoff(0, tb.keymgr_dpe_kmac_intf.req_data_if.H_DataStableWhenValidAndNotReady_A);
+      $assertoff(0, tb.kmac_if.req_data_if.H_DataStableWhenValidAndNotReady_A);
     end else begin
-      $asserton(0, tb.keymgr_dpe_kmac_intf.req_data_if.H_DataStableWhenValidAndNotReady_A);
+      $asserton(0, tb.kmac_if.req_data_if.H_DataStableWhenValidAndNotReady_A);
     end
   end
 

--- a/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_common_vseq.sv
+++ b/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_common_vseq.sv
@@ -123,7 +123,7 @@ class keymgr_dpe_common_vseq extends keymgr_dpe_base_vseq;
     case (if_proxy.sec_cm_type)
       SecCmPrimCount: begin
         if (enable) begin
-          $asserton(0, "tb.keymgr_dpe_kmac_intf");
+          $asserton(0, "tb.kmac_if");
           $asserton(0, "tb.dut.tlul_assert_device.gen_device.gen_d2h.dDataKnown_A");
           $asserton(0, "tb.dut.u_ctrl.DataEn_A");
           $asserton(0, "tb.dut.u_ctrl.DataEnDis_A");
@@ -131,7 +131,7 @@ class keymgr_dpe_common_vseq extends keymgr_dpe_base_vseq;
           $asserton(0, "tb.dut.u_kmac_if.LastStrb_A");
           $asserton(0, "tb.dut.KmacDataKnownO_A");
         end else begin
-          $assertoff(0, "tb.keymgr_dpe_kmac_intf");
+          $assertoff(0, "tb.kmac_if");
           $assertoff(0, "tb.dut.tlul_assert_device.gen_device.gen_d2h.dDataKnown_A");
           $assertoff(0, "tb.dut.u_ctrl.DataEn_A");
           $assertoff(0, "tb.dut.u_ctrl.DataEnDis_A");

--- a/hw/ip/keymgr_dpe/dv/tb.sv
+++ b/hw/ip/keymgr_dpe/dv/tb.sv
@@ -24,11 +24,11 @@ module tb;
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
   keymgr_dpe_if keymgr_dpe_if(.clk(clk), .rst_n(rst_n));
-  kmac_app_intf keymgr_dpe_kmac_intf(.clk(clk), .rst_n(rst_n));
+  kmac_app_if kmac_if(.clk(clk), .rst_n(rst_n));
 
   // connect KDF interface for assertion check
-  assign keymgr_dpe_if.kmac_data_req = keymgr_dpe_kmac_intf.kmac_data_req;
-  assign keymgr_dpe_if.kmac_data_rsp = keymgr_dpe_kmac_intf.kmac_data_rsp;
+  assign keymgr_dpe_if.kmac_data_req = kmac_if.kmac_data_req;
+  assign keymgr_dpe_if.kmac_data_rsp = kmac_if.kmac_data_rsp;
 
   `DV_ALERT_IF_CONNECT()
 
@@ -53,8 +53,8 @@ module tb;
     .aes_key_o            (keymgr_dpe_if.aes_key),
     .otbn_key_o           (keymgr_dpe_if.otbn_key),
     .kmac_key_o           (keymgr_dpe_if.kmac_key),
-    .kmac_data_o          (keymgr_dpe_kmac_intf.kmac_data_req),
-    .kmac_data_i          (keymgr_dpe_kmac_intf.kmac_data_rsp),
+    .kmac_data_o          (kmac_if.kmac_data_req),
+    .kmac_data_i          (kmac_if.kmac_data_rsp),
     .kmac_en_masking_i    (1'b1),
     .lc_keymgr_en_i       (keymgr_dpe_if.keymgr_dpe_en),
     .lc_keymgr_div_i      (keymgr_dpe_if.keymgr_dpe_div),
@@ -83,8 +83,7 @@ module tb;
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual keymgr_dpe_if)::set(null, "*.env", "keymgr_dpe_vif", keymgr_dpe_if);
-    uvm_config_db#(virtual kmac_app_intf)::set(null,
-                   "*env.m_kmac_agent*", "vif", keymgr_dpe_kmac_intf);
+    uvm_config_db#(virtual kmac_app_if)::set(null, "*env.m_kmac_agent*", "vif", kmac_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end

--- a/hw/ip/kmac/dv/tb.sv
+++ b/hw/ip/kmac/dv/tb.sv
@@ -37,7 +37,7 @@ module tb;
     .sideload_key (kmac_sideload_key)
   );
 
-  kmac_app_intf kmac_app_if[NUM_APP_INTF](.clk(clk), .rst_n(rst_n));
+  kmac_app_if kmac_app_if[NUM_APP_INTF](.clk(clk), .rst_n(rst_n));
 
   // edn_clk, edn_rst_n and edn_if is defined and driven in below macro
   `DV_EDN_IF_CONNECT
@@ -90,14 +90,14 @@ module tb;
     .entropy_i          ({edn_if[0].ack, edn_if[0].d_data} )
   );
 
-  for (genvar i = 0; i < NUM_APP_INTF; i++) begin : gen_kmac_app_intf
+  for (genvar i = 0; i < NUM_APP_INTF; i++) begin : gen_kmac_app_if
     assign app_req[i]                   = kmac_app_if[i].kmac_data_req;
     assign kmac_app_if[i].kmac_data_rsp = app_rsp[i];
     assign kmac_if.app_req[i] = app_req[i];
     assign kmac_if.app_rsp[i] = app_rsp[i];
 
     initial begin
-      uvm_config_db#(virtual kmac_app_intf)::set(null,
+      uvm_config_db#(virtual kmac_app_if)::set(null,
           $sformatf("*env.m_kmac_app_agent[%0d]*", i), "vif", kmac_app_if[i]);
     end
   end

--- a/hw/ip/lc_ctrl/dv/tb.sv
+++ b/hw/ip/lc_ctrl/dv/tb.sv
@@ -91,7 +91,7 @@ module tb;
   assign kmac_app_if.kmac_data_req = kmac_data_out;
 
   // KMAC vip
-  kmac_app_intf kmac_app_if (
+  kmac_app_if kmac_app_if (
     .clk  (clk),
     .rst_n(rst_n)
   );
@@ -269,7 +269,7 @@ module tb;
     uvm_config_db#(virtual push_pull_if#(.HostDataWidth(OTP_PROG_HDATA_WIDTH),
                                          .DeviceDataWidth(OTP_PROG_DDATA_WIDTH)))::
                    set(null, "*env.m_otp_prog_pull_agent*", "vif", otp_prog_if);
-    uvm_config_db#(virtual kmac_app_intf)::set(null, "*.env.m_kmac_app_agent", "vif", kmac_app_if);
+    uvm_config_db#(virtual kmac_app_if)::set(null, "*.env.m_kmac_app_agent", "vif", kmac_app_if);
 
     // Parameter config object
     parameters_cfg.alert_async_on = AlertAsyncOn;

--- a/hw/ip/rom_ctrl/dv/tb/tb.sv
+++ b/hw/ip/rom_ctrl/dv/tb/tb.sv
@@ -27,7 +27,7 @@ module tb;
   clk_rst_if rom_clk_rst_if(.clk(), .rst_n()); // dummy clk_rst_vif for second RAL
   tl_if tl_rom_if(.clk(clk), .rst_n(rst_n));
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
-  kmac_app_intf kmac_app_if(.clk(clk), .rst_n(rst_n));
+  kmac_app_if kmac_app_if(.clk(clk), .rst_n(rst_n));
 
   `DV_ALERT_IF_CONNECT()
 
@@ -102,7 +102,7 @@ module tb;
         "*.env.m_tl_agent_rom_ctrl_regs_reg_block*", "vif", tl_if);
     uvm_config_db#(rom_ctrl_bkdr_util)::set(null, "*.env", "rom_ctrl_bkdr_util",
         m_rom_ctrl_bkdr_util);
-    uvm_config_db#(virtual kmac_app_intf)::set(null, "*.env.m_kmac_agent*", "vif", kmac_app_if);
+    uvm_config_db#(virtual kmac_app_if)::set(null, "*.env.m_kmac_agent*", "vif", kmac_app_if);
     uvm_config_db#(rom_ctrl_vif)::set(null, "*.env", "rom_ctrl_vif", dut.rom_ctrl_if);
     uvm_config_db#(virtual rom_ctrl_fsm_if)::set(
         null, "*.env", "rom_ctrl_fsm_vif",


### PR DESCRIPTION
**[kmac,dv] Rename kmac_app_intf to kmac_app_if**
 
No functional change, but this matches the conventional name used in
OpenTitan for interfaces.
