### PR TITLE
[kmac,dv] Pass req/rsp to kmac_app_if through inout ports

### DIFF
--- a/hw/dv/sv/kmac_app_agent/kmac_app_device_driver.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_device_driver.sv
@@ -27,7 +27,7 @@ class kmac_app_device_driver extends kmac_app_driver;
       `uvm_info(`gfn, $sformatf("rcvd item:\n%0s", req.sprint()), UVM_HIGH)
 
       `DV_SPINWAIT_EXIT(repeat (rsp.rsp_delay) @(cfg.vif.device_cb);,
-                        wait(!cfg.vif.rst_n))
+                        wait(!cfg.vif.rst_ni))
 
       cfg.vif.device_cb.rsp_valid         <= 1;
       cfg.vif.device_cb.rsp_digest_share0 <= rsp.digest_s0;
@@ -36,7 +36,7 @@ class kmac_app_device_driver extends kmac_app_driver;
       cfg.vif.device_cb.rsp_finish        <= 0;
 
       `DV_SPINWAIT_EXIT(@(cfg.vif.device_cb);,
-                        wait(!cfg.vif.rst_n))
+                        wait(!cfg.vif.rst_ni))
       invalidate_signals();
 
       `uvm_info(`gfn, "item sent", UVM_HIGH)

--- a/hw/dv/sv/kmac_app_agent/kmac_app_if.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_if.sv
@@ -2,33 +2,35 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// verilog_lint: waive interface-name-style
-interface kmac_app_if (input clk, input rst_n);
+interface kmac_app_if
+  import kmac_pkg::app_req_t, kmac_pkg::app_rsp_t;
+(
+ input      clk_i,
+ input      rst_ni,
+ inout wire app_req_t req,
+ inout wire app_rsp_t rsp
+);
 
   import keymgr_pkg::*;
 
   dv_utils_pkg::if_mode_e if_mode; // interface mode - Host or Device
 
-  // interface pins used to connect with DUT
-  wire kmac_pkg::app_req_t kmac_data_req;
-  wire kmac_pkg::app_rsp_t kmac_data_rsp;
-
   // interface pins used in driver/monitor
   push_pull_if #(.HostDataWidth(kmac_app_agent_pkg::KMAC_REQ_DATA_WIDTH))
-      req_data_if(.clk(clk), .rst_n(rst_n));
+      req_data_if(.clk(clk_i), .rst_n(rst_ni));
   wire rsp_valid;
   wire [kmac_pkg::AppDigestW-1:0] rsp_digest_share0;
   wire [kmac_pkg::AppDigestW-1:0] rsp_digest_share1;
   wire rsp_error;
   wire rsp_finish;
 
-  // all the host pins are handled by push_pull driver, only include clk and rst here
-  clocking host_cb @(posedge clk);
-    input  rst_n;
+  // all the host pins are handled by push_pull driver, only include clk_i and rst here
+  clocking host_cb @(posedge clk_i);
+    input  rst_ni;
   endclocking
 
-  clocking device_cb @(posedge clk);
-    input  rst_n;
+  clocking device_cb @(posedge clk_i);
+    input  rst_ni;
     output rsp_valid;
     output rsp_digest_share0;
     output rsp_digest_share1;
@@ -36,8 +38,8 @@ interface kmac_app_if (input clk, input rst_n);
     output rsp_finish;
   endclocking
 
-  clocking mon_cb @(posedge clk);
-    input rst_n;
+  clocking mon_cb @(posedge clk_i);
+    input rst_ni;
     input rsp_valid;
     input rsp_digest_share0;
     input rsp_digest_share1;
@@ -47,35 +49,33 @@ interface kmac_app_if (input clk, input rst_n);
 
   always @(if_mode) req_data_if.if_mode = if_mode;
 
-  assign kmac_data_req = (if_mode == dv_utils_pkg::Host) ?
-                         {req_data_if.valid, req_data_if.h_data} : 'z;
-  assign {req_data_if.valid, req_data_if.h_data} = (if_mode == dv_utils_pkg::Device) ?
-                                                   kmac_data_req : 'z;
+  assign req = (if_mode == dv_utils_pkg::Host) ? {req_data_if.valid, req_data_if.h_data} : 'z;
+  assign {req_data_if.valid, req_data_if.h_data} = (if_mode == dv_utils_pkg::Device) ? req : 'z;
 
   assign {req_data_if.ready, rsp_valid, rsp_digest_share0, rsp_digest_share1, rsp_error,
           rsp_finish} =
-         (if_mode == dv_utils_pkg::Host) ? kmac_data_rsp : 'z;
-  assign kmac_data_rsp = (if_mode == dv_utils_pkg::Device) ?
+         (if_mode == dv_utils_pkg::Host) ? rsp : 'z;
+  assign rsp = (if_mode == dv_utils_pkg::Device) ?
          {req_data_if.ready, rsp_valid, rsp_digest_share0, rsp_digest_share1, rsp_error,
           rsp_finish} : 'z;
 
   // The following assertions only apply to device mode.
   // strb should never be 0
-  `ASSERT(StrbNotZero_A, kmac_data_req.req_valid |-> kmac_data_req.strb > 0,
-          clk, !rst_n || if_mode == dv_utils_pkg::Host)
+  `ASSERT(StrbNotZero_A, req.req_valid |-> req.strb > 0,
+          clk_i, !rst_ni || if_mode == dv_utils_pkg::Host)
 
   // Check strb is aligned to LSB, for example: if strb[1]==0, strb[$:2] should be 0 too
   for (genvar k = 1; k < KmacDataIfWidth / 8 - 1; k++) begin : gen_strb_check
-    `ASSERT(StrbAlignLSB_A, kmac_data_req.req_valid && kmac_data_req.strb[k] === 0 |->
-                            kmac_data_req.strb[k+1] === 0,
-                            clk, !rst_n || if_mode == dv_utils_pkg::Host)
+    `ASSERT(StrbAlignLSB_A, req.req_valid && req.strb[k] === 0 |-> req.strb[k+1] === 0,
+            clk_i, !rst_ni || if_mode == dv_utils_pkg::Host)
   end
 
   // The following assertions apply for this interface for all modes.
 
   // Done should be asserted after last, before we start another request
   `ASSERT(DoneAssertAfterLast_A,
-    (kmac_data_req.req_last && kmac_data_req.req_valid && kmac_data_rsp.req_ready) |=>
-    !kmac_data_req.req_valid throughout rsp_valid[->1], clk, !rst_n || rsp_error)
+          (req.req_last && req.req_valid && rsp.req_ready) |=>
+          !req.req_valid throughout rsp_valid[->1],
+          clk_i, !rst_ni || rsp_error)
 
 endinterface

--- a/hw/dv/sv/kmac_app_agent/kmac_app_monitor.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_monitor.sv
@@ -28,7 +28,7 @@ class kmac_app_monitor extends dv_reactive_monitor #(
       begin : isolation_fork
         fork
           process_trans();
-          @(negedge cfg.vif.rst_n);
+          @(negedge cfg.vif.rst_ni);
         join_any
         disable fork;
         process_reset();
@@ -88,7 +88,7 @@ class kmac_app_monitor extends dv_reactive_monitor #(
   virtual protected task process_reset();
     `uvm_info(`gfn, $sformatf("Reset occurs"), UVM_MEDIUM)
     ok_to_end = 1;
-    @(posedge cfg.vif.rst_n);
+    @(posedge cfg.vif.rst_ni);
     data_fifo.flush();
   endtask
 

--- a/hw/ip/keymgr/dv/env/keymgr_if.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_if.sv
@@ -387,9 +387,9 @@ interface keymgr_if(input clk, input rst_n);
         `DV_CHECK_STD_RANDOMIZE_FATAL(invalid_kmac_rsp, , msg_id)
         // set `done` to 1, force the other fields to a random value to avoid X propagation
         invalid_kmac_rsp.rsp_valid = 1;
-        force tb.kmac_if.kmac_data_rsp = invalid_kmac_rsp;
+        force tb.kmac_if.rsp = invalid_kmac_rsp;
         @(negedge clk);
-        release tb.kmac_if.kmac_data_rsp;
+        release tb.kmac_if.rsp;
       end
       FaultSideloadNotConsistent: begin
         pre_sideload_valids = tb.dut.u_sideload_ctrl.valids;

--- a/hw/ip/keymgr/dv/tb.sv
+++ b/hw/ip/keymgr/dv/tb.sv
@@ -13,8 +13,10 @@ module tb;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
-  wire clk, rst_n, rst_shadowed_n;
+  wire                          clk, rst_n, rst_shadowed_n;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
+  wire kmac_pkg::app_req_t      kmac_req;
+  wire kmac_pkg::app_rsp_t      kmac_rsp;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
@@ -22,11 +24,11 @@ module tb;
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
   keymgr_if keymgr_if(.clk(clk), .rst_n(rst_n));
-  kmac_app_if kmac_if(.clk(clk), .rst_n(rst_n));
+  kmac_app_if kmac_if(.clk_i(clk), .rst_ni(rst_n), .req(kmac_req), .rsp(kmac_rsp));
 
   // connect KDF interface for assertion check
-  assign keymgr_if.kmac_data_req = kmac_if.kmac_data_req;
-  assign keymgr_if.kmac_data_rsp = kmac_if.kmac_data_rsp;
+  assign keymgr_if.kmac_data_req = kmac_req;
+  assign keymgr_if.kmac_data_rsp = kmac_rsp;
 
   `DV_ALERT_IF_CONNECT()
 
@@ -53,8 +55,8 @@ module tb;
     .aes_key_o            (keymgr_if.aes_key),
     .otbn_key_o           (keymgr_if.otbn_key),
     .kmac_key_o           (keymgr_if.kmac_key),
-    .kmac_data_o          (kmac_if.kmac_data_req),
-    .kmac_data_i          (kmac_if.kmac_data_rsp),
+    .kmac_data_o          (kmac_req),
+    .kmac_data_i          (kmac_rsp),
     .kmac_en_masking_i    (1'b1),
     .lc_keymgr_en_i       (keymgr_if.keymgr_en),
     .lc_keymgr_div_i      (keymgr_if.keymgr_div),

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_if.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_if.sv
@@ -433,9 +433,9 @@ interface keymgr_dpe_if(input clk, input rst_n);
         `DV_CHECK_STD_RANDOMIZE_FATAL(invalid_kmac_rsp, , msg_id)
         // set `rsp_valid` to 1, force the other fields to a random value to avoid X propagation
         invalid_kmac_rsp.rsp_valid = 1;
-        force tb.kmac_if.kmac_data_rsp = invalid_kmac_rsp;
+        force tb.kmac_if.rsp = invalid_kmac_rsp;
         @(negedge clk);
-        release tb.kmac_if.kmac_data_rsp;
+        release tb.kmac_if.rsp;
       end
       FaultSideloadNotConsistent: begin
         pre_sideload_valids = tb.dut.u_sideload_ctrl.valids;

--- a/hw/ip/keymgr_dpe/dv/tb.sv
+++ b/hw/ip/keymgr_dpe/dv/tb.sv
@@ -13,8 +13,10 @@ module tb;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
-  wire clk, rst_n, rst_shadowed_n;
+  wire                          clk, rst_n, rst_shadowed_n;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
+  wire kmac_pkg::app_req_t      kmac_req;
+  wire kmac_pkg::app_rsp_t      kmac_rsp;
 
   assign interrupts[NUM_MAX_INTERRUPTS-1:1] = '0;
 
@@ -24,11 +26,11 @@ module tb;
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
   keymgr_dpe_if keymgr_dpe_if(.clk(clk), .rst_n(rst_n));
-  kmac_app_if kmac_if(.clk(clk), .rst_n(rst_n));
+  kmac_app_if kmac_if(.clk_i(clk), .rst_ni(rst_n), .req(kmac_req), .rsp(kmac_rsp));
 
   // connect KDF interface for assertion check
-  assign keymgr_dpe_if.kmac_data_req = kmac_if.kmac_data_req;
-  assign keymgr_dpe_if.kmac_data_rsp = kmac_if.kmac_data_rsp;
+  assign keymgr_dpe_if.kmac_data_req = kmac_req;
+  assign keymgr_dpe_if.kmac_data_rsp = kmac_rsp;
 
   `DV_ALERT_IF_CONNECT()
 
@@ -53,8 +55,8 @@ module tb;
     .aes_key_o            (keymgr_dpe_if.aes_key),
     .otbn_key_o           (keymgr_dpe_if.otbn_key),
     .kmac_key_o           (keymgr_dpe_if.kmac_key),
-    .kmac_data_o          (kmac_if.kmac_data_req),
-    .kmac_data_i          (kmac_if.kmac_data_rsp),
+    .kmac_data_o          (kmac_req),
+    .kmac_data_i          (kmac_rsp),
     .kmac_en_masking_i    (1'b1),
     .lc_keymgr_en_i       (keymgr_dpe_if.keymgr_dpe_en),
     .lc_keymgr_div_i      (keymgr_dpe_if.keymgr_dpe_div),

--- a/hw/ip/kmac/dv/env/kmac_if.sv
+++ b/hw/ip/kmac/dv/env/kmac_if.sv
@@ -9,21 +9,10 @@ interface kmac_if(input clk_i, input rst_ni);
   logic                                          en_masking_o;
   lc_ctrl_pkg::lc_tx_t                           lc_escalate_en_i;
   prim_mubi_pkg::mubi4_t                         idle_o;
-  kmac_pkg::app_req_t [kmac_env_pkg::NUM_APP_INTF-1:0] app_req;
-  kmac_pkg::app_rsp_t [kmac_env_pkg::NUM_APP_INTF-1:0] app_rsp;
 
   function automatic void drive_lc_escalate(lc_ctrl_pkg::lc_tx_t val);
     lc_escalate_en_i = val;
   endfunction
 
   `ASSERT(KmacMaskingO_A, `EN_MASKING == en_masking_o)
-
-  `ASSERT(AppKeymgrErrOutputZeros_A, app_rsp[AppKeymgr].error |->
-          app_rsp[AppKeymgr].digest_s0 == 0 && app_rsp[AppKeymgr].digest_s1 == 0)
-
-  `ASSERT(AppLcErrOutputZeros_A, app_rsp[AppLc].error |->
-          app_rsp[AppLc].digest_s0 == 0 && app_rsp[AppLc].digest_s1 == 0)
-
-  `ASSERT(AppRomErrOutputZeros_A, app_rsp[AppRom].error |->
-          app_rsp[AppRom].digest_s0 == 0 && app_rsp[AppRom].digest_s1 == 0)
 endinterface

--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -473,8 +473,8 @@ class kmac_scoreboard extends cip_base_scoreboard #(
 
                 // It's possible for SW to not clear the error until after the hash is done.
                 // In this case the hash will be garbage data, so do not check it.
-                if (cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_req.req_valid &&
-                    cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_req.req_last) begin
+                if (cfg.m_kmac_app_agent_cfg[app_mode].vif.req.req_valid &&
+                    cfg.m_kmac_app_agent_cfg[app_mode].vif.req.req_last) begin
                   do_check_digest = 0;
                 end
 

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_edn_timeout_error_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_edn_timeout_error_vseq.sv
@@ -63,11 +63,11 @@ class kmac_edn_timeout_error_vseq extends kmac_app_vseq;
   virtual task check_keymgr_rsp_nonblocking();
     fork begin
       while (cfg.en_scb == 0 && entropy_fetched == 0) begin
-        wait (cfg.m_kmac_app_agent_cfg[AppKeymgr].vif.kmac_data_rsp.rsp_valid == 1);
+        wait (cfg.m_kmac_app_agent_cfg[AppKeymgr].vif.rsp.rsp_valid == 1);
         if (cfg.enable_masking && entropy_mode == EntropyModeEdn) begin
-          `DV_CHECK_EQ(cfg.m_kmac_app_agent_cfg[AppKeymgr].vif.kmac_data_rsp.error, 1)
+          `DV_CHECK_EQ(cfg.m_kmac_app_agent_cfg[AppKeymgr].vif.rsp.error, 1)
         end
-        wait (cfg.m_kmac_app_agent_cfg[AppKeymgr].vif.kmac_data_rsp.rsp_valid == 0);
+        wait (cfg.m_kmac_app_agent_cfg[AppKeymgr].vif.rsp.rsp_valid == 0);
       end
     end join_none
   endtask

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_entropy_mode_error_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_entropy_mode_error_vseq.sv
@@ -31,13 +31,13 @@ class kmac_entropy_mode_error_vseq extends kmac_edn_timeout_error_vseq;
   virtual task check_keymgr_rsp_nonblocking();
     fork begin
       while (cfg.en_scb == 0 && entropy_fetched == 0) begin
-        wait (cfg.m_kmac_app_agent_cfg[AppKeymgr].vif.kmac_data_rsp.rsp_valid == 1);
+        wait (cfg.m_kmac_app_agent_cfg[AppKeymgr].vif.rsp.rsp_valid == 1);
         if (cfg.enable_masking && kmac_err_type == ErrIncorrectEntropyMode) begin
           if (entropy_fetched == 0) begin
-            `DV_CHECK_EQ(cfg.m_kmac_app_agent_cfg[AppKeymgr].vif.kmac_data_rsp.error, 1)
+            `DV_CHECK_EQ(cfg.m_kmac_app_agent_cfg[AppKeymgr].vif.rsp.error, 1)
           end
         end
-        wait (cfg.m_kmac_app_agent_cfg[AppKeymgr].vif.kmac_data_rsp.rsp_valid == 0);
+        wait (cfg.m_kmac_app_agent_cfg[AppKeymgr].vif.rsp.rsp_valid == 0);
       end
     end join_none
   endtask

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_key_error_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_key_error_vseq.sv
@@ -45,8 +45,8 @@ class kmac_key_error_vseq extends kmac_app_vseq;
       fork begin : isolation_fork
         fork
           send_kmac_app_req(app_mode);
-          wait (cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_req.req_valid &&
-                cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_req.req_last);
+          wait (cfg.m_kmac_app_agent_cfg[app_mode].vif.req.req_valid &&
+                cfg.m_kmac_app_agent_cfg[app_mode].vif.req.req_last);
         join_any;
         disable fork;
       end join
@@ -76,18 +76,18 @@ class kmac_key_error_vseq extends kmac_app_vseq;
   virtual task check_keymgr_rsp_nonblocking();
     fork begin
       while (cfg.en_scb == 0) begin
-        wait (cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_rsp.req_ready == 1);
-        `DV_CHECK_EQ(cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_rsp.digest_s0, '0)
-        `DV_CHECK_EQ(cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_rsp.digest_s1, '0)
-        wait (cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_rsp.req_ready == 0);
+        wait (cfg.m_kmac_app_agent_cfg[app_mode].vif.rsp.req_ready == 1);
+        `DV_CHECK_EQ(cfg.m_kmac_app_agent_cfg[app_mode].vif.rsp.digest_s0, '0)
+        `DV_CHECK_EQ(cfg.m_kmac_app_agent_cfg[app_mode].vif.rsp.digest_s1, '0)
+        wait (cfg.m_kmac_app_agent_cfg[app_mode].vif.rsp.req_ready == 0);
       end
     end join_none
 
     fork begin
       while (cfg.en_scb == 0) begin
-        wait (cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_rsp.rsp_valid == 1);
-        `DV_CHECK_EQ(cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_rsp.error, 1)
-        wait (cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_rsp.rsp_valid == 0);
+        wait (cfg.m_kmac_app_agent_cfg[app_mode].vif.rsp.rsp_valid == 1);
+        `DV_CHECK_EQ(cfg.m_kmac_app_agent_cfg[app_mode].vif.rsp.error, 1)
+        wait (cfg.m_kmac_app_agent_cfg[app_mode].vif.rsp.rsp_valid == 0);
       end
     end join_none
   endtask

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_sideload_invalid_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_sideload_invalid_vseq.sv
@@ -76,8 +76,8 @@ class kmac_sideload_invalid_vseq extends kmac_long_msg_and_output_vseq;
       // TODO(lowrisc/opentitan#24739): Currently, when invalidating the key when the
       // app_i.last was received, exiting the StErrorAwaitApp is not possible anymore.
       // After resolving this issue, we simply can wait until we got kmac_done.
-      wait(cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_req.req_valid &&
-           cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_req.req_last);
+      wait(cfg.m_kmac_app_agent_cfg[app_mode].vif.req.req_valid &&
+           cfg.m_kmac_app_agent_cfg[app_mode].vif.req.req_last);
       kmac_done = 1;
     end else begin
       // Issue Start cmd.
@@ -136,7 +136,7 @@ class kmac_sideload_invalid_vseq extends kmac_long_msg_and_output_vseq;
     // app_i.last was received, exiting the StErrorAwaitApp is not possible anymore.
     // After resolving this issue, the last condition can be removed.
     if (invalidate_key && !kmac_done &&
-        (!en_app || !cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_req.req_last)) begin
+        (!en_app || !cfg.m_kmac_app_agent_cfg[app_mode].vif.req.req_last)) begin
       // We got the FSM state, the key is valid, and the operation is not yet done.
       // Invalidate the key and wait for the expected error code.
       `uvm_info(`gfn, $sformatf("invalidated key in state %0b", curr_state), UVM_LOW)

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
@@ -195,7 +195,7 @@ class kmac_smoke_vseq extends kmac_base_vseq;
             bit [TL_DW-1:0] rand_data;
             `DV_CHECK_MEMBER_RANDOMIZE_FATAL(fifo_addr)
             `DV_CHECK_STD_RANDOMIZE_FATAL(rand_data)
-            wait (cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_req.req_valid);
+            wait (cfg.m_kmac_app_agent_cfg[app_mode].vif.req.req_valid);
             tl_access(.addr(ral.get_addr_from_offset(fifo_addr)),
                       .write(1),
                       .data(rand_data),
@@ -211,7 +211,7 @@ class kmac_smoke_vseq extends kmac_base_vseq;
           // the only command that will trigger this particular error is CmdStart.
           if (kmac_err_type == kmac_pkg::ErrSwIssuedCmdInAppActive) begin : sw_cmd_in_app
             kmac_pkg::kmac_cmd_e invalid_cmd = kmac_pkg::CmdStart;
-            wait (cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_req.req_valid);
+            wait (cfg.m_kmac_app_agent_cfg[app_mode].vif.req.req_valid);
             cfg.clk_rst_vif.wait_clks($urandom_range(25, 250));
             issue_cmd(invalid_cmd);
             error_injected = 1;
@@ -221,7 +221,7 @@ class kmac_smoke_vseq extends kmac_base_vseq;
           // provided to an AppKeymgr operation that is in progress.
           if (kmac_err_type == kmac_pkg::ErrKeyNotValid) begin : check_invalid_key_err
             // wait until the first valid request is seen
-            wait (cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_req.req_valid);
+            wait (cfg.m_kmac_app_agent_cfg[app_mode].vif.req.req_valid);
             if (process_key_err_before_app_done) begin
               disable send_kmac_req;
               check_err();

--- a/hw/ip/kmac/dv/tb.sv
+++ b/hw/ip/kmac/dv/tb.sv
@@ -22,8 +22,10 @@ module tb;
   kmac_pkg::app_req_t [NUM_APP_INTF-1:0] app_req;
   kmac_pkg::app_rsp_t [NUM_APP_INTF-1:0] app_rsp;
 
-  // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
+  default clocking @(posedge clk); endclocking
+  default disable iff !rst_n;
+
   rst_shadowed_if rst_shadowed_if(.rst_n(rst_n), .rst_shadowed_n(rst_shadowed_n));
   kmac_if kmac_if(.clk_i(clk), .rst_ni(rst_n));
 
@@ -37,7 +39,31 @@ module tb;
     .sideload_key (kmac_sideload_key)
   );
 
-  kmac_app_if kmac_app_if[NUM_APP_INTF](.clk(clk), .rst_n(rst_n));
+  for (genvar i = 0; i < NUM_APP_INTF; i++) begin : gen_app_if
+    wire kmac_pkg::app_req_t req;
+    wire kmac_pkg::app_rsp_t rsp;
+
+    // In this testbench, the interface is in Host mode, meaning that it will drive req and consume
+    // rsp.
+    assign app_req[i] = req;
+    assign rsp = app_rsp[i];
+
+    kmac_app_if app_if(.clk_i (clk),
+                       .rst_ni(rst_n),
+                       .req   (req),
+                       .rsp   (rsp));
+
+    initial begin
+      uvm_config_db#(virtual kmac_app_if)::set(null,
+                                               $sformatf("*env.m_kmac_app_agent[%0d]*", i),
+                                               "vif",
+                                               app_if);
+    end
+
+    ErrOutputZeros_A:
+      assert property (rsp.error |-> rsp.digest_s0 == 0 && rsp.digest_s1 == 0)
+      else `ASSERT_ERROR(ErrOutputZeros_A)
+  end
 
   // edn_clk, edn_rst_n and edn_if is defined and driven in below macro
   `DV_EDN_IF_CONNECT
@@ -89,18 +115,6 @@ module tb;
     .entropy_o          (edn_if[0].req                     ),
     .entropy_i          ({edn_if[0].ack, edn_if[0].d_data} )
   );
-
-  for (genvar i = 0; i < NUM_APP_INTF; i++) begin : gen_kmac_app_if
-    assign app_req[i]                   = kmac_app_if[i].kmac_data_req;
-    assign kmac_app_if[i].kmac_data_rsp = app_rsp[i];
-    assign kmac_if.app_req[i] = app_req[i];
-    assign kmac_if.app_rsp[i] = app_rsp[i];
-
-    initial begin
-      uvm_config_db#(virtual kmac_app_if)::set(null,
-          $sformatf("*env.m_kmac_app_agent[%0d]*", i), "vif", kmac_app_if[i]);
-    end
-  end
 
   initial begin
     // drive clk and rst_n from clk_if

--- a/hw/ip/lc_ctrl/dv/tb.sv
+++ b/hw/ip/lc_ctrl/dv/tb.sv
@@ -85,16 +85,10 @@ module tb;
 
 
   // KMAC App agent hookup
-  kmac_pkg::app_rsp_t kmac_data_in;
-  kmac_pkg::app_req_t kmac_data_out;
-  assign kmac_data_in = kmac_app_if.kmac_data_rsp;
-  assign kmac_app_if.kmac_data_req = kmac_data_out;
+  wire kmac_pkg::app_rsp_t kmac_data_in;
+  wire kmac_pkg::app_req_t kmac_data_out;
 
-  // KMAC vip
-  kmac_app_if kmac_app_if (
-    .clk  (clk),
-    .rst_n(rst_n)
-  );
+  kmac_app_if kmac_app_if(.clk_i(clk), .rst_ni(rst_n), .req(kmac_data_out), .rsp(kmac_data_in));
 
   `DV_ALERT_IF_CONNECT()
 

--- a/hw/ip/rom_ctrl/dv/tb/tb.sv
+++ b/hw/ip/rom_ctrl/dv/tb/tb.sv
@@ -16,8 +16,8 @@ module tb;
 
   wire                        clk, rst_n;
   bit                         digest_cal_done;
-  kmac_pkg::app_rsp_t         kmac_data_in;
-  kmac_pkg::app_req_t         kmac_data_out;
+  wire kmac_pkg::app_rsp_t    kmac_data_in;
+  wire kmac_pkg::app_req_t    kmac_data_out;
   rom_ctrl_pkg::pwrmgr_data_t pwrmgr_data;
   rom_ctrl_pkg::keymgr_data_t keymgr_data;
   logic kmac_digest_handshake_occured;
@@ -27,13 +27,9 @@ module tb;
   clk_rst_if rom_clk_rst_if(.clk(), .rst_n()); // dummy clk_rst_vif for second RAL
   tl_if tl_rom_if(.clk(clk), .rst_n(rst_n));
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
-  kmac_app_if kmac_app_if(.clk(clk), .rst_n(rst_n));
+  kmac_app_if kmac_app_if(.clk_i(clk), .rst_ni(rst_n), .req (kmac_data_out), .rsp (kmac_data_in));
 
   `DV_ALERT_IF_CONNECT()
-
-  assign kmac_app_if.kmac_data_req = kmac_data_out;
-  assign kmac_data_in              = kmac_app_if.kmac_data_rsp;
-
 
   // dut
   rom_ctrl #(


### PR DESCRIPTION
This PR is in draft because it depends on:
- #30392
- #30394 

Once these two are merged, only a single commit remains, with the following commit message:

> **[kmac,dv] Pass req/rsp to kmac_app_if through inout ports**
> 
> This should be a little cleaner than the version we were using before.
