### PR TITLE
[crypto/ecc] Harden a2b and x25519

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc/curve25519.c
@@ -60,13 +60,13 @@ enum {
   /*
    * The expected instruction counts for constant time functions.
    */
-  kModeKeygenInsCnt = 342099,
-  kModeSignStage1InsCnt = 685167,
+  kModeKeygenInsCnt = 342100,
+  kModeSignStage1InsCnt = 685169,
   kModeSignStage2InsCnt = 662,
-  kModeX25519InsCnt = 366561,
-  kModeX25519SideloadInsCnt = 362932,
-  kModeX25519KeygenInsCnt = 359288,
-  kModeX25519KeygenSideloadInsCnt = 355659,
+  kModeX25519InsCnt = 366575,
+  kModeX25519SideloadInsCnt = 362940,
+  kModeX25519KeygenInsCnt = 359302,
+  kModeX25519KeygenSideloadInsCnt = 355667,
   kModeEd25519VerifyInsCnt = 332987,
 };
 

--- a/sw/device/tests/crypto/ecdh_p256_functest.c
+++ b/sw/device/tests/crypto/ecdh_p256_functest.c
@@ -81,6 +81,8 @@ status_t key_exchange_test(void) {
   // Generate a keypair.
   LOG_INFO("Generating keypair A...");
   TRY(otcrypto_ecdh_p256_keygen(&private_keyA, &public_keyA));
+  LOG_INFO("OTBN instruction count for keygen: 0x%08x",
+           otbn_instruction_count_get());
 
   // Generate a second keypair.
   LOG_INFO("Generating keypair B...");
@@ -107,6 +109,8 @@ status_t key_exchange_test(void) {
   // Compute the shared secret from A's side of the computation.
   LOG_INFO("Generating shared secret (A)...");
   TRY(otcrypto_ecdh_p256(&private_keyA, &public_keyB, &shared_keyA));
+  LOG_INFO("OTBN instruction count for ecdh: 0x%08x",
+           otbn_instruction_count_get());
 
   // Compute the shared secret from B's side of the computation.
   LOG_INFO("Generating shared secret (B)...");

--- a/sw/device/tests/crypto/ecdh_p256_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdh_p256_sideload_functest.c
@@ -98,6 +98,8 @@ status_t key_exchange_test(void) {
   // Generate a keypair.
   LOG_INFO("Generating keypair A...");
   TRY(otcrypto_ecdh_p256_keygen(&private_keyA, &public_keyA));
+  LOG_INFO("OTBN instruction count for keygen: 0x%08x",
+           otbn_instruction_count_get());
 
   // Generate a second keypair.
   LOG_INFO("Generating keypair B...");
@@ -126,6 +128,8 @@ status_t key_exchange_test(void) {
   // private key and B's public key).
   LOG_INFO("Generating shared secret (A)...");
   TRY(otcrypto_ecdh_p256(&private_keyA, &public_keyB, &shared_keyA));
+  LOG_INFO("OTBN instruction count for ecdh: 0x%08x",
+           otbn_instruction_count_get());
 
   // Compute the shared secret from B's side of the computation (using B's
   // private key and A's public key).

--- a/sw/otbn/crypto/25519.s
+++ b/sw/otbn/crypto/25519.s
@@ -1334,6 +1334,7 @@ ext_scmul_sca:
   bn.mov w3, w17
 
   /* [w5:w4] <= w4 + k * L = s1 + k' * L. */
+  bn.mov w20, w31 /* Clear the secret */
   bn.mov w20, w4
   jal x1, sc_blind
   bn.mov w4, w16

--- a/sw/otbn/crypto/run_curve25519.s
+++ b/sw/otbn/crypto/run_curve25519.s
@@ -80,6 +80,57 @@ start:
   unimp
 
 /**
+ * X25519 Wrapper for Arithmetic to Boolean Conversion.
+ * Assumes arithmetic shares are in w8 and w7.
+ */
+x25519_apply_a2b:
+  bn.add   w11, w8, w31
+  bn.xor   w31, w31, w31
+  bn.wsrr  w12, URND
+
+  bn.add   w18, w7, w31
+  bn.wsrr  w19, URND
+
+  addi     x5, x1, 0
+  jal      x1, arithmetic_to_boolean
+  addi     x1, x5, 0
+
+  bn.add   w8, w20, w31
+  bn.xor   w31, w31, w31
+  bn.add   w7, w18, w31
+
+  ret
+
+/**
+ * X25519 Wrapper for Boolean to Arithmetic Conversion.
+ * Assumes boolean shares are in w8 and w7.
+ * Returns the blinded recombined scalar in w2.
+ */
+x25519_apply_b2a:
+  bn.add   w20, w8, w31
+  bn.xor   w31, w31, w31
+  bn.wsrr  w21, URND
+
+  bn.add   w10, w7, w31
+  bn.wsrr  w11, URND
+
+  addi     x5, x1, 0
+  jal      x1, boolean_to_arithmetic
+  addi     x1, x5, 0
+
+  bn.wsrr  w4, URND
+  bn.rshi  w4, w31, w4 >> 1
+
+  bn.wsrw  MOD, w31
+  bn.addm  w5, w10, w4
+  bn.xor   w31, w31, w31
+
+  bn.addm  w2, w20, w5
+  bn.sub   w31, w31, w31, FG0
+
+  ret
+
+/**
  * Ed25519 key generation operation.
  * Generate the encoded public key A.
  *
@@ -202,53 +253,22 @@ run_x25519:
   la       x3, ed25519_s1
   bn.lid   x2, 0(x3)
 
-  /* A_lo = w8, A_hi = 0 */
-  bn.add   w11, w8, w31
-  bn.xor   w12, w31, w31
-
-  /* r_lo = w7, r_hi = 0 */
-  bn.add   w18, w7, w31
-  bn.xor   w19, w31, w31
-
-  /* Convert arithmetic shares to boolean shares */
-  jal      x1, arithmetic_to_boolean
-
-  /* x'_lo (w20) -> w8 (Share 0), r_lo (w18) -> w7 (Share 1) */
-  bn.add   w8, w20, w31
-  bn.add   w7, w18, w31
+  /* Execute full masked A2B sequence */
+  jal      x1, x25519_apply_a2b
 
   /* Clamp the boolean shares */
   jal      x1, x25519_clamp_shares
 
-  /* s0_lo = w8, s0_hi = 0 */
-  bn.add   w20, w8, w31
-  bn.xor   w21, w31, w31
-
-  /* s1_lo = w7, s1_hi = 0 */
-  bn.add   w10, w7, w31
-  bn.xor   w11, w31, w31
-
   /* Convert boolean shares back to arithmetic ones */
-  jal      x1, boolean_to_arithmetic
-
-  /* w4 = 254-bit random mask B */
-  bn.wsrr  w4, URND
-  bn.rshi  w4, w31, w4 >> 2
-
-  /* w5 = w10 + w4 (x1 + B) */
-  bn.add   w5, w10, w4
-  bn.xor   w31, w31, w31 /* clear flags */
-
-  /* w2 = w20 + w5 (x0 + x1 + B) */
-  bn.add   w2, w20, w5
-
-  /* Clear flags before jump */
-  bn.sub   w31, w31, w31, FG0
+  jal      x1, x25519_apply_b2a
 
   /* Load public key into w9 */
   li       x2, 9
   la       x3, x25519_public_key
   bn.lid   x2, 0(x3)
+
+  /* Generate fresh 256-bit random mask for projective coordinates */
+  bn.wsrr  w19, URND
 
   /* Call Edwards-mapped x25519 */
   jal      x1, x25519
@@ -301,51 +321,20 @@ run_x25519_keygen:
   la       x3, ed25519_s1
   bn.lid   x2, 0(x3)
 
-  /* A_lo = w8, A_hi = 0 */
-  bn.add w11, w8, w31
-  bn.xor w12, w31, w31
-
-  /* r_lo = w7, r_hi = 0 */
-  bn.add w18, w7, w31
-  bn.xor w19, w31, w31
-
   /* Convert arithmetic shares to boolean shares */
-  jal  x1, arithmetic_to_boolean
-
-  /* x'_lo (w20) -> w8 (Share 0), r_lo (w18) -> w7 (Share 1) */
-  bn.add   w8, w20, w31
-  bn.add   w7, w18, w31
+  jal x1, x25519_apply_a2b
 
   /* Clamp the boolean shares */
-  jal      x1, x25519_clamp_shares
-
-  /* s0_lo = w8, s0_hi = 0 */
-  bn.add w20, w8, w31
-  bn.xor w21, w31, w31
-
-  /* s1_lo = w7, s1_hi = 0 */
-  bn.add w10, w7, w31
-  bn.xor w11, w31, w31
+  jal x1, x25519_clamp_shares
 
   /* Convert boolean shares back to arithmetic ones */
-  jal x1, boolean_to_arithmetic
-
-  /* w4 = 254-bit random mask B */
-  bn.wsrr w4, URND
-  bn.rshi w4, w31, w4 >> 2
-
-  /* w5 = w10 + w4 (x1 + B) */
-  bn.add w5, w10, w4
-  bn.xor w31, w31, w31 /* clear flags */
-
-  /* w2 = w20 + w5 (x0 + x1 + B) */
-  bn.add w2, w20, w5
-
-  /* Clear flags before jump */
-  bn.sub w31, w31, w31, FG0
+  jal x1, x25519_apply_b2a
 
   /* Set Curve25519 basepoint */
   bn.addi  w9, w31, 9
+
+  /* Generate fresh 256-bit random mask for projective coordinates */
+  bn.wsrr  w19, URND
 
   jal      x1, x25519
 
@@ -385,35 +374,16 @@ run_x25519_sideload:
   /* Clamp the Boolean shares */
   jal x1, x25519_clamp_shares
 
-  /* s0_lo = w8, s0_hi = 0 */
-  bn.add w20, w8, w31
-  bn.xor w21, w31, w31
-
-  /* s1_lo = w7, s1_hi = 0 */
-  bn.add w10, w7, w31
-  bn.xor w11, w31, w31
-
   /* Convert boolean shares back to arithmetic ones */
-  jal x1, boolean_to_arithmetic
-
-  /* w4 = 254-bit random mask B */
-  bn.wsrr w4, URND
-  bn.rshi w4, w31, w4 >> 2
-
-  /* w5 = w10 + w4 (x1 + B) */
-  bn.add w5, w10, w4
-  bn.xor w31, w31, w31 /* clear flags */
-
-  /* w2 = w20 + w5 (x0 + x1 + B) */
-  bn.add w2, w20, w5
-
-  /* Clear flags before jump */
-  bn.sub w31, w31, w31, FG0
+  jal x1, x25519_apply_b2a
 
   /* Load public key into w9 */
   li x2, 9
   la x3, x25519_public_key
   bn.lid x2, 0(x3)
+
+  /* Generate fresh 256-bit random mask for projective coordinates */
+  bn.wsrr  w19, URND
 
   jal x1, x25519
 
@@ -463,33 +433,14 @@ run_x25519_keygen_sideload:
   /* Clamp the Boolean shares */
   jal x1, x25519_clamp_shares
 
-  /* s0_lo = w8, s0_hi = 0 */
-  bn.add w20, w8, w31
-  bn.xor w21, w31, w31
-
-  /* s1_lo = w7, s1_hi = 0 */
-  bn.add w10, w7, w31
-  bn.xor w11, w31, w31
-
   /* Convert boolean shares back to arithmetic ones */
-  jal x1, boolean_to_arithmetic
-
-  /* w4 = 254-bit random mask B */
-  bn.wsrr w4, URND
-  bn.rshi w4, w31, w4 >> 2
-
-  /* w5 = w10 + w4 (x1 + B) */
-  bn.add w5, w10, w4
-  bn.xor w31, w31, w31 /* clear flags */
-
-  /* w2 = w20 + w5 (x0 + x1 + B) */
-  bn.add w2, w20, w5
-
-  /* Clear flags before jump */
-  bn.sub w31, w31, w31, FG0
+  jal x1, x25519_apply_b2a
 
   /* Set Curve25519 basepoint */
   bn.addi w9, w31, 9
+
+  /* Generate fresh 256-bit random mask for projective coordinates */
+  bn.wsrr  w19, URND
 
   jal x1, x25519
 


### PR DESCRIPTION
From the tvla sim test results, harden x25519.
This mainly involves masking the carry in a2b.