### PR TITLE
[i3c] I3C block message buffer

### DIFF
--- a/hw/ip/i3c/dv/env/i3c_utils.svh
+++ b/hw/ip/i3c/dv/env/i3c_utils.svh
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// I3C Helper functions; behavioral implementations of I3C-related operations.
+//
+// - May be useful in constructing a proper DV test bench/environment.
+// - These are used within the basic IP test bench for now.
+
+// Calculate/update parity bits for HDR messages.
+function automatic bit [1:0] update_parity(bit data[], bit [1:0] parity = 2'b01);
+  // NOTE: This assumes that every block of bits supplied to the parity calculation
+  // has an even number of bits, except possibly the last.
+  for (int unsigned b = 0; b < data.size(); b++) begin
+    if (b[0]) parity[0] ^= data[b];
+    else parity[1] ^= data[b];
+  end
+  return parity;
+endfunction
+
+// Calculate/update a CRC-5 value
+function automatic bit [4:0] update_crc5(bit data[], bit [4:0] crc5 = 5'h1F);
+  for (int unsigned b = 0; b < data.size(); b++) begin
+    crc5 = {crc5[3:2], data[b] ^ crc5[4] ^ crc5[1], crc5[0], data[b] ^ crc5[4]};
+  end
+  return crc5;
+endfunction
+
+// Report the contents of a Device Address Table entry.
+function automatic void report_dat_entry(int unsigned idx, i3c_pkg::i3c_dat_entry_t dat);
+  $display("%02x: STAT_ADDR %02x IBI_PAYLOAD %d IBI_REJECT %d CRR_REJECT %d TS %d DYN_ADDR %02x",
+           idx, dat.static_address, dat.ibi_payload, dat.ibi_reject, dat.crr_reject, dat.ts,
+           dat.dynamic_address);
+  $display("    RING_ID %d NACK_RETRY_CNT %d I2C %d AUTOCMD_MASK %02x VALUE %02x MODE %d HDR %02x",
+           dat.ring_id, dat.dev_nack_retry_cnt, dat.device, dat.autocmd_mask, dat.autocmd_value,
+           dat.autocmd_mode, dat.autocmd_hdr_code);
+endfunction
+
+// Report the contents of a Device Characteristics Table entry.
+function automatic void report_dct_entry(int unsigned idx, i3c_pkg::i3c_dct_entry_t dct);
+  $display("%02x: PID %08x%04x DCR %02x BCR %02x DYN_ADDR %02x", idx,
+           dct.pid_hi, dct.pid_lo, dct.dcr, dct.bcr, dct.dynamic_address);
+endfunction

--- a/hw/ip/i3c/i3c.core
+++ b/hw/ip/i3c/i3c.core
@@ -1,0 +1,124 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:ip:i3c:0.1"
+description: "i3c"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:virtual_constants:top_pkg
+      - lowrisc:prim:all
+      - lowrisc:prim:ram_1p_pkg
+      - lowrisc:prim:ram_1p_adv
+      - lowrisc:ip:tlul
+      - lowrisc:ip:i3c_pkg
+      - lowrisc:virtual_constants:top_racl_pkg
+    files:
+      - rtl/i3c_async_event_pkg.sv
+      - rtl/i3c_ctrl_ccc_pkg.sv
+      - rtl/i3c_fifo_pkg.sv
+      - rtl/i3c_targ_ccc_pkg.sv
+      - rtl/i3c_timing_pkg.sv
+      - rtl/i3c_tti_pkg.sv
+      - rtl/buf_en.sv
+      - rtl/buf_inv_en.sv
+      - rtl/i3c_buffer.sv
+      - rtl/i3c_clock_buf_en.sv
+      - rtl/i3c_clock_inv_en.sv
+      - rtl/i3c_cmd_decode.sv
+      - rtl/i3c_controller_ccc.sv
+      - rtl/i3c_controller_fsm.sv
+      - rtl/i3c_controller_ibi.sv
+      - rtl/i3c_controller_state.sv
+      - rtl/i3c_controller.sv
+      - rtl/i3c_controller_trx.sv
+      - rtl/i3c_core.sv
+      - rtl/i3c_counters.sv
+      - rtl/i3c_dat_cache.sv
+      - rtl/i3c_dat.sv
+      - rtl/i3c_data_sink.sv
+      - rtl/i3c_dct.sv
+      - rtl/i3c_dword_collector.sv
+      - rtl/i3c_dword_splitter.sv
+      - rtl/i3c_dxt.sv
+      - rtl/i3c_hci_ibi.sv
+      - rtl/i3c_input_buffers.sv
+      - rtl/i3c_intr.sv
+      - rtl/i3c_patt_detector.sv
+      - rtl/i3c_phy.sv
+      - rtl/i3c_queues.sv
+      - rtl/i3c_reg_top.sv
+      - rtl/i3c_reset_detector.sv
+      - rtl/i3c_stby_cr_regs.sv
+      - rtl/i3c.sv
+      - rtl/i3c_sync_data.sv
+      - rtl/i3c_targ_async_events.sv
+      - rtl/i3c_target_ccc.sv
+      - rtl/i3c_target_fsm.sv
+      - rtl/i3c_target_rst.sv
+      - rtl/i3c_target.sv
+      - rtl/i3c_target_trx.sv
+      - rtl/i3c_targ_start_req.sv
+      - rtl/i3c_timers.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/i3c.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/i3c.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/i3c.vbl
+    file_type: veribleLintWaiver
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+
+targets:
+  default: &default_target
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl
+    toplevel: i3c
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+
+  syn:
+    <<: *default_target
+    default_tool: icarus
+    parameters:
+      - SYNTHESIS=true
+    toplevel: i3c

--- a/hw/ip/i3c/lint/i3c.vbl
+++ b/hw/ip/i3c/lint/i3c.vbl
@@ -1,0 +1,14 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for i3c
+
+# waive naming rules on a localparams that exist only because of overloaded
+# enumeration values
+waive --rule=parameter-name-style --location="i3c_consts_pkg.sv"
+# Line numbers are fragile; use a window for now.
+#waive --rule=parameter-name-style --line=130:170 --location="i3c_consts_pkg.sv:147"
+
+# waive long line violations in generated code
+waive --rule=line-length --location="i3c_reg_top.sv"

--- a/hw/ip/i3c/rtl/i3c_buffer.sv
+++ b/hw/ip/i3c/rtl/i3c_buffer.sv
@@ -1,0 +1,296 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// I3C buffer
+//
+// - This buffer implements a number of independent FIFOs as circular buffers
+//   within a single shared memory.
+// - Each FIFO is written by either (i) the processor, or (ii) the IP block hardware,
+//   and read by the other party.
+// - The size of each FIFO may be configured by software at start up, to adapt to
+//   different use cases and traffic expectations.
+// - Arbitration occurs amongst those requests, with accesses performed by the IP block hardware
+//   being treated as higher priority than processor accesses, oweing to the hard real-time nature
+//   of the I3C traffic.
+// - The direction of each FIFO is specified, so that hardware access may be prioritized.
+
+module i3c_buffer
+  import i3c_pkg::*;
+  import i3c_fifo_pkg::*;
+  import prim_ram_1p_pkg::*;
+#(
+  parameter int unsigned BufAddrW = 9,
+  parameter int unsigned DataWidth = 32,
+  parameter int unsigned NumFifos = 7,
+  // Indicates, for each FIFO in turn, whether the FIFO is used to transmit data over the I3C.
+  // - Tx FIFOs shall prioritize read prefetching over software writes into the FIFO.
+  parameter bit [NumFifos-1:0] DirTx = 0
+) (
+  input                     clk_i,
+  input                     rst_ni,
+  // Synchronous FIFO resets.
+  input                     sw_reset_i[NumFifos],
+  // FIFO configuration.
+  input  fifo_config_t      cfg_i[NumFifos],
+  // FIFO input signals.
+  input  fifo_in_t          in_i[NumFifos],
+  // FIFO output signals.
+  output fifo_out_t         out_o[NumFifos],
+  // Current FIFO state.
+  output fifo_state_t       state_o[NumFifos],
+
+  // Direct software interface to buffer.
+  input                     sw_buf_req_i,
+  output                    sw_buf_gnt_o,
+  input                     sw_buf_we_i,
+  input      [BufAddrW-1:0] sw_buf_addr_i,
+  input     [DataWidth-1:0] sw_buf_wdata_i,
+  output                    sw_buf_rvalid_o,
+  output              [1:0] sw_buf_rerror_o,
+  output    [DataWidth-1:0] sw_buf_rdata_o,
+
+  // DFT-related signals.
+  input  ram_1p_cfg_t       ram_cfg_i,
+  output ram_1p_cfg_rsp_t   ram_cfg_rsp_o
+);
+
+  // Use the arbiter to steer the appropriate inputs.
+  typedef struct packed {
+    logic                 write;
+    logic  [BufAddrW-1:0] addr;
+    logic [DataWidth-1:0] wdata;
+    // FIFO configuration used in address updating.
+    logic  [BufAddrW-1:0] min;
+    logic  [BufAddrW-1:0] max;
+  } arb_data_t;
+  localparam int unsigned ArbDataWidth = $bits(arb_data_t);
+
+  // Arbitration and granting also includes the `sw_buf` direct access at the MSB (lowest priority).
+  localparam int unsigned N = 1 + NumFifos;
+  localparam int unsigned IdxW = $clog2(N);
+
+  // Arbiter request inputs and grant outputs.
+  logic [NumFifos:0] req, gnt;
+  // Arbiter input data.
+  arb_data_t arb[N];
+
+  // Memory outputs.
+  logic                 mem_rvalid;
+  logic      [IdxW-1:0] mem_ridx;
+  logic           [1:0] mem_rerror;
+  logic [DataWidth-1:0] mem_rdata;
+
+  // Direct software access to the entire message buffer.
+  // - this may be useful diagnostically or for supporting a lower-level protocol; the parent
+  //   logic may strip out this access path by tying the inputs low.
+  always_comb begin
+    req[NumFifos]       = sw_buf_req_i;
+    arb[NumFifos].write = sw_buf_we_i;
+    arb[NumFifos].min   = '0;
+    arb[NumFifos].max   = '1;
+    arb[NumFifos].addr  = sw_buf_addr_i;
+    arb[NumFifos].wdata = sw_buf_wdata_i;
+  end
+  assign sw_buf_gnt_o    = gnt[NumFifos];
+  assign sw_buf_rvalid_o = mem_rvalid & (IdxW'(NumFifos) == mem_ridx);
+  assign sw_buf_rdata_o  = mem_rdata;
+  assign sw_buf_rerror_o = mem_rerror;
+
+  // A single read/write request may be performed to the message buffer per clock cycle; a single
+  // incrementer and multiplexer are required to update FIFO state.
+  logic [BufAddrW-1:0] next_addr;
+
+  for (genvar f = 0; f < NumFifos; f++) begin : gen_fifos
+    // Prefetched read data; a single word of read data may be held here, without removing it from
+    // the FIFO yet. The FIFO status is unaffected by whether or not data has been prefetched.
+    logic                 pre_rvalid;
+    logic [DataWidth-1:0] pre_rdata;
+
+    // Current state of the FIFO.
+    logic [BufAddrW-1:0] wptr;  // Write pointer.
+    logic [BufAddrW-1:0] pptr;  // Prefetching pointer.
+    logic [BufAddrW-1:0] rptr;  // Read pointer; lags prefetching pointer by one word, at times.
+    logic full, empty;
+    logic wreq, preq, wgnt, pgnt;
+    logic we, pe;
+    assign empty = (wptr == rptr) & !full;
+
+    // Calculate the number of used entries and the number of entries still available.
+    // - there are 3 pointers into the message buffer for each FIFO implementation:
+    //   - write pointer indicates where the next write shall occur.
+    //   - prefetch pointer indicates the next word to be prefetched from the buffer.
+    //   - read pointer indicates the next word to be consumed by the _external_ logic.
+    // - the external interface (`used`, `avail`, `free` and `empty) are in terms of the
+    //   read and write pointers, thus hiding the fact that prefetching may have occurred.
+    //   This ensures that the `used` and `avail` values remain within the expected dimensions
+    //   of the logical FIFO and avoid confusion. Even though - physically - it would be possible
+    //   to store 'depth + 1' words of data now, this would not conform to the HCI specification.
+    wire [BufAddrW:0] ptr_diff = wptr - rptr;
+    wire [BufAddrW:0] neg_diff = ~ptr_diff + 'b1;
+    wire [BufAddrW:0] left     = cfg_i[f].size + (ptr_diff[BufAddrW] ? ptr_diff : neg_diff);
+    wire [BufAddrW:0] used     = (ptr_diff[BufAddrW] | full) ? left : ptr_diff;
+    wire [BufAddrW:0] avail    = (ptr_diff[BufAddrW] | full) ? neg_diff : left;
+
+    // Generate status information for all clients at all times, and then when a request is received
+    // we arbitrate amongst those which actually CAN proceed.
+    wire prefetching = mem_rvalid & (IdxW'(f) == mem_ridx);
+    always_comb begin
+      // Response to FIFO write requests.
+      out_o[f].wready = wgnt;
+      // Response to FIFO read requests; read data comes from one of two sources:
+      // - we may already have the data prefetched (`pre_rvalid` and `pre_rdata`).
+      // - the memory may be returning it right now, in which case we may forward rather than
+      //   capture data.
+      out_o[f].rvalid = pre_rvalid | prefetching;
+      out_o[f].rdata  = pre_rvalid ? pre_rdata : mem_rdata;
+
+      // FIFO state for use by clients, reporting via the HCI registers, and interrupt generation.
+      state_o[f].full   = full;
+      state_o[f].empty  = empty;
+      state_o[f].used   = used;
+      state_o[f].avail  = avail;
+
+      // Internal state of the FIFO; it reflects the fact that we may have read a word from the
+      // FIFO by prefetching. It is presented only diagnostically in the register interface.
+      state_o[f].wptr = wptr;
+      state_o[f].rptr = rptr;
+      state_o[f].pre  = pre_rvalid;
+    end
+
+    // Prefetched read data, presenting a FIFO interface where the assertion of `rready` consumes
+    // the data rather than starting a read operation.
+    wire consume_rdata = out_o[f].rvalid & in_i[f].rready;
+    wire capt_rdata = &{mem_rvalid, (IdxW'(f) == mem_ridx), !in_i[f].rready};
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        pre_rvalid  <= 1'b0;
+        pre_rdata   <= '0;
+      end else if (sw_reset_i[f]) begin
+        pre_rvalid <= 1'b0;
+        // Reads by software from an empty queue/buffer cannot be prevented; just make the returned
+        // data predictable.
+        pre_rdata  <= '0;
+      end else begin
+        if (consume_rdata | capt_rdata) pre_rvalid <= capt_rdata;
+        // Capture the read data returned by the memory.
+        if (capt_rdata) pre_rdata <= mem_rdata;
+      end
+    end
+
+    // Read pointer advancement.
+    logic [BufAddrW-1:0] next_rptr;
+    assign next_rptr = (rptr == cfg_i[f].max) ? cfg_i[f].min : (rptr + 'b1);
+
+    // FIFO state.
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        wptr <= '0;
+        pptr <= '0;
+        rptr <= '0;
+        full <= 1'b0;
+      end else if (sw_reset_i[f]) begin
+        // Empty the FIFO.
+        wptr <= cfg_i[f].min;
+        pptr <= cfg_i[f].min;
+        rptr <= cfg_i[f].min;
+        full <= 1'b0;
+      end else begin
+        // Updating of write pointer and prefetching pointer.
+        if (wgnt) wptr <= next_addr;
+        if (pgnt) pptr <= next_addr;
+        // Updating of read pointer, and `FIFO full` indicator.
+        if (consume_rdata) rptr <= next_rptr;
+        if (wgnt | consume_rdata) full <= wreq & (next_addr == rptr);
+      end
+    end
+
+    // Is FIFO empty as far as prefetching is concerned?
+    wire pre_empty = (pptr == rptr) ? empty : (pptr == wptr);
+
+    always_comb begin
+      // Should this FIFO be performing a read and/or a write?
+      // - prefetching is initiated here.
+      pe = ((!pre_rvalid & !prefetching) | in_i[f].rready) & !pre_empty;
+      we = in_i[f].wvalid & !full;
+      // Whether read or write has priority over the other depends upon the direction of the FIFO.
+      preq = pe & (!we |  DirTx[f]);
+      wreq = we & (!pe | !DirTx[f]);
+      // Request to memory.
+      req[f]       = we | pe;
+      arb[f].write = wreq;
+      arb[f].min   = cfg_i[f].min;
+      arb[f].max   = cfg_i[f].max;
+      arb[f].addr  = wreq ? wptr : pptr;
+      arb[f].wdata = in_i[f].wdata;
+    end
+    // Only one operation may be granted per clock cycle.
+    assign wgnt = gnt[f] & wreq;
+    assign pgnt = gnt[f] & preq;
+  end
+
+  // After arbitration.
+  logic      mem_req;
+  arb_data_t mem_data;
+
+  // Absolute priority arbiter; index 0 has the highest priority.
+  // - for each FIFO we have already arbitrated above between a read request and a write request
+  //   in the event that they occur simultaneously.
+  logic [IdxW-1:0] idx;
+  prim_arbiter_fixed #(
+    .N    (N),
+    .DW   (ArbDataWidth)
+  ) u_arbiter (
+    .clk_i      (clk_i),
+    .rst_ni     (rst_ni),
+
+    .req_i      (req),
+    .data_i     (arb),
+    .gnt_o      (gnt),
+    .idx_o      (idx),
+
+    .valid_o    (mem_req),
+    .data_o     (mem_data),
+    .ready_i    (1'b1)
+  );
+
+  // Address advancement.
+  // - these two addresses are valid during the cycle in which the memory read/write is initiated.
+  assign next_addr = (mem_data.addr == mem_data.max) ? mem_data.min : (mem_data.addr + 'b1);
+
+  // Return the read data.
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      mem_ridx    <= '0;
+    end else begin
+      if (mem_req & ~mem_data.write) mem_ridx <= idx;  // Assumes single-cycle latency to read data.
+    end
+  end
+
+  // SRAM Wrapper
+  prim_ram_1p_adv #(
+    .Depth                (BufWords),
+    .Width                (DataWidth),
+    .DataBitsPerMask      (DataWidth),
+    .EnableECC            (0), // No Protection
+    .EnableParity         (0),
+    .EnableInputPipeline  (0),
+    .EnableOutputPipeline (0)
+  ) u_buf (
+    .clk_i,
+    .rst_ni,
+
+    .req_i    (mem_req),
+    .write_i  (mem_data.write),
+    .addr_i   (mem_data.addr),
+    .wdata_i  (mem_data.wdata),
+    .wmask_i  ('1),
+    .rdata_o  (mem_rdata),
+    .rvalid_o (mem_rvalid),
+    .rerror_o (mem_rerror),
+    .cfg_i    (ram_cfg_i),
+    .cfg_rsp_o(ram_cfg_rsp_o),
+    .alert_o  ()
+  );
+
+endmodule

--- a/hw/ip/i3c/rtl/i3c_consts_pkg.sv
+++ b/hw/ip/i3c/rtl/i3c_consts_pkg.sv
@@ -1,0 +1,229 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Constants defined by the I3C Specifications rather than this IP block.
+package i3c_consts_pkg;
+
+  // Special I3C Addresses
+  typedef enum logic [6:0] {
+    Addr_MinimalBus = 7'h01,  // Target on Minimal Bus
+    Addr_Broadcast  = 7'h7e   // I3C Broadcast Address
+  } i3c_addr_e;
+
+  // Common Command Codes
+  typedef enum logic [7:0] {
+    // Broadcast
+    ENECB     = 8'h00,  // Enable Events Command
+    DISECB    = 8'h01,  // Disable Events Command
+
+    ENTAS0B   = 8'h02,  // Enter Activity State 0
+    ENTAS1B   = 8'h03,  // Enter Activity State 1
+    ENTAS2B   = 8'h04,  // Enter Activity State 2
+    ENTAS3B   = 8'h05,  // Enter Activity State 3
+
+    RSTDAA    = 8'h06,  // Reset Dynamic Address Assignment
+    ENTDAA    = 8'h07,  // Enter Dynamic Address Assignment
+    DEFTGTS   = 8'h08,  // Define List of Targets
+    SETMWLB   = 8'h09,  // Set Max Write Length
+    SETMRLB   = 8'h0a,  // Set Max Read Length
+    ENTTM     = 8'h0b,  // Enter Test Mode
+
+    ENTHDR0   = 8'h20,  // Enter HDR Mode 0
+    ENTHDR1   = 8'h21,  // Enter HDR Mode 1
+    ENTHDR2   = 8'h22,  // Enter HDR Mode 2
+    ENTHDR3   = 8'h23,  // Enter HDR Mode 3
+    ENTHDR4   = 8'h24,  // Enter HDR Mode 4
+    ENTHDR5   = 8'h25,  // Enter HDR Mode 5
+    ENTHDR6   = 8'h26,  // Enter HDR Mode 6
+    ENTHDR7   = 8'h27,  // Enter HDR Mode 7
+
+    SETAASA   = 8'h29,  // Set All Addresses to Static Addresses
+    RSTACTB   = 8'h2a,  // Target Reset Action
+    DEFGRPA   = 8'h2b,  // Define List of Group Addresses
+    RSTGRPAB  = 8'h2c,  // Reset Group Address
+    MLANEB    = 8'h2d,  // Multi-Lane Data Transfer Control
+
+    // Directed
+    ENEC      = 8'h80,  // Enable Events Command
+    DISEC     = 8'h81,  // Disable Events Command
+
+    ENTAS0    = 8'h82,  // Enter Activity State 0
+    ENTAS1    = 8'h83,  // Enter Activity State 1
+    ENTAS2    = 8'h84,  // Enter Activity State 2
+    ENTAS3    = 8'h85,  // Enter Activity State 3
+
+    SETDASA   = 8'h87,  // Set Dynamic Address from Static Address
+    SETNEWDA  = 8'h88,  // Set New Dynamic Address
+    SETMWL    = 8'h89,  // Set Max Write Length
+    SETMRL    = 8'h8a,  // Set Max Read Length
+    GETMWL    = 8'h8b,  // Get Max Write Length
+    GETMRL    = 8'h8c,  // Get Max Read Length
+    GETPID    = 8'h8d,  // Get Provisioned ID
+    GETBCR    = 8'h8e,  // Get Bus Characteristics Register
+    GETDCR    = 8'h8f,  // Get Device Characteristics Register
+    GETSTATUS = 8'h90,  // Get Device Status
+    GETACCCR  = 8'h91,  // Get Accept Controller Role
+    ENDXFER   = 8'h92,  // Data Transfer Ending Procedure Control
+
+    GETMXDS   = 8'h94,  // Get Max Data Speed
+    GETCAPS   = 8'h95,  // Get Optional Feature Capabilities
+    SETROUTE  = 8'h96,  // Set Route
+
+    SETXTIME  = 8'h98,  // Set Exchange Timing Information
+    GETXTIME  = 8'h99,  // Get Exchange Timing Information
+
+    RSTACT    = 8'h9a,  // Target Reset Action
+    SETGRPA   = 8'h9b,  // Set Group Address
+    RSTGRPA   = 8'h9c,  // Reset Group Address
+    MLANE     = 8'h9d   // Multi-Lane Data Transfer Control
+  } i3c_ccc_e;
+
+  // RSTACT Defining Byte Values (5.1.9.3.26)
+  typedef enum logic [7:0] {
+    RstAct_NoReset         = 8'h00, // No Reset on Target Reset Pattern.
+    RstAct_ResetPeripheral = 8'h01, // Reset the I3C Peripheral Only.
+    RstAct_ResetTarget     = 8'h02, // Reset the Whole Target.
+    RstAct_DebugNetReset   = 8'h03, // Debug Network Adapter Reset.
+    RstAct_VirtualTargDet  = 8'h04, // Virtual Target Detect.
+    RstAct_ResetPeriphTime = 8'h81, // Return Time to Reset Peripheral.
+    RstAct_ResetTargetTime = 8'h82, // Return Time to Reset Whole Target.
+    RstAct_ResetDbgNetTime = 8'h83, // Return Time for Debug Network Adapter Reset.
+    RstAct_VirtTargIndican = 8'h84  // Return Virtual Target Indication.
+  } i3c_rstact_e;
+
+  // I3C Transfer Mode (TCRI 7.1.1.1)
+  typedef enum logic [2:0] {
+    XferMode_SDR0       = 3'h0,  // 12.5 MHz maximum sustainable data rate.
+    XferMode_SDR1       = 3'h1,  // 8 MHz
+    XferMode_SDR2       = 3'h2,  // 6 MHz
+    XferMode_SDR3       = 3'h3,  // 4 MHz
+    XferMode_SDR4       = 3'h4,  // 2 MHz
+    XferMode_HDRTernary = 3'h5,
+    XferMode_HDRDDR     = 3'h6
+  } i3c_xfer_mode_e;
+
+  // I2C Transfer Mode (TCRI 7.1.1.1)
+  typedef enum logic [2:0] {
+    XferMode_I2CFM      = 3'h0,  // 400 kHz maximum sustainable data rate.
+    XferMode_I2CFMPlus  = 3'h1,  // 1 MHz
+    XferMode_I2CUDR1    = 3'h2,  // User Defined Data Rate 1
+    XferMode_I2CUDR2    = 3'h3,
+    XferMode_I2CUDR3    = 3'h4
+  } i2c_xfer_mode_e;
+
+  // CMD_ATTR field of Command Descriptor (TCRI 7.1.2)
+  typedef enum logic [2:0] {
+    CmdAttr_RegTransfer    = 3'h0,
+    CmdAttr_ImmTransfer    = 3'h1,
+    CmdAttr_AddrAssignment = 3'h2,
+    CmdAttr_ComboTransfer  = 3'h3,
+    CmdAttr_InternalCtrl   = 3'h7
+  } i3c_cmd_attr_e;
+
+  // Error Status Codes (TCRI 6.4.1)
+  typedef enum logic [3:0] {
+    ErrStatus_OK = 4'h0,
+    ErrStatus_CRC,
+    ErrStatus_Parity,
+    ErrStatus_Frame,
+    ErrStatus_AddrHeader,
+    ErrStatus_NACK,
+    ErrStatus_OVL,
+    ErrStatus_I3CShortReadErr,
+    ErrStatus_HCAborted,
+    ErrStatus_BusAborted = 4'h9,  // Overloaded; see below for I2C traffic.
+    ErrStatus_NotSupported,
+    ErrStatus_AbortedWithCRC,
+
+    // The following are Transfer Type Specific (Combo Transfers).
+    ErrStatus_ComboNACK2nd = 4'hC,   // Overloaded below; transfer-type specific.
+    ErrStatus_ComboBusAborted2nd
+  } i3c_err_status_e;
+
+  // This value is overloaded, having different meanings for I2C and I3C transfers.
+  localparam i3c_err_status_e ErrStatus_I2cWrDataNack = i3c_err_status_e'(4'h9);
+  // This value is overloaded, being Transfer Type Specific (TCRI 6.4.1.12).
+  localparam i3c_err_status_e ErrStatus_CccFramingNotEnded = i3c_err_status_e'(4'hC);
+
+  // IBI Status Types (HCI 8.6)
+  typedef enum logic [2:0] {
+    IBIStatus_Regular       = 3'b000,
+    IBIStatus_CreditAck     = 3'b001,
+    IBIStatus_ScheduledCmd  = 3'b010,
+    IBIStatus_AutoCmdRead   = 3'b100,
+    IBIStatus_StbyCrBastCCC = 3'b111
+  } i3c_ibi_status_e;
+
+  // Host Controller Secondary Controller enable (HCI 7.7.11.1)
+  typedef enum logic [1:0] {
+    StbyCrEn_Disabled = 2'b00,
+    StbyCrEn_ACMInit,
+    StbyCrEn_SCMRunning,
+    StbyCrEn_SCMHotJoin
+  } i3c_stby_cr_en_init_e;
+
+  // Present State Debug (HCI 7.7.7.3)
+  // Bus Controller Logic Transfer State
+  typedef enum logic [5:0] {
+    BCLState_Idle = 6'h0,
+    BCLState_Start,
+    BCLState_Restart,
+    BCLState_Stop,
+    BCLState_StartHold,
+    BCLState_BcastWrite,
+    BCLState_BcastRead,
+    BCLState_DAA,
+    BCLState_Addr,
+    BCLState_CCC = 6'hB,
+    BCLState_HDR,
+    BCLState_Wr,
+    BCLState_Rd,
+    BCLState_IBIAdrRead,
+    BCLState_IBIDis,
+    BCLState_HDRDDRCRC,
+    BCLState_ClockExt,
+    BCLState_Halt,
+    BCLState_IBIRead
+  } i3c_bcl_tfr_ststat_e;
+
+  typedef enum logic [5:0] {
+    BCLStatus_Idle = 6'h0,
+    BCLStatus_BcastWrite,
+    BCLStatus_TargetWrite,
+    BCLStatus_TargetRead,
+    BCLStatus_EntDAA,
+    BCLStatus_SetDASA,
+    BCLStatus_I3CSDRWrite,
+    BCLStatus_I3CSDRRead,
+    BCLStatus_I2CSDRWrite,
+    BCLStatus_I2CSDRRead,
+    // Ternary states not required.
+    BCLStatus_HDRDDRWrite = 6'hC,
+    BCLStatus_HDRDDRRead,
+    BCLStatus_IBI,
+    BCLStatus_Halted
+  } i3c_bcl_tfr_status_e;
+
+  // MIPI Alliance Command (HCI 8.4.2, Table 135).
+  typedef enum logic [3:0] {
+    MIPICmd_NoOp = 4'h0,
+    MIPICmd_RingBundleLock,
+    MIPICmd_BroadAddrEnable,
+    MIPICmd_DevCtxUpdate,
+    MIPICmd_TargRstPattern,
+    MIPICmd_CtrlSDARecovery,
+    MIPICmd_EndXferHDR,
+    MIPICmd_CtrlHandoff,
+    MIPICmd_AttemptDBR = 4'hD
+  } i3c_mipi_cmd_e;
+
+  // Target Reset Operation Type (HCI 8.4.2.4)
+  typedef enum logic [1:0] {
+    RstOpType_Single = 2'b00,
+    RstOpType_Reserved,
+    RstOpType_RSTACC,
+    RstOpType_Leave
+  } i3c_reset_op_type_e;
+
+endpackage

--- a/hw/ip/i3c/rtl/i3c_fifo_pkg.sv
+++ b/hw/ip/i3c/rtl/i3c_fifo_pkg.sv
@@ -1,0 +1,110 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// FIFO-related constants and structure descriptions.
+//
+// - The Host Controller Interface specification employs a number of FIFOs and this I3C block
+//   implements all of those FIFOs using a single shared message buffer.
+// - Each of the FIFOs carries data words that are 32 bits in width and are referred to as `DWORD`s.
+// - The OpenTitan TTI mimics the HCI to a significant degree and its FIFOs share the same message
+//   buffer.
+// - The FIFOs are:
+//
+//   Controller side:
+//   - Command Queue  - carries 2-DWORD command descriptors.
+//   - Response Queue - carries 1-DWORD response descriptors.
+//   - IBI Queue      - carries In-Band Interrupt data.
+//   - IBI Stat Desc  - carries 1-DWORD IBI Status Descriptors.
+//   - TX Buffer      - carries data for transmission over the I3C bus.
+//   - RX Buffer      - carries data received over the I3C bus.
+//
+//   Target side:
+//   - Targ Txi Buffers - carries data for transmission over the I3C bus, for each Virtual Target.
+//   - Targ Txi Descs   - descriptors for transmitted data, for each Virtual Target.
+//   - Targ IBI Data    - In-Band interrupt payload from all Virtual Targets combined.
+//   - Targ IBI Desc    - descriptors for IBI transmission.
+//   - Targ Rx Buffer   - carries data received over the I3C bus.
+//   - Targ Rx Descs    - descriptors for received data.
+//   - Targ Async Evt   - Asynchronous Events to be reported to software.
+//
+// - Read data will be presented, with `rvalid` asserted, as soon as it becomes available,
+//   and is removed from the FIFO in the presence of `rvalid & rready`.
+// - Write data is accepted into the FIFO only when `wvalid & wready`, with `wready` denoting
+//   the availability of space.
+// - Read data is presented combinationally, so the message buffer and the immediately-associated
+//   reader/writer logic are expected to be operating synchronously on the main clock of the IP
+//   block.
+
+package i3c_fifo_pkg;
+  // Width of offsets and the `base index` of the FIFO within the shared memory.
+  // (FIFO fill level and available space are also derived from this parameter.)
+  localparam int unsigned DepthW = i3c_pkg::BufAddrW;
+
+  // Data width of FIFO, in bits.
+  localparam int unsigned Width = 32;
+
+  // FIFO identifier.
+  // - Note: index 0 is highest priority at the arbiter in `i3c_buffer`.
+  typedef enum {
+    FIFO_TxTarg0   = 0,   // Target 0 transmission buffer.
+    FIFO_TxTarg1   = 1,   // Target 1 transmission buffer.
+    FIFO_TxBuf     = 2,   // Controller transmission buffer.
+    FIFO_IBITarg   = 3,   // IBI Payload, Targets.
+    FIFO_RxTarg    = 4,   // Targets' reception buffer.
+    FIFO_RxBuf     = 5,   // Controller reception buffer.
+    FIFO_IBIQ      = 6,   // IBI Data Queue within the Controller.
+    FIFO_IBIStD    = 7,   // IBI Status Descriptor FIFO within the Controller.
+    FIFO_RspQ      = 8,   // Response Queue, Controller.
+    FIFO_CmdQ      = 9,   // Command Queue, Controller.
+    FIFO_TxDTarg0  = 10,  // Transmission Descriptor, Target 0.
+    FIFO_TxDTarg1  = 11,  // Transmission Descriptor, Target 1.
+    FIFO_RxDTarg   = 12,  // Reception Descriptor, Targets.
+    FIFO_IBIDTarg  = 13,  // IBI Descriptor, Targets.
+    FIFO_AsyncTarg = 14,  // Asynchronous Events Queue, Targets.
+    // Number of FIFOs.
+    FIFO_Count
+  } fifo_id_e;
+
+  // FIFO configuration.
+  typedef struct packed {
+    logic  [DepthW-1:0] min;  // Base address of the FIFO within the shared memory.
+    logic  [DepthW-1:0] max;  // End address, inclusive.
+    logic    [DepthW:0] size; // Size of the FIFO, in DWORD entries.
+  } fifo_config_t;
+
+  // FIFO state information.
+  // - `wptr` and `rptr` are both in the range [0, BufWords)
+  typedef struct packed {
+    logic  [DepthW-1:0] wptr;   // Current write pointer within buffer.
+    logic  [DepthW-1:0] rptr;   // Current read pointer within buffer.
+    logic               full;   // Disambiguates the `wptr == rptr` case.
+    logic               empty;  // Convenience, but may be derived from the above.
+    logic    [DepthW:0] used;   // Number of used entries.
+    logic    [DepthW:0] avail;  // Number of available entries.
+    logic               pre;    // Prefetched data is available; for diagnostic use only.
+  } fifo_state_t;
+
+  // FIFO input signals to the `i3c_buffer` module.
+  typedef struct packed {
+    // Read/write requests.
+    logic             rready;  // Consume read data when available.
+    logic             wvalid;  // Perform write when space available.
+    logic [Width-1:0] wdata;   // Data to be written.
+  } fifo_in_t;
+
+  // FIFO output signals from the `i3c_buffer` module.
+  typedef struct packed {
+    // Responses to read/write requests.
+    logic             wready;
+    logic             rvalid;
+    logic [Width-1:0] rdata;
+  } fifo_out_t;
+
+  // Convenience function that returns the size of the FIFO in DWORD entries; this is not supplied
+  // in the register configuration but is instead derived from the programmed min/max bounds.
+  function automatic bit [DepthW-1:0] fifo_size(input fifo_config_t cfg);
+    return DepthW'(cfg.max - cfg.min) + 'b1;
+  endfunction
+
+endpackage

--- a/hw/ip/i3c/rtl/i3c_queues.sv
+++ b/hw/ip/i3c/rtl/i3c_queues.sv
@@ -1,0 +1,121 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A single SRAM-style interface implements multiple logical queues at successive word addresses.
+// - HCI queues: Command Queue, Response Queue, Data Transfer Buffer, IBI Queue.
+// - TTI queues: TxN buffer, Rx buffer, TxN Desc Queue, Rx Desc Queue, IBI Buffer and Desc Queue,
+//               Async Event Queue.
+
+module i3c_queues
+#(
+  // The number of logical queues implemented by this SRAM interface.
+  parameter int unsigned NumQueues = 4,
+  // Data width, in bits.
+  parameter int unsigned DataWidth = 32,
+  // Indicates, for each queue in turn, whether writing by software is supported.
+  parameter bit [NumQueues-1:0] SupportTx = '1,
+  // Indicates, for each queue in turn, whether reading by software is supported.
+  // - most of the queues in both the HCI and the TTI are unidirectional, with the exception
+  //   being `TL_XferBuf` for example, which maps to both the Tx Data buffer and the Rx Data Buffer.
+  parameter bit [NumQueues-1:0] SupportRx = '1,
+
+  // Derived parameters.
+  localparam int unsigned AddrWidth = $clog2(NumQueues)  // The number of address bits.
+) (
+  // Clock and reset.
+  input                         clk_i,
+  input                         rst_ni,
+
+  // Single SRAM interface (e.g. `tlul_adapter_sram`).
+  input                         req_i,
+  output logic                  gnt_o,
+  input                         we_i,
+  input         [AddrWidth-1:0] addr_i,
+  input         [DataWidth-1:0] wdata_i,
+  output logic                  rvalid_o,
+  output logic  [DataWidth-1:0] rdata_o,
+
+  // Writes to logical queues.
+  input                         buf_wready_i[NumQueues],
+  input                         buf_full_i[NumQueues],
+  output logic                  buf_wvalid_o[NumQueues],
+  output logic  [DataWidth-1:0] buf_wdata_o,
+
+  // Reads from logical queues.
+  input                         buf_rvalid_i[NumQueues],
+  input         [DataWidth-1:0] buf_rdata_i[NumQueues],
+  input                         buf_empty_i[NumQueues],
+  output logic                  buf_rready_o[NumQueues],
+
+  // Diagnostic error indicator.
+  output                        err_o
+);
+
+  // A read from an empty queue will be more apparent if we return all '1's rather than zeros.
+  // localparam logic [DataWidth-1:0] NoRData = '1;
+  // TODO: This is a development aid; replace with the above at some point.
+  localparam logic [DataWidth-1:0] NoRData = 32'hdece_a5ed;
+
+  // Read operations from logical queues.
+  logic [NumQueues-1:0] gnt_rd;
+  logic [NumQueues-1:0] re;
+  logic rd_empty_error;
+  always_comb begin : reads
+    rd_empty_error = 1'b0;
+    for (int unsigned q = 0; q < NumQueues; q++) begin
+      re[q] = req_i & (addr_i == q) & !we_i;
+      // Assert read request iff the queue is not empty, and block until arbitration is won
+      // and read data is available. Normally there will be prefetched data already available.
+      buf_rready_o[q] = re[q] & !buf_empty_i[q] & SupportRx[q];
+      // Can the read proceed?
+      // - reads also proceed by returning data when the queue is empty or reading is unsupported.
+      gnt_rd[q] = re[q] & (buf_rvalid_i[q] | buf_empty_i[q] | !SupportRx[q]);
+      // Report `read when empty` condition.
+      rd_empty_error |= re[q] & (buf_empty_i[q] | !SupportRx[q]);
+    end
+  end
+
+  // Write operations into logical queues.
+  logic [NumQueues-1:0] gnt_wr;
+  logic [NumQueues-1:0] we;
+  logic wr_full_error;
+  always_comb begin : writes
+    wr_full_error = 1'b0;
+    for (int unsigned q = 0; q < NumQueues; q++) begin
+      we[q] = req_i & (addr_i == q) & we_i;
+      // Assert write request iff the queue is not full, and block until arbitration is won
+      // and the write data is accepted.
+      buf_wvalid_o[q] = we[q] & !buf_full_i[q] & SupportTx[q];
+      // Can the write proceed?
+      // - writes proceed with no effect when the queue is full or writes are unsupported.
+      gnt_wr[q] = we[q] & (buf_wready_i[q] | buf_full_i[q] | !SupportTx[q]);
+      // Report `write when full` condition.
+      wr_full_error |= we[q] & (buf_full_i[q] | !SupportTx[q]);
+    end
+    // Write data is just forwarded to all write paths.
+    buf_wdata_o = wdata_i;
+  end
+
+  // Granting of requests.
+  assign gnt_o = |{gnt_rd, gnt_wr};
+
+  // Read data from logical queues.
+  wire rvalid = |gnt_rd;
+  wire rdata_valid = &{addr_i < NumQueues, buf_rvalid_i[addr_i], SupportRx[addr_i]};
+  wire [DataWidth-1:0] rdata = rdata_valid ? buf_rdata_i[addr_i] : NoRData;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rvalid_o  <= 1'b0;
+      rdata_o   <= '0;
+    end else begin
+      rvalid_o  <= rvalid;
+      if (rvalid) rdata_o <= rdata;
+    end
+  end
+
+  // Error output for diagnostic use, in the event of software error.
+  assign err_o = wr_full_error | rd_empty_error;
+
+endmodule


### PR DESCRIPTION
The single-port SRAM message buffer which implements all of the logical FIFOs of the HCI (Controller side), and the OT TTI (Target side).

Access to the message buffer from the TL-UL side is mediated through two instances of the 'i3c_queues' module, each implementing multiple word-sized ports. One provides the HCI queues/buffers and the other is for the TTI.

Also included are some simply utility functions that are presently used within the IP test bench and may be useful in the UVM DV environment, and a package defining standard constants from the various I3C specifications.

[Draft of top level may help provide context](https://github.com/lowRISC/opentitan/pull/30732)