### PR TITLE
[kmac, app interface] Clarify FIFO usage and remove XOF support for SHA3 and KMAC

### DIFF
--- a/hw/ip/kmac/doc/theory_of_operation.md
+++ b/hw/ip/kmac/doc/theory_of_operation.md
@@ -289,10 +289,10 @@ These configuration values are left to the SW as setting these requires system s
 The image below depicts the message data path and its related control signals.
 ![](../doc/kmac-data-path.svg)
 
-The compile-time parameter `EnMasking` and the static parameter `masked` control whether the message FIFO is used or bypassed.
-The FIFO is used unless `EnMasking` and `masked` are both set in which case the FIFO is bypassed.
+The static parameter `masked` controls whether the message FIFO is used or bypassed.
+The FIFO is used unless `masked` is set in which case the FIFO is bypassed.
 
-For both types of interface, messages other than the last are sent using the full width of the `data_s0` / `data_s1` width.
+If the FIFO is bypassed, messages other than the last must be sent using the full width of the `data_s0` / `data_s1` width.
 See the operation principle section for more details about the last message.
 
 Although the message requests make full use of the `data_s0` / `data_s1` signal width (`MsgWidth`), the returned digest size depends on the interface's `if_type`.
@@ -335,11 +335,11 @@ If the configuration is valid, the message requests are forwarded to the hashing
 This engine then starts absorbing, depending on the hashing mode, the key and the prefix data.
 Afterwards it starts absorbing messages from the app interface.
 
-An app must send the full message split up into message requests which make use of the full width.
+If `masked` is set (FIFO bypassed), an app must send the full message split up into message requests which make use of the full width.
 This means `strb` must be all ones.
 An exception is the last message part, which can be less than the full width of the interface.
 Sending this last message part is closely related to how the message phase is ended.
-There are two ways for an app to terminate the message phase.
+Independent of `masked`, there are two ways for an app to terminate the message phase.
 In both cases there must be at most one request which has `req_last` asserted.
 
 - Termination on the last data beat

--- a/hw/ip/kmac/doc/theory_of_operation.md
+++ b/hw/ip/kmac/doc/theory_of_operation.md
@@ -266,7 +266,7 @@ Note that the output length for a KMAC operation is the same as the `digest_sx` 
 | `prefix_mode`   | Static   | The `prefix_mode` determines whether to take the prefix from the CSR or use the hardcoded prefix. For static interfaces, if `prefix_mode` is 1, the `prefix` will be used for both cSHAKE and KMAC operations. If 0, the CSR value is used. For dynamic interfaces, `prefix_mode` has no effect. Independently of the value, if the `mode` is cSHAKE, the CSR prefix is used. If the mode is KMAC, the compile-time value is used. |
 | `mode`          | Session  | The hashing mode which is performed. |
 | `kstrength`     | Session  | The strength of the selected `mode`. Not to be confused with the output length of a hashing operation. |
-| `en_xof`        | Session  | If 1, the app interface will automatically trigger a RUN command once it has pushed the full rate on the response channel. If 0, no squeeze can be performed at all. Usually enabled for SHAKE and cSHAKE and disabled for SHA3 and KMAC. Has no effect on static interfaces. |
+| `en_xof`        | Session  | If 1, the app interface will automatically trigger a RUN command once it has pushed the full rate on the response channel. If 0, no squeeze can be performed at all. Only applicable to SHAKE and cSHAKE. Must be 0 for a dynamic interface if `mode` is SHA3 or KMAC. Must always be 0 if the interface is static. |
 
 The session configuration is sent as the first message request and the configuration values are read from `data_s0` as defined by the struct `app_ses_config_t`.
 
@@ -307,7 +307,10 @@ For SHA3, the number of responses is `Strength / DynAppDigestW = Strength / 64`.
 Note, for SHA3-224 this does not divide properly.
 As such, the interface sends back 4 responses where the last one contains some bits which must be ignored.
 
-For SHAKE, cSHAKE and KMAC the standard defines the `StateWidth` to be 1600 bits (Same as SHA3) and these algorithms produce `StateWidth - 2 * Strength` bits of digest per squeeze.
+For KMAC the requested output length is fixed to `AppDigestW` bits.
+Therefore, the interface sends back `AppDigestW / DynAppDigestW = 384 / 64 = 6` responses.
+
+For SHAKE and cSHAKE the standard defines the `StateWidth` to be 1600 bits (Same as SHA3) and these algorithms produce `StateWidth - 2 * Strength` bits of digest per squeeze.
 A dynamic app interface then returns this digest data in `(StateWidth - 2 * Strength) / DynAppDigestW` responses.
 For example, when performing a SHAKE128 operation, the interface sends `(1600 - 2*128) / 64 = 21` response beats before it triggers a RUN command.
 
@@ -366,13 +369,13 @@ For a static app, one full digest is sent (handshaked) and the app interface ret
 
 For a dynamic app, the interface starts to push the full rate of the hashing operation in `DynAppDigestW` sized responses.
 The app can exert back pressure on the response channel to control how fast it consumes the digest data.
-If `en_xof` is false, the operation is complete once the full digest has been sent.
+If `en_xof` is false or the `mode` is SHA3 or KMAC (no XOF support for SHA3 or KMAC), the operation is complete once the full digest / the requested output length has been sent.
 The interface will just wait for a termination request.
 If `en_xof` is true, the interface automatically sends a RUN command to the hashing engine after sending the first full digest.
 It then waits until the new digest is available and begins to push responses again.
 After each full digest is sent, the interface will send another RUN command to the hashing engine and repeat.
 
-When the app has received the desired amount of responses, it should send another "message" request with the `req_last` signal asserted.
+When the app has received the desired amount of responses, it should send another "message" request with the `req_last` signal asserted (the actual message is irrelevant).
 This termination request tells the interface to stop sending digest responses and it will issue a DONE command to the hashing engine.
 One final finish response (`rsp_finish=1`) is sent to the app to acknowledge the end of the session.
 Once the app has sent the termination request it must make sure to drain the (pipelined) response channel until the finish response is received.
@@ -405,7 +408,7 @@ StAppProcess --> StAppWait
 
 StAppWait --> StAppPushDigest: Digest available
 
-StAppPushDigest --> StAppWait:   DYN && digest pushed && en_xof
+StAppPushDigest --> StAppWait:   DYN && digest pushed && en_xof && mode != {SHA3, KMAC}
 StAppPushDigest --> StAppFinish: STATIC && first digest part pushed
 StAppPushDigest --> StAppFinish: DYN && termination request
 

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -381,6 +381,7 @@ module kmac_app
   logic valid_app_kmac_cfg;
   logic valid_app_mode_strength_raw;
   logic valid_app_mode_strength;
+  logic valid_en_xof_cfg;
   logic valid_app_cfg;
 
   assign valid_app_sha3_strength = app_cfg.session_cfg.kstrength inside {sha3_pkg::L224,
@@ -399,15 +400,20 @@ module kmac_app
   // Ignore the mode and strength check if app allows unsupported combinations.
   assign valid_app_mode_strength = valid_app_mode_strength_raw || app_cfg.en_unsup_comb;
 
-  assign valid_app_kmac_cfg = prim_mubi_pkg::mubi4_test_true_strict(entropy_ready_i);
+  assign valid_app_kmac_cfg = app_cfg.session_cfg.mode == AppKMAC ?
+                              prim_mubi_pkg::mubi4_test_true_strict(entropy_ready_i) : 1'b1;
 
-  assign valid_app_cfg = valid_app_mode_strength &&
-                         (app_cfg.session_cfg.mode == AppKMAC ? valid_app_kmac_cfg : 1'b1);
+  // XOF operation is not supported for SHA3 or KMAC.
+  assign valid_en_xof_cfg = app_cfg.session_cfg.mode inside {AppSHA3, AppKMAC} ?
+                            app_cfg.session_cfg.en_xof == 1'b0 : 1'b1;
 
-  // A compile-time defined configuration must always result in a valid mode-strength
+  assign valid_app_cfg = valid_app_mode_strength && valid_en_xof_cfg && valid_app_kmac_cfg;
+
+  // A compile-time defined configuration must always result in a valid mode-strength and en_xof
   // configuration.
   `ASSERT(ConfigAlwaysValidIfStatic_A,
-          app_active_o && app_cfg.if_type == AppStatic |-> valid_app_mode_strength)
+          app_active_o && app_cfg.if_type == AppStatic
+          |-> valid_app_mode_strength && valid_en_xof_cfg)
 
   /////////////////////////////
   // Application Mux / Demux //
@@ -1151,16 +1157,19 @@ module kmac_app
       end
       sha3_pkg::Shake,
       sha3_pkg::CShake: begin
-        // Expose the full rate for SHAKE, cSHAKE and KMAC. It is save to expose the full rate of
-        // KMAC even if it exceeds the encoded output length.
-        unique case (keccak_strength_q)
-          sha3_pkg::L128: digest_top = DigestCntW'((sha3_pkg::StateW - 2 * 128) / DynAppDigestW);
-          sha3_pkg::L224: digest_top = DigestCntW'((sha3_pkg::StateW - 2 * 224) / DynAppDigestW);
-          sha3_pkg::L256: digest_top = DigestCntW'((sha3_pkg::StateW - 2 * 256) / DynAppDigestW);
-          sha3_pkg::L384: digest_top = DigestCntW'((sha3_pkg::StateW - 2 * 384) / DynAppDigestW);
-          sha3_pkg::L512: digest_top = DigestCntW'((sha3_pkg::StateW - 2 * 512) / DynAppDigestW);
-          default:        digest_top = DigestCntW'((sha3_pkg::StateW - 2 * 512) / DynAppDigestW);
-        endcase
+        // Expose the requested output length for KMAC. Expose the full rate for SHAKE and cSHAKE.
+        if (kmac_en_q) begin
+          digest_top = AppDigestW / DynAppDigestW;
+        end else begin
+          unique case (keccak_strength_q)
+            sha3_pkg::L128: digest_top = DigestCntW'((sha3_pkg::StateW - 2 * 128) / DynAppDigestW);
+            sha3_pkg::L224: digest_top = DigestCntW'((sha3_pkg::StateW - 2 * 224) / DynAppDigestW);
+            sha3_pkg::L256: digest_top = DigestCntW'((sha3_pkg::StateW - 2 * 256) / DynAppDigestW);
+            sha3_pkg::L384: digest_top = DigestCntW'((sha3_pkg::StateW - 2 * 384) / DynAppDigestW);
+            sha3_pkg::L512: digest_top = DigestCntW'((sha3_pkg::StateW - 2 * 512) / DynAppDigestW);
+            default:        digest_top = DigestCntW'((sha3_pkg::StateW - 2 * 512) / DynAppDigestW);
+          endcase
+        end
       end
       default: digest_top = DigestCntW'(128 / DynAppDigestW);
     endcase
@@ -1195,7 +1204,9 @@ module kmac_app
 
   // Only allow a squeeze if the app allows it.
   logic squeeze_again_allowed;
-  assign squeeze_again_allowed = app_cfg.if_type == AppDynamic && app_cfg.session_cfg.en_xof;
+  assign squeeze_again_allowed = app_cfg.if_type == AppDynamic && app_cfg.session_cfg.en_xof &&
+                                 app_cfg.session_cfg.mode != AppSHA3                         &&
+                                 app_cfg.session_cfg.mode != AppKMAC;
 
   // Request a squeeze once we are out of digest parts.
   assign squeeze_again = squeeze_again_allowed && !digest_parts_available;

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -232,8 +232,9 @@ package kmac_pkg;
 
     // If 1, the app interface will automatically trigger a RUN command once it has pushed the
     // full rate on the response channel. If 0, no squeeze can be performed at all and only the
-    // first rate is pushed. Usually enabled for SHAKE and cSHAKE and disabled for SHA3 and KMAC.
-    // Has no effect on static interfaces.
+    // first rate is pushed. Only applicable to SHAKE and cSHAKE. Must be 0 for a dynamic interface
+    // if mode is SHA3 or KMAC. Must always be 0 if the interface is static. Results in a service
+    // rejected error if set wrongly.
     logic en_xof;
   } app_ses_config_t;
 

--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -496,7 +496,7 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
             <tr>
               <td>0</td>
               <td>
-                EN_XOF enables the eXtendable Output Function (XOF) operation. If 1, XOF operation is enabled and the KMAC HWIP will automatically trigger a RUN command once the full rate has been pushed. If 0, KMAC HWIP will only push the first rate, and no other digest will be produced. Usually enabled for SHAKE and cSHAKE and disabled for SHA3 and KMAC modes.
+                EN_XOF enables the eXtendable Output Function (XOF) operation for SHAKE and cSHAKE modes. If 1, XOF operation is enabled and the KMAC HWIP will automatically trigger a RUN command once the full rate has been pushed. If 0, KMAC HWIP will only push the first rate, and no other digest will be produced. Must be 0 if MODE is SHA3 or KMAC. The SHA3 and KMAC modes only return the digest / the requested output length (fixed by KMAC HWIP).
               </td>
             </tr>
             <tr>

--- a/hw/ip/otbn/data/csr.yml
+++ b/hw/ip/otbn/data/csr.yml
@@ -150,10 +150,11 @@
     For a configuration to be valid, the upper fields must contain the bitwise inverted value of the lower fields.
   bits:
     0: |
-      EN_XOF enables the eXtendable Output Function (XOF) operation.
+      EN_XOF enables the eXtendable Output Function (XOF) operation for SHAKE and cSHAKE modes.
       If 1, XOF operation is enabled and the KMAC HWIP will automatically trigger a RUN command once the full rate has been pushed.
       If 0, KMAC HWIP will only push the first rate, and no other digest will be produced.
-      Usually enabled for SHAKE and cSHAKE and disabled for SHA3 and KMAC modes.
+      Must be 0 if MODE is SHA3 or KMAC.
+      The SHA3 and KMAC modes only return the digest / the requested output length (fixed by KMAC HWIP).
     3-1: |
       STRENGTH defines the security strength of the operation.
       Valid values are L128, L224, L256, L384, and L512.

--- a/hw/ip/otbn/doc/theory_of_operation.md
+++ b/hw/ip/otbn/doc/theory_of_operation.md
@@ -654,13 +654,23 @@ After issuing the `PROCESS` command, OTBN software thus must do the following:
 
 The number of digest parts pushed by the app interface depends on the selected mode, strength and XOF setting.
 
-If `KMAC_CFG.EN_XOF = 0`, the KMAC HWIP pushes only the digest parts that make up the first rate (the actual digest only), i.e., it pushes `roundup(digest_width / 64)` responses.
+For SHA3 and KMAC, `KMAC_CFG.EN_XOF` must 0 and the interface pushes only the SHA3 digest or the requested output length for KMAC.
+The requested output length of KMAC is fixed by the KMAC HWIP to 384 bits.
+For SHA3 it pushes `roundup(digest_width / 64)` responses.
+For KMAC it pushes `384 / 64 = 9` responses.
+Once these are pushed, the interface waits for a `DONE` command as explained [below](#ending-a-session).
+
+If the mode is SHAKE or cSHAKE, `KMAC_CFG.EN_XOF` controls whether the KMAC HWIP automatically issues RUN commands.
+If `KMAC_CFG.EN_XOF = 0`, the KMAC HWIP pushes only the digest parts that make up the first rate.
 Once these are pushed, the interface waits for a `DONE` command as explained [below](#ending-a-session).
 
 If `KMAC_CFG.EN_XOF = 1`, the KMAC HWIP pushes infinite responses.
 For this it automatically squeezes more digest by issuing a KMAC HWIP internal `RUN` command each time it finishes pushing one full rate.
 As soon as the squeezing has finished, the app starts again to push the new rate towards OTBN.
 When the OTBN software has received enough XOF output, the session can be terminated as explained [below](#ending-a-session).
+
+For SHAKE and cSHAKE the number of responses per rate depends on the strength and can be computed with (The `StateWidth` is defined by NIST FIPS-202 to be 1600):
+`#Responses = (StateWidth - 2 * Strength) / 64 = (1600 - 2 * Strength) / 64`.
 
 ###### Optimizing the digest retrieval
 The KMAC hashing operation is fully deterministic and thus the polling until `KMAC_STATUS.RSP_VALID = 1` can be optimized.


### PR DESCRIPTION
This clarifies when the FIFO is used and thus when partial message beats are allowed or not.

This removes XOF support for the SHA3 and KMAC modes. The reason are that:
- The SHA3 standard does not specify XOF operation.
- The KMAC XOF operation requires to set the output length to 0. But the KMAC HWIP has this output length hardcoded to 384 bits (the full response width). Thus the KMAC-XOF operation would not adhere to the standard. I removed the support for this.