### PR TITLE
[crypto/25519] Harden ed25519 verify against FI

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc/curve25519.c
@@ -67,6 +67,7 @@ enum {
   kModeX25519SideloadInsCnt = 362932,
   kModeX25519KeygenInsCnt = 359288,
   kModeX25519KeygenSideloadInsCnt = 355659,
+  kModeEd25519VerifyInsCnt = 332987,
 };
 
 /**
@@ -297,6 +298,7 @@ status_t curve25519_verify_finalize(hardened_bool_t *result) {
     return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_CHECK_EQ(ok, kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(otbn_instruction_count_get(), kModeEd25519VerifyInsCnt);
 
   // Read the computed LHS and RHS out of OTBN dmem.
   uint32_t lhs[kCurve25519PointWords];
@@ -307,6 +309,19 @@ status_t curve25519_verify_finalize(hardened_bool_t *result) {
   const otbn_addr_t kOtbnVarVerifyRhs =
       OTBN_ADDR_T_INIT(run_curve25519, ed25519_verify_rhs);
   HARDENED_TRY(otbn_dmem_read(kCurve25519PointWords, kOtbnVarVerifyRhs, rhs));
+
+  // The output rhs should not be zero
+  size_t i = 0;
+  uint32_t rhs_bits_or = 0;
+  for (; launder32(i) < kCurve25519PointWords; ++i) {
+    rhs_bits_or |= rhs[i];
+  }
+  HARDENED_CHECK_EQ(i, kCurve25519PointWords);
+  if (launder32(rhs_bits_or) == 0) {
+    HARDENED_TRY(otbn_dmem_sec_wipe());
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_NE(rhs_bits_or, 0);
 
   *result = hardened_memeq(lhs, rhs, kCurve25519PointWords);
 

--- a/sw/device/tests/crypto/ed25519_functest.c
+++ b/sw/device/tests/crypto/ed25519_functest.c
@@ -234,6 +234,8 @@ static status_t hasheddsa_test(void) {
   CHECK_STATUS_OK(otcrypto_ed25519_verify(
       &public_key, &input_message, kOtcryptoEddsaSignModeHashEddsa,
       &signature_verif, &verification_result));
+  LOG_INFO("OTBN verify instruction count: 0x%08x",
+           otbn_instruction_count_get());
 
   TRY_CHECK(verification_result == kHardenedBoolTrue);
 

--- a/sw/otbn/crypto/25519.s
+++ b/sw/otbn/crypto/25519.s
@@ -241,8 +241,10 @@ ed25519_verify_var:
        [w17:w16] <= k */
   li       x2, 16
   la       x3, ed25519_hash_k
-  bn.lid   x2, 0(x3++)
+  bn.lid   x2, 0(x3)
   addi     x2, x2, 1
+  la       x3, ed25519_hash_k /* load it again for redundancy */
+  addi     x3, x3, 32
   bn.lid   x2, 0(x3)
 
   /* Reduce k modulo L.
@@ -339,6 +341,7 @@ ed25519_verify_var:
   jal      x1, affine_to_ext
 
   /* w28 <= w3 = (8 * k) mod L */
+  bn.wsrr  w28, URND /* pre-randomize */
   bn.mov   w28, w3
 
   /* [w13:w10] <= w28 * [w9:w6] = [8][k]A */
@@ -349,6 +352,14 @@ ed25519_verify_var:
   bn.mov   w6, w4
   bn.mov   w7, w5
   jal      x1, affine_to_ext
+
+  /* Check if [8][k]A is the identity point.
+     If [8][k]A = O, its X-coordinate (w10) is 0 mod p. */
+  bn.cmp   w10, w31
+  csrrs    x2, FG0, x0
+  andi     x2, x2, 8
+  li       x3, 8
+  beq      x2, x3, verify_fail
 
   /* Store the intermediate result [8][k]A for later.
        [w5:w2] <= [w13:w10] = [8][k]A */


### PR DESCRIPTION
Protect ed25519 verify further against fault attacks. Ed25519 is constant time when no error is launched, hence check its instruction count.
Perform a quick check on 8kA.
Perform quick spot fixes such as loading the hash address twice. Reject when the RHS is zero similar to the r check in ecdsa.