### PR TITLE
[rtl] RRAM otp hw plug

### DIFF
--- a/hw/ip/rram_ctrl/data/rram_ctrl.hjson
+++ b/hw/ip/rram_ctrl/data/rram_ctrl.hjson
@@ -1293,24 +1293,6 @@
         ]
       }
 
-      { name: "PHY_ALERT_CFG",
-        desc: "Phy alert configuration",
-        swaccess: "rw",
-        hwaccess: "hro",
-        fields: [
-          { bits: "0",
-            name: "alert_ack",
-            desc: "Acknowledge RRAM phy alert"
-          },
-          { bits: "1",
-            name: "alert_trig",
-            desc: "Trigger RRAM phy alert"
-          }
-        ]
-        tags: [ // alert triggers should be tested by directed tests
-               "excl:CsrAllTests:CsrExclWrite"]
-      },
-
       { name: "PHY_STATUS",
         desc: "RRAM Phy Status",
         swaccess: "ro",

--- a/hw/ip/rram_ctrl/lint/rram_ctrl.waiver
+++ b/hw/ip/rram_ctrl/lint/rram_ctrl.waiver
@@ -3,3 +3,21 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # waiver file for rram_ctrl
+
+# OTP read/write loops in rram_ctrl_otp.sv use otp_size_q as the loop bound
+# and (otp_off_q + k) * OtpWidth as the index.  These constructs are conservative
+# Ascent Lint rules; modern synthesisers handle variable bounds and variable
+# part-selects correctly.  The OTP controller guarantees otp_size_q <= 3 and
+# (otp_off_q + otp_size_q) <= DataWidth/OtpWidth - 1, so no out-of-range access
+# can occur in practice.
+waive -rules {FOR_LOOP_BOUNDS} -location {rram_ctrl_otp.sv} \
+      -regexp {Loop termination value 'otp_size_q' is not a constant} \
+      -comment "otp_size_q is a 2-bit signal bounded by the OTP ctrl protocol; variable loop bound is intentional."
+
+waive -rules {LOOP_VAR_OP} -location {rram_ctrl_otp.sv} \
+      -regexp {otp_off_q.*OtpWidth} \
+      -comment "Part-select index (otp_off_q + k) * OtpWidth is bounded by the OTP ctrl protocol; variable indexing is intentional."
+
+waive -rules {VAR_INDEX_RANGE} -location {rram_ctrl_otp.sv} \
+      -regexp {otp_off_q.*OtpWidth.*maximum value.*rram_word} \
+      -comment "Static range analysis is pessimistic; OTP ctrl guarantees (otp_off_q + otp_size_q) * OtpWidth < DataWidth."

--- a/hw/ip/rram_ctrl/rram_ctrl.core
+++ b/hw/ip/rram_ctrl/rram_ctrl.core
@@ -27,6 +27,7 @@ filesets:
       - rtl/rram_ctrl_rd.sv
       - rtl/rram_ctrl_arb.sv
       - rtl/rram_ctrl_lcmgr.sv
+      - rtl/rram_ctrl_otp.sv
       - rtl/rram_ctrl_region_cfg.sv
       - rtl/rram_ctrl_mp_region_sel.sv
       - rtl/rram_ctrl_mp.sv

--- a/hw/ip/rram_ctrl/rtl/rram_ctrl.sv
+++ b/hw/ip/rram_ctrl/rtl/rram_ctrl.sv
@@ -233,6 +233,7 @@ module rram_ctrl
   logic                    phy_ctrl_wr;
   logic                    phy_ctrl_ecc_en;
   logic                    phy_ctrl_scramble_en;
+  logic                    phy_ctrl_addr_xor_en;
   logic                    phy_ctrl_wr_done;
   logic                    phy_ctrl_rd_err;
   logic                    phy_ctrl_rd_done;
@@ -647,6 +648,8 @@ module rram_ctrl
   ///////////////////
   // OTP_HW_ACCESS //
   ///////////////////
+  // OTP reads raw data without address infection
+  assign hw_otp_rdata = phy_ctrl_rd_data;
 
   rram_ctrl_otp u_rram_ctrl_otp (
     .clk_i,
@@ -726,7 +729,6 @@ module rram_ctrl
     // hw-otp read interface
     .hw_otp_rready_i  (hw_otp_rready),
     .hw_otp_rvalid_o  (hw_otp_rvalid),
-    .hw_otp_rdata_o   (hw_otp_rdata),
     // Arbiter interface to wr/rd handler
     .ctrl_part_o      (ctrl_part),
     .ctrl_num_words_o (ctrl_num_words),
@@ -968,6 +970,7 @@ module rram_ctrl
     .ctrl_wr_o          (phy_ctrl_wr),
     .ctrl_scramble_en_o (phy_ctrl_scramble_en),
     .ctrl_ecc_en_o      (phy_ctrl_ecc_en),
+    .ctrl_addr_xor_en_o (phy_ctrl_addr_xor_en),
     .ctrl_rd_done_i     (phy_ctrl_rd_done),
     .ctrl_wr_done_i     (phy_ctrl_wr_done),
     // Interface signals to/from rram_phy (host)
@@ -1001,6 +1004,7 @@ module rram_ctrl
     .ctrl_req_i        (phy_ctrl_req),
     .ctrl_scramble_en_i(phy_ctrl_scramble_en),
     .ctrl_ecc_en_i     (phy_ctrl_ecc_en),
+    .ctrl_addr_xor_en_i(phy_ctrl_addr_xor_en),
     .ctrl_rd_i         (phy_ctrl_rd),
     .ctrl_wr_i         (phy_ctrl_wr),
     .ctrl_part_i       (ctrl_part),

--- a/hw/ip/rram_ctrl/rtl/rram_ctrl.sv
+++ b/hw/ip/rram_ctrl/rtl/rram_ctrl.sv
@@ -92,7 +92,6 @@ module rram_ctrl
   import prim_mubi_pkg::mubi4_t;
   import prim_mubi_pkg::MuBi4False;
   import prim_mubi_pkg::MuBi4True;
-  import lc_ctrl_pkg::lc_tx_test_true_strict;
 
   ////////////////////////////
   // Localparam definitions //
@@ -296,6 +295,11 @@ module rram_ctrl
     .hw2reg    (hw2reg),
     .intg_err_o(intg_err)
   );
+  // Unused bits
+  logic [top_pkg::TL_DW-1:0] unused_scratch;
+
+  // Unused signals
+  assign unused_scratch = reg2hw.scratch.q;
 
   assign hw2reg.ctrl_regwen.d = (sw_sel | hw_loopback_sel) ? ~reg2hw.control.start.q : 1'b1;
 

--- a/hw/ip/rram_ctrl/rtl/rram_ctrl.sv
+++ b/hw/ip/rram_ctrl/rtl/rram_ctrl.sv
@@ -203,6 +203,8 @@ module rram_ctrl
   logic                          hw_otp_rready;
   logic                          hw_otp_rvalid;
   logic [BusFullWidth-1:0]       hw_otp_rdata;
+  logic                          otp_err;
+  logic                          otp_intg_err;
 
   // Arbiter signals
   rram_sel_e                if_sel;
@@ -295,7 +297,6 @@ module rram_ctrl
     .intg_err_o(intg_err)
   );
 
-  // todo connect in future commits:
   assign hw2reg.ctrl_regwen.d = (sw_sel | hw_loopback_sel) ? ~reg2hw.control.start.q : 1'b1;
 
   assign hw2reg.control.start.d  = 1'b0;
@@ -346,13 +347,13 @@ module rram_ctrl
   assign hw2reg.fault_status.lcmgr_wr_err.d     = 1'b1;
   assign hw2reg.fault_status.lcmgr_wr_err.de    = hw_lcmgr_err.wr_err;
   assign hw2reg.fault_status.otp_op_err.d       = 1'b1;
-  assign hw2reg.fault_status.otp_op_err.de      = 1'b0;
+  assign hw2reg.fault_status.otp_op_err.de      = hw_otp_err.invalid_op_err;
   assign hw2reg.fault_status.otp_mp_err.d       = 1'b1;
-  assign hw2reg.fault_status.otp_mp_err.de      = 1'b0;
+  assign hw2reg.fault_status.otp_mp_err.de      = hw_otp_err.mp_err;
   assign hw2reg.fault_status.otp_rd_err.d       = 1'b1;
-  assign hw2reg.fault_status.otp_rd_err.de      = 1'b0;
+  assign hw2reg.fault_status.otp_rd_err.de      = hw_otp_err.rd_err;
   assign hw2reg.fault_status.otp_wr_err.d       = 1'b1;
-  assign hw2reg.fault_status.otp_wr_err.de      = 1'b0;
+  assign hw2reg.fault_status.otp_wr_err.de      = hw_otp_err.wr_err;
   assign hw2reg.fault_status.seed_err.d         = 1'b1;
   assign hw2reg.fault_status.seed_err.de        = lcmgr_seed_err;
   assign hw2reg.fault_status.phy_relbl_err.d    = 1'b1;
@@ -369,16 +370,16 @@ module rram_ctrl
   // Standard faults - things like FSM / counter / tlul integrity
   assign hw2reg.std_fault_status.reg_intg_err.d     = 1'b1;
   assign hw2reg.std_fault_status.reg_intg_err.de    = intg_err | host_intg_err |
-                                                     tl_gate_intg_err | tl_wr_gate_intg_err |
-                                                     rd_fifo_adapter_intg_err;
+                                                      tl_gate_intg_err | tl_wr_gate_intg_err |
+                                                      rd_fifo_adapter_intg_err;
   assign hw2reg.std_fault_status.lcmgr_err.d        = 1'b1;
   assign hw2reg.std_fault_status.lcmgr_err.de       = lcmgr_err;
   assign hw2reg.std_fault_status.lcmgr_intg_err.d   = 1'b1;
   assign hw2reg.std_fault_status.lcmgr_intg_err.de  = lcmgr_intg_err;
   assign hw2reg.std_fault_status.otp_err.d          = 1'b1;
-  assign hw2reg.std_fault_status.otp_err.de         = 1'b0;
+  assign hw2reg.std_fault_status.otp_err.de         = otp_err;
   assign hw2reg.std_fault_status.otp_intg_err.d     = 1'b1;
-  assign hw2reg.std_fault_status.otp_intg_err.de    = 1'b0;
+  assign hw2reg.std_fault_status.otp_intg_err.de    = otp_intg_err;
   assign hw2reg.std_fault_status.phy_wr_intg_err.d  = 1'b1;
   assign hw2reg.std_fault_status.phy_wr_intg_err.de = phy_wr_intg_err;
   assign hw2reg.std_fault_status.phy_fifo_err.d     = 1'b1;
@@ -402,8 +403,8 @@ module rram_ctrl
   assign hw2reg.corr_err_loc.part.d  = logic'(phy_ecc_corr_part);
   assign hw2reg.corr_err_loc.part.de = phy_ecc_corr_err;
   // corr_err_cnt is saturating
-  assign hw2reg.corr_err_cnt.d       =  &reg2hw.corr_err_cnt.q ? reg2hw.corr_err_cnt.q :
-                                                                 reg2hw.corr_err_cnt.q + 1'b1;
+  assign hw2reg.corr_err_cnt.d       = &reg2hw.corr_err_cnt.q ? reg2hw.corr_err_cnt.q :
+                                                                reg2hw.corr_err_cnt.q + 1'b1;
   assign hw2reg.corr_err_cnt.de = phy_ecc_corr_err;
 
   // Phy status
@@ -642,21 +643,36 @@ module rram_ctrl
   ///////////////////
   // OTP_HW_ACCESS //
   ///////////////////
-  // todo add rram_ctrl_otp
-  assign otp_macro_o.ready  = 1'b0;
-  assign otp_macro_o.rvalid = 1'b0;
-  assign otp_macro_o.rdata  = '0;
-  assign otp_macro_o.err    = otp_ctrl_macro_pkg::NoError;
 
-  assign hw_otp_req              = 1'b0;
-  assign hw_otp_ctrl.start.q     = 1'b0;
-  assign hw_otp_ctrl.op.q        = RramOpRead;
-  assign hw_otp_ctrl.partition.q = RramPartData;
-  assign hw_otp_ctrl.num.q       = 0;
-  assign hw_otp_addr             = '0;
-  assign hw_otp_rready           = 1'b0;
-  assign hw_otp_wvalid           = 1'b0;
-  assign hw_otp_wdata            = '0;
+  rram_ctrl_otp u_rram_ctrl_otp (
+    .clk_i,
+    .rst_ni,
+    .clk_otp_i,
+    .rst_otp_ni,
+    // OTP macro interface (otp clock)
+    .otp_macro_req_i (otp_macro_i),
+    .otp_macro_rsp_o (otp_macro_o),
+    // Control arbiter interface
+    .ctrl_o          (hw_otp_ctrl),
+    .req_o           (hw_otp_req),
+    .addr_o          (hw_otp_addr),
+    .done_i          (hw_otp_done),
+    .err_i           (hw_otp_err),
+    // Read interface
+    .rready_o        (hw_otp_rready),
+    .rvalid_i        (hw_otp_rvalid),
+    .rdata_i         (hw_otp_rdata),
+    // Write interface
+    .wvalid_o        (hw_otp_wvalid),
+    .wready_i        (hw_otp_wready),
+    .wdata_o         (hw_otp_wdata),
+    // Error and status
+    .fatal_err_o     (otp_err),
+    .intg_err_o      (otp_intg_err),
+    .rram_init_done_i(phy_init_done),
+    .rram_wr_busy_i  (phy_wr_busy)
+
+  );
 
   ///////////////////////
   // SW/HW ARBITRATION //
@@ -1324,6 +1340,12 @@ module rram_ctrl
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(LcCtrlFsmCheck_A, u_rram_ctrl_lcmgr.u_state_regs,
                                        alert_tx_o[1])
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(LcCtrlRmaFsmCheck_A, u_rram_ctrl_lcmgr.u_rma_state_regs,
+                                       alert_tx_o[1])
+
+
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(OtpCntBusWordCheck_A, u_rram_ctrl_otp.u_bus_wcnt,
+                                         alert_tx_o[1])
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(OtpFsmCheck_A, u_rram_ctrl_otp.u_state_regs,
                                        alert_tx_o[1])
 
   // rram_phy assertions

--- a/hw/ip/rram_ctrl/rtl/rram_ctrl_arb.sv
+++ b/hw/ip/rram_ctrl/rtl/rram_ctrl_arb.sv
@@ -55,7 +55,6 @@ import rram_ctrl_reg_pkg::rram_ctrl_reg2hw_control_reg_t;
   output logic                          hw_otp_wready_o,
   // hw-otp read interface
   input  logic                          hw_otp_rready_i,
-  output logic [BusFullWidth-1:0]       hw_otp_rdata_o,
   output logic                          hw_otp_rvalid_o,
   // Control to wr/rd handler
   output rram_part_e                    ctrl_part_o,
@@ -290,7 +289,6 @@ import rram_ctrl_reg_pkg::rram_ctrl_reg2hw_control_reg_t;
 
     hw_otp_done_o   = '0;
     hw_otp_err_o    = '0;
-    hw_otp_rdata_o  = '0;
     hw_otp_rvalid_o = '0;
 
     hw_lcmgr_done_o   = '0;
@@ -314,7 +312,6 @@ import rram_ctrl_reg_pkg::rram_ctrl_reg2hw_control_reg_t;
         hw_otp_done_o   = ctrl_done;
         hw_otp_err_o    = ctrl_err;
         hw_otp_rvalid_o = rd_ctrl_rvalid_i;
-        hw_otp_rdata_o  = rd_ctrl_rdata_i;
 
         // fifo related muxing
         hw_otp_wready_o  = wr_fifo_wready_i;

--- a/hw/ip/rram_ctrl/rtl/rram_ctrl_core_reg_top.sv
+++ b/hw/ip/rram_ctrl/rtl/rram_ctrl_core_reg_top.sv
@@ -57,9 +57,9 @@ module rram_ctrl_core_reg_top (
 
   // also check for spurious write enables
   logic reg_we_err;
-  logic [65:0] reg_we_check;
+  logic [64:0] reg_we_check;
   prim_reg_we_check #(
-    .OneHotWidth(66)
+    .OneHotWidth(65)
   ) u_prim_reg_we_check (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
@@ -130,8 +130,8 @@ module rram_ctrl_core_reg_top (
   // Create steering logic
   always_comb begin
     reg_steer =
-        tl_i.a_address[AW-1:0] inside {[264:267]} ? 2'd0 :
-        tl_i.a_address[AW-1:0] inside {[268:271]} ? 2'd1 :
+        tl_i.a_address[AW-1:0] inside {[260:263]} ? 2'd0 :
+        tl_i.a_address[AW-1:0] inside {[264:267]} ? 2'd1 :
         // Default set to register
         2'd2;
 
@@ -566,11 +566,6 @@ module rram_ctrl_core_reg_top (
   logic [7:0] corr_err_cnt_wd;
   logic [20:0] corr_err_loc_addr_qs;
   logic corr_err_loc_part_qs;
-  logic phy_alert_cfg_we;
-  logic phy_alert_cfg_alert_ack_qs;
-  logic phy_alert_cfg_alert_ack_wd;
-  logic phy_alert_cfg_alert_trig_qs;
-  logic phy_alert_cfg_alert_trig_wd;
   logic phy_status_wr_busy_qs;
   logic phy_status_init_done_qs;
   logic scratch_we;
@@ -5916,62 +5911,6 @@ module rram_ctrl_core_reg_top (
   );
 
 
-  // R[phy_alert_cfg]: V(False)
-  //   F[alert_ack]: 0:0
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
-  ) u_phy_alert_cfg_alert_ack (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (phy_alert_cfg_we),
-    .wd     (phy_alert_cfg_alert_ack_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.phy_alert_cfg.alert_ack.q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (phy_alert_cfg_alert_ack_qs)
-  );
-
-  //   F[alert_trig]: 1:1
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
-  ) u_phy_alert_cfg_alert_trig (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (phy_alert_cfg_we),
-    .wd     (phy_alert_cfg_alert_trig_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.phy_alert_cfg.alert_trig.q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (phy_alert_cfg_alert_trig_qs)
-  );
-
-
   // R[phy_status]: V(False)
   //   F[wr_busy]: 0:0
   prim_subreg #(
@@ -6182,7 +6121,7 @@ module rram_ctrl_core_reg_top (
 
 
 
-  logic [65:0] addr_hit;
+  logic [64:0] addr_hit;
   always_comb begin
     addr_hit[ 0] = (reg_addr == RRAM_CTRL_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == RRAM_CTRL_INTR_ENABLE_OFFSET);
@@ -6244,12 +6183,11 @@ module rram_ctrl_core_reg_top (
     addr_hit[57] = (reg_addr == RRAM_CTRL_ERR_ADDR_OFFSET);
     addr_hit[58] = (reg_addr == RRAM_CTRL_CORR_ERR_CNT_OFFSET);
     addr_hit[59] = (reg_addr == RRAM_CTRL_CORR_ERR_LOC_OFFSET);
-    addr_hit[60] = (reg_addr == RRAM_CTRL_PHY_ALERT_CFG_OFFSET);
-    addr_hit[61] = (reg_addr == RRAM_CTRL_PHY_STATUS_OFFSET);
-    addr_hit[62] = (reg_addr == RRAM_CTRL_SCRATCH_OFFSET);
-    addr_hit[63] = (reg_addr == RRAM_CTRL_FIFO_LVL_OFFSET);
-    addr_hit[64] = (reg_addr == RRAM_CTRL_FIFO_CLR_OFFSET);
-    addr_hit[65] = (reg_addr == RRAM_CTRL_CURR_FIFO_LVL_OFFSET);
+    addr_hit[60] = (reg_addr == RRAM_CTRL_PHY_STATUS_OFFSET);
+    addr_hit[61] = (reg_addr == RRAM_CTRL_SCRATCH_OFFSET);
+    addr_hit[62] = (reg_addr == RRAM_CTRL_FIFO_LVL_OFFSET);
+    addr_hit[63] = (reg_addr == RRAM_CTRL_FIFO_CLR_OFFSET);
+    addr_hit[64] = (reg_addr == RRAM_CTRL_CURR_FIFO_LVL_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -6321,8 +6259,7 @@ module rram_ctrl_core_reg_top (
                (addr_hit[61] & (|(RRAM_CTRL_CORE_PERMIT[61] & ~reg_be))) |
                (addr_hit[62] & (|(RRAM_CTRL_CORE_PERMIT[62] & ~reg_be))) |
                (addr_hit[63] & (|(RRAM_CTRL_CORE_PERMIT[63] & ~reg_be))) |
-               (addr_hit[64] & (|(RRAM_CTRL_CORE_PERMIT[64] & ~reg_be))) |
-               (addr_hit[65] & (|(RRAM_CTRL_CORE_PERMIT[65] & ~reg_be)))));
+               (addr_hit[64] & (|(RRAM_CTRL_CORE_PERMIT[64] & ~reg_be)))));
   end
 
   // Generate write-enables
@@ -6690,25 +6627,20 @@ module rram_ctrl_core_reg_top (
   assign corr_err_cnt_we = addr_hit[58] & reg_we & !reg_error;
 
   assign corr_err_cnt_wd = reg_wdata[7:0];
-  assign phy_alert_cfg_we = addr_hit[60] & reg_we & !reg_error;
-
-  assign phy_alert_cfg_alert_ack_wd = reg_wdata[0];
-
-  assign phy_alert_cfg_alert_trig_wd = reg_wdata[1];
-  assign scratch_we = addr_hit[62] & reg_we & !reg_error;
+  assign scratch_we = addr_hit[61] & reg_we & !reg_error;
 
   assign scratch_wd = reg_wdata[31:0];
-  assign fifo_lvl_we = addr_hit[63] & reg_we & !reg_error;
+  assign fifo_lvl_we = addr_hit[62] & reg_we & !reg_error;
 
   assign fifo_lvl_wr_wd = reg_wdata[4:0];
 
   assign fifo_lvl_rd_wd = reg_wdata[12:8];
-  assign fifo_clr_we = addr_hit[64] & reg_we & !reg_error;
+  assign fifo_clr_we = addr_hit[63] & reg_we & !reg_error;
 
   assign fifo_clr_wr_wd = reg_wdata[0];
 
   assign fifo_clr_rd_wd = reg_wdata[1];
-  assign curr_fifo_lvl_re = addr_hit[65] & reg_re & !reg_error;
+  assign curr_fifo_lvl_re = addr_hit[64] & reg_re & !reg_error;
 
   // Assign write-enables to checker logic vector.
   always_comb begin
@@ -6772,12 +6704,11 @@ module rram_ctrl_core_reg_top (
     reg_we_check[57] = 1'b0;
     reg_we_check[58] = corr_err_cnt_we;
     reg_we_check[59] = 1'b0;
-    reg_we_check[60] = phy_alert_cfg_we;
-    reg_we_check[61] = 1'b0;
-    reg_we_check[62] = scratch_we;
-    reg_we_check[63] = fifo_lvl_we;
-    reg_we_check[64] = fifo_clr_we;
-    reg_we_check[65] = 1'b0;
+    reg_we_check[60] = 1'b0;
+    reg_we_check[61] = scratch_we;
+    reg_we_check[62] = fifo_lvl_we;
+    reg_we_check[63] = fifo_clr_we;
+    reg_we_check[64] = 1'b0;
   end
 
   // Read data return
@@ -7159,30 +7090,25 @@ module rram_ctrl_core_reg_top (
       end
 
       addr_hit[60]: begin
-        reg_rdata_next[0] = phy_alert_cfg_alert_ack_qs;
-        reg_rdata_next[1] = phy_alert_cfg_alert_trig_qs;
-      end
-
-      addr_hit[61]: begin
         reg_rdata_next[0] = phy_status_wr_busy_qs;
         reg_rdata_next[1] = phy_status_init_done_qs;
       end
 
-      addr_hit[62]: begin
+      addr_hit[61]: begin
         reg_rdata_next[31:0] = scratch_qs;
       end
 
-      addr_hit[63]: begin
+      addr_hit[62]: begin
         reg_rdata_next[4:0] = fifo_lvl_wr_qs;
         reg_rdata_next[12:8] = fifo_lvl_rd_qs;
       end
 
-      addr_hit[64]: begin
+      addr_hit[63]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
       end
 
-      addr_hit[65]: begin
+      addr_hit[64]: begin
         reg_rdata_next[4:0] = curr_fifo_lvl_wr_qs;
         reg_rdata_next[12:8] = curr_fifo_lvl_rd_qs;
       end

--- a/hw/ip/rram_ctrl/rtl/rram_ctrl_mp.sv
+++ b/hw/ip/rram_ctrl/rtl/rram_ctrl_mp.sv
@@ -54,6 +54,7 @@ module rram_ctrl_mp
   output logic                    ctrl_wr_o,
   output logic                    ctrl_scramble_en_o,
   output logic                    ctrl_ecc_en_o,
+  output logic                    ctrl_addr_xor_en_o,
   input  logic                    ctrl_rd_done_i,
   input  logic                    ctrl_wr_done_i,
   output logic                    host_req_o,
@@ -157,7 +158,7 @@ module rram_ctrl_mp
 
   logic data_en;
   logic data_rd_en, data_wr_en;
-  logic data_scr_en, data_ecc_en;
+  logic data_scr_en, data_ecc_en, data_xor_en;
   logic invalid_data_txn;
 
   assign data_en     = data_part_sel &
@@ -167,6 +168,7 @@ module rram_ctrl_mp
   assign data_wr_en  = data_en & ctrl_wr_req_i & mubi4_test_true_strict(data_region_cfg.wr_en);
   assign data_scr_en = data_en & ctrl_req & mubi4_test_true_strict(data_region_cfg.scramble_en);
   assign data_ecc_en = data_en & ctrl_req & mubi4_test_true_strict(data_region_cfg.ecc_en);
+  assign data_xor_en = data_en & ctrl_req & mubi4_test_true_strict(data_region_cfg.addr_xor_en);
 
   // Check for invalid transactions
   assign invalid_data_txn = ctrl_req & data_part_sel & ~(data_rd_en | data_wr_en);
@@ -226,7 +228,7 @@ module rram_ctrl_mp
 
   logic info_en;
   logic info_rd_en, info_wr_en;
-  logic info_scr_en, info_ecc_en;
+  logic info_scr_en, info_ecc_en, info_xor_en;
   logic invalid_info_txn;
 
   assign info_en     = info_part_sel &
@@ -236,6 +238,7 @@ module rram_ctrl_mp
   assign info_wr_en  = info_en & ctrl_wr_req_i & mubi4_test_true_strict(info_page_cfg.wr_en);
   assign info_scr_en = info_en & ctrl_req & mubi4_test_true_strict(info_page_cfg.scramble_en);
   assign info_ecc_en = info_en & ctrl_req & mubi4_test_true_strict(info_page_cfg.ecc_en);
+  assign info_xor_en = info_en & ctrl_req & mubi4_test_true_strict(info_page_cfg.addr_xor_en);
 
   // Check for invalid transactions
   assign invalid_info_txn = ctrl_req & info_part_sel & ~(info_rd_en | info_wr_en);
@@ -248,6 +251,7 @@ module rram_ctrl_mp
   assign ctrl_wr_o          = ctrl_req & (data_wr_en | info_wr_en);
   assign ctrl_scramble_en_o = ctrl_req & (data_scr_en | info_scr_en);
   assign ctrl_ecc_en_o      = ctrl_req & (data_ecc_en | info_ecc_en);
+  assign ctrl_addr_xor_en_o = ctrl_req & (data_xor_en | info_xor_en);
   assign ctrl_req_o         = ctrl_rd_o | ctrl_wr_o;
 
   logic txn_rd_err_d, txn_rd_err_q;
@@ -309,9 +313,9 @@ module rram_ctrl_mp
     .page_cfg_o  (host_sel_cfg)
   );
 
-  // host is a read-only interface (wr_en not used). word-offset bits not needed in MP
+  // host is a read-only interface (wr_en not used). word-offset bits not needed in MP.
   logic unused_host_mp;
-  assign unused_host_mp = ^{host_sel_cfg.wr_en, host_addr_i[PageW-1:0]};
+  assign unused_host_mp = ^{host_sel_cfg.wr_en, host_sel_cfg.addr_xor_en, host_addr_i[PageW-1:0]};
 
   assign host_data_en     = mubi4_test_true_strict(host_sel_cfg.en);
   assign host_data_rd_en  = host_data_en & mubi4_test_true_strict(host_sel_cfg.rd_en);

--- a/hw/ip/rram_ctrl/rtl/rram_ctrl_otp.sv
+++ b/hw/ip/rram_ctrl/rtl/rram_ctrl_otp.sv
@@ -105,8 +105,8 @@ module rram_ctrl_otp
   logic [BusAddrByteW-1:0]    intg_addr_d, intg_addr_q;
 
   // Encoding generated with:
-  // $ ./util/design/sparse-fsm-encode.py -d 5 -m 14 -n 12 \
-  //     -s 12309347837 --language=sv
+  // $ ./util/design/sparse-fsm-encode.py --language=sv \
+  //     --seed 99887766 --distance 5 --states 15 --bits 12
   //
   // Hamming distance histogram:
   //
@@ -115,36 +115,37 @@ module rram_ctrl_otp
   //  2: --
   //  3: --
   //  4: --
-  //  5: |||||||||||||||||| (29.67%)
-  //  6: |||||||||||||||||||| (32.97%)
-  //  7: ||||||||||| (18.68%)
-  //  8: |||||| (9.89%)
-  //  9: ||| (5.49%)
-  // 10: || (3.30%)
-  // 11: --
+  //  5: |||||||||||||||||| (31.43%)
+  //  6: |||||||||||||||||||| (33.33%)
+  //  7: ||||||||| (16.19%)
+  //  8: |||||| (11.43%)
+  //  9: || (4.76%)
+  // 10: | (1.90%)
+  // 11:  (0.95%)
   // 12: --
   //
   // Minimum Hamming distance: 5
-  // Maximum Hamming distance: 10
+  // Maximum Hamming distance: 11
   // Minimum Hamming weight: 3
-  // Maximum Hamming weight: 10
+  // Maximum Hamming weight: 9
 
   localparam int StateWidth = 12;
   typedef enum logic [StateWidth-1:0] {
-    StReset        = 12'b010110000111,
-    StInit         = 12'b101111001110,
-    StIdle         = 12'b100001111100,
-    StReadIntg     = 12'b001110110101,
-    StRead         = 12'b111101111011,
-    StIntgCheck    = 12'b100100001001,
-    StReqWords     = 12'b111011010010,
-    StReqIntgWords = 12'b010100010000,
-    StWriteMod     = 12'b010011110001,
-    StIntgMod      = 12'b011001101101,
-    StWrite        = 12'b100000000110,
-    StWriteIntg    = 12'b111100100100,
-    StWaitWrite    = 12'b001100101010,
-    StError        = 12'b110010011101
+    StReset        = 12'b011100001001,
+    StInit         = 12'b010110100100,
+    StIdle         = 12'b111001110010,
+    StReadIntg     = 12'b000011000001,
+    StRead         = 12'b101110111100,
+    StIntgCheck    = 12'b101000011111,
+    StReqWords     = 12'b001011101110,
+    StReqIntgWords = 12'b110011010100,
+    StWriteMod     = 12'b010111111010,
+    StIntgMod      = 12'b000101001100,
+    StWrite        = 12'b100111110111,
+    StWriteIntg    = 12'b110001101111,
+    StWaitWrite    = 12'b001000110001,
+    StReadBack     = 12'b101111001011,
+    StError        = 12'b001110010010
   } state_e;
 
   state_e state_d, state_q;
@@ -476,6 +477,24 @@ module rram_ctrl_otp
         end
       end
 
+      // Read back data word just written and compare its recomputed integrity against intg_q
+      // (the ECC of the written data captured in StWrite) to verify the write succeeded.
+      StReadBack: begin
+        req_o = 1'b1;
+        start = 1'b1;
+        op    = RramOpRead;
+        if (rvalid_i) begin
+          bus_cnt_en = 1'b1;
+          if (done_i) begin
+            state_d     = StIntgCheck;
+            bus_cnt_clr = 1'b1;
+            if ((err_i != '0) && (err_q == NoError)) begin
+              err_d = MacroError;
+            end
+          end
+        end
+      end
+
       // Write rram_word_q back to the RRAM and goto StRead in case of zer_en_q or to StWaitWrite
       // to wait for the RRAM write to have completed.
       StWriteIntg: begin
@@ -503,11 +522,10 @@ module rram_ctrl_otp
         end
       end
 
-      // Wait for the RRAM to finish the current write operation.
+      // Wait for the RRAM to finish the current write operation, then read back to verify.
       StWaitWrite: begin
         if (rram_wr_busy_i == 1'b0) begin
-          state_d = StIdle;
-          valid_d = 1'b1;
+          state_d = StReadBack;
         end
       end
 
@@ -552,7 +570,7 @@ module rram_ctrl_otp
         end
       end
 
-      // Compare intgrity from RRAM (intg_q) with recomputed intgerity from RRAM word (intg_ecc).
+      // Compare integrity from RRAM (intg_q) with recomputed integrity from RRAM word (intg_ecc).
       StIntgCheck: begin
         state_d = StIdle;
         valid_d = 1'b1;

--- a/hw/ip/rram_ctrl/rtl/rram_ctrl_otp.sv
+++ b/hw/ip/rram_ctrl/rtl/rram_ctrl_otp.sv
@@ -1,0 +1,624 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// rram_ctrl_otp: A FSM that performs the read-set-write algorithm and supports all commands issued by otp_ctrl.
+//
+// It bridges two clock domains - OTP requests arrive on clk_otp_i and are transferred via an
+// asynchronous FIFO to the RRAM domain (clk_i). The following commands are supported:
+// - Init
+// - Read
+// - Write
+// - ReadRaw
+// - WriteRaw
+// - Zeroize
+// All other commands result in a fatal error.
+//
+// For every 64b data, this module writes an 8b integrity check value to a separate integrity page.
+// Data is only considered to be valid if the value matches the data.
+// The *Raw commands ignore the integrity.
+// Write and WriteRaw emulate OTP behaviour with a read-set-write algorithm.
+// Zeroize sets all bits in the selected word to high.
+//
+// If ECC errors are detected in an integrity or data word, the controller can attempt to correct it
+// with the rewrite mechanism.
+//
+// Note on security: zer_en_q and intg_en_q are mubi encoded for protection against fault injection
+// that targets to skip integrity checks.
+
+`include "prim_assert.sv"
+
+module rram_ctrl_otp
+  import otp_ctrl_macro_pkg::*;
+  import rram_ctrl_pkg::*;
+  import rram_ctrl_reg_pkg::rram_ctrl_reg2hw_control_reg_t;
+(
+  input logic                           clk_i,
+  input logic                           rst_ni,
+  input logic                           clk_otp_i,
+  input logic                           rst_otp_ni,
+  // Incoming request from OTP_CTRL
+  input  otp_ctrl_macro_req_t           otp_macro_req_i,
+  output otp_ctrl_macro_rsp_t           otp_macro_rsp_o,
+  // Interface to ctrl arb control ports
+  output rram_ctrl_reg2hw_control_reg_t ctrl_o,
+  output logic                          req_o,
+  output logic [BusAddrByteW-1:0]       addr_o,
+  input  logic                          done_i,
+  input  rram_ctrl_err_t                err_i,
+  // Interface to rram_ctrl_rd
+  output logic                          rready_o,
+  input  logic                          rvalid_i,
+  input  logic [BusFullWidth-1:0]       rdata_i,
+  // Interface to arbiter
+  output logic                          wvalid_o,
+  input  logic                          wready_i,
+  output logic [BusFullWidth-1:0]       wdata_o,
+  // Fatal errors and status
+  output logic                          fatal_err_o,
+  output logic                          intg_err_o,
+  input  logic                          rram_init_done_i,
+  input  logic                          rram_wr_busy_i
+);
+
+  import prim_mubi_pkg::*;
+  import prim_util_pkg::vbits;
+
+  logic fsm_err;
+  err_e err_d, err_q;
+  logic valid_d, valid_q;
+  logic ready;
+
+  // to store the number of 16b chunks in one RRAM word
+  localparam int unsigned RramOtpSizeWidth = vbits(DataWidth / OtpWidth);
+  localparam int unsigned OtpIntgIndWidth = vbits(DataWidth / OtpIntgWidth);
+  localparam int unsigned OtpDataIndWidth = vbits(DataWidth / OtpIntgDataWidth);
+
+  localparam logic [BusAddrByteW-1:0] OtpStartAddr = (OtpStartPage+1) << (BusAddrByteW - PageW);
+  localparam logic [BusAddrByteW-1:0] OtpIntgStartAddr = OtpStartPage << (BusAddrByteW - PageW);
+
+  localparam int unsigned BusCntWidth = WordSelW + 1;
+
+  logic     start;
+  rram_op_e op;
+  mubi4_t   zer_en_d, zer_en_q;
+
+  logic [BusAddrByteW-1:0]                  otp_byte_addr;
+  logic [2**OtpSizeWidth-1:0][OtpWidth-1:0] otp_wdata_q;
+
+  logic [DataWidth-1:0]    rram_word_d, rram_word_q;
+  logic [BusAddrByteW-1:0] addr_q, addr_d, addr;
+
+  logic                        rmw_en, clr_buf;
+  logic                        wdata_inconsistent;
+  logic [RramOtpSizeWidth-1:0] otp_off_q;
+  logic [OtpSizeWidth-1:0]     otp_size_q;
+
+  logic                   bus_cnt_clr, bus_cnt_en;
+  logic [BusCntWidth-1:0] bus_cnt_q;
+
+  logic [OtpIntgWidth-1:0]    intg_d, intg_q, intg_ecc;
+  mubi4_t                     intg_en_d, intg_en_q;
+  logic                       intg_update;
+  logic [OtpIntgIndWidth-1:0] intg_ind_d, intg_ind_q;
+  logic [BusAddrByteW-1:0]    intg_addr_d, intg_addr_q;
+
+  // Encoding generated with:
+  // $ ./util/design/sparse-fsm-encode.py -d 5 -m 14 -n 12 \
+  //     -s 12309347837 --language=sv
+  //
+  // Hamming distance histogram:
+  //
+  //  0: --
+  //  1: --
+  //  2: --
+  //  3: --
+  //  4: --
+  //  5: |||||||||||||||||| (29.67%)
+  //  6: |||||||||||||||||||| (32.97%)
+  //  7: ||||||||||| (18.68%)
+  //  8: |||||| (9.89%)
+  //  9: ||| (5.49%)
+  // 10: || (3.30%)
+  // 11: --
+  // 12: --
+  //
+  // Minimum Hamming distance: 5
+  // Maximum Hamming distance: 10
+  // Minimum Hamming weight: 3
+  // Maximum Hamming weight: 10
+
+  localparam int StateWidth = 12;
+  typedef enum logic [StateWidth-1:0] {
+    StReset        = 12'b010110000111,
+    StInit         = 12'b101111001110,
+    StIdle         = 12'b100001111100,
+    StReadIntg     = 12'b001110110101,
+    StRead         = 12'b111101111011,
+    StIntgCheck    = 12'b100100001001,
+    StReqWords     = 12'b111011010010,
+    StReqIntgWords = 12'b010100010000,
+    StWriteMod     = 12'b010011110001,
+    StIntgMod      = 12'b011001101101,
+    StWrite        = 12'b100000000110,
+    StWriteIntg    = 12'b111100100100,
+    StWaitWrite    = 12'b001100101010,
+    StError        = 12'b110010011101
+  } state_e;
+
+  state_e state_d, state_q;
+
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, StReset)
+
+  ///////////////////////////////
+  // read data integrity check //
+  ///////////////////////////////
+  // This integrity was added in phy_rd and is checked here
+  logic data_invalid_d, data_invalid_q;
+  logic data_err;
+
+  logic [BusWidth-1:0]                      wdata;
+  logic [2**OtpSizeWidth-1:0][OtpWidth-1:0] rdata;
+  logic [2**OtpSizeWidth-1:0][OtpWidth-1:0] wdata_mod;
+
+  tlul_data_integ_dec u_data_intg_chk (
+    .data_intg_i(rdata_i),
+    .data_err_o (data_err)
+  );
+
+  // hold on to failed integrity until reset
+  assign data_invalid_d = data_invalid_q | (rvalid_i & data_err);
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      data_invalid_q <= '0;
+    end else begin
+      data_invalid_q <= data_invalid_d;
+    end
+  end
+
+  // add bus integrity for wdata
+  tlul_data_integ_enc u_bus_intg (
+    .data_i     (wdata),
+    .data_intg_o(wdata_o)
+  );
+
+  // Instantiate secded encoder and decoder based on parameters.
+  `include "prim_secded_inc.svh"
+
+  ////////////////////////////////
+  // otp_ctrl <-> rram_ctrl CDC //
+  ////////////////////////////////
+  logic [OtpAddrWidth-1:0]                  otp_req_addr;
+  cmd_e                                     otp_req_cmd;
+  logic                                     otp_req_valid;
+  logic [OtpSizeWidth-1:0]                  otp_req_size;
+  logic [2**OtpSizeWidth-1:0][OtpWidth-1:0] otp_req_wdata;
+
+  assign otp_req_addr  = otp_macro_req_i.addr;
+  assign otp_req_cmd   = otp_macro_req_i.cmd;
+  assign otp_req_valid = otp_macro_req_i.valid;
+  assign otp_req_size  = otp_macro_req_i.size;
+  assign otp_req_wdata = otp_macro_req_i.wdata;
+
+  assign otp_macro_rsp_o.rvalid = valid_q;
+  assign otp_macro_rsp_o.err    = err_q;
+  assign otp_macro_rsp_o.rdata  = rdata;
+  assign otp_macro_rsp_o.ready  = ready;
+
+  // faults and alerts propagate to rram_ctrl
+  assign otp_macro_rsp_o.fatal_lc_fsm_err = 1'b0;
+  assign otp_macro_rsp_o.fatal_alert      = 1'b0;
+  assign otp_macro_rsp_o.recov_alert      = 1'b0;
+
+  logic [OtpIntgDataWidth-1:0] unused_data, data_plain;
+
+  assign data_plain = rram_word_q[OtpIntgDataWidth*intg_ind_q[OtpDataIndWidth-1:0] +:
+                                  OtpIntgDataWidth];
+
+  `SECDED_INST_ENC(prim_secded_pkg::SecdedHamming, OtpIntgDataWidth, u_enc, data_plain,
+                   {intg_ecc, unused_data})
+
+  assign otp_byte_addr = BusAddrByteW'(otp_req_addr) << OtpAddrShift;
+
+  // Only issue 128b aligned transfers
+  assign addr_o             = {addr[BusAddrByteW-1 : DataByteWidth], {DataByteWidth{1'b0}}};
+  assign ctrl_o.start.q     = start;
+  assign ctrl_o.op.q        = op;
+  assign ctrl_o.partition.q = RramPartData;
+  assign ctrl_o.num.q       = WidthMultiple - 1;
+
+  assign rready_o = 1'b1;
+
+  always_comb begin : p_fsm
+    // Default
+    state_d     = state_q;
+    ready       = 1'b0;
+    err_d       = err_q;
+    bus_cnt_clr = 1'b0;
+    bus_cnt_en  = 1'b0;
+    rmw_en      = 1'b0;
+    intg_update = 1'b0;
+    clr_buf     = 1'b0;
+    zer_en_d    = zer_en_q;
+    fsm_err     = 1'b0;
+    valid_d     = 1'b0;
+    addr_d      = addr_q;
+    start       = 1'b0;
+    req_o       = 1'b0;
+    op          = RramOpRead;
+    wvalid_o    = 1'b0;
+    intg_d      = intg_q;
+    addr        = addr_q;
+    intg_en_d   = intg_en_q;
+    intg_addr_d = intg_addr_q;
+    intg_ind_d  = intg_ind_q;
+
+    unique case (state_q)
+      // Wait here until the initialization command is received.
+      StReset: begin
+        err_d = NoError;
+        ready = 1'b1;
+        if (otp_req_valid) begin
+          if (otp_req_cmd == Init) begin
+            state_d = StInit;
+          end
+        end
+      end
+
+      // Wait here until the rram has initialized.
+      StInit: begin
+        if (rram_init_done_i) begin
+          state_d = StIdle;
+          valid_d = 1'b1;
+        end
+      end
+
+      // Idle state: ready to receive new commands.
+      StIdle: begin
+        ready    = 1'b1;
+        err_d    = NoError;
+        zer_en_d = MuBi4False;
+        if (otp_req_valid) begin
+          req_o       = 1'b1;
+          addr_d      = OtpStartAddr + otp_byte_addr;
+          intg_addr_d = OtpIntgStartAddr + (otp_byte_addr >> vbits(OtpIntgDataWidth/8));
+          intg_ind_d  = otp_byte_addr[vbits(OtpIntgDataWidth/8) +: OtpIntgIndWidth];
+
+          err_d   = NoError;
+          clr_buf = 1'b1;
+          unique case (otp_req_cmd)
+            Read:  begin
+              state_d   = StReadIntg;
+              intg_en_d = MuBi4True;
+            end
+            Write: begin
+              state_d   = StReqWords;
+              intg_en_d = MuBi4True;
+            end
+            ReadRaw:  begin
+              state_d   = StRead;
+              intg_en_d = MuBi4False;
+            end
+            WriteRaw: begin
+              state_d   = StReqWords;
+              intg_en_d = MuBi4False;
+            end
+            Zeroize: begin
+              state_d   = StReqWords;
+              zer_en_d  = MuBi4True;
+              intg_en_d = MuBi4False;
+            end
+            default: begin
+              state_d = StError;
+              fsm_err = 1'b1;
+            end
+          endcase
+        end
+      end
+
+      // Request words from RRAM to perform RSW.
+      StReqWords: begin
+        req_o = 1'b1;
+        start = 1'b1;
+        op    = RramOpRead;
+        if (rvalid_i) begin
+          bus_cnt_en = 1'b1;
+          if (done_i) begin
+            state_d     = StWriteMod;
+            bus_cnt_clr = 1'b1;
+            if ((err_i != '0) && (err_q == NoError)) begin
+              err_d = MacroError;
+            end
+          end
+        end
+      end
+
+      // Request integrity word from RRAM to update the integrity value after a write operation.
+      StReqIntgWords: begin
+        req_o = 1'b1;
+        start = 1'b1;
+        addr  = intg_addr_q;
+        op    = RramOpRead;
+        if (rvalid_i) begin
+          bus_cnt_en = 1'b1;
+          if (done_i) begin
+            state_d     = StIntgMod;
+            bus_cnt_clr = 1'b1;
+            if ((err_i != '0) && (err_q == NoError)) begin
+              err_d = MacroError;
+            end
+          end
+        end
+      end
+
+      // Set selected bits in rram_word_d and go to StWrite to write it back to the RRAM.
+      StWriteMod: begin
+        req_o  = 1'b1;
+        rmw_en = 1'b1;
+        if (wdata_inconsistent) begin
+          err_d = MacroWriteBlankError;
+        end
+        state_d = StWrite;
+      end
+
+      // Update integrity bits in rram_word_d and go to StWriteIntg to write it back to the RRAM.
+      StIntgMod: begin
+        req_o       = 1'b1;
+        intg_update = 1'b1;
+        state_d     = StWriteIntg;
+      end
+
+      // Write rram_word_q back to RRAM and goto StWaitWrite to wait for the write to complete OR
+      // to StReqIntgWords to read and update the integrity word if zer_en_q or intg_en_q is true.
+      StWrite: begin
+        req_o  = 1'b1;
+        start  = 1'b1;
+        op     = RramOpWrite;
+        intg_d = intg_ecc;
+        if (bus_cnt_q == WidthMultiple) begin
+          bus_cnt_en = 1'b0;
+        end else if (wready_i) begin
+          bus_cnt_en = 1'b1;
+          wvalid_o   = 1'b1;
+        end
+        if (done_i) begin
+          if (mubi4_test_true_strict(mubi4_or_hi(zer_en_q, intg_en_q))) begin
+            // The wait is implicit, we can directly jump to the StReqIntgWords state.
+            state_d = StReqIntgWords;
+          end else begin
+            state_d = StWaitWrite;
+          end
+          bus_cnt_clr = 1'b1;
+          if ((err_i != '0) && (err_q == NoError)) begin
+            err_d = MacroError;
+          end
+        end
+      end
+
+      // Write rram_word_q back to the RRAM and goto StRead in case of zer_en_q or to StWaitWrite
+      // to wait for the RRAM write to have completed.
+      StWriteIntg: begin
+        req_o = 1'b1;
+        start = 1'b1;
+        op    = RramOpWrite;
+        addr  = intg_addr_q;
+        if (bus_cnt_q == WidthMultiple) begin
+          bus_cnt_en = 1'b0;
+        end else if (wready_i) begin
+          bus_cnt_en = 1'b1;
+          wvalid_o   = 1'b1;
+        end
+        if (done_i) begin
+          if (mubi4_test_true_strict(zer_en_q)) begin
+            // The wait is implicit, we can directly jump to the StRead state.
+            state_d = StRead;
+          end else begin
+            state_d = StWaitWrite;
+          end
+          bus_cnt_clr = 1'b1;
+          if ((err_i != '0) && (err_q == NoError)) begin
+            err_d = MacroError;
+          end
+        end
+      end
+
+      // Wait for the RRAM to finish the current write operation.
+      StWaitWrite: begin
+        if (rram_wr_busy_i == 1'b0) begin
+          state_d = StIdle;
+          valid_d = 1'b1;
+        end
+      end
+
+      // Read integrity word from RRAM then go to StRead to read data words.
+      StReadIntg: begin
+        req_o = 1'b1;
+        start = 1'b1;
+        addr  = intg_addr_q;
+        op    = RramOpRead;
+        if (rvalid_i) begin
+          bus_cnt_en = 1'b1;
+          if (done_i) begin
+            state_d     = StRead;
+            bus_cnt_clr = 1'b1;
+            if ((err_i != '0) && (err_q == NoError)) begin
+              err_d = MacroError;
+            end
+            intg_d = rram_word_d[intg_ind_q*OtpIntgWidth +: OtpIntgWidth];
+          end
+        end
+      end
+
+      // Read data words from RRAM and check integrity if intg_en_q is true;
+      StRead: begin
+        req_o = 1'b1;
+        start = 1'b1;
+        op    = RramOpRead;
+        if (rvalid_i) begin
+          bus_cnt_en = 1'b1;
+          if (done_i) begin
+            bus_cnt_clr = 1'b1;
+            if ((err_i != '0) && (err_q == NoError)) begin
+              err_d = MacroError;
+            end
+            if (mubi4_test_true_loose(intg_en_q)) begin
+              state_d = StIntgCheck;
+            end else begin
+              state_d = StIdle;
+              valid_d = 1'b1;
+            end
+          end
+        end
+      end
+
+      // Compare intgrity from RRAM (intg_q) with recomputed intgerity from RRAM word (intg_ecc).
+      StIntgCheck: begin
+        state_d = StIdle;
+        valid_d = 1'b1;
+        if (intg_q != intg_ecc) begin
+          err_d = MacroEccUncorrError;
+        end
+      end
+
+      // Terminal state, can only be reached by FI.
+      StError: begin
+        fsm_err = 1'b1;
+      end
+
+      default: begin
+        state_d = StError;
+        fsm_err = 1'b1;
+      end
+    endcase
+
+    // If mubi values are tampered, go to error state regardless of the current state
+    if (mubi4_test_invalid(zer_en_q) || mubi4_test_invalid(intg_en_q)) begin
+      state_d = StError;
+    end
+  end
+
+  // read modify write operation: OTP can only set bits to 1, but never clear to 0.
+  // zeroization writes set all bits to 1
+  assign wdata_mod = mubi4_test_true_strict(zer_en_q) ? '1 : (otp_wdata_q | rdata);
+
+  // update RRAM word buffer
+  always_comb begin
+    rram_word_d        = rram_word_q;
+    wdata_inconsistent = '0;
+
+    if (rmw_en) begin
+      for (int k = 0; k <= otp_size_q; k++) begin
+        rram_word_d[(otp_off_q + k)*OtpWidth +: OtpWidth] = wdata_mod[k];
+        if (mubi4_test_false_strict(zer_en_q)) begin
+          // Inconsistent write data. Detect if operation tried to clear a bit to zero.
+          if ((otp_wdata_q[k] & rdata[k]) != rdata[k]) begin
+            wdata_inconsistent = 1'b1;
+          end
+        end
+      end
+    end else if (intg_update) begin
+      rram_word_d[intg_ind_q*OtpIntgWidth +: OtpIntgWidth] = intg_q;
+    end else if (clr_buf) begin
+      rram_word_d = '1;
+    end else if (rvalid_i && rready_o) begin
+      if (data_err) begin
+        rram_word_d[bus_cnt_q*BusWidth +: BusWidth] = '1;
+      end else begin
+        rram_word_d[bus_cnt_q*BusWidth +: BusWidth] = rdata_i[BusWidth-1:0];
+      end
+    end
+  end
+
+  // rram word buffer
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rram_word_q <= '0;
+    end else begin
+      rram_word_q <= rram_word_d;
+    end
+  end
+
+  assign wdata = rram_word_q[bus_cnt_q*BusWidth +: BusWidth];
+  always_comb begin
+    rdata = '0;
+
+    for (int k = 0; k <= otp_size_q; k++) begin
+      rdata[k] = rram_word_q[(otp_off_q+k)*OtpWidth +: OtpWidth];
+    end
+  end
+
+  //////////////////////
+  // bus word counter //
+  //////////////////////
+
+  // SEC_CM: CTR.REDUN
+  logic bus_wcnt_err_d, bus_wcnt_err_q;
+  prim_count #(
+    .Width(BusCntWidth),
+    .PossibleActions(prim_count_pkg::Clr |
+                     prim_count_pkg::Incr)
+  ) u_bus_wcnt (
+    .clk_i,
+    .rst_ni,
+    .clr_i             (bus_cnt_clr),
+    .set_i             ('0),
+    .set_cnt_i         ('0),
+    .incr_en_i         (bus_cnt_en),
+    .decr_en_i         (1'b0),
+    .step_i            (BusCntWidth'(1'b1)),
+    .commit_i          (1'b1),
+    .cnt_o             (bus_cnt_q),
+    .cnt_after_commit_o(),
+    .err_o             (bus_wcnt_err_d)
+  );
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      bus_wcnt_err_q <= '0;
+      otp_off_q      <= '0;
+      otp_size_q     <= '0;
+      addr_q         <= '0;
+      otp_wdata_q    <= '0;
+      valid_q        <= '0;
+      zer_en_q       <= MuBi4False;
+      intg_q         <= '0;
+      intg_addr_q    <= '0;
+      intg_ind_q     <= '0;
+      intg_en_q      <= MuBi4True;
+      err_q          <= NoError;
+    end else begin
+      bus_wcnt_err_q <= bus_wcnt_err_q | bus_wcnt_err_d;
+      addr_q         <= addr_d;
+      valid_q        <= valid_d;
+      zer_en_q       <= zer_en_d;
+      intg_q         <= intg_d;
+      intg_addr_q    <= intg_addr_d;
+      intg_ind_q     <= intg_ind_d;
+      intg_en_q      <= intg_en_d;
+      err_q          <= err_d;
+      if (ready && otp_req_valid) begin
+        otp_off_q   <= otp_req_addr[RramOtpSizeWidth-1:0];
+        otp_size_q  <= otp_req_size;
+        otp_wdata_q <= otp_req_wdata;
+      end
+    end
+  end
+
+  // Data has been tampered
+  assign intg_err_o = data_invalid_q;
+  // Illegal states are observed in fsm or counter
+  assign fatal_err_o = fsm_err | bus_wcnt_err_q;
+
+  ////////////////
+  // Assertions //
+  ////////////////
+
+  // check for illegal access requests
+  `ASSERT(AddrAlignment32b, (otp_macro_req_i.valid && (otp_macro_req_i.size == 2'd1))
+                             |-> (otp_macro_req_i.addr[0] == '0))
+  `ASSERT(AddrAlignment64b, (otp_macro_req_i.valid && (otp_macro_req_i.size == 2'd3))
+                             |-> (otp_macro_req_i.addr[1:0] == '0))
+  `ASSERT(IllegalSize,      (otp_macro_req_i.valid |-> (otp_macro_req_i.size != 2'd2)))
+
+endmodule : rram_ctrl_otp

--- a/hw/ip/rram_ctrl/rtl/rram_ctrl_otp.sv
+++ b/hw/ip/rram_ctrl/rtl/rram_ctrl_otp.sv
@@ -585,7 +585,7 @@ module rram_ctrl_otp
     wdata_inconsistent = '0;
 
     if (rsw_en) begin
-      for (int k = 0; k <= otp_size_q; k++) begin
+      for (int unsigned k = 0; k <= otp_size_q; k++) begin
         rram_word_d[(otp_off_q + k)*OtpWidth +: OtpWidth] = wdata_mod[k];
         if (mubi4_test_false_strict(zer_en_q)) begin
           // Inconsistent write data. Detect if operation tried to clear a bit to zero.
@@ -600,9 +600,9 @@ module rram_ctrl_otp
       rram_word_d = '1;
     end else if (rvalid_i && rready_o) begin
       if (data_err) begin
-        rram_word_d[bus_cnt_q*BusWidth +: BusWidth] = '1;
+        rram_word_d[bus_cnt_q[WordSelW-1:0] * BusWidth +: BusWidth] = '1;
       end else begin
-        rram_word_d[bus_cnt_q*BusWidth +: BusWidth] = rdata_i[BusWidth-1:0];
+        rram_word_d[bus_cnt_q[WordSelW-1:0] * BusWidth +: BusWidth] = rdata_i[BusWidth-1:0];
       end
     end
   end
@@ -616,11 +616,11 @@ module rram_ctrl_otp
     end
   end
 
-  assign wdata = rram_word_q[bus_cnt_q*BusWidth +: BusWidth];
+  assign wdata = rram_word_q[bus_cnt_q[WordSelW-1:0] * BusWidth +: BusWidth];
   always_comb begin
     rdata = '0;
 
-    for (int k = 0; k <= otp_size_q; k++) begin
+    for (int unsigned k = 0; k <= otp_size_q; k++) begin
       rdata[k] = rram_word_q[(otp_off_q+k)*OtpWidth +: OtpWidth];
     end
   end

--- a/hw/ip/rram_ctrl/rtl/rram_ctrl_otp.sv
+++ b/hw/ip/rram_ctrl/rtl/rram_ctrl_otp.sv
@@ -67,9 +67,9 @@ module rram_ctrl_otp
   logic fsm_err;
   err_e err_d, err_q;
   logic valid_d, valid_q;
-  logic ready;
+  logic otp_req_ready;
 
-  // to store the number of 16b chunks in one RRAM word
+  // To store the number of 16b chunks in one RRAM word
   localparam int unsigned RramOtpSizeWidth = vbits(DataWidth / OtpWidth);
   localparam int unsigned OtpIntgIndWidth = vbits(DataWidth / OtpIntgWidth);
   localparam int unsigned OtpDataIndWidth = vbits(DataWidth / OtpIntgDataWidth);
@@ -89,7 +89,7 @@ module rram_ctrl_otp
   logic [DataWidth-1:0]    rram_word_d, rram_word_q;
   logic [BusAddrByteW-1:0] addr_q, addr_d, addr;
 
-  logic                        rmw_en, clr_buf;
+  logic                        rsw_en, clr_buf;
   logic                        wdata_inconsistent;
   logic [RramOtpSizeWidth-1:0] otp_off_q;
   logic [OtpSizeWidth-1:0]     otp_size_q;
@@ -151,22 +151,18 @@ module rram_ctrl_otp
   `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, StReset)
 
   ///////////////////////////////
-  // read data integrity check //
+  // Read-data integrity check //
   ///////////////////////////////
   // This integrity was added in phy_rd and is checked here
   logic data_invalid_d, data_invalid_q;
   logic data_err;
-
-  logic [BusWidth-1:0]                      wdata;
-  logic [2**OtpSizeWidth-1:0][OtpWidth-1:0] rdata;
-  logic [2**OtpSizeWidth-1:0][OtpWidth-1:0] wdata_mod;
 
   tlul_data_integ_dec u_data_intg_chk (
     .data_intg_i(rdata_i),
     .data_err_o (data_err)
   );
 
-  // hold on to failed integrity until reset
+  // Hold on to failed integrity until reset
   assign data_invalid_d = data_invalid_q | (rvalid_i & data_err);
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -177,40 +173,120 @@ module rram_ctrl_otp
     end
   end
 
-  // add bus integrity for wdata
+  //////////////////////////////
+  // wdata integrity addition //
+  //////////////////////////////
+  logic [BusWidth-1:0] wdata;
   tlul_data_integ_enc u_bus_intg (
     .data_i     (wdata),
     .data_intg_o(wdata_o)
   );
 
-  // Instantiate secded encoder and decoder based on parameters.
-  `include "prim_secded_inc.svh"
-
   ////////////////////////////////
   // otp_ctrl <-> rram_ctrl CDC //
   ////////////////////////////////
+
+  // -----------------------------------------------------------------------
+  // Request path: OTP domain (clk_otp_i) --> RRAM domain (clk_i)
+  //
+  // A prim_fifo_async_simple captures the OTP request on the write clock
+  // (clk_otp_i) and presents it to the RRAM FSM on the read clock (clk_i).
+  // wready_o (= otp_macro_rsp_o.ready) is asserted whenever the FIFO is
+  // empty, acknowledging OTP in the same cycle it writes.  The FIFO holds
+  // the request until the FSM asserts otp_req_ready (rready_i).
+  // -----------------------------------------------------------------------
+
   logic [OtpAddrWidth-1:0]                  otp_req_addr;
   cmd_e                                     otp_req_cmd;
   logic                                     otp_req_valid;
   logic [OtpSizeWidth-1:0]                  otp_req_size;
   logic [2**OtpSizeWidth-1:0][OtpWidth-1:0] otp_req_wdata;
 
-  assign otp_req_addr  = otp_macro_req_i.addr;
-  assign otp_req_cmd   = otp_macro_req_i.cmd;
-  assign otp_req_valid = otp_macro_req_i.valid;
-  assign otp_req_size  = otp_macro_req_i.size;
-  assign otp_req_wdata = otp_macro_req_i.wdata;
+  localparam int unsigned ReqDataWidth = OtpAddrWidth + $bits(cmd_e) +
+                                         OtpSizeWidth + (2**OtpSizeWidth)*OtpWidth;
 
-  assign otp_macro_rsp_o.rvalid = valid_q;
-  assign otp_macro_rsp_o.err    = err_q;
-  assign otp_macro_rsp_o.rdata  = rdata;
-  assign otp_macro_rsp_o.ready  = ready;
+  prim_fifo_async #(
+    .Width(ReqDataWidth),
+    .Depth(1),
+    .OutputZeroIfInvalid(1'b1)
+  ) u_otp_req_fifo (
+    .clk_wr_i (clk_otp_i),
+    .rst_wr_ni(rst_otp_ni),
+    .wvalid_i (otp_macro_req_i.valid),
+    .wready_o (otp_macro_rsp_o.ready),
+    .wdata_i  ({otp_macro_req_i.addr,
+                otp_macro_req_i.cmd,
+                otp_macro_req_i.size,
+                otp_macro_req_i.wdata}),
+    .wdepth_o (),
+    .clk_rd_i (clk_i),
+    .rst_rd_ni(rst_ni),
+    .rvalid_o (otp_req_valid),
+    .rready_i (otp_req_ready),
+    .rdata_o  ({otp_req_addr,
+                otp_req_cmd,
+                otp_req_size,
+                otp_req_wdata}),
+    .rdepth_o ()
+  );
 
-  // faults and alerts propagate to rram_ctrl
+  // -----------------------------------------------------------------------
+  // Response path: RRAM domain (clk_i) --> OTP domain (clk_otp_i)
+  //
+  // valid_d fires for one cycle when a transaction completes.  valid_q is valid_d delayed by
+  // one clock: at T+1 rram_word_q holds the complete word (all bus-beats registered) and err_q
+  // holds the transaction error (e.g. MacroEccUncorrError from StIntgCheck) before StIdle resets
+  // it to NoError.  The FIFO captures {err_q, rdata} on its write clock and holds them in an
+  // internal register, so there is no hold-stability requirement on the write-side inputs.
+  //
+  // otp_req_ready is gated with !valid_q in StIdle so that a new request cannot fire clr_buf
+  // in the same cycle as the FIFO write (which would corrupt rram_word_q / rdata).
+  // -----------------------------------------------------------------------
+
+  localparam int unsigned RspDataWidth = $bits(err_e) + (2**OtpSizeWidth)*OtpWidth;
+
+  logic fifo_wready;
+
+  logic                                     otp_rsp_valid;
+  err_e                                     otp_rsp_err;
+  logic [2**OtpSizeWidth-1:0][OtpWidth-1:0] otp_rsp_rdata;
+  logic [2**OtpSizeWidth-1:0][OtpWidth-1:0] rdata;
+
+  prim_fifo_async #(
+    .Width(RspDataWidth),
+    .Depth(1),
+    .OutputZeroIfInvalid(1'b1)
+  ) u_otp_rsp_fifo (
+    .clk_wr_i (clk_i),
+    .rst_wr_ni(rst_ni),
+    .wvalid_i (valid_q),
+    .wready_o (fifo_wready),
+    .wdata_i  ({err_q, rdata}),
+    .wdepth_o (),
+    .clk_rd_i (clk_otp_i),
+    .rst_rd_ni(rst_otp_ni),
+    .rvalid_o (otp_rsp_valid),
+    .rready_i (1'b1),
+    .rdata_o  ({otp_rsp_err, otp_rsp_rdata}),
+    .rdepth_o ()
+  );
+
+  assign otp_macro_rsp_o.rvalid = otp_rsp_valid;
+  assign otp_macro_rsp_o.err    = otp_rsp_err;
+  assign otp_macro_rsp_o.rdata  = otp_rsp_rdata;
+
+  // Faults and alerts propagate to rram_ctrl
   assign otp_macro_rsp_o.fatal_lc_fsm_err = 1'b0;
   assign otp_macro_rsp_o.fatal_alert      = 1'b0;
   assign otp_macro_rsp_o.recov_alert      = 1'b0;
 
+  ////////////////////////////////
+  // OTP through read-set-write //
+  ////////////////////////////////
+
+  // Integrity computation
+  // Instantiate secded encoder and decoder based on parameters.
+  `include "prim_secded_inc.svh"
   logic [OtpIntgDataWidth-1:0] unused_data, data_plain;
 
   assign data_plain = rram_word_q[OtpIntgDataWidth*intg_ind_q[OtpDataIndWidth-1:0] +:
@@ -219,7 +295,7 @@ module rram_ctrl_otp
   `SECDED_INST_ENC(prim_secded_pkg::SecdedHamming, OtpIntgDataWidth, u_enc, data_plain,
                    {intg_ecc, unused_data})
 
-  assign otp_byte_addr = BusAddrByteW'(otp_req_addr) << OtpAddrShift;
+  logic [2**OtpSizeWidth-1:0][OtpWidth-1:0] wdata_mod;
 
   // Only issue 128b aligned transfers
   assign addr_o             = {addr[BusAddrByteW-1 : DataByteWidth], {DataByteWidth{1'b0}}};
@@ -227,38 +303,39 @@ module rram_ctrl_otp
   assign ctrl_o.op.q        = op;
   assign ctrl_o.partition.q = RramPartData;
   assign ctrl_o.num.q       = WidthMultiple - 1;
+  assign rready_o           = 1'b1;
 
-  assign rready_o = 1'b1;
+  assign otp_byte_addr = BusAddrByteW'(otp_req_addr) << OtpAddrShift;
 
+  // OTP-FSM
   always_comb begin : p_fsm
-    // Default
-    state_d     = state_q;
-    ready       = 1'b0;
-    err_d       = err_q;
-    bus_cnt_clr = 1'b0;
-    bus_cnt_en  = 1'b0;
-    rmw_en      = 1'b0;
-    intg_update = 1'b0;
-    clr_buf     = 1'b0;
-    zer_en_d    = zer_en_q;
-    fsm_err     = 1'b0;
-    valid_d     = 1'b0;
-    addr_d      = addr_q;
-    start       = 1'b0;
-    req_o       = 1'b0;
-    op          = RramOpRead;
-    wvalid_o    = 1'b0;
-    intg_d      = intg_q;
-    addr        = addr_q;
-    intg_en_d   = intg_en_q;
-    intg_addr_d = intg_addr_q;
-    intg_ind_d  = intg_ind_q;
+    state_d       = state_q;
+    otp_req_ready = 1'b0;
+    err_d         = err_q;
+    bus_cnt_clr   = 1'b0;
+    bus_cnt_en    = 1'b0;
+    rsw_en        = 1'b0;
+    intg_update   = 1'b0;
+    clr_buf       = 1'b0;
+    zer_en_d      = zer_en_q;
+    fsm_err       = 1'b0;
+    valid_d       = 1'b0;
+    addr_d        = addr_q;
+    start         = 1'b0;
+    req_o         = 1'b0;
+    op            = RramOpRead;
+    wvalid_o      = 1'b0;
+    intg_d        = intg_q;
+    addr          = addr_q;
+    intg_en_d     = intg_en_q;
+    intg_addr_d   = intg_addr_q;
+    intg_ind_d    = intg_ind_q;
 
     unique case (state_q)
       // Wait here until the initialization command is received.
       StReset: begin
         err_d = NoError;
-        ready = 1'b1;
+        otp_req_ready = 1'b1;
         if (otp_req_valid) begin
           if (otp_req_cmd == Init) begin
             state_d = StInit;
@@ -276,10 +353,10 @@ module rram_ctrl_otp
 
       // Idle state: ready to receive new commands.
       StIdle: begin
-        ready    = 1'b1;
-        err_d    = NoError;
-        zer_en_d = MuBi4False;
-        if (otp_req_valid) begin
+        otp_req_ready = fifo_wready && !valid_q;
+        err_d         = NoError;
+        zer_en_d      = MuBi4False;
+        if (otp_req_valid && otp_req_ready) begin
           req_o       = 1'b1;
           addr_d      = OtpStartAddr + otp_byte_addr;
           intg_addr_d = OtpIntgStartAddr + (otp_byte_addr >> vbits(OtpIntgDataWidth/8));
@@ -355,7 +432,7 @@ module rram_ctrl_otp
       // Set selected bits in rram_word_d and go to StWrite to write it back to the RRAM.
       StWriteMod: begin
         req_o  = 1'b1;
-        rmw_en = 1'b1;
+        rsw_en = 1'b1;
         if (wdata_inconsistent) begin
           err_d = MacroWriteBlankError;
         end
@@ -498,16 +575,16 @@ module rram_ctrl_otp
     end
   end
 
-  // read modify write operation: OTP can only set bits to 1, but never clear to 0.
-  // zeroization writes set all bits to 1
+  // Read-set-write operation: OTP can only set bits to 1, but never clear to 0.
+  // Zeroization writes set all bits to 1
   assign wdata_mod = mubi4_test_true_strict(zer_en_q) ? '1 : (otp_wdata_q | rdata);
 
-  // update RRAM word buffer
+  // Update RRAM word buffer
   always_comb begin
     rram_word_d        = rram_word_q;
     wdata_inconsistent = '0;
 
-    if (rmw_en) begin
+    if (rsw_en) begin
       for (int k = 0; k <= otp_size_q; k++) begin
         rram_word_d[(otp_off_q + k)*OtpWidth +: OtpWidth] = wdata_mod[k];
         if (mubi4_test_false_strict(zer_en_q)) begin
@@ -530,7 +607,7 @@ module rram_ctrl_otp
     end
   end
 
-  // rram word buffer
+  // RRAM word buffer
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       rram_word_q <= '0;
@@ -549,7 +626,7 @@ module rram_ctrl_otp
   end
 
   //////////////////////
-  // bus word counter //
+  // Bus word counter //
   //////////////////////
 
   // SEC_CM: CTR.REDUN
@@ -573,6 +650,7 @@ module rram_ctrl_otp
     .err_o             (bus_wcnt_err_d)
   );
 
+  // Registers
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       bus_wcnt_err_q <= '0;
@@ -580,24 +658,24 @@ module rram_ctrl_otp
       otp_size_q     <= '0;
       addr_q         <= '0;
       otp_wdata_q    <= '0;
-      valid_q        <= '0;
       zer_en_q       <= MuBi4False;
       intg_q         <= '0;
       intg_addr_q    <= '0;
       intg_ind_q     <= '0;
       intg_en_q      <= MuBi4True;
       err_q          <= NoError;
+      valid_q        <= '0;
     end else begin
       bus_wcnt_err_q <= bus_wcnt_err_q | bus_wcnt_err_d;
       addr_q         <= addr_d;
-      valid_q        <= valid_d;
       zer_en_q       <= zer_en_d;
       intg_q         <= intg_d;
       intg_addr_q    <= intg_addr_d;
       intg_ind_q     <= intg_ind_d;
       intg_en_q      <= intg_en_d;
       err_q          <= err_d;
-      if (ready && otp_req_valid) begin
+      valid_q        <= valid_d;
+      if (otp_req_ready && otp_req_valid) begin
         otp_off_q   <= otp_req_addr[RramOtpSizeWidth-1:0];
         otp_size_q  <= otp_req_size;
         otp_wdata_q <= otp_req_wdata;
@@ -614,11 +692,12 @@ module rram_ctrl_otp
   // Assertions //
   ////////////////
 
-  // check for illegal access requests
+  // Check for illegal access requests - these signals are in the OTP clock domain
   `ASSERT(AddrAlignment32b, (otp_macro_req_i.valid && (otp_macro_req_i.size == 2'd1))
-                             |-> (otp_macro_req_i.addr[0] == '0))
+                             |-> (otp_macro_req_i.addr[0] == '0), clk_otp_i, !rst_otp_ni)
   `ASSERT(AddrAlignment64b, (otp_macro_req_i.valid && (otp_macro_req_i.size == 2'd3))
-                             |-> (otp_macro_req_i.addr[1:0] == '0))
-  `ASSERT(IllegalSize,      (otp_macro_req_i.valid |-> (otp_macro_req_i.size != 2'd2)))
+                             |-> (otp_macro_req_i.addr[1:0] == '0), clk_otp_i, !rst_otp_ni)
+  `ASSERT(IllegalSize,      (otp_macro_req_i.valid |-> (otp_macro_req_i.size != 2'd2)),
+                             clk_otp_i, !rst_otp_ni)
 
 endmodule : rram_ctrl_otp

--- a/hw/ip/rram_ctrl/rtl/rram_ctrl_otp.sv
+++ b/hw/ip/rram_ctrl/rtl/rram_ctrl_otp.sv
@@ -2,7 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// rram_ctrl_otp: A FSM that performs the read-set-write algorithm and supports all commands issued by otp_ctrl.
+// rram_ctrl_otp: A FSM that performs the read-set-write algorithm and supports all commands issued
+// by otp_ctrl.
 //
 // It bridges two clock domains - OTP requests arrive on clk_otp_i and are transferred via an
 // asynchronous FIFO to the RRAM domain (clk_i). The following commands are supported:
@@ -297,7 +298,9 @@ module rram_ctrl_otp
 
   logic [2**OtpSizeWidth-1:0][OtpWidth-1:0] wdata_mod;
 
-  // Only issue 128b aligned transfers
+  // Only issue 128b aligned transfers; lower DataByteWidth bits are always zero
+  logic unused_addr_lsb;
+  assign unused_addr_lsb    = ^addr[DataByteWidth-1:0];
   assign addr_o             = {addr[BusAddrByteW-1 : DataByteWidth], {DataByteWidth{1'b0}}};
   assign ctrl_o.start.q     = start;
   assign ctrl_o.op.q        = op;

--- a/hw/ip/rram_ctrl/rtl/rram_ctrl_pkg.sv
+++ b/hw/ip/rram_ctrl/rtl/rram_ctrl_pkg.sv
@@ -223,6 +223,7 @@ package rram_ctrl_pkg;
     mubi4_t wr_en;
     mubi4_t scramble_en;
     mubi4_t ecc_en;
+    mubi4_t addr_xor_en;
   } page_cfg_t;
 
   typedef struct packed {
@@ -257,7 +258,8 @@ package rram_ctrl_pkg;
     rd_en:       MuBi4True,
     wr_en:       MuBi4False,
     scramble_en: MuBi4True,
-    ecc_en:      MuBi4True
+    ecc_en:      MuBi4True,
+    addr_xor_en: MuBi4True
   };
 
   parameter page_cfg_t CfgAllowRdWr = '{
@@ -265,7 +267,8 @@ package rram_ctrl_pkg;
     rd_en:       MuBi4True,
     wr_en:       MuBi4True,
     scramble_en: MuBi4True,
-    ecc_en:      MuBi4True
+    ecc_en:      MuBi4True,
+    addr_xor_en: MuBi4True
   };
 
   parameter page_cfg_t CfgAllowRdWrOtp = '{
@@ -273,7 +276,8 @@ package rram_ctrl_pkg;
     rd_en:       MuBi4True,
     wr_en:       MuBi4True,
     scramble_en: MuBi4False,
-    ecc_en:      MuBi4True
+    ecc_en:      MuBi4True,
+    addr_xor_en: MuBi4False
   };
 
   parameter page_cfg_t CfgDisable = '{
@@ -281,7 +285,8 @@ package rram_ctrl_pkg;
     rd_en:       MuBi4False,
     wr_en:       MuBi4False,
     scramble_en: MuBi4False,
-    ecc_en:      MuBi4False
+    ecc_en:      MuBi4False,
+    addr_xor_en: MuBi4False
   };
 
   parameter page_cfg_t CfgNoAccess = '{
@@ -289,7 +294,8 @@ package rram_ctrl_pkg;
     rd_en:       MuBi4False,
     wr_en:       MuBi4False,
     scramble_en: MuBi4False,
-    ecc_en:      MuBi4False
+    ecc_en:      MuBi4False,
+    addr_xor_en: MuBi4False
   };
 
   parameter page_cfg_t CfgRw = '{
@@ -297,7 +303,8 @@ package rram_ctrl_pkg;
     rd_en:       MuBi4True,
     wr_en:       MuBi4True,
     scramble_en: MuBi4False,
-    ecc_en:      MuBi4True
+    ecc_en:      MuBi4True,
+    addr_xor_en: MuBi4True
   };
 
   parameter mp_info_cfg_t HwLcMgrInfoPageCfg[HwLcMgrInfoRules] = '{
@@ -418,6 +425,7 @@ package rram_ctrl_pkg;
     logic [AddrW-1:0]                           addr;
     logic                                       descramble_en;
     logic                                       ecc_en;
+    logic                                       addr_xor_en;
     rram_part_e                                 part;
     rd_buf_attr_e                               attr;
     logic                                       err;
@@ -434,7 +442,7 @@ package rram_ctrl_pkg;
     logic                update;
     logic                verify;
     logic [WordSelW-1:0] word_sel;
-    logic [5:0]          cmd_intg;
+    logic [6:0]          cmd_intg;
   } meta_entry_t;
   parameter int unsigned MetaFifoWidth = $bits(meta_entry_t);
 

--- a/hw/ip/rram_ctrl/rtl/rram_ctrl_reg_pkg.sv
+++ b/hw/ip/rram_ctrl/rtl/rram_ctrl_reg_pkg.sv
@@ -20,7 +20,7 @@ package rram_ctrl_reg_pkg;
   parameter int CoreAw = 9;
 
   // Number of registers for every interface
-  parameter int NumRegsCore = 66;
+  parameter int NumRegsCore = 65;
 
   // Alert indices
   typedef enum int {
@@ -324,15 +324,6 @@ package rram_ctrl_reg_pkg;
   } rram_ctrl_reg2hw_corr_err_cnt_reg_t;
 
   typedef struct packed {
-    struct packed {
-      logic        q;
-    } alert_trig;
-    struct packed {
-      logic        q;
-    } alert_ack;
-  } rram_ctrl_reg2hw_phy_alert_cfg_reg_t;
-
-  typedef struct packed {
     logic [31:0] q;
   } rram_ctrl_reg2hw_scratch_reg_t;
 
@@ -608,24 +599,23 @@ package rram_ctrl_reg_pkg;
 
   // Register -> HW type for core interface
   typedef struct packed {
-    rram_ctrl_reg2hw_intr_state_reg_t intr_state; // [728:723]
-    rram_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [722:717]
-    rram_ctrl_reg2hw_intr_test_reg_t intr_test; // [716:705]
-    rram_ctrl_reg2hw_alert_test_reg_t alert_test; // [704:695]
-    rram_ctrl_reg2hw_dis_reg_t dis; // [694:687]
-    rram_ctrl_reg2hw_exec_reg_t exec; // [686:655]
-    rram_ctrl_reg2hw_init_reg_t init; // [654:654]
-    rram_ctrl_reg2hw_control_reg_t control; // [653:640]
-    rram_ctrl_reg2hw_addr_reg_t addr; // [639:619]
-    rram_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [618:459]
-    rram_ctrl_reg2hw_mp_region_mreg_t [7:0] mp_region; // [458:267]
-    rram_ctrl_reg2hw_default_region_reg_t default_region; // [266:251]
-    rram_ctrl_reg2hw_info_page_cfg_mreg_t [7:0] info_page_cfg; // [250:91]
-    rram_ctrl_reg2hw_hw_info_cfg_override_reg_t hw_info_cfg_override; // [90:83]
-    rram_ctrl_reg2hw_std_fault_status_reg_t std_fault_status; // [82:70]
-    rram_ctrl_reg2hw_fault_status_reg_t fault_status; // [69:56]
-    rram_ctrl_reg2hw_corr_err_cnt_reg_t corr_err_cnt; // [55:48]
-    rram_ctrl_reg2hw_phy_alert_cfg_reg_t phy_alert_cfg; // [47:46]
+    rram_ctrl_reg2hw_intr_state_reg_t intr_state; // [726:721]
+    rram_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [720:715]
+    rram_ctrl_reg2hw_intr_test_reg_t intr_test; // [714:703]
+    rram_ctrl_reg2hw_alert_test_reg_t alert_test; // [702:693]
+    rram_ctrl_reg2hw_dis_reg_t dis; // [692:685]
+    rram_ctrl_reg2hw_exec_reg_t exec; // [684:653]
+    rram_ctrl_reg2hw_init_reg_t init; // [652:652]
+    rram_ctrl_reg2hw_control_reg_t control; // [651:638]
+    rram_ctrl_reg2hw_addr_reg_t addr; // [637:617]
+    rram_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [616:457]
+    rram_ctrl_reg2hw_mp_region_mreg_t [7:0] mp_region; // [456:265]
+    rram_ctrl_reg2hw_default_region_reg_t default_region; // [264:249]
+    rram_ctrl_reg2hw_info_page_cfg_mreg_t [7:0] info_page_cfg; // [248:89]
+    rram_ctrl_reg2hw_hw_info_cfg_override_reg_t hw_info_cfg_override; // [88:81]
+    rram_ctrl_reg2hw_std_fault_status_reg_t std_fault_status; // [80:68]
+    rram_ctrl_reg2hw_fault_status_reg_t fault_status; // [67:54]
+    rram_ctrl_reg2hw_corr_err_cnt_reg_t corr_err_cnt; // [53:46]
     rram_ctrl_reg2hw_scratch_reg_t scratch; // [45:14]
     rram_ctrl_reg2hw_fifo_lvl_reg_t fifo_lvl; // [13:4]
     rram_ctrl_reg2hw_fifo_clr_reg_t fifo_clr; // [3:0]
@@ -709,12 +699,11 @@ package rram_ctrl_reg_pkg;
   parameter logic [CoreAw-1:0] RRAM_CTRL_ERR_ADDR_OFFSET = 9'h e4;
   parameter logic [CoreAw-1:0] RRAM_CTRL_CORR_ERR_CNT_OFFSET = 9'h e8;
   parameter logic [CoreAw-1:0] RRAM_CTRL_CORR_ERR_LOC_OFFSET = 9'h ec;
-  parameter logic [CoreAw-1:0] RRAM_CTRL_PHY_ALERT_CFG_OFFSET = 9'h f0;
-  parameter logic [CoreAw-1:0] RRAM_CTRL_PHY_STATUS_OFFSET = 9'h f4;
-  parameter logic [CoreAw-1:0] RRAM_CTRL_SCRATCH_OFFSET = 9'h f8;
-  parameter logic [CoreAw-1:0] RRAM_CTRL_FIFO_LVL_OFFSET = 9'h fc;
-  parameter logic [CoreAw-1:0] RRAM_CTRL_FIFO_CLR_OFFSET = 9'h 100;
-  parameter logic [CoreAw-1:0] RRAM_CTRL_CURR_FIFO_LVL_OFFSET = 9'h 104;
+  parameter logic [CoreAw-1:0] RRAM_CTRL_PHY_STATUS_OFFSET = 9'h f0;
+  parameter logic [CoreAw-1:0] RRAM_CTRL_SCRATCH_OFFSET = 9'h f4;
+  parameter logic [CoreAw-1:0] RRAM_CTRL_FIFO_LVL_OFFSET = 9'h f8;
+  parameter logic [CoreAw-1:0] RRAM_CTRL_FIFO_CLR_OFFSET = 9'h fc;
+  parameter logic [CoreAw-1:0] RRAM_CTRL_CURR_FIFO_LVL_OFFSET = 9'h 100;
 
   // Reset values for hwext registers and their fields for core interface
   parameter logic [5:0] RRAM_CTRL_INTR_TEST_RESVAL = 6'h 0;
@@ -740,10 +729,10 @@ package rram_ctrl_reg_pkg;
   parameter logic [4:0] RRAM_CTRL_CURR_FIFO_LVL_RD_RESVAL = 5'h 0;
 
   // Window parameters for core interface
-  parameter logic [CoreAw-1:0] RRAM_CTRL_WR_FIFO_OFFSET = 9'h 108;
+  parameter logic [CoreAw-1:0] RRAM_CTRL_WR_FIFO_OFFSET = 9'h 104;
   parameter int unsigned       RRAM_CTRL_WR_FIFO_SIZE   = 'h 4;
   parameter int unsigned       RRAM_CTRL_WR_FIFO_IDX    = 0;
-  parameter logic [CoreAw-1:0] RRAM_CTRL_RD_FIFO_OFFSET = 9'h 10c;
+  parameter logic [CoreAw-1:0] RRAM_CTRL_RD_FIFO_OFFSET = 9'h 108;
   parameter int unsigned       RRAM_CTRL_RD_FIFO_SIZE   = 'h 4;
   parameter int unsigned       RRAM_CTRL_RD_FIFO_IDX    = 1;
 
@@ -809,7 +798,6 @@ package rram_ctrl_reg_pkg;
     RRAM_CTRL_ERR_ADDR,
     RRAM_CTRL_CORR_ERR_CNT,
     RRAM_CTRL_CORR_ERR_LOC,
-    RRAM_CTRL_PHY_ALERT_CFG,
     RRAM_CTRL_PHY_STATUS,
     RRAM_CTRL_SCRATCH,
     RRAM_CTRL_FIFO_LVL,
@@ -818,7 +806,7 @@ package rram_ctrl_reg_pkg;
   } rram_ctrl_core_id_e;
 
   // Register width information to check illegal writes for core interface
-  parameter logic [3:0] RRAM_CTRL_CORE_PERMIT [66] = '{
+  parameter logic [3:0] RRAM_CTRL_CORE_PERMIT [65] = '{
     4'b 0001, // index[ 0] RRAM_CTRL_INTR_STATE
     4'b 0001, // index[ 1] RRAM_CTRL_INTR_ENABLE
     4'b 0001, // index[ 2] RRAM_CTRL_INTR_TEST
@@ -879,12 +867,11 @@ package rram_ctrl_reg_pkg;
     4'b 0111, // index[57] RRAM_CTRL_ERR_ADDR
     4'b 0001, // index[58] RRAM_CTRL_CORR_ERR_CNT
     4'b 1111, // index[59] RRAM_CTRL_CORR_ERR_LOC
-    4'b 0001, // index[60] RRAM_CTRL_PHY_ALERT_CFG
-    4'b 0001, // index[61] RRAM_CTRL_PHY_STATUS
-    4'b 1111, // index[62] RRAM_CTRL_SCRATCH
-    4'b 0011, // index[63] RRAM_CTRL_FIFO_LVL
-    4'b 0001, // index[64] RRAM_CTRL_FIFO_CLR
-    4'b 0011  // index[65] RRAM_CTRL_CURR_FIFO_LVL
+    4'b 0001, // index[60] RRAM_CTRL_PHY_STATUS
+    4'b 1111, // index[61] RRAM_CTRL_SCRATCH
+    4'b 0011, // index[62] RRAM_CTRL_FIFO_LVL
+    4'b 0001, // index[63] RRAM_CTRL_FIFO_CLR
+    4'b 0011  // index[64] RRAM_CTRL_CURR_FIFO_LVL
   };
 
 endpackage

--- a/hw/ip/rram_ctrl/rtl/rram_ctrl_region_cfg.sv
+++ b/hw/ip/rram_ctrl/rtl/rram_ctrl_region_cfg.sv
@@ -108,6 +108,7 @@ module rram_ctrl_region_cfg
     assign region_cfgs_o[i].cfg.wr_en       = mubi4_t'(region_cfg_i[i-1].wr_en.q);
     assign region_cfgs_o[i].cfg.scramble_en = mubi4_t'(region_cfg_i[i-1].scramble_en.q);
     assign region_cfgs_o[i].cfg.ecc_en      = mubi4_t'(region_cfg_i[i-1].ecc_en.q);
+    assign region_cfgs_o[i].cfg.addr_xor_en = prim_mubi_pkg::MuBi4True;
     assign region_cfgs_o[i].phase           = PhaseInvalid;
   end
 
@@ -119,6 +120,7 @@ module rram_ctrl_region_cfg
   assign region_cfgs_o[MpRegions+1].cfg.wr_en       = mubi4_t'(default_cfg_i.wr_en.q);
   assign region_cfgs_o[MpRegions+1].cfg.scramble_en = mubi4_t'(default_cfg_i.scramble_en.q);
   assign region_cfgs_o[MpRegions+1].cfg.ecc_en      = mubi4_t'(default_cfg_i.ecc_en.q);
+  assign region_cfgs_o[MpRegions+1].cfg.addr_xor_en = prim_mubi_pkg::MuBi4True;
   assign region_cfgs_o[MpRegions+1].phase           = PhaseInvalid;
 
   /////////////////////////////////////////////
@@ -141,6 +143,7 @@ module rram_ctrl_region_cfg
     assign info_page_cfgs_o[i].phase           = PhaseInvalid;
     assign info_page_cfgs_o[i].cfg.scramble_en = reg_scramble_en;
     assign info_page_cfgs_o[i].cfg.ecc_en      = reg_ecc_en;
+    assign info_page_cfgs_o[i].cfg.addr_xor_en = prim_mubi_pkg::MuBi4True;
     assign info_page_cfgs_o[i].cfg.en          = reg_en;
 
     // Creator, owner, and isolated info page configuration can be overruled by the life-cycle

--- a/hw/ip/rram_ctrl/rtl/rram_phy.sv
+++ b/hw/ip/rram_ctrl/rtl/rram_phy.sv
@@ -29,6 +29,7 @@ module rram_phy
   input  logic                    ctrl_req_i,
   input  logic                    ctrl_scramble_en_i,
   input  logic                    ctrl_ecc_en_i,
+  input  logic                    ctrl_addr_xor_en_i,
   input  logic                    ctrl_rd_i,
   input  logic                    ctrl_wr_i,
   input  rram_part_e              ctrl_part_i,
@@ -108,6 +109,7 @@ module rram_phy
   logic rd_ecc_en;
   logic muxed_scramble_en;
   logic muxed_ecc_en;
+  logic muxed_addr_xor_en;
 
   // scrambling module signals
   scramble_req_t [1:0] scramble_req;
@@ -239,6 +241,8 @@ module rram_phy
   assign muxed_part        = host_gnt ? RramPartData       : ctrl_part_i;
   assign muxed_scramble_en = host_gnt ? host_scramble_en_i : ctrl_scramble_en_i;
   assign muxed_ecc_en      = host_gnt ? host_ecc_en_i      : ctrl_ecc_en_i;
+  // Host TL accesses never go to OTP pages, so addr_xor is always enabled for host
+  assign muxed_addr_xor_en = host_gnt ? 1'b1               : ctrl_addr_xor_en_i;
 
   // without this buffer host_gnt_err will get optimized away
   prim_buf #(
@@ -271,6 +275,7 @@ module rram_phy
     .ack_o          (rd_ack),
     .descramble_en_i(muxed_scramble_en),
     .ecc_en_i       (muxed_ecc_en),
+    .addr_xor_en_i  (muxed_addr_xor_en),
     .wr_req_i       (rram_wr_req),
     .wr_page_addr_i (wr_page_addr),
     .wr_part_i      (rram_macro_req_o.part),
@@ -329,6 +334,7 @@ module rram_phy
     .disable_i     (rram_disable[WrFsmDisableIdx]),
     .scramble_en_i (muxed_scramble_en),
     .ecc_en_i      (muxed_ecc_en),
+    .addr_xor_en_i (ctrl_addr_xor_en_i),
     .rd_idle_i     (rd_idle),
     .req_i         (wr_req),
     .ack_o         (wr_ack),

--- a/hw/ip/rram_ctrl/rtl/rram_phy_rd.sv
+++ b/hw/ip/rram_ctrl/rtl/rram_phy_rd.sv
@@ -22,6 +22,7 @@ module rram_phy_rd
   output logic                    ack_o,
   input  logic                    ecc_en_i,
   input  logic                    descramble_en_i,
+  input  logic                    addr_xor_en_i,
   input  logic                    wr_req_i,
   input  logic [PageW-1:0]        wr_page_addr_i,
   input  rram_part_e              wr_part_i,
@@ -114,6 +115,7 @@ module rram_phy_rd
   rd_buf_t rd_buf [NumRdBuf];
   logic    rd_buf_descramble_en;
   logic    rd_buf_ecc_en;
+  logic    rd_buf_addr_xor_en;
   logic    rd_buf_miss;
   logic    rd_buf_hit;
   logic    rd_buf_update;
@@ -206,17 +208,19 @@ module rram_phy_rd
   for (genvar i = 0; i < NumRdBuf; i++) begin: gen_buf_match
     logic part_match;
     logic descramble_match;
+    logic addr_xor_match;
 
     assign part_match = rd_buf[i].part == part_i;
-
     assign descramble_match = rd_buf[i].descramble_en == descramble_en_i;
+    assign addr_xor_match  = rd_buf[i].addr_xor_en  == addr_xor_en_i;
 
     assign buf_match[i] = req_i &
                           (buf_wip[i] | buf_valid[i] | buf_verified[i]) &
                           (rd_buf[i].addr == rram_word_addr) &
                           ~rd_buf[i].err &
                           part_match &
-                          descramble_match;
+                          descramble_match &
+                          addr_xor_match;
 
     // The content of the rd_buffer must be cleared if a write operation to the same page and
     // partition has been observed
@@ -249,6 +253,7 @@ module rram_phy_rd
       .part_i         (part_i),
       .descramble_en_i(descramble_en_i),
       .ecc_en_i       (ecc_en_i),
+      .addr_xor_en_i  (addr_xor_en_i),
       .data_i         (rram_data_packed_intg),
       .err_i          (rd_fifo_q.err),
       .rd_buf_o       (rd_buf[i]),
@@ -448,9 +453,9 @@ module rram_phy_rd
   assign meta_d.word_sel = shadow_sel ? '0 : addr_i[WordSelW-1:0];
 
   // Command integrity of incoming requests (stored in meta fifo and checked with response)
-  logic [21:0] unused_cmd_data0;
-  prim_secded_inv_28_22_enc u_cmd_intg_req_gen (
-    .data_i({ecc_en_i, descramble_en_i, addr_i, part_i}),
+  logic [31:0] unused_cmd_data0;
+  prim_secded_inv_39_32_enc u_cmd_intg_req_gen (
+    .data_i(32'({ecc_en_i, descramble_en_i, addr_xor_en_i, addr_i, part_i})),
     .data_o({meta_d.cmd_intg, unused_cmd_data0})
   );
 
@@ -553,13 +558,14 @@ module rram_phy_rd
     logic [BusWidth-1:0] unused_data;
     logic [WordSelW-1:0] offset;
     // 1. convert RRAM word to packed bus words
-    // 2. remove addr-xor
+    // 2. remove addr-xor (skip if addr_xor_en == 0)
     // 3. compute integrity per bus word (without addr-xor)
     // 4. combine integrity with address-infected data (xor on data will be removed in controller)
     assign offset = WordSelW'(unsigned'(i));
 
     assign rram_data_packed[i]     = rram_data[i*BusWidth +: BusWidth];
-    assign rram_addr_packed[i]     = {{(BusWidth-BusAddrW){1'b0}}, rd_buf_addr, offset};
+    assign rram_addr_packed[i]     = rd_buf_addr_xor_en ?
+                                      {{(BusWidth-BusAddrW){1'b0}}, rd_buf_addr, offset} : '0;
     assign rram_data_packed_xor[i] = rram_data_packed[i] ^ rram_addr_packed[i];
     // SEC_CM: MEM.BUS.INTEGRITY
     tlul_data_integ_enc u_rram_bus_intg (
@@ -575,6 +581,7 @@ module rram_phy_rd
     rd_buf_part          = RramPartData;
     rd_buf_descramble_en = 1'b0;
     rd_buf_ecc_en        = 1'b1;
+    rd_buf_addr_xor_en   = 1'b1;
     rd_buf_data          = '0;
     rd_buf_err           = '0;
     for (int i = 0; i < NumRdBuf; i++) begin
@@ -584,12 +591,13 @@ module rram_phy_rd
           rd_buf_data = rd_buf[i].data;
           rd_buf_err  = rd_buf[i].err;
         end
-        // Addr, part, descramble ecc_en if entry is alloc, valid or verified (not invalid)
+        // Addr, part, descramble_en, ecc_en, addr_xor_en if entry is alloc, valid or verified
         if (~buf_invalid[i]) begin
           rd_buf_addr          = rd_buf[i].addr;
           rd_buf_part          = rd_buf[i].part;
           rd_buf_descramble_en = rd_buf[i].descramble_en;
           rd_buf_ecc_en        = rd_buf[i].ecc_en;
+          rd_buf_addr_xor_en   = rd_buf[i].addr_xor_en;
         end
       end
     end
@@ -654,12 +662,13 @@ module rram_phy_rd
   assign req_err = rd_req_o & (~(req_i | shadow_rd_req));
 
   // Command integrity must match for all valid data responses
-  logic [21:0] unused_cmd_data1;
-  logic [5:0]  cmd_rsp_intg;
+  logic [31:0] unused_cmd_data1;
+  logic [6:0]  cmd_rsp_intg;
 
   // Command integrity of response
-  prim_secded_inv_28_22_enc u_cmd_intg_rsp_gen (
-    .data_i({rd_buf_ecc_en, rd_buf_descramble_en, rd_buf_addr, meta_q_buf.word_sel, rd_buf_part}),
+  prim_secded_inv_39_32_enc u_cmd_intg_rsp_gen (
+    .data_i(32'({rd_buf_ecc_en, rd_buf_descramble_en, rd_buf_addr_xor_en,
+                 rd_buf_addr, meta_q_buf.word_sel, rd_buf_part})),
     .data_o({cmd_rsp_intg, unused_cmd_data1})
   );
 

--- a/hw/ip/rram_ctrl/rtl/rram_phy_rd_buffer.sv
+++ b/hw/ip/rram_ctrl/rtl/rram_phy_rd_buffer.sv
@@ -29,6 +29,7 @@ module rram_phy_rd_buffer import rram_ctrl_pkg::*; (
   input  rram_part_e                                 part_i,
   input  logic                                       descramble_en_i,
   input  logic                                       ecc_en_i,
+  input  logic                                       addr_xor_en_i,
   input  logic [WidthMultiple-1:0][BusFullWidth-1:0] data_i,
   input  logic                                       err_i,
   output rd_buf_t                                    rd_buf_o,
@@ -53,6 +54,7 @@ module rram_phy_rd_buffer import rram_ctrl_pkg::*; (
       rd_buf_d.err           = 1'b0;
       rd_buf_d.descramble_en = 1'b0;
       rd_buf_d.ecc_en        = 1'b1;
+      rd_buf_d.addr_xor_en   = 1'b1;
       rd_buf_d.attr          = Invalid;
     end else if (alloc_i) begin
       rd_buf_d.data          = '0;
@@ -61,6 +63,7 @@ module rram_phy_rd_buffer import rram_ctrl_pkg::*; (
       rd_buf_d.err           = 1'b0;
       rd_buf_d.descramble_en = descramble_en_i;
       rd_buf_d.ecc_en        = ecc_en_i;
+      rd_buf_d.addr_xor_en   = addr_xor_en_i;
       rd_buf_d.attr          = Alloc;
     end else if (update_i) begin
       rd_buf_d.data = data_i;
@@ -86,6 +89,7 @@ module rram_phy_rd_buffer import rram_ctrl_pkg::*; (
       rd_buf_q.part          <= RramPartData;
       rd_buf_q.descramble_en <= 1'b0;
       rd_buf_q.ecc_en        <= 1'b1;
+      rd_buf_q.addr_xor_en   <= 1'b1;
       rd_buf_q.attr          <= Invalid;
       rd_buf_q.err           <= 1'b0;
     end else begin

--- a/hw/ip/rram_ctrl/rtl/rram_phy_wr.sv
+++ b/hw/ip/rram_ctrl/rtl/rram_phy_wr.sv
@@ -27,6 +27,7 @@ module rram_phy_wr import rram_ctrl_pkg::*; (
   input  prim_mubi_pkg::mubi4_t   disable_i,
   input  logic                    scramble_en_i,
   input  logic                    ecc_en_i,
+  input  logic                    addr_xor_en_i,
   input  logic                    rd_idle_i,
   input  logic                    req_i,
   output logic                    ack_o,
@@ -161,7 +162,7 @@ module rram_phy_wr import rram_ctrl_pkg::*; (
   assign word_sel = addr_i[WordSelW-1:0];
 
   // address infection. It will be removed during read in u_tl_adapter_host or u_rram_ctrl_rd
-  assign addr_xor = {{(BusWidth-BusAddrW){1'b0}}, addr_i[BusAddrW-1:0]};
+  assign addr_xor = addr_xor_en_i ? {{(BusWidth-BusAddrW){1'b0}}, addr_i[BusAddrW-1:0]} : '0;
   // in case of data integrity issues, simply fill with 0
   assign data_xor = (data_intg_err_d ? '0 : data_i[BusWidth-1:0]) ^ addr_xor;
 

--- a/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
@@ -154,12 +154,12 @@
                   additional_fusesoc_argument: "--mapping=lowrisc:systems:top_earlgrey:0.1"
                   rel_path: "hw/ip/rom_ctrl/lint/{tool}"
              },
-             #{    name: rram_ctrl
-             #     fusesoc_core: lowrisc:ip:rram_ctrl
-             #     import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-             #     additional_fusesoc_argument: "--mapping=lowrisc:systems:top_earlgrey:0.1"
-             #     rel_path: "hw/ip/rram_ctrl/lint/{tool}"
-             #},
+             {    name: rram_ctrl
+                  fusesoc_core: lowrisc:ip:rram_ctrl
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  additional_fusesoc_argument: "--mapping=lowrisc:systems:top_earlgrey:0.1"
+                  rel_path: "hw/ip/rram_ctrl/lint/{tool}"
+             },
              {    name: rram_macro
                   fusesoc_core: lowrisc:ip:rram_macro
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]


### PR DESCRIPTION
As per [RFC ](https://docs.google.com/document/d/1kYprEycc14MmAAGHIltgDwPmdEC7HEVOlhRwe60sn7o/edit?tab=t.0#heading=h.7h2usu46nmnp), Earlgrey will be extended with support for RRAM based non-volatile memory.

This 8th PR adds the otp hw module for the RRAM controller.
- `rram_ctrl_otp.sv`: A FSM that performs the read-set-write algorithm and supports all commands issued by `otp_ctrl`.

~This PR also adds the DV for this module with a new testcase:~
- ~`dvsim hw/ip/rram_ctrl/dv/rram_ctrl_sim_cfg.hjson -i rram_ctrl_otp`~

~The smoke test is also extended to issue OTP transactions.~

This PR also enables the lint flow for the full module that was disabled in the first PR (see https://github.com/lowRISC/opentitan/pull/30366#issuecomment-4682662643)

This PR is based on https://github.com/lowRISC/opentitan/pull/30411
