### PR TITLE
[crypto/25519] Randomize between sc_reduce

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc/curve25519.c
@@ -60,9 +60,9 @@ enum {
   /*
    * The expected instruction counts for constant time functions.
    */
-  kModeKeygenInsCnt = 342098,
-  kModeSignStage1InsCnt = 685160,
-  kModeSignStage2InsCnt = 655,
+  kModeKeygenInsCnt = 342099,
+  kModeSignStage1InsCnt = 685167,
+  kModeSignStage2InsCnt = 662,
   kModeX25519InsCnt = 366561,
   kModeX25519SideloadInsCnt = 362932,
   kModeX25519KeygenInsCnt = 359288,

--- a/sw/otbn/crypto/25519.s
+++ b/sw/otbn/crypto/25519.s
@@ -128,6 +128,7 @@ ed25519_gen_public_key:
   /* Clear w16 and w17 with randomness before loading the second share s1. */
   bn.wsrr w16, URND
   bn.wsrr w17, URND
+  bn.sub  w31, w31, w31 /* Clear flags */
 
   /* [w17:w16] <= s1. */
   li       x2, 16
@@ -725,6 +726,7 @@ ed25519_sign_stage2:
   /* Clear w16 and w17 with randomness before loading the second share s1. */
   bn.wsrr w16, URND
   bn.wsrr w17, URND
+  bn.sub  w31, w31, w31 /* Clear flags */
 
   /* [w17:w16] <= s1. */
   li       x2, 16

--- a/sw/otbn/crypto/25519_scalar.s
+++ b/sw/otbn/crypto/25519_scalar.s
@@ -273,6 +273,11 @@ sc_reduce_768:
   bn.mov w17, w22
   jal x1, sc_reduce
 
+  /* Clear w16 and w17 with randomness before loading the second share s1. */
+  bn.wsrr w16, URND
+  bn.wsrr w17, URND
+  bn.sub w31, w31, w31 /* Clear flags */
+
   bn.mov w16, w20
   bn.mov w17, w18
   jal x1, sc_reduce


### PR DESCRIPTION
Randomize the flags between the sc_reduce of the two shares to avoid overwrite leakage.