### PR TITLE
[crypto/state] Add stateful logic for the entropy and imem caching

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -372,6 +372,7 @@ cc_library(
         "//sw/device/lib/base:crc32",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:random_order",
+        "//sw/device/lib/crypto/impl:state",
         "//sw/device/lib/crypto/impl:status",
     ],
 )
@@ -391,10 +392,13 @@ opentitan_test(
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/crypto/drivers:entropy",
+        "//sw/device/lib/crypto/impl:config",
+        "//sw/device/lib/crypto/impl:state",
         "//sw/device/lib/crypto/impl:status",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_alerts",
         "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/tests:otbn_randomness_impl",
     ],
 )
 

--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -220,6 +220,7 @@ dual_cc_library(
             "//hw/ip/entropy_src/data:entropy_src_c_regs",
             "//hw/top_earlgrey/sw/autogen:top_earlgrey",
             "//sw/device/lib/base:abs_mmio",
+            "//sw/device/lib/base:hardened_memory",
             "//sw/device/lib/base:bitfield",
             "//sw/device/lib/base:hardened",
             "//sw/device/lib/base:macros",
@@ -227,6 +228,7 @@ dual_cc_library(
             "//sw/device/lib/base:memory",
         ],
         shared = [
+            "//sw/device/lib/crypto/impl:state",
             "//sw/device/lib/crypto/impl:status",
         ],
     ),

--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -6,9 +6,11 @@
 
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/base/math.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/multibits.h"
+#include "sw/device/lib/crypto/impl/state.h"
 #include "sw/device/lib/crypto/impl/status.h"
 
 #include "csrng_regs.h"        // Generated
@@ -1111,14 +1113,65 @@ status_t entropy_complex_health_test_config_check(hardened_bool_t fips) {
 status_t entropy_csrng_instantiate(
     hardened_bool_t disable_trng_input,
     const entropy_seed_material_t *seed_material) {
-  return csrng_send_app_cmd(kBaseCsrng,
-                            (entropy_csrng_cmd_t){
-                                .id = kEntropyDrbgOpInstantiate,
-                                .disable_trng_input = disable_trng_input,
-                                .seed_material = seed_material,
-                                .generate_len = 0,
-                            },
-                            kEntropyCsrngSendAppCmdTypeCsrng, true);
+  crypto_state_t *state = NULL;
+
+  hardened_bool_t skip_inst = kHardenedBoolFalse;
+  if (status_ok(read_state_pointer(&state)) && state != NULL) {
+    if (launder32(state->csrng_instantiated) == kHardenedBoolTrue &&
+        launder32(hardened_memeq(&state->disable_trng_input,
+                                 &disable_trng_input, 1)) ==
+            kHardenedBoolTrue) {
+      HARDENED_CHECK_EQ(state->csrng_instantiated, kHardenedBoolTrue);
+      HARDENED_CHECK_EQ(
+          hardened_memeq(&state->disable_trng_input, &disable_trng_input, 1),
+          kHardenedBoolTrue);
+      uint32_t len = seed_material == NULL ? 0 : (uint32_t)seed_material->len;
+      uint32_t state_len = (uint32_t)state->csrng_seed_len;
+      if (hardened_memeq(&state_len, &len, 1) == kHardenedBoolTrue) {
+        hardened_bool_t match = kHardenedBoolTrue;
+        if (len > 0 && seed_material != NULL) {
+          match =
+              hardened_memeq(state->csrng_seed_data, seed_material->data, len);
+        }
+        if (launder32(match) == kHardenedBoolTrue) {
+          HARDENED_CHECK_EQ(match, kHardenedBoolTrue);
+          skip_inst = kHardenedBoolTrue;
+        }
+      }
+    }
+  }
+
+  if (launder32(skip_inst) == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(skip_inst, kHardenedBoolTrue);
+    return OTCRYPTO_OK;
+  }
+
+  if (state != NULL && state->csrng_instantiated == kHardenedBoolTrue) {
+    HARDENED_TRY(entropy_csrng_uninstantiate());
+  }
+
+  HARDENED_TRY(csrng_send_app_cmd(kBaseCsrng,
+                                  (entropy_csrng_cmd_t){
+                                      .id = kEntropyDrbgOpInstantiate,
+                                      .disable_trng_input = disable_trng_input,
+                                      .seed_material = seed_material,
+                                      .generate_len = 0,
+                                  },
+                                  kEntropyCsrngSendAppCmdTypeCsrng, true));
+
+  if (state != NULL) {
+    state->csrng_instantiated = kHardenedBoolTrue;
+    state->disable_trng_input = disable_trng_input;
+    if (seed_material != NULL) {
+      state->csrng_seed_len = seed_material->len;
+      memcpy(state->csrng_seed_data, seed_material->data,
+             seed_material->len * sizeof(uint32_t));
+    } else {
+      state->csrng_seed_len = 0;
+    }
+  }
+
+  return OTCRYPTO_OK;
 }
 
 status_t entropy_csrng_reseed(hardened_bool_t disable_trng_input,
@@ -1145,6 +1198,15 @@ status_t entropy_csrng_update(const entropy_seed_material_t *seed_material) {
 
 status_t entropy_csrng_generate_start(
     const entropy_seed_material_t *seed_material, size_t len) {
+  crypto_state_t *state = NULL;
+  // Check whether the state is present and use it if so
+  if (status_ok(read_state_pointer(&state)) && state != NULL) {
+    if (state->csrng_instantiated != kHardenedBoolTrue) {
+      return OTCRYPTO_RECOV_ERR;
+    }
+    HARDENED_CHECK_EQ(state->csrng_instantiated, kHardenedBoolTrue);
+  }
+
   // Round up the number of 128bit blocks. Aligning with respect to uint32_t.
   // TODO(#6112): Consider using a canonical reference for alignment operations.
   const uint32_t num_128bit_blocks = ceil_div(len, 4);
@@ -1215,11 +1277,19 @@ status_t entropy_csrng_generate(const entropy_seed_material_t *seed_material,
 }
 
 status_t entropy_csrng_uninstantiate(void) {
-  return csrng_send_app_cmd(kBaseCsrng,
-                            (entropy_csrng_cmd_t){
-                                .id = kEntropyDrbgOpUninstantiate,
-                                .seed_material = NULL,
-                                .generate_len = 0,
-                            },
-                            kEntropyCsrngSendAppCmdTypeCsrng, true);
+  HARDENED_TRY(csrng_send_app_cmd(kBaseCsrng,
+                                  (entropy_csrng_cmd_t){
+                                      .id = kEntropyDrbgOpUninstantiate,
+                                      .seed_material = NULL,
+                                      .generate_len = 0,
+                                  },
+                                  kEntropyCsrngSendAppCmdTypeCsrng, true));
+
+  crypto_state_t *state = NULL;
+  // Check whether the state is present and use it if so
+  if (status_ok(read_state_pointer(&state)) && state != NULL) {
+    state->csrng_instantiated = kHardenedBoolFalse;
+  }
+
+  return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/drivers/otbn.c
+++ b/sw/device/lib/crypto/drivers/otbn.c
@@ -11,6 +11,7 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/random_order.h"
 #include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/impl/state.h"
 #include "sw/device/lib/crypto/impl/status.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -254,6 +255,13 @@ status_t otbn_imem_sec_wipe(void) {
   HARDENED_TRY(otbn_assert_idle());
   abs_mmio_write32(kBase + OTBN_CMD_REG_OFFSET, kOtbnCmdSecWipeImem);
   HARDENED_TRY(otbn_busy_wait_for_done());
+
+  crypto_state_t *state = NULL;
+  // Check whether the state is present and use it if so
+  if (status_ok(read_state_pointer(&state)) && state != NULL) {
+    state->imem_cache = 0;
+  }
+
   return OTCRYPTO_OK;
 }
 
@@ -317,11 +325,23 @@ status_t otbn_load_app(const otbn_app_t app) {
   // Ensure OTBN is idle.
   HARDENED_TRY(otbn_assert_idle());
 
+  crypto_state_t *state = NULL;
+  hardened_bool_t skip_imem = kHardenedBoolFalse;
+  // Check whether the state is present and use it if so
+  if (status_ok(read_state_pointer(&state)) && state != NULL) {
+    if (launder32(state->imem_cache) == (uint32_t)(uintptr_t)app.imem_start) {
+      HARDENED_CHECK_EQ(state->imem_cache, (uint32_t)(uintptr_t)app.imem_start);
+      skip_imem = kHardenedBoolTrue;
+    }
+  }
+
   const size_t imem_num_words = (size_t)(app.imem_end - app.imem_start);
   const size_t data_num_words =
       (size_t)(app.dmem_data_end - app.dmem_data_start);
 
-  HARDENED_TRY(otbn_imem_sec_wipe());
+  if (launder32(skip_imem) != kHardenedBoolTrue) {
+    HARDENED_TRY(otbn_imem_sec_wipe());
+  }
   HARDENED_TRY(otbn_dmem_sec_wipe());
 
   // Reset the LOAD_CHECKSUM register.
@@ -332,24 +352,29 @@ status_t otbn_load_app(const otbn_app_t app) {
   HARDENED_TRY(check_offset_len(app.dmem_data_start_addr, data_num_words,
                                 kOtbnDMemSizeBytes));
 
-  // Write to IMEM. Always starts at zero on the OTBN side.
-  otbn_addr_t imem_offset = 0;
-  HARDENED_TRY(
-      check_offset_len(imem_offset, imem_num_words, kOtbnIMemSizeBytes));
-  uint32_t imem_start_addr = kBase + OTBN_IMEM_REG_OFFSET + imem_offset;
-  uint32_t i = 0;
-  for (; launder32(i) < imem_num_words; i++) {
-    HARDENED_CHECK_LT(i, imem_num_words);
-    abs_mmio_write32(imem_start_addr + i * sizeof(uint32_t), app.imem_start[i]);
+  if (launder32(skip_imem) != kHardenedBoolTrue) {
+    // Write to IMEM. Always starts at zero on the OTBN side.
+    otbn_addr_t imem_offset = 0;
+    HARDENED_TRY(
+        check_offset_len(imem_offset, imem_num_words, kOtbnIMemSizeBytes));
+    uint32_t imem_start_addr = kBase + OTBN_IMEM_REG_OFFSET + imem_offset;
+    uint32_t i = 0;
+    for (; launder32(i) < imem_num_words; i++) {
+      HARDENED_CHECK_LT(i, imem_num_words);
+      abs_mmio_write32(imem_start_addr + i * sizeof(uint32_t),
+                       app.imem_start[i]);
+    }
+    HARDENED_CHECK_EQ(i, imem_num_words);
+  } else {
+    HARDENED_CHECK_EQ(skip_imem, kHardenedBoolTrue);
   }
-  HARDENED_CHECK_EQ(i, imem_num_words);
 
   // Write the data portion to DMEM.
   otbn_addr_t data_offset = app.dmem_data_start_addr;
   HARDENED_TRY(
       check_offset_len(data_offset, data_num_words, kOtbnDMemSizeBytes));
   uint32_t data_start_addr = kBase + OTBN_DMEM_REG_OFFSET + data_offset;
-  i = 0;
+  uint32_t i = 0;
   for (; launder32(i) < data_num_words; i++) {
     HARDENED_CHECK_LT(i, data_num_words);
     abs_mmio_write32(data_start_addr + i * sizeof(uint32_t),
@@ -357,12 +382,23 @@ status_t otbn_load_app(const otbn_app_t app) {
   }
   HARDENED_CHECK_EQ(i, data_num_words);
 
-  // Ensure that the checksum matches expectations.
-  uint32_t checksum = abs_mmio_read32(kBase + OTBN_LOAD_CHECKSUM_REG_OFFSET);
-  if (launder32(checksum) != app.checksum) {
-    return OTCRYPTO_FATAL_ERR;
+  if (launder32(skip_imem) != kHardenedBoolTrue) {
+    // Ensure that the checksum matches expectations.
+    uint32_t checksum = abs_mmio_read32(kBase + OTBN_LOAD_CHECKSUM_REG_OFFSET);
+    if (launder32(checksum) != app.checksum) {
+      if (state != NULL) {
+        state->imem_cache = 0;
+      }
+      return OTCRYPTO_FATAL_ERR;
+    }
+    HARDENED_CHECK_EQ(checksum, app.checksum);
+
+    if (state != NULL) {
+      state->imem_cache = (uint32_t)(uintptr_t)app.imem_start;
+    }
+  } else {
+    HARDENED_CHECK_EQ(skip_imem, kHardenedBoolTrue);
   }
-  HARDENED_CHECK_EQ(checksum, app.checksum);
 
   return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/drivers/otbn_test.c
+++ b/sw/device/lib/crypto/drivers/otbn_test.c
@@ -7,7 +7,9 @@
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/drivers/entropy.h"
+#include "sw/device/lib/crypto/impl/state.h"
 #include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_alerts.h"
@@ -15,6 +17,8 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "otbn_regs.h"  // Generated.
+
+OTBN_DECLARE_APP_SYMBOLS(randomness);
 
 #define MODULE_ID MAKE_MODULE_ID('t', 's', 't')
 
@@ -72,12 +76,29 @@ static status_t run_negative_test(void) {
   return OTCRYPTO_OK;
 }
 
+static crypto_state_t g_state;
+
+static status_t run_cache_test(void) {
+  LOG_INFO("Running cache tests.");
+
+  const otbn_app_t app = OTBN_APP_T_INIT(randomness);
+  CHECK(otbn_load_app(app).value == OTCRYPTO_OK.value);
+  CHECK(g_state.imem_cache == (uint32_t)(uintptr_t)app.imem_start);
+
+  CHECK(otbn_load_app(app).value == OTCRYPTO_OK.value);
+  CHECK(g_state.imem_cache == (uint32_t)(uintptr_t)app.imem_start);
+
+  return OTCRYPTO_OK;
+}
+
 bool test_main(void) {
   status_t result = OK_STATUS();
 
-  CHECK_STATUS_OK(entropy_complex_init(kHardenedBoolFalse));
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow,
+                                (otcrypto_state_t *)&g_state));
 
   EXECUTE_TEST(result, run_negative_test);
+  EXECUTE_TEST(result, run_cache_test);
 
   return status_ok(result);
 }

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -399,7 +399,6 @@ dual_cc_library(
             "//hw/ip/entropy_src/data:entropy_src_c_regs",
             "//hw/top_earlgrey/sw/autogen:top_earlgrey",
             "//sw/device/lib/base:abs_mmio",
-            "//sw/device/lib/crypto/drivers:entropy",
         ],
         host = [
             "//sw/device/lib/base:hardened",

--- a/sw/device/lib/crypto/impl/mock_state.cc
+++ b/sw/device/lib/crypto/impl/mock_state.cc
@@ -16,6 +16,7 @@ static crypto_state_t default_state = {
     .security_level = kOtcryptoKeySecurityLevelLow,
     .self_check_state = kHardenedBoolFalse,
     .locked_state = kHardenedBoolFalse,
+    .csrng_instantiated = kHardenedBoolFalse,
 };
 
 otcrypto_status_t init_state(otcrypto_state_t *state,
@@ -24,6 +25,7 @@ otcrypto_status_t init_state(otcrypto_state_t *state,
   memset(internal_state, 0, sizeof(*internal_state));
   internal_state->locked_state = kHardenedBoolFalse;
   internal_state->self_check_state = kHardenedBoolFalse;
+  internal_state->csrng_instantiated = kHardenedBoolFalse;
   internal_state->security_level = security_level;
   return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/impl/rsa/rsa_padding.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_padding.c
@@ -736,7 +736,6 @@ status_t rsa_padding_oaep_encode(const otcrypto_hash_mode_t hash_mode,
       /*disable_trng_input=*/kHardenedBoolFalse, &kEntropyEmptySeed));
   HARDENED_TRY(entropy_csrng_generate(&kEntropyEmptySeed, seed, ARRAYSIZE(seed),
                                       /*fips_check=*/kHardenedBoolTrue));
-  HARDENED_TRY(entropy_csrng_uninstantiate());
 
   // Generate dbMask = MGF(seed, k - hLen - 1) (step 2e).
   size_t digest_bytelen = digest_wordlen * sizeof(uint32_t);

--- a/sw/device/lib/crypto/impl/rsa/rsa_signature.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_signature.c
@@ -95,13 +95,11 @@ static status_t message_encode(const otcrypto_hash_digest_t message_digest,
       HARDENED_CHECK_EQ(padding_mode, kRsaSignaturePaddingPss);
       // Generate a random salt value whose length matches the digest length.
       uint32_t salt[message_digest.len];
-      HARDENED_TRY(entropy_csrng_uninstantiate());
       HARDENED_TRY(entropy_csrng_instantiate(
           /*disable_trng_input=*/kHardenedBoolFalse, &kEntropyEmptySeed));
       HARDENED_TRY(entropy_csrng_generate(&kEntropyEmptySeed, salt,
                                           ARRAYSIZE(salt),
                                           /*fips_check=*/kHardenedBoolTrue));
-      HARDENED_TRY(entropy_csrng_uninstantiate());
       return rsa_padding_pss_encode(message_digest, salt, ARRAYSIZE(salt),
                                     encoded_message_len, encoded_message);
     }

--- a/sw/device/lib/crypto/impl/state.c
+++ b/sw/device/lib/crypto/impl/state.c
@@ -6,7 +6,6 @@
 
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/hardened.h"
-#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/drivers/rv_core_ibex.h"
 
 #include "entropy_src_regs.h"  // Generated
@@ -21,6 +20,7 @@ otcrypto_status_t init_state(otcrypto_state_t *state,
   internal_state->kat_state = 0;
   internal_state->locked_state = kHardenedBoolFalse;
   internal_state->self_check_state = kHardenedBoolFalse;
+  internal_state->csrng_instantiated = kHardenedBoolFalse;
   internal_state->security_level = security_level;
   return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/impl/state.c
+++ b/sw/device/lib/crypto/impl/state.c
@@ -61,6 +61,11 @@ status_t read_state_pointer(crypto_state_t **state) {
   uint32_t val_lo = bitfield_field32_read(
       reg_lo, ENTROPY_SRC_EXTHT_LO_THRESHOLDS_FIPS_THRESH_FIELD);
 
+  if (val_hi == 0xFFFF) {
+    *state = NULL;
+    return OTCRYPTO_RECOV_ERR;
+  }
+
   uint32_t state_addr = (val_hi << 16) | val_lo;
   *state = (crypto_state_t *)state_addr;
 

--- a/sw/device/lib/crypto/impl/state.h
+++ b/sw/device/lib/crypto/impl/state.h
@@ -16,9 +16,13 @@ extern "C" {
 typedef struct crypto_state {
   uint32_t imem_cache;
   uint32_t kat_state;
+  uint32_t csrng_seed_data[12];
   otcrypto_key_security_level_t security_level;
+  size_t csrng_seed_len;
   hardened_bool_t self_check_state;
   hardened_bool_t locked_state;
+  hardened_bool_t csrng_instantiated;
+  hardened_bool_t disable_trng_input;
 } crypto_state_t;
 
 static_assert(sizeof(otcrypto_state_t) >= sizeof(crypto_state_t),

--- a/sw/device/lib/crypto/impl/state.h
+++ b/sw/device/lib/crypto/impl/state.h
@@ -82,6 +82,7 @@ status_t read_state_pointer(crypto_state_t **state);
 
 // Standard build: Stateful KAT evaluation is disabled (non FIPS).
 static inline otcrypto_status_t stateful_health_check(kat_bits_t kat_bit) {
+  (void)kat_bit;
   return OTCRYPTO_OK;
 }
 

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -535,7 +535,7 @@ typedef struct otcrypto_hash_digest {
  * State structure for the crypto library.
  */
 typedef struct otcrypto_state {
-  uint32_t data[5];
+  uint32_t data[24];
 } otcrypto_state_t;
 
 #ifdef __cplusplus

--- a/sw/device/tests/crypto/aes_kwp_sideload_functest.c
+++ b/sw/device/tests/crypto/aes_kwp_sideload_functest.c
@@ -139,7 +139,7 @@ status_t test_setup(void) {
   // Initialize entropy complex for cryptolib, which the key manager uses to
   // clear sideloaded keys. The `keymgr_testutils_startup` function restarts
   // the device, so this should happen afterwards.
-  otcrypto_state_t state = {0};
+  static otcrypto_state_t state = {0};
   return otcrypto_init(kOtcryptoKeySecurityLevelLow, &state);
 }
 

--- a/sw/device/tests/crypto/aes_sideload_functest.c
+++ b/sw/device/tests/crypto/aes_sideload_functest.c
@@ -153,7 +153,7 @@ status_t test_setup(void) {
   // Initialize entropy complex for cryptolib, which the key manager uses to
   // clear sideloaded keys. The `keymgr_testutils_startup` function restarts
   // the device, so this should happen afterwards.
-  otcrypto_state_t state = {0};
+  static otcrypto_state_t state = {0};
   return otcrypto_init(kOtcryptoKeySecurityLevelLow, &state);
 }
 

--- a/sw/device/tests/crypto/ecc_p256_dice_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_dice_functest.c
@@ -245,7 +245,7 @@ static status_t test_setup(void) {
   // Initialize entropy complex for cryptolib, which the key manager uses to
   // clear sideloaded keys. The `keymgr_testutils_startup` function restarts
   // the device, so this should happen afterwards.
-  otcrypto_state_t state = {0};
+  static otcrypto_state_t state = {0};
   return otcrypto_init(kOtcryptoKeySecurityLevelLow, &state);
 }
 

--- a/sw/device/tests/crypto/ecdh_p256_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdh_p256_sideload_functest.c
@@ -174,7 +174,7 @@ static status_t test_setup(void) {
   // Initialize entropy complex for cryptolib, which the key manager uses to
   // clear sideloaded keys. The `keymgr_testutils_startup` function restarts
   // the device, so this should happen afterwards.
-  otcrypto_state_t state = {0};
+  static otcrypto_state_t state = {0};
   return otcrypto_init(kOtcryptoKeySecurityLevelLow, &state);
 }
 

--- a/sw/device/tests/crypto/ecdh_p384_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdh_p384_sideload_functest.c
@@ -171,7 +171,7 @@ static status_t test_setup(void) {
   // Initialize entropy complex for cryptolib, which the key manager uses to
   // clear sideloaded keys. The `keymgr_testutils_startup` function restarts
   // the device, so this should happen afterwards.
-  otcrypto_state_t state = {0};
+  static otcrypto_state_t state = {0};
   return otcrypto_init(kOtcryptoKeySecurityLevelLow, &state);
 }
 

--- a/sw/device/tests/crypto/ecdsa_p256_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_sideload_functest.c
@@ -127,7 +127,7 @@ static status_t test_setup(void) {
   // Initialize entropy complex for cryptolib, which the key manager uses to
   // clear sideloaded keys. The `keymgr_testutils_startup` function restarts
   // the device, so this should happen afterwards.
-  otcrypto_state_t state = {0};
+  static otcrypto_state_t state = {0};
   return otcrypto_init(kOtcryptoKeySecurityLevelLow, &state);
 }
 

--- a/sw/device/tests/crypto/ecdsa_p384_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p384_sideload_functest.c
@@ -125,7 +125,7 @@ static status_t test_setup(void) {
   // Initialize entropy complex for cryptolib, which the key manager uses to
   // clear sideloaded keys. The `keymgr_testutils_startup` function restarts
   // the device, so this should happen afterwards.
-  otcrypto_state_t state = {0};
+  static otcrypto_state_t state = {0};
   return otcrypto_init(kOtcryptoKeySecurityLevelLow, &state);
 }
 

--- a/sw/device/tests/crypto/symmetric_keygen_functest.c
+++ b/sw/device/tests/crypto/symmetric_keygen_functest.c
@@ -277,7 +277,7 @@ static status_t test_setup(void) {
   // Initialize entropy complex for cryptolib, which the key manager uses to
   // clear sideloaded keys. The `keymgr_testutils_startup` function restarts
   // the device, so this should happen afterwards.
-  otcrypto_state_t state = {0};
+  static otcrypto_state_t state = {0};
   return otcrypto_init(kOtcryptoKeySecurityLevelLow, &state);
 }
 


### PR DESCRIPTION
- Add imem caching to allow multiple calls to the otbn with the same app to skip loading this imem
- Add caching to the csrng to allow skipping the instantiation of the csrng if it can stay in the same state