### PR TITLE
[tooling] RRAM Earlgrey integration: bazel script update

### DIFF
--- a/hw/top/doc/create_top.md
+++ b/hw/top/doc/create_top.md
@@ -150,6 +150,9 @@ sim_dv(
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     rom_scramble_config = "//hw/top_darjeeling/data/autogen:top_matcha.secrets.testing.gen.hjson",
+    # Only needed for tops that feature RRAM; the example top above does not,
+    # so this would normally be omitted here.
+    rram_scramble_tool = "//util/design:gen-rram-img",
 )
 
 sim_dv(

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -278,6 +278,7 @@ silicon(
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
+    rram_scramble_tool = "//util/design:gen-rram-img",
     slot_spec = EARLGREY_SLOTS,
     test_cmd = """
         --exec="transport init"
@@ -323,6 +324,7 @@ silicon(
         "//signing:test_keys": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_dice_x509_fake_slot_a",
         "//conditions:default": "//sw/device/silicon_creator/rom_ext/sival/binaries:rom_ext_dice_x509_prod",
     }),
+    rram_scramble_tool = "//util/design:gen-rram-img",
     slot_spec = EARLGREY_SLOTS,
     test_cmd = """
         --exec="transport init"
@@ -412,6 +414,7 @@ sim_dv(
     otp = "//hw/top_earlgrey/data/otp:img_rma",
     otp_data_perm = "//util/design/data:data_perm",
     otp_mmap = "//hw/top_earlgrey/data/otp:otp_ctrl_mmap.hjson",
+    rram_scramble_tool = "//util/design:gen-rram-img",
     slot_spec = EARLGREY_SLOTS,
 )
 

--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -656,9 +656,9 @@ common_binary_attrs = {
         default = "{name}_{exec_env}",
     ),
     "kind": attr.string(
-        doc = "Binary kind: flash, ram or rom",
+        doc = "Binary kind: flash, rram, ram or rom",
         default = "flash",
-        values = ["flash", "ram", "rom"],
+        values = ["flash", "rram", "ram", "rom"],
     ),
     # FIXME(cfrantz): This should come from the ExecEnvInfo provider, but
     # I was unable to make that work.  See the comment in `exec_env.bzl`.
@@ -882,9 +882,14 @@ def _opentitan_binary_assemble_impl(ctx):
         name = "{}_{}".format(ctx.attr.name, exec_env_name)
         spec = []
         input_bins = []
+        last_kind = None
         for binary, offset in ctx.attr.bins.items():
-            if binary[exec_env_provider].kind != "flash":
-                fail("Only flash binaries can be assembled.")
+            kind = binary[exec_env_provider].kind
+            if kind not in ("flash", "rram"):
+                fail("Only flash or rram binaries can be assembled, got {}".format(kind))
+            if last_kind != None and kind != last_kind:
+                fail("Cannot assemble binaries of mixed kinds: {} and {}".format(last_kind, kind))
+            last_kind = kind
             input_bins.append(binary[exec_env_provider].default)
             spec.append("{}@{}".format(binary[exec_env_provider].default.path, offset))
         action_param = {}
@@ -902,14 +907,15 @@ def _opentitan_binary_assemble_impl(ctx):
         # Multi-slot binaries are currently only used for bootstrap operations,
         # i.e., non-backdoor loaded sim environments and FPGA/silicon
         # environments. Therefore we only need unscrambled VMEM files.
+        vmem_word_size = 128 if last_kind == "rram" else 64
         vmem = convert_to_vmem(
             ctx,
             name = name,
             src = bin,
-            word_size = 64,
+            word_size = vmem_word_size,
         )
 
-        result.append(exec_env_provider(default = bin, kind = "flash", vmem = vmem))
+        result.append(exec_env_provider(default = bin, kind = last_kind, vmem = vmem))
         assembled_bins.append(bin)
         assembled_bins.append(vmem)
         ot_bin_env_info[exec_env_provider] = env

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -310,7 +310,7 @@ def opentitan_test(
       name: The base name of the test.  The name will be extended with the name
             of the execution environment.
       srcs: The source files for this test.
-      kind: The kind of test (flash, ram, rom).
+      kind: The kind of test (flash, rram, ram, rom).
       deps: Dependecies for this test.
       copts: Compiler options for this test.
       defines: Compiler defines for this test.

--- a/rules/opentitan/exec_env.bzl
+++ b/rules/opentitan/exec_env.bzl
@@ -32,6 +32,7 @@ _FIELDS = {
     "top_secret_cfg": ("file.top_secret_cfg", False),
     "otp_data_perm": ("attr.otp_data_perm", False),
     "flash_scramble_tool": ("attr.flash_scramble_tool", False),
+    "rram_scramble_tool": ("attr.rram_scramble_tool", False),
     "openocd": ("attr.openocd", False),
     "openocd_adapter_config": ("attr.openocd_adapter_config", False),
     "slot_spec": ("attr.slot_spec", False),
@@ -224,6 +225,11 @@ def exec_env_common_attrs(**kwargs):
         ),
         "flash_scramble_tool": attr.label(
             default = kwargs.get("flash_scramble_tool"),
+            executable = True,
+            cfg = "exec",
+        ),
+        "rram_scramble_tool": attr.label(
+            default = kwargs.get("rram_scramble_tool"),
             executable = True,
             cfg = "exec",
         ),

--- a/rules/opentitan/fpga.bzl
+++ b/rules/opentitan/fpga.bzl
@@ -105,7 +105,7 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
         default = elf
         rom = None
         rom32 = None
-    elif ctx.attr.kind == "flash":
+    elif ctx.attr.kind in ("flash", "rram"):
         default = signed_bin if signed_bin else binary
         rom = None
         rom32 = None

--- a/rules/opentitan/legacy.bzl
+++ b/rules/opentitan/legacy.bzl
@@ -6,6 +6,7 @@ load(
     "@lowrisc_opentitan//rules/opentitan:transform.bzl",
     "convert_to_vmem",
     "scramble_flash",
+    "scramble_rram",
     _obj_transform = "obj_transform",
 )
 load("@lowrisc_opentitan//rules:rv.bzl", "rv_rule")
@@ -99,7 +100,7 @@ vmem_file = rv_rule(
             default = 64,
             doc = "Word size of VMEM file",
             mandatory = True,
-            values = [32, 64],
+            values = [32, 64, 128],
         ),
     },
 )
@@ -134,6 +135,41 @@ scramble_flash_vmem = rv_rule(
         ),
         "_tool": attr.label(
             default = "@//util/design:gen-flash-img",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)
+
+def _scramble_rram_vmem_impl(ctx):
+    outputs = [scramble_rram(ctx, suffix = "scr.vmem", name = ctx.attr.out or None)]
+    return [
+        DefaultInfo(
+            files = depset(outputs),
+            data_runfiles = ctx.runfiles(files = outputs),
+        ),
+    ]
+
+scramble_rram_vmem = rv_rule(
+    implementation = _scramble_rram_vmem_impl,
+    attrs = {
+        "src": attr.label(allow_single_file = True),
+        "otp": attr.label(allow_single_file = True),
+        "out": attr.string(
+            default = "",
+            doc = "Optional name for the output file. If provided the output name will be <out>.scr.vmem otherwise <name>.scr.vmem.",
+        ),
+        "top_secret_cfg": attr.label(
+            allow_single_file = True,
+            default = "//hw/top:secrets",
+            doc = "Generated top configuration file including secrets.",
+        ),
+        "otp_data_perm": attr.label(
+            default = "//util/design/data:data_perm",
+            doc = "Option to indicate OTP VMEM file bit layout.",
+        ),
+        "_tool": attr.label(
+            default = "@//util/design:gen-rram-img",
             executable = True,
             cfg = "exec",
         ),

--- a/rules/opentitan/qemu.bzl
+++ b/rules/opentitan/qemu.bzl
@@ -285,6 +285,9 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
             firmware_elf = elf,
         )
         rom = exec_env.rom[SimQemuBinaryInfo].rom
+    elif ctx.attr.kind == "rram":
+        # TODO: add rram implementation
+        fail("RRAM is not yet supported in QEMU")
     else:
         fail("Not implemented: kind == ", ctx.attr.kind)
 

--- a/rules/opentitan/silicon.bzl
+++ b/rules/opentitan/silicon.bzl
@@ -12,6 +12,7 @@ load(
     "convert_to_vmem",
     "extract_software_logs",
     "scramble_flash",
+    "scramble_rram",
 )
 load(
     "@lowrisc_opentitan//rules/opentitan:util.bzl",
@@ -72,7 +73,12 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
             src = signed_bin if signed_bin else binary,
             word_size = 32,
         )
-    elif ctx.attr.kind == "flash":
+    elif ctx.attr.kind in ("flash", "rram"):
+        is_rram = ctx.attr.kind == "rram"
+        word_size = 128 if is_rram else 64
+        scramble = scramble_rram if is_rram else scramble_flash
+        scramble_tool = exec_env.rram_scramble_tool if is_rram else exec_env.flash_scramble_tool
+
         default = signed_bin if signed_bin else binary
         rom = None
 
@@ -81,18 +87,19 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
             ctx,
             name = name,
             src = default,
-            word_size = 64,
+            word_size = word_size,
+            fill = "0x00" if is_rram else "0xff",
         )
-        vmem = scramble_flash(
+        vmem = scramble(
             ctx,
             name = name,
-            suffix = "64.scr.vmem",
+            suffix = "{}.scr.vmem".format(word_size),
             src = vmem_base,
             otp = get_fallback(ctx, "file.otp", exec_env),
             otp_mmap = exec_env.otp_mmap,
             top_secret_cfg = exec_env.top_secret_cfg,
             otp_data_perm = exec_env.otp_data_perm,
-            _tool = exec_env.flash_scramble_tool.files_to_run,
+            _tool = scramble_tool.files_to_run,
         )
     else:
         fail("Not implemented: kind ==", ctx.attr.kind)

--- a/rules/opentitan/sim_dv.bzl
+++ b/rules/opentitan/sim_dv.bzl
@@ -17,6 +17,7 @@ load(
     "convert_to_vmem",
     "extract_software_logs",
     "scramble_flash",
+    "scramble_rram",
 )
 load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
 
@@ -79,8 +80,13 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
             word_size = 32,
         )
         vmem32 = None
-    elif ctx.attr.kind == "flash":
-        # First convert to VMEM, then scramble according to flash
+    elif ctx.attr.kind in ("flash", "rram"):
+        is_rram = ctx.attr.kind == "rram"
+        word_size = 128 if is_rram else 64
+        scramble = scramble_rram if is_rram else scramble_flash
+        scramble_tool = exec_env.rram_scramble_tool if is_rram else exec_env.flash_scramble_tool
+
+        # First convert to VMEM, then scramble according to the technology's
         # scrambling settings.
         # When dvsim and bazel use different otp image which has different scramble option,
         # there is a corner case where dvsim can't find vmem file.
@@ -89,24 +95,28 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
             ctx,
             name = name,
             src = signed_bin if signed_bin else binary,
-            word_size = 64,
+            word_size = word_size,
+            fill = "0x00" if is_rram else "0xff",
         )
-        vmem32 = convert_to_vmem(
+        if not is_rram:
+            vmem32 = convert_to_vmem(
+                ctx,
+                name = name,
+                src = signed_bin if signed_bin else binary,
+                word_size = 32,
+            )
+        else:
+            vmem32 = None
+        vmem = scramble(
             ctx,
             name = name,
-            src = signed_bin if signed_bin else binary,
-            word_size = 32,
-        )
-        vmem = scramble_flash(
-            ctx,
-            name = name,
-            suffix = "64.scr.vmem",
+            suffix = "{}.scr.vmem".format(word_size),
             src = vmem_base,
             otp = get_fallback(ctx, "file.otp", exec_env),
             otp_mmap = exec_env.otp_mmap,
             top_secret_cfg = exec_env.top_secret_cfg,
             otp_data_perm = exec_env.otp_data_perm,
-            _tool = exec_env.flash_scramble_tool.files_to_run,
+            _tool = scramble_tool.files_to_run,
         )
         rom = None
         rom32 = None

--- a/rules/opentitan/sim_verilator.bzl
+++ b/rules/opentitan/sim_verilator.bzl
@@ -75,25 +75,24 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
             src = signed_bin if signed_bin else binary,
             word_size = 32,
         )
-    elif ctx.attr.kind == "flash":
-        # FIXME: We need to separate the concept of a software component from
-        # the physical device and its properties; software test images are
-        # usually loaded into flash memory for English Breakfast and Earl Grey
-        # but they are stored in the ConTrol Network RAM on Darjeeling targets.
-        if exec_env.design == "darjeeling":
-            vmem = convert_to_vmem(
-                ctx,
-                name = name,
-                src = signed_bin if signed_bin else binary,
-                word_size = 32,
-            )
+    elif ctx.attr.kind in ("flash", "rram"):
+        is_rram = ctx.attr.kind == "rram"
+        if is_rram:
+            word_size = 128
         else:
-            vmem = convert_to_vmem(
-                ctx,
-                name = name,
-                src = signed_bin if signed_bin else binary,
-                word_size = 64,
-            )
+            # FIXME: We need to separate the concept of a software component
+            # from the physical device and its properties; software test
+            # images are usually loaded into flash memory for English
+            # Breakfast and Earl Grey but they are stored in the ConTrol
+            # Network RAM on Darjeeling targets.
+            word_size = 32 if exec_env.design == "darjeeling" else 64
+        vmem = convert_to_vmem(
+            ctx,
+            name = name,
+            src = signed_bin if signed_bin else binary,
+            word_size = word_size,
+            fill = "0x00" if is_rram else "0xff",
+        )
         default = vmem
         rom = None
         rom32 = None

--- a/rules/opentitan/transform.bzl
+++ b/rules/opentitan/transform.bzl
@@ -190,6 +190,10 @@ def convert_to_vmem(ctx, **kwargs):
                  if not specified.
         src: The src File object.
         format: The objcopy output-format.
+        fill: The byte value used to pad to word alignment, e.g. "0xff".
+              Defaults to "0xff" (flash's unprogrammed state); callers
+              producing RRAM images should pass "0x00" (RRAM's unprogrammed
+              state).
     Returns:
       The transformed File.
     """
@@ -202,20 +206,23 @@ def convert_to_vmem(ctx, **kwargs):
     output = ctx.actions.declare_file(output)
     src = get_override(ctx, "file.src", kwargs)
 
+    fill_str = kwargs.get("fill", "0xff")
+
     ctx.actions.run(
         outputs = [output],
         inputs = [src],
         arguments = [
             src.path,
             "--binary",
-            # Reverse the endianness of every word.
+            # Reverse the endianness of every word. srec_cat's --byte-swap
+            # width is in bits, matching word_size directly.
             "--offset",
             "0x0",
             "--byte-swap",
-            str(word_size // 8),
+            str(word_size),
             # Pad to word alignment
             "--fill",
-            "0xff",
+            fill_str,
             "-within",
             src.path,
             "-binary",
@@ -269,6 +276,69 @@ def scramble_flash(ctx, **kwargs):
         "--in-flash-vmem",
         src.path,
         "--out-flash-vmem",
+        output.path,
+    ]
+
+    # Always get top_secret_cfg since the tool requires it
+    top_secret_cfg = get_override(ctx, "file.top_secret_cfg", kwargs)
+    arguments.extend(["--top-secret-cfg", top_secret_cfg.path])
+    inputs.append(top_secret_cfg)
+
+    if otp:
+        arguments.extend([
+            "--in-otp-vmem",
+            otp.path,
+        ])
+        inputs.extend([otp])
+
+        otp_data_perm = get_override(ctx, "attr.otp_data_perm", kwargs)
+        if otp_data_perm:
+            arguments.extend(["--otp-data-perm", str(otp_data_perm[BuildSettingInfo].value)])
+
+    tool = get_override(ctx, "executable._tool", kwargs)
+    ctx.actions.run(
+        outputs = [output],
+        inputs = inputs,
+        arguments = arguments,
+        executable = tool,
+    )
+    return output
+
+def scramble_rram(ctx, **kwargs):
+    """Scramble a VMEM file according to a RRAM scrambling configuration.
+
+    Args:
+      ctx: The context object for this rule.
+      kwargs: Overrides of values normally retrived from the context object.
+        output: The name of the output file.  Constructed from `name` and `suffix`
+                 if not specified.
+        suffix: The suffix to give the file if the output isn't specified.
+        src: The src File object.
+        otp: The OTP settings.
+        otp_mmap: The OTP memory mapping file.
+
+        top_secret_cfg: The secret configuration file.
+        otp_data_perm: The OTP data permutation configuration.
+        _tool: The rram scrambling script.
+
+    Returns:
+      The transformed File.
+    """
+    output = kwargs.get("output")
+    if not output:
+        name = get_override(ctx, "attr.name", kwargs)
+        suffix = get_override(ctx, "attr.suffix", kwargs)
+        output = "{}.{}".format(name, suffix)
+
+    output = ctx.actions.declare_file(output)
+    src = get_override(ctx, "file.src", kwargs)
+    otp = get_override(ctx, "file.otp", kwargs)
+
+    inputs = [src]
+    arguments = [
+        "--in-rram-vmem",
+        src.path,
+        "--out-rram-vmem",
         output.path,
     ]
 


### PR DESCRIPTION
As per [RFC ](https://docs.google.com/document/d/1kYprEycc14MmAAGHIltgDwPmdEC7HEVOlhRwe60sn7o/edit?tab=t.0#heading=h.7h2usu46nmnp), Earlgrey will be extended with support for RRAM based non-volatile memory.

This 4th integration PR adds bazel rules for the RRAM image generation

