### PR TITLE
[ci] Temporarily downgrade Git in the cherry-pick action to fix intermittent backport failures

### DIFF
--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -31,6 +31,20 @@ jobs:
     if: github.event.pull_request.merged == true && (github.event_name != 'labeled' || startsWith('CherryPick:', github.event.label.name))
     runs-on: ubuntu-latest
     steps:
+      - name: Downgrade Git version
+        run: |
+          # FIXME: Due to a regression in Git 2.54.0, we temporarily pin a downgraded version.
+          # Ubuntu maintains an apt-repository for candidate/stable releases, but otherwise older
+          # versions are not available. We could optionally compile Git 2.53.0 from source, but
+          # instead we just revert to the latest system Git (2.34.1) since we don't need any newer
+          # features. This should allow the cherry-picking flow to work consistently. When
+          # Git 2.55.0 (which contains a fix) is available and packaged in the GitHub ubuntu 2404
+          # runners, this step should be dropped.
+          # See: https://lore.kernel.org/git/CANOh7gEEw+6146NN3JV8EYxQarj0KkyA7r3RZ6v-DxeqQZLrCA@mail.gmail.com/
+          sudo apt-get update
+          sudo apt-get install --allow-downgrades -y git=1:2.34.1-1ubuntu1 git-man=1:2.34.1-1ubuntu1
+          git --version
+
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Fix the `cherrypick.yml` (backporting) action by manually downgrading the Git version from Git 2.54.0 to Git 2.34.1.

We have been seeing intermittent failures in runs of the cherry-pick action since the version bump (v2.4.1 -> v4.5.2) performed in #30182. See for example #30372 or #30415.

```
Backporting to target branch 'master...'
/usr/bin/git fetch --depth=1 origin master
fatal: shallow file has changed since we read it
Backport failed for `master`: couldn't find remote ref `master`.
```

This appears to be caused by a combination of this change (which picks up the [major version 3.0 bump](https://github.com/korthout/backport-action/releases/tag/v3.0.0) which now cherry-picks the *rebased* commits instead of the commits visible from the pull request head but not from the base - meaning a different sequence of git operations is executed), **combined** with a known Git regression in version 2.54.0. See mailing list discussion: https://lore.kernel.org/git/CANOh7gEEw+6146NN3JV8EYxQarj0KkyA7r3RZ6v-DxeqQZLrCA@mail.gmail.com/

There is a patch for this that will be available in Git 2.55.0 - so when that is released and packaged for Ubuntu (and used by the latest Github runners), we can drop this change as the problem should be fixed. But until then we need to downgrade the Git version to work around this. We cannot trivially downgrade to 2.53.0 since only the latest candidate/stable versions are packaged by Ubuntu - we could compile Git from source, but to make it easier, let's just fall back to the latest packaged system version which is Git 2.34.1.

I've already tested this in a CI workflow to check that there are no obvious errors: https://github.com/lowRISC/opentitan/actions/runs/27620701694/job/81668546486?pr=30425#step:2:1. Hopefully this should be enough to fix the current errors - if not, we will need to investigate further.