### PR TITLE
[earlgrey/verilator] Integrate padring into chiplevel

### DIFF
--- a/hw/top_earlgrey/chip_earlgrey_verilator.core
+++ b/hw/top_earlgrey/chip_earlgrey_verilator.core
@@ -18,6 +18,7 @@ filesets:
       - lowrisc:prim_generic:flash
 
     files:
+      - rtl/padring_verilator.sv: { file_type: systemVerilogSource }
       - rtl/chip_earlgrey_verilator.sv: { file_type: systemVerilogSource }
 
 parameters:

--- a/hw/top_earlgrey/dv/verilator/chip_sim_tb.sv
+++ b/hw/top_earlgrey/dv/verilator/chip_sim_tb.sv
@@ -26,45 +26,53 @@ module chip_sim_tb (
   logic cio_usbdev_dp_p2d, cio_usbdev_dp_d2p, cio_usbdev_dp_en_d2p;
   logic cio_usbdev_dn_p2d, cio_usbdev_dn_d2p, cio_usbdev_dn_en_d2p;
 
+  // DUT: Only clock and reset in port list, I/O driven via XMR
   chip_earlgrey_verilator u_dut (
     .clk_i,
-    .rst_ni,
-
-    // communication with GPIO
-    .cio_gpio_p2d_i(cio_gpio_p2d),
-    .cio_gpio_d2p_o(cio_gpio_d2p),
-    .cio_gpio_en_d2p_o(cio_gpio_en_d2p),
-    .cio_gpio_pull_en_o(cio_gpio_pull_en),
-    .cio_gpio_pull_select_o(cio_gpio_pull_select),
-
-    // communication with UART
-    .cio_uart_rx_p2d_i(cio_uart_rx_p2d),
-    .cio_uart_tx_d2p_o(cio_uart_tx_d2p),
-
-    // communication with SPI
-    .cio_spi_device_sck_p2d_i(cio_spi_device_sck_p2d),
-    .cio_spi_device_csb_p2d_i(cio_spi_device_csb_p2d),
-    .cio_spi_device_sdi_p2d_i(cio_spi_device_sdi_p2d),
-    .cio_spi_device_sdo_d2p_o(cio_spi_device_sdo_d2p),
-    .cio_spi_device_sdo_en_d2p_o(cio_spi_device_sdo_en_d2p),
-
-    // communication with USB
-    .cio_usbdev_sense_p2d_i(cio_usbdev_sense_p2d),
-    .cio_usbdev_dp_pullup_d2p_o(cio_usbdev_dp_pullup_d2p),
-    .cio_usbdev_dn_pullup_d2p_o(cio_usbdev_dn_pullup_d2p),
-    .cio_usbdev_dp_p2d_i(cio_usbdev_dp_p2d),
-    .cio_usbdev_dp_d2p_o(cio_usbdev_dp_d2p),
-    .cio_usbdev_dp_en_d2p_o(cio_usbdev_dp_en_d2p),
-    .cio_usbdev_dn_p2d_i(cio_usbdev_dn_p2d),
-    .cio_usbdev_dn_d2p_o(cio_usbdev_dn_d2p),
-    .cio_usbdev_dn_en_d2p_o(cio_usbdev_dn_en_d2p),
-    .cio_usbdev_d_p2d_i(cio_usbdev_d_p2d),
-    .cio_usbdev_d_d2p_o(cio_usbdev_d_d2p),
-    .cio_usbdev_d_en_d2p_o(cio_usbdev_d_en_d2p),
-    .cio_usbdev_se0_d2p_o(cio_usbdev_se0_d2p),
-    .cio_usbdev_rx_enable_d2p_o(cio_usbdev_rx_enable_d2p),
-    .cio_usbdev_tx_use_d_se0_d2p_o(cio_usbdev_tx_use_d_se0_d2p)
+    .rst_ni
   );
+
+  // ---------------------------------------------------------------------------
+  // Connect the DPI models to the pad-level signals inside the Verilator
+  // padring via hierarchical references. The *_p2d pad nets are undriven
+  // inside padring_verilator, so the testbench is their sole driver; the
+  // *_d2p, *_en_d2p and pull nets are driven in the padring and read out here.
+  // ---------------------------------------------------------------------------
+
+  // GPIO
+  assign u_dut.u_padring.cio_gpio_p2d = cio_gpio_p2d;
+  assign cio_gpio_d2p         = u_dut.u_padring.cio_gpio_d2p;
+  assign cio_gpio_en_d2p      = u_dut.u_padring.cio_gpio_en_d2p;
+  assign cio_gpio_pull_en     = u_dut.u_padring.cio_gpio_pull_en;
+  assign cio_gpio_pull_select = u_dut.u_padring.cio_gpio_pull_select;
+
+  // UART
+  assign u_dut.u_padring.cio_uart_rx_p2d = cio_uart_rx_p2d;
+  assign cio_uart_tx_d2p = u_dut.u_padring.cio_uart_tx_d2p;
+
+  // SPI device
+  assign u_dut.u_padring.cio_spi_device_sck_p2d = cio_spi_device_sck_p2d;
+  assign u_dut.u_padring.cio_spi_device_csb_p2d = cio_spi_device_csb_p2d;
+  assign u_dut.u_padring.cio_spi_device_sdi_p2d = cio_spi_device_sdi_p2d;
+  assign cio_spi_device_sdo_d2p    = u_dut.u_padring.cio_spi_device_sdo_d2p;
+  assign cio_spi_device_sdo_en_d2p = u_dut.u_padring.cio_spi_device_sdo_en_d2p;
+
+  // USB
+  assign u_dut.u_padring.cio_usbdev_sense_p2d = cio_usbdev_sense_p2d;
+  assign u_dut.u_padring.cio_usbdev_dp_p2d    = cio_usbdev_dp_p2d;
+  assign u_dut.u_padring.cio_usbdev_dn_p2d    = cio_usbdev_dn_p2d;
+  assign u_dut.u_padring.cio_usbdev_d_p2d     = cio_usbdev_d_p2d;
+  assign cio_usbdev_dp_pullup_d2p    = u_dut.u_padring.cio_usbdev_dp_pullup_d2p;
+  assign cio_usbdev_dn_pullup_d2p    = u_dut.u_padring.cio_usbdev_dn_pullup_d2p;
+  assign cio_usbdev_dp_d2p           = u_dut.u_padring.cio_usbdev_dp_d2p;
+  assign cio_usbdev_dp_en_d2p        = u_dut.u_padring.cio_usbdev_dp_en_d2p;
+  assign cio_usbdev_dn_d2p           = u_dut.u_padring.cio_usbdev_dn_d2p;
+  assign cio_usbdev_dn_en_d2p        = u_dut.u_padring.cio_usbdev_dn_en_d2p;
+  assign cio_usbdev_d_d2p            = u_dut.u_padring.cio_usbdev_d_d2p;
+  assign cio_usbdev_d_en_d2p         = u_dut.u_padring.cio_usbdev_d_en_d2p;
+  assign cio_usbdev_se0_d2p          = u_dut.u_padring.cio_usbdev_se0_d2p;
+  assign cio_usbdev_rx_enable_d2p    = u_dut.u_padring.cio_usbdev_rx_enable_d2p;
+  assign cio_usbdev_tx_use_d_se0_d2p = u_dut.u_padring.cio_usbdev_tx_use_d_se0_d2p;
 
   // GPIO DPI
   gpiodpi #(.N_GPIO(32)) u_gpiodpi (
@@ -152,9 +160,11 @@ module chip_sim_tb (
     .dp_p2d          (cio_usbdev_dp_p2d),
     .dp_d2p          (cio_usbdev_dp_d2p),
     .dp_en_d2p       (cio_usbdev_dp_en_d2p),
+    .dp_en_p2d       (),
     .dn_p2d          (cio_usbdev_dn_p2d),
     .dn_d2p          (cio_usbdev_dn_d2p),
     .dn_en_d2p       (cio_usbdev_dn_en_d2p),
+    .dn_en_p2d       (),
     .d_p2d           (cio_usbdev_d_p2d),
     .d_d2p           (cio_usbdev_d_d2p),
     .d_en_d2p        (cio_usbdev_d_en_d2p),

--- a/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
@@ -5,43 +5,7 @@
 module chip_earlgrey_verilator (
   // Clock and Reset
   input clk_i,
-  input rst_ni,
-
-  // communication with GPIO
-  input [31:0] cio_gpio_p2d_i,
-  output logic [31:0] cio_gpio_d2p_o,
-  output logic [31:0] cio_gpio_en_d2p_o,
-  output logic [31:0] cio_gpio_pull_en_o,
-  output logic [31:0] cio_gpio_pull_select_o,
-
-  // communication with UART
-  input cio_uart_rx_p2d_i,
-  output logic cio_uart_tx_d2p_o,
-  output logic cio_uart_tx_en_d2p_o,
-
-  // communication with SPI
-  input cio_spi_device_sck_p2d_i,
-  input cio_spi_device_csb_p2d_i,
-  input cio_spi_device_sdi_p2d_i,
-  output logic cio_spi_device_sdo_d2p_o,
-  output logic cio_spi_device_sdo_en_d2p_o,
-
-  // communication with USB
-  input cio_usbdev_sense_p2d_i,
-  output logic cio_usbdev_dp_pullup_d2p_o,
-  output logic cio_usbdev_dn_pullup_d2p_o,
-  input cio_usbdev_dp_p2d_i,
-  output logic cio_usbdev_dp_d2p_o,
-  output logic cio_usbdev_dp_en_d2p_o,
-  input cio_usbdev_dn_p2d_i,
-  output logic cio_usbdev_dn_d2p_o,
-  output logic cio_usbdev_dn_en_d2p_o,
-  input cio_usbdev_d_p2d_i,
-  output logic cio_usbdev_d_d2p_o,
-  output logic cio_usbdev_d_en_d2p_o,
-  output logic cio_usbdev_se0_d2p_o,
-  output logic cio_usbdev_rx_enable_d2p_o,
-  output logic cio_usbdev_tx_use_d_se0_d2p_o
+  input rst_ni
 );
 
   import top_earlgrey_pkg::*;
@@ -49,21 +13,16 @@ module chip_earlgrey_verilator (
 
   logic IO_JTCK, IO_JTMS, IO_JTRST_N, IO_JTDI, IO_JTDO;
 
-  // TODO: instantiate padring and route these signals through that module
   logic [pinmux_reg_pkg::NDioPads-1:0] dio_in;
   logic [pinmux_reg_pkg::NDioPads-1:0] dio_out;
   logic [pinmux_reg_pkg::NDioPads-1:0] dio_oe;
 
-  always_comb begin : assign_dio_in
-    dio_in = '0;
-    dio_in[DioSpiDeviceSck] = cio_spi_device_sck_p2d_i;
-    dio_in[DioSpiDeviceCsb] = cio_spi_device_csb_p2d_i;
-    dio_in[DioSpiDeviceSd0] = cio_spi_device_sdi_p2d_i;
-    dio_in[DioUsbdevUsbDp] = cio_usbdev_dp_p2d_i;
-    dio_in[DioUsbdevUsbDn] = cio_usbdev_dn_p2d_i;
-  end
+  logic [pinmux_reg_pkg::NMioPads-1:0] mio_in;
+  logic [pinmux_reg_pkg::NMioPads-1:0] mio_out;
+  logic [pinmux_reg_pkg::NMioPads-1:0] mio_oe;
+  prim_pad_wrapper_pkg::pad_attr_t[pinmux_reg_pkg::NMioPads-1:0] mio_attr;
 
-  // USB
+  // USB related signals
   logic usb_dp_pullup_en;
   logic usb_dn_pullup_en;
   logic usb_rx_d;
@@ -72,133 +31,26 @@ module chip_earlgrey_verilator (
   logic usb_tx_use_d_se0;
   logic usb_rx_enable;
 
-  assign usb_rx_d = cio_usbdev_d_p2d_i;
-  assign cio_usbdev_d_d2p_o  = usb_tx_d;
-  assign cio_usbdev_d_en_d2p_o = dio_oe[DioUsbdevUsbDp];
-  assign cio_usbdev_dn_pullup_d2p_o = usb_dn_pullup_en;
-  assign cio_usbdev_dp_pullup_d2p_o = usb_dp_pullup_en;
-  assign cio_usbdev_se0_d2p_o = usb_tx_se0;
-  assign cio_usbdev_rx_enable_d2p_o = usb_rx_enable;
-  assign cio_usbdev_tx_use_d_se0_d2p_o = usb_tx_use_d_se0;
+  // Padring substitute that maps the mio/dio interface from pinmux to flat
+  // cio_* signals that the testbench DPI models connect to.
+  padring_verilator u_padring (
+    .mio_in_o  (mio_in ),
+    .mio_out_i (mio_out),
+    .mio_oe_i  (mio_oe ),
+    .mio_attr_i(mio_attr),
 
-  assign cio_usbdev_dp_d2p_o = dio_out[DioUsbdevUsbDp];
-  assign cio_usbdev_dp_en_d2p_o = dio_oe[DioUsbdevUsbDp];
-  assign cio_usbdev_dn_d2p_o = dio_out[DioUsbdevUsbDn];
-  assign cio_usbdev_dn_en_d2p_o = dio_oe[DioUsbdevUsbDn];
+    .dio_in_o (dio_in ),
+    .dio_out_i(dio_out),
+    .dio_oe_i (dio_oe ),
 
-  assign cio_spi_device_sdo_d2p_o = dio_out[DioSpiDeviceSd1];
-  assign cio_spi_device_sdo_en_d2p_o = dio_oe[DioSpiDeviceSd1];
-
-  logic [pinmux_reg_pkg::NMioPads-1:0] mio_in;
-  logic [pinmux_reg_pkg::NMioPads-1:0] mio_out;
-  logic [pinmux_reg_pkg::NMioPads-1:0] mio_oe;
-  prim_pad_wrapper_pkg::pad_attr_t[pinmux_reg_pkg::NMioPads-1:0] mio_attr;
-
-  always_comb begin : assign_mio_in
-    mio_in = '0;
-    // 14 generic GPIOs
-    mio_in[MioPadIob12:MioPadIob6] = cio_gpio_p2d_i[6:0];
-    mio_in[MioPadIor13:MioPadIor5] = cio_gpio_p2d_i[13:7];
-    // SW straps
-    mio_in[MioPadIoc2:MioPadIoc0] = cio_gpio_p2d_i[24:22];
-    // TAP straps
-    mio_in[MioPadIoc5] = cio_gpio_p2d_i[27];
-    mio_in[MioPadIoc8] = cio_gpio_p2d_i[30];
-    // UART RX
-    mio_in[MioPadIoc3] = cio_uart_rx_p2d_i;
-    // USB VBUS sense
-    mio_in[MioPadIoc7] = cio_usbdev_sense_p2d_i;
-  end
-
-
-  // 14 generic GPIOs
-  assign cio_gpio_d2p_o[6:0]        = mio_out[MioPadIob12:MioPadIob6];
-  assign cio_gpio_en_d2p_o[6:0]     = mio_oe[MioPadIob12:MioPadIob6];
-  assign cio_gpio_d2p_o[13:7]       = mio_out[MioPadIor13:MioPadIor5];
-  assign cio_gpio_en_d2p_o[13:7]    = mio_oe[MioPadIor13:MioPadIor5];
-  assign cio_gpio_d2p_o[21:14]      = '0;
-  assign cio_gpio_en_d2p_o[21:14]   = '0;
-  // SW straps
-  assign cio_gpio_d2p_o[24:22]      = mio_out[MioPadIoc2:MioPadIoc0];
-  assign cio_gpio_en_d2p_o[24:22]   = mio_oe[MioPadIoc2:MioPadIoc0];
-  assign cio_gpio_d2p_o[26:25]      = '0;
-  assign cio_gpio_en_d2p_o[26:25]   = '0;
-  // TAP straps
-  assign cio_gpio_d2p_o[27]         = mio_out[MioPadIoc5];
-  assign cio_gpio_en_d2p_o[27]      = mio_oe[MioPadIoc5];
-  assign cio_gpio_d2p_o[29:28]      = '0;
-  assign cio_gpio_en_d2p_o[29:28]   = '0;
-  assign cio_gpio_d2p_o[30]         = mio_out[MioPadIoc8];
-  assign cio_gpio_en_d2p_o[30]      = mio_oe[MioPadIoc8];
-  assign cio_gpio_d2p_o[31]         = '0;
-  assign cio_gpio_en_d2p_o[31]      = '0;
-
-  assign cio_uart_tx_d2p_o    = mio_out[MioPadIoc4];
-  assign cio_uart_tx_en_d2p_o = mio_oe[MioPadIoc4];
-
-  // Note: we're collecting the `pull_en` and `pull_select` signals together
-  // so that the GPIO DPI functions can simulate weak and strong GPIO
-  // inputs.  The `cio_gpio_pull_en_o` and `cio_gpio_pull_select_o` bit
-  // vectors should have the same ordering as the `cio_gpio_d2p_o` vector.
-  // See gpiodpi.c to see how weak/strong inputs work.
-  //
-  // Pull enable for 14 generic GPIOs
-  assign cio_gpio_pull_en_o[0] = mio_attr[MioPadIob6].pull_en;
-  assign cio_gpio_pull_en_o[1] = mio_attr[MioPadIob7].pull_en;
-  assign cio_gpio_pull_en_o[2] = mio_attr[MioPadIob8].pull_en;
-  assign cio_gpio_pull_en_o[3] = mio_attr[MioPadIob9].pull_en;
-  assign cio_gpio_pull_en_o[4] = mio_attr[MioPadIob10].pull_en;
-  assign cio_gpio_pull_en_o[5] = mio_attr[MioPadIob11].pull_en;
-  assign cio_gpio_pull_en_o[6] = mio_attr[MioPadIob12].pull_en;
-  assign cio_gpio_pull_en_o[7] = mio_attr[MioPadIor5].pull_en;
-  assign cio_gpio_pull_en_o[8] = mio_attr[MioPadIor6].pull_en;
-  assign cio_gpio_pull_en_o[9] = mio_attr[MioPadIor7].pull_en;
-  assign cio_gpio_pull_en_o[10] = mio_attr[MioPadIor10].pull_en;
-  assign cio_gpio_pull_en_o[11] = mio_attr[MioPadIor11].pull_en;
-  assign cio_gpio_pull_en_o[12] = mio_attr[MioPadIor12].pull_en;
-  assign cio_gpio_pull_en_o[13] = mio_attr[MioPadIor13].pull_en;
-  assign cio_gpio_pull_en_o[21:14] = '0;
-
-  // Pull enable for SW STRAPs
-  assign cio_gpio_pull_en_o[22] = mio_attr[MioPadIoc0].pull_en;
-  assign cio_gpio_pull_en_o[23] = mio_attr[MioPadIoc1].pull_en;
-  assign cio_gpio_pull_en_o[24] = mio_attr[MioPadIoc2].pull_en;
-
-  // Pull enable for TAP STRAPs
-  assign cio_gpio_pull_en_o[26:25] = '0;
-  assign cio_gpio_pull_en_o[27] = mio_attr[MioPadIoc5].pull_en;
-  assign cio_gpio_pull_en_o[29:28] = '0;
-  assign cio_gpio_pull_en_o[30] = mio_attr[MioPadIoc8].pull_en;
-  assign cio_gpio_pull_en_o[31] = '0;
-
-  // Pull select for 14 generic GPIOs
-  assign cio_gpio_pull_select_o[0] = mio_attr[MioPadIob6].pull_select;
-  assign cio_gpio_pull_select_o[1] = mio_attr[MioPadIob7].pull_select;
-  assign cio_gpio_pull_select_o[2] = mio_attr[MioPadIob8].pull_select;
-  assign cio_gpio_pull_select_o[3] = mio_attr[MioPadIob9].pull_select;
-  assign cio_gpio_pull_select_o[4] = mio_attr[MioPadIob10].pull_select;
-  assign cio_gpio_pull_select_o[5] = mio_attr[MioPadIob11].pull_select;
-  assign cio_gpio_pull_select_o[6] = mio_attr[MioPadIob12].pull_select;
-  assign cio_gpio_pull_select_o[7] = mio_attr[MioPadIor5].pull_select;
-  assign cio_gpio_pull_select_o[8] = mio_attr[MioPadIor6].pull_select;
-  assign cio_gpio_pull_select_o[9] = mio_attr[MioPadIor7].pull_select;
-  assign cio_gpio_pull_select_o[10] = mio_attr[MioPadIor10].pull_select;
-  assign cio_gpio_pull_select_o[11] = mio_attr[MioPadIor11].pull_select;
-  assign cio_gpio_pull_select_o[12] = mio_attr[MioPadIor12].pull_select;
-  assign cio_gpio_pull_select_o[13] = mio_attr[MioPadIor13].pull_select;
-  assign cio_gpio_pull_select_o[21:14] = '0;
-
-  // Pull select for SW STRAPs
-  assign cio_gpio_pull_select_o[22] = mio_attr[MioPadIoc0].pull_select;
-  assign cio_gpio_pull_select_o[23] = mio_attr[MioPadIoc1].pull_select;
-  assign cio_gpio_pull_select_o[24] = mio_attr[MioPadIoc2].pull_select;
-
-  // Pull select for TAP STRAPs
-  assign cio_gpio_pull_select_o[26:25] = '0;
-  assign cio_gpio_pull_select_o[27] = mio_attr[MioPadIoc5].pull_select;
-  assign cio_gpio_pull_select_o[29:28] = '0;
-  assign cio_gpio_pull_select_o[30] = mio_attr[MioPadIoc8].pull_select;
-  assign cio_gpio_pull_select_o[31] = '0;
+    .usb_rx_d_o        (usb_rx_d        ),
+    .usb_tx_d_i        (usb_tx_d        ),
+    .usb_tx_se0_i      (usb_tx_se0      ),
+    .usb_tx_use_d_se0_i(usb_tx_use_d_se0),
+    .usb_rx_enable_i   (usb_rx_enable   ),
+    .usb_dp_pullup_en_i(usb_dp_pullup_en),
+    .usb_dn_pullup_en_i(usb_dn_pullup_en)
+  );
 
   ////////////////////////////////
   // AST - Custom for Verilator //

--- a/hw/top_earlgrey/rtl/padring_verilator.sv
+++ b/hw/top_earlgrey/rtl/padring_verilator.sv
@@ -1,0 +1,220 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Padring substitute for the Verilator simulation top.
+//
+// This module models the (otherwise absent) padring for the Verilator
+// simulation top. It performs the mapping between the mio/dio pad interface
+// of the toplevel and the cio_* interfaces of the IPs that the DPI models in
+// the testbench drive and observe.
+
+// The cio_*_p2d signals are intentionally left *undriven* inside this module:
+// The Verilator testbench (chip_sim_tb) is their sole driver (through hierarchical
+// cross-references). Similarly, the cio_*_d2p and other output signals are driven
+// here and read back by the testbench in the same way.
+//
+// This allows to encapsulate the Verilator padring functionality here instead of
+// having to expose the whole cio_* signals through ports all the way to the Verilator
+// test bench.
+
+module padring_verilator
+  import top_earlgrey_pkg::*;
+(
+  // Multiplexed I/O (to/from top_earlgrey)
+  output logic [pinmux_reg_pkg::NMioPads-1:0] mio_in_o,
+  input  logic [pinmux_reg_pkg::NMioPads-1:0] mio_out_i,
+  input  logic [pinmux_reg_pkg::NMioPads-1:0] mio_oe_i,
+  input  prim_pad_wrapper_pkg::pad_attr_t [pinmux_reg_pkg::NMioPads-1:0] mio_attr_i,
+
+  // Dedicated I/O (to/from top_earlgrey)
+  output logic [pinmux_reg_pkg::NDioPads-1:0] dio_in_o,
+  input  logic [pinmux_reg_pkg::NDioPads-1:0] dio_out_i,
+  input  logic [pinmux_reg_pkg::NDioPads-1:0] dio_oe_i,
+  input  prim_pad_wrapper_pkg::pad_attr_t [pinmux_reg_pkg::NDioPads-1:0] dio_attr_i,
+
+  // USB signals routed directly to/from top_earlgrey (not via mio/dio)
+  output logic usb_rx_d_o,
+  input  logic usb_tx_d_i,
+  input  logic usb_tx_se0_i,
+  input  logic usb_tx_use_d_se0_i,
+  input  logic usb_rx_enable_i,
+  input  logic usb_dp_pullup_en_i,
+  input  logic usb_dn_pullup_en_i
+);
+
+  //////////////////////////////////////////////////////////////////////////
+  // Pad-level signals                                                    //
+  //////////////////////////////////////////////////////////////////////////
+
+  // GPIO
+  logic [31:0] cio_gpio_p2d;
+  logic [31:0] cio_gpio_d2p;
+  logic [31:0] cio_gpio_en_d2p;
+  logic [31:0] cio_gpio_pull_en;
+  logic [31:0] cio_gpio_pull_select;
+
+  // UART
+  logic cio_uart_rx_p2d;
+  logic cio_uart_tx_d2p;
+  logic cio_uart_tx_en_d2p;
+
+  // SPI device
+  logic cio_spi_device_sck_p2d;
+  logic cio_spi_device_csb_p2d;
+  logic cio_spi_device_sdi_p2d;
+  logic cio_spi_device_sdo_d2p;
+  logic cio_spi_device_sdo_en_d2p;
+
+  // USB
+  logic cio_usbdev_sense_p2d;
+  logic cio_usbdev_dp_pullup_d2p;
+  logic cio_usbdev_dn_pullup_d2p;
+  logic cio_usbdev_dp_p2d, cio_usbdev_dp_d2p, cio_usbdev_dp_en_d2p;
+  logic cio_usbdev_dn_p2d, cio_usbdev_dn_d2p, cio_usbdev_dn_en_d2p;
+  logic cio_usbdev_d_p2d,  cio_usbdev_d_d2p,  cio_usbdev_d_en_d2p;
+  logic cio_usbdev_se0_d2p;
+  logic cio_usbdev_rx_enable_d2p;
+  logic cio_usbdev_tx_use_d_se0_d2p;
+
+  //////////////////////////////////////////////////////////////////////////
+  // Dedicated I/O mapping                                                //
+  //////////////////////////////////////////////////////////////////////////
+
+  always_comb begin : assign_dio_in
+    dio_in_o = '0;
+    dio_in_o[DioSpiDeviceSck] = cio_spi_device_sck_p2d;
+    dio_in_o[DioSpiDeviceCsb] = cio_spi_device_csb_p2d;
+    dio_in_o[DioSpiDeviceSd0] = cio_spi_device_sdi_p2d;
+    dio_in_o[DioUsbdevUsbDp]  = cio_usbdev_dp_p2d;
+    dio_in_o[DioUsbdevUsbDn]  = cio_usbdev_dn_p2d;
+  end
+
+  // USB
+  assign usb_rx_d_o                  = cio_usbdev_d_p2d;
+  assign cio_usbdev_d_d2p            = usb_tx_d_i;
+  assign cio_usbdev_d_en_d2p         = dio_oe_i[DioUsbdevUsbDp];
+  assign cio_usbdev_dn_pullup_d2p    = usb_dn_pullup_en_i;
+  assign cio_usbdev_dp_pullup_d2p    = usb_dp_pullup_en_i;
+  assign cio_usbdev_se0_d2p          = usb_tx_se0_i;
+  assign cio_usbdev_rx_enable_d2p    = usb_rx_enable_i;
+  assign cio_usbdev_tx_use_d_se0_d2p = usb_tx_use_d_se0_i;
+
+  assign cio_usbdev_dp_d2p    = dio_out_i[DioUsbdevUsbDp];
+  assign cio_usbdev_dp_en_d2p = dio_oe_i[DioUsbdevUsbDp];
+  assign cio_usbdev_dn_d2p    = dio_out_i[DioUsbdevUsbDn];
+  assign cio_usbdev_dn_en_d2p = dio_oe_i[DioUsbdevUsbDn];
+
+  assign cio_spi_device_sdo_d2p    = dio_out_i[DioSpiDeviceSd1];
+  assign cio_spi_device_sdo_en_d2p = dio_oe_i[DioSpiDeviceSd1];
+
+  //////////////////////////////////////////////////////////////////////////
+  // Multiplexed I/O mapping                                              //
+  //////////////////////////////////////////////////////////////////////////
+
+  always_comb begin : assign_mio_in
+    mio_in_o = '0;
+    // 14 generic GPIOs
+    mio_in_o[MioPadIob12:MioPadIob6] = cio_gpio_p2d[6:0];
+    mio_in_o[MioPadIor13:MioPadIor5] = cio_gpio_p2d[13:7];
+    // SW straps
+    mio_in_o[MioPadIoc2:MioPadIoc0] = cio_gpio_p2d[24:22];
+    // TAP straps
+    mio_in_o[MioPadIoc5] = cio_gpio_p2d[27];
+    mio_in_o[MioPadIoc8] = cio_gpio_p2d[30];
+    // UART RX
+    mio_in_o[MioPadIoc3] = cio_uart_rx_p2d;
+    // USB VBUS sense
+    mio_in_o[MioPadIoc7] = cio_usbdev_sense_p2d;
+  end
+
+  // 14 generic GPIOs
+  assign cio_gpio_d2p[6:0]        = mio_out_i[MioPadIob12:MioPadIob6];
+  assign cio_gpio_en_d2p[6:0]     = mio_oe_i[MioPadIob12:MioPadIob6];
+  assign cio_gpio_d2p[13:7]       = mio_out_i[MioPadIor13:MioPadIor5];
+  assign cio_gpio_en_d2p[13:7]    = mio_oe_i[MioPadIor13:MioPadIor5];
+  assign cio_gpio_d2p[21:14]      = '0;
+  assign cio_gpio_en_d2p[21:14]   = '0;
+  // SW straps
+  assign cio_gpio_d2p[24:22]      = mio_out_i[MioPadIoc2:MioPadIoc0];
+  assign cio_gpio_en_d2p[24:22]   = mio_oe_i[MioPadIoc2:MioPadIoc0];
+  assign cio_gpio_d2p[26:25]      = '0;
+  assign cio_gpio_en_d2p[26:25]   = '0;
+  // TAP straps
+  assign cio_gpio_d2p[27]         = mio_out_i[MioPadIoc5];
+  assign cio_gpio_en_d2p[27]      = mio_oe_i[MioPadIoc5];
+  assign cio_gpio_d2p[29:28]      = '0;
+  assign cio_gpio_en_d2p[29:28]   = '0;
+  assign cio_gpio_d2p[30]         = mio_out_i[MioPadIoc8];
+  assign cio_gpio_en_d2p[30]      = mio_oe_i[MioPadIoc8];
+  assign cio_gpio_d2p[31]         = '0;
+  assign cio_gpio_en_d2p[31]      = '0;
+
+  assign cio_uart_tx_d2p    = mio_out_i[MioPadIoc4];
+  assign cio_uart_tx_en_d2p = mio_oe_i[MioPadIoc4];
+
+  // Note: we're collecting the pull_en and pull_select signals together
+  // such that the GPIO DPI functions can simulate weak and strong GPIO
+  // inputs. The cio_gpio_pull_en and cio_gpio_pull_select bit vectors
+  // must have the same ordering as cio_gpio_d2p.
+  // See gpiodpi.c to see how weak/strong inputs work.
+
+  // Pull enable for 14 generic GPIOs
+  assign cio_gpio_pull_en[0] = mio_attr_i[MioPadIob6].pull_en;
+  assign cio_gpio_pull_en[1] = mio_attr_i[MioPadIob7].pull_en;
+  assign cio_gpio_pull_en[2] = mio_attr_i[MioPadIob8].pull_en;
+  assign cio_gpio_pull_en[3] = mio_attr_i[MioPadIob9].pull_en;
+  assign cio_gpio_pull_en[4] = mio_attr_i[MioPadIob10].pull_en;
+  assign cio_gpio_pull_en[5] = mio_attr_i[MioPadIob11].pull_en;
+  assign cio_gpio_pull_en[6] = mio_attr_i[MioPadIob12].pull_en;
+  assign cio_gpio_pull_en[7] = mio_attr_i[MioPadIor5].pull_en;
+  assign cio_gpio_pull_en[8] = mio_attr_i[MioPadIor6].pull_en;
+  assign cio_gpio_pull_en[9] = mio_attr_i[MioPadIor7].pull_en;
+  assign cio_gpio_pull_en[10] = mio_attr_i[MioPadIor10].pull_en;
+  assign cio_gpio_pull_en[11] = mio_attr_i[MioPadIor11].pull_en;
+  assign cio_gpio_pull_en[12] = mio_attr_i[MioPadIor12].pull_en;
+  assign cio_gpio_pull_en[13] = mio_attr_i[MioPadIor13].pull_en;
+  assign cio_gpio_pull_en[21:14] = '0;
+
+  // Pull enable for SW STRAPs
+  assign cio_gpio_pull_en[22] = mio_attr_i[MioPadIoc0].pull_en;
+  assign cio_gpio_pull_en[23] = mio_attr_i[MioPadIoc1].pull_en;
+  assign cio_gpio_pull_en[24] = mio_attr_i[MioPadIoc2].pull_en;
+
+  // Pull enable for TAP STRAPs
+  assign cio_gpio_pull_en[26:25] = '0;
+  assign cio_gpio_pull_en[27] = mio_attr_i[MioPadIoc5].pull_en;
+  assign cio_gpio_pull_en[29:28] = '0;
+  assign cio_gpio_pull_en[30] = mio_attr_i[MioPadIoc8].pull_en;
+  assign cio_gpio_pull_en[31] = '0;
+
+  // Pull select for 14 generic GPIOs
+  assign cio_gpio_pull_select[0] = mio_attr_i[MioPadIob6].pull_select;
+  assign cio_gpio_pull_select[1] = mio_attr_i[MioPadIob7].pull_select;
+  assign cio_gpio_pull_select[2] = mio_attr_i[MioPadIob8].pull_select;
+  assign cio_gpio_pull_select[3] = mio_attr_i[MioPadIob9].pull_select;
+  assign cio_gpio_pull_select[4] = mio_attr_i[MioPadIob10].pull_select;
+  assign cio_gpio_pull_select[5] = mio_attr_i[MioPadIob11].pull_select;
+  assign cio_gpio_pull_select[6] = mio_attr_i[MioPadIob12].pull_select;
+  assign cio_gpio_pull_select[7] = mio_attr_i[MioPadIor5].pull_select;
+  assign cio_gpio_pull_select[8] = mio_attr_i[MioPadIor6].pull_select;
+  assign cio_gpio_pull_select[9] = mio_attr_i[MioPadIor7].pull_select;
+  assign cio_gpio_pull_select[10] = mio_attr_i[MioPadIor10].pull_select;
+  assign cio_gpio_pull_select[11] = mio_attr_i[MioPadIor11].pull_select;
+  assign cio_gpio_pull_select[12] = mio_attr_i[MioPadIor12].pull_select;
+  assign cio_gpio_pull_select[13] = mio_attr_i[MioPadIor13].pull_select;
+  assign cio_gpio_pull_select[21:14] = '0;
+
+  // Pull select for SW STRAPs
+  assign cio_gpio_pull_select[22] = mio_attr_i[MioPadIoc0].pull_select;
+  assign cio_gpio_pull_select[23] = mio_attr_i[MioPadIoc1].pull_select;
+  assign cio_gpio_pull_select[24] = mio_attr_i[MioPadIoc2].pull_select;
+
+  // Pull select for TAP STRAPs
+  assign cio_gpio_pull_select[26:25] = '0;
+  assign cio_gpio_pull_select[27] = mio_attr_i[MioPadIoc5].pull_select;
+  assign cio_gpio_pull_select[29:28] = '0;
+  assign cio_gpio_pull_select[30] = mio_attr_i[MioPadIoc8].pull_select;
+  assign cio_gpio_pull_select[31] = '0;
+
+endmodule


### PR DESCRIPTION
This PR is the first step towards auto-generating the Verilator chiplevels. These are currently all written by hand, which makes handling them during top/chiplevel restructuring like in #30076 a tedious and error-prone task.

The main challenge here is that Verilator uses a dummy padring, which does not contain any actual pads. Instead, the tb uses DPI modules to directly drive the various `cio_*` signals.

The strategy to achieve the above is therefore as follows:
1) Create Verilator-specific dummy padring(s), which the chiplevel then instantiates for the Verilator target (to be created in a follow-up PR, see below).
2) Connect to said padring through hierarchical module references (XMR) directly from the Verilator tb. This allows us to avoid a huge port list/map from said padring to the chiplevel boundary, which would inflate the shared chiplevel template greatly.
3) Create the Verilator target within the various `top_<name>.hjson` files, which takes care of any target-specific pinout of the "logic" toplevels (which now coincide with power domains).
4) Profit - delete the manually maintained Verilator chiplevels. Let `topgen` handle any updates, and auto-generate `chip_<name>_verilator.sv`.

This PR implements steps 1) and 2) for earlgrey.