### PR TITLE
Manual cherry-pick: [boot_services] Wipe ok status after ECC verify

### DIFF
--- a/sw/device/silicon_creator/lib/otbn_boot_services.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.c
@@ -304,6 +304,10 @@ rom_error_t otbn_boot_sigverify_finish(uint32_t *recovered_r) {
 
   // TODO(#20023): Check the instruction count register (see `mod_exp_otbn`).
 
+  // Clear the status in OTBN.
+  uint32_t zero = 0;
+  HARDENED_RETURN_IF_ERROR(sc_otbn_dmem_write(1, &zero, kOtbnVarBootOk));
+
   // Read the recovered `r` value from DMEM.
   return sc_otbn_dmem_read(kEcdsaP256SignatureComponentWords, kOtbnVarBootXr,
                            recovered_r);


### PR DESCRIPTION
In order to clear the status in OTBN, clear it after using ECDSA verify.


(cherry picked from commit 3c102cd22f183b80a463c7d3e7ce4f90f61aa99c)