### PR TITLE
[ci] Follow-up fix to the `cherrypick.yml` workflow

### DIFF
--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -36,13 +36,18 @@ jobs:
           # FIXME: Due to a regression in Git 2.54.0, we temporarily pin a downgraded version.
           # Ubuntu maintains an apt-repository for candidate/stable releases, but otherwise older
           # versions are not available. We could optionally compile Git 2.53.0 from source, but
-          # instead we just revert to the latest system Git (2.34.1) since we don't need any newer
-          # features. This should allow the cherry-picking flow to work consistently. When
-          # Git 2.55.0 (which contains a fix) is available and packaged in the GitHub ubuntu 2404
+          # instead we just revert to system Git 2.43.0 since we don't need any of the newer
+          # features. This should allow the cherry-picking flow to work consistently. When Git
+          # 2.55.0 (which contains a fix) is available and packaged in the GitHub ubuntu 2404
           # runners, this step should be dropped.
           # See: https://lore.kernel.org/git/CANOh7gEEw+6146NN3JV8EYxQarj0KkyA7r3RZ6v-DxeqQZLrCA@mail.gmail.com/
           sudo apt-get update
-          sudo apt-get install --allow-downgrades -y git=1:2.34.1-1ubuntu1 git-man=1:2.34.1-1ubuntu1
+          mkdir -p /tmp/git-downgrade
+          cd /tmp/git-downgrade
+          apt-get download git=1:2.43.0* git-man=1:2.43.0*
+          sudo dpkg -i *.deb
+          sudo apt-get -f install || true
+          sudo apt-mark hold git git-man
           git --version
 
       - uses: actions/checkout@v6


### PR DESCRIPTION
A follow up fix to #30425 to address some CI failures that started appearing after merging. See for example: https://github.com/lowRISC/opentitan/actions/runs/27680291341/job/81865764311

I believe that the issue is that the git package version that was pinned was tested in an Ubuntu 22 environment, but the cherry pick action runners are using Ubuntu 24 - and so need to pin a different version. There also seems to be some issues with APT getting the packages generally, so for now I'm installing via dpkg. Unfortunately, it is quite hard to test as this workflow uses the `pull_request_target` event, which runs based on the content of the default branch (`master`).

Note that this fix is still quite fragile - Github runner updates could potentially break this workaround if they this version of Git is no longer being packaged by the system. But this should hopefully be sufficient whilst we wait for the default Git version to be bumped. An alternative would be manually compiling Git in this workflow and adding it to `PATH`, but that's probably still a bit too heavyweight for this kind of temporary workaround?

I've tested this by applying [this test commit](https://github.com/alexjones0/opentitan/commits/42c26d6bea28a7ca500e9d90ef3d7272851407b6) in CI which [seems to be working OK](https://github.com/lowRISC/opentitan/actions/runs/27686060185/job/81884925055?pr=30438#step:2:73).