### PR TITLE
[crypto/mldsa] Temporarily disable all MLDSA OTBN unit tests

### DIFF
--- a/sw/otbn/crypto/mldsa87/keygen/tests/BUILD
+++ b/sw/otbn/crypto/mldsa87/keygen/tests/BUILD
@@ -24,18 +24,18 @@ srcs = [
 ]
 
 unit_tests = [
-    "mldsa87_keygen_rej_bounded_poly_test",
-    "mldsa87_keygen_expand_s1_test",
-    "mldsa87_keygen_expand_s2_test",
-    "mldsa87_keygen_encode_t0_test",
-    "mldsa87_keygen_encode_t1_test",
-    "mldsa87_keygen_power2round_test",
-    "mldsa87_keygen_encode_s_test",
-    "mldsa87_keygen_sample_s_test",
-    "mldsa87_keygen_compute_t_test",
-    "mldsa87_keygen_encode_t_test",
-    "mldsa87_keygen_hash_seed_test",
-    "mldsa87_keygen_hash_pk_test",
+    # "mldsa87_keygen_rej_bounded_poly_test",
+    # "mldsa87_keygen_expand_s1_test",
+    # "mldsa87_keygen_expand_s2_test",
+    # "mldsa87_keygen_encode_t0_test",
+    # "mldsa87_keygen_encode_t1_test",
+    # "mldsa87_keygen_power2round_test",
+    # "mldsa87_keygen_encode_s_test",
+    # "mldsa87_keygen_sample_s_test",
+    # "mldsa87_keygen_compute_t_test",
+    # "mldsa87_keygen_encode_t_test",
+    # "mldsa87_keygen_hash_seed_test",
+    # "mldsa87_keygen_hash_pk_test",
 ]
 
 [
@@ -50,9 +50,9 @@ unit_tests = [
 ]
 
 mldsa87_nist_tests = [
-    "mldsa87_keygen_nist_acvp_51_test",
-    "mldsa87_keygen_nist_acvp_52_test",
-    "mldsa87_keygen_nist_acvp_53_test",
+    # "mldsa87_keygen_nist_acvp_51_test",
+    # "mldsa87_keygen_nist_acvp_52_test",
+    # "mldsa87_keygen_nist_acvp_53_test",
 ]
 
 [

--- a/sw/otbn/crypto/mldsa87/sign/tests/BUILD
+++ b/sw/otbn/crypto/mldsa87/sign/tests/BUILD
@@ -23,20 +23,20 @@ srcs = [
 ]
 
 unit_tests = [
-    "mldsa87_sign_sample_mask_poly_test",
-    "mldsa87_sign_expand_mask_test",
-    "mldsa87_sign_decode_t0_test",
-    "mldsa87_sign_decode_w1_test",
-    "mldsa87_sign_encode_z_test",
-    "mldsa87_sign_compute_w_test",
-    "mldsa87_sign_decompose_w_test",
-    "mldsa87_sign_compute_z_test",
-    "mldsa87_sign_compute_r0_pos_test",
-    "mldsa87_sign_compute_r0_neg_test",
-    "mldsa87_sign_compute_x0_test",
-    "mldsa87_sign_make_hint_test",
-    "mldsa87_sign_hw_check_hint_test",
-    "mldsa87_sign_compress_hint_test",
+    # "mldsa87_sign_sample_mask_poly_test",
+    # "mldsa87_sign_expand_mask_test",
+    # "mldsa87_sign_decode_t0_test",
+    # "mldsa87_sign_decode_w1_test",
+    # "mldsa87_sign_encode_z_test",
+    # "mldsa87_sign_compute_w_test",
+    # "mldsa87_sign_decompose_w_test",
+    # "mldsa87_sign_compute_z_test",
+    # "mldsa87_sign_compute_r0_pos_test",
+    # "mldsa87_sign_compute_r0_neg_test",
+    # "mldsa87_sign_compute_x0_test",
+    # "mldsa87_sign_make_hint_test",
+    # "mldsa87_sign_hw_check_hint_test",
+    # "mldsa87_sign_compress_hint_test",
 ]
 
 [
@@ -51,9 +51,9 @@ unit_tests = [
 ]
 
 mldsa87_nist_tests = [
-    "mldsa87_sign_nist_acvp_61_test",
-    "mldsa87_sign_nist_acvp_62_test",
-    "mldsa87_sign_nist_acvp_74_test",
+    # "mldsa87_sign_nist_acvp_61_test",
+    # "mldsa87_sign_nist_acvp_62_test",
+    # "mldsa87_sign_nist_acvp_74_test",
 ]
 
 [

--- a/sw/otbn/crypto/mldsa87/tests/BUILD
+++ b/sw/otbn/crypto/mldsa87/tests/BUILD
@@ -20,29 +20,29 @@ srcs = [
 ]
 
 unit_tests = [
-    "mldsa87_poly_add_test",
-    "mldsa87_poly_sub_test",
-    "mldsa87_poly_mul_test",
-    "mldsa87_poly_mul_add_test",
-    "mldsa87_ntt_test",
-    "mldsa87_intt_test",
-    "mldsa87_ntt_intt_test",
-    "mldsa87_rej_ntt_poly_test",
-    "mldsa87_sample_in_ball_test",
-    "mldsa87_challenge_hash_test",
-    "mldsa87_expand_a_test",
-    "mldsa87_encode_w1_test",
-    "mldsa87_decode_s_test",
-    "mldsa87_xof_shake128_test",
-    "mldsa87_xof_shake256_test",
-    "mldsa87_sec_a2b_test",
-    "mldsa87_sec_b2a_test",
-    "mldsa87_sec_add_test",
-    "mldsa87_sec_unmask_test",
-    "mldsa87_sec_leq_test",
-    "mldsa87_sec_bound_check_test",
-    "mldsa87_sec_decompose_test",
-    "mldsa87_sec_mod5_test",
+    # "mldsa87_poly_add_test",
+    # "mldsa87_poly_sub_test",
+    # "mldsa87_poly_mul_test",
+    # "mldsa87_poly_mul_add_test",
+    # "mldsa87_ntt_test",
+    # "mldsa87_intt_test",
+    # "mldsa87_ntt_intt_test",
+    # "mldsa87_rej_ntt_poly_test",
+    # "mldsa87_sample_in_ball_test",
+    # "mldsa87_challenge_hash_test",
+    # "mldsa87_expand_a_test",
+    # "mldsa87_encode_w1_test",
+    # "mldsa87_decode_s_test",
+    # "mldsa87_xof_shake128_test",
+    # "mldsa87_xof_shake256_test",
+    # "mldsa87_sec_a2b_test",
+    # "mldsa87_sec_b2a_test",
+    # "mldsa87_sec_add_test",
+    # "mldsa87_sec_unmask_test",
+    # "mldsa87_sec_leq_test",
+    # "mldsa87_sec_bound_check_test",
+    # "mldsa87_sec_decompose_test",
+    # "mldsa87_sec_mod5_test",
 ]
 
 [
@@ -60,24 +60,24 @@ unit_tests = [
 # Randomized tests #
 ####################
 
-py_binary(
-    name = "mldsa87_ntt_testgen",
-    srcs = ["mldsa87_ntt_testgen.py"],
-    imports = [
-        "../../../../../hw/ip/otbn/util",
-    ],
-    deps = [
-        "//hw/ip/otbn/util/shared:testgen",
-    ],
-)
+# py_binary(
+#     name = "mldsa87_ntt_testgen",
+#     srcs = ["mldsa87_ntt_testgen.py"],
+#     imports = [
+#         "../../../../../hw/ip/otbn/util",
+#     ],
+#     deps = [
+#         "//hw/ip/otbn/util/shared:testgen",
+#     ],
+# )
 
-otbn_sim_testgen(
-    name = "mldsa87_ntt_rand_test",
-    srcs = [
-        "mldsa87_ntt_test.s",
-        "//sw/otbn/crypto/mldsa87:mldsa87_ntt.s",
-    ],
-    number = 10,
-    testgen = ":mldsa87_ntt_testgen",
-    type = "testcase",
-)
+# otbn_sim_testgen(
+#     name = "mldsa87_ntt_rand_test",
+#     srcs = [
+#         "mldsa87_ntt_test.s",
+#         "//sw/otbn/crypto/mldsa87:mldsa87_ntt.s",
+#     ],
+#     number = 10,
+#     testgen = ":mldsa87_ntt_testgen",
+#     type = "testcase",
+# )

--- a/sw/otbn/crypto/mldsa87/verify/tests/BUILD
+++ b/sw/otbn/crypto/mldsa87/verify/tests/BUILD
@@ -21,17 +21,17 @@ srcs = [
 ]
 
 unit_tests = [
-    "mldsa87_verify_decode_z_test",
-    "mldsa87_verify_decode_t1_test",
-    "mldsa87_verify_decode_h_test",
-    "mldsa87_verify_check_infinity_norm_test",
-    "mldsa87_verify_decompose_test",
-    "mldsa87_verify_shift_left_test",
-    "mldsa87_verify_decode_sig_test",
-    "mldsa87_verify_check_infinity_norm_z_test",
-    "mldsa87_verify_compute_w_approx_test",
-    "mldsa87_verify_use_hint_test",
-    "mldsa87_verify_check_hint_test",
+    # "mldsa87_verify_decode_z_test",
+    # "mldsa87_verify_decode_t1_test",
+    # "mldsa87_verify_decode_h_test",
+    # "mldsa87_verify_check_infinity_norm_test",
+    # "mldsa87_verify_decompose_test",
+    # "mldsa87_verify_shift_left_test",
+    # "mldsa87_verify_decode_sig_test",
+    # "mldsa87_verify_check_infinity_norm_z_test",
+    # "mldsa87_verify_compute_w_approx_test",
+    # "mldsa87_verify_use_hint_test",
+    # "mldsa87_verify_check_hint_test",
 ]
 
 [
@@ -46,12 +46,12 @@ unit_tests = [
 ]
 
 mldsa87_nist_tests = [
-    "mldsa87_verify_nist_acvp_63_test",
-    "mldsa87_verify_nist_acvp_64_test",
-    "mldsa87_verify_nist_acvp_65_test",
-    "mldsa87_verify_nist_acvp_66_test",
-    "mldsa87_verify_nist_acvp_68_test",
-    "mldsa87_verify_nist_acvp_69_test",
+    # "mldsa87_verify_nist_acvp_63_test",
+    # "mldsa87_verify_nist_acvp_64_test",
+    # "mldsa87_verify_nist_acvp_65_test",
+    # "mldsa87_verify_nist_acvp_66_test",
+    # "mldsa87_verify_nist_acvp_68_test",
+    # "mldsa87_verify_nist_acvp_69_test",
 ]
 
 [


### PR DESCRIPTION
Restore master because commit 058efa9ca0 contains a OTBNSim change that does not compile.