### PR TITLE
[bazel,otbn] Declare OTBN YAML files as data for OTBN tools

### DIFF
--- a/hw/ip/otbn/util/shared/BUILD
+++ b/hw/ip/otbn/util/shared/BUILD
@@ -116,6 +116,14 @@ py_library(
 py_library(
     name = "insn_yaml",
     srcs = ["insn_yaml.py"],
+    data = [
+        "//hw/ip/otbn/data:base-insns.yml",
+        "//hw/ip/otbn/data:bignum-insns.yml",
+        "//hw/ip/otbn/data:csr.yml",
+        "//hw/ip/otbn/data:enc-schemes.yml",
+        "//hw/ip/otbn/data:insns.yml",
+        "//hw/ip/otbn/data:wsr.yml",
+    ],
     deps = [
         ":encoding",
         ":encoding_scheme",


### PR DESCRIPTION
We've been seeing local failures when building some OTBN libraries from a clean checkout:
```
./bazelisk.sh clean && ./bazelisk.sh build //sw/otbn/crypto/mldsa87:mldsa87_xof
```
which gives:
```
sw/otbn/crypto/mldsa87/mldsa87_xof.s:121: Failed to recognise csr name from KMAC_INTR.
```

This appears to originate from 058efa9ca0b8706093e838893f54c803761bd4d1. However, if you:
```
git checkout 058efa9ca0b8706093e838893f54c803761bd4d1~1
./bazelisk.sh clean && ./bazelisk.sh build //sw/otbn/crypto/mldsa87:mldsa87_xof
git checkout 058efa9ca0b8706093e838893f54c803761bd4d1
./bazelisk.sh build //sw/otbn/crypto/mldsa87:mldsa87_xof
```
Then it builds cleanly, despite the error being introduced, as Bazel cannot see the changes.

This is because the OTBN `insn_yaml` Python library makes extensive use of the OTBN YAML files for declaring instructions and registers (CSRs and WSRs), but it *doesn't* explicitly declare these files as data being used. This means that - despite often succeeding at building - Bazel won't be aware of changes to these files without cleaning its cache, and as such failures can go unnoticed due to use of stale (working) versions of these `.yml` files.

Future CI runs then pull from the cache (since they aren't aware that YAML file changes should propagate to OTBN library changes), meaning CI keeps passing.

I've added these explicit declarations - from a grep, I can only see them being used in mdbook documentation (out of scope for this PR), and `insn_yaml`. Please do mention if you're aware of them being used elsewhere.