### PR TITLE
[otbn] Add otbn_kmac_if to otbn fusecore

### DIFF
--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -64,10 +64,12 @@ filesets:
       - lowrisc:ip:edn_pkg
       - lowrisc:prim:edn_req
       - lowrisc:ip:otbn_pkg
+      - lowrisc:ip:kmac_pkg
       - lowrisc:ip:otp_ctrl_pkg
     files:
       - rtl/otbn_reg_top.sv
       - rtl/otbn_scramble_ctrl.sv
+      - rtl/otbn_kmac_if.sv
       - rtl/otbn.sv
     file_type: systemVerilogSource
 


### PR DESCRIPTION
Added otbn_kmac_if to otbn fusecore.

This change is required for importing the kmac package for the incoming application interface between OTBN and KMAC. Currently the formal DV tool fails at the RTL file elaboration stage without the inclusion of these files to fusesoc

Signed-off-by: Victor Nwali <victor.nwali@lowrisc.org>