### PR TITLE
[crypto/entropy] Add hardened protection in polling loop

### DIFF
--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -472,6 +472,8 @@ static status_t csrng_send_app_cmd(uint32_t base_address,
       // COVERAGE (HW ERR) The timeout should only happen with a HW error.
       return OTCRYPTO_RECOV_ERR;
     }
+    reg = abs_mmio_read32(sts_reg_addr);
+    HARDENED_CHECK_EQ(bitfield_bit32_read(reg, rdy_bit_offset), true);
   }
 
 #define ENTROPY_CMD(m, i) ((bitfield_field32_t){.mask = m, .index = i})
@@ -527,6 +529,8 @@ static status_t csrng_send_app_cmd(uint32_t base_address,
         // COVERAGE (HW ERR) The timeout should only happen with a HW error.
         return OTCRYPTO_RECOV_ERR;
       }
+      reg = abs_mmio_read32(sts_reg_addr);
+      HARDENED_CHECK_EQ(bitfield_bit32_read(reg, reg_rdy_bit_offset), true);
     }
     abs_mmio_write32(cmd_reg_addr, cmd.seed_material->data[i]);
   }
@@ -669,6 +673,8 @@ static status_t edn_ready_block(uint32_t edn_address) {
     // COVERAGE (HW ERR) The timeout should only happen with a HW error.
     return OTCRYPTO_RECOV_ERR;
   }
+  reg = abs_mmio_read32(edn_address + EDN_SW_CMD_STS_REG_OFFSET);
+  HARDENED_CHECK_EQ(bitfield_bit32_read(reg, EDN_SW_CMD_STS_CMD_RDY_BIT), true);
 
   if (bitfield_field32_read(reg, CSRNG_SW_CMD_STS_CMD_STS_FIELD)) {
     // COVERAGE (HW ERR) The status bit will be 0 unless there was a HW error.


### PR DESCRIPTION
Add the redundant verification that the RNG is ready to provide randomness.