### PR TITLE
[crypto/kmac] Temporarily disable all KMAC tests

### DIFF
--- a/sw/otbn/crypto/tests/BUILD
+++ b/sw/otbn/crypto/tests/BUILD
@@ -222,13 +222,13 @@ otbn_consttime_test(
     ],
 )
 
-otbn_sim_test(
-    name = "kmac_test",
-    srcs = [
-        "kmac_test.s",
-    ],
-    testcase = "kmac_test.hjson",
-)
+#otbn_sim_test(
+#    name = "kmac_test",
+#    srcs = [
+#        "kmac_test.s",
+#    ],
+#    testcase = "kmac_test.hjson",
+#)
 
 otbn_sim_test(
     name = "lcm_test",


### PR DESCRIPTION
Second attempt at restoring master due to the fault introduced in commit 058efa9.