### PR TITLE
[ci,bazel] Mark failing OTBN sim tests as broken instead of commenting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,7 +299,7 @@ jobs:
         with:
           service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
       - name: Execute tests
-        run: ./bazelisk.sh test --test_tag_filters=-nightly //sw/otbn/crypto/...
+        run: ./bazelisk.sh test --test_tag_filters=-broken,-skip_in_ci,-nightly //sw/otbn/crypto/...
 
   verilator_englishbreakfast:
     name: Verilated English Breakfast

--- a/sw/otbn/crypto/mldsa87/keygen/tests/BUILD
+++ b/sw/otbn/crypto/mldsa87/keygen/tests/BUILD
@@ -24,18 +24,18 @@ srcs = [
 ]
 
 unit_tests = [
-    # "mldsa87_keygen_rej_bounded_poly_test",
-    # "mldsa87_keygen_expand_s1_test",
-    # "mldsa87_keygen_expand_s2_test",
-    # "mldsa87_keygen_encode_t0_test",
-    # "mldsa87_keygen_encode_t1_test",
-    # "mldsa87_keygen_power2round_test",
-    # "mldsa87_keygen_encode_s_test",
-    # "mldsa87_keygen_sample_s_test",
-    # "mldsa87_keygen_compute_t_test",
-    # "mldsa87_keygen_encode_t_test",
-    # "mldsa87_keygen_hash_seed_test",
-    # "mldsa87_keygen_hash_pk_test",
+    "mldsa87_keygen_rej_bounded_poly_test",
+    "mldsa87_keygen_expand_s1_test",
+    "mldsa87_keygen_expand_s2_test",
+    "mldsa87_keygen_encode_t0_test",
+    "mldsa87_keygen_encode_t1_test",
+    "mldsa87_keygen_power2round_test",
+    "mldsa87_keygen_encode_s_test",
+    "mldsa87_keygen_sample_s_test",
+    "mldsa87_keygen_compute_t_test",
+    "mldsa87_keygen_encode_t_test",
+    "mldsa87_keygen_hash_seed_test",
+    "mldsa87_keygen_hash_pk_test",
 ]
 
 [
@@ -44,15 +44,19 @@ unit_tests = [
         srcs = srcs + [
             test + ".s",
         ],
+        # FIXME: Temporarily broken after 058efa9ca0 as the mldsa87_xof implementation
+        # refers to CSR `KMAC_INTR` which no longer exists. This should be fixed and
+        # then this tag removed.
+        tags = ["broken"],
         testcase = test + ".hjson",
     )
     for test in unit_tests
 ]
 
 mldsa87_nist_tests = [
-    # "mldsa87_keygen_nist_acvp_51_test",
-    # "mldsa87_keygen_nist_acvp_52_test",
-    # "mldsa87_keygen_nist_acvp_53_test",
+    "mldsa87_keygen_nist_acvp_51_test",
+    "mldsa87_keygen_nist_acvp_52_test",
+    "mldsa87_keygen_nist_acvp_53_test",
 ]
 
 [
@@ -63,6 +67,10 @@ mldsa87_nist_tests = [
             "//sw/otbn/crypto/mldsa87/keygen:mldsa87_keygen.s",
             "//sw/otbn/crypto/mldsa87/keygen:mldsa87_keygen_mem.s",
         ],
+        # FIXME: Temporarily broken after 058efa9ca0 as the mldsa87_xof implementation
+        # refers to CSR `KMAC_INTR` which no longer exists. This should be fixed and
+        # then this tag removed.
+        tags = ["broken"],
         testcase = test + ".hjson",
     )
     for test in mldsa87_nist_tests

--- a/sw/otbn/crypto/tests/BUILD
+++ b/sw/otbn/crypto/tests/BUILD
@@ -222,13 +222,17 @@ otbn_consttime_test(
     ],
 )
 
-#otbn_sim_test(
-#    name = "kmac_test",
-#    srcs = [
-#        "kmac_test.s",
-#    ],
-#    testcase = "kmac_test.hjson",
-#)
+otbn_sim_test(
+    name = "kmac_test",
+    srcs = [
+        "kmac_test.s",
+    ],
+    # FIXME: Temporarily broken after 058efa9ca0 as the test assembly directly
+    # refers to CSR `KMAC_INTR` which no longer exists. This should be fixed and
+    # then this tag removed.
+    tags = ["broken"],
+    testcase = "kmac_test.hjson",
+)
 
 otbn_sim_test(
     name = "lcm_test",


### PR DESCRIPTION
Small cleanup following #30447 and #30459.

For other Bazel tests, we rely on tagging the test as `"broken"` so that these tests are filtered from CI but can still be queried etc. with Bazel locally (as opposed to commenting them out). Add this tag filtering behaviour to the OTBN crypto test job in CI, and change the commented-out tests to instead be marked as broken.

This doesn't matter as much now (as these tests will hopefully be fixed and re-enabled soon), but should be useful for future instances of broken tests.