### PR TITLE
Manual cherry-pick: [crypto] Clear sideload after operations

### DIFF
--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -289,6 +289,7 @@ cc_library(
     deps = [
         ":config",
         ":status",
+        "//sw/device/lib/crypto/drivers:aes",
         "//sw/device/lib/crypto/drivers:rv_core_ibex",
         "//sw/device/lib/crypto/impl:drbg",
         "//sw/device/lib/crypto/impl:integrity",
@@ -303,6 +304,10 @@ cc_test(
     srcs = ["key_transport_unittest.cc"],
     deps = [
         ":key_transport",
+        "//hw/top:aes_c_regs",
+        "//hw/top:keymgr_c_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:abs_mmio",
         "@googletest//:gtest_main",
     ],
 )

--- a/sw/device/lib/crypto/impl/ecc_curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc_curve25519.c
@@ -778,7 +778,8 @@ otcrypto_status_t otcrypto_x25519_keygen_async_finalize(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
   HARDENED_TRY_WIPE_DMEM(curve25519_x25519_keygen_finalize(public_key->key));
   public_key->checksum = otcrypto_integrity_unblinded_checksum(public_key);
-  return otcrypto_eval_exit(OTCRYPTO_OK);
+  // Clear the OTBN sideload slot (in case the seed was sideloaded).
+  return otcrypto_eval_exit(keymgr_sideload_clear_otbn());
 }
 
 otcrypto_status_t otcrypto_x25519_async_start(
@@ -819,5 +820,6 @@ otcrypto_status_t otcrypto_x25519_async_finalize(
     otcrypto_blinded_key_t *shared_secret) {
   HARDENED_TRY_WIPE_DMEM(curve25519_x25519_finalize(shared_secret->keyblob));
   shared_secret->checksum = otcrypto_integrity_blinded_checksum(shared_secret);
-  return otcrypto_eval_exit(OTCRYPTO_OK);
+  // Clear the OTBN sideload slot (in case the seed was sideloaded).
+  return otcrypto_eval_exit(keymgr_sideload_clear_otbn());
 }

--- a/sw/device/lib/crypto/impl/key_transport.c
+++ b/sw/device/lib/crypto/impl/key_transport.c
@@ -6,6 +6,7 @@
 
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/drivers/aes.h"
 #include "sw/device/lib/crypto/impl/aes_kwp/aes_kwp.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/impl/status.h"
@@ -244,6 +245,15 @@ static status_t aes_kwp_key_construct(const otcrypto_blinded_key_t *key_kek,
   return OTCRYPTO_OK;
 }
 
+/**
+ * Hardware cleanup guard.
+ */
+static void hw_wipe_guard(uint32_t *dummy) {
+  (void)dummy;
+  (void)aes_clear();
+  (void)keymgr_sideload_clear_aes();
+}
+
 otcrypto_status_t otcrypto_key_wrap(const otcrypto_blinded_key_t *key_to_wrap,
                                     const otcrypto_blinded_key_t *key_kek,
                                     otcrypto_word32_buf_t *wrapped_key) {
@@ -252,6 +262,10 @@ otcrypto_status_t otcrypto_key_wrap(const otcrypto_blinded_key_t *key_to_wrap,
       wrapped_key->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+
+  // Guarantees hw_wipe_guard() is called on exit.
+  uint32_t hw_cleanup_guard __attribute__((cleanup(hw_wipe_guard))) = 1;
+  (void)hw_cleanup_guard;
 
   // Check the integrity of the key material we are wrapping.
   if (launder32(otcrypto_integrity_blinded_key_check(key_to_wrap)) !=
@@ -311,6 +325,10 @@ otcrypto_status_t otcrypto_key_unwrap(
       unwrapped_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
+
+  // Guarantees hw_wipe_guard() is called on exit.
+  uint32_t hw_cleanup_guard __attribute__((cleanup(hw_wipe_guard))) = 1;
+  (void)hw_cleanup_guard;
 
   *success = kHardenedBoolFalse;
 

--- a/sw/device/lib/crypto/impl/key_transport_unittest.cc
+++ b/sw/device/lib/crypto/impl/key_transport_unittest.cc
@@ -8,10 +8,15 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "sw/device/lib/base/mock_abs_mmio.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/integrity.h"
+
+#include "hw/top/aes_regs.h"
+#include "hw/top/keymgr_regs.h"
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 namespace key_transport_unittest {
 namespace {
@@ -295,6 +300,12 @@ TEST(KeyTransport, BlindedKeyExportNotExportable) {
 }
 
 TEST(KeyTransport, KeyWrapUnwrapNegative) {
+  rom_test::NiceMockAbsMmio mmio;
+  ON_CALL(mmio, Read32(TOP_EARLGREY_AES_BASE_ADDR + AES_STATUS_REG_OFFSET))
+      .WillByDefault(testing::Return(1 << AES_STATUS_IDLE_BIT));
+  ON_CALL(mmio, Read32(TOP_EARLGREY_KEYMGR_BASE_ADDR +
+                       KEYMGR_SIDELOAD_CLEAR_REG_OFFSET))
+      .WillByDefault(testing::Return(KEYMGR_SIDELOAD_CLEAR_VAL_VALUE_AES));
   uint32_t target_keyblob[8] = {0};
   otcrypto_blinded_key_t target_key = {
       .config = kConfigNonExportableAesCtr128,


### PR DESCRIPTION
Clear the sideloaded key in 25519 and in key transport once the operation is done.


(cherry picked from commit f26b2f297ef61e29e9ba430a54dd866d8f07e7fa)