### PR TITLE
[rtl,fpga] Fix FPGA bkdr_loader target index validity check & update docs

### DIFF
--- a/hw/ip/bkdr_loader/README.md
+++ b/hw/ip/bkdr_loader/README.md
@@ -1,16 +1,8 @@
 # BKDR_LOADER Technical Specification
-<!-- BEGIN CMDGEN util/mdbook_regression_links.py --hjson hw/ip/bkdr_loader/data/bkdr_loader.hjson --top earlgrey -->
-| Regression | Version | [Stages](https://opentitan.org/book/doc/project_governance/development_stages.html) | Results |
-|-|-|-|-|
- [`bkdr_loader`](https://dashboard.reports.lowrisc.org/opentitan/earlgrey/dashboard.html) | 0.1.0 | D1, V0 | ![](https://dashboard.reports.lowrisc.org/opentitan/earlgrey/badge/bkdr_loader/test.svg) ![](https://dashboard.reports.lowrisc.org/opentitan/earlgrey/badge/bkdr_loader/passing.svg) ![](https://dashboard.reports.lowrisc.org/opentitan/earlgrey/badge/bkdr_loader/functional.svg) ![](https://dashboard.reports.lowrisc.org/opentitan/earlgrey/badge/bkdr_loader/code.svg) |
-
-<!-- END CMDGEN -->
 
 # Overview
 
-This document specifies the FPGA-only memory Backdoor Loader which is used to preload non-volatile
-and volatile memories on FPGA targets.
-
+This document specifies the FPGA-only memory Backdoor Loader which is used to preload non-volatile and volatile memories on FPGA targets.
 
 ## Features
 
@@ -22,15 +14,12 @@ and volatile memories on FPGA targets.
 
 ## Description
 
-The BKDR_LOADER intercepts the reset and JTAG signals between the FPGA pad array and the top-level
-OpenTitan instance. On reset, the IP samples the tap strap pins and becomes active if both strap
-signals are high (DFT mode on the ASIC).
+The BKDR_LOADER intercepts the reset and JTAG signals between the FPGA pad array and the top-level OpenTitan instance.
+On reset, the IP samples the tap strap pins and becomes active if both strap signals are high (DFT mode on the ASIC).
 
-When active, the module keeps the reset to both the AST and OpenTitan asserted to prevent any access
-to non-initialized memory regions. It presents an internal RISC-V DTM over which the loader's internal
-[registers](doc/registers.md) can be accessed. The BKDR_LOADER presents both the number of targets and key target
-information through its register space.
+When active, the module keeps the reset to both the AST and OpenTitan asserted to prevent any access to non-initialized memory regions.
+It presents an internal RISC-V DTM over which the loader's internal [registers](doc/registers.md) can be accessed.
+The BKDR_LOADER presents both the number of targets and key target information through its register space.
 
-After completing preloading and data validation, the loader is deactivated until the next
-button reset via the control register. In this case, the JTAG signals are forwarded to OpenTitan
-and the reset to the AST and OpenTitan is de-asserted.
+After completing preloading and data validation, the loader is deactivated until the next button reset via the control register.
+In this case, the JTAG signals are forwarded to OpenTitan and the reset to the AST and OpenTitan is de-asserted.

--- a/hw/ip/bkdr_loader/data/bkdr_loader.hjson
+++ b/hw/ip/bkdr_loader/data/bkdr_loader.hjson
@@ -68,7 +68,7 @@
             swaccess: "ro",
             hwaccess: "hwo",
             desc: '''
-                  Whether an error happened on the last access. Clear on read.
+                  Target index is currently misconfigured.
                   ''',
           }
         ]
@@ -84,7 +84,8 @@
             swaccess: "wo",
             hwaccess: "hro",
             desc: '''
-                  Write 1'b1 switches bkdr loader to mission mode.
+                  Write 1 to trigger the bkdr_loader to switch to mission mode.
+                  After this, the bkdr_loader cannot be used until the next reset.
                   ''',
           },
           { bits: "1"

--- a/hw/ip/bkdr_loader/doc/interfaces.md
+++ b/hw/ip/bkdr_loader/doc/interfaces.md
@@ -6,17 +6,27 @@ The following table lists the instantiation parameters of the backdoor loader.
 
 Parameter                   | Default               | Top Earlgrey      | Description
 ----------------------------|-----------------------|-------------------|---------------
-`NumBkdrTgts`               | 8                     | 8                 | Number of RAM targets supported.
-`MaxWordWidthDiv32`         | 4                     | 4                 | Supports up to 128-bit words.
+`NumBkdrTgts`               | 12                    | 12                | Number of RAM targets supported.
+`MaxWordWidthDiv32`         | 8                     | 8                 | Supports up to 256-bit words.
 
 ## Signals
 
+<!-- BEGIN CMDGEN util/regtool.py --interfaces ./hw/ip/bkdr_loader/data/bkdr_loader.hjson -->
 Referring to the [Comportable guideline for peripheral device functionality](https://opentitan.org/book/doc/contributing/hw/comportability), the module **`bkdr_loader`** has the following hardware interfaces defined
 - Primary Clock: **`clk_i`**
 - Other Clocks: *none*
-- Bus Device Interfaces (TL-UL): *none*
+- Bus Device Interfaces (TL-UL): **`regs_tl`**
 - Bus Host Interfaces (TL-UL): *none*
 - Peripheral Pins for Chip IO: *none*
 - Interrupts: *none*
 - Security Alerts: *none*
 - Security Countermeasures: *none*
+
+## [Inter-Module Signals](https://opentitan.org/book/doc/contributing/hw/comportability/index.html#inter-signal-handling)
+
+| Port Name   | Package::Struct   | Type    | Act   |   Width | Description   |
+|:------------|:------------------|:--------|:------|--------:|:--------------|
+| regs_tl     | tlul_pkg::tl      | req_rsp | rsp   |       1 |               |
+
+
+<!-- END CMDGEN -->

--- a/hw/ip/bkdr_loader/doc/registers.md
+++ b/hw/ip/bkdr_loader/doc/registers.md
@@ -75,10 +75,10 @@ Status register
 {"reg": [{"name": "ERROR", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name   | Description                                                  |
-|:------:|:------:|:-------:|:-------|:-------------------------------------------------------------|
-|  31:1  |        |         |        | Reserved                                                     |
-|   0    |   ro   |    x    | ERROR  | Whether an error happened on the last access. Clear on read. |
+|  Bits  |  Type  |  Reset  | Name   | Description                              |
+|:------:|:------:|:-------:|:-------|:-----------------------------------------|
+|  31:1  |        |         |        | Reserved                                 |
+|   0    |   ro   |    x    | ERROR  | Target index is currently misconfigured. |
 
 ## CONTROL
 Control register
@@ -92,13 +92,13 @@ Control register
 {"reg": [{"name": "DONE", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "WRITE_ENA", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 6}, {"name": "TARGET_IDX", "bits": 8, "attr": ["wo"], "rotate": 0}, {"bits": 16}], "config": {"lanes": 1, "fontsize": 10, "vspace": 110}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name       | Description                                                          |
-|:------:|:------:|:-------:|:-----------|:---------------------------------------------------------------------|
-| 31:16  |        |         |            | Reserved                                                             |
-|  15:8  |   wo   |   0x0   | TARGET_IDX | The bkdr memory index to write to.                                   |
-|  7:2   |        |         |            | Reserved                                                             |
-|   1    |   wo   |   0x0   | WRITE_ENA  | If set, a bkdr write is launched when writing to the index register. |
-|   0    |   wo   |   0x0   | DONE       | Write 1'b1 switches bkdr loader to mission mode.                     |
+|  Bits  |  Type  |  Reset  | Name       | Description                                                                                                                    |
+|:------:|:------:|:-------:|:-----------|:-------------------------------------------------------------------------------------------------------------------------------|
+| 31:16  |        |         |            | Reserved                                                                                                                       |
+|  15:8  |   wo   |   0x0   | TARGET_IDX | The bkdr memory index to write to.                                                                                             |
+|  7:2   |        |         |            | Reserved                                                                                                                       |
+|   1    |   wo   |   0x0   | WRITE_ENA  | If set, a bkdr write is launched when writing to the index register.                                                           |
+|   0    |   wo   |   0x0   | DONE       | Write 1 to trigger the bkdr_loader to switch to mission mode. After this, the bkdr_loader cannot be used until the next reset. |
 
 ## NUM_BKDR_TARGETS
 Number of bkdr targets available.

--- a/hw/ip/bkdr_loader/rtl/bkdr_loader.sv
+++ b/hw/ip/bkdr_loader/rtl/bkdr_loader.sv
@@ -154,7 +154,7 @@ module bkdr_loader
   );
 
   // Throw error if we address a non-existing target
-  assign tgt_idx_err = !(reg2hw.control.target_idx.q inside {BkdrValidTgts});
+  assign tgt_idx_err = !(bkdr_idx_e'(reg2hw.control.target_idx.q) inside {BkdrValidTgts});
 
   assign hw2reg.usr_access_timestamp.d = fpga_info_i;
   assign hw2reg.status.d               = tgt_idx_err;

--- a/hw/ip/bkdr_loader/rtl/bkdr_loader_pkg.sv
+++ b/hw/ip/bkdr_loader/rtl/bkdr_loader_pkg.sv
@@ -32,22 +32,22 @@ package bkdr_loader_pkg;
 
   // Target indices
   typedef enum logic [$clog2(NumBkdrTgts)-1:0] {
-    BkdrAon       = 32'd11,
-    BkdrFlashB1I2 = 32'd10,
-    BkdrFlashB1I1 = 32'd9,
-    BkdrFlashB1I0 = 32'd8,
-    BkdrFlashB1   = 32'd7,
-    BkdrFlashB0I2 = 32'd6,
-    BkdrFlashB0I1 = 32'd5,
-    BkdrFlashB0I0 = 32'd4,
-    BkdrFlashB0   = 32'd3,
-    BkdrSram      = 32'd2,
-    BkdrRom       = 32'd1,
-    BkdrOtp       = 32'd0
+    BkdrAon       = 'd11,
+    BkdrFlashB1I2 = 'd10,
+    BkdrFlashB1I1 = 'd9,
+    BkdrFlashB1I0 = 'd8,
+    BkdrFlashB1   = 'd7,
+    BkdrFlashB0I2 = 'd6,
+    BkdrFlashB0I1 = 'd5,
+    BkdrFlashB0I0 = 'd4,
+    BkdrFlashB0   = 'd3,
+    BkdrSram      = 'd2,
+    BkdrRom       = 'd1,
+    BkdrOtp       = 'd0
   } bkdr_idx_e;
 
   // Valid targets
-  localparam bkdr_idx_e [NumBkdrTgts-1:0] BkdrValidTgts = {
+  localparam bkdr_idx_e BkdrValidTgts [NumBkdrTgts] = {
     BkdrAon,
     BkdrFlashB1I2,
     BkdrFlashB1I1,


### PR DESCRIPTION
Fix a bug in the FPGA backdoor loader HW related to the use of packed/unpacked arrays, which was causing the IP to be in a continual error state, and as such not allowing writes to be performed.

Also updates some of the bkdr_loader docs to fix some outdated references, and to clarify some issues seen when attempting to use the bkdr_loader via the DMI interface.

See the commit messages for more info.