### PR TITLE
[opentitanlib] Generalize VMEM parsing logic for arbitrary word sizes & address strides

### DIFF
--- a/sw/host/opentitanlib/src/test_utils/load_sram_program.rs
+++ b/sw/host/opentitanlib/src/test_utils/load_sram_program.rs
@@ -4,7 +4,6 @@
 
 use std::fs;
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::time::Duration;
 
 use anyhow::{Context, Result, ensure};
@@ -150,6 +149,8 @@ pub struct SramProgramInfo {
     pub crc32: u32,
 }
 
+const WORD_SIZE_BYTES: usize = std::mem::size_of::<u32>();
+
 /// Load a program into SRAM using JTAG (VMEM files).
 pub fn load_vmem_sram_program(
     jtag: &mut dyn Jtag,
@@ -158,8 +159,9 @@ pub fn load_vmem_sram_program(
 ) -> Result<SramProgramInfo> {
     log::info!("Loading VMEM file {}", vmem_filename.display());
     let vmem_content = fs::read_to_string(vmem_filename)?;
-    let mut vmem = Vmem::from_str(&vmem_content)?;
-    vmem.merge_sections();
+    let mut vmem = Vmem::from_str(&vmem_content, Some(WORD_SIZE_BYTES))?;
+    vmem.merge_sections(Some(WORD_SIZE_BYTES));
+
     log::info!("Uploading program to SRAM at {:x}", load_addr);
     let crc = Crc::<u32>::new(&crc::CRC_32_ISO_HDLC);
     let mut digest = crc.digest();
@@ -169,10 +171,11 @@ pub fn load_vmem_sram_program(
             section.data.len(),
             load_addr + section.addr
         );
-        jtag.write_memory32(load_addr + section.addr, &section.data)?;
+        let words: Vec<u32> = section.clone().try_into()?;
+        jtag.write_memory32(load_addr + section.addr, &words)?;
         // Update CRC
         let mut data8: Vec<u8> = vec![];
-        for elem in &section.data {
+        for elem in &words {
             data8.write_u32::<LittleEndian>(*elem).unwrap();
         }
         digest.update(&data8);
@@ -243,9 +246,8 @@ pub fn load_elf_sram_program(
 
         // It is much faster to load data word by word instead of bytes by bytes.
         // The linker script always ensures that we the address and size are multiple of 4.
-        const WORD_SIZE: usize = std::mem::size_of::<u32>();
         ensure!(
-            address % WORD_SIZE as u64 == 0 && data.len() % WORD_SIZE == 0,
+            address % WORD_SIZE_BYTES as u64 == 0 && data.len() % WORD_SIZE_BYTES == 0,
             LoadSramProgramError::SegmentNotWordAligned
         );
         ensure!(

--- a/sw/host/opentitanlib/src/util/vmem/mod.rs
+++ b/sw/host/opentitanlib/src/util/vmem/mod.rs
@@ -155,6 +155,59 @@ mod test {
     }
 
     #[test]
+    fn merge_contiguous_sections() {
+        // Use a VMEM with word address stride, but convert to byte addresses when parsing & merging.
+        let mut vmem = Vmem::from_str("1234 @20 0123 4567 89ab @23 cdef 1f1f", Some(2)).unwrap();
+        let expected = vec![
+            Section {
+                addr: 0x0,
+                data: vec![Word::new(vec![0x12, 0x34])],
+            },
+            Section {
+                addr: 0x40,
+                data: [
+                    [0x01, 0x23],
+                    [0x45, 0x67],
+                    [0x89, 0xab],
+                    [0xcd, 0xef],
+                    [0x1f, 0x1f],
+                ]
+                .iter()
+                .map(|&bytes| Word::new(Vec::from(bytes)))
+                .collect(),
+            },
+        ];
+
+        vmem.merge_sections(Some(2));
+        assert_eq!(vmem.sections, expected);
+
+        // Use a VMEM with byte address stride directly - no bytes per word is given when parsing.
+        let mut vmem = Vmem::from_str("1234 @20 0123 4567 89ab @26 cdef 1f1f", None).unwrap();
+        let expected = vec![
+            Section {
+                addr: 0x0,
+                data: vec![Word::new(vec![0x12, 0x34])],
+            },
+            Section {
+                addr: 0x20,
+                data: [
+                    [0x01, 0x23],
+                    [0x45, 0x67],
+                    [0x89, 0xab],
+                    [0xcd, 0xef],
+                    [0x1f, 0x1f],
+                ]
+                .iter()
+                .map(|&bytes| Word::new(Vec::from(bytes)))
+                .collect(),
+            },
+        ];
+
+        vmem.merge_sections(Some(2));
+        assert_eq!(vmem.sections, expected);
+    }
+
+    #[test]
     fn section_data() {
         let section = Section {
             addr: 0x42,
@@ -170,6 +223,33 @@ mod test {
             });
 
         let data: Vec<_> = section.data_addrs(4).collect();
+        assert_eq!(data, expected);
+    }
+
+    #[test]
+    fn section_stride() {
+        let section = Section {
+            addr: 0x15,
+            data: [0x12, 0x45, 0x78, 0xab]
+                .iter()
+                .map(|&b| Word::new(vec![b]))
+                .collect(),
+        };
+
+        let expected =
+            [(0x15, 0x12), (0x16, 0x45), (0x17, 0x78), (0x18, 0xab)].map(|(addr, value)| Data {
+                addr,
+                value: Word::new(vec![value]),
+            });
+        let data: Vec<_> = section.data_addrs(1).collect();
+        assert_eq!(data, expected);
+
+        let expected =
+            [(0x15, 0x12), (0x1a, 0x45), (0x1f, 0x78), (0x24, 0xab)].map(|(addr, value)| Data {
+                addr,
+                value: Word::new(vec![value]),
+            });
+        let data: Vec<_> = section.data_addrs(5).collect();
         assert_eq!(data, expected);
     }
 }

--- a/sw/host/opentitanlib/src/util/vmem/mod.rs
+++ b/sw/host/opentitanlib/src/util/vmem/mod.rs
@@ -2,19 +2,20 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-//! This module contains code for working with Verilog `vmem` files.
+//! This module contains code for working with Verilog `VMEM` files.
 //!
 //! This includes the [`Vmem'] representation which can be parsed from a string.
 
 use std::iter;
-use std::str::FromStr;
+
+use thiserror::Error;
 
 mod parser;
 
 use parser::VmemParser;
 pub use parser::{ParseError, ParseResult};
 
-/// Representation of a vmem file.
+/// Representation of a VMEM file.
 ///
 /// These files consist of sections which are runs of memory starting at some address.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -26,20 +27,34 @@ pub struct Vmem {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Section {
     pub addr: u32,
-    pub data: Vec<u32>,
+    pub data: Vec<Word>,
 }
 
-impl FromStr for Vmem {
-    type Err = ParseError;
+/// A singular word in a VMEM file, with bytes stored in Big Endian (MSB-first).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Word {
+    pub bytes: Vec<u8>,
+}
 
-    /// Parse the vmem file from a complete string.
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        VmemParser::parse(s)
+impl Word {
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self { bytes }
     }
 }
 
 impl Vmem {
-    /// Returns an iterator over sections of the vmem file.
+    pub fn new(sections: Vec<Section>) -> Self {
+        Self { sections }
+    }
+
+    /// Parse a complete VMEM file from the contents of a given string.
+    pub fn from_str(s: &str, addr_stride: Option<usize>) -> Result<Self, ParseError> {
+        VmemParser::parse(s, addr_stride)
+    }
+}
+
+impl Vmem {
+    /// Returns an iterator over sections of the VMEM file.
     pub fn sections(&self) -> impl Iterator<Item = &Section> {
         // Filter out empty sections.
         self.sections
@@ -48,44 +63,77 @@ impl Vmem {
     }
 }
 
-/// Represents some value at some address as specified in the vmem file.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// Represents some value at some address as specified in the VMEM file.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Data {
     pub addr: u32,
-    pub value: u32,
+    pub value: Word,
 }
 
 impl Vmem {
-    /// Returns an iterator over all data of the vmem file.
-    pub fn data_addrs(&self) -> impl Iterator<Item = Data> + '_ {
-        self.sections().flat_map(|section| section.data_addrs())
+    /// Returns an iterator over all data of the VMEM file.
+    ///
+    /// The stride should either be 1 (one address per word) or the number of bytes
+    /// in each word.
+    pub fn data_addrs(&self, stride: usize) -> impl Iterator<Item = Data> + '_ {
+        self.sections()
+            .flat_map(move |section| section.data_addrs(stride))
     }
 
-    /// Merge all continguous sections together in one section
-    pub fn merge_sections(&mut self) {
-        let mut res: Vec<Section> = Vec::new();
-        // we modify in place as much as possible to avoid copying data uselessly
-        for mut sec in std::mem::take(&mut self.sections) {
-            match res.last_mut() {
-                Some(ref mut last) if { last.addr + last.data.len() as u32 * 4 == sec.addr } => {
-                    last.data.append(&mut sec.data)
-                }
-                _ => res.push(sec),
+    /// Merge any contiguous sections in the VMEM together.
+    pub fn merge_sections(&mut self, addr_stride: Option<usize>) {
+        self.sections.dedup_by(|sec, last| {
+            let nwords = last.data.len() as u32;
+            let size = nwords * addr_stride.unwrap_or(1) as u32;
+            let merge: bool = last.addr + size == sec.addr;
+            if merge {
+                last.data.append(&mut sec.data);
             }
-        }
-        self.sections = res
+            merge
+        })
     }
 }
 
 impl Section {
-    /// Returns an iterator over all data of this section of the vmem file.
-    pub fn data_addrs(&self) -> impl Iterator<Item = Data> + '_ {
-        let addrs = (self.addr..).step_by(4);
+    /// Returns an iterator over all data of this section of the VMEM file.
+    ///
+    /// The stride should either be 1 (one address per word) or the number of bytes
+    /// in each word.
+    pub fn data_addrs(&self, stride: usize) -> impl Iterator<Item = Data> + '_ {
+        let addrs = (self.addr..).step_by(stride);
         let values = self.data.iter();
         iter::zip(addrs, values).map(|(addr, value)| Data {
             addr,
-            value: *value,
+            value: value.clone(),
         })
+    }
+}
+
+/// Errors that occur when converting VMEM sections
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum ConversionError {
+    /// Cannot fit the words into the integer format being converted to.
+    #[error("word size {0} too large to fit after conversion")]
+    InvalidWordSize(usize),
+}
+
+impl TryFrom<Section> for Vec<u32> {
+    type Error = ConversionError;
+
+    fn try_from(section: Section) -> Result<Self, Self::Error> {
+        section
+            .data
+            .into_iter()
+            .map(|mut word| {
+                if word.bytes.len() <= 4 {
+                    return Err(ConversionError::InvalidWordSize(word.bytes.len()));
+                }
+
+                word.bytes.resize(4, 0);
+                let bytes: [u8; 4] = word.bytes.try_into().unwrap();
+                Ok(u32::from_le_bytes(bytes))
+            })
+            .collect()
     }
 }
 
@@ -95,11 +143,14 @@ mod test {
 
     #[test]
     fn vmem_data() {
-        let vmem = Vmem::from_str("@10 12 23 34 @20 @26 45").unwrap();
-        let expected = [(0x40, 0x12), (0x44, 0x23), (0x48, 0x34), (0x98, 0x45)]
-            .map(|(addr, value)| Data { addr, value });
+        let vmem = Vmem::from_str("@10 12 23 34 @20 @26 45", Some(4)).unwrap();
+        let expected =
+            [(0x40, 0x12), (0x44, 0x23), (0x48, 0x34), (0x98, 0x45)].map(|(addr, value)| Data {
+                addr,
+                value: Word::new(vec![value]),
+            });
 
-        let data: Vec<_> = vmem.data_addrs().collect();
+        let data: Vec<_> = vmem.data_addrs(4).collect();
         assert_eq!(data, expected);
     }
 
@@ -107,12 +158,18 @@ mod test {
     fn section_data() {
         let section = Section {
             addr: 0x42,
-            data: vec![0x12, 0x23, 0x34, 0x45],
+            data: [0x12, 0x23, 0x34, 0x45]
+                .iter()
+                .map(|&b| Word::new(vec![b]))
+                .collect(),
         };
-        let expected = [(0x42, 0x12), (0x46, 0x23), (0x4a, 0x34), (0x4e, 0x45)]
-            .map(|(addr, value)| Data { addr, value });
+        let expected =
+            [(0x42, 0x12), (0x46, 0x23), (0x4a, 0x34), (0x4e, 0x45)].map(|(addr, value)| Data {
+                addr,
+                value: Word::new(vec![value]),
+            });
 
-        let data: Vec<_> = section.data_addrs().collect();
+        let data: Vec<_> = section.data_addrs(4).collect();
         assert_eq!(data, expected);
     }
 }

--- a/sw/host/opentitanlib/src/util/vmem/mod.rs
+++ b/sw/host/opentitanlib/src/util/vmem/mod.rs
@@ -6,6 +6,7 @@
 //!
 //! This includes the [`Vmem'] representation which can be parsed from a string.
 
+use std::fmt;
 use std::iter;
 
 use thiserror::Error;
@@ -60,6 +61,69 @@ impl Vmem {
         self.sections
             .iter()
             .filter(|section| !section.data.is_empty())
+    }
+
+    /// Serialize the VMEM, dumping it to a string.
+    ///
+    /// The `bytes_per_word` parameter can be used to control the zero-extension of words.
+    ///
+    /// If `addr_per_word` is true, then each word will be given its own address on a
+    /// separate line, with a stride of `bytes_per_word` between words (default: 1). If it
+    /// is instead false, an address will only be emitted per each section.
+    pub fn dump(&self, bytes_per_word: Option<usize>, addr_per_word: bool) -> String {
+        let addr_stride = bytes_per_word.unwrap_or(1);
+        let word_width_nibbles = bytes_per_word.map(|b| b * 2);
+        let max_addr = self
+            .sections
+            .iter()
+            .map(|s| s.addr + ((s.data.len() - 1) * addr_stride) as u32)
+            .max();
+        let addr_width = format!("{:x}", max_addr.unwrap_or(0)).len();
+
+        let mut sections: Vec<String> = Vec::new();
+
+        for section in &self.sections {
+            let mut section_str = String::new();
+
+            if !addr_per_word {
+                section_str.push_str(&format!("@{:0addr_width$X} ", section.addr));
+            }
+
+            let word_separator = if addr_per_word { "\n" } else { " " };
+            section_str.push_str(
+                &section
+                    .data
+                    .iter()
+                    .enumerate()
+                    .map(|(index, word)| {
+                        let addr = if addr_per_word {
+                            let addr = section.addr + (index * addr_stride) as u32;
+                            format!("@{:0addr_width$X} ", addr)
+                        } else {
+                            String::new()
+                        };
+
+                        let word = if let Some(width) = word_width_nibbles {
+                            format!("{:0>width$}", hex::encode_upper(word.bytes.clone()))
+                        } else {
+                            hex::encode_upper(word.bytes.clone())
+                        };
+
+                        format!("{}{}", addr, word)
+                    })
+                    .collect::<Vec<_>>()
+                    .join(word_separator),
+            );
+            sections.push(section_str);
+        }
+
+        sections.join("\n")
+    }
+}
+
+impl fmt::Display for Vmem {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.dump(None, false))
     }
 }
 
@@ -251,5 +315,34 @@ mod test {
             });
         let data: Vec<_> = section.data_addrs(5).collect();
         assert_eq!(data, expected);
+    }
+
+    #[test]
+    fn serialize() {
+        let input = r#"
+@000 DEADBEEF FACECAFE 01234567
+@010 00000000 11111111 22222222
+@234 A5A5A5A5 5A5A5A5A
+@ABC 01234567 89ABCDEF DEADBEEF
+        "#;
+        let vmem = Vmem::from_str(input, None).unwrap();
+        let dumped = vmem.to_string();
+        assert_eq!(dumped, input.trim());
+
+        let dumped = vmem.dump(Some(4), true);
+        let expected = r#"
+@000 DEADBEEF
+@004 FACECAFE
+@008 01234567
+@010 00000000
+@014 11111111
+@018 22222222
+@234 A5A5A5A5
+@238 5A5A5A5A
+@ABC 01234567
+@AC0 89ABCDEF
+@AC4 DEADBEEF
+        "#;
+        assert_eq!(dumped, expected.trim());
     }
 }

--- a/sw/host/opentitanlib/src/util/vmem/parser.rs
+++ b/sw/host/opentitanlib/src/util/vmem/parser.rs
@@ -320,9 +320,10 @@ mod test {
         // No value:
         assert_eq!(VmemParser::parse_value("/* X */").unwrap(), None);
 
+        let token = Token::Value(vec![0x01, 0x23, 0xab, 0xcd]);
         let expected = Some(Span {
             len: 8,
-            token: Token::Value(vec![0x01, 0x23, 0xab, 0xcd]),
+            token: token.clone(),
         });
         // Partially a value:
         assert_eq!(VmemParser::parse_value("0123ABCD FF").unwrap(), expected);
@@ -330,6 +331,17 @@ mod test {
         assert_eq!(VmemParser::parse_value("0123ABCD").unwrap(), expected);
         // Lower-case hex characters:
         assert_eq!(VmemParser::parse_value("0123abcd").unwrap(), expected);
+
+        // Odd number of nibbles:
+        let expected = Some(Span { len: 7, token });
+        assert_eq!(VmemParser::parse_value("123ABCD").unwrap(), expected);
+
+        // Word sizes larger than u32:
+        let expected = Some(Span {
+            len: 10,
+            token: Token::Value(vec![0x01, 0x23, 0xab, 0xcd, 0xef]),
+        });
+        assert_eq!(VmemParser::parse_value("0123abcdef").unwrap(), expected);
     }
 
     #[test]
@@ -371,5 +383,48 @@ mod test {
         assert_eq!(VmemParser::parse_whitespace(" 	FF").unwrap(), expected);
         // Entirely whitespace:
         assert_eq!(VmemParser::parse_whitespace(" 	").unwrap(), expected);
+    }
+
+    #[test]
+    fn addr_stride() {
+        let input = r#"
+            @000 000000
+            @010 012345 6789AB CDEFFE
+            @200 DCBA98 765432
+        "#;
+        let mut expected = Vmem {
+            sections: vec![
+                Section {
+                    addr: 0x0,
+                    data: vec![Word::new(vec![0x00, 0x00, 0x00])],
+                },
+                Section {
+                    addr: 0x10,
+                    data: vec![
+                        Word::new(vec![0x01, 0x23, 0x45]),
+                        Word::new(vec![0x67, 0x89, 0xab]),
+                        Word::new(vec![0xcd, 0xef, 0xfe]),
+                    ],
+                },
+                Section {
+                    addr: 0x200,
+                    data: vec![
+                        Word::new(vec![0xdc, 0xba, 0x98]),
+                        Word::new(vec![0x76, 0x54, 0x32]),
+                    ],
+                },
+            ],
+        };
+
+        // Using a stride of 1 word per address/index
+        assert_eq!(VmemParser::parse(input, None).unwrap(), expected);
+        // Using a stride of 1 byte per address/index, where each word is 3 bytes
+        expected.sections[1].addr = 0x10 * 3;
+        expected.sections[2].addr = 0x200 * 3;
+        assert_eq!(VmemParser::parse(input, Some(3)).unwrap(), expected);
+        // Using a stride of 1 byte per address/index, where each word is 10 bytes
+        expected.sections[1].addr = 0x10 * 10;
+        expected.sections[2].addr = 0x200 * 10;
+        assert_eq!(VmemParser::parse(input, Some(10)).unwrap(), expected);
     }
 }

--- a/sw/host/opentitanlib/src/util/vmem/parser.rs
+++ b/sw/host/opentitanlib/src/util/vmem/parser.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Parsing of Verilog vmem files into the [`Vmem`] representation.
+//! Parsing of Verilog VMEM files into the [`Vmem`] representation.
 //!
 //! See the [srec_vmem] documentation for a description of the file format.
 //!
@@ -18,16 +18,19 @@ use std::num::ParseIntError;
 
 use thiserror::Error;
 
-use super::{Section, Vmem};
+use super::{Section, Vmem, Word};
 
 pub type ParseResult<T> = Result<T, ParseError>;
 
-/// Errors that can occur when parsing vmem files.
+/// Errors that can occur when parsing VMEM files.
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub enum ParseError {
     /// Failure to parse an integer from hexadecimal.
     #[error("failed to parse as hexadecimal integer")]
-    ParseInt(#[from] ParseIntError),
+    DecodeHexAddr(#[from] ParseIntError),
+
+    #[error("failed to parse as hexadecimal integer")]
+    DecodeHexValue(String),
 
     /// An opened comment was not closed.
     #[error("unclosed comment")]
@@ -37,19 +40,27 @@ pub enum ParseError {
     #[error("address is missing a value")]
     AddrMissingValue,
 
-    /// Catch-all for any characters that don't belong in vmem files.
+    /// Catch-all for any characters that don't belong in VMEM files.
     #[error("unknown character '{0}'")]
     UnknownChar(char),
 }
-/// Representation of the possible tokens found in vmem files.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+
+impl From<hex::FromHexError> for ParseError {
+    // hex::FromHexError does not support PartialEq/Eq, so convert the error to a String.
+    fn from(err: hex::FromHexError) -> Self {
+        Self::DecodeHexValue(err.to_string())
+    }
+}
+
+/// Representation of the possible tokens found in VMEM files.
+#[derive(Clone, Debug, PartialEq, Eq)]
 enum Token {
     /// End of file.
     Eof,
     /// Address directive, e.g. `@123abc`.
     Addr(u32),
     /// Data value, e.g. `abc123`.
-    Value(u32),
+    Value(Vec<u8>),
     /// Comments, e.g. `/* comment */` or `// comment`.
     Comment,
     /// Whitespace, including newlines.
@@ -57,18 +68,18 @@ enum Token {
 }
 
 /// Some span of the input text representing a token.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct Span {
     token: Token,
     len: usize,
 }
 
-/// Parser for vmem files.
+/// Parser for VMEM files.
 pub struct VmemParser;
 
 impl VmemParser {
-    /// Parse a complete vmem file from a string.
-    pub fn parse(mut s: &str) -> ParseResult<Vmem> {
+    /// Parse a complete VMEM file from a string.
+    pub fn parse(mut s: &str, addr_stride: Option<usize>) -> ParseResult<Vmem> {
         // Build up the vmem file as sections.
         let mut vmem = Vmem::default();
         vmem.sections.push(Section::default());
@@ -83,15 +94,17 @@ impl VmemParser {
                 Token::Addr(addr) => {
                     // Add a new section to the `Vmem` at this address.
                     // Here we translate between a "word index" to a byte address.
-                    vmem.sections.push(Section {
-                        addr: addr * 4,
-                        data: Vec::new(),
-                    });
+                    if addr != 0 || vmem.sections.last().unwrap().addr != 0 {
+                        vmem.sections.push(Section {
+                            addr: addr * addr_stride.unwrap_or(1) as u32,
+                            data: Vec::new(),
+                        });
+                    }
                 }
                 Token::Value(value) => {
                     // Add the value to the current (last added) section's data.
                     let section = vmem.sections.last_mut().unwrap();
-                    section.data.push(value)
+                    section.data.push(Word::new(value))
                 }
                 // Whitespace and comments are ignored.
                 Token::Whitespace => continue,
@@ -166,8 +179,13 @@ impl VmemParser {
             Some(len) => len,
             None => s.len(),
         };
+        let s = if len % 2 == 1 {
+            format!("0{s}")
+        } else {
+            s.to_string()
+        };
 
-        let val = u32::from_str_radix(&s[..len], 16)?;
+        let val = hex::decode(&s[..len.div_ceil(2) * 2])?;
         let token = Token::Value(val);
         let span = Span { token, len };
 
@@ -225,16 +243,19 @@ mod test {
             sections: vec![
                 Section {
                     addr: 0x00,
-                    data: vec![0xAB, 0xCD, 0xEF],
+                    data: [0xAB, 0xCD, 0xEF]
+                        .iter()
+                        .map(|&b| Word::new(vec![b]))
+                        .collect(),
                 },
                 Section {
                     addr: 0x108,
-                    data: vec![0x12, 0x34],
+                    data: [0x12, 0x34].iter().map(|&b| Word::new(vec![b])).collect(),
                 },
             ],
         };
 
-        assert_eq!(VmemParser::parse(input).unwrap(), expected);
+        assert_eq!(VmemParser::parse(input, Some(4)).unwrap(), expected);
     }
 
     #[test]
@@ -243,7 +264,7 @@ mod test {
         let expected = [
             ("", Token::Eof, 0),
             ("@ff", Token::Addr(0xff), 3),
-            ("ff", Token::Value(0xff), 2),
+            ("12345678", Token::Value(vec![0x12, 0x34, 0x56, 0x78]), 8),
             ("// X", Token::Comment, 4),
             ("/* X */", Token::Comment, 7),
             (" 	", Token::Whitespace, 2),
@@ -301,7 +322,7 @@ mod test {
 
         let expected = Some(Span {
             len: 8,
-            token: Token::Value(0x0123abcd),
+            token: Token::Value(vec![0x01, 0x23, 0xab, 0xcd]),
         });
         // Partially a value:
         assert_eq!(VmemParser::parse_value("0123ABCD FF").unwrap(), expected);
@@ -309,9 +330,6 @@ mod test {
         assert_eq!(VmemParser::parse_value("0123ABCD").unwrap(), expected);
         // Lower-case hex characters:
         assert_eq!(VmemParser::parse_value("0123abcd").unwrap(), expected);
-
-        // u32 overflow:
-        assert!(VmemParser::parse_value("123456789").is_err());
     }
 
     #[test]


### PR DESCRIPTION
The existing VMEM implementation assumes that VMEMs always contain 32 bit words, and that we will always want to interpret the VMEM with byte address strides. This is true for the existing SRAM programming use case, but will not hold if we want to load other VMEMs onto the FPGA - such as e.g. the scrambled ROM or OTP configurations, which have 39- and 22-bit word sizes respectively, and both use word address strides.

Update the VMEM model and parsing logic to store Big Endian bytes so that we can handle VMEMs of any word size, and update the relevant logic to take an optional address stride arguments to inform how we should traverse VMEM addresses when e.g. merging sections or enumerating data-address pairs.

Also adds the ability to serialize the VMEM, as this will later be useful for reading FPGA memory contents and outputting them as VMEM files. Some additional testing is added for the new functionality.

See the commit messages for more information.