### PR TITLE
[opentitantool] Add support for reading memories via the FPGA bkdr_loader

### DIFF
--- a/sw/host/opentitanlib/src/io/fpga_backdoor.rs
+++ b/sw/host/opentitanlib/src/io/fpga_backdoor.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, ensure};
 use clap::Args;
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 use std::time::Duration;
@@ -11,6 +11,7 @@ use crate::app::TransportWrapper;
 use crate::debug::dmi::{Dmi, OpenOcdDmi};
 use crate::io::jtag::{JtagChain, JtagParams, JtagTap};
 use crate::transport::Capability;
+use crate::util::vmem::Word;
 
 /// FPGA Backdoor loader register offsets (byte-addressed) and field definitions.
 /// See hw/ip/bkdr_loader/doc/registers.md
@@ -163,10 +164,49 @@ impl std::fmt::Display for BackdoorTargetInfo {
     }
 }
 
+impl Word {
+    /// Convert the 32-bit chunks read from data registers into a word (MSB-first byte stream).
+    fn from_u32_chunks(chunks: &[u32; DATA_REGS_PER_WORD], bytes_per_word: usize) -> Self {
+        let num_chunks = bytes_per_word.div_ceil(size_of::<u32>());
+        let padding_bytes = (num_chunks * size_of::<u32>()) - bytes_per_word;
+
+        Self {
+            bytes: chunks
+                .iter()
+                .take(num_chunks)
+                .rev()
+                .flat_map(|chunk| chunk.to_be_bytes())
+                .skip(padding_bytes)
+                .collect(),
+        }
+    }
+}
+
 /// Handle for interacting with a given target via the backdoor loader.
-pub struct BackdoorTarget {
+pub struct BackdoorTarget<'a> {
+    backdoor: &'a mut Backdoor,
+    index: u8,
     /// Information about the target.
     pub info: BackdoorTargetInfo,
+}
+
+impl<'a> BackdoorTarget<'a> {
+    /// Read a sequence of words at a given offset (word index) from the target's memory.
+    ///
+    /// The `check_status` parameter is used to control whether the status bit is polled
+    /// after each word read, to check for any errors.
+    pub fn read(&mut self, start: u32, count: u32, check_status: bool) -> Result<Vec<Word>> {
+        ensure!(
+            start + count <= self.info.depth,
+            "fpga bkdr_loader read of len {:#x} to word {:#x} of {} is out of bounds (depth: {:#x})",
+            count,
+            start,
+            self.info.id_str(),
+            self.info.depth,
+        );
+        self.backdoor
+            .read_target(self.index, start, count, check_status)
+    }
 }
 
 /// A struct which represents an active backdoor loader connection.
@@ -278,18 +318,89 @@ impl Backdoor {
         &self.targets
     }
 
-    /// Borrow a target by its integer identifier.
-    pub fn target_by_id(&self, id: u32) -> Option<BackdoorTarget> {
-        let info = self.targets.iter().find(|&t| t.id == id)?;
+    /// Borrow a target by its integer identifier. Only one BackdoorTarget can exist at a time.
+    pub fn target_by_id(&mut self, id: u32) -> Option<BackdoorTarget<'_>> {
+        let (index, info) = self.targets.iter().enumerate().find(|&(_, t)| t.id == id)?;
+        let (index, info) = (index as u8, *info);
 
-        Some(BackdoorTarget { info: *info })
+        Some(BackdoorTarget {
+            backdoor: self,
+            index,
+            info,
+        })
     }
 
-    /// Borrow a target by its string identifier.
-    pub fn target_by_id_str(&self, id: &str) -> Result<Option<BackdoorTarget>> {
+    /// Borrow a target by its string identifier. Only one BackdoorTarget can exist at a time.
+    pub fn target_by_id_str(&mut self, id: &str) -> Result<Option<BackdoorTarget<'_>>> {
         let encoded_id = BackdoorTargetInfo::id_from_str(id)?;
 
         Ok(self.target_by_id(encoded_id))
+    }
+
+    /// Read a sequence of words at a given offset (word index) from a specified target's memory.
+    ///
+    /// The `check_status` parameter is used to control whether the status bit is polled
+    /// after each word read, to check for any errors.
+    pub fn read_target(
+        &mut self,
+        target_index: u8,
+        start: u32,
+        count: u32,
+        check_status: bool,
+    ) -> Result<Vec<Word>> {
+        ensure!(
+            usize::from(target_index) < self.targets.len(),
+            "Target index {} is out of range for {} targets",
+            target_index,
+            self.targets.len()
+        );
+        let info = self.targets[target_index as usize];
+        let width = info.width as usize;
+        let bytes_per_word = width.div_ceil(u8::BITS as usize);
+        let regs_used = width.div_ceil(u32::BITS as usize);
+        ensure!(
+            regs_used <= DATA_REGS_PER_WORD,
+            "Advertised target width {:#x} is too wide for the data registers (needs: {:#x}, has: {:#x})",
+            width,
+            regs_used,
+            DATA_REGS_PER_WORD
+        );
+
+        let mut control = (target_index as u32) << regs::CONTROL_TARGET_IDX_OFFSET;
+        control &= !(0b1 << regs::CONTROL_WRITE_ENA_BIT);
+        self.dmi_write(regs::CONTROL_REG_OFFSET, control)
+            .context("cannot write to control register")?;
+
+        let mut words = Vec::new();
+
+        for word_idx in start..(start + count) {
+            self.dmi_write(regs::INDEX_REG_OFFSET, word_idx)
+                .context("cannot write word index")?;
+
+            if check_status {
+                let status = self
+                    .dmi_read(regs::STATUS_REG_OFFSET)
+                    .context("cannot read status")?;
+                ensure!(
+                    status & (0b1 << regs::STATUS_ERROR_BIT) == 0,
+                    "fpga bkdr_loader reported an error reading from word idx {} of target {}",
+                    word_idx,
+                    info.id_str()
+                );
+            }
+
+            let mut regs = [0u32; DATA_REGS_PER_WORD];
+            for (idx, reg) in regs.iter_mut().enumerate().take(regs_used) {
+                let addr_offset = idx * 4;
+                *reg = self
+                    .dmi_read(regs::READ_DATA_0_REG_OFFSET + addr_offset)
+                    .context("cannot read from read_data register")?;
+            }
+
+            words.push(Word::from_u32_chunks(&regs, bytes_per_word));
+        }
+
+        Ok(words)
     }
 }
 

--- a/sw/host/opentitantool/src/command/fpga_backdoor.rs
+++ b/sw/host/opentitantool/src/command/fpga_backdoor.rs
@@ -6,10 +6,15 @@ use anyhow::{Context, Result};
 use clap::{Args, Subcommand};
 use std::any::Any;
 use std::convert::From;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
 
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::app::command::CommandDispatch;
-use opentitanlib::io::fpga_backdoor::{BackdoorParams, enter_backdoor_loader};
+use opentitanlib::io::fpga_backdoor::{BackdoorParams, BackdoorTargetInfo, enter_backdoor_loader};
+use opentitanlib::util::parse_int::ParseInt;
+use opentitanlib::util::vmem::{Section, Vmem, Word};
 
 /// Commands for interacting with the backdoor FPGA loader.
 #[derive(Debug, Subcommand, CommandDispatch)]
@@ -20,6 +25,8 @@ pub enum InternalBackdoorCommand {
     Exit(BackdoorExit),
     /// Display information about the available backdoor targets
     Info(BackdoorInfo),
+    /// Read words from a target memory via the backdoor.
+    Read(BackdoorRead),
 }
 
 #[derive(Debug, Args)]
@@ -69,7 +76,7 @@ impl CommandDispatch for BackdoorInfo {
     ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let context = context.downcast_ref::<BackdoorCommand>().unwrap();
         let backdoor = context.params.create(transport)?;
-        let backdoor = backdoor.connect(true)?;
+        let mut backdoor = backdoor.connect(true)?;
 
         let info: Box<dyn erased_serde::Serialize> = match &self.target {
             Some(id_str) => {
@@ -82,6 +89,127 @@ impl CommandDispatch for BackdoorInfo {
         };
 
         Ok(Some(info))
+    }
+}
+
+/// Output formats for data that is read from the backdoor loader.
+#[derive(clap::ValueEnum, Clone, Copy, Debug)]
+pub enum OutputFormat {
+    Hex,
+    Raw,
+    Vmem,
+}
+
+#[derive(Debug, Args)]
+pub struct BackdoorRead {
+    /// Target to read from.
+    pub target: String,
+
+    /// First word address / index to read from.
+    #[arg(long, value_parser = <u32 as ParseInt>::from_str, default_value = "0")]
+    pub start: u32,
+
+    /// The number of words to read. If not given, reads the entire memory.
+    #[arg(long, alias = "words", value_parser = <u32 as ParseInt>::from_str)]
+    pub length: Option<u32>,
+
+    /// Optional path to write the output to. If not given, outputs directly to stdout.
+    #[arg(short, long)]
+    pub output: Option<PathBuf>,
+
+    /// The data format to use when outputting words that are read.
+    #[arg(long, default_value = "hex")]
+    pub format: OutputFormat,
+
+    /// If outputting as a Vmem, omit extraneous element indexes for contiguous words
+    #[arg(long)]
+    pub group_vmem_words: bool,
+}
+
+fn output_read_contents(
+    output: Option<&PathBuf>,
+    start: u32,
+    words: Vec<Word>,
+    target_info: &BackdoorTargetInfo,
+    format: OutputFormat,
+    group_vmem_words: bool,
+) -> Result<()> {
+    let mut out: Box<dyn Write> = if let Some(out_path) = &output {
+        Box::new(fs::File::create(out_path)?)
+    } else {
+        Box::new(std::io::stdout())
+    };
+
+    match format {
+        OutputFormat::Hex => {
+            let hex = words
+                .into_iter()
+                .map(|w| hex::encode(w.bytes))
+                .collect::<Vec<_>>()
+                .join(" ");
+            writeln!(out, "{}", hex)?;
+        }
+        OutputFormat::Raw => {
+            for word in words {
+                out.write_all(&word.bytes)?;
+            }
+        }
+        OutputFormat::Vmem => {
+            let num_bytes = target_info.width.div_ceil(8);
+            writeln!(
+                out,
+                "// {} memory file with {} x {} bit layout ({} x {} bytes)",
+                target_info.id_str(),
+                target_info.width,
+                target_info.depth,
+                num_bytes,
+                target_info.depth
+            )?;
+            let vmem = Vmem::new(vec![Section {
+                addr: start,
+                data: words,
+            }]);
+            writeln!(out, "{}", vmem.dump(None, !group_vmem_words))?;
+        }
+    }
+
+    Ok(())
+}
+
+impl CommandDispatch for BackdoorRead {
+    fn run(
+        &self,
+        context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
+        let context = context.downcast_ref::<BackdoorCommand>().unwrap();
+
+        // Connect to the backdoor and try and find the requested target.
+        let backdoor = context.params.create(transport)?;
+        let mut backdoor = backdoor.connect(true)?;
+        let mut target = backdoor
+            .target_by_id_str(&self.target)?
+            .context(format!("FPGA target '{}' not found", self.target))?;
+        let words = self.length.unwrap_or(target.info.depth - self.start);
+
+        // Read and output the requested data
+        log::info!(
+            "Reading {} words at offset {} from target {}...",
+            words,
+            self.start,
+            self.target
+        );
+        let words = target.read(self.start, words, true)?;
+        output_read_contents(
+            self.output.as_ref(),
+            self.start,
+            words,
+            &target.info,
+            self.format,
+            self.group_vmem_words,
+        )?;
+
+        Ok(None)
     }
 }
 


### PR DESCRIPTION
Note that the ROM endpoint is currently disabled for now to allow bitstream splicing flows to continue working. 

Implement FPGA backdoor loader memory read operations via OpenTitanLib / OpenTitanTool. Using the `opentitantool bkdr read` command, you can read from target memories via the backdoor loader (when it is in its preloading mode, entered via `bkdr enter`). Options are available for customizing the offset & size of the read, as well as to output the data in raw / hex / VMEM formats.