### PR TITLE
[opentitantool] Add support for writing (& verifying) memories via the FPGA bkdr_loader

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -147,6 +147,7 @@ rust_library(
         "src/test_utils/crashdump.rs",
         "src/test_utils/e2e_command.rs",
         "src/test_utils/epmp.rs",
+        "src/test_utils/fpga_backdoor.rs",
         "src/test_utils/gpio.rs",
         "src/test_utils/gpio_monitor.rs",
         "src/test_utils/i2c_target.rs",

--- a/sw/host/opentitanlib/src/debug/dmi.rs
+++ b/sw/host/opentitanlib/src/debug/dmi.rs
@@ -76,6 +76,14 @@ pub trait Dmi {
 
     /// Write a DMI register.
     fn dmi_write(&mut self, addr: u32, data: u32) -> Result<()>;
+
+    /// Perform a batch of sequential writes to DMI registers.
+    /// May or may not be more optimized depending on the underlying implementation.
+    fn batched_dmi_writes(&mut self, writes: &[(u32, u32)]) -> Result<()> {
+        writes
+            .iter()
+            .try_for_each(|&(addr, data)| self.dmi_write(addr, data))
+    }
 }
 
 impl<T: Dmi> Dmi for &mut T {
@@ -85,6 +93,10 @@ impl<T: Dmi> Dmi for &mut T {
 
     fn dmi_write(&mut self, addr: u32, data: u32) -> Result<()> {
         T::dmi_write(self, addr, data)
+    }
+
+    fn batched_dmi_writes(&mut self, writes: &[(u32, u32)]) -> Result<()> {
+        T::batched_dmi_writes(self, writes)
     }
 }
 
@@ -126,10 +138,12 @@ impl OpenOcdDmi {
         })
     }
 
+    fn drscan_bits(&self) -> u32 {
+        self.abits + DMI_ADDRESS_SHIFT
+    }
+
     fn dmi_op(&mut self, op: u64) -> Result<u64> {
-        let res = self
-            .openocd
-            .drscan(&self.tap, self.abits + DMI_ADDRESS_SHIFT, op)?;
+        let res = self.openocd.drscan(&self.tap, self.drscan_bits(), op)?;
 
         // We just scanned into the DMI register, so the scanned result should be empty.
         ensure!(res == 0, "Unexpected DMI initial response {res:#x}");
@@ -142,9 +156,7 @@ impl OpenOcdDmi {
         self.openocd.execute("runtest 10")?;
 
         // Read the result.
-        let res = self
-            .openocd
-            .drscan(&self.tap, self.abits + DMI_ADDRESS_SHIFT, 0)?;
+        let res = self.openocd.drscan(&self.tap, self.drscan_bits(), 0)?;
         ensure!(res & 3 == 0, "DMI operation failed with {res:#x}");
 
         // Double check the address matches.
@@ -170,6 +182,47 @@ impl Dmi for OpenOcdDmi {
             (addr as u64) << DMI_ADDRESS_SHIFT | (value as u64) << DMI_DATA_SHIFT | DMI_OP_WRITE,
         )?;
         log::debug!("DMI write {:#x} <- {:#x}", addr, value);
+        Ok(())
+    }
+
+    fn batched_dmi_writes(&mut self, writes: &[(u32, u32)]) -> Result<()> {
+        if writes.is_empty() {
+            return Ok(());
+        }
+
+        log::debug!(
+            "DMI {} batched writes: {}",
+            writes.len(),
+            writes
+                .iter()
+                .map(|&(addr, value)| format!("{:#x} <- {:#x}", addr, value))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+
+        // For optimized writes via drscan, we perform direct drscan write operations without
+        // worrying about the returned scanned values. We only wait in the RunTest state for a
+        // number of cycles at the very end, to allow the final few writes to run and complete,
+        // and we then perform a final write to check the scan status (as errors are sticky).
+        let mut cmd = writes
+            .iter()
+            .map(|&(addr, value)| {
+                let data = (addr as u64) << DMI_ADDRESS_SHIFT
+                    | (value as u64) << DMI_DATA_SHIFT
+                    | DMI_OP_WRITE;
+                self.openocd.drscan_cmd(&self.tap, self.drscan_bits(), data)
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        cmd.push_str(
+            // Wait 10 cycles for last write(s) to complete (arbitrary).
+            format!(
+                "\nruntest 10\n{}",
+                self.openocd.drscan_cmd(&self.tap, self.drscan_bits(), 0)
+            )
+            .as_str(),
+        );
+        self.openocd.execute(&cmd)?;
         Ok(())
     }
 }

--- a/sw/host/opentitanlib/src/debug/openocd.rs
+++ b/sw/host/opentitanlib/src/debug/openocd.rs
@@ -197,7 +197,9 @@ impl OpenOcd {
         let mut buf = Vec::new();
         self.reader.read_until(0x1A, &mut buf)?;
         if !buf.ends_with(b"\x1A") {
-            bail!(OpenOcdError::PrematureExit);
+            bail!(OpenOcdError::PrematureExit(
+                String::from_utf8_lossy(&buf).to_string()
+            ));
         }
         buf.pop();
         String::from_utf8(buf).context("failed to parse OpenOCD response as UTF-8")
@@ -250,8 +252,8 @@ pub struct OpenOcdJtagChain {
 pub enum OpenOcdError {
     #[error("OpenOCD initialization failed: {0}")]
     InitializeFailure(String),
-    #[error("OpenOCD server exited prematurely")]
-    PrematureExit,
+    #[error("OpenOCD server exited prematurely: {0}")]
+    PrematureExit(String),
     #[error("Generic error {0}")]
     Generic(String),
 }

--- a/sw/host/opentitanlib/src/debug/openocd.rs
+++ b/sw/host/opentitanlib/src/debug/openocd.rs
@@ -228,6 +228,11 @@ impl OpenOcd {
         Ok(())
     }
 
+    /// Command for scanning a data register.
+    pub fn drscan_cmd<T: ParseInt + LowerHex>(&self, tap: &str, numbits: u32, data: T) -> String {
+        format!("drscan {} {} {:#x}", tap, numbits, data)
+    }
+
     /// Load data register of a given tap and return the scan.
     pub fn drscan<T: ParseInt + LowerHex>(
         &mut self,
@@ -235,7 +240,7 @@ impl OpenOcd {
         numbits: u32,
         data: T,
     ) -> Result<T> {
-        let cmd = format!("drscan {} {} {:#x}", tap, numbits, data);
+        let cmd = self.drscan_cmd(tap, numbits, data);
         let result = self.execute(&cmd)?;
         Ok(T::from_str_radix(&result, 16).map_err(|x| x.into())?)
     }

--- a/sw/host/opentitanlib/src/io/fpga_backdoor.rs
+++ b/sw/host/opentitanlib/src/io/fpga_backdoor.rs
@@ -102,7 +102,7 @@ impl BackdoorTap<'_> {
 pub struct BackdoorParams {
     /// JTAG options to apply to the backdoor TAP.
     #[command(flatten)]
-    jtag: JtagParams,
+    pub jtag: JtagParams,
 }
 
 impl BackdoorParams {

--- a/sw/host/opentitanlib/src/io/fpga_backdoor.rs
+++ b/sw/host/opentitanlib/src/io/fpga_backdoor.rs
@@ -165,6 +165,29 @@ impl std::fmt::Display for BackdoorTargetInfo {
 }
 
 impl Word {
+    /// Convert the word to a series of 32-bit chunks to be written to the data registers.
+    fn to_u32_chunks(&self) -> Result<[u32; DATA_REGS_PER_WORD]> {
+        ensure!(
+            self.bytes.len() <= DATA_REGS_PER_WORD * 4,
+            "Word '{}' with {} bytes will not fit into {} 32-bit registers.",
+            hex::encode(self.bytes.clone()),
+            self.bytes.len(),
+            DATA_REGS_PER_WORD
+        );
+        let mut chunks = [0u32; DATA_REGS_PER_WORD];
+
+        // Bytes are stored in Big Endian; when written to registers, the u32
+        // chunks are provided in LSB-first order (Little Endian).
+        for (i, &b) in self.bytes.iter().rev().enumerate() {
+            // Within u32 chunks, bytes are still given in MSB-first order (Big Endian).
+            let chunk_idx = i / 4;
+            let byte_pos = i % 4;
+            chunks[chunk_idx] |= (b as u32) << (byte_pos * 8);
+        }
+
+        Ok(chunks)
+    }
+
     /// Convert the 32-bit chunks read from data registers into a word (MSB-first byte stream).
     fn from_u32_chunks(chunks: &[u32; DATA_REGS_PER_WORD], bytes_per_word: usize) -> Self {
         let num_chunks = bytes_per_word.div_ceil(size_of::<u32>());
@@ -191,6 +214,31 @@ pub struct BackdoorTarget<'a> {
 }
 
 impl<'a> BackdoorTarget<'a> {
+    /// Write a sequence of words at a given offset (word index) in the target's memory.
+    ///
+    /// The `write_all` parameter is used to control whether writes can be optimized by
+    /// maintaining shadow CSRs to determine when register contents have genuinely changed.
+    /// The `check_status` parameter is used to control whether the status bit is polled
+    /// after all words are written, to check for any errors.
+    pub fn write(
+        &mut self,
+        start: u32,
+        words: &[Word],
+        write_all: bool,
+        check_status: bool,
+    ) -> Result<()> {
+        ensure!(
+            start + words.len() as u32 <= self.info.depth,
+            "fpga bkdr_loader write of len {:#x} to word {:#x} of {} is out of bounds (depth: {:#x})",
+            words.len(),
+            start,
+            self.info.id_str(),
+            self.info.depth,
+        );
+        self.backdoor
+            .write_target(self.index, start, words, write_all, check_status)
+    }
+
     /// Read a sequence of words at a given offset (word index) from the target's memory.
     ///
     /// The `check_status` parameter is used to control whether the status bit is polled
@@ -337,6 +385,89 @@ impl Backdoor {
         Ok(self.target_by_id(encoded_id))
     }
 
+    /// Write a sequence of words at a given offset (word index) to a specified target's memory.
+    ///
+    /// The `write_all` parameter is used to control whether writes can be optimized by
+    /// maintaining shadow CSRs to determine when register contents have actually changed.
+    /// The `check_status` parameter is used to control whether the status bit is polled
+    /// after all words are written, to check for any errors.
+    pub fn write_target(
+        &mut self,
+        target_index: u8,
+        start: u32,
+        words: &[Word],
+        write_all: bool,
+        check_status: bool,
+    ) -> Result<()> {
+        ensure!(
+            usize::from(target_index) < self.targets.len(),
+            "Target index {} is out of range for {} targets",
+            target_index,
+            self.targets.len()
+        );
+        let info = self.targets[target_index as usize];
+        let width = info.width as usize;
+        let regs_used = width.div_ceil(u32::BITS as usize);
+        ensure!(
+            regs_used <= DATA_REGS_PER_WORD,
+            "Advertised target width {:#x} is too wide for the data registers (needs: {:#x}, has: {:#x})",
+            width,
+            regs_used,
+            DATA_REGS_PER_WORD
+        );
+
+        // Cache previous written values in Shadow CSRs
+        let mut prev_regs = [0u32; DATA_REGS_PER_WORD];
+        let mut word_idx = start;
+        let mut first = true;
+
+        let mut control = (target_index as u32) << regs::CONTROL_TARGET_IDX_OFFSET;
+        control |= 0b1 << regs::CONTROL_WRITE_ENA_BIT;
+        self.dmi_write(regs::CONTROL_REG_OFFSET, control)
+            .context("cannot write to control register")?;
+
+        // We batch together all the necessary writes so that we can perform a single
+        // batched write operation at the end, which is optimized for throughput.
+        let mut writes = Vec::new();
+
+        for word in words {
+            let regs = word.to_u32_chunks()?;
+            for idx in 0..regs_used {
+                // Optimization - maintain shadow CSRs in software, and only write the
+                // data if there is a diff in that CSR from the previous contents. Vastly
+                // minimizes required operations for repetitive payloads.
+                if write_all || first || regs[idx] != prev_regs[idx] {
+                    let addr_offset = idx * 4;
+                    writes.push((
+                        ((regs::WRITE_DATA_0_REG_OFFSET + addr_offset) >> 2) as u32,
+                        regs[idx],
+                    ));
+                    prev_regs[idx] = regs[idx];
+                }
+            }
+            writes.push(((regs::INDEX_REG_OFFSET >> 2) as u32, word_idx));
+            first = false;
+            word_idx += 1;
+        }
+
+        self.dmi
+            .batched_dmi_writes(&writes)
+            .context("failed to perform DMI writes")?;
+
+        if check_status {
+            let status = self
+                .dmi_read(regs::STATUS_REG_OFFSET)
+                .context("cannot read status")?;
+            ensure!(
+                status & (0b1 << regs::STATUS_ERROR_BIT) == 0,
+                "fpga bkdr_loader reported an error writing to target {}",
+                info.id_str()
+            );
+        }
+
+        Ok(())
+    }
+
     /// Read a sequence of words at a given offset (word index) from a specified target's memory.
     ///
     /// The `check_status` parameter is used to control whether the status bit is polled
@@ -419,5 +550,24 @@ mod tests {
             assert_eq!(BackdoorTargetInfo { id, width, depth }.id_str(), id_str);
             assert_eq!(BackdoorTargetInfo::id_from_str(id_str).unwrap(), id);
         }
+    }
+
+    #[test]
+    fn byte_u32_conversion() {
+        // Bytes stored in words are Big Endian (MSB first).
+        let word = Word::new(vec![
+            0x5a, 0xa5, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xbe, 0xef, 0xca, 0xfe,
+        ]);
+        // Register chunks are Little Endian, but bytes in each u32 are Big Endian.
+        // The 4th register should be half-used, the 4 remaining regs should be unused.
+        let mut expected = [0x0; DATA_REGS_PER_WORD];
+        expected[0] = 0xbeefcafe;
+        expected[1] = 0x89abcdef;
+        expected[2] = 0x01234567;
+        expected[3] = 0x00005aa5;
+
+        let chunks = word.to_u32_chunks().unwrap();
+        assert_eq!(chunks, expected);
+        assert_eq!(Word::from_u32_chunks(&chunks, word.bytes.len()), word);
     }
 }

--- a/sw/host/opentitanlib/src/io/fpga_backdoor.rs
+++ b/sw/host/opentitanlib/src/io/fpga_backdoor.rs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{Context, Result, ensure};
+use anyhow::{Context, Result, bail, ensure};
 use clap::Args;
 use serde::ser::{Serialize, SerializeStruct, Serializer};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::app::TransportWrapper;
 use crate::debug::dmi::{Dmi, OpenOcdDmi};
@@ -21,11 +21,13 @@ pub mod regs {
     // STATUS register
     pub const STATUS_REG_OFFSET: usize = 0x0;
     pub const STATUS_ERROR_BIT: u32 = 0;
+    pub const STATUS_CLEAR_IDLE_BIT: u32 = 1;
 
     // CONTROL register
     pub const CONTROL_REG_OFFSET: usize = 0x4;
     pub const CONTROL_DONE_BIT: u32 = 0;
     pub const CONTROL_WRITE_ENA_BIT: u32 = 1;
+    pub const CONTROL_CLEAR_START_BIT: u32 = 2;
     pub const CONTROL_TARGET_IDX_MASK: u32 = 0xff;
     pub const CONTROL_TARGET_IDX_OFFSET: usize = 8;
 
@@ -47,6 +49,9 @@ pub mod consts {
 
     // How long the backdoor loader TAP strapping is held after leaving reset.
     pub const HOLD_TAP_STRAPS_MS: u64 = 50;
+
+    // Time to wait for a clear operation to finish.
+    pub const CLEAR_TIMEOUT_SECS: u64 = 5;
 
     // How many JTAG cycles to wait for before considering the `CONTROL.DONE` transaction
     // as being completed. We default to 10000, which is a conservative threshold.
@@ -254,6 +259,15 @@ impl<'a> BackdoorTarget<'a> {
         );
         self.backdoor
             .read_target(self.index, start, count, check_status)
+    }
+
+    /// Clear the entire memory of the target with a given word.
+    ///
+    /// An optimized fast-path for clearing memories, primarily used to replicate existing
+    /// bitstream synthesis defaults. The `check_status` parameter is used to control
+    /// whether the status bit is polled after clearing, to check for any errors.
+    pub fn clear(&mut self, word: &Word, check_status: bool) -> Result<()> {
+        self.backdoor.clear_target(self.index, word, check_status)
     }
 }
 
@@ -532,6 +546,79 @@ impl Backdoor {
         }
 
         Ok(words)
+    }
+
+    /// Clear the entire memory of a specified target with a given word.
+    ///
+    /// An optimized fast-path for clearing memories, primarily used to replicate existing
+    /// bitstream synthesis defaults. The `check_status` parameter is used to control
+    /// whether the status bit is polled after clearing, to check for any errors.
+    pub fn clear_target(
+        &mut self,
+        target_index: u8,
+        word: &Word,
+        check_status: bool,
+    ) -> Result<()> {
+        ensure!(
+            usize::from(target_index) < self.targets.len(),
+            "Target index {} is out of range for {} targets",
+            target_index,
+            self.targets.len()
+        );
+        let info = self.targets[target_index as usize];
+
+        self.dmi
+            .batched_dmi_writes(
+                &word
+                    .to_u32_chunks()?
+                    .into_iter()
+                    .enumerate()
+                    .map(|(idx, reg)| {
+                        let addr_offset = idx * 4;
+                        (
+                            ((regs::WRITE_DATA_0_REG_OFFSET + addr_offset) >> 2) as u32,
+                            reg,
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+            )
+            .context("failed to perform DMI writes")?;
+
+        let mut control = (target_index as u32) << regs::CONTROL_TARGET_IDX_OFFSET;
+        control |= 0b1 << regs::CONTROL_WRITE_ENA_BIT;
+        control |= 0b1 << regs::CONTROL_CLEAR_START_BIT;
+        self.dmi_write(regs::CONTROL_REG_OFFSET, control)
+            .context("cannot write to control register")?;
+
+        // Wait for the `CLEAR_IDLE` bit to appear set in the status register.
+        let timeout = Instant::now() + Duration::from_secs(CLEAR_TIMEOUT_SECS);
+        let mut status: u32;
+        loop {
+            status = self
+                .dmi_read(regs::STATUS_REG_OFFSET)
+                .context("cannot read status")?;
+            if status & (0b1 << regs::STATUS_CLEAR_IDLE_BIT) != 0 {
+                break;
+            }
+
+            if Instant::now() > timeout {
+                bail!(
+                    "Timed out after {} seconds waiting for {} clear to complete",
+                    CLEAR_TIMEOUT_SECS,
+                    info.id_str()
+                );
+            }
+        }
+
+        if check_status {
+            ensure!(
+                status & (0b1 << regs::STATUS_ERROR_BIT) == 0,
+                "fpga bkdr_loader reported an error writing to target {}",
+                info.id_str()
+            );
+        }
+
+        Ok(())
     }
 }
 

--- a/sw/host/opentitanlib/src/test_utils/fpga_backdoor.rs
+++ b/sw/host/opentitanlib/src/test_utils/fpga_backdoor.rs
@@ -1,0 +1,186 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context, Result, bail};
+use clap::Args;
+use std::convert::From;
+use std::fs;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use crate::app::TransportWrapper;
+use crate::io::fpga_backdoor::{Backdoor, BackdoorParams, BackdoorTarget, enter_backdoor_loader};
+use crate::io::jtag::JtagParams;
+use crate::util::vmem::{Section, Vmem, Word};
+
+// Reset the SoC and enter the backdoor loader, initializing a connection via JTAG.
+pub fn enter_backdoor(transport: &TransportWrapper, jtag_params: &JtagParams) -> Result<Backdoor> {
+    enter_backdoor_loader(transport)?;
+    let backdoor_params = BackdoorParams {
+        jtag: jtag_params.clone(),
+    };
+    backdoor_params.create(transport)?.connect(true)
+}
+
+// Normalize a word to a given number of bits.
+fn normalize_word(word: &mut Word, bits_per_word: usize) {
+    let bytes_per_word = bits_per_word.div_ceil(8);
+    if word.bytes.len() > bytes_per_word {
+        let start = word.bytes.len() - bytes_per_word;
+        word.bytes.drain(..start);
+    } else if word.bytes.len() < bytes_per_word {
+        let mut padded = vec![0u8; bytes_per_word - word.bytes.len()];
+        padded.append(&mut word.bytes);
+        word.bytes = padded;
+    }
+
+    let extra_bits = bits_per_word % 8;
+    if extra_bits > 0 {
+        word.bytes[0] &= 0xFF >> (8 - extra_bits);
+    }
+}
+
+// Check that words read from target memory match input words.
+pub fn verify_readback(
+    input: &mut [Word],
+    readback: &mut [Word],
+    bits_per_word: usize,
+    mut offset: u32,
+) -> Result<()> {
+    for (write_word, read_word) in readback.iter_mut().zip(input) {
+        normalize_word(write_word, bits_per_word);
+        normalize_word(read_word, bits_per_word);
+        if write_word != read_word {
+            bail!(
+                "Read verification at word {} failed. Expected: {}, Got: {}",
+                offset,
+                hex::encode(write_word.bytes.clone()),
+                hex::encode(read_word.bytes.clone()),
+            );
+        }
+
+        offset += 1;
+    }
+
+    Ok(())
+}
+
+pub fn write_to_target(
+    target: &mut BackdoorTarget,
+    target_id: &str,
+    data: Vec<Section>,
+    verify: bool,
+) -> Result<()> {
+    // Perform the write(s)
+    log::info!("Writing to the {}...", target_id);
+    for mut section in data {
+        log::debug!(
+            "Writing section of size {} to word {} of target {}",
+            section.data.len(),
+            section.addr,
+            target_id
+        );
+
+        target.write(section.addr, &section.data, false, verify)?;
+
+        // If requested, read back the data and verify against written contents
+        if verify {
+            let mut readback = target.read(section.addr, section.data.len() as u32, false)?;
+            verify_readback(
+                &mut section.data,
+                &mut readback,
+                target.info.width as usize,
+                section.addr,
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+pub struct TargetWrite {
+    pub target: String,
+    pub path: PathBuf,
+    pub offset: Option<u32>,
+}
+
+impl FromStr for TargetWrite {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (target_path, offset) = s
+            .split_once('@')
+            .map(|(x, y)| (x, y.parse::<u32>().ok()))
+            .unwrap_or((s, None));
+
+        let (target, path) = target_path
+            .split_once('=')
+            .context("expected input like TARGET=FILE[@OFFSET], but no '=' was seen")?;
+        if target.is_empty() {
+            bail!("target name cannot be empty");
+        }
+        if path.is_empty() {
+            bail!("file path cannot be empty");
+        }
+
+        Ok(TargetWrite {
+            target: target.to_string(),
+            path: PathBuf::from(path),
+            offset,
+        })
+    }
+}
+
+impl TargetWrite {
+    pub fn load_data(&self) -> Result<Vec<Section>> {
+        log::info!("Loading VMEM file: {}", self.path.display());
+        let vmem_content = fs::read_to_string(&self.path)?;
+        let mut vmem = Vmem::from_str(&vmem_content, None)?;
+        vmem.merge_sections(None);
+        let mut sections: Vec<Section> = vmem.sections().cloned().collect();
+
+        // If an offset is given, all sections must be offset by that amount.
+        if let Some(offset) = self.offset {
+            for section in &mut sections {
+                section.addr += offset;
+            }
+        }
+
+        Ok(sections)
+    }
+
+    pub fn backdoor_write(&self, backdoor: &mut Backdoor, verify: bool) -> Result<()> {
+        let mut target = backdoor
+            .target_by_id_str(&self.target)?
+            .context(format!("FPGA target '{}' not found", &self.target))?;
+
+        let data = self.load_data()?;
+        write_to_target(&mut target, &self.target, data, verify)
+    }
+}
+
+// Write FPGA memories after loading the bitstream
+#[derive(Debug, Args)]
+pub struct LoadMemories {
+    /// Memories to be written, mapping VMEM files to FPGA target memories.
+    #[arg(long = "load-memory", value_name = "TARGET=FILE[@OFFSET]")]
+    pub target_writes: Vec<TargetWrite>,
+}
+
+impl LoadMemories {
+    pub fn init(&self, transport: &TransportWrapper, jtag_params: &JtagParams) -> Result<()> {
+        if self.target_writes.is_empty() {
+            return Ok(());
+        }
+
+        let mut backdoor = enter_backdoor(transport, jtag_params)?;
+        self.target_writes
+            .iter()
+            .try_for_each(|t| t.backdoor_write(&mut backdoor, false))?;
+        backdoor.set_done()?;
+
+        Ok(())
+    }
+}

--- a/sw/host/opentitanlib/src/test_utils/fpga_backdoor.rs
+++ b/sw/host/opentitanlib/src/test_utils/fpga_backdoor.rs
@@ -10,7 +10,9 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use crate::app::TransportWrapper;
-use crate::io::fpga_backdoor::{Backdoor, BackdoorParams, BackdoorTarget, enter_backdoor_loader};
+use crate::io::fpga_backdoor::{
+    Backdoor, BackdoorParams, BackdoorTarget, BackdoorTargetInfo, enter_backdoor_loader,
+};
 use crate::io::jtag::JtagParams;
 use crate::util::vmem::{Section, Vmem, Word};
 
@@ -82,7 +84,22 @@ pub fn write_to_target(
             target_id
         );
 
-        target.write(section.addr, &section.data, false, verify)?;
+        // Special case - if we're just trying to clear the entire target memory,
+        // instead use the fast clearing operation.
+        let first_word = &section.data.first().clone();
+        if section.addr == 0
+            && section.data.len() == target.info.depth as usize
+            && section.data.iter().all(|w| w == first_word.unwrap())
+        {
+            log::debug!(
+                "Clearing target {} with word {}",
+                target_id,
+                hex::encode(first_word.unwrap().bytes.clone())
+            );
+            target.clear(first_word.unwrap(), verify)?;
+        } else {
+            target.write(section.addr, &section.data, false, verify)?;
+        }
 
         // If requested, read back the data and verify against written contents
         if verify {
@@ -161,9 +178,74 @@ impl TargetWrite {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct TargetClear {
+    pub target: String,
+    pub num_words: Option<u32>,
+    pub offset: Option<u32>,
+}
+
+impl FromStr for TargetClear {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (target_words, offset) = s
+            .split_once('@')
+            .map(|(x, y)| (x, y.parse::<u32>().ok()))
+            .unwrap_or((s, None));
+
+        let (target, num_words) = target_words
+            .split_once('=')
+            .context("expected input like TARGET=NUM_WORDS[@OFFSET], but no '=' was seen")?;
+        if target.is_empty() {
+            bail!("target name cannot be empty");
+        }
+        if num_words.is_empty() {
+            bail!("num_words cannot be empty");
+        }
+        let num_words = if num_words.to_lowercase() == "all" {
+            None
+        } else {
+            Some(num_words.parse::<u32>()?)
+        };
+
+        Ok(TargetClear {
+            target: target.to_string(),
+            num_words,
+            offset,
+        })
+    }
+}
+
+impl TargetClear {
+    pub fn as_sections(&self, target_info: &BackdoorTargetInfo) -> Vec<Section> {
+        let num_bytes = target_info.width.div_ceil(8) as usize;
+        let remaining_words = target_info.depth - self.offset.unwrap_or(0);
+        let num_words = self.num_words.unwrap_or(remaining_words);
+        let data = vec![Word::new(vec![0x00; num_bytes]); num_words as usize];
+        vec![Section {
+            addr: self.offset.unwrap_or(0),
+            data,
+        }]
+    }
+
+    pub fn backdoor_write(&self, backdoor: &mut Backdoor, verify: bool) -> Result<()> {
+        let mut target = backdoor
+            .target_by_id_str(&self.target)?
+            .context(format!("FPGA target '{}' not found", &self.target))?;
+
+        let data = self.as_sections(&target.info);
+        write_to_target(&mut target, &self.target, data, verify)
+    }
+}
+
 // Write FPGA memories after loading the bitstream
 #[derive(Debug, Args)]
 pub struct LoadMemories {
+    /// Memories to be cleared / zeroed. All clears apply before writes.
+    #[arg(long = "clear-memory", value_name = "TARGET=NUM_WORDS[@OFFSET]")]
+    pub target_clears: Vec<TargetClear>,
+
     /// Memories to be written, mapping VMEM files to FPGA target memories.
     #[arg(long = "load-memory", value_name = "TARGET=FILE[@OFFSET]")]
     pub target_writes: Vec<TargetWrite>,
@@ -171,11 +253,14 @@ pub struct LoadMemories {
 
 impl LoadMemories {
     pub fn init(&self, transport: &TransportWrapper, jtag_params: &JtagParams) -> Result<()> {
-        if self.target_writes.is_empty() {
+        if self.target_clears.is_empty() && self.target_writes.is_empty() {
             return Ok(());
         }
 
         let mut backdoor = enter_backdoor(transport, jtag_params)?;
+        self.target_clears
+            .iter()
+            .try_for_each(|t| t.backdoor_write(&mut backdoor, false))?;
         self.target_writes
             .iter()
             .try_for_each(|t| t.backdoor_write(&mut backdoor, false))?;

--- a/sw/host/opentitanlib/src/test_utils/init.rs
+++ b/sw/host/opentitanlib/src/test_utils/init.rs
@@ -14,6 +14,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use super::bootstrap::Bootstrap;
+use super::fpga_backdoor::LoadMemories;
 use super::load_bitstream::LoadBitstream;
 use crate::app::TransportWrapper;
 use crate::backend;
@@ -42,6 +43,9 @@ pub struct InitializeTest {
     //pub uart_params: UartParams,
     #[command(flatten)]
     pub load_bitstream: LoadBitstream,
+
+    #[command(flatten)]
+    pub load_memories: LoadMemories,
 
     #[command(flatten)]
     pub bootstrap: Bootstrap,
@@ -155,6 +159,14 @@ impl InitializeTest {
         Self::print_result(
             "load_bitstream",
             self.load_bitstream.init(&transport).map(|_| None),
+        )?;
+
+        // Program any memories (e.g. ROM, OTP).
+        Self::print_result(
+            "load_memories",
+            self.load_memories
+                .init(&transport, &self.jtag_params)
+                .map(|_| None),
         )?;
 
         // Bootstrap an rv32 test program.

--- a/sw/host/opentitanlib/src/test_utils/load_bitstream.rs
+++ b/sw/host/opentitanlib/src/test_utils/load_bitstream.rs
@@ -28,6 +28,10 @@ pub struct LoadBitstream {
     /// Duration of ROM detection timeout.
     #[arg(long, value_parser = humantime::parse_duration, default_value = "2s")]
     pub rom_timeout: Duration,
+
+    /// Load the bitstream, regardless of a matching USR_ACCESS.
+    #[arg(long)]
+    pub force: bool,
 }
 
 impl LoadBitstream {
@@ -56,7 +60,7 @@ impl LoadBitstream {
             progress: Box::new(progress),
         };
 
-        if operation.should_skip(transport)? {
+        if !self.force && operation.should_skip(transport)? {
             return Ok(());
         }
 

--- a/sw/host/opentitanlib/src/test_utils/mod.rs
+++ b/sw/host/opentitanlib/src/test_utils/mod.rs
@@ -11,6 +11,7 @@ pub mod epmp;
 // set of CSRs as the "earlgrey" chip.
 #[cfg(not(feature = "english_breakfast"))]
 pub mod extclk;
+pub mod fpga_backdoor;
 pub mod gpio;
 pub mod gpio_monitor;
 pub mod i2c_target;

--- a/sw/host/opentitanlib/src/transport/common/fpga.rs
+++ b/sw/host/opentitanlib/src/transport/common/fpga.rs
@@ -11,6 +11,11 @@ use crate::io::uart::Uart;
 use crate::transport::ProgressIndicator;
 use crate::util::rom_detect::RomDetect;
 
+// TODO: Consider deprecating use of `RomDetect` and instead use the FPGA `bkdr_loader`'s
+// `USR_ACCESS_TIMESTAMP` register, which should be exposing the exact same info. This
+// allows us to query this info even for tests that cannot boot into ROM. However, this
+// will require a JTAG connection to go via the bkdr_loader TAP.
+
 /// Command for Transport::dispatch().
 pub struct FpgaProgram {
     /// The bitstream content to load into the FPGA.

--- a/sw/host/opentitantool/src/command/fpga_backdoor.rs
+++ b/sw/host/opentitantool/src/command/fpga_backdoor.rs
@@ -9,6 +9,7 @@ use std::convert::From;
 use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::app::command::CommandDispatch;
@@ -33,6 +34,8 @@ pub enum InternalBackdoorCommand {
     Write(BackdoorWrite),
     /// Verify that the contents of some target memory matches some given data.
     Verify(BackdoorVerify),
+    /// A command that combines entering, writing several files to different targets, and starting.
+    Batch(BackdoorBatch),
 }
 
 #[derive(Debug, Args)]
@@ -486,6 +489,86 @@ impl CommandDispatch for BackdoorVerify {
                 target.info.width as usize,
                 section.addr,
             )?;
+        }
+
+        Ok(None)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TargetWrite {
+    pub target: String,
+    pub path: PathBuf,
+    pub offset: Option<u32>,
+}
+
+impl FromStr for TargetWrite {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (target_path, offset) = s
+            .split_once('@')
+            .map(|(x, y)| (x, y.parse::<u32>().ok()))
+            .unwrap_or((s, None));
+
+        let (target, path) = target_path
+            .split_once('=')
+            .context("expected input like TARGET=FILE[@OFFSET], but no '=' was seen")?;
+        if target.is_empty() {
+            bail!("target name cannot be empty");
+        }
+        if path.is_empty() {
+            bail!("file path cannot be empty");
+        }
+
+        Ok(TargetWrite {
+            target: target.to_string(),
+            path: PathBuf::from(path),
+            offset,
+        })
+    }
+}
+
+#[derive(Debug, Args)]
+pub struct BackdoorBatch {
+    /// Write operations to be batched, mapping VMEM files to FPGA targets.
+    #[arg(long = "write", required = true, value_name = "TARGET=FILE[@OFFSET]")]
+    pub targets: Vec<TargetWrite>,
+
+    /// After completing all writes, enter "mission mode" & start the chip.
+    #[arg(long)]
+    pub start: bool,
+
+    /// Read back and verify the written data (may take noticeably longer).
+    #[arg(long)]
+    pub verify: bool,
+}
+
+impl CommandDispatch for BackdoorBatch {
+    fn run(
+        &self,
+        context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
+        let context = context.downcast_ref::<BackdoorCommand>().unwrap();
+        let backdoor = context.params.create(transport)?;
+        let mut backdoor = backdoor.connect(true)?;
+
+        for write_op in &self.targets {
+            let input = WriteInput::Vmem(VmemInput {
+                path: write_op.path.clone(),
+            });
+            write_to_target(
+                &mut backdoor,
+                &write_op.target,
+                &input,
+                write_op.offset,
+                self.verify,
+            )?;
+        }
+
+        if self.start {
+            backdoor.set_done()?;
         }
 
         Ok(None)

--- a/sw/host/opentitantool/src/command/fpga_backdoor.rs
+++ b/sw/host/opentitantool/src/command/fpga_backdoor.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::{Args, Subcommand};
 use std::any::Any;
 use std::convert::From;
@@ -12,7 +12,9 @@ use std::path::PathBuf;
 
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::app::command::CommandDispatch;
-use opentitanlib::io::fpga_backdoor::{BackdoorParams, BackdoorTargetInfo, enter_backdoor_loader};
+use opentitanlib::io::fpga_backdoor::{
+    Backdoor, BackdoorParams, BackdoorTargetInfo, enter_backdoor_loader,
+};
 use opentitanlib::util::parse_int::ParseInt;
 use opentitanlib::util::vmem::{Section, Vmem, Word};
 
@@ -27,6 +29,10 @@ pub enum InternalBackdoorCommand {
     Info(BackdoorInfo),
     /// Read words from a target memory via the backdoor.
     Read(BackdoorRead),
+    /// Write words to a target memory via the backdoor.
+    Write(BackdoorWrite),
+    /// Verify that the contents of some target memory matches some given data.
+    Verify(BackdoorVerify),
 }
 
 #[derive(Debug, Args)]
@@ -208,6 +214,279 @@ impl CommandDispatch for BackdoorRead {
             self.format,
             self.group_vmem_words,
         )?;
+
+        Ok(None)
+    }
+}
+
+#[derive(Debug, Args)]
+pub struct BackdoorWrite {
+    /// Target to write to.
+    pub target: String,
+
+    /// First word address / index to write to.
+    #[arg(long, value_parser = <u32 as ParseInt>::from_str)]
+    pub offset: Option<u32>,
+
+    /// Read back and verify the written data (may take noticeably longer).
+    #[arg(long)]
+    pub verify: bool,
+
+    /// The input source to write
+    #[command(subcommand)]
+    pub input: WriteInput,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum WriteInput {
+    /// Write/verify words given as a whitespace-separated hex string
+    Hex(HexInput),
+    /// Write/verify words that are some repeated clear pattern (e.g. all 0s, 0xA5 repeated)
+    Clear(ClearInput),
+    /// Write/verify words loaded from a Verilog VMEM file
+    Vmem(VmemInput),
+}
+
+#[derive(Args, Debug)]
+pub struct HexInput {
+    /// Input hexadecimal words, with whitespace separating each word
+    #[arg(required = true, num_args = 1..)]
+    pub data: Vec<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct ClearInput {
+    /// The number of cleared words. If unspecified, the remainder of the target is cleared.
+    #[arg(value_parser = <u32 as ParseInt>::from_str)]
+    pub words: Option<u32>,
+
+    /// The pattern (byte) that is repeated.
+    #[arg(long, value_parser = <u8 as ParseInt>::from_str, default_value = "0x00")]
+    pub pattern: u8,
+}
+
+#[derive(Args, Debug)]
+pub struct VmemInput {
+    /// Path to the Verilog VMEM file
+    pub path: PathBuf,
+}
+
+impl WriteInput {
+    fn load_hex_words(hex: &HexInput) -> Result<Vec<Section>> {
+        let words = hex
+            .data
+            .join(" ")
+            .split_whitespace()
+            .map(|word| {
+                let normalized = word
+                    .strip_prefix("0x")
+                    .or_else(|| word.strip_prefix("0X"))
+                    .unwrap_or(word);
+                let normalized = if normalized.len() % 2 != 0 {
+                    format!("0{}", normalized)
+                } else {
+                    String::from(normalized)
+                };
+
+                Ok(Word::new(hex::decode(normalized)?))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(vec![Section {
+            addr: 0,
+            data: words,
+        }])
+    }
+
+    fn load_input(
+        input: &WriteInput,
+        target_info: &BackdoorTargetInfo,
+        offset: Option<u32>,
+    ) -> Result<Vec<Section>> {
+        let mut sections: Vec<Section> = match input {
+            WriteInput::Hex(hex) => WriteInput::load_hex_words(hex)?,
+            WriteInput::Clear(clear) => {
+                let num_bytes = target_info.width.div_ceil(8) as usize;
+                let remaining_words = target_info.depth - offset.unwrap_or(0);
+                let num_words = clear.words.unwrap_or(remaining_words);
+                let data = vec![Word::new(vec![clear.pattern; num_bytes]); num_words as usize];
+                vec![Section { addr: 0, data }]
+            }
+            WriteInput::Vmem(vmem) => {
+                log::info!("Loading VMEM file: {}", vmem.path.display());
+                let vmem_content = fs::read_to_string(&vmem.path)?;
+                let mut vmem = Vmem::from_str(&vmem_content, None)?;
+                vmem.merge_sections(None);
+                vmem.sections().cloned().collect()
+            }
+        };
+
+        // If an offset is given, all sections must be offset by that amount.
+        if let Some(offset) = offset {
+            for section in &mut sections {
+                section.addr += offset;
+            }
+        }
+
+        Ok(sections)
+    }
+}
+
+// Normalize a word to a given number of bits.
+fn normalize_word(word: &mut Word, bits_per_word: usize) {
+    let bytes_per_word = bits_per_word.div_ceil(8);
+    if word.bytes.len() > bytes_per_word {
+        let start = word.bytes.len() - bytes_per_word;
+        word.bytes.drain(..start);
+    } else if word.bytes.len() < bytes_per_word {
+        let mut padded = vec![0u8; bytes_per_word - word.bytes.len()];
+        padded.append(&mut word.bytes);
+        word.bytes = padded;
+    }
+
+    let extra_bits = bits_per_word % 8;
+    if extra_bits > 0 {
+        word.bytes[0] &= 0xFF >> (8 - extra_bits);
+    }
+}
+
+// Check that words read from target memory match input words.
+fn verify_readback(
+    input: &mut [Word],
+    readback: &mut [Word],
+    bits_per_word: usize,
+    mut offset: u32,
+) -> Result<()> {
+    for (write_word, read_word) in readback.iter_mut().zip(input) {
+        normalize_word(write_word, bits_per_word);
+        normalize_word(read_word, bits_per_word);
+        if write_word != read_word {
+            bail!(
+                "Read verification at word {} failed. Expected: {}, Got: {}",
+                offset,
+                hex::encode(write_word.bytes.clone()),
+                hex::encode(read_word.bytes.clone()),
+            );
+        }
+
+        offset += 1;
+    }
+
+    Ok(())
+}
+
+fn write_to_target(
+    backdoor: &mut Backdoor,
+    target_id: &str,
+    input: &WriteInput,
+    offset: Option<u32>,
+    verify: bool,
+) -> Result<()> {
+    // Try and find the requested target.
+    let mut target = backdoor
+        .target_by_id_str(target_id)?
+        .context(format!("FPGA target '{}' not found", target_id))?;
+
+    // Parse the input, which will depend on the given input type.
+    let sections: Vec<Section> = WriteInput::load_input(input, &target.info, offset)?;
+
+    // Perform the write(s)
+    log::info!("Writing to the {}...", target_id);
+    for mut section in sections {
+        log::debug!(
+            "Writing section of size {} to word {} of target {}",
+            section.data.len(),
+            section.addr,
+            target_id
+        );
+        target.write(section.addr, &section.data, false, verify)?;
+
+        // If requested, read back the data and verify against written contents
+        if verify {
+            let mut readback = target.read(section.addr, section.data.len() as u32, false)?;
+            verify_readback(
+                &mut section.data,
+                &mut readback,
+                target.info.width as usize,
+                section.addr,
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+impl CommandDispatch for BackdoorWrite {
+    fn run(
+        &self,
+        context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
+        let context = context.downcast_ref::<BackdoorCommand>().unwrap();
+        let backdoor = context.params.create(transport)?;
+        let mut backdoor = backdoor.connect(true)?;
+        write_to_target(
+            &mut backdoor,
+            &self.target,
+            &self.input,
+            self.offset,
+            self.verify,
+        )?;
+
+        Ok(None)
+    }
+}
+
+#[derive(Debug, Args)]
+pub struct BackdoorVerify {
+    /// Target to verify the contents of.
+    pub target: String,
+
+    /// First word address / index to read from.
+    #[arg(long, value_parser = <u32 as ParseInt>::from_str)]
+    pub offset: Option<u32>,
+
+    /// The input source to verify against.
+    #[command(subcommand)]
+    pub input: WriteInput,
+}
+
+impl CommandDispatch for BackdoorVerify {
+    fn run(
+        &self,
+        context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
+        let context = context.downcast_ref::<BackdoorCommand>().unwrap();
+
+        // Connect to the backdoor and try and find the requested target.
+        let backdoor = context.params.create(transport)?;
+        let mut backdoor = backdoor.connect(true)?;
+        let mut target = backdoor
+            .target_by_id_str(&self.target)?
+            .context(format!("FPGA target '{}' not found", self.target))?;
+
+        // Parse the input, which will depend on the given input type.
+        let sections: Vec<Section> =
+            WriteInput::load_input(&self.input, &target.info, self.offset)?;
+
+        // Read the data and check it matches our input.
+        log::info!("Verifying the {}...", self.target);
+        for mut section in sections {
+            log::debug!(
+                "Verifying section of size {} at word {} of target {}",
+                section.data.len(),
+                section.addr,
+                self.target
+            );
+            let mut readback = target.read(section.addr, section.data.len() as u32, false)?;
+            verify_readback(
+                &mut section.data,
+                &mut readback,
+                target.info.width as usize,
+                section.addr,
+            )?;
+        }
 
         Ok(None)
     }

--- a/sw/host/opentitantool/src/command/fpga_backdoor.rs
+++ b/sw/host/opentitantool/src/command/fpga_backdoor.rs
@@ -2,20 +2,18 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use clap::{Args, Subcommand};
 use std::any::Any;
 use std::convert::From;
 use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
-use std::str::FromStr;
 
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::app::command::CommandDispatch;
-use opentitanlib::io::fpga_backdoor::{
-    Backdoor, BackdoorParams, BackdoorTargetInfo, enter_backdoor_loader,
-};
+use opentitanlib::io::fpga_backdoor::{BackdoorParams, BackdoorTargetInfo, enter_backdoor_loader};
+use opentitanlib::test_utils::fpga_backdoor::{TargetWrite, verify_readback, write_to_target};
 use opentitanlib::util::parse_int::ParseInt;
 use opentitanlib::util::vmem::{Section, Vmem, Word};
 
@@ -302,11 +300,11 @@ impl WriteInput {
     }
 
     fn load_input(
-        input: &WriteInput,
+        &self,
         target_info: &BackdoorTargetInfo,
         offset: Option<u32>,
     ) -> Result<Vec<Section>> {
-        let mut sections: Vec<Section> = match input {
+        let mut sections: Vec<Section> = match self {
             WriteInput::Hex(hex) => WriteInput::load_hex_words(hex)?,
             WriteInput::Clear(clear) => {
                 let num_bytes = target_info.width.div_ceil(8) as usize;
@@ -335,90 +333,6 @@ impl WriteInput {
     }
 }
 
-// Normalize a word to a given number of bits.
-fn normalize_word(word: &mut Word, bits_per_word: usize) {
-    let bytes_per_word = bits_per_word.div_ceil(8);
-    if word.bytes.len() > bytes_per_word {
-        let start = word.bytes.len() - bytes_per_word;
-        word.bytes.drain(..start);
-    } else if word.bytes.len() < bytes_per_word {
-        let mut padded = vec![0u8; bytes_per_word - word.bytes.len()];
-        padded.append(&mut word.bytes);
-        word.bytes = padded;
-    }
-
-    let extra_bits = bits_per_word % 8;
-    if extra_bits > 0 {
-        word.bytes[0] &= 0xFF >> (8 - extra_bits);
-    }
-}
-
-// Check that words read from target memory match input words.
-fn verify_readback(
-    input: &mut [Word],
-    readback: &mut [Word],
-    bits_per_word: usize,
-    mut offset: u32,
-) -> Result<()> {
-    for (write_word, read_word) in readback.iter_mut().zip(input) {
-        normalize_word(write_word, bits_per_word);
-        normalize_word(read_word, bits_per_word);
-        if write_word != read_word {
-            bail!(
-                "Read verification at word {} failed. Expected: {}, Got: {}",
-                offset,
-                hex::encode(write_word.bytes.clone()),
-                hex::encode(read_word.bytes.clone()),
-            );
-        }
-
-        offset += 1;
-    }
-
-    Ok(())
-}
-
-fn write_to_target(
-    backdoor: &mut Backdoor,
-    target_id: &str,
-    input: &WriteInput,
-    offset: Option<u32>,
-    verify: bool,
-) -> Result<()> {
-    // Try and find the requested target.
-    let mut target = backdoor
-        .target_by_id_str(target_id)?
-        .context(format!("FPGA target '{}' not found", target_id))?;
-
-    // Parse the input, which will depend on the given input type.
-    let sections: Vec<Section> = WriteInput::load_input(input, &target.info, offset)?;
-
-    // Perform the write(s)
-    log::info!("Writing to the {}...", target_id);
-    for mut section in sections {
-        log::debug!(
-            "Writing section of size {} to word {} of target {}",
-            section.data.len(),
-            section.addr,
-            target_id
-        );
-        target.write(section.addr, &section.data, false, verify)?;
-
-        // If requested, read back the data and verify against written contents
-        if verify {
-            let mut readback = target.read(section.addr, section.data.len() as u32, false)?;
-            verify_readback(
-                &mut section.data,
-                &mut readback,
-                target.info.width as usize,
-                section.addr,
-            )?;
-        }
-    }
-
-    Ok(())
-}
-
 impl CommandDispatch for BackdoorWrite {
     fn run(
         &self,
@@ -428,13 +342,15 @@ impl CommandDispatch for BackdoorWrite {
         let context = context.downcast_ref::<BackdoorCommand>().unwrap();
         let backdoor = context.params.create(transport)?;
         let mut backdoor = backdoor.connect(true)?;
-        write_to_target(
-            &mut backdoor,
-            &self.target,
-            &self.input,
-            self.offset,
-            self.verify,
-        )?;
+
+        // Try and find the requested target.
+        let mut target = backdoor
+            .target_by_id_str(&self.target)?
+            .context(format!("FPGA target '{}' not found", &self.target))?;
+
+        // Parse the input & write it to the target memory.
+        let sections: Vec<Section> = self.input.load_input(&target.info, self.offset)?;
+        write_to_target(&mut target, &self.target, sections, self.verify)?;
 
         Ok(None)
     }
@@ -495,45 +411,11 @@ impl CommandDispatch for BackdoorVerify {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct TargetWrite {
-    pub target: String,
-    pub path: PathBuf,
-    pub offset: Option<u32>,
-}
-
-impl FromStr for TargetWrite {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (target_path, offset) = s
-            .split_once('@')
-            .map(|(x, y)| (x, y.parse::<u32>().ok()))
-            .unwrap_or((s, None));
-
-        let (target, path) = target_path
-            .split_once('=')
-            .context("expected input like TARGET=FILE[@OFFSET], but no '=' was seen")?;
-        if target.is_empty() {
-            bail!("target name cannot be empty");
-        }
-        if path.is_empty() {
-            bail!("file path cannot be empty");
-        }
-
-        Ok(TargetWrite {
-            target: target.to_string(),
-            path: PathBuf::from(path),
-            offset,
-        })
-    }
-}
-
 #[derive(Debug, Args)]
 pub struct BackdoorBatch {
     /// Write operations to be batched, mapping VMEM files to FPGA targets.
-    #[arg(long = "write", required = true, value_name = "TARGET=FILE[@OFFSET]")]
-    pub targets: Vec<TargetWrite>,
+    #[arg(long = "write", value_name = "TARGET=FILE[@OFFSET]")]
+    pub target_writes: Vec<TargetWrite>,
 
     /// After completing all writes, enter "mission mode" & start the chip.
     #[arg(long)]
@@ -554,18 +436,9 @@ impl CommandDispatch for BackdoorBatch {
         let backdoor = context.params.create(transport)?;
         let mut backdoor = backdoor.connect(true)?;
 
-        for write_op in &self.targets {
-            let input = WriteInput::Vmem(VmemInput {
-                path: write_op.path.clone(),
-            });
-            write_to_target(
-                &mut backdoor,
-                &write_op.target,
-                &input,
-                write_op.offset,
-                self.verify,
-            )?;
-        }
+        self.target_writes
+            .iter()
+            .try_for_each(|t| t.backdoor_write(&mut backdoor, false))?;
 
         if self.start {
             backdoor.set_done()?;

--- a/sw/host/opentitantool/src/command/fpga_backdoor.rs
+++ b/sw/host/opentitantool/src/command/fpga_backdoor.rs
@@ -13,7 +13,9 @@ use std::path::PathBuf;
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::app::command::CommandDispatch;
 use opentitanlib::io::fpga_backdoor::{BackdoorParams, BackdoorTargetInfo, enter_backdoor_loader};
-use opentitanlib::test_utils::fpga_backdoor::{TargetWrite, verify_readback, write_to_target};
+use opentitanlib::test_utils::fpga_backdoor::{
+    TargetClear, TargetWrite, verify_readback, write_to_target,
+};
 use opentitanlib::util::parse_int::ParseInt;
 use opentitanlib::util::vmem::{Section, Vmem, Word};
 
@@ -413,6 +415,10 @@ impl CommandDispatch for BackdoorVerify {
 
 #[derive(Debug, Args)]
 pub struct BackdoorBatch {
+    /// Clear/zero operations to be batched. All clears apply before writes.
+    #[arg(long = "clear", value_name = "TARGET=NUM_WORDS[@OFFSET]")]
+    pub target_clears: Vec<TargetClear>,
+
     /// Write operations to be batched, mapping VMEM files to FPGA targets.
     #[arg(long = "write", value_name = "TARGET=FILE[@OFFSET]")]
     pub target_writes: Vec<TargetWrite>,
@@ -436,6 +442,9 @@ impl CommandDispatch for BackdoorBatch {
         let backdoor = context.params.create(transport)?;
         let mut backdoor = backdoor.connect(true)?;
 
+        self.target_clears
+            .iter()
+            .try_for_each(|t| t.backdoor_write(&mut backdoor, false))?;
         self.target_writes
             .iter()
             .try_for_each(|t| t.backdoor_write(&mut backdoor, false))?;

--- a/sw/host/opentitantool/src/command/load_bitstream.rs
+++ b/sw/host/opentitantool/src/command/load_bitstream.rs
@@ -20,9 +20,14 @@ pub struct LoadBitstream {
     /// Duration of the reset pulse.
     #[arg(long, value_parser = humantime::parse_duration, default_value = "50ms")]
     pub rom_reset_pulse: Duration,
+
     /// Duration of ROM detection timeout.
     #[arg(long, value_parser = humantime::parse_duration, default_value = "2s")]
     pub rom_timeout: Duration,
+
+    /// Load the bitstream, regardless of a matching USR_ACCESS.
+    #[arg(long)]
+    pub force: bool,
 }
 
 impl CommandDispatch for LoadBitstream {
@@ -36,6 +41,7 @@ impl CommandDispatch for LoadBitstream {
             bitstream: Some(self.filename.clone()),
             rom_reset_pulse: self.rom_reset_pulse,
             rom_timeout: self.rom_timeout,
+            force: self.force,
         }
         .init(transport)?;
 


### PR DESCRIPTION
Note that the ROM endpoint is currently disabled for now to allow bitstream splicing flows to continue working. 

Implement FPGA backdoor loader memory write operations via OpenTitanLib / OpenTitanTool. Adds three new commands:
* Using the `opentitantool fpga backdoor write` command, you can write to target memories via the backdoor loader (when it is in its preloading mode, entered via `fpga backdoor enter`). Options are available for customizing the offset of the write, and for whether to read back written data and verify the write (which can be much slower). 3 input formats are supported:
    * `hex` - hex words given as arguments over stdin.
    * `clear` - clear some portion or the entirety of a target's memory with a byte pattern.
    * `vmem` - load data from a VMEM file and write that to the target memory. For now, these are assumed to always have a stride of 1 word per address.
* The `opentitantool fpga backdoor verify` command is almost identical to `fpga backdoor write --verify`, except it does not write the data. It instead takes the same inputs and only does the readback verification.
* The `opentitantool fpga backdoor batch` command is an "orchestrator" that batches multiple VMEM writes. This is needed because a common use case for FPGA testing will be to splice multiple memories (e.g. ROM, OTP, potentially flash in the future). If these are all separate write commands, OpenTitanTool will spin up a separate OpenOCD instance each time, which will add some non-insignificant overheads to these operations. By batching we can amortize these overheads. However, `clap` does not naturally support nested/chained subcommands, and as such for now we implement a subset of write operations (only VMEM writes for now).

One difficulty with the bkdr_loader operations is that they can be somewhat slow, as they can require many DMI writes and reads over JTAG. The current implementation for DMI writes is particularly inefficient for the case where we have multiple writes in a row -- as is required to write to a target's memory via the bkdr_loader -- so an optimized batched writing interface is added to the `Dmi` trait, with a custom implementation for OpenOCD. There are also shadow CSRs maintained to minimize the number of DMI writes.

For clears of memory, a further optimization is introduced to use a dedicated HW clearing operation as a 'fast path', which can allow us to quickly clear memories. This is useful for e.g. zeroing non-volatile memories at the start of every test run, to emulate the behaviour currently provided by loading a newly spliced bitstream.