### PR TITLE
[vendor] PULP debug module patch cleanup

### DIFF
--- a/hw/vendor/patches/pulp_riscv_dbg/0001-Fix-lint-errors.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0001-Fix-lint-errors.patch
@@ -1,23 +1,19 @@
 From 144819373e52cbc15ecb19cf11b374be41a26016 Mon Sep 17 00:00:00 2001
 From: Michael Schaffner <msf@google.com>
 Date: Tue, 25 Oct 2022 18:28:07 -0700
-Subject: [PATCH 1/7] Fix lint errors
+Subject: Fix lint errors
 
 Signed-off-by: Michael Schaffner <msf@google.com>
 
 diff --git a/src/dm_mem.sv b/src/dm_mem.sv
-index 9ff3c86..62cdf02 100755
+index 9ff3c86..2b4497e 100755
 --- a/src/dm_mem.sv
 +++ b/src/dm_mem.sv
-@@ -82,7 +82,15 @@ module dm_mem #(
+@@ -82,7 +82,11 @@ module dm_mem #(
    localparam logic [DbgAddressBits-1:0] ResumingAddr  = 'h110;
    localparam logic [DbgAddressBits-1:0] ExceptionAddr = 'h118;
  
 -  logic [dm::ProgBufSize/2-1:0][63:0]   progbuf;
-+  localparam logic [DbgAddressBits-1:0] RomBaseAddr   = dm::HaltAddress;
-+  // The size is arbitrarily set to 0x800, so as to make the dm_space exactly 0x900 long. This is
-+  // more than eough to cover the 19 x 64bit = 0x98 bytes currenty allocated in the debug ROM.
-+  localparam logic [DbgAddressBits-1:0] RomEndAddr    = dm::HaltAddress + 'h7FF;
 +  // Prog buff size after repacking the 32bit array into a 64bit array.
 +  localparam int unsigned ProgBuf64Size = dm::ProgBufSize / 2;
 +  localparam int unsigned ProgBuf64AddrSize = $clog2(ProgBuf64Size);
@@ -26,7 +22,7 @@ index 9ff3c86..62cdf02 100755
    logic [7:0][63:0]   abstract_cmd;
    logic [NrHarts-1:0] halted_d, halted_q;
    logic [NrHarts-1:0] resuming_d, resuming_q;
-@@ -265,12 +273,13 @@ module dm_mem #(
+@@ -265,12 +269,13 @@ module dm_mem #(
            // core can write data registers
            [DataBaseAddr:DataEndAddr]: begin
              data_valid_o = 1'b1;
@@ -43,7 +39,7 @@ index 9ff3c86..62cdf02 100755
                          data_bits[dc+1][(i-4)*8+:8] = wdata_i[i*8+:8];
                        end
                      end else begin // for lower 32bit data write
-@@ -310,14 +319,17 @@ module dm_mem #(
+@@ -310,14 +315,17 @@ module dm_mem #(
  
            [DataBaseAddr:DataEndAddr]: begin
              rdata_d = {

--- a/hw/vendor/patches/pulp_riscv_dbg/0002-Add-access-error-signal-to-dm_mem.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0002-Add-access-error-signal-to-dm_mem.patch
@@ -1,12 +1,12 @@
 From d2fe1d8aa26b8d6c03ada39962bdf779d0c43efd Mon Sep 17 00:00:00 2001
 From: Michael Schaffner <msf@google.com>
 Date: Tue, 25 Oct 2022 19:38:49 -0700
-Subject: [PATCH 2/7] Add access error signal to dm_mem
+Subject: Add access error signal to dm_mem
 
 Signed-off-by: Michael Schaffner <msf@google.com>
 
 diff --git a/src/dm_mem.sv b/src/dm_mem.sv
-index 62cdf02..f7a5f7d 100755
+index 2b4497e..f7a5f7d 100755
 --- a/src/dm_mem.sv
 +++ b/src/dm_mem.sv
 @@ -20,7 +20,8 @@ module dm_mem #(
@@ -31,7 +31,18 @@ index 62cdf02..f7a5f7d 100755
  );
    localparam int unsigned DbgAddressBits = 12;
    localparam int unsigned HartSelLen     = (NrHarts == 1) ? 1 : $clog2(NrHarts);
-@@ -239,6 +241,7 @@ module dm_mem #(
+@@ -82,6 +84,10 @@ module dm_mem #(
+   localparam logic [DbgAddressBits-1:0] ResumingAddr  = 'h110;
+   localparam logic [DbgAddressBits-1:0] ExceptionAddr = 'h118;
+ 
++  localparam logic [DbgAddressBits-1:0] RomBaseAddr   = dm::HaltAddress;
++  // The size is arbitrarily set to 0x800, so as to make the dm_space exactly 0x900 long. This is
++  // more than eough to cover the 19 x 64bit = 0x98 bytes currenty allocated in the debug ROM.
++  localparam logic [DbgAddressBits-1:0] RomEndAddr    = dm::HaltAddress + 'h7FF;
+   // Prog buff size after repacking the 32bit array into a 64bit array.
+   localparam int unsigned ProgBuf64Size = dm::ProgBufSize / 2;
+   localparam int unsigned ProgBuf64AddrSize = $clog2(ProgBuf64Size);
+@@ -235,6 +241,7 @@ module dm_mem #(
      rdata_d        = rdata_q;
      data_bits      = data_i;
      rdata          = '0;
@@ -39,7 +50,7 @@ index 62cdf02..f7a5f7d 100755
  
      // write data in csr register
      data_valid_o   = 1'b0;
-@@ -290,7 +293,7 @@ module dm_mem #(
+@@ -286,7 +293,7 @@ module dm_mem #(
                end
              end
            end
@@ -48,7 +59,7 @@ index 62cdf02..f7a5f7d 100755
          endcase
  
        // this is a read
-@@ -347,6 +350,11 @@ module dm_mem #(
+@@ -343,6 +350,11 @@ module dm_mem #(
              end
              rdata_d = rdata;
            end
@@ -60,7 +71,7 @@ index 62cdf02..f7a5f7d 100755
            default: ;
          endcase
        end
-@@ -361,6 +369,54 @@ module dm_mem #(
+@@ -357,6 +369,54 @@ module dm_mem #(
      data_o = data_bits;
    end
  
@@ -115,7 +126,7 @@ index 62cdf02..f7a5f7d 100755
    always_comb begin : p_abstract_cmd_rom
      // this abstract command is currently unsupported
      unsupported_command = 1'b0;
-@@ -527,10 +583,6 @@ module dm_mem #(
+@@ -523,10 +583,6 @@ module dm_mem #(
      );
    end
  

--- a/hw/vendor/patches/pulp_riscv_dbg/0003-Use-lowrisc-instead-of-PULP-primitives.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0003-Use-lowrisc-instead-of-PULP-primitives.patch
@@ -1,7 +1,7 @@
 From 9323ea206e15381283e67a780aac8ffbb5a5d19b Mon Sep 17 00:00:00 2001
 From: Michael Schaffner <msf@google.com>
 Date: Tue, 25 Oct 2022 18:27:27 -0700
-Subject: [PATCH 3/7] Use lowrisc instead of PULP primitives
+Subject: Use lowrisc instead of PULP primitives
 
 Signed-off-by: Michael Schaffner <msf@google.com>
 

--- a/hw/vendor/patches/pulp_riscv_dbg/0004-Extend-DMI-address-width.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0004-Extend-DMI-address-width.patch
@@ -1,7 +1,7 @@
 From c1d7ebe40689eced35ae6b8cc2f1431f6ce42e51 Mon Sep 17 00:00:00 2001
 From: Michael Schaffner <msf@opentitan.org>
 Date: Thu, 17 Aug 2023 10:30:17 -0700
-Subject: [PATCH 4/7] Extend DMI address width
+Subject: Extend DMI address width
 
 Make the DMI interface address 32bits so that larger
 address ranges can be supported (e.g. to take advantage

--- a/hw/vendor/patches/pulp_riscv_dbg/0005-dm_csrs-Implement-nextdm-register.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0005-dm_csrs-Implement-nextdm-register.patch
@@ -1,7 +1,7 @@
 From 149fb72ccfe2af0a18e37884146c73e214817050 Mon Sep 17 00:00:00 2001
 From: Michael Schaffner <msf@opentitan.org>
 Date: Tue, 21 Nov 2023 19:40:16 -0800
-Subject: [PATCH 5/7] [dm_csrs] Implement nextdm register
+Subject: [dm_csrs] Implement nextdm register
 
 Signed-off-by: Michael Schaffner <msf@opentitan.org>
 

--- a/hw/vendor/patches/pulp_riscv_dbg/0006-dm_csrs-Correct-behavior-of-hartsel.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0006-dm_csrs-Correct-behavior-of-hartsel.patch
@@ -1,7 +1,7 @@
 From d7544597def65a4fcd7a853ed64604bdc24ae9df Mon Sep 17 00:00:00 2001
 From: Michael Schaffner <msf@opentitan.org>
 Date: Wed, 13 Mar 2024 12:15:24 -0700
-Subject: [PATCH 6/7] [dm_csrs] Correct behavior of hartsel
+Subject: [dm_csrs] Correct behavior of hartsel
 
 The hartsel register is supposed to have WARL behavior depending on how
 many harts are supported.

--- a/hw/vendor/patches/pulp_riscv_dbg/0007-dm_csrs-Pull-out-acknowledgement-signal-for-ndmreset.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0007-dm_csrs-Pull-out-acknowledgement-signal-for-ndmreset.patch
@@ -1,7 +1,7 @@
 From 91dd09788d0151fb48b85fa32eb07e9e1b0b0dd3 Mon Sep 17 00:00:00 2001
 From: Michael Schaffner <msf@opentitan.org>
 Date: Thu, 14 Mar 2024 09:36:40 -0700
-Subject: [PATCH 7/7] [dm_csrs] Pull out acknowledgement signal for ndmreset
+Subject: [dm_csrs] Pull out acknowledgement signal for ndmreset
 
 This signal can be used to implement more accurate ndmreset completion
 tracking outside of RV_DM.


### PR DESCRIPTION
Move RomBaseAddr and RomEndAddr definitions to the patch that actually uses them. This commit also removes the patch numbers inside the subject because this will get out-dated when new patches are added (as has happened with the addition of the eighth patch.