### PR TITLE
Manual cherry-pick: [crypto/cleanup] Barrier the cleanup functions

### DIFF
--- a/sw/device/lib/crypto/drivers/hmac.c
+++ b/sw/device/lib/crypto/drivers/hmac.c
@@ -410,7 +410,7 @@ static status_t oneshot(const uint32_t cfg, const hmac_key_t *key,
                         const otcrypto_const_byte_buf_t *msg,
                         size_t digest_wordlen, uint32_t *digest) {
   uint32_t hw_cleanup_guard __attribute__((cleanup(hmac_wipe_guard))) = 1;
-  (void)hw_cleanup_guard;
+  barrier32(hw_cleanup_guard);
 
   // Check that the block is idle.
   HARDENED_TRY(ensure_idle());
@@ -796,7 +796,7 @@ hardened_bool_t hmac_key_integrity_checksum_check(const hmac_key_t *key) {
 
 status_t hmac_update(hmac_ctx_t *ctx, const otcrypto_const_byte_buf_t *data) {
   uint32_t hw_cleanup_guard __attribute__((cleanup(hmac_wipe_guard))) = 1;
-  (void)hw_cleanup_guard;
+  barrier32(hw_cleanup_guard);
 
   // If we don't have enough new bytes to fill a block, just update the partial
   // block and return.
@@ -845,7 +845,7 @@ status_t hmac_update(hmac_ctx_t *ctx, const otcrypto_const_byte_buf_t *data) {
 
 status_t hmac_final(hmac_ctx_t *ctx, otcrypto_word32_buf_t *digest) {
   uint32_t hw_cleanup_guard __attribute__((cleanup(hmac_wipe_guard))) = 1;
-  (void)hw_cleanup_guard;
+  barrier32(hw_cleanup_guard);
 
   // Restore context will restore the context and also hit start or continue
   // button as necessary.

--- a/sw/device/lib/crypto/drivers/kmac.c
+++ b/sw/device/lib/crypto/drivers/kmac.c
@@ -8,6 +8,7 @@
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/crc32.h"
+#include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/drivers/rv_core_ibex.h"
@@ -619,7 +620,7 @@ static status_t kmac_process_msg_blocks(
     uint32_t *digest, size_t digest_len_bytes, hardened_bool_t masked_digest) {
   // This variable guarantees kmac_wipe_guard() is called on exit.
   uint32_t hw_cleanup_guard __attribute__((cleanup(kmac_wipe_guard))) = 1;
-  (void)hw_cleanup_guard;
+  barrier32(hw_cleanup_guard);
 
   // Block until KMAC is idle.
   HARDENED_TRY(wait_status_bit(KMAC_STATUS_SHA3_IDLE_BIT, 1));

--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -307,7 +307,7 @@ static otcrypto_status_t otcrypto_aes_impl(
     otcrypto_aes_padding_t aes_padding, otcrypto_byte_buf_t *cipher_output) {
   // Guarantees hw_wipe_guard() is called on exit.
   uint32_t hw_cleanup_guard __attribute__((cleanup(hw_wipe_guard))) = 1;
-  (void)hw_cleanup_guard;
+  barrier32(hw_cleanup_guard);
 
   // Calculate the number of blocks for the input, including the padding for
   // encryption.

--- a/sw/device/lib/crypto/impl/aes_gcm.c
+++ b/sw/device/lib/crypto/impl/aes_gcm.c
@@ -290,7 +290,7 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt(
   hardened_bool_t is_sideloaded __attribute__((cleanup(sideload_wipe_guard))) =
       kHardenedBoolFalse;
   uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
-  (void)hw_cleanup_guard;
+  barrier32(hw_cleanup_guard);
 
   // Ensure the plaintext and ciphertext lengths match.
   if (launder32(ciphertext->len) != plaintext->len) {
@@ -346,7 +346,7 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt(
   hardened_bool_t is_sideloaded __attribute__((cleanup(sideload_wipe_guard))) =
       kHardenedBoolFalse;
   uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
-  (void)hw_cleanup_guard;
+  barrier32(hw_cleanup_guard);
 
   // Construct the AES key.
   aes_key_t aes_key;
@@ -385,7 +385,7 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_init(
   hardened_bool_t is_sideloaded __attribute__((cleanup(sideload_wipe_guard))) =
       kHardenedBoolFalse;
   uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
-  (void)hw_cleanup_guard;
+  barrier32(hw_cleanup_guard);
 
   // Construct the AES key.
   aes_key_t aes_key;
@@ -419,7 +419,7 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt_init(
   hardened_bool_t is_sideloaded __attribute__((cleanup(sideload_wipe_guard))) =
       kHardenedBoolFalse;
   uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
-  (void)hw_cleanup_guard;
+  barrier32(hw_cleanup_guard);
 
   // Construct the AES key.
   aes_key_t aes_key;
@@ -456,7 +456,7 @@ otcrypto_status_t otcrypto_aes_gcm_update_aad(
   hardened_bool_t is_sideloaded __attribute__((cleanup(sideload_wipe_guard))) =
       kHardenedBoolFalse;
   uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
-  (void)hw_cleanup_guard;
+  barrier32(hw_cleanup_guard);
 
   // Restore the AES-GCM context object and load the key if needed.
   aes_gcm_context_t internal_ctx;
@@ -494,7 +494,7 @@ otcrypto_status_t otcrypto_aes_gcm_update_encrypted_data(
   hardened_bool_t is_sideloaded __attribute__((cleanup(sideload_wipe_guard))) =
       kHardenedBoolFalse;
   uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
-  (void)hw_cleanup_guard;
+  barrier32(hw_cleanup_guard);
 
   // Restore the AES-GCM context object and load the key if needed.
   aes_gcm_context_t internal_ctx;
@@ -554,7 +554,7 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_final(
   hardened_bool_t is_sideloaded __attribute__((cleanup(sideload_wipe_guard))) =
       kHardenedBoolFalse;
   uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
-  (void)hw_cleanup_guard;
+  barrier32(hw_cleanup_guard);
 
   // Restore the AES-GCM context object and load the key if needed.
   aes_gcm_context_t internal_ctx;
@@ -606,7 +606,7 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt_final(
   hardened_bool_t is_sideloaded __attribute__((cleanup(sideload_wipe_guard))) =
       kHardenedBoolFalse;
   uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
-  (void)hw_cleanup_guard;
+  barrier32(hw_cleanup_guard);
 
   // Restore the AES-GCM context object and load the key if needed.
   aes_gcm_context_t internal_ctx;

--- a/sw/device/lib/crypto/impl/cmac.c
+++ b/sw/device/lib/crypto/impl/cmac.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/crypto/include/cmac.h"
 
+#include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/crypto/drivers/aes.h"
 #include "sw/device/lib/crypto/drivers/keymgr.h"
@@ -346,7 +347,7 @@ otcrypto_status_t otcrypto_cmac(const otcrypto_blinded_key_t *key,
 
   // Clear AES unconditionally, and clear sideload if requested.
   uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
-  (void)hw_cleanup_guard;
+  barrier32(hw_cleanup_guard);
   hardened_bool_t is_sideloaded __attribute__((cleanup(sideload_wipe_guard))) =
       kHardenedBoolFalse;
 
@@ -434,7 +435,7 @@ otcrypto_status_t otcrypto_cmac_init(otcrypto_cmac_context_t *ctx,
 #endif
 
   uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
-  (void)hw_cleanup_guard;
+  barrier32(hw_cleanup_guard);
 
   HARDENED_TRY(check_key(key));
 
@@ -501,7 +502,7 @@ otcrypto_status_t otcrypto_cmac_update(
 #endif
 
   uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
-  (void)hw_cleanup_guard;
+  barrier32(hw_cleanup_guard);
 
   otcrypto_key_security_level_t security_level =
       (otcrypto_key_security_level_t)ctx->data[kCtxSecurityLevelOffset];
@@ -551,7 +552,7 @@ otcrypto_status_t otcrypto_cmac_final(otcrypto_cmac_context_t *const ctx,
 #endif
 
   uint32_t hw_cleanup_guard __attribute__((cleanup(aes_wipe_guard))) = 1;
-  (void)hw_cleanup_guard;
+  barrier32(hw_cleanup_guard);
   hardened_bool_t is_sideloaded __attribute__((cleanup(sideload_wipe_guard))) =
       kHardenedBoolFalse;
 

--- a/sw/device/lib/crypto/impl/key_transport.c
+++ b/sw/device/lib/crypto/impl/key_transport.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/crypto/include/key_transport.h"
 
+#include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/drivers/aes.h"
@@ -265,7 +266,7 @@ otcrypto_status_t otcrypto_key_wrap(const otcrypto_blinded_key_t *key_to_wrap,
 
   // Guarantees hw_wipe_guard() is called on exit.
   uint32_t hw_cleanup_guard __attribute__((cleanup(hw_wipe_guard))) = 1;
-  (void)hw_cleanup_guard;
+  barrier32(hw_cleanup_guard);
 
   // Check the integrity of the key material we are wrapping.
   if (launder32(otcrypto_integrity_blinded_key_check(key_to_wrap)) !=
@@ -328,7 +329,7 @@ otcrypto_status_t otcrypto_key_unwrap(
 
   // Guarantees hw_wipe_guard() is called on exit.
   uint32_t hw_cleanup_guard __attribute__((cleanup(hw_wipe_guard))) = 1;
-  (void)hw_cleanup_guard;
+  barrier32(hw_cleanup_guard);
 
   *success = kHardenedBoolFalse;
 


### PR DESCRIPTION
Add a barrier for the cleanup functions to stop optimizations by the compiler.


(cherry picked from commit 4cd5e2aa95bea94a6176febaa44b104958106daa)