### PR TITLE
[rtl, prim] Explicitly define length of PossibleActions

### DIFF
--- a/hw/ip/prim/rtl/prim_fifo_sync_cnt.sv
+++ b/hw/ip/prim/rtl/prim_fifo_sync_cnt.sv
@@ -75,7 +75,7 @@ module prim_fifo_sync_cnt #(
     logic wptr_err;
     prim_count #(
       .Width(WrapPtrW),
-      .PossibleActions((NeverClears ? 0 : prim_count_pkg::Clr) |
+      .PossibleActions((NeverClears ? prim_count_pkg::action_mask_t'(0) : prim_count_pkg::Clr) |
                        prim_count_pkg::Set | prim_count_pkg::Incr)
     ) u_wptr (
       .clk_i,
@@ -95,7 +95,7 @@ module prim_fifo_sync_cnt #(
     logic rptr_err;
     prim_count #(
       .Width(WrapPtrW),
-      .PossibleActions((NeverClears ? 0 : prim_count_pkg::Clr) |
+      .PossibleActions((NeverClears ? prim_count_pkg::action_mask_t'(0) : prim_count_pkg::Clr) |
                        prim_count_pkg::Set | prim_count_pkg::Incr)
     ) u_rptr (
       .clk_i,


### PR DESCRIPTION
In case prim_fifo_sync_cnt is configured in Secure mode and NeverClears, The PossibleActions parameter is set to 0 without an explicit size. This leads to build errors for a one of my OTBN smoke tests.

This PR should fix that issue.