### PR TITLE
[ci] update qemu version pulled in override test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -693,7 +693,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: lowRISC/qemu
-          ref: v9.2.0-2025-02-11
+          ref: v10.2.0-2026-01-15
           path: qemu
       - name: Check that overrides works
         run: |


### PR DESCRIPTION
This version is very old and does not match the one downloaded by bazel. This old version also does not compile anymore due to a mirror being discontinued.

A different fix was done on master branch, see explanation there https://github.com/lowRISC/opentitan/pull/30445