### PR TITLE
[cw310] Stub out ENTROPY_SRC, OTBN, USBDEV, disable Ibex features

### DIFF
--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -1121,9 +1121,17 @@ module chip_earlgrey_cw310 #(
   // Top-level design //
   //////////////////////
   top_earlgrey #(
+    .EntropySrcStub(1'b1), // Stub ENTROPY_SRC to reduce resource usage on CW310. See #30062.
+    .OtbnStub(1'b1), // Stub OTBN to reduce resource usage on CW310. See #30062.
+    .UsbdevStub(1'b1), // Stub USBDEV to reduce resource usage on CW310. See #30062.
     .SecAesMasking(1'b0), // Disable AES masking on the CW310, where we are constrained by area.
-    .OtbnFeatStubMai(1'b1), // Stub MAI to reduce resource usage on CW310. See #30062.
     .SecAesSBoxImpl(aes_pkg::SBoxImplLut),
+    .RvCoreIbexPMPEnable(1'b0),
+    .RvCoreIbexRV32B(ibex_pkg::RV32BNone),
+    .RvCoreIbexRV32ZC(ibex_pkg::RV32Zca),
+    .RvCoreIbexBranchTargetALU(1'b0),
+    .RvCoreIbexWritebackStage(1'b0),
+    .RvCoreIbexICache(1'b0),
     .SecAesStartTriggerDelay(0),
     .SecAesAllowForcingMasks(1'b1),
     .CsrngSBoxImpl(aes_pkg::SBoxImplLut),

--- a/hw/top_earlgrey/templates/chiplevel.sv.tpl
+++ b/hw/top_earlgrey/templates/chiplevel.sv.tpl
@@ -1148,9 +1148,17 @@ module chip_${top["name"]}_${target["name"]} #(
   //////////////////////
   top_${top["name"]} #(
 % if target["name"] == "cw310":
+    .EntropySrcStub(1'b1), // Stub ENTROPY_SRC to reduce resource usage on CW310. See #30062.
+    .OtbnStub(1'b1), // Stub OTBN to reduce resource usage on CW310. See #30062.
+    .UsbdevStub(1'b1), // Stub USBDEV to reduce resource usage on CW310. See #30062.
     .SecAesMasking(1'b0), // Disable AES masking on the CW310, where we are constrained by area.
-    .OtbnFeatStubMai(1'b1), // Stub MAI to reduce resource usage on CW310. See #30062.
     .SecAesSBoxImpl(aes_pkg::SBoxImplLut),
+    .RvCoreIbexPMPEnable(1'b0),
+    .RvCoreIbexRV32B(ibex_pkg::RV32BNone),
+    .RvCoreIbexRV32ZC(ibex_pkg::RV32Zca),
+    .RvCoreIbexBranchTargetALU(1'b0),
+    .RvCoreIbexWritebackStage(1'b0),
+    .RvCoreIbexICache(1'b0),
 % elif target["name"]  == "cw340":
     .SecAesMasking(1'b1),
     .SecAesSBoxImpl(aes_pkg::SBoxImplDom),


### PR DESCRIPTION
It has recently become almost impossible to merge any RTL changes due to the CW310 CI issues. This PR stubs out various IP blocks from CW310 builds. This should substantially reduce the area but the resulting bitstream won't be able to run much software. But as we don't run any tests on the CW310 currently, this should be okay.
