### PR TITLE
[sw] Fix CW310 -> CW340 target

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/boot_policy_valid/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_valid/BUILD
@@ -40,7 +40,7 @@ BOOT_POLICY_VALID_CASES = [
     },
     {
         "desc": "bad",
-        "suffix": "_corrupted_fpga_cw310_rom_with_fake_keys_signed_bin",
+        "suffix": "_corrupted_fpga_cw340_rom_with_fake_keys_signed_bin",
     },
 ]
 

--- a/sw/device/silicon_creator/rom/e2e/sigverify_always/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_always/BUILD
@@ -83,7 +83,7 @@ SIGVERIFY_BAD_CASES = [
                 if case[slot] == "bad"
             ]),
             binaries = {
-                "//sw/device/silicon_creator/rom/e2e:empty_test_slot_{}_{}_corrupted_fpga_cw310_rom_with_fake_keys_signed_bin"
+                "//sw/device/silicon_creator/rom/e2e:empty_test_slot_{}_{}_corrupted_fpga_cw340_rom_with_fake_keys_signed_bin"
                     .format(
                     slot,
                     filter_key_structs_for_lc_state(ECDSA_ONLY_KEY_STRUCTS, lc_state_val)[0].ecdsa.name,


### PR DESCRIPTION
We need to point the two different test to CW340 instead to CW310 as they are supposed to run on this FPGA board.

Closes lowRISC/opentitan#30498