### PR TITLE
[otp_ctrl,dv] Fix lc_state/lc_cnt order in lc_otp_program h_data + DV_CHECK_EQ arg order

### DIFF
--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv.tpl
@@ -1108,7 +1108,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
     // On reads, if do_read_check, is set, then check mirrored_value against item.d_data
     if (data_phase_read) begin
       if (do_read_check) begin
-        `DV_CHECK_EQ(csr.get_mirrored_value(), item.d_data,
+        // DV_CHECK_EQ takes (ACT_, EXP_); item.d_data is the value observed
+        // on the bus and csr.get_mirrored_value() is the predicted value.
+        `DV_CHECK_EQ(item.d_data, csr.get_mirrored_value(),
                      $sformatf("reg name: %0s", csr.get_full_name()))
         if (cfg.en_cov && cfg.otp_ctrl_vif.alert_reqs) begin
           cov.csr_rd_after_alert_cg_wrap.sample(csr.get_offset());

--- a/hw/ip_templates/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv.tpl
@@ -604,7 +604,12 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
         lc_state = lc_ctrl_dv_utils_pkg::encode_lc_state(next_lc_state);
         lc_cnt   = next_lc_cnt;
       end
-      cfg.m_lc_prog_pull_agent_cfg.add_h_user_data({lc_cnt, lc_state});
+      // h_data ordering must mirror lc_otp_program_req_t in otp_ctrl_pkg.sv,
+      // which is packed as {req, state, count}. Without the req bit, the lower
+      // half of the user data is {lc_state, lc_cnt} — state is the MSB-side
+      // field, cnt the LSB-side field. Swapping the two corrupts the LC state
+      // delivered to the DUT (see #27451).
+      cfg.m_lc_prog_pull_agent_cfg.add_h_user_data({lc_state, lc_cnt});
     end
 
     `DV_CHECK_RANDOMIZE_FATAL(lc_prog_pull_seq)

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -1317,7 +1317,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
     // On reads, if do_read_check, is set, then check mirrored_value against item.d_data
     if (data_phase_read) begin
       if (do_read_check) begin
-        `DV_CHECK_EQ(csr.get_mirrored_value(), item.d_data,
+        // DV_CHECK_EQ takes (ACT_, EXP_); item.d_data is the value observed
+        // on the bus and csr.get_mirrored_value() is the predicted value.
+        `DV_CHECK_EQ(item.d_data, csr.get_mirrored_value(),
                      $sformatf("reg name: %0s", csr.get_full_name()))
         if (cfg.en_cov && cfg.otp_ctrl_vif.alert_reqs) begin
           cov.csr_rd_after_alert_cg_wrap.sample(csr.get_offset());

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -758,7 +758,12 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
         lc_state = lc_ctrl_dv_utils_pkg::encode_lc_state(next_lc_state);
         lc_cnt   = next_lc_cnt;
       end
-      cfg.m_lc_prog_pull_agent_cfg.add_h_user_data({lc_cnt, lc_state});
+      // h_data ordering must mirror lc_otp_program_req_t in otp_ctrl_pkg.sv,
+      // which is packed as {req, state, count}. Without the req bit, the lower
+      // half of the user data is {lc_state, lc_cnt} — state is the MSB-side
+      // field, cnt the LSB-side field. Swapping the two corrupts the LC state
+      // delivered to the DUT (see #27451).
+      cfg.m_lc_prog_pull_agent_cfg.add_h_user_data({lc_state, lc_cnt});
     end
 
     `DV_CHECK_RANDOMIZE_FATAL(lc_prog_pull_seq)

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -1199,7 +1199,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
     // On reads, if do_read_check, is set, then check mirrored_value against item.d_data
     if (data_phase_read) begin
       if (do_read_check) begin
-        `DV_CHECK_EQ(csr.get_mirrored_value(), item.d_data,
+        // DV_CHECK_EQ takes (ACT_, EXP_); item.d_data is the value observed
+        // on the bus and csr.get_mirrored_value() is the predicted value.
+        `DV_CHECK_EQ(item.d_data, csr.get_mirrored_value(),
                      $sformatf("reg name: %0s", csr.get_full_name()))
         if (cfg.en_cov && cfg.otp_ctrl_vif.alert_reqs) begin
           cov.csr_rd_after_alert_cg_wrap.sample(csr.get_offset());

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -666,7 +666,12 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
         lc_state = lc_ctrl_dv_utils_pkg::encode_lc_state(next_lc_state);
         lc_cnt   = next_lc_cnt;
       end
-      cfg.m_lc_prog_pull_agent_cfg.add_h_user_data({lc_cnt, lc_state});
+      // h_data ordering must mirror lc_otp_program_req_t in otp_ctrl_pkg.sv,
+      // which is packed as {req, state, count}. Without the req bit, the lower
+      // half of the user data is {lc_state, lc_cnt} — state is the MSB-side
+      // field, cnt the LSB-side field. Swapping the two corrupts the LC state
+      // delivered to the DUT (see #27451).
+      cfg.m_lc_prog_pull_agent_cfg.add_h_user_data({lc_state, lc_cnt});
     end
 
     `DV_CHECK_RANDOMIZE_FATAL(lc_prog_pull_seq)


### PR DESCRIPTION
Closes #27451.

## Summary

The OTP controller's request struct in `hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv` is packed as:

```systemverilog
typedef struct packed {
    logic                         req;
    lc_ctrl_state_pkg::lc_state_e state;
    lc_ctrl_state_pkg::lc_cnt_e   count;
} lc_otp_program_req_t;
```

so the lower half of the vector — the bit range the LC program pull
agent drives via `h_data` — is `{state, count}`. `state` is the
MSB-side field; `count` is the LSB-side field.

`otp_ctrl_base_vseq` was passing them in the opposite order:

```systemverilog
cfg.m_lc_prog_pull_agent_cfg.add_h_user_data({lc_cnt, lc_state});
```

This delivers `lc_cnt` into the `state` bits and `lc_state` into the
`count` bits, so both fields seen by the DUT are corrupted whenever
this vseq runs. The fix swaps the order to `{lc_state, lc_cnt}`.

## Secondary fix

`otp_ctrl_scoreboard.sv` (per-CSR read check) currently calls:

```systemverilog
`DV_CHECK_EQ(csr.get_mirrored_value(), item.d_data, ...)
```

The `DV_CHECK_EQ` macro is `DV_CHECK_EQ(ACT_, EXP_, ...)`. `item.d_data`
is the value observed on the bus (actual); `csr.get_mirrored_value()`
is the predicted value (expected). The previous order printed them
swapped in the failure message and is also inconsistent with the
other ~6 `DV_CHECK_EQ(item.d_data, exp, ...)` call sites in the same
file. Reorders to `(item.d_data, csr.get_mirrored_value())`.

## Scope

Both fixes are applied in three places so the template and the two
regenerated copies stay in sync:

- `hw/ip_templates/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv.tpl`
- `hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv`
- `hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv`
- `hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv.tpl`
- `hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv`
- `hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv`

A short inline comment is added next to each modified line so the
struct-layout dependency / macro-argument convention is visible at
the call site for future maintainers.

## Attribution

The root cause + the specific fix were analysed in #27451 by
@martin-velay, with confirming discussion from @matutem and @Razer6.
This PR just applies the agreed-upon change and keeps the template
and the auto-gen trees in sync.