### PR TITLE
[crypto] Fix implicit conversion warning

### DIFF
--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -837,7 +837,7 @@ static status_t entropy_src_configure(const entropy_src_config_t *config) {
       config->alert_threshold);
   alert_threshold = bitfield_field32_write(
       alert_threshold, ENTROPY_SRC_ALERT_THRESHOLD_ALERT_THRESHOLD_INV_FIELD,
-      ~config->alert_threshold);
+      (uint32_t)~config->alert_threshold);
   abs_mmio_write32(entropy_src_base() + ENTROPY_SRC_ALERT_THRESHOLD_REG_OFFSET,
                    alert_threshold);
 


### PR DESCRIPTION
A trivial commit. Good to test CI after https://github.com/lowRISC/opentitan/pull/30494.