### PR TITLE
Explicitly set the rust edition on all crates.

### DIFF
--- a/hw/top_earlgrey/sw/autogen/chip/BUILD
+++ b/hw/top_earlgrey/sw/autogen/chip/BUILD
@@ -15,4 +15,5 @@ rust_library(
     name = "top_earlgrey",
     srcs = [":all_files"],
     crate_root = "mod.rs",
+    edition = "2024",
 )

--- a/sw/device/lib/ujson/rust/BUILD
+++ b/sw/device/lib/ujson/rust/BUILD
@@ -24,6 +24,7 @@ rust_test(
         ":example",
         "//sw/device/lib/ujson:example_roundtrip",
     ],
+    edition = "2024",
     env = {
         "ROUNDTRIP_CLIENT": "$(rootpath //sw/device/lib/ujson:example_roundtrip)",
         "RUST_BACKTRACE": "1",

--- a/sw/device/silicon_creator/manuf/extensions/repo/BUILD.bazel
+++ b/sw/device/silicon_creator/manuf/extensions/repo/BUILD.bazel
@@ -24,6 +24,7 @@ rust_library(
     name = "default_ft_ext_lib",
     srcs = ["default_ft_ext_lib.rs"],
     crate_name = "ft_ext_lib",
+    edition = "2024",
     deps = [
         "@crate_index//:anyhow",
         "@crate_index//:arrayvec",

--- a/sw/device/silicon_owner/tock/apps/hello/BUILD
+++ b/sw/device/silicon_owner/tock/apps/hello/BUILD
@@ -13,6 +13,7 @@ rust_binary(
     srcs = [
         "src/hello.rs",
     ],
+    edition = "2021",
     # We specifically restrict our build target to the OpenTitan
     # CPU because libtock does not support an x86_64 target.
     target_compatible_with = [OPENTITAN_CPU],

--- a/sw/device/silicon_owner/tock/kernel/BUILD
+++ b/sw/device/silicon_owner/tock/kernel/BUILD
@@ -29,6 +29,7 @@ rust_binary(
         "src/main.rs",
         "src/otbn.rs",
     ],
+    edition = "2021",
     rustc_flags = [
         "-g",
         # TODO(opentitan#19491): determine the appropriate set of linker flags.

--- a/sw/device/silicon_owner/tock/tests/basic/BUILD
+++ b/sw/device/silicon_owner/tock/tests/basic/BUILD
@@ -13,6 +13,7 @@ rust_binary(
     srcs = [
         "src/basic.rs",
     ],
+    edition = "2021",
     # We specifically restrict our build target to the OpenTitan
     # CPU because libtock does not support an x86_64 target.
     target_compatible_with = [OPENTITAN_CPU],

--- a/sw/device/silicon_owner/tock/upstream_kernel/BUILD
+++ b/sw/device/silicon_owner/tock/upstream_kernel/BUILD
@@ -28,6 +28,7 @@ rust_binary(
         "@tock//boards/opentitan/earlgrey-cw310:kernel_srcs",
     ],
     crate_features = ["fpga_cw310"],
+    edition = "2021",
     rustc_flags = [
         "-g",
         # TODO(opentitan#19491): determine the appropriate set of linker flags.

--- a/sw/host/cryptotest/BUILD
+++ b/sw/host/cryptotest/BUILD
@@ -9,6 +9,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "cryptotest_parser",
     srcs = ["cryptotest_parser.rs"],
+    edition = "2024",
     deps = [
         "@crate_index//:once_cell",
         "@crate_index//:regex",
@@ -19,4 +20,5 @@ rust_library(
 rust_test(
     name = "cryptotest_parser_test",
     crate = ":cryptotest_parser",
+    edition = "2024",
 )

--- a/sw/host/cryptotest/ujson_lib/BUILD
+++ b/sw/host/cryptotest/ujson_lib/BUILD
@@ -112,6 +112,7 @@ rust_library(
         ":sphincsplus_commands_rust",
         ":x25519_commands_rust",
     ],
+    edition = "2024",
     rustc_env = {
         "commands_loc": "$(execpath :commands_rust)",
         "aes_commands_loc": "$(execpath :aes_commands_rust)",

--- a/sw/host/hsmtool/BUILD
+++ b/sw/host/hsmtool/BUILD
@@ -78,6 +78,7 @@ rust_library(
         "src/util/wrap.rs",
     ],
     crate_name = "hsmtool",
+    edition = "2024",
     deps = [
         "//sw/host/hsmtool/acorn",
         "//sw/host/sphincsplus",
@@ -117,6 +118,7 @@ rust_library(
 rust_binary(
     name = "hsmtool",
     srcs = ["src/hsmtool.rs"],
+    edition = "2024",
     rustc_flags = select({
         "//rules:static_link_host_tools_enabled": ["--codegen=target-feature=+crt-static"],
         "//conditions:default": [],
@@ -138,6 +140,7 @@ rust_test(
     data = glob([
         "testdata/**",
     ]),
+    edition = "2024",
     env = {
         "TESTDATA": "$(rootpath testdata/key/test1_pkcs1.der)",
     },

--- a/sw/host/hsmtool/acorn/BUILD
+++ b/sw/host/hsmtool/acorn/BUILD
@@ -15,6 +15,7 @@ rust_library(
         "spx.rs",
     ],
     crate_root = "lib.rs",
+    edition = "2024",
     deps = [
         "//sw/host/hsmtool/acorn/vendor:acorn_bindgen",
         "//sw/host/sphincsplus",

--- a/sw/host/hsmtool/acorn/vendor/BUILD
+++ b/sw/host/hsmtool/acorn/vendor/BUILD
@@ -13,6 +13,7 @@ cc_library(
 
 rust_bindgen_library(
     name = "acorn_bindgen",
+    edition = "2024",
     bindgen_flags = [
         "--with-derive-default",
         "--impl-debug",

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -297,6 +297,7 @@ rust_library(
         "//sw/device:is_english_breakfast": ["english_breakfast"],
         "//conditions:default": [],
     }),
+    edition = "2024",
     proc_macro_deps = [
         "//sw/host/opentitanlib/opentitantool_derive",
     ],
@@ -386,6 +387,7 @@ rust_test(
         ":gpio",
         ":pinmux_config",
     ],
+    edition = "2024",
     env = {
         "RUST_MIN_STACK": "4194304",
         "TESTDATA": "$(rootpath testdata/otp/lc_ctrl_state.hjson)",

--- a/sw/host/opentitanlib/bindgen/BUILD
+++ b/sw/host/opentitanlib/bindgen/BUILD
@@ -69,6 +69,7 @@ rust_bindgen_library(
         "--allowlist-type=AlertEscalate",
     ],
     cc_lib = "//sw/device/silicon_creator/lib/drivers:alert",
+    edition = "2024",
     header = "//sw/device/silicon_creator/lib/drivers:alert.h",
     rustc_flags = [
         "--allow=non_snake_case",
@@ -126,6 +127,7 @@ rust_bindgen_library(
         "-DOT_IS_ENGLISH_BREAKFAST_REDUCED_SUPPORT_FOR_INTERNAL_USE_ONLY_",
     ] if _TOPLEVEL == "englishbreakfast" else [
     ],
+    edition = "2024",
     header = "difs.h",
     rustc_flags = [
         "--allow=non_snake_case",
@@ -152,6 +154,7 @@ rust_bindgen_library(
         "--allowlist-type=top_earlgrey_hintable_clocks",
     ],
     cc_lib = "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+    edition = "2024",
     header = "//hw/top_earlgrey/sw/autogen:top_earlgrey.h",
     rustc_flags = [
         "--allow=non_snake_case",
@@ -167,6 +170,7 @@ rust_bindgen_library(
         "--allowlist-type=hardened_byte_bool",
     ],
     cc_lib = "//sw/device/lib/base:hardened",
+    edition = "2024",
     header = "//sw/device/lib/base:hardened.h",
     rustc_flags = [
         "--allow=non_snake_case",
@@ -181,6 +185,7 @@ rust_bindgen_library(
         "--allowlist-type=multi_bit_bool",
     ],
     cc_lib = "//sw/device/lib/base:multibits",
+    edition = "2024",
     header = "//sw/device/lib/base:multibits.h",
     rustc_flags = [
         "--allow=non_snake_case",
@@ -232,6 +237,7 @@ rust_bindgen_library(
         "--allowlist-var=SRAM_MAGIC_SP_.*",
     ],
     cc_lib = "//sw/device/silicon_creator/manuf/lib:sram_start_headers",
+    edition = "2024",
     header = "//sw/device/silicon_creator/manuf/lib:sram_start.h",
     rustc_flags = [
         "--allow=non_snake_case",
@@ -259,6 +265,7 @@ rust_bindgen_library(
         "--with-derive-custom=ot_status_create_record=zerocopy::FromBytes",
     ],
     cc_lib = "//sw/device/lib/base:status",
+    edition = "2024",
     header = "//sw/device/lib/base:status.h",
     rustc_flags = [
         "--allow=non_snake_case",
@@ -276,6 +283,7 @@ rust_bindgen_library(
         "--allowlist-type=test_status_t",
     ],
     cc_lib = "//sw/device/lib/testing/test_framework:status_headers",
+    edition = "2024",
     header = "//sw/device/lib/testing/test_framework:status.h",
     rustc_flags = [
         "--allow=non_snake_case",
@@ -290,6 +298,7 @@ rust_library(
         "lib.rs",
         ":rom_error",
     ],
+    edition = "2024",
     deps = [
         ":alert",
         ":dif",

--- a/sw/host/opentitanlib/opentitantool_derive/BUILD
+++ b/sw/host/opentitanlib/opentitantool_derive/BUILD
@@ -9,6 +9,7 @@ package(default_visibility = ["//visibility:public"])
 rust_proc_macro(
     name = "opentitantool_derive",
     srcs = ["src/lib.rs"],
+    edition = "2024",
     deps = [
         "@crate_index//:proc-macro2",
         "@crate_index//:quote",

--- a/sw/host/opentitanlib/util/BUILD
+++ b/sw/host/opentitanlib/util/BUILD
@@ -9,6 +9,7 @@ package(default_visibility = ["//visibility:public"])
 rust_library(
     name = "util",
     srcs = ["src/lib.rs"],
+    edition = "2024",
     deps = [
         "@crate_index//:anyhow",
         "@crate_index//:pem-rfc7468",

--- a/sw/host/opentitansession/BUILD
+++ b/sw/host/opentitansession/BUILD
@@ -9,6 +9,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "opentitansession",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -42,6 +42,7 @@ rust_binary(
         "src/command/xmodem.rs",
         "src/main.rs",
     ],
+    edition = "2024",
     proc_macro_deps = [
         "//sw/host/opentitanlib/opentitantool_derive",
     ],
@@ -99,6 +100,7 @@ pkg_filegroup(
 rust_test(
     name = "opentitantool_test",
     crate = ":opentitantool",
+    edition = "2024",
     # stamping is necessary because opentitantool builds version.rs that needs it
     stamp = 1,
 )

--- a/sw/host/ot_certs/BUILD
+++ b/sw/host/ot_certs/BUILD
@@ -40,6 +40,7 @@ rust_library(
         "src/x509.rs",
         "src/x509/extension.rs",
     ],
+    edition = "2024",
     proc_macro_deps = [
         "@crate_index//:indoc",
     ],
@@ -72,6 +73,7 @@ rust_library(
 rust_test(
     name = "ot_certs_test",
     crate = ":ot_certs",
+    edition = "2024",
     proc_macro_deps = [
         "@crate_index//:indoc",
     ],
@@ -88,6 +90,7 @@ rust_test_suite(
         ":example_cert",
         ":example_data",
     ],
+    edition = "2024",
     deps = [
         ":ot_certs",
         "@crate_index//:anyhow",

--- a/sw/host/penetrationtests/ujson_lib/BUILD
+++ b/sw/host/penetrationtests/ujson_lib/BUILD
@@ -154,6 +154,7 @@ rust_library(
         ":sca_otbn_commands_rust",
         ":sca_sha3_commands_rust",
     ],
+    edition = "2024",
     rustc_env = {
         "commands_loc": "$(execpath :commands_rust)",
         "fi_crypto_commands_loc": "$(execpath :fi_crypto_commands_rust)",

--- a/sw/host/provisioning/cert_lib/BUILD
+++ b/sw/host/provisioning/cert_lib/BUILD
@@ -10,6 +10,7 @@ rust_library(
     name = "cert_lib",
     srcs = ["src/lib.rs"],
     data = ["//sw/device/silicon_creator/manuf/keys/fake:ext_ca.pem"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/ot_certs",
@@ -31,4 +32,5 @@ rust_test(
     name = "openssl_verify",
     timeout = "short",
     crate = ":cert_lib",
+    edition = "2024",
 )

--- a/sw/host/provisioning/cp/BUILD
+++ b/sw/host/provisioning/cp/BUILD
@@ -9,6 +9,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "cp",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/provisioning/cp_lib",

--- a/sw/host/provisioning/cp_lib/BUILD
+++ b/sw/host/provisioning/cp_lib/BUILD
@@ -17,6 +17,7 @@ rust_library(
         "src/lib.rs",
         ":lc_raw_unlock_token",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/provisioning/ujson_lib",

--- a/sw/host/provisioning/ft/BUILD
+++ b/sw/host/provisioning/ft/BUILD
@@ -14,6 +14,7 @@ package(default_visibility = ["//visibility:public"])
     rust_binary(
         name = "ft_{}".format(sku),
         srcs = ["src/main.rs"],
+        edition = "2024",
         deps = [
             "//sw/host/opentitanlib",
             "//sw/host/provisioning/ft_lib:ft_lib_{}".format(sku),

--- a/sw/host/provisioning/ft_lib/BUILD
+++ b/sw/host/provisioning/ft_lib/BUILD
@@ -14,6 +14,7 @@ package(default_visibility = ["//visibility:public"])
             "src/lib.rs",
         ],
         crate_name = "ft_lib",
+        edition = "2024",
         deps = [
             "//sw/host/opentitanlib",
             "//sw/host/opentitanlib/bindgen",

--- a/sw/host/provisioning/perso_tlv_lib/BUILD
+++ b/sw/host/provisioning/perso_tlv_lib/BUILD
@@ -18,6 +18,7 @@ rust_bindgen_library(
         "--allowlist-type=perso_tlv_cert_header_fields_t",
     ],
     cc_lib = "//sw/device/silicon_creator/manuf/base:perso_tlv_headers",
+    edition = "2024",
     header = "//sw/device/silicon_creator/manuf/base:perso_tlv_data.h",
     rustc_flags = [
         "--allow=non_snake_case",
@@ -29,6 +30,7 @@ rust_bindgen_library(
 rust_library(
     name = "perso_tlv_lib",
     srcs = ["src/lib.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/provisioning/perso_tlv_lib:perso_tlv_objects",
         "@crate_index//:anyhow",

--- a/sw/host/provisioning/ujson_lib/BUILD
+++ b/sw/host/provisioning/ujson_lib/BUILD
@@ -19,6 +19,7 @@ rust_library(
         ":src/provisioning_data.rs",
     ],
     compile_data = [":provisioning_data"],
+    edition = "2024",
     rustc_env = {
         "provisioning_data": "$(location :provisioning_data)",
     },

--- a/sw/host/provisioning/util_lib/BUILD
+++ b/sw/host/provisioning/util_lib/BUILD
@@ -12,6 +12,7 @@ rust_library(
         "src/lib.rs",
         "src/response.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/provisioning/cert_lib",

--- a/sw/host/sphincsplus/BUILD
+++ b/sw/host/sphincsplus/BUILD
@@ -28,6 +28,7 @@ rust_bindgen_library(
         "-DPARAMS=sphincs-shake-128s",
         "-DNAMESPACE=SPX_shake_128s_simple_",
     ],
+    edition = "2024",
     header = "@sphincsplus_fips205_ipd//:api.h",
 )
 
@@ -43,6 +44,7 @@ rust_bindgen_library(
         "-DPARAMS=sphincs-sha2-128s",
         "-DNAMESPACE=SPX_sha2_128s_simple_",
     ],
+    edition = "2024",
     header = "@sphincsplus_fips205_ipd//:api.h",
 )
 
@@ -55,6 +57,7 @@ rust_library(
         "signature.rs",
         "variants.rs",
     ],
+    edition = "2024",
     proc_macro_deps = [
         "@crate_index//:paste",
     ],
@@ -74,4 +77,5 @@ rust_library(
 rust_test(
     name = "sphincsplus_test",
     crate = ":sphincsplus",
+    edition = "2024",
 )

--- a/sw/host/tests/attestation/BUILD
+++ b/sw/host/tests/attestation/BUILD
@@ -9,6 +9,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "attestation_test",
     srcs = ["attestation_test.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/ot_certs",

--- a/sw/host/tests/chip/example_sival/BUILD
+++ b/sw/host/tests/chip/example_sival/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/chip/flash_ctrl/BUILD
+++ b/sw/host/tests/chip/flash_ctrl/BUILD
@@ -9,6 +9,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "host_rma_test",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/chip/gpio/BUILD
+++ b/sw/host/tests/chip/gpio/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/gpio_pinmux.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -27,6 +28,7 @@ rust_binary(
     srcs = [
         "src/gpio_intr.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -43,6 +45,7 @@ rust_binary(
     srcs = [
         "src/sleep_pin_mio_dio_val.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -59,6 +62,7 @@ rust_binary(
     srcs = [
         "src/sleep_pin_retention.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -75,6 +79,7 @@ rust_binary(
     srcs = [
         "src/sleep_pin_wake.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/chip/i2c_host_override/BUILD
+++ b/sw/host/tests/chip/i2c_host_override/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/chip/i2c_target/BUILD
+++ b/sw/host/tests/chip/i2c_target/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -27,6 +28,7 @@ rust_binary(
     srcs = [
         "src/smbus_arp.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/chip/jtag/BUILD
+++ b/sw/host/tests/chip/jtag/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/openocd_test.rs",
     ],
+    edition = "2024",
     deps = [
         "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",
         "//sw/host/opentitanlib",
@@ -29,6 +30,7 @@ rust_binary(
     srcs = [
         "src/sram_load.rs",
     ],
+    edition = "2024",
     deps = [
         "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",
         "//sw/host/opentitanlib",

--- a/sw/host/tests/chip/mem/BUILD
+++ b/sw/host/tests/chip/mem/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/chip/ottf_console_with_gpio_tx_indicator/BUILD
+++ b/sw/host/tests/chip/ottf_console_with_gpio_tx_indicator/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/provisioning/ujson_lib",

--- a/sw/host/tests/chip/ottf_dual_console/BUILD
+++ b/sw/host/tests/chip/ottf_dual_console/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/chip/pattgen/BUILD
+++ b/sw/host/tests/chip/pattgen/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "pattgen_ios.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/chip/power_virus/BUILD
+++ b/sw/host/tests/chip/power_virus/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/chip/pwm_smoketest/BUILD
+++ b/sw/host/tests/chip/pwm_smoketest/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/chip/pwrmgr/BUILD
+++ b/sw/host/tests/chip/pwrmgr/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/sleep_all_resets.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -25,6 +26,7 @@ rust_binary(
     srcs = [
         "src/sleep_all_wakeups.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -39,6 +41,7 @@ rust_binary(
     srcs = [
         "src/sleep_por.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/chip/rv_core_ibex_epmp/BUILD
+++ b/sw/host/tests/chip/rv_core_ibex_epmp/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/chip/rv_core_ibex_isa/BUILD
+++ b/sw/host/tests/chip/rv_core_ibex_isa/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/chip/rv_dm/BUILD
+++ b/sw/host/tests/chip/rv_dm/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/csr_rw.rs",
     ],
+    edition = "2024",
     deps = [
         "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",
         "//sw/host/opentitanlib",
@@ -29,6 +30,7 @@ rust_binary(
     srcs = [
         "src/mem_access.rs",
     ],
+    edition = "2024",
     deps = [
         "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",
         "//sw/host/opentitanlib",
@@ -47,6 +49,7 @@ rust_binary(
     srcs = [
         "src/jtag.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -60,6 +63,7 @@ rust_binary(
     srcs = [
         "src/jtag_tap_sel.rs",
     ],
+    edition = "2024",
     deps = [
         "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",
         "//sw/host/opentitanlib",
@@ -76,6 +80,7 @@ rust_binary(
     srcs = [
         "src/lc_disabled.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -90,6 +95,7 @@ rust_binary(
     srcs = [
         "src/ndm_reset_req.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -104,6 +110,7 @@ rust_binary(
     srcs = [
         "src/ndm_reset_req_when_cpu_halted.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -118,6 +125,7 @@ rust_binary(
     srcs = [
         "src/dtm.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -133,6 +141,7 @@ rust_binary(
     srcs = [
         "src/control_status.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -147,6 +156,7 @@ rust_binary(
     srcs = [
         "src/access_after_wakeup.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -163,6 +173,7 @@ rust_binary(
     srcs = [
         "src/access_after_hw_reset.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/chip/spi_device/BUILD
+++ b/sw/host/tests/chip/spi_device/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/spi_device_flash_smoketest.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -27,6 +28,7 @@ rust_binary(
     srcs = [
         "src/spi_device_tpm_test.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -44,6 +46,7 @@ rust_binary(
     srcs = [
         "src/spi_passthru.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -60,6 +63,7 @@ rust_binary(
     srcs = [
         "src/spi_device_sleep_test.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -77,6 +81,7 @@ rust_binary(
     srcs = [
         "src/spi_host_config_test.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/chip/spi_device_ottf_console/BUILD
+++ b/sw/host/tests/chip/spi_device_ottf_console/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/chip/spi_device_ujson_console_test/BUILD
+++ b/sw/host/tests/chip/spi_device_ujson_console_test/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/provisioning/ujson_lib",

--- a/sw/host/tests/chip/sram_ctrl/BUILD
+++ b/sw/host/tests/chip/sram_ctrl/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/sram_ctrl_lc_escalation.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/chip/sysrst_ctrl/BUILD
+++ b/sw/host/tests/chip/sysrst_ctrl/BUILD
@@ -12,6 +12,7 @@ rust_library(
         "mod.rs",
         "sysrst_ctrl.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -24,6 +25,7 @@ rust_binary(
     srcs = [
         "sysrst_ctrl_inputs.rs",
     ],
+    edition = "2024",
     deps = [
         ":sysrst_ctrl",
         "//sw/host/opentitanlib",
@@ -42,6 +44,7 @@ rust_binary(
     srcs = [
         "sysrst_ctrl_outputs.rs",
     ],
+    edition = "2024",
     deps = [
         ":sysrst_ctrl",
         "//sw/host/opentitanlib",
@@ -60,6 +63,7 @@ rust_binary(
     srcs = [
         "sysrst_ctrl_in_irq.rs",
     ],
+    edition = "2024",
     deps = [
         ":sysrst_ctrl",
         "//sw/host/opentitanlib",
@@ -78,6 +82,7 @@ rust_binary(
     srcs = [
         "sysrst_ctrl_ulp_z3_wakeup.rs",
     ],
+    edition = "2024",
     deps = [
         ":sysrst_ctrl",
         "//sw/host/opentitanlib",
@@ -96,6 +101,7 @@ rust_binary(
     srcs = [
         "sysrst_ctrl_ec_rst_l.rs",
     ],
+    edition = "2024",
     deps = [
         ":sysrst_ctrl",
         "//sw/host/opentitanlib",
@@ -114,6 +120,7 @@ rust_binary(
     srcs = [
         "sysrst_ctrl_reset.rs",
     ],
+    edition = "2024",
     deps = [
         ":sysrst_ctrl",
         "//sw/host/opentitanlib",

--- a/sw/host/tests/chip/uart/BUILD
+++ b/sw/host/tests/chip/uart/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/uart_tx_rx.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -27,6 +28,7 @@ rust_binary(
     srcs = [
         "src/uart_baud_rate.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -42,6 +44,7 @@ rust_binary(
     srcs = [
         "src/uart_loopback.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -57,6 +60,7 @@ rust_binary(
     srcs = [
         "src/uart_parity_break.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/chip/usb/BUILD
+++ b/sw/host/tests/chip/usb/BUILD
@@ -12,6 +12,7 @@ rust_library(
         "mod.rs",
         "usb.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -27,6 +28,7 @@ rust_binary(
     srcs = [
         "usbdev_aon_wake.rs",
     ],
+    edition = "2024",
     deps = [
         ":usb",
         "//sw/host/opentitanlib",
@@ -43,6 +45,7 @@ rust_binary(
     srcs = [
         "usbdev_suspend.rs",
     ],
+    edition = "2024",
     deps = [
         ":usb",
         "//sw/host/opentitanlib",
@@ -60,6 +63,7 @@ rust_binary(
     srcs = [
         "usb_harness.rs",
     ],
+    edition = "2024",
     deps = [
         ":usb",
         "//sw/host/opentitanlib",
@@ -75,6 +79,7 @@ rust_binary(
     srcs = [
         "usbdev_smoketest.rs",
     ],
+    edition = "2024",
     deps = [
         ":usb",
         "//sw/host/opentitanlib",
@@ -92,6 +97,7 @@ rust_binary(
     srcs = [
         "silicon_creator_harness.rs",
     ],
+    edition = "2024",
     deps = [
         ":usb",
         "//sw/host/opentitanlib",

--- a/sw/host/tests/crypto/acvp/BUILD
+++ b/sw/host/tests/crypto/acvp/BUILD
@@ -21,6 +21,7 @@ rust_binary(
         "src/sha.rs",
         "src/x25519.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
         "//sw/host/opentitanlib",

--- a/sw/host/tests/crypto/aes_gcm_nist_kat/BUILD
+++ b/sw/host/tests/crypto/aes_gcm_nist_kat/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
         "//sw/host/opentitanlib",

--- a/sw/host/tests/crypto/aes_nist_kat/BUILD
+++ b/sw/host/tests/crypto/aes_nist_kat/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
         "//sw/host/opentitanlib",

--- a/sw/host/tests/crypto/drbg_kat/BUILD
+++ b/sw/host/tests/crypto/drbg_kat/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
         "//sw/host/opentitanlib",

--- a/sw/host/tests/crypto/ecdh_kat/BUILD
+++ b/sw/host/tests/crypto/ecdh_kat/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
         "//sw/host/opentitanlib",

--- a/sw/host/tests/crypto/ecdsa_kat/BUILD
+++ b/sw/host/tests/crypto/ecdsa_kat/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
         "//sw/host/opentitanlib",

--- a/sw/host/tests/crypto/ed25519_kat/BUILD
+++ b/sw/host/tests/crypto/ed25519_kat/BUILD
@@ -9,6 +9,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
         "//sw/host/opentitanlib",

--- a/sw/host/tests/crypto/hash_kat/BUILD
+++ b/sw/host/tests/crypto/hash_kat/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
         "//sw/host/opentitanlib",

--- a/sw/host/tests/crypto/hmac_kat/BUILD
+++ b/sw/host/tests/crypto/hmac_kat/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
         "//sw/host/opentitanlib",

--- a/sw/host/tests/crypto/kmac_kat/BUILD
+++ b/sw/host/tests/crypto/kmac_kat/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
         "//sw/host/opentitanlib",

--- a/sw/host/tests/crypto/rsa_kat/BUILD
+++ b/sw/host/tests/crypto/rsa_kat/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
         "//sw/host/opentitanlib",

--- a/sw/host/tests/crypto/sphincsplus_kat/BUILD
+++ b/sw/host/tests/crypto/sphincsplus_kat/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
         "//sw/host/opentitanlib",

--- a/sw/host/tests/crypto/x25519_kat/BUILD
+++ b/sw/host/tests/crypto/x25519_kat/BUILD
@@ -9,6 +9,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
         "//sw/host/opentitanlib",

--- a/sw/host/tests/manuf/cp_provision_functest/BUILD
+++ b/sw/host/tests/manuf/cp_provision_functest/BUILD
@@ -9,6 +9,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "cp_provision_functest",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/provisioning/cp_lib",

--- a/sw/host/tests/manuf/individualize_sw_cfg_functest/BUILD
+++ b/sw/host/tests/manuf/individualize_sw_cfg_functest/BUILD
@@ -9,6 +9,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "individualize_sw_cfg_functest",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/manuf/manuf_cp_ast_test_execution/BUILD
+++ b/sw/host/tests/manuf/manuf_cp_ast_test_execution/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/manuf/manuf_cp_device_info_flash_wr/BUILD
+++ b/sw/host/tests/manuf/manuf_cp_device_info_flash_wr/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/manuf/manuf_cp_test_lock/BUILD
+++ b/sw/host/tests/manuf/manuf_cp_test_lock/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/manuf/manuf_cp_unlock_raw/BUILD
+++ b/sw/host/tests/manuf/manuf_cp_unlock_raw/BUILD
@@ -17,6 +17,7 @@ rust_binary(
         "src/main.rs",
         ":lc_raw_unlock_token",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/manuf/manuf_cp_volatile_unlock_raw/BUILD
+++ b/sw/host/tests/manuf/manuf_cp_volatile_unlock_raw/BUILD
@@ -17,6 +17,7 @@ rust_binary(
         "src/main.rs",
         ":lc_raw_unlock_token",
     ],
+    edition = "2024",
     deps = [
         "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",
         "//sw/host/opentitanlib",

--- a/sw/host/tests/manuf/manuf_cp_yield_test/BUILD
+++ b/sw/host/tests/manuf/manuf_cp_yield_test/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",
         "//sw/host/opentitanlib",

--- a/sw/host/tests/manuf/manuf_scrap/BUILD
+++ b/sw/host/tests/manuf/manuf_scrap/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/manuf/manuf_sram_program_crc_check/BUILD
+++ b/sw/host/tests/manuf/manuf_sram_program_crc_check/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/opentitanlib/bindgen",

--- a/sw/host/tests/manuf/manuf_ujson_msg_padding/BUILD
+++ b/sw/host/tests/manuf/manuf_ujson_msg_padding/BUILD
@@ -9,6 +9,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "manuf_ujson_msg_padding",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/provisioning/ujson_lib",

--- a/sw/host/tests/manuf/manuf_ujson_msg_size/BUILD
+++ b/sw/host/tests/manuf/manuf_ujson_msg_size/BUILD
@@ -9,6 +9,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "manuf_ujson_msg_size",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/provisioning/ujson_lib",

--- a/sw/host/tests/manuf/otp_ctrl/BUILD
+++ b/sw/host/tests/manuf/otp_ctrl/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/manuf/personalize_functest/BUILD
+++ b/sw/host/tests/manuf/personalize_functest/BUILD
@@ -19,6 +19,7 @@ rust_binary(
         "src/provisioning_data.rs",
     ],
     compile_data = [":provisioning_data"],
+    edition = "2024",
     rustc_env = {
         "provisioning_data": "$(location :provisioning_data)",
     },

--- a/sw/host/tests/ownership/BUILD
+++ b/sw/host/tests/ownership/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_library(
     name = "transfer_lib",
     srcs = ["transfer_lib.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/sphincsplus",
@@ -22,6 +23,7 @@ rust_library(
 rust_binary(
     name = "transfer_test",
     srcs = ["transfer_test.rs"],
+    edition = "2024",
     deps = [
         ":transfer_lib",
         "//sw/host/opentitanlib",
@@ -36,6 +38,7 @@ rust_binary(
 rust_binary(
     name = "rescue_limit_test",
     srcs = ["rescue_limit_test.rs"],
+    edition = "2024",
     deps = [
         ":transfer_lib",
         "//sw/host/opentitanlib",
@@ -50,6 +53,7 @@ rust_binary(
 rust_binary(
     name = "rescue_permission_test",
     srcs = ["rescue_permission_test.rs"],
+    edition = "2024",
     deps = [
         ":transfer_lib",
         "//sw/host/opentitanlib",
@@ -64,6 +68,7 @@ rust_binary(
 rust_binary(
     name = "flash_permission_test",
     srcs = ["flash_permission_test.rs"],
+    edition = "2024",
     deps = [
         ":transfer_lib",
         "//sw/host/opentitanlib",
@@ -78,6 +83,7 @@ rust_binary(
 rust_binary(
     name = "newversion_test",
     srcs = ["newversion_test.rs"],
+    edition = "2024",
     deps = [
         ":transfer_lib",
         "//sw/host/opentitanlib",
@@ -92,6 +98,7 @@ rust_binary(
 rust_binary(
     name = "bl0_secver_persistence_test",
     srcs = ["bl0_secver_persistence_test.rs"],
+    edition = "2024",
     deps = [
         ":transfer_lib",
         "//sw/host/opentitanlib",

--- a/sw/host/tests/penetrationtests/fi_asym_cryptolib/BUILD
+++ b/sw/host/tests/penetrationtests/fi_asym_cryptolib/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/penetrationtests/ujson_lib:pentest_commands",

--- a/sw/host/tests/penetrationtests/fi_crypto/BUILD
+++ b/sw/host/tests/penetrationtests/fi_crypto/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/penetrationtests/ujson_lib:pentest_commands",

--- a/sw/host/tests/penetrationtests/fi_ibex/BUILD
+++ b/sw/host/tests/penetrationtests/fi_ibex/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/penetrationtests/ujson_lib:pentest_commands",

--- a/sw/host/tests/penetrationtests/fi_lc_ctrl/BUILD
+++ b/sw/host/tests/penetrationtests/fi_lc_ctrl/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/penetrationtests/ujson_lib:pentest_commands",

--- a/sw/host/tests/penetrationtests/fi_otbn/BUILD
+++ b/sw/host/tests/penetrationtests/fi_otbn/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/penetrationtests/ujson_lib:pentest_commands",

--- a/sw/host/tests/penetrationtests/fi_otp/BUILD
+++ b/sw/host/tests/penetrationtests/fi_otp/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/penetrationtests/ujson_lib:pentest_commands",

--- a/sw/host/tests/penetrationtests/fi_rng/BUILD
+++ b/sw/host/tests/penetrationtests/fi_rng/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/penetrationtests/ujson_lib:pentest_commands",

--- a/sw/host/tests/penetrationtests/fi_rom/BUILD
+++ b/sw/host/tests/penetrationtests/fi_rom/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/penetrationtests/ujson_lib:pentest_commands",

--- a/sw/host/tests/penetrationtests/fi_sym_cryptolib/BUILD
+++ b/sw/host/tests/penetrationtests/fi_sym_cryptolib/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/penetrationtests/ujson_lib:pentest_commands",

--- a/sw/host/tests/penetrationtests/pentest_lib/BUILD
+++ b/sw/host/tests/penetrationtests/pentest_lib/BUILD
@@ -9,6 +9,7 @@ package(default_visibility = ["//visibility:public"])
 rust_library(
     name = "pentest_lib",
     srcs = ["src/lib.rs"],
+    edition = "2024",
     deps = [
         "@crate_index//:serde_json",
     ],

--- a/sw/host/tests/penetrationtests/sca_aes/BUILD
+++ b/sw/host/tests/penetrationtests/sca_aes/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/penetrationtests/ujson_lib:pentest_commands",

--- a/sw/host/tests/penetrationtests/sca_asym_cryptolib/BUILD
+++ b/sw/host/tests/penetrationtests/sca_asym_cryptolib/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/penetrationtests/ujson_lib:pentest_commands",

--- a/sw/host/tests/penetrationtests/sca_edn/BUILD
+++ b/sw/host/tests/penetrationtests/sca_edn/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/penetrationtests/ujson_lib:pentest_commands",

--- a/sw/host/tests/penetrationtests/sca_hmac/BUILD
+++ b/sw/host/tests/penetrationtests/sca_hmac/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/penetrationtests/ujson_lib:pentest_commands",

--- a/sw/host/tests/penetrationtests/sca_ibex/BUILD
+++ b/sw/host/tests/penetrationtests/sca_ibex/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/penetrationtests/ujson_lib:pentest_commands",

--- a/sw/host/tests/penetrationtests/sca_kmac/BUILD
+++ b/sw/host/tests/penetrationtests/sca_kmac/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/penetrationtests/ujson_lib:pentest_commands",

--- a/sw/host/tests/penetrationtests/sca_otbn/BUILD
+++ b/sw/host/tests/penetrationtests/sca_otbn/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/penetrationtests/ujson_lib:pentest_commands",

--- a/sw/host/tests/penetrationtests/sca_sha3/BUILD
+++ b/sw/host/tests/penetrationtests/sca_sha3/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/penetrationtests/ujson_lib:pentest_commands",

--- a/sw/host/tests/penetrationtests/sca_sym_cryptolib/BUILD
+++ b/sw/host/tests/penetrationtests/sca_sym_cryptolib/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "harness",
     srcs = ["src/main.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/penetrationtests/ujson_lib:pentest_commands",

--- a/sw/host/tests/qemu/BUILD
+++ b/sw/host/tests/qemu/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/test_status.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -23,6 +24,7 @@ rust_binary(
     srcs = [
         "src/i2c_target.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/rescue/BUILD
+++ b/sw/host/tests/rescue/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "xmodem_protocol",
     srcs = ["xmodem_protocol.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -23,6 +24,7 @@ rust_binary(
 rust_binary(
     name = "usbdfu_protocol",
     srcs = ["usbdfu_protocol.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -35,6 +37,7 @@ rust_binary(
 rust_binary(
     name = "rescue_test",
     srcs = ["rescue_test.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -51,6 +54,7 @@ rust_binary(
 rust_binary(
     name = "xmodem_rescue_error_handling",
     srcs = ["xmodem_rescue_error_handling.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -67,6 +71,7 @@ rust_binary(
 rust_binary(
     name = "dfu_rescue_error_handling",
     srcs = ["dfu_rescue_error_handling.rs"],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/rom/e2e_bootstrap_disabled/BUILD
+++ b/sw/host/tests/rom/e2e_bootstrap_disabled/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/rom/e2e_bootstrap_entry/BUILD
+++ b/sw/host/tests/rom/e2e_bootstrap_entry/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/rom/e2e_bootstrap_rma/BUILD
+++ b/sw/host/tests/rom/e2e_bootstrap_rma/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
@@ -27,6 +28,7 @@ rust_test(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/rom/e2e_chip_specific_startup/BUILD
+++ b/sw/host/tests/rom/e2e_chip_specific_startup/BUILD
@@ -19,6 +19,7 @@ rust_binary(
         "src/main.rs",
     ],
     compile_data = [":chip_specific_startup"],
+    edition = "2024",
     rustc_env = {
         "chip_specific_startup": "$(location :chip_specific_startup)",
     },

--- a/sw/host/tests/rom/e2e_openocd_debug_test/BUILD
+++ b/sw/host/tests/rom/e2e_openocd_debug_test/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/asm_interrupt_handler.rs",
     ],
+    edition = "2024",
     deps = [
         "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",
         "//sw/host/opentitanlib",
@@ -27,6 +28,7 @@ rust_binary(
     srcs = [
         "src/shutdown_execution_asm.rs",
     ],
+    edition = "2024",
     deps = [
         "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",
         "//sw/host/opentitanlib",
@@ -43,6 +45,7 @@ rust_binary(
     srcs = [
         "src/asm_watchdog_bark.rs",
     ],
+    edition = "2024",
     deps = [
         "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",
         "//sw/host/opentitanlib",
@@ -59,6 +62,7 @@ rust_binary(
     srcs = [
         "src/asm_watchdog_bite.rs",
     ],
+    edition = "2024",
     deps = [
         "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",
         "//sw/host/opentitanlib",
@@ -75,6 +79,7 @@ rust_binary(
     srcs = [
         "src/debug_test.rs",
     ],
+    edition = "2024",
     deps = [
         "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",
         "//sw/host/opentitanlib",

--- a/sw/host/tests/rom/sw_strap_value/BUILD
+++ b/sw/host/tests/rom/sw_strap_value/BUILD
@@ -12,6 +12,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/rom_ext/device_status/BUILD
+++ b/sw/host/tests/rom_ext/device_status/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/rom_ext/e2e_variation_interop/BUILD
+++ b/sw/host/tests/rom_ext/e2e_variation_interop/BUILD
@@ -11,6 +11,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",

--- a/sw/host/tests/xmodem/BUILD
+++ b/sw/host/tests/xmodem/BUILD
@@ -13,6 +13,7 @@ rust_bindgen_library(
         "--allowlist-function=xmodem_.*",
     ],
     cc_lib = "//sw/device/silicon_creator/lib/rescue:xmodem_testlib",
+    edition = "2024",
     header = "//sw/device/silicon_creator/lib/rescue:xmodem_testlib.h",
     rustc_flags = [
         "--allow=non_snake_case",
@@ -26,6 +27,7 @@ rust_library(
     srcs = [
         "xmodem.rs",
     ],
+    edition = "2024",
     deps = [
         ":xmodem_testlib",
         "//sw/host/opentitanlib",
@@ -41,6 +43,7 @@ rust_test(
     srcs = [
         "lrzsz_test.rs",
     ],
+    edition = "2024",
     deps = [
         ":xmodem",
         "//sw/host/opentitanlib",

--- a/sw/host/tpm2_test_server/BUILD
+++ b/sw/host/tpm2_test_server/BUILD
@@ -13,6 +13,7 @@ rust_binary(
         "src/interface.rs",
         "src/main.rs",
     ],
+    edition = "2024",
     stamp = 1,
     deps = [
         "//sw/host/opentitanlib",

--- a/util/coverage/collect_cc_coverage/BUILD
+++ b/util/coverage/collect_cc_coverage/BUILD
@@ -12,6 +12,7 @@ rust_library(
     data = [
         "//toolchain:opentitan_toolchain",
     ],
+    edition = "2024",
     deps = [
         "@crate_index//:anyhow",
         "@crate_index//:byteorder",
@@ -26,6 +27,7 @@ rust_library(
 rust_binary(
     name = "collect_cc_coverage",
     srcs = ["collect_cc_coverage.rs"],
+    edition = "2024",
     deps = [
         ":coverage_lib",
         "@crate_index//:anyhow",
@@ -36,6 +38,7 @@ rust_binary(
 rust_binary(
     name = "generate_coverage_view",
     srcs = ["generate_coverage_view.rs"],
+    edition = "2024",
     deps = [
         ":coverage_lib",
         "@crate_index//:addr2line",


### PR DESCRIPTION
When these crates are consumed externally, they may not be built with a toolchain that has a compatible default edition. Thus, it is important that they specify explicitly which edition they are compatible with.