### PR TITLE
runtime/print: Suppress unterminated string warning

### DIFF
--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -625,6 +625,20 @@ extern "C++" {
 #define OT_USED __attribute__((used))
 
 /**
+ * Annotation for character arrays that are intentionally not NUL-terminated.
+ *
+ * This suppresses `-Wunterminated-string-initialization` warnings and allows
+ * the compiler to help detect accidental usage in functions that expect
+ * NUL-terminated strings.
+ */
+#if __has_attribute(nonstring)
+#define OT_NONSTRING __attribute__((nonstring))
+#endif
+#ifndef OT_NONSTRING
+#define OT_NONSTRING
+#endif
+
+/**
  * OT_BUILD_FOR_STATIC_ANALYZER indicates whether we are compiling for the
  * purpose of static analysis. Currently, this macro only detects
  * Clang-Analyzer, which is used as a backend by Clang-Tidy.

--- a/sw/device/lib/runtime/print.c
+++ b/sw/device/lib/runtime/print.c
@@ -44,12 +44,12 @@ enum {
 
 // NOTE: all of the lengths of the strings below are given so that the NUL
 // terminator is left off; that way, `sizeof(kConst)` does not include it.
-static const char kDigitsLow[16] = "0123456789abcdef";
-static const char kDigitsHigh[16] = "0123456789ABCDEF";
+static const char kDigitsLow[16] OT_NONSTRING = "0123456789abcdef";
+static const char kDigitsHigh[16] OT_NONSTRING = "0123456789ABCDEF";
 
-static const char kErrorNul[17] = "%<unexpected nul>";
-static const char kUnknownSpec[15] = "%<unknown spec>";
-static const char kErrorTooWide[12] = "%<bad width>";
+static const char kErrorNul[17] OT_NONSTRING = "%<unexpected nul>";
+static const char kUnknownSpec[15] OT_NONSTRING = "%<unknown spec>";
+static const char kErrorTooWide[12] OT_NONSTRING = "%<bad width>";
 
 static size_t base_dev_null(void *data, const char *buf, size_t len) {
   OT_DISCARD(data);
@@ -583,7 +583,7 @@ size_t base_vfprintf(buffer_sink_t out, const char *format, va_list args) {
   return bytes_written;
 }
 
-const char kBaseHexdumpDefaultFmtAlphabet[256] =
+const char kBaseHexdumpDefaultFmtAlphabet[256] OT_NONSTRING =
     // clang-format off
   // First 32 characters are not printable.
   "................................"
@@ -646,7 +646,7 @@ size_t base_fhexdump_with(buffer_sink_t out, base_hexdump_fmt_t fmt,
     size_t line_bytes_written = 0;
     for (size_t word = 0; word < bytes_per_line; word += fmt.bytes_per_word) {
       if (len < line + word) {
-        char spaces[16] = "                ";
+        char spaces[16] OT_NONSTRING = "                ";
         while (line_bytes_written < chars_per_line) {
           size_t to_print = chars_per_line - line_bytes_written;
           if (to_print > sizeof(spaces)) {


### PR DESCRIPTION
Introduce new OT_NONSTRING macro that tells clang that the string does not have a null terminator.