### PR TITLE
Fix missing bazel deps in reggen.

### DIFF
--- a/hw/ip/otbn/util/shared/BUILD
+++ b/hw/ip/otbn/util/shared/BUILD
@@ -212,5 +212,8 @@ py_library(
 
 py_library(
     name = "toolchain",
-    srcs = ["toolchain.py"],
+    srcs = [
+        "__init__.py",
+        "toolchain.py",
+    ],
 )

--- a/util/BUILD
+++ b/util/BUILD
@@ -24,6 +24,7 @@ py_binary(
 py_binary(
     name = "build_info",
     srcs = ["build_info.py"],
+    deps = [":version_file"],
 )
 
 py_test(
@@ -32,23 +33,33 @@ py_test(
         "build_info.py",
         "build_info_test.py",
     ],
+    deps = [":version_file"],
 )
 
 py_binary(
     name = "cryptolib_build_info",
     srcs = ["cryptolib_build_info.py"],
+    deps = [":version_file"],
+)
+
+py_library(
+    name = "version_file",
+    srcs = ["version_file.py"],
 )
 
 py_binary(
     name = "regtool",
     srcs = ["regtool.py"],
     deps = [
+        ":version_file",
         "//util/reggen:countermeasure",
+        "//util/reggen:gen_cfg_md",
         "//util/reggen:gen_cheader",
         "//util/reggen:gen_dv",
         "//util/reggen:gen_fpv",
         "//util/reggen:gen_html",
         "//util/reggen:gen_json",
+        "//util/reggen:gen_md",
         "//util/reggen:gen_rtl",
         "//util/reggen:gen_rust",
         "//util/reggen:gen_sec_cm_testplan",

--- a/util/reggen/BUILD
+++ b/util/reggen/BUILD
@@ -281,6 +281,37 @@ py_library(
 )
 
 py_library(
+    name = "md_helpers",
+    srcs = ["md_helpers.py"],
+    deps = [
+        ":signal",
+        requirement("tabulate"),
+    ],
+)
+
+py_library(
+    name = "gen_cfg_md",
+    srcs = ["gen_cfg_md.py"],
+    deps = [
+        ":ip_block",
+        ":md_helpers",
+    ],
+)
+
+py_library(
+    name = "gen_md",
+    srcs = ["gen_md.py"],
+    deps = [
+        ":ip_block",
+        ":md_helpers",
+        ":multi_register",
+        ":reg_block",
+        ":register",
+        ":window",
+    ],
+)
+
+py_library(
     name = "gen_tock",
     srcs = ["gen_tock.py"],
     deps = [
@@ -291,6 +322,7 @@ py_library(
         ":register",
         ":signal",
         ":window",
+        "//util:version_file",
     ],
 )
 

--- a/util/topgen/BUILD
+++ b/util/topgen/BUILD
@@ -56,6 +56,7 @@ py_library(
         "rust.py",
     ],
     deps = [
+        "//util:version_file",
         "//util/reggen:inter_signal",
         "//util/reggen:ip_block",
         "//util/reggen:validate",


### PR DESCRIPTION
External users may need to use newer versions of rules_python than opentitan's 1.2.0.

rules_python 1.8.5 and later enforce stricter dependency isolation in Python rules. Under the newer version, Python targets must explicitly declare all imported modules in their `deps` to ensure they are packaged into the runfiles sandbox.

Without these fixes, running `regtool` fails with the following import error due to missing sandbox files:

```
Traceback (most recent call last):
  ...
  File ".../util/regtool.py", line 14, in <module>
    from reggen import (
  File ".../util/reggen/gen_tock.py", line 21, in <module>
    from version_file import VersionInformation
ModuleNotFoundError: No module named 'version_file'
```