### PR TITLE
[provisioning] fix provisioning test flakes

### DIFF
--- a/sw/host/opentitanlib/src/test_utils/lc.rs
+++ b/sw/host/opentitanlib/src/test_utils/lc.rs
@@ -26,8 +26,8 @@ pub fn read_lc_state(
     // We must wait for the lc_ctrl to initialize before the LC state is exposed.
     wait_for_status(
         &mut *jtag,
-        Duration::from_secs(1),
-        LcCtrlStatus::INITIALIZED,
+        Duration::from_secs(3),
+        LcCtrlStatus::INITIALIZED | LcCtrlStatus::READY,
     )?;
     let raw_lc_state = jtag.read_lc_ctrl_reg(&LcCtrlReg::LcState)?;
     jtag.disconnect()?;
@@ -50,8 +50,8 @@ pub fn read_device_id(
     // We must wait for the lc_ctrl to initialize before the LC state is exposed.
     wait_for_status(
         &mut *jtag,
-        Duration::from_secs(1),
-        LcCtrlStatus::INITIALIZED,
+        Duration::from_secs(3),
+        LcCtrlStatus::INITIALIZED | LcCtrlStatus::READY,
     )?;
 
     let mut device_id = ArrayVec::<u32, 8>::new();

--- a/sw/host/opentitanlib/src/test_utils/lc_transition.rs
+++ b/sw/host/opentitanlib/src/test_utils/lc_transition.rs
@@ -82,12 +82,13 @@ fn setup_lc_transition(
     target_lc_state: DifLcCtrlState,
     token: Option<[u32; 4]>,
 ) -> Result<()> {
-    // Check the lc_ctrl is initialized and ready to accept a transition request.
-    let status = jtag.read_lc_ctrl_reg(&LcCtrlReg::Status)?;
-    let status = LcCtrlStatus::from_bits(status).ok_or(LcTransitionError::InvalidState(status))?;
-    if status != LcCtrlStatus::INITIALIZED | LcCtrlStatus::READY {
-        return Err(LcTransitionError::LcCtrlNotReady(status).into());
-    }
+    // Wait for the lc_ctrl to become initialized and ready.
+    wait_for_status(
+        jtag,
+        Duration::from_secs(3),
+        LcCtrlStatus::INITIALIZED | LcCtrlStatus::READY,
+    )
+    .context("LC controller did not become ready to accept a transition request.")?;
 
     claim_lc_mutex(jtag, true)?;
 

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -21,10 +21,10 @@ use cert_lib::{
 use ft_ext_lib::{ft_inject_certs_ext, ft_post_boot_ext};
 use opentitanlib::app::{TransportWrapper, UartRx};
 use opentitanlib::console::spi::SpiConsoleDevice;
-use opentitanlib::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg};
+use opentitanlib::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg, LcCtrlStatus};
 use opentitanlib::io::jtag::{JtagParams, JtagTap, RiscvGpr, RiscvReg};
 use opentitanlib::test_utils::init::InitializeTest;
-use opentitanlib::test_utils::lc_transition::trigger_lc_transition;
+use opentitanlib::test_utils::lc_transition::{self, trigger_lc_transition};
 use opentitanlib::test_utils::load_sram_program::{
     ExecutionMode, ExecutionResult, SramProgramParams,
 };
@@ -51,6 +51,13 @@ pub fn test_unlock(
     transport.reset(UartRx::Clear)?;
     let mut jtag = jtag_params.create(transport)?.connect(JtagTap::LcTap)?;
 
+    // Wait for LC controller to be ready.
+    lc_transition::wait_for_status(
+        &mut *jtag,
+        Duration::from_secs(3),
+        LcCtrlStatus::INITIALIZED | LcCtrlStatus::READY,
+    )?;
+
     // Check that LC state is currently `TEST_LOCKED0`.
     let state = jtag.read_lc_ctrl_reg(&LcCtrlReg::LcState)?;
     assert_eq!(state, DifLcCtrlState::TestLocked0.redundant_encoding());
@@ -68,6 +75,13 @@ pub fn test_unlock(
     )?;
 
     jtag = jtag_params.create(transport)?.connect(JtagTap::LcTap)?;
+
+    // Wait for LC controller to be ready.
+    lc_transition::wait_for_status(
+        &mut *jtag,
+        Duration::from_secs(3),
+        LcCtrlStatus::INITIALIZED | LcCtrlStatus::READY,
+    )?;
 
     // Check that LC state has transitioned to `TestUnlocked1`.
     let state = jtag.read_lc_ctrl_reg(&LcCtrlReg::LcState)?;

--- a/sw/host/provisioning/orchestrator/src/orchestrator.py
+++ b/sw/host/provisioning/orchestrator/src/orchestrator.py
@@ -203,6 +203,9 @@ def main(args_in):
     if db.DeviceRecord.query(db_handle, dut.device_id.to_hexstr()) is not None:
         logging.warning(
             "DeviceId already exists in database. Overwrite record?")
+        if args.non_interactive:
+            logging.error("Cannot overwrite database record in non-interactive mode.")
+            sys.exit(1)
         confirm()
 
     # Register the DUT in the database.

--- a/sw/host/provisioning/orchestrator/src/ot_dut.py
+++ b/sw/host/provisioning/orchestrator/src/ot_dut.py
@@ -74,6 +74,7 @@ class OtDut():
         Retuns:
             The extracted JSON data.
         """
+        json_data = {}
         with open(log_file, "r", encoding='utf-8', errors='ignore') as f:
             log_data = f.read()
 
@@ -85,10 +86,16 @@ class OtDut():
                 json_data = hjson.loads(json_string)
             except hjson.HjsonDecodeError as e:
                 logging.error(f"Failed to parse {key}: {e}")
-                confirm()
+                if self.require_confirmation:
+                    confirm()
+                else:
+                    sys.exit(1)
         else:
             logging.error(f"{key} not found.")
-            confirm()
+            if self.require_confirmation:
+                confirm()
+            else:
+                sys.exit(1)
         return json_data
 
     def _base_dev_dir(self) -> str:
@@ -153,7 +160,10 @@ class OtDut():
 
             if res.returncode != 0:
                 logging.warning(f"CP failed with exit code: {res.returncode}.")
-                confirm()
+                if self.require_confirmation:
+                    confirm()
+                else:
+                    sys.exit(res.returncode)
 
             # Extract CP device ID.
             chip_probe_data = self._extract_json_data("CHIP_PROBE_DATA",
@@ -161,7 +171,10 @@ class OtDut():
             din_from_device = None
             if "cp_device_id" not in chip_probe_data:
                 logging.error("cp_device_id not found in CHIP_PROBE_DATA.")
-                confirm()
+                if self.require_confirmation:
+                    confirm()
+                else:
+                    sys.exit(1)
             else:
                 # This can occur if the orchestrator is provisioning a chip that
                 # has already run through CP, and only needs to execute FT.
@@ -296,7 +309,10 @@ class OtDut():
             res = run(cmd, stdout_logfile, stderr_logfile)
             if res.returncode != 0:
                 logging.warning(f"FT failed with exit code: {res.returncode}.")
-                confirm()
+                if self.require_confirmation:
+                    confirm()
+                else:
+                    sys.exit(res.returncode)
 
             self.ft_data = self._extract_json_data("PROVISIONING_DATA",
                                                    stdout_logfile)

--- a/sw/host/provisioning/orchestrator/src/util.py
+++ b/sw/host/provisioning/orchestrator/src/util.py
@@ -6,6 +6,7 @@ import logging
 import os
 import shlex
 import subprocess
+import sys
 
 from python.runfiles import Runfiles
 
@@ -47,10 +48,13 @@ def bcd_encode(x: int) -> int:
 
 def confirm():
     """Get user confirmation to continue."""
+    if not sys.stdin.isatty():
+        logging.error("Non-interactive environment detected. Cannot confirm. Aborting.")
+        sys.exit(1)
     confirm = input("Type confirm to continue: ")
     if confirm != "confirm":
         logging.info("Did not receive confirmation from user. Aborting.")
-        exit(1)
+        sys.exit(1)
 
 
 def run(cmd, stdout_logfile, stderr_logfile):


### PR DESCRIPTION
This PR is to address the issue of flaky provisioning tests.
The error message looks like:

ERROR:root:PROVISIONING_DATA not found.
Type confirm to continue: Traceback (most recent call last):
  File "/tmp/Bazel.runfiles_p3z3ewkq/runfiles/_main/sw/host/provisioning/orchestrator/src/orchestrator.py", line 215, in <module>
    main(sys.argv[1:])
  File "/tmp/Bazel.runfiles_p3z3ewkq/runfiles/_main/sw/host/provisioning/orchestrator/src/orchestrator.py", line 195, in main
    dut.run_ft()
  File "/tmp/Bazel.runfiles_p3z3ewkq/runfiles/_main/sw/host/provisioning/orchestrator/src/ot_dut.py", line 301, in run_ft
    self.ft_data = self._extract_json_data("PROVISIONING_DATA",
  File "/tmp/Bazel.runfiles_p3z3ewkq/runfiles/_main/sw/host/provisioning/orchestrator/src/ot_dut.py", line 91, in _extract_json_data
    confirm()
  File "/tmp/Bazel.runfiles_p3z3ewkq/runfiles/_main/sw/host/provisioning/orchestrator/src/util.py", line 50, in confirm
    confirm = input("Type confirm to continue: ")
EOFError: EOF when reading a line

It's due to the keyword "PROVISIONING_DATA" cannot be found in the stdout file.
After out_tee.stdin.close() and err_tee.stdin.close() are called, it takes time to flush the logs to the stdout/stderr files.
Without wait(), if the file write is slower, then run() function will return before the file write is complete thus the call to self._extract_json_data("PROVISIONING_DATA", stdout_logfile) in ot_dut.py could fail.

Please refer to https://github.com/lowRISC/opentitan/blob/earlgrey_1.0.0/sw/host/provisioning/orchestrator/src/ot_dut.py#L296 for more details.

In addition, implementation of confirm() is updated so if it's a non-interactive environment, return directly instead of waiting for input from user. For all error cases it could also be implemented  as follows
```
    if self.require_confirmation:                                                                                                                                                       
        confirm()                                                                                                                                                                       
    else:                                                                                                                                                                               
        sys.exit(1) # Explicitly fail in CI      
```
It introduces a lot of duplicated error-handling logic.