### PR TITLE
[reggen] Adding a REGWEN bit to ALERT_TEST registers

### DIFF
--- a/hw/Makefile
+++ b/hw/Makefile
@@ -36,6 +36,7 @@ IPS ?= aes           \
        mbx           \
        otbn          \
        otp_macro     \
+       pattgen       \
        pwm           \
        rom_ctrl      \
        rram_ctrl     \

--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -243,8 +243,17 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
     `DV_CHECK_NE_FATAL(alert_test_csr, null,
                        $sformatf("cannot find alert_test csr in %0s", blk.get_name()))
 
-    `DV_CHECK_EQ(alert_test_csr.get_n_used_bits(), alert_names.size(),
-                 "alert_test field number and list_of_alerts size mismatch")
+    // Ignore the `regwen` field in the alert_test register
+    begin
+      uvm_reg_field alert_test_fields[$];
+      int num_alert_test_fields;
+      alert_test_csr.get_fields(alert_test_fields);
+      foreach (alert_test_fields[i]) begin
+        if (alert_test_fields[i].get_name() != "regwen") num_alert_test_fields++;
+      end
+      `DV_CHECK_EQ(num_alert_test_fields, alert_names.size(),
+                   "alert_test field number and list_of_alerts size mismatch")
+    end
 
     foreach(alert_names[i]) begin
       uvm_reg_field alert_test_field = blk.get_field_by_name(alert_names[i]);

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -950,16 +950,55 @@ endtask
 task cip_base_vseq::run_alert_test_vseq(int num_times = 1);
   int num_alerts = cfg.list_of_alerts.size();
   dv_base_reg alert_test_csr = ral.get_dv_base_reg_by_name("alert_test");
+  // Ensure we write the regwen bit of the alert_test register to not disable write access
+  uvm_reg_field alert_test_regwen_fld = alert_test_csr.get_field_by_name("regwen");
+  bit [BUS_DW-1:0] regwen_mask =
+      (alert_test_regwen_fld != null) ? (BUS_DW'(1) << alert_test_regwen_fld.get_lsb_pos()) : '0;
   `DV_CHECK_FATAL(num_alerts > 0, "Please declare `list_of_alerts` under cfg!")
 
   for (int trans = 1; trans <= num_times; trans++) begin
     `uvm_info(`gfn, $sformatf("Running alert test iteration %0d/%0d", trans, num_times), UVM_LOW)
 
     repeat ($urandom_range(num_alerts, num_alerts * 10)) begin
-      bit [BUS_DW-1:0] alert_req = $urandom_range(0, (1'b1 << num_alerts) - 1);
-      // Write random value to alert_test register.
-      csr_wr(.ptr(alert_test_csr), .value(alert_req));
+      bit [BUS_DW-1:0] alert_req     = $urandom_range(0, (1'b1 << num_alerts) - 1);
+      bit regwen_val_before          = 1'b1;
+      bit regwen_wr_val              = 1'b1;
+      bit [BUS_DW-1:0] regwen_wr_bit = regwen_mask;
+
+      // Read the current regwen value as it might already be 0. While
+      // still 1, randomly, 10%, write 0 to it to exercise the in-register lock.
+      if (alert_test_regwen_fld != null) begin
+        bit [BUS_DW-1:0] regwen_rd_val;
+        csr_rd(.ptr(alert_test_csr), .value(regwen_rd_val));
+        regwen_val_before = regwen_rd_val[alert_test_regwen_fld.get_lsb_pos()];
+        regwen_wr_val = (regwen_val_before && $urandom_range(1, 10) == 1) ? 1'b0 : regwen_val_before;
+        regwen_wr_bit = BUS_DW'(regwen_wr_val) << alert_test_regwen_fld.get_lsb_pos();
+      end
+
+      // Write random value to alert_test register
+      csr_wr(.ptr(alert_test_csr), .value(alert_req | regwen_wr_bit));
       `uvm_info(`gfn, $sformatf("Write alert_test with val %0h", alert_req), UVM_HIGH)
+
+      // Check the value written to regwen by reading the CSR back.
+      if (alert_test_regwen_fld != null) begin
+        bit [BUS_DW-1:0] regwen_rd_val;
+        csr_rd(.ptr(alert_test_csr), .value(regwen_rd_val));
+        `DV_CHECK_EQ(regwen_rd_val[alert_test_regwen_fld.get_lsb_pos()], regwen_wr_val,
+                     "alert_test regwen readback does not match the value written")
+      end
+
+      if (!regwen_val_before) begin
+        // regwen was already locked entering this write: the write-enable gate used that
+        // already-registered value, so this write could not have set any alert field.
+        cfg.clk_rst_vif.wait_clks($urandom_range(0, 3));
+        foreach (cfg.list_of_alerts[i]) begin
+          `DV_CHECK_EQ(cfg.m_alert_agent_cfgs[cfg.list_of_alerts[i]].vif.get_alert(), 0,
+                       $sformatf("expect no alert_test alert:%0s while regwen is locked",
+                                 cfg.list_of_alerts[i]))
+        end
+        continue;
+      end
+
       for (int i = 0; i < num_alerts; i++) begin
         string alert_name = cfg.list_of_alerts[i];
 
@@ -973,7 +1012,7 @@ task cip_base_vseq::run_alert_test_vseq(int num_times = 1);
 
           // write alert_test during alert handshake will be ignored
           if ($urandom_range(1, 10) == 10) begin
-            csr_wr(.ptr(alert_test_csr), .value(1'b1 << i));
+            csr_wr(.ptr(alert_test_csr), .value((1'b1 << i) | regwen_mask));
             `uvm_info(`gfn, "Write alert_test again during alert handshake", UVM_HIGH)
           end
 
@@ -987,12 +1026,13 @@ task cip_base_vseq::run_alert_test_vseq(int num_times = 1);
          `DV_CHECK_EQ(cfg.m_alert_agent_cfgs[alert_name].vif.get_alert(), 0,
                       $sformatf("alert_test did not set alert:%0s", alert_name))
 
-          // write alert_test field when there is ongoing alert handshake
-          if ($urandom_range(1, 10) == 10) begin
+          // write alert_test field when there is ongoing alert handshake. Skip if the write
+          // above just locked regwen.
+          if (regwen_wr_val && $urandom_range(1, 10) == 10) begin
             `uvm_info(`gfn,
                       $sformatf("Write alert_test with val %0h during alert_handshake",
                       1'b1 << i), UVM_HIGH)
-            csr_wr(.ptr(alert_test_csr), .value(1'b1 << i));
+            csr_wr(.ptr(alert_test_csr), .value((1'b1 << i) | regwen_mask));
             `DV_SPINWAIT_EXIT(while (!cfg.m_alert_agent_cfgs[alert_name].vif.get_alert())
                               cfg.clk_rst_vif.wait_clks(1);,
                               cfg.clk_rst_vif.wait_clks(2);,

--- a/hw/ip/adc_ctrl/doc/registers.md
+++ b/hw/ip/adc_ctrl/doc/registers.md
@@ -92,19 +92,20 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## adc_en_ctl
 ADC enable control register

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_pkg.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_pkg.sv
@@ -268,8 +268,9 @@ package adc_ctrl_reg_pkg;
   // Reset values for hwext registers and their fields
   parameter logic [0:0] ADC_CTRL_INTR_TEST_RESVAL = 1'h 0;
   parameter logic [0:0] ADC_CTRL_INTR_TEST_MATCH_PENDING_RESVAL = 1'h 0;
-  parameter logic [0:0] ADC_CTRL_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] ADC_CTRL_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] ADC_CTRL_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] ADC_CTRL_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [4:0] ADC_CTRL_ADC_FSM_STATE_RESVAL = 5'h 0;
   parameter logic [4:0] ADC_CTRL_ADC_FSM_STATE_STATE_RESVAL = 5'h 0;
 
@@ -314,7 +315,7 @@ package adc_ctrl_reg_pkg;
     4'b 0001, // index[ 0] ADC_CTRL_INTR_STATE
     4'b 0001, // index[ 1] ADC_CTRL_INTR_ENABLE
     4'b 0001, // index[ 2] ADC_CTRL_INTR_TEST
-    4'b 0001, // index[ 3] ADC_CTRL_ALERT_TEST
+    4'b 1111, // index[ 3] ADC_CTRL_ALERT_TEST
     4'b 0001, // index[ 4] ADC_CTRL_ADC_EN_CTL
     4'b 1111, // index[ 5] ADC_CTRL_ADC_PD_CTL
     4'b 0001, // index[ 6] ADC_CTRL_ADC_LP_SAMPLE_CTL

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
@@ -130,7 +130,9 @@ module adc_ctrl_reg_top (
   logic intr_test_we;
   logic intr_test_wd;
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic adc_en_ctl_we;
   logic [1:0] adc_en_ctl_qs;
   logic adc_en_ctl_busy;
@@ -1429,14 +1431,18 @@ module adc_ctrl_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -1445,6 +1451,33 @@ module adc_ctrl_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[adc_en_ctl]: V(False)
@@ -4055,7 +4088,9 @@ module adc_ctrl_reg_top (
   assign intr_test_wd = reg_wdata[0];
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign adc_en_ctl_we = addr_hit[4] & reg_we & !reg_error;
 
 
@@ -4225,6 +4260,7 @@ module adc_ctrl_reg_top (
 
       addr_hit[3]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/ip/aes/doc/registers.md
+++ b/hw/ip/aes/doc/registers.md
@@ -56,20 +56,21 @@ For a detailed overview of the register tool, please refer to the [Register Tool
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0x0`
-- Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000003`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "recov_ctrl_update_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 230}}
+{"reg": [{"name": "recov_ctrl_update_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 29}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 230}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                  | Description                                      |
-|:------:|:------:|:-------:|:----------------------|:-------------------------------------------------|
-|  31:2  |        |         |                       | Reserved                                         |
-|   1    |   wo   |   0x0   | fatal_fault           | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | recov_ctrl_update_err | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name                  | Description                                            |
+|:------:|:------:|:-------:|:----------------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen                | Write 0 to disable alert testing until the next reset. |
+|  30:2  |        |         |                       | Reserved                                               |
+|   1    |   wo   |   0x0   | fatal_fault           | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | recov_ctrl_update_err | Write 1 to trigger one alert event of this kind.       |
 
 ## KEY_SHARE0
 Initial Key Registers Share 0.

--- a/hw/ip/aes/rtl/aes_reg_pkg.sv
+++ b/hw/ip/aes/rtl/aes_reg_pkg.sv
@@ -310,9 +310,10 @@ package aes_reg_pkg;
   parameter logic [BlockAw-1:0] AES_CTRL_GCM_SHADOWED_OFFSET = 8'h 88;
 
   // Reset values for hwext registers and their fields
-  parameter logic [1:0] AES_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [31:0] AES_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] AES_ALERT_TEST_RECOV_CTRL_UPDATE_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] AES_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] AES_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [31:0] AES_KEY_SHARE0_0_RESVAL = 32'h 0;
   parameter logic [31:0] AES_KEY_SHARE0_0_KEY_SHARE0_0_RESVAL = 32'h 0;
   parameter logic [31:0] AES_KEY_SHARE0_1_RESVAL = 32'h 0;
@@ -413,7 +414,7 @@ package aes_reg_pkg;
 
   // Register width information to check illegal writes
   parameter logic [3:0] AES_PERMIT [35] = '{
-    4'b 0001, // index[ 0] AES_ALERT_TEST
+    4'b 1111, // index[ 0] AES_ALERT_TEST
     4'b 1111, // index[ 1] AES_KEY_SHARE0_0
     4'b 1111, // index[ 2] AES_KEY_SHARE0_1
     4'b 1111, // index[ 3] AES_KEY_SHARE0_2

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -128,6 +128,8 @@ module aes_reg_top (
   logic alert_test_we;
   logic alert_test_recov_ctrl_update_err_wd;
   logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic key_share0_0_we;
   logic [31:0] key_share0_0_wd;
   logic key_share0_1_we;
@@ -241,14 +243,17 @@ module aes_reg_top (
   // Register instances
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [1:0] alert_test_flds_we;
+  logic [2:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[recov_ctrl_update_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_recov_ctrl_update_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_ctrl_update_err_wd),
     .d      ('0),
     .qre    (),
@@ -264,7 +269,7 @@ module aes_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
@@ -274,6 +279,33 @@ module aes_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_fault.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[2]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // Subregister 0 of Multireg key_share0
@@ -1560,6 +1592,8 @@ module aes_reg_top (
   assign alert_test_recov_ctrl_update_err_wd = reg_wdata[0];
 
   assign alert_test_fatal_fault_wd = reg_wdata[1];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign key_share0_0_we = addr_hit[1] & reg_we & !reg_error;
 
   assign key_share0_0_wd = reg_wdata[31:0];
@@ -1725,6 +1759,7 @@ module aes_reg_top (
       addr_hit[0]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[1]: begin

--- a/hw/ip/aon_timer/doc/registers.md
+++ b/hw/ip/aon_timer/doc/registers.md
@@ -23,19 +23,20 @@
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0x0`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## WKUP_CTRL
 Wakeup Timer Control register.

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_pkg.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_pkg.sv
@@ -174,8 +174,9 @@ package aon_timer_reg_pkg;
   parameter logic [BlockAw-1:0] AON_TIMER_WKUP_CAUSE_OFFSET = 6'h 34;
 
   // Reset values for hwext registers and their fields
-  parameter logic [0:0] AON_TIMER_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] AON_TIMER_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] AON_TIMER_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] AON_TIMER_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [1:0] AON_TIMER_INTR_TEST_RESVAL = 2'h 0;
 
   // Register index
@@ -198,7 +199,7 @@ package aon_timer_reg_pkg;
 
   // Register width information to check illegal writes
   parameter logic [3:0] AON_TIMER_PERMIT [14] = '{
-    4'b 0001, // index[ 0] AON_TIMER_ALERT_TEST
+    4'b 1111, // index[ 0] AON_TIMER_ALERT_TEST
     4'b 0011, // index[ 1] AON_TIMER_WKUP_CTRL
     4'b 1111, // index[ 2] AON_TIMER_WKUP_THOLD_HI
     4'b 1111, // index[ 3] AON_TIMER_WKUP_THOLD_LO

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
@@ -135,7 +135,9 @@ module aon_timer_reg_top
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic wkup_ctrl_we;
   logic [12:0] wkup_ctrl_qs;
   logic wkup_ctrl_busy;
@@ -590,14 +592,18 @@ module aon_timer_reg_top
   // Register instances
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -606,6 +612,33 @@ module aon_timer_reg_top
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[wkup_ctrl]: V(False)
@@ -1189,7 +1222,9 @@ module aon_timer_reg_top
   // Generate write-enables
   assign alert_test_we = racl_addr_hit_write[0] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign wkup_ctrl_we = racl_addr_hit_write[1] & reg_we & !reg_error;
 
 
@@ -1250,6 +1285,7 @@ module aon_timer_reg_top
     unique case (1'b1)
       racl_addr_hit_read[0]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       racl_addr_hit_read[1]: begin

--- a/hw/ip/csrng/doc/registers.md
+++ b/hw/ip/csrng/doc/registers.md
@@ -93,20 +93,21 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000003`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "recov_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "recov_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 29}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:2  |        |         |             | Reserved                                         |
-|   1    |   wo   |   0x0   | fatal_alert | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | recov_alert | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:2  |        |         |             | Reserved                                               |
+|   1    |   wo   |   0x0   | fatal_alert | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | recov_alert | Write 1 to trigger one alert event of this kind.       |
 
 ## REGWEN
 Register write enable for all control registers

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -349,9 +349,10 @@ package csrng_reg_pkg;
   parameter logic [0:0] CSRNG_INTR_TEST_CS_ENTROPY_REQ_RESVAL = 1'h 0;
   parameter logic [0:0] CSRNG_INTR_TEST_CS_HW_INST_EXC_RESVAL = 1'h 0;
   parameter logic [0:0] CSRNG_INTR_TEST_CS_FATAL_ERR_RESVAL = 1'h 0;
-  parameter logic [1:0] CSRNG_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [31:0] CSRNG_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] CSRNG_ALERT_TEST_RECOV_ALERT_RESVAL = 1'h 0;
   parameter logic [0:0] CSRNG_ALERT_TEST_FATAL_ALERT_RESVAL = 1'h 0;
+  parameter logic [0:0] CSRNG_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [31:0] CSRNG_RESEED_COUNTER_0_RESVAL = 32'h 0;
   parameter logic [31:0] CSRNG_RESEED_COUNTER_0_RESEED_COUNTER_0_RESVAL = 32'h 0;
   parameter logic [31:0] CSRNG_RESEED_COUNTER_1_RESVAL = 32'h 0;
@@ -395,7 +396,7 @@ package csrng_reg_pkg;
     4'b 0001, // index[ 0] CSRNG_INTR_STATE
     4'b 0001, // index[ 1] CSRNG_INTR_ENABLE
     4'b 0001, // index[ 2] CSRNG_INTR_TEST
-    4'b 0001, // index[ 3] CSRNG_ALERT_TEST
+    4'b 1111, // index[ 3] CSRNG_ALERT_TEST
     4'b 0001, // index[ 4] CSRNG_REGWEN
     4'b 0011, // index[ 5] CSRNG_CTRL
     4'b 1111, // index[ 6] CSRNG_CMD_REQ

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -147,6 +147,8 @@ module csrng_reg_top (
   logic alert_test_we;
   logic alert_test_recov_alert_wd;
   logic alert_test_fatal_alert_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic regwen_we;
   logic regwen_qs;
   logic regwen_wd;
@@ -521,14 +523,17 @@ module csrng_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [1:0] alert_test_flds_we;
+  logic [2:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[recov_alert]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_recov_alert (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_alert_wd),
     .d      ('0),
     .qre    (),
@@ -544,7 +549,7 @@ module csrng_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_alert (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_alert_wd),
     .d      ('0),
     .qre    (),
@@ -554,6 +559,33 @@ module csrng_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_alert.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[2]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[regwen]: V(False)
@@ -1815,6 +1847,8 @@ module csrng_reg_top (
   assign alert_test_recov_alert_wd = reg_wdata[0];
 
   assign alert_test_fatal_alert_wd = reg_wdata[1];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign regwen_we = addr_hit[4] & reg_we & !reg_error;
 
   assign regwen_wd = reg_wdata[0];
@@ -1933,6 +1967,7 @@ module csrng_reg_top (
       addr_hit[3]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/ip/dma/doc/registers.md
+++ b/hw/ip/dma/doc/registers.md
@@ -129,19 +129,20 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## SRC_ADDR_LO
 Lower 32 bits of the physical or virtual address of memory location within SoC memory address map or physical address within OT non-secure memory space.

--- a/hw/ip/dma/rtl/dma_reg_pkg.sv
+++ b/hw/ip/dma/rtl/dma_reg_pkg.sv
@@ -438,8 +438,9 @@ package dma_reg_pkg;
   parameter logic [0:0] DMA_INTR_TEST_DMA_DONE_RESVAL = 1'h 0;
   parameter logic [0:0] DMA_INTR_TEST_DMA_CHUNK_DONE_RESVAL = 1'h 0;
   parameter logic [0:0] DMA_INTR_TEST_DMA_ERROR_RESVAL = 1'h 0;
-  parameter logic [0:0] DMA_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] DMA_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] DMA_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] DMA_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [3:0] DMA_CFG_REGWEN_RESVAL = 4'h 6;
   parameter logic [3:0] DMA_CFG_REGWEN_REGWEN_RESVAL = 4'h 6;
 
@@ -515,7 +516,7 @@ package dma_reg_pkg;
     4'b 0001, // index[ 0] DMA_INTR_STATE
     4'b 0001, // index[ 1] DMA_INTR_ENABLE
     4'b 0001, // index[ 2] DMA_INTR_TEST
-    4'b 0001, // index[ 3] DMA_ALERT_TEST
+    4'b 1111, // index[ 3] DMA_ALERT_TEST
     4'b 1111, // index[ 4] DMA_SRC_ADDR_LO
     4'b 1111, // index[ 5] DMA_SRC_ADDR_HI
     4'b 1111, // index[ 6] DMA_DST_ADDR_LO

--- a/hw/ip/dma/rtl/dma_reg_top.sv
+++ b/hw/ip/dma/rtl/dma_reg_top.sv
@@ -147,7 +147,9 @@ module dma_reg_top
   logic intr_test_dma_chunk_done_wd;
   logic intr_test_dma_error_wd;
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic src_addr_lo_we;
   logic [31:0] src_addr_lo_qs;
   logic [31:0] src_addr_lo_wd;
@@ -543,14 +545,18 @@ module dma_reg_top
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -559,6 +565,33 @@ module dma_reg_top
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[src_addr_lo]: V(False)
@@ -3231,7 +3264,9 @@ module dma_reg_top
   assign intr_test_dma_error_wd = reg_wdata[2];
   assign alert_test_we = racl_addr_hit_write[3] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign src_addr_lo_we = racl_addr_hit_write[4] & reg_we & !reg_error;
 
   assign src_addr_lo_wd = reg_wdata[31:0];
@@ -3470,6 +3505,7 @@ module dma_reg_top
 
       racl_addr_hit_read[3]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       racl_addr_hit_read[4]: begin

--- a/hw/ip/edn/doc/registers.md
+++ b/hw/ip/edn/doc/registers.md
@@ -81,20 +81,21 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000003`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "recov_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "recov_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 29}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:2  |        |         |             | Reserved                                         |
-|   1    |   wo   |   0x0   | fatal_alert | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | recov_alert | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:2  |        |         |             | Reserved                                               |
+|   1    |   wo   |   0x0   | fatal_alert | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | recov_alert | Write 1 to trigger one alert event of this kind.       |
 
 ## REGWEN
 Register write enable for all control registers

--- a/hw/ip/edn/rtl/edn_reg_pkg.sv
+++ b/hw/ip/edn/rtl/edn_reg_pkg.sv
@@ -287,9 +287,10 @@ package edn_reg_pkg;
   parameter logic [1:0] EDN_INTR_TEST_RESVAL = 2'h 0;
   parameter logic [0:0] EDN_INTR_TEST_EDN_CMD_REQ_DONE_RESVAL = 1'h 0;
   parameter logic [0:0] EDN_INTR_TEST_EDN_FATAL_ERR_RESVAL = 1'h 0;
-  parameter logic [1:0] EDN_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [31:0] EDN_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] EDN_ALERT_TEST_RECOV_ALERT_RESVAL = 1'h 0;
   parameter logic [0:0] EDN_ALERT_TEST_FATAL_ALERT_RESVAL = 1'h 0;
+  parameter logic [0:0] EDN_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [31:0] EDN_SW_CMD_REQ_RESVAL = 32'h 0;
   parameter logic [31:0] EDN_RESEED_CMD_RESVAL = 32'h 0;
   parameter logic [31:0] EDN_GENERATE_CMD_RESVAL = 32'h 0;
@@ -321,7 +322,7 @@ package edn_reg_pkg;
     4'b 0001, // index[ 0] EDN_INTR_STATE
     4'b 0001, // index[ 1] EDN_INTR_ENABLE
     4'b 0001, // index[ 2] EDN_INTR_TEST
-    4'b 0001, // index[ 3] EDN_ALERT_TEST
+    4'b 1111, // index[ 3] EDN_ALERT_TEST
     4'b 0001, // index[ 4] EDN_REGWEN
     4'b 0011, // index[ 5] EDN_CTRL
     4'b 1111, // index[ 6] EDN_BOOT_INS_CMD

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -137,6 +137,8 @@ module edn_reg_top (
   logic alert_test_we;
   logic alert_test_recov_alert_wd;
   logic alert_test_fatal_alert_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic regwen_we;
   logic regwen_qs;
   logic regwen_wd;
@@ -351,14 +353,17 @@ module edn_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [1:0] alert_test_flds_we;
+  logic [2:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[recov_alert]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_recov_alert (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_alert_wd),
     .d      ('0),
     .qre    (),
@@ -374,7 +379,7 @@ module edn_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_alert (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_alert_wd),
     .d      ('0),
     .qre    (),
@@ -384,6 +389,33 @@ module edn_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_alert.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[2]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[regwen]: V(False)
@@ -1449,6 +1481,8 @@ module edn_reg_top (
   assign alert_test_recov_alert_wd = reg_wdata[0];
 
   assign alert_test_fatal_alert_wd = reg_wdata[1];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign regwen_we = addr_hit[4] & reg_we & !reg_error;
 
   assign regwen_wd = reg_wdata[0];
@@ -1540,6 +1574,7 @@ module edn_reg_top (
       addr_hit[3]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/ip/entropy_src/doc/registers.md
+++ b/hw/ip/entropy_src/doc/registers.md
@@ -119,20 +119,21 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000003`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "recov_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "recov_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 29}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:2  |        |         |             | Reserved                                         |
-|   1    |   wo   |   0x0   | fatal_alert | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | recov_alert | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:2  |        |         |             | Reserved                                               |
+|   1    |   wo   |   0x0   | fatal_alert | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | recov_alert | Write 1 to trigger one alert event of this kind.       |
 
 ## ME_REGWEN
 Register write enable for module enable register

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
@@ -688,9 +688,10 @@ package entropy_src_reg_pkg;
   parameter logic [0:0] ENTROPY_SRC_INTR_TEST_ES_HEALTH_TEST_FAILED_RESVAL = 1'h 0;
   parameter logic [0:0] ENTROPY_SRC_INTR_TEST_ES_OBSERVE_FIFO_READY_RESVAL = 1'h 0;
   parameter logic [0:0] ENTROPY_SRC_INTR_TEST_ES_FATAL_ERR_RESVAL = 1'h 0;
-  parameter logic [1:0] ENTROPY_SRC_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [31:0] ENTROPY_SRC_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] ENTROPY_SRC_ALERT_TEST_RECOV_ALERT_RESVAL = 1'h 0;
   parameter logic [0:0] ENTROPY_SRC_ALERT_TEST_FATAL_ALERT_RESVAL = 1'h 0;
+  parameter logic [0:0] ENTROPY_SRC_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [31:0] ENTROPY_SRC_ENTROPY_DATA_RESVAL = 32'h 0;
   parameter logic [15:0] ENTROPY_SRC_REPCNT_THRESHOLD_RESVAL = 16'h ffff;
   parameter logic [15:0] ENTROPY_SRC_REPCNT_THRESHOLD_REPCNT_THRESHOLD_RESVAL = 16'h ffff;
@@ -792,7 +793,7 @@ package entropy_src_reg_pkg;
     4'b 0001, // index[ 0] ENTROPY_SRC_INTR_STATE
     4'b 0001, // index[ 1] ENTROPY_SRC_INTR_ENABLE
     4'b 0001, // index[ 2] ENTROPY_SRC_INTR_TEST
-    4'b 0001, // index[ 3] ENTROPY_SRC_ALERT_TEST
+    4'b 1111, // index[ 3] ENTROPY_SRC_ALERT_TEST
     4'b 0001, // index[ 4] ENTROPY_SRC_ME_REGWEN
     4'b 0001, // index[ 5] ENTROPY_SRC_SW_REGUPD
     4'b 0001, // index[ 6] ENTROPY_SRC_REGWEN

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -147,6 +147,8 @@ module entropy_src_reg_top (
   logic alert_test_we;
   logic alert_test_recov_alert_wd;
   logic alert_test_fatal_alert_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic me_regwen_we;
   logic me_regwen_qs;
   logic me_regwen_wd;
@@ -642,14 +644,17 @@ module entropy_src_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [1:0] alert_test_flds_we;
+  logic [2:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[recov_alert]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_recov_alert (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_alert_wd),
     .d      ('0),
     .qre    (),
@@ -665,7 +670,7 @@ module entropy_src_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_alert (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_alert_wd),
     .d      ('0),
     .qre    (),
@@ -675,6 +680,33 @@ module entropy_src_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_alert.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[2]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[me_regwen]: V(False)
@@ -3142,6 +3174,8 @@ module entropy_src_reg_top (
   assign alert_test_recov_alert_wd = reg_wdata[0];
 
   assign alert_test_fatal_alert_wd = reg_wdata[1];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign me_regwen_we = addr_hit[4] & reg_we & !reg_error;
 
   assign me_regwen_wd = reg_wdata[0];
@@ -3381,6 +3415,7 @@ module entropy_src_reg_top (
       addr_hit[3]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/ip/hmac/doc/registers.md
+++ b/hw/ip/hmac/doc/registers.md
@@ -140,19 +140,20 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## CFG
 HMAC Configuration register.

--- a/hw/ip/hmac/rtl/hmac_reg_pkg.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_pkg.sv
@@ -313,8 +313,9 @@ package hmac_reg_pkg;
   parameter logic [0:0] HMAC_INTR_TEST_HMAC_DONE_RESVAL = 1'h 0;
   parameter logic [0:0] HMAC_INTR_TEST_FIFO_EMPTY_RESVAL = 1'h 0;
   parameter logic [0:0] HMAC_INTR_TEST_HMAC_ERR_RESVAL = 1'h 0;
-  parameter logic [0:0] HMAC_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] HMAC_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] HMAC_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] HMAC_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [14:0] HMAC_CFG_RESVAL = 15'h 4100;
   parameter logic [0:0] HMAC_CFG_ENDIAN_SWAP_RESVAL = 1'h 0;
   parameter logic [0:0] HMAC_CFG_DIGEST_SWAP_RESVAL = 1'h 0;
@@ -450,7 +451,7 @@ package hmac_reg_pkg;
     4'b 0001, // index[ 0] HMAC_INTR_STATE
     4'b 0001, // index[ 1] HMAC_INTR_ENABLE
     4'b 0001, // index[ 2] HMAC_INTR_TEST
-    4'b 0001, // index[ 3] HMAC_ALERT_TEST
+    4'b 1111, // index[ 3] HMAC_ALERT_TEST
     4'b 0011, // index[ 4] HMAC_CFG
     4'b 0001, // index[ 5] HMAC_CMD
     4'b 0011, // index[ 6] HMAC_STATUS

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -188,7 +188,9 @@ module hmac_reg_top (
   logic intr_test_fifo_empty_wd;
   logic intr_test_hmac_err_wd;
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic cfg_re;
   logic cfg_we;
   logic cfg_hmac_en_qs;
@@ -577,14 +579,18 @@ module hmac_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -593,6 +599,33 @@ module hmac_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[cfg]: V(True)
@@ -2091,7 +2124,9 @@ module hmac_reg_top (
   assign intr_test_hmac_err_wd = reg_wdata[2];
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign cfg_re = addr_hit[4] & reg_re & !reg_error;
   assign cfg_we = addr_hit[4] & reg_we & !reg_error;
 
@@ -2377,6 +2412,7 @@ module hmac_reg_top (
 
       addr_hit[3]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/ip/i2c/doc/registers.md
+++ b/hw/ip/i2c/doc/registers.md
@@ -134,19 +134,20 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## CTRL
 I2C Control Register

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -737,8 +737,9 @@ package i2c_reg_pkg;
   parameter logic [0:0] I2C_INTR_TEST_ACQ_STRETCH_RESVAL = 1'h 0;
   parameter logic [0:0] I2C_INTR_TEST_UNEXP_STOP_RESVAL = 1'h 0;
   parameter logic [0:0] I2C_INTR_TEST_HOST_TIMEOUT_RESVAL = 1'h 0;
-  parameter logic [0:0] I2C_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] I2C_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] I2C_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] I2C_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [10:0] I2C_STATUS_RESVAL = 11'h 33c;
   parameter logic [0:0] I2C_STATUS_FMTEMPTY_RESVAL = 1'h 1;
   parameter logic [0:0] I2C_STATUS_HOSTIDLE_RESVAL = 1'h 1;
@@ -795,7 +796,7 @@ package i2c_reg_pkg;
     4'b 0011, // index[ 0] I2C_INTR_STATE
     4'b 0011, // index[ 1] I2C_INTR_ENABLE
     4'b 0011, // index[ 2] I2C_INTR_TEST
-    4'b 0001, // index[ 3] I2C_ALERT_TEST
+    4'b 1111, // index[ 3] I2C_ALERT_TEST
     4'b 0001, // index[ 4] I2C_CTRL
     4'b 0011, // index[ 5] I2C_STATUS
     4'b 0001, // index[ 6] I2C_RDATA

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -204,7 +204,9 @@ module i2c_reg_top
   logic intr_test_unexp_stop_wd;
   logic intr_test_host_timeout_wd;
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic ctrl_we;
   logic ctrl_enablehost_qs;
   logic ctrl_enablehost_wd;
@@ -1420,14 +1422,18 @@ module i2c_reg_top
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -1436,6 +1442,33 @@ module i2c_reg_top
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[ctrl]: V(False)
@@ -3604,7 +3637,9 @@ module i2c_reg_top
   assign intr_test_host_timeout_wd = reg_wdata[14];
   assign alert_test_we = racl_addr_hit_write[3] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign ctrl_we = racl_addr_hit_write[4] & reg_we & !reg_error;
 
   assign ctrl_enablehost_wd = reg_wdata[0];
@@ -3845,6 +3880,7 @@ module i2c_reg_top
 
       racl_addr_hit_read[3]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       racl_addr_hit_read[4]: begin

--- a/hw/ip/keymgr/doc/registers.md
+++ b/hw/ip/keymgr/doc/registers.md
@@ -123,20 +123,21 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000003`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "recov_operation_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_fault_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 210}}
+{"reg": [{"name": "recov_operation_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_fault_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 29}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 210}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                | Description                                      |
-|:------:|:------:|:-------:|:--------------------|:-------------------------------------------------|
-|  31:2  |        |         |                     | Reserved                                         |
-|   1    |   wo   |   0x0   | fatal_fault_err     | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | recov_operation_err | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name                | Description                                            |
+|:------:|:------:|:-------:|:--------------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen              | Write 0 to disable alert testing until the next reset. |
+|  30:2  |        |         |                     | Reserved                                               |
+|   1    |   wo   |   0x0   | fatal_fault_err     | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | recov_operation_err | Write 1 to trigger one alert event of this kind.       |
 
 ## CFG_REGWEN
 Key manager configuration enable

--- a/hw/ip/keymgr/rtl/keymgr_reg_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_pkg.sv
@@ -402,9 +402,10 @@ package keymgr_reg_pkg;
   // Reset values for hwext registers and their fields
   parameter logic [0:0] KEYMGR_INTR_TEST_RESVAL = 1'h 0;
   parameter logic [0:0] KEYMGR_INTR_TEST_OP_DONE_RESVAL = 1'h 0;
-  parameter logic [1:0] KEYMGR_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [31:0] KEYMGR_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] KEYMGR_ALERT_TEST_RECOV_OPERATION_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] KEYMGR_ALERT_TEST_FATAL_FAULT_ERR_RESVAL = 1'h 0;
+  parameter logic [0:0] KEYMGR_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] KEYMGR_CFG_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] KEYMGR_CFG_REGWEN_EN_RESVAL = 1'h 1;
   parameter logic [0:0] KEYMGR_SW_BINDING_REGWEN_RESVAL = 1'h 1;
@@ -482,7 +483,7 @@ package keymgr_reg_pkg;
     4'b 0001, // index[ 0] KEYMGR_INTR_STATE
     4'b 0001, // index[ 1] KEYMGR_INTR_ENABLE
     4'b 0001, // index[ 2] KEYMGR_INTR_TEST
-    4'b 0001, // index[ 3] KEYMGR_ALERT_TEST
+    4'b 1111, // index[ 3] KEYMGR_ALERT_TEST
     4'b 0001, // index[ 4] KEYMGR_CFG_REGWEN
     4'b 0001, // index[ 5] KEYMGR_START
     4'b 0011, // index[ 6] KEYMGR_CONTROL_SHADOWED

--- a/hw/ip/keymgr/rtl/keymgr_reg_top.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_top.sv
@@ -136,6 +136,8 @@ module keymgr_reg_top (
   logic alert_test_we;
   logic alert_test_recov_operation_err_wd;
   logic alert_test_fatal_fault_err_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic cfg_regwen_re;
   logic cfg_regwen_qs;
   logic start_we;
@@ -441,14 +443,17 @@ module keymgr_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [1:0] alert_test_flds_we;
+  logic [2:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[recov_operation_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_recov_operation_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_operation_err_wd),
     .d      ('0),
     .qre    (),
@@ -464,7 +469,7 @@ module keymgr_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_fault_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_fault_err_wd),
     .d      ('0),
     .qre    (),
@@ -474,6 +479,33 @@ module keymgr_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_fault_err.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[2]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[cfg_regwen]: V(True)
@@ -3090,6 +3122,8 @@ module keymgr_reg_top (
   assign alert_test_recov_operation_err_wd = reg_wdata[0];
 
   assign alert_test_fatal_fault_err_wd = reg_wdata[1];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign cfg_regwen_re = addr_hit[4] & reg_re & !reg_error;
   assign start_we = addr_hit[5] & reg_we & !reg_error;
 
@@ -3372,6 +3406,7 @@ module keymgr_reg_top (
       addr_hit[3]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/ip/keymgr_dpe/doc/registers.md
+++ b/hw/ip/keymgr_dpe/doc/registers.md
@@ -114,20 +114,21 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000003`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "recov_operation_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_fault_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 210}}
+{"reg": [{"name": "recov_operation_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_fault_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 29}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 210}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                | Description                                      |
-|:------:|:------:|:-------:|:--------------------|:-------------------------------------------------|
-|  31:2  |        |         |                     | Reserved                                         |
-|   1    |   wo   |   0x0   | fatal_fault_err     | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | recov_operation_err | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name                | Description                                            |
+|:------:|:------:|:-------:|:--------------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen              | Write 0 to disable alert testing until the next reset. |
+|  30:2  |        |         |                     | Reserved                                               |
+|   1    |   wo   |   0x0   | fatal_fault_err     | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | recov_operation_err | Write 1 to trigger one alert event of this kind.       |
 
 ## CFG_REGWEN
 Key manager configuration enable

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_pkg.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_pkg.sv
@@ -433,9 +433,10 @@ package keymgr_dpe_reg_pkg;
   // Reset values for hwext registers and their fields
   parameter logic [0:0] KEYMGR_DPE_INTR_TEST_RESVAL = 1'h 0;
   parameter logic [0:0] KEYMGR_DPE_INTR_TEST_OP_DONE_RESVAL = 1'h 0;
-  parameter logic [1:0] KEYMGR_DPE_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [31:0] KEYMGR_DPE_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] KEYMGR_DPE_ALERT_TEST_RECOV_OPERATION_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] KEYMGR_DPE_ALERT_TEST_FATAL_FAULT_ERR_RESVAL = 1'h 0;
+  parameter logic [0:0] KEYMGR_DPE_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] KEYMGR_DPE_CFG_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] KEYMGR_DPE_CFG_REGWEN_EN_RESVAL = 1'h 1;
   parameter logic [0:0] KEYMGR_DPE_SLOT_POLICY_REGWEN_RESVAL = 1'h 1;
@@ -508,7 +509,7 @@ package keymgr_dpe_reg_pkg;
     4'b 0001, // index[ 0] KEYMGR_DPE_INTR_STATE
     4'b 0001, // index[ 1] KEYMGR_DPE_INTR_ENABLE
     4'b 0001, // index[ 2] KEYMGR_DPE_INTR_TEST
-    4'b 0001, // index[ 3] KEYMGR_DPE_ALERT_TEST
+    4'b 1111, // index[ 3] KEYMGR_DPE_ALERT_TEST
     4'b 0001, // index[ 4] KEYMGR_DPE_CFG_REGWEN
     4'b 0001, // index[ 5] KEYMGR_DPE_START
     4'b 0111, // index[ 6] KEYMGR_DPE_CONTROL_SHADOWED

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_top.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_top.sv
@@ -136,6 +136,8 @@ module keymgr_dpe_reg_top (
   logic alert_test_we;
   logic alert_test_recov_operation_err_wd;
   logic alert_test_fatal_fault_err_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic cfg_regwen_re;
   logic cfg_regwen_qs;
   logic start_we;
@@ -426,14 +428,17 @@ module keymgr_dpe_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [1:0] alert_test_flds_we;
+  logic [2:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[recov_operation_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_recov_operation_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_operation_err_wd),
     .d      ('0),
     .qre    (),
@@ -449,7 +454,7 @@ module keymgr_dpe_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_fault_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_fault_err_wd),
     .d      ('0),
     .qre    (),
@@ -459,6 +464,33 @@ module keymgr_dpe_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_fault_err.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[2]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[cfg_regwen]: V(True)
@@ -2914,6 +2946,8 @@ module keymgr_dpe_reg_top (
   assign alert_test_recov_operation_err_wd = reg_wdata[0];
 
   assign alert_test_fatal_fault_err_wd = reg_wdata[1];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign cfg_regwen_re = addr_hit[4] & reg_re & !reg_error;
   assign start_we = addr_hit[5] & reg_we & !reg_error;
 
@@ -3172,6 +3206,7 @@ module keymgr_dpe_reg_top (
       addr_hit[3]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/ip/kmac/doc/registers.md
+++ b/hw/ip/kmac/doc/registers.md
@@ -140,20 +140,21 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000003`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "recov_operation_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_fault_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 210}}
+{"reg": [{"name": "recov_operation_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_fault_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 29}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 210}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                | Description                                      |
-|:------:|:------:|:-------:|:--------------------|:-------------------------------------------------|
-|  31:2  |        |         |                     | Reserved                                         |
-|   1    |   wo   |   0x0   | fatal_fault_err     | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | recov_operation_err | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name                | Description                                            |
+|:------:|:------:|:-------:|:--------------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen              | Write 0 to disable alert testing until the next reset. |
+|  30:2  |        |         |                     | Reserved                                               |
+|   1    |   wo   |   0x0   | fatal_fault_err     | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | recov_operation_err | Write 1 to trigger one alert event of this kind.       |
 
 ## CFG_REGWEN
 Controls the configurability of [`CFG_SHADOWED`](#cfg_shadowed) register.

--- a/hw/ip/kmac/rtl/kmac_reg_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_pkg.sv
@@ -330,9 +330,10 @@ package kmac_reg_pkg;
   parameter logic [0:0] KMAC_INTR_TEST_KMAC_DONE_RESVAL = 1'h 0;
   parameter logic [0:0] KMAC_INTR_TEST_FIFO_EMPTY_RESVAL = 1'h 0;
   parameter logic [0:0] KMAC_INTR_TEST_KMAC_ERR_RESVAL = 1'h 0;
-  parameter logic [1:0] KMAC_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [31:0] KMAC_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] KMAC_ALERT_TEST_RECOV_OPERATION_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] KMAC_ALERT_TEST_FATAL_FAULT_ERR_RESVAL = 1'h 0;
+  parameter logic [0:0] KMAC_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] KMAC_CFG_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] KMAC_CFG_REGWEN_EN_RESVAL = 1'h 1;
   parameter logic [10:0] KMAC_CMD_RESVAL = 11'h 0;
@@ -449,7 +450,7 @@ package kmac_reg_pkg;
     4'b 0001, // index[ 0] KMAC_INTR_STATE
     4'b 0001, // index[ 1] KMAC_INTR_ENABLE
     4'b 0001, // index[ 2] KMAC_INTR_TEST
-    4'b 0001, // index[ 3] KMAC_ALERT_TEST
+    4'b 1111, // index[ 3] KMAC_ALERT_TEST
     4'b 0001, // index[ 4] KMAC_CFG_REGWEN
     4'b 1111, // index[ 5] KMAC_CFG_SHADOWED
     4'b 0011, // index[ 6] KMAC_CMD

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -197,6 +197,8 @@ module kmac_reg_top (
   logic alert_test_we;
   logic alert_test_recov_operation_err_wd;
   logic alert_test_fatal_fault_err_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic cfg_regwen_re;
   logic cfg_regwen_qs;
   logic cfg_shadowed_re;
@@ -596,14 +598,17 @@ module kmac_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [1:0] alert_test_flds_we;
+  logic [2:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[recov_operation_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_recov_operation_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_operation_err_wd),
     .d      ('0),
     .qre    (),
@@ -619,7 +624,7 @@ module kmac_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_fault_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_fault_err_wd),
     .d      ('0),
     .qre    (),
@@ -629,6 +634,33 @@ module kmac_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_fault_err.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[2]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[cfg_regwen]: V(True)
@@ -2739,6 +2771,8 @@ module kmac_reg_top (
   assign alert_test_recov_operation_err_wd = reg_wdata[0];
 
   assign alert_test_fatal_fault_err_wd = reg_wdata[1];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign cfg_regwen_re = addr_hit[4] & reg_re & !reg_error;
   assign cfg_shadowed_re = addr_hit[5] & reg_re & !reg_error;
   assign cfg_shadowed_we = addr_hit[5] & reg_we & !reg_error;
@@ -3005,6 +3039,7 @@ module kmac_reg_top (
       addr_hit[3]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/ip/lc_ctrl/doc/registers.md
+++ b/hw/ip/lc_ctrl/doc/registers.md
@@ -44,21 +44,22 @@
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0x0`
-- Reset default: `0x0`
-- Reset mask: `0x7`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000007`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_prog_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_state_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_bus_integ_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 29}], "config": {"lanes": 1, "fontsize": 10, "vspace": 230}}
+{"reg": [{"name": "fatal_prog_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_state_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_bus_integ_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 28}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 230}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                  | Description                                      |
-|:------:|:------:|:-------:|:----------------------|:-------------------------------------------------|
-|  31:3  |        |         |                       | Reserved                                         |
-|   2    |   wo   |   0x0   | fatal_bus_integ_error | Write 1 to trigger one alert event of this kind. |
-|   1    |   wo   |   0x0   | fatal_state_error     | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | fatal_prog_error      | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name                  | Description                                            |
+|:------:|:------:|:-------:|:----------------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen                | Write 0 to disable alert testing until the next reset. |
+|  30:3  |        |         |                       | Reserved                                               |
+|   2    |   wo   |   0x0   | fatal_bus_integ_error | Write 1 to trigger one alert event of this kind.       |
+|   1    |   wo   |   0x0   | fatal_state_error     | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | fatal_prog_error      | Write 1 to trigger one alert event of this kind.       |
 
 ## STATUS
 life cycle status register. Note that all errors are terminal and require a reset cycle.

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
@@ -268,10 +268,11 @@ package lc_ctrl_reg_pkg;
   parameter logic [RegsAw-1:0] LC_CTRL_MANUF_STATE_7_OFFSET = 8'h 88;
 
   // Reset values for hwext registers and their fields for regs interface
-  parameter logic [2:0] LC_CTRL_ALERT_TEST_RESVAL = 3'h 0;
+  parameter logic [31:0] LC_CTRL_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] LC_CTRL_ALERT_TEST_FATAL_PROG_ERROR_RESVAL = 1'h 0;
   parameter logic [0:0] LC_CTRL_ALERT_TEST_FATAL_STATE_ERROR_RESVAL = 1'h 0;
   parameter logic [0:0] LC_CTRL_ALERT_TEST_FATAL_BUS_INTEG_ERROR_RESVAL = 1'h 0;
+  parameter logic [0:0] LC_CTRL_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [11:0] LC_CTRL_STATUS_RESVAL = 12'h 0;
   parameter logic [7:0] LC_CTRL_CLAIM_TRANSITION_IF_RESVAL = 8'h 69;
   parameter logic [7:0] LC_CTRL_CLAIM_TRANSITION_IF_MUTEX_RESVAL = 8'h 69;
@@ -350,7 +351,7 @@ package lc_ctrl_reg_pkg;
 
   // Register width information to check illegal writes for regs interface
   parameter logic [3:0] LC_CTRL_REGS_PERMIT [35] = '{
-    4'b 0001, // index[ 0] LC_CTRL_ALERT_TEST
+    4'b 1111, // index[ 0] LC_CTRL_ALERT_TEST
     4'b 0011, // index[ 1] LC_CTRL_STATUS
     4'b 0001, // index[ 2] LC_CTRL_CLAIM_TRANSITION_IF_REGWEN
     4'b 0001, // index[ 3] LC_CTRL_CLAIM_TRANSITION_IF

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_regs_reg_top.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_regs_reg_top.sv
@@ -125,6 +125,8 @@ module lc_ctrl_regs_reg_top (
   logic alert_test_fatal_prog_error_wd;
   logic alert_test_fatal_state_error_wd;
   logic alert_test_fatal_bus_integ_error_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic status_re;
   logic status_initialized_qs;
   logic status_ready_qs;
@@ -229,14 +231,17 @@ module lc_ctrl_regs_reg_top (
   // Register instances
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [2:0] alert_test_flds_we;
+  logic [3:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[fatal_prog_error]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_fatal_prog_error (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_prog_error_wd),
     .d      ('0),
     .qre    (),
@@ -252,7 +257,7 @@ module lc_ctrl_regs_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_state_error (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_state_error_wd),
     .d      ('0),
     .qre    (),
@@ -268,7 +273,7 @@ module lc_ctrl_regs_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_bus_integ_error (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_bus_integ_error_wd),
     .d      ('0),
     .qre    (),
@@ -278,6 +283,33 @@ module lc_ctrl_regs_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_bus_integ_error.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[3]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[status]: V(True)
@@ -1224,6 +1256,8 @@ module lc_ctrl_regs_reg_top (
   assign alert_test_fatal_state_error_wd = reg_wdata[1];
 
   assign alert_test_fatal_bus_integ_error_wd = reg_wdata[2];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign status_re = addr_hit[1] & reg_re & !reg_error;
   assign claim_transition_if_regwen_we = addr_hit[2] & reg_we & !reg_error;
 
@@ -1336,6 +1370,7 @@ module lc_ctrl_regs_reg_top (
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
         reg_rdata_next[2] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[1]: begin

--- a/hw/ip/mbx/doc/registers.md
+++ b/hw/ip/mbx/doc/registers.md
@@ -83,20 +83,21 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000003`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 29}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:2  |        |         |             | Reserved                                         |
-|   1    |   wo   |   0x0   | recov_fault | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:2  |        |         |             | Reserved                                               |
+|   1    |   wo   |   0x0   | recov_fault | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## CONTROL
 DOE mailbox control register visible to OpenTitan

--- a/hw/ip/mbx/rtl/mbx_core_reg_top.sv
+++ b/hw/ip/mbx/rtl/mbx_core_reg_top.sv
@@ -153,6 +153,8 @@ module mbx_core_reg_top
   logic alert_test_we;
   logic alert_test_fatal_fault_wd;
   logic alert_test_recov_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic control_re;
   logic control_we;
   logic control_abort_qs;
@@ -417,14 +419,17 @@ module mbx_core_reg_top
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [1:0] alert_test_flds_we;
+  logic [2:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
@@ -440,7 +445,7 @@ module mbx_core_reg_top
     .DW    (1)
   ) u_alert_test_recov_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_fault_wd),
     .d      ('0),
     .qre    (),
@@ -450,6 +455,33 @@ module mbx_core_reg_top
     .qs     ()
   );
   assign reg2hw.alert_test.recov_fault.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[2]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[control]: V(True)
@@ -996,6 +1028,8 @@ module mbx_core_reg_top
   assign alert_test_fatal_fault_wd = reg_wdata[0];
 
   assign alert_test_recov_fault_wd = reg_wdata[1];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign control_re = racl_addr_hit_read[4] & reg_re & !reg_error;
   assign control_we = racl_addr_hit_write[4] & reg_we & !reg_error;
 
@@ -1077,6 +1111,7 @@ module mbx_core_reg_top
       racl_addr_hit_read[3]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       racl_addr_hit_read[4]: begin

--- a/hw/ip/mbx/rtl/mbx_reg_pkg.sv
+++ b/hw/ip/mbx/rtl/mbx_reg_pkg.sv
@@ -229,9 +229,10 @@ package mbx_reg_pkg;
   parameter logic [0:0] MBX_INTR_TEST_MBX_READY_RESVAL = 1'h 0;
   parameter logic [0:0] MBX_INTR_TEST_MBX_ABORT_RESVAL = 1'h 0;
   parameter logic [0:0] MBX_INTR_TEST_MBX_ERROR_RESVAL = 1'h 0;
-  parameter logic [1:0] MBX_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [31:0] MBX_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] MBX_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
   parameter logic [0:0] MBX_ALERT_TEST_RECOV_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] MBX_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [3:0] MBX_CONTROL_RESVAL = 4'h 0;
   parameter logic [0:0] MBX_CONTROL_ABORT_RESVAL = 1'h 0;
   parameter logic [0:0] MBX_CONTROL_ERROR_RESVAL = 1'h 0;
@@ -276,7 +277,7 @@ package mbx_reg_pkg;
     4'b 0001, // index[ 0] MBX_INTR_STATE
     4'b 0001, // index[ 1] MBX_INTR_ENABLE
     4'b 0001, // index[ 2] MBX_INTR_TEST
-    4'b 0001, // index[ 3] MBX_ALERT_TEST
+    4'b 1111, // index[ 3] MBX_ALERT_TEST
     4'b 0001, // index[ 4] MBX_CONTROL
     4'b 0001, // index[ 5] MBX_STATUS
     4'b 0001, // index[ 6] MBX_ADDRESS_RANGE_REGWEN

--- a/hw/ip/otbn/doc/registers.md
+++ b/hw/ip/otbn/doc/registers.md
@@ -73,20 +73,21 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000003`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "fatal", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 29}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name   | Description                                      |
-|:------:|:------:|:-------:|:-------|:-------------------------------------------------|
-|  31:2  |        |         |        | Reserved                                         |
-|   1    |   wo   |   0x0   | recov  | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | fatal  | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name   | Description                                            |
+|:------:|:------:|:-------:|:-------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen | Write 0 to disable alert testing until the next reset. |
+|  30:2  |        |         |        | Reserved                                               |
+|   1    |   wo   |   0x0   | recov  | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | fatal  | Write 1 to trigger one alert event of this kind.       |
 
 ## CMD
 Command Register

--- a/hw/ip/otbn/dv/otbnsim/sim/ext_regs.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/ext_regs.py
@@ -51,7 +51,7 @@ class RGField:
                  reset_value: int,
                  swaccess: str):
         # We only support some values of swaccess (the ones we need)
-        assert swaccess in ['rw1c', 'rw', 'wo', 'r0w1c', 'ro']
+        assert swaccess in ['rw1c', 'rw0c', 'rw', 'wo', 'r0w1c', 'ro']
         assert width > 0
         assert lsb >= 0
 
@@ -62,6 +62,7 @@ class RGField:
 
         # swaccess
         self.w1c = swaccess in ['rw1c', 'r0w1c']
+        self.w0c = swaccess == 'rw0c'
         self.read_only = swaccess == 'ro'
         self.read_zero = swaccess in ['wo', 'r0w1c']
 
@@ -98,6 +99,8 @@ class RGField:
             pass
         elif self.w1c and not from_hw:
             self.next_value &= ~masked
+        elif self.w0c and not from_hw:
+            self.next_value &= masked
         else:
             self.next_value = masked
 

--- a/hw/ip/otbn/rtl/otbn_reg_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_pkg.sv
@@ -291,9 +291,10 @@ package otbn_reg_pkg;
   // Reset values for hwext registers and their fields
   parameter logic [0:0] OTBN_INTR_TEST_RESVAL = 1'h 0;
   parameter logic [0:0] OTBN_INTR_TEST_DONE_RESVAL = 1'h 0;
-  parameter logic [1:0] OTBN_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [31:0] OTBN_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] OTBN_ALERT_TEST_FATAL_RESVAL = 1'h 0;
   parameter logic [0:0] OTBN_ALERT_TEST_RECOV_RESVAL = 1'h 0;
+  parameter logic [0:0] OTBN_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [7:0] OTBN_CMD_RESVAL = 8'h 0;
   parameter logic [7:0] OTBN_CMD_CMD_RESVAL = 8'h 0;
   parameter logic [0:0] OTBN_CTRL_RESVAL = 1'h 0;
@@ -349,7 +350,7 @@ package otbn_reg_pkg;
     4'b 0001, // index[ 0] OTBN_INTR_STATE
     4'b 0001, // index[ 1] OTBN_INTR_ENABLE
     4'b 0001, // index[ 2] OTBN_INTR_TEST
-    4'b 0001, // index[ 3] OTBN_ALERT_TEST
+    4'b 1111, // index[ 3] OTBN_ALERT_TEST
     4'b 0001, // index[ 4] OTBN_CMD
     4'b 0001, // index[ 5] OTBN_CTRL
     4'b 0001, // index[ 6] OTBN_STATUS

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -184,6 +184,8 @@ module otbn_reg_top (
   logic alert_test_we;
   logic alert_test_fatal_wd;
   logic alert_test_recov_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic cmd_we;
   logic [7:0] cmd_wd;
   logic ctrl_re;
@@ -323,14 +325,17 @@ module otbn_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [1:0] alert_test_flds_we;
+  logic [2:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[fatal]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_fatal (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_wd),
     .d      ('0),
     .qre    (),
@@ -346,7 +351,7 @@ module otbn_reg_top (
     .DW    (1)
   ) u_alert_test_recov (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_wd),
     .d      ('0),
     .qre    (),
@@ -356,6 +361,33 @@ module otbn_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.recov.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[2]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[cmd]: V(True)
@@ -1010,6 +1042,8 @@ module otbn_reg_top (
   assign alert_test_fatal_wd = reg_wdata[0];
 
   assign alert_test_recov_wd = reg_wdata[1];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign cmd_we = addr_hit[4] & reg_we & !reg_error;
 
   assign cmd_wd = reg_wdata[7:0];
@@ -1096,6 +1130,7 @@ module otbn_reg_top (
       addr_hit[3]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/ip/pattgen/doc/registers.md
+++ b/hw/ip/pattgen/doc/registers.md
@@ -75,19 +75,20 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## CTRL
 PATTGEN control register

--- a/hw/ip/pattgen/rtl/pattgen_reg_pkg.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_pkg.sv
@@ -165,8 +165,9 @@ package pattgen_reg_pkg;
   parameter logic [1:0] PATTGEN_INTR_TEST_RESVAL = 2'h 0;
   parameter logic [0:0] PATTGEN_INTR_TEST_DONE_CH0_RESVAL = 1'h 0;
   parameter logic [0:0] PATTGEN_INTR_TEST_DONE_CH1_RESVAL = 1'h 0;
-  parameter logic [0:0] PATTGEN_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] PATTGEN_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] PATTGEN_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] PATTGEN_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
 
   // Register index
   typedef enum int {
@@ -189,7 +190,7 @@ package pattgen_reg_pkg;
     4'b 0001, // index[ 0] PATTGEN_INTR_STATE
     4'b 0001, // index[ 1] PATTGEN_INTR_ENABLE
     4'b 0001, // index[ 2] PATTGEN_INTR_TEST
-    4'b 0001, // index[ 3] PATTGEN_ALERT_TEST
+    4'b 1111, // index[ 3] PATTGEN_ALERT_TEST
     4'b 0001, // index[ 4] PATTGEN_CTRL
     4'b 1111, // index[ 5] PATTGEN_PREDIV_CH0
     4'b 1111, // index[ 6] PATTGEN_PREDIV_CH1

--- a/hw/ip/pattgen/rtl/pattgen_reg_top.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_top.sv
@@ -135,7 +135,9 @@ module pattgen_reg_top (
   logic intr_test_done_ch0_wd;
   logic intr_test_done_ch1_wd;
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic ctrl_we;
   logic ctrl_enable_ch0_qs;
   logic ctrl_enable_ch0_wd;
@@ -333,14 +335,18 @@ module pattgen_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -349,6 +355,33 @@ module pattgen_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[ctrl]: V(False)
@@ -905,7 +938,9 @@ module pattgen_reg_top (
   assign intr_test_done_ch1_wd = reg_wdata[1];
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign ctrl_we = addr_hit[4] & reg_we & !reg_error;
 
   assign ctrl_enable_ch0_wd = reg_wdata[0];
@@ -988,6 +1023,7 @@ module pattgen_reg_top (
 
       addr_hit[3]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/ip/rom_ctrl/doc/registers.md
+++ b/hw/ip/rom_ctrl/doc/registers.md
@@ -27,19 +27,20 @@
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0x0`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "fatal", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name   | Description                                      |
-|:------:|:------:|:-------:|:-------|:-------------------------------------------------|
-|  31:1  |        |         |        | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal  | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name   | Description                                            |
+|:------:|:------:|:-------:|:-------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |        | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal  | Write 1 to trigger one alert event of this kind.       |
 
 ## FATAL_ALERT_CAUSE
 The cause of a fatal alert.

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_reg_pkg.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_reg_pkg.sv
@@ -93,8 +93,9 @@ package rom_ctrl_reg_pkg;
   parameter logic [RegsAw-1:0] ROM_CTRL_EXP_DIGEST_7_OFFSET = 7'h 44;
 
   // Reset values for hwext registers and their fields for regs interface
-  parameter logic [0:0] ROM_CTRL_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] ROM_CTRL_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] ROM_CTRL_ALERT_TEST_FATAL_RESVAL = 1'h 0;
+  parameter logic [0:0] ROM_CTRL_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
 
   // Register index for regs interface
   typedef enum int {
@@ -120,7 +121,7 @@ package rom_ctrl_reg_pkg;
 
   // Register width information to check illegal writes for regs interface
   parameter logic [3:0] ROM_CTRL_REGS_PERMIT [18] = '{
-    4'b 0001, // index[ 0] ROM_CTRL_ALERT_TEST
+    4'b 1111, // index[ 0] ROM_CTRL_ALERT_TEST
     4'b 0001, // index[ 1] ROM_CTRL_FATAL_ALERT_CAUSE
     4'b 1111, // index[ 2] ROM_CTRL_DIGEST_0
     4'b 1111, // index[ 3] ROM_CTRL_DIGEST_1

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_regs_reg_top.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_regs_reg_top.sv
@@ -122,7 +122,9 @@ module rom_ctrl_regs_reg_top (
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic fatal_alert_cause_checker_error_qs;
   logic fatal_alert_cause_integrity_error_qs;
   logic [31:0] digest_0_qs;
@@ -145,14 +147,18 @@ module rom_ctrl_regs_reg_top (
   // Register instances
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -161,6 +167,33 @@ module rom_ctrl_regs_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[fatal_alert_cause]: V(False)
@@ -734,7 +767,9 @@ module rom_ctrl_regs_reg_top (
   // Generate write-enables
   assign alert_test_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
 
   // Assign write-enables to checker logic vector.
   always_comb begin
@@ -764,6 +799,7 @@ module rom_ctrl_regs_reg_top (
     unique case (1'b1)
       addr_hit[0]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[1]: begin

--- a/hw/ip/rram_ctrl/rtl/rram_ctrl_core_reg_top.sv
+++ b/hw/ip/rram_ctrl/rtl/rram_ctrl_core_reg_top.sv
@@ -208,6 +208,8 @@ module rram_ctrl_core_reg_top (
   logic alert_test_fatal_err_wd;
   logic alert_test_fatal_macro_err_wd;
   logic alert_test_recov_macro_err_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic dis_we;
   logic [3:0] dis_sw_dis_qs;
   logic [3:0] dis_sw_dis_wd;
@@ -1020,14 +1022,17 @@ module rram_ctrl_core_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [4:0] alert_test_flds_we;
+  logic [5:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[recov_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_recov_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_err_wd),
     .d      ('0),
     .qre    (),
@@ -1043,7 +1048,7 @@ module rram_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_std_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_std_err_wd),
     .d      ('0),
     .qre    (),
@@ -1059,7 +1064,7 @@ module rram_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_err_wd),
     .d      ('0),
     .qre    (),
@@ -1075,7 +1080,7 @@ module rram_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_macro_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_macro_err_wd),
     .d      ('0),
     .qre    (),
@@ -1091,7 +1096,7 @@ module rram_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_recov_macro_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_macro_err_wd),
     .d      ('0),
     .qre    (),
@@ -1101,6 +1106,33 @@ module rram_ctrl_core_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.recov_macro_err.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[5]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[dis]: V(False)
@@ -6368,6 +6400,8 @@ module rram_ctrl_core_reg_top (
   assign alert_test_fatal_macro_err_wd = reg_wdata[3];
 
   assign alert_test_recov_macro_err_wd = reg_wdata[4];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign dis_we = addr_hit[4] & reg_we & !reg_error;
 
   assign dis_sw_dis_wd = reg_wdata[3:0];
@@ -6817,6 +6851,7 @@ module rram_ctrl_core_reg_top (
         reg_rdata_next[2] = '0;
         reg_rdata_next[3] = '0;
         reg_rdata_next[4] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/ip/rram_ctrl/rtl/rram_ctrl_reg_pkg.sv
+++ b/hw/ip/rram_ctrl/rtl/rram_ctrl_reg_pkg.sv
@@ -724,12 +724,13 @@ package rram_ctrl_reg_pkg;
   parameter logic [0:0] RRAM_CTRL_INTR_TEST_RD_LVL_RESVAL = 1'h 0;
   parameter logic [0:0] RRAM_CTRL_INTR_TEST_OP_DONE_RESVAL = 1'h 0;
   parameter logic [0:0] RRAM_CTRL_INTR_TEST_CORR_ERR_RESVAL = 1'h 0;
-  parameter logic [4:0] RRAM_CTRL_ALERT_TEST_RESVAL = 5'h 0;
+  parameter logic [31:0] RRAM_CTRL_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] RRAM_CTRL_ALERT_TEST_RECOV_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] RRAM_CTRL_ALERT_TEST_FATAL_STD_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] RRAM_CTRL_ALERT_TEST_FATAL_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] RRAM_CTRL_ALERT_TEST_FATAL_MACRO_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] RRAM_CTRL_ALERT_TEST_RECOV_MACRO_ERR_RESVAL = 1'h 0;
+  parameter logic [0:0] RRAM_CTRL_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] RRAM_CTRL_CTRL_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] RRAM_CTRL_CTRL_REGWEN_EN_RESVAL = 1'h 1;
   parameter logic [1:0] RRAM_CTRL_FIFO_CLR_RESVAL = 2'h 0;
@@ -822,7 +823,7 @@ package rram_ctrl_reg_pkg;
     4'b 0001, // index[ 0] RRAM_CTRL_INTR_STATE
     4'b 0001, // index[ 1] RRAM_CTRL_INTR_ENABLE
     4'b 0001, // index[ 2] RRAM_CTRL_INTR_TEST
-    4'b 0001, // index[ 3] RRAM_CTRL_ALERT_TEST
+    4'b 1111, // index[ 3] RRAM_CTRL_ALERT_TEST
     4'b 0001, // index[ 4] RRAM_CTRL_DIS
     4'b 1111, // index[ 5] RRAM_CTRL_EXEC
     4'b 0001, // index[ 6] RRAM_CTRL_INIT

--- a/hw/ip/rv_dm/doc/registers.md
+++ b/hw/ip/rv_dm/doc/registers.md
@@ -12,19 +12,20 @@
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0x0`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## LATE_DEBUG_ENABLE_REGWEN
 Lock bit for [`LATE_DEBUG_ENABLE`](#late_debug_enable) register.

--- a/hw/ip/rv_dm/rtl/rv_dm_reg_pkg.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm_reg_pkg.sv
@@ -50,8 +50,9 @@ package rv_dm_reg_pkg;
   parameter logic [RegsAw-1:0] RV_DM_LATE_DEBUG_ENABLE_OFFSET = 4'h 8;
 
   // Reset values for hwext registers and their fields for regs interface
-  parameter logic [0:0] RV_DM_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] RV_DM_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] RV_DM_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] RV_DM_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
 
   // Register index for regs interface
   typedef enum int {
@@ -62,7 +63,7 @@ package rv_dm_reg_pkg;
 
   // Register width information to check illegal writes for regs interface
   parameter logic [3:0] RV_DM_REGS_PERMIT [3] = '{
-    4'b 0001, // index[0] RV_DM_ALERT_TEST
+    4'b 1111, // index[0] RV_DM_ALERT_TEST
     4'b 0001, // index[1] RV_DM_LATE_DEBUG_ENABLE_REGWEN
     4'b 1111  // index[2] RV_DM_LATE_DEBUG_ENABLE
   };

--- a/hw/ip/rv_dm/rtl/rv_dm_regs_reg_top.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm_regs_reg_top.sv
@@ -132,7 +132,9 @@ module rv_dm_regs_reg_top
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic late_debug_enable_regwen_we;
   logic late_debug_enable_regwen_qs;
   logic late_debug_enable_regwen_wd;
@@ -143,14 +145,18 @@ module rv_dm_regs_reg_top
   // Register instances
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -159,6 +165,33 @@ module rv_dm_regs_reg_top
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[late_debug_enable_regwen]: V(False)
@@ -293,7 +326,9 @@ module rv_dm_regs_reg_top
   // Generate write-enables
   assign alert_test_we = racl_addr_hit_write[0] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign late_debug_enable_regwen_we = racl_addr_hit_write[1] & reg_we & !reg_error;
 
   assign late_debug_enable_regwen_wd = reg_wdata[0];
@@ -314,6 +349,7 @@ module rv_dm_regs_reg_top
     unique case (1'b1)
       racl_addr_hit_read[0]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       racl_addr_hit_read[1]: begin

--- a/hw/ip/rv_timer/doc/registers.md
+++ b/hw/ip/rv_timer/doc/registers.md
@@ -19,19 +19,20 @@
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0x0`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## CTRL
 Control register

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_pkg.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_pkg.sv
@@ -124,8 +124,9 @@ package rv_timer_reg_pkg;
   parameter logic [BlockAw-1:0] RV_TIMER_COMPARE_UPPER0_0_OFFSET = 9'h 11c;
 
   // Reset values for hwext registers and their fields
-  parameter logic [0:0] RV_TIMER_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] RV_TIMER_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] RV_TIMER_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] RV_TIMER_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] RV_TIMER_INTR_TEST0_RESVAL = 1'h 0;
 
   // Register index
@@ -144,7 +145,7 @@ package rv_timer_reg_pkg;
 
   // Register width information to check illegal writes
   parameter logic [3:0] RV_TIMER_PERMIT [10] = '{
-    4'b 0001, // index[0] RV_TIMER_ALERT_TEST
+    4'b 1111, // index[0] RV_TIMER_ALERT_TEST
     4'b 0001, // index[1] RV_TIMER_CTRL
     4'b 0001, // index[2] RV_TIMER_INTR_ENABLE0
     4'b 0001, // index[3] RV_TIMER_INTR_STATE0

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
@@ -133,7 +133,9 @@ module rv_timer_reg_top
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic ctrl_we;
   logic ctrl_qs;
   logic ctrl_wd;
@@ -166,14 +168,18 @@ module rv_timer_reg_top
   // Register instances
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -182,6 +188,33 @@ module rv_timer_reg_top
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // Subregister 0 of Multireg ctrl
@@ -571,7 +604,9 @@ module rv_timer_reg_top
   // Generate write-enables
   assign alert_test_we = racl_addr_hit_write[0] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign ctrl_we = racl_addr_hit_write[1] & reg_we & !reg_error;
 
   assign ctrl_wd = reg_wdata[0];
@@ -622,6 +657,7 @@ module rv_timer_reg_top
     unique case (1'b1)
       racl_addr_hit_read[0]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       racl_addr_hit_read[1]: begin

--- a/hw/ip/soc_dbg_ctrl/doc/registers.md
+++ b/hw/ip/soc_dbg_ctrl/doc/registers.md
@@ -20,20 +20,21 @@ Depending on the configured debug category, a consumer might accept the debug co
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0x0`
-- Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000003`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_ctrl_update_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 230}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_ctrl_update_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 29}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 230}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                  | Description                                      |
-|:------:|:------:|:-------:|:----------------------|:-------------------------------------------------|
-|  31:2  |        |         |                       | Reserved                                         |
-|   1    |   wo   |   0x0   | recov_ctrl_update_err | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | fatal_fault           | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name                  | Description                                            |
+|:------:|:------:|:-------:|:----------------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen                | Write 0 to disable alert testing until the next reset. |
+|  30:2  |        |         |                       | Reserved                                               |
+|   1    |   wo   |   0x0   | recov_ctrl_update_err | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | fatal_fault           | Write 1 to trigger one alert event of this kind.       |
 
 ## DEBUG_POLICY_VALID_SHADOWED
 Debug Policy Valid.

--- a/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_core_reg_top.sv
+++ b/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_core_reg_top.sv
@@ -128,6 +128,8 @@ module soc_dbg_ctrl_core_reg_top (
   logic alert_test_we;
   logic alert_test_fatal_fault_wd;
   logic alert_test_recov_ctrl_update_err_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic debug_policy_valid_shadowed_re;
   logic debug_policy_valid_shadowed_we;
   logic [3:0] debug_policy_valid_shadowed_qs;
@@ -159,14 +161,17 @@ module soc_dbg_ctrl_core_reg_top (
   // Register instances
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [1:0] alert_test_flds_we;
+  logic [2:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
@@ -182,7 +187,7 @@ module soc_dbg_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_recov_ctrl_update_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_ctrl_update_err_wd),
     .d      ('0),
     .qre    (),
@@ -192,6 +197,33 @@ module soc_dbg_ctrl_core_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.recov_ctrl_update_err.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[2]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[debug_policy_valid_shadowed]: V(False)
@@ -532,6 +564,8 @@ module soc_dbg_ctrl_core_reg_top (
   assign alert_test_fatal_fault_wd = reg_wdata[0];
 
   assign alert_test_recov_ctrl_update_err_wd = reg_wdata[1];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign debug_policy_valid_shadowed_re = addr_hit[1] & reg_re & !reg_error;
   assign debug_policy_valid_shadowed_we = addr_hit[1] & reg_we & !reg_error;
 
@@ -573,6 +607,7 @@ module soc_dbg_ctrl_core_reg_top (
       addr_hit[0]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[1]: begin

--- a/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_reg_pkg.sv
+++ b/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_reg_pkg.sv
@@ -119,9 +119,10 @@ package soc_dbg_ctrl_reg_pkg;
   parameter logic [CoreAw-1:0] SOC_DBG_CTRL_STATUS_OFFSET = 5'h 18;
 
   // Reset values for hwext registers and their fields for core interface
-  parameter logic [1:0] SOC_DBG_CTRL_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [31:0] SOC_DBG_CTRL_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] SOC_DBG_CTRL_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
   parameter logic [0:0] SOC_DBG_CTRL_ALERT_TEST_RECOV_CTRL_UPDATE_ERR_RESVAL = 1'h 0;
+  parameter logic [0:0] SOC_DBG_CTRL_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [6:0] SOC_DBG_CTRL_DEBUG_POLICY_CATEGORY_SHADOWED_RESVAL = 7'h 50;
   parameter logic [6:0]
       SOC_DBG_CTRL_DEBUG_POLICY_CATEGORY_SHADOWED_DEBUG_POLICY_CATEGORY_RESVAL =
@@ -140,7 +141,7 @@ package soc_dbg_ctrl_reg_pkg;
 
   // Register width information to check illegal writes for core interface
   parameter logic [3:0] SOC_DBG_CTRL_CORE_PERMIT [7] = '{
-    4'b 0001, // index[0] SOC_DBG_CTRL_ALERT_TEST
+    4'b 1111, // index[0] SOC_DBG_CTRL_ALERT_TEST
     4'b 0001, // index[1] SOC_DBG_CTRL_DEBUG_POLICY_VALID_SHADOWED
     4'b 0001, // index[2] SOC_DBG_CTRL_DEBUG_POLICY_CATEGORY_SHADOWED
     4'b 0001, // index[3] SOC_DBG_CTRL_DEBUG_POLICY_RELOCKED

--- a/hw/ip/spi_device/doc/registers.md
+++ b/hw/ip/spi_device/doc/registers.md
@@ -156,19 +156,20 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## CONTROL
 Control register

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -742,8 +742,9 @@ package spi_device_reg_pkg;
   parameter logic [0:0] SPI_DEVICE_INTR_TEST_TPM_HEADER_NOT_EMPTY_RESVAL = 1'h 0;
   parameter logic [0:0] SPI_DEVICE_INTR_TEST_TPM_RDFIFO_CMD_END_RESVAL = 1'h 0;
   parameter logic [0:0] SPI_DEVICE_INTR_TEST_TPM_RDFIFO_DROP_RESVAL = 1'h 0;
-  parameter logic [0:0] SPI_DEVICE_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] SPI_DEVICE_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] SPI_DEVICE_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] SPI_DEVICE_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [6:0] SPI_DEVICE_STATUS_RESVAL = 7'h 60;
   parameter logic [0:0] SPI_DEVICE_STATUS_CSB_RESVAL = 1'h 1;
   parameter logic [0:0] SPI_DEVICE_STATUS_TPM_CSB_RESVAL = 1'h 1;
@@ -846,7 +847,7 @@ package spi_device_reg_pkg;
     4'b 0001, // index[ 0] SPI_DEVICE_INTR_STATE
     4'b 0001, // index[ 1] SPI_DEVICE_INTR_ENABLE
     4'b 0001, // index[ 2] SPI_DEVICE_INTR_TEST
-    4'b 0001, // index[ 3] SPI_DEVICE_ALERT_TEST
+    4'b 1111, // index[ 3] SPI_DEVICE_ALERT_TEST
     4'b 0001, // index[ 4] SPI_DEVICE_CONTROL
     4'b 1111, // index[ 5] SPI_DEVICE_CFG
     4'b 0001, // index[ 6] SPI_DEVICE_STATUS

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -227,7 +227,9 @@ module spi_device_reg_top
   logic intr_test_tpm_rdfifo_cmd_end_wd;
   logic intr_test_tpm_rdfifo_drop_wd;
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic control_we;
   logic control_flash_status_fifo_clr_qs;
   logic control_flash_status_fifo_clr_wd;
@@ -2132,14 +2134,18 @@ module spi_device_reg_top
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -2148,6 +2154,33 @@ module spi_device_reg_top
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[control]: V(False)
@@ -19731,7 +19764,9 @@ module spi_device_reg_top
   assign intr_test_tpm_rdfifo_drop_wd = reg_wdata[7];
   assign alert_test_we = racl_addr_hit_write[3] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign control_we = racl_addr_hit_write[4] & reg_we & !reg_error;
 
   assign control_flash_status_fifo_clr_wd = reg_wdata[0];
@@ -21158,6 +21193,7 @@ module spi_device_reg_top
 
       racl_addr_hit_read[3]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       racl_addr_hit_read[4]: begin

--- a/hw/ip/spi_host/doc/registers.md
+++ b/hw/ip/spi_host/doc/registers.md
@@ -77,19 +77,20 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## CONTROL
 Control register

--- a/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
@@ -324,8 +324,9 @@ package spi_host_reg_pkg;
   parameter logic [1:0] SPI_HOST_INTR_TEST_RESVAL = 2'h 0;
   parameter logic [0:0] SPI_HOST_INTR_TEST_ERROR_RESVAL = 1'h 0;
   parameter logic [0:0] SPI_HOST_INTR_TEST_SPI_EVENT_RESVAL = 1'h 0;
-  parameter logic [0:0] SPI_HOST_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] SPI_HOST_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] SPI_HOST_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] SPI_HOST_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [24:0] SPI_HOST_COMMAND_RESVAL = 25'h 0;
   parameter logic [0:0] SPI_HOST_COMMAND_CSAAT_RESVAL = 1'h 0;
   parameter logic [1:0] SPI_HOST_COMMAND_SPEED_RESVAL = 2'h 0;
@@ -361,7 +362,7 @@ package spi_host_reg_pkg;
     4'b 0001, // index[ 0] SPI_HOST_INTR_STATE
     4'b 0001, // index[ 1] SPI_HOST_INTR_ENABLE
     4'b 0001, // index[ 2] SPI_HOST_INTR_TEST
-    4'b 0001, // index[ 3] SPI_HOST_ALERT_TEST
+    4'b 1111, // index[ 3] SPI_HOST_ALERT_TEST
     4'b 1111, // index[ 4] SPI_HOST_CONTROL
     4'b 1111, // index[ 5] SPI_HOST_STATUS
     4'b 1111, // index[ 6] SPI_HOST_CONFIGOPTS

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -197,7 +197,9 @@ module spi_host_reg_top
   logic intr_test_error_wd;
   logic intr_test_spi_event_wd;
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic control_we;
   logic [7:0] control_rx_watermark_qs;
   logic [7:0] control_rx_watermark_wd;
@@ -436,14 +438,18 @@ module spi_host_reg_top
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -452,6 +458,33 @@ module spi_host_reg_top
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[control]: V(False)
@@ -1828,7 +1861,9 @@ module spi_host_reg_top
   assign intr_test_spi_event_wd = reg_wdata[1];
   assign alert_test_we = racl_addr_hit_write[3] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign control_we = racl_addr_hit_write[4] & reg_we & !reg_error;
 
   assign control_rx_watermark_wd = reg_wdata[7:0];
@@ -1942,6 +1977,7 @@ module spi_host_reg_top
 
       racl_addr_hit_read[3]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       racl_addr_hit_read[4]: begin

--- a/hw/ip/sram_ctrl/doc/registers.md
+++ b/hw/ip/sram_ctrl/doc/registers.md
@@ -18,19 +18,20 @@
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0x0`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_error | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_error | Write 1 to trigger one alert event of this kind.       |
 
 ## STATUS
 SRAM status register.

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_pkg.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_pkg.sv
@@ -139,8 +139,9 @@ package sram_ctrl_reg_pkg;
   parameter logic [RegsAw-1:0] SRAM_CTRL_READBACK_OFFSET = 6'h 20;
 
   // Reset values for hwext registers and their fields for regs interface
-  parameter logic [0:0] SRAM_CTRL_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] SRAM_CTRL_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] SRAM_CTRL_ALERT_TEST_FATAL_ERROR_RESVAL = 1'h 0;
+  parameter logic [0:0] SRAM_CTRL_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
 
   // Register index for regs interface
   typedef enum int {
@@ -157,7 +158,7 @@ package sram_ctrl_reg_pkg;
 
   // Register width information to check illegal writes for regs interface
   parameter logic [3:0] SRAM_CTRL_REGS_PERMIT [9] = '{
-    4'b 0001, // index[0] SRAM_CTRL_ALERT_TEST
+    4'b 1111, // index[0] SRAM_CTRL_ALERT_TEST
     4'b 0001, // index[1] SRAM_CTRL_STATUS
     4'b 0001, // index[2] SRAM_CTRL_EXEC_REGWEN
     4'b 0001, // index[3] SRAM_CTRL_EXEC

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
@@ -133,7 +133,9 @@ module sram_ctrl_regs_reg_top
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_error_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic status_bus_integ_error_qs;
   logic status_init_error_qs;
   logic status_escalated_qs;
@@ -167,14 +169,18 @@ module sram_ctrl_regs_reg_top
   // Register instances
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_error]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_error (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_error_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -183,6 +189,33 @@ module sram_ctrl_regs_reg_top
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[status]: V(False)
@@ -734,7 +767,9 @@ module sram_ctrl_regs_reg_top
   // Generate write-enables
   assign alert_test_we = racl_addr_hit_write[0] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_error_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign exec_regwen_we = racl_addr_hit_write[2] & reg_we & !reg_error;
 
   assign exec_regwen_wd = reg_wdata[0];
@@ -778,6 +813,7 @@ module sram_ctrl_regs_reg_top
     unique case (1'b1)
       racl_addr_hit_read[0]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       racl_addr_hit_read[1]: begin

--- a/hw/ip/sysrst_ctrl/doc/registers.md
+++ b/hw/ip/sysrst_ctrl/doc/registers.md
@@ -103,19 +103,20 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## REGWEN
 Configuration write enable control register

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_pkg.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_pkg.sv
@@ -632,8 +632,9 @@ package sysrst_ctrl_reg_pkg;
   // Reset values for hwext registers and their fields
   parameter logic [0:0] SYSRST_CTRL_INTR_TEST_RESVAL = 1'h 0;
   parameter logic [0:0] SYSRST_CTRL_INTR_TEST_EVENT_DETECTED_RESVAL = 1'h 0;
-  parameter logic [0:0] SYSRST_CTRL_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] SYSRST_CTRL_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] SYSRST_CTRL_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] SYSRST_CTRL_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
 
   // Register index
   typedef enum int {
@@ -687,7 +688,7 @@ package sysrst_ctrl_reg_pkg;
     4'b 0001, // index[ 0] SYSRST_CTRL_INTR_STATE
     4'b 0001, // index[ 1] SYSRST_CTRL_INTR_ENABLE
     4'b 0001, // index[ 2] SYSRST_CTRL_INTR_TEST
-    4'b 0001, // index[ 3] SYSRST_CTRL_ALERT_TEST
+    4'b 1111, // index[ 3] SYSRST_CTRL_ALERT_TEST
     4'b 0001, // index[ 4] SYSRST_CTRL_REGWEN
     4'b 0011, // index[ 5] SYSRST_CTRL_EC_RST_CTL
     4'b 0011, // index[ 6] SYSRST_CTRL_ULP_AC_DEBOUNCE_CTL

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
@@ -130,7 +130,9 @@ module sysrst_ctrl_reg_top (
   logic intr_test_we;
   logic intr_test_wd;
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic regwen_we;
   logic regwen_qs;
   logic regwen_wd;
@@ -1900,14 +1902,18 @@ module sysrst_ctrl_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -1916,6 +1922,33 @@ module sysrst_ctrl_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[regwen]: V(False)
@@ -6659,7 +6692,9 @@ module sysrst_ctrl_reg_top (
   assign intr_test_wd = reg_wdata[0];
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign regwen_we = addr_hit[4] & reg_we & !reg_error;
 
   assign regwen_wd = reg_wdata[0];
@@ -6941,6 +6976,7 @@ module sysrst_ctrl_reg_top (
 
       addr_hit[3]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/ip/uart/doc/registers.md
+++ b/hw/ip/uart/doc/registers.md
@@ -97,19 +97,20 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## CTRL
 UART control register

--- a/hw/ip/uart/rtl/uart_reg_pkg.sv
+++ b/hw/ip/uart/rtl/uart_reg_pkg.sv
@@ -373,8 +373,9 @@ package uart_reg_pkg;
   parameter logic [0:0] UART_INTR_TEST_RX_TIMEOUT_RESVAL = 1'h 0;
   parameter logic [0:0] UART_INTR_TEST_RX_PARITY_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] UART_INTR_TEST_TX_EMPTY_RESVAL = 1'h 0;
-  parameter logic [0:0] UART_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] UART_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] UART_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] UART_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [5:0] UART_STATUS_RESVAL = 6'h 3c;
   parameter logic [0:0] UART_STATUS_TXEMPTY_RESVAL = 1'h 1;
   parameter logic [0:0] UART_STATUS_TXIDLE_RESVAL = 1'h 1;
@@ -406,7 +407,7 @@ package uart_reg_pkg;
     4'b 0011, // index[ 0] UART_INTR_STATE
     4'b 0011, // index[ 1] UART_INTR_ENABLE
     4'b 0011, // index[ 2] UART_INTR_TEST
-    4'b 0001, // index[ 3] UART_ALERT_TEST
+    4'b 1111, // index[ 3] UART_ALERT_TEST
     4'b 1111, // index[ 4] UART_CTRL
     4'b 0001, // index[ 5] UART_STATUS
     4'b 0001, // index[ 6] UART_RDATA

--- a/hw/ip/uart/rtl/uart_reg_top.sv
+++ b/hw/ip/uart/rtl/uart_reg_top.sv
@@ -178,7 +178,9 @@ module uart_reg_top
   logic intr_test_rx_parity_err_wd;
   logic intr_test_tx_empty_wd;
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic ctrl_we;
   logic ctrl_tx_qs;
   logic ctrl_tx_wd;
@@ -874,14 +876,18 @@ module uart_reg_top
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -890,6 +896,33 @@ module uart_reg_top
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[ctrl]: V(False)
@@ -1714,7 +1747,9 @@ module uart_reg_top
   assign intr_test_tx_empty_wd = reg_wdata[8];
   assign alert_test_we = racl_addr_hit_write[3] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign ctrl_we = racl_addr_hit_write[4] & reg_we & !reg_error;
 
   assign ctrl_tx_wd = reg_wdata[0];
@@ -1820,6 +1855,7 @@ module uart_reg_top
 
       racl_addr_hit_read[3]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       racl_addr_hit_read[4]: begin

--- a/hw/ip/usbdev/doc/registers.md
+++ b/hw/ip/usbdev/doc/registers.md
@@ -222,19 +222,20 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## usbctrl
 USB Control

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -924,8 +924,9 @@ package usbdev_reg_pkg;
   parameter logic [0:0] USBDEV_INTR_TEST_POWERED_RESVAL = 1'h 0;
   parameter logic [0:0] USBDEV_INTR_TEST_LINK_OUT_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] USBDEV_INTR_TEST_AV_SETUP_EMPTY_RESVAL = 1'h 0;
-  parameter logic [0:0] USBDEV_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] USBDEV_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] USBDEV_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] USBDEV_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [31:0] USBDEV_USBSTAT_RESVAL = 32'h 80000000;
   parameter logic [0:0] USBDEV_USBSTAT_RX_EMPTY_RESVAL = 1'h 1;
   parameter logic [4:0] USBDEV_AVOUTBUFFER_RESVAL = 5'h 0;
@@ -1022,7 +1023,7 @@ package usbdev_reg_pkg;
     4'b 0111, // index[ 0] USBDEV_INTR_STATE
     4'b 0111, // index[ 1] USBDEV_INTR_ENABLE
     4'b 0111, // index[ 2] USBDEV_INTR_TEST
-    4'b 0001, // index[ 3] USBDEV_ALERT_TEST
+    4'b 1111, // index[ 3] USBDEV_ALERT_TEST
     4'b 0111, // index[ 4] USBDEV_USBCTRL
     4'b 0011, // index[ 5] USBDEV_EP_OUT_ENABLE
     4'b 0011, // index[ 6] USBDEV_EP_IN_ENABLE

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -261,7 +261,9 @@ module usbdev_reg_top (
   logic intr_test_link_out_err_wd;
   logic intr_test_av_setup_empty_wd;
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic usbctrl_we;
   logic usbctrl_enable_qs;
   logic usbctrl_enable_wd;
@@ -2118,14 +2120,18 @@ module usbdev_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -2134,6 +2140,33 @@ module usbdev_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[usbctrl]: V(False)
@@ -8569,7 +8602,9 @@ module usbdev_reg_top (
   assign intr_test_av_setup_empty_wd = reg_wdata[17];
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign usbctrl_we = addr_hit[4] & reg_we & !reg_error;
 
   assign usbctrl_enable_wd = reg_wdata[0];
@@ -9164,6 +9199,7 @@ module usbdev_reg_top (
 
       addr_hit[3]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/ip_templates/racl_ctrl/data/racl_ctrl.hjson.tpl
+++ b/hw/ip_templates/racl_ctrl/data/racl_ctrl.hjson.tpl
@@ -193,6 +193,7 @@
       hwaccess: "hro",
       hwqe:     "True",
       hwext:    "True",
+      inregwen: "regwen",
       fields: [
         { bits: "0",
           name: "fatal_fault",
@@ -201,6 +202,13 @@
         { bits: "1",
           name: "recov_ctrl_update_err",
           desc: "'Write 1 to trigger one alert event of this kind.'",
+        }
+        { bits: "31",
+          name: "regwen",
+          swaccess: "rw0c",
+          hwaccess: "none",
+          resval: "1",
+          desc: "Write 0 to disable alert testing until the next reset.",
         }
       ],
     }

--- a/hw/ip_templates/rv_plic/data/rv_plic.hjson.tpl
+++ b/hw/ip_templates/rv_plic/data/rv_plic.hjson.tpl
@@ -239,10 +239,18 @@
       hwaccess: "hro",
       hwqe:     "True",
       hwext:    "True",
+      inregwen: "regwen",
       fields: [
         { bits: "0",
           name: "fatal_fault",
           desc: "'Write 1 to trigger one alert event of this kind.'",
+        }
+        { bits: "31",
+          name: "regwen",
+          swaccess: "rw0c",
+          hwaccess: "none",
+          resval: "1",
+          desc: "Write 0 to disable alert testing until the next reset.",
         }
       ],
     }

--- a/hw/top_darjeeling/ip/soc_proxy/rtl/soc_proxy_core_reg_top.sv
+++ b/hw/top_darjeeling/ip/soc_proxy/rtl/soc_proxy_core_reg_top.sv
@@ -121,20 +121,26 @@ module soc_proxy_core_reg_top (
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_alert_intg_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic dummy_qs;
 
   // Register instances
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_alert_intg]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_alert_intg (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_alert_intg_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -143,6 +149,33 @@ module soc_proxy_core_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[dummy]: V(False)
@@ -169,7 +202,9 @@ module soc_proxy_core_reg_top (
   // Generate write-enables
   assign alert_test_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_alert_intg_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
 
   // Assign write-enables to checker logic vector.
   always_comb begin
@@ -183,6 +218,7 @@ module soc_proxy_core_reg_top (
     unique case (1'b1)
       addr_hit[0]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[1]: begin

--- a/hw/top_darjeeling/ip/soc_proxy/rtl/soc_proxy_reg_pkg.sv
+++ b/hw/top_darjeeling/ip/soc_proxy/rtl/soc_proxy_reg_pkg.sv
@@ -39,8 +39,9 @@ package soc_proxy_reg_pkg;
   parameter logic [CoreAw-1:0] SOC_PROXY_DUMMY_OFFSET = 3'h 4;
 
   // Reset values for hwext registers and their fields for core interface
-  parameter logic [0:0] SOC_PROXY_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] SOC_PROXY_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] SOC_PROXY_ALERT_TEST_FATAL_ALERT_INTG_RESVAL = 1'h 0;
+  parameter logic [0:0] SOC_PROXY_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
 
   // Register index for core interface
   typedef enum int {
@@ -50,7 +51,7 @@ package soc_proxy_reg_pkg;
 
   // Register width information to check illegal writes for core interface
   parameter logic [3:0] SOC_PROXY_CORE_PERMIT [2] = '{
-    4'b 0001, // index[0] SOC_PROXY_ALERT_TEST
+    4'b 1111, // index[0] SOC_PROXY_ALERT_TEST
     4'b 0001  // index[1] SOC_PROXY_DUMMY
   };
 

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/doc/registers.md
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/doc/registers.md
@@ -228,20 +228,21 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000003`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "recov_ctrl_update_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 230}}
+{"reg": [{"name": "recov_ctrl_update_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 29}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 230}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                  | Description                                      |
-|:------:|:------:|:-------:|:----------------------|:-------------------------------------------------|
-|  31:2  |        |         |                       | Reserved                                         |
-|   1    |   wo   |   0x0   | fatal_fault           | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | recov_ctrl_update_err | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name                  | Description                                            |
+|:------:|:------:|:-------:|:----------------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen                | Write 0 to disable alert testing until the next reset. |
+|  30:2  |        |         |                       | Reserved                                               |
+|   1    |   wo   |   0x0   | fatal_fault           | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | recov_ctrl_update_err | Write 1 to trigger one alert event of this kind.       |
 
 ## ALERT_STATUS
 Status of hardware alerts.

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_pkg.sv
@@ -381,9 +381,10 @@ package ac_range_check_reg_pkg;
   // Reset values for hwext registers and their fields
   parameter logic [0:0] AC_RANGE_CHECK_INTR_TEST_RESVAL = 1'h 0;
   parameter logic [0:0] AC_RANGE_CHECK_INTR_TEST_DENY_CNT_REACHED_RESVAL = 1'h 0;
-  parameter logic [1:0] AC_RANGE_CHECK_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [31:0] AC_RANGE_CHECK_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] AC_RANGE_CHECK_ALERT_TEST_RECOV_CTRL_UPDATE_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] AC_RANGE_CHECK_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] AC_RANGE_CHECK_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [9:0] AC_RANGE_CHECK_LOG_CONFIG_RESVAL = 10'h 0;
   parameter logic [0:0] AC_RANGE_CHECK_LOG_CONFIG_LOG_ENABLE_RESVAL = 1'h 0;
   parameter logic [0:0] AC_RANGE_CHECK_LOG_CONFIG_LOG_CLEAR_RESVAL = 1'h 0;
@@ -566,7 +567,7 @@ package ac_range_check_reg_pkg;
     4'b 0001, // index[  0] AC_RANGE_CHECK_INTR_STATE
     4'b 0001, // index[  1] AC_RANGE_CHECK_INTR_ENABLE
     4'b 0001, // index[  2] AC_RANGE_CHECK_INTR_TEST
-    4'b 0001, // index[  3] AC_RANGE_CHECK_ALERT_TEST
+    4'b 1111, // index[  3] AC_RANGE_CHECK_ALERT_TEST
     4'b 0001, // index[  4] AC_RANGE_CHECK_ALERT_STATUS
     4'b 0011, // index[  5] AC_RANGE_CHECK_LOG_CONFIG
     4'b 1111, // index[  6] AC_RANGE_CHECK_LOG_STATUS

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_top.sv
@@ -145,6 +145,8 @@ module ac_range_check_reg_top
   logic alert_test_we;
   logic alert_test_recov_ctrl_update_err_wd;
   logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic alert_status_re;
   logic alert_status_shadowed_update_err_qs;
   logic alert_status_shadowed_update_err_wd;
@@ -1209,14 +1211,17 @@ module ac_range_check_reg_top
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [1:0] alert_test_flds_we;
+  logic [2:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[recov_ctrl_update_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_recov_ctrl_update_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_ctrl_update_err_wd),
     .d      ('0),
     .qre    (),
@@ -1232,7 +1237,7 @@ module ac_range_check_reg_top
     .DW    (1)
   ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
@@ -1242,6 +1247,33 @@ module ac_range_check_reg_top
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_fault.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[2]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[alert_status]: V(False)
@@ -12359,6 +12391,8 @@ module ac_range_check_reg_top
   assign alert_test_recov_ctrl_update_err_wd = reg_wdata[0];
 
   assign alert_test_fatal_fault_wd = reg_wdata[1];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign alert_status_re = racl_addr_hit_read[4] & reg_re & !reg_error;
 
   assign alert_status_shadowed_update_err_wd = '1;
@@ -13394,6 +13428,7 @@ module ac_range_check_reg_top
       racl_addr_hit_read[3]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       racl_addr_hit_read[4]: begin

--- a/hw/top_darjeeling/ip_autogen/clkmgr/doc/registers.md
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/doc/registers.md
@@ -22,20 +22,21 @@
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0x0`
-- Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000003`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "recov_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "recov_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 29}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:2  |        |         |             | Reserved                                         |
-|   1    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | recov_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:2  |        |         |             | Reserved                                               |
+|   1    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | recov_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## JITTER_REGWEN
 Jitter write enable

--- a/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
@@ -216,9 +216,10 @@ package clkmgr_reg_pkg;
   parameter logic [BlockAw-1:0] CLKMGR_FATAL_ERR_CODE_OFFSET = 6'h 3c;
 
   // Reset values for hwext registers and their fields
-  parameter logic [1:0] CLKMGR_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [31:0] CLKMGR_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] CLKMGR_ALERT_TEST_RECOV_FAULT_RESVAL = 1'h 0;
   parameter logic [0:0] CLKMGR_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] CLKMGR_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
 
   // Register index
   typedef enum int {
@@ -239,7 +240,7 @@ package clkmgr_reg_pkg;
 
   // Register width information to check illegal writes
   parameter logic [3:0] CLKMGR_PERMIT [13] = '{
-    4'b 0001, // index[ 0] CLKMGR_ALERT_TEST
+    4'b 1111, // index[ 0] CLKMGR_ALERT_TEST
     4'b 0001, // index[ 1] CLKMGR_JITTER_REGWEN
     4'b 0001, // index[ 2] CLKMGR_JITTER_ENABLE
     4'b 0001, // index[ 3] CLKMGR_CLK_ENABLES

--- a/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -132,6 +132,8 @@ module clkmgr_reg_top (
   logic alert_test_we;
   logic alert_test_recov_fault_wd;
   logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic jitter_regwen_we;
   logic jitter_regwen_qs;
   logic jitter_regwen_wd;
@@ -371,14 +373,17 @@ module clkmgr_reg_top (
   // Register instances
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [1:0] alert_test_flds_we;
+  logic [2:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[recov_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_recov_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_fault_wd),
     .d      ('0),
     .qre    (),
@@ -394,7 +399,7 @@ module clkmgr_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
@@ -404,6 +409,33 @@ module clkmgr_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_fault.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[2]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[jitter_regwen]: V(False)
@@ -1368,6 +1400,8 @@ module clkmgr_reg_top (
   assign alert_test_recov_fault_wd = reg_wdata[0];
 
   assign alert_test_fatal_fault_wd = reg_wdata[1];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign jitter_regwen_we = addr_hit[1] & reg_we & !reg_error;
 
   assign jitter_regwen_wd = reg_wdata[0];
@@ -1437,6 +1471,7 @@ module clkmgr_reg_top (
       addr_hit[0]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[1]: begin

--- a/hw/top_darjeeling/ip_autogen/gpio/doc/registers.md
+++ b/hw/top_darjeeling/ip_autogen/gpio/doc/registers.md
@@ -91,19 +91,20 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## DATA_IN
 GPIO Input data read value

--- a/hw/top_darjeeling/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
@@ -313,8 +313,9 @@ package gpio_reg_pkg;
   // Reset values for hwext registers and their fields
   parameter logic [31:0] GPIO_INTR_TEST_RESVAL = 32'h 0;
   parameter logic [31:0] GPIO_INTR_TEST_GPIO_RESVAL = 32'h 0;
-  parameter logic [0:0] GPIO_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] GPIO_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] GPIO_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] GPIO_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [31:0] GPIO_DIRECT_OUT_RESVAL = 32'h 0;
   parameter logic [31:0] GPIO_MASKED_OUT_LOWER_RESVAL = 32'h 0;
   parameter logic [31:0] GPIO_MASKED_OUT_UPPER_RESVAL = 32'h 0;
@@ -365,7 +366,7 @@ package gpio_reg_pkg;
     4'b 1111, // index[ 0] GPIO_INTR_STATE
     4'b 1111, // index[ 1] GPIO_INTR_ENABLE
     4'b 1111, // index[ 2] GPIO_INTR_TEST
-    4'b 0001, // index[ 3] GPIO_ALERT_TEST
+    4'b 1111, // index[ 3] GPIO_ALERT_TEST
     4'b 1111, // index[ 4] GPIO_DATA_IN
     4'b 1111, // index[ 5] GPIO_DIRECT_OUT
     4'b 1111, // index[ 6] GPIO_MASKED_OUT_LOWER

--- a/hw/top_darjeeling/ip_autogen/gpio/rtl/gpio_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/rtl/gpio_reg_top.sv
@@ -141,7 +141,9 @@ module gpio_reg_top
   logic intr_test_we;
   logic [31:0] intr_test_wd;
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic [31:0] data_in_qs;
   logic direct_out_re;
   logic direct_out_we;
@@ -382,14 +384,18 @@ module gpio_reg_top
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -398,6 +404,33 @@ module gpio_reg_top
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[data_in]: V(False)
@@ -2292,7 +2325,9 @@ module gpio_reg_top
   assign intr_test_wd = reg_wdata[31:0];
   assign alert_test_we = racl_addr_hit_write[3] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign direct_out_re = racl_addr_hit_read[5] & reg_re & !reg_error;
   assign direct_out_we = racl_addr_hit_write[5] & reg_we & !reg_error;
 
@@ -2509,6 +2544,7 @@ module gpio_reg_top
 
       racl_addr_hit_read[3]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       racl_addr_hit_read[4]: begin

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/doc/registers.md
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/doc/registers.md
@@ -160,23 +160,24 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x1f`
+- Reset default: `0x80000000`
+- Reset mask: `0x8000001f`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_macro_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_check_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_bus_integ_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_prim_otp_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_prim_otp_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 27}], "config": {"lanes": 1, "fontsize": 10, "vspace": 230}}
+{"reg": [{"name": "fatal_macro_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_check_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_bus_integ_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_prim_otp_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_prim_otp_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 26}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 230}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                  | Description                                      |
-|:------:|:------:|:-------:|:----------------------|:-------------------------------------------------|
-|  31:5  |        |         |                       | Reserved                                         |
-|   4    |   wo   |   0x0   | recov_prim_otp_alert  | Write 1 to trigger one alert event of this kind. |
-|   3    |   wo   |   0x0   | fatal_prim_otp_alert  | Write 1 to trigger one alert event of this kind. |
-|   2    |   wo   |   0x0   | fatal_bus_integ_error | Write 1 to trigger one alert event of this kind. |
-|   1    |   wo   |   0x0   | fatal_check_error     | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | fatal_macro_error     | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name                  | Description                                            |
+|:------:|:------:|:-------:|:----------------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen                | Write 0 to disable alert testing until the next reset. |
+|  30:5  |        |         |                       | Reserved                                               |
+|   4    |   wo   |   0x0   | recov_prim_otp_alert  | Write 1 to trigger one alert event of this kind.       |
+|   3    |   wo   |   0x0   | fatal_prim_otp_alert  | Write 1 to trigger one alert event of this kind.       |
+|   2    |   wo   |   0x0   | fatal_bus_integ_error | Write 1 to trigger one alert event of this kind.       |
+|   1    |   wo   |   0x0   | fatal_check_error     | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | fatal_macro_error     | Write 1 to trigger one alert event of this kind.       |
 
 ## STATUS
 OTP status register.

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
@@ -189,6 +189,8 @@ module otp_ctrl_core_reg_top (
   logic alert_test_fatal_bus_integ_error_wd;
   logic alert_test_fatal_prim_otp_alert_wd;
   logic alert_test_recov_prim_otp_alert_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic status_re;
   logic status_partition_error_qs;
   logic status_dai_error_qs;
@@ -585,14 +587,17 @@ module otp_ctrl_core_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [4:0] alert_test_flds_we;
+  logic [5:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[fatal_macro_error]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_fatal_macro_error (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_macro_error_wd),
     .d      ('0),
     .qre    (),
@@ -608,7 +613,7 @@ module otp_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_check_error (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_check_error_wd),
     .d      ('0),
     .qre    (),
@@ -624,7 +629,7 @@ module otp_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_bus_integ_error (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_bus_integ_error_wd),
     .d      ('0),
     .qre    (),
@@ -640,7 +645,7 @@ module otp_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_prim_otp_alert (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_prim_otp_alert_wd),
     .d      ('0),
     .qre    (),
@@ -656,7 +661,7 @@ module otp_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_recov_prim_otp_alert (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_prim_otp_alert_wd),
     .d      ('0),
     .qre    (),
@@ -666,6 +671,33 @@ module otp_ctrl_core_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.recov_prim_otp_alert.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[5]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[status]: V(True)
@@ -3322,6 +3354,8 @@ module otp_ctrl_core_reg_top (
   assign alert_test_fatal_prim_otp_alert_wd = reg_wdata[3];
 
   assign alert_test_recov_prim_otp_alert_wd = reg_wdata[4];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign status_re = addr_hit[4] & reg_re & !reg_error;
   assign partition_status_0_re = addr_hit[5] & reg_re & !reg_error;
   assign err_code_0_re = addr_hit[6] & reg_re & !reg_error;
@@ -3601,6 +3635,7 @@ module otp_ctrl_core_reg_top (
         reg_rdata_next[2] = '0;
         reg_rdata_next[3] = '0;
         reg_rdata_next[4] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -860,12 +860,13 @@ package otp_ctrl_reg_pkg;
   parameter logic [1:0] OTP_CTRL_INTR_TEST_RESVAL = 2'h 0;
   parameter logic [0:0] OTP_CTRL_INTR_TEST_OTP_OPERATION_DONE_RESVAL = 1'h 0;
   parameter logic [0:0] OTP_CTRL_INTR_TEST_OTP_ERROR_RESVAL = 1'h 0;
-  parameter logic [4:0] OTP_CTRL_ALERT_TEST_RESVAL = 5'h 0;
+  parameter logic [31:0] OTP_CTRL_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] OTP_CTRL_ALERT_TEST_FATAL_MACRO_ERROR_RESVAL = 1'h 0;
   parameter logic [0:0] OTP_CTRL_ALERT_TEST_FATAL_CHECK_ERROR_RESVAL = 1'h 0;
   parameter logic [0:0] OTP_CTRL_ALERT_TEST_FATAL_BUS_INTEG_ERROR_RESVAL = 1'h 0;
   parameter logic [0:0] OTP_CTRL_ALERT_TEST_FATAL_PRIM_OTP_ALERT_RESVAL = 1'h 0;
   parameter logic [0:0] OTP_CTRL_ALERT_TEST_RECOV_PRIM_OTP_ALERT_RESVAL = 1'h 0;
+  parameter logic [0:0] OTP_CTRL_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [9:0] OTP_CTRL_STATUS_RESVAL = 10'h 0;
   parameter logic [0:0] OTP_CTRL_STATUS_PARTITION_ERROR_RESVAL = 1'h 0;
   parameter logic [0:0] OTP_CTRL_STATUS_DAI_ERROR_RESVAL = 1'h 0;
@@ -1185,7 +1186,7 @@ package otp_ctrl_reg_pkg;
     4'b 0001, // index[ 0] OTP_CTRL_INTR_STATE
     4'b 0001, // index[ 1] OTP_CTRL_INTR_ENABLE
     4'b 0001, // index[ 2] OTP_CTRL_INTR_TEST
-    4'b 0001, // index[ 3] OTP_CTRL_ALERT_TEST
+    4'b 1111, // index[ 3] OTP_CTRL_ALERT_TEST
     4'b 0011, // index[ 4] OTP_CTRL_STATUS
     4'b 0111, // index[ 5] OTP_CTRL_PARTITION_STATUS_0
     4'b 0001, // index[ 6] OTP_CTRL_ERR_CODE_0

--- a/hw/top_darjeeling/ip_autogen/pinmux/doc/registers.md
+++ b/hw/top_darjeeling/ip_autogen/pinmux/doc/registers.md
@@ -512,19 +512,20 @@
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0x0`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## MIO_PERIPH_INSEL_REGWEN
 Register write enable for MIO peripheral input selects.

--- a/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
@@ -797,8 +797,9 @@ package pinmux_reg_pkg;
   parameter logic [BlockAw-1:0] PINMUX_WKUP_CAUSE_OFFSET = 11'h 7d8;
 
   // Reset values for hwext registers and their fields
-  parameter logic [0:0] PINMUX_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] PINMUX_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] PINMUX_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] PINMUX_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [23:0] PINMUX_MIO_PAD_ATTR_0_RESVAL = 24'h 0;
   parameter logic [0:0] PINMUX_MIO_PAD_ATTR_0_INVERT_0_RESVAL = 1'h 0;
   parameter logic [0:0] PINMUX_MIO_PAD_ATTR_0_VIRTUAL_OD_EN_0_RESVAL = 1'h 0;
@@ -2244,7 +2245,7 @@ package pinmux_reg_pkg;
 
   // Register width information to check illegal writes
   parameter logic [3:0] PINMUX_PERMIT [503] = '{
-    4'b 0001, // index[  0] PINMUX_ALERT_TEST
+    4'b 1111, // index[  0] PINMUX_ALERT_TEST
     4'b 0001, // index[  1] PINMUX_MIO_PERIPH_INSEL_REGWEN_0
     4'b 0001, // index[  2] PINMUX_MIO_PERIPH_INSEL_REGWEN_1
     4'b 0001, // index[  3] PINMUX_MIO_PERIPH_INSEL_REGWEN_2

--- a/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
@@ -124,7 +124,9 @@ module pinmux_reg_top (
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic mio_periph_insel_regwen_0_we;
   logic mio_periph_insel_regwen_0_qs;
   logic mio_periph_insel_regwen_0_wd;
@@ -4453,14 +4455,18 @@ module pinmux_reg_top (
   // Register instances
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -4469,6 +4475,33 @@ module pinmux_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // Subregister 0 of Multireg mio_periph_insel_regwen
@@ -35443,7 +35476,9 @@ module pinmux_reg_top (
   // Generate write-enables
   assign alert_test_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign mio_periph_insel_regwen_0_we = addr_hit[1] & reg_we & !reg_error;
 
   assign mio_periph_insel_regwen_0_wd = reg_wdata[0];
@@ -39239,6 +39274,7 @@ module pinmux_reg_top (
     unique case (1'b1)
       addr_hit[0]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[1]: begin

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/doc/registers.md
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/doc/registers.md
@@ -77,19 +77,20 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## CTRL_CFG_REGWEN
 Controls the configurability of the [`CONTROL`](#control) register.

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
@@ -230,8 +230,9 @@ package pwrmgr_reg_pkg;
   // Reset values for hwext registers and their fields
   parameter logic [0:0] PWRMGR_INTR_TEST_RESVAL = 1'h 0;
   parameter logic [0:0] PWRMGR_INTR_TEST_WAKEUP_RESVAL = 1'h 0;
-  parameter logic [0:0] PWRMGR_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] PWRMGR_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] PWRMGR_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] PWRMGR_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] PWRMGR_CTRL_CFG_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] PWRMGR_CTRL_CFG_REGWEN_EN_RESVAL = 1'h 1;
   parameter logic [4:0] PWRMGR_WAKE_INFO_RESVAL = 5'h 0;
@@ -265,7 +266,7 @@ package pwrmgr_reg_pkg;
     4'b 0001, // index[ 0] PWRMGR_INTR_STATE
     4'b 0001, // index[ 1] PWRMGR_INTR_ENABLE
     4'b 0001, // index[ 2] PWRMGR_INTR_TEST
-    4'b 0001, // index[ 3] PWRMGR_ALERT_TEST
+    4'b 1111, // index[ 3] PWRMGR_ALERT_TEST
     4'b 0001, // index[ 4] PWRMGR_CTRL_CFG_REGWEN
     4'b 0001, // index[ 5] PWRMGR_CONTROL
     4'b 0001, // index[ 6] PWRMGR_CFG_CDC_SYNC

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
@@ -132,7 +132,9 @@ module pwrmgr_reg_top (
   logic intr_test_we;
   logic intr_test_wd;
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic ctrl_cfg_regwen_re;
   logic ctrl_cfg_regwen_qs;
   logic control_we;
@@ -267,14 +269,18 @@ module pwrmgr_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -283,6 +289,33 @@ module pwrmgr_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[ctrl_cfg_regwen]: V(True)
@@ -1050,7 +1083,9 @@ module pwrmgr_reg_top (
   assign intr_test_wd = reg_wdata[0];
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign ctrl_cfg_regwen_re = addr_hit[4] & reg_re & !reg_error;
   assign control_we = addr_hit[5] & reg_we & !reg_error;
 
@@ -1133,6 +1168,7 @@ module pwrmgr_reg_top (
 
       addr_hit[3]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/data/racl_ctrl.hjson
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/data/racl_ctrl.hjson
@@ -239,6 +239,7 @@
       hwaccess: "hro",
       hwqe:     "True",
       hwext:    "True",
+      inregwen: "regwen",
       fields: [
         { bits: "0",
           name: "fatal_fault",
@@ -247,6 +248,13 @@
         { bits: "1",
           name: "recov_ctrl_update_err",
           desc: "'Write 1 to trigger one alert event of this kind.'",
+        }
+        { bits: "31",
+          name: "regwen",
+          swaccess: "rw0c",
+          hwaccess: "none",
+          resval: "1",
+          desc: "Write 0 to disable alert testing until the next reset.",
         }
       ],
     }

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/doc/registers.md
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/doc/registers.md
@@ -120,20 +120,21 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register.
 - Offset: `0xf4`
-- Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000003`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_ctrl_update_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 230}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_ctrl_update_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 29}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 230}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                  | Description                                        |
-|:------:|:------:|:-------:|:----------------------|:---------------------------------------------------|
-|  31:2  |        |         |                       | Reserved                                           |
-|   1    |   wo   |    x    | recov_ctrl_update_err | 'Write 1 to trigger one alert event of this kind.' |
-|   0    |   wo   |    x    | fatal_fault           | 'Write 1 to trigger one alert event of this kind.' |
+|  Bits  |  Type  |  Reset  | Name                  | Description                                            |
+|:------:|:------:|:-------:|:----------------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen                | Write 0 to disable alert testing until the next reset. |
+|  30:2  |        |         |                       | Reserved                                               |
+|   1    |   wo   |    x    | recov_ctrl_update_err | 'Write 1 to trigger one alert event of this kind.'     |
+|   0    |   wo   |    x    | fatal_fault           | 'Write 1 to trigger one alert event of this kind.'     |
 
 ## ERROR_LOG
 Error logging registers

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_pkg.sv
@@ -148,7 +148,8 @@ package racl_ctrl_reg_pkg;
 
   // Reset values for hwext registers and their fields
   parameter logic [0:0] RACL_CTRL_INTR_TEST_RESVAL = 1'h 0;
-  parameter logic [1:0] RACL_CTRL_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [31:0] RACL_CTRL_ALERT_TEST_RESVAL = 32'h 80000000;
+  parameter logic [0:0] RACL_CTRL_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
 
   // Register index
   typedef enum int {
@@ -171,7 +172,7 @@ package racl_ctrl_reg_pkg;
     4'b 0001, // index[3] RACL_CTRL_INTR_STATE
     4'b 0001, // index[4] RACL_CTRL_INTR_ENABLE
     4'b 0001, // index[5] RACL_CTRL_INTR_TEST
-    4'b 0001, // index[6] RACL_CTRL_ALERT_TEST
+    4'b 1111, // index[6] RACL_CTRL_ALERT_TEST
     4'b 0011, // index[7] RACL_CTRL_ERROR_LOG
     4'b 1111  // index[8] RACL_CTRL_ERROR_LOG_ADDRESS
   };

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_top.sv
@@ -172,6 +172,8 @@ module racl_ctrl_reg_top
   logic alert_test_we;
   logic alert_test_fatal_fault_wd;
   logic alert_test_recov_ctrl_update_err_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic error_log_we;
   logic error_log_valid_qs;
   logic error_log_valid_wd;
@@ -482,14 +484,17 @@ module racl_ctrl_reg_top
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [1:0] alert_test_flds_we;
+  logic [2:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
@@ -505,7 +510,7 @@ module racl_ctrl_reg_top
     .DW    (1)
   ) u_alert_test_recov_ctrl_update_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_ctrl_update_err_wd),
     .d      ('0),
     .qre    (),
@@ -515,6 +520,33 @@ module racl_ctrl_reg_top
     .qs     ()
   );
   assign reg2hw.alert_test.recov_ctrl_update_err.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[2]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[error_log]: V(False)
@@ -809,6 +841,8 @@ module racl_ctrl_reg_top
   assign alert_test_fatal_fault_wd = reg_wdata[0];
 
   assign alert_test_recov_ctrl_update_err_wd = reg_wdata[1];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign error_log_we = racl_addr_hit_write[7] & reg_we & !reg_error;
 
   assign error_log_valid_wd = reg_wdata[0];
@@ -860,6 +894,7 @@ module racl_ctrl_reg_top
       racl_addr_hit_read[6]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       racl_addr_hit_read[7]: begin

--- a/hw/top_darjeeling/ip_autogen/rstmgr/doc/registers.md
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/doc/registers.md
@@ -27,20 +27,21 @@
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0x0`
-- Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000003`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_cnsty_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 190}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_cnsty_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 29}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 190}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name              | Description                                      |
-|:------:|:------:|:-------:|:------------------|:-------------------------------------------------|
-|  31:2  |        |         |                   | Reserved                                         |
-|   1    |   wo   |   0x0   | fatal_cnsty_fault | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | fatal_fault       | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name              | Description                                            |
+|:------:|:------:|:-------:|:------------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen            | Write 0 to disable alert testing until the next reset. |
+|  30:2  |        |         |                   | Reserved                                               |
+|   1    |   wo   |   0x0   | fatal_cnsty_fault | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | fatal_fault       | Write 1 to trigger one alert event of this kind.       |
 
 ## RESET_REQ
 Software requested system reset.

--- a/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
@@ -198,9 +198,10 @@ package rstmgr_reg_pkg;
   parameter logic [BlockAw-1:0] RSTMGR_ERR_CODE_OFFSET = 7'h 44;
 
   // Reset values for hwext registers and their fields
-  parameter logic [1:0] RSTMGR_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [31:0] RSTMGR_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] RSTMGR_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
   parameter logic [0:0] RSTMGR_ALERT_TEST_FATAL_CNSTY_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] RSTMGR_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [3:0] RSTMGR_ALERT_INFO_ATTR_RESVAL = 4'h 0;
   parameter logic [3:0] RSTMGR_ALERT_INFO_ATTR_CNT_AVAIL_RESVAL = 4'h 0;
   parameter logic [31:0] RSTMGR_ALERT_INFO_RESVAL = 32'h 0;
@@ -234,7 +235,7 @@ package rstmgr_reg_pkg;
 
   // Register width information to check illegal writes
   parameter logic [3:0] RSTMGR_PERMIT [18] = '{
-    4'b 0001, // index[ 0] RSTMGR_ALERT_TEST
+    4'b 1111, // index[ 0] RSTMGR_ALERT_TEST
     4'b 0001, // index[ 1] RSTMGR_RESET_REQ
     4'b 0001, // index[ 2] RSTMGR_RESET_INFO
     4'b 0001, // index[ 3] RSTMGR_ALERT_REGWEN

--- a/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
@@ -126,6 +126,8 @@ module rstmgr_reg_top (
   logic alert_test_we;
   logic alert_test_fatal_fault_wd;
   logic alert_test_fatal_cnsty_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic reset_req_we;
   logic [3:0] reset_req_qs;
   logic [3:0] reset_req_wd;
@@ -189,14 +191,17 @@ module rstmgr_reg_top (
   // Register instances
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [1:0] alert_test_flds_we;
+  logic [2:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
@@ -212,7 +217,7 @@ module rstmgr_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_cnsty_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_cnsty_fault_wd),
     .d      ('0),
     .qre    (),
@@ -222,6 +227,33 @@ module rstmgr_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_cnsty_fault.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[2]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[reset_req]: V(False)
@@ -928,6 +960,8 @@ module rstmgr_reg_top (
   assign alert_test_fatal_fault_wd = reg_wdata[0];
 
   assign alert_test_fatal_cnsty_fault_wd = reg_wdata[1];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign reset_req_we = addr_hit[1] & reg_we & !reg_error;
 
   assign reset_req_wd = reg_wdata[3:0];
@@ -1008,6 +1042,7 @@ module rstmgr_reg_top (
       addr_hit[0]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[1]: begin

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/doc/registers.md
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/doc/registers.md
@@ -279,22 +279,23 @@ A number of memory-mapped registers are available to control Ibex-related functi
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0x0`
-- Reset default: `0x0`
-- Reset mask: `0xf`
+- Reset default: `0x80000000`
+- Reset mask: `0x8000000f`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_sw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_sw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_hw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_hw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 28}], "config": {"lanes": 1, "fontsize": 10, "vspace": 140}}
+{"reg": [{"name": "fatal_sw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_sw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_hw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_hw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 27}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 140}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name         | Description                                      |
-|:------:|:------:|:-------:|:-------------|:-------------------------------------------------|
-|  31:4  |        |         |              | Reserved                                         |
-|   3    |   wo   |   0x0   | recov_hw_err | Write 1 to trigger one alert event of this kind. |
-|   2    |   wo   |   0x0   | fatal_hw_err | Write 1 to trigger one alert event of this kind. |
-|   1    |   wo   |   0x0   | recov_sw_err | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | fatal_sw_err | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name         | Description                                            |
+|:------:|:------:|:-------:|:-------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen       | Write 0 to disable alert testing until the next reset. |
+|  30:4  |        |         |              | Reserved                                               |
+|   3    |   wo   |   0x0   | recov_hw_err | Write 1 to trigger one alert event of this kind.       |
+|   2    |   wo   |   0x0   | fatal_hw_err | Write 1 to trigger one alert event of this kind.       |
+|   1    |   wo   |   0x0   | recov_sw_err | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | fatal_sw_err | Write 1 to trigger one alert event of this kind.       |
 
 ## SW_RECOV_ERR
 Software recoverable error

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
@@ -175,6 +175,8 @@ module rv_core_ibex_cfg_reg_top (
   logic alert_test_recov_sw_err_wd;
   logic alert_test_fatal_hw_err_wd;
   logic alert_test_recov_hw_err_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic sw_recov_err_we;
   logic [3:0] sw_recov_err_qs;
   logic [3:0] sw_recov_err_wd;
@@ -985,14 +987,17 @@ module rv_core_ibex_cfg_reg_top (
   // Register instances
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [3:0] alert_test_flds_we;
+  logic [4:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[fatal_sw_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_fatal_sw_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_sw_err_wd),
     .d      ('0),
     .qre    (),
@@ -1008,7 +1013,7 @@ module rv_core_ibex_cfg_reg_top (
     .DW    (1)
   ) u_alert_test_recov_sw_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_sw_err_wd),
     .d      ('0),
     .qre    (),
@@ -1024,7 +1029,7 @@ module rv_core_ibex_cfg_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_hw_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_hw_err_wd),
     .d      ('0),
     .qre    (),
@@ -1040,7 +1045,7 @@ module rv_core_ibex_cfg_reg_top (
     .DW    (1)
   ) u_alert_test_recov_hw_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_hw_err_wd),
     .d      ('0),
     .qre    (),
@@ -1050,6 +1055,33 @@ module rv_core_ibex_cfg_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.recov_hw_err.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[4]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[sw_recov_err]: V(False)
@@ -12313,6 +12345,8 @@ module rv_core_ibex_cfg_reg_top (
   assign alert_test_fatal_hw_err_wd = reg_wdata[2];
 
   assign alert_test_recov_hw_err_wd = reg_wdata[3];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign sw_recov_err_we = addr_hit[1] & reg_we & !reg_error;
 
   assign sw_recov_err_wd = reg_wdata[3:0];
@@ -13396,6 +13430,7 @@ module rv_core_ibex_cfg_reg_top (
         reg_rdata_next[1] = '0;
         reg_rdata_next[2] = '0;
         reg_rdata_next[3] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[1]: begin

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
@@ -463,11 +463,12 @@ package rv_core_ibex_reg_pkg;
   parameter logic [CfgAw-1:0] RV_CORE_IBEX_MCOUNTEREN_WRITABLE_OFFSET = 11'h 428;
 
   // Reset values for hwext registers and their fields for cfg interface
-  parameter logic [3:0] RV_CORE_IBEX_ALERT_TEST_RESVAL = 4'h 0;
+  parameter logic [31:0] RV_CORE_IBEX_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] RV_CORE_IBEX_ALERT_TEST_FATAL_SW_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] RV_CORE_IBEX_ALERT_TEST_RECOV_SW_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] RV_CORE_IBEX_ALERT_TEST_FATAL_HW_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] RV_CORE_IBEX_ALERT_TEST_RECOV_HW_ERR_RESVAL = 1'h 0;
+  parameter logic [0:0] RV_CORE_IBEX_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [31:0] RV_CORE_IBEX_RND_DATA_RESVAL = 32'h 0;
   parameter logic [31:0] RV_CORE_IBEX_RND_DATA_DATA_RESVAL = 32'h 0;
   parameter logic [1:0] RV_CORE_IBEX_RND_STATUS_RESVAL = 2'h 0;
@@ -754,7 +755,7 @@ package rv_core_ibex_reg_pkg;
 
   // Register width information to check illegal writes for cfg interface
   parameter logic [3:0] RV_CORE_IBEX_CFG_PERMIT [267] = '{
-    4'b 0001, // index[  0] RV_CORE_IBEX_ALERT_TEST
+    4'b 1111, // index[  0] RV_CORE_IBEX_ALERT_TEST
     4'b 0001, // index[  1] RV_CORE_IBEX_SW_RECOV_ERR
     4'b 0001, // index[  2] RV_CORE_IBEX_SW_FATAL_ERR
     4'b 0001, // index[  3] RV_CORE_IBEX_IBUS_REGWEN_0

--- a/hw/top_darjeeling/ip_autogen/rv_plic/data/rv_plic.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/data/rv_plic.hjson
@@ -199,10 +199,18 @@
       hwaccess: "hro",
       hwqe:     "True",
       hwext:    "True",
+      inregwen: "regwen",
       fields: [
         { bits: "0",
           name: "fatal_fault",
           desc: "'Write 1 to trigger one alert event of this kind.'",
+        }
+        { bits: "31",
+          name: "regwen",
+          swaccess: "rw0c",
+          hwaccess: "none",
+          resval: "1",
+          desc: "Write 0 to disable alert testing until the next reset.",
         }
       ],
     }

--- a/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
@@ -229,7 +229,8 @@ package rv_plic_reg_pkg;
 
   // Reset values for hwext registers and their fields
   parameter logic [7:0] RV_PLIC_CC0_RESVAL = 8'h 0;
-  parameter logic [0:0] RV_PLIC_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] RV_PLIC_ALERT_TEST_RESVAL = 32'h 80000000;
+  parameter logic [0:0] RV_PLIC_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
 
   // Register index
   typedef enum int {
@@ -528,7 +529,7 @@ package rv_plic_reg_pkg;
     4'b 0001, // index[142] RV_PLIC_THRESHOLD0
     4'b 0001, // index[143] RV_PLIC_CC0
     4'b 0001, // index[144] RV_PLIC_MSIP0
-    4'b 0001  // index[145] RV_PLIC_ALERT_TEST
+    4'b 1111  // index[145] RV_PLIC_ALERT_TEST
   };
 
 endpackage

--- a/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
@@ -929,7 +929,9 @@ module rv_plic_reg_top (
   logic msip0_qs;
   logic msip0_wd;
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
 
   // Register instances
   // Subregister 0 of Multireg prio
@@ -11996,14 +11998,18 @@ module rv_plic_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -12012,6 +12018,33 @@ module rv_plic_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
 
@@ -12996,7 +13029,9 @@ module rv_plic_reg_top (
   assign msip0_wd = reg_wdata[0];
   assign alert_test_we = addr_hit[145] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
 
   // Assign write-enables to checker logic vector.
   always_comb begin
@@ -13988,6 +14023,7 @@ module rv_plic_reg_top (
 
       addr_hit[145]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       default: begin

--- a/hw/top_earlgrey/ip/sensor_ctrl/doc/registers.md
+++ b/hw/top_earlgrey/ip/sensor_ctrl/doc/registers.md
@@ -92,20 +92,21 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000003`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "recov_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "recov_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 29}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:2  |        |         |             | Reserved                                         |
-|   1    |   wo   |   0x0   | fatal_alert | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | recov_alert | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:2  |        |         |             | Reserved                                               |
+|   1    |   wo   |   0x0   | fatal_alert | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | recov_alert | Write 1 to trigger one alert event of this kind.       |
 
 ## CFG_REGWEN
 Controls the configurability of [`FATAL_ALERT_EN`](#fatal_alert_en) register.

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_pkg.sv
@@ -206,9 +206,10 @@ package sensor_ctrl_reg_pkg;
   parameter logic [1:0] SENSOR_CTRL_INTR_TEST_RESVAL = 2'h 0;
   parameter logic [0:0] SENSOR_CTRL_INTR_TEST_IO_STATUS_CHANGE_RESVAL = 1'h 0;
   parameter logic [0:0] SENSOR_CTRL_INTR_TEST_INIT_STATUS_CHANGE_RESVAL = 1'h 0;
-  parameter logic [1:0] SENSOR_CTRL_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [31:0] SENSOR_CTRL_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] SENSOR_CTRL_ALERT_TEST_RECOV_ALERT_RESVAL = 1'h 0;
   parameter logic [0:0] SENSOR_CTRL_ALERT_TEST_FATAL_ALERT_RESVAL = 1'h 0;
+  parameter logic [0:0] SENSOR_CTRL_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [7:0] SENSOR_CTRL_MANUAL_PAD_ATTR_0_RESVAL = 8'h 0;
   parameter logic [0:0] SENSOR_CTRL_MANUAL_PAD_ATTR_0_PULL_EN_0_RESVAL = 1'h 0;
   parameter logic [0:0] SENSOR_CTRL_MANUAL_PAD_ATTR_0_PULL_SELECT_0_RESVAL = 1'h 0;
@@ -264,7 +265,7 @@ package sensor_ctrl_reg_pkg;
     4'b 0001, // index[ 0] SENSOR_CTRL_INTR_STATE
     4'b 0001, // index[ 1] SENSOR_CTRL_INTR_ENABLE
     4'b 0001, // index[ 2] SENSOR_CTRL_INTR_TEST
-    4'b 0001, // index[ 3] SENSOR_CTRL_ALERT_TEST
+    4'b 1111, // index[ 3] SENSOR_CTRL_ALERT_TEST
     4'b 0001, // index[ 4] SENSOR_CTRL_CFG_REGWEN
     4'b 0011, // index[ 5] SENSOR_CTRL_ALERT_TRIG
     4'b 0001, // index[ 6] SENSOR_CTRL_ALERT_EN_0

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
@@ -137,6 +137,8 @@ module sensor_ctrl_reg_top (
   logic alert_test_we;
   logic alert_test_recov_alert_wd;
   logic alert_test_fatal_alert_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic cfg_regwen_we;
   logic cfg_regwen_qs;
   logic cfg_regwen_wd;
@@ -453,14 +455,17 @@ module sensor_ctrl_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [1:0] alert_test_flds_we;
+  logic [2:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[recov_alert]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_recov_alert (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_alert_wd),
     .d      ('0),
     .qre    (),
@@ -476,7 +481,7 @@ module sensor_ctrl_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_alert (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_alert_wd),
     .d      ('0),
     .qre    (),
@@ -486,6 +491,33 @@ module sensor_ctrl_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_alert.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[2]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[cfg_regwen]: V(False)
@@ -2589,6 +2621,8 @@ module sensor_ctrl_reg_top (
   assign alert_test_recov_alert_wd = reg_wdata[0];
 
   assign alert_test_fatal_alert_wd = reg_wdata[1];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign cfg_regwen_we = addr_hit[4] & reg_we & !reg_error;
 
   assign cfg_regwen_wd = reg_wdata[0];
@@ -2794,6 +2828,7 @@ module sensor_ctrl_reg_top (
       addr_hit[3]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/top_earlgrey/ip_autogen/clkmgr/doc/registers.md
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/doc/registers.md
@@ -31,20 +31,21 @@
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0x0`
-- Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000003`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "recov_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "recov_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 29}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:2  |        |         |             | Reserved                                         |
-|   1    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | recov_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:2  |        |         |             | Reserved                                               |
+|   1    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | recov_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## EXTCLK_CTRL_REGWEN
 External clock control write enable

--- a/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
@@ -338,9 +338,10 @@ package clkmgr_reg_pkg;
   parameter logic [BlockAw-1:0] CLKMGR_FATAL_ERR_CODE_OFFSET = 7'h 54;
 
   // Reset values for hwext registers and their fields
-  parameter logic [1:0] CLKMGR_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [31:0] CLKMGR_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] CLKMGR_ALERT_TEST_RECOV_FAULT_RESVAL = 1'h 0;
   parameter logic [0:0] CLKMGR_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] CLKMGR_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [3:0] CLKMGR_EXTCLK_STATUS_RESVAL = 4'h 9;
   parameter logic [3:0] CLKMGR_EXTCLK_STATUS_ACK_RESVAL = 4'h 9;
 
@@ -372,7 +373,7 @@ package clkmgr_reg_pkg;
 
   // Register width information to check illegal writes
   parameter logic [3:0] CLKMGR_PERMIT [22] = '{
-    4'b 0001, // index[ 0] CLKMGR_ALERT_TEST
+    4'b 1111, // index[ 0] CLKMGR_ALERT_TEST
     4'b 0001, // index[ 1] CLKMGR_EXTCLK_CTRL_REGWEN
     4'b 0001, // index[ 2] CLKMGR_EXTCLK_CTRL
     4'b 0001, // index[ 3] CLKMGR_EXTCLK_STATUS

--- a/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -138,6 +138,8 @@ module clkmgr_reg_top (
   logic alert_test_we;
   logic alert_test_recov_fault_wd;
   logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic extclk_ctrl_regwen_we;
   logic extclk_ctrl_regwen_qs;
   logic extclk_ctrl_regwen_wd;
@@ -696,14 +698,17 @@ module clkmgr_reg_top (
   // Register instances
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [1:0] alert_test_flds_we;
+  logic [2:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[recov_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_recov_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_fault_wd),
     .d      ('0),
     .qre    (),
@@ -719,7 +724,7 @@ module clkmgr_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
@@ -729,6 +734,33 @@ module clkmgr_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_fault.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[2]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[extclk_ctrl_regwen]: V(False)
@@ -2603,6 +2635,8 @@ module clkmgr_reg_top (
   assign alert_test_recov_fault_wd = reg_wdata[0];
 
   assign alert_test_fatal_fault_wd = reg_wdata[1];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign extclk_ctrl_regwen_we = addr_hit[1] & reg_we & !reg_error;
 
   assign extclk_ctrl_regwen_wd = reg_wdata[0];
@@ -2726,6 +2760,7 @@ module clkmgr_reg_top (
       addr_hit[0]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[1]: begin

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/doc/registers.md
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/doc/registers.md
@@ -188,23 +188,24 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x1f`
+- Reset default: `0x80000000`
+- Reset mask: `0x8000001f`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "recov_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_std_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_prim_flash_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_prim_flash_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 27}], "config": {"lanes": 1, "fontsize": 10, "vspace": 240}}
+{"reg": [{"name": "recov_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_std_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_prim_flash_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_prim_flash_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 26}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 240}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                   | Description                                      |
-|:------:|:------:|:-------:|:-----------------------|:-------------------------------------------------|
-|  31:5  |        |         |                        | Reserved                                         |
-|   4    |   wo   |   0x0   | recov_prim_flash_alert | Write 1 to trigger one alert event of this kind. |
-|   3    |   wo   |   0x0   | fatal_prim_flash_alert | Write 1 to trigger one alert event of this kind. |
-|   2    |   wo   |   0x0   | fatal_err              | Write 1 to trigger one alert event of this kind. |
-|   1    |   wo   |   0x0   | fatal_std_err          | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | recov_err              | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name                   | Description                                            |
+|:------:|:------:|:-------:|:-----------------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen                 | Write 0 to disable alert testing until the next reset. |
+|  30:5  |        |         |                        | Reserved                                               |
+|   4    |   wo   |   0x0   | recov_prim_flash_alert | Write 1 to trigger one alert event of this kind.       |
+|   3    |   wo   |   0x0   | fatal_prim_flash_alert | Write 1 to trigger one alert event of this kind.       |
+|   2    |   wo   |   0x0   | fatal_err              | Write 1 to trigger one alert event of this kind.       |
+|   1    |   wo   |   0x0   | fatal_std_err          | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | recov_err              | Write 1 to trigger one alert event of this kind.       |
 
 ## DIS
 Disable flash functionality

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -212,6 +212,8 @@ module flash_ctrl_core_reg_top (
   logic alert_test_fatal_err_wd;
   logic alert_test_fatal_prim_flash_alert_wd;
   logic alert_test_recov_prim_flash_alert_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic dis_we;
   logic [3:0] dis_qs;
   logic [3:0] dis_wd;
@@ -1449,14 +1451,17 @@ module flash_ctrl_core_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [4:0] alert_test_flds_we;
+  logic [5:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[recov_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_recov_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_err_wd),
     .d      ('0),
     .qre    (),
@@ -1472,7 +1477,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_std_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_std_err_wd),
     .d      ('0),
     .qre    (),
@@ -1488,7 +1493,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_err_wd),
     .d      ('0),
     .qre    (),
@@ -1504,7 +1509,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_prim_flash_alert (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_prim_flash_alert_wd),
     .d      ('0),
     .qre    (),
@@ -1520,7 +1525,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_recov_prim_flash_alert (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_prim_flash_alert_wd),
     .d      ('0),
     .qre    (),
@@ -1530,6 +1535,33 @@ module flash_ctrl_core_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.recov_prim_flash_alert.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[5]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[dis]: V(False)
@@ -12088,6 +12120,8 @@ module flash_ctrl_core_reg_top (
   assign alert_test_fatal_prim_flash_alert_wd = reg_wdata[3];
 
   assign alert_test_recov_prim_flash_alert_wd = reg_wdata[4];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign dis_we = addr_hit[4] & reg_we & !reg_error;
 
   assign dis_wd = reg_wdata[3:0];
@@ -13003,6 +13037,7 @@ module flash_ctrl_core_reg_top (
         reg_rdata_next[2] = '0;
         reg_rdata_next[3] = '0;
         reg_rdata_next[4] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -921,12 +921,13 @@ package flash_ctrl_reg_pkg;
   parameter logic [0:0] FLASH_CTRL_INTR_TEST_RD_LVL_RESVAL = 1'h 0;
   parameter logic [0:0] FLASH_CTRL_INTR_TEST_OP_DONE_RESVAL = 1'h 0;
   parameter logic [0:0] FLASH_CTRL_INTR_TEST_CORR_ERR_RESVAL = 1'h 0;
-  parameter logic [4:0] FLASH_CTRL_ALERT_TEST_RESVAL = 5'h 0;
+  parameter logic [31:0] FLASH_CTRL_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] FLASH_CTRL_ALERT_TEST_RECOV_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] FLASH_CTRL_ALERT_TEST_FATAL_STD_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] FLASH_CTRL_ALERT_TEST_FATAL_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] FLASH_CTRL_ALERT_TEST_FATAL_PRIM_FLASH_ALERT_RESVAL = 1'h 0;
   parameter logic [0:0] FLASH_CTRL_ALERT_TEST_RECOV_PRIM_FLASH_ALERT_RESVAL = 1'h 0;
+  parameter logic [0:0] FLASH_CTRL_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] FLASH_CTRL_CTRL_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] FLASH_CTRL_CTRL_REGWEN_EN_RESVAL = 1'h 1;
   parameter logic [10:0] FLASH_CTRL_DEBUG_STATE_RESVAL = 11'h 0;
@@ -1059,7 +1060,7 @@ package flash_ctrl_reg_pkg;
     4'b 0001, // index[  0] FLASH_CTRL_INTR_STATE
     4'b 0001, // index[  1] FLASH_CTRL_INTR_ENABLE
     4'b 0001, // index[  2] FLASH_CTRL_INTR_TEST
-    4'b 0001, // index[  3] FLASH_CTRL_ALERT_TEST
+    4'b 1111, // index[  3] FLASH_CTRL_ALERT_TEST
     4'b 0001, // index[  4] FLASH_CTRL_DIS
     4'b 1111, // index[  5] FLASH_CTRL_EXEC
     4'b 0001, // index[  6] FLASH_CTRL_INIT

--- a/hw/top_earlgrey/ip_autogen/gpio/doc/registers.md
+++ b/hw/top_earlgrey/ip_autogen/gpio/doc/registers.md
@@ -75,19 +75,20 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## DATA_IN
 GPIO Input data read value

--- a/hw/top_earlgrey/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
@@ -248,8 +248,9 @@ package gpio_reg_pkg;
   // Reset values for hwext registers and their fields
   parameter logic [31:0] GPIO_INTR_TEST_RESVAL = 32'h 0;
   parameter logic [31:0] GPIO_INTR_TEST_GPIO_RESVAL = 32'h 0;
-  parameter logic [0:0] GPIO_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] GPIO_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] GPIO_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] GPIO_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [31:0] GPIO_DIRECT_OUT_RESVAL = 32'h 0;
   parameter logic [31:0] GPIO_MASKED_OUT_LOWER_RESVAL = 32'h 0;
   parameter logic [31:0] GPIO_MASKED_OUT_UPPER_RESVAL = 32'h 0;
@@ -284,7 +285,7 @@ package gpio_reg_pkg;
     4'b 1111, // index[ 0] GPIO_INTR_STATE
     4'b 1111, // index[ 1] GPIO_INTR_ENABLE
     4'b 1111, // index[ 2] GPIO_INTR_TEST
-    4'b 0001, // index[ 3] GPIO_ALERT_TEST
+    4'b 1111, // index[ 3] GPIO_ALERT_TEST
     4'b 1111, // index[ 4] GPIO_DATA_IN
     4'b 1111, // index[ 5] GPIO_DIRECT_OUT
     4'b 1111, // index[ 6] GPIO_MASKED_OUT_LOWER

--- a/hw/top_earlgrey/ip_autogen/gpio/rtl/gpio_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/rtl/gpio_reg_top.sv
@@ -141,7 +141,9 @@ module gpio_reg_top
   logic intr_test_we;
   logic [31:0] intr_test_wd;
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic [31:0] data_in_qs;
   logic direct_out_re;
   logic direct_out_we;
@@ -270,14 +272,18 @@ module gpio_reg_top
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -286,6 +292,33 @@ module gpio_reg_top
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[data_in]: V(False)
@@ -812,7 +845,9 @@ module gpio_reg_top
   assign intr_test_wd = reg_wdata[31:0];
   assign alert_test_we = racl_addr_hit_write[3] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign direct_out_re = racl_addr_hit_read[5] & reg_re & !reg_error;
   assign direct_out_we = racl_addr_hit_write[5] & reg_we & !reg_error;
 
@@ -901,6 +936,7 @@ module gpio_reg_top
 
       racl_addr_hit_read[3]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       racl_addr_hit_read[4]: begin

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/doc/registers.md
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/doc/registers.md
@@ -121,23 +121,24 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x1f`
+- Reset default: `0x80000000`
+- Reset mask: `0x8000001f`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_macro_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_check_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_bus_integ_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_prim_otp_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_prim_otp_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 27}], "config": {"lanes": 1, "fontsize": 10, "vspace": 230}}
+{"reg": [{"name": "fatal_macro_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_check_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_bus_integ_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_prim_otp_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_prim_otp_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 26}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 230}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                  | Description                                      |
-|:------:|:------:|:-------:|:----------------------|:-------------------------------------------------|
-|  31:5  |        |         |                       | Reserved                                         |
-|   4    |   wo   |   0x0   | recov_prim_otp_alert  | Write 1 to trigger one alert event of this kind. |
-|   3    |   wo   |   0x0   | fatal_prim_otp_alert  | Write 1 to trigger one alert event of this kind. |
-|   2    |   wo   |   0x0   | fatal_bus_integ_error | Write 1 to trigger one alert event of this kind. |
-|   1    |   wo   |   0x0   | fatal_check_error     | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | fatal_macro_error     | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name                  | Description                                            |
+|:------:|:------:|:-------:|:----------------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen                | Write 0 to disable alert testing until the next reset. |
+|  30:5  |        |         |                       | Reserved                                               |
+|   4    |   wo   |   0x0   | recov_prim_otp_alert  | Write 1 to trigger one alert event of this kind.       |
+|   3    |   wo   |   0x0   | fatal_prim_otp_alert  | Write 1 to trigger one alert event of this kind.       |
+|   2    |   wo   |   0x0   | fatal_bus_integ_error | Write 1 to trigger one alert event of this kind.       |
+|   1    |   wo   |   0x0   | fatal_check_error     | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | fatal_macro_error     | Write 1 to trigger one alert event of this kind.       |
 
 ## STATUS
 OTP status register.

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
@@ -189,6 +189,8 @@ module otp_ctrl_core_reg_top (
   logic alert_test_fatal_bus_integ_error_wd;
   logic alert_test_fatal_prim_otp_alert_wd;
   logic alert_test_recov_prim_otp_alert_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic status_re;
   logic status_partition_error_qs;
   logic status_dai_error_qs;
@@ -486,14 +488,17 @@ module otp_ctrl_core_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [4:0] alert_test_flds_we;
+  logic [5:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[fatal_macro_error]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_fatal_macro_error (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_macro_error_wd),
     .d      ('0),
     .qre    (),
@@ -509,7 +514,7 @@ module otp_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_check_error (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_check_error_wd),
     .d      ('0),
     .qre    (),
@@ -525,7 +530,7 @@ module otp_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_bus_integ_error (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_bus_integ_error_wd),
     .d      ('0),
     .qre    (),
@@ -541,7 +546,7 @@ module otp_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_prim_otp_alert (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_prim_otp_alert_wd),
     .d      ('0),
     .qre    (),
@@ -557,7 +562,7 @@ module otp_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_recov_prim_otp_alert (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_prim_otp_alert_wd),
     .d      ('0),
     .qre    (),
@@ -567,6 +572,33 @@ module otp_ctrl_core_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.recov_prim_otp_alert.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[5]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[status]: V(True)
@@ -2169,6 +2201,8 @@ module otp_ctrl_core_reg_top (
   assign alert_test_fatal_prim_otp_alert_wd = reg_wdata[3];
 
   assign alert_test_recov_prim_otp_alert_wd = reg_wdata[4];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign status_re = addr_hit[4] & reg_re & !reg_error;
   assign partition_status_0_re = addr_hit[5] & reg_re & !reg_error;
   assign err_code_0_re = addr_hit[6] & reg_re & !reg_error;
@@ -2350,6 +2384,7 @@ module otp_ctrl_core_reg_top (
         reg_rdata_next[2] = '0;
         reg_rdata_next[3] = '0;
         reg_rdata_next[4] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -661,12 +661,13 @@ package otp_ctrl_reg_pkg;
   parameter logic [1:0] OTP_CTRL_INTR_TEST_RESVAL = 2'h 0;
   parameter logic [0:0] OTP_CTRL_INTR_TEST_OTP_OPERATION_DONE_RESVAL = 1'h 0;
   parameter logic [0:0] OTP_CTRL_INTR_TEST_OTP_ERROR_RESVAL = 1'h 0;
-  parameter logic [4:0] OTP_CTRL_ALERT_TEST_RESVAL = 5'h 0;
+  parameter logic [31:0] OTP_CTRL_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] OTP_CTRL_ALERT_TEST_FATAL_MACRO_ERROR_RESVAL = 1'h 0;
   parameter logic [0:0] OTP_CTRL_ALERT_TEST_FATAL_CHECK_ERROR_RESVAL = 1'h 0;
   parameter logic [0:0] OTP_CTRL_ALERT_TEST_FATAL_BUS_INTEG_ERROR_RESVAL = 1'h 0;
   parameter logic [0:0] OTP_CTRL_ALERT_TEST_FATAL_PRIM_OTP_ALERT_RESVAL = 1'h 0;
   parameter logic [0:0] OTP_CTRL_ALERT_TEST_RECOV_PRIM_OTP_ALERT_RESVAL = 1'h 0;
+  parameter logic [0:0] OTP_CTRL_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [9:0] OTP_CTRL_STATUS_RESVAL = 10'h 0;
   parameter logic [0:0] OTP_CTRL_STATUS_PARTITION_ERROR_RESVAL = 1'h 0;
   parameter logic [0:0] OTP_CTRL_STATUS_DAI_ERROR_RESVAL = 1'h 0;
@@ -850,7 +851,7 @@ package otp_ctrl_reg_pkg;
     4'b 0001, // index[ 0] OTP_CTRL_INTR_STATE
     4'b 0001, // index[ 1] OTP_CTRL_INTR_ENABLE
     4'b 0001, // index[ 2] OTP_CTRL_INTR_TEST
-    4'b 0001, // index[ 3] OTP_CTRL_ALERT_TEST
+    4'b 1111, // index[ 3] OTP_CTRL_ALERT_TEST
     4'b 0011, // index[ 4] OTP_CTRL_STATUS
     4'b 0011, // index[ 5] OTP_CTRL_PARTITION_STATUS_0
     4'b 0001, // index[ 6] OTP_CTRL_ERR_CODE_0

--- a/hw/top_earlgrey/ip_autogen/pinmux/doc/registers.md
+++ b/hw/top_earlgrey/ip_autogen/pinmux/doc/registers.md
@@ -577,19 +577,20 @@
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0x0`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## MIO_PERIPH_INSEL_REGWEN
 Register write enable for MIO peripheral input selects.

--- a/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
@@ -862,8 +862,9 @@ package pinmux_reg_pkg;
   parameter logic [BlockAw-1:0] PINMUX_WKUP_CAUSE_OFFSET = 12'h 8dc;
 
   // Reset values for hwext registers and their fields
-  parameter logic [0:0] PINMUX_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] PINMUX_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] PINMUX_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] PINMUX_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [23:0] PINMUX_MIO_PAD_ATTR_0_RESVAL = 24'h 0;
   parameter logic [0:0] PINMUX_MIO_PAD_ATTR_0_INVERT_0_RESVAL = 1'h 0;
   parameter logic [0:0] PINMUX_MIO_PAD_ATTR_0_VIRTUAL_OD_EN_0_RESVAL = 1'h 0;
@@ -2132,7 +2133,7 @@ package pinmux_reg_pkg;
 
   // Register width information to check illegal writes
   parameter logic [3:0] PINMUX_PERMIT [568] = '{
-    4'b 0001, // index[  0] PINMUX_ALERT_TEST
+    4'b 1111, // index[  0] PINMUX_ALERT_TEST
     4'b 0001, // index[  1] PINMUX_MIO_PERIPH_INSEL_REGWEN_0
     4'b 0001, // index[  2] PINMUX_MIO_PERIPH_INSEL_REGWEN_1
     4'b 0001, // index[  3] PINMUX_MIO_PERIPH_INSEL_REGWEN_2

--- a/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
@@ -124,7 +124,9 @@ module pinmux_reg_top (
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic mio_periph_insel_regwen_0_we;
   logic mio_periph_insel_regwen_0_qs;
   logic mio_periph_insel_regwen_0_wd;
@@ -4188,14 +4190,18 @@ module pinmux_reg_top (
   // Register instances
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -4204,6 +4210,33 @@ module pinmux_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // Subregister 0 of Multireg mio_periph_insel_regwen
@@ -33677,7 +33710,9 @@ module pinmux_reg_top (
   // Generate write-enables
   assign alert_test_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign mio_periph_insel_regwen_0_we = addr_hit[1] & reg_we & !reg_error;
 
   assign mio_periph_insel_regwen_0_wd = reg_wdata[0];
@@ -37273,6 +37308,7 @@ module pinmux_reg_top (
     unique case (1'b1)
       addr_hit[0]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[1]: begin

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/doc/registers.md
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/doc/registers.md
@@ -77,19 +77,20 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## CTRL_CFG_REGWEN
 Controls the configurability of the [`CONTROL`](#control) register.

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
@@ -239,8 +239,9 @@ package pwrmgr_reg_pkg;
   // Reset values for hwext registers and their fields
   parameter logic [0:0] PWRMGR_INTR_TEST_RESVAL = 1'h 0;
   parameter logic [0:0] PWRMGR_INTR_TEST_WAKEUP_RESVAL = 1'h 0;
-  parameter logic [0:0] PWRMGR_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] PWRMGR_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] PWRMGR_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] PWRMGR_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] PWRMGR_CTRL_CFG_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] PWRMGR_CTRL_CFG_REGWEN_EN_RESVAL = 1'h 1;
   parameter logic [7:0] PWRMGR_WAKE_INFO_RESVAL = 8'h 0;
@@ -274,7 +275,7 @@ package pwrmgr_reg_pkg;
     4'b 0001, // index[ 0] PWRMGR_INTR_STATE
     4'b 0001, // index[ 1] PWRMGR_INTR_ENABLE
     4'b 0001, // index[ 2] PWRMGR_INTR_TEST
-    4'b 0001, // index[ 3] PWRMGR_ALERT_TEST
+    4'b 1111, // index[ 3] PWRMGR_ALERT_TEST
     4'b 0001, // index[ 4] PWRMGR_CTRL_CFG_REGWEN
     4'b 0011, // index[ 5] PWRMGR_CONTROL
     4'b 0001, // index[ 6] PWRMGR_CFG_CDC_SYNC

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
@@ -132,7 +132,9 @@ module pwrmgr_reg_top (
   logic intr_test_we;
   logic intr_test_wd;
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic ctrl_cfg_regwen_re;
   logic ctrl_cfg_regwen_qs;
   logic control_we;
@@ -280,14 +282,18 @@ module pwrmgr_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -296,6 +302,33 @@ module pwrmgr_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[ctrl_cfg_regwen]: V(True)
@@ -1279,7 +1312,9 @@ module pwrmgr_reg_top (
   assign intr_test_wd = reg_wdata[0];
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign ctrl_cfg_regwen_re = addr_hit[4] & reg_re & !reg_error;
   assign control_we = addr_hit[5] & reg_we & !reg_error;
 
@@ -1372,6 +1407,7 @@ module pwrmgr_reg_top (
 
       addr_hit[3]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/top_earlgrey/ip_autogen/rstmgr/doc/registers.md
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/doc/registers.md
@@ -37,20 +37,21 @@
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0x0`
-- Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000003`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_cnsty_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 190}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_cnsty_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 29}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 190}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name              | Description                                      |
-|:------:|:------:|:-------:|:------------------|:-------------------------------------------------|
-|  31:2  |        |         |                   | Reserved                                         |
-|   1    |   wo   |   0x0   | fatal_cnsty_fault | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | fatal_fault       | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name              | Description                                            |
+|:------:|:------:|:-------:|:------------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen            | Write 0 to disable alert testing until the next reset. |
+|  30:2  |        |         |                   | Reserved                                               |
+|   1    |   wo   |   0x0   | fatal_cnsty_fault | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | fatal_fault       | Write 1 to trigger one alert event of this kind.       |
 
 ## RESET_REQ
 Software requested system reset.

--- a/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
@@ -208,9 +208,10 @@ package rstmgr_reg_pkg;
   parameter logic [BlockAw-1:0] RSTMGR_ERR_CODE_OFFSET = 7'h 6c;
 
   // Reset values for hwext registers and their fields
-  parameter logic [1:0] RSTMGR_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [31:0] RSTMGR_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] RSTMGR_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
   parameter logic [0:0] RSTMGR_ALERT_TEST_FATAL_CNSTY_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] RSTMGR_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [3:0] RSTMGR_ALERT_INFO_ATTR_RESVAL = 4'h 0;
   parameter logic [3:0] RSTMGR_ALERT_INFO_ATTR_CNT_AVAIL_RESVAL = 4'h 0;
   parameter logic [31:0] RSTMGR_ALERT_INFO_RESVAL = 32'h 0;
@@ -254,7 +255,7 @@ package rstmgr_reg_pkg;
 
   // Register width information to check illegal writes
   parameter logic [3:0] RSTMGR_PERMIT [28] = '{
-    4'b 0001, // index[ 0] RSTMGR_ALERT_TEST
+    4'b 1111, // index[ 0] RSTMGR_ALERT_TEST
     4'b 0001, // index[ 1] RSTMGR_RESET_REQ
     4'b 0001, // index[ 2] RSTMGR_RESET_INFO
     4'b 0001, // index[ 3] RSTMGR_ALERT_REGWEN

--- a/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
@@ -126,6 +126,8 @@ module rstmgr_reg_top (
   logic alert_test_we;
   logic alert_test_fatal_fault_wd;
   logic alert_test_fatal_cnsty_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic reset_req_we;
   logic [3:0] reset_req_qs;
   logic [3:0] reset_req_wd;
@@ -219,14 +221,17 @@ module rstmgr_reg_top (
   // Register instances
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [1:0] alert_test_flds_we;
+  logic [2:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
@@ -242,7 +247,7 @@ module rstmgr_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_cnsty_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_cnsty_fault_wd),
     .d      ('0),
     .qre    (),
@@ -252,6 +257,33 @@ module rstmgr_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_cnsty_fault.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[2]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[reset_req]: V(False)
@@ -1283,6 +1315,8 @@ module rstmgr_reg_top (
   assign alert_test_fatal_fault_wd = reg_wdata[0];
 
   assign alert_test_fatal_cnsty_fault_wd = reg_wdata[1];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign reset_req_we = addr_hit[1] & reg_we & !reg_error;
 
   assign reset_req_wd = reg_wdata[3:0];
@@ -1403,6 +1437,7 @@ module rstmgr_reg_top (
       addr_hit[0]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[1]: begin

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/doc/registers.md
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/doc/registers.md
@@ -39,22 +39,23 @@ A number of memory-mapped registers are available to control Ibex-related functi
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0x0`
-- Reset default: `0x0`
-- Reset mask: `0xf`
+- Reset default: `0x80000000`
+- Reset mask: `0x8000000f`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_sw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_sw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_hw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_hw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 28}], "config": {"lanes": 1, "fontsize": 10, "vspace": 140}}
+{"reg": [{"name": "fatal_sw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_sw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_hw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_hw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 27}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 140}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name         | Description                                      |
-|:------:|:------:|:-------:|:-------------|:-------------------------------------------------|
-|  31:4  |        |         |              | Reserved                                         |
-|   3    |   wo   |   0x0   | recov_hw_err | Write 1 to trigger one alert event of this kind. |
-|   2    |   wo   |   0x0   | fatal_hw_err | Write 1 to trigger one alert event of this kind. |
-|   1    |   wo   |   0x0   | recov_sw_err | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | fatal_sw_err | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name         | Description                                            |
+|:------:|:------:|:-------:|:-------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen       | Write 0 to disable alert testing until the next reset. |
+|  30:4  |        |         |              | Reserved                                               |
+|   3    |   wo   |   0x0   | recov_hw_err | Write 1 to trigger one alert event of this kind.       |
+|   2    |   wo   |   0x0   | fatal_hw_err | Write 1 to trigger one alert event of this kind.       |
+|   1    |   wo   |   0x0   | recov_sw_err | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | fatal_sw_err | Write 1 to trigger one alert event of this kind.       |
 
 ## SW_RECOV_ERR
 Software recoverable error

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
@@ -175,6 +175,8 @@ module rv_core_ibex_cfg_reg_top (
   logic alert_test_recov_sw_err_wd;
   logic alert_test_fatal_hw_err_wd;
   logic alert_test_recov_hw_err_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic sw_recov_err_we;
   logic [3:0] sw_recov_err_qs;
   logic [3:0] sw_recov_err_wd;
@@ -265,14 +267,17 @@ module rv_core_ibex_cfg_reg_top (
   // Register instances
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [3:0] alert_test_flds_we;
+  logic [4:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[fatal_sw_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_fatal_sw_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_sw_err_wd),
     .d      ('0),
     .qre    (),
@@ -288,7 +293,7 @@ module rv_core_ibex_cfg_reg_top (
     .DW    (1)
   ) u_alert_test_recov_sw_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_sw_err_wd),
     .d      ('0),
     .qre    (),
@@ -304,7 +309,7 @@ module rv_core_ibex_cfg_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_hw_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_hw_err_wd),
     .d      ('0),
     .qre    (),
@@ -320,7 +325,7 @@ module rv_core_ibex_cfg_reg_top (
     .DW    (1)
   ) u_alert_test_recov_hw_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_hw_err_wd),
     .d      ('0),
     .qre    (),
@@ -330,6 +335,33 @@ module rv_core_ibex_cfg_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.recov_hw_err.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[4]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[sw_recov_err]: V(False)
@@ -1453,6 +1485,8 @@ module rv_core_ibex_cfg_reg_top (
   assign alert_test_fatal_hw_err_wd = reg_wdata[2];
 
   assign alert_test_recov_hw_err_wd = reg_wdata[3];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign sw_recov_err_we = addr_hit[1] & reg_we & !reg_error;
 
   assign sw_recov_err_wd = reg_wdata[3:0];
@@ -1576,6 +1610,7 @@ module rv_core_ibex_cfg_reg_top (
         reg_rdata_next[1] = '0;
         reg_rdata_next[2] = '0;
         reg_rdata_next[3] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[1]: begin

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
@@ -223,11 +223,12 @@ package rv_core_ibex_reg_pkg;
   parameter logic [CfgAw-1:0] RV_CORE_IBEX_MCOUNTEREN_WRITABLE_OFFSET = 8'h 68;
 
   // Reset values for hwext registers and their fields for cfg interface
-  parameter logic [3:0] RV_CORE_IBEX_ALERT_TEST_RESVAL = 4'h 0;
+  parameter logic [31:0] RV_CORE_IBEX_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] RV_CORE_IBEX_ALERT_TEST_FATAL_SW_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] RV_CORE_IBEX_ALERT_TEST_RECOV_SW_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] RV_CORE_IBEX_ALERT_TEST_FATAL_HW_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] RV_CORE_IBEX_ALERT_TEST_RECOV_HW_ERR_RESVAL = 1'h 0;
+  parameter logic [0:0] RV_CORE_IBEX_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [31:0] RV_CORE_IBEX_RND_DATA_RESVAL = 32'h 0;
   parameter logic [31:0] RV_CORE_IBEX_RND_DATA_DATA_RESVAL = 32'h 0;
   parameter logic [1:0] RV_CORE_IBEX_RND_STATUS_RESVAL = 2'h 0;
@@ -274,7 +275,7 @@ package rv_core_ibex_reg_pkg;
 
   // Register width information to check illegal writes for cfg interface
   parameter logic [3:0] RV_CORE_IBEX_CFG_PERMIT [27] = '{
-    4'b 0001, // index[ 0] RV_CORE_IBEX_ALERT_TEST
+    4'b 1111, // index[ 0] RV_CORE_IBEX_ALERT_TEST
     4'b 0001, // index[ 1] RV_CORE_IBEX_SW_RECOV_ERR
     4'b 0001, // index[ 2] RV_CORE_IBEX_SW_FATAL_ERR
     4'b 0001, // index[ 3] RV_CORE_IBEX_IBUS_REGWEN_0

--- a/hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic.hjson
@@ -199,10 +199,18 @@
       hwaccess: "hro",
       hwqe:     "True",
       hwext:    "True",
+      inregwen: "regwen",
       fields: [
         { bits: "0",
           name: "fatal_fault",
           desc: "'Write 1 to trigger one alert event of this kind.'",
+        }
+        { bits: "31",
+          name: "regwen",
+          swaccess: "rw0c",
+          hwaccess: "none",
+          resval: "1",
+          desc: "Write 0 to disable alert testing until the next reset.",
         }
       ],
     }

--- a/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
@@ -283,7 +283,8 @@ package rv_plic_reg_pkg;
 
   // Reset values for hwext registers and their fields
   parameter logic [7:0] RV_PLIC_CC0_RESVAL = 8'h 0;
-  parameter logic [0:0] RV_PLIC_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] RV_PLIC_ALERT_TEST_RESVAL = 32'h 80000000;
+  parameter logic [0:0] RV_PLIC_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
 
   // Register index
   typedef enum int {
@@ -690,7 +691,7 @@ package rv_plic_reg_pkg;
     4'b 0001, // index[196] RV_PLIC_THRESHOLD0
     4'b 0001, // index[197] RV_PLIC_CC0
     4'b 0001, // index[198] RV_PLIC_MSIP0
-    4'b 0001  // index[199] RV_PLIC_ALERT_TEST
+    4'b 1111  // index[199] RV_PLIC_ALERT_TEST
   };
 
 endpackage

--- a/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
@@ -1242,7 +1242,9 @@ module rv_plic_reg_top (
   logic msip0_qs;
   logic msip0_wd;
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
 
   // Register instances
   // Subregister 0 of Multireg prio
@@ -16631,14 +16633,18 @@ module rv_plic_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -16647,6 +16653,33 @@ module rv_plic_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
 
@@ -18000,7 +18033,9 @@ module rv_plic_reg_top (
   assign msip0_wd = reg_wdata[0];
   assign alert_test_we = addr_hit[199] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
 
   // Assign write-enables to checker logic vector.
   always_comb begin
@@ -19364,6 +19399,7 @@ module rv_plic_reg_top (
 
       addr_hit[199]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       default: begin

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/doc/registers.md
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/doc/registers.md
@@ -29,20 +29,21 @@
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0x0`
-- Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000003`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "recov_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "recov_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 29}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:2  |        |         |             | Reserved                                         |
-|   1    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | recov_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:2  |        |         |             | Reserved                                               |
+|   1    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | recov_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## EXTCLK_CTRL_REGWEN
 External clock control write enable

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
@@ -282,9 +282,10 @@ package clkmgr_reg_pkg;
   parameter logic [BlockAw-1:0] CLKMGR_FATAL_ERR_CODE_OFFSET = 7'h 4c;
 
   // Reset values for hwext registers and their fields
-  parameter logic [1:0] CLKMGR_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [31:0] CLKMGR_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] CLKMGR_ALERT_TEST_RECOV_FAULT_RESVAL = 1'h 0;
   parameter logic [0:0] CLKMGR_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] CLKMGR_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [3:0] CLKMGR_EXTCLK_STATUS_RESVAL = 4'h 9;
   parameter logic [3:0] CLKMGR_EXTCLK_STATUS_ACK_RESVAL = 4'h 9;
 
@@ -314,7 +315,7 @@ package clkmgr_reg_pkg;
 
   // Register width information to check illegal writes
   parameter logic [3:0] CLKMGR_PERMIT [20] = '{
-    4'b 0001, // index[ 0] CLKMGR_ALERT_TEST
+    4'b 1111, // index[ 0] CLKMGR_ALERT_TEST
     4'b 0001, // index[ 1] CLKMGR_EXTCLK_CTRL_REGWEN
     4'b 0001, // index[ 2] CLKMGR_EXTCLK_CTRL
     4'b 0001, // index[ 3] CLKMGR_EXTCLK_STATUS

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -136,6 +136,8 @@ module clkmgr_reg_top (
   logic alert_test_we;
   logic alert_test_recov_fault_wd;
   logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic extclk_ctrl_regwen_we;
   logic extclk_ctrl_regwen_qs;
   logic extclk_ctrl_regwen_wd;
@@ -584,14 +586,17 @@ module clkmgr_reg_top (
   // Register instances
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [1:0] alert_test_flds_we;
+  logic [2:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[recov_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_recov_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_fault_wd),
     .d      ('0),
     .qre    (),
@@ -607,7 +612,7 @@ module clkmgr_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
@@ -617,6 +622,33 @@ module clkmgr_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_fault.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[2]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[extclk_ctrl_regwen]: V(False)
@@ -2087,6 +2119,8 @@ module clkmgr_reg_top (
   assign alert_test_recov_fault_wd = reg_wdata[0];
 
   assign alert_test_fatal_fault_wd = reg_wdata[1];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign extclk_ctrl_regwen_we = addr_hit[1] & reg_we & !reg_error;
 
   assign extclk_ctrl_regwen_wd = reg_wdata[0];
@@ -2192,6 +2226,7 @@ module clkmgr_reg_top (
       addr_hit[0]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[1]: begin

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/doc/registers.md
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/doc/registers.md
@@ -188,23 +188,24 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x1f`
+- Reset default: `0x80000000`
+- Reset mask: `0x8000001f`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "recov_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_std_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_prim_flash_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_prim_flash_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 27}], "config": {"lanes": 1, "fontsize": 10, "vspace": 240}}
+{"reg": [{"name": "recov_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_std_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_prim_flash_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_prim_flash_alert", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 26}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 240}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                   | Description                                      |
-|:------:|:------:|:-------:|:-----------------------|:-------------------------------------------------|
-|  31:5  |        |         |                        | Reserved                                         |
-|   4    |   wo   |   0x0   | recov_prim_flash_alert | Write 1 to trigger one alert event of this kind. |
-|   3    |   wo   |   0x0   | fatal_prim_flash_alert | Write 1 to trigger one alert event of this kind. |
-|   2    |   wo   |   0x0   | fatal_err              | Write 1 to trigger one alert event of this kind. |
-|   1    |   wo   |   0x0   | fatal_std_err          | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | recov_err              | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name                   | Description                                            |
+|:------:|:------:|:-------:|:-----------------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen                 | Write 0 to disable alert testing until the next reset. |
+|  30:5  |        |         |                        | Reserved                                               |
+|   4    |   wo   |   0x0   | recov_prim_flash_alert | Write 1 to trigger one alert event of this kind.       |
+|   3    |   wo   |   0x0   | fatal_prim_flash_alert | Write 1 to trigger one alert event of this kind.       |
+|   2    |   wo   |   0x0   | fatal_err              | Write 1 to trigger one alert event of this kind.       |
+|   1    |   wo   |   0x0   | fatal_std_err          | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | recov_err              | Write 1 to trigger one alert event of this kind.       |
 
 ## DIS
 Disable flash functionality

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -212,6 +212,8 @@ module flash_ctrl_core_reg_top (
   logic alert_test_fatal_err_wd;
   logic alert_test_fatal_prim_flash_alert_wd;
   logic alert_test_recov_prim_flash_alert_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic dis_we;
   logic [3:0] dis_qs;
   logic [3:0] dis_wd;
@@ -1449,14 +1451,17 @@ module flash_ctrl_core_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [4:0] alert_test_flds_we;
+  logic [5:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[recov_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_recov_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_err_wd),
     .d      ('0),
     .qre    (),
@@ -1472,7 +1477,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_std_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_std_err_wd),
     .d      ('0),
     .qre    (),
@@ -1488,7 +1493,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_err_wd),
     .d      ('0),
     .qre    (),
@@ -1504,7 +1509,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_prim_flash_alert (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_prim_flash_alert_wd),
     .d      ('0),
     .qre    (),
@@ -1520,7 +1525,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_recov_prim_flash_alert (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_prim_flash_alert_wd),
     .d      ('0),
     .qre    (),
@@ -1530,6 +1535,33 @@ module flash_ctrl_core_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.recov_prim_flash_alert.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[5]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[dis]: V(False)
@@ -12088,6 +12120,8 @@ module flash_ctrl_core_reg_top (
   assign alert_test_fatal_prim_flash_alert_wd = reg_wdata[3];
 
   assign alert_test_recov_prim_flash_alert_wd = reg_wdata[4];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign dis_we = addr_hit[4] & reg_we & !reg_error;
 
   assign dis_wd = reg_wdata[3:0];
@@ -13003,6 +13037,7 @@ module flash_ctrl_core_reg_top (
         reg_rdata_next[2] = '0;
         reg_rdata_next[3] = '0;
         reg_rdata_next[4] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -921,12 +921,13 @@ package flash_ctrl_reg_pkg;
   parameter logic [0:0] FLASH_CTRL_INTR_TEST_RD_LVL_RESVAL = 1'h 0;
   parameter logic [0:0] FLASH_CTRL_INTR_TEST_OP_DONE_RESVAL = 1'h 0;
   parameter logic [0:0] FLASH_CTRL_INTR_TEST_CORR_ERR_RESVAL = 1'h 0;
-  parameter logic [4:0] FLASH_CTRL_ALERT_TEST_RESVAL = 5'h 0;
+  parameter logic [31:0] FLASH_CTRL_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] FLASH_CTRL_ALERT_TEST_RECOV_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] FLASH_CTRL_ALERT_TEST_FATAL_STD_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] FLASH_CTRL_ALERT_TEST_FATAL_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] FLASH_CTRL_ALERT_TEST_FATAL_PRIM_FLASH_ALERT_RESVAL = 1'h 0;
   parameter logic [0:0] FLASH_CTRL_ALERT_TEST_RECOV_PRIM_FLASH_ALERT_RESVAL = 1'h 0;
+  parameter logic [0:0] FLASH_CTRL_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] FLASH_CTRL_CTRL_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] FLASH_CTRL_CTRL_REGWEN_EN_RESVAL = 1'h 1;
   parameter logic [10:0] FLASH_CTRL_DEBUG_STATE_RESVAL = 11'h 0;
@@ -1059,7 +1060,7 @@ package flash_ctrl_reg_pkg;
     4'b 0001, // index[  0] FLASH_CTRL_INTR_STATE
     4'b 0001, // index[  1] FLASH_CTRL_INTR_ENABLE
     4'b 0001, // index[  2] FLASH_CTRL_INTR_TEST
-    4'b 0001, // index[  3] FLASH_CTRL_ALERT_TEST
+    4'b 1111, // index[  3] FLASH_CTRL_ALERT_TEST
     4'b 0001, // index[  4] FLASH_CTRL_DIS
     4'b 1111, // index[  5] FLASH_CTRL_EXEC
     4'b 0001, // index[  6] FLASH_CTRL_INIT

--- a/hw/top_englishbreakfast/ip_autogen/gpio/doc/registers.md
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/doc/registers.md
@@ -75,19 +75,20 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## DATA_IN
 GPIO Input data read value

--- a/hw/top_englishbreakfast/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
@@ -248,8 +248,9 @@ package gpio_reg_pkg;
   // Reset values for hwext registers and their fields
   parameter logic [31:0] GPIO_INTR_TEST_RESVAL = 32'h 0;
   parameter logic [31:0] GPIO_INTR_TEST_GPIO_RESVAL = 32'h 0;
-  parameter logic [0:0] GPIO_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] GPIO_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] GPIO_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] GPIO_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [31:0] GPIO_DIRECT_OUT_RESVAL = 32'h 0;
   parameter logic [31:0] GPIO_MASKED_OUT_LOWER_RESVAL = 32'h 0;
   parameter logic [31:0] GPIO_MASKED_OUT_UPPER_RESVAL = 32'h 0;
@@ -284,7 +285,7 @@ package gpio_reg_pkg;
     4'b 1111, // index[ 0] GPIO_INTR_STATE
     4'b 1111, // index[ 1] GPIO_INTR_ENABLE
     4'b 1111, // index[ 2] GPIO_INTR_TEST
-    4'b 0001, // index[ 3] GPIO_ALERT_TEST
+    4'b 1111, // index[ 3] GPIO_ALERT_TEST
     4'b 1111, // index[ 4] GPIO_DATA_IN
     4'b 1111, // index[ 5] GPIO_DIRECT_OUT
     4'b 1111, // index[ 6] GPIO_MASKED_OUT_LOWER

--- a/hw/top_englishbreakfast/ip_autogen/gpio/rtl/gpio_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/rtl/gpio_reg_top.sv
@@ -141,7 +141,9 @@ module gpio_reg_top
   logic intr_test_we;
   logic [31:0] intr_test_wd;
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic [31:0] data_in_qs;
   logic direct_out_re;
   logic direct_out_we;
@@ -270,14 +272,18 @@ module gpio_reg_top
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -286,6 +292,33 @@ module gpio_reg_top
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[data_in]: V(False)
@@ -812,7 +845,9 @@ module gpio_reg_top
   assign intr_test_wd = reg_wdata[31:0];
   assign alert_test_we = racl_addr_hit_write[3] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign direct_out_re = racl_addr_hit_read[5] & reg_re & !reg_error;
   assign direct_out_we = racl_addr_hit_write[5] & reg_we & !reg_error;
 
@@ -901,6 +936,7 @@ module gpio_reg_top
 
       racl_addr_hit_read[3]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       racl_addr_hit_read[4]: begin

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/doc/registers.md
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/doc/registers.md
@@ -529,19 +529,20 @@
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0x0`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## MIO_PERIPH_INSEL_REGWEN
 Register write enable for MIO peripheral input selects.

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
@@ -814,8 +814,9 @@ package pinmux_reg_pkg;
   parameter logic [BlockAw-1:0] PINMUX_WKUP_CAUSE_OFFSET = 12'h 81c;
 
   // Reset values for hwext registers and their fields
-  parameter logic [0:0] PINMUX_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] PINMUX_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] PINMUX_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] PINMUX_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [23:0] PINMUX_MIO_PAD_ATTR_0_RESVAL = 24'h 0;
   parameter logic [0:0] PINMUX_MIO_PAD_ATTR_0_INVERT_0_RESVAL = 1'h 0;
   parameter logic [0:0] PINMUX_MIO_PAD_ATTR_0_VIRTUAL_OD_EN_0_RESVAL = 1'h 0;
@@ -2014,7 +2015,7 @@ package pinmux_reg_pkg;
 
   // Register width information to check illegal writes
   parameter logic [3:0] PINMUX_PERMIT [520] = '{
-    4'b 0001, // index[  0] PINMUX_ALERT_TEST
+    4'b 1111, // index[  0] PINMUX_ALERT_TEST
     4'b 0001, // index[  1] PINMUX_MIO_PERIPH_INSEL_REGWEN_0
     4'b 0001, // index[  2] PINMUX_MIO_PERIPH_INSEL_REGWEN_1
     4'b 0001, // index[  3] PINMUX_MIO_PERIPH_INSEL_REGWEN_2

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
@@ -124,7 +124,9 @@ module pinmux_reg_top (
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic mio_periph_insel_regwen_0_we;
   logic mio_periph_insel_regwen_0_qs;
   logic mio_periph_insel_regwen_0_wd;
@@ -4002,14 +4004,18 @@ module pinmux_reg_top (
   // Register instances
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -4018,6 +4024,33 @@ module pinmux_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // Subregister 0 of Multireg mio_periph_insel_regwen
@@ -31600,7 +31633,9 @@ module pinmux_reg_top (
   // Generate write-enables
   assign alert_test_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign mio_periph_insel_regwen_0_we = addr_hit[1] & reg_we & !reg_error;
 
   assign mio_periph_insel_regwen_0_wd = reg_wdata[0];
@@ -34962,6 +34997,7 @@ module pinmux_reg_top (
     unique case (1'b1)
       addr_hit[0]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[1]: begin

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/doc/registers.md
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/doc/registers.md
@@ -77,19 +77,20 @@ Interrupt Test Register
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0xc`
-- Reset default: `0x0`
-- Reset mask: `0x1`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000001`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name        | Description                                      |
-|:------:|:------:|:-------:|:------------|:-------------------------------------------------|
-|  31:1  |        |         |             | Reserved                                         |
-|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name        | Description                                            |
+|:------:|:------:|:-------:|:------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen      | Write 0 to disable alert testing until the next reset. |
+|  30:1  |        |         |             | Reserved                                               |
+|   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind.       |
 
 ## CTRL_CFG_REGWEN
 Controls the configurability of the [`CONTROL`](#control) register.

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
@@ -231,8 +231,9 @@ package pwrmgr_reg_pkg;
   // Reset values for hwext registers and their fields
   parameter logic [0:0] PWRMGR_INTR_TEST_RESVAL = 1'h 0;
   parameter logic [0:0] PWRMGR_INTR_TEST_WAKEUP_RESVAL = 1'h 0;
-  parameter logic [0:0] PWRMGR_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] PWRMGR_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] PWRMGR_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] PWRMGR_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] PWRMGR_CTRL_CFG_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] PWRMGR_CTRL_CFG_REGWEN_EN_RESVAL = 1'h 1;
   parameter logic [4:0] PWRMGR_WAKE_INFO_RESVAL = 5'h 0;
@@ -266,7 +267,7 @@ package pwrmgr_reg_pkg;
     4'b 0001, // index[ 0] PWRMGR_INTR_STATE
     4'b 0001, // index[ 1] PWRMGR_INTR_ENABLE
     4'b 0001, // index[ 2] PWRMGR_INTR_TEST
-    4'b 0001, // index[ 3] PWRMGR_ALERT_TEST
+    4'b 1111, // index[ 3] PWRMGR_ALERT_TEST
     4'b 0001, // index[ 4] PWRMGR_CTRL_CFG_REGWEN
     4'b 0011, // index[ 5] PWRMGR_CONTROL
     4'b 0001, // index[ 6] PWRMGR_CFG_CDC_SYNC

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
@@ -132,7 +132,9 @@ module pwrmgr_reg_top (
   logic intr_test_we;
   logic intr_test_wd;
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic ctrl_cfg_regwen_re;
   logic ctrl_cfg_regwen_qs;
   logic control_we;
@@ -268,14 +270,18 @@ module pwrmgr_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -284,6 +290,33 @@ module pwrmgr_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[ctrl_cfg_regwen]: V(True)
@@ -1049,7 +1082,9 @@ module pwrmgr_reg_top (
   assign intr_test_wd = reg_wdata[0];
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign ctrl_cfg_regwen_re = addr_hit[4] & reg_re & !reg_error;
   assign control_we = addr_hit[5] & reg_we & !reg_error;
 
@@ -1134,6 +1169,7 @@ module pwrmgr_reg_top (
 
       addr_hit[3]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/doc/registers.md
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/doc/registers.md
@@ -27,20 +27,21 @@
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0x0`
-- Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset default: `0x80000000`
+- Reset mask: `0x80000003`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_cnsty_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 190}}
+{"reg": [{"name": "fatal_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_cnsty_fault", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 29}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 190}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name              | Description                                      |
-|:------:|:------:|:-------:|:------------------|:-------------------------------------------------|
-|  31:2  |        |         |                   | Reserved                                         |
-|   1    |   wo   |   0x0   | fatal_cnsty_fault | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | fatal_fault       | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name              | Description                                            |
+|:------:|:------:|:-------:|:------------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen            | Write 0 to disable alert testing until the next reset. |
+|  30:2  |        |         |                   | Reserved                                               |
+|   1    |   wo   |   0x0   | fatal_cnsty_fault | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | fatal_fault       | Write 1 to trigger one alert event of this kind.       |
 
 ## RESET_REQ
 Software requested system reset.

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
@@ -198,9 +198,10 @@ package rstmgr_reg_pkg;
   parameter logic [BlockAw-1:0] RSTMGR_ERR_CODE_OFFSET = 7'h 44;
 
   // Reset values for hwext registers and their fields
-  parameter logic [1:0] RSTMGR_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [31:0] RSTMGR_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] RSTMGR_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
   parameter logic [0:0] RSTMGR_ALERT_TEST_FATAL_CNSTY_FAULT_RESVAL = 1'h 0;
+  parameter logic [0:0] RSTMGR_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [3:0] RSTMGR_ALERT_INFO_ATTR_RESVAL = 4'h 0;
   parameter logic [3:0] RSTMGR_ALERT_INFO_ATTR_CNT_AVAIL_RESVAL = 4'h 0;
   parameter logic [31:0] RSTMGR_ALERT_INFO_RESVAL = 32'h 0;
@@ -234,7 +235,7 @@ package rstmgr_reg_pkg;
 
   // Register width information to check illegal writes
   parameter logic [3:0] RSTMGR_PERMIT [18] = '{
-    4'b 0001, // index[ 0] RSTMGR_ALERT_TEST
+    4'b 1111, // index[ 0] RSTMGR_ALERT_TEST
     4'b 0001, // index[ 1] RSTMGR_RESET_REQ
     4'b 0001, // index[ 2] RSTMGR_RESET_INFO
     4'b 0001, // index[ 3] RSTMGR_ALERT_REGWEN

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
@@ -126,6 +126,8 @@ module rstmgr_reg_top (
   logic alert_test_we;
   logic alert_test_fatal_fault_wd;
   logic alert_test_fatal_cnsty_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic reset_req_we;
   logic [3:0] reset_req_qs;
   logic [3:0] reset_req_wd;
@@ -189,14 +191,17 @@ module rstmgr_reg_top (
   // Register instances
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [1:0] alert_test_flds_we;
+  logic [2:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
@@ -212,7 +217,7 @@ module rstmgr_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_cnsty_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_cnsty_fault_wd),
     .d      ('0),
     .qre    (),
@@ -222,6 +227,33 @@ module rstmgr_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.fatal_cnsty_fault.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[2]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[reset_req]: V(False)
@@ -928,6 +960,8 @@ module rstmgr_reg_top (
   assign alert_test_fatal_fault_wd = reg_wdata[0];
 
   assign alert_test_fatal_cnsty_fault_wd = reg_wdata[1];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign reset_req_we = addr_hit[1] & reg_we & !reg_error;
 
   assign reset_req_wd = reg_wdata[3:0];
@@ -1008,6 +1042,7 @@ module rstmgr_reg_top (
       addr_hit[0]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[1]: begin

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/doc/registers.md
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/doc/registers.md
@@ -39,22 +39,23 @@ A number of memory-mapped registers are available to control Ibex-related functi
 ## ALERT_TEST
 Alert Test Register
 - Offset: `0x0`
-- Reset default: `0x0`
-- Reset mask: `0xf`
+- Reset default: `0x80000000`
+- Reset mask: `0x8000000f`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fatal_sw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_sw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_hw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_hw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 28}], "config": {"lanes": 1, "fontsize": 10, "vspace": 140}}
+{"reg": [{"name": "fatal_sw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_sw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "fatal_hw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "recov_hw_err", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 27}, {"name": "regwen", "bits": 1, "attr": ["rw0c"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 140}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name         | Description                                      |
-|:------:|:------:|:-------:|:-------------|:-------------------------------------------------|
-|  31:4  |        |         |              | Reserved                                         |
-|   3    |   wo   |   0x0   | recov_hw_err | Write 1 to trigger one alert event of this kind. |
-|   2    |   wo   |   0x0   | fatal_hw_err | Write 1 to trigger one alert event of this kind. |
-|   1    |   wo   |   0x0   | recov_sw_err | Write 1 to trigger one alert event of this kind. |
-|   0    |   wo   |   0x0   | fatal_sw_err | Write 1 to trigger one alert event of this kind. |
+|  Bits  |  Type  |  Reset  | Name         | Description                                            |
+|:------:|:------:|:-------:|:-------------|:-------------------------------------------------------|
+|   31   |  rw0c  |   0x1   | regwen       | Write 0 to disable alert testing until the next reset. |
+|  30:4  |        |         |              | Reserved                                               |
+|   3    |   wo   |   0x0   | recov_hw_err | Write 1 to trigger one alert event of this kind.       |
+|   2    |   wo   |   0x0   | fatal_hw_err | Write 1 to trigger one alert event of this kind.       |
+|   1    |   wo   |   0x0   | recov_sw_err | Write 1 to trigger one alert event of this kind.       |
+|   0    |   wo   |   0x0   | fatal_sw_err | Write 1 to trigger one alert event of this kind.       |
 
 ## SW_RECOV_ERR
 Software recoverable error

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
@@ -175,6 +175,8 @@ module rv_core_ibex_cfg_reg_top (
   logic alert_test_recov_sw_err_wd;
   logic alert_test_fatal_hw_err_wd;
   logic alert_test_recov_hw_err_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
   logic sw_recov_err_we;
   logic [3:0] sw_recov_err_qs;
   logic [3:0] sw_recov_err_wd;
@@ -265,14 +267,17 @@ module rv_core_ibex_cfg_reg_top (
   // Register instances
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [3:0] alert_test_flds_we;
+  logic [4:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
   //   F[fatal_sw_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test_fatal_sw_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_sw_err_wd),
     .d      ('0),
     .qre    (),
@@ -288,7 +293,7 @@ module rv_core_ibex_cfg_reg_top (
     .DW    (1)
   ) u_alert_test_recov_sw_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_sw_err_wd),
     .d      ('0),
     .qre    (),
@@ -304,7 +309,7 @@ module rv_core_ibex_cfg_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_hw_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_fatal_hw_err_wd),
     .d      ('0),
     .qre    (),
@@ -320,7 +325,7 @@ module rv_core_ibex_cfg_reg_top (
     .DW    (1)
   ) u_alert_test_recov_hw_err (
     .re     (1'b0),
-    .we     (alert_test_we),
+    .we     (alert_test_gated_we),
     .wd     (alert_test_recov_hw_err_wd),
     .d      ('0),
     .qre    (),
@@ -330,6 +335,33 @@ module rv_core_ibex_cfg_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.recov_hw_err.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[4]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
   // R[sw_recov_err]: V(False)
@@ -1453,6 +1485,8 @@ module rv_core_ibex_cfg_reg_top (
   assign alert_test_fatal_hw_err_wd = reg_wdata[2];
 
   assign alert_test_recov_hw_err_wd = reg_wdata[3];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
   assign sw_recov_err_we = addr_hit[1] & reg_we & !reg_error;
 
   assign sw_recov_err_wd = reg_wdata[3:0];
@@ -1576,6 +1610,7 @@ module rv_core_ibex_cfg_reg_top (
         reg_rdata_next[1] = '0;
         reg_rdata_next[2] = '0;
         reg_rdata_next[3] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       addr_hit[1]: begin

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
@@ -223,11 +223,12 @@ package rv_core_ibex_reg_pkg;
   parameter logic [CfgAw-1:0] RV_CORE_IBEX_MCOUNTEREN_WRITABLE_OFFSET = 8'h 68;
 
   // Reset values for hwext registers and their fields for cfg interface
-  parameter logic [3:0] RV_CORE_IBEX_ALERT_TEST_RESVAL = 4'h 0;
+  parameter logic [31:0] RV_CORE_IBEX_ALERT_TEST_RESVAL = 32'h 80000000;
   parameter logic [0:0] RV_CORE_IBEX_ALERT_TEST_FATAL_SW_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] RV_CORE_IBEX_ALERT_TEST_RECOV_SW_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] RV_CORE_IBEX_ALERT_TEST_FATAL_HW_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] RV_CORE_IBEX_ALERT_TEST_RECOV_HW_ERR_RESVAL = 1'h 0;
+  parameter logic [0:0] RV_CORE_IBEX_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
   parameter logic [31:0] RV_CORE_IBEX_RND_DATA_RESVAL = 32'h 0;
   parameter logic [31:0] RV_CORE_IBEX_RND_DATA_DATA_RESVAL = 32'h 0;
   parameter logic [1:0] RV_CORE_IBEX_RND_STATUS_RESVAL = 2'h 0;
@@ -274,7 +275,7 @@ package rv_core_ibex_reg_pkg;
 
   // Register width information to check illegal writes for cfg interface
   parameter logic [3:0] RV_CORE_IBEX_CFG_PERMIT [27] = '{
-    4'b 0001, // index[ 0] RV_CORE_IBEX_ALERT_TEST
+    4'b 1111, // index[ 0] RV_CORE_IBEX_ALERT_TEST
     4'b 0001, // index[ 1] RV_CORE_IBEX_SW_RECOV_ERR
     4'b 0001, // index[ 2] RV_CORE_IBEX_SW_FATAL_ERR
     4'b 0001, // index[ 3] RV_CORE_IBEX_IBUS_REGWEN_0

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/data/rv_plic.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/data/rv_plic.hjson
@@ -199,10 +199,18 @@
       hwaccess: "hro",
       hwqe:     "True",
       hwext:    "True",
+      inregwen: "regwen",
       fields: [
         { bits: "0",
           name: "fatal_fault",
           desc: "'Write 1 to trigger one alert event of this kind.'",
+        }
+        { bits: "31",
+          name: "regwen",
+          swaccess: "rw0c",
+          hwaccess: "none",
+          resval: "1",
+          desc: "Write 0 to disable alert testing until the next reset.",
         }
       ],
     }

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
@@ -181,7 +181,8 @@ package rv_plic_reg_pkg;
 
   // Reset values for hwext registers and their fields
   parameter logic [6:0] RV_PLIC_CC0_RESVAL = 7'h 0;
-  parameter logic [0:0] RV_PLIC_ALERT_TEST_RESVAL = 1'h 0;
+  parameter logic [31:0] RV_PLIC_ALERT_TEST_RESVAL = 32'h 80000000;
+  parameter logic [0:0] RV_PLIC_ALERT_TEST_REGWEN_RESVAL = 1'h 1;
 
   // Register index
   typedef enum int {
@@ -384,7 +385,7 @@ package rv_plic_reg_pkg;
     4'b 0001, // index[94] RV_PLIC_THRESHOLD0
     4'b 0001, // index[95] RV_PLIC_CC0
     4'b 0001, // index[96] RV_PLIC_MSIP0
-    4'b 0001  // index[97] RV_PLIC_ALERT_TEST
+    4'b 1111  // index[97] RV_PLIC_ALERT_TEST
   };
 
 endpackage

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
@@ -663,7 +663,9 @@ module rv_plic_reg_top (
   logic msip0_qs;
   logic msip0_wd;
   logic alert_test_we;
-  logic alert_test_wd;
+  logic alert_test_fatal_fault_wd;
+  logic alert_test_regwen_qs;
+  logic alert_test_regwen_wd;
 
   // Register instances
   // Subregister 0 of Multireg prio
@@ -8066,14 +8068,18 @@ module rv_plic_reg_top (
 
   // R[alert_test]: V(True)
   logic alert_test_qe;
-  logic [0:0] alert_test_flds_we;
+  logic [1:0] alert_test_flds_we;
   assign alert_test_qe = &alert_test_flds_we;
+  // Create REGWEN-gated WE signal
+  logic alert_test_gated_we;
+  assign alert_test_gated_we = alert_test_we && alert_test_regwen_qs;
+  //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_alert_test (
+  ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_we),
-    .wd     (alert_test_wd),
+    .we     (alert_test_gated_we),
+    .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
     .qe     (alert_test_flds_we[0]),
@@ -8082,6 +8088,33 @@ module rv_plic_reg_top (
     .qs     ()
   );
   assign reg2hw.alert_test.qe = alert_test_qe;
+
+  //   F[regwen]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_alert_test_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (alert_test_we),
+    .wd     (alert_test_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (alert_test_flds_we[1]),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (alert_test_regwen_qs)
+  );
 
 
 
@@ -8748,7 +8781,9 @@ module rv_plic_reg_top (
   assign msip0_wd = reg_wdata[0];
   assign alert_test_we = addr_hit[97] & reg_we & !reg_error;
 
-  assign alert_test_wd = reg_wdata[0];
+  assign alert_test_fatal_fault_wd = reg_wdata[0];
+
+  assign alert_test_regwen_wd = reg_wdata[31];
 
   // Assign write-enables to checker logic vector.
   always_comb begin
@@ -9416,6 +9451,7 @@ module rv_plic_reg_top (
 
       addr_hit[97]: begin
         reg_rdata_next[0] = '0;
+        reg_rdata_next[31] = alert_test_regwen_qs;
       end
 
       default: begin

--- a/util/reggen/README.md
+++ b/util/reggen/README.md
@@ -164,6 +164,7 @@ hwext | optional | string | 'true' if the register is stored outside of the regi
 hwqe | optional | string | 'true' if hardware uses 'q' enable signal, which is latched signal of software write pulse.
 hwre | optional | string | 'true' if hardware uses 're' signal, which is latched signal of software read pulse.
 regwen | optional | string | if register is write-protected by another register, that register name should be given here. empty-string for no register write protection
+inregwen | optional | string | if the writable fields of this register are write-protected by a single-bit field *within the same register*, that field name should be given here. The named control field is stored inside the register block (even when the register is hwext) and gates the write-enable (and hence the 'qe' strobe) of all other writable fields. empty-string for no in-register write protection
 resval | optional | int | reset value of full register (default 0)
 tags | optional | string | tags for the register, following the format 'tag_name:item1:item2...'
 shadowed | optional | string | 'true' if the register is shadowed
@@ -359,6 +360,7 @@ hwext | optional | string | 'true' if the register is stored outside of the regi
 hwqe | optional | string | 'true' if hardware uses 'q' enable signal, which is latched signal of software write pulse.
 hwre | optional | string | 'true' if hardware uses 're' signal, which is latched signal of software read pulse.
 regwen | optional | string | if register is write-protected by another register, that register name should be given here. empty-string for no register write protection
+inregwen | optional | string | if the writable fields of this register are write-protected by a single-bit field *within the same register*, that field name should be given here. The named control field is stored inside the register block (even when the register is hwext) and gates the write-enable (and hence the 'qe' strobe) of all other writable fields. empty-string for no in-register write protection
 resval | optional | int | reset value of full register (default 0)
 tags | optional | string | tags for the register, following the format 'tag_name:item1:item2...'
 shadowed | optional | string | 'true' if the register is shadowed

--- a/util/reggen/multi_register.py
+++ b/util/reggen/multi_register.py
@@ -321,9 +321,9 @@ class MultiRegister(RegBase):
             ret += reg.get_field_list()
         return ret
 
-    def is_homogeneous(self) -> bool:
+    def is_homogeneous(self, inregwen: bool = False) -> bool:
         assert self.pregs
-        return self.pregs[0].is_homogeneous()
+        return self.pregs[0].is_homogeneous(inregwen)
 
     def needs_qe(self) -> bool:
         return self._needs_qe

--- a/util/reggen/reg_base.py
+++ b/util/reggen/reg_base.py
@@ -56,13 +56,16 @@ class RegBase:
         '''
         raise NotImplementedError()
 
-    def is_homogeneous(self) -> bool:
+    def is_homogeneous(self, inregwen: bool = False) -> bool:
         '''True if every field in the block is identical
 
         For a single register, this is true if it only has one field. For a
         multireg, it is true if the generating register has just one field.
         Note that if the compact flag is set, the generated registers might
         have multiple (replicated) fields.
+
+        When inregwen is True, the inregwen control field is ignored so that
+        this bit does not affect the number of fields in a register.
 
         '''
         raise NotImplementedError()

--- a/util/reggen/reg_block.py
+++ b/util/reggen/reg_block.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 
 from reggen.alert import Alert
 from reggen.access import SWAccess, HWAccess
+from reggen.bits import Bits
 from reggen.bus_interfaces import BusInterfaces
 from reggen.clocking import Clocking, ClockingItem
 from reggen.field import Field
@@ -577,11 +578,62 @@ class RegBlock:
 
     def make_alert_regs(self, alerts: list[Alert]) -> None:
         assert alerts
-        assert len(alerts) < self._reg_width
-        self._add_intr_alert_reg(alerts, 'ALERT_TEST', 'Alert Test Register',
-                                 ('Write 1 to trigger '
-                                  'one alert event of this kind.'), 'wo',
-                                 'hro', True, [])
+        # The alert-test fields occupy bits [0 .. len(alerts)-1]; a single-bit
+        # in-register write-enable, `regwen`, is placed at the MSB. Make sure they
+        # do not overlap.
+        msb = self._reg_width - 1
+        assert len(alerts) <= msb
+
+        alert_sw = SWAccess('RegBlock.make_alert_regs()', 'wo')
+        alert_hw = HWAccess('RegBlock.make_alert_regs()', 'hro')
+        # rw0c, reset 1: alert testing is enabled out of reset; software writes 0
+        # to this bit to disable it until the next reset.
+        lock_sw = SWAccess('RegBlock.make_alert_regs()', 'rw0c')
+        lock_hw = HWAccess('RegBlock.make_alert_regs()', 'none')
+
+        fields = []
+        for alert in alerts:
+            fields.append(
+                Field(
+                    alert.name,
+                    None,  # no alias target
+                    'Write 1 to trigger one alert event of this kind.',
+                    tags=[],
+                    swaccess=alert_sw,
+                    hwaccess=alert_hw,
+                    hwqe=True,
+                    bits=alert.bits,
+                    resval=0,
+                    enum=None,
+                    mubi=False,
+                    auto_split=False))
+
+        fields.append(
+            Field(
+                'regwen',
+                None,  # no alias target
+                'Write 0 to disable alert testing until the next reset.',
+                tags=[],
+                swaccess=lock_sw,
+                hwaccess=lock_hw,
+                hwqe=False,
+                bits=Bits(msb, msb),
+                resval=1,
+                enum=None,
+                mubi=False,
+                auto_split=False))
+
+        self.add_register(Register('ALERT_TEST',
+                                   self.offset,
+                                   async_clk=None,
+                                   sync_clk=None,
+                                   alias_target=None,
+                                   desc='Alert Test Register',
+                                   fields=fields,
+                                   hwext=True,
+                                   hwqe=True,
+                                   inregwen='regwen',
+                                   tags=[]))
 
     def get_addr_width(self) -> int:
         '''Calculate the number of bits to address every byte of the block'''

--- a/util/reggen/reg_pkg.sv.tpl
+++ b/util/reggen/reg_pkg.sv.tpl
@@ -45,12 +45,13 @@ ${hdr}
 %>\
 
   typedef struct packed {
-    % if r.is_homogeneous():
+    % if r.is_homogeneous(inregwen=True):
       ## If we have a homogeneous register or multireg, there is just one field
       ## (possibly replicated many times). The typedef is for one copy of that
-      ## field.
+      ## field. An inregwen control field is internal, so it is excluded here.
 <%
-      field = r.get_field_list()[0]
+      field = [f for f in r.get_field_list()
+               if r0.inregwen is None or f.name != r0.inregwen][0]
       field_q_width = field.get_n_bits(r0.hwext, r0.hwre, ['q'])
       field_q_bits = lib.bitarray(field_q_width, 2)
 %>\
@@ -101,12 +102,13 @@ ${hdr}
 %>\
 
   typedef struct packed {
-    % if r.is_homogeneous():
+    % if r.is_homogeneous(inregwen=True):
       ## If we have a homogeneous register or multireg, there is just one field
       ## (possibly replicated many times). The typedef is for one copy of that
-      ## field.
+      ## field. An inregwen control field is internal, so it is excluded here.
 <%
-      field = r.get_field_list()[0]
+      field = [f for f in r.get_field_list()
+               if r0.inregwen is None or f.name != r0.inregwen][0]
       field_d_width = field.get_n_bits(r0.hwext, r0.hwre, ['d'])
       field_d_bits = lib.bitarray(field_d_width, 2)
 %>\

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -117,6 +117,11 @@
           else:
             fsig_name = '{}.{}'.format(fsig_pfx, fld_name)
 
+        # The inregwen field is internal
+        if (not isinstance(r, MultiRegister) and sr.inregwen is not None
+                and sr.is_homogeneous(inregwen=True)):
+          fsig_name = fsig_pfx
+
         finst_names[(sr, field)] = (fsig_name, finst_name)
 
 %>
@@ -635,6 +640,11 @@ ${reg_hdr}
       if reg.name == sr.regwen and reg.fields[0].mubi:
         we_expr = f'''{we_signal} &
           prim_mubi_pkg::mubi{reg.fields[0].bits.width()}_test_true_strict(prim_mubi_pkg::mubi{reg.fields[0].bits.width()}_t\'({sr.regwen.lower()}_qs))'''
+  elif sr.inregwen:
+    # In-register write-enable: gate by the registered value (qs) of the control
+    # field that lives within this same register.
+    inregwen_qs = f'{sr_name}_{sr.inregwen.lower()}_qs'
+    we_expr = f'{we_signal} && {inregwen_qs}'
   else:
     we_expr = we_signal
 
@@ -645,7 +655,7 @@ ${reg_hdr}
   % endif
   ## Only create this helper signal if there actually is a REGWEN gate.
   ## Otherwise the WE signal is connected directly to the register.
-  % if sr.regwen and sr.needs_we():
+  % if (sr.regwen or sr.inregwen) and sr.needs_we():
   // Create REGWEN-gated WE signal
   logic ${we_expr_regwen_gated};
 <%
@@ -1005,13 +1015,22 @@ ${bits.msb}\
     rst_expr = reg.async_clk[1].reset if reg.async_clk else reg_rst_expr
     re_expr = f'{clk_base_name}{reg_name}_re' if field.swaccess.allows_read() or reg.shadowed else "1'b0"
 
+    # The inregwen control field is stored inside the reg block even for registers marked as `hwext`
+    is_inregwen_ctrl = (reg.inregwen is not None and
+                         field.name == reg.inregwen)
+    field_is_ext = reg.hwext and not is_inregwen_ctrl
+
     # software inputs to field instance, write enable, read enable, write data
     if field.swaccess.allows_write():
       # We usually use the REG_we signal, but use REG_re for RC fields
       # (which get updated on a read, not a write)
       we_suffix = 're' if field.swaccess.swrd() == SwRdAccess.RC else 'we'
-      # If this is a REGWEN gated field, need to use the gated WE signal.
-      gated_suffix = '_gated' if reg.regwen else ''
+      # If this is a REGWEN gated field, need to use the gated WE signal. For
+      # an inregwen register every field is gated EXCEPT the control bit itself
+      # (which must stay writable so software can engage/release the lock).
+      gated = bool(reg.regwen) or (reg.inregwen is not None and
+                                   not is_inregwen_ctrl)
+      gated_suffix = '_gated' if gated else ''
       we_expr = f'{clk_base_name}{reg_name}{gated_suffix}_{we_suffix}'
 
       # when async, pick from the cdc handled data
@@ -1060,7 +1079,7 @@ ${bits.msb}\
     ds_expr = f'{clk_base_name}{finst_name}_ds{async_suffix}' if reg.async_clk and reg.is_hw_writable() else ''
 
 %>\
-  % if reg.hwext:       ## if hwext, instantiate prim_subreg_ext
+  % if field_is_ext:    ## if hwext (and not an inregwen control bit), instantiate prim_subreg_ext
 <%
     subreg_block = "prim_subreg_ext"
 %>\

--- a/util/reggen/register.py
+++ b/util/reggen/register.py
@@ -64,6 +64,14 @@ OPTIONAL_FIELDS = {
         "register name should be given here. empty-string for no register "
         "write protection"
     ],
+    'inregwen': [
+        's', "if the writable fields of this register are write-protected by a "
+        "single-bit field *within the same register*, that field name should "
+        "be given here. The named control field is stored inside the register "
+        "block (even when the register is hwext) and gates the write-enable "
+        "(and hence the 'qe' strobe) of all other writable fields. empty-string "
+        "for no in-register write protection"
+    ],
     'resval': ['d', "reset value of full register (default 0)"],
     'tags': [
         's',
@@ -100,6 +108,7 @@ class Register(RegBase):
     update_err_alert: str | None = None
     storage_err_alert: str | None = None
     writes_ignore_errors: bool = False
+    inregwen: str | None = None
     resval: int = field(init=False)
     resmask: int = field(init=False)
     name_to_field: dict[str, Field] = field(init=False)
@@ -132,9 +141,39 @@ class Register(RegBase):
                     f'{fld.name}.')
             self.name_to_field[fld.name] = fld
 
+        # Validate an in-register write-enable ("inregwen"), if present.
+        if self.inregwen is not None:
+            if self.inregwen not in self.name_to_field:
+                raise ValueError(
+                    f'Register {self.name} names {self.inregwen} as its '
+                    'inregwen, but it has no such field.')
+            ctrl = self.name_to_field[self.inregwen]
+            if ctrl.bits.width() != 1:
+                raise ValueError(
+                    f'The inregwen field {self.inregwen} of register '
+                    f'{self.name} must be a single bit, not '
+                    f'{ctrl.bits.width()} bits.')
+            # The control bit is stored inside the reg block and must not be
+            # exposed to HW and it must be SW-writable so software can engage the lock.
+            if ctrl.hwaccess.key != 'none':
+                raise ValueError(
+                    f'The inregwen field {self.inregwen} of register '
+                    f'{self.name} must have hwaccess "none" (it is stored in '
+                    f'the reg block), not "{ctrl.hwaccess.key}".')
+            if not ctrl.sw_writable():
+                raise ValueError(
+                    f'The inregwen field {self.inregwen} of register '
+                    f'{self.name} must be writable by software (mode '
+                    f'{ctrl.swaccess.key}).')
+
         # Check that fields have compatible access types if we are hwext
         if self.hwext:
             for fld in self.fields:
+                # An inregwen control field is intentionally stored inside the
+                # reg block, so it is exempt from the hwext field
+                # constraints below.
+                if self.inregwen is not None and fld.name == self.inregwen:
+                    continue
                 if fld.hwaccess.key == 'hro' and fld.sw_readable():
                     raise ValueError(
                         f'The {self.name} register has hwext set, but field '
@@ -288,6 +327,13 @@ class Register(RegBase):
         else:
             regwen = check_name(raw_regwen, f'regwen for {name} register')
 
+        raw_inregwen = rd.get('inregwen', '')
+        if not raw_inregwen:
+            inregwen = None
+        else:
+            inregwen = check_name(raw_inregwen,
+                                  f'inregwen for {name} register')
+
         raw_resval = rd.get('resval')
         if raw_resval is None:
             resval = None
@@ -357,7 +403,7 @@ class Register(RegBase):
                         desc, fields, hwext, hwqe, hwre, regwen,
                         tags, resval, shadowed,
                         update_err_alert, storage_err_alert,
-                        writes_ignore_errors)
+                        writes_ignore_errors, inregwen=inregwen)
 
     def next_offset(self, addrsep: int) -> int:
         return self.offset + addrsep
@@ -370,8 +416,16 @@ class Register(RegBase):
     def get_field_list(self) -> List[Field]:
         return self.fields
 
-    def is_homogeneous(self) -> bool:
-        return len(self.fields) == 1
+    def is_homogeneous(self, inregwen: bool = False) -> bool:
+        '''True if the register has a single field.
+
+        When inregwen is True, the inregwen control field is ignored so that
+        this bit does not affect the number of fields in a register.
+        '''
+        fields = self.fields
+        if inregwen and self.inregwen is not None:
+            fields = [fld for fld in fields if fld.name != self.inregwen]
+        return len(fields) == 1
 
     def is_hw_writable(self) -> bool:
         '''Returns true if any field in this register can be modified by HW'''
@@ -442,6 +496,12 @@ class Register(RegBase):
         for fld in self.fields:
             if fld.swaccess.key == 'rc':
                 return True
+
+            # An inregwen control field is stored inside the reg block (not
+            # external), so its read does not need a read-enable even though the
+            # register is hwext.
+            if self.inregwen is not None and fld.name == self.inregwen:
+                continue
 
             if self.hwext and fld.swaccess.allows_read():
                 return True
@@ -638,6 +698,8 @@ class Register(RegBase):
         }  # type: Dict[str, object]
         if self.regwen is not None:
             rd['regwen'] = self.regwen
+        if self.inregwen is not None:
+            rd['inregwen'] = self.inregwen
         if self.update_err_alert is not None:
             rd['update_err_alert'] = self.update_err_alert
         if self.storage_err_alert is not None:


### PR DESCRIPTION
Tackling #30490, this PR introduces a write enable bit to each ALERT_TEST register to prevent SW from throwing an alert accidentally. We extended `util/reggen` to support a new bitregwen key allowing to gate write access of fields via a bit in the same register. All HWIPs are regenerated to feature this lockout mechanism.