### PR TITLE
[otlib,usb] Backports + workaround for chip whisperer problem with the USB transceiver

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -377,7 +377,14 @@ fpga_cw340(
         "--interface={interface}",
         "--drop-reset",
     ] + select({
-        "//ci:lowrisc_fpga_cw340": ["--uarts=/dev/ttyACM_CW340_1,/dev/ttyACM_CW340_0"],
+        "//ci:lowrisc_fpga_cw340": [
+            "--uarts=/dev/ttyACM_CW340_1,/dev/ttyACM_CW340_0",
+            # The CW340 board has a small design problem where the USB transceiver has its
+            # SOFTCONN pin directly connected to the FPGA without any pull down. When the
+            # bitstream is not loaded, the pin is left floating which can cause the transceiver
+            # to random connect to the bus and confuse the host.
+            "--cw-usb-port-workaround=4",
+        ],
         "//conditions:default": [],
     }),
     design = "earlgrey",

--- a/sw/host/opentitanlib/src/backend/hyperdebug.rs
+++ b/sw/host/opentitanlib/src/backend/hyperdebug.rs
@@ -5,14 +5,27 @@
 use crate::transport::Transport;
 use crate::transport::hyperdebug::{Flavor, Hyperdebug, HyperdebugDfu};
 use anyhow::Result;
+use clap::Args;
 
 use crate::backend::BackendOpts;
+
+#[derive(Debug, Args)]
+pub struct HyperdebugOpts {
+    /// Work around the USB transceiver on the CW boards not being disabled when the FPGA is
+    /// is not loaded. Enabling this option will cause the backend to disable the USB port
+    /// prior to clearing the bitstream and only re-enable it after loading. It assumes that
+    /// the USB port is connected to the same parent hub as the hyperdebug device and this option
+    /// specifies the port number of that hub.
+    #[arg(long)]
+    pub cw_usb_port_workaround: Option<u8>,
+}
 
 pub fn create<T: 'static + Flavor>(args: &BackendOpts) -> Result<Box<dyn Transport>> {
     Ok(Box::new(Hyperdebug::<T>::open(
         args.usb_vid,
         args.usb_pid,
         args.usb_serial.as_deref(),
+        args.hyperdebug_opts.cw_usb_port_workaround,
     )?))
 }
 

--- a/sw/host/opentitanlib/src/backend/mod.rs
+++ b/sw/host/opentitanlib/src/backend/mod.rs
@@ -54,6 +54,9 @@ pub struct BackendOpts {
     pub opts: chip_whisperer::ChipWhispererOpts,
 
     #[command(flatten)]
+    pub hyperdebug_opts: hyperdebug::HyperdebugOpts,
+
+    #[command(flatten)]
     pub verilator_opts: verilator::VerilatorOpts,
 
     #[command(flatten)]

--- a/sw/host/opentitanlib/src/io/usb/desc.rs
+++ b/sw/host/opentitanlib/src/io/usb/desc.rs
@@ -51,6 +51,28 @@ pub struct DeviceDescriptor {
     pub num_config: u8,
 }
 
+pub struct Device<'a> {
+    bytes: &'a [u8],
+}
+
+impl<'a> Device<'a> {
+    pub fn new(bytes: &'a [u8]) -> Self {
+        Device { bytes }
+    }
+
+    /// Return the entire configuration (all descriptors).
+    pub fn as_bytes(&self) -> &'a [u8] {
+        self.bytes
+    }
+
+    /// Return the configuration descriptor.
+    pub fn descriptor(&self) -> Result<&'a DeviceDescriptor> {
+        DeviceDescriptor::ref_from_prefix(self.bytes)
+            .map(|(desc, _)| desc)
+            .map_err(|_err| anyhow!("Cannot parse device descriptor"))
+    }
+}
+
 #[derive(Clone, FromBytes, KnownLayout, Immutable, Unaligned, Debug)]
 #[repr(C)]
 pub struct ConfigurationDescriptor {

--- a/sw/host/opentitanlib/src/io/usb/mod.rs
+++ b/sw/host/opentitanlib/src/io/usb/mod.rs
@@ -66,6 +66,9 @@ pub trait UsbDevice {
     /// Return the device's bus number.
     fn bus_number(&self) -> u8;
 
+    /// Return the device's address.
+    fn address(&self) -> u8;
+
     /// Return the sequence of port numbers from the root down to the device.
     fn port_numbers(&self) -> Result<Vec<u8>>;
 

--- a/sw/host/opentitanlib/src/io/usb/mod.rs
+++ b/sw/host/opentitanlib/src/io/usb/mod.rs
@@ -54,6 +54,9 @@ pub trait UsbDevice {
     /// Attach the kernel driver to the device.
     fn attach_kernel_driver(&self, iface: u8) -> Result<()>;
 
+    /// Return the device's descriptor.
+    fn device_descriptor(&self) -> desc::Device<'_>;
+
     /// Return the currently active configuration's descriptor.
     fn active_configuration(&self) -> Result<desc::Configuration>;
 

--- a/sw/host/opentitanlib/src/io/usb/mod.rs
+++ b/sw/host/opentitanlib/src/io/usb/mod.rs
@@ -33,6 +33,9 @@ pub trait UsbDevice {
     /// Gets the serial number of the device.
     fn get_serial_number(&self) -> Option<&str>;
 
+    /// Try to get the parent of this device (or None if root).
+    fn get_parent(&self) -> Result<Box<dyn UsbDevice>>;
+
     /// Set the active configuration.
     fn set_active_configuration(&self, config: u8) -> Result<()>;
 

--- a/sw/host/opentitanlib/src/transport/common/usb.rs
+++ b/sw/host/opentitanlib/src/transport/common/usb.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{Context, Result, ensure};
+use anyhow::{Context, Result, bail, ensure};
 use rusb::{self, UsbContext};
 use std::time::{Duration, Instant};
 
@@ -394,5 +394,130 @@ impl UsbDevice for RusbDevice {
             .write_bulk(endpoint, data, timeout)
             .context("USB error")?;
         Ok(len)
+    }
+}
+
+// Structure representing a USB hub. The device needs to have sufficient permission
+// to be opened.
+pub struct UsbHub {
+    handle: rusb::DeviceHandle<rusb::Context>,
+}
+
+// USB hub operation.
+pub enum UsbHubOp {
+    // Suspend a specific port.
+    Suspend,
+    // Suspend a specific port.
+    Resume,
+    // Reset a specific port.
+    Reset,
+}
+
+const PORT_SUSPEND: u16 = 2;
+const PORT_RESET: u16 = 4;
+
+impl UsbHub {
+    // Construct a hub from a device.
+    pub fn from_device(dev: &rusb::Device<rusb::Context>) -> Result<UsbHub> {
+        // Make sure the device is a hub.
+        let dev_desc = dev.device_descriptor()?;
+        // Assume that if the device has the HUB class then Linux will already enforce
+        // that it follows the specification.
+        ensure!(
+            dev_desc.class_code() == rusb::constants::LIBUSB_CLASS_HUB,
+            "device is not a hub"
+        );
+        Ok(UsbHub {
+            handle: dev.open().with_context(|| {
+                format!(
+                    "Cannot access USB hub on bus {bus}, address {addr}\n\
+                If this test requires access to the HUB, you need to make sure that \
+                the program has sufficient permissions to access the hub\n\
+                See sw/host/tests/chip/usb/README.md for more information\n\
+                The following command may fix the issue:\n\
+                sudo chmod 0666 /dev/bus/usb/{bus:03}/{addr:03}",
+                    bus = dev.bus_number(),
+                    addr = dev.address(),
+                )
+            })?,
+        })
+    }
+
+    pub fn device(&self) -> rusb::Device<rusb::Context> {
+        self.handle.device()
+    }
+
+    // Report the status of a port (only returns the port status, not the port change).
+    fn port_status(&self, port: u8, timeout: Duration) -> Result<u16> {
+        let req_type = rusb::constants::LIBUSB_RECIPIENT_OTHER
+            | rusb::constants::LIBUSB_REQUEST_TYPE_CLASS
+            | rusb::constants::LIBUSB_ENDPOINT_IN;
+        let mut status = [0u8; 4];
+        let _ = self.handle.read_control(
+            req_type,
+            rusb::constants::LIBUSB_REQUEST_GET_STATUS,
+            0,
+            port as u16,
+            &mut status,
+            timeout,
+        )?;
+        Ok(status[0] as u16 | (status[1] as u16) << 8)
+    }
+
+    // Perform an operation.
+    pub fn op(&self, op: UsbHubOp, port: u8, timeout: Duration, check_status: bool) -> Result<()> {
+        let (feature_index, set_feature, human_op) = match op {
+            UsbHubOp::Suspend => (PORT_SUSPEND, true, "suspend"),
+            UsbHubOp::Resume => (PORT_SUSPEND, false, "resume"),
+            UsbHubOp::Reset => (PORT_RESET, true, "reset"),
+        };
+        let req = if set_feature {
+            rusb::constants::LIBUSB_REQUEST_SET_FEATURE
+        } else {
+            rusb::constants::LIBUSB_REQUEST_CLEAR_FEATURE
+        };
+        let req_type = rusb::constants::LIBUSB_RECIPIENT_OTHER
+            | rusb::constants::LIBUSB_REQUEST_TYPE_CLASS
+            | rusb::constants::LIBUSB_ENDPOINT_OUT;
+        // Make sure that the port status is the expected one before the operation.
+        let port_status_mask = 1u16 << feature_index;
+        let port_status_before = if set_feature { 0u16 } else { port_status_mask };
+        let port_status_after = if set_feature { port_status_mask } else { 0u16 };
+
+        if check_status {
+            let port_status = self.port_status(port, timeout)?;
+            ensure!(
+                port_status & port_status_mask == port_status_before,
+                "Trying to {} port {} but port has unexpected status {:#x}",
+                human_op,
+                port,
+                port_status
+            );
+        }
+        // Perform operation.
+        let _ =
+            self.handle
+                .write_control(req_type, req, feature_index, port as u16, &[], timeout)?;
+        // Wait until port has changed status.
+        if check_status {
+            let start = Instant::now();
+            loop {
+                let port_status = self.port_status(port, timeout)?;
+                if port_status & port_status_mask == port_status_after {
+                    break;
+                }
+                if start.elapsed() >= timeout {
+                    bail!(
+                        "Trying to {} port {} but port did not change status (last status was {:x})",
+                        human_op,
+                        port,
+                        port_status
+                    );
+                }
+            }
+            log::info!("{} performed in {:#?}", human_op, start.elapsed());
+        }
+
+        Ok(())
     }
 }

--- a/sw/host/opentitanlib/src/transport/common/usb.rs
+++ b/sw/host/opentitanlib/src/transport/common/usb.rs
@@ -377,6 +377,10 @@ impl UsbDevice for RusbDevice {
         self.handle.device().bus_number()
     }
 
+    fn address(&self) -> u8 {
+        self.handle.device().address()
+    }
+
     fn port_numbers(&self) -> Result<Vec<u8>> {
         self.handle.device().port_numbers().context("USB error")
     }

--- a/sw/host/opentitanlib/src/transport/common/usb.rs
+++ b/sw/host/opentitanlib/src/transport/common/usb.rs
@@ -443,7 +443,7 @@ impl UsbDevice for RusbDevice {
 // Structure representing a USB hub. The device needs to have sufficient permission
 // to be opened.
 pub struct UsbHub {
-    handle: rusb::DeviceHandle<rusb::Context>,
+    handle: Box<dyn UsbDevice>,
 }
 
 // USB hub operation.
@@ -465,34 +465,39 @@ const PORT_RESET: u16 = 4;
 const PORT_POWER: u16 = 8;
 
 impl UsbHub {
-    // Construct a hub from a device.
-    pub fn from_device(dev: &rusb::Device<rusb::Context>) -> Result<UsbHub> {
-        // Make sure the device is a hub.
-        let dev_desc = dev.device_descriptor()?;
-        // Assume that if the device has the HUB class then Linux will already enforce
-        // that it follows the specification.
-        ensure!(
-            dev_desc.class_code() == rusb::constants::LIBUSB_CLASS_HUB,
-            "device is not a hub"
-        );
-        Ok(UsbHub {
-            handle: dev.open().with_context(|| {
-                format!(
-                    "Cannot access USB hub on bus {bus}, address {addr}\n\
+    // Construct a hub from the parent of a device.
+    pub fn from_parent_device(dev: &dyn UsbDevice) -> Result<UsbHub> {
+        let handle = dev.get_parent().with_context(|| {
+            format!(
+                "Cannot access USB parent hub of device on bus {bus}, address {addr}\n\
                 If this test requires access to the HUB, you need to make sure that \
                 the program has sufficient permissions to access the hub\n\
                 See sw/host/tests/chip/usb/README.md for more information\n\
                 The following command may fix the issue:\n\
-                sudo chmod 0666 /dev/bus/usb/{bus:03}/{addr:03}",
-                    bus = dev.bus_number(),
-                    addr = dev.address(),
-                )
-            })?,
-        })
+                sudo chmod 0666 /dev/bus/usb/{bus:03}/ADDR\n\
+                where ADDR is the address of the hub",
+                bus = dev.bus_number(),
+                addr = dev.address(),
+            )
+        })?;
+        UsbHub::from_device(handle)
     }
 
-    pub fn device(&self) -> rusb::Device<rusb::Context> {
-        self.handle.device()
+    // Construct a hub from a device.
+    pub fn from_device(dev: Box<dyn UsbDevice>) -> Result<UsbHub> {
+        // Make sure the device is a hub.
+        let dev_desc = dev.device_descriptor().descriptor()?;
+        // Assume that if the device has the HUB class then Linux will already enforce
+        // that it follows the specification.
+        ensure!(
+            dev_desc.class == rusb::constants::LIBUSB_CLASS_HUB,
+            "device is not a hub"
+        );
+        Ok(UsbHub { handle: dev })
+    }
+
+    pub fn device(&self) -> &dyn UsbDevice {
+        &*self.handle
     }
 
     // Report the status of a port (only returns the port status, not the port change).
@@ -501,7 +506,7 @@ impl UsbHub {
             | rusb::constants::LIBUSB_REQUEST_TYPE_CLASS
             | rusb::constants::LIBUSB_ENDPOINT_IN;
         let mut status = [0u8; 4];
-        let _ = self.handle.read_control(
+        let _ = self.handle.read_control_timeout(
             req_type,
             rusb::constants::LIBUSB_REQUEST_GET_STATUS,
             0,
@@ -545,9 +550,14 @@ impl UsbHub {
             );
         }
         // Perform operation.
-        let _ =
-            self.handle
-                .write_control(req_type, req, feature_index, port as u16, &[], timeout)?;
+        let _ = self.handle.write_control_timeout(
+            req_type,
+            req,
+            feature_index,
+            port as u16,
+            &[],
+            timeout,
+        )?;
         // Wait until port has changed status.
         if check_status {
             let start = Instant::now();

--- a/sw/host/opentitanlib/src/transport/common/usb.rs
+++ b/sw/host/opentitanlib/src/transport/common/usb.rs
@@ -283,6 +283,22 @@ impl UsbDevice for RusbDevice {
         self.timeout
     }
 
+    fn get_parent(&self) -> Result<Box<dyn UsbDevice>> {
+        let device = self
+            .handle
+            .device()
+            .get_parent()
+            .context("Unable to get parent USB device")?;
+        let handle = device.open().context(format!(
+            "Could not open device at bus={} address={}",
+            device.bus_number(),
+            device.address(),
+        ))?;
+        // We do not try to read the serial number of the parent because hubs generally do not have
+        // unique serial numbers.
+        Ok(Box::new(RusbDevice::new(handle, None, self.get_timeout())?))
+    }
+
     fn get_vendor_id(&self) -> u16 {
         self.handle
             .device()

--- a/sw/host/opentitanlib/src/transport/common/usb.rs
+++ b/sw/host/opentitanlib/src/transport/common/usb.rs
@@ -405,6 +405,10 @@ pub struct UsbHub {
 
 // USB hub operation.
 pub enum UsbHubOp {
+    // Power-off a specific port.
+    PowerOff,
+    // Power-on a specific port.
+    PowerOn,
     // Suspend a specific port.
     Suspend,
     // Suspend a specific port.
@@ -415,6 +419,7 @@ pub enum UsbHubOp {
 
 const PORT_SUSPEND: u16 = 2;
 const PORT_RESET: u16 = 4;
+const PORT_POWER: u16 = 8;
 
 impl UsbHub {
     // Construct a hub from a device.
@@ -470,6 +475,8 @@ impl UsbHub {
             UsbHubOp::Suspend => (PORT_SUSPEND, true, "suspend"),
             UsbHubOp::Resume => (PORT_SUSPEND, false, "resume"),
             UsbHubOp::Reset => (PORT_RESET, true, "reset"),
+            UsbHubOp::PowerOn => (PORT_POWER, true, "power on"),
+            UsbHubOp::PowerOff => (PORT_POWER, false, "power off"),
         };
         let req = if set_feature {
             rusb::constants::LIBUSB_REQUEST_SET_FEATURE

--- a/sw/host/opentitanlib/src/transport/common/usb.rs
+++ b/sw/host/opentitanlib/src/transport/common/usb.rs
@@ -212,7 +212,7 @@ impl OtUsbContext for RusbContext {
 }
 
 impl RusbDevice {
-    fn new(
+    pub fn new(
         handle: rusb::DeviceHandle<rusb::Context>,
         serial_number: Option<String>,
         timeout: Duration,

--- a/sw/host/opentitanlib/src/transport/common/usb.rs
+++ b/sw/host/opentitanlib/src/transport/common/usb.rs
@@ -534,21 +534,10 @@ impl UsbHub {
         let req_type = rusb::constants::LIBUSB_RECIPIENT_OTHER
             | rusb::constants::LIBUSB_REQUEST_TYPE_CLASS
             | rusb::constants::LIBUSB_ENDPOINT_OUT;
-        // Make sure that the port status is the expected one before the operation.
+        // Expected port status after the operation.
         let port_status_mask = 1u16 << feature_index;
-        let port_status_before = if set_feature { 0u16 } else { port_status_mask };
         let port_status_after = if set_feature { port_status_mask } else { 0u16 };
 
-        if check_status {
-            let port_status = self.port_status(port, timeout)?;
-            ensure!(
-                port_status & port_status_mask == port_status_before,
-                "Trying to {} port {} but port has unexpected status {:#x}",
-                human_op,
-                port,
-                port_status
-            );
-        }
         // Perform operation.
         let _ = self.handle.write_control_timeout(
             req_type,

--- a/sw/host/opentitanlib/src/transport/common/usb.rs
+++ b/sw/host/opentitanlib/src/transport/common/usb.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result, bail, ensure};
 use rusb::{self, UsbContext};
 use std::time::{Duration, Instant};
 
-use crate::io::usb::{UsbContext as OtUsbContext, UsbDevice, desc::Configuration};
+use crate::io::usb::{UsbContext as OtUsbContext, UsbDevice, desc};
 use crate::transport::TransportError;
 
 /// Represents a device provided by the `rusb` crate.
@@ -14,6 +14,7 @@ pub struct RusbDevice {
     handle: rusb::DeviceHandle<rusb::Context>,
     serial_number: Option<String>,
     timeout: Duration,
+    device_desc: Vec<u8>,
     configurations: Vec<Vec<u8>>,
 }
 
@@ -221,6 +222,23 @@ impl RusbDevice {
         // Unfortunately, rusb simply wraps around libusb which does not
         // give access to the raw configuration descriptor so we must
         // get it directly from the device.
+        let dev_desc_size = handle.device().device_descriptor()?.length() as usize;
+        let mut device_desc = vec![0u8; dev_desc_size];
+        let size = handle
+            .read_control(
+                0x80,   // Standard, device, IN
+                6,      // GET_DESCRIPTOR
+                1 << 8, // DEVICE
+                0,
+                &mut device_desc,
+                timeout,
+            )
+            .context("could not retrieve device descriptor")?;
+        ensure!(
+            size == dev_desc_size,
+            "Device did not return the full device descriptor"
+        );
+
         let nr_config = handle
             .device()
             .device_descriptor()
@@ -254,6 +272,7 @@ impl RusbDevice {
             handle,
             serial_number,
             timeout,
+            device_desc,
             configurations,
         })
     }
@@ -317,14 +336,18 @@ impl UsbDevice for RusbDevice {
         self.handle.attach_kernel_driver(iface).context("USB error")
     }
 
-    fn active_configuration(&self) -> Result<Configuration> {
+    fn device_descriptor(&self) -> desc::Device<'_> {
+        desc::Device::new(&self.device_desc)
+    }
+
+    fn active_configuration(&self) -> Result<desc::Configuration> {
         let active_cfg_val = self
             .handle
             .active_configuration()
             .context("Cannot retrieve active configuration value")?;
         // Find the configuration matching the currently active one.
         for cfg in self.configurations.iter() {
-            let cfg = Configuration::new(cfg);
+            let cfg = desc::Configuration::new(cfg);
             if let Ok(desc) = cfg.descriptor() {
                 if desc.config_val == active_cfg_val {
                     return Ok(cfg);

--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -29,7 +29,7 @@ use crate::transport::chip_whisperer::ChipWhisperer;
 use crate::transport::chip_whisperer::board::Board;
 use crate::transport::common::fpga::{ClearBitstream, FpgaProgram};
 use crate::transport::common::uart::flock_serial;
-use crate::transport::common::usb::RusbContext;
+use crate::transport::common::usb::{RusbContext, UsbHub, UsbHubOp};
 use crate::transport::{
     Capabilities, Capability, SetJtagPins, Transport, TransportError, TransportInterfaceType,
     UpdateFirmware,
@@ -61,6 +61,7 @@ pub struct Hyperdebug<T: Flavor> {
     current_firmware_version: Option<String>,
     cmsis_google_capabilities: Cell<Option<u16>>,
     phantom: PhantomData<T>,
+    cw_usb_port_workaround: Option<u8>,
 }
 
 /// Trait allowing slightly different treatment of USB devices that work almost like a
@@ -142,6 +143,7 @@ impl<T: Flavor> Hyperdebug<T> {
         usb_vid: Option<u16>,
         usb_pid: Option<u16>,
         usb_serial: Option<&str>,
+        cw_usb_port_workaround: Option<u8>,
     ) -> Result<Self> {
         let usb_context = RusbContext::new();
         let device = usb_context.device_by_id(
@@ -304,6 +306,7 @@ impl<T: Flavor> Hyperdebug<T> {
             current_firmware_version,
             cmsis_google_capabilities: Cell::new(None),
             phantom: PhantomData,
+            cw_usb_port_workaround,
         };
         Ok(result)
     }
@@ -408,6 +411,28 @@ impl<T: Flavor> Hyperdebug<T> {
             .usb_device
             .release_interface(cmsis_interface.interface)?;
         Ok(capabilities)
+    }
+
+    // Return the parent hub of the hyperdebug device.
+    fn dut_usb_parent_hub(&self) -> Result<UsbHub> {
+        UsbHub::from_parent_device(&*self.inner.usb_device)
+            .context("failed to open the parent hub of the hyperdebug device")
+    }
+
+    fn enable_dut_usb_port(&self, en: bool) -> Result<()> {
+        if let Some(port) = self.cw_usb_port_workaround {
+            let (op, msg) = match en {
+                true => (UsbHubOp::PowerOn, "on"),
+                false => (UsbHubOp::PowerOff, "off"),
+            };
+            let hub = self.dut_usb_parent_hub()?;
+            log::info!("Powering {msg} port {port} on hyperdebug parent hub (CW USB workaround)");
+            hub.op(op, port, std::time::Duration::from_secs(1), true)
+                .context(format!(
+                    "failed to disable port {port} on hyperdebug parent hub (CW USB workaround)"
+                ))?;
+        }
+        Ok(())
     }
 }
 
@@ -803,9 +828,16 @@ impl<T: Flavor> Transport for Hyperdebug<T> {
                 _ => Err(TransportError::UnsupportedOperation.into()),
             }
         } else if let Some(fpga_program) = action.downcast_ref::<FpgaProgram>() {
-            T::load_bitstream(fpga_program).map(|_| None)
+            // Before loading the bitstream, we disable the USB port which corresponds to the USB OT
+            // device and only re-enable it after loading.
+            self.enable_dut_usb_port(false)?;
+            T::load_bitstream(fpga_program)?;
+            self.enable_dut_usb_port(true)?;
+            Ok(None)
         } else if let Some(clear) = action.downcast_ref::<ClearBitstream>() {
-            T::clear_bitstream(clear).map(|_| None)
+            self.enable_dut_usb_port(false)?;
+            T::clear_bitstream(clear)?;
+            Ok(None)
         } else {
             Err(TransportError::UnsupportedOperation.into())
         }

--- a/sw/host/opentitanlib/src/transport/qemu/usbdev.rs
+++ b/sw/host/opentitanlib/src/transport/qemu/usbdev.rs
@@ -293,6 +293,10 @@ impl QemuUsbDevice {
 }
 
 impl UsbDevice for QemuUsbDevice {
+    fn get_parent(&self) -> anyhow::Result<Box<dyn UsbDevice>> {
+        Err(anyhow!("this is the root USB device"))
+    }
+
     fn get_vendor_id(&self) -> u16 {
         // This cannot fail, the device descriptor was parsed during enumeration.
         desc::DeviceDescriptor::ref_from_bytes(&self.dev_info.dev_desc)

--- a/sw/host/opentitanlib/src/transport/qemu/usbdev.rs
+++ b/sw/host/opentitanlib/src/transport/qemu/usbdev.rs
@@ -381,6 +381,10 @@ impl UsbDevice for QemuUsbDevice {
         0
     }
 
+    fn address(&self) -> u8 {
+        self.dev_info.address
+    }
+
     /// Return the sequence of port numbers from the root down to the device.
     fn port_numbers(&self) -> anyhow::Result<Vec<u8>> {
         Ok(vec![0])

--- a/sw/host/opentitanlib/src/transport/qemu/usbdev.rs
+++ b/sw/host/opentitanlib/src/transport/qemu/usbdev.rs
@@ -361,6 +361,10 @@ impl UsbDevice for QemuUsbDevice {
         Ok(())
     }
 
+    fn device_descriptor(&self) -> desc::Device<'_> {
+        desc::Device::new(&self.dev_info.dev_desc)
+    }
+
     /// Return the currently active configuration's descriptor.
     fn active_configuration(&self) -> anyhow::Result<desc::Configuration> {
         Ok(desc::Configuration::new(

--- a/sw/host/tests/chip/usb/usb.rs
+++ b/sw/host/tests/chip/usb/usb.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 use opentitanlib::app::TransportWrapper;
+use opentitanlib::transport::common::usb::{RusbDevice, UsbHub};
 
 pub type UsbDevice = rusb::Device<rusb::Context>;
 pub type UsbDeviceHandle = rusb::DeviceHandle<rusb::Context>;
@@ -174,6 +175,33 @@ impl UsbOpts {
             // Wait a bit before polling again.
             std::thread::sleep(self.usb_poll_delay());
         }
+    }
+
+    // Wait for a device to appear and then return the parent device and port number.
+    pub fn wait_for_device_and_get_parent(&self, timeout: Duration) -> Result<(UsbHub, u8)> {
+        // Wait for USB device to appear.
+        log::info!("waiting for device...");
+        let devices = self.wait_for_device(timeout)?;
+        if devices.is_empty() {
+            bail!("no USB device found");
+        }
+        if devices.len() > 1 {
+            bail!("several USB devices found");
+        }
+        let device = devices.into_iter().next().unwrap();
+        log::info!(
+            "device found at bus={} address={}",
+            device.device().bus_number(),
+            device.device().address()
+        );
+        let port = device.device().port_number();
+        let usb_dev = Box::new(RusbDevice::new(device, None, Duration::from_millis(500))?);
+
+        Ok((
+            UsbHub::from_parent_device(&*usb_dev)
+                .context("cannot open parent hub, you need to have permissions for this test")?,
+            port,
+        ))
     }
 
     pub fn usb_poll_delay(&self) -> Duration {

--- a/sw/host/tests/chip/usb/usb.rs
+++ b/sw/host/tests/chip/usb/usb.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{Context, Result, bail, ensure};
+use anyhow::{Context, Result, bail};
 use clap::Parser;
 use rusb::UsbContext;
 
@@ -225,131 +225,6 @@ impl UsbOpts {
                 pin_strapping.remove()?;
             }
         }
-        Ok(())
-    }
-}
-
-// Structure representing a USB hub. The device needs to have sufficient permission
-// to be opened.
-pub struct UsbHub {
-    handle: UsbDeviceHandle,
-}
-
-// USB hub operation.
-pub enum UsbHubOp {
-    // Suspend a specific port.
-    Suspend,
-    // Suspend a specific port.
-    Resume,
-    // Reset a specific port.
-    Reset,
-}
-
-const PORT_SUSPEND: u16 = 2;
-const PORT_RESET: u16 = 4;
-
-impl UsbHub {
-    // Construct a hub from a device.
-    pub fn from_device(dev: &UsbDevice) -> Result<UsbHub> {
-        // Make sure the device is a hub.
-        let dev_desc = dev.device_descriptor()?;
-        // Assume that if the device has the HUB class then Linux will already enforce
-        // that it follows the specification.
-        ensure!(
-            dev_desc.class_code() == rusb::constants::LIBUSB_CLASS_HUB,
-            "device is not a hub"
-        );
-        Ok(UsbHub {
-            handle: dev.open().with_context(|| {
-                format!(
-                    "Cannot access USB hub on bus {bus}, address {addr}\n\
-                If this test requires access to the HUB, you need to make sure that \
-                the program has sufficient permissions to access the hub\n\
-                See sw/host/tests/chip/usb/README.md for more information\n\
-                The following command may fix the issue:\n\
-                sudo chmod 0666 /dev/bus/usb/{bus:03}/{addr:03}",
-                    bus = dev.bus_number(),
-                    addr = dev.address(),
-                )
-            })?,
-        })
-    }
-
-    pub fn device(&self) -> UsbDevice {
-        self.handle.device()
-    }
-
-    // Report the status of a port (only returns the port status, not the port change).
-    fn port_status(&self, port: u8, timeout: Duration) -> Result<u16> {
-        let req_type = rusb::constants::LIBUSB_RECIPIENT_OTHER
-            | rusb::constants::LIBUSB_REQUEST_TYPE_CLASS
-            | rusb::constants::LIBUSB_ENDPOINT_IN;
-        let mut status = [0u8; 4];
-        let _ = self.handle.read_control(
-            req_type,
-            rusb::constants::LIBUSB_REQUEST_GET_STATUS,
-            0,
-            port as u16,
-            &mut status,
-            timeout,
-        )?;
-        Ok(status[0] as u16 | (status[1] as u16) << 8)
-    }
-
-    // Perform an operation.
-    pub fn op(&self, op: UsbHubOp, port: u8, timeout: Duration, check_status: bool) -> Result<()> {
-        let (feature_index, set_feature, human_op) = match op {
-            UsbHubOp::Suspend => (PORT_SUSPEND, true, "suspend"),
-            UsbHubOp::Resume => (PORT_SUSPEND, false, "resume"),
-            UsbHubOp::Reset => (PORT_RESET, true, "reset"),
-        };
-        let req = if set_feature {
-            rusb::constants::LIBUSB_REQUEST_SET_FEATURE
-        } else {
-            rusb::constants::LIBUSB_REQUEST_CLEAR_FEATURE
-        };
-        let req_type = rusb::constants::LIBUSB_RECIPIENT_OTHER
-            | rusb::constants::LIBUSB_REQUEST_TYPE_CLASS
-            | rusb::constants::LIBUSB_ENDPOINT_OUT;
-        // Make sure that the port status is the expected one before the operation.
-        let port_status_mask = 1u16 << feature_index;
-        let port_status_before = if set_feature { 0u16 } else { port_status_mask };
-        let port_status_after = if set_feature { port_status_mask } else { 0u16 };
-
-        if check_status {
-            let port_status = self.port_status(port, timeout)?;
-            ensure!(
-                port_status & port_status_mask == port_status_before,
-                "Trying to {} port {} but port has unexpected status {:#x}",
-                human_op,
-                port,
-                port_status
-            );
-        }
-        // Perform operation.
-        let _ =
-            self.handle
-                .write_control(req_type, req, feature_index, port as u16, &[], timeout)?;
-        // Wait until port has changed status.
-        if check_status {
-            let start = Instant::now();
-            loop {
-                let port_status = self.port_status(port, timeout)?;
-                if port_status & port_status_mask == port_status_after {
-                    break;
-                }
-                if start.elapsed() >= timeout {
-                    bail!(
-                        "Trying to {} port {} but port did not change status (last status was {:x})",
-                        human_op,
-                        port,
-                        port_status
-                    );
-                }
-            }
-            log::info!("{} performed in {:#?}", human_op, start.elapsed());
-        }
-
         Ok(())
     }
 }

--- a/sw/host/tests/chip/usb/usbdev_aon_wake.rs
+++ b/sw/host/tests/chip/usb/usbdev_aon_wake.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{Context, Result, bail, ensure};
+use anyhow::{Result, ensure};
 use clap::{Parser, ValueEnum};
 use std::time::Duration;
 
@@ -10,7 +10,7 @@ use opentitanlib::app::TransportWrapper;
 use opentitanlib::execute_test;
 use opentitanlib::io::uart::Uart;
 use opentitanlib::test_utils::init::InitializeTest;
-use opentitanlib::transport::common::usb::{UsbHub, UsbHubOp};
+use opentitanlib::transport::common::usb::UsbHubOp;
 use opentitanlib::uart::console::UartConsole;
 
 use usb::UsbOpts;
@@ -39,35 +39,6 @@ enum WakeMethod {
     Disconnect,
 }
 
-// Wait for a device to appear and then return the parent device and port number.
-fn wait_for_device_and_get_parent(opts: &Opts) -> Result<(rusb::Device<rusb::Context>, u8)> {
-    // Wait for USB device to appear.
-    log::info!("waiting for device...");
-    let devices = opts.usb.wait_for_device(opts.timeout)?;
-    if devices.is_empty() {
-        bail!("no USB device found");
-    }
-    if devices.len() > 1 {
-        bail!("several USB devices found");
-    }
-    let device = &devices[0];
-    log::info!(
-        "device found at bus={} address={}",
-        device.device().bus_number(),
-        device.device().address()
-    );
-
-    // Important note: here the handle will be dropped and the device handle
-    // will be closed.
-    Ok((
-        device
-            .device()
-            .get_parent()
-            .context("device has no parent, you need to connect it via a hub for this test")?,
-        device.device().port_number(),
-    ))
-}
-
 fn usbdev_aon_wake(opts: &Opts, transport: &TransportWrapper, uart: &dyn Uart) -> Result<()> {
     opts.usb.apply_strappings(transport, true)?;
     // Enable VBUS sense on the board if necessary.
@@ -83,21 +54,10 @@ fn usbdev_aon_wake(opts: &Opts, transport: &TransportWrapper, uart: &dyn Uart) -
     }
 
     // Wait for device to appear.
-    let (parent, port) = wait_for_device_and_get_parent(opts)?;
-    log::info!(
-        "parent hub at bus={}, address={}, port numbers={:?}",
-        parent.bus_number(),
-        parent.address(),
-        parent.port_numbers()?
-    );
-    log::info!("device under test is on port {}", port);
-    // At this point, we are not holding any device handle. If we really want to make sure,
-    // we could unbind the device from the driver but this requires a lot of privileges.
+    let (hub, port) = opts.usb.wait_for_device_and_get_parent(opts.timeout)?;
 
     // Next, we suspend the device by directly accessing the parent hub.
     let _ = UartConsole::wait_for(uart, r"configured, waiting for suspend", opts.timeout)?;
-    let hub = UsbHub::from_device(&parent)
-        .context("For this test, you need to make sure that the program has access the hub")?;
     log::info!("suspend device");
     hub.op(
         UsbHubOp::Suspend,

--- a/sw/host/tests/chip/usb/usbdev_aon_wake.rs
+++ b/sw/host/tests/chip/usb/usbdev_aon_wake.rs
@@ -10,9 +10,10 @@ use opentitanlib::app::TransportWrapper;
 use opentitanlib::execute_test;
 use opentitanlib::io::uart::Uart;
 use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::transport::common::usb::{UsbHub, UsbHubOp};
 use opentitanlib::uart::console::UartConsole;
 
-use usb::{UsbHub, UsbHubOp, UsbOpts};
+use usb::UsbOpts;
 
 #[derive(Debug, Parser)]
 struct Opts {

--- a/sw/host/tests/chip/usb/usbdev_suspend.rs
+++ b/sw/host/tests/chip/usb/usbdev_suspend.rs
@@ -14,7 +14,7 @@
 // The above are sub-sections of the following full sequence test:
 // - usbdev_suspend_full_test
 
-use anyhow::{Context, Result, anyhow, bail, ensure};
+use anyhow::{Context, Result, anyhow, ensure};
 use clap::{Parser, ValueEnum};
 use std::time::Duration;
 
@@ -79,35 +79,6 @@ enum SuspendPhase {
     DeepDisconnect,
     // Final test state; device disconnects and test completes.
     Shutdown,
-}
-
-// Wait for a device to appear and then return the parent device and port number.
-fn wait_for_device_and_get_parent(opts: &Opts) -> Result<(rusb::Device<rusb::Context>, u8)> {
-    // Wait for USB device to appear.
-    log::info!("waiting for device...");
-    let devices = opts.usb.wait_for_device(opts.timeout)?;
-    if devices.is_empty() {
-        bail!("no USB device found");
-    }
-    if devices.len() > 1 {
-        bail!("several USB devices found");
-    }
-    let device = &devices[0];
-    log::info!(
-        "device found at bus={} address={}",
-        device.device().bus_number(),
-        device.device().address()
-    );
-
-    // Important note: here the handle will be dropped and the device handle
-    // will be closed.
-    Ok((
-        device
-            .device()
-            .get_parent()
-            .context("device has no parent, you need to connect it via a hub for this test")?,
-        device.device().port_number(),
-    ))
 }
 
 // Delay for the specified number of USB milliseconds (= bus frames).
@@ -222,21 +193,7 @@ fn usbdev_suspend(
     }
 
     // Wait for device to appear.
-    let (parent, port) = wait_for_device_and_get_parent(opts)?;
-    log::info!(
-        "parent hub at bus={}, address={}, port numbers={:?}",
-        parent.bus_number(),
-        parent.address(),
-        parent.port_numbers()?
-    );
-    log::info!("device under test is on port {}", port);
-    // At this point, we are not holding any device handle. If we really want to make sure,
-    // we could unbind the device from the driver but this requires a lot of privileges.
-
-    let _devices = opts.usb.wait_for_device(opts.timeout)?;
-
-    let hub = UsbHub::from_device(&parent)
-        .context("for this test, you need to make sure to access the hub")?;
+    let (hub, port) = opts.usb.wait_for_device_and_get_parent(opts.timeout)?;
 
     // Collect test phases.
     let init_phase = opts.init_phase.clone();

--- a/sw/host/tests/chip/usb/usbdev_suspend.rs
+++ b/sw/host/tests/chip/usb/usbdev_suspend.rs
@@ -22,9 +22,10 @@ use opentitanlib::app::TransportWrapper;
 use opentitanlib::execute_test;
 use opentitanlib::io::uart::Uart;
 use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::transport::common::usb::{UsbHub, UsbHubOp};
 use opentitanlib::uart::console::UartConsole;
 
-use usb::{UsbHub, UsbHubOp, UsbOpts, get_device_by_port_numbers};
+use usb::{UsbOpts, get_device_by_port_numbers};
 
 #[derive(Debug, Parser)]
 struct Opts {


### PR DESCRIPTION
This is a rather complicated backport of several things on the master branch:
- it back-backports some elements of https://github.com/lowRISC/opentitan/pull/29958 which were introduced on the master branch
- it backports the change to workaround a CW board design problem: https://github.com/lowRISC/opentitan/pull/29372
- picks a commit from https://github.com/lowRISC/opentitan/pull/29594 related to hub operations checks