### PR TITLE
[aes] Add output_valid and input_ready outputs to ease DMA integrations

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -197,6 +197,18 @@
       struct:  "mubi4",
       width:   "1"
     },
+    { name:    "output_valid",
+      type:    "uni",
+      act:     "req",
+      struct:  "logic",
+      width:   "1"
+    },
+    { name:    "input_ready",
+      type:    "uni",
+      act:     "req",
+      struct:  "logic",
+      width:   "1"
+    },
     { struct:  "lc_tx"
       type:    "uni"
       name:    "lc_escalate_en"
@@ -972,7 +984,8 @@
       }
       { bits: "3",
         name: "OUTPUT_VALID",
-        resval: "0"
+        resval: "0",
+        hwaccess: "hrw",
         desc:  '''
           The AES unit has no valid output (0) or has valid output data (1).
         '''
@@ -981,6 +994,7 @@
       { bits: "4",
         name: "INPUT_READY",
         resval: "0",
+        hwaccess: "hrw",
         desc:  '''
           The AES unit is ready (1) or not ready (0) to receive new data input via the DATA_IN registers.
           If the present values in the DATA_IN registers have not yet been loaded into the

--- a/hw/ip/aes/doc/interfaces.md
+++ b/hw/ip/aes/doc/interfaces.md
@@ -13,6 +13,8 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 | Port Name      | Package::Struct        | Type    | Act   |   Width | Description   |
 |:---------------|:-----------------------|:--------|:------|--------:|:--------------|
 | idle           | prim_mubi_pkg::mubi4   | uni     | req   |       1 |               |
+| output_valid   | logic                  | uni     | req   |       1 |               |
+| input_ready    | logic                  | uni     | req   |       1 |               |
 | lc_escalate_en | lc_ctrl_pkg::lc_tx     | uni     | rcv   |       1 |               |
 | edn            | edn_pkg::edn           | req_rsp | req   |       1 |               |
 | keymgr_key     | keymgr_pkg::hw_key_req | uni     | rcv   |       1 |               |

--- a/hw/ip/aes/dv/tb/tb.sv
+++ b/hw/ip/aes/dv/tb/tb.sv
@@ -54,6 +54,8 @@ module tb;
     .rst_shadowed_ni  ( rst_shadowed_n                    ),
 
     .idle_o           ( idle_s                            ),
+    .output_valid_o   (                                   ),
+    .input_ready_o    (                                   ),
     .lc_escalate_en_i ( lc_escalate_en                    ),
     .clk_edn_i        ( edn_clk                           ),
     .rst_edn_ni       ( edn_rst_n                         ),

--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -46,6 +46,10 @@ module aes
   // Idle indicator for clock manager
   output prim_mubi_pkg::mubi4_t                     idle_o,
 
+  // Status indicators for DMA integrations
+  output logic                                      output_valid_o,
+  output logic                                      input_ready_o,
+
   // Life cycle
   input  lc_ctrl_pkg::lc_tx_t                       lc_escalate_en_i,
 
@@ -215,6 +219,8 @@ module aes
   );
 
   assign idle_o = prim_mubi_pkg::mubi4_bool_to_mubi(reg2hw.status.idle.q);
+  assign output_valid_o = reg2hw.status.output_valid.q;
+  assign input_ready_o = reg2hw.status.input_ready.q;
 
   ////////////
   // Alerts //

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -1090,8 +1090,9 @@ module aes_core
   assign unused_alert_signals = ^reg2hw.alert_test;
 
   // Unused inputs
-  logic unused_idle;
-  assign unused_idle = reg2hw.status.idle.q;
+  logic unused_status;
+  assign unused_status =
+      reg2hw.status.idle.q ^ reg2hw.status.output_valid.q ^ reg2hw.status.input_ready.q;
 
   ////////////////
   // Assertions //

--- a/hw/ip/aes/rtl/aes_reg_pkg.sv
+++ b/hw/ip/aes/rtl/aes_reg_pkg.sv
@@ -124,6 +124,12 @@ package aes_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
+    } input_ready;
+    struct packed {
+      logic        q;
+    } output_valid;
+    struct packed {
+      logic        q;
     } output_lost;
     struct packed {
       logic        q;
@@ -246,16 +252,16 @@ package aes_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    aes_reg2hw_alert_test_reg_t alert_test; // [970:967]
-    aes_reg2hw_key_share0_mreg_t [7:0] key_share0; // [966:703]
-    aes_reg2hw_key_share1_mreg_t [7:0] key_share1; // [702:439]
-    aes_reg2hw_iv_mreg_t [3:0] iv; // [438:307]
-    aes_reg2hw_data_in_mreg_t [3:0] data_in; // [306:175]
-    aes_reg2hw_data_out_mreg_t [3:0] data_out; // [174:43]
-    aes_reg2hw_ctrl_shadowed_reg_t ctrl_shadowed; // [42:21]
-    aes_reg2hw_ctrl_aux_shadowed_reg_t ctrl_aux_shadowed; // [20:19]
-    aes_reg2hw_trigger_reg_t trigger; // [18:15]
-    aes_reg2hw_status_reg_t status; // [14:13]
+    aes_reg2hw_alert_test_reg_t alert_test; // [972:969]
+    aes_reg2hw_key_share0_mreg_t [7:0] key_share0; // [968:705]
+    aes_reg2hw_key_share1_mreg_t [7:0] key_share1; // [704:441]
+    aes_reg2hw_iv_mreg_t [3:0] iv; // [440:309]
+    aes_reg2hw_data_in_mreg_t [3:0] data_in; // [308:177]
+    aes_reg2hw_data_out_mreg_t [3:0] data_out; // [176:45]
+    aes_reg2hw_ctrl_shadowed_reg_t ctrl_shadowed; // [44:23]
+    aes_reg2hw_ctrl_aux_shadowed_reg_t ctrl_aux_shadowed; // [22:21]
+    aes_reg2hw_trigger_reg_t trigger; // [20:17]
+    aes_reg2hw_status_reg_t status; // [16:13]
     aes_reg2hw_ctrl_gcm_shadowed_reg_t ctrl_gcm_shadowed; // [12:0]
   } aes_reg2hw_t;
 

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -1346,7 +1346,7 @@ module aes_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (),
+    .q      (reg2hw.status.output_valid.q),
     .ds     (),
 
     // to register interface (read)
@@ -1373,7 +1373,7 @@ module aes_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (),
+    .q      (reg2hw.status.input_ready.q),
     .ds     (),
 
     // to register interface (read)

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -5064,6 +5064,24 @@
           conn_type: false
         }
         {
+          name: output_valid
+          struct: logic
+          type: uni
+          act: req
+          width: 1
+          inst_name: aes
+          index: -1
+        }
+        {
+          name: input_ready
+          struct: logic
+          type: uni
+          act: req
+          width: 1
+          inst_name: aes
+          index: -1
+        }
+        {
           name: lc_escalate_en
           struct: lc_tx
           package: lc_ctrl_pkg
@@ -25205,6 +25223,24 @@
         index: 0
         external: true
         conn_type: false
+      }
+      {
+        name: output_valid
+        struct: logic
+        type: uni
+        act: req
+        width: 1
+        inst_name: aes
+        index: -1
+      }
+      {
+        name: input_ready
+        struct: logic
+        type: uni
+        act: req
+        width: 1
+        inst_name: aes
+        index: -1
       }
       {
         name: lc_escalate_en

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -1554,6 +1554,8 @@ module top_darjeeling #(
 
     // Inter-module signals
     .idle_o(clkmgr_aon_idle_o[0]),
+    .output_valid_o(),
+    .input_ready_o(),
     .lc_escalate_en_i(lc_ctrl_lc_escalate_en),
     .edn_o(edn0_edn_req[4]),
     .edn_i(edn0_edn_rsp[4]),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -7123,6 +7123,24 @@
           conn_type: false
         }
         {
+          name: output_valid
+          struct: logic
+          type: uni
+          act: req
+          width: 1
+          inst_name: aes
+          index: -1
+        }
+        {
+          name: input_ready
+          struct: logic
+          type: uni
+          act: req
+          width: 1
+          inst_name: aes
+          index: -1
+        }
+        {
           name: lc_escalate_en
           struct: lc_tx
           package: lc_ctrl_pkg
@@ -24518,6 +24536,24 @@
         index: 0
         external: true
         conn_type: false
+      }
+      {
+        name: output_valid
+        struct: logic
+        type: uni
+        act: req
+        width: 1
+        inst_name: aes
+        index: -1
+      }
+      {
+        name: input_ready
+        struct: logic
+        type: uni
+        act: req
+        width: 1
+        inst_name: aes
+        index: -1
       }
       {
         name: lc_escalate_en

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -2059,6 +2059,8 @@ module top_earlgrey #(
 
     // Inter-module signals
     .idle_o(clkmgr_aon_idle_o[0]),
+    .output_valid_o(),
+    .input_ready_o(),
     .lc_escalate_en_i(lc_ctrl_lc_escalate_en),
     .edn_o(edn0_edn_req[5]),
     .edn_i(edn0_edn_rsp[5]),

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -3670,6 +3670,24 @@
           conn_type: false
         }
         {
+          name: output_valid
+          struct: logic
+          type: uni
+          act: req
+          width: 1
+          inst_name: aes
+          index: -1
+        }
+        {
+          name: input_ready
+          struct: logic
+          type: uni
+          act: req
+          width: 1
+          inst_name: aes
+          index: -1
+        }
+        {
           name: lc_escalate_en
           struct: lc_tx
           package: lc_ctrl_pkg
@@ -11872,6 +11890,24 @@
         index: -1
         external: true
         conn_type: false
+      }
+      {
+        name: output_valid
+        struct: logic
+        type: uni
+        act: req
+        width: 1
+        inst_name: aes
+        index: -1
+      }
+      {
+        name: input_ready
+        struct: logic
+        type: uni
+        act: req
+        width: 1
+        inst_name: aes
+        index: -1
       }
       {
         name: lc_escalate_en

--- a/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
@@ -899,6 +899,8 @@ module top_englishbreakfast #(
 
     // Inter-module signals
     .idle_o(clkmgr_aon_idle_o),
+    .output_valid_o(),
+    .input_ready_o(),
     .lc_escalate_en_i(lc_ctrl_pkg::Off),
     .edn_o(),
     .edn_i(edn_pkg::EDN_RSP_DEFAULT),


### PR DESCRIPTION
Having these status bits available as output signals is very helpful for integrations into DMA engines as for example in Caliptra.