### PR TITLE
Fix cryptolib build regression with modern LLVM

### DIFF
--- a/sw/device/lib/base/hardened.h
+++ b/sw/device/lib/base/hardened.h
@@ -504,7 +504,7 @@ inline ct_bool32_t ct_seq32(uint32_t a, uint32_t b) {
  */
 OT_WARN_UNUSED_RESULT
 inline uint32_t ct_cmov32(ct_bool32_t c, uint32_t a, uint32_t b) {
-#if defined(OT_PLATFORM_RV32)
+#if defined(OT_PLATFORM_RV32) && defined(OT_PLATFORM_RV32_SUPPORTS_ZBT0P93)
   uint32_t res;
   asm volatile(
       ".option push;"
@@ -633,7 +633,7 @@ inline ct_boolw_t ct_seqw(uintptr_t a, uintptr_t b) {
  */
 OT_WARN_UNUSED_RESULT
 inline uintptr_t ct_cmovw(ct_boolw_t c, uintptr_t a, uintptr_t b) {
-#if defined(OT_PLATFORM_RV32)
+#if defined(OT_PLATFORM_RV32) && defined(OT_PLATFORM_RV32_SUPPORTS_ZBT0P93)
   uintptr_t res;
   asm volatile(
       ".option push;"

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -280,7 +280,10 @@ cc_args(
         "@rules_cc//cc/toolchains/actions:compile_actions",
         "@rules_cc//cc/toolchains/actions:link_actions",
     ],
-    args = ["-march=rv32imc_zba_zbb_zbc_zbs"],
+    args = [
+        "-march=rv32imc_zba_zbb_zbc_zbs",
+        "-DOT_PLATFORM_RV32_SUPPORTS_ZBT0P93",
+    ],
     requires_any_of = [":constraint_bitmanip"],
 )
 


### PR DESCRIPTION
Regression in https://github.com/lowRISC/opentitan/pull/30374

When built with LLVM 23:

```
external/lowrisc_opentitan+/sw/device/lib/base/hardened.h:510:7: error: extension version number parsing not currently implemented
  510 |       ".option push;"
      |       ^
<inline asm>:1:30: note: instantiated into assembly here
    1 |         .option push;.option arch, +zbt0p93;cmov a0, a0, a1, a2;.option pop;
      |                                     ^
In file included from external/lowrisc_opentitan+/sw/device/lib/base/hardened.c:5:
```