### PR TITLE
[crypto/state] Update CSRNG caching

### DIFF
--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -675,6 +675,14 @@ The DRBG can be seeded with new entropy from OpenTitan's hardware [entropy sourc
 It is also possible to instantiate or reseed the DRBG with *only* caller-provided entropy ("manual instantiate" and "manual reseed").
 This is useful for testing, but undermines security guarantees and FIPS compliance until the DRBG is uninstantiated again, so it is best to use these operations with caution.
 
+### CSRNG Caching and Modes (Default vs Custom)
+
+The cryptolib distinguishes between two instantiation modes for CSRNG:
+
+1. **Default Instantiation (`otcrypto_drbg_instantiate(NULL)` or with empty string):** Instantiates the CSRNG using automatic hardware TRNG input without any personalization string or extra seed material.
+Redundant requests for default instantiation (such as internal calls during RSA padding and signature generation) detect this cached state and skip hardware re-instantiation for higher efficiency.
+2. **Custom Instantiation (`otcrypto_drbg_instantiate(perso_string)` with non-empty string, or manual operations):** Instantiates the CSRNG with custom personalization data or user-supplied entropy.
+Custom instantiations are not cached and will always perform a full re-instantiation of the hardware CSRNG.
 
 To learn more about DRBG details such as entropy requirements, seed construction, derivation functions and prediction resistance, please refer to the [NIST SP800-90A][nist-drbg-spec], [NIST SP800-90B][nist-entropy-spec], [NIST SP800-90C][nist-rng-spec], and [BSI AIS31][bsi-ais31] documents and the links in the [reference](#reference) section.
 

--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -1129,29 +1129,22 @@ status_t entropy_csrng_instantiate(
     const entropy_seed_material_t *seed_material) {
   crypto_state_t *state = NULL;
 
+  hardened_bool_t is_default = kHardenedBoolFalse;
+  if (launder32(disable_trng_input) == kHardenedBoolFalse &&
+      (seed_material == NULL || seed_material->len == 0)) {
+    HARDENED_CHECK_EQ(disable_trng_input, kHardenedBoolFalse);
+    is_default = kHardenedBoolTrue;
+  }
+
   hardened_bool_t skip_inst = kHardenedBoolFalse;
   if (status_ok(read_state_pointer(&state)) && state != NULL) {
-    if (launder32(state->csrng_instantiated) == kHardenedBoolTrue &&
-        launder32(hardened_memeq(&state->disable_trng_input,
-                                 &disable_trng_input, 1)) ==
-            kHardenedBoolTrue) {
+    if (launder32(is_default) == kHardenedBoolTrue &&
+        launder32(state->csrng_instantiated) == kHardenedBoolTrue &&
+        launder32(state->csrng_is_default) == kHardenedBoolTrue) {
+      HARDENED_CHECK_EQ(is_default, kHardenedBoolTrue);
       HARDENED_CHECK_EQ(state->csrng_instantiated, kHardenedBoolTrue);
-      HARDENED_CHECK_EQ(
-          hardened_memeq(&state->disable_trng_input, &disable_trng_input, 1),
-          kHardenedBoolTrue);
-      uint32_t len = seed_material == NULL ? 0 : (uint32_t)seed_material->len;
-      uint32_t state_len = (uint32_t)state->csrng_seed_len;
-      if (hardened_memeq(&state_len, &len, 1) == kHardenedBoolTrue) {
-        hardened_bool_t match = kHardenedBoolTrue;
-        if (len > 0 && seed_material != NULL) {
-          match =
-              hardened_memeq(state->csrng_seed_data, seed_material->data, len);
-        }
-        if (launder32(match) == kHardenedBoolTrue) {
-          HARDENED_CHECK_EQ(match, kHardenedBoolTrue);
-          skip_inst = kHardenedBoolTrue;
-        }
-      }
+      HARDENED_CHECK_EQ(state->csrng_is_default, kHardenedBoolTrue);
+      skip_inst = kHardenedBoolTrue;
     }
   }
 
@@ -1175,14 +1168,7 @@ status_t entropy_csrng_instantiate(
 
   if (state != NULL) {
     state->csrng_instantiated = kHardenedBoolTrue;
-    state->disable_trng_input = disable_trng_input;
-    if (seed_material != NULL) {
-      state->csrng_seed_len = seed_material->len;
-      memcpy(state->csrng_seed_data, seed_material->data,
-             seed_material->len * sizeof(uint32_t));
-    } else {
-      state->csrng_seed_len = 0;
-    }
+    state->csrng_is_default = is_default;
   }
 
   return OTCRYPTO_OK;
@@ -1303,6 +1289,7 @@ status_t entropy_csrng_uninstantiate(void) {
   // Check whether the state is present and use it if so
   if (status_ok(read_state_pointer(&state)) && state != NULL) {
     state->csrng_instantiated = kHardenedBoolFalse;
+    state->csrng_is_default = kHardenedBoolFalse;
   }
 
   return OTCRYPTO_OK;

--- a/sw/device/lib/crypto/impl/drbg.c
+++ b/sw/device/lib/crypto/impl/drbg.c
@@ -32,6 +32,10 @@
 static status_t seed_material_construct(
     const otcrypto_const_byte_buf_t *value,
     entropy_seed_material_t *seed_material) {
+  if (value == NULL || value->len == 0) {
+    seed_material->len = 0;
+    return OTCRYPTO_OK;
+  }
   if (value->len > kEntropySeedBytes) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -111,7 +115,8 @@ otcrypto_status_t otcrypto_drbg_instantiate(
     const otcrypto_const_byte_buf_t *perso_string) {
 #ifndef OTCRYPTO_DISABLE_NULL_CHECKS
   // Check for NULL pointers or bad length.
-  if (perso_string->len != 0 && perso_string->data == NULL) {
+  if (perso_string != NULL && perso_string->len != 0 &&
+      perso_string->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 #endif
@@ -122,7 +127,6 @@ otcrypto_status_t otcrypto_drbg_instantiate(
       hardened_memshred(seed_material.data, ARRAYSIZE(seed_material.data)));
   HARDENED_TRY(seed_material_construct(perso_string, &seed_material));
 
-  HARDENED_TRY(entropy_csrng_uninstantiate());
   return otcrypto_eval_exit(entropy_csrng_instantiate(
       /*disable_trng_input=*/kHardenedBoolFalse, &seed_material));
 }

--- a/sw/device/lib/crypto/impl/mock_state.cc
+++ b/sw/device/lib/crypto/impl/mock_state.cc
@@ -17,6 +17,7 @@ static crypto_state_t default_state = {
     .self_check_state = kHardenedBoolFalse,
     .locked_state = kHardenedBoolFalse,
     .csrng_instantiated = kHardenedBoolFalse,
+    .csrng_is_default = kHardenedBoolFalse,
 };
 
 otcrypto_status_t init_state(otcrypto_state_t *state,
@@ -26,6 +27,7 @@ otcrypto_status_t init_state(otcrypto_state_t *state,
   internal_state->locked_state = kHardenedBoolFalse;
   internal_state->self_check_state = kHardenedBoolFalse;
   internal_state->csrng_instantiated = kHardenedBoolFalse;
+  internal_state->csrng_is_default = kHardenedBoolFalse;
   internal_state->security_level = security_level;
   return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/impl/rsa/rsa_padding.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_padding.c
@@ -733,8 +733,9 @@ status_t rsa_padding_oaep_encode(const otcrypto_hash_mode_t hash_mode,
   // Generate a random string the same length as a hash digest (step 2d).
   uint32_t seed[digest_wordlen];
   HARDENED_TRY(entropy_csrng_instantiate(
-      /*disable_trng_input=*/kHardenedBoolFalse, &kEntropyEmptySeed));
-  HARDENED_TRY(entropy_csrng_generate(&kEntropyEmptySeed, seed, ARRAYSIZE(seed),
+      /*disable_trng_input=*/kHardenedBoolFalse, /*seed_material=*/NULL));
+  HARDENED_TRY(entropy_csrng_generate(/*seed_material=*/NULL, seed,
+                                      ARRAYSIZE(seed),
                                       /*fips_check=*/kHardenedBoolTrue));
 
   // Generate dbMask = MGF(seed, k - hLen - 1) (step 2e).

--- a/sw/device/lib/crypto/impl/rsa/rsa_signature.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_signature.c
@@ -96,8 +96,8 @@ static status_t message_encode(const otcrypto_hash_digest_t message_digest,
       // Generate a random salt value whose length matches the digest length.
       uint32_t salt[message_digest.len];
       HARDENED_TRY(entropy_csrng_instantiate(
-          /*disable_trng_input=*/kHardenedBoolFalse, &kEntropyEmptySeed));
-      HARDENED_TRY(entropy_csrng_generate(&kEntropyEmptySeed, salt,
+          /*disable_trng_input=*/kHardenedBoolFalse, /*seed_material=*/NULL));
+      HARDENED_TRY(entropy_csrng_generate(/*seed_material=*/NULL, salt,
                                           ARRAYSIZE(salt),
                                           /*fips_check=*/kHardenedBoolTrue));
       return rsa_padding_pss_encode(message_digest, salt, ARRAYSIZE(salt),

--- a/sw/device/lib/crypto/impl/state.c
+++ b/sw/device/lib/crypto/impl/state.c
@@ -21,6 +21,7 @@ otcrypto_status_t init_state(otcrypto_state_t *state,
   internal_state->locked_state = kHardenedBoolFalse;
   internal_state->self_check_state = kHardenedBoolFalse;
   internal_state->csrng_instantiated = kHardenedBoolFalse;
+  internal_state->csrng_is_default = kHardenedBoolFalse;
   internal_state->security_level = security_level;
   return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/impl/state.h
+++ b/sw/device/lib/crypto/impl/state.h
@@ -16,13 +16,11 @@ extern "C" {
 typedef struct crypto_state {
   uint32_t imem_cache;
   uint32_t kat_state;
-  uint32_t csrng_seed_data[12];
   otcrypto_key_security_level_t security_level;
-  size_t csrng_seed_len;
   hardened_bool_t self_check_state;
   hardened_bool_t locked_state;
   hardened_bool_t csrng_instantiated;
-  hardened_bool_t disable_trng_input;
+  hardened_bool_t csrng_is_default;
 } crypto_state_t;
 
 static_assert(sizeof(otcrypto_state_t) >= sizeof(crypto_state_t),

--- a/sw/device/lib/crypto/include/drbg.h
+++ b/sw/device/lib/crypto/include/drbg.h
@@ -22,12 +22,17 @@ extern "C" {
  * Initializes the DRBG and the context for DRBG. Gets the required entropy
  * input automatically from the entropy source.
  *
- * The personalization string may empty, and may be up to 48 bytes long; any
- * longer will result in an error. If the string is word aligned and the size
- * is a multiple of the word length (32-bit), it is handled using SCA hardened
- * memory operations. If not, a non SCA hardened fallback is used.
+ * The personalization string may be empty (or NULL), and may be up to 48 bytes
+ * long; any longer will result in an error.
  *
- * @param perso_string Pointer to personalization bitstring.
+ * Calling this function with NULL or an empty personalization string selects
+ * the default CSRNG instantiation mode (hardware TRNG input with no extra seed
+ * material). This default mode is cached in the internal state so that
+ * redundant calls skip hardware re-instantiation. Providing a non-empty
+ * personalization string selects a custom instantiation, which is not cached.
+ *
+ * @param perso_string Pointer to personalization bitstring, or NULL for default
+ * mode.
  * @return Result of the DRBG instantiate operation.
  */
 otcrypto_status_t otcrypto_drbg_instantiate(


### PR DESCRIPTION
In order to reduce the size of the state, the caching of the CSRNG moves to caching whether it is instantiated and whether the CSRNG is in the default state. The default state is to instantiate it with TRNG input and without additional seed data. When asking for an instantiation, the caching will look into this default state and skip it in if the CSRNG is already in this default state.
When using the CSRNG in any custom state such as providing a seed input or disabling the TRNG, this is seen as a custom state and no caching is supported.

Also update the documentation is this regard.