### PR TITLE
[otbn,mai] Check that MAI_CTRL.OPERATION is constant during execution

### DIFF
--- a/hw/ip/otbn/doc/theory_of_operation.md
+++ b/hw/ip/otbn/doc/theory_of_operation.md
@@ -884,6 +884,7 @@ The overlapping execution software flow is:
 - Repeat the steps starting with "Poll until `MAI_STATUS.READY = 1`".
 
 This procedure can be even further optimized for secAdd, secAddMod, and A2B because their latency is deterministic and thus the polling can be replaced with the correct number of other instructions.
+It is only possible to overlap executions of the same type / configuration as `MAI_CTRL.OPERATION` must remain constant as long as `MAI_STATUS.BUSY = 1`.
 
 The following image depicts the flow for multiple secAdd executions without any memory operations (to load data from/to WDRs / DMEM).
 A result with “1p” means that this WSR contains partial results (vector elements) / is being overwritten with results from the current conversion (2p for results of the second conversion, etc).
@@ -900,11 +901,12 @@ This will trigger an abortion of the OTBN execution with a secure wipe.
 
 The `MAI_SOFTWARE_ERROR` is triggered when:
 - `MAI_CTRL.OPERATION` contains an invalid selection when the `MAI_CTRL.START` bit is set.
-- The `MAI_CTRL.START` bit is set or `MAI_CTRL.OPERATION` is changed whilst `MAI_STATUS.BUSY = 1`.
+- The `MAI_CTRL.START` bit is set or `MAI_CTRL.OPERATION` is written to whilst `MAI_STATUS.BUSY = 1`.
 - A write to input WSRs is detected whilst `MAI_STATUS.READY = 0`.
   - The `MAI_INx_Sy` registers are used as input buffers.
     Modifying the register content can lead to unexpected results.
 - A write to the reserved section of `MAI_CTRL` is detected.
+  - Note that the MOD WSR must also remain constant but this is not checked for in HW.
 
 A write to the output WSRs whilst an operation is ongoing is on purpose not handled as an error.
 This allows clearing the output WSRs between two overlapping operations if this would be required for security reasons.

--- a/hw/ip/otbn/rtl/otbn_mai.sv
+++ b/hw/ip/otbn/rtl/otbn_mai.sv
@@ -429,14 +429,13 @@ module otbn_mai
   assign ispr_mai_ctrl_rdata_o = ispr_mai_ctrl_r;
 
   // Erroneous control accesses
-  assign ispr_mai_sw_err.busy_start     = ma_start & ma_busy_q;
-  // There may not be a write to the input WSRs nor the configuration whilst an execution is
-  // ongoing. This is required to keep data and configuration stable and valid for the whole
-  // execution.
+  // The start bit and configuration may only be written when not busy.
+  assign ispr_mai_sw_err.busy_start     = ma_busy_q & ispr_mai_ctrl_wr_i;
+  // There may not be a write to the input WSRs whilst an execution is ongoing. This is required to
+  // keep data stable and valid as long as elements are dispatched.
   assign ispr_mai_sw_err.busy_write     = ma_in_valid_q &
                                           |{ispr_mai_in0_s0_wr_i, ispr_mai_in0_s1_wr_i,
-                                            ispr_mai_in1_s0_wr_i, ispr_mai_in1_s1_wr_i,
-                                            ispr_mai_ctrl_wr_i};
+                                            ispr_mai_in1_s0_wr_i, ispr_mai_in1_s1_wr_i};
   assign ispr_mai_sw_err.rsvd_csr_write = ispr_mai_ctrl_wr_i & (|ispr_mai_ctrl_w.rsvd);
   // The configuration latched when an execution starts must be valid.
   assign ispr_mai_sw_err.invalid_op     = !(ma_mask_op_d inside


### PR DESCRIPTION
The MAI_CTRL.OPERATION field was only required to be constant as long as elements were dispatched into the masking accelerator. Now it must remain stable for the whole execution.

This is a follow up of https://github.com/lowRISC/opentitan/pull/30505.