### PR TITLE
[otbn] Extend MAI test to a top level test

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3204,6 +3204,28 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "otbn_mai_test",
+    srcs = ["otbn_mai_test.c"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        DARJEELING_TEST_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
+            "//hw/top_earlgrey:silicon_creator": None,
+        },
+    ),
+    deps = [
+        "//hw/top/dt",
+        "//sw/device/lib/dif:otbn",
+        "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing:otbn_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/otbn/mai:mai_tlt_test",
+    ],
+)
+
+opentitan_test(
     name = "otbn_isa_test",
     srcs = ["otbn_isa_test.c"],
     exec_env = dicts.add(

--- a/sw/device/tests/otbn_mai_test.c
+++ b/sw/device/tests/otbn_mai_test.c
@@ -1,0 +1,105 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This test runs an OTBN program that exercises the OTBN Masked Arithmetic
+// Interface (MAI). It tests two operations:
+//   - A B2A conversion followed by an A2B conversion, which must return the
+//     secret unchanged.
+//   - secAdd, a Boolean-masked arithmetic addition of two operands.
+// Ibex loads the inputs into OTBN's data memory, runs the program, and checks
+// the results.
+
+#include "hw/top/dt/otbn.h"
+#include "sw/device/lib/dif/dif_otbn.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/otbn_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+OTBN_DECLARE_APP_SYMBOLS(mai_tlt_test);
+OTBN_DECLARE_SYMBOL_ADDR(mai_tlt_test, secret);
+OTBN_DECLARE_SYMBOL_ADDR(mai_tlt_test, operand_a);
+OTBN_DECLARE_SYMBOL_ADDR(mai_tlt_test, operand_b);
+OTBN_DECLARE_SYMBOL_ADDR(mai_tlt_test, result);
+OTBN_DECLARE_SYMBOL_ADDR(mai_tlt_test, result_secadd);
+
+static const otbn_app_t kAppMaiTest = OTBN_APP_T_INIT(mai_tlt_test);
+static const otbn_addr_t kSecret = OTBN_ADDR_T_INIT(mai_tlt_test, secret);
+static const otbn_addr_t kOperandA = OTBN_ADDR_T_INIT(mai_tlt_test, operand_a);
+static const otbn_addr_t kOperandB = OTBN_ADDR_T_INIT(mai_tlt_test, operand_b);
+static const otbn_addr_t kResult = OTBN_ADDR_T_INIT(mai_tlt_test, result);
+static const otbn_addr_t kResultSecAdd =
+    OTBN_ADDR_T_INIT(mai_tlt_test, result_secadd);
+
+static_assert(kDtOtbnCount >= 1,
+              "This test requires at least one OTBN instance");
+
+static dt_otbn_t kTestOtbn = (dt_otbn_t)0;
+
+OTTF_DEFINE_TEST_CONFIG();
+
+// The secret to convert stored as little-endian 32-bit words.
+static const uint32_t kSecretInput[8] = {
+    0x0003a981, 0x00165e68, 0x007b4968, 0x0028b454,
+    0x00670489, 0x003f3539, 0x007325a8, 0x004b0797,
+};
+
+// After a B2A conversion followed by an A2B conversion the secret must be
+// unchanged, so the expected result equals the input.
+static const uint32_t kExpectedResult[8] = {
+    0x0003a981, 0x00165e68, 0x007b4968, 0x0028b454,
+    0x00670489, 0x003f3539, 0x007325a8, 0x004b0797,
+};
+
+// The two operands for secAdd, stored as little-endian 32-bit words.
+static const uint32_t kOperandAInput[8] = {
+    0x00000001, 0x00100000, 0x00200000, 0x00300000,
+    0x00400000, 0x00010203, 0x00040506, 0x0000abcd,
+};
+static const uint32_t kOperandBInput[8] = {
+    0x00000002, 0x00100000, 0x00080000, 0x00040000,
+    0x00010000, 0x00010101, 0x00000a0b, 0x00001111,
+};
+
+// secAdd adds the operands element-wise (mod 2^32).
+static const uint32_t kExpectedSecAdd[8] = {
+    0x00000003, 0x00200000, 0x00280000, 0x00340000,
+    0x00410000, 0x00020304, 0x00040f11, 0x0000bcde,
+};
+
+bool test_main(void) {
+  // OTBN needs entropy for the URND WSR that is used to mask the inputs.
+  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
+
+  // Load the OTBN program
+  dif_otbn_t otbn;
+  CHECK_DIF_OK(dif_otbn_init_from_dt(kTestOtbn, &otbn));
+  CHECK_STATUS_OK(otbn_testutils_load_app(&otbn, kAppMaiTest));
+
+  // Load the inputs into DMEM.
+  CHECK_STATUS_OK(otbn_testutils_write_data(&otbn, sizeof(kSecretInput),
+                                            kSecretInput, kSecret));
+  CHECK_STATUS_OK(otbn_testutils_write_data(&otbn, sizeof(kOperandAInput),
+                                            kOperandAInput, kOperandA));
+  CHECK_STATUS_OK(otbn_testutils_write_data(&otbn, sizeof(kOperandBInput),
+                                            kOperandBInput, kOperandB));
+
+  // Run the program and wait for it to finish without errors.
+  CHECK_STATUS_OK(otbn_testutils_execute(&otbn));
+  CHECK_STATUS_OK(otbn_testutils_wait_for_done(&otbn, kDifOtbnErrBitsNoError));
+
+  // Read the results out of OTBN DMEM and compare them against the expected
+  // values.
+  uint32_t result[8];
+  CHECK_STATUS_OK(
+      otbn_testutils_read_data(&otbn, sizeof(result), kResult, result));
+  CHECK_ARRAYS_EQ(result, kExpectedResult, ARRAYSIZE(result));
+
+  uint32_t result_secadd[8];
+  CHECK_STATUS_OK(otbn_testutils_read_data(&otbn, sizeof(result_secadd),
+                                           kResultSecAdd, result_secadd));
+  CHECK_ARRAYS_EQ(result_secadd, kExpectedSecAdd, ARRAYSIZE(result_secadd));
+
+  return true;
+}

--- a/sw/otbn/mai/BUILD
+++ b/sw/otbn/mai/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:otbn.bzl", "otbn_sim_test")
+load("//rules:otbn.bzl", "otbn_binary", "otbn_sim_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -12,4 +12,12 @@ otbn_sim_test(
         "mai_test.s",
     ],
     testcase = "mai_test.hjson",
+)
+
+# Same program as a linkable binary, for use as a top-level test (otbn_mai_test).
+otbn_binary(
+    name = "mai_tlt_test",
+    srcs = [
+        "mai_test.s",
+    ],
 )

--- a/sw/otbn/mai/mai_test.hjson
+++ b/sw/otbn/mai/mai_test.hjson
@@ -4,17 +4,20 @@
 {
   "entrypoint": "main",
   "input": {
-    "regs": {
-      # w31 is zero
-      "w31": "0x0",
+    "dmem": {
       # The secrets in 32-bit elements. Each element is < q = 8380417 = 2^23 - 2^13 + 1
-      "w0": "0x004b0797007325a8003f3539006704890028b454007b496800165e680003a981",
+      "secret": "0x004b0797007325a8003f3539006704890028b454007b496800165e680003a981",
+      # The two operands for secAdd, in 32-bit elements. Each element is < q.
+      "operand_a": "0x0000abcd00040506000102030040000000300000002000000010000000000001",
+      "operand_b": "0x0000111100000a0b000101010001000000040000000800000010000000000002",
     }
   }
   "output": {
-    "regs": {
-      # The secrets should be returned unchanged
-      "w24": "0x004b0797007325a8003f3539006704890028b454007b496800165e680003a981",
+    "dmem": {
+      # The secret should be returned unchanged by the B2A/A2B round trip.
+      "result": "0x004b0797007325a8003f3539006704890028b454007b496800165e680003a981",
+      # The per-element sums produced by secAdd (mod 2^32).
+      "result_secadd": "0x0000bcde00040f11000203040041000000340000002800000020000000000003",
     }
   }
 }

--- a/sw/otbn/mai/mai_test.s
+++ b/sw/otbn/mai/mai_test.s
@@ -3,82 +3,183 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /**
- * A simple program showcasing how to use the MAI and testing it by
- * performing a B2A conversion followed by an A2B conversion.
+ * A simple program showcasing how to use the MAI and testing its operations.
+ *
+ * Each operation is tested separately in its own subroutine:
+ *   - B2A followed by A2B, which must return the secret unchanged.
+ *   - secAdd, a Boolean-masked addition of two operands.
  */
 .global main
 
 .text
 
 main:
-  /* Load modulus */
+  bn.xor w31, w31, w31
+
+  /* Load the modulus used by the MAI operations. */
   li x2, 30
   la x3, mod32
   bn.lid x2, 0(x3)
   bn.wsrw MOD, w30
 
-  /* Optional: Dump the initial state to the trace */
-  csrrs x4, MAI_CTRL, x0
-  csrrs x3, MAI_STATUS, x0
+  jal x1, _test_b2a_a2b
+  jal x1, _test_secadd
 
-  /* Add boolean mask to the secret in w0 */
-  bn.wsrr w2, URND
-  bn.xor w1, w0, w2
-
-  /* Write shares to input WSRs */
-  bn.wsrw MAI_IN0_S0, w1
-  bn.wsrw MAI_IN0_S1, w2
-
-  /* Optional: Check if MAI is ready - Bit 1 must be set */
-  csrrs x3, MAI_STATUS, x0
-  andi x3, x3, 0x2
-  beq x3, x0, _mai_error
-
-  /* Start A2B conversion by writing the operation and the start bit */
-  li x10, 0x21
-  csrrs x3, MAI_STATUS, x0  /* Optional: Just to populate the trace */
-  csrrw x0, MAI_CTRL, x10
-
-  /* Poll busy bit */
-  jal x1, _poll_busy
-
-  /* Read arithmetically masked results from output WSRs */
-  bn.wsrr w20, MAI_RES_S0
-  bn.wsrr w21, MAI_RES_S1
-
-  /* Convert them back to boolean masked domain */
-  bn.wsrw MAI_IN0_s1, w20
-  bn.wsrw MAI_IN0_s0, w21
-
-  /* Start B2A conversion by writing the start bit */
-  li x10, 0x17
-  csrrw x0, MAI_CTRL, x10
-
-  jal x1, _poll_busy
-
-  /* Read results from output WSRs */
-  bn.wsrr w22, MAI_RES_S0
-  bn.wsrr w23, MAI_RES_S1
-
-  /* Unmask the secret */
-  bn.xor w24, w22, w23
+  /* TODO: add secAddMod test */
 
   ecall
 
+/**
+ * Tests the B2A and A2B conversions.
+ *
+ * Boolean-masks the secrets in DMEM, converts it to the arithmetically masked
+ * domain and back, then stores the unmasked secrets to `result`. On
+ * success the stored value equals the original secrets.
+ */
+_test_b2a_a2b:
+  /* Load the secret to be converted from DMEM into w0. */
+  li x2, 0
+  la x3, secret
+  bn.lid x2, 0(x3)
+
+  /* Add a Boolean mask to the secrets. */
+  bn.wsrr w2, URND
+  bn.xor w1, w0, w2
+
+  /* Write the Boolean masked shares to the WSRs. */
+  bn.wsrw MAI_IN0_S0, w1
+  bn.wsrw MAI_IN0_S1, w2
+
+  /* Start the B2A conversion. */
+  jal x1, _poll_ready
+  li x10, 0x21
+  csrrw x0, MAI_CTRL, x10
+  jal x1, _poll_busy
+
+  /* Retrieve the arithmetically-masked shares. */
+  bn.wsrr w20, MAI_RES_S0
+  bn.wsrr w21, MAI_RES_S1
+
+  /* Start the A2B conversion. */
+  bn.wsrw MAI_IN0_S0, w20
+  bn.wsrw MAI_IN0_S1, w21
+
+  jal x1, _poll_ready
+  li x10, 0x17
+  csrrw x0, MAI_CTRL, x10
+  jal x1, _poll_busy
+
+  /* Read the Boolean masked shares and unmask the secret. */
+  bn.wsrr w22, MAI_RES_S0
+  bn.wsrr w23, MAI_RES_S1
+  bn.xor w24, w22, w23
+
+  /* Store the recovered secret. */
+  li x2, 24
+  la x3, result
+  bn.sid x2, 0(x3)
+  ret
+
+/**
+ * Tests the secAdd operation.
+ *
+ * Loads two operands from DMEM, masks them Boolean, computes their arithmetic sum, and stores the
+ * unmasked sum to `result_secadd`.
+ */
+_test_secadd:
+  li x2, 0
+  la x3, operand_a
+  bn.lid x2, 0(x3)            /* w0 = x */
+  li x2, 3
+  la x3, operand_b
+  bn.lid x2, 0(x3)            /* w3 = y */
+
+  li x10, 0x2f               /* CTRL: secAdd + start */
+
+  /* Add a Boolean mask to both operands: (x ^ r, r) and (y ^ s, s). */
+  bn.wsrr w4, URND
+  bn.xor w5, w0, w4
+  bn.wsrr w6, URND
+  bn.xor w7, w3, w6
+
+  /* Write the masked shares to the IN0 and IN1 WSRs. */
+  bn.wsrw MAI_IN0_S0, w5
+  bn.wsrw MAI_IN0_S1, w4
+  bn.wsrw MAI_IN1_S0, w7
+  bn.wsrw MAI_IN1_S1, w6
+
+  /* Start the operation and wait for it to complete. */
+  jal x1, _poll_ready
+  csrrw x0, MAI_CTRL, x10
+  jal x1, _poll_busy
+
+  /* Read the result shares and unmask the result. */
+  bn.wsrr w8, MAI_RES_S0
+  bn.wsrr w9, MAI_RES_S1
+  bn.xor w10, w8, w9
+
+  /* Store the unmasked result. */
+  la x11, result_secadd
+  li x2, 10
+  bn.sid x2, 0(x11)
+
+  ret
+
+/**
+ * Polls the MAI_STATUS busy bit until the MAI is no longer busy.
+ * Clobbers: x2
+ */
 _poll_busy:
   csrrs x2, MAI_STATUS, x0
   andi x2, x2, 0x1
   bne x2, x0, _poll_busy
   ret
 
-_mai_error:
-  unimp
+/**
+ * Polls the MAI_STATUS ready bit until the MAI is ready for inputs.
+ * Clobbers: x2
+ */
+_poll_ready:
+  csrrs x2, MAI_STATUS, x0
+  andi x2, x2, 0x2
+  beq x2, x0, _poll_ready
+  ret
 
 .section .data
+
+/* The secret to be converted by the B2A/A2B test. */
+.balign 32
+.globl secret
+secret:
+  .zero 32
+
+/* The two operands added by the secAdd and secAddMod tests. */
+.balign 32
+.globl operand_a
+operand_a:
+  .zero 32
+
+.balign 32
+.globl operand_b
+operand_b:
+  .zero 32
+
+/* The recovered secret of the B2A/A2B test. */
+.balign 32
+.globl result
+result:
+  .zero 32
+
+/* The unmasked sum produced by the secAdd test. */
+.balign 32
+.globl result_secadd
+result_secadd:
+  .zero 32
 
 /*
   mod32 = 8380417
 */
+.balign 32
 mod32:
   .word 0x007fe001
   .word 0x00000000


### PR DESCRIPTION
This extends the MAI test with the corresponding top level C test. It also extends the test with the secAdd operation.