### PR TITLE
[crypto] Fix usage of launder32()

### DIFF
--- a/sw/device/lib/crypto/drivers/keymgr.c
+++ b/sw/device/lib/crypto/drivers/keymgr.c
@@ -100,18 +100,16 @@ static status_t keymgr_wait_until_done(void) {
   // be possible.
   // The `IDLE` status is left unhandled because the keymgr should never be
   // idle after an operation has been started by the caller.
-  switch (status) {
+  switch (launder32(status)) {
     case KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS:
-      HARDENED_CHECK_EQ(launder32(status),
-                        KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+      HARDENED_CHECK_EQ(status, KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
       return OTCRYPTO_OK;
     case KEYMGR_OP_STATUS_STATUS_VALUE_DONE_ERROR: {
       // Clear the ERR_CODE register before returning.
       uint32_t err_code =
           abs_mmio_read32(kBaseAddr + KEYMGR_ERR_CODE_REG_OFFSET);
       abs_mmio_write32(kBaseAddr + KEYMGR_ERR_CODE_REG_OFFSET, err_code);
-      HARDENED_CHECK_EQ(launder32(status),
-                        KEYMGR_OP_STATUS_STATUS_VALUE_DONE_ERROR);
+      HARDENED_CHECK_EQ(status, KEYMGR_OP_STATUS_STATUS_VALUE_DONE_ERROR);
       return OTCRYPTO_RECOV_ERR;
     }
   }

--- a/sw/device/lib/crypto/drivers/rv_core_ibex.c
+++ b/sw/device/lib/crypto/drivers/rv_core_ibex.c
@@ -73,18 +73,18 @@ status_t ibex_disable_icache(hardened_bool_t *icache_enabled) {
   // Check if the instruction cache is already disabled.
   uint32_t csr;
   CSR_READ(CSR_REG_CPUCTRL, &csr);
-  if ((csr & kCpuctrlICacheMask) == 1) {
+  if (launder32(csr & kCpuctrlICacheMask) == 1) {
     *icache_enabled = kHardenedBoolTrue;
   } else {
     *icache_enabled = kHardenedBoolFalse;
-    HARDENED_CHECK_EQ(launder32((csr & kCpuctrlICacheMask)), 0);
+    HARDENED_CHECK_EQ(csr & kCpuctrlICacheMask, 0);
   }
 
   // If the instruction cache is enabled, disable it.
-  if (*icache_enabled == kHardenedBoolTrue) {
+  if (launder32(*icache_enabled) == kHardenedBoolTrue) {
     CSR_CLEAR_BITS(CSR_REG_CPUCTRL, kCpuctrlICacheMask);
   } else {
-    HARDENED_CHECK_EQ(launder32(*icache_enabled), kHardenedBoolFalse);
+    HARDENED_CHECK_EQ(*icache_enabled, kHardenedBoolFalse);
   }
 
   return LAUNDERED_OTCRYPTO_OK;

--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -372,16 +372,16 @@ static otcrypto_status_t otcrypto_aes_impl(
   // Construct the IV and check its length. ECB mode will ignore the IV, so in
   // this case it is left uninitialized.
   aes_block_t aes_iv;
-  if (aes_mode == kAesCipherModeEcb) {
-    HARDENED_CHECK_EQ(launder32(aes_mode), kAesCipherModeEcb);
+  if (launder32(aes_mode) == kAesCipherModeEcb) {
+    HARDENED_CHECK_EQ(aes_mode, kAesCipherModeEcb);
   } else {
     HARDENED_CHECK_NE(launder32(aes_mode), kAesCipherModeEcb);
 
     // The IV must be exactly one block long.
-    if (iv->len != kAesBlockNumWords) {
+    if (launder32(iv->len) != kAesBlockNumWords) {
       return OTCRYPTO_BAD_ARGS;
     }
-    HARDENED_CHECK_EQ(launder32(iv->len), kAesBlockNumWords);
+    HARDENED_CHECK_EQ(iv->len, kAesBlockNumWords);
     HARDENED_TRY(hardened_memcpy(aes_iv.data, iv->data, kAesBlockNumWords));
   }
 

--- a/sw/device/lib/crypto/impl/ecc_curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc_curve25519.c
@@ -83,17 +83,16 @@ static status_t curve25519_private_key_length_check(
                     kHardenedBoolTrue);
 
   // Check the unmasked length.
-  if (private_key->config.key_length != kCurve25519KeyBytes) {
+  if (launder32(private_key->config.key_length) != kCurve25519KeyBytes) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(private_key->config.key_length),
-                    kCurve25519KeyBytes);
+  HARDENED_CHECK_EQ(private_key->config.key_length, kCurve25519KeyBytes);
 
   // Check the key mode.
-  if (private_key->config.key_mode != expected_mode) {
+  if (launder32(private_key->config.key_mode) != expected_mode) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode), expected_mode);
+  HARDENED_CHECK_EQ(private_key->config.key_mode, expected_mode);
 
   // Check the integrity of the key.
   if (otcrypto_integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
@@ -127,10 +126,10 @@ static status_t curve25519_public_key_length_check(
 #endif
   // Check the key struct and key length.
   if (key->key_length != kCurve25519KeyBytes ||
-      key->key_mode != expected_mode) {
+      launder32(key->key_mode) != expected_mode) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(key->key_mode), expected_mode);
+  HARDENED_CHECK_EQ(key->key_mode, expected_mode);
 
   // Check the integrity of the key.
   if (otcrypto_integrity_unblinded_key_check(key) != kHardenedBoolTrue) {
@@ -162,10 +161,11 @@ static status_t ed25519_signature_check(otcrypto_word32_buf_t *signature) {
 #endif
   // Check the signature struct and signature length.
   if (signature->len > UINT32_MAX / sizeof(uint32_t) ||
-      signature->len * sizeof(uint32_t) != sizeof(curve25519_signature_t)) {
+      launder32(signature->len) * sizeof(uint32_t) !=
+          sizeof(curve25519_signature_t)) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(signature->len) * sizeof(uint32_t),
+  HARDENED_CHECK_EQ(signature->len * sizeof(uint32_t),
                     sizeof(curve25519_signature_t));
 
   // Verify the input buffer
@@ -749,9 +749,8 @@ otcrypto_status_t otcrypto_x25519_keygen_async_start(
   HARDENED_TRY(
       curve25519_private_key_length_check(private_key, kOtcryptoKeyModeX25519));
 
-  if (private_key->config.hw_backed == kHardenedBoolTrue) {
-    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                      kHardenedBoolTrue);
+  if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
 
     HARDENED_TRY(keyblob_sideload_key_otbn(private_key));
 
@@ -790,9 +789,8 @@ otcrypto_status_t otcrypto_x25519_async_start(
   HARDENED_TRY(
       curve25519_public_key_length_check(public_key, kOtcryptoKeyModeX25519));
 
-  if (private_key->config.hw_backed == kHardenedBoolTrue) {
-    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                      kHardenedBoolTrue);
+  if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
 
     HARDENED_TRY(keyblob_sideload_key_otbn(private_key));
 

--- a/sw/device/lib/crypto/impl/ecc_p256.c
+++ b/sw/device/lib/crypto/impl/ecc_p256.c
@@ -79,17 +79,17 @@ OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p256_private_key_length_check(
                     kHardenedBoolTrue);
 
   // Check the unmasked length.
-  if (private_key->config.key_length != kP256ScalarBytes) {
+  if (launder32(private_key->config.key_length) != kP256ScalarBytes) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(private_key->config.key_length),
-                    kP256ScalarBytes);
+  HARDENED_CHECK_EQ(private_key->config.key_length, kP256ScalarBytes);
 
   // Check the keyblob length.
-  if (private_key->keyblob_length != kP256MaskedScalarTotalShareBytes) {
+  if (launder32(private_key->keyblob_length) !=
+      kP256MaskedScalarTotalShareBytes) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(private_key->keyblob_length),
+  HARDENED_CHECK_EQ(private_key->keyblob_length,
                     kP256MaskedScalarTotalShareBytes);
 
   return OTCRYPTO_OK;
@@ -110,10 +110,10 @@ OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p256_private_key_length_check(
  */
 OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p256_public_key_length_check(
     const otcrypto_unblinded_key_t *public_key) {
-  if (public_key->key_length != sizeof(p256_point_t)) {
+  if (launder32(public_key->key_length) != sizeof(p256_point_t)) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(public_key->key_length), sizeof(p256_point_t));
+  HARDENED_CHECK_EQ(public_key->key_length, sizeof(p256_point_t));
   return OTCRYPTO_OK;
 }
 
@@ -141,13 +141,11 @@ OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t internal_p256_keygen_finalize(
   // The `finalize` call should be the last potentially error-causing line
   // before returning to the caller.
 
-  if (private_key->config.hw_backed == kHardenedBoolTrue) {
-    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                      kHardenedBoolTrue);
+  if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
     HARDENED_TRY(p256_sideload_keygen_finalize(pk));
-  } else if (private_key->config.hw_backed == kHardenedBoolFalse) {
-    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                      kHardenedBoolFalse);
+  } else if (launder32(private_key->config.hw_backed) == kHardenedBoolFalse) {
+    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
 
     // Randomize the keyblob before writing secret data.
     HARDENED_TRY(hardened_memshred(private_key->keyblob,
@@ -190,11 +188,10 @@ OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t internal_p256_keygen_finalize(
 OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p256_signature_length_check(
     size_t len) {
   if (len > UINT32_MAX / sizeof(uint32_t) ||
-      len * sizeof(uint32_t) != sizeof(p256_ecdsa_signature_t)) {
+      launder32(len) * sizeof(uint32_t) != sizeof(p256_ecdsa_signature_t)) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(len) * sizeof(uint32_t),
-                    sizeof(p256_ecdsa_signature_t));
+  HARDENED_CHECK_EQ(len * sizeof(uint32_t), sizeof(p256_ecdsa_signature_t));
 
   return OTCRYPTO_OK;
 }
@@ -212,14 +209,12 @@ OT_NOINLINE
 OT_WARN_UNUSED_RESULT
 static status_t internal_p256_keygen_start(
     const otcrypto_blinded_key_t *private_key) {
-  if (private_key->config.hw_backed == kHardenedBoolTrue) {
-    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                      kHardenedBoolTrue);
+  if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
     HARDENED_TRY(keyblob_sideload_key_otbn(private_key));
     return otcrypto_eval_exit(p256_sideload_keygen_start());
-  } else if (private_key->config.hw_backed == kHardenedBoolFalse) {
-    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                      kHardenedBoolFalse);
+  } else if (launder32(private_key->config.hw_backed) == kHardenedBoolFalse) {
+    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
     return otcrypto_eval_exit(p256_keygen_start());
   }
   return OTCRYPTO_BAD_ARGS;
@@ -255,16 +250,15 @@ static otcrypto_status_t otcrypto_ecdsa_p256_sign_async_start_setup(
       launder32(otcrypto_integrity_blinded_key_check(private_key)),
       kHardenedBoolTrue);
 
-  if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP256) {
+  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdsaP256) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
-                    kOtcryptoKeyModeEcdsaP256);
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdsaP256);
 
-  if (message_digest.len != kP256ScalarWords) {
+  if (launder32(message_digest.len) != kP256ScalarWords) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(message_digest.len), kP256ScalarWords);
+  HARDENED_CHECK_EQ(message_digest.len, kP256ScalarWords);
 
   HARDENED_TRY(p256_private_key_length_check(private_key));
 
@@ -419,11 +413,10 @@ otcrypto_status_t otcrypto_ecdsa_p256_keygen_async_start(
 #endif
 
   // Check the key mode.
-  if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP256) {
+  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdsaP256) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
-                    kOtcryptoKeyModeEcdsaP256);
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdsaP256);
 
   HARDENED_TRY_WIPE_DMEM(internal_p256_keygen_start(private_key));
 
@@ -441,13 +434,12 @@ otcrypto_status_t otcrypto_ecdsa_p256_keygen_async_finalize(
 #endif
 
   // Check the key modes.
-  if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP256 ||
-      public_key->key_mode != kOtcryptoKeyModeEcdsaP256) {
+  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdsaP256 ||
+      launder32(public_key->key_mode) != kOtcryptoKeyModeEcdsaP256) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
-                    kOtcryptoKeyModeEcdsaP256);
-  HARDENED_CHECK_EQ(launder32(public_key->key_mode), kOtcryptoKeyModeEcdsaP256);
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdsaP256);
+  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdsaP256);
 
   HARDENED_TRY_WIPE_DMEM(
       internal_p256_keygen_finalize(private_key, public_key));
@@ -465,11 +457,10 @@ otcrypto_status_t otcrypto_ecdsa_p256_dice_keygen_async_start(
 #endif
 
   // Check the key mode.
-  if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP256) {
+  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdsaP256) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
-                    kOtcryptoKeyModeEcdsaP256);
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdsaP256);
 
   HARDENED_TRY(load_attestation_diversification(private_key));
   HARDENED_TRY_WIPE_DMEM(
@@ -527,20 +518,18 @@ otcrypto_status_t otcrypto_ecdsa_p256_sign_async_start(
       otcrypto_ecdsa_p256_sign_async_start_setup(private_key, message_digest));
 
   // Load the secret key d.
-  if (private_key->config.hw_backed == kHardenedBoolFalse) {
+  if (launder32(private_key->config.hw_backed) == kHardenedBoolFalse) {
     // Start the asynchronous signature-generation routine.
-    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                      kHardenedBoolFalse);
+    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
     p256_masked_scalar_t private_scalar;
     HARDENED_TRY(load_private_scalar(private_key, &private_scalar));
     HARDENED_TRY_WIPE_DMEM(
         p256_ecdsa_sign_start(message_digest.data, &private_scalar));
     hardened_memshred((uint32_t *)&private_scalar,
                       kP256MaskedScalarTotalShareWords);
-  } else if (private_key->config.hw_backed == kHardenedBoolTrue) {
+  } else if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
     // Load the key and start in sideloaded-key mode.
-    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                      kHardenedBoolTrue);
+    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
     HARDENED_TRY_WIPE_DMEM(keyblob_sideload_key_otbn(private_key));
     HARDENED_TRY_WIPE_DMEM(p256_ecdsa_sideload_sign_start(message_digest.data));
   } else {
@@ -592,17 +581,16 @@ otcrypto_status_t otcrypto_ecdsa_p256_dice_sign_async_start(
 #endif
 
   // Check the key mode.
-  if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP256) {
+  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdsaP256) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
-                    kOtcryptoKeyModeEcdsaP256);
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdsaP256);
 
   // Check the digest length.
-  if (message_digest.len != kP256ScalarWords) {
+  if (launder32(message_digest.len) != kP256ScalarWords) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(message_digest.len), kP256ScalarWords);
+  HARDENED_CHECK_EQ(message_digest.len, kP256ScalarWords);
 
   keymgr_diversification_t diversification;
   HARDENED_TRY(keyblob_to_keymgr_attestation_diversification(private_key,
@@ -640,20 +628,20 @@ otcrypto_status_t otcrypto_ecdsa_p256_verify_async_start(
       kHardenedBoolTrue);
 
   // Check the public key mode.
-  if (public_key->key_mode != kOtcryptoKeyModeEcdsaP256) {
+  if (launder32(public_key->key_mode) != kOtcryptoKeyModeEcdsaP256) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(public_key->key_mode), kOtcryptoKeyModeEcdsaP256);
+  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdsaP256);
 
   // Check the public key size.
   HARDENED_TRY(p256_public_key_length_check(public_key));
   p256_point_t *pk = (p256_point_t *)public_key->key;
 
   // Check the digest length.
-  if (message_digest.len != kP256ScalarWords) {
+  if (launder32(message_digest.len) != kP256ScalarWords) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(message_digest.len), kP256ScalarWords);
+  HARDENED_CHECK_EQ(message_digest.len, kP256ScalarWords);
 
   // Check the signature lengths.
   HARDENED_TRY(p256_signature_length_check(signature->len));
@@ -697,11 +685,10 @@ otcrypto_status_t otcrypto_ecdh_p256_keygen_async_start(
   }
 #endif
 
-  if (private_key->config.key_mode != kOtcryptoKeyModeEcdhP256) {
+  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdhP256) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
-                    kOtcryptoKeyModeEcdhP256);
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdhP256);
 
   HARDENED_TRY_WIPE_DMEM(internal_p256_keygen_start(private_key));
 
@@ -718,13 +705,12 @@ otcrypto_status_t otcrypto_ecdh_p256_keygen_async_finalize(
   }
 #endif
 
-  if (public_key->key_mode != kOtcryptoKeyModeEcdhP256 ||
-      private_key->config.key_mode != kOtcryptoKeyModeEcdhP256) {
+  if (launder32(public_key->key_mode) != kOtcryptoKeyModeEcdhP256 ||
+      launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdhP256) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(public_key->key_mode), kOtcryptoKeyModeEcdhP256);
-  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
-                    kOtcryptoKeyModeEcdhP256);
+  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdhP256);
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdhP256);
   HARDENED_TRY_WIPE_DMEM(
       internal_p256_keygen_finalize(private_key, public_key));
   return otcrypto_eval_exit(OTCRYPTO_OK);
@@ -753,27 +739,24 @@ otcrypto_status_t otcrypto_ecdh_p256_async_start(
       kHardenedBoolTrue);
 
   // Check the key modes.
-  if (private_key->config.key_mode != kOtcryptoKeyModeEcdhP256 ||
-      public_key->key_mode != kOtcryptoKeyModeEcdhP256) {
+  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdhP256 ||
+      launder32(public_key->key_mode) != kOtcryptoKeyModeEcdhP256) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
-                    kOtcryptoKeyModeEcdhP256);
-  HARDENED_CHECK_EQ(launder32(public_key->key_mode), kOtcryptoKeyModeEcdhP256);
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdhP256);
+  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdhP256);
 
   // Check the key lengths.
   HARDENED_TRY(p256_private_key_length_check(private_key));
   HARDENED_TRY(p256_public_key_length_check(public_key));
   p256_point_t *pk = (p256_point_t *)public_key->key;
 
-  if (private_key->config.hw_backed == kHardenedBoolTrue) {
-    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                      kHardenedBoolTrue);
+  if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
     HARDENED_TRY_WIPE_DMEM(keyblob_sideload_key_otbn(private_key));
     HARDENED_TRY_WIPE_DMEM(p256_sideload_ecdh_start(pk));
-  } else if (private_key->config.hw_backed == kHardenedBoolFalse) {
-    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                      kHardenedBoolFalse);
+  } else if (launder32(private_key->config.hw_backed) == kHardenedBoolFalse) {
+    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
     p256_masked_scalar_t private_scalar;
     HARDENED_TRY(load_private_scalar(private_key, &private_scalar));
     HARDENED_TRY_WIPE_DMEM(p256_ecdh_start(&private_scalar, pk));
@@ -815,17 +798,16 @@ otcrypto_status_t otcrypto_ecdh_p256_async_finalize(
                     kHardenedBoolFalse);
 
   // Check shared secret length.
-  if (shared_secret->config.key_length != kP256CoordBytes) {
+  if (launder32(shared_secret->config.key_length) != kP256CoordBytes) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(shared_secret->config.key_length),
-                    kP256CoordBytes);
-  if (shared_secret->keyblob_length !=
+  HARDENED_CHECK_EQ(shared_secret->config.key_length, kP256CoordBytes);
+  if (launder32(shared_secret->keyblob_length) !=
       keyblob_num_words(shared_secret->config) * sizeof(uint32_t)) {
     return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_CHECK_EQ(
-      launder32(shared_secret->keyblob_length),
+      shared_secret->keyblob_length,
       keyblob_num_words(shared_secret->config) * sizeof(uint32_t));
 
   // Note: This operation wipes DMEM after retrieving the keys, so if an error
@@ -858,11 +840,12 @@ otcrypto_status_t otcrypto_ecc_p256_public_key_import(
 #endif
 
   // Check the lengths of the input coordinate buffers.
-  if (x.len != kP256CoordWords || y.len != kP256CoordWords) {
+  if (launder32(x.len) != kP256CoordWords ||
+      launder32(y.len) != kP256CoordWords) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(x.len), kP256CoordWords);
-  HARDENED_CHECK_EQ(launder32(y.len), kP256CoordWords);
+  HARDENED_CHECK_EQ(x.len, kP256CoordWords);
+  HARDENED_CHECK_EQ(y.len, kP256CoordWords);
 
   // Check the output key mode; both ECDSA and ECDH P-256 public key modes are
   // accepted since the underlying point representation is the same.
@@ -896,11 +879,12 @@ otcrypto_status_t otcrypto_ecc_p256_public_key_export(
 #endif
 
   // Check the lengths of the output coordinate buffers.
-  if (x->len != kP256CoordWords || y->len != kP256CoordWords) {
+  if (launder32(x->len) != kP256CoordWords ||
+      launder32(y->len) != kP256CoordWords) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(x->len), kP256CoordWords);
-  HARDENED_CHECK_EQ(launder32(y->len), kP256CoordWords);
+  HARDENED_CHECK_EQ(x->len, kP256CoordWords);
+  HARDENED_CHECK_EQ(y->len, kP256CoordWords);
 
   // Check the output key mode; both ECDSA and ECDH P-256 public key modes are
   // accepted since the underlying point representation is the same.
@@ -937,12 +921,12 @@ otcrypto_status_t otcrypto_ecc_p256_private_key_import(
 
   // Each share must be 320 bits (256-bit scalar + 64 redundant bits for
   // side-channel protection).
-  if (share0.len != kP256MaskedScalarShareWords ||
-      share1.len != kP256MaskedScalarShareWords) {
+  if (launder32(share0.len) != kP256MaskedScalarShareWords ||
+      launder32(share1.len) != kP256MaskedScalarShareWords) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(share0.len), kP256MaskedScalarShareWords);
-  HARDENED_CHECK_EQ(launder32(share1.len), kP256MaskedScalarShareWords);
+  HARDENED_CHECK_EQ(share0.len, kP256MaskedScalarShareWords);
+  HARDENED_CHECK_EQ(share1.len, kP256MaskedScalarShareWords);
 
   // Check the key mode; both ECDSA and ECDH P-256 modes are accepted since
   // the private key representation is identical for both.
@@ -952,11 +936,10 @@ otcrypto_status_t otcrypto_ecc_p256_private_key_import(
   }
 
   // Import is only supported for software-backed keys.
-  if (private_key->config.hw_backed != kHardenedBoolFalse) {
+  if (launder32(private_key->config.hw_backed) != kHardenedBoolFalse) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                    kHardenedBoolFalse);
+  HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
 
   // Check that the caller-allocated keyblob matches the expected P-256 layout.
   HARDENED_TRY(p256_private_key_length_check(private_key));
@@ -992,12 +975,12 @@ otcrypto_status_t otcrypto_ecc_p256_private_key_export(
 
   // Check the output buffer lengths: each must be exactly 320 bits (256-bit
   // scalar + 64 redundant bits for side-channel protection).
-  if (share0->len != kP256MaskedScalarShareWords ||
-      share1->len != kP256MaskedScalarShareWords) {
+  if (launder32(share0->len) != kP256MaskedScalarShareWords ||
+      launder32(share1->len) != kP256MaskedScalarShareWords) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(share0->len), kP256MaskedScalarShareWords);
-  HARDENED_CHECK_EQ(launder32(share1->len), kP256MaskedScalarShareWords);
+  HARDENED_CHECK_EQ(share0->len, kP256MaskedScalarShareWords);
+  HARDENED_CHECK_EQ(share1->len, kP256MaskedScalarShareWords);
 
   // Check the key mode; both ECDSA and ECDH P-256 modes are accepted since
   // the private key representation is identical for both.
@@ -1007,11 +990,10 @@ otcrypto_status_t otcrypto_ecc_p256_private_key_export(
   }
 
   // Export is only supported for software-backed keys.
-  if (private_key->config.hw_backed != kHardenedBoolFalse) {
+  if (launder32(private_key->config.hw_backed) != kHardenedBoolFalse) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                    kHardenedBoolFalse);
+  HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
 
   // Check that the key is marked exportable.
   if (launder32(private_key->config.exportable) != kHardenedBoolTrue) {
@@ -1053,14 +1035,12 @@ otcrypto_status_t otcrypto_ecc_p256_arith_share_private_key(
 #endif
 
   // The key shares must resided in 320-bit buffers.
-  if (bool_private_key_share0->len != kP256MaskedScalarShareWords ||
-      bool_private_key_share1->len != kP256MaskedScalarShareWords) {
+  if (launder32(bool_private_key_share0->len) != kP256MaskedScalarShareWords ||
+      launder32(bool_private_key_share1->len) != kP256MaskedScalarShareWords) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(bool_private_key_share0->len),
-                    kP256MaskedScalarShareWords);
-  HARDENED_CHECK_EQ(launder32(bool_private_key_share1->len),
-                    kP256MaskedScalarShareWords);
+  HARDENED_CHECK_EQ(bool_private_key_share0->len, kP256MaskedScalarShareWords);
+  HARDENED_CHECK_EQ(bool_private_key_share1->len, kP256MaskedScalarShareWords);
 
   // Check the key mode; both ECDSA and ECDH P-256 modes are accepted since
   // the private key representation is identical for both.
@@ -1070,11 +1050,10 @@ otcrypto_status_t otcrypto_ecc_p256_arith_share_private_key(
   }
 
   // Import is only supported for software-backed keys.
-  if (arith_private_key->config.hw_backed != kHardenedBoolFalse) {
+  if (launder32(arith_private_key->config.hw_backed) != kHardenedBoolFalse) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(arith_private_key->config.hw_backed),
-                    kHardenedBoolFalse);
+  HARDENED_CHECK_EQ(arith_private_key->config.hw_backed, kHardenedBoolFalse);
 
   // Check that the caller-allocated keyblob matches the expected P-256 layout.
   HARDENED_TRY(p256_private_key_length_check(arith_private_key));

--- a/sw/device/lib/crypto/impl/ecc_p384.c
+++ b/sw/device/lib/crypto/impl/ecc_p384.c
@@ -26,14 +26,12 @@
  */
 OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t internal_p384_keygen_start(
     const otcrypto_blinded_key_t *private_key) {
-  if (private_key->config.hw_backed == kHardenedBoolTrue) {
-    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                      kHardenedBoolTrue);
+  if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
     HARDENED_TRY(keyblob_sideload_key_otbn(private_key));
     return p384_sideload_keygen_start();
-  } else if (private_key->config.hw_backed == kHardenedBoolFalse) {
-    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                      kHardenedBoolFalse);
+  } else if (launder32(private_key->config.hw_backed) == kHardenedBoolFalse) {
+    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
     return p384_keygen_start();
   } else {
     return OTCRYPTO_BAD_ARGS;
@@ -61,11 +59,10 @@ otcrypto_status_t otcrypto_ecdsa_p384_keygen_async_start(
 #endif
 
   // Check the key mode.
-  if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP384) {
+  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdsaP384) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
-                    kOtcryptoKeyModeEcdsaP384);
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdsaP384);
 
   HARDENED_TRY_WIPE_DMEM(internal_p384_keygen_start(private_key));
   return otcrypto_eval_exit(OTCRYPTO_OK);
@@ -101,17 +98,17 @@ OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p384_private_key_length_check(
                     kHardenedBoolTrue);
 
   // Check the unmasked length.
-  if (private_key->config.key_length != kP384ScalarBytes) {
+  if (launder32(private_key->config.key_length) != kP384ScalarBytes) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(private_key->config.key_length),
-                    kP384ScalarBytes);
+  HARDENED_CHECK_EQ(private_key->config.key_length, kP384ScalarBytes);
 
   // Check the keyblob length.
-  if (private_key->keyblob_length != kP384MaskedScalarTotalShareBytes) {
+  if (launder32(private_key->keyblob_length) !=
+      kP384MaskedScalarTotalShareBytes) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(private_key->keyblob_length),
+  HARDENED_CHECK_EQ(private_key->keyblob_length,
                     kP384MaskedScalarTotalShareBytes);
 
   return OTCRYPTO_OK;
@@ -132,10 +129,10 @@ OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p384_private_key_length_check(
  */
 OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p384_public_key_length_check(
     const otcrypto_unblinded_key_t *public_key) {
-  if (public_key->key_length != sizeof(p384_point_t)) {
+  if (launder32(public_key->key_length) != sizeof(p384_point_t)) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(public_key->key_length), sizeof(p384_point_t));
+  HARDENED_CHECK_EQ(public_key->key_length, sizeof(p384_point_t));
   return OTCRYPTO_OK;
 }
 
@@ -160,17 +157,15 @@ OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t internal_p384_keygen_finalize(
   // Interpret the key buffer as a P-384 point.
   p384_point_t *pk = (p384_point_t *)public_key->key;
 
-  if (private_key->config.hw_backed == kHardenedBoolTrue) {
+  if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
     // Note: This operation wipes DMEM after retrieving the keys, so if an error
     // occurs after this point then the keys would be unrecoverable. This should
     // be the last potentially error-causing line before returning to the
     // caller.
-    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                      kHardenedBoolTrue);
+    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
     HARDENED_TRY(p384_sideload_keygen_finalize(pk));
-  } else if (private_key->config.hw_backed == kHardenedBoolFalse) {
-    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                      kHardenedBoolFalse);
+  } else if (launder32(private_key->config.hw_backed) == kHardenedBoolFalse) {
+    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
 
     // Randomize the keyblob before writing secret data.
     HARDENED_TRY(hardened_memshred(private_key->keyblob,
@@ -213,11 +208,10 @@ OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t internal_p384_keygen_finalize(
 OT_NOINLINE OT_WARN_UNUSED_RESULT static status_t p384_signature_length_check(
     size_t len) {
   if (len > UINT32_MAX / sizeof(uint32_t) ||
-      len * sizeof(uint32_t) != sizeof(p384_ecdsa_signature_t)) {
+      launder32(len) * sizeof(uint32_t) != sizeof(p384_ecdsa_signature_t)) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(len) * sizeof(uint32_t),
-                    sizeof(p384_ecdsa_signature_t));
+  HARDENED_CHECK_EQ(len * sizeof(uint32_t), sizeof(p384_ecdsa_signature_t));
 
   return OTCRYPTO_OK;
 }
@@ -343,13 +337,12 @@ otcrypto_status_t otcrypto_ecdsa_p384_keygen_async_finalize(
 #endif
 
   // Check the key modes.
-  if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP384 ||
-      public_key->key_mode != kOtcryptoKeyModeEcdsaP384) {
+  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdsaP384 ||
+      launder32(public_key->key_mode) != kOtcryptoKeyModeEcdsaP384) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
-                    kOtcryptoKeyModeEcdsaP384);
-  HARDENED_CHECK_EQ(launder32(public_key->key_mode), kOtcryptoKeyModeEcdsaP384);
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdsaP384);
+  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdsaP384);
 
   HARDENED_TRY_WIPE_DMEM(
       internal_p384_keygen_finalize(private_key, public_key));
@@ -376,17 +369,16 @@ OT_NOINLINE static otcrypto_status_t otcrypto_ecdsa_p384_sign_async_start_setup(
       launder32(otcrypto_integrity_blinded_key_check(private_key)),
       kHardenedBoolTrue);
 
-  if (private_key->config.key_mode != kOtcryptoKeyModeEcdsaP384) {
+  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdsaP384) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
-                    kOtcryptoKeyModeEcdsaP384);
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdsaP384);
 
   // Check the digest length.
-  if (message_digest.len != kP384ScalarWords) {
+  if (launder32(message_digest.len) != kP384ScalarWords) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(message_digest.len), kP384ScalarWords);
+  HARDENED_CHECK_EQ(message_digest.len, kP384ScalarWords);
 
   // Check the key length.
   HARDENED_TRY(p384_private_key_length_check(private_key));
@@ -441,10 +433,9 @@ otcrypto_status_t otcrypto_ecdsa_p384_sign_async_start(
       otcrypto_ecdsa_p384_sign_async_start_setup(private_key, message_digest));
 
   // Load the secret key d.
-  if (private_key->config.hw_backed == kHardenedBoolFalse) {
+  if (launder32(private_key->config.hw_backed) == kHardenedBoolFalse) {
     // Start the asynchronous signature-generation routine.
-    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                      kHardenedBoolFalse);
+    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
     p384_masked_scalar_t private_scalar;
     HARDENED_TRY(load_private_scalar(private_key, &private_scalar));
     HARDENED_TRY_WIPE_DMEM(
@@ -452,10 +443,9 @@ otcrypto_status_t otcrypto_ecdsa_p384_sign_async_start(
 
     hardened_memshred((uint32_t *)&private_scalar,
                       kP384MaskedScalarTotalShareWords);
-  } else if (private_key->config.hw_backed == kHardenedBoolTrue) {
+  } else if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
     // Load the key and start in sideloaded-key mode.
-    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                      kHardenedBoolTrue);
+    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
     HARDENED_TRY_WIPE_DMEM(keyblob_sideload_key_otbn(private_key));
     HARDENED_TRY_WIPE_DMEM(p384_ecdsa_sideload_sign_start(message_digest.data));
   } else {
@@ -515,20 +505,20 @@ otcrypto_status_t otcrypto_ecdsa_p384_verify_async_start(
       kHardenedBoolTrue);
 
   // Check the public key mode.
-  if (public_key->key_mode != kOtcryptoKeyModeEcdsaP384) {
+  if (launder32(public_key->key_mode) != kOtcryptoKeyModeEcdsaP384) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(public_key->key_mode), kOtcryptoKeyModeEcdsaP384);
+  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdsaP384);
 
   // Check the public key size.
   HARDENED_TRY(p384_public_key_length_check(public_key));
   p384_point_t *pk = (p384_point_t *)public_key->key;
 
   // Check the digest length.
-  if (message_digest.len != kP384ScalarWords) {
+  if (launder32(message_digest.len) != kP384ScalarWords) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(message_digest.len), kP384ScalarWords);
+  HARDENED_CHECK_EQ(message_digest.len, kP384ScalarWords);
 
   // Check the signature lengths.
   HARDENED_TRY(p384_signature_length_check(signature->len));
@@ -575,11 +565,10 @@ otcrypto_status_t otcrypto_ecdh_p384_keygen_async_start(
   }
 #endif
 
-  if (private_key->config.key_mode != kOtcryptoKeyModeEcdhP384) {
+  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdhP384) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
-                    kOtcryptoKeyModeEcdhP384);
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdhP384);
   HARDENED_TRY_WIPE_DMEM(internal_p384_keygen_start(private_key));
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }
@@ -594,13 +583,12 @@ otcrypto_status_t otcrypto_ecdh_p384_keygen_async_finalize(
   }
 #endif
 
-  if (public_key->key_mode != kOtcryptoKeyModeEcdhP384 ||
-      private_key->config.key_mode != kOtcryptoKeyModeEcdhP384) {
+  if (launder32(public_key->key_mode) != kOtcryptoKeyModeEcdhP384 ||
+      launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdhP384) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(public_key->key_mode), kOtcryptoKeyModeEcdhP384);
-  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
-                    kOtcryptoKeyModeEcdhP384);
+  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdhP384);
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdhP384);
   HARDENED_TRY_WIPE_DMEM(
       internal_p384_keygen_finalize(private_key, public_key));
   return otcrypto_eval_exit(OTCRYPTO_OK);
@@ -629,27 +617,24 @@ otcrypto_status_t otcrypto_ecdh_p384_async_start(
       kHardenedBoolTrue);
 
   // Check the key modes.
-  if (private_key->config.key_mode != kOtcryptoKeyModeEcdhP384 ||
-      public_key->key_mode != kOtcryptoKeyModeEcdhP384) {
+  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdhP384 ||
+      launder32(public_key->key_mode) != kOtcryptoKeyModeEcdhP384) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(private_key->config.key_mode),
-                    kOtcryptoKeyModeEcdhP384);
-  HARDENED_CHECK_EQ(launder32(public_key->key_mode), kOtcryptoKeyModeEcdhP384);
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdhP384);
+  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdhP384);
 
   // Check the key lengths.
   HARDENED_TRY(p384_private_key_length_check(private_key));
   HARDENED_TRY(p384_public_key_length_check(public_key));
   p384_point_t *pk = (p384_point_t *)public_key->key;
 
-  if (private_key->config.hw_backed == kHardenedBoolTrue) {
-    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                      kHardenedBoolTrue);
+  if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
     HARDENED_TRY_WIPE_DMEM(keyblob_sideload_key_otbn(private_key));
     HARDENED_TRY_WIPE_DMEM(p384_sideload_ecdh_start(pk));
-  } else if (private_key->config.hw_backed == kHardenedBoolFalse) {
-    HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                      kHardenedBoolFalse);
+  } else if (launder32(private_key->config.hw_backed) == kHardenedBoolFalse) {
+    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
     p384_masked_scalar_t private_scalar;
     HARDENED_TRY(load_private_scalar(private_key, &private_scalar));
     HARDENED_TRY_WIPE_DMEM(p384_ecdh_start(&private_scalar, pk));
@@ -684,19 +669,17 @@ otcrypto_status_t otcrypto_ecdh_p384_async_finalize(
   HARDENED_TRY(hardened_memshred(shared_secret->keyblob, kP384CoordWords));
 
   // Shared keys cannot be sideloaded because they are software-generated.
-  if (shared_secret->config.hw_backed != kHardenedBoolFalse) {
+  if (launder32(shared_secret->config.hw_backed) != kHardenedBoolFalse) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(shared_secret->config.hw_backed),
-                    kHardenedBoolFalse);
+  HARDENED_CHECK_EQ(shared_secret->config.hw_backed, kHardenedBoolFalse);
 
   // Check shared secret length.
-  if (shared_secret->config.key_length != kP384CoordBytes) {
+  if (launder32(shared_secret->config.key_length) != kP384CoordBytes) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(shared_secret->config.key_length),
-                    kP384CoordBytes);
-  if (shared_secret->keyblob_length !=
+  HARDENED_CHECK_EQ(shared_secret->config.key_length, kP384CoordBytes);
+  if (launder32(shared_secret->keyblob_length) !=
       keyblob_num_words(shared_secret->config) * sizeof(uint32_t)) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -734,11 +717,12 @@ otcrypto_status_t otcrypto_ecc_p384_public_key_import(
 #endif
 
   // Check the lengths of the input coordinate buffers.
-  if (x.len != kP384CoordWords || y.len != kP384CoordWords) {
+  if (launder32(x.len) != kP384CoordWords ||
+      launder32(y.len) != kP384CoordWords) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(x.len), kP384CoordWords);
-  HARDENED_CHECK_EQ(launder32(y.len), kP384CoordWords);
+  HARDENED_CHECK_EQ(x.len, kP384CoordWords);
+  HARDENED_CHECK_EQ(y.len, kP384CoordWords);
 
   // Check the output key mode; both ECDSA and ECDH P-384 public key modes are
   // accepted since the underlying point representation is the same.
@@ -772,11 +756,12 @@ otcrypto_status_t otcrypto_ecc_p384_public_key_export(
 #endif
 
   // Check the lengths of the output coordinate buffers.
-  if (x->len != kP384CoordWords || y->len != kP384CoordWords) {
+  if (launder32(x->len) != kP384CoordWords ||
+      launder32(y->len) != kP384CoordWords) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(x->len), kP384CoordWords);
-  HARDENED_CHECK_EQ(launder32(y->len), kP384CoordWords);
+  HARDENED_CHECK_EQ(x->len, kP384CoordWords);
+  HARDENED_CHECK_EQ(y->len, kP384CoordWords);
 
   // Check the output key mode; both ECDSA and ECDH P-384 public key modes are
   // accepted since the underlying point representation is the same.
@@ -813,12 +798,12 @@ otcrypto_status_t otcrypto_ecc_p384_private_key_import(
 
   // Each share must be 448 bits (384-bit scalar + 64 redundant bits for
   // side-channel protection).
-  if (share0.len != kP384MaskedScalarShareWords ||
-      share1.len != kP384MaskedScalarShareWords) {
+  if (launder32(share0.len) != kP384MaskedScalarShareWords ||
+      launder32(share1.len) != kP384MaskedScalarShareWords) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(share0.len), kP384MaskedScalarShareWords);
-  HARDENED_CHECK_EQ(launder32(share1.len), kP384MaskedScalarShareWords);
+  HARDENED_CHECK_EQ(share0.len, kP384MaskedScalarShareWords);
+  HARDENED_CHECK_EQ(share1.len, kP384MaskedScalarShareWords);
 
   // Check the key mode; both ECDSA and ECDH P-384 modes are accepted since
   // the private key representation is identical for both.
@@ -828,11 +813,10 @@ otcrypto_status_t otcrypto_ecc_p384_private_key_import(
   }
 
   // Import is only supported for software-backed keys.
-  if (private_key->config.hw_backed != kHardenedBoolFalse) {
+  if (launder32(private_key->config.hw_backed) != kHardenedBoolFalse) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                    kHardenedBoolFalse);
+  HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
 
   // Check that the caller-allocated keyblob matches the expected P-384 layout.
   HARDENED_TRY(p384_private_key_length_check(private_key));
@@ -868,12 +852,12 @@ otcrypto_status_t otcrypto_ecc_p384_private_key_export(
 
   // Check the output buffer lengths: each must be exactly 448 bits (384-bit
   // scalar + 64 redundant bits for side-channel protection).
-  if (share0->len != kP384MaskedScalarShareWords ||
-      share1->len != kP384MaskedScalarShareWords) {
+  if (launder32(share0->len) != kP384MaskedScalarShareWords ||
+      launder32(share1->len) != kP384MaskedScalarShareWords) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(share0->len), kP384MaskedScalarShareWords);
-  HARDENED_CHECK_EQ(launder32(share1->len), kP384MaskedScalarShareWords);
+  HARDENED_CHECK_EQ(share0->len, kP384MaskedScalarShareWords);
+  HARDENED_CHECK_EQ(share1->len, kP384MaskedScalarShareWords);
 
   // Check the key mode; both ECDSA and ECDH P-384 modes are accepted since
   // the private key representation is identical for both.
@@ -883,11 +867,10 @@ otcrypto_status_t otcrypto_ecc_p384_private_key_export(
   }
 
   // Export is only supported for software-backed keys.
-  if (private_key->config.hw_backed != kHardenedBoolFalse) {
+  if (launder32(private_key->config.hw_backed) != kHardenedBoolFalse) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(private_key->config.hw_backed),
-                    kHardenedBoolFalse);
+  HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
 
   // Check that the key is marked exportable.
   if (launder32(private_key->config.exportable) != kHardenedBoolTrue) {
@@ -929,14 +912,12 @@ otcrypto_status_t otcrypto_ecc_p384_arith_share_private_key(
 #endif
 
   // The key shares must resided in 448-bit buffers.
-  if (bool_private_key_share0->len != kP384MaskedScalarShareWords ||
-      bool_private_key_share1->len != kP384MaskedScalarShareWords) {
+  if (launder32(bool_private_key_share0->len) != kP384MaskedScalarShareWords ||
+      launder32(bool_private_key_share1->len) != kP384MaskedScalarShareWords) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(bool_private_key_share0->len),
-                    kP384MaskedScalarShareWords);
-  HARDENED_CHECK_EQ(launder32(bool_private_key_share1->len),
-                    kP384MaskedScalarShareWords);
+  HARDENED_CHECK_EQ(bool_private_key_share0->len, kP384MaskedScalarShareWords);
+  HARDENED_CHECK_EQ(bool_private_key_share1->len, kP384MaskedScalarShareWords);
 
   // Check the key mode; both ECDSA and ECDH P-384 modes are accepted since
   // the private key representation is identical for both.
@@ -946,11 +927,10 @@ otcrypto_status_t otcrypto_ecc_p384_arith_share_private_key(
   }
 
   // Import is only supported for software-backed keys.
-  if (arith_private_key->config.hw_backed != kHardenedBoolFalse) {
+  if (launder32(arith_private_key->config.hw_backed) != kHardenedBoolFalse) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(launder32(arith_private_key->config.hw_backed),
-                    kHardenedBoolFalse);
+  HARDENED_CHECK_EQ(arith_private_key->config.hw_backed, kHardenedBoolFalse);
 
   // Check that the caller-allocated keyblob matches the expected P-384 layout.
   HARDENED_TRY(p384_private_key_length_check(arith_private_key));

--- a/sw/device/lib/crypto/impl/hmac.c
+++ b/sw/device/lib/crypto/impl/hmac.c
@@ -244,16 +244,16 @@ otcrypto_status_t otcrypto_hmac(const otcrypto_blinded_key_t *key,
   hmac_key_t hmac_key;
   HARDENED_TRY(hmac_key_construct(key, block_words, &hmac_key));
 
-  if (key->config.security_level == kOtcryptoKeySecurityLevelLow) {
+  if (launder32(key->config.security_level) == kOtcryptoKeySecurityLevelLow) {
     // No protection against FI.
-    HARDENED_CHECK_EQ(launder32(key->config.security_level),
-                      kOtcryptoKeySecurityLevelLow);
+    HARDENED_CHECK_EQ(key->config.security_level, kOtcryptoKeySecurityLevelLow);
     return otcrypto_eval_exit(cl_fn(&hmac_key, input_message, tag));
-  } else if (key->config.security_level == kOtcryptoKeySecurityLevelMedium) {
+  } else if (launder32(key->config.security_level) ==
+             kOtcryptoKeySecurityLevelMedium) {
     // Call the HMAC core twice and compare both tags. This serves as a FI
     // countermeasure.
     // First HMAC computation using the HMAC core.
-    HARDENED_CHECK_EQ(launder32(key->config.security_level),
+    HARDENED_CHECK_EQ(key->config.security_level,
                       kOtcryptoKeySecurityLevelMedium);
     HARDENED_TRY(cl_fn(&hmac_key, input_message, tag));
     // Second HMAC computation using the HMAC core.

--- a/sw/device/lib/crypto/impl/rsa/run_rsa.c
+++ b/sw/device/lib/crypto/impl/rsa/run_rsa.c
@@ -161,12 +161,12 @@ static status_t rsa_modexp_finalize(const size_t num_words, uint32_t *result) {
   HARDENED_TRY(rsa_modexp_wait(&num_words_inferred));
 
   // Check that the inferred result size matches expectations.
-  if (num_words != num_words_inferred) {
+  if (launder32(num_words) != num_words_inferred) {
     // COVERAGE (SW ERR) This is an internal functions only provided with
     // correct inputs.
     return OTCRYPTO_FATAL_ERR;
   }
-  HARDENED_CHECK_EQ(launder32(num_words), num_words_inferred);
+  HARDENED_CHECK_EQ(num_words, num_words_inferred);
 
   HARDENED_TRY(rsa_check_otbn_status());
 
@@ -239,10 +239,10 @@ static status_t keygen_finalize(uint32_t exp_mode, size_t num_words,
   uint32_t act_mode = 0;
   const otbn_addr_t kOtbnVarRsaMode = OTBN_ADDR_T_INIT(run_rsa, mode);
   HARDENED_TRY(otbn_dmem_read(1, kOtbnVarRsaMode, &act_mode));
-  if (act_mode != exp_mode) {
+  if (launder32(act_mode) != exp_mode) {
     return OTCRYPTO_RECOV_ERR;
   }
-  HARDENED_CHECK_EQ(launder32(act_mode), exp_mode);
+  HARDENED_CHECK_EQ(act_mode, exp_mode);
 
   // Make sure that an exact amount of Miller-Rabin iterations have been
   // performed for both primes p and q.
@@ -251,23 +251,23 @@ static status_t keygen_finalize(uint32_t exp_mode, size_t num_words,
   // Prime p.
   const otbn_addr_t kOtbnVarRsaMrIterP = OTBN_ADDR_T_INIT(run_rsa, mr_iter_p);
   HARDENED_TRY(otbn_dmem_read(1, kOtbnVarRsaMrIterP, &mr_iters));
-  if (mr_iters != kMrIters) {
+  if (launder32(mr_iters) != kMrIters) {
     // COVERAGE (FI CM) The number of iterations can only deviate if there was a
     // fault injection or fatal error.
     return OTCRYPTO_FATAL_ERR;
   }
-  HARDENED_CHECK_EQ(launder32(mr_iters), kMrIters);
+  HARDENED_CHECK_EQ(mr_iters, kMrIters);
 
   // Prime q.
   mr_iters = 0;
   const otbn_addr_t kOtbnVarRsaMrIterQ = OTBN_ADDR_T_INIT(run_rsa, mr_iter_q);
   HARDENED_TRY(otbn_dmem_read(1, kOtbnVarRsaMrIterQ, &mr_iters));
-  if (mr_iters != kMrIters) {
+  if (launder32(mr_iters) != kMrIters) {
     // COVERAGE (FI CM) The number of iterations can only deviate if there was a
     // fault injection or fatal error.
     return OTCRYPTO_FATAL_ERR;
   }
-  HARDENED_CHECK_EQ(launder32(mr_iters), kMrIters);
+  HARDENED_CHECK_EQ(mr_iters, kMrIters);
 
   // Read the public modulus (n) from OTBN dmem.
   const otbn_addr_t kOtbnVarRsaN = OTBN_ADDR_T_INIT(run_rsa, rsa_n);

--- a/sw/device/lib/crypto/impl/rsa/run_rsa_key_from_cofactor.c
+++ b/sw/device/lib/crypto/impl/rsa/run_rsa_key_from_cofactor.c
@@ -153,10 +153,10 @@ status_t rsa_keygen_from_cofactor_finalize(rsa_size_t size,
       OTBN_ADDR_T_INIT(run_rsa_key_from_cofactor, mode);
   HARDENED_TRY_WIPE_DMEM(
       otbn_dmem_read(kOtbnRsaModeWords, kOtbnVarRsaMode, &act_mode));
-  if (act_mode != exp_mode) {
+  if (launder32(act_mode) != exp_mode) {
     return OTCRYPTO_RECOV_ERR;
   }
-  HARDENED_CHECK_EQ(launder32(act_mode), exp_mode);
+  HARDENED_CHECK_EQ(act_mode, exp_mode);
 
   // Read the public modulus (n) from OTBN dmem.
   const otbn_addr_t kOtbnVarRsaN =

--- a/sw/device/tests/penetrationtests/firmware/firmware_gdb.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware_gdb.c
@@ -224,9 +224,9 @@ status_t handle_gdb_if_test(ujson_t *uj) {
   pentest_set_trigger_high();
 
   // Cases best use magic values.
-  if (if_check == kHardenedBoolFalse) {
+  if (launder32(if_check) == kHardenedBoolFalse) {
     // In an if loop, check the case again via a HARDENED_CHECK_EQ.
-    HARDENED_CHECK_EQ(launder32(if_check), kHardenedBoolTrue);
+    HARDENED_CHECK_EQ(if_check, kHardenedBoolTrue);
     // The desired state for the attacker.
     uj_output.result = false;
   }


### PR DESCRIPTION
launder32() is an optimization barrier. In the cryptolib it is used such that a redundant check after a guard (e.g. HARDENED_CHECK_EQ) actually re-reads the live value. If the guard is a bare comparison, the compiler already knows the value equals the constant, so the redundant check just compares the constant against itself and always passes.

This commit applies launder32() to the operand in the guard condition and not in the check. This hides the value from the compiler, so the redundant check has to reload it and compare the actual value and not the immedate placed by the compiler.

An example is:
https://github.com/lowRISC/opentitan/blob/06d6ee5dee59e31a89333961aded6a172258013a/sw/device/lib/crypto/impl/ecc_p256.c#L82-L85
**Before this PR:**
<img width="1483" height="559" alt="Screenshot From 2026-06-29 18-12-36" src="https://github.com/user-attachments/assets/f697fcc6-e4e5-4cab-a863-22a38dd37f73" />
The beq at `20012c56` checks a3 and a2 - both of these values are set to an immediate (32). If we would skip the branch we want to protect (20012c4e), the check just compares the two immediates and not the actual value. So this redundant check does not provide any protection.
**After this PR:**
<img width="1939" height="442" alt="Screenshot From 2026-06-30 09-16-41" src="https://github.com/user-attachments/assets/c06fc2c4-9f5e-47ae-b3a5-732fb1d5b0bc" />

Now, the actual redundant check at 20012c5e compares the actual value (stored in a3) to the immediate stored in a2. If we skip the initial branch (20012c58), the comparison is again conducted.