### PR TITLE
[lint] Waive errors and warnings flagged by more recent tool versions

### DIFF
--- a/hw/ip/kmac/lint/sha3.waiver
+++ b/hw/ip/kmac/lint/sha3.waiver
@@ -22,6 +22,9 @@ waive -rules {ARITH_CONTEXT} -location {sha3pad.sv} -regexp {.*Bitlength of arit
 waive -rules {VAR_INDEX_RANGE} -location {keccak_2share.sv} -regexp {.*of length 32 excluding the sign bit is larger than the.*bits required to address.*} \
       -comment "Indexing range does not match."
 
+waive -rules {VAR_INDEX_RANGE} -location {keccak_2share.sv} -regexp {'index_z' minimum value -1 is too small for 'c' range '\[W - 1:0\]' \(\[63:0\]\)} \
+      -comment "index_z can only be -1 if W was 0, but we ensure that W >= 1 with an SVA."
+
 waive -rules USE_BEFORE_DECL -location {keccak_2share.sv} -msg {'bitarray_to_box' is referenced before its declaration at keccak_2share.sv} \
       -comment "bitarray_to_box is a function defined towards the end of the file."
 

--- a/hw/ip/prim/lint/prim_secded.waiver
+++ b/hw/ip/prim/lint/prim_secded.waiver
@@ -8,6 +8,8 @@ waive -rules {SAME_NAME_TYPE} -location {*} -regexp {'prim_secded_.*' is used as
       -comment "The secded functions and primitives may have the same name."
 waive -rules {SAME_NAME_TYPE} -location {*} -regexp {'prim_secded_.*' is used as a function here, and as a module at prim_secded_.*} \
       -comment "The secded functions and primitives may have the same name."
+waive -rules {TWO_STATE_TYPE} -location {*} -regexp {'prim_secded_type_e' is of two state type } \
+      -comment "prim_secded_type_e is used in constant functions that are used for generates"
 waive -rules {TWO_STATE_TYPE} -location {*} -regexp {'sd_type' is of two state type } \
       -comment "sd_type is used in constant functions that are used for generates"
 waive -rules {TWO_STATE_TYPE} -location {*} -regexp {'width' is of two state type } \

--- a/hw/ip/rv_dm/lint/rv_dm.waiver
+++ b/hw/ip/rv_dm/lint/rv_dm.waiver
@@ -91,6 +91,18 @@ waive -rules NOT_READ -location {dm_mem.sv} -regexp {Signal 'ac_ar.(regno.13.|ze
 waive -rules LOOP_VAR_OP -location {dm_mem.sv} \
       -msg {Loop variable 'dc' is in arithmetic expression 'dc < (dm::DataCount - 1)' with non-constant terms} \
       -comment "This is incorrect because all terms except the loop variable are constant in the arithmetic expression."
+waive -rules LHS_TOO_SHORT -location {dm_mem.sv} \
+      -msg {Bitlength mismatch between 'RomBaseAddr' length 12 and 'dm::HaltAddress' length 64} \
+      -comment "The DbgAddressBits parameter (12 bits) is defined as localparam in dm_mem.sv and the HaltAddress localparam is hardcoded to 'h800' in dm_pkg.sv. None of these localparams can be overwritten in OpenTitan."
+waive -rules VAR_INDEX_RANGE -location {dm_mem.sv} \
+      -regexp {'\$clog2\(dm::DataCount\)'\(\(\(addr_i\[DbgAddressBits - 1:3\] - DataBaseAddr\[DbgAddressBits - 1:3\]\).*' minimum value -.* is too small for 'data_i' range.*} \
+      -comment "The surrounding unique case statement ensures 'addr_i' is always in the range [DataBaseAddr:DataEndAddr], the resulting index is thus always positive"
+waive -rules VAR_INDEX_RANGE -location {dm_mem.sv} \
+      -regexp {'ProgBuf64AddrSize'\(addr_i\[DbgAddressBits - 1:3\] - ProgBufBaseAddr\[DbgAddressBits - 1:3\]\).*' minimum value -.* is too small for 'progbuf' range.*} \
+      -comment "The surrounding unique case statement ensures 'addr_i' is always in the range [ProgBufBaseAddr:ProgBufEndAddr], the resulting index is thus always positive"
+waive -rules VAR_INDEX_RANGE -location {dm_mem.sv} \
+      -regexp {'3'\(addr_i\[DbgAddressBits - 1:3\] - AbstractCmdBaseAddr\[DbgAddressBits - 1:3\]\).*' minimum value -.* is too small for 'abstract_cmd' range.*} \
+      -comment "The surrounding unique case statement ensures 'addr_i' is always in the range [AbstractCmdBaseAddr:AbstractCmdEndAddr], the resulting index is thus always positive"
 
 # dm_sba
 waive -rules HIER_BRANCH_NOT_READ  -location {dm_sba.sv}            -regexp {Net 'dmactive_i' is not read from in module 'dm_sba'} \

--- a/hw/top_darjeeling/lint/top_darjeeling.waiver
+++ b/hw/top_darjeeling/lint/top_darjeeling.waiver
@@ -39,7 +39,7 @@ waive -rules {CLOCK_USE} -location {pinmux.sv}  -regexp {'dio_wkup_mux\[(42|43)\
 # Since these functions / parameters / signals live in different scopes, this is acceptable, and we can waive them.
 waive -rules SAME_NAME_TYPE -location {aes_sbox_canright_pkg.sv keccak_2share.sv} -regexp {'theta' is used as a (reg|function) here, and as a (function|reg) at} \
       -comment {This is acceptable, since these are used in different hierarchies.}
-waive -rules SAME_NAME_TYPE -location {keccak_round.sv otbn_pkg.sv} -regexp {'L' is used as a (parameter|reg) here, and as a (reg|parameter) at} \
+waive -rules SAME_NAME_TYPE -location {keccak_round.sv keccak_2share.sv otbn_pkg.sv} -regexp {'L' is used as a (parameter|reg) here, and as a (reg|parameter) at} \
       -comment {This is acceptable, since these are used in different hierarchies.}
 waive -rules SAME_NAME_TYPE -location {spi_device.sv rstmgr_pkg.sv} -regexp {'spi_device' is used as a (module|reg) here, and as a (reg|module) at } \
       -comment {This is acceptable, since these are used in different hierarchies.}

--- a/hw/top_earlgrey/lint/top_earlgrey.waiver
+++ b/hw/top_earlgrey/lint/top_earlgrey.waiver
@@ -65,7 +65,7 @@ waive -rules CLOCK_USE -location {top_earlgrey.sv} -regexp {'clkmgr_aon_clocks.c
 # Since these functions / parameters / signals live in different scopes, this is acceptable, and we can waive them.
 waive -rules SAME_NAME_TYPE -location {aes_sbox_canright_pkg.sv keccak_2share.sv} -regexp {'theta' is used as a (reg|function) here, and as a (function|reg) at} \
       -comment {This is acceptable, since these are used in different hierarchies.}
-waive -rules SAME_NAME_TYPE -location {keccak_round.sv otbn_pkg.sv} -regexp {'L' is used as a (parameter|reg) here, and as a (reg|parameter) at} \
+waive -rules SAME_NAME_TYPE -location {keccak_round.sv keccak_2share.sv otbn_pkg.sv} -regexp {'L' is used as a (parameter|reg) here, and as a (reg|parameter) at} \
       -comment {This is acceptable, since these are used in different hierarchies.}
 waive -rules SAME_NAME_TYPE -location {spi_device.sv rstmgr_pkg.sv} -regexp {'spi_device' is used as a (module|reg) here, and as a (reg|module) at } \
       -comment {This is acceptable, since these are used in different hierarchies.}


### PR DESCRIPTION
This commit waives a couple of uncritical lint errors and warnings showing up in more recent versions of AscentLint.

There are some more VAR_INDEX_RANGE warnings that I think we should actually fix instead of waiving. I'll file issues for these. 