### PR TITLE
[fusesoc] Move away from `fileset_partner` to select `ast_pkg`

### DIFF
--- a/hw/ip/adc_ctrl/adc_ctrl.core
+++ b/hw/ip/adc_ctrl/adc_ctrl.core
@@ -10,8 +10,7 @@ filesets:
       - lowrisc:virtual_constants:top_pkg
       - lowrisc:prim:all
       - lowrisc:ip:tlul
-      - "fileset_partner  ? (partner:systems:ast_pkg)"
-      - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
+      - lowrisc:systems:ast_pkg
 
     files:
       - rtl/adc_ctrl_pkg.sv

--- a/hw/ip/prim_generic/prim_generic_flash.core
+++ b/hw/ip/prim_generic/prim_generic_flash.core
@@ -13,8 +13,7 @@ filesets:
     depend:
       - lowrisc:tlul:headers
       - lowrisc:prim:ram_1p
-      - "fileset_partner  ? (partner:systems:ast_pkg)"
-      - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
+      - lowrisc:systems:ast_pkg
       - lowrisc:virtual_ip:flash_ctrl_top_specific_pkg
       - lowrisc:virtual_ip:flash_ctrl_prim_reg_top
     files:

--- a/hw/ip/rram_ctrl/rram_ctrl_pkg.core
+++ b/hw/ip/rram_ctrl/rram_ctrl_pkg.core
@@ -17,8 +17,7 @@ filesets:
       - lowrisc:earlgrey_ip:pwrmgr_pkg
       - lowrisc:ip:jtag_pkg
       - lowrisc:tlul:headers
-      - "fileset_partner  ? (partner:systems:ast_pkg)"
-      - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
+      - lowrisc:systems:ast_pkg
     files:
       - rtl/rram_ctrl_reg_pkg.sv
       - rtl/rram_ctrl_pkg.sv

--- a/hw/ip_templates/flash_ctrl/flash_ctrl_top_specific_pkg.core.tpl
+++ b/hw/ip_templates/flash_ctrl/flash_ctrl_top_specific_pkg.core.tpl
@@ -18,8 +18,7 @@ filesets:
       - lowrisc:ip:edn_pkg
       - lowrisc:tlul:headers
       - lowrisc:ip:flash_ctrl_pkg
-      - "fileset_partner  ? (partner:systems:ast_pkg)"
-      - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
+      - lowrisc:systems:ast_pkg
     files:
       - rtl/flash_ctrl_reg_pkg.sv
       - rtl/flash_ctrl_top_specific_pkg.sv

--- a/hw/ip_templates/otp_ctrl/otp_ctrl.core.tpl
+++ b/hw/ip_templates/otp_ctrl/otp_ctrl.core.tpl
@@ -29,8 +29,7 @@ filesets:
       - ${instance_vlnv("lowrisc:ip:pwrmgr_pkg")}
       - lowrisc:ip:edn_pkg
       - lowrisc:prim:sparse_fsm
-      - "fileset_partner  ? (partner:systems:ast_pkg)"
-      - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
+      - lowrisc:systems:ast_pkg
     files:
       - rtl/otp_ctrl_core_reg_top.sv
       - rtl/otp_ctrl_ecc_reg.sv

--- a/hw/top_darjeeling/dv/env/chip_env.core
+++ b/hw/top_darjeeling/dv/env/chip_env.core
@@ -33,8 +33,7 @@ filesets:
       - lowrisc:darjeeling_ip:pwrmgr_pkg
       - lowrisc:dv:lc_ctrl_dv_utils
       - lowrisc:dv:top_darjeeling_chip_ral
-      - "!fileset_partner ? (lowrisc:systems:top_darjeeling_ast_pkg)"
-      - "fileset_partner ? (partner:systems:top_darjeeling_ast_pkg)"
+      - lowrisc:systems:ast_pkg
     files:
       - chip_common_pkg.sv
       - chip_if.sv

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/otp_ctrl.core
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/otp_ctrl.core
@@ -29,8 +29,7 @@ filesets:
       - lowrisc:darjeeling_ip:pwrmgr_pkg
       - lowrisc:ip:edn_pkg
       - lowrisc:prim:sparse_fsm
-      - "fileset_partner  ? (partner:systems:ast_pkg)"
-      - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
+      - lowrisc:systems:ast_pkg
     files:
       - rtl/otp_ctrl_core_reg_top.sv
       - rtl/otp_ctrl_ecc_reg.sv

--- a/hw/top_darjeeling/top_darjeeling.core
+++ b/hw/top_darjeeling/top_darjeeling.core
@@ -60,8 +60,7 @@ filesets:
       - lowrisc:prim:all
       - lowrisc:prim:mubi
       - lowrisc:systems:top_darjeeling_pkg
-      - "fileset_partner  ? (partner:systems:top_darjeeling_ast_pkg)"
-      - "!fileset_partner ? (lowrisc:systems:top_darjeeling_ast_pkg)"
+      - lowrisc:systems:ast_pkg
     files:
       - rtl/autogen/top_darjeeling_racl_pkg.sv
       - rtl/autogen/top_darjeeling.sv

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -34,8 +34,7 @@ filesets:
       - lowrisc:earlgrey_ip:pwrmgr_pkg
       - lowrisc:dv:lc_ctrl_dv_utils
       - lowrisc:dv:top_earlgrey_chip_ral
-      - "!fileset_partner ? (lowrisc:systems:top_earlgrey_ast_pkg)"
-      - "fileset_partner ? (partner:systems:top_earlgrey_ast_pkg)"
+      - lowrisc:systems:ast_pkg
     files:
       - chip_common_pkg.sv
       - chip_if.sv

--- a/hw/top_earlgrey/ip/sensor_ctrl/sensor_ctrl_pkg.core
+++ b/hw/top_earlgrey/ip/sensor_ctrl/sensor_ctrl_pkg.core
@@ -9,8 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:earlgrey_constants:top_pkg
-      - "!fileset_partner ? (lowrisc:systems:top_earlgrey_ast_pkg)"
-      - "fileset_partner ? (partner:systems:top_earlgrey_ast_pkg)"
+      - lowrisc:systems:ast_pkg
       - lowrisc:systems:top_earlgrey_sensor_ctrl_reg
     files:
       - rtl/sensor_ctrl_pkg.sv

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl_top_specific_pkg.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl_top_specific_pkg.core
@@ -18,8 +18,7 @@ filesets:
       - lowrisc:ip:edn_pkg
       - lowrisc:tlul:headers
       - lowrisc:ip:flash_ctrl_pkg
-      - "fileset_partner  ? (partner:systems:ast_pkg)"
-      - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
+      - lowrisc:systems:ast_pkg
     files:
       - rtl/flash_ctrl_reg_pkg.sv
       - rtl/flash_ctrl_top_specific_pkg.sv

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/otp_ctrl.core
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/otp_ctrl.core
@@ -29,8 +29,7 @@ filesets:
       - lowrisc:earlgrey_ip:pwrmgr_pkg
       - lowrisc:ip:edn_pkg
       - lowrisc:prim:sparse_fsm
-      - "fileset_partner  ? (partner:systems:ast_pkg)"
-      - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
+      - lowrisc:systems:ast_pkg
     files:
       - rtl/otp_ctrl_core_reg_top.sv
       - rtl/otp_ctrl_ecc_reg.sv

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -58,8 +58,7 @@ filesets:
       - lowrisc:prim:usb_diff_rx
       - lowrisc:prim:mubi
       - lowrisc:systems:top_earlgrey_pkg
-      - "fileset_partner  ? (partner:systems:top_earlgrey_ast_pkg)"
-      - "!fileset_partner ? (lowrisc:systems:top_earlgrey_ast_pkg)"
+      - lowrisc:systems:ast_pkg
       - "fileset_partner  ? (partner:ip:otp_macro)"
       - "!fileset_partner ? (lowrisc:ip:otp_macro)"
     files:

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/flash_ctrl_top_specific_pkg.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/flash_ctrl_top_specific_pkg.core
@@ -18,8 +18,7 @@ filesets:
       - lowrisc:ip:edn_pkg
       - lowrisc:tlul:headers
       - lowrisc:ip:flash_ctrl_pkg
-      - "fileset_partner  ? (partner:systems:ast_pkg)"
-      - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
+      - lowrisc:systems:ast_pkg
     files:
       - rtl/flash_ctrl_reg_pkg.sv
       - rtl/flash_ctrl_top_specific_pkg.sv


### PR DESCRIPTION
`lowrisc:systems:ast_pkg` is a FuseSoC virtual core.  In the open-source code, this virtual core is implemented by `top_earlgrey_ast_pkg` and `top_darjeeling_ast_pkg`.  Integrators can use FuseSoC's `mapping` mechanism to override it with their own implementation.  Prior to mappings, this was done with the `fileset_partner` flag.