### PR TITLE
[rom_ext,dice] Fixed sized tlv encoder

### DIFF
--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -126,6 +126,21 @@ cc_test(
 )
 
 cc_library(
+    name = "dice_storage",
+    srcs = ["dice_storage.c"],
+    hdrs = ["dice_storage.h"],
+    deps = [
+        "//hw/top_earlgrey/ip_autogen/flash_ctrl:flash_ctrl_c_regs",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:memory",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+        "//sw/device/silicon_creator/lib/drivers:hmac",
+        "//sw/device/silicon_creator/manuf/base:perso_tlv_data",
+    ],
+)
+
+cc_library(
     name = "dice_api",
     hdrs = ["dice.h"],
     deps = [

--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -163,6 +163,7 @@ cc_library(
     deps = [
         ":cert",
         ":dice_api",
+        ":dice_storage",
         ":template",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",
@@ -214,6 +215,7 @@ cc_library(
         ":cert",
         ":cwt_template",
         ":dice_api",
+        ":dice_storage",
         "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:status",
@@ -281,7 +283,7 @@ cc_library(
     srcs = ["dice_chain.c"],
     hdrs = ["dice_chain.h"],
     deps = [
-        "//hw/top_earlgrey/ip_autogen/flash_ctrl:flash_ctrl_c_regs",
+        ":dice_storage",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/crypto/drivers:entropy",
@@ -299,6 +301,5 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:keymgr",
         "//sw/device/silicon_creator/lib/drivers:kmac",
         "//sw/device/silicon_creator/lib/ownership:datatypes",
-        "//sw/device/silicon_creator/manuf/base:perso_tlv_data",
     ],
 )

--- a/sw/device/silicon_creator/lib/cert/dice.c
+++ b/sw/device/silicon_creator/lib/cert/dice.c
@@ -14,6 +14,7 @@
 #include "sw/device/silicon_creator/lib/cert/cert.h"
 #include "sw/device/silicon_creator/lib/cert/dice_chain.h"
 #include "sw/device/silicon_creator/lib/cert/dice_keys.h"
+#include "sw/device/silicon_creator/lib/cert/dice_storage.h"
 #include "sw/device/silicon_creator/lib/cert/template.h"
 #include "sw/device/silicon_creator/lib/cert/uds.h"  // Generated.
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
@@ -25,6 +26,20 @@
 #include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
 #include "sw/device/silicon_creator/manuf/base/perso_tlv_data.h"
 #include "sw/device/silicon_creator/manuf/lib/flash_info_fields.h"
+
+enum {
+  kDiceSlotSize = 936,
+};
+
+const dice_storage_slot_t kDiceStorageCdi0Ecdsa = DICE_STORAGE_SLOT(
+    "CDI_0", &kFlashCtrlInfoPageDiceCerts,
+    /*offset_val=*/0,
+    /*slot_size_val=*/kDiceSlotSize, kPersoObjectTypeX509Cert);
+
+const dice_storage_slot_t kDiceStorageCdi1Ecdsa = DICE_STORAGE_SLOT(
+    "CDI_1", &kFlashCtrlInfoPageDiceCerts,
+    /*offset_val=*/kDiceSlotSize,
+    /*slot_size_val=*/kDiceSlotSize, kPersoObjectTypeX509Cert);
 
 static ecdsa_p256_signature_t curr_tbs_signature = {.r = {0}, .s = {0}};
 
@@ -257,8 +272,7 @@ rom_error_t dice_attest_cdi_1(const manifest_t *owner_manifest,
                               owner_app_domain_t key_domain) {
   HARDENED_RETURN_IF_ERROR(dice_chain_init());
   HARDENED_RETURN_IF_ERROR(dice_chain_rom_ext_check());
-  HARDENED_RETURN_IF_ERROR(dice_chain_attestation_owner(
-      owner_manifest, bl0_measurement, owner_measurement, owner_history_hash,
-      sealing_binding, key_domain));
-  return dice_chain_flush_flash();
+  return dice_chain_attestation_owner(owner_manifest, bl0_measurement,
+                                      owner_measurement, owner_history_hash,
+                                      sealing_binding, key_domain);
 }

--- a/sw/device/silicon_creator/lib/cert/dice_chain.c
+++ b/sw/device/silicon_creator/lib/cert/dice_chain.c
@@ -4,6 +4,10 @@
 
 #include "sw/device/silicon_creator/lib/cert/dice_chain.h"
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
@@ -13,6 +17,7 @@
 #include "sw/device/silicon_creator/lib/base/static_dice_cdi_0.h"
 #include "sw/device/silicon_creator/lib/base/util.h"
 #include "sw/device/silicon_creator/lib/cert/dice.h"
+#include "sw/device/silicon_creator/lib/cert/dice_storage.h"
 #include "sw/device/silicon_creator/lib/dbg_print.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/kmac.h"
@@ -20,256 +25,12 @@
 #include "sw/device/silicon_creator/lib/manifest.h"
 #include "sw/device/silicon_creator/lib/otbn_boot_services.h"
 #include "sw/device/silicon_creator/lib/ownership/datatypes.h"
-#include "sw/device/silicon_creator/manuf/base/perso_tlv_data.h"
+static dice_storage_page_t dice_page;
 
-#include "flash_ctrl_regs.h"  // Generated.
-
-enum {
-  kFlashPageSize = FLASH_CTRL_PARAM_BYTES_PER_PAGE,
-};
-
-/**
- * Defines a class for parsing and building the DICE cert chain.
- *
- * All of the fields in this struct should be considered private, and users
- * should call the public `dice_chain_*` functions instead.
- */
-typedef struct dice_chain {
-  /**
-   * RAM buffer that mirrors the DICE cert chain in a flash page.
-   */
-  dice_page_t page;
-
-  /**
-   * Indicate whether `page` needs to be written back to flash.
-   */
-  hardened_bool_t data_dirty;
-
-  /**
-   * The amount of bytes in `page.data` that has been processed.
-   */
-  size_t tail_offset;
-
-  /**
-   * Indicate the info page currently buffered in `page`.
-   * This is used to skip unnecessary read ops.
-   */
-  const flash_ctrl_info_page_t *info_page;
-
-  /**
-   * Id pair which points to the endorsement and cert ids below.
-   */
-  cert_key_id_pair_t key_ids;
-
-  /**
-   * Public key id for signing endorsement cert.
-   */
-  hmac_digest_t endorsement_pubkey_id;
-
-  /**
-   * Subject public key id of the current cert.
-   */
-  hmac_digest_t subject_pubkey_id;
-
-  /**
-   * Subject public key contents of the current cert.
-   */
-  ecdsa_p256_public_key_t subject_pubkey;
-
-  /**
-   * Scratch buffer for constructing CDI certs.
-   */
-  uint8_t scratch_cert[kDicePageDataSize];
-
-  /**
-   * The current tlv cert the builder is processing.
-   */
-  perso_tlv_cert_obj_t cert_obj;
-
-  /**
-   * Indicate whether the `cert_obj` is valid for the current `subject_pubkey`.
-   */
-  hardened_bool_t cert_valid;
-
-} dice_chain_t;
-
-static dice_chain_t dice_chain;
-
-cert_key_id_pair_t dice_chain_cdi_0_key_ids = (cert_key_id_pair_t){
+static cert_key_id_pair_t dice_chain_cdi_0_key_ids = (cert_key_id_pair_t){
     .endorsement = &static_dice_cdi_0.uds_pubkey_id,
     .cert = &static_dice_cdi_0.cdi_0_pubkey_id,
 };
-
-// Get the size of the remaining tail space that is not processed yet.
-OT_WARN_UNUSED_RESULT
-OT_NOINLINE
-static size_t dice_chain_get_tail_size(void) {
-  HARDENED_CHECK_GE(sizeof(dice_chain.page.data), dice_chain.tail_offset);
-  return sizeof(dice_chain.page.data) - dice_chain.tail_offset;
-}
-
-// Get the pointer to the remaining tail space that is not processed yet.
-OT_WARN_UNUSED_RESULT
-static uint8_t *dice_chain_get_tail_buffer(void) {
-  return &dice_chain.page.data[dice_chain.tail_offset];
-}
-
-// Cleanup stale `cert_obj` data and mark it as invalid.
-static void dice_chain_reset_cert_obj(void) {
-  memset(&dice_chain.cert_obj, 0, sizeof(dice_chain.cert_obj));
-  dice_chain.cert_valid = kHardenedBoolFalse;
-}
-
-/**
- * Increments the DICE cert buffer offset to the next TLV object.
- * (ensuring to round up to the 64-bit flash word offset to prevent potential
- * ECC issues).
- */
-static void dice_chain_next_cert_obj(void) {
-  // Round up to next flash word for next perso TLV object offset.
-  size_t cert_size = dice_chain.cert_obj.obj_size;
-
-  // The cert_size is only 12-bit, which won't cause unsigned overflow.
-  cert_size = util_size_to_words(cert_size) * sizeof(uint32_t);
-  cert_size = util_round_up_to(cert_size, 3);
-
-  // Jump to the next object.
-  dice_chain.tail_offset += cert_size;
-
-  // Post-check for the buffer boundary.
-  HARDENED_CHECK_LE(dice_chain.tail_offset, sizeof(dice_chain.page.data));
-
-  dice_chain_reset_cert_obj();
-}
-
-/**
- * Load the tlv cert obj from the tail buffer and check if it's valid.
- *
- * This method will update the `dice_chain` fields of current certificate:
- *   * `cert_obj` will be all zeros if not TLV cert entry is found.
- *   * `cert_valid` will only be set to true if name and pubkey matches.
- *
- * @param name The cert name to match.
- * @param name_size Size in byte of the `name` argument. Caller has to ensure it
- * is smaller than kCrthNameSizeFieldMask.
- * @return errors encountered during the operation.
- */
-OT_WARN_UNUSED_RESULT
-static rom_error_t dice_chain_load_cert_obj(const char *name,
-                                            size_t name_size) {
-  rom_error_t err =
-      perso_tlv_get_cert_obj(dice_chain_get_tail_buffer(),
-                             dice_chain_get_tail_size(), &dice_chain.cert_obj);
-
-  if (err != kErrorOk) {
-    // Cleanup the stale value if error.
-    dice_chain_reset_cert_obj();
-
-    // If the cert is not found or corrupted, continue and allow the ROM_EXT
-    // to generate an identity certificate for the current DICE stage. The
-    // error is not fatal, and the cert obj has been marked as invalid.
-    return kErrorOk;
-  }
-
-  // Check if this cert is what we are looking for. The name and type (X.509 vs
-  // CWT) should match.
-  const perso_tlv_object_type_t kExpectedCertType =
-      kDiceCertFormat == kDiceCertFormatX509TcbInfo ? kPersoObjectTypeX509Cert
-                                                    : kPersoObjectTypeCwtCert;
-  if (name == NULL || memcmp(dice_chain.cert_obj.name, name, name_size) != 0 ||
-      kExpectedCertType != dice_chain.cert_obj.obj_type) {
-    // Name unmatched, keep the cert_obj but mark it as invalid.
-    dice_chain.cert_valid = kHardenedBoolFalse;
-    return kErrorOk;
-  }
-
-  // Check if the subject pubkey is matched. `cert_valid` will be set to false
-  // if unmatched.
-  RETURN_IF_ERROR(dice_cert_check_valid(
-      &dice_chain.cert_obj, &dice_chain.subject_pubkey_id,
-      &dice_chain.subject_pubkey, &dice_chain.cert_valid));
-
-  return kErrorOk;
-}
-
-// Skip the TLV entry if the name matches.
-static rom_error_t dice_chain_skip_cert_obj(const char *name,
-                                            size_t name_size) {
-  RETURN_IF_ERROR(dice_chain_load_cert_obj(NULL, 0));
-  if (memcmp(dice_chain.cert_obj.name, name, name_size) == 0) {
-    dice_chain_next_cert_obj();
-  }
-  return kErrorOk;
-}
-
-// Load the certificate data from flash to RAM buffer.
-OT_WARN_UNUSED_RESULT
-static rom_error_t dice_chain_load_flash(
-    const flash_ctrl_info_page_t *info_page) {
-  // Skip reload if it's already buffered.
-  if (dice_chain.info_page == info_page) {
-    dice_chain.tail_offset = 0;
-    return kErrorOk;
-  }
-
-  // We are switching to a different page, flush changes (if dirty) first.
-  RETURN_IF_ERROR(dice_chain_flush_flash());
-
-  // Read in a DICE certificate(s) page.
-  static_assert(sizeof(dice_chain.page) == kFlashPageSize,
-                "Invalid dice_chain buffer size");
-  RETURN_IF_ERROR(flash_ctrl_info_read_zeros_on_read_error(
-      info_page, /*offset=*/0,
-      /*word_count=*/kFlashPageSize / sizeof(uint32_t), &dice_chain.page));
-
-  // Resets the flash page status.
-  dice_chain.data_dirty = kHardenedBoolFalse;
-  dice_chain.tail_offset = 0;
-  dice_chain.info_page = info_page;
-  dice_chain_reset_cert_obj();
-
-  return kErrorOk;
-}
-
-// Add the hash digest to the last of the page.
-static rom_error_t dice_chain_seal_page(void) {
-  // Hash the entire page before the digest.
-  hmac_sha256(&dice_chain.page,
-              sizeof(dice_chain.page) - sizeof(dice_chain.page.digest),
-              &dice_chain.page.digest);
-
-  // The page is going to be updated.
-  dice_chain.data_dirty = kHardenedBoolTrue;
-
-  return kErrorOk;
-}
-
-// Push the certificate to the tail with TLV header.
-OT_WARN_UNUSED_RESULT
-static rom_error_t dice_chain_push_cert(const char *name, const uint8_t *cert,
-                                        const size_t cert_size) {
-  // The data is going to be updated, mark it as dirty and clear the tail.
-  dice_chain.data_dirty = kHardenedBoolTrue;
-
-  // Invalidate all the remaining certificates in the tail buffer.
-  memset(dice_chain_get_tail_buffer(), 0, dice_chain_get_tail_size());
-
-  // Encode the certificate to the tail buffer.
-  size_t cert_page_left = dice_chain_get_tail_size();
-  perso_tlv_object_type_t cert_type =
-      kDiceCertFormat == kDiceCertFormatX509TcbInfo ? kPersoObjectTypeX509Cert
-                                                    : kPersoObjectTypeCwtCert;
-  RETURN_IF_ERROR(perso_tlv_cert_obj_build(name, cert_type, cert, cert_size,
-                                           dice_chain_get_tail_buffer(),
-                                           &cert_page_left));
-
-  // Move the offset to the new tail.
-  RETURN_IF_ERROR(perso_tlv_get_cert_obj(dice_chain_get_tail_buffer(),
-                                         dice_chain_get_tail_size(),
-                                         &dice_chain.cert_obj));
-  dice_chain_next_cert_obj();
-  return kErrorOk;
-}
 
 rom_error_t dice_chain_attestation_silicon(void) {
   // Initialize the entropy complex and KMAC for key manager operations.
@@ -307,12 +68,6 @@ rom_error_t dice_chain_attestation_silicon(void) {
   return kErrorOk;
 }
 
-static rom_error_t dice_chain_get_cdi_0_id(uint64_t *cdi_0_id) {
-  return flash_ctrl_info_read_zeros_on_read_error(
-      &kFlashCtrlInfoPageDiceCerts, offsetof(dice_page_t, cdi_0_key_id),
-      sizeof(uint64_t) / sizeof(uint32_t), cdi_0_id);
-}
-
 rom_error_t dice_chain_attestation_creator(
     keymgr_binding_value_t *rom_ext_measurement,
     const manifest_t *rom_ext_manifest) {
@@ -330,10 +85,11 @@ rom_error_t dice_chain_attestation_creator(
       &static_dice_cdi_0.cdi_0_pubkey));
 
   // Check if the current CDI_0 cert is valid.
-  uint64_t expected_cdi0_id =
-      *(uint64_t *)static_dice_cdi_0.cdi_0_pubkey_id.digest;
+  uint64_t expected_cdi0_id = read_64(static_dice_cdi_0.cdi_0_pubkey_id.digest);
+
   uint64_t cached_cdi0_id;
-  RETURN_IF_ERROR(dice_chain_get_cdi_0_id(&cached_cdi0_id));
+  RETURN_IF_ERROR(dice_storage_get_cdi_0_id(&cached_cdi0_id));
+
   bool cache_valid = cached_cdi0_id == expected_cdi0_id;
 
   if (!cache_valid) {
@@ -356,97 +112,22 @@ rom_error_t dice_chain_attestation_creator(
   return kErrorOk;
 }
 
-// Compare the UDS identity in the static critical section to the UDS cert
-// cached in the flash.
-static rom_error_t dice_chain_attestation_check_uds(void) {
-  // Switch page for the factory provisioned UDS cert.
-  RETURN_IF_ERROR(dice_chain_load_flash(&kFlashCtrlInfoPageFactoryCerts));
-
-  // Check if the UDS cert is valid.
-  dice_chain.endorsement_pubkey_id = static_dice_cdi_0.uds_pubkey_id;
-  dice_chain.subject_pubkey_id = static_dice_cdi_0.uds_pubkey_id;
-  dice_chain.subject_pubkey = static_dice_cdi_0.uds_pubkey;
-  RETURN_IF_ERROR(dice_chain_load_cert_obj("UDS", /*name_size=*/4));
-  if (dice_chain.cert_valid == kHardenedBoolFalse) {
-    // The UDS key ID (and cert itself) should never change unless:
-    // 1. there is a hardware issue / the page has been corrupted, or
-    // 2. the cert has not yet been provisioned.
-    //
-    // In both cases, we do nothing, and boot normally, later attestation
-    // attempts will fail in a detectable manner.
-
-    // CAUTION: This error message should match the one in
-    //   //sw/host/provisioning/ft_lib/src/lib.rs
-    dbg_puts("error: UDS certificate not valid\r\n");
-  }
-
-  return kErrorOk;
-}
-
-// Refresh the cache if a new CDI_0 is generated.
-static rom_error_t dice_chain_attestation_check_cdi_0(void) {
-  // Switch page for the device CDI chain.
-  RETURN_IF_ERROR(dice_chain_load_flash(&kFlashCtrlInfoPageDiceCerts));
-
-  // Set the endorsement key for the next cert.
-  dice_chain.endorsement_pubkey_id = static_dice_cdi_0.cdi_0_pubkey_id;
-
-  // Save cdi 0 to flash if regenerated.
-  if (static_dice_cdi_0.cert_size != 0) {
-    dbg_puts("warning: CDI_0 certificate not valid; updating\r\n");
-    dice_chain.page.cdi_0_key_id =
-        read_64(static_dice_cdi_0.cdi_0_pubkey_id.digest);
-    return dice_chain_push_cert("CDI_0", static_dice_cdi_0.cert_data,
-                                static_dice_cdi_0.cert_size);
-  } else {
-    return dice_chain_skip_cert_obj("CDI_0", /*name_size=*/6);
-  }
-}
-
-// Check the hash digest at the last of the page.
-static rom_error_t dice_chain_seal_page_check(
-    const flash_ctrl_info_page_t *info_page) {
-  RETURN_IF_ERROR(dice_chain_load_flash(info_page));
-  // Hash the entire page before the digest.
-  hmac_digest_t expected_digest;
-  hmac_sha256(&dice_chain.page,
-              sizeof(dice_chain.page) - sizeof(dice_chain.page.digest),
-              &expected_digest);
-
-  // Compare with the digest stored at the end of the page.
-  if (memcmp(&dice_chain.page.digest, &expected_digest,
-             sizeof(hmac_digest_t)) != 0) {
-    return kErrorDicePageCorrupted;
-  }
-
-  return kErrorOk;
-}
-
 rom_error_t dice_chain_rom_ext_check(void) {
-  if (dice_chain_seal_page_check(&kFlashCtrlInfoPageFactoryCerts) != kErrorOk) {
-    dbg_puts("warning: corrupted FactoryCerts page\r\n");
+  // If a CDI_0 certificate is issued, the entire cache will be rebuilt, so
+  // the digest check can be skipped.
+  if (static_dice_cdi_0.cert_size != 0) {
+    return kErrorOk;
   }
 
-  // Retry if the current cache is corrupted.
-  rom_error_t error = dice_chain_seal_page_check(&kFlashCtrlInfoPageDiceCerts);
-  if (error == kErrorDicePageCorrupted) {
-    dbg_puts("warning: corrupted DiceCerts page\r\n");
-    // Clear the corrupted page and reboot.
-    dice_chain.data_dirty = kHardenedBoolTrue;
-    memset(&dice_chain.page, 0, sizeof(dice_chain.page));
-    RETURN_IF_ERROR(dice_chain_flush_flash());
+  RETURN_IF_ERROR(dice_storage_load_page(&dice_page));
 
-    if (static_dice_cdi_0.cert_size > 0) {
-      // Continue since CDI_0 has been generated
-      error = kErrorOk;
-    }
+  rom_error_t status = dice_storage_check_digest(&dice_page);
+  if (status != kErrorOk) {
+    dbg_printf("warning: corrupted page; erasing\r\n");
+    RETURN_IF_ERROR(flash_ctrl_info_erase(&kFlashCtrlInfoPageDiceCerts,
+                                          kFlashCtrlEraseTypePage));
+    return status;
   }
-  RETURN_IF_ERROR(error);
-
-  // Handles the certificates from the immutable rom_ext.
-  RETURN_IF_ERROR(dice_chain_attestation_check_uds());
-  RETURN_IF_ERROR(dice_chain_attestation_check_cdi_0());
-
   return kErrorOk;
 }
 
@@ -454,6 +135,14 @@ rom_error_t dice_chain_attestation_owner(
     const manifest_t *owner_manifest, keymgr_binding_value_t *bl0_measurement,
     hmac_digest_t *owner_measurement, hmac_digest_t *owner_history_hash,
     keymgr_binding_value_t *sealing_binding, owner_app_domain_t key_domain) {
+  // Local variables for CDI_1 key generation and cert building
+  hmac_digest_t subject_pubkey_id;
+  ecdsa_p256_public_key_t subject_pubkey;
+  cert_key_id_pair_t key_ids = {
+      .endorsement = &static_dice_cdi_0.cdi_0_pubkey_id,
+      .cert = &subject_pubkey_id,
+  };
+
   // Generate CDI_1 attestation keys and (potentially) update certificate.
   SEC_MMIO_WRITE_INCREMENT(kScKeymgrSecMmioSwBindingSet +
                            kScKeymgrSecMmioOwnerIntMaxVerSet);
@@ -477,71 +166,64 @@ rom_error_t dice_chain_attestation_owner(
       /*attest_binding=*/(keymgr_binding_value_t *)&attest_measurement,
       owner_manifest->max_key_version));
   HARDENED_RETURN_IF_ERROR(otbn_boot_cert_ecc_p256_keygen(
-      kDiceKeyCdi1, &dice_chain.subject_pubkey_id, &dice_chain.subject_pubkey));
+      kDiceKeyCdi1, &subject_pubkey_id, &subject_pubkey));
 
-  uint64_t expected_cdi1_id = read_64(dice_chain.subject_pubkey_id.digest);
+  // Load page to dice_page.
+  RETURN_IF_ERROR(dice_storage_load_page(&dice_page));
+
+  uint64_t expected_cdi1_id = read_64(subject_pubkey_id.digest);
+
   bool cache_valid = (static_dice_cdi_0.cert_size == 0 &&
-                      dice_chain.page.cdi_1_key_id == expected_cdi1_id);
+                      dice_page.cdi_1_key_id == expected_cdi1_id);
 
   if (!cache_valid) {
-    dbg_puts("warning: CDI_1 certificate not valid; updating\r\n");
-    // Update the cert page buffer.
-    size_t updated_cert_size = kDicePageDataSize;
+    dbg_puts("info: DICE cert cache miss; updating\r\n");
+
+    // If CDI_0 in RAM is valid, copy it to dice_page.
+    if (static_dice_cdi_0.cert_size != 0) {
+      dice_storage_slot_init(&kDiceStorageCdi0Ecdsa, &dice_page);
+      memcpy(dice_storage_slot_data(&kDiceStorageCdi0Ecdsa, &dice_page),
+             static_dice_cdi_0.cert_data, static_dice_cdi_0.cert_size);
+      dice_storage_set_cert_size(&kDiceStorageCdi0Ecdsa,
+                                 static_dice_cdi_0.cert_size, &dice_page);
+      dice_page.cdi_0_key_id =
+          read_64(static_dice_cdi_0.cdi_0_pubkey_id.digest);
+    }
+
+    // Generate CDI_1 directly into dice_page.
+    dice_storage_slot_init(&kDiceStorageCdi1Ecdsa, &dice_page);
+    uint8_t *cdi1_cert_data_ptr =
+        dice_storage_slot_data(&kDiceStorageCdi1Ecdsa, &dice_page);
+    size_t generated_cdi1_size = kDiceStorageCdi1Ecdsa.data_size;
     HARDENED_RETURN_IF_ERROR(dice_cdi_1_cert_build(
         (hmac_digest_t *)bl0_measurement, owner_measurement, owner_history_hash,
-        owner_manifest->security_version, key_domain, &dice_chain.key_ids,
-        &static_dice_cdi_0.cdi_0_pubkey, &dice_chain.subject_pubkey,
-        dice_chain.scratch_cert, &updated_cert_size));
+        owner_manifest->security_version, key_domain, &key_ids,
+        &static_dice_cdi_0.cdi_0_pubkey, &subject_pubkey, cdi1_cert_data_ptr,
+        &generated_cdi1_size));
+    dice_storage_set_cert_size(&kDiceStorageCdi1Ecdsa, generated_cdi1_size,
+                               &dice_page);
+    dice_page.cdi_1_key_id = expected_cdi1_id;
 
-    dice_chain.page.cdi_1_key_id = expected_cdi1_id;
+    // Calculate and update digest.
+    dice_storage_digest_page(&dice_page, &dice_page.digest);
 
-    RETURN_IF_ERROR(dice_chain_push_cert("CDI_1", dice_chain.scratch_cert,
-                                         updated_cert_size));
+    // Flush page to flash.
+    RETURN_IF_ERROR(dice_storage_flush_page(&dice_page));
   } else {
     // Replace CDI_0 with CDI_1 key for endorsing next stage cert.
     HARDENED_RETURN_IF_ERROR(otbn_boot_attestation_key_save(
         kDiceKeyCdi1.keygen_seed_idx, kDiceKeyCdi1.type,
         *kDiceKeyCdi1.keymgr_diversifier));
   }
-  dice_chain.endorsement_pubkey_id = dice_chain.subject_pubkey_id;
 
   sc_keymgr_sw_binding_unlock_wait();
-
-  return kErrorOk;
-}
-
-// Write the DICE certs to flash if they have been updated.
-rom_error_t dice_chain_flush_flash(void) {
-  if (dice_chain.data_dirty == kHardenedBoolTrue &&
-      dice_chain.info_page != NULL) {
-    RETURN_IF_ERROR(dice_chain_seal_page());
-
-    RETURN_IF_ERROR(
-        flash_ctrl_info_erase(dice_chain.info_page, kFlashCtrlEraseTypePage));
-    static_assert(sizeof(dice_chain.page) == kFlashPageSize,
-                  "Invalid dice_chain buffer size");
-    RETURN_IF_ERROR(flash_ctrl_info_write(
-        dice_chain.info_page,
-        /*offset=*/0,
-        /*word_count=*/FLASH_CTRL_PARAM_BYTES_PER_PAGE / sizeof(uint32_t),
-        &dice_chain.page));
-    dice_chain.data_dirty = kHardenedBoolFalse;
-  }
   return kErrorOk;
 }
 
 rom_error_t dice_chain_init(void) {
-  // Variable initialization.
-  memset(&dice_chain, 0, sizeof(dice_chain));
-  dice_chain.data_dirty = kHardenedBoolFalse;
-  dice_chain.key_ids = (cert_key_id_pair_t){
-      .endorsement = &dice_chain.endorsement_pubkey_id,
-      .cert = &dice_chain.subject_pubkey_id,
-  };
-  dice_chain_reset_cert_obj();
-
   // Configure DICE certificate flash info page and buffer it into RAM.
   flash_ctrl_cert_info_page_creator_cfg(&kFlashCtrlInfoPageDiceCerts);
+  // Configure factory certs page.
   flash_ctrl_info_cfg_set(&kFlashCtrlInfoPageFactoryCerts,
                           kCertificateInfoPageCfg);
   flash_ctrl_cert_info_page_owner_restrict(&kFlashCtrlInfoPageFactoryCerts);

--- a/sw/device/silicon_creator/lib/cert/dice_chain.h
+++ b/sw/device/silicon_creator/lib/cert/dice_chain.h
@@ -12,29 +12,9 @@
 #include "sw/device/silicon_creator/lib/manifest.h"
 #include "sw/device/silicon_creator/lib/ownership/datatypes.h"
 
-#include "flash_ctrl_regs.h"  // Generated.
-
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-enum {
-  kDicePageDataSize = FLASH_CTRL_PARAM_BYTES_PER_PAGE -
-                      (2 * sizeof(uint64_t) + sizeof(hmac_digest_t)),
-};
-
-/**
- * The flash page schema for holding DICE certificates.
- */
-typedef struct dice_page {
-  uint8_t data[kDicePageDataSize];
-  uint64_t cdi_0_key_id;
-  uint64_t cdi_1_key_id;
-  hmac_digest_t digest;
-} dice_page_t;
-
-static_assert(sizeof(dice_page_t) == FLASH_CTRL_PARAM_BYTES_PER_PAGE,
-              "Invalid dice page size");
 
 /**
  * Initialize the dice chain builder with data from the flash pages.
@@ -80,14 +60,6 @@ rom_error_t dice_chain_attestation_owner(
     const manifest_t *owner_manifest, keymgr_binding_value_t *bl0_measurement,
     hmac_digest_t *owner_measurement, hmac_digest_t *owner_history_hash,
     keymgr_binding_value_t *sealing_binding, owner_app_domain_t key_domain);
-
-/**
- * Write back the certificate chain to flash if changed.
- *
- * @return errors encountered during the operation.
- */
-OT_WARN_UNUSED_RESULT
-rom_error_t dice_chain_flush_flash(void);
 
 /**
  * Checks that the factory-provisioned certificates in flash are valid and

--- a/sw/device/silicon_creator/lib/cert/dice_cwt.c
+++ b/sw/device/silicon_creator/lib/cert/dice_cwt.c
@@ -16,6 +16,7 @@
 #include "sw/device/silicon_creator/lib/cert/dice.h"
 #include "sw/device/silicon_creator/lib/cert/dice_chain.h"
 #include "sw/device/silicon_creator/lib/cert/dice_keys.h"
+#include "sw/device/silicon_creator/lib/cert/dice_storage.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
@@ -27,6 +28,20 @@
 #include "sw/device/silicon_creator/manuf/base/perso_tlv_data.h"
 
 #include "otp_ctrl_regs.h"  // Generated.
+
+enum {
+  kDiceSlotSize = 936,
+};
+
+const dice_storage_slot_t kDiceStorageCdi0Ecdsa =
+    DICE_STORAGE_SLOT("CDI_0", &kFlashCtrlInfoPageDiceCerts,
+                      /*offset_val=*/0,
+                      /*slot_size_val=*/kDiceSlotSize, kPersoObjectTypeCwtCert);
+
+const dice_storage_slot_t kDiceStorageCdi1Ecdsa =
+    DICE_STORAGE_SLOT("CDI_1", &kFlashCtrlInfoPageDiceCerts,
+                      /*offset_val=*/kDiceSlotSize,
+                      /*slot_size_val=*/kDiceSlotSize, kPersoObjectTypeCwtCert);
 
 const dice_cert_format_t kDiceCertFormat = kDiceCertFormatCWTAndroid;
 
@@ -509,8 +524,7 @@ rom_error_t dice_attest_cdi_1(const manifest_t *owner_manifest,
                               owner_app_domain_t key_domain) {
   HARDENED_RETURN_IF_ERROR(dice_chain_init());
   HARDENED_RETURN_IF_ERROR(dice_chain_rom_ext_check());
-  HARDENED_RETURN_IF_ERROR(dice_chain_attestation_owner(
-      owner_manifest, bl0_measurement, owner_measurement, owner_history_hash,
-      sealing_binding, key_domain));
-  return dice_chain_flush_flash();
+  return dice_chain_attestation_owner(owner_manifest, bl0_measurement,
+                                      owner_measurement, owner_history_hash,
+                                      sealing_binding, key_domain);
 }

--- a/sw/device/silicon_creator/lib/cert/dice_storage.c
+++ b/sw/device/silicon_creator/lib/cert/dice_storage.c
@@ -1,0 +1,75 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/cert/dice_storage.h"
+
+#include <stddef.h>
+#include <string.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/manuf/base/perso_tlv_data.h"
+
+#include "flash_ctrl_regs.h"  // Generated.
+
+extern dice_storage_header_t *dice_storage_slot_header(
+    const dice_storage_slot_t *layout, dice_storage_page_t *page);
+
+extern uint8_t *dice_storage_slot_data(const dice_storage_slot_t *layout,
+                                       dice_storage_page_t *page);
+
+rom_error_t dice_storage_load_page(dice_storage_page_t *page) {
+  return flash_ctrl_info_read_zeros_on_read_error(
+      &kFlashCtrlInfoPageDiceCerts, 0,
+      sizeof(dice_storage_page_t) / sizeof(uint32_t), page);
+}
+
+rom_error_t dice_storage_flush_page(const dice_storage_page_t *page) {
+  RETURN_IF_ERROR(flash_ctrl_info_erase(&kFlashCtrlInfoPageDiceCerts,
+                                        kFlashCtrlEraseTypePage));
+  return flash_ctrl_info_write(&kFlashCtrlInfoPageDiceCerts, 0,
+                               sizeof(dice_storage_page_t) / sizeof(uint32_t),
+                               page);
+}
+
+rom_error_t dice_storage_get_cdi_0_id(uint64_t *cdi_0_id) {
+  return flash_ctrl_info_read_zeros_on_read_error(
+      &kFlashCtrlInfoPageDiceCerts, offsetof(dice_storage_page_t, cdi_0_key_id),
+      sizeof(uint64_t) / sizeof(uint32_t), cdi_0_id);
+}
+
+void dice_storage_slot_init(const dice_storage_slot_t *layout,
+                            dice_storage_page_t *page) {
+  uint8_t *header_ptr = (uint8_t *)dice_storage_slot_header(layout, page);
+  memset(header_ptr, 0, layout->header_size + layout->data_size);
+  memcpy(header_ptr, &layout->header, sizeof(layout->header));
+}
+
+void dice_storage_set_cert_size(const dice_storage_slot_t *layout,
+                                size_t cert_size, dice_storage_page_t *page) {
+  dice_storage_header_t *header = dice_storage_slot_header(layout, page);
+  size_t wrapped_size =
+      layout->header_size - sizeof(layout->header.object_header) + cert_size;
+  PERSO_TLV_SET_FIELD(Crth, Size, header->cert_header, wrapped_size);
+}
+
+void dice_storage_digest_page(const dice_storage_page_t *page,
+                              hmac_digest_t *digest_out) {
+  hmac_sha256(page, sizeof(dice_storage_page_t) - sizeof(hmac_digest_t),
+              digest_out);
+}
+
+rom_error_t dice_storage_check_digest(const dice_storage_page_t *page) {
+  hmac_digest_t actual;
+  dice_storage_digest_page(page, &actual);
+
+  if (memcmp(&actual, &page->digest, sizeof(hmac_digest_t)) != 0) {
+    return kErrorDicePageCorrupted;
+  }
+
+  return kErrorOk;
+}

--- a/sw/device/silicon_creator/lib/cert/dice_storage.h
+++ b/sw/device/silicon_creator/lib/cert/dice_storage.h
@@ -1,0 +1,227 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_DICE_STORAGE_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_DICE_STORAGE_H_
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/manuf/base/perso_tlv_data.h"
+
+#include "flash_ctrl_regs.h"  // Generated.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+  kDiceStoragePageDataSize = FLASH_CTRL_PARAM_BYTES_PER_PAGE -
+                             (2 * sizeof(uint64_t) + sizeof(hmac_digest_t)),
+};
+
+typedef struct dice_storage_header {
+  uint16_t object_header;  // Big Endian
+  uint16_t cert_header;    // Big Endian
+  char name[12];           // "CDI_0" or "CDI_1", padded with 0
+} dice_storage_header_t;
+
+OT_ASSERT_MEMBER_OFFSET(dice_storage_header_t, object_header, 0);
+OT_ASSERT_MEMBER_OFFSET(dice_storage_header_t, cert_header, 2);
+OT_ASSERT_MEMBER_OFFSET(dice_storage_header_t, name, 4);
+OT_ASSERT_SIZE(dice_storage_header_t, 16);
+
+typedef struct dice_storage_slot {
+  const flash_ctrl_info_page_t *info_page;
+  uint32_t page_offset;
+  dice_storage_header_t header;  // Template
+  uint8_t header_size;
+  uint16_t data_size;
+} dice_storage_slot_t;
+
+#define DICE_STORAGE_SLOT(name_str, info_page_ptr, offset_val, slot_size_val, \
+                          type_val)                                           \
+  {                                                                           \
+    .info_page = info_page_ptr, .page_offset = offset_val,                    \
+    .header =                                                                 \
+        {                                                                     \
+            .object_header = TLV_OBJ_HEADER(type_val, slot_size_val),         \
+            .cert_header = TLV_CERT_HEADER(sizeof(name_str) - 1, 0),          \
+            .name = name_str,                                                 \
+        },                                                                    \
+    .header_size = 4 + sizeof(name_str) - 1,                                  \
+    .data_size = slot_size_val - (4 + sizeof(name_str) - 1),                  \
+  }
+
+/**
+ * The flash page schema for holding DICE certificates.
+ */
+typedef struct dice_storage_page {
+  uint8_t data[kDiceStoragePageDataSize];
+  uint64_t cdi_1_key_id;
+  uint64_t cdi_0_key_id;
+  hmac_digest_t digest;
+} dice_storage_page_t;
+
+OT_ASSERT_MEMBER_OFFSET(dice_storage_page_t, data, 0);
+OT_ASSERT_MEMBER_OFFSET(dice_storage_page_t, cdi_1_key_id, 2000);
+OT_ASSERT_MEMBER_OFFSET(dice_storage_page_t, cdi_0_key_id, 2008);
+OT_ASSERT_MEMBER_OFFSET(dice_storage_page_t, digest, 2016);
+OT_ASSERT_SIZE(dice_storage_page_t, FLASH_CTRL_PARAM_BYTES_PER_PAGE);
+
+/**
+ * The DICE page (2048 bytes) is divided into two certificate slots and a
+ * metadata block at the end.
+ *
+ * The slot size is configurable in each DICE variant; the following example
+ * illustrates the layout with 936-byte slots.
+ *
+ * Note: Although the offset is hardcoded in the rom_ext implementation,
+ * OwnerSw clients should still parse the TLV structure dynamically to ensure
+ * future layout changes do not break compatibility.
+ *
+ * +--------------------------------------------------------------------------+
+ * |                         DiceCerts Page (2048 B)                          |
+ * +--------------------------------------------------------------------------+
+ * | TLV Object: CDI_0 (936 B)                                                |
+ * | +----------------------------------------------------------------------+ |
+ * | | Object Header (2 B): type=kPersoObjectTypeX509Cert, size=936B        | |
+ * | +----------------------------------------------------------------------+ |
+ * | | TLV Cert Object (9 B + len(cert) B)                                  | |
+ * | | +------------------------------------------------------------------+ | |
+ * | | | Cert Header (2 B): len(name)=5B, len(cert)=var-size              | | |
+ * | | +------------------------------------------------------------------+ | |
+ * | | | Cert Name (5 B): "CDI_0"                                         | | |
+ * | | +------------------------------------------------------------------+ | |
+ * | | | Cert Body: Cert Data (variable size)                             | | |
+ * | | +------------------------------------------------------------------+ | |
+ * | +----------------------------------------------------------------------+ |
+ * | | Padding: Padded to 936 B                                             | |
+ * | +----------------------------------------------------------------------+ |
+ * +--------------------------------------------------------------------------+
+ * | TLV Object: CDI_1 (936 B)                                                |
+ * | +----------------------------------------------------------------------+ |
+ * | | Object Header (2 B): type=kPersoObjectTypeX509Cert, size=936B        | |
+ * | +----------------------------------------------------------------------+ |
+ * | | TLV Cert Object (9 B + len(cert) B)                                  | |
+ * | | +------------------------------------------------------------------+ | |
+ * | | | Cert Header (2 B): len(name)=5B, len(cert)=var-size              | | |
+ * | | +------------------------------------------------------------------+ | |
+ * | | | Cert Name (5 B): "CDI_1"                                         | | |
+ * | | +------------------------------------------------------------------+ | |
+ * | | | Cert Body: Cert Data (variable size)                             | | |
+ * | | +------------------------------------------------------------------+ | |
+ * | +----------------------------------------------------------------------+ |
+ * | | Padding: Padded to 936 B                                             | |
+ * | +----------------------------------------------------------------------+ |
+ * +--------------------------------------------------------------------------+
+ * | Gap / Reserved (128 B)                                                   |
+ * +--------------------------------------------------------------------------+
+ * | Metadata Block: dice_page_meta_t (48 B)                                  |
+ * | +----------------------------------------------------------------------+ |
+ * | | cdi_1_key_id (8 B): Cache ID to skip regeneration                    | |
+ * | +----------------------------------------------------------------------+ |
+ * | | cdi_0_key_id (8 B): Cache ID to skip regeneration                    | |
+ * | +----------------------------------------------------------------------+ |
+ * | | digest (32 B): Integrity check for corruption or interrupted write   | |
+ * | +----------------------------------------------------------------------+ |
+ * +--------------------------------------------------------------------------+
+ */
+extern const dice_storage_slot_t kDiceStorageCdi0Ecdsa;
+extern const dice_storage_slot_t kDiceStorageCdi1Ecdsa;
+
+/**
+ * Return pointer to the certificate header in a page slot.
+ *
+ * @param layout Slot layout.
+ * @param page Pointer to the page in memory.
+ * @return Pointer to the certificate header.
+ */
+inline dice_storage_header_t *dice_storage_slot_header(
+    const dice_storage_slot_t *layout, dice_storage_page_t *page) {
+  return (dice_storage_header_t *)((uint8_t *)page + layout->page_offset);
+}
+
+/**
+ * Return pointer to the certificate data area in a page slot.
+ *
+ * @param layout Slot layout.
+ * @param page Pointer to the page in memory.
+ * @return Pointer to the certificate data.
+ */
+inline uint8_t *dice_storage_slot_data(const dice_storage_slot_t *layout,
+                                       dice_storage_page_t *page) {
+  return (uint8_t *)page + layout->page_offset + layout->header_size;
+}
+
+/**
+ * Load the DICE certificates page from flash.
+ *
+ * @param page Destination buffer.
+ * @return Error code.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t dice_storage_load_page(dice_storage_page_t *page);
+
+/**
+ * Write the DICE certificates page to flash after erasing it.
+ *
+ * @param page Source page data.
+ * @return Error code.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t dice_storage_flush_page(const dice_storage_page_t *page);
+
+/**
+ * Read the CDI_0 key ID from flash.
+ *
+ * @param cdi_0_id Destination buffer.
+ * @return Error code.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t dice_storage_get_cdi_0_id(uint64_t *cdi_0_id);
+
+/**
+ * Initialize a slot in the page buffer with its default header.
+ *
+ * @param layout Slot layout.
+ * @param page Pointer to the page in memory.
+ */
+void dice_storage_slot_init(const dice_storage_slot_t *layout,
+                            dice_storage_page_t *page);
+
+/**
+ * Set the actual certificate size in the slot header.
+ *
+ * @param layout Slot layout.
+ * @param cert_size Actual size of the certificate.
+ * @param page Pointer to the page in memory.
+ */
+void dice_storage_set_cert_size(const dice_storage_slot_t *layout,
+                                size_t cert_size, dice_storage_page_t *page);
+
+/**
+ * Calculate the SHA256 digest of the certificates page.
+ *
+ * @param page Page data.
+ * @param digest_out Destination buffer for the digest.
+ */
+void dice_storage_digest_page(const dice_storage_page_t *page,
+                              hmac_digest_t *digest_out);
+
+/**
+ * Check if the digest in the page matches the page contents.
+ *
+ * @param page Page data.
+ * @return Error code.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t dice_storage_check_digest(const dice_storage_page_t *page);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_DICE_STORAGE_H_

--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -381,6 +381,7 @@ manifest(d = {
             "//sw/device/silicon_creator/lib/cert:cdi_0_template_library",
             "//sw/device/silicon_creator/lib/cert:cdi_1_template_library",
             "//sw/device/silicon_creator/lib/cert:dice_chain",
+            "//sw/device/silicon_creator/lib/cert:dice_storage",
             "//sw/device/silicon_creator/lib/cert:uds_template_library",
             "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
             "//sw/device/silicon_creator/lib/drivers:hmac",

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -37,6 +37,7 @@
 #include "sw/device/silicon_creator/lib/cert/cert.h"
 #include "sw/device/silicon_creator/lib/cert/dice.h"
 #include "sw/device/silicon_creator/lib/cert/dice_chain.h"
+#include "sw/device/silicon_creator/lib/cert/dice_storage.h"
 #include "sw/device/silicon_creator/lib/cert/uds.h"  // Generated.
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
@@ -158,7 +159,7 @@ static uint8_t all_certs[8192];
 // 1K should be enough for the largest certificate perso LTV object.
 enum { kBufferSize = 1024 };
 static alignas(uint32_t) uint8_t cert_buffer[kBufferSize];
-static alignas(uint64_t) dice_page_t dice_page;
+static alignas(uint64_t) dice_storage_page_t dice_page;
 static size_t uds_offset;
 static size_t cdi_0_offset;
 static size_t cdi_1_offset;

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -146,6 +146,15 @@ typedef enum perso_tlv_cert_header_fields {
     *(field_value) = (__builtin_bswap16(full_value) >> shift) & mask;       \
   }
 
+// Helper macros for compile-time Big Endian conversion
+#define TLV_TO_BE16(val) __builtin_bswap16((uint16_t)(val))
+
+#define TLV_OBJ_HEADER(type, size) \
+  TLV_TO_BE16(((((uint16_t)(type)&0xF) << 12) | ((uint16_t)(size)&0xFFF)))
+
+#define TLV_CERT_HEADER(name_len, size) \
+  TLV_TO_BE16(((((uint16_t)(name_len)&0xF) << 12) | ((uint16_t)(size)&0xFFF)))
+
 /**
  * A helper structure for quick access to a certificate stored as a perso LTV
  * object.

--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
@@ -37,12 +37,12 @@ package(default_visibility = ["//visibility:public"])
             "//hw/top_earlgrey:sim_qemu_rom_ext": None,
         },
         fpga = fpga_params(
-            exit_failure = "Rebooting[\\s\\S]*CDI_1 certificate not valid[\\s\\S]*Rebooted",
+            exit_failure = "Rebooting[\\s\\S]*DICE cert cache miss[\\s\\S]*Rebooted",
             exit_success = "Rebooted\r\n",
             rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_{}_slot_a".format(variation_name),
         ),
         qemu = qemu_params(
-            exit_failure = "Rebooting[\\s\\S]*CDI_1 certificate not valid[\\s\\S]*Rebooted",
+            exit_failure = "Rebooting[\\s\\S]*DICE cert cache miss[\\s\\S]*Rebooted",
             exit_success = "Rebooted\r\n",
             rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_{}_slot_a".format(variation_name),
         ),

--- a/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
@@ -150,6 +150,8 @@ SECTIONS {
     *(.srodata.*)
     *(.rodata)
     *(.rodata.*)
+    /* Ensure section end is word-aligned. */
+    . = ALIGN(4);
   } > rom_ext_flash
 
   INCLUDE sw/device/lib/coverage/rodata.ld

--- a/sw/host/tests/rom_ext/e2e_variation_interop/src/main.rs
+++ b/sw/host/tests/rom_ext/e2e_variation_interop/src/main.rs
@@ -42,13 +42,7 @@ fn main() -> anyhow::Result<()> {
     let uart = transport.uart("console").context("failed to get UART")?;
 
     // Wait for CDI_* update messags.
-    for i in 0..2 {
-        let _ = UartConsole::wait_for(
-            &*uart,
-            format!(r"warning: CDI_{:?} certificate not valid; updating", i).as_str(),
-            opts.timeout,
-        )?;
-    }
+    let _ = UartConsole::wait_for(&*uart, "DICE cert cache miss; updating", opts.timeout)?;
 
     // Wait for pass message from first owner firmware stage.
     let _ = UartConsole::wait_for(&*uart, r"PASS!", opts.timeout)?;


### PR DESCRIPTION
This PR redesign the DICE certificate TLV encoder to use a simplified, fixed-size layout for the DICE certificate page, allowing most fields to be constructed at compile-time. This replaces the previous dynamic TLV parsing and shifting logic in ROM_EXT.

The new implementation saves 1.6KB of code size.

---

### FAQ - What if the certificate slot size needs to be changed?

Just change the hard coded constant.

Since updating the layout requires a rom_ext update, this process naturally invalidates the cached CDI_0 and CDI_1 certificates. During first boot, they will be automatically regenerated and written to flash using the newly defined layout.