### PR TITLE
[ot_certs] Support algorithm variants in a single template

### DIFF
--- a/sw/device/silicon_creator/lib/cert/template.h
+++ b/sw/device/silicon_creator/lib/cert/template.h
@@ -149,6 +149,16 @@ static inline void template_push_const(template_state_t *state, size_t size) {
 }
 
 /**
+ * Skip `size` bytes from the pre-generated template.
+ *
+ * @param state Pointer to the template engine state.
+ * @param size Number of the bytes to skip.
+ */
+static inline void template_skip_const(template_state_t *state, size_t size) {
+  state->const_end += size;
+}
+
+/**
  * Private implementation of `template_asn1_integer`.
  *
  * @param out Pointer to the output buffer.

--- a/sw/host/ot_certs/BUILD
+++ b/sw/host/ot_certs/BUILD
@@ -119,6 +119,7 @@ rust_test_suite(
         ":example_data",
         ":mldsa_certs",
         ":fw_ids_raw_test_files",
+        "tests/variants.hjson",
     ],
     edition = "2024",
     deps = [
@@ -148,4 +149,9 @@ certificate_template(
 certificate_template(
     name = "mldsa_87_test_template",
     template = "tests/mldsa_87.hjson",
+)
+
+certificate_template(
+    name = "variants_test_template",
+    template = "tests/variants.hjson",
 )

--- a/sw/host/ot_certs/README.md
+++ b/sw/host/ot_certs/README.md
@@ -16,13 +16,23 @@ More detailed documentation on OpenTitan certificates will be published soon.
 
 ### ASN1 Variable Typing
 
-The asn1 template supports four variable types: byte-array, string, integer, and
-boolean. Array types (byte-array, string, and integer) require the size in bytes
-of the value it represents to be specified.
+The asn1 template supports five variable types: byte-array, string, integer,
+boolean, and selector.
+
+Array types (byte-array, string, and integer) require the size in bytes of the
+value it represents to be specified.
 
 ```javascript
 type: "integer", // or "string" or "byte-array"
 exact-size: 20, // or `range-size: [min, max]` if size could be variable
+```
+
+The selector type is a special integer type (always 32-bit) used to select a
+branch in a dynamic choice. It requires `num_choices` to be specified.
+
+```javascript
+type: "selector",
+num_choices: 3,
 ```
 
 When the variable is an integer, the size is determined using its big-endian
@@ -38,3 +48,42 @@ type: "byte-array",
 exact-size: 20, // or `range-size: [min, max]` if size could be variable
 [tweak-msb: true,] // if destination could be an integer
 ```
+
+### Algorithm Variants
+
+The template engine supports dynamic branching between alternative algorithms
+(e.g., between ML-DSA and ECDSA) using `choices`. This allows a single template
+and device builder function to generate hybrid certificate endorsements based
+on a runtime parameter.
+
+The selection is controlled by a `selector` variable, which must be of type
+`selector`. The length of the `choices` array must match the `num_choices`
+declared in the selector variable.
+
+```javascript
+subject_public_key_info: {
+    selector: "pub_key_type", // A selector variable defined in `variables`
+    choices: [
+        {
+            algorithm: "ec-public-key",
+            curve: "prime256v1",
+            public_key: {
+                x: { var: "pub_key_ec_x" },
+                y: { var: "pub_key_ec_y" },
+            }
+        },
+        {
+            algorithm: "mldsa-65",
+            public_key: { var: "pub_key_mldsa_65" },
+        },
+        {
+            algorithm: "mldsa-87",
+            public_key: { var: "pub_key_mldsa_87" },
+        }
+    ]
+}
+```
+
+When generating C code, the engine places precomputed DER constants for all
+branches into Flash (`.rodata`) and automatically emits an `if/else` block
+with pointer skip adjustments (`template_skip_const`).

--- a/sw/host/ot_certs/src/asn1/builder.rs
+++ b/sw/host/ot_certs/src/asn1/builder.rs
@@ -10,7 +10,7 @@ use anyhow::{Result, ensure};
 use num_bigint_dig::BigUint;
 
 use crate::asn1::{Oid, Tag};
-use crate::template::{RawOr, Value};
+use crate::template::{RawOr, SelectableChoice, Value};
 
 /// Helper function to add a suffix to a name hint.
 pub fn concat_suffix(name_hint: &Option<String>, suffix: &str) -> Option<String> {
@@ -143,4 +143,9 @@ pub trait Builder {
             RawOr::Raw(raw) => self.push_byte_array(name_hint, raw),
         }
     }
+
+    /// Push a dynamic choice between multiple branches.
+    fn push_choices<T, F>(&mut self, choice: &SelectableChoice<T>, cb: F) -> Result<()>
+    where
+        F: FnMut(&mut Self, &T) -> Result<()>;
 }

--- a/sw/host/ot_certs/src/asn1/codegen.rs
+++ b/sw/host/ot_certs/src/asn1/codegen.rs
@@ -10,7 +10,7 @@ use std::cmp::max;
 use crate::asn1::builder::Builder;
 use crate::asn1::der::Der;
 use crate::asn1::{Oid, Tag};
-use crate::template::{Conversion, Value, Variable, VariableType};
+use crate::template::{Conversion, SelectableChoice, Value, Variable, VariableType};
 
 /// Information about how to refer to a variable in the code.
 #[derive(Debug, Clone)]
@@ -865,6 +865,111 @@ impl Builder for Codegen<'_> {
             );
         }
         self.unindent();
+        Ok(())
+    }
+
+    fn push_choices<T, F>(&mut self, choice: &SelectableChoice<T>, mut cb: F) -> Result<()>
+    where
+        F: FnMut(&mut Self, &T) -> Result<()>,
+    {
+        let VariableInfo { codegen, .. } = (self.variable_info)(&choice.selector)?;
+        let VariableCodegenInfo::Uint32 { value_expr } = codegen else {
+            bail!(
+                "selector variable '{}' must be a u32 integer",
+                choice.selector
+            );
+        };
+
+        ensure!(!choice.choices.is_empty(), "choices must not be empty");
+
+        // We need to run all branches to get their size and constants.
+        let mut branch_builders = Vec::new();
+        for c in &choice.choices {
+            let mut branch_builder = Codegen {
+                output: CodeOutput::new(),
+                variable_info: self.variable_info,
+                min_out_size: 0,
+                max_out_size: 0,
+            };
+            cb(&mut branch_builder, c)?;
+            branch_builders.push(branch_builder);
+        }
+
+        // Calculate constants for each branch.
+        let branch_consts: Vec<usize> = branch_builders
+            .iter()
+            .map(|b| {
+                b.output
+                    .iter()
+                    .filter(|x| x.code.is_constant())
+                    .map(|x| x.code.len())
+                    .sum()
+            })
+            .collect();
+
+        let min_branch_size = branch_builders
+            .iter()
+            .map(|b| b.min_out_size)
+            .min()
+            .unwrap_or(0);
+        let max_branch_size = branch_builders
+            .iter()
+            .map(|b| b.max_out_size)
+            .max()
+            .unwrap_or(0);
+
+        for (i, branch_builder) in branch_builders.into_iter().enumerate() {
+            let cond = if i == 0 {
+                format!("if ({value_expr} == {i}) {{\n")
+            } else if i == branch_consts.len() - 1 {
+                "} else {\n".to_string()
+            } else {
+                format!("}} else if ({value_expr} == {i}) {{\n")
+            };
+
+            self.push_chunk(
+                CodeChunk::Code(cond),
+                Some(format!("Choice {} on {}", i, choice.selector)),
+            );
+
+            // Skip constants before this branch
+            let skip_before: usize = branch_consts[0..i].iter().sum();
+            if skip_before > 0 {
+                self.push_chunk(
+                    CodeChunk::Code(format!("template_skip_const(&state, {skip_before});\n")),
+                    Some(format!(
+                        "Skip branches 0..{} constants ({} B)",
+                        i - 1,
+                        skip_before
+                    )),
+                );
+            }
+
+            // Execute branch
+            self.output.extend(branch_builder.output);
+
+            // Skip constants after this branch
+            let skip_after: usize = branch_consts[i + 1..].iter().sum();
+            if skip_after > 0 {
+                self.push_chunk(
+                    CodeChunk::Code(format!("template_skip_const(&state, {skip_after});\n")),
+                    Some(format!(
+                        "Skip branches {}..{} constants ({} B)",
+                        i + 1,
+                        branch_consts.len() - 1,
+                        skip_after
+                    )),
+                );
+            }
+        }
+        self.push_chunk(
+            CodeChunk::Code("}\n".to_string()),
+            Some(format!("End choice on {}", choice.selector)),
+        );
+
+        self.min_out_size += min_branch_size;
+        self.max_out_size += max_branch_size;
+
         Ok(())
     }
 }

--- a/sw/host/ot_certs/src/asn1/der.rs
+++ b/sw/host/ot_certs/src/asn1/der.rs
@@ -11,7 +11,7 @@ use num_bigint_dig::BigUint;
 
 use crate::asn1::builder::Builder;
 use crate::asn1::{Oid, Tag};
-use crate::template::{Value, Variable};
+use crate::template::{SelectableChoice, Value, Variable};
 
 impl Tag {
     // Return the DER representation of the identifier octet(s) of a tag.
@@ -221,6 +221,13 @@ impl Builder for Der {
         }
         // Push content
         self.push_bytes(&content.output)
+    }
+
+    fn push_choices<T, F>(&mut self, _choice: &SelectableChoice<T>, _cb: F) -> Result<()>
+    where
+        F: FnMut(&mut Self, &T) -> Result<()>,
+    {
+        bail!("Der generation does not support unresolved dynamic choices")
     }
 }
 

--- a/sw/host/ot_certs/src/asn1/x509.rs
+++ b/sw/host/ot_certs/src/asn1/x509.rs
@@ -10,7 +10,8 @@ use crate::asn1::builder::{Builder, concat_suffix};
 use crate::asn1::{Oid, Tag};
 use crate::template::{
     AttributeType, BasicConstraints, Certificate, CertificateExtension, EcCurve, EcPublicKeyInfo,
-    EcdsaSignature, HashAlgorithm, KeyUsage, Name, Signature, SubjectPublicKeyInfo, Value,
+    EcdsaSignature, HashAlgorithm, KeyUsage, Name, Selectable, Signature, SubjectPublicKeyInfo,
+    Value,
 };
 
 impl HashAlgorithm {
@@ -64,6 +65,17 @@ impl AttributeType {
     }
 }
 
+fn push_selectable<B: Builder, T>(
+    builder: &mut B,
+    selectable: &Selectable<T>,
+    push_value: &mut dyn FnMut(&mut B, &T) -> Result<()>,
+) -> Result<()> {
+    match selectable {
+        Selectable::Choice(choice) => builder.push_choices(choice, push_value),
+        Selectable::Value(val) => push_value(builder, val),
+    }
+}
+
 pub struct X509;
 
 impl X509 {
@@ -72,7 +84,7 @@ impl X509 {
     pub fn push_certificate<B: Builder>(
         builder: &mut B,
         tbs_cert_var: &Value<Vec<u8>>,
-        sig: &Signature,
+        sig: &Selectable<Signature>,
     ) -> Result<()> {
         // From https://datatracker.ietf.org/doc/html/rfc5280#section-4.1:
         // Certificate  ::=  SEQUENCE  {
@@ -81,9 +93,12 @@ impl X509 {
         //   signatureValue       BIT STRING }
         builder.push_seq(Some("cert".into()), |builder| {
             builder.push_byte_array(Some("tbs".into()), tbs_cert_var)?;
-            Self::push_sig_alg_id(builder, sig)?;
-            builder.push_as_bit_string(Some("cert_sig".into()), &Tag::BitString, 0, |builder| {
-                Self::push_signature(builder, sig)
+            push_selectable(builder, sig, &mut |builder, val| {
+                let sig_val = Selectable::Value(val.clone());
+                Self::push_sig_alg_id(builder, &sig_val)?;
+                builder.push_as_bit_string(Some("cert_sig".into()), &Tag::BitString, 0, |builder| {
+                    Self::push_signature(builder, &sig_val)
+                })
             })
         })
     }
@@ -380,34 +395,36 @@ impl X509 {
 
     pub fn push_public_key_info<B: Builder>(
         builder: &mut B,
-        pubkey_info: &SubjectPublicKeyInfo,
+        pubkey_info: &Selectable<SubjectPublicKeyInfo>,
     ) -> Result<()> {
         // From https://datatracker.ietf.org/doc/html/rfc5280#section-4.1:
         // SubjectPublicKeyInfo  ::=  SEQUENCE  {
         // algorithm            AlgorithmIdentifier,
         // subjectPublicKey     BIT STRING  }
-        builder.push_seq(Some("subject_public_key_info".into()), |builder| {
-            Self::push_pubkey_alg_id(builder, pubkey_info)?;
-            builder.push_as_bit_string(
-                Some("subject_public_key".into()),
-                &Tag::BitString,
-                0,
-                |builder| Self::push_public_key(builder, pubkey_info),
-            )
+        push_selectable(builder, pubkey_info, &mut |builder, val| {
+            builder.push_seq(Some("subject_public_key_info".into()), |builder| {
+                let val_selectable = Selectable::Value(val.clone());
+                Self::push_pubkey_alg_id(builder, &val_selectable)?;
+                builder.push_as_bit_string(
+                    Some("subject_public_key".into()),
+                    &Tag::BitString,
+                    0,
+                    |builder| Self::push_public_key(builder, &val_selectable),
+                )
+            })
         })
     }
 
     pub fn push_pubkey_alg_id<B: Builder>(
         builder: &mut B,
-        pubkey_info: &SubjectPublicKeyInfo,
+        pubkey_info: &Selectable<SubjectPublicKeyInfo>,
     ) -> Result<()> {
         // From https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.1.2
         // AlgorithmIdentifier  ::=  SEQUENCE  {
         // algorithm               OBJECT IDENTIFIER,
         // parameters              ANY DEFINED BY algorithm OPTIONAL  }
-        builder.push_seq(
-            Some("subject_public_key_alg".into()),
-            |builder| match pubkey_info {
+        push_selectable(builder, pubkey_info, &mut |builder, val| {
+            builder.push_seq(Some("subject_public_key_alg".into()), |builder| match val {
                 SubjectPublicKeyInfo::EcPublicKey(ec_pubkey) => {
                     builder.push_oid(&Oid::EcPublicKey)?;
                     Self::push_ec_public_key_params(builder, ec_pubkey)
@@ -415,15 +432,15 @@ impl X509 {
                 SubjectPublicKeyInfo::Mldsa44(_) => builder.push_oid(&Oid::Mldsa44),
                 SubjectPublicKeyInfo::Mldsa65(_) => builder.push_oid(&Oid::Mldsa65),
                 SubjectPublicKeyInfo::Mldsa87(_) => builder.push_oid(&Oid::Mldsa87),
-            },
-        )
+            })
+        })
     }
 
     pub fn push_public_key<B: Builder>(
         builder: &mut B,
-        pubkey_info: &SubjectPublicKeyInfo,
+        pubkey_info: &Selectable<SubjectPublicKeyInfo>,
     ) -> Result<()> {
-        match pubkey_info {
+        push_selectable(builder, pubkey_info, &mut |builder, val| match val {
             SubjectPublicKeyInfo::EcPublicKey(ec_pubkey) => {
                 Self::push_ec_public_key(builder, ec_pubkey)
             }
@@ -432,7 +449,7 @@ impl X509 {
             | SubjectPublicKeyInfo::Mldsa87(mldsa_pubkey) => {
                 builder.push_byte_array(Some("pubkey_mldsa".into()), &mldsa_pubkey.public_key)
             }
-        }
+        })
     }
 
     pub fn push_ec_public_key_params<B: Builder>(
@@ -509,23 +526,25 @@ impl X509 {
         })
     }
 
-    pub fn push_sig_alg_id<B: Builder>(builder: &mut B, sig: &Signature) -> Result<()> {
+    pub fn push_sig_alg_id<B: Builder>(builder: &mut B, sig: &Selectable<Signature>) -> Result<()> {
         // From https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.1.2
         // AlgorithmIdentifier  ::=  SEQUENCE  {
         // algorithm               OBJECT IDENTIFIER,
         // parameters              ANY DEFINED BY algorithm OPTIONAL  }
         //
         // Per the X509 specification, the signature parameters must not contain any parameters
-        builder.push_seq(Some("algorithm_identifier".into()), |builder| match sig {
-            Signature::EcdsaWithSha256 { .. } => builder.push_oid(&Oid::EcdsaWithSha256),
-            Signature::Mldsa44 { .. } => builder.push_oid(&Oid::Mldsa44),
-            Signature::Mldsa65 { .. } => builder.push_oid(&Oid::Mldsa65),
-            Signature::Mldsa87 { .. } => builder.push_oid(&Oid::Mldsa87),
+        push_selectable(builder, sig, &mut |builder, val| {
+            builder.push_seq(Some("algorithm_identifier".into()), |builder| match val {
+                Signature::EcdsaWithSha256 { .. } => builder.push_oid(&Oid::EcdsaWithSha256),
+                Signature::Mldsa44 { .. } => builder.push_oid(&Oid::Mldsa44),
+                Signature::Mldsa65 { .. } => builder.push_oid(&Oid::Mldsa65),
+                Signature::Mldsa87 { .. } => builder.push_oid(&Oid::Mldsa87),
+            })
         })
     }
 
-    pub fn push_signature<B: Builder>(builder: &mut B, sig: &Signature) -> Result<()> {
-        match sig {
+    pub fn push_signature<B: Builder>(builder: &mut B, sig: &Selectable<Signature>) -> Result<()> {
+        push_selectable(builder, sig, &mut |builder, val| match val {
             Signature::EcdsaWithSha256 { value } => {
                 let zero = BigUint::from_u32(0).expect("cannot build BigUint from u32");
                 let empty_ecdsa = EcdsaSignature {
@@ -543,7 +562,7 @@ impl X509 {
                     value.as_ref().unwrap_or(&empty_sig),
                 )
             }
-        }
+        })
     }
 
     pub fn push_ecdsa_sig<B: Builder>(builder: &mut B, sig: &EcdsaSignature) -> Result<()> {

--- a/sw/host/ot_certs/src/codegen.rs
+++ b/sw/host/ot_certs/src/codegen.rs
@@ -622,5 +622,11 @@ fn c_variable_info(
             },
             format!("bool {name};\n"),
         ),
+        VariableType::Selector { .. } => (
+            VariableCodegenInfo::Uint32 {
+                value_expr: format!("{struct_expr}{name}"),
+            },
+            format!("    uint32_t {name};\n"),
+        ),
     }
 }

--- a/sw/host/ot_certs/src/template/mod.rs
+++ b/sw/host/ot_certs/src/template/mod.rs
@@ -54,6 +54,20 @@ pub struct Template {
     pub certificate: Certificate,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum Selectable<T> {
+    Choice(SelectableChoice<T>),
+    Value(T),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SelectableChoice<T> {
+    pub selector: String,
+    pub choices: Vec<T>,
+}
+
 /// Certificate specification.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -69,7 +83,7 @@ pub struct Certificate {
     /// X509 certificate's subject.
     pub subject: Name,
     /// X509 certificate's public key.
-    pub subject_public_key_info: SubjectPublicKeyInfo,
+    pub subject_public_key_info: Selectable<SubjectPublicKeyInfo>,
     /// X509 certificate's authority key identifier.
     pub authority_key_identifier: Option<Value<Vec<u8>>>,
     /// X509 certificate's public key identifier.
@@ -84,7 +98,7 @@ pub struct Certificate {
     #[serde(default)]
     pub private_extensions: Vec<CertificateExtension>,
     /// X509 certificate's signature.
-    pub signature: Signature,
+    pub signature: Selectable<Signature>,
 }
 
 /// An X501 Name (or DistinguishedName, aka DN): a DN consists of a sequence of
@@ -457,6 +471,8 @@ pub enum VariableType {
     },
     /// Boolean variable.
     Boolean,
+    /// Selector variable for choices.
+    Selector { num_choices: usize },
 }
 
 impl VariableType {
@@ -494,7 +510,7 @@ impl VariableType {
             ByteArray { size, .. } | String { size, .. } => size.range(),
             // The array buffer for integer should always have the maximum size.
             Integer { size, .. } => (size.range().1, size.range().1),
-            Boolean => panic!("Boolean variable has no array size"),
+            Boolean | Selector { .. } => panic!("Boolean or Selector variable has no array size"),
         }
     }
 
@@ -521,8 +537,9 @@ impl VariableType {
                 "Encoding ByteArray variable without tweak-msb as an integer is not supported"
             ),
             Integer { size, .. } => (size.range().0, size.range().1 + extra_bytes),
-            String { .. } => panic!("String variable has no integer size"),
-            Boolean => panic!("Boolean variable has no integer size"),
+            String { .. } | Boolean | Selector { .. } => {
+                panic!("String, Boolean or Selector variable has no integer size")
+            }
         }
     }
 }
@@ -576,140 +593,182 @@ impl Template {
     }
 
     fn validate_public_key(&self) -> Result<()> {
-        match &self.certificate.subject_public_key_info {
-            SubjectPublicKeyInfo::EcPublicKey(ec) => {
-                let expected_size = match ec.curve {
-                    EcCurve::Prime256v1 => 32,
-                };
-                if let Value::Variable(var) = &ec.public_key.x {
-                    self.validate_variable_size(
-                        &var.name,
-                        expected_size,
-                        "public key X coordinate",
-                    )?;
+        self.validate_selectable(&self.certificate.subject_public_key_info, |val| {
+            match val {
+                SubjectPublicKeyInfo::EcPublicKey(ec) => {
+                    let expected_size = match ec.curve {
+                        EcCurve::Prime256v1 => 32,
+                    };
+                    if let Value::Variable(var) = &ec.public_key.x {
+                        self.validate_variable_size(
+                            &var.name,
+                            expected_size,
+                            "public key X coordinate",
+                        )?;
+                    }
+                    if let Value::Variable(var) = &ec.public_key.y {
+                        self.validate_variable_size(
+                            &var.name,
+                            expected_size,
+                            "public key Y coordinate",
+                        )?;
+                    }
                 }
-                if let Value::Variable(var) = &ec.public_key.y {
-                    self.validate_variable_size(
-                        &var.name,
-                        expected_size,
-                        "public key Y coordinate",
-                    )?;
+                SubjectPublicKeyInfo::Mldsa44(mldsa) => {
+                    if let Value::Variable(var) = &mldsa.public_key {
+                        self.validate_variable_size(&var.name, 1312, "ML-DSA-44 public key")?;
+                    } else if let Value::Literal(bytes) = &mldsa.public_key {
+                        ensure!(
+                            bytes.len() == 1312,
+                            "ML-DSA-44 literal public key must be 1312 bytes, got {}",
+                            bytes.len()
+                        );
+                    }
+                }
+                SubjectPublicKeyInfo::Mldsa65(mldsa) => {
+                    if let Value::Variable(var) = &mldsa.public_key {
+                        self.validate_variable_size(&var.name, 1952, "ML-DSA-65 public key")?;
+                    } else if let Value::Literal(bytes) = &mldsa.public_key {
+                        ensure!(
+                            bytes.len() == 1952,
+                            "ML-DSA-65 literal public key must be 1952 bytes, got {}",
+                            bytes.len()
+                        );
+                    }
+                }
+                SubjectPublicKeyInfo::Mldsa87(mldsa) => {
+                    if let Value::Variable(var) = &mldsa.public_key {
+                        self.validate_variable_size(&var.name, 2592, "ML-DSA-87 public key")?;
+                    } else if let Value::Literal(bytes) = &mldsa.public_key {
+                        ensure!(
+                            bytes.len() == 2592,
+                            "ML-DSA-87 literal public key must be 2592 bytes, got {}",
+                            bytes.len()
+                        );
+                    }
                 }
             }
-            SubjectPublicKeyInfo::Mldsa44(mldsa) => {
-                if let Value::Variable(var) = &mldsa.public_key {
-                    self.validate_variable_size(&var.name, 1312, "ML-DSA-44 public key")?;
-                } else if let Value::Literal(bytes) = &mldsa.public_key {
-                    ensure!(
-                        bytes.len() == 1312,
-                        "ML-DSA-44 literal public key must be 1312 bytes, got {}",
-                        bytes.len()
-                    );
+            Ok(())
+        })
+    }
+
+    fn validate_selectable_choice<T>(&self, choice: &SelectableChoice<T>) -> Result<()> {
+        let selector = &choice.selector;
+        let var_type = self
+            .variables
+            .get(selector)
+            .with_context(|| format!("selector variable '{selector}' is not declared"))?;
+        let expected_choices = match var_type {
+            VariableType::Selector { num_choices } => *num_choices,
+            _ => bail!("selector variable '{selector}' must be a Selector"),
+        };
+        ensure!(
+            choice.choices.len() == expected_choices,
+            "selector variable '{selector}' expects {expected_choices} choices, but template has {}",
+            choice.choices.len()
+        );
+        Ok(())
+    }
+
+    fn validate_selectable<T, F>(
+        &self,
+        selectable: &Selectable<T>,
+        mut validate_value: F,
+    ) -> Result<()>
+    where
+        F: FnMut(&T) -> Result<()>,
+    {
+        match selectable {
+            Selectable::Choice(choice) => {
+                self.validate_selectable_choice(choice)?;
+                for branch in &choice.choices {
+                    validate_value(branch)?;
                 }
             }
-            SubjectPublicKeyInfo::Mldsa65(mldsa) => {
-                if let Value::Variable(var) = &mldsa.public_key {
-                    self.validate_variable_size(&var.name, 1952, "ML-DSA-65 public key")?;
-                } else if let Value::Literal(bytes) = &mldsa.public_key {
-                    ensure!(
-                        bytes.len() == 1952,
-                        "ML-DSA-65 literal public key must be 1952 bytes, got {}",
-                        bytes.len()
-                    );
-                }
-            }
-            SubjectPublicKeyInfo::Mldsa87(mldsa) => {
-                if let Value::Variable(var) = &mldsa.public_key {
-                    self.validate_variable_size(&var.name, 2592, "ML-DSA-87 public key")?;
-                } else if let Value::Literal(bytes) = &mldsa.public_key {
-                    ensure!(
-                        bytes.len() == 2592,
-                        "ML-DSA-87 literal public key must be 2592 bytes, got {}",
-                        bytes.len()
-                    );
-                }
-            }
+            Selectable::Value(val) => validate_value(val)?,
         }
         Ok(())
     }
 
     fn validate_signature(&self) -> Result<()> {
-        match &self.certificate.signature {
-            Signature::EcdsaWithSha256 { value } => {
-                if let Some(sig) = value {
-                    if let Value::Variable(var) = &sig.r {
-                        let var_type = self.variables.get(&var.name).with_context(|| {
-                            format!(
-                                "variable '{}' used in signature R is not declared",
-                                var.name
-                            )
-                        })?;
-                        let (_, max_size) = var_type.array_size();
-                        ensure!(
-                            max_size <= 32,
-                            "variable '{}' used in signature R must have max size <= 32, got {}",
-                            var.name,
-                            max_size
-                        );
+        self.validate_selectable(&self.certificate.signature, |val| {
+            match val {
+                Signature::EcdsaWithSha256 { value } => {
+                    if let Some(sig) = value {
+                        if let Value::Variable(var) = &sig.r {
+                            let var_type = self.variables.get(&var.name).with_context(|| {
+                                format!(
+                                    "variable '{}' used in signature R is not declared",
+                                    var.name
+                                )
+                            })?;
+                            let (_, max_size) = var_type.array_size();
+                            ensure!(
+                                max_size <= 32,
+                                "variable '{}' used in signature R must have max size <= 32, got {}",
+                                var.name,
+                                max_size
+                            );
+                        }
+                        if let Value::Variable(var) = &sig.s {
+                            let var_type = self.variables.get(&var.name).with_context(|| {
+                                format!(
+                                    "variable '{}' used in signature S is not declared",
+                                    var.name
+                                )
+                            })?;
+                            let (_, max_size) = var_type.array_size();
+                            ensure!(
+                                max_size <= 32,
+                                "variable '{}' used in signature S must have max size <= 32, got {}",
+                                var.name,
+                                max_size
+                            );
+                        }
                     }
-                    if let Value::Variable(var) = &sig.s {
-                        let var_type = self.variables.get(&var.name).with_context(|| {
-                            format!(
-                                "variable '{}' used in signature S is not declared",
-                                var.name
-                            )
-                        })?;
-                        let (_, max_size) = var_type.array_size();
-                        ensure!(
-                            max_size <= 32,
-                            "variable '{}' used in signature S must have max size <= 32, got {}",
-                            var.name,
-                            max_size
-                        );
+                }
+                Signature::Mldsa44 { value } => {
+                    if let Some(val) = value {
+                        if let Value::Variable(var) = val {
+                            self.validate_variable_size(&var.name, 2420, "ML-DSA-44 signature")?;
+                        } else if let Value::Literal(bytes) = val {
+                            ensure!(
+                                bytes.len() == 2420,
+                                "ML-DSA-44 literal signature must be 2420 bytes, got {}",
+                                bytes.len()
+                            );
+                        }
+                    }
+                }
+                Signature::Mldsa65 { value } => {
+                    if let Some(val) = value {
+                        if let Value::Variable(var) = val {
+                            self.validate_variable_size(&var.name, 3300, "ML-DSA-65 signature")?;
+                        } else if let Value::Literal(bytes) = val {
+                            ensure!(
+                                bytes.len() == 3300,
+                                "ML-DSA-65 literal signature must be 3300 bytes, got {}",
+                                bytes.len()
+                            );
+                        }
+                    }
+                }
+                Signature::Mldsa87 { value } => {
+                    if let Some(val) = value {
+                        if let Value::Variable(var) = val {
+                            self.validate_variable_size(&var.name, 4627, "ML-DSA-87 signature")?;
+                        } else if let Value::Literal(bytes) = val {
+                            ensure!(
+                                bytes.len() == 4627,
+                                "ML-DSA-87 literal signature must be 4627 bytes, got {}",
+                                bytes.len()
+                            );
+                        }
                     }
                 }
             }
-            Signature::Mldsa44 { value } => {
-                if let Some(val) = value {
-                    if let Value::Variable(var) = val {
-                        self.validate_variable_size(&var.name, 2420, "ML-DSA-44 signature")?;
-                    } else if let Value::Literal(bytes) = val {
-                        ensure!(
-                            bytes.len() == 2420,
-                            "ML-DSA-44 literal signature must be 2420 bytes, got {}",
-                            bytes.len()
-                        );
-                    }
-                }
-            }
-            Signature::Mldsa65 { value } => {
-                if let Some(val) = value {
-                    if let Value::Variable(var) = val {
-                        self.validate_variable_size(&var.name, 3300, "ML-DSA-65 signature")?;
-                    } else if let Value::Literal(bytes) = val {
-                        ensure!(
-                            bytes.len() == 3300,
-                            "ML-DSA-65 literal signature must be 3300 bytes, got {}",
-                            bytes.len()
-                        );
-                    }
-                }
-            }
-            Signature::Mldsa87 { value } => {
-                if let Some(val) = value {
-                    if let Value::Variable(var) = val {
-                        self.validate_variable_size(&var.name, 4627, "ML-DSA-87 signature")?;
-                    } else if let Value::Literal(bytes) = val {
-                        ensure!(
-                            bytes.len() == 4627,
-                            "ML-DSA-87 literal signature must be 4627 bytes, got {}",
-                            bytes.len()
-                        );
-                    }
-                }
-            }
-        }
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -909,13 +968,15 @@ mod tests {
                 AttributeType::SerialNumber,
                 Value::convert("owner_pub_key_id", Conversion::LowercaseHex),
             )])],
-            subject_public_key_info: SubjectPublicKeyInfo::EcPublicKey(EcPublicKeyInfo {
-                curve: EcCurve::Prime256v1,
-                public_key: EcPublicKey {
-                    x: Value::variable("owner_pub_key_ec_x"),
-                    y: Value::variable("owner_pub_key_ec_y"),
+            subject_public_key_info: Selectable::Value(SubjectPublicKeyInfo::EcPublicKey(
+                EcPublicKeyInfo {
+                    curve: EcCurve::Prime256v1,
+                    public_key: EcPublicKey {
+                        x: Value::variable("owner_pub_key_ec_x"),
+                        y: Value::variable("owner_pub_key_ec_y"),
+                    },
                 },
-            }),
+            )),
             authority_key_identifier: Some(Value::variable("signing_pub_key_id")),
             subject_key_identifier: Some(Value::variable("owner_pub_key_id")),
             basic_constraints: None,
@@ -951,12 +1012,12 @@ mod tests {
                     debug: Value::Literal(false),
                 }),
             })],
-            signature: Signature::EcdsaWithSha256 {
+            signature: Selectable::Value(Signature::EcdsaWithSha256 {
                 value: Some(EcdsaSignature {
                     r: Value::variable("cert_signature_r"),
                     s: Value::variable("cert_signature_s"),
                 }),
-            },
+            }),
         };
 
         // Compare expected and actual parsed structs.

--- a/sw/host/ot_certs/src/template/subst.rs
+++ b/sw/host/ot_certs/src/template/subst.rs
@@ -15,8 +15,8 @@ use serde::{Deserialize, Serialize};
 use crate::template::{
     BasicConstraints, Certificate, CertificateExtension, Conversion, DiceTcbInfoExtension,
     DiceTcbInfoFlags, EcPublicKey, EcPublicKeyInfo, EcdsaSignature, FirmwareId, KeyUsage,
-    MldsaPublicKeyInfo, RawOr, Signature, SizeRange, SubjectPublicKeyInfo, Template, Value,
-    Variable, VariableType,
+    MldsaPublicKeyInfo, RawOr, Selectable, SelectableChoice, Signature, SizeRange,
+    SubjectPublicKeyInfo, Template, Value, Variable, VariableType,
 };
 
 /// Substitution value: this is the raw value loaded from a hjson/json file
@@ -75,6 +75,7 @@ impl SubstValue {
             VariableType::Integer { .. } => self.parse_as_integer(var_type.size()),
             VariableType::String { .. } => self.parse_as_string(var_type.size()),
             VariableType::Boolean => self.parse_as_boolean(),
+            VariableType::Selector { num_choices } => self.parse_as_selector(num_choices),
         }
     }
 
@@ -170,6 +171,20 @@ impl SubstValue {
             },
             _ => bail!("cannot parse value {self:?} as a boolean"),
         })
+    }
+
+    fn parse_as_selector(&self, num_choices: usize) -> Result<SubstValue> {
+        let val = match self {
+            SubstValue::Uint32(x) => *x,
+            _ => bail!("cannot parse value {self:?} as a selector (must be a u32)"),
+        };
+        ensure!(
+            (val as usize) < num_choices,
+            "selector value {} out of range (max {})",
+            val,
+            num_choices - 1
+        );
+        Ok(SubstValue::Uint32(val))
     }
 }
 
@@ -593,6 +608,34 @@ where
 {
     fn subst(&self, data: &SubstData) -> Result<Option<T>> {
         self.as_ref().map(|x| x.subst(data)).transpose()
+    }
+}
+
+impl<T: Subst> Subst for Selectable<T> {
+    fn subst(&self, data: &SubstData) -> Result<Selectable<T>> {
+        match self {
+            Selectable::Value(val) => Ok(Selectable::Value(val.subst(data)?)),
+            Selectable::Choice(choice) => match data.values.get(&choice.selector) {
+                Some(val) => {
+                    let val = val.parse_as_selector(choice.choices.len())?;
+                    let index = match val {
+                        SubstValue::Uint32(x) => x as usize,
+                        _ => unreachable!(),
+                    };
+                    Ok(Selectable::Value(choice.choices[index].subst(data)?))
+                }
+                None => {
+                    let mut new_choices = Vec::new();
+                    for c in &choice.choices {
+                        new_choices.push(c.subst(data)?);
+                    }
+                    Ok(Selectable::Choice(SelectableChoice {
+                        selector: choice.selector.clone(),
+                        choices: new_choices,
+                    }))
+                }
+            },
+        }
     }
 }
 

--- a/sw/host/ot_certs/src/template/testgen.rs
+++ b/sw/host/ot_certs/src/template/testgen.rs
@@ -6,6 +6,7 @@
 //! to test corner cases of the certificate generator.
 
 use anyhow::{Result, ensure};
+use rand::Rng;
 use rand::distributions::{DistString, Distribution, Uniform};
 
 use openssl::bn::{BigNum, BigNumContext};
@@ -15,7 +16,8 @@ use openssl::pkey::Private;
 
 use crate::template::subst::{SubstData, SubstValue};
 use crate::template::{
-    EcCurve, EcPublicKeyInfo, MldsaPublicKeyInfo, SubjectPublicKeyInfo, Template, Value, Variable,
+    EcCurve, EcPublicKeyInfo, MldsaPublicKeyInfo, Selectable, SubjectPublicKeyInfo, Template,
+    Value, Variable,
 };
 
 // Convert a template curve name to an openssl one.
@@ -54,6 +56,10 @@ impl Template {
                     }
                 }
                 super::VariableType::Boolean => SubstValue::Boolean(rand::random::<bool>()),
+                super::VariableType::Selector { num_choices } => {
+                    let value = rand::thread_rng().gen_range(0..num_choices) as u32;
+                    SubstValue::Uint32(value)
+                }
             };
             data.values.insert(var.to_string(), val);
         }
@@ -115,7 +121,25 @@ impl Template {
     }
 
     fn random_public_key(&self) -> Result<SubstData> {
-        match &self.certificate.subject_public_key_info {
+        Self::random_public_key_info(&self.certificate.subject_public_key_info)
+    }
+
+    fn random_public_key_info(info: &Selectable<SubjectPublicKeyInfo>) -> Result<SubstData> {
+        match info {
+            Selectable::Choice(choice) => {
+                let mut data = SubstData::default();
+                for c in &choice.choices {
+                    data.values
+                        .extend(Self::random_public_key_info_value(c)?.values);
+                }
+                Ok(data)
+            }
+            Selectable::Value(val) => Self::random_public_key_info_value(val),
+        }
+    }
+
+    fn random_public_key_info_value(val: &SubjectPublicKeyInfo) -> Result<SubstData> {
+        match val {
             SubjectPublicKeyInfo::EcPublicKey(ec) => Self::random_ec_public_key(ec),
             SubjectPublicKeyInfo::Mldsa44(mldsa) => Self::random_mldsa_public_key(mldsa, 1312),
             SubjectPublicKeyInfo::Mldsa65(mldsa) => Self::random_mldsa_public_key(mldsa, 1952),

--- a/sw/host/ot_certs/src/template/vars.rs
+++ b/sw/host/ot_certs/src/template/vars.rs
@@ -7,11 +7,25 @@ use indexmap::IndexSet;
 use crate::template::{
     BasicConstraints, Certificate, CertificateExtension, DiceTcbInfoExtension, DiceTcbInfoFlags,
     EcPublicKey, EcPublicKeyInfo, EcdsaSignature, FirmwareId, KeyUsage, MldsaPublicKeyInfo, Name,
-    RawOr, Signature, SubjectPublicKeyInfo, Value, Variable,
+    RawOr, Selectable, Signature, SubjectPublicKeyInfo, Value, Variable,
 };
 
 pub trait ListVariables {
     fn list_variables(&self, names: &mut IndexSet<String>);
+}
+
+impl<T: ListVariables> ListVariables for Selectable<T> {
+    fn list_variables(&self, names: &mut IndexSet<String>) {
+        match self {
+            Selectable::Value(val) => val.list_variables(names),
+            Selectable::Choice(choice) => {
+                names.insert(choice.selector.clone());
+                for c in &choice.choices {
+                    c.list_variables(names);
+                }
+            }
+        }
+    }
 }
 
 impl<T> ListVariables for Value<T> {
@@ -199,6 +213,9 @@ impl Certificate {
         self.subject_alt_name.list_variables(names);
         for ext in &self.private_extensions {
             ext.list_variables(names);
+        }
+        if let Selectable::Choice(choice) = &self.signature {
+            names.insert(choice.selector.clone());
         }
     }
 }

--- a/sw/host/ot_certs/src/x509.rs
+++ b/sw/host/ot_certs/src/x509.rs
@@ -20,8 +20,8 @@ use crate::asn1::der;
 use crate::asn1::x509;
 
 use crate::template::{
-    self, AttributeType, EcCurve, EcPublicKeyInfo, EcdsaSignature, KeyUsage, Name, Signature,
-    SubjectPublicKeyInfo, Value,
+    self, AttributeType, EcCurve, EcPublicKeyInfo, EcdsaSignature, KeyUsage, Name, Selectable,
+    Signature, SubjectPublicKeyInfo, Value,
 };
 
 pub mod extension;
@@ -169,8 +169,9 @@ fn extract_signature(x509: &X509) -> Result<Signature> {
 pub fn generate_certificate_from_tbs(tbs: Vec<u8>, signature: &Signature) -> Result<Vec<u8>> {
     // Generate certificate.
     let tbs = Value::Literal(tbs);
-    let cert =
-        der::Der::generate(|builder| x509::X509::push_certificate(builder, &tbs, signature))?;
+    let cert = der::Der::generate(|builder| {
+        x509::X509::push_certificate(builder, &tbs, &Selectable::Value(signature.clone()))
+    })?;
     Ok(cert)
 }
 
@@ -271,13 +272,13 @@ pub fn parse_certificate(cert: &[u8]) -> Result<template::Certificate> {
         not_before: asn1time_to_string(x509.not_before())
             .context("cannot parse not_before time")?,
         not_after: asn1time_to_string(x509.not_after()).context("cannot parse not_after time")?,
-        subject_public_key_info,
+        subject_public_key_info: Selectable::Value(subject_public_key_info),
         authority_key_identifier: auth_key_id,
         subject_key_identifier: subj_key_id,
         basic_constraints,
         key_usage,
         subject_alt_name: get_subject_alt_name(&x509)?,
         private_extensions,
-        signature: extract_signature(&x509)?,
+        signature: Selectable::Value(extract_signature(&x509)?),
     })
 }

--- a/sw/host/ot_certs/tests/variants.hjson
+++ b/sw/host/ot_certs/tests/variants.hjson
@@ -1,0 +1,132 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+    name: "variants",
+
+    variables: {
+        pub_key_type: {
+            type: "selector",
+            num_choices: 3,
+        },
+        sig_type: {
+            type: "selector",
+            num_choices: 3,
+        },
+        serial_number: {
+            type: "integer",
+            range-size: [0, 32],
+        },
+        not_before: {
+            type: "string",
+            exact-size: 15,
+        }
+        not_after: {
+            type: "string",
+            exact-size: 15,
+        }
+        pub_key_id: {
+            type: "byte-array",
+            exact-size: 20,
+            tweak-msb: true,
+        },
+        auth_key_id: {
+            type: "byte-array",
+            exact-size: 20,
+            tweak-msb: true,
+        },
+        pub_key_ec_x: {
+            type: "integer",
+            exact-size: 32,
+        },
+        pub_key_ec_y: {
+            type: "integer",
+            exact-size: 32,
+        },
+        pub_key_mldsa_44: {
+            type: "byte-array",
+            exact-size: 1312,
+        },
+        pub_key_mldsa_87: {
+            type: "byte-array",
+            exact-size: 2592,
+        },
+        sig_ec_r: {
+            type: "integer",
+            range-size: [24, 32],
+        },
+        sig_ec_s: {
+            type: "integer",
+            range-size: [24, 32],
+        },
+        sig_mldsa_44: {
+            type: "byte-array",
+            exact-size: 2420,
+        },
+        sig_mldsa_87: {
+            type: "byte-array",
+            exact-size: 4627,
+        }
+    },
+
+    certificate: {
+        serial_number: { var: "serial_number" },
+        issuer: [
+            { common_name: "Test Issuer" },
+        ],
+        subject: [
+            { common_name: "Test Subject" },
+        ],
+        not_before: { var: "not_before" },
+        not_after: { var: "not_after" },
+        subject_public_key_info: {
+            selector: "pub_key_type",
+            choices: [
+                // 0: ECDSA
+                {
+                    algorithm: "ec-public-key",
+                    curve: "prime256v1",
+                    public_key: {
+                        x: { var: "pub_key_ec_x" },
+                        y: { var: "pub_key_ec_y" },
+                    }
+                },
+                // 1: MLDSA-44
+                {
+                    algorithm: "mldsa-44",
+                    public_key: { var: "pub_key_mldsa_44" },
+                },
+                // 2: MLDSA-87
+                {
+                    algorithm: "mldsa-87",
+                    public_key: { var: "pub_key_mldsa_87" },
+                }
+            ]
+        },
+        authority_key_identifier: { var: "auth_key_id" },
+        subject_key_identifier: { var: "pub_key_id" },
+        signature: {
+            selector: "sig_type",
+            choices: [
+                // 0: ECDSA
+                {
+                    algorithm: "ecdsa-with-sha256",
+                    value: {
+                        r: { var: "sig_ec_r" },
+                        s: { var: "sig_ec_s" }
+                    }
+                },
+                // 1: MLDSA-44
+                {
+                    algorithm: "mldsa-44",
+                    value: { var: "sig_mldsa_44" }
+                },
+                // 2: MLDSA-87
+                {
+                    algorithm: "mldsa-87",
+                    value: { var: "sig_mldsa_87" }
+                }
+            ]
+        }
+    }
+}

--- a/sw/host/ot_certs/tests/variants_test.rs
+++ b/sw/host/ot_certs/tests/variants_test.rs
@@ -1,0 +1,51 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use ot_certs::codegen::generate_cert;
+use ot_certs::template::Template;
+use ot_certs::template::subst::Subst;
+
+const VARIANTS_CERT: &str = include_str!("variants.hjson");
+
+#[test]
+fn test_variants_codegen() -> Result<()> {
+    let tmpl = Template::from_hjson_str(VARIANTS_CERT)?;
+    let codegen = generate_cert("tests/variants.hjson", &tmpl)?;
+
+    // Basic sanity checks on generated code.
+    assert!(codegen.source_h.contains("variants_tbs_values_t"));
+    assert!(codegen.source_h.contains("variants_sig_values_t"));
+    assert!(codegen.source_h.contains("variants_build_tbs"));
+    assert!(codegen.source_h.contains("variants_build_cert"));
+
+    // Check that variables are present in the struct.
+    assert!(codegen.source_h.contains("uint32_t pub_key_type;"));
+    assert!(codegen.source_h.contains("uint32_t sig_type;"));
+    assert!(codegen.source_h.contains("uint8_t *pub_key_ec_x;"));
+    assert!(codegen.source_h.contains("uint8_t *pub_key_mldsa_87;"));
+    assert!(codegen.source_h.contains("uint8_t *pub_key_mldsa_44;"));
+    assert!(codegen.source_h.contains("uint8_t *sig_mldsa_87;"));
+    assert!(codegen.source_h.contains("uint8_t *sig_mldsa_44;"));
+
+    // Check that skip helpers are generated.
+    assert!(codegen.source_c.contains("template_skip_const(&state,"));
+
+    Ok(())
+}
+
+#[test]
+fn test_variants_random_test() -> Result<()> {
+    let tmpl = Template::from_hjson_str(VARIANTS_CERT)?;
+    for i in 0..10 {
+        let random_data = tmpl.random_test()?;
+        eprintln!("Run {}: random_data = {:#?}", i, random_data);
+        // Verify substitution succeeds.
+        let subst_tmpl = tmpl.subst(&random_data)?;
+        eprintln!("Run {}: subst_tmpl = {:#?}", i, subst_tmpl);
+        // Verify DER generation succeeds.
+        let _cert = ot_certs::x509::generate_certificate(&subst_tmpl)?;
+    }
+    Ok(())
+}

--- a/sw/host/tests/attestation/attestation_test.rs
+++ b/sw/host/tests/attestation/attestation_test.rs
@@ -18,7 +18,9 @@ use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::uart::console::UartConsole;
 use opentitanlib::util::file::FromReader;
 
-use ot_certs::template::{AttributeType, CertificateExtension, Name, SubjectPublicKeyInfo, Value};
+use ot_certs::template::{
+    AttributeType, CertificateExtension, Name, Selectable, SubjectPublicKeyInfo, Value,
+};
 use ot_certs::x509;
 
 #[derive(Debug, Parser)]
@@ -68,7 +70,17 @@ fn get_base64_blob(haystack: &str, rx: &str) -> Result<Vec<u8>> {
     Ok(bin)
 }
 
-fn check_public_key(key: &SubjectPublicKeyInfo, id: &[u8], subject: &Name) -> Result<bool> {
+fn check_public_key(
+    key: &Selectable<SubjectPublicKeyInfo>,
+    id: &[u8],
+    subject: &Name,
+) -> Result<bool> {
+    let key = match key {
+        Selectable::Value(val) => val,
+        Selectable::Choice(_) => {
+            unreachable!("Selector cannot appear in parsed DER certificates")
+        }
+    };
     let material = match key {
         SubjectPublicKeyInfo::EcPublicKey(info) => {
             let mut material = Vec::new();


### PR DESCRIPTION
This PR introduces support for dynamic algorithm variants within a single certificate template. This allows a single template and device builder function to generate hybrid certificate endorsements (e.g., choosing between ML-DSA and ECDSA) based on a runtime parameter, avoiding the need for separate templates to reduce code size.

### HJSON Template Example
```json5
    variables: {
        pub_key_type: {
            type: "selector",
            num_choices: 3,
        },
        ...
    },
...
        subject_public_key_info: {
            selector: "pub_key_type",
            choices: [
                {  // 0: ECDSA
                    algorithm: "ec-public-key",
                    curve: "prime256v1",
                    public_key: {
                        x: { var: "pub_key_ec_x" },
                        y: { var: "pub_key_ec_y" },
                    }
                },
                {  // 1: MLDSA-44
                    algorithm: "mldsa-44",
                    public_key: { var: "pub_key_mldsa_44" },
                },
                {  // 2: MLDSA-87
                    algorithm: "mldsa-87",
                    public_key: { var: "pub_key_mldsa_87" },
                }
            ]
        },
```