### PR TITLE
[rom_ext] Add expected base address check for ownersw 

### DIFF
--- a/rules/manifest.bzl
+++ b/rules/manifest.bzl
@@ -103,6 +103,9 @@ def _manifest_impl(ctx):
     if ctx.attr.address_translation:
         mf["address_translation"] = ctx.attr.address_translation
 
+    if ctx.attr.manifest_base_address:
+        mf["manifest_base_address"] = ctx.attr.manifest_base_address
+
     # The binding_value, if provided, must be exactly 8 words.
     if ctx.attr.binding_value:
         if len(ctx.attr.binding_value) != 8:
@@ -229,6 +232,7 @@ _manifest = rule(
         "manuf_state_owner": attr.string(doc = "Usage constraint for silicon owner manufacturing status as a 0x-prefixed hex-encoded string"),
         "life_cycle_state": attr.string(doc = "Usage constraint for life cycle status as a 0x-prefixed hex-encoded string"),
         "address_translation": attr.string(doc = "Whether this image uses address translation as a 0x-prefixed hex-encoded string"),
+        "manifest_base_address": attr.string(doc = "Manifest base address as a 0x-prefixed hex-encoded string"),
         "identifier": attr.string(doc = "Manifest identifier as a 0x-prefixed hex-encoded string"),
         "manifest_version_major": attr.string(doc = "Manifest major version as a 0x-prefixed hex-encoded string"),
         "manifest_version_minor": attr.string(doc = "Manifest minor version as a 0x-prefixed hex-encoded string"),

--- a/sw/device/lib/testing/test_framework/ottf_common.ld
+++ b/sw/device/lib/testing/test_framework/ottf_common.ld
@@ -79,6 +79,7 @@ SECTIONS {
   INCLUDE sw/device/silicon_creator/lib/base/static_critical.ld
 
   .manifest _ottf_start_address : {
+    _manifest_base_address = .;
     KEEP(*(.manifest))
     . = ALIGN(4);
   } > ottf_flash : manifest_segment

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -109,6 +109,7 @@ enum module_ {
   X(kErrorManifestBadSignedRegion,    ERROR_(3, kModuleManifest, kInternal)), \
   X(kErrorManifestBadExtension,       ERROR_(4, kModuleManifest, kInternal)), \
   X(kErrorManifestBadVersionMajor,    ERROR_(5, kModuleManifest, kInternal)), \
+  X(kErrorManifestBadBaseAddress,     ERROR_(6, kModuleManifest, kInternal)), \
   \
   X(kErrorAlertBadIndex,              ERROR_(1, kModuleAlertHandler, kInvalidArgument)), \
   X(kErrorAlertBadClass,              ERROR_(2, kModuleAlertHandler, kInvalidArgument)), \

--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -245,7 +245,11 @@ typedef struct manifest {
    * When allocating reserved bytes, please allocate from the end of this field
    * to allow for the potential size expansion of the public key field above.
    */
-  uint32_t reserved[40];
+  uint32_t reserved[39];
+  /**
+   * Address where the manifest is expected to be loaded.
+   */
+  uint32_t manifest_base_address;
   /**
    * Address translation (hardened boolean).
    */
@@ -333,6 +337,7 @@ OT_ASSERT_MEMBER_OFFSET(manifest_t, usage_constraints, 384);
 OT_ASSERT_MEMBER_OFFSET(manifest_t, ecdsa_public_key, 432);
 OT_ASSERT_MEMBER_OFFSET(manifest_t, reserved_public_key, 496);
 OT_ASSERT_MEMBER_OFFSET(manifest_t, reserved, 656);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, manifest_base_address, 812);
 OT_ASSERT_MEMBER_OFFSET(manifest_t, address_translation, 816);
 OT_ASSERT_MEMBER_OFFSET(manifest_t, identifier, 820);
 OT_ASSERT_MEMBER_OFFSET(manifest_t, manifest_version, 824);

--- a/sw/device/silicon_creator/lib/manifest_def.c
+++ b/sw/device/silicon_creator/lib/manifest_def.c
@@ -13,6 +13,7 @@ extern char _manifest_code_start[];
 extern char _manifest_code_end[];
 extern char _manifest_entry_point[];
 extern char _manifest_address_translation[];
+extern char _manifest_base_address[];
 
 /**
  * Manifest definition.
@@ -34,6 +35,7 @@ OT_USED OT_SECTION(".manifest") static manifest_t kManifest_ = {
     .code_end = (uint32_t)_manifest_code_end,
     .entry_point = (uint32_t)_manifest_entry_point,
     .address_translation = (uint32_t)_manifest_address_translation,
+    .manifest_base_address = (uint32_t)_manifest_base_address,
 };
 
 const manifest_t *manifest_def_get(void) { return &kManifest_; }

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -98,6 +98,7 @@ cc_library(
     hdrs = ["rom_ext_boot_policy.h"],
     deps = [
         ":rom_ext_boot_policy_ptrs",
+        ":rom_ext_manifest",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:csr",

--- a/sw/device/silicon_creator/rom_ext/e2e/handoff/fault_common.ld
+++ b/sw/device/silicon_creator/rom_ext/e2e/handoff/fault_common.ld
@@ -56,6 +56,7 @@ _manifest_address_translation = (_text_start >= ORIGIN(eflash) &&
  */
 SECTIONS {
   .manifest _slot_start_address : {
+    _manifest_base_address = .;
     KEEP(*(.manifest))
     . = ALIGN(256);
   } > owner_flash

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
@@ -78,6 +78,15 @@ _POSITIONS = {
         "success": "bl0_slot = AA__\r\n",
         "otp_img": None,
     },
+    "owner_slot_a_absent_base_address": {
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
+        "romext_offset": "{rom_ext_slot_a}",
+        "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
+        "owner_offset": "{owner_slot_a}",
+        "success": "bl0_slot = AA__\r\n",
+        "otp_img": None,
+        "manifest": ":manifest_base_address_default",
+    },
     "owner_slot_b": {
         "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
         "romext_offset": "{rom_ext_slot_a}",
@@ -192,6 +201,7 @@ _POSITIONS = {
             romext_offset = position["romext_offset"],
         ),
         linker_script = position["linker_script"],
+        manifest = position.get("manifest", None),
         qemu = qemu_params(
             assemble = "{romext}@{romext_offset} {firmware}@{owner_offset}",
             binaries = {
@@ -223,6 +233,13 @@ manifest(d = {
     "name": "manifest_base_address_mismatch",
     "address_translation": hex(CONST.HARDENED_TRUE),
     "manifest_base_address": "0x10000000",
+    "identifier": hex(CONST.OWNER),
+    "visibility": ["//visibility:public"],
+})
+
+manifest(d = {
+    "name": "manifest_base_address_default",
+    "manifest_base_address": "0xa5a5a5a5",
     "identifier": hex(CONST.OWNER),
     "visibility": ["//visibility:public"],
 })
@@ -280,8 +297,49 @@ opentitan_test(
     manifest = ":manifest_base_address_mismatch",
     qemu = qemu_params(
         exit_failure = "PASS|FAIL|FAULT|BFV:.{8}",
+        # BFV:064d410d corresponds to kErrorManifestBadBaseAddress
         exit_success = "BFV:064d410d",
     ),
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
+)
+
+opentitan_test(
+    name = "bad_base_address_absent_large_rom_ext_test",
+    srcs = [":boot_test"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+        "//hw/top_earlgrey:sim_qemu_rom_ext": None,
+    },
+    fpga = fpga_params(
+        assemble = "{romext}@{romext_offset} {firmware}@{owner_offset}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_dice_mldsa_slot_a": "romext",
+        },
+        exit_failure = "PASS|FAIL|FAULT|BFV:.{8}",
+        # BFV:064d410d corresponds to kErrorManifestBadBaseAddress
+        exit_success = "BFV:064d410d",
+        owner_offset = ROM_EXT_VARIATIONS["dice_mldsa"].slot_spec["owner_slot_a"],
+        romext_offset = "0x0",
+    ),
+    manifest = ":manifest_base_address_default",
+    qemu = qemu_params(
+        assemble = "{romext}@{romext_offset} {firmware}@{owner_offset}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_dice_mldsa_slot_a": "romext",
+        },
+        exit_failure = "PASS|FAIL|FAULT|BFV:.{8}",
+        # BFV:064d410d corresponds to kErrorManifestBadBaseAddress
+        exit_success = "BFV:064d410d",
+        owner_offset = ROM_EXT_VARIATIONS["dice_mldsa"].slot_spec["owner_slot_a"],
+        romext_offset = "0x0",
+    ),
+    slot_spec = ROM_EXT_VARIATIONS["dice_mldsa"].slot_spec,
     deps = [
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
@@ -220,6 +220,14 @@ test_suite(
 )
 
 manifest(d = {
+    "name": "manifest_base_address_mismatch",
+    "address_translation": hex(CONST.HARDENED_TRUE),
+    "manifest_base_address": "0x10000000",
+    "identifier": hex(CONST.OWNER),
+    "visibility": ["//visibility:public"],
+})
+
+manifest(d = {
     "name": "bad_manifest",
     "address_translation": hex(CONST.HARDENED_FALSE),
     "identifier": hex(CONST.OWNER),
@@ -246,6 +254,33 @@ opentitan_test(
     qemu = qemu_params(
         exit_failure = "PASS|FAIL|FAULT|BFV:.{8}",
         exit_success = "BFV:054d410d",
+    ),
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
+)
+
+opentitan_test(
+    name = "bad_base_address_manifest_test",
+    srcs = [":boot_test"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+        "//hw/top_earlgrey:sim_qemu_rom_ext": None,
+    },
+    fpga = fpga_params(
+        exit_failure = "PASS|FAIL|FAULT|BFV:.{8}",
+        # Because our bad manifest has an invalid base address, we should
+        # expect kErrorManifestBadBaseAddress from the ROM_EXT.
+        exit_success = "BFV:064d410d",
+    ),
+    manifest = ":manifest_base_address_mismatch",
+    qemu = qemu_params(
+        exit_failure = "PASS|FAIL|FAULT|BFV:.{8}",
+        exit_success = "BFV:064d410d",
     ),
     deps = [
         "//sw/device/lib/base:status",

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -202,27 +202,6 @@ void rom_ext_sram_exec(owner_sram_exec_mode_t mode) {
   }
 }
 
-/**
- * These symbols are defined in
- * `opentitan/sw/device/silicon_creator/rom_ext/rom_ext.ld`, and describe the
- * location of the flash header.
- */
-extern char _owner_virtual_start_address[];
-extern char _owner_virtual_size[];
-
-/**
- * Compute the virtual address corresponding to the physical address `lma_addr`.
- *
- * @param manifest Pointer to the current manifest.
- * @param lma_addr Load address or physical address.
- * @return the computed virtual address.
- */
-OT_WARN_UNUSED_RESULT
-static uintptr_t owner_vma_get(const manifest_t *manifest, uintptr_t lma_addr) {
-  return (lma_addr - (uintptr_t)manifest +
-          (uintptr_t)_owner_virtual_start_address + (uint32_t)_rom_ext_size);
-}
-
 OT_WARN_UNUSED_RESULT
 static rom_error_t rom_ext_boot(boot_data_t *boot_data, boot_log_t *boot_log,
                                 const manifest_t *manifest,

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.c
@@ -8,6 +8,7 @@
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/manifest.h"
 #include "sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h"
+#include "sw/device/silicon_creator/rom_ext/rom_ext_manifest.h"
 
 rom_ext_boot_policy_manifests_t rom_ext_boot_policy_manifests_get(
     const boot_data_t *boot_data) {
@@ -61,6 +62,23 @@ static inline rom_error_t manifest_check_rom_ext(const manifest_t *manifest) {
   return kErrorOk;
 }
 
+static rom_error_t manifest_base_address_check(const manifest_t *manifest) {
+  uintptr_t actual_base = (uintptr_t)manifest;
+  uintptr_t expected_base = (uintptr_t)manifest->manifest_base_address;
+  // For backward compatibility, skip the check if the expected base address
+  // is the default unset value (0xa5a5a5a5) and the ROM_EXT size is 64KB.
+  if (expected_base == 0xa5a5a5a5 && (uintptr_t)_rom_ext_size == 0x10000) {
+    return kErrorOk;
+  }
+  if (manifest->address_translation == kHardenedBoolTrue) {
+    actual_base = owner_vma_get(manifest, (uintptr_t)manifest);
+  }
+  if (expected_base != actual_base) {
+    return kErrorManifestBadBaseAddress;
+  }
+  return kErrorOk;
+}
+
 rom_error_t rom_ext_boot_policy_manifest_check(const manifest_t *manifest,
                                                const boot_data_t *boot_data) {
   if (manifest->identifier != CHIP_BL0_IDENTIFIER) {
@@ -82,6 +100,7 @@ rom_error_t rom_ext_boot_policy_manifest_check(const manifest_t *manifest,
                     boot_data->min_security_version_bl0);
 
   RETURN_IF_ERROR(manifest_check_rom_ext(manifest));
+  RETURN_IF_ERROR(manifest_base_address_check(manifest));
   return kErrorOk;
 }
 

--- a/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
@@ -64,6 +64,7 @@ REGION_ALIAS("coverage_flash", rom_ext_flash);
  */
 SECTIONS {
   .manifest _rom_ext_start_address : {
+    _manifest_base_address = .;
     KEEP(*(.manifest))
     . = ALIGN(4);
   } > rom_ext_flash

--- a/sw/device/silicon_creator/rom_ext/rom_ext_manifest.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_manifest.c
@@ -21,3 +21,6 @@ const manifest_t *rom_ext_manifest(void) {
   pc &= ~((uintptr_t)kFlashHalf - 1);
   return (const manifest_t *)pc;
 }
+
+// Extern declarations for the inline functions in the header.
+extern uintptr_t owner_vma_get(const manifest_t *manifest, uintptr_t lma_addr);

--- a/sw/device/silicon_creator/rom_ext/rom_ext_manifest.h
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_manifest.h
@@ -5,6 +5,8 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_ROM_EXT_MANIFEST_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_ROM_EXT_MANIFEST_H_
 
+#include <stddef.h>
+
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/manifest.h"
 
@@ -17,6 +19,28 @@ extern "C" {
  */
 OT_WARN_UNUSED_RESULT
 const manifest_t *rom_ext_manifest(void);
+
+/**
+ * These symbols are defined in
+ * `opentitan/sw/device/silicon_creator/rom_ext/rom_ext.ld`, and describe the
+ * location of the flash header.
+ */
+extern char _owner_virtual_start_address[];
+extern char _owner_virtual_size[];
+extern char _rom_ext_size[];
+
+/**
+ * Compute the virtual address corresponding to the physical address `lma_addr`.
+ *
+ * @param manifest Pointer to the current manifest.
+ * @param lma_addr Load address or physical address.
+ * @return the computed virtual address.
+ */
+OT_WARN_UNUSED_RESULT
+inline uintptr_t owner_vma_get(const manifest_t *manifest, uintptr_t lma_addr) {
+  return (lma_addr - (uintptr_t)manifest +
+          (uintptr_t)_owner_virtual_start_address + (uint32_t)_rom_ext_size);
+}
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/silicon_owner/bare_metal/bare_metal_common.ld
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_common.ld
@@ -58,6 +58,7 @@ REGION_ALIAS("coverage_flash", owner_flash);
  */
 SECTIONS {
   .manifest _slot_start_address : {
+    _manifest_base_address = .;
     KEEP(*(.manifest))
     . = ALIGN(256);
   } > owner_flash

--- a/sw/host/opentitanlib/src/image/manifest.rs
+++ b/sw/host/opentitanlib/src/image/manifest.rs
@@ -94,7 +94,8 @@ pub struct Manifest {
     pub usage_constraints: ManifestUsageConstraints,
     pub pub_key: SigverifyBuffer,
     pub reserved_public_key: ReservedBuffer<160>,
-    pub reserved: ReservedBuffer<160>,
+    pub reserved: ReservedBuffer<156>,
+    pub manifest_base_address: u32,
     pub address_translation: u32,
     pub identifier: u32,
     pub manifest_version: ManifestVersion,
@@ -315,6 +316,7 @@ mod tests {
         assert_eq!(offset_of!(Manifest, pub_key), 432);
         assert_eq!(offset_of!(Manifest, reserved_public_key), 496);
         assert_eq!(offset_of!(Manifest, reserved), 656);
+        assert_eq!(offset_of!(Manifest, manifest_base_address), 812);
         assert_eq!(offset_of!(Manifest, address_translation), 816);
         assert_eq!(offset_of!(Manifest, identifier), 820);
         assert_eq!(offset_of!(Manifest, manifest_version), 824);

--- a/sw/host/opentitanlib/src/image/manifest_def.rs
+++ b/sw/host/opentitanlib/src/image/manifest_def.rs
@@ -252,6 +252,9 @@ pub struct ManifestSpec {
     pub_key: ManifestSigverifyBigInt,
 
     #[serde(default)]
+    manifest_base_address: ManifestSmallInt<u32>,
+
+    #[serde(default)]
     address_translation: ManifestSmallInt<u32>,
 
     #[serde(default)]
@@ -312,6 +315,11 @@ impl ManifestPacked<Manifest> for ManifestSpec {
             pub_key: self.pub_key.unpack("pub_key")?.try_into()?,
             reserved_public_key: Default::default(),
             reserved: Default::default(),
+            manifest_base_address: self
+                .manifest_base_address
+                .0
+                .map(|v| v.0)
+                .unwrap_or(0xa5a5a5a5),
             address_translation: self.address_translation.unpack("address_translation")?,
             identifier: self.identifier.unpack("identifier")?,
             manifest_version: self.manifest_version.unpack("manifest_version")?,
@@ -334,6 +342,8 @@ impl ManifestPacked<Manifest> for ManifestSpec {
         self.signature.overwrite(o.signature);
         self.usage_constraints.overwrite(o.usage_constraints);
         self.pub_key.overwrite(o.pub_key);
+        self.manifest_base_address
+            .overwrite(o.manifest_base_address);
         self.address_translation.overwrite(o.address_translation);
         self.identifier.overwrite(o.identifier);
         self.manifest_version.overwrite(o.manifest_version);
@@ -370,6 +380,7 @@ impl TryFrom<&Manifest> for ManifestSpec {
             signature: (&o.signature).try_into()?,
             usage_constraints: (&o.usage_constraints).try_into()?,
             pub_key: (&o.pub_key).try_into()?,
+            manifest_base_address: (&o.manifest_base_address).into(),
             address_translation: (&o.address_translation).into(),
             identifier: (&o.identifier).into(),
             manifest_version: (&o.manifest_version).try_into()?,


### PR DESCRIPTION
A new field named `manifest_base_address` is introduced in the OwnerSw manifest header to reject validly signed but misplaced OwnerSw images. ROM_EXT validates that the physical execution PC address matches this field prior to boot.

Context: For the ML-DSA-enabled eg100 SKU, the ROM_EXT will be larger, shifting the OwnerSw accordingly.

---

Backport note: This field is added to all manifests, including ROM_EXT's. After backporting to master, we can also add a similar check in v2 ROM to reject misplaced ROM_EXT.