### PR TITLE
[top_earlgrey] Update device ID and JTAG IDCODE

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2367,7 +2367,7 @@
       {
         SecVolatileRawUnlockEn: top_pkg::SecVolatileRawUnlockEn
         SiliconCreatorId: 16'h 4001
-        ProductId: 16'h 0002
+        ProductId: 16'h 0010
         RevisionId: 8'h 01
         IdcodeValue: jtag_id_pkg::LC_CTRL_JTAG_IDCODE
         EscNumSeverities: AlertHandlerEscNumSeverities
@@ -2422,7 +2422,7 @@
           name: ProductId
           desc: Chip revision number.
           type: logic [15:0]
-          default: 16'h 0002
+          default: 16'h 0010
           local: "false"
           expose: "true"
           name_top: LcCtrlProductId

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -438,7 +438,7 @@
         // The following three values get exposed in the life cycle CSRs
         // that are also readable via the TAP.
         SiliconCreatorId: "16'h 4001", // Creator ID for Earlgrey discrete integration
-        ProductId: "16'h 0002", // Earlgrey PROD
+        ProductId: "16'h 0010", // Earlgrey 2
         RevisionId: "8'h 01",   // First tapeout
         IdcodeValue: "jtag_id_pkg::LC_CTRL_JTAG_IDCODE",
         EscNumSeverities: "AlertHandlerEscNumSeverities",

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -35,7 +35,7 @@ module top_earlgrey #(
   parameter bit SecLcCtrlVolatileRawUnlockEn = top_pkg::SecVolatileRawUnlockEn,
   parameter bit LcCtrlUseDmiInterface = 0,
   parameter logic [15:0] LcCtrlSiliconCreatorId = 16'h 4001,
-  parameter logic [15:0] LcCtrlProductId = 16'h 0002,
+  parameter logic [15:0] LcCtrlProductId = 16'h 0010,
   parameter logic [7:0] LcCtrlRevisionId = 8'h 01,
   parameter logic [31:0] LcCtrlIdcodeValue = jtag_id_pkg::LC_CTRL_JTAG_IDCODE,
   // parameters for alert_handler

--- a/hw/top_earlgrey/rtl/jtag_id_pkg.sv
+++ b/hw/top_earlgrey/rtl/jtag_id_pkg.sv
@@ -8,7 +8,7 @@ package jtag_id_pkg;
   // lowRISC JEDEC Manufacturer ID, bank 13 0xEF
   localparam logic [10:0] JEDEC_MANUFACTURER_ID = {4'd12, 7'b110_1111};
   localparam logic [3:0] JTAG_VERSION = 4'h1;
-  localparam logic [11:0] PART_TYPE = 12'h0;
+  localparam logic [11:0] PART_TYPE = 12'h2;
 
   // These are the open source facing JTAG values that silicon creators may wish to replace We have
   // two TAPs, one for rv_dm and the other for lc_ctrl, they each have their own JTAG_IDCODE.  They

--- a/sw/host/tests/chip/rv_dm/src/control_status.rs
+++ b/sw/host/tests/chip/rv_dm/src/control_status.rs
@@ -17,7 +17,7 @@ struct Opts {
 }
 
 // Needs to match util/openocd/target
-const RISCV_IDCODE: u32 = 0x10001cdf;
+const RISCV_IDCODE: u32 = 0x10021cdf;
 
 fn test_control_status(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     transport.pin_strapping("PINMUX_TAP_RISCV")?.apply()?;

--- a/sw/host/tests/chip/rv_dm/src/dtm.rs
+++ b/sw/host/tests/chip/rv_dm/src/dtm.rs
@@ -17,7 +17,7 @@ struct Opts {
 }
 
 // Needs to match util/openocd/target
-const RISCV_IDCODE: u32 = 0x10001cdf;
+const RISCV_IDCODE: u32 = 0x10021cdf;
 
 #[allow(clippy::unusual_byte_groupings)]
 fn test_dtm(opts: &Opts, transport: &TransportWrapper) -> Result<()> {

--- a/sw/host/tests/chip/rv_dm/src/jtag.rs
+++ b/sw/host/tests/chip/rv_dm/src/jtag.rs
@@ -16,7 +16,7 @@ struct Opts {
 }
 
 // Needs to match util/openocd/target
-const RISCV_IDCODE: u32 = 0x10001cdf;
+const RISCV_IDCODE: u32 = 0x10021cdf;
 
 fn test_jtag(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     // Avoid watchdog timeout by entering bootstrap mode.

--- a/sw/host/tests/chip/rv_dm/src/ndm_reset_req.rs
+++ b/sw/host/tests/chip/rv_dm/src/ndm_reset_req.rs
@@ -24,7 +24,7 @@ struct Opts {
 }
 
 // Needs to match util/openocd/target
-const RISCV_IDCODE: u32 = 0x10001cdf;
+const RISCV_IDCODE: u32 = 0x10021cdf;
 
 fn test_ndm_reset_req(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     // This test requires RV_DM access so first strap and reset.

--- a/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
@@ -39,7 +39,12 @@ struct Opts {
     jedec_id: u8,
 
     /// JEDEC manufacturer product ID.
-    #[arg(long, value_parser = u8::from_str, default_value = "0x29")]
+    /// This ID consists of the following fields:
+    /// [[4 LSBs of ProductId] [1] [3 LSBs of RevisionId]]
+    /// For details, see also
+    /// - spi_device_init() in sw/device/silicon_creator/lib/drivers/spi_device.c, and
+    /// - ProductId and RevisionId in the top-level hjson file.
+    #[arg(long, value_parser = u8::from_str, default_value = "0x09")]
     jedec_product: u8,
 
     /// Size of the internal flash.

--- a/util/openocd/target/lowrisc-earlgrey-lc.cfg
+++ b/util/openocd/target/lowrisc-earlgrey-lc.cfg
@@ -21,7 +21,7 @@ if { [info exists CPUTAPID ] } {
    set _CPUTAPID $CPUTAPID
 } else {
    # Defined in `hw/top_earlgrey/rtl/jtag_id_pkg.sv`.
-   set _CPUTAPID 0x10002cdf
+   set _CPUTAPID 0x10022cdf
 }
 
 jtag newtap $_CHIPNAME tap -irlen 5 -expected-id $_CPUTAPID -ignore-bypass

--- a/util/openocd/target/lowrisc-earlgrey.cfg
+++ b/util/openocd/target/lowrisc-earlgrey.cfg
@@ -14,7 +14,7 @@ if { [info exists CPUTAPID ] } {
    set _CPUTAPID $CPUTAPID
 } else {
    # Defined in `hw/top_earlgrey/rtl/jtag_id_pkg.sv`.
-   set _CPUTAPID 0x10001cdf
+   set _CPUTAPID 0x10021cdf
 }
 
 jtag newtap $_CHIPNAME tap -irlen 5 -expected-id $_CPUTAPID


### PR DESCRIPTION
Device ID and JTAG IDCODE for the second generation of Earl Grey have been agreed by partners. This PR implements the corresponding changes.