### PR TITLE
[rom_ext] Move `load_attestation_keygen_seed()` to a dedicated library

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -498,6 +498,7 @@ cc_library(
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
         "//sw/device/silicon_creator/lib/base:util",
+        "//sw/device/silicon_creator/lib/cert:seeds",
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/lib/drivers:hmac",
         "//sw/device/silicon_creator/lib/drivers:keymgr",

--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -262,6 +262,17 @@ cc_library(
 )
 
 cc_library(
+    name = "seeds",
+    srcs = ["seeds.c"],
+    hdrs = ["seeds.h"],
+    deps = [
+        "//sw/device/silicon_creator/lib:attestation",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+    ],
+)
+
+cc_library(
     name = "dice_chain",
     srcs = ["dice_chain.c"],
     hdrs = ["dice_chain.h"],

--- a/sw/device/silicon_creator/lib/cert/seeds.c
+++ b/sw/device/silicon_creator/lib/cert/seeds.c
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/cert/seeds.h"
+
+#include <string.h>
+
+#include "sw/device/silicon_creator/lib/attestation.h"
+#include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
+
+rom_error_t load_attestation_keygen_seed(uint32_t additional_seed_idx,
+                                         uint32_t *seed) {
+  uint32_t seed_flash_offset =
+      0 + (additional_seed_idx * kAttestationSeedBytes);
+  rom_error_t err =
+      flash_ctrl_info_read(&kFlashCtrlInfoPageAttestationKeySeeds,
+                           seed_flash_offset, kAttestationSeedWords, seed);
+
+  if (err != kErrorOk) {
+    flash_ctrl_error_code_t flash_ctrl_err_code;
+    flash_ctrl_error_code_get(&flash_ctrl_err_code);
+    if (flash_ctrl_err_code.rd_err) {
+      // If we encountered a read error, this means the attestation seed page
+      // has not been provisioned yet. Clear the seed and continue.
+      memset(seed, 0, kAttestationSeedBytes);
+      return kErrorOk;
+    }
+    return err;
+  }
+
+  return kErrorOk;
+}

--- a/sw/device/silicon_creator/lib/cert/seeds.h
+++ b/sw/device/silicon_creator/lib/cert/seeds.h
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_SEEDS_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_SEEDS_H_
+
+#include <stdint.h>
+
+#include "sw/device/silicon_creator/lib/error.h"
+
+/**
+ * Loads the factory attestation keygen seed from the flash info page.
+ *
+ * @param additional_seed_idx Index of the seed (0 for UDS, 1 for CDI_0, etc.)
+ * @param[out] seed Output buffer of size kAttestationSeedWords (10 words / 320
+ * bits).
+ * @return Error code.
+ */
+rom_error_t load_attestation_keygen_seed(uint32_t additional_seed_idx,
+                                         uint32_t *seed);
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_SEEDS_H_

--- a/sw/device/silicon_creator/lib/otbn_boot_services.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.c
@@ -8,6 +8,7 @@
 #include "sw/device/silicon_creator/lib/attestation.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/base/util.h"
+#include "sw/device/silicon_creator/lib/cert/seeds.h"
 #include "sw/device/silicon_creator/lib/dbg_print.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
@@ -79,32 +80,6 @@ enum {
        kScOtbnWideWordNumWords) *
       kScOtbnWideWordNumWords,
 };
-
-OT_WARN_UNUSED_RESULT
-static rom_error_t load_attestation_keygen_seed(uint32_t additional_seed_idx,
-                                                uint32_t *seed) {
-  // Read seed from flash info page.
-  uint32_t seed_flash_offset =
-      0 + (additional_seed_idx * kAttestationSeedBytes);
-  rom_error_t err =
-      flash_ctrl_info_read(&kFlashCtrlInfoPageAttestationKeySeeds,
-                           seed_flash_offset, kAttestationSeedWords, seed);
-
-  if (err != kErrorOk) {
-    flash_ctrl_error_code_t flash_ctrl_err_code;
-    flash_ctrl_error_code_get(&flash_ctrl_err_code);
-    if (flash_ctrl_err_code.rd_err) {
-      // If we encountered a read error, this means the attestation seed page
-      // has not been provisioned yet. In this case, we clear the seed and
-      // continue, which will simply result in generating an invalid identity.
-      memset(seed, 0, kAttestationSeedBytes);
-      return kErrorOk;
-    }
-    return err;
-  }
-
-  return kErrorOk;
-}
 
 rom_error_t otbn_boot_app_load(void) { return sc_otbn_load_app(kOtbnAppBoot); }
 


### PR DESCRIPTION
Move the `load_attestation_keygen_seed` function out of `otbn_boot_services.c` into a new `seeds` library in `silicon_creator/lib/cert`.

This decouples key generation seed loading from OTBN boot services, allowing other components (e.g. MLDSA signing) to retrieve attestation keygen seeds using this function.