### PR TITLE
[dice] Add ML-DSA DICE keys and keymgr parameters

### DIFF
--- a/sw/device/silicon_creator/lib/cert/dice_keys.c
+++ b/sw/device/silicon_creator/lib/cert/dice_keys.c
@@ -73,3 +73,72 @@ const sc_keymgr_ecc_key_t kDiceKeyCdi1 = {
     .keymgr_diversifier = &kCdi1KeymgrDiversifier,
     .required_keymgr_state = kScKeymgrStateOwnerKey,
 };
+
+// ML-DSA UDS attestation key diversifier constants.
+const sc_keymgr_diversification_t kMldsaUdsKeymgrDiversifier = {
+    .salt =
+        {
+            0xc4fb8ad2,
+            0x878bfacc,
+            0x54316606,
+            0xb1b3fa6d,
+            0x618bbe59,
+            0xd5d00230,
+            0x6cf238bb,
+            0x856c60e4,
+        },
+    .version = 0,
+};
+
+// ML-DSA CDI_0 attestation key diversifier constants.
+const sc_keymgr_diversification_t kMldsaCdi0KeymgrDiversifier = {
+    .salt =
+        {
+            0xf98bbbb7,
+            0x764f8423,
+            0x176255bd,
+            0x6c8b2427,
+            0xd1b628a8,
+            0x0fc92ed6,
+            0xdaf741eb,
+            0x36007c3c,
+        },
+    .version = 0,
+};
+
+// ML-DSA CDI_1 attestation key diversifier constants.
+const sc_keymgr_diversification_t kMldsaCdi1KeymgrDiversifier = {
+    .salt =
+        {
+            0xe2fe21da,
+            0xa17996a4,
+            0x286270ae,
+            0x1d020db2,
+            0x3f4d1cf9,
+            0xe7b5b364,
+            0x4eed9d65,
+            0x4069cd9e,
+        },
+    .version = 0,
+};
+
+const sc_keymgr_ecc_key_t kDiceKeyMldsaUds = {
+    .type = kScKeymgrKeyTypeAttestation,
+    .keygen_seed_idx = kFlashInfoFieldMldsaUdsKeySeedIdx,
+    .keymgr_diversifier = &kMldsaUdsKeymgrDiversifier,
+    .required_keymgr_state = kScKeymgrStateCreatorRootKey,
+};
+
+const sc_keymgr_ecc_key_t kDiceKeyMldsaCdi0 = {
+    .type = kScKeymgrKeyTypeAttestation,
+    .keygen_seed_idx = kFlashInfoFieldMldsaCdi0KeySeedIdx,
+    .keymgr_diversifier = &kMldsaCdi0KeymgrDiversifier,
+    .required_keymgr_state = kScKeymgrStateOwnerIntermediateKey,
+};
+
+const sc_keymgr_ecc_key_t kDiceKeyMldsaCdi1 = {
+    .type = kScKeymgrKeyTypeAttestation,
+    .keygen_seed_idx = kFlashInfoFieldMldsaCdi1KeySeedIdx,
+    .keymgr_diversifier = &kMldsaCdi1KeymgrDiversifier,
+    .required_keymgr_state = kScKeymgrStateOwnerKey,
+};

--- a/sw/device/silicon_creator/lib/cert/dice_keys.h
+++ b/sw/device/silicon_creator/lib/cert/dice_keys.h
@@ -11,4 +11,8 @@ extern const sc_keymgr_ecc_key_t kDiceKeyUds;
 extern const sc_keymgr_ecc_key_t kDiceKeyCdi0;
 extern const sc_keymgr_ecc_key_t kDiceKeyCdi1;
 
+extern const sc_keymgr_ecc_key_t kDiceKeyMldsaUds;
+extern const sc_keymgr_ecc_key_t kDiceKeyMldsaCdi0;
+extern const sc_keymgr_ecc_key_t kDiceKeyMldsaCdi1;
+
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_DICE_KEYS_H_

--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
@@ -100,6 +100,9 @@ enum {
   kFlashInfoFieldCdi0KeySeedIdx = 1,
   kFlashInfoFieldCdi1KeySeedIdx = 2,
   kFlashInfoFieldTpmEkKeySeedIdx = 3,
+  kFlashInfoFieldMldsaUdsKeySeedIdx = 4,
+  kFlashInfoFieldMldsaCdi0KeySeedIdx = 5,
+  kFlashInfoFieldMldsaCdi1KeySeedIdx = 6,
 };
 
 // Info Page 0 fields.


### PR DESCRIPTION
This PR adds the definitions, keymgr diversification constants (salts), and DICE key parameters for ML-DSA UDS, CDI_0, and CDI_1.

#### Key Changes
1.  **DICE Keys (`sw/device/silicon_creator/lib/cert/dice_keys.c`, `dice_keys.h`)**:
    *   Defined ML-DSA keymgr diversification constants (`kMldsaUdsKeymgrDiversifier`, `kMldsaCdi0KeymgrDiversifier`, `kMldsaCdi1KeymgrDiversifier`).
    *   Defined `sc_keymgr_ecc_key_t` structures for ML-DSA UDS, CDI_0, and CDI_1 keys, linking them to their respective flash info seed indexes and diversifiers.
2.  **Flash Info Fields (`sw/device/silicon_creator/manuf/lib/flash_info_fields.h`)**:
    *   Added new seed indexes for ML-DSA keys:
        *   `kFlashInfoFieldMldsaUdsKeySeedIdx = 4`
        *   `kFlashInfoFieldMldsaCdi0KeySeedIdx = 5`
        *   `kFlashInfoFieldMldsaCdi1KeySeedIdx = 6`