### PR TITLE
[sw,keymgr] Add support for generating software output keys

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/keymgr.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.c
@@ -245,6 +245,58 @@ rom_error_t sc_keymgr_generate_key(
   return keymgr_wait_until_done();
 }
 
+rom_error_t sc_keymgr_generate_key_sw(
+    sc_keymgr_key_type_t key_type, sc_keymgr_diversification_t diversification,
+    keymgr_binding_value_t *key_out) {
+  HARDENED_RETURN_IF_ERROR(keymgr_is_idle());
+
+  uint32_t ctrl = 0;
+
+  // Software key generation has no HW destination.
+  ctrl = bitfield_field32_write(0, KEYMGR_CONTROL_SHADOWED_DEST_SEL_FIELD,
+                                KEYMGR_CONTROL_SHADOWED_DEST_SEL_VALUE_NONE);
+
+  // Select the attestation CDI.
+  if (key_type == kScKeymgrKeyTypeAttestation) {
+    ctrl =
+        bitfield_bit32_write(ctrl, KEYMGR_CONTROL_SHADOWED_CDI_SEL_BIT, true);
+  }
+
+  // Select the "generate software output" operation.
+  ctrl = bitfield_field32_write(
+      ctrl, KEYMGR_CONTROL_SHADOWED_OPERATION_FIELD,
+      KEYMGR_CONTROL_SHADOWED_OPERATION_VALUE_GENERATE_SW_OUTPUT);
+
+  // Write the control register.
+  abs_mmio_write32_shadowed(kBase + KEYMGR_CONTROL_SHADOWED_REG_OFFSET, ctrl);
+
+  // Set the version.
+  abs_mmio_write32(kBase + KEYMGR_KEY_VERSION_REG_OFFSET,
+                   diversification.version);
+  // Set the salt.
+  for (size_t i = 0; i < kScKeymgrSaltNumWords; i++) {
+    abs_mmio_write32(kBase + KEYMGR_SALT_0_REG_OFFSET + (i * sizeof(uint32_t)),
+                     diversification.salt[i]);
+  }
+
+  // Issue the start command.
+  abs_mmio_write32(kBase + KEYMGR_START_REG_OFFSET, 1 << KEYMGR_START_EN_BIT);
+
+  // Block until keymgr is done.
+  HARDENED_RETURN_IF_ERROR(keymgr_wait_until_done());
+
+  // Read the software output shares and XOR them to reconstruct the seed.
+  for (size_t i = 0; i < kScKeymgrSaltNumWords; i++) {
+    uint32_t share0 = abs_mmio_read32(
+        kBase + KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + (i * sizeof(uint32_t)));
+    uint32_t share1 = abs_mmio_read32(
+        kBase + KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + (i * sizeof(uint32_t)));
+    key_out->data[i] = share0 ^ share1;
+  }
+
+  return kErrorOk;
+}
+
 rom_error_t sc_keymgr_sideload_clear(sc_keymgr_dest_t destination) {
   HARDENED_RETURN_IF_ERROR(keymgr_is_idle());
 

--- a/sw/device/silicon_creator/lib/drivers/keymgr.h
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.h
@@ -249,6 +249,22 @@ rom_error_t sc_keymgr_generate_key(sc_keymgr_dest_t destination,
                                    sc_keymgr_diversification_t diversification);
 
 /**
+ * Generate a versioned software output key from the key manager.
+ *
+ * Calls the key manager to generate a software output key, reads the shares,
+ * and XORs them to reconstruct the final seed.
+ *
+ * @param key_type Key type: attestation or sealing.
+ * @param diversification Diversification input for the key derivation.
+ * @param[out] key_out Reconstructed software key.
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sc_keymgr_generate_key_sw(
+    sc_keymgr_key_type_t key_type, sc_keymgr_diversification_t diversification,
+    keymgr_binding_value_t *key_out);
+
+/**
  * Clear the requested sideloaded key slot.
  *
  * The entropy complex needs to be initialized before calling this function, so

--- a/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
@@ -126,6 +126,17 @@ class KeymgrTest : public rom_test::RomTest {
     EXPECT_ABS_READ32(base_ + KEYMGR_OP_STATUS_REG_OFFSET, end_status);
     EXPECT_ABS_WRITE32(base_ + KEYMGR_OP_STATUS_REG_OFFSET, end_status);
   }
+  void ExpectSwKeyRead(const keymgr_binding_value_t &share0,
+                       const keymgr_binding_value_t &share1) {
+    for (size_t i = 0; i < kScKeymgrSaltNumWords; ++i) {
+      EXPECT_ABS_READ32(
+          base_ + KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + i * sizeof(uint32_t),
+          share0.data[i]);
+      EXPECT_ABS_READ32(
+          base_ + KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET + i * sizeof(uint32_t),
+          share1.data[i]);
+    }
+  }
   uint32_t base_ = TOP_EARLGREY_KEYMGR_BASE_ADDR;
   SwBindingCfg cfg_ = {
       .max_key_ver = 0xA5A5A5A5,
@@ -322,6 +333,148 @@ TEST_F(KeymgrTest, GenOtbnKeyError) {
 
   EXPECT_EQ(sc_keymgr_generate_key_otbn(kScKeymgrKeyTypeAttestation,
                                         test_diversification),
+            kErrorKeymgrInternal);
+}
+
+TEST_F(KeymgrTest, GenSwAttestationKey) {
+  sc_keymgr_diversification_t test_diversification = {
+      .salt = {0xf0f1f2f3, 0xf4f5f6f7, 0xf8f9fafb, 0xfcfdfeff, 0xd0d1d2d3,
+               0xd4d5d6d7, 0xd8d9dadb, 0xdcdddedf},
+      .version = cfg_.max_key_ver - 1,
+  };
+  keymgr_binding_value_t share0 = {
+      .data = {0x01020304, 0x05060708, 0x090a0b0c, 0x0d0e0f00, 0x11121314,
+               0x15161718, 0x191a1b1c, 0x1d1e1f10},
+  };
+  keymgr_binding_value_t share1 = {
+      .data = {0xf1f2f3f4, 0xf5f6f7f8, 0xf9fafbfc, 0xfdfeff00, 0xe1e2e3e4,
+               0xe5e6e7e8, 0xe9eaebec, 0xedeeeff0},
+  };
+
+  ExpectIdleCheck(KEYMGR_OP_STATUS_STATUS_VALUE_IDLE);
+  EXPECT_ABS_WRITE32_SHADOWED(
+      base_ + KEYMGR_CONTROL_SHADOWED_REG_OFFSET,
+      {
+          {KEYMGR_CONTROL_SHADOWED_DEST_SEL_OFFSET,
+           KEYMGR_CONTROL_SHADOWED_DEST_SEL_VALUE_NONE},
+          {KEYMGR_CONTROL_SHADOWED_CDI_SEL_BIT, true},
+          {KEYMGR_CONTROL_SHADOWED_OPERATION_OFFSET,
+           KEYMGR_CONTROL_SHADOWED_OPERATION_VALUE_GENERATE_SW_OUTPUT},
+      });
+  ExpectDiversificationWrite(test_diversification);
+  EXPECT_ABS_WRITE32(base_ + KEYMGR_START_REG_OFFSET,
+                     {
+                         {KEYMGR_START_EN_BIT, true},
+                     });
+  ExpectWaitUntilDone(/*busy_cycles=*/2,
+                      KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+  ExpectSwKeyRead(share0, share1);
+
+  keymgr_binding_value_t key_out;
+  EXPECT_EQ(sc_keymgr_generate_key_sw(kScKeymgrKeyTypeAttestation,
+                                      test_diversification, &key_out),
+            kErrorOk);
+  for (size_t i = 0; i < kScKeymgrSaltNumWords; ++i) {
+    EXPECT_EQ(key_out.data[i], share0.data[i] ^ share1.data[i]);
+  }
+}
+
+TEST_F(KeymgrTest, GenSwSealingKey) {
+  sc_keymgr_diversification_t test_diversification = {
+      .salt = {0xf0f1f2f3, 0xf4f5f6f7, 0xf8f9fafb, 0xfcfdfeff, 0xd0d1d2d3,
+               0xd4d5d6d7, 0xd8d9dadb, 0xdcdddedf},
+      .version = cfg_.max_key_ver - 1,
+  };
+  keymgr_binding_value_t share0 = {
+      .data = {0x01020304, 0x05060708, 0x090a0b0c, 0x0d0e0f00, 0x11121314,
+               0x15161718, 0x191a1b1c, 0x1d1e1f10},
+  };
+  keymgr_binding_value_t share1 = {
+      .data = {0xf1f2f3f4, 0xf5f6f7f8, 0xf9fafbfc, 0xfdfeff00, 0xe1e2e3e4,
+               0xe5e6e7e8, 0xe9eaebec, 0xedeeeff0},
+  };
+
+  ExpectIdleCheck(KEYMGR_OP_STATUS_STATUS_VALUE_IDLE);
+  EXPECT_ABS_WRITE32_SHADOWED(
+      base_ + KEYMGR_CONTROL_SHADOWED_REG_OFFSET,
+      {
+          {KEYMGR_CONTROL_SHADOWED_DEST_SEL_OFFSET,
+           KEYMGR_CONTROL_SHADOWED_DEST_SEL_VALUE_NONE},
+          {KEYMGR_CONTROL_SHADOWED_CDI_SEL_BIT, false},
+          {KEYMGR_CONTROL_SHADOWED_OPERATION_OFFSET,
+           KEYMGR_CONTROL_SHADOWED_OPERATION_VALUE_GENERATE_SW_OUTPUT},
+      });
+  ExpectDiversificationWrite(test_diversification);
+  EXPECT_ABS_WRITE32(base_ + KEYMGR_START_REG_OFFSET,
+                     {
+                         {KEYMGR_START_EN_BIT, true},
+                     });
+  ExpectWaitUntilDone(/*busy_cycles=*/2,
+                      KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+  ExpectSwKeyRead(share0, share1);
+
+  keymgr_binding_value_t key_out;
+  EXPECT_EQ(sc_keymgr_generate_key_sw(kScKeymgrKeyTypeSealing,
+                                      test_diversification, &key_out),
+            kErrorOk);
+  for (size_t i = 0; i < kScKeymgrSaltNumWords; ++i) {
+    EXPECT_EQ(key_out.data[i], share0.data[i] ^ share1.data[i]);
+  }
+}
+
+TEST_F(KeymgrTest, GenSwKeyNotIdle) {
+  sc_keymgr_diversification_t test_diversification = {
+      .salt = {0xf0f1f2f3, 0xf4f5f6f7, 0xf8f9fafb, 0xfcfdfeff, 0xd0d1d2d3,
+               0xd4d5d6d7, 0xd8d9dadb, 0xdcdddedf},
+      .version = cfg_.max_key_ver - 1,
+  };
+  keymgr_binding_value_t key_out;
+
+  ExpectIdleCheck(KEYMGR_OP_STATUS_STATUS_VALUE_WIP);
+  EXPECT_EQ(sc_keymgr_generate_key_sw(kScKeymgrKeyTypeAttestation,
+                                      test_diversification, &key_out),
+            kErrorKeymgrInternal);
+  ExpectIdleCheck(KEYMGR_OP_STATUS_STATUS_VALUE_DONE_ERROR);
+  EXPECT_EQ(sc_keymgr_generate_key_sw(kScKeymgrKeyTypeAttestation,
+                                      test_diversification, &key_out),
+            kErrorKeymgrInternal);
+  ExpectIdleCheck(KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+  EXPECT_EQ(sc_keymgr_generate_key_sw(kScKeymgrKeyTypeAttestation,
+                                      test_diversification, &key_out),
+            kErrorKeymgrInternal);
+}
+
+TEST_F(KeymgrTest, GenSwKeyError) {
+  sc_keymgr_diversification_t test_diversification = {
+      .salt = {0xf0f1f2f3, 0xf4f5f6f7, 0xf8f9fafb, 0xfcfdfeff, 0xd0d1d2d3,
+               0xd4d5d6d7, 0xd8d9dadb, 0xdcdddedf},
+      .version = cfg_.max_key_ver - 1,
+  };
+  uint32_t err_code = 0x1;
+  keymgr_binding_value_t key_out;
+
+  ExpectIdleCheck(KEYMGR_OP_STATUS_STATUS_VALUE_IDLE);
+  EXPECT_ABS_WRITE32_SHADOWED(
+      base_ + KEYMGR_CONTROL_SHADOWED_REG_OFFSET,
+      {
+          {KEYMGR_CONTROL_SHADOWED_DEST_SEL_OFFSET,
+           KEYMGR_CONTROL_SHADOWED_DEST_SEL_VALUE_NONE},
+          {KEYMGR_CONTROL_SHADOWED_CDI_SEL_BIT, true},
+          {KEYMGR_CONTROL_SHADOWED_OPERATION_OFFSET,
+           KEYMGR_CONTROL_SHADOWED_OPERATION_VALUE_GENERATE_SW_OUTPUT},
+      });
+  ExpectDiversificationWrite(test_diversification);
+  EXPECT_ABS_WRITE32(base_ + KEYMGR_START_REG_OFFSET,
+                     {
+                         {KEYMGR_START_EN_BIT, true},
+                     });
+  ExpectWaitUntilDone(/*busy_cycles=*/2,
+                      KEYMGR_OP_STATUS_STATUS_VALUE_DONE_ERROR);
+  EXPECT_ABS_READ32(base_ + KEYMGR_ERR_CODE_REG_OFFSET, err_code);
+  EXPECT_ABS_WRITE32(base_ + KEYMGR_ERR_CODE_REG_OFFSET, err_code);
+
+  EXPECT_EQ(sc_keymgr_generate_key_sw(kScKeymgrKeyTypeAttestation,
+                                      test_diversification, &key_out),
             kErrorKeymgrInternal);
 }
 


### PR DESCRIPTION
This PR adds support for generating software-visible versioned keys (attestation or sealing) from the key manager.

#### Key Changes
1.  **Keymgr Driver Update (`sw/device/silicon_creator/lib/drivers/keymgr.c`)**:
    *   Implemented `sc_keymgr_generate_key_sw()`. This function configures the key manager with `DEST_SEL = NONE` and `OPERATION = GENERATE_SW_OUTPUT`, waits for completion, and then reconstructs the software key by XORing the `SW_SHARE0` and `SW_SHARE1` output registers.
2.  **Unit Tests (`sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc`)**:
    *   Added `GenSwAttestationKey` and `GenSwSealingKey` to verify successful software key generation.
    *   Added `GenSwKeyNotIdle` and `GenSwKeyError` to verify error handling.
