### PR TITLE
[dice] Add static_dice_mldsa_cdi region

### DIFF
--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -56,6 +56,7 @@ ld_library(
         "//sw/device:info_sections",
         "//sw/device/lib/coverage:coverage_sections",
         "//sw/device/silicon_creator/lib/base:static_critical_sections",
+        "//sw/device/silicon_creator/lib/base:static_dice_sections",
     ],
 )
 

--- a/sw/device/lib/testing/test_framework/ottf_common.ld
+++ b/sw/device/lib/testing/test_framework/ottf_common.ld
@@ -78,6 +78,8 @@ SECTIONS {
    */
   INCLUDE sw/device/silicon_creator/lib/base/static_critical.ld
 
+  INCLUDE sw/device/silicon_creator/lib/base/static_dice.ld
+
   .manifest _ottf_start_address : {
     KEEP(*(.manifest))
     . = ALIGN(4);

--- a/sw/device/silicon_creator/lib/base/BUILD
+++ b/sw/device/silicon_creator/lib/base/BUILD
@@ -145,13 +145,6 @@ ld_library(
 )
 
 cc_library(
-    name = "static_dice",
-    deps = [
-        ":static_dice_cdi_0",
-    ],
-)
-
-cc_library(
     name = "chip",
     hdrs = ["chip.h"],
 )

--- a/sw/device/silicon_creator/lib/base/BUILD
+++ b/sw/device/silicon_creator/lib/base/BUILD
@@ -137,6 +137,17 @@ cc_library(
     alwayslink = True,
 )
 
+cc_library(
+    name = "static_dice_mldsa_cdi",
+    srcs = ["static_dice_mldsa_cdi.c"],
+    hdrs = ["static_dice_mldsa_cdi.h"],
+    deps = [
+        "//sw/device/lib/base:macros",
+    ],
+    # This library provides a special symbol that the linker will find.
+    alwayslink = True,
+)
+
 ld_library(
     name = "static_dice_sections",
     includes = [

--- a/sw/device/silicon_creator/lib/base/static_dice.ld
+++ b/sw/device/silicon_creator/lib/base/static_dice.ld
@@ -13,13 +13,26 @@
  */
 
 .static_dice (NOLOAD) : ALIGN(4) {
+  _static_dice_start = .;
   ASSERT(
     . == ORIGIN(ram_main) + SIZEOF(.static_critical),
     "Error: .static_dice section does not follow the .static_critical section.");
 
+  _static_dice_cdi_0_start = .;
   KEEP(*(.static_dice.cdi_0))
+  _static_dice_cdi_0_end = .;
+  _static_dice_cdi_0_size = _static_dice_cdi_0_end - _static_dice_cdi_0_start;
+
+  _static_dice_mldsa_cdi_start = .;
+  KEEP(*(.static_dice.mldsa_cdi))
+  _static_dice_mldsa_cdi_end = .;
+  _static_dice_mldsa_cdi_size = _static_dice_mldsa_cdi_end - _static_dice_mldsa_cdi_start;
 
   ASSERT(
-    SIZEOF(.static_dice) == 1220,
-    "Error: .static_dice section size has changed");
+    _static_dice_cdi_0_size == 1220 || _static_dice_cdi_0_size == 0,
+    "Error: .static_dice.cdi_0 section size must be 1220 or 0");
+  ASSERT(
+    _static_dice_mldsa_cdi_size == 18984 || _static_dice_mldsa_cdi_size == 0,
+    "Error: .static_dice.mldsa_cdi section size must be 18984 or 0");
+  _static_dice_end = .;
 } > ram_main

--- a/sw/device/silicon_creator/lib/base/static_dice_mldsa_cdi.c
+++ b/sw/device/silicon_creator/lib/base/static_dice_mldsa_cdi.c
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/base/static_dice_mldsa_cdi.h"
+
+#include "sw/device/lib/base/macros.h"
+
+// ML-DSA DICE certs and keys.
+//
+// This is placed at a fixed location in memory within the
+// .static_dice section. It will be populated by the imm_section (for UDS/CDI_0)
+// and ROM_EXT (for CDI_1) to hand over post-quantum DICE chain data.
+OT_SET_BSS_SECTION(".static_dice.mldsa_cdi",
+                   OT_USED static_dice_mldsa_cdi_t static_dice_mldsa_cdi;)

--- a/sw/device/silicon_creator/lib/base/static_dice_mldsa_cdi.h
+++ b/sw/device/silicon_creator/lib/base/static_dice_mldsa_cdi.h
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BASE_STATIC_DICE_MLDSA_CDI_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BASE_STATIC_DICE_MLDSA_CDI_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+
+// The post-quantum DICE chain information passed from imm_section to
+// ROM_EXT, and from ROM_EXT to the Owner image.
+typedef struct {
+  uint8_t uds_pub[2592];
+  uint8_t cdi_0_cert[8192];
+  uint32_t cdi_0_cert_size;
+  uint8_t cdi_1_cert[8192];
+  uint32_t cdi_1_cert_size;
+} static_dice_mldsa_cdi_t;
+
+OT_ASSERT_MEMBER_OFFSET(static_dice_mldsa_cdi_t, uds_pub, 0);
+OT_ASSERT_MEMBER_OFFSET(static_dice_mldsa_cdi_t, cdi_0_cert, 2592);
+OT_ASSERT_MEMBER_OFFSET(static_dice_mldsa_cdi_t, cdi_0_cert_size, 10784);
+OT_ASSERT_MEMBER_OFFSET(static_dice_mldsa_cdi_t, cdi_1_cert, 10788);
+OT_ASSERT_MEMBER_OFFSET(static_dice_mldsa_cdi_t, cdi_1_cert_size, 18980);
+OT_ASSERT_SIZE(static_dice_mldsa_cdi_t, 18984);
+
+extern static_dice_mldsa_cdi_t static_dice_mldsa_cdi;
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BASE_STATIC_DICE_MLDSA_CDI_H_

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -281,7 +281,6 @@ asm_library_with_coverage(
             "//sw/device/silicon_creator/lib/base:chip",
             "//sw/device/silicon_creator/lib/base:sec_mmio",
             "//sw/device/silicon_creator/lib/base:static_critical",
-            "//sw/device/silicon_creator/lib/base:static_dice",
             "//sw/device/silicon_creator/lib/base:util",
             "//sw/device/silicon_creator/lib/boot_svc:boot_svc_msg",
             "//sw/device/silicon_creator/lib/cert:dice_api",

--- a/sw/device/silicon_creator/rom_ext/imm_section/BUILD
+++ b/sw/device/silicon_creator/rom_ext/imm_section/BUILD
@@ -59,7 +59,6 @@ cc_library(
         "//sw/device/silicon_creator/lib/base:boot_measurements",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
         "//sw/device/silicon_creator/lib/base:static_critical",
-        "//sw/device/silicon_creator/lib/base:static_dice",
         "//sw/device/silicon_creator/lib/cert:dice_api",
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/lib/drivers:otbn",


### PR DESCRIPTION
Introduce a static BSS memory section `.static_dice.mldsa_cdi` to hold the post-quantum ML-DSA DICE chain certificates and public keys. This section is located at a fixed location in memory, immediately following the ECDSA CDI_0 section in the `.static_dice` RAM block.

This allows the post-quantum DICE chain data to be passed cleanly from imm_section to ROM_EXT.

The buffers are large enough to hold MLDSA-44/65/87 certs.

Specifically, this change:
1. Defines the `static_dice_mldsa_cdi_t` struct (18984 bytes) and declares its member offsets in a new header `static_dice_mldsa_cdi.h`.
2. Allocates the global symbol `static_dice_mldsa_cdi` in the new section `.static_dice.mldsa_cdi` in `static_dice_mldsa_cdi.c`.
3. Updates `static_dice.ld` to support and assert on the 18984-byte ML-DSA DICE CDI region.
4. Adds the corresponding BUILD targets and links the new sections into the OTTF test framework to prevent OTTF overwrite this region when linked with the static_dice_mldsa_cdi library.