### PR TITLE
[otbn] Expose the INSN_CNT register to OTBN SW

### DIFF
--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -629,6 +629,16 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
       </td>
     </tr>
     <tr>
+      <td>0xFC2</td>
+      <td>RO</td>
+      <td>INSN_CNT</td>
+      <td>
+        This CSR exposes the top level `INSN_CNT` register such that it can be used by OTBN software for security related checks.
+        A read returns the number of instructions retired before the current CSR read instruction (i.e, the read instruction in not included).
+        See the `INSN_CNT` register description for more details regarding how it is cleared.
+      </td>
+    </tr>
+    <tr>
       <td>0xFCA</td>
       <td>RO</td>
       <td>MAI_STATUS</td>
@@ -972,6 +982,9 @@ In order to detect and mitigate fault injection attacks on the OTBN, the host CP
 The host CPU can clear the instruction counter when OTBN is not running.
 Writing any value to [`INSN_CNT`](doc/registers.md#insn_cnt) clears this register to zero.
 Write attempts while OTBN is running are ignored.
+
+This instruction count is also exposed to the OTBN SW directly via the read-only `INSN_CNT` CSR.
+This allows to do more fine grained instruction count based countermeasures.
 
 ## Key Sideloading
 

--- a/hw/ip/otbn/data/csr.yml
+++ b/hw/ip/otbn/data/csr.yml
@@ -232,6 +232,14 @@
     The number is sourced from an local PRNG.
     Reads never stall.
 
+- name: insn_cnt
+  address: 0xfc2
+  read-only: true
+  doc: |
+    This CSR exposes the top level `INSN_CNT` register such that it can be used by OTBN software for security related checks.
+    A read returns the number of instructions retired before the current CSR read instruction (i.e, the read instruction in not included).
+    See the `INSN_CNT` register description for more details regarding how it is cleared.
+
 - name: mai_status
   address: 0xfca
   read-only: true

--- a/hw/ip/otbn/dv/otbnsim/sim/constants.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/constants.py
@@ -83,6 +83,7 @@ class CsrAddrs(IntEnum):
     MAI_CTRL = 0x7e0
     RND = 0xfc0
     URND = 0xfc1
+    INSN_CNT = 0xfc2
     MAI_STATUS = 0xfca
 
 

--- a/hw/ip/otbn/dv/otbnsim/sim/csr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/csr.py
@@ -4,6 +4,7 @@
 
 from typing import Any, Callable, Dict, List, Optional
 from .constants import CsrAddrs
+from .ext_regs import OTBNExtRegs
 from .flags import FlagGroups
 from .kmac_ispr import KmacStatusCSR, KmacCtrlCSR, KmacCfgCSR, KmacStrbCSR
 from .mai_ispr import MaiCtrlCSR, MaiStatusCSR
@@ -41,7 +42,7 @@ class WrapperCSR:
 
 class CSRFile:
     '''A model of the CSR file'''
-    def __init__(self, wsrs: WSRFile) -> None:
+    def __init__(self, wsrs: WSRFile, ext_regs: OTBNExtRegs) -> None:
         self.flags = FlagGroups()
         self.RND_PREFETCH = WrapperCSR(
             write_func=lambda val: wsrs.RND.request_value()
@@ -54,6 +55,7 @@ class CSRFile:
         self.URND = WrapperCSR(read_func=wsrs.URND.read_u32)
         self.MAI_CTRL = MaiCtrlCSR()
         self.MAI_STATUS = MaiStatusCSR()
+        self.INSN_CNT = WrapperCSR(read_func=ext_regs.read_insn_cnt)
 
         # This does not include all CSR addresses because:
         # - FG0 and FG1 map to the same underlying register.
@@ -69,6 +71,7 @@ class CSRFile:
             CsrAddrs.RND: self.RND,
             CsrAddrs.URND: self.URND,
             CsrAddrs.MAI_STATUS: self.MAI_STATUS,
+            CsrAddrs.INSN_CNT: self.INSN_CNT,
         }
 
     @staticmethod

--- a/hw/ip/otbn/dv/otbnsim/sim/ext_regs.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/ext_regs.py
@@ -314,6 +314,10 @@ class OTBNExtRegs:
         fld = reg.fields[0]
         reg.write(min(fld.value + 1, (1 << 32) - 1), True)
 
+    def read_insn_cnt(self) -> int:
+        reg = self._get_reg('INSN_CNT')
+        return reg.read(True)
+
     def read(self, reg_name: str, from_hw: bool) -> int:
         reg = self.regs.get(reg_name)
         if reg is None:

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -84,7 +84,7 @@ class OTBNState:
 
         self.ext_regs = OTBNExtRegs()
         self.wsrs = WSRFile(self.ext_regs)
-        self.csrs = CSRFile(self.wsrs)
+        self.csrs = CSRFile(self.wsrs, self.ext_regs)
         self.kmac = Kmac(self.csrs, self.wsrs)
 
         self.pc = 0
@@ -382,7 +382,7 @@ class OTBNState:
         # treatment because some of them have values that persist across
         # operations.
         self.wsrs.on_start()
-        self.csrs = CSRFile(self.wsrs)
+        self.csrs = CSRFile(self.wsrs, self.ext_regs)
         # TODO: Figure out how to model the secure wipe persistent behaviour of the KMAC interface.
         self.kmac.on_start(self.csrs, self.wsrs)
         self.mai.on_start(self.csrs, self.wsrs)

--- a/hw/ip/otbn/dv/smoke/smoke_expected.txt
+++ b/hw/ip/otbn/dv/smoke/smoke_expected.txt
@@ -35,7 +35,7 @@ x26 | 0x00000016
 x27 | 0x0000001a
 x28 | 0x00400000
 x29 | 0x00018000
-x30 | 0x0092876e
+x30 | 0x53bcb7d3
 x31 | 0x00000804
 
 Final Bignum Register Values:

--- a/hw/ip/otbn/dv/smoke/smoke_test.s
+++ b/hw/ip/otbn/dv/smoke/smoke_test.s
@@ -14,6 +14,13 @@ add x2, x2, 0x513
 lui x3, 0xa0be9
 add x3, x3, 0x11a
 
+# Test the INSN_CNT register read
+csrrs x4, INSN_CNT, x0
+addi x5, x0, 4
+beq x4, x5, _insn_cnt_ok
+unimp
+_insn_cnt_ok:
+
 # x4 = x2 + x3 = 0x717d462d
 add x4, x2, x3
 

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -83,6 +83,8 @@ interface otbn_trace_if
 
   input logic [otbn_pkg::UrndLen-1:0] urnd_data,
 
+  input logic [31:0] insn_cnt,
+
   input logic [1:0][otbn_pkg::SideloadKeyWidth-1:0] sideload_key_shares_i,
 
   input logic secure_wipe_req,
@@ -436,6 +438,12 @@ interface otbn_trace_if
   assign ispr_write[IsprKmacStrb]      = u_otbn_kmac_if.ispr_kmac_strb_wr_i;
   assign ispr_write_data[IsprKmacStrb] = {{(WLEN - 32'd32){1'b0}},
                                           u_otbn_kmac_if.ispr_kmac_strb_wdata_i};
+
+  assign ispr_write[IsprInsnCnt] = 1'b0;
+  assign ispr_write_data[IsprInsnCnt] = '0;
+
+  assign ispr_read[IsprInsnCnt] = any_ispr_read & (ispr_addr == IsprInsnCnt);
+  assign ispr_read_data[IsprInsnCnt] = {{(WLEN - 32){1'b0}}, insn_cnt};
 
   // Separate per flag group tracking using the flags_t struct so tracer can cleanly present flag
   // accesses.

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
@@ -117,6 +117,7 @@ module otbn_tracer (
       IsprKmacCtrl: return "KMAC_CTRL";
       IsprKmacCfg: return "KMAC_CFG";
       IsprKmacStrb: return "KMAC_STRB";
+      IsprInsnCnt: return "INSN_CNT";
       default: return $sformatf("UNKNOWN_ISPR: (%d)", ispr);
     endcase
   endfunction
@@ -144,7 +145,8 @@ module otbn_tracer (
       IsprMaiStatus,
       IsprKmacStatus,
       IsprKmacCtrl,
-      IsprKmacStrb: return 32;
+      IsprKmacStrb,
+      IsprInsnCnt: return 32;
       default: return -1;
     endcase
   endfunction

--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -189,6 +189,7 @@ module otbn_alu_bignum
 
   input  logic [WLEN-1:0]             rnd_data_i,
   input  logic [WLEN-1:0]             urnd_data_i,
+  input  logic [31:0]                 insn_cnt_i,
 
   input  logic [1:0][SideloadKeyWidth-1:0] sideload_key_shares_i,
 
@@ -660,7 +661,7 @@ module otbn_alu_bignum
   // 2. Select between the ISPRs that have integrity bits and the result of the first stage.
 
   // Number of ISPRs that have no integrity protection
-  localparam int NNoIntgIspr = 12;
+  localparam int NNoIntgIspr = 13;
   // IDs for ISPRs without integrity
   localparam int IsprRndNoIntg = 0;
   localparam int IsprUrndNoIntg = 1;
@@ -674,6 +675,7 @@ module otbn_alu_bignum
   localparam int IsprKmacStatusNoIntg = 9;
   localparam int IsprKmacCfgNoIntg = 10;
   localparam int IsprKmacStrbNoIntg = 11;
+  localparam int IsprInsnCntNoIntg = 12;
 
   logic [NNoIntgIspr-1:0] ispr_rdata_no_intg_mux_sel;
 
@@ -714,6 +716,7 @@ module otbn_alu_bignum
   assign ispr_rdata_no_intg_mux_in[IsprKeyS1LNoIntg] = sideload_key_shares_i[1][255:0];
   assign ispr_rdata_no_intg_mux_in[IsprKeyS1HNoIntg] =
       {{(WLEN - (SideloadKeyWidth - 256)){1'b0}}, sideload_key_shares_i[1][SideloadKeyWidth-1:256]};
+  assign ispr_rdata_no_intg_mux_in[IsprInsnCntNoIntg] = {{(WLEN - 32){1'b0}}, insn_cnt_i};
 
   assign ispr_rdata_no_intg_mux_in[IsprKmacStatusNoIntg] =
       {{(WLEN - 32){1'b0}}, ispr_kmac_status_rdata_i};
@@ -748,6 +751,9 @@ module otbn_alu_bignum
       ispr_bignum_predec_i.ispr_rd_en[IsprKmacStrb];
   // KMAC_CTRL always reads as '0. We use the onehot MUX to output '0 by not factoring in the
   // KMAC_CTRL read enable signal into its select signal.
+
+  assign ispr_rdata_no_intg_mux_sel[IsprInsnCntNoIntg]  =
+      ispr_bignum_predec_i.ispr_rd_en[IsprInsnCnt];
 
   logic [WLEN-1:0]    ispr_rdata_no_intg;
   logic [ExtWLEN-1:0] ispr_rdata_intg_calc;
@@ -806,7 +812,8 @@ module otbn_alu_bignum
       ispr_bignum_predec_i.ispr_rd_en[IsprKmacDataS1];
 
   assign ispr_rdata_intg_mux_sel[IsprNoIntg] =
-    |{ispr_bignum_predec_i.ispr_rd_en[IsprKmacStrb],
+    |{ispr_bignum_predec_i.ispr_rd_en[IsprInsnCnt],
+      ispr_bignum_predec_i.ispr_rd_en[IsprKmacStrb],
       ispr_bignum_predec_i.ispr_rd_en[IsprKmacCfg],
       ispr_bignum_predec_i.ispr_rd_en[IsprKmacCtrl],
       ispr_bignum_predec_i.ispr_rd_en[IsprKmacStatus],

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -1337,6 +1337,10 @@ module otbn_controller
         ispr_addr_base      = IsprMaiStatus;
         ispr_word_addr_base = '0;
       end
+      CsrInsnCnt: begin
+        ispr_addr_base      = IsprInsnCnt;
+        ispr_word_addr_base = '0;
+      end
       default: csr_illegal_addr = 1'b1;
     endcase
   end

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -1054,6 +1054,7 @@ module otbn_core
 
     .rnd_data_i (rnd_data),
     .urnd_data_i(urnd_data[WLEN-1:0]),
+    .insn_cnt_i (insn_cnt),
 
     .sideload_key_shares_i,
 

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -421,7 +421,8 @@ package otbn_pkg;
     // 0xFC0-0xFFF Custom read-only
     CsrRnd         = 12'hFC0,
     CsrUrnd        = 12'hFC1,
-    CsrMaiStatus   = 12'hfca
+    CsrInsnCnt     = 12'hFC2,
+    CsrMaiStatus   = 12'hFCA
   } csr_e;
 
   // Wide Special Purpose Registers (WSRs)
@@ -449,7 +450,7 @@ package otbn_pkg;
   // Internal Special Purpose Registers (ISPRs)
   // CSRs and WSRs have some overlap into what they map into. ISPRs are the actual registers in the
   // design which CSRs and WSRs are mapped on to.
-  parameter int NIspr = 23;
+  parameter int NIspr = 24;
   parameter int IsprNumWidth = $clog2(NIspr);
   typedef enum logic [IsprNumWidth-1:0] {
     IsprMod        = 'd0,
@@ -474,7 +475,8 @@ package otbn_pkg;
     IsprKmacStatus = 'd19,
     IsprKmacCtrl   = 'd20,
     IsprKmacCfg    = 'd21,
-    IsprKmacStrb   = 'd22
+    IsprKmacStrb   = 'd22,
+    IsprInsnCnt    = 'd23
   } ispr_e;
 
   typedef logic [$clog2(NFlagGroups)-1:0] flag_group_t;

--- a/hw/ip/otbn/rtl/otbn_predecode.sv
+++ b/hw/ip/otbn/rtl/otbn_predecode.sv
@@ -767,6 +767,7 @@ module otbn_predecode
         CsrKmacStrb:                        ispr_addr = IsprKmacStrb;
         CsrMaiCtrl:                         ispr_addr = IsprMaiCtrl;
         CsrMaiStatus:                       ispr_addr = IsprMaiStatus;
+        CsrInsnCnt:                         ispr_addr = IsprInsnCnt;
         default: ;
       endcase
     end else begin

--- a/sw/device/tests/otbn_isa_test.c
+++ b/sw/device/tests/otbn_isa_test.c
@@ -31,7 +31,7 @@ static const otbn_addr_t kWdrState = OTBN_ADDR_T_INIT(smoke_test, wdr_state);
 enum {
   kNumExpectedGprs = 30,
   kNumExpectedWdrs = 32,
-  kExpectedInstrCount = 296,
+  kExpectedInstrCount = 299,
 };
 
 // The expected values of the GPRs and WDRs are taken from


### PR DESCRIPTION
This exposes the [INSN_CNT](https://opentitan.org/book/hw/ip/otbn/doc/registers.html#insn_cnt) register to OTBN SW via a CSR. This information is useful to harden SW against instruction skips.