### PR TITLE
[otbn,mai] Fix MAI test and clarify naming of the READY flag

### DIFF
--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -648,7 +648,7 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
             <tr>
               <td>1</td>
               <td>
-                READY: This bit is set to 1 when the MAI_INx_Sx WSRs are ready to accept new values for the next execution.
+                INPUT_READY: This bit is set to 1 when the MAI_INx_Sx WSRs are ready to accept new values for the next execution.
               </td>
             </tr>
             <tr>

--- a/hw/ip/otbn/data/csr.yml
+++ b/hw/ip/otbn/data/csr.yml
@@ -242,5 +242,5 @@
       BUSY: This bit is set to 1 when an MAI operation is in progress.
       If reset, the MAI accepts new configuration values and a new execution can be started by writing to the START bit in MAI_CTRL.
     1: |
-      READY: This bit is set to 1 when the MAI_INx_Sx WSRs are ready to accept new values for the next execution.
+      INPUT_READY: This bit is set to 1 when the MAI_INx_Sx WSRs are ready to accept new values for the next execution.
     31-2: Reserved. Always reads as 0.

--- a/hw/ip/otbn/doc/theory_of_operation.md
+++ b/hw/ip/otbn/doc/theory_of_operation.md
@@ -864,8 +864,8 @@ OTBN SW can perform a masking operation by following these steps (see also illus
 
 This sequence can be optimized, because:
 - The input WSRs can be overwritten with the next data as soon as the MAI pushed all elements into the accelerator.
-  - This is the case as soon as `MAI_STATUS.READY = 1`.
-  - Note that `MAI_STATUS.READY = 1` does not signal that the MAI is ready to start the next execution.
+  - This is the case as soon as `MAI_STATUS.INPUT_READY = 1`.
+  - Note that `MAI_STATUS.INPUT_READY = 1` does not signal that the MAI is ready to start the next execution.
     It just indicates that it is ready to receive new data.
 - The START command of the next execution can be issued before the results are read back.
   - This is possible because the accelerator latency delays the update to the result WSRs.
@@ -876,12 +876,12 @@ This allows overlapping data transfers with the accelerator latency.
 The overlapping execution software flow is:
 - Setup the MAI as described above.
 - Start the first execution by issuing the `MAI_CTRL.START` command.
-- Poll until `MAI_STATUS.READY = 1`.
+- Poll until `MAI_STATUS.INPUT_READY = 1`.
 - Update the `MAI_INx_Sy` with the next data.
 - Poll until `MAI_STATUS.BUSY = 0`.
 - Issue the `MAI_CTRL.START` command for the next execution.
 - Read back the result of the first execution.
-- Repeat the steps starting with "Poll until `MAI_STATUS.READY = 1`".
+- Repeat the steps starting with "Poll until `MAI_STATUS.INPUT_READY = 1`".
 
 This procedure can be even further optimized for secAdd, secAddMod, and A2B because their latency is deterministic and thus the polling can be replaced with the correct number of other instructions.
 It is only possible to overlap executions of the same type / configuration as `MAI_CTRL.OPERATION` must remain constant as long as `MAI_STATUS.BUSY = 1`.
@@ -902,7 +902,7 @@ This will trigger an abortion of the OTBN execution with a secure wipe.
 The `MAI_SOFTWARE_ERROR` is triggered when:
 - `MAI_CTRL.OPERATION` contains an invalid selection when the `MAI_CTRL.START` bit is set.
 - The `MAI_CTRL.START` bit is set or `MAI_CTRL.OPERATION` is written to whilst `MAI_STATUS.BUSY = 1`.
-- A write to input WSRs is detected whilst `MAI_STATUS.READY = 0`.
+- A write to input WSRs is detected whilst `MAI_STATUS.INPUT_READY = 0`.
   - The `MAI_INx_Sy` registers are used as input buffers.
     Modifying the register content can lead to unexpected results.
 - A write to the reserved section of `MAI_CTRL` is detected.

--- a/hw/ip/otbn/dv/otbnsim/sim/mai.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/mai.py
@@ -253,9 +253,9 @@ class MaskingAcceleratorInterface:
             # Immediately set the busy bit so the current instruction is not allowed to start the
             # next execution.
             self.csrs.MAI_STATUS.update_busy_bit(True)
-            # Immediately reset the ready bit such that any configuration change check does not
-            # allow changing the operation type.
-            self.csrs.MAI_STATUS.update_ready_bit(False)
+            # Immediately reset the input-ready bit such that any configuration change check does
+            # not allow changing the operation type.
+            self.csrs.MAI_STATUS.update_input_ready_bit(False)
             # Immediately reset the start bit such that it always reads zero.
             self.csrs.MAI_CTRL.update_start_bit(False)
 
@@ -270,19 +270,20 @@ class MaskingAcceleratorInterface:
         if self._dispatch_idx >= 8:
             self._dispatch_idx = 0
             self.is_dispatching = False
-            # Immediately set the ready bit as the input WSRs can be overwritten in this cycle.
-            self.csrs.MAI_STATUS.update_ready_bit(True)
+            # Immediately set the input-ready bit as the input WSRs can be overwritten in this
+            # cycle.
+            self.csrs.MAI_STATUS.update_input_ready_bit(True)
 
     def is_busy(self) -> bool:
         '''Returns whether the MAI is currently busy processing an operation.'''
         return self.csrs.MAI_STATUS.is_busy()
 
-    def is_ready(self) -> bool:
+    def is_input_ready(self) -> bool:
         '''Returns whether the MAI is ready to accept new inputs.'''
-        return self.csrs.MAI_STATUS.is_ready()
+        return self.csrs.MAI_STATUS.is_input_ready()
 
     def ready_for_inputs(self) -> bool:
-        return self.is_ready()
+        return self.is_input_ready()
 
     def ready_to_start(self) -> bool:
         return not self.is_busy()

--- a/hw/ip/otbn/dv/otbnsim/sim/mai_ispr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/mai_ispr.py
@@ -117,7 +117,7 @@ class MaiStatusCSR(DumbISPR):
     '''Models the MAI STATUS CSR'''
     def __init__(self) -> None:
         self.BUSY_BIT_OFFSET = 0
-        self.READY_BIT_OFFSET = 1
+        self.INPUT_READY_BIT_OFFSET = 1
         super().__init__("MAI_STATUS", 32)
         self.on_start()
 
@@ -125,7 +125,7 @@ class MaiStatusCSR(DumbISPR):
         super().on_start()
         # On start, the MAI is not busy and is ready for new inputs.
         self._is_busy = False
-        self._is_ready = True
+        self._is_input_ready = True
         self._value = self._get_value()
 
     def write_unsigned(self, value: int) -> None:
@@ -136,27 +136,30 @@ class MaiStatusCSR(DumbISPR):
         return
 
     def _get_value(self) -> int:
-        '''Construct the register value based on the current busy and ready bits.'''
-        return ((self._is_busy << self.BUSY_BIT_OFFSET) | (self._is_ready << self.READY_BIT_OFFSET))
+        '''Construct the register value based on the current busy and input-ready bits.'''
+        return ((self._is_busy << self.BUSY_BIT_OFFSET) |
+                (self._is_input_ready << self.INPUT_READY_BIT_OFFSET))
 
-    def _update_bits(self, busy: Optional[bool] = None, ready: Optional[bool] = None) -> None:
-        '''Set or clear the busy and ready bits in the CSR based on the provided values.
+    def _update_bits(self,
+                     busy: Optional[bool] = None,
+                     input_ready: Optional[bool] = None) -> None:
+        '''Set or clear the busy and input-ready bits in the CSR based on the provided values.
 
         This takes effect immediately. Note that we still report the change to generate a proper
         trace.'''
         if busy is not None:
             self._is_busy = busy
-        if ready is not None:
-            self._is_ready = ready
+        if input_ready is not None:
+            self._is_input_ready = input_ready
         self._value = self._get_value()
         self._next_value = self._get_value()
         self._pending_write = False
 
-    def is_ready(self) -> bool:
-        return self._is_ready
+    def is_input_ready(self) -> bool:
+        return self._is_input_ready
 
-    def update_ready_bit(self, ready: bool) -> None:
-        self._update_bits(ready=ready)
+    def update_input_ready_bit(self, input_ready: bool) -> None:
+        self._update_bits(input_ready=input_ready)
 
     def is_busy(self) -> bool:
         return self._is_busy

--- a/hw/ip/otbn/rtl/otbn_mai.sv
+++ b/hw/ip/otbn/rtl/otbn_mai.sv
@@ -78,7 +78,7 @@ module otbn_mai
 
   typedef struct packed {
     logic [31-2:0] rsvd;
-    logic          ready;
+    logic          input_ready;
     logic          busy;
   } ispr_mai_status_t;
 
@@ -417,10 +417,10 @@ module otbn_mai
   assign ma_start        = ispr_mai_ctrl_wr_i & ispr_mai_ctrl_w.start;
 
   // Status read
-  assign ispr_mai_status.rsvd    = '0;
-  assign ispr_mai_status.ready   = !ma_in_valid_q;
-  assign ispr_mai_status.busy    = ma_busy_q;
-  assign ispr_mai_status_rdata_o = ispr_mai_status;
+  assign ispr_mai_status.rsvd        = '0;
+  assign ispr_mai_status.input_ready = !ma_in_valid_q;
+  assign ispr_mai_status.busy        = ma_busy_q;
+  assign ispr_mai_status_rdata_o     = ispr_mai_status;
 
   // Control read
   assign ispr_mai_ctrl_r.rsvd  = '0;

--- a/sw/otbn/mai/mai_test.s
+++ b/sw/otbn/mai/mai_test.s
@@ -47,7 +47,7 @@ _test_b2a_a2b:
   bn.xor w1, w0, w2
 
   /* Write the Boolean masked shares to the WSRs. */
-  jal x1, _poll_ready
+  jal x1, _poll_ready_for_inputs
   bn.wsrw MAI_IN0_S0, w1
   bn.wsrw MAI_IN0_S1, w2
 
@@ -62,7 +62,7 @@ _test_b2a_a2b:
   bn.wsrr w21, MAI_RES_S1
 
   /* Write the arithmetically-masked shares to the WSRs. */
-  jal x1, _poll_ready
+  jal x1, _poll_ready_for_inputs
   bn.wsrw MAI_IN0_S0, w20
   bn.wsrw MAI_IN0_S1, w21
 
@@ -106,7 +106,7 @@ _test_secadd:
   bn.xor w7, w3, w6
 
   /* Write the masked shares to the IN0 and IN1 WSRs. */
-  jal x1, _poll_ready
+  jal x1, _poll_ready_for_inputs
   bn.wsrw MAI_IN0_S0, w5
   bn.wsrw MAI_IN0_S1, w4
   bn.wsrw MAI_IN1_S0, w7
@@ -130,7 +130,7 @@ _test_secadd:
   ret
 
 /**
- * Polls the MAI_STATUS busy bit until the MAI is no longer busy.
+ * Polls the MAI_STATUS BUSY bit until the MAI is no longer busy.
  * Clobbers: x2
  */
 _poll_busy:
@@ -140,13 +140,13 @@ _poll_busy:
   ret
 
 /**
- * Polls the MAI_STATUS ready bit until the MAI is ready for inputs.
+ * Polls the MAI_STATUS INPUT_READY bit until the MAI is ready for inputs.
  * Clobbers: x2
  */
-_poll_ready:
+_poll_ready_for_inputs:
   csrrs x2, MAI_STATUS, x0
   andi x2, x2, 0x2
-  beq x2, x0, _poll_ready
+  beq x2, x0, _poll_ready_for_inputs
   ret
 
 .section .data

--- a/sw/otbn/mai/mai_test.s
+++ b/sw/otbn/mai/mai_test.s
@@ -47,11 +47,12 @@ _test_b2a_a2b:
   bn.xor w1, w0, w2
 
   /* Write the Boolean masked shares to the WSRs. */
+  jal x1, _poll_ready
   bn.wsrw MAI_IN0_S0, w1
   bn.wsrw MAI_IN0_S1, w2
 
   /* Start the B2A conversion. */
-  jal x1, _poll_ready
+  jal x1, _poll_busy
   li x10, 0x21
   csrrw x0, MAI_CTRL, x10
   jal x1, _poll_busy
@@ -60,11 +61,13 @@ _test_b2a_a2b:
   bn.wsrr w20, MAI_RES_S0
   bn.wsrr w21, MAI_RES_S1
 
-  /* Start the A2B conversion. */
+  /* Write the arithmetically-masked shares to the WSRs. */
+  jal x1, _poll_ready
   bn.wsrw MAI_IN0_S0, w20
   bn.wsrw MAI_IN0_S1, w21
 
-  jal x1, _poll_ready
+  /* Start the A2B conversion. */
+  jal x1, _poll_busy
   li x10, 0x17
   csrrw x0, MAI_CTRL, x10
   jal x1, _poll_busy
@@ -103,13 +106,14 @@ _test_secadd:
   bn.xor w7, w3, w6
 
   /* Write the masked shares to the IN0 and IN1 WSRs. */
+  jal x1, _poll_ready
   bn.wsrw MAI_IN0_S0, w5
   bn.wsrw MAI_IN0_S1, w4
   bn.wsrw MAI_IN1_S0, w7
   bn.wsrw MAI_IN1_S1, w6
 
   /* Start the operation and wait for it to complete. */
-  jal x1, _poll_ready
+  jal x1, _poll_busy
   csrrw x0, MAI_CTRL, x10
   jal x1, _poll_busy
 


### PR DESCRIPTION
The first commit fixes the MAI test:

The MAI test did poll MAI_READY before starting an operation instead of MAI_BUSY. MAI_READY indicates only if new inputs can be written to the input WSRs. It does not tell anything about whether an operation can be started. This only depends on MAI_BUSY.

The second commit renames the MAI_READY flag to INPUT_READY to hopefully avoid this confusion in future.