### PR TITLE
[keymgr_dpe] Replace keymgr in EG - PR2 testplan

### DIFF
--- a/hw/ip/keymgr_dpe/data/keymgr_dpe_testplan.hjson
+++ b/hw/ip/keymgr_dpe/data/keymgr_dpe_testplan.hjson
@@ -10,33 +10,523 @@
                      "hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/sec_cm_count_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/sec_cm_fsm_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+                     "keymgr_dpe_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke
       desc: '''
-            Smoke test accessing a major datapath within the keymgr_dpe.
-            Test operations (advance, gen-sw-out, gen-hw-out) at every stage.
+            Smoke test exercising the major datapath within keymgr_dpe.
+            Tests operations (advance, gen-sw-out, gen-hw-out) at every stage.
 
             Stimulus:
-            - Randomly select a destination slot x and issue advance call
+            - Randomly select a destination slot x and issue an advance call
               (which should latch the root key into slot x).
-            - At each stage, issue gen-hw-out and gen-sw-out by using the previously loaded key slot.
+            - At each stage, issue gen-hw-out and gen-sw-out using the previously loaded key slot.
             - At each stage, advance to the next stage by randomly picking a new destination slot y,
               and advancing to it from slot x (x = y is also allowed).
-            - Use fixed values for max_key_version = 0 and policy.allow_child = 1, during advance calls.
+            - Use fixed values for max_key_version = 0 and policy.allow_child = 1 during advance calls.
             - Use default/fixed values for HW/SW inputs. Use key_version = 0 during key generation.
 
             Checks:
-            - Check STATUS reg for each operation.
-            - Check interrupts `op_done` is triggered when operation is done.
-            - Check `err` and alert `recov_operation_err` are triggered after invalid operation.
-            - Check that valid bit is set to 1 in the destination slot.
-            - Check that policy field is correctly updated from POLICY_SLOT CSR.
-            - Check KMAC key, KMAC data and output SW data for correctness.
+            - Check the STATUS register after each operation.
+            - Check that the `op_done` interrupt is triggered when an operation completes.
+            - Check that `err` and alert `recov_operation_err` are triggered after an invalid operation.
+            - Check that the valid bit is set to 1 in the destination slot.
+            - Check that the policy field is correctly updated from the SLOT_POLICY CSR.
+            - Check KMAC key, KMAC data, and SW output data for correctness.
             '''
       stage: V1
       tests: ["keymgr_dpe_smoke"]
+    }
+    {
+      name: random_sw_input
+      desc: '''
+            Extends the smoke test by randomizing all SW input data.
+            - Fully randomize SW inputs: rom_ext_desc_*, software_binding_*, salt_*, max_*_key_ver,
+              *_key_ver_regwen.
+            - Randomize key_version to any value less than max_*_key_ver, to avoid triggering
+              the `invalid_kmac_input` error.
+            - Fully randomize HW inputs from flash, OTP, and life cycle.
+            - Randomize *sw_binding_regwen. Verify that this gates *_sw_binding writes and that
+              it is cleared after a successful advance operation.
+
+            Stimulus and checks are the same as smoke.
+            '''
+      stage: V1
+      tests: [/*TODO(#30753) Implement test: "keymgr_dpe_random_sw_input"*/]
+    }
+    {
+      name: cfgen_during_op
+      desc: '''
+            `cfg_regwen` is a read-only register that gates a number of write accesses to other
+            registers, which is not tested in common CSR tests. When a operation is started,
+            register protected by this EN (e.g. SW Binding registers) are not longer modifiable
+            until the operation completes.
+
+            Stimulus and checks:
+            Verify that commands and register accesses gated by `cfg_regwen` are ignored while
+            an operation is in progress.
+            '''
+      stage: V2
+      tests: [/*TODO(#30753) Implement test: "keymgr_dpe_cfg_regwen"*/]
+    }
+    {
+      name: sideload
+      desc: '''
+            keymgr_dpe exposes hardware sideload interfaces that deliver keys to KMAC, AES,
+            and OTBN. After each exposure clear the key from the sideload interface.
+
+            Stimulus:
+            - Generate a keymgr_dpe output to each HW sideload interface, exercising all three.
+            - After each key generation clear the corresponding interface by writing into the
+              SIDELOAD_CLEAR register.
+            - Reset the clear mechanism by writing 0 into the SIDELOAD_CLEAR register.
+
+            Checks:
+            - Verify that the sideload interfaces deliver the requested keys.
+            - Verify the clear operation on the interface port.
+            '''
+      stage: V2
+      tests: [/*TODO(#30753) Define + Implement Test(s)*/]
+    }
+    {
+      name: invalid_hw_slot_overwrite
+      desc: '''
+            Stimulus:
+            - Attempt to derive a DPE context into an already-occupied hardware slot
+
+            Checks:
+            - Verify 'INVALID_OP' is raised.
+            - Verify the content of the hardware slot is unchanged.
+            '''
+      stage: V2
+      tests: [/*TODO(#30753) Define + Implement Test(s)*/]
+    }
+    {
+      name: invalid_parent_policy
+      desc: '''
+            The parent policy of a DPE context determines whether a derived child context must
+            overwrite the parent hardware slot (retain_parent == 0) or must target a different,
+            empty slot (retain_parent == 1).
+
+            Stimulus:
+            - Derive a DPE context with retain_parent == 1, then attempt to overwrite
+              the parent slot.
+            - Derive a DPE context with retain_parent == 0, then attempt to advance the child
+              into a different (empty) slot.
+
+            Checks:
+            - Verify that 'INVALID_OP' is raised in both cases.
+            - Verify the content of the source hardware slot is unchanged.
+            - Verify the content of the destination hardware slot is unchanged.
+            - Verify the empty slot remains empty and invalid.
+            '''
+      stage: V2
+      tests: [/*TODO(#30753) Define + Implement Test(s)*/]
+    }
+    {
+      name: invalid_child_policy
+      desc: '''
+            Verify that deriving a child context is rejected when the allow_child policy bit
+            is false.
+
+            Stimulus:
+            - Derive a DPE context with allow_child == 0.
+            - Attempt to derive a child context from it.
+
+            Checks:
+            - Verify that 'INVALID_OP' is raised.
+            - Verify the content of the hardware slot is unchanged.
+            '''
+      stage: V2
+      tests: [/*TODO(#30753) Define + Implement Test(s)*/]
+    }
+    {
+      name: erase_dpe_context
+      desc: '''
+            Erase a DPE context from a hardware slot using a software command.
+
+            Stimulus:
+            - Derive a DPE context into a slot, then issue an erase command.
+
+            Checks:
+            - Verify that the destination slot is no longer marked as valid.
+            - Verify the stored key is overwritten with randomness.
+            '''
+      stage: V2
+      tests: [/*TODO(#30753) Define + Implement Test(s)*/]
+    }
+    {
+      name: erase_empty_dpe_context
+      desc: '''
+            Attempt to erase a DPE context from a hardware slot that is not occupied.
+
+            Stimulus:
+            Issue an erase command targeting an empty slot.
+
+            Checks:
+            - Verify that 'INVALID_OP' is raised.
+            - Verify the content of the hardware slot is unchanged.
+            '''
+      stage: V2
+      tests: [/*TODO(#30753) Define + Implement Test(s)*/]
+    }
+    {
+      name: load_uds_command
+      desc: '''
+            Reload the UDS into an empty hardware slot after keymgr_dpe has already reached
+            the Available state.
+
+            Stimulus:
+            - Bring keymgr_dpe out of the Reset state and into the Available state by
+              issuing a single advance call.
+            - Issue the corresponding software command to load the UDS a second time.
+
+            Checks:
+            - Verify that the second load successfully populates the hardware slot with the UDS.
+            '''
+      stage: V2
+      tests: [/*TODO(#30753) Define + Implement Test(s)*/]
+    }
+    {
+      name: load_uds_command_without_default_policy
+      desc: '''
+            Reload the UDS into an empty hardware slot after keymgr_dpe has reached the
+            Available state, with SLOT_POLICY programmed to values that differ from the
+            RTL-defined defaults.
+
+            Stimulus:
+            - Bring keymgr_dpe out of the Reset state and into the Available state by
+              issuing a single advance call.
+            - Issue the corresponding software command to load the UDS a second time.
+
+            Checks:
+            - Verify that the resulting slot policies match the RTL-defined defaults from the
+              keymgr_dpe package, not the values programmed via the SLOT_POLICY register.
+            - Verify that max_key_version is correctly copied from the MAX_KEY_VER_SHADOWED
+              register.
+            '''
+      stage: V2
+      tests: [/*TODO(#30753) Define + Implement Test(s)*/]
+    }
+    {
+      name: load_uds_command_in_occupied_slot
+      desc: '''
+            Attempt to reload the UDS into an already-occupied hardware slot.
+
+            Stimulus:
+            - Bring keymgr_dpe out of the Reset state and into the Available state by
+              issuing a single advance call.
+            - Attempt to load the UDS into the exact same hardware slot.
+
+            Checks:
+            - Verify that 'INVALID_OP' is raised.
+            - Verify the content of the hardware slot is unchanged.
+            '''
+      stage: V2
+      tests: [/*TODO(#30753) Define + Implement Test(s)*/]
+    }
+    {
+      name: lock_loading_uds_command
+      desc: '''
+            Attempt to load the UDS when the load_key_lock hardware register is set.
+
+            Stimulus:
+            - Bring keymgr_dpe out of the Reset state and into the Available state by
+              issuing a single advance call.
+            - Set the load_key_lock register, then attempt to issue the load UDS command.
+
+            Checks:
+            - Verify that 'INVALID_OP' is raised.
+            - Verify the content of the hardware slot is unchanged.
+            '''
+      stage: V2
+      tests: [/*TODO(#30753) Define + Implement Test(s)*/]
+    }
+    {
+      name: invalid_uds
+      desc: '''
+            Verify keymgr_dpe behavior when the valid signal of the uds is false.
+
+            Stimulus:
+            - Drive the valid signal for the uds low
+            - Bring keymgr_dpe out of the Reset state and into the Available state by
+              issuing a single advance call.
+
+            Checks:
+            - Verify the keymgr_dpe enters the Invalid state.
+            - Verify the corresponding INVALID_ROOT_KEY entry inside the debug register is set.
+            '''
+      stage: V2
+      tests: [/*TODO(#30753) Implement test: "keymgr_dpe_invalid_uds"*/]
+    }
+    {
+      name: use_excl_sw_binding_option
+      desc: '''
+            When deriving from the initial DPE slot, HW binding values from the life cycle state
+            are normally included in the KMAC message for the first, second, and third advance
+            calls. The excl_sw_binding flag suppresses these hw binding values.
+
+            Stimulus:
+            - Bring keymgr_dpe out of the Reset state and into the Available state by
+              issuing a single advance call.
+            - Perform three advance operations with the excl_sw_binding flag set.
+
+            Checks:
+            - Verify that the corresponding hw binding values on the KMAC interface are driven to
+              zero when the flag is set, and carry their expected non-zero values when it is
+              cleared.
+            - Generate a SW readable key from the derived DPE context and compare it against a
+              known golden model.
+            '''
+      stage: V2
+      tests: [/*TODO(#30753) Define + Implement Test(s)*/]
+    }
+    {
+      name: direct_to_disabled_state
+      desc: '''
+            Issue the disable command from each reachable state and verify that keymgr_dpe
+            correctly enters the `StDisabled` state.
+            '''
+      stage: V2
+      tests: [/*TODO(#30753) Implement test: "keymgr_dpe_direct_to_disabled"*/]
+    }
+    {
+      name: check_lc_reset_state
+      desc: '''
+            The life cycle controller can deactivate / activate the keymgr_dpe.
+
+            Stimulus:
+            - Deactivate the keymgr_dpe by the LC controller
+            - Issue a single advance call
+            - Activate the keymgr_dpe by the LC controller
+            - Issue a single advance call
+
+            Checks:
+            - Verify that 'INVALID_OP' is raised by the first advance call.
+            - Verify the keymgr_dpe transition into the Available state with the second advance call.
+            '''
+      stage: V2
+      tests: [/*TODO(#30753) Implement test: "keymgr_dpe_check_lc_reset_state"*/]
+    }
+    {
+      name: check_lc_available_state
+      desc: '''
+            The life cycle controller can deactivate the keymgr_dpe, causing it to wipe all secret
+            key material immediately.
+
+            Stimulus:
+            - Bring keymgr_dpe out of the Reset state and into the Available state by
+              issuing a single advance call.
+            - Assert LC deactivation
+
+            Checks:
+            - Verify that all sideload ports are immediately wiped and that SW output is invalid
+              after the operation completes.
+            - Verify the keymgr_dpe transition into the Invalid state.
+            '''
+      stage: V2
+      tests: [/*TODO(#30753) Implement test: "keymgr_dpe_check_lc_available_state"*/]
+    }
+    {
+      name: check_lc_disable_state
+      desc: '''
+            The life cycle controller can deactivate the keymgr_dpe, causing it to wipe all secret
+            key material immediately.
+
+            Stimulus:
+            - Bring keymgr_dpe out of the Reset state and into the Available state by
+              issuing a single advance call.
+            - Issue a disable operation with the register interface
+            - Assert LC deactivation
+
+            Checks:
+            - Verify the keymgr_dpe transition into the Disabled state.
+            - Verify that all sideload ports are immediately wiped and that SW output is invalid
+              after the operation completes.
+            - Verify the keymgr_dpe transition into the Invalid state.
+            '''
+      stage: V2
+      tests: [/*TODO(#30753) Implement test: "keymgr_dpe_check_lc_disable_state"*/]
+    }
+    {
+      name: kmac_error_response
+      desc: '''
+            Verify keymgr_dpe behavior when an error response is received from KMAC after
+            initiating a key derivation transaction.
+
+            Stimulus:
+            - Assert the KMAC error signal while the KMAC output valid signal is high.
+            - Alternatively, drive all-zeros or all-ones as the KMAC digest output to trigger
+              the output validity check.
+
+            Checks:
+            - Verify that `KMAC_OP` inside the `fault_status` is updated correctly.
+            '''
+      stage: V2
+      tests: [/*TODO(#30753) Implement test: "keymgr_dpe_kmac_error_response"*/]
+    }
+    {
+      name: invalid_sw_input
+      desc: '''
+            Verify keymgr_dpe behavior when KEY_VERSION exceeds MAX_KEY_VER for the selected
+            source slot.
+
+            Stimulus:
+            Randomize KEY_VERSION and MAX_KEY_VER registers such that KEY_VERSION > MAX_KEY_VER.
+
+            Checks:
+            - Verify that alert `recov_operation_err` is triggered and err_code is
+              `INVALID_KMAC_INPUT`.
+            - Verify the content of the destination hardware slot is unchanged.
+            '''
+      stage: V2
+      tests: [/*TODO(#30753) Implement test: "keymgr_dpe_sw_invalid_input"*/]
+    }
+    {
+      name: invalid_hw_input
+      desc: '''
+            Verify keymgr_dpe behavior when hardware-supplied inputs contain invalid data
+            patterns (all zeros or all ones).
+
+            Stimulus:
+            - Drive all-zeros or all-ones on any of the following inputs: flash seeds, otp_key,
+              diversification ID, ROM digest, etc.
+
+            Checks:
+            - Verify that alert `recov_operation_err` is triggered and err_code is
+              `INVALID_KMAC_INPUT`.
+            - Verify the content of the destination hardware slot is unchanged.
+            - Verify the corresponding invalid entry inside the debug register is set.
+            '''
+      stage: V2
+      tests: [/*TODO(#30753) Implement test: "keymgr_dpe_hw_invalid_input"*/]
+    }
+    {
+      name: sync_async_fault_cross
+      desc: '''
+            Verify keymgr_dpe behavior when synchronous and asynchronous faults are triggered
+            in combination.
+
+            Stimulus:
+            Create the following two direct tests:
+            - A sync (transactional) fault occurs, followed by an async (non-transactional) fault.
+            - An async (non-transactional) fault occurs, followed by a sync (transactional) fault.
+
+            Checks:
+            - Check alert `fatal_fault_err` is triggered on the first fault.
+            - Verify that `fault_status` register is updated correctly with both faults.
+            '''
+      stage: V2
+      tests: [/*TODO(#30753) Implement test: "keymgr_dpe_sync_async_fault_cross"*/]
+    }
+    {
+      name: stress_all
+      desc: '''
+            - Combine the sequences above into a single test that runs them sequentially,
+              excluding the CSR sequence and keymgr_dpe_cfg_regwen (which requires zero delays).
+            - Randomly insert a hardware reset between sequences.
+            '''
+      stage: V2
+      tests: [/*TODO(#30753) Implement test: "keymgr_dpe_stress_all"*/]
+    }
+    {
+      name: sec_cm_additional_check
+      desc: '''
+            Verify the behavior of keymgr_dpe when faults are injected into its security
+            countermeasures.
+
+            Stimulus:
+            Follow the stimulus described in `prim_count_check`, `prim_one_hot_check`, and
+            `prim_fsm_check`.
+
+            Checks:
+            - In addition to checking the alert and `fault_status`, issue an operation after
+              fault injection and verify that `op_status` reports failure and the design
+              enters `StInvalid`.
+            '''
+      stage: V2S
+      tests: [/*TODO(#30753) Implement test: "keymgr_dpe_sec_cm"*/]
+    }
+  ]
+  covergroups: [
+    {
+      name: state_and_op_cg
+      desc: '''
+            - Cover all operations crossed with `cdi_sel`, `dest_sel`, and `op_status`
+              (success or failure) across all working states.
+            - Sampled once each operation completes.'''
+    }
+    {
+      name: lc_disable_cg
+      desc: '''
+             - Cover LC disable events occurring in each working state and during each
+               operation type.
+             - Sampled when LC disables keymgr_dpe.'''
+    }
+    {
+      name: sideload_clear_cg
+      desc: '''
+            - Cover all SIDELOAD_CLEAR values used after each operation type and in each
+              working state.
+            - Cross with every combination of sideload interface availability across the
+              three interfaces.
+            - Sampled when SIDELOAD_CLEAR is programmed after an operation.'''
+    }
+    {
+      name: reseed_interval_cg
+      desc: '''
+            - Cover small RESEED_INTERVAL values so that the testbench can verify that EDN
+              requests are issued at the correct frequency.
+            - Also cover large values to ensure all register bits are toggled.'''
+    }
+    {
+      name: keymgr_dpe_sw_input_cg
+      desc: '''
+            - Cover toggle of all bits across SW input registers.
+            - SW inputs include: `sw_binding`, `salt`, `key_version` and `max_key_ver*`.
+            - Cross with the corresponding regwen value, confirm writes are attempted
+              while the regwen allows the write (unlocked) and while it blocks it (locked).'''
+    }
+    {
+      name: err_code_cg
+      desc: '''
+            - Cover all `err_code` values except `invalid_shadow_update`, which is tested in
+              a common direct test.
+            - Sampled when `err_code` is read.'''
+    }
+    {
+      name: hw_invalid_input_cg
+      desc: '''
+            Cover all HW invalid input scenarios, including:
+            - All ones/zeros on the OTP root key.
+            - OTP root key valid is low.
+            - All ones/zeros on the LC keymgr_dpe health state.
+            - All ones/zeros on ROM digest.
+            - ROM digest valid is low.
+            - All ones/zeros on flash creator seeds.
+            - All ones/zeros on flash owner seeds.'''
+    }
+    {
+      name: key_version_compare_cg
+      desc: '''
+            - Cover all comparison outcomes (equal, less than, greater than) between
+              key_version and the current max_key_version.
+            - Crossed with the working state and operation type (gen-sw-out or gen-hw-out).'''
+    }
+    {
+      name: fault_status_cg
+      desc: '''
+            - Cover all `fault_status` bit values
+            - Sampled when `fault_status` is read.'''
+    }
+    {
+      name: sync_async_fault_cross_cg
+      desc: '''
+            - Cover both orderings of a sync/async fault cross: sync fault occurring first,
+              and async fault occurring first.
+            - Sampled after `fault_status` is read in the cross-fault sequence.'''
     }
   ]
 }


### PR DESCRIPTION
# PR2 - testplan
This PR is the second in a series which will replace the [_keymgr_](https://opentitan.org/book/hw/ip/keymgr/index.html) with the [_kemgr_dpe_](https://opentitan.org/book/hw/ip/keymgr_dpe/index.html) in earlgrey. The replacement was approved by [this RFC](https://docs.google.com/document/d/1iF0EWyJkSEtRL9d057imLo4s6DWNrZ6Mpt0QKD8OMMc/).

## Merge-Dependencies

None

## Description

This PR adds a first draft version for the testplan to improve the dv coverage. Currently is not yet complete and none of the proposed test are implemented.

This PR is mainly to give an DV engineer a first overview of the proposed tests.