### PR TITLE
[keymgr_dpe] Replace keymgr in EG - PR3 blocklevel dv

### DIFF
--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_ctrl_if.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_ctrl_if.sv
@@ -1,0 +1,28 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// An interface that should be bound into an instance of keymgr_dpe_ctrl (and can access RTL signals
+// through upwards hierarchical references).
+interface keymgr_dpe_ctrl_if (input clk_i, input rst_ni);
+  import uvm_pkg::*;
+
+  // Function to access the key of one slot via backdoor.
+  // Required to load the UDS after XORing with generated randomness.
+  function automatic keymgr_dpe_env_pkg::key_shares_t get_key_of_slot(int unsigned slot);
+    import keymgr_dpe_pkg::DpeNumSlots;
+
+    // Check that the slot index is in range. The key_slots_q array has length DpeNumSlots, which is
+    // a global parameter.
+    if (slot >= DpeNumSlots) begin
+      `uvm_error($sformatf("%m"),
+                 $sformatf("Slot index out of range: index is %0d but DpeNumSlots is %0d",
+                           slot, DpeNumSlots))
+      return '0;
+    end
+
+    // This is an upwards hierarchical reference through the keymgr_dpe_ctrl module (into an
+    // instance of which this interface is bound)
+    return keymgr_dpe_ctrl.key_slots_q[slot].key;
+  endfunction
+endinterface

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env.core
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env.core
@@ -14,6 +14,7 @@ filesets:
       - lowrisc:ip:kmac_pkg
     files:
       - keymgr_dpe_env_pkg.sv
+      - keymgr_dpe_ctrl_if.sv
       - keymgr_dpe_if.sv
       - keymgr_dpe_env_cfg.sv: {is_include_file: true}
       - keymgr_dpe_env_cov.sv: {is_include_file: true}

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env.sv
@@ -25,6 +25,10 @@ class keymgr_dpe_env extends cip_base_env #(
       `uvm_fatal(`gfn, "failed to get keymgr_dpe_vif from uvm_config_db")
     end
     cfg.scb = scoreboard;
+    if (!uvm_config_db#(virtual keymgr_dpe_ctrl_if)::get(this, "", "keymgr_dpe_ctrl_vif",
+                                                         cfg.keymgr_dpe_ctrl_vif)) begin
+      `uvm_fatal(get_full_name(), "Could not get keymgr_dpe_ctrl_vif from uvm_config_db.")
+    end
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env_cfg.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env_cfg.sv
@@ -15,6 +15,9 @@ class keymgr_dpe_env_cfg extends cip_base_env_cfg #(.RAL_T(keymgr_dpe_reg_block)
 
   `uvm_object_new
 
+  // Interface that is bound into the keymgr_dpe_ctrl instance
+  virtual keymgr_dpe_ctrl_if keymgr_dpe_ctrl_vif;
+
   virtual function void initialize();
     list_of_alerts = keymgr_dpe_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_fault_err";

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
@@ -145,6 +145,8 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     int unsigned  nonzero_share1_indices[$];
     keymgr_dpe_pkg::keymgr_dpe_ops_e op;
     bit is_err;
+    bit invalid_hw_input;
+    bit invalid_op;
     logic [keymgr_dpe_pkg::DpeBootStagesWidth-1:0] boot_stage =
       current_internal_key[current_key_slot.src_slot].boot_stage;
 
@@ -154,8 +156,9 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     op = get_operation();
 
     `uvm_info(`gfn,
-              $sformatf("process_kmac_data_req: for op %s in state %s",
-                        op.name, current_state.name),
+              $sformatf({"process_kmac_data_req: for op %s in state %s",
+                           "with boot_stage set to %0d"},
+        op.name, current_state.name, boot_stage),
               UVM_MEDIUM)
 
     packet.get_share_byte_queue(0, req_bytes);
@@ -177,8 +180,11 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
       keymgr_dpe_pkg::OpDpeAdvance: begin
         // Invalid outputs and invalid operations should results in random data
         // for message data.
-        is_err = get_hw_invalid_input() || get_invalid_op();
-        `uvm_info(`gfn, $sformatf("What is is_err: %d", is_err), UVM_MEDIUM)
+        invalid_hw_input = get_hw_invalid_input();
+        invalid_op = get_invalid_op();
+        is_err = invalid_hw_input || invalid_op;
+        `uvm_info(`gfn, $sformatf({"Invalid HW Input %0b || Invalid OP %0b",
+            " = is_err %0b"}, invalid_hw_input, invalid_op, is_err), UVM_MEDIUM)
         case (current_state)
           keymgr_dpe_pkg::StWorkDpeAvailable: begin
             if(boot_stage == keymgr_dpe_pkg::BootStageCreator) begin
@@ -998,8 +1004,8 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     current_internal_key[current_key_slot.dst_slot].boot_stage = keymgr_dpe_pkg::BootStageCreator;
     current_internal_key[current_key_slot.dst_slot].max_key_version = max_key_version;
     current_internal_key[current_key_slot.dst_slot].key = otp_key;
-    current_internal_key[current_key_slot.dst_slot].key_policy = '0;
-    current_internal_key[current_key_slot.dst_slot].key_policy.allow_child = 1;
+    current_internal_key[current_key_slot.dst_slot].key_policy =
+        keymgr_dpe_pkg::DEFAULT_UDS_POLICY;
     `uvm_info(`gfn,
       $sformatf("latch_otp_key: key %p",
       current_internal_key[current_key_slot.dst_slot]
@@ -1084,11 +1090,10 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     key_policy : current_internal_key[current_key_slot.src_slot].key_policy;
     keymgr_dpe_pkg::keymgr_dpe_ops_e op = get_operation();
     `uvm_info(`gfn,
-    $sformatf({"get_invalid_op: op %s current_state: %s, ",
-        "current_internal_key[%0d] = %p"},
-        op.name, current_state.name, current_key_slot.src_slot,
-       current_internal_key[current_key_slot.src_slot]),
-       UVM_MEDIUM)
+    $sformatf({"get_invalid_op: op %s current_state: %s, src: %0d dst: %0d",
+        "current_internal_key = %p"}, op.name, current_state.name,
+        current_key_slot.src_slot, current_key_slot.dst_slot,
+        current_internal_key[current_key_slot.src_slot]), UVM_MEDIUM)
     case (current_state)
       keymgr_dpe_pkg::StWorkDpeReset : begin
         if (get_operation() != keymgr_dpe_pkg::OpDpeAdvance) begin
@@ -1284,6 +1289,8 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
   );
     adv_creator_data_t exp, act;
     string str = $sformatf("src_slot: %0d\n", current_key_slot.src_slot);
+
+    `uvm_info(`gfn, $sformatf("Compare data for boot stage 0"), UVM_MEDIUM)
 
     if (exp_match) `DV_CHECK_EQ(byte_data_q.size, keymgr_dpe_pkg::DpeAdvDataWidth / 8)
     act = {<<8{byte_data_q}};

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
@@ -71,6 +71,12 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
   bit                                is_kmac_rsp_err;
   bit                                is_kmac_invalid_data;
   bit                                is_sw_share_corrupted;
+  // Indicates if the UDS was fetched by the keymgr_dpe for the first time.
+  // The UDS needs to be xored with randomness to counter SCA, however the
+  // current dv environment cannot replicate this randomness. As a workaround
+  // the generated value (UDS xored with randomness) is loaded by a backdoor
+  // directly from the DUT.
+  bit                                load_uds_with_randomness;
 
   // HW internal key, used for OP in current state
   keymgr_dpe_env_pkg::keymgr_dpe_key_slot_t current_key_slot;
@@ -145,8 +151,6 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     int unsigned  nonzero_share1_indices[$];
     keymgr_dpe_pkg::keymgr_dpe_ops_e op;
     bit is_err;
-    bit invalid_hw_input;
-    bit invalid_op;
     logic [keymgr_dpe_pkg::DpeBootStagesWidth-1:0] boot_stage =
       current_internal_key[current_key_slot.src_slot].boot_stage;
 
@@ -156,9 +160,8 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     op = get_operation();
 
     `uvm_info(`gfn,
-              $sformatf({"process_kmac_data_req: for op %s in state %s",
-                           "with boot_stage set to %0d"},
-        op.name, current_state.name, boot_stage),
+              $sformatf("process_kmac_data_req: for op %s in state %s with boot_stage set to %0d",
+                        op.name, current_state.name, boot_stage),
               UVM_MEDIUM)
 
     packet.get_share_byte_queue(0, req_bytes);
@@ -178,38 +181,45 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
 
     case (op)
       keymgr_dpe_pkg::OpDpeAdvance: begin
+        bit invalid_hw_input;
+        bit invalid_op;
         // Invalid outputs and invalid operations should results in random data
         // for message data.
         invalid_hw_input = get_hw_invalid_input();
         invalid_op = get_invalid_op();
         is_err = invalid_hw_input || invalid_op;
-        `uvm_info(`gfn, $sformatf({"Invalid HW Input %0b || Invalid OP %0b",
-            " = is_err %0b"}, invalid_hw_input, invalid_op, is_err), UVM_MEDIUM)
+        `uvm_info("advance_req",
+                  $sformatf("Invalid HW input %0b or invalid OP %0b, so is_err %0b",
+                            invalid_hw_input, invalid_op, is_err),
+                  UVM_MEDIUM)
         case (current_state)
           keymgr_dpe_pkg::StWorkDpeAvailable: begin
             if(boot_stage == keymgr_dpe_pkg::BootStageCreator) begin
               `uvm_info(`gfn,
-              $sformatf({"process_kmac_data_req: boot_stage %0d is_err %0d",
-               "compare_boot_stage_0_data"},
-               boot_stage, is_err), UVM_LOW)
+                        $sformatf({"process_kmac_data_req: boot_stage %0d is_err %0d",
+                                   "compare_boot_stage_0_data"},
+                                   boot_stage, is_err),
+                        UVM_LOW)
               compare_boot_stage_0_data(
                 .exp_match(!is_err),
                 .byte_data_q(req_bytes)
               );
             end else if (boot_stage == keymgr_dpe_pkg::BootStageOwner) begin
               `uvm_info(`gfn,
-              $sformatf({"process_kmac_data_req: boot_stage %0d is_err %0d",
-               "compare_boot_stage_1_data"},
-               boot_stage, is_err), UVM_LOW)
+                        $sformatf({"process_kmac_data_req: boot_stage %0d is_err %0d",
+                                   "compare_boot_stage_1_data"},
+                                   boot_stage, is_err),
+                        UVM_LOW)
                compare_boot_stage_1_data(
                 .exp_match(!is_err),
                 .byte_data_q(req_bytes)
                );
             end else begin
               `uvm_info(`gfn,
-              $sformatf({"process_kmac_data_req: boot_stage %0d is_err %0d",
-               "compare_boot_stage_gte_2_data"},
-               boot_stage, is_err), UVM_LOW)
+                        $sformatf({"process_kmac_data_req: boot_stage %0d is_err %0d",
+                                   "compare_boot_stage_2_data"},
+                                   boot_stage, is_err),
+                        UVM_LOW)
                compare_boot_stage_gte_2_data(
                 .exp_match(!is_err),
                 .byte_data_q(req_bytes)
@@ -266,8 +276,10 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
 
     update_result = process_update_after_op_done();
 
-    `uvm_info(`gfn, $sformatf("process_kmac_data_rsp update_result %s for op %s in state %s with",
-         update_result.name, op.name, current_state.name), UVM_MEDIUM)
+    `uvm_info(`gfn,
+              $sformatf("process_kmac_data_rsp update_result %s for op %s in state %s with",
+                        update_result.name, op.name, current_state.name),
+              UVM_MEDIUM)
 
     case (update_result)
       // Should occur when a valid OpDpeAdvance is issued in the StWorkDpeAvailable state
@@ -1003,6 +1015,12 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     current_internal_key[current_key_slot.dst_slot].valid = 1;
     current_internal_key[current_key_slot.dst_slot].boot_stage = keymgr_dpe_pkg::BootStageCreator;
     current_internal_key[current_key_slot.dst_slot].max_key_version = max_key_version;
+    // This call loads the "true" UDS without the randomness present in the
+    // HW slot. The problem is that when this function is invoked (when writing into the start
+    // register for the first time) the randomness in the HW slot is not yet generated.
+    // The current workaround is to backdoor load the randomness from the hardware. This is done on
+    // the first advance call in the available state as the src_slot has the UDS loaded.
+    // TODO(#30758): Remove this backdoor load
     current_internal_key[current_key_slot.dst_slot].key = otp_key;
     current_internal_key[current_key_slot.dst_slot].key_policy =
         keymgr_dpe_pkg::DEFAULT_UDS_POLICY;
@@ -1015,6 +1033,15 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
       current_internal_key[current_key_slot.dst_slot].key,
       current_state
     );
+  endfunction
+
+  // Directly access the slot which holds the UDS with the xored randmoness
+  // Otherwise the scorebord would need to manually replicate the randomness
+  // generation.
+  // TODO(#30758): Remove this backdoor load
+  virtual function void backdoor_load_uds(int slot);
+    `uvm_info(`gfn, "Load UDS with randomness via backdoor", UVM_MEDIUM)
+    current_internal_key[slot].key = cfg.keymgr_dpe_ctrl_vif.get_key_of_slot(slot);
   endfunction
 
   virtual function bit [TL_DW-1:0] get_current_max_version(
@@ -1090,10 +1117,12 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     key_policy : current_internal_key[current_key_slot.src_slot].key_policy;
     keymgr_dpe_pkg::keymgr_dpe_ops_e op = get_operation();
     `uvm_info(`gfn,
-    $sformatf({"get_invalid_op: op %s current_state: %s, src: %0d dst: %0d",
-        "current_internal_key = %p"}, op.name, current_state.name,
-        current_key_slot.src_slot, current_key_slot.dst_slot,
-        current_internal_key[current_key_slot.src_slot]), UVM_MEDIUM)
+              $sformatf({"get_invalid_op: op %s current_state: %s, src: %0d dst: %0d ",
+                         "current_internal_key = %p"},
+                         op.name, current_state.name, current_key_slot.src_slot,
+                         current_key_slot.dst_slot,
+                         current_internal_key[current_key_slot.src_slot]),
+              UVM_MEDIUM)
     case (current_state)
       keymgr_dpe_pkg::StWorkDpeReset : begin
         if (get_operation() != keymgr_dpe_pkg::OpDpeAdvance) begin
@@ -1119,7 +1148,7 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
             ) begin
               `uvm_info(`gfn,
                 $sformatf(
-                  {"get_invalid_op: op %s current_state: %s retain_parent == 1",
+                  {"get_invalid_op: op %s current_state: %s retain_parent == 1 ",
                   "dst_slot valid err"},
                   op.name, current_state.name), UVM_MEDIUM)
               return 1;
@@ -1139,6 +1168,13 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
               $sformatf({"get_invalid_op: op %s current_state: %s",
                   "src_slot valid == 0 err"}, op.name, current_state.name), UVM_MEDIUM)
               return 1;
+            end
+            // Workaround to load the UDS with the xored randomness into the
+            // correct internal slot. The first (successful) advance call will
+            // use the UDS per default.
+            if (load_uds_with_randomness == 1'b0) begin
+              load_uds_with_randomness = 1'b1;
+              backdoor_load_uds(current_key_slot.src_slot);
             end
             return 0;
           end
@@ -1290,7 +1326,11 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     adv_creator_data_t exp, act;
     string str = $sformatf("src_slot: %0d\n", current_key_slot.src_slot);
 
-    `uvm_info(`gfn, $sformatf("Compare data for boot stage 0"), UVM_MEDIUM)
+    `uvm_info(`gfn,
+              $sformatf("compare_boot_stage_0_data src_slot %0d src_slot_val %p",
+                        current_key_slot.src_slot,
+                        current_internal_key[current_key_slot.src_slot]),
+              UVM_HIGH)
 
     if (exp_match) `DV_CHECK_EQ(byte_data_q.size, keymgr_dpe_pkg::DpeAdvDataWidth / 8)
     act = {<<8{byte_data_q}};
@@ -1329,6 +1369,12 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     adv_owner_int_data_t exp, act;
     string str = $sformatf("src_slot: %0d\n", current_key_slot.src_slot);
 
+    `uvm_info(`gfn,
+              $sformatf("compare_boot_stage_1_data src_slot %0d src_slot_val %p",
+                        current_key_slot.src_slot,
+                        current_internal_key[current_key_slot.src_slot]),
+              UVM_HIGH)
+
     act = {<<8{byte_data_q}};
     exp.OwnerRootSecret = cfg.keymgr_dpe_vif.owner_seed.seed;
     get_sw_binding_mirrored_value(exp.SoftwareBinding);
@@ -1357,10 +1403,13 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     adv_owner_data_t exp, act;
     string str = $sformatf("src_slot: %0d\n", current_key_slot.src_slot);
 
-    act = {<<8{byte_data_q}};
+    `uvm_info(`gfn,
+              $sformatf("compare_boot_stage_gte_2_data src_slot %0d src_slot_val %p",
+                        current_key_slot.src_slot,
+                        current_internal_key[current_key_slot.src_slot]),
+              UVM_HIGH)
 
-    `uvm_info(`gfn, $sformatf("compare_boot_stage_gte_2_data src_slot %0d src_slot_val %p",
-    current_key_slot.src_slot, current_internal_key[current_key_slot.src_slot]), UVM_MEDIUM)
+    act = {<<8{byte_data_q}};
 
     get_sw_binding_mirrored_value(exp.SoftwareBinding);
 
@@ -1547,6 +1596,7 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     is_kmac_rsp_err       = 0;
     is_kmac_invalid_data  = 0;
     is_sw_share_corrupted = 0;
+    load_uds_with_randomness = 0;
     foreach (current_internal_key[slot]) begin
       current_internal_key[slot].key = '0;
       current_internal_key[slot].key_policy = '0;

--- a/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_base_vseq.sv
+++ b/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_base_vseq.sv
@@ -100,7 +100,7 @@ class keymgr_dpe_base_vseq extends cip_base_vseq #(
       end
     end
 
-    `uvm_info(`gfn, "Initializating key manager", UVM_MEDIUM)
+    `uvm_info(`gfn, "Initializing keymgr dpe", UVM_MEDIUM)
 
     `DV_CHECK_RANDOMIZE_FATAL(ral.intr_enable)
     csr_update(.csr(ral.intr_enable));
@@ -117,8 +117,7 @@ class keymgr_dpe_base_vseq extends cip_base_vseq #(
       bit clr_output = $urandom_range(0, 1),
       bit wait_done = 1
   );
-    `uvm_info(`gfn,
-      $sformatf("Start keymgr_dpe_erase"), UVM_MEDIUM)
+    `uvm_info(`gfn, "Start keymgr_dpe_erase", UVM_MEDIUM)
 
     ral.control_shadowed.operation.set(keymgr_dpe_pkg::OpDpeErase);
     ral.control_shadowed.slot_src_sel.set(src_slot);
@@ -148,14 +147,16 @@ class keymgr_dpe_base_vseq extends cip_base_vseq #(
     end
   endtask : keymgr_dpe_erase
 
+  // Invoke the disable operation for the keymgr_dpe. This operation will
+  // the keymgr_dpe only if it's in the available state, otherwise the DUT
+  // will ignore this operation.
   virtual task keymgr_dpe_disable(
       int num_gen_op = $urandom_range(1, 4),
       int num_adv_op = $urandom_range(1, 4),
       bit clr_output = $urandom_range(0, 1),
       bit wait_done = 1
   );
-    `uvm_info(`gfn,
-      $sformatf("Start keymgr_dpe_disable"), UVM_MEDIUM)
+    `uvm_info(`gfn, "Start keymgr_dpe_disable", UVM_MEDIUM)
 
     ral.control_shadowed.operation.set(keymgr_dpe_pkg::OpDpeDisable);
     ral.control_shadowed.slot_src_sel.set(src_slot);
@@ -166,8 +167,22 @@ class keymgr_dpe_base_vseq extends cip_base_vseq #(
     if (wait_done)
       wait_op_done();
 
-    repeat (num_adv_op) begin
-      keymgr_dpe_advance(wait_done);
+    // Fix to make the smoketest pass again. The problem is that if
+    // the advance operation is invoked in the reset state, it is impossible
+    // to know how many times a valid advance operation is generated. However
+    // the current smoketest relies on knowing which slots are filled with
+    // valid entries.
+    // TODO(#323): Rewrite / Improve DV coverage of the keymgr_dpe
+    if (current_state == keymgr_dpe_pkg::StWorkDpeReset) begin
+      if (num_adv_op != 0) begin
+        `uvm_error(`gfn,
+                   {"Invoking the disable operation in the Reset State with the number of ",
+                    "request advance call not set to 0 can lead to unexpected behavior."})
+      end
+    end else begin
+      repeat (num_adv_op) begin
+        keymgr_dpe_advance(wait_done);
+      end
     end
 
     repeat (num_gen_op) begin
@@ -186,8 +201,9 @@ class keymgr_dpe_base_vseq extends cip_base_vseq #(
                                      bit clr_output    = $urandom_range(0, 1),
                                      bit wait_done     = 1);
     `uvm_info(`gfn,
-      $sformatf("Start keymgr_dpe_operations num_gen_op %0d advance_state %0d",
-        num_gen_op, advance_state), UVM_MEDIUM)
+              $sformatf("Start keymgr_dpe_operations num_gen_op %0d advance_state %0d",
+                        num_gen_op, advance_state),
+              UVM_MEDIUM)
 
     if (advance_state) keymgr_dpe_advance(wait_done);
 
@@ -253,8 +269,10 @@ class keymgr_dpe_base_vseq extends cip_base_vseq #(
             is_good_op &= !cfg.keymgr_dpe_vif.internal_key_slots[dst_slot].valid;
           end
         end
-        `uvm_info(`gfn, $sformatf("wait_op_done: current_state %s is_good_op %d",
-            current_state.name, is_good_op), UVM_MEDIUM)
+        `uvm_info(`gfn,
+                  $sformatf("wait_op_done: current_state %s is_good_op %d",
+                            current_state.name, is_good_op),
+                  UVM_MEDIUM)
       end
       keymgr_dpe_pkg::OpDpeGenSwOut,
       keymgr_dpe_pkg::OpDpeGenHwOut: begin
@@ -288,12 +306,13 @@ class keymgr_dpe_base_vseq extends cip_base_vseq #(
       end
     endcase
 
-    `uvm_info(`gfn, $sformatf({"Wait for operation done in state %0s, operation %0s, ",
-                               "src_slot[%0d] = %p, dst_slot[%0d] = %p, good_op %0d"},
-                              current_state.name, cast_operation.name,
-                              src_slot, cfg.keymgr_dpe_vif.internal_key_slots[src_slot],
-                              dst_slot, cfg.keymgr_dpe_vif.internal_key_slots[dst_slot],
-                              is_good_op),
+    `uvm_info(`gfn,
+              $sformatf({"Wait for operation done in state %0s, operation %0s, ",
+                         "src_slot[%0d] = %p, dst_slot[%0d] = %p, good_op %0d"},
+                         current_state.name, cast_operation.name,
+                         src_slot, cfg.keymgr_dpe_vif.internal_key_slots[src_slot],
+                         dst_slot, cfg.keymgr_dpe_vif.internal_key_slots[dst_slot],
+                         is_good_op),
               UVM_MEDIUM)
 
     // wait for status to get out of OpWip and check
@@ -356,8 +375,13 @@ class keymgr_dpe_base_vseq extends cip_base_vseq #(
     keymgr_dpe_pkg::keymgr_dpe_exposed_working_state_e exp_next_state = get_next_state(
       current_state, keymgr_dpe_pkg::OpDpeAdvance);
     sema_update_control_csr.get();
-    `uvm_info(`gfn, $sformatf("Advance key manager state from %0s slot %0d to %0d",
-      current_state.name, src_slot, dst_slot), UVM_MEDIUM)
+    `uvm_info(`gfn,
+              $sformatf({"Derive DPE context from %0d to %0d in state %s",
+                         " - pol. parent: %b pol. child: %b, pol. export: %b"},
+                         src_slot, dst_slot, current_state.name,
+                         policy.retain_parent, policy.allow_child,
+                         policy.exportable),
+              UVM_MEDIUM)
 
     ral.control_shadowed.operation.set(keymgr_dpe_pkg::OpDpeAdvance);
     ral.control_shadowed.slot_src_sel.set(src_slot);
@@ -389,8 +413,9 @@ class keymgr_dpe_base_vseq extends cip_base_vseq #(
     );
     sema_update_control_csr.get();
     `uvm_info(`gfn,
-      $sformatf("Generate key manager output w/operation %s and dest %s",
-        operation.name, key_dest.name), UVM_MEDIUM)
+              $sformatf("Generate key manager output w/operation %s and dest %s",
+                        operation.name, key_dest.name),
+              UVM_MEDIUM)
 
     ral.control_shadowed.operation.set(int'(operation));
     ral.control_shadowed.dest_sel.set(int'(key_dest));

--- a/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_smoke_vseq.sv
+++ b/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_smoke_vseq.sv
@@ -24,14 +24,16 @@ class keymgr_dpe_smoke_vseq extends keymgr_dpe_base_vseq;
   // for initial latch of OTP key src slot does not matter
   // it can be completely random
   constraint initial_slot_vals_c {
-    soft src_slot inside {[0:keymgr_dpe_pkg::DpeNumSlots-1]};
-    (!otp_latched) -> {soft dst_slot == 0;}
+    soft src_slot < keymgr_dpe_pkg::DpeNumSlots;
+    soft dst_slot < keymgr_dpe_pkg::DpeNumSlots;
+    if (!otp_latched) { soft dst_slot == 0; }
   }
 
   task body();
     // This test does the following:
-    // 1. While in reset state does a keymgr_dpe disable operation.
-    //    - also does a random amount of advances and generations
+    // 0. The keymgr_dpe is in the reset state.
+    // 1. Invoke a disable operation which should not affect the keymgr_dpe
+    //    at all as the disable operation is only valid in the available state!
     // 2. Fill key slots
     //    - latches OTP key and fills all key slots
     //    - each time doing a random amount of generations
@@ -45,35 +47,59 @@ class keymgr_dpe_smoke_vseq extends keymgr_dpe_base_vseq;
 
     // Checks are done via the scoreboard, but this test does have some additional checks
     // in terms of valid bit for key slots for checking key slots are filled and empty
-    `uvm_info(`gfn, "Key Manager DPE Smoke Start", UVM_HIGH)
+    `uvm_info(`gfn, "Key Manager DPE smoke - disable test", UVM_LOW)
 
     // 1.
-    keymgr_dpe_disable();
+    keymgr_dpe_disable(.num_adv_op(0));
 
     // 2.
-    for (int iter = 0; iter<keymgr_dpe_pkg::DpeNumSlots+1; iter++) begin
-      // retain_parent == 0, for the latched OTP
-      // so src_slot must == dst_slot
-      if (iter == 1) begin
-        otp_latched = 1'b1;
-        src_slot = dst_slot;
-      // retain_parent == 1, for further advances calls
-      // so src_slot must != dst_slot
-      end else if (iter > 1 & iter < keymgr_dpe_pkg::DpeNumSlots)  begin
-        src_slot = dst_slot;
-        dst_slot ++;
-      end
-      // Boot stages 0-3 are used for previous key slots. In the final key slot
-      // src_slot must differ from last iteration's dst slot.
-      // FIXME: Remove this constraint since DpeNumBootStages is removed.
-      else if (iter == keymgr_dpe_pkg::DpeNumSlots) begin
-        src_slot = $urandom_range(0,(keymgr_dpe_pkg::DpeNumSlots-1)-2);
-        dst_slot ++;
-      end
+    // unravel loop to both cover the retain_parent == 0/1 options
+    `uvm_info(`gfn, "Key Manager DPE smoke - advance test", UVM_LOW)
+
+    // load the UDS into dst_slot with an advance call
+    dst_slot = 0;
+    `uvm_info(`gfn,
+              $sformatf("Key Manager DPE smoke load UDS into dst_slot %d",
+                        dst_slot),
+              UVM_LOW)
+
+    // The keymgr_dpe is advanced once (which loads the UDS into the predefined
+    // slot - by the constraint: initial_slot_vals_c). Afterwards the
+    // keymgr_dpe_base_vseq.sv generates between 5 and 10 random key generation
+    // operations for the keymgr_dpe.
+    keymgr_dpe_operations(.advance_state(1), .num_gen_op($urandom_range(5,10)),
+                          .clr_output(1));
+
+    // Indicate the UDS is latched
+    otp_latched = 1'b1;
+
+    // If the default policy retain_parent is clear then we add an extra
+    // advance call to overwrite the UDS.
+    if (keymgr_dpe_pkg::DEFAULT_UDS_POLICY.retain_parent == 1'b0) begin
+      dst_slot = 0;
+      src_slot = 0;
+      // Indicate which stage is derived
       `uvm_info(`gfn,
-        $sformatf("Key Manager DPE Smoke Iter %0d: src_slot %d dst_slot %d",
-          iter, src_slot ,dst_slot), UVM_HIGH)
-      keymgr_dpe_operations(.advance_state(1), .num_gen_op($urandom_range(5,10)), .clr_output(1));
+                $sformatf({"Key Manager DPE smoke overwrite UDS when retain_parent=0: ",
+                           "src_slot %d dst_slot %d"},
+                           src_slot, dst_slot),
+                UVM_LOW)
+      keymgr_dpe_operations(.advance_state(1), .num_gen_op($urandom_range(5,10)),
+                            .clr_output(1));
+    end
+
+    // Iterate through all slots and fill them with DPE context
+    for (int iter = 0; iter < (keymgr_dpe_pkg::DpeNumSlots - 1); iter++) begin
+      // set source and destination
+      src_slot = dst_slot;
+      dst_slot ++;
+      // Indicate which slot is derived
+      `uvm_info(`gfn,
+                $sformatf("Key Manager DPE smoke iter %0d: src_slot %d dst_slot %d",
+                          iter, src_slot, dst_slot),
+                UVM_MEDIUM)
+      keymgr_dpe_operations(.advance_state(1), .num_gen_op($urandom_range(5,10)),
+                            .clr_output(1));
     end
 
     // Check to make sure all key slots are valid after the advance operations
@@ -88,6 +114,7 @@ class keymgr_dpe_smoke_vseq extends keymgr_dpe_base_vseq;
     // key slot that is still valid. The reason for picking slot 0 is that it should
     // only have boot_stage 1, which gives us enough boot_stages to advance and fill
     // key_slots 1-3 again.
+    `uvm_info(`gfn, "Key Manager DPE smoke - erase test", UVM_LOW)
     for (int iter = 1; iter<keymgr_dpe_pkg::DpeNumSlots; iter++) begin
       dst_slot = iter;
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(src_slot)
@@ -142,10 +169,10 @@ class keymgr_dpe_smoke_vseq extends keymgr_dpe_base_vseq;
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(dst_slot)
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(src_slot)
       `uvm_info(`gfn,
-      $sformatf(
-        {"Random Key Manager DPE Smoke randomize advance and operations:",
-        "src_slot %d dst_slot %d"},
-        src_slot ,dst_slot), UVM_HIGH)
+                $sformatf({"Random Key Manager DPE smoke advance ",
+                           "and operations: src_slot %d dst_slot %d"},
+                          src_slot, dst_slot),
+                UVM_HIGH)
       keymgr_dpe_operations(.advance_state(1), .num_gen_op($urandom_range(5,10)), .clr_output(1));
     end
 

--- a/hw/ip/keymgr_dpe/dv/tb.sv
+++ b/hw/ip/keymgr_dpe/dv/tb.sv
@@ -28,6 +28,8 @@ module tb;
   keymgr_dpe_if keymgr_dpe_if(.clk(clk), .rst_n(rst_n));
   kmac_app_if kmac_if(.clk_i(clk), .rst_ni(rst_n), .req(kmac_req), .rsp(kmac_rsp));
 
+  bind dut.u_ctrl keymgr_dpe_ctrl_if u_if (.clk_i, .rst_ni);
+
   // connect KDF interface for assertion check
   assign keymgr_dpe_if.kmac_data_req = kmac_req;
   assign keymgr_dpe_if.kmac_data_rsp = kmac_rsp;
@@ -85,6 +87,8 @@ module tb;
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual keymgr_dpe_if)::set(null, "*.env", "keymgr_dpe_vif", keymgr_dpe_if);
+    uvm_config_db#(virtual keymgr_dpe_ctrl_if)::set(null, "*.env", "keymgr_dpe_ctrl_vif",
+                                                    dut.u_ctrl.u_if);
     uvm_config_db#(virtual kmac_app_if)::set(null, "*env.m_kmac_agent*", "vif", kmac_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();


### PR DESCRIPTION
# PR3 - blocklevel dv
This PR is the third in a series which will replace the [_keymgr_](https://opentitan.org/book/hw/ip/keymgr/index.html) with the [_kemgr_dpe_](https://opentitan.org/book/hw/ip/keymgr_dpe/index.html) in earlgrey. The replacement was approved by [this RFC](https://docs.google.com/document/d/1iF0EWyJkSEtRL9d057imLo4s6DWNrZ6Mpt0QKD8OMMc/).

## Merge-Dependencies

- #30615 

## Relevant Commits

Last two commits

## Description

This PR cleans the blocklevel dv of the `keymgr_dpe` to support further development. Now both `retain_parent` policy are accurately mirror in the scoreboard. The scoreboard loads the UDS directly from the DUT via interface.