### PR TITLE
[keymgr_dpe] Replace keymgr in EG - PR4 BootStageOwnerInt / Top dep. parameter

### DIFF
--- a/hw/ip/keymgr_dpe/data/keymgr_dpe.hjson
+++ b/hw/ip/keymgr_dpe/data/keymgr_dpe.hjson
@@ -228,11 +228,33 @@
       default: "1",
       local: "true"
     },
+    { name: "NumMaxHwSlot",
+      desc: '''
+        Number of maximum supported HW slots. If this value is changed then the
+        bit width in SLOT_SRC_SEL / SLOT_DST_SEL in the
+        "CONTROL_SHADOWED" register needs to be updated too.
+      ''',
+      type: "int",
+      default: "8",
+      local: "true"
+    },
+    { name: "NumInstHwSlot",
+      desc: "Number of instantiated HW slots",
+      type: "int",
+      default: "4",
+      expose:  "true"
+    },
+    { name: "NumBootStages",
+      desc: "Number of available boot stage",
+      type: "int",
+      default: "3",
+      expose:  "true"
+    },
     { name: "NumRomDigestInputs",
       desc: "Number of digest inputs from ROM_CTRL",
       type: "int",
-      default: "2",
-      local: "true"
+      default: "1",
+      expose:  "true"
     },
   ],
 
@@ -551,6 +573,9 @@ countermeasures: [
           '''
         }
       ],
+      // TODO(#30682): Remove this label as soon as the RTL raises an
+      // error instead of a assertion.
+      tags: ["excl:CsrAllTests:CsrExclWrite"]
     },
 
     { name: "SIDELOAD_CLEAR",

--- a/hw/ip/keymgr_dpe/doc/theory_of_operation.md
+++ b/hw/ip/keymgr_dpe/doc/theory_of_operation.md
@@ -28,7 +28,7 @@ In order to address the relationships among keymgr_dpe slots and their stored DP
 
 ## Key Manager Slots
 
-Keymgr_dpe consists of `DpeNumSlots` slots, which is a generic parameter.
++Keymgr_dpe consists of `NumInstHwSlot` slots, which is a top-level parameter (instantiated up to `NumMaxHwSlot`).
 Each of these key manager slots can store a DPE context, i.e. all DICE-related information for a particular boot stage. That includes a secret key along with additional context information described below.
 The secret key size is fixed to 256-bit.
 
@@ -45,7 +45,7 @@ When a slot is active, `boot_stage` refers to its DPE context boot stage.
 For flexibility, `boot_stage` is a simple unsigned integer that is incremented from the parent's `boot_stage` during advance calls.
 Its actual mapping to boot stages such as ROM, BL0 or Kernel can be determined by SW.
 Hence, keymgr_dpe is oblivious to this mapping between counter values and the boot stages, though with an exception.
-The exception is that the first two stages are treated specially by RTL during KDF advance calls, as they consume other HW-backed inputs that come from keymgr_dpe’s peripheral inputs.
+The exception is that the initial boot stages are treated specially by RTL during KDF advance calls, as they consume other HW-backed inputs that come from keymgr_dpe’s peripheral inputs.
 From SW's point of view, they are still treated as any arbitrary DICE layer in that SW can provide further inputs through `SW_CDI_INPUT` CSR.
 
 A slot's `max_key_version` receives its value from `MAX_KEY_VERSION` register during a previous advance call that ends up populating this slot with DPE context.
@@ -127,16 +127,25 @@ The only relevant registers (or register fields) during the first advance call a
 
 In particular, the destination slot for the UDS is chosen by SW, and there is no designated special slot for it.
 Moreover, since the destination slot for this first advance call has no parent, its `boot_stage` value is not incremented but initialized to `0`.
-This initial latching can only be done once until the next power cycle.
+This initial latching can be repeated with the _Load Root Key_ operation unless locked with the `LOAD_KEY_LOCK` register.
 If the OTP creator root key is not valid during the latching cycle, keymgr_dpe moves to `Invalid`state.
 
 Further advance calls use the key stored in the specified `CONTROL_SHADOWED.SLOT_SRC_SEL` slot (equally referred to as _parent_ or _source_ slot) , and the result of the derivation updates the slot specified by `CONTROL_SHADOWED.SLOT_DST_SEL`  (referred to as _destination_ or _child_ slot).
 Assuming that `key_policy`, `boot_stage` or `valid` bits of the parent context permit, the child secret is derived from the parent secret through a key derivation function during advance operation.
-`child_key = KDF(parent_key, message)`, where the message input might take few forms depending on the parent slot's `boot_stage` value.
-In particular:
-* If `boot_stage = 0` for the parent, then `message = SW_CDI_INPUT || hw_revision_seed || device_identifier || health_st_measurement || rom_descriptors || creator_seed`. See [KDF Details](#kdf-details) for more details on HW-backed inputs.
-* If `boot_stage = 1` for the parent, then `message = SW_CDI_INPUT || owner_seed`.
-* If `boot_stage > 1` for the parent, then `message = SW_CDI_INPUT`.
+`child_key = KDF(parent_key, message)`, where the message input takes different forms depending on the parent slot's `boot_stage` value.
+Which HW-backed inputs are consumed at each stage is controlled by the `NumBootStages` parameter, and in particular whether the `creator_seed` is consumed together with the other creator inputs (two-stage configuration) or by a dedicated intermediate owner stage (three-stage configuration).
+See [KDF Details](#kdf-details) for more details on HW-backed inputs.
+
+With `NumBootStages = 3`, the `creator_seed` is consumed by a dedicated `OwnerInt` (owner intermediate) stage:
+* If `boot_stage = 0` (Creator) for the parent, then `message = SW_CDI_INPUT || device_identifier || health_st_measurement || rom_descriptors || hw_revision_seed`.
+* If `boot_stage = 1` (OwnerInt) for the parent, then `message = SW_CDI_INPUT || creator_seed`.
+* If `boot_stage = 2` (Owner) for the parent, then `message = SW_CDI_INPUT || owner_seed`.
+* If `boot_stage > 2` for the parent, then `message = SW_CDI_INPUT`.
+
+With `NumBootStages = 2`, the `OwnerInt` stage is omitted; the `creator_seed` is consumed together with the other creator inputs, and an advance from `Creator` increments `boot_stage` directly to `Owner` (i.e. `boot_stage = 1` is not used):
+* If `boot_stage = 0` (Creator) for the parent, then `message = SW_CDI_INPUT || hw_revision_seed || device_identifier || health_st_measurement || rom_descriptors || creator_seed`.
+* If `boot_stage = 2` (Owner) for the parent, then `message = SW_CDI_INPUT || owner_seed`.
+* If `boot_stage > 2` for the parent, then `message = SW_CDI_INPUT`.
 
 At the end of a successful advance operation, the following updates are made for the slot selected by `SLOT_DST_SEL`:
 * `valid` bit is set to 1.
@@ -161,7 +170,7 @@ When there is no fault and the enable signal is active by life cycle controller,
   * If `retain_parent = true`, then the source and the destination slots are different.
   * If `retain_parent = true`, then the destination slot is not valid (i.e. `valid = 0`).
   * If `retain_parent = false`, then the source and the destination slots are the same.
-  * `boot_stage` of the source slot has not reached to the maximum value supported by HW (i.e. `boot_stage + 1 < DpeNumBootStages`.
+  * `boot_stage` of the source slot has not reached to the maximum value supported by HW (i.e. `boot_stage + 1 < NumBootStages`).
 
 
 ### Versioned Key Generation
@@ -212,7 +221,7 @@ During advance operations, KDF inputs are 0 padded to `AdvDataWidth` bits. Depen
 * `hw_revision_seed` is a 256-bit netlist constant.
 * `device_identifier` is a 256-bit non-secret device identifier. This value is received from peripheral OTP port.
 * `health_st_measurement` is a 128-bit domain separator (i.e. diversification constant) that depends on the life cycle stage. This value is received from peripheral LC port.
-* `rom_descriptors` are two hash values for ROM0, ROM1. Each digest is 256-bits. These values are received from their respective ROM controllers.
+* `rom_descriptors` are `NumRomDigestInputs` hash values received from the respective ROM controller(s). Each digest is 256-bits.
 * `creator_seed` is 256-bit creator secret received from the `SECRET2` OTP partition..
 * `owner_seed` is 256-bit owner secret received from the `SECRET3` OTP partition.
 

--- a/hw/ip/keymgr_dpe/dv/README.md
+++ b/hw/ip/keymgr_dpe/dv/README.md
@@ -102,6 +102,7 @@ Here's how to run a smoke test:
 ```console
 $ dvsim $REPO_TOP/hw/ip/keymgr_dpe/dv/keymgr_dpe_sim_cfg.hjson -i keymgr_dpe_smoke
 ```
+With the configurations `keymgr_dpe_earlgrey_sim_cfg.hjson` / `keymgr_dpe_darjeeling_sim_cfg.hjson` it is possible to test the top dependent default configurations.
 
 ## Testplan
 [Testplan](../data/keymgr_dpe_testplan.hjson)

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_ctrl_if.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_ctrl_if.sv
@@ -10,14 +10,14 @@ interface keymgr_dpe_ctrl_if (input clk_i, input rst_ni);
   // Function to access the key of one slot via backdoor.
   // Required to load the UDS after XORing with generated randomness.
   function automatic keymgr_dpe_env_pkg::key_shares_t get_key_of_slot(int unsigned slot);
-    import keymgr_dpe_pkg::DpeNumSlots;
+    import keymgr_dpe_env_pkg::DvNumInstHwSlot;
 
-    // Check that the slot index is in range. The key_slots_q array has length DpeNumSlots, which is
-    // a global parameter.
-    if (slot >= DpeNumSlots) begin
+    // Check that the slot index is in range. The key_slots_q array has length DvNumInstHwSlot,
+    // which is a global parameter.
+    if (slot >= DvNumInstHwSlot) begin
       `uvm_error($sformatf("%m"),
-                 $sformatf("Slot index out of range: index is %0d but DpeNumSlots is %0d",
-                           slot, DpeNumSlots))
+                 $sformatf("Slot index out of range: index is %0d but DvNumInstHwSlot is %0d",
+                           slot, DvNumInstHwSlot))
       return '0;
     end
 

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env_pkg.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env_pkg.sv
@@ -20,6 +20,39 @@ package keymgr_dpe_env_pkg;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
+  // Define default values for all blocklevel dv parameter
+  `ifndef DEF_DV_BOOT_STAGES
+   `define DEF_DV_BOOT_STAGES 3
+  `endif
+  `ifndef DEF_DV_DPE_NUM_SLOT
+   `define DEF_DV_DPE_NUM_SLOT 4
+  `endif
+  `ifndef DEF_DV_NUM_ROM_DIGEST
+   `define DEF_DV_NUM_ROM_DIGEST 1
+  `endif
+
+  // Avoid using defines throughout the DV code by introducing the following
+  // parameters.
+  parameter int DvBootStages = `DEF_DV_BOOT_STAGES;
+  parameter int DvNumInstHwSlot = `DEF_DV_DPE_NUM_SLOT;
+  parameter int DvNumRomDigestInputs = `DEF_DV_NUM_ROM_DIGEST;
+
+  // Advance width calculation
+  // When deriving from the UDS the following data are consumed (Not ordered):
+  //   - Software binding
+  //   - Revision seed
+  //   - OTP device ID
+  //   - LC keymgr diversification value
+  //   - ROM digests
+  //   - Creator seed (only if boot stage equals two)
+  parameter int DvDpeAdvDataWidth = keymgr_pkg::SwBindingWidth +
+      keymgr_pkg::KeyWidth + keymgr_pkg::KeyWidth * (DvBootStages == 2) +
+      lc_ctrl_pkg::LcKeymgrDivWidth + keymgr_dpe_pkg::DeviceIdWidth +
+      keymgr_pkg::KeyWidth * DvNumRomDigestInputs;
+
+  localparam int DvNumInstHwSlotWidth = prim_util_pkg::vbits(DvNumInstHwSlot);
+  typedef logic [DvNumInstHwSlotWidth-1:0] dv_keymgr_dpe_slot_idx_e;
+
   // parameters and types
   parameter uint NUM_ALERTS = 2;
   parameter string LIST_OF_ALERTS[NUM_ALERTS] = {"recov_operation_err", "fatal_fault_err"};
@@ -64,8 +97,8 @@ package keymgr_dpe_env_pkg;
   } keymgr_dpe_fault_inject_type_e;
 
   typedef struct{
-    keymgr_dpe_pkg::keymgr_dpe_slot_idx_e src_slot;
-    keymgr_dpe_pkg::keymgr_dpe_slot_idx_e dst_slot;
+    dv_keymgr_dpe_slot_idx_e src_slot;
+    dv_keymgr_dpe_slot_idx_e dst_slot;
   } keymgr_dpe_key_slot_t;
 
   string msg_id = "keymgr_dpe_env_pkg";

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_if.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_if.sv
@@ -7,7 +7,6 @@ interface keymgr_dpe_if(input clk, input rst_n);
 
   import uvm_pkg::*;
   import keymgr_dpe_env_pkg::*;
-  import keymgr_dpe_reg_pkg::NumRomDigestInputs;
 
   // Represents the keymgr_dpe sideload state for each sideload interface.
   //
@@ -16,13 +15,13 @@ interface keymgr_dpe_if(input clk, input rst_n);
   // Status can't be directly changed from SideLoadClear to SideLoadAvail.
   // When status is SideLoadClear due to SIDELOAD_CLEAR programmed, need to write CSR to 0 to reset
   // it so that status is changed to SideLoadNotAvail, then we may set it to SideLoadAvail again
-  lc_ctrl_pkg::lc_tx_t                                keymgr_dpe_en;
-  lc_ctrl_pkg::lc_keymgr_div_t                        keymgr_dpe_div;
-  keymgr_dpe_pkg::keymgr_dpe_device_id_t              otp_device_id;
-  keymgr_dpe_pkg::keymgr_dpe_creator_root_key_t       creator_root_key;
-  keymgr_dpe_pkg::keymgr_dpe_creator_seed_t           creator_seed;
-  keymgr_dpe_pkg::keymgr_dpe_owner_seed_t             owner_seed;
-  rom_ctrl_pkg::keymgr_data_t[NumRomDigestInputs-1:0] rom_digests;
+  lc_ctrl_pkg::lc_tx_t                                  keymgr_dpe_en;
+  lc_ctrl_pkg::lc_keymgr_div_t                          keymgr_dpe_div;
+  keymgr_dpe_pkg::keymgr_dpe_device_id_t                otp_device_id;
+  keymgr_dpe_pkg::keymgr_dpe_creator_root_key_t         creator_root_key;
+  keymgr_dpe_pkg::keymgr_dpe_creator_seed_t             creator_seed;
+  keymgr_dpe_pkg::keymgr_dpe_owner_seed_t               owner_seed;
+  rom_ctrl_pkg::keymgr_data_t[DvNumRomDigestInputs-1:0] rom_digests;
 
   keymgr_pkg::hw_key_req_t kmac_key;
   keymgr_pkg::hw_key_req_t aes_key;
@@ -103,7 +102,7 @@ interface keymgr_dpe_if(input clk, input rst_n);
 
   // assigned from the keymgr_dpe.keymgr_dpe_ctrl.key_slots_q signal, which should hold the
   // current value of the keyslots in the dut.
-  keymgr_dpe_pkg::keymgr_dpe_slot_t [keymgr_dpe_pkg::DpeNumSlots-1:0] internal_key_slots;
+  keymgr_dpe_pkg::keymgr_dpe_slot_t [DvNumInstHwSlot-1:0] internal_key_slots;
 
   task automatic init(bit rand_otp_key, bit invalid_otp_key);
     // Keymgr_dpe only latches OTP key once, so this scb does not support change OTP key on the
@@ -115,7 +114,7 @@ interface keymgr_dpe_if(input clk, input rst_n);
     keymgr_dpe_en = lc_ctrl_pkg::On;
     keymgr_dpe_div = 64'h5CFBD765CE33F34E;
     otp_device_id = 'hF0F0;
-    for (int i = 0; i < NumRomDigestInputs; ++i) begin
+    for (int i = 0; i < DvNumRomDigestInputs; ++i) begin
       rom_digests[i].data = 256'hA20A046CF42E6EAC560A3F82BFA76285B5C1D4AEA7C915E49A32D1C89BE0F507;
       rom_digests[i].valid = '1;
     end
@@ -193,14 +192,14 @@ interface keymgr_dpe_if(input clk, input rst_n);
     // as a set of flags / counters.
     bit bad_keymgr_dpe_div = 1'b0;
     bit bad_otp_device_id = 1'b0;
-    bit [NumRomDigestInputs-1:0] bad_rom_data = '0, bad_rom_valid = '0;
+    bit [DvNumRomDigestInputs-1:0] bad_rom_data = '0, bad_rom_valid = '0;
 
     repeat (num_invalid_input) begin
       randcase
         1: bad_keymgr_dpe_div = 1'b1;
         1: bad_otp_device_id = 1'b1;
-        1: bad_rom_data[$urandom % NumRomDigestInputs] = 1'b1;
-        1: bad_rom_valid[$urandom % NumRomDigestInputs] = 1'b1;
+        1: bad_rom_data[$urandom % DvNumRomDigestInputs] = 1'b1;
+        1: bad_rom_valid[$urandom % DvNumRomDigestInputs] = 1'b1;
       endcase
     end
 
@@ -221,7 +220,7 @@ interface keymgr_dpe_if(input clk, input rst_n);
 
       // rom_digests
       begin
-        for (int i = 0; i < NumRomDigestInputs; i++)
+        for (int i = 0; i < DvNumRomDigestInputs; i++)
           fork
             automatic int local_i = i;
             #($urandom_range(1000, 0) * 1ns);
@@ -239,8 +238,8 @@ interface keymgr_dpe_if(input clk, input rst_n);
   function automatic void compare_internal_key_slot(
     keymgr_dpe_pkg::keymgr_dpe_slot_t dst_key_slot,
     keymgr_dpe_pkg::keymgr_dpe_slot_t src_key_slot,
-    keymgr_dpe_pkg::keymgr_dpe_slot_idx_e dst_slot_index,
-    keymgr_dpe_pkg::keymgr_dpe_slot_idx_e src_slot_index,
+    dv_keymgr_dpe_slot_idx_e dst_slot_index,
+    dv_keymgr_dpe_slot_idx_e src_slot_index,
     bit check_parent_retained
   );
     `DV_CHECK_EQ(dst_key_slot, internal_key_slots[dst_slot_index],

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
@@ -14,7 +14,7 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
   `define CREATE_CMP_STR(VAR) \
     str = $sformatf("%0s\n %0s act: 0x%0h, exp: 0x%0h", str, `"VAR`", act.``VAR, exp.``VAR);
 
-  // if boot_stage == 0
+  // if boot_stage == 0 with creator seed
   typedef struct packed {
     // SW_CDI_INPUT
     bit [keymgr_dpe_reg_pkg::NumSwBindingReg-1:0][TL_DW-1:0]               SoftwareBinding;
@@ -25,27 +25,52 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     // HEALTH_ST_MEASUREMENT
     bit [keymgr_pkg::HealthStateWidth-1:0]                                 HealthMeasurement;
     // ROM_DESCRIPTORS
-    bit [keymgr_dpe_reg_pkg::NumRomDigestInputs-1:0][keymgr_pkg::KeyWidth-1:0] RomDigests;
+    bit [keymgr_dpe_env_pkg::DvNumRomDigestInputs-1:0][keymgr_pkg::KeyWidth-1:0] RomDigests;
     // CREATOR_SEED
-    bit [keymgr_pkg::KeyWidth-1:0]                                         DiversificationKey;
-  } adv_creator_data_t;
+    bit [keymgr_pkg::KeyWidth-1:0]                                         CreatorRootSecret;
+  } adv_creator_data_with_creator_seed_t;
+
+  // if boot_stage == 0 without creator seed
+  typedef struct packed {
+    // SW_CDI_INPUT
+    bit [keymgr_dpe_reg_pkg::NumSwBindingReg-1:0][TL_DW-1:0]               SoftwareBinding;
+    // DEVICE_IDENTIFIER
+    bit [keymgr_pkg::DevIdWidth-1:0]                                       DeviceIdentifier;
+    // HEALTH_ST_MEASUREMENT
+    bit [keymgr_pkg::HealthStateWidth-1:0]                                 HealthMeasurement;
+    // ROM_DESCRIPTORS
+    bit [keymgr_dpe_env_pkg::DvNumRomDigestInputs-1:0][keymgr_pkg::KeyWidth-1:0] RomDigests;
+    // HW_REVISION_SEED
+    bit [keymgr_pkg::KeyWidth-1:0]                                         HardwareRevisionSecret;
+  } adv_creator_data_without_creator_seed_t;
 
   typedef struct packed {
     // some portions are unused, which are 0s
-    bit [keymgr_dpe_pkg::DpeAdvDataWidth-keymgr_pkg::KeyWidth-keymgr_pkg::SwBindingWidth-1:0]
+    bit [keymgr_dpe_env_pkg::DvDpeAdvDataWidth-keymgr_pkg::KeyWidth-keymgr_pkg::SwBindingWidth-1:0]
+        unused;
+    // SW_CDI_INPUT
+    bit [keymgr_dpe_reg_pkg::NumSwBindingReg-1:0][TL_DW-1:0] SoftwareBinding;
+    // CREATOR_SEED
+    bit [keymgr_pkg::KeyWidth-1:0] CreatorRootSecret;
+  } adv_owner_int_data_t;
+
+  typedef struct packed {
+    // some portions are unused, which are 0s
+    bit [keymgr_dpe_env_pkg::DvDpeAdvDataWidth-keymgr_pkg::KeyWidth-keymgr_pkg::SwBindingWidth-1:0]
         unused;
     // SW_CDI_INPUT
     bit [keymgr_dpe_reg_pkg::NumSwBindingReg-1:0][TL_DW-1:0] SoftwareBinding;
     // OWNER SEED
     bit [keymgr_pkg::KeyWidth-1:0] OwnerRootSecret;
-  } adv_owner_int_data_t;
+  } adv_owner_data_t;
 
   typedef struct packed {
     // some portions are unused, which are 0s
-    bit [keymgr_dpe_pkg::DpeAdvDataWidth-keymgr_pkg::SwBindingWidth-1:0]  unused;
+    bit [keymgr_dpe_env_pkg::DvDpeAdvDataWidth-keymgr_pkg::SwBindingWidth-1:0]
+        unused;
     // SW_CDI_INPUT
     bit [keymgr_dpe_reg_pkg::NumSwBindingReg-1:0][TL_DW-1:0] SoftwareBinding;
-  } adv_owner_data_t;
+  } adv_runtime_data_t;
 
   typedef struct packed {
     bit [TL_DW-1:0]      KeyVersion;
@@ -80,7 +105,7 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
 
   // HW internal key, used for OP in current state
   keymgr_dpe_env_pkg::keymgr_dpe_key_slot_t current_key_slot;
-  keymgr_dpe_pkg::keymgr_dpe_slot_t current_internal_key[keymgr_dpe_pkg::DpeNumSlots];
+  keymgr_dpe_pkg::keymgr_dpe_slot_t current_internal_key[keymgr_dpe_env_pkg::DvNumInstHwSlot];
   bit [keymgr_pkg::KeyWidth-1:0] old_key;
   // bit used to flag a comparison of key slot is required
   // it's set by the process_kmac_data_rsp() function, during an
@@ -104,8 +129,8 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
 
   // local queues to hold incoming packets pending comparison
   // store meaningful data, in non-working state, should not match to these data
-  bit [keymgr_dpe_pkg::DpeAdvDataWidth-1:0] adv_data_a_array[
-    keymgr_dpe_pkg::DpeNumSlots][
+  bit [keymgr_dpe_env_pkg::DvDpeAdvDataWidth-1:0] adv_data_a_array[
+    keymgr_dpe_env_pkg::DvNumInstHwSlot][
     keymgr_dpe_pkg::keymgr_dpe_exposed_working_state_e];
   bit [keymgr_pkg::IdDataWidth-1:0]  id_data_a_array[
     keymgr_dpe_pkg::keymgr_dpe_exposed_working_state_e];
@@ -196,31 +221,41 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
           keymgr_dpe_pkg::StWorkDpeAvailable: begin
             if(boot_stage == keymgr_dpe_pkg::BootStageCreator) begin
               `uvm_info(`gfn,
-                        $sformatf({"process_kmac_data_req: boot_stage %0d is_err %0d",
-                                   "compare_boot_stage_0_data"},
+                        $sformatf({"process_kmac_data_req: boot_stage %0d ",
+                                   "is_err %0d compare_boot_stage_0_data"},
                                    boot_stage, is_err),
                         UVM_LOW)
               compare_boot_stage_0_data(
                 .exp_match(!is_err),
                 .byte_data_q(req_bytes)
               );
-            end else if (boot_stage == keymgr_dpe_pkg::BootStageOwner) begin
+            end else if (boot_stage == keymgr_dpe_pkg::BootStageOwnerInt) begin
               `uvm_info(`gfn,
-                        $sformatf({"process_kmac_data_req: boot_stage %0d is_err %0d",
-                                   "compare_boot_stage_1_data"},
+                        $sformatf({"process_kmac_data_req: boot_stage %0d ",
+                                   "is_err %0d compare_boot_stage_1_data"},
                                    boot_stage, is_err),
                         UVM_LOW)
                compare_boot_stage_1_data(
                 .exp_match(!is_err),
                 .byte_data_q(req_bytes)
                );
-            end else begin
+            end else if (boot_stage == keymgr_dpe_pkg::BootStageOwner) begin
               `uvm_info(`gfn,
-                        $sformatf({"process_kmac_data_req: boot_stage %0d is_err %0d",
-                                   "compare_boot_stage_2_data"},
+                        $sformatf({"process_kmac_data_req: boot_stage %0d ",
+                                   "is_err %0d compare_boot_stage_2_data"},
                                    boot_stage, is_err),
                         UVM_LOW)
-               compare_boot_stage_gte_2_data(
+               compare_boot_stage_2_data(
+                .exp_match(!is_err),
+                .byte_data_q(req_bytes)
+               );
+            end else begin
+              `uvm_info(`gfn,
+                        $sformatf({"process_kmac_data_req: boot_stage %0d ",
+                                   "is_err %0d compare_boot_stage_runtime_data"},
+                                   boot_stage, is_err),
+                        UVM_LOW)
+               compare_boot_stage_runtime_data(
                 .exp_match(!is_err),
                 .byte_data_q(req_bytes)
                );
@@ -295,6 +330,15 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
         // runtime stage, we do not increment the boot stage.
         case(current_internal_key[current_key_slot.src_slot].boot_stage)
           keymgr_dpe_pkg::BootStageCreator: begin
+            if (DvBootStages == 2) begin
+              current_internal_key[current_key_slot.dst_slot].boot_stage =
+                keymgr_dpe_pkg::BootStageOwner;
+            end else begin
+              current_internal_key[current_key_slot.dst_slot].boot_stage =
+                keymgr_dpe_pkg::BootStageOwnerInt;
+            end
+          end
+          keymgr_dpe_pkg::BootStageOwnerInt: begin
             current_internal_key[current_key_slot.dst_slot].boot_stage =
               keymgr_dpe_pkg::BootStageOwner;
           end
@@ -1269,7 +1313,7 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
         `uvm_info(`gfn, "HW invalid input on otp_device_id", UVM_LOW)
       end
 
-      for (int i = 0; i < keymgr_dpe_reg_pkg::NumRomDigestInputs; ++i) begin
+      for (int i = 0; i < keymgr_dpe_env_pkg::DvNumRomDigestInputs; ++i) begin
         if (cfg.keymgr_dpe_vif.rom_digests[i].data inside {0, '1}) begin
           invalid_hw_input_type = RomDigestInvalid;
           void'(ral.debug.invalid_digest.predict(1));
@@ -1323,43 +1367,91 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
       bit exp_match,
       const ref byte unsigned byte_data_q[$]
   );
-    adv_creator_data_t exp, act;
     string str = $sformatf("src_slot: %0d\n", current_key_slot.src_slot);
 
-    `uvm_info(`gfn,
-              $sformatf("compare_boot_stage_0_data src_slot %0d src_slot_val %p",
-                        current_key_slot.src_slot,
-                        current_internal_key[current_key_slot.src_slot]),
-              UVM_HIGH)
-
-    if (exp_match) `DV_CHECK_EQ(byte_data_q.size, keymgr_dpe_pkg::DpeAdvDataWidth / 8)
-    act = {<<8{byte_data_q}};
-    exp.DiversificationKey = cfg.keymgr_dpe_vif.creator_seed.seed;
-
-    for (int i = 0; i < keymgr_dpe_reg_pkg::NumRomDigestInputs; ++i) begin
-      exp.RomDigests[i] = cfg.keymgr_dpe_vif.rom_digests[i].data;
-    end
-    exp.HealthMeasurement  = cfg.keymgr_dpe_vif.keymgr_dpe_div;
-    exp.DeviceIdentifier   = cfg.keymgr_dpe_vif.otp_device_id;
-    exp.HardwareRevisionSecret = keymgr_pkg::RndCnstRevisionSeedDefault;
-
-    get_sw_binding_mirrored_value(exp.SoftwareBinding);
-
-    // The order of the string creation must match the design
-    `CREATE_CMP_STR(DiversificationKey)
-    `CREATE_CMP_STR(RomDigests)
-    `CREATE_CMP_STR(HealthMeasurement)
-    `CREATE_CMP_STR(DeviceIdentifier)
-    `CREATE_CMP_STR(HardwareRevisionSecret)
-    `CREATE_CMP_STR(SoftwareBinding)
-
     if (exp_match) begin
-      `DV_CHECK_EQ(act, exp, str)
-    end else begin
-      `DV_CHECK_NE(act, exp, str)
+      `DV_CHECK_EQ(byte_data_q.size, keymgr_dpe_env_pkg::DvDpeAdvDataWidth / 8)
     end
 
-    if (exp_match) adv_data_a_array[current_key_slot.src_slot][current_state] = act;
+    if (DvBootStages == 2) begin
+      adv_creator_data_with_creator_seed_t exp, act;
+
+      `uvm_info(`gfn,
+                $sformatf({"compare_boot_stage_0_data src_slot %0d src_slot_val %p ",
+                           "with the creator seed"},
+                           current_key_slot.src_slot,
+                           current_internal_key[current_key_slot.src_slot]),
+                UVM_HIGH)
+
+      act = {<<8{byte_data_q}};
+
+      exp.CreatorRootSecret = cfg.keymgr_dpe_vif.creator_seed.seed;
+      for (int i = 0; i < keymgr_dpe_env_pkg::DvNumRomDigestInputs; ++i) begin
+        exp.RomDigests[i] = cfg.keymgr_dpe_vif.rom_digests[i].data;
+      end
+      exp.HealthMeasurement  = cfg.keymgr_dpe_vif.keymgr_dpe_div;
+      exp.DeviceIdentifier   = cfg.keymgr_dpe_vif.otp_device_id;
+      exp.HardwareRevisionSecret = keymgr_pkg::RndCnstRevisionSeedDefault;
+
+      get_sw_binding_mirrored_value(exp.SoftwareBinding);
+
+      // The order of the string creation must match the design
+      `CREATE_CMP_STR(CreatorRootSecret)
+      for (int i = 0; i < keymgr_dpe_env_pkg::DvNumRomDigestInputs; ++i) begin
+        `CREATE_CMP_STR(RomDigests[i])
+      end
+      `CREATE_CMP_STR(HealthMeasurement)
+      `CREATE_CMP_STR(DeviceIdentifier)
+      `CREATE_CMP_STR(HardwareRevisionSecret)
+      for (int i = 0; i < keymgr_dpe_reg_pkg::NumSwBindingReg; i++) begin
+        `CREATE_CMP_STR(SoftwareBinding[i])
+      end
+
+      if (exp_match) begin
+        `DV_CHECK_EQ(act, exp, str)
+      end else begin
+        `DV_CHECK_NE(act, exp, str)
+      end
+
+      if (exp_match) adv_data_a_array[current_key_slot.src_slot][current_state] = act;
+    end else begin
+      adv_creator_data_without_creator_seed_t exp, act;
+
+      `uvm_info(`gfn,
+                $sformatf({"compare_boot_stage_0_data src_slot %0d src_slot_val %p ",
+                           "without the creator seed"},
+                           current_key_slot.src_slot,
+                           current_internal_key[current_key_slot.src_slot]),
+                UVM_HIGH)
+
+      act = {<<8{byte_data_q}};
+
+      for (int i = 0; i < keymgr_dpe_env_pkg::DvNumRomDigestInputs; ++i) begin
+        exp.RomDigests[i] = cfg.keymgr_dpe_vif.rom_digests[i].data;
+      end
+      exp.HealthMeasurement  = cfg.keymgr_dpe_vif.keymgr_dpe_div;
+      exp.DeviceIdentifier   = cfg.keymgr_dpe_vif.otp_device_id;
+      exp.HardwareRevisionSecret = keymgr_pkg::RndCnstRevisionSeedDefault;
+
+      get_sw_binding_mirrored_value(exp.SoftwareBinding);
+
+      // The order of the string creation must match the design
+      `CREATE_CMP_STR(HardwareRevisionSecret)
+      `CREATE_CMP_STR(RomDigests)
+      `CREATE_CMP_STR(HealthMeasurement)
+      `CREATE_CMP_STR(DeviceIdentifier)
+      for (int i = 0; i < keymgr_dpe_reg_pkg::NumSwBindingReg; i++) begin
+        `CREATE_CMP_STR(SoftwareBinding[i])
+      end
+
+      if (exp_match) begin
+        `DV_CHECK_EQ(act, exp, str)
+      end else begin
+        `DV_CHECK_NE(act, exp, str)
+      end
+
+      if (exp_match) adv_data_a_array[current_key_slot.src_slot][current_state] = act;
+    end
   endfunction
 
   virtual function void compare_boot_stage_1_data(
@@ -1371,6 +1463,38 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
 
     `uvm_info(`gfn,
               $sformatf("compare_boot_stage_1_data src_slot %0d src_slot_val %p",
+                        current_key_slot.src_slot,
+                        current_internal_key[current_key_slot.src_slot]),
+              UVM_HIGH)
+
+    act = {<<8{byte_data_q}};
+    exp.CreatorRootSecret = cfg.keymgr_dpe_vif.creator_seed.seed;
+    get_sw_binding_mirrored_value(exp.SoftwareBinding);
+
+    `CREATE_CMP_STR(unused)
+    `CREATE_CMP_STR(CreatorRootSecret)
+    for (int i = 0; i < keymgr_dpe_reg_pkg::NumSwBindingReg; i++) begin
+      `CREATE_CMP_STR(SoftwareBinding[i])
+    end
+
+    if (exp_match) begin
+      `DV_CHECK_EQ(act, exp, str)
+    end else begin
+      `DV_CHECK_NE(act, exp, str)
+    end
+
+    if (exp_match) adv_data_a_array[current_key_slot.src_slot][current_state] = act;
+  endfunction
+
+  virtual function void compare_boot_stage_2_data(
+      bit exp_match,
+      const ref byte unsigned byte_data_q[$]
+    );
+    adv_owner_data_t exp, act;
+    string str = $sformatf("src_slot: %0d\n", current_key_slot.src_slot);
+
+    `uvm_info(`gfn,
+              $sformatf("compare_boot_stage_2_data src_slot %0d src_slot_val %p",
                         current_key_slot.src_slot,
                         current_internal_key[current_key_slot.src_slot]),
               UVM_HIGH)
@@ -1396,15 +1520,15 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
 
   // For boot stages >= 2, we expect the same key material format
   // being sent out to the kmac engine
-  virtual function void compare_boot_stage_gte_2_data(
+  virtual function void compare_boot_stage_runtime_data(
      bit exp_match,
      const ref byte unsigned byte_data_q[$]
    );
-    adv_owner_data_t exp, act;
+    adv_runtime_data_t exp, act;
     string str = $sformatf("src_slot: %0d\n", current_key_slot.src_slot);
 
     `uvm_info(`gfn,
-              $sformatf("compare_boot_stage_gte_2_data src_slot %0d src_slot_val %p",
+              $sformatf("compare_boot_stage_runtime_data src_slot %0d src_slot_val %p",
                         current_key_slot.src_slot,
                         current_internal_key[current_key_slot.src_slot]),
               UVM_HIGH)
@@ -1616,7 +1740,7 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
   function void check_phase(uvm_phase phase);
     super.check_phase(phase);
     // post test checks - ensure that all local fifos and queues are empty
-    for (int slot = 0; slot < keymgr_dpe_pkg::DpeNumSlots; slot++) begin
+    for (int slot = 0; slot < keymgr_dpe_env_pkg::DvNumInstHwSlot; slot++) begin
       `DV_CHECK_EQ(cfg.keymgr_dpe_vif.internal_key_slots[slot].valid,
                    current_internal_key[slot].valid)
       if (current_internal_key[slot].valid) begin

--- a/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_base_vseq.sv
+++ b/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_base_vseq.sv
@@ -30,8 +30,8 @@ class keymgr_dpe_base_vseq extends cip_base_vseq #(
   rand bit do_rand_otp_key;
   rand bit do_invalid_otp_key;
   rand keymgr_dpe_pkg::keymgr_dpe_policy_t policy;
-  rand keymgr_dpe_pkg::keymgr_dpe_slot_idx_e src_slot;
-  rand keymgr_dpe_pkg::keymgr_dpe_slot_idx_e dst_slot;
+  rand keymgr_dpe_env_pkg::dv_keymgr_dpe_slot_idx_e src_slot;
+  rand keymgr_dpe_env_pkg::dv_keymgr_dpe_slot_idx_e dst_slot;
 
   // save DUT returned current state here, rather than using it from RAL,
   // it's needed info to predict operation result in seq
@@ -101,6 +101,13 @@ class keymgr_dpe_base_vseq extends cip_base_vseq #(
     end
 
     `uvm_info(`gfn, "Initializing keymgr dpe", UVM_MEDIUM)
+    `uvm_info(`gfn,
+              $sformatf({"Top dependent dv parameter > # Bootstages: %0d # HW slots: %0d ",
+                         "# ROM Digest values: %0d Size Adv Data: %0d"},
+                         keymgr_dpe_env_pkg::DvBootStages, keymgr_dpe_env_pkg::DvNumInstHwSlot,
+                         keymgr_dpe_env_pkg::DvNumRomDigestInputs,
+                         keymgr_dpe_env_pkg::DvDpeAdvDataWidth),
+              UVM_LOW)
 
     `DV_CHECK_RANDOMIZE_FATAL(ral.intr_enable)
     csr_update(.csr(ral.intr_enable));

--- a/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_smoke_vseq.sv
+++ b/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_smoke_vseq.sv
@@ -24,8 +24,8 @@ class keymgr_dpe_smoke_vseq extends keymgr_dpe_base_vseq;
   // for initial latch of OTP key src slot does not matter
   // it can be completely random
   constraint initial_slot_vals_c {
-    soft src_slot < keymgr_dpe_pkg::DpeNumSlots;
-    soft dst_slot < keymgr_dpe_pkg::DpeNumSlots;
+    soft src_slot < keymgr_dpe_env_pkg::DvNumInstHwSlot;
+    soft dst_slot < keymgr_dpe_env_pkg::DvNumInstHwSlot;
     if (!otp_latched) { soft dst_slot == 0; }
   }
 
@@ -89,7 +89,7 @@ class keymgr_dpe_smoke_vseq extends keymgr_dpe_base_vseq;
     end
 
     // Iterate through all slots and fill them with DPE context
-    for (int iter = 0; iter < (keymgr_dpe_pkg::DpeNumSlots - 1); iter++) begin
+    for (int iter = 0; iter < (keymgr_dpe_env_pkg::DvNumInstHwSlot - 1); iter++) begin
       // set source and destination
       src_slot = dst_slot;
       dst_slot ++;
@@ -104,7 +104,7 @@ class keymgr_dpe_smoke_vseq extends keymgr_dpe_base_vseq;
 
     // Check to make sure all key slots are valid after the advance operations
     // this is checked via the valid bit being set in the key slot
-    for (int slot = 0; slot < keymgr_dpe_pkg::DpeNumSlots; slot++) begin
+    for (int slot = 0; slot < keymgr_dpe_env_pkg::DvNumInstHwSlot; slot++) begin
       `DV_CHECK_EQ(cfg.keymgr_dpe_vif.internal_key_slots[slot].valid, 1)
     end
 
@@ -115,7 +115,7 @@ class keymgr_dpe_smoke_vseq extends keymgr_dpe_base_vseq;
     // only have boot_stage 1, which gives us enough boot_stages to advance and fill
     // key_slots 1-3 again.
     `uvm_info(`gfn, "Key Manager DPE smoke - erase test", UVM_LOW)
-    for (int iter = 1; iter<keymgr_dpe_pkg::DpeNumSlots; iter++) begin
+    for (int iter = 1; iter < keymgr_dpe_env_pkg::DvNumInstHwSlot; iter++) begin
       dst_slot = iter;
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(src_slot)
       keymgr_dpe_erase(.num_adv_op(4));
@@ -123,7 +123,7 @@ class keymgr_dpe_smoke_vseq extends keymgr_dpe_base_vseq;
 
     // To verify the erase operation succeeded, check that the valid bits
     // of the erased key slots are not de-asserted.
-    for (int slot = 1; slot < keymgr_dpe_pkg::DpeNumSlots; slot++) begin
+    for (int slot = 1; slot < keymgr_dpe_env_pkg::DvNumInstHwSlot; slot++) begin
       `DV_CHECK_EQ(cfg.keymgr_dpe_vif.internal_key_slots[slot].valid, 0)
     end
 
@@ -136,17 +136,17 @@ class keymgr_dpe_smoke_vseq extends keymgr_dpe_base_vseq;
     // set dst_slot to 1, to begin filling slot 1-3 again
     src_slot = 0;
     dst_slot = 1;
-    for (int iter = 0; iter<keymgr_dpe_pkg::DpeNumSlots; iter++) begin
+    for (int iter = 0; iter < keymgr_dpe_env_pkg::DvNumInstHwSlot; iter++) begin
       // The boot_stage for key_slot 2 is expected to be 3.
       // This means we can not use it to derive key_slot 3.
       // We have to use either key_slot 0 or 1. So on the final iteration
       // randomize to use either key_slot 0 or 1
-      if (iter == keymgr_dpe_pkg::DpeNumSlots-2) begin
+      if (iter == keymgr_dpe_env_pkg::DvNumInstHwSlot-2) begin
         src_slot = $urandom_range(0, 1);
         // Set retain_parent to 0. So that an additional advance can be done with the same src and dst slot
         policy.retain_parent = 0;
       end
-      if (iter == keymgr_dpe_pkg::DpeNumSlots-1) begin
+      if (iter == keymgr_dpe_env_pkg::DvNumInstHwSlot-1) begin
         src_slot = 3;
         dst_slot = 3;
       end
@@ -157,7 +157,7 @@ class keymgr_dpe_smoke_vseq extends keymgr_dpe_base_vseq;
 
     // Check to make sure all key slots are valid after the advance operations
     // this is checked via the valid bit being set in the key slot
-    for (int slot = 1; slot < keymgr_dpe_pkg::DpeNumSlots; slot++) begin
+    for (int slot = 1; slot < keymgr_dpe_env_pkg::DvNumInstHwSlot; slot++) begin
       `DV_CHECK_EQ(cfg.keymgr_dpe_vif.internal_key_slots[slot].valid, 1)
     end
 

--- a/hw/ip/keymgr_dpe/dv/keymgr_dpe_darjeeling_sim_cfg.hjson
+++ b/hw/ip/keymgr_dpe/dv/keymgr_dpe_darjeeling_sim_cfg.hjson
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+{
+  // Name of the sim cfg variant
+  variant: darjeeling
+
+  // Import the keymgr_dpe sim_cfg file
+  import_cfgs: ["{proj_root}/hw/ip/keymgr_dpe/dv/keymgr_dpe_sim_cfg.hjson"]
+
+  build_opts: ["+define+DEF_DV_BOOT_STAGES=2",
+               "+define+DEF_DV_DPE_NUM_SLOT=8",
+               "+define+DEF_DV_NUM_ROM_DIGEST=2"]
+}

--- a/hw/ip/keymgr_dpe/dv/keymgr_dpe_earlgrey_sim_cfg.hjson
+++ b/hw/ip/keymgr_dpe/dv/keymgr_dpe_earlgrey_sim_cfg.hjson
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+{
+  // Name of the sim cfg variant
+  variant: earlgrey
+
+  // Import the keymgr_dpe sim_cfg file
+  import_cfgs: ["{proj_root}/hw/ip/keymgr_dpe/dv/keymgr_dpe_sim_cfg.hjson"]
+
+  build_opts:  ["+define+DEF_DV_BOOT_STAGES=3",
+                "+define+DEF_DV_DPE_NUM_SLOT=4",
+                "+define+DEF_DV_NUM_ROM_DIGEST=1"]
+}

--- a/hw/ip/keymgr_dpe/dv/tb.sv
+++ b/hw/ip/keymgr_dpe/dv/tb.sv
@@ -48,7 +48,11 @@ module tb;
   // dut
   // TODO(opentitan-integrated/issues/332):
   // need to model the OTP seed input
-  keymgr_dpe dut (
+  keymgr_dpe # (
+    .NumInstHwSlot        (keymgr_dpe_env_pkg::DvNumInstHwSlot),
+    .NumBootStages        (keymgr_dpe_env_pkg::DvBootStages),
+    .NumRomDigestInputs   (keymgr_dpe_env_pkg::DvNumRomDigestInputs)
+  ) dut (
     .clk_i                (clk           ),
     .rst_ni               (rst_n         ),
     .rst_shadowed_ni      (rst_shadowed_n),

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe.sv
@@ -25,7 +25,13 @@ module keymgr_dpe
   parameter seed_t RndCnstNoneSeed             = RndCnstNoneSeedDefault,
   parameter seed_t RndCnstAesSeed              = RndCnstAesSeedDefault,
   parameter seed_t RndCnstOtbnSeed             = RndCnstOtbnSeedDefault,
-  parameter seed_t RndCnstKmacSeed             = RndCnstKmacSeedDefault
+  parameter seed_t RndCnstKmacSeed             = RndCnstKmacSeedDefault,
+  // Number of instantiated HW slots
+  parameter int unsigned NumInstHwSlot         = 4,
+  // Number of available boot stages
+  parameter int unsigned NumBootStages         = 3,
+  // Number of ROM digest inputs
+  parameter int unsigned NumRomDigestInputs    = 1
 ) (
   input clk_i,
   input rst_ni,
@@ -74,9 +80,28 @@ module keymgr_dpe
   output prim_alert_pkg::alert_tx_t [keymgr_reg_pkg::NumAlerts-1:0] alert_tx_o
 );
 
+  // Advance width calculation
+  // When deriving from the UDS the following data are consumed (Not ordered):
+  //   - Software binding
+  //   - Revision seed
+  //   - OTP device ID
+  //   - LC keymgr diversification value
+  //   - ROM digests
+  //   - Creator seed (only if boot stage equals two)
+  localparam int DpeAdvDataWidth = SwBindingWidth + KeyWidth + DeviceIdWidth +
+      lc_ctrl_pkg::LcKeymgrDivWidth + KeyWidth * NumRomDigestInputs +
+      KeyWidth * (NumBootStages == 2);
+
+  // Determine the width of the data consumed by the KMAC IF during the inital
+  // derivation of the CreatorRootKey.
   `ASSERT_INIT(DpeAdvDataWidth_A, DpeAdvDataWidth <= KDFMaxWidth)
   `ASSERT_INIT(GenDataWidth_A, GenDataWidth <= KDFMaxWidth)
   `ASSERT_INIT(OutputKeyDiff_A, RndCnstHardOutputSeed != RndCnstSoftOutputSeed)
+
+  // Determine the actual signal width to address all the hw slots
+  localparam int NumInstHwSlotWidth = prim_util_pkg::vbits(NumInstHwSlot);
+  localparam int NumMaxHwSlotWidth = prim_util_pkg::vbits(NumMaxHwSlot);
+  typedef logic [NumInstHwSlotWidth-1:0] keymgr_dpe_slot_idx_e;
 
   import prim_mubi_pkg::mubi4_test_true_strict;
   import prim_mubi_pkg::mubi4_test_false_strict;
@@ -278,7 +303,34 @@ module keymgr_dpe
   logic op_start;
   assign op_start = reg2hw.start.q;
   logic invalid_advance;
-  keymgr_dpe_ctrl u_ctrl (
+
+  // TODO(#30682): Remove this assertion
+  // Raise an assertion if the source / destination field provided by the
+  // sw register is out of bounds.
+  `ASSERT(SrcSelInRange_A, reg2hw.control_shadowed.slot_src_sel.q < NumInstHwSlot)
+  `ASSERT(DstSelInRange_A, reg2hw.control_shadowed.slot_dst_sel.q < NumInstHwSlot)
+  keymgr_dpe_slot_idx_e slot_src_sel_trunc, slot_dst_sel_trunc;
+  assign slot_src_sel_trunc =
+      keymgr_dpe_slot_idx_e'(reg2hw.control_shadowed.slot_src_sel.q);
+  assign slot_dst_sel_trunc =
+      keymgr_dpe_slot_idx_e'(reg2hw.control_shadowed.slot_dst_sel.q);
+
+  // AscentLint: Tie off upper bits of the slot selection register field if not the
+  // full register width is used.
+  if (NumInstHwSlotWidth < prim_util_pkg::vbits(NumMaxHwSlot)) begin : gen_unused_slot_sel_bits
+    logic unused_dst_slot_sel;
+    logic unused_src_slot_sel;
+    assign unused_dst_slot_sel = ^reg2hw.control_shadowed.slot_dst_sel.q[
+      NumMaxHwSlotWidth-1:NumInstHwSlotWidth];
+    assign unused_src_slot_sel = ^reg2hw.control_shadowed.slot_src_sel.q[
+      NumMaxHwSlotWidth-1:NumInstHwSlotWidth];
+  end
+
+  keymgr_dpe_ctrl # (
+    .NumInstHwSlot(NumInstHwSlot),
+    .NumInstHwSlotWidth(NumInstHwSlotWidth),
+    .NumBootStages(NumBootStages)
+  ) u_ctrl (
     .clk_i,
     .rst_ni,
     .en_i(lc_tx_test_true_strict(lc_keymgr_en[KeymgrDpeEnCtrl])),
@@ -297,8 +349,8 @@ module keymgr_dpe
     .load_key_lock_i(reg2hw.load_key_lock.q),
     // TODO(#384): Add assertions to check that we are not losing some bits by casting
     // slot_src/dst_sel bits to enum type
-    .slot_src_sel_i(keymgr_dpe_slot_idx_e'(reg2hw.control_shadowed.slot_src_sel.q)),
-    .slot_dst_sel_i(keymgr_dpe_slot_idx_e'(reg2hw.control_shadowed.slot_dst_sel.q)),
+    .slot_src_sel_i(slot_src_sel_trunc),
+    .slot_dst_sel_i(slot_dst_sel_trunc),
     .slot_policy_i(keymgr_dpe_policy_t'(reg2hw.slot_policy)),
     .max_key_version_i(reg2hw.max_key_ver_shadowed),
     .key_version_i(reg2hw.key_version),
@@ -460,24 +512,51 @@ module keymgr_dpe
   assign unused_owner_seed = ^{owner_seed_i.seed_valid};
   assign owner_seed = owner_seed_i.seed;
 
+  // If the system support only two boot stages then the creator seed is
+  // consumed in BootStageCreator.
+  logic [DpeAdvDataWidth-1:0] adv_data_creator;
+  logic adv_data_creator_valid;
+  logic [DpeAdvDataWidth-1:0] adv_data_owner_int;
+  logic adv_data_owner_int_valid;
+  if (NumBootStages == 2) begin : gen_adv_matrix_for_two_boot_stages
+    assign adv_data_creator = DpeAdvDataWidth'({sw_binding,
+                                                revision_seed,
+                                                device_id_i,
+                                                lc_keymgr_div_i,
+                                                rom_digests,
+                                                creator_seed});
+    assign adv_data_creator_valid = devid_vld &
+                                    health_state_vld &
+                                    rom_digest_vld &
+                                    creator_seed_vld;
+    assign adv_data_owner_int = '0;
+    assign adv_data_owner_int_valid = '0;
+  end else begin : gen_adv_matrix_for_three_boot_stages
+    assign adv_data_creator = DpeAdvDataWidth'({sw_binding,
+                                                device_id_i,
+                                                lc_keymgr_div_i,
+                                                rom_digests,
+                                                revision_seed});
+    assign adv_data_creator_valid = devid_vld &
+                                    health_state_vld &
+                                    rom_digest_vld;
+    assign adv_data_owner_int = DpeAdvDataWidth'({sw_binding,
+                                                  creator_seed});
+    assign adv_data_owner_int_valid = creator_seed_vld;
+  end
+
   always_comb begin : gen_adv_matrix_all
     // One default only use SW binding
     adv_matrix = {(2 ** DpeBootStagesWidth){DpeAdvDataWidth'(sw_binding)}};
     adv_dvalid = {(2 ** DpeBootStagesWidth){1'b1}};
 
     if (reg2hw.control_shadowed.sw_binding_only.q == 1'b0) begin
-      // For (0 = Creator) and (1 = OwnerInt), check seed validity
-      adv_matrix[BootStageCreator] = DpeAdvDataWidth'({sw_binding,
-                                                      revision_seed,
-                                                      device_id_i,
-                                                      lc_keymgr_div_i,
-                                                      rom_digests,
-                                                      creator_seed});
-      adv_dvalid[BootStageCreator] = creator_seed_vld &
-                                    devid_vld         &
-                                    health_state_vld  &
-                                    rom_digest_vld;
-      adv_matrix[BootStageOwner] = DpeAdvDataWidth'({sw_binding,owner_seed});
+      // For (0 = Creator) / (1 = OwnerInt) / (2 = Owner), check seed validity
+      adv_matrix[BootStageCreator] = adv_data_creator;
+      adv_dvalid[BootStageCreator] = adv_data_creator_valid;
+      adv_matrix[BootStageOwnerInt] = adv_data_owner_int;
+      adv_dvalid[BootStageOwnerInt] = adv_data_owner_int_valid;
+      adv_matrix[BootStageOwner] = DpeAdvDataWidth'({sw_binding, owner_seed});
       adv_dvalid[BootStageOwner] = owner_seed_vld;
     end
   end
@@ -541,18 +620,29 @@ module keymgr_dpe
   assign hw2reg.debug.inactive_lc_en.d        = lc_tx_test_false_loose(
                                                   lc_keymgr_en[KeymgrDpeEnDebug]);
 
-  // creator_seed, dev_id, health_state and rom digest are used when boot_stage is incremented from
-  // 0 (= Creator) to 1 (= OwnerInt), so only latch them during consumption.
+  // Only latch required signals to advance the bootstage during consumption.
   logic is_creator_boot_stage, is_owner_boot_stage;
-  assign is_creator_boot_stage = active_key_slot.boot_stage == BootStageCreator;
-  assign is_owner_boot_stage   = active_key_slot.boot_stage == BootStageOwner;
+  assign is_creator_boot_stage   = active_key_slot.boot_stage == BootStageCreator;
+  assign is_owner_boot_stage     = active_key_slot.boot_stage == BootStageOwner;
 
-  assign hw2reg.debug.invalid_creator_seed.de = adv_en & is_creator_boot_stage;
+  // dev_id, health_state and rom digest is used when boot_stage is incremented
+  // from 0 (= Creator) to 1 (= OwnerInt)
   assign hw2reg.debug.invalid_dev_id.de       = adv_en & is_creator_boot_stage;
   assign hw2reg.debug.invalid_health_state.de = adv_en & is_creator_boot_stage;
   assign hw2reg.debug.invalid_digest.de       = adv_en & is_creator_boot_stage;
 
-  // owner_seed is used when boot_stage is incremented from 1 (= OwnerInt) to 2 (= Owner).
+  // creator_seed is consumed when boot_stage is incremented from 1 (= OwnerInt)
+  // to 2 (= Owner) in the three-stage configuration, or from 0 (= Creator) to
+  // 2 (= Owner) in the two-stage configuration (where OwnerInt is omitted).
+  if (NumBootStages == 2) begin : gen_invalid_creator_seed_for_2_boot_stages
+    assign hw2reg.debug.invalid_creator_seed.de =
+        adv_en & is_creator_boot_stage;
+  end else begin : gen_invalid_creator_seed_for_3_boot_stages
+    assign hw2reg.debug.invalid_creator_seed.de =
+        adv_en & (active_key_slot.boot_stage == BootStageOwnerInt);
+  end
+
+  // owner_seed is used when boot_stage is incremented from 2 (= Owner) to 3 (= Runtime).
   assign hw2reg.debug.invalid_owner_seed.de    = adv_en & is_owner_boot_stage;
 
   // key validity and versions are checked regardless of the boot stage, when there is an ongoing
@@ -819,6 +909,14 @@ module keymgr_dpe
   assign unused_active_key_version = active_key_slot.max_key_version;
 
   `ASSERT_INIT(KeyWidthEqualityCheck_A, KeyMgrKeyWidth == KeyWidth)
+
+  // Verify supported number of boot stage
+  `ASSERT_INIT(InvalidNumOfBootStage_A, NumBootStages inside {2, 3})
+
+  // Verify the number of instanciated HW slots
+  `ASSERT_INIT(InvalidNumHwSlot_A, NumInstHwSlot <= NumMaxHwSlot)
+  // Only a power-of-two for the NumInstHwSlot is supported
+  `ASSERT_INIT(NumInstHwSlotPowerOfTwo_A, (NumInstHwSlot & (NumInstHwSlot - 1)) == 0)
 
   `ASSERT_INIT_NET(KmacMaskCheck_A, KmacEnMasking == kmac_en_masking_i)
 

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_ctrl.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_ctrl.sv
@@ -12,7 +12,13 @@ module keymgr_dpe_ctrl
   import keymgr_dpe_pkg::*;
   import keymgr_dpe_reg_pkg::*;
 // TODO(#384): Bring back KmacEnMasking parameter
-(
+#(
+  // Number of instantiated HW slots
+  parameter int unsigned NumInstHwSlot = 4,
+  parameter int unsigned NumInstHwSlotWidth = 2,
+  // Number of available boot stages
+  parameter int unsigned NumBootStages = 3
+) (
   input clk_i,
   input rst_ni,
 
@@ -32,8 +38,8 @@ module keymgr_dpe_ctrl
   input op_start_i,
   input keymgr_dpe_ops_e op_i,
   input load_key_lock_i,
-  input [DpeNumSlotsWidth-1:0] slot_src_sel_i,
-  input [DpeNumSlotsWidth-1:0] slot_dst_sel_i,
+  input [NumInstHwSlotWidth-1:0] slot_src_sel_i,
+  input [NumInstHwSlotWidth-1:0] slot_dst_sel_i,
   input keymgr_dpe_policy_t slot_policy_i,
    // `max_key_version_i` is stored during advance to be compared with `key_version_i` during
    // generate calls
@@ -110,8 +116,8 @@ module keymgr_dpe_ctrl
 
   logic [EntropyRndWidth-1:0] cnt;
 
-  keymgr_dpe_slot_t [DpeNumSlots-1:0] key_slots_q;
-  keymgr_dpe_slot_t [DpeNumSlots-1:0] key_slots_d;
+  keymgr_dpe_slot_t [NumInstHwSlot-1:0] key_slots_q;
+  keymgr_dpe_slot_t [NumInstHwSlot-1:0] key_slots_d;
 
   // error conditions
   logic invalid_kmac_out;
@@ -282,6 +288,20 @@ module keymgr_dpe_ctrl
   logic destination_slot_valid;
   assign destination_slot_valid = key_slots_q[slot_dst_sel_i].valid;
 
+  // Determine the boot stage for the next DPE context derivation.
+  // If there are only two boot stages, BootStageOwnerInt will be omitted
+  keymgr_dpe_boot_stage_e next_boot_stage;
+  if (NumBootStages == 2) begin : gen_two_boot_stage
+    assign next_boot_stage =
+        (active_key_slot_o.boot_stage == BootStageCreator) ? BootStageOwner :
+        BootStageRuntime;
+  end else begin : gen_three_boot_stage
+    assign next_boot_stage =
+        (active_key_slot_o.boot_stage == BootStageCreator) ? BootStageOwnerInt :
+        (active_key_slot_o.boot_stage == BootStageOwnerInt) ? BootStageOwner :
+        BootStageRuntime;
+  end
+
   /////////////////////////
   // Keymgr slots MUX
   /////////////////////////
@@ -320,8 +340,7 @@ module keymgr_dpe_ctrl
         key_slots_d[slot_dst_sel_i].valid = 1;
         key_slots_d[slot_dst_sel_i].key = kmac_data_i;
         key_slots_d[slot_dst_sel_i].max_key_version = max_key_version_i;
-        key_slots_d[slot_dst_sel_i].boot_stage =
-          (active_key_slot_o.boot_stage == BootStageCreator) ? BootStageOwner : BootStageRuntime;
+        key_slots_d[slot_dst_sel_i].boot_stage = next_boot_stage;
         key_slots_d[slot_dst_sel_i].key_policy = slot_policy_i;
       end
 
@@ -346,7 +365,7 @@ module keymgr_dpe_ctrl
       // sideload interfaces, but that is outside the scope of this mux.)
       SlotWipeAll,
       SlotWipeInternalOnly: begin
-        for (int i = 0; i < DpeNumSlots; i++) begin
+        for (int i = 0; i < NumInstHwSlot; i++) begin
           // Note that '0 for `key_policy` is a safe default, as it is the most restrictive policy
           key_slots_d[i] = '0;
           for (int j = 0; j < Shares; j++) begin
@@ -746,6 +765,10 @@ module keymgr_dpe_ctrl
   // qe / re etc.
   `ASSERT_INIT(SameErrCnt_A, $bits(keymgr_dpe_reg2hw_fault_status_reg_t) ==
                              (SyncFaultLastIdx + AsyncFaultLastIdx))
+
+  // verify supported number of boot stage
+  `ASSERT_INIT(InvalidNumOfBootStage_A, NumBootStages inside {2, 3})
+
 
   // // stage select should always be Disable whenever it is not enabled
   // `ASSERT(StageDisableSel_A, !en_i |-> stage_sel_o == Disable)

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_pkg.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_pkg.sv
@@ -7,25 +7,9 @@ package keymgr_dpe_pkg;
   // Most of the parameters are directly reused from keymgr_pkg
   import keymgr_pkg::*;
 
-  parameter int DpeNumSlots = 8;
-  parameter int DpeNumSlotsWidth = prim_util_pkg::vbits(DpeNumSlots);
-
   // Chip Device ID
   parameter int DeviceIdWidth = 256;
   typedef logic [DeviceIdWidth-1:0] keymgr_dpe_device_id_t;
-
-  // keymgr and keymgr_dpe have different maximum KMAC input widths. The below widths correspond to
-  // the following inputs to advance to the creator root key state:
-  //   - Software binding
-  //   - Revision seed
-  //   - OTP device ID
-  //   - LC keymgr diversification value
-  //   - ROM digests
-  //   - Creator seed
-  parameter int DpeAdvDataWidth = SwBindingWidth + KeyWidth + DeviceIdWidth +
-      lc_ctrl_pkg::LcKeymgrDivWidth + KeyWidth*keymgr_dpe_reg_pkg::NumRomDigestInputs + KeyWidth;
-
-  typedef logic [DpeNumSlotsWidth-1:0] keymgr_dpe_slot_idx_e;
 
   // Enumeration for operation
   typedef enum logic [2:0] {
@@ -130,9 +114,10 @@ package keymgr_dpe_pkg;
   // advance calls.
   parameter int DpeBootStagesWidth = 2;
   typedef enum logic [DpeBootStagesWidth-1:0] {
-    BootStageCreator = 0,
-    BootStageOwner   = 1,
-    BootStageRuntime = 2
+    BootStageCreator  = 0,
+    BootStageOwnerInt = 1,
+    BootStageOwner    = 2,
+    BootStageRuntime  = 3
   } keymgr_dpe_boot_stage_e;
 
   // An internal secret key slot

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_pkg.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_pkg.sv
@@ -11,7 +11,7 @@ package keymgr_dpe_reg_pkg;
   parameter int NumSwBindingReg = 8;
   parameter int NumOutReg = 8;
   parameter int NumKeyVersion = 1;
-  parameter int NumRomDigestInputs = 2;
+  parameter int NumMaxHwSlot = 8;
   parameter int NumAlerts = 2;
 
   // Address widths within the block

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -5737,12 +5737,17 @@
           domain: Main
         }
       }
+      param_decl:
+      {
+        NumInstHwSlot: "8"
+        NumBootStages: "2"
+        NumRomDigestInputs: "2"
+      }
       clock_connections:
       {
         clk_i: clkmgr_clocks_i.clk_main_secure
         clk_edn_i: clkmgr_clocks_i.clk_main_secure
       }
-      param_decl: {}
       memory: {}
       param_list:
       [
@@ -5754,6 +5759,33 @@
           local: "false"
           expose: "true"
           name_top: KeymgrDpeKmacEnMasking
+        }
+        {
+          name: NumInstHwSlot
+          desc: Number of instantiated HW slots
+          type: int
+          default: "8"
+          local: "true"
+          expose: "true"
+          name_top: KeymgrDpeNumInstHwSlot
+        }
+        {
+          name: NumBootStages
+          desc: Number of available boot stage
+          type: int
+          default: "2"
+          local: "true"
+          expose: "true"
+          name_top: KeymgrDpeNumBootStages
+        }
+        {
+          name: NumRomDigestInputs
+          desc: Number of digest inputs from ROM_CTRL
+          type: int
+          default: "2"
+          local: "true"
+          expose: "true"
+          name_top: KeymgrDpeNumRomDigestInputs
         }
       ]
       inter_signal_list:

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -732,6 +732,11 @@
       base_addr: {
         hart: "0x21140000",
       },
+      param_decl: {
+        NumInstHwSlot: "8",
+        NumBootStages: "2",
+        NumRomDigestInputs: "2",
+      },
     },
     { name: "csrng",
       type: "csrng",

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_keymgr_dpe_key_derivation_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_keymgr_dpe_key_derivation_vseq.sv
@@ -10,7 +10,6 @@ class chip_sw_keymgr_dpe_key_derivation_vseq extends chip_sw_base_vseq;
 
   `uvm_object_new
 
-  typedef bit [keymgr_pkg::AdvDataWidth-1:0]                  adv_data_t;
   typedef bit [kmac_pkg::AppDigestW-1:0]                      digest_t;
   typedef bit [TL_DW-1:0]                                     tl_data_t;
   typedef bit [keymgr_pkg::KeyWidth-1:0]                      key_t;
@@ -30,9 +29,13 @@ class chip_sw_keymgr_dpe_key_derivation_vseq extends chip_sw_base_vseq;
     key_t                                  CreatorSeed;
   } adv_creator_data_t;
 
+  // Must match the advance width defined as localparam inside the keymgr_dpe.sv.
+  localparam int DpeAdvDataWidth = $bits(adv_creator_data_t);
+  typedef bit [DpeAdvDataWidth-1:0] adv_data_t;
+
   typedef struct packed {
     // some portions are unused, which are 0s
-    bit [(keymgr_pkg::AdvDataWidth - keymgr_pkg::KeyWidth - keymgr_pkg::SwBindingWidth) - 1 : 0]
+    bit [(DpeAdvDataWidth - keymgr_pkg::KeyWidth - keymgr_pkg::SwBindingWidth) - 1 : 0]
                  unused;
     sw_binding_t SoftwareBinding;
     key_t        OwnerSeed;
@@ -40,7 +43,7 @@ class chip_sw_keymgr_dpe_key_derivation_vseq extends chip_sw_base_vseq;
 
   typedef struct packed {
     // some portions are unused, which are 0s
-    bit [(keymgr_pkg::AdvDataWidth - keymgr_pkg::SwBindingWidth) - 1 : 0]
+    bit [(DpeAdvDataWidth - keymgr_pkg::SwBindingWidth) - 1 : 0]
                  unused;
     sw_binding_t SoftwareBinding;
   } adv_sw_data_t;
@@ -54,18 +57,31 @@ class chip_sw_keymgr_dpe_key_derivation_vseq extends chip_sw_base_vseq;
 
   localparam int KmacDigestBytes = kmac_pkg::AppDigestW / 8;
 
+  int num_hw_slots;
   bit lc_at_prod;
 
   virtual task dut_init(string reset_kind = "HARD");
+    string num_hw_slots_path =
+        "tb.dut.top_darjeeling.darjeeling_pd_main.u_keymgr_dpe.NumInstHwSlot";
+    string adv_data_width_path =
+        "tb.dut.top_darjeeling.darjeeling_pd_main.u_keymgr_dpe.DpeAdvDataWidth";
+    int unsigned rtl_adv_data_width;
     super.dut_init(reset_kind);
     void'($value$plusargs("lc_at_prod=%0d", lc_at_prod));
     if (lc_at_prod) begin
       otp_write_lc_partition_state(cfg.mem_bkdr_util_h[Otp], LcStProd);
     end
+    // Backdoor load the number of hw slots available
+    `DV_CHECK_FATAL(uvm_hdl_read(num_hw_slots_path, num_hw_slots))
+    // Verify the width of the advance message
+    `DV_CHECK_FATAL(uvm_hdl_read(adv_data_width_path, rtl_adv_data_width))
+    `DV_CHECK_EQ_FATAL(DpeAdvDataWidth, rtl_adv_data_width,
+                       "Advance data width mirrored in this vseq does not match the RTL")
   endtask
 
   virtual task body();
     key_shares_t stage_0_key, stage_1_key, stage_2_key, stage_3_key;
+    int idx_stage_2_key;
 
     super.body();
 
@@ -78,7 +94,10 @@ class chip_sw_keymgr_dpe_key_derivation_vseq extends chip_sw_base_vseq;
     // creator root key and be in boot stage 0.  Verify that this holds.
     begin
       bit valid_found = 1'b0;
-      for (int i = 0; i < keymgr_dpe_pkg::DpeNumSlots; i++) begin
+      key_shares_t otp_root_key = get_otp_root_key();
+      bit [keymgr_pkg::KeyWidth-1:0] stage_key_unmasked;
+      bit [keymgr_pkg::KeyWidth-1:0] otp_root_key_unmasked;
+      for (int i = 0; i < num_hw_slots; i++) begin
         keymgr_dpe_pkg::keymgr_dpe_slot_t slot = get_key_slot(i);
         if (slot.valid) begin
           `DV_CHECK_EQ(valid_found, 1'b0, "Expecting only one valid key slot")
@@ -87,9 +106,14 @@ class chip_sw_keymgr_dpe_key_derivation_vseq extends chip_sw_base_vseq;
           stage_0_key = slot.key;
         end
       end
+      // The key from the slot is scrambled with random entropy! Therefore it is necessary to xor
+      // both shares together for both keys and compare this result!
+      stage_key_unmasked = get_unmasked_key(stage_0_key);
+      otp_root_key_unmasked = get_unmasked_key(otp_root_key);
+      // Compare the UDS with its ground truth
       `DV_CHECK_EQ(valid_found, 1'b1, "Expecting one valid key slot")
-      `DV_CHECK_EQ(stage_0_key, get_otp_root_key(),
-                   "Expecting boot stage 0 key to equal creator root key (UDS) from OTP")
+      `DV_CHECK_EQ(stage_key_unmasked, otp_root_key_unmasked,
+                   $sformatf("Expecting UDS in dpe context to be equal to the UDS from OTP"));
     end
     `uvm_info(`gfn, $sformatf("Boot stage 0 key:\n%s", key_shares_str(stage_0_key)), UVM_LOW)
 
@@ -140,7 +164,7 @@ class chip_sw_keymgr_dpe_key_derivation_vseq extends chip_sw_base_vseq;
     // holds.
     begin
       bit key_found = 1'b0;
-      for (int i = 0; i < keymgr_dpe_pkg::DpeNumSlots; i++) begin
+      for (int i = 0; i < num_hw_slots; i++) begin
         keymgr_dpe_pkg::keymgr_dpe_slot_t slot = get_key_slot(i);
         if (slot.valid && slot.boot_stage == keymgr_dpe_pkg::BootStageOwner) begin
           `DV_CHECK_EQ(key_found, 1'b0, "Expecting only one boot stage 1 key")
@@ -189,12 +213,13 @@ class chip_sw_keymgr_dpe_key_derivation_vseq extends chip_sw_base_vseq;
     // holds.
     begin
       bit key_found = 1'b0;
-      for (int i = 0; i < keymgr_dpe_pkg::DpeNumSlots; i++) begin
+      for (int i = 0; i < num_hw_slots; i++) begin
         keymgr_dpe_pkg::keymgr_dpe_slot_t slot = get_key_slot(i);
         if (slot.valid && slot.boot_stage == keymgr_dpe_pkg::BootStageRuntime) begin
           `DV_CHECK_EQ(key_found, 1'b0, "Expecting only one boot stage 2 key")
           key_found = 1'b1;
           stage_2_key = slot.key;
+          idx_stage_2_key = i;
         end
       end
     end
@@ -233,18 +258,20 @@ class chip_sw_keymgr_dpe_key_derivation_vseq extends chip_sw_base_vseq;
 
     // Wait for keymgr_dpe to have advanced to boot stage 3.
     `DV_WAIT(cfg.sw_logger_vif.printed_log == "KeymgrDpe derived boot stage 3 key")
-    // At this point, exactly one key slot should contain the boot stage 3 key.  Verify that this
+    // At this point, two keys slot should contain a boot stage 3 key. Verify that this
     // holds.
     begin
-     bit key_found = 1'b0;
-     for (int i = 0; i < keymgr_dpe_pkg::DpeNumSlots; i++) begin
-       keymgr_dpe_pkg::keymgr_dpe_slot_t slot = get_key_slot(i);
-       if (slot.valid && slot.boot_stage == keymgr_dpe_pkg::BootStageRuntime) begin
-         `DV_CHECK_EQ(key_found, 1'b0, "Expecting only one boot stage 3 key")
-         key_found = 1'b1;
-         stage_3_key = slot.key;
-       end
-     end
+      bit key_found = 1'b0;
+      for (int i = 0; i < num_hw_slots; i++) begin
+        keymgr_dpe_pkg::keymgr_dpe_slot_t slot = get_key_slot(i);
+        if (slot.valid && slot.boot_stage == keymgr_dpe_pkg::BootStageRuntime) begin
+          if (i != idx_stage_2_key) begin
+            `DV_CHECK_EQ(key_found, 1'b0, "Expecting only one boot stage 3 key")
+            key_found = 1'b1;
+            stage_3_key = slot.key;
+          end
+        end
+      end
     end
     `uvm_info(`gfn, $sformatf("Boot stage 3 key:\n%s", key_shares_str(stage_3_key)), UVM_LOW)
 
@@ -346,7 +373,7 @@ class chip_sw_keymgr_dpe_key_derivation_vseq extends chip_sw_base_vseq;
     // TODO: We appear to have more life cycle states now.
     creator_data.HealthMeasurement =
         lc_at_prod ? top_darjeeling_rnd_cnst_pkg::RndCnstLcCtrlLcKeymgrDivProduction
-                   : top_darjeeling_rnd_cnst_pkg::RndCnstLcCtrlLcKeymgrDivTestUnlocked;
+                   : top_darjeeling_rnd_cnst_pkg::RndCnstLcCtrlLcKeymgrDivRma;
     `uvm_info(`gfn, $sformatf("HealthMeasurement:\n128'h%032h", creator_data.HealthMeasurement),
               UVM_LOW)
 
@@ -363,7 +390,7 @@ class chip_sw_keymgr_dpe_key_derivation_vseq extends chip_sw_base_vseq;
     // CreatorSeed is stored in OTP.
     creator_data.CreatorSeed = get_otp_creator_seed();
 
-    return keymgr_pkg::AdvDataWidth'(creator_data);
+    return adv_data_t'(creator_data);
   endfunction
 
   // Collect data used as 'message' to derive the owner key (boot stage 2).
@@ -383,7 +410,7 @@ class chip_sw_keymgr_dpe_key_derivation_vseq extends chip_sw_base_vseq;
     // OwnerSeed is stored in OTP.
     owner_data.OwnerSeed = get_otp_owner_seed();
 
-    return keymgr_pkg::AdvDataWidth'(owner_data);
+    return adv_data_t'(owner_data);
   endfunction
 
   // Read OwnerSeed from OTP via backdoor and descramble it.
@@ -393,13 +420,11 @@ class chip_sw_keymgr_dpe_key_derivation_vseq extends chip_sw_base_vseq;
       otp_owner_seed[i * 32 +: 32] =
           cfg.mem_bkdr_util_h[Otp].read32(otp_ctrl_reg_pkg::OwnerSeedOffset + i * 4);
     end
-    `uvm_fatal(`gfn, "OTP Secret3 key required")
-    // TODO(#26288): Secret3 present only in Darjeeling.
-    //for (int i = 0; i < otp_ctrl_reg_pkg::OwnerSeedSize / 8; i++) begin
-    //  otp_owner_seed[i * 64 +: 64] =
-    //      otp_scrambler_pkg::descramble_data(otp_owner_seed[i * 64 +: 64],
-    //                                         otp_ctrl_part_pkg::Secret3Idx);
-    //end
+    for (int i = 0; i < otp_ctrl_reg_pkg::OwnerSeedSize / 8; i++) begin
+      otp_owner_seed[i * 64 +: 64] =
+          otp_scrambler_pkg::descramble_data(otp_owner_seed[i * 64 +: 64],
+                                             otp_ctrl_part_pkg::Secret3Idx);
+    end
     `uvm_info(`gfn, $sformatf("OwnerSeed:\n%s", key_str(otp_owner_seed)), UVM_LOW)
     return otp_owner_seed;
   endfunction

--- a/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
+++ b/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
@@ -29,7 +29,7 @@
              "{proj_root}/hw/ip/entropy_src/dv/entropy_src_rng16bits_sim_cfg.hjson",
              "{proj_root}/hw/ip/hmac/dv/hmac_sim_cfg.hjson",
              "{proj_root}/hw/ip/i2c/dv/i2c_sim_cfg.hjson",
-             "{proj_root}/hw/ip/keymgr_dpe/dv/keymgr_dpe_sim_cfg.hjson",
+             "{proj_root}/hw/ip/keymgr_dpe/dv/keymgr_dpe_darjeeling_sim_cfg.hjson",
              "{proj_root}/hw/ip/kmac/dv/kmac_masked_sim_cfg.hjson",
              "{proj_root}/hw/ip/kmac/dv/kmac_unmasked_sim_cfg.hjson",
              "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_dmi_volatile_unlock_disabled_sim_cfg.hjson",

--- a/hw/top_darjeeling/rtl/autogen/darjeeling_pd_main.sv
+++ b/hw/top_darjeeling/rtl/autogen/darjeeling_pd_main.sv
@@ -324,6 +324,10 @@ module darjeeling_pd_main #(
   localparam int LcCtrlNumRmaAckSigs = 1;
   // local parameters for spi_host0
   localparam int SpiHost0NumCS = 1;
+  // local parameters for keymgr_dpe
+  localparam int KeymgrDpeNumInstHwSlot = 8;
+  localparam int KeymgrDpeNumBootStages = 2;
+  localparam int KeymgrDpeNumRomDigestInputs = 2;
   // local parameters for entropy_src
   localparam int EntropySrcEsFifoDepth = 3;
   localparam int unsigned EntropySrcDistrFifoDepth = 11;
@@ -1683,7 +1687,10 @@ module darjeeling_pd_main #(
     .RndCnstAesSeed(RndCnstKeymgrDpeAesSeed),
     .RndCnstKmacSeed(RndCnstKeymgrDpeKmacSeed),
     .RndCnstOtbnSeed(RndCnstKeymgrDpeOtbnSeed),
-    .RndCnstNoneSeed(RndCnstKeymgrDpeNoneSeed)
+    .RndCnstNoneSeed(RndCnstKeymgrDpeNoneSeed),
+    .NumInstHwSlot(KeymgrDpeNumInstHwSlot),
+    .NumBootStages(KeymgrDpeNumBootStages),
+    .NumRomDigestInputs(KeymgrDpeNumRomDigestInputs)
   ) u_keymgr_dpe (
     // Clock and reset connections
     .clk_i(clkmgr_clocks_i.clk_main_secure),


### PR DESCRIPTION
# PR4 - BootStageOwnerInt / Top dep. parameter
This PR is the fourth in a series which will replace the [_keymgr_](https://opentitan.org/book/hw/ip/keymgr/index.html) with the [_kemgr_dpe_](https://opentitan.org/book/hw/ip/keymgr_dpe/index.html) in earlgrey. The replacement was approved by [this RFC](https://docs.google.com/document/d/1iF0EWyJkSEtRL9d057imLo4s6DWNrZ6Mpt0QKD8OMMc/).

## Merge-Dependencies

- #30617 
- #30615 


## Relevant Commits

Last two commits

## Description

The goal of this PR is twofold:

- Introduce the third bootstage required for the integration of the `keymgr_dpe` into earlgrey as approved by the RFC.
 - Make all necessary parameters top dependent which diverge between darjeeling and earlgrey (to avoid templating the IP)

After this PR is approved, both commits should be squashed together into a single commit.
