### PR TITLE
[otbn,mai] Fix input handshake and assertions for config stability

### DIFF
--- a/hw/ip/otbn/rtl/otbn_mai.sv
+++ b/hw/ip/otbn/rtl/otbn_mai.sv
@@ -291,7 +291,7 @@ module otbn_mai
   );
 
   assign in_cnt_tgt      = (in_cnt_load_val_q - mai_cnt_t'('d1));
-  assign in_cnt_done     = ispr_mai_in_mux_sel == in_cnt_tgt;
+  assign in_cnt_done     = (ispr_mai_in_mux_sel == in_cnt_tgt) && ma_in_consume;
   assign in_cnt_overflow = ispr_mai_in_mux_sel == '1;
   assign in_cnt_set      = in_cnt_done || sec_wipe_mai_i;
 
@@ -372,7 +372,7 @@ module otbn_mai
 
   assign out_cnt_load_val_d = sec_wipe_mai_i ? cnt_load_val : in_cnt_load_val_q;
   assign out_cnt_tgt        = (out_cnt_load_val_q - mai_cnt_t'('d1));
-  assign out_cnt_done       = ispr_mai_out_demux_sel == out_cnt_tgt;
+  assign out_cnt_done       = (ispr_mai_out_demux_sel == out_cnt_tgt) && ma_out_ready;
   assign out_cnt_overflow   = ispr_mai_out_demux_sel == '1;
   assign out_cnt_set        = out_cnt_done || sec_wipe_mai_i;
 
@@ -587,5 +587,11 @@ module otbn_mai
   assign mai_state_err_o              = |mai_state_err;
   // Sw error
   assign mai_software_error_o         = |ispr_mai_sw_err;
+
+  // The masking accelerator requires mod and operation to be stable during an execution. This
+  // check is much simpler when we base it on the busy flag instead of recreating the information
+  // inside the MA. These must remain stable also during a secure wipe.
+  `ASSERT(ModStableDuringExecution_A, ma_busy_q && !$rose(ma_busy_q) |-> $stable(ma_mod_lsw))
+  `ASSERT(MaskOpStableDuringExecution_A, ma_busy_q && !$rose(ma_busy_q) |-> $stable(ma_mask_op_q))
 
 endmodule

--- a/hw/ip/otbn/rtl/otbn_mask_accelerator.sv
+++ b/hw/ip/otbn/rtl/otbn_mask_accelerator.sv
@@ -423,32 +423,8 @@ module otbn_mask_accelerator
     assign wready_o = wready;
   end
 
-`ifdef INC_ASSERT
-  // High from the first wvalid_i of a batch until adder_batch_complete fires (all VecSize
-  // inputs accepted). Bridges intra-batch gaps where wvalid_i may deassert between individual
-  // element handshakes.
-  logic batch_in_progress_q;
-  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_batch_in_progress
-    if (!rst_ni) begin
-      batch_in_progress_q <= 1'b0;
-    end else if (wvalid_i) begin
-      batch_in_progress_q <= 1'b1;
-    end else if (adder_batch_complete) begin
-      batch_in_progress_q <= 1'b0;
-    end
-  end
-
-  // mod_i and mask_op_i must remain stable for the full batch lifetime: while batch inputs are
-  // being inserted (batch_in_progress_q), while the adder is busy with pass-2 (!wready_o), and
-  // while results drain out (rvalid_o).
-  `ASSERT(ModIStableDuringBatch_A,
-          !sec_wipe_running_i && (batch_in_progress_q || !wready_o || rvalid_o) |-> $stable(mod_i))
-  `ASSERT(MaskOpStableDuringBatch_A,
-          (batch_in_progress_q || !wready_o || rvalid_o) |-> $stable(mask_op_i))
-
   // wvalid_i follows the 'valid locked-in' principle: once asserted it must not fall until
   // wready_o is sampled high.
   `ASSERT(WvalidLockedIn_A, wvalid_i && !wready_o |=> wvalid_i)
-`endif
 
 endmodule


### PR DESCRIPTION
The MAI did not incorporate the handshake properly if there was a stall during a B2A execution. It did not consider the handshake and just ended the dispatch phase.

The masking accelerator requires the modulus and chosen operation to be stable as long as elements are in the pipeline. The previous assertion did not reset batch_in_progress_q for a secAdd operation. The assertions are now moved up a level where we can directly make them dependent on the busy flag. This is much simpler than reconstructing the busy information inside the accelerator.