### PR TITLE
[aes/sw] Reduce alerts in aes_masking_off test

### DIFF
--- a/sw/device/lib/testing/aes_testutils.c
+++ b/sw/device/lib/testing/aes_testutils.c
@@ -91,8 +91,9 @@ const uint32_t kEdnSeedMaterialReseed[kEdnSeedMaterialLen] = {
     0x96994362, 0x7ef8f0b9, 0x5b5332dc, 0xd0df9b12, 0x96dfbaa9, 0xac0b5af7,
     0xec2504be, 0xb00fb68c, 0xf37e0a7f, 0x88172eec, 0x4e4b5f58, 0xfec120c0};
 
-status_t aes_testutils_masking_prng_zero_output_seed(const dif_csrng_t *csrng,
-                                                     const dif_edn_t *edn0) {
+status_t aes_testutils_masking_prng_zero_output_seed(
+    const dif_csrng_t *csrng, const dif_edn_t *edn0,
+    bool gen_zero_output_seed) {
   // Shutdown EDN0 and CSRNG
   TRY(dif_edn_stop(edn0));
   TRY(dif_csrng_stop(csrng));
@@ -136,7 +137,11 @@ status_t aes_testutils_masking_prng_zero_output_seed(const dif_csrng_t *csrng,
                       .len = 0,
                   },
           },
-      .reseed_interval = 1,  // Reseed after every single generate.
+      // When producing the seed causing AES to output an all-zero output, we
+      // need to reseed CSRNG after every single generate. Otherwise, we reseed
+      // less frequently. This produces a different seed and avoids repetition
+      // alerts in EDN.
+      .reseed_interval = gen_zero_output_seed ? 1 : 16,
   };
   memcpy(edn0_params.instantiate_cmd.seed_material.data,
          kEdnSeedMaterialInstantiate, sizeof(kEdnSeedMaterialInstantiate));

--- a/sw/device/lib/testing/aes_testutils.h
+++ b/sw/device/lib/testing/aes_testutils.h
@@ -52,11 +52,15 @@ inline bool aes_testutils_get_status(dif_aes_t *aes, dif_aes_status_t status) {
  *
  * @param csrng A CSRNG DIF handle.
  * @param edn0 An EDN DIF handle.
+ * @param gen_zero_output_seed If not set, the produced seed will not result in
+ * an all-zero output vector of the PRNG but it will also not trigger repetition
+ * alerts in EDN.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 status_t aes_testutils_masking_prng_zero_output_seed(const dif_csrng_t *csrng,
-                                                     const dif_edn_t *edn0);
+                                                     const dif_edn_t *edn0,
+                                                     bool gen_zero_output_seed);
 
 /**
  * CTR_DRBG Known-Answer-Test (KAT) using the CSRNG SW application interface.

--- a/sw/device/sca/aes_serial.c
+++ b/sw/device/sca/aes_serial.c
@@ -229,7 +229,8 @@ static void aes_key_mask_and_config(const uint8_t *key, size_t key_len) {
   const dif_edn_t edn0 = {
       .base_addr = mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR)};
 
-  CHECK_STATUS_OK(aes_testutils_masking_prng_zero_output_seed(&csrng, &edn0));
+  CHECK_STATUS_OK(
+      aes_testutils_masking_prng_zero_output_seed(&csrng, &edn0, true));
 #endif
   SS_CHECK_DIF_OK(dif_aes_start(&aes, &transaction, &key_shares, NULL));
 
@@ -818,7 +819,8 @@ bool test_main(void) {
     const dif_edn_t edn0 = {
         .base_addr = mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR)};
 
-    CHECK_STATUS_OK(aes_testutils_masking_prng_zero_output_seed(&csrng, &edn0));
+    CHECK_STATUS_OK(
+        aes_testutils_masking_prng_zero_output_seed(&csrng, &edn0, true));
     aes_sca_load_fixed_seed();
   }
 #endif

--- a/sw/device/tests/aes_masking_off_test.c
+++ b/sw/device/tests/aes_masking_off_test.c
@@ -63,7 +63,8 @@ status_t execute_test(const dif_csrng_t *csrng, const dif_edn_t *edn0) {
   LOG_INFO("Testing AES with masking switched off");
 
   // Initialize EDN and CSRNG to generate the required seed.
-  CHECK_STATUS_OK(aes_testutils_masking_prng_zero_output_seed(csrng, edn0));
+  CHECK_STATUS_OK(
+      aes_testutils_masking_prng_zero_output_seed(csrng, edn0, true));
 
   // Initialise AES.
   dif_aes_t aes;
@@ -110,6 +111,13 @@ status_t execute_test(const dif_csrng_t *csrng, const dif_edn_t *edn0) {
   CHECK_DIF_OK(dif_aes_trigger(&aes, kDifAesTriggerPrngReseed));
   AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusIdle, true, kTestTimeout);
 
+  // Now reconfigure the CSRNG and EDN0 to avoid triggering further recoverable
+  // alerts in EDN0. Depending on the execution environment, other entropy
+  // consumers than AES can request entropy which would trigger the alert, too.
+  CHECK_STATUS_OK(
+      aes_testutils_masking_prng_zero_output_seed(csrng, edn0, false));
+
+  // Check that the only recoverable alert that fired was for repeated genbits.
   uint32_t alerts;
   CHECK_DIF_OK(dif_edn_get_recoverable_alerts(&edn, &alerts));
   CHECK(alerts == (1 << kDifEdnRecoverableAlertRepeatedGenBits));

--- a/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
@@ -1029,7 +1029,8 @@ status_t handle_aes_pentest_seed_lfsr(ujson_t *uj) {
     const dif_edn_t edn0 = {
         .base_addr = mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR)};
 
-    status_t res = aes_testutils_masking_prng_zero_output_seed(&csrng, &edn0);
+    status_t res =
+        aes_testutils_masking_prng_zero_output_seed(&csrng, &edn0, true);
     if (res.value != 0) {
       return ABORTED();
     }


### PR DESCRIPTION
This PR modifies the test to reconfigure the entropy complex in auto mode after seeding the AES PRNG with the required seed. Depending on the execution environment, other entropy consumers may also request entropy from EDN0 in the background, which can trigger additional recoverable alerts in EDN0 otherwise.