### PR TITLE
[otbn] Update ELF header

### DIFF
--- a/util/otbn_build.py
+++ b/util/otbn_build.py
@@ -346,6 +346,10 @@ def main() -> int:
 
         call_rv32_objcopy(uncomp_args + [str(out_elf), str(uncomp_obj)])
 
+        with open(uncomp_obj, 'r+b') as emb_file:
+            emb_file.seek(0x10)
+            emb_file.write(b'\1\0')
+
         # Generate the compressed object using LZ4
         imem_bin = out_dir / f"{app_name}_imem.bin"
         dmem_bin = out_dir / f"{app_name}_dmem.bin"


### PR DESCRIPTION
Update the ELF header of the uncompressed OTBN ELF to ET_REL (relocatable file).
Before this change it was flagged as ET_EXEC (executable file), however, the otbn binary still has to be linked to the final application.