### PR TITLE
[keymgr_dpe] Replace keymgr in EG - PR6 silicon creator driver

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/keymgr_dpe.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_dpe.c
@@ -1,0 +1,638 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/keymgr_dpe.h"
+
+#include <assert.h>
+
+#include "hw/top/dt/keymgr_dpe.h"
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
+
+#include "hw/top/keymgr_dpe_regs.h"  // Generated.
+
+#define KEYMGR_DPE_ASSERT(a, b) static_assert(a == b, "Bad value for " #a)
+KEYMGR_DPE_ASSERT(kScKeymgrDPEStateReset,
+                  KEYMGR_DPE_WORKING_STATE_STATE_VALUE_RESET);
+KEYMGR_DPE_ASSERT(kScKeymgrDPEStateAvailable,
+                  KEYMGR_DPE_WORKING_STATE_STATE_VALUE_AVAILABLE);
+KEYMGR_DPE_ASSERT(kScKeymgrDPEStateDisabled,
+                  KEYMGR_DPE_WORKING_STATE_STATE_VALUE_DISABLED);
+KEYMGR_DPE_ASSERT(kScKeymgrDPEStateInvalid,
+                  KEYMGR_DPE_WORKING_STATE_STATE_VALUE_INVALID);
+
+/**
+ * Internal keymgr dpe operation definition
+ */
+typedef enum sc_keymgr_dpe_operation {
+  kScKeymgrDPEOpsAdvance = 0,
+  kScKeymgrDPEOpsEraseSlot = 1,
+  kScKeymgrDPEOpsGenSwKey = 2,
+  kScKeymgrDPEOpsGenHwKey = 3,
+  kScKeymgrDPEOpsDisable = 4,
+  kScKeymgrDPEOpsLoadRootKey = 5,
+} sc_keymgr_dpe_operation_t;
+
+/**
+ * Base address of the keymgr dpe registers.
+ */
+static inline uint32_t sc_keymgr_dpe_base(void) {
+  return dt_keymgr_dpe_reg_block(kDtKeymgrDpe, kDtKeymgrDpeRegBlockCore);
+}
+
+/**
+ * Sets the context of the control register for the next command.
+ *
+ * @param exl_sw_binding Should additional hw bindings be used during the
+ * next advance call. Only impact DPE context generation if either the
+ * creator root key / owner int key / owner key is being generated.
+ * @param ops The type of operation to execute next.
+ * @param sel_src_slot Source slot when either advancing a DPE context inside
+ * the slot or if an HW / SW key is being generated.
+ * @param sel_dst_slot Destination slot in which the next advance call will
+ * load the newly generated DPE context.
+ * @param key_dest Determine the sideload port when deriving a HW key.
+ */
+void sc_keymgr_dpe_control_reg_set(
+    const sc_keymgr_dpe_sw_binding_t exl_sw_binding, const uint32_t ops,
+    const sc_keymgr_dpe_dest_t key_dest, uint32_t sel_src_slot,
+    uint32_t sel_dst_slot) {
+  // Build the control register
+  uint32_t ctrl = 0;
+  ctrl = bitfield_field32_write(
+      ctrl, KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_FIELD, ops);
+  ctrl = bitfield_field32_write(
+      ctrl, KEYMGR_DPE_CONTROL_SHADOWED_DEST_SEL_FIELD, key_dest);
+  ctrl = bitfield_field32_write(
+      ctrl, KEYMGR_DPE_CONTROL_SHADOWED_SLOT_SRC_SEL_FIELD, sel_src_slot);
+  ctrl = bitfield_field32_write(
+      ctrl, KEYMGR_DPE_CONTROL_SHADOWED_SLOT_DST_SEL_FIELD, sel_dst_slot);
+  ctrl = bitfield_bit32_write(
+      ctrl, KEYMGR_DPE_CONTROL_SHADOWED_SW_BINDING_ONLY_BIT, exl_sw_binding);
+
+  // Write the control register.
+  abs_mmio_write32_shadowed(
+      sc_keymgr_dpe_base() + KEYMGR_DPE_CONTROL_SHADOWED_REG_OFFSET, ctrl);
+}
+
+/**
+ * Start the command.
+ */
+void sc_keymgr_dpe_start_operation(void) {
+  // Issue the start command.
+  abs_mmio_write32(sc_keymgr_dpe_base() + KEYMGR_DPE_START_REG_OFFSET,
+                   1 << KEYMGR_DPE_START_EN_BIT);
+}
+
+/**
+ * Wait for the key manager dpe to finish an operation.
+ *
+ * Polls the key manager dpe until it is no longer busy. If the operation
+ * completed successfully, returns `kErrorOk`. If there was an error during the
+ * operation, reads and clears the error code and returns
+ * `kErrorKeymgrInternal`.
+ *
+ * @return `kErrorOk` if the status is either "idle" or the operation
+ * finished with "done_successfully", `kErrorKeymgrInternal` otherwise.
+ */
+rom_error_t sc_keymgr_dpe_wait_until_done(void) {
+  // Poll the OP_STATUS register until it is different than "WIP".
+  uint32_t reg = 0;
+  uint32_t status = 0;
+  do {
+    // Read OP_STATUS and then clear by writing back the value we read.
+    reg =
+        abs_mmio_read32(sc_keymgr_dpe_base() + KEYMGR_DPE_OP_STATUS_REG_OFFSET);
+    abs_mmio_write32(sc_keymgr_dpe_base() + KEYMGR_DPE_OP_STATUS_REG_OFFSET,
+                     reg);
+    status = bitfield_field32_read(reg, KEYMGR_DPE_OP_STATUS_STATUS_FIELD);
+  } while (status == KEYMGR_DPE_OP_STATUS_STATUS_VALUE_WIP);
+
+  // Check if the keymgr_dpe reported errors. If it completed an operation
+  // successfully, return an OK status. A `WIP` status should not be possible
+  // because of the check above.
+  // The `IDLE` status is left unhandled because the keymgr_dpe should never
+  // be idle after an operation has been started by the caller.
+  switch (launder32(status)) {
+    case KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_SUCCESS:
+      HARDENED_CHECK_EQ(status, KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+      return kErrorOk;
+    case KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_ERROR: {
+      // Clear the ERR_CODE register before returning.
+      uint32_t err_code = abs_mmio_read32(sc_keymgr_dpe_base() +
+                                          KEYMGR_DPE_ERR_CODE_REG_OFFSET);
+      abs_mmio_write32(sc_keymgr_dpe_base() + KEYMGR_DPE_ERR_CODE_REG_OFFSET,
+                       err_code);
+      return kErrorKeymgrInternal;
+    }
+    default:
+      // Should be unreachable.
+      HARDENED_TRAP();
+      return kErrorKeymgrInternal;
+  }
+}
+
+/**
+ * Checks the key manager dpe `expected_state`.
+ *
+ * This function reads and clears the status and error code registers.
+ *
+ * @return `kErrorOk` if the key manager dpe is at the `expected_state` and the
+ * status is idle or success.
+ */
+OT_WARN_UNUSED_RESULT
+static rom_error_t expected_state_check(uint32_t expected_state) {
+  // Read and clear the status register by writing back the read value,
+  // polling until the status is non-WIP.
+  uint32_t op_status = 0;
+  uint32_t op_status_field = 0;
+  do {
+    op_status =
+        abs_mmio_read32(sc_keymgr_dpe_base() + KEYMGR_DPE_OP_STATUS_REG_OFFSET);
+    abs_mmio_write32(sc_keymgr_dpe_base() + KEYMGR_DPE_OP_STATUS_REG_OFFSET,
+                     op_status);
+    op_status_field =
+        bitfield_field32_read(op_status, KEYMGR_DPE_OP_STATUS_STATUS_FIELD);
+  } while (op_status_field == KEYMGR_DPE_OP_STATUS_STATUS_VALUE_WIP ||
+           op_status_field == KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+
+  // Read and clear the error register by writing back the read value.
+  uint32_t error_code =
+      abs_mmio_read32(sc_keymgr_dpe_base() + KEYMGR_DPE_ERR_CODE_REG_OFFSET);
+  abs_mmio_write32(sc_keymgr_dpe_base() + KEYMGR_DPE_ERR_CODE_REG_OFFSET,
+                   error_code);
+
+  // Read the working state with sec_mmio so that we can check the expected
+  // value periodically.
+  // TODO(#30665): changed this towards abs_mmio_read32(...) instead of
+  // sec_mmio_read32(...) as otherwise several test fail.
+  // The test currently investigating is: 0.rom_e2e_asm_init_test_unlocked0!
+  uint32_t got_state = abs_mmio_read32(sc_keymgr_dpe_base() +
+                                       KEYMGR_DPE_WORKING_STATE_REG_OFFSET);
+
+  if (launder32(op_status_field) == KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE &&
+      launder32(error_code) == 0u && launder32(got_state) == expected_state) {
+    HARDENED_CHECK_EQ(op_status_field, KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE);
+    HARDENED_CHECK_EQ(error_code, 0u);
+    HARDENED_CHECK_EQ(got_state, expected_state);
+    return kErrorOk;
+  }
+  return kErrorKeymgrInternal;
+}
+
+/**
+ * Fails if the keymgr_dpe is not idle.
+ *
+ * @return OK if the key manager is idle, `kErrorKeymgrInternal` otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+static rom_error_t keymgr_dpe_is_idle(void) {
+  uint32_t reg =
+      abs_mmio_read32(sc_keymgr_dpe_base() + KEYMGR_DPE_OP_STATUS_REG_OFFSET);
+  uint32_t status =
+      bitfield_field32_read(reg, KEYMGR_DPE_OP_STATUS_STATUS_FIELD);
+  if (launder32(status) == KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE) {
+    HARDENED_CHECK_EQ(status, KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE);
+    return kErrorOk;
+  }
+  return kErrorKeymgrInternal;
+}
+
+/**
+ * Advances a DPE context from `sel_src_slot` into `sel_dst_slot`.
+ *
+ * Sets the max key version, software binding, and policy for the new
+ * context, then starts the advance operation. Used by every advance call
+ * except the initial UDS advance out of reset, whose starting state and
+ * register setup differ.
+ *
+ * @param exl_sw_binding whether the software binding should be used
+ * exclusively, or combined with the hardware binding.
+ * @param adv_data source / destination slots and sw binding values /
+ * policy / version data for the advance call.
+ */
+static void sc_keymgr_dpe_advance(
+    const sc_keymgr_dpe_sw_binding_t exl_sw_binding,
+    sc_keymgr_dpe_advance_data_t adv_data) {
+  // Set the current key version
+  sc_keymgr_dpe_max_ver_set(adv_data.version);
+
+  // Set the sw binding
+  sc_keymgr_dpe_sw_binding_set(adv_data.binding_value);
+
+  // Set the policy for the DPE context
+  sc_keymgr_dpe_policy_set(adv_data.policy);
+
+  // Set the control register entries
+  sc_keymgr_dpe_control_reg_set(
+      exl_sw_binding, KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_VALUE_ADVANCE,
+      KEYMGR_DPE_CONTROL_SHADOWED_DEST_SEL_VALUE_NONE, adv_data.sel_src_slot,
+      adv_data.sel_dst_slot);
+
+  // Start the advance operation
+  sc_keymgr_dpe_start_operation();
+}
+
+/**
+ * Sets the entropy reseed interval of the key manager dpe.
+ */
+void sc_keymgr_dpe_entropy_reseed_interval_set(uint16_t reseed_interval) {
+  SEC_MMIO_ASSERT_WRITE_INCREMENT(kScKeymgrDPESecMmioReseedIntervalSet, 1);
+  uint32_t reg = bitfield_field32_write(
+      0, KEYMGR_DPE_RESEED_INTERVAL_SHADOWED_VAL_FIELD, reseed_interval);
+  sec_mmio_write32_shadowed(
+      sc_keymgr_dpe_base() + KEYMGR_DPE_RESEED_INTERVAL_SHADOWED_REG_OFFSET,
+      reg);
+}
+
+/**
+ * Sets the key manager dpe software binding input.
+ */
+void sc_keymgr_dpe_sw_binding_set(keymgr_dpe_binding_value_t *binding_value) {
+  SEC_MMIO_ASSERT_WRITE_INCREMENT(kScKeymgrDPESecMmioSwBindingSet, 8);
+  for (size_t i = 0; i < ARRAYSIZE(binding_value->data); ++i) {
+    sec_mmio_write32(sc_keymgr_dpe_base() + KEYMGR_DPE_SW_BINDING_0_REG_OFFSET +
+                         i * sizeof(uint32_t),
+                     binding_value->data[i]);
+  }
+  // Write and lock (rw0c) the software binding value. This register is
+  // unlocked by hardware upon a successful state transition.
+  // TODO(#30665): sec_mmio_writes currently does not work properly with
+  // auto reset register. The reason is if we start an advance operation
+  // then the HW will set this register afterwards. However, the
+  // sec_mmio_check_value() function still expects the written value of 0!
+  abs_mmio_write32(
+      sc_keymgr_dpe_base() + KEYMGR_DPE_SW_BINDING_REGWEN_REG_OFFSET, 0);
+}
+
+/**
+ * Blocks until the software binding registers are unlocked.
+ */
+void sc_keymgr_dpe_sw_binding_unlock_wait(void) {
+  // wait until the sw binding register is unlocked
+  while (!abs_mmio_read32(sc_keymgr_dpe_base() +
+                          KEYMGR_DPE_SW_BINDING_REGWEN_REG_OFFSET)) {
+  }
+  // Ignore the return value since this read is performed to check and update
+  // the expected value.
+  OT_DISCARD(sec_mmio_read32(sc_keymgr_dpe_base() +
+                             KEYMGR_DPE_SW_BINDING_REGWEN_REG_OFFSET));
+}
+
+/**
+ * Sets the current max key version used to advance a DPE context.
+ */
+void sc_keymgr_dpe_max_ver_set(uint32_t max_key_ver) {
+  SEC_MMIO_ASSERT_WRITE_INCREMENT(kScKeymgrDPESecMmioMaxVerSet, 1);
+  // Write and lock (rw0c) the max key version.
+  sec_mmio_write32_shadowed(
+      sc_keymgr_dpe_base() + KEYMGR_DPE_MAX_KEY_VER_SHADOWED_REG_OFFSET,
+      max_key_ver);
+  // TODO(#30665): sec_mmio_writes currently does not work > The reason is if
+  // we start an advance operation then the HW will set this register
+  // afterwards. However the sec_mmio_check_value() function still expects the
+  // written 0 value!
+  abs_mmio_write32(
+      sc_keymgr_dpe_base() + KEYMGR_DPE_MAX_KEY_VER_REGWEN_REG_OFFSET, 0);
+}
+
+/**
+ * Sets the key version used to generate a key.
+ */
+void sc_keymgr_dpe_key_ver_set(uint32_t key_ver) {
+  abs_mmio_write32(sc_keymgr_dpe_base() + KEYMGR_DPE_KEY_VERSION_REG_OFFSET,
+                   key_ver);
+}
+
+/**
+ * Sets all the slot policies for the next advance call.
+ */
+void sc_keymgr_dpe_policy_set(sc_keymgr_dpe_policies_t policy) {
+  SEC_MMIO_ASSERT_WRITE_INCREMENT(kScKeymgrDPESecMmioSlotPolicy, 1);
+  // Build, write and lock (rw0c) the policy field.
+  uint32_t reg = 0;
+  reg = bitfield_bit32_write(reg, KEYMGR_DPE_SLOT_POLICY_ALLOW_CHILD_BIT,
+                             policy.child);
+  reg = bitfield_bit32_write(reg, KEYMGR_DPE_SLOT_POLICY_EXPORTABLE_BIT,
+                             policy.expo);
+  reg = bitfield_bit32_write(reg, KEYMGR_DPE_SLOT_POLICY_RETAIN_PARENT_BIT,
+                             policy.parent);
+  sec_mmio_write32(sc_keymgr_dpe_base() + KEYMGR_DPE_SLOT_POLICY_REG_OFFSET,
+                   reg);
+  // TODO(#30665): sec_mmio_writes currently does not work > The reason is if
+  // we start an advance operation then the HW will set this register
+  // afterwards. However the sec_mmio_check_value() function still expects the
+  // written 0 value!
+  abs_mmio_write32(
+      sc_keymgr_dpe_base() + KEYMGR_DPE_SLOT_POLICY_REGWEN_REG_OFFSET, 0);
+}
+
+/**
+ * Checks the state of the key manager and compares against the provided
+ * value.
+ */
+rom_error_t sc_keymgr_dpe_state_check(sc_keymgr_dpe_state_t expected_state) {
+  return expected_state_check(expected_state);
+}
+
+/**
+ * Generate a key manager dpe key and sideload to the requested block.
+ */
+rom_error_t sc_keymgr_dpe_generate_key(
+    const sc_keymgr_dpe_dest_t destination,
+    sc_keymgr_dpe_diversification_t diversification) {
+  // Wait until the keymgr dpe has finished any previous operation
+  // Keys can only be generated in the Available state
+  HARDENED_RETURN_IF_ERROR(expected_state_check(kScKeymgrDPEStateAvailable));
+
+  // Determine if destination enforce either the HW or SW key
+  const uint32_t ops =
+      (destination == kScKeymgrDPEDestNone)
+          ? KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_VALUE_GENERATE_SW_OUTPUT
+          : KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_VALUE_GENERATE_HW_OUTPUT;
+
+  // Set the current key version
+  sc_keymgr_dpe_key_ver_set(diversification.version);
+
+  // Set the salt value for the key generation
+  for (size_t i = 0; i < kScKeymgrDPESaltNumWords; ++i) {
+    abs_mmio_write32(sc_keymgr_dpe_base() + KEYMGR_DPE_SALT_0_REG_OFFSET +
+                         i * sizeof(uint32_t),
+                     diversification.salt[i]);
+  }
+
+  // Set the control register entries
+  sc_keymgr_dpe_control_reg_set(kScKeymgrDPEUseAdditionalHwBinding, ops,
+                                destination, diversification.sel_src_slot, 0);
+
+  // Start the advance operation
+  sc_keymgr_dpe_start_operation();
+
+  // Blocks until the key is generated
+  return sc_keymgr_dpe_wait_until_done();
+}
+
+/**
+ * Read the generated sw key.
+ */
+rom_error_t sc_keymgr_dpe_read_key(uint32_t *share0, uint32_t *share1) {
+  // Return a error if the keymgr_dpe is not idle
+  HARDENED_RETURN_IF_ERROR(keymgr_dpe_is_idle());
+  // To avoid side-channel leakage, first randomize the destination buffers
+  // using memshred and then read the key.
+  hardened_memshred(share0, kScKeymgrDPEKeyNumWords);
+  hardened_memcpy(share0,
+                  (uint32_t *)(sc_keymgr_dpe_base() +
+                               KEYMGR_DPE_SW_SHARE0_OUTPUT_0_REG_OFFSET),
+                  kScKeymgrDPEKeyNumWords);
+  hardened_memshred(share1, kScKeymgrDPEKeyNumWords);
+  hardened_memcpy(share1,
+                  (uint32_t *)(sc_keymgr_dpe_base() +
+                               KEYMGR_DPE_SW_SHARE1_OUTPUT_0_REG_OFFSET),
+                  kScKeymgrDPEKeyNumWords);
+  return kErrorOk;
+}
+
+/**
+ * Clear the requested sideloaded key slot.
+ */
+rom_error_t sc_keymgr_dpe_clear_key(sc_keymgr_dpe_dest_t destination) {
+  uint32_t reg = 0;
+  // Return an error if the keymgr_dpe is not idle
+  HARDENED_RETURN_IF_ERROR(keymgr_dpe_is_idle());
+
+  // Set SIDELOAD_CLEAR to begin continuously clearing the requested slot.
+  reg = bitfield_field32_write(reg, KEYMGR_DPE_SIDELOAD_CLEAR_VAL_FIELD,
+                               destination);
+  abs_mmio_write32(sc_keymgr_dpe_base() + KEYMGR_DPE_SIDELOAD_CLEAR_REG_OFFSET,
+                   reg);
+
+  // Read back the value (hardening measure).
+  uint32_t sideload_clear = abs_mmio_read32(
+      sc_keymgr_dpe_base() + KEYMGR_DPE_SIDELOAD_CLEAR_REG_OFFSET);
+  if (bitfield_field32_read(
+          sideload_clear, KEYMGR_DPE_SIDELOAD_CLEAR_VAL_FIELD) != destination) {
+    return kErrorKeymgrInternal;
+  }
+
+  // Stop continuous clearing.
+  reg = 0;
+  reg = bitfield_field32_write(reg, KEYMGR_DPE_SIDELOAD_CLEAR_VAL_FIELD,
+                               KEYMGR_DPE_SIDELOAD_CLEAR_VAL_VALUE_NONE);
+  abs_mmio_write32(sc_keymgr_dpe_base() + KEYMGR_DPE_SIDELOAD_CLEAR_REG_OFFSET,
+                   reg);
+
+  return kErrorOk;
+}
+
+/**
+ * Enforces that only sw bindings are used for the advancement.
+ */
+rom_error_t sc_keymgr_dpe_advance_dpe_context(
+    sc_keymgr_dpe_advance_data_t adv_data) {
+  HARDENED_RETURN_IF_ERROR(expected_state_check(kScKeymgrDPEStateAvailable));
+  sc_keymgr_dpe_advance(kScKeymgrDPEUseExclusiveSwBinding, adv_data);
+  return kErrorOk;
+}
+
+/**
+ * Write into the lock register for the UDS.
+ */
+void sc_keymgr_dpe_lock_uds(void) {
+  // Issue the start command.
+  abs_mmio_write32(sc_keymgr_dpe_base() + KEYMGR_DPE_LOAD_KEY_LOCK_REG_OFFSET,
+                   1 << KEYMGR_DPE_LOAD_KEY_LOCK_LOCK_BIT);
+}
+
+/**
+ * Load the UDS into the provided destination slot.
+ */
+// TODO(#30667): Verify if the max key version needs to be written here too!
+//              When loading the UDS the RTL fetches the max key version from
+//              the SW register. Verify that the lock is released when the
+//              version register is locked.
+rom_error_t sc_keymgr_dpe_load_uds(uint32_t sel_dst_slot) {
+  // Set the control register entries
+  sc_keymgr_dpe_control_reg_set(
+      kScKeymgrDPEUseAdditionalHwBinding,
+      KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_VALUE_LOAD_ROOT_KEY,
+      KEYMGR_DPE_CONTROL_SHADOWED_DEST_SEL_VALUE_NONE, 0, sel_dst_slot);
+
+  // Start the load operation
+  sc_keymgr_dpe_start_operation();
+  return sc_keymgr_dpe_wait_until_done();
+}
+
+/**
+ * Executes the first advance call to load the UDS in the selected slot and
+ * sets the keymgr_dpe FSM to available.
+ */
+// TODO(#30667): Verify if the max key version needs to be written here too!
+//              When loading the UDS the RTL fetches the max key version from
+//              the SW register. Verify that the lock is released when the
+//              version register is locked.
+rom_error_t sc_keymgr_dpe_advance_initial(const uint32_t sel_dst_slot_uds) {
+  // Verify the reset state
+  HARDENED_RETURN_IF_ERROR(expected_state_check(kScKeymgrDPEStateReset));
+
+  // Set the control register entries
+  sc_keymgr_dpe_control_reg_set(
+      kScKeymgrDPEUseAdditionalHwBinding,
+      KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_VALUE_ADVANCE,
+      KEYMGR_DPE_CONTROL_SHADOWED_DEST_SEL_VALUE_NONE, 0, sel_dst_slot_uds);
+
+  // Start the advance operation
+  sc_keymgr_dpe_start_operation();
+
+  // Wait until UDS is loaded
+  HARDENED_RETURN_IF_ERROR(sc_keymgr_dpe_wait_until_done());
+
+  // Verify the available state
+  return expected_state_check(kScKeymgrDPEStateAvailable);
+}
+
+/**
+ * Sets the binding registers / key version registers and advances the
+ * UDS into the creator keys (sealing and attestation).
+ */
+rom_error_t sc_keymgr_dpe_advance_creator(
+    sc_keymgr_dpe_advance_data_t adv_data_sealing,
+    sc_keymgr_dpe_advance_data_t adv_data_attestation) {
+  // Sanity checks
+  if ((adv_data_sealing.policy.parent != kScKeymgrDPESlotPolEraseParent) ||
+      (adv_data_attestation.policy.parent != kScKeymgrDPESlotPolEraseParent)) {
+    return kErrorKeymgrInternal;
+  }
+
+  // Verify the keymgr_dpe is in the correct FSM state
+  HARDENED_RETURN_IF_ERROR(expected_state_check(kScKeymgrDPEStateAvailable));
+
+  // Advance the sealing key chain
+  sc_keymgr_dpe_advance(kScKeymgrDPEUseAdditionalHwBinding, adv_data_sealing);
+  HARDENED_RETURN_IF_ERROR(sc_keymgr_dpe_wait_until_done());
+
+  // Load the UDS into the attestation source slot
+  HARDENED_RETURN_IF_ERROR(
+      sc_keymgr_dpe_load_uds(adv_data_attestation.sel_src_slot));
+
+  // Advance the attestation key chain
+  sc_keymgr_dpe_advance(kScKeymgrDPEUseAdditionalHwBinding,
+                        adv_data_attestation);
+
+  return sc_keymgr_dpe_wait_until_done();
+}
+
+/**
+ * Sets the binding registers / key version registers and advances the
+ * creator keys into the owner int keys (sealing and attestation).
+ */
+rom_error_t sc_keymgr_dpe_advance_owner_int(
+    sc_keymgr_dpe_advance_data_t adv_data_sealing,
+    sc_keymgr_dpe_advance_data_t adv_data_attestation) {
+  // Sanity checks
+  if ((adv_data_sealing.sel_src_slot != adv_data_sealing.sel_dst_slot) ||
+      (adv_data_attestation.sel_src_slot !=
+       adv_data_attestation.sel_dst_slot) ||
+      (adv_data_sealing.policy.parent != kScKeymgrDPESlotPolEraseParent) ||
+      (adv_data_attestation.policy.parent != kScKeymgrDPESlotPolEraseParent)) {
+    return kErrorKeymgrInternal;
+  }
+  HARDENED_RETURN_IF_ERROR(expected_state_check(kScKeymgrDPEStateAvailable));
+
+  // Advance the sealing key
+  sc_keymgr_dpe_advance(kScKeymgrDPEUseAdditionalHwBinding, adv_data_sealing);
+  HARDENED_RETURN_IF_ERROR(sc_keymgr_dpe_wait_until_done());
+
+  // Advance the attestation key
+  sc_keymgr_dpe_advance(kScKeymgrDPEUseAdditionalHwBinding,
+                        adv_data_attestation);
+
+  return sc_keymgr_dpe_wait_until_done();
+}
+
+/**
+ * Sets the binding registers / key version registers and advances the
+ * owner int keys into the owner keys (sealing and attestation).
+ */
+rom_error_t sc_keymgr_dpe_advance_owner(
+    sc_keymgr_dpe_advance_data_t adv_data_sealing,
+    sc_keymgr_dpe_advance_data_t adv_data_attestation) {
+  // Sanity checks
+  if ((adv_data_sealing.sel_src_slot != adv_data_sealing.sel_dst_slot) ||
+      (adv_data_attestation.sel_src_slot !=
+       adv_data_attestation.sel_dst_slot)) {
+    return kErrorKeymgrInternal;
+  }
+  HARDENED_RETURN_IF_ERROR(expected_state_check(kScKeymgrDPEStateAvailable));
+
+  // Advance the sealing key
+  sc_keymgr_dpe_advance(kScKeymgrDPEUseAdditionalHwBinding, adv_data_sealing);
+  HARDENED_RETURN_IF_ERROR(sc_keymgr_dpe_wait_until_done());
+
+  // Advance the attestation key
+  sc_keymgr_dpe_advance(kScKeymgrDPEUseAdditionalHwBinding,
+                        adv_data_attestation);
+
+  return sc_keymgr_dpe_wait_until_done();
+}
+
+/**
+ * Erase the DPE context of any slot.
+ */
+rom_error_t sc_keymgr_dpe_erase_slot(uint32_t sel_dst_slot) {
+  // Set the control register entries
+  sc_keymgr_dpe_control_reg_set(
+      kScKeymgrDPEUseAdditionalHwBinding,
+      KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_VALUE_ERASE_SLOT,
+      KEYMGR_DPE_CONTROL_SHADOWED_DEST_SEL_VALUE_NONE, 0, sel_dst_slot);
+
+  // Start the advance operation
+  sc_keymgr_dpe_start_operation();
+
+  // Wait until the erase operation has finished
+  return sc_keymgr_dpe_wait_until_done();
+}
+
+/**
+ * Advances the keymgr dpe into the disable state. All keys store in the
+ * sideloaded interface are continuously scrambled.
+ */
+rom_error_t sc_keymgr_dpe_disable(void) {
+  // Check if we are in the available state (Stalls until all ops are done)
+  HARDENED_RETURN_IF_ERROR(expected_state_check(kScKeymgrDPEStateAvailable));
+
+  // Set the control register entries
+  sc_keymgr_dpe_control_reg_set(
+      kScKeymgrDPEUseExclusiveSwBinding,
+      KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_VALUE_DISABLE,
+      KEYMGR_DPE_CONTROL_SHADOWED_DEST_SEL_VALUE_NONE, 0, 0);
+
+  // Start the advance operation
+  sc_keymgr_dpe_start_operation();
+  // Wait until keymgr_dpe is finished and verify if state if disabled
+  HARDENED_RETURN_IF_ERROR(expected_state_check(kScKeymgrDPEStateDisabled));
+  // According to the documentation for the SIDELOAD_CLEAR register, an invalid
+  // destination will enable continuous clearing of all destinations.
+  abs_mmio_write32(sc_keymgr_dpe_base() + KEYMGR_DPE_SIDELOAD_CLEAR_REG_OFFSET,
+                   UINT32_MAX);
+  return kErrorOk;
+}
+
+/**
+ * Generate a key manager key and sideload to the OTBN block.
+ */
+rom_error_t sc_keymgr_dpe_generate_key_otbn(
+    sc_keymgr_dpe_diversification_t diversification) {
+  return sc_keymgr_dpe_generate_key(kScKeymgrDPEDestOtbn, diversification);
+}
+
+/**
+ * Clear OTBN's sideloaded key slot.
+ */
+rom_error_t sc_keymgr_dpe_clear_sideload_key_otbn(void) {
+  return sc_keymgr_dpe_clear_key(kScKeymgrDPEDestOtbn);
+}

--- a/sw/device/silicon_creator/lib/drivers/keymgr_dpe.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_dpe.c
@@ -171,6 +171,8 @@ static rom_error_t expected_state_check(uint32_t expected_state) {
   // TODO(#30665): changed this towards abs_mmio_read32(...) instead of
   // sec_mmio_read32(...) as otherwise several test fail.
   // The test currently investigating is: 0.rom_e2e_asm_init_test_unlocked0!
+  // When fixing this issue the keymgr_dpe_unittest.cc must reflect the
+  // changes too!
   uint32_t got_state = abs_mmio_read32(sc_keymgr_dpe_base() +
                                        KEYMGR_DPE_WORKING_STATE_REG_OFFSET);
 
@@ -265,6 +267,8 @@ void sc_keymgr_dpe_sw_binding_set(keymgr_dpe_binding_value_t *binding_value) {
   // auto reset register. The reason is if we start an advance operation
   // then the HW will set this register afterwards. However, the
   // sec_mmio_check_value() function still expects the written value of 0!
+  // When fixing this issue the keymgr_dpe_unittest.cc must reflect the changes
+  // too!
   abs_mmio_write32(
       sc_keymgr_dpe_base() + KEYMGR_DPE_SW_BINDING_REGWEN_REG_OFFSET, 0);
 }
@@ -295,7 +299,8 @@ void sc_keymgr_dpe_max_ver_set(uint32_t max_key_ver) {
   // TODO(#30665): sec_mmio_writes currently does not work > The reason is if
   // we start an advance operation then the HW will set this register
   // afterwards. However the sec_mmio_check_value() function still expects the
-  // written 0 value!
+  // written 0 value! When fixing this issue the keymgr_dpe_unittest.cc must
+  // reflect the changes too!
   abs_mmio_write32(
       sc_keymgr_dpe_base() + KEYMGR_DPE_MAX_KEY_VER_REGWEN_REG_OFFSET, 0);
 }
@@ -326,7 +331,8 @@ void sc_keymgr_dpe_policy_set(sc_keymgr_dpe_policies_t policy) {
   // TODO(#30665): sec_mmio_writes currently does not work > The reason is if
   // we start an advance operation then the HW will set this register
   // afterwards. However the sec_mmio_check_value() function still expects the
-  // written 0 value!
+  // written 0 value! When fixing this issue the keymgr_dpe_unittest.cc must
+  // reflect the changes too!
   abs_mmio_write32(
       sc_keymgr_dpe_base() + KEYMGR_DPE_SLOT_POLICY_REGWEN_REG_OFFSET, 0);
 }

--- a/sw/device/silicon_creator/lib/drivers/keymgr_dpe.h
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_dpe.h
@@ -1,0 +1,520 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_KEYMGR_DPE_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_KEYMGR_DPE_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/keymgr_dpe_binding_value.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Key Manager states.
+ */
+typedef enum sc_keymgr_dpe_state {
+  /**
+   * Key manager dpe control is still in reset. Please wait for initialization
+   * complete before issuing operations.
+   */
+  kScKeymgrDPEStateReset,
+  /**
+   * Key manager control has finished latching OTP root key and will
+   * now accept software commands.
+   */
+  kScKeymgrDPEStateAvailable,
+  /**
+   * Key manager dpe currently disabled. Please reset the key manager. Sideload
+   * keys are still valid.
+   */
+  kScKeymgrDPEStateDisabled,
+  /**
+   * Key manager dpe currently invalid. Please reset the key manager. Sideload
+   * keys are no longer valid.
+   */
+  kScKeymgrDPEStateInvalid,
+  /**
+   * This is not a state - it is the total number of states.
+   */
+  kScKeymgrDPEStateCount,
+} sc_keymgr_dpe_state_t;
+
+/**
+ * Option to exclude the hw bindings values when deriving a DPE context
+ * (only applicable when deriving either a first, second or third generation
+ * DPE context in respect to the UDS).
+ */
+typedef enum sc_keymgr_dpe_sw_binding {
+  kScKeymgrDPEUseAdditionalHwBinding = 0,
+  kScKeymgrDPEUseExclusiveSwBinding = 1,
+} sc_keymgr_dpe_sw_binding_t;
+
+/**
+ * Set whether further advance operations should overwrite the source slot.
+ */
+typedef enum sc_keymgr_dpe_policy_parent {
+  kScKeymgrDPESlotPolEraseParent = 0,
+  kScKeymgrDPESlotPolRetainParent = 1,
+} sc_keymgr_dpe_policy_parent_t;
+
+/**
+ * Set whether the key for the target slot is exportable.
+ * Currently the export function is not implemented in RTL (Issue #30612)!
+ */
+typedef enum sc_keymgr_dpe_policy_export {
+  kScKeymgrDPESlotPolNoExport = 0,
+  kScKeymgrDPESlotPolAllowExport = 1,
+} sc_keymgr_dpe_policy_export_t;
+
+/**
+ * Set whether this DPE context allows to derive further DPE context.
+ */
+typedef enum sc_keymgr_dpe_policy_children {
+  kScKeymgrDPESlotPolNoChild = 0,
+  kScKeymgrDPESlotPolAllowChild = 1,
+} sc_keymgr_dpe_policy_children_t;
+
+/**
+ * Merges the three policies into a single struct.
+ */
+typedef struct sc_keymgr_dpe_policies {
+  sc_keymgr_dpe_policy_parent_t parent;
+  sc_keymgr_dpe_policy_children_t child;
+  sc_keymgr_dpe_policy_export_t expo;
+} sc_keymgr_dpe_policies_t;
+
+enum {
+  /**
+   * Number of 32-bit words for the salt.
+   */
+  kScKeymgrDPESaltNumWords = 8,
+  /**
+   * Number of 32-bit words for the key.
+   */
+  kScKeymgrDPEKeyNumWords = 8,
+};
+
+/**
+ * Data used to differentiate a generated keymgr key.
+ */
+typedef struct sc_keymgr_dpe_diversification {
+  /**
+   * Salt value to use for key generation.
+   */
+  uint32_t salt[kScKeymgrDPESaltNumWords];
+  /**
+   * The source slot to be used as parent DPE context.
+   */
+  uint32_t sel_src_slot;
+  /**
+   * Version for key generation (anti-rollback protection).
+   */
+  uint32_t version;
+} sc_keymgr_dpe_diversification_t;
+
+/**
+ * Data used to advance the state of one DPE context.
+ */
+typedef struct sc_keymgr_dpe_advance_data {
+  /**
+   * Binding values for the advance call.
+   */
+  keymgr_dpe_binding_value_t *binding_value;
+  /**
+   * Policy for the newly created DPE context.
+   */
+  sc_keymgr_dpe_policies_t policy;
+  /**
+   * The source slot to be used as parent DPE context.
+   */
+  uint32_t sel_src_slot;
+  /**
+   * The destination slot for the derived DPE context.
+   */
+  uint32_t sel_dst_slot;
+  /**
+   * Max version for key generation (anti-rollback protection).
+   */
+  uint32_t version;
+} sc_keymgr_dpe_advance_data_t;
+
+/**
+ * Destination for key generation.
+ */
+typedef enum sc_keymgr_dpe_dest {
+  kScKeymgrDPEDestNone = 0,
+  kScKeymgrDPEDestAes = 1,
+  kScKeymgrDPEDestKmac = 2,
+  kScKeymgrDPEDestOtbn = 3,
+} sc_keymgr_dpe_dest_t;
+
+/**
+ * The following constants represent the expected number of sec_mmio register
+ * writes performed by functions provided in this module. See
+ * `SEC_MMIO_WRITE_INCREMENT()` for more details.
+ *
+ * Example:
+ * ```
+ *  sc_keymgr_sw_binding_set();
+ *  SEC_MMIO_WRITE_INCREMENT(kScKeymgrSecMmioSwBindingSet);
+ * ```
+ */
+enum {
+  kScKeymgrDPESecMmioReseedIntervalSet = 1,
+  kScKeymgrDPESecMmioSwBindingSet = 8,
+  kScKeymgrDPESecMmioMaxVerSet = 1,
+  kScKeymgrDPESecMmioSlotPolicy = 1,
+};
+
+/**
+ * Keymgr DPE ECC key generation descriptor.
+ *
+ * The attestation or sealing key chain is directly mapped towards one of the
+ * keymgr_dpe slots thus removing the need to differentiate between the two
+ * of them.
+ *
+ * Attestation keys are derived from the system state, which changes when the
+ * ROM_EXT or the owner firmware is updated. Sealing keys remain stable as
+ * long as the device remains under the same ownership and hardware lifecycle
+ * state.
+ */
+typedef struct sc_keymgr_dpe_ecc_key {
+  /**
+   * Index into the kFlashCtrlInfoPageAttestationKeySeeds flash info page that
+   * holds a seed for generating the ECC key pair.
+   */
+  uint32_t keygen_seed_idx;
+  /**
+   * Pointer to the keymgr dpe diversifier that is used when actuating the
+   * keymgr's "output-generate" function to generate another ECC keygen seed
+   * that will be sideloaded to OTBN.
+   */
+  const sc_keymgr_dpe_diversification_t *keymgr_dpe_diversifier;
+  /**
+   * Currently there is no way to control if the correct key was already
+   * generated inside of keymgr_dpe slot. The program execution flow has to
+   * guarantee the correct DPE context!
+   */
+  sc_keymgr_dpe_state_t required_keymgr_dpe_state;
+} sc_keymgr_dpe_ecc_key_t;
+
+/**
+ * Wait for the key manager dpe to finish an operation.
+ *
+ * Polls the key manager dpe until it is no longer busy. If the operation
+ * completed successfully, returns `kErrorOk`. If there was an error during the
+ * operation, reads and clears the error code and returns
+ * `kErrorKeymgrInternal`.
+ *
+ * @return `kErrorOk` if the status is either "idle" or the operation
+ * finished with "done_successfully", `kErrorKeymgrInternal` otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sc_keymgr_dpe_wait_until_done(void);
+
+/**
+ * Sets the context of the control register for the next command.
+ *
+ * @param exl_sw_binding Should additional hw bindings be used during the
+ * next advance call. Only impact DPE context generation if either the
+ * creator root key / owner int key / owner key is being generated.
+ * @param ops The type of operation to execute next.
+ * @param sel_src_slot Source slot when either advancing a DPE context inside
+ * the slot or if an HW / SW key is being generated.
+ * @param sel_dst_slot Destination slot in which the next advance call will
+ * load the newly generated DPE context.
+ * @param key_dest Determine the sideload port when deriving a HW key.
+ */
+void sc_keymgr_dpe_control_reg_set(
+    const sc_keymgr_dpe_sw_binding_t exl_sw_binding, const uint32_t ops,
+    const sc_keymgr_dpe_dest_t key_dest, uint32_t sel_src_slot,
+    uint32_t sel_dst_slot);
+
+/**
+ * Start the pre-programmed operation.
+ */
+void sc_keymgr_dpe_start_operation(void);
+
+/**
+ * Sets the entropy reseed interval of the key manager dpe.
+ *
+ * @param reseed_interval Number of key manager dpe cycles before the
+ * entropy is reseeded.
+ */
+void sc_keymgr_dpe_entropy_reseed_interval_set(uint16_t reseed_interval);
+
+/**
+ * Sets the key manager dpe software binding input.
+ *
+ * This function also clears and caches the value of the `SW_BINDING_REGWEN`
+ * register in the `sec_mmio` expectations table. This register is unlocked
+ * after a successful transaction. It is recommended to call
+ * `sc_keymgr_dpe_sw_binding_unlock_wait()` after initiating a transition
+ * to update its value in the `sec_mmio` expectations table.
+ *
+ * @param binding_value Software binding value
+ */
+void sc_keymgr_dpe_sw_binding_set(keymgr_dpe_binding_value_t *binding_value);
+
+/**
+ * Blocks until the software binding registers are unlocked.
+ *
+ * This function can be called after `sc_keymgr_dpe_advance_state()` to wait
+ * for the software binding registers to become available for writing and to
+ * update the cached value of `SW_BINDING_REGWEN` register in the `sec_mmio`
+ * expectations table.
+ */
+void sc_keymgr_dpe_sw_binding_unlock_wait(void);
+
+/**
+ * Sets the current max key version used to advance a DPE context.
+ *
+ * This function sets the current max key version. The subfield
+ * max_key_version of each hardware slot is populated with this value
+ * during an advance call which target the corresponding slot.
+ *
+ * @param max_key_ver Maximum key version
+ */
+void sc_keymgr_dpe_max_ver_set(uint32_t max_key_ver);
+
+/**
+ * Sets the key version used to generate a key.
+ *
+ * This version is compared against the max version stores in the subfield of
+ * the source slot. Only if this version is smaller or equal to the max version
+ * the key is generated.
+ *
+ * @param key_ver key version
+ */
+void sc_keymgr_dpe_key_ver_set(uint32_t key_ver);
+
+/**
+ * Sets all the slot policies for the next advance call.
+ *
+ * @param policy combined policy vector for the next advance call.
+ */
+void sc_keymgr_dpe_policy_set(sc_keymgr_dpe_policies_t policy);
+
+/**
+ * Checks the state of the key manager and compares against the provided
+ * value.
+ *
+ * @param expected_state Expected key manager dpe state.
+ * @return `kErrorOk` if the key manager dpe is in `expected_state` and the
+ * status is idle or success; otherwise returns `kErrorKeymgrInternal`.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sc_keymgr_dpe_state_check(sc_keymgr_dpe_state_t expected_state);
+
+/**
+ * Generate a key manager dpe key and sideload to the requested block.
+ *
+ * Calls the key manager dpe to sideload a key into the requested hardware block
+ * and waits until the operation is completed before returning.
+ *
+ * @param destination: Hardware destination for key material.
+ * @param diversification Diversification input for the key derivation.
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sc_keymgr_dpe_generate_key(
+    const sc_keymgr_dpe_dest_t destination,
+    sc_keymgr_dpe_diversification_t diversification);
+
+/**
+ * Read the generated sw key.
+ *
+ * The caller ensure the pointer have sufficient space for the full
+ * key in each share and that a key was successfully generated first.
+ *
+ * @param[out] share0 Pointer to store the first share of the generated key with
+ * the required size defined in kScKeymgrDPEKeyNumWords.
+ * @param[out] share1 Pointer to store the second share of the generated key
+ * with the required size defined in kScKeymgrDPEKeyNumWords.
+ * @return OK or `kErrorKeymgrInternal` if keymgr_dpe is not idle.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sc_keymgr_dpe_read_key(uint32_t *share0, uint32_t *share1);
+
+/**
+ * Clear the requested sideloaded key slot.
+ *
+ * The entropy complex needs to be initialized before calling this function, so
+ * that keymgr dpe can use it to clear the slot.
+ *
+ * @param destination Hardware block to clear key material.
+ * @return OK or `kErrorKeymgrInternal` if keymgr_dpe is not idle.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sc_keymgr_dpe_clear_key(sc_keymgr_dpe_dest_t destination);
+
+/**
+ * Advances the DPE context of one slot inside the keymgr_dpe.
+ *
+ * This function can only be called if the targeted key_slot has already
+ * advanced three times. If the function is called sooner it will generate
+ * invalid keys and the boot process will be corrupted. The function stalls at
+ * the start if the keymgr dpe is not idle.
+ *
+ * The caller must ensure that this function finish successfully by calling
+ * `sc_keymgr_dpe_wait_until_done()`.
+ *
+ * @param adv_data All required data to advance the key of one DPE Context.
+ * @return The result of the advance call.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sc_keymgr_dpe_advance_dpe_context(
+    sc_keymgr_dpe_advance_data_t adv_data);
+
+/**
+ * Locks the load uds operation until the next reset.
+ *
+ * When this function is called then the function "sc_keymgr_dpe_load_uds" will
+ * generate an error as the uds is locked. This lock can only be released by
+ * resetting the device.
+ *
+ */
+void sc_keymgr_dpe_lock_uds(void);
+
+/**
+ * Load the UDS into an empty hw slot.
+ *
+ * Load the UDS into the selected hw slot. If the selected hw slot is not
+ * empty then the keymgr_dpe will throw an error.
+ *
+ * @param sel_dst_slot empty destination slot for the UDS.
+ * @return `kErrorOk`
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sc_keymgr_dpe_load_uds(uint32_t sel_dst_slot);
+
+/**
+ * Executes the first advance call to load the UDS in the selected slot and
+ * sets the keymgr_dpe FSM to available.
+ *
+ * Precondition: keymgr_dpe has to be in the state `kScKeymgrDPEStateReset`
+ *
+ * @param sel_dst_slot DPE context slot for the UDS.
+ * @return The result of the advance call.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sc_keymgr_dpe_advance_initial(const uint32_t sel_dst_slot_uds);
+
+/**
+ * Sets the binding registers / key version registers and advances the
+ * UDS to the creator keys (sealing and attestation).
+ *
+ * First the sealing key is generated from the preloaded UDS while the UDS
+ * is manually loaded a second time to generate the attestation key.
+ * Additionally, the retain parent policy bit must be cleared to avoid leaving
+ * the creator keys existing beyond its designated boot stage. This
+ * function blocks until the advance operation was successfully.
+ *
+ * Precondition: keymgr_dpe has to be in the state `kScKeymgrDPEStateAvailable`
+ *
+ * @param adv_data_sealing All required data to advance the UDS to the
+ * sealing owner key.
+ * @param adv_data_attestation All required data to advance the UDS to the
+ * attestation owner key.
+ * @return The result of the advance call.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sc_keymgr_dpe_advance_creator(
+    sc_keymgr_dpe_advance_data_t adv_data_sealing,
+    sc_keymgr_dpe_advance_data_t adv_data_attestation);
+
+/**
+ * Sets the binding registers / key version registers and advances the
+ * creator keys to the owner int keys (sealing and attestation).
+ *
+ * The retain parent policy bit must be cleared to avoid leaving the owner int
+ * keys existing beyond its designated boot stage. Due to the retain parent
+ * policy on the creator keys the source and destination slot have to be equal.
+ * This function blocks until the advance operation was successfully.
+ *
+ * Precondition: keymgr_dpe has to be in the state `kScKeymgrDPEStateAvailable`
+ *
+ * @param adv_data_sealing All required data for the sealing key.
+ * @param adv_data_attestation All required data for the attestation key.
+ * @return The result of the advance call.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sc_keymgr_dpe_advance_owner_int(
+    sc_keymgr_dpe_advance_data_t adv_data_sealing,
+    sc_keymgr_dpe_advance_data_t adv_data_attestation);
+
+/**
+ * Sets the binding registers / key version registers and advances the
+ * owner int keys to the owner keys (sealing and attestation).
+ *
+ * Due to the retain parent policy on the owner int the source and
+ * destination slot have to be equal. This function is blocking until the
+ * advance operation was successfully.
+ *
+ * Precondition: keymgr_dpe has to be in the state `kScKeymgrDPEStateAvailable`
+ *
+ * @param adv_data_sealing All required data for the sealing key.
+ * @param adv_data_attestation All required data for the attestation key.
+ * @return The result of the advance call.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sc_keymgr_dpe_advance_owner(
+    sc_keymgr_dpe_advance_data_t adv_data_sealing,
+    sc_keymgr_dpe_advance_data_t adv_data_attestation);
+
+/**
+ * Erase the DPE context of any slot
+ *
+ * This function blocks until the advance operation was successfully.
+ *
+ * @param sel_dst_slot selected DPE context to erase.
+ * @return The result of the erase call.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sc_keymgr_dpe_erase_slot(uint32_t sel_dst_slot);
+
+/**
+ * Advances the keymgr dpe into the disable state.
+ *
+ * All keys stored in the sideloaded interface are continuously scrambled.
+ *
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sc_keymgr_dpe_disable(void);
+
+/**
+ * Generate a key manager key and sideload to the OTBN block.
+ *
+ * Calls the key manager to sideload a key into the OTBN hardware block and
+ * waits until the operation is completed before returning.
+ *
+ * @param diversification Diversification input for the key derivation.
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sc_keymgr_dpe_generate_key_otbn(
+    sc_keymgr_dpe_diversification_t diversification);
+
+/**
+ * Clear OTBN's sideloaded key slot.
+ *
+ * The entropy complex needs to be initialized before calling this function, so
+ * that keymgr dpe can use it to clear the slot.
+ *
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sc_keymgr_dpe_clear_sideload_key_otbn(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_KEYMGR_DPE_H_

--- a/sw/device/silicon_creator/lib/drivers/keymgr_dpe_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_dpe_unittest.cc
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "hw/top/dt/keymgr_dpe.h"
+
+#include <array>
+#include <limits>
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mock_abs_mmio.h"
+#include "sw/device/silicon_creator/lib/base/mock_sec_mmio.h"
+#include "sw/device/silicon_creator/lib/drivers/keymgr_dpe.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#include "hw/top/keymgr_dpe_regs.h"  // Generated.
+
+namespace keymgr_dpe_unittest {
+namespace {
+
+// TODO(#30609): write this unittest
+
+}  // namespace
+}  // namespace keymgr_dpe_unittest

--- a/sw/device/silicon_creator/lib/drivers/keymgr_dpe_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_dpe_unittest.cc
@@ -18,7 +18,664 @@
 namespace keymgr_dpe_unittest {
 namespace {
 
-// TODO(#30609): write this unittest
+// TODO(#30609): extend this unittest
+
+class KeymgrDpeTest : public rom_test::RomTest {
+ protected:
+  /**
+   * Expects a read of the OP_STATUS register followed by the write that
+   * clears the status by writing back the read value.
+   */
+  void ExpectOpStatusReadClear(uint32_t op_status) {
+    EXPECT_ABS_READ32(base_ + KEYMGR_DPE_OP_STATUS_REG_OFFSET, op_status);
+    EXPECT_ABS_WRITE32(base_ + KEYMGR_DPE_OP_STATUS_REG_OFFSET, op_status);
+  }
+
+  /**
+   * Expects a read-and-clear of the ERR_CODE register.
+   */
+  void ExpectErrCodeReadClear(uint32_t err_code) {
+    EXPECT_ABS_READ32(base_ + KEYMGR_DPE_ERR_CODE_REG_OFFSET, err_code);
+    EXPECT_ABS_WRITE32(base_ + KEYMGR_DPE_ERR_CODE_REG_OFFSET, err_code);
+  }
+
+  /**
+   * Expects a full `expected_state_check()` sequence with a single,
+   * non-polling OP_STATUS read.
+   */
+  void ExpectStatusCheck(uint32_t op_status, uint32_t km_state,
+                         uint32_t err_code) {
+    ExpectOpStatusReadClear(op_status);
+    ExpectErrCodeReadClear(err_code);
+    EXPECT_ABS_READ32(base_ + KEYMGR_DPE_WORKING_STATE_REG_OFFSET, km_state);
+  }
+
+  /**
+   * Expects a single OP_STATUS read as performed by `keymgr_dpe_is_idle()`.
+   */
+  void ExpectIdleCheck(uint32_t op_status) {
+    EXPECT_ABS_READ32(base_ + KEYMGR_DPE_OP_STATUS_REG_OFFSET, op_status);
+  }
+
+  /**
+   * Expects a write to the CONTROL_SHADOWED register.
+   */
+  void ExpectControlRegSet(bool sw_binding_only, uint32_t ops, uint32_t dest,
+                           uint32_t src_slot, uint32_t dst_slot) {
+    EXPECT_ABS_WRITE32_SHADOWED(
+        base_ + KEYMGR_DPE_CONTROL_SHADOWED_REG_OFFSET,
+        {
+            {KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_OFFSET, ops},
+            {KEYMGR_DPE_CONTROL_SHADOWED_DEST_SEL_OFFSET, dest},
+            {KEYMGR_DPE_CONTROL_SHADOWED_SLOT_SRC_SEL_OFFSET, src_slot},
+            {KEYMGR_DPE_CONTROL_SHADOWED_SLOT_DST_SEL_OFFSET, dst_slot},
+            {KEYMGR_DPE_CONTROL_SHADOWED_SW_BINDING_ONLY_BIT, sw_binding_only},
+        });
+  }
+
+  /**
+   * Expects a write to the START register.
+   */
+  void ExpectStartOperation(void) {
+    EXPECT_ABS_WRITE32(base_ + KEYMGR_DPE_START_REG_OFFSET,
+                       {
+                           {KEYMGR_DPE_START_EN_BIT, true},
+                       });
+  }
+
+  /**
+   * Expects a `sc_keymgr_dpe_wait_until_done()` polling sequence that reads
+   * `busy_cycles` WIP statuses before the final `end_status`.
+   */
+  void ExpectWaitUntilDone(size_t busy_cycles, uint32_t end_status) {
+    for (size_t i = 0; i < busy_cycles; i++) {
+      ExpectOpStatusReadClear(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_WIP);
+    }
+    ExpectOpStatusReadClear(end_status);
+  }
+
+  /**
+   * Expects a `sc_keymgr_dpe_max_ver_set()` sequence.
+   */
+  void ExpectMaxVerSet(uint32_t max_key_ver) {
+    EXPECT_SEC_WRITE32_SHADOWED(
+        base_ + KEYMGR_DPE_MAX_KEY_VER_SHADOWED_REG_OFFSET, max_key_ver);
+    EXPECT_ABS_WRITE32(base_ + KEYMGR_DPE_MAX_KEY_VER_REGWEN_REG_OFFSET, 0);
+  }
+
+  /**
+   * Expects a `sc_keymgr_dpe_sw_binding_set()` sequence.
+   */
+  void ExpectSwBindingSet(const keymgr_dpe_binding_value_t *binding_value) {
+    for (size_t i = 0; i < ARRAYSIZE(binding_value->data); ++i) {
+      EXPECT_SEC_WRITE32(
+          base_ + KEYMGR_DPE_SW_BINDING_0_REG_OFFSET + i * sizeof(uint32_t),
+          binding_value->data[i]);
+    }
+    EXPECT_ABS_WRITE32(base_ + KEYMGR_DPE_SW_BINDING_REGWEN_REG_OFFSET, 0);
+  }
+
+  /**
+   * Expects a `sc_keymgr_dpe_policy_set()` sequence.
+   */
+  void ExpectPolicySet(sc_keymgr_dpe_policies_t policy) {
+    EXPECT_SEC_WRITE32(
+        base_ + KEYMGR_DPE_SLOT_POLICY_REG_OFFSET,
+        {
+            {KEYMGR_DPE_SLOT_POLICY_ALLOW_CHILD_BIT, policy.child},
+            {KEYMGR_DPE_SLOT_POLICY_EXPORTABLE_BIT, policy.expo},
+            {KEYMGR_DPE_SLOT_POLICY_RETAIN_PARENT_BIT, policy.parent},
+        });
+    EXPECT_ABS_WRITE32(base_ + KEYMGR_DPE_SLOT_POLICY_REGWEN_REG_OFFSET, 0);
+  }
+
+  /**
+   * Expects a full `sc_keymgr_dpe_advance()` sequence up to and
+   * including the start of the operation.
+   */
+  void ExpectAdvanceWrapper(bool sw_binding_only,
+                            const sc_keymgr_dpe_advance_data_t &adv_data) {
+    ExpectMaxVerSet(adv_data.version);
+    ExpectSwBindingSet(adv_data.binding_value);
+    ExpectPolicySet(adv_data.policy);
+    ExpectControlRegSet(sw_binding_only,
+                        KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_VALUE_ADVANCE,
+                        KEYMGR_DPE_CONTROL_SHADOWED_DEST_SEL_VALUE_NONE,
+                        adv_data.sel_src_slot, adv_data.sel_dst_slot);
+    ExpectStartOperation();
+  }
+
+  /**
+   * Expects a `sc_keymgr_dpe_load_uds()` sequence.
+   */
+  void ExpectLoadUds(uint32_t dst_slot) {
+    ExpectControlRegSet(
+        /*sw_binding_only=*/false,
+        KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_VALUE_LOAD_ROOT_KEY,
+        KEYMGR_DPE_CONTROL_SHADOWED_DEST_SEL_VALUE_NONE, /*src_slot=*/0,
+        dst_slot);
+    ExpectStartOperation();
+    ExpectWaitUntilDone(/*busy_cycles=*/1,
+                        KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+  }
+
+  uint32_t base_ =
+      dt_keymgr_dpe_reg_block(kDtKeymgrDpe, kDtKeymgrDpeRegBlockCore);
+  keymgr_dpe_binding_value_t binding_value_sealing_ = {
+      {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}};
+  keymgr_dpe_binding_value_t binding_value_attestation_ = {
+      {0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f}};
+  sc_keymgr_dpe_policies_t policy_erase_parent_ = {
+      .parent = kScKeymgrDPESlotPolEraseParent,
+      .child = kScKeymgrDPESlotPolAllowChild,
+      .expo = kScKeymgrDPESlotPolNoExport,
+  };
+  sc_keymgr_dpe_diversification_t diversification_ = {
+      .salt = {0xf0f1f2f3, 0xf4f5f6f7, 0xf8f9fafb, 0xfcfdfeff, 0xd0d1d2d3,
+               0xd4d5d6d7, 0xd8d9dadb, 0xdcdddedf},
+      .sel_src_slot = 2,
+      .version = 0xA5A5A5A4,
+  };
+  rom_test::MockAbsMmio mmio_;
+  rom_test::MockSecMmio sec_mmio_;
+};
+
+TEST_F(KeymgrDpeTest, EntropyReseedIntervalSet) {
+  EXPECT_SEC_WRITE32_SHADOWED(
+      base_ + KEYMGR_DPE_RESEED_INTERVAL_SHADOWED_REG_OFFSET, 0x1234u);
+  sc_keymgr_dpe_entropy_reseed_interval_set(0x1234u);
+}
+
+TEST_F(KeymgrDpeTest, SwBindingValueSet) {
+  ExpectSwBindingSet(&binding_value_sealing_);
+  sc_keymgr_dpe_sw_binding_set(&binding_value_sealing_);
+}
+
+TEST_F(KeymgrDpeTest, SwBindingUnlockWait) {
+  // The function polls until the REGWEN register reads non-zero and then
+  // reads it once more through sec_mmio to update the expectations table.
+  EXPECT_ABS_READ32(base_ + KEYMGR_DPE_SW_BINDING_REGWEN_REG_OFFSET, 0);
+  EXPECT_ABS_READ32(base_ + KEYMGR_DPE_SW_BINDING_REGWEN_REG_OFFSET, 1);
+  EXPECT_SEC_READ32(base_ + KEYMGR_DPE_SW_BINDING_REGWEN_REG_OFFSET, 1);
+  sc_keymgr_dpe_sw_binding_unlock_wait();
+}
+
+TEST_F(KeymgrDpeTest, MaxVerSet) {
+  ExpectMaxVerSet(0xA5A5A5A5);
+  sc_keymgr_dpe_max_ver_set(0xA5A5A5A5);
+}
+
+TEST_F(KeymgrDpeTest, KeyVerSet) {
+  EXPECT_ABS_WRITE32(base_ + KEYMGR_DPE_KEY_VERSION_REG_OFFSET, 0x5A5A5A5A);
+  sc_keymgr_dpe_key_ver_set(0x5A5A5A5A);
+}
+
+TEST_F(KeymgrDpeTest, PolicySet) {
+  sc_keymgr_dpe_policies_t policy = {
+      .parent = kScKeymgrDPESlotPolRetainParent,
+      .child = kScKeymgrDPESlotPolAllowChild,
+      .expo = kScKeymgrDPESlotPolNoExport,
+  };
+  ExpectPolicySet(policy);
+  sc_keymgr_dpe_policy_set(policy);
+}
+
+TEST_F(KeymgrDpeTest, ControlRegSet_1) {
+  ExpectControlRegSet(/*sw_binding_only=*/true,
+                      KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_VALUE_ADVANCE,
+                      KEYMGR_DPE_CONTROL_SHADOWED_DEST_SEL_VALUE_OTBN,
+                      /*src_slot=*/1, /*dst_slot=*/2);
+  sc_keymgr_dpe_control_reg_set(
+      kScKeymgrDPEUseExclusiveSwBinding,
+      KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_VALUE_ADVANCE, kScKeymgrDPEDestOtbn,
+      /*sel_src_slot=*/1, /*sel_dst_slot=*/2);
+}
+
+TEST_F(KeymgrDpeTest, ControlRegSet_2) {
+  ExpectControlRegSet(/*sw_binding_only=*/false,
+                      KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_VALUE_ADVANCE,
+                      KEYMGR_DPE_CONTROL_SHADOWED_DEST_SEL_VALUE_NONE,
+                      /*src_slot=*/0, /*dst_slot=*/3);
+  sc_keymgr_dpe_control_reg_set(
+      kScKeymgrDPEUseAdditionalHwBinding,
+      KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_VALUE_ADVANCE, kScKeymgrDPEDestNone,
+      /*sel_src_slot=*/0, /*sel_dst_slot=*/3);
+}
+
+TEST_F(KeymgrDpeTest, StartOperation) {
+  ExpectStartOperation();
+  sc_keymgr_dpe_start_operation();
+}
+
+TEST_F(KeymgrDpeTest, WaitUntilDoneSuccess) {
+  ExpectWaitUntilDone(/*busy_cycles=*/2,
+                      KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+  EXPECT_EQ(sc_keymgr_dpe_wait_until_done(), kErrorOk);
+}
+
+TEST_F(KeymgrDpeTest, WaitUntilDoneError) {
+  ExpectWaitUntilDone(/*busy_cycles=*/1,
+                      KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_ERROR);
+  // On error the ERR_CODE register is read and cleared.
+  ExpectErrCodeReadClear(1 << KEYMGR_DPE_ERR_CODE_INVALID_OP_BIT);
+  EXPECT_EQ(sc_keymgr_dpe_wait_until_done(), kErrorKeymgrInternal);
+}
+
+TEST_F(KeymgrDpeTest, CheckState) {
+  ExpectStatusCheck(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_DPE_WORKING_STATE_STATE_VALUE_AVAILABLE,
+                    /*err_code=*/0u);
+  EXPECT_EQ(sc_keymgr_dpe_state_check(kScKeymgrDPEStateAvailable), kErrorOk);
+}
+
+TEST_F(KeymgrDpeTest, CheckStatePolling) {
+  // The status check polls while the OP_STATUS register reads either WIP or
+  // DONE_SUCCESS.
+  ExpectOpStatusReadClear(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_WIP);
+  ExpectOpStatusReadClear(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+  ExpectStatusCheck(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_DPE_WORKING_STATE_STATE_VALUE_AVAILABLE,
+                    /*err_code=*/0u);
+  EXPECT_EQ(sc_keymgr_dpe_state_check(kScKeymgrDPEStateAvailable), kErrorOk);
+}
+
+TEST_F(KeymgrDpeTest, CheckStateInvalidResponse) {
+  // A state mismatch is expected to fail.
+  ExpectStatusCheck(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_DPE_WORKING_STATE_STATE_VALUE_INVALID,
+                    /*err_code=*/0u);
+  EXPECT_EQ(sc_keymgr_dpe_state_check(kScKeymgrDPEStateAvailable),
+            kErrorKeymgrInternal);
+
+  // Any non-idle status is expected to fail.
+  ExpectStatusCheck(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_ERROR,
+                    KEYMGR_DPE_WORKING_STATE_STATE_VALUE_AVAILABLE,
+                    /*err_code=*/0u);
+  EXPECT_EQ(sc_keymgr_dpe_state_check(kScKeymgrDPEStateAvailable),
+            kErrorKeymgrInternal);
+
+  // Any non-zero error code is expected to fail.
+  ExpectStatusCheck(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_DPE_WORKING_STATE_STATE_VALUE_AVAILABLE,
+                    /*err_code=*/1u);
+  EXPECT_EQ(sc_keymgr_dpe_state_check(kScKeymgrDPEStateAvailable),
+            kErrorKeymgrInternal);
+}
+
+TEST_F(KeymgrDpeTest, GenerateKeySwOutput) {
+  ExpectStatusCheck(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_DPE_WORKING_STATE_STATE_VALUE_AVAILABLE,
+                    /*err_code=*/0u);
+  EXPECT_ABS_WRITE32(base_ + KEYMGR_DPE_KEY_VERSION_REG_OFFSET,
+                     diversification_.version);
+  for (size_t i = 0; i < kScKeymgrDPESaltNumWords; ++i) {
+    EXPECT_ABS_WRITE32(
+        base_ + KEYMGR_DPE_SALT_0_REG_OFFSET + i * sizeof(uint32_t),
+        diversification_.salt[i]);
+  }
+  ExpectControlRegSet(
+      /*sw_binding_only=*/false,
+      KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_VALUE_GENERATE_SW_OUTPUT,
+      KEYMGR_DPE_CONTROL_SHADOWED_DEST_SEL_VALUE_NONE,
+      diversification_.sel_src_slot, /*dst_slot=*/0);
+  ExpectStartOperation();
+  ExpectWaitUntilDone(/*busy_cycles=*/2,
+                      KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+
+  EXPECT_EQ(sc_keymgr_dpe_generate_key(kScKeymgrDPEDestNone, diversification_),
+            kErrorOk);
+}
+
+TEST_F(KeymgrDpeTest, GenerateKeyOtbn) {
+  ExpectStatusCheck(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_DPE_WORKING_STATE_STATE_VALUE_AVAILABLE,
+                    /*err_code=*/0u);
+  EXPECT_ABS_WRITE32(base_ + KEYMGR_DPE_KEY_VERSION_REG_OFFSET,
+                     diversification_.version);
+  for (size_t i = 0; i < kScKeymgrDPESaltNumWords; ++i) {
+    EXPECT_ABS_WRITE32(
+        base_ + KEYMGR_DPE_SALT_0_REG_OFFSET + i * sizeof(uint32_t),
+        diversification_.salt[i]);
+  }
+  ExpectControlRegSet(
+      /*sw_binding_only=*/false,
+      KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_VALUE_GENERATE_HW_OUTPUT,
+      KEYMGR_DPE_CONTROL_SHADOWED_DEST_SEL_VALUE_OTBN,
+      diversification_.sel_src_slot, /*dst_slot=*/0);
+  ExpectStartOperation();
+  ExpectWaitUntilDone(/*busy_cycles=*/2,
+                      KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+
+  EXPECT_EQ(sc_keymgr_dpe_generate_key_otbn(diversification_), kErrorOk);
+}
+
+TEST_F(KeymgrDpeTest, GenerateKeyBadState) {
+  ExpectStatusCheck(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_DPE_WORKING_STATE_STATE_VALUE_RESET,
+                    /*err_code=*/0u);
+  EXPECT_EQ(sc_keymgr_dpe_generate_key(kScKeymgrDPEDestOtbn, diversification_),
+            kErrorKeymgrInternal);
+}
+
+TEST_F(KeymgrDpeTest, ReadKeyNotIdle) {
+  std::array<uint32_t, kScKeymgrDPEKeyNumWords> share0;
+  std::array<uint32_t, kScKeymgrDPEKeyNumWords> share1;
+
+  ExpectIdleCheck(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_WIP);
+  EXPECT_EQ(sc_keymgr_dpe_read_key(share0.data(), share1.data()),
+            kErrorKeymgrInternal);
+}
+
+TEST_F(KeymgrDpeTest, ClearKeyOtbn) {
+  ExpectIdleCheck(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE);
+  EXPECT_ABS_WRITE32(base_ + KEYMGR_DPE_SIDELOAD_CLEAR_REG_OFFSET,
+                     {
+                         {KEYMGR_DPE_SIDELOAD_CLEAR_VAL_OFFSET,
+                          KEYMGR_DPE_SIDELOAD_CLEAR_VAL_VALUE_OTBN},
+                     });
+  EXPECT_ABS_READ32(base_ + KEYMGR_DPE_SIDELOAD_CLEAR_REG_OFFSET,
+                    {
+                        {KEYMGR_DPE_SIDELOAD_CLEAR_VAL_OFFSET,
+                         KEYMGR_DPE_SIDELOAD_CLEAR_VAL_VALUE_OTBN},
+                    });
+  EXPECT_ABS_WRITE32(base_ + KEYMGR_DPE_SIDELOAD_CLEAR_REG_OFFSET,
+                     {
+                         {KEYMGR_DPE_SIDELOAD_CLEAR_VAL_OFFSET,
+                          KEYMGR_DPE_SIDELOAD_CLEAR_VAL_VALUE_NONE},
+                     });
+
+  EXPECT_EQ(sc_keymgr_dpe_clear_sideload_key_otbn(), kErrorOk);
+}
+
+TEST_F(KeymgrDpeTest, ClearKeyNotIdle) {
+  ExpectIdleCheck(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_WIP);
+  EXPECT_EQ(sc_keymgr_dpe_clear_key(kScKeymgrDPEDestOtbn),
+            kErrorKeymgrInternal);
+}
+
+TEST_F(KeymgrDpeTest, ClearKeyReadbackMismatch) {
+  ExpectIdleCheck(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE);
+  EXPECT_ABS_WRITE32(base_ + KEYMGR_DPE_SIDELOAD_CLEAR_REG_OFFSET,
+                     {
+                         {KEYMGR_DPE_SIDELOAD_CLEAR_VAL_OFFSET,
+                          KEYMGR_DPE_SIDELOAD_CLEAR_VAL_VALUE_OTBN},
+                     });
+
+  // Readback does not match the value written.
+  EXPECT_ABS_READ32(base_ + KEYMGR_DPE_SIDELOAD_CLEAR_REG_OFFSET,
+                    {
+                        {KEYMGR_DPE_SIDELOAD_CLEAR_VAL_OFFSET,
+                         KEYMGR_DPE_SIDELOAD_CLEAR_VAL_VALUE_AES},
+                    });
+
+  EXPECT_EQ(sc_keymgr_dpe_clear_key(kScKeymgrDPEDestOtbn),
+            kErrorKeymgrInternal);
+}
+
+TEST_F(KeymgrDpeTest, AdvanceDpeContext) {
+  sc_keymgr_dpe_advance_data_t adv_data = {
+      .binding_value = &binding_value_sealing_,
+      .policy = policy_erase_parent_,
+      .sel_src_slot = 1,
+      .sel_dst_slot = 2,
+      .version = 0xA5A5A5A5,
+  };
+
+  ExpectStatusCheck(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_DPE_WORKING_STATE_STATE_VALUE_AVAILABLE,
+                    /*err_code=*/0u);
+  // Advancing a generic DPE context uses the sw binding exclusively.
+  ExpectAdvanceWrapper(/*sw_binding_only=*/true, adv_data);
+  EXPECT_EQ(sc_keymgr_dpe_advance_dpe_context(adv_data), kErrorOk);
+}
+
+TEST_F(KeymgrDpeTest, LockUds) {
+  EXPECT_ABS_WRITE32(base_ + KEYMGR_DPE_LOAD_KEY_LOCK_REG_OFFSET,
+                     {
+                         {KEYMGR_DPE_LOAD_KEY_LOCK_LOCK_BIT, true},
+                     });
+  sc_keymgr_dpe_lock_uds();
+}
+
+TEST_F(KeymgrDpeTest, LoadUds) {
+  ExpectLoadUds(/*dst_slot=*/1);
+  EXPECT_EQ(sc_keymgr_dpe_load_uds(/*sel_dst_slot=*/1), kErrorOk);
+}
+
+TEST_F(KeymgrDpeTest, LoadUdsError) {
+  ExpectControlRegSet(
+      /*sw_binding_only=*/false,
+      KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_VALUE_LOAD_ROOT_KEY,
+      KEYMGR_DPE_CONTROL_SHADOWED_DEST_SEL_VALUE_NONE, /*src_slot=*/0,
+      /*dst_slot=*/1);
+  ExpectStartOperation();
+  // Loading the UDS into an occupied slot or while locked reports an error.
+  ExpectWaitUntilDone(/*busy_cycles=*/1,
+                      KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_ERROR);
+  ExpectErrCodeReadClear(1 << KEYMGR_DPE_ERR_CODE_INVALID_OP_BIT);
+  EXPECT_EQ(sc_keymgr_dpe_load_uds(/*sel_dst_slot=*/1), kErrorKeymgrInternal);
+}
+
+TEST_F(KeymgrDpeTest, AdvanceInitial) {
+  ExpectStatusCheck(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_DPE_WORKING_STATE_STATE_VALUE_RESET,
+                    /*err_code=*/0u);
+  ExpectControlRegSet(/*sw_binding_only=*/false,
+                      KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_VALUE_ADVANCE,
+                      KEYMGR_DPE_CONTROL_SHADOWED_DEST_SEL_VALUE_NONE,
+                      /*src_slot=*/0, /*dst_slot=*/1);
+  ExpectStartOperation();
+  ExpectWaitUntilDone(/*busy_cycles=*/2,
+                      KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+  ExpectStatusCheck(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_DPE_WORKING_STATE_STATE_VALUE_AVAILABLE,
+                    /*err_code=*/0u);
+
+  EXPECT_EQ(sc_keymgr_dpe_advance_initial(/*sel_dst_slot_uds=*/1), kErrorOk);
+}
+
+TEST_F(KeymgrDpeTest, AdvanceInitialBadState) {
+  // The initial advance call requires the keymgr_dpe to be in reset state.
+  ExpectStatusCheck(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_DPE_WORKING_STATE_STATE_VALUE_AVAILABLE,
+                    /*err_code=*/0u);
+  EXPECT_EQ(sc_keymgr_dpe_advance_initial(/*sel_dst_slot_uds=*/1),
+            kErrorKeymgrInternal);
+}
+
+TEST_F(KeymgrDpeTest, AdvanceCreator) {
+  sc_keymgr_dpe_advance_data_t adv_data_sealing = {
+      .binding_value = &binding_value_sealing_,
+      .policy = policy_erase_parent_,
+      .sel_src_slot = 0,
+      .sel_dst_slot = 1,
+      .version = 0xA5A5A5A5,
+  };
+  sc_keymgr_dpe_advance_data_t adv_data_attestation = {
+      .binding_value = &binding_value_attestation_,
+      .policy = policy_erase_parent_,
+      .sel_src_slot = 2,
+      .sel_dst_slot = 3,
+      .version = 0xA5A5A5A5,
+  };
+
+  ExpectStatusCheck(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_DPE_WORKING_STATE_STATE_VALUE_AVAILABLE,
+                    /*err_code=*/0u);
+  // Advance the sealing key chain from the preloaded UDS.
+  ExpectAdvanceWrapper(/*sw_binding_only=*/false, adv_data_sealing);
+  ExpectWaitUntilDone(/*busy_cycles=*/1,
+                      KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+  // Reload the UDS into the attestation source slot.
+  ExpectLoadUds(adv_data_attestation.sel_src_slot);
+  // Advance the attestation key chain.
+  ExpectAdvanceWrapper(/*sw_binding_only=*/false, adv_data_attestation);
+  ExpectWaitUntilDone(/*busy_cycles=*/1,
+                      KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+
+  EXPECT_EQ(
+      sc_keymgr_dpe_advance_creator(adv_data_sealing, adv_data_attestation),
+      kErrorOk);
+}
+
+TEST_F(KeymgrDpeTest, AdvanceCreatorBadPolicy) {
+  sc_keymgr_dpe_advance_data_t adv_data = {
+      .binding_value = &binding_value_sealing_,
+      .policy = policy_erase_parent_,
+      .sel_src_slot = 0,
+      .sel_dst_slot = 1,
+      .version = 0xA5A5A5A5,
+  };
+  // The creator keys must not outlive their boot stage; a retain parent
+  // policy is rejected before any register access.
+  sc_keymgr_dpe_advance_data_t adv_data_bad_policy = adv_data;
+  adv_data_bad_policy.policy.parent = kScKeymgrDPESlotPolRetainParent;
+
+  EXPECT_EQ(sc_keymgr_dpe_advance_creator(adv_data_bad_policy, adv_data),
+            kErrorKeymgrInternal);
+  EXPECT_EQ(sc_keymgr_dpe_advance_creator(adv_data, adv_data_bad_policy),
+            kErrorKeymgrInternal);
+}
+
+TEST_F(KeymgrDpeTest, AdvanceOwnerInt) {
+  sc_keymgr_dpe_advance_data_t adv_data_sealing = {
+      .binding_value = &binding_value_sealing_,
+      .policy = policy_erase_parent_,
+      .sel_src_slot = 1,
+      .sel_dst_slot = 1,
+      .version = 0xA5A5A5A5,
+  };
+  sc_keymgr_dpe_advance_data_t adv_data_attestation = {
+      .binding_value = &binding_value_attestation_,
+      .policy = policy_erase_parent_,
+      .sel_src_slot = 3,
+      .sel_dst_slot = 3,
+      .version = 0xA5A5A5A5,
+  };
+
+  ExpectStatusCheck(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_DPE_WORKING_STATE_STATE_VALUE_AVAILABLE,
+                    /*err_code=*/0u);
+  ExpectAdvanceWrapper(/*sw_binding_only=*/false, adv_data_sealing);
+  ExpectWaitUntilDone(/*busy_cycles=*/1,
+                      KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+  ExpectAdvanceWrapper(/*sw_binding_only=*/false, adv_data_attestation);
+  ExpectWaitUntilDone(/*busy_cycles=*/1,
+                      KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+
+  EXPECT_EQ(
+      sc_keymgr_dpe_advance_owner_int(adv_data_sealing, adv_data_attestation),
+      kErrorOk);
+}
+
+TEST_F(KeymgrDpeTest, AdvanceOwnerIntBadArguments) {
+  sc_keymgr_dpe_advance_data_t adv_data = {
+      .binding_value = &binding_value_sealing_,
+      .policy = policy_erase_parent_,
+      .sel_src_slot = 1,
+      .sel_dst_slot = 1,
+      .version = 0xA5A5A5A5,
+  };
+
+  // The source and destination slots have to be equal.
+  sc_keymgr_dpe_advance_data_t adv_data_bad_slot = adv_data;
+  adv_data_bad_slot.sel_dst_slot = 2;
+  EXPECT_EQ(sc_keymgr_dpe_advance_owner_int(adv_data_bad_slot, adv_data),
+            kErrorKeymgrInternal);
+  EXPECT_EQ(sc_keymgr_dpe_advance_owner_int(adv_data, adv_data_bad_slot),
+            kErrorKeymgrInternal);
+
+  // The retain parent policy is rejected.
+  sc_keymgr_dpe_advance_data_t adv_data_bad_policy = adv_data;
+  adv_data_bad_policy.policy.parent = kScKeymgrDPESlotPolRetainParent;
+  EXPECT_EQ(sc_keymgr_dpe_advance_owner_int(adv_data_bad_policy, adv_data),
+            kErrorKeymgrInternal);
+  EXPECT_EQ(sc_keymgr_dpe_advance_owner_int(adv_data, adv_data_bad_policy),
+            kErrorKeymgrInternal);
+}
+
+TEST_F(KeymgrDpeTest, AdvanceOwner) {
+  sc_keymgr_dpe_advance_data_t adv_data_sealing = {
+      .binding_value = &binding_value_sealing_,
+      .policy = policy_erase_parent_,
+      .sel_src_slot = 1,
+      .sel_dst_slot = 1,
+      .version = 0xA5A5A5A5,
+  };
+  sc_keymgr_dpe_advance_data_t adv_data_attestation = {
+      .binding_value = &binding_value_attestation_,
+      .policy = policy_erase_parent_,
+      .sel_src_slot = 3,
+      .sel_dst_slot = 3,
+      .version = 0xA5A5A5A5,
+  };
+
+  ExpectStatusCheck(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_DPE_WORKING_STATE_STATE_VALUE_AVAILABLE,
+                    /*err_code=*/0u);
+  ExpectAdvanceWrapper(/*sw_binding_only=*/false, adv_data_sealing);
+  ExpectWaitUntilDone(/*busy_cycles=*/1,
+                      KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+  ExpectAdvanceWrapper(/*sw_binding_only=*/false, adv_data_attestation);
+  ExpectWaitUntilDone(/*busy_cycles=*/1,
+                      KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+
+  EXPECT_EQ(sc_keymgr_dpe_advance_owner(adv_data_sealing, adv_data_attestation),
+            kErrorOk);
+}
+
+TEST_F(KeymgrDpeTest, AdvanceOwnerBadSlots) {
+  sc_keymgr_dpe_advance_data_t adv_data = {
+      .binding_value = &binding_value_sealing_,
+      .policy = policy_erase_parent_,
+      .sel_src_slot = 1,
+      .sel_dst_slot = 1,
+      .version = 0xA5A5A5A5,
+  };
+
+  // The source and destination slots have to be equal.
+  sc_keymgr_dpe_advance_data_t adv_data_bad_slot = adv_data;
+  adv_data_bad_slot.sel_dst_slot = 2;
+  EXPECT_EQ(sc_keymgr_dpe_advance_owner(adv_data_bad_slot, adv_data),
+            kErrorKeymgrInternal);
+  EXPECT_EQ(sc_keymgr_dpe_advance_owner(adv_data, adv_data_bad_slot),
+            kErrorKeymgrInternal);
+}
+
+TEST_F(KeymgrDpeTest, EraseSlot) {
+  ExpectControlRegSet(/*sw_binding_only=*/false,
+                      KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_VALUE_ERASE_SLOT,
+                      KEYMGR_DPE_CONTROL_SHADOWED_DEST_SEL_VALUE_NONE,
+                      /*src_slot=*/0, /*dst_slot=*/2);
+  ExpectStartOperation();
+  ExpectWaitUntilDone(/*busy_cycles=*/1,
+                      KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+
+  EXPECT_EQ(sc_keymgr_dpe_erase_slot(/*sel_dst_slot=*/2), kErrorOk);
+}
+
+TEST_F(KeymgrDpeTest, Disable) {
+  ExpectStatusCheck(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_DPE_WORKING_STATE_STATE_VALUE_AVAILABLE,
+                    /*err_code=*/0u);
+  ExpectControlRegSet(/*sw_binding_only=*/true,
+                      KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_VALUE_DISABLE,
+                      KEYMGR_DPE_CONTROL_SHADOWED_DEST_SEL_VALUE_NONE,
+                      /*src_slot=*/0, /*dst_slot=*/0);
+  ExpectStartOperation();
+  // The final state check polls through the WIP and DONE_SUCCESS statuses
+  // of the disable operation.
+  ExpectOpStatusReadClear(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_WIP);
+  ExpectOpStatusReadClear(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+  ExpectStatusCheck(KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_DPE_WORKING_STATE_STATE_VALUE_DISABLED,
+                    /*err_code=*/0u);
+  // An invalid destination enables continuous clearing of all destinations.
+  EXPECT_ABS_WRITE32(base_ + KEYMGR_DPE_SIDELOAD_CLEAR_REG_OFFSET,
+                     std::numeric_limits<uint32_t>::max());
+
+  EXPECT_EQ(sc_keymgr_dpe_disable(), kErrorOk);
+}
 
 }  // namespace
 }  // namespace keymgr_dpe_unittest

--- a/sw/device/silicon_creator/lib/keymgr_dpe_binding_value.h
+++ b/sw/device/silicon_creator/lib/keymgr_dpe_binding_value.h
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_KEYMGR_DPE_BINDING_VALUE_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_KEYMGR_DPE_BINDING_VALUE_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Binding value used by key manager dpe to derive secret values.
+ *
+ * A change in this value changes the secret value of key manager dpe, and
+ * consequently, the versioned keys and identity seeds generated at subsequent
+ * boot stages.
+ *
+ * Note: The size of this value is an implementation detail of the key manager
+ * dpe hardware.
+ */
+typedef struct keymgr_dpe_binding_value {
+  uint32_t data[8];
+} keymgr_dpe_binding_value_t;
+
+OT_ASSERT_MEMBER_OFFSET(keymgr_dpe_binding_value_t, data, 0);
+OT_ASSERT_SIZE(keymgr_dpe_binding_value_t, 32);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_KEYMGR_DPE_BINDING_VALUE_H_


### PR DESCRIPTION
# PR6 - Silicon Creator Driver
This PR is the sixth in a series which will replace the [_keymgr_](https://opentitan.org/book/hw/ip/keymgr/index.html) with the [_kemgr_dpe_](https://opentitan.org/book/hw/ip/keymgr_dpe/index.html) in earlgrey. The replacement was approved by [this RFC](https://docs.google.com/document/d/1iF0EWyJkSEtRL9d057imLo4s6DWNrZ6Mpt0QKD8OMMc/).

## Merge-Dependencies

-  #30615  
-  #30617 
-  #30618 
-  #30619

## Relevant Commits

Last commit

## Description

This PR will add a first version of the silicon creator driver for the `keymgr_dpe`. It adds the basic functionality to interact with the `keymgr_dpe`. It is not yet included in the bazel build system as several dependencies are missing until the top integration is finished.