### PR TITLE
[keymgr_dpe] Replace keymgr in EG - PR7 keymgr_dpe testutils

### DIFF
--- a/sw/device/lib/testing/keymgr_dpe_testutils.c
+++ b/sw/device/lib/testing/keymgr_dpe_testutils.c
@@ -2,6 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// This #if define ... ensures backwards compatibility with darjeeling. Either
+// both tops will get their own testutils or this define guard can be
+// implemented at a more granular level (i.e. at function level).
+#if defined(OPENTITAN_IS_DARJEELING)
+
 #include "sw/device/lib/testing/keymgr_dpe_testutils.h"
 
 #include "hw/top/dt/keymgr_dpe.h"
@@ -109,3 +114,357 @@ status_t keymgr_dpe_testutils_wait_for_operation_done(
             status);
   return OK_STATUS();
 }
+
+#elif defined(OPENTITAN_IS_EARLGREY) || defined(OPENTITAN_IS_ENGLISHBREAKFAST)
+#include "hw/top/dt/otp_ctrl.h"
+#include "sw/device/lib/arch/boot_stage.h"
+#include "sw/device/lib/dif/dif_keymgr_dpe.h"
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/keymgr_dpe_testutils.h"
+#include "sw/device/lib/testing/kmac_testutils.h"
+#include "sw/device/lib/testing/nvm_testutils.h"
+#include "sw/device/lib/testing/otp_ctrl_testutils.h"
+#include "sw/device/lib/testing/rstmgr_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/silicon_creator/lib/base/chip.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+#define MODULE_ID MAKE_MODULE_ID('k', 'm', 'd')
+
+const static char *kKeymgrStageNames[] = {
+    [kDifKeymgrDpeStateReset] = "Reset",
+    [kDifKeymgrDpeStateAvailable] = "Available",
+    [kDifKeymgrDpeStateDisabled] = "Disabled",
+    [kDifKeymgrDpeStateInvalid] = "Invalid"};
+
+status_t keymgr_dpe_testutils_nvm_init(
+    const keymgr_dpe_testutils_secret_t *creator_secret,
+    const keymgr_dpe_testutils_secret_t *owner_secret) {
+  // Initialize flash secrets.
+  if (creator_secret) {
+    TRY(nvm_testutils_info_page_setup(kNvmInfoPageCreatorSecret, kPageReadWrite,
+                                      kPageScrambleCfg));
+    TRY(nvm_testutils_write_info_page(kNvmInfoPageCreatorSecret,
+                                      /*byte_offset=*/0, creator_secret->value,
+                                      ARRAYSIZE(creator_secret->value),
+                                      /*erase_before_write=*/true,
+                                      /*readback=*/true));
+  }
+  TRY(nvm_testutils_info_page_setup(kNvmInfoPageOwnerSecret, kPageReadWrite,
+                                    kPageScrambleCfg));
+  return nvm_testutils_write_info_page(kNvmInfoPageOwnerSecret,
+                                       /*byte_offset=*/0, owner_secret->value,
+                                       ARRAYSIZE(owner_secret->value),
+                                       /*erase_before_write=*/true,
+                                       /*readback=*/true);
+}
+
+static status_t check_lock_otp_partition(void) {
+  dif_otp_ctrl_t otp;
+  TRY(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp));
+
+  bool is_computed;
+  TRY(dif_otp_ctrl_is_digest_computed(&otp, kDifOtpCtrlPartitionSecret2,
+                                      &is_computed));
+  if (is_computed) {
+    uint64_t digest;
+    TRY(dif_otp_ctrl_get_digest(&otp, kDifOtpCtrlPartitionSecret2, &digest));
+    LOG_INFO("OTP partition locked. Digest: %x-%x", ((uint32_t *)&digest)[0],
+             ((uint32_t *)&digest)[1]);
+    return OK_STATUS();
+  }
+
+  return otp_ctrl_testutils_lock_partition(&otp, kDifOtpCtrlPartitionSecret2,
+                                           0);
+}
+
+static status_t dif_init(dif_keymgr_dpe_t *keymgr_dpe, dif_kmac_t *kmac) {
+  // Initialize KMAC in preparation for keymgr use.
+  TRY(dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), kmac));
+
+  // We shouldn't use the KMAC block's default entropy setting for keymgr, so
+  // configure it to use software entropy (and a sideloaded key, although it
+  // shouldn't matter here and tests should reconfigure if needed).
+  TRY(kmac_testutils_config(kmac, /*sideload=*/true));
+
+  // Initialize keymgr context.
+  TRY(dif_keymgr_dpe_init(
+      mmio_region_from_addr(TOP_EARLGREY_KEYMGR_DPE_BASE_ADDR), keymgr_dpe));
+  return OK_STATUS();
+}
+
+/**
+ * Wrapper around the erase slot call.
+ */
+status_t keymgr_dpe_testutils_erase_slot(
+    const dif_keymgr_dpe_t *keymgr_dpe,
+    const dif_keymgr_dpe_erase_params_t *params) {
+  TRY(dif_keymgr_dpe_erase_slot(keymgr_dpe, params));
+  return keymgr_dpe_testutils_wait_for_operation_done(keymgr_dpe);
+}
+
+status_t keymgr_dpe_initialize_sim_dv(dif_keymgr_dpe_t *keymgr_dpe,
+                                      dif_kmac_t *kmac) {
+  // Initialize keymgr and advance to CreatorRootKey state.
+  TRY(keymgr_dpe_testutils_startup(keymgr_dpe, kmac));
+  LOG_INFO("Keymgr DPE generated the CreatorRootKey in slot %d",
+           kCreatorRootKeyParams.slot_dst_sel);
+  // Generate key at CreatorRootKey (to follow same sequence and reuse
+  // chip_sw_keymgr_key_derivation_vseq.sv).
+  TRY(keymgr_dpe_testutils_generate_key(keymgr_dpe, &kKeyVersionedParams));
+  LOG_INFO("Keymgr DPE generated key at CreatorRootKey State");
+
+  // Advance to OwnerIntermediateKey state and check that the state is correct.
+  // The sim_dv testbench expects this state.
+  TRY(keymgr_dpe_testutils_advance_state(keymgr_dpe, &kOwnerIntKeyParams));
+  LOG_INFO("Keymgr DPE generated the OwnerIntKey in slot %d",
+           kOwnerIntKeyParams.slot_dst_sel);
+  return OK_STATUS();
+}
+
+status_t keymgr_dpe_initialize_sival(dif_keymgr_dpe_t *keymgr_dpe,
+                                     dif_kmac_t *kmac) {
+  dif_keymgr_dpe_state_t keymgr_dpe_state;
+
+  // keymgr_dpe should have loaded the Creator Key after this function
+  TRY(keymgr_dpe_testutils_try_startup(keymgr_dpe, kmac, &keymgr_dpe_state));
+
+  // Advance the Creator Key to the Owner Int Key
+  TRY(keymgr_dpe_testutils_advance_state(keymgr_dpe, &kOwnerIntKeyParams));
+
+  // Advance the Owner Int Key to the Owner Key
+  TRY(keymgr_dpe_testutils_advance_state(keymgr_dpe, &kOwnerKeyParams));
+
+  return keymgr_dpe_testutils_check_state(keymgr_dpe,
+                                          kDifKeymgrDpeStateAvailable);
+}
+
+status_t keymgr_dpe_testutils_initialize(dif_keymgr_dpe_t *keymgr_dpe,
+                                         dif_kmac_t *kmac) {
+  if (kBootStage == kBootStageOwner) {
+    return keymgr_dpe_initialize_sival(keymgr_dpe, kmac);
+  }
+  // All other configurations use the sim_dv initialization.
+  return keymgr_dpe_initialize_sim_dv(keymgr_dpe, kmac);
+}
+
+status_t keymgr_dpe_testutils_try_startup(
+    dif_keymgr_dpe_t *keymgr_dpe, dif_kmac_t *kmac,
+    dif_keymgr_dpe_state_t *keymgr_dpe_state) {
+  TRY(dif_init(keymgr_dpe, kmac));
+
+  // Check keymgr dpe state. If initialized, there is no need to proceed with
+  // the initialization process.
+  TRY(dif_keymgr_dpe_get_state(keymgr_dpe, keymgr_dpe_state));
+
+  TRY_CHECK(*keymgr_dpe_state == kDifKeymgrDpeStateInvalid ||
+                *keymgr_dpe_state == kDifKeymgrDpeStateDisabled,
+            "Unexpected keymgr dpe state: 0x%x", *keymgr_dpe_state);
+
+  if (*keymgr_dpe_state == kDifKeymgrDpeStateReset) {
+    TRY(keymgr_dpe_testutils_startup(keymgr_dpe, kmac));
+    TRY(dif_keymgr_dpe_get_state(keymgr_dpe, keymgr_dpe_state));
+  }
+
+  return OK_STATUS();
+}
+
+status_t keymgr_dpe_testutils_init_nvm_then_reset(void) {
+  dif_rstmgr_t rstmgr;
+  dif_otp_ctrl_t otp_ctrl;
+
+  TRY(dif_rstmgr_init(mmio_region_from_addr(TOP_EARLGREY_RSTMGR_BASE_ADDR),
+                      &rstmgr));
+  const dif_rstmgr_reset_info_bitfield_t reset_info =
+      rstmgr_testutils_reason_get();
+
+  // POR reset.
+  if (reset_info == kDifRstmgrResetInfoPor) {
+    LOG_INFO("Powered up for the first time, program flash");
+
+    TRY(dif_otp_ctrl_init(
+        mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR),
+        &otp_ctrl));
+
+    bool secret2_computed = false;
+    TRY(dif_otp_ctrl_is_digest_computed(&otp_ctrl, kDifOtpCtrlPartitionSecret2,
+                                        &secret2_computed));
+
+    // Only initialise the creator secret if `SECRET2` digest has not been
+    // computed.
+    const keymgr_dpe_testutils_secret_t *creator_secret = NULL;
+    if (!secret2_computed) {
+      creator_secret = &kCreatorSecret;
+    }
+    TRY(keymgr_dpe_testutils_nvm_init(creator_secret, &kOwnerSecret));
+
+    TRY(check_lock_otp_partition());
+
+    // Reboot device.
+    LOG_INFO(
+        "Requesting a reset to make OTP partitions accessible to keymgr DPE");
+    rstmgr_testutils_reason_clear();
+    TRY(dif_rstmgr_software_device_reset(&rstmgr));
+
+    // Wait here until device reset.
+    wait_for_interrupt();
+
+    // Should never reach this.
+    return INTERNAL();
+
+  } else {
+    // Not POR reset: this function has done its job (or can't run because it's
+    // supposed to run after POR).
+    return OK_STATUS();
+  }
+}
+
+status_t keymgr_dpe_testutils_startup(dif_keymgr_dpe_t *keymgr_dpe,
+                                      dif_kmac_t *kmac) {
+  dif_rstmgr_t rstmgr;
+
+  // Check the last word of the retention SRAM creator area to determine the
+  // type of the ROM.
+  bool is_using_test_rom =
+      retention_sram_get()
+          ->creator
+          .reserved[ARRAYSIZE((retention_sram_t){0}.creator.reserved) - 1] ==
+      TEST_ROM_IDENTIFIER;
+
+  TRY(keymgr_dpe_testutils_init_nvm_then_reset());
+
+  TRY(dif_rstmgr_init(mmio_region_from_addr(TOP_EARLGREY_RSTMGR_BASE_ADDR),
+                      &rstmgr));
+  const dif_rstmgr_reset_info_bitfield_t info = rstmgr_testutils_reason_get();
+
+  TRY_CHECK(info == kDifRstmgrResetInfoSw, "Unexpected reset reason: %08x",
+            info);
+
+  LOG_INFO("Initializing entropy complex in Auto mode");
+
+  TRY(entropy_testutils_auto_mode_init());
+
+  LOG_INFO(
+      "Powered up for the second time, actuate keymgr dpe and perform test.");
+
+  TRY(dif_init(keymgr_dpe, kmac));
+
+  // Advance to CreatorRootKey state.
+  if (is_using_test_rom) {
+    // Verify keymgr_dpe state and load UDS into predefined hw slot
+    LOG_INFO("Using test_rom, setting inputs and advancing state...");
+    TRY(keymgr_dpe_testutils_check_state(keymgr_dpe, kDifKeymgrDpeStateReset));
+    TRY(keymgr_dpe_testutils_initial_load_uds(keymgr_dpe, &kInitialParams));
+    TRY(keymgr_dpe_testutils_check_state(keymgr_dpe,
+                                         kDifKeymgrDpeStateAvailable));
+    LOG_INFO("Keymgr DPE loaded the UDS and entered Available state.");
+
+    // Generate the creator root key
+    TRY(keymgr_dpe_testutils_advance_state(keymgr_dpe, &kCreatorRootKeyParams));
+    LOG_INFO("Keymgr DPE testutils derived the CreatorRootKey");
+  } else {
+    LOG_INFO("Using ROM");
+    LOG_INFO(
+        "The keymgr DPE should already contain the derived CreatorRootKey");
+  }
+
+  // Key generation is not really necessary for all tests, but it is
+  // added to make sure each test using this function is also compatible with
+  // the DV_WAIT sequences from keymgr_key_derivation vseq
+  TRY(keymgr_dpe_testutils_generate_key(keymgr_dpe, &kKeyVersionedParams));
+  LOG_INFO("Keymgr DPE generated sw key from the CreatorRootKey");
+
+  return OK_STATUS();
+}
+
+/**
+ * Wrapper around the initial advance call. It is not possible to subsidize
+ * this call with a normal advance call as the rtl does not handle them
+ * equally. If writing to any lockable register (sw-binding, max key version,
+ * policy register) then these locks are not removed after the initial advance
+ * call completes.
+ */
+// TODO(#30665): Verify if the max key version needs to be written here too!
+// When loading the UDS the RTL fetches the max key version from the SW
+// register. Verify that the lock is released when the version register is
+// locked.
+status_t keymgr_dpe_testutils_initial_load_uds(
+    const dif_keymgr_dpe_t *keymgr_dpe,
+    const dif_keymgr_dpe_advance_params_t *params) {
+  TRY(dif_keymgr_dpe_initialize(keymgr_dpe, params->slot_dst_sel));
+  return keymgr_dpe_testutils_wait_for_operation_done(keymgr_dpe);
+}
+
+status_t keymgr_dpe_testutils_advance_state(
+    const dif_keymgr_dpe_t *keymgr_dpe,
+    const dif_keymgr_dpe_advance_params_t *params) {
+  TRY(dif_keymgr_dpe_advance_state(keymgr_dpe, params));
+  return keymgr_dpe_testutils_wait_for_operation_done(keymgr_dpe);
+}
+
+status_t keymgr_dpe_testutils_check_state(
+    const dif_keymgr_dpe_t *keymgr_dpe,
+    const dif_keymgr_dpe_state_t exp_state) {
+  dif_keymgr_dpe_state_t act_state;
+  TRY(dif_keymgr_dpe_get_state(keymgr_dpe, &act_state));
+  TRY_CHECK(act_state == exp_state,
+            "Keymgr DPE in unexpected state: %x, expected to be %x", act_state,
+            exp_state);
+  return OK_STATUS();
+}
+
+status_t keymgr_dpe_testutils_generate_key(
+    const dif_keymgr_dpe_t *keymgr_dpe,
+    const dif_keymgr_dpe_generate_params_t *params) {
+  TRY(dif_keymgr_dpe_generate(keymgr_dpe, params));
+  return keymgr_dpe_testutils_wait_for_operation_done(keymgr_dpe);
+}
+
+status_t keymgr_dpe_testutils_disable(const dif_keymgr_dpe_t *keymgr_dpe) {
+  TRY(dif_keymgr_dpe_disable(keymgr_dpe));
+  TRY(keymgr_dpe_testutils_wait_for_operation_done(keymgr_dpe));
+  return keymgr_dpe_testutils_check_state(keymgr_dpe,
+                                          kDifKeymgrDpeStateDisabled);
+}
+
+status_t keymgr_dpe_testutils_wait_for_operation_done(
+    const dif_keymgr_dpe_t *keymgr_dpe) {
+  dif_keymgr_dpe_status_codes_t status;
+  do {
+    TRY(dif_keymgr_dpe_get_status_codes(keymgr_dpe, &status));
+  } while (status == 0);
+  // If status code indicate any error (not only idle flag is set) then this
+  // try_check will fail!
+  TRY_CHECK(status == kDifKeymgrDpeStatusCodeIdle, "Unexpected status: %x",
+            status);
+  return OK_STATUS();
+}
+
+status_t keymgr_dpe_testutils_state_string_get(
+    const dif_keymgr_dpe_t *keymgr_dpe, const char **stage_name) {
+  dif_keymgr_dpe_state_t state;
+  TRY(dif_keymgr_dpe_get_state(keymgr_dpe, &state));
+
+  if (state >= ARRAYSIZE(kKeymgrStageNames)) {
+    *stage_name = NULL;
+    return INTERNAL();
+  }
+
+  *stage_name = kKeymgrStageNames[state];
+  return OK_STATUS();
+}
+
+status_t keymgr_dpe_testutils_clear_sideload_key(
+    const dif_keymgr_dpe_t *keymgr_dpe,
+    dif_keymgr_dpe_sideload_clr_t clear_dest) {
+  TRY(dif_keymgr_dpe_clear_sideload_key(keymgr_dpe, clear_dest));
+  return OK_STATUS();
+}
+#else
+#error "[Keymgr_dpe, testutils] None of the supported tops defined!"
+#endif

--- a/sw/device/lib/testing/keymgr_dpe_testutils.h
+++ b/sw/device/lib/testing/keymgr_dpe_testutils.h
@@ -5,6 +5,11 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_KEYMGR_DPE_TESTUTILS_H_
 #define OPENTITAN_SW_DEVICE_LIB_TESTING_KEYMGR_DPE_TESTUTILS_H_
 
+// This #if define ... ensures backwards compatibility with darjeeling. Either
+// both tops will get their own testutils or this define guard can be
+// implemented at a more granular level (i.e. at function level).
+#if defined(OPENTITAN_IS_DARJEELING)
+
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/dif/dif_keymgr_dpe.h"
 
@@ -14,7 +19,8 @@
  *
  * This procedure essentially gets the keymgr_dpe into the stage where it
  * can be used for tests. An example is given below:
- * ```
+ *
+ * ```c
  * void test_main(void) {
  *   // The following sets up keymgr_dpe and asks it to latch UDS.
  *   dif_keymgr_dpe_t keymgr_dpe;
@@ -92,5 +98,302 @@ status_t keymgr_dpe_testutils_check_state(
 OT_WARN_UNUSED_RESULT
 status_t keymgr_dpe_testutils_wait_for_operation_done(
     const dif_keymgr_dpe_t *keymgr_dpe);
+
+#elif defined(OPENTITAN_IS_EARLGREY) || defined(OPENTITAN_IS_ENGLISHBREAKFAST)
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_keymgr_dpe.h"
+#include "sw/device/lib/dif/dif_kmac.h"
+
+// Note: In the testutil only a single key derivation chain is generated,
+// rather than two key chains (attestation and sealing keys)
+
+/**
+ * Versioned key parameters for testing.
+ *
+ * Change destination in order to sideload keys to hardware.
+ */
+static const dif_keymgr_dpe_generate_params_t kKeyVersionedParams = {
+    .key_dest = kDifKeymgrDpeKeyDestNone,
+    .sideload_key = false,
+    .salt = {0xb6521d8f, 0x13a0e876, 0x1ca1567b, 0xb4fb0fdf, 0x9f89bc56,
+             0x4bd127c7, 0x322288d8, 0xde919d54},
+    .version = 0x11,
+    .slot_src_sel = 1,
+};
+
+/**
+ * Parameter list for the initial advancement. The slot_dst_sel determines in
+ * which slot the UDS is loaded. Any other parameters are discarded.
+ */
+static const dif_keymgr_dpe_advance_params_t kInitialParams = {
+    .binding_value = {0, 0, 0, 0, 0, 0, 0, 0},
+    .max_key_version = 0,
+    .slot_src_sel = 0,
+    .slot_dst_sel = 1,
+    .slot_policy = 0};
+
+/**
+ * Parameters for advancing: UDS > creator root key
+ */
+static const dif_keymgr_dpe_advance_params_t kCreatorRootKeyParams = {
+    .binding_value = {0xdc96c23d, 0xaf36e268, 0xcb68ff71, 0xe92f76e2,
+                      0xb8a8379d, 0x426dc745, 0x19f5cff7, 0x4ec9c6d6},
+    .max_key_version = 0x11,
+    .slot_src_sel = 1,
+    .slot_dst_sel = 1,
+    .slot_policy = 1  // 0b001 Allow children without retaining the parent
+};
+
+/**
+ * Parameter for advancing: creator root key > owner int key
+ */
+static const dif_keymgr_dpe_advance_params_t kOwnerIntKeyParams = {
+    .binding_value = {0xe4987b39, 0x3f83d390, 0xc2f3bbaf, 0x3195dbfa,
+                      0x23fb480c, 0xb012ae5e, 0xf1394d28, 0x1940ceeb},
+    .max_key_version = 0xaa,
+    .slot_src_sel = 1,
+    .slot_dst_sel = 1,
+    .slot_policy = 1  // 0b001 Allow children without retaining the parent
+};
+
+/**
+ * Parameter for advancing: owner int key > owner key
+ */
+static const dif_keymgr_dpe_advance_params_t kOwnerKeyParams = {
+    .binding_value = {0xd8a812ea, 0xb6ebe129, 0x217773d4, 0x35b37c77,
+                      0xec8298be, 0x1f7dec77, 0x1803199e, 0xa02ad81d},
+    .max_key_version = 0xaa,
+    .slot_src_sel = 1,
+    .slot_dst_sel = 1,
+    .slot_policy = 5  // 0b101 Allow children with retaining the parent
+};
+
+/**
+ * Struct to hold the creator or owner secrets for the key manager dpe.
+ */
+typedef struct keymgr_dpe_testutils_secret {
+  uint32_t value[8];
+} keymgr_dpe_testutils_secret_t;
+
+/**
+ * Key manager dpe Creator Secret (seed) stored in info flash page.
+ */
+static const keymgr_dpe_testutils_secret_t kCreatorSecret = {
+    .value = {0x4e919d54, 0x322288d8, 0x4bd127c7, 0x9f89bc56, 0xb4fb0fdf,
+              0x1ca1567b, 0x13a0e876, 0xa6521d8f}};
+
+/**
+ * Key manager dpe Owner Secret (seed) stored in info flash page.
+ */
+static const keymgr_dpe_testutils_secret_t kOwnerSecret = {
+    .value = {0xa6521d8f, 0x13a0e876, 0x1ca1567b, 0xb4fb0fdf, 0x9f89bc56,
+              0x4bd127c7, 0x322288d8, 0x4e919d54}};
+
+/**
+ * Programs nvm with secrets so that the keymgr dpe can be advanced to
+ * CreatorRootKey state.
+ *
+ * This is normally a subfunction of keymgr_testutils_startup, but some tests
+ * use the function separately as well.
+ *
+ * @param creator_secret The creator secret to be programmed to flash, or NULL
+ *                       to skip writing the creator secret.
+ * @param owner_secret The owner secret to be programmed to flash.
+ *
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_nvm_init(
+    const keymgr_dpe_testutils_secret_t *creator_secret,
+    const keymgr_dpe_testutils_secret_t *owner_secret);
+
+/**
+ * Initializes the key manager dpe and its dependencies for testing.
+ *
+ * This function initializes the key manager dpe and its dependencies for
+ * testing.
+ *
+ * This function will call `keymgr_dpe_testutils_try_startup()` if the boot
+ * stage is `kBootStageOwner`; otherwise, it will call
+ * `keymgr_testutils_startup()`. Additional checks are performed to ensure that
+ * the key manager is in a valid state, and ready to perform key derivations.
+ *
+ * @param keymgr_dpe A key manager dpe handle, may be uninitialized.
+ * @param kmac A KMAC handle, may be uninitialized.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_initialize(dif_keymgr_dpe_t *keymgr_dpe,
+                                         dif_kmac_t *kmac);
+
+/**
+ * Wrapper function to `keymgr_testutils_startup()`.
+ *
+ * This function checks the state of the key manager before attempting to
+ * initialize its dependencies and state.
+ *
+ * The function will return an error if the keymgr is disabled or in invalid
+ * state.
+ *
+ * @param keymgr_dpe A key manager dpe handle, may be uninitialized.
+ * @param kmac A KMAC handle, may be uninitialized.
+ * @param[out] keymgr_dpe_state The state of the keymgr dpe after startup.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_try_startup(
+    dif_keymgr_dpe_t *keymgr_dpe, dif_kmac_t *kmac,
+    dif_keymgr_dpe_state_t *keymgr_dpe_state);
+
+/**
+ * Initialize non-volatile memory (flash and OTP) for keymgr dpe and then
+ * reset, so that the relevant OTP partitions become accessible to keymgr dpe.
+ * After calling this function, keymgr dpe can be initialized.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_init_nvm_then_reset(void);
+
+/**
+ * Programs flash, restarts, and advances keymgr to Available state.
+ * Afterwards the CreatorRootKey is generated in the slot defined by
+ * kCreatorRootKeyParams. Note that this function assumes that the keymgr dpe
+ * is in the initial reset state after ROM execution.
+ *
+ * This procedure essentially gets the keymgr into the first state where it can
+ * be used for tests. Tests should call it before anything else, like below:
+ *
+ * ```c
+ * void test_main(void) {
+ *   // Set up and generate the CreatorRootKey.
+ *   dif_keymgr_dpe_t keymgr_dpe;
+ *   dif_kmac_t kmac;
+ *   keymgr_dpe_testutils_startup(&keymgr_dpe, &kmac);
+ *
+ *   // Remainder of test; optionally advance the CreatorRootKey to the
+ *   // OwnerIntKey, generate keys and identities.
+ *   ...
+ * }
+ * ```
+ *
+ * Because the key manager dpe uses KMAC, this procedure also initializes and
+ * configures KMAC. Software should not rely on the configuration here and
+ * should reconfigure KMAC if needed. The purpose of configuring KMAC in this
+ * procedure is so that the key manager dpe will not use KMAC with the default
+ * entropy settings.
+ *
+ * @param keymgr_dpe A key manager dpe handle, may be uninitialized.
+ * @param kmac A KMAC handle, may be uninitialized.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_startup(dif_keymgr_dpe_t *keymgr_dpe,
+                                      dif_kmac_t *kmac);
+
+/**
+ * Advances the DPE context of the keymgr_dpe and wait for it to complete
+ *
+ * @param keymgr_dpe A key manager dpe handle.
+ * @param params The binding and max key version value for the next state.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_advance_state(
+    const dif_keymgr_dpe_t *keymgr_dpe,
+    const dif_keymgr_dpe_advance_params_t *params);
+
+/**
+ * Loads the UDS into the keymgr dpe and move the state from `Reset`
+ * to `Available`.
+ *
+ * The first advance call is automatically mapped to latch the UDS into the
+ * designated destination slot rather than advancing any DPE context.
+ * Therefore most registers used in the regular advance call are ignored
+ * during initialization.
+ *
+ * @param keymgr_dpe A key manager dpe handle.
+ * @param params The .slot_dst_sel subfield determines the slot for the UDS
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_initial_load_uds(
+    const dif_keymgr_dpe_t *keymgr_dpe,
+    const dif_keymgr_dpe_advance_params_t *params);
+
+/**
+ * Checks if the current keymgr dpe state matches the expected state
+ *
+ * @param keymgr_dpe A key manager dpe handle.
+ * @param exp_state The expected key manager state.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_check_state(
+    const dif_keymgr_dpe_t *keymgr_dpe, const dif_keymgr_dpe_state_t exp_state);
+
+/**
+ * Issues a keymgr dpe HW/SW versioned key generation and wait for it
+ * to complete.
+ *
+ * @param keymgr_dpe A key manager dpe handle.
+ * @param params Key generation parameters.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_generate_key(
+    const dif_keymgr_dpe_t *keymgr_dpe,
+    const dif_keymgr_dpe_generate_params_t *params);
+
+/**
+ * Erase a keymgr_dpe slot.
+ *
+ * @param keymgr_dpe A key manager handle.
+ * @param params A wrapper struct that contains the destination slot to be
+ * erased.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_erase_slot(
+    const dif_keymgr_dpe_t *keymgr_dpe,
+    const dif_keymgr_dpe_erase_params_t *params);
+
+/**
+ * Issues a keymgr dpe disable and wait for it to complete
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_disable(const dif_keymgr_dpe_t *keymgr_dpe);
+
+/**
+ * Polling keymgr dpe status until it becomes idle.
+ * Fail the test if the status code indicates any error.
+ *
+ * @param keymgr_dpe A key manager dpe handle.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_wait_for_operation_done(
+    const dif_keymgr_dpe_t *keymgr_dpe);
+
+/**
+ * Get the current state of the key manager dpe.
+ *
+ * @param keymgr_dpe A key manager dpe handle.
+ * @param[out] state The current state of the key manager dpe in
+ * C string format.
+ *
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_state_string_get(
+    const dif_keymgr_dpe_t *keymgr_dpe, const char **stage_name);
+
+/**
+ * Clears the key from one sideload slot
+ *
+ * @param keymgr_dpe A key manager dpe handle.
+ * @param clear_dest Destination for the clear operation
+ *
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_clear_sideload_key(
+    const dif_keymgr_dpe_t *keymgr_dpe,
+    dif_keymgr_dpe_sideload_clr_t clear_dest);
+
+#else
+#error "[Keymgr_dpe, testutils] None of the supported tops defined!"
+#endif
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_KEYMGR_DPE_TESTUTILS_H_


### PR DESCRIPTION
# PR7 - keymgr_dpe testutils
This PR is the seventh in a series which will replace the [_keymgr_](https://opentitan.org/book/hw/ip/keymgr/index.html) with the [_kemgr_dpe_](https://opentitan.org/book/hw/ip/keymgr_dpe/index.html) in earlgrey. The replacement was approved by [this RFC](https://docs.google.com/document/d/1iF0EWyJkSEtRL9d057imLo4s6DWNrZ6Mpt0QKD8OMMc/).

## Merge-Dependencies

-  #30615  
-  #30617 
-  #30618 
-  #30619
-  #30668 

## Relevant Commits

Last commit

## Description

This PR extends the existing testutils for the `keymgr_dpe`. Because darjeeling and earlgrey are significant different on a fundamental level, the `keymgr_dpe_testutils` can not be shared between the two tops, resulting in two separate "testutils". In the first version, both testutils reside in the same file, but are mutually exclusive and included via `#ifdefine`!

It is not yet included in the bazel build system as several dependencies are missing until the top integration is finished.

## Note

To review the functionality of the `earlgrey` testutil it make sense to compare against the [original keymgr testutils](https://github.com/lowRISC/opentitan/blob/master/sw/device/lib/testing/keymgr_testutils.c) rather than the `darjeeling` one.