### PR TITLE
[lint] Waive VAR_INDEX_RANGE warnings shown in new tool versions

### DIFF
--- a/hw/ip/csrng/lint/csrng.waiver
+++ b/hw/ip/csrng/lint/csrng.waiver
@@ -8,3 +8,5 @@ waive -rules {ONE_BIT_MEM_WIDTH} -location {prim_arbiter_ppc.sv} -regexp {.*has 
       -comment "Usage case specific to CSRNG and how the arbiter is used."
 waive -rules {LHS_TOO_SHORT} -location {aes_cipher_control_fsm.sv aes_cipher_core.sv aes_key_expand.sv aes_sbox.sv} -regexp {Bitlength mismatch between 'unused_assert_static_lint_error' length 1 and.*} \
       -comment "CSRNG intentionally uses an unmasked AES implementation."
+waive -rules {VAR_INDEX_RANGE} -location {csrng_ctr_drbg.sv} -regexp {'\(NumBlkPerUpd - 1 - concat_ctr_q\) \* BlkLen \+: BlkLen' minimum value -128 is too small for 'concat_key_v_d' range.*} \
+      -comment "concat_ctr_q must be lower than NumBlkPerUpd, otherwise concat_ctr_done is set and we end up in the other if/else branch, the index into concat_key_v_d is always valid."

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg.sv
@@ -285,7 +285,9 @@ module csrng_ctr_drbg import csrng_pkg::*; (
       concat_key_v_d = '0;
     end else if (concat_ctr_inc) begin
       concat_ctr_d = concat_ctr_q + 1;
-      // Steer the v-response from block encrypt to the correct lane, MSB down
+      // Steer the v-response from block encrypt to the correct lane, MSB down.
+      // concat_ctr_q must be lower than NumBlkPerUpd, otherwise concat_ctr_done is set and we end
+      // up in the if branch above, i.e., the index into concat_key_v_d is always valid.
       concat_key_v_d[(NumBlkPerUpd - 1 - concat_ctr_q) * BlkLen +: BlkLen]
         = block_encrypt_rsp_data_i;
     end

--- a/hw/ip/rom_ctrl/lint/rom_ctrl.waiver
+++ b/hw/ip/rom_ctrl/lint/rom_ctrl.waiver
@@ -8,3 +8,6 @@
 waive -rules {CONST_FF} -location {rom_ctrl_counter.sv} \
       -regexp {Flip-flop 'req_q' is driven by constant one} \
       -comment "This is intentional: the signal should be true from one cycle after reset."
+waive -rules {VAR_INDEX_RANGE} -location {rom_ctrl_compare.sv} \
+      -regexp {'digest_idx -: 32' minimum value -31 is too small for '.*digest_i' range '.*} \
+      -comment "The 5 LSBs of digest_idx are fixed to 5'd31, i.e., the minimum value is actually 0 and the index is always valid"


### PR DESCRIPTION
Once these changes are in, we can upgrade the tool version used in CI with what is used in the development environment.